### PR TITLE
feat: Add flashinfer prefill context parallel support

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -452,12 +452,6 @@ class FlashInferAttnBackend(AttentionBackend):
                 "FlashInfer prefill context parallel does not support encoder-decoder / cross-attention yet."
             )
 
-    def _raise_if_prefill_cp_cuda_graph_unsupported(self, forward_mode: ForwardMode):
-        if forward_mode.is_context_parallel_extend() and self.attn_cp_size > 1:
-            raise NotImplementedError(
-                "FlashInfer prefill context parallel does not support CUDA graph yet."
-            )
-
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         if forward_batch.forward_mode.is_decode_or_idle():
             self.indices_updater_decode.update(
@@ -602,7 +596,6 @@ class FlashInferAttnBackend(AttentionBackend):
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInput],
     ):
-        self._raise_if_prefill_cp_cuda_graph_unsupported(forward_mode)
         if forward_mode.is_decode_or_idle():
             decode_wrappers = []
             for i in range(self.num_wrappers):
@@ -742,7 +735,6 @@ class FlashInferAttnBackend(AttentionBackend):
         spec_info: Optional[SpecInput],
         seq_lens_cpu: Optional[torch.Tensor],
     ):
-        self._raise_if_prefill_cp_cuda_graph_unsupported(forward_mode)
         if forward_mode.is_decode_or_idle():
             self.indices_updater_decode.update(
                 req_pool_indices[:bs],

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -434,6 +434,30 @@ class FlashInferAttnBackend(AttentionBackend):
             ),
         )
 
+    def _validate_prefill_cp_support(self, forward_batch: ForwardBatch):
+        if forward_batch.spec_info is not None:
+            raise NotImplementedError(
+                "FlashInfer prefill context parallel does not support spec_info yet."
+            )
+        if self.multi_item_scoring_delimiter is not None:
+            raise NotImplementedError(
+                "FlashInfer prefill context parallel does not support multi-item scoring yet."
+            )
+        if self.dispatch_reason == WrapperDispatch.SLIDING_WINDOW:
+            raise NotImplementedError(
+                "FlashInfer prefill context parallel does not support sliding window yet."
+            )
+        if self.dispatch_reason == WrapperDispatch.CROSS_ATTENTION:
+            raise NotImplementedError(
+                "FlashInfer prefill context parallel does not support encoder-decoder / cross-attention yet."
+            )
+
+    def _raise_if_prefill_cp_cuda_graph_unsupported(self, forward_mode: ForwardMode):
+        if forward_mode.is_context_parallel_extend() and self.attn_cp_size > 1:
+            raise NotImplementedError(
+                "FlashInfer prefill context parallel does not support CUDA graph yet."
+            )
+
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         if forward_batch.forward_mode.is_decode_or_idle():
             self.indices_updater_decode.update(
@@ -486,8 +510,9 @@ class FlashInferAttnBackend(AttentionBackend):
             is_cp_mode = (forward_batch.forward_mode.is_context_parallel_extend()
             and forward_batch.attn_cp_metadata is not None
             and self.attn_cp_size > 1)
-            
+
             if is_cp_mode:
+                self._validate_prefill_cp_support(forward_batch)
                 use_ragged = False
                 extend_no_prefix = False
             # Disable ragged wrapper and ensure prefix handling for multimodal and multi-item scoring
@@ -577,6 +602,7 @@ class FlashInferAttnBackend(AttentionBackend):
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInput],
     ):
+        self._raise_if_prefill_cp_cuda_graph_unsupported(forward_mode)
         if forward_mode.is_decode_or_idle():
             decode_wrappers = []
             for i in range(self.num_wrappers):
@@ -716,6 +742,7 @@ class FlashInferAttnBackend(AttentionBackend):
         spec_info: Optional[SpecInput],
         seq_lens_cpu: Optional[torch.Tensor],
     ):
+        self._raise_if_prefill_cp_cuda_graph_unsupported(forward_mode)
         if forward_mode.is_decode_or_idle():
             self.indices_updater_decode.update(
                 req_pool_indices[:bs],
@@ -1607,15 +1634,11 @@ class FlashInferIndicesUpdaterPrefill:
     ):
         assert forward_batch is not None
         assert forward_batch.attn_cp_metadata is not None
