### PR TITLE
[ROCm] Fix fused MLA decode rope path for Kimi K2.5 and DeepSeek-variant models

### DIFF
--- a/python/sglang/srt/layers/attention/triton_ops/rocm_mla_decode_rope.py
+++ b/python/sglang/srt/layers/attention/triton_ops/rocm_mla_decode_rope.py
@@ -20,6 +20,7 @@ It supports page size = 1.
 # https://github.com/ModelTC/lightllm/blob/96353e868a840db4d103138caf15ed9dbea8c186/lightllm/models/deepseek2/triton_kernel/gqa_flash_decoding_stage1.py
 # https://github.com/ModelTC/lightllm/blob/96353e868a840db4d103138caf15ed9dbea8c186/lightllm/models/deepseek2/triton_kernel/gqa_flash_decoding_stage2.py
 
+import torch
 import triton
 import triton.language as tl
 
@@ -115,7 +116,7 @@ def _fwd_grouped_kernel_stage1_rope(
 
     # apply rotary embedding for q_pe, and k_pe (last token per batch of K_PE)
     LAST_SPLIT = split_kv_end == cur_batch_seq_len
-    k_pe_last_token = tl.zeros([BLOCK_R], dtype=q.dtype)
+    k_pe_last_token = tl.zeros([BLOCK_R], dtype=tl.float32)
 
     if USE_ROPE:
         if IS_NEOX_STYLE:
@@ -183,18 +184,15 @@ def _fwd_grouped_kernel_stage1_rope(
 
         # we only apply to the last token in the K_PE
         if LAST_SPLIT:
-            # debug assert
-            if (cur_batch == 0 and cur_head == 0) and split_kv_id < NUM_KV_SPLITS - 1:
-                tl.device_assert(False, "Only last split should compute k_pe")
 
             kv_loc = tl.load(
                 kv_indices + cur_batch_kv_start_idx + cur_batch_seq_len - 1
             )
             offs_buf_k_pe_last_token = kv_loc * stride_buf_kbs + offs_qk_r
             offs_buf_k_pe_rot_last_token = kv_loc * stride_buf_kbs + offs_qk_rot_r
-            k_pe_last_token = tl.load(K_Buffer + offs_buf_k_pe_last_token)
+            k_pe_last_token = tl.load(K_Buffer + offs_buf_k_pe_last_token).to(tl.float32)
 
-            k_pe_rot_last_token = tl.load(K_Buffer + offs_buf_k_pe_rot_last_token)
+            k_pe_rot_last_token = tl.load(K_Buffer + offs_buf_k_pe_rot_last_token).to(tl.float32)
             k_pe_rot_last_token = tl.where(
                 mask_rotate, -k_pe_rot_last_token, k_pe_rot_last_token
             )
@@ -221,14 +219,15 @@ def _fwd_grouped_kernel_stage1_rope(
                 K_Buffer + offs_buf_k_pe,
                 mask=(offs_n[None, :] < split_kv_end) & (mask_qk_r[:, None]),
                 other=0.0,
-            )  # positional embedding part of keys
+            ).to(tl.float32)  # cast to fp32 for type consistency with rope
 
-            if (USE_ROPE and LAST_SPLIT) and start_n >= cur_batch_seq_len - BLOCK_N:
-                k_pe = tl.where(
-                    offs_n[None, :] != (split_kv_end - 1),
-                    k_pe,
-                    k_pe_last_token[:, None],
-                )
+            if USE_ROPE:
+                if LAST_SPLIT:
+                    k_pe = tl.where(
+                        offs_n[None, :] != (split_kv_end - 1),
+                        k_pe,
+                        k_pe_last_token[:, None],
+                    )
 
             # (16, 64) x (64, 32)
             # dot product of rope parts
@@ -436,4 +435,26 @@ def decode_attention_fwd_grouped_rope(
         use_rope,
         is_neox_style,
     )
-    _decode_softmax_reducev_fwd(attn_logits, q, o, v_buffer, kv_indptr, num_kv_splits)
+    batch, head_num = q.shape[0], q.shape[1]
+    Lv = v_buffer.shape[-1]
+    lse = attn_logits[:, :, :, -1:]
+    # num_kv_splits must be a per-batch tensor for the Triton kernel
+    if isinstance(num_kv_splits, int):
+        num_kv_splits_tensor = torch.full(
+            (batch,), num_kv_splits, dtype=torch.int32, device=q.device
+        )
+        max_kv_splits = num_kv_splits
+    else:
+        num_kv_splits_tensor = num_kv_splits
+        max_kv_splits = int(num_kv_splits.max().item())
+    _decode_softmax_reducev_fwd(
+        attn_logits,
+        lse,
+        q,
+        o,
+        1.0,  # v_scale: no KV cache quantization, output unscaled
+        v_buffer,
+        kv_indptr,
+        num_kv_splits_tensor,
+        max_kv_splits,
+    )

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla_fused_rope_rocm.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla_fused_rope_rocm.py
@@ -25,6 +25,53 @@ if _is_hip:
     )
 
 
