### PR TITLE
fix: Fix error output msg when serving kimi-k2.5 with enable_attn_tp_input_scattered and fp8_e4m3 flashmla kvcache backend

### DIFF
--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
@@ -272,6 +272,10 @@ class DeepseekMHAForwardMixin:
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
         attn_output = self.attn_mha(q, k, v, forward_batch, save_kv_cache=False)
+        if get_attn_tp_context().input_scattered:
+            n_valid = forward_batch.extend_num_tokens
+            if n_valid is not None and n_valid < attn_output.shape[0]:
+                attn_output[n_valid:] = 0
         attn_output = attn_output.reshape(-1, self.num_local_heads * self.v_head_dim)
         output, _ = self.o_proj(attn_output)
         return output
@@ -325,6 +329,20 @@ class DeepseekMHAForwardMixin:
                 accum_lse=lse,
                 forward_batch=forward_batch,
             )
+
+        # When input_scattered is enabled, prepare_attn_tp_scatter_input pads
+        # the token count to be divisible by TP world size. The attention backend
+        # (both ragged and paged paths) only processes the valid tokens governed
+        # by qo_indptr, leaving padding positions with uninitialized output from
+        # torch.empty. These garbage values propagate through AllReduce in
+        # prepare_mlp and corrupt valid tokens. With fp8 kv_cache, the GPU
+        # memory pool contains uint8 data that reinterprets as NaN/Inf,
+        # making this corruption catastrophic.
+        # Zero out padding positions to prevent contamination.
+        if get_attn_tp_context().input_scattered:
+            n_valid = forward_batch.extend_num_tokens
+            if n_valid is not None and n_valid < attn_output.shape[0]:
+                attn_output[n_valid:] = 0
 
         attn_output = attn_output.reshape(-1, self.num_local_heads * self.v_head_dim)
         output, _ = self.o_proj(attn_output)

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
@@ -15,6 +15,7 @@ from sglang.srt.models.deepseek_common.utils import (
     _is_hip,
     _is_npu,
     _use_aiter_gfx95,
+    zero_attn_tp_scatter_padding,
 )
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import BumpAllocator, get_bool_env_var, next_power_of_2
@@ -272,10 +273,9 @@ class DeepseekMHAForwardMixin:
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
         attn_output = self.attn_mha(q, k, v, forward_batch, save_kv_cache=False)
-        if get_attn_tp_context().input_scattered:
-            n_valid = forward_batch.extend_num_tokens
-            if n_valid is not None and n_valid < attn_output.shape[0]:
-                attn_output[n_valid:] = 0
+        attn_output = zero_attn_tp_scatter_padding(
+            attn_output, forward_batch.extend_num_tokens
+        )
         attn_output = attn_output.reshape(-1, self.num_local_heads * self.v_head_dim)
         output, _ = self.o_proj(attn_output)
         return output
@@ -330,19 +330,9 @@ class DeepseekMHAForwardMixin:
                 forward_batch=forward_batch,
             )
 
-        # When input_scattered is enabled, prepare_attn_tp_scatter_input pads
-        # the token count to be divisible by TP world size. The attention backend
-        # (both ragged and paged paths) only processes the valid tokens governed
-        # by qo_indptr, leaving padding positions with uninitialized output from
-        # torch.empty. These garbage values propagate through AllReduce in
-        # prepare_mlp and corrupt valid tokens. With fp8 kv_cache, the GPU
-        # memory pool contains uint8 data that reinterprets as NaN/Inf,
-        # making this corruption catastrophic.
-        # Zero out padding positions to prevent contamination.
-        if get_attn_tp_context().input_scattered:
-            n_valid = forward_batch.extend_num_tokens
-            if n_valid is not None and n_valid < attn_output.shape[0]:
-                attn_output[n_valid:] = 0
+        attn_output = zero_attn_tp_scatter_padding(
+            attn_output, forward_batch.extend_num_tokens
+        )
 
         attn_output = attn_output.reshape(-1, self.num_local_heads * self.v_head_dim)
         output, _ = self.o_proj(attn_output)

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -23,6 +23,7 @@ from sglang.srt.models.deepseek_common.utils import (
     _is_hip,
     _use_aiter,
     _use_aiter_gfx95,
+    zero_attn_tp_scatter_padding,
 )
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import BumpAllocator
@@ -393,12 +394,9 @@ class DeepseekMLAForwardMixin:
                 save_kv_cache=save_kv_cache,
                 **(dict(topk_indices=topk_indices) if topk_indices is not None else {}),
             )
