### PR TITLE
[ROCm] Add RDNA3 consumer GPU support (gfx1100, gfx1103)

### DIFF
--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -3,6 +3,7 @@
 #   docker build --build-arg SGL_BRANCH=v0.5.9 --build-arg GPU_ARCH=gfx942-rocm720 -t v0.5.9-rocm720-mi30x -f rocm.Dockerfile .
 #   docker build --build-arg SGL_BRANCH=v0.5.9 --build-arg GPU_ARCH=gfx950 -t v0.5.9-rocm700-mi35x -f rocm.Dockerfile .
 #   docker build --build-arg SGL_BRANCH=v0.5.9 --build-arg GPU_ARCH=gfx950-rocm720 -t v0.5.9-rocm720-mi35x -f rocm.Dockerfile .
+#   docker build --build-arg SGL_BRANCH=v0.5.9 --build-arg GPU_ARCH=gfx1100 -t v0.5.9-rocm-rdna3-rx7900 -f rocm.Dockerfile .
 
 # Usage (to build SGLang ROCm + Mori docker image):
 #   docker build --build-arg SGL_BRANCH=v0.5.9 --build-arg GPU_ARCH=gfx942 --build-arg ENABLE_MORI=1 --build-arg NIC_BACKEND=ainic -t v0.5.9-rocm700-mi30x -f rocm.Dockerfile .
@@ -15,6 +16,9 @@ ARG BASE_IMAGE_942="rocm/sgl-dev:rocm7-vllm-20250904"
 ARG BASE_IMAGE_942_ROCM720="rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1"
 ARG BASE_IMAGE_950="rocm/sgl-dev:rocm7-vllm-20250904"
 ARG BASE_IMAGE_950_ROCM720="rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1"
+# RDNA3 consumer GPUs (RX 7900 XTX/XT, gfx1100) use ROCm 7.2 pytorch base image.
+# Note: gfx1103 (Radeon 780M iGPU) uses the same base image as gfx1100.
+ARG BASE_IMAGE_1100="rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1"
 
 # This is necessary for scope purpose
 ARG GPU_ARCH=gfx950
@@ -28,6 +32,7 @@ ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
 ENV AITER_COMMIT_DEFAULT="v0.1.11.post1"
+ENV SGLANG_USE_AITER="1"
 
 # ===============================
 # Base image 942 with rocm720 and args
@@ -38,6 +43,7 @@ ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
 ENV AITER_COMMIT_DEFAULT="v0.1.11.post1"
+ENV SGLANG_USE_AITER="1"
 
 # ===============================
 # Base image 950 and args
@@ -48,6 +54,7 @@ ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
 ENV AITER_COMMIT_DEFAULT="v0.1.11.post1"
+ENV SGLANG_USE_AITER="1"
 
 # ===============================
 # Base image 950 with rocm720 and args
@@ -58,6 +65,34 @@ ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
 ENV AITER_COMMIT_DEFAULT="v0.1.11.post1"
+ENV SGLANG_USE_AITER="1"
+
+# ===============================
+# Base image for RDNA3 consumer GPUs (gfx1100: RX 7900 XTX/XT, gfx1103: Radeon 780M iGPU)
+# RDNA3 limitations: no native FP8 hardware, AITER kernels do not compile/run on consumer GPUs.
+# AITER is fully disabled: BUILD_AITER_ALL=0, AITER_PREBUILD_KERNELS=0, SGLANG_USE_AITER=0.
+# BUILD_MOONCAKE is disabled as it requires data-center networking hardware (InfiniBand/RoCE).
+FROM $BASE_IMAGE_1100 AS gfx1100
+ENV BUILD_VLLM="0"
+ENV BUILD_TRITON="1"
+ENV BUILD_LLVM="0"
+# Disable AITER: kernels do not compile/run on RDNA3 consumer GPUs.
+ENV BUILD_AITER_ALL="0"
+ENV BUILD_MOONCAKE="0"
+ENV AITER_COMMIT_DEFAULT="v0.1.11.post1"
+ENV AITER_PREBUILD_KERNELS="0"
+ENV SGLANG_USE_AITER="0"
+
+# gfx1103 (Radeon 780M / Ryzen AI iGPU) uses the same base image and settings as gfx1100.
+FROM $BASE_IMAGE_1100 AS gfx1103
+ENV BUILD_VLLM="0"
+ENV BUILD_TRITON="1"
+ENV BUILD_LLVM="0"
+ENV BUILD_AITER_ALL="0"
+ENV BUILD_MOONCAKE="0"
+ENV AITER_COMMIT_DEFAULT="v0.1.11.post1"
+ENV AITER_PREBUILD_KERNELS="0"
+ENV SGLANG_USE_AITER="0"
 
 # ===============================
 # Chosen arch and args
@@ -66,7 +101,7 @@ FROM ${GPU_ARCH}
 # This is necessary for scope purpose, again
 ARG GPU_ARCH=gfx950
 ENV GPU_ARCH_LIST=${GPU_ARCH%-*}
