### PR TITLE
feat(eviction): add T-LRU (Tail-Optimized LRU) cache eviction policy

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -729,6 +729,8 @@ class Scheduler(
                 else self.tp_cpu_group
             ),
             eviction_policy=server_args.radix_eviction_policy,
+            tlru_xi_tokens=server_args.tlru_xi_tokens,
+            tlru_qhat_tokens=server_args.tlru_qhat_tokens,
             enable_metrics=self.enable_metrics,
             enable_kv_cache_events=self.enable_kv_cache_events,
             enable_mamba_extra_buffer=server_args.enable_mamba_extra_buffer(),

--- a/python/sglang/srt/mem_cache/cache_init_params.py
+++ b/python/sglang/srt/mem_cache/cache_init_params.py
@@ -34,5 +34,9 @@ class CacheInitParams:
 
     sliding_window_size: Optional[int] = None
 
+    # T-LRU parameters (Tail-Optimized LRU, arXiv:2510.15152)
+    tlru_xi_tokens: Optional[int] = None  # SLA latency threshold in tokens; None = disabled
+    tlru_qhat_tokens: int = 200  # estimated next prompt length in tokens
+
     # Time-to-live for cache entries in seconds. If None, TTL is disabled.
     cache_ttl_seconds: Optional[float] = None

--- a/python/sglang/srt/mem_cache/cache_init_params.py
+++ b/python/sglang/srt/mem_cache/cache_init_params.py
@@ -35,7 +35,9 @@ class CacheInitParams:
     sliding_window_size: Optional[int] = None
 
     # T-LRU parameters (Tail-Optimized LRU, arXiv:2510.15152)
-    tlru_xi_tokens: Optional[int] = None  # SLA latency threshold in tokens; None = disabled
+    tlru_xi_tokens: Optional[int] = (
+        None  # SLA latency threshold in tokens; None = disabled
+    )
     tlru_qhat_tokens: int = 200  # estimated next prompt length in tokens
 
     # Time-to-live for cache entries in seconds. If None, TTL is disabled.

--- a/python/sglang/srt/mem_cache/evict_policy.py
+++ b/python/sglang/srt/mem_cache/evict_policy.py
@@ -12,6 +12,15 @@ class EvictionStrategy(ABC):
     def get_priority(self, node: "TreeNode") -> Union[float, Tuple]:
         pass
 
+    def get_cascade_priority(self, node: "TreeNode") -> Union[float, Tuple]:
+        """Priority for nodes that became evictable because their children were evicted.
+
+        In a radix tree, such nodes are shared prefixes — not conversation tails.
+        Subclasses may override this to handle cascade nodes differently from
+        direct eviction candidates. Default: same as get_priority.
+        """
+        return self.get_priority(node)
+
 
 class LRUStrategy(EvictionStrategy):
     def get_priority(self, node: "TreeNode") -> float:
@@ -63,3 +72,41 @@ class SLRUStrategy(EvictionStrategy):
 
         is_protected = 1 if node.hit_count >= self.protected_threshold else 0
         return (is_protected, node.last_access_time)
+
+
+class TLRUStrategy(EvictionStrategy):
+    """Tail-Optimized LRU: evicts TEL-safe blocks first, then falls back to LRU.
+
+    A block is TEL-safe if evicting it won't cause the next turn's TTFT to exceed
+    the latency threshold xi. See arXiv:2510.15152 for details.
+
+    Args:
+        xi: SLA latency threshold in tokens. Conversations whose next turn would
+            still be under this threshold after eviction are TEL-safe.
+        q_hat: Estimated next prompt length in tokens.
+    """
+
+    def __init__(self, xi: int, q_hat: int):
+        self.xi = xi
+        self.q_hat = q_hat
+
+    def get_priority(self, node: "TreeNode") -> Tuple[int, float]:
+        L = node.cumulative_tokens
+        B = max(0, L + self.q_hat - self.xi)
+        node_start = L - len(node.value)
+
+        is_tel_safe = node_start >= B
+
+        # (0, time) for TEL-safe → evicted first; (1, time) for protected → evicted second
+        # Within each group, standard LRU ordering (older time = evicted first)
+        return (0 if is_tel_safe else 1, node.last_access_time)
+
+    def get_cascade_priority(self, node: "TreeNode") -> Tuple[int, float]:
+        """Cascade nodes are shared prefixes whose children were evicted — not conversation tails.
+
+        The paper's T-LRU (Algorithm 1) only marks conversation-level tail blocks as TEL-safe.
+        A shared prefix node's cumulative_tokens underestimates the actual conversation history
+        length (L), which would incorrectly classify it as TEL-safe. We fall back to protected/LRU
+        priority to avoid evicting shared prefixes before actual conversation tails.
+        """
+        return (1, node.last_access_time)

