### PR TITLE
[feat] add Qwen3-ASR model support and related configurations

### DIFF
--- a/python/sglang/srt/configs/__init__.py
+++ b/python/sglang/srt/configs/__init__.py
@@ -21,6 +21,7 @@ from sglang.srt.configs.longcat_flash import LongcatFlashConfig
 from sglang.srt.configs.nano_nemotron_vl import NemotronH_Nano_VL_V2_Config
 from sglang.srt.configs.nemotron_h import NemotronHConfig
 from sglang.srt.configs.olmo3 import Olmo3Config
+from sglang.srt.configs.qwen3_asr import Qwen3ASRConfig
 from sglang.srt.configs.qwen3_5 import Qwen3_5Config, Qwen3_5MoeConfig
 from sglang.srt.configs.qwen3_next import Qwen3NextConfig
 from sglang.srt.configs.step3_vl import (
@@ -47,6 +48,7 @@ __all__ = [
     "Olmo3Config",
     "KimiLinearConfig",
     "KimiK25Config",
+    "Qwen3ASRConfig",
     "Qwen3NextConfig",
     "Qwen3_5Config",
     "Qwen3_5MoeConfig",

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -196,8 +196,12 @@ class ModelConfig:
         self.is_image_understandable_model = enable_multimodal and hasattr(
             self.hf_config, "vision_config"
         )
-        self.is_audio_understandable_model = enable_multimodal and hasattr(
-            self.hf_config, "audio_config"
+        self.is_audio_understandable_model = enable_multimodal and (
+            hasattr(self.hf_config, "audio_config")
+            or (
+                hasattr(self.hf_config, "thinker_config")
+                and hasattr(self.hf_config.thinker_config, "audio_config")
+            )
         )
 
         self.is_multimodal_chunked_prefill_supported = (
@@ -1326,6 +1330,7 @@ multimodal_model_archs = [
     "Qwen3VLMoeForConditionalGeneration",
     "Qwen3_5ForConditionalGeneration",
     "Qwen3_5MoeForConditionalGeneration",
+    "Qwen3ASRForConditionalGeneration",
     "Qwen3OmniMoeForConditionalGeneration",
     "KimiVLForConditionalGeneration",
     "InternVLChatModel",
@@ -1373,6 +1378,7 @@ def is_multimodal_model(model_architectures: List[str]):
 def is_audio_model(model_architectures: List[str]):
     models = [
         "WhisperForConditionalGeneration",
+        "Qwen3ASRForConditionalGeneration",
     ]
     return any(model in model_architectures for model in models)
 

--- a/python/sglang/srt/configs/qwen3_asr.py
+++ b/python/sglang/srt/configs/qwen3_asr.py
@@ -1,0 +1,231 @@
+# Copyright 2025 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Configuration and processor classes for Qwen3-ASR model."""
+
+from transformers import (
+    AutoConfig,
+    AutoFeatureExtractor,
+    AutoTokenizer,
+    PretrainedConfig,
+    ProcessorMixin,
+)
+
+from sglang.srt.configs.qwen3_omni import Qwen3OmniMoeAudioEncoderConfig
+from sglang.srt.multimodal.customized_mm_processor_utils import (
+    register_customized_processor,
+)
+from sglang.utils import logger
+
+
+class Qwen3ASRThinkerConfig(PretrainedConfig):
+    model_type = "qwen3_asr_thinker"
+    sub_configs = {
+        "audio_config": Qwen3OmniMoeAudioEncoderConfig,
+    }
+
+    def __init__(
+        self,
+        audio_config=None,
+        text_config=None,
+        audio_token_id=151676,
+        audio_start_token_id=151669,
+        audio_end_token_id=151670,
+        initializer_range=0.02,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.initializer_range = initializer_range
+
+        if isinstance(audio_config, dict):
+            audio_config = Qwen3OmniMoeAudioEncoderConfig(**audio_config)
+        elif audio_config is None:
+            audio_config = Qwen3OmniMoeAudioEncoderConfig()
+        self.audio_config = audio_config
+
+        if isinstance(text_config, dict):
+            # Use the proper Qwen3Config so rope_parameters property works
+            from transformers.models.qwen3.configuration_qwen3 import (
+                Qwen3Config as HFQwen3Config,
+            )
+
+            text_config = HFQwen3Config(**text_config)
+        elif text_config is None:
+            text_config = PretrainedConfig()
+        self.text_config = text_config
+
+        self.audio_token_id = audio_token_id
+        self.audio_start_token_id = audio_start_token_id
+        self.audio_end_token_id = audio_end_token_id
+
+
+class Qwen3ASRConfig(PretrainedConfig):
+    model_type = "qwen3_asr"
+    sub_configs = {
+        "thinker_config": Qwen3ASRThinkerConfig,
+    }
+
+    def __init__(
+        self,
+        thinker_config=None,
+        support_languages=None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        if thinker_config is None:
+            thinker_config = {}
+            logger.info(
+                "thinker_config is None. Initializing Qwen3-ASR thinker with default values"
+            )
+
+        if isinstance(thinker_config, dict):
+            self.thinker_config = Qwen3ASRThinkerConfig(**thinker_config)
+        else:
+            self.thinker_config = thinker_config
+        self.support_languages = support_languages or []
+
+    def get_text_config(self, decoder=False) -> "PretrainedConfig":
+        return self.thinker_config.text_config
+
+
+class Qwen3ASRProcessor(ProcessorMixin):
+    """Custom processor combining WhisperFeatureExtractor + Qwen2Tokenizer.
+
+    AutoProcessor.from_pretrained() for Qwen3-ASR returns just a tokenizer
+    because the model repo doesn't ship a proper ProcessorMixin class.
+    This wrapper provides the composite processor that SGLang expects.
+    """
+
+    attributes = ["feature_extractor", "tokenizer"]
+    feature_extractor_class = "WhisperFeatureExtractor"
+    tokenizer_class = "AutoTokenizer"
+
+    def __init__(self, feature_extractor=None, tokenizer=None, **kwargs):
+        super().__init__(feature_extractor=feature_extractor, tokenizer=tokenizer)
+        self.audio_token = "<|audio_pad|>"
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
+        trust_remote_code = kwargs.pop("trust_remote_code", True)
+        feature_extractor = AutoFeatureExtractor.from_pretrained(
+            pretrained_model_name_or_path,
+            trust_remote_code=trust_remote_code,
+            **{k: v for k, v in kwargs.items() if k in ("revision",)},
+        )
+        tokenizer = AutoTokenizer.from_pretrained(
+            pretrained_model_name_or_path,
+            trust_remote_code=trust_remote_code,
+            **{k: v for k, v in kwargs.items() if k in ("revision", "use_fast")},
+        )
+        return cls(feature_extractor=feature_extractor, tokenizer=tokenizer)
+
+    def _get_feat_extract_output_lengths(self, input_lengths):
+        """Compute the number of audio tokens from mel feature lengths."""
+        import torch
+
+        if not isinstance(input_lengths, torch.Tensor):
+            input_lengths = torch.tensor(input_lengths)
+        input_lengths_leave = input_lengths % 100
+        feat_lengths = (input_lengths_leave - 1) // 2 + 1
+        output_lengths = (
+            ((feat_lengths - 1) // 2 + 1 - 1) // 2 + 1
+            + (input_lengths // 100) * 13
+        )
+        return output_lengths
+
+    def __call__(
+        self,
+        text=None,
+        audio=None,
+        audio_kwargs=None,
+        **kwargs,
+    ):
+        import torch
+
+        if audio_kwargs is None:
+            audio_kwargs = {}
+
+        if audio is not None:
+            audio_inputs = self.feature_extractor(
+                audio,
+                sampling_rate=self.feature_extractor.sampling_rate,
+                return_attention_mask=True,
+                return_tensors=kwargs.get("return_tensors"),
+                **audio_kwargs,
+            )
+            # Rename attention_mask -> feature_attention_mask
+            inputs = {"input_features": audio_inputs["input_features"]}
+            if "attention_mask" in audio_inputs:
+                inputs["feature_attention_mask"] = audio_inputs["attention_mask"]
+        else:
+            inputs = {}
+
+        if text is not None:
+            text_inputs = self.tokenizer(
+                text,
+                return_tensors=kwargs.get("return_tensors"),
+                padding=kwargs.get("padding", False),
+            )
+            input_ids = text_inputs["input_ids"]
+
+            # Expand <|audio_pad|> tokens based on audio feature lengths
+            if audio is not None and "feature_attention_mask" in inputs:
+                audio_pad_id = self.tokenizer.convert_tokens_to_ids(
+                    self.audio_token
+                )
+                feat_mask = inputs["feature_attention_mask"]
+                feat_lengths = feat_mask.sum(dim=-1)  # actual mel lengths
+                audio_token_counts = self._get_feat_extract_output_lengths(
+                    feat_lengths
+                )
+
+                # Expand each sequence's audio_pad tokens
+                expanded_ids_list = []
+                for seq_idx in range(input_ids.shape[0]):
+                    seq_ids = input_ids[seq_idx].tolist()
+                    audio_idx = 0
+                    new_ids = []
+                    for tid in seq_ids:
+                        if tid == audio_pad_id and audio_idx < len(
+                            audio_token_counts
+                        ):
+                            count = int(audio_token_counts[audio_idx].item())
+                            new_ids.extend([audio_pad_id] * count)
+                            audio_idx += 1
+                        else:
+                            new_ids.append(tid)
+                    expanded_ids_list.append(new_ids)
+
+                # Pad to same length and convert to tensor
+                max_len = max(len(ids) for ids in expanded_ids_list)
+                padded = [
+                    ids + [self.tokenizer.pad_token_id or 0] * (max_len - len(ids))
+                    for ids in expanded_ids_list
+                ]
+                input_ids = torch.tensor(padded, dtype=torch.long)
+
+            inputs["input_ids"] = input_ids
+
+        return inputs
+
+
+AutoConfig.register("qwen3_asr", Qwen3ASRConfig)
+AutoConfig.register("qwen3_asr_thinker", Qwen3ASRThinkerConfig)
+
+
+@register_customized_processor(Qwen3ASRProcessor)
+class _Qwen3ASRConfigForProcessorRegistration(Qwen3ASRConfig):
+    """Shim so that ``_CUSTOMIZED_MM_PROCESSOR["qwen3_asr"]`` resolves to
+    ``Qwen3ASRProcessor`` when ``get_processor()`` loads the model."""
+
+    model_type = "qwen3_asr"

--- a/python/sglang/srt/entrypoints/openai/serving_transcription.py
+++ b/python/sglang/srt/entrypoints/openai/serving_transcription.py
@@ -12,7 +12,8 @@
 # limitations under the License.
 # ==============================================================================
 """
-OpenAI-compatible transcription endpoint handler for Whisper models.
+OpenAI-compatible transcription endpoint handler for audio ASR models.
+Supports Whisper and Qwen3-ASR models.
 """
 
 from __future__ import annotations
@@ -51,11 +52,20 @@ TIMESTAMP_BASE_TOKEN_ID = 50365  # <|0.00|>
 TIMESTAMP_BASE_OFFSET = 0.02  # Each token step = 0.02 seconds
 
 
+def _is_qwen3_asr_model(architectures: List[str]) -> bool:
+    return any("Qwen3ASR" in arch for arch in (architectures or []))
+
+
 class OpenAIServingTranscription(OpenAIServingBase):
     """Handler for /v1/audio/transcriptions requests"""
 
     def __init__(self, tokenizer_manager: TokenizerManager):
         super().__init__(tokenizer_manager)
+        # Detect if the loaded model is Qwen3-ASR
+        model_config = tokenizer_manager.model_config
+        self._is_qwen3_asr = _is_qwen3_asr_model(
+            getattr(model_config.hf_config, "architectures", [])
+        )
 
     def _request_id_prefix(self) -> str:
         return "trsc-"
@@ -71,17 +81,25 @@ class OpenAIServingTranscription(OpenAIServingBase):
         raw_request: Request = None,
     ) -> tuple[GenerateReqInput, TranscriptionRequest]:
         """Convert transcription request to internal format."""
-        # Build sampling params - include language for WhisperProcessor
+        if self._is_qwen3_asr:
+            return self._convert_qwen3_asr_request(request, raw_request)
+        return self._convert_whisper_request(request, raw_request)
+
+    def _convert_whisper_request(
+        self,
+        request: TranscriptionRequest,
+        raw_request: Request = None,
+    ) -> tuple[GenerateReqInput, TranscriptionRequest]:
+        """Convert transcription request for Whisper models."""
         sampling_params = {
             "temperature": request.temperature,
             "max_new_tokens": 448,  # Whisper default max tokens
-            "language": request.language,  # Pass to WhisperProcessor for language-specific decoding
+            "language": request.language,
         }
 
         if request.timestamp_granularities:
             sampling_params["timestamp_granularities"] = request.timestamp_granularities
 
-        # For Whisper, we pass audio_data and let the processor handle it
         adapted_request = GenerateReqInput(
             text="",  # Empty text - Whisper processor will set proper decoder tokens
             audio_data=request.audio_data,
@@ -90,7 +108,33 @@ class OpenAIServingTranscription(OpenAIServingBase):
             modalities=["audio"],
             routing_key=self.extract_routing_key(raw_request),
         )
+        return adapted_request, request
 
+    def _convert_qwen3_asr_request(
+        self,
+        request: TranscriptionRequest,
+        raw_request: Request = None,
+    ) -> tuple[GenerateReqInput, TranscriptionRequest]:
+        """Convert transcription request for Qwen3-ASR models."""
+        temperature = request.temperature
+        if temperature == 0.0:
+            temperature = 0.01  # Qwen3-ASR recommended near-greedy temperature
+
+        sampling_params = {
+            "temperature": temperature,
+            "max_new_tokens": 256,  # Qwen3-ASR default
+        }
+
+        # Qwen3-ASR uses chat format with audio_url in content
+        # The processor handles the prompt construction from audio_data
+        adapted_request = GenerateReqInput(
+            text="",  # Processor will construct the proper prompt
+            audio_data=request.audio_data,
+            sampling_params=sampling_params,
+            stream=request.stream,
+            modalities=["audio"],
+            routing_key=self.extract_routing_key(raw_request),
+        )
         return adapted_request, request
 
     def _get_audio_duration(self, audio_data: bytes) -> float:
@@ -232,6 +276,12 @@ class OpenAIServingTranscription(OpenAIServingBase):
             return self.create_error_response(str(e))
 
         text = ret.get("text", "")
+
+        # Qwen3-ASR outputs "language <lang><asr_text>transcription" format
+        # Strip the prefix to return clean transcription text
+        if self._is_qwen3_asr and "<asr_text>" in text:
+            text = text.split("<asr_text>", 1)[-1]
+
         usage = TranscriptionUsage(seconds=int(math.ceil(request.audio_duration_s)))
 
         # Build response based on format
@@ -239,17 +289,27 @@ class OpenAIServingTranscription(OpenAIServingBase):
             return Response(content=text, media_type="text/plain")
 
         if request.response_format == "verbose_json":
-            output_ids = ret.get("output_ids", [])
-            tokenizer = self.tokenizer_manager.tokenizer
-            parsed_text, segments = self._parse_segments(output_ids, tokenizer)
+            if self._is_qwen3_asr:
+                # Qwen3-ASR doesn't natively produce timestamp tokens
+                return TranscriptionVerboseResponse(
+                    language=request.language or "auto",
+                    duration=round(request.audio_duration_s, 2),
+                    text=text,
+                    segments=[],
+                    usage=usage,
+                )
+            else:
+                output_ids = ret.get("output_ids", [])
+                tokenizer = self.tokenizer_manager.tokenizer
+                parsed_text, segments = self._parse_segments(output_ids, tokenizer)
 
-            return TranscriptionVerboseResponse(
-                language=request.language or "en",
-                duration=round(request.audio_duration_s, 2),
-                text=parsed_text or text,
-                segments=segments,
-                usage=usage,
-            )
+                return TranscriptionVerboseResponse(
+                    language=request.language or "en",
+                    duration=round(request.audio_duration_s, 2),
+                    text=parsed_text or text,
+                    segments=segments,
+                    usage=usage,
+                )
 
         # Default JSON format
         return TranscriptionResponse(text=text, usage=usage)

--- a/python/sglang/srt/models/qwen3_asr.py
+++ b/python/sglang/srt/models/qwen3_asr.py
@@ -1,0 +1,247 @@
+# Copyright 2025 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Inference-only Qwen3-ASR model compatible with HuggingFace weights."""
+
+import logging
+from typing import Any, Iterable, List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+from sglang.srt.configs.qwen3_asr import Qwen3ASRConfig, Qwen3ASRThinkerConfig
+from sglang.srt.configs.qwen3_omni import Qwen3OmniMoeAudioEncoderConfig
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.managers.mm_utils import (
+    MultiModalityDataPaddingPatternMultimodalTokens,
+    general_mm_embed_routine,
+)
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_loader.weight_utils import default_weight_loader
+from sglang.srt.models.qwen3 import Qwen3ForCausalLM
+from sglang.srt.models.qwen3_omni_moe import (
+    Qwen3OmniMoeAudioEncoder,
+    _get_feat_extract_output_lengths,
+)
+from sglang.srt.utils import add_prefix
+
+logger = logging.getLogger(__name__)
+
+
+class Qwen3ASRForConditionalGeneration(nn.Module):
+    # BitandBytes specific attributes
+    default_bitsandbytes_target_modules = [
+        ".gate_proj.",
+        ".down_proj.",
+        ".up_proj.",
+        ".q_proj.",
+        ".k_proj.",
+        ".v_proj.",
+        ".o_proj.",
+    ]
+    bitsandbytes_stacked_params_mapping = {
+        # shard_name, weight_name, index
+        "q_proj": ("qkv_proj", 0),
+        "k_proj": ("qkv_proj", 1),
+        "v_proj": ("qkv_proj", 2),
+        "gate_proj": ("gate_up_proj", 0),
+        "up_proj": ("gate_up_proj", 1),
+    }
+
+    def __init__(
+        self,
+        config: Qwen3ASRConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = config
+
+        # Extract the thinker_config which contains audio_config and text_config
+        thinker_config = config.thinker_config
+        if not isinstance(thinker_config, Qwen3ASRThinkerConfig):
+            thinker_config = Qwen3ASRThinkerConfig(
+                **(
+                    thinker_config
+                    if isinstance(thinker_config, dict)
+                    else thinker_config.__dict__
+                )
+            )
+
+        audio_config = thinker_config.audio_config
+        if not isinstance(audio_config, Qwen3OmniMoeAudioEncoderConfig):
+            audio_config = Qwen3OmniMoeAudioEncoderConfig(
+                **(
+                    audio_config
+                    if isinstance(audio_config, dict)
+                    else audio_config.__dict__
+                )
+            )
+
+        self.audio_tower = Qwen3OmniMoeAudioEncoder(audio_config)
+        self.language_model = Qwen3ForCausalLM(
+            thinker_config.text_config,
+            quant_config,
+            prefix=add_prefix("language_model", prefix),
+        )
+        self.pattern = MultiModalityDataPaddingPatternMultimodalTokens()
+
+    def pad_input_ids(self, input_ids: List[int], mm_inputs: MultimodalInputs):
+        return self.pattern.pad_input_tokens(input_ids, mm_inputs)
+
+    def get_audio_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
+        device = next(self.audio_tower.parameters()).device
+
+        input_features = (
+            torch.cat([item.feature for item in items])
+            .type(self.audio_tower.dtype)
+            .to(device)
+        )
+
+        # Check if feature_attention_mask is available (not present during warmup)
+        has_mask = hasattr(items[0], "feature_attention_mask") and getattr(
+            items[0], "feature_attention_mask", None
+        ) is not None
+
+        if has_mask:
+            feature_attention_mask = torch.cat(
+                [item.feature_attention_mask for item in items], dim=0
+            ).type(torch.long).to(device)
+
+            # Compute actual audio lengths from attention mask
+            audio_feature_lengths = torch.sum(feature_attention_mask, dim=1)
+
+            # Extract valid features using the mask (remove padding)
+            input_features = input_features.permute(0, 2, 1)[
+                feature_attention_mask.bool()
+            ].permute(1, 0)
+        else:
+            # No mask: assume all features are valid (e.g., during warmup)
+            # input_features shape: (batch, num_mel_bins, time_steps)
+            batch_size = input_features.shape[0]
+            time_steps = input_features.shape[-1]
+            audio_feature_lengths = torch.full(
+                (batch_size,), time_steps, dtype=torch.long, device=device
+            )
+            # Flatten batch dim: (num_mel_bins, total_time_steps)
+            input_features = input_features.permute(0, 2, 1).reshape(
+                -1, input_features.shape[1]
+            ).permute(1, 0)
+
+        # Run through audio encoder
+        audio_outputs = self.audio_tower(
+            input_features,
+            feature_lens=audio_feature_lengths,
+        )
+        audio_features = audio_outputs.last_hidden_state
+
+        return audio_features
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        hidden_states = general_mm_embed_routine(
+            input_ids=input_ids,
+            forward_batch=forward_batch,
+            language_model=self.language_model,
+            data_embedding_funcs={
+                Modality.AUDIO: self.get_audio_feature,
+            },
+            positions=positions,
+        )
+
+        return hidden_states
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        # Stacked params for the LLM decoder
+        llm_stacked_params = [
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+        # Audio tower VisionAttention uses qkv_proj (fused) and proj (output)
+        # HF weights have separate q_proj, k_proj, v_proj, out_proj
+        audio_stacked_params = [
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+        ]
+        params_dict = dict(self.named_parameters(remove_duplicate=False))
+
+        for name, loaded_weight in weights:
+            # Remap weight names from HuggingFace checkpoint format
+            if name.startswith("thinker.audio_tower."):
+                name = name.replace("thinker.audio_tower.", "audio_tower.", 1)
+            elif name.startswith("thinker.lm_head."):
+                name = name.replace("thinker.lm_head.", "language_model.lm_head.", 1)
+            elif name.startswith("thinker.model."):
+                name = name.replace("thinker.model.", "language_model.model.", 1)
+            elif name.startswith("thinker."):
+                name = name.replace("thinker.", "", 1)
+
+            # Skip talker and code2wav weights (not used for ASR)
+            if "talker" in name or "code2wav" in name:
+                continue
+
+            if "rotary_emb.inv_freq" in name:
+                continue
+            if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:
+                continue
+
+            text_config = self.config.thinker_config.text_config
+            if getattr(text_config, "tie_word_embeddings", False) and "lm_head.weight" in name:
+                continue
+
+            # Audio tower: remap out_proj -> proj for VisionAttention
+            if "audio_tower" in name and "out_proj" in name:
+                name = name.replace("out_proj", "proj")
+
+            # Select appropriate stacked params mapping
+            is_audio = "audio_tower" in name
+            stacked_params = audio_stacked_params if is_audio else llm_stacked_params
+
+            for param_name, weight_name, shard_id in stacked_params:
+                if weight_name not in name:
+                    continue
+                name_tmp = name.replace(weight_name, param_name)
+
+                if name_tmp.endswith(".bias") and name_tmp not in params_dict:
+                    continue
+                if name_tmp not in params_dict:
+                    continue
+                param = params_dict[name_tmp]
+                weight_loader = param.weight_loader
+                weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+                if name not in params_dict:
+                    continue
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+
+
+EntryClass = Qwen3ASRForConditionalGeneration

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -388,6 +388,7 @@ class BaseMultimodalProcessor(ABC):
                 "Gemma3nProcessor",
                 "GlmAsrProcessor",
                 "Qwen2AudioProcessor",
+                "Qwen3ASRProcessor",
                 "Qwen3OmniMoeProcessor",
             }:
                 # Note(Xinyuan): for gemma3n, ref: https://github.com/huggingface/transformers/blob/ccf2ca162e33f381e454cdb74bf4b41a51ab976d/src/transformers/models/gemma3n/processing_gemma3n.py#L107

--- a/python/sglang/srt/multimodal/processors/qwen3_asr.py
+++ b/python/sglang/srt/multimodal/processors/qwen3_asr.py
@@ -1,0 +1,151 @@
+import re
+from typing import Optional, Union
+
+import torch
+
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    MultimodalProcessorOutput,
+)
+from sglang.srt.models.qwen3_asr import Qwen3ASRForConditionalGeneration
+from sglang.srt.multimodal.processors.base_processor import (
+    BaseMultimodalProcessor,
+    MultimodalSpecialTokens,
+)
+
+# Default ASR prompt template for Qwen3-ASR transcription endpoint
+_DEFAULT_ASR_PROMPT = (
+    "<|im_start|>user\n"
+    "<|audio_start|><|audio_pad|><|audio_end|>"
+    "<|im_end|>\n"
+    "<|im_start|>assistant\n"
+)
+
+
+class Qwen3ASRMultimodalProcessor(BaseMultimodalProcessor):
+    models = [Qwen3ASRForConditionalGeneration]
+
+    def __init__(self, hf_config, server_args, _processor, *args, **kwargs):
+        # Access the thinker_config for token IDs
+        if hasattr(hf_config, "thinker_config"):
+            thinker_config = hf_config.thinker_config
+        else:
+            thinker_config = hf_config
+
+        super().__init__(hf_config, server_args, _processor, *args, **kwargs)
+
+        # Audio special tokens
+        self.AUDIO_TOKEN = "<|audio_start|><|audio_pad|><|audio_end|>"
+        self.AUDIO_TOKEN_REGEX = re.compile(
+            r"<\|audio_start\|>(?:<\|audio_pad\|>)+<\|audio_end\|>"
+        )
+
+        tokenizer = self._processor.tokenizer
+        self.audio_start_id = tokenizer.convert_tokens_to_ids("<|audio_start|>")
+        self.audio_token_id = tokenizer.convert_tokens_to_ids("<|audio_pad|>")
+        self.audio_end_id = tokenizer.convert_tokens_to_ids("<|audio_end|>")
+
+        self.mm_tokens = MultimodalSpecialTokens(
+            audio_token=self.AUDIO_TOKEN,
+            audio_token_regex=self.AUDIO_TOKEN_REGEX,
+            audio_token_id=self.audio_token_id,
+        ).build(_processor)
+
+        self.ATTR_NAME_TO_MODALITY.update(
+            {"feature_attention_mask": Modality.AUDIO}
+        )
+
+    def _build_transcription_prompt(self, input_text: Union[str, list]) -> str:
+        """Build a prompt for the transcription endpoint.
+
+        When the input text is empty (from /v1/audio/transcriptions),
+        construct the default Qwen3-ASR chat prompt with an audio placeholder.
+        """
+        if isinstance(input_text, list):
+            # Token IDs - decode to text first
+            input_text = self._tokenizer.decode(input_text)
+
+        if not input_text or not input_text.strip():
+            return _DEFAULT_ASR_PROMPT
+        return input_text
+
+    def _compute_mrope_positions(
+        self,
+        input_ids: torch.Tensor,
+        audio_feature_lengths: Optional[torch.Tensor] = None,
+    ):
+        """Compute MRoPE positions for Qwen3-ASR.
+
+        For audio-only model, all 3 MRoPE dimensions get the same sequential
+        positions. Audio tokens get sequential positions just like text tokens.
+        """
+        seq_len = input_ids.shape[0]
+        if input_ids.dim() > 1:
+            seq_len = input_ids.shape[-1]
+
+        # For Qwen3-ASR, all 3 dimensions get identical sequential positions
+        # since audio tokens don't have spatial structure
+        positions = torch.arange(seq_len, dtype=torch.long)
+        mrope_positions = positions.unsqueeze(0).expand(3, -1).clone()
+        mrope_position_delta = torch.tensor([0], dtype=torch.long)
+
+        return mrope_positions, mrope_position_delta
+
+    def compute_mrope_positions(self, input_ids, mm_items):
+        """Compute M-RoPE positions for Qwen3-ASR.
+
+        All 3 dimensions get identical sequential positions since audio
+        tokens have no spatial structure.
+        """
+        if isinstance(input_ids, list):
+            seq_len = len(input_ids)
+        else:
+            seq_len = input_ids.shape[-1] if input_ids.dim() > 1 else input_ids.shape[0]
+
+        positions = torch.arange(seq_len, dtype=torch.long)
+        mrope_positions = positions.unsqueeze(0).expand(3, -1).clone()
+        return mrope_positions, torch.tensor([0], dtype=torch.long)
+
+    async def process_mm_data_async(
+        self,
+        audio_data=None,
+        input_text=None,
+        request_obj=None,
+        **kwargs,
+    ):
+        if not audio_data:
+            return None
+
+        # Build the prompt - handles empty text from transcription endpoint
+        prompt = self._build_transcription_prompt(input_text)
+
+        base_output = self.load_mm_data(
+            prompt=prompt,
+            audio_data=audio_data,
+            multimodal_tokens=self.mm_tokens,
+        )
+        if base_output is None:
+            return None
+
+        mm_items, input_ids, ret = self.process_and_combine_mm_data(
+            base_output, self.mm_tokens
+        )
+
+        # The feature_attention_mask is automatically set on audio items
+        # by the base processor's collect_mm_items_from_processor_output()
+        # since we registered it in ATTR_NAME_TO_MODALITY
+
+        # Compute MRoPE positions
+        mrope_positions, mrope_position_delta = self._compute_mrope_positions(
+            input_ids
+        )
+
+        return MultimodalProcessorOutput(
+            mm_items=mm_items,
+            input_ids=input_ids.tolist(),
+            audio_start_id=self.audio_start_id,
+            audio_token_id=self.audio_token_id,
+            audio_end_id=self.audio_end_id,
+            mrope_positions=mrope_positions,
+            mrope_position_delta=mrope_position_delta,
+        )

--- a/test/manual/models/test_qwen3_asr.py
+++ b/test/manual/models/test_qwen3_asr.py
@@ -1,0 +1,118 @@
+"""
+Test Qwen3-ASR model support in SGLang.
+
+Tests /v1/audio/transcriptions endpoint (OpenAI-compatible).
+
+Usage:
+    python test/manual/models/test_qwen3_asr.py
+"""
+
+import io
+import os
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+MODEL = "Qwen/Qwen3-ASR-1.7B"
+TEST_AUDIO_EN_URL = (
+    "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen3-ASR-Repo/asr_en.wav"
+)
+TEST_AUDIO_ZH_URL = (
+    "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen3-ASR-Repo/asr_zh.wav"
+)
+TEST_AUDIO_EN_LOCAL = "/tmp/test_qwen3_asr_en.wav"
+TEST_AUDIO_ZH_LOCAL = "/tmp/test_qwen3_asr_zh.wav"
+
+
+def download_audio(url, local_path):
+    """Download audio file if not already cached."""
+    if os.path.exists(local_path):
+        with open(local_path, "rb") as f:
+            return f.read()
+    resp = requests.get(url, timeout=60)
+    resp.raise_for_status()
+    with open(local_path, "wb") as f:
+        f.write(resp.content)
+    return resp.content
+
+
+class TestQwen3ASRTranscription(CustomTestCase):
+    """Test Qwen3-ASR via /v1/audio/transcriptions endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = MODEL
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--served-model-name",
+                "qwen3-asr",
+                "--trust-remote-code",
+                "--disable-cuda-graph",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def _transcribe(self, audio_url, local_path, language=None):
+        """Send a transcription request."""
+        audio_bytes = download_audio(audio_url, local_path)
+        data = {"model": "qwen3-asr"}
+        if language:
+            data["language"] = language
+        response = requests.post(
+            self.base_url + "/v1/audio/transcriptions",
+            files={"file": ("audio.wav", io.BytesIO(audio_bytes), "audio/wav")},
+            data=data,
+            timeout=120,
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        return response.json()
+
+    def test_english_transcription(self):
+        """Test English audio transcription."""
+        result = self._transcribe(TEST_AUDIO_EN_URL, TEST_AUDIO_EN_LOCAL)
+        self.assertIn("text", result)
+        text = result["text"]
+        self.assertTrue(len(text) > 0, "Transcription should not be empty")
+        print(f"[EN Transcription] {text}")
+
+    def test_chinese_transcription(self):
+        """Test Chinese audio transcription."""
+        result = self._transcribe(TEST_AUDIO_ZH_URL, TEST_AUDIO_ZH_LOCAL)
+        self.assertIn("text", result)
+        text = result["text"]
+        self.assertTrue(len(text) > 0, "Transcription should not be empty")
+        print(f"[ZH Transcription] {text}")
+
+    def test_multiple_requests_consistency(self):
+        """Test that repeated requests produce consistent output."""
+        results = []
+        for _ in range(3):
+            result = self._transcribe(TEST_AUDIO_EN_URL, TEST_AUDIO_EN_LOCAL)
+            results.append(result["text"])
+
+        for i in range(1, len(results)):
+            self.assertEqual(
+                results[0],
+                results[i],
+                f"Request {i+1} differs from first request",
+            )
+        print(f"[Consistency] All 3 requests match: {results[0][:80]}...")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

#22025 

## Modifications

<!-- Detail the changes made in this pull request. -->

- Introduced Qwen3-ASR model with configuration and processor classes.
- Updated entry points to handle Qwen3-ASR in the transcription endpoint.
- Enhanced multimodal processing to support Qwen3-ASR.
- Added tests for Qwen3-ASR transcription functionality.
- Updated existing files to include Qwen3ASR in relevant imports and configurations.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

- official `qwen_asr`

```bash
$ python test_qwen3_asr_official.py 
Loading checkpoint shards: 100%|██████████████████████████████████████████████████| 2/2 [00:00<00:00,  2.42it/s]
The following generation flags are not valid and may be ignored: ['temperature']. Set `TRANSFORMERS_VERBOSITY=info` for more details.
Setting `pad_token_id` to `eos_token_id`:151645 for open-end generation.
English
Uh huh. Oh yeah, yeah. He wasn't even that big when I started listening to him, but and his solo music didn't do overly well, but he did very well when he started writing for other people.
Setting `pad_token_id` to `eos_token_id`:151645 for open-end generation.
Chinese
甚至出现交易几乎停滞的情况。
```

- this PR

```bash
$ python test_qwen3_asr.py 
command=sglang serve --model-path Qwen/Qwen3-ASR-1.7B --served-model-name qwen3-asr --trust-remote-code --disable-cuda-graph --device cuda --host 127.0.0.1 --port 21000
CI_OFFLINE: Launching server HF_HUB_OFFLINE=0 model=Qwen/Qwen3-ASR-1.7B
Unrecognized keys in `rope_parameters` for 'rope_type'='default': {'mrope_section', 'mrope_interleaved', 'interleaved'}
`torch_dtype` is deprecated! Use `dtype` instead!
The following generation flags are not valid and may be ignored: ['temperature']. Set `TRANSFORMERS_VERBOSITY=info` for more details.
/data/yihao/repos/sglang/python/sglang/srt/entrypoints/http_server.py:172: FastAPIDeprecationWarning: ORJSONResponse is deprecated, FastAPI now serializes data directly to JSON bytes via Pydantic when a return type or response model is set, which is faster and doesn't need a custom response class. Read more in the FastAPI docs: https://fastapi.tiangolo.com/advanced/custom-response/#orjson-or-response-model and https://fastapi.tiangolo.com/tutorial/response-model/
  from sglang.srt.utils.json_response import (
[2026-04-03 19:21:26] server_args=ServerArgs(model_path='Qwen/Qwen3-ASR-1.7B', tokenizer_path='Qwen/Qwen3-ASR-1.7B', tokenizer_mode='auto', tokenizer_worker_num=1, skip_tokenizer_init=False, load_format='auto', model_loader_extra_config='{}', trust_remote_code=True, context_length=None, is_embedding=False, enable_multimodal=None, revision=None, model_impl='auto', host='127.0.0.1', port=21000, fastapi_root_path='', grpc_mode=False, skip_server_warmup=False, warmups=None, nccl_port=None, checkpoint_engine_wait_weights_before_ready=False, ssl_keyfile=None, ssl_certfile=None, ssl_ca_certs=None, ssl_keyfile_password=None, enable_ssl_refresh=False, dtype='auto', quantization=None, quantization_param_path=None, kv_cache_dtype='auto', enable_fp32_lm_head=False, modelopt_quant=None, modelopt_checkpoint_restore_path=None, modelopt_checkpoint_save_path=None, modelopt_export_path=None, quantize_and_serve=False, rl_quant_profile=None, mem_fraction_static=0.907, max_running_requests=None, max_queued_requests=None, max_total_tokens=None, chunked_prefill_size=8192, enable_dynamic_chunking=False, max_prefill_tokens=16384, prefill_max_requests=None, schedule_policy='fcfs', enable_priority_scheduling=False, disable_priority_preemption=False, default_priority_value=None, abort_on_priority_when_disabled=False, schedule_low_priority_values_first=False, priority_scheduling_preemption_threshold=10, schedule_conservativeness=1.0, page_size=1, swa_full_tokens_ratio=0.8, disable_hybrid_swa_memory=False, radix_eviction_policy='lru', enable_prefill_delayer=False, prefill_delayer_max_delay_passes=30, prefill_delayer_token_usage_low_watermark=None, prefill_delayer_forward_passes_buckets=None, prefill_delayer_wait_seconds_buckets=None, device='cuda', tp_size=1, pp_size=1, pp_max_micro_batch_size=None, pp_async_batch_depth=0, stream_interval=1, incremental_streaming_output=False, enable_streaming_session=False, random_seed=222246292, constrained_json_whitespace_pattern=None, constrained_json_disable_any_whitespace=False, watchdog_timeout=300, soft_watchdog_timeout=None, dist_timeout=None, download_dir=None, model_checksum=None, base_gpu_id=0, gpu_id_step=1, sleep_on_idle=False, use_ray=False, custom_sigquit_handler=None, log_level='info', log_level_http=None, log_requests=False, log_requests_level=2, log_requests_format='text', log_requests_target=None, uvicorn_access_log_exclude_prefixes=[], crash_dump_folder=None, show_time_cost=False, enable_metrics=False, enable_mfu_metrics=False, enable_metrics_for_all_schedulers=False, tokenizer_metrics_custom_labels_header='x-custom-labels', tokenizer_metrics_allowed_custom_labels=None, extra_metric_labels=None, bucket_time_to_first_token=None, bucket_inter_token_latency=None, bucket_e2e_request_latency=None, collect_tokens_histogram=False, prompt_tokens_buckets=None, generation_tokens_buckets=None, gc_warning_threshold_secs=0.0, decode_log_interval=40, enable_request_time_stats_logging=False, kv_events_config=None, enable_trace=False, otlp_traces_endpoint='localhost:4317', export_metrics_to_file=False, export_metrics_to_file_dir=None, api_key=None, admin_api_key=None, served_model_name='qwen3-asr', weight_version='default', chat_template=None, hf_chat_template_name=None, completion_template=None, file_storage_path='sglang_storage', enable_cache_report=False, reasoning_parser=None, tool_call_parser=None, tool_server=None, sampling_defaults='model', dp_size=1, load_balance_method='round_robin', attn_cp_size=1, moe_dp_size=1, dist_init_addr=None, nnodes=1, node_rank=0, json_model_override_args='{}', preferred_sampling_params=None, enable_lora=None, enable_lora_overlap_loading=None, max_lora_rank=None, lora_target_modules=None, lora_paths=None, max_loaded_loras=None, max_loras_per_batch=8, lora_eviction_policy='lru', lora_backend='csgmv', max_lora_chunk_size=16, experts_shared_outer_loras=None, attention_backend='fa3', decode_attention_backend=None, prefill_attention_backend=None, sampling_backend='flashinfer', grammar_backend='xgrammar', mm_attention_backend=None, fp8_gemm_runner_backend='auto', fp4_gemm_runner_backend='auto', nsa_prefill_backend=None, nsa_decode_backend=None, disable_flashinfer_autotune=False, mamba_backend='triton', speculative_algorithm=None, speculative_draft_model_path=None, speculative_draft_model_revision=None, speculative_draft_load_format=None, speculative_num_steps=None, speculative_eagle_topk=None, speculative_num_draft_tokens=None, speculative_accept_threshold_single=1.0, speculative_accept_threshold_acc=1.0, speculative_token_map=None, speculative_attention_mode='prefill', speculative_draft_attention_backend=None, speculative_moe_runner_backend='auto', speculative_moe_a2a_backend=None, speculative_draft_model_quantization=None, speculative_ngram_min_bfs_breadth=1, speculative_ngram_max_bfs_breadth=10, speculative_ngram_match_type='BFS', speculative_ngram_max_trie_depth=18, speculative_ngram_capacity=10000000, enable_multi_layer_eagle=False, ep_size=1, moe_a2a_backend='none', moe_runner_backend='auto', flashinfer_mxfp4_moe_precision='default', enable_flashinfer_allreduce_fusion=False, enforce_disable_flashinfer_allreduce_fusion=False, enable_aiter_allreduce_fusion=False, deepep_mode='auto', ep_num_redundant_experts=0, ep_dispatch_algorithm=None, init_expert_location='trivial', enable_eplb=False, eplb_algorithm='auto', eplb_rebalance_num_iterations=1000, eplb_rebalance_layers_per_chunk=None, eplb_min_rebalancing_utilization_threshold=1.0, expert_distribution_recorder_mode=None, expert_distribution_recorder_buffer_size=1000, enable_expert_distribution_metrics=False, deepep_config=None, moe_dense_tp_size=None, elastic_ep_backend=None, enable_elastic_expert_backup=False, mooncake_ib_device=None, max_mamba_cache_size=None, mamba_ssm_dtype=None, mamba_full_memory_ratio=0.9, mamba_scheduler_strategy='no_buffer', mamba_track_interval=256, linear_attn_backend='triton', linear_attn_decode_backend=None, linear_attn_prefill_backend=None, enable_hierarchical_cache=False, hicache_ratio=2.0, hicache_size=0, hicache_write_policy='write_through', hicache_io_backend='kernel', hicache_mem_layout='layer_first', hicache_storage_backend=None, hicache_storage_prefetch_policy='best_effort', hicache_storage_backend_extra_config=None, enable_hisparse=False, hisparse_config=None, enable_lmcache=False, kt_weight_path=None, kt_method='AMXINT4', kt_cpuinfer=None, kt_threadpool_count=2, kt_num_gpu_experts=None, kt_max_deferred_experts_per_token=None, dllm_algorithm=None, dllm_algorithm_config=None, enable_double_sparsity=False, ds_channel_config_path=None, ds_heavy_channel_num=32, ds_heavy_token_num=256, ds_heavy_channel_type='qk', ds_sparse_decode_threshold=4096, cpu_offload_gb=0, offload_group_size=-1, offload_num_in_group=1, offload_prefetch_step=1, offload_mode='cpu', multi_item_scoring_delimiter=None, disable_radix_cache=False, cuda_graph_max_bs=256, cuda_graph_bs=[1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256], disable_cuda_graph=True, disable_cuda_graph_padding=False, enable_profile_cuda_graph=False, enable_cudagraph_gc=False, enable_layerwise_nvtx_marker=False, enable_nccl_nvls=False, enable_symm_mem=False, disable_flashinfer_cutlass_moe_fp4_allgather=False, enable_tokenizer_batch_encode=False, disable_tokenizer_batch_decode=False, disable_outlines_disk_cache=False, disable_custom_all_reduce=False, enable_mscclpp=False, enable_torch_symm_mem=False, pre_warm_nccl=False, disable_overlap_schedule=False, enable_mixed_chunk=False, enable_dp_attention=False, enable_dp_lm_head=False, enable_two_batch_overlap=False, enable_single_batch_overlap=False, tbo_token_distribution_threshold=0.48, enable_torch_compile=False, disable_piecewise_cuda_graph=True, enforce_piecewise_cuda_graph=False, enable_torch_compile_debug_mode=False, torch_compile_max_bs=32, piecewise_cuda_graph_max_tokens=8192, piecewise_cuda_graph_tokens=[4, 8, 12, 16, 20, 24, 28, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256, 288, 320, 352, 384, 416, 448, 480, 512, 576, 640, 704, 768, 832, 896, 960, 1024, 1280, 1536, 1792, 2048, 2304, 2560, 2816, 3072, 3328, 3584, 3840, 4096, 4608, 5120, 5632, 6144, 6656, 7168, 7680, 8192], piecewise_cuda_graph_compiler='eager', torchao_config='', enable_nan_detection=False, enable_p2p_check=False, triton_attention_reduce_in_fp32=False, triton_attention_num_kv_splits=8, triton_attention_split_tile_size=None, num_continuous_decode_steps=1, delete_ckpt_after_loading=False, enable_memory_saver=False, enable_weights_cpu_backup=False, enable_draft_weights_cpu_backup=False, allow_auto_truncate=False, enable_custom_logit_processor=False, flashinfer_mla_disable_ragged=False, disable_shared_experts_fusion=False, disable_chunked_prefix_cache=False, disable_fast_image_processor=False, keep_mm_feature_on_device=False, enable_return_hidden_states=False, enable_return_routed_experts=False, scheduler_recv_interval=1, numa_node=None, enable_deterministic_inference=False, rl_on_policy_target=None, enable_attn_tp_input_scattered=False, gc_threshold=None, enable_nsa_prefill_context_parallel=False, nsa_prefill_cp_mode='round-robin-split', enable_fused_qk_norm_rope=False, enable_precise_embedding_interpolation=False, enable_fused_moe_sum_all_reduce=False, enable_prefill_context_parallel=False, prefill_cp_mode='in-seq-split', enable_dynamic_batch_tokenizer=False, dynamic_batch_tokenizer_batch_size=32, dynamic_batch_tokenizer_batch_timeout=0.002, debug_tensor_dump_output_folder=None, debug_tensor_dump_layers=None, debug_tensor_dump_input_file=None, debug_tensor_dump_inject=False, disaggregation_mode='null', disaggregation_transfer_backend='mooncake', disaggregation_bootstrap_port=8998, disaggregation_ib_device=None, disaggregation_decode_enable_offload_kvcache=False, num_reserved_decode_tokens=512, disaggregation_decode_polling_interval=1, encoder_only=False, language_only=False, encoder_transfer_backend='zmq_to_scheduler', encoder_urls=[], enable_adaptive_dispatch_to_encoder=False, custom_weight_loader=[], weight_loader_disable_mmap=False, remote_instance_weight_loader_seed_instance_ip=None, remote_instance_weight_loader_seed_instance_service_port=None, remote_instance_weight_loader_send_weights_group_ports=None, remote_instance_weight_loader_backend='nccl', remote_instance_weight_loader_start_seed_via_transfer_engine=False, engine_info_bootstrap_port=6789, modelexpress_config=None, enable_pdmux=False, pdmux_config_path=None, sm_group_num=8, enable_broadcast_mm_inputs_process=False, enable_prefix_mm_cache=False, mm_enable_dp_encoder=False, mm_process_config={}, limit_mm_data_per_request=None, enable_mm_global_cache=False, decrypted_config_file=None, decrypted_draft_config_file=None, forward_hooks=None)
[2026-04-03 19:21:26] mp.set_executable /data/yihao/repos/sglang/.venv/bin/python3 -> /tmp/sglang_temp_file_1775244086.9585037_837831.sh (script='#!/bin/sh\nexec numactl --cpunodebind=0 --membind=0 /data/yihao/repos/sglang/.venv/bin/python3 "$@"')
[2026-04-03 19:21:26] mp.set_executable revert to /data/yihao/repos/sglang/.venv/bin/python3
2026-04-03 19:21:27.102 DEBUG Persistent cache disabled, using in-memory JIT cache
[2026-04-03 19:21:27] Persistent cache disabled, using in-memory JIT cache
2026-04-03 19:21:27.102 DEBUG Persistent cache disabled, using in-memory JIT cache
[2026-04-03 19:21:27] Persistent cache disabled, using in-memory JIT cache
2026-04-03 19:21:27.102 DEBUG Persistent cache disabled, using in-memory JIT cache
[2026-04-03 19:21:27] Persistent cache disabled, using in-memory JIT cache
2026-04-03 19:21:27.102 DEBUG Persistent cache disabled, using in-memory JIT cache
[2026-04-03 19:21:27] Persistent cache disabled, using in-memory JIT cache
2026-04-03 19:21:27.102 DEBUG Persistent cache disabled, using in-memory JIT cache
[2026-04-03 19:21:27] Persistent cache disabled, using in-memory JIT cache
Unrecognized keys in `rope_parameters` for 'rope_type'='default': {'mrope_section', 'mrope_interleaved', 'interleaved'}
[2026-04-03 19:21:27] thinker_config is None. Initializing Qwen3-ASR thinker with default values
Unrecognized keys in `rope_parameters` for 'rope_type'='default': {'mrope_section', 'mrope_interleaved', 'interleaved'}
[2026-04-03 19:21:27] thinker_config is None. Initializing Qwen3-ASR thinker with default values
Fetching 7 files: 100%|█████████████████████████████████████████████████████████| 7/7 [00:00<00:00, 8279.79it/s]
Download complete: : 0.00B [00:00, ?B/s]                                                  | 0/7 [00:00<?, ?it/s]
[2026-04-03 19:21:28] No HuggingFace chat template found
[2026-04-03 19:21:28] No chat template found, defaulting to 'string' content format
[2026-04-03 19:21:34] NUMA affinity is already constrained for process, skipping NUMA node configuration for GPU. Remove your constraints to allow automatic configuration.
Unrecognized keys in `rope_parameters` for 'rope_type'='default': {'mrope_interleaved', 'interleaved', 'mrope_section'}
[2026-04-03 19:21:34] thinker_config is None. Initializing Qwen3-ASR thinker with default values
`torch_dtype` is deprecated! Use `dtype` instead!
The following generation flags are not valid and may be ignored: ['temperature']. Set `TRANSFORMERS_VERBOSITY=info` for more details.
Unrecognized keys in `rope_parameters` for 'rope_type'='default': {'mrope_interleaved', 'interleaved', 'mrope_section'}
[2026-04-03 19:21:34] thinker_config is None. Initializing Qwen3-ASR thinker with default values
Unrecognized keys in `rope_parameters` for 'rope_type'='default': {'mrope_interleaved', 'interleaved', 'mrope_section'}
[2026-04-03 19:21:34] thinker_config is None. Initializing Qwen3-ASR thinker with default values
Unrecognized keys in `rope_parameters` for 'rope_type'='default': {'mrope_interleaved', 'interleaved', 'mrope_section'}
[2026-04-03 19:21:34] thinker_config is None. Initializing Qwen3-ASR thinker with default values
Fetching 7 files: 100%|████████████████████████████████████████████████████████| 7/7 [00:00<00:00, 10138.17it/s]
Download complete: : 0.00B [00:00, ?B/s]                                                  | 0/7 [00:00<?, ?it/s]
2026-04-03 19:21:35.519 DEBUG Persistent cache disabled, using in-memory JIT cache
[2026-04-03 19:21:35] Persistent cache disabled, using in-memory JIT cache
2026-04-03 19:21:35.519 DEBUG Persistent cache disabled, using in-memory JIT cache
[2026-04-03 19:21:35] Persistent cache disabled, using in-memory JIT cache
2026-04-03 19:21:35.519 DEBUG Persistent cache disabled, using in-memory JIT cache
[2026-04-03 19:21:35] Persistent cache disabled, using in-memory JIT cache
2026-04-03 19:21:35.519 DEBUG Persistent cache disabled, using in-memory JIT cache
[2026-04-03 19:21:35] Persistent cache disabled, using in-memory JIT cache
2026-04-03 19:21:35.519 DEBUG Persistent cache disabled, using in-memory JIT cache
[2026-04-03 19:21:35] Persistent cache disabled, using in-memory JIT cache
[2026-04-03 19:21:36] Init torch distributed begin.
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[2026-04-03 19:21:36] Init torch distributed ends. elapsed=0.24 s, mem usage=0.09 GB
[2026-04-03 19:21:36] Load weight begin. avail mem=139.12 GB
[2026-04-03 19:21:36] Multimodal attention backend not set. Use fa3.
[2026-04-03 19:21:36] Using fa3 as multimodal attention backend.
[2026-04-03 19:21:36] Found local HF snapshot for Qwen/Qwen3-ASR-1.7B at /home/radixark/.cache/huggingface/hub/models--Qwen--Qwen3-ASR-1.7B/snapshots/7278e1e70fe206f11671096ffdd38061171dd6e5; skipping download.
Multi-thread loading shards: 100% Completed | 2/2 [00:00<00:00,  4.40it/s]
[2026-04-03 19:21:37] Load weight end. elapsed=0.85 s, type=Qwen3ASRForConditionalGeneration, avail mem=135.21 GB, mem usage=3.91 GB.
[2026-04-03 19:21:37] Using KV cache dtype: torch.bfloat16
[2026-04-03 19:21:37] KV Cache is allocated. #tokens: 1144694, K size: 61.13 GB, V size: 61.13 GB
[2026-04-03 19:21:37] Memory pool end. avail mem=11.91 GB
[2026-04-03 19:21:37] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
Unrecognized keys in `rope_parameters` for 'rope_type'='default': {'mrope_interleaved', 'interleaved', 'mrope_section'}
[2026-04-03 19:21:37] thinker_config is None. Initializing Qwen3-ASR thinker with default values
Unrecognized keys in `rope_parameters` for 'rope_type'='default': {'mrope_interleaved', 'interleaved', 'mrope_section'}
[2026-04-03 19:21:37] thinker_config is None. Initializing Qwen3-ASR thinker with default values
Fetching 7 files: 100%|████████████████████████████████████████████████████████| 7/7 [00:00<00:00, 74329.44it/s]
Download complete: : 0.00B [00:00, ?B/s]              [2026-04-03 19:21:38] max_total_num_tokens=1144694, chunked_prefill_size=8192, max_prefill_tokens=16384, max_running_requests=4096, context_len=65536, available_gpu_mem=11.81 GB
[2026-04-03 19:21:38] INFO:     Started server process [2931704]
[2026-04-03 19:21:38] INFO:     Waiting for application startup.
[2026-04-03 19:21:38] Using default chat sampling params from model generation config: {'temperature': 1e-06}
[2026-04-03 19:21:38] INFO:     Application startup complete.
[2026-04-03 19:21:38] INFO:     Uvicorn running on http://127.0.0.1:21000 (Press CTRL+C to quit)
[2026-04-03 19:21:38] INFO:     127.0.0.1:53444 - "GET /health_generate HTTP/1.1" 503 Service Unavailable
[2026-04-03 19:21:39] INFO:     127.0.0.1:53446 - "GET /model_info HTTP/1.1" 200 OK
Download complete: : 0.00B [00:01, ?B/s]
2026-04-03 19:21:40,391 - CUTE_DSL - WARNING - [handle_import_error] - Unexpected error during package walk: cutlass.cute.experimental
[2026-04-03 19:21:40] Unexpected error during package walk: cutlass.cute.experimental
[2026-04-03 19:21:41] Prefill batch, #new-seq: 1, #new-token: 6, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, cuda graph: False, input throughput (token/s): 0.00
[2026-04-03 19:21:41] INFO:     127.0.0.1:53454 - "POST /generate HTTP/1.1" 200 OK
[2026-04-03 19:21:41] The server is fired up and ready to roll!
[2026-04-03 19:21:48] Prefill batch, #new-seq: 1, #new-token: 1, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, cuda graph: False, input throughput (token/s): 0.76
[2026-04-03 19:21:49] INFO:     127.0.0.1:34368 - "GET /health_generate HTTP/1.1" 200 OK
test_chinese_transcription (__main__.TestQwen3ASRTranscription.test_chinese_transcription)
Test Chinese audio transcription. ... [CI Test Method] TestQwen3ASRTranscription.test_chinese_transcription
[2026-04-03 19:21:50] Prefill batch, #new-seq: 1, #new-token: 65, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, cuda graph: False, input throughput (token/s): 0.68
[2026-04-03 19:21:50] INFO:     127.0.0.1:34384 - "POST /v1/audio/transcriptions HTTP/1.1" 200 OK
[ZH Transcription] 甚至出现交易几乎停滞的情况。
ok
test_english_transcription (__main__.TestQwen3ASRTranscription.test_english_transcription)
Test English audio transcription. ... [CI Test Method] TestQwen3ASRTranscription.test_english_transcription
[2026-04-03 19:21:50] Prefill batch, #new-seq: 1, #new-token: 202, #cached-token: 4, token usage: 0.00, #running-req: 0, #queue-req: 0, cuda graph: False, input throughput (token/s): 231.21
[2026-04-03 19:21:51] Decode batch, #running-req: 1, #token: 227, token usage: 0.00, cuda graph: False, gen throughput (token/s): 2.40, #queue-req: 0
[2026-04-03 19:21:51] INFO:     127.0.0.1:34400 - "POST /v1/audio/transcriptions HTTP/1.1" 200 OK
[EN Transcription] Uh huh. Oh yeah, yeah. He wasn't even that big when I started listening to him, but and his solo music didn't do overly well, but he did very well when he started writing for other people.
ok
test_multiple_requests_consistency (__main__.TestQwen3ASRTranscription.test_multiple_requests_consistency)
Test that repeated requests produce consistent output. ... [CI Test Method] TestQwen3ASRTranscription.test_multiple_requests_consistency
[2026-04-03 19:21:51] Prefill batch, #new-seq: 1, #new-token: 1, #cached-token: 205, token usage: 0.00, #running-req: 0, #queue-req: 0, cuda graph: False, input throughput (token/s): 251.48
[2026-04-03 19:21:51] Decode batch, #running-req: 1, #token: 218, token usage: 0.00, cuda graph: False, gen throughput (token/s): 60.06, #queue-req: 0
[2026-04-03 19:21:52] INFO:     127.0.0.1:34406 - "POST /v1/audio/transcriptions HTTP/1.1" 200 OK
[2026-04-03 19:21:52] Prefill batch, #new-seq: 1, #new-token: 1, #cached-token: 205, token usage: 0.00, #running-req: 0, #queue-req: 0, cuda graph: False, input throughput (token/s): 1.26
[2026-04-03 19:21:52] Decode batch, #running-req: 1, #token: 209, token usage: 0.00, cuda graph: False, gen throughput (token/s): 60.93, #queue-req: 0
[2026-04-03 19:21:52] Decode batch, #running-req: 1, #token: 249, token usage: 0.00, cuda graph: False, gen throughput (token/s): 65.79, #queue-req: 0
[2026-04-03 19:21:53] INFO:     127.0.0.1:34414 - "POST /v1/audio/transcriptions HTTP/1.1" 200 OK
[2026-04-03 19:21:53] Prefill batch, #new-seq: 1, #new-token: 1, #cached-token: 205, token usage: 0.00, #running-req: 0, #queue-req: 0, cuda graph: False, input throughput (token/s): 1.26
[2026-04-03 19:21:53] Decode batch, #running-req: 1, #token: 240, token usage: 0.00, cuda graph: False, gen throughput (token/s): 60.92, #queue-req: 0
[2026-04-03 19:21:53] INFO:     127.0.0.1:34418 - "POST /v1/audio/transcriptions HTTP/1.1" 200 OK
[Consistency] All 3 requests match: Uh huh. Oh yeah, yeah. He wasn't even that big when I started listening to him, ...
ok

----------------------------------------------------------------------
Ran 3 tests in 34.964s

OK
```

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

More tests will be posted here.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
