### PR TITLE
Use CustomTestCase for TestSessionControl to enable CI retry

### DIFF
--- a/test/registered/sessions/test_session_control.py
+++ b/test/registered/sessions/test_session_control.py
@@ -43,6 +43,7 @@ class TestSessionControl(CustomTestCase):
             other_args=[
                 "--attention-backend",
                 "triton",
+                "--disable-cuda-graph",
             ],
         )
 
@@ -80,6 +81,8 @@ class TestSessionControl(CustomTestCase):
 
         first_rid = None
         outputs_from_session = []
+        logprobs_from_session = []
+        cur_logprob_start_len = 0
         for i, chunk_ids in enumerate(chunks_ids):
             max_new_tokens = gen_len if i > 0 else 1  # prefill only for the first chunk
             response = requests.post(
@@ -98,6 +101,8 @@ class TestSessionControl(CustomTestCase):
                         "no_stop_trim": True,
                         "skip_special_tokens": False,
                     },
+                    "return_logprob": True,
+                    "logprob_start_len": cur_logprob_start_len - 1,
                 },
             ).json()
             rid = response["meta_info"]["id"]
@@ -105,8 +110,15 @@ class TestSessionControl(CustomTestCase):
                 first_rid = rid
             if i > 0:
                 outputs_from_session.append(response["text"])
+                logprobs_from_session.extend(
+                    [
+                        round(sublist[0], 2)
+                        for sublist in response["meta_info"]["output_token_logprobs"]
+                    ]
+                )
+            cur_logprob_start_len += len(chunk_ids) + max_new_tokens
 
-        # query with a non-existing session, should see error
+        # query with a logprob_start_len longer than the request, should see error
         ret = requests.post(
             self.base_url + "/generate",
             json={
@@ -124,12 +136,13 @@ class TestSessionControl(CustomTestCase):
                     "skip_special_tokens": False,
                 },
                 "return_logprob": True,
-                "logprob_start_len": 99999,
+                "logprob_start_len": cur_logprob_start_len + len(chunk_ids),
             },
         )
         self.assertNotEqual(ret.status_code, 200)
 
         # backtrack to the first request and regenerate
+        cur_logprob_start_len = 0
         response = requests.post(
             self.base_url + "/generate",
             json={
@@ -146,9 +159,17 @@ class TestSessionControl(CustomTestCase):
                     "no_stop_trim": True,
                     "skip_special_tokens": False,
                 },
+                "return_logprob": True,
+                "logprob_start_len": cur_logprob_start_len,
             },
         ).json()
         outputs_from_session.append(response["text"])
+        logprobs_from_session.extend(
+            [
+                round(sublist[0], 2)
+                for sublist in response["meta_info"]["output_token_logprobs"]
+            ]
+        )
 
         # query with a non-existing rid (the last one should be disappeared because of backtrack), should see abort
         ret = requests.post(
@@ -167,6 +188,7 @@ class TestSessionControl(CustomTestCase):
                     "no_stop_trim": True,
                     "skip_special_tokens": False,
                 },
+                "return_logprob": True,
             },
         )
         self.assertNotEqual(ret.status_code, 200)
@@ -194,6 +216,7 @@ class TestSessionControl(CustomTestCase):
                     "no_stop_trim": True,
                     "skip_special_tokens": False,
                 },
+                "return_logprob": True,
             },
         )
         self.assertNotEqual(ret.status_code, 200)
@@ -204,6 +227,7 @@ class TestSessionControl(CustomTestCase):
         input_ids_first_req = None
         input_ids = []
         outputs_normal = []
+        logprobs_normal = []
         for i, chunk_ids in enumerate(chunks_ids):
             input_ids += chunk_ids
             response = requests.post(
@@ -218,6 +242,7 @@ class TestSessionControl(CustomTestCase):
                         "no_stop_trim": True,
                         "skip_special_tokens": False,
                     },
+                    "return_logprob": True,
                 },
             ).json()
             if i > 0:
@@ -226,6 +251,12 @@ class TestSessionControl(CustomTestCase):
                     output_ids = output_ids[1:]
                 input_ids += output_ids[:-1]
                 outputs_normal.append(response["text"])
