### PR TITLE
fix: suppress resource tracker in ShmPointerMMData to prevent shm race

### DIFF
--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -7,8 +7,9 @@ import hashlib
 import pickle
 from abc import abstractmethod
 from collections import defaultdict
-from multiprocessing import shared_memory
+from multiprocessing import resource_tracker, shared_memory
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
+from unittest.mock import patch
 
 import numpy as np
 import torch
@@ -1632,6 +1633,12 @@ class ShmPointerMMData:
     """
     Wraps a tensor to be sent via a shared memory handle.
     This acts as a "pointer" to the tensor data across process boundaries.
+
+    Lifecycle: tokenizer creates the segment, scheduler ranks open it by name
+    during deserialization, and materialize() clones + unlinks.  We suppress
+    Python's resource_tracker everywhere to prevent it from unlinking the
+    segment behind our back (same workaround used in shm_broadcast.py).
+    See https://stackoverflow.com/q/62748654/9191338.
     """
 
     def __init__(self, tensor: torch.Tensor):
@@ -1643,6 +1650,7 @@ class ShmPointerMMData:
         self.dtype = tensor.dtype
         nbytes = tensor.numel() * tensor.element_size()
         shm = shared_memory.SharedMemory(create=True, size=nbytes)
+        resource_tracker.unregister(shm._name, "shared_memory")
         try:
             dst = torch.frombuffer(shm.buf, dtype=torch.uint8)
             dst.copy_(tensor.view(torch.uint8).reshape(-1))
@@ -1666,8 +1674,11 @@ class ShmPointerMMData:
         self.shape = state["shape"]
         self.dtype = state["dtype"]
         self.shm = None
-        self._shm_handle = shared_memory.SharedMemory(name=self.shm_name)
-        # Zero-copy view into shared memory (no clone, no unlink)
+        with patch(
+            "multiprocessing.resource_tracker.register",
+            lambda *args, **kwargs: None,
+        ):
+            self._shm_handle = shared_memory.SharedMemory(name=self.shm_name)
         self.tensor = torch.frombuffer(self._shm_handle.buf, dtype=self.dtype).reshape(
             self.shape
         )
@@ -1685,7 +1696,6 @@ class ShmPointerMMData:
         return tensor
 
     def __del__(self):
-        # Only close; never unlink. Unlinking is materialize()'s job.
         if getattr(self, "_shm_handle", None) is not None:
             self._shm_handle.close()
             self._shm_handle = None


### PR DESCRIPTION
## Summary
- Suppress Python's `resource_tracker` in `ShmPointerMMData` to prevent POSIX shared memory segments from being unlinked before all TP ranks can open them
- Follows the existing workaround pattern used in `shm_broadcast.py` and `parallel_state.py` ([stackoverflow.com/q/62748654](https://stackoverflow.com/q/62748654/9191338))

## Root Cause

`ShmPointerMMData.__init__` (tokenizer side) creates a POSIX shm segment via `SharedMemory(create=True)`, which registers the name with Python's `resource_tracker`. After `shm.close()`, the tracker still owns the name. When the tracker performs cleanup (process exit, daemon disruption, or fd pressure), it calls `shm_unlink()` — deleting the segment while scheduler TP ranks still need it.

Similarly, `__setstate__` (scheduler side) opens the segment with `SharedMemory(name=...)`, which also registers with the local resource tracker, creating multiple trackers that each believe they own the segment.

The segment disappears between TP0 opening it (ZMQ recv) and TP1/2/3 opening it (during `broadcast_pyobj`), causing `FileNotFoundError` on non-root TP ranks.

## Fix
- `__init__`: call `resource_tracker.unregister()` immediately after creation
- `__setstate__`: suppress `resource_tracker.register` during open (matching `shm_broadcast.py` pattern)

## Reproduction

Any VLM model with TP>1 (no DP) under concurrent multimodal requests:

```bash
python3 -m sglang.launch_server \
  --model-path Qwen/Qwen3.5-397B-A17B-FP8 --tp 4 \
  --attention-backend=trtllm_mha --enable-multimodal \
  --trust-remote-code --host 0.0.0.0 --port 30000
# Then send 500+ concurrent MMMU-Pro requests via NeMo Skills
```

Observed on: Qwen3.5 FP8 TP4, Kimi-K2.5 NVFP4 TP4 (both crash on TP1/2/3 during multimodal accuracy eval). TP4+DP4+DPA is unaffected because multimodal work requests skip the TP broadcast path.

## Test plan
- [ ] Reproduce on GB300 with Qwen3.5 FP8 TP4 + MMMU-Pro eval
- [ ] Verify TP1/2/3 no longer crash with FileNotFoundError
- [ ] Verify TP4+DP4+DPA still works (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)