### PR TITLE
Patch transformers is_base_mistral in CI to avoid HF 429 rate limiting

### DIFF
--- a/python/sglang/srt/utils/hf_transformers_utils.py
+++ b/python/sglang/srt/utils/hf_transformers_utils.py
@@ -712,6 +712,49 @@ class TokenizerWarningsFilter(logging.Filter):
         return "Calling super().encode with" not in record.getMessage()
 
 
+_is_base_mistral_patched = False
+
+# transformers version where is_base_mistral calls model_info() on every tokenizer load
+_TRANSFORMERS_PATCHED_VERSION = "5.3.0"
+
+
+def _patch_is_base_mistral_in_ci():
+    """Patch transformers' is_base_mistral to avoid HF API calls in CI.
+
+    transformers calls model_info() inside _patch_mistral_regex -> is_base_mistral
+    for every tokenizer load, which hits HF API even with HF_HUB_OFFLINE=1.
+    In CI this exhausts the 3000 req/5min rate limit and causes 429 errors.
+    """
+    global _is_base_mistral_patched
+    if _is_base_mistral_patched:
+        return
+
+    from sglang.srt.environ import envs
+
+    if not envs.SGLANG_IS_IN_CI.get():
+        return
+
+    import transformers
+
+    if transformers.__version__ != _TRANSFORMERS_PATCHED_VERSION:
+        logger.warning(
+            "transformers version changed to %s (expected %s), "
+            "is_base_mistral patch skipped — may need update if 429 errors recur",
+            transformers.__version__,
+            _TRANSFORMERS_PATCHED_VERSION,
+        )
+        _is_base_mistral_patched = True  # don't warn repeatedly
+        return
+
+    import transformers.tokenization_utils_tokenizers as tut
+
+    if hasattr(tut, "is_base_mistral"):
+        tut.is_base_mistral = lambda *a, **kw: False
+        logger.info("CI: patched is_base_mistral to skip HF API calls")
+
+    _is_base_mistral_patched = True
+
+
 def get_tokenizer(
     tokenizer_name: str,
     *args,
@@ -754,6 +797,8 @@ def get_tokenizer(
         client = create_remote_connector(tokenizer_name)
         client.pull_files(ignore_pattern=["*.pt", "*.safetensors", "*.bin"])
         tokenizer_name = client.get_local_dir()
+
+    _patch_is_base_mistral_in_ci()
 
     try:
         tokenizer = AutoTokenizer.from_pretrained(


### PR DESCRIPTION
## Motivation

CI scheduled runs hit HuggingFace 429 rate limiting (`3000 req/5min` quota exhausted), causing widespread test failures (9/14 jobs in https://github.com/sgl-project/sglang/actions/runs/23673199523).

The root cause is `transformers` (v5.3.0) calling `model_info()` on the HF API inside `_patch_mistral_regex` → `is_base_mistral` for **every tokenizer load**, even when models are locally cached and `HF_HUB_OFFLINE=1` is set. With N concurrent CI jobs each loading multiple tokenizers, this quickly exhausts the rate limit.

Traceback from CI:
```
AutoTokenizer.from_pretrained
  → XLMRobertaTokenizer.__init__
    → _patch_mistral_regex
      → is_base_mistral(model_id)
        → model_info(model_id)  # HF API call
          → 429 Too Many Requests
```

## Modification

Monkey-patch `transformers.tokenization_utils_tokenizers.is_base_mistral` to return `False` when `SGLANG_IS_IN_CI=true`. The patch is applied once before the first `AutoTokenizer.from_pretrained` call in `get_tokenizer()`.

This is safe because:
- CI models are all pre-cached HF-format checkpoints, never actual Mistral native format
- The patch only affects CI (`SGLANG_IS_IN_CI`), not user-facing deployments
- `is_base_mistral` only controls regex pattern selection in tokenizer init — returning `False` uses the standard path

## Test plan

- [x] Existing CI — this fix *is* the test: scheduled runs should stop hitting 429