### PR TITLE
Try to Fix Grammer PD Error

### DIFF
--- a/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
@@ -117,18 +117,21 @@ class ScheduleBatchDisaggregationDecodeMixin:
                     # accept the token as it's already accepted
                     if req.grammar.current_token is None:
                         req.grammar.accept_token(req.output_ids[-1])
+                    req.grammar.finished = req.finished()
                 except ValueError as e:
                     from sglang.srt.managers.schedule_batch import FINISH_ABORT
 
                     # Grammar accept_token can raise ValueError if the token is not in the grammar.
-                    # This can happen if the grammar is not set correctly or the token is invalid.
-                    # Use to_finish (not finished_reason) so that process_batch_result_prebuilt
+                    # In PD disaggregation, this can occur when grammar state is
+                    # initialized independently on the decode node. Use to_finish
+                    # (not finished_reason) so that process_batch_result_prebuilt
                     # handles the release via check_finished -> release_kv_cache in one place.
                     error_message = f"Grammar accept_token failed for req {req.rid} with token {req.output_ids[-1]}: {e}"
+                    logger.warning(error_message)
+                    req.grammar = None
                     req.to_finish = FINISH_ABORT(
                         error_message, HTTPStatus.INTERNAL_SERVER_ERROR
                     )
-                req.grammar.finished = req.finished()
         self.output_ids = torch.tensor(self.output_ids, device=self.device)
 
         # Simulate the eagle run.

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -533,17 +533,17 @@ class SchedulerDisaggregationPrefillMixin:
                     # FIXME: this try-except block is for handling unexpected xgrammar issue.
                     try:
                         req.grammar.accept_token(next_token_id)
+                        req.grammar.finished = req.finished()
                     except ValueError as e:
-                        # Grammar accept_token can raise ValueError if the token is not in the grammar.
-                        # This can happen if the grammar is not set correctly or the token is invalid.
                         error_message = f"Grammar accept_token failed for req {req.rid} with token {next_token_id}: {e}"
+                        logger.warning(error_message)
+                        req.grammar = None
                         release_kv_cache(req, self.tree_cache)
                         prepare_abort(
                             req,
                             error_message,
                             status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
                         )
-                    req.grammar.finished = req.finished()
             else:
                 # being chunked reqs' prefill is not finished
                 req.is_chunked -= 1

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -688,6 +688,8 @@ class OpenAIServingChat(OpenAIServingBase):
                         code = finish_reason.get(
                             "status_code", HTTPStatus.INTERNAL_SERVER_ERROR
                         )
