### PR TITLE
README: coding agent sponsorship for long-term contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ SGLang is currently hosted under the non-profit open-source organization [LMSYS]
 <img src="https://raw.githubusercontent.com/sgl-project/sgl-learning-materials/refs/heads/main/slides/adoption.png" alt="logo" width="800" margin="10px"></img>
 
 ## Contact Us
-For enterprises interested in adopting or deploying SGLang at scale, including technical consulting, sponsorship opportunities, or partnership inquiries, please contact us at sglang@lmsys.org
+For enterprises interested in adopting or deploying SGLang at scale, including technical consulting, sponsorship opportunities, or partnership inquiries, please contact us at [sglang@lmsys.org](mailto:sglang@lmsys.org).
+
+Long-term active SGLang contributors are eligible for coding agent sponsorship, such as Claude Code or OpenAI Codex. Email [sglang@lmsys.org](mailto:sglang@lmsys.org) with your most important commits or pull requests.
 
 ## Acknowledgment
 We learned the design and reused code from the following projects: [Guidance](https://github.com/guidance-ai/guidance), [vLLM](https://github.com/vllm-project/vllm), [LightLLM](https://github.com/ModelTC/lightllm), [FlashInfer](https://github.com/flashinfer-ai/flashinfer), [Outlines](https://github.com/outlines-dev/outlines), and [LMQL](https://github.com/eth-sri/lmql).


### PR DESCRIPTION
## Summary

Adds a short note under **Contact Us** so long-term active contributors know they can email `contact@sglang.ai` to ask about coding agent sponsorship (e.g. Claude Code, Codex, or other tools), and that they should include their most important commits or PRs.

Also adds the missing period at the end of the enterprise contact sentence for consistency.

Made with [Cursor](https://cursor.com)