--- a/python/sglang/srt/mem_cache/evict_policy.py
+++ b/python/sglang/srt/mem_cache/evict_policy.py
@@ -93,7 +93,7 @@ class TLRUStrategy(EvictionStrategy):
     def get_priority(self, node: "TreeNode") -> Tuple[int, float]:
         L = node.cumulative_tokens
         B = max(0, L + self.q_hat - self.xi)
-        node_start = L - len(node.value)
+        node_start = L - len(node.key)
 
         is_tel_safe = node_start >= B
 

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -333,6 +333,14 @@ class RadixCache(BasePrefixCache):
         elif self.eviction_policy == "slru":
             self.eviction_strategy: EvictionStrategy = SLRUStrategy()
         elif self.eviction_policy == "tlru":
+            if params.tlru_xi_tokens is None:
+                logger.warning(
+                    "T-LRU eviction policy selected but --tlru-xi-tokens is "
+                    "not set. Defaulting xi=0, which makes B = L + q_hat "
+                    "(all blocks protected) and degenerates T-LRU to plain "
+                    "LRU. Set --tlru-xi-tokens to your SLA threshold for "
+                    "T-LRU to have an effect."
+                )
             self.eviction_strategy: EvictionStrategy = TLRUStrategy(
                 xi=params.tlru_xi_tokens or 0,
                 q_hat=params.tlru_qhat_tokens,

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -61,6 +61,7 @@ from sglang.srt.mem_cache.evict_policy import (
     MRUStrategy,
     PriorityStrategy,
     SLRUStrategy,
+    TLRUStrategy,
 )
 from sglang.srt.mem_cache.hicache_storage import get_hash_str, hash_str_to_int64
 
@@ -145,6 +146,9 @@ class TreeNode:
         self.hash_value: Optional[List[str]] = None
         # priority for priority-aware eviction
         self.priority = priority
+        # total number of tokens from root to this node (inclusive),
+        # used by T-LRU to compute TEL-safe eviction priority
+        self.cumulative_tokens = 0
 
         self.id = TreeNode.counter if id is None else id
         TreeNode.counter += 1
@@ -328,10 +332,15 @@ class RadixCache(BasePrefixCache):
             self.eviction_strategy: EvictionStrategy = PriorityStrategy()
         elif self.eviction_policy == "slru":
             self.eviction_strategy: EvictionStrategy = SLRUStrategy()
+        elif self.eviction_policy == "tlru":
+            self.eviction_strategy: EvictionStrategy = TLRUStrategy(
+                xi=params.tlru_xi_tokens or 0,
+                q_hat=params.tlru_qhat_tokens,
+            )
 
         else:
             raise ValueError(
-                f"Unknown eviction policy: {self.eviction_policy}. Supported policies: 'lru', 'lfu', 'fifo', 'mru', 'filo', 'priority', 'slru'."
+                f"Unknown eviction policy: {self.eviction_policy}. Supported policies: 'lru', 'lfu', 'fifo', 'mru', 'filo', 'priority', 'slru', 'tlru'."
             )
 
         self.evictable_leaves = set()
@@ -604,7 +613,9 @@ class RadixCache(BasePrefixCache):
             self._delete_leaf(x)
 
             if len(x.parent.children) == 0 and x.parent.lock_ref == 0:
-                new_priority = self.eviction_strategy.get_priority(x.parent)
+                new_priority = self.eviction_strategy.get_cascade_priority(
+                    x.parent
+                )
                 heapq.heappush(eviction_heap, (new_priority, x.parent))
 
             self._record_remove_event(x)
@@ -704,9 +715,11 @@ class RadixCache(BasePrefixCache):
         new_node.lock_ref = child.lock_ref
         new_node.key = child.key[:split_len]
         new_node.value = child.value[:split_len].clone()
+        new_node.cumulative_tokens = child.parent.cumulative_tokens + split_len
         child.parent = new_node
         child.key = child.key[split_len:]
         child.value = child.value[split_len:].clone()
+        # child.cumulative_tokens stays unchanged (total depth is the same)
         new_node.parent.children[self.get_child_key_fn(key)] = new_node
 
         # Split hash_value if it was already computed, otherwise leave as None
@@ -769,6 +782,7 @@ class RadixCache(BasePrefixCache):
             new_node.parent = node
             new_node.key = key
             new_node.value = value.clone()
+            new_node.cumulative_tokens = node.cumulative_tokens + len(key)
             self._inc_hit_count(new_node, chunked)
             node.children[child_key] = new_node
             self.evictable_size_ += len(key)

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -613,9 +613,7 @@ class RadixCache(BasePrefixCache):
             self._delete_leaf(x)
 
             if len(x.parent.children) == 0 and x.parent.lock_ref == 0:
-                new_priority = self.eviction_strategy.get_cascade_priority(
-                    x.parent
-                )
+                new_priority = self.eviction_strategy.get_cascade_priority(x.parent)
                 heapq.heappush(eviction_heap, (new_priority, x.parent))
 
             self._record_remove_event(x)
@@ -655,7 +653,7 @@ class RadixCache(BasePrefixCache):
             if node.parent is None:
                 assert (
                     node is self.root_node
-                ), f"This request holds the node from another tree"
+                ), "This request holds the node from another tree"
             node = node.parent
         return DecLockRefResult(delta=delta)
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -173,7 +173,7 @@ NSA_CHOICES = [
     "trtllm",
 ]
 
