### PR TITLE
Fix circular reference in CustomTestCase.__init_subclass__

### DIFF
--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -2068,9 +2068,11 @@ class CustomTestCase(unittest.TestCase):
         if getattr(setup, "_safe_setup_wrapped", False):
             return
 
-        def safe_setUpClass(klass, _orig=setup):
+        orig_func = setup.__func__
+
+        def safe_setUpClass(klass):
             try:
-                _orig.__func__(klass)
+                orig_func(klass)
             except Exception:
                 # Best-effort cleanup; suppress teardown errors so the
                 # original setUpClass exception propagates clearly.


### PR DESCRIPTION
## Summary
- The `safe_setUpClass` wrapper captured a bound method via default parameter (`_orig=setup`), which holds a reference to `cls` through `__self__`, creating a reference cycle: `cls → setUpClass → safe_setUpClass → _orig → __self__ → cls`
- This caused `dill` serialization failures when pickling `CustomLogitProcessor` subclasses defined inside test methods of `CustomTestCase` subclasses
- Fix: capture `setup.__func__` (plain function, no `cls` reference) instead of the bound method, breaking the cycle

## Test plan
- [ ] Existing CI tests pass (no behavioral change, only reference graph change)
- [ ] `dill.dumps` on locally-defined `CustomLogitProcessor` subclasses inside `CustomTestCase` methods no longer raises circular reference errors