### PR TITLE
feat: add available GPU memory metric to Prometheus and /v1/loads

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1763,6 +1763,10 @@ class MemoryMetrics:
     token_capacity: int = field(
         metadata={"metric": ("gauge", "Max tokens in KV cache")}
     )
+    available_gpu_memory_gb: float = field(
+        default=0.0,
+        metadata={"metric": ("gauge", "Available GPU memory in GB")},
+    )
 
 
 @dataclass

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -130,6 +130,9 @@ class SchedulerStats:
     hicache_host_used_tokens: int = 0
     hicache_host_total_tokens: int = 0
 
+    # GPU memory
+    available_gpu_memory_gb: float = 0.0
+
     # Routing key metrics
     num_unique_running_routing_keys: int = 0
     routing_key_running_req_counts: List[int] = field(default_factory=list)
@@ -395,6 +398,14 @@ class SchedulerMetricsCollector:
         self.max_running_requests_under_SLO = Gauge(
             name="sglang:max_running_requests_under_SLO",
             documentation="The maximum number of running requests under SLO.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+
+        # GPU memory
+        self.available_gpu_memory_gb = Gauge(
+            name="sglang:available_gpu_memory_gb",
+            documentation="Available GPU memory in GB.",
             labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
         )
@@ -1020,6 +1031,9 @@ class SchedulerMetricsCollector:
                 self.max_running_requests_under_SLO,
                 stats.max_running_requests_under_SLO,
             )
+
+        # GPU memory
+        self._log_gauge(self.available_gpu_memory_gb, stats.available_gpu_memory_gb)
 
         # Engine startup time
         self._log_gauge(self.engine_startup_time, stats.engine_startup_time)

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -30,7 +30,7 @@ from sglang.srt.observability.metrics_collector import (
     SchedulerStats,
     compute_routing_key_stats,
 )
-from sglang.srt.utils import get_bool_env_var
+from sglang.srt.utils import get_available_gpu_memory, get_bool_env_var
 from sglang.srt.utils.device_timer import DeviceTimer, GapTimer
 from sglang.srt.utils.scheduler_status_logger import SchedulerStatusLogger
 
@@ -490,6 +490,11 @@ class SchedulerMetricsMixin:
                     self.disagg_decode_transfer_queue.queue, priority_enabled
                 )
 
+            # GPU memory
+            self.stats.available_gpu_memory_gb = (
+                self._get_available_gpu_memory_gb()
+            )
+
             # Others
             self.calculate_utilization()
             self.update_lora_metrics()
@@ -735,6 +740,11 @@ class SchedulerMetricsMixin:
                 running_routing_keys + waiting_routing_keys
             )
 
+            # GPU memory
+            self.stats.available_gpu_memory_gb = (
+                self._get_available_gpu_memory_gb()
+            )
+
             # Others
             self.calculate_utilization()
             self.update_lora_metrics()
@@ -891,6 +901,16 @@ class SchedulerMetricsMixin:
             ts_tic=time.perf_counter(),
         )
 
+    def _get_available_gpu_memory_gb(self: Scheduler) -> float:
+        """Get available GPU memory in GB, returning 0.0 on failure."""
+        try:
+            return get_available_gpu_memory(
+                self.device, self.gpu_id, empty_cache=False
+            )
+        except Exception as e:
+            logger.debug(f"Failed to get available GPU memory: {e}")
+            return 0.0
+
     def get_loads(self: Scheduler, req: GetLoadsReqInput = None) -> GetLoadsReqOutput:
         """
         Get comprehensive load metrics for /v1/loads endpoint.
@@ -945,6 +965,9 @@ class SchedulerMetricsMixin:
                     ),
                     graph_gb=round(self.tp_worker.model_runner.graph_mem_usage, 3),
                     token_capacity=int(self.max_total_num_tokens),
+                    available_gpu_memory_gb=round(
+                        self._get_available_gpu_memory_gb(), 3
+                    ),
                 )
             except AttributeError as e:
                 logger.debug(f"Memory metrics not available: {e}")


### PR DESCRIPTION
## Summary
- Add `sglang:available_gpu_memory_gb` Prometheus Gauge metric reporting current available GPU memory in GB
- Add `available_gpu_memory_gb` field to `MemoryMetrics` in the `/v1/loads` endpoint response
- Collect available memory in both prefill and decode stats logging paths via a new `_get_available_gpu_memory_gb()` helper (uses `get_available_gpu_memory` with `empty_cache=False` to avoid performance impact)

## Motivation
Available GPU memory is useful for monitoring and autoscaling decisions. The existing memory metrics (`weight_gb`, `kv_cache_gb`, `graph_gb`) show static allocations but don't reflect dynamic available memory.

## Changes
- `io_struct.py`: Add `available_gpu_memory_gb` field to `MemoryMetrics` dataclass (default 0.0, with gauge metadata)
- `metrics_collector.py`: Add field to `SchedulerStats`, create Prometheus Gauge, wire `_log_gauge` in `log_stats()`
- `scheduler_metrics_mixin.py`: Add `_get_available_gpu_memory_gb()` helper with try/except, set stats in prefill/decode paths, populate in `get_loads` MemoryMetrics

## Test plan
- [x] Unit tested dataclass fields, Gauge definition, log_stats wiring, and source verification
- [x] Verified `get_available_gpu_memory(device, gpu_id, empty_cache=False)` returns correct value on real GPU (H100)
- [ ] Integration test: verify `sglang:available_gpu_memory_gb` appears in `/metrics` scrape
- [ ] Integration test: verify `available_gpu_memory_gb` appears in `/v1/loads?include=memory` response

🤖 Generated with [Claude Code](https://claude.com/claude-code)