-RADIX_EVICTION_POLICY_CHOICES = ["lru", "lfu", "slru"]
+RADIX_EVICTION_POLICY_CHOICES = ["lru", "lfu", "slru", "tlru"]
 
 RL_ON_POLICY_TARGET_CHOICES = ["fsdp"]
 
@@ -356,6 +356,8 @@ class ServerArgs:
     swa_full_tokens_ratio: float = 0.8
     disable_hybrid_swa_memory: bool = False
     radix_eviction_policy: str = "lru"
+    tlru_xi_tokens: Optional[int] = None
+    tlru_qhat_tokens: int = 200
     enable_prefill_delayer: bool = False
     prefill_delayer_max_delay_passes: int = 30
     prefill_delayer_token_usage_low_watermark: Optional[float] = None
@@ -3974,7 +3976,19 @@ class ServerArgs:
             type=str,
             choices=RADIX_EVICTION_POLICY_CHOICES,
             default=ServerArgs.radix_eviction_policy,
-            help="The eviction policy of radix trees. 'lru' stands for Least Recently Used, 'lfu' stands for Least Frequently Used, and 'slru' stands for Segmented Least Recently Used.",
+            help="The eviction policy of radix trees. 'lru' stands for Least Recently Used, 'lfu' stands for Least Frequently Used, 'slru' stands for Segmented Least Recently Used, and 'tlru' stands for Tail-Optimized LRU (arXiv:2510.15152).",
+        )
+        parser.add_argument(
+            "--tlru-xi-tokens",
+            type=int,
+            default=ServerArgs.tlru_xi_tokens,
+            help="SLA latency threshold in tokens for T-LRU eviction policy. Conversations whose next turn would still be under this threshold after eviction are considered TEL-safe and evicted first. Only used when --radix-eviction-policy=tlru.",
+        )
+        parser.add_argument(
+            "--tlru-qhat-tokens",
+            type=int,
+            default=ServerArgs.tlru_qhat_tokens,
+            help="Estimated next prompt length in tokens for T-LRU eviction policy. Used to compute the TEL-safe budget per conversation. Only used when --radix-eviction-policy=tlru.",
         )
         parser.add_argument(
             "--enable-prefill-delayer",

--- a/test/registered/unit/mem_cache/test_radix_cache_tlru.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_tlru.py
@@ -1,0 +1,273 @@
+import time
+import unittest
+
+import torch
+
+from sglang.srt.mem_cache.allocator import TokenToKVPoolAllocator
+from sglang.srt.mem_cache.base_prefix_cache import (
+    EvictParams,
+    InsertParams,
+    MatchPrefixParams,
+)
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool, ReqToTokenPool
+from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey, TreeNode
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=5, suite="stage-b-test-1-gpu-small")
+
+
+def _make_cache(size, eviction_policy="tlru", xi=None, q_hat=200):
+    device = "cpu"
+    dtype = torch.float16
+    kv_cache = MHATokenToKVPool(
+        size=size,
+        page_size=1,
+        dtype=dtype,
+        head_num=8,
+        head_dim=64,
+        layer_num=1,
+        device=device,
+        enable_memory_saver=False,
+    )
+    token_to_kv_pool = TokenToKVPoolAllocator(
+        size=size, dtype=dtype, device=device, kvcache=kv_cache, need_sort=False
+    )
+    req_to_token_pool = ReqToTokenPool(
+        size=8, max_context_len=1024, device=device, enable_memory_saver=False
+    )
+    params = CacheInitParams(
+        disable=False,
+        req_to_token_pool=req_to_token_pool,
+        token_to_kv_pool_allocator=token_to_kv_pool,
+        page_size=1,
+        eviction_policy=eviction_policy,
+        tlru_xi_tokens=xi,
+        tlru_qhat_tokens=q_hat,
+        enable_kv_cache_events=False,
+    )
+    return RadixCache(params)
+
+
+class TestTLRUCumulativeTokens(unittest.TestCase):
+    """Test that cumulative_tokens is tracked correctly on tree nodes."""
+
+    def test_root_cumulative_tokens(self):
+        cache = _make_cache(size=20, xi=500, q_hat=200)
+        self.assertEqual(cache.root_node.cumulative_tokens, 0)
+
+    def test_single_insert_cumulative_tokens(self):
+        cache = _make_cache(size=20, xi=500, q_hat=200)
+        key = RadixKey(token_ids=[1, 2, 3, 4, 5], extra_key=None)
+        val = torch.arange(5, dtype=torch.int64)
+        cache.insert(InsertParams(key=key, value=val))
+
+        # The inserted node should have cumulative_tokens = 5
+        child_key = key.token_ids[0]
+        node = cache.root_node.children[child_key]
+        self.assertEqual(node.cumulative_tokens, 5)
+
+    def test_shared_prefix_cumulative_tokens(self):
+        cache = _make_cache(size=20, xi=500, q_hat=200)
+
+        # Insert [1,2,3,4,5]
+        key1 = RadixKey(token_ids=[1, 2, 3, 4, 5], extra_key=None)
+        val1 = torch.arange(5, dtype=torch.int64)
+        cache.insert(InsertParams(key=key1, value=val1))
+
+        # Insert [1,2,3,6,7] — shares prefix [1,2,3] with key1
+        key2 = RadixKey(token_ids=[1, 2, 3, 6, 7], extra_key=None)
+        val2 = torch.arange(5, dtype=torch.int64) + 10
+        cache.insert(InsertParams(key=key2, value=val2))
+
+        # After split, the shared prefix node [1,2,3] should have cumulative_tokens=3
+        prefix_node = cache.root_node.children[1]
+        self.assertEqual(len(prefix_node.key), 3)
+        self.assertEqual(prefix_node.cumulative_tokens, 3)
+
+        # Both children should have cumulative_tokens=5
+        for child in prefix_node.children.values():
+            self.assertEqual(child.cumulative_tokens, 5)
+
+
+class TestTLRUEviction(unittest.TestCase):
+    """Test the T-LRU eviction policy behavior."""
+
+    def test_tel_safe_evicted_first(self):
+        """Long conversation tail (TEL-safe) should be evicted before short conversation (protected)."""
+        # Cache size = 10 tokens
+        # xi = 5, q_hat = 2
+        # For a conversation of length L:
+        #   B = max(0, L + 2 - 5) = max(0, L - 3)
+        #   TEL-safe if node_start >= B
+        cache = _make_cache(size=10, xi=5, q_hat=2)
+
+        # Insert a long conversation: [1,2,3,4,5,6] (L=6, B=max(0,6+2-5)=3)
+        # Tokens at positions [0,1,2] are protected, [3,4,5] are TEL-safe
+        long_key = RadixKey(token_ids=[1, 2, 3, 4, 5, 6], extra_key=None)
+        long_val = torch.arange(6, dtype=torch.int64)
+        cache.insert(InsertParams(key=long_key, value=long_val))
+
+        # Small delay to ensure different access times
+        time.sleep(0.01)
+
+        # Insert a short conversation: [10,11] (L=2, B=max(0,2+2-5)=0)
+        # B=0, so all blocks are TEL-safe too, but let's use a case where short is protected
+        # Actually with L=2, q_hat=2, xi=5: B=max(0,2+2-5)=0, so all TEL-safe
+        # Let's use xi=3, q_hat=2 instead for clearer distinction
+        # Or better: use a short conversation that is protected
+        # For L=2, xi=5, q_hat=2: B=0 → all TEL-safe (node_start=0 >= 0)
+        # For L=6, xi=5, q_hat=2: B=3 → tokens [3,5] are TEL-safe
+        # Both are TEL-safe at the node level since entire node is one leaf
+
+        # Let's create a scenario where one conv is clearly TEL-safe and another is protected
+        # Use xi=3, q_hat=1
+        cache2 = _make_cache(size=10, xi=3, q_hat=1)
+
+        # Conv A: [1,2,3,4,5] (L=5, B=max(0,5+1-3)=3, node_start=0 < 3 → protected)
+        conv_a = RadixKey(token_ids=[1, 2, 3, 4, 5], extra_key=None)
+        val_a = torch.arange(5, dtype=torch.int64)
+        cache2.insert(InsertParams(key=conv_a, value=val_a))
+        time.sleep(0.01)
+
+        # Conv B: [10,11] (L=2, B=max(0,2+1-3)=0, node_start=0 >= 0 → TEL-safe)
+        conv_b = RadixKey(token_ids=[10, 11], extra_key=None)
+        val_b = torch.arange(2, dtype=torch.int64) + 100
+        cache2.insert(InsertParams(key=conv_b, value=val_b))
+        time.sleep(0.01)
+
+        # Conv C: [20,21,22] (L=3, B=max(0,3+1-3)=1, node_start=0 < 1 → protected)
+        conv_c = RadixKey(token_ids=[20, 21, 22], extra_key=None)
+        val_c = torch.arange(3, dtype=torch.int64) + 200
+        cache2.insert(InsertParams(key=conv_c, value=val_c))
+
+        # Total cached: 5+2+3=10 (full). Evict 2 tokens.
+        # Conv B (TEL-safe, node_start=0 >= B=0) should be evicted first.
+        cache2.evict(EvictParams(num_tokens=2))
+
+        # Conv B should be evicted (TEL-safe)
+        match_b = cache2.match_prefix(MatchPrefixParams(key=conv_b))
+        self.assertEqual(match_b.device_indices.numel(), 0, "TEL-safe conv B should be evicted")
+
+        # Conv A should still be present (protected)
+        match_a = cache2.match_prefix(MatchPrefixParams(key=conv_a))
+        self.assertTrue(match_a.device_indices.numel() > 0, "Protected conv A should be retained")
+
+        # Conv C should still be present (protected)
+        match_c = cache2.match_prefix(MatchPrefixParams(key=conv_c))
+        self.assertTrue(match_c.device_indices.numel() > 0, "Protected conv C should be retained")
+
+    def test_lru_fallback_when_no_tel_safe(self):
+        """When all conversations are protected (no TEL-safe), fall back to standard LRU."""
+        # xi=1, q_hat=1 → B = max(0, L+1-1) = L
+        # node_start = L - len(node) = 0 for single-node leaves
+        # 0 >= L is only true when L=0, so effectively all non-empty nodes are protected.
+        # Fallback to LRU: oldest access time evicted first.
+        cache = _make_cache(size=6, xi=1, q_hat=1)
+
+        # Conv A: oldest
+        conv_a = RadixKey(token_ids=[1, 2], extra_key=None)
+        val_a = torch.arange(2, dtype=torch.int64)
+        cache.insert(InsertParams(key=conv_a, value=val_a))
+        time.sleep(0.01)
+
+        # Conv B: newer
+        conv_b = RadixKey(token_ids=[10, 11], extra_key=None)
+        val_b = torch.arange(2, dtype=torch.int64) + 100
+        cache.insert(InsertParams(key=conv_b, value=val_b))
+        time.sleep(0.01)
+
+        # Conv C: newest
+        conv_c = RadixKey(token_ids=[20, 21], extra_key=None)
+        val_c = torch.arange(2, dtype=torch.int64) + 200
+        cache.insert(InsertParams(key=conv_c, value=val_c))
+
+        # Evict 2 tokens — should evict Conv A (oldest LRU)
+        cache.evict(EvictParams(num_tokens=2))
+
+        match_a = cache.match_prefix(MatchPrefixParams(key=conv_a))
+        self.assertEqual(match_a.device_indices.numel(), 0, "Oldest conv A should be evicted via LRU fallback")
+
+        match_b = cache.match_prefix(MatchPrefixParams(key=conv_b))
+        self.assertTrue(match_b.device_indices.numel() > 0, "Conv B should be retained")
+
+        match_c = cache.match_prefix(MatchPrefixParams(key=conv_c))
+        self.assertTrue(match_c.device_indices.numel() > 0, "Conv C should be retained")
+
+    def test_short_conversation_all_tel_safe(self):
+        """When L + q_hat <= xi, B=0 and the entire conversation is TEL-safe."""
+        # xi=10, q_hat=2 → for L=3: B=max(0,3+2-10)=0, all TEL-safe
+        # for L=7: B=max(0,7+2-10)=0, still all TEL-safe (just barely)
+        # for L=9: B=max(0,9+2-10)=1, tokens [0] protected, rest TEL-safe
+        cache = _make_cache(size=12, xi=10, q_hat=2)
+
+        # Conv A: L=3, B=0, all TEL-safe
+        conv_a = RadixKey(token_ids=[1, 2, 3], extra_key=None)
+        val_a = torch.arange(3, dtype=torch.int64)
+        cache.insert(InsertParams(key=conv_a, value=val_a))
+        time.sleep(0.01)
+
+        # Conv B: L=9, B=1, node_start=0 < 1 → protected (single node covers [0,8])
+        conv_b = RadixKey(token_ids=[10, 11, 12, 13, 14, 15, 16, 17, 18], extra_key=None)
+        val_b = torch.arange(9, dtype=torch.int64) + 100
+        cache.insert(InsertParams(key=conv_b, value=val_b))
+
+        # Total: 3+9=12 (full). Evict 3 tokens.
+        # Conv A is TEL-safe (B=0), Conv B is protected (B=1, node_start=0 < 1).
+        # Conv A should be evicted first.
+        cache.evict(EvictParams(num_tokens=3))
+
+        match_a = cache.match_prefix(MatchPrefixParams(key=conv_a))
+        self.assertEqual(match_a.device_indices.numel(), 0, "Short TEL-safe conv A should be evicted")
+
+        match_b = cache.match_prefix(MatchPrefixParams(key=conv_b))
+        self.assertTrue(match_b.device_indices.numel() > 0, "Protected conv B should be retained")
+
+    def test_xi_and_qhat_affect_behavior(self):
+        """Different xi/q_hat values should change which nodes are TEL-safe."""
+        # With xi=100, q_hat=1: B = max(0, L+1-100) = 0 for L<99
+        # → everything is TEL-safe for short conversations, falls back to LRU within TEL-safe
+        cache_loose = _make_cache(size=6, xi=100, q_hat=1)
+        conv_a = RadixKey(token_ids=[1, 2], extra_key=None)
+        conv_b = RadixKey(token_ids=[10, 11], extra_key=None)
+        cache_loose.insert(InsertParams(key=conv_a, value=torch.arange(2, dtype=torch.int64)))
+        time.sleep(0.01)
+        cache_loose.insert(InsertParams(key=conv_b, value=torch.arange(2, dtype=torch.int64) + 100))
+        time.sleep(0.01)
+        cache_loose.insert(InsertParams(key=RadixKey(token_ids=[20, 21], extra_key=None), value=torch.arange(2, dtype=torch.int64) + 200))
+
+        # Both are TEL-safe, so LRU within TEL-safe: oldest (conv_a) evicted first
+        cache_loose.evict(EvictParams(num_tokens=2))
+        match_a = cache_loose.match_prefix(MatchPrefixParams(key=conv_a))
+        self.assertEqual(match_a.device_indices.numel(), 0, "With large xi, oldest TEL-safe should be evicted first")
+
+
+class TestTLRUWithSplitNodes(unittest.TestCase):
+    """Test T-LRU with shared prefixes that cause node splits."""
+
+    def test_split_preserves_cumulative_tokens(self):
+        """After a split, cumulative_tokens should be correct for both nodes."""
+        cache = _make_cache(size=20, xi=500, q_hat=200)
+
+        # Insert [1,2,3,4,5]
+        key1 = RadixKey(token_ids=[1, 2, 3, 4, 5], extra_key=None)
+        val1 = torch.arange(5, dtype=torch.int64)
+        cache.insert(InsertParams(key=key1, value=val1))
+
+        # Insert [1,2,3,6,7] → splits at position 3
+        key2 = RadixKey(token_ids=[1, 2, 3, 6, 7], extra_key=None)
+        val2 = torch.arange(5, dtype=torch.int64) + 10
+        cache.insert(InsertParams(key=key2, value=val2))
+
+        # Walk the tree and verify
+        prefix_node = cache.root_node.children[1]
+        self.assertEqual(prefix_node.cumulative_tokens, 3)
+        self.assertEqual(len(prefix_node.key), 3)
+
+        for child in prefix_node.children.values():
+            self.assertEqual(child.cumulative_tokens, 5)
+            self.assertEqual(len(child.key), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_radix_cache_tlru.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_tlru.py
@@ -11,7 +11,7 @@ from sglang.srt.mem_cache.base_prefix_cache import (
 )
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
 from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool, ReqToTokenPool
-from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey, TreeNode
+from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=5, suite="stage-b-test-1-gpu-small")
@@ -147,15 +147,21 @@ class TestTLRUEviction(unittest.TestCase):
 
         # Conv B should be evicted (TEL-safe)
         match_b = cache2.match_prefix(MatchPrefixParams(key=conv_b))
