### PR TITLE
[Fix][Qwen3.5]: Fix incorrect Mamba conv_state transfer in PD disaggregation

### DIFF
--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -26,6 +26,7 @@ class KVArgs:
     state_type: str  # "none", "mamba", "swa"
     # for mamba state different tp slice transfer
     state_dim_per_tensor: List[int]  # dimension to slice for each state tensor
+    state_segment_dims_per_tensor: List[List[int]]  # optional per-tensor segment dims
     ib_device: str
     ib_traffic_class: str
     gpu_id: int

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -362,6 +362,10 @@ class DecodePreallocQueue:
                     kv_args.state_dim_per_tensor = (
                         self.token_to_kv_pool.get_state_dim_per_tensor()
                     )
+                if hasattr(self.token_to_kv_pool, "get_state_segment_dims_per_tensor"):
+                    kv_args.state_segment_dims_per_tensor = (
+                        self.token_to_kv_pool.get_state_segment_dims_per_tensor()
+                    )
             elif isinstance(self.token_to_kv_pool, NSATokenToKVPool):
                 kv_args.state_type = "nsa"
             else:

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1075,7 +1075,9 @@ class MooncakeKVManager(CommonKVManager):
         prefill_state_data_ptrs = self.kv_args.state_data_ptrs
         prefill_state_item_lens = self.kv_args.state_item_lens
         src_state_dim_per_tensor = getattr(self.kv_args, "state_dim_per_tensor", [])
-
+        src_state_segment_dims_per_tensor = getattr(
+            self.kv_args, "state_segment_dims_per_tensor", []
+        )
         # If no dimension info available, fall back to regular transfer
         if not src_state_dim_per_tensor or not dst_state_dim_per_tensor:
             return self._send_mamba_state(req, prefill_mamba_index, dst_state_data_ptrs)
@@ -1098,10 +1100,59 @@ class MooncakeKVManager(CommonKVManager):
             if self.attn_tp_size > dst_attn_tp_size:
                 # Multiple prefill ranks send to 1 decode rank
                 # Each prefill sends all its dims to the appropriate offset in decode
-                src_dim_start = 0
-                num_dims_to_send = src_dim
                 writers_per_decode = self.attn_tp_size // dst_attn_tp_size
                 local_writer_idx = local_tp_rank_in_group % writers_per_decode
+
+                # Mamba conv_state concatenates [intermediate, SSM, SSM] along the
+                # TP-sliced dimension. When prefill_tp > decode_tp, a single
+                # contiguous merge transfer misaligns the decode-side layout, so use
+                # per-segment transfers when segment metadata is available.
+                src_segment_dims = (
+                    src_state_segment_dims_per_tensor[i]
+                    if i < len(src_state_segment_dims_per_tensor)
+                    else []
+                )
+                if src_segment_dims and sum(src_segment_dims) == src_dim:
+                    src_dim_prefix = 0
+                    dst_dim_prefix = 0
+                    segment_blocks = []
+                    segment_valid = True
+
+                    for src_segment_dim in src_segment_dims:
+                        full_segment_dim = src_segment_dim * self.attn_tp_size
+                        if full_segment_dim % dst_attn_tp_size != 0:
+                            segment_valid = False
+                            break
+
+                        dst_segment_dim = full_segment_dim // dst_attn_tp_size
+                        src_dim_offset = src_dim_prefix * src_bytes_per_dim
+                        dst_dim_offset = (
+                            dst_dim_prefix + local_writer_idx * src_segment_dim
+                        ) * dst_bytes_per_dim
+                        bytes_to_send = src_segment_dim * src_bytes_per_dim
+
+                        src_addr = (
+                            prefill_state_data_ptrs[i]
+                            + src_item_len * int(prefill_mamba_index[0])
+                            + src_dim_offset
+                        )
+                        dst_addr = (
+                            dst_state_ptr
+                            + dst_item_len * int(req.dst_state_indices[0])
+                            + dst_dim_offset
+                        )
+                        segment_blocks.append((src_addr, dst_addr, bytes_to_send))
+
+                        src_dim_prefix += src_segment_dim
+                        dst_dim_prefix += dst_segment_dim
+
+                    if segment_valid:
+                        transfer_blocks.extend(segment_blocks)
+                        continue
+
+                # Fallback for tensors without segment metadata.
+                src_dim_start = 0
+                num_dims_to_send = src_dim
                 dst_dim_start = local_writer_idx * src_dim
             else:
                 # 1 prefill rank sends to multiple decode ranks

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -185,6 +185,11 @@ class PrefillBootstrapQueue:
                     kv_args.state_dim_per_tensor = (
                         self.token_to_kv_pool.get_state_dim_per_tensor()
                     )
+                # Optional: per-tensor segment sizes for Mamba conv state slice transfer.
+                if hasattr(self.token_to_kv_pool, "get_state_segment_dims_per_tensor"):
+                    kv_args.state_segment_dims_per_tensor = (
+                        self.token_to_kv_pool.get_state_segment_dims_per_tensor()
+                    )
             elif isinstance(self.token_to_kv_pool, NSATokenToKVPool):
                 kv_args.state_type = "nsa"
             else:

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -228,6 +228,7 @@ class MambaPool:
         enable_memory_saver: bool = False,
         speculative_num_draft_tokens: Optional[int] = None,
     ):
