### PR TITLE
fix: Mistral Small 4 fails to start due to config/weight format mismatch

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3159,22 +3159,46 @@ class ServerArgs:
     def _is_mistral_native_format(self) -> bool:
         """Detect if the model uses Mistral native format (params.json + consolidated weights).
 
-        Models like Mistral-7B-Instruct-v0.3 have BOTH params.json (native) and
-        config.json (HF standard). When both exist, prefer the HF format to avoid
-        parameter name mismatches between consolidated.safetensors (native names
-        like layers.0.attention.wk.weight) and HuggingFace model classes (names
-        like model.layers.0.self_attn.k_proj.weight).
+        When both params.json and config.json exist, default to HF format to
+        avoid weight-name mismatches (e.g. Mistral-7B-Instruct-v0.3).
+
+        Exception: models routed through ``_load_mistral_large_3_for_causal_LM``
+        (mistral-large-3, mistral-small-4, leanstral) build their config from
+        params.json and expect native weight names, so native format is required
+        even when config.json is also present.
         """
+        # Keep in sync with the name checks in
+        # hf_transformers_utils.py::get_config / get_tokenizer.
+        _MISTRAL_NATIVE_CONFIG_PATTERNS = ("mistral-large-3", "mistral-small-4", "leanstral")
+
         if os.path.isdir(self.model_path):
             has_params = os.path.exists(os.path.join(self.model_path, "params.json"))
-            has_hf_config = os.path.exists(os.path.join(self.model_path, "config.json"))
-            return has_params and not has_hf_config
+            has_hf_config = os.path.exists(
+                os.path.join(self.model_path, "config.json")
+            )
+            if has_params and not has_hf_config:
+                return True
+            if has_params and has_hf_config:
+                model_lower = str(self.model_path).lower()
+                if any(name in model_lower for name in _MISTRAL_NATIVE_CONFIG_PATTERNS):
+                    return True
+            return False
         # For hub models, check remote files
         try:
             from huggingface_hub import HfApi
 
-            files = {s.rfilename for s in HfApi().model_info(self.model_path).siblings}
-            return "params.json" in files and "config.json" not in files
+            files = {
+                s.rfilename for s in HfApi().model_info(self.model_path).siblings
+            }
+            has_params = "params.json" in files
+            has_hf_config = "config.json" in files
+            if has_params and not has_hf_config:
+                return True
+            if has_params and has_hf_config:
+                model_lower = str(self.model_path).lower()
+                if any(name in model_lower for name in _MISTRAL_NATIVE_CONFIG_PATTERNS):
+                    return True
+            return False
         except Exception:
             return False
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3171,11 +3171,7 @@ class ServerArgs:
         # hf_transformers_utils.py::get_config / get_tokenizer.
         _MISTRAL_NATIVE_CONFIG_PATTERNS = ("mistral-large-3", "mistral-small-4", "leanstral")
 
-        if os.path.isdir(self.model_path):
-            has_params = os.path.exists(os.path.join(self.model_path, "params.json"))
-            has_hf_config = os.path.exists(
-                os.path.join(self.model_path, "config.json")
-            )
+        def _check_format(has_params: bool, has_hf_config: bool) -> bool:
             if has_params and not has_hf_config:
                 return True
             if has_params and has_hf_config:
@@ -3183,6 +3179,14 @@ class ServerArgs:
                 if any(name in model_lower for name in _MISTRAL_NATIVE_CONFIG_PATTERNS):
                     return True
             return False
+
+        if os.path.isdir(self.model_path):
+            has_params = os.path.exists(os.path.join(self.model_path, "params.json"))
+            has_hf_config = os.path.exists(
+                os.path.join(self.model_path, "config.json")
+            )
+            return _check_format(has_params, has_hf_config)
+
         # For hub models, check remote files
         try:
             from huggingface_hub import HfApi
@@ -3190,15 +3194,7 @@ class ServerArgs:
             files = {
                 s.rfilename for s in HfApi().model_info(self.model_path).siblings
             }
