### PR TITLE
[CI] Remove crashing Kimi K2.5 EAGLE3/MTP variants, keep TP8 and TP8+DP8

### DIFF
--- a/test/registered/8-gpu-models/test_kimi_k25.py
+++ b/test/registered/8-gpu-models/test_kimi_k25.py
@@ -10,19 +10,13 @@ from sglang.test.test_utils import ModelLaunchSettings
 register_cuda_ci(est_time=3600, suite="nightly-8-gpu-common", nightly=True)
 
 KIMI_K25_MODEL_PATH = "moonshotai/Kimi-K2.5"
-EAGLE3_DRAFT_MODEL_PATH = "AQ-MedAI/Kimi-K25-eagle3"
 
 
 class TestKimiK25(unittest.TestCase):
     """Unified test class for Kimi-K2.5 performance and accuracy.
 
-    Two variants:
-    - basic: TP=8 + tool/reasoning parsers
-    - eagle3: TP=8 + EAGLE3 speculative decoding with draft model
-
-    Each variant runs BOTH:
-    - Performance test (using NightlyBenchmarkRunner)
-    - Accuracy test (using run_eval with gsm8k)
+    Runs TP=8 with tool/reasoning parsers.
+    Runs BOTH performance test and accuracy test (gsm8k).
     """
 
     def test_kimi_k25(self):
@@ -31,13 +25,6 @@ class TestKimiK25(unittest.TestCase):
             "--trust-remote-code",
             "--tool-call-parser=kimi_k2",
             "--reasoning-parser=kimi_k2",
-        ]
-        eagle3_args = [
-            "--speculative-algorithm=EAGLE3",
-            f"--speculative-draft-model-path={EAGLE3_DRAFT_MODEL_PATH}",
-            "--speculative-num-steps=3",
-            "--speculative-eagle-topk=1",
-            "--speculative-num-draft-tokens=4",
             "--model-loader-extra-config",
             '{"enable_multithread_load": true, "num_threads": 64}',
         ]
@@ -57,14 +44,8 @@ class TestKimiK25(unittest.TestCase):
             ModelLaunchSettings(
                 KIMI_K25_MODEL_PATH,
                 tp_size=8,
-                extra_args=base_args + eagle3_args,
-                variant="TP8+MTP",
-            ),
-            ModelLaunchSettings(
-                KIMI_K25_MODEL_PATH,
-                tp_size=8,
-                extra_args=base_args + dp_attn_args + eagle3_args,
-                variant="TP8+DP8+MTP",
+                extra_args=base_args + dp_attn_args,
+                variant="TP8+DP8",
             ),
         ]
 


### PR DESCRIPTION
## Summary

- Remove Kimi K2.5 MTP variants (TP8+MTP and TP8+DP8+MTP) that crash in nightly tests
- Keep TP8 base variant and add TP8+DP8 variant (without EAGLE3 speculative decoding)

The TP8+MTP variant crashes with exit code -9 (OOM killed) and TP8+DP8+MTP crashes with exit code 1 on both H200 and B200.

## Test plan

- [ ] Kimi K2.5 TP8 and TP8+DP8 variants pass on 8-gpu runners