### PR TITLE
[Bug][VLM] Fix Kimi K2.5 image re-embedding device mismatch

### DIFF
--- a/python/sglang/srt/models/kimi_k25.py
+++ b/python/sglang/srt/models/kimi_k25.py
@@ -726,15 +726,18 @@ class KimiK25ForConditionalGeneration(nn.Module):
             self.mm_projector = self.mm_projector.to(dtype=target_dtype)
 
     def get_image_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
-        pixel_values = torch.cat([item.feature for item in items], dim=0).type(
-            self.vision_tower.dtype
+        target_device = self.vision_tower.device
+        target_dtype = self.vision_tower.dtype
+        # mm_utils can offload multimodal features back to CPU between
+        # chunked-prefill batches, so restore the concatenated feature tensor
+        # onto the vision tower device before re-embedding on cache miss.
+        pixel_values = torch.cat([item.feature for item in items], dim=0).to(
+            device=target_device,
+            dtype=target_dtype,
         )
         grid_thws = torch.concat([item.grid_thws for item in items], dim=0).to(
-            self.vision_tower.device
+            target_device
         )
-
-        target_dtype = self.vision_tower.patch_embed.proj.weight.dtype
-        pixel_values = pixel_values.to(target_dtype)
 
         if self.use_data_parallel:
             image_embeds = run_dp_sharded_mrope_vision_model(


### PR DESCRIPTION
## Motivation

Kimi K2.5 multimodal requests can crash during chunked-prefill re-embedding with:

```text
RuntimeError: Expected all tensors to be on the same device, but got weight is on cuda:X, different from other tensors on cpu
```

The failure happens when multimodal features have been offloaded back to CPU and then re-embedded on a later chunk/cache-miss path.

A representative stack is:

- `general_mm_embed_routine`
- `embed_mm_inputs`
- `_get_chunked_prefill_embedding`
- `KimiK25ForConditionalGeneration.get_image_feature`
- `vision_tower_forward_auto`
- `patch_embed`
- `conv2d`

## Modifications

Fix `KimiK25ForConditionalGeneration.get_image_feature()` to restore each `item.feature` onto the vision tower device before concatenation, and cast it to the patch embedding dtype.

Before this change, the code only fixed dtype, so CPU-offloaded image features could be re-embedded against CUDA vision weights and crash.

## Accuracy Tests

### Repro shape

I used an oversized multimodal `chat/completions` request with repeated copies of a public image to force the chunked-prefill re-embedding path after the multimodal embedding cache fills.

Request:

```python
import json, urllib.request

base = "http://127.0.0.1:32000"
img = "https://raw.githubusercontent.com/sgl-project/sglang/main/examples/assets/example_image.png"

payload = {
    "model": "default",
    "messages": [{
        "role": "user",
        "content": [
            *[
                {
                    "type": "image_url",
                    "image_url": {"url": img},
                    "modalities": "multi-images",
                }
                for _ in range(56)
            ],
            {
                "type": "text",
                "text": "Describe all images briefly and mention if they are the same.",
            },
        ],
    }],
    "temperature": 0,
    "max_tokens": 16,
}

req = urllib.request.Request(
    base + "/v1/chat/completions",
    data=json.dumps(payload).encode(),
    headers={"Content-Type": "application/json"},
)

with urllib.request.urlopen(req, timeout=300) as r:
    print(r.status)
    print(r.read().decode())
```

### Before fix

A large multi-image request could hit:

```text
Multimodal embedding cache is full
...
RuntimeError: Expected all tensors to be on the same device, but got weight is on cuda:X, different from other tensors on cpu
...
Received sigquit
```

### After fix

The same 56-image request was validated against a local patched Kimi K2.5-compatible sampler.

In the patched run:
- the server still logs `Multimodal embedding cache is full`
- it continues into chunked prefill
- there is no `Expected all tensors to be on the same device`
- there is no `Received sigquit`
- the request returns `200 OK`
- the server remains healthy after the request

## Speed Tests and Profiling

N/A. This is a correctness fix only and does not intentionally change kernel selection or scheduling behavior.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls or people with write permission to merge the PR.
