### PR TITLE
[Bug][Benchmark] Fix multimodal bench_serving crash when peak_memory_mb is absent

### DIFF
--- a/python/sglang/multimodal_gen/benchmarks/bench_serving.py
+++ b/python/sglang/multimodal_gen/benchmarks/bench_serving.py
@@ -390,7 +390,11 @@ def calculate_metrics(
 
     num_success = len(success_outputs)
     latencies = [o.latency for o in success_outputs]
-    peak_memories = [o.peak_memory_mb for o in success_outputs if o.peak_memory_mb > 0]
+    peak_memories = [
+        o.peak_memory_mb
+        for o in success_outputs
+        if isinstance(o.peak_memory_mb, (int, float)) and o.peak_memory_mb > 0
+    ]
 
     metrics = {
         "duration": total_duration,


### PR DESCRIPTION
## Motivation

`python -m sglang.multimodal_gen.benchmarks.bench_serving` can fail at the end of a run while computing summary metrics. Successful async jobs may complete without peak_memory_mb in the polled status payload, leaving RequestFuncOutput.peak_memory_mb as None. calculate_metrics() then evaluates o.peak_memory_mb > 0 and raises:
> TypeError: '>' not supported between instances of 'NoneType' and 'int'

This blocks benchmarking clients even when all requests technically succeeded.

## Modifications

In `python/sglang/multimodal_gen/benchmarks/bench_serving.py`, inside `calculate_metrics()`:

- When building peak_memories, only include o.peak_memory_mb if it is numeric (int or float) and > 0.
- If there are no valid samples, downstream peak_memory_mb_max / _mean / _median stay 0 (same as the prior empty-list behavior when nothing was positive).

## Accuracy Tests

Not applicable to model outputs: this change only affects client-side metric aggregation for the multimodal serving benchmark. Manual repro: run bench_serving against a server that omits or nulls peak_memory_mb on completed jobs; before the fix the process crashes in calculate_metrics, after the fix it finishes and reports metrics (peak-memory stats default to 0 when absent).

## Speed Tests and Profiling

Not applicable. No inference path, kernel, or server scheduling behavior is changed.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.