+        self.cache_params = cache_params
         conv_state_shape = cache_params.shape.conv
         temporal_state_shape = cache_params.shape.temporal
         conv_dtype = cache_params.dtype.conv
@@ -443,6 +444,69 @@ class MambaPool:
             # Repeat for each layer since we have per-layer data_ptrs
             dim_per_tensor += [sliceable_dim] * self.num_mamba_layers
         return dim_per_tensor
+
+    def get_state_segment_dims_per_tensor(self):
+        """Get optional segment dims for TP-sliced state tensors.
+
+        For Mamba conv state, the TP-sliced dim is laid out as
+        [intermediate_size, n_groups * state_size, n_groups * state_size].
+        We only expose this for layouts if it is safe. Tensors without segment metadata
+        return an empty list and will fall back to the original contiguous slice transfer.
+        """
+        shape = getattr(self.cache_params, "shape", None)
+        if (
+            shape is None
+            or not hasattr(shape, "conv")
+            or not hasattr(shape, "conv_dim")
+            or not hasattr(shape, "intermediate_size")
+            or not hasattr(shape, "conv_kernel")
+        ):
+            return []
+        if len(shape.conv) != 1:
+            return []
+
+        local_conv_dim = int(shape.conv[0][0])
+        full_conv_dim = int(shape.conv_dim)
+        conv_kernel_size = int(shape.conv_kernel)
+        if local_conv_dim <= 0 or full_conv_dim % local_conv_dim != 0:
+            return []
+        tp_world_size = full_conv_dim // local_conv_dim
+        if tp_world_size <= 0:
+            return []
+
+        intermediate_size = int(shape.intermediate_size)
+        ngroups_state_size = full_conv_dim - intermediate_size
+        if (
+            intermediate_size % tp_world_size != 0
+            or ngroups_state_size <= 0
+            or ngroups_state_size % 2 != 0
+        ):
+            return []
+        ngroups_state_size //= 2
+        if ngroups_state_size % tp_world_size != 0:
+            return []
+
+        conv_segment_dims = [
+            intermediate_size // tp_world_size,
+            ngroups_state_size // tp_world_size,
+            ngroups_state_size // tp_world_size,
+        ]
+
+        state_tensors = []
+        for field in vars(self.mamba_cache):
+            value = getattr(self.mamba_cache, field)
+            if isinstance(value, list):
+                state_tensors.extend(value)
+            else:
+                state_tensors.append(value)
+
+        segment_dims_per_tensor = []
+        for state_tensor in state_tensors:
+            segment_dims = (
+                conv_segment_dims if state_tensor.shape[-1] == conv_kernel_size - 1 else []
+            )
+            segment_dims_per_tensor += [segment_dims] * self.num_mamba_layers
+        return segment_dims_per_tensor
 
 
 class HybridReqToTokenPool(ReqToTokenPool):
@@ -1324,6 +1388,10 @@ class HybridLinearKVPool(KVCache):
     def get_state_dim_per_tensor(self):
         """Get the sliceable dimension size for each mamba state tensor."""
         return self.mamba_pool.get_state_dim_per_tensor()
+
+    def get_state_segment_dims_per_tensor(self):
+        """Get optional segment dims for TP-sliced mamba state tensors."""
+        return self.mamba_pool.get_state_segment_dims_per_tensor()
 
     def maybe_get_custom_mem_pool(self):
         return self.full_kv_pool.maybe_get_custom_mem_pool()


### PR DESCRIPTION
## Motivation

In the Qwen3.5 prefill-decode (PD) disaggregated deployment, the following setup works as expected:
Prefill: attn_tp=2, dp=4, ep=8, Decode: attn_tp=1, dp=8, ep=8. However, when we change the prefill configuration to attn_tp=8, dp=1, ep=8 while keeping the decode config we observe an accuracy issue when evaluating the MMLU-Pro dataset with EvalScope. A small portion of samples show obvious repetitive generation, with a frequency of roughly 1 / 1000. This is not a typical decoding-time repetition issue, instead, the repetition begins from the very first token produced by the decode node, which strongly suggests that the transferred KV cache (Mamba cache) is already incorrect before decode generation starts. The affected question IDs are also not stably reproducible across runs.
<img width="2770" height="942" alt="image" src="https://github.com/user-attachments/assets/c70ff12e-9f24-4283-99ab-79eac0ee4f42" />


## Modifications

Conv_state has the shape: [num_layers, size + 1, conv_dim / tp, conv_kernel - 1], its TP-sliced dimension is not a single contiguous logical shard. Internally, it is composed of three concatenated segments: intermediate, SSM, SSM. The previous logic merges the entire local TP shard in one shot. However, the correct behavior is to merge each segment independently.

