### PR TITLE
[CI] nvfp4 in nightly

### DIFF
--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -27,6 +27,7 @@ on:
           - 'nightly-test-perf-8-gpu-b200'
           - 'nightly-test-kernel-1-gpu-h100'
           - 'nightly-test-diffusion-comparison'
+          - 'nightly-test-diffusion-comparison-b200'
           - 'nightly-test-kernel-8-gpu-h200'
   workflow_call:
     inputs:
@@ -716,6 +717,70 @@ jobs:
       - uses: ./.github/actions/upload-cuda-coredumps
         if: always()
 
+  # Diffusion cross-framework comparison (B200 / NVFP4)
+  nightly-test-diffusion-comparison-b200:
+    if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-diffusion-comparison-b200')
+    runs-on: 4-gpu-b200
+    timeout-minutes: 240
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Install dependencies
+        run: |
+          bash scripts/ci/cuda/ci_install_dependency.sh diffusion
+
+      - name: Run cross-framework comparison (B200)
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          PYTHONUNBUFFERED: "1"
+        timeout-minutes: 210
+        run: |
+          python3 -u scripts/ci/utils/diffusion/run_comparison.py \
+            --config scripts/ci/utils/diffusion/comparison_configs_b200.json \
+            --output comparison-results.json
+
+      - name: Generate dashboard
+        if: always()
+        env:
+          GH_PAT_FOR_NIGHTLY_CI_DATA: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+        run: |
+          python3 scripts/ci/utils/diffusion/generate_diffusion_dashboard.py \
+            --results comparison-results.json \
+            --output dashboard.md \
+            --charts-dir comparison-charts \
+            --fetch-history \
+            --step-summary
+
+      - name: Publish to sglang-ci-data
+        if: always()
+        env:
+          GH_PAT_FOR_NIGHTLY_CI_DATA: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+        run: |
+          python3 scripts/ci/utils/diffusion/publish_comparison_results.py \
+            --results comparison-results.json \
+            --dashboard dashboard.md \
+            --charts-dir comparison-charts
+
+      - name: Upload comparison artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: diffusion-comparison-b200-${{ github.run_id }}
+          path: |
+            comparison-results.json
+            dashboard.md
+            comparison-charts/
+            comparison-logs/
+          retention-days: 90
+          if-no-files-found: ignore
+
+      - uses: ./.github/actions/upload-cuda-coredumps
+        if: always()
+
   # Consolidate performance metrics from all jobs
   consolidate-metrics:
     if: github.repository == 'sgl-project/sglang' && always()
@@ -778,6 +843,7 @@ jobs:
       - nightly-test-perf-4-gpu-b200
       - nightly-test-specialized-8-gpu-b200
       - nightly-test-diffusion-comparison
+      - nightly-test-diffusion-comparison-b200
       - consolidate-metrics
     runs-on: ubuntu-latest
     steps:

--- a/scripts/ci/utils/diffusion/comparison_configs.json
+++ b/scripts/ci/utils/diffusion/comparison_configs.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Per-model comparison config. Only frameworks listed under each case are tested. vLLM-Omni disabled until dep install issues resolved.",
+  "_comment": "Per-model comparison config. Only frameworks listed under each case are tested.",
   "test_image_url": "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/cat.png",
   "cases": [
     {
@@ -16,6 +16,10 @@
       "frameworks": {
         "sglang": {
           "serve_args": "--enable-torch-compile --warmup --dit-layerwise-offload false",
+          "extra_env": {}
+        },
+        "vllm-omni": {
+          "serve_args": "",
           "extra_env": {}
         }
       }

--- a/scripts/ci/utils/diffusion/comparison_configs_b200.json
+++ b/scripts/ci/utils/diffusion/comparison_configs_b200.json
@@ -1,0 +1,24 @@
+{
+  "_comment": "B200-only comparison cases (requires SM100+).",
+  "test_image_url": "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/cat.png",
+  "cases": [
+    {
+      "id": "flux2_dev_nvfp4_t2i_1024",
+      "model": "black-forest-labs/FLUX.2-dev-NVFP4",
+      "task": "text-to-image",
+      "prompt": "A futuristic cyberpunk city at night, neon lights reflecting on wet streets",
+      "width": 1024,
+      "height": 1024,
+      "num_inference_steps": 50,
+      "guidance_scale": 4.0,
+      "seed": 42,
+      "num_gpus": 1,
+      "frameworks": {
+        "sglang": {
+          "serve_args": "--enable-torch-compile --warmup --dit-layerwise-offload false",
+          "extra_env": {}
+        }
+      }
+    }
+  ]
+}

--- a/scripts/ci/utils/install_comparison_frameworks.sh
+++ b/scripts/ci/utils/install_comparison_frameworks.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FRAMEWORK="${1:-}"
+
+if [[ -z "$FRAMEWORK" ]]; then
+    echo "Usage: $0 <framework>"
+    echo "  Supported: vllm-omni, lightx2v"
+    exit 1
+fi
+
+case "$FRAMEWORK" in
+    vllm-omni)
+        echo "Installing vllm-omni ..."
+        pip install vllm --no-build-isolation 2>&1
+        echo "vllm-omni installed successfully."
+        ;;
+    lightx2v)
+        echo "Installing lightx2v ..."
+        pip install lightx2v 2>&1
+        echo "lightx2v installed successfully."
+        ;;
+    *)
+        echo "ERROR: Unknown framework '$FRAMEWORK'"
+        echo "  Supported: vllm-omni, lightx2v"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Motivation

Add NVFP4 diffusion model coverage to the nightly comparison benchmark. Currently `nightly-test-diffusion-comparison` runs on H100 (SM90) which cannot run NVFP4 (requires SM100+), leaving zero nightly coverage for NVFP4 diffusion.

## Modifications

- Add `comparison_configs_b200.json` with a `flux2_dev_nvfp4_t2i_1024` case (`FLUX.2-dev-NVFP4`, T2I 1024x1024).
- Add `nightly-test-diffusion-comparison-b200` job in `nightly-test-nvidia.yml` that runs on `4-gpu-b200` using the B200-specific config.
- Wire up `job_filter` dropdown and `check-all-jobs.needs`.

Existing H100 job and config are untouched.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).