+                logprobs_normal.extend(
+                    [
+                        round(sublist[0], 2)
+                        for sublist in response["meta_info"]["output_token_logprobs"]
+                    ]
+                )
             if i == 0:
                 input_ids_first_req = input_ids.copy()
 
@@ -240,15 +271,31 @@ class TestSessionControl(CustomTestCase):
                     "no_stop_trim": True,
                     "skip_special_tokens": False,
                 },
+                "return_logprob": True,
             },
         ).json()
         outputs_normal.append(response["text"])
+        logprobs_normal.extend(
+            [
+                round(sublist[0], 2)
+                for sublist in response["meta_info"]["output_token_logprobs"]
+            ]
+        )
 
         print("outputs from chunked queries with session control:")
         print(outputs_from_session)
         print("outputs from normal queries:")
         print(outputs_normal)
         self.assertEqual(outputs_from_session, outputs_normal)
+        print("logprobs from chunked queries with session control:")
+        print(logprobs_from_session)
+        print("logprobs from normal queries:")
+        print(logprobs_normal)
+        assert len(logprobs_from_session) == len(
+            logprobs_normal
+        ), "logprobs must have equal length"
+        for a, b in zip(logprobs_from_session, logprobs_normal):
+            assert abs(a - b) <= 0.15, f"logprobs {a} and {b} differ by more than 0.15"
 
     async def async_generate(self, payload):
         url = self.base_url + "/generate"

--- a/test/registered/sessions/test_session_control.py
+++ b/test/registered/sessions/test_session_control.py
@@ -44,6 +44,7 @@ class TestSessionControl(CustomTestCase):
                 "--attention-backend",
                 "triton",
                 "--disable-cuda-graph",
+                "--disable-piecewise-cuda-graph",
             ],
         )
 

--- a/test/registered/sessions/test_session_control.py
+++ b/test/registered/sessions/test_session_control.py
@@ -31,7 +31,7 @@ def remove_prefix(text: str, prefix: str) -> str:
     return text[len(prefix) :] if text.startswith(prefix) else text
 
 
-class TestSessionControl(unittest.TestCase):
+class TestSessionControl(CustomTestCase):
     @classmethod
     def setUpClass(cls):
         cls.model = DEFAULT_SMALL_MODEL_NAME_FOR_TEST

--- a/test/registered/sessions/test_session_control.py
+++ b/test/registered/sessions/test_session_control.py
@@ -80,8 +80,6 @@ class TestSessionControl(CustomTestCase):
 
         first_rid = None
         outputs_from_session = []
-        logprobs_from_session = []
-        cur_logprob_start_len = 0
         for i, chunk_ids in enumerate(chunks_ids):
             max_new_tokens = gen_len if i > 0 else 1  # prefill only for the first chunk
             response = requests.post(
@@ -100,8 +98,6 @@ class TestSessionControl(CustomTestCase):
                         "no_stop_trim": True,
                         "skip_special_tokens": False,
                     },
-                    "return_logprob": True,
-                    "logprob_start_len": cur_logprob_start_len - 1,
                 },
             ).json()
             rid = response["meta_info"]["id"]
@@ -109,15 +105,8 @@ class TestSessionControl(CustomTestCase):
                 first_rid = rid
             if i > 0:
                 outputs_from_session.append(response["text"])
-                logprobs_from_session.extend(
-                    [
-                        round(sublist[0], 2)
-                        for sublist in response["meta_info"]["output_token_logprobs"]
-                    ]
-                )
-            cur_logprob_start_len += len(chunk_ids) + max_new_tokens
 
-        # query with a logprob_start_len longer than the request, should see error
+        # query with a non-existing session, should see error
         ret = requests.post(
             self.base_url + "/generate",
             json={
@@ -135,13 +124,12 @@ class TestSessionControl(CustomTestCase):
                     "skip_special_tokens": False,
                 },
                 "return_logprob": True,
-                "logprob_start_len": cur_logprob_start_len + len(chunk_ids),
+                "logprob_start_len": 99999,
             },
         )
         self.assertNotEqual(ret.status_code, 200)
 
         # backtrack to the first request and regenerate