-            has_params = "params.json" in files
-            has_hf_config = "config.json" in files
-            if has_params and not has_hf_config:
-                return True
-            if has_params and has_hf_config:
-                model_lower = str(self.model_path).lower()
-                if any(name in model_lower for name in _MISTRAL_NATIVE_CONFIG_PATTERNS):
-                    return True
-            return False
+            return _check_format("params.json" in files, "config.json" in files)
         except Exception:
             return False
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3169,7 +3169,11 @@ class ServerArgs:
         """
         # Keep in sync with the name checks in
         # hf_transformers_utils.py::get_config / get_tokenizer.
-        _MISTRAL_NATIVE_CONFIG_PATTERNS = ("mistral-large-3", "mistral-small-4", "leanstral")
+        _MISTRAL_NATIVE_CONFIG_PATTERNS = (
+            "mistral-large-3",
+            "mistral-small-4",
+            "leanstral",
+        )
 
         def _check_format(has_params: bool, has_hf_config: bool) -> bool:
             if has_params and not has_hf_config:
@@ -3182,18 +3186,14 @@ class ServerArgs:
 
         if os.path.isdir(self.model_path):
             has_params = os.path.exists(os.path.join(self.model_path, "params.json"))
-            has_hf_config = os.path.exists(
-                os.path.join(self.model_path, "config.json")
-            )
+            has_hf_config = os.path.exists(os.path.join(self.model_path, "config.json"))
             return _check_format(has_params, has_hf_config)
 
         # For hub models, check remote files
         try:
             from huggingface_hub import HfApi
 
-            files = {
-                s.rfilename for s in HfApi().model_info(self.model_path).siblings
-            }
+            files = {s.rfilename for s in HfApi().model_info(self.model_path).siblings}
             return _check_format("params.json" in files, "config.json" in files)
         except Exception:
             return False

--- a/test/registered/models/test_ministral3_models.py
+++ b/test/registered/models/test_ministral3_models.py
@@ -8,7 +8,8 @@ from sglang.test.server_fixtures.mmmu_fixture import MMMUServerBase
 
 register_cuda_ci(
     est_time=200,
-    suite="stage-b-test-1-gpu-large",
+    suite="stage-b-test-1-gpu-small",
+    disabled="Temporarily disabled",
 )
 
 MODEL = "mistralai/Ministral-3-3B-Instruct-2512"

--- a/test/registered/models/test_ministral3_models.py
+++ b/test/registered/models/test_ministral3_models.py
@@ -9,7 +9,6 @@ from sglang.test.server_fixtures.mmmu_fixture import MMMUServerBase
 register_cuda_ci(
     est_time=200,
     suite="stage-b-test-1-gpu-small",
-    disabled="Temporarily disabled",
 )
 
 MODEL = "mistralai/Ministral-3-3B-Instruct-2512"

--- a/test/registered/models/test_ministral3_models.py
+++ b/test/registered/models/test_ministral3_models.py
@@ -8,7 +8,7 @@ from sglang.test.server_fixtures.mmmu_fixture import MMMUServerBase
 
 register_cuda_ci(
     est_time=200,
-    suite="stage-b-test-1-gpu-small",
+    suite="stage-b-test-1-gpu-large",
 )
 
 MODEL = "mistralai/Ministral-3-3B-Instruct-2512"

--- a/test/registered/models/test_ministral4_models.py
+++ b/test/registered/models/test_ministral4_models.py
@@ -1,0 +1,22 @@
+import unittest
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
+from sglang.test.server_fixtures.default_fixture import DefaultServerBase
+
+register_cuda_ci(
+    est_time=200,
+    suite="stage-b-test-2-gpu-large",
+)
+
+MODEL = "mistralai/Mistral-Small-4-119B-2603"
+
+
+class TestMistralSmall4TextOnly(GSM8KMixin, DefaultServerBase):
+    gsm8k_accuracy_thres = 0.6
+    model = MODEL
+    other_args = ["--tp-size", "2", "--trust-remote-code"]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/models/test_ministral4_models.py
+++ b/test/registered/models/test_ministral4_models.py
@@ -2,11 +2,13 @@ import unittest
 
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
+from sglang.test.kits.mmmu_vlm_kit import MMMUMixin
 from sglang.test.server_fixtures.default_fixture import DefaultServerBase
+from sglang.test.server_fixtures.mmmu_fixture import MMMUServerBase
 
 register_cuda_ci(
     est_time=200,
-    suite="stage-b-test-2-gpu-large",
+    suite="stage-c-test-4-gpu-h100",
 )
 
 MODEL = "mistralai/Mistral-Small-4-119B-2603"
@@ -16,6 +18,14 @@ class TestMistralSmall4TextOnly(GSM8KMixin, DefaultServerBase):
     gsm8k_accuracy_thres = 0.6
     model = MODEL
     other_args = ["--tp-size", "2", "--trust-remote-code"]
+
+
+class TestMistralSmall4MMMU(MMMUMixin, MMMUServerBase):
+    accuracy = 0.3
+    model = MODEL
+    other_args = ["--tp-size", "2", "--trust-remote-code"]
+    mmmu_args = ["--limit=0.1"]
+    """`--limit=0.1`: 10 percent of each task - this is fine for testing since the nominal result isn't interesting - this run is just to prevent relative regressions."""
 
 
 if __name__ == "__main__":

