### PR TITLE
Skip broken AutoModel mapping entries when resolving Llava submodules

### DIFF
--- a/python/sglang/srt/models/llava.py
+++ b/python/sglang/srt/models/llava.py
@@ -53,6 +53,9 @@ from sglang.srt.multimodal.mm_utils import (
 )
 from sglang.srt.utils import add_prefix, flatten_nested_list, logger
 
+_KNOWN_BROKEN_AUTOMODEL_CONFIG = "VoxtralRealtimeTextConfig"
+_KNOWN_BROKEN_AUTOMODEL_ERROR = "Could not find VoxtralRealtimeTextModel"
+
 
 class LlavaBaseForCausalLM(nn.Module):
     def pad_input_ids(self, input_ids: List[int], image_inputs: MultimodalInputs):
@@ -659,7 +662,13 @@ class LlavaForConditionalGeneration(LlavaBaseForCausalLM):
         for config_cls in auto_model_type._model_mapping.keys():
             try:
                 archs = auto_model_type._model_mapping.get(config_cls, None)
-            except Exception as exc:
+            except ValueError as exc:
+                if (
+                    auto_model_type is not AutoModel
+                    or config_cls.__name__ != _KNOWN_BROKEN_AUTOMODEL_CONFIG
+                    or _KNOWN_BROKEN_AUTOMODEL_ERROR not in str(exc)
+                ):
+                    raise
                 logger.warning(
                     "Skipping broken %s mapping for config %s: %s",
                     auto_model_type.__name__,

--- a/python/sglang/srt/models/llava.py
+++ b/python/sglang/srt/models/llava.py
@@ -657,7 +657,16 @@ class LlavaForConditionalGeneration(LlavaBaseForCausalLM):
     ) -> Dict[str, str]:
         mapping = {}
         for config_cls in auto_model_type._model_mapping.keys():