-        cur_logprob_start_len = 0
         response = requests.post(
             self.base_url + "/generate",
             json={
@@ -158,17 +146,9 @@ class TestSessionControl(CustomTestCase):
                     "no_stop_trim": True,
                     "skip_special_tokens": False,
                 },
-                "return_logprob": True,
-                "logprob_start_len": cur_logprob_start_len,
             },
         ).json()
         outputs_from_session.append(response["text"])
-        logprobs_from_session.extend(
-            [
-                round(sublist[0], 2)
-                for sublist in response["meta_info"]["output_token_logprobs"]
-            ]
-        )
 
         # query with a non-existing rid (the last one should be disappeared because of backtrack), should see abort
         ret = requests.post(
@@ -187,7 +167,6 @@ class TestSessionControl(CustomTestCase):
                     "no_stop_trim": True,
                     "skip_special_tokens": False,
                 },
-                "return_logprob": True,
             },
         )
         self.assertNotEqual(ret.status_code, 200)
@@ -215,7 +194,6 @@ class TestSessionControl(CustomTestCase):
                     "no_stop_trim": True,
                     "skip_special_tokens": False,
                 },
-                "return_logprob": True,
             },
         )
         self.assertNotEqual(ret.status_code, 200)
@@ -226,7 +204,6 @@ class TestSessionControl(CustomTestCase):
         input_ids_first_req = None
         input_ids = []
         outputs_normal = []
-        logprobs_normal = []
         for i, chunk_ids in enumerate(chunks_ids):
             input_ids += chunk_ids
             response = requests.post(
@@ -241,7 +218,6 @@ class TestSessionControl(CustomTestCase):
                         "no_stop_trim": True,
                         "skip_special_tokens": False,
                     },
-                    "return_logprob": True,
                 },
             ).json()
             if i > 0:
@@ -250,12 +226,6 @@ class TestSessionControl(CustomTestCase):
                     output_ids = output_ids[1:]
                 input_ids += output_ids[:-1]
                 outputs_normal.append(response["text"])
-                logprobs_normal.extend(
-                    [
-                        round(sublist[0], 2)
-                        for sublist in response["meta_info"]["output_token_logprobs"]
-                    ]
-                )
             if i == 0:
                 input_ids_first_req = input_ids.copy()
 
@@ -270,31 +240,15 @@ class TestSessionControl(CustomTestCase):
                     "no_stop_trim": True,
                     "skip_special_tokens": False,
                 },
-                "return_logprob": True,
             },
         ).json()
         outputs_normal.append(response["text"])
-        logprobs_normal.extend(
-            [
-                round(sublist[0], 2)
-                for sublist in response["meta_info"]["output_token_logprobs"]
-            ]
-        )
 
         print("outputs from chunked queries with session control:")
         print(outputs_from_session)
         print("outputs from normal queries:")
         print(outputs_normal)
         self.assertEqual(outputs_from_session, outputs_normal)
-        print("logprobs from chunked queries with session control:")
-        print(logprobs_from_session)
-        print("logprobs from normal queries:")
-        print(logprobs_normal)
-        assert len(logprobs_from_session) == len(
-            logprobs_normal
-        ), "logprobs must have equal length"
-        for a, b in zip(logprobs_from_session, logprobs_normal):
-            assert abs(a - b) <= 0.15, f"logprobs {a} and {b} differ by more than 0.15"
 
     async def async_generate(self, payload):
         url = self.base_url + "/generate"


### PR DESCRIPTION
## Root Cause

`test_session_control` and `test_session_control_with_branching` fail deterministically on H200 GPUs in CI.

The root cause is a **piecewise cuda graph mismatch** between session mode and normal mode:
- Session mode with `return_logprob` + `logprob_start_len` triggers `piecewise_cuda_graph_runner.can_run()` to return `False` (line 421-427: `start_len < seq_len`), so session extend runs **without** piecewise cuda graph
- Normal mode with `return_logprob` (no explicit `logprob_start_len`) keeps piecewise cuda graph **enabled**
- On H200, the two computation paths produce slightly different numerical results, causing `temperature=0` greedy decoding to diverge at token boundaries

