### PR TITLE
Fix killall_sglang missing the main sglang serve process

### DIFF
--- a/python/sglang/cli/killall.py
+++ b/python/sglang/cli/killall.py
@@ -28,7 +28,7 @@ MEMORY_THRESHOLD_PCT = 10
 
 # Patterns matching SGLang process command lines (equivalent to pgrep -f in killall_sglang.sh)
 _SGLANG_PROCESS_PATTERNS = re.compile(
-    r"sglang::|sglang\.launch_server|sglang\.bench|sglang\.data_parallel|sglang\.srt|sgl_diffusion::"
+    r"sglang::|sglang\.launch_server|sglang\.bench|sglang\.data_parallel|sglang\.srt|sgl_diffusion::|sglang serve"
 )
 
 # Boxed output helpers


### PR DESCRIPTION
## Motivation

`killall_sglang` (CI cleanup script) uses regex pattern matching on `/proc/PID/cmdline` to find and kill SGLang processes. However, the main server process launched via `sglang serve` is **not matched** by the current patterns, because its cmdline looks like:

```
/usr/local/bin/python3 /usr/local/bin/sglang serve --model-path ...
```

while the existing patterns only cover child process names (`sglang::*`, `sglang.launch_server`, etc.).

### Process tree and pattern coverage (before this fix)

```
sglang serve --model-path ... --port 19000       ← MISSED (holds HTTP port)
├── sglang::scheduler_gpu0_tp0                   ← matched by sglang::
├── sglang::scheduler_gpu1_tp1                   ← matched by sglang::
├── sglang::detokenizer                          ← matched by sglang::
└── [thread] subprocess-watchdog
```

All child processes use `setproctitle("sglang::...")` and are matched. The root process (which owns the uvicorn HTTP server and the listening port) is the only one missed.

### Why a broader pattern like just `sglang` doesn't work

CI processes like test runners and test files have `sglang` in their **path**:

```
python3 /actions-runner/_work/sglang/sglang/test/run_suite.py ...
python3 /actions-runner/_work/sglang/sglang/test/registered/models/test_foo.py -f
```

Matching bare `sglang` would kill the test infrastructure itself.

## Modifications

Add `sglang serve` to `_SGLANG_PROCESS_PATTERNS` in `python/sglang/cli/killall.py`.

## Checklist
- [x] Format: `pre-commit run --all-files`