### PR TITLE
Fix missing restore_weights_before_loading in CompressedTensorsFusedMoEMethod

### DIFF
--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -968,6 +968,10 @@ class CompressedTensorsFusedMoEMethod(FusedMoEMethodBase):
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         layer.scheme.process_weights_after_loading(layer)
 
+    def restore_weights_before_loading(self, layer: torch.nn.Module) -> None:
+        if hasattr(layer.scheme, "restore_weights_before_loading"):
+            layer.scheme.restore_weights_before_loading(layer)
+
     def create_weights(
         self,
         layer: torch.nn.Module,


### PR DESCRIPTION
## Summary
- The quantization refactor in #17503 introduced `CompressedTensorsFusedMoEMethod` as a unified `quant_method` for all compressed-tensors MoE schemes, delegating to `layer.scheme`. However, `restore_weights_before_loading` was not forwarded.
- This causes INT4 weight update to fail in RL training (miles): `post_process_weights` with `restore_weights_before_load=True` skips FusedMoE modules because `hasattr(quant_method, "restore_weights_before_loading")` returns `False`. The INT4 packed weights are never restored to full size before loading new weights.
- Error: `RuntimeError: start (0) + length (1536) exceeds dimension size (768)` in `FusedMoE._load_w13`

## Fix
Add `restore_weights_before_loading` to `CompressedTensorsFusedMoEMethod` that delegates to `layer.scheme`, with a `hasattr` guard since only `CompressedTensorsWNA16MoE` implements this method.

## Test plan
- [ ] Run INT4 rollout CI (`e2e/megatron/test_qwen3_30B_A3B.py` with `MILES_TEST_USE_INT4_ROLLOUT=1`)