### PR TITLE
Add ExtendedChatCompletionRequest to preserve extra fields in chat co…

### DIFF
--- a/sgl-model-gateway/src/app_context.rs
+++ b/sgl-model-gateway/src/app_context.rs
@@ -515,8 +515,7 @@ impl AppContextBuilder {
     fn with_wasm_manager(mut self, config: &RouterConfig) -> Result<Self, String> {
         self.wasm_manager = if config.enable_wasm {
             Some(Arc::new(
-                WasmModuleManager::new(WasmRuntimeConfig::default())
-                    .map_err(|e| format!("Failed to initialize WASM module manager: {}", e))?,
+                WasmModuleManager::new(WasmRuntimeConfig::default()),
             ))
         } else {
             None

--- a/sgl-model-gateway/src/core/steps/wasm_module_registration.rs
+++ b/sgl-model-gateway/src/core/steps/wasm_module_registration.rs
@@ -501,7 +501,7 @@ impl StepExecutor<WasmRegistrationWorkflowData> for RegisterModuleStep {
                 last_accessed_at: now,
                 access_count: 0,
                 attach_points: descriptor.attach_points.clone(),
-                wasm_bytes,
+                wasm_bytes: Arc::new(wasm_bytes),
             },
         };
 

--- a/sgl-model-gateway/src/extended_chat.rs
+++ b/sgl-model-gateway/src/extended_chat.rs
@@ -1,0 +1,50 @@
+//! Extended ChatCompletionRequest wrapper that preserves unknown fields during
+//! deserialization, enabling transparent pass-through of engine-specific parameters
+//! not explicitly modeled in the `openai-protocol` crate.
+
+use std::collections::HashMap;
+use std::ops::Deref;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::protocols::chat::ChatCompletionRequest;
+use crate::protocols::common::GenerationRequest;
+
+/// A wrapper around [`ChatCompletionRequest`] that captures any extra JSON fields
+/// not defined in the upstream struct via `#[serde(flatten)]`.
+///
+/// On serialization the known fields and extras are merged back into a single
+/// JSON object, so forwarding preserves the full original payload.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ExtendedChatCompletionRequest {
+    #[serde(flatten)]
+    pub inner: ChatCompletionRequest,
+
+    /// Extra fields not modeled in `ChatCompletionRequest` (e.g. `rid`,
+    /// `priority`, `input_ids`, `data_parallel_rank`, `stop_regex`, …).
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+impl Deref for ExtendedChatCompletionRequest {
+    type Target = ChatCompletionRequest;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl GenerationRequest for ExtendedChatCompletionRequest {
+    fn is_stream(&self) -> bool {
+        self.inner.is_stream()
+    }
+
+    fn get_model(&self) -> Option<&str> {
+        self.inner.get_model()
+    }
+
+    fn extract_text_for_routing(&self) -> String {
+        self.inner.extract_text_for_routing()
+    }
+}

--- a/sgl-model-gateway/src/lib.rs
+++ b/sgl-model-gateway/src/lib.rs
@@ -5,6 +5,7 @@ pub mod core;
 pub mod middleware;
 pub mod observability;
 pub mod policies;
+pub mod extended_chat;
 pub use openai_protocol as protocols;
 pub use reasoning_parser;
 pub mod routers;

--- a/sgl-model-gateway/src/routers/grpc/pd_router.rs
+++ b/sgl-model-gateway/src/routers/grpc/pd_router.rs
@@ -13,6 +13,7 @@ use crate::{
         UNKNOWN_MODEL_ID,
     },
     observability::metrics::{metrics_labels, Metrics},
+    extended_chat::ExtendedChatCompletionRequest,
     protocols::{chat::ChatCompletionRequest, generate::GenerateRequest},
     routers::RouterTrait,
 };
@@ -232,10 +233,10 @@ impl RouterTrait for GrpcPDRouter {
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        body: &ChatCompletionRequest,
+        body: &ExtendedChatCompletionRequest,
         model_id: Option<&str>,
     ) -> Response {
-        self.route_chat_impl(headers, body, model_id).await
+        self.route_chat_impl(headers, &body.inner, model_id).await
     }
 
     fn router_type(&self) -> &'static str {

--- a/sgl-model-gateway/src/routers/grpc/router.rs
+++ b/sgl-model-gateway/src/routers/grpc/router.rs
@@ -23,6 +23,7 @@ use crate::{
     config::types::RetryConfig,
     core::{is_retryable_status, RetryExecutor, WorkerRegistry, UNKNOWN_MODEL_ID},
     observability::metrics::{metrics_labels, Metrics},
+    extended_chat::ExtendedChatCompletionRequest,
     protocols::{
         chat::ChatCompletionRequest,
         classify::ClassifyRequest,
@@ -386,10 +387,10 @@ impl RouterTrait for GrpcRouter {
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        body: &ChatCompletionRequest,
+        body: &ExtendedChatCompletionRequest,
         model_id: Option<&str>,
     ) -> Response {
-        self.route_chat_impl(headers, body, model_id).await
+        self.route_chat_impl(headers, &body.inner, model_id).await
     }
 
     async fn route_responses(

--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -28,6 +28,7 @@ use crate::{
         otel_trace::inject_trace_context_http,
     },
     policies::{LoadBalancingPolicy, PolicyRegistry, SelectWorkerInfo},
+    extended_chat::ExtendedChatCompletionRequest,
     protocols::{
         chat::{ChatCompletionRequest, ChatMessage, MessageContent},
         classify::ClassifyRequest,
@@ -1278,7 +1279,7 @@ impl RouterTrait for PDRouter {
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        body: &ChatCompletionRequest,
+        body: &ExtendedChatCompletionRequest,
         model_id: Option<&str>,
     ) -> Response {
         let is_stream = body.stream;

--- a/sgl-model-gateway/src/routers/http/router.rs
+++ b/sgl-model-gateway/src/routers/http/router.rs
@@ -25,8 +25,8 @@ use crate::{
         otel_trace::inject_trace_context_http,
     },
     policies::{PolicyRegistry, SelectWorkerInfo},
+    extended_chat::ExtendedChatCompletionRequest,
     protocols::{
-        chat::ChatCompletionRequest,
         classify::ClassifyRequest,
         common::GenerationRequest,
         completion::CompletionRequest,
@@ -748,7 +748,7 @@ impl RouterTrait for Router {
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        body: &ChatCompletionRequest,
+        body: &ExtendedChatCompletionRequest,
         model_id: Option<&str>,
     ) -> Response {
         self.route_typed_request(headers, body, "/v1/chat/completions", model_id)

--- a/sgl-model-gateway/src/routers/mod.rs
+++ b/sgl-model-gateway/src/routers/mod.rs
@@ -10,8 +10,8 @@ use axum::{
     response::{IntoResponse, Response},
 };
 
+use crate::extended_chat::ExtendedChatCompletionRequest;
 use crate::protocols::{
-    chat::ChatCompletionRequest,
     classify::ClassifyRequest,
     completion::CompletionRequest,
     embedding::EmbeddingRequest,
@@ -93,7 +93,7 @@ pub trait RouterTrait: Send + Sync + Debug {
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        body: &ChatCompletionRequest,
+        body: &ExtendedChatCompletionRequest,
         model_id: Option<&str>,
     ) -> Response;
 

--- a/sgl-model-gateway/src/routers/openai/router.rs
+++ b/sgl-model-gateway/src/routers/openai/router.rs
@@ -35,8 +35,8 @@ use crate::{
         RuntimeType, Worker, WorkerRegistry,
     },
     observability::metrics::{bool_to_static_str, metrics_labels, Metrics},
+    extended_chat::ExtendedChatCompletionRequest,
     protocols::{
-        chat::ChatCompletionRequest,
         responses::{
             generate_id, ResponseContentPart, ResponseInput, ResponseInputOutputItem,
             ResponsesGetParams, ResponsesRequest,
@@ -470,7 +470,7 @@ impl crate::routers::RouterTrait for OpenAIRouter {
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        body: &ChatCompletionRequest,
+        body: &ExtendedChatCompletionRequest,
         model_id: Option<&str>,
     ) -> Response {
         let start = Instant::now();
@@ -536,7 +536,7 @@ impl crate::routers::RouterTrait for OpenAIRouter {
         }
 
         let mut ctx = RequestContext::for_chat(
-            Arc::new(body.clone()),
+            Arc::new(body.inner.clone()),
             headers.cloned(),
             model_id.map(String::from),
             ComponentRefs::Shared(self.shared_components()),

--- a/sgl-model-gateway/src/routers/router_manager.rs
+++ b/sgl-model-gateway/src/routers/router_manager.rs
@@ -22,8 +22,8 @@ use crate::{
     app_context::AppContext,
     config::RoutingMode,
     core::{ConnectionMode, RuntimeType, WorkerRegistry, WorkerType},
+    extended_chat::ExtendedChatCompletionRequest,
     protocols::{
-        chat::ChatCompletionRequest,
         classify::ClassifyRequest,
         completion::CompletionRequest,
         embedding::EmbeddingRequest,
@@ -527,7 +527,7 @@ impl RouterTrait for RouterManager {
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        body: &ChatCompletionRequest,
+        body: &ExtendedChatCompletionRequest,
         model_id: Option<&str>,
     ) -> Response {
         // In IGW mode, resolve model_id and fail fast if not resolvable

--- a/sgl-model-gateway/src/server.rs
+++ b/sgl-model-gateway/src/server.rs
@@ -33,6 +33,7 @@ use crate::{
         worker_manager::WorkerManager,
         Job,
     },
+    extended_chat::ExtendedChatCompletionRequest,
     middleware::{self, AuthConfig, QueuedRequest},
     observability::{
         logging::{self, LoggingConfig},
@@ -40,7 +41,6 @@ use crate::{
         otel_trace,
     },
     protocols::{
-        chat::ChatCompletionRequest,
         classify::ClassifyRequest,
         completion::CompletionRequest,
         embedding::EmbeddingRequest,
@@ -184,8 +184,25 @@ async fn generate(
 async fn v1_chat_completions(
     State(state): State<Arc<AppState>>,
     headers: http::HeaderMap,
-    ValidatedJson(body): ValidatedJson<ChatCompletionRequest>,
+    Json(mut body): Json<ExtendedChatCompletionRequest>,
 ) -> Response {
+    use openai_protocol::validated::Normalizable;
+    use validator::Validate;
+
+    body.inner.normalize();
+    if let Err(e) = body.inner.validate() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": {
+                    "message": e.to_string(),
+                    "type": "invalid_request_error",
+                    "code": 400
+                }
+            })),
+        )
+            .into_response();
+    }
     state
         .router
         .route_chat(Some(&headers), &body, Some(&body.model))

--- a/sgl-model-gateway/tests/spec/extended_chat.rs
+++ b/sgl-model-gateway/tests/spec/extended_chat.rs
@@ -1,0 +1,104 @@
+use serde_json::json;
+use smg::extended_chat::ExtendedChatCompletionRequest;
+
+/// Verify that unknown/extra fields survive a JSON → ExtendedChatCompletionRequest → JSON roundtrip.
+#[test]
+fn test_extra_fields_roundtrip() {
+    let input = json!({
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "hello"}],
+        "temperature": 0.7,
+        // --- sglang-specific fields NOT modeled in openai-protocol crate ---
+        "rid": "req-001",
+        "priority": 5,
+        "input_ids": [1, 2, 3, 4],
+        "data_parallel_rank": 2,
+        "stop_regex": "\\n\\n",
+        "cache_salt": "salt-abc",
+        "custom_field_xyz": "should_survive"
+    });
+
+    // Deserialize
+    let extended: ExtendedChatCompletionRequest =
+        serde_json::from_value(input.clone()).expect("deserialization should succeed");
+
+    // Known fields land in inner
+    assert_eq!(extended.inner.model, "test-model");
+    assert_eq!(extended.inner.temperature, Some(0.7));
+
+    // Extra fields are captured
+    assert_eq!(extended.extra.get("rid").and_then(|v| v.as_str()), Some("req-001"));
+    assert_eq!(extended.extra.get("priority").and_then(|v| v.as_i64()), Some(5));
+    assert_eq!(
+        extended.extra.get("input_ids"),
+        Some(&json!([1, 2, 3, 4]))
+    );
+    assert_eq!(
+        extended.extra.get("data_parallel_rank").and_then(|v| v.as_i64()),
+        Some(2)
+    );
+    assert_eq!(
+        extended.extra.get("stop_regex").and_then(|v| v.as_str()),
+        Some("\\n\\n")
+    );
+    assert_eq!(
+        extended.extra.get("cache_salt").and_then(|v| v.as_str()),
+        Some("salt-abc")
+    );
+    assert_eq!(
+        extended.extra.get("custom_field_xyz").and_then(|v| v.as_str()),
+        Some("should_survive")
+    );
+
+    // Re-serialize and verify all fields are present
+    let output = serde_json::to_value(&extended).expect("serialization should succeed");
+    let obj = output.as_object().expect("should be object");
+
+    assert_eq!(obj.get("model").and_then(|v| v.as_str()), Some("test-model"));
+    // temperature is f32 in the struct, so precision may differ slightly
+    let temp = obj.get("temperature").and_then(|v| v.as_f64()).unwrap();
+    assert!((temp - 0.7).abs() < 1e-6, "temperature should be ~0.7, got {}", temp);
+    assert_eq!(obj.get("rid").and_then(|v| v.as_str()), Some("req-001"));
+    assert_eq!(obj.get("priority").and_then(|v| v.as_i64()), Some(5));
+    assert_eq!(obj.get("input_ids"), Some(&json!([1, 2, 3, 4])));
+    assert_eq!(obj.get("data_parallel_rank").and_then(|v| v.as_i64()), Some(2));
+    assert_eq!(obj.get("stop_regex").and_then(|v| v.as_str()), Some("\\n\\n"));
+    assert_eq!(obj.get("cache_salt").and_then(|v| v.as_str()), Some("salt-abc"));
+    assert_eq!(
+        obj.get("custom_field_xyz").and_then(|v| v.as_str()),
+        Some("should_survive")
+    );
+}
+
+/// Verify Deref gives transparent access to inner fields.
+#[test]
+fn test_deref_access() {
+    let input = json!({
+        "model": "my-model",
+        "messages": [{"role": "user", "content": "hi"}],
+        "stream": true,
+        "rid": "r1"
+    });
+
+    let extended: ExtendedChatCompletionRequest =
+        serde_json::from_value(input).unwrap();
+
+    // Access via Deref (no .inner needed)
+    assert_eq!(extended.model, "my-model");
+    assert!(extended.stream);
+}
+
+/// Verify that a request with no extra fields works fine (extra map is empty).
+#[test]
+fn test_no_extra_fields() {
+    let input = json!({
+        "model": "test",
+        "messages": [{"role": "user", "content": "hello"}]
+    });
+
+    let extended: ExtendedChatCompletionRequest =
+        serde_json::from_value(input).unwrap();
+
+    assert!(extended.extra.is_empty());
+    assert_eq!(extended.model, "test");
+}

--- a/sgl-model-gateway/tests/spec/mod.rs
+++ b/sgl-model-gateway/tests/spec/mod.rs
@@ -5,5 +5,6 @@
 mod chat_completion;
 mod chat_message;
 mod embedding;
+mod extended_chat;
 mod rerank;
 mod responses;


### PR DESCRIPTION
## Motivation

The SGLang Python backend's `ChatCompletionRequest` carries many engine-specific fields (e.g. `rid`, `priority`, `input_ids`, `data_parallel_rank`, `stop_regex`, `cache_salt`) that are not modeled in the `openai-protocol` Rust crate used by `sgl-model-gateway`. When clients send these fields, the router silently drops them before forwarding to backends, causing loss of routing hints and engine-specific parameters.

## Modifications

- **`sgl-model-gateway/src/extended_chat.rs`** (new): Introduce `ExtendedChatCompletionRequest`, a wrapper around `ChatCompletionRequest` that uses `#[serde(flatten)]` to capture all unknown JSON fields into a `HashMap<String, Value>`. Implements `Deref` and `GenerationRequest` for transparent access to inner fields.
- **`sgl-model-gateway/src/routers/mod.rs`**: Update `RouterTrait::route_chat` signature to accept `&ExtendedChatCompletionRequest` instead of `&ChatCompletionRequest`.
- **`sgl-model-gateway/src/routers/{http,grpc,openai}/*.rs`** and **`router_manager.rs`**: Update all `route_chat` implementations to match the new trait signature, accessing `body.inner` where the original `ChatCompletionRequest` is needed.
- **`sgl-model-gateway/src/server.rs`**: Replace `ValidatedJson<ChatCompletionRequest>` with `Json<ExtendedChatCompletionRequest>` in the `/v1/chat/completions` handler, with manual normalization and validation.
- **`sgl-model-gateway/src/app_context.rs`**: Minor cleanup — remove unnecessary `map_err` on `WasmModuleManager::new`.
- **`sgl-model-gateway/src/core/steps/wasm_module_registration.rs`**: Wrap `wasm_bytes` in `Arc` for cheaper cloning.
- **`sgl-model-gateway/tests/spec/extended_chat.rs`** (new): Unit tests for extra-fields roundtrip, `Deref` access, and no-extra-fields case.

## Accuracy Tests

N/A — This change only affects the Rust router layer (serialization/deserialization). No model output or inference logic is modified.

## Benchmarking and Profiling

N/A — The additional overhead is one `HashMap` allocation per request for extra fields, which is negligible compared to inference latency.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
