### PR TITLE
[Bugfix] RealESRGAN fp16 dtype mismatch in upscaler

### DIFF
--- a/python/sglang/multimodal_gen/runtime/postprocess/realesrgan_upscaler.py
+++ b/python/sglang/multimodal_gen/runtime/postprocess/realesrgan_upscaler.py
@@ -27,8 +27,10 @@ logger = init_logger(__name__)
 _DEFAULT_REALESRGAN_HF_REPO = "ai-forever/Real-ESRGAN"
 _DEFAULT_REALESRGAN_FILENAME = "RealESRGAN_x4.pth"
 
-# Module-level cache: model_path -> UpscalerModel instance
-_MODEL_CACHE: dict[str, "UpscalerModel"] = {}
+# Module-level cache: (model_path, device, dtype) -> UpscalerModel instance
+# NOTE: dtype is part of the key to avoid fp16/fp32 collisions when
+# `half_precision` differs between calls.
+_MODEL_CACHE: dict[tuple[str, str, torch.dtype], "UpscalerModel"] = {}
 
 
 # ---------------------------------------------------------------------------
@@ -263,6 +265,15 @@ class UpscalerModel:
     def device(self) -> torch.device:
         return next(self.net.parameters()).device
 
+    @property
+    def dtype(self) -> torch.dtype:
+        # Prefer parameter dtype; fall back to buffer dtype if needed.
+        for p in self.net.parameters():
+            return p.dtype
+        for b in self.net.buffers():
+            return b.dtype
+        return torch.float32
+
     def upscale(self, frame: np.ndarray, outscale: float | None = None) -> np.ndarray:
         """Upscale a single HWC uint8 frame → HWC uint8 frame.
 
@@ -276,7 +287,13 @@ class UpscalerModel:
         """
         h, w = frame.shape[:2]
         img = frame.astype(np.float32) / 255.0
-        img_t = torch.from_numpy(img).permute(2, 0, 1).unsqueeze(0).to(self.device)
+        # Match input dtype to model weights (e.g., fp16 weights require fp16 inputs).
+        img_t = (
+            torch.from_numpy(img)
+            .permute(2, 0, 1)
+            .unsqueeze(0)
+            .to(device=self.device, dtype=self.dtype)
+        )
         with torch.no_grad():
             out = self.net(img_t)
 
@@ -289,7 +306,8 @@ class UpscalerModel:
                 out, size=(target_h, target_w), mode="bicubic", align_corners=False
             )
 
-        out_np = out.squeeze(0).permute(1, 2, 0).clamp(0.0, 1.0).cpu().numpy()
+        # Convert to float32 for stable post-processing before returning uint8.
+        out_np = out.squeeze(0).permute(1, 2, 0).clamp(0.0, 1.0).float().cpu().numpy()
         return (out_np * 255.0).astype(np.uint8)
 
 
@@ -323,8 +341,13 @@ class ImageUpscaler:
         # Resolve: local .pth pass-through, or HF repo → download single file
         resolved_path = _resolve_model_path(model_path)
 
-        if resolved_path in _MODEL_CACHE:
-            return _MODEL_CACHE[resolved_path]
+        device = current_platform.get_local_torch_device()
+        use_half = self._half_precision and device.type in ("cuda", "mps")
+        target_dtype = torch.float16 if use_half else torch.float32
+        cache_key = (resolved_path, str(device), target_dtype)
+
+        if cache_key in _MODEL_CACHE:
+            return _MODEL_CACHE[cache_key]
 
         logger.info("Loading Real-ESRGAN weights from %s", resolved_path)
         try:
@@ -356,10 +379,16 @@ class ImageUpscaler:
             ) from e
         net.eval()
 
-        device = current_platform.get_local_torch_device()
-        if self._half_precision:
-            net = net.half()
+        if self._half_precision and not use_half:
+            logger.warning(
+                "Real-ESRGAN half_precision=True requested, but device=%s does not "
+                "support reliable fp16 execution; falling back to fp32.",
+                device,
+            )
+
         net = net.to(device)
+        if use_half:
+            net = net.half()
 
         # Detect the model's native scale from network architecture
         native_scale = 4  # sensible default
@@ -369,10 +398,11 @@ class ImageUpscaler:
             native_scale = net.scale
 
         model = UpscalerModel(net=net, scale=native_scale)
