### PR TITLE
[AMD] Add GLM-5-FP8 nightly performance benchmarks for MI30x and MI35x

### DIFF
--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -665,7 +665,7 @@ jobs:
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}
 
-  # 8-GPU GLM-5 (Accuracy) ROCm 7.2
+  # 8-GPU GLM-5 (Accuracy + Performance combined) ROCm 7.2
   nightly-8-gpu-glm5-rocm720:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-glm5-rocm720,'))
     runs-on: linux-mi325-8gpu-sglang
@@ -694,6 +694,18 @@ jobs:
           bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
             -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
             python3 run_suite.py --hw amd --suite nightly-amd-accuracy-8-gpu-glm5 --nightly --timeout-per-file 3600 ${{ inputs.continue_on_error && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
+      - name: Performance Test ROCm 7.2 (8-GPU GLM-5)
+        timeout-minutes: 120
+        continue-on-error: true  # Perf test failure doesn't fail the job if accuracy passed
+        run: |
+          > github_summary.md  # Clear summary file
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e SGLANG_USE_AITER=1 \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-perf-8-gpu-glm5 --nightly --timeout-per-file 5400 ${{ inputs.continue_on_error && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}
 
@@ -1276,6 +1288,7 @@ jobs:
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}
 
+  # MI35x 8-GPU GLM-5 (Accuracy + Performance combined) ROCm 7.2
   nightly-8-gpu-mi35x-glm5-rocm720:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-mi35x-glm5-rocm720,'))
     runs-on: linux-mi35x-gpu-8
@@ -1306,6 +1319,17 @@ jobs:
           bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
             -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
             python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-glm5 --nightly --timeout-per-file 7200 ${{ inputs.continue_on_error && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
+      - name: Performance Test MI35x ROCm 7.2 (8-GPU GLM-5)
+        timeout-minutes: 120
+        continue-on-error: true  # Perf test failure doesn't fail the job if accuracy passed
+        run: |
+          > github_summary.md  # Clear summary file
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-perf-8-gpu-mi35x-glm5 --nightly --timeout-per-file 5400 ${{ inputs.continue_on_error && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}
 

--- a/.github/workflows/nightly-test-amd.yml
+++ b/.github/workflows/nightly-test-amd.yml
@@ -668,6 +668,7 @@ jobs:
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}
 
+  # 8-GPU GLM-5 (Accuracy + Performance combined)
   nightly-8-gpu-glm5:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-glm5,'))
     runs-on: linux-mi325-8gpu-sglang
@@ -696,6 +697,18 @@ jobs:
           bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
             -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
             python3 run_suite.py --hw amd --suite nightly-amd-accuracy-8-gpu-glm5 --nightly --timeout-per-file 3600 ${{ inputs.continue_on_error && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
+      - name: Performance Test (8-GPU GLM-5)
+        timeout-minutes: 120
+        continue-on-error: true  # Perf test failure doesn't fail the job if accuracy passed
+        run: |
+          > github_summary.md  # Clear summary file
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e SGLANG_USE_AITER=1 \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-perf-8-gpu-glm5 --nightly --timeout-per-file 5400 ${{ inputs.continue_on_error && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}
 
@@ -1281,6 +1294,7 @@ jobs:
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}
 
+  # MI35x 8-GPU GLM-5 (Accuracy + Performance combined)
   nightly-8-gpu-mi35x-glm5:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-mi35x-glm5,'))
     runs-on: linux-mi35x-gpu-8
@@ -1311,6 +1325,17 @@ jobs:
           bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
             -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
             python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-glm5 --nightly --timeout-per-file 7200 ${{ inputs.continue_on_error && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
+      - name: Performance Test MI35x (8-GPU GLM-5)
+        timeout-minutes: 120
+        continue-on-error: true  # Perf test failure doesn't fail the job if accuracy passed
+        run: |
+          > github_summary.md  # Clear summary file
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-perf-8-gpu-mi35x-glm5 --nightly --timeout-per-file 5400 ${{ inputs.continue_on_error && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}
 

--- a/test/registered/amd/accuracy/mi30x/test_glm5_eval_amd.py
+++ b/test/registered/amd/accuracy/mi30x/test_glm5_eval_amd.py
@@ -59,13 +59,17 @@ class ModelConfig:
 GLM5_MODELS = [
     # GLM-5 with NSA attention (TP=8)
     ModelConfig(
-        model_path="zai-org/GLM-5",
+        model_path="zai-org/GLM-5-FP8",
         tp_size=8,
         accuracy_threshold=0.93,
         timeout=3600,
         variant="nsa",
         other_args=[
             "--trust-remote-code",
+            "--reasoning-parser",
+            "glm45",
+            "--tool-call-parser",
+            "glm47",
             "--nsa-prefill-backend",
             "tilelang",
             "--nsa-decode-backend",
@@ -77,7 +81,7 @@ GLM5_MODELS = [
             "--model-loader-extra-config",
             '{"enable_multithread_load": true}',
             "--watchdog-timeout",
-            "1200",  # 20 minutes for weight loading
+            "1200",
         ],
         env_vars={"SGLANG_USE_AITER": "1"},
     ),

--- a/test/registered/amd/accuracy/mi35x/test_glm5_eval_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_glm5_eval_mi35x.py
@@ -64,13 +64,17 @@ class ModelConfig:
 MI35X_GLM5_MODELS = [
     # GLM-5 with NSA attention (TP=8)
     ModelConfig(
-        model_path="zai-org/GLM-5",
+        model_path="zai-org/GLM-5-FP8",
         tp_size=8,
         accuracy_threshold=0.93,
         timeout=5400,
         variant="nsa",
         other_args=[
             "--trust-remote-code",
+            "--reasoning-parser",
+            "glm45",
+            "--tool-call-parser",
+            "glm47",
             "--nsa-prefill-backend",
             "tilelang",
             "--nsa-decode-backend",
@@ -82,7 +86,7 @@ MI35X_GLM5_MODELS = [
             "--model-loader-extra-config",
             '{"enable_multithread_load": true}',
             "--watchdog-timeout",
-            "1200",  # 20 minutes for weight loading
+            "1200",
         ],
         env_vars={},
     ),

--- a/test/registered/amd/perf/mi30x/test_glm5_perf_amd.py
+++ b/test/registered/amd/perf/mi30x/test_glm5_perf_amd.py
@@ -1,0 +1,138 @@
+"""Nightly performance benchmark for GLM-5 on MI30x.
+
+Tests GLM-5 with NSA attention backend using bench_one_batch on 8 GPUs.
+
+Model paths can be configured via environment variables:
+- GLM5_MODEL_PATH: Path to GLM-5 model (default: zai-org/GLM-5-FP8)
+
+Example usage:
+    python -m pytest test_glm5_perf_amd.py -v
+"""
+
+import os
+import unittest
+from typing import List
+
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.nightly_bench_utils import BenchmarkResult
+from sglang.test.nightly_utils import NightlyBenchmarkRunner
+from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
+
+register_amd_ci(est_time=5400, suite="nightly-perf-8-gpu-glm5", nightly=True)
+
+
+def generate_simple_markdown_report(results: List[BenchmarkResult]) -> str:
+    model_header = results[0].model_path
+    if results[0].run_name and results[0].run_name != "default":
+        model_header += f" ({results[0].run_name})"
+
+    gpu_config = os.getenv("GPU_CONFIG", "MI325")
+    if gpu_config:
+        model_header += f" [{gpu_config}]"
+
+    summary = f"### {model_header}\n"
+    summary += "| batch size | input len | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |\n"
+    summary += "| ---------- | --------- | ----------- | ------------------------ | ------------------------- | -------- |\n"
+
+    report_results = (
+        results[1:]
+        if len(results) > 1 and results[0].batch_size == results[1].batch_size
+        else results
+    )
+
+    for result in report_results:
+        itl = 1 / (result.output_throughput / result.batch_size) * 1000
+        summary += f"| {result.batch_size} | {result.input_len} | {result.latency:.2f} | {result.input_throughput:.2f} | {result.output_throughput:.2f} | {itl:.2f} |\n"
+
+    return summary
+
+
+GLM5_MODEL_PATH = os.environ.get("GLM5_MODEL_PATH", "zai-org/GLM-5-FP8")
+PROFILE_DIR = "performance_profiles_glm5"
+
+
+class TestNightlyGLM5Performance(unittest.TestCase):
+    """Nightly performance benchmark for GLM-5.
+
+    Tests GLM-5 with NSA attention backend on TP=8.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.batch_sizes = [1, 8, 16, 64]
+        cls.input_lens = tuple(_parse_int_list_env("NIGHTLY_INPUT_LENS", "4096"))
+        cls.output_lens = tuple(_parse_int_list_env("NIGHTLY_OUTPUT_LENS", "512"))
+
+        cls.model_config = {
+            "name": "glm5",
+            "model_path": GLM5_MODEL_PATH,
+            "other_args": [
+                "--trust-remote-code",
+                "--reasoning-parser",
+                "glm45",
+                "--tool-call-parser",
+                "glm47",
+                "--tp",
+                "8",
+                "--nsa-prefill-backend",
+                "tilelang",
+                "--nsa-decode-backend",
+                "tilelang",
+                "--chunked-prefill-size",
+                "131072",
+                "--mem-fraction-static",
+                "0.85",
+                "--model-loader-extra-config",
+                '{"enable_multithread_load": true}',
+                "--watchdog-timeout",
+                "1200",
+            ],
+            "env_vars": {
+                "SGLANG_USE_AITER": "1",
+            },
+        }
+
+        cls.runner = NightlyBenchmarkRunner(PROFILE_DIR, cls.__name__, cls.base_url)
+        cls.runner.setup_profile_directory()
+        cls.runner.full_report = f"## {cls.__name__}\n"
+
+    def test_bench_glm5(self):
+        """Run benchmark for GLM-5."""
+        old_env = {}
+        for key, value in self.model_config.get("env_vars", {}).items():
+            old_env[key] = os.environ.get(key)
+            os.environ[key] = value
+
+        try:
+            result_tuple = self.runner.run_benchmark_for_model(
+                model_path=self.model_config["model_path"],
+                batch_sizes=self.batch_sizes,
+                input_lens=self.input_lens,
+                output_lens=self.output_lens,
+                other_args=self.model_config["other_args"],
+                variant=self.model_config["name"],
+                extra_bench_args=["--trust-remote-code"],
+                enable_profile=False,
+                timeout=5400,
+            )
+            results = result_tuple[0]
+            success = result_tuple[1]
+
+            if results:
+                self.runner.full_report += (
+                    generate_simple_markdown_report(results) + "\n"
+                )
+
+            self.assertTrue(success, f"Benchmark failed for {GLM5_MODEL_PATH}")
+        finally:
+            for key, value in old_env.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+            self.runner.write_final_report()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/amd/perf/mi30x/test_glm5_perf_amd.py
+++ b/test/registered/amd/perf/mi30x/test_glm5_perf_amd.py
@@ -79,6 +79,8 @@ class TestNightlyGLM5Performance(unittest.TestCase):
                 "tilelang",
                 "--nsa-decode-backend",
                 "tilelang",
+                "--kv-cache-dtype",
+                "fp8_e4m3",
                 "--chunked-prefill-size",
                 "131072",
                 "--mem-fraction-static",

--- a/test/registered/amd/perf/mi35x/test_glm5_perf_mi35x.py
+++ b/test/registered/amd/perf/mi35x/test_glm5_perf_mi35x.py
@@ -1,0 +1,141 @@
+"""MI35x Nightly performance benchmark for GLM-5.
+
+Tests GLM-5 with NSA attention backend using bench_one_batch on 8 GPUs.
+
+Registry: nightly-perf-8-gpu-mi35x-glm5 suite
+"""
+
+import os
+
+os.environ.setdefault("HF_HOME", "/data2/models/huggingface")
+os.environ.setdefault("HF_HUB_CACHE", "/data2/models/huggingface/hub")
+
+import unittest
+from typing import List
+
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.nightly_bench_utils import BenchmarkResult
+from sglang.test.nightly_utils import NightlyBenchmarkRunner
+from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
+
+register_amd_ci(est_time=5400, suite="nightly-perf-8-gpu-mi35x-glm5", nightly=True)
+
+
+def generate_simple_markdown_report(results: List[BenchmarkResult]) -> str:
+    model_header = results[0].model_path
+    if results[0].run_name and results[0].run_name != "default":
+        model_header += f" ({results[0].run_name})"
+
+    gpu_config = os.getenv("GPU_CONFIG", "MI35x")
+    if gpu_config:
+        model_header += f" [{gpu_config}]"
+
+    summary = f"### {model_header}\n"
+    summary += "| batch size | input len | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |\n"
+    summary += "| ---------- | --------- | ----------- | ------------------------ | ------------------------- | -------- |\n"
+
+    report_results = (
+        results[1:]
+        if len(results) > 1 and results[0].batch_size == results[1].batch_size
+        else results
+    )
+
+    for result in report_results:
+        itl = 1 / (result.output_throughput / result.batch_size) * 1000
+        summary += f"| {result.batch_size} | {result.input_len} | {result.latency:.2f} | {result.input_throughput:.2f} | {result.output_throughput:.2f} | {itl:.2f} |\n"
+
+    return summary
+
+
+GLM5_MODEL_PATH = os.environ.get("GLM5_MODEL_PATH", "zai-org/GLM-5-FP8")
+PROFILE_DIR = "performance_profiles_glm5_mi35x"
+
+
+class TestGLM5PerfMI35x(unittest.TestCase):
+    """Nightly performance benchmark for GLM-5 on MI35x.
+
+    Tests GLM-5 with NSA attention backend on TP=8.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.batch_sizes = [1, 8, 16, 64]
+        cls.input_lens = tuple(_parse_int_list_env("NIGHTLY_INPUT_LENS", "4096"))
+        cls.output_lens = tuple(_parse_int_list_env("NIGHTLY_OUTPUT_LENS", "512"))
+
+        cls.model_config = {
+            "name": "glm5-mi35x",
+            "model_path": GLM5_MODEL_PATH,
+            "other_args": [
+                "--trust-remote-code",
+                "--reasoning-parser",
+                "glm45",
+                "--tool-call-parser",
+                "glm47",
+                "--tp",
+                "8",
+                "--nsa-prefill-backend",
+                "tilelang",
+                "--nsa-decode-backend",
+                "tilelang",
+                "--chunked-prefill-size",
+                "131072",
+                "--mem-fraction-static",
+                "0.85",
+                "--model-loader-extra-config",
+                '{"enable_multithread_load": true, "num_threads": 8}',
+                "--watchdog-timeout",
+                "1200",
+            ],
+            "env_vars": {
+                "SGLANG_ROCM_FUSED_DECODE_MLA": "0",
+                "ROCM_QUICK_REDUCE_QUANTIZATION": "INT4",
+                "SAFETENSORS_FAST_GPU": "1",
+            },
+        }
+
+        os.environ.setdefault("SGLANG_BENCH_TIMEOUT", "3600")
+        cls.runner = NightlyBenchmarkRunner(PROFILE_DIR, cls.__name__, cls.base_url)
+        cls.runner.setup_profile_directory()
+        cls.runner.full_report = f"## {cls.__name__}\n"
+
+    def test_glm5_perf(self):
+        """Run GLM-5 performance benchmark on MI35x."""
+        old_env = {}
+        for key, value in self.model_config.get("env_vars", {}).items():
+            old_env[key] = os.environ.get(key)
+            os.environ[key] = value
+
+        try:
+            result_tuple = self.runner.run_benchmark_for_model(
+                model_path=self.model_config["model_path"],
+                batch_sizes=self.batch_sizes,
+                input_lens=self.input_lens,
+                output_lens=self.output_lens,
+                other_args=self.model_config["other_args"],
+                variant=self.model_config["name"],
+                extra_bench_args=["--trust-remote-code"],
+                enable_profile=False,
+                timeout=5400,
+            )
+            results = result_tuple[0]
+            success = result_tuple[1]
+
+            if results:
+                self.runner.full_report += (
+                    generate_simple_markdown_report(results) + "\n"
+                )
+
+            self.assertTrue(success, f"Benchmark failed for {GLM5_MODEL_PATH} on MI35x")
+        finally:
+            for key, value in old_env.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+            self.runner.write_final_report()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/amd/perf/mi35x/test_glm5_perf_mi35x.py
+++ b/test/registered/amd/perf/mi35x/test_glm5_perf_mi35x.py
@@ -79,6 +79,8 @@ class TestGLM5PerfMI35x(unittest.TestCase):
                 "tilelang",
                 "--nsa-decode-backend",
                 "tilelang",
+                "--kv-cache-dtype",
+                "fp8_e4m3",
                 "--chunked-prefill-size",
                 "131072",
                 "--mem-fraction-static",


### PR DESCRIPTION
## Summary
Add GLM-5-FP8 nightly perf benchmarks (`bench_one_batch`) for MI30x and MI35x. Both accuracy and perf use `zai-org/GLM-5-FP8` with NSA tilelang backend, TP=8, FP8 KV cache, and `--reasoning-parser=glm45 --tool-call-parser=glm47` (matching NV/InferenceX configs).

## Changes
- **New**: `test/registered/amd/perf/mi30x/test_glm5_perf_amd.py` (suite: `nightly-perf-8-gpu-glm5`)
- **New**: `test/registered/amd/perf/mi35x/test_glm5_perf_mi35x.py` (suite: `nightly-perf-8-gpu-mi35x-glm5`)
- **Modified**: accuracy tests in `mi30x/` and `mi35x/` — switch model to `zai-org/GLM-5-FP8`, add parser flags
- **Modified**: `nightly-test-amd.yml` and `nightly-test-amd-rocm720.yml` — add perf step after accuracy in each GLM-5 job

## Workflow behavior
- Accuracy step has no `continue-on-error` — if it fails, perf is skipped and the job fails
- Perf step has `continue-on-error: true` — perf failures don't block CI

## Dependencies
- #22314: Fix MI300 FP8 KV quant path dispatch (enables `--kv-cache-dtype fp8_e4m3` on MI30x)
- #22232: Fix NSA indexer GPU memory fault at batch_size=64 (fixes MI35x perf crash)

## Server config

| | MI30x | MI35x |
|---|---|---|
| `--kv-cache-dtype` | fp8_e4m3 | fp8_e4m3 |
| `--mem-fraction-static` | 0.85 | 0.85 |
| `--model-loader-extra-config` | `{"enable_multithread_load": true}` | `{"enable_multithread_load": true, "num_threads": 8}` |
| Env | `SGLANG_USE_AITER=1` | `SGLANG_ROCM_FUSED_DECODE_MLA=0`, `ROCM_QUICK_REDUCE_QUANTIZATION=INT4`, `SAFETENSORS_FAST_GPU=1` |

## CI validation
- Nightly Test (AMD): https://github.com/sgl-project/sglang/actions/runs/24118470025
- Nightly Test (AMD ROCm 7.2): https://github.com/sgl-project/sglang/actions/runs/24118470693

### MI30x perf results (earlier run, without FP8 KV cache)
From [AMD run](https://github.com/sgl-project/sglang/actions/runs/23865805251) / [ROCm 7.2 run](https://github.com/sgl-project/sglang/actions/runs/23865806266):

| batch | ISL | latency (s) | input tok/s | output tok/s | ITL (ms) |
|-------|-----|-------------|-------------|--------------|----------|
| 1 | 4096 | 25.50 | 1735 | 22.1 | 45.2 |
| 8 | 4096 | 33.76 | 5172 | 149.4 | 53.6 |
| 16 | 4096 | 40.23 | 6313 | 274.5 | 58.3 |
| 64 | 4096 | 85.64 | 6351 | 738.7 | 86.6 |