### PR TITLE
[AMD] Resolve the performance degression when launch server with "--enable-aiter-allreduce-fusion"

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -686,6 +686,7 @@ class GroupCoordinator:
                 512,
                 1024,
                 2048,
+                2880,
                 4096,
             }
 


### PR DESCRIPTION
…sed-rms kernel

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
With --enable-aiter-allreduce-fusion, SGLang uses GroupCoordinator.fused_allreduce_rmsnorm, which may call custom_fused_ar_rms with a use_1stage_ar flag. For the default (non-deterministic) path, 1-stage is selected only when the payload is small (total_bytes <= 128 * 1024) and hidden_dim is in an explicit allowlist.

Models with hidden size 2880 (e.g. GPT-OSS) were not in that set, so they always took the 2-stage path even when the 1-stage path would be appropriate. That led to a measurable performance regression compared to the intended AITER fusion behavior. Adding 2880 aligns this heuristic with AITER-supported hidden sizes for the fused kernel path.

## Modifications

<!-- Detail the changes made in this pull request. -->
python/sglang/srt/distributed/parallel_state.py: Add 2880 to the hidden_dim set used when computing use_1stage_ar inside fused_allreduce_rmsnorm (alongside 512, 1024, 2048, 4096).
## Accuracy Tests
<details><summary>Server launch command</summary>
<p>

"python3", "-m", "sglang.launch_server",
    "--model-path", args.model,
    "--tp", "8",
    "--trust-remote-code",
    "--chunked-prefill-size", "131072",
    "--max-running-requests", "128",
    "--mem-fraction-static", "0.5",
    "--prefill-attention-backend", args.prefill,
    "--decode-attention-backend", args.decode,
    "--page-size", "64",
    "--disable-radix-cache",
    "--enable-aiter-allreduce-fusion",
    "--port", "8000",

</p>
</details> 

<details><summary>Client eval command</summary>
<p>
lm_eval --model local-chat-completions --model_args model=/dockerx/data/models/gpt-oss-120b/,base_url=http://127.0.0.1:8000/v1/chat/completions,num_concurrent=128,timeout=999999,max_gen_toks=2048 --tasks gsm8k --batch_size 1024 --apply_chat_template --num_fewshot 3
</p>
</details> 

**Result**
<img width="734" height="84" alt="image" src="https://github.com/user-attachments/assets/7e279147-1b27-4d22-9db4-0c315a16d57b" />


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
<img width="1180" height="528" alt="image" src="https://github.com/user-attachments/assets/4b11070e-7dc5-46eb-9a4d-7d6772317545" />


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
