### PR TITLE
Fix CVEs in Docker image: pillow, linux-libc-dev, and broken sgl-model-gateway build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -114,6 +114,7 @@ RUN --mount=type=cache,target=/var/cache/apt,id=base-apt \
     libczmq4 \
     libczmq-dev \
     libfabric-dev \
+    linux-libc-dev \
     # Package building tools
     devscripts \
     debhelper \
@@ -306,9 +307,12 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     cubloaty \
     google-cloud-storage
 
-# Build and install sgl-model-gateway (install Rust, build, then remove to save space)
+# Build and install sgl-model-gateway (install Rust, build, then remove Rust toolchain)
+# Cleanup runs unconditionally via trap to ensure Rust artifacts don't bloat the layer
 RUN --mount=type=cache,target=/root/.cache/pip \
-    curl --proto '=https' --tlsv1.2 --retry 3 --retry-delay 2 -sSf https://sh.rustup.rs | sh -s -- -y \
+    cleanup() { rm -rf /root/.cargo /root/.rustup /sgl-workspace/sglang/sgl-model-gateway/target /sgl-workspace/sglang/sgl-model-gateway/bindings/python/target /sgl-workspace/sglang/sgl-model-gateway/bindings/python/dist; sed -i '/\.cargo\/env/d' /root/.profile /root/.bashrc 2>/dev/null; } \
+    && trap cleanup EXIT \
+    && curl --proto '=https' --tlsv1.2 --retry 3 --retry-delay 2 -sSf https://sh.rustup.rs | sh -s -- -y \
     && export PATH="/root/.cargo/bin:${PATH}" \
     && rustc --version && cargo --version \
     && python3 -m pip install maturin \
@@ -316,10 +320,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     && ulimit -n 65536 && maturin build --release --features vendored-openssl --out dist \
     && python3 -m pip install --force-reinstall dist/*.whl \
     && cd /sgl-workspace/sglang/sgl-model-gateway \
-    && cargo build --release --bin sglang-router --features vendored-openssl \
-    && cp target/release/sglang-router /usr/local/bin/sglang-router \
-    && rm -rf /root/.cargo /root/.rustup target dist ~/.cargo \
-    && sed -i '/\.cargo\/env/d' /root/.profile /root/.bashrc 2>/dev/null || true
+    && cargo build --release --bin sgl-model-gateway --features vendored-openssl \
+    && cp target/release/sgl-model-gateway /usr/local/bin/sgl-model-gateway
 
 RUN --mount=type=cache,target=/root/.cache/pip \
    python3 -m pip install "nvidia-cutlass-dsl>=4.4.1" "nvidia-cutlass-dsl-libs-base>=4.4.1" --force-reinstall --no-deps;
@@ -448,7 +450,7 @@ RUN if [ "${CUDA_VERSION%%.*}" = "13" ] && [ -d /usr/local/lib/python3.12/dist-p
         ln -s /usr/local/cuda/bin/ptxas /usr/local/lib/python3.12/dist-packages/triton/backends/nvidia/bin/ptxas; \
     fi
 
-RUN python3 -m pip install --upgrade "urllib3>=2.6.3"
+RUN python3 -m pip install --upgrade "urllib3>=2.6.3" "pillow>=12.1.1"
 
 # Set workspace directory
 WORKDIR /sgl-workspace/sglang
@@ -532,6 +534,7 @@ RUN --mount=type=cache,target=/var/cache/apt,id=runtime-apt \
     libnccl-dev \
     # GPG key verification
     gnupg2 \
+    linux-libc-dev \
     && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 2 \
     && update-alternatives --set python3 /usr/bin/python3.12 \
     && ln -sf /usr/bin/python3.12 /usr/bin/python \


### PR DESCRIPTION
## Summary
- **Pillow CVE-2026-25990** (HIGH: out-of-bounds write): upgrade to >=12.1.1
- **linux-libc-dev** (16 kernel CVEs): upgrade from 6.8.0-64.67 to latest in both framework and runtime stages
- **Rust cargo cache CVEs**: fix broken `cargo build --bin sglang-router` that has been silently failing since Dec 2025, leaving 2.6GB of Rust artifacts with known CVEs in the image

## Details

**Broken sgl-model-gateway build (root cause of Rust CVEs):**

The binary was renamed from `sglang-router` to `sgl-model-gateway` in #14312 (Dec 2025), but the Dockerfile was not updated. `cargo build --bin sglang-router` fails, the `|| true` at the end swallows the error, and the `rm -rf` cleanup is skipped:

```
# Old (broken):
&& cargo build --release --bin sglang-router ...   # FAILS: binary renamed
&& cp target/release/sglang-router ...             # SKIPPED (&&)
&& rm -rf /root/.cargo /root/.rustup ...           # SKIPPED (&&)
|| true                                            # SWALLOWS ERROR
```

**Fix:** Update binary name to `sgl-model-gateway` and use `trap cleanup EXIT` so Rust artifacts are always cleaned up:
```
cleanup() { rm -rf /root/.cargo /root/.rustup ...; ... }
&& trap cleanup EXIT
&& cargo build --release --bin sgl-model-gateway ...
&& cp target/release/sgl-model-gateway ...
# trap fires unconditionally on exit
```

**Trivy scan results before/after:**

| Category | Before | After |
|----------|--------|-------|
| Ubuntu/linux-libc-dev | 16 HIGH | 0 |
| Pillow | 1 HIGH | 0 |
| Rust crates (cargo cache) | ~10 HIGH, 1 CRITICAL | 0 |
| Go stdlib (hf-xet, upstream) | 1 CRITICAL, 6 HIGH | 1 CRITICAL, 6 HIGH |
| **Total** | **31 CVEs** | **7 CVEs** (77% reduction) |

## Test plan
- [x] Built image on remote dev machine with patched Dockerfile
- [x] Verified `/root/.cargo` and `/root/.rustup` do not exist in final image
- [x] Verified `sgl-model-gateway --help` works (real Rust binary)
- [x] Verified `python3 -c "from sglang_router import sglang_router_rs"` works
- [x] Verified pillow upgraded to 12.1.1
- [x] Verified linux-libc-dev upgraded from 6.8.0-64.67 to 6.8.0-106.106
- [x] Trivy scan confirms 31 → 7 CVEs (remaining 7 are upstream hf-xet Go stdlib)
- [ ] CI nightly build with this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)