-            archs = auto_model_type._model_mapping.get(config_cls, None)
+            try:
+                archs = auto_model_type._model_mapping.get(config_cls, None)
+            except Exception as exc:
+                logger.warning(
+                    "Skipping broken %s mapping for config %s: %s",
+                    auto_model_type.__name__,
+                    config_cls.__name__,
+                    exc,
+                )
+                continue
             if archs is not None:
                 if isinstance(archs, tuple):
                     mapping[config_cls.__name__] = tuple(

--- a/test/registered/unit/models/test_llava.py
+++ b/test/registered/unit/models/test_llava.py
@@ -1,0 +1,65 @@
+import unittest
+from unittest.mock import patch
+
+from sglang.srt.models.llava import LlavaForConditionalGeneration
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="stage-a-test-cpu")
+
+
+class GoodConfig:
+    pass
+
+
+class BrokenConfig:
+    pass
+
+
+class GoodArch:
+    pass
+
+
+class FakeMapping:
+    def keys(self):
+        return [BrokenConfig, GoodConfig]
+
+    def get(self, config_cls, default=None):
+        if config_cls is BrokenConfig:
+            raise ValueError("broken mapping entry")
+        if config_cls is GoodConfig:
+            return GoodArch
+        return default
+
+
+class FakeAutoModel:
+    _model_mapping = FakeMapping()
+
+
+class TestLlavaForConditionalGeneration(CustomTestCase):
+    @patch("sglang.srt.models.llava.logger.warning")
+    def test_skip_broken_automodel_mapping_entries(self, mock_warning):
+        llava_model = object.__new__(LlavaForConditionalGeneration)
+        build_mapping = (
+            LlavaForConditionalGeneration._config_cls_name_to_arch_name_mapping.__wrapped__
+        )
+
+        mapping = build_mapping(llava_model, FakeAutoModel)
+
+        self.assertEqual(mapping[GoodConfig.__name__], GoodArch.__name__)
+        self.assertNotIn(BrokenConfig.__name__, mapping)
+
+        mock_warning.assert_called_once()
+        self.assertEqual(
+            mock_warning.call_args.args,
+            (
+                "Skipping broken %s mapping for config %s: %s",
+                FakeAutoModel.__name__,
+                BrokenConfig.__name__,
+                unittest.mock.ANY,
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_llava.py
+++ b/test/registered/unit/models/test_llava.py
@@ -2,10 +2,10 @@ import unittest
 from unittest.mock import patch
 
 from sglang.srt.models.llava import AutoModel, LlavaForConditionalGeneration
-from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_cpu_ci(est_time=1, suite="stage-a-test-cpu")
+register_cuda_ci(est_time=1, suite="stage-b-test-1-gpu-small")
 
 
 class PixtralVisionConfig:

--- a/test/registered/unit/models/test_llava.py
+++ b/test/registered/unit/models/test_llava.py
@@ -1,18 +1,26 @@
 import unittest
 from unittest.mock import patch
 
-from sglang.srt.models.llava import LlavaForConditionalGeneration
+from sglang.srt.models.llava import AutoModel, LlavaForConditionalGeneration
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=1, suite="stage-a-test-cpu")
 
 
+class PixtralVisionConfig:
+    pass
+
+
+class VoxtralRealtimeTextConfig:
+    pass
+
+
 class GoodConfig:
     pass
 
 
-class BrokenConfig:
+class PixtralVisionModel:
     pass
 
 
@@ -21,44 +29,62 @@ class GoodArch:
 
 
 class FakeMapping:
+    def __init__(self, voxtral_error):
+        self.voxtral_error = voxtral_error
+
     def keys(self):
-        return [BrokenConfig, GoodConfig]
+        return [VoxtralRealtimeTextConfig, PixtralVisionConfig, GoodConfig]
 
     def get(self, config_cls, default=None):
-        if config_cls is BrokenConfig:
-            raise ValueError("broken mapping entry")
+        if config_cls is VoxtralRealtimeTextConfig:
+            raise self.voxtral_error
+        if config_cls is PixtralVisionConfig:
+            return (PixtralVisionModel,)
         if config_cls is GoodConfig:
             return GoodArch
         return default
 
 
-class FakeAutoModel:
-    _model_mapping = FakeMapping()
+KNOWN_VOXTRAL_ERROR = ValueError(
+    "Could not find VoxtralRealtimeTextModel neither in "
+    "<module 'transformers.models.voxtral_realtime'> nor in "
+    "<module 'transformers'>!"
+)
 
 
 class TestLlavaForConditionalGeneration(CustomTestCase):
-    @patch("sglang.srt.models.llava.logger.warning")
-    def test_skip_broken_automodel_mapping_entries(self, mock_warning):
-        llava_model = object.__new__(LlavaForConditionalGeneration)
-        build_mapping = (
-            LlavaForConditionalGeneration._config_cls_name_to_arch_name_mapping.__wrapped__
-        )
+    def setUp(self):
+        LlavaForConditionalGeneration._config_cls_name_to_arch_name_mapping.cache_clear()
 
-        mapping = build_mapping(llava_model, FakeAutoModel)
+    def _build_mapping(self, mapping):
+        with patch.object(AutoModel, "_model_mapping", mapping):
+            llava_model = object.__new__(LlavaForConditionalGeneration)
+            return llava_model._config_cls_name_to_arch_name_mapping(AutoModel)
+
+    @patch("sglang.srt.models.llava.logger.warning")
+    def test_skip_known_broken_voxtral_automodel_mapping_entry(self, mock_warning):
+        mapping = self._build_mapping(FakeMapping(KNOWN_VOXTRAL_ERROR))
 
         self.assertEqual(mapping[GoodConfig.__name__], GoodArch.__name__)
-        self.assertNotIn(BrokenConfig.__name__, mapping)
+        self.assertEqual(
+            mapping[PixtralVisionConfig.__name__], (PixtralVisionModel.__name__,)
+        )
+        self.assertNotIn(VoxtralRealtimeTextConfig.__name__, mapping)
 
         mock_warning.assert_called_once()
         self.assertEqual(
             mock_warning.call_args.args,
             (
                 "Skipping broken %s mapping for config %s: %s",
-                FakeAutoModel.__name__,
-                BrokenConfig.__name__,
+                AutoModel.__name__,
+                VoxtralRealtimeTextConfig.__name__,
                 unittest.mock.ANY,
             ),
         )
+
+    def test_other_voxtral_mapping_failures_still_raise(self):
+        with self.assertRaisesRegex(ValueError, "some other failure"):
+            self._build_mapping(FakeMapping(ValueError("some other failure")))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Made with Codex

## Summary
- skip broken `AutoModel` mapping entries when building Llava submodule config-to-arch mappings
- log a warning and continue instead of failing the entire lookup
- add a regression unit test that covers broken unrelated mapping entries

## Problem
`LlavaForConditionalGeneration._config_cls_name_to_arch_name_mapping()` walks the entire `auto_model_type._model_mapping` and eagerly calls `.get()` on every config class.

On current `main`, SGLang pins `transformers==5.3.0`. In that version, `AutoModel` contains a broken unrelated entry for `VoxtralRealtimeTextConfig -> VoxtralRealtimeTextModel`. That entry raises:

```text
ValueError: Could not find VoxtralRealtimeTextModel ...
```

before Llava reaches the actual target config.

This blocks multimodal Mistral3/Pixtral-style models such as `mistralai/Devstral-Small-2-24B-Instruct-2512`, even though SGLang already has a matching Pixtral vision implementation.

## Reproduction
1. Use current `main` with `transformers==5.3.0`.
2. Try to load `mistralai/Devstral-Small-2-24B-Instruct-2512`, or directly invoke `LlavaForConditionalGeneration._config_cls_name_to_arch_name_mapping(..., AutoModel)`.
3. Observe `ValueError: Could not find VoxtralRealtimeTextModel ...`.

## Fix
Catch exceptions from broken unrelated mapping entries, emit a warning, and continue scanning the remaining entries.

## Result
- unrelated broken `AutoModel` entries no longer abort Llava submodule resolution
- `PixtralVisionConfig` resolves successfully again
- `mistralai/Devstral-Small-2-24B-Instruct-2512` can proceed past this blocker in the patched environment

## Validation
- `python3 -m py_compile python/sglang/srt/models/llava.py test/registered/unit/models/test_llava.py`
- `pytest -q test/registered/unit/models/test_llava.py -q` on B200
- manual B200 before/after probe:
  - unpatched `main` raises `ValueError: Could not find VoxtralRealtimeTextModel ...`
  - patched copy resolves `PixtralVisionConfig -> PixtralVisionModel` and skips the broken entry with a warning