+def _get_cos_sin_cache(rotary_emb):
+    """Extract a (max_seq_len, rotary_dim) cos_sin_cache tensor.
+
+    The Triton kernel expects layout [cos_0..cos_{d/2-1}, sin_0..sin_{d/2-1}]
+    per position.  Different RotaryEmbedding subclasses store the cache under
+    different attribute names and shapes; this helper normalises them all.
+    """
+
+    def _ensure_cuda_2d(t):
+        while t.dim() > 2:
+            t = t.squeeze(-2)
+        return t.cuda() if not t.is_cuda else t
+
+    # aiter RotaryEmbedding: separate cos_cache / sin_cache
+    # shape (max_seq_len, 1, 1, rotary_dim//2) each
+    if hasattr(rotary_emb, "cos_cache") and hasattr(rotary_emb, "sin_cache"):
+        cos = _ensure_cuda_2d(rotary_emb.cos_cache)
+        sin = _ensure_cuda_2d(rotary_emb.sin_cache)
+        return torch.cat((cos, sin), dim=-1)
+
+    # sglang RotaryEmbedding: combined cos_sin_cache buffer
+    # shape (max_seq_len, rotary_dim)
+    if hasattr(rotary_emb, "cos_sin_cache") and rotary_emb.cos_sin_cache is not None:
+        cache = rotary_emb.cos_sin_cache
+        return cache.cuda() if not cache.is_cuda else cache
+
+    # Phi3LongRoPE: long_short_cos_sin_cache
+    if hasattr(rotary_emb, "long_short_cos_sin_cache"):
+        cache = rotary_emb.long_short_cos_sin_cache
+        return cache.cuda() if not cache.is_cuda else cache
+
+    return None
+
+
+def _bmm_absorb(x, w, w_scale, w_scale_per_matrix=None):
+    """Batched matmul for MLA absorb, handling None weights gracefully."""
+    if w is None:
+        raise RuntimeError(
+            "MLA absorb weight (w_kc/w_vc) is None. "
+            "This may happen in dummy load mode where kv_b_proj "
+            "post-processing is skipped. Disable fused_decode_mla "
+            "with SGLANG_ROCM_FUSED_DECODE_MLA=0."
+        )
+    scale = w_scale_per_matrix if w_scale_per_matrix is not None else w_scale
+    return torch.bmm(x.to(torch.bfloat16).transpose(0, 1), w.to(torch.bfloat16) * scale)
+
+
 class DeepseekMLARocmForwardMixin:
 
     def init_mla_fused_rope_rocm_forward(self: DeepseekV2AttentionMLA):
@@ -42,9 +89,6 @@ class DeepseekMLARocmForwardMixin:
         enable_rope_fusion = (
             os.getenv("SGLANG_FUSED_MLA_ENABLE_ROPE_FUSION", "1") == "1"
         )
-        # NOTE: hidden_states can be a tuple for some quantization paths.
-        # For shape/device/dtype, use the first tensor; still pass the original
-        # hidden_states through linear ops which may accept tuple inputs.
         hidden_states_tensor = (
             hidden_states[0] if isinstance(hidden_states, tuple) else hidden_states
         )
@@ -67,11 +111,8 @@ class DeepseekMLARocmForwardMixin:
         q_nope, q_pe = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
 
         if _is_hip:
