### PR TITLE
[Diffusion][NPU] add ring sp performance benchmark page in npu

### DIFF
--- a/docs/platforms/ascend/ascend_npu_support.rst
+++ b/docs/platforms/ascend/ascend_npu_support.rst
@@ -13,6 +13,7 @@ Ascend NPUs
    mindspore_backend.md
    ascend_contribution_guide.md
    ascend_npu_best_practice.md
+   ascend_npu_ring_sp_performance.md
    ascend_npu_qwen3_5_examples.md
    ascend_npu_glm5_examples.md
    ascend_npu_environment_variables.md

--- a/docs/platforms/ascend_npu_ring_sp_performance.md
+++ b/docs/platforms/ascend_npu_ring_sp_performance.md
@@ -1,0 +1,55 @@
+# Ascend NPU Ring-SP Performance (Wan2.1-T2V-1.3B)
+
+This page reports Ring-SP performance on Ascend NPU with `torch_npu==2.10.0`.
+
+- Baseline config: `ulysses=1, ring=1` (short: `u1r1`)
+- Ring-SP config: `ulysses=1, ring=2` (short: `u1r2`)
+
+## Benchmark Setup
+
+- Model: `Wan2.1-T2V-1.3B-Diffusers`
+- Prompt: `"a cat is playing piano"`
+- Framework command: `sglang generate`
+- Runtime: `torch_npu==2.10.0`
+
+## Generate Commands
+
+### Baseline (`u1r1`)
+
+```bash
+sglang generate --model-path /nas/disk1/Wan2.1-T2V-1.3B-Diffusers \
+    --prompt "a cat is playing piano" --num-gpus 1 --ring-degree 1 \
+    --save-output
+```
+
+### Ring-SP (`u1r2`)
+
+```bash
+sglang generate --model-path /nas/disk1/Wan2.1-T2V-1.3B-Diffusers \
+    --prompt "a cat is playing piano" --num-gpus 2 --ring-degree 2 \
+    --save-output
+```
+
+## Benchmarks
+
+Benchmark Disclaimer
+
+These numbers are from one fixed setup and one prompt case. Actual performance may vary by model settings, environment, and workload.
+
+### Stage Time Breakdown
+
+| Stage / Metric | `u1r2` (s) | `u1r1` baseline (s) | Speedup |
+|---|---:|---:|---:|
+| InputValidation | 0.0003 | 0.0002 | 0.67x |
+| TextEncoding | 3.5936 | 3.5820 | 1.00x |
+| LatentPreparation | 0.0007 | 0.0055 | 7.86x |
+| TimestepPreparation | 0.0008 | 0.0007 | 0.88x |
+| Denoising | 121.2788 | 239.2580 | 1.97x |
+| Decoding | 13.8685 | 16.4969 | 1.19x |
+| **Total (Pixel data generated)** | **141.86** | **266.50** | **1.88x** |
+
+## Summary
+
+- With `torch_npu==2.10.0`, Ring-SP (`u1r2`) runs successfully on NPU for this case.
+- End-to-end generation time improves from `266.50s` to `141.86s` (`1.88x`).
+- The main gain comes from `DenoisingStage` (`1.97x`), while decoding also improves (`1.19x`).


### PR DESCRIPTION
## Motivation

This PR adds documentation for **Ring-SP performance on Ascend NPU** in SGLang Diffusion.

The goal is to document that with `torch_npu==2.10.0`, NPU can run Ring-SP (`ring-degree=2`) and to provide reproducible benchmark results against baseline (`ring-degree=1`) for `Wan2.1-T2V-1.3B-Diffusers`.

Address the questions in this issue:  [#20996](https://github.com/sgl-project/sglang/issues/20996) 

## Modifications

- Added a new NPU performance doc:
  - `docs/platforms/ascend_npu_ring_sp_performance.md`
- Added doc entry in Ascend NPU toctree:
  - `docs/platforms/ascend_npu_support.rst`

The new document includes:
- Benchmark setup and runtime version (`torch_npu==2.10.0`)
- Reproducible commands for `u1r1` and `u1r2`
- Stage-level timing comparison
- Denoising per-step comparison
- Summary and notes (including runtime warning context)

## Speed Tests and Profiling

### Setup

- Model: `Wan2.1-T2V-1.3B-Diffusers`
- Prompt: `"a cat is playing piano"`
- Runtime: `torch_npu==2.10.0`
- Baseline: `--num-gpus 1 --ring-degree 1` (`u1r1`)
- Ring-SP: `--num-gpus 2 --ring-degree 2` (`u1r2`)

### Stage Time Breakdown

| Stage / Metric | `u1r2` (s) | `u1r1` baseline (s) | Speedup |
|---|---:|---:|---:|
| InputValidation | 0.0003 | 0.0002 | 0.67x |
| TextEncoding | 3.5936 | 3.5820 | 1.00x |
| LatentPreparation | 0.0007 | 0.0055 | 7.86x |
| TimestepPreparation | 0.0008 | 0.0007 | 0.88x |
| Denoising | 121.2788 | 239.2580 | 1.97x |
| Decoding | 13.8685 | 16.4969 | 1.19x |
| **Total (Pixel data generated)** | **141.86** | **266.50** | **1.88x** |

### Denoising Step Statistics

| Metric | `u1r2` | `u1r1` baseline | Speedup |
|---|---:|---:|---:|
| Average denoising time per step (s) | 2.4254 | 4.7849 | 1.97x |

### Notes

- During `u1r2`, runtime warning observed:
  - `Device do not support double dtype now, dtype cast replace with float`
- Benchmark completed successfully and output was generated.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). *(Not applicable: docs-only PR)*
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

