### PR TITLE
fix: prevent --preferred-sampling-params from being silently overridden by Pydantic defaults

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -17,7 +17,18 @@ import logging
 import time
 import uuid
 from dataclasses import dataclass
-from typing import Any, Dict, List, NamedTuple, Optional, Tuple, TypeAlias, Union
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    List,
+    NamedTuple,
+    Optional,
+    Set,
+    Tuple,
+    TypeAlias,
+    Union,
+)
 
 from openai.types.responses import (
     ResponseFunctionToolCall,
@@ -317,6 +328,43 @@ class CompletionRequest(BaseModel):
 
     # For custom metric labels
     custom_labels: Optional[Dict[str, str]] = None
+
+    # Mapping from request field names to sampling_params dict key names.
+    _FIELD_TO_SAMPLING_KEY: ClassVar[Dict[str, str]] = {
+        "max_tokens": "max_new_tokens",
+        "min_tokens": "min_new_tokens",
+        "stop": "stop",
+        "stop_token_ids": "stop_token_ids",
+        "stop_regex": "stop_regex",
+        "temperature": "temperature",
+        "top_p": "top_p",
+        "top_k": "top_k",
+        "min_p": "min_p",
+        "presence_penalty": "presence_penalty",
+        "frequency_penalty": "frequency_penalty",
+        "repetition_penalty": "repetition_penalty",
+        "regex": "regex",
+        "json_schema": "json_schema",
+        "ebnf": "ebnf",
+        "n": "n",
+        "no_stop_trim": "no_stop_trim",
+        "ignore_eos": "ignore_eos",
+        "skip_special_tokens": "skip_special_tokens",
+        "logit_bias": "logit_bias",
+        "custom_params": "custom_params",
+        "seed": "sampling_seed",
+        "response_format": "json_schema",
+    }
+
+    def get_explicit_sampling_keys(self) -> Set[str]:
+        """Return the set of sampling param keys explicitly set by the user."""
+        keys = set()
+        for field, sampling_key in self._FIELD_TO_SAMPLING_KEY.items():
+            if field in self.model_fields_set:
+                keys.add(sampling_key)
+        if "response_format" in self.model_fields_set:
+            keys.add("structural_tag")
+        return keys
 
     @model_validator(mode="before")
     @classmethod
@@ -738,6 +786,43 @@ class ChatCompletionRequest(BaseModel):
             }
 
         return values
