### PR TITLE
[Perf] Add support for fused down GEMM + combine kernel (EP over NVLINK)

### DIFF
--- a/docs_new/docs/references/environment_variables.mdx
+++ b/docs_new/docs/references/environment_variables.mdx
@@ -331,6 +331,11 @@ SGLang supports various environment variables that can be used to configure its 
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Run shared experts on an alternate stream when single batch overlap is enabled on GB200. When not setting this flag, shared experts and down gemm will be overlapped with DeepEP combine together.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`"false"`</td>
     </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`SGLANG_FUSED_GROUPED_GEMM_COMBINE_FP32`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Enable the use of FP32 accumulation in fused grouped GEMM + combine kernel for higher numerical accuracy.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`false`</td>
+    </tr>
   </tbody>
 </table>
 

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -557,6 +557,7 @@ class Envs:
     # Force dynamic DeepEP Waterfill with runtime EP all-reduce instead of the
     # default static local-batch path.
     SGLANG_DISABLE_STATIC_WATERFILL = EnvBool(False)
+    SGLANG_FUSED_GROUPED_GEMM_COMBINE_FP32 = EnvBool(False)
 
     # NIXL-EP
     SGLANG_NIXL_EP_BF16_DISPATCH = EnvBool(False)

--- a/python/sglang/srt/hardware_backend/npu/quantization/fused_moe_method_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/quantization/fused_moe_method_npu.py
@@ -430,15 +430,9 @@ def maybe_apply_deepep_npu(
     else:
         if TYPE_CHECKING:
             assert isinstance(dispatch_output, DeepEPLLDispatchOutput)
-        (
-            hidden_states,
-            hidden_states_scale,
-            _,
-            _,
-            group_list,
-            _,
-        ) = dispatch_output
-        group_list = group_list.to(torch.int64)
+        hidden_states = dispatch_output.hidden_states
+        hidden_states_scale = dispatch_output.hidden_states_scale
+        group_list = dispatch_output.masked_m.to(torch.int64)
         combine_cls = DeepEPLLCombineInput
 
     hidden_states = quant_method.apply_without_routing_weights(

--- a/python/sglang/srt/layers/moe/flashinfer_cutedsl_moe.py
+++ b/python/sglang/srt/layers/moe/flashinfer_cutedsl_moe.py
@@ -1,11 +1,18 @@
 from typing import Optional
 
+import cutlass.torch as cutlass_torch
 import torch
+import torch.distributed._symmetric_memory as torch_symmetric_memory
 from flashinfer import (
     scaled_fp4_grouped_quantize,
     silu_and_mul_scaled_nvfp4_experts_quantize,
 )
 from flashinfer.cute_dsl.blockscaled_gemm import grouped_gemm_nt_masked
+
+from sglang.srt.distributed.parallel_state import get_tp_group
+from sglang.srt.environ import envs
+
+_SYMMETRIC_BARRIER_TENSORS = (None, None)
 
 
 def get_cute_dtype(input: torch.Tensor) -> str:
@@ -30,9 +37,14 @@ def flashinfer_cutedsl_moe_masked(
     w2_blockscale: torch.Tensor,
     w2_alpha,
     masked_m: torch.Tensor,
+    topk_weights: Optional[torch.Tensor] = None,
+    recv_rank_info: Optional[torch.Tensor] = None,
+    recv_idx_info: Optional[torch.Tensor] = None,
     down_sm_count: Optional[int] = None,
     down_signals: Optional[torch.Tensor] = None,
     down_start_event: Optional[torch.cuda.Event] = None,
+    combine_out: Optional[torch.Tensor] = None,
+    combine_out_ptrs: Optional[torch.Tensor] = None,
 ):
     """
     Perform masked Mixture-of-Experts computation with FlashInfer's CuteDSL
@@ -145,6 +157,7 @@ def flashinfer_cutedsl_moe_masked(
         sf_vec_size=sf_vec_size,
         alpha=w1_alpha.view(1, 1, num_experts),
         alpha_dtype=get_cute_dtype(w1_alpha),
+        is_swap_ab=True,
     )  # in logical [m, n, l]
 
     # SILU and quantization
@@ -158,8 +171,45 @@ def flashinfer_cutedsl_moe_masked(
         down_start_event.record()
 
     # Gemm2
-    out = torch.empty((num_experts, m, k), dtype=torch.bfloat16, device=a_q.device)
-    out = out.permute(1, 2, 0)  # requirement of kernel
+    is_combine_fusion = combine_out is not None
+    if is_combine_fusion:
+        group = get_tp_group().device_group
+        num_ranks = group.size()
+        global _SYMMETRIC_BARRIER_TENSORS
+        if _SYMMETRIC_BARRIER_TENSORS[0] is None:
+            num_sms = torch.cuda.get_device_properties("cuda").multi_processor_count
+            barrier_flag_local = torch_symmetric_memory.empty(
+                (num_sms,),
+                device=a_q.device,
+                dtype=torch.int32,
+            )
+            barrier_flag_local.fill_(0)
+            barrier_flag_local_handle = torch_symmetric_memory.rendezvous(
+                barrier_flag_local, group=group
+            )
+            barrier_flag_multicast = cutlass_torch.as_tensor(
+                barrier_flag_local_handle.multicast_ptr,
+                barrier_flag_local.shape,
+                barrier_flag_local.dtype,
+            )
+            _SYMMETRIC_BARRIER_TENSORS = (
+                barrier_flag_local,
+                barrier_flag_multicast,
+            )
+        else:
+            barrier_flag_local, barrier_flag_multicast = _SYMMETRIC_BARRIER_TENSORS
+
+        # Modify c_dtype based on fused grouped gemm + combine precision
+        c_dtype = "bfloat16" if combine_out.dtype == torch.bfloat16 else "float32"
+        out = combine_out
+    else:
+        num_ranks = 0
+        barrier_flag_local = None
+        barrier_flag_multicast = None
+        recv_idx_info = None
+        out = torch.empty((num_experts, m, k), dtype=torch.bfloat16, device=a_q.device)
+        out = out.permute(1, 2, 0)  # requirement of kernel
+
     grouped_gemm_nt_masked(
         (diq, diq_sf),
         (w2.permute(1, 2, 0), w2_blockscale),
@@ -179,5 +229,21 @@ def flashinfer_cutedsl_moe_masked(
             if down_sm_count is not None or down_signals is not None
             else {}
         ),
-    )  # in logical [m, k, l]
-    return out.permute(2, 0, 1)
+        is_swap_ab=True,
+        is_combine_fusion=is_combine_fusion,
+        topk_weights=topk_weights,
+        idx_src_info=recv_idx_info,
+        rank_src_info=recv_rank_info,
+        out_ptrs=combine_out_ptrs,
+        num_ranks=num_ranks,
+        barrier_flag_local=barrier_flag_local,
+        barrier_flag_multicast=barrier_flag_multicast,
+    )
+
+    if envs.SGLANG_FUSED_GROUPED_GEMM_COMBINE_FP32.get():
+        out = out.to(torch.bfloat16)
+
+    if not is_combine_fusion:
+        # in logical [m, k, l]
+        out = out.permute(2, 0, 1)
+    return out

--- a/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
@@ -669,9 +669,12 @@ def pre_permute_deepep_ll_to_deep_gemm(
     runner_config: MoeRunnerConfig,
     running_state: dict,
 ) -> DeepGemmRunnerInput:
-    hidden_states, hidden_states_scale, topk_ids, topk_weights, masked_m, expected_m = (
-        dispatch_output
-    )
+    hidden_states = dispatch_output.hidden_states
+    hidden_states_scale = dispatch_output.hidden_states_scale
+    topk_ids = dispatch_output.topk_ids
+    topk_weights = dispatch_output.topk_weights
+    masked_m = dispatch_output.masked_m
+    expected_m = dispatch_output.expected_m
 
     running_state["topk_ids"] = topk_ids
     running_state["topk_weights"] = topk_weights

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutedsl.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutedsl.py
@@ -470,7 +470,14 @@ def fused_experts_deepep_to_flashinfer_cutedsl_fp4(
         not runner_config.apply_router_weight_on_input
     ), "apply_router_weight_on_input is not supported for Flashinfer"
 
-    hidden_states, hidden_states_scale, _, _, masked_m, _ = dispatch_output
+    hidden_states = dispatch_output.hidden_states
+    hidden_states_scale = dispatch_output.hidden_states_scale
+    masked_m = dispatch_output.masked_m
+    recv_topk_weights = dispatch_output.recv_topk_weights
+    recv_rank_info = dispatch_output.recv_rank_info
+    recv_idx_info = dispatch_output.recv_idx_info
+    combine_out = dispatch_output.combine_out
+    combine_out_ptrs = dispatch_output.combine_out_ptrs
 
     # flashinfer_cutedsl_moe_masked reinterprets scales as float8_e4m3fn.
     # Same-dtype .view is a no-op; only wider dtypes (e.g. int32-packed
@@ -501,6 +508,11 @@ def fused_experts_deepep_to_flashinfer_cutedsl_fp4(
         w2_blockscale=quant_info.w2_weight_sf,
         w2_alpha=quant_info.w2_alpha,
         masked_m=masked_m,
+        topk_weights=recv_topk_weights,
+        recv_rank_info=recv_rank_info,
+        recv_idx_info=recv_idx_info,
+        combine_out=combine_out,
+        combine_out_ptrs=combine_out_ptrs,
         **(
             dict(
                 down_sm_count=overlap.num_sms,

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -25,6 +25,7 @@ from sglang.srt.layers.moe.utils import (
     DeepEPOutputDtype,
     get_deepep_config,
     get_deepep_output_dtype,
+    is_fused_grouped_gemm_combine_enabled,
     is_tbo_enabled,
 )
 from sglang.srt.utils import (
@@ -60,6 +61,7 @@ from enum import Enum, IntEnum, auto
 
 import torch
 import torch.distributed as dist
+import torch.distributed._symmetric_memory as torch_symmetric_memory
 
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and is_hip()
 
@@ -73,6 +75,12 @@ def _deepep_precompile_tp_barrier() -> None:
     # We apply this barrier only in the compile stage to prevent extra all-reduce overhead at runtime.
     if envs.SGLANG_IN_DEEPGEMM_PRECOMPILE_STAGE.get():
         get_tp_group().barrier()
+
+
+@dataclass
+class FusedGroupedGemmCombineArgs:
+    output_tensor: torch.Tensor
+    out_ptrs_tensor: torch.Tensor
 
 
 class DeepEPPDispatchHooks(DispatcherBaseHooks):
@@ -104,6 +112,11 @@ class DeepEPLLDispatchOutput(NamedTuple):
     topk_weights: torch.Tensor
     masked_m: torch.Tensor
     expected_m: int
+    recv_topk_weights: torch.Tensor
+    recv_rank_info: torch.Tensor
+    recv_idx_info: torch.Tensor
+    combine_out: torch.Tensor
+    combine_out_ptrs: torch.Tensor
 
     @property
     def format(self) -> DispatchOutputFormat:
@@ -611,6 +624,9 @@ class _DeepEPDispatcherImplNormal(_DeepEPDispatcherImplBase):
 
 
 class _DeepEPDispatcherImplLowLatency(_DeepEPDispatcherImplBase):
+    # Class data member for fused grouped gemm combine
+    fused_grouped_gemm_combine_args: Optional[FusedGroupedGemmCombineArgs] = None
+
     def __init__(self, return_recv_hook: bool, **kwargs):
         super().__init__(**kwargs)
 
@@ -621,6 +637,9 @@ class _DeepEPDispatcherImplLowLatency(_DeepEPDispatcherImplBase):
         self.return_recv_hook = return_recv_hook
         self.device_module = torch.get_device_module()
         self.quant_config = {}
+        self.fused_grouped_gemm_combine_enabled = (
+            is_fused_grouped_gemm_combine_enabled()
+        )
 
     def dispatch_a(
         self,
@@ -628,15 +647,60 @@ class _DeepEPDispatcherImplLowLatency(_DeepEPDispatcherImplBase):
         topk_output: TopKOutput,
     ):
         buffer = self._get_buffer()
-        topk_weights, topk_ids = topk_output.topk_weights, topk_output.topk_ids
+        if self.fused_grouped_gemm_combine_enabled:
+            out_dtype = (
+                torch.float32
+                if envs.SGLANG_FUSED_GROUPED_GEMM_COMBINE_FP32.get()
+                else torch.bfloat16
+            )
+            assert (
+                hidden_states.shape[0] <= self.num_max_dispatch_tokens_per_rank
+            ), "hidden_states.shape[0] must be less than or equal to SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK"
+            # Allocate MoE block symmetric output buffer large enough to support BS up to SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK
+            # TODO @nvcastet: Refactor allocation to use a mempool
+            if _DeepEPDispatcherImplLowLatency.fused_grouped_gemm_combine_args is None:
+                max_bs_rank = self.num_max_dispatch_tokens_per_rank
+                out = torch_symmetric_memory.empty(
+                    [max_bs_rank, hidden_states.shape[1]],
+                    dtype=out_dtype,
+                    device=hidden_states.device,
+                )
+                out_handle = torch_symmetric_memory.rendezvous(out, group=buffer.group)
+                out_ptrs = out_handle.buffer_ptrs
+                # out = out.permute(1, 2, 0)  # requirement of kernel
+                out_ptrs_tensor = torch.tensor(
+                    out_ptrs, dtype=torch.int64, device=hidden_states.device
+                )
+                _DeepEPDispatcherImplLowLatency.fused_grouped_gemm_combine_args = (
+                    FusedGroupedGemmCombineArgs(
+                        out,
+                        out_ptrs_tensor,
+                    )
+                )
+            # Only zero out the output tensor slice needed for the current batch
+            _DeepEPDispatcherImplLowLatency.fused_grouped_gemm_combine_args.output_tensor[
+                : hidden_states.shape[0], :
+            ].zero_()
+
+        topk_weights = topk_output.topk_weights
+        topk_ids = topk_output.topk_ids
         topk_ids = topk_ids.to(torch.int64)
         expected_m = (
             hidden_states.shape[0] * buffer.group_size * topk_ids.shape[1]
             + self.num_experts
         ) // self.num_experts
-        hidden_states, masked_m, event, hook = self._dispatch_core(
+        (
+            hidden_states,
+            masked_m,
+            recv_topk_weights,
+            recv_rank_info,
+            recv_idx_info,
+            event,
+            hook,
+        ) = self._dispatch_core(
             hidden_states,
             topk_ids,
+            topk_weights if self.fused_grouped_gemm_combine_enabled else None,
         )
         return (
             hidden_states,
@@ -644,6 +708,9 @@ class _DeepEPDispatcherImplLowLatency(_DeepEPDispatcherImplBase):
             topk_weights,
             masked_m,
             expected_m,
+            recv_topk_weights,
+            recv_rank_info,
+            recv_idx_info,
             event,
             hook,
         )
@@ -655,6 +722,9 @@ class _DeepEPDispatcherImplLowLatency(_DeepEPDispatcherImplBase):
         topk_weights,
         masked_m,
         expected_m,
+        recv_topk_weights,
+        recv_rank_info,
+        recv_idx_info,
         event,
         hook,
     ):
@@ -676,6 +746,19 @@ class _DeepEPDispatcherImplLowLatency(_DeepEPDispatcherImplBase):
             topk_weights,
             masked_m,
             expected_m,
+            recv_topk_weights,
+            recv_rank_info,
+            recv_idx_info,
+            (
+                _DeepEPDispatcherImplLowLatency.fused_grouped_gemm_combine_args.output_tensor
+                if self.fused_grouped_gemm_combine_enabled
+                else None
+            ),
+            (
+                _DeepEPDispatcherImplLowLatency.fused_grouped_gemm_combine_args.out_ptrs_tensor
+                if self.fused_grouped_gemm_combine_enabled
+                else None
+            ),
         )
         return deepep_output
 
@@ -683,6 +766,7 @@ class _DeepEPDispatcherImplLowLatency(_DeepEPDispatcherImplBase):
         self,
         hidden_states: torch.Tensor,
         topk_ids: torch.Tensor,
+        topk_weights: Optional[torch.Tensor] = None,
     ):
         input_global_scale = self.quant_config.get("input_global_scale", None)
 
@@ -702,25 +786,52 @@ class _DeepEPDispatcherImplLowLatency(_DeepEPDispatcherImplBase):
 
         buffer = self._get_buffer()
         _deepep_precompile_tp_barrier()
-        packed_recv_hidden, self.packed_recv_count, self.handle, event, hook = (
-            buffer.low_latency_dispatch(
-                hidden_states,
-                topk_ids,
-                self.num_max_dispatch_tokens_per_rank,
-                self.num_experts,
-                use_fp8=self.use_fp8,
-                **(dict(use_nvfp4=True) if self.use_nvfp4 else dict()),
-                **(
-                    dict(x_global_scale=input_global_scale)
-                    if input_global_scale is not None
-                    else dict()
-                ),
-                async_finish=not self.return_recv_hook,
-                return_recv_hook=self.return_recv_hook,
-                **fp8_deepgemm_scale_opts,
-            )
+        dispatch_output = buffer.low_latency_dispatch(
+            hidden_states,
+            topk_ids,
+            self.num_max_dispatch_tokens_per_rank,
+            self.num_experts,
+            use_fp8=self.use_fp8,
+            **(dict(use_nvfp4=True) if self.use_nvfp4 else dict()),
+            **(
+                dict(x_global_scale=input_global_scale)
+                if input_global_scale is not None
+                else dict()
+            ),
+            topk_weights=topk_weights,
+            async_finish=not self.return_recv_hook,
+            return_recv_hook=self.return_recv_hook,
+            **fp8_deepgemm_scale_opts,
         )
-        return packed_recv_hidden, self.packed_recv_count, event, hook
+        if topk_weights is not None:
+            (
+                packed_recv_hidden,
+                self.packed_recv_count,
+                recv_topk_weights,
+                recv_rank_info,
+                self.handle,
+                event,
+                hook,
+            ) = dispatch_output
+        else:
+            (
+                packed_recv_hidden,
+                self.packed_recv_count,
+                self.handle,
+                event,
+                hook,
+            ) = dispatch_output
+            recv_topk_weights = None
+            recv_rank_info = None
+        return (
+            packed_recv_hidden,
+            self.packed_recv_count,
+            recv_topk_weights,
+            recv_rank_info,
+            self.handle[0],
+            event,
+            hook,
+        )
 
     def combine_a(
         self,
@@ -740,7 +851,11 @@ class _DeepEPDispatcherImplLowLatency(_DeepEPDispatcherImplBase):
         if overlap_args is not None:
             overlap_args.stream.wait_stream(self.device_module.current_stream())
 
-        hook() if self.return_recv_hook else event.current_stream_wait()
+        (
+            hook()
+            if self.return_recv_hook or event is None
+            else event.current_stream_wait()
+        )
 
         if overlap_args is not None:
             self.device_module.current_stream().wait_stream(overlap_args.stream)
@@ -753,6 +868,8 @@ class _DeepEPDispatcherImplLowLatency(_DeepEPDispatcherImplBase):
         topk_ids: torch.Tensor,
         topk_weights: torch.Tensor,
     ):
+        if self.fused_grouped_gemm_combine_enabled:
+            return hidden_states[: topk_ids.shape[0], :], None, lambda: None
         buffer = self._get_buffer()
         overlap_args = self.overlap_args
         meta_overlap_args = self.meta_overlap_args

--- a/python/sglang/srt/layers/moe/token_dispatcher/nixl.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/nixl.py
@@ -261,6 +261,11 @@ class _NixlEPDispatcherImpl(_NixlEPDispatcherImplBase):
             topk_weights,
             masked_m,
             expected_m,
+            None,
+            None,
+            None,
+            None,
+            None,
         )
         return nixl_output
 

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -268,6 +268,7 @@ def initialize_moe_config(server_args: ServerArgs):
     global DEEPEP_CONFIG
     global IS_TBO_ENABLED
     global IS_SBO_ENABLED
+    global IS_FUSED_GROUPED_GEMM_COMBINE
     global TBO_TOKEN_DISTRIBUTION_THRESHOLD
     global DISABLE_FLASHINFER_CUTLASS_MOE_FP4_ALLGATHER
     global MOE_QUANTIZATION
@@ -293,6 +294,7 @@ def initialize_moe_config(server_args: ServerArgs):
             raise ValueError(
                 "SBO (single batch overlap) is not supported on SM90 GPUs with latest sgl-deep-gemm wheel. Please try removing --enable-single-batch-overlap argument."
             )
+    IS_FUSED_GROUPED_GEMM_COMBINE = server_args.enable_fused_grouped_gemm_combine
     TBO_TOKEN_DISTRIBUTION_THRESHOLD = server_args.tbo_token_distribution_threshold
     DISABLE_FLASHINFER_CUTLASS_MOE_FP4_ALLGATHER = (
         server_args.disable_flashinfer_cutlass_moe_fp4_allgather
@@ -376,6 +378,13 @@ def is_flashinfer_cutedsl_v1_path() -> bool:
         get_moe_runner_backend().is_flashinfer_cutedsl()
         and get_moe_a2a_backend().is_deepep()
     )
+
+
+def is_fused_grouped_gemm_combine_enabled() -> bool:
+    global IS_FUSED_GROUPED_GEMM_COMBINE
+    if IS_FUSED_GROUPED_GEMM_COMBINE is None:
+        IS_FUSED_GROUPED_GEMM_COMBINE = False
+    return IS_FUSED_GROUPED_GEMM_COMBINE
 
 
 def get_tbo_token_distribution_threshold() -> float:

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -791,8 +791,8 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
             )
             combine_cls = DeepEPNormalCombineInput
         else:
-            hidden_states, _, _, _, group_list, _ = dispatch_output
-            group_list = group_list.to(torch.int64)
+            hidden_states = dispatch_output.hidden_states
+            group_list = dispatch_output.masked_m.to(torch.int64)
             combine_cls = DeepEPLLCombineInput
 
         hidden_states = npu_fused_moe_without_routing_weights_bf16(

--- a/python/sglang/srt/layers/quantization/w4afp8.py
+++ b/python/sglang/srt/layers/quantization/w4afp8.py
@@ -334,7 +334,10 @@ class W4AFp8MoEMethod(FusedMoEMethodBase):
 
         from sglang.srt.layers.moe.cutlass_w4a8_moe import cutlass_w4a8_moe_deepep_ll
 
-        hidden_states, hidden_scales, topk_ids, _, masked_m, _ = dispatch_output
+        hidden_states = dispatch_output.hidden_states
+        hidden_scales = dispatch_output.hidden_states_scale
+        topk_ids = dispatch_output.topk_ids
+        masked_m = dispatch_output.masked_m
 
         output = cutlass_w4a8_moe_deepep_ll(
             hidden_states,

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -107,6 +107,7 @@ from sglang.srt.layers.moe.utils import (
     RoutingMethodType,
     filter_moe_weight_param_global_expert,
     is_deepep_class_backend,
+    is_fused_grouped_gemm_combine_enabled,
     is_sbo_enabled,
     is_tbo_enabled,
 )
@@ -1108,7 +1109,12 @@ class DeepseekV2MoE(nn.Module):
         input_ids_global: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         shared_output = None
-        sbo_enabled_flag = self._fuse_shared_experts_inside_sbo and not self.is_nextn
+        fused_down_gemm_combine = is_fused_grouped_gemm_combine_enabled()
+        sbo_enabled_flag = (
+            self._fuse_shared_experts_inside_sbo
+            and not self.is_nextn
+            and not fused_down_gemm_combine
+        )
         sbo_overlap_dispatch_flag = (
             sbo_enabled_flag and SboFlags.enable_dispatch_shared_one_stream_overlap()
         )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -760,6 +760,7 @@ class ServerArgs:
     enable_dp_lm_head: bool = False
     enable_two_batch_overlap: bool = False
     enable_single_batch_overlap: bool = False
+    enable_fused_grouped_gemm_combine: bool = False
     tbo_token_distribution_threshold: float = 0.48
     enable_torch_compile: bool = False
     disable_piecewise_cuda_graph: bool = False
@@ -3604,6 +3605,20 @@ class ServerArgs:
                 assert (
                     self.chunked_prefill_size
                 ) <= envs.SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK.get(), "SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK (default 4096) must be larger or equal to chunked_prefill_size"
+
+        if self.enable_fused_grouped_gemm_combine:
+            assert (
+                not self.enable_single_batch_overlap
+            ), "Fused grouped GEMM + combine is incompatible with single batch overlap."
+            assert (
+                self.moe_runner_backend == "flashinfer_cutedsl"
+            ), "Fused grouped GEMM + combine is only supported with 'flashinfer_cutedsl' MoE backend."
+            assert (
+                self.moe_a2a_backend == "deepep"
+            ), "Fused grouped GEMM + combine is only supported with 'deepep' MoE A2A backend."
+            assert (
+                self.deepep_mode == "low_latency"
+            ), "Fused grouped GEMM + combine is only supported with DeepEP 'low_latency' mode."
 
     def _handle_eplb_and_dispatch(self):
         if self.enable_eplb and (self.expert_distribution_recorder_mode is None):
@@ -6639,6 +6654,11 @@ class ServerArgs:
             "--enable-single-batch-overlap",
             action="store_true",
             help="Let computation and communication overlap within one micro batch.",
+        )
+        parser.add_argument(
+            "--enable-fused-grouped-gemm-combine",
+            action="store_true",
+            help="Enable fusion of grouped gemm and combine for NVLINK communication. This is only supported with cuteDSL MoE backend and DeepEP low_latency mode.",
         )
         parser.add_argument(
             "--tbo-token-distribution-threshold",


### PR DESCRIPTION
## Prerequisites:
- flashinfer kernel: https://github.com/flashinfer-ai/flashinfer/pull/2944
- DeepEP LL dispatch modifications to send topk_weight and src rank info: https://github.com/deepseek-ai/DeepEP/pull/599

## Summary
- Adds a new `--enable-fused-grouped-gemm-combine` flag that fuses the down GEMM (second MoE expert GEMM) with the DeepEP low-latency combine step into a single kernel, reducing latency by overlapping computation and communication.
- Leverages FlashInfer CuteDSL's `grouped_gemm_nt_masked` with combine fusion support, using symmetric memory for cross-rank output and barrier synchronization.
- Adds `SGLANG_FUSED_GROUPED_GEMM_COMBINE_FP32` env var to optionally use FP32 accumulation in the fused kernel.
- When fused combine is enabled, single batch overlap (SBO) is disabled since the combine is already fused into the GEMM.

## Performance
<img width="2058" height="1180" alt="benchmark_plot" src="https://github.com/user-attachments/assets/18104a9d-46df-4a21-b483-76a2aea9aa67" />


## Changes
- **`server_args.py`**: New `--enable-fused-grouped-gemm-combine` CLI flag with validation (incompatible with SBO).
- **`deepep.py`**: Propagates topk weights, rank/idx info, and symmetric memory output buffers through dispatch/combine paths. Skips the standalone combine kernel when fusion is active.
- **`flashinfer_cutedsl_moe.py`**: Allocates symmetric memory barriers, passes combine fusion args to `grouped_gemm_nt_masked`, enables `is_swap_ab` for both GEMMs.
- **`ep_moe/layer.py`**, **`modelopt_quant.py`**: Thread new combine fusion args through the MoE method interface.
- **`deepseek_v2.py`**: Disables SBO shared expert fusion when fused combine is active.
- **`utils.py`**, **`environ.py`**, **`environment_variables.md`**: Config plumbing.

## Test plan
- [ ] Run DeepSeek-V3/R1 with `--enable-fused-grouped-gemm-combine` on multi-node DeepEP low-latency setup and verify correctness
- [ ] Benchmark latency improvement vs baseline (no fusion)
- [ ] Verify SBO + fused combine raises assertion error as expected

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27239593442](https://github.com/sgl-project/sglang/actions/runs/27239593442)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27239593302](https://github.com/sgl-project/sglang/actions/runs/27239593302)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->