### PR TITLE
[Test][AMD] Extract shared GSM8K helpers into gsm8k_completion_kit

### DIFF
--- a/python/sglang/test/kits/gsm8k_completion_kit.py
+++ b/python/sglang/test/kits/gsm8k_completion_kit.py
@@ -1,0 +1,99 @@
+"""GSM8K few-shot completion benchmark kit.
+
+Provides a reusable ``run_gsm8k_benchmark`` function for AMD accuracy tests
+that launch their own SGLang server and evaluate it with the GSM8K few-shot
+completion benchmark.
+
+The three helper functions (``INVALID``, ``get_one_example``,
+``get_few_shot_examples``, ``get_answer_value``) are re-exported from
+``sglang.test.few_shot_gsm8k`` to avoid duplicating logic.
+
+Usage::
+
+    from sglang.test.kits.gsm8k_completion_kit import run_gsm8k_benchmark
+
+    acc, invalid, latency = run_gsm8k_benchmark(base_url, num_questions=200)
+"""
+
+import time
+from typing import Tuple
+
+from sglang.test.few_shot_gsm8k import (
+    INVALID,
+    get_answer_value,
+    get_few_shot_examples,
+    get_one_example,
+)
+from sglang.utils import download_and_cache_file, read_jsonl
+
+__all__ = [
+    "INVALID",
+    "get_answer_value",
+    "get_few_shot_examples",
+    "get_one_example",
+    "run_gsm8k_benchmark",
+]
+
+
+def run_gsm8k_benchmark(
+    base_url: str,
+    num_questions: int = 200,
+    num_shots: int = 5,
+    parallel: int = 64,
+) -> Tuple[float, float, float]:
+    """Run the GSM8K few-shot completion benchmark against a running SGLang server.
+
+    Args:
+        base_url: Base URL of the SGLang server (e.g. ``"http://127.0.0.1:30000"``).
+        num_questions: Number of test questions to evaluate.
+        num_shots: Number of few-shot examples to prepend.
+        parallel: Number of parallel requests.
+
+    Returns:
+        A 3-tuple ``(accuracy, invalid_rate, latency)`` where:
+
+        - ``accuracy``     — fraction of questions answered correctly.
+        - ``invalid_rate`` — fraction of predictions that could not be parsed
+          (equal to ``INVALID``).
+        - ``latency``      — wall-clock seconds for the full batch.
+    """
+    import numpy as np
+
+    import sglang as sgl
+    from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
+
+    url = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl"
+    data_path = download_and_cache_file(url)
+    lines = list(read_jsonl(data_path))
+
+    few_shot_examples = get_few_shot_examples(lines, num_shots)
+
+    questions = []
+    labels = []
+    for i in range(len(lines[:num_questions])):
+        questions.append(get_one_example(lines, i, False))
+        labels.append(get_answer_value(lines[i]["answer"]))
+    assert all(label != INVALID for label in labels)
+    arguments = [{"question": q} for q in questions]
+
+    @sgl.function
+    def few_shot_gsm8k(s, question):
+        s += few_shot_examples + question
+        s += sgl.gen(
+            "answer", max_tokens=512, stop=["Question", "Assistant:", "<|separator|>"]
+        )
+
+    backend = RuntimeEndpoint(base_url)
+    sgl.set_default_backend(backend)
+
+    tic = time.perf_counter()
+    states = few_shot_gsm8k.run_batch(
+        arguments, temperature=0, num_threads=parallel, progress_bar=True
+    )
+    latency = time.perf_counter() - tic
+
+    preds = [get_answer_value(states[i]["answer"]) for i in range(len(states))]
+    acc = np.mean(np.array(preds) == np.array(labels))
+    invalid = np.mean(np.array(preds) == INVALID)
+
+    return float(acc), float(invalid), float(latency)

--- a/python/sglang/test/kits/gsm8k_completion_kit.py
+++ b/python/sglang/test/kits/gsm8k_completion_kit.py
@@ -18,6 +18,8 @@ Usage::
 import time
 from typing import Tuple
 
+import sglang as sgl
+from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
 from sglang.test.few_shot_gsm8k import (
     INVALID,
     get_answer_value,
@@ -57,22 +59,18 @@ def run_gsm8k_benchmark(
           (equal to ``INVALID``).
         - ``latency``      — wall-clock seconds for the full batch.
     """
-    import numpy as np
-
-    import sglang as sgl
-    from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
-
     url = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl"
     data_path = download_and_cache_file(url)
     lines = list(read_jsonl(data_path))
 
     few_shot_examples = get_few_shot_examples(lines, num_shots)
 
-    questions = []
-    labels = []
-    for i in range(len(lines[:num_questions])):
-        questions.append(get_one_example(lines, i, False))
-        labels.append(get_answer_value(lines[i]["answer"]))
+    questions = [
+        get_one_example(lines, i, False) for i in range(len(lines[:num_questions]))
+    ]
+    labels = [
+        get_answer_value(lines[i]["answer"]) for i in range(len(lines[:num_questions]))
+    ]
     assert all(label != INVALID for label in labels)
     arguments = [{"question": q} for q in questions]
 
@@ -92,8 +90,8 @@ def run_gsm8k_benchmark(
     )
     latency = time.perf_counter() - tic
 
-    preds = [get_answer_value(states[i]["answer"]) for i in range(len(states))]
-    acc = np.mean(np.array(preds) == np.array(labels))
-    invalid = np.mean(np.array(preds) == INVALID)
+    preds = [get_answer_value(s["answer"]) for s in states]
+    acc = sum(p == l for p, l in zip(preds, labels)) / len(preds) if preds else 0.0
+    invalid = sum(p == INVALID for p in preds) / len(preds) if preds else 0.0
 
     return float(acc), float(invalid), float(latency)

--- a/test/registered/amd/accuracy/mi30x/test_deepseek_r1_eval_amd.py
+++ b/test/registered/amd/accuracy/mi30x/test_deepseek_r1_eval_amd.py
@@ -6,18 +6,14 @@ using few-shot completion benchmark on MI300X.
 Registry: nightly-amd-8-gpu-deepseek-r1 suite
 """
 
-import ast
 import os
-import re
-import time
 import unittest
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
-
-import numpy as np
+from typing import List, Optional
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.kits.gsm8k_completion_kit import run_gsm8k_benchmark
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
@@ -25,15 +21,11 @@ from sglang.test.test_utils import (
     popen_launch_server,
     write_github_step_summary,
 )
-from sglang.utils import download_and_cache_file, read_jsonl
 
 # Register for AMD CI - DeepSeek-R1 accuracy tests (~120 min)
 register_amd_ci(
     est_time=7200, suite="nightly-amd-accuracy-8-gpu-deepseek-r1", nightly=True
 )
-
-INVALID = -9999999
-
 
 @dataclass
 class ModelConfig:
@@ -150,81 +142,6 @@ DEEPSEEK_R1_MODELS = [
         },
     ),
 ]
-
-
-def get_one_example(lines, i, include_answer):
-    """Format a single GSM8K example."""
-    ret = "Question: " + lines[i]["question"] + "\nAnswer:"
-    if include_answer:
-        ret += " " + lines[i]["answer"]
-    return ret
-
-
-def get_few_shot_examples(lines, k):
-    """Get k few-shot examples for prompting."""
-    ret = ""
-    for i in range(k):
-        ret += get_one_example(lines, i, True) + "\n\n"
-    return ret
-
-
-def get_answer_value(answer_str):
-    """Extract numerical answer from response."""
-    answer_str = answer_str.replace(",", "")
-    numbers = re.findall(r"\d+", answer_str)
-    if len(numbers) < 1:
-        return INVALID
-    try:
-        return ast.literal_eval(numbers[-1])
-    except SyntaxError:
-        return INVALID
-
-
-def run_gsm8k_benchmark(
-    base_url: str,
-    num_questions: int = 200,
-    num_shots: int = 5,
-    parallel: int = 64,
-) -> Tuple[float, float, float]:
-    """Run GSM8K few-shot completion benchmark."""
-    import sglang as sgl
-    from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
-
-    url = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl"
-    data_path = download_and_cache_file(url)
-    lines = list(read_jsonl(data_path))
-
-    few_shot_examples = get_few_shot_examples(lines, num_shots)
-
-    questions = []
-    labels = []
-    for i in range(len(lines[:num_questions])):
-        questions.append(get_one_example(lines, i, False))
-        labels.append(get_answer_value(lines[i]["answer"]))
-    assert all(l != INVALID for l in labels)
-    arguments = [{"question": q} for q in questions]
-
-    @sgl.function
-    def few_shot_gsm8k(s, question):
-        s += few_shot_examples + question
-        s += sgl.gen(
-            "answer", max_tokens=512, stop=["Question", "Assistant:", "<|separator|>"]
-        )
-
-    backend = RuntimeEndpoint(base_url)
-    sgl.set_default_backend(backend)
-
-    tic = time.perf_counter()
-    states = few_shot_gsm8k.run_batch(
-        arguments, temperature=0, num_threads=parallel, progress_bar=True
-    )
-    latency = time.perf_counter() - tic
-
-    preds = [get_answer_value(states[i]["answer"]) for i in range(len(states))]
-    acc = np.mean(np.array(preds) == np.array(labels))
-    invalid = np.mean(np.array(preds) == INVALID)
-
-    return float(acc), float(invalid), float(latency)
 
 
 class TestDeepSeekR1EvalAMD(unittest.TestCase):

--- a/test/registered/amd/accuracy/mi30x/test_deepseek_r1_eval_amd.py
+++ b/test/registered/amd/accuracy/mi30x/test_deepseek_r1_eval_amd.py
@@ -27,6 +27,7 @@ register_amd_ci(
     est_time=7200, suite="nightly-amd-accuracy-8-gpu-deepseek-r1", nightly=True
 )
 
+
 @dataclass
 class ModelConfig:
     """Configuration for a model to test."""

