### PR TITLE
Fix ngram doc for speculative_num_draft_tokens default

### DIFF
--- a/docs/advanced_features/speculative_decoding.md
+++ b/docs/advanced_features/speculative_decoding.md
@@ -387,7 +387,7 @@ Enable it with:
 
 | Parameter | Description | Default |
 |---|---|---|
-| `--speculative-num-draft-tokens` | Number of draft tokens verified per step. If omitted, defaults to `min(--speculative-ngram-max-trie-depth, 12)`. | `12` (with default ngram settings) |
+| `--speculative-num-draft-tokens` | Number of draft tokens verified per step. | `12` |
 | `--speculative-ngram-min-bfs-breadth` | Minimum BFS breadth. | `1` |
 | `--speculative-ngram-max-bfs-breadth` | Maximum BFS breadth. | `10` |
 | `--speculative-ngram-match-type` | Ngram tree-building mode: `"BFS"` for recency-based expansion or `"PROB"` for frequency-based expansion. | `"BFS"` |


### PR DESCRIPTION
## Summary
- Fix incorrect default description for `--speculative-num-draft-tokens` in ngram speculative decoding docs
- The doc incorrectly stated the default is `min(--speculative-ngram-max-trie-depth, 12)`, but the code hardcodes `12` — these two params are orthogonal (draft tree budget vs suffix match length)