### PR TITLE
Fix Forward hooks never fire on NemotronH decoder layers

### DIFF
--- a/python/sglang/srt/models/nemotron_h.py
+++ b/python/sglang/srt/models/nemotron_h.py
@@ -334,7 +334,7 @@ class NemotronHMLPDecoderLayer(nn.Module):
         else:
             hidden_states, residual = self.norm(hidden_states, residual)
 
-        hidden_states = self.mixer.forward(hidden_states)
+        hidden_states = self.mixer(hidden_states)
         return hidden_states, residual
 
 
@@ -370,7 +370,7 @@ class NemotronHMoEDecoderLayer(nn.Module):
         else:
             hidden_states, residual = self.norm(hidden_states, residual)
 
-        hidden_states = self.mixer.forward(hidden_states)
+        hidden_states = self.mixer(hidden_states)
         return hidden_states, residual
 
 
@@ -502,7 +502,7 @@ class NemotronHAttention(nn.Module):
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-        attn_output = self.attn.forward(q, k, v, forward_batch)
+        attn_output = self.attn(q, k, v, forward_batch)
         output, _ = self.o_proj(attn_output)
         return output
 
@@ -539,7 +539,7 @@ class NemotronHAttentionDecoderLayer(nn.Module):
         else:
             hidden_states, residual = self.norm(hidden_states, residual)
 
-        hidden_states = self.mixer.forward(
+        hidden_states = self.mixer(
             hidden_states=hidden_states, forward_batch=forward_batch
         )
         return hidden_states, residual
@@ -628,7 +628,7 @@ class NemotronHModel(nn.Module):
             layer = self.layers[i]
             if not isinstance(layer, Layers):
                 raise ValueError(f"Unknown layer type: {type(layer)}")
-            hidden_states, residual = layer.forward(
+            hidden_states, residual = layer(
                 hidden_states=hidden_states,
                 residual=residual,
                 forward_batch=forward_batch,
@@ -744,7 +744,7 @@ class NemotronHForCausalLM(nn.Module):
         input_embeds: Optional[torch.Tensor] = None,
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ):
-        hidden_states = self.model.forward(
+        hidden_states = self.model(
             input_ids, positions, forward_batch, pp_proxy_tensors, input_embeds
         )
         if self.pp_group.is_last_rank:


### PR DESCRIPTION
## Motivation

This PR solves issue #21686 

`register_forward_hook` only runs when a module is invoked through `nn.Module.__call__` (e.g. `layer(...)`). In `nemotron_h.py`, several `nn.Module` paths called `.forward(...)` directly, which skips `__call__` and therefore **never runs forward hooks** registered via `--forward-hooks` / `sgl.Engine(forward_hooks=...)`.

In practice, hooks matched on `model.layers.*` did not fire for NemotronH, while hooks on `logits_processor` still worked (that path already uses `__call__`). This breaks any feature that relies on forward hooks for NemotronH (debugging, activation capture, etc.).

## Modifications

In `python/sglang/srt/models/nemotron_h.py`, replace direct `nn.Module.forward(...)` calls with `module(...)` so hooks dispatch consistently:

| Location | Change |
|----------|--------|
| `NemotronHMLPDecoderLayer.forward` | `self.mixer.forward(hidden_states)` → `self.mixer(hidden_states)` |
| `NemotronHMoEDecoderLayer.forward` | same for MoE mixer |
| `NemotronHAttention.forward` | `self.attn.forward(q, k, v, forward_batch)` → `self.attn(q, k, v, forward_batch)` |
| `NemotronHAttentionDecoderLayer.forward` | `self.mixer.forward(...)` → `self.mixer(...)` |
| `NemotronHModel.forward` | `layer.forward(...)` → `layer(...)` |
| `NemotronHForCausalLM.forward` | `self.model.forward(...)` → `self.model(...)` |

**Intentionally unchanged:** `attn_backend.linear_attn_backend.forward(...)` in `_forward_mamba` — this is a backend API, not an `nn.Module` `forward` routed through `__call__`.

## Accuracy Tests

```
python3 -m sglang.test.few_shot_gsm8k --num-questions 200
Accuracy: 0.900
Invalid: 0.000
Latency: 14.978 s
Output throughput: 1610.991 token/s
```

## Speed Tests and Profiling

Previous code

```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 16        
Successful requests:                     80        
Benchmark duration (s):                  4.31      
Total input tokens:                      10573     
Total input text tokens:                 10573     
Total generated tokens:                  1221      
Total generated tokens (retokenized):    1177      
Request throughput (req/s):              18.57     
Input token throughput (tok/s):          2454.52   
Output token throughput (tok/s):         283.45    
Peak output token throughput (tok/s):    297.00    
Peak concurrent requests:                37        
Total token throughput (tok/s):          2737.97   
Concurrency:                             15.41     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   829.93    
Median E2E Latency (ms):                 753.20    
P90 E2E Latency (ms):                    1503.15   
P99 E2E Latency (ms):                    1856.55   
---------------Time to First Token----------------
Mean TTFT (ms):                          118.52    
Median TTFT (ms):                        103.93    
P99 TTFT (ms):                           220.35    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          49.11     
Median TPOT (ms):                        52.11     
P99 TPOT (ms):                           78.16     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           49.92     
Median ITL (ms):                         12.91     
P95 ITL (ms):                            143.03    
P99 ITL (ms):                            245.18    
Max ITL (ms):                            248.92    
==================================================
```

New code

```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 16        
Successful requests:                     80        
Benchmark duration (s):                  3.89      
Total input tokens:                      10573     
Total input text tokens:                 10573     
Total generated tokens:                  1221      
Total generated tokens (retokenized):    1177      
Request throughput (req/s):              20.58     
Input token throughput (tok/s):          2719.71   
Output token throughput (tok/s):         314.08    
Peak output token throughput (tok/s):    356.00    
Peak concurrent requests:                35        
Total token throughput (tok/s):          3033.79   
Concurrency:                             15.36     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   746.57    
Median E2E Latency (ms):                 673.06    
P90 E2E Latency (ms):                    1383.69   
P99 E2E Latency (ms):                    1639.89   
---------------Time to First Token----------------
Mean TTFT (ms):                          101.93    
Median TTFT (ms):                        88.89     
P99 TTFT (ms):                           159.72    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          43.99     
Median TPOT (ms):                        47.67     
P99 TPOT (ms):                           65.90     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           45.24     
Median ITL (ms):                         12.79     
P95 ITL (ms):                            136.36    
P99 ITL (ms):                            196.26    
Max ITL (ms):                            196.53    
==================================================
```

