### PR TITLE
[Workflow] Fix kernel release jobs skipped on push events

### DIFF
--- a/.github/workflows/release-whl-kernel.yml
+++ b/.github/workflows/release-whl-kernel.yml
@@ -36,7 +36,7 @@ jobs:
   build-cu129-matrix:
     if: |
       github.repository == 'sgl-project/sglang' &&
-      (github.event.inputs.target == 'all' || github.event.inputs.target == 'cu129')
+      (github.event_name == 'push' || github.event.inputs.target == 'all' || github.event.inputs.target == 'cu129')
     strategy:
       matrix:
         python-version: ["3.10"]
@@ -135,7 +135,7 @@ jobs:
   build-cu130-matrix:
     if: |
       github.repository == 'sgl-project/sglang' &&
-      (github.event.inputs.target == 'all' || github.event.inputs.target == 'cu130')
+      (github.event_name == 'push' || github.event.inputs.target == 'all' || github.event.inputs.target == 'cu130')
     strategy:
       matrix:
         python-version: ["3.10"]
@@ -227,7 +227,7 @@ jobs:
   build-rocm-matrix:
     if: |
       github.repository == 'sgl-project/sglang' &&
-      (github.event.inputs.target == 'all' || github.event.inputs.target == 'rocm700' || github.event.inputs.target == 'rocm720')
+      (github.event_name == 'push' || github.event.inputs.target == 'all' || github.event.inputs.target == 'rocm700' || github.event.inputs.target == 'rocm720')
     runs-on: amd-docker-scale
     strategy:
       matrix:
@@ -362,7 +362,7 @@ jobs:
   build-musa43:
     if: |
       github.repository == 'sgl-project/sglang' &&
-      (github.event.inputs.target == 'all' || github.event.inputs.target == 'musa43')
+      (github.event_name == 'push' || github.event.inputs.target == 'all' || github.event.inputs.target == 'musa43')
     runs-on: kernel-build-node-musa
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
- The `release-whl-kernel.yml` workflow's build jobs were all skipped when triggered by a push to `main` (e.g. [this run](https://github.com/sgl-project/sglang/actions/runs/23935264422))
- Root cause: each build job's `if` condition only checked `github.event.inputs.target`, which is `null` for push events — it's only populated for `workflow_dispatch`
- Fix: add `github.event_name == 'push'` to each build job's condition so they run for both push and workflow_dispatch triggers

## Test plan
- [ ] Verify the next kernel version bump push to `main` triggers all build jobs instead of skipping them
- [ ] Verify `workflow_dispatch` with a specific target still only runs the selected target

🤖 Generated with [Claude Code](https://claude.com/claude-code)