### PR TITLE
[NPU] replace mlp linear with matmul in Qwen2.5-VL

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -323,7 +323,7 @@ class Envs:
     SGLANG_USE_AG_AFTER_QLORA = EnvBool(False)
     SGLANG_NPU_FUSED_MOE_MODE = EnvInt(1)
     # Replace mlp matmul with torch kernel for better performance for Qwen-vl
-    USE_TORCH_MATMUL_FOR_MLP = EnvBool(False)
+    USE_MATMUL_REPLACE_LINEAR = EnvBool(False)
 
 
     # Quantization

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -322,6 +322,9 @@ class Envs:
     # Delay all-gather after qlora for better performance for Deepseek v3.2
     SGLANG_USE_AG_AFTER_QLORA = EnvBool(False)
     SGLANG_NPU_FUSED_MOE_MODE = EnvInt(1)
+    # Replace mlp matmul with torch kernel for better performance for Qwen-vl
+    USE_TORCH_MATMUL_FOR_MLP = EnvBool(False)
+
 
     # Quantization
     SGLANG_INT4_WEIGHT = EnvBool(False)

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -130,6 +130,8 @@ class UnquantizedLinearMethod(LinearMethodBase):
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         if _is_cpu and _is_cpu_amx_available:
             _amx_process_weight_after_loading(layer, ["weight"])
+        if getattr(layer, "layout_KN", False):
+            layer.weight.data = layer.weight.data.permute(1, 0).contiguous()
 
     def apply(
         self,

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -130,7 +130,7 @@ class UnquantizedLinearMethod(LinearMethodBase):
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         if _is_cpu and _is_cpu_amx_available:
             _amx_process_weight_after_loading(layer, ["weight"])
-        if getattr(layer, "layout_KN", False):
+        if getattr(layer, "layout_matmul_replace_linear", False):
             layer.weight.data = layer.weight.data.permute(1, 0).contiguous()
 
     def apply(
@@ -155,6 +155,12 @@ class UnquantizedLinearMethod(LinearMethodBase):
 
         elif _use_aiter and type(layer.weight.data) is torch.Tensor:
             return tgemm.mm(x, layer.weight, bias, otype=x.dtype)
+
+        elif getattr(layer, "layout_matmul_replace_linear", False):
+            output = torch.matmul(x, layer.weight)
+            if bias is not None:
+                output += bias
+            return output
 
         return F.linear(x, layer.weight, bias)
 

--- a/python/sglang/srt/models/qwen2.py
+++ b/python/sglang/srt/models/qwen2.py
@@ -26,7 +26,9 @@ from sglang.srt.distributed import (
     get_pp_group,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
+    tensor_model_parallel_all_reduce,
 )
+from sglang.srt.environ import envs
 from sglang.srt.layers.activation import SiluAndMul
 from sglang.srt.layers.dp_attention import is_dp_attention_enabled
 from sglang.srt.layers.layernorm import RMSNorm
@@ -51,13 +53,14 @@ from sglang.srt.model_loader.weight_utils import (
     kv_cache_scales_loader,
 )
 from sglang.srt.server_args import get_global_server_args
-from sglang.srt.utils import add_prefix, make_layers
+from sglang.srt.utils import add_prefix, is_npu, make_layers
 from sglang.srt.utils.hf_transformers_utils import get_rope_config
 
 Qwen2Config = None
 
-
+_use_torch_matmul = envs.USE_TORCH_MATMUL_FOR_MLP.get()
 logger = logging.getLogger(__name__)
+_is_npu = is_npu()
 
 
 class Qwen2MLP(nn.Module):
@@ -84,6 +87,8 @@ class Qwen2MLP(nn.Module):
             quant_config=quant_config,
             prefix=add_prefix("down_proj", prefix),
         )
+        if _use_torch_matmul:
+            setattr(self.down_proj, "layout_KN", True)
         if hidden_act != "silu":
             raise ValueError(
                 f"Unsupported activation: {hidden_act}. "
@@ -91,13 +96,17 @@ class Qwen2MLP(nn.Module):
             )
         self.act_fn = SiluAndMul()
 
-    def forward(self, x):
+    def forward(self, x, forward_batch: ForwardBatch):
         if get_global_server_args().rl_on_policy_target is not None:
             x = x.bfloat16()
 
         gate_up, _ = self.gate_up_proj(x)
         x = self.act_fn(gate_up)
-        x, _ = self.down_proj(x)
+        if _use_torch_matmul:
+            x = torch.matmul(x, self.down_proj.weight.data)
+            x = tensor_model_parallel_all_reduce(x)
+        else:
+            x, _ = self.down_proj(x)
         return x
 
 
@@ -254,7 +263,7 @@ class Qwen2DecoderLayer(nn.Module):
 
         # Fully Connected
         hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
-        hidden_states = self.mlp(hidden_states)
+        hidden_states = self.mlp(hidden_states, forward_batch)
         return hidden_states, residual
 
 

--- a/python/sglang/srt/models/qwen2.py
+++ b/python/sglang/srt/models/qwen2.py
@@ -26,7 +26,6 @@ from sglang.srt.distributed import (
     get_pp_group,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
-    tensor_model_parallel_all_reduce,
 )
 from sglang.srt.environ import envs
 from sglang.srt.layers.activation import SiluAndMul
@@ -53,14 +52,13 @@ from sglang.srt.model_loader.weight_utils import (
     kv_cache_scales_loader,
 )
 from sglang.srt.server_args import get_global_server_args
-from sglang.srt.utils import add_prefix, is_npu, make_layers
+from sglang.srt.utils import add_prefix, make_layers
 from sglang.srt.utils.hf_transformers_utils import get_rope_config
 
 Qwen2Config = None
 
-_use_torch_matmul = envs.USE_TORCH_MATMUL_FOR_MLP.get()
+_use_matmul_replace_linear = envs.USE_MATMUL_REPLACE_LINEAR.get()
 logger = logging.getLogger(__name__)
-_is_npu = is_npu()
 
 
 class Qwen2MLP(nn.Module):
@@ -87,8 +85,10 @@ class Qwen2MLP(nn.Module):
             quant_config=quant_config,
             prefix=add_prefix("down_proj", prefix),
         )
