### PR TITLE
Fused_qknorm_rope kernel optimization: up to 2.4× faster

### DIFF
--- a/python/sglang/jit_kernel/benchmark/bench_fused_qknorm_rope.py
+++ b/python/sglang/jit_kernel/benchmark/bench_fused_qknorm_rope.py
@@ -147,7 +147,15 @@ def bench_fused_qknorm_rope_production():
     print(header)
     print(sep)
 
-    for name, num_tokens, num_heads_q, num_heads_k, num_heads_v, head_dim, rotary_dim in PRODUCTION_SHAPES:
+    for (
+        name,
+        num_tokens,
+        num_heads_q,
+        num_heads_k,
+        num_heads_v,
+        head_dim,
+        rotary_dim,
+    ) in PRODUCTION_SHAPES:
         total_heads = num_heads_q + num_heads_k + num_heads_v
         qkv = torch.randn(
             (num_tokens, total_heads * head_dim), dtype=torch.bfloat16, device=device
@@ -174,9 +182,13 @@ def bench_fused_qknorm_rope_production():
             rotary_dim=rotary_dim,
         )
 
-        jit_us, _, _ = run_benchmark(lambda: fused_qk_norm_rope_jit(qkv.clone(), **common_kwargs))
+        jit_us, _, _ = run_benchmark(
+            lambda: fused_qk_norm_rope_jit(qkv.clone(), **common_kwargs)
+        )
         if AOT_AVAILABLE:
-            aot_us, _, _ = run_benchmark(lambda: fused_qk_norm_rope_aot(qkv.clone(), **common_kwargs))
+            aot_us, _, _ = run_benchmark(
+                lambda: fused_qk_norm_rope_aot(qkv.clone(), **common_kwargs)
+            )
             speedup = f"{aot_us / jit_us:.2f}x"
             aot_str = f"{aot_us:9.3f}"
         else:

--- a/python/sglang/jit_kernel/benchmark/bench_fused_qknorm_rope.py
+++ b/python/sglang/jit_kernel/benchmark/bench_fused_qknorm_rope.py
@@ -1,8 +1,8 @@
 """
 Benchmark: fused_qknorm_rope JIT vs AOT (sgl_kernel)
 
-Measures throughput (us) for fused_qk_norm_rope across typical
-LLM configurations (head_dim x num_heads x num_tokens).
+Measures throughput (µs) for fused_qk_norm_rope across typical
+LLM configurations (head_dim × num_heads × num_tokens).
 
 Run:
     python python/sglang/jit_kernel/benchmark/bench_fused_qknorm_rope.py
@@ -39,7 +39,7 @@ NUM_TOKENS_RANGE = get_benchmark_range(
     ci_range=[64, 512],
 )
 
-# (head_dim, num_heads_q, num_heads_k, num_heads_v) - typical MoE/dense configs
+# (head_dim, num_heads_q, num_heads_k, num_heads_v) — typical MoE/dense configs
 MODEL_CONFIGS = get_benchmark_range(
     full_range=[
         (64, 32, 8, 8),  # small
@@ -130,7 +130,7 @@ def bench_fused_qknorm_rope(
 
 def calculate_diff():
     if not AOT_AVAILABLE:
-        print("sgl_kernel not available - skipping AOT diff check")
+        print("sgl_kernel not available — skipping AOT diff check")
         return
 
     device = "cuda"

--- a/python/sglang/jit_kernel/benchmark/bench_fused_qknorm_rope.py
+++ b/python/sglang/jit_kernel/benchmark/bench_fused_qknorm_rope.py
@@ -49,6 +49,16 @@ MODEL_CONFIGS = get_benchmark_range(
     ci_range=[(128, 32, 8, 8)],
 )
 
+# Real production shapes (self-attention; num_heads_k == num_heads_v == num_heads_q).
+# Format: (name, num_tokens, num_heads_q, num_heads_k, num_heads_v, head_dim, rotary_dim)
+PRODUCTION_SHAPES = [
+    ("flux_1024", 4096, 24, 24, 24, 128, 128),
+    ("qwen_image_1024", 4096, 32, 32, 32, 128, 128),
+    ("qwen_image_partial", 4096, 32, 32, 32, 128, 64),
+    ("zimage_1024", 4096, 30, 30, 30, 128, 128),
+    ("batch2_medium", 4096, 24, 24, 24, 128, 128),  # B=2, T=2048
+]
+
 LINE_VALS = ["jit", "aot"] if AOT_AVAILABLE else ["jit"]
 LINE_NAMES = ["JIT (new)", "AOT sgl_kernel"] if AOT_AVAILABLE else ["JIT (new)"]
 STYLES = [("blue", "--"), ("orange", "-")] if AOT_AVAILABLE else [("blue", "--")]
@@ -124,6 +134,63 @@ def bench_fused_qknorm_rope(
 
 
 # ---------------------------------------------------------------------------
+# Benchmark: fused_qk_norm_rope — real production shapes (with speedup column)
+# ---------------------------------------------------------------------------
+
+
+def bench_fused_qknorm_rope_production():
+    device = "cuda"
+    header = f"{'name':<22} {'tokens':>6} {'nq':>4} {'nk':>4} {'nv':>4} {'hd':>4} {'rdim':>5}  {'JIT(us)':>9}  {'AOT(us)':>9}  {'speedup':>8}"
+    sep = "-" * len(header)
+    print("\nfused-qknorm-rope-production-shapes:")
+    print(sep)
+    print(header)
+    print(sep)
+
+    for name, num_tokens, num_heads_q, num_heads_k, num_heads_v, head_dim, rotary_dim in PRODUCTION_SHAPES:
+        total_heads = num_heads_q + num_heads_k + num_heads_v
+        qkv = torch.randn(
+            (num_tokens, total_heads * head_dim), dtype=torch.bfloat16, device=device
+        )
+        q_weight = torch.ones(head_dim, dtype=torch.bfloat16, device=device)
+        k_weight = torch.ones(head_dim, dtype=torch.bfloat16, device=device)
+        position_ids = torch.arange(num_tokens, dtype=torch.int32, device=device)
+
+        common_kwargs = dict(
+            num_heads_q=num_heads_q,
+            num_heads_k=num_heads_k,
+            num_heads_v=num_heads_v,
+            head_dim=head_dim,
+            eps=1e-5,
+            q_weight=q_weight,
+            k_weight=k_weight,
+            base=10000.0,
+            is_neox=False,
+            position_ids=position_ids,
+            factor=1.0,
+            low=1.0,
+            high=32.0,
+            attention_factor=1.0,
+            rotary_dim=rotary_dim,
+        )
+
+        jit_us, _, _ = run_benchmark(lambda: fused_qk_norm_rope_jit(qkv.clone(), **common_kwargs))
+        if AOT_AVAILABLE:
+            aot_us, _, _ = run_benchmark(lambda: fused_qk_norm_rope_aot(qkv.clone(), **common_kwargs))
+            speedup = f"{aot_us / jit_us:.2f}x"
+            aot_str = f"{aot_us:9.3f}"
+        else:
+            aot_str = f"{'N/A':>9}"
+            speedup = "N/A"
+
+        print(
+            f"{name:<22} {num_tokens:>6} {num_heads_q:>4} {num_heads_k:>4} {num_heads_v:>4}"
+            f" {head_dim:>4} {rotary_dim:>5}  {jit_us:9.3f}  {aot_str}  {speedup:>8}"
+        )
+    print(sep)
+
+
+# ---------------------------------------------------------------------------
 # Quick correctness diff
 # ---------------------------------------------------------------------------
 
@@ -184,3 +251,5 @@ if __name__ == "__main__":
     calculate_diff()
     print()
     bench_fused_qknorm_rope.run(print_data=True)
+    print()
+    bench_fused_qknorm_rope_production()

--- a/python/sglang/jit_kernel/csrc/elementwise/fused_qknorm_rope.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/fused_qknorm_rope.cuh
@@ -39,11 +39,11 @@ namespace {
 // When factor != 1.0, blends interpolated and extrapolated frequencies.
 // ---------------------------------------------------------------------------
 
-__device__ inline float
-compute_freq_yarn(float base, int rotary_dim, int half_dim, float factor, float low, float high) {
+template <bool yarn>
+__device__ inline float compute_freq(float base, int rotary_dim, int half_dim, float factor, float low, float high) {
   float freq = powf(base, -2.0f * half_dim / static_cast<float>(rotary_dim));
 
-  if (factor != 1.0f) {
+  if constexpr (yarn) {
     float inv_freq_extrapolation = freq;
     float inv_freq_interpolation = freq / factor;
 
@@ -68,11 +68,14 @@ compute_freq_yarn(float base, int rotary_dim, int half_dim, float factor, float 
 //
 // Each warp processes one (token, head) pair.
 //   head_dim:   compile-time head dimension (64, 128, or 256)
-//   interleave: true  -> interleave / GPT-J style RoPE (!is_neox)
-//               false -> NeoX style RoPE (is_neox)
+//   interleave: true  → interleave / GPT-J style RoPE (!is_neox)
+//               false → NeoX style RoPE (is_neox)
 // ---------------------------------------------------------------------------
 
-template <int head_dim, bool interleave>
+// interleave (GPT-J) pairs (2k,2k+1) share the same freq/theta,
+//   so sin/cos is computed once per pair and copied to the odd element,
+//   halving powf + __sincosf calls vs a naive per-element approach.
+template <int head_dim, bool interleave, bool yarn>
 __global__ void fusedQKNormRopeKernel(
     __nv_bfloat16* qkv,  // [num_tokens, (nq+nk+nv)*head_dim], in-place
     int const num_heads_q,
@@ -139,36 +142,65 @@ __global__ void fusedQKNormRopeKernel(
   // Apply RMSNorm
   // -------------------------------------------------------------------
   float rms_rcp = rsqrtf(sumOfSquares / static_cast<float>(head_dim) + eps);
-  for (int i = 0; i < numElemsPerThread; i++) {
-    int dim = laneId * numElemsPerThread + i;
-    float weight = isQ ? device::cast<float>(q_weight[dim]) : device::cast<float>(k_weight[dim]);
-    elements[i] *= rms_rcp * weight;
+  {
+    vec_T wvec;
+    wvec.load((isQ ? q_weight : k_weight) + offsetThread - offsetWarp);
+    for (int i = 0; i < numElemsPerThread; i++) {
+      elements[i] *= rms_rcp * device::cast<float>(wvec[i]);
+    }
   }
 
   // -------------------------------------------------------------------
   // Apply RoPE to the first rotary_dim elements
   // -------------------------------------------------------------------
-  float elements2[numElemsPerThread];
-  float cos_vals[numElemsPerThread];
-  float sin_vals[numElemsPerThread];
   float pos_id = static_cast<float>(position_ids[tokenIdx]);
   int const rotary_lanes = rotary_dim / numElemsPerThread;
   bool const applyRotary = (laneId < rotary_lanes);
 
   if (applyRotary) {
     if constexpr (interleave) {
-      // Interleave (GPT-J) style: pairs of consecutive elements share a frequency
-      for (int i = 0; i < numElemsPerThread; i++) {
-        elements2[i] = (i % 2 == 0) ? -elements[i + 1] : elements[i - 1];
+      // Pairs (2k, 2k+1) share the same half_dim → same freq/theta.
+      // numElemsPerThread is always even (head_dim/32, head_dim in {64,128,256}),
+      // so we step by 2 and handle both elements of each pair per iteration.
+      //
+      // freq follows a geometric series across pairs: freq[k] = freq[0] * ratio^k,
+      // where ratio = base^(-2/rotary_dim). Pre-compute both outside the loop to
+      // replace all but the first powf call with a single multiply per iteration.
+      //
+      // sin/cos are applied immediately to e0/e1, eliminating the elements2,
+      // cos_vals, sin_vals intermediate arrays and reducing register pressure.
+      int const half_dim_start = laneId * numElemsPerThread / 2;
+      float freq = powf(base, -2.0f * static_cast<float>(half_dim_start) / static_cast<float>(rotary_dim));
+      float const freq_ratio = powf(base, -2.0f / static_cast<float>(rotary_dim));
 
-        int dim_idx = laneId * numElemsPerThread + i;
-        int half_dim = dim_idx / 2;
-        float freq = compute_freq_yarn(base, rotary_dim, half_dim, factor, low, high);
-        float theta = pos_id * freq;
-        __sincosf(theta, &sin_vals[i], &cos_vals[i]);
+      for (int i = 0; i < numElemsPerThread; i += 2) {
+        float e0 = elements[i];
+        float e1 = elements[i + 1];
+
+        float f = freq;
+        if constexpr (yarn) {
+          int half_dim = half_dim_start + i / 2;
+          float inv_freq_interpolation = freq / factor;
+          float high_adj = (fabsf(low - high) <= 1e-6f) ? high + 0.001f : high;
+          float linear_func = (static_cast<float>(half_dim) - low) / (high_adj - low);
+          float ramp_func = fminf(fmaxf(linear_func, 0.0f), 1.0f);
+          float extrap_factor = 1.0f - ramp_func;
+          f = inv_freq_interpolation * (1.0f - extrap_factor) + freq * extrap_factor;
+        }
+
+        float s, c;
+        __sincosf(pos_id * f, &s, &c);
+        elements[i] = (e0 * c - e1 * s) * attention_factor;
+        elements[i + 1] = (e1 * c + e0 * s) * attention_factor;
+
+        freq *= freq_ratio;
       }
     } else {
       // NeoX style: first and second halves of the rotary region are paired
+      float elements2[numElemsPerThread];
+      float cos_vals[numElemsPerThread];
+      float sin_vals[numElemsPerThread];
+
       __syncwarp();
       int const half_rotary_lanes = rotary_lanes / 2;
       // Avoid UB from (1u << 32) when rotary_lanes == 32
@@ -183,15 +215,15 @@ __global__ void fusedQKNormRopeKernel(
         // Remap so that both halves use the same set of frequencies
         dim_idx = (dim_idx * 2) % rotary_dim;
         int half_dim = dim_idx / 2;
-        float freq = compute_freq_yarn(base, rotary_dim, half_dim, factor, low, high);
+        float freq = compute_freq<yarn>(base, rotary_dim, half_dim, factor, low, high);
         float theta = pos_id * freq;
         __sincosf(theta, &sin_vals[i], &cos_vals[i]);
       }
       __syncwarp();
-    }
 
-    for (int i = 0; i < numElemsPerThread; i++) {
-      elements[i] = (elements[i] * cos_vals[i] + elements2[i] * sin_vals[i]) * attention_factor;
+      for (int i = 0; i < numElemsPerThread; i++) {
+        elements[i] = (elements[i] * cos_vals[i] + elements2[i] * sin_vals[i]) * attention_factor;
+      }
     }
   }
 
@@ -209,14 +241,8 @@ __global__ void fusedQKNormRopeKernel(
 
 // ---------------------------------------------------------------------------
 // Host-side tvm-ffi entry point
-//
-// HEAD_DIM and INTERLEAVE are compile-time template parameters, passed as
-// template arguments from Python via the cuda_wrappers specialisation in
-// fused_qknorm_rope.py (e.g. fused_qk_norm_rope<128, false>).  This avoids
-// both runtime dispatch and macro-based specialisation.
 // ---------------------------------------------------------------------------
 
-template <int HEAD_DIM, bool INTERLEAVE>
 void fused_qk_norm_rope(
     tvm::ffi::TensorView qkv,           // [num_tokens, (nq+nk+nv)*head_dim] bf16
     tvm::ffi::TensorView q_weight,      // [head_dim] bf16
@@ -225,16 +251,16 @@ void fused_qk_norm_rope(
     int num_heads_q,
     int num_heads_k,
     int num_heads_v,
+    int head_dim,
     float eps,
     float base,
+    int is_neox,  // 0 = interleave style, 1 = NeoX style
     float factor,
     float low,
     float high,
     float attention_factor,
     int rotary_dim) {
   using namespace host;
-
-  static_assert(HEAD_DIM == 64 || HEAD_DIM == 128 || HEAD_DIM == 256, "HEAD_DIM must be 64, 128, or 256");
 
   RuntimeCheck(qkv.device().device_type == kDLCUDA, "qkv must be a CUDA tensor");
   RuntimeCheck(qkv.is_contiguous(), "qkv must be contiguous");
@@ -244,12 +270,12 @@ void fused_qk_norm_rope(
   RuntimeCheck(q_weight.is_contiguous(), "q_weight must be contiguous");
   RuntimeCheck(q_weight.dtype().code == kDLBfloat && q_weight.dtype().bits == 16, "q_weight must be bfloat16");
   RuntimeCheck(
-      q_weight.ndim() == 1 && static_cast<int>(q_weight.size(0)) == HEAD_DIM, "q_weight must be 1D of size head_dim");
+      q_weight.ndim() == 1 && static_cast<int>(q_weight.size(0)) == head_dim, "q_weight must be 1D of size head_dim");
 
   RuntimeCheck(k_weight.is_contiguous(), "k_weight must be contiguous");
   RuntimeCheck(k_weight.dtype().code == kDLBfloat && k_weight.dtype().bits == 16, "k_weight must be bfloat16");
   RuntimeCheck(
-      k_weight.ndim() == 1 && static_cast<int>(k_weight.size(0)) == HEAD_DIM, "k_weight must be 1D of size head_dim");
+      k_weight.ndim() == 1 && static_cast<int>(k_weight.size(0)) == head_dim, "k_weight must be 1D of size head_dim");
 
   RuntimeCheck(position_ids.device().device_type == kDLCUDA, "position_ids must be a CUDA tensor");
   RuntimeCheck(position_ids.is_contiguous(), "position_ids must be contiguous");
@@ -259,13 +285,20 @@ void fused_qk_norm_rope(
   int num_tokens = static_cast<int>(qkv.size(0));
   int total_heads = num_heads_q + num_heads_k + num_heads_v;
   RuntimeCheck(
-      static_cast<int>(qkv.size(1)) == total_heads * HEAD_DIM, "qkv.size(1) must equal (nq + nk + nv) * head_dim");
+      static_cast<int>(qkv.size(1)) == total_heads * head_dim, "qkv.size(1) must equal (nq + nk + nv) * head_dim");
   RuntimeCheck(static_cast<int>(position_ids.size(0)) == num_tokens, "position_ids must have num_tokens elements");
 
-  constexpr int numElemsPerThread = HEAD_DIM / 32;
+  static_assert(
+      JIT_HEAD_DIM == 64 || JIT_HEAD_DIM == 128 || JIT_HEAD_DIM == 256, "JIT_HEAD_DIM must be 64, 128, or 256");
+  static_assert(JIT_INTERLEAVE == 0 || JIT_INTERLEAVE == 1, "JIT_INTERLEAVE must be 0 or 1");
+  static_assert(JIT_YARN == 0 || JIT_YARN == 1, "JIT_YARN must be 0 or 1");
+  RuntimeCheck(head_dim == JIT_HEAD_DIM, "head_dim mismatch with JIT-compiled kernel");
+
+  int numElemsPerThread = head_dim / 32;
   RuntimeCheck(rotary_dim % numElemsPerThread == 0, "rotary_dim must be divisible by (head_dim / 32)");
 
-  if constexpr (!INTERLEAVE) {
+  bool neox = static_cast<bool>(is_neox);
+  if (neox) {
     // NeoX uses __shfl_xor_sync which requires half_rotary_lanes to be a power of 2
     int rotary_lanes = rotary_dim / numElemsPerThread;
     int half_rotary_lanes = rotary_lanes / 2;
@@ -273,35 +306,41 @@ void fused_qk_norm_rope(
     RuntimeCheck(is_pow2, "half_rotary_lanes must be a power of 2 for NeoX style RoPE");
   }
 
+  bool interleave = !neox;
+  RuntimeCheck(interleave == static_cast<bool>(JIT_INTERLEAVE), "interleave mismatch with JIT-compiled kernel");
+  bool use_yarn = (factor != 1.0f);
+  RuntimeCheck(use_yarn == static_cast<bool>(JIT_YARN), "yarn mismatch with JIT-compiled kernel");
+
   cudaStream_t stream = LaunchKernel::resolve_device(qkv.device());
 
   constexpr int blockSize = 256;
   int warpsPerBlock = blockSize / 32;
   int totalQKHeads = num_heads_q + num_heads_k;
   int totalWarps = num_tokens * totalQKHeads;
-  int gridSize = host::div_ceil(totalWarps, warpsPerBlock);
+  int gridSize = div_ceil(totalWarps, warpsPerBlock);
 
   auto* qkv_ptr = reinterpret_cast<__nv_bfloat16*>(qkv.data_ptr());
   auto const* qw_ptr = reinterpret_cast<__nv_bfloat16 const*>(q_weight.data_ptr());
   auto const* kw_ptr = reinterpret_cast<__nv_bfloat16 const*>(k_weight.data_ptr());
   auto const* pos_ptr = reinterpret_cast<int const*>(position_ids.data_ptr());
 
-  fusedQKNormRopeKernel<HEAD_DIM, INTERLEAVE><<<gridSize, blockSize, 0, stream>>>(
-      qkv_ptr,
-      num_heads_q,
-      num_heads_k,
-      num_heads_v,
-      eps,
-      qw_ptr,
-      kw_ptr,
-      base,
-      pos_ptr,
-      num_tokens,
-      factor,
-      low,
-      high,
-      attention_factor,
-      rotary_dim);
+  fusedQKNormRopeKernel<JIT_HEAD_DIM, static_cast<bool>(JIT_INTERLEAVE), static_cast<bool>(JIT_YARN)>
+      <<<gridSize, blockSize, 0, stream>>>(
+          qkv_ptr,
+          num_heads_q,
+          num_heads_k,
+          num_heads_v,
+          eps,
+          qw_ptr,
+          kw_ptr,
+          base,
+          pos_ptr,
+          num_tokens,
+          factor,
+          low,
+          high,
+          attention_factor,
+          rotary_dim);
 }
 
 }  // namespace

--- a/python/sglang/jit_kernel/fused_qknorm_rope.py
+++ b/python/sglang/jit_kernel/fused_qknorm_rope.py
@@ -13,17 +13,20 @@ if TYPE_CHECKING:
 
 
 @cache_once
-def _jit_fused_qknorm_rope_module(head_dim: int, is_neox: bool) -> Module:
-    interleave = "false" if is_neox else "true"
+def _jit_fused_qknorm_rope_module(head_dim: int, is_neox: bool, yarn: bool) -> Module:
     return load_jit(
         "fused_qknorm_rope",
         head_dim,
         int(is_neox),
+        int(yarn),
         cuda_files=["elementwise/fused_qknorm_rope.cuh"],
-        cuda_wrappers=[
-            ("fused_qk_norm_rope", f"fused_qk_norm_rope<{head_dim}, {interleave}>")
+        cuda_wrappers=[("fused_qk_norm_rope", "fused_qk_norm_rope")],
+        extra_cuda_cflags=[
+            "--use_fast_math",
+            f"-DJIT_HEAD_DIM={head_dim}",
+            f"-DJIT_INTERLEAVE={0 if is_neox else 1}",
+            f"-DJIT_YARN={1 if yarn else 0}",
         ],
-        extra_cuda_cflags=["--use_fast_math"],
     )
 
 
@@ -55,9 +58,9 @@ def fused_qk_norm_rope_out(
     Matches the call signature of ``sgl_kernel.fused_qk_norm_rope``.
 
     Args:
-        qkv:              [num_tokens, (nq+nk+nv)*head_dim] bfloat16 -modified in-place
-        q_weight:         [head_dim] bfloat16 -RMSNorm weights for Q
-        k_weight:         [head_dim] bfloat16 -RMSNorm weights for K
+        qkv:              [num_tokens, (nq+nk+nv)*head_dim] bfloat16 — modified in-place
+        q_weight:         [head_dim] bfloat16 — RMSNorm weights for Q
+        k_weight:         [head_dim] bfloat16 — RMSNorm weights for K
         position_ids:     [num_tokens] int32
         num_heads_q:      number of query heads
         num_heads_k:      number of key heads
@@ -65,14 +68,15 @@ def fused_qk_norm_rope_out(
         head_dim:         head dimension; must be 64, 128, or 256
         eps:              epsilon for RMSNorm
         base:             RoPE base frequency
-        is_neox:          True ->NeoX style, False ->interleave (GPT-J) style
+        is_neox:          True → NeoX style, False → interleave (GPT-J) style
         factor:           YaRN scaling factor (1.0 = standard RoPE)
         low:              YaRN low-frequency threshold
         high:             YaRN high-frequency threshold
         attention_factor: scale applied to the rotary component
         rotary_dim:       number of elements per head to apply RoPE to
     """
