### PR TITLE
[VLM] Add VLM TP=4 per-commit CI test and improve MMMU eval prompt/parser

### DIFF
--- a/python/sglang/test/simple_eval_mmmu_vlm.py
+++ b/python/sglang/test/simple_eval_mmmu_vlm.py
@@ -148,12 +148,20 @@ class MMMUVLMEval(Eval):
                     options = None
 
             # Build final textual prompt; include choices if MC
-            prompt_text = f"Question: {question}\n\n"
+            prompt_text = f"{question}\n"
             if options:
                 letters = [chr(ord("A") + i) for i in range(len(options))]
                 for letter, opt in zip(letters, options):
-                    prompt_text += f"{letter}) {opt}\n"
-            prompt_text += "\nAnswer: "
+                    prompt_text += f"{letter}. {opt}\n"
+                prompt_text += (
+                    "\nAnswer the following multiple-choice question. "
+                    "The last line of your response should be of the "
+                    "following format: 'Answer: $LETTER' (without quotes) "
+                    "where LETTER is one of the options. "
+                    "Think step by step before answering."
+                )
+            else:
+                prompt_text += "\nAnswer: "
 
             samples.append(
                 {
@@ -330,6 +338,14 @@ def _parse_multi_choice_response(
     response: str, all_choices: List[str], index2ans: dict
 ) -> str:
     # loosely adapted from benchmark mmmu eval
+
+    # First, look for explicit "Answer: X" pattern (last occurrence)
+    answer_matches = re.findall(r"[Aa]nswer\s*:\s*\*?\*?\s*\(?([A-Z])\)?", response)
+    if answer_matches:
+        candidate = answer_matches[-1]
+        if candidate in all_choices:
+            return candidate
+
     for char in [",", ".", "!", "?", ";", ":", "'"]:
         response = response.strip(char)
     response = " " + response + " "

--- a/test/registered/vlm/test_vlm_tp4.py
+++ b/test/registered/vlm/test_vlm_tp4.py
@@ -1,0 +1,82 @@
+"""
+VLM TP=4 per-commit test using Qwen3.5-27B with MMMU evaluation.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=200, suite="stage-c-test-4-gpu-h100")
+
+QWEN35_27B_MODEL = "Qwen/Qwen3.5-27B"
+MMMU_ACCURACY_THRESHOLD = 0.65
+MMMU_NUM_EXAMPLES = 32
+
+
+class TestVLMTP4(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = QWEN35_27B_MODEL
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--tp-size",
+                "4",
+                "--cuda-graph-max-bs",
+                "32",
+                "--mem-fraction-static",
+                "0.8",
+                "--trust-remote-code",
+                "--mamba-scheduler-strategy",
+                "extra_buffer",
+                "--mamba-track-interval",
+                "128",
+                "--mamba-ssm-dtype",
+                "bfloat16",
+                "--chunked-prefill-size",
+                "2048",
+                "--max-running-requests",
+                "128",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process") and cls.process:
+            kill_process_tree(cls.process.pid)
+
+    def test_mmmu_accuracy(self):
+        args = SimpleNamespace(
+            model=self.model,
+            eval_name="mmmu",
+            num_examples=MMMU_NUM_EXAMPLES,
+            num_threads=16,
+            max_tokens=2048,
+            chat_template_kwargs={"enable_thinking": False},
+            base_url=self.base_url,
+            host="http://127.0.0.1",
+            port=int(self.base_url.split(":")[-1]),
+        )
+        metrics = run_eval(args)
+        print(f"MMMU score: {metrics['score']}")
+        self.assertGreaterEqual(
+            metrics["score"],
+            MMMU_ACCURACY_THRESHOLD,
+            f"MMMU accuracy {metrics['score']:.4f} below threshold {MMMU_ACCURACY_THRESHOLD}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

  - Add Qwen3.5-27B VLM TP=4 MMMU test to stage-c-test-4-gpu-h100 per-commit CI (previously no VLM tests in any 4-GPU suite)                                                              
  - Improve MMMU eval prompt: use Kimi-style CoT instruction with explicit answer format (Answer: $LETTER), replacing the bare Answer:  prompt             
    - refernece: https://github.com/MoonshotAI/Kimi-Vendor-Verifier/tree/main                              
  - Improve MMMU answer parser: prioritize Answer: X pattern matching before falling back to bracket/space matching                                                                       
                                                                                                                                                                                          
These changes increase MMMU eval accuracy from ~0.34 (parser fallback artifacts) to ~0.75-0.78 on Qwen3.5-27B, and reduce eval latency from 145s to ~28s.   

Note: The prompt and parser changes in `simple_eval_mmmu_vlm.py` affect all tests using VLM MMMU eval , which may result in higher accuracy scores and lower eval latency. I will monitor this effect in the CI runs of this PR.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
