### PR TITLE
[CI] Upgrade upload/download-artifact to v5 in release docker workflows

### DIFF
--- a/.github/workflows/release-docker-cu13-framework.yml
+++ b/.github/workflows/release-docker-cu13-framework.yml
@@ -77,7 +77,7 @@ jobs:
           echo "${DIGEST}" > /tmp/digest-cu130-amd64-framework.txt
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: digest-cu130-amd64
           path: /tmp/digest-cu130-amd64-framework.txt
@@ -139,7 +139,7 @@ jobs:
           echo "${DIGEST}" > /tmp/digest-cu130-arm64-framework.txt
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: digest-cu130-arm64
           path: /tmp/digest-cu130-arm64-framework.txt
@@ -160,13 +160,13 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Download amd64 digest
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: digest-cu130-amd64
           path: /tmp/digests/amd64
 
       - name: Download arm64 digest
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: digest-cu130-arm64
           path: /tmp/digests/arm64

--- a/.github/workflows/release-docker-dev.yml
+++ b/.github/workflows/release-docker-dev.yml
@@ -113,7 +113,7 @@ jobs:
           echo "${DIGEST}" > /tmp/digest.txt
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: digest-${{ matrix.arch_tag }}
           path: /tmp/digest.txt
@@ -141,13 +141,13 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Download x86 digest
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: digest-${{ matrix.variant.x86 }}
           path: /tmp/digests/x86
 
       - name: Download arm64 digest
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: digest-${{ matrix.variant.arm64 }}
           path: /tmp/digests/arm64

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -169,7 +169,7 @@ jobs:
           echo "${DIGEST}" > /tmp/digest-cu130-amd64-runtime.txt
 
       - name: Upload digests
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: digests-amd64
           path: /tmp/digest-*.txt
@@ -311,7 +311,7 @@ jobs:
           echo "${DIGEST}" > /tmp/digest-cu130-arm64-runtime.txt
 
       - name: Upload digests
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: digests-arm64
           path: /tmp/digest-*.txt
@@ -358,13 +358,13 @@ jobs:
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Download amd64 digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: digests-amd64
           path: /tmp/digests/amd64
 
       - name: Download arm64 digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: digests-arm64
           path: /tmp/digests/arm64


### PR DESCRIPTION
## Summary
- Upgrade `actions/upload-artifact` and `actions/download-artifact` from v4 to v5 in the three release docker workflows (`release-docker.yml`, `release-docker-dev.yml`, `release-docker-cu13-framework.yml`)
- Fixes the v0.5.10rc0 docker release failure where `upload-artifact@v4` on Node.js 20 hit "Maximum call stack size exceeded", causing the `create-manifests` job to be skipped and leaving no tagged images on Docker Hub

## Test plan
- [ ] Verify the next docker release workflow completes the artifact upload step successfully
- [ ] Verify multi-arch manifests are created and tagged images appear on Docker Hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)