## Fix

1. Inherit `CustomTestCase` for `TestSessionControl` to enable automatic retry for remaining flakiness
2. Add `--disable-cuda-graph --disable-piecewise-cuda-graph` to the test server launch args, ensuring both session and normal paths use identical computation

## Validation

Dispatched 70 CI runs on `1-gpu-h100` runners (mixed H100/H200 pool):

**With fix** (`--disable-piecewise-cuda-graph`): **40/40 pass (0% fail rate)**

**Without fix** (main branch, piecewise cuda graph enabled): **10 pass / 20 fail (67% fail rate)**
- All failures on H200 runners, all passes on H100 runners
- Failure diff is deterministic (same output difference every time)

<details>
<summary>With fix - 40 run links (40/40 pass)</summary>


- ✅ https://github.com/sgl-project/sglang/actions/runs/23844982184
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844980556
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844978748
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844976891
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844975010
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844973265
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844971523
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844969641
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844967735
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844965902
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844964111
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844962574
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844960880
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844959129
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844957318
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844955575
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844953855
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844951808
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844950279
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844948305
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844946672
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844944990
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844943242
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844941606
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844939913
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844938229
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844936503
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844934668
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844932737
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844930927
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844770370
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844768676
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844766943
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844765221
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844763613
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844761880
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844760281
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844758623
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844756772
- ✅ https://github.com/sgl-project/sglang/actions/runs/23844754974

</details>

<details>
<summary>Without fix - 30 run links (10 pass / 20 fail)</summary>


- ✅ https://github.com/sgl-project/sglang/actions/runs/23845430405
- ❌ https://github.com/sgl-project/sglang/actions/runs/23845428061
- ❌ https://github.com/sgl-project/sglang/actions/runs/23845425945
- ❌ https://github.com/sgl-project/sglang/actions/runs/23845423560
- ❌ https://github.com/sgl-project/sglang/actions/runs/23845421404
- ❌ https://github.com/sgl-project/sglang/actions/runs/23845419401
- ✅ https://github.com/sgl-project/sglang/actions/runs/23845417289
- ❌ https://github.com/sgl-project/sglang/actions/runs/23845415013
- ✅ https://github.com/sgl-project/sglang/actions/runs/23845412732
- ✅ https://github.com/sgl-project/sglang/actions/runs/23845410833
- ✅ https://github.com/sgl-project/sglang/actions/runs/23845408591
- ❌ https://github.com/sgl-project/sglang/actions/runs/23845406519
- ❌ https://github.com/sgl-project/sglang/actions/runs/23845322918
- ❌ https://github.com/sgl-project/sglang/actions/runs/23845320674
- ❌ https://github.com/sgl-project/sglang/actions/runs/23845319005
- ✅ https://github.com/sgl-project/sglang/actions/runs/23845317343
- ✅ https://github.com/sgl-project/sglang/actions/runs/23845315512
- ✅ https://github.com/sgl-project/sglang/actions/runs/23845313781
- ❌ https://github.com/sgl-project/sglang/actions/runs/23845312020
- ❌ https://github.com/sgl-project/sglang/actions/runs/23845310197
- ❌ https://github.com/sgl-project/sglang/actions/runs/23845308257
- ❌ https://github.com/sgl-project/sglang/actions/runs/23845306140
- ❌ https://github.com/sgl-project/sglang/actions/runs/23845304272
- ✅ https://github.com/sgl-project/sglang/actions/runs/23845302302
- ❌ https://github.com/sgl-project/sglang/actions/runs/23845300345
- ❌ https://github.com/sgl-project/sglang/actions/runs/23845298414
- ❌ https://github.com/sgl-project/sglang/actions/runs/23845296587
- ❌ https://github.com/sgl-project/sglang/actions/runs/23845294872
- ❌ https://github.com/sgl-project/sglang/actions/runs/23845292969
- ✅ https://github.com/sgl-project/sglang/actions/runs/23845290797

</details>

---
*Investigated and fixed with Claude Code*