### PR TITLE
[Refactor]Benchmark: Make bench_serving benchmark args reusable for speculative bench

### DIFF
--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -1645,55 +1645,56 @@ def check_chat_template(model_path):
         return False
 
 
+def normalize_benchmark_args(args_: argparse.Namespace):
+    if not hasattr(args_, "max_concurrency"):
+        args_.max_concurrency = None
+
+    if not hasattr(args_, "warmup_requests"):
+        args_.warmup_requests = 1
+
+    if not hasattr(args_, "output_details"):
+        args_.output_details = False
+
+    if not hasattr(args_, "tokenize_prompt"):
+        args_.tokenize_prompt = False
+
+    if not hasattr(args_, "plot_throughput"):
+        args_.plot_throughput = False
+
+    if not hasattr(args_, "top_logprobs_num"):
+        args_.top_logprobs_num = 0
+    if not hasattr(args_, "token_ids_logprob"):
+        args_.token_ids_logprob = None
+    if not hasattr(args_, "logprob_start_len"):
+        args_.logprob_start_len = -1
+    if not hasattr(args_, "return_logprob"):
+        args_.return_logprob = False
+
+    if not hasattr(args_, "use_trace_timestamps"):
+        args_.use_trace_timestamps = False
+    if not hasattr(args_, "mooncake_slowdown_factor"):
+        args_.mooncake_slowdown_factor = 1.0
+
+    if not hasattr(args_, "mooncake_num_rounds"):
+        args_.mooncake_num_rounds = 1
+
+    if not hasattr(args_, "served_model_name"):
+        args_.served_model_name = None
+
+    return args_
+
+
+
 def set_global_args(args_: argparse.Namespace):
     """Set the global args."""
     global args
-    args = args_
+    args = normalize_benchmark_args(args_)
+
 
 
 def run_benchmark(args_: argparse.Namespace):
     global args
-    args = args_
-
-    # Set default value for max_concurrency if not present
-    if not hasattr(args, "max_concurrency"):
-        args.max_concurrency = None
-
-    # Set default value for warmup_requests if not present
-    if not hasattr(args, "warmup_requests"):
-        args.warmup_requests = 1
-
-    if not hasattr(args, "output_details"):
-        args.output_details = False
-
-    if not hasattr(args, "tokenize_prompt"):
-        args.tokenize_prompt = False
-
-    if not hasattr(args, "plot_throughput"):
-        args.plot_throughput = False
-
-    if not hasattr(args, "top_logprobs_num"):
-        args.top_logprobs_num = 0
-    if not hasattr(args, "token_ids_logprob"):
-        args.token_ids_logprob = None
-    if not hasattr(args, "logprob_start_len"):
-        args.logprob_start_len = -1
-    if not hasattr(args, "return_logprob"):
-        args.return_logprob = False
-
-    if not hasattr(args, "use_trace_timestamps"):
-        args.use_trace_timestamps = False
-    if not hasattr(args, "mooncake_slowdown_factor"):
-        args.mooncake_slowdown_factor = 1.0
-
-    if not hasattr(args, "mooncake_slowdown_factor"):
-        args.mooncake_slowdown_factor = 1.0
-
-    if not hasattr(args, "mooncake_num_rounds"):
-        args.mooncake_num_rounds = 1
-
-    if not hasattr(args, "served_model_name"):
-        args.served_model_name = None
+    args = normalize_benchmark_args(args_)
 
     if getattr(args, "print_requests", False):
         assert args.backend == "sglang-oai-chat"  # only support this now

--- a/scripts/playground/bench_speculative.py
+++ b/scripts/playground/bench_speculative.py
@@ -165,33 +165,24 @@ def main(args, server_args):
             other_args = []
         else:
             other_args = [
-                "--speculative-num-steps",
-                steps,
-                "--speculative-eagle-topk",
-                topk,
-                "--speculative-num-draft-tokens",
-                num_draft_tokens,
+                f"--speculative-num-steps={steps}",
+                f"--speculative-eagle-topk={topk}",
+                f"--speculative-num-draft-tokens={num_draft_tokens}",
             ]
             if server_args.speculative_draft_model_path is not None:
                 other_args.extend(
                     [
-                        "--speculative-draft-model-path",
-                        server_args.speculative_draft_model_path,
-                        "--speculative-algorithm",
-                        server_args.speculative_algorithm,
+                        f"--speculative-draft-model-path={server_args.speculative_draft_model_path}",
+                        f"--speculative-algorithm={server_args.speculative_algorithm}",
                     ]
                 )
 
         other_args.extend(
             [
-                "--cuda-graph-max-bs",
-                batch_size,
-                "--mem-fraction-static",
-                server_args.mem_fraction_static,
-                "--tp-size",
-                server_args.tp_size,
-                "--max-running-requests",
-                batch_size,
+                f"--cuda-graph-max-bs={batch_size}",
+                f"--mem-fraction-static={server_args.mem_fraction_static}",
+                f"--tp-size={server_args.tp_size}",
+                f"--max-running-requests={batch_size}",
             ]
         )
 