-        assert not use_ragged, "CP prefill for flashinfer only supports paged mode for now"
-        assert spec_info is None, "CP prefill for flashinfer does not support spec_info yet"
-        assert not use_sliding_window_kv_pool, "CP prefill for flashinfer does not support SWA yet"
-        assert multi_item_params is None or not multi_item_params.is_enabled(), (
-            "CP prefill for flashinfer does not support multi-item scoring yet"
-        )
-        assert (
-            kv_start_idx is None
-        ), "CP prefill for flashinfer does not support kv_start_idx (encoder-decoder / cross-attention) yet"
+        assert not use_ragged
+        assert spec_info is None
+        assert not use_sliding_window_kv_pool
+        assert multi_item_params is None or not multi_item_params.is_enabled()
+        assert kv_start_idx is None
 
         bs = len(seq_lens)
         assert bs == 1

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from sglang.srt.layers.utils.cp_utils import cp_allgather_and_save_kv_cache
+
 """
 Support different attention backends.
 Now there are two backends: FlashInfer and Triton.
@@ -25,8 +27,13 @@ from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.utils import create_flashinfer_kv_indices_triton
-from sglang.srt.layers.dp_attention import get_attention_tp_size
+from sglang.srt.layers.dp_attention import get_attention_cp_rank, get_attention_tp_size
 from sglang.srt.layers.radix_attention import AttentionType
+from sglang.srt.layers.utils.cp_utils import (
+    can_cp_split,
+    is_prefill_context_parallel_enabled,
+    prepare_context_parallel_metadata,
+)
 from sglang.srt.mem_cache.swa_memory_pool import SWATokenToKVPoolAllocator
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.speculative.spec_info import SpecInput
@@ -128,6 +135,12 @@ class FlashInferAttnBackend(AttentionBackend):
         super().__init__()
         self.prefill_backend = "fa2"
         self.decode_backend = "fa2"
+        self.attn_cp_size = model_runner.attn_cp_size
+        self.attn_cp_rank = (
+            model_runner.attn_cp_rank
+            if model_runner.attn_cp_rank is not None
+            else get_attention_cp_rank()
+        )
 
         # Store multi-item scoring delimiter for efficient access
         self.multi_item_scoring_delimiter = (
@@ -427,7 +440,31 @@ class FlashInferAttnBackend(AttentionBackend):
             ),
         )
 
+    def _maybe_prepare_prefill_cp_metadata(self, forward_batch: ForwardBatch):
+        if (
+            forward_batch.attn_cp_metadata is not None
+            or not is_prefill_context_parallel_enabled()
+            or not forward_batch.forward_mode.is_context_parallel_extend()
+        ):
+            return
+
+        if can_cp_split(forward_batch.seq_lens_sum, self.attn_cp_size, forward_batch):
+            logger.warning(
+                "DEBUG flashinfer cp meta prepare: seq_lens_sum=%s seq_lens_cpu=%s cp_rank=%s cp_size=%s",
+                forward_batch.seq_lens_sum,
+                forward_batch.seq_lens_cpu.tolist() if forward_batch.seq_lens_cpu is not None else None,
+                self.attn_cp_rank,
+                self.attn_cp_size,
+            )
+            forward_batch.attn_cp_metadata = prepare_context_parallel_metadata(
+                forward_batch.seq_lens_sum,
+                self.attn_cp_rank,
+                self.attn_cp_size,
+                forward_batch.seq_lens_cpu.tolist(),
+            )
+
     def init_forward_metadata(self, forward_batch: ForwardBatch):
+        self._maybe_prepare_prefill_cp_metadata(forward_batch)
         if forward_batch.forward_mode.is_decode_or_idle():
             self.indices_updater_decode.update(
                 forward_batch.req_pool_indices,
@@ -452,6 +489,7 @@ class FlashInferAttnBackend(AttentionBackend):
                 use_ragged=False,
                 encoder_lens=forward_batch.encoder_lens,
                 spec_info=forward_batch.spec_info,
+                forward_batch=forward_batch,
             )
             self.forward_metadata = PrefillMetadata(
                 self.prefill_wrappers_paged, False, False
@@ -467,6 +505,7 @@ class FlashInferAttnBackend(AttentionBackend):
                 use_ragged=False,
                 encoder_lens=forward_batch.encoder_lens,
                 spec_info=forward_batch.spec_info,
+                forward_batch=forward_batch,
             )
             self.forward_metadata = PrefillMetadata(
                 self.prefill_wrappers_verify, False, False
@@ -474,8 +513,15 @@ class FlashInferAttnBackend(AttentionBackend):
         else:
             prefix_lens = forward_batch.extend_prefix_lens
 
+            is_cp_mode = (forward_batch.forward_mode.is_context_parallel_extend()
+            and forward_batch.attn_cp_metadata is not None
+            and self.attn_cp_size > 1)
+            
+            if is_cp_mode:
+                use_ragged = False
+                extend_no_prefix = False
             # Disable ragged wrapper and ensure prefix handling for multimodal and multi-item scoring
-            if self.is_multimodal or self.multi_item_scoring_delimiter is not None:
+            elif self.is_multimodal or self.multi_item_scoring_delimiter is not None:
                 # use_ragged = False: Multi-item scoring requires the paged wrapper because:
                 # 1. Ragged wrapper doesn't support the specialized multi-item parameters
                 #    (prefix_len_ptr, token_pos_in_items_ptr, etc.)
@@ -508,6 +554,7 @@ class FlashInferAttnBackend(AttentionBackend):
                 spec_info=None,
                 fixed_split_size=self.prefill_split_tile_size,
                 multi_item_params=multi_item_params,
+                forward_batch=forward_batch,
             )
             self.forward_metadata = PrefillMetadata(
                 self.prefill_wrappers_paged,
@@ -772,6 +819,12 @@ class FlashInferAttnBackend(AttentionBackend):
             else forward_batch.encoder_out_cache_loc
         )
 
+        is_cp_mode = (
+            forward_batch.forward_mode.is_context_parallel_extend()
+            and forward_batch.attn_cp_metadata is not None
+            and self.attn_cp_size > 1
+        )
+
         logits_soft_cap = layer.logit_cap
 
         q = q.contiguous()
@@ -779,9 +832,14 @@ class FlashInferAttnBackend(AttentionBackend):
             if k is not None:
                 assert v is not None
                 if save_kv_cache:
-                    forward_batch.token_to_kv_pool.set_kv_buffer(
-                        layer, cache_loc, k, v, layer.k_scale, layer.v_scale
-                    )
+                    if is_cp_mode:
+                        cp_allgather_and_save_kv_cache(
+                            forward_batch, layer, k, v, self.attn_cp_size
+                        )
+                    else:
+                        forward_batch.token_to_kv_pool.set_kv_buffer(
+                            layer, cache_loc, k, v, layer.k_scale, layer.v_scale
+                        )
 
             o = prefill_wrapper_paged.forward(
                 q.view(-1, layer.tp_q_head_num, layer.head_dim),
@@ -886,6 +944,16 @@ class FlashInferAttnBackend(AttentionBackend):
             if not layer.is_cross_attention
             else forward_batch.encoder_out_cache_loc
         )
+        if (
+            cache_loc is not None
+            and k is not None
+            and self.attn_cp_size > 1
+            and cache_loc.numel() != k.shape[0]
+            and cache_loc.numel() == k.shape[0] * self.attn_cp_size
+        ):
+            cache_loc = cache_loc.view(k.shape[0], self.attn_cp_size)[
+                :, self.attn_cp_rank
+            ].contiguous()
 
         if k is not None:
             assert v is not None
@@ -1196,6 +1264,7 @@ class FlashInferIndicesUpdaterPrefill:
         self.q_data_type = model_runner.dtype
         self.sliding_window_size = model_runner.sliding_window_size
         self.attn_backend = attn_backend
+        self.attn_cp_size = attn_backend.attn_cp_size
         self.page_size = attn_backend.page_size
 
         # Buffers and wrappers
@@ -1227,6 +1296,7 @@ class FlashInferIndicesUpdaterPrefill:
         encoder_lens: Optional[torch.Tensor],
         spec_info: Optional[SpecInput],
         fixed_split_size: Optional[int] = None,
+        multi_item_params: Optional[MultiItemScoringParams] = None,
     ):
         # Keep the signature for type checking. It will be assigned during runtime.
         raise NotImplementedError()
@@ -1244,6 +1314,7 @@ class FlashInferIndicesUpdaterPrefill:
         spec_info: Optional[SpecInput],
         fixed_split_size: Optional[int] = None,
         multi_item_params: Optional[MultiItemScoringParams] = None,
+        forward_batch: Optional[ForwardBatch] = None,
     ):
         if use_ragged:
             # TODO: remove this device sync, we can use forward_batch.extend_prefix_lens_cpu
@@ -1269,6 +1340,7 @@ class FlashInferIndicesUpdaterPrefill:
             spec_info,
             fixed_split_size=fixed_split_size,
             multi_item_params=multi_item_params,
+            forward_batch=forward_batch
         )
 
     def update_sliding_window(
@@ -1284,6 +1356,7 @@ class FlashInferIndicesUpdaterPrefill:
         spec_info: Optional[SpecInput],
         fixed_split_size: Optional[int] = None,
         multi_item_params: Optional[MultiItemScoringParams] = None,
+        forward_batch: Optional[ForwardBatch] = None,
     ):
         for wrapper_id in range(2):
             if wrapper_id == 0:
@@ -1318,6 +1391,7 @@ class FlashInferIndicesUpdaterPrefill:
                 spec_info,
                 use_sliding_window_kv_pool=use_sliding_window_kv_pool,
                 multi_item_params=multi_item_params,
+                forward_batch=forward_batch
             )
 
     def update_cross_attention(
@@ -1333,6 +1407,7 @@ class FlashInferIndicesUpdaterPrefill:
         spec_info: Optional[SpecInput],
         fixed_split_size: Optional[int] = None,
         multi_item_params: Optional[MultiItemScoringParams] = None,
+        forward_batch: Optional[ForwardBatch] = None,
     ):
         for wrapper_id in range(2):
             if wrapper_id == 0:
@@ -1360,6 +1435,7 @@ class FlashInferIndicesUpdaterPrefill:
                 use_ragged,
                 spec_info,
                 multi_item_params=multi_item_params,
+                forward_batch=forward_batch
             )
 
     def call_begin_forward(
@@ -1379,7 +1455,31 @@ class FlashInferIndicesUpdaterPrefill:
         use_sliding_window_kv_pool: bool = False,
         fixed_split_size: Optional[int] = None,
         multi_item_params: Optional[MultiItemScoringParams] = None,
+        forward_batch: Optional[ForwardBatch] = None,
     ):
+        if (
+            forward_batch is not None and
+            forward_batch.forward_mode.is_context_parallel_extend()
+            and forward_batch.attn_cp_metadata is not None
+            and self.attn_cp_size > 1):
+            return self.call_begin_forward_cp(
+                wrapper_ragged,
+                wrapper_paged,
+                req_pool_indices,
+                paged_kernel_lens,
+                paged_kernel_lens_sum,
+                seq_lens,
+                prefix_lens,
+                kv_start_idx,
+                kv_indptr,
+                qo_indptr,
+                use_ragged,
+                spec_info,
+                use_sliding_window_kv_pool,
+                fixed_split_size,
+                multi_item_params,
+                forward_batch
+            )
         bs = len(seq_lens)
         if spec_info is None:
             assert len(seq_lens) == len(req_pool_indices)
@@ -1489,6 +1589,153 @@ class FlashInferIndicesUpdaterPrefill:
             token_pos_in_items_ptr = None
             token_pos_in_items_len = 0
             max_item_len_ptr = None
+
+        wrapper_paged.begin_forward(
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            self.kv_last_page_len[:bs_eff],
+            self.num_qo_heads,
+            self.num_kv_heads,
+            self.head_dim,
+            1,
+            q_data_type=self.q_data_type,
+            kv_data_type=self.data_type,
+            custom_mask=use_custom_mask,
+            non_blocking=True,
+            fixed_split_size=fixed_split_size,
+            prefix_len_ptr=prefix_len_ptr,
+            token_pos_in_items_ptr=token_pos_in_items_ptr,
+            token_pos_in_items_len=token_pos_in_items_len,
+            max_item_len_ptr=max_item_len_ptr,
+        )
+    
+    def call_begin_forward_cp(
+        self,
+        wrapper_ragged: BatchPrefillWithRaggedKVCacheWrapper,
+        wrapper_paged: BatchPrefillWithPagedKVCacheWrapper,
+        req_pool_indices: torch.Tensor,
+        paged_kernel_lens: torch.Tensor,
+        paged_kernel_lens_sum: int,
+        seq_lens: torch.Tensor,
+        prefix_lens: torch.Tensor,
+        kv_start_idx: torch.Tensor,
+        kv_indptr: torch.Tensor,
+        qo_indptr: torch.Tensor,
+        use_ragged: bool,
+        spec_info: Optional[SpecInput],
+        use_sliding_window_kv_pool: bool = False,
+        fixed_split_size: Optional[int] = None,
+        multi_item_params: Optional[MultiItemScoringParams] = None,
+        forward_batch: Optional[ForwardBatch] = None,
+    ):
+        assert forward_batch is not None
+        assert forward_batch.attn_cp_metadata is not None
+        assert not use_ragged, "CP prefill for flashinfer only supports paged mode for now"
+        assert spec_info is None, "CP prefill for flashinfer does not support spec_info yet"
+        assert not use_sliding_window_kv_pool, "CP prefill for flashinfer does not support SWA yet"
+        assert multi_item_params is None or not multi_item_params.is_enabled(), (
+            "CP prefill for flashinfer does not support multi-item scoring yet"
+        )
+
+        bs = len(seq_lens)
+        assert bs == 1
+        device = req_pool_indices.device
+        actual_seq_q_prev = forward_batch.attn_cp_metadata.actual_seq_q_prev
+        actual_seq_q_next = forward_batch.attn_cp_metadata.actual_seq_q_next
+        kv_len_prev = forward_batch.attn_cp_metadata.kv_len_prev
+        kv_len_next = forward_batch.attn_cp_metadata.kv_len_next
+        # assert len(seq_lens) == len(req_pool_indices)
+        # Normal extend
+        kv_indptr = torch.tensor([0, kv_len_prev, kv_len_prev + kv_len_next], dtype=torch.int32, device=kv_indptr.device)
+        # Reserve extra space in kv_indices for a potential piecewise CUDA graph
+        # dummy request (see below). Worst case: static_num_tokens extra pages.
+        fwd_ctx = get_forward_context()
+        pcg_num_tokens = fwd_ctx.num_tokens if fwd_ctx is not None else None
+        extra_kv = pcg_num_tokens if pcg_num_tokens is not None else 0
+        kv_total = kv_len_prev + kv_len_next
+        kv_indices = torch.empty(
+            kv_total + extra_kv + 256,
+            dtype=torch.int32,
+            device=device,
+        )
+        bs_cp = 2
+        req_idx = req_pool_indices[0]
+        req_pool_indices_cp = torch.tensor(
+            [req_idx, req_idx],
+            dtype=req_pool_indices.dtype,
+            device=device,
+        )
+        paged_kernel_lens_cp = torch.tensor(
+            [kv_len_prev, kv_len_next],
+            dtype=torch.int32,
+            device=device,
+        )
+
+        kv_start_idx_cp = torch.zeros(
+            2,
+            dtype=torch.int32,
+            device=device,
+        )
+
+        create_flashinfer_kv_indices_triton[(bs_cp,)](
+            self.req_to_token,
+            req_pool_indices_cp,
+            paged_kernel_lens_cp,
+            kv_indptr,
+            kv_start_idx_cp,
+            kv_indices,
+            self.req_to_token.shape[1],
+        )
+        qo_indptr = torch.tensor([0, actual_seq_q_prev, actual_seq_q_prev + actual_seq_q_next],dtype = torch.int32, device=qo_indptr.device)
+
+        # Piecewise CUDA graph padding: input_ids are padded to static_num_tokens,
+        # so q.shape[0] == static_num_tokens but qo_indptr[-1] == actual tokens.
+        # Append a dummy request for the padding tokens so that
+        # qo_indptr[-1] == static_num_tokens, satisfying flashinfer's shape check
+        # without corrupting the causal masks of real requests.
+        # The dummy request's KV indices all point to slot 0 (a scratch location);
+        # its attention output is discarded via the [:raw_num_tokens] slice in replay.
+        bs_eff = bs_cp
+        # extend_num_tokens is a Python int (== sum of seq_lens - prefix_lens),
+        # and paged_kernel_lens_sum is also a Python int (== kv_indptr[-1]),
+        # so this block requires no CPU-GPU synchronisation.
+        actual_qo_tokens = (
+            actual_seq_q_prev + actual_seq_q_next
+        )
+        custom_mask = None
+        if (
+            pcg_num_tokens is not None
+            and actual_qo_tokens is not None
+            and pcg_num_tokens > actual_qo_tokens
+        ):
+            pad_tokens = pcg_num_tokens - actual_qo_tokens
+            num_dummy_pages = (pad_tokens + self.page_size - 1) // self.page_size
+            kv_start = (
+                kv_total  # equals kv_indptr[-1], no .item() needed
+            )
+            kv_indices[kv_start : kv_start + num_dummy_pages] = 0
+            qo_indptr = torch.cat(
+                [qo_indptr, qo_indptr.new_tensor([pcg_num_tokens])]
+            )
+            kv_indptr = torch.cat(
+                [kv_indptr, kv_indptr.new_tensor([kv_start + num_dummy_pages])]
+            )
+            bs_eff = bs_cp + 1
+
+        if use_sliding_window_kv_pool:
+            kv_last_index = kv_indptr[-1]
+            kv_indices[:kv_last_index] = (
+                self.token_to_kv_pool_allocator.translate_loc_from_full_to_swa(
+                    kv_indices[:kv_last_index]
+                )
+            )
+        
+        use_custom_mask = custom_mask
+        prefix_len_ptr = None
+        token_pos_in_items_ptr = None
+        token_pos_in_items_len = 0
+        max_item_len_ptr = None
 
         wrapper_paged.begin_forward(
             qo_indptr,
@@ -1637,6 +1884,13 @@ class FlashInferMultiStepDraftBackend:
             )
 
     def init_forward_metadata_capture_cuda_graph(self, forward_batch: ForwardBatch):
+        is_cp_mode = (forward_batch.forward_mode.is_context_parallel_extend()
+            and forward_batch.attn_cp_metadata is not None
+            and self.attn_cp_size > 1)
+        if is_cp_mode:
+            raise NotImplementedError(
+                "FlashInfer prefill context parallel does not support CUDA graph yet."
+            )
         def call_fn(i, forward_batch):
             self.attn_backends[i].init_forward_metadata_capture_cuda_graph(
                 forward_batch.batch_size,
@@ -1653,6 +1907,13 @@ class FlashInferMultiStepDraftBackend:
     def init_forward_metadata_replay_cuda_graph(
         self, forward_batch: ForwardBatch, bs: int
     ):
+        is_cp_mode = (forward_batch.forward_mode.is_context_parallel_extend()
+            and forward_batch.attn_cp_metadata is not None
+            and self.attn_cp_size > 1)
+        if is_cp_mode:
+            raise NotImplementedError(
+                "FlashInfer prefill context parallel does not support CUDA graph yet."
+            )
         def call_fn(i, forward_batch):
             self.attn_backends[i].init_forward_metadata_replay_cuda_graph(
                 bs,

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -29,11 +29,6 @@ from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.utils import create_flashinfer_kv_indices_triton
 from sglang.srt.layers.dp_attention import get_attention_cp_rank, get_attention_tp_size
 from sglang.srt.layers.radix_attention import AttentionType
-from sglang.srt.layers.utils.cp_utils import (
-    can_cp_split,
-    is_prefill_context_parallel_enabled,
-    prepare_context_parallel_metadata,
-)
 from sglang.srt.mem_cache.swa_memory_pool import SWATokenToKVPoolAllocator
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.speculative.spec_info import SpecInput
@@ -440,31 +435,7 @@ class FlashInferAttnBackend(AttentionBackend):
             ),
         )
 
-    def _maybe_prepare_prefill_cp_metadata(self, forward_batch: ForwardBatch):
-        if (
-            forward_batch.attn_cp_metadata is not None
-            or not is_prefill_context_parallel_enabled()
-            or not forward_batch.forward_mode.is_context_parallel_extend()
-        ):
-            return
-
-        if can_cp_split(forward_batch.seq_lens_sum, self.attn_cp_size, forward_batch):
-            logger.warning(
-                "DEBUG flashinfer cp meta prepare: seq_lens_sum=%s seq_lens_cpu=%s cp_rank=%s cp_size=%s",
-                forward_batch.seq_lens_sum,
-                forward_batch.seq_lens_cpu.tolist() if forward_batch.seq_lens_cpu is not None else None,
-                self.attn_cp_rank,
-                self.attn_cp_size,
-            )
-            forward_batch.attn_cp_metadata = prepare_context_parallel_metadata(
-                forward_batch.seq_lens_sum,
-                self.attn_cp_rank,
-                self.attn_cp_size,
-                forward_batch.seq_lens_cpu.tolist(),
-            )
-
     def init_forward_metadata(self, forward_batch: ForwardBatch):
-        self._maybe_prepare_prefill_cp_metadata(forward_batch)
         if forward_batch.forward_mode.is_decode_or_idle():
             self.indices_updater_decode.update(
                 forward_batch.req_pool_indices,

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from sglang.srt.layers.utils.cp_utils import cp_allgather_and_save_kv_cache
-
 """
 Support different attention backends.
 Now there are two backends: FlashInfer and Triton.
