### PR TITLE
[Bugfix] Fix non-contiguous a/b tensors in GDN when num_v_heads == num_k_heads

### DIFF
--- a/python/sglang/srt/models/qwen3_next.py
+++ b/python/sglang/srt/models/qwen3_next.py
@@ -324,8 +324,8 @@ class Qwen3GatedDeltaNet(nn.Module):
         # [b, sq, ng, np/ng * hn] -> [b, sq, np, hn]
         value = value.reshape(value.size(0), -1, self.head_v_dim)
         z = z.reshape(z.size(0), -1, self.head_v_dim)
-        b = b.reshape(b.size(0), self.num_v_heads // self.attn_tp_size)
-        a = a.reshape(a.size(0), self.num_v_heads // self.attn_tp_size)
+        b = b.reshape(b.size(0), self.num_v_heads // self.attn_tp_size).contiguous()
+        a = a.reshape(a.size(0), self.num_v_heads // self.attn_tp_size).contiguous()
 
         return query, key, value, z, b, a
 

--- a/test/srt/cpu/test_gdn_contiguity.py
+++ b/test/srt/cpu/test_gdn_contiguity.py
@@ -1,0 +1,97 @@
+"""
+Regression test for the GDN ratio=1 contiguity bug.
+
+When num_v_heads == num_k_heads, fix_query_key_value_ordering produces
+non-contiguous a/b tensors unless .contiguous() is applied after reshape.
+The downstream fused_gdn_gating triton kernel assumes contiguous layout,
+so non-contiguous a/b leads to reading wrong values.
+
+This was never caught because the original Qwen3 GDN uses ratio=2
+(num_v_heads = 2 * num_k_heads), where reshape forces a contiguous copy.
+"""
+
+import types
+import unittest
+
+import torch
+
+from sglang.srt.models.qwen3_next import Qwen3GatedDeltaNet
+from sglang.test.test_utils import CustomTestCase
+
+torch.manual_seed(42)
+
+
+def make_mock(num_k_heads, num_v_heads, head_k_dim=128, head_v_dim=128, tp_size=1):
+    """Create a minimal mock with attributes fix_query_key_value_ordering needs."""
+    return types.SimpleNamespace(
+        num_k_heads=num_k_heads,
+        num_v_heads=num_v_heads,
+        head_k_dim=head_k_dim,
+        head_v_dim=head_v_dim,
+        attn_tp_size=tp_size,
+    )
+
+
+def kernel_reads_correct_values(tensor):
+    """Check whether a triton kernel assuming contiguous layout reads correct values.
+
+    The fused_gdn_gating kernel indexes with: off = i_b * NUM_HEADS + head_idx,
+    which is equivalent to reading from a contiguous [batch, num_heads] tensor.
+    """
+    num_heads = tensor.shape[1]
+    as_kernel_sees = tensor.as_strided(tensor.shape, (num_heads, 1))
+    return torch.allclose(tensor.contiguous(), as_kernel_sees)
+
+
+class TestGDNContiguity(CustomTestCase):
+    def _run_ratio(self, num_k_heads, num_v_heads):
+        head_k_dim = 128
+        head_v_dim = 128
+        seq_len = 64
+
+        proj_qkvz = num_k_heads * head_k_dim * 2 + num_v_heads * head_v_dim * 2
+        proj_ba = num_v_heads * 2
+
+        mixed_qkvz = torch.randn(seq_len, proj_qkvz)
+        mixed_ba = torch.randn(seq_len, proj_ba)
+
+        mock = make_mock(num_k_heads, num_v_heads, head_k_dim, head_v_dim)
+        query, key, value, z, b, a = Qwen3GatedDeltaNet.fix_query_key_value_ordering(
+            mock, mixed_qkvz, mixed_ba
+        )
+
+        ratio = num_v_heads // num_k_heads
+        self.assertTrue(
+            a.is_contiguous(),
+            f"ratio={ratio}: a not contiguous -- "
+            f"shape={list(a.shape)}, stride={list(a.stride())}",
+        )
+        self.assertTrue(
+            b.is_contiguous(),
+            f"ratio={ratio}: b not contiguous -- "
+            f"shape={list(b.shape)}, stride={list(b.stride())}",
+        )
+        self.assertTrue(
+            kernel_reads_correct_values(a),
+            f"ratio={ratio}: kernel reads wrong values for a",
+        )
+        self.assertTrue(
+            kernel_reads_correct_values(b),
+            f"ratio={ratio}: kernel reads wrong values for b",
+        )
+
+    def test_ratio_1(self):
+        """num_v_heads == num_k_heads -- the case that triggered the bug."""
+        self._run_ratio(num_k_heads=16, num_v_heads=16)
+
+    def test_ratio_2(self):
+        """num_v_heads == 2 * num_k_heads -- original Qwen3 GDN config."""
+        self._run_ratio(num_k_heads=16, num_v_heads=32)
+
+    def test_ratio_4(self):
+        """num_v_heads == 4 * num_k_heads."""
+        self._run_ratio(num_k_heads=16, num_v_heads=64)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #21843

## Motivation

`Qwen3GatedDeltaNet` produces incorrect results when configured with `num_v_heads == num_k_heads` (ratio=1). Models with ratio=2 and ratio=4 work as expected.

In `fix_query_key_value_ordering`, after `torch.split` on `mixed_ba` and `reshape`, the `a` and `b` tensors end up non-contiguous with strides `(2*num_k_heads, 2)` instead of `(num_v_heads, 1)`. The `fused_gdn_gating` triton kernel indexes these as flat contiguous arrays, so it reads interleaved a/b values from the packed tensor.

This only affects ratio=1 because the reshape from `[S, num_k_heads, 1]` to `[S, num_v_heads]` merely squeezes a trailing dim, preserving the non-contiguous strides. For ratio>=2 the reshape genuinely changes the shape (e.g. `[S, 16, 2]` to `[S, 32]`), which forces a contiguous copy automatically.

Likely never caught because the original Qwen3 GDN uses ratio=2 (`num_v_heads = 2 * num_k_heads`), where the bug doesn't manifest.

## Modifications

Added `.contiguous()` to `a` and `b` after reshape in `fix_query_key_value_ordering` (`python/sglang/srt/models/qwen3_next.py`). No-op for ratio>=2 (already contiguous).

## Accuracy Tests

See `test/srt/cpu/test_gdn_contiguity.py`. Tests that `a` and `b` are contiguous and readable by triton kernels assuming flat layout, for ratio 1, 2, and 4.

## Benchmarking and Profiling

No performance impact. `.contiguous()` is a no-op when the tensor is already contiguous (ratio>=2). For ratio=1 it copies a small `[seq_len, num_v_heads]` tensor.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.