@@ -205,16 +196,14 @@ def main(args, server_args):
         if server_args.attention_backend:
             other_args.extend(
                 [
-                    "--attention-backend",
-                    server_args.attention_backend,
+                    f"--attention-backend={server_args.attention_backend}",
                 ]
             )
 
         if server_args.quantization:
             other_args.extend(
                 [
-                    "--quantization",
-                    server_args.quantization,
+                    f"--quantization={server_args.quantization}",
                 ]
             )
 

--- a/scripts/playground/bench_speculative.py
+++ b/scripts/playground/bench_speculative.py
@@ -165,24 +165,33 @@ def main(args, server_args):
             other_args = []
         else:
             other_args = [
-                f"--speculative-num-steps={steps}",
-                f"--speculative-eagle-topk={topk}",
-                f"--speculative-num-draft-tokens={num_draft_tokens}",
+                "--speculative-num-steps",
+                steps,
+                "--speculative-eagle-topk",
+                topk,
+                "--speculative-num-draft-tokens",
+                num_draft_tokens,
             ]
             if server_args.speculative_draft_model_path is not None:
                 other_args.extend(
                     [
-                        f"--speculative-draft-model-path={server_args.speculative_draft_model_path}",
-                        f"--speculative-algorithm={server_args.speculative_algorithm}",
+                        "--speculative-draft-model-path",
+                        server_args.speculative_draft_model_path,
+                        "--speculative-algorithm",
+                        server_args.speculative_algorithm,
                     ]
                 )
 
         other_args.extend(
             [
-                f"--cuda-graph-max-bs={batch_size}",
-                f"--mem-fraction-static={server_args.mem_fraction_static}",
-                f"--tp-size={server_args.tp_size}",
-                f"--max-running-requests={batch_size}",
+                "--cuda-graph-max-bs",
+                batch_size,
+                "--mem-fraction-static",
+                server_args.mem_fraction_static,
+                "--tp-size",
+                server_args.tp_size,
+                "--max-running-requests",
+                batch_size,
             ]
         )
 
@@ -196,14 +205,16 @@ def main(args, server_args):
         if server_args.attention_backend:
             other_args.extend(
                 [
-                    f"--attention-backend={server_args.attention_backend}",
+                    "--attention-backend",
+                    server_args.attention_backend,
                 ]
             )
 
         if server_args.quantization:
             other_args.extend(
                 [
-                    f"--quantization={server_args.quantization}",
+                    "--quantization",
+                    server_args.quantization,
                 ]
             )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
To fix #22013 and prevent similar issues from recurring, I refactored bench_serving.py so direct benchmark callers can safely reuse the existing benchmarking flow without failing on missing optional arguments.

bench_serving.py function calls looks like:

- send_one_batch() -> args = SimpleNamespace(  ) -> set_global_args(args) -> benchmark from sglang.bench_serving

However, bench_speculative.py constructs a SimpleNamespace with an incomplete set of benchmark arguments. In particular, it does not provide logprob_start_len, which caused this issue.
Otherwise, we observed that bench_serving.py already had benchmark-argument fallback logic, but it was not reused by direct callers of benchmark().Therefore, we refactored the fallback logic into a separate function and reused it in set_global_args().

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

Use
``` 
python3 ./scripts/playground/bench_speculative.py --model-path /gfs/space/chatrl/public/models/ZhipuAI/GLM-4.7-Flash-0309 --tp-size 2 --trust-remote-code --batch-size 1 4 8 16 32 --steps 0 1 2 --topk 0 1 2 4 --num_draft_tokens 0 2 4 8 
```
to reproduct this issue.

Before update
<img width="1252" height="601" alt="企业微信截图_17751924947278" src="https://github.com/user-attachments/assets/d80f995d-2c47-4053-b654-725112c77501" />

After update
<img width="1259" height="796" alt="企业微信截图_17751964803135" src="https://github.com/user-attachments/assets/b377727a-09be-4345-b4cd-3fcdbd4e9eeb" />


<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


## CC @FortPercent @qzweng