### PR TITLE
[Bugfix] Return HTTP 400 for client-side multimodal URL fetch failures

### DIFF
--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -511,6 +511,8 @@ class BaseMultimodalProcessor(ABC):
             elif modality == Modality.AUDIO:
                 return load_audio(data, audio_sample_rate)
 
+        except ValueError:
+            raise
         except Exception as e:
             raise RuntimeError(f"Error while loading data {data}: {e}")
 
@@ -956,6 +958,8 @@ class BaseMultimodalProcessor(ABC):
                 raise RuntimeError(
                     f"An exception occurred while loading multimodal data: {e}"
                 )
+            except ValueError:
+                raise
             except Exception as e:
                 raise RuntimeError(
                     f"An exception occurred while loading multimodal data: {e}"

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -706,7 +706,17 @@ def load_audio(
     ):
         timeout = int(os.getenv("REQUEST_TIMEOUT", "5"))
         with requests.get(audio_file, timeout=timeout) as response:
-            response.raise_for_status()
+            try:
+                response.raise_for_status()
+            except requests.exceptions.HTTPError as e:
+                status_code = (
+                    e.response.status_code if e.response is not None else None
+                )
+                if status_code is not None and 400 <= status_code < 500:
+                    raise ValueError(
+                        f"Failed to load audio from URL: {status_code} Client Error for url: {audio_file}"
+                    ) from e
+                raise
             source = response.content
     elif isinstance(audio_file, str) and audio_file.startswith("file://"):
         source = unquote(urlparse(audio_file).path)
@@ -856,6 +866,13 @@ def get_image_bytes(image_file: Union[str, bytes]) -> bytes:
         try:
             response.raise_for_status()
             result = response.content
+        except requests.exceptions.HTTPError as e:
+            status_code = e.response.status_code if e.response is not None else None
+            if status_code is not None and 400 <= status_code < 500:
+                raise ValueError(
+                    f"Failed to load image from URL: {status_code} Client Error for url: {image_file}"
+                ) from e
+            raise
         finally:
             response.close()
         return result
@@ -885,7 +902,17 @@ def _normalize_video_input(
         if video_file.startswith(("http://", "https://")):
             timeout = int(os.getenv("REQUEST_TIMEOUT", "10"))
             response = requests.get(video_file, stream=True, timeout=timeout)
-            response.raise_for_status()
+            try:
+                response.raise_for_status()
+            except requests.exceptions.HTTPError as e:
+                status_code = (
+                    e.response.status_code if e.response is not None else None
+                )
+                if status_code is not None and 400 <= status_code < 500:
+                    raise ValueError(
+                        f"Failed to load video from URL: {status_code} Client Error for url: {video_file}"
+                    ) from e
+                raise
             return response.content
         elif video_file.startswith("data:"):
             _, encoded = video_file.split(",", 1)


### PR DESCRIPTION
## Summary
- When a user-provided image/video/audio URL returns a 4xx HTTP error (e.g., 404 Not Found, 403 Forbidden), the server incorrectly returns HTTP 500 Internal Server Error instead of HTTP 400 Bad Request.
- Root cause: `requests.exceptions.HTTPError` gets wrapped in `RuntimeError` by `_load_single_item` and `load_mm_data`, and `handle_request` maps all `RuntimeError`s to 500.
- Fix: In `get_image_bytes`, `_normalize_video_input`, and `load_audio`, catch 4xx `HTTPError` and raise `ValueError`. In `base_processor.py`, let `ValueError` propagate without wrapping in `RuntimeError`. `handle_request` already maps `ValueError` → HTTP 400.

## Changes
- `python/sglang/srt/utils/common.py`: In `get_image_bytes`, `_normalize_video_input`, and `load_audio`, catch `requests.exceptions.HTTPError` for 4xx status codes and raise `ValueError` with a descriptive message. 5xx errors continue to propagate as `HTTPError`.
- `python/sglang/srt/multimodal/processors/base_processor.py`: In `_load_single_item` and `load_mm_data`, add `except ValueError: raise` before the `except Exception` block so `ValueError` is not wrapped in `RuntimeError`.

## Test plan
- [x] Verified bug exists on latest main: 404 URL → `HTTPError` → `RuntimeError` → HTTP 500
- [x] Verified fix: 404/403 URLs → `ValueError` → HTTP 400 Bad Request
- [x] Verified 5xx server errors still return HTTP 500
- [x] Verified normal 200 path returns image data successfully