--- a/test/registered/models/test_ministral4_models.py
+++ b/test/registered/models/test_ministral4_models.py
@@ -21,7 +21,7 @@ class TestMistralSmall4TextOnly(GSM8KMixin, DefaultServerBase):
 
 
 class TestMistralSmall4MMMU(MMMUMixin, MMMUServerBase):
-    accuracy = 0.5
+    accuracy = 0.45
     model = MODEL
     other_args = ["--tp-size", "2", "--trust-remote-code"]
     mmmu_args = ["--limit=0.1"]

--- a/test/registered/models/test_ministral4_models.py
+++ b/test/registered/models/test_ministral4_models.py
@@ -8,20 +8,20 @@ from sglang.test.server_fixtures.mmmu_fixture import MMMUServerBase
 
 register_cuda_ci(
     est_time=200,
-    suite="stage-c-test-4-gpu-h100",
+    suite="stage-b-test-2-gpu-large",
 )
 
 MODEL = "mistralai/Mistral-Small-4-119B-2603"
 
 
 class TestMistralSmall4TextOnly(GSM8KMixin, DefaultServerBase):
-    gsm8k_accuracy_thres = 0.6
+    gsm8k_accuracy_thres = 0.9
     model = MODEL
     other_args = ["--tp-size", "2", "--trust-remote-code"]
 
 
 class TestMistralSmall4MMMU(MMMUMixin, MMMUServerBase):
-    accuracy = 0.3
+    accuracy = 0.5
     model = MODEL
     other_args = ["--tp-size", "2", "--trust-remote-code"]
     mmmu_args = ["--limit=0.1"]


### PR DESCRIPTION
## Motivation

Fixes #21611

`mistralai/Mistral-Small-4-119B-2603` fails to start with `AttributeError` because `w_kc` is `None`.

## Root Cause

Mistral Small 4 ships with **both** `params.json` and `config.json`. This causes a config-vs-weight loading mismatch:

1. **Config path**: `hf_transformers_utils.py` matches `"mistral-small-4"` → calls `_load_mistral_large_3_for_causal_LM()` → parses `params.json` → expects **Mistral native weight names** (e.g. `layers.X.attention.wkv_b.weight`)
2. **Weight path**: `_is_mistral_native_format()` sees both files → returns `False` → `load_format` stays `"auto"` → loads **HF-format weight names** (e.g. `language_model.model.layers.X.self_attn.kv_b_proj.weight`)
3. **Result**: Remapping regex cannot match HF names → all weights skipped as "Unrecognized" → `kv_b_proj` never loaded → `w_kc` is `None` → crash

## Modifications

**`python/sglang/srt/server_args.py`**: In `_is_mistral_native_format()`, when both `params.json` and `config.json` exist, check if the model name matches patterns that trigger `_load_mistral_large_3_for_causal_LM` (`mistral-large-3`, `mistral-small-4`, `leanstral`). If so, return `True` so `load_format` is set to `"mistral"`.

Single-file change, no impact on other models.

## Checklist
- [x] `Mistral-Small-4-119B-2603`: No more "Unrecognized weight", server starts and serves requests successfully (TP4, B200)
- [x] Models with only `params.json` (e.g. Mistral Large 3): original logic unchanged
- [x] Models with both files but not in pattern list (e.g. Mistral-7B-v0.3): still default to HF format