### PR TITLE
[AMD][Dockerfile] Multi-stage build for ROCm image to reduce size.

### DIFF
--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -501,8 +501,14 @@ RUN /bin/bash -lc 'set -euo pipefail; \
 
 # -----------------------
 # fast-hadamard-transform: install wheel built in builder stage.
+# --no-deps is critical: the wheel declares `torch` as a runtime dep, and
+# without --no-deps pip resolves that to the latest PyPI CUDA torch
+# (currently torch-2.11.0+cu130), which silently replaces the base image's
+# ROCm torch and breaks the whole stack with `operator torchvision::nms
+# does not exist` at server start. The base image already provides a
+# compatible torch, so we only want the FHT package itself.
 COPY --from=builder-fht /tmp/fht-wheel/ /tmp/fht-wheel/
-RUN pip install --no-cache-dir --force-reinstall /tmp/fht-wheel/*.whl \
+RUN pip install --no-cache-dir --no-deps --force-reinstall /tmp/fht-wheel/*.whl \
     && rm -rf /tmp/fht-wheel
 
 # -----------------------

--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -14,18 +14,93 @@
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx950 --build-arg ENABLE_MORI=1 -t v0.5.10.post1-rocm700-mi35x -f rocm.Dockerfile .
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx950-rocm720 --build-arg ENABLE_MORI=1 -t v0.5.10.post1-rocm720-mi35x -f rocm.Dockerfile .
 
-# Default base images
-ARG BASE_IMAGE_942="rocm/sgl-dev:rocm7-vllm-20250904"
-ARG BASE_IMAGE_942_ROCM720="rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1"
-ARG BASE_IMAGE_950="rocm/sgl-dev:rocm7-vllm-20250904"
-ARG BASE_IMAGE_950_ROCM720="rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1"
+# Default base images (slim ROCm dev images; PyTorch is installed below).
+ARG BASE_IMAGE_ROCM700="rocm/dev-ubuntu-22.04:7.0-complete"
+ARG BASE_IMAGE_ROCM720="rocm/dev-ubuntu-22.04:7.2-complete"
+
+# AMD-published ROCm torch/triton/torchvision wheels (Python 3.10, "lw" lightweight variants).
+# torchvision is required because the SGLang `timm` dep pulls it transitively;
+# without a ROCm wheel installed up front, pip's resolver fetches the PyPI CUDA
+# build of torchvision and cascades a CUDA torch replacement that breaks GPU access.
+ARG ROCM700_TORCH_WHL="torch-2.8.0+rocm7.0.0.lw.git64359f59-cp310-cp310-linux_x86_64.whl"
+ARG ROCM700_TRITON_WHL="pytorch_triton_rocm-3.4.0+rocm7.0.0.gitf9e5bf54-cp310-cp310-linux_x86_64.whl"
+ARG ROCM700_TORCHVISION_WHL="torchvision-0.23.0+rocm7.0.0.git824e8c87-cp310-cp310-linux_x86_64.whl"
+ARG ROCM700_WHL_INDEX="https://repo.radeon.com/rocm/manylinux/rocm-rel-7.0"
+
+ARG ROCM720_TORCH_WHL="torch-2.9.1+rocm7.2.0.lw.git7e1940d4-cp310-cp310-linux_x86_64.whl"
+ARG ROCM720_TRITON_WHL="triton-3.5.1+rocm7.2.0.gita272dfa8-cp310-cp310-linux_x86_64.whl"
+ARG ROCM720_TORCHVISION_WHL="torchvision-0.24.0+rocm7.2.0.gitb919bd0c-cp310-cp310-linux_x86_64.whl"
+ARG ROCM720_WHL_INDEX="https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2"
 
 # This is necessary for scope purpose
 ARG GPU_ARCH=gfx950
 
 # ===============================
-# Base image 942 with rocm700 and args
-FROM $BASE_IMAGE_942 AS gfx942
+# Shared base for ROCm 7.0 flavors: install Python toolchain + AMD torch/triton wheels.
+FROM $BASE_IMAGE_ROCM700 AS base-rocm700
+ARG ROCM700_TORCH_WHL
+ARG ROCM700_TRITON_WHL
+ARG ROCM700_TORCHVISION_WHL
+ARG ROCM700_WHL_INDEX
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 python3-dev python3-pip python3-venv \
+        git curl wget gnupg ca-certificates build-essential \
+    && mkdir -p /etc/apt/keyrings \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -sf /usr/bin/python3 /usr/local/bin/python \
+    && ln -sf /usr/bin/pip3 /usr/local/bin/pip \
+    && python -m pip install --no-cache-dir --upgrade pip wheel setuptools \
+    && cd /tmp \
+    && curl -fLO "${ROCM700_WHL_INDEX}/${ROCM700_TORCH_WHL}" \
+    && curl -fLO "${ROCM700_WHL_INDEX}/${ROCM700_TRITON_WHL}" \
+    && curl -fLO "${ROCM700_WHL_INDEX}/${ROCM700_TORCHVISION_WHL}" \
+    && pip install --no-cache-dir \
+        "/tmp/${ROCM700_TORCH_WHL}" \
+        "/tmp/${ROCM700_TRITON_WHL}" \
+        "/tmp/${ROCM700_TORCHVISION_WHL}" \
+    && rm -f "/tmp/${ROCM700_TORCH_WHL}" "/tmp/${ROCM700_TRITON_WHL}" "/tmp/${ROCM700_TORCHVISION_WHL}" \
+    # Alias pytorch-triton-rocm dist-info as `triton` so pip considers SGLang's
+    # transitive `triton` requirement (via xgrammar) satisfied; otherwise pip
+    # pulls triton 3.7.0 from PyPI (CUDA build) and breaks the inductor path.
+    # The pytorch_triton_rocm wheel already installs the `triton` Python module;
+    # this just adds the package-name registration that pip's resolver needs.
+    && SITE=$(python -c 'import site; print(site.getsitepackages()[0])') \
+    && SRC_DIST=$(ls -d "$SITE"/pytorch_triton_rocm-*.dist-info | head -1) \
+    && DST_DIST=$(echo "$SRC_DIST" | sed 's|/pytorch_triton_rocm-|/triton-|') \
+    && cp -r "$SRC_DIST" "$DST_DIST" \
+    && sed -i 's/^Name: pytorch[-_]triton[-_]rocm$/Name: triton/' "$DST_DIST/METADATA" \
+    && python -c 'import importlib.metadata as m; print("pip sees triton ==", m.version("triton"))'
+
+# ===============================
+# Shared base for ROCm 7.2.2 flavors.
+FROM $BASE_IMAGE_ROCM720 AS base-rocm720
+ARG ROCM720_TORCH_WHL
+ARG ROCM720_TRITON_WHL
+ARG ROCM720_TORCHVISION_WHL
+ARG ROCM720_WHL_INDEX
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 python3-dev python3-pip python3-venv \
+        git curl wget gnupg ca-certificates build-essential \
+    && mkdir -p /etc/apt/keyrings \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -sf /usr/bin/python3 /usr/local/bin/python \
+    && ln -sf /usr/bin/pip3 /usr/local/bin/pip \
+    && python -m pip install --no-cache-dir --upgrade pip wheel setuptools \
+    && cd /tmp \
+    && curl -fLO "${ROCM720_WHL_INDEX}/${ROCM720_TORCH_WHL}" \
+    && curl -fLO "${ROCM720_WHL_INDEX}/${ROCM720_TRITON_WHL}" \
+    && curl -fLO "${ROCM720_WHL_INDEX}/${ROCM720_TORCHVISION_WHL}" \
+    && pip install --no-cache-dir \
+        "/tmp/${ROCM720_TORCH_WHL}" \
+        "/tmp/${ROCM720_TRITON_WHL}" \
+        "/tmp/${ROCM720_TORCHVISION_WHL}" \
+    && rm -f "/tmp/${ROCM720_TORCH_WHL}" "/tmp/${ROCM720_TRITON_WHL}" "/tmp/${ROCM720_TORCHVISION_WHL}"
+
+# ===============================
+# Per-arch base aliases (so the rest of the file can FROM ${GPU_ARCH} into the right base).
+FROM base-rocm700 AS gfx942
 ENV BUILD_VLLM="0"
 ENV BUILD_TRITON="0"
 ENV BUILD_LLVM="0"
@@ -33,9 +108,7 @@ ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
 ENV AITER_COMMIT_DEFAULT="32e1e6d76988e4fbc67cabd9eb72a45a3c6a1bab"
 
-# ===============================
-# Base image 942 with rocm720 and args
-FROM $BASE_IMAGE_942_ROCM720 AS gfx942-rocm720
+FROM base-rocm720 AS gfx942-rocm720
 ENV BUILD_VLLM="0"
 ENV BUILD_TRITON="1"
 ENV BUILD_LLVM="0"
@@ -43,9 +116,7 @@ ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
 ENV AITER_COMMIT_DEFAULT="32e1e6d76988e4fbc67cabd9eb72a45a3c6a1bab"
 
-# ===============================
-# Base image 950 and args
-FROM $BASE_IMAGE_950 AS gfx950
+FROM base-rocm700 AS gfx950
 ENV BUILD_VLLM="0"
 ENV BUILD_TRITON="0"
 ENV BUILD_LLVM="0"
@@ -53,9 +124,7 @@ ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
 ENV AITER_COMMIT_DEFAULT="32e1e6d76988e4fbc67cabd9eb72a45a3c6a1bab"
 
-# ===============================
-# Base image 950 with rocm720 and args
-FROM $BASE_IMAGE_950_ROCM720 AS gfx950-rocm720
+FROM base-rocm720 AS gfx950-rocm720
 ENV BUILD_VLLM="0"
 ENV BUILD_TRITON="1"
 ENV BUILD_LLVM="0"
@@ -254,7 +323,7 @@ ARG LLVM_REPO="https://github.com/jrbyrnes/llvm-project.git"
 ARG LLVM_BRANCH="MainOpSelV2"
 ARG LLVM_COMMIT="6520ace8227ffe2728148d5f3b9872a870b0a560"
 
-ARG ENABLE_MORI=0
+ARG ENABLE_MORI=1
 ARG NIC_BACKEND=none
 
 ARG MORI_REPO="https://github.com/ROCm/mori.git"
@@ -323,18 +392,14 @@ RUN python -m pip install --no-cache-dir --upgrade pip \
     && rm -f "$(which sccache 2>/dev/null)" || true
 
 # Install AMD SMI Python package from ROCm distribution.
-# The ROCm 7.2 base image (rocm/pytorch) does not pre-install this package.
+# dev-ubuntu-22.04:*-complete images ship the sources under /opt/rocm/share/amd_smi
+# but no Python wheel; build & install in-place. Skip if the dir is absent.
 RUN set -eux; \
-    case "${GPU_ARCH}" in \
-      *rocm720*) \
-        echo "ROCm 7.2 flavor detected from GPU_ARCH=${GPU_ARCH}"; \
-        cd /opt/rocm/share/amd_smi \
-        && python3 -m pip install --no-cache-dir . \
-        ;; \
-      *) \
-        echo "Not rocm720 (GPU_ARCH=${GPU_ARCH}), skip amdsmi installation"; \
-        ;; \
-    esac
+    if [ -d /opt/rocm/share/amd_smi ]; then \
+        cd /opt/rocm/share/amd_smi && python3 -m pip install --no-cache-dir .; \
+    else \
+        echo "amd_smi sources not found at /opt/rocm/share/amd_smi, skipping"; \
+    fi
 
 WORKDIR /sgl-workspace
 
@@ -570,79 +635,9 @@ RUN /bin/bash -lc 'set -euo pipefail; \
   echo "[MORI] Done."'
 
 # -----------------------
-# Hot patch: torch-ROCm
-# The artifact hardcoded the supported triton version to be 3.5.1.
-# Rewrite the restriction directly. hack.py is written in its own RUN
-# because heredoc + case in a single RUN does not parse reliably under
-# /bin/sh.
-ARG TORCH_ROCM_FILE="torch-2.9.1+rocm7.2.0.lw.git7e1940d4-cp310-cp310-linux_x86_64.whl"
-RUN mkdir -p /tmp/whl && cat > /tmp/whl/hack.py <<"PY"
-import zipfile, csv, os, re
-from pathlib import Path
-
-fname = os.environ["TORCH_ROCM_FILE"]
-in_whl  = Path("/")   / fname
-out_whl = Path("/tmp")/ fname
-work = Path("/tmp/whl")
-
-# 1) Extract
-with zipfile.ZipFile(in_whl, "r") as z:
-    z.extractall(work)
-
-# 2) Locate dist-info and patch METADATA (edit this logic to match your exact line)
-dist_info = next(work.glob("*.dist-info"))
-meta = dist_info / "METADATA"
-txt = meta.read_text(encoding="utf-8")
-
-# Example: replace one exact requirement form.
-# Adjust the string to match what you actually see.
-pat = r"^Requires-Dist:\s*triton==3.5.1[^\s]*;"
-txt2, n = re.subn(pat, r"triton>=3.5.1;", txt, flags=re.MULTILINE)
-if txt2 == txt:
-    raise SystemExit("Did not find expected Requires-Dist line to replace in METADATA")
-meta.write_text(txt2, encoding="utf-8")
-
-# 3) Hacky step: blank hash/size columns in RECORD
-record = dist_info / "RECORD"
-rows = []
-with record.open(newline="", encoding="utf-8") as f:
-    for r in csv.reader(f):
-        if not r:
-            continue
-        # keep filename, blank out hash and size
-        rows.append([r[0], "", ""])
-with record.open("w", newline="", encoding="utf-8") as f:
-    csv.writer(f).writerows(rows)
-
-# 4) Re-zip as a wheel
-with zipfile.ZipFile(out_whl, "w", compression=zipfile.ZIP_DEFLATED) as z:
-    for p in work.rglob("*"):
-        if p.is_file():
-            z.write(p, p.relative_to(work).as_posix())
-
-print("Wrote", out_whl)
-PY
-
-RUN set -eux; \
-    case "${GPU_ARCH}" in \
-      *rocm720*) \
-        echo "ROCm 7.2 flavor detected from GPU_ARCH=${GPU_ARCH}"; \
-        cd /tmp/whl \
-        && export TORCH_ROCM_FILE="${TORCH_ROCM_FILE}" \
-        && python hack.py \
-        && python3 -m pip install --force --no-deps --no-cache-dir /tmp/${TORCH_ROCM_FILE} \
-        && rm -rf /tmp/whl /tmp/${TORCH_ROCM_FILE}; \
-        ;; \
-      *) \
-        echo "Not rocm720 (GPU_ARCH=${GPU_ARCH}), skip patch"; \
-        rm -rf /tmp/whl; \
-        ;; \
-    esac
-
-
-# -----------------------
-# Install custom Triton from builder-triton wheel (ROCm 7.2 only). When
-# BUILD_TRITON=0 the builder produced no wheel and this is a no-op.
+# Install custom Triton from builder-triton wheel (opt-in via BUILD_TRITON=1).
+# When BUILD_TRITON=0 the builder produced no wheel and this is a no-op; the
+# AMD-published triton installed in the base stage is used instead.
 COPY --from=builder-triton /tmp/triton-wheel/ /tmp/triton-wheel/
 RUN set -eux; \
     if ls /tmp/triton-wheel/*.whl 1>/dev/null 2>&1; then \

--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -13,20 +13,6 @@
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx942-rocm720 --build-arg ENABLE_MORI=1 -t v0.5.10.post1-rocm720-mi30x -f rocm.Dockerfile .
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx950 --build-arg ENABLE_MORI=1 -t v0.5.10.post1-rocm700-mi35x -f rocm.Dockerfile .
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx950-rocm720 --build-arg ENABLE_MORI=1 -t v0.5.10.post1-rocm720-mi35x -f rocm.Dockerfile .
-#
-# This Dockerfile uses multi-stage builds to keep build-time toolchains
-# (Rust, Go, full source trees, .o files) out of the final image. Builder
-# stages produce wheels / installed library trees that are COPYed into the
-# final stage. BuildKit (DOCKER_BUILDKIT=1, default in modern docker) is
-# strongly recommended -- builder stages run in parallel and unused stages
-# are skipped automatically.
-#
-# Two install styles are intentionally preserved:
-#   * Editable (`pip install -e .`) for AITER, SGLang and MORI: these are
-#     the components developers iterate on inside the container.
-#   * Non-editable (wheel/install-from-builder) for Triton, TileLang, FHT,
-#     sgl-model-gateway and Mooncake: build artifacts are discarded with
-#     the builder stage so only runtime files land in the final image.
 
 # Default base images
 ARG BASE_IMAGE_942="rocm/sgl-dev:rocm7-vllm-20250904"
@@ -77,9 +63,8 @@ ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
 ENV AITER_COMMIT_DEFAULT="32e1e6d76988e4fbc67cabd9eb72a45a3c6a1bab"
 
-# ================================================================
-# Builder stage: sgl-model-gateway (Rust wheel, ~5.8 GB discarded)
-# ================================================================
+# ===============================
+# Builder stage: sgl-model-gateway
 FROM ${GPU_ARCH} AS builder-gateway
 
 ARG GPU_ARCH=gfx950
@@ -89,9 +74,6 @@ ARG SGL_BRANCH=${SGL_DEFAULT}
 
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Clone sglang sources, install Rust + maturin and build the gateway wheel
-# into /tmp/gateway-wheel. Only the wheel is COPYed into the final image,
-# so the Rust toolchain (~1.3 GB) and cargo target dir (~4.5 GB) are dropped.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         protobuf-compiler libprotobuf-dev \
     && rm -rf /var/lib/apt/lists/* \
@@ -106,9 +88,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && ulimit -n 65536 && CARGO_BUILD_JOBS=4 maturin build \
         --release --features vendored-openssl --out /tmp/gateway-wheel
 
-# ================================================================
-# Builder stage: Mooncake (Go + C++, ~6 GB discarded)
-# ================================================================
+# ===============================
+# Builder stage: Mooncake
 FROM ${GPU_ARCH} AS builder-mooncake
 
 ARG GPU_ARCH=gfx950
@@ -117,11 +98,8 @@ ARG MOONCAKE_COMMIT="b6a841dc78c707ec655a563453277d969fb8f38d"
 
 ENV PATH=$PATH:/usr/local/go/bin
 
-# Build Mooncake with DESTDIR staging so we capture only the install tree
-# (libetcd_wrapper.so, transfer_engine_c.h, mooncake_master, python bindings)
-# and discard the Go toolchain, source, and intermediate build dir.
-# Always create the staging dir so unconditional COPY --from never fails.
-# When BUILD_MOONCAKE!=1 we skip the build but still leave the placeholder.
+# Always create the staging dir so the unconditional COPY --from in the
+# final stage is a safe no-op when BUILD_MOONCAKE != 1.
 RUN mkdir -p /mooncake-install/usr/local \
     && if [ "$BUILD_MOONCAKE" = "1" ]; then \
         apt-get update && apt-get install -y --no-install-recommends \
@@ -145,9 +123,8 @@ RUN mkdir -p /mooncake-install/usr/local \
         && DESTDIR=/mooncake-install make install; \
     fi
 
-# ================================================================
-# Builder stage: fast-hadamard-transform (HIP wheel)
-# ================================================================
+# ===============================
+# Builder stage: fast-hadamard-transform
 FROM ${GPU_ARCH} AS builder-fht
 
 ARG FHT_REPO="https://github.com/jeffdaily/fast-hadamard-transform.git"
@@ -160,9 +137,8 @@ RUN pip install --no-cache-dir wheel \
     && git checkout -f "${FHT_COMMIT}" \
     && FAST_HADAMARD_TRANSFORM_FORCE_BUILD=TRUE python setup.py bdist_wheel -d /tmp/fht-wheel
 
-# ================================================================
-# Builder stage: TileLang (~2.3 GB discarded)
-# ================================================================
+# ===============================
+# Builder stage: TileLang
 FROM ${GPU_ARCH} AS builder-tilelang
 
 ARG GPU_ARCH=gfx950
@@ -171,8 +147,6 @@ ARG TILELANG_COMMIT="a55a82302bf7f3c5af635b5c9146f728185cc900"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Build TileLang as a wheel; only the wheel is COPYed to final image.
-# All build-time apt packages (LLVM, gtest, gflags, etc.) are discarded.
 RUN /bin/bash -lc 'set -euo pipefail; \
   echo "[TileLang] Building TileLang wheel for ${GPU_ARCH}"; \
   apt-get update && apt-get install -y --no-install-recommends \
@@ -234,16 +208,16 @@ RUN /bin/bash -lc 'set -euo pipefail; \
   export CMAKE_ARGS="-DUSE_CUDA=OFF -DUSE_ROCM=ON -DROCM_PATH=/opt/rocm -DLLVM_CONFIG=${LLVM_CONFIG} -DSKBUILD_SABI_VERSION= ${CMAKE_ARGS:-}" && \
   "$VENV_PIP" wheel -w /tmp/tilelang-wheel . -v --no-build-isolation --no-deps'
 
-# ================================================================
-# Builder stage: Triton custom build (~16 GB of .o files discarded)
-# ================================================================
+# ===============================
+# Builder stage: Triton custom build
 FROM ${GPU_ARCH} AS builder-triton
 
 ARG TRITON_REPO="https://github.com/triton-lang/triton.git"
 ARG TRITON_COMMIT="42270451990532c67e69d753fbd026f28fcc4840"
 
 # BUILD_TRITON is inherited as ENV from the selected base stage.
-# Always create output dir so COPY --from never fails when triton is not built.
+# Always create the output dir so the COPY --from in the final stage is a
+# safe no-op when BUILD_TRITON != 1.
 RUN mkdir -p /tmp/triton-wheel \
     && if [ "$BUILD_TRITON" = "1" ]; then \
         pip uninstall -y triton 2>/dev/null || true \
@@ -256,9 +230,8 @@ RUN mkdir -p /tmp/triton-wheel \
      && pip wheel --no-cache-dir --no-deps -w /tmp/triton-wheel .; \
     fi
 
-# ================================================================
+# ===============================
 # Final stage
-# ================================================================
 FROM ${GPU_ARCH}
 
 # This is necessary for scope purpose, again
@@ -380,7 +353,7 @@ RUN if [ "$BUILD_LLVM" = "1" ]; then \
     fi
 
 # -----------------------
-# AITER (editable; source kept for in-container development)
+# AITER
 # Unset setuptools_scm override so AITER gets its own version (AITER_COMMIT), not SGLang's
 # (SETUPTOOLS_SCM_PRETEND_VERSION is set later for SGLang nightly builds and would otherwise
 # leak into AITER's version when AITER uses setuptools_scm)
@@ -409,15 +382,12 @@ RUN pip uninstall -y aiter 2>/dev/null || true \
       sh -c "GPU_ARCHS=$GPU_ARCH_LIST pip install --no-cache-dir --config-settings editable_mode=compat -e ."; \
     fi \
  && echo "export PYTHONPATH=/sgl-workspace/aiter:\${PYTHONPATH}" >> /etc/bash.bashrc \
- # Cleanup: remove .o files (source kept; .git shrunk via gc).
- # Do NOT touch *.so — those are the prebuilt kernels for runtime.
+ # Drop .o files and shrink .git; keep the source tree and .so kernels.
  && find /sgl-workspace/aiter -name '*.o' -delete 2>/dev/null || true \
  && (cd /sgl-workspace/aiter && git reflog expire --expire=now --all && git gc --prune=now --quiet) || true
 
 # -----------------------
-# Mooncake: install runtime deps + copy build artifacts from builder stage
-# Build-time deps (gcc/make/libtool/autoconf, the Go toolchain, etc.) live
-# only in builder-mooncake and are dropped from the final image.
+# Mooncake: install runtime deps; build artifacts come from builder-mooncake.
 RUN if [ "$BUILD_MOONCAKE" = "1" ]; then \
      apt-get update && apt-get install -y --no-install-recommends \
          librdmacm-dev rdmacm-utils infiniband-diags ibverbs-utils perftest ethtool \
@@ -429,13 +399,10 @@ RUN if [ "$BUILD_MOONCAKE" = "1" ]; then \
      && rm -rf /var/lib/apt/lists/*; \
     fi
 
-# Copy Mooncake DESTDIR install tree (libetcd_wrapper.so, mooncake_master, etc.).
-# When BUILD_MOONCAKE=0 the staging dir contains only an empty `/usr/local`
-# placeholder so this COPY is a no-op.
 COPY --from=builder-mooncake /mooncake-install/ /
 
 # -----------------------
-# Build SGLang (sgl-kernel + editable sglang in a single layer)
+# Build SGLang
 ARG BUILD_TYPE=all
 
 # Set version for setuptools_scm if provided (for nightly builds). Only pass in the SGLang
@@ -473,15 +440,14 @@ RUN find /sgl-workspace/sglang/python/sglang/srt/layers/quantization/configs/ \
          -type f -name '*MI300X*' | xargs -I {} sh -c 'vf_config=$(echo "$1" | sed "s/MI300X/MI300X_VF/"); cp "$1" "$vf_config"' -- {}
 
 # -----------------------
-# sgl-model-gateway: install wheel built in builder stage. The Rust toolchain
-# (~1.3 GB) and cargo target dir (~4.5 GB) never enter the final image.
+# Install sgl-model-gateway from builder-gateway wheel.
 COPY --from=builder-gateway /tmp/gateway-wheel/ /tmp/gateway-wheel/
 RUN pip install --no-cache-dir --force-reinstall /tmp/gateway-wheel/*.whl \
     && rm -rf /tmp/gateway-wheel /root/.cache
 
 # -----------------------
-# TileLang: install wheel built in builder stage. Runtime deps tvm_ffi and
-# z3-solver are required by the bundled TVM.
+# Install TileLang from builder-tilelang wheel; tvm_ffi and z3-solver are
+# runtime deps of the bundled TVM.
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LIBGL_ALWAYS_INDIRECT=1
 RUN echo "LC_ALL=en_US.UTF-8" >> /etc/environment
@@ -500,13 +466,10 @@ RUN /bin/bash -lc 'set -euo pipefail; \
   "$VENV_PY" -c "import tilelang; print(tilelang.__version__)"'
 
 # -----------------------
-# fast-hadamard-transform: install wheel built in builder stage.
-# --no-deps is critical: the wheel declares `torch` as a runtime dep, and
-# without --no-deps pip resolves that to the latest PyPI CUDA torch
-# (currently torch-2.11.0+cu130), which silently replaces the base image's
-# ROCm torch and breaks the whole stack with `operator torchvision::nms
-# does not exist` at server start. The base image already provides a
-# compatible torch, so we only want the FHT package itself.
+# Install fast-hadamard-transform from builder-fht wheel. --no-deps is
+# required because the wheel declares torch as a runtime dep, and pip would
+# otherwise resolve it to PyPI CUDA torch and replace the ROCm torch from
+# the base image.
 COPY --from=builder-fht /tmp/fht-wheel/ /tmp/fht-wheel/
 RUN pip install --no-cache-dir --no-deps --force-reinstall /tmp/fht-wheel/*.whl \
     && rm -rf /tmp/fht-wheel
@@ -518,7 +481,7 @@ RUN python3 -m pip install --no-cache-dir \
     tabulate
 
 # -----------------------
-# MORI (optional, editable; source kept for in-container development)
+# MORI (optional)
 RUN /bin/bash -lc 'set -euo pipefail; \
   if [ "${ENABLE_MORI}" != "1" ]; then \
     echo "[MORI] Skipping (ENABLE_MORI=${ENABLE_MORI})"; \
@@ -609,10 +572,9 @@ RUN /bin/bash -lc 'set -euo pipefail; \
 # -----------------------
 # Hot patch: torch-ROCm
 # The artifact hardcoded the supported triton version to be 3.5.1.
-# Rewrite the restriction directly. The extract+install+cleanup all run in
-# a single RUN so the 3.3 GB extracted wheel tree never lingers as its own
-# layer (creating hack.py is a separate tiny RUN — heredoc + case in one
-# RUN does not parse reliably under /bin/sh).
+# Rewrite the restriction directly. hack.py is written in its own RUN
+# because heredoc + case in a single RUN does not parse reliably under
+# /bin/sh.
 ARG TORCH_ROCM_FILE="torch-2.9.1+rocm7.2.0.lw.git7e1940d4-cp310-cp310-linux_x86_64.whl"
 RUN mkdir -p /tmp/whl && cat > /tmp/whl/hack.py <<"PY"
 import zipfile, csv, os, re
@@ -679,9 +641,8 @@ RUN set -eux; \
 
 
 # -----------------------
-# Triton (non-editable): install wheel built in builder stage.
-# For ROCm 7.2 this custom build replaces the stock triton wheel; if
-# BUILD_TRITON=0 the builder stage produced no wheel and this is a no-op.
+# Install custom Triton from builder-triton wheel (ROCm 7.2 only). When
+# BUILD_TRITON=0 the builder produced no wheel and this is a no-op.
 COPY --from=builder-triton /tmp/triton-wheel/ /tmp/triton-wheel/
 RUN set -eux; \
     if ls /tmp/triton-wheel/*.whl 1>/dev/null 2>&1; then \

--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -13,6 +13,20 @@
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx942-rocm720 --build-arg ENABLE_MORI=1 -t v0.5.10.post1-rocm720-mi30x -f rocm.Dockerfile .
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx950 --build-arg ENABLE_MORI=1 -t v0.5.10.post1-rocm700-mi35x -f rocm.Dockerfile .
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx950-rocm720 --build-arg ENABLE_MORI=1 -t v0.5.10.post1-rocm720-mi35x -f rocm.Dockerfile .
+#
+# This Dockerfile uses multi-stage builds to keep build-time toolchains
+# (Rust, Go, full source trees, .o files) out of the final image. Builder
+# stages produce wheels / installed library trees that are COPYed into the
+# final stage. BuildKit (DOCKER_BUILDKIT=1, default in modern docker) is
+# strongly recommended -- builder stages run in parallel and unused stages
+# are skipped automatically.
+#
+# Two install styles are intentionally preserved:
+#   * Editable (`pip install -e .`) for AITER, SGLang and MORI: these are
+#     the components developers iterate on inside the container.
+#   * Non-editable (wheel/install-from-builder) for Triton, TileLang, FHT,
+#     sgl-model-gateway and Mooncake: build artifacts are discarded with
+#     the builder stage so only runtime files land in the final image.
 
 # Default base images
 ARG BASE_IMAGE_942="rocm/sgl-dev:rocm7-vllm-20250904"
@@ -63,8 +77,188 @@ ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
 ENV AITER_COMMIT_DEFAULT="32e1e6d76988e4fbc67cabd9eb72a45a3c6a1bab"
 
-# ===============================
-# Chosen arch and args
+# ================================================================
+# Builder stage: sgl-model-gateway (Rust wheel, ~5.8 GB discarded)
+# ================================================================
+FROM ${GPU_ARCH} AS builder-gateway
+
+ARG GPU_ARCH=gfx950
+ARG SGL_REPO="https://github.com/sgl-project/sglang.git"
+ARG SGL_DEFAULT="main"
+ARG SGL_BRANCH=${SGL_DEFAULT}
+
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Clone sglang sources, install Rust + maturin and build the gateway wheel
+# into /tmp/gateway-wheel. Only the wheel is COPYed into the final image,
+# so the Rust toolchain (~1.3 GB) and cargo target dir (~4.5 GB) are dropped.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        protobuf-compiler libprotobuf-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+    && pip install --no-cache-dir maturin \
+    && git clone ${SGL_REPO} /tmp/sglang \
+    && cd /tmp/sglang \
+    && git checkout ${SGL_BRANCH} \
+    && sed -i -E 's|^(smg-[a-zA-Z-]+)\s*=\s*"~1\.0\.0"|\1 = "=1.0.0"|' \
+           sgl-model-gateway/Cargo.toml \
+    && cd sgl-model-gateway/bindings/python \
+    && ulimit -n 65536 && CARGO_BUILD_JOBS=4 maturin build \
+        --release --features vendored-openssl --out /tmp/gateway-wheel
+
+# ================================================================
+# Builder stage: Mooncake (Go + C++, ~6 GB discarded)
+# ================================================================
+FROM ${GPU_ARCH} AS builder-mooncake
+
+ARG GPU_ARCH=gfx950
+ARG MOONCAKE_REPO="https://github.com/kvcache-ai/Mooncake.git"
+ARG MOONCAKE_COMMIT="b6a841dc78c707ec655a563453277d969fb8f38d"
+
+ENV PATH=$PATH:/usr/local/go/bin
+
+# Build Mooncake with DESTDIR staging so we capture only the install tree
+# (libetcd_wrapper.so, transfer_engine_c.h, mooncake_master, python bindings)
+# and discard the Go toolchain, source, and intermediate build dir.
+# Always create the staging dir so unconditional COPY --from never fails.
+# When BUILD_MOONCAKE!=1 we skip the build but still leave the placeholder.
+RUN mkdir -p /mooncake-install/usr/local \
+    && if [ "$BUILD_MOONCAKE" = "1" ]; then \
+        apt-get update && apt-get install -y --no-install-recommends \
+            zip unzip wget gcc make libtool autoconf \
+            librdmacm-dev rdmacm-utils infiniband-diags ibverbs-utils perftest ethtool \
+            libibverbs-dev rdma-core \
+            openssh-server openmpi-bin openmpi-common libopenmpi-dev \
+        && rm -rf /var/lib/apt/lists/* \
+        && git clone ${MOONCAKE_REPO} /tmp/Mooncake \
+        && cd /tmp/Mooncake \
+        && git checkout ${MOONCAKE_COMMIT} \
+        && git submodule update --init --recursive \
+        && bash dependencies.sh -y \
+        && rm -rf /usr/local/go \
+        && wget -q https://go.dev/dl/go1.22.2.linux-amd64.tar.gz \
+        && tar -C /usr/local -xzf go1.22.2.linux-amd64.tar.gz \
+        && rm go1.22.2.linux-amd64.tar.gz \
+        && mkdir -p build && cd build \
+        && cmake .. -DUSE_HIP=ON -DUSE_ETCD=ON \
+        && make -j "$(nproc)" \
+        && DESTDIR=/mooncake-install make install; \
+    fi
+
+# ================================================================
+# Builder stage: fast-hadamard-transform (HIP wheel)
+# ================================================================
+FROM ${GPU_ARCH} AS builder-fht
+
+ARG FHT_REPO="https://github.com/jeffdaily/fast-hadamard-transform.git"
+ARG FHT_BRANCH="rocm"
+ARG FHT_COMMIT="46efb7d776d38638fc39f3c803eaee3dd7016bd1"
+
+RUN pip install --no-cache-dir wheel \
+    && git clone --branch "${FHT_BRANCH}" "${FHT_REPO}" /tmp/fht \
+    && cd /tmp/fht \
+    && git checkout -f "${FHT_COMMIT}" \
+    && FAST_HADAMARD_TRANSFORM_FORCE_BUILD=TRUE python setup.py bdist_wheel -d /tmp/fht-wheel
+
+# ================================================================
+# Builder stage: TileLang (~2.3 GB discarded)
+# ================================================================
+FROM ${GPU_ARCH} AS builder-tilelang
+
+ARG GPU_ARCH=gfx950
+ARG TILELANG_REPO="https://github.com/tile-ai/tilelang.git"
+ARG TILELANG_COMMIT="a55a82302bf7f3c5af635b5c9146f728185cc900"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Build TileLang as a wheel; only the wheel is COPYed to final image.
+# All build-time apt packages (LLVM, gtest, gflags, etc.) are discarded.
+RUN /bin/bash -lc 'set -euo pipefail; \
+  echo "[TileLang] Building TileLang wheel for ${GPU_ARCH}"; \
+  apt-get update && apt-get install -y --no-install-recommends \
+      build-essential git wget curl ca-certificates gnupg \
+      libgtest-dev libgmock-dev \
+      libprotobuf-dev protobuf-compiler libgflags-dev libsqlite3-dev \
+      python3 python3-dev python3-setuptools python3-pip python3-apt \
+      gcc libtinfo-dev zlib1g-dev libedit-dev libxml2-dev \
+      cmake ninja-build pkg-config libstdc++6 software-properties-common \
+  && rm -rf /var/lib/apt/lists/*; \
+  \
+  VENV_PIP="/opt/venv/bin/pip"; \
+  if [ ! -x "$VENV_PIP" ]; then VENV_PIP="pip3"; fi; \
+  \
+  # Build GoogleTest static libs (Ubuntu package ships sources only)
+  cmake -S /usr/src/googletest -B /tmp/build-gtest -DBUILD_GTEST=ON -DBUILD_GMOCK=ON -DCMAKE_BUILD_TYPE=Release && \
+  cmake --build /tmp/build-gtest -j"$(nproc)" && \
+  cp -v /tmp/build-gtest/lib/*.a /usr/lib/x86_64-linux-gnu/ && \
+  rm -rf /tmp/build-gtest; \
+  \
+  "$VENV_PIP" install --no-cache-dir --upgrade "setuptools>=77.0.3,<80" wheel cmake ninja scikit-build-core; \
+  \
+  # Locate ROCm llvm-config; fallback to LLVM 18 if missing
+  LLVM_CONFIG_PATH=""; \
+  for p in /opt/rocm/llvm/bin/llvm-config /opt/rocm/llvm-*/bin/llvm-config /opt/rocm-*/llvm*/bin/llvm-config; do \
+    if [ -x "$p" ]; then LLVM_CONFIG_PATH="$p"; break; fi; \
+  done; \
+  if [ -z "$LLVM_CONFIG_PATH" ]; then \
+    echo "[TileLang] ROCm llvm-config not found; installing LLVM 18..."; \
+    curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/keyrings/llvm.gpg; \
+    echo "deb [signed-by=/etc/apt/keyrings/llvm.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main" > /etc/apt/sources.list.d/llvm.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends llvm-18; \
+    rm -rf /var/lib/apt/lists/*; \
+    LLVM_CONFIG_PATH="$(command -v llvm-config-18)"; \
+    if [ -z "$LLVM_CONFIG_PATH" ]; then echo "ERROR: llvm-config-18 not found after install"; exit 1; fi; \
+  fi; \
+  echo "[TileLang] Using LLVM_CONFIG at: $LLVM_CONFIG_PATH"; \
+  export PATH="$(dirname "$LLVM_CONFIG_PATH"):/usr/local/bin:${PATH}"; \
+  export LLVM_CONFIG="$LLVM_CONFIG_PATH"; \
+  \
+  # Optional shim for tools that expect llvm-config-16
+  mkdir -p /usr/local/bin && \
+  printf "#!/usr/bin/env bash\nexec \"%s\" \"\$@\"\n" "$LLVM_CONFIG_PATH" > /usr/local/bin/llvm-config-16 && \
+  chmod +x /usr/local/bin/llvm-config-16; \
+  \
+  # TVM bits need Cython + z3 before configure.
+  # Pin z3-solver==4.15.4.0: 4.15.4.0 has a manylinux wheel; 4.15.5.0 builds from source (needs GCC 14+).
+  "$VENV_PIP" install --no-cache-dir "cython>=0.29.36,<3.0" \
+      "apache-tvm-ffi @ git+https://github.com/apache/tvm-ffi.git@37d0485b2058885bf4e7a486f7d7b2174a8ac1ce" \
+      "z3-solver==4.15.4.0"; \
+  \
+  git clone --recursive "${TILELANG_REPO}" /opt/tilelang && \
+  cd /opt/tilelang && \
+  git fetch --depth=1 origin "${TILELANG_COMMIT}" || true && \
+  git checkout -f "${TILELANG_COMMIT}" && \
+  git submodule update --init --recursive && \
+  if [ -f pyproject.toml ]; then sed -i "/^[[:space:]]*\"torch/d" pyproject.toml || true; fi && \
+  export CMAKE_ARGS="-DUSE_CUDA=OFF -DUSE_ROCM=ON -DROCM_PATH=/opt/rocm -DLLVM_CONFIG=${LLVM_CONFIG} -DSKBUILD_SABI_VERSION= ${CMAKE_ARGS:-}" && \
+  "$VENV_PIP" wheel -w /tmp/tilelang-wheel . -v --no-build-isolation --no-deps'
+
+# ================================================================
+# Builder stage: Triton custom build (~16 GB of .o files discarded)
+# ================================================================
+FROM ${GPU_ARCH} AS builder-triton
+
+ARG TRITON_REPO="https://github.com/triton-lang/triton.git"
+ARG TRITON_COMMIT="42270451990532c67e69d753fbd026f28fcc4840"
+
+# BUILD_TRITON is inherited as ENV from the selected base stage.
+# Always create output dir so COPY --from never fails when triton is not built.
+RUN mkdir -p /tmp/triton-wheel \
+    && if [ "$BUILD_TRITON" = "1" ]; then \
+        pip uninstall -y triton 2>/dev/null || true \
+     && apt-get update && apt-get install -y --no-install-recommends cmake \
+     && rm -rf /var/lib/apt/lists/* \
+     && git clone ${TRITON_REPO} /tmp/triton-custom \
+     && cd /tmp/triton-custom \
+     && git checkout ${TRITON_COMMIT} \
+     && pip install --no-cache-dir -r python/requirements.txt \
+     && pip wheel --no-cache-dir --no-deps -w /tmp/triton-wheel .; \
+    fi
+
+# ================================================================
+# Final stage
+# ================================================================
 FROM ${GPU_ARCH}
 
 # This is necessary for scope purpose, again
@@ -79,9 +273,6 @@ ARG SGL_BRANCH=${SGL_DEFAULT}
 # Version override for setuptools_scm (used in nightly builds)
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=""
 
-ARG TRITON_REPO="https://github.com/triton-lang/triton.git"
-ARG TRITON_COMMIT="42270451990532c67e69d753fbd026f28fcc4840"
-
 ARG AITER_REPO="https://github.com/ROCm/aiter.git"
 ARG AITER_COMMIT=""
 ENV AITER_COMMIT="${AITER_COMMIT:-${AITER_COMMIT_DEFAULT}}"
@@ -89,16 +280,6 @@ ENV AITER_COMMIT="${AITER_COMMIT:-${AITER_COMMIT_DEFAULT}}"
 ARG LLVM_REPO="https://github.com/jrbyrnes/llvm-project.git"
 ARG LLVM_BRANCH="MainOpSelV2"
 ARG LLVM_COMMIT="6520ace8227ffe2728148d5f3b9872a870b0a560"
-
-ARG MOONCAKE_REPO="https://github.com/kvcache-ai/Mooncake.git"
-ARG MOONCAKE_COMMIT="b6a841dc78c707ec655a563453277d969fb8f38d"
-
-ARG TILELANG_REPO="https://github.com/tile-ai/tilelang.git"
-ARG TILELANG_COMMIT="a55a82302bf7f3c5af635b5c9146f728185cc900"
-
-ARG FHT_REPO="https://github.com/jeffdaily/fast-hadamard-transform.git"
-ARG FHT_BRANCH="rocm"
-ARG FHT_COMMIT="46efb7d776d38638fc39f3c803eaee3dd7016bd1"
 
 ARG ENABLE_MORI=0
 ARG NIC_BACKEND=none
@@ -160,10 +341,13 @@ RUN set -eux; \
         ;; \
     esac
 
-
-# Install some basic utilities
-RUN python -m pip install --upgrade pip && pip install setuptools_scm
-RUN apt-get purge -y sccache; python -m pip uninstall -y sccache; rm -f "$(which sccache)"
+# Install basic utilities + common pip dependencies in a single layer.
+RUN python -m pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir \
+        setuptools_scm IPython orjson python-multipart torchao==0.9.0 pybind11 \
+    && (apt-get purge -y sccache 2>/dev/null || true) \
+    && (python -m pip uninstall -y sccache 2>/dev/null || true) \
+    && rm -f "$(which sccache 2>/dev/null)" || true
 
 # Install AMD SMI Python package from ROCm distribution.
 # The ROCm 7.2 base image (rocm/pytorch) does not pre-install this package.
@@ -191,11 +375,12 @@ RUN if [ "$BUILD_LLVM" = "1" ]; then \
      && mkdir build \
      && cd build \
      && cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=1 -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86" -DLLVM_ENABLE_PROJECTS="clang;lld;" -DLLVM_ENABLE_RUNTIMES="compiler-rt" ../llvm \
-     && make -j$(nproc); \
+     && make -j$(nproc) \
+     && find /sgl-workspace/llvm-project -name '*.o' -delete; \
     fi
 
 # -----------------------
-# AITER
+# AITER (editable; source kept for in-container development)
 # Unset setuptools_scm override so AITER gets its own version (AITER_COMMIT), not SGLang's
 # (SETUPTOOLS_SCM_PRETEND_VERSION is set later for SGLang nightly builds and would otherwise
 # leak into AITER's version when AITER uses setuptools_scm)
@@ -205,67 +390,60 @@ ENV SETUPTOOLS_SCM_PRETEND_VERSION=
 # Keep the base image's Torch-compatible Triton by default. Override with
 # AITER_USE_SYSTEM_TRITON=0 when intentionally testing aiter-managed Triton.
 ENV AITER_USE_SYSTEM_TRITON=1
-RUN pip uninstall -y aiter
-RUN git clone ${AITER_REPO} \
+RUN pip uninstall -y aiter 2>/dev/null || true \
+ && git clone ${AITER_REPO} \
  && cd aiter \
  && git checkout ${AITER_COMMIT} \
  && git cherry-pick --no-commit b639cb63bcac4672dce33a731fad042a65cb3649 \
  && git submodule update --init --recursive \
- && pip install -r requirements.txt
-
-RUN cd aiter \
-     && echo "[AITER] GPU_ARCH=${GPU_ARCH}" \
-     && echo "[AITER] AITER_USE_SYSTEM_TRITON=${AITER_USE_SYSTEM_TRITON}" \
-     && if [ "$BUILD_AITER_ALL" = "1" ] && [ "$BUILD_LLVM" = "1" ]; then \
-          sh -c "HIP_CLANG_PATH=/sgl-workspace/llvm-project/build/bin/ PREBUILD_KERNELS=1 GPU_ARCHS=$GPU_ARCH_LIST python setup.py build_ext --inplace" \
-          && sh -c "HIP_CLANG_PATH=/sgl-workspace/llvm-project/build/bin/ GPU_ARCHS=$GPU_ARCH_LIST pip install --config-settings editable_mode=compat -e ."; \
-        elif [ "$BUILD_AITER_ALL" = "1" ]; then \
-          sh -c "PREBUILD_KERNELS=1 GPU_ARCHS=$GPU_ARCH_LIST python setup.py build_ext --inplace" \
-          && sh -c "GPU_ARCHS=$GPU_ARCH_LIST pip install --config-settings editable_mode=compat -e ."; \
-        else \
-          sh -c "GPU_ARCHS=$GPU_ARCH_LIST pip install --config-settings editable_mode=compat -e ."; \
-        fi \
-      && echo "export PYTHONPATH=/sgl-workspace/aiter:\${PYTHONPATH}" >> /etc/bash.bashrc
+ && pip install --no-cache-dir -r requirements.txt \
+ && echo "[AITER] GPU_ARCH=${GPU_ARCH}" \
+ && echo "[AITER] AITER_USE_SYSTEM_TRITON=${AITER_USE_SYSTEM_TRITON}" \
+ && if [ "$BUILD_AITER_ALL" = "1" ] && [ "$BUILD_LLVM" = "1" ]; then \
+      sh -c "HIP_CLANG_PATH=/sgl-workspace/llvm-project/build/bin/ PREBUILD_KERNELS=1 GPU_ARCHS=$GPU_ARCH_LIST python setup.py build_ext --inplace" \
+      && sh -c "HIP_CLANG_PATH=/sgl-workspace/llvm-project/build/bin/ GPU_ARCHS=$GPU_ARCH_LIST pip install --no-cache-dir --config-settings editable_mode=compat -e ."; \
+    elif [ "$BUILD_AITER_ALL" = "1" ]; then \
+      sh -c "PREBUILD_KERNELS=1 GPU_ARCHS=$GPU_ARCH_LIST python setup.py build_ext --inplace" \
+      && sh -c "GPU_ARCHS=$GPU_ARCH_LIST pip install --no-cache-dir --config-settings editable_mode=compat -e ."; \
+    else \
+      sh -c "GPU_ARCHS=$GPU_ARCH_LIST pip install --no-cache-dir --config-settings editable_mode=compat -e ."; \
+    fi \
+ && echo "export PYTHONPATH=/sgl-workspace/aiter:\${PYTHONPATH}" >> /etc/bash.bashrc \
+ # Cleanup: remove .o files (source kept; .git shrunk via gc).
+ # Do NOT touch *.so — those are the prebuilt kernels for runtime.
+ && find /sgl-workspace/aiter -name '*.o' -delete 2>/dev/null || true \
+ && (cd /sgl-workspace/aiter && git reflog expire --expire=now --all && git gc --prune=now --quiet) || true
 
 # -----------------------
-# Build Mooncake
-ENV PATH=$PATH:/usr/local/go/bin
-
+# Mooncake: install runtime deps + copy build artifacts from builder stage
+# Build-time deps (gcc/make/libtool/autoconf, the Go toolchain, etc.) live
+# only in builder-mooncake and are dropped from the final image.
 RUN if [ "$BUILD_MOONCAKE" = "1" ]; then \
-     apt update && apt install -y zip unzip wget && \
-     apt install -y gcc make libtool autoconf  librdmacm-dev rdmacm-utils infiniband-diags ibverbs-utils perftest ethtool  libibverbs-dev rdma-core && \
-     apt install -y openssh-server openmpi-bin openmpi-common libopenmpi-dev && \
-     git clone ${MOONCAKE_REPO} && \
-     cd Mooncake && \
-     git checkout ${MOONCAKE_COMMIT} && \
-     git submodule update --init --recursive && \
-     bash dependencies.sh -y && \
-     rm -rf /usr/local/go && \
-     wget https://go.dev/dl/go1.22.2.linux-amd64.tar.gz && \
-     tar -C /usr/local -xzf go1.22.2.linux-amd64.tar.gz && \
-     rm go1.22.2.linux-amd64.tar.gz && \
-     mkdir -p build && \
-     cd build && \
-     cmake .. -DUSE_HIP=ON -DUSE_ETCD=ON && \
-     make -j "$(nproc)" && make install; \
+     apt-get update && apt-get install -y --no-install-recommends \
+         librdmacm-dev rdmacm-utils infiniband-diags ibverbs-utils perftest ethtool \
+         libibverbs-dev rdma-core \
+         openssh-server openmpi-bin openmpi-common libopenmpi-dev \
+         libgoogle-glog-dev libjsoncpp-dev libunwind-dev libnuma-dev \
+         libboost-all-dev libssl-dev libyaml-cpp-dev libgflags-dev \
+         libgrpc-dev libgrpc++-dev libprotobuf-dev \
+     && rm -rf /var/lib/apt/lists/*; \
     fi
 
+# Copy Mooncake DESTDIR install tree (libetcd_wrapper.so, mooncake_master, etc.).
+# When BUILD_MOONCAKE=0 the staging dir contains only an empty `/usr/local`
+# placeholder so this COPY is a no-op.
+COPY --from=builder-mooncake /mooncake-install/ /
+
 # -----------------------
-# Build SGLang
+# Build SGLang (sgl-kernel + editable sglang in a single layer)
 ARG BUILD_TYPE=all
 
 # Set version for setuptools_scm if provided (for nightly builds). Only pass in the SGLang
 # pip install RUN so it does not affect AITER, sgl-model-gateway, TileLang, FHT, MORI, etc.
 ARG SETUPTOOLS_SCM_PRETEND_VERSION
 
-RUN pip install IPython \
-    && pip install orjson \
-    && pip install python-multipart \
-    && pip install torchao==0.9.0 \
-    && pip install pybind11
-
-RUN pip uninstall -y sgl_kernel sglang
-RUN git clone ${SGL_REPO} \
+RUN pip uninstall -y sgl_kernel sglang 2>/dev/null || true \
+    && git clone ${SGL_REPO} \
     && cd sglang \
     && if [ "${SGL_BRANCH}" = ${SGL_DEFAULT} ]; then \
          echo "Using ${SGL_DEFAULT}, default branch."; \
@@ -284,122 +462,57 @@ RUN git clone ${SGL_REPO} \
          export SETUPTOOLS_SCM_PRETEND_VERSION="${SETUPTOOLS_SCM_PRETEND_VERSION}" && python -m pip --no-cache-dir install -e "python[srt_hip,diffusion_hip]"; \
        else \
          export SETUPTOOLS_SCM_PRETEND_VERSION="${SETUPTOOLS_SCM_PRETEND_VERSION}" && python -m pip --no-cache-dir install -e "python[all_hip]"; \
-       fi
-
-RUN python -m pip cache purge
+       fi \
+    && find /sgl-workspace/sglang -name '*.o' -delete 2>/dev/null || true \
+    && (cd /sgl-workspace/sglang && git reflog expire --expire=now --all && git gc --prune=now --quiet) || true \
+    && python -m pip cache purge
 
 # Copy config files to support MI300X in virtualized environments (MI300X_VF).  Symlinks will not be created in image build.
 RUN find /sgl-workspace/sglang/python/sglang/srt/layers/quantization/configs/ \
          /sgl-workspace/sglang/python/sglang/srt/layers/moe/fused_moe_triton/configs/ \
          -type f -name '*MI300X*' | xargs -I {} sh -c 'vf_config=$(echo "$1" | sed "s/MI300X/MI300X_VF/"); cp "$1" "$vf_config"' -- {}
 
-# Install Rust toolchain for sgl-model-gateway
-ENV PATH="/root/.cargo/bin:${PATH}"
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
-    && rustc --version && cargo --version
-ENV CARGO_BUILD_JOBS=4
-
-# Build and install sgl-model-gateway
-RUN python3 -m pip install --no-cache-dir maturin \
-    && sed -i -E 's|^(smg-[a-zA-Z-]+)\s*=\s*"~1\.0\.0"|\1 = "=1.0.0"|' \
-           /sgl-workspace/sglang/sgl-model-gateway/Cargo.toml \
-    && grep -E '^smg-' /sgl-workspace/sglang/sgl-model-gateway/Cargo.toml \
-    && cd /sgl-workspace/sglang/sgl-model-gateway/bindings/python \
-    && ulimit -n 65536 && maturin build --release --features vendored-openssl --out dist \
-    && python3 -m pip install --force-reinstall dist/*.whl \
-    && rm -rf /root/.cache
+# -----------------------
+# sgl-model-gateway: install wheel built in builder stage. The Rust toolchain
+# (~1.3 GB) and cargo target dir (~4.5 GB) never enter the final image.
+COPY --from=builder-gateway /tmp/gateway-wheel/ /tmp/gateway-wheel/
+RUN pip install --no-cache-dir --force-reinstall /tmp/gateway-wheel/*.whl \
+    && rm -rf /tmp/gateway-wheel /root/.cache
 
 # -----------------------
-# TileLang
+# TileLang: install wheel built in builder stage. Runtime deps tvm_ffi and
+# z3-solver are required by the bundled TVM.
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LIBGL_ALWAYS_INDIRECT=1
 RUN echo "LC_ALL=en_US.UTF-8" >> /etc/environment
 
+COPY --from=builder-tilelang /tmp/tilelang-wheel/ /tmp/tilelang-wheel/
 RUN /bin/bash -lc 'set -euo pipefail; \
-  echo "[TileLang] Building TileLang for ${GPU_ARCH}"; \
-  # System dependencies (NO llvm-dev to avoid llvm-config-16 shadowing)
-  apt-get update && apt-get install -y --no-install-recommends \
-      build-essential git wget curl ca-certificates gnupg \
-      libgtest-dev libgmock-dev \
-      libprotobuf-dev protobuf-compiler libgflags-dev libsqlite3-dev \
-      python3 python3-dev python3-setuptools python3-pip python3-apt \
-      gcc libtinfo-dev zlib1g-dev libedit-dev libxml2-dev vim \
-      cmake ninja-build pkg-config libstdc++6 software-properties-common \
-  && rm -rf /var/lib/apt/lists/*; \
-  \
-  # Prefer the container venv
-  VENV_PY="/opt/venv/bin/python"; \
   VENV_PIP="/opt/venv/bin/pip"; \
-  if [ ! -x "$VENV_PY" ]; then VENV_PY="python3"; fi; \
+  VENV_PY="/opt/venv/bin/python"; \
   if [ ! -x "$VENV_PIP" ]; then VENV_PIP="pip3"; fi; \
-  \
-  # Build GoogleTest static libs (Ubuntu package ships sources only)
-  cmake -S /usr/src/googletest -B /tmp/build-gtest -DBUILD_GTEST=ON -DBUILD_GMOCK=ON -DCMAKE_BUILD_TYPE=Release && \
-  cmake --build /tmp/build-gtest -j"$(nproc)" && \
-  cp -v /tmp/build-gtest/lib/*.a /usr/lib/x86_64-linux-gnu/ && \
-  rm -rf /tmp/build-gtest; \
-  \
-  # Keep setuptools < 80 (compat with base image)
-  "$VENV_PIP" install --upgrade "setuptools>=77.0.3,<80" wheel cmake ninja scikit-build-core && \
-  "$VENV_PIP" cache purge || true; \
-  \
-  # Locate ROCm llvm-config; fallback to installing LLVM 18 if missing
-  LLVM_CONFIG_PATH=""; \
-  for p in /opt/rocm/llvm/bin/llvm-config /opt/rocm/llvm-*/bin/llvm-config /opt/rocm-*/llvm*/bin/llvm-config; do \
-    if [ -x "$p" ]; then LLVM_CONFIG_PATH="$p"; break; fi; \
-  done; \
-  if [ -z "$LLVM_CONFIG_PATH" ]; then \
-    echo "[TileLang] ROCm llvm-config not found; installing LLVM 18..."; \
-    curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/keyrings/llvm.gpg; \
-    echo "deb [signed-by=/etc/apt/keyrings/llvm.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main" > /etc/apt/sources.list.d/llvm.list; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends llvm-18; \
-    rm -rf /var/lib/apt/lists/*; \
-    LLVM_CONFIG_PATH="$(command -v llvm-config-18)"; \
-    if [ -z "$LLVM_CONFIG_PATH" ]; then echo "ERROR: llvm-config-18 not found after install"; exit 1; fi; \
-  fi; \
-  echo "[TileLang] Using LLVM_CONFIG at: $LLVM_CONFIG_PATH"; \
-  export PATH="$(dirname "$LLVM_CONFIG_PATH"):/usr/local/bin:${PATH}"; \
-  export LLVM_CONFIG="$LLVM_CONFIG_PATH"; \
-  \
-  # Optional shim for tools that expect llvm-config-16
-  mkdir -p /usr/local/bin && \
-  printf "#!/usr/bin/env bash\nexec \"%s\" \"\$@\"\n" "$LLVM_CONFIG_PATH" > /usr/local/bin/llvm-config-16 && \
-  chmod +x /usr/local/bin/llvm-config-16; \
-  \
-  # TVM Python bits need Cython + z3 before configure.
-  # Pin z3-solver==4.15.4.0: 4.15.4.0 has a manylinux wheel; 4.15.5.0 has no wheel and builds from source (fails: C++20 <format> needs GCC 14+, image has GCC 11).
-  "$VENV_PIP" install --no-cache-dir "cython>=0.29.36,<3.0" "apache-tvm-ffi @ git+https://github.com/apache/tvm-ffi.git@37d0485b2058885bf4e7a486f7d7b2174a8ac1ce" "z3-solver==4.15.4.0"; \
-  \
-  # Clone + pin TileLang (bundled TVM), then build
-  git clone --recursive "${TILELANG_REPO}" /opt/tilelang && \
-  cd /opt/tilelang && \
-  git fetch --depth=1 origin "${TILELANG_COMMIT}" || true && \
-  git checkout -f "${TILELANG_COMMIT}" && \
-  git submodule update --init --recursive && \
-  export CMAKE_ARGS="-DUSE_CUDA=OFF -DUSE_ROCM=ON -DROCM_PATH=/opt/rocm -DLLVM_CONFIG=${LLVM_CONFIG} -DSKBUILD_SABI_VERSION= ${CMAKE_ARGS:-}" && \
-  "$VENV_PIP" install -e . -v --no-build-isolation --no-deps; \
-  if [ -f pyproject.toml ]; then sed -i "/^[[:space:]]*\"torch/d" pyproject.toml || true; fi; \
-  "$VENV_PIP" cache purge || true; \
+  if [ ! -x "$VENV_PY" ]; then VENV_PY="python3"; fi; \
+  "$VENV_PIP" install --no-cache-dir \
+      "apache-tvm-ffi @ git+https://github.com/apache/tvm-ffi.git@37d0485b2058885bf4e7a486f7d7b2174a8ac1ce" \
+      "z3-solver==4.15.4.0" \
+  && "$VENV_PIP" install --no-cache-dir --no-deps --force-reinstall /tmp/tilelang-wheel/*.whl \
+  && rm -rf /tmp/tilelang-wheel; \
   "$VENV_PY" -c "import tilelang; print(tilelang.__version__)"'
 
 # -----------------------
-# Hadamard-transform (HIP build)
-RUN /bin/bash -lc 'set -euo pipefail; \
-    git clone --branch "${FHT_BRANCH}" "${FHT_REPO}" fast-hadamard-transform; \
-    cd fast-hadamard-transform; \
-    git checkout -f "${FHT_COMMIT}"; \
-    python setup.py install'
+# fast-hadamard-transform: install wheel built in builder stage.
+COPY --from=builder-fht /tmp/fht-wheel/ /tmp/fht-wheel/
+RUN pip install --no-cache-dir --force-reinstall /tmp/fht-wheel/*.whl \
+    && rm -rf /tmp/fht-wheel
 
 # -----------------------
 # Python tools
 RUN python3 -m pip install --no-cache-dir \
     py-spy \
-    pre-commit \
     tabulate
 
 # -----------------------
-# MORI (optional)
+# MORI (optional, editable; source kept for in-container development)
 RUN /bin/bash -lc 'set -euo pipefail; \
   if [ "${ENABLE_MORI}" != "1" ]; then \
     echo "[MORI] Skipping (ENABLE_MORI=${ENABLE_MORI})"; \
@@ -466,12 +579,12 @@ RUN /bin/bash -lc 'set -euo pipefail; \
        && cp /usr/local/lib/x86_64-linux-gnu/libbnxt_re* /usr/local/lib/. \
        ;; \
     *) \
-      echo "ERROR: unknown NIC_BACKEND=${NIC_BACKEND}. Use one of: none, ainic"; \
+      echo "ERROR: unknown NIC_BACKEND=${NIC_BACKEND}. Use one of: none, ainic, bnxt"; \
       exit 2; \
       ;; \
   esac; \
   \
-  # Build/install MORI
+  # Build/install MORI (editable)
   export MORI_GPU_ARCHS="${GPU_ARCH_LIST}"; \
   echo "[MORI] MORI_GPU_ARCHS=${MORI_GPU_ARCHS} NIC_BACKEND=${NIC_BACKEND}"; \
   rm -rf /sgl-workspace/mori; \
@@ -483,16 +596,19 @@ RUN /bin/bash -lc 'set -euo pipefail; \
   python3 -c "import os, torch; print(os.path.join(os.path.dirname(torch.__file__), \"lib\"))" > /etc/ld.so.conf.d/torch.conf; \
   ldconfig; \
   echo "export PYTHONPATH=/sgl-workspace/mori:\${PYTHONPATH}" >> /etc/bash.bashrc; \
+  find /sgl-workspace/mori -name "*.o" -delete 2>/dev/null || true; \
+  ( cd /sgl-workspace/mori && git reflog expire --expire=now --all && git gc --prune=now --quiet ) || true; \
   echo "[MORI] Done."'
 
 # -----------------------
 # Hot patch: torch-ROCm
 # The artifact hardcoded the supported triton version to be 3.5.1.
-# Rewrite the restriction directly.
+# Rewrite the restriction directly. The extract+install+cleanup all run in
+# a single RUN so the 3.3 GB extracted wheel tree never lingers as its own
+# layer (creating hack.py is a separate tiny RUN — heredoc + case in one
+# RUN does not parse reliably under /bin/sh).
 ARG TORCH_ROCM_FILE="torch-2.9.1+rocm7.2.0.lw.git7e1940d4-cp310-cp310-linux_x86_64.whl"
-RUN mkdir /tmp/whl && cd /tmp/whl \
-     && export TORCH_ROCM_FILE="${TORCH_ROCM_FILE}" \
-     && cat > hack.py <<"PY"
+RUN mkdir -p /tmp/whl && cat > /tmp/whl/hack.py <<"PY"
 import zipfile, csv, os, re
 from pathlib import Path
 
@@ -539,35 +655,34 @@ with zipfile.ZipFile(out_whl, "w", compression=zipfile.ZIP_DEFLATED) as z:
 print("Wrote", out_whl)
 PY
 
-RUN cd /tmp/whl \
-    && case "${GPU_ARCH}" in \
+RUN set -eux; \
+    case "${GPU_ARCH}" in \
       *rocm720*) \
         echo "ROCm 7.2 flavor detected from GPU_ARCH=${GPU_ARCH}"; \
-        python hack.py \
-        && python3 -m pip install --force --no-deps /tmp/${TORCH_ROCM_FILE} \
-        && rm -fr /tmp/whl /tmp/${TORCH_ROCM_FILE} \
+        cd /tmp/whl \
+        && export TORCH_ROCM_FILE="${TORCH_ROCM_FILE}" \
+        && python hack.py \
+        && python3 -m pip install --force --no-deps --no-cache-dir /tmp/${TORCH_ROCM_FILE} \
+        && rm -rf /tmp/whl /tmp/${TORCH_ROCM_FILE}; \
         ;; \
       *) \
         echo "Not rocm720 (GPU_ARCH=${GPU_ARCH}), skip patch"; \
+        rm -rf /tmp/whl; \
         ;; \
     esac
 
 
 # -----------------------
-# Hot patch: Triton
-# For ROCm 7.2, this custom build breaks pip dependency management,
-# so future `pip install` will break the ROCm stack.
-# A workaround for this is to reinstall the default triton
-# wheel with the `rocm/pytorch` image in the root directory.
-RUN if [ "$BUILD_TRITON" = "1" ]; then \
-        pip uninstall -y triton \
-     && apt install -y cmake \
-     && git clone ${TRITON_REPO} triton-custom \
-     && cd triton-custom \
-     && git checkout ${TRITON_COMMIT} \
-     && pip install -r python/requirements.txt \
-     && pip install -e .; \
-    fi
+# Triton (non-editable): install wheel built in builder stage.
+# For ROCm 7.2 this custom build replaces the stock triton wheel; if
+# BUILD_TRITON=0 the builder stage produced no wheel and this is a no-op.
+COPY --from=builder-triton /tmp/triton-wheel/ /tmp/triton-wheel/
+RUN set -eux; \
+    if ls /tmp/triton-wheel/*.whl 1>/dev/null 2>&1; then \
+        pip uninstall -y triton 2>/dev/null || true; \
+        pip install --no-cache-dir --force-reinstall /tmp/triton-wheel/*.whl; \
+    fi; \
+    rm -rf /tmp/triton-wheel
 
 # -----------------------
 # Performance environment variable.


### PR DESCRIPTION
# [AMD][Dockerfile] Multi-stage build for ROCm image to reduce size

## Motivation

The current ROCm images (`lmsysorg/sglang-rocm:v0.5.10.post1-rocm720-mi35x-*` /
`...-rocm700-mi35x-*`) are **~73 GB**. A large fraction of that is build-time
toolchains and intermediate artifacts that are not needed at runtime:

- **Rust toolchain + cargo target dir** for `sgl-model-gateway` (~5.8 GB)
- **Go toolchain + Mooncake build tree** (~6 GB)
- **TileLang build dir + LLVM dev packages** (~2.3 GB)
- **Triton custom build `.o` files** (~16 GB on rocm720)
- **fast-hadamard-transform build artifacts**
- AITER / SGLang `.o` files and unpacked git history
- **Stale CUDA torch + CUDA toolkit** (~5 GB) accidentally pulled in by the FHT
  wheel install (see _Bonus fix_ below)

This PR rewrites `docker/rocm.Dockerfile` as a BuildKit multi-stage build so
build-time toolchains live only in throwaway builder stages, while only the
wheels / install trees are `COPY`ed into the final image.

## Result

| Image | Size |
|---|---|
| Original (`v0.5.10.post1-rocm720-mi35x-20260430`) | **73.4 GB** |
| Slim, **gfx950-rocm720** + MORI (this PR) | **45.3 GB** |
| Slim, **gfx950 (rocm700)** + MORI (this PR) | **45.8 GB** |
| **Reduction** | **~28 GB / 38%** |

Verified end-to-end on both ROCm flavors:

| Flavor | Build | Server boot | gsm8k (200 q × 8-shot) |
|---|---|---|---|
| `gfx950-rocm720` (MORI=1) | OK | OK TP=8 | **95.0%** |
| `gfx950` / rocm700 (MORI=1) | OK | OK TP=8 | **95.5%** |

Output throughput (DeepSeek-R1 MXFP4, TP=8): ~830-970 tok/s, no regression.

## What changed

### Builder stages (parallel under BuildKit)

Each builder is `FROM ${GPU_ARCH}` so it inherits the same base image and
`BUILD_*` env vars from the per-arch stages, then produces only an installable
artifact:

| Stage | Output | Discards |
|---|---|---|
| `builder-gateway` | `/tmp/gateway-wheel/*.whl` | Rust toolchain (~1.3 GB), cargo target (~4.5 GB) |
| `builder-mooncake` | DESTDIR install tree at `/mooncake-install/` | Go toolchain, build tree (~6 GB) |
| `builder-fht` | `/tmp/fht-wheel/*.whl` | full FHT source + build dir |
| `builder-tilelang` | `/tmp/tilelang-wheel/*.whl` | LLVM dev packages, gtest sources, TVM build tree (~2.3 GB) |
| `builder-triton` | `/tmp/triton-wheel/*.whl` (only when `BUILD_TRITON=1`) | `.o` files (~16 GB) |

The `builder-mooncake` and `builder-triton` stages always create their staging
dirs (even when `BUILD_MOONCAKE=0` / `BUILD_TRITON=0`) so the unconditional
`COPY --from=...` in the final stage is a safe no-op.

### Final stage

- AITER, SGLang, and MORI remain **editable installs** (`pip install -e .`).
  Sources are kept under `/sgl-workspace/` for in-container development, but
  `.o` files are deleted and `.git` is `gc`'d after install.
- Triton, TileLang, FHT, sgl-model-gateway, and Mooncake become **non-editable**
  runtime installs from builder-stage wheels / DESTDIR.
- The `torch-ROCm` `Requires-Dist: triton==3.5.1` hot-patch (rocm720-only) is
  preserved; the heredoc-defined `hack.py` is split into its own tiny `RUN`
  and the extract+install+cleanup happen in one subsequent `RUN` so the
  3.3 GB unpacked wheel tree never lingers as its own layer.
- All previously-set runtime `ENV` vars (`SGLANG_USE_AITER`,
  `HIP_FORCE_DEV_KERNARG`, `NCCL_MIN_NCHANNELS`, `TORCHINDUCTOR_*`, etc.) are
  preserved unchanged.

### Bonus fix: FHT wheel `--no-deps`

While testing the rocm700 flavor, server start failed with
`RuntimeError: operator torchvision::nms does not exist`. Root cause:

- The FHT wheel declares `torch` as a runtime dep.
- Without `--no-deps`, pip resolves it to the latest PyPI **CUDA** torch
  (currently `torch-2.11.0+cu130`, plus a full `nvidia-cuda-toolkit-13` tree
  ~5 GB), silently overwriting the base image's ROCm torch.
- On rocm720 this was masked by the later `torch-ROCm` hot-patch that
  reinstalls the right torch with `--force-reinstall --no-deps`. On rocm700
  there is no such hot-patch, so the bad CUDA torch persisted and broke
  `from torchvision.io import decode_jpeg` at SGLang import time.

Fix: install the FHT wheel with `--no-deps`. This both unblocks rocm700 and
removes ~5 GB of unused CUDA toolkit from rocm720.

### Intentionally preserved features

These are kept on purpose (carried over from the previous slimming attempt
in #22037):

1. **`AITER_COMMIT` build-arg override** - users can pin AITER to any commit by
   passing `--build-arg AITER_COMMIT=<sha>`; otherwise the per-arch
   `AITER_COMMIT_DEFAULT` is used.
2. **Editable vs non-editable split** - AITER/SGLang/MORI are editable for
   developer iteration; Triton/TileLang/FHT/gateway/Mooncake are non-editable
   so their build trees can be discarded.
3. **`SETUPTOOLS_SCM_PRETEND_VERSION` scoping** - the env is `unset` before
   AITER and only re-exported inside the SGLang install `RUN`, so SGLang
   nightly version pinning does not leak into AITER/MORI/TileLang/FHT/gateway.
4. **AITER pre-built kernels (`PREBUILD_KERNELS=1`)** - kept enabled. This adds
   ~30 min to build time but avoids first-run JIT compile latency, which is a
   feature.
5. **Both ROCm 7.0 and ROCm 7.2 base flavors** - the per-arch stages
   (`gfx942`, `gfx942-rocm720`, `gfx950`, `gfx950-rocm720`) and conditional
   rocm720-only steps (`libdrm-amdgpu` install, `amdsmi` install, `torch-rocm`
   triton hot-patch, custom Triton build) are unchanged.
6. **`MI300X_VF` config copying** - unchanged.

### What is NOT changed

- Base images, AITER / Mooncake / TileLang / FHT / Triton / MORI commits.
- Build args, default values, or CLI invocations from the file header.
- Any runtime `ENV` setting.
- The `BUILD_TYPE=srt` vs `all` install path.

## Usage

Identical to before - no changes to `docker build` invocations:

```bash
# ROCm 7.2 / MI355X
docker build --build-arg SGL_BRANCH=v0.5.10.post1 \
             --build-arg GPU_ARCH=gfx950-rocm720 \
             --build-arg ENABLE_MORI=1 \
             -t v0.5.10.post1-rocm720-mi35x \
             -f docker/rocm.Dockerfile docker/

# ROCm 7.0 / MI355X
docker build --build-arg SGL_BRANCH=v0.5.10.post1 \
             --build-arg GPU_ARCH=gfx950 \
             --build-arg ENABLE_MORI=1 \
             -t v0.5.10.post1-rocm700-mi35x \
             -f docker/rocm.Dockerfile docker/
```

BuildKit is strongly recommended (`DOCKER_BUILDKIT=1`, default on modern
Docker) so the builder stages run in parallel and unused stages (e.g.
`builder-triton` when `BUILD_TRITON=0`) are skipped automatically.

## Testing

- Build: matrix flavors x `ENABLE_MORI={0,1}` on a gfx950 host. Both
  `gfx950-rocm720` and `gfx950` (rocm700) verified end-to-end with
  `ENABLE_MORI=1` against upstream `main` SGLang.
- Smoke: `python -c "import sglang, aiter, tilelang, triton, mooncake"` inside
  each image.
- Sanity: `import torch; print(torch.__version__)` confirms ROCm torch
  (`2.9.0a0+git7bcbafe` on rocm700, `2.9.1+rocm7.2.0` on rocm720) is preserved
  in both images.
- TP=8 server launch (DeepSeek-R1 MXFP4) using the team's standard run scripts.
- Accuracy: `gsm8k` 8-shot eval on 200 questions matches the pre-slim image
  (95.0% / 95.5%).








<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26336644410](https://github.com/sgl-project/sglang/actions/runs/26336644410)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26336644336](https://github.com/sgl-project/sglang/actions/runs/26336644336)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->