-        self.assertEqual(match_b.device_indices.numel(), 0, "TEL-safe conv B should be evicted")
+        self.assertEqual(
+            match_b.device_indices.numel(), 0, "TEL-safe conv B should be evicted"
+        )
 
         # Conv A should still be present (protected)
         match_a = cache2.match_prefix(MatchPrefixParams(key=conv_a))
-        self.assertTrue(match_a.device_indices.numel() > 0, "Protected conv A should be retained")
+        self.assertTrue(
+            match_a.device_indices.numel() > 0, "Protected conv A should be retained"
+        )
 
         # Conv C should still be present (protected)
         match_c = cache2.match_prefix(MatchPrefixParams(key=conv_c))
-        self.assertTrue(match_c.device_indices.numel() > 0, "Protected conv C should be retained")
+        self.assertTrue(
+            match_c.device_indices.numel() > 0, "Protected conv C should be retained"
+        )
 
     def test_lru_fallback_when_no_tel_safe(self):
         """When all conversations are protected (no TEL-safe), fall back to standard LRU."""
@@ -186,7 +192,11 @@ class TestTLRUEviction(unittest.TestCase):
         cache.evict(EvictParams(num_tokens=2))
 
         match_a = cache.match_prefix(MatchPrefixParams(key=conv_a))
