### PR TITLE
Add persistent diffusion workspace reuse and extend random benchmarks for image-conditioned tasks

### DIFF
--- a/docs/diffusion/environment_variables.md
+++ b/docs/diffusion/environment_variables.md
@@ -30,6 +30,12 @@ See [cache-dit documentation](performance/cache/cache_dit.md) for detailed confi
 | `SGLANG_CACHE_DIT_SCM_COMPUTE_BINS` | not set | Custom SCM compute bins                  |
 | `SGLANG_CACHE_DIT_SCM_CACHE_BINS`   | not set | Custom SCM cache bins                    |
 
+### Workspace Reuse
+
+| Environment Variable | Default | Description |
+|----------------------|---------|-------------|
+| `SGLANG_DIFFUSION_PERSISTENT_WORKSPACE` | false | Reuse diffusion workspace buffers between requests to reduce allocation overhead. |
+
 ## Cloud Storage
 
 These variables configure S3-compatible cloud storage for automatically uploading generated images and videos.

--- a/python/sglang/multimodal_gen/benchmarks/bench_serving.py
+++ b/python/sglang/multimodal_gen/benchmarks/bench_serving.py
@@ -519,6 +519,16 @@ async def benchmark(args):
 
     setattr(args, "task_name", task_name)
 
+    if (
+        task_name in ("image-to-image", "image-to-video")
+        and args.dataset == "random"
+        and not getattr(args, "image_path", None)
+    ):
+        raise ValueError(
+            "Random dataset for image-conditional tasks requires --image-path. "
+            "Provide a local image file path to use as input_reference."
+        )
+
     if args.dataset == "vbench":
         dataset = VBenchDataset(args, api_url, args.model)
     elif args.dataset == "random":
@@ -694,6 +704,12 @@ if __name__ == "__main__":
         type=str,
         default=None,
         help="Path to local dataset file (optional).",
+    )
+    parser.add_argument(
+        "--image-path",
+        type=str,
+        default=None,
+        help="Local image path for random dataset when task requires image input.",
     )
     parser.add_argument(
         "--num-prompts", type=int, default=10, help="Number of prompts to benchmark."

--- a/python/sglang/multimodal_gen/benchmarks/datasets.py
+++ b/python/sglang/multimodal_gen/benchmarks/datasets.py
@@ -298,4 +298,9 @@ class RandomDataset(BaseDataset):
             height=self.args.height,
             num_frames=self.args.num_frames,
             fps=self.args.fps,
+            image_paths=(
+                [self.args.image_path]
+                if getattr(self.args, "image_path", None)
+                else None
+            ),
         )

--- a/python/sglang/multimodal_gen/envs.py
+++ b/python/sglang/multimodal_gen/envs.py
@@ -245,6 +245,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # If set, sgl_diffusion will enable stage logging, which will print the time
     # taken for each stage
     "SGLANG_DIFFUSION_STAGE_LOGGING": _lazy_bool("SGLANG_DIFFUSION_STAGE_LOGGING"),
+    # If set, diffusion denoising will reuse persistent per-request workspaces
+    # to avoid per-step allocations in denoising loops.
+    "SGLANG_DIFFUSION_PERSISTENT_WORKSPACE": _lazy_bool(
+        "SGLANG_DIFFUSION_PERSISTENT_WORKSPACE", "false"
+    ),
     "SGLANG_DIFFUSION_VAE_CHANNELS_LAST_3D": _lazy_bool(
         "SGLANG_DIFFUSION_VAE_CHANNELS_LAST_3D", "false"
     ),

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -85,6 +85,31 @@ from sglang.srt.utils.common import get_compiler_backend
 logger = init_logger(__name__)
 
 
