### PR TITLE
[NPU] Fix libGL ImportError by using opencv-python-headless

### DIFF
--- a/python/pyproject_npu.toml
+++ b/python/pyproject_npu.toml
@@ -72,7 +72,7 @@ diffusion = [
     "imageio==2.36.0",
     "imageio-ffmpeg==0.5.1",
     "moviepy>=2.0.0",
-    "opencv-python==4.10.0.84",
+    "opencv-python-headless==4.10.0.84",
     "remote-pdb",
     "cache-dit==1.2.1",
     "addict",


### PR DESCRIPTION
Fixes #21717

## Motivation

The Ascend NPU Docker image (`quay.io/ascend/sglang:main-cann8.5.0-910b`) crashes on startup with `ImportError: libGL.so.1: cannot open shared object file`. `pyproject_npu.toml` uses `opencv-python` which depends on `libGL.so.1` and installs `cv2/typing/__init__.py` that shadows Python's stdlib `typing` module. Both `pyproject.toml` (CUDA) and `pyproject_other.toml` (ROCm) already use the headless variant correctly.

## Modifications

Replace `opencv-python==4.10.0.84` with `opencv-python-headless==4.10.0.84` in `python/pyproject_npu.toml` (line 75) to match other platform configs.

## Accuracy Tests

N/A — dependency-only change, no model output or forward code affected.

## Speed Tests and Profiling

N/A — no inference code changes.

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process
1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.