### PR TITLE
[AMD]fix: add record_stream protection for shared attention metadata buffers

### DIFF
--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -578,6 +578,20 @@ class EagleDraftWorker(BaseDraftWorker):
         if forward_batch.spec_info.accept_length is None:
             forward_batch.spec_info.accept_length = batch_result.accept_lens
 
+        # Record shared buffers on default stream
+        if self.plan_stream:
+            _cur_stream = torch.get_device_module(self.device).current_stream()
+            if (
+                hasattr(forward_batch, "out_cache_loc")
+                and forward_batch.out_cache_loc is not None
+            ):
+                forward_batch.out_cache_loc.record_stream(_cur_stream)
+            if (
+                hasattr(forward_batch, "positions")
+                and forward_batch.positions is not None
+            ):
+                forward_batch.positions.record_stream(_cur_stream)
+
         # Run draft extend batch in the main compute stream
         can_cuda_graph = (
             self.cuda_graph_runner_for_draft_extend
@@ -779,6 +793,28 @@ class EAGLEWorkerV2(BaseSpecWorker):
                     else None
                 ),
             )
+
+        # Record shared attention metadata buffers on default stream to prevent
+        # plan_stream in _draft_extend_for_decode from overwriting them while
+        # the verify forward GPU kernels are still reading them.
+        if self.plan_stream:
+            _cur_stream = torch.get_device_module(self.device).current_stream()
+            _attn = self.target_worker.model_runner.attn_backend
+            for _buf in [
+                getattr(_attn, "kv_indptr", None),
+                getattr(_attn, "qo_indptr", None),
+                getattr(_attn, "qo_indptr_", None),
+                getattr(_attn, "cuda_graph_kv_indices", None),
+                getattr(_attn, "cuda_graph_kv_last_page_len", None),
+                getattr(_attn, "work_metadata", None),
+                getattr(_attn, "work_info_set", None),
+                getattr(_attn, "work_indptr", None),
+                getattr(_attn, "reduce_indptr", None),
+                getattr(_attn, "reduce_final_map", None),
+                getattr(_attn, "reduce_partial_map", None),
+            ]:
+                if _buf is not None and isinstance(_buf, torch.Tensor):
+                    _buf.record_stream(_cur_stream)
 
         # Prepare grammar data on CPU if needed
         if batch.has_grammar:


### PR DESCRIPTION
@ZhaiFeiyue 
fix issue [#21942](https://github.com/sgl-project/sglang/issues/21942)
Prevent plan_stream in _draft_extend_for_decode from overwriting shared attention metadata buffers (kv_indptr, qo_indptr, kv_indices, etc.) while verify forward GPU kernels are still reading them on the default stream. Also protect out_cache_loc and positions in draft extend path.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
