### PR TITLE
Increase hicache eval to 200 examples

### DIFF
--- a/test/registered/hicache/test_hicache_storage_file_backend.py
+++ b/test/registered/hicache/test_hicache_storage_file_backend.py
@@ -297,9 +297,9 @@ def run_eval_accuracy_test(test_instance, accuracy_threshold: float = 0.03):
     args_initial = SimpleNamespace(
         num_shots=5,
         data_path=None,
-        num_questions=50,
+        num_questions=200,
         max_new_tokens=512,
-        parallel=10,
+        parallel=64,
         host=f"http://{test_instance.base_host}",
         port=int(test_instance.base_port),
     )


### PR DESCRIPTION
Increase GSM8K examples from 50 to 200 in hicache consistency test. With 50 examples each sample is worth 0.02, causing flaky score diffs > 0.03 threshold. With 200 examples, locally verified diff = 0.01 < 0.03.