### PR TITLE
[MUSA][9/N] Add FA3 attention backend support through MATE (MUSA AI Tensor Engine)

### DIFF
--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -114,8 +114,11 @@ srt_musa = [
     "sglang[runtime_common]",
     "torch",
     "torch_musa",
-    "torchada>=0.1.45",
+    "torchada>=0.1.48",
     "mthreads-ml-py",
+    "mate",
+    "mate-deep_gemm",
+    "mate-flash-attention",
     "numpy<2.0",
 ]
 

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -575,6 +575,12 @@ class ModelConfig:
         self.num_key_value_heads = getattr(
             self.hf_text_config, "num_key_value_heads", None
         )
+        self.first_k_dense_replace = getattr(
+            self.hf_text_config, "first_k_dense_replace", None
+        )
+        self.full_attention_interval = getattr(
+            self.hf_text_config, "full_attention_interval", None
+        )
 
         # for Dbrx and MPT models
         if self.hf_config.model_type in ["dbrx", "mpt"]:

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -331,6 +331,9 @@ class Envs:
     SGLANG_USE_AG_AFTER_QLORA = EnvBool(False)
     SGLANG_NPU_FUSED_MOE_MODE = EnvInt(1)
 
+    # MTHREADS & MUSA
+    SGLANG_MUSA_FA3_FORCE_UPDATE_METADATA = EnvBool(False)
+
     # Quantization
     SGLANG_INT4_WEIGHT = EnvBool(False)
     SGLANG_CPU_QUANTIZATION = EnvBool(False)

--- a/python/sglang/srt/hardware_backend/musa/__init__.py
+++ b/python/sglang/srt/hardware_backend/musa/__init__.py
@@ -1,0 +1,1 @@
+# MUSA (Moore Threads GPU) hardware backend

--- a/python/sglang/srt/hardware_backend/musa/attention/__init__.py
+++ b/python/sglang/srt/hardware_backend/musa/attention/__init__.py
@@ -1,0 +1,3 @@
+from .flashattention_backend import MusaFlashAttentionBackend
+
+__all__ = ["MusaFlashAttentionBackend"]

