### PR TITLE
[Fix] Register _MOE_TP group in graph_capture for MoE models with ep>1

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -1551,11 +1551,12 @@ def graph_capture(stream: Optional[torch.cuda.Stream] = None):
     with get_tp_group().graph_capture(
         stream=stream
     ) as context, get_pp_group().graph_capture(context):
-        moe_ep = _MOE_EP
-        if moe_ep is not None and moe_ep is not _TP:
-            with moe_ep.graph_capture(context):
-                yield context
-        else:
+        with contextlib.ExitStack() as stack:
+            seen = {id(_TP)}
+            for group in (_MOE_EP, _MOE_TP):
+                if group is not None and id(group) not in seen:
+                    seen.add(id(group))
+                    stack.enter_context(group.graph_capture(context))
             yield context
 
 


### PR DESCRIPTION
## Summary
- PR #18233 switched MoE allreduce from `_TP` to `_MOE_TP` group but forgot to register `_MOE_TP` in the `graph_capture()` context manager
- When `1 < ep < tp` (e.g., `--tp 8 --ep 2`), `_MOE_TP` is a distinct group from `_TP` with `moe_tp_size = tp/ep = 4`. During CUDA graph replay, custom allreduce dereferences unregistered IPC handles from `_MOE_TP`, causing the process to hang/crash
- Fix uses `ExitStack` to register both `_MOE_EP` and `_MOE_TP` groups (when distinct from `_TP`) during graph capture, with identity-based deduplication to avoid double-registering aliased groups

## Test plan
- [x] Launched `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8 --tp 8 --ep 2` on 8xH200 — previously hung during graph capture, now starts successfully
- [x] GSM8K accuracy test: **97.5%** (200 questions, 8-shot) confirming model correctness

## Related
- Regression introduced by #18233
- Similar fix proposed in #21907 (draft)

🤖 Generated with [Claude Code](https://claude.com/claude-code)