### PR TITLE
[Benchmark] Fix incorrect generated_len counting in bench_multiturn with speculative decoding

### DIFF
--- a/python/sglang/test/kits/cache_hit_kit.py
+++ b/python/sglang/test/kits/cache_hit_kit.py
@@ -29,7 +29,7 @@ async def async_request_sglang_generate(
         st = time.perf_counter()
         most_recent_timestamp = st
         output = RequestFuncOutput()
-        completion_tokens = 0
+        completion_tokens = None
 
         try:
             async with session.post(url=url, json=payload, headers=headers) as response:
@@ -81,7 +81,9 @@ async def async_request_sglang_generate(
                     output.prompt_len = prompt_tokens
                     output.cached_tokens = cached_tokens
                     output.generated_len = (
-                        completion_tokens if completion_tokens else len(output.itl) + 1
+                        completion_tokens
+                        if completion_tokens is not None
+                        else len(output.itl) + 1
                     )
                 else:
                     output.error = response.reason or ""

--- a/python/sglang/test/kits/cache_hit_kit.py
+++ b/python/sglang/test/kits/cache_hit_kit.py
@@ -29,6 +29,7 @@ async def async_request_sglang_generate(
         st = time.perf_counter()
         most_recent_timestamp = st
         output = RequestFuncOutput()
+        completion_tokens = 0
 
         try:
             async with session.post(url=url, json=payload, headers=headers) as response:
@@ -69,13 +70,19 @@ async def async_request_sglang_generate(
 
                                 most_recent_timestamp = timestamp
 
+                            completion_tokens = (data.get("meta_info") or {}).get(
+                                "completion_tokens", completion_tokens
+                            )
+
                     output.generated_text = generated_text
                     output.output_ids = all_output_ids
                     output.success = True
                     output.latency = latency
                     output.prompt_len = prompt_tokens
                     output.cached_tokens = cached_tokens
-                    output.generated_len = len(output.itl) + 1
+                    output.generated_len = (
+                        completion_tokens if completion_tokens else len(output.itl) + 1
+                    )
                 else:
                     output.error = response.reason or ""
                     output.success = False


### PR DESCRIPTION
## Motivation

`bench_multiturn.py` reports incorrect `Average Output Length` and `Output Throughput` when running with speculative decoding (e.g., EAGLE3).

The root cause is in `async_request_sglang_generate()`: it counts streaming events (`len(output.itl) + 1`) as the number of generated tokens. Without speculative decoding this is correct (1 event = 1 token), but with EAGLE3 each streaming event carries ~2-3 accepted tokens from a single speculative step. This causes `generated_len` to undercount by roughly the `accept_len` factor (~2.2x).

**Example (DPA + EAGLE3, 16 clients, 100K prompt, output_length=2048):**
- Before fix: `Average Output Length: 886.94`, `Output Throughput: 68.54 tok/s`
- After fix: `Average Output Length: 2048.00`, `Output Throughput: ~158 tok/s`

The OpenAI chat completions path in the same file already handles this correctly by using `completion_tokens` from the usage stats.

## Modifications

In `async_request_sglang_generate()` (`python/sglang/test/kits/cache_hit_kit.py`):
- Track `completion_tokens` from `meta_info` across streaming events (the server always populates this with the correct cumulative count).
- Use `completion_tokens` for `generated_len` when available, falling back to `len(output.itl) + 1` for backward compatibility.
- This matches the approach already used in `async_request_openai_chat_completions()`.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).