-        _MODEL_CACHE[resolved_path] = model
+        _MODEL_CACHE[cache_key] = model
         logger.info(
-            "Real-ESRGAN model loaded on device: %s (native_scale=%dx, outscale=%s)",
+            "Real-ESRGAN model loaded on device: %s (dtype=%s, native_scale=%dx, outscale=%s)",
             device,
+            str(target_dtype).replace("torch.", ""),
             native_scale,
             f"{self._scale}x" if self._scale != native_scale else "native",
         )

--- a/python/sglang/multimodal_gen/runtime/postprocess/realesrgan_upscaler.py
+++ b/python/sglang/multimodal_gen/runtime/postprocess/realesrgan_upscaler.py
@@ -307,7 +307,8 @@ class UpscalerModel:
             )
 
         # Convert to float32 for stable post-processing before returning uint8.
-        out_np = out.squeeze(0).permute(1, 2, 0).clamp(0.0, 1.0).float().cpu().numpy()
+        # Do the dtype conversion on CPU to avoid an extra GPU cast+copy for fp16 outputs.
+        out_np = out.squeeze(0).permute(1, 2, 0).clamp(0.0, 1.0).cpu().float().numpy()
         return (out_np * 255.0).astype(np.uint8)
 
 
@@ -342,7 +343,24 @@ class ImageUpscaler:
         resolved_path = _resolve_model_path(model_path)
 
         device = current_platform.get_local_torch_device()
-        use_half = self._half_precision and device.type in ("cuda", "mps")
+        use_half = False
+        if self._half_precision:
+            if device.type == "cuda":
+                # CUDA supports fp16 tensors broadly, but very old GPUs/drivers can be flaky.
+                # Gate on minimum compute capability that has native fp16 support.
+                cc = None
+                try:
+                    cc = torch.cuda.get_device_capability(device)
+                except Exception:
+                    try:
+                        cc = torch.cuda.get_device_capability()
+                    except Exception:
+                        cc = None
+
+                use_half = cc is None or cc >= (5, 3)
+            elif device.type == "mps":
+                use_half = True
+
         target_dtype = torch.float16 if use_half else torch.float32
         cache_key = (resolved_path, str(device), target_dtype)
 

--- a/python/sglang/multimodal_gen/runtime/postprocess/realesrgan_upscaler.py
+++ b/python/sglang/multimodal_gen/runtime/postprocess/realesrgan_upscaler.py
@@ -345,20 +345,29 @@ class ImageUpscaler:
         device = current_platform.get_local_torch_device()
         use_half = False
         if self._half_precision:
-            if device.type == "cuda":
+            if current_platform.is_cuda():
                 # CUDA supports fp16 tensors broadly, but very old GPUs/drivers can be flaky.
                 # Gate on minimum compute capability that has native fp16 support.
+                # Enable fp16 only on GPUs with native fp16 support.
                 cc = None
-                try:
-                    cc = torch.cuda.get_device_capability(device)
-                except Exception:
+                for candidate in (device, None):
                     try:
-                        cc = torch.cuda.get_device_capability()
+                        cc = torch.cuda.get_device_capability(candidate)
+                        break
                     except Exception:
-                        cc = None
+                        pass
 
-                use_half = cc is None or cc >= (5, 3)
-            elif device.type == "mps":
+                # Enable fp16 only if we successfully determined compute capability
+                # and it meets the minimum requirement (5.3 = Maxwell/GTX 900 series).
+                # If cc is None (unknown), conservatively disable fp16.
+                use_half = cc is not None and cc >= (5, 3)
+            elif (
+                current_platform.is_rocm()
+                or current_platform.is_mps()
+                or current_platform.is_musa()
+                or current_platform.is_npu()
+            ):
+                # ROCM, MPS, MUSA, and NPU generally support fp16
                 use_half = True
 
         target_dtype = torch.float16 if use_half else torch.float32

