### PR TITLE
fix: remove duplicate words in comments

### DIFF
--- a/python/sglang/srt/layers/attention/mamba/mamba.py
+++ b/python/sglang/srt/layers/attention/mamba/mamba.py
@@ -60,7 +60,7 @@ def mamba_v2_sharded_weight_loader(
 ) -> LoaderFunction:
     """Create a weight loader for mamba v2. This ensures that the projections
     are correctly sharded so that they can be split into x, B, C. It also
-    ensures the the all the groups corresponding to a head shard is placed
+    ensures that all the groups corresponding to a head shard is placed
     together with it.
     """
 

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -1283,7 +1283,7 @@ class QKVParallelLinear(ColumnParallelLinear):
                         output_dim, start_idx, shard_size
                     )
 
-        # Special case for for AQLM codebooks.
+        # Special case for AQLM codebooks.
         elif is_metadata:
             # metadata indicates fixed size concatenated along dim 0
             shard_size = loaded_weight.shape[0]

--- a/python/sglang/srt/layers/quantization/marlin_utils.py
+++ b/python/sglang/srt/layers/quantization/marlin_utils.py
@@ -261,7 +261,7 @@ def marlin_make_workspace(
     device: torch.device, max_blocks_per_sm: int = 1
 ) -> torch.Tensor:
     # In the new marlin kernel, we use the num of threadblocks as workspace
-    # size. The num of threadblocks is is sms_count * max_blocks_per_sm.
+    # size. The num of threadblocks is sms_count * max_blocks_per_sm.
     sms = torch.cuda.get_device_properties(device).multi_processor_count
     return torch.zeros(
         sms * max_blocks_per_sm, dtype=torch.int, device=device, requires_grad=False

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -289,7 +289,7 @@ class ServerArgs:
     The arguments of the server.
 
     NOTE: When you add new arguments, please make sure the order
-    in this class definition the same as the order in the the function
+    in this class definition the same as the order in the function
     `ServerArgs.add_cli_args`.
     Please follow the existing style to group the new arguments into related groups or create new groups.
     """


### PR DESCRIPTION
Four instances of duplicate words in comments/docstrings:

- `marlin_utils.py`: "is is" → "is"
- `server_args.py`: "the the" → "the"
- `mamba.py`: "the the" → "that"
- `linear.py`: "for for" → "for"