### PR TITLE
Improve KV split algorithm in Triton backend

### DIFF
--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -82,6 +82,9 @@ class TritonAttnBackend(AttentionBackend):
         # Parse args
         self.skip_prefill = skip_prefill
         max_bs = model_runner.req_to_token_pool.size
+        self.max_buffer_bs = (
+            kv_indptr_buf.shape[0] - 1 if kv_indptr_buf is not None else max_bs
+        )
         self.sliding_window_size = model_runner.sliding_window_size
         self.req_to_token = model_runner.req_to_token_pool.req_to_token
         self.token_to_kv_pool_allocator = model_runner.token_to_kv_pool_allocator
@@ -174,6 +177,7 @@ class TritonAttnBackend(AttentionBackend):
         # Initialize forward metadata
         self.forward_metadata: ForwardMetadata = None
         self.device_core_count = get_device_core_count(model_runner.gpu_id)
+        self.seq_threshold_3D = max(1, 128 // self.num_kv_head)
         self.max_kv_splits = max(
             self.max_kv_splits, next_power_of_2(self.device_core_count // 4)
         )
@@ -184,9 +188,10 @@ class TritonAttnBackend(AttentionBackend):
         headdim_padded = next_power_of_2(
             model_runner.token_to_kv_pool.get_key_buffer(0).shape[-1]
         )
+        split_buffer_bs = max(1, min(self.seq_threshold_3D, self.max_buffer_bs))
         self.softmax_segm_output = torch.empty(
             (
-                max_bs,
+                split_buffer_bs,
                 self.num_head,
                 self.max_kv_splits,
                 headdim_padded,
@@ -195,12 +200,32 @@ class TritonAttnBackend(AttentionBackend):
             device=self.device,
         )
         self.softmax_segm_max = torch.empty(
-            (max_bs, self.num_head, self.max_kv_splits),
+            (split_buffer_bs, self.num_head, self.max_kv_splits),
             dtype=torch.float32,
             device=self.device,
         )
         self.softmax_segm_expsum = torch.empty(
-            (max_bs, self.num_head, self.max_kv_splits),
+            (split_buffer_bs, self.num_head, self.max_kv_splits),
+            dtype=torch.float32,
+            device=self.device,
+        )
+        self.softmax_segm_output_nosplit = torch.empty(
+            (
+                self.max_buffer_bs,
+                self.num_head,
+                1,
+                headdim_padded,
+            ),
+            dtype=torch.float32,
+            device=self.device,
+        )
+        self.softmax_segm_max_nosplit = torch.empty(
+            (self.max_buffer_bs, self.num_head, 1),
+            dtype=torch.float32,
+            device=self.device,
+        )
+        self.softmax_segm_expsum_nosplit = torch.empty(
+            (self.max_buffer_bs, self.num_head, 1),
             dtype=torch.float32,
             device=self.device,
         )
@@ -217,6 +242,10 @@ class TritonAttnBackend(AttentionBackend):
         # num_kv_splits.shape[0] will be topk * real_num_token.
         # And the real_num_token is num_seq in decoding phase.
         num_group = num_token // num_seq
+
+        if num_token > self.seq_threshold_3D:
+            num_kv_splits.fill_(1)
+            return
 
         assert (
             num_group * num_seq == num_token
@@ -317,6 +346,8 @@ class TritonAttnBackend(AttentionBackend):
             qo_indptr = None
             custom_mask = None
             mask_indptr = None
+            attn_logits = None
+            attn_lse = None
             max_extend_len = None
         elif forward_batch.forward_mode.is_target_verify():
             bs = len(forward_batch.req_pool_indices)
@@ -1094,6 +1125,20 @@ class TritonAttnBackend(AttentionBackend):
             k_descale = 1.0
             v_descale = 1.0
 
+        q_bs = q.shape[0]
+        if q_bs > self.seq_threshold_3D:
+            # Large decode batches already have enough parallelism; force no split.
+            runtime_max_kv_splits = 1
+            self.forward_metadata.num_kv_splits[:q_bs].fill_(1)
+            softmax_segm_output = self.softmax_segm_output_nosplit
+            softmax_segm_max = self.softmax_segm_max_nosplit
+            softmax_segm_expsum = self.softmax_segm_expsum_nosplit
+        else:
+            runtime_max_kv_splits = self.max_kv_splits
+            softmax_segm_output = self.softmax_segm_output
+            softmax_segm_max = self.softmax_segm_max
+            softmax_segm_expsum = self.softmax_segm_expsum
+
         self.decode_attention_fwd(
             q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
             forward_batch.token_to_kv_pool.get_key_buffer(layer.layer_id),
@@ -1102,16 +1147,16 @@ class TritonAttnBackend(AttentionBackend):
             kv_indptr,
             kv_indices,
             self.forward_metadata.num_kv_splits,
-            self.max_kv_splits,
+            runtime_max_kv_splits,
             layer.scaling,
             k_descale,
             v_descale,
             logit_cap=logits_soft_cap,
             sinks=sinks,
             xai_temperature_len=layer.xai_temperature_len,
-            softmax_segm_output=self.softmax_segm_output,
-            softmax_segm_max=self.softmax_segm_max,
-            softmax_segm_expsum=self.softmax_segm_expsum,
+            softmax_segm_output=softmax_segm_output,
+            softmax_segm_max=softmax_segm_max,
+            softmax_segm_expsum=softmax_segm_expsum,
         )
         return o
 

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -135,11 +135,6 @@ class TritonAttnBackend(AttentionBackend):
                 model_runner.server_args.triton_attention_split_tile_size
             )
 
-        if self.split_tile_size is not None:
-            self.max_kv_splits = (
-                self.max_context_len + self.split_tile_size - 1
-            ) // self.split_tile_size
-
         # Check arguments
         assert not (
             model_runner.sliding_window_size is not None
@@ -178,6 +173,37 @@ class TritonAttnBackend(AttentionBackend):
 
         # Initialize forward metadata
         self.forward_metadata: ForwardMetadata = None
+        self.device_core_count = get_device_core_count(model_runner.gpu_id)
+        self.max_kv_splits = max(
+            self.max_kv_splits, next_power_of_2(self.device_core_count // 4)
+        )
+        if self.split_tile_size is not None:
+            self.max_kv_splits = (
+                self.max_context_len + self.split_tile_size - 1
+            ) // self.split_tile_size
+        headdim_padded = next_power_of_2(
+            model_runner.token_to_kv_pool.get_key_buffer(0).shape[-1]
+        )
+        self.softmax_segm_output = torch.empty(
+            (
+                max_bs,
+                self.num_head,
+                self.max_kv_splits,
+                headdim_padded,
+            ),
+            dtype=torch.float32,
+            device=self.device,
+        )
+        self.softmax_segm_max = torch.empty(
+            (max_bs, self.num_head, self.max_kv_splits),
+            dtype=torch.float32,
+            device=self.device,
+        )
+        self.softmax_segm_expsum = torch.empty(
+            (max_bs, self.num_head, self.max_kv_splits),
+            dtype=torch.float32,
+            device=self.device,
+        )
 
         self.cuda_graph_custom_mask = None
 
@@ -285,16 +311,6 @@ class TritonAttnBackend(AttentionBackend):
                 kv_indptr, kv_indices = spec_info.kv_indptr, spec_info.kv_indices
                 bs = kv_indptr.shape[0] - 1
 
-            attn_logits = torch.empty(
-                (bs, self.num_head, self.max_kv_splits, self.v_head_dim),
-                dtype=torch.float32,
-                device=self.device,
-            )
-            attn_lse = torch.empty(
-                (bs, self.num_head, self.max_kv_splits),
-                dtype=torch.float32,
-                device=self.device,
-            )
             num_kv_splits = torch.empty((bs,), dtype=torch.int32, device=self.device)
             self.get_num_kv_splits(num_kv_splits, forward_batch.seq_lens)
 
@@ -445,17 +461,6 @@ class TritonAttnBackend(AttentionBackend):
         kv_indices_buf: Optional[torch.Tensor] = None,
         cuda_graph_num_kv_splits_buf: Optional[torch.Tensor] = None,
     ):
-        self.cuda_graph_attn_logits = torch.zeros(
-            (max_num_tokens, self.num_head, self.max_kv_splits, self.v_head_dim),
-            dtype=torch.float32,
-            device=self.device,
-        )
-        self.cuda_graph_attn_lse = torch.zeros(
-            (max_num_tokens, self.num_head, self.max_kv_splits),
-            dtype=torch.float32,
-            device=self.device,
-        )
-
         if cuda_graph_num_kv_splits_buf is None:
             self.cuda_graph_num_kv_splits = torch.full(
                 (max_num_tokens,),
@@ -557,8 +562,8 @@ class TritonAttnBackend(AttentionBackend):
             else:
                 kv_indptr, kv_indices = spec_info.kv_indptr, spec_info.kv_indices
 
-            attn_logits = self.cuda_graph_attn_logits
-            attn_lse = self.cuda_graph_attn_lse
+            attn_logits = None
+            attn_lse = None
             max_extend_len = None
             num_kv_splits = self.cuda_graph_num_kv_splits
             qo_indptr = None
@@ -1096,8 +1101,6 @@ class TritonAttnBackend(AttentionBackend):
             o.view(-1, layer.tp_q_head_num, layer.v_head_dim),
             kv_indptr,
             kv_indices,
-            self.forward_metadata.attn_logits,
-            self.forward_metadata.attn_lse,
             self.forward_metadata.num_kv_splits,
             self.max_kv_splits,
             layer.scaling,
@@ -1106,6 +1109,9 @@ class TritonAttnBackend(AttentionBackend):
             logit_cap=logits_soft_cap,
             sinks=sinks,
             xai_temperature_len=layer.xai_temperature_len,
+            softmax_segm_output=self.softmax_segm_output,
+            softmax_segm_max=self.softmax_segm_max,
+            softmax_segm_expsum=self.softmax_segm_expsum,
         )
         return o
 

--- a/python/sglang/srt/layers/attention/triton_ops/decode_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/decode_attention.py
@@ -49,8 +49,9 @@ def _fwd_kernel_stage1(
     sm_scale_withk,
     kv_indptr,
     kv_indices,
-    Att_Out,
-    Att_Lse,
+    softmax_segm_output,
+    softmax_segm_max,
+    softmax_segm_expsum,
     num_kv_splits,
     stride_qbs,
     stride_qh,
@@ -58,9 +59,12 @@ def _fwd_kernel_stage1(
     stride_buf_kh,
     stride_buf_vbs,
     stride_buf_vh,
-    stride_mid_ob,
-    stride_mid_oh,
-    stride_mid_os,
+    stride_segm_output_b,
+    stride_segm_output_h,
+    stride_segm_output_s,
+    stride_segm_logic_b,
+    stride_segm_logic_h,
+    stride_segm_logic_s,
     kv_group_num: tl.constexpr,
     BLOCK_DMODEL: tl.constexpr,
     BLOCK_DV: tl.constexpr,
@@ -155,27 +159,32 @@ def _fwd_kernel_stage1(
             e_max = n_e_max
 
         offs_mid_o = (
-            cur_batch * stride_mid_ob
-            + cur_head * stride_mid_oh
-            + split_kv_id * stride_mid_os
+            cur_batch * stride_segm_output_b
+            + cur_head * stride_segm_output_h
+            + split_kv_id * stride_segm_output_s
             + offs_dv
         )
 
         tl.store(
-            Att_Out + offs_mid_o,
-            acc / e_sum,
+            softmax_segm_output + offs_mid_o,
+            acc,
             mask=(mask_dv),
         )
 
         offs_mid_o_1 = (
-            cur_batch * stride_mid_ob
-            + cur_head * stride_mid_oh
-            + split_kv_id * stride_mid_os
-        ) // Lv
+            cur_batch * stride_segm_logic_b
+            + cur_head * stride_segm_logic_h
+            + split_kv_id * stride_segm_logic_s
+        )
 
         tl.store(
-            Att_Lse + offs_mid_o_1,
-            e_max + tl.log(e_sum),
+            softmax_segm_max + offs_mid_o_1,
+            e_max,
+        )
+
+        tl.store(
+            softmax_segm_expsum + offs_mid_o_1,
+            e_sum,
         )
 
 
@@ -183,8 +192,6 @@ def _decode_att_m_fwd(
     q,
     k_buffer,
     v_buffer,
-    att_out,
-    att_lse,
     kv_indptr,
     kv_indices,
     num_kv_splits,
@@ -192,6 +199,9 @@ def _decode_att_m_fwd(
     sm_scale_withk,
     logit_cap,
     xai_temperature_len=-1,
+    softmax_segm_output=None,
+    softmax_segm_max=None,
+    softmax_segm_expsum=None,
 ):
     BLOCK = 64
     # [TODO] work around SGPR limit on MI3xx
@@ -223,8 +233,9 @@ def _decode_att_m_fwd(
         sm_scale_withk,
         kv_indptr,
         kv_indices,
-        att_out,
-        att_lse,
+        softmax_segm_output,
+        softmax_segm_max,
+        softmax_segm_expsum,
         num_kv_splits,
         q.stride(0),
         q.stride(1),
@@ -232,9 +243,12 @@ def _decode_att_m_fwd(
         k_buffer.stride(1),
         v_buffer.stride(0),
         v_buffer.stride(1),
-        att_out.stride(0),
-        att_out.stride(1),
-        att_out.stride(2),
+        softmax_segm_output.stride(0),
+        softmax_segm_output.stride(1),
+        softmax_segm_output.stride(2),
+        softmax_segm_max.stride(0),
+        softmax_segm_max.stride(1),
+        softmax_segm_max.stride(2),
         kv_group_num=kv_group_num,
         BLOCK_DMODEL=BLOCK_DMODEL,
         BLOCK_DV=BLOCK_DV,
@@ -257,8 +271,9 @@ def _fwd_grouped_kernel_stage1(
     sm_scale_withk,
     kv_indptr,
     kv_indices,
-    Att_Out,
-    Att_Lse,
+    softmax_segm_output,
+    softmax_segm_max,
+    softmax_segm_expsum,
     num_kv_splits,
     stride_qbs,
     stride_qh,
@@ -266,9 +281,12 @@ def _fwd_grouped_kernel_stage1(
     stride_buf_kh,
     stride_buf_vbs,
     stride_buf_vh,
-    stride_mid_ob,
-    stride_mid_oh,
-    stride_mid_os,
+    stride_segm_output_b,
+    stride_segm_output_h,
+    stride_segm_output_s,
+    stride_segm_logic_b,
+    stride_segm_logic_h,
+    stride_segm_logic_s,
     kv_group_num: tl.constexpr,
     q_head_num: tl.constexpr,
     BLOCK_DMODEL: tl.constexpr,
@@ -398,27 +416,33 @@ def _fwd_grouped_kernel_stage1(
             e_max = n_e_max
 
         offs_mid_o = (
-            cur_batch * stride_mid_ob
-            + cur_head[:, None] * stride_mid_oh
-            + split_kv_id * stride_mid_os
+            cur_batch * stride_segm_output_b
+            + cur_head[:, None] * stride_segm_output_h
+            + split_kv_id * stride_segm_output_s
             + offs_dv[None, :]
         )
 
         tl.store(
-            Att_Out + offs_mid_o,
-            acc / e_sum[:, None],
+            softmax_segm_output + offs_mid_o,
+            acc,
             mask=(mask_h[:, None]) & (mask_dv[None, :]),
         )
 
         offs_mid_o_1 = (
-            cur_batch * stride_mid_ob
-            + cur_head * stride_mid_oh
-            + split_kv_id * stride_mid_os
-        ) // Lv
+            cur_batch * stride_segm_logic_b
+            + cur_head * stride_segm_logic_h
+            + split_kv_id * stride_segm_logic_s
+        )
 
         tl.store(
-            Att_Lse + offs_mid_o_1,
-            e_max + tl.log(e_sum),
+            softmax_segm_max + offs_mid_o_1,
+            e_max,
+            mask=mask_h,
+        )
+
+        tl.store(
+            softmax_segm_expsum + offs_mid_o_1,
+            e_sum,
             mask=mask_h,
         )
 
@@ -427,8 +451,6 @@ def _decode_grouped_att_m_fwd(
     q,
     k_buffer,
     v_buffer,
-    att_out,
-    att_lse,
     kv_indptr,
     kv_indices,
     num_kv_splits,
@@ -436,6 +458,9 @@ def _decode_grouped_att_m_fwd(
     sm_scale_withk,
     logit_cap,
     xai_temperature_len=-1,
+    softmax_segm_output=None,
+    softmax_segm_max=None,
+    softmax_segm_expsum=None,
 ):
     BLOCK = 32
     Lk = k_buffer.shape[-1]
@@ -482,8 +507,9 @@ def _decode_grouped_att_m_fwd(
         sm_scale_withk,
         kv_indptr,
         kv_indices,
-        att_out,
-        att_lse,
+        softmax_segm_output,
+        softmax_segm_max,
+        softmax_segm_expsum,
         num_kv_splits,
         q.stride(0),
         q.stride(1),
@@ -491,9 +517,12 @@ def _decode_grouped_att_m_fwd(
         k_buffer.stride(1),
         v_buffer.stride(0),
         v_buffer.stride(1),
-        att_out.stride(0),
-        att_out.stride(1),
-        att_out.stride(2),
+        softmax_segm_output.stride(0),
+        softmax_segm_output.stride(1),
+        softmax_segm_output.stride(2),
+        softmax_segm_max.stride(0),
+        softmax_segm_max.stride(1),
+        softmax_segm_max.stride(2),
         kv_group_num=kv_group_num,
         q_head_num=head_num,
         BLOCK_DMODEL=BLOCK_DMODEL,
@@ -514,16 +543,20 @@ def _decode_grouped_att_m_fwd(
 
 @triton.jit
 def _fwd_kernel_stage2(
-    Mid_O,
-    Mid_O_1,
+    softmax_segm_output,
+    softmax_segm_max,
+    softmax_segm_expsum,
     O,
     v_scale,
     kv_indptr,
     num_kv_splits,
     sink_ptr,
-    stride_mid_ob,
-    stride_mid_oh,
-    stride_mid_os,
+    stride_segm_output_b,
+    stride_segm_output_h,
+    stride_segm_output_s,
+    stride_segm_logic_b,
+    stride_segm_logic_h,
+    stride_segm_logic_s,
     stride_obs,
     stride_oh,
     MAX_KV_SPLITS: tl.constexpr,
@@ -543,49 +576,66 @@ def _fwd_kernel_stage2(
     offs_d = tl.arange(0, BLOCK_DV)
     mask_d = offs_d < Lv
 
-    e_sum = 0.0
-    e_max = -float("inf")
-    acc = tl.zeros([BLOCK_DV], dtype=tl.float32)
-
-    offs_v = cur_batch * stride_mid_ob + cur_head * stride_mid_oh + offs_d
-    offs_logic = (cur_batch * stride_mid_ob + cur_head * stride_mid_oh) // Lv
+    acc_sum = tl.zeros([BLOCK_DV], dtype=tl.float32)
     kv_len_per_split = (
         tl.cdiv(tl.cdiv(cur_batch_seq_len, kv_splits), MIN_BLOCK_KV) * MIN_BLOCK_KV
     )
+    act_num_splits = tl.where(
+        kv_len_per_split > 0, tl.cdiv(cur_batch_seq_len, kv_len_per_split), 0
+    )
+    offs_split = tl.arange(0, MAX_KV_SPLITS)
+    split_mask = offs_split < act_num_splits
 
-    for split_kv_id in range(0, MAX_KV_SPLITS):
-        split_kv_start = kv_len_per_split * split_kv_id
-        split_kv_end = tl.minimum(split_kv_start + kv_len_per_split, cur_batch_seq_len)
+    segm_logic_offset = (
+        cur_batch * stride_segm_logic_b
+        + cur_head * stride_segm_logic_h
+        + offs_split * stride_segm_logic_s
+    )
 
-        if split_kv_end > split_kv_start:
-            tv = tl.load(
-                Mid_O + offs_v + split_kv_id * stride_mid_os, mask=mask_d, other=0.0
-            )
-            tlogic = tl.load(Mid_O_1 + offs_logic + split_kv_id * stride_mid_os // Lv)
-            n_e_max = tl.maximum(tlogic, e_max)
+    segm_max = tl.load(
+        softmax_segm_max + segm_logic_offset,
+        mask=split_mask,
+        other=float("-inf"),
+    )
+    segm_expsum = tl.load(
+        softmax_segm_expsum + segm_logic_offset,
+        mask=split_mask,
+        other=0.0,
+    )
 
-            old_scale = tl.exp(e_max - n_e_max)
-            acc *= old_scale
-            exp_logic = tl.exp(tlogic - n_e_max)
-            acc += exp_logic * tv
+    overall_max = tl.max(segm_max)
+    has_split = act_num_splits > 0
+    overall_max = tl.where(has_split, overall_max, 0.0)
+    segm_scale = tl.exp(segm_max - overall_max)
+    overall_expsum = tl.sum(segm_expsum * segm_scale, axis=0)
 
-            e_sum = e_sum * old_scale + exp_logic
-            e_max = n_e_max
+    segm_output_offset = (
+        cur_batch * stride_segm_output_b
+        + cur_head * stride_segm_output_h
+        + offs_split[:, None] * stride_segm_output_s
+        + offs_d[None, :]
+    )
+    segm_output = tl.load(
+        softmax_segm_output + segm_output_offset,
+        mask=split_mask[:, None] & mask_d[None, :],
+        other=0.0,
+    )
+    acc_sum = tl.sum(segm_output * segm_scale[:, None], axis=0)
 
     if HAS_SINK:
         cur_sink = tl.load(sink_ptr + cur_head)
-        e_sum += tl.exp(cur_sink - e_max)
+        overall_expsum += tl.exp(cur_sink - overall_max)
+
+    acc = tl.where(overall_expsum == 0.0, 0.0, acc_sum / overall_expsum)
 
     tl.store(
         O + cur_batch * stride_obs + cur_head * stride_oh + offs_d,
-        acc / e_sum * v_scale,
+        acc * v_scale,
         mask=mask_d,
     )
 
 
 def _decode_softmax_reducev_fwd(
-    logits,
-    lse,
     q,
     o,
     v_scale,
@@ -594,6 +644,9 @@ def _decode_softmax_reducev_fwd(
     num_kv_splits,
     max_kv_splits,
     sinks=None,
+    softmax_segm_output=None,
+    softmax_segm_max=None,
+    softmax_segm_expsum=None,
 ):
     batch, head_num = q.shape[0], q.shape[1]
     Lv = v_buffer.shape[-1]
@@ -610,16 +663,20 @@ def _decode_softmax_reducev_fwd(
 
     grid = (batch, head_num)
     _fwd_kernel_stage2[grid](
-        logits,
-        lse,
+        softmax_segm_output,
+        softmax_segm_max,
+        softmax_segm_expsum,
         o,
         v_scale,
         kv_indptr,
         num_kv_splits,
         sinks,
-        logits.stride(0),
-        logits.stride(1),
-        logits.stride(2),
+        softmax_segm_output.stride(0),
+        softmax_segm_output.stride(1),
+        softmax_segm_output.stride(2),
+        softmax_segm_max.stride(0),
+        softmax_segm_max.stride(1),
+        softmax_segm_max.stride(2),
         o.stride(0),
         o.stride(1),
         MAX_KV_SPLITS=MAX_KV_SPLITS,
@@ -640,8 +697,6 @@ def decode_attention_fwd_normal(
     o,
     kv_indptr,
     kv_indices,
-    attn_logits,
-    attn_lse,
     num_kv_splits,
     max_kv_splits,
     sm_scale_withk,
@@ -649,13 +704,14 @@ def decode_attention_fwd_normal(
     logit_cap=0.0,
     sinks=None,
     xai_temperature_len=-1,
+    softmax_segm_output=None,
+    softmax_segm_max=None,
+    softmax_segm_expsum=None,
 ):
     _decode_att_m_fwd(
         q,
         k_buffer,
         v_buffer,
-        attn_logits,
-        attn_lse,
         kv_indptr,
         kv_indices,
         num_kv_splits,
@@ -663,10 +719,11 @@ def decode_attention_fwd_normal(
         sm_scale_withk,
         logit_cap,
         xai_temperature_len,
+        softmax_segm_output=softmax_segm_output,
+        softmax_segm_max=softmax_segm_max,
+        softmax_segm_expsum=softmax_segm_expsum,
     )
     _decode_softmax_reducev_fwd(
-        attn_logits,
-        attn_lse,
         q,
         o,
         v_scale,
@@ -675,6 +732,9 @@ def decode_attention_fwd_normal(
         num_kv_splits,
         max_kv_splits,
         sinks,
+        softmax_segm_output=softmax_segm_output,
+        softmax_segm_max=softmax_segm_max,
+        softmax_segm_expsum=softmax_segm_expsum,
     )
 
 
@@ -685,8 +745,6 @@ def decode_attention_fwd_grouped(
     o,
     kv_indptr,
     kv_indices,
-    attn_logits,
-    attn_lse,
     num_kv_splits,
     max_kv_splits,
     sm_scale_withk,
@@ -694,13 +752,14 @@ def decode_attention_fwd_grouped(
     logit_cap=0.0,
     sinks=None,
     xai_temperature_len=-1,
+    softmax_segm_output=None,
+    softmax_segm_max=None,
+    softmax_segm_expsum=None,
 ):
     _decode_grouped_att_m_fwd(
         q,
         k_buffer,
         v_buffer,
-        attn_logits,
-        attn_lse,
         kv_indptr,
         kv_indices,
         num_kv_splits,
@@ -708,10 +767,11 @@ def decode_attention_fwd_grouped(
         sm_scale_withk,
         logit_cap,
         xai_temperature_len,
+        softmax_segm_output=softmax_segm_output,
+        softmax_segm_max=softmax_segm_max,
+        softmax_segm_expsum=softmax_segm_expsum,
     )
     _decode_softmax_reducev_fwd(
-        attn_logits,
-        attn_lse,
         q,
         o,
         v_scale,
@@ -720,6 +780,9 @@ def decode_attention_fwd_grouped(
         num_kv_splits,
         max_kv_splits,
         sinks,
+        softmax_segm_output=softmax_segm_output,
+        softmax_segm_max=softmax_segm_max,
+        softmax_segm_expsum=softmax_segm_expsum,
     )
 
 
@@ -730,8 +793,6 @@ def decode_attention_fwd(
     o,
     kv_indptr,
     kv_indices,
-    attn_logits,
-    attn_lse,
     num_kv_splits,
     max_kv_splits,
     sm_scale,
@@ -740,10 +801,15 @@ def decode_attention_fwd(
     logit_cap=0.0,
     sinks=None,
     xai_temperature_len=-1,
+    softmax_segm_output=None,
+    softmax_segm_max=None,
+    softmax_segm_expsum=None,
 ):
-    assert max_kv_splits == attn_logits.shape[2]
+    assert softmax_segm_output is not None
+    assert softmax_segm_max is not None
+    assert softmax_segm_expsum is not None
     assert q.shape[0] <= kv_indptr.shape[0] - 1
-    assert q.shape[0] <= attn_logits.shape[0]
+    assert q.shape[0] <= softmax_segm_output.shape[0]
 
     kv_group_num = q.shape[1] // v_buffer.shape[1]
 
@@ -756,8 +822,6 @@ def decode_attention_fwd(
             o,
             kv_indptr,
             kv_indices,
-            attn_logits,
-            attn_lse,
             num_kv_splits,
             max_kv_splits,
             sm_scale * k_scale,
@@ -765,6 +829,9 @@ def decode_attention_fwd(
             logit_cap=logit_cap,
             sinks=sinks,
             xai_temperature_len=xai_temperature_len,
+            softmax_segm_output=softmax_segm_output,
+            softmax_segm_max=softmax_segm_max,
+            softmax_segm_expsum=softmax_segm_expsum,
         )
     else:
         # GQA/MQA/MLA
@@ -775,8 +842,6 @@ def decode_attention_fwd(
             o,
             kv_indptr,
             kv_indices,
-            attn_logits,
-            attn_lse,
             num_kv_splits,
             max_kv_splits,
             sm_scale * k_scale,
@@ -784,4 +849,7 @@ def decode_attention_fwd(
             logit_cap=logit_cap,
             sinks=sinks,
             xai_temperature_len=xai_temperature_len,
+            softmax_segm_output=softmax_segm_output,
+            softmax_segm_max=softmax_segm_max,
+            softmax_segm_expsum=softmax_segm_expsum,
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Improve the decode speed of current triton backend

## Modifications

- Replaced the fixed kv-splits cap with a dynamic cap based on SM count:
  `self.max_kv_splits = max(self.max_kv_splits, next_power_of_2(self.device_core_count // 4))`.

- Rewrote decode stage-2 reduction from sequential accumulation to vectorized reduction over split buffers.

- Refactored decode kernel to store results into persistent buffers (`softmax_segm_max`, `softmax_segm_expsum`, `softmax_segm_output`) allocated during backend initialization, this supports vectorized reduction.

- Separated buffer memory allocation for small batches (bounded by 3d threshold) and large batches (bounded by single kv split) to optimize memory

- Removed old dependency on `attn_logits` and `attn_lse`

## Accuracy Tests

passed gsm8k

## Speed Tests and Profiling

Benchmarked on H100

**Overall +24.89% decode tok/s, At 32k +74.85% decode tok/s**

#### Qwen/Qwen3-8B (head_dim = 128)

**Decode throughput (tok/s)**
| Input Length (L) | Old Triton | New Triton | FlashInfer |
| :--- | :--- | :--- | :--- |
| 1000 | 141.37 | 144.00 | 142.71 |
| 2000 | 132.60 | 140.32 | 140.11 |
| 4000 | 118.36 | 138.60 | 138.67 |
| 8000 | 98.63 | 133.60 | 135.00 |
| 16000 | 74.12 | 125.28 | 126.81 |
| 32000 | 48.35 | 110.62 | 113.23 |

---

#### google/gemma-3-12b-it (head_dim = 256)

**Decode throughput (tok/s)**
| Input Length (L) | Old Triton | New Triton | FlashInfer |
| :--- | :--- | :--- | :--- |
| 1000 | 61.66 | 63.52 | 63.76 |
| 2000 | 61.06 | 61.59 | 61.83 |
| 4000 | 60.28 | 61.42 | 61.45 |
| 8000 | 58.22 | 60.95 | 61.09 |
| 16000 | 55.23 | 60.32 | 59.65 |
| 32000 | 48.71 | 58.89 | 58.17 |

<img width="4800" height="1800" alt="benchmark_decode_charts" src="https://github.com/user-attachments/assets/20b53cb8-1613-414f-a42a-948c202b442d" />

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