--- a/python/sglang/multimodal_gen/test/unit/test_realesrgan_fp16.py
+++ b/python/sglang/multimodal_gen/test/unit/test_realesrgan_fp16.py
@@ -1,0 +1,83 @@
+import ast
+import unittest
+from pathlib import Path
+
+
+class TestRealESRGANHalfPrecisionSafety(unittest.TestCase):
+    def setUp(self):
+        multimodal_gen_dir = Path(__file__).resolve().parents[2]
+        self.src_path = (
+            multimodal_gen_dir / "runtime" / "postprocess" / "realesrgan_upscaler.py"
+        )
+        self.tree = ast.parse(self.src_path.read_text(encoding="utf-8"))
+
+    def _get_method(self, class_name: str, method_name: str) -> ast.FunctionDef:
+        for node in self.tree.body:
+            if isinstance(node, ast.ClassDef) and node.name == class_name:
+                for item in node.body:
+                    if isinstance(item, ast.FunctionDef) and item.name == method_name:
+                        return item
+        raise AssertionError(
+            f"Could not find {class_name}.{method_name} in {self.src_path}"
+        )
+
+    def test_upscale_casts_input_to_model_dtype(self):
+        """Regression test: fp16 weights require fp16 inputs (no float/half mismatch)."""
+        upscale_fn = self._get_method("UpscalerModel", "upscale")
+
+        found_dtype_kw = False
+        for node in ast.walk(upscale_fn):
+            if not (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "to"
+            ):
+                continue
+
+            dtype_kw = None
+            for kw in node.keywords:
+                if kw.arg == "dtype":
+                    dtype_kw = kw.value
+                    break
+            if dtype_kw is None:
+                continue
+
+            # Expect `.to(..., dtype=self.dtype)` (or equivalent)
+            if (
+                isinstance(dtype_kw, ast.Attribute)
+                and isinstance(dtype_kw.value, ast.Name)
+                and dtype_kw.value.id == "self"
+                and dtype_kw.attr == "dtype"
+            ):
+                found_dtype_kw = True
+                break
+
+        self.assertTrue(
+            found_dtype_kw,
+            "Expected UpscalerModel.upscale to cast input tensor dtype to match model dtype.",
+        )
+
+    def test_model_cache_key_includes_dtype(self):
+        """Regression test: fp16/fp32 loads must not collide in the global cache."""
+        ensure_fn = self._get_method("ImageUpscaler", "_ensure_model_loaded")
+
+        found_cache_key = False
+        for node in ast.walk(ensure_fn):
+            if not isinstance(node, ast.Assign):
+                continue
+            if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+                continue
+            if node.targets[0].id != "cache_key":
+                continue
+            if not isinstance(node.value, ast.Tuple) or len(node.value.elts) != 3:
+                continue
+
+            third = node.value.elts[2]
+            if isinstance(third, ast.Name) and third.id == "target_dtype":
+                found_cache_key = True
+                break
+
+        self.assertTrue(
+            found_cache_key,
+            "Expected ImageUpscaler._ensure_model_loaded cache_key to include target_dtype.",
+        )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
RealESRGAN upscaling supports half_precision=True , but the current implementation can crash in fp16 mode because the input tensor stays float32 while model weights are converted to float16 (dtype mismatch).

## Modifications

- Cast the input tensor to the model’s parameter dtype inside  UpscalerModel.upscale()  to ensure fp16 weights receive fp16 inputs (avoids Float / Half  mismatch crashes).
- Update the global model cache key to include  (model_path, device, dtype)  to avoid fp16/fp32 cache collisions across calls.  
- Convert output to  float32  on CPU before NumPy conversion ( out.cpu().float().numpy() ) to avoid an extra GPU cast+copy when the network output is fp16. 
- Refine fp16 enablement on CUDA by gating on minimum compute capability (fallbacks to fp32 on very old/unknown devices); keep fp16 enabled  on MPS.
- Add a lightweight unit test (AST-based, no torch import) to prevent regressions
  - Verifies the input  .to(..., dtype=self.dtype)  cast exists.
  - Verifies the cache key includes  target_dtype 

## Accuracy Tests

Not applicable. This change does not modify model math beyond matching the input dtype to the already-selected inference dtype (fp32 stays fp32; fp16 runs fp16 as intended).

## Speed Tests and Profiling

Not measured in this PR. Expected impact:
- fp32 path: no meaningful change (extra .to(dtype=float32) is a no-op).
- fp16 path: enables fp16 execution without dtype-mismatch crashes; performance depends on device/backend.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
