### PR TITLE
feat: Add idle request lifecycle duplicate-rid diagnostic

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -218,6 +218,7 @@ class Envs:
     SGLANG_TEST_RETRACT_NO_PREFILL_BS = EnvInt(2 ** 31)
     SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY = EnvInt(0)
     SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_IDLE = EnvBool(True)
+    SGLANG_ENABLE_STRICT_REQUEST_LIFECYCLE_CHECK = EnvBool(False)
 
     # Scheduler: new token ratio hyperparameters
     SGLANG_INIT_NEW_TOKEN_RATIO = EnvFloat(0.7)

--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -276,7 +276,7 @@ class SchedulerRuntimeCheckerMixin:
         err_rids: dict[str, set[str]] = {}
         conflicts_rids: dict[str, str] = {}
 
-        def check_reqs(reqs: list, container_name: str):
+        def check_reqs(reqs: Sequence[Req], container_name: str):
             for req in reqs:
                 if req.rid in conflicts_rids:
                     err_rids.setdefault(req.rid, set()).update(

--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -270,6 +270,38 @@ class SchedulerRuntimeCheckerMixin:
                 msg,
             )
 
+    def _check_request_lifecycle_consistency(self: Scheduler):
+        # Check that no request is present in multiple places at the same time,
+        # which would indicate a lifecycle management bug.
+        err_rids: dict[str, set[str]] = {}
+        conflicts_rids: dict[str, str] = {}
+
+        def check_reqs(reqs: list, container_name: str):
+            for req in reqs:
+                if req.rid in conflicts_rids:
+                    err_rids.setdefault(req.rid, set()).update(
+                        {conflicts_rids[req.rid]} | {container_name}
+                    )
+                else:
+                    conflicts_rids[req.rid] = container_name
+
+        # can add more req containers to check here if needed
+        check_reqs(self.waiting_queue, "waiting_queue")
+        check_reqs(self.running_batch.reqs, "running_batch")
+        check_reqs(self.grammar_manager.grammar_queue, "grammar_queue")
+
+        if err_rids:
+            lines = ["Duplicate rid detected in scheduler request containers."]
+            for rid, container_names in sorted(err_rids.items()):
+                lines.append(f"rid={rid}, containers={sorted(container_names)}")
+            raise_error_or_warn(
+                self,
+                envs.SGLANG_ENABLE_STRICT_REQUEST_LIFECYCLE_CHECK.get(),
+                "count_request_lifecycle_warnings",
+                "\n".join(lines),
+                log_interval=100,
+            )
+
     def check_memory(self: Scheduler):
         if self.is_hybrid_swa:
             memory_leak, token_msg = self._check_hybrid_memory()
@@ -358,6 +390,8 @@ class SchedulerRuntimeCheckerMixin:
             self.tree_cache.sanity_check()
 
     def self_check_during_idle(self: Scheduler):
+        self._check_request_lifecycle_consistency()
+
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
             if len(self.disagg_prefill_inflight_queue) > 0:
                 return


### PR DESCRIPTION
## Motivation

This PR adds a lightweight scheduler-side diagnostic for request lifecycle inconsistencies.

While debugging request lifecycle issues, it is useful to know when the same request id (`rid`) appears in multiple scheduler request containers at the same time. This should normally not happen for the stable containers checked here, and can be a useful signal when investigating lifecycle bugs or unexpected queue transitions.

## Modifications

- Add `_check_request_lifecycle_consistency()` to [`python/sglang/srt/managers/scheduler_runtime_checker_mixin.py`](python/sglang/srt/managers/scheduler_runtime_checker_mixin.py).
- Check duplicate `rid`s across:
  - `waiting_queue`
  - `running_batch`
  - `grammar_queue`
- Run this diagnostic from `self_check_during_idle()`.
- Log a warning message when duplicate `rid`s are detected.
- Add a dedicated env flag:
  - `SGLANG_ENABLE_STRICT_REQUEST_LIFECYCLE_CHECK`
- Keep the new lifecycle diagnostic separate from the existing memory-check strictness flag.

This is intended as a small diagnostic / hardening change rather than a behavior change in the scheduler.

## Accuracy Tests

N/A. This change does not modify model outputs.

## Speed Tests and Profiling

N/A. This change only adds an idle-time diagnostic path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.