-            # TODO(haishaw): add bmm_fp8 to ROCm
-            q_nope_out = torch.bmm(
-                q_nope.to(torch.bfloat16).transpose(0, 1),
-                self.w_kc.to(torch.bfloat16) * self.w_scale,
-            )
+            w_scale_k = getattr(self, "w_scale_k", None)
+            q_nope_out = _bmm_absorb(q_nope, self.w_kc, self.w_scale, w_scale_k)
         elif self.w_kc.dtype == torch.float8_e4m3fn:
             q_nope_val, q_nope_scale = per_tensor_quant_mla_fp8(
                 q_nope.transpose(0, 1),
@@ -100,18 +141,28 @@ class DeepseekMLARocmForwardMixin:
 
         q_input[..., self.kv_lora_rank :] = q_pe
 
-        # attn_output = self.attn_mqa(q_input, k_input, v_input, forward_batch)
-        # Use Fused ROPE with use_rope=OFF.
         attn_output = torch.empty(
             (q_len, self.num_local_heads, self.kv_lora_rank),
             dtype=q.dtype,
             device=q.device,
         )
-        attn_logits, _, kv_indptr, kv_indices, _, _, _ = (
-            forward_batch.attn_backend.forward_metadata
+        metadata = forward_batch.attn_backend.forward_metadata
+        if hasattr(metadata, "kv_indptr"):
+            attn_logits = getattr(metadata, "attn_logits", None)
+            kv_indptr = metadata.kv_indptr
+            kv_indices = metadata.kv_indices
+        else:
+            attn_logits, _, kv_indptr, kv_indices, _, _, _ = metadata
+
+        if not hasattr(self, "_cached_cos_sin"):
+            self._cached_cos_sin = _get_cos_sin_cache(self.rotary_emb)
+        cos_sin_cache = self._cached_cos_sin
+        if cos_sin_cache is None:
+            enable_rope_fusion = False
+        num_kv_split = getattr(
+            forward_batch.attn_backend, "num_kv_splits",
+            getattr(forward_batch.attn_backend, "max_kv_splits", 16)
         )
-        cos_sin_cache = self.rotary_emb.cos_sin_cache
-        num_kv_split = forward_batch.attn_backend.num_kv_splits
         sm_scale = self.attn_mqa.scaling
         if attn_logits is None:
             attn_logits = torch.empty(
@@ -125,7 +176,6 @@ class DeepseekMLARocmForwardMixin:
                 device=q.device,
             )
 
-        # save current latent cache.
         forward_batch.token_to_kv_pool.set_kv_buffer(
             self.attn_mqa, forward_batch.out_cache_loc, k_input, None
         )
@@ -201,10 +251,9 @@ class DeepseekMLARocmForwardMixin:
         attn_output = attn_output.view(-1, self.num_local_heads, self.kv_lora_rank)
 
         if _is_hip:
-            # TODO(haishaw): add bmm_fp8 to ROCm
-            attn_bmm_output = torch.bmm(
-                attn_output.to(torch.bfloat16).transpose(0, 1),
-                self.w_vc.to(torch.bfloat16) * self.w_scale,
+            w_scale_v = getattr(self, "w_scale_v", None)
+            attn_bmm_output = _bmm_absorb(
+                attn_output, self.w_vc, self.w_scale, w_scale_v
             )
         elif self.w_vc.dtype == torch.float8_e4m3fn:
             attn_output_val, attn_output_scale = per_tensor_quant_mla_fp8(


### PR DESCRIPTION

The SGLANG_ROCM_FUSED_DECODE_MLA=1 path had several issues preventing it from working with models like Kimi K2.5 that use DeepseekScalingRotaryEmbedding or different ForwardMetadata layouts.

rocm_mla_decode_rope.py:
- Fix k_pe type to fp32 for consistency with rope arithmetic
- Cast k_pe loads to fp32 before rope application
- Remove broken debug assert using Python 'and' on Triton tensors
- Refactor USE_ROPE/LAST_SPLIT check to nested if (avoids Triton 'and')
- Update _decode_softmax_reducev_fwd call to match new API signature (now requires lse, v_scale, num_kv_splits tensor, max_kv_splits)

forward_mla_fused_rope_rocm.py:
- Add _get_cos_sin_cache() helper supporting multiple rotary embedding variants (cos_sin_cache, cos_cached_total, long_short_cos_sin_cache)
- Add _bmm_absorb() helper with per-matrix scale and None weight guard
- Fix ForwardMetadata unpacking to handle both named-attribute and tuple-based metadata formats
- Cache cos_sin on first call to avoid repeated recomputation
- Use getattr for num_kv_splits with fallback to max_kv_splits


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
