### PR TITLE
[fix] Anthropic /v1/messages endpoint: forward original error instead of returning generic 500

### DIFF
--- a/python/sglang/srt/entrypoints/anthropic/serving.py
+++ b/python/sglang/srt/entrypoints/anthropic/serving.py
@@ -49,6 +49,38 @@ STOP_REASON_MAP = {
     "tool_calls": "tool_use",
 }
 
+# Map HTTP status codes to Anthropic error types
+_HTTP_STATUS_TO_ANTHROPIC_ERROR_TYPE = {
+    400: "invalid_request_error",
+    401: "authentication_error",
+    403: "permission_error",
+    404: "not_found_error",
+    429: "rate_limit_error",
+    500: "api_error",
+    503: "overloaded_error",
+}
+
+
+def _extract_error_message(body: dict, default: str = "Internal processing error") -> str:
+    """Extract error message from an OpenAI-style error response body.
+
+    Handles both flat format (from create_error_response):
+        {"object": "error", "message": "...", ...}
+    and nested format (from create_streaming_error_response):
+        {"error": {"message": "...", ...}}
+    """
+    # Try flat structure first: {"message": "..."}
+    msg = body.get("message")
+    if isinstance(msg, str) and msg:
+        return msg
+    # Try nested structure: {"error": {"message": "..."}}
+    error_obj = body.get("error")
+    if isinstance(error_obj, dict):
+        msg = error_obj.get("message")
+        if isinstance(msg, str) and msg:
+            return msg
+    return default
+
 
 def _wrap_sse_event(data: str, event_type: str) -> str:
     """Format an Anthropic SSE event with event type and data lines."""
@@ -351,11 +383,27 @@ class AnthropicServing:
 
         # Check for error responses from OpenAI handler
         if not isinstance(response, ChatCompletionResponse):
-            # It's an error response (ORJSONResponse)
+            # It's an error response (ORJSONResponse), extract the original error info
+            status_code = getattr(response, "status_code", 500)
+            error_message = "Internal processing error"
+            try:
+                error_body = json.loads(response.body)
+                error_message = _extract_error_message(error_body, error_message)
+            except Exception:
+                pass
+            # Map HTTP status code to Anthropic error type
+            error_type = _HTTP_STATUS_TO_ANTHROPIC_ERROR_TYPE.get(
+                status_code, "api_error"
+            )
+            logger.warning(
+                "OpenAI handler returned error (status=%s): %s",
+                status_code,
+                error_message,
+            )
             return self._error_response(
-                status_code=500,
-                error_type="internal_error",
-                message="Internal processing error",
+                status_code=status_code,
+                error_type=error_type,
+                message=error_message,
             )
 
         # Convert to Anthropic response
@@ -482,11 +530,22 @@ class AnthropicServing:
             try:
                 chunk = ChatCompletionStreamResponse.model_validate_json(data_str)
             except Exception:
-                logger.debug("Failed to parse stream chunk: %s", data_str)
+                # Try to extract error info from the original data
+                error_message = "Stream processing error"
+                try:
+                    error_data = json.loads(data_str)
+                    error_message = _extract_error_message(
+                        error_data, error_message
+                    )
+                except Exception:
+                    pass
+                logger.warning(
+                    "Failed to parse stream chunk: %s", data_str[:500]
+                )
                 error_event = AnthropicStreamEvent(
                     type="error",
                     error=AnthropicError(
-                        type="api_error", message="Stream processing error"
+                        type="api_error", message=error_message
                     ),
                 )
                 yield _wrap_sse_event(


### PR DESCRIPTION


## Motivation

The Anthropic-compatible `/v1/messages` endpoint returns a generic HTTP 500 `"Internal processing error"` for **all** errors from the underlying OpenAI handler, even when the real error is a 400 (e.g., token count exceeded). The original error message and status code are silently discarded with no server-side logging, making debugging extremely difficult.

For example, when a request exceeds the model's context length, the OpenAI handler correctly produces a 400 with a detailed message, but the Anthropic adapter swallows it:

```
# Before fix
{"type":"error","error":{"type":"internal_error","message":"Internal processing error"}}  # HTTP 500

# After fix
{"type":"error","error":{"type":"invalid_request_error","message":"Requested token count exceeds the model's maximum context length of 65536 tokens. You requested a total of 65710 tokens: 57710 tokens from the input messages and 8000 tokens for the completion."}}  # HTTP 400
```

## Modifications

**File:** `python/sglang/srt/entrypoints/anthropic/serving.py`

1. **Add HTTP-to-Anthropic error type mapping:** A `_HTTP_STATUS_TO_ANTHROPIC_ERROR_TYPE` dict maps HTTP status codes to Anthropic error types (`400 → invalid_request_error`, `429 → rate_limit_error`, `500 → api_error`, etc.).

2. **Fix non-streaming error forwarding:** In `_handle_non_streaming`, when the OpenAI handler returns an `ORJSONResponse` instead of `ChatCompletionResponse`, extract the real `status_code` and `message` from the response body and forward them with the correct Anthropic error type. Also adds a `logger.warning` so the error is visible in server logs.

3. **Fix streaming error forwarding:** In `_generate_anthropic_stream`, when a stream chunk fails to parse as `ChatCompletionStreamResponse`, attempt to extract the actual error message from the raw JSON data. Upgrade log level from `debug` to `warning`.

## Accuracy Tests

N/A — This change only affects error handling in the Anthropic API adapter layer. It does not modify model inference, kernels, or request processing logic.

## Speed Tests and Profiling

N/A — No impact on inference speed. The added code only runs on error paths.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).