### PR TITLE
[Bugfix] Fix --preferred-sampling-params not taking effect

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -772,27 +772,30 @@ class ChatCompletionRequest(BaseModel):
             else self.chat_template_kwargs.get("spaces_between_special_tokens", True)
         )
 
-        # Parameters that use get_param() are always included (they have proper fallback).
-        sampling_params = {
-            "temperature": get_param("temperature"),
-            "top_p": get_param("top_p"),
-            "top_k": get_param("top_k"),
-            "min_p": get_param("min_p"),
-            "repetition_penalty": get_param("repetition_penalty"),
-        }
+        # Priority: user explicit > model_generation_config > preferred_sampling_params > defaults
+        sampling_params = {}
+
+        for name in ("temperature", "top_p", "top_k", "min_p", "repetition_penalty"):
+            if name in user_set:
+                sampling_params[name] = get_param(name)
+            elif name in model_generation_config:
+                sampling_params[name] = model_generation_config[name]
 
         # stop is always passed from the caller (derived from chat template + request),
         # so it should always be included.
         sampling_params["stop"] = stop
 
         # For max_new_tokens, only include if the user explicitly set max_completion_tokens or max_tokens.
-        max_new_tokens = self.max_completion_tokens or self.max_tokens
+        max_new_tokens = (
+            self.max_completion_tokens
+            if self.max_completion_tokens is not None
+            else self.max_tokens
+        )
         if max_new_tokens is not None:
             sampling_params["max_new_tokens"] = max_new_tokens
 
