### PR TITLE
fix: correct typos and grammar in code comments

### DIFF
--- a/python/sglang/srt/batch_invariant_ops/batch_invariant_ops.py
+++ b/python/sglang/srt/batch_invariant_ops/batch_invariant_ops.py
@@ -18,7 +18,7 @@ if ENABLE_JIT_DEEPGEMM:
 _ENABLE_MM_DEEPGEMM = get_bool_env_var(
     "SGLANG_BATCH_INVARIANT_OPS_ENABLE_MM_DEEPGEMM", "1"
 )
-# If true, allows to fallback to batch variant gemm when the shape cannot be run in DeepGEMM
+# If true, allows falling back to batch variant gemm when the shape cannot be run in DeepGEMM
 _ENABLE_MM_FALLBACK_VARIANT = get_bool_env_var(
     "SGLANG_BATCH_INVARIANT_OPS_ENABLE_MM_FALLBACK_VARIANT", "0"
 )

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -731,7 +731,7 @@ class FlashAttentionBackend(AttentionBackend):
                 o_expand, softmax_lse_expand, *rest_expand = flash_attn_with_kvcache(
                     q=q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim),
                     # Here metadata_expand.page_table is not divided with page_size.
-                    # This is because we loose the fine control of  what token to attend,
+                    # This is because we lose the fine control of what token to attend,
                     # but has to attend to some block completely.
                     k_cache=key_cache.view(-1, 1, layer.tp_k_head_num, layer.head_dim),
                     v_cache=value_cache.view(

--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -133,7 +133,7 @@ def _per_token_group_quant_8bit(
     y_stride,
     # Columns of input
     N,
-    # Avoid to divide zero
+    # Avoid division by zero
     eps,
     # Information for float8
     bit8_min,
@@ -177,7 +177,7 @@ def _per_token_group_quant_8bit_colmajor(
     y_num_columns,
     # Stride from one column to the next of y_s
     y_s_col_stride,
-    # Avoid to divide zero
+    # Avoid division by zero
     eps,
     # Information for float8
     bit8_min,

--- a/python/sglang/srt/layers/quantization/gptq.py
+++ b/python/sglang/srt/layers/quantization/gptq.py
@@ -1366,7 +1366,7 @@ class GPTQMarlinMoEMethod(FusedMoEMethodBase):
         )
         layer.register_parameter("w2_scales", w2_scales)
         set_weight_attrs(w2_scales, extra_weight_attrs)
-        # dont shard the w2 scales when running act order
+        # don't shard the w2 scales when running act order
         set_weight_attrs(w2_scales, {"load_full_w2": self.quant_config.desc_act})
         # up_proj scales
         w13_qzeros = torch.nn.Parameter(
@@ -1392,7 +1392,7 @@ class GPTQMarlinMoEMethod(FusedMoEMethodBase):
         )
         layer.register_parameter("w2_qzeros", w2_qzeros)
         set_weight_attrs(w2_qzeros, extra_weight_attrs)
-        # dont shard the w2 scales when running act order
+        # don't shard the w2 scales when running act order
         set_weight_attrs(w2_qzeros, {"load_full_w2": self.quant_config.desc_act})
         w13_g_idx = torch.nn.Parameter(
             torch.empty(

--- a/python/sglang/srt/layers/quantization/int8_kernel.py
+++ b/python/sglang/srt/layers/quantization/int8_kernel.py
@@ -99,7 +99,7 @@ def _per_token_group_quant_int8(
     y_stride,
     # Columns of input
     N,
-    # Avoid to divide zero
+    # Avoid division by zero
     eps,
     # Information for int8
     int8_min,

--- a/python/sglang/srt/models/llama_eagle3.py
+++ b/python/sglang/srt/models/llama_eagle3.py
@@ -234,7 +234,7 @@ class LlamaForCausalLMEagle3(LlamaForCausalLM):
         config_ = copy.deepcopy(config)
         config_.vocab_size = (
             config_.draft_vocab_size
-        )  # draft logits processor has it's own vocab size
+        )  # draft logits processor has its own vocab size
         self.logits_processor = LogitsProcessor(config_)
 
         self.capture_aux_hidden_states = True

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -107,7 +107,7 @@ class SpeculativeAlgorithm(Enum):
 
 class SpecInputType(IntEnum):
     # NOTE: introduce this to distinguish the SpecInput types of multiple algorithms when asserting in attention backends.
-    # If all algorithms can share the same datastrucutre of draft_input and verify_input, consider simplify it
+    # If all algorithms can share the same datastructure of draft_input and verify_input, consider simplifying it
     EAGLE_DRAFT = auto()
     EAGLE_VERIFY = auto()
     NGRAM_VERIFY = auto()


### PR DESCRIPTION
## Summary
- Fix typo: `datastrucutre` → `datastructure`
- Fix grammar: `consider simplify` → `consider simplifying`
- Fix missing apostrophe: `dont` → `don't` (2 instances)
- Fix grammar: `Avoid to divide zero` → `Avoid division by zero` (3 instances, matching 9+ existing uses in codebase)
- Fix possessive: `it's own` → `its own`
- Fix grammar: `allows to fallback` → `allows falling back`
- Fix spelling + double space: `loose` → `lose`

## Test plan
- [ ] Comment-only changes, no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)