### PR TITLE
perf: enable inductor combo_kernels for horizontal fusion

### DIFF
--- a/python/sglang/srt/compilation/compilation_config.py
+++ b/python/sglang/srt/compilation/compilation_config.py
@@ -28,6 +28,7 @@ class CompilationConfig:
         self.enable_debug_mode = enable_debug_mode
         self.split_ops = []
         self.split_ops.extend(SPLIT_OPS)
+        self.configure_inductor()
 
     def add_split_op(self, op: str):
         self.split_ops.append(op)
@@ -43,3 +44,16 @@ class CompilationConfig:
 
     def get_enable_debug_mode(self):
         return self.enable_debug_mode
+
+    def configure_inductor(self):
+        """Apply inductor-specific optimizations when using inductor compiler."""
+        if self.compiler != "inductor":
+            return
+
+        import torch._inductor.config as inductor_config
+
+        # Horizontal fusion for sibling ops with different shapes,
+        # e.g. fusing q_norm + k_norm into a single triton kernel.
+        if hasattr(inductor_config, "combo_kernels"):
+            inductor_config.combo_kernels = True
+            inductor_config.benchmark_combo_kernel = True


### PR DESCRIPTION
Enable `combo_kernels` and `benchmark_combo_kernel` in inductor config to allow horizontal fusion of sibling ops with different shapes. This fuses operations like q_norm + k_norm (QK normalization) into a single triton kernel instead of generating separate kernels for each.

Requires torch >= 2.9.0.
<img width="1297" height="327" alt="Screenshot 2026-04-02 at 3 49 15 PM" src="https://github.com/user-attachments/assets/a1b3b3d2-0637-4b66-a43f-818d406028ec" />
<img width="1428" height="367" alt="Screenshot 2026-04-02 at 3 47 59 PM" src="https://github.com/user-attachments/assets/40a7ff69-7228-4688-ae36-b267abc1e301" />

## Profile Results

Qwen3-0.6B FP8 embeddings on H200, PCG inductor, 7k tokens:

| Metric | Before | After |
|--------|:------:|:-----:|
| GPU kernels per forward | 413 | **357** (-14%) |
| QK norm kernels per layer | 4 | **2** |
| `split_with_sizes` / `clone` in kernel names | Present | **Gone** |

The QK norm reduction + pointwise kernels for q and k are now horizontally fused into single kernels.

Throughput impact is neutral at 60 RPS (kernel launch overhead is not the bottleneck at this load), but the reduced kernel count should help at higher concurrency or with smaller models where launch overhead is proportionally larger.