### PR TITLE
feat: metrics for prefill only

### DIFF
--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -308,6 +308,16 @@ class SchedulerMetricsCollector:
             documentation="Total number of retracted output tokens.",
             labelnames=labels.keys(),
         )
+        self.num_prefill_only_requests_total = Counter(
+            name="sglang:num_prefill_only_requests_total",
+            documentation="Total number of prefill-only requests (max_new_tokens=0) processed.",
+            labelnames=labels.keys(),
+        )
+        self.prefill_only_tokens_total = Counter(
+            name="sglang:prefill_only_tokens_total",
+            documentation="Total number of tokens processed by prefill-only requests.",
+            labelnames=labels.keys(),
+        )
         self.num_paused_reqs = Gauge(
             name="sglang:num_paused_reqs",
             documentation="The number of paused requests by async weight sync.",
@@ -889,6 +899,12 @@ class SchedulerMetricsCollector:
         self.num_retracted_output_tokens_total.labels(**self.labels).inc(
             num_retracted_output_tokens
         )
+
+    def increment_prefill_only_reqs(
+        self, num_reqs: int, num_tokens: int
+    ) -> None:
+        self.num_prefill_only_requests_total.labels(**self.labels).inc(num_reqs)
+        self.prefill_only_tokens_total.labels(**self.labels).inc(num_tokens)
 
     def increment_decode_cuda_graph_pass(self, value: bool) -> None:
         mode = "decode_cuda_graph" if value else "decode_none"

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -55,6 +55,8 @@ class PrefillStats:
     new_token_ratio: float
     num_running_reqs: QueueCount
     num_new_seqs: int  # len(can_run_list)
+    num_prefill_only_reqs: int
+    num_prefill_only_tokens: int
 
     @classmethod
     def from_adder(
@@ -63,6 +65,7 @@ class PrefillStats:
         running_reqs: List[Req],
         enable_priority_scheduling: bool = False,
     ):
+        prefill_only_reqs = [r for r in adder.can_run_list if r.is_prefill_only]
         return cls(
             log_input_tokens=adder.log_input_tokens,
             log_hit_tokens=adder.log_hit_tokens,
@@ -71,6 +74,10 @@ class PrefillStats:
                 running_reqs, enable_priority_scheduling
             ),
             num_new_seqs=len(adder.can_run_list),
+            num_prefill_only_reqs=len(prefill_only_reqs),
+            num_prefill_only_tokens=sum(
+                len(r.origin_input_ids) for r in prefill_only_reqs
+            ),
         )
 
 
@@ -432,6 +439,11 @@ class SchedulerMetricsMixin:
                 prefill_cache_tokens=prefill_stats.log_hit_tokens,
                 dp_cooperation_info=dp_cooperation_info,
             )
+            if prefill_stats.num_prefill_only_reqs > 0:
+                self.metrics_collector.increment_prefill_only_reqs(
+                    num_reqs=prefill_stats.num_prefill_only_reqs,
+                    num_tokens=prefill_stats.num_prefill_only_tokens,
+                )
             if self.enable_mfu_metrics:
                 flops, read_bytes, write_bytes = self._estimate_prefill_perf(
                     prefill_stats.log_input_tokens

--- a/test/registered/observability/test_metrics.py
+++ b/test/registered/observability/test_metrics.py
@@ -139,6 +139,16 @@ class TestEnableMetrics(CustomTestCase):
             )
             self.assertEqual(response.status_code, 200)
 
+            # Send a prefill-only request (max_new_tokens=0)
+            response = requests.post(
+                f"{DEFAULT_URL_FOR_TEST}/generate",
+                json={
+                    "text": "The capital of France is Paris",
+                    "sampling_params": {"max_new_tokens": 0},
+                },
+            )
+            self.assertEqual(response.status_code, 200)
+
             # Get metrics
             metrics_response = requests.get(f"{DEFAULT_URL_FOR_TEST}/metrics")
             self.assertEqual(metrics_response.status_code, 200)
@@ -212,6 +222,8 @@ class TestEnableMetrics(CustomTestCase):
             ("sglang:gpu_execution_seconds_total", {"category": "forward_extend"}),
             ("sglang:gpu_execution_seconds_total", {"category": "forward_decode"}),
             ("sglang:process_cpu_seconds_total", {"component": "tokenizer"}),
+            ("sglang:num_prefill_only_requests_total", {}),
+            ("sglang:prefill_only_tokens_total", {}),
         ]
         _check_metrics_positive(self, metrics, metrics_to_check)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Add Prometheus metrics to track prefill-only requests (max_new_tokens=0) separately.