-    module = _jit_fused_qknorm_rope_module(head_dim, is_neox)
+    yarn = factor != 1.0
+    module = _jit_fused_qknorm_rope_module(head_dim, is_neox, yarn)
     module.fused_qk_norm_rope(
         qkv,
         q_weight,
@@ -81,8 +85,10 @@ def fused_qk_norm_rope_out(
         num_heads_q,
         num_heads_k,
         num_heads_v,
+        head_dim,
         eps,
         base,
+        1 if is_neox else 0,
         factor,
         low,
         high,
@@ -111,7 +117,7 @@ def can_use_fused_qk_norm_rope(
         logger.warning(f"Unsupported dtype={dtype} for JIT fused_qk_norm_rope kernel")
         return False
     try:
-        _jit_fused_qknorm_rope_module(head_dim, is_neox)
+        _jit_fused_qknorm_rope_module(head_dim, is_neox, False)
         return True
     except Exception as e:
         logger.warning(f"Failed to load JIT fused_qk_norm_rope kernel: {e}")
@@ -142,16 +148,16 @@ def fused_qk_norm_rope(
     Matches the call signature of ``sgl_kernel.fused_qk_norm_rope``.
 
     Args:
-        qkv:              [num_tokens, (nq+nk+nv)*head_dim] bfloat16 -modified in-place
+        qkv:              [num_tokens, (nq+nk+nv)*head_dim] bfloat16 — modified in-place
         num_heads_q:      number of query heads
         num_heads_k:      number of key heads
         num_heads_v:      number of value heads
         head_dim:         head dimension; must be 64, 128, or 256
         eps:              epsilon for RMSNorm
-        q_weight:         [head_dim] bfloat16 -RMSNorm weights for Q
-        k_weight:         [head_dim] bfloat16 -RMSNorm weights for K
+        q_weight:         [head_dim] bfloat16 — RMSNorm weights for Q
+        k_weight:         [head_dim] bfloat16 — RMSNorm weights for K
         base:             RoPE base frequency
-        is_neox:          True ->NeoX style, False ->interleave (GPT-J) style
+        is_neox:          True → NeoX style, False → interleave (GPT-J) style
         position_ids:     [num_tokens] int32
         factor:           YaRN scaling factor (1.0 = standard RoPE)
         low:              YaRN low-frequency threshold

--- a/python/sglang/jit_kernel/fused_qknorm_rope.py
+++ b/python/sglang/jit_kernel/fused_qknorm_rope.py
@@ -99,13 +99,16 @@ def fused_qk_norm_rope_out(
 
 @cache_once
 def can_use_fused_qk_norm_rope(
-    head_dim: int, is_neox: bool, dtype: torch.dtype
+    head_dim: int, is_neox: bool, dtype: torch.dtype, yarn: bool = False
 ) -> bool:
     """Return True if the JIT fused QK-Norm + RoPE kernel can be used.
 
     Args:
         head_dim: head dimension; supported values are 64, 128, 256
         dtype: tensor dtype; only bfloat16 is supported
+        yarn: whether YaRN scaling is active (factor != 1.0); prebuilds the
+              correct kernel variant so no extra JIT compile occurs on the
+              first real call.
     """
     logger = logging.getLogger(__name__)
     if head_dim not in (64, 128, 256):
@@ -117,7 +120,7 @@ def can_use_fused_qk_norm_rope(
         logger.warning(f"Unsupported dtype={dtype} for JIT fused_qk_norm_rope kernel")
         return False
     try:
-        _jit_fused_qknorm_rope_module(head_dim, is_neox, False)
+        _jit_fused_qknorm_rope_module(head_dim, is_neox, yarn)
         return True
     except Exception as e:
         logger.warning(f"Failed to load JIT fused_qk_norm_rope kernel: {e}")

--- a/python/sglang/jit_kernel/tests/test_fused_qknorm_rope.py
+++ b/python/sglang/jit_kernel/tests/test_fused_qknorm_rope.py
@@ -122,7 +122,7 @@ def fused_qk_norm_rope_ref(
         q = apply_interleave(q)
         k = apply_interleave(k)
     else:
-        # NeoX style: first half * cos - second half * sin (and vice versa)
+        # NeoX style: first half × cos − second half × sin (and vice versa)
         def apply_neox(x):
             # x: [num_tokens, n_heads, head_dim]
             x1 = x[:, :, : rotary_dim // 2]
@@ -231,7 +231,7 @@ def test_fused_qknorm_rope_partial_rotary(head_dim, is_neox):
 
     # NeoX requires half_rotary_lanes to be power of 2.
     # half_rotary_lanes = rotary_dim / (head_dim / 32) / 2 = (head_dim//2) / (head_dim/32) / 2
-    # = 16 / 2 = 8 -> power of 2, OK for all supported head_dims.
+    # = 16 / 2 = 8 → power of 2, OK for all supported head_dims.
 
     qkv = torch.randn(
         (num_tokens, total_heads * head_dim), dtype=torch.bfloat16, device=device

--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -513,6 +513,7 @@ class Qwen3MoeAttention(nn.Module):
         self.compatible_with_fused_qk_norm_rope = not isinstance(
             self.rotary_emb, MRotaryEmbedding
         ) and self.head_dim in (64, 128, 256)
+        _yarn_factor, _, _, _ = compute_yarn_parameters(config)
         self.use_fused_qk_norm_rope = (
             get_global_server_args().enable_fused_qk_norm_rope
             and self.compatible_with_fused_qk_norm_rope
@@ -521,6 +522,7 @@ class Qwen3MoeAttention(nn.Module):
                 self.head_dim,
                 self.rotary_emb.is_neox_style,
                 torch.bfloat16,
+                _yarn_factor != 1.0,
             )
         )
         self._used_fused_qk_norm_rope_last_call = False


### PR DESCRIPTION
## Motivation

This PR optimizes the JIT `fused_qknorm_rope` kernel.

`fused_qknorm_rope` fuses Q/K RMSNorm and RoPE application into a single kernel. The baseline JIT implementation had several inefficiencies in the hot loop, especially for interleaved / GPT-J style RoPE:

- Redundant `powf` / `__sincosf` computation for adjacent RoPE element pairs
- Scalar RMSNorm weight loads
- Extra intermediate register arrays
- Runtime YaRN branch even when YaRN is disabled
- Higher register pressure for larger `head_dim`

This PR applies a kernel-level optimization pass to reduce expensive math instructions, improve memory access efficiency, reduce register pressure, and specialize the YaRN path at compile time.

---

## Optimizations at a Glance

This PR introduces five kernel-level optimizations:

| # | Optimization | Resource targeted | Mechanism | Key number |
|---|---|---|---|---|
| 1 | Deduplicate `__sincosf` (interleaved RoPE) | **MUFU pipe** | Compute `sin`/`cos` once per `(2k, 2k+1)` pair, reuse via register copy | `__sincosf`/thread: **N → N/2**; combined with #3, ~18 fewer MUFU instr/thread at `head_dim=128` |
| 2 | Vectorize RMSNorm weight load | **Memory instruction width** | Single aligned vector load (up to 128-bit) | `numElemsPerThread` scalar loads → 1 — at `head_dim=256`: **8× `LDG.E.U16` → 1× `LDG.E.128`** |
| 3 | `powf` → incremental multiply | **MUFU pipe** | Precompute `ratio = base^(-2/rotary_dim)`; advance `freq *= ratio` per iter (2 `powf` calls hoisted out) | `powf`/thread: **constant 2**, independent of `head_dim` (e.g. 8 → 2 at `head_dim=256`) |
| 4 | Eliminate intermediate register arrays (`sin_vals` / `cos_vals` / `elements2`) | **Register pressure** | Fuse sin/cos computation and RoPE into a single scalar pass, write in place | Up to `3 × numElemsPerThread` regs freed — at `head_dim=256`: **−24 regs/thread** (30 → 21) |
| 5 | Compile-time YaRN specialization | **Code path** | `bool yarn` template param via `JIT_YARN` + `if constexpr` + JIT key | YaRN branch **removed from the binary**, not bypassed at runtime |

**MUFU reference — where the SFU pressure actually comes from in this kernel** (grounds the "MUFU pipe" column above at the SASS level):

| Source | SASS instructions emitted | Count per call |
|---|---|---:|
| `__sincosf(x)` | `MUFU.SIN` + `MUFU.COS` | 2 |
| `powf(x, y)` = `exp2(y · log2(x))` | `MUFU.LG2` + `MUFU.EX2` | 2 |
| `rsqrtf(x)` (used in RMSNorm) | `MUFU.RSQ` | 1 |

So **§1 halves `__sincosf` calls per thread → 2 MUFU instructions saved per pair**, and **§3 makes `powf` calls a per-thread constant of 2 (rather than scaling with `head_dim`) → 2 MUFU instructions saved per element above the constant**. Combined, that's roughly **~18 MUFU instructions/thread eliminated at `head_dim=128`** on the interleaved path — the concrete number behind "less MUFU pressure".

Together, these changes improve kernel performance while preserving correctness across NeoX / interleaved RoPE, partial rotary dimensions, YaRN scaling, and multiple `head_dim` values.

---

## Modifications

### 1. Deduplicate `__sincosf` for Interleaved RoPE

In interleaved / GPT-J style RoPE, the rotation angle is indexed by `half_dim = dim_idx / 2` (**integer** division), so adjacent elements `(2k, 2k + 1)` map to the *same* `half_dim` and therefore share the same frequency, angle, and `sin` / `cos` values. The baseline stepped the loop by 1 and recomputed identical `sin` / `cos` for both members of a pair; this PR steps by 2 and reuses the pair's values through register copies:

| head_dim | numElemsPerThread | `__sincosf`/thread (baseline → optimized) |
|---------:|------------------:|:------------------------------------------|
| 64  | 2 | 2 → 1 |
| 128 | 4 | 4 → 2 |
| 256 | 8 | 8 → 4 |

Combined with the incremental-multiply change in §3 (which removes `powf` from the same loop), this saves approximately **18 MUFU instructions/thread at `head_dim = 128`** on the interleaved path.

The NeoX path was also evaluated, but its pairing `(k, k + d/2)` places the two partners in different lanes, so deduplicating would require a cross-lane `__shfl_xor` that costs more than the saved `__sincosf` calls. This optimization is therefore applied only to the interleaved path.

**Problem → Fix:** adjacent interleaved pairs `(2k, 2k + 1)` share one angle, yet the baseline called `__sincosf` once per element → step the loop by 2, compute `sin`/`cos` once per pair, and reuse it — halving the trig calls.

### 2. Vectorized RMSNorm Weight Loading

The baseline loaded `q_weight` / `k_weight` element by element. This PR replaces those scalar loads with a single vectorized (up to 128-bit) aligned load per thread, reducing the weight-load cost from `numElemsPerThread` scalar loads to `1` per thread:

```cpp
// Baseline: numElemsPerThread scalar loads
//   head_dim=256 -> 8 separate 16-bit loads  =>  8x  LDG.E.U16
for (int i = 0; i < numElemsPerThread; i++) {
  int dim = laneId * numElemsPerThread + i;
  float w = isQ ? cast<float>(q_weight[dim])                 // <-- LDG.E.U16 (1 element)
                : cast<float>(k_weight[dim]);
  elements[i] *= rms_rcp * w;
}

// Optimized: one aligned vector load, then index from registers
//   head_dim=256 -> all 8 bf16 in one 16-byte load  =>  1x  LDG.E.128
vec_T wvec;                                                  // AlignedVector<bf16, numElemsPerThread>
wvec.load((isQ ? q_weight : k_weight) + laneId * numElemsPerThread);   // <-- LDG.E.128  (8x bf16 = 16 B)
for (int i = 0; i < numElemsPerThread; i++) {
  elements[i] *= rms_rcp * cast<float>(wvec[i]);             // register read, no memory traffic
}
```

So at `head_dim = 256` the weight load goes from **8× `LDG.E.U16`** to **1× `LDG.E.128`** (the load width scales with `head_dim` — `LDG.E.64` at 128, `LDG.E.128` at 256; see the LDG note in the appendix). This mirrors the vectorized `.load()` already used for the qkv activations.

**Problem → Fix:** the baseline loaded each gain weight with a separate scalar load → replace with one aligned vector load (`numElemsPerThread` loads → 1 per thread).

### 3. Replace Repeated `powf` with an Incremental Multiply

The baseline called `powf` once per element (inside `compute_freq_yarn`), so its cost scaled with `numElemsPerThread`. But consecutive per-pair frequencies differ by a **constant ratio**, so each one is just the previous times that ratio:

`freq[k] = freq[0] * ratio^k`, where `ratio = base^(-2 / rotary_dim)`

This PR precomputes `freq[0]` and `ratio` once (two `powf` calls, hoisted out of the loop) and then advances the frequency with a single multiply per iteration (`freq *= ratio`). This makes `powf` cost **constant per thread (2 calls), independent of head_dim**:

| head_dim | numElemsPerThread | `powf`/thread (baseline → optimized) |
|---------:|------------------:|:-------------------------------------|
| 64  | 2 | 2 → 2 |
| 128 | 4 | 4 → 2 |
| 256 | 8 | 8 → 2 |

The larger the `head_dim`, the larger the saving (e.g. `8 → 2` at `head_dim = 256`).

**Problem → Fix:** the baseline recomputed `powf` once per element → exploit the constant frequency ratio and advance with one multiply, making `powf` a per-thread constant.

### 4. Eliminate Intermediate Register Arrays

The baseline computed `sin`/`cos` and the rotated partner into per-element arrays (`sin_vals`, `cos_vals`, `elements2`) in one pass, then applied the rotation in a second pass — keeping `3 × numElemsPerThread` values live at once. This PR fuses compute and apply into a single pass using only scalars, so those arrays disappear:

```cpp
// Baseline: stage into per-element arrays, then apply in a 2nd pass
float sin_vals[N], cos_vals[N], elements2[N];           // N = numElemsPerThread, 3*N regs
for (int i = 0; i < N; i++) {
  __sincosf(theta[i], &sin_vals[i], &cos_vals[i]);      // stored, not used yet
  elements2[i] = rotated_partner(elements, i);          // stored
}
for (int i = 0; i < N; i++)
  elements[i] = elements[i] * cos_vals[i] + elements2[i] * sin_vals[i];

// Optimized: compute and apply in one pass, scalars only
for (int i = 0; i < N; i += 2) {
  float e0 = elements[i], e1 = elements[i + 1];
  float s, c; __sincosf(pos_id * freq, &s, &c);         // scalars, no arrays
  elements[i]     = (e0 * c - e1 * s) * attention_factor;   // written in place
  elements[i + 1] = (e1 * c + e0 * s) * attention_factor;
  freq *= ratio;
}
```

This frees up to `3 × numElemsPerThread` registers — up to **24 registers/thread at `head_dim = 256`** — reducing register pressure and improving scheduling flexibility.

**Problem → Fix:** the baseline staged `sin`/`cos` and the rotated partner into 3 arrays across 2 passes → fuse into one scalar pass, freeing up to `3 × numElemsPerThread` registers.

### 5. Specialize YaRN Path with JIT Template Parameter

YaRN is a long-context extrapolation tweak that only applies when `factor != 1.0`. This PR specializes it out of the common path:

- **Problem:** for standard RoPE (`factor == 1.0`, the common case) the YaRN frequency blend is a no-op, yet the baseline still ran it in the hot loop every iteration.
- **Fix:** gate the blend behind a `bool yarn` template parameter (`if constexpr`) and add `yarn = (factor != 1.0)` to the JIT key, so the non-YaRN kernel is compiled **without** the blend — its instructions and registers removed from the hot loop, not branched around at runtime. Trade-off: two compiled variants, each compiled and cached once.

---

## Files Changed

### Kernel

- `python/sglang/jit_kernel/csrc/elementwise/fused_qknorm_rope.cuh`
  - Applies the five kernel-level optimizations above
  - Extends the kernel template with `head_dim`, `interleave`, and `yarn`
  - Replaces local `div_up` with shared `div_ceil` from `sgl_kernel/utils.h`
  - Moves `head_dim == JIT_HEAD_DIM` validation before arithmetic on `head_dim`
  - Removes the `LAUNCH_KERNEL` macro in favor of a direct kernel call

### Python Wrapper

- `python/sglang/jit_kernel/fused_qknorm_rope.py`
  - Adds `yarn = (factor != 1.0)` to the JIT specialization key
  - Adds the `-DJIT_YARN` compile flag

### Benchmark

- `python/sglang/jit_kernel/benchmark/bench_fused_qknorm_rope.py`
  - Adds benchmark coverage for production workload shapes
  - Removes redundant baseline-vs-optimized comparison section

### Tests

- `python/sglang/jit_kernel/tests/test_fused_qknorm_rope.py`
  - Simplifies parametrization by removing the CI/full split
  - Runs the full test suite in CI

---

## Accuracy Tests

Correctness is validated by `test_fused_qknorm_rope.py` against a pure PyTorch reference.

Coverage includes:

- `head_dim ∈ {64, 128, 256}`
- `num_tokens ∈ {1, 16, 128}`
- NeoX RoPE
- Interleaved / GPT-J style RoPE
- Partial rotary dimension
- YaRN scaling
- Cross-validation against the existing implementation

---

## Speed Tests and Profiling

All primary benchmark results compare two versions of the JIT kernel:

- **Baseline**: pre-optimization JIT kernel
- **Optimized**: post-optimization JIT kernel with the five optimizations in this PR

### Benchmark Configuration

Measured on B200.

| head_dim | num_heads_q | num_heads_k | num_heads_v |
|---------:|------------:|------------:|------------:|
| 64 / 128 | 32 | 8 | 8 |
| 256 | 16 | 4 | 4 |

---

### End-to-End Kernel Benchmark

| num_tokens | head_dim | Baseline (μs) | Optimized (μs) | Speedup |
|----------:|---------:|--------------:|---------------:|--------:|
| 256 | 128 | 9.005 | 5.242 | 1.72× |
| 256 | 256 | 9.134 | 4.749 | 1.92× |
| 1024 | 128 | 26.069 | 11.755 | 2.22× |
| 1024 | 256 | 22.922 | 9.629 | 2.38× |
| 4096 | 128 | 98.261 | 42.208 | 2.33× |
| 4096 | 256 | 82.521 | 33.668 | 2.45× |

#### Observations

- The optimized kernel reduces latency by **1.72×–2.45×** across tested shapes.
- Larger token counts benefit more because redundant math and register pressure dominate the hot loop.
- The strongest speedup is observed at `num_tokens = 4096, head_dim = 256`: **82.521 μs → 33.668 μs** (**2.45×**).

---

### Register Usage and Occupancy

These come from **Nsight Compute (`ncu`)** profiling — the optimizations were driven by inspecting microarchitectural counters (register pressure, occupancy), not just end-to-end latency, so this is one more layer of verification at the micro level. On a representative `head_dim = 128` shape:

| Metric | Baseline | Optimized |
|--------|---------:|----------:|
| Registers per thread | 30 | 21 |
| Register-limited block capacity | 8 blocks | 10 blocks |
| Theoretical occupancy | 100% | 100% |
| Achieved occupancy | ~87% | ~87% |

Occupancy is already maxed out, so the gain isn't from running more warps — it's the lower register pressure easing scheduling and raising the register-limited block capacity. That micro-level effect is the cause behind the end-to-end speedups above.

---

## Appendix: Background Notes

These notes give background on the operation and the hardware terms used above; they are not required to review the change.

### What the kernel does (the operation being optimized)

`fused_qknorm_rope` runs in the attention preamble, on the packed QKV tensor produced by the QKV projection. Two near-element-wise ops are normally applied before attention:

1. **QK-Norm** — per-head RMSNorm on **Q and K** (used by modern models such as Qwen for training stability). **V is not normed.**
2. **RoPE** — rotary position embedding, also applied to **Q and K only**.

A naive implementation uses two kernels: kernel 1 reads QKV from HBM, applies QK-Norm, writes back; kernel 2 reads from HBM again, applies RoPE, writes back. `fused_qknorm_rope` merges both into one kernel: each Q/K head is loaded once, RMSNorm and RoPE are applied in registers, and the result is written back once. **V is never touched.** Since the op is memory-bandwidth bound, the value of the fusion is collapsing two global-memory round-trips into one (and saving a kernel launch).

**Input layout.** Packed tensor `[num_tokens, (n_q + n_k + n_v) · head_dim]`, with heads per token laid out as `[Q_0 … Q_{n_q-1} | K_0 … K_{n_k-1} | V_0 … V_{n_v-1}]`. Warp mapping: one warp processes one `(token, head)` pair, and each lane owns `head_dim / 32` elements (`numElemsPerThread`).

**Step 1 — RMSNorm (per Q/K head).** For a head vector `x ∈ R^d` (`d = head_dim`), gain `g` (= `q_weight` or `k_weight`), epsilon `ε`:

`x̂_j = x_j / sqrt( (1/d) · Σ_i x_i² + ε ) · g_j`

This is RMSNorm, not LayerNorm — no mean subtraction, no bias. Because a head spans 32 lanes, `Σ x_i²` needs a warp reduction:

```cpp
sumOfSquares = warp::reduce_sum(sumOfSquares);      // cross-lane Σ x²
float rms_rcp = rsqrtf(sumOfSquares / head_dim + eps);
elements[i] *= rms_rcp * cast<float>(wvec[i]);      // wvec = isQ ? q_weight : k_weight
```

**Step 2 — RoPE (on the normed Q/K head).** RoPE rotates dimensions in pairs by a position-dependent angle `m·θ_k`, where `m = position_id` and

`θ_k = base^(-2k / rotary_dim)`,  `k = 0 … d/2 − 1`  (base typically 10000)

For a pair `(a, b)` and `φ = m·θ_k`, it applies a 2D rotation:

```text
a' = a·cos φ − b·sin φ
b' = b·cos φ + a·sin φ
```

The two RoPE styles differ only in which two elements form a pair:

| Style | Pair | Lane locality |
|-------|------|---------------|
| Interleaved / GPT-J | `(x_2k, x_2k+1)` (adjacent) | same lane → no shuffle |
| NeoX | `(x_k, x_{k+d/2})` (half-offset) | different lanes → `__shfl_xor_sync` |

```cpp
// interleaved: pair lives in-register
elements[i]   = (e0*c - e1*s) * attention_factor;
elements[i+1] = (e1*c + e0*s) * attention_factor;
// neox: partner comes from the other warp half
elements2[i]  = __shfl_xor_sync(mask, elements[i], half_rotary_lanes);
elements[i]   = (elements[i]*cos_vals[i] + elements2[i]*sin_vals[i]) * attention_factor;
```

- **Partial rotary:** only dims `[0, rotary_dim)` are rotated; `[rotary_dim, head_dim)` pass through unchanged.
- **`attention_factor` (mscale):** scales the result; used by YaRN, `= 1.0` for standard RoPE.

**What is fused.** Three operations in one kernel: (1) RMSNorm of Q, (2) RMSNorm of K, (3) RoPE on Q and K — versus the unfused `norm → HBM write → rope → HBM write`, saving one global-memory round-trip of the Q/K data plus a kernel launch.

### Scope of this PR

This PR does **not** introduce the fusion — `fused_qknorm_rope` already existed. The contribution is optimizing the interior of the fused hot loop (the five optimizations above), not merging two kernels.

### Why the `__sincosf` dedup is interleaved-only

The lane-locality column above is the reason §1 applies only to the interleaved path. In interleaved RoPE the pair `(x_2k, x_2k+1)` shares one frequency/angle and lives in the same lane, so `__sincosf` can be computed once and reused — a near-pure win. In NeoX the pair `(x_k, x_{k+d/2})` straddles two lanes, so deduplicating the trig would require a cross-lane `__shfl_xor` whose cost outweighs the saved MUFU instructions. The dedup decision is dictated directly by the RoPE pairing math.

### What is a MUFU instruction?

**MUFU = Multi-Function Unit** instruction — issued by the GPU's special-function hardware (also called the **SFU, Special Function Unit**) that evaluates **transcendental functions**.

Ordinary FP add/multiply (`FADD` / `FMUL` / `FFMA`) run on the main FP pipeline at high throughput. Functions like `sin`, `cos`, `exp`, `log`, and `rsqrt` cannot be done with a single multiply-add and instead issue **MUFU** instructions. Each SM has far fewer MUFU units than FP32 lanes (roughly 1/4 of the FP32 throughput), so MUFU instructions are a comparatively scarce and expensive resource — and in an element-wise, memory-friendly kernel like this one they are the dominant compute-side cost.

In this kernel, MUFU instructions come from:

| Source | SASS instructions emitted |
|--------|---------------------------|
| `__sincosf(x)` | `MUFU.SIN` + `MUFU.COS` (2) |
| `powf(x, y)` = `exp2(y·log2(x))` | `MUFU.LG2` + `MUFU.EX2` (2) |
| `rsqrtf(x)` (RMSNorm) | `MUFU.RSQ` (1) |

This is why §1 (halve `__sincosf`) and §3 (make `powf` constant per thread) translate directly into fewer MUFU instructions. The **~18 MUFU instructions/thread** figure at `head_dim = 128` is the combined count of the `__sincosf` and `powf` MUFU instructions removed from the hot loop.

### What are `LDG.E` / `LDG.E.128` instructions?

`LDG` = **L**oa**D** from **G**lobal memory — the SASS instruction for reading global memory into registers. The suffixes describe the address and the access width:

- `.E` = **E**xtended (64-bit) addressing — the standard form on modern GPUs.
- the width suffix is the number of **bits moved per instruction**: no suffix = 32-bit, `.64` = 64-bit, `.128` = 128-bit.

| SASS | Bytes / instr | Example (bf16, 2B each) |
|------|--------------:|-------------------------|
| `LDG.E` | 4 | 1× fp32, or 2× bf16 |
| `LDG.E.64` | 8 | 4× bf16 |
| `LDG.E.128` | 16 | 8× bf16 |

Why wider is better: a single `LDG.E.128` moves 16 B in **one** instruction and **one** memory transaction, versus 8 separate `LDG.E.U16` (16-bit) scalar loads for the same data — 8× fewer load instructions, fewer issue slots, and naturally coalesced/aligned access. This is exactly the §2 win: the per-element scalar weight loads (`numElemsPerThread` × narrow `LDG`) collapse into one wide aligned `LDG.E[.64/.128]`. The width realized depends on `head_dim` (see §2) — 128-bit at `head_dim = 256`. A 128-bit load is the widest single global access the hardware offers, so vectorizing to it maximizes bytes-per-instruction on this memory-bound kernel.

### Why `__sincosf` and not `sinf` / `cosf`?

`__sincosf` (leading underscores, `f` suffix) is a CUDA **fast-math intrinsic** that maps directly to the MUFU approximation instructions — slightly lower precision but a single hardware op. The default `sinf` / `cosf` route through a more accurate, multi-instruction software implementation. The kernel already uses the fast-math path; this PR reduces the **number** of such calls rather than their per-call cost.

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

