### PR TITLE
[CI] [FlashInfer v0.6.7] Use offline quantized checkpoint for MXFP8 Gemm tests

### DIFF
--- a/test/registered/quant/test_fp8_blockwise_gemm.py
+++ b/test/registered/quant/test_fp8_blockwise_gemm.py
@@ -120,9 +120,6 @@ class TestFP8BlockwiseGemmFlashinferDeepGemm(FP8BlockwiseGemmBase, unittest.Test
     backend = "flashinfer_deepgemm"
 
 
-@unittest.skip(
-    "Temporarily disabled until https://github.com/sgl-project/sglang/pull/19835 is merged"
-)
 @unittest.skipIf(get_device_sm() < 100, "Test requires CUDA SM 100 or higher")
 class TestMXFP8GemmTriton(MXFP8GemmBase, unittest.TestCase):
     backend = "triton"

--- a/test/registered/quant/test_fp8_blockwise_gemm.py
+++ b/test/registered/quant/test_fp8_blockwise_gemm.py
@@ -15,7 +15,7 @@ from sglang.test.test_utils import (
 register_cuda_ci(est_time=420, suite="stage-c-test-4-gpu-b200")
 
 MODEL_PATH = "Qwen/Qwen3-4B-Instruct-2507-FP8"
-BF16_MODEL_PATH = "Qwen/Qwen3-4B-Instruct-2507"
+MXFP8_MODEL_PATH = "zianglih/Qwen3-4B-Instruct-2507-MXFP8"
 
 
 class FP8BlockwiseGemmBase:
@@ -67,12 +67,10 @@ class MXFP8GemmBase:
     def setUpClass(cls):
         if cls.backend is None:
             raise NotImplementedError("Subclass must set 'backend' attribute")
-        cls.model = try_cached_model(BF16_MODEL_PATH)
+        cls.model = try_cached_model(MXFP8_MODEL_PATH)
         cls.base_url = DEFAULT_URL_FOR_TEST
         other_args = [
             "--trust-remote-code",
-            "--quantization",
-            "mxfp8",
             "--fp8-gemm-backend",
             cls.backend,
         ]
@@ -122,6 +120,9 @@ class TestFP8BlockwiseGemmFlashinferDeepGemm(FP8BlockwiseGemmBase, unittest.Test
     backend = "flashinfer_deepgemm"
 
 
+@unittest.skip(
+    "Temporarily disabled until https://github.com/sgl-project/sglang/pull/19835 is merged"
+)
 @unittest.skipIf(get_device_sm() < 100, "Test requires CUDA SM 100 or higher")
 class TestMXFP8GemmTriton(MXFP8GemmBase, unittest.TestCase):
     backend = "triton"

--- a/test/registered/quant/test_fp8_blockwise_gemm.py
+++ b/test/registered/quant/test_fp8_blockwise_gemm.py
@@ -120,6 +120,7 @@ class TestFP8BlockwiseGemmFlashinferDeepGemm(FP8BlockwiseGemmBase, unittest.Test
     backend = "flashinfer_deepgemm"
 
 
+@unittest.skip("Currently PCG capture takes too long to complete, disable until fixed")
 @unittest.skipIf(get_device_sm() < 100, "Test requires CUDA SM 100 or higher")
 class TestMXFP8GemmTriton(MXFP8GemmBase, unittest.TestCase):
     backend = "triton"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
@humansand

Use offline mxfp8 checkpoint for CI stability.

MXFP8 Gemm CI is unstable after FlashInfer v0.6.7 update:
```
pip uninstall -y flashinfer-jit-cache flashinfer-python flashinfer-cubin
pip install flashinfer-python==0.6.7 flashinfer-cubin==0.6.7
pip install flashinfer-jit-cache==0.6.7 --index-url https://flashinfer.ai/whl/cu129

python3 -m pytest -s -q test/registered/quant/test_fp8_blockwise_gemm.py -k MXFP8
========================================== short test summary info ==========================================
FAILED test/registered/quant/test_fp8_blockwise_gemm.py::TestMXFP8GemmTriton::test_gsm8k - AssertionError: np.float64(0.7619408642911296) not greater than or equal to 0.8
FAILED test/registered/quant/test_fp8_blockwise_gemm.py::TestMXFP8GemmFlashinferTrtllm::test_gsm8k - AssertionError: np.float64(0.7619408642911296) not greater than or equal to 0.8
2 failed, 4 deselected, 5 warnings in 121.20s (0:02:01)
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
# If reverting to v0.6.6:
pip uninstall -y flashinfer-jit-cache flashinfer-python flashinfer-cubin
pip install flashinfer-python==0.6.6 flashinfer-cubin==0.6.6
pip install flashinfer-jit-cache==0.6.6 --index-url https://flashinfer.ai/whl/cu129

python3 -m pytest -s -q test/registered/quant/test_fp8_blockwise_gemm.py -k MXFP8
============================================= warnings summary ==============================================
../../usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1428
  /usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1428: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

registered/quant/test_fp8_blockwise_gemm.py::TestMXFP8GemmTriton::test_gsm8k
registered/quant/test_fp8_blockwise_gemm.py::TestMXFP8GemmFlashinferTrtllm::test_gsm8k
  /sgl-workspace/sglang/python/sglang/test/few_shot_gsm8k.py:54: DeprecationWarning: Including the scheme in --host ('http://127.0.0.1') is deprecated. Pass just the hostname (e.g. '127.0.0.1') instead.
    set_default_backend(RuntimeEndpoint(normalize_base_url(args.host, args.port)))

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
2 passed, 4 deselected, 5 warnings in 138.05s (0:02:18)
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```

After investigating, the root cause is due to the instability of the online quantization code path itself, not flashinfer v0.6.7:
```
# v0.6.6 online quantization
python3 -m sglang.launch_server --kv-cache-dtype bf16 --model Qwen/Qwen3-4B-Instruct-2507 --quantization mxfp8 --fp8-gemm-backend flashinfer_trtllm
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1209 --parallel 1209 --platinum
Accuracy: 0.716
Invalid: 0.000
Latency: 10.441 s
Output throughput: 27218.943 token/s

# v0.6.6 offline quantization
python3 -m sglang.launch_server --kv-cache-dtype bf16 --model zianglih/Qwen3-4B-Instruct-2507-MXFP8 --fp8-gemm-backend flashinfer_trtllm
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1209 --parallel 1209 --platinum
Accuracy: 0.840
Invalid: 0.000
Latency: 8.577 s
Output throughput: 25232.410 token/s

# v0.6.7 online quantization
python3 -m sglang.launch_server --kv-cache-dtype bf16 --model Qwen/Qwen3-4B-Instruct-2507 --quantization mxfp8 --fp8-gemm-backend flashinfer_trtllm
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1209 --parallel 1209 --platinum
Accuracy: 0.796
Invalid: 0.000
Latency: 8.984 s
Output throughput: 27016.746 token/s

# v0.6.7 offline quantization
python3 -m sglang.launch_server --kv-cache-dtype bf16 --model zianglih/Qwen3-4B-Instruct-2507-MXFP8 --fp8-gemm-backend flashinfer_trtllm
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1209 --parallel 1209 --platinum
Accuracy: 0.841
Invalid: 0.000
Latency: 8.538 s
Output throughput: 25126.517 token/s
```
Note, `TestMXFP8GemmTriton` is temporarily disabled until ~a fix in https://github.com/sgl-project/sglang/pull/19835 is merged~ long PCG capture time is fixed.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
```
root@B200-124:/sgl-workspace/sglang# python3 -m pytest -s -q test/registered/quant/test_fp8_blockwise_gemm.py -k TestMXFP8
...
Accuracy: 0.850
Invalid: 0.000
Latency: 14.914 s
Output throughput: 15622.660 token/s
{'accuracy': np.float64(0.8498862774829417), 'invalid': np.float64(0.0), 'latency': 14.914425703696907, 'output_throughput': 15622.65987501245}
.
================== warnings summary ==================
../../usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1428
  /usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1428: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

registered/quant/test_fp8_blockwise_gemm.py::TestMXFP8GemmFlashinferTrtllm::test_gsm8k
  /sgl-workspace/sglang/python/sglang/test/few_shot_gsm8k.py:54: DeprecationWarning: Including the scheme in --host ('http://127.0.0.1') is deprecated. Pass just the hostname (e.g. '127.0.0.1') instead.
    set_default_backend(RuntimeEndpoint(normalize_base_url(args.host, args.port)))

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
1 passed, 1 skipped, 4 deselected, 4 warnings in 64.06s (0:01:04)
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
root@B200-124:/sgl-workspace/sglang# 
```
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