+class DiffusionWorkspace:
+    """Simple per-request buffer cache keyed by buffer name."""
+
+    def __init__(self) -> None:
+        self.buffers: dict[str, torch.Tensor] = {}
+
+    def get_buffer(
+        self,
+        name: str,
+        shape: tuple[int, ...],
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> torch.Tensor:
+        buf = self.buffers.get(name)
+        if (
+            buf is None
+            or buf.shape != shape
+            or buf.dtype != dtype
+            or buf.device != device
+        ):
+            buf = torch.empty(shape, dtype=dtype, device=device)
+            self.buffers[name] = buf
+        return buf
+
+
 class DenoisingStage(PipelineStage):
     """
     Stage for running the denoising loop in diffusion pipelines.
@@ -129,6 +154,78 @@ class DenoisingStage(PipelineStage):
         self._cache_dit_enabled = False
         self._cached_num_steps = None
         self._is_warmed_up = False
+
+    def _workspace_enabled(self) -> bool:
+        return getattr(envs, "SGLANG_DIFFUSION_PERSISTENT_WORKSPACE", False)
+
+    def _get_workspace_pool(
+        self, batch: Req
+    ) -> dict[tuple[Any, ...], DiffusionWorkspace]:
+        pool = batch.extra.get("diffusion_workspace")
+        if pool is None:
+            pool = {}
+            batch.extra["diffusion_workspace"] = pool
+        return pool
+
+    def _build_workspace_key(
+        self,
+        batch: Req,
+        latents: torch.Tensor,
+        target_dtype: torch.dtype,
+        server_args: ServerArgs,
+    ) -> tuple[Any, ...]:
+        bucket_id = getattr(batch, "bucket_id", None)
+        raw_shape = (
+            tuple(batch.raw_latent_shape)
+            if batch.raw_latent_shape is not None
+            else None
+        )
+        exec_shape = tuple(latents.shape)
+        return (
+            latents.device,
+            target_dtype,
+            exec_shape,
+            raw_shape,
+            self.attn_backend.get_enum(),
+            batch.do_classifier_free_guidance,
+            server_args.pipeline_config.task_type,
+            bucket_id,
+        )
+
+    def _get_or_create_workspace(
+        self,
+        batch: Req,
+        latents: torch.Tensor,
+        target_dtype: torch.dtype,
+        server_args: ServerArgs,
+    ) -> DiffusionWorkspace:
+        pool = self._get_workspace_pool(batch)
+        key = self._build_workspace_key(batch, latents, target_dtype, server_args)
+        workspace = pool.get(key)
+        if workspace is None:
+            workspace = DiffusionWorkspace()
+            pool[key] = workspace
+        batch.extra["diffusion_workspace_key"] = key
+        return workspace
+
+    def _get_workspace_entry(self, batch: Req) -> DiffusionWorkspace | None:
+        pool = batch.extra.get("diffusion_workspace")
+        key = batch.extra.get("diffusion_workspace_key")
+        if pool is None or key is None:
+            return None
+        return pool.get(key)
+
+    def _get_or_create_buffer(
+        self,
+        workspace: DiffusionWorkspace | None,
+        name: str,
+        shape: tuple[int, ...],
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> torch.Tensor:
+        if workspace is None:
+            return torch.empty(shape, dtype=dtype, device=device)
+        return workspace.get_buffer(name, shape, dtype, device)
 
     def _maybe_enable_torch_compile(self, module: object) -> None:
         """
@@ -527,6 +624,12 @@ class DenoisingStage(PipelineStage):
             A dictionary containing all the prepared variables for the denoising loop.
         """
         assert self.transformer is not None
+        if batch.extra.get("logged_workspace_flag") is None:
+            batch.extra["logged_workspace_flag"] = True
+            logger.info(
+                "SGLANG_DIFFUSION_PERSISTENT_WORKSPACE=%s",
+                getattr(envs, "SGLANG_DIFFUSION_PERSISTENT_WORKSPACE", False),
+            )
         pipeline = self.pipeline() if self.pipeline else None
 
         boundary_timestep = self._handle_boundary_ratio(server_args, batch)
@@ -631,6 +734,12 @@ class DenoisingStage(PipelineStage):
             latents.device,
         )
 
+        workspace = None
+        if self._workspace_enabled():
+            workspace = self._get_or_create_workspace(
+                batch, latents, target_dtype, server_args
+            )
+
         image_kwargs = self.prepare_extra_func_kwargs(
             getattr(self.transformer, "forward", self.transformer),
             {
@@ -700,6 +809,7 @@ class DenoisingStage(PipelineStage):
             "reserved_frames_mask": reserved_frames_mask_sp,  # Use SP-sharded version
             "seq_len": seq_len,
             "guidance": guidance,
+            "workspace": workspace,
         }
 
     def _post_denoising_loop(
@@ -901,6 +1011,7 @@ class DenoisingStage(PipelineStage):
         target_dtype,
         seq_len: int | None,
         reserved_frames_mask,
+        workspace: DiffusionWorkspace | None = None,
     ):
         bsz = batch.raw_latent_shape[0]
         should_preprocess_for_wan_ti2v = (
@@ -908,6 +1019,8 @@ class DenoisingStage(PipelineStage):
             and batch.condition_image is not None
             and type(server_args.pipeline_config) is Wan2_2_TI2V_5B_Config
         )
+
+        use_workspace = workspace is not None
 
         # expand timestep
         if should_preprocess_for_wan_ti2v:
@@ -926,24 +1039,59 @@ class DenoisingStage(PipelineStage):
                 # Rank 0 has the first frame, create a special timestep tensor
                 # NOTE: The spatial downsampling in the next line is suspicious but kept
                 # to match original model's potential training configuration.
-                temp_ts = (
-                    reserved_frames_mask[0][:, ::2, ::2] * t_device_rounded
-                ).flatten()
+                if use_workspace:
+                    timestep = self._get_or_create_buffer(
+                        workspace,
+                        "timestep_ti2v",
+                        (bsz, local_seq_len),
+                        target_dtype,
+                        t_device.device,
+                    )
+                    timestep.fill_(t_device_rounded)
+                    temp_ts_view = reserved_frames_mask[0][:, ::2, ::2]
+                    temp_len = temp_ts_view.numel()
+                    temp_slice = timestep[:, :temp_len]
+                    temp_slice.copy_(temp_ts_view.reshape(1, -1))
+                    temp_slice.mul_(t_device_rounded)
+                else:
+                    temp_ts = (
+                        reserved_frames_mask[0][:, ::2, ::2] * t_device_rounded
+                    ).flatten()
 
-                # Pad to full local sequence length
-                temp_ts = torch.cat(
-                    [
-                        temp_ts,
-                        temp_ts.new_ones(local_seq_len - temp_ts.size(0))
-                        * t_device_rounded,
-                    ]
-                )
-                timestep = temp_ts.unsqueeze(0).repeat(bsz, 1)
+                    # Pad to full local sequence length
+                    temp_ts = torch.cat(
+                        [
+                            temp_ts,
+                            temp_ts.new_ones(local_seq_len - temp_ts.size(0))
+                            * t_device_rounded,
+                        ]
+                    )
+                    timestep = temp_ts.unsqueeze(0).repeat(bsz, 1)
             else:
                 # Other ranks get a uniform timestep tensor of the correct shape [B, local_seq_len]
-                timestep = t_device.repeat(bsz, local_seq_len)
+                if use_workspace:
+                    timestep = self._get_or_create_buffer(
+                        workspace,
+                        "timestep_ti2v",
+                        (bsz, local_seq_len),
+                        t_device.dtype,
+                        t_device.device,
+                    )
+                    timestep.copy_(t_device.expand(bsz, local_seq_len))
+                else:
+                    timestep = t_device.repeat(bsz, local_seq_len)
         else:
-            timestep = t_device.repeat(bsz)
+            if use_workspace:
+                timestep = self._get_or_create_buffer(
+                    workspace,
+                    "timestep",
+                    (bsz,),
+                    t_device.dtype,
+                    t_device.device,
+                )
+                timestep.copy_(t_device.expand(bsz))
+            else:
+                timestep = t_device.repeat(bsz)
         return timestep
 
     def post_forward_for_ti2v_task(
@@ -1000,6 +1148,7 @@ class DenoisingStage(PipelineStage):
         reserved_frames_mask = prepared_vars["reserved_frames_mask"]
         seq_len = prepared_vars["seq_len"]
         guidance = prepared_vars["guidance"]
+        workspace = prepared_vars.get("workspace")
 
         # Initialize lists for ODE trajectory
         trajectory_timesteps: list[torch.Tensor] = []
@@ -1038,15 +1187,44 @@ class DenoisingStage(PipelineStage):
                         )
 
                         # Expand latents for I2V
-                        latent_model_input = latents.to(target_dtype)
+                        if workspace is not None:
+                            latent_model_input = self._get_or_create_buffer(
+                                workspace,
+                                "latent_model_input",
+                                tuple(latents.shape),
+                                target_dtype,
+                                latents.device,
+                            )
+                            latent_model_input.copy_(latents)
+                        else:
+                            latent_model_input = latents.to(target_dtype)
                         if batch.image_latent is not None:
                             assert (
                                 not server_args.pipeline_config.task_type
                                 == ModelTaskType.TI2V
                             ), "image latents should not be provided for TI2V task"
-                            latent_model_input = torch.cat(
-                                [latent_model_input, batch.image_latent], dim=1
-                            ).to(target_dtype)
+                            if workspace is not None:
+                                cat_shape = (
+                                    latent_model_input.shape[0],
+                                    latent_model_input.shape[1]
+                                    + batch.image_latent.shape[1],
+                                    *latent_model_input.shape[2:],
+                                )
+                                latent_cat = self._get_or_create_buffer(
+                                    workspace,
+                                    "latent_cat",
+                                    cat_shape,
+                                    target_dtype,
+                                    latent_model_input.device,
+                                )
+                                c = latent_model_input.shape[1]
+                                latent_cat[:, :c].copy_(latent_model_input)
+                                latent_cat[:, c:].copy_(batch.image_latent)
+                                latent_model_input = latent_cat
+                            else:
+                                latent_model_input = torch.cat(
+                                    [latent_model_input, batch.image_latent], dim=1
+                                ).to(target_dtype)
 
                         timestep = self.expand_timestep_before_forward(
                             batch,
@@ -1055,6 +1233,7 @@ class DenoisingStage(PipelineStage):
                             target_dtype,
                             seq_len,
                             reserved_frames_mask,
+                            workspace,
                         )
 
                         latent_model_input = self.scheduler.scale_model_input(
@@ -1279,8 +1458,17 @@ class DenoisingStage(PipelineStage):
             assert noise_pred_cond is not None
             cond_noise = noise_pred_cond
         else:
-            # TODO: cache this?
-            cond_noise = torch.empty_like(noise_pred)
+            workspace = self._get_workspace_entry(batch)
+            if workspace is not None:
+                cond_noise = self._get_or_create_buffer(
+                    workspace,
+                    "cond_noise",
+                    tuple(noise_pred.shape),
+                    noise_pred.dtype,
+                    noise_pred.device,
+                )
+            else:
+                cond_noise = torch.empty_like(noise_pred)
         cond_noise = get_cfg_group().broadcast(cond_noise, src=0)
 
         # qwen-image uses true_cfg_scale, match the per-token norm back to the conditional branch
@@ -1374,18 +1562,20 @@ class DenoisingStage(PipelineStage):
             i: The current timestep index.
         """
         attn_metadata = None
-        self.attn_metadata_builder = None
         try:
-            self.attn_metadata_builder_cls = self.attn_backend.get_builder_cls()
+            attn_metadata_builder_cls = self.attn_backend.get_builder_cls()
         except NotImplementedError:
-            self.attn_metadata_builder_cls = None
-        if self.attn_metadata_builder_cls:
-            self.attn_metadata_builder = self.attn_metadata_builder_cls()
+            attn_metadata_builder_cls = None
+        if attn_metadata_builder_cls:
+            attn_metadata_builder = batch.extra.get("attn_metadata_builder")
+            if not isinstance(attn_metadata_builder, attn_metadata_builder_cls):
+                attn_metadata_builder = attn_metadata_builder_cls()
+                batch.extra["attn_metadata_builder"] = attn_metadata_builder
         if (
             self.attn_backend.get_enum() == AttentionBackendEnum.SLIDING_TILE_ATTN
             or self.attn_backend.get_enum() == AttentionBackendEnum.VIDEO_SPARSE_ATTN
         ):
-            attn_metadata = self.attn_metadata_builder.build(
+            attn_metadata = attn_metadata_builder.build(
                 current_timestep=i,
                 raw_latent_shape=batch.raw_latent_shape[2:5],
                 patch_size=server_args.pipeline_config.dit_config.patch_size,
@@ -1461,7 +1651,7 @@ class DenoisingStage(PipelineStage):
                 if prompt_length is None:
                     prompt_length = context_length
 
-            attn_metadata = self.attn_metadata_builder.build(
+            attn_metadata = attn_metadata_builder.build(
                 current_timestep=current_timestep,
                 raw_latent_shape=batch.raw_latent_shape,
                 patch_size=patch_size,
@@ -1490,7 +1680,7 @@ class DenoisingStage(PipelineStage):
                 }
             )
         elif self.attn_backend.get_enum() == AttentionBackendEnum.FA:
-            attn_metadata = self.attn_metadata_builder.build(
+            attn_metadata = attn_metadata_builder.build(
                 raw_latent_shape=batch.raw_latent_shape
             )
         else:

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising_dmd.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising_dmd.py
@@ -69,13 +69,29 @@ class DmdDenoisingStage(DenoisingStage):
         autocast_enabled = prepared_vars["autocast_enabled"]
         num_warmup_steps = prepared_vars["num_warmup_steps"]
         latents = prepared_vars["latents"]
+        workspace = prepared_vars.get("workspace")
         video_raw_latent_shape = latents.shape
 
-        timesteps = torch.tensor(
-            server_args.pipeline_config.dmd_denoising_steps,
-            dtype=torch.long,
-            device=get_local_torch_device(),
-        )
+        dmd_steps = server_args.pipeline_config.dmd_denoising_steps
+        if not dmd_steps:
+            if batch.timesteps is None:
+                raise ValueError(
+                    "DMD denoising steps are not set and no timesteps were prepared. "
+                    "Provide dmd_denoising_steps in the pipeline config."
+                )
+            timesteps = batch.timesteps
+            if isinstance(timesteps, torch.Tensor):
+                timesteps = timesteps.to(
+                    device=get_local_torch_device(), dtype=torch.long
+                )
+            else:
+                timesteps = torch.tensor(
+                    timesteps, dtype=torch.long, device=get_local_torch_device()
+                )
+        else:
+            timesteps = torch.tensor(
+                dmd_steps, dtype=torch.long, device=get_local_torch_device()
+            )
 
         # prepare image_kwargs
         image_embeds = batch.image_embeds
@@ -121,23 +137,68 @@ class DmdDenoisingStage(DenoisingStage):
                         current_model = self.transformer
                         self._manage_device_placement(current_model, None, server_args)
                     # Expand latents for I2V
-                    noise_latents = latents.clone()
-                    latent_model_input = latents.to(target_dtype)
+                    if workspace is not None:
+                        noise_latents = self._get_or_create_buffer(
+                            workspace,
+                            "noise_latents",
+                            tuple(latents.shape),
+                            latents.dtype,
+                            latents.device,
+                        )
+                        noise_latents.copy_(latents)
+                        latent_model_input = self._get_or_create_buffer(
+                            workspace,
+                            "latent_model_input",
+                            tuple(latents.shape),
+                            target_dtype,
+                            latents.device,
+                        )
+                        latent_model_input.copy_(latents)
+                    else:
+                        noise_latents = latents.clone()
+                        latent_model_input = latents.to(target_dtype)
 
                     if batch.image_latent is not None:
-                        latent_model_input = torch.cat(
-                            [
-                                latent_model_input,
-                                batch.image_latent.permute(0, 2, 1, 3, 4),
-                            ],
-                            dim=2,
-                        ).to(target_dtype)
+                        image_latent = batch.image_latent.permute(0, 2, 1, 3, 4)
+                        if workspace is not None:
+                            cat_shape = (
+                                latent_model_input.shape[0],
+                                latent_model_input.shape[1],
+                                latent_model_input.shape[2] + image_latent.shape[2],
+                                *latent_model_input.shape[3:],
+                            )
+                            latent_cat = self._get_or_create_buffer(
+                                workspace,
+                                "latent_cat",
+                                cat_shape,
+                                target_dtype,
+                                latent_model_input.device,
+                            )
+                            c = latent_model_input.shape[2]
+                            latent_cat[:, :, :c].copy_(latent_model_input)
+                            latent_cat[:, :, c:].copy_(image_latent)
+                            latent_model_input = latent_cat
+                        else:
+                            latent_model_input = torch.cat(
+                                [latent_model_input, image_latent],
+                                dim=2,
+                            ).to(target_dtype)
                     assert not torch.isnan(
                         latent_model_input
                     ).any(), "latent_model_input contains nan"
 
                     # Prepare inputs for transformer
-                    t_expand = t.repeat(latent_model_input.shape[0])
+                    if workspace is not None:
+                        t_expand = self._get_or_create_buffer(
+                            workspace,
+                            "t_expand",
+                            (latent_model_input.shape[0],),
+                            t.dtype,
+                            t.device,
+                        )
+                        t_expand.copy_(t.expand_as(t_expand))
+                    else:
+                        t_expand = t.repeat(latent_model_input.shape[0])
 
                     guidance_expand = self.get_or_build_guidance(
                         latent_model_input.shape[0],
@@ -176,15 +237,33 @@ class DmdDenoisingStage(DenoisingStage):
                         ).unflatten(0, pred_noise.shape[:2])
 
                         if i < len(timesteps) - 1:
-                            next_timestep = timesteps[i + 1] * torch.ones(
-                                [1], dtype=torch.long, device=pred_video.device
-                            )
-                            noise = torch.randn(
-                                video_raw_latent_shape,
-                                dtype=pred_video.dtype,
-                                generator=batch.generator[0],
-                                device=self.device,
-                            )
+                            if workspace is not None:
+                                next_timestep = self._get_or_create_buffer(
+                                    workspace,
+                                    "next_timestep",
+                                    (1,),
+                                    timesteps.dtype,
+                                    pred_video.device,
+                                )
+                                next_timestep.fill_(timesteps[i + 1])
+                                noise = self._get_or_create_buffer(
+                                    workspace,
+                                    "noise",
+                                    tuple(video_raw_latent_shape),
+                                    pred_video.dtype,
+                                    self.device,
+                                )
+                                noise.normal_(generator=batch.generator[0])
+                            else:
+                                next_timestep = timesteps[i + 1] * torch.ones(
+                                    [1], dtype=torch.long, device=pred_video.device
+                                )
+                                noise = torch.randn(
+                                    video_raw_latent_shape,
+                                    dtype=pred_video.dtype,
+                                    generator=batch.generator[0],
+                                    device=self.device,
+                                )
                             latents = self.scheduler.add_noise(
                                 pred_video.flatten(0, 1),
                                 noise.flatten(0, 1),

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/helios_denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/helios_denoising.py
@@ -13,12 +13,16 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 
+from sglang.multimodal_gen import envs
 from sglang.multimodal_gen.runtime.distributed import get_local_torch_device
 from sglang.multimodal_gen.runtime.managers.forward_context import set_forward_context
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
 from sglang.multimodal_gen.runtime.pipelines_core.stages.base import (
     PipelineStage,
     StageParallelismType,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.stages.denoising import (
+    DiffusionWorkspace,
 )
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
@@ -86,6 +90,19 @@ def sample_block_noise(
     return noise
 
 
+def get_request_workspace(batch: Req, key: tuple) -> DiffusionWorkspace:
+    pool = batch.extra.get("diffusion_workspace")
+    if pool is None:
+        pool = {}
+        batch.extra["diffusion_workspace"] = pool
+    workspace = pool.get(key)
+    if workspace is None:
+        workspace = DiffusionWorkspace()
+        pool[key] = workspace
+    batch.extra["diffusion_workspace_key"] = key
+    return workspace
+
+
 class HeliosChunkedDenoisingStage(PipelineStage):
     """
     Helios chunked denoising stage implementing Stage 1 loop.
@@ -131,6 +148,34 @@ class HeliosChunkedDenoisingStage(PipelineStage):
         batch_size = latents.shape[0]
         do_cfg = guidance_scale > 1.0
 
+        workspace = None
+        if batch is not None and envs.SGLANG_DIFFUSION_PERSISTENT_WORKSPACE:
+            bucket_id = getattr(batch, "bucket_id", None)
+            key = (
+                device,
+                target_dtype,
+                tuple(latents.shape),
+                "helios_stage1",
+                bucket_id,
+            )
+            workspace = get_request_workspace(batch, key)
+
+        latents_history_short_cast = (
+            latents_history_short.to(target_dtype)
+            if latents_history_short is not None
+            else None
+        )
+        latents_history_mid_cast = (
+            latents_history_mid.to(target_dtype)
+            if latents_history_mid is not None
+            else None
+        )
+        latents_history_long_cast = (
+            latents_history_long.to(target_dtype)
+            if latents_history_long is not None
+            else None
+        )
+
         for i, t in enumerate(timesteps):
             with StageProfiler(
                 f"denoising_step_{global_step_offset + i}",
@@ -140,8 +185,21 @@ class HeliosChunkedDenoisingStage(PipelineStage):
                     batch.perf_dump_path is not None if batch is not None else False
                 ),
             ):
-                timestep = t.expand(batch_size)
-                latent_model_input = latents.to(target_dtype)
+                if workspace is not None:
+                    timestep = workspace.get_buffer(
+                        "timestep", (batch_size,), t.dtype, t.device
+                    )
+                    timestep.copy_(t.expand_as(timestep))
+                    latent_model_input = workspace.get_buffer(
+                        "latent_model_input",
+                        tuple(latents.shape),
+                        target_dtype,
+                        latents.device,
+                    )
+                    latent_model_input.copy_(latents)
+                else:
+                    timestep = t.expand(batch_size)
+                    latent_model_input = latents.to(target_dtype)
 
                 with set_forward_context(
                     current_timestep=t,
@@ -156,21 +214,9 @@ class HeliosChunkedDenoisingStage(PipelineStage):
                         indices_latents_history_short=indices_latents_history_short,
                         indices_latents_history_mid=indices_latents_history_mid,
                         indices_latents_history_long=indices_latents_history_long,
-                        latents_history_short=(
-                            latents_history_short.to(target_dtype)
-                            if latents_history_short is not None
-                            else None
-                        ),
-                        latents_history_mid=(
-                            latents_history_mid.to(target_dtype)
-                            if latents_history_mid is not None
-                            else None
-                        ),
-                        latents_history_long=(
-                            latents_history_long.to(target_dtype)
-                            if latents_history_long is not None
-                            else None
-                        ),
+                        latents_history_short=latents_history_short_cast,
+                        latents_history_mid=latents_history_mid_cast,
+                        latents_history_long=latents_history_long_cast,
                     )
 
                 if do_cfg:
@@ -187,21 +233,9 @@ class HeliosChunkedDenoisingStage(PipelineStage):
                             indices_latents_history_short=indices_latents_history_short,
                             indices_latents_history_mid=indices_latents_history_mid,
                             indices_latents_history_long=indices_latents_history_long,
-                            latents_history_short=(
-                                latents_history_short.to(target_dtype)
-                                if latents_history_short is not None
-                                else None
-                            ),
-                            latents_history_mid=(
-                                latents_history_mid.to(target_dtype)
-                                if latents_history_mid is not None
-                                else None
-                            ),
-                            latents_history_long=(
-                                latents_history_long.to(target_dtype)
-                                if latents_history_long is not None
-                                else None
-                            ),
+                            latents_history_short=latents_history_short_cast,
+                            latents_history_mid=latents_history_mid_cast,
+                            latents_history_long=latents_history_long_cast,
                         )
 
                     if is_cfg_zero_star:
@@ -282,6 +316,26 @@ class HeliosChunkedDenoisingStage(PipelineStage):
         do_cfg = guidance_scale > 1.0
         step_counter = global_step_offset
 
+        workspace_enabled = (
+            batch is not None and envs.SGLANG_DIFFUSION_PERSISTENT_WORKSPACE
+        )
+        bucket_id = getattr(batch, "bucket_id", None) if batch is not None else None
+        latents_history_short_cast = (
+            latents_history_short.to(target_dtype)
+            if latents_history_short is not None
+            else None
+        )
+        latents_history_mid_cast = (
+            latents_history_mid.to(target_dtype)
+            if latents_history_mid is not None
+            else None
+        )
+        latents_history_long_cast = (
+            latents_history_long.to(target_dtype)
+            if latents_history_long is not None
+            else None
+        )
+
         for i_s in range(pyramid_num_stages):
             # Compute mu for current resolution
             image_seq_len = (
@@ -300,6 +354,18 @@ class HeliosChunkedDenoisingStage(PipelineStage):
                 is_amplify_first_chunk=is_amplify_first_chunk,
             )
             timesteps = self.scheduler.timesteps
+
+            workspace = None
+            if workspace_enabled:
+                key = (
+                    device,
+                    target_dtype,
+                    tuple(latents.shape),
+                    "helios_stage2",
+                    i_s,
+                    bucket_id,
+                )
+                workspace = get_request_workspace(batch, key)
 
             if i_s > 0:
                 # Upsample 2x nearest-neighbor
@@ -339,8 +405,21 @@ class HeliosChunkedDenoisingStage(PipelineStage):
                         batch.perf_dump_path is not None if batch is not None else False
                     ),
                 ):
-                    timestep = t.expand(batch_size)
-                    latent_model_input = latents.to(target_dtype)
+                    if workspace is not None:
+                        timestep = workspace.get_buffer(
+                            "timestep", (batch_size,), t.dtype, t.device
+                        )
+                        timestep.copy_(t.expand_as(timestep))
+                        latent_model_input = workspace.get_buffer(
+                            "latent_model_input",
+                            tuple(latents.shape),
+                            target_dtype,
+                            latents.device,
+                        )
+                        latent_model_input.copy_(latents)
+                    else:
+                        timestep = t.expand(batch_size)
+                        latent_model_input = latents.to(target_dtype)
 
                     with set_forward_context(
                         current_timestep=t,
@@ -355,21 +434,9 @@ class HeliosChunkedDenoisingStage(PipelineStage):
                             indices_latents_history_short=indices_latents_history_short,
                             indices_latents_history_mid=indices_latents_history_mid,
                             indices_latents_history_long=indices_latents_history_long,
-                            latents_history_short=(
-                                latents_history_short.to(target_dtype)
-                                if latents_history_short is not None
-                                else None
-                            ),
-                            latents_history_mid=(
-                                latents_history_mid.to(target_dtype)
-                                if latents_history_mid is not None
-                                else None
-                            ),
-                            latents_history_long=(
-                                latents_history_long.to(target_dtype)
-                                if latents_history_long is not None
-                                else None
-                            ),
+                            latents_history_short=latents_history_short_cast,
+                            latents_history_mid=latents_history_mid_cast,
+                            latents_history_long=latents_history_long_cast,
                         )
 
                     if do_cfg:
@@ -386,21 +453,9 @@ class HeliosChunkedDenoisingStage(PipelineStage):
                                 indices_latents_history_short=indices_latents_history_short,
                                 indices_latents_history_mid=indices_latents_history_mid,
                                 indices_latents_history_long=indices_latents_history_long,
-                                latents_history_short=(
-                                    latents_history_short.to(target_dtype)
-                                    if latents_history_short is not None
-                                    else None
-                                ),
-                                latents_history_mid=(
-                                    latents_history_mid.to(target_dtype)
-                                    if latents_history_mid is not None
-                                    else None
-                                ),
-                                latents_history_long=(
-                                    latents_history_long.to(target_dtype)
-                                    if latents_history_long is not None
-                                    else None
-                                ),
+                                latents_history_short=latents_history_short_cast,
+                                latents_history_mid=latents_history_mid_cast,
+                                latents_history_long=latents_history_long_cast,
                             )
 
                         if is_cfg_zero_star:

--- a/python/sglang/multimodal_gen/test/test_denoising_workspace_cpu.py
+++ b/python/sglang/multimodal_gen/test/test_denoising_workspace_cpu.py
@@ -1,0 +1,20 @@
+import torch
+
+from sglang.multimodal_gen.runtime.pipelines_core.stages.denoising import (
+    DiffusionWorkspace,
+)
+
+
+def test_diffusion_workspace_reuses_buffers_cpu():
+    workspace = DiffusionWorkspace()
+    device = torch.device("cpu")
+
+    buf_a = workspace.get_buffer("latent", (2, 3), torch.float32, device)
+    buf_b = workspace.get_buffer("latent", (2, 3), torch.float32, device)
+    assert buf_a is buf_b
+
+    buf_c = workspace.get_buffer("latent", (2, 4), torch.float32, device)
+    assert buf_c is not buf_a
+
+    buf_d = workspace.get_buffer("latent", (2, 4), torch.float16, device)
+    assert buf_d is not buf_c

--- a/python/sglang/multimodal_gen/test/test_dummy_denoising_loop.py
+++ b/python/sglang/multimodal_gen/test/test_dummy_denoising_loop.py
@@ -152,6 +152,8 @@ def test_dummy_denoising_loop_accuracy():
     server_args = DummyServerArgs()
     previous_server_args = server_args_module._global_server_args
     set_global_server_args(server_args)
+    previous_get_attn_backend = denoising_module.get_attn_backend
+    previous_get_sp_world_size = denoising_module.get_sp_world_size
     try:
         denoising_module.get_attn_backend = lambda *args, **kwargs: DummyAttnBackend()
         denoising_module.get_sp_world_size = lambda: 1
@@ -175,4 +177,6 @@ def test_dummy_denoising_loop_accuracy():
 
         assert torch.allclose(result.latents, latents)
     finally:
+        denoising_module.get_attn_backend = previous_get_attn_backend
+        denoising_module.get_sp_world_size = previous_get_sp_world_size
         server_args_module._global_server_args = previous_server_args

--- a/python/sglang/multimodal_gen/test/test_dummy_denoising_loop.py
+++ b/python/sglang/multimodal_gen/test/test_dummy_denoising_loop.py
@@ -5,7 +5,9 @@ from dataclasses import dataclass, field
 import torch
 import torch.nn as nn
 
+import sglang.multimodal_gen.runtime.pipelines_core.stages.denoising as denoising_module
 from sglang.multimodal_gen.configs.pipeline_configs.base import ModelTaskType
+from sglang.multimodal_gen.runtime import server_args as server_args_module
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
 from sglang.multimodal_gen.runtime.pipelines_core.stages.denoising import (
     DenoisingStage,
@@ -148,27 +150,29 @@ def test_dummy_denoising_loop_accuracy():
     transformer = DummyTransformer().to(device)
     scheduler = DummyScheduler(num_steps=num_steps)
     server_args = DummyServerArgs()
+    previous_server_args = server_args_module._global_server_args
     set_global_server_args(server_args)
-    import sglang.multimodal_gen.runtime.pipelines_core.stages.denoising as denoising_module
+    try:
+        denoising_module.get_attn_backend = lambda *args, **kwargs: DummyAttnBackend()
+        denoising_module.get_sp_world_size = lambda: 1
+        stage = MinimalDenoisingStage(transformer=transformer, scheduler=scheduler)
 
-    denoising_module.get_attn_backend = lambda *args, **kwargs: DummyAttnBackend()
-    denoising_module.get_sp_world_size = lambda: 1
-    stage = MinimalDenoisingStage(transformer=transformer, scheduler=scheduler)
+        latents = torch.randn(
+            batch_size, channels, spatial_size, spatial_size, device=device
+        )
+        batch = Req(
+            prompt="dummy",
+            raw_latent_shape=[batch_size, channels, spatial_size, spatial_size],
+            latents=latents.clone(),
+            timesteps=scheduler.timesteps.to(device),
+            num_inference_steps=num_steps,
+            guidance_scale=1.0,
+            do_classifier_free_guidance=False,
+            return_trajectory_latents=False,
+        )
+        batch.extra = {}
+        result = stage.forward(batch=batch, server_args=server_args)
 
-    latents = torch.randn(
-        batch_size, channels, spatial_size, spatial_size, device=device
-    )
-    batch = Req(
-        prompt="dummy",
-        raw_latent_shape=[batch_size, channels, spatial_size, spatial_size],
-        latents=latents.clone(),
-        timesteps=scheduler.timesteps.to(device),
-        num_inference_steps=num_steps,
-        guidance_scale=1.0,
-        do_classifier_free_guidance=False,
-        return_trajectory_latents=False,
-    )
-    batch.extra = {}
-    result = stage.forward(batch=batch, server_args=server_args)
-
-    assert torch.allclose(result.latents, latents)
+        assert torch.allclose(result.latents, latents)
+    finally:
+        server_args_module._global_server_args = previous_server_args

--- a/python/sglang/multimodal_gen/test/test_dummy_denoising_loop.py
+++ b/python/sglang/multimodal_gen/test/test_dummy_denoising_loop.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import torch
+import torch.nn as nn
+
+from sglang.multimodal_gen.configs.pipeline_configs.base import ModelTaskType
+from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
+from sglang.multimodal_gen.runtime.pipelines_core.stages.denoising import (
+    DenoisingStage,
+)
+from sglang.multimodal_gen.runtime.server_args import set_global_server_args
+
+
+class DummyTransformer(nn.Module):
+    def forward(self, hidden_states, timestep, **kwargs):
+        return torch.zeros_like(hidden_states)
+
+
+class DummyAttnBackend:
+    def get_enum(self):
+        return "DUMMY"
+
+    def get_builder_cls(self):
+        return None
+
+
+class DummyScheduler:
+    def __init__(self, num_steps: int) -> None:
+        self.num_inference_steps = num_steps
+        self.timesteps = torch.arange(num_steps, 0, -1, dtype=torch.float32)
+        self.order = 1
+
+    def set_timesteps(self, num_steps, device=None):
+        self.timesteps = torch.arange(
+            num_steps, 0, -1, dtype=torch.float32, device=device
+        )
+
+    def set_begin_index(self, index: int) -> None:
+        return None
+
+    def scale_model_input(self, sample, timestep):
+        return sample
+
+    def step(self, model_output, timestep, sample, **kwargs):
+        return (sample,)
+
+
+@dataclass
+class DummyDiTConfig:
+    hidden_size: int = 64
+    num_attention_heads: int = 8
+
+
+@dataclass
+class DummyPipelineConfig:
+    task_type: ModelTaskType = ModelTaskType.T2I
+    embedded_cfg_scale: float = 1.0
+    should_use_guidance: bool = False
+    dit_config: DummyDiTConfig = field(default_factory=DummyDiTConfig)
+
+    def slice_noise_pred(self, noise_pred, latents):
+        return noise_pred
+
+    def get_classifier_free_guidance_scale(self, batch, guidance_scale):
+        return guidance_scale
+
+    def postprocess_cfg_noise(self, batch, noise_pred, noise_pred_cond):
+        return noise_pred
+
+    def post_denoising_loop(self, latents, batch):
+        return latents
+
+
+@dataclass
+class DummyServerArgs:
+    pipeline_config: DummyPipelineConfig = field(default_factory=DummyPipelineConfig)
+    enable_cfg_parallel: bool = False
+    comfyui_mode: bool = False
+    disable_autocast: bool = True
+    enable_torch_compile: bool = False
+    device: str = "cpu"
+
+
+class MinimalDenoisingStage(DenoisingStage):
+    def _prepare_denoising_loop(self, batch: Req, server_args: DummyServerArgs):
+        timesteps = batch.timesteps
+        num_inference_steps = batch.num_inference_steps
+        return {
+            "extra_step_kwargs": {},
+            "target_dtype": batch.latents.dtype,
+            "autocast_enabled": False,
+            "timesteps": timesteps,
+            "num_inference_steps": num_inference_steps,
+            "num_warmup_steps": 0,
+            "image_kwargs": {},
+            "pos_cond_kwargs": {},
+            "neg_cond_kwargs": {},
+            "latents": batch.latents,
+            "boundary_timestep": None,
+            "z": None,
+            "reserved_frames_mask": None,
+            "seq_len": None,
+            "guidance": None,
+            "workspace": None,
+        }
+
+    def _build_attn_metadata(self, *args, **kwargs):
+        return None
+
+    def _select_and_manage_model(self, t_int, boundary_timestep, server_args, batch):
+        return self.transformer, batch.guidance_scale
+
+    def _predict_noise_with_cfg(
+        self,
+        current_model,
+        latent_model_input,
+        timestep,
+        **kwargs,
+    ):
+        return current_model(hidden_states=latent_model_input, timestep=timestep)
+
+    def progress_bar(self, iterable=None, total=None):
+        class _Bar:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def update(self, *args, **kwargs):
+                return None
+
+        return _Bar()
+
+    def step_profile(self):
+        return None
+
+
+def test_dummy_denoising_loop_accuracy():
+    device = torch.device("cpu")
+    batch_size = 1
+    channels = 4
+    spatial_size = 8
+    num_steps = 4
+
+    transformer = DummyTransformer().to(device)
+    scheduler = DummyScheduler(num_steps=num_steps)
+    server_args = DummyServerArgs()
+    set_global_server_args(server_args)
+    import sglang.multimodal_gen.runtime.pipelines_core.stages.denoising as denoising_module
+
+    denoising_module.get_attn_backend = lambda *args, **kwargs: DummyAttnBackend()
+    denoising_module.get_sp_world_size = lambda: 1
+    stage = MinimalDenoisingStage(transformer=transformer, scheduler=scheduler)
+
+    latents = torch.randn(
+        batch_size, channels, spatial_size, spatial_size, device=device
+    )
+    batch = Req(
+        prompt="dummy",
+        raw_latent_shape=[batch_size, channels, spatial_size, spatial_size],
+        latents=latents.clone(),
+        timesteps=scheduler.timesteps.to(device),
+        num_inference_steps=num_steps,
+        guidance_scale=1.0,
+        do_classifier_free_guidance=False,
+        return_trajectory_latents=False,
+    )
+    batch.extra = {}
+    result = stage.forward(batch=batch, server_args=server_args)
+
+    assert torch.allclose(result.latents, latents)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Reduce per‑step allocation overhead in diffusion denoising loops by reusing persistent per‑request buffers, and extend random benchmarks to support image‑conditional tasks (I2V/I2I). 

## Modifications
- Add a persistent workspace cache to reuse tensors across denoising steps.                                                                  
- Wire workspace reuse into standard, DMD, and Helios denoising stages.                                                                      
- Introduce  SGLANG_DIFFUSION_PERSISTENT_WORKSPACE  env flag.                                                                                
- Extend random benchmark to support image‑conditional tasks: 
  - require  --image-path  for image‑conditional random runs,                                                                                
  - pass  image_paths  into requests.                                                                                                        
- Add CPU unit tests for the denoising loop and workspace reuse.  
- Note: Helios‑Mid benchmarking requires upstream bug fixes               
                                                                  
## Accuracy Tests

Not run (no algorithmic change to model outputs; buffer reuse only).   

## Benchmarking and Profiling

Environment: H200, single GPU   
Note: We cover all three denoising loops and select a representative model for each
- DMD loop: Wan2.2‑I2V‑A14B‑Diffusers  
- Standard loop: FLUX.2‑klein‑4B  
- Helios loop: Helios‑Mid
                                                                                              
Commands:
- For Wan2.2-I2V-A14B-Diffusers 
    ```
    export SGLANG_DIFFUSION_PERSISTENT_WORKSPACE=true 

    CUDA_VISIBLE_DEVICES=1 python -m sglang.multimodal_gen.runtime.launch_server \                                                             
      --model-path models/Wan2.2-I2V-A14B-Diffusers \                                                                                  
      --num-gpus 1 --port 1234 --log-level debug \                                                                                             
      --dmd-denoising-steps 1000,757,522  

    python -m sglang.multimodal_gen.benchmarks.bench_serving \                                                                                 
      --dataset random --num-prompts 10 --height 512 --width 512 \                                                                             
      --num-inference-steps 20 --port 1234 \                                                                                                   
      --image-path models/Wan2.2-I2V-A14B-Diffusers/examples/i2v_input.JPG \                                                           
      --task image-to-video
    ```

- For FLUX.2-klein-4B
    ```
    export SGLANG_DIFFUSION_PERSISTENT_WORKSPACE=true 

    CUDA_VISIBLE_DEVICES=1 python -m sglang.multimodal_gen.runtime.launch_server \                                                             
      --model-path models/FLUX.2-klein-4B \                                                                                  
      --num-gpus 1 --port 1234 --log-level debug  

    python -m sglang.multimodal_gen.benchmarks.bench_serving \                                                                                 
      --dataset random --num-prompts 10 --height 512 --width 512 \                                                                             
      --num-inference-steps 20 --port 1234                                                                                          
    ```     
                                                                                                                                  
- For Helios-Mid
    ```
    export SGLANG_DIFFUSION_PERSISTENT_WORKSPACE=true 

    CUDA_VISIBLE_DEVICES=1 python -m sglang.multimodal_gen.runtime.launch_server \                                                             
      --model-path models/Helios-Mid \                                                                                  
      --num-gpus 1 --port 1234 --log-level debug  

    python -m sglang.multimodal_gen.benchmarks.bench_serving \                                                                                 
      --dataset random --num-prompts 10 --height 512 --width 512 \                                                                             
      --num-inference-steps 20 --port 1234                                                                                          
    ```    

## Results

| Model | Loop | Feature enabled | Latency mean | P99 | Peak mem mean | Mean latency delta | P99 delta | Peak mem delta |
|---|---|---:|---:|---:|---:|---:|---:|---:|
| Wan2.2-I2V-A14B | DMD loop | true  | 69.42s  | 70.13s  | 41456 MB | -0.29s | -0.89s | -86 MB |
| Wan2.2-I2V-A14B | DMD loop | false | 69.71s  | 71.02s  | 41542 MB | baseline | baseline | baseline |
| FLUX.2-klein-4B | standard loop | true  | 0.28s | 0.33s | 9972 MB | -0.01s | +0.04s | 0 MB |
| FLUX.2-klein-4B | standard loop | false | 0.29s | 0.29s | 9972 MB | baseline | baseline | baseline |
| Helios-Mid | Helios loop | true  | 227.27s | 228.91s | 33513 MB | -4.44s | -4.16s | +8 MB |
| Helios-Mid | Helios loop | false | 231.71s | 233.07s | 33505 MB | baseline | baseline | baseline |

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