A simplified example makes this clearer. Suppose the TP-sliced dimension has a total length of 12, with intermediate_size = 4, SSM part 1 = 4, SSM part 2 = 4. The global logical layout is: [I0 I1 I2 I3 | S10 S11 S12 S13 | S20 S21 S22 S23]. The conv_state is produced by MergedColumnParallelLinear, TP sharding is done per segment. For example, with: Prefill attn_tp = 4 Decode attn_tp = 2 the prefill-side layout is effectively: prefill rank0: [I0 | S10 | S20], prefill rank1: [I1 | S11 | S21], .... Then decode rank0 expected to receive [I0 I1 | S10 S11 | S20 S21], but the original merge logic instead produces: [I0 S10 S20 | I1 S11 S21]. This results in a semantically incorrect conv_state layout on the decode side, which can corrupt generation from the very first emitted token.

This PR fixes the conv_state merge logic for PD disaggregation when prefill TP and decode TP differ. The key change is: Instead of merging the whole local TP shard as one contiguous block, split the TP-sliced dimension into its logical segments first, then merge each segment independently, and finally concatenate the merged segments back in the correct global order. 

## Accuracy Tests

We validate the fix on the Qwen3.5 PD disaggregated setup using EvalScope on MMLU-Pro with:
- Prefill: attn_tp=8, dp=1, ep=8
- Decode: attn_tp=1, dp=8, ep=8
EvalScope command:
evalscope eval --model Qwen3.5-FP8 --api-url http://xxxx:xxxx/v1/chat/completions --api-key EMPTY --eval-type openai_api --datasets mmlu_pro --dataset-hub huggingface --generation-config '{"temperature":0.6, "top_p": 0.95, "top_k": 20, "max_tokens":32000, "retries": 10, "retry_interval": 30}' --limit 10000 --eval-batch-size 100 --timeout 1800

Before this fix: score: 0.8739 repetition cases: 37
After this fix: score: 0.8821 repetition cases: 0

## Prefill Config
`export NCCL_IB_HCA=mlx5_2,mlx5_3,mlx5_4,mlx5_5,mlx5_6,mlx5_7,mlx5_8,mlx5_9
model_path=/workspace/Models/Qwen3.5-397B-A17B-FP8
python -m sglang.launch_server \
  --model-path ${model_path} \
  --disaggregation-mode prefill \
  --reasoning-parser qwen3 \
  --tool-call-parser qwen3_coder \
  --attention-backend fa3 \
  --mm-attention-backend fa3 \
  --mamba-ssm-dtype bfloat16 \
  --mamba-scheduler-strategy extra_buffer \
  --mamba-track-interval 128 \
  --quantization fp8 \
  --kv-cache-dtype fp8_e4m3 \
  --tensor-parallel-size 8 \
  --data-parallel-size 1 \
  --moe-dense-tp-size 1 \
  --enable-dp-attention \
  --enable-dp-lm-head \
  --mem-fraction-static 0.9 \
  --page-size 64 \
  --context-length 262144 \
  --chunked-prefill-size 16384 \
  --prefill-max-requests 1 \
  --moe-a2a-backend deepep \
  --deepep-mode normal \
  --load-balance-method round_robin \
  --disaggregation-bootstrap-port 8998 \
  --disaggregation-transfer-backend mooncake \
  --disaggregation-ib-device ${NCCL_IB_HCA} \
  --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 32}' \
  --speculative-algorithm EAGLE \
  --speculative-attention-mode prefill \
  --speculative-num-steps 3 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4 \
  --trust-remote-code`

## Decode Config
`export NCCL_IB_HCA=mlx5_2,mlx5_3,mlx5_4,mlx5_5,mlx5_6,mlx5_7,mlx5_8,mlx5_9
model_path=/workspace/Models/Qwen3.5-397B-A17B-FP8
python -m sglang.launch_server \
  --model-path ${model_path} \
  --disaggregation-mode decode \
  --reasoning-parser qwen3 \
  --tool-call-parser qwen3_coder \
  --attention-backend fa3 \
  --mm-attention-backend fa3 \
  --max-running-requests 350 \
  --mamba-ssm-dtype bfloat16 \
  --mamba-scheduler-strategy extra_buffer \
  --mamba-track-interval 128 \
  --quantization fp8 \
  --kv-cache-dtype fp8_e4m3 \
  --tensor-parallel-size 8 \
  --data-parallel-size 8 \
  --enable-dp-attention \
  --enable-dp-lm-head \
  --moe-dense-tp-size 1 \
  --moe-a2a-backend deepep \
  --deepep-mode low_latency \
  --mem-fraction-static 0.8 \
  --page-size 64 \
  --context-length 262144 \
  --cuda-graph-max-bs 48 \
  --disaggregation-transfer-backend mooncake \
  --disaggregation-ib-device ${NCCL_IB_HCA} \
  --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 32}' \
  --speculative-algorithm EAGLE \
  --speculative-attention-mode decode \
  --speculative-num-steps 3 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4 \
  --trust-remote-code`