--- a/python/sglang/srt/hardware_backend/musa/attention/flashattention_backend.py
+++ b/python/sglang/srt/hardware_backend/musa/attention/flashattention_backend.py
@@ -1,0 +1,913 @@
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING, Optional, Tuple, Union
+
+import torch
+from flash_attn import flash_attn_varlen_func
+from flash_attn import flash_attn_with_kvcache as mate_flash_attn_with_kvcache
+from flash_attn import get_scheduler_metadata
+
+from sglang.srt.distributed import get_pp_group, get_pp_indices
+from sglang.srt.environ import envs
+from sglang.srt.layers.attention.flashattention_backend import (
+    FlashAttentionBackend,
+    merge_state_v2_wrapper,
+)
+from sglang.srt.layers.radix_attention import AttentionType
+from sglang.srt.layers.utils.cp_utils import (
+    cp_allgather_and_save_kv_cache,
+    cp_attn_forward_extend,
+)
+from sglang.srt.server_args import get_global_server_args
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.radix_attention import RadixAttention
+    from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+    from sglang.srt.model_executor.model_runner import ModelRunner
+
+# Global workspace buffer for MLA
+_MATE_MLA_WORKSPACE_SIZE_BYTES = 128 * 1024 * 1024
+_MATE_MLA_WORKSPACE_BUFFER: torch.Tensor | None = None
+
+# Cache for non-MLA scheduler metadata by prefix
+_MATE_NO_MLA_SCHEDULER_METADATA_DICT: dict = {}
+_MATE_NO_MLA_SCHEDULER_METADATA_LOCK = threading.Lock()
+
+# Global reference to the current backend instance (set during __init__)
+_CURRENT_BACKEND: Optional["MusaFlashAttentionBackend"] = None
+
+
+def _compute_scheduler_metadata(
+    backend: "MusaFlashAttentionBackend",
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k_new: Optional[torch.Tensor],
+    cache_seqlens: torch.Tensor,
+    max_seqlen_q: int,
+    page_size: int,
+    causal: bool,
+    window_size: Tuple[int, int],
+    num_splits: int,
+) -> Tuple[torch.Tensor, bool] | torch.Tensor:
+    """Compute scheduler metadata based on backend's current state."""
+    global _MATE_MLA_WORKSPACE_BUFFER, _MATE_NO_MLA_SCHEDULER_METADATA_DICT
+
+    layer = backend._current_layer
+    current_layer_id = layer.layer_id
+    batch_size = cu_seqlens_q.shape[-1] - 1
+
+    # Determine if scheduler metadata should be updated
+    should_update = True
+    pp_group = get_pp_group()
+    pp_rank = pp_group.rank_in_group
+    start_layer_id, _ = get_pp_indices(
+        backend.num_hidden_layers, pp_group.rank_in_group, pp_group.world_size
+    )
+    if backend._current_can_run_tbo and pp_rank == 0:
+        start_layer_id += (
+            backend.first_k_dense_replace
+            if backend.first_k_dense_replace is not None
+            else 0
+        )
+
+    if backend.full_attention_interval is not None:
+        start_layer_id += backend.full_attention_interval - 1
+
+    if current_layer_id > start_layer_id:
+        should_update = False
+
+    if envs.SGLANG_MUSA_FA3_FORCE_UPDATE_METADATA.get():
+        should_update = True
+
+    if backend.use_mla:
+        if _MATE_MLA_WORKSPACE_BUFFER is None:
+            _MATE_MLA_WORKSPACE_BUFFER = torch.empty(
+                _MATE_MLA_WORKSPACE_SIZE_BYTES, device=backend.device, dtype=torch.uint8
+            )
+        return (_MATE_MLA_WORKSPACE_BUFFER, not should_update)
+    else:
+        with _MATE_NO_MLA_SCHEDULER_METADATA_LOCK:
+            if (
+                should_update
+                or backend._current_prefix not in _MATE_NO_MLA_SCHEDULER_METADATA_DICT
+            ):
+                _MATE_NO_MLA_SCHEDULER_METADATA_DICT[backend._current_prefix] = (
+                    get_scheduler_metadata(
+                        batch_size=batch_size,
+                        num_heads_q=layer.tp_q_head_num,
+                        num_heads_kv=layer.tp_k_head_num,
+                        headdim=layer.qk_head_dim,
+                        headdim_v=layer.v_head_dim,
+                        cache_seqlens=cache_seqlens,
+                        cu_seqlens_q=cu_seqlens_q,
+                        cu_seqlens_k_new=cu_seqlens_k_new,
+                        max_seqlen_q=max_seqlen_q,
+                        max_seqlen_k=backend._current_max_seqlen_k,
+                        page_size=page_size,
+                        causal=causal,
+                        window_size=window_size,
+                        num_splits=num_splits,
+                    )
+                )
+            return _MATE_NO_MLA_SCHEDULER_METADATA_DICT[backend._current_prefix]
+
+
+def flash_attn_with_kvcache(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    k: Optional[torch.Tensor] = None,
+    v: Optional[torch.Tensor] = None,
+    qv: Optional[torch.Tensor] = None,
+    rotary_cos: Optional[torch.Tensor] = None,
+    rotary_sin: Optional[torch.Tensor] = None,
+    cache_seqlens: Optional[Union[int, torch.Tensor]] = None,
+    cache_batch_idx: Optional[torch.Tensor] = None,
+    cache_leftpad: Optional[torch.Tensor] = None,
+    page_table: Optional[torch.Tensor] = None,
+    cu_seqlens_q: Optional[torch.Tensor] = None,
+    cu_seqlens_k_new: Optional[torch.Tensor] = None,
+    max_seqlen_q: Optional[int] = None,
+    rotary_seqlens: Optional[torch.Tensor] = None,
+    q_descale: Optional[torch.Tensor] = None,
+    k_descale: Optional[torch.Tensor] = None,
+    v_descale: Optional[torch.Tensor] = None,
+    softmax_scale: Optional[float] = None,
+    causal: bool = False,
+    window_size: Tuple[int, int] = (-1, -1),
+    attention_chunk: int = 0,
+    softcap: float = 0.0,
+    rotary_interleaved: bool = True,
+    scheduler_metadata: Optional[torch.Tensor] = None,
+    num_splits: int = 0,
+    pack_gqa=None,
+    sm_margin: int = 0,
+    return_softmax_lse: bool = False,
+    ver: int = 3,
+    **kwargs,
+):
+    """MUSA flash_attn_with_kvcache wrapper that auto-injects scheduler_metadata."""
+    if scheduler_metadata is None and _CURRENT_BACKEND is not None:
+        backend = _CURRENT_BACKEND
+        # Ensure backend has been properly set up for this call
+        if backend._current_layer is not None:
+            page_size = k_cache.shape[1] if k_cache is not None else 1
+            scheduler_metadata = _compute_scheduler_metadata(
+                backend=backend,
+                cu_seqlens_q=cu_seqlens_q,
+                cu_seqlens_k_new=cu_seqlens_k_new,
+                cache_seqlens=cache_seqlens,
+                max_seqlen_q=max_seqlen_q,
+                page_size=page_size,
+                causal=causal,
+                window_size=window_size,
+                num_splits=num_splits,
+            )
+
+    return mate_flash_attn_with_kvcache(
+        q=q,
+        k_cache=k_cache,
+        v_cache=v_cache,
+        k=k,
+        v=v,
+        qv=qv,
+        rotary_cos=rotary_cos,
+        rotary_sin=rotary_sin,
+        cache_seqlens=cache_seqlens,
+        cache_batch_idx=cache_batch_idx,
+        cache_leftpad=cache_leftpad,
+        page_table=page_table,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k_new=cu_seqlens_k_new,
+        max_seqlen_q=max_seqlen_q,
+        rotary_seqlens=rotary_seqlens,
+        q_descale=q_descale,
+        k_descale=k_descale,
+        v_descale=v_descale,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        window_size=window_size,
+        attention_chunk=attention_chunk,
+        softcap=softcap,
+        rotary_interleaved=rotary_interleaved,
+        scheduler_metadata=scheduler_metadata,
+        num_splits=num_splits,
+        pack_gqa=pack_gqa,
+        sm_margin=sm_margin,
+        return_softmax_lse=return_softmax_lse,
+    )
+
+
+class MusaFlashAttentionBackend(FlashAttentionBackend):
+    def __init__(self, model_runner: ModelRunner, **kwargs):
+        super().__init__(model_runner, **kwargs)
+        self.num_hidden_layers = model_runner.model_config.num_hidden_layers
+        self.first_k_dense_replace = model_runner.model_config.first_k_dense_replace
+        self.full_attention_interval = model_runner.model_config.full_attention_interval
+
+        # State for current attention call (simplified from thread‑local context)
+        self._current_layer: Optional[RadixAttention] = None
+        self._current_prefix: str = ""
+        self._current_max_seqlen_k: int = 0
+        self._current_can_run_tbo: bool = False
+
+        # Register this backend as the global current instance for the wrapper
+        global _CURRENT_BACKEND
+        _CURRENT_BACKEND = self
+
+    def _set_current_state(
+        self, layer: RadixAttention, prefix: str, max_seqlen_k: int, can_run_tbo: bool
+    ):
+        """Set the dynamic state for the upcoming flash attention call."""
+        self._current_layer = layer
+        self._current_prefix = prefix
+        self._current_max_seqlen_k = max_seqlen_k
+        self._current_can_run_tbo = can_run_tbo
+
+    def init_forward_metadata(self, forward_batch: ForwardBatch):
+        super().init_forward_metadata(forward_batch)
+        metadata = self.forward_metadata
+        if not hasattr(metadata, "extend_with_prefix"):
+            metadata.extend_with_prefix = False
+
+        if forward_batch.forward_mode.is_extend_or_draft_extend_or_mixed(
+            include_draft_extend_v2=True
+        ):
+            metadata.extend_with_prefix = any(forward_batch.extend_prefix_lens_cpu)
+
+    def forward_extend(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        save_kv_cache=True,
+        q_rope: Optional[torch.Tensor] = None,
+        k_rope: Optional[torch.Tensor] = None,
+        sinks: Optional[torch.Tensor] = None,
+    ):
+        if k is not None:
+            assert v is not None
+
+            is_cp_mode = (
+                forward_batch.forward_mode.is_context_parallel_extend()
+                and forward_batch.attn_cp_metadata is not None
+                and self.attn_cp_size > 1
+            )
+
+            if save_kv_cache and not is_cp_mode:
+                cache_loc = (
+                    forward_batch.out_cache_loc
+                    if not layer.is_cross_attention
+                    else forward_batch.encoder_out_cache_loc
+                )
+                if not self.use_mla:
+                    forward_batch.token_to_kv_pool.set_kv_buffer(
+                        layer, cache_loc, k, v, layer.k_scale, layer.v_scale
+                    )
+                else:
+                    forward_batch.token_to_kv_pool.set_mla_kv_buffer(
+                        layer,
+                        cache_loc,
+                        k,
+                        k_rope,
+                    )
+            if is_cp_mode:
+                cp_allgather_and_save_kv_cache(
+                    forward_batch, layer, k, v, self.attn_cp_size
+                )
+
+        metadata = self.forward_metadata
+
+        is_swa_layer = (
+            layer.sliding_window_size is not None and layer.sliding_window_size > -1
+        )
+        window_size = (layer.sliding_window_size, 0) if is_swa_layer else (-1, -1)
+        k_descale, v_descale = None, None
+        if (
+            self.kv_cache_dtype_str != "auto"
+            and layer.head_dim <= 256
+            and self.fa_impl_ver != 4
+        ):
+            if layer.k_scale is not None:
+                descale_shape = (forward_batch.batch_size, layer.tp_k_head_num)
+                k_descale = layer.k_scale.expand(descale_shape)
+                v_descale = layer.v_scale.expand(descale_shape)
+            q = q.to(self.kv_cache_dtype)
+            q_rope = q_rope.to(self.kv_cache_dtype) if q_rope is not None else None
+            k_rope = k_rope.to(self.kv_cache_dtype) if k_rope is not None else None
+        causal = True
+        if layer.is_cross_attention or layer.attn_type == AttentionType.ENCODER_ONLY:
+            causal = False
+
+        use_local_attn = (
+            self.has_local_attention
+            and self.attention_chunk_size is not None
+            and metadata.local_attn_metadata is not None
+            and (hasattr(layer, "use_irope") and layer.use_irope)
+        )
+
+        use_cascade_attn = (
+            forward_batch.forward_mode.is_target_verify()
+            and self.topk > 1
+            and not is_swa_layer
+        )
+
+        kwargs = {}
+        if sinks is not None:
+            kwargs["sinks"] = sinks
+
+        if use_local_attn:
+            local_metadata = metadata.local_attn_metadata
+            page_table = local_metadata.local_block_table
+            cu_seqlens_q = local_metadata.local_query_start_loc
+            cache_seqlens = local_metadata.local_seqused_k
+            max_seqlen_q = local_metadata.local_max_query_len
+            max_seqlen_k = local_metadata.local_max_seq_len
+        elif is_swa_layer and metadata.swa_spec_metadata is not None:
+            swa_spec_metadata = metadata.swa_spec_metadata
+            page_table = swa_spec_metadata.page_table
+            cu_seqlens_q = swa_spec_metadata.cu_seqlens_q
+            cache_seqlens = swa_spec_metadata.cache_seqlens_int32
+            max_seqlen_q = swa_spec_metadata.max_seq_len_q
+            cu_seqlens_k = swa_spec_metadata.cu_seqlens_k
+            max_seqlen_k = swa_spec_metadata.max_seq_len_k
+        else:
+            page_table = metadata.page_table
+            if is_swa_layer and self.use_sliding_window_kv_pool:
+                if metadata.swa_page_table is not None:
+                    page_table = metadata.swa_page_table
+                else:
+                    page_table = self.token_to_kv_pool.translate_loc_from_full_to_swa(
+                        metadata.page_table
+                    )
+            cu_seqlens_q = metadata.cu_seqlens_q
+            cache_seqlens = metadata.cache_seqlens_int32
+            max_seqlen_q = metadata.max_seq_len_q
+            cu_seqlens_k = metadata.cu_seqlens_k
+            max_seqlen_k = metadata.max_seq_len_k
+
+        # Set current state for the flash attention call
+        self._set_current_state(
+            layer=layer,
+            prefix="forward_extend",
+            max_seqlen_k=max_seqlen_k,
+            can_run_tbo=forward_batch.can_run_tbo,
+        )
+        if not self.use_mla:
+            key_cache, value_cache = forward_batch.token_to_kv_pool.get_kv_buffer(
+                layer.layer_id
+            )
+
+            key_cache = key_cache.view(
+                -1, self.page_size, layer.tp_k_head_num, layer.head_dim
+            )
+            value_cache = value_cache.view(
+                -1, self.page_size, layer.tp_v_head_num, layer.v_head_dim
+            )
+            if layer.is_cross_attention:
+                page_table = metadata.encoder_page_table
+                cache_seqlens = metadata.encoder_lens_int32
+                cu_seqlens_k = metadata.encoder_cu_seqlens_k
+                window_size = (-1, -1)
+
+            if (
+                forward_batch.forward_mode.is_context_parallel_extend()
+                and forward_batch.attn_cp_metadata is not None
+                and self.attn_cp_size > 1
+            ):
+
+                def _fa_cp_attn(
+                    q_chunk, cu_seqlens_q_cp, cache_seqlens_cp, max_seqlen_q_cp
+                ):
+                    return flash_attn_with_kvcache(
+                        q=q_chunk,
+                        k_cache=key_cache,
+                        v_cache=value_cache,
+                        page_table=page_table,
+                        cache_seqlens=cache_seqlens_cp,
+                        cu_seqlens_q=cu_seqlens_q_cp,
+                        cu_seqlens_k_new=(cu_seqlens_k if not use_local_attn else None),
+                        max_seqlen_q=max_seqlen_q_cp,
+                        softmax_scale=layer.scaling,
+                        causal=False if use_cascade_attn else causal,
+                        window_size=window_size,
+                        softcap=layer.logit_cap,
+                        k_descale=k_descale,
+                        v_descale=v_descale,
+                        return_softmax_lse=use_cascade_attn,
+                        num_splits=self.num_splits,
+                        **kwargs,
+                    )
+
+                result = cp_attn_forward_extend(
+                    forward_batch,
+                    q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim),
+                    self.device,
+                    _fa_cp_attn,
+                )
+            elif (
+                metadata.extend_with_prefix
+                or forward_batch.forward_mode.is_target_verify()
+                or forward_batch.forward_mode.is_draft_extend()
+            ):
+                result = flash_attn_with_kvcache(
+                    q=q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim),
+                    k_cache=key_cache,
+                    v_cache=value_cache,
+                    page_table=page_table,
+                    cache_seqlens=cache_seqlens,
+                    cu_seqlens_q=cu_seqlens_q,
+                    cu_seqlens_k_new=cu_seqlens_k if not use_local_attn else None,
+                    max_seqlen_q=max_seqlen_q,
+                    softmax_scale=layer.scaling,
+                    causal=False if use_cascade_attn else causal,
+                    window_size=window_size,
+                    softcap=layer.logit_cap,
+                    k_descale=k_descale,
+                    v_descale=v_descale,
+                    return_softmax_lse=use_cascade_attn,
+                    num_splits=self.num_splits,
+                    **kwargs,
+                )
+
+                if use_cascade_attn:
+                    # Update state for the second call
+                    self._current_prefix = "forward_extend_use_cascade_attn"
+                    self._current_max_seqlen_k = (
+                        self.forward_metadata_spec_decode_expand.max_seq_len_k
+                    )
+
+                    o, softmax_lse, *rest = result
+                    o_expand, softmax_lse_expand, *rest_expand = (
+                        flash_attn_with_kvcache(
+                            q=q.contiguous().view(
+                                -1, layer.tp_q_head_num, layer.head_dim
+                            ),
+                            k_cache=key_cache.view(
+                                -1, 1, layer.tp_k_head_num, layer.head_dim
+                            ),
+                            v_cache=value_cache.view(
+                                -1, 1, layer.tp_v_head_num, layer.head_dim
+                            ),
+                            page_table=self.forward_metadata_spec_decode_expand.page_table,
+                            cache_seqlens=self.forward_metadata_spec_decode_expand.cache_seqlens_int32,
+                            cu_seqlens_q=self.forward_metadata_spec_decode_expand.cu_seqlens_q,
+                            cu_seqlens_k_new=self.forward_metadata_spec_decode_expand.cu_seqlens_k,
+                            max_seqlen_q=self.forward_metadata_spec_decode_expand.max_seq_len_q,
+                            softmax_scale=layer.scaling,
+                            causal=False,
+                            window_size=window_size,
+                            softcap=layer.logit_cap,
+                            k_descale=k_descale,
+                            v_descale=v_descale,
+                            return_softmax_lse=True,
+                            num_splits=self.num_splits,
+                            **kwargs,
+                        )
+                    )
+                    o, _ = merge_state_v2_wrapper(
+                        o,
+                        softmax_lse.T.contiguous(),
+                        o_expand,
+                        softmax_lse_expand.T.contiguous(),
+                    )
+                else:
+                    o = result
+            else:
+                output = flash_attn_varlen_func(
+                    q=q.view(-1, layer.tp_q_head_num, layer.head_dim),
+                    k=k.view(-1, layer.tp_k_head_num, layer.head_dim).to(q.dtype),
+                    v=v.view(-1, layer.tp_k_head_num, layer.v_head_dim).to(q.dtype),
+                    cu_seqlens_q=metadata.cu_seqlens_q,
+                    cu_seqlens_k=metadata.cu_seqlens_q,
+                    max_seqlen_q=metadata.max_seq_len_q,
+                    max_seqlen_k=metadata.max_seq_len_q,
+                    softmax_scale=layer.scaling,
+                    causal=True,
+                    return_softmax_lse=forward_batch.mha_return_lse,
+                )
+                if forward_batch.mha_return_lse:
+                    output, lse, *rest = output
+                    lse = torch.transpose(lse, 0, 1).contiguous()
+                    return (
+                        output.view(-1, layer.tp_q_head_num * layer.v_head_dim),
+                        lse,
+                    )
+                return output.view(-1, layer.tp_q_head_num * layer.v_head_dim)
+        else:
+            if (
+                forward_batch.attn_attend_prefix_cache is not None
+                and not forward_batch.forward_mode.is_target_verify()
+                and not forward_batch.forward_mode.is_draft_extend(include_v2=True)
+            ):
+                if forward_batch.attn_attend_prefix_cache:
+                    assert not get_global_server_args().disable_chunked_prefix_cache
+                    assert forward_batch.prefix_chunk_idx is not None
+                    assert forward_batch.prefix_chunk_cu_seq_lens is not None
+                    assert forward_batch.prefix_chunk_max_seq_lens is not None
+
+                    chunk_idx = forward_batch.prefix_chunk_idx
+                    assert chunk_idx >= 0
+
+                    assert forward_batch.mha_return_lse
+                    output = flash_attn_varlen_func(
+                        q=q.view(-1, layer.tp_q_head_num, layer.head_dim),
+                        k=k.view(-1, layer.tp_k_head_num, layer.head_dim).to(q.dtype),
+                        v=v.view(-1, layer.tp_k_head_num, layer.v_head_dim).to(q.dtype),
+                        cu_seqlens_q=metadata.cu_seqlens_q,
+                        cu_seqlens_k=forward_batch.prefix_chunk_cu_seq_lens[chunk_idx],
+                        max_seqlen_q=metadata.max_seq_len_q,
+                        max_seqlen_k=forward_batch.prefix_chunk_max_seq_lens[chunk_idx],
+                        softmax_scale=layer.scaling,
+                        causal=False,
+                        return_softmax_lse=True,
+                        **kwargs,
+                    )
+                else:
+                    cu_seqlens_k = (
+                        metadata.cu_seqlens_q
+                        if not forward_batch.mha_one_shot
+                        else metadata.cu_seqlens_k
+                    )
+                    max_seqlen_k = (
+                        metadata.max_seq_len_q
+                        if not forward_batch.mha_one_shot
+                        else metadata.max_seq_len_k
+                    )
+                    output = flash_attn_varlen_func(
+                        q=q.view(-1, layer.tp_q_head_num, layer.head_dim),
+                        k=k.view(-1, layer.tp_k_head_num, layer.head_dim).to(q.dtype),
+                        v=v.view(-1, layer.tp_k_head_num, layer.v_head_dim).to(q.dtype),
+                        cu_seqlens_q=metadata.cu_seqlens_q,
+                        cu_seqlens_k=cu_seqlens_k,
+                        max_seqlen_q=metadata.max_seq_len_q,
+                        max_seqlen_k=max_seqlen_k,
+                        softmax_scale=layer.scaling,
+                        causal=True,
+                        return_softmax_lse=forward_batch.mha_return_lse,
+                        **kwargs,
+                    )
+                if forward_batch.mha_return_lse:
+                    output, lse, *rest = output
+                    lse = torch.transpose(lse, 0, 1).contiguous()
+                    return output, lse
+                return output
+            else:
+                kv_cache = forward_batch.token_to_kv_pool.get_key_buffer(
+                    layer.layer_id
+                ).to(q.dtype)
+                k_rope = kv_cache[:, :, layer.v_head_dim :]
+                c_kv = kv_cache[:, :, : layer.v_head_dim]
+                k_rope_cache = k_rope.view(
+                    -1,
+                    self.page_size,
+                    layer.tp_k_head_num,
+                    layer.head_dim - layer.v_head_dim,
+                )
+                c_kv_cache = c_kv.view(
+                    -1, self.page_size, layer.tp_v_head_num, layer.v_head_dim
+                )
+                if q_rope is not None:
+                    q_nope = q.view(-1, layer.tp_q_head_num, layer.v_head_dim)
+                    q_rope = q_rope.view(
+                        -1, layer.tp_q_head_num, layer.head_dim - layer.v_head_dim
+                    )
+                else:
+                    q_all = q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim)
+                    q_nope = q_all[:, :, : layer.v_head_dim]
+                    q_rope = q_all[:, :, layer.v_head_dim :]
+
+                result = flash_attn_with_kvcache(
+                    q=q_rope,
+                    k_cache=k_rope_cache,
+                    v_cache=c_kv_cache,
+                    qv=q_nope,
+                    page_table=page_table,
+                    cache_seqlens=cache_seqlens,
+                    cu_seqlens_q=cu_seqlens_q,
+                    cu_seqlens_k_new=cu_seqlens_k if not use_local_attn else None,
+                    max_seqlen_q=max_seqlen_q,
+                    softmax_scale=layer.scaling,
+                    causal=False if use_cascade_attn else causal,
+                    softcap=layer.logit_cap,
+                    k_descale=k_descale,
+                    v_descale=v_descale,
+                    return_softmax_lse=use_cascade_attn,
+                    num_splits=self.num_splits,
+                )
+                if use_cascade_attn:
+                    self._current_prefix = "forward_extend_use_cascade_attn"
+                    self._current_max_seqlen_k = (
+                        self.forward_metadata_spec_decode_expand.max_seq_len_k
+                    )
+
+                    o, softmax_lse, *rest = result
+                    o_expand, softmax_lse_expand, *rest_expand = (
+                        flash_attn_with_kvcache(
+                            q=q_rope,
+                            k_cache=k_rope_cache,
+                            v_cache=c_kv_cache,
+                            qv=q_nope,
+                            page_table=self.forward_metadata_spec_decode_expand.page_table,
+                            cache_seqlens=self.forward_metadata_spec_decode_expand.cache_seqlens_int32,
+                            cu_seqlens_q=self.forward_metadata_spec_decode_expand.cu_seqlens_q,
+                            cu_seqlens_k_new=self.forward_metadata_spec_decode_expand.cu_seqlens_k,
+                            max_seqlen_q=self.forward_metadata_spec_decode_expand.max_seq_len_q,
+                            softmax_scale=layer.scaling,
+                            causal=False,
+                            window_size=window_size,
+                            softcap=layer.logit_cap,
+                            k_descale=k_descale,
+                            v_descale=v_descale,
+                            return_softmax_lse=True,
+                            num_splits=self.num_splits,
+                        )
+                    )
+                    o, _ = merge_state_v2_wrapper(
+                        o,
+                        softmax_lse.T.contiguous(),
+                        o_expand,
+                        softmax_lse_expand.T.contiguous(),
+                    )
+                else:
+                    o = result
+
+        return o.view(-1, layer.tp_q_head_num * layer.v_head_dim)
+
+    def forward_decode(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        save_kv_cache=True,
+        q_rope: Optional[torch.Tensor] = None,
+        k_rope: Optional[torch.Tensor] = None,
+        sinks: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if k is not None:
+            assert v is not None
+            if save_kv_cache:
+                cache_loc = (
+                    forward_batch.out_cache_loc
+                    if not layer.is_cross_attention
+                    else forward_batch.encoder_out_cache_loc
+                )
+                if not self.use_mla:
+                    forward_batch.token_to_kv_pool.set_kv_buffer(
+                        layer, cache_loc, k, v, layer.k_scale, layer.v_scale
+                    )
+                else:
+                    forward_batch.token_to_kv_pool.set_mla_kv_buffer(
+                        layer,
+                        cache_loc,
+                        k,
+                        k_rope,
+                    )
+
+        metadata = self.forward_metadata
+        local_attn_metadata = getattr(metadata, "local_attn_metadata", None)
+        use_local_attn = (
+            self.has_local_attention
+            and self.attention_chunk_size is not None
+            and local_attn_metadata is not None
+            and (hasattr(layer, "use_irope") and layer.use_irope)
+        )
+
+        use_cascade_attn = forward_batch.spec_info is not None and self.topk > 1
+
+        is_swa_layer = (
+            layer.sliding_window_size is not None and layer.sliding_window_size > -1
+        )
+        window_size = (layer.sliding_window_size, 0) if is_swa_layer else (-1, -1)
+
+        causal = True
+        if layer.is_cross_attention or layer.attn_type == AttentionType.ENCODER_ONLY:
+            causal = False
+
+        kwargs = {}
+        if sinks is not None:
+            kwargs["sinks"] = sinks
+
+        k_descale, v_descale = None, None
+        if self.kv_cache_dtype_str != "auto" and layer.head_dim <= 256:
+            if layer.k_scale is not None:
+                descale_shape = (forward_batch.batch_size, layer.tp_k_head_num)
+                k_descale = layer.k_scale.expand(descale_shape)
+                v_descale = layer.v_scale.expand(descale_shape)
+            q = q.to(self.kv_cache_dtype)
+            q_rope = q_rope.to(self.kv_cache_dtype) if q_rope is not None else None
+            k_rope = k_rope.to(self.kv_cache_dtype) if k_rope is not None else None
+
+        # Set current state for the flash attention call
+        self._set_current_state(
+            layer=layer,
+            prefix="forward_decode",
+            max_seqlen_k=metadata.max_seq_len_k,
+            can_run_tbo=forward_batch.can_run_tbo,
+        )
+        if not self.use_mla:
+            key_cache, value_cache = forward_batch.token_to_kv_pool.get_kv_buffer(
+                layer.layer_id
+            )
+            key_cache = key_cache.view(
+                -1, self.page_size, layer.tp_k_head_num, layer.head_dim
+            )
+            value_cache = value_cache.view(
+                -1, self.page_size, layer.tp_v_head_num, layer.v_head_dim
+            )
+
+            if layer.is_cross_attention:
+                o = flash_attn_with_kvcache(
+                    q=q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim),
+                    k_cache=key_cache,
+                    v_cache=value_cache,
+                    page_table=metadata.encoder_page_table,
+                    cache_seqlens=metadata.encoder_lens_int32,
+                    cu_seqlens_q=metadata.cu_seqlens_q,
+                    cu_seqlens_k_new=metadata.encoder_cu_seqlens_k,
+                    max_seqlen_q=1,
+                    softmax_scale=layer.scaling,
+                    causal=False,
+                    window_size=(-1, -1),
+                    softcap=layer.logit_cap,
+                    k_descale=k_descale,
+                    v_descale=v_descale,
+                    num_splits=self.num_splits,
+                    **kwargs,
+                )
+            elif use_local_attn:
+                o = flash_attn_with_kvcache(
+                    q=q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim),
+                    k_cache=key_cache,
+                    v_cache=value_cache,
+                    page_table=local_attn_metadata.local_block_table,
+                    cache_seqlens=local_attn_metadata.local_seqused_k,
+                    cu_seqlens_q=local_attn_metadata.local_query_start_loc,
+                    cu_seqlens_k_new=None,
+                    max_seqlen_q=local_attn_metadata.local_max_query_len,
+                    softmax_scale=layer.scaling,
+                    causal=True,
+                    window_size=(-1, -1),
+                    softcap=layer.logit_cap,
+                    k_descale=k_descale,
+                    v_descale=v_descale,
+                    num_splits=self.num_splits,
+                    **kwargs,
+                )
+            else:
+                page_table = metadata.page_table
+                if is_swa_layer and self.use_sliding_window_kv_pool:
+                    if metadata.swa_page_table is not None:
+                        page_table = metadata.swa_page_table
+                    else:
+                        page_table = (
+                            self.token_to_kv_pool.translate_loc_from_full_to_swa(
+                                metadata.page_table
+                            )
+                        )
+                cache_seqlens = metadata.cache_seqlens_int32
+                cu_seqlens_k = metadata.cu_seqlens_k
+                max_seqlen_q = metadata.max_seq_len_q
+                q_reshaped = q.contiguous().view(
+                    -1, layer.tp_q_head_num, layer.head_dim
+                )
+
+                result = flash_attn_with_kvcache(
+                    q=q_reshaped,
+                    k_cache=key_cache,
+                    v_cache=value_cache,
+                    page_table=page_table,
+                    cache_seqlens=cache_seqlens,
+                    cu_seqlens_q=metadata.cu_seqlens_q,
+                    max_seqlen_q=max_seqlen_q,
+                    softmax_scale=layer.scaling,
+                    causal=False if use_cascade_attn else causal,
+                    window_size=window_size,
+                    softcap=layer.logit_cap,
+                    k_descale=k_descale,
+                    v_descale=v_descale,
+                    return_softmax_lse=use_cascade_attn,
+                    num_splits=self.num_splits,
+                    **kwargs,
+                )
+                if use_cascade_attn:
+                    self._current_prefix = "forward_decode_use_cascade_attn"
+                    self._current_max_seqlen_k = (
+                        self.forward_metadata_spec_decode_expand.max_seq_len_k
+                    )
+
+                    o, softmax_lse, *rest = result
+                    o_expand, softmax_lse_expand, *rest_expand = (
+                        flash_attn_with_kvcache(
+                            q=q_reshaped,
+                            k_cache=key_cache,
+                            v_cache=value_cache,
+                            page_table=self.forward_metadata_spec_decode_expand.page_table,
+                            cache_seqlens=self.forward_metadata_spec_decode_expand.cache_seqlens_int32,
+                            cu_seqlens_q=self.forward_metadata_spec_decode_expand.cu_seqlens_q,
+                            cu_seqlens_k_new=self.forward_metadata_spec_decode_expand.cu_seqlens_k,
+                            max_seqlen_q=self.forward_metadata_spec_decode_expand.max_seq_len_q,
+                            softmax_scale=layer.scaling,
+                            causal=False,
+                            window_size=window_size,
+                            softcap=layer.logit_cap,
+                            k_descale=k_descale,
+                            v_descale=v_descale,
+                            return_softmax_lse=True,
+                            num_splits=self.num_splits,
+                            **kwargs,
+                        )
+                    )
+                    o, _ = merge_state_v2_wrapper(
+                        o,
+                        softmax_lse.T.contiguous(),
+                        o_expand,
+                        softmax_lse_expand.T.contiguous(),
+                    )
+                else:
+                    o = result
+        else:
+            kv_cache = forward_batch.token_to_kv_pool.get_key_buffer(layer.layer_id).to(
+                q.dtype
+            )
+            k_rope = kv_cache[:, :, layer.v_head_dim :]
+            c_kv = kv_cache[:, :, : layer.v_head_dim]
+            k_rope_cache = k_rope.view(
+                -1,
+                self.page_size,
+                layer.tp_k_head_num,
+                layer.head_dim - layer.v_head_dim,
+            )
+            c_kv_cache = c_kv.view(
+                -1, self.page_size, layer.tp_v_head_num, layer.v_head_dim
+            )
+
+            if q_rope is not None:
+                q_nope = q.view(-1, layer.tp_q_head_num, layer.v_head_dim)
+                q_rope = q_rope.view(
+                    -1, layer.tp_q_head_num, layer.head_dim - layer.v_head_dim
+                )
+            else:
+                q_all = q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim)
+                q_nope = q_all[:, :, : layer.v_head_dim]
+                q_rope = q_all[:, :, layer.v_head_dim :]
+            max_seqlen_q = metadata.max_seq_len_q
+
+            result = flash_attn_with_kvcache(
+                q=q_rope,
+                k_cache=k_rope_cache,
+                v_cache=c_kv_cache,
+                qv=q_nope,
+                page_table=metadata.page_table,
+                cache_seqlens=metadata.cache_seqlens_int32,
+                cu_seqlens_q=metadata.cu_seqlens_q,
+                cu_seqlens_k_new=metadata.cu_seqlens_k,
+                max_seqlen_q=max_seqlen_q,
+                softmax_scale=layer.scaling,
+                causal=False if use_cascade_attn else causal,
+                softcap=layer.logit_cap,
+                k_descale=k_descale,
+                v_descale=v_descale,
+                return_softmax_lse=use_cascade_attn,
+                num_splits=self.num_splits,
+            )
+            if use_cascade_attn:
+                self._current_prefix = "forward_decode_use_cascade_attn"
+                self._current_max_seqlen_k = (
+                    self.forward_metadata_spec_decode_expand.max_seq_len_k
+                )
+
+                o, softmax_lse, *rest = result
+                o_expand, softmax_lse_expand, *rest_expand = flash_attn_with_kvcache(
+                    q=q_rope,
+                    k_cache=k_rope_cache,
+                    v_cache=c_kv_cache,
+                    qv=q_nope,
+                    page_table=self.forward_metadata_spec_decode_expand.page_table,
+                    cache_seqlens=self.forward_metadata_spec_decode_expand.cache_seqlens_int32,
+                    cu_seqlens_q=self.forward_metadata_spec_decode_expand.cu_seqlens_q,
+                    cu_seqlens_k_new=self.forward_metadata_spec_decode_expand.cu_seqlens_k,
+                    max_seqlen_q=self.forward_metadata_spec_decode_expand.max_seq_len_q,
+                    softmax_scale=layer.scaling,
+                    causal=False,
+                    window_size=window_size,
+                    softcap=layer.logit_cap,
+                    k_descale=k_descale,
+                    v_descale=v_descale,
+                    return_softmax_lse=True,
+                    num_splits=self.num_splits,
+                )
+                o, _ = merge_state_v2_wrapper(
+                    o,
+                    softmax_lse.T.contiguous(),
+                    o_expand,
+                    softmax_lse_expand.T.contiguous(),
+                )
+            else:
+                o = result
+
+        return o.view(-1, layer.tp_q_head_num * layer.v_head_dim)

