### PR TITLE
Fix EP-aware slicing for NVFP4 MoE input scales in non-FlashInfer backends

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -130,6 +130,10 @@ tracing = [
   "opentelemetry-sdk",
 ]
 
+model-gateway = [
+  "sglang-router",
+]
+
 test = [
   "accelerate",
   "bitsandbytes",
@@ -152,6 +156,7 @@ dev = ["sglang[test]"]
 all = [
   "sglang[diffusion]",
   "sglang[tracing]",
+  "sglang[model-gateway]",
 ]
 
 [tool.uv.extra-build-dependencies]

--- a/python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py
@@ -40,6 +40,7 @@ from sglang.multimodal_gen.runtime.platforms import (
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import maybe_download_model
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.srt.utils import get_compiler_backend, is_npu
 
 logger = init_logger(__name__)
 
@@ -637,15 +638,25 @@ class DiffusersPipeline(ComposedPipelineBase):
                     # TODO(DefTruth): Add support for 'compile_repeated_blocks' for 'transformer'
                     # modules which can significantly reduce compilation time for large models
                     # with repeated blocks.
-                    if isinstance(component, torch.nn.Module) and hasattr(
-                        component, "compile"
-                    ):
-                        # Prefer in-place compilation if supported. According to PyTorch documentation:
-                        # https://docs.pytorch.org/docs/stable/generated/torch.compile.html
-                        component.compile()
+                    if is_npu():
+                        backend = get_compiler_backend()
+                        if isinstance(component, torch.nn.Module) and hasattr(
+                            component, "compile"
+                        ):
+                            component.compile(backend=backend)
+                        else:
+                            compiled_component = torch.compile(component, backend=backend)
+                            setattr(pipe, comp, compiled_component)
                     else:
-                        compiled_component = torch.compile(component)
-                        setattr(pipe, comp, compiled_component)
+                        if isinstance(component, torch.nn.Module) and hasattr(
+                            component, "compile"
+                        ):
+                            # Prefer in-place compilation if supported. According to PyTorch documentation:
+                            # https://docs.pytorch.org/docs/stable/generated/torch.compile.html
+                            component.compile()
+                        else:
+                            compiled_component = torch.compile(component)
+                            setattr(pipe, comp, compiled_component)
                     logger.info(
                         f"Applied torch.compile to {comp} component of the pipeline"
                     )

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -78,6 +78,7 @@ from sglang.multimodal_gen.runtime.utils.layerwise_offload import OffloadableDiT
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.multimodal_gen.runtime.utils.perf_logger import StageProfiler
 from sglang.multimodal_gen.runtime.utils.profiler import SGLDiffusionProfiler
+from sglang.srt.utils import get_compiler_backend, is_npu
 from sglang.multimodal_gen.utils import dict_to_3d_list, masks_like
 
 logger = init_logger(__name__)
@@ -145,8 +146,13 @@ class DenoisingStage(PipelineStage):
             pass
         mode = os.environ.get("SGLANG_TORCH_COMPILE_MODE", "max-autotune-no-cudagraphs")
         logger.info(f"Compiling transformer with mode: {mode}")
-        # TODO(triple-mu): support customized fullgraph and dynamic in the future
-        module.compile(mode=mode, fullgraph=False, dynamic=None)
+        
+        if is_npu():
+            backend = get_compiler_backend()
+            logger.info(f"Using NPU compiler backend: {backend}")
+            module.compile(backend=backend)
+        else:
+            module.compile(mode=mode, fullgraph=False, dynamic=None)
 
     def _maybe_enable_cache_dit(
         self, num_inference_steps: int | tuple[int, int], batch: Req

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/hunyuan3d_paint.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/hunyuan3d_paint.py
@@ -33,6 +33,7 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.validators import (
 )
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.srt.utils import get_compiler_backend, is_npu
 
 logger = init_logger(__name__)
 
@@ -589,7 +590,12 @@ class Hunyuan3DPaintTexGenStage(PipelineStage):
                 "SGLANG_TORCH_COMPILE_MODE", "max-autotune-no-cudagraphs"
             )
             logger.info("Compiling paint transformer with mode: %s", compile_mode)
-            self.transformer.compile(mode=compile_mode, fullgraph=False, dynamic=None)
+            if is_npu():
+                backend = get_compiler_backend()
+                logger.info("Using NPU compiler backend: %s", backend)
+                self.transformer.compile(backend=backend)
+            else:
+                self.transformer.compile(mode=compile_mode, fullgraph=False, dynamic=None)
 
     def _convert_pil_list_to_tensor(
         self, images: list, device: torch.device

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/mova.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/mova.py
@@ -66,6 +66,7 @@ from sglang.multimodal_gen.runtime.utils.layerwise_offload import OffloadableDiT
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.multimodal_gen.runtime.utils.perf_logger import StageProfiler
 from sglang.multimodal_gen.runtime.utils.profiler import SGLDiffusionProfiler
+from sglang.srt.utils import get_compiler_backend, is_npu
 from sglang.multimodal_gen.utils import PRECISION_TO_TYPE
 
 logger = init_logger(__name__)
@@ -216,8 +217,13 @@ class MOVADenoisingStage(PipelineStage):
             pass
         mode = os.environ.get("SGLANG_TORCH_COMPILE_MODE", "max-autotune-no-cudagraphs")
         logger.info("Compiling %s with mode: %s", module.__class__.__name__, mode)
-        # TODO(triple-mu): support customized fullgraph and dynamic in the future
-        module.compile(mode=mode, fullgraph=False, dynamic=None)
+        
+        if is_npu():
+            backend = get_compiler_backend()
+            logger.info("Using NPU compiler backend: %s", backend)
+            module.compile(backend=backend)
+        else:
+            module.compile(mode=mode, fullgraph=False, dynamic=None)
 
     def _maybe_compile_dits(self, server_args: ServerArgs):
         if self._torch_compiled or not server_args.enable_torch_compile:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When using NVFP4 quantized MoE models (e.g., MiniMax-M2.5-NVFP4) with Expert Parallelism (EP > 1) and non-FlashInfer backends, ModelOptNvFp4FusedMoEMethod.process_weights_after_loading() crashes with a shape mismatch error:
RuntimeError: The size of tensor a (256) must match the size of tensor b (128) at non-singleton dimension 0

Root Cause:

- w13_input_scale and w2_input_scale are allocated with global shape (num_experts,) (marked with _sglang_require_global_experts = True )
- w13_weight_scale_2 and w2_weight_scale_2 are EP-local with shape (num_local_experts,)
- In the else branch (when no FlashInfer backend is active), the code performs element-wise multiplication between these tensors without EP-aware slicing, causing the shape mismatch
- 
## Modifications
File: python/sglang/srt/layers/quantization/modelopt_quant.py

Added EP-aware slicing in the else branch of process_weights_after_loading() to handle the case when layer.moe_ep_size > 1 :
else:
    w13_input_scale = layer.w13_input_scale.max(dim=-1).values.to(torch.float32)
    w2_input_scale = layer.w2_input_scale

    # EP-aware slicing for non-flashinfer backends
    # When EP > 1, input scales are global (num_experts) but weight scales are local (num_local_experts)
    if layer.moe_ep_size > 1:
        ep_start = layer.moe_ep_rank * layer.num_local_experts
        ep_end = ep_start + layer.num_local_experts
        w13_input_scale = w13_input_scale[ep_start:ep_end]
        w2_input_scale = w2_input_scale[ep_start:ep_end]
## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
