### PR TITLE
[Fix] gptq: fix hardcoded torch.half dtype in GPTQMarlinMoE scale ten…

### DIFF
--- a/python/sglang/srt/layers/quantization/gptq.py
+++ b/python/sglang/srt/layers/quantization/gptq.py
@@ -1065,7 +1065,7 @@ class GPTQMarlinMoEMethod(FusedMoEMethodBase):
                 num_experts,
                 scales_size13,
                 2 * intermediate_size_per_partition,
-                dtype=torch.half,
+                dtype=params_dtype,
             ),
             requires_grad=False,
         )
@@ -1073,7 +1073,7 @@ class GPTQMarlinMoEMethod(FusedMoEMethodBase):
         set_weight_attrs(w13_scales, extra_weight_attrs)
         # down_proj scales
         w2_scales = torch.nn.Parameter(
-            torch.empty(num_experts, scales_size2, hidden_size, dtype=torch.half),
+            torch.empty(num_experts, scales_size2, hidden_size, dtype=params_dtype),
             requires_grad=False,
         )
         layer.register_parameter("w2_scales", w2_scales)


### PR DESCRIPTION
**Problem**                                                                                                                                                                           
                                                                                                                                                                                        
  When running MoE models (e.g. Qwen3.5-35B-A3B-GPTQ-Int4) with `--quantization gptq_marlin`, the server crashes if the model's default dtype is `bfloat16`:                            
                                                                                                                                                                                        
  AssertionError: moe_wna16_marlin_gemm assumes                                                                                                                                         
    hidden_states.dtype (torch.bfloat16) == w1_scale.dtype (torch.float16)                                                                                                              
                                                                                                                                                                                        
  **Root Cause**                                                                                                                                                                        
                                                                                                                                                                                        
  In `GPTQMarlinMoEMethod.create_weights_moe()`, the MoE scale tensors (`w13_scales`, `w2_scales`) are hardcoded to `dtype=torch.half`, ignoring the actual `params_dtype`:             
                                                                                                                                                                                        
  ```python                                                                                                                                                                             
  # Before (bug)  
  w13_scales = torch.nn.Parameter(torch.empty(..., dtype=torch.half))                                                                                                                   
  w2_scales  = torch.nn.Parameter(torch.empty(..., dtype=torch.half))                                                                                                                   
                                                                                                                                                                                        
  Fix                                                                                                                                                                                   
                                                                                                                                                                                        
  Replace with params_dtype to match actual model dtype, consistent with how awq.py handles the same tensors:                                                                           
                  
  # After (fix)                                                                                                                                                                         
  w13_scales = torch.nn.Parameter(torch.empty(..., dtype=params_dtype))                                                                                                                 
  w2_scales  = torch.nn.Parameter(torch.empty(..., dtype=params_dtype))                                                                                                                 
                                                                                                                                                                                        
  Tested on                                                                                                                                                                             
  - Jetson Orin AGX (ARM64, JetPack R36.4.3, CUDA 12.6)                                                                                                                                 
  - SGLang v0.5.9                                                                                                                                                                       
  - Model: Qwen3.5-35B-A3B-GPTQ-Int4 with --quantization gptq_marlin