--- a/python/sglang/srt/layers/attention/attention_registry.py
+++ b/python/sglang/srt/layers/attention/attention_registry.py
@@ -5,6 +5,9 @@ from sglang.srt.configs.linear_attn_model_registry import (
     get_linear_attn_config,
     import_backend_class,
 )
+from sglang.srt.utils import get_device_capability, is_musa
+
+_is_musa = is_musa()
 
 logger = logging.getLogger(__name__)
 
@@ -130,17 +133,28 @@ def create_flashmla_backend(runner):
 
 @register_attention_backend("fa3")
 def create_flashattention_v3_backend(runner):
-    import torch
 
-    assert (
-        torch.cuda.get_device_capability()[0] == 8 and not runner.use_mla_backend
-    ) or torch.cuda.get_device_capability()[0] == 9, (
-        "FlashAttention v3 Backend requires SM>=80 and SM<=90. "
-        "Please use `--attention-backend flashinfer`."
-    )
-    from sglang.srt.layers.attention.flashattention_backend import FlashAttentionBackend
+    major, minor = get_device_capability()
+    if not _is_musa:
+        assert (major == 8 and not runner.use_mla_backend) or major == 9, (
+            "FlashAttention v3 Backend requires SM>=80 and SM<=90. "
+            "Please use `--attention-backend flashinfer`."
+        )
+        from sglang.srt.layers.attention.flashattention_backend import (
+            FlashAttentionBackend,
+        )
 