@@ -29,6 +27,7 @@ from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.utils import create_flashinfer_kv_indices_triton
 from sglang.srt.layers.dp_attention import get_attention_cp_rank, get_attention_tp_size
 from sglang.srt.layers.radix_attention import AttentionType
+from sglang.srt.layers.utils.cp_utils import cp_allgather_and_save_kv_cache
 from sglang.srt.mem_cache.swa_memory_pool import SWATokenToKVPoolAllocator
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.speculative.spec_info import SpecInput
@@ -1429,10 +1428,16 @@ class FlashInferIndicesUpdaterPrefill:
         forward_batch: Optional[ForwardBatch] = None,
     ):
         if (
-            forward_batch is not None and
-            forward_batch.forward_mode.is_context_parallel_extend()
+            forward_batch is not None
+            and kv_start_idx is None
+            and not use_ragged
+            and spec_info is None
+            and not use_sliding_window_kv_pool
+            and (multi_item_params is None or not multi_item_params.is_enabled())
+            and forward_batch.forward_mode.is_context_parallel_extend()
             and forward_batch.attn_cp_metadata is not None
-            and self.attn_cp_size > 1):
+            and self.attn_cp_size > 1
+        ):
             return self.call_begin_forward_cp(
                 wrapper_ragged,
                 wrapper_paged,
@@ -1608,6 +1613,9 @@ class FlashInferIndicesUpdaterPrefill:
         assert multi_item_params is None or not multi_item_params.is_enabled(), (
             "CP prefill for flashinfer does not support multi-item scoring yet"
         )
+        assert (
+            kv_start_idx is None
+        ), "CP prefill for flashinfer does not support kv_start_idx (encoder-decoder / cross-attention) yet"
 
         bs = len(seq_lens)
         assert bs == 1
@@ -1616,21 +1624,37 @@ class FlashInferIndicesUpdaterPrefill:
         actual_seq_q_next = forward_batch.attn_cp_metadata.actual_seq_q_next
         kv_len_prev = forward_batch.attn_cp_metadata.kv_len_prev
         kv_len_next = forward_batch.attn_cp_metadata.kv_len_next
-        # assert len(seq_lens) == len(req_pool_indices)
-        # Normal extend
-        kv_indptr = torch.tensor([0, kv_len_prev, kv_len_prev + kv_len_next], dtype=torch.int32, device=kv_indptr.device)
+        assert len(seq_lens) == len(req_pool_indices)
+
+        # FlashInfer's prefill wrapper plans work per batch item. Under CP, each
+        # *real* request is split into (prev, next) query chunks on each rank.
+        # We represent these two chunks as two *virtual* requests so that the
+        # wrapper can plan different (qo_len, visible_kv_len) for each chunk.
+        bs_cp = 2
+        kv_total = kv_len_prev + kv_len_next
+        actual_qo_tokens = actual_seq_q_prev + actual_seq_q_next
+
+        # Write into the provided buffers to match non-CP behaviour.
+        kv_indptr_buf = kv_indptr[: bs_cp + 1]
+        kv_indptr_buf[0] = 0
+        kv_indptr_buf[1] = kv_len_prev
+        kv_indptr_buf[2] = kv_total
+
+        qo_indptr_buf = qo_indptr[: bs_cp + 1]
+        qo_indptr_buf[0] = 0
+        qo_indptr_buf[1] = actual_seq_q_prev
+        qo_indptr_buf[2] = actual_qo_tokens
+
         # Reserve extra space in kv_indices for a potential piecewise CUDA graph
         # dummy request (see below). Worst case: static_num_tokens extra pages.
         fwd_ctx = get_forward_context()
         pcg_num_tokens = fwd_ctx.num_tokens if fwd_ctx is not None else None
         extra_kv = pcg_num_tokens if pcg_num_tokens is not None else 0
-        kv_total = kv_len_prev + kv_len_next
         kv_indices = torch.empty(
             kv_total + extra_kv + 256,
             dtype=torch.int32,
             device=device,
         )
-        bs_cp = 2
         req_idx = req_pool_indices[0]
         req_pool_indices_cp = torch.tensor(
             [req_idx, req_idx],
@@ -1653,12 +1677,11 @@ class FlashInferIndicesUpdaterPrefill:
             self.req_to_token,
             req_pool_indices_cp,
             paged_kernel_lens_cp,
-            kv_indptr,
+            kv_indptr_buf,
             kv_start_idx_cp,
             kv_indices,
             self.req_to_token.shape[1],
         )
-        qo_indptr = torch.tensor([0, actual_seq_q_prev, actual_seq_q_prev + actual_seq_q_next],dtype = torch.int32, device=qo_indptr.device)
 
         # Piecewise CUDA graph padding: input_ids are padded to static_num_tokens,
         # so q.shape[0] == static_num_tokens but qo_indptr[-1] == actual tokens.
@@ -1668,12 +1691,6 @@ class FlashInferIndicesUpdaterPrefill:
         # The dummy request's KV indices all point to slot 0 (a scratch location);
         # its attention output is discarded via the [:raw_num_tokens] slice in replay.
         bs_eff = bs_cp
-        # extend_num_tokens is a Python int (== sum of seq_lens - prefix_lens),
-        # and paged_kernel_lens_sum is also a Python int (== kv_indptr[-1]),
-        # so this block requires no CPU-GPU synchronisation.
-        actual_qo_tokens = (
-            actual_seq_q_prev + actual_seq_q_next
-        )
         custom_mask = None
         if (
             pcg_num_tokens is not None
@@ -1686,12 +1703,11 @@ class FlashInferIndicesUpdaterPrefill:
                 kv_total  # equals kv_indptr[-1], no .item() needed
             )
             kv_indices[kv_start : kv_start + num_dummy_pages] = 0
-            qo_indptr = torch.cat(
-                [qo_indptr, qo_indptr.new_tensor([pcg_num_tokens])]
-            )
-            kv_indptr = torch.cat(
-                [kv_indptr, kv_indptr.new_tensor([kv_start + num_dummy_pages])]
-            )
+            # Use the next slots in the buffers to avoid allocating new tensors.
+            qo_indptr_buf = qo_indptr[: bs_cp + 2]
+            kv_indptr_buf = kv_indptr[: bs_cp + 2]
+            qo_indptr_buf[bs_cp + 1] = pcg_num_tokens
+            kv_indptr_buf[bs_cp + 1] = kv_start + num_dummy_pages
             bs_eff = bs_cp + 1
 
         if use_sliding_window_kv_pool:
@@ -1709,8 +1725,8 @@ class FlashInferIndicesUpdaterPrefill:
         max_item_len_ptr = None
 
         wrapper_paged.begin_forward(
-            qo_indptr,
-            kv_indptr,
+            qo_indptr_buf[: bs_eff + 1],
+            kv_indptr_buf[: bs_eff + 1],
             kv_indices,
             self.kv_last_page_len[:bs_eff],
             self.num_qo_heads,

--- a/python/sglang/srt/layers/utils/cp_utils.py
+++ b/python/sglang/srt/layers/utils/cp_utils.py
@@ -247,6 +247,34 @@ def cp_all_gather_rerange_kv_cache(input_tensor, cp_size, forward_batch, stream)
     return output_tensor
 
 
+def cp_all_gather_rerange_cache_loc(cache_loc, cp_size, forward_batch):
+    max_len = (forward_batch.attn_cp_metadata.total_seq_lens + cp_size - 1) // cp_size
+    pad_size = max_len - cache_loc.shape[0]
+    if pad_size > 0:
+        cache_loc = F.pad(cache_loc, (0, pad_size), mode="constant", value=0)
+
+    cache_loc_full = get_attention_cp_group().all_gather(cache_loc, dim=0)
+    outputs_list_max = list(
+        torch.split(cache_loc_full, forward_batch.attn_cp_metadata.max_rank_len, dim=0)
+    )
+    outputs = torch.cat(
+        [
+            outputs_list_max[index][:per_rank_len]
+            for index, per_rank_len in enumerate(
+                forward_batch.attn_cp_metadata.per_rank_actual_token
+            )
+        ],
+        dim=0,
+    )
+    outputs_list = list(
+        torch.split(outputs, forward_batch.attn_cp_metadata.reverse_split_len, dim=0)
+    )
+    return torch.cat(
+        [outputs_list[i] for i in forward_batch.attn_cp_metadata.cp_reverse_index],
+        dim=0,
+    )
+
+
 def cp_allgather_and_save_kv_cache(forward_batch, layer, k, v, cp_size):
     """
     Allgather KV cache from all CP ranks and write the full result
@@ -267,15 +295,24 @@ def cp_allgather_and_save_kv_cache(forward_batch, layer, k, v, cp_size):
     value_cache_full = cp_all_gather_rerange_kv_cache(
         v, cp_size, forward_batch, torch.cuda.current_stream()
     )
+    if cache_loc.shape[0] == key_cache_full.shape[0]:
+        cache_loc_full = cache_loc
+    else:
+        cache_loc_full = cp_all_gather_rerange_cache_loc(
+            cache_loc, cp_size, forward_batch
+        )
+    token_to_kv_pool = forward_batch.token_to_kv_pool
+    if key_cache_full.dtype != token_to_kv_pool.dtype:
+        if layer.k_scale is not None:
+            key_cache_full = key_cache_full / layer.k_scale
+        if layer.v_scale is not None:
+            value_cache_full = value_cache_full / layer.v_scale
+        key_cache_full = key_cache_full.to(token_to_kv_pool.dtype)
+        value_cache_full = value_cache_full.to(token_to_kv_pool.dtype)
 
-    forward_batch.token_to_kv_pool.set_kv_buffer(
-        layer,
-        cache_loc,
-        key_cache_full,
-        value_cache_full,
-        layer.k_scale,
-        layer.v_scale,
-    )
+    key_buffer, value_buffer = token_to_kv_pool.get_kv_buffer(layer.layer_id)
+    key_buffer[cache_loc_full] = key_cache_full
+    value_buffer[cache_loc_full] = value_cache_full
 
 
 def cp_attn_forward_extend(

--- a/python/sglang/srt/layers/utils/cp_utils.py
+++ b/python/sglang/srt/layers/utils/cp_utils.py
@@ -247,34 +247,6 @@ def cp_all_gather_rerange_kv_cache(input_tensor, cp_size, forward_batch, stream)
     return output_tensor
 
 
-def cp_all_gather_rerange_cache_loc(cache_loc, cp_size, forward_batch):
-    max_len = (forward_batch.attn_cp_metadata.total_seq_lens + cp_size - 1) // cp_size
-    pad_size = max_len - cache_loc.shape[0]
-    if pad_size > 0:
-        cache_loc = F.pad(cache_loc, (0, pad_size), mode="constant", value=0)
-
-    cache_loc_full = get_attention_cp_group().all_gather(cache_loc, dim=0)
-    outputs_list_max = list(
-        torch.split(cache_loc_full, forward_batch.attn_cp_metadata.max_rank_len, dim=0)
-    )
-    outputs = torch.cat(
-        [
-            outputs_list_max[index][:per_rank_len]
-            for index, per_rank_len in enumerate(
-                forward_batch.attn_cp_metadata.per_rank_actual_token
-            )
-        ],
-        dim=0,
-    )
-    outputs_list = list(
-        torch.split(outputs, forward_batch.attn_cp_metadata.reverse_split_len, dim=0)
-    )
-    return torch.cat(
-        [outputs_list[i] for i in forward_batch.attn_cp_metadata.cp_reverse_index],
-        dim=0,
-    )
-
-
 def cp_allgather_and_save_kv_cache(forward_batch, layer, k, v, cp_size):
     """
     Allgather KV cache from all CP ranks and write the full result
@@ -295,25 +267,14 @@ def cp_allgather_and_save_kv_cache(forward_batch, layer, k, v, cp_size):
     value_cache_full = cp_all_gather_rerange_kv_cache(
         v, cp_size, forward_batch, torch.cuda.current_stream()
     )
-    if cache_loc.shape[0] == key_cache_full.shape[0]:
-        cache_loc_full = cache_loc
-    else:
-        cache_loc_full = cp_all_gather_rerange_cache_loc(
-            cache_loc, cp_size, forward_batch
-        )
-    token_to_kv_pool = forward_batch.token_to_kv_pool
-    if key_cache_full.dtype != token_to_kv_pool.dtype:
-        if layer.k_scale is not None:
-            key_cache_full = key_cache_full / layer.k_scale
-        if layer.v_scale is not None:
-            value_cache_full = value_cache_full / layer.v_scale
-        key_cache_full = key_cache_full.to(token_to_kv_pool.dtype)
-        value_cache_full = value_cache_full.to(token_to_kv_pool.dtype)
-
-    key_buffer, value_buffer = token_to_kv_pool.get_kv_buffer(layer.layer_id)
-    key_buffer[cache_loc_full] = key_cache_full
-    value_buffer[cache_loc_full] = value_cache_full
-
+    forward_batch.token_to_kv_pool.set_kv_buffer(
+        layer,
+        cache_loc,
+        key_cache_full,
+        value_cache_full,
+        layer.k_scale,
+        layer.v_scale,
+    )
 
 def cp_attn_forward_extend(
     forward_batch,

--- a/python/sglang/test/attention/test_flashinfer_backend.py
+++ b/python/sglang/test/attention/test_flashinfer_backend.py
@@ -179,7 +179,12 @@ def _setup_prefix_kv_cache(
     if prefix_k.numel() == 0:
         return
 
-    cache_loc = torch.arange(prefix_k.shape[0], device=prefix_k.device)
+    # Keep the same "slot id" convention as req_to_token_pool in this test:
+    # token position t is stored at slot (t + page_size).
+    cache_loc = (
+        torch.arange(prefix_k.shape[0], device=prefix_k.device, dtype=torch.int32)
+        + token_to_kv_pool.page_size
+    )
     token_to_kv_pool.set_kv_buffer(
         layer,
         cache_loc,
@@ -197,6 +202,7 @@ def _run_flashinfer_cp_worker(
     prefix_len: int,
     num_heads: int,
     head_dim: int,
+    page_size: int = 1,
 ):
     torch.cuda.set_device(rank)
     device = f"cuda:{rank}"
@@ -206,7 +212,7 @@ def _run_flashinfer_cp_worker(
     model_runner = MockModelRunner(
         rank=rank,
         world_size=world_size,
-        page_size=1,
+        page_size=page_size,
         num_heads=num_heads,
         head_dim=head_dim,
     )
@@ -247,8 +253,11 @@ def _run_flashinfer_cp_worker(
         local_q = _split_for_cp(full_q, cp_meta)
         local_k = _split_for_cp(full_k, cp_meta)
         local_v = _split_for_cp(full_v, cp_meta)
-        full_cache_loc = torch.arange(
-            prefix_len, total_len, dtype=torch.int32, device=device
+        # Keep out_cache_loc consistent with req_to_token: token position t maps to
+        # slot (t + page_size).
+        full_cache_loc = (
+            torch.arange(prefix_len, total_len, dtype=torch.int32, device=device)
+            + page_size
         )
 
         _setup_prefix_kv_cache(model_runner.token_to_kv_pool, layer, prefix_k, prefix_v)
@@ -256,7 +265,7 @@ def _run_flashinfer_cp_worker(
         ref_forward_batch = _build_forward_batch(
             ref_backend,
             input_ids=torch.randint(0, 100, (1, q_len), device=device),
-            out_cache_loc=torch.arange(prefix_len, total_len, dtype=torch.int32, device=device),
+            out_cache_loc=full_cache_loc,
             seq_len=total_len,
             extend_len=q_len,
             prefix_len=prefix_len,
@@ -335,6 +344,21 @@ class TestFlashInferBackend(CustomTestCase):
             prefix_len=64,
             num_heads=8,
             head_dim=64,
+        )
+
+    def test_forward_extend_cp_with_prefix_page_size_16(self):
+        if torch.cuda.device_count() < 2:
+            self.skipTest("FlashInfer CP test requires at least 2 GPUs")
+
+        run_distributed_test(
+            _run_flashinfer_cp_worker,
+            world_size=2,
+            backend="nccl",
+            q_len=128,
+            prefix_len=64,
+            num_heads=8,
+            head_dim=64,
+            page_size=16,
         )
 
 

--- a/python/sglang/test/attention/test_flashinfer_backend.py
+++ b/python/sglang/test/attention/test_flashinfer_backend.py
@@ -1,0 +1,341 @@
+import unittest
+from unittest.mock import patch
+
+import torch
+import torch.distributed as dist
+
+from sglang.srt.configs.model_config import AttentionArch
+from sglang.srt.layers.attention.flashinfer_backend import FlashInferAttnBackend
+from sglang.srt.layers.attention.torch_native_backend import TorchNativeAttnBackend
+from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.layers.utils.cp_utils import prepare_context_parallel_metadata
+from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.utils import is_flashinfer_available
+from sglang.test.test_utils import CustomTestCase, run_distributed_test
+
+
+class MockModelRunner:
+    def __init__(
+        self,
+        rank: int,
+        world_size: int,
+        page_size: int = 1,
+        num_heads: int = 2,
+        head_dim: int = 8,
+    ):
+        self.device = f"cuda:{rank}"
+        self.dtype = torch.float16
+        self.kv_cache_dtype = torch.float16
+        self.is_hybrid_swa = False
+        self.attention_chunk_size = None
+        self.attn_cp_size = world_size
+        self.attn_cp_rank = rank
+        self.page_size = page_size
+        self.sliding_window_size = None
+        self.token_to_kv_pool_allocator = None
+
+        max_batch_size = 8
+        max_context_len = 2048
+
+        hf_config = type(
+            "HFConfig",
+            (),
+            {
+                "architectures": ["LlamaForCausalLM"],
+            },
+        )()
+
+        self.model_config = type(
+            "ModelConfig",
+            (),
+            {
+                "context_len": max_context_len,
+                "is_multimodal": False,
+                "attention_arch": AttentionArch.MHA,
+                "is_encoder_decoder": False,
+                "is_local_attention_model": False,
+                "num_attention_heads": num_heads,
+                "head_dim": head_dim,
+                "hf_config": hf_config,
+                "get_num_kv_heads": lambda _self, _tp_size: num_heads,
+            },
+        )()
+
+        self.server_args = type(
+            "ServerArgs",
+            (),
+            {
+                "kv_cache_dtype": "auto",
+                "speculative_eagle_topk": None,
+                "speculative_num_draft_tokens": 0,
+                "enable_deterministic_inference": False,
+                "multi_item_scoring_delimiter": None,
+                "disable_piecewise_cuda_graph": True,
+                "dllm_algorithm": None,
+                "dllm_algorithm_config": None,
+                "max_running_requests": None,
+                "model_path": None,
+                "revision": None,
+            },
+        )()
+
+        self.req_to_token_pool = type(
+            "TokenPool",
+            (),
+            {
+                "size": max_batch_size,
+                "req_to_token": torch.zeros(
+                    max_batch_size,
+                    max_context_len,
+                    dtype=torch.int32,
+                    device=self.device,
+                ),
+            },
+        )()
+
+        self.token_to_kv_pool = MHATokenToKVPool(
+            size=max_batch_size * max_context_len,
+            page_size=page_size,
+            dtype=self.dtype,
+            head_num=num_heads,
+            head_dim=head_dim,
+            layer_num=1,
+            device=self.device,
+            enable_memory_saver=False,
+        )
+
+
+class _FakeCPGroup:
+    def cp_all_gather_into_tensor_async(self, output, input_tensor, _stream):
+        if hasattr(dist, "all_gather_into_tensor"):
+            dist.all_gather_into_tensor(output, input_tensor.contiguous())
+            return
+
+        gathered = [torch.empty_like(input_tensor) for _ in range(dist.get_world_size())]
+        dist.all_gather(gathered, input_tensor.contiguous())
+        output.copy_(torch.cat(gathered, dim=0))
+
+    def all_gather(self, input_tensor, dim=0):
+        gathered = [torch.empty_like(input_tensor) for _ in range(dist.get_world_size())]
+        dist.all_gather(gathered, input_tensor.contiguous())
+        return torch.cat(gathered, dim=dim)
+
+
+def _split_for_cp(tensor: torch.Tensor, cp_meta) -> torch.Tensor:
+    pieces = list(torch.split(tensor, cp_meta.split_list, dim=0))
+    return torch.cat([pieces[i] for i in cp_meta.zigzag_index], dim=0).contiguous()
+
+
+def _write_req_to_token(model_runner: MockModelRunner, seq_len: int):
+    req_to_token = (
+        torch.arange(0, 1, dtype=torch.int32, device=model_runner.device)[:, None]
+        * seq_len
+        + torch.arange(0, seq_len, dtype=torch.int32, device=model_runner.device)[None, :]
+        + model_runner.page_size
+    )
+    model_runner.req_to_token_pool.req_to_token[:1, :seq_len] = req_to_token
+
+
+def _build_forward_batch(
+    backend,
+    input_ids: torch.Tensor,
+    out_cache_loc: torch.Tensor,
+    seq_len: int,
+    extend_len: int,
+    prefix_len: int,
+    token_to_kv_pool: MHATokenToKVPool,
+    req_to_token_pool,
+    cp_meta=None,
+):
+    forward_batch = ForwardBatch(
+        batch_size=1,
+        input_ids=input_ids,
+        out_cache_loc=out_cache_loc,
+        seq_lens_sum=seq_len,
+        forward_mode=ForwardMode.EXTEND,
+        req_pool_indices=torch.tensor([0], device=input_ids.device),
+        seq_lens=torch.tensor([seq_len], device=input_ids.device),
+        seq_lens_cpu=torch.tensor([seq_len], device="cpu"),
+        extend_prefix_lens=torch.tensor([prefix_len], device=input_ids.device),
+        extend_prefix_lens_cpu=torch.tensor([prefix_len], device="cpu"),
+        extend_seq_lens=torch.tensor([extend_len], device=input_ids.device),
+        extend_seq_lens_cpu=torch.tensor([extend_len], device="cpu"),
+        attn_backend=backend,
+    )
+    forward_batch.req_to_token_pool = req_to_token_pool
+    forward_batch.token_to_kv_pool = token_to_kv_pool
+    if cp_meta is not None:
+        forward_batch.attn_cp_metadata = cp_meta
+    return forward_batch
+
+
+def _setup_prefix_kv_cache(
+    token_to_kv_pool: MHATokenToKVPool,
+    layer: RadixAttention,
+    prefix_k: torch.Tensor,
+    prefix_v: torch.Tensor,
+):
+    if prefix_k.numel() == 0:
+        return
+
+    cache_loc = torch.arange(prefix_k.shape[0], device=prefix_k.device)
+    token_to_kv_pool.set_kv_buffer(
+        layer,
+        cache_loc,
+        prefix_k,
+        prefix_v,
+        layer.k_scale,
+        layer.v_scale,
+    )
+
+
+def _run_flashinfer_cp_worker(
+    rank: int,
+    *,
+    q_len: int,
+    prefix_len: int,
+    num_heads: int,
+    head_dim: int,
+):
+    torch.cuda.set_device(rank)
+    device = f"cuda:{rank}"
+    world_size = dist.get_world_size()
+    total_len = prefix_len + q_len
+
+    model_runner = MockModelRunner(
+        rank=rank,
+        world_size=world_size,
+        page_size=1,
+        num_heads=num_heads,
+        head_dim=head_dim,
+    )
+    _write_req_to_token(model_runner, total_len)
+
+    with patch(
+        "sglang.srt.layers.attention.flashinfer_backend.get_attention_tp_size",
+        return_value=1,
+    ):
+        backend = FlashInferAttnBackend(model_runner)
+        ref_backend = TorchNativeAttnBackend(model_runner)
+        layer = RadixAttention(
+            num_heads=num_heads,
+            head_dim=head_dim,
+            scaling=1.0,
+            num_kv_heads=num_heads,
+            layer_id=0,
+        )
+
+        torch.manual_seed(1234)
+        prefix_k = torch.randn(
+            (prefix_len, num_heads, head_dim), dtype=torch.float16, device=device
+        )
+        prefix_v = torch.randn(
+            (prefix_len, num_heads, head_dim), dtype=torch.float16, device=device
+        )
+        full_q = torch.randn(
+            (q_len, num_heads, head_dim), dtype=torch.float16, device=device
+        )
+        full_k = torch.randn(
+            (q_len, num_heads, head_dim), dtype=torch.float16, device=device
+        )
+        full_v = torch.randn(
+            (q_len, num_heads, head_dim), dtype=torch.float16, device=device
+        )
+
+        cp_meta = prepare_context_parallel_metadata(q_len, rank, world_size, [total_len])
+        local_q = _split_for_cp(full_q, cp_meta)
+        local_k = _split_for_cp(full_k, cp_meta)
+        local_v = _split_for_cp(full_v, cp_meta)
+        local_cache_loc = _split_for_cp(
+            torch.arange(prefix_len, total_len, dtype=torch.int32, device=device),
+            cp_meta,
+        )
+
+        _setup_prefix_kv_cache(model_runner.token_to_kv_pool, layer, prefix_k, prefix_v)
+
+        ref_forward_batch = _build_forward_batch(
+            ref_backend,
+            input_ids=torch.randint(0, 100, (1, q_len), device=device),
+            out_cache_loc=torch.arange(prefix_len, total_len, dtype=torch.int32, device=device),
+            seq_len=total_len,
+            extend_len=q_len,
+            prefix_len=prefix_len,
+            token_to_kv_pool=model_runner.token_to_kv_pool,
+            req_to_token_pool=model_runner.req_to_token_pool,
+        )
+        ref_output = ref_backend.forward_extend(
+            full_q, full_k, full_v, layer, ref_forward_batch
+        )
+        expected_local = _split_for_cp(ref_output.view(q_len, -1), cp_meta)
+
+        cp_forward_batch = _build_forward_batch(
+            backend,
+            input_ids=torch.randint(0, 100, (1, local_q.shape[0]), device=device),
+            out_cache_loc=local_cache_loc,
+            seq_len=total_len,
+            extend_len=local_q.shape[0],
+            prefix_len=prefix_len,
+            token_to_kv_pool=model_runner.token_to_kv_pool,
+            req_to_token_pool=model_runner.req_to_token_pool,
+            cp_meta=cp_meta,
+        )
+
+        fake_cp_group = _FakeCPGroup()
+        with patch(
+            "sglang.srt.layers.utils.cp_utils.get_attention_cp_group",
+            return_value=fake_cp_group,
+        ):
+            backend.init_forward_metadata(cp_forward_batch)
+            output = backend.forward_extend(
+                local_q, local_k, local_v, layer, cp_forward_batch
+            )
+
+    output = output.view(local_q.shape[0], -1)
+    if not torch.allclose(output, expected_local, atol=1e-1, rtol=0.0):
+        diff_mask = ~torch.isclose(output, expected_local, atol=1e-1, rtol=0.0)
+        if diff_mask.any():
+            mismatch = diff_mask.nonzero()[0]
+            idx = tuple(mismatch.tolist())
+            raise AssertionError(
+                f"rank={rank} mismatch at {idx}: "
+                f"got={output[idx].item()} expected={expected_local[idx].item()}"
+            )
+
+
+@unittest.skipIf(
+    not torch.cuda.is_available() or not is_flashinfer_available(),
+    "CUDA + flashinfer required",
+)
+class TestFlashInferBackend(CustomTestCase):
+    def test_forward_extend_cp(self):
+        if torch.cuda.device_count() < 2:
+            self.skipTest("FlashInfer CP test requires at least 2 GPUs")
+
+        run_distributed_test(
+            _run_flashinfer_cp_worker,
+            world_size=2,
+            backend="nccl",
+            q_len=128,
+            prefix_len=0,
+            num_heads=8,
+            head_dim=64,
+        )
+
+    def test_forward_extend_cp_with_prefix(self):
+        if torch.cuda.device_count() < 2:
+            self.skipTest("FlashInfer CP test requires at least 2 GPUs")
+
+        run_distributed_test(
+            _run_flashinfer_cp_worker,
+            world_size=2,
+            backend="nccl",
+            q_len=128,
+            prefix_len=64,
+            num_heads=8,
+            head_dim=64,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sglang/test/attention/test_flashinfer_backend.py
+++ b/python/sglang/test/attention/test_flashinfer_backend.py
@@ -247,9 +247,8 @@ def _run_flashinfer_cp_worker(
         local_q = _split_for_cp(full_q, cp_meta)
         local_k = _split_for_cp(full_k, cp_meta)
         local_v = _split_for_cp(full_v, cp_meta)
-        local_cache_loc = _split_for_cp(
-            torch.arange(prefix_len, total_len, dtype=torch.int32, device=device),
-            cp_meta,
+        full_cache_loc = torch.arange(
+            prefix_len, total_len, dtype=torch.int32, device=device
         )
 
         _setup_prefix_kv_cache(model_runner.token_to_kv_pool, layer, prefix_k, prefix_v)
@@ -271,10 +270,12 @@ def _run_flashinfer_cp_worker(
 
         cp_forward_batch = _build_forward_batch(
             backend,
-            input_ids=torch.randint(0, 100, (1, local_q.shape[0]), device=device),
-            out_cache_loc=local_cache_loc,
+            # In production, CP splits q/k/v via hidden_states sharding, while
+            # ForwardBatch metadata (including out_cache_loc) remains global.
+            input_ids=torch.randint(0, 100, (1, q_len), device=device),
+            out_cache_loc=full_cache_loc,
             seq_len=total_len,
-            extend_len=local_q.shape[0],
+            extend_len=q_len,
             prefix_len=prefix_len,
             token_to_kv_pool=model_runner.token_to_kv_pool,
             req_to_token_pool=model_runner.req_to_token_pool,


### PR DESCRIPTION
## Motivation

This PR adds an initial implementation of prefill context parallel support for the `flashinfer` MHA/GQA backend.

The goal is to align `flashinfer` with the existing zigzag-based prefill CP path already used by the FA3/FA4 backend, so that `flashinfer` can support the same prefill-only CP workflow.

This is intentionally scoped as a draft / minimal version first.

## Modifications

- Add prefill CP detection and metadata preparation in the `flashinfer` backend
- Add CP KV all-gather + save path for `flashinfer` prefill
- Add CP-aware paged prefill planning for `flashinfer`
- Add a synthetic backend test for `flashinfer` prefill CP
- Add a synthetic backend test for the prefix-cache prefill CP case

Current scope:
- prefill / `forward_extend` only
- paged path only
- `bs=1`
- no ragged CP
- no speculative / `spec_info`
- no sliding window CP
- no multi-item scoring CP
- no CUDA graph support for CP

## Accuracy Tests

Added synthetic backend tests comparing `flashinfer` CP outputs against `TorchNativeAttnBackend` reference outputs.

Tested cases:
- `test_forward_extend_cp`
- `test_forward_extend_cp_with_prefix`

Both passed on a 2-GPU CUDA machine.

## Speed Tests and Profiling

Not included in this draft PR.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Notes

This PR is a draft and is currently focused on correctness for the minimal prefill CP path before expanding support to more cases.