Currently there is no way to distinguish prefill-only requests from normal generation requests in the /metrics endpoint, which makes capacity planning difficult since prefill-only requests have a fundamentally different resource profile (no decode KV reservation, immediate KV release after prefill).

## Modifications

- Add `sglang:num_prefill_only_requests_total` counter
- Add `sglang:prefill_only_tokens_total` counter  
- Add `num_prefill_only_reqs` and `num_prefill_only_tokens` fields to `PrefillStats`
- Add test coverage in `test_metrics.py`

## Test plan
- [x] Unit test: added prefill-only request to `test_metrics.py`, verified both
  counters are positive after a max_new_tokens=0 request
- [x] Manual verification on RunPod (RTX 4090, Qwen3-0.6B):

### 1. Launch server
python -m sglang.launch_server --model-path Qwen/Qwen3-0.6B --port 9000 --enable-metrics

### 2. Confirm no prefill_only metrics before any request
curl -s http://127.0.0.1:9000/metrics | grep prefill_only

```
(.venv) root@720fc8461331:/workspace/sglang# curl -s http://127.0.0.1:9000/metrics | grep prefill_only
(.venv) root@720fc8461331:/workspace/sglang#
```


### 3. Send prefill-only request (6 tokens) → requests=1, tokens=6

```
curl -s http://127.0.0.1:9000/generate     -H "Content-Type: application/json"     -d '{"text":"The capital of France is Paris","sampling_params":{"max_new_tokens":0}}'
```

### 4. Read metrics

```
(.venv) root@720fc8461331:/workspace/sglang# curl -s http://127.0.0.1:9000/metrics | grep prefill_only
# HELP sglang:num_prefill_only_requests_total Total number of prefill-only requests (max_new_tokens=0) processed.
# TYPE sglang:num_prefill_only_requests_total counter
sglang:num_prefill_only_requests_total{engine_type="unified",model_name="/workspace/models/Qwen3-0.6B",moe_ep_rank="0",pp_rank="0",tp_rank="0"} 1.0
# HELP sglang:prefill_only_tokens_total Total number of tokens processed by prefill-only requests.
# TYPE sglang:prefill_only_tokens_total counter
sglang:prefill_only_tokens_total{engine_type="unified",model_name="/workspace/models/Qwen3-0.6B",moe_ep_rank="0",pp_rank="0",tp_rank="0"} 6.0
```


### 5. Send normal request

```
curl -s http://127.0.0.1:9000/generate \
  -H "Content-Type: application/json" \
  -d '{"text":"Hello","sampling_params":{"max_new_tokens":10}}'
```

### 6. Confirm counters unchanged
curl -s http://127.0.0.1:9000/metrics | grep prefill_only

```
(.venv) root@720fc8461331:/workspace/sglang# curl -s http://127.0.0.1:9000/metrics | grep prefill_only
# HELP sglang:num_prefill_only_requests_total Total number of prefill-only requests (max_new_tokens=0) processed.
# TYPE sglang:num_prefill_only_requests_total counter
sglang:num_prefill_only_requests_total{engine_type="unified",model_name="/workspace/models/Qwen3-0.6B",moe_ep_rank="0",pp_rank="0",tp_rank="0"} 1.0
# HELP sglang:prefill_only_tokens_total Total number of tokens processed by prefill-only requests.
# TYPE sglang:prefill_only_tokens_total counter
sglang:prefill_only_tokens_total{engine_type="unified",model_name="/workspace/models/Qwen3-0.6B",moe_ep_rank="0",pp_rank="0",tp_rank="0"} 6.0
```

### 7. Send another prefill-only request

```
curl -s http://127.0.0.1:9000/generate \
  -H "Content-Type: application/json" \
  -d '{"text":"Two plus two equals four","sampling_params":{"max_new_tokens":0}}'
```

### 8. Check metrics

```
(.venv) root@720fc8461331:/workspace/sglang# curl -s http://127.0.0.1:9000/metrics | grep prefill_only
# HELP sglang:num_prefill_only_requests_total Total number of prefill-only requests (max_new_tokens=0) processed.
# TYPE sglang:num_prefill_only_requests_total counter
sglang:num_prefill_only_requests_total{engine_type="unified",model_name="/workspace/models/Qwen3-0.6B",moe_ep_rank="0",pp_rank="0",tp_rank="0"} 2.0
# HELP sglang:prefill_only_tokens_total Total number of tokens processed by prefill-only requests.
# TYPE sglang:prefill_only_tokens_total counter
sglang:prefill_only_tokens_total{engine_type="unified",model_name="/workspace/models/Qwen3-0.6B",moe_ep_rank="0",pp_rank="0",tp_rank="0"} 11.0
```

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
