### PR TITLE
[AMD] Disable the Split-K CK feature for MoE

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -307,7 +307,8 @@ class Envs:
     SGLANG_USE_AITER = EnvBool(False)
     SGLANG_ROCM_FUSED_DECODE_MLA = EnvBool(False)
     SGLANG_ROCM_DISABLE_LINEARQUANT = EnvBool(False)
-    SGLANG_AITER_KSPLIT = EnvInt(1)
+    # TODO remove after ksplit fix, check perf
+    AITER_KSPLIT = EnvInt(1)
 
     # MPS (Apple Silicon)
     SGLANG_USE_MLX = EnvBool(False)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -307,6 +307,7 @@ class Envs:
     SGLANG_USE_AITER = EnvBool(False)
     SGLANG_ROCM_FUSED_DECODE_MLA = EnvBool(False)
     SGLANG_ROCM_DISABLE_LINEARQUANT = EnvBool(False)
+    SGLANG_AITER_KSPLIT = EnvInt(1)
 
     # MPS (Apple Silicon)
     SGLANG_USE_MLX = EnvBool(False)


### PR DESCRIPTION
## Motivation

This flag disables the CK Split-K kernel, which only affects performance for FP8 block quantization. We will remove this flag as soon as the new FlyDSL kernel is ready.

## Modifications

- Add a new global variable on the AMD ROCm platform to temporarily disable the CK Split-K kernel for FP8 block quantization.
- No functional or accuracy impact — this change only affects kernel selection for FP8 block-quantized matmuls on AMD GPUs.

## Accuracy Tests

**Model:** Qwen3.5-397B-A17B-FP8

| Benchmark | Score  |
|:---------:|:------:|
| GSM8K Accuracy | 0.936 |
| GSM8K Invalid  | 0.011 |
| Latency        | 84.084 s |
| Output Throughput | 2570.934 tok/s |

## Speed Tests and Profiling

**Model:** Qwen3.5-397B-A17B-FP8
**Spec:** Input Length 8K, Output Length 1K

| Concurrency | Median E2E Latency (ms) |          |         | Total Throughput (tok/s) |         |         |
|:-----------:|:-----------------------:|:--------:|:-------:|:------------------------:|:-------:|:-------:|
|             | Before                  | After    | Diff    | Before                   | After   | Diff    |
| 1           | 9880.35                 | 9976.26  | +0.97%  | 932.53                   | 923.50  | -0.97%  |

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