--- a/test/registered/amd/accuracy/mi30x/test_deepseek_v31_eval_amd.py
+++ b/test/registered/amd/accuracy/mi30x/test_deepseek_v31_eval_amd.py
@@ -5,96 +5,27 @@ Tests DeepSeek-V3.1 model using few-shot completion benchmark on MI300X.
 Registry: nightly-amd-8-gpu-deepseek-v31 suite
 """
 
-import ast
 import os
-import re
-import time
 import unittest
-
-import numpy as np
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.kits.gsm8k_completion_kit import run_gsm8k_benchmark
 from sglang.test.test_utils import (
     DEFAULT_URL_FOR_TEST,
     is_in_ci,
     popen_launch_server,
     write_github_step_summary,
 )
-from sglang.utils import download_and_cache_file, read_jsonl
 
 # Register for AMD CI - DeepSeek-V3.1 accuracy tests (~60 min)
 register_amd_ci(
     est_time=3600, suite="nightly-amd-accuracy-8-gpu-deepseek-v31", nightly=True
 )
 
-INVALID = -9999999
-
 DEEPSEEK_V31_MODEL_PATH = os.environ.get(
     "DEEPSEEK_V31_MODEL_PATH", "deepseek-ai/DeepSeek-V3-0324"
 )
-
-
-def get_one_example(lines, i, include_answer):
-    ret = "Question: " + lines[i]["question"] + "\nAnswer:"
-    if include_answer:
-        ret += " " + lines[i]["answer"]
-    return ret
-
-
-def get_few_shot_examples(lines, k):
-    ret = ""
-    for i in range(k):
-        ret += get_one_example(lines, i, True) + "\n\n"
-    return ret
-
-
-def get_answer_value(answer_str):
-    answer_str = answer_str.replace(",", "")
-    numbers = re.findall(r"\d+", answer_str)
-    if len(numbers) < 1:
-        return INVALID
-    try:
-        return ast.literal_eval(numbers[-1])
-    except SyntaxError:
-        return INVALID
-
-
-def run_gsm8k_benchmark(base_url, num_questions=200, num_shots=5, parallel=64):
-    import sglang as sgl
-    from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
-
-    url = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl"
-    data_path = download_and_cache_file(url)
-    lines = list(read_jsonl(data_path))
-
-    few_shot_examples = get_few_shot_examples(lines, num_shots)
-    questions = []
-    labels = []
-    for i in range(len(lines[:num_questions])):
-        questions.append(get_one_example(lines, i, False))
-        labels.append(get_answer_value(lines[i]["answer"]))
-    arguments = [{"question": q} for q in questions]
-
-    @sgl.function
-    def few_shot_gsm8k(s, question):
-        s += few_shot_examples + question
-        s += sgl.gen(
-            "answer", max_tokens=512, stop=["Question", "Assistant:", "<|separator|>"]
-        )
-
-    backend = RuntimeEndpoint(base_url)
-    sgl.set_default_backend(backend)
-
-    tic = time.perf_counter()
-    states = few_shot_gsm8k.run_batch(
-        arguments, temperature=0, num_threads=parallel, progress_bar=True
-    )
-    latency = time.perf_counter() - tic
-
-    preds = [get_answer_value(states[i]["answer"]) for i in range(len(states))]
-    acc = np.mean(np.array(preds) == np.array(labels))
-    return float(acc), float(latency)
 
 
 class TestDeepSeekV31EvalAMD(unittest.TestCase):
@@ -132,7 +63,7 @@ class TestDeepSeekV31EvalAMD(unittest.TestCase):
         )
 
         try:
-            acc, latency = run_gsm8k_benchmark(
+            acc, _invalid, latency = run_gsm8k_benchmark(
                 self.base_url, num_questions=self.num_questions
             )
             passed = acc >= self.accuracy_threshold

--- a/test/registered/amd/accuracy/mi30x/test_deepseek_v32_eval_amd.py
+++ b/test/registered/amd/accuracy/mi30x/test_deepseek_v32_eval_amd.py
@@ -29,6 +29,7 @@ register_amd_ci(
     nightly=True,
 )
 
+
 @dataclass
 class ModelConfig:
     """Configuration for a model to test."""

--- a/test/registered/amd/accuracy/mi30x/test_deepseek_v32_eval_amd.py
+++ b/test/registered/amd/accuracy/mi30x/test_deepseek_v32_eval_amd.py
@@ -6,18 +6,14 @@ benchmark on MI325/MI300X.
 Registry: nightly-amd-accuracy-8-gpu-deepseek-v32 suite
 """
 
-import ast
 import os
-import re
-import time
 import unittest
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
-
-import numpy as np
+from typing import List, Optional
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.kits.gsm8k_completion_kit import run_gsm8k_benchmark
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
@@ -25,7 +21,6 @@ from sglang.test.test_utils import (
     popen_launch_server,
     write_github_step_summary,
 )
-from sglang.utils import download_and_cache_file, read_jsonl
 
 # Register for AMD CI - DeepSeek-V3.2 accuracy test (~60 min for basic only)
 register_amd_ci(
@@ -33,9 +28,6 @@ register_amd_ci(
     suite="nightly-amd-accuracy-8-gpu-deepseek-v32",
     nightly=True,
 )
-
-INVALID = -9999999
-
 
 @dataclass
 class ModelConfig:
@@ -86,81 +78,6 @@ DEEPSEEK_V32_MODELS = [
         env_vars={"SGLANG_USE_AITER": "1"},
     ),
 ]
-
-
-def get_one_example(lines, i, include_answer):
-    """Format a single GSM8K example."""
-    ret = "Question: " + lines[i]["question"] + "\nAnswer:"
-    if include_answer:
-        ret += " " + lines[i]["answer"]
-    return ret
-
-
-def get_few_shot_examples(lines, k):
-    """Get k few-shot examples for prompting."""
-    ret = ""
-    for i in range(k):
-        ret += get_one_example(lines, i, True) + "\n\n"
-    return ret
-
-
-def get_answer_value(answer_str):
-    """Extract numerical answer from response."""
-    answer_str = answer_str.replace(",", "")
-    numbers = re.findall(r"\d+", answer_str)
-    if len(numbers) < 1:
-        return INVALID
-    try:
-        return ast.literal_eval(numbers[-1])
-    except SyntaxError:
-        return INVALID
-
-
-def run_gsm8k_benchmark(
-    base_url: str,
-    num_questions: int = 200,
-    num_shots: int = 5,
-    parallel: int = 64,
-) -> Tuple[float, float, float]:
-    """Run GSM8K few-shot completion benchmark."""
-    import sglang as sgl
-    from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
-
-    url = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl"
-    data_path = download_and_cache_file(url)
-    lines = list(read_jsonl(data_path))
-
-    few_shot_examples = get_few_shot_examples(lines, num_shots)
-
-    questions = []
-    labels = []
-    for i in range(len(lines[:num_questions])):
-        questions.append(get_one_example(lines, i, False))
-        labels.append(get_answer_value(lines[i]["answer"]))
-    assert all(l != INVALID for l in labels)
-    arguments = [{"question": q} for q in questions]
-
-    @sgl.function
-    def few_shot_gsm8k(s, question):
-        s += few_shot_examples + question
-        s += sgl.gen(
-            "answer", max_tokens=512, stop=["Question", "Assistant:", "<|separator|>"]
-        )
-
-    backend = RuntimeEndpoint(base_url)
-    sgl.set_default_backend(backend)
-
-    tic = time.perf_counter()
-    states = few_shot_gsm8k.run_batch(
-        arguments, temperature=0, num_threads=parallel, progress_bar=True
-    )
-    latency = time.perf_counter() - tic
-
-    preds = [get_answer_value(states[i]["answer"]) for i in range(len(states))]
-    acc = np.mean(np.array(preds) == np.array(labels))
-    invalid = np.mean(np.array(preds) == INVALID)
-
-    return float(acc), float(invalid), float(latency)
 
 
 class TestDeepSeekV32EvalAMD(unittest.TestCase):

--- a/test/registered/amd/accuracy/mi30x/test_glm5_eval_amd.py
+++ b/test/registered/amd/accuracy/mi30x/test_glm5_eval_amd.py
@@ -6,18 +6,14 @@ benchmark on MI325/MI300X.
 Registry: nightly-amd-accuracy-8-gpu-glm5 suite
 """
 
-import ast
 import os
-import re
-import time
 import unittest
 from dataclasses import dataclass, field
-from typing import List, Optional, Tuple
-
-import numpy as np
+from typing import List, Optional
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.kits.gsm8k_completion_kit import run_gsm8k_benchmark
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
@@ -25,7 +21,6 @@ from sglang.test.test_utils import (
     popen_launch_server,
     write_github_step_summary,
 )
-from sglang.utils import download_and_cache_file, read_jsonl
 
 # Register for AMD CI - GLM-5 accuracy test (~60 min)
 register_amd_ci(
@@ -33,9 +28,6 @@ register_amd_ci(
     suite="nightly-amd-accuracy-8-gpu-glm5",
     nightly=True,
 )
-
-INVALID = -9999999
-
 
 @dataclass
 class ModelConfig:
@@ -82,81 +74,6 @@ GLM5_MODELS = [
         env_vars={"SGLANG_USE_AITER": "1"},
     ),
 ]
-
-
-def get_one_example(lines, i, include_answer):
-    """Format a single GSM8K example."""
-    ret = "Question: " + lines[i]["question"] + "\nAnswer:"
-    if include_answer:
-        ret += " " + lines[i]["answer"]
-    return ret
-
-
-def get_few_shot_examples(lines, k):
-    """Get k few-shot examples for prompting."""
-    ret = ""
-    for i in range(k):
-        ret += get_one_example(lines, i, True) + "\n\n"
-    return ret
-
-
-def get_answer_value(answer_str):
-    """Extract numerical answer from response."""
-    answer_str = answer_str.replace(",", "")
-    numbers = re.findall(r"\d+", answer_str)
-    if len(numbers) < 1:
-        return INVALID
-    try:
-        return ast.literal_eval(numbers[-1])
-    except SyntaxError:
-        return INVALID
-
-
-def run_gsm8k_benchmark(
-    base_url: str,
-    num_questions: int = 200,
-    num_shots: int = 5,
-    parallel: int = 64,
-) -> Tuple[float, float, float]:
-    """Run GSM8K few-shot completion benchmark."""
-    import sglang as sgl
-    from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
-
-    url = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl"
-    data_path = download_and_cache_file(url)
-    lines = list(read_jsonl(data_path))
-
-    few_shot_examples = get_few_shot_examples(lines, num_shots)
-
-    questions = []
-    labels = []
-    for i in range(len(lines[:num_questions])):
-        questions.append(get_one_example(lines, i, False))
-        labels.append(get_answer_value(lines[i]["answer"]))
-    assert all(l != INVALID for l in labels)
-    arguments = [{"question": q} for q in questions]
-
-    @sgl.function
-    def few_shot_gsm8k(s, question):
-        s += few_shot_examples + question
-        s += sgl.gen(
-            "answer", max_tokens=512, stop=["Question", "Assistant:", "<|separator|>"]
-        )
-
-    backend = RuntimeEndpoint(base_url)
-    sgl.set_default_backend(backend)
-
-    tic = time.perf_counter()
-    states = few_shot_gsm8k.run_batch(
-        arguments, temperature=0, num_threads=parallel, progress_bar=True
-    )
-    latency = time.perf_counter() - tic
-
-    preds = [get_answer_value(states[i]["answer"]) for i in range(len(states))]
-    acc = np.mean(np.array(preds) == np.array(labels))
-    invalid = np.mean(np.array(preds) == INVALID)
-
-    return float(acc), float(invalid), float(latency)
 
 
 class TestGLM5EvalAMD(unittest.TestCase):

--- a/test/registered/amd/accuracy/mi30x/test_glm5_eval_amd.py
+++ b/test/registered/amd/accuracy/mi30x/test_glm5_eval_amd.py
@@ -29,6 +29,7 @@ register_amd_ci(
     nightly=True,
 )
 
+
 @dataclass
 class ModelConfig:
     """Configuration for a model to test."""

--- a/test/registered/amd/accuracy/mi30x/test_gpt_oss_eval_amd.py
+++ b/test/registered/amd/accuracy/mi30x/test_gpt_oss_eval_amd.py
@@ -6,18 +6,14 @@ few-shot completion benchmark on MI300X.
 Registry: nightly-amd-8-gpu suite
 """
 
-import ast
 import os
-import re
-import time
 import unittest
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
-
-import numpy as np
+from typing import List, Optional
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.kits.gsm8k_completion_kit import run_gsm8k_benchmark
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
@@ -25,13 +21,9 @@ from sglang.test.test_utils import (
     popen_launch_server,
     write_github_step_summary,
 )
-from sglang.utils import download_and_cache_file, read_jsonl
 
 # Register for AMD CI - GPT-OSS accuracy tests (~30 min)
 register_amd_ci(est_time=1800, suite="nightly-amd-accuracy-8-gpu-gpt-oss", nightly=True)
-
-INVALID = -9999999
-
 
 @dataclass
 class ModelConfig:
@@ -89,81 +81,6 @@ GPT_OSS_MODELS = [
         env_vars={"SGLANG_USE_AITER": "1"},
     ),
 ]
