### PR TITLE
[CI] Add timeouts to Slack upload urlopen and WebClient

### DIFF
--- a/python/sglang/multimodal_gen/test/slack_utils.py
+++ b/python/sglang/multimodal_gen/test/slack_utils.py
@@ -130,7 +130,7 @@ def upload_file_to_slack(
                 try:
                     suffix = os.path.splitext(urlparse(path).path)[1] or ".tmp"
                     with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tf:
-                        with urlopen(path) as response:
+                        with urlopen(path, timeout=30) as response:
                             tf.write(response.read())
                     temp_paths.append(tf.name)
                     final_origin_paths.append(tf.name)
@@ -155,7 +155,7 @@ def upload_file_to_slack(
             f"*Case ID:* `{case_id}`\n" f"*Model:* `{model}`\n" f"*Prompt:* {prompt}"
         )
 
-        client = WebClient(token=token)
+        client = WebClient(token=token, timeout=60)
         channel_id = "C0A02NDF7UY"
         thread_ts = None
 


### PR DESCRIPTION
## Summary
- `urlopen()` falls back to the global default socket timeout (typically the OS TCP timeout of ~2+ minutes) when no explicit timeout is set, causing the diffusion nightly CI job to stall long enough to hit the 60-minute GitHub Actions step timeout.
- Add `timeout=30s` to `urlopen` (image download) and `timeout=60s` to Slack `WebClient` (API calls) for faster failure and retry.

## Test plan
- [ ] Verify diffusion nightly CI no longer hangs on Slack upload when network is slow/unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)