### PR TITLE
feat(anthropic): add thinking/reasoning support and cache token usage to /v1/messages

### DIFF
--- a/python/sglang/srt/entrypoints/anthropic/protocol.py
+++ b/python/sglang/srt/entrypoints/anthropic/protocol.py
@@ -97,6 +97,16 @@ class AnthropicCountTokensResponse(BaseModel):
     input_tokens: int
 
 
+class AnthropicThinkingParam(BaseModel):
+    """Thinking configuration for extended thinking support.
+
+    See: https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking
+    """
+
+    type: Literal["enabled", "disabled"]
+    budget_tokens: Optional[int] = None
+
+
 class AnthropicMessagesRequest(BaseModel):
     """Anthropic Messages API request"""
 
@@ -108,6 +118,7 @@ class AnthropicMessagesRequest(BaseModel):
     stream: Optional[bool] = False
     system: Optional[str | list[AnthropicContentBlock]] = None
     temperature: Optional[float] = None
+    thinking: Optional[AnthropicThinkingParam] = None
     tool_choice: Optional[AnthropicToolChoice] = None
     tools: Optional[list[AnthropicTool]] = None
     top_k: Optional[int] = None
@@ -131,8 +142,12 @@ class AnthropicMessagesRequest(BaseModel):
 class AnthropicDelta(BaseModel):
     """Delta for streaming responses"""
 
-    type: Optional[Literal["text_delta", "input_json_delta"]] = None
+    type: Optional[
+        Literal["text_delta", "thinking_delta", "signature_delta", "input_json_delta"]
+    ] = None
     text: Optional[str] = None
+    thinking: Optional[str] = None
+    signature: Optional[str] = None
     partial_json: Optional[str] = None
 
     # Message delta fields

--- a/python/sglang/srt/entrypoints/anthropic/serving.py
+++ b/python/sglang/srt/entrypoints/anthropic/serving.py
@@ -184,7 +184,28 @@ class AnthropicServing:
             content_parts = []
             tool_calls = []
 
+            # For assistant messages, reconstruct thinking blocks as <think>
+            # tags so the chat template receives the correct format for
+            # multi-turn conversations with reasoning models.
+            if msg.role == "assistant":
+                thinking_parts = [
+                    block.thinking
+                    for block in msg.content
+                    if block.type == "thinking" and block.thinking
+                ]
+                if thinking_parts:
+                    combined = "\n".join(thinking_parts)
+                    content_parts.append(
+                        {
+                            "type": "text",
+                            "text": f"<think>\n{combined}\n</think>",
+                        }
+                    )
+
             for block in msg.content:
+                if block.type in ("thinking", "redacted_thinking"):
+                    # Already handled above for assistant messages
+                    continue
                 if block.type == "text" and block.text:
                     content_parts.append({"type": "text", "text": block.text})
 
@@ -262,6 +283,24 @@ class AnthropicServing:
             request_data["top_k"] = anthropic_request.top_k
         if anthropic_request.stop_sequences is not None:
             request_data["stop"] = anthropic_request.stop_sequences
+
+        # Wire thinking param through to the OpenAI layer.
+        # We use the `reasoning` dict which is normalized by
+        # ChatCompletionRequest.normalize_reasoning_inputs() to set the
+        # correct model-specific chat_template_kwargs via
+        # _get_reasoning_from_request().
+        if anthropic_request.thinking is not None:
+            if anthropic_request.thinking.type == "enabled":
+                request_data["reasoning"] = {"enabled": True}
+                request_data["separate_reasoning"] = True
+                request_data["stream_reasoning"] = True
+                if anthropic_request.thinking.budget_tokens is not None:
+                    logger.warning("budget_tokens is not supported and will be ignored")
+            else:
+                # type == "disabled"
+                request_data["reasoning_effort"] = "none"
+                request_data["separate_reasoning"] = False
+                request_data["stream_reasoning"] = False
 
         # Enable usage in stream so we can report it
         if anthropic_request.stream:
@@ -428,6 +467,7 @@ class AnthropicServing:
         first_chunk = True
         content_block_index = 0
         content_block_open = False
+        thinking_block_open = False
         finish_reason: Optional[str] = None
         usage_info: Optional[dict] = None
         message_id = f"msg_{uuid.uuid4().hex}"