-ENV PYTORCH_ROCM_ARCH=gfx942;gfx950
+ENV PYTORCH_ROCM_ARCH=gfx942;gfx950;gfx1100;gfx1103
 
 ARG SGL_REPO="https://github.com/sgl-project/sglang.git"
 ARG SGL_DEFAULT="main"
@@ -545,8 +580,11 @@ ENV SGLANG_MOE_PADDING=1
 ENV SGLANG_ROCM_DISABLE_LINEARQUANT=0
 ENV SGLANG_ROCM_FUSED_DECODE_MLA=1
 ENV SGLANG_SET_CPU_AFFINITY=1
-ENV SGLANG_USE_AITER=1
 ENV SGLANG_USE_ROCM700A=1
+
+# SGLANG_USE_AITER is set per-arch in the multi-stage build above:
+# CDNA stages (gfx942, gfx950) inherit the default SGLANG_USE_AITER=1,
+# RDNA3 stages (gfx1100, gfx1103) explicitly set SGLANG_USE_AITER=0.
 
 ENV NCCL_MIN_NCHANNELS=112
 ENV ROCM_QUICK_REDUCE_QUANTIZATION=INT8

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -258,14 +258,12 @@ class RMSNorm(MultiPlatformOp):
             # NOTE: Remove this if aiter kernel supports discontinuous input
             x = x.contiguous()
         if residual is not None:
-            out = torch.empty_like(x)
-            residual_out = torch.empty_like(x)
             if post_residual_addition is not None:
                 residual = residual + post_residual_addition
-            fused_add_rms_norm(
-                out, x, residual_out, residual, self.weight.data, self.variance_epsilon
-            )
-            return out, residual_out
+            # vllm API: fused_add_rms_norm(x, residual, weight, eps) modifies x and residual
+            # in-place: x becomes the normalized output, residual becomes x+residual.
+            fused_add_rms_norm(x, residual, self.weight.data, self.variance_epsilon)
+            return x, residual
         out = torch.empty_like(x)
         rms_norm(out, x, self.weight.data, self.variance_epsilon)
         return out
@@ -520,19 +518,17 @@ class GemmaRMSNorm(MultiPlatformOp):
                 return output, residual_out
             return rms_norm(x, w, self.variance_epsilon)
         else:
-            # vllm API: rms_norm(out, input, weight, eps) -> None (in-place)
-            #           fused_add_rms_norm(out, input, residual_out, residual, weight, eps)
+            # vllm API (in-place):
+            #   rms_norm(out, input, weight, eps) -> None
+            #   fused_add_rms_norm(input, residual, weight, eps) -> None
+            #     input becomes normalized output, residual becomes input+residual
             if not x.is_contiguous():
                 x = x.contiguous()
             if residual is not None:
-                out = torch.empty_like(x)
-                residual_out = torch.empty_like(x)
                 if post_residual_addition is not None:
                     residual = residual + post_residual_addition
-                fused_add_rms_norm(
-                    out, x, residual_out, residual, w, self.variance_epsilon
-                )
-                return out, residual_out
+                fused_add_rms_norm(x, residual, w, self.variance_epsilon)
+                return x, residual
             out = torch.empty_like(x)
             rms_norm(out, x, w, self.variance_epsilon)
             return out

--- a/sgl-kernel/setup_rocm.py
+++ b/sgl-kernel/setup_rocm.py
@@ -72,21 +72,42 @@ if torch.cuda.is_available():
 else:
     print(f"Warning: torch.cuda not available. Using default target: {amdgpu_target}")
 
-if amdgpu_target not in ["gfx942", "gfx950"]:
+# Supported GPU architectures:
+# - gfx942: AMD Instinct MI300X/MI325X (data-center, full FP8 + AITER support)
+# - gfx950: AMD Instinct MI350X (data-center, full FP8 + AITER support)
+# - gfx1100: AMD Radeon RX 7900 XTX/XT/GRE (RDNA3 consumer, no native FP8, no AITER)
+# - gfx1103: AMD Radeon 780M / Ryzen AI iGPU (RDNA3 consumer, no native FP8, no AITER)
+_supported_targets = ["gfx942", "gfx950", "gfx1100", "gfx1103"]
+
+# RDNA3 consumer GPUs lack FP8 hardware and AITER kernel support.
+_rdna3_targets = ["gfx1100", "gfx1103"]
+
+if amdgpu_target not in _supported_targets:
     print(
-        f"Warning: Unsupported GPU architecture detected '{amdgpu_target}'. Expected 'gfx942' or 'gfx950'."
+        f"Warning: Unsupported GPU architecture detected '{amdgpu_target}'. "
+        f"Expected one of: {', '.join(_supported_targets)}."
     )
     sys.exit(1)
 
