### PR TITLE
Implement defunctionalization for sgl_kernel ops in FixFunctionalizationPass

### DIFF
--- a/python/sglang/srt/compilation/fix_functionalization.py
+++ b/python/sglang/srt/compilation/fix_functionalization.py
@@ -2,6 +2,7 @@
 
 import logging
 import operator
+from collections import defaultdict
 from collections.abc import Iterable
 from typing import Optional, Union
 
@@ -14,25 +15,89 @@ from sglang.srt.compilation.inductor_pass import SGLangInductorPass
 logger = logging.getLogger(__name__)
 
 
+def _get_op(namespace: str, op_name: str) -> Optional[torch.ops.OpOverload]:
+    """Return ``torch.ops.<namespace>.<op_name>.default``, or None."""
+    ns = getattr(torch.ops, namespace, None)
+    if ns is None:
+        return None
+    op = getattr(ns, op_name, None)
+    if op is None:
+        return None
+    return getattr(op, "default", None)
+
+
 class FixFunctionalizationPass(SGLangInductorPass):
     """
     This pass defunctionalizes certain nodes to avoid redundant tensor copies.
     After this pass, DCE (dead-code elimination) should never be run,
     as de-functionalized nodes may appear as dead code.
 
-    To add new nodes to defunctionalize, add to the if-elif chain in __call__.
+    To add new ops, add entries to ``_build_op_table``.
     """
+
+    def _build_op_table(self):
+        """Build a dispatch table mapping op targets to handler functions."""
+        table = {}
+
+        # Activation ops — 'out' kwarg conflicts with inductor lowering.
+        for name in ("silu_and_mul", "gelu_tanh_and_mul", "gelu_and_mul"):
+            op = _get_op("sgl_kernel", name)
+            if op is not None:
+                table[op] = lambda g, n: self.defunctionalize(
+                    g, n, {1: "out"}, args=("out", "input")
+                )
+
+        # Normalization ops
+        for name in ("rmsnorm", "gemma_rmsnorm"):
+            op = _get_op("sgl_kernel", name)
+            if op is not None:
+                table[op] = lambda g, n: self.defunctionalize(g, n, {1: "output"})
+
+        for name in ("fused_add_rmsnorm", "gemma_fused_add_rmsnorm"):
+            op = _get_op("sgl_kernel", name)
+            if op is not None:
+                table[op] = lambda g, n: self.defunctionalize(
+                    g, n, {1: "input", 2: "residual"}
+                )
+
+        # Rotary embedding ops
+        op = _get_op("sgl_kernel", "rotary_embedding")
+        if op is not None:
+            table[op] = lambda g, n: self.defunctionalize(g, n, {1: "query", 2: "key"})
+
+        op = _get_op("sgl_kernel", "apply_rope_pos_ids_cos_sin_cache")
+        if op is not None:
+            table[op] = self._handle_apply_rope_pos_ids
+
+        logger.debug("FixFunctionalizationPass: %d ops registered", len(table))
+        return table
+
+    def _handle_apply_rope_pos_ids(self, graph, node):
+        """Handle optional mutated args (k_buffer, v_buffer)."""
+        mutated_args = {1: "q_rope", 2: "k_rope"}
+        getitem_map = self.getitem_users(node)
+        if 3 in getitem_map:
+            mutated_args[3] = "k_buffer"
+        if 4 in getitem_map:
+            mutated_args[4] = "v_buffer"
+        self.defunctionalize(graph, node, mutated_args)
 
     def __call__(self, graph: torch.fx.Graph):
         self.begin()
         self.dump_graph(graph, "before_fix_functionalization")
 
+        op_table = self._build_op_table()
+
         self.nodes_to_remove: list[torch.fx.Node] = []
         count = 0
         for node in graph.nodes:
             if not is_func(node, auto_functionalized):
-                continue  # Avoid deep if-elif nesting
-            count += 1
+                continue
+
+            handler = op_table.get(node.args[0])
+            if handler is not None:
+                handler(graph, node)
+                count += 1
 
         self.dump_graph(graph, "before_fix_functionalization_cleanup")
 
@@ -82,22 +147,25 @@ class FixFunctionalizationPass(SGLangInductorPass):
         :param mutated_args: The mutated arguments, indexed by getitem index.
         If the value of an arg is a string, `node.kwargs[arg]` is used.
         """
-        for idx, user in self.getitem_users(node).items():
+        for idx, users in self.getitem_users(node).items():
+            if idx not in mutated_args:
+                continue
             arg = mutated_args[idx]
             arg = node.kwargs[arg] if isinstance(arg, str) else arg
-            user.replace_all_uses_with(arg)
-            self._remove(user)
+            for user in users:
+                user.replace_all_uses_with(arg)
+                self._remove(user)
 
-    def getitem_users(self, node: torch.fx.Node) -> dict[int, torch.fx.Node]:
+    def getitem_users(self, node: torch.fx.Node) -> dict[int, list[torch.fx.Node]]:
         """
         Returns the operator.getitem users of the auto-functionalized node,
-        indexed by the index they are getting.
+        indexed by the index they are getting. Multiple getitem nodes for the
+        same index are collected into a list.
         """
-        users = {}
+        users: dict[int, list[torch.fx.Node]] = defaultdict(list)
         for user in node.users:
             if is_func(user, operator.getitem):
-                idx = user.args[1]
-                users[idx] = user
+                users[user.args[1]].append(user)
         return users
 
     def insert_defunctionalized(


### PR DESCRIPTION
## Motivation & Modifications

Implement the `sgl_kernel` dispatch table in `FixFunctionalizationPass` and address the related handling issues discussed in #21550.

## Accuracy & Speed Tests

Environment: **NVIDIA H200 x2 (TP=2)**, **Meta-Llama-3.1-8B-Instruct**, with `--enable-torch-compile --cuda-graph-max-bs 4`

| Test | Result | Detail | Threshold |
|---|---|---:|---:|
| `test_mmlu` | PASS | Score: 0.734 | >= 0.65 |
| `test_throughput` | PASS | 305.3 tokens/s | >= 152 tokens/s |