### PR TITLE
[Fix] Add timeout and retry to MGSM data download to prevent CI timeout

### DIFF
--- a/python/sglang/test/simple_eval_mgsm.py
+++ b/python/sglang/test/simple_eval_mgsm.py
@@ -9,6 +9,8 @@ https://arxiv.org/abs/2210.03057 reference: https://github.com/google-research/u
 
 import re
 import urllib
+import urllib.error
+import urllib.request
 from typing import Optional
 
 from sglang.test import simple_eval_common as common
@@ -112,16 +114,32 @@ def score_mgsm(target: str, prediction: str) -> bool:
     return target == prediction
 
 
-def get_lang_examples(lang: str) -> list[dict[str, str]]:
+def get_lang_examples(
+    lang: str, timeout: int = 60, max_retries: int = 3
+) -> list[dict[str, str]]:
     fpath = LANG_TO_FPATH[lang]
     examples = []
-    with urllib.request.urlopen(fpath) as f:
-        for line in f.read().decode("utf-8").splitlines():
-            inputs, targets = line.strip().split("\t")
-            if "." in targets:
-                raise ValueError(f"targets {targets} contains a decimal point.")
-            # targets = int(targets.replace(",", ""))
-            examples.append({"inputs": inputs, "targets": targets, "lang": lang})
+    for attempt in range(max_retries):
+        try:
+            with urllib.request.urlopen(fpath, timeout=timeout) as f:
+                for line in f.read().decode("utf-8").splitlines():
+                    inputs, targets = line.strip().split("\t")
+                    if "." in targets:
+                        raise ValueError(f"targets {targets} contains a decimal point.")
+                    examples.append(
+                        {"inputs": inputs, "targets": targets, "lang": lang}
+                    )
+            return examples
+        except (urllib.error.URLError, TimeoutError) as e:
+            if attempt < max_retries - 1:
+                import time
+
+                time.sleep(2**attempt)
+            else:
+                raise RuntimeError(
+                    f"Failed to download MGSM data for {lang} from {fpath} "
+                    f"after {max_retries} attempts: {e}"
+                ) from e
     return examples
 
 


### PR DESCRIPTION
## Summary
- `test_moe_eval_accuracy_large.py::test_mgsm_en` has been consistently timing out in CI since ~Mar 30 12:00 UTC
- **Root cause**: `urllib.request.urlopen()` in `simple_eval_mgsm.py:get_lang_examples()` has no timeout when downloading MGSM benchmark data from `openaipublic.blob.core.windows.net`. When the download hangs (network issue from CI runners), the test hangs indefinitely until the 1200s CI timeout kills it
- **Evidence**: Server logs show zero Prefill/Decode batches during the entire 18+ minute hang — the test is stuck in data download, not inference
- **Not a code regression**: Bisect shows the 3 commits between last pass (`62a63eeff`) and first fail (`b76730701`) don't touch inference code for Mixtral

## Changes
- Add `timeout=60` to `urllib.request.urlopen()` call
- Add retry logic (3 attempts with exponential backoff)
- Add explicit `urllib.error` and `urllib.request` imports

## Test plan
- [ ] CI `test_moe_eval_accuracy_large` passes (if blob storage is reachable) or fails fast with a clear error (if not)
- [ ] No functional change to test behavior when download succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)