### PR TITLE
Fix killall.py crash when sglang is not yet installed

### DIFF
--- a/python/sglang/cli/killall.py
+++ b/python/sglang/cli/killall.py
@@ -78,9 +78,8 @@ def _run_smi(query, query_type="gpu"):
 
 def _get_smi_version():
     """Return nvidia-smi driver version and GPU name, or None on failure."""
-    # Inline nvidia-smi query instead of importing from sglang.srt.utils.common,
-    # because killall.py runs before `pip install -e` and sglang may not be importable
-    # (git clean -ffdx removes sglang.egg-info, breaking editable installs).
+    # Inline nvidia-smi query — killall.py runs before pip install, so sglang
+    # internals may not be importable.
     try:
         result = subprocess.run(
             [

--- a/python/sglang/cli/killall.py
+++ b/python/sglang/cli/killall.py
@@ -78,9 +78,24 @@ def _run_smi(query, query_type="gpu"):
 
 def _get_smi_version():
     """Return nvidia-smi driver version and GPU name, or None on failure."""
-    from sglang.srt.utils.common import get_nvidia_driver_version_str
-
-    driver = get_nvidia_driver_version_str()
+    # Inline nvidia-smi query instead of importing from sglang.srt.utils.common,
+    # because killall.py runs before `pip install -e` and sglang may not be importable
+    # (git clean -ffdx removes sglang.egg-info, breaking editable installs).
+    try:
+        result = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=driver_version",
+                "--format=csv,noheader,nounits",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=10,
+        )
+        driver = result.stdout.strip().split("\n")[0].strip() or None
+    except (subprocess.SubprocessError, FileNotFoundError):
+        driver = None
     if driver is None:
         return None
     try:


### PR DESCRIPTION
## Summary
- `killall.py` runs before `pip install -e` in CI, but since #21780 it imports `from sglang.srt.utils.common import get_nvidia_driver_version_str`
- On runners where sglang was never installed (or was uninstalled), `import sglang` fails immediately
- Fix: inline the `nvidia-smi` driver version query directly in `killall.py` instead of importing from `sglang`

## Failure evidence

Multiple GPU runners fail with `ModuleNotFoundError: No module named 'sglang'` at the `killall.py` step:

- **5090-b-runner-0** (stage-a-test-1-gpu-small): https://github.com/sgl-project/sglang/actions/runs/23824830054/job/69445358212?pr=21790
- **b200-dgx-020-0123** (stage-b-test-4-gpu-b200): https://github.com/sgl-project/sglang/actions/runs/23824830054/job/69446515631?pr=21790

### Why some runners pass and others fail

- **Passing runners** (e.g. `5090-a-runner-5`): had a previous successful `pip install -e sglang` — the editable `.pth` file persists in `site-packages` across `git clean -ffdx`, so `import sglang` still works
- **Failing runners**: never had sglang installed for this workspace (new runner or changed workspace path) — `site-packages` has no sglang entry, so the import fails

This is not a flaky test — it deterministically fails on any runner that hasn't had sglang installed before. As new runners are added, the failure rate will increase.

## Test plan
- [ ] CI passes without `ModuleNotFoundError` on all GPU runners