### PR TITLE
[Fix] Fix memory leak on abort in decode KV cache offload mode

### DIFF
--- a/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
+++ b/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
@@ -285,6 +285,73 @@ class DecodeKVCacheOffloadManager:
         self.ongoing_backup[ack_id] = (req.rid, host_indices, start_time)
         return page_hashes[-1] if len(page_hashes) > 0 else prior_hash
 
+    def release_aborted_request(self, rid: str) -> None:
+        """Free GPU KV cache and host memory for an aborted request.
+
+        Requests in ongoing_backup are handled by _check_backup_progress and
+        need no special treatment here.
+        """
+        aborted_ack_ids = {
+            ack_id
+            for ack_id, (req, *_) in self.ongoing_offload.items()
+            if req.rid == rid
+        }
+        if not aborted_ack_ids:
+            return
+
+        remaining_acks = []
+        for ack in self.cache_controller.ack_write_queue:
+            _, finish_event, node_ids = ack
+            aborted_in_batch = [n for n in node_ids if n in aborted_ack_ids]
+            normal_in_batch = [n for n in node_ids if n not in aborted_ack_ids]
+
+            if not aborted_in_batch:
+                remaining_acks.append(ack)
+                continue
+
+            finish_event.synchronize()
+
+            for ack_id in aborted_in_batch:
+                req, host_indices, _, _, start, end = self.ongoing_offload.pop(ack_id)
+                if req.finished():
+                    self._release_finished_req(req, start)
+                else:
+                    kv_indices = self.req_to_token_pool.req_to_token[
+                        req.req_pool_idx, start:end
+                    ]
+                    self.token_to_kv_pool_allocator.free(kv_indices)
+                    self.offloaded_state.pop(req.rid, None)
+                self.decode_host_mem_pool.free(host_indices)
+
+            for ack_id in normal_in_batch:
+                (
+                    req,
+                    host_indices,
+                    incremental_tokens,
+                    start_time,
+                    start,
+                    end,
+                ) = self.ongoing_offload.pop(ack_id)
+                if req.finished():
+                    self._release_finished_req(req, start)
+                else:
+                    kv_indices = self.req_to_token_pool.req_to_token[
+                        req.req_pool_idx, start:end
+                    ]
+                    self.token_to_kv_pool_allocator.free(kv_indices)
+                prior_hash = (
+                    self.offloaded_state[req.rid].last_hash
+                    if req.rid in self.offloaded_state
+                    else None
+                )
+                last_hash = self._trigger_backup(
+                    req, host_indices, incremental_tokens, start_time, prior_hash
+                )
+                if req.rid in self.offloaded_state:
+                    self.offloaded_state[req.rid].last_hash = last_hash
+
+        self.cache_controller.ack_write_queue = remaining_acks
+
     def _compute_prefix_hash(self, tokens, prior_hash=""):
         page_hashes = []
         last_hash = prior_hash

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3191,6 +3191,17 @@ class Scheduler(
                         req.disagg_kv_sender.abort()
 
         elif self.disaggregation_mode == DisaggregationMode.DECODE:
+            if self.decode_offload_manager is not None:
+                rids = list(
+                    {
+                        req.rid
+                        for req, *_ in self.decode_offload_manager.ongoing_offload.values()
+                        if recv_req.abort_all or req.rid.startswith(recv_req.rid)
+                    }
+                )
+                for rid in rids:
+                    self.decode_offload_manager.release_aborted_request(rid)
+
             # Abort requests that have not yet finished preallocation
             for decode_req in self.disagg_decode_prealloc_queue.queue:
                 if recv_req.abort_all or decode_req.req.rid.startswith(recv_req.rid):

--- a/test/registered/disaggregation/test_disaggregation_decode_offload.py
+++ b/test/registered/disaggregation/test_disaggregation_decode_offload.py
@@ -1,7 +1,11 @@
 import os
 import shutil
+import time
 import unittest
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from types import SimpleNamespace
+
+import requests
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_cuda_ci
@@ -169,6 +173,88 @@ class TestDisaggregationDecodeOffload(PDDisaggregationServerBase):
 
         # Score should be consistent: round 2 should be >= round 1, or at least within a 0.05 margin if slightly lower
         self.assertGreaterEqual(metrics2["score"], metrics1["score"] - 0.05)
+
+    def test_abort_no_memory_leak(self):
+        """
+        Verify that aborting requests mid-flight in decode-offload mode does not
+        leak GPU KV cache or host memory.
+
+        Strategy:
+        1. Fire a batch of long-running requests through the load balancer.
+        2. After a short delay (so some requests have started offloading), abort
+           all of them via the decode server's /abort_request endpoint.
+        3. Wait for the server to stabilize, then send a fresh batch of requests
+           and verify they complete successfully — which would fail if KV cache
+           or host memory had been exhausted by the leak.
+        """
+        num_requests = 8
+        prompt = (
+            "Repeat the following sentence 100 times: The quick brown fox jumps over the lazy dog. "
+            * 3
+        )
+
+        def send_one(_):
+            try:
+                requests.post(
+                    f"{self.lb_url}/generate",
+                    json={
+                        "text": prompt,
+                        "sampling_params": {
+                            "temperature": 0,
+                            "max_new_tokens": 512,
+                            "ignore_eos": True,
+                        },
+                    },
+                    timeout=60,
+                )
+            except Exception:
+                pass
+
+        # Start requests concurrently
+        with ThreadPoolExecutor(num_requests) as executor:
+            futures = [executor.submit(send_one, i) for i in range(num_requests)]
+
+            # Give the decode server time to start offloading KV cache
+            time.sleep(3)
+
+            # Abort all in-flight requests on the decode server directly
+            abort_resp = requests.post(
+                f"{self.decode_url}/abort_request",
+                json={"abort_all": True},
+                timeout=10,
+            )
+            self.assertIn(abort_resp.status_code, (200, 204))
+
+            # Wait for all client threads to finish (they may get abort responses)
+            for future in as_completed(futures, timeout=30):
+                future.result()
+
+        # Allow the server to fully process the abort and reclaim resources
+        time.sleep(5)
+
+        # Verify the server is still healthy after the abort
+        health_resp = requests.get(f"{self.decode_url}/health", timeout=10)
+        self.assertEqual(health_resp.status_code, 200)
+
+        # Send a fresh batch of short requests; if memory leaked these would
+        # fail with OOM or hang indefinitely
+        def send_short(_):
+            resp = requests.post(
+                f"{self.lb_url}/generate",
+                json={
+                    "text": "The capital of France is",
+                    "sampling_params": {"temperature": 0, "max_new_tokens": 16},
+                },
+                timeout=60,
+            )
+            return resp
+
+        with ThreadPoolExecutor(num_requests) as executor:
+            results = list(executor.map(send_short, range(num_requests)))
+
+        for resp in results:
+            self.assertEqual(resp.status_code, 200)
+            self.assertIn("text", resp.json())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

In PD disaggregation decode mode with KV cache offloading enabled
(`--disaggregation-decode-enable-offload-kvcache`), when a request finishes
generation its KV cache is asynchronously transferred from GPU to host memory and
tracked in `DecodeKVCacheOffloadManager.ongoing_offload`. If the request is aborted
(e.g. client disconnect, `/abort_request`, or waiting-queue timeout) while this
transfer is in progress, the scheduler's `abort_request()` had no code path to clean
up `ongoing_offload` entries. This caused permanent leaks of:

- **GPU KV cache slots** (`token_to_kv_pool_allocator`)
- **Request pool slots** (`req_to_token_pool`)
- **Host memory** (`decode_host_mem_pool`)

Under sustained abort traffic the server would eventually exhaust its KV cache pool
and stop accepting new requests.

## Modifications

**`python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py`**

Add `DecodeKVCacheOffloadManager.release_aborted_request(rid)`:
- Finds all `ack_id`s in `ongoing_offload` that belong to the given `rid`
- Iterates `cache_controller.ack_write_queue` to locate the matching D2H transfer batch
- Calls `finish_event.synchronize()` to wait for the in-flight transfer to complete safely
- For the aborted request: calls `_release_finished_req()` (frees GPU KV + req slot) and `decode_host_mem_pool.free()` (frees host memory), **skipping backup**
- For non-aborted peers merged in the same CUDA stream batch: processes them through the normal `_release_finished_req` + `_trigger_backup` path so they are unaffected
- Requests in `ongoing_backup` (host→storage) require no special handling; `_check_backup_progress()` already frees host memory on completion

**`python/sglang/srt/managers/scheduler.py`**

In `abort_request()`, inside the `DisaggregationMode.DECODE` branch, call
`decode_offload_manager.release_aborted_request(rid)` for each matching request
found in `ongoing_offload` before the existing prealloc/transfer queue cleanup.

**`test/registered/disaggregation/test_disaggregation_decode_offload.py`**

Add `test_abort_no_memory_leak`: fires a batch of long-running requests, aborts them
mid-offload via `/abort_request`, then verifies the server remains healthy and can
serve a fresh batch — which would fail if KV cache or host memory had leaked.

## Accuracy Tests

No change to model forward pass or sampling logic.

## Speed Tests and Profiling

No change to the hot path. The new `release_aborted_request` method is only called
on the abort code path, which is not latency-sensitive.