### PR TITLE
fix: add missing f-string prefixes in warning and assert messages

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -1201,7 +1201,7 @@ class MambaPoolHost(HostKVCache):
             "page_first",
             "page_first_direct",
             "layer_first",
-        ], "Unsupported layout: {layout}"
+        ], f"Unsupported layout: {layout}"
 
         self.layout = layout
         self.pin_memory = pin_memory

--- a/python/sglang/srt/models/phi4mm.py
+++ b/python/sglang/srt/models/phi4mm.py
@@ -529,7 +529,7 @@ class Phi4MMForCausalLM(nn.Module):
                 param = params_dict.get(name)
                 if param is None:
                     if "lora" not in name:
-                        logger.warning("Warning: {name} not found in model parameters")
+                        logger.warning(f"Warning: {name} not found in model parameters")
                     continue
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)


### PR DESCRIPTION
## Summary
- Add missing `f` prefix in `phi4mm.py` where `{name}` is printed literally in warning message
- Add missing `f` prefix in `memory_pool_host.py` where `{layout}` is printed literally in assert message

## Motivation
Without the `f` prefix, these messages show literal `{name}` and `{layout}` text instead of actual variable values, making debugging harder.

## Test plan
- [ ] Verify warning/assert messages correctly interpolate variable values

🤖 Generated with [Claude Code](https://claude.com/claude-code)