### PR TITLE
Fix dispatch imbalance in DP under total_tokens load balancing

### DIFF
--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -90,7 +90,7 @@ class DPBudget:
             self.total_requests[load.dp_rank] = load.num_reqs
             self.total_tokens[load.dp_rank] = load.num_tokens
 
-    def dispatch(self, method: LoadBalanceMethod):
+    def dispatch(self, method: LoadBalanceMethod,req: Req =None):
         if method == LoadBalanceMethod.TOTAL_REQUESTS:
             target_rank = self.total_requests.index(min(self.total_requests))
         elif method == LoadBalanceMethod.TOTAL_TOKENS:
@@ -104,6 +104,8 @@ class DPBudget:
 
         # Increment the load of that worker by one as a heuristic
         self.total_requests[target_rank] += 1
+        if req is not None:
+          self.total_tokens[target_rank] += len(req.input_ids)
         return target_rank
 
 
@@ -557,7 +559,7 @@ class DataParallelController:
     def total_tokens_scheduler(self, req: Req):
         if self.maybe_external_dp_rank_routing(req):
             return
-        target_worker = self.dp_budget.dispatch(LoadBalanceMethod.TOTAL_TOKENS)
+        target_worker = self.dp_budget.dispatch(LoadBalanceMethod.TOTAL_TOKENS,req=req)
         self.workers[target_worker].send_pyobj(req)
 
     def event_loop(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Under `--load-balance-method total_tokens`, DPBudget relies on asynchronous worker-side load updates to estimate the current load of each DP rank.

However, dispatch decisions are made synchronously, while load updates are delayed. This leads to systematic load underestimation during burst traffic, especially under DP Attention mode.

This results in incorrect dispatch decisions where multiple requests are routed to the same DP rank, leading to load imbalance and degraded TTFT.

## Modifications

We introduce a minimal optimistic update to `DPBudget.dispatch()`:

```python
if req is not None:
    self.total_tokens[target_rank] += len(req.input_ids)
```
## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

We evaluate the change under burst request scenarios with DP Attention enabled.

Before:

Requests are frequently routed to the same DP rank due to stale load estimation
TTFT degradation under burst traffic
<img width="1426" height="391" alt="image" src="https://github.com/user-attachments/assets/89bbd6b1-0e16-45e0-8566-5b459aba0551" />
<img width="777" height="936" alt="image" src="https://github.com/user-attachments/assets/91f63ae3-bdac-4ef7-bedd-bdc0bc00662d" />


After:

Requests are more evenly distributed across DP ranks
TTFT improved
<img width="1121" height="368" alt="image" src="https://github.com/user-attachments/assets/3663e844-1926-4203-be51-acbf1fd457e2" />
<img width="847" height="817" alt="image" src="https://github.com/user-attachments/assets/2a646aaf-4029-4623-a7aa-ad8e3e13dc68" />


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