-        if _use_torch_matmul:
-            setattr(self.down_proj, "layout_KN", True)
+        # For NPU, replacing the linear layer with matmul + bias to achieve better performance. The "layout_KN"
+        # attribute is used to indicate that the weight layout is transposed (K, N) for the matmul operation.
+        if _use_matmul_replace_linear:
+            setattr(self.down_proj, "layout_matmul_replace_linear", True)
         if hidden_act != "silu":
             raise ValueError(
                 f"Unsupported activation: {hidden_act}. "
@@ -96,17 +96,13 @@ class Qwen2MLP(nn.Module):
             )
         self.act_fn = SiluAndMul()
 
-    def forward(self, x, forward_batch: ForwardBatch):
+    def forward(self, x):
         if get_global_server_args().rl_on_policy_target is not None:
             x = x.bfloat16()
 
         gate_up, _ = self.gate_up_proj(x)
         x = self.act_fn(gate_up)
-        if _use_torch_matmul:
-            x = torch.matmul(x, self.down_proj.weight.data)
-            x = tensor_model_parallel_all_reduce(x)
-        else:
-            x, _ = self.down_proj(x)
+        x, _ = self.down_proj(x)
         return x
 
 
@@ -263,7 +259,7 @@ class Qwen2DecoderLayer(nn.Module):
 
         # Fully Connected
         hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
-        hidden_states = self.mlp(hidden_states, forward_batch)
+        hidden_states = self.mlp(hidden_states)
         return hidden_states, residual
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

The performance of the original custom matmul kernel on NPU is currently suboptimal compared to torch.matmul. This PR replaces several custom kernels with torch.matmul to leverage its optimized implementation and improve overall execution speed.

## Modifications

Add environment variable USE_TORCH_MATMUL_FOR_MLP to optionally enable torch matmul optimization for improved Qwen-VL model performance.
Refactor Qwen2MLP forward pass to use torch.matmul() with tensor parallel all-reduce instead of custom linear layers when optimization is enabled.