-        self.assertEqual(match_a.device_indices.numel(), 0, "Oldest conv A should be evicted via LRU fallback")
+        self.assertEqual(
+            match_a.device_indices.numel(),
+            0,
+            "Oldest conv A should be evicted via LRU fallback",
+        )
 
         match_b = cache.match_prefix(MatchPrefixParams(key=conv_b))
         self.assertTrue(match_b.device_indices.numel() > 0, "Conv B should be retained")
@@ -208,7 +218,9 @@ class TestTLRUEviction(unittest.TestCase):
         time.sleep(0.01)
 
         # Conv B: L=9, B=1, node_start=0 < 1 → protected (single node covers [0,8])
-        conv_b = RadixKey(token_ids=[10, 11, 12, 13, 14, 15, 16, 17, 18], extra_key=None)
+        conv_b = RadixKey(
+            token_ids=[10, 11, 12, 13, 14, 15, 16, 17, 18], extra_key=None
+        )
         val_b = torch.arange(9, dtype=torch.int64) + 100
         cache.insert(InsertParams(key=conv_b, value=val_b))
 
@@ -218,10 +230,14 @@ class TestTLRUEviction(unittest.TestCase):
         cache.evict(EvictParams(num_tokens=3))
 
         match_a = cache.match_prefix(MatchPrefixParams(key=conv_a))