-
-
-def get_one_example(lines, i, include_answer):
-    """Format a single GSM8K example."""
-    ret = "Question: " + lines[i]["question"] + "\nAnswer:"
-    if include_answer:
-        ret += " " + lines[i]["answer"]
-    return ret
-
-
-def get_few_shot_examples(lines, k):
-    """Get k few-shot examples for prompting."""
-    ret = ""
-    for i in range(k):
-        ret += get_one_example(lines, i, True) + "\n\n"
-    return ret
-
-
-def get_answer_value(answer_str):
-    """Extract numerical answer from response."""
-    answer_str = answer_str.replace(",", "")
-    numbers = re.findall(r"\d+", answer_str)
-    if len(numbers) < 1:
-        return INVALID
-    try:
-        return ast.literal_eval(numbers[-1])
-    except SyntaxError:
-        return INVALID
-
-
-def run_gsm8k_benchmark(
-    base_url: str,
-    num_questions: int = 200,
-    num_shots: int = 5,
-    parallel: int = 64,
-) -> Tuple[float, float, float]:
-    """Run GSM8K few-shot completion benchmark."""
-    import sglang as sgl
-    from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
-
-    url = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl"
-    data_path = download_and_cache_file(url)
-    lines = list(read_jsonl(data_path))
-
-    few_shot_examples = get_few_shot_examples(lines, num_shots)
-
-    questions = []
-    labels = []
-    for i in range(len(lines[:num_questions])):
-        questions.append(get_one_example(lines, i, False))
-        labels.append(get_answer_value(lines[i]["answer"]))
-    assert all(l != INVALID for l in labels)
-    arguments = [{"question": q} for q in questions]
-
-    @sgl.function
-    def few_shot_gsm8k(s, question):
-        s += few_shot_examples + question
-        s += sgl.gen(
-            "answer", max_tokens=512, stop=["Question", "Assistant:", "<|separator|>"]
-        )
-
-    backend = RuntimeEndpoint(base_url)
-    sgl.set_default_backend(backend)
-
-    tic = time.perf_counter()
-    states = few_shot_gsm8k.run_batch(
-        arguments, temperature=0, num_threads=parallel, progress_bar=True
-    )
-    latency = time.perf_counter() - tic
-
-    preds = [get_answer_value(states[i]["answer"]) for i in range(len(states))]
-    acc = np.mean(np.array(preds) == np.array(labels))
-    invalid = np.mean(np.array(preds) == INVALID)
-
-    return float(acc), float(invalid), float(latency)
 
 
 class TestGptOssEvalAMD(unittest.TestCase):

--- a/test/registered/amd/accuracy/mi30x/test_gpt_oss_eval_amd.py
+++ b/test/registered/amd/accuracy/mi30x/test_gpt_oss_eval_amd.py
@@ -25,6 +25,7 @@ from sglang.test.test_utils import (
 # Register for AMD CI - GPT-OSS accuracy tests (~30 min)
 register_amd_ci(est_time=1800, suite="nightly-amd-accuracy-8-gpu-gpt-oss", nightly=True)
 
+
 @dataclass
 class ModelConfig:
     """Configuration for a model to test."""

--- a/test/registered/amd/accuracy/mi30x/test_grok1_fp8_eval_amd.py
+++ b/test/registered/amd/accuracy/mi30x/test_grok1_fp8_eval_amd.py
@@ -5,95 +5,26 @@ Tests Grok-1 FP8 model using few-shot completion benchmark on MI300X.
 Registry: nightly-amd-8-gpu-grok1-fp8 suite
 """
 
-import ast
 import os
-import re
-import time
 import unittest
-
-import numpy as np
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.kits.gsm8k_completion_kit import run_gsm8k_benchmark
 from sglang.test.test_utils import (
     DEFAULT_URL_FOR_TEST,
     is_in_ci,
     popen_launch_server,
     write_github_step_summary,
 )
-from sglang.utils import download_and_cache_file, read_jsonl
 
 # Register for AMD CI - GROK1-FP8 accuracy tests (~25 min)
 register_amd_ci(
     est_time=1500, suite="nightly-amd-accuracy-8-gpu-grok1-fp8", nightly=True
 )
 
-INVALID = -9999999
-
 GROK1_FP8_MODEL_PATH = os.environ.get("GROK1_MODEL_PATH", "lmzheng/grok-1")
 GROK1_TOKENIZER_PATH = os.environ.get("GROK1_TOKENIZER_PATH", "Xenova/grok-1-tokenizer")
-
-
-def get_one_example(lines, i, include_answer):
-    ret = "Question: " + lines[i]["question"] + "\nAnswer:"
-    if include_answer:
-        ret += " " + lines[i]["answer"]
-    return ret
-
-
-def get_few_shot_examples(lines, k):
-    ret = ""
-    for i in range(k):
-        ret += get_one_example(lines, i, True) + "\n\n"
-    return ret
-
-
-def get_answer_value(answer_str):
-    answer_str = answer_str.replace(",", "")
-    numbers = re.findall(r"\d+", answer_str)
-    if len(numbers) < 1:
-        return INVALID
-    try:
-        return ast.literal_eval(numbers[-1])
-    except SyntaxError:
-        return INVALID
-
-
-def run_gsm8k_benchmark(base_url, num_questions=200, num_shots=5, parallel=64):
-    import sglang as sgl
-    from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
-
-    url = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl"
-    data_path = download_and_cache_file(url)
-    lines = list(read_jsonl(data_path))
-
-    few_shot_examples = get_few_shot_examples(lines, num_shots)
-    questions = []
-    labels = []
-    for i in range(len(lines[:num_questions])):
-        questions.append(get_one_example(lines, i, False))
-        labels.append(get_answer_value(lines[i]["answer"]))
-    arguments = [{"question": q} for q in questions]
-
-    @sgl.function
-    def few_shot_gsm8k(s, question):
-        s += few_shot_examples + question
-        s += sgl.gen(
-            "answer", max_tokens=512, stop=["Question", "Assistant:", "<|separator|>"]
-        )
-
-    backend = RuntimeEndpoint(base_url)
-    sgl.set_default_backend(backend)
-
-    tic = time.perf_counter()
-    states = few_shot_gsm8k.run_batch(
-        arguments, temperature=0, num_threads=parallel, progress_bar=True
-    )
-    latency = time.perf_counter() - tic
-
-    preds = [get_answer_value(states[i]["answer"]) for i in range(len(states))]
-    acc = np.mean(np.array(preds) == np.array(labels))
-    return float(acc), float(latency)
 
 
 class TestGrok1FP8EvalAMD(unittest.TestCase):
@@ -135,7 +66,7 @@ class TestGrok1FP8EvalAMD(unittest.TestCase):
         )
 
         try:
-            acc, latency = run_gsm8k_benchmark(
+            acc, _invalid, latency = run_gsm8k_benchmark(
                 self.base_url, num_questions=self.num_questions
             )
             passed = acc >= self.accuracy_threshold

--- a/test/registered/amd/accuracy/mi30x/test_grok1_int4_eval_amd.py
+++ b/test/registered/amd/accuracy/mi30x/test_grok1_int4_eval_amd.py
@@ -5,95 +5,26 @@ Tests Grok-1 INT4 (W4A8KV8) model using few-shot completion benchmark on MI300X.
 Registry: nightly-amd-8-gpu-grok1-int4 suite
 """
 
-import ast
 import os
-import re
-import time
 import unittest
-
-import numpy as np
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.kits.gsm8k_completion_kit import run_gsm8k_benchmark
 from sglang.test.test_utils import (
     DEFAULT_URL_FOR_TEST,
     is_in_ci,
     popen_launch_server,
     write_github_step_summary,
 )
-from sglang.utils import download_and_cache_file, read_jsonl
 
 # Register for AMD CI - GROK1-INT4 accuracy tests (~25 min)
 register_amd_ci(
     est_time=1500, suite="nightly-amd-accuracy-8-gpu-grok1-int4", nightly=True
 )
 
-INVALID = -9999999
-
 GROK1_INT4_MODEL_PATH = os.environ.get("GROK1_INT4_MODEL_PATH", "amd/grok-1-W4A8KV8")
 GROK1_TOKENIZER_PATH = os.environ.get("GROK1_TOKENIZER_PATH", "Xenova/grok-1-tokenizer")
-
-
-def get_one_example(lines, i, include_answer):
-    ret = "Question: " + lines[i]["question"] + "\nAnswer:"
-    if include_answer:
-        ret += " " + lines[i]["answer"]
-    return ret
-
-
-def get_few_shot_examples(lines, k):
-    ret = ""
-    for i in range(k):
-        ret += get_one_example(lines, i, True) + "\n\n"
-    return ret
-
-
-def get_answer_value(answer_str):
-    answer_str = answer_str.replace(",", "")
-    numbers = re.findall(r"\d+", answer_str)
-    if len(numbers) < 1:
-        return INVALID
-    try:
-        return ast.literal_eval(numbers[-1])
-    except SyntaxError:
-        return INVALID
-
-
-def run_gsm8k_benchmark(base_url, num_questions=200, num_shots=5, parallel=64):
-    import sglang as sgl
-    from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
-
-    url = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl"
-    data_path = download_and_cache_file(url)
-    lines = list(read_jsonl(data_path))
-
-    few_shot_examples = get_few_shot_examples(lines, num_shots)
-    questions = []
-    labels = []
-    for i in range(len(lines[:num_questions])):
-        questions.append(get_one_example(lines, i, False))
-        labels.append(get_answer_value(lines[i]["answer"]))
-    arguments = [{"question": q} for q in questions]
-
-    @sgl.function
-    def few_shot_gsm8k(s, question):
-        s += few_shot_examples + question
-        s += sgl.gen(
-            "answer", max_tokens=512, stop=["Question", "Assistant:", "<|separator|>"]
-        )
-
-    backend = RuntimeEndpoint(base_url)
-    sgl.set_default_backend(backend)
-
-    tic = time.perf_counter()
-    states = few_shot_gsm8k.run_batch(
-        arguments, temperature=0, num_threads=parallel, progress_bar=True
-    )
-    latency = time.perf_counter() - tic
-
-    preds = [get_answer_value(states[i]["answer"]) for i in range(len(states))]
-    acc = np.mean(np.array(preds) == np.array(labels))
-    return float(acc), float(latency)
 
 
 class TestGrok1INT4EvalAMD(unittest.TestCase):
@@ -135,7 +66,7 @@ class TestGrok1INT4EvalAMD(unittest.TestCase):
         )
 
         try:
-            acc, latency = run_gsm8k_benchmark(
+            acc, _invalid, latency = run_gsm8k_benchmark(
                 self.base_url, num_questions=self.num_questions
             )
             passed = acc >= self.accuracy_threshold

--- a/test/registered/amd/accuracy/mi30x/test_grok2_eval_amd.py
+++ b/test/registered/amd/accuracy/mi30x/test_grok2_eval_amd.py
@@ -5,95 +5,26 @@ Tests Grok-2 model using few-shot completion benchmark on MI300X.
 Registry: nightly-amd-8-gpu-grok2 suite
 """
 
-import ast
 import os
-import re
-import time
 import unittest
-
-import numpy as np
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.kits.gsm8k_completion_kit import run_gsm8k_benchmark
 from sglang.test.test_utils import (
     DEFAULT_URL_FOR_TEST,
     is_in_ci,
     popen_launch_server,
     write_github_step_summary,
 )
-from sglang.utils import download_and_cache_file, read_jsonl
 
 # Register for AMD CI - GROK2 accuracy tests (~25 min)
 register_amd_ci(est_time=1500, suite="nightly-amd-accuracy-8-gpu-grok2", nightly=True)
-
-INVALID = -9999999
 
 GROK2_MODEL_PATH = os.environ.get("GROK2_MODEL_PATH", "xai-org/grok-2")
 GROK2_TOKENIZER_PATH = os.environ.get(
     "GROK2_TOKENIZER_PATH", "alvarobartt/grok-2-tokenizer"
 )
-
-
-def get_one_example(lines, i, include_answer):
-    ret = "Question: " + lines[i]["question"] + "\nAnswer:"
-    if include_answer:
-        ret += " " + lines[i]["answer"]
-    return ret
-
-
-def get_few_shot_examples(lines, k):
-    ret = ""
-    for i in range(k):
-        ret += get_one_example(lines, i, True) + "\n\n"
-    return ret
-
-
-def get_answer_value(answer_str):
-    answer_str = answer_str.replace(",", "")
-    numbers = re.findall(r"\d+", answer_str)
-    if len(numbers) < 1:
-        return INVALID
-    try:
-        return ast.literal_eval(numbers[-1])
-    except SyntaxError:
-        return INVALID
-
-
-def run_gsm8k_benchmark(base_url, num_questions=200, num_shots=5, parallel=64):
-    import sglang as sgl
-    from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
-
-    url = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl"
-    data_path = download_and_cache_file(url)
-    lines = list(read_jsonl(data_path))
-
-    few_shot_examples = get_few_shot_examples(lines, num_shots)
-    questions = []
-    labels = []
-    for i in range(len(lines[:num_questions])):
-        questions.append(get_one_example(lines, i, False))
-        labels.append(get_answer_value(lines[i]["answer"]))
-    arguments = [{"question": q} for q in questions]
-
-    @sgl.function
-    def few_shot_gsm8k(s, question):
-        s += few_shot_examples + question
-        s += sgl.gen(
-            "answer", max_tokens=512, stop=["Question", "Assistant:", "<|separator|>"]
-        )
-
-    backend = RuntimeEndpoint(base_url)
-    sgl.set_default_backend(backend)
-
-    tic = time.perf_counter()
-    states = few_shot_gsm8k.run_batch(
-        arguments, temperature=0, num_threads=parallel, progress_bar=True
-    )
-    latency = time.perf_counter() - tic
-
-    preds = [get_answer_value(states[i]["answer"]) for i in range(len(states))]
-    acc = np.mean(np.array(preds) == np.array(labels))
-    return float(acc), float(latency)
 
 
 class TestGrok2EvalAMD(unittest.TestCase):
@@ -135,7 +66,7 @@ class TestGrok2EvalAMD(unittest.TestCase):
         )
 
         try:
-            acc, latency = run_gsm8k_benchmark(
+            acc, _invalid, latency = run_gsm8k_benchmark(
                 self.base_url, num_questions=self.num_questions
             )
             passed = acc >= self.accuracy_threshold

--- a/test/registered/amd/accuracy/mi30x/test_grok_eval_amd.py
+++ b/test/registered/amd/accuracy/mi30x/test_grok_eval_amd.py
@@ -31,6 +31,7 @@ register_amd_ci(
     disabled="Split into test_grok1_fp8_eval_amd.py, test_grok1_int4_eval_amd.py, test_grok2_eval_amd.py",
 )
 
+
 @dataclass
 class ModelConfig:
     """Configuration for a model to test."""

--- a/test/registered/amd/accuracy/mi30x/test_grok_eval_amd.py
+++ b/test/registered/amd/accuracy/mi30x/test_grok_eval_amd.py
@@ -6,18 +6,14 @@ few-shot completion benchmark on MI300X.
 Registry: nightly-amd-8-gpu-grok suite
 """
 
-import ast
 import os
-import re
-import time
 import unittest
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
-
-import numpy as np
+from typing import List, Optional
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.kits.gsm8k_completion_kit import run_gsm8k_benchmark
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
@@ -25,7 +21,6 @@ from sglang.test.test_utils import (
     popen_launch_server,
     write_github_step_summary,
 )
-from sglang.utils import download_and_cache_file, read_jsonl
 
 # DISABLED: Split into individual files for each model variant
 # See: test_grok1_fp8_eval_amd.py, test_grok1_int4_eval_amd.py, test_grok2_eval_amd.py
@@ -35,9 +30,6 @@ register_amd_ci(
     nightly=True,
     disabled="Split into test_grok1_fp8_eval_amd.py, test_grok1_int4_eval_amd.py, test_grok2_eval_amd.py",
 )
-
-INVALID = -9999999
-
 
 @dataclass
 class ModelConfig:
@@ -127,81 +119,6 @@ GROK_MODELS = [
         },
     ),
 ]
-
-
-def get_one_example(lines, i, include_answer):
-    """Format a single GSM8K example."""
-    ret = "Question: " + lines[i]["question"] + "\nAnswer:"
-    if include_answer:
-        ret += " " + lines[i]["answer"]
-    return ret
-
-
-def get_few_shot_examples(lines, k):
-    """Get k few-shot examples for prompting."""
-    ret = ""
-    for i in range(k):
-        ret += get_one_example(lines, i, True) + "\n\n"
-    return ret
-
-
-def get_answer_value(answer_str):
-    """Extract numerical answer from response."""
-    answer_str = answer_str.replace(",", "")
-    numbers = re.findall(r"\d+", answer_str)
-    if len(numbers) < 1:
-        return INVALID
-    try:
-        return ast.literal_eval(numbers[-1])
-    except SyntaxError:
-        return INVALID
-
-
-def run_gsm8k_benchmark(
-    base_url: str,
-    num_questions: int = 200,
-    num_shots: int = 5,
-    parallel: int = 64,
-) -> Tuple[float, float, float]:
-    """Run GSM8K few-shot completion benchmark."""
-    import sglang as sgl
-    from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
-
-    url = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl"
-    data_path = download_and_cache_file(url)
-    lines = list(read_jsonl(data_path))
-
-    few_shot_examples = get_few_shot_examples(lines, num_shots)
-
-    questions = []
-    labels = []
-    for i in range(len(lines[:num_questions])):
-        questions.append(get_one_example(lines, i, False))
-        labels.append(get_answer_value(lines[i]["answer"]))
-    assert all(l != INVALID for l in labels)
-    arguments = [{"question": q} for q in questions]
-
-    @sgl.function
-    def few_shot_gsm8k(s, question):
-        s += few_shot_examples + question
-        s += sgl.gen(
-            "answer", max_tokens=512, stop=["Question", "Assistant:", "<|separator|>"]
-        )
-
-    backend = RuntimeEndpoint(base_url)
-    sgl.set_default_backend(backend)
-
-    tic = time.perf_counter()
-    states = few_shot_gsm8k.run_batch(
-        arguments, temperature=0, num_threads=parallel, progress_bar=True
-    )
-    latency = time.perf_counter() - tic
-
-    preds = [get_answer_value(states[i]["answer"]) for i in range(len(states))]
-    acc = np.mean(np.array(preds) == np.array(labels))
-    invalid = np.mean(np.array(preds) == INVALID)
-
-    return float(acc), float(invalid), float(latency)
 
 
 class TestGrokEvalAMD(unittest.TestCase):

--- a/test/registered/amd/accuracy/mi30x/test_minimax_m25_eval_amd.py
+++ b/test/registered/amd/accuracy/mi30x/test_minimax_m25_eval_amd.py
@@ -28,6 +28,7 @@ register_amd_ci(
     nightly=True,
 )
 
+
 @dataclass
 class ModelConfig:
     """Configuration for a model to test."""

--- a/test/registered/amd/accuracy/mi30x/test_minimax_m25_eval_amd.py
+++ b/test/registered/amd/accuracy/mi30x/test_minimax_m25_eval_amd.py
@@ -6,18 +6,14 @@ benchmark on MI325/MI300X.
 Registry: nightly-amd-accuracy-8-gpu-minimax-m25 suite
 """
 
-import ast
 import os
-import re
-import time
 import unittest
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
-
-import numpy as np
+from typing import List, Optional
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.kits.gsm8k_completion_kit import run_gsm8k_benchmark
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
@@ -25,16 +21,12 @@ from sglang.test.test_utils import (
     popen_launch_server,
     write_github_step_summary,
 )
-from sglang.utils import download_and_cache_file, read_jsonl
 
 register_amd_ci(
     est_time=3600,
     suite="nightly-amd-accuracy-8-gpu-minimax-m25",
     nightly=True,
 )
-
-INVALID = -9999999
-
 
 @dataclass
 class ModelConfig:
@@ -83,81 +75,6 @@ MINIMAX_M25_MODELS = [
         env_vars={"SGLANG_USE_AITER": "1"},
     ),
 ]
-
-
-def get_one_example(lines, i, include_answer):
-    """Format a single GSM8K example."""
-    ret = "Question: " + lines[i]["question"] + "\nAnswer:"
-    if include_answer:
-        ret += " " + lines[i]["answer"]
-    return ret
-
-
-def get_few_shot_examples(lines, k):
-    """Get k few-shot examples for prompting."""
-    ret = ""
-    for i in range(k):
-        ret += get_one_example(lines, i, True) + "\n\n"
-    return ret
-
-
-def get_answer_value(answer_str):
-    """Extract numerical answer from response."""
-    answer_str = answer_str.replace(",", "")
-    numbers = re.findall(r"\d+", answer_str)
-    if len(numbers) < 1:
-        return INVALID
-    try:
-        return ast.literal_eval(numbers[-1])
-    except SyntaxError:
-        return INVALID
-
-
-def run_gsm8k_benchmark(
-    base_url: str,
-    num_questions: int = 200,
-    num_shots: int = 5,
-    parallel: int = 64,
-) -> Tuple[float, float, float]:
-    """Run GSM8K few-shot completion benchmark."""
-    import sglang as sgl
-    from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
-
-    url = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl"
-    data_path = download_and_cache_file(url)
-    lines = list(read_jsonl(data_path))
-
-    few_shot_examples = get_few_shot_examples(lines, num_shots)
-
-    questions = []
-    labels = []
-    for i in range(len(lines[:num_questions])):
-        questions.append(get_one_example(lines, i, False))
-        labels.append(get_answer_value(lines[i]["answer"]))
-    assert all(l != INVALID for l in labels)
-    arguments = [{"question": q} for q in questions]
-
-    @sgl.function
-    def few_shot_gsm8k(s, question):
-        s += few_shot_examples + question
-        s += sgl.gen(
-            "answer", max_tokens=512, stop=["Question", "Assistant:", "<|separator|>"]
-        )
-
-    backend = RuntimeEndpoint(base_url)
-    sgl.set_default_backend(backend)
-
-    tic = time.perf_counter()
-    states = few_shot_gsm8k.run_batch(
-        arguments, temperature=0, num_threads=parallel, progress_bar=True
-    )
-    latency = time.perf_counter() - tic
-
-    preds = [get_answer_value(states[i]["answer"]) for i in range(len(states))]
-    acc = np.mean(np.array(preds) == np.array(labels))
-    invalid = np.mean(np.array(preds) == INVALID)
-
-    return float(acc), float(invalid), float(latency)
 
 
 class TestMiniMaxM25EvalAMD(unittest.TestCase):

--- a/test/registered/amd/accuracy/mi35x/test_deepseek_r1_eval_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_deepseek_r1_eval_mi35x.py
@@ -6,23 +6,19 @@ benchmark on MI35x.
 Registry: nightly-amd-accuracy-8-gpu-mi35x-deepseek-r1 suite
 """
 
-import ast
 import os
 
 # Set HF cache for MI35x
 os.environ.setdefault("HF_HOME", "/data2/models/huggingface")
 os.environ.setdefault("HF_HUB_CACHE", "/data2/models/huggingface/hub")
 