@@ -442,6 +482,20 @@ class AnthropicServing:
             if data_str == "[DONE]":
                 # Close any open content block
                 if content_block_open:
+                    # Emit signature_delta before closing a thinking block
+                    if thinking_block_open:
+                        sig_event = AnthropicStreamEvent(
+                            type="content_block_delta",
+                            index=content_block_index,
+                            delta=AnthropicDelta(
+                                type="signature_delta",
+                                signature="",
+                            ),
+                        )
+                        yield _wrap_sse_event(
+                            sig_event.model_dump_json(exclude_none=True),
+                            "content_block_delta",
+                        )
                     stop_event = AnthropicStreamEvent(
                         type="content_block_stop",
                         index=content_block_index,
@@ -498,6 +552,15 @@ class AnthropicServing:
             if first_chunk:
                 first_chunk = False
 
+                # Extract cache token info if available
+                cache_read = None
+                if (
+                    chunk.usage
+                    and chunk.usage.prompt_tokens_details
+                    and chunk.usage.prompt_tokens_details.cached_tokens
+                ):
+                    cache_read = chunk.usage.prompt_tokens_details.cached_tokens
+
                 start_event = AnthropicStreamEvent(
                     type="message_start",
                     message=AnthropicMessagesResponse(
@@ -509,6 +572,7 @@ class AnthropicServing:
                                 chunk.usage.prompt_tokens if chunk.usage else 0
                             ),
                             output_tokens=0,
+                            cache_read_input_tokens=cache_read,
                         ),
                     ),
                 )
@@ -550,6 +614,21 @@ class AnthropicServing:
                     if tc_func and tc_func.name:
                         # Close previous content block if open
                         if content_block_open:
+                            # Emit signature_delta if closing a thinking block
+                            if thinking_block_open:
+                                sig_event = AnthropicStreamEvent(
+                                    type="content_block_delta",
+                                    index=content_block_index,
+                                    delta=AnthropicDelta(
+                                        type="signature_delta",
+                                        signature="",
+                                    ),
+                                )
+                                yield _wrap_sse_event(
+                                    sig_event.model_dump_json(exclude_none=True),
+                                    "content_block_delta",
+                                )
+                                thinking_block_open = False
                             stop_event = AnthropicStreamEvent(
                                 type="content_block_stop",
                                 index=content_block_index,
@@ -608,8 +687,68 @@ class AnthropicServing:
                         )
                 continue
 
+            # Handle reasoning/thinking content deltas
+            if delta.reasoning_content is not None and delta.reasoning_content != "":
+                # Start a thinking content block if needed
+                if not thinking_block_open:
+                    start_event = AnthropicStreamEvent(
+                        type="content_block_start",
+                        index=content_block_index,
+                        content_block=AnthropicContentBlock(
+                            type="thinking", thinking=""
+                        ),
+                    )
+                    yield _wrap_sse_event(
+                        start_event.model_dump_json(exclude_none=True),
+                        "content_block_start",
+                    )
+                    thinking_block_open = True
+                    content_block_open = True
+
+                # Emit thinking delta
+                delta_event = AnthropicStreamEvent(
+                    type="content_block_delta",
+                    index=content_block_index,
+                    delta=AnthropicDelta(
+                        type="thinking_delta",
+                        thinking=delta.reasoning_content,
+                    ),
+                )
+                yield _wrap_sse_event(
+                    delta_event.model_dump_json(exclude_none=True),
+                    "content_block_delta",
+                )
+                continue
+
             # Handle text content deltas
             if delta.content is not None and delta.content != "":