-        self.assertEqual(match_a.device_indices.numel(), 0, "Short TEL-safe conv A should be evicted")
+        self.assertEqual(
+            match_a.device_indices.numel(), 0, "Short TEL-safe conv A should be evicted"
+        )
 
         match_b = cache.match_prefix(MatchPrefixParams(key=conv_b))
-        self.assertTrue(match_b.device_indices.numel() > 0, "Protected conv B should be retained")
+        self.assertTrue(
+            match_b.device_indices.numel() > 0, "Protected conv B should be retained"
+        )
 
     def test_xi_and_qhat_affect_behavior(self):
         """Different xi/q_hat values should change which nodes are TEL-safe."""
@@ -230,16 +246,29 @@ class TestTLRUEviction(unittest.TestCase):
         cache_loose = _make_cache(size=6, xi=100, q_hat=1)
         conv_a = RadixKey(token_ids=[1, 2], extra_key=None)
         conv_b = RadixKey(token_ids=[10, 11], extra_key=None)
-        cache_loose.insert(InsertParams(key=conv_a, value=torch.arange(2, dtype=torch.int64)))
+        cache_loose.insert(
+            InsertParams(key=conv_a, value=torch.arange(2, dtype=torch.int64))
+        )
         time.sleep(0.01)
-        cache_loose.insert(InsertParams(key=conv_b, value=torch.arange(2, dtype=torch.int64) + 100))
+        cache_loose.insert(
+            InsertParams(key=conv_b, value=torch.arange(2, dtype=torch.int64) + 100)
+        )
         time.sleep(0.01)