-import re
-import time
 import unittest
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
-
-import numpy as np
+from typing import List, Optional
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.kits.gsm8k_completion_kit import run_gsm8k_benchmark
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
@@ -30,7 +26,6 @@ from sglang.test.test_utils import (
     popen_launch_server,
     write_github_step_summary,
 )
-from sglang.utils import download_and_cache_file, read_jsonl
 
 # Register for AMD CI - MI35x DeepSeek-R1-0528 accuracy test (~30 min for basic only)
 register_amd_ci(
@@ -38,9 +33,6 @@ register_amd_ci(
     suite="nightly-amd-accuracy-8-gpu-mi35x-deepseek-r1",
     nightly=True,
 )
-
-INVALID = -9999999
-
 
 @dataclass
 class ModelConfig:
@@ -91,81 +83,6 @@ MI35X_DEEPSEEK_R1_MODELS = [
         env_vars={"SGLANG_USE_AITER": "1"},
     ),
 ]
-
-
-def get_one_example(lines, i, include_answer):
-    """Format a single GSM8K example."""
-    ret = "Question: " + lines[i]["question"] + "\nAnswer:"
-    if include_answer:
-        ret += " " + lines[i]["answer"]
-    return ret
-
-
-def get_few_shot_examples(lines, k):
-    """Get k few-shot examples for prompting."""
-    ret = ""
-    for i in range(k):
-        ret += get_one_example(lines, i, True) + "\n\n"
-    return ret
-
-
-def get_answer_value(answer_str):
-    """Extract numerical answer from response."""
-    answer_str = answer_str.replace(",", "")
-    numbers = re.findall(r"\d+", answer_str)
-    if len(numbers) < 1:
-        return INVALID
-    try:
-        return ast.literal_eval(numbers[-1])
-    except SyntaxError:
-        return INVALID
-
-
-def run_gsm8k_benchmark(
-    base_url: str,
-    num_questions: int = 200,
-    num_shots: int = 5,
-    parallel: int = 64,
-) -> Tuple[float, float, float]:
-    """Run GSM8K few-shot completion benchmark."""
-    import sglang as sgl
-    from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
-
-    url = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl"
-    data_path = download_and_cache_file(url)
-    lines = list(read_jsonl(data_path))
-
-    few_shot_examples = get_few_shot_examples(lines, num_shots)
-
-    questions = []
-    labels = []
-    for i in range(len(lines[:num_questions])):
-        questions.append(get_one_example(lines, i, False))
-        labels.append(get_answer_value(lines[i]["answer"]))
-    assert all(l != INVALID for l in labels)
-    arguments = [{"question": q} for q in questions]
-
-    @sgl.function
-    def few_shot_gsm8k(s, question):
-        s += few_shot_examples + question
-        s += sgl.gen(
-            "answer", max_tokens=512, stop=["Question", "Assistant:", "<|separator|>"]
-        )
-
-    backend = RuntimeEndpoint(base_url)
-    sgl.set_default_backend(backend)
-
-    tic = time.perf_counter()
-    states = few_shot_gsm8k.run_batch(
-        arguments, temperature=0, num_threads=parallel, progress_bar=True
-    )
-    latency = time.perf_counter() - tic
-
-    preds = [get_answer_value(states[i]["answer"]) for i in range(len(states))]
-    acc = np.mean(np.array(preds) == np.array(labels))
-    invalid = np.mean(np.array(preds) == INVALID)
-
-    return float(acc), float(invalid), float(latency)
 
 
 class TestDeepSeekR1EvalMI35x(unittest.TestCase):

--- a/test/registered/amd/accuracy/mi35x/test_deepseek_r1_eval_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_deepseek_r1_eval_mi35x.py
@@ -34,6 +34,7 @@ register_amd_ci(
     nightly=True,
 )
 
+
 @dataclass
 class ModelConfig:
     """Configuration for a model to test."""

--- a/test/registered/amd/accuracy/mi35x/test_deepseek_r1_mxfp4_ar_fusion_eval_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_deepseek_r1_mxfp4_ar_fusion_eval_mi35x.py
@@ -6,23 +6,19 @@ using few-shot completion benchmark on MI35x.
 Registry: nightly-amd-8-gpu-mi35x-deepseek-r1-mxfp4-ar-fusion suite
 """
 
-import ast
 import os
 
 # Set HF cache for MI35x
 os.environ.setdefault("HF_HOME", "/data2/models/huggingface")
 os.environ.setdefault("HF_HUB_CACHE", "/data2/models/huggingface/hub")
 
-import re
-import time
 import unittest
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
-
-import numpy as np
+from typing import List, Optional
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.kits.gsm8k_completion_kit import run_gsm8k_benchmark
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
@@ -30,7 +26,6 @@ from sglang.test.test_utils import (
     popen_launch_server,
     write_github_step_summary,
 )
-from sglang.utils import download_and_cache_file, read_jsonl
 
 # Register for AMD CI - MI35x DeepSeek-R1-MXFP4 AllReduce Fusion accuracy test (~60 min)
 register_amd_ci(
@@ -38,8 +33,6 @@ register_amd_ci(
     suite="nightly-amd-8-gpu-mi35x-deepseek-r1-mxfp4-ar-fusion",
     nightly=True,
 )
-
-INVALID = -9999999
 
 # Model path configuration for MI35x DeepSeek-R1-MXFP4
 # Priority: 1) env var, 2) local path, 3) HuggingFace model ID
@@ -105,81 +98,6 @@ def get_mxfp4_models() -> List[ModelConfig]:
             env_vars={"SGLANG_USE_AITER": "1"},
         ),
     ]
-
-
-def get_one_example(lines, i, include_answer):
-    """Format a single GSM8K example."""
-    ret = "Question: " + lines[i]["question"] + "\nAnswer:"
-    if include_answer:
-        ret += " " + lines[i]["answer"]
-    return ret
-
-
-def get_few_shot_examples(lines, k):
-    """Get k few-shot examples for prompting."""
-    ret = ""
-    for i in range(k):
-        ret += get_one_example(lines, i, True) + "\n\n"
-    return ret
-
-
-def get_answer_value(answer_str):
-    """Extract numerical answer from response."""
-    answer_str = answer_str.replace(",", "")
-    numbers = re.findall(r"\d+", answer_str)
-    if len(numbers) < 1:
-        return INVALID
-    try:
-        return ast.literal_eval(numbers[-1])
-    except SyntaxError:
-        return INVALID
-
-
-def run_gsm8k_benchmark(
-    base_url: str,
-    num_questions: int = 200,
-    num_shots: int = 5,
-    parallel: int = 64,
-) -> Tuple[float, float, float]:
-    """Run GSM8K few-shot completion benchmark."""
-    import sglang as sgl
-    from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
-
-    url = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl"
-    data_path = download_and_cache_file(url)
-    lines = list(read_jsonl(data_path))
-
-    few_shot_examples = get_few_shot_examples(lines, num_shots)
-
-    questions = []
-    labels = []
-    for i in range(len(lines[:num_questions])):
-        questions.append(get_one_example(lines, i, False))
-        labels.append(get_answer_value(lines[i]["answer"]))
-    assert all(l != INVALID for l in labels)
-    arguments = [{"question": q} for q in questions]
-
-    @sgl.function
-    def few_shot_gsm8k(s, question):
-        s += few_shot_examples + question
-        s += sgl.gen(
-            "answer", max_tokens=512, stop=["Question", "Assistant:", "<|separator|>"]
-        )
-
-    backend = RuntimeEndpoint(base_url)
-    sgl.set_default_backend(backend)
-
-    tic = time.perf_counter()
-    states = few_shot_gsm8k.run_batch(
-        arguments, temperature=0, num_threads=parallel, progress_bar=True
-    )
-    latency = time.perf_counter() - tic
-
-    preds = [get_answer_value(states[i]["answer"]) for i in range(len(states))]
-    acc = np.mean(np.array(preds) == np.array(labels))
-    invalid = np.mean(np.array(preds) == INVALID)
-
-    return float(acc), float(invalid), float(latency)
 
 
 class TestDeepSeekR1MXFP4ArFusionEvalMI35x(unittest.TestCase):

--- a/test/registered/amd/accuracy/mi35x/test_deepseek_r1_mxfp4_eval_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_deepseek_r1_mxfp4_eval_mi35x.py
@@ -6,23 +6,19 @@ using few-shot completion benchmark on MI35x.
 Registry: nightly-amd-8-gpu-mi35x-deepseek-r1-mxfp4 suite
 """
 
-import ast
 import os
 
 # Set HF cache for MI35x
 os.environ.setdefault("HF_HOME", "/data2/models/huggingface")
 os.environ.setdefault("HF_HUB_CACHE", "/data2/models/huggingface/hub")
 
-import re
-import time
 import unittest
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
-
-import numpy as np
+from typing import List, Optional
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.kits.gsm8k_completion_kit import run_gsm8k_benchmark
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
@@ -30,14 +26,11 @@ from sglang.test.test_utils import (
     popen_launch_server,
     write_github_step_summary,
 )
-from sglang.utils import download_and_cache_file, read_jsonl
 
 # Register for AMD CI - MI35x DeepSeek-R1-MXFP4 accuracy test (~60 min, basic only)
 register_amd_ci(
     est_time=3600, suite="nightly-amd-8-gpu-mi35x-deepseek-r1-mxfp4", nightly=True
 )
-
-INVALID = -9999999
 
 # Model path configuration for MI35x DeepSeek-R1-MXFP4
 # Priority: 1) env var, 2) local path, 3) HuggingFace model ID
@@ -103,81 +96,6 @@ def get_mxfp4_models() -> List[ModelConfig]:
             env_vars={"SGLANG_USE_AITER": "1"},
         ),
     ]
-
-
-def get_one_example(lines, i, include_answer):
-    """Format a single GSM8K example."""
-    ret = "Question: " + lines[i]["question"] + "\nAnswer:"
-    if include_answer:
-        ret += " " + lines[i]["answer"]
-    return ret
-
-
-def get_few_shot_examples(lines, k):
-    """Get k few-shot examples for prompting."""
-    ret = ""
-    for i in range(k):
-        ret += get_one_example(lines, i, True) + "\n\n"
-    return ret
-
-
-def get_answer_value(answer_str):
-    """Extract numerical answer from response."""
-    answer_str = answer_str.replace(",", "")
-    numbers = re.findall(r"\d+", answer_str)
-    if len(numbers) < 1:
-        return INVALID
-    try:
-        return ast.literal_eval(numbers[-1])
-    except SyntaxError:
-        return INVALID
-
-
-def run_gsm8k_benchmark(
-    base_url: str,
-    num_questions: int = 200,
-    num_shots: int = 5,
-    parallel: int = 64,
-) -> Tuple[float, float, float]:
-    """Run GSM8K few-shot completion benchmark."""
-    import sglang as sgl
-    from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
-
-    url = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl"
-    data_path = download_and_cache_file(url)
-    lines = list(read_jsonl(data_path))
-
-    few_shot_examples = get_few_shot_examples(lines, num_shots)
-
-    questions = []
-    labels = []
-    for i in range(len(lines[:num_questions])):
-        questions.append(get_one_example(lines, i, False))
-        labels.append(get_answer_value(lines[i]["answer"]))
-    assert all(l != INVALID for l in labels)
-    arguments = [{"question": q} for q in questions]
-
-    @sgl.function
-    def few_shot_gsm8k(s, question):
-        s += few_shot_examples + question
-        s += sgl.gen(
-            "answer", max_tokens=512, stop=["Question", "Assistant:", "<|separator|>"]
-        )
-
-    backend = RuntimeEndpoint(base_url)
-    sgl.set_default_backend(backend)
-
-    tic = time.perf_counter()
-    states = few_shot_gsm8k.run_batch(
-        arguments, temperature=0, num_threads=parallel, progress_bar=True
-    )
-    latency = time.perf_counter() - tic
-
-    preds = [get_answer_value(states[i]["answer"]) for i in range(len(states))]
-    acc = np.mean(np.array(preds) == np.array(labels))
-    invalid = np.mean(np.array(preds) == INVALID)
-
-    return float(acc), float(invalid), float(latency)
 
 
 class TestDeepSeekR1MXFP4EvalMI35x(unittest.TestCase):

