### PR TITLE
[Bugfix] Fix warmup endpoint mismatch for VLM in PD disaggregation mode

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1784,7 +1784,13 @@ def _execute_server_warmup(server_args: ServerArgs):
     # Construct a warmup request
     is_vlm = bool(model_info.get("has_image_understanding", False))
     if model_info["is_generation"]:
-        if is_vlm and not server_args.skip_tokenizer_init:
+        if (
+            is_vlm
+            and not server_args.skip_tokenizer_init
+            and server_args.disaggregation_mode == "null"
+        ):
+            # In PD disaggregation mode the warmup payload uses input_ids (no messages),
+            # so /v1/chat/completions would return 400. Fall back to /generate.
             request_name = "/v1/chat/completions"
         else:
             request_name = "/generate"


### PR DESCRIPTION
**Motivation**

When a VLM model is launched in PD disaggregation mode (`--disaggregation-mode prefill` or `decode`), server warmup fails with HTTP 400, leaving the worker in `UnHealthy` state and preventing the sglang-router from registering it.

The root cause is a mismatch between the warmup *endpoint* and the warmup *payload*:

- `request_name` was set to `/v1/chat/completions` for any VLM, regardless of disaggregation mode.
- In PD mode the warmup payload is always constructed with `input_ids` / `bootstrap_host` / `bootstrap_room` fields — no `messages` field.
- `/v1/chat/completions` requires `messages`, so it returns 400 before ever reaching the generate handler.

The `json_data` construction block already had the correct guard:
```python
elif is_vlm and server_args.disaggregation_mode == "null" and ...:
    # use chat-completions payload with messages
```
but the `request_name` selection above it did not.

Closes #20836

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
