### PR TITLE
perf: optimize PCG inductor path for FP8 models

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -29,6 +29,7 @@ from sglang.srt.layers.quantization.fp8_kernel import (
     w8a8_block_fp8_matmul_deepgemm,
     w8a8_block_fp8_matmul_triton,
 )
+from sglang.srt.environ import envs
 from sglang.srt.utils import (
     ceil_align,
     ceil_div,
@@ -1456,16 +1457,17 @@ def apply_fp8_linear(
         num_token_padding = output_padding
         if cutlass_fp8_supported and weight_scale.numel() == weight.shape[1]:
             num_token_padding = None
-        # For static per-tensor scales under torch.compile, use pure PyTorch
+        # For static per-tensor scales when using inductor compiler, use pure PyTorch
         # ops instead of the opaque sgl_kernel quant kernel. Inductor fuses
         # these with surrounding ops (RMSNorm, residual add), eliminating
-        # a separate kernel launch per linear layer. Only activates during
-        # inductor tracing (prefill PCG); decode uses the faster custom kernel.
+        # a separate kernel launch per linear layer. Only activates when
+        # piecewise_cuda_graph_compiler=inductor; eager PCG and decode both
+        # use the faster custom kernel.
         if (
             input_scale is not None
             and input_scale.numel() == 1
             and weight_scale.numel() == 1
-            and torch.compiler.is_compiling()
+            and envs.SGLANG_ENABLE_TORCH_COMPILE.get()
         ):
             qinput = (
                 (input_2d * input_scale.reciprocal())

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -29,7 +29,7 @@ from sglang.srt.layers.quantization.fp8_kernel import (
     w8a8_block_fp8_matmul_deepgemm,
     w8a8_block_fp8_matmul_triton,
 )
-from sglang.srt.environ import envs
+from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import (
     ceil_align,
     ceil_div,
@@ -1467,7 +1467,7 @@ def apply_fp8_linear(
             input_scale is not None
             and input_scale.numel() == 1
             and weight_scale.numel() == 1
-            and envs.SGLANG_ENABLE_TORCH_COMPILE.get()
+            and get_global_server_args().piecewise_cuda_graph_compiler == "inductor"
         ):
             qinput = (
                 (input_2d * input_scale.reciprocal())

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 from sglang.srt.layers.quantization.fp8_kernel import (
     fp8_dtype,
     fp8_max,
+    fp8_min,
     is_fp8_fnuz,
     mxfp8_block_scaled_matmul_triton,
     per_token_group_quant_fp8,
@@ -28,6 +29,7 @@ from sglang.srt.layers.quantization.fp8_kernel import (
     w8a8_block_fp8_matmul_deepgemm,
     w8a8_block_fp8_matmul_triton,
 )
+from sglang.srt.environ import envs
 from sglang.srt.utils import (
     ceil_align,
     ceil_div,
@@ -1455,12 +1457,27 @@ def apply_fp8_linear(
         num_token_padding = output_padding
         if cutlass_fp8_supported and weight_scale.numel() == weight.shape[1]:
             num_token_padding = None
-        qinput, x_scale = scaled_fp8_quant(
-            input_2d,
-            input_scale,
-            num_token_padding=num_token_padding,
-            use_per_token_if_dynamic=use_per_token_if_dynamic,
-        )
+        # For static per-tensor scales, use pure PyTorch ops instead of the
+        # opaque sgl_kernel quant kernel. Inductor can fuse these with
+        # surrounding ops (RMSNorm, residual add), eliminating a separate
+        # kernel launch per linear layer.
+        if (
+            input_scale is not None
+            and input_scale.numel() == 1
+            and weight_scale.numel() == 1
+            and envs.SGLANG_ENABLE_TORCH_COMPILE.get()
+        ):
+            qinput = (input_2d * input_scale.reciprocal()).clamp(
+                min=fp8_min, max=fp8_max
+            ).to(fp8_dtype)
+            x_scale = input_scale
+        else:
+            qinput, x_scale = scaled_fp8_quant(
+                input_2d,
+                input_scale,
+                num_token_padding=num_token_padding,
+                use_per_token_if_dynamic=use_per_token_if_dynamic,
+            )
     else:
         # cutlass w8a8 fp8 sgl-kernel only supports per-token scale
         if input_scale is not None:

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -1457,16 +1457,17 @@ def apply_fp8_linear(
         num_token_padding = output_padding
         if cutlass_fp8_supported and weight_scale.numel() == weight.shape[1]:
             num_token_padding = None
-        # For static per-tensor scales when using inductor compiler, use pure PyTorch
-        # ops instead of the opaque sgl_kernel quant kernel. Inductor fuses
-        # these with surrounding ops (RMSNorm, residual add), eliminating
-        # a separate kernel launch per linear layer. Only activates when
+        # For static per-tensor activation scales when using inductor compiler,
+        # use pure PyTorch ops instead of the opaque sgl_kernel quant kernel.
+        # Inductor fuses these with surrounding ops (RMSNorm, residual add),
+        # eliminating a separate kernel launch per linear layer.
+        # weight_scale shape does not matter here -- it is only used in the
+        # GEMM epilogue, not in the activation quant fusion. Only activates when
         # piecewise_cuda_graph_compiler=inductor; eager PCG and decode both
         # use the faster custom kernel.
         if (
             input_scale is not None
             and input_scale.numel() == 1
-            and weight_scale.numel() == 1
             and get_global_server_args().piecewise_cuda_graph_compiler == "inductor"
         ):
             qinput = (

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Callable, List, Optional, Tuple
 
 import torch
 
-from sglang.srt.environ import envs
 from sglang.srt.layers import deep_gemm_wrapper
 from sglang.srt.layers.quantization.fp8_kernel import sglang_per_token_group_quant_fp8
 from sglang.srt.layers.quantization.mxfp4_tensor import MXFP4QuantizeUtil
@@ -1457,15 +1456,16 @@ def apply_fp8_linear(
         num_token_padding = output_padding
         if cutlass_fp8_supported and weight_scale.numel() == weight.shape[1]:
             num_token_padding = None
-        # For static per-tensor scales, use pure PyTorch ops instead of the
-        # opaque sgl_kernel quant kernel. Inductor can fuse these with
-        # surrounding ops (RMSNorm, residual add), eliminating a separate
-        # kernel launch per linear layer.
+        # For static per-tensor scales under torch.compile, use pure PyTorch
+        # ops instead of the opaque sgl_kernel quant kernel. Inductor fuses
+        # these with surrounding ops (RMSNorm, residual add), eliminating
+        # a separate kernel launch per linear layer. Only activates during
+        # inductor tracing (prefill PCG); decode uses the faster custom kernel.
         if (
             input_scale is not None
             and input_scale.numel() == 1
             and weight_scale.numel() == 1
-            and envs.SGLANG_ENABLE_TORCH_COMPILE.get()
+            and torch.compiler.is_compiling()
         ):
             qinput = (
                 (input_2d * input_scale.reciprocal())

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Callable, List, Optional, Tuple
 
 import torch
 
+from sglang.srt.environ import envs
 from sglang.srt.layers import deep_gemm_wrapper
 from sglang.srt.layers.quantization.fp8_kernel import sglang_per_token_group_quant_fp8
 from sglang.srt.layers.quantization.mxfp4_tensor import MXFP4QuantizeUtil
@@ -29,7 +30,6 @@ from sglang.srt.layers.quantization.fp8_kernel import (
     w8a8_block_fp8_matmul_deepgemm,
     w8a8_block_fp8_matmul_triton,
 )
-from sglang.srt.environ import envs
 from sglang.srt.utils import (
     ceil_align,
     ceil_div,
@@ -1467,9 +1467,11 @@ def apply_fp8_linear(
             and weight_scale.numel() == 1
             and envs.SGLANG_ENABLE_TORCH_COMPILE.get()
         ):
-            qinput = (input_2d * input_scale.reciprocal()).clamp(
-                min=fp8_min, max=fp8_max
-            ).to(fp8_dtype)
+            qinput = (
+                (input_2d * input_scale.reciprocal())
+                .clamp(min=fp8_min, max=fp8_max)
+                .to(fp8_dtype)
+            )
             x_scale = input_scale
         else:
             qinput, x_scale = scaled_fp8_quant(

--- a/python/sglang/srt/models/utils.py
+++ b/python/sglang/srt/models/utils.py
@@ -30,6 +30,7 @@ from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
+from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import get_current_device_stream_fast, is_cuda, is_hip
 from sglang.srt.utils.custom_op import register_custom_op
 
@@ -422,7 +423,8 @@ def apply_qk_norm(
         and allow_inplace  # TODO(dark): this can be relaxed if needed
         and (q_eps == k_eps)  # TODO(dark): this can also be relaxed
         and not envs.SGLANG_ENABLE_DETERMINISTIC_INFERENCE.get()
-        and not envs.SGLANG_ENABLE_TORCH_COMPILE.get()  # let inductor fuse QK norm
+        and get_global_server_args().piecewise_cuda_graph_compiler
+        != "inductor"  # let inductor fuse QK norm
         and can_use_fused_inplace_qknorm(head_dim, q.dtype)
     ):
         fused_inplace_qknorm(

--- a/python/sglang/srt/models/utils.py
+++ b/python/sglang/srt/models/utils.py
@@ -422,6 +422,7 @@ def apply_qk_norm(
         and allow_inplace  # TODO(dark): this can be relaxed if needed
         and (q_eps == k_eps)  # TODO(dark): this can also be relaxed
         and not envs.SGLANG_ENABLE_DETERMINISTIC_INFERENCE.get()
+        and not envs.SGLANG_ENABLE_TORCH_COMPILE.get()  # let inductor fuse QK norm
         and can_use_fused_inplace_qknorm(head_dim, q.dtype)
     ):
         fused_inplace_qknorm(
@@ -437,16 +438,16 @@ def apply_qk_norm(
     if alt_stream is not None and get_is_capture_mode():
         current_stream = get_current_device_stream_fast()
         alt_stream.wait_stream(current_stream)
-        q_by_head = q.reshape(-1, head_dim)
+        q_by_head = q.view(*q.shape[:-1], -1, head_dim)
         q_by_head = q_norm(q_by_head)
         with torch.cuda.stream(alt_stream):
-            k_by_head = k.reshape(-1, head_dim)
+            k_by_head = k.view(*k.shape[:-1], -1, head_dim)
             k_by_head = k_norm(k_by_head)
         current_stream.wait_stream(alt_stream)
     else:
-        q_by_head = q.reshape(-1, head_dim)
+        q_by_head = q.view(*q.shape[:-1], -1, head_dim)
         q_by_head = q_norm(q_by_head)
-        k_by_head = k.reshape(-1, head_dim)
+        k_by_head = k.view(*k.shape[:-1], -1, head_dim)
         k_by_head = k_norm(k_by_head)
     q = q_by_head.view(q.shape)
     k = k_by_head.view(k.shape)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3616,7 +3616,13 @@ class ServerArgs:
                 self.enable_dynamic_batch_tokenizer = False
 
     def _handle_environment_variables(self):
-        envs.SGLANG_ENABLE_TORCH_COMPILE.set("1" if self.enable_torch_compile else "0")
+        # Also enable torch_compile env when PCG uses inductor compiler,
+        # so that code can check this env to prefer inductor-fusible ops
+        # over custom CUDA kernels that become opaque nodes in the graph.
+        use_torch_compile = self.enable_torch_compile or (
+            self.piecewise_cuda_graph_compiler == "inductor"
+        )
+        envs.SGLANG_ENABLE_TORCH_COMPILE.set("1" if use_torch_compile else "0")
         if self.mamba_ssm_dtype is not None:
             envs.SGLANG_MAMBA_SSM_DTYPE.set(self.mamba_ssm_dtype)
         envs.SGLANG_DISABLE_OUTLINES_DISK_CACHE.set(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3616,13 +3616,7 @@ class ServerArgs:
                 self.enable_dynamic_batch_tokenizer = False
 
     def _handle_environment_variables(self):
-        # Also enable torch_compile env when PCG uses inductor compiler,
-        # so that code can check this env to prefer inductor-fusible ops
-        # over custom CUDA kernels that become opaque nodes in the graph.
-        use_torch_compile = self.enable_torch_compile or (
-            self.piecewise_cuda_graph_compiler == "inductor"
-        )
-        envs.SGLANG_ENABLE_TORCH_COMPILE.set("1" if use_torch_compile else "0")
+        envs.SGLANG_ENABLE_TORCH_COMPILE.set("1" if self.enable_torch_compile else "0")
         if self.mamba_ssm_dtype is not None:
             envs.SGLANG_MAMBA_SSM_DTYPE.set(self.mamba_ssm_dtype)
         envs.SGLANG_DISABLE_OUTLINES_DISK_CACHE.set(


### PR DESCRIPTION
Three changes that reduce GPU kernel overhead under PCG with inductor compiler:

1. **models/utils** (`apply_qk_norm`): Skip `fused_inplace_qknorm` when `piecewise_cuda_graph_compiler == "inductor"`; fix reshape pattern from `reshape(-1, head_dim)` to `view(*shape[:-1], -1, head_dim)`. The old 2D reshape forced inductor to emit separate `as_strided`/`clone`/`split_with_sizes` kernels; the new 3D view is stride-preserving and fuses cleanly with RMSNorm.
2. **fp8_utils** (`apply_fp8_linear`): For static per-tensor FP8 quantization, use pure PyTorch ops (`reciprocal` + `clamp` + `cast`) instead of the opaque `sgl_kernel.per_tensor_quant_fp8` kernel when `piecewise_cuda_graph_compiler == "inductor"`. Inductor fuses these with surrounding RMSNorm and GEMM dispatch, eliminating a separate kernel launch per linear layer. Eager PCG and decode both continue to use the faster custom kernel.

The inductor check is done locally at each call site via `get_global_server_args().piecewise_cuda_graph_compiler` rather than modifying the global `SGLANG_ENABLE_TORCH_COMPILE` env var, avoiding potential side effects on other code paths.

## Embedding Benchmarks

Qwen3-0.6B embeddings on H200, PCG inductor, production traffic distribution, 60 RPS:

| Config | Items/sec | vs baseline |
|--------|:---------:|:-----------:|
| **This PR (FP8)** | **34.38** | **+24%** |
| main (non-fp8, baseline) | 27.68 | — |

## Generation Benchmarks

Qwen3-0.6B FP8 on H200, PCG inductor, 100 in / 30k out, 10 prompts, request rate 2:

| Server | Output tok/s |
|--------|:------------:|
| **This PR** | **1,025** |
| main | 1,021 |

No regression in decode.

## Per-request GPU profile (FP8 embedding, 7k tokens)

| Metric | main | This PR | Change |
|--------|:----:|:-------:|:------:|
| GPU time/req | 9.8ms | 7.8ms | **-20%** |
| Kernel launches/req | 581 | 441 | **-24%** |

Eliminated kernels per request:
- `fused_qknorm_warp` (28x) — now fused into triton RMSNorm kernels
- `triton_poi_fused_as_strided_clone_split_with_sizes_view` (54x) — eliminated by stride-preserving reshape
- `triton_poi_fused_as_strided_view` (27x) — eliminated by stride-preserving reshape
- `per_tensor_quant_fp8_kernel` (112x) — fused into triton RMSNorm+quant kernels