### PR TITLE
bugfix(model):fix deepstack index out of range error

### DIFF
--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -994,6 +994,8 @@ def embed_mm_inputs(
                     multimodal_model.separate_deepstack_embeds(embedding)
                 )
                 deepstack_embeddings += [deepstack_embedding]
+            else:
+                deepstack_embeddings += [None]
             modalities += [modality]
             embeddings += [embedding]
             masks += [mask]


### PR DESCRIPTION
## Motivation

This PR fixes a bookkeeping issue in the multimodal DeepStack embedding path.

In the current logic, `deepstack_embeddings` is appended only when `use_deepstack.get(modality, None)` is enabled and `embedding is not None`. However, `modalities`, `embeddings`, and `masks` are appended for every modality branch. As a result, when a modality does not produce an embedding, or when DeepStack is not applied for that modality, `deepstack_embeddings` can become misaligned with the other per-modality lists.

This misalignment can cause downstream indexing / merging issues in the DeepStack embedding assembly path. The goal of this PR is to keep these modality-wise lists strictly aligned and make the DeepStack path more robust for mixed multimodal inputs.

## Modifications

This PR adds an explicit fallback branch in the multimodal embedding collection logic:

```python
if use_deepstack.get(modality, None) and embedding is not None:
    embedding, deepstack_embedding = (
        multimodal_model.separate_deepstack_embeds(embedding)
    )
    deepstack_embeddings += [deepstack_embedding]
else:
    deepstack_embeddings += [None]
```

Concretely, the change does the following:

- preserves the existing behavior when DeepStack is enabled and a valid modality embedding is produced;
- appends `None` to `deepstack_embeddings` when DeepStack is not used for the modality, or when `embedding is None`;
- ensures `deepstack_embeddings`, `modalities`, `embeddings`, and `masks` always remain one-to-one aligned;
- keeps the downstream `input_deepstack_embeds` construction logic unchanged.

This is intended to be a robustness / consistency fix rather than a functional change to the normal embedding computation path.

## Accuracy Tests

Not run yet.

Expected behavior:

- no output change for existing unaffected cases;
- no shape / indexing mismatch in DeepStack-enabled multimodal requests;
- improved robustness when some modalities do not yield embeddings.

Planned / recommended validation:

- run existing multimodal regression tests with DeepStack disabled and confirm output parity;
- run DeepStack-enabled multimodal cases with mixed modalities, including cases where some modality embeddings are `None`;
- verify that list/tensor alignment is preserved and the forward path completes successfully.

## Speed Tests and Profiling

Not run yet.

This change is not expected to have a meaningful performance impact, since it only adds a Python-side fallback append (`deepstack_embeddings += [None]`) and does not modify kernels, tensor math, or the main embedding computation.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
