### PR TITLE
[Fix] Fix weight_loader property assignment for qwen3-next FP8 models

### DIFF
--- a/python/sglang/srt/models/qwen3_next.py
+++ b/python/sglang/srt/models/qwen3_next.py
@@ -135,10 +135,10 @@ class Qwen3GatedDeltaNet(nn.Module):
 
         # Override weight_loader for packed checkpoint format.
         # Must capture original_loader BEFORE overwriting.
-        self.in_proj_qkvz.weight.weight_loader = self._make_packed_weight_loader(
+        self.in_proj_qkvz.weight._weight_loader = self._make_packed_weight_loader(
             self.in_proj_qkvz
         )
-        self.in_proj_ba.weight.weight_loader = self._make_packed_weight_loader(
+        self.in_proj_ba.weight._weight_loader = self._make_packed_weight_loader(
             self.in_proj_ba
         )
 

--- a/python/sglang/srt/models/qwen3_next.py
+++ b/python/sglang/srt/models/qwen3_next.py
@@ -135,11 +135,11 @@ class Qwen3GatedDeltaNet(nn.Module):
 
         # Override weight_loader for packed checkpoint format.
         # Must capture original_loader BEFORE overwriting.
-        self.in_proj_qkvz.weight._weight_loader = self._make_packed_weight_loader(
-            self.in_proj_qkvz
+        self._override_weight_loader(
+            self.in_proj_qkvz, self._make_packed_weight_loader(self.in_proj_qkvz)
         )
-        self.in_proj_ba.weight._weight_loader = self._make_packed_weight_loader(
-            self.in_proj_ba
+        self._override_weight_loader(
+            self.in_proj_ba, self._make_packed_weight_loader(self.in_proj_ba)
         )
 
         # Conv1d weight loader setup
@@ -215,6 +215,19 @@ class Qwen3GatedDeltaNet(nn.Module):
             A_log=self.A_log,
             dt_bias=self.dt_bias,
         )
+
+    @staticmethod
+    def _override_weight_loader(module, new_loader):
+        """Override weight_loader on a module's weight parameter.
+
+        ModelWeightParameter exposes weight_loader as a read-only property
+        backed by _weight_loader, while plain parameters store it as a
+        regular attribute.  This helper handles both cases."""
+        param = module.weight
+        if hasattr(param, "_weight_loader"):
+            param._weight_loader = new_loader
+        else:
+            param.weight_loader = new_loader
 
     @staticmethod
     def _make_packed_weight_loader(module):


### PR DESCRIPTION
## Summary
- Fix `AttributeError: property 'weight_loader' of 'ModelWeightParameter' object has no setter` when loading Qwen3-Coder-Next-FP8 weights
- `BasevLLMParameter.weight_loader` is a read-only property (no setter), so direct assignment fails for quantized models that use `ModelWeightParameter`
- Add `_override_weight_loader()` helper that detects whether the parameter uses a property-backed `_weight_loader` (quantized) or a plain attribute `weight_loader` (non-quantized) and assigns accordingly

Fixes #21638

## Test plan
- [x] Reproduced the bug on latest main with `Qwen/Qwen3-Coder-Next-FP8` (TP=2)
- [x] Verified FP8 model loads successfully with the fix
- [x] `test_qwen3_next_models.py` — all 4 tests pass (GSM8K accuracy + KL divergence + prefix cache branching) on H200

🤖 Generated with [Claude Code](https://claude.com/claude-code)