+                # Close thinking block if transitioning to text
+                if thinking_block_open:
+                    # Emit signature_delta before closing thinking block
+                    sig_event = AnthropicStreamEvent(
+                        type="content_block_delta",
+                        index=content_block_index,
+                        delta=AnthropicDelta(
+                            type="signature_delta",
+                            signature="",
+                        ),
+                    )
+                    yield _wrap_sse_event(
+                        sig_event.model_dump_json(exclude_none=True),
+                        "content_block_delta",
+                    )
+                    stop_event = AnthropicStreamEvent(
+                        type="content_block_stop",
+                        index=content_block_index,
+                    )
+                    yield _wrap_sse_event(
+                        stop_event.model_dump_json(exclude_none=True),
+                        "content_block_stop",
+                    )
+                    content_block_index += 1
+                    thinking_block_open = False
+                    content_block_open = False
+
                 # Start a text content block if needed
                 if not content_block_open:
                     start_event = AnthropicStreamEvent(
@@ -652,6 +791,16 @@ class AnthropicServing:
         choice = response.choices[0]
         content: list[AnthropicContentBlock] = []
 
+        # Add thinking content block if reasoning_content is present
+        if choice.message.reasoning_content:
+            content.append(
+                AnthropicContentBlock(
+                    type="thinking",
+                    thinking=choice.message.reasoning_content,
+                    signature="",
+                )
+            )
+
         # Add text content
         if choice.message.content:
             content.append(
@@ -678,6 +827,15 @@ class AnthropicServing:
         # Map stop reason
         stop_reason = STOP_REASON_MAP.get(choice.finish_reason or "stop", "end_turn")
 
+        # Extract cache token info if available
+        cache_read = None
+        if (
+            response.usage
+            and response.usage.prompt_tokens_details
+            and response.usage.prompt_tokens_details.cached_tokens
+        ):
+            cache_read = response.usage.prompt_tokens_details.cached_tokens
+
         return AnthropicMessagesResponse(
             id=f"msg_{uuid.uuid4().hex}",
             content=content,
@@ -685,7 +843,10 @@ class AnthropicServing:
             stop_reason=stop_reason,
             usage=AnthropicUsage(
                 input_tokens=response.usage.prompt_tokens if response.usage else 0,
-                output_tokens=response.usage.completion_tokens if response.usage else 0,
+                output_tokens=(
+                    response.usage.completion_tokens if response.usage else 0
+                ),
+                cache_read_input_tokens=cache_read,
             ),
         )
 

--- a/test/registered/openai_server/basic/test_anthropic_server.py
+++ b/test/registered/openai_server/basic/test_anthropic_server.py
@@ -19,7 +19,10 @@ import unittest
 
 import requests
 
-from sglang.srt.entrypoints.anthropic.protocol import AnthropicMessagesRequest
+from sglang.srt.entrypoints.anthropic.protocol import (
+    AnthropicMessagesRequest,
+    AnthropicThinkingParam,
+)
 from sglang.srt.entrypoints.anthropic.serving import AnthropicServing
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
@@ -554,6 +557,523 @@ class TestAnthropicServer(CustomTestCase):
                     pass
 
         return events
+
+
+class TestAnthropicThinkingConversion(unittest.TestCase):
+    """Unit tests for thinking/reasoning support in request/response conversion.
+
+    These tests verify the translation logic without requiring a running server.
+    """
+
+    def _make_serving(self):
+        return AnthropicServing(openai_serving_chat=object())
+
+    def test_thinking_enabled_sets_reasoning(self):
+        """thinking.type='enabled' should set reasoning={enabled: True},
+        separate_reasoning/stream_reasoning=True, and
+        chat_template_kwargs.thinking=True on the chat request."""
+        request = AnthropicMessagesRequest(
+            model="test-model",
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "Think about this."}],
+            thinking=AnthropicThinkingParam(type="enabled", budget_tokens=4096),
+        )
+        serving = self._make_serving()
+        chat_req = serving._convert_to_chat_completion_request(request)
+
+        self.assertTrue(chat_req.separate_reasoning)
+        self.assertTrue(chat_req.stream_reasoning)
+        # The normalize_reasoning_inputs validator should set this
+        self.assertIsNotNone(chat_req.chat_template_kwargs)
+        self.assertTrue(chat_req.chat_template_kwargs.get("thinking"))
+
+    def test_thinking_disabled_sets_reasoning_effort_none(self):
+        """thinking.type='disabled' should set reasoning_effort='none',
+        separate_reasoning/stream_reasoning=False, and
+        chat_template_kwargs.thinking=False."""
+        request = AnthropicMessagesRequest(
+            model="test-model",
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "No thinking please."}],
+            thinking=AnthropicThinkingParam(type="disabled"),
+        )
+        serving = self._make_serving()
+        chat_req = serving._convert_to_chat_completion_request(request)
+
+        self.assertEqual(chat_req.reasoning_effort, "none")
+        self.assertFalse(chat_req.separate_reasoning)
+        self.assertFalse(chat_req.stream_reasoning)
+        # reasoning_effort="none" should set thinking=False
+        self.assertIsNotNone(chat_req.chat_template_kwargs)
+        self.assertFalse(chat_req.chat_template_kwargs.get("thinking"))
+        self.assertFalse(chat_req.chat_template_kwargs.get("enable_thinking"))
+
+    def test_no_thinking_param_preserves_defaults(self):
+        """When thinking is not specified, separate_reasoning and stream_reasoning
+        should remain at their defaults (True)."""
+        request = AnthropicMessagesRequest(
+            model="test-model",
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "Hello."}],
+        )
+        serving = self._make_serving()
+        chat_req = serving._convert_to_chat_completion_request(request)
+
+        self.assertTrue(chat_req.separate_reasoning)
+        self.assertTrue(chat_req.stream_reasoning)
+        self.assertIsNone(chat_req.reasoning_effort)
+
+    def test_multi_turn_thinking_blocks_reconstructed(self):
+        """Thinking blocks in assistant messages should be reconstructed as
+        <think>...</think> tags for the chat template."""
+        request = AnthropicMessagesRequest(
+            model="test-model",
+            max_tokens=1024,
+            messages=[
+                {"role": "user", "content": "What is 2+2?"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "thinking",
+                            "thinking": "Let me calculate: 2+2=4",
+                        },
+                        {"type": "text", "text": "The answer is 4."},
+                    ],
+                },
+                {"role": "user", "content": "And 3+3?"},
+            ],
+        )
+        serving = self._make_serving()
+        chat_req = serving._convert_to_chat_completion_request(request)
+        converted = chat_req.model_dump()
+
+        # Find the assistant message
+        assistant_msgs = [
+            m for m in converted["messages"] if m.get("role") == "assistant"
+        ]
+        self.assertEqual(len(assistant_msgs), 1)
+
+        assistant_content = assistant_msgs[0]["content"]
+        # Should be a list with <think> block + text
+        self.assertIsInstance(assistant_content, list)
+        texts = [p["text"] for p in assistant_content if p.get("type") == "text"]
+        # First part should contain the think tags
+        self.assertTrue(
+            any("<think>" in t for t in texts),
+            f"Expected <think> tag in assistant content, got: {texts}",
+        )
+        # Second part should be the actual response
+        self.assertTrue(
+            any("The answer is 4." in t for t in texts),
+            f"Expected response text in assistant content, got: {texts}",
+        )
+
+    def test_redacted_thinking_blocks_skipped(self):
+        """Redacted thinking blocks should be skipped in conversion."""
+        request = AnthropicMessagesRequest(
+            model="test-model",
+            max_tokens=1024,
+            messages=[
+                {"role": "user", "content": "Hello"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "redacted_thinking"},
+                        {"type": "text", "text": "Hi there!"},
+                    ],
+                },
+                {"role": "user", "content": "Bye"},
+            ],
+        )
+        serving = self._make_serving()
+        chat_req = serving._convert_to_chat_completion_request(request)
+        converted = chat_req.model_dump()
+
+        assistant_msgs = [
+            m for m in converted["messages"] if m.get("role") == "assistant"
+        ]
+        self.assertEqual(len(assistant_msgs), 1)
+        # Content should only have the text, not redacted_thinking
+        content = assistant_msgs[0]["content"]
+        if isinstance(content, str):
+            self.assertEqual(content, "Hi there!")
+        else:
+            texts = [p["text"] for p in content if p.get("type") == "text"]
+            self.assertNotIn("<think>", " ".join(texts))
+
+    def test_convert_response_with_reasoning_content(self):
+        """Non-streaming response with reasoning_content should include a
+        thinking content block before text."""
+        from sglang.srt.entrypoints.openai.protocol import (
+            ChatCompletionResponse,
+            ChatCompletionResponseChoice,
+            ChatMessage,
+            UsageInfo,
+        )
+
+        response = ChatCompletionResponse(
+            id="chatcmpl-test",
+            model="test-model",
+            choices=[
+                ChatCompletionResponseChoice(
+                    index=0,
+                    message=ChatMessage(
+                        role="assistant",
+                        content="The answer is 4.",
+                        reasoning_content="Let me think step by step: 2+2=4",
+                    ),
+                    finish_reason="stop",
+                )
+            ],
+            usage=UsageInfo(prompt_tokens=10, completion_tokens=20, total_tokens=30),
+        )
+
+        serving = self._make_serving()
+        result = serving._convert_response(response)
+
+        # Should have thinking block + text block
+        self.assertEqual(len(result.content), 2)
+        self.assertEqual(result.content[0].type, "thinking")
+        self.assertEqual(result.content[0].thinking, "Let me think step by step: 2+2=4")
+        self.assertEqual(result.content[0].signature, "")
+        self.assertEqual(result.content[1].type, "text")
+        self.assertEqual(result.content[1].text, "The answer is 4.")
+
+    def test_convert_response_without_reasoning_content(self):
+        """Non-streaming response without reasoning_content should only have
+        text block (no thinking block)."""
+        from sglang.srt.entrypoints.openai.protocol import (
+            ChatCompletionResponse,
+            ChatCompletionResponseChoice,
+            ChatMessage,
+            UsageInfo,
+        )
+
+        response = ChatCompletionResponse(
+            id="chatcmpl-test",
+            model="test-model",
+            choices=[
+                ChatCompletionResponseChoice(
+                    index=0,
+                    message=ChatMessage(
+                        role="assistant",
+                        content="Hello world.",
+                    ),
+                    finish_reason="stop",
+                )
+            ],
+            usage=UsageInfo(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+        )
+
+        serving = self._make_serving()
+        result = serving._convert_response(response)
+
+        self.assertEqual(len(result.content), 1)
+        self.assertEqual(result.content[0].type, "text")
+        self.assertEqual(result.content[0].text, "Hello world.")
+
+    def test_convert_response_cache_tokens(self):
+        """Cache token info should be populated in the Anthropic response."""
+        from sglang.srt.entrypoints.openai.protocol import (
+            ChatCompletionResponse,
+            ChatCompletionResponseChoice,
+            ChatMessage,
+            PromptTokensDetails,
+            UsageInfo,
+        )
+
+        response = ChatCompletionResponse(
+            id="chatcmpl-test",
+            model="test-model",
+            choices=[
+                ChatCompletionResponseChoice(
+                    index=0,
+                    message=ChatMessage(role="assistant", content="Cached response."),
+                    finish_reason="stop",
+                )
+            ],
+            usage=UsageInfo(
+                prompt_tokens=100,
+                completion_tokens=10,
+                total_tokens=110,
+                prompt_tokens_details=PromptTokensDetails(cached_tokens=80),
+            ),
+        )
+
+        serving = self._make_serving()
+        result = serving._convert_response(response)
+
+        self.assertEqual(result.usage.input_tokens, 100)
+        self.assertEqual(result.usage.output_tokens, 10)
+        self.assertEqual(result.usage.cache_read_input_tokens, 80)
+
+
+class TestAnthropicThinkingStreaming(unittest.TestCase):
+    """Unit tests for streaming thinking/reasoning event translation.
+
+    These tests mock the OpenAI stream output and verify the Anthropic
+    event sequence without requiring a running server.
+    """
+
+    def _collect_events(self, sse_output: list[str]) -> list[dict]:
+        """Parse Anthropic SSE events from raw output strings.
+
+        Each string from _wrap_sse_event is 'event: ...\ndata: ...\n\n'.
+        """
+        events = []
+        for chunk in sse_output:
+            for line in chunk.split("\n"):
+                line = line.strip()
+                if line.startswith("data: "):
+                    data_str = line[6:].strip()
+                    if data_str and data_str != "[DONE]":
+                        events.append(json.loads(data_str))
+        return events
+
+    async def _run_stream(self, openai_chunks: list[str]) -> list[str]:
+        """Run the Anthropic stream generator with mocked OpenAI chunks."""
+        from unittest.mock import MagicMock
+
+        # Create mock serving
+        mock_chat = MagicMock()
+
+        async def mock_stream(*args, **kwargs):
+            for chunk in openai_chunks:
+                yield chunk
+
+        mock_chat._generate_chat_stream = mock_stream
+
+        serving = AnthropicServing(openai_serving_chat=mock_chat)
+
+        anthropic_request = AnthropicMessagesRequest(
+            model="test-model",
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "test"}],
+            thinking=AnthropicThinkingParam(type="enabled"),
+        )
+
+        lines = []
+        async for line in serving._generate_anthropic_stream(
+            adapted_request=MagicMock(),
+            processed_request=MagicMock(),
+            anthropic_request=anthropic_request,
+            raw_request=MagicMock(),
+        ):
+            lines.append(line)
+        return lines
+
+    def _make_openai_chunk(
+        self,
+        content=None,
+        reasoning_content=None,
+        finish_reason=None,
+        role=None,
+        usage=None,
+        tool_calls=None,
+    ):
+        """Build a mock OpenAI SSE data line."""
+        chunk = {
+            "id": "chatcmpl-test",
+            "object": "chat.completion.chunk",
+            "created": 1234567890,
+            "model": "test-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {},
+                    "finish_reason": finish_reason,
+                }
+            ],
+        }
+        delta = chunk["choices"][0]["delta"]
+        if role is not None:
+            delta["role"] = role
+        if content is not None:
+            delta["content"] = content
+        if reasoning_content is not None:
+            delta["reasoning_content"] = reasoning_content
+        if tool_calls is not None:
+            delta["tool_calls"] = tool_calls
+        if usage is not None:
+            # Ensure total_tokens is present (required by UsageInfo)
+            if "total_tokens" not in usage:
+                usage["total_tokens"] = usage.get("prompt_tokens", 0) + usage.get(
+                    "completion_tokens", 0
+                )
+            chunk["usage"] = usage
+            if finish_reason is None and content is None and reasoning_content is None:
+                # Usage-only chunk has no choices
+                chunk["choices"] = []
+        return f"data: {json.dumps(chunk)}"
+
+    def test_thinking_then_text_stream(self):
+        """Streaming: thinking deltas → text deltas should produce correct
+        Anthropic event sequence with signature_delta."""
+        import asyncio
+
+        chunks = [
+            # First chunk with role + usage
+            self._make_openai_chunk(
+                role="assistant",
+                content="",
+                usage={"prompt_tokens": 10, "completion_tokens": 0},
+            ),
+            # Thinking deltas
+            self._make_openai_chunk(reasoning_content="Let me "),
+            self._make_openai_chunk(reasoning_content="think..."),
+            # Text deltas
+            self._make_openai_chunk(content="The answer"),
+            self._make_openai_chunk(content=" is 4."),
+            # Finish
+            self._make_openai_chunk(finish_reason="stop"),
+            # Usage chunk
+            self._make_openai_chunk(
+                usage={"prompt_tokens": 10, "completion_tokens": 20}
+            ),
+            "data: [DONE]",
+        ]
+
+        lines = asyncio.run(self._run_stream(chunks))
+        events = self._collect_events(lines)
+
+        event_types = [e["type"] for e in events]
+
+        # Verify event sequence
+        self.assertEqual(event_types[0], "message_start")
+
+        # Should have: thinking block_start, thinking_deltas, signature_delta,
+        # thinking block_stop, text block_start, text_deltas, text block_stop
+        self.assertIn("content_block_start", event_types)
+        self.assertIn("content_block_delta", event_types)
+        self.assertIn("content_block_stop", event_types)
+
+        # Find thinking block events
+        block_starts = [e for e in events if e["type"] == "content_block_start"]
+        self.assertEqual(len(block_starts), 2)
+        self.assertEqual(block_starts[0]["content_block"]["type"], "thinking")
+        self.assertEqual(block_starts[0]["index"], 0)
+        self.assertEqual(block_starts[1]["content_block"]["type"], "text")
+        self.assertEqual(block_starts[1]["index"], 1)
+
+        # Find thinking deltas
+        thinking_deltas = [
+            e
+            for e in events
+            if e["type"] == "content_block_delta"
+            and e.get("delta", {}).get("type") == "thinking_delta"
+        ]
+        self.assertEqual(len(thinking_deltas), 2)
+        self.assertEqual(thinking_deltas[0]["delta"]["thinking"], "Let me ")
+        self.assertEqual(thinking_deltas[1]["delta"]["thinking"], "think...")
+
+        # Find signature_delta (should appear before thinking block_stop)
+        sig_deltas = [
+            e
+            for e in events
+            if e["type"] == "content_block_delta"
+            and e.get("delta", {}).get("type") == "signature_delta"
+        ]
+        self.assertEqual(len(sig_deltas), 1)
+        self.assertEqual(sig_deltas[0]["delta"]["signature"], "")
+
+        # Find text deltas
+        text_deltas = [
+            e
+            for e in events
+            if e["type"] == "content_block_delta"
+            and e.get("delta", {}).get("type") == "text_delta"
+        ]
+        self.assertEqual(len(text_deltas), 2)
+        full_text = "".join(d["delta"]["text"] for d in text_deltas)
+        self.assertEqual(full_text, "The answer is 4.")
+
+        # Verify message_delta with stop_reason
+        msg_deltas = [e for e in events if e["type"] == "message_delta"]
+        self.assertEqual(len(msg_deltas), 1)
+        self.assertEqual(msg_deltas[0]["delta"]["stop_reason"], "end_turn")
+
+    def test_thinking_only_stream(self):
+        """Streaming: thinking deltas only (no text) should still produce
+        correct events with signature_delta before block_stop."""
+        import asyncio
+
+        chunks = [
+            self._make_openai_chunk(
+                role="assistant",
+                content="",
+                usage={"prompt_tokens": 5, "completion_tokens": 0},
+            ),
+            self._make_openai_chunk(reasoning_content="Deep thought..."),
+            self._make_openai_chunk(finish_reason="stop"),
+            self._make_openai_chunk(
+                usage={"prompt_tokens": 5, "completion_tokens": 10}
+            ),
+            "data: [DONE]",
+        ]
+
+        lines = asyncio.run(self._run_stream(chunks))
+        events = self._collect_events(lines)
+
+        # Should have: message_start, thinking block_start, thinking_delta,
+        # signature_delta, thinking block_stop, message_delta, message_stop
+        block_starts = [e for e in events if e["type"] == "content_block_start"]
+        self.assertEqual(len(block_starts), 1)
+        self.assertEqual(block_starts[0]["content_block"]["type"], "thinking")
+
+        # Only one block stop (for thinking)
+        block_stops = [e for e in events if e["type"] == "content_block_stop"]
+        self.assertEqual(len(block_stops), 1)
+
+        # Signature delta should be present
+        sig_deltas = [
+            e
+            for e in events
+            if e["type"] == "content_block_delta"
+            and e.get("delta", {}).get("type") == "signature_delta"
+        ]
+        self.assertEqual(len(sig_deltas), 1)
+
+    def test_text_only_stream_unchanged(self):
+        """Streaming: text-only should produce standard events with no
+        thinking blocks (regression test)."""
+        import asyncio
+
+        chunks = [
+            self._make_openai_chunk(
+                role="assistant",
+                content="",
+                usage={"prompt_tokens": 5, "completion_tokens": 0},
+            ),
+            self._make_openai_chunk(content="Hello world."),
+            self._make_openai_chunk(finish_reason="stop"),
+            self._make_openai_chunk(usage={"prompt_tokens": 5, "completion_tokens": 3}),
+            "data: [DONE]",
+        ]
+
+        lines = asyncio.run(self._run_stream(chunks))
+        events = self._collect_events(lines)
+
+        block_starts = [e for e in events if e["type"] == "content_block_start"]
+        self.assertEqual(len(block_starts), 1)
+        self.assertEqual(block_starts[0]["content_block"]["type"], "text")
+
+        # No thinking or signature deltas
+        thinking_deltas = [
+            e
+            for e in events
+            if e["type"] == "content_block_delta"
+            and e.get("delta", {}).get("type") == "thinking_delta"
+        ]
+        self.assertEqual(len(thinking_deltas), 0)
+
+        sig_deltas = [
+            e
+            for e in events
+            if e["type"] == "content_block_delta"
+            and e.get("delta", {}).get("type") == "signature_delta"
+        ]
+        self.assertEqual(len(sig_deltas), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Add support for extended thinking/reasoning in the Anthropic Messages API compatibility layer (`/v1/messages`). Currently, the `thinking` request parameter is silently dropped and `reasoning_content` from the OpenAI layer is never mapped to Anthropic thinking content blocks.

**Closes #19257** — Anthropic API swallows thinking tokens and ignores thinking control parameters
**Closes #20754** — Anthropic API missing thinking/reasoning support and cache token usage report

## Prior Work

This PR builds on the work in #19334 and #20902. Key improvements:

- **Addresses @JustinTong0323's feedback** from #19334: instead of hardcoding model-specific thinking keys, we wire through the existing `reasoning`/`reasoning_effort` fields which cascade to model-specific `chat_template_kwargs` via `normalize_reasoning_inputs()` and `_get_reasoning_from_request()`. This handles deepseek-v3, qwen3, glm45, kimi_k2, nemotron_3, interns1, mimo, and mistral correctly.
- **Multi-turn thinking history**: reconstructs thinking blocks in assistant messages as `<think>` tags for correct chat template formatting (fixes 500 errors identified by @dangell7 in #19334).
- **Cache token usage**: populates `cache_read_input_tokens` from `prompt_tokens_details.cached_tokens` (from #20754).
- **Streaming signature_delta events**: emits `signature_delta` before `content_block_stop` for thinking blocks, matching the Anthropic SSE spec.

## Changes

### `protocol.py` (+17 lines)
- `AnthropicThinkingParam` model (`type: "enabled"|"disabled"`, `budget_tokens`)
- `thinking` field on `AnthropicMessagesRequest`
- `"thinking_delta"`, `"signature_delta"` added to `AnthropicDelta.type`
- `thinking`, `signature` fields on `AnthropicDelta`

### `serving.py` (+163 lines)

**Request conversion:**
- `thinking.type="enabled"` → `reasoning={"enabled": True}`, `separate_reasoning=True`, `stream_reasoning=True`
- `thinking.type="disabled"` → `reasoning_effort="none"`, `separate_reasoning=False`, `stream_reasoning=False`
- Logs warning when `budget_tokens` is provided (not yet supported by the backend)
- Reconstructs thinking/redacted_thinking blocks as `<think>` tags in multi-turn assistant messages

**Streaming:**
- Opens thinking content block (`type="thinking"`) when `reasoning_content` arrives
- Emits `thinking_delta` events with reasoning tokens
- Emits `signature_delta` + `content_block_stop` on thinking block close
- Handles transitions: thinking→text, thinking→tool_calls, thinking→done

**Non-streaming:**
- Maps `reasoning_content` to thinking `AnthropicContentBlock` (with `signature=""`) prepended before text

**Cache tokens:**
- Populates `cache_read_input_tokens` from `prompt_tokens_details.cached_tokens` in both streaming and non-streaming paths

### Tests (+522 lines)

**`TestAnthropicThinkingConversion`** (8 unit tests):
- Thinking enabled/disabled/default param conversion
- `chat_template_kwargs.thinking` set correctly
- Multi-turn thinking block reconstruction
- Redacted thinking skip
- Non-streaming response with/without reasoning_content + signature field
- Cache token passthrough

**`TestAnthropicThinkingStreaming`** (3 unit tests with mocked OpenAI stream):
- Thinking→text transition (full event sequence verification)
- Thinking-only stream (signature_delta before block_stop)
- Text-only regression test (no thinking events emitted)

## Known Limitations

- `budget_tokens` is accepted but not forwarded to the backend (no equivalent in the OpenAI protocol). A warning is logged.
- `signature` field uses an empty string since local models do not produce Anthropic cryptographic signatures.
- Multi-turn thinking reconstruction uses `<think>` tags, which matches deepseek/qwen3/glm conventions but may need adjustment for models with different reasoning delimiters.

## Testing

```bash
# Unit tests (no GPU required)
python3 -m pytest test/registered/openai_server/basic/test_anthropic_server.py::TestAnthropicThinkingConversion -v
python3 -m pytest test/registered/openai_server/basic/test_anthropic_server.py::TestAnthropicThinkingStreaming -v

# Pre-commit
pre-commit run --all-files
```

All 11 tests pass. All pre-commit checks (black, isort, ruff, codespell) pass.