### PR TITLE
[Bugfix] Harden video output saving for Helios runtime.

### DIFF
--- a/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py
@@ -318,7 +318,7 @@ class DiffGenerator:
                         samples_out: list[Any] = []
                         audios_out: list[Any] = []
                         frames_out: list[Any] = []
-                        save_outputs(
+                        output_paths = save_outputs(
                             output_batch.output,
                             requests[0].data_type,
                             requests[0].fps,
@@ -356,7 +356,7 @@ class DiffGenerator:
                                     frames=frames_out[idx],
                                     audio=audios_out[idx],
                                     prompt_index=global_output_index + idx,
-                                    output_file_path=req.output_file_path(1, 0),
+                                    output_file_path=output_paths[idx],
                                 )
                             )
             except Exception as e:

--- a/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
@@ -292,7 +292,7 @@ async def forward_to_scheduler(
             output_file_path = response.output_file_paths[0]
         else:
             output_file_path = sp.output_file_path()
-            save_outputs(
+            output_paths = save_outputs(
                 [response.output[0]],
                 sp.data_type,
                 sp.fps,
@@ -308,6 +308,7 @@ async def forward_to_scheduler(
                 upscaling_model_path=sp.upscaling_model_path,
                 upscaling_scale=sp.upscaling_scale,
             )
+            output_file_path = output_paths[0] if output_paths else output_file_path
 
         if hasattr(response, "model_dump"):
             data = response.model_dump()

--- a/python/sglang/multimodal_gen/runtime/entrypoints/utils.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/utils.py
@@ -43,6 +43,17 @@ from sglang.srt.observability.trace import TraceReqContext
 logger = init_logger(__name__)
 
 
+# Video outputs are written through imageio/ffmpeg as MP4/H.264 and optional
+# audio muxing also targets MP4. Keep the visible path aligned with the
+# container we actually create.
+VIDEO_OUTPUT_EXTENSIONS = frozenset({".mp4"})
+
+# Audio sample-rate bounds used for best-effort validation/inference.
+MIN_AUDIO_SAMPLE_RATE = 8000
+MAX_AUDIO_SAMPLE_RATE = 192000
+DEFAULT_AUDIO_SAMPLE_RATE = 24000
+
+
 @dataclass
 class SetLoraReq:
     lora_nickname: Union[str, List[str]]
@@ -293,8 +304,10 @@ def _pick_audio_sample_rate(
 ) -> int:
     """Pick a plausible sample rate, falling back to inferring from video duration."""
     selected_sr = int(audio_sample_rate) if audio_sample_rate is not None else None
-    if selected_sr is None or not (8000 <= selected_sr <= 192000):
-        selected_sr = 24000
+    if selected_sr is None or not (
+        MIN_AUDIO_SAMPLE_RATE <= selected_sr <= MAX_AUDIO_SAMPLE_RATE
+    ):
+        selected_sr = DEFAULT_AUDIO_SAMPLE_RATE
         try:
             duration_s = float(num_frames) / float(fps) if fps else 0.0
             if duration_s > 0:
@@ -304,11 +317,66 @@ def _pick_audio_sample_rate(
                     else int(audio_np.shape[-1])
                 )
                 inferred_sr = int(round(float(audio_len) / duration_s))
-                if 8000 <= inferred_sr <= 192000:
+                if MIN_AUDIO_SAMPLE_RATE <= inferred_sr <= MAX_AUDIO_SAMPLE_RATE:
                     selected_sr = inferred_sr
         except Exception:
             pass
     return selected_sr
+
+
+def _ensure_parent_dir(file_path: str) -> None:
+    parent_dir = os.path.dirname(file_path)
+    if parent_dir:
+        os.makedirs(parent_dir, exist_ok=True)
+
+
+def _normalize_video_output_path(
+    save_file_path: Optional[str], data_type: DataType
+) -> Optional[str]:
+    if data_type != DataType.VIDEO or not save_file_path:
+        return save_file_path
+
+    _, ext = os.path.splitext(save_file_path)
+    if ext.lower() in VIDEO_OUTPUT_EXTENSIONS:
+        return save_file_path
+
+    base = save_file_path if not ext else save_file_path[: -len(ext)]
+    corrected_path = f"{base}.mp4"
+    logger.warning(
+        "Video output path %s has non-video extension %s; saving as %s",
+        save_file_path,
+        ext or "<none>",
+        corrected_path,
+    )
+    return corrected_path
+
+
+def _write_video_frames(
+    *,
+    save_file_path: str,
+    frames: list[Any],
+    fps: int,
+    output_compression: Optional[int],
+) -> None:
+    mimsave_kwargs: dict[str, Any] = {
+        "fps": fps,
+        "format": DataType.VIDEO.get_default_extension(),
+        "codec": "libx264",
+    }
+    if output_compression is not None:
+        mimsave_kwargs["quality"] = output_compression / 10
+
+    try:
+        imageio.mimsave(save_file_path, frames, **mimsave_kwargs)
+    except TypeError:
+        if "quality" not in mimsave_kwargs:
+            raise
+        logger.warning(
+            "Video writer rejected the quality option; retrying without it",
+            exc_info=True,
+        )
+        mimsave_kwargs.pop("quality", None)
+        imageio.mimsave(save_file_path, frames, **mimsave_kwargs)
 
 
 def _resolve_ffmpeg_exe() -> str:
@@ -578,23 +646,21 @@ def save_materialized_output(
     save_output: bool = True,
     audio_sample_rate: Optional[int] = None,
     output_compression: Optional[int] = None,
-) -> None:
+) -> Optional[str]:
     if not save_output:
-        return
+        return save_file_path
     if not save_file_path:
-        logger.info(f"No output path provided, output not saved")
-        return
+        logger.info("No output path provided, output not saved")
+        return save_file_path
 
-    os.makedirs(os.path.dirname(save_file_path), exist_ok=True)
+    save_file_path = _normalize_video_output_path(save_file_path, data_type)
+    _ensure_parent_dir(save_file_path)
     if data_type == DataType.VIDEO:
-        quality = output_compression / 10 if output_compression is not None else 5
-        imageio.mimsave(
-            save_file_path,
-            materialized.frames,
+        _write_video_frames(
+            save_file_path=save_file_path,
+            frames=materialized.frames,
             fps=materialized.fps,
-            format=data_type.get_default_extension(),
-            codec="libx264",
-            quality=quality,
+            output_compression=output_compression,
         )
 
         _maybe_mux_audio_into_mp4(
@@ -619,6 +685,7 @@ def save_materialized_output(
                 save_file_path, materialized.frames[0], quality, output_compression
             )
     logger.info(f"Output saved to {CYAN}{save_file_path}{RESET}")
+    return save_file_path
 
 
 def _save_image_frame(
@@ -660,6 +727,7 @@ def save_outputs(
     output_paths: list[str] = []
     for idx, sample in enumerate(outputs):
         save_file_path = build_output_path(idx)
+        save_file_path = _normalize_video_output_path(save_file_path, data_type)
         if data_type == DataType.VIDEO:
             sample = attach_audio_to_video_sample(sample, audio, idx)
 
@@ -722,7 +790,7 @@ def post_process_sample(
         upscaling_model_path=upscaling_model_path,
         upscaling_scale=upscaling_scale,
     )
-    save_materialized_output(
+    actual_save_file_path = save_materialized_output(
         materialized,
         data_type,
         save_file_path,
@@ -730,4 +798,6 @@ def post_process_sample(
         audio_sample_rate=audio_sample_rate,
         output_compression=output_compression,
     )
+    if actual_save_file_path != save_file_path:
+        logger.debug("Saved output path adjusted to %s", actual_save_file_path)
     return materialized.frames

--- a/python/sglang/multimodal_gen/test/unit/test_output_saving.py
+++ b/python/sglang/multimodal_gen/test/unit/test_output_saving.py
@@ -66,3 +66,60 @@ def test_png_output_saving_uses_fast_pillow_path(
     )
 
     assert save_calls == [("PNG", expected_compress_level)]
+
+
+def test_video_output_saving_normalizes_extension(tmp_path, monkeypatch):
+    frame = _rgb_frame()
+    requested_path = tmp_path / "sample.png"
+    saved_paths = []
+
+    def fake_mimsave(path, frames, **kwargs):
+        saved_paths.append((path, kwargs))
+        with open(path, "wb") as f:
+            f.write(b"video")
+
+    monkeypatch.setattr(output_utils.imageio, "mimsave", fake_mimsave)
+    monkeypatch.setattr(output_utils, "_maybe_mux_audio_into_mp4", lambda **_: None)
+
+    output_paths = output_utils.save_outputs(
+        [frame],
+        DataType.VIDEO,
+        fps=8,
+        save_output=True,
+        build_output_path=lambda _idx: str(requested_path),
+    )
+
+    expected_path = str(tmp_path / "sample.mp4")
+    assert output_paths == [expected_path]
+    assert saved_paths[0][0] == expected_path
+    assert (tmp_path / "sample.mp4").exists()
+    assert not requested_path.exists()
+
+
+def test_video_output_saving_retries_without_quality(tmp_path, monkeypatch):
+    frame = _rgb_frame()
+    output_path = tmp_path / "sample.mp4"
+    calls = []
+
+    def fake_mimsave(path, frames, **kwargs):
+        calls.append(kwargs.copy())
+        if "quality" in kwargs:
+            raise TypeError("quality is unsupported")
+        with open(path, "wb") as f:
+            f.write(b"video")
+
+    monkeypatch.setattr(output_utils.imageio, "mimsave", fake_mimsave)
+    monkeypatch.setattr(output_utils, "_maybe_mux_audio_into_mp4", lambda **_: None)
+
+    post_process_sample(
+        frame,
+        DataType.VIDEO,
+        fps=8,
+        save_file_path=str(output_path),
+        output_compression=50,
+    )
+
+    assert len(calls) == 2
+    assert calls[0]["quality"] == 5.0
+    assert "quality" not in calls[1]
+    assert output_path.exists()


### PR DESCRIPTION
## Motivation

Harden Helios video output saving by fixing several failure cases in the current runtime output path:

- Video generation can fail to save when the requested output path has no extension or uses a non-video extension, because the writer receives a path that does not match the file encoded with H.264 that we actually produce.
- Even when saving succeeds after correcting the extension internally, callers may still report or read from the original stale path, causing downstream failures such as missing output files or failed base64 encoding in the HTTP path.
- Some imageio.mimsave backends reject the quality argument for video writing, which can cause otherwise valid video generation to fail during output persistence.

## Modifications

- Normalize video output paths to a supported video extension, defaulting to .mp4 when the requested path has no extension or uses a non-video extension.
- Propagate the actual saved output path back to DiffGenerator and the HTTP server so callers observe the path that was actually written.
- Add a robust video-writing helper that retries imageio.mimsave without quality when the selected backend rejects that argument.
- Make video parent-directory creation safe for paths without an explicit directory component.
Replace hard-coded audio sample-rate bounds and defaults with named constants.
- Add unit coverage for video extension normalization and retrying video saves without quality.

## Accuracy Tests

- Added unit tests in test_output_saving.py for:
   - normalizing invalid video output extensions to .mp4;
   - retrying video writes when quality is unsupported by the backend.
- Ran targeted standalone validation for the same video-saving paths.

## Benchmarking and Profiling

Not run (no performance-critical changes).   

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27975380334](https://github.com/sgl-project/sglang/actions/runs/27975380334)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27975379756](https://github.com/sgl-project/sglang/actions/runs/27975379756)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->