### PR TITLE
Remove flashinfer wheel cache cleanup that deletes other versions

### DIFF
--- a/scripts/ci/cuda/ci_download_flashinfer_jit_cache.sh
+++ b/scripts/ci/cuda/ci_download_flashinfer_jit_cache.sh
@@ -25,8 +25,6 @@ if [ "$FLASHINFER_JIT_CACHE_INSTALLED" = false ]; then
     FLASHINFER_CACHE_DIR="${HOME}/.cache/flashinfer-wheels"
     mkdir -p "${FLASHINFER_CACHE_DIR}"
 
-    find "${FLASHINFER_CACHE_DIR}" -name "flashinfer_jit_cache-*.whl" ! -name "flashinfer_jit_cache-${FLASHINFER_PYTHON_REQUIRED}*" -type f -delete 2>/dev/null || true
-
     FLASHINFER_WHEEL_PATTERN="flashinfer_jit_cache-${FLASHINFER_PYTHON_REQUIRED}*.whl"
     CACHED_WHEEL=$(find "${FLASHINFER_CACHE_DIR}" -name "${FLASHINFER_WHEEL_PATTERN}" -type f 2>/dev/null | head -n 1)
 


### PR DESCRIPTION
## Summary
- Remove the `find -delete` line in `ci_download_flashinfer_jit_cache.sh` that deletes cached flashinfer wheels not matching the current required version
- This cleanup causes problems when runner hosts pre-cache multiple versions (e.g. 0.6.6 + 0.6.7) — different CI jobs or PRs expecting different versions keep wiping each other's cached wheels, forcing re-downloads of 1.6-1.9GB files
- Keeping old wheel versions on disk is harmless and avoids costly re-downloads on bandwidth-limited machines (e.g. RTX 5090 runners at ~3MB/s)

Example failure: https://github.com/sgl-project/sglang/actions/runs/23769215101/job/69256426384 — 5090 runners timed out during "Install dependencies" because the wheel cache was wiped and had to re-download

## Test plan
- [ ] CI passes without the cleanup line
- [ ] Pre-cached wheels persist across different CI jobs