+
+    # Mapping from request field names to sampling_params dict key names.
+    _FIELD_TO_SAMPLING_KEY: ClassVar[Dict[str, str]] = {
+        "max_completion_tokens": "max_new_tokens",
+        "max_tokens": "max_new_tokens",
+        "min_tokens": "min_new_tokens",
+        "stop": "stop",
+        "stop_token_ids": "stop_token_ids",
+        "stop_regex": "stop_regex",
+        "temperature": "temperature",
+        "top_p": "top_p",
+        "top_k": "top_k",
+        "min_p": "min_p",
+        "presence_penalty": "presence_penalty",
+        "frequency_penalty": "frequency_penalty",
+        "repetition_penalty": "repetition_penalty",
+        "regex": "regex",
+        "ebnf": "ebnf",
+        "n": "n",
+        "no_stop_trim": "no_stop_trim",
+        "ignore_eos": "ignore_eos",
+        "skip_special_tokens": "skip_special_tokens",
+        "logit_bias": "logit_bias",
+        "custom_params": "custom_params",
+        "seed": "sampling_seed",
+        "response_format": "json_schema",
+    }
+
+    def get_explicit_sampling_keys(self) -> Set[str]:
+        """Return the set of sampling param keys explicitly set by the user."""
+        keys = set()
+        for field, sampling_key in self._FIELD_TO_SAMPLING_KEY.items():
+            if field in self.model_fields_set:
+                keys.add(sampling_key)
+        if "response_format" in self.model_fields_set:
+            keys.add("structural_tag")
+        return keys
 
     def to_sampling_params(
         self,
@@ -1201,6 +1286,19 @@ class ResponsesRequest(BaseModel):
     min_p: float = 0.0
     repetition_penalty: float = 1.0
 
+    # Mapping from request field names to sampling_params dict key names.
+    _FIELD_TO_SAMPLING_KEY: ClassVar[Dict[str, str]] = {
+        "max_output_tokens": "max_new_tokens",
+        "temperature": "temperature",
+        "top_p": "top_p",
+        "top_k": "top_k",
+        "min_p": "min_p",
+        "frequency_penalty": "frequency_penalty",
+        "presence_penalty": "presence_penalty",
+        "repetition_penalty": "repetition_penalty",
+        "stop": "stop",
+    }
+
     # Default sampling parameters
     _DEFAULT_SAMPLING_PARAMS = {
         "temperature": 0.7,
@@ -1209,6 +1307,14 @@ class ResponsesRequest(BaseModel):
         "min_p": 0.0,
         "repetition_penalty": 1.0,
     }
+
+    def get_explicit_sampling_keys(self) -> Set[str]:
+        """Return the set of sampling param keys explicitly set by the user."""
+        keys = set()
+        for field, sampling_key in self._FIELD_TO_SAMPLING_KEY.items():
+            if field in self.model_fields_set:
+                keys.add(sampling_key)
+        return keys
 
     def to_sampling_params(
         self, default_max_tokens: int, default_params: Optional[Dict] = None

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -297,6 +297,7 @@ class OpenAIServingChat(OpenAIServingBase):
             video_data=processed_messages.video_data,
             audio_data=processed_messages.audio_data,
             sampling_params=sampling_params,
+            sampling_params_explicit_keys=request.get_explicit_sampling_keys(),
             return_logprob=request.logprobs,
             logprob_start_len=-1,
             top_logprobs_num=request.top_logprobs or 0,

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -108,6 +108,7 @@ class OpenAIServingCompletion(OpenAIServingBase):
         adapted_request = GenerateReqInput(
             **prompt_kwargs,
             sampling_params=sampling_params,
+            sampling_params_explicit_keys=request.get_explicit_sampling_keys(),
             return_logprob=request.logprobs is not None,
             top_logprobs_num=request.logprobs if request.logprobs is not None else 0,
             logprob_start_len=logprob_start_len,

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -281,6 +281,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                     adapted_request = GenerateReqInput(
                         input_ids=engine_prompt,
                         sampling_params=sampling_params,
+                        sampling_params_explicit_keys=request.get_explicit_sampling_keys(),
                         stream=request.stream,
                         rid=request.request_id,
                         extra_key=self._compute_extra_key(request),
@@ -1298,6 +1299,7 @@ class OpenAIServingResponses(OpenAIServingChat):
             adapted_request = GenerateReqInput(
                 input_ids=prompt_token_ids,
                 sampling_params=sampling_params,
+                sampling_params_explicit_keys=adapted_request.sampling_params_explicit_keys,
                 stream=adapted_request.stream,
                 rid=request_id,
                 extra_key=adapted_request.extra_key,

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -24,7 +24,7 @@ from abc import ABC
 from collections import Counter
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Set, Union
 
 import torch
 
@@ -150,6 +150,9 @@ class GenerateReqInput(BaseReq):
     audio_data: Optional[MultimodalDataInputFormat] = None
     # The sampling_params. See descriptions below.
     sampling_params: Optional[Union[List[Dict], Dict]] = None
+    # The set of sampling param keys explicitly set by the user request.
+    # Used to correctly merge with preferred_sampling_params.
+    sampling_params_explicit_keys: Optional[Set[str]] = None
     # Whether to return logprobs.
     return_logprob: Optional[Union[List[bool], bool]] = None
     # If return logprobs, the start location in the prompt for returning logprobs.
@@ -611,6 +614,7 @@ class GenerateReqInput(BaseReq):
             video_data=self.video_data[i],
             audio_data=self.audio_data[i],
             sampling_params=self.sampling_params[i],
+            sampling_params_explicit_keys=self.sampling_params_explicit_keys,
             rid=self.rid[i],
             return_logprob=self.return_logprob[i],
             logprob_start_len=self.logprob_start_len[i],

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -939,7 +939,11 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
         # Note: if there are preferred sampling params, we use them if they are not
         # explicitly passed in sampling_params
         if self.preferred_sampling_params:
-            sampling_kwargs = {**self.preferred_sampling_params, **obj.sampling_params}
+            sampling_kwargs = dict(self.preferred_sampling_params)
+            explicit_keys = getattr(obj, "sampling_params_explicit_keys", None)
+            for k, v in obj.sampling_params.items():
+                if explicit_keys is None or k in explicit_keys:
+                    sampling_kwargs[k] = v
         else:
             sampling_kwargs = obj.sampling_params
         sampling_params = self.sampling_params_class(**sampling_kwargs)

--- a/test/registered/unit/managers/test_preferred_sampling_params.py
+++ b/test/registered/unit/managers/test_preferred_sampling_params.py
@@ -1,0 +1,204 @@
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import (
+    ChatCompletionRequest,
+    CompletionRequest,
+    ResponsesRequest,
+)
+
+
+class TestGetExplicitSamplingKeys(unittest.TestCase):
+    """Test get_explicit_sampling_keys() for ChatCompletionRequest and CompletionRequest."""
+
+    def test_chat_no_explicit_params(self):
+        """When user only sends messages, no sampling keys should be explicit."""
+        req = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hello"}],
+        )
+        keys = req.get_explicit_sampling_keys()
+        self.assertEqual(keys, set())
+
+    def test_chat_explicit_temperature(self):
+        """When user sets temperature, it should appear in explicit keys."""
+        req = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hello"}],
+            temperature=0.5,
+        )
+        keys = req.get_explicit_sampling_keys()
+        self.assertIn("temperature", keys)
+
+    def test_chat_explicit_multiple_params(self):
+        """When user sets multiple params, all should appear in explicit keys."""
+        req = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hello"}],
+            temperature=0.5,
+            top_p=0.9,
+            presence_penalty=0.1,
+            max_completion_tokens=100,
+        )
+        keys = req.get_explicit_sampling_keys()
+        self.assertIn("temperature", keys)
+        self.assertIn("top_p", keys)
+        self.assertIn("presence_penalty", keys)
+        self.assertIn("max_new_tokens", keys)
+
+    def test_chat_seed_maps_to_sampling_seed(self):
+        """The 'seed' field should map to 'sampling_seed' key."""
+        req = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hello"}],
+            seed=42,
+        )
+        keys = req.get_explicit_sampling_keys()
+        self.assertIn("sampling_seed", keys)
+
+    def test_completion_no_explicit_params(self):
+        """CompletionRequest with only prompt should have no explicit sampling keys."""
+        req = CompletionRequest(prompt="hello")
+        keys = req.get_explicit_sampling_keys()
+        self.assertEqual(keys, set())
+
+    def test_completion_explicit_temperature(self):
+        """CompletionRequest with explicit temperature."""
+        req = CompletionRequest(prompt="hello", temperature=0.5)
+        keys = req.get_explicit_sampling_keys()
+        self.assertIn("temperature", keys)
+
+    def test_completion_max_tokens_maps_to_max_new_tokens(self):
+        """CompletionRequest 'max_tokens' should map to 'max_new_tokens'."""
+        req = CompletionRequest(prompt="hello", max_tokens=50)
+        keys = req.get_explicit_sampling_keys()
+        self.assertIn("max_new_tokens", keys)
+
+
+class TestResponsesGetExplicitSamplingKeys(unittest.TestCase):
+    """Test get_explicit_sampling_keys() for ResponsesRequest."""
+
+    def test_responses_no_explicit_params(self):
+        """When user only sends input, no sampling keys should be explicit."""
+        req = ResponsesRequest(
+            model="test-model",
+            input="hello",
+        )
+        keys = req.get_explicit_sampling_keys()
+        self.assertEqual(keys, set())
+
+    def test_responses_explicit_temperature(self):
+        """When user sets temperature, it should appear in explicit keys."""
+        req = ResponsesRequest(
+            model="test-model",
+            input="hello",
+            temperature=0.5,
+        )
+        keys = req.get_explicit_sampling_keys()
+        self.assertIn("temperature", keys)
+
+    def test_responses_explicit_multiple_params(self):
+        """When user sets multiple params, all should appear in explicit keys."""
+        req = ResponsesRequest(
+            model="test-model",
+            input="hello",
+            temperature=0.5,
+            top_p=0.9,
+            max_output_tokens=100,
+        )
+        keys = req.get_explicit_sampling_keys()
+        self.assertIn("temperature", keys)
+        self.assertIn("top_p", keys)
+        self.assertIn("max_new_tokens", keys)
+
+    def test_responses_max_output_tokens_maps_to_max_new_tokens(self):
+        """ResponsesRequest 'max_output_tokens' should map to 'max_new_tokens'."""
+        req = ResponsesRequest(
+            model="test-model",
+            input="hello",
+            max_output_tokens=200,
+        )
+        keys = req.get_explicit_sampling_keys()
+        self.assertIn("max_new_tokens", keys)
+
+
+class TestPreferredSamplingParamsMerge(unittest.TestCase):
+    """Test the merge logic between preferred_sampling_params and request params."""
+
+    def _merge(self, preferred, request_params, explicit_keys):
+        """Simulate the merge logic from tokenizer_manager._create_tokenized_object."""
+        if preferred:
+            sampling_kwargs = dict(preferred)
+            for k, v in request_params.items():
+                if explicit_keys is None or k in explicit_keys:
+                    sampling_kwargs[k] = v
+        else:
+            sampling_kwargs = request_params
+        return sampling_kwargs
+
+    def test_no_preferred_params(self):
+        """Without preferred params, request params are used as-is."""
+        request_params = {"temperature": 1.0, "max_new_tokens": 16}
+        result = self._merge(None, request_params, set())
+        self.assertEqual(result, request_params)
+
+    def test_preferred_not_overridden_by_defaults(self):
+        """Preferred params should NOT be overridden by non-explicit request defaults."""
+        preferred = {"temperature": 0.8, "max_new_tokens": 100}
+        request_params = {
+            "temperature": 1.0,  # default, not explicit
+            "max_new_tokens": None,  # default, not explicit
+            "presence_penalty": 0.0,  # default, not explicit
+        }
+        explicit_keys = set()  # user didn't set any sampling params
+
+        result = self._merge(preferred, request_params, explicit_keys)
+        self.assertEqual(result["temperature"], 0.8)
+        self.assertEqual(result["max_new_tokens"], 100)
+
+    def test_explicit_user_value_overrides_preferred(self):
+        """User-explicit values should override preferred params."""
+        preferred = {"temperature": 0.8, "max_new_tokens": 100}
+        request_params = {
+            "temperature": 0.5,  # user explicitly set this
+            "max_new_tokens": None,  # default, not explicit
+            "presence_penalty": 0.0,  # default, not explicit
+        }
+        explicit_keys = {"temperature"}  # only temperature was explicit
+
+        result = self._merge(preferred, request_params, explicit_keys)
+        self.assertEqual(result["temperature"], 0.5)  # overridden by user
+        self.assertEqual(result["max_new_tokens"], 100)  # kept from preferred
+
+    def test_explicit_keys_none_falls_back_to_old_behavior(self):
+        """When explicit_keys is None (e.g., /generate API), all keys override."""
+        preferred = {"temperature": 0.8, "max_new_tokens": 100}
+        request_params = {
+            "temperature": 1.0,
+            "max_new_tokens": 16,
+        }
+        explicit_keys = None  # no info about explicit keys
+
+        result = self._merge(preferred, request_params, explicit_keys)
+        self.assertEqual(result["temperature"], 1.0)  # overridden (old behavior)
+        self.assertEqual(result["max_new_tokens"], 16)  # overridden (old behavior)
+
+    def test_preferred_params_fill_missing_keys(self):
+        """Preferred params should provide values for keys not in request."""
+        preferred = {"temperature": 0.8, "top_k": 50, "max_new_tokens": 200}
+        request_params = {"presence_penalty": 0.1}
+        explicit_keys = {"presence_penalty"}
+
+        result = self._merge(preferred, request_params, explicit_keys)
+        self.assertEqual(result["temperature"], 0.8)
+        self.assertEqual(result["top_k"], 50)
+        self.assertEqual(result["max_new_tokens"], 200)
+        self.assertEqual(result["presence_penalty"], 0.1)
+
+    def test_user_explicitly_sets_zero(self):
+        """User explicitly setting 0.0 should override preferred (not treated as default)."""
+        preferred = {"presence_penalty": 0.5}
+        request_params = {"presence_penalty": 0.0}
+        explicit_keys = {"presence_penalty"}  # user explicitly set it to 0.0
+
+        result = self._merge(preferred, request_params, explicit_keys)
+        self.assertEqual(result["presence_penalty"], 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #21816

When launching the server with `--preferred-sampling-params`, most parameter values are silently ignored because `to_sampling_params()` unconditionally writes Pydantic default values into the sampling params dict, which then override the preferred values during dict merging in `tokenizer_manager.py`:

```python
sampling_kwargs = {**self.preferred_sampling_params, **obj.sampling_params}
```

This means parameters like `presence_penalty: 0.0`, `n: 1`, `skip_special_tokens: True` etc. always override preferred values, even when the user never explicitly set them.

## Modifications

Use Pydantic `model_fields_set` to track which sampling parameters were explicitly provided by the user request. Only explicitly set values override preferred params.

- **protocol.py**: Add `_FIELD_TO_SAMPLING_KEY` (ClassVar) and `get_explicit_sampling_keys()` to `CompletionRequest`, `ChatCompletionRequest`, and `ResponsesRequest`
- **serving_chat.py / serving_completions.py / serving_responses.py**: Pass `sampling_params_explicit_keys` to `GenerateReqInput`
- **io_struct.py**: Add `sampling_params_explicit_keys` field to `GenerateReqInput`; forward it in `__getitem__` for batch requests
- **tokenizer_manager.py**: Change merge logic — only keys in `explicit_keys` override preferred params; `None` falls back to old behavior for backward compatibility

## Checklist
- [x] Format: `pre-commit run --all-files`
- [x] Unit tests: 17 tests covering explicit keys extraction + merge logic for all three endpoints
- [x] Backward compatible: `explicit_keys=None` (native API, Ollama, Engine) falls back to old merge behavior