### PR TITLE
[diffusion] fix: align qwen-image cond batch for multi-output generation

### DIFF
--- a/python/sglang/multimodal_gen/runtime/managers/memory_managers/component_manager.py
+++ b/python/sglang/multimodal_gen/runtime/managers/memory_managers/component_manager.py
@@ -178,15 +178,26 @@ class ComponentResidencyManager:
             self.strategy_for.cache_clear()
         self.server_args = server_args
 
+    @staticmethod
+    def _batch_is_warmup(batch: ResidencyBatch | list[ResidencyBatch]) -> bool:
+        if isinstance(batch, list):
+            return bool(batch) and all(
+                getattr(item, "is_warmup", False) for item in batch
+            )
+        return getattr(batch, "is_warmup", False)
+
     def begin_request(
         self,
         stages: Sequence[ComponentResidencyStage],
-        batch: ResidencyBatch,
+        batch: ResidencyBatch | list[ResidencyBatch],
         server_args: ServerArgs,
     ) -> None:
         """A hook called before processing an actual request"""
         self.refresh_server_args(server_args)
-        self.state = ResidencyState(stages=stages, batch_is_warmup=batch.is_warmup)
+        self.state = ResidencyState(
+            stages=stages,
+            batch_is_warmup=self._batch_is_warmup(batch),
+        )
         self._active_use = None
         self._active_use_module = None
         self._disable_active_nvtx()

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py
@@ -1013,6 +1013,11 @@ class ComposedPipelineBase(ABC):
                 main_process_only=True,
             )
 
+        self.component_residency_manager = get_global_component_residency_manager(
+            self, server_args
+        )
+        self.executor.component_residency_manager = self.component_residency_manager
+
         return self.executor.execute_group_with_profiling(
             self.stages, batches, server_args
         )


### PR DESCRIPTION
## Motivation

Qwen-Image base generation currently fails when `num_outputs_per_prompt > 1`.

The root cause is that the sample batch is expanded for multi-output generation, while the text condition batch remains at the original prompt batch size. This causes a batch mismatch in the Qwen DiT denoising path, which previously reproduced as:

`ValueError: Validate failed: unsupported tensor shape: torch.Size([2, 3072])`

This PR fixes the batch size inconsistency between latent samples and text conditions during multi-output generation.

## Modifications

- Keep the fix model-specific in `QwenImagePipelineConfig`
- Add a small helper to expand prompt and negative-prompt condition batches to `batch.batch_size` via `repeat_interleave`
- Reuse the same logic in:
  - `get_pos_prompt_embeds`
  - `get_neg_prompt_embeds`
  - `prepare_pos_cond_kwargs`
  - `prepare_neg_cond_kwargs`
- Do not change generic text encoding or denoising stages

## Accuracy Tests

Local smoke tests on `Qwen/Qwen-Image` after this change:

| Test | Result | Notes |
| --- | --- | --- |
| `num_outputs_per_prompt=1` | Pass | Single-output generation still works |
| `num_outputs_per_prompt=2` | Pass | Multi-output generation succeeds and no longer hits the denoising shape mismatch |

I also generated and checked sample outputs for the multi-output case.

## Speed Tests and Profiling

Benchmark setup:

- Model: `Qwen/Qwen-Image`
- `num_inference_steps=2`
- Single GPU
- Speedup is computed as `n * t(n=1) / t(n=batch)`
- Peak memory below is peak reserved GPU memory

| Resolution | num_outputs_per_prompt | Total time (s) | Speedup vs serial | Peak mem (GB) | Status |
| --- | ---: | ---: | ---: | ---: | --- |
| 512x512 | 1 | 0.8746 | 1.00x | 41.6 | Pass |
| 512x512 | 2 | 0.9455 | 1.85x | 43.2 | Pass |
| 512x512 | 4 | 1.1526 | 3.04x | 47.7 | Pass |
| 512x512 | 8 | 1.5127 | 4.63x | 55.9 | Pass |
| 512x512 | 16 | 2.3835 | 5.87x | 73.1 | Pass |
| 1024x1024 | 1 | 1.0820 | 1.00x | 73.1 | Pass |
| 1024x1024 | 2 | 1.5754 | 1.37x | 73.1 | Pass |
| 1024x1024 | 4 | 2.4831 | 1.74x | 73.1 | Pass |
| 1024x1024 | 8 | 4.5556 | 1.90x | 106.1 | Pass |
| 1024x1024 | 16 | N/A | N/A | N/A | OOM in VAE decode |

I also plotted and attached the following three figures:

- 512x512 multi-output speedup curve
<img width="1422" height="917" alt="qwen_image_speedup_512" src="https://github.com/user-attachments/assets/8f2d27ea-8dbb-4be6-8631-ecaaa29509b0" />
- 1024x1024 multi-output speedup curve
<img width="1422" height="917" alt="qwen_image_speedup_1024" src="https://github.com/user-attachments/assets/7bf59ca3-b740-4aba-ad60-8b8f446c1223" />
- 512x512 vs 1024x1024 peak memory curve
<img width="1494" height="954" alt="qwen_image_peak_memory" src="https://github.com/user-attachments/assets/9c0b677d-c135-4485-96db-865f9593823b" />

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27997643271](https://github.com/sgl-project/sglang/actions/runs/27997643271)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27997643155](https://github.com/sgl-project/sglang/actions/runs/27997643155)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->