### PR TITLE
[AMD] DO NOT MERGE - Move unwrap_shm_features before broadcast to fix TP>1 VLM crash (AMD nightly-4-gpu)

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1454,6 +1454,13 @@ class Scheduler(
         if self.input_blocker is not None:
             recv_reqs = self.input_blocker.handle(recv_reqs)
 
+        # Unwrap shared memory features on rank 0 BEFORE broadcast so that
+        # broadcasts send regular tensors instead of shm_name references.
+        # Other ranks cannot open shm segments created in the tokenizer process.
+        if recv_reqs:
+            for req in recv_reqs:
+                unwrap_shm_features(req)
+
         if self.server_args.enable_dp_attention:
             if self.attn_tp_rank == 0 and self.attn_cp_rank == 0:
                 work_reqs, control_reqs = self._split_work_and_control_reqs(recv_reqs)
@@ -1509,13 +1516,6 @@ class Scheduler(
                 )
                 prepare_abort(req, error_msg, status_code=status_code)
                 self.stream_output([req], req.return_logprob)
-
-        # Unwrap shared memory features AFTER all broadcasts complete,
-        # so that ShmPointerMMData metadata (not full tensor data) is what
-        # gets serialized during broadcast_pyobj.
-        if recv_reqs:
-            for req in recv_reqs:
-                unwrap_shm_features(req)
 
         return recv_reqs
 


### PR DESCRIPTION
## Motivation
#21465 moved `unwrap_shm_features` to after `broadcast_pyobj` so that only `shm_name` metadata (instead of full tensors) is serialized during broadcast. However, shared memory segments are created by the tokenizer manager process and are only accessible from that process's namespace. When non-rank-0 schedulers deserialize `ShmPointerMMData` during broadcast, they call `shm_open(shm_name)` which fails with `FileNotFoundError` because the segment has already been unlinked by the tokenizer side.
This causes `test_encoder_dp.py` (Qwen3-VL-32B, TP=4, `--mm-enable-dp-encoder`) to crash on TP1/TP3 with:
`FileNotFoundError: [Errno 2] No such file or directory: '/psm_43f004c4'` (see: https://github.com/sgl-project/sglang/actions/runs/23759205665/job/69221928169#step:5:12320)
resulting in MMMU accuracy dropping to 0.25 (random guessing).


## Modifications

Move `unwrap_shm_features` back to **before** broadcast. Rank 0 materializes shm into regular tensors first, then broadcast sends normal tensor data that all ranks can deserialize without shm access.
The `ShmPointerMMData` refactoring from pr21465 (`materialize()`, zero-copy `__setstate__`, `__del__` guard) is preserved, only the call order in `scheduler.py` is changed.


## Accuracy Tests

https://github.com/sgl-project/sglang/actions/runs/23782802453/job/69299041224

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
