### PR TITLE
[Apple][MLX][Test] Add Qwen3 correctness and accuracy tests for Apple Silicon

### DIFF
--- a/test/registered/models/test_qwen3_mlx_accuracy.py
+++ b/test/registered/models/test_qwen3_mlx_accuracy.py
@@ -1,0 +1,70 @@
+import os
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.few_shot_gsm8k import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+    try_cached_model,
+)
+
+MODEL_PATH = "Qwen/Qwen3-0.6B"
+
+# TODO: hook this into the appropriate Apple/Mac CI suite once maintainer guidance is confirmed.
+
+
+class TestQwen3MlxAccuracy(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = try_cached_model(MODEL_PATH)
+        cls.base_url = DEFAULT_URL_FOR_TEST
+
+        env = os.environ.copy()
+        env["SGLANG_USE_MLX"] = "1"
+
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--tp-size",
+                "1",
+                "--disable-radix-cache",
+                "--disable-cuda-graph",
+            ],
+            env=env,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process") and cls.process is not None:
+            kill_process_tree(cls.process.pid)
+
+    def test_gsm8k_accuracy(self):
+        args = SimpleNamespace(
+            num_shots=5,
+            data_path=None,
+            num_questions=25,
+            max_new_tokens=256,
+            parallel=16,
+            host="http://127.0.0.1",
+            port=int(self.base_url.split(":")[-1]),
+            temperature=0.0,
+        )
+
+        metrics = run_eval(args)
+        print(f"{metrics=}")
+
+        # Lightweight regression guard for the Apple MLX path.
+        # Thresholds are calibrated from repeated local runs and are intentionally conservative.
+        self.assertGreater(metrics["accuracy"], 0.40)
+        self.assertLess(metrics["invalid"], 0.10)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/models/test_qwen3_mlx_correctness.py
+++ b/test/registered/models/test_qwen3_mlx_correctness.py
@@ -1,0 +1,88 @@
+import os
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+    try_cached_model,
+)
+
+MODEL_PATH = "Qwen/Qwen3-0.6B"
+
+
+class TestQwen3MlxCorrectness(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = try_cached_model(MODEL_PATH)
+        cls.base_url = DEFAULT_URL_FOR_TEST
+
+        env = os.environ.copy()
+        env["SGLANG_USE_MLX"] = "1"
+
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--tp-size",
+                "1",
+                "--disable-radix-cache",
+                "--disable-cuda-graph",
+            ],
+            env=env,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def _chat(self, messages, max_tokens=32, temperature=0):
+        resp = requests.post(
+            f"{self.base_url}/v1/chat/completions",
+            json={
+                "model": MODEL_PATH,
+                "messages": messages,
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+                "chat_template_kwargs": {
+                    "enable_thinking": False
+                },
+            },
+            timeout=60,
+        )
+        resp.raise_for_status()
+        return resp.json()["choices"][0]["message"]["content"].strip()
+
+    def test_basic_generation_nonempty(self):
+        text = self._chat(
+            [
+                {"role": "system", "content": "You are a concise assistant."},
+                {"role": "user", "content": "Say hello briefly."},
+            ],
+            max_tokens=16,
+            temperature=0,
+        )
+        self.assertTrue(len(text) > 0)
+        self.assertIsInstance(text, str)
+
+    def test_simple_fact_sanity(self):
+        text = self._chat(
+            [
+                {"role": "system", "content": "You are a concise assistant."},
+                {"role": "user", "content": "What is 2+2? Reply briefly."},
+            ],
+            max_tokens=8,
+            temperature=0,
+        )
+        self.assertTrue(len(text) > 0)
+        self.assertIn("4", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/models/test_qwen3_mlx_correctness.py
+++ b/test/registered/models/test_qwen3_mlx_correctness.py
@@ -40,7 +40,8 @@ class TestQwen3MlxCorrectness(CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
+        if hasattr(cls, "process") and cls.process is not None:
+            kill_process_tree(cls.process.pid)
 
     def _chat(self, messages, max_tokens=32, temperature=0):
         resp = requests.post(


### PR DESCRIPTION
## Summary

This PR adds initial correctness coverage for the Apple Silicon MLX path using `Qwen/Qwen3-0.6B`.

## What’s included

- `test/registered/models/test_qwen3_mlx_correctness.py`
  - a small non-thinking smoke test for the Apple MLX path
- `test/registered/models/test_qwen3_mlx_accuracy.py`
  - a lightweight GSM8K-based accuracy regression test

## Notes

- The correctness test uses `chat_template_kwargs.enable_thinking=false` for stability.
- The accuracy test uses a lightweight GSM8K slice to keep runtime practical on Apple Silicon.
- The initial accuracy/invalid thresholds were calibrated from repeated local runs and are intended as a conservative regression guard rather than a benchmark target.

### Local Apple MLX results

Repeated local runs on a Mac mini M4 (16GB) with the current lightweight GSM8K slice produced:

- Run 1: Accuracy 0.440 / Invalid 0.000 / Latency 151.770 s / Output throughput 18.778 token/s
- Run 2: Accuracy 0.440 / Invalid 0.040 / Latency 139.757 s / Output throughput 19.269 token/s
- Run 3: Accuracy 0.440 / Invalid 0.000 / Latency 144.957 s / Output throughput 19.302 token/s

These local results are included here to make the initial Apple MLX thresholds explicit. The thresholds in this PR are intended as conservative regression guards for the Apple MLX path rather than benchmark targets.

Relates to #19137.

I’d also appreciate maintainer guidance on the preferred Apple/Mac CI suite hook for these tests.