--- a/test/registered/amd/accuracy/mi35x/test_deepseek_r1_mxfp4_kv_fp8_eval_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_deepseek_r1_mxfp4_kv_fp8_eval_mi35x.py
@@ -6,23 +6,19 @@ using few-shot completion benchmark on MI35x.
 Registry: nightly-amd-8-gpu-mi35x-deepseek-r1-mxfp4-kv-fp8 suite
 """
 
-import ast
 import os
 
 # Set HF cache for MI35x
 os.environ.setdefault("HF_HOME", "/data2/models/huggingface")
 os.environ.setdefault("HF_HUB_CACHE", "/data2/models/huggingface/hub")
 
-import re
-import time
 import unittest
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
-
-import numpy as np
+from typing import List, Optional
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.kits.gsm8k_completion_kit import run_gsm8k_benchmark
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
@@ -30,7 +26,6 @@ from sglang.test.test_utils import (
     popen_launch_server,
     write_github_step_summary,
 )
-from sglang.utils import download_and_cache_file, read_jsonl
 
 # Register for AMD CI - MI35x DeepSeek-R1-MXFP4 KV FP8 accuracy test (~60 min)
 register_amd_ci(
@@ -38,8 +33,6 @@ register_amd_ci(
     suite="nightly-amd-8-gpu-mi35x-deepseek-r1-mxfp4-kv-fp8",
     nightly=True,
 )
-
-INVALID = -9999999
 
 # Model path configuration for MI35x DeepSeek-R1-MXFP4
 # Priority: 1) env var, 2) local path, 3) HuggingFace model ID
@@ -106,81 +99,6 @@ def get_mxfp4_models() -> List[ModelConfig]:
             env_vars={"SGLANG_USE_AITER": "1"},
         ),
     ]
-
-
-def get_one_example(lines, i, include_answer):
-    """Format a single GSM8K example."""
-    ret = "Question: " + lines[i]["question"] + "\nAnswer:"
-    if include_answer:
-        ret += " " + lines[i]["answer"]
-    return ret
-
-
-def get_few_shot_examples(lines, k):
-    """Get k few-shot examples for prompting."""
-    ret = ""
-    for i in range(k):
-        ret += get_one_example(lines, i, True) + "\n\n"
-    return ret
-
-
-def get_answer_value(answer_str):
-    """Extract numerical answer from response."""
-    answer_str = answer_str.replace(",", "")
-    numbers = re.findall(r"\d+", answer_str)
-    if len(numbers) < 1:
-        return INVALID
-    try:
-        return ast.literal_eval(numbers[-1])
-    except SyntaxError:
-        return INVALID
-
-
-def run_gsm8k_benchmark(
-    base_url: str,
-    num_questions: int = 200,
-    num_shots: int = 5,
-    parallel: int = 64,
-) -> Tuple[float, float, float]:
-    """Run GSM8K few-shot completion benchmark."""
-    import sglang as sgl
-    from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
-
-    url = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl"
-    data_path = download_and_cache_file(url)
-    lines = list(read_jsonl(data_path))
-
-    few_shot_examples = get_few_shot_examples(lines, num_shots)
-
-    questions = []
-    labels = []
-    for i in range(len(lines[:num_questions])):
-        questions.append(get_one_example(lines, i, False))
-        labels.append(get_answer_value(lines[i]["answer"]))
-    assert all(l != INVALID for l in labels)
-    arguments = [{"question": q} for q in questions]
-
-    @sgl.function
-    def few_shot_gsm8k(s, question):
-        s += few_shot_examples + question
-        s += sgl.gen(
-            "answer", max_tokens=512, stop=["Question", "Assistant:", "<|separator|>"]
-        )
-
-    backend = RuntimeEndpoint(base_url)
-    sgl.set_default_backend(backend)
-
-    tic = time.perf_counter()
-    states = few_shot_gsm8k.run_batch(
-        arguments, temperature=0, num_threads=parallel, progress_bar=True
-    )
-    latency = time.perf_counter() - tic
-
-    preds = [get_answer_value(states[i]["answer"]) for i in range(len(states))]
-    acc = np.mean(np.array(preds) == np.array(labels))
-    invalid = np.mean(np.array(preds) == INVALID)
-
-    return float(acc), float(invalid), float(latency)
 
 
 class TestDeepSeekR1MXFP4KvFp8EvalMI35x(unittest.TestCase):

--- a/test/registered/amd/accuracy/mi35x/test_deepseek_v32_eval_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_deepseek_v32_eval_mi35x.py
@@ -6,23 +6,19 @@ benchmark on MI35x.
 Registry: nightly-amd-accuracy-8-gpu-mi35x-deepseek-v32 suite
 """
 
-import ast
 import os
 
 # Set HF cache for MI35x
 os.environ.setdefault("HF_HOME", "/data2/models/huggingface")
 os.environ.setdefault("HF_HUB_CACHE", "/data2/models/huggingface/hub")
 
-import re
-import time
 import unittest
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
-
-import numpy as np
+from typing import List, Optional
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.kits.gsm8k_completion_kit import run_gsm8k_benchmark
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
@@ -30,7 +26,6 @@ from sglang.test.test_utils import (
     popen_launch_server,
     write_github_step_summary,
 )
-from sglang.utils import download_and_cache_file, read_jsonl
 
 # Register for AMD CI - MI35x DeepSeek-V3.2 accuracy test (~90 min for basic only)
 register_amd_ci(
@@ -38,9 +33,6 @@ register_amd_ci(
     suite="nightly-amd-8-gpu-mi35x-deepseek-v32",
     nightly=True,
 )
-
-INVALID = -9999999
-
 
 @dataclass
 class ModelConfig:
@@ -92,81 +84,6 @@ MI35X_DEEPSEEK_V32_MODELS = [
         env_vars={},
     ),
 ]
-
-
-def get_one_example(lines, i, include_answer):
-    """Format a single GSM8K example."""
-    ret = "Question: " + lines[i]["question"] + "\nAnswer:"
-    if include_answer:
-        ret += " " + lines[i]["answer"]
-    return ret
-
-
-def get_few_shot_examples(lines, k):
-    """Get k few-shot examples for prompting."""
-    ret = ""
-    for i in range(k):
-        ret += get_one_example(lines, i, True) + "\n\n"
-    return ret
-
-
-def get_answer_value(answer_str):
-    """Extract numerical answer from response."""
-    answer_str = answer_str.replace(",", "")
-    numbers = re.findall(r"\d+", answer_str)
-    if len(numbers) < 1:
-        return INVALID
-    try:
-        return ast.literal_eval(numbers[-1])
-    except SyntaxError:
-        return INVALID
-
-
-def run_gsm8k_benchmark(
-    base_url: str,
-    num_questions: int = 200,
-    num_shots: int = 5,
-    parallel: int = 64,
-) -> Tuple[float, float, float]:
-    """Run GSM8K few-shot completion benchmark."""
-    import sglang as sgl
-    from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
-
-    url = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl"
-    data_path = download_and_cache_file(url)
-    lines = list(read_jsonl(data_path))
-
-    few_shot_examples = get_few_shot_examples(lines, num_shots)
-
-    questions = []
-    labels = []
-    for i in range(len(lines[:num_questions])):
-        questions.append(get_one_example(lines, i, False))
-        labels.append(get_answer_value(lines[i]["answer"]))
-    assert all(l != INVALID for l in labels)
-    arguments = [{"question": q} for q in questions]
-
-    @sgl.function
-    def few_shot_gsm8k(s, question):
-        s += few_shot_examples + question
-        s += sgl.gen(
-            "answer", max_tokens=512, stop=["Question", "Assistant:", "<|separator|>"]
-        )
-
-    backend = RuntimeEndpoint(base_url)
-    sgl.set_default_backend(backend)
-
-    tic = time.perf_counter()
-    states = few_shot_gsm8k.run_batch(
-        arguments, temperature=0, num_threads=parallel, progress_bar=True
-    )
-    latency = time.perf_counter() - tic
-
-    preds = [get_answer_value(states[i]["answer"]) for i in range(len(states))]
-    acc = np.mean(np.array(preds) == np.array(labels))
-    invalid = np.mean(np.array(preds) == INVALID)
-
-    return float(acc), float(invalid), float(latency)
 
 
 class TestDeepSeekV32EvalMI35x(unittest.TestCase):

--- a/test/registered/amd/accuracy/mi35x/test_deepseek_v32_eval_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_deepseek_v32_eval_mi35x.py
@@ -34,6 +34,7 @@ register_amd_ci(
     nightly=True,
 )
 
+
 @dataclass
 class ModelConfig:
     """Configuration for a model to test."""

--- a/test/registered/amd/accuracy/mi35x/test_glm5_eval_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_glm5_eval_mi35x.py
@@ -6,23 +6,19 @@ benchmark on MI35x.
 Registry: nightly-amd-8-gpu-mi35x-glm5 suite
 """
 
-import ast
 import os
 
 # Set HF cache for MI35x
 os.environ.setdefault("HF_HOME", "/data2/models/huggingface")
 os.environ.setdefault("HF_HUB_CACHE", "/data2/models/huggingface/hub")
 
-import re
-import time
 import unittest
 from dataclasses import dataclass, field
-from typing import List, Optional, Tuple
-
-import numpy as np
+from typing import List, Optional
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.kits.gsm8k_completion_kit import run_gsm8k_benchmark
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
@@ -30,7 +26,6 @@ from sglang.test.test_utils import (
     popen_launch_server,
     write_github_step_summary,
 )
-from sglang.utils import download_and_cache_file, read_jsonl
 
 # Register for AMD CI - MI35x GLM-5 accuracy test (~90 min)
 register_amd_ci(
@@ -38,9 +33,6 @@ register_amd_ci(
     suite="nightly-amd-8-gpu-mi35x-glm5",
     nightly=True,
 )
-
-INVALID = -9999999
-
 
 @dataclass
 class ModelConfig:
@@ -87,81 +79,6 @@ MI35X_GLM5_MODELS = [
         env_vars={},
     ),
 ]
-
-
-def get_one_example(lines, i, include_answer):
-    """Format a single GSM8K example."""
-    ret = "Question: " + lines[i]["question"] + "\nAnswer:"
-    if include_answer:
-        ret += " " + lines[i]["answer"]
-    return ret
-
-
-def get_few_shot_examples(lines, k):
-    """Get k few-shot examples for prompting."""
-    ret = ""
-    for i in range(k):
-        ret += get_one_example(lines, i, True) + "\n\n"
-    return ret
-
-
-def get_answer_value(answer_str):
-    """Extract numerical answer from response."""
-    answer_str = answer_str.replace(",", "")
-    numbers = re.findall(r"\d+", answer_str)
-    if len(numbers) < 1:
-        return INVALID
-    try:
-        return ast.literal_eval(numbers[-1])
-    except SyntaxError:
-        return INVALID
-
-
-def run_gsm8k_benchmark(
-    base_url: str,
-    num_questions: int = 200,
-    num_shots: int = 5,
-    parallel: int = 64,
-) -> Tuple[float, float, float]:
-    """Run GSM8K few-shot completion benchmark."""
-    import sglang as sgl
-    from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
-
-    url = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl"
-    data_path = download_and_cache_file(url)
-    lines = list(read_jsonl(data_path))
-
-    few_shot_examples = get_few_shot_examples(lines, num_shots)
-
-    questions = []
-    labels = []
-    for i in range(len(lines[:num_questions])):
-        questions.append(get_one_example(lines, i, False))
-        labels.append(get_answer_value(lines[i]["answer"]))
-    assert all(l != INVALID for l in labels)
-    arguments = [{"question": q} for q in questions]
-
-    @sgl.function
-    def few_shot_gsm8k(s, question):
-        s += few_shot_examples + question
-        s += sgl.gen(
-            "answer", max_tokens=512, stop=["Question", "Assistant:", "<|separator|>"]
-        )
-
-    backend = RuntimeEndpoint(base_url)
-    sgl.set_default_backend(backend)
-
-    tic = time.perf_counter()
-    states = few_shot_gsm8k.run_batch(
-        arguments, temperature=0, num_threads=parallel, progress_bar=True
-    )
-    latency = time.perf_counter() - tic
-
-    preds = [get_answer_value(states[i]["answer"]) for i in range(len(states))]
-    acc = np.mean(np.array(preds) == np.array(labels))
-    invalid = np.mean(np.array(preds) == INVALID)
-
-    return float(acc), float(invalid), float(latency)
 
 
 class TestGLM5EvalMI35x(unittest.TestCase):

--- a/test/registered/amd/accuracy/mi35x/test_glm5_eval_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_glm5_eval_mi35x.py
@@ -34,6 +34,7 @@ register_amd_ci(
     nightly=True,
 )
 
+
 @dataclass
 class ModelConfig:
     """Configuration for a model to test."""

--- a/test/registered/amd/accuracy/mi35x/test_gpt_oss_eval_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_gpt_oss_eval_mi35x.py
@@ -8,23 +8,19 @@ Note: MI35x uses openai/* paths, not lmsys/* paths like MI300X.
 Registry: nightly-amd-8-gpu-mi35x suite
 """
 