-fp8_macro = (
-    "-DHIP_FP8_TYPE_FNUZ" if amdgpu_target == "gfx942" else "-DHIP_FP8_TYPE_E4M3"
-)
+# FP8 is only supported on CDNA3 (gfx942/gfx950) data-center GPUs.
+# RDNA3 consumer GPUs (gfx1100, gfx1103) have no FP8 hardware support.
+enable_fp8 = amdgpu_target not in _rdna3_targets
+
+if enable_fp8:
+    fp8_macro = (
+        "-DHIP_FP8_TYPE_FNUZ" if amdgpu_target == "gfx942" else "-DHIP_FP8_TYPE_E4M3"
+    )
+else:
+    fp8_macro = None
 
 # Dynamic shared-memory budget for the TopK kernels.
 # - gfx942 (MI300/MI325): LDS is typically 64KB per workgroup -> keep dynamic smem <= ~48KB
 #   (leaves room for static shared allocations in the kernel).
 # - gfx95x (MI350): LDS is larger (e.g. 160KB per CU) -> allow the original 128KB dynamic smem.
-topk_dynamic_smem_bytes = 48 * 1024 if amdgpu_target == "gfx942" else 32 * 1024 * 4
+# - gfx110x (RDNA3): LDS is 64KB per workgroup, same budget as gfx942.
+topk_dynamic_smem_bytes = (
+    48 * 1024 if amdgpu_target in ["gfx942"] + _rdna3_targets else 32 * 1024 * 4
+)
 
 hipcc_flags = [
     "-DNDEBUG",
@@ -97,10 +118,11 @@ hipcc_flags = [
     "-std=c++17",
     f"--amdgpu-target={amdgpu_target}",
     "-DENABLE_BF16",
-    "-DENABLE_FP8",
-    fp8_macro,
     f"-DSGL_TOPK_DYNAMIC_SMEM_BYTES={topk_dynamic_smem_bytes}",
 ]
+
+if enable_fp8:
+    hipcc_flags += ["-DENABLE_FP8", fp8_macro]
 
 ext_modules = [
     CUDAExtension(


### PR DESCRIPTION
## Summary

Add support for consumer RDNA 3 GPUs (gfx1100: RX 7900 series, gfx1103: Radeon 780M iGPU) to SGLang's ROCm build pipeline and runtime.

## Motivation

SGLang currently only supports datacenter AMD GPUs (gfx942/MI300, gfx950/MI350). Consumer RDNA 3 GPUs are blocked at build time by `setup_rocm.py` calling `sys.exit(1)` for any unsupported target. Multiple community PRs (#19165, #17957) have attempted to add this but remain unmerged. This PR provides a clean, complete implementation.

## Changes

### 1. `sgl-kernel/setup_rocm.py` — Build system
- Add `gfx1100` and `gfx1103` to `_supported_targets`
- Disable FP8 macros for RDNA3 (no native FP8 hardware)
- Set correct shared memory budget (48KB for RDNA3)

### 2. `docker/rocm.Dockerfile` — Docker support
- Add `gfx1100` and `gfx1103` multi-stage build targets using stable `rocm/pytorch:rocm7.2` base image
- Disable AITER for RDNA3 (`BUILD_AITER_ALL=0`, `AITER_PREBUILD_KERNELS=0`, `SGLANG_USE_AITER=0`) - AITER kernels produce invalid instruction errors on consumer GPUs
- Disable Mooncake for RDNA3 (requires InfiniBand/RoCE networking)
- Set `SGLANG_USE_AITER` per-arch in each Docker stage (not via runtime hack) so the correct value is baked into the image

### 3. `python/sglang/srt/layers/layernorm.py` — Runtime bugfix
- Fix `RMSNorm.forward_hip` and `GemmaRMSNorm.forward_hip` vllm fallback paths: the 6-arg `fused_add_rms_norm()` call was wrong - the vllm API is 4-arg in-place (`fused_add_rms_norm(input, residual, weight, eps)`)
- This was dead code on CDNA (AITER always enabled) but crashes on RDNA3 where AITER is disabled and the vllm fallback is exercised

## How this differs from existing PRs

| | PR #17957 | PR #19165 | This PR |
|---|---|---|---|
| gfx1103 support | No | No | Yes |
| Base image | Custom vllm-dev | nightly rocm | Stable `rocm/pytorch:rocm7.2` |
| AITER on RDNA3 | Runtime disable | PREBUILD=0 only | Fully disabled (build + runtime) |
| Mooncake on RDNA3 | Enabled | Enabled | Disabled |
| Layernorm bugfix | No | No | Yes (vllm fallback path) |
| SGLANG_USE_AITER | Not addressed | Not addressed | Per-arch Docker ENV |

## Test commands run

```bash
pre-commit run --files docker/rocm.Dockerfile python/sglang/srt/layers/layernorm.py sgl-kernel/setup_rocm.py
# Result: All 14 hooks passed (isort, ruff, black, codespell, etc.)

# FP8 gating logic verified:
# gfx1100 -> enable_fp8=False, gfx1103 -> enable_fp8=False
# gfx942 -> enable_fp8=True, gfx950 -> enable_fp8=True
```

## Known limitations

- RDNA3 has no native FP8 hardware - FP8 quantization is disabled
- Vision models using MIOpen convolution may hang on first invocation (MIOpen lacks solver DBs for consumer GPUs)
- Tested with text models; multimodal/vision models need further validation on hardware

## AI assistance disclosure

AI assistance was used (Claude) for implementation. All changed lines reviewed by human submitter.
