### PR TITLE
Skip Go stdlib and NVIDIA tool CVEs in Trivy scan

### DIFF
--- a/.github/workflows/trivy-scan-dev.yml
+++ b/.github/workflows/trivy-scan-dev.yml
@@ -36,6 +36,7 @@ jobs:
           output: 'trivy-results-${{ matrix.tag }}.sarif'
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
+          skip-dirs: 'usr/local/go,opt/nvidia'
 
       - name: Upload Trivy scan results to GitHub Security
         uses: github/codeql-action/upload-sarif@v4
@@ -53,6 +54,7 @@ jobs:
           format: 'table'
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
+          skip-dirs: 'usr/local/go,opt/nvidia'
 
       - name: Scan summary
         if: always()


### PR DESCRIPTION
## Summary
- Add `skip-dirs: usr/local/go,opt/nvidia` to both Trivy scan steps in the nightly workflow
- These directories contain Go binaries from the NVIDIA CUDA devel base image (`nvidia/cuda:12.9.1-cudnn-devel-ubuntu24.04`) that SGLang doesn't use or control
- Eliminates ~500 non-actionable alerts (Go stdlib CVEs in `/usr/local/go` Go 1.23.8 toolchain, and NVIDIA Nsight EFA metrics plugin CVEs in `/opt/nvidia`)

## Context

The NVIDIA base image ships:
- `/usr/local/go` — full Go 1.23.8 toolchain (used by NVIDIA build tools)
- `/opt/nvidia/nsight-compute/.../nic_sampler` — Go binary for EFA metrics

Trivy's gobinary scanner flags every Go stdlib CVE against these binaries, producing hundreds of alerts that can't be fixed without switching base images.

## Test plan
- [ ] Trigger workflow manually and verify alert count drops significantly
- [ ] Verify actionable CVEs (Python packages, Rust deps, OS packages) are still reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)