### PR TITLE
[Bugfix] Fix CUDA graph replay stride mismatch in trtllm_mla draft extend

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -543,21 +543,21 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             metadata.seq_lens_k.copy_(seq_lens.to(dtype=torch.int32))
             del seq_lens_sum  # not handle "num_draft_tokens" but we do not need it
         elif forward_mode.is_draft_extend(include_v2=True):
-            accept_length = spec_info.accept_length[:bs]
-            if spec_info.accept_length_cpu:
-                metadata.max_seq_len_q = max(spec_info.accept_length_cpu[:bs]) + 1
-                metadata.sum_seq_lens_q = sum(spec_info.accept_length_cpu[:bs]) + bs
-            else:
-                metadata.max_seq_len_q = 1
-                metadata.sum_seq_lens_q = bs
-            # draft_extend uses (accept_length + 1) query tokens per sequence
-            extend_seq_lens = accept_length + 1
-            metadata.cu_seqlens_q[1:].copy_(
-                torch.cumsum(extend_seq_lens, dim=0, dtype=torch.int32)
+            num_tokens_per_bs = self.speculative_num_steps + 1
+            metadata.max_seq_len_q = num_tokens_per_bs
+            metadata.sum_seq_lens_q = num_tokens_per_bs * bs
+            metadata.cu_seqlens_q[: bs + 1].copy_(
+                torch.arange(
+                    0,
+                    bs * num_tokens_per_bs + 1,
+                    step=num_tokens_per_bs,
+                    dtype=torch.int32,
+                    device=seq_lens.device,
+                )
             )
-            metadata.seq_lens_q.copy_(extend_seq_lens)
+            metadata.seq_lens_q[:bs].fill_(num_tokens_per_bs)
             # see NOTE(draft_extend seq_len handling)
-            seq_lens = seq_lens[:bs] - metadata.seq_lens_q + metadata.max_seq_len_q
+            seq_lens = seq_lens[:bs] - metadata.seq_lens_q[:bs] + metadata.max_seq_len_q
             metadata.seq_lens_k.copy_(seq_lens.to(torch.int32))
 
         # Update block indices for new sequences.

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -543,7 +543,7 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             metadata.seq_lens_k.copy_(seq_lens.to(dtype=torch.int32))
             del seq_lens_sum  # not handle "num_draft_tokens" but we do not need it
         elif forward_mode.is_draft_extend(include_v2=True):
-            num_tokens_per_bs = self.speculative_num_steps + 1
+            num_tokens_per_bs = self.num_draft_tokens
             metadata.max_seq_len_q = num_tokens_per_bs
             metadata.sum_seq_lens_q = num_tokens_per_bs * bs
             metadata.cu_seqlens_q[: bs + 1].copy_(


### PR DESCRIPTION
**CLOSED** in favor of https://github.com/sgl-project/sglang/pull/21987 

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Fix the test failure here https://github.com/sgl-project/sglang/actions/runs/23877953915/job/69624981292
Same root cause and fix as PR #19807 

**Root cause**

`cu_seqlens_q` tensor layout differs in capture and replay path

In `init_forward_metadata_capture_cuda_graph`, `cu_seqlens_q` is built with a **uniform stride** via `torch.arange`.
In `init_forward_metadata_replay_cuda_graph`, the replay path was building `cu_seqlens_q` with a **variable stride** via `torch.cumsum(accept_length + 1)`. 


## Modifications

<!-- Detail the changes made in this pull request. -->

- Build `cu_seqlens_q` in the replay path using `torch.arange` with a fixed step of `num_draft_tokens`, matching the capture path.
- Set `max_seq_len_q` to the fixed `num_draft_tokens` instead of `max(accept_length) + 1`.
- Fill `seq_lens_q` with uniform `num_draft_tokens` instead of variable `accept_length + 1`.
- Use `self.num_draft_tokens` (from `server_args.speculative_num_draft_tokens`) instead of `self.speculative_num_steps + 1`, which doesn't exist on this backend.
- Remove the `accept_length_cpu` fast path — uniform stride makes the CPU-side path unnecessary.

## Accuracy Tests
Before fix this test will fail consistently. After fix this test passed 
`python -m pytest test/registered/spec/eagle/test_eagle_infer_beta_dp_attention_large.py::TestEagleDPAttnServerLarge -xvs`

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
N/A

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