-        # For all other parameters, only include them if the user explicitly provided them
-        # in the request. This prevents protocol-level defaults from overriding
-        # server-level preferred_sampling_params.
+        # IMPORTANT: When adding new optional sampling fields to ChatCompletionRequest,
+        # add them here to ensure they participate in the preferred_sampling_params mechanism.
         _optional_fields = {
             "min_new_tokens": "min_tokens",
             "stop_token_ids": "stop_token_ids",
@@ -814,7 +817,9 @@ class ChatCompletionRequest(BaseModel):
                 sampling_params[param_key] = getattr(self, field_name)
 
         if "chat_template_kwargs" in user_set:
-            sampling_params["spaces_between_special_tokens"] = spaces_between_special_tokens
+            sampling_params["spaces_between_special_tokens"] = (
+                spaces_between_special_tokens
+            )
 
         if self.response_format and self.response_format.type == "json_schema":
             sampling_params["json_schema"] = convert_json_schema_to_str(

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -748,6 +748,10 @@ class ChatCompletionRequest(BaseModel):
         """
         Convert request to sampling parameters.
         Priority: user value > model generation_config > OpenAI defaults
+
+        Only explicitly user-provided parameters are included in the returned dict,
+        so that server-level preferred_sampling_params are not silently overridden
+        by protocol-level defaults.
         """
 
         def get_param(param_name: str):
@@ -758,6 +762,9 @@ class ChatCompletionRequest(BaseModel):
                 )
             return value
 
+        # Use model_fields_set to determine which fields the user explicitly provided.
+        user_set = self.model_fields_set
+
         # add per user request
         spaces_between_special_tokens = (
             True
@@ -765,30 +772,49 @@ class ChatCompletionRequest(BaseModel):
             else self.chat_template_kwargs.get("spaces_between_special_tokens", True)
         )
 
+        # Parameters that use get_param() are always included (they have proper fallback).
         sampling_params = {
             "temperature": get_param("temperature"),
-            "max_new_tokens": self.max_completion_tokens or self.max_tokens,
-            "min_new_tokens": self.min_tokens,
-            "stop": stop,
-            "stop_token_ids": self.stop_token_ids,
-            "stop_regex": self.stop_regex,
             "top_p": get_param("top_p"),
             "top_k": get_param("top_k"),
             "min_p": get_param("min_p"),
-            "presence_penalty": self.presence_penalty,
-            "frequency_penalty": self.frequency_penalty,
             "repetition_penalty": get_param("repetition_penalty"),
-            "regex": self.regex,
-            "ebnf": self.ebnf,
-            "n": self.n,
-            "no_stop_trim": self.no_stop_trim,
-            "ignore_eos": self.ignore_eos,
-            "skip_special_tokens": self.skip_special_tokens,
-            "logit_bias": self.logit_bias,
-            "custom_params": self.custom_params,
-            "sampling_seed": self.seed,
-            "spaces_between_special_tokens": spaces_between_special_tokens,
         }
+
+        # stop is always passed from the caller (derived from chat template + request),
+        # so it should always be included.
+        sampling_params["stop"] = stop
+
+        # For max_new_tokens, only include if the user explicitly set max_completion_tokens or max_tokens.
+        max_new_tokens = self.max_completion_tokens or self.max_tokens
+        if max_new_tokens is not None:
+            sampling_params["max_new_tokens"] = max_new_tokens
+
+        # For all other parameters, only include them if the user explicitly provided them
+        # in the request. This prevents protocol-level defaults from overriding
+        # server-level preferred_sampling_params.
+        _optional_fields = {
+            "min_new_tokens": "min_tokens",
+            "stop_token_ids": "stop_token_ids",
+            "stop_regex": "stop_regex",
+            "presence_penalty": "presence_penalty",
+            "frequency_penalty": "frequency_penalty",
+            "regex": "regex",
+            "ebnf": "ebnf",
+            "n": "n",
+            "no_stop_trim": "no_stop_trim",
+            "ignore_eos": "ignore_eos",
+            "skip_special_tokens": "skip_special_tokens",
+            "logit_bias": "logit_bias",
+            "custom_params": "custom_params",
+            "sampling_seed": "seed",
+        }
+        for param_key, field_name in _optional_fields.items():
+            if field_name in user_set:
+                sampling_params[param_key] = getattr(self, field_name)
+
+        if "chat_template_kwargs" in user_set:
+            sampling_params["spaces_between_special_tokens"] = spaces_between_special_tokens
 
         if self.response_format and self.response_format.type == "json_schema":
             sampling_params["json_schema"] = convert_json_schema_to_str(

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -138,44 +138,38 @@ class OpenAIServingCompletion(OpenAIServingBase):
         Only explicitly user-provided parameters are included in the returned dict,
         so that server-level preferred_sampling_params are not silently overridden
         by protocol-level defaults.
-
-        Note: CompletionRequest fields that have OpenAI-spec defaults (e.g.,
-        max_tokens=16, temperature=1.0) are always included because they are
-        part of the OpenAI API contract. Only SGLang-extension fields use
-        model_fields_set to determine if the user explicitly set them.
         """
         user_set = request.model_fields_set
 
-        # OpenAI-spec fields: always include (they have spec-defined defaults).
-        sampling_params = {
-            "temperature": request.temperature,
-            "max_new_tokens": request.max_tokens,
-            "stop": request.stop,
-            "top_p": request.top_p,
-            "presence_penalty": request.presence_penalty,
-            "frequency_penalty": request.frequency_penalty,
-            "n": request.n,
-            "logit_bias": request.logit_bias,
-        }
-
-        # SGLang-extension fields: only include if the user explicitly set them.
-        _sglang_fields = {
+        # Map request field names to sampling param keys.
+        # Only include fields that the user explicitly set in the request.
+        _field_to_param = {
+            "temperature": "temperature",
+            "max_tokens": "max_new_tokens",
             "min_tokens": "min_new_tokens",
+            "stop": "stop",
             "stop_token_ids": "stop_token_ids",
             "stop_regex": "stop_regex",
+            "top_p": "top_p",
             "top_k": "top_k",
             "min_p": "min_p",
+            "presence_penalty": "presence_penalty",
+            "frequency_penalty": "frequency_penalty",
             "repetition_penalty": "repetition_penalty",
             "regex": "regex",
             "json_schema": "json_schema",
             "ebnf": "ebnf",
+            "n": "n",
             "no_stop_trim": "no_stop_trim",
             "ignore_eos": "ignore_eos",
             "skip_special_tokens": "skip_special_tokens",
+            "logit_bias": "logit_bias",
             "custom_params": "custom_params",
             "seed": "sampling_seed",
         }
-        for field_name, param_key in _sglang_fields.items():
+
+        sampling_params = {}
+        for field_name, param_key in _field_to_param.items():
             if field_name in user_set:
                 sampling_params[param_key] = getattr(request, field_name)
 

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -133,32 +133,51 @@ class OpenAIServingCompletion(OpenAIServingBase):
         return adapted_request, request
 
     def _build_sampling_params(self, request: CompletionRequest) -> Dict[str, Any]:
-        """Build sampling parameters for the request"""
-        # Start with common parameters
+        """Build sampling parameters for the request.
+
+        Only explicitly user-provided parameters are included in the returned dict,
+        so that server-level preferred_sampling_params are not silently overridden
+        by protocol-level defaults.
+
+        Note: CompletionRequest fields that have OpenAI-spec defaults (e.g.,
+        max_tokens=16, temperature=1.0) are always included because they are
+        part of the OpenAI API contract. Only SGLang-extension fields use
+        model_fields_set to determine if the user explicitly set them.
+        """
+        user_set = request.model_fields_set
+
+        # OpenAI-spec fields: always include (they have spec-defined defaults).
         sampling_params = {
             "temperature": request.temperature,
             "max_new_tokens": request.max_tokens,
-            "min_new_tokens": request.min_tokens,
             "stop": request.stop,
-            "stop_token_ids": request.stop_token_ids,
-            "stop_regex": request.stop_regex,
             "top_p": request.top_p,
-            "top_k": request.top_k,
-            "min_p": request.min_p,
             "presence_penalty": request.presence_penalty,
             "frequency_penalty": request.frequency_penalty,
-            "repetition_penalty": request.repetition_penalty,
-            "regex": request.regex,
-            "json_schema": request.json_schema,
-            "ebnf": request.ebnf,
             "n": request.n,
-            "no_stop_trim": request.no_stop_trim,
-            "ignore_eos": request.ignore_eos,
-            "skip_special_tokens": request.skip_special_tokens,
             "logit_bias": request.logit_bias,
-            "custom_params": request.custom_params,
-            "sampling_seed": request.seed,
         }
+
+        # SGLang-extension fields: only include if the user explicitly set them.
+        _sglang_fields = {
+            "min_tokens": "min_new_tokens",
+            "stop_token_ids": "stop_token_ids",
+            "stop_regex": "stop_regex",
+            "top_k": "top_k",
+            "min_p": "min_p",
+            "repetition_penalty": "repetition_penalty",
+            "regex": "regex",
+            "json_schema": "json_schema",
+            "ebnf": "ebnf",
+            "no_stop_trim": "no_stop_trim",
+            "ignore_eos": "ignore_eos",
+            "skip_special_tokens": "skip_special_tokens",
+            "custom_params": "custom_params",
+            "seed": "sampling_seed",
+        }
+        for field_name, param_key in _sglang_fields.items():
+            if field_name in user_set:
+                sampling_params[param_key] = getattr(request, field_name)
 
         # Handle response_format constraints
         if request.response_format and request.response_format.type == "json_schema":

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -141,8 +141,8 @@ class OpenAIServingCompletion(OpenAIServingBase):
         """
         user_set = request.model_fields_set
 
-        # Map request field names to sampling param keys.
-        # Only include fields that the user explicitly set in the request.
+        # IMPORTANT: When adding new optional sampling fields to CompletionRequest,
+        # add them here to ensure they participate in the preferred_sampling_params mechanism.
         _field_to_param = {
             "temperature": "temperature",
             "max_tokens": "max_new_tokens",

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -970,9 +970,14 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerScoreMixin):
         """Create a tokenized request object from common parameters."""
         # Parse sampling parameters
         # Note: if there are preferred sampling params, we use them if they are not
-        # explicitly passed in sampling_params
+        # explicitly passed in sampling_params.
+        # Filter out None values from request params to prevent them from overriding
+        # preferred params (None means "not set by user").
         if self.preferred_sampling_params:
-            sampling_kwargs = {**self.preferred_sampling_params, **obj.sampling_params}
+            request_params = {
+                k: v for k, v in obj.sampling_params.items() if v is not None
+            }
+            sampling_kwargs = {**self.preferred_sampling_params, **request_params}
         else:
             sampling_kwargs = obj.sampling_params
         sampling_params = self.sampling_params_class(**sampling_kwargs)

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -974,6 +974,15 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerScoreMixin):
         # Filter out None values from request params to prevent them from overriding
         # preferred params (None means "not set by user").
         if self.preferred_sampling_params:
+            # Note: this None filter cannot distinguish "field not set" from
+            # "user explicitly sent null". The protocol layer's model_fields_set
+            # check is the primary guard; this is a defense-in-depth layer.
+            filtered = [k for k, v in obj.sampling_params.items() if v is None]
+            if filtered:
+                logger.debug(
+                    "Filtered None-valued params before preferred merge: %s",
+                    filtered,
+                )
             request_params = {
                 k: v for k, v in obj.sampling_params.items() if v is not None
             }

--- a/test/registered/openai_server/basic/test_protocol.py
+++ b/test/registered/openai_server/basic/test_protocol.py
@@ -292,6 +292,107 @@ class TestChatCompletionRequest(unittest.TestCase):
         self.assertEqual(strict, True)
 
 
+class TestPreferredSamplingParamsInteraction(unittest.TestCase):
+    """Test that to_sampling_params() only includes user-set fields,
+    allowing preferred_sampling_params to take effect for unset fields."""
+
+    def _make_chat_request(self, **kwargs):
+        defaults = {"model": "x", "messages": [{"role": "user", "content": "Hi"}]}
+        defaults.update(kwargs)
+        return ChatCompletionRequest(**defaults)
+
+    def test_unset_fields_omitted_for_preferred_params(self):
+        """preferred_sampling_params should take effect when user does not set the field."""
+        req = self._make_chat_request()
+        params = req.to_sampling_params(stop=[], model_generation_config={})
+        # These should NOT be present so preferred_sampling_params can fill them
+        for key in ("temperature", "top_p", "top_k", "min_p", "repetition_penalty"):
+            self.assertNotIn(key, params, f"{key} should be omitted when not user-set")
+        for key in (
+            "max_new_tokens",
+            "presence_penalty",
+            "frequency_penalty",
+            "ignore_eos",
+        ):
+            self.assertNotIn(key, params, f"{key} should be omitted when not user-set")
+
+    def test_user_set_fields_override_preferred(self):
+        """User-set fields should always appear in params (overriding preferred)."""
+        req = self._make_chat_request(
+            temperature=0.5,
+            top_k=50,
+            presence_penalty=0.3,
+            max_tokens=200,
+        )
+        params = req.to_sampling_params(stop=[], model_generation_config={})
+        self.assertEqual(params["temperature"], 0.5)
+        self.assertEqual(params["top_k"], 50)
+        self.assertEqual(params["presence_penalty"], 0.3)
+        self.assertEqual(params["max_new_tokens"], 200)
+
+    def test_model_generation_config_used_when_user_unset(self):
+        """model_generation_config should fill in when user hasn't set the field."""
+        req = self._make_chat_request()
+        gen_config = {"temperature": 0.3, "top_k": 40}
+        params = req.to_sampling_params(stop=[], model_generation_config=gen_config)
+        self.assertEqual(params["temperature"], 0.3)
+        self.assertEqual(params["top_k"], 40)
+        # Fields not in gen_config should remain omitted
+        self.assertNotIn("top_p", params)
+
+    def test_user_set_overrides_model_generation_config(self):
+        """User-set values should beat model_generation_config."""
+        req = self._make_chat_request(temperature=0.9)
+        gen_config = {"temperature": 0.3}
+        params = req.to_sampling_params(stop=[], model_generation_config=gen_config)
+        self.assertEqual(params["temperature"], 0.9)
+
+    def test_max_completion_tokens_zero(self):
+        """max_completion_tokens=0 should not be dropped by falsy check."""
+        req = self._make_chat_request(max_completion_tokens=0, max_tokens=100)
+        params = req.to_sampling_params(stop=[], model_generation_config={})
+        self.assertEqual(params["max_new_tokens"], 0)
+
+    def test_max_completion_tokens_precedence_over_max_tokens(self):
+        """max_completion_tokens takes precedence over max_tokens when both set."""
+        req = self._make_chat_request(max_completion_tokens=50, max_tokens=100)
+        params = req.to_sampling_params(stop=[], model_generation_config={})
+        self.assertEqual(params["max_new_tokens"], 50)
+
+    def test_max_tokens_fallback(self):
+        """max_tokens used when max_completion_tokens is not set."""
+        req = self._make_chat_request(max_tokens=200)
+        params = req.to_sampling_params(stop=[], model_generation_config={})
+        self.assertEqual(params["max_new_tokens"], 200)
+
+    def test_stop_always_included(self):
+        """stop is always included regardless of user setting."""
+        req = self._make_chat_request()
+        params = req.to_sampling_params(
+            stop=["</s>", "<|end|>"], model_generation_config={}
+        )
+        self.assertEqual(params["stop"], ["</s>", "<|end|>"])
+
+    def test_consistent_with_completions_endpoint(self):
+        """Both endpoints should omit unset get_param fields identically."""
+        chat_req = self._make_chat_request()
+        chat_params = chat_req.to_sampling_params(stop=[], model_generation_config={})
+        comp_req = CompletionRequest(model="x", prompt="Hello", max_tokens=16)
+        # CompletionRequest uses _build_sampling_params via serving layer,
+        # but we can check model_fields_set behavior directly
+        comp_user_set = comp_req.model_fields_set
+        for name in ("temperature", "top_p", "top_k", "min_p", "repetition_penalty"):
+            chat_has = name in chat_params
+            comp_explicit = name in comp_user_set
+            # If user didn't explicitly set in either, both should allow preferred to win
+            self.assertEqual(
+                chat_has,
+                comp_explicit,
+                f"Asymmetry for '{name}': chat_params has={chat_has}, "
+                f"comp explicit={comp_explicit}",
+            )
+
+
 class TestModelSerialization(unittest.TestCase):
     """Test model serialization with hidden states"""
 

--- a/test/registered/openai_server/basic/test_serving_completions.py
+++ b/test/registered/openai_server/basic/test_serving_completions.py
@@ -162,6 +162,37 @@ class ServingCompletionTestCase(unittest.TestCase):
         # (but might have json_schema from the legacy json_schema field)
         self.assertIsNone(sampling_params.get("structural_tag"))
 
+    # ---------- preferred_sampling_params interaction ----------
+    def test_unset_fields_omitted_for_preferred_params(self):
+        """Fields not explicitly set should be omitted from sampling_params,
+        allowing preferred_sampling_params to take effect."""
+        req = CompletionRequest(model="x", prompt="Hello", max_tokens=100)
+        params = self.sc._build_sampling_params(req)
+        # max_tokens is explicitly set, should be present
+        self.assertEqual(params["max_new_tokens"], 100)
+        # These were not set, should be absent
+        for key in ("temperature", "top_p", "top_k", "min_p", "repetition_penalty"):
+            self.assertNotIn(key, params, f"{key} should be omitted when not user-set")
+        for key in ("presence_penalty", "frequency_penalty", "ignore_eos"):
+            self.assertNotIn(key, params, f"{key} should be omitted when not user-set")
+
+    def test_user_set_fields_included(self):
+        """Explicitly set fields should always appear in sampling_params."""
+        req = CompletionRequest(
+            model="x",
+            prompt="Hello",
+            max_tokens=100,
+            temperature=0.5,
+            top_k=50,
+            presence_penalty=0.3,
+            ignore_eos=True,
+        )
+        params = self.sc._build_sampling_params(req)
+        self.assertEqual(params["temperature"], 0.5)
+        self.assertEqual(params["top_k"], 50)
+        self.assertEqual(params["presence_penalty"], 0.3)
+        self.assertEqual(params["ignore_eos"], True)
+
     def test_logprobs_false_non_streaming(self):
         """Test that logprobs=False doesn't cause KeyError in non-streaming response."""
         req = CompletionRequest(


### PR DESCRIPTION
## Related Issue

#21816 

## Motivation

When launching the server with `--preferred-sampling-params`, most parameter values are silently ignored. For example:

```bash
python -m sglang.launch_server --model-path <model> \
  --preferred-sampling-params '{"max_new_tokens": 2048, "presence_penalty": 0.5}'
```

Sending a `/v1/chat/completions` request **without** specifying `max_tokens` or `presence_penalty` results in the preferred values being discarded. The root cause is that `to_sampling_params()` / `_build_sampling_params()` unconditionally write all parameters — including `None` and hard-coded protocol defaults — into the sampling params dict. During dict merging in `tokenizer_manager.py`:

```python
sampling_kwargs = {**self.preferred_sampling_params, **obj.sampling_params}
```

these default/`None` values override the preferred params because Python dict merging doesn't distinguish `None` from explicit values.

Only 5 parameters (`temperature`, `top_p`, `top_k`, `min_p`, `repetition_penalty`) in `ChatCompletionRequest` worked correctly because they used the `get_param()` helper with proper `None` fallback. All other parameters — including `max_new_tokens`, `presence_penalty`, `frequency_penalty`, `ignore_eos`, `skip_special_tokens`, etc. — were affected.

## Modifications

### `protocol.py` — `ChatCompletionRequest.to_sampling_params()`
- Use Pydantic v2's `model_fields_set` to determine which fields the user **explicitly** provided in the request.
- Parameters using `get_param()` (`temperature`, `top_p`, `top_k`, `min_p`, `repetition_penalty`) are always included — they already have proper fallback logic.
- `stop` is always included (derived from chat template + request).
- `max_new_tokens` is only included when `max_completion_tokens` or `max_tokens` is explicitly set.
- All other parameters are only included if the user explicitly set them, allowing `preferred_sampling_params` to take effect as the default.

### `serving_completions.py` — `_build_sampling_params()`
- **OpenAI-spec fields** (`max_tokens`, `temperature`, `top_p`, `stop`, `presence_penalty`, `frequency_penalty`, `n`, `logit_bias`) are always included because they have API-contract defaults (e.g., `max_tokens=16` per OpenAI spec).
- **SGLang-extension fields** (`top_k`, `min_p`, `repetition_penalty`, `regex`, `ebnf`, `ignore_eos`, etc.) use `model_fields_set` to check explicit user intent, allowing preferred params to fill in as defaults.

### `tokenizer_manager.py` — Merge logic defense layer
- Filter out `None` values from request params before merging with `preferred_sampling_params`, preventing any residual `None` from overriding preferred values.

## Accuracy Tests

This change does not affect model forward computation or kernel code. It only affects how sampling parameters are assembled from request inputs and server defaults. When `--preferred-sampling-params` is not used, behavior is unchanged.

## Speed Tests and Profiling

No performance impact — the change only adds lightweight dict filtering and `model_fields_set` lookups during request parsing.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).