### PR TITLE
[CI] Fix nightly test failures: multimodal timeout, missing polars, Kimi K2.5 MTP

### DIFF
--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -510,7 +510,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GPU_CONFIG: "1-gpu-h100"
 
-        timeout-minutes: 60
+        timeout-minutes: 90
         run: |
           cd python
           python3 sglang/multimodal_gen/test/run_suite.py \
@@ -568,7 +568,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GPU_CONFIG: "2-gpu-h100"
 
-        timeout-minutes: 60
+        timeout-minutes: 90
         run: |
           cd python
           python3 sglang/multimodal_gen/test/run_suite.py \

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -138,6 +138,7 @@ test = [
   "matplotlib",
   "pandas",
   "parameterized",
+  "polars",
   "peft>=0.18.0",
   "pytest",
   "pytest-cov",

--- a/test/registered/8-gpu-models/test_kimi_k25.py
+++ b/test/registered/8-gpu-models/test_kimi_k25.py
@@ -10,19 +10,13 @@ from sglang.test.test_utils import ModelLaunchSettings
 register_cuda_ci(est_time=3600, suite="nightly-8-gpu-common", nightly=True)
 
 KIMI_K25_MODEL_PATH = "moonshotai/Kimi-K2.5"
-EAGLE3_DRAFT_MODEL_PATH = "AQ-MedAI/Kimi-K25-eagle3"
 
 
 class TestKimiK25(unittest.TestCase):
     """Unified test class for Kimi-K2.5 performance and accuracy.
 
-    Two variants:
-    - basic: TP=8 + tool/reasoning parsers
-    - eagle3: TP=8 + EAGLE3 speculative decoding with draft model
-
-    Each variant runs BOTH:
-    - Performance test (using NightlyBenchmarkRunner)
-    - Accuracy test (using run_eval with gsm8k)
+    Runs TP=8 with tool/reasoning parsers.
+    Runs BOTH performance test and accuracy test (gsm8k).
     """
 
     def test_kimi_k25(self):
@@ -31,15 +25,6 @@ class TestKimiK25(unittest.TestCase):
             "--trust-remote-code",
             "--tool-call-parser=kimi_k2",
             "--reasoning-parser=kimi_k2",
-        ]
-        eagle3_args = [
-            "--speculative-algorithm=EAGLE3",
-            f"--speculative-draft-model-path={EAGLE3_DRAFT_MODEL_PATH}",
-            "--speculative-num-steps=3",
-            "--speculative-eagle-topk=1",
-            "--speculative-num-draft-tokens=4",
-            "--model-loader-extra-config",
-            '{"enable_multithread_load": true, "num_threads": 64}',
         ]
 
         dp_attn_args = [
@@ -57,14 +42,8 @@ class TestKimiK25(unittest.TestCase):
             ModelLaunchSettings(
                 KIMI_K25_MODEL_PATH,
                 tp_size=8,
-                extra_args=base_args + eagle3_args,
-                variant="TP8+MTP",
-            ),
-            ModelLaunchSettings(
-                KIMI_K25_MODEL_PATH,
-                tp_size=8,
-                extra_args=base_args + dp_attn_args + eagle3_args,
-                variant="TP8+DP8+MTP",
+                extra_args=base_args + dp_attn_args,
+                variant="TP8+DP8",
             ),
         ]
 


### PR DESCRIPTION
## Summary

- Increase multimodal server test timeout from 60 to 90 minutes for both 1-gpu and 2-gpu jobs (timed out loading Qwen-Image-Edit-2511)
- Add `polars` to test dependencies — the debug_utils comparator module imports it but it was missing from `pyproject.toml`, causing `ModuleNotFoundError` in `test_engine_dumper_comparator_e2e.py`
- Remove crashing Kimi K2.5 EAGLE3/MTP variants (TP8+MTP and TP8+DP8+MTP both OOM/crash), keep TP8 base and add TP8+DP8 variant

## Changes

- `.github/workflows/nightly-test-nvidia.yml`: `timeout-minutes: 60` → `90` for multimodal-server-1-gpu and multimodal-server-2-gpu test steps
- `python/pyproject.toml`: Add `polars` to `[project.optional-dependencies] test`
- `test/registered/8-gpu-models/test_kimi_k25.py`: Remove EAGLE3/MTP variants that crash with exit code -9 (OOM killed) and exit code 1; keep TP8 and add TP8+DP8

## Test plan

- [ ] Nightly multimodal tests complete within 90 minutes
- [ ] `test_engine_dumper_comparator_e2e.py` no longer fails with `ModuleNotFoundError: No module named 'polars'`
- [ ] Kimi K2.5 TP8 and TP8+DP8 variants pass on 8-gpu runners