+                        if isinstance(code, int) and not isinstance(code, HTTPStatus):
+                            code = HTTPStatus(code)
                         error = self.create_streaming_error_response(
                             finish_reason.get("message", "Generation aborted."),
                             code.name,

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -290,6 +290,8 @@ class OpenAIServingCompletion(OpenAIServingBase):
                     code = finish_reason.get(
                         "status_code", HTTPStatus.INTERNAL_SERVER_ERROR
                     )
+                    if isinstance(code, int) and not isinstance(code, HTTPStatus):
+                        code = HTTPStatus(code)
                     error = self.create_streaming_error_response(
                         finish_reason.get("message", "Generation aborted."),
                         code.name,


### PR DESCRIPTION
Draft PR for #21945

## Root Cause Analysis

I dug through the codebase to understand this issue end-to-end. There are actually **two distinct bugs** here — a primary grammar state synchronization issue and a secondary crash in the streaming error handler. But it could be wrong since this is just based on what I saw.

### Bug 1 (Primary): Grammar `accept_token` fails on the Decode node

**How grammar works in PD disaggregation:**

1. **Prefill node**: Request arrives → `grammar_manager.process_req_with_grammar()` compiles a fresh grammar object → prefill runs → first token is sampled **with** grammar bitmask constraint → `req.grammar.accept_token(first_token)` is called → KV cache is sent to decode node.

2. **Decode node**: The same request also arrives at the decode scheduler → `grammar_manager.process_req_with_grammar()` compiles a **new, independent** grammar object from the same schema → KV transfer completes, first token is attached to `req.output_ids` → `process_prebuilt()` calls `req.grammar.accept_token(req.output_ids[-1])` on this fresh grammar.

**The problem**: The decode node creates a grammar object entirely independently from the prefill node. There is **no grammar state transfer** between the two. The decode node's fresh grammar rejects the very first token that was validly sampled by the prefill node's grammar.

This can happen due to:
- **Non-deterministic grammar compilation** in xgrammar — the same JSON schema compiled independently on two nodes may produce subtly different acceptance sets for certain states.
- **Overlap scheduling timing** — if the grammar bitmask wasn't fully applied during sampling on the prefill side (race between `update_regex_vocab_mask()` and the actual sampling step).
- The existing `FIXME` comments in both `prefill.py:533` and `decode_schedule_batch_mixin.py:114` confirm this is a known intermittent issue.

**Relevant code path on decode side** (`decode_schedule_batch_mixin.py:113-131`):

```python
if req.grammar is not None:
    try:
        if req.grammar.current_token is None:
            req.grammar.accept_token(req.output_ids[-1])  # ← fails here
    except ValueError as e:
        req.to_finish = FINISH_ABORT(error_message, HTTPStatus.INTERNAL_SERVER_ERROR)
    req.grammar.finished = req.finished()  # ← runs even after error (Bug 3)
```

### Bug 2 (Secondary): `AttributeError: 'int' object has no attribute 'name'`

When the grammar error triggers `FINISH_ABORT`, the error flows through:

```
FINISH_ABORT.to_json() → {"status_code": HTTPStatus.INTERNAL_SERVER_ERROR, ...}
  → IPC (pickle via zmq) → detokenizer → tokenizer_manager → serving layer
```

In `serving_chat.py:688-694` and `serving_completions.py:290-297`:

```python
code = finish_reason.get("status_code", HTTPStatus.INTERNAL_SERVER_ERROR)
error = self.create_streaming_error_response(
    finish_reason.get("message", "Generation aborted."),
    code.name,   # ← crashes if code is plain int
    code.value,
)
```

`HTTPStatus.INTERNAL_SERVER_ERROR` is an `IntEnum`. After serialization/deserialization through the IPC layer, it can degrade to a plain `int(500)`. Calling `.name` on a plain `int` raises `AttributeError: 'int' object has no attribute 'name'`.

### Bug 3 (Error Handling): `req.grammar.finished` accessed after abort

In both `prefill.py:546` and `decode_schedule_batch_mixin.py:131`:

```python
    except ValueError as e:
        # ... abort handling ...
    req.grammar.finished = req.finished()  # ← OUTSIDE try block, runs after error
```

`req.grammar.finished = req.finished()` executes unconditionally — even after the grammar just failed and the request was aborted. This accesses a grammar object that's in an inconsistent state.

---

## Proposed Fixes

### Fix 1: Defensive `HTTPStatus` conversion in streaming error handlers

**`serving_completions.py`** and **`serving_chat.py`** — convert plain `int` back to `HTTPStatus`:

```python
code = finish_reason.get("status_code", HTTPStatus.INTERNAL_SERVER_ERROR)
if isinstance(code, int) and not isinstance(code, HTTPStatus):
    code = HTTPStatus(code)
```

### Fix 2: Move `grammar.finished` inside try block + clean up grammar on error

**`decode_schedule_batch_mixin.py`**:

```python
if req.grammar is not None:
    try:
        if req.grammar.current_token is None:
            req.grammar.accept_token(req.output_ids[-1])
        req.grammar.finished = req.finished()  # ← moved INSIDE try
    except ValueError as e:
        from sglang.srt.managers.schedule_batch import FINISH_ABORT

        error_message = f"Grammar accept_token failed for req {req.rid} with token {req.output_ids[-1]}: {e}"
        logger.warning(error_message)
        req.grammar = None  # ← clean up inconsistent grammar
        req.to_finish = FINISH_ABORT(
            error_message, HTTPStatus.INTERNAL_SERVER_ERROR
        )
```

### Fix 3: Same pattern for prefill side

**`prefill.py`**:

```python
if req.grammar is not None:
    try:
        req.grammar.accept_token(next_token_id)
        req.grammar.finished = req.finished()  # ← moved INSIDE try
    except ValueError as e:
        error_message = f"Grammar accept_token failed for req {req.rid} with token {next_token_id}: {e}"
        logger.warning(error_message)
        req.grammar = None  # ← clean up
        release_kv_cache(req, self.tree_cache)
        prepare_abort(req, error_message, status_code=HTTPStatus.INTERNAL_SERVER_ERROR)
```

---

## Longer-term Fix (Root Cause)

The fundamental issue is that **grammar state is not synchronized between prefill and decode nodes**. Each node compiles and maintains its own grammar independently. To truly fix this, one of the following would be needed:

1. **Transfer grammar state from prefill to decode** — serialize the `accepted_tokens` list alongside the KV cache, and replay them on the decode side's grammar before accepting new tokens.
2. **Report upstream to xgrammar** — if the same compiled grammar produces different acceptance results for the same token, that's a library bug.

---

## Reproduction

This requires a PD disaggregation setup (prefill + decode on separate GPUs). Send streaming requests with `json_schema` or `regex` constraints under load. The grammar `accept_token` failure is intermittent and more likely to appear under high concurrency.

I don't currently have access to a multi-GPU PD disaggregation environment to reproduce this directly. **If anyone with a PD setup could test the above fixes and it seems good, that would be very helpful.** I'm already submit a Draft PR (#21964 ) with these changes.