### PR TITLE
[Feature] Support incremental streaming for tool_call arguments in Qwen3CoderDetector

### DIFF
--- a/python/sglang/srt/function_call/qwen3_coder_detector.py
+++ b/python/sglang/srt/function_call/qwen3_coder_detector.py
@@ -54,6 +54,13 @@ class Qwen3CoderDetector(BaseFormatDetector):
         # Initialize attributes that were missing in the original PR
         self.current_func_name: Optional[str] = None
 
+        # Incremental parameter streaming state
+        # When a string parameter value is very long (e.g. code), we stream it
+        # incrementally instead of waiting for the complete </parameter> tag.
+        self._streaming_param_active: bool = False
+        self._streaming_param_emitted: int = 0  # chars processed in rest_of_slice
+        self._streaming_param_leading_checked: bool = False
+
     def has_tool_call(self, text: str) -> bool:
         return self.tool_call_start_token in text
 
@@ -168,6 +175,51 @@ class Qwen3CoderDetector(BaseFormatDetector):
                     f"Parsed value '{param_value}' of parameter '{param_name}' cannot be converted via Python `ast.literal_eval()` in tool '{func_name}', degenerating to string."
                 )
             return param_value
+
+    def _should_stream_param(self, param_name: str, tools: List[Tool]) -> bool:
+        """Check if a parameter's type supports incremental streaming.
+        Only string-like types can be streamed incrementally because non-string
+        types (int, bool, array, object) need the complete value for type
+        conversion via _convert_param_value.
+        """
+        param_config = self._get_arguments_config(self.current_func_name, tools)
+        if param_name not in param_config:
+            # Unknown param schema - default to streaming (treat as string)
+            return True
+        p_info = param_config[param_name]
+        if isinstance(p_info, dict) and "type" in p_info:
+            p_type = str(p_info["type"]).strip().lower()
+            return p_type in ("string", "str", "text", "varchar", "char", "enum")
+        # No type info - default to streaming
+        return True
+
+    def _find_safe_emit_end(self, text: str) -> int:
+        """Find safe position up to which we can emit, avoiding partial closing tags.
+        We must not cut text in the middle of a potential closing tag like
+        '</parameter>' or '</function>'. This finds the rightmost position
+        that is safe to emit.
+        """
+        if not text:
+            return 0
+        last_angle = text.rfind("<")
+        if last_angle == -1:
+            return len(text)
+        suffix = text[last_angle:]
+        closing_tags = [
+            self.parameter_end_token,
+            self.parameter_prefix,
+            self.function_end_token,
+        ]
+        for tag in closing_tags:
+            if tag.startswith(suffix):
+                return last_angle
+        return len(text)
+
+    def _reset_streaming_param(self):
+        """Reset incremental parameter streaming state."""
+        self._streaming_param_active = False
+        self._streaming_param_emitted = 0
+        self._streaming_param_leading_checked = False
 
     def detect_and_parse(self, text: str, tools: List[Tool]) -> StreamingParseResult:
         """One-shot parsing for non-streaming scenarios."""
@@ -329,6 +381,36 @@ class Qwen3CoderDetector(BaseFormatDetector):
                         end_pos = best_cand[0]
                         end_token_len = best_cand[1]
 
+                        if self._streaming_param_active:
+                            # Was streaming incrementally - emit remaining and close
+                            raw_value = rest_of_slice[:end_pos]
+                            remaining = raw_value[self._streaming_param_emitted :]
+                            # Strip trailing \n from remaining (format artifact)
+                            if remaining.endswith("\n"):
+                                remaining = remaining[:-1]
+                            if remaining:
+                                escaped = json.dumps(remaining, ensure_ascii=False)[
+                                    1:-1
+                                ]
+                                calls.append(
+                                    ToolCallItem(
+                                        tool_index=self.current_tool_id,
+                                        parameters=escaped,
+                                    )
+                                )
+                            # Close the JSON string value
+                            calls.append(
+                                ToolCallItem(
+                                    tool_index=self.current_tool_id,
+                                    parameters='"',
+                                )
+                            )
+                            self.current_tool_param_count += 1
+                            self._reset_streaming_param()
+                            total_len = value_start_idx + end_pos + end_token_len
+                            self.parsed_pos += total_len
+                            continue
+
                         param_name = current_slice[
                             len(self.parameter_prefix) : name_end
                         ]
