### PR TITLE
Fix kimi-linear launch server error

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -491,6 +491,11 @@ class ModelConfig:
             self.qk_rope_head_dim = self.hf_config.qk_rope_head_dim
             self.v_head_dim = self.hf_config.v_head_dim
             self.qk_nope_head_dim = self.hf_config.qk_nope_head_dim
+            self.scaling = 1 / math.sqrt(self.qk_nope_head_dim + self.qk_rope_head_dim)
+            if self.hf_config.rope_scaling:
+                self.scaling = compute_mla_mscale_scaling(
+                    self.hf_config.rope_scaling, self.scaling
+                )
         elif (
             "BailingMoeV2_5ForCausalLM" in self.hf_config.architectures
             or "BailingMoeForCausalLMNextN" in self.hf_config.architectures


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Main kimi-linear was broken due to self.scaling being deleted.
```
self.scaling = 1 / math.sqrt(self.qk_nope_head_dim + self.qk_rope_head_dim)
```
It causes the server launch error for kimi-linear model.
```
➜  python git:(main) ✗ sglang serve --model-path moonshotai/Kimi-Linear-48B-A3B-Instruct --tp-size 2 --trust-remote --device cuda --host 127.0.0.1 --port 30000
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
Disabling Radix Cache for KimiLinearForCausalLM as it is not yet supported.
/sgl-workspace/sglang/python/sglang/srt/entrypoints/http_server.py:176: FastAPIDeprecationWarning: ORJSONResponse is deprecated, FastAPI now serializes data directly to JSON bytes via Pydantic when a return type or response model is set, which is faster and doesn't need a custom response class. Read more in the FastAPI docs: https://fastapi.tiangolo.com/advanced/custom-response/#orjson-or-response-model and https://fastapi.tiangolo.com/tutorial/response-model/
  from sglang.srt.utils.json_response import (
  ......
            if rope_scaling:
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/managers/tp_worker.py", line 261, in __init__
    self._init_model_runner()
  File "/sgl-workspace/sglang/python/sglang/srt/managers/tp_worker.py", line 344, in _init_model_runner
    self._model_runner = ModelRunner(
                         ^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 426, in __init__
    self.initialize(pre_model_load_memory)
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 643, in initialize
    self.init_attention_backend()
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 1877, in init_attention_backend
    self.attn_backend = self._get_attention_backend()
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 1922, in _get_attention_backend
    attn_backend = self._get_attention_backend_from_str(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 1939, in _get_attention_backend_from_str
    full_attention_backend = ATTENTION_BACKENDS[backend_str](self)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/layers/attention/attention_registry.py", line 45, in create_flashinfer_backend
    return FlashInferMLAAttnBackend(runner)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/layers/attention/flashinfer_mla_backend.py", line 273, in __init__
    self.indices_updater_prefill = FlashInferMLAIndicesUpdaterPrefill(
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/layers/attention/flashinfer_mla_backend.py", line 775, in __init__
    self.scaling = model_runner.model_config.scaling
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'ModelConfig' object has no attribute 'scaling'

[2026-03-31 09:35:41] Received sigquit from a child process. It usually means the child failed.
[2026-03-31 09:35:41 TP0] Scheduler hit an exception: Traceback (most recent call last):
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 3574, in run_scheduler_process
    scheduler = Scheduler(
                ^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 382, in __init__
    self.init_model_worker()
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 626, in init_model_worker
    self.init_tp_model_worker()
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 594, in init_tp_model_worker
    self.tp_worker = TpModelWorker(**worker_kwargs)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/managers/tp_worker.py", line 261, in __init__
    self._init_model_runner()
  File "/sgl-workspace/sglang/python/sglang/srt/managers/tp_worker.py", line 344, in _init_model_runner
    self._model_runner = ModelRunner(
                         ^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 426, in __init__
    self.initialize(pre_model_load_memory)
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 643, in initialize
    self.init_attention_backend()
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 1877, in init_attention_backend
    self.attn_backend = self._get_attention_backend()
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 1922, in _get_attention_backend
    attn_backend = self._get_attention_backend_from_str(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 1939, in _get_attention_backend_from_str
    full_attention_backend = ATTENTION_BACKENDS[backend_str](self)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/layers/attention/attention_registry.py", line 45, in create_flashinfer_backend
    return FlashInferMLAAttnBackend(runner)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/layers/attention/flashinfer_mla_backend.py", line 273, in __init__
    self.indices_updater_prefill = FlashInferMLAIndicesUpdaterPrefill(
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/layers/attention/flashinfer_mla_backend.py", line 775, in __init__
    self.scaling = model_runner.model_config.scaling
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'ModelConfig' object has no attribute 'scaling'

[2026-03-31 09:35:41] Received sigquit from a child process. It usually means the child failed.
[1]    23612 killed     sglang serve --model-path moonshotai/Kimi-Linear-48B-A3B-Instruct --tp-size 2
```
With fix, it runs correctly:
```
➜  python git:(main) ✗ sglang serve --model-path moonshotai/Kimi-Linear-48B-A3B-Instruct --tp-size 2 --trust-remote --device cuda --host 127.0.0.1 --port 30000
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
Disabling Radix Cache for KimiLinearForCausalLM as it is not yet supported.
/sgl-workspace/sglang/python/sglang/srt/entrypoints/http_server.py:176: FastAPIDeprecationWarning: ORJSONResponse is deprecated, FastAPI now serializes data directly to JSON bytes via Pydantic when a return type or response model is set, which is faster and doesn't need a custom response class. Read more in the FastAPI docs: https://fastapi.tiangolo.com/advanced/custom-response/#orjson-or-response-model and https://fastapi.tiangolo.com/tutorial/response-model/
  from sglang.srt.utils.json_response import (
[2026-03-31 09:39:18] server_args=ServerArgs(model_path='moonshotai/Kimi-Linear-48B-A3B-Instruct', tokenizer_path='moonshotai/Kimi-Linear-48B-A3B-Instruct', tokenizer_mode='auto', tokenizer_worker_num=1, skip_tokenizer_init=False, load_format='auto', model_loader_extra_config='{}', trust_remote_code=True, context_length=None, is_embedding=False, enable_multimodal=None, revision=None, model_impl='auto', host='127.0.0.1', port=30000, fastapi_root_path='', grpc_mode=False, skip_server_warmup=False, warmups=None, nccl_port=None, checkpoint_engine_wait_weights_before_ready=False, ssl_keyfile=None, ssl_certfile=None, ssl_ca_certs=None, ssl_keyfile_password=None, enable_ssl_refresh=False, dtype='auto', quantization=None, quantization_param_path=None, kv_cache_dtype='auto', enable_fp32_lm_head=False, modelopt_quant=None, modelopt_checkpoint_restore_path=None, modelopt_checkpoint_save_path=None, modelopt_export_path=None, quantize_and_serve=False, rl_quant_profile=None, mem_fraction_static=0.848, max_running_requests=None, max_queued_requests=None, max_total_tokens=None, chunked_prefill_size=16384, enable_dynamic_chunking=False, max_prefill_tokens=16384, prefill_max_requests=None, schedule_policy='fcfs', enable_priority_scheduling=False, disable_priority_preemption=False, default_priority_value=None, abort_on_priority_when_disabled=False, schedule_low_priority_values_first=False, priority_scheduling_preemption_threshold=10, schedule_conservativeness=1.0, page_size=1, swa_full_tokens_ratio=0.8, disable_hybrid_swa_memory=False, radix_eviction_policy='lru', enable_prefill_delayer=False, prefill_delayer_max_delay_passes=30, prefill_delayer_token_usage_low_watermark=None, prefill_delayer_forward_passes_buckets=None, prefill_delayer_wait_seconds_buckets=None, device='cuda', tp_size=2, pp_size=1, pp_max_micro_batch_size=None, pp_async_batch_depth=0, stream_interval=1, incremental_streaming_output=False, enable_streaming_session=False, random_seed=677587393, constrained_json_whitespace_pattern=None, constrained_json_disable_any_whitespace=False, watchdog_timeout=300, soft_watchdog_timeout=None, dist_timeout=None, download_dir=None, model_checksum=None, base_gpu_id=0, gpu_id_step=1, sleep_on_idle=False, use_ray=False, custom_sigquit_handler=None, log_level='info', log_level_http=None, log_requests=False, log_requests_level=2, log_requests_format='text', log_requests_target=None, uvicorn_access_log_exclude_prefixes=[], crash_dump_folder=None, show_time_cost=False, enable_metrics=False, enable_mfu_metrics=False, enable_metrics_for_all_schedulers=False, tokenizer_metrics_custom_labels_header='x-custom-labels', tokenizer_metrics_allowed_custom_labels=None, extra_metric_labels=None, bucket_time_to_first_token=None, bucket_inter_token_latency=None, bucket_e2e_request_latency=None, collect_tokens_histogram=False, prompt_tokens_buckets=None, generation_tokens_buckets=None, gc_warning_threshold_secs=0.0, decode_log_interval=40, enable_request_time_stats_logging=False, kv_events_config=None, enable_trace=False, otlp_traces_endpoint='localhost:4317', export_metrics_to_file=False, export_metrics_to_file_dir=None, api_key=None, admin_api_key=None, served_model_name='moonshotai/Kimi-Linear-48B-A3B-Instruct', weight_version='default', chat_template=None, hf_chat_template_name=None, completion_template=None, file_storage_path='sglang_storage', enable_cache_report=False, reasoning_parser=None, tool_call_parser=None, tool_server=None, sampling_defaults='model', dp_size=1, load_balance_method='round_robin', attn_cp_size=1, moe_dp_size=1, dist_init_addr=None, nnodes=1, node_rank=0, json_model_override_args='{}', preferred_sampling_params=None, enable_lora=None, enable_lora_overlap_loading=None, max_lora_rank=None, lora_target_modules=None, lora_paths=None, max_loaded_loras=None, max_loras_per_batch=8, lora_eviction_policy='lru', lora_backend='csgmv', max_lora_chunk_size=16, attention_backend='flashinfer', decode_attention_backend=None, prefill_attention_backend=None, sampling_backend='flashinfer', grammar_backend='xgrammar', mm_attention_backend=None, fp8_gemm_runner_backend='auto', fp4_gemm_runner_backend='auto', nsa_prefill_backend=None, nsa_decode_backend=None, disable_flashinfer_autotune=False, mamba_backend='triton', speculative_algorithm=None, speculative_draft_model_path=None, speculative_draft_model_revision=None, speculative_draft_load_format=None, speculative_num_steps=None, speculative_eagle_topk=None, speculative_num_draft_tokens=None, speculative_accept_threshold_single=1.0, speculative_accept_threshold_acc=1.0, speculative_token_map=None, speculative_attention_mode='prefill', speculative_draft_attention_backend=None, speculative_moe_runner_backend='auto', speculative_moe_a2a_backend=None, speculative_draft_model_quantization=None, speculative_ngram_min_match_window_size=1, speculative_ngram_max_match_window_size=12, speculative_ngram_min_bfs_breadth=1, speculative_ngram_max_bfs_breadth=10, speculative_ngram_match_type='BFS', speculative_ngram_max_trie_depth=18, speculative_ngram_capacity=10000000, enable_multi_layer_eagle=False, ep_size=1, moe_a2a_backend='none', moe_runner_backend='auto', flashinfer_mxfp4_moe_precision='default', enable_flashinfer_allreduce_fusion=False, enable_aiter_allreduce_fusion=False, deepep_mode='auto', ep_num_redundant_experts=0, ep_dispatch_algorithm=None, init_expert_location='trivial', enable_eplb=False, eplb_algorithm='auto', eplb_rebalance_num_iterations=1000, eplb_rebalance_layers_per_chunk=None, eplb_min_rebalancing_utilization_threshold=1.0, expert_distribution_recorder_mode=None, expert_distribution_recorder_buffer_size=1000, enable_expert_distribution_metrics=False, deepep_config=None, moe_dense_tp_size=None, elastic_ep_backend=None, enable_elastic_expert_backup=False, mooncake_ib_device=None, max_mamba_cache_size=None, mamba_ssm_dtype=None, mamba_full_memory_ratio=0.9, mamba_scheduler_strategy='no_buffer', mamba_track_interval=256, linear_attn_backend='triton', linear_attn_decode_backend=None, linear_attn_prefill_backend=None, enable_hierarchical_cache=False, hicache_ratio=2.0, hicache_size=0, hicache_write_policy='write_through', hicache_io_backend='kernel', hicache_mem_layout='layer_first', hicache_storage_backend=None, hicache_storage_prefetch_policy='best_effort', hicache_storage_backend_extra_config=None, enable_hisparse=False, hisparse_config=None, enable_lmcache=False, kt_weight_path=None, kt_method='AMXINT4', kt_cpuinfer=None, kt_threadpool_count=2, kt_num_gpu_experts=None, kt_max_deferred_experts_per_token=None, dllm_algorithm=None, dllm_algorithm_config=None, enable_double_sparsity=False, ds_channel_config_path=None, ds_heavy_channel_num=32, ds_heavy_token_num=256, ds_heavy_channel_type='qk', ds_sparse_decode_threshold=4096, cpu_offload_gb=0, offload_group_size=-1, offload_num_in_group=1, offload_prefetch_step=1, offload_mode='cpu', multi_item_scoring_delimiter=None, disable_radix_cache=True, cuda_graph_max_bs=512, cuda_graph_bs=[1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512], disable_cuda_graph=False, disable_cuda_graph_padding=False, enable_profile_cuda_graph=False, enable_cudagraph_gc=False, enable_layerwise_nvtx_marker=False, enable_nccl_nvls=False, enable_symm_mem=False, disable_flashinfer_cutlass_moe_fp4_allgather=False, enable_tokenizer_batch_encode=False, disable_tokenizer_batch_decode=False, disable_outlines_disk_cache=False, disable_custom_all_reduce=False, enable_mscclpp=False, enable_torch_symm_mem=False, pre_warm_nccl=False, disable_overlap_schedule=False, enable_mixed_chunk=False, enable_dp_attention=False, enable_dp_lm_head=False, enable_two_batch_overlap=False, enable_single_batch_overlap=False, tbo_token_distribution_threshold=0.48, enable_torch_compile=False, disable_piecewise_cuda_graph=False, enforce_piecewise_cuda_graph=False, enable_torch_compile_debug_mode=False, torch_compile_max_bs=32, piecewise_cuda_graph_max_tokens=2048, piecewise_cuda_graph_tokens=[4, 8, 12, 16, 20, 24, 28, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256, 288, 320, 352, 384, 416, 448, 480, 512, 576, 640, 704, 768, 832, 896, 960, 1024, 1280, 1536, 1792, 2048], piecewise_cuda_graph_compiler='eager', torchao_config='', enable_nan_detection=False, enable_p2p_check=False, triton_attention_reduce_in_fp32=False, triton_attention_num_kv_splits=8, triton_attention_split_tile_size=None, num_continuous_decode_steps=1, delete_ckpt_after_loading=False, enable_memory_saver=False, enable_weights_cpu_backup=False, enable_draft_weights_cpu_backup=False, allow_auto_truncate=False, enable_custom_logit_processor=False, flashinfer_mla_disable_ragged=False, disable_shared_experts_fusion=False, disable_chunked_prefix_cache=False, disable_fast_image_processor=False, keep_mm_feature_on_device=False, enable_return_hidden_states=False, enable_return_routed_experts=False, scheduler_recv_interval=1, numa_node=None, enable_deterministic_inference=False, rl_on_policy_target=None, enable_attn_tp_input_scattered=False, gc_threshold=None, enable_nsa_prefill_context_parallel=False, nsa_prefill_cp_mode='round-robin-split', enable_fused_qk_norm_rope=False, enable_precise_embedding_interpolation=False, enable_fused_moe_sum_all_reduce=False, enable_prefill_context_parallel=False, prefill_cp_mode='in-seq-split', enable_dynamic_batch_tokenizer=False, dynamic_batch_tokenizer_batch_size=32, dynamic_batch_tokenizer_batch_timeout=0.002, debug_tensor_dump_output_folder=None, debug_tensor_dump_layers=None, debug_tensor_dump_input_file=None, debug_tensor_dump_inject=False, disaggregation_mode='null', disaggregation_transfer_backend='mooncake', disaggregation_bootstrap_port=8998, disaggregation_ib_device=None, disaggregation_decode_enable_offload_kvcache=False, num_reserved_decode_tokens=512, disaggregation_decode_polling_interval=1, encoder_only=False, language_only=False, encoder_transfer_backend='zmq_to_scheduler', encoder_urls=[], enable_adaptive_dispatch_to_encoder=False, custom_weight_loader=[], weight_loader_disable_mmap=False, remote_instance_weight_loader_seed_instance_ip=None, remote_instance_weight_loader_seed_instance_service_port=None, remote_instance_weight_loader_send_weights_group_ports=None, remote_instance_weight_loader_backend='nccl', remote_instance_weight_loader_start_seed_via_transfer_engine=False, modelexpress_config=None, enable_pdmux=False, pdmux_config_path=None, sm_group_num=8, mm_max_concurrent_calls=32, mm_per_request_timeout=10.0, enable_broadcast_mm_inputs_process=False, enable_prefix_mm_cache=False, mm_enable_dp_encoder=False, mm_process_config={}, limit_mm_data_per_request=None, enable_mm_global_cache=False, decrypted_config_file=None, decrypted_draft_config_file=None, forward_hooks=None)
[2026-03-31 09:39:18] mp.set_executable /usr/bin/python3 -> /tmp/sglang_temp_file_1774949958.5523_2372825.sh (script='#!/bin/sh\nexec numactl --cpunodebind=0 --membind=0 /usr/bin/python3 "$@"')
[2026-03-31 09:39:18] mp.set_executable revert to /usr/bin/python3
[2026-03-31 09:39:18] mp.set_executable /usr/bin/python3 -> /tmp/sglang_temp_file_1774949958.5585132_5873546.sh (script='#!/bin/sh\nexec numactl --cpunodebind=0 --membind=0 /usr/bin/python3 "$@"')
[2026-03-31 09:39:18] mp.set_executable revert to /usr/bin/python3
[2026-03-31 09:39:19] Reloaded tiktoken model from /root/.cache/huggingface/hub/models--moonshotai--Kimi-Linear-48B-A3B-Instruct/snapshots/e1df551a447157d4658b573f9a695d57658590e9/tiktoken.model
[2026-03-31 09:39:19] #words: 163842 - BOS ID: 163584 - EOS ID: 163585
/sgl-workspace/sglang/python/sglang/srt/utils/hf_transformers_utils.py:858: UserWarning: Using a slow tokenizer. This might cause a significant slowdown. Consider using a fast tokenizer instead.
  warnings.warn(
[2026-03-31 09:39:19] Using default HuggingFace chat template with detected content format: openai
[2026-03-31 09:39:26 TP0] NUMA affinity is already constrained for process, skipping NUMA node configuration for GPU. Remove your constraints to allow automatic configuration.
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
[2026-03-31 09:39:26 TP0] Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
[2026-03-31 09:39:27 TP0] Reloaded tiktoken model from /root/.cache/huggingface/hub/models--moonshotai--Kimi-Linear-48B-A3B-Instruct/snapshots/e1df551a447157d4658b573f9a695d57658590e9/tiktoken.model
[2026-03-31 09:39:27 TP0] #words: 163842 - BOS ID: 163584 - EOS ID: 163585
/sgl-workspace/sglang/python/sglang/srt/utils/hf_transformers_utils.py:858: UserWarning: Using a slow tokenizer. This might cause a significant slowdown. Consider using a fast tokenizer instead.
  warnings.warn(
[2026-03-31 09:39:27 TP0] Init torch distributed begin.
[2026-03-31 09:39:28 TP1] NUMA affinity is already constrained for process, skipping NUMA node configuration for GPU. Remove your constraints to allow automatic configuration.
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
[2026-03-31 09:39:28] Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
[2026-03-31 09:39:28 TP1] Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
[2026-03-31 09:39:29] Reloaded tiktoken model from /root/.cache/huggingface/hub/models--moonshotai--Kimi-Linear-48B-A3B-Instruct/snapshots/e1df551a447157d4658b573f9a695d57658590e9/tiktoken.model
[2026-03-31 09:39:29] #words: 163842 - BOS ID: 163584 - EOS ID: 163585
/sgl-workspace/sglang/python/sglang/srt/utils/hf_transformers_utils.py:858: UserWarning: Using a slow tokenizer. This might cause a significant slowdown. Consider using a fast tokenizer instead.
  warnings.warn(
[2026-03-31 09:39:29 TP1] Reloaded tiktoken model from /root/.cache/huggingface/hub/models--moonshotai--Kimi-Linear-48B-A3B-Instruct/snapshots/e1df551a447157d4658b573f9a695d57658590e9/tiktoken.model
[2026-03-31 09:39:29 TP1] #words: 163842 - BOS ID: 163584 - EOS ID: 163585
/sgl-workspace/sglang/python/sglang/srt/utils/hf_transformers_utils.py:858: UserWarning: Using a slow tokenizer. This might cause a significant slowdown. Consider using a fast tokenizer instead.
  warnings.warn(
[2026-03-31 09:39:29 TP1] Init torch distributed begin.
[Gloo] Rank 1 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 0 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 1 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 0 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[2026-03-31 09:39:30 TP0] sglang is using nccl==2.27.5
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[2026-03-31 09:39:31 TP0] Init torch distributed ends. elapsed=3.75 s, mem usage=1.16 GB
[2026-03-31 09:39:31 TP1] Init torch distributed ends. elapsed=1.38 s, mem usage=1.16 GB
2026-03-31 09:39:31.402 DEBUG Persistent cache disabled, using in-memory JIT cache
[2026-03-31 09:39:31 TP1] Persistent cache disabled, using in-memory JIT cache
2026-03-31 09:39:31.402 DEBUG Persistent cache disabled, using in-memory JIT cache
2026-03-31 09:39:31.402 DEBUG Persistent cache disabled, using in-memory JIT cache
[2026-03-31 09:39:31 TP1] Persistent cache disabled, using in-memory JIT cache
[2026-03-31 09:39:31 TP0] Persistent cache disabled, using in-memory JIT cache
2026-03-31 09:39:31.402 DEBUG Persistent cache disabled, using in-memory JIT cache
[2026-03-31 09:39:31 TP1] Persistent cache disabled, using in-memory JIT cache
2026-03-31 09:39:31.402 DEBUG Persistent cache disabled, using in-memory JIT cache
[2026-03-31 09:39:31 TP0] Persistent cache disabled, using in-memory JIT cache
2026-03-31 09:39:31.402 DEBUG Persistent cache disabled, using in-memory JIT cache
[2026-03-31 09:39:31 TP1] Persistent cache disabled, using in-memory JIT cache
2026-03-31 09:39:31.402 DEBUG Persistent cache disabled, using in-memory JIT cache
[2026-03-31 09:39:31 TP0] Persistent cache disabled, using in-memory JIT cache
2026-03-31 09:39:31.402 DEBUG Persistent cache disabled, using in-memory JIT cache
[2026-03-31 09:39:31 TP0] Persistent cache disabled, using in-memory JIT cache
2026-03-31 09:39:31.402 DEBUG Persistent cache disabled, using in-memory JIT cache
[2026-03-31 09:39:31 TP1] Persistent cache disabled, using in-memory JIT cache
2026-03-31 09:39:31.402 DEBUG Persistent cache disabled, using in-memory JIT cache
[2026-03-31 09:39:31 TP0] Persistent cache disabled, using in-memory JIT cache
[2026-03-31 09:39:31 TP0] Load weight begin. avail mem=176.57 GB
[2026-03-31 09:39:31 TP1] Load weight begin. avail mem=176.57 GB
[2026-03-31 09:39:31 TP0] Found local HF snapshot for moonshotai/Kimi-Linear-48B-A3B-Instruct at /root/.cache/huggingface/hub/models--moonshotai--Kimi-Linear-48B-A3B-Instruct/snapshots/e1df551a447157d4658b573f9a695d57658590e9; skipping download.
Loading safetensors checkpoint shards: 100% Completed | 20/20 [00:11<00:00,  1.77it/s]
[2026-03-31 09:39:43 TP0] Load weight end. elapsed=11.54 s, type=KimiLinearForCausalLM, avail mem=130.74 GB, mem usage=45.84 GB.
[2026-03-31 09:39:43 TP1] Load weight end. elapsed=11.83 s, type=KimiLinearForCausalLM, avail mem=130.74 GB, mem usage=45.84 GB.
[2026-03-31 09:39:43 TP0] Using KV cache dtype: torch.bfloat16
[2026-03-31 09:39:43 TP1] Mamba Cache is allocated. max_mamba_cache_size: 2434, conv_state size: 1.67GB, ssm_state size: 47.56GB
[2026-03-31 09:39:43 TP0] Mamba Cache is allocated. max_mamba_cache_size: 2434, conv_state size: 1.67GB, ssm_state size: 47.56GB
[2026-03-31 09:39:43 TP1] KV Cache is allocated. #tokens: 7281752, KV size: 54.69 GB
[2026-03-31 09:39:43 TP0] KV Cache is allocated. #tokens: 7281752, KV size: 54.69 GB
[2026-03-31 09:39:43 TP1] Memory pool end. avail mem=17.25 GB
[2026-03-31 09:39:43 TP0] Memory pool end. avail mem=17.25 GB
[2026-03-31 09:39:44 TP1] Capture cuda graph begin. This can take up to several minutes. avail mem=16.76 GB
[2026-03-31 09:39:44 TP0] Linear attention kernel backend: decode=triton, prefill=triton
[2026-03-31 09:39:44 TP0] KDA kernel dispatcher: decode=TritonKDAKernel, extend=TritonKDAKernel
[2026-03-31 09:39:44 TP0] Capture cuda graph begin. This can take up to several minutes. avail mem=16.76 GB
[2026-03-31 09:39:44 TP0] Capture cuda graph bs [1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512]
Capturing batches (bs=512 avail_mem=14.44 GB):   0%|                                                                                                                                                                                                                                                                                               | 0/52 [00:00<?, ?it/s][2026-03-31 09:39:45 TP1] Config file not found at /sgl-workspace/sglang/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_5_1/E=256,N=512,device_name=NVIDIA_B200.json. Fallback to triton version 3.4.0 and use MoE kernel config from /sgl-workspace/sglang/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_4_0/E=256,N=512,device_name=NVIDIA_B200.json. Performance might be sub-optimal!
[2026-03-31 09:39:45 TP1] Using MoE kernel config with down_moe=False. Performance might be sub-optimal! Config file not found at /sgl-workspace/sglang/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_5_1/E=256,N=512,device_name=NVIDIA_B200_down.json, you can create them with https://github.com/sgl-project/sglang/tree/main/benchmark/kernels/fused_moe_triton
[2026-03-31 09:39:45 TP0] Config file not found at /sgl-workspace/sglang/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_5_1/E=256,N=512,device_name=NVIDIA_B200.json. Fallback to triton version 3.4.0 and use MoE kernel config from /sgl-workspace/sglang/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_4_0/E=256,N=512,device_name=NVIDIA_B200.json. Performance might be sub-optimal!
[2026-03-31 09:39:45 TP0] Using MoE kernel config with down_moe=False. Performance might be sub-optimal! Config file not found at /sgl-workspace/sglang/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_5_1/E=256,N=512,device_name=NVIDIA_B200_down.json, you can create them with https://github.com/sgl-project/sglang/tree/main/benchmark/kernels/fused_moe_triton
Capturing batches (bs=1 avail_mem=13.29 GB): 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 52/52 [00:08<00:00,  6.37it/s]
[2026-03-31 09:39:52 TP0] Registering 2860 cuda graph addresses
[2026-03-31 09:39:52 TP0] Capture cuda graph end. Time elapsed: 8.70 s. mem usage=3.49 GB. avail mem=13.27 GB.
[2026-03-31 09:39:52 TP0] Capture piecewise CUDA graph begin. avail mem=13.27 GB
[2026-03-31 09:39:52 TP0] Capture cuda graph num tokens [4, 8, 12, 16, 20, 24, 28, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256, 288, 320, 352, 384, 416, 448, 480, 512, 576, 640, 704, 768, 832, 896, 960, 1024, 1280, 1536, 1792, 2048]
[2026-03-31 09:39:52 TP1] Capture cuda graph end. Time elapsed: 8.71 s. mem usage=3.49 GB. avail mem=13.27 GB.
[2026-03-31 09:39:52 TP1] Capture piecewise CUDA graph begin. avail mem=13.27 GB
Compiling num tokens (num_tokens=2048):   0%|                                                                                                                                                                                                                                                                                                      | 0/42 [00:00<?, ?it/s]
[2026-03-31 09:40:54 TP0] Compiling a graph for dynamic shape takes 1.16 s
[2026-03-31 09:40:56 TP1] Compiling a graph for dynamic shape takes 1.96 s
Compiling num tokens (num_tokens=1792):   2%|██████▊                                                                                                                                                                                                                                                                                       | 1/42 [00:10<07:30, 10.99s/it][2026-03-31 09:41:03 TP1] Compiling a graph for dynamic shape takes 1.28 s
[2026-03-31 09:41:03 TP0] Compiling a graph for dynamic shape takes 1.28 s
Compiling num tokens (num_tokens=4): 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 42/42 [00:19<00:00,  2.14it/s]
Capturing num tokens (num_tokens=4 avail_mem=12.12 GB): 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 42/42 [00:04<00:00,  8.79it/s]
[2026-03-31 09:41:11 TP0] Registering 2255 cuda graph addresses
[2026-03-31 09:41:11 TP1] Capture piecewise CUDA graph end. Time elapsed: 79.25 s. mem usage=1.15 GB. avail mem=12.12 GB.
[2026-03-31 09:41:11 TP0] Capture piecewise CUDA graph end. Time elapsed: 79.26 s. mem usage=1.15 GB. avail mem=12.12 GB.
[2026-03-31 09:41:12 TP1] Reloaded tiktoken model from /root/.cache/huggingface/hub/models--moonshotai--Kimi-Linear-48B-A3B-Instruct/snapshots/e1df551a447157d4658b573f9a695d57658590e9/tiktoken.model
[2026-03-31 09:41:12 TP1] #words: 163842 - BOS ID: 163584 - EOS ID: 163585
[2026-03-31 09:41:12 TP0] Reloaded tiktoken model from /root/.cache/huggingface/hub/models--moonshotai--Kimi-Linear-48B-A3B-Instruct/snapshots/e1df551a447157d4658b573f9a695d57658590e9/tiktoken.model
[2026-03-31 09:41:12 TP0] #words: 163842 - BOS ID: 163584 - EOS ID: 163585
/sgl-workspace/sglang/python/sglang/srt/utils/hf_transformers_utils.py:858: UserWarning: Using a slow tokenizer. This might cause a significant slowdown. Consider using a fast tokenizer instead.
  warnings.warn(
/sgl-workspace/sglang/python/sglang/srt/utils/hf_transformers_utils.py:858: UserWarning: Using a slow tokenizer. This might cause a significant slowdown. Consider using a fast tokenizer instead.
  warnings.warn(
[2026-03-31 09:41:12 TP0] max_total_num_tokens=7281752, chunked_prefill_size=16384, max_prefill_tokens=16384, max_running_requests=2434, context_len=1048576, available_gpu_mem=12.12 GB
[2026-03-31 09:41:12] SubprocessWatchdog started, monitoring 3 process(es)
[2026-03-31 09:41:12] INFO:     Started server process [24308]
[2026-03-31 09:41:12] INFO:     Waiting for application startup.
[2026-03-31 09:41:12] INFO:     Application startup complete.
[2026-03-31 09:41:12] INFO:     Uvicorn running on http://127.0.0.1:30000 (Press CTRL+C to quit)
[2026-03-31 09:41:13] INFO:     127.0.0.1:28364 - "GET /model_info HTTP/1.1" 200 OK
[2026-03-31 09:41:28 TP0] Prefill batch, #new-seq: 1, #new-token: 6, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, cuda graph: True, input throughput (token/s): 0.00
[2026-03-31 09:41:28] INFO:     127.0.0.1:28368 - "POST /generate HTTP/1.1" 200 OK
[2026-03-31 09:41:28] The server is fired up and ready to roll!
```


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