## Accuracy Tests
*without replacement*
```python
100% 1319/1319 [07:06<00:00,  3.09it/s]
Accuracy: 0.688
Invalid: 0.001
Latency: 426.878 s
Output throughput: 1432.730 token/s
```
*with replacement*
```python
100% 1319/1319 [06:29<00:00,  3.39it/s]
Accuracy: 0.689
Invalid: 0.001
Latency: 389.330 s
Output throughput: 1570.437 token/s
```

## Speed Tests and Profiling

> **Key differences**
> - **Output token throughput**: `1360.31` vs `1261.08` (**+99.23 tok/s, +7.87%**)
> - **Mean TPOT**: `49.80 ms` vs `55.69 ms` (**-5.89 ms, -10.58%**)
> - **Mean TTFT**: `50706.96 ms` vs `52662.11 ms` (**-1955.15 ms, -3.71%**)

*test commond*
```python
vllm bench serve 
--backend openai-chat 
--model /path/to/weight/Qwen2.5-VL-72B-Instruct-bf16  
--tokenizer /path/to/weight/Qwen2.5-VL-72B-Instruct-bf16  
--served-model-name Qwen2.5-VL-72B-Instruct-bf16  
--dataset-name random-mm  
--random-input-len 0  
--random-output-len 1024  
--random-mm-base-items-per-request 1  
--random-mm-limit-mm-per-prompt '{"image": 1}'  
--random-mm-bucket-config '{(1024,1024,1): 1}'  
--request-rate 1024  
--endpoint /v1/chat/completions  
--host 127.0.0.1 --port 22001  --seed 1000  
--percentile-metrics ttft,tpot,itl,e2el  
--ignore-eos  
--trust-remote-code  
--temperature 0 
--max-concurrency 148  
--num-prompts 384
```
*result*
```python
Traffic request rate: 1024.0
Burstiness factor: 1.0 (Poisson process)
Maximum request concurrency: 148
100% 384/384 [04:49<00:00,  1.33it/s]
tip: install termplotlib and gnuplot to plot the metrics
============ Serving Benchmark Result ============
Successful requests:                     384       
Failed requests:                         0         
Maximum request concurrency:             148       
Request rate configured (RPS):           1024.00   
Benchmark duration (s):                  289.06    
Total input tokens:                      0         
Total generated tokens:                  393216    
Request throughput (req/s):              1.33      
Output token throughput (tok/s):         1360.31   
Peak output token throughput (tok/s):    2244.00   
Peak concurrent requests:                244.00    
Total token throughput (tok/s):          1360.31   
---------------Time to First Token----------------
Mean TTFT (ms):                          50706.96  
Median TTFT (ms):                        27678.22  
P99 TTFT (ms):                           91967.78  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          49.80     
Median TPOT (ms):                        46.59     
P99 TPOT (ms):                           58.59     
---------------Inter-token Latency----------------
Mean ITL (ms):                           84.23     
Median ITL (ms):                         89.75     
P99 ITL (ms):                            95.93     
----------------End-to-end Latency----------------
Mean E2EL (ms):                          101655.54 
Median E2EL (ms):                        75342.97  
P99 E2EL (ms):                           146197.98 
==================================================

```
*result without using torch matmul*
```python
============ Serving Benchmark Result ============
Successful requests:                     384       
Failed requests:                         0         
Maximum request concurrency:             148       
Request rate configured (RPS):           1024.00   
Benchmark duration (s):                  311.81    
Total input tokens:                      0         
Total generated tokens:                  393216    
Request throughput (req/s):              1.23      
Output token throughput (tok/s):         1261.08   
Peak output token throughput (tok/s):    1950.00   
Peak concurrent requests:                244.00    
Total token throughput (tok/s):          1261.08   
---------------Time to First Token----------------
Mean TTFT (ms):                          52662.11  
Median TTFT (ms):                        26946.70  
P99 TTFT (ms):                           97287.06  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          55.69     
Median TPOT (ms):                        52.48     
P99 TPOT (ms):                           73.33     
---------------Inter-token Latency----------------
Mean ITL (ms):                           95.46     
Median ITL (ms):                         101.62    
P99 ITL (ms):                            107.55    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          109633.21 
Median E2EL (ms):                        80704.88  
P99 E2EL (ms):                           157427.52 
==================================================
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
