### PR TITLE
Fix HFRunner hang when subprocess dies during init

### DIFF
--- a/python/sglang/test/runners.py
+++ b/python/sglang/test/runners.py
@@ -15,6 +15,7 @@
 import json
 import multiprocessing as mp
 import os
+import queue as queue_mod
 from dataclasses import dataclass
 from typing import Any, List, Optional, Tuple, Union
 
@@ -412,16 +413,15 @@ class HFRunner:
             (prompts, image_data, max_new_tokens, lora_paths, token_ids_logprob)
         )
         while True:
-            if not self.model_proc.is_alive() and self.out_queue.empty():
-                exitcode = self.model_proc.exitcode
-                raise RuntimeError(
-                    f"HFRunner subprocess died with exit code {exitcode} "
-                    f"before producing output"
-                )
             try:
                 return self.out_queue.get(timeout=5)
-            except Exception:
-                continue
+            except queue_mod.Empty:
+                if not self.model_proc.is_alive() and self.out_queue.empty():
+                    exitcode = self.model_proc.exitcode
+                    raise RuntimeError(
+                        f"HFRunner subprocess died with exit code {exitcode} "
+                        f"before producing output"
+                    )
 
     def terminate(self):
         self.model_proc.terminate()

--- a/python/sglang/test/runners.py
+++ b/python/sglang/test/runners.py
@@ -411,7 +411,17 @@ class HFRunner:
         self.in_queue.put(
             (prompts, image_data, max_new_tokens, lora_paths, token_ids_logprob)
         )
-        return self.out_queue.get()
+        while True:
+            if not self.model_proc.is_alive() and self.out_queue.empty():
+                exitcode = self.model_proc.exitcode
+                raise RuntimeError(
+                    f"HFRunner subprocess died with exit code {exitcode} "
+                    f"before producing output"
+                )
+            try:
+                return self.out_queue.get(timeout=5)
+            except Exception:
+                continue
 
     def terminate(self):
         self.model_proc.terminate()


### PR DESCRIPTION
## Motivation

When `HFRunner.start_model_process` crashes during initialization (e.g., HuggingFace 429 rate limiting during `get_tokenizer`), the subprocess dies before entering its `while True` loop, so it never puts a result into `out_queue`. The parent process then blocks forever on `out_queue.get()` with no timeout, hanging until the CI step timeout kills it (~18 minutes wasted).

**Example failure:** https://github.com/sgl-project/sglang/actions/runs/23673199523/job/68970973420

The `test_cross_encoder_models.py` subprocess hit 429 loading `BAAI/bge-reranker-v2-m3` tokenizer and crashed. The parent hung from 00:42 to 01:00 (18 min) with zero output until the 30-min step timeout killed it.

This is the test-runner-side counterpart to #21471 which fixed the same 429 hang on the server side (DetokenizerManager).

## Modification

Replace `out_queue.get()` (infinite block) with a polling loop that checks `model_proc.is_alive()` every 5 seconds. If the subprocess is dead and the queue is empty, raise `RuntimeError` immediately instead of hanging.

## Test plan

- [x] Existing CI (no behavioral change when subprocess is healthy)
- Dead subprocess now raises `RuntimeError` within ~5s instead of hanging forever