### PR TITLE
[Fix] Handle pre-release tags in nightly wheel version parsing

### DIFF
--- a/.github/workflows/release-pypi-nightly.yml
+++ b/.github/workflows/release-pypi-nightly.yml
@@ -61,11 +61,15 @@ jobs:
           HASH="g$(git rev-parse --short HEAD)"
           BUILD_DATE=$(date -u +%Y%m%d)
 
-          # Increment patch version for nightlies (e.g., v0.5.8 -> 0.5.9)
+          # Increment patch version for nightlies (e.g., v0.5.9 -> 0.5.10)
+          # Must always increment so nightly > latest tag per PEP 440 ordering:
+          #   X.Y.Z.devN < X.Y.Z.rcN < X.Y.Z < X.Y.(Z+1).devN
           VERSION=${TAG#v}  # Remove 'v' prefix
           MAJOR=$(echo "$VERSION" | cut -d. -f1)
           MINOR=$(echo "$VERSION" | cut -d. -f2)
-          PATCH=$(echo "$VERSION" | cut -d. -f3)
+          PATCH_RAW=$(echo "$VERSION" | cut -d. -f3)
+          # Strip pre-release suffixes (rc0, post1, etc.) to get numeric patch
+          PATCH=$(echo "$PATCH_RAW" | sed 's/[^0-9].*//')
           NEXT_PATCH=$((PATCH + 1))
           NEXT_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}"
 


### PR DESCRIPTION
## Summary
- The nightly wheel build (`build-nightly-wheel` job) fails when the latest git tag contains a pre-release suffix like `v0.5.10rc0`
- `cut -d. -f3` extracts `10rc0` from the version, and bash arithmetic `$((10rc0 + 1))` fails with `value too great for base (error token is "10rc0")`
- This produces an invalid version string `0.5..dev20260328+g9fa7b974f`, which causes `packaging.version.InvalidVersion`
- Fix: strip non-numeric suffixes (rc, post, alpha, beta, etc.) from the patch component before incrementing

Fixes: https://github.com/sgl-project/sglang/actions/runs/23676142751/job/68979443002

## Test plan
- [x] Verified fix handles all tag formats: `v0.5.9` → `0.5.10`, `v0.5.10rc0` → `0.5.11`, `v0.5.8.post1` → `0.5.9`, `v1.0.0alpha1` → `1.0.1`
- [ ] Re-run nightly wheel build to confirm it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)