### PR TITLE
[CI] Replace upload/download-artifact with job outputs in release-docker workflow

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -18,6 +18,9 @@ jobs:
   publish-x86:
     if: github.repository == 'sgl-project/sglang'
     environment: "prod"
+    outputs:
+      digest-cu129: ${{ steps.build-cu129.outputs.digest }}
+      digest-cu130: ${{ steps.build-cu130.outputs.digest }}
     strategy:
       matrix:
         variant:
@@ -75,6 +78,7 @@ jobs:
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Build AMD64 Framework
+        id: build-cu129
         run: |
           version=${{ steps.version.outputs.version }}
 
@@ -94,9 +98,10 @@ jobs:
 
           DIGEST=$(python3 -c "import json; print(json.load(open('/tmp/metadata-cu129-framework.json'))['containerimage.digest'])")
           echo "Pushed digest: ${DIGEST}"
-          echo "${DIGEST}" > /tmp/digest-cu129-amd64-framework.txt
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
 
       - name: Build and Push AMD64 Framework (CUDA 13)
+        id: build-cu130
         run: |
           version=${{ steps.version.outputs.version }}
 
@@ -116,18 +121,14 @@ jobs:
 
           DIGEST=$(python3 -c "import json; print(json.load(open('/tmp/metadata-cu130-framework.json'))['containerimage.digest'])")
           echo "Pushed digest: ${DIGEST}"
-          echo "${DIGEST}" > /tmp/digest-cu130-amd64-framework.txt
-
-      - name: Upload digests
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-amd64
-          path: /tmp/digest-*.txt
-          retention-days: 1
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
 
   publish-arm64:
     if: github.repository == 'sgl-project/sglang'
     environment: "prod"
+    outputs:
+      digest-cu129: ${{ steps.build-cu129.outputs.digest }}
+      digest-cu130: ${{ steps.build-cu130.outputs.digest }}
     strategy:
       matrix:
         variant:
@@ -174,6 +175,7 @@ jobs:
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Build ARM64 Framework
+        id: build-cu129
         run: |
           version=${{ steps.version.outputs.version }}
 
@@ -193,9 +195,10 @@ jobs:
 
           DIGEST=$(python3 -c "import json; print(json.load(open('/tmp/metadata-cu129-framework.json'))['containerimage.digest'])")
           echo "Pushed digest: ${DIGEST}"
-          echo "${DIGEST}" > /tmp/digest-cu129-arm64-framework.txt
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
 
       - name: Build and Push ARM64 Framework (CUDA 13)
+        id: build-cu130
         run: |
           version=${{ steps.version.outputs.version }}
 
@@ -215,14 +218,7 @@ jobs:
 
           DIGEST=$(python3 -c "import json; print(json.load(open('/tmp/metadata-cu130-framework.json'))['containerimage.digest'])")
           echo "Pushed digest: ${DIGEST}"
-          echo "${DIGEST}" > /tmp/digest-cu130-arm64-framework.txt
-
-      - name: Upload digests
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-arm64
-          path: /tmp/digest-*.txt
-          retention-days: 1
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
 
   create-manifests:
     runs-on: ubuntu-22.04
@@ -264,26 +260,14 @@ jobs:
 
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
-      - name: Download amd64 digests
-        uses: actions/download-artifact@v4
-        with:
-          name: digests-amd64
-          path: /tmp/digests/amd64
-
-      - name: Download arm64 digests
-        uses: actions/download-artifact@v4
-        with:
-          name: digests-arm64
-          path: /tmp/digests/arm64
-
       - name: Create multi-arch manifests
         run: |
           version=${{ steps.version.outputs.version }}
 
-          CU129_AMD64_FW=$(cat /tmp/digests/amd64/digest-cu129-amd64-framework.txt)
-          CU130_AMD64_FW=$(cat /tmp/digests/amd64/digest-cu130-amd64-framework.txt)
-          CU129_ARM64_FW=$(cat /tmp/digests/arm64/digest-cu129-arm64-framework.txt)
-          CU130_ARM64_FW=$(cat /tmp/digests/arm64/digest-cu130-arm64-framework.txt)
+          CU129_AMD64_FW=${{ needs.publish-x86.outputs.digest-cu129 }}
+          CU130_AMD64_FW=${{ needs.publish-x86.outputs.digest-cu130 }}
+          CU129_ARM64_FW=${{ needs.publish-arm64.outputs.digest-cu129 }}
+          CU130_ARM64_FW=${{ needs.publish-arm64.outputs.digest-cu130 }}
 
           # Create versioned framework manifest (default)
           docker buildx imagetools create \


### PR DESCRIPTION
## Summary
- Replace `actions/upload-artifact` and `actions/download-artifact` with GitHub Actions job outputs for passing digest SHAs between build and manifest jobs
- Fixes persistent "Maximum call stack size exceeded" error in `upload-artifact@v4`/`v6` (e.g., https://github.com/sgl-project/sglang/actions/runs/23672239074/job/68967948322)
- Job outputs are the right mechanism for short strings — simpler and more reliable than artifact files

## Test plan
- [ ] Trigger `Release Docker Images` workflow via `workflow_dispatch` and verify `create-manifests` job receives digests correctly
- [ ] Verify multi-arch manifests are created successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)