### PR TITLE
[FlashInver v0.6.7] Integrate flashinfer_trtllm mxfp8 gemm

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -495,19 +495,43 @@ class Fp8LinearMethod(LinearMethodBase):
             return
 
         if get_fp8_gemm_runner_backend().is_flashinfer_trtllm():
+            from flashinfer import shuffle_matrix_a, shuffle_matrix_sf_a
+
+            weight = layer.weight.data
+            scale_u8 = layer.weight_scale_inv.data
+            n, k = weight.shape
+            epilogue_tile_m = 128
+
+            copy_or_rebind_param(
+                layer,
+                "weight",
+                shuffle_matrix_a(
+                    weight.contiguous().view(torch.uint8), epilogue_tile_m
+                ).view(torch.float8_e4m3fn),
+            )
+            copy_or_rebind_param(
+                layer,
+                "weight_scale_inv",
+                shuffle_matrix_sf_a(
+                    scale_u8.contiguous().view(torch.uint8).reshape(n, k // 32),
+                    epilogue_tile_m,
+                    num_elts_per_sf=32,
+                )
+                .reshape_as(scale_u8)
+                .contiguous(),
+            )
+        elif get_fp8_gemm_runner_backend().is_flashinfer_cutlass():
             from flashinfer import block_scale_interleave
 
             scale_u8 = layer.weight_scale_inv.data
-            new_swizzled = block_scale_interleave(scale_u8.contiguous()).contiguous()
+            copy_or_rebind_param(
+                layer,
+                "weight_scale_inv",
+                block_scale_interleave(scale_u8.contiguous()).contiguous(),
+            )
         else:
             # Triton path consumes canonical 2D UE8M0 scales directly.
             return
-
-        copy_or_rebind_param(layer, "weight_scale_inv_swizzled", new_swizzled)
-        layer._weight_scale_inv_swizzled_src_version = layer.weight_scale_inv._version
-        layer._weight_scale_inv_swizzled_src_data_ptr = (
-            layer.weight_scale_inv.data_ptr()
-        )
 
     def _quantize_mxfp8_weights(self, layer: Module) -> None:
         weight = layer.weight.data
@@ -657,22 +681,18 @@ class Fp8LinearMethod(LinearMethodBase):
             )
 
         if self.use_mxfp8:
-            if get_fp8_gemm_runner_backend().is_flashinfer_trtllm():
-                weight_scale = layer.weight_scale_inv_swizzled
-            else:
-                weight_scale = layer.weight_scale_inv
             if isinstance(x, tuple):
                 return self.w8a8_mxfp8_linear(
                     input=x[0],
                     weight=layer.weight,
-                    weight_scale=weight_scale,
+                    weight_scale=layer.weight_scale_inv,
                     input_scale=x[1],
                     bias=bias,
                 )
             return self.w8a8_mxfp8_linear(
                 input=x,
                 weight=layer.weight,
-                weight_scale=weight_scale,
+                weight_scale=layer.weight_scale_inv,
                 input_scale=None,
                 bias=bias,
             )

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -214,6 +214,7 @@ def _check_cutlass_block_fp8_hardware_support() -> bool:
 
 
 if is_blackwell_supported() and is_flashinfer_available():
+    from flashinfer import SfLayout
     from flashinfer import mm_mxfp8 as _raw_flashinfer_mm_mxfp8
     from flashinfer import mxfp8_quantize as _raw_flashinfer_mxfp8_quantize
     from flashinfer.gemm import gemm_fp8_nt_groupwise as _raw_gemm_fp8_nt_groupwise
@@ -279,6 +280,7 @@ if is_blackwell_supported() and is_flashinfer_available():
         input: torch.Tensor,
         _is_sf_swizzled_layout: bool = True,
         alignment: int = 32,
+        _use_8x4_sf_layout: bool = False,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         # Fake mode only needs dtypes and output rank to propagate compile graph.
         # The scale tensor shape is not consumed before the following fake mm op.
@@ -298,7 +300,21 @@ if is_blackwell_supported() and is_flashinfer_available():
         input: torch.Tensor,
         is_sf_swizzled_layout: bool = True,
         alignment: int = 32,