-    return FlashAttentionBackend(runner)
+        return FlashAttentionBackend(runner)
+    else:
+        assert major == 3 and minor >= 1, (
+            "FlashAttention v3 Backend requires MP>=31. "
+            "Please use `--attention-backend triton`."
+        )
+        from sglang.srt.hardware_backend.musa.attention import (
+            MusaFlashAttentionBackend,
+        )
+
+        return MusaFlashAttentionBackend(runner)
 
 
 @register_attention_backend("fa4")

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -53,6 +53,7 @@ from sglang.srt.utils.common import (
     is_hip,
     is_hopper_with_cuda_12_3,
     is_mps,
+    is_musa,
     is_no_spec_infer_or_topk_one,
     is_npu,
     is_remote_url,
@@ -2591,7 +2592,10 @@ class ServerArgs:
 
     def _handle_page_size(self):
         if self.page_size is None:
-            self.page_size = 1
+            if not is_musa():
+                self.page_size = 1
+            else:
+                self.page_size = 64
 
     def _handle_amd_specifics(self):
         if is_hip():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR fixes the Flash Attention backend support that was previously merged in PR #17985 but later reverted in PR #22002 due to a bug. The original commit 2373552 caused CI failures (see [failed CI job](https://github.com/sgl-project/sglang/actions/runs/23928333410/job/69789912493)).

Previously, the MUSA-adapted flash attention implementation had a bug in the `_forward_extend_impl` method. The code was missing a proper mechanism to select the correct kernel implementation based on the `fa_impl_ver` parameter, causing it to always use the default FA3 implementation regardless of the specified version.

## Fix Applied
After rebasing to the latest main branch, the kernel selection logic has been refactored and moved to the `FlashAttentionBackend.__init__` method. This ensures that the appropriate flash attention implementation is selected during initialization based on the `fa_impl_ver` parameter.

1. **Moved kernel selection to `__init__`**: The logic to select the correct flash attention kernel (including MUSA-specific implementations) is now handled in the `FlashAttentionBackend.__init__` method, where two instance variables are initialized:
   - `self.flash_attn_with_kvcache`: For cached attention operations
   - `self.flash_attn_varlen_func`: For variable-length attention operations

2. **Updated forward methods**: Both `_forward_extend_impl` and `_forward_decode_impl` now use these instance variables instead of directly calling the default implementations, ensuring the correct kernel is used based on the initialized configuration.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
```
root@324a10004:/sgl-workspace/sglang# python3 -m sglang.launch_server \
            --model-path /mnt/seed17/001688/models/Qwen2.5-7B-Instruct/ \
            --served-model-name base-model \
            --trust-remote-code \
            --mem-fraction-static 0.80 \
            --cuda-graph-bs $(seq 1 2) \
            --host 0.0.0.0 \
            --port 30000 \
            --attention-backend fa3 \
            --tp-size 2 \
            --pp-size 2 \
            --disable-radix-cache \
            --chunked-prefill-size -1
2026-04-09 20:05:05 | warnings | 140537684047680 | WARNING : /mnt/seed17/001688/qzg/qwen3/260124/github/sglang/python/sglang/launch_server.py:51: UserWarning: 'python -m sglang.launch_server' is still supported, but 'sglang serve' is the recommended entrypoint.
  Example: sglang serve --model-path <model> [options]
  warnings.warn(

2026-04-09 20:05:06 | __init__ | 140537684047680 | INFO : Available plugins for group vllm.platform_plugins:
2026-04-09 20:05:06 | __init__ | 140537684047680 | INFO : - musa -> vllm_musa:register
2026-04-09 20:05:06 | __init__ | 140537684047680 | INFO : All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
2026-04-09 20:05:06 | __init__ | 140537684047680 | INFO : Available plugins for group vllm.platform_plugins:
2026-04-09 20:05:06 | __init__ | 140537684047680 | INFO : - musa -> vllm_musa:register
2026-04-09 20:05:06 | __init__ | 140537684047680 | INFO : All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
2026-04-09 20:05:06 | __init__ | 140537684047680 | INFO : Platform plugin musa is activated
2026-04-09 20:05:06 | __init__ | 140537684047680 | INFO : No platform detected, vLLM is running on UnspecifiedPlatform
2026-04-09 20:05:06 | _custom_ops | 140537684047680 | WARNING : Failed to import from vllm._C with ModuleNotFoundError("No module named 'vllm._C'")
2026-04-09 20:05:06 | warnings | 140537684047680 | WARNING : /mnt/seed17/001688/qzg/qwen3/260124/github/sglang/python/sglang/srt/layers/quantization/awq.py:87: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-04-09 20:05:06 | warnings | 140537684047680 | WARNING : /mnt/seed17/001688/qzg/qwen3/260124/github/sglang/python/sglang/srt/layers/quantization/gguf.py:48: UserWarning: Only CUDA and MUSA support GGUF quantization currently.
  warnings.warn(f"Only CUDA and MUSA support GGUF quantization currently.")

2026-04-09 20:05:07 | server_args | 140537684047680 | WARNING : Pipeline parallelism is incompatible with overlap schedule.
[2026-04-09 20:05:07] server_args=ServerArgs(model_path='/mnt/seed17/001688/models/Qwen2.5-7B-Instruct/', tokenizer_path='/mnt/seed17/001688/models/Qwen2.5-7B-Instruct/', tokenizer_mode='auto', tokenizer_worker_num=1, skip_tokenizer_init=False, load_format='auto', model_loader_extra_config='{}', trust_remote_code=True, context_length=None, is_embedding=False, enable_multimodal=None, revision=None, model_impl='auto', host='0.0.0.0', port=30000, fastapi_root_path='', grpc_mode=False, skip_server_warmup=False, warmups=None, nccl_port=None, checkpoint_engine_wait_weights_before_ready=False, ssl_keyfile=None, ssl_certfile=None, ssl_ca_certs=None, ssl_keyfile_password=None, enable_ssl_refresh=False, enable_http2=False, dtype='auto', quantization=None, quantization_param_path=None, kv_cache_dtype='auto', enable_fp32_lm_head=False, modelopt_quant=None, modelopt_checkpoint_restore_path=None, modelopt_checkpoint_save_path=None, modelopt_export_path=None, quantize_and_serve=False, rl_quant_profile=None, mem_fraction_static=0.8, max_running_requests=None, max_queued_requests=None, max_total_tokens=None, chunked_prefill_size=-1, enable_dynamic_chunking=False, max_prefill_tokens=16384, prefill_max_requests=None, schedule_policy='fcfs', enable_priority_scheduling=False, disable_priority_preemption=False, default_priority_value=None, abort_on_priority_when_disabled=False, schedule_low_priority_values_first=False, priority_scheduling_preemption_threshold=10, schedule_conservativeness=1.0, page_size=64, swa_full_tokens_ratio=0.8, disable_hybrid_swa_memory=False, radix_eviction_policy='lru', enable_prefill_delayer=False, prefill_delayer_max_delay_passes=30, prefill_delayer_token_usage_low_watermark=None, prefill_delayer_forward_passes_buckets=None, prefill_delayer_wait_seconds_buckets=None, device='musa', tp_size=2, pp_size=2, pp_max_micro_batch_size=None, pp_async_batch_depth=0, stream_interval=1, stream_response_default_include_usage=False, incremental_streaming_output=False, enable_streaming_session=False, random_seed=400815404, constrained_json_whitespace_pattern=None, constrained_json_disable_any_whitespace=False, watchdog_timeout=300, soft_watchdog_timeout=None, dist_timeout=None, download_dir=None, model_checksum=None, base_gpu_id=0, gpu_id_step=1, sleep_on_idle=False, use_ray=False, custom_sigquit_handler=None, log_level='info', log_level_http=None, log_requests=False, log_requests_level=2, log_requests_format='text', log_requests_target=None, uvicorn_access_log_exclude_prefixes=[], crash_dump_folder=None, show_time_cost=False, enable_metrics=False, enable_mfu_metrics=False, enable_metrics_for_all_schedulers=False, tokenizer_metrics_custom_labels_header='x-custom-labels', tokenizer_metrics_allowed_custom_labels=None, extra_metric_labels=None, bucket_time_to_first_token=None, bucket_inter_token_latency=None, bucket_e2e_request_latency=None, collect_tokens_histogram=False, prompt_tokens_buckets=None, generation_tokens_buckets=None, gc_warning_threshold_secs=0.0, decode_log_interval=40, enable_request_time_stats_logging=False, kv_events_config=None, enable_trace=False, otlp_traces_endpoint='localhost:4317', export_metrics_to_file=False, export_metrics_to_file_dir=None, api_key=None, admin_api_key=None, served_model_name='base-model', weight_version='default', chat_template=None, hf_chat_template_name=None, completion_template=None, file_storage_path='sglang_storage', enable_cache_report=False, reasoning_parser=None, tool_call_parser=None, tool_server=None, sampling_defaults='model', dp_size=1, load_balance_method='round_robin', attn_cp_size=1, moe_dp_size=1, dist_init_addr=None, nnodes=1, node_rank=0, json_model_override_args='{}', preferred_sampling_params=None, enable_lora=None, enable_lora_overlap_loading=None, max_lora_rank=None, lora_target_modules=None, lora_paths=None, max_loaded_loras=None, max_loras_per_batch=8, lora_eviction_policy='lru', lora_backend='csgmv', max_lora_chunk_size=16, experts_shared_outer_loras=None, attention_backend='fa3', decode_attention_backend=None, prefill_attention_backend=None, sampling_backend='pytorch', grammar_backend='xgrammar', mm_attention_backend=None, fp8_gemm_runner_backend='auto', fp4_gemm_runner_backend='auto', nsa_prefill_backend=None, nsa_decode_backend=None, disable_flashinfer_autotune=False, mamba_backend='triton', speculative_algorithm=None, speculative_draft_model_path=None, speculative_draft_model_revision=None, speculative_draft_load_format=None, speculative_num_steps=None, speculative_eagle_topk=None, speculative_num_draft_tokens=None, speculative_dflash_block_size=None, speculative_dflash_draft_window_size=None, speculative_accept_threshold_single=1.0, speculative_accept_threshold_acc=1.0, speculative_token_map=None, speculative_attention_mode='prefill', speculative_draft_attention_backend=None, speculative_moe_runner_backend='auto', speculative_moe_a2a_backend=None, speculative_draft_model_quantization=None, speculative_ngram_min_bfs_breadth=1, speculative_ngram_max_bfs_breadth=10, speculative_ngram_match_type='BFS', speculative_ngram_max_trie_depth=18, speculative_ngram_capacity=10000000, speculative_ngram_external_corpus_path=None, speculative_ngram_external_sam_budget=0, speculative_ngram_external_corpus_max_tokens=10000000, enable_multi_layer_eagle=False, ep_size=1, moe_a2a_backend='none', moe_runner_backend='auto', flashinfer_mxfp4_moe_precision='default', enable_flashinfer_allreduce_fusion=False, enforce_disable_flashinfer_allreduce_fusion=False, enable_aiter_allreduce_fusion=False, deepep_mode='auto', ep_num_redundant_experts=0, ep_dispatch_algorithm=None, init_expert_location='trivial', enable_eplb=False, eplb_algorithm='auto', eplb_rebalance_num_iterations=1000, eplb_rebalance_layers_per_chunk=None, eplb_min_rebalancing_utilization_threshold=1.0, expert_distribution_recorder_mode=None, expert_distribution_recorder_buffer_size=1000, enable_expert_distribution_metrics=False, deepep_config=None, moe_dense_tp_size=None, elastic_ep_backend=None, enable_elastic_expert_backup=False, mooncake_ib_device=None, max_mamba_cache_size=None, mamba_ssm_dtype=None, mamba_full_memory_ratio=0.9, mamba_scheduler_strategy='no_buffer', mamba_track_interval=256, linear_attn_backend='triton', linear_attn_decode_backend=None, linear_attn_prefill_backend=None, enable_hierarchical_cache=False, hicache_ratio=2.0, hicache_size=0, hicache_write_policy='write_through', hicache_io_backend='kernel', hicache_mem_layout='layer_first', hicache_storage_backend=None, hicache_storage_prefetch_policy='best_effort', hicache_storage_backend_extra_config=None, enable_hisparse=False, hisparse_config=None, enable_lmcache=False, kt_weight_path=None, kt_method='AMXINT4', kt_cpuinfer=None, kt_threadpool_count=2, kt_num_gpu_experts=None, kt_max_deferred_experts_per_token=None, dllm_algorithm=None, dllm_algorithm_config=None, enable_double_sparsity=False, ds_channel_config_path=None, ds_heavy_channel_num=32, ds_heavy_token_num=256, ds_heavy_channel_type='qk', ds_sparse_decode_threshold=4096, cpu_offload_gb=0, offload_group_size=-1, offload_num_in_group=1, offload_prefetch_step=1, offload_mode='cpu', multi_item_scoring_delimiter=None, disable_radix_cache=True, cuda_graph_max_bs=2, cuda_graph_bs=[1, 2], disable_cuda_graph=False, disable_cuda_graph_padding=False, enable_profile_cuda_graph=False, enable_cudagraph_gc=False, enable_layerwise_nvtx_marker=False, enable_nccl_nvls=False, enable_symm_mem=False, disable_flashinfer_cutlass_moe_fp4_allgather=False, enable_tokenizer_batch_encode=False, disable_tokenizer_batch_decode=False, disable_outlines_disk_cache=False, disable_custom_all_reduce=False, enable_mscclpp=False, enable_torch_symm_mem=False, pre_warm_nccl=False, disable_overlap_schedule=True, enable_mixed_chunk=False, enable_dp_attention=False, enable_dp_lm_head=False, enable_two_batch_overlap=False, enable_single_batch_overlap=False, tbo_token_distribution_threshold=0.48, enable_torch_compile=False, disable_piecewise_cuda_graph=True, enforce_piecewise_cuda_graph=False, enable_torch_compile_debug_mode=False, torch_compile_max_bs=32, piecewise_cuda_graph_max_tokens=-1, piecewise_cuda_graph_tokens=[], piecewise_cuda_graph_compiler='eager', torchao_config='', enable_nan_detection=False, enable_p2p_check=False, triton_attention_reduce_in_fp32=False, triton_attention_num_kv_splits=8, triton_attention_split_tile_size=None, num_continuous_decode_steps=1, delete_ckpt_after_loading=False, enable_memory_saver=False, enable_weights_cpu_backup=False, enable_draft_weights_cpu_backup=False, allow_auto_truncate=False, enable_custom_logit_processor=False, flashinfer_mla_disable_ragged=False, disable_shared_experts_fusion=False, disable_chunked_prefix_cache=False, disable_fast_image_processor=False, keep_mm_feature_on_device=False, enable_return_hidden_states=False, enable_return_routed_experts=False, scheduler_recv_interval=1, numa_node=None, enable_deterministic_inference=False, rl_on_policy_target=None, enable_attn_tp_input_scattered=False, gc_threshold=None, enable_nsa_prefill_context_parallel=False, nsa_prefill_cp_mode='round-robin-split', enable_fused_qk_norm_rope=False, enable_precise_embedding_interpolation=False, enable_fused_moe_sum_all_reduce=False, enable_prefill_context_parallel=False, prefill_cp_mode='in-seq-split', enable_dynamic_batch_tokenizer=False, dynamic_batch_tokenizer_batch_size=32, dynamic_batch_tokenizer_batch_timeout=0.002, debug_tensor_dump_output_folder=None, debug_tensor_dump_layers=None, debug_tensor_dump_input_file=None, debug_tensor_dump_inject=False, disaggregation_mode='null', disaggregation_transfer_backend='mooncake', disaggregation_bootstrap_port=8998, disaggregation_ib_device=None, disaggregation_decode_enable_offload_kvcache=False, num_reserved_decode_tokens=512, disaggregation_decode_polling_interval=1, encoder_only=False, language_only=False, encoder_transfer_backend='zmq_to_scheduler', encoder_urls=[], enable_adaptive_dispatch_to_encoder=False, custom_weight_loader=[], weight_loader_disable_mmap=False, remote_instance_weight_loader_seed_instance_ip=None, remote_instance_weight_loader_seed_instance_service_port=None, remote_instance_weight_loader_send_weights_group_ports=None, remote_instance_weight_loader_backend='nccl', remote_instance_weight_loader_start_seed_via_transfer_engine=False, engine_info_bootstrap_port=6789, modelexpress_config=None, enable_pdmux=False, pdmux_config_path=None, sm_group_num=8, enable_broadcast_mm_inputs_process=False, enable_prefix_mm_cache=False, mm_enable_dp_encoder=False, mm_process_config={}, limit_mm_data_per_request=None, enable_mm_global_cache=False, decrypted_config_file=None, decrypted_draft_config_file=None, forward_hooks=None)
[2026-04-09 20:05:08] Using default HuggingFace chat template with detected content format: string
2026-04-09 20:05:14 | __init__ | 140102443353920 | INFO : Available plugins for group vllm.platform_plugins:
2026-04-09 20:05:14 | __init__ | 140102443353920 | INFO : - musa -> vllm_musa:register
2026-04-09 20:05:14 | __init__ | 140102443353920 | INFO : All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
2026-04-09 20:05:14 | __init__ | 140314952234816 | INFO : Available plugins for group vllm.platform_plugins:
2026-04-09 20:05:14 | __init__ | 140314952234816 | INFO : - musa -> vllm_musa:register
2026-04-09 20:05:14 | __init__ | 140314952234816 | INFO : All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
2026-04-09 20:05:14 | __init__ | 139839021729600 | INFO : Available plugins for group vllm.platform_plugins:
2026-04-09 20:05:14 | __init__ | 139839021729600 | INFO : - musa -> vllm_musa:register
2026-04-09 20:05:14 | __init__ | 139839021729600 | INFO : All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
2026-04-09 20:05:14 | __init__ | 140102443353920 | INFO : Available plugins for group vllm.platform_plugins:
2026-04-09 20:05:14 | __init__ | 140102443353920 | INFO : - musa -> vllm_musa:register
2026-04-09 20:05:14 | __init__ | 140102443353920 | INFO : All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
2026-04-09 20:05:14 | __init__ | 140314952234816 | INFO : Available plugins for group vllm.platform_plugins:
2026-04-09 20:05:14 | __init__ | 140314952234816 | INFO : - musa -> vllm_musa:register
2026-04-09 20:05:14 | __init__ | 140314952234816 | INFO : All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
2026-04-09 20:05:14 | __init__ | 140102443353920 | INFO : Platform plugin musa is activated
2026-04-09 20:05:14 | __init__ | 140314952234816 | INFO : Platform plugin musa is activated
2026-04-09 20:05:14 | __init__ | 139839021729600 | INFO : Available plugins for group vllm.platform_plugins:
2026-04-09 20:05:14 | __init__ | 139839021729600 | INFO : - musa -> vllm_musa:register
2026-04-09 20:05:14 | __init__ | 139839021729600 | INFO : All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
2026-04-09 20:05:14 | __init__ | 139839021729600 | INFO : Platform plugin musa is activated
2026-04-09 20:05:14 | __init__ | 140605230712640 | INFO : Available plugins for group vllm.platform_plugins:
2026-04-09 20:05:14 | __init__ | 140605230712640 | INFO : - musa -> vllm_musa:register
2026-04-09 20:05:14 | __init__ | 140605230712640 | INFO : All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
2026-04-09 20:05:14 | __init__ | 140605230712640 | INFO : Available plugins for group vllm.platform_plugins:
2026-04-09 20:05:14 | __init__ | 140605230712640 | INFO : - musa -> vllm_musa:register
2026-04-09 20:05:14 | __init__ | 140605230712640 | INFO : All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
2026-04-09 20:05:14 | __init__ | 140605230712640 | INFO : Platform plugin musa is activated
2026-04-09 20:05:14 | __init__ | 140715677046592 | INFO : Available plugins for group vllm.platform_plugins:
2026-04-09 20:05:14 | __init__ | 140715677046592 | INFO : - musa -> vllm_musa:register
2026-04-09 20:05:14 | __init__ | 140715677046592 | INFO : All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
2026-04-09 20:05:14 | __init__ | 140715677046592 | INFO : Available plugins for group vllm.platform_plugins:
2026-04-09 20:05:14 | __init__ | 140715677046592 | INFO : - musa -> vllm_musa:register
2026-04-09 20:05:14 | __init__ | 140715677046592 | INFO : All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
2026-04-09 20:05:14 | __init__ | 140715677046592 | INFO : Platform plugin musa is activated
2026-04-09 20:05:15 | __init__ | 140102443353920 | INFO : No platform detected, vLLM is running on UnspecifiedPlatform
2026-04-09 20:05:15 | _custom_ops | 140102443353920 | WARNING : Failed to import from vllm._C with ModuleNotFoundError("No module named 'vllm._C'")
2026-04-09 20:05:15 | __init__ | 140314952234816 | INFO : No platform detected, vLLM is running on UnspecifiedPlatform
2026-04-09 20:05:15 | _custom_ops | 140314952234816 | WARNING : Failed to import from vllm._C with ModuleNotFoundError("No module named 'vllm._C'")
2026-04-09 20:05:15 | warnings | 140102443353920 | WARNING : /mnt/seed17/001688/qzg/qwen3/260124/github/sglang/python/sglang/srt/layers/quantization/awq.py:87: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-04-09 20:05:15 | warnings | 140314952234816 | WARNING : /mnt/seed17/001688/qzg/qwen3/260124/github/sglang/python/sglang/srt/layers/quantization/awq.py:87: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-04-09 20:05:15 | __init__ | 139839021729600 | INFO : No platform detected, vLLM is running on UnspecifiedPlatform
2026-04-09 20:05:15 | _custom_ops | 139839021729600 | WARNING : Failed to import from vllm._C with ModuleNotFoundError("No module named 'vllm._C'")
2026-04-09 20:05:15 | warnings | 139839021729600 | WARNING : /mnt/seed17/001688/qzg/qwen3/260124/github/sglang/python/sglang/srt/layers/quantization/awq.py:87: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-04-09 20:05:15 | __init__ | 140605230712640 | INFO : No platform detected, vLLM is running on UnspecifiedPlatform
2026-04-09 20:05:15 | _custom_ops | 140605230712640 | WARNING : Failed to import from vllm._C with ModuleNotFoundError("No module named 'vllm._C'")
2026-04-09 20:05:15 | warnings | 140605230712640 | WARNING : /mnt/seed17/001688/qzg/qwen3/260124/github/sglang/python/sglang/srt/layers/quantization/awq.py:87: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-04-09 20:05:15 | __init__ | 140715677046592 | INFO : No platform detected, vLLM is running on UnspecifiedPlatform
2026-04-09 20:05:15 | _custom_ops | 140715677046592 | WARNING : Failed to import from vllm._C with ModuleNotFoundError("No module named 'vllm._C'")
2026-04-09 20:05:15 | warnings | 140715677046592 | WARNING : /mnt/seed17/001688/qzg/qwen3/260124/github/sglang/python/sglang/srt/layers/quantization/awq.py:87: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-04-09 20:05:15 | warnings | 140102443353920 | WARNING : /mnt/seed17/001688/qzg/qwen3/260124/github/sglang/python/sglang/srt/layers/quantization/gguf.py:48: UserWarning: Only CUDA and MUSA support GGUF quantization currently.
  warnings.warn(f"Only CUDA and MUSA support GGUF quantization currently.")

2026-04-09 20:05:15 | warnings | 140314952234816 | WARNING : /mnt/seed17/001688/qzg/qwen3/260124/github/sglang/python/sglang/srt/layers/quantization/gguf.py:48: UserWarning: Only CUDA and MUSA support GGUF quantization currently.
  warnings.warn(f"Only CUDA and MUSA support GGUF quantization currently.")

2026-04-09 20:05:15 | warnings | 139839021729600 | WARNING : /mnt/seed17/001688/qzg/qwen3/260124/github/sglang/python/sglang/srt/layers/quantization/gguf.py:48: UserWarning: Only CUDA and MUSA support GGUF quantization currently.
  warnings.warn(f"Only CUDA and MUSA support GGUF quantization currently.")

2026-04-09 20:05:15 | warnings | 140605230712640 | WARNING : /mnt/seed17/001688/qzg/qwen3/260124/github/sglang/python/sglang/srt/layers/quantization/gguf.py:48: UserWarning: Only CUDA and MUSA support GGUF quantization currently.
  warnings.warn(f"Only CUDA and MUSA support GGUF quantization currently.")

2026-04-09 20:05:15 | warnings | 140715677046592 | WARNING : /mnt/seed17/001688/qzg/qwen3/260124/github/sglang/python/sglang/srt/layers/quantization/gguf.py:48: UserWarning: Only CUDA and MUSA support GGUF quantization currently.
  warnings.warn(f"Only CUDA and MUSA support GGUF quantization currently.")

[2026-04-09 20:05:15 PP1 TP0] Process 1187068 gpu_id 2 is running on CPUs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95]
[2026-04-09 20:05:15 PP1 TP1] Process 1187069 gpu_id 3 is running on CPUs: [32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127]
[2026-04-09 20:05:15 PP0 TP1] Process 1187067 gpu_id 1 is running on CPUs: [32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127]
[2026-04-09 20:05:16 PP0 TP0] Process 1187066 gpu_id 0 is running on CPUs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95]
[2026-04-09 20:05:16 PP1 TP1] Init torch distributed begin.
[2026-04-09 20:05:16 PP1 TP0] Init torch distributed begin.
[2026-04-09 20:05:16 PP0 TP1] Init torch distributed begin.
[2026-04-09 20:05:16 PP0 TP0] Init torch distributed begin.
[Gloo] Rank 2 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 0 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 1 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 3 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 1 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 0 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 1 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[2026-04-09 20:05:18 PP1 TP0] sglang is using nccl==2.11.4
[Gloo] Rank 0 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[2026-04-09 20:05:18 PP0 TP0] sglang is using nccl==2.11.4
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 1 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 0 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 0 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 1 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[2026-04-09 20:05:20 PP0 TP1] sglang is using nccl==2.11.4
[2026-04-09 20:05:20 PP0 TP0] sglang is using nccl==2.11.4
[2026-04-09 20:05:20 PP0 TP0] Init torch distributed ends. elapsed=3.35 s, mem usage=0.89 GB
[2026-04-09 20:05:20 PP1 TP1] Init torch distributed ends. elapsed=3.69 s, mem usage=0.97 GB
[2026-04-09 20:05:20 PP0 TP1] Init torch distributed ends. elapsed=3.64 s, mem usage=0.97 GB
[2026-04-09 20:05:20 PP1 TP0] Init torch distributed ends. elapsed=3.64 s, mem usage=0.97 GB
[2026-04-09 20:05:20 PP1 TP1] Ignore import error when loading sglang.srt.models.gemma4_audio: cannot import name 'Gemma4AudioConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-09 20:05:20 PP1 TP1] Ignore import error when loading sglang.srt.models.gemma4_causal: cannot import name 'Gemma4TextConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-09 20:05:20 PP1 TP1] Ignore import error when loading sglang.srt.models.gemma4_mm: cannot import name 'Gemma4AudioConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-09 20:05:20 PP1 TP1] Ignore import error when loading sglang.srt.models.gemma4_vision: cannot import name 'Gemma4VisionConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-09 20:05:20 PP0 TP1] Ignore import error when loading sglang.srt.models.gemma4_audio: cannot import name 'Gemma4AudioConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-09 20:05:20 PP0 TP1] Ignore import error when loading sglang.srt.models.gemma4_causal: cannot import name 'Gemma4TextConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-09 20:05:20 PP0 TP1] Ignore import error when loading sglang.srt.models.gemma4_mm: cannot import name 'Gemma4AudioConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-09 20:05:20 PP0 TP1] Ignore import error when loading sglang.srt.models.gemma4_vision: cannot import name 'Gemma4VisionConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-09 20:05:20 PP1 TP1] Ignore import error when loading sglang.srt.models.glm_ocr: No module named 'transformers.models.glm_ocr'
[2026-04-09 20:05:20 PP0 TP0] Ignore import error when loading sglang.srt.models.gemma4_audio: cannot import name 'Gemma4AudioConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-09 20:05:20 PP0 TP1] Ignore import error when loading sglang.srt.models.glm_ocr: No module named 'transformers.models.glm_ocr'
[2026-04-09 20:05:20 PP1 TP1] Ignore import error when loading sglang.srt.models.glm_ocr_nextn: No module named 'transformers.models.glm_ocr'
[2026-04-09 20:05:20 PP0 TP0] Ignore import error when loading sglang.srt.models.gemma4_causal: cannot import name 'Gemma4TextConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-09 20:05:20 PP0 TP1] Ignore import error when loading sglang.srt.models.glm_ocr_nextn: No module named 'transformers.models.glm_ocr'
[2026-04-09 20:05:20 PP1 TP1] Ignore import error when loading sglang.srt.models.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-09 20:05:20 PP0 TP1] Ignore import error when loading sglang.srt.models.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-09 20:05:20 PP0 TP0] Ignore import error when loading sglang.srt.models.gemma4_mm: cannot import name 'Gemma4AudioConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-09 20:05:20 PP0 TP0] Ignore import error when loading sglang.srt.models.gemma4_vision: cannot import name 'Gemma4VisionConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-09 20:05:20 PP1 TP0] Ignore import error when loading sglang.srt.models.gemma4_audio: cannot import name 'Gemma4AudioConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-09 20:05:20 PP1 TP0] Ignore import error when loading sglang.srt.models.gemma4_causal: cannot import name 'Gemma4TextConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-09 20:05:20 PP1 TP0] Ignore import error when loading sglang.srt.models.gemma4_mm: cannot import name 'Gemma4AudioConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-09 20:05:20 PP1 TP0] Ignore import error when loading sglang.srt.models.gemma4_vision: cannot import name 'Gemma4VisionConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-09 20:05:20 PP0 TP0] Ignore import error when loading sglang.srt.models.glm_ocr: No module named 'transformers.models.glm_ocr'
[2026-04-09 20:05:20 PP0 TP0] Ignore import error when loading sglang.srt.models.glm_ocr_nextn: No module named 'transformers.models.glm_ocr'
[2026-04-09 20:05:20 PP0 TP0] Ignore import error when loading sglang.srt.models.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-09 20:05:20 PP1 TP0] Ignore import error when loading sglang.srt.models.glm_ocr: No module named 'transformers.models.glm_ocr'
[2026-04-09 20:05:20 PP1 TP0] Ignore import error when loading sglang.srt.models.glm_ocr_nextn: No module named 'transformers.models.glm_ocr'
[2026-04-09 20:05:20 PP1 TP0] Ignore import error when loading sglang.srt.models.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-09 20:05:20 PP1 TP1] Ignore import error when loading sglang.srt.models.midashenglm: No module named 'torchaudio'
[2026-04-09 20:05:20 PP0 TP0] Ignore import error when loading sglang.srt.models.midashenglm: No module named 'torchaudio'
[2026-04-09 20:05:20 PP0 TP1] Ignore import error when loading sglang.srt.models.midashenglm: No module named 'torchaudio'
[2026-04-09 20:05:20 PP1 TP0] Ignore import error when loading sglang.srt.models.midashenglm: No module named 'torchaudio'
[2026-04-09 20:05:20 PP1 TP0] Load weight begin. avail mem=78.37 GB
[2026-04-09 20:05:20 PP1 TP1] Load weight begin. avail mem=78.37 GB
[2026-04-09 20:05:20 PP0 TP0] Load weight begin. avail mem=78.26 GB
[2026-04-09 20:05:20 PP0 TP1] Load weight begin. avail mem=78.37 GB
Multi-thread loading shards:  50% Completed | 2/4 [00:06<00:07,  3.54s/it][2026-04-09 20:05:30 PP0 TP1] Parameter lm_head.weight not found in params_dict
[2026-04-09 20:05:30 PP0 TP1] Parameter model.norm.weight not found in params_dict
[2026-04-09 20:05:30 PP0 TP0] Parameter lm_head.weight not found in params_dict
[2026-04-09 20:05:30 PP0 TP0] Parameter model.norm.weight not found in params_dict
Multi-thread loading shards: 100% Completed | 4/4 [00:12<00:00,  3.05s/it]
[2026-04-09 20:05:36 PP0 TP1] Load weight end. elapsed=15.82 s, type=Qwen2ForCausalLM, avail mem=74.52 GB, mem usage=3.86 GB.
[2026-04-09 20:05:36 PP0 TP0] Load weight end. elapsed=15.83 s, type=Qwen2ForCausalLM, avail mem=74.40 GB, mem usage=3.86 GB.
[2026-04-09 20:05:36 PP0 TP0] Using KV cache dtype: torch.bfloat16
[2026-04-09 20:05:37 PP1 TP1] Parameter model.embed_tokens.weight not found in params_dict
[2026-04-09 20:05:37 PP1 TP0] Parameter model.embed_tokens.weight not found in params_dict
[2026-04-09 20:05:37 PP1 TP1] Load weight end. elapsed=16.38 s, type=Qwen2ForCausalLM, avail mem=74.52 GB, mem usage=3.86 GB.
[2026-04-09 20:05:37 PP1 TP0] Load weight end. elapsed=16.38 s, type=Qwen2ForCausalLM, avail mem=74.52 GB, mem usage=3.86 GB.
[2026-04-09 20:05:37 PP1 TP0] Using KV cache dtype: torch.bfloat16
[2026-04-09 20:05:37 PP0 TP0] KV Cache is allocated. #tokens: 4400192, K size: 29.37 GB, V size: 29.37 GB
[2026-04-09 20:05:37 PP1 TP0] KV Cache is allocated. #tokens: 4400192, K size: 29.37 GB, V size: 29.37 GB
[2026-04-09 20:05:37 PP0 TP0] Memory pool end. avail mem=14.99 GB
[2026-04-09 20:05:37 PP1 TP0] Memory pool end. avail mem=15.11 GB
[2026-04-09 20:05:37 PP0 TP1] KV Cache is allocated. #tokens: 4400192, K size: 29.37 GB, V size: 29.37 GB
[2026-04-09 20:05:37 PP1 TP1] KV Cache is allocated. #tokens: 4400192, K size: 29.37 GB, V size: 29.37 GB
[2026-04-09 20:05:37 PP0 TP1] Memory pool end. avail mem=15.11 GB
[2026-04-09 20:05:37 PP1 TP1] Memory pool end. avail mem=15.11 GB
[2026-04-09 20:05:38 PP0 TP1] Capture cuda graph begin. This can take up to several minutes. avail mem=15.05 GB
[2026-04-09 20:05:38 PP1 TP1] Capture cuda graph begin. This can take up to several minutes. avail mem=15.05 GB
[2026-04-09 20:05:38 PP1 TP0] Capture cuda graph begin. This can take up to several minutes. avail mem=15.05 GB
[2026-04-09 20:05:38 PP1 TP0] Capture cuda graph bs [1, 2]
[2026-04-09 20:05:38 PP0 TP0] Capture cuda graph begin. This can take up to several minutes. avail mem=14.94 GB
[2026-04-09 20:05:38 PP0 TP0] Capture cuda graph bs [1, 2]
Capturing batches (bs=1 avail_mem=14.32 GB): 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [01:02<00:00, 31.37s/it]
[2026-04-09 20:06:41 PP1 TP0] Registering 56 cuda graph addresses
[2026-04-09 20:06:42 PP1 TP1] Capture cuda graph end. Time elapsed: 63.94 s. mem usage=0.74 GB. avail mem=14.32 GB.
[2026-04-09 20:06:42 PP1 TP1] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
[2026-04-09 20:06:42 PP1 TP0] Capture cuda graph end. Time elapsed: 63.95 s. mem usage=0.74 GB. avail mem=14.32 GB.
[2026-04-09 20:06:42 PP1 TP0] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
Capturing batches (bs=1 avail_mem=14.21 GB): 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [01:04<00:00, 32.34s/it]
[2026-04-09 20:06:43 PP0 TP0] Registering 58 cuda graph addresses
[2026-04-09 20:06:44 PP0 TP1] Capture cuda graph end. Time elapsed: 66.49 s. mem usage=0.74 GB. avail mem=14.32 GB.
[2026-04-09 20:06:44 PP0 TP1] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
[2026-04-09 20:06:44 PP0 TP0] Capture cuda graph end. Time elapsed: 66.50 s. mem usage=0.74 GB. avail mem=14.20 GB.
[2026-04-09 20:06:44 PP0 TP0] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
[2026-04-09 20:06:45 PP0 TP0] max_total_num_tokens=4400192, chunked_prefill_size=-1, max_prefill_tokens=16384, max_running_requests=4096, context_len=32768, available_gpu_mem=14.20 GB
[2026-04-09 20:06:45 PP1 TP0] max_total_num_tokens=4400192, chunked_prefill_size=-1, max_prefill_tokens=16384, max_running_requests=4096, context_len=32768, available_gpu_mem=14.32 GB
[2026-04-09 20:06:45] INFO:     Started server process [1185766]
[2026-04-09 20:06:45] INFO:     Waiting for application startup.
[2026-04-09 20:06:45] Using default chat sampling params from model generation config: {'repetition_penalty': 1.05, 'temperature': 0.7, 'top_k': 20, 'top_p': 0.8}
[2026-04-09 20:06:45] INFO:     Application startup complete.
[2026-04-09 20:06:45] INFO:     Uvicorn running on http://0.0.0.0:30000 (Press CTRL+C to quit)
[2026-04-09 20:06:46] INFO:     127.0.0.1:35942 - "GET /model_info HTTP/1.1" 200 OK
[2026-04-09 20:06:47 PP0 TP1] /mnt/seed17/001688/qzg/qwen3/260124/github/sglang/python/sglang/srt/distributed/parallel_state.py:1058: UserWarning: The given buffer is not writable, and PyTorch does not support non-writable tensors. This means you can write to the underlying (supposedly non-writable) buffer using the tensor. You may want to copy the buffer to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /home/pytorch/torch/csrc/utils/tensor_new.cpp:1581.)
  object_tensor = torch.frombuffer(pickle.dumps(obj), dtype=torch.uint8)

[2026-04-09 20:06:48 PP0 TP0] /mnt/seed17/001688/qzg/qwen3/260124/github/sglang/python/sglang/srt/distributed/parallel_state.py:1058: UserWarning: The given buffer is not writable, and PyTorch does not support non-writable tensors. This means you can write to the underlying (supposedly non-writable) buffer using the tensor. You may want to copy the buffer to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /home/pytorch/torch/csrc/utils/tensor_new.cpp:1581.)
  object_tensor = torch.frombuffer(pickle.dumps(obj), dtype=torch.uint8)

[2026-04-09 20:06:48 PP1 TP1] /mnt/seed17/001688/qzg/qwen3/260124/github/sglang/python/sglang/srt/distributed/parallel_state.py:1058: UserWarning: The given buffer is not writable, and PyTorch does not support non-writable tensors. This means you can write to the underlying (supposedly non-writable) buffer using the tensor. You may want to copy the buffer to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /home/pytorch/torch/csrc/utils/tensor_new.cpp:1581.)
  object_tensor = torch.frombuffer(pickle.dumps(obj), dtype=torch.uint8)

[2026-04-09 20:06:48 PP1 TP0] /mnt/seed17/001688/qzg/qwen3/260124/github/sglang/python/sglang/srt/distributed/parallel_state.py:1058: UserWarning: The given buffer is not writable, and PyTorch does not support non-writable tensors. This means you can write to the underlying (supposedly non-writable) buffer using the tensor. You may want to copy the buffer to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /home/pytorch/torch/csrc/utils/tensor_new.cpp:1581.)
  object_tensor = torch.frombuffer(pickle.dumps(obj), dtype=torch.uint8)

[2026-04-09 20:06:48 PP0 TP0] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, cuda graph: False, input throughput (token/s): 0.00
[2026-04-09 20:06:48 PP1 TP0] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, cuda graph: False, input throughput (token/s): 0.00
[2026-04-09 20:06:49] INFO:     127.0.0.1:35956 - "POST /generate HTTP/1.1" 200 OK
[2026-04-09 20:06:49] The server is fired up and ready to roll!
[2026-04-09 20:06:59 PP0 TP0] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, cuda graph: False, input throughput (token/s): 5.84
[2026-04-09 20:06:59 PP1 TP0] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, cuda graph: False, input throughput (token/s): 6.08
[2026-04-09 20:06:59 PP0 TP0] Decode batch, #running-req: 1, #token: 64, token usage: 0.00, cuda graph: True, gen throughput (token/s): 0.39, #queue-req: 0
[2026-04-09 20:06:59 PP1 TP0] Decode batch, #running-req: 1, #token: 64, token usage: 0.00, cuda graph: True, gen throughput (token/s): 0.39, #queue-req: 0
[2026-04-09 20:07:01 PP0 TP0] Decode batch, #running-req: 1, #token: 128, token usage: 0.00, cuda graph: True, gen throughput (token/s): 24.78, #queue-req: 0
[2026-04-09 20:07:01 PP1 TP0] Decode batch, #running-req: 1, #token: 128, token usage: 0.00, cuda graph: True, gen throughput (token/s): 24.77, #queue-req: 0
[2026-04-09 20:07:01 PP0 TP0] Decode batch, #running-req: 1, #token: 192, token usage: 0.00, cuda graph: True, gen throughput (token/s): 59.19, #queue-req: 0
[2026-04-09 20:07:01 PP1 TP0] Decode batch, #running-req: 1, #token: 192, token usage: 0.00, cuda graph: True, gen throughput (token/s): 59.23, #queue-req: 0
[2026-04-09 20:07:02 PP0 TP0] Decode batch, #running-req: 1, #token: 192, token usage: 0.00, cuda graph: True, gen throughput (token/s): 58.99, #queue-req: 0
[2026-04-09 20:07:02 PP1 TP0] Decode batch, #running-req: 1, #token: 192, token usage: 0.00, cuda graph: True, gen throughput (token/s): 59.03, #queue-req: 0
[2026-04-09 20:07:03 PP0 TP0] Decode batch, #running-req: 1, #token: 256, token usage: 0.00, cuda graph: True, gen throughput (token/s): 58.76, #queue-req: 0
[2026-04-09 20:07:03 PP1 TP0] Decode batch, #running-req: 1, #token: 256, token usage: 0.00, cuda graph: True, gen throughput (token/s): 58.76, #queue-req: 0
[2026-04-09 20:07:04 PP0 TP0] Decode batch, #running-req: 1, #token: 256, token usage: 0.00, cuda graph: True, gen throughput (token/s): 58.73, #queue-req: 0
[2026-04-09 20:07:04 PP1 TP0] Decode batch, #running-req: 1, #token: 256, token usage: 0.00, cuda graph: True, gen throughput (token/s): 58.73, #queue-req: 0
[2026-04-09 20:07:04 PP0 TP0] Decode batch, #running-req: 1, #token: 320, token usage: 0.00, cuda graph: True, gen throughput (token/s): 58.69, #queue-req: 0
[2026-04-09 20:07:04 PP1 TP0] Decode batch, #running-req: 1, #token: 320, token usage: 0.00, cuda graph: True, gen throughput (token/s): 58.69, #queue-req: 0
[2026-04-09 20:07:05] INFO:     127.0.0.1:56346 - "POST /generate HTTP/1.1" 200 OK

python3 /sglang/python/sglang/test/few_shot_gsm8k.py
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [01:54<00:00,  1.75it/s]
Accuracy: 0.870
Invalid: 0.000
Latency: 114.105 s
Output throughput: 322.844 token/s
```


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit .
- [ ] Add unit tests according to the https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests .
- [ ] Update documentation according to https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations .
- [ ] Provide accuracy and speed benchmark results according to https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy and https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed .
- [ ] Follow the SGLang code style https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance .

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process .
2. Get approvals from https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS and other reviewers.
3. Trigger CI tests with https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

---

**Related Links:**
- Original merge PR: #17985
- Revert PR: #22002 (commit efa7b2d5d358bd25c6af729abcb581f643168f71)
- Failed CI job: https://github.com/sgl-project/sglang/actions/runs/23928333410/job/69789912493
- Fix commits: 0af5fe5488d204ab55f431e4741997b6b63b06fa