### PR TITLE
[AMD][CI] Extract generate_simple_markdown_report into shared utility

### DIFF
--- a/python/sglang/test/nightly_bench_utils.py
+++ b/python/sglang/test/nightly_bench_utils.py
@@ -122,6 +122,44 @@ def generate_markdown_report(
     return summary
 
 
+def generate_simple_markdown_report(
+    results: List[BenchmarkResult], default_gpu_config: str = "MI325"
+) -> str:
+    """Generate a simplified markdown report without traces and cost columns.
+
+    Used by AMD perf tests where Perfetto profiling is not available.
+    Skips the first result if it's a warmup run (duplicate batch_size).
+
+    Args:
+        results: List of BenchmarkResult from a benchmark run.
+        default_gpu_config: Fallback when GPU_CONFIG env is unset
+            (e.g. "MI325", "MI35x", "AMD").
+    """
+    model_header = results[0].model_path
+    if results[0].run_name and results[0].run_name != "default":
+        model_header += f" ({results[0].run_name})"
+
+    gpu_config = os.getenv("GPU_CONFIG", default_gpu_config)
+    if gpu_config:
+        model_header += f" [{gpu_config}]"
+
+    summary = f"### {model_header}\n"
+    summary += "| batch size | input len | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |\n"
+    summary += "| ---------- | --------- | ----------- | ------------------------ | ------------------------- | -------- |\n"
+
+    report_results = (
+        results[1:]
+        if len(results) > 1 and results[0].batch_size == results[1].batch_size
+        else results
+    )
+
+    for result in report_results:
+        itl = 1 / (result.output_throughput / result.batch_size) * 1000
+        summary += f"| {result.batch_size} | {result.input_len} | {result.latency:.2f} | {result.input_throughput:.2f} | {result.output_throughput:.2f} | {itl:.2f} |\n"
+
+    return summary
+
+
 def save_results_as_pydantic_models(
     results: List,
     pydantic_result_filename: str,

--- a/test/registered/amd/perf/mi30x/test_deepseek_v31_perf.py
+++ b/test/registered/amd/perf/mi30x/test_deepseek_v31_perf.py
@@ -10,46 +10,14 @@ Example usage:
 
 import os
 import unittest
-from typing import List
 
 from sglang.test.ci.ci_register import register_amd_ci
-from sglang.test.nightly_bench_utils import BenchmarkResult
+from sglang.test.nightly_bench_utils import generate_simple_markdown_report
 from sglang.test.nightly_utils import NightlyBenchmarkRunner
 from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
 
 # Register for AMD CI - DeepSeek-V3.1 benchmark (basic + MTP, ~300 min)
 register_amd_ci(est_time=18000, suite="nightly-perf-8-gpu-deepseek-v31", nightly=True)
-
-
-def generate_simple_markdown_report(results: List[BenchmarkResult]) -> str:
-    """Generate a simplified markdown report without traces and cost columns.
-
-    Skips the first result if it's a warmup run (duplicate batch_size).
-    """
-    model_header = results[0].model_path
-    if results[0].run_name and results[0].run_name != "default":
-        model_header += f" ({results[0].run_name})"
-
-    gpu_config = os.getenv("GPU_CONFIG", "")
-    if gpu_config:
-        model_header += f" [{gpu_config}]"
-
-    summary = f"### {model_header}\n"
-    summary += "| batch size | input len | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |\n"
-    summary += "| ---------- | --------- | ----------- | ------------------------ | ------------------------- | -------- |\n"
-
-    # Skip first result if it's a warmup (same batch_size as second result)
-    report_results = (
-        results[1:]
-        if len(results) > 1 and results[0].batch_size == results[1].batch_size
-        else results
-    )
-
-    for result in report_results:
-        itl = 1 / (result.output_throughput / result.batch_size) * 1000
-        summary += f"| {result.batch_size} | {result.input_len} | {result.latency:.2f} | {result.input_throughput:.2f} | {result.output_throughput:.2f} | {itl:.2f} |\n"
-
-    return summary
 
 
 # Model path can be overridden via environment variable
@@ -140,7 +108,10 @@ class TestNightlyDeepseekV31Performance(unittest.TestCase):
                     # Use simplified report format without traces
                     if results:
                         self.runner.full_report += (
-                            generate_simple_markdown_report(results) + "\n"
+                            generate_simple_markdown_report(
+                                results, default_gpu_config=""
+                            )
+                            + "\n"
                         )
         finally:
             self.runner.write_final_report()

--- a/test/registered/amd/perf/mi30x/test_deepseek_v32_basic_perf_amd.py
+++ b/test/registered/amd/perf/mi30x/test_deepseek_v32_basic_perf_amd.py
@@ -12,10 +12,9 @@ Example usage:
 
 import os
 import unittest
-from typing import List
 
 from sglang.test.ci.ci_register import register_amd_ci
-from sglang.test.nightly_bench_utils import BenchmarkResult
+from sglang.test.nightly_bench_utils import generate_simple_markdown_report
 from sglang.test.nightly_utils import NightlyBenchmarkRunner
 from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
 
@@ -23,37 +22,6 @@ from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
 register_amd_ci(
     est_time=5400, suite="nightly-perf-8-gpu-deepseek-v32-basic", nightly=True
 )
-
-
-def generate_simple_markdown_report(results: List[BenchmarkResult]) -> str:
-    """Generate a simplified markdown report without traces and cost columns.
-
-    Skips the first result if it's a warmup run (duplicate batch_size).
-    """
-    model_header = results[0].model_path
-    if results[0].run_name and results[0].run_name != "default":
-        model_header += f" ({results[0].run_name})"
-
-    gpu_config = os.getenv("GPU_CONFIG", "MI325")
-    if gpu_config:
-        model_header += f" [{gpu_config}]"
-
-    summary = f"### {model_header}\n"
-    summary += "| batch size | input len | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |\n"
-    summary += "| ---------- | --------- | ----------- | ------------------------ | ------------------------- | -------- |\n"
-
-    # Skip first result if it's a warmup (same batch_size as second result)
-    report_results = (
-        results[1:]
-        if len(results) > 1 and results[0].batch_size == results[1].batch_size
-        else results
-    )
-
-    for result in report_results:
-        itl = 1 / (result.output_throughput / result.batch_size) * 1000
-        summary += f"| {result.batch_size} | {result.input_len} | {result.latency:.2f} | {result.input_throughput:.2f} | {result.output_throughput:.2f} | {itl:.2f} |\n"
-
-    return summary
 
 
 # Model path can be overridden via environment variable

--- a/test/registered/amd/perf/mi30x/test_deepseek_v32_mtp_perf_amd.py
+++ b/test/registered/amd/perf/mi30x/test_deepseek_v32_mtp_perf_amd.py
@@ -13,10 +13,9 @@ Example usage:
 
 import os
 import unittest
-from typing import List
 
 from sglang.test.ci.ci_register import register_amd_ci
-from sglang.test.nightly_bench_utils import BenchmarkResult
+from sglang.test.nightly_bench_utils import generate_simple_markdown_report
 from sglang.test.nightly_utils import NightlyBenchmarkRunner
 from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
 
@@ -24,37 +23,6 @@ from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
 register_amd_ci(
     est_time=7200, suite="nightly-perf-8-gpu-deepseek-v32-mtp", nightly=True
 )
-
-
-def generate_simple_markdown_report(results: List[BenchmarkResult]) -> str:
-    """Generate a simplified markdown report without traces and cost columns.
-
-    Skips the first result if it's a warmup run (duplicate batch_size).
-    """
-    model_header = results[0].model_path
-    if results[0].run_name and results[0].run_name != "default":
-        model_header += f" ({results[0].run_name})"
-
-    gpu_config = os.getenv("GPU_CONFIG", "MI325")
-    if gpu_config:
-        model_header += f" [{gpu_config}]"
-
-    summary = f"### {model_header}\n"
-    summary += "| batch size | input len | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |\n"
-    summary += "| ---------- | --------- | ----------- | ------------------------ | ------------------------- | -------- |\n"
-
-    # Skip first result if it's a warmup (same batch_size as second result)
-    report_results = (
-        results[1:]
-        if len(results) > 1 and results[0].batch_size == results[1].batch_size
-        else results
-    )
-
-    for result in report_results:
-        itl = 1 / (result.output_throughput / result.batch_size) * 1000
-        summary += f"| {result.batch_size} | {result.input_len} | {result.latency:.2f} | {result.input_throughput:.2f} | {result.output_throughput:.2f} | {itl:.2f} |\n"
-
-    return summary
 
 
 # Model path can be overridden via environment variable

--- a/test/registered/amd/perf/mi30x/test_deepseek_v3_perf.py
+++ b/test/registered/amd/perf/mi30x/test_deepseek_v3_perf.py
@@ -10,36 +10,14 @@ Example usage:
 
 import os
 import unittest
-from typing import List
 
 from sglang.test.ci.ci_register import register_amd_ci
-from sglang.test.nightly_bench_utils import BenchmarkResult
+from sglang.test.nightly_bench_utils import generate_simple_markdown_report
 from sglang.test.nightly_utils import NightlyBenchmarkRunner
 from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
 
 # Register for AMD CI - DeepSeek-V3 benchmark (basic + MTP, ~300 min)
 register_amd_ci(est_time=18000, suite="nightly-perf-8-gpu-deepseek-v3", nightly=True)
-
-
-def generate_simple_markdown_report(results: List[BenchmarkResult]) -> str:
-    """Generate a simplified markdown report without traces and cost columns."""
-    model_header = results[0].model_path
-    if results[0].run_name and results[0].run_name != "default":
-        model_header += f" ({results[0].run_name})"
-
-    gpu_config = os.getenv("GPU_CONFIG", "")
-    if gpu_config:
-        model_header += f" [{gpu_config}]"
-
-    summary = f"### {model_header}\n"
-    summary += "| batch size | input len | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |\n"
-    summary += "| ---------- | --------- | ----------- | ------------------------ | ------------------------- | -------- |\n"
-
-    for result in results:
-        itl = 1 / (result.output_throughput / result.batch_size) * 1000
-        summary += f"| {result.batch_size} | {result.input_len} | {result.latency:.2f} | {result.input_throughput:.2f} | {result.output_throughput:.2f} | {itl:.2f} |\n"
-
-    return summary
 
 
 # Model path can be overridden via environment variable
@@ -130,7 +108,10 @@ class TestNightlyDeepseekV3Performance(unittest.TestCase):
                     # Use simplified report format without traces
                     if results:
                         self.runner.full_report += (
-                            generate_simple_markdown_report(results) + "\n"
+                            generate_simple_markdown_report(
+                                results, default_gpu_config=""
+                            )
+                            + "\n"
                         )
         finally:
             self.runner.write_final_report()

--- a/test/registered/amd/perf/mi30x/test_grok1_fp8_perf.py
+++ b/test/registered/amd/perf/mi30x/test_grok1_fp8_perf.py
@@ -12,36 +12,14 @@ Example usage:
 
 import os
 import unittest
-from typing import List
 
 from sglang.test.ci.ci_register import register_amd_ci
-from sglang.test.nightly_bench_utils import BenchmarkResult
+from sglang.test.nightly_bench_utils import generate_simple_markdown_report
 from sglang.test.nightly_utils import NightlyBenchmarkRunner
 from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
 
 # Register for AMD CI - Grok-1 FP8 benchmark (~25 min)
 register_amd_ci(est_time=1500, suite="nightly-perf-8-gpu-grok1-fp8", nightly=True)
-
-
-def generate_simple_markdown_report(results: List[BenchmarkResult]) -> str:
-    """Generate a simplified markdown report without traces and cost columns."""
-    model_header = results[0].model_path
-    if results[0].run_name and results[0].run_name != "default":
-        model_header += f" ({results[0].run_name})"
-
-    gpu_config = os.getenv("GPU_CONFIG", "")
-    if gpu_config:
-        model_header += f" [{gpu_config}]"
-
-    summary = f"### {model_header}\n"
-    summary += "| batch size | input len | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |\n"
-    summary += "| ---------- | --------- | ----------- | ------------------------ | ------------------------- | -------- |\n"
-
-    for result in results:
-        itl = 1 / (result.output_throughput / result.batch_size) * 1000
-        summary += f"| {result.batch_size} | {result.input_len} | {result.latency:.2f} | {result.input_throughput:.2f} | {result.output_throughput:.2f} | {itl:.2f} |\n"
-
-    return summary
 
 
 # Model and tokenizer paths can be overridden via environment variables
@@ -116,7 +94,8 @@ class TestNightlyGrok1FP8Performance(unittest.TestCase):
 
             if results:
                 self.runner.full_report += (
-                    generate_simple_markdown_report(results) + "\n"
+                    generate_simple_markdown_report(results, default_gpu_config="")
+                    + "\n"
                 )
 
             self.assertTrue(success, "Benchmark failed for Grok-1 FP8")

--- a/test/registered/amd/perf/mi30x/test_grok1_int4_perf.py
+++ b/test/registered/amd/perf/mi30x/test_grok1_int4_perf.py
@@ -12,46 +12,14 @@ Example usage:
 
 import os
 import unittest
-from typing import List
 
 from sglang.test.ci.ci_register import register_amd_ci
-from sglang.test.nightly_bench_utils import BenchmarkResult
+from sglang.test.nightly_bench_utils import generate_simple_markdown_report
 from sglang.test.nightly_utils import NightlyBenchmarkRunner
 from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
 
 # Register for AMD CI - Grok-1 INT4 benchmark (~25 min)
 register_amd_ci(est_time=1500, suite="nightly-perf-8-gpu-grok1-int4", nightly=True)
-
-
-def generate_simple_markdown_report(results: List[BenchmarkResult]) -> str:
-    """Generate a simplified markdown report without traces and cost columns.
-
-    Skips the first result if it's a warmup run (duplicate batch_size).
-    """
-    model_header = results[0].model_path
-    if results[0].run_name and results[0].run_name != "default":
-        model_header += f" ({results[0].run_name})"
-
-    gpu_config = os.getenv("GPU_CONFIG", "")
-    if gpu_config:
-        model_header += f" [{gpu_config}]"
-
-    summary = f"### {model_header}\n"
-    summary += "| batch size | input len | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |\n"
-    summary += "| ---------- | --------- | ----------- | ------------------------ | ------------------------- | -------- |\n"
-
-    # Skip first result if it's a warmup (same batch_size as second result)
-    report_results = (
-        results[1:]
-        if len(results) > 1 and results[0].batch_size == results[1].batch_size
-        else results
-    )
-
-    for result in report_results:
-        itl = 1 / (result.output_throughput / result.batch_size) * 1000
-        summary += f"| {result.batch_size} | {result.input_len} | {result.latency:.2f} | {result.input_throughput:.2f} | {result.output_throughput:.2f} | {itl:.2f} |\n"
-
-    return summary
 
 
 # Model and tokenizer paths can be overridden via environment variables
@@ -126,7 +94,8 @@ class TestNightlyGrok1INT4Performance(unittest.TestCase):
 
             if results:
                 self.runner.full_report += (
-                    generate_simple_markdown_report(results) + "\n"
+                    generate_simple_markdown_report(results, default_gpu_config="")
+                    + "\n"
                 )
 
             self.assertTrue(success, "Benchmark failed for Grok-1 INT4")

--- a/test/registered/amd/perf/mi30x/test_grok2_perf.py
+++ b/test/registered/amd/perf/mi30x/test_grok2_perf.py
@@ -12,46 +12,14 @@ Example usage:
 
 import os
 import unittest
-from typing import List
 
 from sglang.test.ci.ci_register import register_amd_ci
-from sglang.test.nightly_bench_utils import BenchmarkResult
+from sglang.test.nightly_bench_utils import generate_simple_markdown_report
 from sglang.test.nightly_utils import NightlyBenchmarkRunner
 from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
 
 # Register for AMD CI - Grok-2 benchmark (~25 min)
 register_amd_ci(est_time=1500, suite="nightly-perf-8-gpu-grok2", nightly=True)
-
-
-def generate_simple_markdown_report(results: List[BenchmarkResult]) -> str:
-    """Generate a simplified markdown report without traces and cost columns.
-
-    Skips the first result if it's a warmup run (duplicate batch_size).
-    """
-    model_header = results[0].model_path
-    if results[0].run_name and results[0].run_name != "default":
-        model_header += f" ({results[0].run_name})"
-
-    gpu_config = os.getenv("GPU_CONFIG", "")
-    if gpu_config:
-        model_header += f" [{gpu_config}]"
-
-    summary = f"### {model_header}\n"
-    summary += "| batch size | input len | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |\n"
-    summary += "| ---------- | --------- | ----------- | ------------------------ | ------------------------- | -------- |\n"
-
-    # Skip first result if it's a warmup (same batch_size as second result)
-    report_results = (
-        results[1:]
-        if len(results) > 1 and results[0].batch_size == results[1].batch_size
-        else results
-    )
-
-    for result in report_results:
-        itl = 1 / (result.output_throughput / result.batch_size) * 1000
-        summary += f"| {result.batch_size} | {result.input_len} | {result.latency:.2f} | {result.input_throughput:.2f} | {result.output_throughput:.2f} | {itl:.2f} |\n"
-
-    return summary
 
 
 # Model and tokenizer paths can be overridden via environment variables
@@ -128,7 +96,8 @@ class TestNightlyGrok2Performance(unittest.TestCase):
 
             if results:
                 self.runner.full_report += (
-                    generate_simple_markdown_report(results) + "\n"
+                    generate_simple_markdown_report(results, default_gpu_config="")
+                    + "\n"
                 )
 
             self.assertTrue(success, "Benchmark failed for Grok-2")

--- a/test/registered/amd/perf/mi30x/test_minimax_m25_perf_amd.py
+++ b/test/registered/amd/perf/mi30x/test_minimax_m25_perf_amd.py
@@ -12,44 +12,13 @@ Example usage:
 
 import os
 import unittest
-from typing import List
 
 from sglang.test.ci.ci_register import register_amd_ci
-from sglang.test.nightly_bench_utils import BenchmarkResult
+from sglang.test.nightly_bench_utils import generate_simple_markdown_report
 from sglang.test.nightly_utils import NightlyBenchmarkRunner
 from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
 
 register_amd_ci(est_time=5400, suite="nightly-perf-8-gpu-minimax-m25", nightly=True)
-
-
-def generate_simple_markdown_report(results: List[BenchmarkResult]) -> str:
-    """Generate a simplified markdown report without traces and cost columns.
-
-    Skips the first result if it's a warmup run (duplicate batch_size).
-    """
-    model_header = results[0].model_path
-    if results[0].run_name and results[0].run_name != "default":
-        model_header += f" ({results[0].run_name})"
-
-    gpu_config = os.getenv("GPU_CONFIG", "MI325")
-    if gpu_config:
-        model_header += f" [{gpu_config}]"
-
-    summary = f"### {model_header}\n"
-    summary += "| batch size | input len | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |\n"
-    summary += "| ---------- | --------- | ----------- | ------------------------ | ------------------------- | -------- |\n"
-
-    report_results = (
-        results[1:]
-        if len(results) > 1 and results[0].batch_size == results[1].batch_size
-        else results
-    )
-
-    for result in report_results:
-        itl = 1 / (result.output_throughput / result.batch_size) * 1000
-        summary += f"| {result.batch_size} | {result.input_len} | {result.latency:.2f} | {result.input_throughput:.2f} | {result.output_throughput:.2f} | {itl:.2f} |\n"
-
-    return summary
 
 
 MINIMAX_M25_MODEL_PATH = os.environ.get(

--- a/test/registered/amd/perf/mi30x/test_text_models_perf_amd.py
+++ b/test/registered/amd/perf/mi30x/test_text_models_perf_amd.py
@@ -8,12 +8,10 @@ Example usage:
     python -m pytest test_text_models_perf_amd.py -v
 """
 
-import os
 import unittest
-from typing import List
 
 from sglang.test.ci.ci_register import register_amd_ci
-from sglang.test.nightly_bench_utils import BenchmarkResult
+from sglang.test.nightly_bench_utils import generate_simple_markdown_report
 from sglang.test.nightly_utils import NightlyBenchmarkRunner
 from sglang.test.test_utils import (
     DEFAULT_URL_FOR_TEST,
@@ -26,37 +24,6 @@ from sglang.test.test_utils import (
 register_amd_ci(est_time=3600, suite="nightly-amd-perf-text-2-gpu", nightly=True)
 
 PROFILE_DIR = "performance_profiles_text_models_amd"
-
-
-def generate_simple_markdown_report(results: List[BenchmarkResult]) -> str:
-    """Generate a simplified markdown report without traces and cost columns.
-
-    Skips the first result if it's a warmup run (duplicate batch_size).
-    """
-    model_header = results[0].model_path
-    if results[0].run_name and results[0].run_name != "default":
-        model_header += f" ({results[0].run_name})"
-
-    gpu_config = os.getenv("GPU_CONFIG", "AMD")
-    if gpu_config:
-        model_header += f" [{gpu_config}]"
-
-    summary = f"### {model_header}\n"
-    summary += "| batch size | input len | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |\n"
-    summary += "| ---------- | --------- | ----------- | ------------------------ | ------------------------- | -------- |\n"
-
-    # Skip first result if it's a warmup (same batch_size as second result)
-    report_results = (
-        results[1:]
-        if len(results) > 1 and results[0].batch_size == results[1].batch_size
-        else results
-    )
-
-    for result in report_results:
-        itl = 1 / (result.output_throughput / result.batch_size) * 1000
-        summary += f"| {result.batch_size} | {result.input_len} | {result.latency:.2f} | {result.input_throughput:.2f} | {result.output_throughput:.2f} | {itl:.2f} |\n"
-
-    return summary
 
 
 class TestNightlyTextModelsPerfAMD(unittest.TestCase):
@@ -120,7 +87,10 @@ class TestNightlyTextModelsPerfAMD(unittest.TestCase):
 
                     if results:
                         self.runner.full_report += (
-                            generate_simple_markdown_report(results) + "\n"
+                            generate_simple_markdown_report(
+                                results, default_gpu_config="AMD"
+                            )
+                            + "\n"
                         )
         finally:
             self.runner.write_final_report()

--- a/test/registered/amd/perf/mi30x/test_vlms_perf_amd.py
+++ b/test/registered/amd/perf/mi30x/test_vlms_perf_amd.py
@@ -11,10 +11,9 @@ Example usage:
 import os
 import unittest
 import warnings
-from typing import List
 
 from sglang.test.ci.ci_register import register_amd_ci
-from sglang.test.nightly_bench_utils import BenchmarkResult
+from sglang.test.nightly_bench_utils import generate_simple_markdown_report
 from sglang.test.nightly_utils import NightlyBenchmarkRunner
 from sglang.test.test_utils import (
     DEFAULT_URL_FOR_TEST,
@@ -39,37 +38,6 @@ MODEL_DEFAULTS = [
         tp_size=2,
     ),
 ]
-
-
-def generate_simple_markdown_report(results: List[BenchmarkResult]) -> str:
-    """Generate a simplified markdown report without traces and cost columns.
-
-    Skips the first result if it's a warmup run (duplicate batch_size).
-    """
-    model_header = results[0].model_path
-    if results[0].run_name and results[0].run_name != "default":
-        model_header += f" ({results[0].run_name})"
-
-    gpu_config = os.getenv("GPU_CONFIG", "AMD")
-    if gpu_config:
-        model_header += f" [{gpu_config}]"
-
-    summary = f"### {model_header}\n"
-    summary += "| batch size | input len | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |\n"
-    summary += "| ---------- | --------- | ----------- | ------------------------ | ------------------------- | -------- |\n"
-
-    # Skip first result if it's a warmup (same batch_size as second result)
-    report_results = (
-        results[1:]
-        if len(results) > 1 and results[0].batch_size == results[1].batch_size
-        else results
-    )
-
-    for result in report_results:
-        itl = 1 / (result.output_throughput / result.batch_size) * 1000
-        summary += f"| {result.batch_size} | {result.input_len} | {result.latency:.2f} | {result.input_throughput:.2f} | {result.output_throughput:.2f} | {itl:.2f} |\n"
-
-    return summary
 
 
 class TestNightlyVLMsPerfAMD(unittest.TestCase):
@@ -133,7 +101,10 @@ class TestNightlyVLMsPerfAMD(unittest.TestCase):
 
                     if results:
                         self.runner.full_report += (
-                            generate_simple_markdown_report(results) + "\n"
+                            generate_simple_markdown_report(
+                                results, default_gpu_config="AMD"
+                            )
+                            + "\n"
                         )
         finally:
             self.runner.write_final_report()

--- a/test/registered/amd/perf/mi35x/test_deepseek_r1_mxfp4_ar_fusion_perf_mi35x.py
+++ b/test/registered/amd/perf/mi35x/test_deepseek_r1_mxfp4_ar_fusion_perf_mi35x.py
@@ -17,10 +17,9 @@ import os
 os.environ.setdefault("HF_HOME", "/data2/models/huggingface")
 os.environ.setdefault("HF_HUB_CACHE", "/data2/models/huggingface/hub")
 import unittest
-from typing import List
 
 from sglang.test.ci.ci_register import register_amd_ci
-from sglang.test.nightly_bench_utils import BenchmarkResult
+from sglang.test.nightly_bench_utils import generate_simple_markdown_report
 from sglang.test.nightly_utils import NightlyBenchmarkRunner
 from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
 
@@ -30,37 +29,6 @@ register_amd_ci(
     suite="nightly-perf-8-gpu-mi35x-deepseek-r1-mxfp4-ar-fusion",
     nightly=True,
 )
-
-
-def generate_simple_markdown_report(results: List[BenchmarkResult]) -> str:
-    """Generate a simplified markdown report without traces and cost columns.
-
-    Skips the first result if it's a warmup run (duplicate batch_size).
-    """
-    model_header = results[0].model_path
-    if results[0].run_name and results[0].run_name != "default":
-        model_header += f" ({results[0].run_name})"
-
-    gpu_config = os.getenv("GPU_CONFIG", "MI35x")
-    if gpu_config:
-        model_header += f" [{gpu_config}]"
-
-    summary = f"### {model_header}\n"
-    summary += "| batch size | input len | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |\n"
-    summary += "| ---------- | --------- | ----------- | ------------------------ | ------------------------- | -------- |\n"
-
-    # Skip first result if it's a warmup (same batch_size as second result)
-    report_results = (
-        results[1:]
-        if len(results) > 1 and results[0].batch_size == results[1].batch_size
-        else results
-    )
-
-    for result in report_results:
-        itl = 1 / (result.output_throughput / result.batch_size) * 1000
-        summary += f"| {result.batch_size} | {result.input_len} | {result.latency:.2f} | {result.input_throughput:.2f} | {result.output_throughput:.2f} | {itl:.2f} |\n"
-
-    return summary
 
 
 # Model path configuration for MI35x DeepSeek-R1-MXFP4
@@ -161,7 +129,10 @@ class TestDeepseekR1MXFP4ArFusionPerfMI35x(unittest.TestCase):
 
                     if results:
                         self.runner.full_report += (
-                            generate_simple_markdown_report(results) + "\n"
+                            generate_simple_markdown_report(
+                                results, default_gpu_config="MI35x"
+                            )
+                            + "\n"
                         )
         finally:
             self.runner.write_final_report()

--- a/test/registered/amd/perf/mi35x/test_deepseek_r1_mxfp4_kv_fp8_perf_mi35x.py
+++ b/test/registered/amd/perf/mi35x/test_deepseek_r1_mxfp4_kv_fp8_perf_mi35x.py
@@ -17,10 +17,9 @@ import os
 os.environ.setdefault("HF_HOME", "/data2/models/huggingface")
 os.environ.setdefault("HF_HUB_CACHE", "/data2/models/huggingface/hub")
 import unittest
-from typing import List
 
 from sglang.test.ci.ci_register import register_amd_ci
-from sglang.test.nightly_bench_utils import BenchmarkResult
+from sglang.test.nightly_bench_utils import generate_simple_markdown_report
 from sglang.test.nightly_utils import NightlyBenchmarkRunner
 from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
 
@@ -30,37 +29,6 @@ register_amd_ci(
     suite="nightly-perf-8-gpu-mi35x-deepseek-r1-mxfp4-kv-fp8",
     nightly=True,
 )
-
-
-def generate_simple_markdown_report(results: List[BenchmarkResult]) -> str:
-    """Generate a simplified markdown report without traces and cost columns.
-
-    Skips the first result if it's a warmup run (duplicate batch_size).
-    """
-    model_header = results[0].model_path
-    if results[0].run_name and results[0].run_name != "default":
-        model_header += f" ({results[0].run_name})"
-
-    gpu_config = os.getenv("GPU_CONFIG", "MI35x")
-    if gpu_config:
-        model_header += f" [{gpu_config}]"
-
-    summary = f"### {model_header}\n"
-    summary += "| batch size | input len | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |\n"
-    summary += "| ---------- | --------- | ----------- | ------------------------ | ------------------------- | -------- |\n"
-
-    # Skip first result if it's a warmup (same batch_size as second result)
-    report_results = (
-        results[1:]
-        if len(results) > 1 and results[0].batch_size == results[1].batch_size
-        else results
-    )
-
-    for result in report_results:
-        itl = 1 / (result.output_throughput / result.batch_size) * 1000
-        summary += f"| {result.batch_size} | {result.input_len} | {result.latency:.2f} | {result.input_throughput:.2f} | {result.output_throughput:.2f} | {itl:.2f} |\n"
-
-    return summary
 
 
 # Model path configuration for MI35x DeepSeek-R1-MXFP4
@@ -162,7 +130,10 @@ class TestDeepseekR1MXFP4KvFp8PerfMI35x(unittest.TestCase):
 
                     if results:
                         self.runner.full_report += (
-                            generate_simple_markdown_report(results) + "\n"
+                            generate_simple_markdown_report(
+                                results, default_gpu_config="MI35x"
+                            )
+                            + "\n"
                         )
         finally:
             self.runner.write_final_report()

--- a/test/registered/amd/perf/mi35x/test_deepseek_r1_mxfp4_perf_mi35x.py
+++ b/test/registered/amd/perf/mi35x/test_deepseek_r1_mxfp4_perf_mi35x.py
@@ -16,10 +16,9 @@ import os
 os.environ.setdefault("HF_HOME", "/data2/models/huggingface")
 os.environ.setdefault("HF_HUB_CACHE", "/data2/models/huggingface/hub")
 import unittest
-from typing import List
 
 from sglang.test.ci.ci_register import register_amd_ci
-from sglang.test.nightly_bench_utils import BenchmarkResult
+from sglang.test.nightly_bench_utils import generate_simple_markdown_report
 from sglang.test.nightly_utils import NightlyBenchmarkRunner
 from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
 
@@ -27,37 +26,6 @@ from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
 register_amd_ci(
     est_time=18000, suite="nightly-perf-8-gpu-mi35x-deepseek-r1-mxfp4", nightly=True
 )
-
-
-def generate_simple_markdown_report(results: List[BenchmarkResult]) -> str:
-    """Generate a simplified markdown report without traces and cost columns.
-
-    Skips the first result if it's a warmup run (duplicate batch_size).
-    """
-    model_header = results[0].model_path
-    if results[0].run_name and results[0].run_name != "default":
-        model_header += f" ({results[0].run_name})"
-
-    gpu_config = os.getenv("GPU_CONFIG", "MI35x")
-    if gpu_config:
-        model_header += f" [{gpu_config}]"
-
-    summary = f"### {model_header}\n"
-    summary += "| batch size | input len | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |\n"
-    summary += "| ---------- | --------- | ----------- | ------------------------ | ------------------------- | -------- |\n"
-
-    # Skip first result if it's a warmup (same batch_size as second result)
-    report_results = (
-        results[1:]
-        if len(results) > 1 and results[0].batch_size == results[1].batch_size
-        else results
-    )
-
-    for result in report_results:
-        itl = 1 / (result.output_throughput / result.batch_size) * 1000
-        summary += f"| {result.batch_size} | {result.input_len} | {result.latency:.2f} | {result.input_throughput:.2f} | {result.output_throughput:.2f} | {itl:.2f} |\n"
-
-    return summary
 
 
 # Model path configuration for MI35x DeepSeek-R1-MXFP4
@@ -163,7 +131,10 @@ class TestDeepseekR1MXFP4PerfMI35x(unittest.TestCase):
                     # Use simplified report format without traces
                     if results:
                         self.runner.full_report += (
-                            generate_simple_markdown_report(results) + "\n"
+                            generate_simple_markdown_report(
+                                results, default_gpu_config="MI35x"
+                            )
+                            + "\n"
                         )
         finally:
             self.runner.write_final_report()

--- a/test/registered/amd/perf/mi35x/test_deepseek_v32_basic_perf_mi35x.py
+++ b/test/registered/amd/perf/mi35x/test_deepseek_v32_basic_perf_mi35x.py
@@ -12,10 +12,9 @@ Example usage:
 
 import os
 import unittest
-from typing import List
 
 from sglang.test.ci.ci_register import register_amd_ci
-from sglang.test.nightly_bench_utils import BenchmarkResult
+from sglang.test.nightly_bench_utils import generate_simple_markdown_report
 from sglang.test.nightly_utils import NightlyBenchmarkRunner
 from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
 
@@ -23,37 +22,6 @@ from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
 register_amd_ci(
     est_time=5400, suite="nightly-perf-8-gpu-mi35x-deepseek-v32-basic", nightly=True
 )
-
-
-def generate_simple_markdown_report(results: List[BenchmarkResult]) -> str:
-    """Generate a simplified markdown report without traces and cost columns.
-
-    Skips the first result if it's a warmup run (duplicate batch_size).
-    """
-    model_header = results[0].model_path
-    if results[0].run_name and results[0].run_name != "default":
-        model_header += f" ({results[0].run_name})"
-
-    gpu_config = os.getenv("GPU_CONFIG", "MI35x")
-    if gpu_config:
-        model_header += f" [{gpu_config}]"
-
-    summary = f"### {model_header}\n"
-    summary += "| batch size | input len | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |\n"
-    summary += "| ---------- | --------- | ----------- | ------------------------ | ------------------------- | -------- |\n"
-
-    # Skip first result if it's a warmup (same batch_size as second result)
-    report_results = (
-        results[1:]
-        if len(results) > 1 and results[0].batch_size == results[1].batch_size
-        else results
-    )
-
-    for result in report_results:
-        itl = 1 / (result.output_throughput / result.batch_size) * 1000
-        summary += f"| {result.batch_size} | {result.input_len} | {result.latency:.2f} | {result.input_throughput:.2f} | {result.output_throughput:.2f} | {itl:.2f} |\n"
-
-    return summary
 
 
 # Model path can be overridden via environment variable
@@ -123,7 +91,10 @@ class TestNightlyDeepseekV32BasicPerformance(unittest.TestCase):
             # Use simplified report format without traces
             if results:
                 self.runner.full_report += (
-                    generate_simple_markdown_report(results) + "\n"
+                    generate_simple_markdown_report(
+                        results, default_gpu_config="MI35x"
+                    )
+                    + "\n"
                 )
 
             if not success:

--- a/test/registered/amd/perf/mi35x/test_deepseek_v32_mtp_perf_mi35x.py
+++ b/test/registered/amd/perf/mi35x/test_deepseek_v32_mtp_perf_mi35x.py
@@ -17,7 +17,7 @@ from typing import List, Optional, Tuple
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci
-from sglang.test.nightly_bench_utils import BenchmarkResult
+from sglang.test.nightly_bench_utils import BenchmarkResult, generate_simple_markdown_report
 from sglang.test.nightly_utils import NightlyBenchmarkRunner
 from sglang.test.test_utils import (
     DEFAULT_URL_FOR_TEST,
@@ -29,37 +29,6 @@ from sglang.test.test_utils import (
 register_amd_ci(
     est_time=5400, suite="nightly-perf-8-gpu-mi35x-deepseek-v32-mtp", nightly=True
 )
-
-
-def generate_simple_markdown_report(results: List[BenchmarkResult]) -> str:
-    """Generate a simplified markdown report without traces and cost columns.
-
-    Skips the first result if it's a warmup run (duplicate batch_size).
-    """
-    model_header = results[0].model_path
-    if results[0].run_name and results[0].run_name != "default":
-        model_header += f" ({results[0].run_name})"
-
-    gpu_config = os.getenv("GPU_CONFIG", "MI35x")
-    if gpu_config:
-        model_header += f" [{gpu_config}]"
-
-    summary = f"### {model_header}\n"
-    summary += "| batch size | input len | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |\n"
-    summary += "| ---------- | --------- | ----------- | ------------------------ | ------------------------- | -------- |\n"
-
-    # Skip first result if it's a warmup (same batch_size as second result)
-    report_results = (
-        results[1:]
-        if len(results) > 1 and results[0].batch_size == results[1].batch_size
-        else results
-    )
-
-    for result in report_results:
-        itl = 1 / (result.output_throughput / result.batch_size) * 1000
-        summary += f"| {result.batch_size} | {result.input_len} | {result.latency:.2f} | {result.input_throughput:.2f} | {result.output_throughput:.2f} | {itl:.2f} |\n"
-
-    return summary
 
 
 def _run_benchmark_with_timeout(
@@ -190,7 +159,10 @@ class TestNightlyDeepseekV32MTPPerformance(unittest.TestCase):
             # Use simplified report format without traces
             if results:
                 self.runner.full_report += (
-                    generate_simple_markdown_report(results) + "\n"
+                    generate_simple_markdown_report(
+                        results, default_gpu_config="MI35x"
+                    )
+                    + "\n"
                 )
 
             if not success:

--- a/test/registered/amd/perf/mi35x/test_grok1_int4_perf_mi35x.py
+++ b/test/registered/amd/perf/mi35x/test_grok1_int4_perf_mi35x.py
@@ -7,10 +7,9 @@ Registry: nightly-perf-8-gpu-mi35x-grok1-int4 suite
 
 import os
 import unittest
-from typing import List
 
 from sglang.test.ci.ci_register import register_amd_ci
-from sglang.test.nightly_bench_utils import BenchmarkResult
+from sglang.test.nightly_bench_utils import generate_simple_markdown_report
 from sglang.test.nightly_utils import NightlyBenchmarkRunner
 from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
 
@@ -18,37 +17,6 @@ from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
 register_amd_ci(
     est_time=1500, suite="nightly-perf-8-gpu-mi35x-grok1-int4", nightly=True
 )
-
-
-def generate_simple_markdown_report(results: List[BenchmarkResult]) -> str:
-    """Generate a simplified markdown report without traces and cost columns.
-
-    Skips the first result if it's a warmup run (duplicate batch_size).
-    """
-    model_header = results[0].model_path
-    if results[0].run_name and results[0].run_name != "default":
-        model_header += f" ({results[0].run_name})"
-
-    gpu_config = os.getenv("GPU_CONFIG", "MI35x")
-    if gpu_config:
-        model_header += f" [{gpu_config}]"
-
-    summary = f"### {model_header}\n"
-    summary += "| batch size | input len | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |\n"
-    summary += "| ---------- | --------- | ----------- | ------------------------ | ------------------------- | -------- |\n"
-
-    # Skip first result if it's a warmup (same batch_size as second result)
-    report_results = (
-        results[1:]
-        if len(results) > 1 and results[0].batch_size == results[1].batch_size
-        else results
-    )
-
-    for result in report_results:
-        itl = 1 / (result.output_throughput / result.batch_size) * 1000
-        summary += f"| {result.batch_size} | {result.input_len} | {result.latency:.2f} | {result.input_throughput:.2f} | {result.output_throughput:.2f} | {itl:.2f} |\n"
-
-    return summary
 
 
 # Model and tokenizer paths can be overridden via environment variables
@@ -119,7 +87,10 @@ class TestGrok1INT4PerfMI35x(unittest.TestCase):
 
             if results:
                 self.runner.full_report += (
-                    generate_simple_markdown_report(results) + "\n"
+                    generate_simple_markdown_report(
+                        results, default_gpu_config="MI35x"
+                    )
+                    + "\n"
                 )
 
             self.assertTrue(success, "Benchmark failed for Grok-1 INT4 on MI35x")

--- a/test/registered/amd/perf/mi35x/test_grok2_perf_mi35x.py
+++ b/test/registered/amd/perf/mi35x/test_grok2_perf_mi35x.py
@@ -7,46 +7,14 @@ Registry: nightly-perf-8-gpu-mi35x-grok2 suite
 
 import os
 import unittest
-from typing import List
 
 from sglang.test.ci.ci_register import register_amd_ci
-from sglang.test.nightly_bench_utils import BenchmarkResult
+from sglang.test.nightly_bench_utils import generate_simple_markdown_report
 from sglang.test.nightly_utils import NightlyBenchmarkRunner
 from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
 
 # Register for AMD CI - Grok-2 benchmark on MI35x (~25 min)
 register_amd_ci(est_time=1500, suite="nightly-perf-8-gpu-mi35x-grok2", nightly=True)
-
-
-def generate_simple_markdown_report(results: List[BenchmarkResult]) -> str:
-    """Generate a simplified markdown report without traces and cost columns.
-
-    Skips the first result if it's a warmup run (duplicate batch_size).
-    """
-    model_header = results[0].model_path
-    if results[0].run_name and results[0].run_name != "default":
-        model_header += f" ({results[0].run_name})"
-
-    gpu_config = os.getenv("GPU_CONFIG", "MI35x")
-    if gpu_config:
-        model_header += f" [{gpu_config}]"
-
-    summary = f"### {model_header}\n"
-    summary += "| batch size | input len | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |\n"
-    summary += "| ---------- | --------- | ----------- | ------------------------ | ------------------------- | -------- |\n"
-
-    # Skip first result if it's a warmup (same batch_size as second result)
-    report_results = (
-        results[1:]
-        if len(results) > 1 and results[0].batch_size == results[1].batch_size
-        else results
-    )
-
-    for result in report_results:
-        itl = 1 / (result.output_throughput / result.batch_size) * 1000
-        summary += f"| {result.batch_size} | {result.input_len} | {result.latency:.2f} | {result.input_throughput:.2f} | {result.output_throughput:.2f} | {itl:.2f} |\n"
-
-    return summary
 
 
 # Model and tokenizer paths can be overridden via environment variables
@@ -119,7 +87,10 @@ class TestGrok2PerfMI35x(unittest.TestCase):
 
             if results:
                 self.runner.full_report += (
-                    generate_simple_markdown_report(results) + "\n"
+                    generate_simple_markdown_report(
+                        results, default_gpu_config="MI35x"
+                    )
+                    + "\n"
                 )
 
             self.assertTrue(success, "Benchmark failed for Grok-2 on MI35x")

--- a/test/registered/amd/perf/mi35x/test_minimax_m25_perf_mi35x.py
+++ b/test/registered/amd/perf/mi35x/test_minimax_m25_perf_mi35x.py
@@ -16,46 +16,15 @@ os.environ.setdefault("HF_HOME", "/data2/models/huggingface")
 os.environ.setdefault("HF_HUB_CACHE", "/data2/models/huggingface/hub")
 
 import unittest
-from typing import List
 
 from sglang.test.ci.ci_register import register_amd_ci
-from sglang.test.nightly_bench_utils import BenchmarkResult
+from sglang.test.nightly_bench_utils import generate_simple_markdown_report
 from sglang.test.nightly_utils import NightlyBenchmarkRunner
 from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
 
 register_amd_ci(
     est_time=5400, suite="nightly-perf-8-gpu-mi35x-minimax-m25", nightly=True
 )
-
-
-def generate_simple_markdown_report(results: List[BenchmarkResult]) -> str:
-    """Generate a simplified markdown report without traces and cost columns.
-
-    Skips the first result if it's a warmup run (duplicate batch_size).
-    """
-    model_header = results[0].model_path
-    if results[0].run_name and results[0].run_name != "default":
-        model_header += f" ({results[0].run_name})"
-
-    gpu_config = os.getenv("GPU_CONFIG", "MI35x")
-    if gpu_config:
-        model_header += f" [{gpu_config}]"
-
-    summary = f"### {model_header}\n"
-    summary += "| batch size | input len | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |\n"
-    summary += "| ---------- | --------- | ----------- | ------------------------ | ------------------------- | -------- |\n"
-
-    report_results = (
-        results[1:]
-        if len(results) > 1 and results[0].batch_size == results[1].batch_size
-        else results
-    )
-
-    for result in report_results:
-        itl = 1 / (result.output_throughput / result.batch_size) * 1000
-        summary += f"| {result.batch_size} | {result.input_len} | {result.latency:.2f} | {result.input_throughput:.2f} | {result.output_throughput:.2f} | {itl:.2f} |\n"
-
-    return summary
 
 
 MINIMAX_M25_MODEL_PATH = os.environ.get(
@@ -129,7 +98,10 @@ class TestNightlyMiniMaxM25PerformanceMI35x(unittest.TestCase):
 
             if results:
                 self.runner.full_report += (
-                    generate_simple_markdown_report(results) + "\n"
+                    generate_simple_markdown_report(
+                        results, default_gpu_config="MI35x"
+                    )
+                    + "\n"
                 )
 
             self.assertTrue(success, "Benchmark failed for MiniMax-M2.5 on MI35x")


### PR DESCRIPTION
## Summary
- Move duplicated `generate_simple_markdown_report` from **19 AMD perf test files** into `nightly_bench_utils.py` as a shared utility
- Add `default_gpu_config` parameter to preserve each file's original GPU label ("MI325", "MI35x", "AMD", or "")
- Remove ~530 lines of copy-pasted code across mi30x and mi35x perf tests
- Keep the separate-file architecture that gives AMD CI granular per-model scheduling

## Motivation
Every AMD perf test file contained an identical copy of `generate_simple_markdown_report` (a simplified markdown table without Perfetto traces or cost columns). This made maintenance error-prone — any bug fix or format change required updating 19+ files. The NV/GB300 tests (PR #21487) already use shared infrastructure (`run_combined_tests`); this brings AMD perf tests closer to parity.

## Changes
| File | Change |
|------|--------|
| `python/sglang/test/nightly_bench_utils.py` | Added `generate_simple_markdown_report()` with `default_gpu_config` param |
| 11 mi30x perf tests | Removed local function, import from shared utility |
| 8 mi35x perf tests | Removed local function, import from shared utility |

## Test plan
- [x] `python3 -m ruff check --select=F401,F821` passes on all 19 files
- [x] `python3 -c "import ast; ast.parse(...)"` passes on all 19 files
- [x] No behavior change — markdown output is byte-identical to before
- [ ] AMD nightly CI: any existing perf suite exercises the shared function