### PR TITLE
Allow /rerun-test to checkout fork PR branch for trusted users

### DIFF
--- a/.github/workflows/slash-command-handler.yml
+++ b/.github/workflows/slash-command-handler.yml
@@ -59,7 +59,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          PERM=$(gh api repos/${{ github.repository }}/collaborators/${{ github.event.comment.user.login }}/permission --jq '.permission') || PERM="none"
+          PERM=$(gh api repos/${{ github.repository }}/collaborators/${{ github.event.comment.user.login }}/permission --jq '.permission') || {
+            PERM="none"
+            echo "::warning::Failed to check commenter permission, defaulting to none"
+          }
           if [[ "$PERM" == "admin" || "$PERM" == "maintain" || "$PERM" == "write" ]]; then
             echo "safe_to_checkout_pr=true" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/slash-command-handler.yml
+++ b/.github/workflows/slash-command-handler.yml
@@ -49,14 +49,31 @@ jobs:
           fi
           echo "is_fork=$IS_FORK" >> $GITHUB_OUTPUT
           echo "ref=$(echo "$PR_DATA" | jq -r '.headRefName')" >> $GITHUB_OUTPUT
+          echo "pr_ref=refs/pull/${{ github.event.issue.number }}/head" >> $GITHUB_OUTPUT
           echo "PR owner: $HEAD_OWNER, Repo owner: $REPO_OWNER, Is fork: $IS_FORK"
+
+      - name: Check commenter permission for fork PRs
+        id: perm
+        if: steps.pr.outputs.is_fork == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PERM=$(gh api repos/${{ github.repository }}/collaborators/${{ github.event.comment.user.login }}/permission --jq '.permission') || PERM="none"
+          if [[ "$PERM" == "admin" || "$PERM" == "maintain" || "$PERM" == "write" ]]; then
+            echo "safe_to_checkout_pr=true" >> $GITHUB_OUTPUT
+          else
+            echo "safe_to_checkout_pr=false" >> $GITHUB_OUTPUT
+          fi
+          echo "Commenter ${{ github.event.comment.user.login }} permission: $PERM"
 
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          # For non-fork PRs, checkout PR branch to allow testing handler changes
-          # For fork PRs, stay on main for security (don't run untrusted code with elevated permissions)
-          ref: ${{ steps.pr.outputs.is_fork == 'false' && steps.pr.outputs.ref || '' }}
+          # For non-fork PRs: checkout PR branch by name
+          # For fork PRs with trusted commenter: checkout via refs/pull/N/head
+          # For fork PRs with untrusted commenter: stay on main for security
+          ref: ${{ steps.pr.outputs.is_fork == 'false' && steps.pr.outputs.ref || (steps.perm.outputs.safe_to_checkout_pr == 'true' && steps.pr.outputs.pr_ref || '') }}
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary

- `/rerun-test` on fork PRs fails with "File not found" when the test file only exists on the PR branch, because the workflow always checks out `main` for fork PRs
- The Python handler (`handle_rerun_test`) already gates fork PRs by requiring the commenter to have write+ repo permission
- This fix adds a permission check step in the YAML workflow: if the commenter has write+ permission, checkout the PR branch via `refs/pull/N/head`; otherwise stay on `main` (Python handler will reject anyway)
- Uses `refs/pull/N/head` instead of branch name for fork PRs since the branch only exists on the fork repo

## Test plan

- [ ] Maintainer runs `/rerun-test <new_file>` on a fork PR → file found, test dispatched
- [ ] Non-collaborator runs `/rerun-test` on a fork PR → rejected by Python handler (unchanged)
- [ ] `/rerun-test` on non-fork PRs → unchanged behavior
- [ ] `/rerun-stage`, `/tag-run-ci-label` on fork PRs → unchanged behavior