### PR TITLE
Fix human-eval CI install on 5090 runners

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -687,9 +687,10 @@ jobs:
         run: |
           source /etc/profile.d/sglang-ci.sh
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
+          pip install "setuptools<71"
           git clone https://github.com/merrymercy/human-eval.git
           cd human-eval
-          pip install .
+          pip install . --no-build-isolation
 
       - name: Run test
         timeout-minutes: 30
@@ -801,9 +802,10 @@ jobs:
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
+          pip install "setuptools<71"
           git clone https://github.com/merrymercy/human-eval.git
           cd human-eval
-          pip install .
+          pip install . --no-build-isolation
 
       - name: Run test
         timeout-minutes: 30

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -689,7 +689,7 @@ jobs:
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
           git clone https://github.com/merrymercy/human-eval.git
           cd human-eval
-          pip install -e . --no-build-isolation
+          pip install . --no-build-isolation
 
       - name: Run test
         timeout-minutes: 30
@@ -803,7 +803,7 @@ jobs:
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
           git clone https://github.com/merrymercy/human-eval.git
           cd human-eval
-          pip install -e . --no-build-isolation
+          pip install . --no-build-isolation
 
       - name: Run test
         timeout-minutes: 30

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -690,7 +690,7 @@ jobs:
           pip install "setuptools<71"
           git clone https://github.com/merrymercy/human-eval.git
           cd human-eval
-          pip install . --no-build-isolation
+          pip install -e . --no-build-isolation
 
       - name: Run test
         timeout-minutes: 30
@@ -805,7 +805,7 @@ jobs:
           pip install "setuptools<71"
           git clone https://github.com/merrymercy/human-eval.git
           cd human-eval
-          pip install . --no-build-isolation
+          pip install -e . --no-build-isolation
 
       - name: Run test
         timeout-minutes: 30

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -689,7 +689,7 @@ jobs:
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
           git clone https://github.com/merrymercy/human-eval.git
           cd human-eval
-          pip install . --no-build-isolation
+          pip install .
 
       - name: Run test
         timeout-minutes: 30
@@ -803,7 +803,7 @@ jobs:
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
           git clone https://github.com/merrymercy/human-eval.git
           cd human-eval
-          pip install . --no-build-isolation
+          pip install .
 
       - name: Run test
         timeout-minutes: 30

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -687,7 +687,7 @@ jobs:
         run: |
           source /etc/profile.d/sglang-ci.sh
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
-          pip install "setuptools<71"
+          pip install "setuptools==70.0.0"
           git clone https://github.com/merrymercy/human-eval.git
           cd human-eval
           pip install -e . --no-build-isolation
@@ -802,7 +802,7 @@ jobs:
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
-          pip install "setuptools<71"
+          pip install "setuptools==70.0.0"
           git clone https://github.com/merrymercy/human-eval.git
           cd human-eval
           pip install -e . --no-build-isolation


### PR DESCRIPTION
## Summary
- Add `pip install "setuptools<71"` before `human-eval` install in CI
- `setuptools>=71` removed `pkg_resources` from the default install, which `human-eval`'s `setup.py` imports
- `setuptools<71` also supports PEP 660 editable installs (added in 64), so `-e .` works
- This was not an issue before because 5090 runners used a pre-built CI image with `setuptools==70.x`. After switching to inline install with `nvidia/cuda:12.8.0-devel-ubuntu22.04` (ships `setuptools==59.6`), CI's `uv pip install` upgrades it to latest (82.x) which lacks `pkg_resources`

Failure examples:
- PEP 660: https://github.com/sgl-project/sglang/actions/runs/23773307757/job/69272846947
- pkg_resources: https://github.com/sgl-project/sglang/actions/runs/23775101374/job/69275134478

## Test plan
- [x] CI `stage-b-test-1-gpu-small` passes on 5090 runners
- [ ] CI `stage-b-test-2-gpu-large` passes on H100 runners