### PR TITLE
[gRPC] Preserve original ImportError in grpc_server.py

### DIFF
--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -7,9 +7,11 @@ async def serve_grpc(server_args, model_info=None):
     """Start the standalone gRPC server with integrated scheduler."""
     try:
         from smg_grpc_servicer.sglang.server import serve_grpc as _serve_grpc
-    except ImportError:
+    except ImportError as e:
         raise ImportError(
             "gRPC mode requires the smg-grpc-servicer package. "
-            "Install it with: pip install smg-grpc-servicer[sglang]"
-        ) from None
+            "If not installed, run: pip install smg-grpc-servicer[sglang]. "
+            "If already installed, there may be a broken import due to a "
+            "version mismatch — see the chained exception above for details."
+        ) from e
     await _serve_grpc(server_args, model_info)


### PR DESCRIPTION
## Motivation

When `smg-grpc-servicer` is installed but has a broken internal import (e.g. `from sglang.srt.utils import get_zmq_socket` fails because the function moved to `sglang.srt.utils.network`), the current `from None` suppresses the real error and shows only:

```
ImportError: gRPC mode requires the smg-grpc-servicer package.
Install it with: pip install smg-grpc-servicer[sglang]
```

This is misleading — the package IS installed, but an internal import failed. The user has no idea what actually went wrong.

## Modifications

- Change `from None` to `from e` so Python chains the original exception
- Update the error message to mention both cases: not installed, or installed but broken import

With this fix, the output becomes:

```
ImportError: cannot import name 'get_zmq_socket' from 'sglang.srt.utils'

The above exception was the direct cause of the following exception:

ImportError: gRPC mode requires the smg-grpc-servicer package.
If not installed, run: pip install smg-grpc-servicer[sglang].
If already installed, there may be a broken import due to a version mismatch
— see the chained exception above for details.
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).