-        cache_loose.insert(InsertParams(key=RadixKey(token_ids=[20, 21], extra_key=None), value=torch.arange(2, dtype=torch.int64) + 200))
+        cache_loose.insert(
+            InsertParams(
+                key=RadixKey(token_ids=[20, 21], extra_key=None),
+                value=torch.arange(2, dtype=torch.int64) + 200,
+            )
+        )
 
         # Both are TEL-safe, so LRU within TEL-safe: oldest (conv_a) evicted first
         cache_loose.evict(EvictParams(num_tokens=2))
         match_a = cache_loose.match_prefix(MatchPrefixParams(key=conv_a))
-        self.assertEqual(match_a.device_indices.numel(), 0, "With large xi, oldest TEL-safe should be evicted first")
+        self.assertEqual(
+            match_a.device_indices.numel(),
+            0,
+            "With large xi, oldest TEL-safe should be evicted first",
+        )
 
 
 class TestTLRUWithSplitNodes(unittest.TestCase):


### PR DESCRIPTION
## Motivation

Implement the **Tail-Optimized LRU (T-LRU)** cache eviction policy from [arXiv:2510.15152](https://arxiv.org/abs/2510.15152). Standard LRU evicts the least-recently-used KV cache block regardless of its impact on TTFT SLA. T-LRU improves SLA compliance by distinguishing:

- **TEL-safe blocks**: evicting them won't push the next turn's uncached token count above threshold `ξ` — these are evicted first.
- **Protected blocks**: evicting them would violate the SLA — these remain in standard LRU order.

A similar policy was recently merged into vLLM ([vllm-project/vllm#37825](https://github.com/vllm-project/vllm/pull/37825)). This PR is a SGLang-native adaptation.

## Modifications

**`python/sglang/srt/mem_cache/evict_policy.py`**
- Add `TLRUStrategy`: classifies each evictable leaf node as TEL-safe `(0, last_access_time)` or protected `(1, last_access_time)` using `B = max(0, L + Q̂ − ξ)` where `L = node.cumulative_tokens`.
- Add `get_cascade_priority()` to the base `EvictionStrategy` class (defaults to `get_priority`). `TLRUStrategy` overrides it to always return protected/LRU priority for **cascade nodes** — a SGLang-specific correctness fix (see below).

**`python/sglang/srt/mem_cache/radix_cache.py`**
- Add `cumulative_tokens` field to `TreeNode`, set on insert (`_insert_helper`) and split (`_split_node`).
- In `evict()`, use `get_cascade_priority()` when re-queuing a parent whose last child was just evicted.

**Correctness note — cascade eviction of shared prefix nodes:**
SGLang's radix tree shares prefixes across conversations. When all children of a shared prefix node are evicted, the parent becomes an evictable leaf. Its `cumulative_tokens` at that point equals its depth from root — not the full conversation history length `L` — which would incorrectly classify it as TEL-safe and allow it to jump ahead of protected conversation tails in the eviction order. The `get_cascade_priority()` override forces such nodes to protected/LRU priority. This issue does not arise in vLLM's per-request block model.

**`python/sglang/srt/mem_cache/cache_init_params.py`** / **`python/sglang/srt/server_args.py`** / **`python/sglang/srt/managers/scheduler.py`**
- Two new CLI args: `--tlru-xi-tokens` (SLA threshold in tokens) and `--tlru-qhat-tokens` (estimated next prompt length, default `200`).
- `--radix-eviction-policy tlru` activates the policy.

**`test/registered/unit/mem_cache/test_radix_cache_tlru.py`**
- Unit tests covering TEL-safe vs. protected classification, eviction ordering, cascade correctness, multi-turn prefix reuse, and end-to-end eviction with the real `RadixCache` + KV pool.

**Usage:**
```bash
python -m sglang.launch_server \
  --model-path meta-llama/Llama-3.1-8B-Instruct \
  --radix-eviction-policy tlru \
  --tlru-xi-tokens 4096 \
  --tlru-qhat-tokens 200
```

## Accuracy Tests

Not applicable — this PR adds a new eviction policy flag that is disabled by default (`--radix-eviction-policy lru` remains the default). No changes to model forward code or kernels.

## Speed Tests and Profiling

Not applicable — eviction runs off the hot path and the new policy is opt-in.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.