### PR TITLE
[1/N] feat: support compressed-tensors w4afp8 MoE

### DIFF
--- a/benchmark/kernels/quantization/bench_w4a8_moe_decode.py
+++ b/benchmark/kernels/quantization/bench_w4a8_moe_decode.py
@@ -1,0 +1,887 @@
+"""Benchmark breakdown for CUTLASS W4A8 MoE decode (TP=8 dimensions).
+
+Profiles each stage of cutlass_w4a8_moe and compares with Marlin W4A16:
+  1. pre_reorder + FP8 quant
+  2. get_cutlass_w4a8_moe_mm_data
+  3. GEMM 1 (gate+up)
+  4. SiLU + FP8 quant
+  5. GEMM 2 (down)
+  6. post_reorder
+
+Usage:
+    python benchmarks/bench_w4a8_moe_decode.py [--batch 1 2 4 8 16 32]
+    python benchmarks/bench_w4a8_moe_decode.py --batch 1 4 8 16 32 --no-marlin
+    python benchmarks/bench_w4a8_moe_decode.py --batch 1 4 8 16 32 --no-breakdown
+    python benchmarks/bench_w4a8_moe_decode.py --tune-gemm2 --batch 1 4 8 16 32
+"""
+
+import argparse
+import socket
+from unittest.mock import patch
+
+import torch
+import torch.distributed
+
+from sglang.srt.distributed import (
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+
+
+def init_dist():
+    if not torch.distributed.is_initialized():
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", 0))
+            port = s.getsockname()[1]
+        init_distributed_environment(
+            world_size=1,
+            rank=0,
+            local_rank=0,
+            backend="nccl",
+            distributed_init_method=f"tcp://127.0.0.1:{port}",
+        )
+    try:
+        initialize_model_parallel(tensor_model_parallel_size=1)
+    except AssertionError:
+        pass
+
+
+def pack_int4_to_int8(vals: torch.Tensor) -> torch.Tensor:
+    low = vals[..., 0::2].to(torch.int8)
+    high = vals[..., 1::2].to(torch.int8)
+    return ((high << 4) | (low & 0x0F)).to(torch.int8)
+
+
+def pack_interleave(num_experts, ref_weight, ref_scale, alignment=None):
+    """Matches sgl-kernel/tests/test_cutlass_w4a8_moe_mm.py::pack_interleave."""
+    n, k = ref_weight.shape[1], ref_weight.shape[2]
+    w_q = pack_int4_to_int8(ref_weight.cpu()).cuda()
+    w_q = w_q.view(num_experts, n, k // 2).contiguous()
+
+    if alignment is None:
+        alignment = 4 if k % 512 == 0 else 1
+
+    s = ref_scale
+    s = s.reshape(s.shape[0], s.shape[1], s.shape[2] // alignment, alignment)
+    s = s.permute(0, 2, 1, 3)
+    s = s.reshape(
+        ref_scale.shape[0],
+        ref_scale.shape[2] // alignment,
+        ref_scale.shape[1] * alignment,
+    )
+    w_scale = s.contiguous()
+    return w_q, w_scale
+
+
+class CUDATimer:
+    def __init__(self):
+        self.start_ev = torch.cuda.Event(enable_timing=True)
+        self.end_ev = torch.cuda.Event(enable_timing=True)
+
+    def start(self):
+        self.start_ev.record()
+
+    def stop(self) -> float:
+        self.end_ev.record()
+        torch.cuda.synchronize()
+        return self.start_ev.elapsed_time(self.end_ev)
+
+
+def _stats(vals):
+    mean = sum(vals) / len(vals)
+    std = (sum((v - mean) ** 2 for v in vals) / len(vals)) ** 0.5
+    return mean, std
+
+
+# ---------------------------------------------------------------------------
+# Prepare CUTLASS weights (shared across benchmarks)
+# ---------------------------------------------------------------------------
+def prepare_cutlass_weights(E, K, N, group_size):
+    device = "cuda"
+    ref_w1 = torch.randint(-8, 8, (E, 2 * N, K), dtype=torch.int8, device=device)
+    scale_1 = (
+        torch.randn(E, 2 * N, K // group_size, dtype=torch.bfloat16, device=device)
+        * 0.005
+    )
+    w1_q, w1_scale = pack_interleave(E, ref_w1, scale_1)
+
+    ref_w2 = torch.randint(-8, 8, (E, K, N), dtype=torch.int8, device=device)
+    scale_2 = (
+        torch.randn(E, K, N // group_size, dtype=torch.bfloat16, device=device) * 0.005
+    )
+    w2_q, w2_scale = pack_interleave(E, ref_w2, scale_2, alignment=1)
+
+    del ref_w1, ref_w2, scale_1, scale_2
+    torch.cuda.empty_cache()
+    return w1_q, w1_scale, w2_q, w2_scale
+
+
+# ---------------------------------------------------------------------------
+# CUTLASS real E2E — calls cutlass_w4a8_moe directly, no per-stage sync
+# ---------------------------------------------------------------------------
+def benchmark_cutlass_real_e2e(
+    M: int,
+    w1_q,
+    w1_scale,
+    w2_q,
+    w2_scale,
+    E: int = 384,
+    hidden_size: int = 7168,
+    intermediate_tp: int = 256,
+    topk: int = 6,
+    warmup: int = 10,
+    repeat: int = 50,
+):
+    from sglang.srt.layers.moe.cutlass_w4a8_moe import cutlass_w4a8_moe
+    from sglang.srt.layers.moe.topk import TopKConfig, select_experts
+
+    device = "cuda"
+    K = hidden_size
+    N = intermediate_tp
+
+    a_strides1 = torch.full((E, 3), K, device=device, dtype=torch.int64)
+    c_strides1 = torch.full((E, 3), 2 * N, device=device, dtype=torch.int64)
+    a_strides2 = torch.full((E, 3), N, device=device, dtype=torch.int64)
+    c_strides2 = torch.full((E, 3), K, device=device, dtype=torch.int64)
+    b_strides1 = a_strides1
+    s_strides13 = c_strides1
+    b_strides2 = a_strides2
+    s_strides2 = c_strides2
+    expert_offsets = torch.empty(E + 1, dtype=torch.int32, device=device)
+    problem_sizes1 = torch.empty((E, 3), dtype=torch.int32, device=device)
+    problem_sizes2 = torch.empty((E, 3), dtype=torch.int32, device=device)
+
+    a = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+    score = torch.randn(M, E, dtype=torch.bfloat16, device=device)
+    topk_output = select_experts(
+        hidden_states=a,
+        router_logits=score,
+        topk_config=TopKConfig(top_k=topk, renormalize=False),
+    )
+    topk_weights, topk_ids, _ = topk_output
+
+    times = []
+    for i in range(warmup + repeat):
+        t = CUDATimer()
+        t.start()
+        cutlass_w4a8_moe(
+            a,
+            w1_q,
+            w2_q,
+            w1_scale,
+            w2_scale,
+            topk_weights,
+            topk_ids,
+            a_strides1,
+            b_strides1,
+            c_strides1,
+            a_strides2,
+            b_strides2,
+            c_strides2,
+            s_strides13,
+            s_strides2,
+            expert_offsets,
+            problem_sizes1,
+            problem_sizes2,
+        )
+        ms = t.stop()
+        if i >= warmup:
+            times.append(ms)
+
+    mean, std = _stats(times)
+    return mean, std
+
+
+# ---------------------------------------------------------------------------
+# CUTLASS per-stage breakdown (with per-stage sync for profiling)
+# ---------------------------------------------------------------------------
+def benchmark_cutlass_breakdown(
+    M: int,
+    w1_q,
+    w1_scale,
+    w2_q,
+    w2_scale,
+    E: int = 384,
+    hidden_size: int = 7168,
+    intermediate_tp: int = 256,
+    topk: int = 6,
+    group_size: int = 128,
+    warmup: int = 10,
+    repeat: int = 50,
+):
+    from sgl_kernel import cutlass_w4a8_moe_mm, get_cutlass_w4a8_moe_mm_data
+
+    from sglang.jit_kernel.per_tensor_absmax_fp8 import per_tensor_absmax_fp8
+    from sglang.srt.layers.moe.ep_moe.kernels import (
+        cutlass_w4_run_moe_ep_preproess,
+        post_reorder_for_cutlass_moe,
+        pre_reorder_for_cutlass_moe,
+        silu_mul_static_tensorwise_quant_for_cutlass_moe,
+    )
+    from sglang.srt.layers.moe.topk import TopKConfig, select_experts
+
+    device = "cuda"
+    K = hidden_size
+    N = intermediate_tp
+
+    a_strides1 = torch.full((E, 3), K, device=device, dtype=torch.int64)
+    c_strides1 = torch.full((E, 3), 2 * N, device=device, dtype=torch.int64)
+    a_strides2 = torch.full((E, 3), N, device=device, dtype=torch.int64)
+    c_strides2 = torch.full((E, 3), K, device=device, dtype=torch.int64)
+    b_strides1 = a_strides1
+    s_strides13 = c_strides1
+    b_strides2 = a_strides2
+    s_strides2 = c_strides2
+    expert_offsets = torch.empty(E + 1, dtype=torch.int32, device=device)
+    problem_sizes1 = torch.empty((E, 3), dtype=torch.int32, device=device)
+    problem_sizes2 = torch.empty((E, 3), dtype=torch.int32, device=device)
+
+    a = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+    score = torch.randn(M, E, dtype=torch.bfloat16, device=device)
+    topk_output = select_experts(
+        hidden_states=a,
+        router_logits=score,
+        topk_config=TopKConfig(top_k=topk, renormalize=False),
+    )
+    topk_weights, topk_ids, _ = topk_output
+
+    a1_scale = torch.empty(1, dtype=torch.float32, device=device)
+    per_tensor_absmax_fp8(a, a1_scale)
+
+    num_local_experts = E
+    timings = {
+        "1_pre_reorder_quant": [],
+        "2_get_mm_data": [],
+        "3_gemm1": [],
+        "4_a2scale+silu_quant": [],
+        "5_gemm2": [],
+        "6_post_reorder": [],
+        "total_e2e": [],
+    }
+
+    for i in range(warmup + repeat):
+        src2dst = cutlass_w4_run_moe_ep_preproess(topk_ids)
+        gateup_input = torch.empty(
+            (M * topk, K), device=device, dtype=torch.float8_e4m3fn
+        )
+
+        te = CUDATimer()
+        te.start()
+
+        t1 = CUDATimer()
+        t1.start()
+        pre_reorder_for_cutlass_moe(
+            a,
+            gateup_input,
+            src2dst,
+            topk_ids,
+            a1_scale,
+            num_local_experts,
+            topk,
+            M,
+            K,
+        )
+        t1_ms = t1.stop()
+
+        t2 = CUDATimer()
+        t2.start()
+        a_map = torch.empty(topk_ids.numel(), dtype=torch.int32, device=device)
+        c_map = torch.empty(topk_ids.numel(), dtype=torch.int32, device=device)
+        get_cutlass_w4a8_moe_mm_data(
+            topk_ids,
+            expert_offsets,
+            problem_sizes1,
+            problem_sizes2,
+            a_map,
+            c_map,
+            num_local_experts,
+            N,
+            K,
+        )
+        t2_ms = t2.stop()
+
+        c1 = torch.empty((M * topk, N * 2), device=device, dtype=torch.bfloat16)
+        t3 = CUDATimer()
+        t3.start()
+        cutlass_w4a8_moe_mm(
+            c1,
+            gateup_input,
+            w1_q,
+            a1_scale.float(),
+            w1_scale,
+            expert_offsets[:-1],
+            problem_sizes1,
+            a_strides1,
+            b_strides1,
+            c_strides1,
+            s_strides13,
+            128,
+            topk,
+        )
+        t3_ms = t3.stop()
+
+        intermediate_q = torch.empty(
+            (M * topk, N), dtype=torch.float8_e4m3fn, device=device
+        )
+        a2_scale = torch.empty(1, dtype=torch.float32, device=device)
+        t4 = CUDATimer()
+        t4.start()
+        per_tensor_absmax_fp8(c1, a2_scale)
+        silu_mul_static_tensorwise_quant_for_cutlass_moe(
+            c1,
+            intermediate_q,
+            a2_scale.float(),
+            expert_offsets[-1:],
+            M * topk,
+            N,
+        )
+        t4_ms = t4.stop()
+
+        c2 = torch.empty((M * topk, K), device=device, dtype=torch.bfloat16)
+        t5 = CUDATimer()
+        t5.start()
+        cutlass_w4a8_moe_mm(
+            c2,
+            intermediate_q,
+            w2_q,
+            a2_scale.float(),
+            w2_scale,
+            expert_offsets[:-1],
+            problem_sizes2,
+            a_strides2,
+            b_strides2,
+            c_strides2,
+            s_strides2,
+            128,
+            topk,
+        )
+        t5_ms = t5.stop()
+
+        output = torch.empty_like(a)
+        t6 = CUDATimer()
+        t6.start()
+        post_reorder_for_cutlass_moe(
+            c2,
+            output,
+            src2dst,
+            topk_ids,
+            topk_weights,
+            num_local_experts,
+            topk,
+            M,
+            K,
+            1.0,
+        )
+        t6_ms = t6.stop()
+
+        te_ms = te.stop()
+
+        if i >= warmup:
+            timings["1_pre_reorder_quant"].append(t1_ms)
+            timings["2_get_mm_data"].append(t2_ms)
+            timings["3_gemm1"].append(t3_ms)
+            timings["4_a2scale+silu_quant"].append(t4_ms)
+            timings["5_gemm2"].append(t5_ms)
+            timings["6_post_reorder"].append(t6_ms)
+            timings["total_e2e"].append(te_ms)
+
+    e2e_mean = sum(timings["total_e2e"]) / repeat
+
+    print(f"\n{'='*70}")
+    print(f"  [CUTLASS W4A8 Breakdown] M={M}, E={E}, N_tp={N}, K={K}, topk={topk}")
+    print(f"  GEMM1: N={2*N}, K={K}   GEMM2: N={K}, K={N}")
+    print(f"{'='*70}")
+    print(f"  {'Stage':<25s}  {'Mean(ms)':>10s}  {'Std(ms)':>10s}  {'Pct':>8s}")
+    print(f"  {'-'*25}  {'-'*10}  {'-'*10}  {'-'*8}")
+
+    stage_sum = 0.0
+    for name, vals in timings.items():
+        mean, std = _stats(vals)
+        pct = mean / e2e_mean * 100 if e2e_mean > 0 else 0
+        print(f"  {name:<25s}  {mean:10.3f}  {std:10.3f}  {pct:7.1f}%")
+        if name != "total_e2e":
+            stage_sum += mean
+
+    overhead = e2e_mean - stage_sum
+    print(
+        f"  {'overhead(sync+alloc+py)':<25s}  {overhead:10.3f}  {'':>10s}  {overhead/e2e_mean*100:7.1f}%"
+    )
+
+    return e2e_mean
+
+
+# ---------------------------------------------------------------------------
+# Marlin W4A16 E2E benchmark
+# ---------------------------------------------------------------------------
+def prepare_marlin_weights(E, K, N, group_size):
+    from sglang.srt.layers.quantization.gptq import gptq_marlin_moe_repack
+    from sglang.srt.layers.quantization.marlin_utils import marlin_moe_permute_scales
+
+    device = "cuda"
+    pack_factor = 8
+
+    print("  Preparing Marlin W4A16 weights (one-time, ~30s for E=384)...")
+
+    w1_gptq = torch.randint(
+        0,
+        2**16,
+        (E, K // pack_factor, 2 * N),
+        dtype=torch.int32,
+        device=device,
+    )
+    w2_gptq = torch.randint(
+        0,
+        2**16,
+        (E, N // pack_factor, K),
+        dtype=torch.int32,
+        device=device,
+    )
+
+    w1_scale = (
+        torch.randn(E, K // group_size, 2 * N, dtype=torch.bfloat16, device=device)
+        * 0.005
+    )
+    w2_scale = (
+        torch.randn(E, N // group_size, K, dtype=torch.bfloat16, device=device) * 0.005
+    )
+
+    sort_indices = torch.empty((E, 0), dtype=torch.int32, device=device)
+
+    w1 = gptq_marlin_moe_repack(w1_gptq, sort_indices, K, 2 * N, 4)
+    w2 = gptq_marlin_moe_repack(w2_gptq, sort_indices, N, K, 4)
+    del w1_gptq, w2_gptq
+
+    w1_scale = marlin_moe_permute_scales(w1_scale, K, 2 * N, group_size)
+    w2_scale = marlin_moe_permute_scales(w2_scale, N, K, group_size)
+
+    torch.cuda.empty_cache()
+    print("  Marlin weights ready.")
+    return w1, w2, w1_scale, w2_scale
+
+
+def benchmark_marlin_e2e(
+    M: int,
+    marlin_w1,
+    marlin_w2,
+    marlin_w1_scale,
+    marlin_w2_scale,
+    E: int = 384,
+    hidden_size: int = 7168,
+    intermediate_tp: int = 256,
+    topk: int = 6,
+    warmup: int = 10,
+    repeat: int = 50,
+):
+    from sglang.srt.layers.moe.fused_moe_triton.fused_marlin_moe import (
+        fused_marlin_moe,
+    )
+    from sglang.srt.layers.moe.topk import TopKConfig, select_experts
+
+    device = "cuda"
+    K = hidden_size
+
+    a = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+    score = torch.randn(M, E, dtype=torch.bfloat16, device=device)
+    topk_output = select_experts(
+        hidden_states=a,
+        router_logits=score,
+        topk_config=TopKConfig(top_k=topk, renormalize=False),
+    )
+    topk_weights, topk_ids, _ = topk_output
+
+    times = []
+    for i in range(warmup + repeat):
+        t = CUDATimer()
+        t.start()
+        fused_marlin_moe(
+            hidden_states=a,
+            w1=marlin_w1,
+            w2=marlin_w2,
+            w1_scale=marlin_w1_scale,
+            w2_scale=marlin_w2_scale,
+            gating_output=score,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            num_bits=4,
+        )
+        ms = t.stop()
+        if i >= warmup:
+            times.append(ms)
+
+    mean, std = _stats(times)
+    return mean, std
+
+
+# ---------------------------------------------------------------------------
+# GEMM2-only isolated benchmark (for tile config tuning)
+# ---------------------------------------------------------------------------
+GEMM2_TUNE_CONFIGS = {
+    0: "PP< 64, 16,128, 1,1,1>  (baseline)",
+    1: "PP< 64, 32,128, 1,1,1>  (2x TileN)",
+    2: "PP< 64, 64,128, 1,1,1>  (4x TileN)",
+    3: "PP< 64, 16,128, 2,1,1>  (2x ClusterM)",
+    4: "CO<128, 16,128, 1,1,1>  (cooperative)",
+    5: "CO<128, 32,128, 1,1,1>  (CO + 2x TileN)",
+}
+
+GEMM2_TUNE_CONFIGS_MED = {
+    0: "PP<128, 32,128, 1,1,1>  (baseline)",
+    1: "PP<128, 64,128, 1,1,1>  (2x TileN)",
+    2: "PP<128, 32,128, 2,1,1>  (2x ClusterM)",
+    3: "CO<128, 16,128, 1,1,1>  (cooperative)",
+    4: "CO<128, 32,128, 1,1,1>  (CO + TileN=32)",
+    5: "CO<128, 32,128, 2,1,1>  (CO + cluster)",
+}
+
+
+def benchmark_gemm2_only(
+    M: int,
+    w2_q,
+    w2_scale,
+    E: int = 384,
+    hidden_size: int = 7168,
+    intermediate_tp: int = 256,
+    topk: int = 6,
+    group_size: int = 128,
+    warmup: int = 20,
+    repeat: int = 200,
+):
+    """Benchmark only the GEMM2 kernel (cutlass_w4a8_moe_mm for down-proj)."""
+    from sgl_kernel import cutlass_w4a8_moe_mm, get_cutlass_w4a8_moe_mm_data
+
+    from sglang.jit_kernel.per_tensor_absmax_fp8 import per_tensor_absmax_fp8
+    from sglang.srt.layers.moe.ep_moe.kernels import (
+        cutlass_w4_run_moe_ep_preproess,
+    )
+    from sglang.srt.layers.moe.topk import TopKConfig, select_experts
+
+    device = "cuda"
+    K = hidden_size
+    N = intermediate_tp
+
+    a_strides2 = torch.full((E, 3), N, device=device, dtype=torch.int64)
+    c_strides2 = torch.full((E, 3), K, device=device, dtype=torch.int64)
+    b_strides2 = a_strides2
+    s_strides2 = c_strides2
+    expert_offsets = torch.empty(E + 1, dtype=torch.int32, device=device)
+    problem_sizes1 = torch.empty((E, 3), dtype=torch.int32, device=device)
+    problem_sizes2 = torch.empty((E, 3), dtype=torch.int32, device=device)
+
+    a = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+    score = torch.randn(M, E, dtype=torch.bfloat16, device=device)
+    topk_output = select_experts(
+        hidden_states=a,
+        router_logits=score,
+        topk_config=TopKConfig(top_k=topk, renormalize=False),
+    )
+    _, topk_ids, _ = topk_output
+
+    src2dst = cutlass_w4_run_moe_ep_preproess(topk_ids)
+
+    a_map = torch.empty(topk_ids.numel(), dtype=torch.int32, device=device)
+    c_map = torch.empty(topk_ids.numel(), dtype=torch.int32, device=device)
+    get_cutlass_w4a8_moe_mm_data(
+        topk_ids,
+        expert_offsets,
+        problem_sizes1,
+        problem_sizes2,
+        a_map,
+        c_map,
+        E,
+        N,
+        K,
+    )
+
+    intermediate_q = torch.randn(M * topk, N, dtype=torch.bfloat16, device=device).to(
+        torch.float8_e4m3fn
+    )
+    a2_scale = torch.empty(1, dtype=torch.float32, device=device)
+    per_tensor_absmax_fp8(
+        torch.randn(M * topk, 2 * N, dtype=torch.bfloat16, device=device), a2_scale
+    )
+
+    c2 = torch.empty((M * topk, K), device=device, dtype=torch.bfloat16)
+
+    times = []
+    for i in range(warmup + repeat):
+        t = CUDATimer()
+        t.start()
+        cutlass_w4a8_moe_mm(
+            c2,
+            intermediate_q,
+            w2_q,
+            a2_scale.float(),
+            w2_scale,
+            expert_offsets[:-1],
+            problem_sizes2,
+            a_strides2,
+            b_strides2,
+            c_strides2,
+            s_strides2,
+            128,
+            topk,
+        )
+        ms = t.stop()
+        if i >= warmup:
+            times.append(ms)
+
+    mean, std = _stats(times)
+    return mean, std
+
+
+def run_gemm2_tuning_sweep(args):
+    """Run GEMM2 tile config sweep: test each config for all batch sizes."""
+    import os
+
+    E, K, N = args.E, args.hidden, args.intermediate_tp
+
+    print("  Preparing CUTLASS W4A8 weights (w2 only)...")
+    _, _, w2_q, w2_scale = prepare_cutlass_weights(E, K, N, 128)
+    print("  Weights ready.\n")
+
+    num_configs = max(len(GEMM2_TUNE_CONFIGS), len(GEMM2_TUNE_CONFIGS_MED))
+    results = {}
+
+    for cfg_id in range(num_configs):
+        os.environ["SGL_GEMM2_TUNE"] = str(cfg_id)
+        cfg_desc_small = GEMM2_TUNE_CONFIGS.get(cfg_id, f"config {cfg_id}")
+        cfg_desc_med = GEMM2_TUNE_CONFIGS_MED.get(cfg_id, f"config {cfg_id}")
+
+        print(f"{'='*74}")
+        print(f"  Config {cfg_id}")
+        print(f"    m<=8:  {cfg_desc_small}")
+        print(f"    m<=32: {cfg_desc_med}")
+        print(f"{'='*74}")
+
+        results[cfg_id] = {}
+        for batch in args.batch:
+            try:
+                mean, std = benchmark_gemm2_only(
+                    M=batch,
+                    w2_q=w2_q,
+                    w2_scale=w2_scale,
+                    E=E,
+                    hidden_size=K,
+                    intermediate_tp=N,
+                    topk=args.topk,
+                    warmup=args.warmup,
+                    repeat=args.repeat,
+                )
+                results[cfg_id][batch] = (mean, std)
+                print(f"    M={batch:4d}  GEMM2={mean:.4f}ms (std={std:.4f})")
+            except Exception as e:
+                results[cfg_id][batch] = None
+                print(f"    M={batch:4d}  FAILED: {e}")
+        print()
+
+    os.environ.pop("SGL_GEMM2_TUNE", None)
+
+    print(f"\n{'='*74}")
+    print(f"  GEMM2 Tile Config Comparison (N={K}, K={N})")
+    print(f"{'='*74}")
+
+    hdr = f"  {'Config':>6s}  {'Description':<36s}"
+    for b in args.batch:
+        hdr += f"  {'M='+str(b):>8s}"
+    print(hdr)
+    print(f"  {'-'*6}  {'-'*36}" + "".join(f"  {'-'*8}" for _ in args.batch))
+
+    baseline = results.get(0, {})
+    for cfg_id in range(num_configs):
+        desc = GEMM2_TUNE_CONFIGS.get(cfg_id, f"config {cfg_id}")
+        line = f"  {cfg_id:6d}  {desc:<36s}"
+        for b in args.batch:
+            r = results.get(cfg_id, {}).get(b)
+            bl = baseline.get(b)
+            if r is None:
+                line += f"  {'FAIL':>8s}"
+            elif bl is not None and bl[0] > 0:
+                speedup = bl[0] / r[0]
+                line += (
+                    f"  {r[0]:.3f}ms"
+                    if speedup < 1.01 and speedup > 0.99
+                    else f"  {speedup:+7.1%}"
+                )
+            else:
+                line += f"  {r[0]:.4f}"
+        print(line)
+
+    best_for_batch = {}
+    for b in args.batch:
+        best_cfg = 0
+        best_time = float("inf")
+        for cfg_id in range(num_configs):
+            r = results.get(cfg_id, {}).get(b)
+            if r is not None and r[0] < best_time:
+                best_time = r[0]
+                best_cfg = cfg_id
+        best_for_batch[b] = (best_cfg, best_time)
+
+    print(f"\n  Best config per batch:")
+    for b in args.batch:
+        cfg_id, t = best_for_batch[b]
+        bl = baseline.get(b)
+        speedup = bl[0] / t if bl and bl[0] > 0 else 1.0
+        desc = GEMM2_TUNE_CONFIGS.get(cfg_id, "")
+        print(
+            f"    M={b:4d}: config {cfg_id} ({desc.strip()})  {t:.4f}ms  ({speedup:.1%} vs baseline)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--batch", type=int, nargs="+", default=[1, 4, 8, 16, 32])
+    parser.add_argument("--E", type=int, default=384)
+    parser.add_argument("--hidden", type=int, default=7168)
+    parser.add_argument("--intermediate-tp", type=int, default=256)
+    parser.add_argument("--topk", type=int, default=8)
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--repeat", type=int, default=200)
+    parser.add_argument(
+        "--no-marlin", action="store_true", help="Skip Marlin comparison"
+    )
+    parser.add_argument(
+        "--no-breakdown", action="store_true", help="Skip per-stage breakdown"
+    )
+    parser.add_argument(
+        "--tune-gemm2", action="store_true", help="Run GEMM2 tile config tuning sweep"
+    )
+    args = parser.parse_args()
+
+    init_dist()
+
+    if args.tune_gemm2:
+        run_gemm2_tuning_sweep(args)
+        return
+
+    K = args.hidden
+    N = args.intermediate_tp
+    E = args.E
+
+    print("  Preparing CUTLASS W4A8 weights...")
+    cutlass_w1_q, cutlass_w1_s, cutlass_w2_q, cutlass_w2_s = prepare_cutlass_weights(
+        E, K, N, 128
+    )
+    print("  CUTLASS weights ready.")
+
+    cutlass_real_e2e = {}
+    cutlass_profiled_e2e = {}
+
+    # ---- CUTLASS real E2E (no per-stage sync) ----
+    print(f"\n{'='*70}")
+    print(f"  CUTLASS W4A8 Real E2E (no per-stage sync)")
+    print(f"{'='*70}")
+    for batch in args.batch:
+        with patch(
+            "sglang.srt.layers.moe.cutlass_w4a8_moe.get_moe_expert_parallel_world_size",
+            return_value=1,
+        ):
+            mean, std = benchmark_cutlass_real_e2e(
+                M=batch,
+                w1_q=cutlass_w1_q,
+                w1_scale=cutlass_w1_s,
+                w2_q=cutlass_w2_q,
+                w2_scale=cutlass_w2_s,
+                E=E,
+                hidden_size=K,
+                intermediate_tp=N,
+                topk=args.topk,
+                warmup=args.warmup,
+                repeat=args.repeat,
+            )
+            cutlass_real_e2e[batch] = mean
+            print(f"  [CUTLASS Real] M={batch:4d}  E2E={mean:.3f}ms (std={std:.3f})")
+
+    # ---- CUTLASS per-stage breakdown (with sync) ----
+    if not args.no_breakdown:
+        for batch in args.batch:
+            with patch(
+                "sglang.srt.layers.moe.cutlass_w4a8_moe.get_moe_expert_parallel_world_size",
+                return_value=1,
+            ):
+                profiled = benchmark_cutlass_breakdown(
+                    M=batch,
+                    w1_q=cutlass_w1_q,
+                    w1_scale=cutlass_w1_s,
+                    w2_q=cutlass_w2_q,
+                    w2_scale=cutlass_w2_s,
+                    E=E,
+                    hidden_size=K,
+                    intermediate_tp=N,
+                    topk=args.topk,
+                    warmup=args.warmup,
+                    repeat=args.repeat,
+                )
+                cutlass_profiled_e2e[batch] = profiled
+
+    del cutlass_w1_q, cutlass_w1_s, cutlass_w2_q, cutlass_w2_s
+    torch.cuda.empty_cache()
+
+    # ---- Marlin E2E ----
+    marlin_e2e = {}
+    if not args.no_marlin:
+        print(f"\n{'='*70}")
+        print(f"  Marlin W4A16 Benchmark")
+        print(f"{'='*70}")
+        marlin_w1, marlin_w2, marlin_w1s, marlin_w2s = prepare_marlin_weights(
+            E, K, N, 128
+        )
+        for batch in args.batch:
+            mean, std = benchmark_marlin_e2e(
+                M=batch,
+                marlin_w1=marlin_w1,
+                marlin_w2=marlin_w2,
+                marlin_w1_scale=marlin_w1s,
+                marlin_w2_scale=marlin_w2s,
+                E=E,
+                hidden_size=K,
+                intermediate_tp=N,
+                topk=args.topk,
+                warmup=args.warmup,
+                repeat=args.repeat,
+            )
+            marlin_e2e[batch] = (mean, std)
+            print(f"  [Marlin W4A16]  M={batch:4d}  E2E={mean:.3f}ms (std={std:.3f})")
+        del marlin_w1, marlin_w2, marlin_w1s, marlin_w2s
+        torch.cuda.empty_cache()
+
+    # ---- Final comparison table ----
+    print(f"\n{'='*70}")
+    print(f"  Final Comparison — per-MoE-layer E2E")
+    print(f"  E={E}, N_tp={N}, K={K}, topk={args.topk}")
+    print(f"{'='*70}")
+
+    has_marlin = bool(marlin_e2e)
+    has_profiled = bool(cutlass_profiled_e2e)
+
+    hdr = f"  {'M':>4s}  {'Real(ms)':>10s}"
+    sep = f"  {'-'*4}  {'-'*10}"
+    if has_profiled:
+        hdr += f"  {'Profiled(ms)':>12s}  {'SyncOH(ms)':>10s}"
+        sep += f"  {'-'*12}  {'-'*10}"
+    if has_marlin:
+        hdr += f"  {'Marlin(ms)':>10s}  {'Real/M':>8s}  {'RealGap':>10s}"
+        sep += f"  {'-'*10}  {'-'*8}  {'-'*10}"
+    print(hdr)
+    print(sep)
+
+    for batch in args.batch:
+        r = cutlass_real_e2e.get(batch, 0)
+        line = f"  {batch:4d}  {r:10.3f}"
+        if has_profiled:
+            p = cutlass_profiled_e2e.get(batch, 0)
+            sync_oh = p - r
+            line += f"  {p:12.3f}  {sync_oh:+9.3f}"
+        if has_marlin:
+            m_mean, _ = marlin_e2e.get(batch, (0, 0))
+            ratio = r / m_mean if m_mean > 0 else float("inf")
+            gap = r - m_mean
+            line += f"  {m_mean:10.3f}  {ratio:7.2f}x  {gap:+9.3f}ms"
+        print(line)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sglang/jit_kernel/benchmark/bench_per_tensor_absmax_fp8.py
+++ b/python/sglang/jit_kernel/benchmark/bench_per_tensor_absmax_fp8.py
@@ -1,0 +1,65 @@
+import itertools
+
+import torch
+import triton
+import triton.testing
+
+from sglang.jit_kernel.benchmark.utils import (
+    DEFAULT_DEVICE,
+    get_benchmark_range,
+    run_benchmark,
+)
+from sglang.jit_kernel.per_tensor_absmax_fp8 import per_tensor_absmax_fp8
+
+FP8_MAX = torch.finfo(torch.float8_e4m3fn).max
+
+BATCH_SIZE_LIST = get_benchmark_range(
+    full_range=[1, 16, 64, 256, 1024, 4096],
+    ci_range=[16, 256],
+)
+HIDDEN_DIM_LIST = get_benchmark_range(
+    full_range=[2048, 4096, 7168, 14336],
+    ci_range=[4096],
+)
+
+configs = list(itertools.product(BATCH_SIZE_LIST, HIDDEN_DIM_LIST))
+
+
+def torch_absmax_scale(x: torch.Tensor) -> torch.Tensor:
+    return torch.max(torch.abs(x)).float().div_(FP8_MAX).view(1)
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["batch_size", "hidden_dim"],
+        x_vals=configs,
+        line_arg="provider",
+        line_vals=["jit", "torch"],
+        line_names=["SGL JIT Kernel", "PyTorch"],
+        styles=[("blue", "-"), ("red", "--")],
+        ylabel="us",
+        plot_name="per-tensor-absmax-fp8-performance",
+        args={},
+    )
+)
+def benchmark(batch_size: int, hidden_dim: int, provider: str):
+    device = torch.device(DEFAULT_DEVICE)
+    x = torch.randn(batch_size, hidden_dim, dtype=torch.bfloat16, device=device)
+
+    if provider == "jit":
+        scale = torch.zeros(1, dtype=torch.float32, device=device)
+
+        def fn():
+            scale.zero_()
+            per_tensor_absmax_fp8(x, scale)
+
+    else:
+
+        def fn():
+            torch_absmax_scale(x)
+
+    return run_benchmark(fn)
+
+
+if __name__ == "__main__":
+    benchmark.run(print_data=True)

--- a/python/sglang/jit_kernel/benchmark/bench_per_tensor_absmax_fp8.py
+++ b/python/sglang/jit_kernel/benchmark/bench_per_tensor_absmax_fp8.py
@@ -10,6 +10,9 @@ from sglang.jit_kernel.benchmark.utils import (
     run_benchmark,
 )
 from sglang.jit_kernel.per_tensor_absmax_fp8 import per_tensor_absmax_fp8
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=5, suite="stage-b-kernel-benchmark-1-gpu-large")
 
 FP8_MAX = torch.finfo(torch.float8_e4m3fn).max
 

--- a/python/sglang/jit_kernel/csrc/gemm/per_tensor_absmax_fp8.cuh
+++ b/python/sglang/jit_kernel/csrc/gemm/per_tensor_absmax_fp8.cuh
@@ -1,0 +1,86 @@
+#include <sgl_kernel/tensor.h>  // For TensorMatcher, SymbolicSize, SymbolicDevice
+#include <sgl_kernel/utils.h>   // For div_ceil
+
+#include <sgl_kernel/atomic.cuh>  // For atomic::max
+#include <sgl_kernel/cta.cuh>     // For cta::reduce_max
+#include <sgl_kernel/math.cuh>    // For math::max, math::abs, math::FP8_E4M3_MAX
+#include <sgl_kernel/tile.cuh>    // For tile::Memory
+#include <sgl_kernel/utils.cuh>   // For LaunchKernel, kWarpThreads, fp16_t, bf16_t, fp32_t
+#include <sgl_kernel/vec.cuh>     // For AlignedVector
+#include <sgl_kernel/warp.cuh>    // For warp reduction (used by cta::reduce_max)
+
+#include <cstddef>
+#include <cstdint>
+
+namespace {
+
+constexpr size_t kBlockSize = 256;
+
+// Identical to per_tensor_absmax_kernel in per_tensor_quant_fp8.cuh,
+// but exposed as a standalone entry point so callers that only need
+// the scale (without the quantization pass) can avoid the extra write.
+template <typename T>
+__global__ void
+per_tensor_absmax_fp8_kernel(const T* __restrict__ input, float* __restrict__ output_s, const int64_t num_elements) {
+  using namespace device;
+  constexpr uint32_t VEC_SIZE = 16 / sizeof(T);
+
+  const int64_t gid = blockIdx.x * blockDim.x + threadIdx.x;
+
+  float max_value = 0.0f;
+  if (gid * VEC_SIZE + VEC_SIZE <= num_elements) {
+    using vec_t = AlignedVector<T, VEC_SIZE>;
+    const auto gmem_in = tile::Memory<vec_t>::thread();
+    const auto input_vec = gmem_in.load(input, gid);
+#pragma unroll
+    for (uint32_t i = 0; i < VEC_SIZE; ++i) {
+      const float value = static_cast<float>(input_vec[i]);
+      max_value = math::max(max_value, math::abs(value));
+    }
+  } else if (gid * VEC_SIZE < num_elements) {
+    [[unlikely]];
+    const auto remainder = num_elements - gid * VEC_SIZE;
+    for (uint32_t i = 0; i < remainder; ++i) {
+      const float value = static_cast<float>(input[gid * VEC_SIZE + i]);
+      max_value = math::max(max_value, math::abs(value));
+    }
+  }
+
+  __shared__ float smem[kWarpThreads];
+  cta::reduce_max(max_value, smem);
+  if (threadIdx.x == 0) {
+    const auto max_value = smem[0];
+    atomic::max(output_s, max_value / math::FP8_E4M3_MAX);
+  }
+}
+
+template <typename DType>
+void per_tensor_absmax_fp8(tvm::ffi::TensorView input, tvm::ffi::TensorView output_s) {
+  using namespace host;
+
+  auto N = SymbolicSize{"num_elements"};
+  auto device = SymbolicDevice{};
+  device.set_options<kDLCUDA>();
+
+  TensorMatcher({N})  //
+      .with_dtype<DType>()
+      .with_device(device)
+      .verify(input);
+  TensorMatcher({1})  //
+      .with_dtype<float>()
+      .with_device(device)
+      .verify(output_s);
+
+  const auto num_elements = N.unwrap();
+
+  constexpr size_t kElementsPerBlock = kBlockSize * (16 / sizeof(DType));
+  const uint32_t num_blocks = div_ceil(num_elements, kElementsPerBlock);
+
+  LaunchKernel(num_blocks, kBlockSize, device.unwrap())(
+      per_tensor_absmax_fp8_kernel<DType>,
+      static_cast<const DType*>(input.data_ptr()),
+      static_cast<float*>(output_s.data_ptr()),
+      static_cast<int64_t>(num_elements));
+}
+
+}  // namespace

--- a/python/sglang/jit_kernel/per_tensor_absmax_fp8.py
+++ b/python/sglang/jit_kernel/per_tensor_absmax_fp8.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.jit_kernel.utils import cache_once, load_jit, make_cpp_args
+from sglang.srt.utils.custom_op import register_custom_op
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+@cache_once
+def _jit_per_tensor_absmax_fp8_module(dtype: torch.dtype) -> Module:
+    args = make_cpp_args(dtype)
+    return load_jit(
+        "per_tensor_absmax_fp8",
+        *args,
+        cuda_files=["gemm/per_tensor_absmax_fp8.cuh"],
+        cuda_wrappers=[("per_tensor_absmax_fp8", f"per_tensor_absmax_fp8<{args}>")],
+    )
+
+
+@register_custom_op(
+    op_name="per_tensor_absmax_fp8",
+    mutates_args=["output_s"],
+)
+def per_tensor_absmax_fp8(
+    input: torch.Tensor,
+    output_s: torch.Tensor,
+) -> None:
+    """Compute scale = max(abs(input)) / fp8_e4m3_max via atomic-max reduction.
+
+    The caller must zero-initialise ``output_s`` before the call (the kernel
+    uses ``atomic_max`` across blocks, so starting from 0 is required).
+
+    Args:
+        input: Input tensor (float16, bfloat16, or float32). Any shape.
+        output_s: Pre-allocated float32 tensor of shape (1,), zero-initialised.
+    """
+    module = _jit_per_tensor_absmax_fp8_module(input.dtype)
+    module.per_tensor_absmax_fp8(input.view(-1), output_s.view(-1))

--- a/python/sglang/jit_kernel/tests/test_per_tensor_absmax_fp8.py
+++ b/python/sglang/jit_kernel/tests/test_per_tensor_absmax_fp8.py
@@ -1,11 +1,24 @@
 import itertools
+import sys
 
 import pytest
 import torch
 
 from sglang.jit_kernel.per_tensor_absmax_fp8 import per_tensor_absmax_fp8
+from sglang.test.ci.ci_register import register_cuda_ci
 
-FP8_MAX = torch.finfo(torch.float8_e4m3fn).max
+register_cuda_ci(est_time=10, suite="stage-b-kernel-unit-1-gpu-large")
+register_cuda_ci(est_time=60, suite="nightly-kernel-1-gpu", nightly=True)
+
+try:
+    from sglang.srt.utils import is_hip
+
+    _is_hip = is_hip()
+except ImportError:
+    _is_hip = False
+
+fp8_type_ = torch.float8_e4m3fnuz if _is_hip else torch.float8_e4m3fn
+FP8_MAX = torch.finfo(fp8_type_).max
 
 
 def reference_absmax_scale(x: torch.Tensor) -> torch.Tensor:
@@ -65,4 +78,4 @@ def test_absmax_large():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__, "-v", "-s"])
+    sys.exit(pytest.main([__file__, "-v", "-s"]))

--- a/python/sglang/jit_kernel/tests/test_per_tensor_absmax_fp8.py
+++ b/python/sglang/jit_kernel/tests/test_per_tensor_absmax_fp8.py
@@ -1,0 +1,68 @@
+import itertools
+
+import pytest
+import torch
+
+from sglang.jit_kernel.per_tensor_absmax_fp8 import per_tensor_absmax_fp8
+
+FP8_MAX = torch.finfo(torch.float8_e4m3fn).max
+
+
+def reference_absmax_scale(x: torch.Tensor) -> torch.Tensor:
+    return torch.max(torch.abs(x)).float() / FP8_MAX
+
+
+@pytest.mark.parametrize(
+    "num_tokens,hidden_dim",
+    list(itertools.product([1, 7, 128, 512], [64, 512, 2048, 4096])),
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_absmax_correctness(num_tokens: int, hidden_dim: int, dtype: torch.dtype):
+    device = torch.device("cuda")
+    x = torch.randn(num_tokens, hidden_dim, dtype=dtype, device=device)
+
+    scale = torch.zeros(1, dtype=torch.float32, device=device)
+    per_tensor_absmax_fp8(x, scale)
+
+    expected = reference_absmax_scale(x)
+    torch.testing.assert_close(scale.squeeze(), expected, rtol=1e-5, atol=1e-8)
+
+
+@pytest.mark.parametrize("numel", [1, 3, 127, 128, 1023, 1024, 4097, 100003])
+def test_absmax_1d(numel: int):
+    device = torch.device("cuda")
+    x = torch.randn(numel, dtype=torch.bfloat16, device=device)
+
+    scale = torch.zeros(1, dtype=torch.float32, device=device)
+    per_tensor_absmax_fp8(x, scale)
+
+    expected = reference_absmax_scale(x)
+    torch.testing.assert_close(scale.squeeze(), expected, rtol=1e-5, atol=1e-8)
+
+
+@pytest.mark.parametrize("shape", [(4, 8, 64), (2, 16, 128)])
+def test_absmax_3d(shape):
+    device = torch.device("cuda")
+    x = torch.randn(shape, dtype=torch.float16, device=device)
+
+    scale = torch.zeros(1, dtype=torch.float32, device=device)
+    per_tensor_absmax_fp8(x, scale)
+
+    expected = reference_absmax_scale(x)
+    torch.testing.assert_close(scale.squeeze(), expected, rtol=1e-5, atol=1e-8)
+
+
+def test_absmax_large():
+    """Stress test with a large tensor to exercise multi-block atomic reduction."""
+    device = torch.device("cuda")
+    x = torch.randn(4096, 7168, dtype=torch.bfloat16, device=device)
+
+    scale = torch.zeros(1, dtype=torch.float32, device=device)
+    per_tensor_absmax_fp8(x, scale)
+
+    expected = reference_absmax_scale(x)
+    torch.testing.assert_close(scale.squeeze(), expected, rtol=1e-5, atol=1e-8)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/python/sglang/srt/layers/moe/cutlass_w4a8_moe.py
+++ b/python/sglang/srt/layers/moe/cutlass_w4a8_moe.py
@@ -133,6 +133,14 @@ def cutlass_w4a8_moe(
         dtype=torch.float8_e4m3fn,
     )
 
+    if a1_scale is None:
+        a1_scale = (
+            torch.max(torch.abs(a))
+            .to(torch.float32)
+            .div_(torch.finfo(torch.float8_e4m3fn).max)
+            .view(1)
+        )
+
     pre_reorder_for_cutlass_moe(
         a,
         gateup_input,
@@ -184,6 +192,15 @@ def cutlass_w4a8_moe(
     intermediate_q = torch.empty(
         (m * topk, n), dtype=torch.float8_e4m3fn, device=device
     )
+
+    if a2_scale is None:
+        a2_scale = (
+            torch.max(torch.abs(c1))
+            .to(torch.float32)
+            .div_(torch.finfo(torch.float8_e4m3fn).max)
+            .view(1)
+        )
+
     silu_mul_static_tensorwise_quant_for_cutlass_moe(
         c1, intermediate_q, a2_scale.float(), expert_offsets[-1:], m * topk, n
     )

--- a/python/sglang/srt/layers/moe/cutlass_w4a8_moe.py
+++ b/python/sglang/srt/layers/moe/cutlass_w4a8_moe.py
@@ -13,11 +13,11 @@ if _is_cuda_alike:
     from sgl_kernel import (
         cutlass_w4a8_moe_mm,
         get_cutlass_w4a8_moe_mm_data,
+        silu_and_mul,
     )
+    from sglang.jit_kernel.per_tensor_absmax_fp8 import per_tensor_absmax_fp8
+    from sglang.jit_kernel.per_tensor_quant_fp8 import per_tensor_quant_fp8
 
-from sgl_kernel import silu_and_mul
-
-from sglang.jit_kernel.per_tensor_quant_fp8 import per_tensor_quant_fp8
 from sglang.srt.distributed import get_moe_expert_parallel_world_size
 from sglang.srt.layers.moe.ep_moe.kernels import (
     cutlass_w4_run_moe_ep_preproess,
@@ -29,6 +29,7 @@ from sglang.srt.layers.moe.ep_moe.kernels import (
     post_reorder_for_cutlass_moe,
     pre_reorder_for_cutlass_moe,
     silu_and_mul_masked_post_per_tensor_quant_fwd,
+    silu_mul_dynamic_tensorwise_quant_for_cutlass_moe,
     silu_mul_static_tensorwise_quant_for_cutlass_moe,
 )
 
@@ -133,13 +134,10 @@ def cutlass_w4a8_moe(
         dtype=torch.float8_e4m3fn,
     )
 
+    # TODO: fuse per_tensor_absmax_fp8 and pre_reorder_for_cutlass_moe
     if a1_scale is None:
-        a1_scale = (
-            torch.max(torch.abs(a))
-            .to(torch.float32)
-            .div_(torch.finfo(torch.float8_e4m3fn).max)
-            .view(1)
-        )
+        a1_scale = torch.zeros(1, dtype=torch.float32, device=device)
+        per_tensor_absmax_fp8(a, a1_scale)
 
     pre_reorder_for_cutlass_moe(
         a,
@@ -194,16 +192,14 @@ def cutlass_w4a8_moe(
     )
 
     if a2_scale is None:
-        a2_scale = (
-            torch.max(torch.abs(c1))
-            .to(torch.float32)
-            .div_(torch.finfo(torch.float8_e4m3fn).max)
-            .view(1)
+        a2_scale = torch.zeros(1, dtype=torch.float32, device=device)
+        silu_mul_dynamic_tensorwise_quant_for_cutlass_moe(
+            c1, intermediate_q, a2_scale, expert_offsets[-1:], m * topk, n
         )
-
-    silu_mul_static_tensorwise_quant_for_cutlass_moe(
-        c1, intermediate_q, a2_scale.float(), expert_offsets[-1:], m * topk, n
-    )
+    else:
+        silu_mul_static_tensorwise_quant_for_cutlass_moe(
+            c1, intermediate_q, a2_scale.float(), expert_offsets[-1:], m * topk, n
+        )
 
     cutlass_w4a8_moe_mm(
         c2,

--- a/python/sglang/srt/layers/moe/ep_moe/kernels.py
+++ b/python/sglang/srt/layers/moe/ep_moe/kernels.py
@@ -430,6 +430,68 @@ def silu_and_mul_masked_post_quant_fwd(
 
 
 @triton.jit
+def silu_mul_dynamic_scale_triton_kernel_for_cutlass_moe(
+    input_ptr,
+    scale_ptr,
+    num_tokens_tensor_ptr,
+    intermediate_size,
+    fp8_max,
+    BLOCK_SIZE: tl.constexpr,
+    NUM_STAGES: tl.constexpr,
+):
+    num_tokens = tl.load(num_tokens_tensor_ptr)
+    numel = num_tokens * intermediate_size
+    gate_ptr = input_ptr
+    up_ptr = input_ptr + intermediate_size
+
+    start_idx = tl.program_id(0) * BLOCK_SIZE
+    step = tl.num_programs(0) * BLOCK_SIZE
+    absmax = 0.0
+
+    for id in tl.range(start_idx, numel, step, num_stages=NUM_STAGES):
+        ids = id + tl.arange(0, BLOCK_SIZE)
+        token_ids = ids // intermediate_size
+        mask = ids < numel
+
+        offs = ids + token_ids * intermediate_size
+        gate = tl.load(gate_ptr + offs, mask=mask, other=0.0).to(tl.float32)
+        up = tl.load(up_ptr + offs, mask=mask, other=0.0).to(tl.float32)
+        gate_up = gate / (1 + tl.exp(-gate)) * up
+        absmax = tl.maximum(absmax, tl.max(tl.abs(gate_up)))
+
+    absmax = tl.maximum(absmax, 1e-10)
+    tl.atomic_max(scale_ptr, absmax / fp8_max)
+
+
+def silu_mul_dynamic_tensorwise_quant_for_cutlass_moe(
+    input: torch.Tensor,
+    output: torch.Tensor,
+    scale: torch.Tensor,
+    num_tokens_tensor: torch.Tensor,
+    expected_num_tokens: int,
+    intermediate_size: int,
+):
+    grid, block_dim = _get_launch_config_1d(
+        input.device, expected_num_tokens * intermediate_size
+    )
+    scale.zero_()
+    fp8_max = torch.finfo(torch.float8_e4m3fn).max
+
+    silu_mul_dynamic_scale_triton_kernel_for_cutlass_moe[grid](
+        input_ptr=input,
+        scale_ptr=scale,
+        num_tokens_tensor_ptr=num_tokens_tensor,
+        intermediate_size=intermediate_size,
+        fp8_max=fp8_max,
+        BLOCK_SIZE=block_dim,
+        NUM_STAGES=3,
+    )
+    silu_mul_static_tensorwise_quant_for_cutlass_moe(
+        input, output, scale, num_tokens_tensor, expected_num_tokens, intermediate_size
+    )
+
+
+@triton.jit
 def silu_mul_static_tensorwise_quant_triton_kernel_for_cutlass_moe(
     input_ptr,
     output_ptr,

--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -43,6 +43,7 @@ from sglang.srt.layers.quantization.compressed_tensors.schemes import (
     CompressedTensorsMxInt4MoE,
     CompressedTensorsW4A4Fp4,
     CompressedTensorsW4A4Nvfp4MoE,
+    CompressedTensorsW4AFP8MoE,
     CompressedTensorsW8A8Fp8,
     CompressedTensorsW8A8Fp8MoE,
     CompressedTensorsW8A8Int8,
@@ -304,15 +305,16 @@ class CompressedTensorsConfig(QuantizationConfig):
                 target_scheme_map[target]["input_activations"] = None
                 if is_activation_quantization_format(quant_format):
                     input_activations = quant_config.get("input_activations")
-                    # The only case where we have activation quant supported
-                    # but no input_activations provided in the config
-                    # should be w8a16fp8 w8a16fp8 can also run for cases where
-                    # there is an input_quant but it is ignored
+                    # When activation quant format is set but no
+                    # input_activations provided: valid for w8a16fp8 (FLOAT
+                    # weights) and pack-quantized without activation quant
+                    # (INT weights, W4A16 style).
                     if not input_activations:
-                        assert (
-                            target_scheme_map[target]["weights"].type
-                            == QuantizationType.FLOAT
-                        )
+                        weight_type = target_scheme_map[target]["weights"].type
+                        if weight_type == QuantizationType.INT:
+                            pass
+                        else:
+                            assert weight_type == QuantizationType.FLOAT
                     else:
                         target_scheme_map[target]["input_activations"] = (
                             QuantizationArgs.model_validate(  # noqa: E501
@@ -361,6 +363,20 @@ class CompressedTensorsConfig(QuantizationConfig):
             and is_token
             and weight_quant.symmetric
             and is_dynamic
+        )
+
+    def _is_w4afp8(self, weight_quant: BaseModel, input_quant: BaseModel) -> bool:
+        """Detect W4AFP8: INT4 weights + FP8 dynamic per-token activations."""
+        if weight_quant is None or input_quant is None:
+            return False
+        return (
+            weight_quant.num_bits == 4
+            and weight_quant.type == QuantizationType.INT
+            and weight_quant.symmetric
+            and not weight_quant.dynamic
+            and input_quant.num_bits == 8
+            and input_quant.type == QuantizationType.FLOAT
+            and input_quant.dynamic  # currently not support static input scales
         )
 
     def _is_static_tensor_w8a8(
@@ -712,6 +728,9 @@ class CompressedTensorsConfig(QuantizationConfig):
                 raise NotImplementedError(
                     f"The W8A8Int8 Fused MoE scheme is implemented only for NPU for now."
                 )
+        elif self._is_w4afp8(weight_quant, input_quant):
+            logger.info_once("Using CompressedTensorsW4AFP8MoE")
+            return CompressedTensorsW4AFP8MoE(self, weight_quant, input_quant)
         elif self._is_dynamic_token_w4a8(weight_quant, input_quant):
             if _is_npu:
                 logger.info_once("Using NPUCompressedTensorsW4A8Int8DynamicMoE")

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/__init__.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/__init__.py
@@ -7,6 +7,7 @@ from .compressed_tensors_scheme import (
 from .compressed_tensors_w4a4_mxint4_moe import CompressedTensorsMxInt4MoE
 from .compressed_tensors_w4a4_nvfp4 import CompressedTensorsW4A4Fp4
 from .compressed_tensors_w4a4_nvfp4_moe import CompressedTensorsW4A4Nvfp4MoE
+from .compressed_tensors_w4a8_fp8_moe import CompressedTensorsW4AFP8MoE
 from .compressed_tensors_w4a8_int8_moe import NPUCompressedTensorsW4A8Int8DynamicMoE
 from .compressed_tensors_w8a8_fp8 import CompressedTensorsW8A8Fp8
 from .compressed_tensors_w8a8_fp8_moe import CompressedTensorsW8A8Fp8MoE
@@ -41,4 +42,5 @@ __all__ = [
     "CompressedTensorsW4A4Nvfp4MoE",
     "NPUCompressedTensorsW4A8Int8DynamicMoE",
     "CompressedTensorsMxInt4MoE",
+    "CompressedTensorsW4AFP8MoE",
 ]

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a8_fp8_moe.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a8_fp8_moe.py
@@ -1,0 +1,309 @@
+"""W4AFP8 MoE scheme: INT4 group-quantized weights + FP8 dynamic activations.
+
+Loads INT4 weights from compressed-tensors pack-quantized format,
+converts to CUTLASS W4A8 layout, and runs CUTLASS grouped GEMM
+with dynamic FP8 activation quantization.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import torch
+from compressed_tensors import CompressionFormat
+
+from sglang.srt.layers.moe import MoeRunnerConfig
+from sglang.srt.layers.quantization.compressed_tensors.schemes import (
+    CompressedTensorsMoEScheme,
+)
+from sglang.srt.layers.quantization.w4afp8 import interleave_scales
+from sglang.srt.utils import set_weight_attrs
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.moe.token_dispatcher import (
+        CombineInput,
+        StandardDispatchOutput,
+    )
+    from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors import (
+        CompressedTensorsConfig,
+    )
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["CompressedTensorsW4AFP8MoE"]
+
+
+def _unpack_repack_int32_to_cutlass_int8(
+    weight_packed: torch.Tensor, num_bits: int
+) -> torch.Tensor:
+    """Convert compressed-tensors pack_to_int32 format to CUTLASS int8-packed format.
+
+    pack_to_int32 stores 8 unsigned-offset int4 values per int32.
+    CUTLASS expects pairs of signed int4 values packed into int8
+    (low nibble = even index, high nibble = odd index, two's complement).
+
+    Args:
+        weight_packed: [E, N, K // pack_factor] int32  (pack_factor = 32 // num_bits)
+        num_bits: quantization bit width (e.g. 4)
+
+    Returns:
+        [E, N, K // 2] int8 in CUTLASS layout
+    """
+    pack_factor = 32 // num_bits
+    mask = (1 << num_bits) - 1
+    offset = 1 << (num_bits - 1)
+
+    # Unpack: each int32 → pack_factor signed int4 values
+    unpacked = torch.stack(
+        [(weight_packed >> (num_bits * i)) & mask for i in range(pack_factor)],
+        dim=-1,
+    )  # [..., K_packed, pack_factor]
+    unpacked = unpacked.flatten(-2).to(torch.int8) - offset  # [..., K] signed int4
+
+    # Repack pairs into CUTLASS int8: low nibble = even, high nibble = odd
+    low_nibbles = unpacked[..., 0::2]
+    high_nibbles = unpacked[..., 1::2]
+    return ((high_nibbles << 4) | (low_nibbles & 0x0F)).to(torch.int8).contiguous()
+
+
+class CompressedTensorsW4AFP8MoE(CompressedTensorsMoEScheme):
+    """W4AFP8 MoE: INT4 weights (pack-quantized) + dynamic per-token FP8 activations,
+    using CUTLASS W4A8 grouped GEMM kernel."""
+
+    def __init__(
+        self,
+        quant_config: CompressedTensorsConfig,
+        weight_quant,
+        input_quant,
+    ):
+        self.quant_config = quant_config
+        config = self.quant_config.target_scheme_map["Linear"].get("weights")
+        self.num_bits = config.num_bits
+        self.packed_factor = 32 // config.num_bits
+        self.group_size = config.group_size
+        self.weight_quant = weight_quant
+        self.input_quant = input_quant
+
+        assert config.symmetric, "Only symmetric quantization is supported"
+        assert (
+            self.quant_config.quant_format == CompressionFormat.pack_quantized.value
+        ), f"W4AFP8MoE requires pack-quantized format, got {self.quant_config.quant_format}"
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return 90
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size_per_partition: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+
+        from sglang.srt.layers.moe.fused_moe_triton import FusedMoeWeightScaleSupported
+
+        # Weights in checkpoint (non-transposed) layout: [E, N, K // pack_factor]
+        # This matches the pack-quantized checkpoint format directly.
+        w13_weight = torch.nn.Parameter(
+            torch.empty(
+                num_experts,
+                2 * intermediate_size_per_partition,
+                hidden_size // self.packed_factor,
+                dtype=torch.int32,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w13_weight_packed", w13_weight)
+        set_weight_attrs(w13_weight, extra_weight_attrs)
+
+        w2_weight = torch.nn.Parameter(
+            torch.empty(
+                num_experts,
+                hidden_size,
+                intermediate_size_per_partition // self.packed_factor,
+                dtype=torch.int32,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w2_weight_packed", w2_weight)
+        set_weight_attrs(w2_weight, extra_weight_attrs)
+
+        # Scales: [E, N, K // group_size]
+        num_groups_w13 = hidden_size // self.group_size
+        num_groups_w2 = intermediate_size_per_partition // self.group_size
+
+        extra_weight_attrs.update(
+            {"quant_method": FusedMoeWeightScaleSupported.GROUP.value}
+        )
+
+        w13_scale = torch.nn.Parameter(
+            torch.zeros(
+                num_experts,
+                2 * intermediate_size_per_partition,
+                num_groups_w13,
+                dtype=torch.float32,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w13_weight_scale", w13_scale)
+        set_weight_attrs(w13_scale, extra_weight_attrs)
+
+        w2_scale = torch.nn.Parameter(
+            torch.zeros(
+                num_experts,
+                hidden_size,
+                num_groups_w2,
+                dtype=torch.float32,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w2_weight_scale", w2_scale)
+        set_weight_attrs(w2_scale, extra_weight_attrs)
+
+        # Placeholder params to accept checkpoint tensors that we don't use.
+        # Without these, the weight loader warns "not found in params_dict".
+        for name, shape in [
+            ("w13_weight_shape", (num_experts, 2)),
+            ("w2_weight_shape", (num_experts, 2)),
+        ]:
+            p = torch.nn.Parameter(
+                torch.empty(shape, dtype=torch.int32), requires_grad=False
+            )
+            layer.register_parameter(name, p)
+            set_weight_attrs(p, extra_weight_attrs)
+
+        self._init_cutlass_buffers(
+            num_experts,
+            hidden_size,
+            intermediate_size_per_partition,
+            layer.w13_weight_packed.device,
+        )
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        """Convert pack-quantized INT32 weights to CUTLASS INT8-packed format.
+
+        Unpacks weights from compressed-tensors pack_to_int32 format and repacks
+        into CUTLASS int8 layout, then interleaves scales.
+          INT32 [E, N, K//8] → unpack signed int4 → repack INT8 [E, N, K//2]
+          Scales [E, N, K//gs] → interleaved bfloat16
+        """
+        if getattr(layer, "is_w4afp8_converted", False):
+            return
+
+        dtype = torch.bfloat16
+        device = layer.w2_weight_packed.device
+
+        # TODO: currently only support per tensor quant.
+        layer.a13_scale = None
+        layer.a2_scale = None
+
+        w13 = _unpack_repack_int32_to_cutlass_int8(
+            layer.w13_weight_packed.data, self.num_bits
+        )
+        layer.w13_weight_packed = torch.nn.Parameter(w13, requires_grad=False)
+
+        w2 = _unpack_repack_int32_to_cutlass_int8(
+            layer.w2_weight_packed.data, self.num_bits
+        )
+        layer.w2_weight_packed = torch.nn.Parameter(w2, requires_grad=False)
+
+        w13_weight_scale = layer.w13_weight_scale.to(dtype)
+        w13_weight_scale = interleave_scales(w13_weight_scale)
+        layer.w13_weight_scale = torch.nn.Parameter(
+            w13_weight_scale, requires_grad=False
+        )
+
+        w2_weight_scale = layer.w2_weight_scale.to(dtype)
+        w2_weight_scale = interleave_scales(w2_weight_scale)
+        layer.w2_weight_scale = torch.nn.Parameter(w2_weight_scale, requires_grad=False)
+
+        layer.is_w4afp8_converted = True
+
+    def create_moe_runner(
+        self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
+    ):
+        self.moe_runner_config = moe_runner_config
+
+    def _init_cutlass_buffers(
+        self,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size: int,
+        device: torch.device,
+    ):
+        """Pre-allocate stride and workspace tensors for CUTLASS grouped GEMM."""
+        self.a_strides1 = torch.full(
+            (num_experts, 3), hidden_size, device=device, dtype=torch.int64
+        )
+        self.c_strides1 = torch.full(
+            (num_experts, 3),
+            2 * intermediate_size,
+            device=device,
+            dtype=torch.int64,
+        )
+        self.a_strides2 = torch.full(
+            (num_experts, 3), intermediate_size, device=device, dtype=torch.int64
+        )
+        self.c_strides2 = torch.full(
+            (num_experts, 3), hidden_size, device=device, dtype=torch.int64
+        )
+        self.b_strides1 = self.a_strides1
+        self.s_strides13 = self.c_strides1
+        self.b_strides2 = self.a_strides2
+        self.s_strides2 = self.c_strides2
+
+        self.expert_offsets = torch.empty(
+            num_experts + 1, dtype=torch.int32, device=device
+        )
+        self.problem_sizes1 = torch.empty(
+            (num_experts, 3), dtype=torch.int32, device=device
+        )
+        self.problem_sizes2 = torch.empty(
+            (num_experts, 3), dtype=torch.int32, device=device
+        )
+
+    def apply_weights(
+        self,
+        layer: torch.nn.Module,
+        dispatch_output: StandardDispatchOutput,
+    ) -> CombineInput:
+        from sglang.srt.layers.moe.cutlass_w4a8_moe import cutlass_w4a8_moe
+        from sglang.srt.layers.moe.token_dispatcher import StandardCombineInput
+
+        assert (
+            self.moe_runner_config.activation == "silu"
+        ), "Only SiLU activation is supported."
+
+        x = dispatch_output.hidden_states
+        topk_output = dispatch_output.topk_output
+        topk_weights, topk_ids, _ = topk_output
+
+        # TODO: currently, group_size is hardcoded to 128 in the cutlass_w4a8_moe kernel.
+        output = cutlass_w4a8_moe(
+            x,
+            layer.w13_weight_packed,
+            layer.w2_weight_packed,
+            layer.w13_weight_scale,
+            layer.w2_weight_scale,
+            topk_weights,
+            topk_ids,
+            self.a_strides1,
+            self.b_strides1,
+            self.c_strides1,
+            self.a_strides2,
+            self.b_strides2,
+            self.c_strides2,
+            self.s_strides13,
+            self.s_strides2,
+            self.expert_offsets,
+            self.problem_sizes1,
+            self.problem_sizes2,
+            layer.a13_scale,
+            layer.a2_scale,
+            routed_scaling_factor=self.moe_runner_config.routed_scaling_factor or 1.0,
+        )
+        return StandardCombineInput(hidden_states=output)

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a8_fp8_moe.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a8_fp8_moe.py
@@ -53,18 +53,24 @@ def _unpack_repack_int32_to_cutlass_int8(
     pack_factor = 32 // num_bits
     mask = (1 << num_bits) - 1
     offset = 1 << (num_bits - 1)
+    pair_factor = pack_factor // 2
 
-    # Unpack: each int32 → pack_factor signed int4 values
-    unpacked = torch.stack(
-        [(weight_packed >> (num_bits * i)) & mask for i in range(pack_factor)],
-        dim=-1,
-    )  # [..., K_packed, pack_factor]
-    unpacked = unpacked.flatten(-2).to(torch.int8) - offset  # [..., K] signed int4
+    # Repack directly into CUTLASS int8 without materializing full unpacked int32.
+    # This reduces peak memory from O(pack_factor) large int32 buffers to O(1) temporaries.
+    out = torch.empty(
+        (*weight_packed.shape[:-1], weight_packed.shape[-1], pair_factor),
+        dtype=torch.int8,
+        device=weight_packed.device,
+    )
+    for pair_idx in range(pair_factor):
+        low_shift = num_bits * (2 * pair_idx)
+        high_shift = low_shift + num_bits
 
-    # Repack pairs into CUTLASS int8: low nibble = even, high nibble = odd
-    low_nibbles = unpacked[..., 0::2]
-    high_nibbles = unpacked[..., 1::2]
-    return ((high_nibbles << 4) | (low_nibbles & 0x0F)).to(torch.int8).contiguous()
+        low_nibbles = ((weight_packed >> low_shift) & mask) - offset
+        high_nibbles = ((weight_packed >> high_shift) & mask) - offset
+        out[..., pair_idx] = ((high_nibbles << 4) | (low_nibbles & 0x0F)).to(torch.int8)
+
+    return out.flatten(-2).contiguous()
 
 
 class CompressedTensorsW4AFP8MoE(CompressedTensorsMoEScheme):

--- a/python/sglang/srt/layers/quantization/compressed_tensors/utils.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/utils.py
@@ -15,6 +15,7 @@ def is_activation_quantization_format(format: str) -> bool:
         CompressionFormat.int_quantized.value,
         CompressionFormat.float_quantized.value,
         CompressionFormat.nvfp4_pack_quantized.value,
+        CompressionFormat.pack_quantized.value,
     ]
     return format in _ACTIVATION_QUANTIZATION_FORMATS
 

--- a/python/sglang/test/test_cutlass_w4a8_moe.py
+++ b/python/sglang/test/test_cutlass_w4a8_moe.py
@@ -1,12 +1,48 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import socket
 from typing import Optional
+from unittest.mock import patch
 
 import pytest
 import torch
 
+from sglang.srt.distributed import (
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+from sglang.srt.distributed.parallel_state import destroy_model_parallel
 from sglang.srt.layers.moe.cutlass_w4a8_moe import cutlass_w4a8_moe
 from sglang.srt.layers.moe.topk import TopKConfig, select_experts
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _init_single_gpu_moe_parallel():
+    """cutlass_w4a8_moe calls get_moe_expert_parallel_world_size() which needs MoE EP group."""
+    if not torch.cuda.is_available():
+        yield
+        return
+
+    if not torch.distributed.is_initialized():
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", 0))
+            port = sock.getsockname()[1]
+        init_distributed_environment(
+            world_size=1,
+            rank=0,
+            local_rank=0,
+            backend="nccl",
+            distributed_init_method=f"tcp://127.0.0.1:{port}",
+        )
+    try:
+        initialize_model_parallel(tensor_model_parallel_size=1)
+    except AssertionError:
+        # e.g. tensor / MoE parallel groups already initialized by the test runner
+        pass
+
+    yield
+
+    destroy_model_parallel()
 
 
 def pack_int4_values_to_int8(int4_values_interleaved: torch.Tensor) -> torch.Tensor:
@@ -122,6 +158,7 @@ def test_cutlass_w4a8_moe(M, N, K, E, tp_size, use_ep_moe, topk, group_size, dty
     expert_map = torch.arange(E, dtype=torch.int32, device=device)
     expert_map[local_e:] = -1
 
+    ep_size = tp_size if use_ep_moe else 1
     output = cutlass_moe(
         a,
         w1_q,
@@ -142,6 +179,7 @@ def test_cutlass_w4a8_moe(M, N, K, E, tp_size, use_ep_moe, topk, group_size, dty
         a1_scale,
         a2_scale,
         expert_map,
+        ep_size=ep_size,
     )
 
     ref_output = ref(
@@ -190,6 +228,7 @@ def cutlass_moe(
     a2_scale: Optional[torch.Tensor] = None,
     expert_map: Optional[torch.Tensor] = None,
     apply_router_weight_on_input: bool = False,
+    ep_size: int = 1,
 ):
     topk_ids = expert_map[topk_ids]
     device = a.device
@@ -203,29 +242,33 @@ def cutlass_moe(
     problem_sizes2 = torch.empty(
         (num_local_experts, 3), dtype=torch.int32, device=device
     )
-    return cutlass_w4a8_moe(
-        a,
-        w1_q,
-        w2_q,
-        w1_scale,
-        w2_scale,
-        topk_weights,
-        topk_ids,
-        a_strides1,
-        b_strides1,
-        c_strides1,
-        a_strides2,
-        b_strides2,
-        c_strides2,
-        s_strides13,
-        s_strides2,
-        expert_offsets,
-        problem_sizes1,
-        problem_sizes2,
-        a1_scale,
-        a2_scale,
-        apply_router_weight_on_input,
-    )
+    with patch(
+        "sglang.srt.layers.moe.cutlass_w4a8_moe.get_moe_expert_parallel_world_size",
+        return_value=ep_size,
+    ):
+        return cutlass_w4a8_moe(
+            a,
+            w1_q,
+            w2_q,
+            w1_scale,
+            w2_scale,
+            topk_weights,
+            topk_ids,
+            a_strides1,
+            b_strides1,
+            c_strides1,
+            a_strides2,
+            b_strides2,
+            c_strides2,
+            s_strides13,
+            s_strides2,
+            expert_offsets,
+            problem_sizes1,
+            problem_sizes2,
+            a1_scale,
+            a2_scale,
+            apply_router_weight_on_input,
+        )
 
 
 def ref(

--- a/sgl-kernel/csrc/moe/cutlass_moe/w4a8/w4a8_grouped_mm_c3x.cu
+++ b/sgl-kernel/csrc/moe/cutlass_moe/w4a8/w4a8_grouped_mm_c3x.cu
@@ -146,9 +146,13 @@ void dispatch_w4a8_moe_mm_sm90(
       INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 64, 512, 1, 1, 1>));
     }
   } else if (n == 7168 && k == 256) {
-    // group gemm 2 for tp
-    if (m <= 8) {
-      INVOKE_GEMM_WITH_CONFIG((SM90_PP<64, 16, 128, 1, 1, 1>));
+    // group gemm 2 for tp — K=256 means TileK=128 gives only 2 mainloop
+    // iterations.  Cooperative schedule hides latency better than PingPong
+    // for small m (benchmarked +10-32% on H20).
+    if (m <= 4) {
+      INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 16, 128, 1, 1, 1>));
+    } else if (m <= 8) {
+      INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 32, 128, 1, 1, 1>));
     } else if (m <= 32) {
       INVOKE_GEMM_WITH_CONFIG((SM90_PP<128, 32, 128, 1, 1, 1>));
     } else if (m <= 512) {

--- a/sgl-kernel/csrc/moe/cutlass_moe/w4a8/w4a8_grouped_mm_c3x.cu
+++ b/sgl-kernel/csrc/moe/cutlass_moe/w4a8/w4a8_grouped_mm_c3x.cu
@@ -146,13 +146,9 @@ void dispatch_w4a8_moe_mm_sm90(
       INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 64, 512, 1, 1, 1>));
     }
   } else if (n == 7168 && k == 256) {
-    // group gemm 2 for tp — K=256 means TileK=128 gives only 2 mainloop
-    // iterations.  Cooperative schedule hides latency better than PingPong
-    // for small m (benchmarked +10-32% on H20).
-    if (m <= 4) {
-      INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 16, 128, 1, 1, 1>));
-    } else if (m <= 8) {
-      INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 32, 128, 1, 1, 1>));
+    // group gemm 2 for tp
+    if (m <= 8) {
+      INVOKE_GEMM_WITH_CONFIG((SM90_PP<64, 16, 128, 1, 1, 1>));
     } else if (m <= 32) {
       INVOKE_GEMM_WITH_CONFIG((SM90_PP<128, 32, 128, 1, 1, 1>));
     } else if (m <= 512) {


### PR DESCRIPTION
## Motivation

Add support for loading compressed-tensors W4AFP8 MoE checkpoints in SGLang's `compressed_tensors` path. This enables INT4 group-quantized MoE weights with dynamic FP8 activation quantization to run through the CUTLASS W4A8 kernel, and also reduces peak CUDA memory during the weight repack step.

- support per tensor dynamic quant 
- only support weight quant group_size=128 because of w4a8 cutlass kernel impl limit

coauther @yuyu5333 


## Modifications

- add `CompressedTensorsW4AFP8MoE` and wire W4AFP8 scheme detection/registration into `CompressedTensorsConfig`
- convert pack-quantized INT32 weights into CUTLASS int8-packed layout and interleave group scales during post-load processing
- update `test_cutlass_w4a8_moe` to initialize single-GPU distributed state and mock EP world size so the expert-map sentinel path is exercised correctly

## Accuracy Tests

- `pytest -q python/sglang/test/test_cutlass_w4a8_moe.py -q` ✅

```python
### baseline
#python -m sglang.test.few_shot_gsm8k   --host 127.0.0.1   --port 30000   --num-questions 200   --num-shots 5
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [00:20<00:00,  9.54it/s]
Accuracy: 0.945
Invalid: 0.000
Latency: 21.101 s
Output throughput: 909.622 token/s

### pr
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [00:23<00:00,  8.37it/s]
Accuracy: 0.945
Invalid: 0.000
Latency: 24.029 s
Output throughput: 826.904 token/s
```
## Speed Tests and Profiling

<img width="781" height="373" alt="image" src="https://github.com/user-attachments/assets/962482c5-131f-432d-b552-37fc4230e910" />

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Note(WIP)
- [ ] fuse quant/dequant kernel to optimize tpot when batch size is small
- [ ] opt cutlass w4a8 kernel