+        use_8x4_sf_layout: bool = False,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if is_sf_swizzled_layout:
+            if use_8x4_sf_layout:
+                return _raw_flashinfer_mxfp8_quantize(
+                    input,
+                    sf_swizzle_layout=SfLayout.layout_8x4,
+                    alignment=alignment,
+                )
+            else:
+                return _raw_flashinfer_mxfp8_quantize(
+                    input,
+                    sf_swizzle_layout=SfLayout.layout_128x4,
+                    alignment=alignment,
+                )
         return _raw_flashinfer_mxfp8_quantize(
             input,
             is_sf_swizzled_layout=is_sf_swizzled_layout,
@@ -308,7 +324,7 @@ if is_blackwell_supported() and is_flashinfer_available():
     @register_custom_op(
         op_name="flashinfer_mm_mxfp8",
         mutates_args=[],
-        fake_impl=lambda q_input, weight_t, x_scale_u8, weight_scale_t, out_dtype, backend="auto": (
+        fake_impl=lambda q_input, weight_t, x_scale_u8, weight_scale_t, out_dtype, use_8x4_sf_layout=False, backend="auto": (
             q_input.new_empty((q_input.shape[0], weight_t.shape[1]), dtype=out_dtype)
         ),
     )
@@ -318,6 +334,7 @@ if is_blackwell_supported() and is_flashinfer_available():
         x_scale_u8: torch.Tensor,
         weight_scale_t: torch.Tensor,
         out_dtype: torch.dtype,
+        use_8x4_sf_layout: bool = False,
         backend: str = "auto",
     ) -> torch.Tensor:
         return _raw_flashinfer_mm_mxfp8(
@@ -326,6 +343,7 @@ if is_blackwell_supported() and is_flashinfer_available():
             x_scale_u8,
             weight_scale_t,
             out_dtype=out_dtype,
+            use_8x4_sf_layout=use_8x4_sf_layout,
             backend=backend,
         )
 
@@ -357,10 +375,12 @@ def dispatch_w8a8_mxfp8_linear() -> Callable:
     """Dispatch MXFP8 linear kernel by --fp8-gemm-backend.
 
     For MXFP8, Triton remains the default path. We only route to FlashInfer
-    when backend is explicitly set to flashinfer_trtllm.
+    when backend is explicitly set to flashinfer_cutlass or flashinfer_trtllm.
     """
     backend = get_fp8_gemm_runner_backend()
     if backend.is_flashinfer_trtllm():
+        return flashinfer_mxfp8_blockscaled_linear
+    elif backend.is_flashinfer_cutlass():
         return flashinfer_mxfp8_blockscaled_linear
     return triton_mxfp8_blockscaled_linear
 
@@ -944,6 +964,8 @@ def flashinfer_mxfp8_blockscaled_linear(
     output_dtype: Optional[torch.dtype] = None,
 ) -> torch.Tensor:
     """MXFP8 dense linear via FlashInfer mm_mxfp8."""
+    use_8x4_sf_layout = get_fp8_gemm_runner_backend().is_flashinfer_trtllm()
+
     input_2d = input.view(-1, input.shape[-1]).contiguous()
     output_shape = [*input.shape[:-1], weight.shape[0]]
 
@@ -958,10 +980,14 @@ def flashinfer_mxfp8_blockscaled_linear(
 
     if input_scale is None:
         q_input, x_scale_u8 = flashinfer_mxfp8_quantize(
-            input_2d, is_sf_swizzled_layout=True, alignment=32
+            input_2d,
+            is_sf_swizzled_layout=True,
+            alignment=32,
+            use_8x4_sf_layout=use_8x4_sf_layout,
         )
     else:
         q_input = input_2d
+        x_scale_u8 = input_scale.contiguous()
 
     if output_dtype is None:
         if input_2d.dtype in (torch.float16, torch.bfloat16, torch.float32):
@@ -971,19 +997,34 @@ def flashinfer_mxfp8_blockscaled_linear(
 
     # Ensure transposed tensors are contiguous for FlashInfer's internal runner.
     weight_t = weight.contiguous().t()
-    weight_scale_t = (
-        weight_scale.contiguous().t()
-        if weight_scale.ndim == 2
-        else weight_scale.contiguous()
-    )
-    output = flashinfer_mm_mxfp8(
-        q_input,
-        weight_t,
-        x_scale_u8,
-        weight_scale_t,
-        out_dtype=output_dtype,
-        backend="auto",
-    )
+
+    if get_fp8_gemm_runner_backend().is_flashinfer_trtllm():
+
+        weight_scale_t = weight_scale.contiguous().view(-1)
+        output = flashinfer_mm_mxfp8(
+            q_input,
+            weight_t,
+            x_scale_u8,
+            weight_scale_t,
+            out_dtype=output_dtype,
+            use_8x4_sf_layout=use_8x4_sf_layout,
+            backend="trtllm",
+        )
+    elif get_fp8_gemm_runner_backend().is_flashinfer_cutlass():
+        weight_scale_t = (
+            weight_scale.contiguous().t()
+            if weight_scale.ndim == 2
+            else weight_scale.contiguous()
+        )
+        output = flashinfer_mm_mxfp8(
+            q_input,
+            weight_t,
+            x_scale_u8,
+            weight_scale_t,
+            out_dtype=output_dtype,
+            use_8x4_sf_layout=False,
+            backend="cutlass",
+        )
 
     if bias is not None:
         output += bias

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -280,7 +280,6 @@ if is_blackwell_supported() and is_flashinfer_available():
         input: torch.Tensor,
         _is_sf_swizzled_layout: bool = True,
         alignment: int = 32,
-        _use_8x4_sf_layout: bool = False,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         # Fake mode only needs dtypes and output rank to propagate compile graph.
         # The scale tensor shape is not consumed before the following fake mm op.
@@ -300,25 +299,12 @@ if is_blackwell_supported() and is_flashinfer_available():
         input: torch.Tensor,
         is_sf_swizzled_layout: bool = True,
         alignment: int = 32,
-        use_8x4_sf_layout: bool = False,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        if is_sf_swizzled_layout:
-            if use_8x4_sf_layout:
-                return _raw_flashinfer_mxfp8_quantize(
-                    input,
-                    sf_swizzle_layout=SfLayout.layout_8x4,
-                    alignment=alignment,
-                )
-            else:
-                return _raw_flashinfer_mxfp8_quantize(
-                    input,
-                    sf_swizzle_layout=SfLayout.layout_128x4,
-                    alignment=alignment,
-                )
         return _raw_flashinfer_mxfp8_quantize(
             input,
             is_sf_swizzled_layout=is_sf_swizzled_layout,
             alignment=alignment,
+            sf_swizzle_layout=SfLayout.layout_128x4,
         )
 
     @register_custom_op(
@@ -964,8 +950,6 @@ def flashinfer_mxfp8_blockscaled_linear(
     output_dtype: Optional[torch.dtype] = None,
 ) -> torch.Tensor:
     """MXFP8 dense linear via FlashInfer mm_mxfp8."""
-    use_8x4_sf_layout = get_fp8_gemm_runner_backend().is_flashinfer_trtllm()
-
     input_2d = input.view(-1, input.shape[-1]).contiguous()
     output_shape = [*input.shape[:-1], weight.shape[0]]
 
@@ -980,10 +964,7 @@ def flashinfer_mxfp8_blockscaled_linear(
 
     if input_scale is None:
         q_input, x_scale_u8 = flashinfer_mxfp8_quantize(
-            input_2d,
-            is_sf_swizzled_layout=True,
-            alignment=32,
-            use_8x4_sf_layout=use_8x4_sf_layout,
+            input_2d, is_sf_swizzled_layout=True, alignment=32
         )
     else:
         q_input = input_2d
@@ -1007,7 +988,7 @@ def flashinfer_mxfp8_blockscaled_linear(
             x_scale_u8,
             weight_scale_t,
             out_dtype=output_dtype,
-            use_8x4_sf_layout=use_8x4_sf_layout,
+            use_8x4_sf_layout=False,
             backend="trtllm",
         )
     elif get_fp8_gemm_runner_backend().is_flashinfer_cutlass():

--- a/test/registered/quant/test_fp8_blockwise_gemm.py
+++ b/test/registered/quant/test_fp8_blockwise_gemm.py
@@ -73,6 +73,8 @@ class MXFP8GemmBase:
             "--trust-remote-code",
             "--fp8-gemm-backend",
             cls.backend,
+            "--attention-backend",
+            "triton",
         ]
         cls.process = popen_launch_server(
             cls.model,
@@ -129,6 +131,11 @@ class TestMXFP8GemmTriton(MXFP8GemmBase, unittest.TestCase):
 @unittest.skipIf(get_device_sm() < 100, "Test requires CUDA SM 100 or higher")
 class TestMXFP8GemmFlashinferTrtllm(MXFP8GemmBase, unittest.TestCase):
     backend = "flashinfer_trtllm"
+
+
+@unittest.skipIf(get_device_sm() < 100, "Test requires CUDA SM 100 or higher")
+class TestMXFP8GemmFlashinferCutlass(MXFP8GemmBase, unittest.TestCase):
+    backend = "flashinfer_cutlass"
 
 
 if __name__ == "__main__":

--- a/test/registered/quant/test_fp8_blockwise_gemm.py
+++ b/test/registered/quant/test_fp8_blockwise_gemm.py
@@ -73,8 +73,6 @@ class MXFP8GemmBase:
             "--trust-remote-code",
             "--fp8-gemm-backend",
             cls.backend,
-            "--attention-backend",
-            "triton",
         ]
         cls.process = popen_launch_server(
             cls.model,

--- a/test/registered/rl/test_update_weights_from_disk_mxfp8.py
+++ b/test/registered/rl/test_update_weights_from_disk_mxfp8.py
@@ -45,6 +45,9 @@ class TestServerUpdateWeightsFromDiskMXFP8(CustomTestCase):
                 fp8_gemm_backend,
                 "--moe-runner-backend",
                 moe_runner_backend,
+                "--attention-backend",
+                "triton",
+                "--enable-deterministic-inference",
             ],
         )
 

--- a/test/registered/rl/test_update_weights_from_disk_mxfp8.py
+++ b/test/registered/rl/test_update_weights_from_disk_mxfp8.py
@@ -45,9 +45,6 @@ class TestServerUpdateWeightsFromDiskMXFP8(CustomTestCase):
                 fp8_gemm_backend,
                 "--moe-runner-backend",
                 moe_runner_backend,
-                "--attention-backend",
-                "triton",
-                "--enable-deterministic-inference",
             ],
         )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
@humansand

Integrate FlashInfer v0.6.7 trtllm gen mxfp8 gemm from https://github.com/flashinfer-ai/flashinfer/pull/2653 @IwakuraRein .

Now both `flashinfer_trtllm` and `flashinfer_cutlass` support mxfp8.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

- Integrate `flashinfer_mm_mxfp8` `backend="cutlass"`, `backend="trtllm"`
- Avoid storing both swizzled & non-swizzled scaling factors
    - Use `copy_or_rebind_param` for in-place replace in `process_weights_after_loading`
- Expand test coverage

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
`test/registered/rl/test_update_weights_from_disk_mxfp8.py` and `test/registered/quant/test_fp8_blockwise_gemm.py` passed.

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling
### GSM8K
```
python3 -m sglang.launch_server --kv-cache-dtype bf16 --model zianglih/Qwen3-4B-Instruct-2507-MXFP8 --fp8-gemm-backend flashinfer_trtllm
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1209 --parallel 1209 --platinum
Accuracy: 0.841
Invalid: 0.000
Latency: 8.748 s
Output throughput: 24524.995 token/s
Accuracy: 0.841
Invalid: 0.000
Latency: 8.927 s
Output throughput: 24031.762 token/s

python3 -m sglang.launch_server --kv-cache-dtype bf16 --model zianglih/Qwen3-4B-Instruct-2507-MXFP8 --fp8-gemm-backend flashinfer_cutlass
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1209 --parallel 1209 --platinum
Accuracy: 0.841
Invalid: 0.000
Latency: 8.618 s
Output throughput: 24892.399 token/s
Accuracy: 0.841
Invalid: 0.000
Latency: 8.822 s
Output throughput: 24317.718 token/s
```
### `bench_serving`
bs 64
```
[
    {
        "timestamp": "2026-04-01-18-59",
        "device_type": "nvidia",
        "env_vars": {},
        "sglang_server_args": {
            "--disable-piecewise-cuda-graph": true,
            "--tp": 1,
            "--fp8-gemm-backend": "flashinfer_trtllm",
            "--max-running-requests": 64,
            "--cuda-graph-max-bs": 256,
            "--stream-interval": 256
        },
        "inside_container": true,
        "docker_image": "unknown",
        "warmup_requests": 1,
        "model_path": "zianglih/Qwen3-4B-Instruct-2507-MXFP8",
        "num_prompts": 256,
        "random_input": 1024,
        "random_output": 2048,
        "function": "benchmark_sglang",
        "server_command": "bash -c ' python3 -m sglang.launch_server --model-path zianglih/Qwen3-4B-Instruct-2507-MXFP8 --disable-piecewise-cuda-graph --tp 1 --fp8-gemm-backend flashinfer_trtllm --max-running-requests 64 --cuda-graph-max-bs 256 --stream-interval 256 --trust-remote-code --host 0.0.0.0 --port 30000'",
        "bench_serving_command": "bash -c ' python3 -m sglang.bench_serving --warmup-requests 1 --backend sglang --dataset-name random-ids --random-range-ratio 0 --num-prompts 256 --random-input 1024 --random-output 2048 --host 0.0.0.0 --port 30000 '",
        "benchmark_result": [
            "============ Serving Benchmark Result ============",
            "Backend:                                 sglang",
            "Traffic request rate:                    inf",
            "Max request concurrency:                 not set",
            "Successful requests:                     256",
            "Benchmark duration (s):                  29.84",
            "Total input tokens:                      131653",
            "Total input text tokens:                 131653",
            "Total generated tokens:                  253220",
            "Total generated tokens (retokenized):    249283",
            "Request throughput (req/s):              8.58",
            "Input token throughput (tok/s):          4412.06",
            "Output token throughput (tok/s):         8486.11",
            "Peak output token throughput (tok/s):    11862.00",
            "Peak concurrent requests:                256",
            "Total token throughput (tok/s):          12898.17",
            "Concurrency:                             127.79",
            "----------------End-to-End Latency----------------",
            "Mean E2E Latency (ms):                   14894.72",
            "Median E2E Latency (ms):                 15302.80",
            "P90 E2E Latency (ms):                    24605.82",
            "P99 E2E Latency (ms):                    28061.47",
            "---------------Time to First Token----------------",
            "Mean TTFT (ms):                          9089.05",
            "Median TTFT (ms):                        8720.21",
            "P99 TTFT (ms):                           21029.56",
            "-----Time per Output Token (excl. 1st token)------",
            "Mean TPOT (ms):                          5.81",
            "Median TPOT (ms):                        6.05",
            "P99 TPOT (ms):                           6.47",
            "---------------Inter-Token Latency----------------",
            "Mean ITL (ms):                           5.99",
            "Median ITL (ms):                         6.17",
            "P95 ITL (ms):                            6.56",
            "P99 ITL (ms):                            6.73",
            "Max ITL (ms):                            7.06",
            "=================================================="
        ]
    },
    {
        "timestamp": "2026-04-01-18-59",
        "device_type": "nvidia",
        "env_vars": {},
        "sglang_server_args": {
            "--disable-piecewise-cuda-graph": true,
            "--tp": 1,
            "--fp8-gemm-backend": "flashinfer_cutlass",
            "--max-running-requests": 64,
            "--cuda-graph-max-bs": 256,
            "--stream-interval": 256
        },
        "inside_container": true,
        "docker_image": "unknown",
        "warmup_requests": 1,
        "model_path": "zianglih/Qwen3-4B-Instruct-2507-MXFP8",
        "num_prompts": 256,
        "random_input": 1024,
        "random_output": 2048,
        "function": "benchmark_sglang",
        "server_command": "bash -c ' python3 -m sglang.launch_server --model-path zianglih/Qwen3-4B-Instruct-2507-MXFP8 --disable-piecewise-cuda-graph --tp 1 --fp8-gemm-backend flashinfer_cutlass --max-running-requests 64 --cuda-graph-max-bs 256 --stream-interval 256 --trust-remote-code --host 0.0.0.0 --port 30000'",
        "bench_serving_command": "bash -c ' python3 -m sglang.bench_serving --warmup-requests 1 --backend sglang --dataset-name random-ids --random-range-ratio 0 --num-prompts 256 --random-input 1024 --random-output 2048 --host 0.0.0.0 --port 30000 '",
        "benchmark_result": [
            "============ Serving Benchmark Result ============",
            "Backend:                                 sglang",
            "Traffic request rate:                    inf",
            "Max request concurrency:                 not set",
            "Successful requests:                     256",
            "Benchmark duration (s):                  30.36",
            "Total input tokens:                      131653",
            "Total input text tokens:                 131653",
            "Total generated tokens:                  253220",
            "Total generated tokens (retokenized):    249283",
            "Request throughput (req/s):              8.43",
            "Input token throughput (tok/s):          4336.85",
            "Output token throughput (tok/s):         8341.45",
            "Peak output token throughput (tok/s):    13773.00",
            "Peak concurrent requests:                256",
            "Total token throughput (tok/s):          12678.30",
            "Concurrency:                             122.76",
            "----------------End-to-End Latency----------------",
            "Mean E2E Latency (ms):                   14557.20",
            "Median E2E Latency (ms):                 14925.02",
            "P90 E2E Latency (ms):                    24314.44",
            "P99 E2E Latency (ms):                    28253.46",
            "---------------Time to First Token----------------",
            "Mean TTFT (ms):                          8815.18",
            "Median TTFT (ms):                        8403.28",
            "P99 TTFT (ms):                           20503.95",
            "-----Time per Output Token (excl. 1st token)------",
            "Mean TPOT (ms):                          5.66",
            "Median TPOT (ms):                        6.02",
            "P99 TPOT (ms):                           6.32",
            "---------------Inter-Token Latency----------------",
            "Mean ITL (ms):                           5.92",
            "Median ITL (ms):                         6.08",
            "P95 ITL (ms):                            6.32",
            "P99 ITL (ms):                            6.37",
            "Max ITL (ms):                            6.80",
            "=================================================="
        ]
    },
    {
        "timestamp": "2026-04-01-18-59",
        "device_type": "nvidia",
        "env_vars": {},
        "sglang_server_args": {
            "--disable-piecewise-cuda-graph": true,
            "--tp": 1,
            "--fp8-gemm-backend": "triton",
            "--max-running-requests": 64,
            "--cuda-graph-max-bs": 256,
            "--stream-interval": 256
        },
        "inside_container": true,
        "docker_image": "unknown",
        "warmup_requests": 1,
        "model_path": "zianglih/Qwen3-4B-Instruct-2507-MXFP8",
        "num_prompts": 256,
        "random_input": 1024,
        "random_output": 2048,
        "function": "benchmark_sglang",
        "server_command": "bash -c ' python3 -m sglang.launch_server --model-path zianglih/Qwen3-4B-Instruct-2507-MXFP8 --disable-piecewise-cuda-graph --tp 1 --fp8-gemm-backend triton --max-running-requests 64 --cuda-graph-max-bs 256 --stream-interval 256 --trust-remote-code --host 0.0.0.0 --port 30000'",
        "bench_serving_command": "bash -c ' python3 -m sglang.bench_serving --warmup-requests 1 --backend sglang --dataset-name random-ids --random-range-ratio 0 --num-prompts 256 --random-input 1024 --random-output 2048 --host 0.0.0.0 --port 30000 '",
        "benchmark_result": [
            "============ Serving Benchmark Result ============",
            "Backend:                                 sglang",
            "Traffic request rate:                    inf",
            "Max request concurrency:                 not set",
            "Successful requests:                     256",
            "Benchmark duration (s):                  51.35",
            "Total input tokens:                      131653",
            "Total input text tokens:                 131653",
            "Total generated tokens:                  253220",
            "Total generated tokens (retokenized):    249283",
            "Request throughput (req/s):              4.99",
            "Input token throughput (tok/s):          2564.06",
            "Output token throughput (tok/s):         4931.69",
            "Peak output token throughput (tok/s):    7033.00",
            "Peak concurrent requests:                256",
            "Total token throughput (tok/s):          7495.76",
            "Concurrency:                             141.09",
            "----------------End-to-End Latency----------------",
            "Mean E2E Latency (ms):                   28298.61",
            "Median E2E Latency (ms):                 29067.31",
            "P90 E2E Latency (ms):                    42893.94",
            "P99 E2E Latency (ms):                    48459.60",
            "---------------Time to First Token----------------",
            "Mean TTFT (ms):                          18425.91",
            "Median TTFT (ms):                        19230.65",
            "P99 TTFT (ms):                           37513.63",
            "-----Time per Output Token (excl. 1st token)------",
            "Mean TPOT (ms):                          10.72",
            "Median TPOT (ms):                        9.25",
            "P99 TPOT (ms):                           31.39",
            "---------------Inter-Token Latency----------------",
            "Mean ITL (ms):                           10.18",
            "Median ITL (ms):                         9.24",
            "P95 ITL (ms):                            19.47",
            "P99 ITL (ms):                            24.04",
            "Max ITL (ms):                            46.04",
            "=================================================="
        ]
    },
    {
        "timestamp": "2026-04-01-18-59",
        "device_type": "nvidia",
        "env_vars": {},
        "sglang_server_args": {
            "--disable-piecewise-cuda-graph": true,
            "--tp": 1,
            "--fp8-gemm-backend": "flashinfer_trtllm",
            "--max-running-requests": 64,
            "--cuda-graph-max-bs": 256,
            "--stream-interval": 256
        },
        "inside_container": true,
        "docker_image": "unknown",
        "warmup_requests": 1,
        "model_path": "zianglih/Qwen3-4B-Instruct-2507-MXFP8",
        "num_prompts": 256,
        "random_input": 8192,
        "random_output": 2048,
        "function": "benchmark_sglang",
        "server_command": "bash -c ' python3 -m sglang.launch_server --model-path zianglih/Qwen3-4B-Instruct-2507-MXFP8 --disable-piecewise-cuda-graph --tp 1 --fp8-gemm-backend flashinfer_trtllm --max-running-requests 64 --cuda-graph-max-bs 256 --stream-interval 256 --trust-remote-code --host 0.0.0.0 --port 30000'",
        "bench_serving_command": "bash -c ' python3 -m sglang.bench_serving --warmup-requests 1 --backend sglang --dataset-name random-ids --random-range-ratio 0 --num-prompts 256 --random-input 8192 --random-output 2048 --host 0.0.0.0 --port 30000 '",
        "benchmark_result": [
            "============ Serving Benchmark Result ============",
            "Backend:                                 sglang",
            "Traffic request rate:                    inf",
            "Max request concurrency:                 not set",
            "Successful requests:                     256",
            "Benchmark duration (s):                  58.36",
            "Total input tokens:                      1040965",
            "Total input text tokens:                 1040965",
            "Total generated tokens:                  253220",
            "Total generated tokens (retokenized):    246067",
            "Request throughput (req/s):              4.39",
            "Input token throughput (tok/s):          17838.38",
            "Output token throughput (tok/s):         4339.28",
            "Peak output token throughput (tok/s):    5559.00",
            "Peak concurrent requests:                256",
            "Total token throughput (tok/s):          22177.66",
            "Concurrency:                             140.03",
            "----------------End-to-End Latency----------------",
            "Mean E2E Latency (ms):                   31919.45",
            "Median E2E Latency (ms):                 32532.65",
            "P90 E2E Latency (ms):                    51995.04",
            "P99 E2E Latency (ms):                    56796.88",
            "---------------Time to First Token----------------",
            "Mean TTFT (ms):                          20076.21",
            "Median TTFT (ms):                        19036.36",
            "P99 TTFT (ms):                           45396.01",
            "-----Time per Output Token (excl. 1st token)------",
            "Mean TPOT (ms):                          11.89",
            "Median TPOT (ms):                        12.55",
            "P99 TPOT (ms):                           14.24",
            "---------------Inter-Token Latency----------------",
            "Mean ITL (ms):                           12.47",
            "Median ITL (ms):                         12.76",
            "P95 ITL (ms):                            14.29",
            "P99 ITL (ms):                            14.49",
            "Max ITL (ms):                            22.83",
            "=================================================="
        ]
    },
    {
        "timestamp": "2026-04-01-18-59",
        "device_type": "nvidia",
        "env_vars": {},
        "sglang_server_args": {
            "--disable-piecewise-cuda-graph": true,
            "--tp": 1,
            "--fp8-gemm-backend": "flashinfer_cutlass",
            "--max-running-requests": 64,
            "--cuda-graph-max-bs": 256,
            "--stream-interval": 256
        },
        "inside_container": true,
        "docker_image": "unknown",
        "warmup_requests": 1,
        "model_path": "zianglih/Qwen3-4B-Instruct-2507-MXFP8",
        "num_prompts": 256,
        "random_input": 8192,
        "random_output": 2048,
        "function": "benchmark_sglang",
        "server_command": "bash -c ' python3 -m sglang.launch_server --model-path zianglih/Qwen3-4B-Instruct-2507-MXFP8 --disable-piecewise-cuda-graph --tp 1 --fp8-gemm-backend flashinfer_cutlass --max-running-requests 64 --cuda-graph-max-bs 256 --stream-interval 256 --trust-remote-code --host 0.0.0.0 --port 30000'",
        "bench_serving_command": "bash -c ' python3 -m sglang.bench_serving --warmup-requests 1 --backend sglang --dataset-name random-ids --random-range-ratio 0 --num-prompts 256 --random-input 8192 --random-output 2048 --host 0.0.0.0 --port 30000 '",
        "benchmark_result": [
            "============ Serving Benchmark Result ============",
            "Backend:                                 sglang",
            "Traffic request rate:                    inf",
            "Max request concurrency:                 not set",
            "Successful requests:                     256",
            "Benchmark duration (s):                  58.66",
            "Total input tokens:                      1040965",
            "Total input text tokens:                 1040965",
            "Total generated tokens:                  253220",
            "Total generated tokens (retokenized):    246067",
            "Request throughput (req/s):              4.36",
            "Input token throughput (tok/s):          17745.95",
            "Output token throughput (tok/s):         4316.79",
            "Peak output token throughput (tok/s):    5601.00",
            "Peak concurrent requests:                256",
            "Total token throughput (tok/s):          22062.74",
            "Concurrency:                             137.06",
            "----------------End-to-End Latency----------------",
            "Mean E2E Latency (ms):                   31404.66",
            "Median E2E Latency (ms):                 31923.53",
            "P90 E2E Latency (ms):                    51390.90",
            "P99 E2E Latency (ms):                    56791.60",
            "---------------Time to First Token----------------",
            "Mean TTFT (ms):                          19692.55",
            "Median TTFT (ms):                        18644.48",
            "P99 TTFT (ms):                           44566.70",
            "-----Time per Output Token (excl. 1st token)------",
            "Mean TPOT (ms):                          11.70",
            "Median TPOT (ms):                        12.32",
            "P99 TPOT (ms):                           14.02",
            "---------------Inter-Token Latency----------------",
            "Mean ITL (ms):                           12.33",
            "Median ITL (ms):                         12.56",
            "P95 ITL (ms):                            13.99",
            "P99 ITL (ms):                            14.22",
            "Max ITL (ms):                            21.75",
            "=================================================="
        ]
    },
    {
        "timestamp": "2026-04-01-18-59",
        "device_type": "nvidia",
        "env_vars": {},
        "sglang_server_args": {
            "--disable-piecewise-cuda-graph": true,
            "--tp": 1,
            "--fp8-gemm-backend": "triton",
            "--max-running-requests": 64,
            "--cuda-graph-max-bs": 256,
            "--stream-interval": 256
        },
        "inside_container": true,
        "docker_image": "unknown",
        "warmup_requests": 1,
        "model_path": "zianglih/Qwen3-4B-Instruct-2507-MXFP8",
        "num_prompts": 256,
        "random_input": 8192,
        "random_output": 2048,
        "function": "benchmark_sglang",
        "server_command": "bash -c ' python3 -m sglang.launch_server --model-path zianglih/Qwen3-4B-Instruct-2507-MXFP8 --disable-piecewise-cuda-graph --tp 1 --fp8-gemm-backend triton --max-running-requests 64 --cuda-graph-max-bs 256 --stream-interval 256 --trust-remote-code --host 0.0.0.0 --port 30000'",
        "bench_serving_command": "bash -c ' python3 -m sglang.bench_serving --warmup-requests 1 --backend sglang --dataset-name random-ids --random-range-ratio 0 --num-prompts 256 --random-input 8192 --random-output 2048 --host 0.0.0.0 --port 30000 '",
        "benchmark_result": [
            "============ Serving Benchmark Result ============",
            "Backend:                                 sglang",
            "Traffic request rate:                    inf",
            "Max request concurrency:                 not set",
            "Successful requests:                     256",
            "Benchmark duration (s):                  116.93",
            "Total input tokens:                      1040965",
            "Total input text tokens:                 1040965",
            "Total generated tokens:                  253220",
            "Total generated tokens (retokenized):    246067",
            "Request throughput (req/s):              2.19",
            "Input token throughput (tok/s):          8902.80",
            "Output token throughput (tok/s):         2165.65",
            "Peak output token throughput (tok/s):    3604.00",
            "Peak concurrent requests:                256",
            "Total token throughput (tok/s):          11068.45",
            "Concurrency:                             163.45",
            "----------------End-to-End Latency----------------",
            "Mean E2E Latency (ms):                   74655.70",
            "Median E2E Latency (ms):                 78238.55",
            "P90 E2E Latency (ms):                    107345.46",
            "P99 E2E Latency (ms):                    114413.03",
            "---------------Time to First Token----------------",
            "Mean TTFT (ms):                          50997.37",
            "Median TTFT (ms):                        56024.66",
            "P99 TTFT (ms):                           98492.96",
            "-----Time per Output Token (excl. 1st token)------",
            "Mean TPOT (ms):                          25.60",
            "Median TPOT (ms):                        22.44",
            "P99 TPOT (ms):                           68.72",
            "---------------Inter-Token Latency----------------",
            "Mean ITL (ms):                           24.90",
            "Median ITL (ms):                         22.90",
            "P95 ITL (ms):                            37.68",
            "P99 ITL (ms):                            66.70",
            "Max ITL (ms):                            189.30",
            "=================================================="
        ]
    }
]
```
bs4
```
[
    {
        "timestamp": "2026-04-01-19-10",
        "device_type": "nvidia",
        "env_vars": {},
        "sglang_server_args": {
            "--disable-piecewise-cuda-graph": true,
            "--tp": 1,
            "--fp8-gemm-backend": "flashinfer_trtllm",
            "--max-running-requests": 4,
            "--cuda-graph-max-bs": 64,
            "--stream-interval": 256
        },
        "inside_container": true,
        "docker_image": "unknown",
        "warmup_requests": 1,
        "model_path": "zianglih/Qwen3-4B-Instruct-2507-MXFP8",
        "num_prompts": 64,
        "random_input": 1024,
        "random_output": 1024,
        "function": "benchmark_sglang",
        "server_command": "bash -c ' python3 -m sglang.launch_server --model-path zianglih/Qwen3-4B-Instruct-2507-MXFP8 --disable-piecewise-cuda-graph --tp 1 --fp8-gemm-backend flashinfer_trtllm --max-running-requests 4 --cuda-graph-max-bs 64 --stream-interval 256 --trust-remote-code --host 0.0.0.0 --port 30000'",
        "bench_serving_command": "bash -c ' python3 -m sglang.bench_serving --warmup-requests 1 --backend sglang --dataset-name random-ids --random-range-ratio 0 --num-prompts 64 --random-input 1024 --random-output 1024 --host 0.0.0.0 --port 30000 '",
        "benchmark_result": [
            "============ Serving Benchmark Result ============",
            "Backend:                                 sglang",
            "Traffic request rate:                    inf",
            "Max request concurrency:                 not set",
            "Successful requests:                     64",
            "Benchmark duration (s):                  31.95",
            "Total input tokens:                      33742",
            "Total input text tokens:                 33742",
            "Total generated tokens:                  31891",
            "Total generated tokens (retokenized):    31557",
            "Request throughput (req/s):              2.00",
            "Input token throughput (tok/s):          1055.98",
            "Output token throughput (tok/s):         998.05",
            "Peak output token throughput (tok/s):    1050.00",
            "Peak concurrent requests:                64",
            "Total token throughput (tok/s):          2054.03",
            "Concurrency:                             31.70",
            "----------------End-to-End Latency----------------",
            "Mean E2E Latency (ms):                   15828.25",
            "Median E2E Latency (ms):                 15703.46",
            "P90 E2E Latency (ms):                    28061.07",
            "P99 E2E Latency (ms):                    31654.11",
            "---------------Time to First Token----------------",
            "Mean TTFT (ms):                          13942.90",
            "Median TTFT (ms):                        13783.17",
            "P99 TTFT (ms):                           28498.10",
            "-----Time per Output Token (excl. 1st token)------",
            "Mean TPOT (ms):                          3.74",
            "Median TPOT (ms):                        3.85",
            "P99 TPOT (ms):                           3.94",
            "---------------Inter-Token Latency----------------",
            "Mean ITL (ms):                           3.85",
            "Median ITL (ms):                         3.84",
            "P95 ITL (ms):                            3.94",
            "P99 ITL (ms):                            4.05",
            "Max ITL (ms):                            4.24",
            "=================================================="
        ]
    },
    {
        "timestamp": "2026-04-01-19-10",
        "device_type": "nvidia",
        "env_vars": {},
        "sglang_server_args": {
            "--disable-piecewise-cuda-graph": true,
            "--tp": 1,
            "--fp8-gemm-backend": "flashinfer_cutlass",
            "--max-running-requests": 4,
            "--cuda-graph-max-bs": 64,
            "--stream-interval": 256
        },
        "inside_container": true,
        "docker_image": "unknown",
        "warmup_requests": 1,
        "model_path": "zianglih/Qwen3-4B-Instruct-2507-MXFP8",
        "num_prompts": 64,
        "random_input": 1024,
        "random_output": 1024,
        "function": "benchmark_sglang",
        "server_command": "bash -c ' python3 -m sglang.launch_server --model-path zianglih/Qwen3-4B-Instruct-2507-MXFP8 --disable-piecewise-cuda-graph --tp 1 --fp8-gemm-backend flashinfer_cutlass --max-running-requests 4 --cuda-graph-max-bs 64 --stream-interval 256 --trust-remote-code --host 0.0.0.0 --port 30000'",
        "bench_serving_command": "bash -c ' python3 -m sglang.bench_serving --warmup-requests 1 --backend sglang --dataset-name random-ids --random-range-ratio 0 --num-prompts 64 --random-input 1024 --random-output 1024 --host 0.0.0.0 --port 30000 '",
        "benchmark_result": [
            "============ Serving Benchmark Result ============",
            "Backend:                                 sglang",
            "Traffic request rate:                    inf",
            "Max request concurrency:                 not set",
            "Successful requests:                     64",
            "Benchmark duration (s):                  39.14",
            "Total input tokens:                      33742",
            "Total input text tokens:                 33742",
            "Total generated tokens:                  31891",
            "Total generated tokens (retokenized):    31557",
            "Request throughput (req/s):              1.64",
            "Input token throughput (tok/s):          862.18",
            "Output token throughput (tok/s):         814.88",
            "Peak output token throughput (tok/s):    861.00",
            "Peak concurrent requests:                64",
            "Total token throughput (tok/s):          1677.06",
            "Concurrency:                             31.65",
            "----------------End-to-End Latency----------------",
            "Mean E2E Latency (ms):                   19356.49",
            "Median E2E Latency (ms):                 19200.14",
            "P90 E2E Latency (ms):                    34336.79",
            "P99 E2E Latency (ms):                    38762.37",
            "---------------Time to First Token----------------",
            "Mean TTFT (ms):                          17044.06",
            "Median TTFT (ms):                        16846.26",
            "P99 TTFT (ms):                           34865.52",
            "-----Time per Output Token (excl. 1st token)------",
            "Mean TPOT (ms):                          4.59",
            "Median TPOT (ms):                        4.72",
            "P99 TPOT (ms):                           4.81",
            "---------------Inter-Token Latency----------------",
            "Mean ITL (ms):                           4.72",
            "Median ITL (ms):                         4.72",
            "P95 ITL (ms):                            4.81",
            "P99 ITL (ms):                            4.90",
            "Max ITL (ms):                            5.05",
            "=================================================="
        ]
    },
    {
        "timestamp": "2026-04-01-19-10",
        "device_type": "nvidia",
        "env_vars": {},
        "sglang_server_args": {
            "--disable-piecewise-cuda-graph": true,
            "--tp": 1,
            "--fp8-gemm-backend": "triton",
            "--max-running-requests": 4,
            "--cuda-graph-max-bs": 64,
            "--stream-interval": 256
        },
        "inside_container": true,
        "docker_image": "unknown",
        "warmup_requests": 1,
        "model_path": "zianglih/Qwen3-4B-Instruct-2507-MXFP8",
        "num_prompts": 64,
        "random_input": 1024,
        "random_output": 1024,
        "function": "benchmark_sglang",
        "server_command": "bash -c ' python3 -m sglang.launch_server --model-path zianglih/Qwen3-4B-Instruct-2507-MXFP8 --disable-piecewise-cuda-graph --tp 1 --fp8-gemm-backend triton --max-running-requests 4 --cuda-graph-max-bs 64 --stream-interval 256 --trust-remote-code --host 0.0.0.0 --port 30000'",
        "bench_serving_command": "bash -c ' python3 -m sglang.bench_serving --warmup-requests 1 --backend sglang --dataset-name random-ids --random-range-ratio 0 --num-prompts 64 --random-input 1024 --random-output 1024 --host 0.0.0.0 --port 30000 '",
        "benchmark_result": [
            "============ Serving Benchmark Result ============",
            "Backend:                                 sglang",
            "Traffic request rate:                    inf",
            "Max request concurrency:                 not set",
            "Successful requests:                     64",
            "Benchmark duration (s):                  56.57",
            "Total input tokens:                      33742",
            "Total input text tokens:                 33742",
            "Total generated tokens:                  31891",
            "Total generated tokens (retokenized):    31557",
            "Request throughput (req/s):              1.13",
            "Input token throughput (tok/s):          596.44",
            "Output token throughput (tok/s):         563.72",
            "Peak output token throughput (tok/s):    604.00",
            "Peak concurrent requests:                64",
            "Total token throughput (tok/s):          1160.17",
            "Concurrency:                             31.69",
            "----------------End-to-End Latency----------------",
            "Mean E2E Latency (ms):                   28012.67",
            "Median E2E Latency (ms):                 27797.61",
            "P90 E2E Latency (ms):                    49660.68",
            "P99 E2E Latency (ms):                    56055.62",
            "---------------Time to First Token----------------",
            "Mean TTFT (ms):                          24667.41",
            "Median TTFT (ms):                        24388.94",
            "P99 TTFT (ms):                           50423.98",
            "-----Time per Output Token (excl. 1st token)------",
            "Mean TPOT (ms):                          6.64",
            "Median TPOT (ms):                        6.82",
            "P99 TPOT (ms):                           6.98",
            "---------------Inter-Token Latency----------------",
            "Mean ITL (ms):                           6.82",
            "Median ITL (ms):                         6.81",
            "P95 ITL (ms):                            6.96",
            "P99 ITL (ms):                            7.15",
            "Max ITL (ms):                            7.30",
            "=================================================="
        ]
    }
]
```

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
