### PR TITLE
[AMD] Fix CI multimodal-gen-test-1-gpu-amd for gen model 

### DIFF
--- a/python/sglang/jit_kernel/diffusion/triton/scale_shift.py
+++ b/python/sglang/jit_kernel/diffusion/triton/scale_shift.py
@@ -79,13 +79,20 @@ def _fused_layernorm_scale_shift_gate_select01_kernel(
     shift1_ptrs = shift1_ptr + batch_idx * stride_sh1_b + cols * stride_sh1_c
     gate1_ptrs = gate1_ptr + batch_idx * stride_g1_b + cols * stride_g1_c
 
-    scale_ptrs = tl.where(idx, scale1_ptrs, scale0_ptrs)
-    shift_ptrs = tl.where(idx, shift1_ptrs, shift0_ptrs)
-    gate_ptrs = tl.where(idx, gate1_ptrs, gate0_ptrs)
-
-    scale = tl.load(scale_ptrs, mask=mask, other=0.0).to(tl.float32)
-    shift = tl.load(shift_ptrs, mask=mask, other=0.0).to(tl.float32)
-    gate = tl.load(gate_ptrs, mask=mask, other=0.0)
+    # Branch on scalar idx instead of using tl.where on pointers.
+    # tl.where on pointers triggers an assertion in AMD Triton's
+    # CanonicalizePointers pass (ConvertArithSelectOp) on gfx950.
+    # This keeps it at 3 loads (not 6), avoids the pointer-level
+    # tl.where entirely, and since idx is uniform across all threads
+    # the branch has no divergence cost.
+    if idx:
+        scale = tl.load(scale1_ptrs, mask=mask, other=0.0).to(tl.float32)
+        shift = tl.load(shift1_ptrs, mask=mask, other=0.0).to(tl.float32)
+        gate = tl.load(gate1_ptrs, mask=mask, other=0.0)
+    else:
+        scale = tl.load(scale0_ptrs, mask=mask, other=0.0).to(tl.float32)
+        shift = tl.load(shift0_ptrs, mask=mask, other=0.0).to(tl.float32)
+        gate = tl.load(gate0_ptrs, mask=mask, other=0.0)
     y = x_hat * (1.0 + scale) + shift
 
     tl.store(out_row_ptr + cols, y, mask=mask)
@@ -180,13 +187,20 @@ def _fused_residual_layernorm_scale_shift_gate_select01_kernel(
     shift1_ptrs = shift1_ptr + batch_idx * stride_sh1_b + cols * stride_sh1_c
     gate1_ptrs = gate1_ptr + batch_idx * stride_g1_b + cols * stride_g1_c
 
-    scale_ptrs = tl.where(idx, scale1_ptrs, scale0_ptrs)
-    shift_ptrs = tl.where(idx, shift1_ptrs, shift0_ptrs)
-    gate_ptrs = tl.where(idx, gate1_ptrs, gate0_ptrs)
-
-    scale = tl.load(scale_ptrs, mask=mask, other=0.0).to(tl.float32)
-    shift = tl.load(shift_ptrs, mask=mask, other=0.0).to(tl.float32)
-    gate = tl.load(gate_ptrs, mask=mask, other=0.0)
+    # Branch on scalar idx instead of using tl.where on pointers.
+    # tl.where on pointers triggers an assertion in AMD Triton's
+    # CanonicalizePointers pass (ConvertArithSelectOp) on gfx950.
+    # This keeps it at 3 loads (not 6), avoids the pointer-level
+    # tl.where entirely, and since idx is uniform across all threads
+    # the branch has no divergence cost.
+    if idx:
+        scale = tl.load(scale1_ptrs, mask=mask, other=0.0).to(tl.float32)
+        shift = tl.load(shift1_ptrs, mask=mask, other=0.0).to(tl.float32)
+        gate = tl.load(gate1_ptrs, mask=mask, other=0.0)
+    else:
+        scale = tl.load(scale0_ptrs, mask=mask, other=0.0).to(tl.float32)
+        shift = tl.load(shift0_ptrs, mask=mask, other=0.0).to(tl.float32)
+        gate = tl.load(gate0_ptrs, mask=mask, other=0.0)
     y = x_hat * (1.0 + scale) + shift
 
     tl.store(out_row_ptr + cols, y, mask=mask)


### PR DESCRIPTION
## Motivation

Fix Triton `CanonicalizePointers` assertion on AMD gfx950 by branching on scalar `idx` instead of `tl.where` on pointers.

AMD Triton's `TritonAMDGPUCanonicalizePointers` pass hits an assertion in `ConvertArithSelectOp::matchAndRewrite_` when `arith.select` is used on pointer tensors whose two branches have different "narrowability" properties. The `_fused_layernorm_scale_shift_gate_select01_kernel` and `_fused_residual_layernorm_scale_shift_gate_select01_kernel` kernels use `tl.where(idx, ptr1, ptr0)` to conditionally select between two sets of scale/shift/gate pointers, which triggers this bug on gfx950 (MI350X).

## Modifications

- **`python/sglang/jit_kernel/diffusion/triton/scale_shift.py`**: In both `_fused_layernorm_scale_shift_gate_select01_kernel` and `_fused_residual_layernorm_scale_shift_gate_select01_kernel`, replaced pointer-level `tl.where` with `if/else` branching on the scalar `idx`:
  - **Before**: `tl.where(idx, scale1_ptrs, scale0_ptrs)` then `tl.load(scale_ptrs, ...)`
  - **After**: `if idx: scale = tl.load(scale1_ptrs, ...) else: scale = tl.load(scale0_ptrs, ...)`
  - This keeps it at 3 loads (not 6), avoids the pointer-level `tl.where` entirely, and since `idx` is uniform across all threads the branch has no divergence cost.

## Accuracy Tests
```bash
python -m pytest -xvs     "sglang/multimodal_gen/test/server/test_server_a.py::TestDiffusionServerOneGpu::test_diffusion_generation[qwen_image_edit_2511_ti2i]"
```
CI test `test_diffusion_generation[qwen_image_edit_2511_ti2i]` was failing with `RuntimeError: PassManager::run failed` due to the Triton compilation assertion. This fix resolves the compilation failure.
## Speed Tests and Profiling

No performance impact. The change replaces a pointer-select + 3 loads with an `if/else` branch + 3 loads. The `idx` value is a scalar uniform across all threads in the block, so the branch has zero divergence cost.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