-import ast
 import os
 
 # Set HF cache for MI35x
 os.environ.setdefault("HF_HOME", "/data2/models/huggingface")
 os.environ.setdefault("HF_HUB_CACHE", "/data2/models/huggingface/hub")
 
-import re
-import time
 import unittest
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
-
-import numpy as np
+from typing import List, Optional
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.kits.gsm8k_completion_kit import run_gsm8k_benchmark
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
@@ -32,13 +28,9 @@ from sglang.test.test_utils import (
     popen_launch_server,
     write_github_step_summary,
 )
-from sglang.utils import download_and_cache_file, read_jsonl
 
 # Register for AMD CI - MI35x GPT-OSS accuracy tests (~30 min)
 register_amd_ci(est_time=1800, suite="nightly-amd-8-gpu-mi35x", nightly=True)
-
-INVALID = -9999999
-
 
 @dataclass
 class ModelConfig:
@@ -96,81 +88,6 @@ MI35X_GPT_OSS_MODELS = [
         env_vars={"SGLANG_USE_AITER": "1"},
     ),
 ]
-
-
-def get_one_example(lines, i, include_answer):
-    """Format a single GSM8K example."""
-    ret = "Question: " + lines[i]["question"] + "\nAnswer:"
-    if include_answer:
-        ret += " " + lines[i]["answer"]
-    return ret
-
-
-def get_few_shot_examples(lines, k):
-    """Get k few-shot examples for prompting."""
-    ret = ""
-    for i in range(k):
-        ret += get_one_example(lines, i, True) + "\n\n"
-    return ret
-
-
-def get_answer_value(answer_str):
-    """Extract numerical answer from response."""
-    answer_str = answer_str.replace(",", "")
-    numbers = re.findall(r"\d+", answer_str)
-    if len(numbers) < 1:
-        return INVALID
-    try:
-        return ast.literal_eval(numbers[-1])
-    except SyntaxError:
-        return INVALID
-
-
-def run_gsm8k_benchmark(
-    base_url: str,
-    num_questions: int = 200,
-    num_shots: int = 5,
-    parallel: int = 64,
-) -> Tuple[float, float, float]:
-    """Run GSM8K few-shot completion benchmark."""
-    import sglang as sgl
-    from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
-
-    url = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl"
-    data_path = download_and_cache_file(url)
-    lines = list(read_jsonl(data_path))
-
-    few_shot_examples = get_few_shot_examples(lines, num_shots)
-
-    questions = []
-    labels = []
-    for i in range(len(lines[:num_questions])):
-        questions.append(get_one_example(lines, i, False))
-        labels.append(get_answer_value(lines[i]["answer"]))
-    assert all(l != INVALID for l in labels)
-    arguments = [{"question": q} for q in questions]
-
-    @sgl.function
-    def few_shot_gsm8k(s, question):
-        s += few_shot_examples + question
-        s += sgl.gen(
-            "answer", max_tokens=512, stop=["Question", "Assistant:", "<|separator|>"]
-        )
-
-    backend = RuntimeEndpoint(base_url)
-    sgl.set_default_backend(backend)
-
-    tic = time.perf_counter()
-    states = few_shot_gsm8k.run_batch(
-        arguments, temperature=0, num_threads=parallel, progress_bar=True
-    )
-    latency = time.perf_counter() - tic
-
-    preds = [get_answer_value(states[i]["answer"]) for i in range(len(states))]
-    acc = np.mean(np.array(preds) == np.array(labels))
-    invalid = np.mean(np.array(preds) == INVALID)
-
-    return float(acc), float(invalid), float(latency)
 
 
 class TestGptOssEvalMI35x(unittest.TestCase):

--- a/test/registered/amd/accuracy/mi35x/test_gpt_oss_eval_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_gpt_oss_eval_mi35x.py
@@ -32,6 +32,7 @@ from sglang.test.test_utils import (
 # Register for AMD CI - MI35x GPT-OSS accuracy tests (~30 min)
 register_amd_ci(est_time=1800, suite="nightly-amd-8-gpu-mi35x", nightly=True)
 
+
 @dataclass
 class ModelConfig:
     """Configuration for a model to test."""

--- a/test/registered/amd/accuracy/mi35x/test_grok1_int4_eval_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_grok1_int4_eval_mi35x.py
@@ -5,95 +5,26 @@ Tests Grok-1 INT4 (W4A8KV8) model using few-shot completion benchmark on MI35x.
 Registry: nightly-amd-accuracy-8-gpu-mi35x-grok1-int4 suite
 """
 
-import ast
 import os
-import re
-import time
 import unittest
-
-import numpy as np
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.kits.gsm8k_completion_kit import run_gsm8k_benchmark
 from sglang.test.test_utils import (
     DEFAULT_URL_FOR_TEST,
     is_in_ci,
     popen_launch_server,
     write_github_step_summary,
 )
-from sglang.utils import download_and_cache_file, read_jsonl
 
 # Register for AMD CI - GROK1-INT4 accuracy tests on MI35x (~70 min)
 register_amd_ci(
     est_time=4200, suite="nightly-amd-accuracy-8-gpu-mi35x-grok1-int4", nightly=True
 )
 
-INVALID = -9999999
-
 GROK1_INT4_MODEL_PATH = os.environ.get("GROK1_INT4_MODEL_PATH", "amd/grok-1-W4A8KV8")
 GROK1_TOKENIZER_PATH = os.environ.get("GROK1_TOKENIZER_PATH", "Xenova/grok-1-tokenizer")
-
-
-def get_one_example(lines, i, include_answer):
-    ret = "Question: " + lines[i]["question"] + "\nAnswer:"
-    if include_answer:
-        ret += " " + lines[i]["answer"]
-    return ret
-
-
-def get_few_shot_examples(lines, k):
-    ret = ""
-    for i in range(k):
-        ret += get_one_example(lines, i, True) + "\n\n"
-    return ret
-
-
-def get_answer_value(answer_str):
-    answer_str = answer_str.replace(",", "")
-    numbers = re.findall(r"\d+", answer_str)
-    if len(numbers) < 1:
-        return INVALID
-    try:
-        return ast.literal_eval(numbers[-1])
-    except SyntaxError:
-        return INVALID
-
-
-def run_gsm8k_benchmark(base_url, num_questions=200, num_shots=5, parallel=64):
-    import sglang as sgl
-    from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
-
-    url = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl"
-    data_path = download_and_cache_file(url)
-    lines = list(read_jsonl(data_path))
-
-    few_shot_examples = get_few_shot_examples(lines, num_shots)
-    questions = []
-    labels = []
-    for i in range(len(lines[:num_questions])):
-        questions.append(get_one_example(lines, i, False))
-        labels.append(get_answer_value(lines[i]["answer"]))
-    arguments = [{"question": q} for q in questions]
-
-    @sgl.function
-    def few_shot_gsm8k(s, question):
-        s += few_shot_examples + question
-        s += sgl.gen(
-            "answer", max_tokens=512, stop=["Question", "Assistant:", "<|separator|>"]
-        )
-
-    backend = RuntimeEndpoint(base_url)
-    sgl.set_default_backend(backend)
-
-    tic = time.perf_counter()
-    states = few_shot_gsm8k.run_batch(
-        arguments, temperature=0, num_threads=parallel, progress_bar=True
-    )
-    latency = time.perf_counter() - tic
-
-    preds = [get_answer_value(states[i]["answer"]) for i in range(len(states))]
-    acc = np.mean(np.array(preds) == np.array(labels))
-    return float(acc), float(latency)
 
 
 class TestGrok1INT4EvalMI35x(unittest.TestCase):
@@ -135,7 +66,7 @@ class TestGrok1INT4EvalMI35x(unittest.TestCase):
         )
 
         try:
-            acc, latency = run_gsm8k_benchmark(
+            acc, _invalid, latency = run_gsm8k_benchmark(
                 self.base_url, num_questions=self.num_questions
             )
             passed = acc >= self.accuracy_threshold

--- a/test/registered/amd/accuracy/mi35x/test_grok2_eval_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_grok2_eval_mi35x.py
@@ -5,97 +5,28 @@ Tests Grok-2 model using few-shot completion benchmark on MI35x.
 Registry: nightly-amd-accuracy-8-gpu-mi35x-grok2 suite
 """
 
-import ast
 import os
-import re
-import time
 import unittest
-
-import numpy as np
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.kits.gsm8k_completion_kit import run_gsm8k_benchmark
 from sglang.test.test_utils import (
     DEFAULT_URL_FOR_TEST,
     is_in_ci,
     popen_launch_server,
     write_github_step_summary,
 )
-from sglang.utils import download_and_cache_file, read_jsonl
 
 # Register for AMD CI - GROK2 accuracy tests on MI35x (~25 min)
 register_amd_ci(
     est_time=1500, suite="nightly-amd-accuracy-8-gpu-mi35x-grok2", nightly=True
 )
 
-INVALID = -9999999
-
 GROK2_MODEL_PATH = os.environ.get("GROK2_MODEL_PATH", "xai-org/grok-2")
 GROK2_TOKENIZER_PATH = os.environ.get(
     "GROK2_TOKENIZER_PATH", "alvarobartt/grok-2-tokenizer"
 )
-
-
-def get_one_example(lines, i, include_answer):
-    ret = "Question: " + lines[i]["question"] + "\nAnswer:"
-    if include_answer:
-        ret += " " + lines[i]["answer"]
-    return ret
-
-
-def get_few_shot_examples(lines, k):
-    ret = ""
-    for i in range(k):
-        ret += get_one_example(lines, i, True) + "\n\n"
-    return ret
-
-
-def get_answer_value(answer_str):
-    answer_str = answer_str.replace(",", "")
-    numbers = re.findall(r"\d+", answer_str)
-    if len(numbers) < 1:
-        return INVALID
-    try:
-        return ast.literal_eval(numbers[-1])
-    except SyntaxError:
-        return INVALID
-
-
-def run_gsm8k_benchmark(base_url, num_questions=200, num_shots=5, parallel=64):
-    import sglang as sgl
-    from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
-
-    url = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl"
-    data_path = download_and_cache_file(url)
-    lines = list(read_jsonl(data_path))
-
-    few_shot_examples = get_few_shot_examples(lines, num_shots)
-    questions = []
-    labels = []
-    for i in range(len(lines[:num_questions])):
-        questions.append(get_one_example(lines, i, False))
-        labels.append(get_answer_value(lines[i]["answer"]))
-    arguments = [{"question": q} for q in questions]
-
-    @sgl.function
-    def few_shot_gsm8k(s, question):
-        s += few_shot_examples + question
-        s += sgl.gen(
-            "answer", max_tokens=512, stop=["Question", "Assistant:", "<|separator|>"]
-        )
-
-    backend = RuntimeEndpoint(base_url)
-    sgl.set_default_backend(backend)
-
-    tic = time.perf_counter()
-    states = few_shot_gsm8k.run_batch(
-        arguments, temperature=0, num_threads=parallel, progress_bar=True
-    )
-    latency = time.perf_counter() - tic
-
-    preds = [get_answer_value(states[i]["answer"]) for i in range(len(states))]
-    acc = np.mean(np.array(preds) == np.array(labels))
-    return float(acc), float(latency)
 
 
 class TestGrok2EvalMI35x(unittest.TestCase):
@@ -137,7 +68,7 @@ class TestGrok2EvalMI35x(unittest.TestCase):
         )
 
         try:
