### PR TITLE
[AMD] fix performance regression issue when run gpt-oss with "--context-length 13824"

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -2503,7 +2503,7 @@ class AiterAttnBackend(AttentionBackend):
 
                 o = torch.empty_like(q, dtype=self.input_dtype)
 
-                max_kv_len = page_table.shape[1]
+                max_kv_len = page_table.shape[1] * self.page_size
 
                 unified_attention(
                     q=q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Run gpt-oss model and set the context-length is lees than 32768, 
The E2E performance will have 40% drop

## Modifications

For the `unified_attention`, it will use the max_kv_len to decide what kernel is launched.

The condition is "max_seqlen_k <= 512" will select the `kernel_unified_attention_2d`, others will select the kernel `kernel_unified_attention_3d`.

In the current code logic, we don't consider the page_size factor, so the max_kv_len is `context-length/64` that is the pages not the real kv length. Need to consider the page_size and calculate the real kv length to select the correct launched kernel for decode attention.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

**Before issue fixed**
<img width="1206" height="801" alt="image" src="https://github.com/user-attachments/assets/1df8bda5-be08-4d65-a9cd-cb0b429fe18c" />

**After issue fixed**
<img width="1206" height="801" alt="image" src="https://github.com/user-attachments/assets/eda356ab-6c37-4439-a2dc-52a8ccd2a9a7" />


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
