### PR TITLE
Fix DP attention worker port binding for IPv6 support

### DIFF
--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -53,7 +53,12 @@ from sglang.srt.utils.common import (
     kill_itself_when_parent_died,
     maybe_reindex_device_id,
 )
-from sglang.srt.utils.network import NetworkAddress, bind_port, get_zmq_socket
+from sglang.srt.utils.network import (
+    NetworkAddress,
+    bind_port,
+    get_zmq_socket,
+    get_zmq_socket_on_host,
+)
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 from sglang.srt.utils.watchdog import Watchdog
 from sglang.utils import TypeBasedDispatcher, get_exception_traceback
@@ -372,14 +377,26 @@ class DataParallelController:
     def launch_dp_attention_schedulers(
         self, server_args: ServerArgs, port_args: PortArgs
     ):
+        if server_args.dist_init_addr is None:
+            bind_host = "127.0.0.1"
+        else:
+            bind_host = NetworkAddress.parse(server_args.dist_init_addr).host
+
         # Pre-allocate worker ports on node 0 to avoid conflicts
         worker_ports = []
         if server_args.node_rank == 0:
             for dp_rank in range(server_args.dp_size):
-                port_and_socket = get_zmq_socket(self.context, zmq.PUSH)
-                worker_ports.append(port_and_socket[0])
-                self.workers[dp_rank] = port_and_socket[1]
-                logger.debug(f"Assigned port {port_and_socket[0]} to worker {dp_rank}")
+                worker_port, worker_socket = get_zmq_socket_on_host(
+                    self.context, zmq.PUSH, host=bind_host
+                )
+                worker_ports.append(worker_port)
+                self.workers[dp_rank] = worker_socket
+                logger.debug(
+                    "Assigned port %s to worker %s on host %s",
+                    worker_port,
+                    dp_rank,
+                    bind_host,
+                )
 
         broadcasted_ports = self._broadcast_worker_ports(
             server_args, worker_ports if worker_ports else None


### PR DESCRIPTION
## Summary

The old code used `get_zmq_socket` which binds to `tcp://*` — this is IPv4-only in ZMQ (no `zmq.IPV6` flag set), so DP attention worker PUSH sockets are unreachable on IPv6-only networks.

Switch to `get_zmq_socket_on_host` with the host derived from `dist_init_addr`, which properly detects IPv6, sets `zmq.IPV6=1`, and binds with bracket notation. This also ensures the PUSH socket binds to the same host the scheduler PULL socket connects to.

## Motivation

On IPv6-only clusters, the DP controller`s worker PUSH sockets bind to `tcp://*` (IPv4 wildcard) while schedulers try to connect via IPv6 addresses from `dist_init_addr`. The connection silently fails because ZMQ requires explicit `zmq.IPV6=1` to listen on IPv6.

## Modifications

- `data_parallel_controller.py`: In `launch_dp_attention_schedulers`, derive `bind_host` from `dist_init_addr` (same logic as `_broadcast_worker_ports`) and use `get_zmq_socket_on_host` instead of `get_zmq_socket`.
