### PR TITLE
[Diffusion][NPU] Add support for MOVA

### DIFF
--- a/python/sglang/jit_kernel/diffusion/triton/npu_fallback.py
+++ b/python/sglang/jit_kernel/diffusion/triton/npu_fallback.py
@@ -30,8 +30,8 @@ def apply_rotary_embedding_native(
         and x.shape[2] < NPU_ROTARY_MUL_MAX_HEAD_SIZE
     ):
         if cos.size(-1) * 2 == x.size(-1):
-            cos = torch.cat([cos, cos], dim = -1)
-            sin = torch.cat([sin, sin], dim = -1)
+            cos = torch.cat([cos, cos], dim=-1)
+            sin = torch.cat([sin, sin], dim=-1)
         cos = cos.unsqueeze(0)
         sin = sin.unsqueeze(0)
         x = x.unsqueeze(0)

--- a/python/sglang/jit_kernel/diffusion/triton/npu_fallback.py
+++ b/python/sglang/jit_kernel/diffusion/triton/npu_fallback.py
@@ -1,4 +1,8 @@
 import torch
+import torch_npu
+
+NPU_ROTARY_MUL_MAX_NUM_HEADS = 1000
+NPU_ROTARY_MUL_MAX_HEAD_SIZE = 896
 
 
 # TODO: remove this when triton ascend bug is fixed
@@ -18,6 +22,23 @@ def apply_rotary_embedding_native(
 ) -> torch.Tensor:
     cos = cos.unsqueeze(-2).to(x.dtype)
     sin = sin.unsqueeze(-2).to(x.dtype)
+
+    if (
+        cos.dim() == 3
+        and x.dim() == 3
+        and x.shape[1] < NPU_ROTARY_MUL_MAX_NUM_HEADS
+        and x.shape[2] < NPU_ROTARY_MUL_MAX_HEAD_SIZE
+    ):
+        if cos.size(-1) * 2 == x.size(-1):
+            cos = torch.cat([cos, cos], dim = -1)
+            sin = torch.cat([sin, sin], dim = -1)
+        cos = cos.unsqueeze(0)
+        sin = sin.unsqueeze(0)
+        x = x.unsqueeze(0)
+        x_embed = torch_npu.npu_rotary_mul(x, cos, sin)
+        x_embed = x_embed.squeeze(0)
+        return x_embed
+
     x1 = x[..., ::2]
     x2 = x[..., 1::2]
     o1 = x1 * cos - x2 * sin

--- a/python/sglang/multimodal_gen/runtime/layers/rotary_embedding/utils.py
+++ b/python/sglang/multimodal_gen/runtime/layers/rotary_embedding/utils.py
@@ -7,10 +7,8 @@ import torch
 from sglang.jit_kernel.diffusion.triton.rotary import apply_rotary_embedding
 from sglang.kernel_api_logging import debug_kernel_api
 from sglang.multimodal_gen.runtime.platforms import current_platform
-from sglang.srt.layers.rotary_embedding.utils import apply_rotary_pos_emb
 from sglang.srt.utils.custom_op import register_custom_op_from_extern
 
-_is_npu = current_platform.is_npu()
 _is_cuda = current_platform.is_cuda()
 if _is_cuda:
     try:
