### PR TITLE
 [NPU][feature adapt] adp remote load weight   without pta support

### DIFF
--- a/python/sglang/srt/connector/remote_instance.py
+++ b/python/sglang/srt/connector/remote_instance.py
@@ -44,7 +44,10 @@ class RemoteInstanceConnector(BaseConnector):
         master_address = parsed_url.hostname
         master_port = parsed_url.port
         group_name = f"send_weights_{instance_ip}_{master_port}_{tp_rank}"
-        backend = "nccl"
+        if self.device.type == "cuda":
+            backend = "nccl"
+        elif self.device.type == "npu":
+            backend = "hccl"
 
         logger.info(
             f"init custom process group: master_address={master_address}, master_port={master_port}, "

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1794,8 +1794,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             device_id = torch.device("npu", self.gpu_id)
             backend = "hccl"
         else:
-            logger.error(f"Unsupported device: {self.device}. Only 'cuda' and 'npu' are supported.")
-            raise ValueError(f"Unsupported device: {self.device}. Only 'cuda' and 'npu' are supported.")
+            logger.error(
+                f"Unsupported device: {self.device}. Only 'cuda' and 'npu' are supported."
+            )
+            raise ValueError(
+                f"Unsupported device: {self.device}. Only 'cuda' and 'npu' are supported."
+            )
         try:
             na = NetworkAddress(master_address, group_port)
             self._weights_send_group[group_name] = init_custom_process_group(

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1787,6 +1787,15 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         torch.cuda.empty_cache()
         success = False
         message = ""
+        device_id = None
+        if self.device == "cuda":
+            device_id = torch.device("cuda", self.gpu_id)
+        elif self.device == "npu":
+            device_id = torch.device("npu", self.gpu_id)
+            backend = "hccl"
+        else:
+            logger.error(f"Unsupported device: {self.device}. Only 'cuda' and 'npu' are supported.")
+            raise ValueError(f"Unsupported device: {self.device}. Only 'cuda' and 'npu' are supported.")
         try:
             na = NetworkAddress(master_address, group_port)
             self._weights_send_group[group_name] = init_custom_process_group(
@@ -1795,7 +1804,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 world_size=world_size,
                 rank=group_rank,
                 group_name=group_name,
-                device_id=torch.device("cuda", self.gpu_id),
+                device_id=device_id,
             )
             dist.barrier(group=self._weights_send_group[group_name])
             success = True

--- a/test/registered/distributed/test_load_weights_from_remote_instance_npu.py
+++ b/test/registered/distributed/test_load_weights_from_remote_instance_npu.py
@@ -34,7 +34,9 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-DEFAULT_SMALL_MODEL_NAME_FOR_TEST = "/LLM-Research/Llama-3.2-1B-Instruct"  # Example ModelScope model
+DEFAULT_SMALL_MODEL_NAME_FOR_TEST = (
+    "/LLM-Research/Llama-3.2-1B-Instruct"  # Example ModelScope model
+)
 
 from sglang.utils import terminate_process
 

--- a/test/registered/distributed/test_load_weights_from_remote_instance_npu.py
+++ b/test/registered/distributed/test_load_weights_from_remote_instance_npu.py
@@ -27,13 +27,15 @@ import sglang as sgl
 from sglang.test.ci.ci_register import register_npu_ci
 from sglang.test.test_utils import (
     DEFAULT_PORT_FOR_SRT_TEST_RUNNER,
-    DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
     is_in_ci,
     popen_launch_server,
 )
+
+DEFAULT_SMALL_MODEL_NAME_FOR_TEST = "/LLM-Research/Llama-3.2-1B-Instruct"  # Example ModelScope model
+
 from sglang.utils import terminate_process
 
 mp.set_start_method("spawn", force=True)
@@ -42,7 +44,6 @@ register_npu_ci(
     est_time=400,
     suite="nightly-1-npu-a3",
     nightly=True,
-    disabled="run failed",
 )
 
 
@@ -216,6 +217,7 @@ def init_process_dst(
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             other_args=(
                 "--attention-backend",
+                "ascend",
                 "--device",
                 "npu",
                 "--base-gpu-id",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->
```shell
[2026-411172Inremort errrwhen1ing slangsrtmlsbaingmext:Nmodlenmed
[2026-04-10 13:17:24] I
Ignore 1mport errorwhen1oading sglangsrtmodels.midashenglm:Nomodule named 'torchaudio
[2826-4-112Ignreimerhedinsglansrdmndormdnmnd
[2026-04-18 13:17:24] L
 Load weight begin. avail mem=60.89 GB 
[2026-84-18 13:17:24] Loading weights from remote instance ...!
[2026-04-10 13:17:24] 1
init custmprcessgroutran=msteraddress=2mstprt=rornk=wdsze=rmdweghbacken
[26-nsrmadrssffseghbk
[2026-04-10 13:17:25]
Failed to initialize custom process group: Distributed package doesn't have NCCL built in.
[2026-04-10 13:17:25]
Failed to init group: Distributed package doesn't have NCCL built in.
[2026-04-18 13:17:25] I
INFO: 
127.0.0.1:35156 - *POST /init_weights_send-group-for_-remote_instance HTTP/1.1 400 Bad Request 
[2026-04-10 13:17:25] Scheduler hit an exception: Traceback (most recent cal1 last): 
File /usr/local/python311.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", 1line 3562, in run-scheduler-process 
 scheduler = Scheduler( 
AAAAAAAAAA
File "/usr/local/python3.1.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 382, in --init--
```
pta 接口 不支持 参数为 nccl 和 npu

## Motivation
+ fix  remote instance adapts to the NPU.
+ fix ut model path adpt modelscope

Run the following command and get the following result:
```shell
unset https_proxy
unset http_proxy
unset HTTPS_PROXY
unset HTTP_PROXY
source /usr/local/Ascend/ascend-toolkit/set_env.sh
source /usr/local/Ascend/nnal/atb/set_env.sh
export SGLANG_USE_MODELSCOPE=true
python -m unittest sglang-main/test/registered/distributed/test_load_weights_from_remote_instance_npu.py
```

```shell
[2026-01-31 07:59:26 TP0] max_total_num_tokens=654592, chunked_prefill_size=8192, max_prefill_tokens=16384, max_running_requests=2557, context_len=131072, available_gpu_mem=10.60 GB
[2026-01-31 07:59:27] INFO:     Started server process [436789]
[2026-01-31 07:59:27] INFO:     Waiting for application startup.
[2026-01-31 07:59:27] Using default chat sampling params from model generation config: {'repetition_penalty': 1.0, 'temperature': 0.6, 'top_k': 50, 'top_p': 0.9}
[2026-01-31 07:59:27] Using default chat sampling params from model generation config: {'repetition_penalty': 1.0, 'temperature': 0.6, 'top_k': 50, 'top_p': 0.9}
[2026-01-31 07:59:27] INFO:     Application startup complete.
[2026-01-31 07:59:27] INFO:     Uvicorn running on http://127.0.0.1:31002 (Press CTRL+C to quit)
[2026-01-31 07:59:28] INFO:     127.0.0.1:52000 - "GET /model_info HTTP/1.1" 200 OK
[2026-01-31 07:59:28 TP0] Prefill batch, #new-seq: 1, #new-token: 128, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, input throughput (token/s): 0.00, 
[2026-01-31 07:59:33] INFO:     127.0.0.1:52004 - "GET /health_generate HTTP/1.1" 503 Service Unavailable
[rank0]:[W131 07:59:38.575271730 compiler_depend.ts:3136] Warning: The indexFromRank 0is not equal indexFromCurDevice 8 , which might be normal if the number of devices on your collective communication server is inconsistent.Otherwise, you need to check if the current device is correct when calling the interface.If it's incorrect, it might have introduced an error. (function operator())
[rank1]:[W131 07:59:38.577284820 compiler_depend.ts:3136] Warning: The indexFromRank 1is not equal indexFromCurDevice 9 , which might be normal if the number of devices on your collective communication server is inconsistent.Otherwise, you need to check if the current device is correct when calling the interface.If it's incorrect, it might have introduced an error. (function operator())
[2026-01-31 07:59:40] INFO:     127.0.0.1:52002 - "POST /generate HTTP/1.1" 200 OK
[2026-01-31 07:59:40] The server is fired up and ready to roll!
[2026-01-31 07:59:43 TP0] Prefill batch, #new-seq: 1, #new-token: 128, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, input throughput (token/s): 8.72, 
[2026-01-31 07:59:44] INFO:     127.0.0.1:52006 - "GET /health_generate HTTP/1.1" 200 OK
[2026-01-31 07:59:56] INFO:     127.0.0.1:52008 - "GET /get_weights_by_name HTTP/1.1" 200 OK
[2026-01-31 07:59:56] INFO:     127.0.0.1:52010 - "GET /get_weights_by_name HTTP/1.1" 200 OK
[2026-01-31 07:59:57] INFO:     127.0.0.1:52012 - "GET /get_weights_by_name HTTP/1.1" 200 OK
[2026-01-31 07:59:57] INFO:     127.0.0.1:52014 - "GET /get_weights_by_name HTTP/1.1" 200 OK
[2026-01-31 07:59:57] INFO:     127.0.0.1:52016 - "GET /get_weights_by_name HTTP/1.1" 200 OK
[2026-01-31 07:59:58] INFO:     127.0.0.1:52018 - "GET /get_weights_by_name HTTP/1.1" 200 OK
[2026-01-31 07:59:59] INFO:     127.0.0.1:52020 - "GET /get_weights_by_name HTTP/1.1" 200 OK
[2026-01-31 08:00:00] INFO:     127.0.0.1:52024 - "GET /get_weights_by_name HTTP/1.1" 200 OK
[2026-01-31 08:00:02] INFO:     127.0.0.1:52028 - "GET /get_weights_by_name HTTP/1.1" 200 OK
[2026-01-31 08:00:02] INFO:     127.0.0.1:52032 - "GET /get_weights_by_name HTTP/1.1" 200 OK
[2026-01-31 08:00:02] INFO:     127.0.0.1:52034 - "GET /get_weights_by_name HTTP/1.1" 200 OK
.
----------------------------------------------------------------------
Ran 1 test in 1032.597s

OK
```


<!-- Describe the purpose and goals of this pull request. -->

## Modifications
+ fix  remote instance adapts to the NPU.
+ fix ut model path adpt modelscope
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
NA
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling
NA
<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [√ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [√ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [√ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [√ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [√ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