-        # Same as forward_mha.forward_normal_core: with input_scattered, TP padding
-        # leaves trailing rows uninitialized; zero them before o_proj / comms.
-        if get_attn_tp_context().input_scattered:
-            n_valid = forward_batch.extend_num_tokens
-            if n_valid is not None and n_valid < attn_output.shape[0]:
-                attn_output[n_valid:] = 0
+        attn_output = zero_attn_tp_scatter_padding(
+            attn_output, forward_batch.extend_num_tokens
+        )
         attn_output = attn_output.view(-1, self.num_local_heads, self.kv_lora_rank)
 
         if self.use_deep_gemm_bmm:

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -393,6 +393,12 @@ class DeepseekMLAForwardMixin:
                 save_kv_cache=save_kv_cache,
                 **(dict(topk_indices=topk_indices) if topk_indices is not None else {}),
             )
+        # Same as forward_mha.forward_normal_core: with input_scattered, TP padding
+        # leaves trailing rows uninitialized; zero them before o_proj / comms.
+        if get_attn_tp_context().input_scattered:
+            n_valid = forward_batch.extend_num_tokens
+            if n_valid is not None and n_valid < attn_output.shape[0]:
+                attn_output[n_valid:] = 0
         attn_output = attn_output.view(-1, self.num_local_heads, self.kv_lora_rank)
 
         if self.use_deep_gemm_bmm:

--- a/python/sglang/srt/models/deepseek_common/utils.py
+++ b/python/sglang/srt/models/deepseek_common/utils.py
@@ -18,6 +18,7 @@ from typing import Optional
 import torch
 
 from sglang.srt.environ import envs
+from sglang.srt.layers.communicator import get_attn_tp_context
 from sglang.srt.layers.moe.fused_moe_triton.layer import get_moe_runner_backend
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
@@ -61,6 +62,28 @@ FORWARD_ABSORB_CORE_ATTENTION_BACKENDS = [
     "trtllm_mla",
     "ascend",
 ]
+
+
+def zero_attn_tp_scatter_padding(
+    attn_output: torch.Tensor, extend_num_tokens: Optional[int]
+) -> torch.Tensor:
+    """Zero TP-scatter padding rows that attention kernels may leave dirty.
+
+    When `input_scattered` is enabled, `prepare_attn_tp_scatter_input` pads the
+    token count to be divisible by the TP world size. Attention backends only
+    compute the valid rows described by `qo_indptr`, so the trailing padded rows
+    may retain uninitialized `torch.empty` data. Those garbage values can then
+    flow into later collectives / projections and corrupt valid tokens. This is
+    especially harmful with FP8 KV cache because stale uint8 pool contents can
+    be reinterpreted as NaN/Inf.
+    """
+    if not get_attn_tp_context().input_scattered:
+        return attn_output
+
+    if extend_num_tokens is not None and extend_num_tokens < attn_output.shape[0]:
+        attn_output[extend_num_tokens:] = 0
+
+    return attn_output
 
 
 def awq_dequantize_func():


### PR DESCRIPTION
## Motivation
previous pr https://github.com/sgl-project/sglang/pull/21301.
With --enable-attn-tp-input-scattered on Kimi-K2.5, TTFT improves by ~9% vs the same setup without the flag.  
But there is a bug when serving with **`--kv-cache-dtype=fp8_e4m3`**, the reason is:
With `--enable-attn-tp-input-scattered` prefill batches are padded so the token count is divisible by TP world size. The attention backend only computes valid tokens (via `qo_indptr`); rows for padded tokens come from `torch.empty` and are **uninitialized**.
Those values participate in later communication (e.g. AllReduce in the MLP path) and corrupt valid tokens. This is especially serving with **`--kv-cache-dtype=fp8_e4m3`**: KV pool memory can hold FP8 bytes that reinterpret as NaN/Inf, producing catastrophic outputs (e.g. repeated `"!"` / all-zero token ids) on MLA-family models (e.g. Kimi-K2.5, DeepSeek V2) with backends such as FlashMLA.

This change zeros padded rows so the optimization remains safe to use.

## Modifications

- `forward_mha.py`: After `attn_mha` in `forward_normal_core` and `forward_normal_chunked_kv_core`, when `get_attn_tp_context().input_scattered` is true and `extend_num_tokens < attn_output.shape[0]`, set `attn_output[n_valid:] = 0`.
- `forward_mla.py`: Apply the same zeroing after `attn_mqa` in the absorb path so padded rows are not propagated before `o_proj` / comms.

## Bug Reproduce
```bash
python3 -m sglang.launch_server --model-path=moonshotai/Kimi-K2.5 --tp-size=8 --trust-remote-code --attention-backend=flashmla --kv-cache-dtype=fp8_e4m3 --enable-attn-tp-input-scattered
```
when server is ready and check warmup response in stdout

- **Before fix:** warmup completion showed garbage, e.g. `output_ids` all zeros and text like repeated `!`.
- **After fix:** normal coherent text and non-trivial `output_ids`.

## Accuracy Tests
```bash
#python3 -m sglang.test.few_shot_gsm8k --num-questions 200
100%|█████████████████████████████████████████████████████████| 200/200 [00:26<00:00,  7.44it/s]
Accuracy: 0.955
Invalid: 0.000
Latency: 27.179 s
Output throughput: 726.854 token/s
```



## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
