### PR TITLE
fix: remove duplicate words in comments and docstrings

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/linear.py
+++ b/python/sglang/multimodal_gen/runtime/layers/linear.py
@@ -903,7 +903,7 @@ class QKVParallelLinear(ColumnParallelLinear):
             if not is_sharded_weight:
                 loaded_weight = loaded_weight.narrow(output_dim, start_idx, shard_size)
 
-        # Special case for for AQLM codebooks.
+        # Special case for AQLM codebooks.
         elif is_metadata:
             # metadata indicates fixed size concatenated along dim 0
             shard_size = loaded_weight.shape[0]

--- a/python/sglang/srt/configs/internvl.py
+++ b/python/sglang/srt/configs/internvl.py
@@ -140,7 +140,7 @@ class InternLM2Config(PretrainedConfig):
 
         if not isinstance(self.rope_scaling, dict) or len(self.rope_scaling) != 2:
             raise ValueError(
-                "`rope_scaling` must be a dictionary with with two fields, `type` and `factor`, "
+                "`rope_scaling` must be a dictionary with two fields, `type` and `factor`, "
                 f"got {self.rope_scaling}"
             )
         rope_scaling_type = self.rope_scaling.get("type", None)

--- a/python/sglang/srt/layers/quantization/compressed_tensors/utils.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/utils.py
@@ -96,7 +96,7 @@ def find_matched_target(
     config that a layer corresponds to.
 
     Recall that a compressed-tensors configs has a concept of
-    config_groups, where each layer can be quantized with with a different
+    config_groups, where each layer can be quantized with a different
     scheme.
 
     targets in each config_group will be a list of either layer names

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -409,7 +409,7 @@ def patch_model(
     num_tokens: int,
     tp_group: GroupCoordinator,
 ):
-    """Patch the model to make it compatible with with torch.compile"""
+    """Patch the model to make it compatible with torch.compile"""
     backup_ca_comm = None
 
     try:

--- a/python/sglang/srt/models/minicpmo.py
+++ b/python/sglang/srt/models/minicpmo.py
@@ -1183,7 +1183,7 @@ class MiniCPMWhisperEncoderLayer(nn.Module):
         return outputs
 
 
-# Copied from from transformers.models.whisper.modeling_whisper.WhisperEncoder and add use_cache for streaming inference
+# Copied from transformers.models.whisper.modeling_whisper.WhisperEncoder and add use_cache for streaming inference
 class MiniCPMWhisperEncoder(WhisperEncoder):
 
     def __init__(self, config: WhisperConfig):

--- a/sgl-kernel/python/sgl_kernel/sampling.py
+++ b/sgl-kernel/python/sgl_kernel/sampling.py
@@ -37,8 +37,8 @@ def top_k_renorm_probs(
     probs: torch.Tensor
         Probabilities, shape ``(batch_size, num_classes)``.
     top_k: Union[torch.Tensor, int]
-        Either a scalar or a tensor of shape ``(batch_size,)``, representing the top-k threshold for for
-        for re-normalizing probabilities, should be in ``(0, num_classes)``.
+        Either a scalar or a tensor of shape ``(batch_size,)``, representing the top-k threshold for
+        re-normalizing probabilities, should be in ``(0, num_classes)``.
         If a scalar, the same threshold is used for all requests.
         If a tensor, each request has its own threshold.
         We keep the top-k probabilities, set the rest to zero, and renormalize the probabilities.
@@ -88,7 +88,7 @@ def top_p_renorm_probs(
     probs: torch.Tensor
         Probabilities, shape ``(batch_size, num_classes)``.
     top_p: Union[torch.Tensor, float]
-        Either a scalar or a tensor of shape ``(batch_size,)``, representing the top-p threshold for for
+        Either a scalar or a tensor of shape ``(batch_size,)``, representing the top-p threshold for
         re-normalizing probabilities, should be in ``(0, 1)``.
         If a scalar, the same threshold is used for all requests.
         If a tensor, each request has its own threshold.


### PR DESCRIPTION
## Summary
- Fix 7 instances of duplicate words across the codebase:
  - `for for` → `for` (3 instances)
  - `with with` → `with` (3 instances)
  - `from from` → `from` (1 instance)

## Test plan
- [ ] Verify no functional changes, comments/docstrings only

🤖 Generated with [Claude Code](https://claude.com/claude-code)