@@ -376,6 +458,64 @@ class Qwen3CoderDetector(BaseFormatDetector):
                         total_len = (name_end + 1) + end_pos + end_token_len
                         self.parsed_pos += total_len
                         continue
+                
+                    param_name = current_slice[
+                        len(self.parameter_prefix) : name_end
+                    ]
+                    if not self._streaming_param_active:
+                        # First time seeing this incomplete parameter
+                        if not self._should_stream_param(param_name, tools):
+                            break  # Non-string type: buffer until complete
+                        self._streaming_param_active = True
+                        self._streaming_param_emitted = 0
+                        self._streaming_param_leading_checked = False
+                        # Emit JSON key prefix: "key": "
+                        if not self.json_started:
+                            calls.append(
+                                ToolCallItem(
+                                    tool_index=self.current_tool_id,
+                                    parameters="{",
+                                )
+                            )
+                            self.json_started = True
+                        key_prefix = f'{json.dumps(param_name)}: "'
+                        if self.current_tool_param_count > 0:
+                            key_prefix = f", {key_prefix}"
+                        calls.append(
+                            ToolCallItem(
+                                tool_index=self.current_tool_id,
+                                parameters=key_prefix,
+                            )
+                        )
+                    # Emit available content incrementally
+                    new_content = rest_of_slice[self._streaming_param_emitted :]
+                    # Skip leading \n on first content emission (format artifact)
+                    if (
+                        not self._streaming_param_leading_checked
+                        and new_content
+                    ):
+                        if new_content[0] == "\n":
+                            new_content = new_content[1:]
+                            self._streaming_param_emitted += 1
+                        self._streaming_param_leading_checked = True
+                    if new_content:
+                        safe_end = self._find_safe_emit_end(new_content)
+                        if safe_end > 0 and new_content[safe_end - 1] == "\n":
+                            safe_end -= 1
+                        if safe_end > 0:
+                            emit_part = new_content[:safe_end]
+                            escaped = json.dumps(
+                                emit_part, ensure_ascii=False
+                            )[1:-1]
+                            if escaped:
+                                calls.append(
+                                    ToolCallItem(
+                                        tool_index=self.current_tool_id,
+                                        parameters=escaped,
+                                    )
+                                )
+                            self._streaming_param_emitted += safe_end
+                    break  # Wait for more content
 
                 # Incomplete parameter tag or value
                 break

--- a/python/sglang/srt/function_call/qwen3_coder_detector.py
+++ b/python/sglang/srt/function_call/qwen3_coder_detector.py
@@ -209,6 +209,9 @@ class Qwen3CoderDetector(BaseFormatDetector):
             self.parameter_end_token,
             self.parameter_prefix,
             self.function_end_token,
+            self.tool_call_start_token,
+            self.tool_call_end_token,
+            self.tool_call_prefix,
         ]
         for tag in closing_tags:
             if tag.startswith(suffix):


### PR DESCRIPTION
## Motivation

When using --tool-call-parser qwen3_coder with streaming enabled, the arguments field of toolcall deltas is not streamed incrementally. Instead, the entire parameter value is buffered until the closing </parameter> tag arrives, and then emitted as a single massive chunk.

## Modifications

1. New state variables

- _streaming_param_active: whether we are in incremental streaming mode for the current parameter
- _streaming_param_emitted: cursor tracking how many chars of the value have been emitted
- _streaming_param_leading_checked: whether the leading \n format artifact has been checked

2. Three new helper methods

- _should_stream_param(param_name, tools): Checks the parameter's schema type. Only string-like types (string, str, text, enum, etc.) are eligible for incremental streaming. Non-string types (int, bool, array, object) require the complete value for type conversion, so they fall back to the original buffering behavior.
- _find_safe_emit_end(text): Finds the rightmost safe position to emit up to, avoiding truncation in the middle of a potential closing tag prefix (e.g. </param which could be the start of </parameter>).
- _reset_streaming_param(): Resets incremental streaming state after a parameter is completed.

3. Modified parameter parsing section in parse_streaming_increment 

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