@@ -113,15 +111,8 @@ def apply_flashinfer_rope_qk_inplace(
             sin = cos_sin_cache[positions, half_size:].to(q.dtype)
         q_flat = q.reshape(bsz * seqlen, nheads, d)
         k_flat = k.reshape(bsz * seqlen, nheads, d)
-
-        if _is_npu and is_neox:
-            cos = torch.cat([cos, cos], dim=-1)
-            sin = torch.cat([sin, sin], dim=-1)
-            q_rot, k_rot = apply_rotary_pos_emb(q_flat, k_flat, cos, sin)
-        else:
-            q_rot = apply_rotary_embedding(q_flat, cos, sin, interleaved=not is_neox)
-            k_rot = apply_rotary_embedding(k_flat, cos, sin, interleaved=not is_neox)
-
+        q_rot = apply_rotary_embedding(q_flat, cos, sin, interleaved=not is_neox)
+        k_rot = apply_rotary_embedding(k_flat, cos, sin, interleaved=not is_neox)
         return q_rot.view(bsz, seqlen, nheads, d), k_rot.view(bsz, seqlen, nheads, d)
 
     if positions is None:

--- a/python/sglang/multimodal_gen/runtime/layers/rotary_embedding/utils.py
+++ b/python/sglang/multimodal_gen/runtime/layers/rotary_embedding/utils.py
@@ -7,8 +7,10 @@ import torch
 from sglang.jit_kernel.diffusion.triton.rotary import apply_rotary_embedding
 from sglang.kernel_api_logging import debug_kernel_api
 from sglang.multimodal_gen.runtime.platforms import current_platform
+from sglang.srt.layers.rotary_embedding.utils import apply_rotary_pos_emb
 from sglang.srt.utils.custom_op import register_custom_op_from_extern
 
+_is_npu = current_platform.is_npu()
 _is_cuda = current_platform.is_cuda()
 if _is_cuda:
     try:
@@ -111,8 +113,15 @@ def apply_flashinfer_rope_qk_inplace(
             sin = cos_sin_cache[positions, half_size:].to(q.dtype)
         q_flat = q.reshape(bsz * seqlen, nheads, d)
         k_flat = k.reshape(bsz * seqlen, nheads, d)
-        q_rot = apply_rotary_embedding(q_flat, cos, sin, interleaved=not is_neox)
-        k_rot = apply_rotary_embedding(k_flat, cos, sin, interleaved=not is_neox)
+
+        if _is_npu and is_neox:
+            cos = torch.cat([cos, cos], dim=-1)
+            sin = torch.cat([sin, sin], dim=-1)
+            q_rot, k_rot = apply_rotary_pos_emb(q_flat, k_flat, cos, sin)
+        else:
+            q_rot = apply_rotary_embedding(q_flat, cos, sin, interleaved=not is_neox)
+            k_rot = apply_rotary_embedding(k_flat, cos, sin, interleaved=not is_neox)
+
         return q_rot.view(bsz, seqlen, nheads, d), k_rot.view(bsz, seqlen, nheads, d)
 
     if positions is None:

--- a/python/sglang/multimodal_gen/runtime/models/dits/mova_video_dit.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/mova_video_dit.py
@@ -16,6 +16,7 @@ from torch.distributed.tensor import DTensor
 from sglang.multimodal_gen.configs.models.dits.mova_video import MOVAVideoConfig
 from sglang.multimodal_gen.runtime.distributed import get_tp_world_size
 from sglang.multimodal_gen.runtime.layers.attention import LocalAttention, USPAttention
+from sglang.multimodal_gen.runtime.platforms import current_platform
 
 # Reuse SGLang's optimized RMSNorm instead of torch.nn.RMSNorm or custom SlowRMSNorm
 from sglang.multimodal_gen.runtime.layers.layernorm import (
@@ -522,7 +523,10 @@ class WanModel(CachableDiT, OffloadableDiTMixin):
         self, x: torch.Tensor, control_camera_latents_input: torch.Tensor | None = None
     ):
         # NOTE(dhyu): avoid slow_conv
-        x = x.contiguous(memory_format=torch.channels_last_3d)
+        if current_platform.is_npu:
+            x = x.contiguous()
+        else:
+            x = x.contiguous(memory_format=torch.channels_last_3d)
         x = self.patch_embedding(x)
         grid_size = x.shape[2:]
         x = rearrange(x, "b c f h w -> b (f h w) c").contiguous()

--- a/python/sglang/multimodal_gen/runtime/models/dits/mova_video_dit.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/mova_video_dit.py
@@ -522,10 +522,11 @@ class WanModel(CachableDiT, OffloadableDiTMixin):
     def patchify(
         self, x: torch.Tensor, control_camera_latents_input: torch.Tensor | None = None
     ):
-        # NOTE(dhyu): avoid slow_conv
+        # torch.channels_last_3d is not supported on NPU
         if current_platform.is_npu:
             x = x.contiguous()
         else:
+            # NOTE(dhyu): avoid slow_conv
             x = x.contiguous(memory_format=torch.channels_last_3d)
         x = self.patch_embedding(x)
         grid_size = x.shape[2:]

--- a/python/sglang/multimodal_gen/runtime/models/dits/mova_video_dit.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/mova_video_dit.py
@@ -16,7 +16,6 @@ from torch.distributed.tensor import DTensor
 from sglang.multimodal_gen.configs.models.dits.mova_video import MOVAVideoConfig
 from sglang.multimodal_gen.runtime.distributed import get_tp_world_size
 from sglang.multimodal_gen.runtime.layers.attention import LocalAttention, USPAttention
-from sglang.multimodal_gen.runtime.platforms import current_platform
 
 # Reuse SGLang's optimized RMSNorm instead of torch.nn.RMSNorm or custom SlowRMSNorm
 from sglang.multimodal_gen.runtime.layers.layernorm import (
@@ -35,6 +34,7 @@ from sglang.multimodal_gen.runtime.layers.quantization.configs.base_config impor
     QuantizationConfig,
 )
 from sglang.multimodal_gen.runtime.models.dits.base import CachableDiT
+from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.utils.layerwise_offload import OffloadableDiTMixin
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
@@ -522,8 +522,8 @@ class WanModel(CachableDiT, OffloadableDiTMixin):
     def patchify(
         self, x: torch.Tensor, control_camera_latents_input: torch.Tensor | None = None
     ):
-        # torch.channels_last_3d is not supported on NPU
         if current_platform.is_npu:
+            # torch.channels_last_3d is not supported on NPU
             x = x.contiguous()
         else:
             # NOTE(dhyu): avoid slow_conv

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/mova.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/mova.py
@@ -719,7 +719,8 @@ class MOVADenoisingStage(PipelineStage):
             # TODO: remove this when torch.complex128 is supported for torch.cat on NPU
             visual_freqs = tuple(
                 freq.to(device=visual_x.device, dtype=torch.complex64)
-                for freq in visual_dit.freqs)
+                for freq in visual_dit.freqs
+            )
         else:
             visual_freqs = tuple(freq.to(visual_x.device) for freq in visual_dit.freqs)
         visual_freqs = (
@@ -742,23 +743,23 @@ class MOVADenoisingStage(PipelineStage):
         # Build audio freqs for full sequence
         self.audio_dit._init_freqs()
         if _is_npu:
-            # TODO: remove this when torch.complex128 is supported for torch.cat on NPU    
+            # TODO: remove this when torch.complex128 is supported for torch.cat on NPU
             audio_freqs = tuple(
                 freq.to(device=audio_x.device, dtype=torch.complex64)
-                for freq in self.audio_dit.freqs)
-        else:
-            audio_freqs = tuple(freq.to(audio_x.device) for freq in self.audio_dit.freqs)
-        audio_freqs = (
-            torch.cat(
-                [
-                    audio_freqs[0][:f].view(f, -1).expand(f, -1),
-                    audio_freqs[1][:f].view(f, -1).expand(f, -1),
-                    audio_freqs[2][:f].view(f, -1).expand(f, -1),
-                ],
-                dim=-1,
+                for freq in self.audio_dit.freqs
             )
-            .reshape(full_audio_seq_len, 1, -1)
-        )
+        else:
+            audio_freqs = tuple(
+                freq.to(audio_x.device) for freq in self.audio_dit.freqs
+            )
+        audio_freqs = torch.cat(
+            [
+                audio_freqs[0][:f].view(f, -1).expand(f, -1),
+                audio_freqs[1][:f].view(f, -1).expand(f, -1),
+                audio_freqs[2][:f].view(f, -1).expand(f, -1),
+            ],
+            dim=-1,
+        ).reshape(full_audio_seq_len, 1, -1)
 
         # Shard sequences for SP
         visual_x, visual_pad_len = self._shard_sequence_for_sp(visual_x, dim=1)

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/mova.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/mova.py
@@ -69,6 +69,7 @@ from sglang.multimodal_gen.runtime.utils.profiler import SGLDiffusionProfiler
 from sglang.multimodal_gen.utils import PRECISION_TO_TYPE
 from sglang.srt.utils.common import get_compiler_backend
 
+_is_npu = current_platform.is_npu()
 logger = init_logger(__name__)
 
 
@@ -714,7 +715,12 @@ class MOVADenoisingStage(PipelineStage):
 
         # Build visual freqs for full sequence
         visual_dit._init_freqs()
-        visual_freqs = tuple(freq.to(visual_x.device) for freq in visual_dit.freqs)
+        if _is_npu:
+            visual_freqs = tuple(
+                freq.to(device=visual_x.device, dtype=torch.complex64)
+                for freq in visual_dit.freqs)
+        else:
+            visual_freqs = tuple(freq.to(visual_x.device) for freq in visual_dit.freqs)
         visual_freqs = (
             torch.cat(
                 [
@@ -734,17 +740,22 @@ class MOVADenoisingStage(PipelineStage):
 
         # Build audio freqs for full sequence
         self.audio_dit._init_freqs()
+        if _is_npu:    
+            audio_freqs = tuple(
+                freq.to(device=audio_x.device, dtype=torch.complex64)
+                for freq in self.audio_dit.freqs)
+        else:
+            audio_freqs = tuple(freq.to(audio_x.device) for freq in self.audio_dit.freqs)
         audio_freqs = (
             torch.cat(
                 [
-                    self.audio_dit.freqs[0][:f].view(f, -1).expand(f, -1),
-                    self.audio_dit.freqs[1][:f].view(f, -1).expand(f, -1),
-                    self.audio_dit.freqs[2][:f].view(f, -1).expand(f, -1),
+                    audio_freqs[0][:f].view(f, -1).expand(f, -1),
+                    audio_freqs[1][:f].view(f, -1).expand(f, -1),
+                    audio_freqs[2][:f].view(f, -1).expand(f, -1),
                 ],
                 dim=-1,
             )
             .reshape(full_audio_seq_len, 1, -1)
-            .to(audio_x.device)
         )
 
         # Shard sequences for SP

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/mova.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/mova.py
@@ -716,6 +716,7 @@ class MOVADenoisingStage(PipelineStage):
         # Build visual freqs for full sequence
         visual_dit._init_freqs()
         if _is_npu:
+            # TODO: remove this when torch.complex128 is supported for torch.cat on NPU
             visual_freqs = tuple(
                 freq.to(device=visual_x.device, dtype=torch.complex64)
                 for freq in visual_dit.freqs)
@@ -740,7 +741,8 @@ class MOVADenoisingStage(PipelineStage):
 
         # Build audio freqs for full sequence
         self.audio_dit._init_freqs()
-        if _is_npu:    
+        if _is_npu:
+            # TODO: remove this when torch.complex128 is supported for torch.cat on NPU    
             audio_freqs = tuple(
                 freq.to(device=audio_x.device, dtype=torch.complex64)
                 for freq in self.audio_dit.freqs)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

This PR adds NPU support to the MOVA model.

ref: [Roadmap](https://github.com/sgl-project/sglang/issues/18967)

## Modifications

<!-- Detail the changes made in this pull request. -->

1. Fix aclnnCat calling failure on NPU backend.
2. Resolve channels_last_3d incompatibility for contiguous() on NPU.
3. Optimize RoPE fallback with torch_npu.npu_rotary_mul.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

### NPU (910B)
CMD: 
python -m sglang.multimodal_gen.runtime.entrypoints.cli.main generate --model-path=/path/to/MOVA-360p --prompt="A beautiful sunset over the ocean" --image-path="/path/to/sunset.jpg" --num-gpus 2 --tp-size 2

* Before:
Execution failed

* After:

https://github.com/user-attachments/assets/133cec91-9417-4c12-82df-670427b4c44a



### GPU (A100)

CMD: 
same to NPU

* Before:

https://github.com/user-attachments/assets/d25640e8-ee8f-4818-adb2-387493ee6ee4




* After:

https://github.com/user-attachments/assets/748dd252-c14c-41c8-a58a-00e544027063




## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

NPU (910B * 2)

CMD:
python -m sglang.multimodal_gen.runtime.entrypoints.cli.main generate --model-path=/path/to/MOVA-360p --prompt="A beautiful sunset over the ocean" --image-path="/path/to/sunset.jpg" --num-gpus 2 --tp-size 2 --perf-dump-path ../perf.json

<details>
<summary> perf.json details </summary>

```json
{
  "timestamp": "2026-03-28T05:33:56.351047+00:00",
  "request_id": "05c0954c-8d72-420e-95f8-54cc59a45f4d",
  "commit_hash": "2d288ba8c92f249d5d0d8c98b70751396ebf6f57",
  "tag": "cli_generate",
  "total_duration_ms": 1442029.9231852405,
  "steps": [
    {
      "name": "InputValidationStage",
      "duration_ms": 348.9822098053992
    },
    {
      "name": "TextEncodingStage",
      "duration_ms": 5167.57582500577
    },
    {
      "name": "ImageVAEEncodingStage",
      "duration_ms": 32805.15577085316
    },
    {
      "name": "MOVALatentPreparationStage",
      "duration_ms": 1.4249910600483418
    },
    {
      "name": "MOVATimestepPreparationStage",
      "duration_ms": 1.059889793395996
    },
    {
      "name": "MOVADenoisingStage",
      "duration_ms": 1394177.5044971146
    },
    {
      "name": "MOVADecodingStage",
      "duration_ms": 9497.18012707308
    }
  ],
  "denoise_steps_ms": [
    {
      "step": 0,
      "duration_ms": 33048.6817676574
    },
    {
      "step": 1,
      "duration_ms": 27540.082891937345
    },
    {
      "step": 2,
      "duration_ms": 27543.46876917407
    },
    {
      "step": 3,
      "duration_ms": 27564.08131122589
    },
    {
      "step": 4,
      "duration_ms": 27572.385392151773
    },
    {
      "step": 5,
      "duration_ms": 27563.069929834455
    },
    {
      "step": 6,
      "duration_ms": 27554.35159895569
    },
    {
      "step": 7,
      "duration_ms": 27544.700287282467
    },
    {
      "step": 8,
      "duration_ms": 27545.560833066702
    },
    {
      "step": 9,
      "duration_ms": 27560.257910750806
    },
    {
      "step": 10,
      "duration_ms": 27558.356884866953
    },
    {
      "step": 11,
      "duration_ms": 27562.871324829757
    },
    {
      "step": 12,
      "duration_ms": 27542.85261593759
    },
    {
      "step": 13,
      "duration_ms": 27534.70282582566
    },
    {
      "step": 14,
      "duration_ms": 27556.59586004913
    },
    {
      "step": 15,
      "duration_ms": 27554.725165944546
    },
    {
      "step": 16,
      "duration_ms": 27562.35018791631
    },
    {
      "step": 17,
      "duration_ms": 27558.70906310156
    },
    {
      "step": 18,
      "duration_ms": 37494.191779289395
    },
    {
      "step": 19,
      "duration_ms": 27553.44924610108
    },
    {
      "step": 20,
      "duration_ms": 27550.2935401164
    },
    {
      "step": 21,
      "duration_ms": 27549.314457923174
    },
    {
      "step": 22,
      "duration_ms": 27542.06692101434
    },
    {
      "step": 23,
      "duration_ms": 27541.823348030448
    },
    {
      "step": 24,
      "duration_ms": 27534.0299801901
    },
    {
      "step": 25,
      "duration_ms": 27542.893416248262
    },
    {
      "step": 26,
      "duration_ms": 27541.230192873627
    },
    {
      "step": 27,
      "duration_ms": 27549.92396896705
    },
    {
      "step": 28,
      "duration_ms": 27549.031677190214
    },
    {
      "step": 29,
      "duration_ms": 27543.825132306665
    },
    {
      "step": 30,
      "duration_ms": 27539.762417785823
    },
    {
      "step": 31,
      "duration_ms": 27543.440429959446
    },
    {
      "step": 32,
      "duration_ms": 27533.849772065878
    },
    {
      "step": 33,
      "duration_ms": 27530.339628923684
    },
    {
      "step": 34,
      "duration_ms": 27538.736396003515
    },
    {
      "step": 35,
      "duration_ms": 27536.152893211693
    },
    {
      "step": 36,
      "duration_ms": 27540.032375603914
    },
    {
      "step": 37,
      "duration_ms": 27532.260360661894
    },
    {
      "step": 38,
      "duration_ms": 27536.8240037933
    },
    {
      "step": 39,
      "duration_ms": 27547.218392137438
    },
    {
      "step": 40,
      "duration_ms": 27538.26627600938
    },
    {
      "step": 41,
      "duration_ms": 27534.237804356962
    },
    {
      "step": 42,
      "duration_ms": 27530.491921119392
    },
    {
      "step": 43,
      "duration_ms": 27540.967030916363
    },
    {
      "step": 44,
      "duration_ms": 27550.79106008634
    },
    {
      "step": 45,
      "duration_ms": 27536.134408786893
    },
    {
      "step": 46,
      "duration_ms": 27528.610394801944
    },
    {
      "step": 47,
      "duration_ms": 27525.37116408348
    },
    {
      "step": 48,
      "duration_ms": 27526.621586177498
    },
    {
      "step": 49,
      "duration_ms": 27530.62317101285
    }
  ],
  "memory_checkpoints": {
    "before_forward": {
      "allocated_mb": 0.0,
      "reserved_mb": 0.0,
      "peak_allocated_mb": 0.0,
      "peak_reserved_mb": 0.0
    },
    "after_forward": {
      "allocated_mb": 34421.4,
      "reserved_mb": 51406.0,
      "peak_allocated_mb": 39303.89,
      "peak_reserved_mb": 51406.0
    }
  },
  "meta": {
    "prompt": [
      "A beautiful sunset over the ocean"
    ],
    "model": "/path/to/openmoss/MOVA-360p"
  }
}
```
</details>

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
