### PR TITLE
[Fix] Cast weight dtype in sgl-kernel norm wrappers for flashinfer 0.6.7

### DIFF
--- a/sgl-kernel/python/sgl_kernel/elementwise.py
+++ b/sgl-kernel/python/sgl_kernel/elementwise.py
@@ -120,6 +120,8 @@ def rmsnorm(
     ):
         return _rmsnorm_internal(input, weight, eps, out, enable_pdl)
     else:
+        if weight.dtype != input.dtype:
+            weight = weight.to(input.dtype)
         return _flashinfer_norm.rmsnorm(input, weight, eps, out, enable_pdl)
 
 
@@ -162,6 +164,8 @@ def fused_add_rmsnorm(
     ):
         _fused_add_rmsnorm_internal(input, residual, weight, eps, enable_pdl)
     else:
+        if weight.dtype != input.dtype:
+            weight = weight.to(input.dtype)
         _flashinfer_norm.fused_add_rmsnorm(input, residual, weight, eps, enable_pdl)
 
 
@@ -205,6 +209,8 @@ def gemma_rmsnorm(
     ):
         return _gemma_rmsnorm_internal(input, weight, eps, out, enable_pdl)
     else:
+        if weight.dtype != input.dtype:
+            weight = weight.to(input.dtype)
         return _flashinfer_norm.gemma_rmsnorm(input, weight, eps, out, enable_pdl)
 
 
@@ -247,6 +253,8 @@ def gemma_fused_add_rmsnorm(
     ):
         _gemma_fused_add_rmsnorm_internal(input, residual, weight, eps, enable_pdl)
     else:
+        if weight.dtype != input.dtype:
+            weight = weight.to(input.dtype)
         _flashinfer_norm.gemma_fused_add_rmsnorm(
             input, residual, weight, eps, enable_pdl
         )


### PR DESCRIPTION
## Summary
- Flashinfer 0.6.7 switched its `rmsnorm` implementation to CuTe-based kernels via TVM FFI, which enforce strict dtype matching between input and weight tensors
- When `RMSNorm` weight is fp32 but input is bf16/fp16 (common in diffusion models), the new kernels raise `ValueError: Mismatched Tensor on argument #1`
- This fix casts weight to match input dtype before calling flashinfer norm functions in all 4 affected wrappers: `rmsnorm`, `fused_add_rmsnorm`, `gemma_rmsnorm`, `gemma_fused_add_rmsnorm`

Fixes the CI failure in PR #21422 (`bench_fused_norm_scale_shift.py`).

## Test plan
- [x] Reproduced the bug on H200 with flashinfer 0.6.7
- [x] Verified fix resolves the dtype mismatch error
- [x] Verified numerical correctness (exact match when using same-dtype reference)
- [ ] CI should pass `stage-b-kernel-benchmark-1-gpu-large` suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)