-            acc, latency = run_gsm8k_benchmark(
+            acc, _invalid, latency = run_gsm8k_benchmark(
                 self.base_url, num_questions=self.num_questions
             )
             passed = acc >= self.accuracy_threshold

--- a/test/registered/amd/accuracy/mi35x/test_minimax_m25_eval_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_minimax_m25_eval_mi35x.py
@@ -6,22 +6,18 @@ benchmark on MI35x.
 Registry: nightly-amd-8-gpu-mi35x-minimax-m25 suite
 """
 
-import ast
 import os
 
 os.environ.setdefault("HF_HOME", "/data2/models/huggingface")
 os.environ.setdefault("HF_HUB_CACHE", "/data2/models/huggingface/hub")
 
-import re
-import time
 import unittest
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
-
-import numpy as np
+from typing import List, Optional
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.kits.gsm8k_completion_kit import run_gsm8k_benchmark
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
@@ -29,16 +25,12 @@ from sglang.test.test_utils import (
     popen_launch_server,
     write_github_step_summary,
 )
-from sglang.utils import download_and_cache_file, read_jsonl
 
 register_amd_ci(
     est_time=5400,
     suite="nightly-amd-8-gpu-mi35x-minimax-m25",
     nightly=True,
 )
-
-INVALID = -9999999
-
 
 @dataclass
 class ModelConfig:
@@ -87,81 +79,6 @@ MI35X_MINIMAX_M25_MODELS = [
         env_vars={"SGLANG_USE_AITER": "1"},
     ),
 ]
-
-
-def get_one_example(lines, i, include_answer):
-    """Format a single GSM8K example."""
-    ret = "Question: " + lines[i]["question"] + "\nAnswer:"
-    if include_answer:
-        ret += " " + lines[i]["answer"]
-    return ret
-
-
-def get_few_shot_examples(lines, k):
-    """Get k few-shot examples for prompting."""
-    ret = ""
-    for i in range(k):
-        ret += get_one_example(lines, i, True) + "\n\n"
-    return ret
-
-
-def get_answer_value(answer_str):
-    """Extract numerical answer from response."""
-    answer_str = answer_str.replace(",", "")
-    numbers = re.findall(r"\d+", answer_str)
-    if len(numbers) < 1:
-        return INVALID
-    try:
-        return ast.literal_eval(numbers[-1])
-    except SyntaxError:
-        return INVALID
-
-
-def run_gsm8k_benchmark(
-    base_url: str,
-    num_questions: int = 200,
-    num_shots: int = 5,
-    parallel: int = 64,
-) -> Tuple[float, float, float]:
-    """Run GSM8K few-shot completion benchmark."""
-    import sglang as sgl
-    from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
-
-    url = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl"
-    data_path = download_and_cache_file(url)
-    lines = list(read_jsonl(data_path))
-
-    few_shot_examples = get_few_shot_examples(lines, num_shots)
-
-    questions = []
-    labels = []
-    for i in range(len(lines[:num_questions])):
-        questions.append(get_one_example(lines, i, False))
-        labels.append(get_answer_value(lines[i]["answer"]))
-    assert all(l != INVALID for l in labels)
-    arguments = [{"question": q} for q in questions]
-
-    @sgl.function
-    def few_shot_gsm8k(s, question):
-        s += few_shot_examples + question
-        s += sgl.gen(
-            "answer", max_tokens=512, stop=["Question", "Assistant:", "<|separator|>"]
-        )
-
-    backend = RuntimeEndpoint(base_url)
-    sgl.set_default_backend(backend)
-
-    tic = time.perf_counter()
-    states = few_shot_gsm8k.run_batch(
-        arguments, temperature=0, num_threads=parallel, progress_bar=True
-    )
-    latency = time.perf_counter() - tic
-
-    preds = [get_answer_value(states[i]["answer"]) for i in range(len(states))]
-    acc = np.mean(np.array(preds) == np.array(labels))
-    invalid = np.mean(np.array(preds) == INVALID)
-
-    return float(acc), float(invalid), float(latency)
 
 
 class TestMiniMaxM25EvalMI35x(unittest.TestCase):

--- a/test/registered/amd/accuracy/mi35x/test_minimax_m25_eval_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_minimax_m25_eval_mi35x.py
@@ -32,6 +32,7 @@ register_amd_ci(
     nightly=True,
 )
 
+
 @dataclass
 class ModelConfig:
     """Configuration for a model to test."""

--- a/test/registered/amd/accuracy/mi35x/test_qwen3_coder_next_eval_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_qwen3_coder_next_eval_mi35x.py
@@ -6,23 +6,19 @@ using few-shot completion benchmark on MI35x.
 Registry: nightly-amd-8-gpu-mi35x-qwen3-coder-next suite
 """
 
-import ast
 import os
 
 # Set HF cache for MI35x
 os.environ.setdefault("HF_HOME", "/data2/models/huggingface")
 os.environ.setdefault("HF_HUB_CACHE", "/data2/models/huggingface/hub")
 
-import re
-import time
 import unittest
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
-
-import numpy as np
+from typing import List, Optional
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.kits.gsm8k_completion_kit import run_gsm8k_benchmark
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
@@ -30,12 +26,9 @@ from sglang.test.test_utils import (
     popen_launch_server,
     write_github_step_summary,
 )
-from sglang.utils import download_and_cache_file, read_jsonl
 
 # Register for AMD CI - MI35x Qwen3-Coder-Next accuracy test
 register_amd_ci(est_time=3600, suite="nightly-amd-8-gpu-mi35x", nightly=True)
-
-INVALID = -9999999
 
 # Model path configuration for MI35x Qwen3-Coder-Next
 # Priority: 1) env var, 2) local path
@@ -127,81 +120,6 @@ def get_qwen3_coder_next_models() -> List[ModelConfig]:
             ],
         ),
     ]
-
-
-def get_one_example(lines, i, include_answer):
-    """Format a single GSM8K example."""
-    ret = "Question: " + lines[i]["question"] + "\nAnswer:"
-    if include_answer:
-        ret += " " + lines[i]["answer"]
-    return ret
-
-
-def get_few_shot_examples(lines, k):
-    """Get k few-shot examples for prompting."""
-    ret = ""
-    for i in range(k):
-        ret += get_one_example(lines, i, True) + "\n\n"
-    return ret
-
-
-def get_answer_value(answer_str):
-    """Extract numerical answer from response."""
-    answer_str = answer_str.replace(",", "")
-    numbers = re.findall(r"\d+", answer_str)
-    if len(numbers) < 1:
-        return INVALID
-    try:
-        return ast.literal_eval(numbers[-1])
-    except SyntaxError:
-        return INVALID
-
-
-def run_gsm8k_benchmark(
-    base_url: str,
-    num_questions: int = 200,
-    num_shots: int = 5,
-    parallel: int = 64,
-) -> Tuple[float, float, float]:
-    """Run GSM8K few-shot completion benchmark."""
-    import sglang as sgl
-    from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
-
-    url = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl"
-    data_path = download_and_cache_file(url)
-    lines = list(read_jsonl(data_path))
-
-    few_shot_examples = get_few_shot_examples(lines, num_shots)
-
-    questions = []
-    labels = []
-    for i in range(len(lines[:num_questions])):
-        questions.append(get_one_example(lines, i, False))
-        labels.append(get_answer_value(lines[i]["answer"]))
-    assert all(l != INVALID for l in labels)
-    arguments = [{"question": q} for q in questions]
-
-    @sgl.function
-    def few_shot_gsm8k(s, question):
-        s += few_shot_examples + question
-        s += sgl.gen(
-            "answer", max_tokens=512, stop=["Question", "Assistant:", "<|separator|>"]
-        )
-
-    backend = RuntimeEndpoint(base_url)
-    sgl.set_default_backend(backend)
-
-    tic = time.perf_counter()
-    states = few_shot_gsm8k.run_batch(
-        arguments, temperature=0, num_threads=parallel, progress_bar=True
-    )
-    latency = time.perf_counter() - tic
-
-    preds = [get_answer_value(states[i]["answer"]) for i in range(len(states))]
-    acc = np.mean(np.array(preds) == np.array(labels))
-    invalid = np.mean(np.array(preds) == INVALID)
-
-    return float(acc), float(invalid), float(latency)
 
 
 class TestQwen3CoderNextEvalMI35x(unittest.TestCase):


### PR DESCRIPTION
## Summary

Resolves #21049 (part of #21046)

Extracts 4 copy-pasted functions (`get_one_example`, `get_few_shot_examples`, `get_answer_value`, `run_gsm8k_benchmark`) from 21 AMD accuracy test files into a shared kit at `python/sglang/test/kits/gsm8k_completion_kit.py`.

### Changes
- **New file**: `python/sglang/test/kits/gsm8k_completion_kit.py` (99 lines)
  - Re-exports `INVALID`, `get_one_example`, `get_few_shot_examples`, `get_answer_value` from `sglang.test.few_shot_gsm8k`
  - Provides canonical `run_gsm8k_benchmark` with unified 3-tuple return `(accuracy, invalid_rate, latency)`
- **Updated 21 test files** (10 mi30x + 11 mi35x): replaced local definitions with imports from the kit
- **2-tuple → 3-tuple migration**: 6 files that used `acc, latency =` updated to `acc, _invalid, latency =`
- **Unused imports cleaned up**: removed stale `ast`, `re`, `time`, `numpy`, `download_and_cache_file`, `read_jsonl`, etc.

### Stats
- **Net: -1,556 lines** (+141 / -1,697)
- Pure refactor — no behavior change
- Note: the 6 two-tuple files now also get the `assert all(label != INVALID ...)` validation from the canonical kit (safe — official GSM8K answers are always valid integers)

### Verification
```
ruff check python/sglang/test/kits/gsm8k_completion_kit.py  # Clean
ruff check --select F401 test/registered/amd/accuracy/       # No unused imports
grep -r "def run_gsm8k_benchmark" test/registered/amd/       # Zero local definitions remain
```
34 pre-existing F541 warnings in the test files are unchanged.