### PR TITLE
[Feature] Integrate cuLA KDA Backend

### DIFF
--- a/benchmark/bench_linear_attention/bench_cula_kda_prefill.py
+++ b/benchmark/bench_linear_attention/bench_cula_kda_prefill.py
@@ -1,0 +1,636 @@
+"""
+Benchmark & Correctness: cuLA KDA Prefill vs Triton KDA Prefill.
+
+Compares:
+  - Triton:  sglang's chunk_kda (chunked KDA prefill with delta rule)
+  - cuLA:    SM90 fully-fused KDA prefill kernel (CUTLASS TMA + WGMMA)
+
+Both kernels share the same API shape convention:
+  - q/k = [1, T, H, K], v = [1, T, H, V], g = [1, T, H, K], beta = [1, T, H]
+  - ssm_states (pool) = [pool_size, H, V, K] (VK layout, float32)
+  - cu_seqlens = [N+1], cache_indices = [N]
+
+Reports correctness (output & state matching) and performance (ms, TFLOPS, TB/s).
+
+Usage:
+    python bench_cula_kda_prefill.py                        # default sweep
+    python bench_cula_kda_prefill.py --mode bench            # benchmark only
+    python bench_cula_kda_prefill.py --mode correctness      # correctness only
+    python bench_cula_kda_prefill.py --preset kimi-linear     # Kimi-Linear config
+"""
+
+import argparse
+import math
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "python"))
+
+import torch
+
+from sglang.srt.layers.attention.fla.cumsum import chunk_local_cumsum
+from sglang.srt.layers.attention.fla.kda import chunk_kda
+from sglang.srt.layers.attention.fla.l2norm import l2norm_fwd
+
+# cuLA kernel uses exp2() internally, so gate values must be in log-base-2 space.
+RCP_LN2 = 1.0 / math.log(2.0)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def kda_flops(
+    total_seq_len: int,
+    num_heads: int,
+    head_size_k: int,
+    head_size_v: int,
+) -> int:
+    """
+    FLOPs for KDA prefill (delta rule).
+
+    Per token per head:
+      1. k @ v^T (outer product):  2 * K * V
+      2. q @ state (output):       2 * K * V
+    """
+    outer_product_flops = 2 * total_seq_len * num_heads * head_size_k * head_size_v
+    output_flops = 2 * total_seq_len * num_heads * head_size_k * head_size_v
+    return outer_product_flops + output_flops
+
+
+def kda_bytes(
+    total_seq_len: int,
+    num_heads: int,
+    head_size_k: int,
+    head_size_v: int,
+    num_seqs: int,
+    dtype: torch.dtype,
+) -> int:
+    """Memory bytes accessed (inputs + outputs + state)."""
+    elem = dtype.itemsize
+
+    q_bytes = total_seq_len * num_heads * head_size_k * elem
+    k_bytes = total_seq_len * num_heads * head_size_k * elem
+    v_bytes = total_seq_len * num_heads * head_size_v * elem
+    o_bytes = total_seq_len * num_heads * head_size_v * elem
+
+    # state (float32): read + write
+    state_bytes = 2 * num_seqs * num_heads * head_size_k * head_size_v * 4
+
+    # g (float32, per-dim), beta (float32, per-head)
+    g_bytes = total_seq_len * num_heads * head_size_k * 4
+    beta_bytes = total_seq_len * num_heads * 4
+
+    return q_bytes + k_bytes + v_bytes + o_bytes + state_bytes + g_bytes + beta_bytes
+
+
+# ---------------------------------------------------------------------------
+# Input factory
+# ---------------------------------------------------------------------------
+
+
+def make_inputs(
+    B: int,
+    T_per_seq: int,
+    H: int,
+    K: int,
+    V: int,
+    pool_size: int,
+    device: str,
+    dtype: torch.dtype,
+    sequential_indices: bool = False,
+    seed: int = 42,
+):
+    """Create all input tensors for a single benchmark / correctness run."""
+    T = B * T_per_seq
+    torch.manual_seed(seed)
+
+    if sequential_indices:
+        cache_indices = torch.arange(B, dtype=torch.int32, device=device)
+    else:
+        perm = torch.randperm(pool_size, device=device)[:B]
+        cache_indices = perm.to(torch.int32)
+
+    # SSM state pool: VK layout [pool_size, H, V, K], float32
+    pool_init = (
+        torch.randn(pool_size, H, V, K, dtype=torch.float32, device=device) * 0.1
+    )
+
+    cu_seqlens = torch.arange(
+        0, (B + 1) * T_per_seq, T_per_seq, dtype=torch.long, device=device
+    )
+
+    # Triton / cuLA format: [1, T, H, D]
+    q = torch.randn(1, T, H, K, dtype=dtype, device=device)
+    k = torch.randn(1, T, H, K, dtype=dtype, device=device)
+    v = torch.randn(1, T, H, V, dtype=dtype, device=device)
+
+    # g (raw gate, per-dim): [1, T, H, K]
+    # Real KDA gates are negative (decay): gate = -exp(A_log)*dt + softplus(a*dt_bias)
+    # Use logsigmoid (always negative, bounded) for realistic values.
+    # Clamp to _CULA_GATE_MIN=-8 to avoid cuLA fallback.
+    g = (
+        torch.nn.functional.logsigmoid(
+            torch.randn(1, T, H, K, dtype=torch.float32, device=device)
+        )
+        .clamp(min=-7.0)
+        .to(dtype)
+    )
+
+    # beta (sigmoid): [1, T, H] — cuLA requires float32
+    beta = torch.sigmoid(torch.randn(1, T, H, dtype=torch.float32, device=device))
+
+    return dict(
+        B=B,
+        T=T,
+        T_per_seq=T_per_seq,
+        H=H,
+        K=K,
+        V=V,
+        pool_size=pool_size,
+        cache_indices=cache_indices,
+        pool_init=pool_init,
+        cu_seqlens=cu_seqlens,
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Runner wrappers
+# ---------------------------------------------------------------------------
+
+
+def run_triton(inp):
+    """Triton path: chunk_kda with VK-layout pool, pool-indexed."""
+    pool = inp["pool_init"].clone()
+
+    o = chunk_kda(
+        q=inp["q"],
+        k=inp["k"],
+        v=inp["v"],
+        g=inp["g"],
+        beta=inp["beta"],
+        initial_state=pool,
+        initial_state_indices=inp["cache_indices"],
+        use_qk_l2norm_in_kernel=True,
+        cu_seqlens=inp["cu_seqlens"],
+    )
+    return o, pool
+
+
+def run_cula(inp):
+    """cuLA path: matches CulaKDAKernel._cula_extend() preprocessing exactly."""
+    from sgl_kernel import kda_fwd_prefill
+
+    q = inp["q"]
+    k = inp["k"]
+    v = inp["v"]
+    g = inp["g"]
+    beta = inp["beta"]
+    pool = inp["pool_init"].clone()
+    cache_indices = inp["cache_indices"]
+    cu_seqlens = inp["cu_seqlens"]
+
+    batch_size = q.shape[0]
+    packed_seq = q.shape[1]
+    num_heads = q.shape[2]
+    head_dim = q.shape[3]
+
+    # 1. L2 normalize Q, K
+    q = l2norm_fwd(q.contiguous())
+    k = l2norm_fwd(k.contiguous())
+
+    # 2. Gate cumsum preprocessing (scale=RCP_LN2 for cuLA's exp2-based kernel)
+    g = chunk_local_cumsum(g, chunk_size=64, scale=RCP_LN2, cu_seqlens=cu_seqlens)
+
+    # 3. Reshape [1, packed_seq, H, D] -> [packed_seq, H, D]
+    q = q.reshape(packed_seq, num_heads, head_dim).contiguous()
+    k = k.reshape(packed_seq, num_heads, head_dim).contiguous()
+    v = v.reshape(packed_seq, num_heads, head_dim).contiguous()
+    g = g.reshape(packed_seq, num_heads, head_dim).contiguous()
+    beta = beta.reshape(packed_seq, num_heads).contiguous()
+
+    # 4. State gather
+    input_state = pool[cache_indices].contiguous()
+
+    # 5. cu_seqlens
+    cu_seqlens_i32 = cu_seqlens.to(torch.int32)
+
+    # 6. Workspace buffer
+    sm_count = torch.cuda.get_device_properties(q.device).multi_processor_count
+    workspace_buffer = torch.zeros(sm_count * 128, dtype=torch.uint8, device=q.device)
+
+    # 7. Scale
+    scale = head_dim**-0.5
+
+    # 8. Call C++ kernel
+    output, output_state = kda_fwd_prefill(
+        q=q,
+        k=k,
+        v=v,
+        cu_seqlens=cu_seqlens_i32,
+        workspace_buffer=workspace_buffer,
+        scale=scale,
+        safe_gate=True,
+        input_state=input_state,
+        alpha=g,
+        beta=beta,
+    )
+
+    # 9. Write state back
+    pool[cache_indices] = output_state
+
+    # 10. Reshape output
+    output = output.reshape(batch_size, packed_seq, num_heads, head_dim)
+
+    return output, pool
+
+
+# ---------------------------------------------------------------------------
+# Correctness check
+# ---------------------------------------------------------------------------
+
+
+def check_shape(
+    B,
+    T_per_seq,
+    H,
+    K,
+    V,
+    pool_size,
+    device,
+    dtype,
+    sequential_indices=False,
+    seed=42,
+):
+    """Run correctness check for a single shape config. Returns True if PASS.
+
+    Pass/fail is based on OUTPUT comparison only (atol=1e-1).
+    Pool state diff is reported as informational — state divergence over many
+    tokens is expected due to different chunk sizes and accumulation order
+    (Triton uses autotuned BT, cuLA uses fixed chunk_size=64 with exp2 gates).
+    """
+    tag = (
+        f"B={B:>3} T/seq={T_per_seq:>4} H={H:>2} K={K:>3} V={V:>3} pool={pool_size:>4}"
+    )
+    idx_tag = " (seq)" if sequential_indices else ""
+
+    inp = make_inputs(
+        B,
+        T_per_seq,
+        H,
+        K,
+        V,
+        pool_size,
+        device,
+        dtype,
+        sequential_indices=sequential_indices,
+        seed=seed,
+    )
+
+    o_triton, pool_triton = run_triton(inp)
+
+    try:
+        o_cula, pool_cula = run_cula(inp)
+        torch.cuda.synchronize()
+    except Exception as e:
+        try:
+            torch.cuda.synchronize()
+        except Exception:
+            pass
+        print(f"  [SKIP] {tag}{idx_tag}  (cuLA error: {e})")
+        return True
+
+    # --- Output comparison (pass/fail criterion) ---
+    out_diff = (o_triton.float() - o_cula.float()).abs().max().item()
+    out_ok = out_diff < 1e-1
+
+    # --- State comparison (informational only) ---
+    cache_indices = inp["cache_indices"]
+    state_diff = (
+        (pool_triton[cache_indices].float() - pool_cula[cache_indices].float())
+        .abs()
+        .max()
+        .item()
+    )
+
+    status = "PASS" if out_ok else "FAIL"
+    print(
+        f"  [{status}] {tag}{idx_tag}  "
+        f"out_diff={out_diff:.4f}  state_diff={state_diff:.4f}"
+    )
+    return out_ok
+
+
+# ---------------------------------------------------------------------------
+# Benchmark
+# ---------------------------------------------------------------------------
+
+
+def bench_shape(B, H, T_per_seq, K, V, pool_size, device, dtype):
+    """Benchmark Triton vs cuLA for a single config."""
+    import triton.testing
+
+    T = B * T_per_seq
+    inp = make_inputs(B, T_per_seq, H, K, V, pool_size, device, dtype)
+
+    # -- Shared read-only tensors --
+    q, k_t, v = inp["q"], inp["k"], inp["v"]
+    g, beta = inp["g"], inp["beta"]
+    cu_seqlens = inp["cu_seqlens"]
+    cache_indices = inp["cache_indices"]
+    pool_v = inp["pool_init"]
+
+    # -- Pre-compute cuLA format tensors (outside timing for fair comparison) --
+    packed_seq = q.shape[1]
+    num_heads = q.shape[2]
+    head_dim = q.shape[3]
+
+    q_normed = l2norm_fwd(q.contiguous())
+    k_normed = l2norm_fwd(k_t.contiguous())
+    g_cumsum = chunk_local_cumsum(
+        g, chunk_size=64, scale=RCP_LN2, cu_seqlens=cu_seqlens
+    )
+
+    q_cula = q_normed.reshape(packed_seq, num_heads, head_dim).contiguous()
+    k_cula = k_normed.reshape(packed_seq, num_heads, head_dim).contiguous()
+    v_cula = v.reshape(packed_seq, num_heads, head_dim).contiguous()
+    g_cula = g_cumsum.reshape(packed_seq, num_heads, head_dim).contiguous()
+    beta_cula = beta.reshape(packed_seq, num_heads).contiguous()
+    cu_seqlens_i32 = cu_seqlens.to(torch.int32)
+
+    sm_count = torch.cuda.get_device_properties(q.device).multi_processor_count
+    workspace_buffer = torch.zeros(sm_count * 128, dtype=torch.uint8, device=q.device)
+    scale = head_dim**-0.5
+
+    from sgl_kernel import kda_fwd_prefill
+
+    def fn_triton():
+        pool = pool_v.clone()
+        chunk_kda(
+            q=q,
+            k=k_t,
+            v=v,
+            g=g,
+            beta=beta,
+            initial_state=pool,
+            initial_state_indices=cache_indices,
+            cu_seqlens=cu_seqlens,
+            use_qk_l2norm_in_kernel=True,
+        )
+
+    def fn_cula():
+        input_state = pool_v[cache_indices].contiguous()
+        kda_fwd_prefill(
+            q=q_cula,
+            k=k_cula,
+            v=v_cula,
+            cu_seqlens=cu_seqlens_i32,
+            workspace_buffer=workspace_buffer,
+            scale=scale,
+            safe_gate=True,
+            input_state=input_state,
+            alpha=g_cula,
+            beta=beta_cula,
+        )
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    # Warmup
+    for _ in range(5):
+        fn_triton()
+        fn_cula()
+    torch.cuda.synchronize()
+
+    ms_triton, _, _ = triton.testing.do_bench(
+        fn_triton, quantiles=quantiles, warmup=50, rep=200
+    )
+    ms_cula, _, _ = triton.testing.do_bench(
+        fn_cula, quantiles=quantiles, warmup=50, rep=200
+    )
+
+    # Metrics
+    flops = kda_flops(T, H, K, V)
+    mem_bytes = kda_bytes(T, H, K, V, B, dtype)
+
+    tflops_triton = flops / ms_triton / 1e9
+    tflops_cula = flops / ms_cula / 1e9
+    tb_s_triton = mem_bytes / ms_triton / 1e9
+    tb_s_cula = mem_bytes / ms_cula / 1e9
+
+    speedup = ms_triton / ms_cula if ms_cula > 0 else float("inf")
+
+    print(
+        f"  {B:>5}  {H:>3}  {T_per_seq:>6}  {T:>7} | "
+        f"{ms_triton:>8.3f}  {tflops_triton:>7.2f}  {tb_s_triton:>7.2f} | "
+        f"{ms_cula:>8.3f}  {tflops_cula:>7.2f}  {tb_s_cula:>7.2f} | "
+        f"{speedup:>7.2f}x"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def run_correctness(device, dtype):
+    print("=" * 78)
+    print("Correctness sweep: Triton KDA Prefill vs cuLA KDA Prefill")
+    print("=" * 78)
+
+    shapes = [
+        # (B, T_per_seq, H,  K,   V,   pool_size)
+        # --- baseline (Kimi-Linear style) ---
+        (4, 64, 16, 128, 128, 32),
+        (4, 128, 16, 128, 128, 32),
+        (4, 256, 16, 128, 128, 32),
+        # --- different batch sizes ---
+        (1, 128, 16, 128, 128, 32),
+        (8, 128, 16, 128, 128, 64),
+        (16, 64, 16, 128, 128, 128),
+        (32, 64, 16, 128, 128, 256),
+        # --- different head counts ---
+        (4, 128, 4, 128, 128, 32),
+        (4, 128, 8, 128, 128, 32),
+        (4, 128, 32, 128, 128, 32),
+        # --- longer sequences ---
+        (4, 512, 16, 128, 128, 32),
+        (4, 1024, 16, 128, 128, 32),
+        # --- large pool (sparse access) ---
+        (4, 128, 16, 128, 128, 512),
+        # --- combined stress ---
+        (32, 128, 32, 128, 128, 256),
+    ]
+
+    shapes_seq = [
+        (8, 128, 16, 128, 128, 8),
+        (4, 128, 32, 128, 128, 4),
+        (32, 128, 16, 128, 128, 32),
+    ]
+
+    all_pass = True
+    for B, T_per_seq, H, K, V, pool_size in shapes:
+        if not check_shape(B, T_per_seq, H, K, V, pool_size, device, dtype):
+            all_pass = False
+
+    print()
+    print("Sequential-index variants:")
+    for B, T_per_seq, H, K, V, pool_size in shapes_seq:
+        if not check_shape(
+            B,
+            T_per_seq,
+            H,
+            K,
+            V,
+            pool_size,
+            device,
+            dtype,
+            sequential_indices=True,
+        ):
+            all_pass = False
+
+    print()
+    if all_pass:
+        print("ALL PASSED.")
+    else:
+        print("SOME FAILED.")
+    return all_pass
+
+
+def run_benchmark(device, dtype, args):
+    print()
+    print("=" * 105)
+    print("Benchmark: Triton KDA Prefill vs cuLA KDA Prefill  (do_bench)")
+    print("=" * 105)
+
+    K = args.head_size_k
+    V = args.head_size_v
+    pool_size = args.pool_size
+
+    if args.preset == "kimi-linear":
+        bench_configs = [
+            # (B,   H, T_per_seq)
+            (4, 16, 128),
+            (4, 16, 256),
+            (4, 16, 512),
+            (4, 16, 1024),
+            (4, 16, 2048),
+            (16, 16, 128),
+            (16, 16, 256),
+            (16, 16, 512),
+            (16, 16, 1024),
+            (32, 16, 128),
+            (32, 16, 256),
+            (32, 16, 512),
+            (64, 16, 128),
+            (64, 16, 256),
+            (128, 16, 128),
+            (128, 16, 256),
+            # larger head counts
+            (4, 32, 256),
+            (4, 32, 512),
+            (4, 32, 1024),
+            (16, 32, 256),
+            (16, 32, 512),
+            (32, 32, 256),
+        ]
+    else:
+        bench_configs = []
+        for B in args.batch_sizes:
+            for H in args.num_heads:
+                for T_per_seq in args.seq_lens:
+                    bench_configs.append((B, H, T_per_seq))
+
+    print(f"  Config: K={K}, V={V}, pool_size={pool_size}, dtype={dtype}")
+    print(
+        f"  {'B':>5}  {'H':>3}  {'T/seq':>6}  {'T_tot':>7} | "
+        f"{'tri(ms)':>8}  {'TFLOPS':>7}  {'TB/s':>7} | "
+        f"{'cula(ms)':>8}  {'TFLOPS':>7}  {'TB/s':>7} | "
+        f"{'speedup':>8}"
+    )
+    print("  " + "-" * 98)
+
+    for B, H, T_per_seq in bench_configs:
+        actual_pool = max(pool_size, B)
+        bench_shape(B, H, T_per_seq, K, V, actual_pool, device, dtype)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Benchmark & Correctness: Triton KDA Prefill vs cuLA KDA Prefill"
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["all", "correctness", "bench"],
+        default="all",
+        help="Run mode (default: all)",
+    )
+    parser.add_argument(
+        "--preset",
+        choices=["kimi-linear", "custom"],
+        default="kimi-linear",
+        help="Preset config (default: kimi-linear)",
+    )
+    parser.add_argument(
+        "--dtype",
+        choices=["float16", "bfloat16"],
+        default="bfloat16",
+    )
+    parser.add_argument("--head-size-k", type=int, default=128)
+    parser.add_argument("--head-size-v", type=int, default=128)
+    parser.add_argument("--pool-size", type=int, default=256)
+    parser.add_argument(
+        "--batch-sizes",
+        type=int,
+        nargs="+",
+        default=[4, 16, 32, 64, 128],
+    )
+    parser.add_argument(
+        "--num-heads",
+        type=int,
+        nargs="+",
+        default=[16, 32],
+    )
+    parser.add_argument(
+        "--seq-lens",
+        type=int,
+        nargs="+",
+        default=[128, 256, 512, 1024],
+    )
+    args = parser.parse_args()
+
+    if args.preset == "kimi-linear":
+        args.head_size_k = 128
+        args.head_size_v = 128
+
+    device = "cuda"
+    dtype = getattr(torch, args.dtype)
+
+    # Check SM version
+    cap = torch.cuda.get_device_capability()
+    dev_name = torch.cuda.get_device_name()
+    print(f"Device: {dev_name}  (SM {cap[0]}{cap[1]})")
+
+    if cap[0] < 9:
+        print(
+            "WARNING: cuLA KDA requires SM90 (Hopper) GPU. Correctness tests will skip cuLA."
+        )
+
+    if args.mode in ("all", "correctness"):
+        all_pass = run_correctness(device, dtype)
+        if not all_pass and args.mode == "all":
+            print("\nSkipping benchmark due to correctness failures.")
+            return 1
+
+    if args.mode in ("all", "bench"):
+        run_benchmark(device, dtype, args)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -55,15 +55,23 @@ class KDAKernelDispatcher:
         else:
             raise ValueError(
                 f"Unsupported KDA decode backend: {decode_backend}. "
-                "KDA currently only supports 'triton'."
+                "KDA decode supports 'triton' and 'cutedsl'."
             )
 
         if prefill_backend.is_triton():
             self.extend_kernel = triton_kernel
+        elif prefill_backend.is_cula():
+            if not is_cuda():
+                raise ValueError("KDA cuLA backend requires CUDA")
+            from sglang.srt.layers.attention.linear.kernels.kda_cula import (
+                CulaKDAKernel,
+            )
+
+            self.extend_kernel = CulaKDAKernel()
         else:
             raise ValueError(
                 f"Unsupported KDA prefill backend: {prefill_backend}. "
-                "KDA currently only supports 'triton'."
+                "KDA currently supports 'triton' and 'cula'."
             )
 
         rank0_log(

--- a/python/sglang/srt/layers/attention/linear/kernels/kda_cula.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/kda_cula.py
@@ -1,6 +1,21 @@
+import math
 from typing import Dict
 
 import torch
+
+# cuLA kernel uses exp2() internally, so gate values must be in log-base-2 space.
+# RCP_LN2 converts from natural log space (model output) to log-base-2 space.
+RCP_LN2 = 1.0 / math.log(2.0)
+
+# cuLA kernel chunk size. Sequences shorter than this cause NaN in the
+# internal matrix inversion (GarbageFilledDiagonal + partial chunk).
+_CULA_CHUNK_SIZE = 64
+
+# Per-element gate value threshold. If min(g) < this, the chunk-local cumsum
+# (64 elements * |threshold| * RCP_LN2) exceeds the range where cuLA's
+# in-kernel Gaussian elimination stays numerically stable.
+# -8 => worst-case cumsum ≈ -8 * 64 * 1.44 ≈ -737, within safe range.
+_CULA_GATE_MIN = -8.0
 
 from sglang.srt.layers.attention.linear.kernels.kernel_backend import (
     LinearAttnKernelBase,
@@ -19,6 +34,23 @@ def _get_workspace_buffer(device: torch.device) -> torch.Tensor:
             sm_count * 128, dtype=torch.uint8, device=device
         )
     return _workspace_cache[device_idx]
+
+
+def _triton_fallback(q, k, v, g, beta, ssm_states, cache_indices, query_start_loc):
+    """Fall back to the Triton chunk_kda kernel (handles all preprocessing)."""
+    from sglang.srt.layers.attention.fla.kda import chunk_kda
+
+    return chunk_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        initial_state=ssm_states,
+        initial_state_indices=cache_indices,
+        use_qk_l2norm_in_kernel=True,
+        cu_seqlens=query_start_loc,
+    )
 
 
 class CulaKDAKernel(LinearAttnKernelBase):
@@ -54,6 +86,46 @@ class CulaKDAKernel(LinearAttnKernelBase):
         query_start_loc: torch.Tensor,
         **kwargs,
     ) -> torch.Tensor:
+        # Guard 1: cuLA's matrix inversion produces NaN for partial chunks
+        # when any sequence_length < chunk_size (64).
+        seq_lens = query_start_loc[1:] - query_start_loc[:-1]
+        min_seq_len = seq_lens.min().item()
+        if min_seq_len < _CULA_CHUNK_SIZE:
+            return _triton_fallback(
+                q, k, v, g, beta, ssm_states, cache_indices, query_start_loc
+            )
+
+        # Guard 2: extreme gate values cause near-singular K@K^T in the
+        # in-kernel Gaussian elimination. Check raw gate values before cumsum.
+        g_min = g.min().item()
+        if g_min < _CULA_GATE_MIN:
+            return _triton_fallback(
+                q, k, v, g, beta, ssm_states, cache_indices, query_start_loc
+            )
+
+        return self._cula_extend(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            ssm_states=ssm_states,
+            cache_indices=cache_indices,
+            query_start_loc=query_start_loc,
+        )
+
+    def _cula_extend(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        *,
+        ssm_states: torch.Tensor,
+        cache_indices: torch.Tensor,
+        query_start_loc: torch.Tensor,
+    ) -> torch.Tensor:
         from sgl_kernel import kda_fwd_prefill
 
         from sglang.srt.layers.attention.fla.cumsum import chunk_local_cumsum
@@ -69,8 +141,10 @@ class CulaKDAKernel(LinearAttnKernelBase):
         q = l2norm_fwd(q.contiguous())
         k = l2norm_fwd(k.contiguous())
 
-        # 2. Gate cumsum preprocessing
-        g = chunk_local_cumsum(g, chunk_size=64, cu_seqlens=query_start_loc)
+        # 2. Gate cumsum preprocessing (scale=RCP_LN2 for cuLA's exp2-based kernel)
+        g = chunk_local_cumsum(
+            g, chunk_size=64, scale=RCP_LN2, cu_seqlens=query_start_loc
+        )
 
         # 3. Reshape [1, packed_seq, H, D] -> [packed_seq, H, D], ensure contiguous
         q = q.reshape(packed_seq, num_heads, head_dim).contiguous()

--- a/python/sglang/srt/layers/attention/linear/kernels/kda_cula.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/kda_cula.py
@@ -1,0 +1,134 @@
+from typing import Dict
+
+import torch
+
+from sglang.srt.layers.attention.linear.kernels.kernel_backend import (
+    LinearAttnKernelBase,
+)
+
+# Cache workspace buffers per CUDA device
+_workspace_cache: Dict[int, torch.Tensor] = {}
+
+
+def _get_workspace_buffer(device: torch.device) -> torch.Tensor:
+    """Get or create a workspace buffer for the given device."""
+    device_idx = device.index if device.index is not None else 0
+    if device_idx not in _workspace_cache:
+        sm_count = torch.cuda.get_device_properties(device).multi_processor_count
+        _workspace_cache[device_idx] = torch.zeros(
+            sm_count * 128, dtype=torch.uint8, device=device
+        )
+    return _workspace_cache[device_idx]
+
+
+class CulaKDAKernel(LinearAttnKernelBase):
+    """cuLA SM90 fully-fused kernel for KDA (Kimi Delta Attention) prefill."""
+
+    def decode(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        *,
+        A_log: torch.Tensor,
+        dt_bias: torch.Tensor,
+        ssm_states: torch.Tensor,
+        cache_indices: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        **kwargs,
+    ) -> torch.Tensor:
+        raise NotImplementedError("CulaKDAKernel only supports prefill (extend)")
+
+    def extend(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        *,
+        ssm_states: torch.Tensor,
+        cache_indices: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        **kwargs,
+    ) -> torch.Tensor:
+        from sgl_kernel import kda_fwd_prefill
+
+        from sglang.srt.layers.attention.fla.cumsum import chunk_local_cumsum
+        from sglang.srt.layers.attention.fla.l2norm import l2norm_fwd
+
+        # Input shapes: q, k, v = [1, packed_seq, H, D], g = [1, packed_seq, H, D], beta = [1, packed_seq, H]
+        batch_size = q.shape[0]  # should be 1
+        packed_seq = q.shape[1]
+        num_heads = q.shape[2]
+        head_dim = q.shape[3]
+
+        # 1. L2 normalize Q, K (consistent with Triton path use_qk_l2norm_in_kernel=True)
+        q = l2norm_fwd(q.contiguous())
+        k = l2norm_fwd(k.contiguous())
+
+        # 2. Gate cumsum preprocessing
+        g = chunk_local_cumsum(g, chunk_size=64, cu_seqlens=query_start_loc)
+
+        # 3. Reshape [1, packed_seq, H, D] -> [packed_seq, H, D], ensure contiguous
+        q = q.reshape(packed_seq, num_heads, head_dim).contiguous()
+        k = k.reshape(packed_seq, num_heads, head_dim).contiguous()
+        v = v.reshape(packed_seq, num_heads, head_dim).contiguous()
+        g = g.reshape(packed_seq, num_heads, head_dim).contiguous()
+        beta = beta.reshape(packed_seq, num_heads).contiguous()
+
+        # 4. State gather: get per-batch states from the pool
+        input_state = ssm_states[cache_indices]  # [N, H, V, K] (SGLang VK layout)
+
+        # 5. State layout conversion: [N, H, V, K] -> [N, H, K, V] (cuLA KV layout)
+        input_state = input_state.transpose(-1, -2).contiguous()
+
+        # 6. cu_seqlens
+        cu_seqlens = query_start_loc.to(torch.int32)
+
+        # 7. Workspace buffer
+        workspace_buffer = _get_workspace_buffer(q.device)
+
+        # 8. Scale
+        scale = head_dim**-0.5
+
+        # 9. Call C++ kernel
+        output, output_state = kda_fwd_prefill(
+            q=q,
+            k=k,
+            v=v,
+            cu_seqlens=cu_seqlens,
+            workspace_buffer=workspace_buffer,
+            scale=scale,
+            safe_gate=True,
+            input_state=input_state,
+            alpha=g,
+            beta=beta,
+        )
+
+        # 10. Write output state back: [N, H, K, V] -> [N, H, V, K] (back to SGLang VK layout)
+        ssm_states[cache_indices] = output_state.transpose(-1, -2)
+
+        # 11. Reshape output: [packed_seq, H, D] -> [1, packed_seq, H, D]
+        output = output.reshape(batch_size, packed_seq, num_heads, head_dim)
+
+        return output
+
+    def target_verify(
+        self,
+        A_log: torch.Tensor,
+        dt_bias: torch.Tensor,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        *,
+        ssm_states: torch.Tensor,
+        cache_indices: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        **kwargs,
+    ) -> torch.Tensor:
+        raise NotImplementedError("CulaKDAKernel does not support target_verify")

--- a/python/sglang/srt/layers/attention/linear/kernels/kda_cula.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/kda_cula.py
@@ -153,11 +153,9 @@ class CulaKDAKernel(LinearAttnKernelBase):
         g = g.reshape(packed_seq, num_heads, head_dim).contiguous()
         beta = beta.reshape(packed_seq, num_heads).contiguous()
 
-        # 4. State gather: get per-batch states from the pool
-        input_state = ssm_states[cache_indices]  # [N, H, V, K] (SGLang VK layout)
-
-        # 5. State layout conversion: [N, H, V, K] -> [N, H, K, V] (cuLA KV layout)
-        input_state = input_state.transpose(-1, -2).contiguous()
+        # 4. State gather: get per-batch states from the pool (VK layout [N, H, V, K])
+        # The kernel natively uses VK layout via CuTe LayoutLeft (K, V, H, N).
+        input_state = ssm_states[cache_indices].contiguous()
 
         # 6. cu_seqlens
         cu_seqlens = query_start_loc.to(torch.int32)
@@ -182,8 +180,8 @@ class CulaKDAKernel(LinearAttnKernelBase):
             beta=beta,
         )
 
-        # 10. Write output state back: [N, H, K, V] -> [N, H, V, K] (back to SGLang VK layout)
-        ssm_states[cache_indices] = output_state.transpose(-1, -2)
+        # 10. Write output state back (already in VK layout from C++ API)
+        ssm_states[cache_indices] = output_state
 
         # 11. Reshape output: [packed_seq, H, D] -> [1, packed_seq, H, D]
         output = output.reshape(batch_size, packed_seq, num_heads, head_dim)

--- a/python/sglang/srt/layers/attention/linear/utils.py
+++ b/python/sglang/srt/layers/attention/linear/utils.py
@@ -16,6 +16,7 @@ class LinearAttnKernelBackend(Enum):
     TRITON = "triton"
     CUTEDSL = "cutedsl"
     FLASHINFER = "flashinfer"
+    CULA = "cula"
 
     def is_triton(self):
         return self == LinearAttnKernelBackend.TRITON
@@ -25,6 +26,9 @@ class LinearAttnKernelBackend(Enum):
 
     def is_flashinfer(self):
         return self == LinearAttnKernelBackend.FLASHINFER
+
+    def is_cula(self):
+        return self == LinearAttnKernelBackend.CULA
 
 
 LINEAR_ATTN_DECODE_BACKEND: Optional[LinearAttnKernelBackend] = None

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -227,7 +227,7 @@ MAMBA_SSM_DTYPE_CHOICES = ["float32", "bfloat16", "float16"]
 MAMBA_SCHEDULER_STRATEGY_CHOICES = ["auto", "no_buffer", "extra_buffer"]
 
 MAMBA_BACKEND_CHOICES = ["triton", "flashinfer"]
-LINEAR_ATTN_KERNEL_BACKEND_CHOICES = ["triton", "cutedsl", "flashinfer"]
+LINEAR_ATTN_KERNEL_BACKEND_CHOICES = ["triton", "cutedsl", "flashinfer", "cula"]
 
 
 # Allow external code to add more choices
@@ -2583,6 +2583,13 @@ class ServerArgs:
     def _handle_linear_attn_backend(self):
         # SM100+ FlashInfer GDN decode requires bf16 state; SM90 uses float32.
         import torch
+
+        # cuLA only supports prefill; auto-fallback decode to triton.
+        if (
+            self.linear_attn_backend == "cula"
+            and self.linear_attn_decode_backend is None
+        ):
+            self.linear_attn_decode_backend = "triton"
 
         decode = self.linear_attn_decode_backend or self.linear_attn_backend
         if (

--- a/sgl-kernel/CMakeLists.txt
+++ b/sgl-kernel/CMakeLists.txt
@@ -501,6 +501,53 @@ if (SGL_KERNEL_ENABLE_FA3)
     target_compile_definitions(flash_ops PRIVATE ${FLASH_OPS_COMPILE_DEFS})
 endif()
 
+# ============================ cuLA KDA SM90 Prefill ============================= #
+# Build cula_kda_ops as a separate, optional extension for KDA prefill on SM90a.
+# Reuses the SGL_KERNEL_ENABLE_FA3 guard (CUDA >= 12.4 + SM90a).
+if (SGL_KERNEL_ENABLE_FA3)
+    set(SGL_KDA_CUDA_FLAGS
+        "-O3"
+        "-Xcompiler"
+        "-fPIC"
+        "-gencode=arch=compute_90a,code=sm_90a"
+        "-std=c++17"
+        "-DSGL_KDA_SM90A_ENABLED"
+        "-DCUTE_USE_PACKED_TUPLE=1"
+        "-DCUTLASS_ENABLE_TENSOR_CORE_MMA=1"
+        "-DCUTLASS_VERSIONS_GENERATED"
+        "-DCUTLASS_TEST_LEVEL=0"
+        "-DCUTLASS_TEST_ENABLE_CACHED_RESULTS=1"
+        "-DCUTLASS_DEBUG_TRACE_LEVEL=0"
+        "-DCUTLASS_ENABLE_GDC_FOR_SM90"
+        "-DCUTE_SM90_EXTENDED_MMA_SHAPES_ENABLED"
+        "--expt-relaxed-constexpr"
+        "--expt-extended-lambda"
+        "--use_fast_math"
+        "-Xcompiler=-Wconversion"
+        "-Xcompiler=-fno-strict-aliasing"
+        "--threads=${SGL_KERNEL_COMPILE_THREADS}"
+    )
+
+    set(KDA_SOURCES
+        "csrc/kda/kda_sm90_api.cu"
+        "csrc/kda/sm90/kda_fwd_sm90.cu"
+        "csrc/kda/sm90/kda_fwd_sm90_safe_gate.cu"
+    )
+
+    Python_add_library(cula_kda_ops MODULE WITH_SOABI ${KDA_SOURCES})
+
+    target_compile_options(cula_kda_ops PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:${SGL_KDA_CUDA_FLAGS}>)
+    target_include_directories(cula_kda_ops PRIVATE
+        csrc/
+        csrc/kerutils/include/
+        ${repo-cutlass_SOURCE_DIR}/include
+        ${repo-cutlass_SOURCE_DIR}/tools/util/include
+    )
+    target_link_libraries(cula_kda_ops PRIVATE ${TORCH_LIBRARIES} c10 cuda)
+
+    install(TARGETS cula_kda_ops LIBRARY DESTINATION "sgl_kernel")
+endif()
+
 # Build spatial_ops as a separate, optional extension for green contexts
 set(SPATIAL_SOURCES
     "csrc/spatial/greenctx_stream.cu"

--- a/sgl-kernel/csrc/kda/kda_sm90_api.cu
+++ b/sgl-kernel/csrc/kda/kda_sm90_api.cu
@@ -1,0 +1,156 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ATen/cuda/CUDAContext.h>
+#include <cutlass/arch/arch.h>
+#include <torch/extension.h>
+
+#include <cute/numeric/numeric_types.hpp>
+
+#include "kda/sm90/prefill_kernel.hpp"
+
+using OptionalTensor = std::optional<torch::Tensor>;
+
+std::tuple<torch::Tensor, torch::Tensor> kda_fwd_prefill(
+    OptionalTensor output_,
+    OptionalTensor output_state_,
+    torch::Tensor const& q,
+    torch::Tensor const& k,
+    torch::Tensor const& v,
+    OptionalTensor input_state_,
+    OptionalTensor alpha_,
+    OptionalTensor beta_,
+    torch::Tensor const& cu_seqlens,
+    torch::Tensor workspace_buffer,
+    float scale,
+    bool safe_gate) {
+  // Q, K, V: [packed_seq, H, D] (already packed by Python layer)
+  auto packed_seq = q.size(0);
+  auto num_heads = q.size(1);
+  auto head_size = q.size(2);
+  auto num_seqs = cu_seqlens.size(0) - 1;
+
+  // KDA constraint: all head counts must be the same
+  TORCH_CHECK(num_heads == k.size(1), "KDA requires num_q_heads == num_k_heads, got ", num_heads, " vs ", k.size(1));
+  TORCH_CHECK(num_heads == v.size(1), "KDA requires num_q_heads == num_v_heads, got ", num_heads, " vs ", v.size(1));
+  TORCH_CHECK(head_size == v.size(2), "KDA requires Q and V head dim to match, got ", head_size, " vs ", v.size(2));
+
+  // Allocate output if not provided
+  torch::Tensor output = output_.has_value() ? output_.value()
+                                             : torch::empty(
+                                                   {packed_seq, num_heads, head_size},
+                                                   torch::TensorOptions().dtype(q.dtype()).device(q.device()));
+
+  // Allocate output state if not provided
+  torch::Tensor output_state = output_state_.has_value()
+                                   ? output_state_.value()
+                                   : torch::zeros(
+                                         {num_seqs, num_heads, head_size, head_size},
+                                         torch::TensorOptions().dtype(torch::kFloat32).device(q.device()));
+
+  // Validate dtypes
+  TORCH_CHECK(q.dtype() == torch::kBFloat16, "q must be bfloat16");
+  TORCH_CHECK(k.dtype() == torch::kBFloat16, "k must be bfloat16");
+  TORCH_CHECK(v.dtype() == torch::kBFloat16, "v must be bfloat16");
+  TORCH_CHECK(cu_seqlens.dtype() == torch::kInt32, "cu_seqlens must be int32");
+
+  // Validate contiguity
+  TORCH_CHECK(q.is_contiguous(), "q must be contiguous");
+  TORCH_CHECK(k.is_contiguous(), "k must be contiguous");
+  TORCH_CHECK(v.is_contiguous(), "v must be contiguous");
+  TORCH_CHECK(output.is_contiguous(), "output must be contiguous");
+  TORCH_CHECK(output_state.is_contiguous(), "output_state must be contiguous");
+  TORCH_CHECK(cu_seqlens.is_contiguous(), "cu_seqlens must be contiguous");
+  TORCH_CHECK(workspace_buffer.is_contiguous(), "workspace_buffer must be contiguous");
+
+  // Extract optional pointers
+  float const* alpha_ptr = nullptr;
+  float const* beta_ptr = nullptr;
+  float const* input_state_ptr = nullptr;
+
+  if (alpha_.has_value()) {
+    auto& alpha = alpha_.value();
+    TORCH_CHECK(alpha.dtype() == torch::kFloat32, "alpha must be float32");
+    TORCH_CHECK(alpha.is_contiguous(), "alpha must be contiguous");
+    TORCH_CHECK(
+        alpha.size(0) == packed_seq && alpha.size(1) == num_heads && alpha.size(2) == head_size,
+        "alpha shape must be [packed_seq, num_heads, head_size]");
+    alpha_ptr = alpha.data_ptr<float>();
+  }
+  if (beta_.has_value()) {
+    auto& beta = beta_.value();
+    TORCH_CHECK(beta.dtype() == torch::kFloat32, "beta must be float32");
+    TORCH_CHECK(beta.is_contiguous(), "beta must be contiguous");
+    TORCH_CHECK(beta.size(0) == packed_seq && beta.size(1) == num_heads, "beta shape must be [packed_seq, num_heads]");
+    beta_ptr = beta.data_ptr<float>();
+  }
+  if (input_state_.has_value()) {
+    auto& input_state = input_state_.value();
+    TORCH_CHECK(input_state.dtype() == torch::kFloat32, "input_state must be float32");
+    TORCH_CHECK(input_state.is_contiguous(), "input_state must be contiguous");
+    input_state_ptr = input_state.data_ptr<float>();
+  }
+
+  // Auto-compute scale if 0
+  if (scale == 0.0f) {
+    scale = 1.0f / std::sqrt(static_cast<float>(head_size));
+  }
+
+  auto stream = at::cuda::getCurrentCUDAStream();
+  auto sm_count = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
+
+  using bf16 = cute::bfloat16_t;
+  using Sm90 = cutlass::arch::Sm90;
+
+  kda::sm90::launch_kda_fwd_prefill_kernel<Sm90, bf16, bf16, float>(
+      stream,
+      reinterpret_cast<bf16*>(output.data_ptr()),
+      output_state.data_ptr<float>(),
+      reinterpret_cast<bf16 const*>(q.data_ptr()),
+      reinterpret_cast<bf16 const*>(k.data_ptr()),
+      reinterpret_cast<bf16 const*>(v.data_ptr()),
+      input_state_ptr,
+      alpha_ptr,
+      beta_ptr,
+      cu_seqlens.data_ptr<int32_t>(),
+      workspace_buffer.data_ptr<uint8_t>(),
+      static_cast<int32_t>(num_seqs),
+      static_cast<int32_t>(num_heads),
+      static_cast<int32_t>(head_size),
+      static_cast<int64_t>(packed_seq),
+      scale,
+      safe_gate,
+      static_cast<int32_t>(sm_count));
+
+  return {output, output_state};
+}
+
+TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
+  m.def(
+      "kda_fwd_prefill("
+      "Tensor? output_, "
+      "Tensor? output_state_, "
+      "Tensor q, "
+      "Tensor k, "
+      "Tensor v, "
+      "Tensor? input_state_, "
+      "Tensor? alpha_, "
+      "Tensor? beta_, "
+      "Tensor cu_seqlens, "
+      "Tensor workspace_buffer, "
+      "float scale, "
+      "bool safe_gate"
+      ") -> (Tensor, Tensor)");
+  m.impl("kda_fwd_prefill", &kda_fwd_prefill);
+}

--- a/sgl-kernel/csrc/kda/kda_sm90_api.cu
+++ b/sgl-kernel/csrc/kda/kda_sm90_api.cu
@@ -96,6 +96,8 @@ std::tuple<torch::Tensor, torch::Tensor> kda_fwd_prefill(
     TORCH_CHECK(beta.size(0) == packed_seq && beta.size(1) == num_heads, "beta shape must be [packed_seq, num_heads]");
     beta_ptr = beta.data_ptr<float>();
   }
+  // input_state is in SGLang VK layout [N, H, V, K], which matches the kernel's
+  // native LayoutLeft (K, V, H, N) — K is the contiguous dimension in both.
   if (input_state_.has_value()) {
     auto& input_state = input_state_.value();
     TORCH_CHECK(input_state.dtype() == torch::kFloat32, "input_state must be float32");
@@ -135,6 +137,8 @@ std::tuple<torch::Tensor, torch::Tensor> kda_fwd_prefill(
       safe_gate,
       static_cast<int32_t>(sm_count));
 
+  // output_state uses CuTe LayoutLeft (K, V, H, N), which maps to
+  // PyTorch contiguous [N, H, V, K] — already in SGLang VK layout.
   return {output, output_state};
 }
 

--- a/sgl-kernel/csrc/kda/kda_sm90_api.cu
+++ b/sgl-kernel/csrc/kda/kda_sm90_api.cu
@@ -19,6 +19,7 @@
 #include <cute/numeric/numeric_types.hpp>
 
 #include "kda/sm90/prefill_kernel.hpp"
+#include "sgl_flash_kernel_ops.h"
 
 using OptionalTensor = std::optional<torch::Tensor>;
 
@@ -33,7 +34,7 @@ std::tuple<torch::Tensor, torch::Tensor> kda_fwd_prefill(
     OptionalTensor beta_,
     torch::Tensor const& cu_seqlens,
     torch::Tensor workspace_buffer,
-    float scale,
+    double scale,
     bool safe_gate) {
   // Q, K, V: [packed_seq, H, D] (already packed by Python layer)
   auto packed_seq = q.size(0);
@@ -103,8 +104,9 @@ std::tuple<torch::Tensor, torch::Tensor> kda_fwd_prefill(
   }
 
   // Auto-compute scale if 0
-  if (scale == 0.0f) {
-    scale = 1.0f / std::sqrt(static_cast<float>(head_size));
+  float scale_f = static_cast<float>(scale);
+  if (scale_f == 0.0f) {
+    scale_f = 1.0f / std::sqrt(static_cast<float>(head_size));
   }
 
   auto stream = at::cuda::getCurrentCUDAStream();
@@ -129,7 +131,7 @@ std::tuple<torch::Tensor, torch::Tensor> kda_fwd_prefill(
       static_cast<int32_t>(num_heads),
       static_cast<int32_t>(head_size),
       static_cast<int64_t>(packed_seq),
-      scale,
+      scale_f,
       safe_gate,
       static_cast<int32_t>(sm_count));
 
@@ -154,3 +156,5 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       ") -> (Tensor, Tensor)");
   m.impl("kda_fwd_prefill", &kda_fwd_prefill);
 }
+
+REGISTER_EXTENSION(cula_kda_ops)

--- a/sgl-kernel/csrc/kda/sm90/collective/common.hpp
+++ b/sgl-kernel/csrc/kda/sm90/collective/common.hpp
@@ -1,0 +1,462 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cutlass/kernel_hardware_info.h>
+
+#include <cute/tensor.hpp>
+
+namespace kda::sm90::collective {
+
+using namespace cute;
+
+template <typename Atom, typename TA, typename TB, typename TC>
+CUTE_DEVICE void gemm_reset_zero_acc(Atom& atom, TA const& tA, TB const& tB, TC&& tC) {
+  constexpr int rA = decltype(rank(tA))::value;
+  constexpr int rB = decltype(rank(tB))::value;
+  constexpr int rC = decltype(rank(tC))::value;
+  if constexpr (rA == 2 && rB == 2 && rC == 1) {
+    CUTE_UNROLL
+    for (int k_block = 0; k_block < size<1>(tA); k_block++) {
+      cute::gemm(atom, tA(_, k_block), tB(_, k_block), tC);
+      atom.accumulate_ = GMMA::ScaleOut::One;
+    }
+  } else {
+    static_assert(rA == 3 && rB == 3 && rC == 3);
+    CUTE_UNROLL
+    for (int k_block = 0; k_block < size<2>(tA); k_block++) {
+      cute::gemm(atom, tA(_, _, k_block), tB(_, _, k_block), tC);
+      atom.accumulate_ = GMMA::ScaleOut::One;
+    }
+  }
+}
+
+template <typename Atom, typename TA, typename TB, typename TC>
+CUTE_DEVICE void gemm_zero_acc(Atom& atom, TA const& tA, TB const& tB, TC&& tC) {
+  atom.accumulate_ = GMMA::ScaleOut::Zero;
+  gemm_reset_zero_acc(atom, tA, tB, tC);
+}
+
+template <
+    template <cute::GMMA::Major, cute::GMMA::Major, cute::GMMA::ScaleIn, cute::GMMA::ScaleIn> class Primitive,
+    cute::GMMA::Major tA,
+    cute::GMMA::Major tB,
+    cute::GMMA::ScaleIn sA,
+    cute::GMMA::ScaleIn sB>
+CUTE_DEVICE constexpr auto convert_to_gmma_rs(cute::MMA_Atom<Primitive<tA, tB, sA, sB>> const& tiled_mma) {
+  using Atom = cute::MMA_Atom<Primitive<tA, tB, sA, sB>>;
+  using ElementA = typename Atom::ValTypeA;
+  using ElementB = typename Atom::ValTypeB;
+  using ElementC = typename Atom::ValTypeC;
+  using Shape_MNK = typename Atom::Shape_MNK;
+  using RS = decltype(cute::GMMA::rs_op_selector<ElementA, ElementB, ElementC, Shape_MNK, tA, tB, sA, sB>());
+  return cute::MMA_Atom<RS>{};
+}
+
+template <
+    template <cute::GMMA::ScaleIn, cute::GMMA::ScaleIn> class Primitive,
+    cute::GMMA::ScaleIn sA,
+    cute::GMMA::ScaleIn sB>
+CUTE_DEVICE constexpr auto convert_to_gmma_rs(cute::MMA_Atom<Primitive<sA, sB>> const& tiled_mma) {
+  using Atom = cute::MMA_Atom<Primitive<sA, sB>>;
+  using ElementA = typename Atom::ValTypeA;
+  using ElementB = typename Atom::ValTypeB;
+  using ElementC = typename Atom::ValTypeC;
+  using Shape_MNK = typename Atom::Shape_MNK;
+  constexpr auto tA = cute::GMMA::Major::K;
+  constexpr auto tB = cute::GMMA::Major::K;
+  using RS = decltype(cute::GMMA::rs_op_selector<ElementA, ElementB, ElementC, Shape_MNK, tA, tB, sA, sB>());
+  return cute::MMA_Atom<RS>{};
+}
+
+template <class Atom, class... Args>
+CUTE_DEVICE constexpr auto convert_to_gmma_rs(cute::TiledMMA<Atom, Args...> const& tiled_mma) {
+  return cute::TiledMMA<decltype(convert_to_gmma_rs(Atom{})), Args...>{};
+}
+
+template <typename CLayout, typename AValueShape>
+CUTE_DEVICE constexpr auto convert_c_layout_to_a_layout(CLayout const& c, AValueShape const& a) {
+  return make_layout(
+      make_shape(a, shape<1>(c), make_shape(shape<2>(c), size<0>(c) / size(a))),
+      make_stride(stride<0>(c), stride<1>(c), make_stride(stride<2>(c), size<2>(a) * stride<0, 2>(c))));
+}
+
+template <class Layout, class Stages = _1>
+CUTE_DEVICE constexpr auto unstage_smem_layout(Layout const& layout, Stages stages = {}) {
+  return composition(layout, make_tuple(_, _, make_layout(stages)));
+}
+
+template <class Element, class Accumulator, class OperandLayout_TV>
+CUTE_DEVICE auto make_acc_into_op(Accumulator const& acc, OperandLayout_TV const& operand_layout_tv) {
+  Tensor operand = make_fragment_like<Element>(convert_c_layout_to_a_layout(acc.layout(), shape<1>(operand_layout_tv)));
+  Tensor operand_as_acc = make_tensor(operand.data(), acc.layout());
+
+  cute::copy(acc, operand_as_acc);
+
+  if constexpr (sizeof(Element) == 1) {
+    // 00 11 22 33 00 11 22 33 acc layout
+    // 00 00 11 11 22 22 33 33 operand layout
+    // BB AA AA BB AA BB BB AA conflict-free exchange pattern
+    //                         16-bit exchange; so process two at a time potentially
+    int tid = threadIdx.x % 4;
+    auto values_u32 = recast<uint32_t>(operand);
+
+    CUTE_UNROLL
+    for (int n = 0; n < size<1>(values_u32); n++) {
+      CUTE_UNROLL
+      for (int k = 0; k < size<2>(values_u32); k++) {
+        CUTE_UNROLL
+        for (int ii = 0; ii < 8; ii += 4) {
+          uint32_t values_tmp_0 = values_u32(ii / 2 + 0, n, k);
+          uint32_t values_tmp_1 = values_u32(ii / 2 + 1, n, k);
+
+          // step A:
+          // t 1 v 0 -> t 0 v 1
+          // t 2 v 0 -> t 1 v 0
+          // t 0 v 1 -> t 2 v 0
+          // t 3 v 1 -> t 3 v 1
+
+          int v_to_send = tid == 1 || tid == 2 ? 0 : 1;
+          int v_to_recv = v_to_send;
+          int t_to_recv_from = (0x3021 >> (tid * 4)) & 0xF;
+
+          uint32_t values_tmp_a = v_to_send == 0 ? values_tmp_0 : values_tmp_1;
+
+          values_tmp_a = __shfl_sync(0xFFFFFFFF, values_tmp_a, t_to_recv_from, 4);
+
+          // step B:
+          // t 0 v 0 -> t 0 v 0
+          // t 3 v 0 -> t 1 v 1
+          // t 1 v 1 -> t 2 v 1
+          // t 2 v 1 -> t 3 v 0
+
+          v_to_send = 1 - v_to_send;
+          v_to_recv = 1 - v_to_recv;
+          t_to_recv_from = (0x2130 >> (tid * 4)) & 0xF;
+
+          uint32_t values_tmp_b = v_to_send == 0 ? values_tmp_0 : values_tmp_1;
+
+          values_tmp_b = __shfl_sync(0xFFFFFFFF, values_tmp_b, t_to_recv_from, 4);
+
+          values_u32(ii / 2 + 0, n, k) = __byte_perm(values_tmp_a, values_tmp_b, v_to_send == 0 ? 0x1054 : 0x5410);
+          values_u32(ii / 2 + 1, n, k) = __byte_perm(values_tmp_a, values_tmp_b, v_to_send == 0 ? 0x3276 : 0x7632);
+        }
+      }
+    }
+  }
+
+  return operand;
+}
+
+// Convert float register values from BF16 MMA operand A layout to TF32 MMA operand A layout.
+//
+// Both SM80_16x8x8_F32BF16BF16F32_TN and SM80_16x8x8_F32TF32TF32F32_TN have the same
+// per-thread fragment shape: ((_2,_2),_1,_4):((_1,_2),_0,_4) → 16 values per thread.
+// But they map different (M, K) positions to each thread.
+//
+// BF16 LayoutA_TV: ((_4,_8),(_2,_2)):((_32,_1),(_16,_8))
+//   t0 = tid % 4, t1 = tid / 4 (note: Shape<_4,_8> → colmajor → t0 = tid%4)
+//   v_flat = v0 + v1*2: v0 → K offset (stride 16), v1 → M offset (stride 8)
+//   Thread t0 holds K = {2*t0, 2*t0+1} (consecutive K per thread)
+//
+// TF32 LayoutA_TV: ((_4,_8),(_2,_2)):((_16,_1),(_8,_64))
+//   v_flat = v0 + v1*2: v0 → M offset (stride 8), v1 → K offset (stride 64)
+//   Thread t0 holds K = {t0, t0+4} (stride-4 K per thread)
+//
+// Algorithm (two-phase shuffle):
+//   For each v0_tf32 (M selector in TF32), the source data is at v1_bf16 = v0_tf32
+//   in BF16 layout. Both v1_tf32 outputs need the same BF16 value index but from
+//   different source threads.
+//
+//   Phase 1: shuffle bf16_frag[idx0] (v0_bf16=0) from source thread
+//   Phase 2: shuffle bf16_frag[idx1] (v0_bf16=1) from source thread
+//   Then select phase1 or phase2 result based on t0%2.
+//
+// Supports BK=32 (NumKAtoms=4, 16 values) and BK=64 (NumKAtoms=8, 32 values).
+// The shuffle pattern is identical per k-atom; only the loop count changes.
+//
+// @param frag_A  Float tensor with NumKAtoms*4 values in BF16 MMA A layout, converted
+//                in-place to TF32 MMA A layout. Values remain as float; the TF32 MMA
+//                hardware will truncate mantissa bits automatically during execution.
+//                Caller uses recast<DstType>(frag_A) to obtain a typed view if needed.
+// @param local_thread_idx  Thread index within the MMA tile (0..63)
+template <int NumKAtoms = 4, class FragA>
+CUTE_DEVICE void convert_bf16_to_tf32_operandA_layout(FragA& frag_A, int local_thread_idx) {
+  static_assert(cute::is_tensor<cute::remove_cvref_t<FragA>>::value);
+  static_assert(NumKAtoms == 4 || NumKAtoms == 8, "Only BK=32 (4 k-atoms) and BK=64 (8 k-atoms) supported");
+  static_assert(decltype(size(frag_A))::value == NumKAtoms * 4);
+  // Fragment must hold float values (gated results are already in float).
+  // MMA hardware will truncate to tf32 precision automatically.
+  using ElemType = typename cute::remove_cvref_t<FragA>::value_type;
+  static_assert(cute::is_same_v<ElemType, float>, "Fragment must be float; tf32 truncation is done by MMA hw");
+
+  int tid = local_thread_idx % 32;  // lane within warp
+  int t0 = tid % 4;
+  bool sel_odd = (t0 & 1);  // t0%2: selects v0_bf16=1 result
+
+  // Source lane for v1_tf32=0: t0_src = t0/2, lane = t0_src + (tid & ~3)
+  // Source lane for v1_tf32=1: t0_src = t0/2+2, lane = (t0/2+2) + (tid & ~3)
+  int src_lane_lo = (t0 / 2) + (tid & ~3);
+  int src_lane_hi = (t0 / 2 + 2) + (tid & ~3);
+
+  // Process NumKAtoms k-iterations, each with 4 values: [4j+0, 4j+1, 4j+2, 4j+3]
+  // BF16 fragment layout per k-iter: (v0_bf16=0,v1_bf16=0), (v0_bf16=1,v1_bf16=0),
+  //                                   (v0_bf16=0,v1_bf16=1), (v0_bf16=1,v1_bf16=1)
+  // TF32 output layout per k-iter:   (v0_tf32=0,v1_tf32=0), (v0_tf32=1,v1_tf32=0),
+  //                                   (v0_tf32=0,v1_tf32=1), (v0_tf32=1,v1_tf32=1)
+  CUTE_UNROLL
+  for (int j = 0; j < NumKAtoms; j++) {
+    // Read all 4 input values for this k-iter before writing any output,
+    // to avoid read-after-write hazard (in-place update).
+    float in0 = frag_A(0 + 4 * j);  // v0_bf16=0, v1_bf16=0
+    float in1 = frag_A(1 + 4 * j);  // v0_bf16=1, v1_bf16=0
+    float in2 = frag_A(2 + 4 * j);  // v0_bf16=0, v1_bf16=1
+    float in3 = frag_A(3 + 4 * j);  // v0_bf16=1, v1_bf16=1
+
+    // For v0_tf32=0: M is selected by v1_bf16=0, so source values are (in0, in1)
+    // For v0_tf32=1: M is selected by v1_bf16=1, so source values are (in2, in3)
+    float out_vals[4];
+    CUTE_UNROLL
+    for (int v0_tf32 = 0; v0_tf32 < 2; v0_tf32++) {
+      float val0 = (v0_tf32 == 0) ? in0 : in2;  // v0_bf16=0 at chosen v1_bf16
+      float val1 = (v0_tf32 == 0) ? in1 : in3;  // v0_bf16=1 at chosen v1_bf16
+
+      // Shuffle to get values from source threads
+      float recv0_lo = __shfl_sync(0xFFFFFFFF, val0, src_lane_lo);
+      float recv1_lo = __shfl_sync(0xFFFFFFFF, val1, src_lane_lo);
+      float recv0_hi = __shfl_sync(0xFFFFFFFF, val0, src_lane_hi);
+      float recv1_hi = __shfl_sync(0xFFFFFFFF, val1, src_lane_hi);
+
+      // Select based on t0%2: even → v0_bf16=0, odd → v0_bf16=1
+      out_vals[v0_tf32 + 0] = sel_odd ? recv1_lo : recv0_lo;  // v1_tf32=0
+      out_vals[v0_tf32 + 2] = sel_odd ? recv1_hi : recv0_hi;  // v1_tf32=1
+    }
+
+    // Write all 4 output values
+    frag_A(0 + 4 * j) = out_vals[0];
+    frag_A(1 + 4 * j) = out_vals[1];
+    frag_A(2 + 4 * j) = out_vals[2];
+    frag_A(3 + 4 * j) = out_vals[3];
+  }
+}
+
+// Convert float register values from BF16 MMA operand B layout to TF32 MMA operand B layout.
+//
+// BF16 LayoutB_TV: ((_4,_8),_2):((_16,_1),_8)
+//   Thread t0 holds K = {2*t0, 2*t0+1}. v selects K offset (consecutive).
+//
+// TF32 LayoutB_TV: ((_4,_8),_2):((_8,_1),_32)
+//   Thread t0 holds K = {t0, t0+4}. v selects K offset (stride-4).
+//
+// Same two-phase shuffle approach as operand A, but B has only 2 values per atom
+// (no M dimension in the value index).
+//
+// Supports BK=32 (NumKAtoms=4, 8 values) and BK=64 (NumKAtoms=8, 16 values).
+//
+// @param frag_B  Float tensor with NumKAtoms*2 values in BF16 MMA B layout, converted
+//                in-place. Values remain as float; TF32 MMA hardware truncates automatically.
+//                Caller uses recast<DstType>(frag_B) to obtain a typed view if needed.
+// @param local_thread_idx  Thread index within the MMA tile (0..63)
+template <int NumKAtoms = 4, class FragB>
+CUTE_DEVICE void convert_bf16_to_tf32_operandB_layout(FragB& frag_B, int local_thread_idx) {
+  static_assert(cute::is_tensor<cute::remove_cvref_t<FragB>>::value);
+  static_assert(NumKAtoms == 4 || NumKAtoms == 8, "Only BK=32 (4 k-atoms) and BK=64 (8 k-atoms) supported");
+  static_assert(decltype(size(frag_B))::value == NumKAtoms * 2);
+  // Fragment must hold float values; MMA hardware truncates to tf32 automatically.
+  using ElemType = typename cute::remove_cvref_t<FragB>::value_type;
+  static_assert(cute::is_same_v<ElemType, float>, "Fragment must be float; tf32 truncation is done by MMA hw");
+
+  int tid = local_thread_idx % 32;
+  int t0 = tid % 4;
+  bool sel_odd = (t0 & 1);
+
+  int src_lane_lo = (t0 / 2) + (tid & ~3);
+  int src_lane_hi = (t0 / 2 + 2) + (tid & ~3);
+
+  // Process NumKAtoms k-iterations, each with 2 values: [2j, 2j+1]
+  CUTE_UNROLL
+  for (int j = 0; j < NumKAtoms; j++) {
+    int idx0 = 2 * j;      // BF16 v=0, K = 2*t0
+    int idx1 = 2 * j + 1;  // BF16 v=1, K = 2*t0+1
+
+    float val0 = frag_B(idx0);
+    float val1 = frag_B(idx1);
+
+    // v_tf32=0: need K=t0 from src_t0=t0/2
+    float recv0_lo = __shfl_sync(0xFFFFFFFF, val0, src_lane_lo);
+    float recv1_lo = __shfl_sync(0xFFFFFFFF, val1, src_lane_lo);
+    // v_tf32=1: need K=t0+4 from src_t0=t0/2+2
+    float recv0_hi = __shfl_sync(0xFFFFFFFF, val0, src_lane_hi);
+    float recv1_hi = __shfl_sync(0xFFFFFFFF, val1, src_lane_hi);
+
+    frag_B(idx0) = sel_odd ? recv1_lo : recv0_lo;
+    frag_B(idx1) = sel_odd ? recv1_hi : recv0_hi;
+  }
+}
+
+// Broadcast row 0 from a BF16 MMA operand A fragment and output directly
+// into a BF16 MMA operand B fragment.
+//
+// Combines broadcast_row0 + extract_A_to_B into one step, avoiding the
+// intermediate 16-float operand A broadcast tensor (saves 8 float registers).
+//
+// Since g_first is broadcast (all M rows identical), operand B only needs
+// the K-dimension values. We shuffle v1=0 values from the t1=0 thread
+// and output the 8-value B fragment directly.
+//
+// BF16 A layout: t0 = tid % 4, t1 = tid / 4. Row 0 at t1=0, v1=0.
+//   frag_A(4j+0) = (v0=0, v1=0), frag_A(4j+1) = (v0=1, v1=0)
+// BF16 B layout: frag_B(2j+0) = v=0, frag_B(2j+1) = v=1
+// Both have K = {2*t0, 2*t0+1} at same positions.
+//
+// Supports BK=32 (NumKAtoms=4) and BK=64 (NumKAtoms=8).
+//
+// Cost: 2 shuffles per k-iter × NumKAtoms k-iters.
+// Saves: NumKAtoms*4-float intermediate tensor (vs broadcast_row0 + extract).
+//
+// @param frag_A       Input: alpha[m, k] in BF16 MMA A layout (NumKAtoms*4 values)
+// @param frag_B_first Output: alpha[0, k] in BF16 MMA B layout (NumKAtoms*2 values)
+// @param local_thread_idx  Thread index within the MMA tile (0..63)
+template <int NumKAtoms = 4, class FragA, class FragB>
+CUTE_DEVICE void
+broadcast_row0_operandA_to_operandB_bf16_layout(FragA const& frag_A, FragB& frag_B_first, int local_thread_idx) {
+  static_assert(cute::is_tensor<cute::remove_cvref_t<FragA>>::value);
+  static_assert(cute::is_tensor<cute::remove_cvref_t<FragB>>::value);
+  static_assert(NumKAtoms == 4 || NumKAtoms == 8, "Only BK=32 (4 k-atoms) and BK=64 (8 k-atoms) supported");
+  static_assert(decltype(size(frag_A))::value == NumKAtoms * 4);
+  static_assert(decltype(size(frag_B_first))::value == NumKAtoms * 2);
+
+  int tid = local_thread_idx % 32;  // lane within warp
+  // Row 0 is at t1=0. In BF16 A layout, t0 = tid % 4, t1 = tid / 4.
+  // Source lane: same t0, t1=0 → src = tid % 4.
+  int src_lane = tid % 4;
+
+  CUTE_UNROLL
+  for (int j = 0; j < NumKAtoms; j++) {
+    // Shuffle v1=0 values from thread with t1=0 (row 0 holder)
+    // frag_A(4j+0) = (v0=0, v1=0) → K=2*t0
+    // frag_A(4j+1) = (v0=1, v1=0) → K=2*t0+1
+    auto val0 = __shfl_sync(0xFFFFFFFF, frag_A(4 * j + 0), src_lane);
+    auto val1 = __shfl_sync(0xFFFFFFFF, frag_A(4 * j + 1), src_lane);
+
+    // Output directly into B layout: frag_B(2j) = K_lo, frag_B(2j+1) = K_hi
+    frag_B_first(2 * j + 0) = val0;
+    frag_B_first(2 * j + 1) = val1;
+  }
+}
+
+// Broadcast row 0 across all M rows in a BF16 MMA operand A fragment.
+//
+// Given frag_A holding alpha[m, k] per thread, produces frag_A_first holding alpha[0, k]
+// for all m (broadcast). This eliminates a redundant S2R load of g_first from shared memory.
+//
+// BF16 LayoutA_TV: ((_4,_8),(_2,_2)):((_32,_1),(_16,_8))
+//   tid decomposition: t0 = tid % 4, t1 = tid / 4
+//   m = t1 + v1*8 (v1 selects M row within thread)
+//   Row 0 is held by threads with t1=0, at v1=0 positions.
+//
+// Algorithm:
+//   For each k-iter, shuffle v1=0 values from thread (tid % 4) (same t0, t1=0),
+//   then replicate to v1=1 positions.
+//
+// Supports BK=32 (NumKAtoms=4) and BK=64 (NumKAtoms=8).
+//
+// Cost: 2 shuffles per k-iter × NumKAtoms k-iters.
+//
+// @param frag_A       Input: alpha[m, k] in BF16 MMA A layout (NumKAtoms*4 values)
+// @param frag_A_first Output: alpha[0, k] broadcast in BF16 MMA A layout (NumKAtoms*4 values)
+// @param local_thread_idx  Thread index within the MMA tile (0..63)
+template <int NumKAtoms = 4, class FragA, class FragAFirst>
+CUTE_DEVICE void
+broadcast_row0_operandA_bf16_layout(FragA const& frag_A, FragAFirst& frag_A_first, int local_thread_idx) {
+  static_assert(cute::is_tensor<cute::remove_cvref_t<FragA>>::value);
+  static_assert(cute::is_tensor<cute::remove_cvref_t<FragAFirst>>::value);
+  static_assert(NumKAtoms == 4 || NumKAtoms == 8, "Only BK=32 (4 k-atoms) and BK=64 (8 k-atoms) supported");
+  static_assert(decltype(size(frag_A))::value == NumKAtoms * 4);
+  static_assert(decltype(size(frag_A_first))::value == NumKAtoms * 4);
+
+  int tid = local_thread_idx % 32;  // lane within warp
+  // Row 0 is at t1=0 → tid % 4 (keep same t0, set t1=0)
+  int src_lane = tid % 4;
+
+  CUTE_UNROLL
+  for (int j = 0; j < NumKAtoms; j++) {
+    // v1=0 positions hold m=t1, v1=1 positions hold m=t1+8
+    // We want m=0, which is at t1=0, v1=0 → indices 4j+0 and 4j+1
+    auto val0 = __shfl_sync(0xFFFFFFFF, frag_A(4 * j + 0), src_lane);  // alpha[0, 2*t0] from t1=0
+    auto val1 = __shfl_sync(0xFFFFFFFF, frag_A(4 * j + 1), src_lane);  // alpha[0, 2*t0+1] from t1=0
+
+    // Broadcast to both v1=0 and v1=1 (same value, different M rows)
+    frag_A_first(4 * j + 0) = val0;  // v0=0, v1=0
+    frag_A_first(4 * j + 1) = val1;  // v0=1, v1=0
+    frag_A_first(4 * j + 2) = val0;  // v0=0, v1=1 (broadcast)
+    frag_A_first(4 * j + 3) = val1;  // v0=1, v1=1 (broadcast)
+  }
+}
+
+// Extract BF16 MMA operand B fragment from a BF16 MMA operand A fragment,
+// for data that is **broadcast across M rows** (e.g., g_first = g[row=0, :]).
+//
+// When the source data is broadcast (identical for all M rows), the K-dimension
+// mapping is the same in both A and B BF16 MMA layouts:
+//   A: thread t0 holds K = {2*t0, 2*t0+1} at v0={0,1}, with v1 selecting M row
+//   B: thread t0 holds K = {2*t0, 2*t0+1} at v={0,1}
+//
+// Since M rows are identical (broadcast), we can simply pick v1=0 from A:
+//   frag_B(2j + 0) = frag_A(4j + 0)   // v0_bf16=0 → K=2*t0
+//   frag_B(2j + 1) = frag_A(4j + 1)   // v0_bf16=1 → K=2*t0+1
+//
+// Supports BK=32 (NumKAtoms=4) and BK=64 (NumKAtoms=8).
+//
+// This avoids a redundant S2R load from shared memory.
+// No warp shuffles needed — purely register-local extraction.
+//
+// @param frag_A  Float tensor with NumKAtoms*4 values in BF16 MMA A layout (broadcast data)
+// @param frag_B  Float tensor with NumKAtoms*2 values in BF16 MMA B layout (output)
+template <int NumKAtoms = 4, class FragA, class FragB>
+CUTE_DEVICE void extract_broadcast_operandA_to_operandB_bf16_layout(FragA const& frag_A, FragB& frag_B) {
+  static_assert(cute::is_tensor<cute::remove_cvref_t<FragA>>::value);
+  static_assert(cute::is_tensor<cute::remove_cvref_t<FragB>>::value);
+  static_assert(NumKAtoms == 4 || NumKAtoms == 8, "Only BK=32 (4 k-atoms) and BK=64 (8 k-atoms) supported");
+  static_assert(decltype(size(frag_A))::value == NumKAtoms * 4);
+  static_assert(decltype(size(frag_B))::value == NumKAtoms * 2);
+
+  CUTE_UNROLL
+  for (int j = 0; j < NumKAtoms; j++) {
+    // A layout per k-iter: [4j+0]=(v0=0,v1=0), [4j+1]=(v0=1,v1=0), [4j+2]=(v0=0,v1=1), [4j+3]=(v0=1,v1=1)
+    // B layout per k-iter: [2j+0]=v=0, [2j+1]=v=1
+    // For broadcast data, v1 doesn't matter, so pick v1=0:
+    frag_B(2 * j + 0) = frag_A(4 * j + 0);  // K = 2*t0
+    frag_B(2 * j + 1) = frag_A(4 * j + 1);  // K = 2*t0+1
+  }
+}
+
+}  // namespace kda::sm90::collective

--- a/sgl-kernel/csrc/kda/sm90/collective/load_predicated.hpp
+++ b/sgl-kernel/csrc/kda/sm90/collective/load_predicated.hpp
@@ -1,0 +1,190 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cutlass/cutlass.h>
+
+#include <cute/tensor.hpp>
+#include <cutlass/pipeline/sm90_pipeline.hpp>
+
+#include "kda/sm90/utils/debug.hpp"
+#include "kda/sm90/utils/unused.hpp"
+
+namespace kda::sm90::collective {
+
+using namespace cute;
+
+// Wraps a callable into a predicate "tensor" usable by CuTe's copy_if.
+// copy_if calls pred(i) with a linear index; the wrapped function maps that index to bool.
+template <class Fn>
+struct FunctionPredTensor {
+  Fn fn_;
+  CUTE_HOST_DEVICE
+  FunctionPredTensor(Fn fn) : fn_(fn) {}
+  template <class Idx>
+  CUTE_HOST_DEVICE bool operator()(Idx const& i) const {
+    return fn_(i);
+  }
+};
+
+enum class LoadKindVector {
+  kAlpha,
+  kBeta,
+};
+
+CUTE_HOST_DEVICE constexpr char const* to_string(LoadKindVector kind) {
+  if (kind == LoadKindVector::kAlpha) {
+    return "alpha";
+  } else if (kind == LoadKindVector::kBeta) {
+    return "beta";
+  } else {
+    return "unknown loadkind";
+  }
+}
+
+template <
+    LoadKindVector kKind,
+    class Pipeline,
+    class ElementSrc,
+    class GmemLayout,
+    class ElementDst,
+    class SmemLayout,
+    class VectorProcessor_ = Unused>
+struct CollectiveLoadVector {
+  using SharedStorage = cute::array_aligned<ElementDst, cute::cosize_v<SmemLayout>>;
+  using PipelineState = typename cutlass::PipelineState<Pipeline::Stages>;
+
+  using VectorProcessor = VectorProcessor_;
+
+  static_assert(rank_v<SmemLayout> == 2 || rank_v<SmemLayout> == 3);
+
+  static constexpr LoadKindVector kind = kKind;
+  static constexpr int VectorSize = size<0>(SmemLayout{});
+
+  CUTE_DEVICE
+  CollectiveLoadVector(
+      ElementSrc const* src, GmemLayout layout, ElementSrc oob_value, Pipeline& pipeline, SharedStorage& storage)
+      : src_(src), src_layout_(layout), src_oob_value_(oob_value), pipeline_(pipeline), storage_(storage) {}
+
+  template <class ProblemSize, class TileShape, class WorkDesc>
+  CUTE_DEVICE auto
+  partition_SD(ProblemSize const& problem_size, TileShape const& tile_shape, WorkDesc const& work_desc) {
+    constexpr auto BlkSeqQ = decltype(get<0>(tile_shape))::value;
+
+    Tensor g = [&] {
+      auto head_idx = work_desc.o_head_idx();
+      DPRINTF0_W(
+          "slice view GMEM %s: seq_idx:%d head_idx:%d tok_offset:%lld\n",
+          to_string(kind),
+          work_desc.seq_idx,
+          head_idx,
+          work_desc.tok_offset);
+      Tensor m_varlen_head = make_tensor(make_gmem_ptr(src_), src_layout_);
+
+      Tensor m_varlen = m_varlen_head(_, head_idx);  // slice into current head_idx
+      Tensor m_offset =
+          domain_offset(make_coord(work_desc.tok_offset), m_varlen);  // offset to start of the current sequence
+      Tensor g_full = flat_divide(m_offset, BlkSeqQ);                 // (blk, iter_blk)
+      return g_full;
+    }();
+    // (blk, pipe) or (blk, pipe, N), N for feature rich preprocess, data will be stored at 0
+    Tensor s = make_tensor(make_smem_ptr(storage_.data()), SmemLayout{});
+
+    auto thr_layout = Layout<_32>{};
+    auto val_layout = Layout<_1>{};
+    auto tiled_copy = make_tiled_copy(Copy_Atom<UniversalCopy<ElementSrc>, ElementDst>{}, thr_layout, val_layout);
+    auto thr_copy = tiled_copy.get_thread_slice(cutlass::canonical_lane_idx());
+
+    auto coord = thr_copy.partition_S(make_identity_tensor(Shape<Int<BlkSeqQ>, _1>{}));
+    int seq_len = work_desc.chunk_len();
+    auto len_of_last_blk = seq_len - (ceil_div(seq_len, BlkSeqQ) - 1) * BlkSeqQ;
+
+    auto mask = FunctionPredTensor([coord, len_of_last_blk](auto frag_coord) {
+      auto coord_in_blk = get<0>(coord(frag_coord));
+      return coord_in_blk < len_of_last_blk;
+    });
+
+    auto src = thr_copy.partition_S(g);  // (cpy, iter_cpy, iter_blk)
+    auto dst = thr_copy.partition_D(s);  // (cpy, iter_cpy, pipe)
+
+    return make_tuple(src, dst, mask);
+  }
+
+  template <bool IsTail, class SrcDst>
+  CUTE_DEVICE void
+  step(SrcDst const& src_dst, int src_iter, PipelineState& dst_pipe, int num_iters, VectorProcessor processor = {}) {
+    auto src = get<0>(src_dst);
+    auto dst = get<1>(src_dst);
+
+    auto regs = make_fragment_like<ElementSrc>(take<0, 2>(shape(dst)));
+    if constexpr (!IsTail) {
+      copy(src(_, _, src_iter), regs);
+    } else {
+      auto mask = get<2>(src_dst);
+      fill(regs, src_oob_value_);
+      copy_if(mask, src(_, _, src_iter), regs);
+    }
+
+    int dst_pipe_idx = dst_pipe.index();
+
+    DPRINTF0_WG("%s pipeline.producer_acquire smem_pipe_write:%d\n", to_string(kind), dst_pipe_idx);
+    pipeline_.producer_acquire(dst_pipe);
+    cutlass::arch::fence_view_async_shared();
+
+    if constexpr (rank_v<SmemLayout> == 3) {
+      copy(regs, dst(_, _, _0{}, dst_pipe_idx));
+    } else {
+      copy(regs, dst(_, _, dst_pipe_idx));
+    }
+
+    Tensor s = make_tensor(make_smem_ptr(storage_.data()), SmemLayout{});
+    if constexpr (!std::is_same_v<VectorProcessor, Unused>) {
+      if constexpr (rank_v<SmemLayout> == 3) {
+        processor(s(_, _, dst_pipe_idx));
+      } else {
+        processor(s(_, dst_pipe_idx));
+      }
+    }
+
+    cutlass::arch::fence_view_async_shared();
+    pipeline_.producer_commit(dst_pipe);
+    ++dst_pipe;
+  }
+
+ private:
+  ElementSrc const* src_;
+  GmemLayout src_layout_;  // in (packed_seq, H) coordinate
+  ElementSrc src_oob_value_;
+  Pipeline& pipeline_;
+  SharedStorage& storage_;
+};
+
+}  // namespace kda::sm90::collective

--- a/sgl-kernel/csrc/kda/sm90/collective/load_tma.hpp
+++ b/sgl-kernel/csrc/kda/sm90/collective/load_tma.hpp
@@ -1,0 +1,166 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cutlass/cutlass.h>
+
+#include <cute/tensor.hpp>
+#include <cutlass/pipeline/sm90_pipeline.hpp>
+
+#include "kda/sm90/utils/debug.hpp"
+
+namespace kda::sm90::collective {
+
+using namespace cute;
+
+enum class LoadKind {
+  kQ,
+  kK,
+  kV,
+  kAlpha,
+};
+
+CUTE_HOST_DEVICE constexpr char const* to_string(LoadKind kind) {
+  if (kind == LoadKind::kQ) {
+    return "Q";
+  } else if (kind == LoadKind::kK) {
+    return "K";
+  } else if (kind == LoadKind::kV) {
+    return "V";
+  } else if (kind == LoadKind::kAlpha) {
+    return "Alpha";
+  } else {
+    return "unknown loadkind";
+  }
+}
+
+template <LoadKind kKind, class Pipeline, class Element, class SmemLayout, class TMA>
+struct CollectiveLoadTma {
+  using SharedStorage = cute::array_aligned<Element, cute::cosize_v<SmemLayout>>;
+  using PipelineState = typename cutlass::PipelineState<Pipeline::Stages>;
+
+  static constexpr LoadKind kind = kKind;
+  TMA const& tma_load;
+  Pipeline& pipeline;
+  SharedStorage& storage;
+
+  CUTE_DEVICE
+  CollectiveLoadTma(TMA const& tma_load, Pipeline& pipeline, SharedStorage& storage)
+      : tma_load(tma_load), pipeline(pipeline), storage(storage) {}
+
+  template <class ProblemSize, class TileShape, class WorkDesc>
+  CUTE_DEVICE auto
+  partition_SD(ProblemSize const& problem_size, TileShape const& tile_shape, WorkDesc const& work_desc) {
+    constexpr auto BlkSeqQ = decltype(get<0>(tile_shape))::value;
+    constexpr auto BlkSeqKV = decltype(get<1>(tile_shape))::value;
+    constexpr auto HeadSize = decltype(get<2>(tile_shape))::value;
+
+    Tensor g = [&] {
+      if constexpr (kind == LoadKind::kQ) {
+        DPRINTF0_W(
+            "slice view GMEM %s: seq_idx:%d head_idx:%d tok_offset:%lld\n",
+            to_string(kind),
+            work_desc.seq_idx,
+            work_desc.q_head_idx(),
+            work_desc.tok_offset);
+        Tensor m_varlen_head = tma_load.get_tma_tensor(make_shape(
+            problem_size.total_seqlen,
+            problem_size.head_size,
+            problem_size.num_heads));                                   // global view to the packed varlen sequence
+        Tensor m_varlen = m_varlen_head(_, _, work_desc.q_head_idx());  // slice into current head_idx
+        Tensor m_offset = domain_offset(
+            make_coord(work_desc.tok_offset, _0{}),
+            m_varlen);  // offset to start of the current sequence
+        Tensor g_full = local_tile(m_offset, make_tile(BlkSeqQ, HeadSize), make_coord(_, _0{}));  // (blk, d, iter_blk)
+        return g_full;
+      } else if constexpr (kind == LoadKind::kAlpha) {  // same as Q currently
+        DPRINTF0_W(
+            "slice view GMEM %s: seq_idx:%d head_idx:%d tok_offset:%lld\n",
+            to_string(kind),
+            work_desc.seq_idx,
+            work_desc.q_head_idx(),
+            work_desc.tok_offset);
+        Tensor m_varlen_head = tma_load.get_tma_tensor(make_shape(
+            problem_size.total_seqlen,
+            problem_size.head_size,
+            problem_size.num_heads));                                   // global view to the packed varlen sequence
+        Tensor m_varlen = m_varlen_head(_, _, work_desc.q_head_idx());  // slice into current head_idx
+        Tensor m_offset = domain_offset(
+            make_coord(work_desc.tok_offset, _0{}),
+            m_varlen);  // offset to start of the current sequence
+        Tensor g_full = local_tile(m_offset, make_tile(BlkSeqQ, HeadSize), make_coord(_, _0{}));  // (blk, d, iter_blk)
+        return g_full;
+      } else {
+        auto head_idx = (kind == LoadKind::kK ? work_desc.k_head_idx() : work_desc.v_head_idx());
+        DPRINTF0_W(
+            "slice view GMEM %s: seq_idx:%d head_idx:%d tok_offset:%lld\n",
+            to_string(kind),
+            work_desc.seq_idx,
+            head_idx,
+            work_desc.tok_offset);
+        Tensor m_varlen_head = tma_load.get_tma_tensor(make_shape(
+            problem_size.head_size,
+            problem_size.total_seqlen,
+            problem_size.num_heads));                     // global view to the packed varlen sequence
+        Tensor m_varlen = m_varlen_head(_, _, head_idx);  // slice into current head_idx
+        Tensor m_offset = domain_offset(
+            make_coord(_0{}, work_desc.tok_offset),
+            m_varlen);  // offset to start of the current sequence
+        Tensor g_full = local_tile(m_offset, make_tile(HeadSize, BlkSeqKV), make_coord(_0{}, _));  // (d, blk, iter_blk)
+        return g_full;
+      }
+    }();
+    Tensor s = make_tensor(make_smem_ptr(storage.data()), SmemLayout{});
+
+    auto block_tma = tma_load.get_slice(_0{});  // do not support cluster
+    return make_tuple(block_tma.partition_S(g), block_tma.partition_D(s));
+  }
+
+  template <bool kAcquireBarrier = true, class SrcDst>
+  CUTE_DEVICE void step(SrcDst const& src_dst, int src_iter, PipelineState& dst_pipe, uint32_t lane_predicate) {
+    if (lane_predicate == 1) {
+      DPRINTF_WG("%s pipeline.producer_acquire smem_pipe_write:%d\n", to_string(kind), dst_pipe.index());
+      if constexpr (kAcquireBarrier) {
+        pipeline.producer_acquire(dst_pipe);
+      }
+      using BarrierType = typename Pipeline::ProducerBarrierType;
+      BarrierType* tma_barrier = pipeline.producer_get_barrier(dst_pipe);
+
+      auto src = get<0>(src_dst);
+      auto dst = get<1>(src_dst);
+
+      copy(tma_load.with(*tma_barrier), src(_, _, _, src_iter), dst(_, _, _, dst_pipe.index()));
+      ++dst_pipe;
+    }
+  }
+};
+
+}  // namespace kda::sm90::collective

--- a/sgl-kernel/csrc/kda/sm90/collective/mainloop_kda_fwd.hpp
+++ b/sgl-kernel/csrc/kda/sm90/collective/mainloop_kda_fwd.hpp
@@ -1,0 +1,2047 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cutlass/cutlass.h>
+
+#include <cutlass/gemm/collective/collective_builder.hpp>
+
+#include "kda/sm90/collective/common.hpp"
+#include "kda/sm90/collective/load_predicated.hpp"
+#include "kda/sm90/collective/load_tma.hpp"
+#include "kda/sm90/collective/named_barriers.hpp"
+#include "kda/sm90/collective/store_tma.hpp"
+#include "kda/sm90/kernel/options.hpp"
+#include "kda/sm90/utils/debug.hpp"
+#include "kda/sm90/utils/math_order_barrier.hpp"
+#include "kda/sm90/utils/unused.hpp"
+#include "kerutils/kerutils.cuh"
+
+// #define INLINE_LAMBDA [[gnu::always_inline]]
+#define INLINE_LAMBDA __attribute__((always_inline))
+// #define INLINE_LAMBDA [[msvc::forceinline]]
+
+#define WORKAROUND_WGMMA_PERFORMANCE_LOSS() \
+  if (thread_idx > 8192) {                  \
+    __syncwarp();                           \
+  }
+
+namespace kda::sm90::collective {
+
+struct KdaNamedBarriers : FlatSharedNamedBarriers {
+  static constexpr int StateMath = FlatSharedNamedBarriers::NumBarriersUsed + 0;
+  static constexpr int AuxMath = FlatSharedNamedBarriers::NumBarriersUsed + 1;
+  static constexpr int StateMathWG0 = FlatSharedNamedBarriers::NumBarriersUsed + 2;
+  // NOTE: only for debug
+  // used for subchunk MMA with two groups, each group has 2 warps
+  // static constexpr int AuxMathWarp0 = FlatSharedNamedBarriers::NumBarriersUsed + 3;
+  // static constexpr int AuxMathWarp1 = FlatSharedNamedBarriers::NumBarriersUsed + 4;
+};
+
+using ku::alignment_for_swizzle;
+using ku::select_layout;
+using ku::select_tensor;
+using namespace cute;
+using kda::sm90::kernel::find_option_t;
+using kda::sm90::kernel::Tag;
+
+template <
+    class Element_,
+    class ElementAccumulatorQK_,
+    class ElementAccumulatorKV_,
+    class TileShape_,  // (seqlen_q, seqlen_kv, d)
+    class LayoutQ_,
+    class LayoutK_,
+    class LayoutV_,
+    class LayoutO_,  // (seqlen_q/k, d, h)
+    class Options>
+struct FlatMainloopTmaWarpSpecializedKdaFwd {
+  using Element = Element_;
+  using ElementAccumulatorQK = ElementAccumulatorQK_;
+  using ElementAccumulatorO = ElementAccumulatorQK;
+  using ElementAccumulatorKV = ElementAccumulatorKV_;
+  using ElementO = Element;
+  using ElementAlpha = float;
+  // TODO: support bf16 beta
+  using ElementBeta = float;
+  using ElementGatedMMA = cutlass::tfloat32_t;
+
+  using TileShape = TileShape_;
+
+  using LayoutQ = LayoutQ_;      // (seqlen_q, d, h)
+  using LayoutK = LayoutK_;      // (seqlen_k, d, h)
+  using LayoutV = LayoutV_;      // (seqlen_k, d, h)
+  using LayoutO = LayoutO_;      // (seqlen_k, d, h)
+  using LayoutAlpha = LayoutQ_;  // (seqlen_q, d, h)
+
+  // Options
+  static constexpr bool kIsPersistent = find_option_t<Tag::kIsPersistent, false_type, Options>::value;
+
+  static constexpr bool kInitStateFromInput = find_option_t<Tag::kInitStateFromInput, false_type, Options>::value;
+
+  static constexpr int NumLoadWarpGroups = 1;
+  static constexpr int NumStateMmaWarpGroups = 2;
+  static constexpr int NumAuxMmaWarpGroups = 1;
+
+  static constexpr int StageCountQ = find_option_t<Tag::kStagesQ, Int<2>, Options>::value;
+  static constexpr int StageCountK = find_option_t<Tag::kStagesK, Int<2>, Options>::value;
+  static constexpr int StageCountV = find_option_t<Tag::kStagesV, Int<1>, Options>::value;
+
+  static constexpr int NeedsAlpha = find_option_t<Tag::kNeedsAlpha, cute::true_type, Options>::value;
+  static constexpr int NeedsBeta = find_option_t<Tag::kNeedsBeta, cute::true_type, Options>::value;
+  static_assert(NeedsAlpha && NeedsBeta, "Alpha and Beta are both used in KDA.");
+
+  static constexpr int SafeGate = true;  // only support safe_gate=true
+
+  static constexpr int NumLoadThreads = NumLoadWarpGroups * 128;
+  static constexpr int NumStateMmaThreads = NumStateMmaWarpGroups * 128;
+  static constexpr int NumAuxMmaThreads = NumAuxMmaWarpGroups * 128;
+
+  static constexpr uint32_t OrderedBarrierId0 = uint32_t(cutlass::arch::ReservedNamedBarriers::StreamkBarrier0);
+  static constexpr uint32_t OrderedBarrierId1 = uint32_t(cutlass::arch::ReservedNamedBarriers::StreamkBarrier1);
+
+  using OrderedMathBarriers = std::conditional_t<
+      NumStateMmaWarpGroups == 2,
+      OrderedNamedBarriers</*UseReservedNB=*/true, OrderedBarrierId0, OrderedBarrierId1>,
+      OrderedNamedBarriers</*UseReservedNB=*/true, OrderedBarrierId0>>;
+
+  using StagesQ = cutlass::gemm::collective::StageCount<StageCountQ>;
+  using StagesK = cutlass::gemm::collective::StageCount<StageCountK>;
+  using StagesV = cutlass::gemm::collective::StageCount<StageCountV>;
+  using StagesQ_K_Scaled = cutlass::gemm::collective::StageCount<2>;
+  using StagesO = cutlass::gemm::collective::StageCount<1>;
+  using ClusterShape = Shape<_1, _1, _1>;
+
+  using StagesQK = cutlass::gemm::collective::StageCount<2>;
+  using StagesKK = cutlass::gemm::collective::StageCount<2>;
+
+  using StagesAlpha = cutlass::gemm::collective::StageCount<2>;
+  using StagesBeta = cutlass::gemm::collective::StageCount<2>;
+
+  static constexpr int Alignment = 16 / sizeof(Element);
+
+  static constexpr auto BlkSeqQ = get<0>(TileShape{});   // Blk_Q
+  static constexpr auto BlkSeqKV = get<1>(TileShape{});  // Blk_K/V
+  static constexpr auto HeadSize = get<2>(TileShape{});  // D (Dq, Dk, Dv all equal)
+  static constexpr auto HeadSizeQK = HeadSize;
+  static constexpr auto HeadSizeV = HeadSize;
+  using HeadSizeHalf = _64;
+  using HeadSizeQuar = _32;
+
+  using TileShapeQK = decltype(make_shape(BlkSeqQ, BlkSeqKV, HeadSizeQK));
+  // used for element-wise in compute_aux prologue, to reduce register usage
+  using TileShapeQK_Half = decltype(make_shape(BlkSeqQ, BlkSeqKV, HeadSizeHalf{}));
+  using TileShapeQK_Quar = decltype(make_shape(BlkSeqQ, BlkSeqKV, HeadSizeQuar{}));
+  using TileShapeKK = decltype(make_shape(BlkSeqKV, BlkSeqKV, HeadSizeQK));
+  using TileShapeKV = decltype(make_shape(HeadSizeV, HeadSizeQK, BlkSeqKV));
+  static_assert(std::is_same_v<TileShapeQK, TileShapeKK>);
+
+  using TileShapeO2 = decltype(make_shape(HeadSizeV, BlkSeqQ, BlkSeqKV));
+  using TileShapeO1 = decltype(make_shape(HeadSizeV, BlkSeqQ, HeadSizeQK));
+
+  static_assert(BlkSeqQ % 64 == 0);
+  static_assert(BlkSeqQ == 64 || BlkSeqQ == 128);
+  static_assert(BlkSeqQ == BlkSeqKV);
+  static constexpr bool IsQKCooperative = BlkSeqQ == 128;
+  static constexpr bool IsKKCooperative = IsQKCooperative;
+
+  using DummyStages = cutlass::gemm::collective::StageCount<2>;
+  ;
+  using CollectiveMmaQK = typename cutlass::gemm::collective::CollectiveBuilder<
+      cutlass::arch::Sm90,
+      cutlass::arch::OpClassTensorOp,
+      Element,
+      LayoutQ,
+      Alignment,
+      Element,
+      LayoutK,
+      Alignment,
+      ElementAccumulatorQK,
+      TileShapeQK,
+      ClusterShape,
+      DummyStages,
+      std::conditional_t<
+          IsQKCooperative,
+          cutlass::gemm::KernelTmaWarpSpecializedCooperative,
+          cutlass::gemm::KernelTmaWarpSpecialized>>::CollectiveOp;
+
+  // dummy TiledMmaQK RS for S2R/R2S layout consistency
+  using AtomLayoutQK = Layout<Shape<Int<BlkSeqQ / 64>, _1, _1>>;
+  using TiledMmaQK_RS = decltype(make_tiled_mma(
+      decltype(cute::GMMA::rs_op_selector<Element, Element, ElementAccumulatorQK, TileShapeQK>()){}, AtomLayoutQK{}));
+  static_assert(size(TiledMmaQK_RS{}) == NumAuxMmaThreads);
+  using TiledMmaQK_RS_Quar = decltype(make_tiled_mma(
+      decltype(cute::GMMA::rs_op_selector<Element, Element, ElementAccumulatorQK, TileShapeQK_Quar>()){},
+      AtomLayoutQK{}));
+  static_assert(size(TiledMmaQK_RS_Quar{}) == NumAuxMmaThreads);
+
+  using CollectiveMmaKV_G2S = typename cutlass::gemm::collective::CollectiveBuilder<
+      cutlass::arch::Sm90,
+      cutlass::arch::OpClassTensorOp,
+      Element,
+      decltype(select<1, 0, 2>(LayoutV{})),
+      Alignment,  // direct TMA copy for GMEM -> SMEM
+      Element,
+      decltype(select<1, 0, 2>(LayoutK{})),
+      Alignment,
+      ElementAccumulatorKV,
+      TileShapeKV,
+      ClusterShape,
+      DummyStages,
+      cutlass::gemm::KernelTmaWarpSpecializedCooperative>::CollectiveOp;
+
+  using SmemLayoutAlphaAtom = GMMA::Layout_K_SW128_Atom<ElementAlpha>;
+  using SmemLayoutAlpha_SD = decltype(tile_to_shape(
+      SmemLayoutAlphaAtom{},
+      make_shape(
+          shape<1>(TileShapeQK{}),
+          shape<2>(TileShapeQK{}),
+          Int<StagesAlpha::value>{})));                     // (blk_kv, head_size), (64, 128)
+  using GmemShapeAlpha = Shape<int64_t, int32_t, int32_t>;  // (seqlen_k, d, h)
+  using GmemStrideAlpha = Stride<int64_t, _1, int32_t>;
+  using GmemLayoutAlpha = Layout<GmemShapeAlpha, GmemStrideAlpha>;
+  using GmemTiledCopyAlpha = cute::SM90_TMA_LOAD;
+  using TMA_Alpha = decltype(make_tma_copy(
+      GmemTiledCopyAlpha{},
+      make_tensor(make_gmem_ptr(static_cast<float const*>(nullptr)), GmemLayoutAlpha{}),
+      take<0, 2>(SmemLayoutAlpha_SD{}),
+      select<1, 2>(TileShapeQK{}),
+      size<0>(ClusterShape{})));
+
+  // raw layout for copy
+  using SmemLayoutQ_SD = decltype(unstage_smem_layout(typename CollectiveMmaQK::SmemLayoutA{}, Int<StagesQ::value>{}));
+  using SmemLayoutQ_K_Scaled_SD =
+      decltype(unstage_smem_layout(typename CollectiveMmaQK::SmemLayoutA{}, Int<StagesQ_K_Scaled::value>{}));
+  using SmemLayoutK_DS =
+      decltype(unstage_smem_layout(typename CollectiveMmaKV_G2S::SmemLayoutB{}, Int<StagesK::value>{}));
+  using SmemLayoutQ_K_Scaled_DS =
+      decltype(unstage_smem_layout(typename CollectiveMmaKV_G2S::SmemLayoutB{}, Int<StagesQ_K_Scaled::value>{}));
+  using SmemLayoutV_DS =
+      decltype(unstage_smem_layout(typename CollectiveMmaKV_G2S::SmemLayoutA{}, Int<StagesV::value>{}));
+
+  // Layout for V^T
+  using RefLayoutV = decltype(make_layout(select<0, 2>(TileShapeKV{}), LayoutRight{}));
+  using CollectiveMmaKV = typename cutlass::gemm::collective::CollectiveBuilder<
+      cutlass::arch::Sm90,
+      cutlass::arch::OpClassTensorOp,
+      Element,
+      RefLayoutV,
+      Alignment,  // needs a S2R transposition for MMA
+      Element,
+      decltype(select<1, 0, 2>(LayoutK{})),
+      Alignment,
+      ElementAccumulatorKV,
+      TileShapeKV,
+      ClusterShape,
+      DummyStages,
+      cutlass::gemm::KernelTmaWarpSpecializedCooperative>::CollectiveOp;
+
+  using RefLayoutKV = decltype(make_layout(select<0, 1>(TileShapeKV{}), LayoutRight{}));  // (dv, dk)
+  using CollectiveMmaO1 = typename cutlass::gemm::collective::CollectiveBuilder<
+      cutlass::arch::Sm90,
+      cutlass::arch::OpClassTensorOp,
+      Element,
+      RefLayoutKV,
+      Alignment,  // NOTE: S (KV) as operand A
+      Element,
+      LayoutQ,
+      Alignment,
+      ElementAccumulatorO,
+      TileShapeO1,
+      ClusterShape,
+      DummyStages,
+      cutlass::gemm::KernelTmaWarpSpecializedCooperative>::CollectiveOp;
+
+  // (blk_q,blk_k) to align with O2 mma, LayoutRight to align with QK mma output
+  using DesiredLayoutQK = decltype(make_layout(select<0, 1>(TileShapeQK{}), LayoutRight{}));
+  using CollectiveMmaO2 = typename cutlass::gemm::collective::CollectiveBuilder<
+      cutlass::arch::Sm90,
+      cutlass::arch::OpClassTensorOp,
+      Element,
+      RefLayoutV,
+      Alignment,  // V^T
+      Element,
+      DesiredLayoutQK,
+      Alignment,
+      ElementAccumulatorO,
+      TileShapeO2,
+      ClusterShape,
+      DummyStages,
+      cutlass::gemm::KernelTmaWarpSpecializedCooperative>::CollectiveOp;
+
+  using TiledMmaQK = typename CollectiveMmaQK::TiledMma;  // Q@K^t
+  using TiledMmaKV = decltype(convert_to_gmma_rs(typename CollectiveMmaKV::TiledMma{}));
+  using TiledMmaO1 = decltype(convert_to_gmma_rs(typename CollectiveMmaO1::TiledMma{}));
+  using TiledMmaO2 = decltype(convert_to_gmma_rs(typename CollectiveMmaO2::TiledMma{}));
+
+  static_assert(size(TiledMmaQK{}) == NumAuxMmaThreads);
+
+  static_assert(size(TiledMmaKV{}) == NumStateMmaThreads);
+  static_assert(size(TiledMmaO1{}) == NumStateMmaThreads);
+  static_assert(size(TiledMmaO2{}) == NumStateMmaThreads);
+
+  using CollectiveStoreO = CollectiveStoreTma<
+      TileShapeO1,
+      ClusterShape,
+      ElementO,
+      ElementAccumulatorO,
+      /*Seme*/ ElementO,
+      decltype(select<1, 0, 2>(LayoutO{})),
+      StagesO::value>;
+
+  // layout for compute
+  using QKSmemLayoutQ = SmemLayoutQ_SD;
+  using QKSmemLayoutK = decltype(select_layout<1, 0, 2>(SmemLayoutK_DS{}));
+  using QKScaledSmemLayoutQ = SmemLayoutQ_K_Scaled_SD;
+
+  using KVSmemLayoutK = SmemLayoutK_DS;
+  using KVSmemLayoutV = SmemLayoutV_DS;
+  using QKScaledSmemLayoutKt = SmemLayoutQ_K_Scaled_DS;
+
+  using QKQSmemLayoutAlpha = SmemLayoutAlpha_SD;
+  using QKKSmemLayoutAlpha = decltype(select_layout<1, 0, 2>(SmemLayoutAlpha_SD{}));
+  using KKTKSmemLayoutAlpha = SmemLayoutAlpha_SD;
+  using KKTKTSmemLayoutAlpha = decltype(select_layout<1, 0, 2>(SmemLayoutAlpha_SD{}));
+
+  // layout for compute output
+  using SmemLayoutQK = decltype(tile_to_shape(
+      GMMA::Layout_K_INTER_Atom<Element>{},
+      flatten(make_shape(select<0, 1>(TileShapeQK{}), Int<StagesQK::value>{})),
+      Step<_1, _2, _3>{}));
+  using SmemLayoutO = typename CollectiveStoreO::SmemLayoutO;
+
+  using SmemLayoutKK = decltype(tile_to_shape(
+      GMMA::Layout_K_INTER_Atom<Element>{},
+      flatten(make_shape(select<0, 1>(TileShapeQK{}), Int<StagesQK::value>{})),
+      Step<_1, _2, _3>{}));
+
+  using InverseType = cutlass::half_t;
+  using CollectiveInverse = ku::CollectiveInverse<InverseType, true, false>;
+
+  using ElementAccumulatorSK = float;
+  using TileShapeSK = decltype(make_shape(HeadSizeV, BlkSeqKV, HeadSizeQK));
+  using CollectiveMmaSK = typename cutlass::gemm::collective::CollectiveBuilder<  // basically the same as O1
+        cutlass::arch::Sm90,
+        cutlass::arch::OpClassTensorOp,
+        Element,
+        RefLayoutKV,
+        Alignment,
+        Element,
+        LayoutK,
+        Alignment,
+        ElementAccumulatorSK,
+        TileShapeSK,
+        ClusterShape,
+        DummyStages,
+        cutlass::gemm::KernelTmaWarpSpecializedCooperative>::CollectiveOp;
+
+  using ElementAccumulatorNewV = float;
+  using TileShapeNewV = decltype(make_shape(HeadSizeV, BlkSeqKV, BlkSeqKV));
+  using RefLayoutSK = decltype(make_layout(select<0, 2>(TileShapeNewV{}), LayoutRight{}));      // (dv, Blk)
+  using DesiredLayoutKK = decltype(make_layout(select<1, 2>(TileShapeNewV{}), LayoutRight{}));  //
+  using CollectiveMmaNewV = typename cutlass::gemm::collective::CollectiveBuilder<
+      cutlass::arch::Sm90,
+      cutlass::arch::OpClassTensorOp,
+      Element,
+      RefLayoutSK,
+      Alignment,
+      Element,
+      DesiredLayoutKK,
+      Alignment,
+      ElementAccumulatorKV,
+      TileShapeNewV,
+      ClusterShape,
+      DummyStages,
+      cutlass::gemm::KernelTmaWarpSpecializedCooperative>::CollectiveOp;
+
+  // FIXME: K@K^t are not exactly the same as Q@K^t, but similar enough (what does this mean??)
+  using TiledMmaKK = typename CollectiveMmaQK::TiledMma;  // T = inv(I + strict_lower_triangular(K@K^t))
+  using TiledMmaSK = decltype(convert_to_gmma_rs(typename CollectiveMmaSK::TiledMma{}));      // ??   = -S@K^t + V^t
+  using TiledMmaNewV = decltype(convert_to_gmma_rs(typename CollectiveMmaNewV::TiledMma{}));  // NewV = ??@T^t
+
+  static_assert(size(TiledMmaKK{}) == NumAuxMmaThreads);
+
+  using GmemStrideBeta = Stride<int64_t, int32_t>;
+  using GmemLayoutBeta = Layout<Shape<int64_t, int32_t>, GmemStrideBeta>;  // (seq, head)
+
+  // only store the last row in Alpha
+  using SmemLayoutAlphaLast = decltype(make_layout(make_shape(HeadSize, Int<StagesAlpha::value>{})));
+  using SmemLayoutBeta = decltype(make_layout(make_shape(BlkSeqQ, Int<StagesBeta::value>{})));
+
+  using MainloopQPipeline = cutlass::PipelineTmaAsync<StagesQ::value>;
+  using MainloopKPipeline = cutlass::PipelineTmaAsync<StagesK::value>;
+  using MainloopVPipeline = cutlass::PipelineTmaAsync<StagesV::value>;
+  using MainloopAlphaPipeline = std::conditional_t<NeedsAlpha, cutlass::PipelineTmaAsync<StagesAlpha::value>, Unused>;
+  using MainloopOPipeline = typename CollectiveStoreO::Pipeline;
+
+  using MainloopQKPipeline = cutlass::PipelineAsync<StagesQK::value>;
+  using MainloopKKPipeline = cutlass::PipelineAsync<StagesKK::value>;
+
+  using MainloopAlphaLastPipeline = std::conditional_t<NeedsAlpha, cutlass::PipelineAsync<StagesAlpha::value>, Unused>;
+
+  using MainloopBetaPipeline = std::conditional_t<NeedsBeta, cutlass::PipelineAsync<StagesBeta::value>, Unused>;
+
+  using QPipelineState = typename cutlass::PipelineState<MainloopQPipeline::Stages>;
+  using KPipelineState = typename cutlass::PipelineState<MainloopKPipeline::Stages>;
+  using VPipelineState = typename cutlass::PipelineState<MainloopVPipeline::Stages>;
+  using OPipelineState = typename CollectiveStoreO::PipelineState;
+
+  using QKPipelineState = cutlass::PipelineState<MainloopQKPipeline::Stages>;
+  using KKPipelineState = cutlass::PipelineState<MainloopKKPipeline::Stages>;
+
+  using AlphaLastPipelineState =
+      std::conditional_t<NeedsAlpha, cutlass::PipelineState<MainloopAlphaLastPipeline::Stages>, Unused>;
+
+  using AlphaPipelineState =
+      std::conditional_t<NeedsAlpha, cutlass::PipelineState<MainloopAlphaPipeline::Stages>, Unused>;
+  using BetaPipelineState = std::conditional_t<NeedsBeta, cutlass::PipelineState<MainloopBetaPipeline::Stages>, Unused>;
+
+  using BetaProcessor = Unused;
+
+  static constexpr int LoadQBytes = size(QKSmemLayoutQ{}(_, _, _0{})) * sizeof(Element);
+  static constexpr int LoadKBytes = size(KVSmemLayoutK{}(_, _, _0{})) * sizeof(Element);
+  static constexpr int LoadVBytes = size(KVSmemLayoutV{}(_, _, _0{})) * sizeof(Element);
+  static constexpr int LoadAlphaBytes = size(QKQSmemLayoutAlpha{}(_, _, _0{})) * sizeof(ElementAlpha);
+  static constexpr int StoreOBytes = CollectiveStoreO::TmaTransactionBytes;
+
+  using SharedStorageO = typename CollectiveStoreO::SharedStorage;
+
+  struct SharedStorage {
+    alignas(alignment_for_swizzle(QKSmemLayoutQ{})) cute::array_aligned<Element, cute::cosize_v<QKSmemLayoutQ>> smem_q;
+    alignas(alignment_for_swizzle(KVSmemLayoutK{})) cute::array_aligned<Element, cute::cosize_v<KVSmemLayoutK>> smem_k;
+    alignas(alignment_for_swizzle(KVSmemLayoutV{})) cute::array_aligned<Element, cute::cosize_v<KVSmemLayoutV>> smem_v;
+    alignas(alignment_for_swizzle(
+        QKQSmemLayoutAlpha{})) cute::array_aligned<ElementAlpha, cute::cosize_v<QKQSmemLayoutAlpha>> smem_alpha;
+    alignas(alignment_for_swizzle(SmemLayoutQK{})) cute::array_aligned<Element, cute::cosize_v<SmemLayoutQK>> smem_qk;
+    alignas(
+        alignment_for_swizzle(SmemLayoutKK{})) cute::array_aligned<InverseType, cute::cosize_v<SmemLayoutKK>> smem_kk;
+    // smemq_k_scaled for exp(alpha) * Q and exp(alpha) * K in QS and KS, computed in Math WG2/3
+    alignas(alignment_for_swizzle(
+        QKScaledSmemLayoutQ{})) cute::array_aligned<Element, cute::cosize_v<QKScaledSmemLayoutQ>> smem_q_k_scaled;
+
+    SharedStorageO smem_o;
+
+    cute::array_aligned<ElementBeta, cute::cosize_v<SmemLayoutBeta>> smem_beta;
+    // store last row in Alpha separately, used for S'=K^T NewV's epilogue and S+=decay(S') (one fused epilogue)
+    cute::array_aligned<ElementAlpha, cute::cosize_v<SmemLayoutAlphaLast>> smem_alpha_last;
+  };
+
+  using TMA_Q = typename CollectiveMmaQK::Params::TMA_A;
+  using TMA_K = typename CollectiveMmaKV_G2S::Params::TMA_B;
+  using TMA_V = typename CollectiveMmaKV_G2S::Params::TMA_A;
+  using TMA_O = typename CollectiveStoreO::Params::TMA_O;
+
+  using LoadQ = CollectiveLoadTma<LoadKind::kQ, MainloopQPipeline, Element, QKSmemLayoutQ, TMA_Q>;
+  using LoadK = CollectiveLoadTma<LoadKind::kK, MainloopKPipeline, Element, KVSmemLayoutK, TMA_K>;
+  using LoadV = CollectiveLoadTma<LoadKind::kV, MainloopVPipeline, Element, KVSmemLayoutV, TMA_V>;
+  using LoadAlpha =
+      CollectiveLoadTma<LoadKind::kAlpha, MainloopAlphaPipeline, ElementAlpha, QKQSmemLayoutAlpha, TMA_Alpha>;
+
+  using LoadBeta = CollectiveLoadVector<
+      LoadKindVector::kBeta,
+      MainloopBetaPipeline,
+      ElementBeta,
+      GmemLayoutBeta,
+      ElementBeta,
+      SmemLayoutBeta,
+      BetaProcessor>;
+
+  struct Arguments {  // clang-format off
+    Element const* ptr_Q; LayoutQ dQ;
+    Element const* ptr_K; LayoutK dK;
+    Element const* ptr_V; LayoutV dV;
+    Element*       ptr_O; LayoutO dO;
+    float   const* ptr_Alpha; LayoutAlpha dAlpha;
+    float*        ptr_output_state; // layout fixed (kdim, vdim, num_heads, num_seqs):LayoutLeft{}
+    float const*  ptr_input_state;
+    float scale;
+    ElementBeta const* beta_ptr;  GmemStrideBeta beta_stride;
+  };  // clang-format on
+
+  struct Params {
+    TMA_Q tma_load_q;
+    TMA_K tma_load_k;
+    TMA_V tma_load_v;
+    TMA_Alpha tma_load_alpha;
+    TMA_O tma_store_o;
+    void* tensormaps;
+    float scale;
+
+    float* ptr_output_state;
+    float const* ptr_input_state;
+
+    ElementBeta const* beta_ptr;
+    GmemLayoutBeta beta_layout;
+  };
+
+  template <class ProblemShape>
+  static bool can_implement(ProblemShape const& problem_size, Arguments const& args) {
+    return true && (problem_size.head_size <= get<2>(TileShape{})) && ((problem_size.head_size % Alignment) == 0);
+  }
+
+  template <class ProblemShape>
+  static Params to_underlying_arguments(ProblemShape const& problem_size, Arguments const& args, void* workspace) {
+    int64_t s = problem_size.total_seqlen;
+    int64_t t = problem_size.total_seqlen;
+    int32_t d = problem_size.head_size;
+
+    auto params_qk = CollectiveMmaQK::to_underlying_arguments(
+        make_shape(s, t, d, problem_size.num_heads),
+        typename CollectiveMmaQK::Arguments{
+            args.ptr_Q, args.dQ, args.ptr_K, args.dK,  // never used, dummy
+        },
+        /*workspace=*/nullptr);
+
+    auto params_kv_k = CollectiveMmaKV_G2S::to_underlying_arguments(
+        make_shape(d, d, s, problem_size.num_heads),
+        typename CollectiveMmaKV_G2S::Arguments{
+            args.ptr_V,
+            select<1, 0, 2>(args.dV),  // not used
+            args.ptr_K,
+            select<1, 0, 2>(args.dK),  // used as G2S for K
+        },
+        /*workspace=*/nullptr);
+
+    auto alpha_shape = make_shape(s, d, problem_size.num_heads);
+    auto alpha_stride = make_stride(
+        get<0>(args.dAlpha),  // seqlen stride
+        get<1>(args.dAlpha),  // head_dim stride
+        get<2>(args.dAlpha)   // head stride
+    );
+    Tensor mAlpha = make_tensor(make_gmem_ptr(args.ptr_Alpha), make_layout(alpha_shape, alpha_stride));
+    TMA_Alpha tma_load_alpha = make_tma_copy(
+        GmemTiledCopyAlpha{},
+        mAlpha,
+        take<0, 2>(SmemLayoutAlpha_SD{}),
+        select<1, 2>(TileShapeQK{}),
+        size<0>(ClusterShape{}));
+
+    auto params_kv_v = CollectiveMmaKV_G2S::to_underlying_arguments(
+        make_shape(d, d, s, problem_size.num_heads),
+        typename CollectiveMmaKV_G2S::Arguments{
+            args.ptr_V,
+            select<1, 0, 2>(args.dV),  // used as G2S for V
+            args.ptr_K,
+            select<1, 0, 2>(args.dK),  // not used
+        },
+        /*workspace=*/nullptr);
+
+    auto params_o = CollectiveStoreO::to_underlying_arguments(
+        make_shape(d, s, d, problem_size.num_heads),  // in O1
+        // make_shape(d, s, s, problem_size.num_heads),  // in O2
+        typename CollectiveStoreO::Arguments{args.ptr_O, select<1, 0, 2>(args.dO), workspace},
+        workspace);
+
+    return Params{
+        .tma_load_q = params_qk.tma_load_a,
+        .tma_load_k = params_kv_k.tma_load_b,
+        .tma_load_v = params_kv_v.tma_load_a,
+        .tma_load_alpha = tma_load_alpha,
+        .tma_store_o = params_o.tma_store_o,
+        .tensormaps = params_o.tensormaps,
+        .scale = args.scale,
+
+        .ptr_output_state = args.ptr_output_state,
+        .ptr_input_state = args.ptr_input_state,
+
+        // TODO: refactor all name to varname_vartype
+        .beta_ptr = args.beta_ptr,
+        .beta_layout = make_layout(make_shape(s, problem_size.num_heads), args.beta_stride),
+    };
+  }
+
+  static size_t get_workspace_size(Arguments const& args, int sm_count) {
+    return CollectiveStoreO::get_workspace_size(sm_count);
+  }
+
+  template <class ProblemShape>
+  static cutlass::Status
+  initialize_workspace(ProblemShape const& problem_shape, Arguments const& args, void* workspace, cudaStream_t stream) {
+    return CollectiveStoreO::initialize_workspace(problem_shape, workspace, stream);
+  }
+
+  CUTE_DEVICE static void prefetch_tma_descriptors(Params const& params) {
+    cute::prefetch_tma_descriptor(params.tma_load_q.get_tma_descriptor());
+    cute::prefetch_tma_descriptor(params.tma_load_k.get_tma_descriptor());
+    cute::prefetch_tma_descriptor(params.tma_load_v.get_tma_descriptor());
+    cute::prefetch_tma_descriptor(params.tma_load_alpha.get_tma_descriptor());
+    cute::prefetch_tma_descriptor(params.tma_store_o.get_tma_descriptor());
+  }
+
+  template <typename ProblemShape, typename LoadTileShape, typename WorkDesc>
+  CUTE_DEVICE void load_qkv(
+      Params const& params,
+      ProblemShape const& problem_size,
+      LoadTileShape const& load_tile_shape,
+      WorkDesc const& work_desc,
+      MainloopQPipeline& q_pipeline,
+      QPipelineState& q_smem_pipe_write,
+      MainloopKPipeline& k_pipeline,
+      KPipelineState& k_smem_pipe_write,
+      MainloopVPipeline& v_pipeline,
+      VPipelineState& v_smem_pipe_write,
+      MainloopAlphaPipeline& alpha_pipeline,
+      AlphaPipelineState& alpha_smem_pipe_write,
+      SharedStorage& storage) {
+    int32_t num_blocks = ceil_div(work_desc.seq_len, get<0>(TileShape{}));
+    uint32_t lane_predicate = cute::elect_one_sync();
+
+    auto q_collective_load = LoadQ(params.tma_load_q, q_pipeline, storage.smem_q);
+    auto k_collective_load = LoadK(params.tma_load_k, k_pipeline, storage.smem_k);
+    auto v_collective_load = LoadV(params.tma_load_v, v_pipeline, storage.smem_v);
+    auto alpha_collective_load = LoadAlpha{params.tma_load_alpha, alpha_pipeline, storage.smem_alpha};
+
+    auto q_src_dst = q_collective_load.partition_SD(problem_size, load_tile_shape, work_desc);
+    auto k_src_dst = k_collective_load.partition_SD(problem_size, load_tile_shape, work_desc);
+    auto v_src_dst = v_collective_load.partition_SD(problem_size, load_tile_shape, work_desc);
+    auto alpha_src_dst = alpha_collective_load.partition_SD(problem_size, load_tile_shape, work_desc);
+
+    CUTE_NO_UNROLL
+    for (int blk = 0; blk < num_blocks; ++blk) {
+      alpha_collective_load.step(alpha_src_dst, blk, alpha_smem_pipe_write, lane_predicate);
+      q_collective_load.step(q_src_dst, blk, q_smem_pipe_write, lane_predicate);
+      k_collective_load.step(k_src_dst, blk, k_smem_pipe_write, lane_predicate);
+      v_collective_load.step(v_src_dst, blk, v_smem_pipe_write, lane_predicate);
+    }
+  }
+
+  template <typename ProblemShape, typename TileShape, typename WorkDesc>
+  CUTE_DEVICE void load_beta(
+      Params const& params,
+      ProblemShape const& problem_size,
+      TileShape const& tile_shape,
+      WorkDesc const& work_desc,
+      MainloopBetaPipeline& pipeline,
+      BetaPipelineState& smem_pipe_write,
+      SharedStorage& storage) {
+    int32_t num_blocks = ceil_div(work_desc.seq_len, get<0>(TileShape{}));
+
+    // fuse post inverse diag(beta) into diagonal of IKK
+    // auto collective_load = LoadBeta{params.beta_ptr, params.beta_layout, /*oob_value=*/1.0f, pipeline,
+    // storage.smem_beta};
+    auto collective_load =
+        LoadBeta{params.beta_ptr, params.beta_layout, /*oob_value=*/0.0f, pipeline, storage.smem_beta};
+    auto src_dst = collective_load.partition_SD(problem_size, tile_shape, work_desc);
+
+    CUTE_NO_UNROLL
+    for (int blk = 0; blk < num_blocks - 1; ++blk) {
+      collective_load.step</*IsTail=*/false>(src_dst, blk, smem_pipe_write, num_blocks);
+    }
+    collective_load.step</*IsTail=*/true>(src_dst, num_blocks - 1, smem_pipe_write, num_blocks);
+  }
+
+  template <typename ProblemShape, typename TileShape, typename WorkDesc>
+  CUTE_DEVICE void extract_alpha_last(
+      Params const& params,
+      ProblemShape const& problem_size,
+      TileShape const& tile_shape,
+      WorkDesc const& work_desc,
+      MainloopAlphaPipeline& alpha_pipeline,
+      AlphaPipelineState& alpha_smem_pipe_read,
+      MainloopAlphaLastPipeline& alpha_last_pipeline,
+      AlphaLastPipelineState& alpha_last_smem_pipe_write,
+      SharedStorage& storage) {
+    int thread_idx = threadIdx.x % cutlass::NumThreadsPerWarp;
+
+    Tensor sAqkq = make_tensor(make_smem_ptr(storage.smem_alpha.data()), QKQSmemLayoutAlpha{});
+    Tensor sAlast = make_tensor(make_smem_ptr(storage.smem_alpha_last.data()), SmemLayoutAlphaLast{});
+
+    auto extract_loop_body = [&](int blk, auto is_final_block_) INLINE_LAMBDA {
+      constexpr bool is_final_block = decltype(is_final_block_)::value;
+
+      int B = is_final_block ? valid_seq_len(work_desc, blk) : BlkSeqKV;
+
+      auto sAqkq_curr = sAqkq(_, _, alpha_smem_pipe_read.index());
+      Tensor sAlast_out = sAlast(_, alpha_last_smem_pipe_write.index());
+
+      alpha_pipeline.consumer_wait(alpha_smem_pipe_read);
+      alpha_last_pipeline.producer_acquire(alpha_last_smem_pipe_write);
+
+      // each thread copy 4 elements, total 128 elements with one warp
+      CUTE_UNROLL
+      for (int t = thread_idx; t < HeadSize; t += 32) {
+        sAlast_out(t) = sAqkq_curr(B - 1, t);
+      }
+
+      cutlass::arch::fence_view_async_shared();
+      alpha_last_pipeline.producer_commit(alpha_last_smem_pipe_write);
+      ++alpha_last_smem_pipe_write;
+      alpha_pipeline.consumer_release(alpha_smem_pipe_read);
+      ++alpha_smem_pipe_read;
+    };
+
+    int32_t num_blocks = ceil_div(work_desc.seq_len, get<0>(TileShape{}));
+    CUTE_NO_UNROLL
+    for (int blk = 0; blk < num_blocks - 1; ++blk) {
+      extract_loop_body(blk, /*is_final_block_=*/cute::false_type{});
+    }
+    extract_loop_body(num_blocks - 1, /*is_final_block_=*/cute::true_type{});
+  }
+
+  template <typename ProblemSize, typename StoreTileShape, typename WorkDesc, typename PipelineState>
+  CUTE_DEVICE void store(
+      TMA_O const& tma_store,
+      void* tensormaps,
+      ProblemSize const& problem_size,
+      StoreTileShape const& store_tile_shape,
+      WorkDesc const& work_desc,
+      MainloopOPipeline& pipeline,
+      PipelineState& smem_pipe_read,
+      SharedStorageO& storage) {
+    int32_t num_blocks = ceil_div(work_desc.seq_len, get<0>(TileShape{}));
+    uint32_t lane_predicate = cute::elect_one_sync();
+
+    auto collective_store = CollectiveStoreO{tma_store, pipeline, storage, tensormaps};
+    auto src_dst = collective_store.partition_SD(problem_size, store_tile_shape, work_desc);
+
+    CUTE_NO_UNROLL
+    for (int blk = 0; blk < num_blocks; ++blk) {
+      DPRINTF0_W(
+          "O collective_store.step smem_pipe_read:%d -> blk_idx:%d, num_blocks:%d\n",
+          smem_pipe_read.index(),
+          blk,
+          num_blocks);
+      collective_store.step(problem_size, work_desc, src_dst, smem_pipe_read, blk, num_blocks, lane_predicate);
+    }
+  }
+
+  template <class ProblemShape, class WorkDesc>
+  CUTE_DEVICE void compute(
+      Params const& params,
+      ProblemShape const& problem_size,
+      WorkDesc const& work_desc,
+      MainloopQPipeline& q_pipeline,
+      QPipelineState& q_smem_pipe_read,
+      MainloopKPipeline& k_pipeline,
+      KPipelineState& k_smem_pipe_read,
+      MainloopVPipeline& v_pipeline,
+      VPipelineState& v_smem_pipe_read,
+      MainloopOPipeline& o_pipeline,
+      OPipelineState& o_smem_pipe_write,
+      MainloopQKPipeline& qk_pipeline,
+      QKPipelineState& qk_smem_pipe_read,
+      MainloopKKPipeline& kk_pipeline,
+      KKPipelineState& kk_smem_pipe_read,
+      MainloopAlphaPipeline& alpha_pipeline,
+      AlphaPipelineState& alpha_smem_pipe_read,
+      MainloopBetaPipeline& beta_pipeline,
+      BetaPipelineState& beta_smem_pipe_read,
+      MainloopAlphaLastPipeline& alpha_last_pipeline,
+      AlphaLastPipelineState& alpha_last_smem_pipe_read,
+      OrderedMathBarriers& math_barriers,
+      SharedStorage& storage) {
+    // MAKE NVCC HAPPY!
+    constexpr auto zero = Element{};
+
+    int32_t num_blocks = ceil_div(work_desc.seq_len, get<0>(TileShape{}));
+    DPRINTF0_WG("num_blocks: %d\n", num_blocks);
+
+    int thread_idx = int(threadIdx.x) - NumLoadThreads;
+    int warpgroup_idx = thread_idx / cutlass::NumThreadsPerWarpGroup;
+    int thread_idx_in_wg = thread_idx % cutlass::NumThreadsPerWarpGroup;
+
+    float scale = params.scale;
+
+    Tensor Beta = make_tensor(make_smem_ptr(storage.smem_beta.data()), SmemLayoutBeta{});
+    Tensor AlphaLast = make_tensor(make_smem_ptr(storage.smem_alpha_last.data()), SmemLayoutAlphaLast{});
+
+    Tensor sQqk = make_tensor(make_smem_ptr(storage.smem_q.data()), QKSmemLayoutQ{});
+    Tensor sKqk = make_tensor(make_smem_ptr(storage.smem_k.data()), QKSmemLayoutK{});
+    Tensor sAqkq = make_tensor(make_smem_ptr(storage.smem_alpha.data()), QKQSmemLayoutAlpha{});
+    Tensor sVkv = make_tensor(make_smem_ptr(storage.smem_v.data()), KVSmemLayoutV{});
+    Tensor sQK = make_tensor(make_smem_ptr(storage.smem_qk.data()), SmemLayoutQK{});
+    Tensor sO = make_tensor(make_smem_ptr(storage.smem_o.data()), SmemLayoutO{});
+
+    static_assert(sizeof(InverseType) == sizeof(Element));
+    Tensor sKK_inv = make_tensor(make_smem_ptr(storage.smem_kk.data()), SmemLayoutKK{});
+    Tensor sKK_opd = make_tensor(make_smem_ptr(reinterpret_cast<Element*>(storage.smem_kk.data())), SmemLayoutKK{});
+
+    Tensor sQ_K_scaled = make_tensor(make_smem_ptr(storage.smem_q_k_scaled.data()), QKScaledSmemLayoutQ{});
+    Tensor sQ_K_scaled_Kt = make_tensor(make_smem_ptr(storage.smem_q_k_scaled.data()), QKScaledSmemLayoutKt{});
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Q@S, K@S, Q/K prologue
+    // each WG process 32 at a time, reduce peak register usage
+    // each WG process half head dim (64) at all
+    auto qk_tiled_mma_rs_quar = TiledMmaQK_RS_Quar{};
+    auto qk_thr_mma_rs_quar = qk_tiled_mma_rs_quar.get_thread_slice(thread_idx_in_wg);
+    constexpr auto tiler_alpha = Shape<_64, Shape<_32, _1>>{};
+    constexpr auto tiler_qk = Shape<_64, Shape<_32, _1>>{};
+    constexpr auto tiler_alpha_last = Shape<_32>{};
+    // used for Alpha S2R (float)
+    using CopyAlphaAtom = Copy_Atom<AutoVectorizingCopyWithAssumedAlignment<128>, ElementAlpha>;
+    // used for Q/K S2R and R2S (fp16/bf16)
+    using CopyOpS2R = SM75_U32x4_LDSM_N;
+    using CopyOpR2S = SM90_U32x4_STSM_N;
+    auto tiled_load_qk_quar = make_tiled_copy_A(Copy_Atom<CopyOpS2R, Element>{}, qk_thr_mma_rs_quar);
+    auto thr_load_qk_quar = tiled_load_qk_quar.get_thread_slice(thread_idx_in_wg);
+    auto tiled_store_qk_quar = make_tiled_copy_A(Copy_Atom<CopyOpR2S, Element>{}, qk_thr_mma_rs_quar);
+    auto thr_store_qk_quar = tiled_store_qk_quar.get_thread_slice(thread_idx_in_wg);
+
+    auto cMq_quar = make_identity_tensor(select<0, 2>(TileShapeQK_Quar{}));  // (QTok, HeadDim / 2)
+    auto tQcMq_quar = qk_thr_mma_rs_quar.partition_A(cMq_quar);              // (idx) -> (tok_q, head_dim / 2)
+
+    ///////////////////////////////////////////////////////////////////////////
+    // K@K  (basically I + strict_lower_triangular(K K^T)
+    auto kk_tiled_mma = TiledMmaKK{};
+    auto kk_thr_mma = kk_tiled_mma.get_thread_slice(thread_idx_in_wg);
+    Tensor tKKsK = kk_thr_mma.partition_B(sKqk);
+    Tensor tKKrA = kk_thr_mma.make_fragment_A(tKKsK);
+    auto cMqk = make_identity_tensor(select<0, 1>(TileShapeQK{}));  // (QTok, KTok)
+    auto const& cMkk = cMqk;
+    auto tKKcMkk = kk_thr_mma.partition_C(cMkk);
+
+    // S@K  (-S K^T  +  V^T)
+    auto sk_tiled_mma = TiledMmaSK{};
+    auto sk_thr_mma = sk_tiled_mma.get_thread_slice(thread_idx);
+
+    // tSKrV adds to tSKrSK (acc)
+    using SK_V_S2R = Copy_Atom<SM75_U16x8_LDSM_T, Element>;
+    auto tSKrV_tiled_copy = make_tiled_copy_C(SK_V_S2R{}, sk_tiled_mma);
+    auto tSKrV_thr_copy = tSKrV_tiled_copy.get_thread_slice(thread_idx);
+
+    Tensor tSKsK = sk_thr_mma.partition_B(sQ_K_scaled);
+    Tensor tSKrK = sk_thr_mma.make_fragment_B(tSKsK);
+
+    ///////////////////////////////////////////////////////////////////////////
+    // NewV = (S@K result) @ T^t
+    auto newv_tiled_mma = TiledMmaNewV{};
+    auto newv_thr_mma = newv_tiled_mma.get_thread_slice(thread_idx);
+
+    Tensor tNewVsB = newv_thr_mma.partition_B(sKK_opd);
+    Tensor tNewVrB = newv_thr_mma.make_fragment_B(tNewVsB);
+
+    ///////////////////////////////////////////////////////////////////////////
+    // K@V
+    auto kv_tiled_mma = TiledMmaKV{};  // (V, Blk_k) @ (Blk_k, K) = (V, K)
+    auto kv_thr_mma = kv_tiled_mma.get_thread_slice(thread_idx);
+
+    Tensor tKVrKV = partition_fragment_C(kv_thr_mma, select<0, 1>(TileShapeKV{}));
+
+    // Tensor tKVrV    = kv_thr_mma.partition_fragment_A(sVkv(_, _, _0{}));  // mma src
+    // Tensor tKVrV_cv = tKVrV_thr_copy.retile_D(tKVrV);                     // copy view dst
+    // Tensor tKVsV    = tKVrV_thr_copy.partition_S(sVkv);                   // copy view src
+
+    auto const cV = make_identity_tensor(Shape<Int<HeadSizeV>, Int<BlkSeqKV>>{});
+    Tensor tKVcV = kv_thr_mma.partition_A(cV);
+    auto const cS = make_identity_tensor(Shape<Int<HeadSizeV>, Int<HeadSizeQK>>{});
+    Tensor tKVcS = kv_thr_mma.partition_C(cS);
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Q@K@V
+    auto o1_tiled_mma = TiledMmaO1{};
+    auto o1_thr_mma = o1_tiled_mma.get_thread_slice(thread_idx);
+    auto o2_tiled_mma = TiledMmaO2{};
+    auto o2_thr_mma = o2_tiled_mma.get_thread_slice(thread_idx);
+
+    // A1 for Q@(KV)
+    // Tensor tOrKV = make_acc_into_op<Element>(tKVrKV, typename TiledMmaO1::LayoutA_TV{});
+    // B1 for Q@(KV)
+    Tensor tOsQ = o1_thr_mma.partition_B(sQ_K_scaled);
+    Tensor tOrQ = o1_thr_mma.make_fragment_B(tOsQ);
+
+    // A2 for QK@V
+    // Tensor tOsV = o2_thr_mma.partition_A(sVkv);
+    // Tensor tOrV = o2_thr_mma.make_fragment_A(tOsV);
+    // B2 for QK@V
+    Tensor tOsQK = o2_thr_mma.partition_B(sQK);
+    Tensor tOrQK = o2_thr_mma.make_fragment_B(tOsQK);
+
+    using O_R2S = typename CollectiveStoreO::CopyAtomR2S;
+    auto tiled_copy_o = make_tiled_copy_C(O_R2S{}, o1_tiled_mma);
+    auto thr_copy_o = tiled_copy_o.get_thread_slice(thread_idx);
+    auto tOsO = thr_copy_o.partition_D(sO);
+
+    auto const cO = make_identity_tensor(Shape<Int<HeadSizeQK>, Int<BlkSeqQ>>{});
+    Tensor tOcO = o1_thr_mma.partition_C(cO);
+
+    auto const seq_idx = work_desc.seq_idx;
+    auto const q_head_idx = work_desc.q_head_idx();
+    auto const k_head_idx = work_desc.k_head_idx();
+    auto const v_head_idx = work_desc.v_head_idx();
+
+    auto sk_load_v = [&](int pipe_idx) INLINE_LAMBDA {
+      Tensor tSKrV = make_fragment_like<Element>(partition_fragment_C(sk_thr_mma, sVkv(_, _, _0{})));  // mma acc
+      Tensor tSKrV_cv = tSKrV_thr_copy.retile_D(tSKrV);                                                // copy view dst
+      Tensor tSKsV = tSKrV_thr_copy.partition_S(sVkv);                                                 // copy view src
+      copy(tSKrV_tiled_copy, tSKsV(_, _, _, pipe_idx), tSKrV_cv);
+      return tSKrV;
+    };
+
+    auto kv_load = [&](auto& tKVrKV) INLINE_LAMBDA {
+      DPRINTF0_WG("[%d,%d,%d,%d]>> load tKVgKV -> tKVrKV\n", seq_idx, q_head_idx, k_head_idx, v_head_idx);
+      int num_state_heads = problem_size.num_heads;
+      int state_head_idx = work_desc.o_head_idx();
+      auto gKV = make_tensor(
+          make_gmem_ptr(params.ptr_input_state),
+          make_layout(make_shape(Int<HeadSizeQK>{}, Int<HeadSizeV>{}, num_state_heads, problem_size.num_seqs)))(
+          _, _, state_head_idx, seq_idx);  // (KDim, VDim), K-contiguous
+      // NOTE: load S in transposed GMEM
+      // because in GDN's equation, S = NewV^T @ K, while in KDA, S = K^T @ NewV
+      auto gKV_trans = make_tensor(
+          make_gmem_ptr(gKV.data()),
+          make_layout(
+              make_shape(get<1>(gKV.layout().shape()), get<0>(gKV.layout().shape())),
+              make_stride(get<1>(gKV.layout().stride()), get<0>(gKV.layout().stride()))));
+
+      auto tiled_copy_kv = make_tiled_copy_C(Copy_Atom<AutoVectorizingCopy, Element>{}, kv_tiled_mma);
+      auto thr_copy_kv = tiled_copy_kv.get_thread_slice(thread_idx);
+
+      auto tKVgKV = thr_copy_kv.partition_S(select_tensor<1, 0>(gKV_trans));
+      copy(tiled_copy_kv, tKVgKV, tKVrKV);
+    };
+
+    auto kv_store = [&]() INLINE_LAMBDA {  // tKVrKV is carried over whole mainloop
+      DPRINTF0_WG("[%d,%d,%d,%d]>> save tKVrKV -> tKVgKV\n", seq_idx, q_head_idx, k_head_idx, v_head_idx);
+      int num_state_heads = problem_size.num_heads;
+      int state_head_idx = work_desc.o_head_idx();
+      auto gKV = make_tensor(
+          make_gmem_ptr(params.ptr_output_state),
+          make_layout(make_shape(Int<HeadSizeQK>{}, Int<HeadSizeV>{}, num_state_heads, problem_size.num_seqs)))(
+          _, _, state_head_idx, seq_idx);  // (KDim, VDim), K-contiguous
+      // NOTE: store S in transposed GMEM
+      // because in GDN's equation, S = NewV^T @ K, while in KDA, S = K^T @ NewV
+      auto gKV_trans = make_tensor(
+          make_gmem_ptr(gKV.data()),
+          make_layout(
+              make_shape(get<1>(gKV.layout().shape()), get<0>(gKV.layout().shape())),
+              make_stride(get<1>(gKV.layout().stride()), get<0>(gKV.layout().stride()))));
+
+      auto tiled_copy_kv = make_tiled_copy_C(Copy_Atom<AutoVectorizingCopy, Element>{}, kv_tiled_mma);
+      auto thr_copy_kv = tiled_copy_kv.get_thread_slice(thread_idx);
+
+      auto tKVgKV = thr_copy_kv.partition_D(select_tensor<1, 0>(gKV_trans));
+      copy(tiled_copy_kv, tKVrKV, tKVgKV);
+    };
+
+    auto s_decay = [&](auto& tKVrKV, auto const& alpha_last_smem_pipe_read) INLINE_LAMBDA {
+      Tensor alpha_last_curr = AlphaLast(_, alpha_last_smem_pipe_read.index());
+      for_each(make_int_sequence<size(tKVcS)>{}, [&](auto i) {
+        auto coord = tKVcS(i);
+        auto [s, t] = coord;  // (head_size_v, head_size_k)
+        tKVrKV(i) *= exp2f(alpha_last_curr(t));
+      });
+    };
+
+    auto o1_epi = [&](auto& tOrO1) INLINE_LAMBDA {
+      CUTE_UNROLL
+      for (int i = 0; i < size(tOrO1); ++i) {
+        tOrO1(i) = scale * tOrO1(i);
+      }
+    };
+
+    auto o_store = [&](auto tOrO) INLINE_LAMBDA {
+      auto tOrO_cvt = make_fragment_like<ElementO>(tOrO);
+      copy(tOrO, tOrO_cvt);
+
+      DPRINTF0_WG("compute: o_pipeline.producer_wait: smem_pipe_write:%d\n", o_smem_pipe_write.index());
+      o_pipeline.producer_acquire(o_smem_pipe_write);
+      Tensor tOrO_cvt_cv = thr_copy_o.retile_S(tOrO_cvt);
+      cutlass::arch::fence_view_async_shared();
+      copy(tiled_copy_o, tOrO_cvt_cv, tOsO(_, _, _, o_smem_pipe_write.index()));
+      cutlass::arch::fence_view_async_shared();
+      o_pipeline.producer_commit(o_smem_pipe_write);
+      ++o_smem_pipe_write;
+    };
+
+    auto kk_inv = [&](auto const& kk_smem_pipe_read) INLINE_LAMBDA {
+      auto sKK_inv_pipe_slice = sKK_inv(_, _, kk_smem_pipe_read.index());
+      static_assert(sizeof(Element) == 2);
+      using CopyOpR2S = SM90_U32x4_STSM_N;
+      auto tiled_store_kk = make_tiled_copy_C(Copy_Atom<CopyOpR2S, InverseType>{}, kk_tiled_mma);
+      auto thr_store_kk = tiled_store_kk.get_thread_slice(thread_idx);
+      auto tKKsKK = thr_store_kk.partition_D(sKK_inv_pipe_slice);
+      // TODO: use tKKcMkk? no more allocating fragments
+      auto tKKrKK = kk_thr_mma.partition_fragment_C(sKK_inv_pipe_slice);
+      auto tKKrKK_cv = thr_store_kk.retile_S(tKKrKK);
+      auto collective_inverse = CollectiveInverse(KdaNamedBarriers::StateMathWG0);
+      collective_inverse.compute(sKK_inv_pipe_slice);
+      // FIXME: we can ignore core matrices above diagonal
+      if constexpr (NeedsBeta || !std::is_same_v<InverseType, Element>) {
+        cutlass::arch::NamedBarrier::arrive_and_wait(cutlass::NumThreadsPerWarpGroup, KdaNamedBarriers::StateMathWG0);
+        using CopyOpS2R = SM75_U32x4_LDSM_N;
+        auto tiled_load_kk = make_tiled_copy_C(Copy_Atom<CopyOpS2R, InverseType>{}, kk_tiled_mma);
+        auto thr_load_kk = tiled_load_kk.get_thread_slice(thread_idx);
+        auto tKKrKK_cpy = make_fragment_like<InverseType>(tKKrKK_cv);
+        auto tKKrKK_cvt = make_fragment_like<Element>(tKKrKK_cv);
+        auto tKKcMkk_cv = thr_load_kk.retile_D(tKKcMkk);
+        copy(tiled_load_kk, thr_load_kk.partition_S(sKK_inv_pipe_slice), tKKrKK_cpy);
+        cute::transform(tKKrKK_cpy, tKKcMkk_cv, tKKrKK_cvt, [&](auto val, auto coord) {
+          auto [_, t] = coord;
+          if constexpr (NeedsBeta) {
+            return Element(float(val) * Beta(t, beta_smem_pipe_read.index()));
+          } else {
+            return Element(val);
+          }
+        });
+        copy(tiled_store_kk, tKKrKK_cvt, recast<Element>(tKKsKK));
+      }
+    };
+
+    auto compute_loop_body = [&](int blk, auto is_first_block_, auto is_final_block_) INLINE_LAMBDA {
+      constexpr bool is_first_block = decltype(is_first_block_)::value;
+      constexpr bool is_final_block = decltype(is_final_block_)::value;
+      int B = is_final_block ? valid_seq_len(work_desc, blk) : BlkSeqKV;
+
+      auto sQqk_curr = sQqk(_, _, q_smem_pipe_read.index());
+      auto sKqk_curr = sKqk(_, _, k_smem_pipe_read.index());
+      auto sQ_scaled_curr = sQ_K_scaled(_, _, _0{});
+      auto sK_scaled_curr = sQ_K_scaled(_, _, _1{});
+      auto sAlast_curr = AlphaLast(_, alpha_last_smem_pipe_read.index());
+      auto sAqkq_curr = sAqkq(_, _, alpha_smem_pipe_read.index());
+      auto sQqk_slice = flat_divide(sQqk_curr, tiler_qk);
+      auto sKqk_slice = flat_divide(sKqk_curr, tiler_qk);
+      auto sQ_scaled_slice = flat_divide(sQ_scaled_curr, tiler_qk);
+      auto sK_scaled_slice = flat_divide(sK_scaled_curr, tiler_qk);
+      auto sAqkq_slice = flat_divide(sAqkq_curr, tiler_alpha);
+      auto sAlast_slice = flat_divide(sAlast_curr, tiler_alpha_last);
+
+      if constexpr (NeedsAlpha) {
+        alpha_pipeline.consumer_wait(alpha_smem_pipe_read);
+      }
+      DPRINTF0_WG("compute: q_pipeline.consumer_wait: smem_pipe_read:%d\n", q_smem_pipe_read.index());
+      q_pipeline.consumer_wait(q_smem_pipe_read);
+      DPRINTF0_WG("compute: k_pipeline.consumer_wait: smem_pipe_read:%d\n", k_smem_pipe_read.index());
+      k_pipeline.consumer_wait(k_smem_pipe_read);
+
+      // load alpha and exp2(alpha) only once
+      // and reuse these registers in exp(alpha) * Q/K prologue
+      if constexpr (!is_first_block) {
+        // make sure sQ_K_scaled is already consumed for previous K^@V
+        cutlass::arch::NamedBarrier::arrive_and_wait(NumStateMmaThreads, KdaNamedBarriers::StateMath);
+        // Each WG iterates over 2 slices of 32 elements each.
+        // WG0 (thread_idx < 128): wg_idx=0, processes alpha indices {0,1}, Q/K dim1=0
+        // WG1 (thread_idx >= 128): wg_idx=1, processes alpha indices {2,3}, Q/K dim1=1
+        {
+          int wg_idx = thread_idx / 128;  // 0 or 1
+          int alpha_base = wg_idx * 2;    // 0 or 2
+
+          // Allocate Q/K register fragments once (reused across slices)
+          // Only shape/layout matters for partition_fragment_A, use compile-time indices
+          auto tQKrQ_wg = qk_thr_mma_rs_quar.partition_fragment_A(sQqk_slice(_, _, _0{}, make_coord(_0{}, _0{})));
+          auto tQKrK_wg = qk_thr_mma_rs_quar.partition_fragment_A(sKqk_slice(_, _, _0{}, make_coord(_0{}, _0{})));
+          auto tArA = make_fragment_like<ElementAlpha>(tQKrQ_wg);
+
+          for (int s = 0; s < 2; ++s) {
+            // S2R Alpha: alpha_col = wg_idx * 2 + s
+            int alpha_col = alpha_base + s;
+            auto sA_cur = sAqkq_slice(_, _, _0{}, make_coord(0, alpha_col));
+            auto tAsA_cur = qk_thr_mma_rs_quar.partition_A(sA_cur);
+            copy(CopyAlphaAtom{}, tAsA_cur, tArA);
+
+            cute::transform(tArA, [](auto g) { return exp2f(g); });
+
+            // S2R Q
+            auto sQqk_cur = sQqk_slice(_, _, _0{}, make_coord(s, wg_idx));
+            auto tQKsQ_cur = thr_load_qk_quar.partition_S(sQqk_cur);
+            auto tQKrQ_cv = thr_load_qk_quar.retile_D(tQKrQ_wg);
+            copy(tiled_load_qk_quar, tQKsQ_cur, tQKrQ_cv);
+
+            // element-wise exp(alpha) * Q
+            cute::transform(tQKrQ_wg, tArA, tQKrQ_wg, [&](auto q, auto alpha) {
+              Element dst = Element(alpha * float(q));
+              return dst;
+            });
+
+            // R2S Q -> stage 0
+            auto sQ_scaled_cur = sQ_scaled_slice(_, _, _0{}, make_coord(s, wg_idx));
+            auto tQKsQ_out = thr_store_qk_quar.partition_D(sQ_scaled_cur);
+            auto tQKrQ_out_cv = thr_store_qk_quar.retile_S(tQKrQ_wg);
+            copy(tiled_store_qk_quar, tQKrQ_out_cv, tQKsQ_out);
+
+            // S2R K
+            auto sKqk_cur = sKqk_slice(_, _, _0{}, make_coord(s, wg_idx));
+            auto tQKsK_cur = thr_load_qk_quar.partition_S(sKqk_cur);
+            auto tQKrK_cv = thr_load_qk_quar.retile_D(tQKrK_wg);
+            copy(tiled_load_qk_quar, tQKsK_cur, tQKrK_cv);
+
+            // element-wise exp(alpha) * K
+            cute::transform(tQKrK_wg, tArA, tQKrK_wg, [&](auto k, auto alpha) {
+              Element dst = Element(alpha * float(k));
+              return dst;
+            });
+
+            // R2S K -> stage 1
+            auto sK_scaled_cur = sK_scaled_slice(_, _, _0{}, make_coord(s, wg_idx));
+            auto tQKsK_out = thr_store_qk_quar.partition_D(sK_scaled_cur);
+            auto tQKrK_out_cv = thr_store_qk_quar.retile_S(tQKrK_wg);
+            copy(tiled_store_qk_quar, tQKrK_out_cv, tQKsK_out);
+          }
+        }
+        cutlass::arch::NamedBarrier::arrive_and_wait(NumStateMmaThreads, KdaNamedBarriers::StateMath);
+        // fence to produce data for WGMMA async proxy
+        cutlass::arch::fence_view_async_shared();
+        // if (blk <= 1 && thread_idx == 0) {
+        //   printf("After Q/K prologue: exp(alpha) * Q at stage 0, exp(alpha) * K at stage 1\n");
+        //   cute::print_tensor(sQ_K_scaled_curr);
+        // }
+      }
+
+      // 2.1 Q @ KV, NOTE: use old KV here
+
+      DPRINTF0_WG("[%d,%d,%d,%d]** dispatch O WGMMA\n", seq_idx, q_head_idx, k_head_idx, v_head_idx);
+      auto tOrO = partition_fragment_C(o1_thr_mma, select<0, 1>(TileShapeO1{}));
+      if constexpr (is_first_block) {
+        DPRINTF0_WG("compute: q_pipeline.consumer_release: smem_pipe_read:%d\n", q_smem_pipe_read.index());
+        q_pipeline.consumer_release(q_smem_pipe_read);
+        ++q_smem_pipe_read;
+      } else {
+        Tensor tOrKV = make_acc_into_op<Element>(tKVrKV, typename TiledMmaO1::LayoutA_TV{});
+        warpgroup_fence_operand(tOrKV);
+        warpgroup_fence_operand(tOrO);
+        // ======DEBUG=======
+        // if (blk <= 6 && thread_idx == 0) {
+        //   printf("=======Before Q@S, block_idx: %d, thread_idx: %d=======\n", blk, thread_idx);
+        //   cute::print_tensor(tOrKV);
+        //   cute::print_tensor(sQ_K_scaled_slice);
+        // }
+
+        math_barriers.ordered_or_wait(warpgroup_idx);
+        warpgroup_arrive();
+        gemm_zero_acc(o1_thr_mma, tOrKV, tOrQ(_, _, _, 0), tOrO);
+        warpgroup_commit_batch();  // q@kv batch
+        math_barriers.notify_next_blocked(warpgroup_idx);
+      }
+      if constexpr (!is_first_block) {
+        warpgroup_wait<0>();  // q@kv batch
+        // ======DEBUG=======
+        // if (blk <= 1 && thread_idx == 0) {
+        //   printf("\n");
+        //   printf("=======O_inter after Q@S, block_idx: %d, thread_idx: %d=======\n", blk, thread_idx);
+        //   cute::print_tensor(tOrO);
+        // }
+        DPRINTF0_WG("compute: q_pipeline.consumer_release: smem_pipe_read:%d\n", q_smem_pipe_read.index());
+        q_pipeline.consumer_release(q_smem_pipe_read);
+        ++q_smem_pipe_read;
+        o1_epi(tOrO);
+      }
+
+      auto tSKrSK = partition_fragment_C(sk_thr_mma, sVkv(_, _, _0{}));
+      if constexpr (!is_first_block) {
+        auto tSKrS = make_acc_into_op<Element>(tKVrKV, typename TiledMmaSK::LayoutA_TV{});
+        warpgroup_fence_operand(tSKrSK);
+        warpgroup_fence_operand(tSKrS);
+        math_barriers.ordered_or_wait(warpgroup_idx);
+        warpgroup_arrive();
+
+        // ======DEBUG=======
+        // if (blk <= 6 && thread_idx == 0) {
+        //   printf("=======Before K@S, block_idx: %d, thread_idx: %d=======\n", blk, thread_idx);
+        //   cute::print_tensor(tSKrS);
+        // }
+
+        // SK: K_scaled is in stage 1 of sQ_K_scaled
+        gemm_zero_acc(sk_tiled_mma, tSKrS, tSKrK(_, _, _, 1), tSKrSK);
+        warpgroup_commit_batch();
+        math_barriers.notify_next_blocked(warpgroup_idx);
+        warpgroup_wait<0>();
+      }
+      // ======DEBUG=======
+      // if (blk <= 6 && thread_idx == 0) {
+      //   printf("=======After K@S, block_idx: %d, thread_idx: %d=======\n", blk, thread_idx);
+      //   cute::print_tensor(tSKrSK);
+      // }
+
+      DPRINTF0_WG("compute: v_pipeline.consumer_wait: smem_pipe_read:%d\n", v_smem_pipe_read.index());
+      v_pipeline.consumer_wait(v_smem_pipe_read);
+      auto tSKrV = sk_load_v(v_smem_pipe_read.index());
+      if constexpr (!is_first_block) {
+        // sk_epi(tSKrSK, alpha_smem_pipe_read);
+        // V' = V - SK
+        transform(tSKrV, tSKrSK, tSKrV, [](auto v, auto sk) { return v - Element(sk); });
+      }
+
+      kk_pipeline.consumer_wait(kk_smem_pipe_read);
+      beta_pipeline.consumer_wait(beta_smem_pipe_read);
+      cutlass::arch::fence_view_async_shared();
+      // KK inverse
+      if (warpgroup_idx == 0) {
+        kk_inv(kk_smem_pipe_read);
+      }
+      // wait for KK inverse ready
+      cutlass::arch::NamedBarrier::arrive_and_wait(NumStateMmaThreads, KdaNamedBarriers::StateMath);
+
+      auto tNewVrA = make_acc_into_op<Element>(tSKrV, typename TiledMmaNewV::LayoutA_TV{});
+      auto tNewVrC = partition_fragment_C(newv_thr_mma, select<0, 1>(TileShapeNewV{}));
+      warpgroup_fence_operand(tNewVrA);
+      warpgroup_fence_operand(tNewVrC);
+      math_barriers.ordered_or_wait(warpgroup_idx);
+      warpgroup_arrive();
+      // if constexpr (is_final_block) {
+      //   if (thread_idx == 0) {
+      //     printf("\n");
+      //     printf("=======tNewVrA, tNewVrB before V'@T, block_idx: %d, thread_idx: %d=======\n", blk,
+      //     thread_idx); printf("tNewVrA\n"); cute::print_tensor(tNewVrA); printf("sKK_opd\n");
+      //     cute::print_tensor(sKK_opd);
+      //     printf("=======tNewVrA, tNewVrB before V'@T, block_idx: %d, thread_idx: %d=======\n", blk,
+      //     thread_idx); printf("\n");
+      //   }
+      // }
+      // NewV = V'T
+      gemm_zero_acc(o1_thr_mma, tNewVrA, tNewVrB(_, _, _, kk_smem_pipe_read.index()), tNewVrC);
+      warpgroup_commit_batch();  // new_v batch
+      math_barriers.notify_next_blocked(warpgroup_idx);
+      warpgroup_wait<0>();  // new_v batch
+      // if constexpr (is_final_block) {
+      //   if (thread_idx == 0) {
+      //     printf("\n");
+      //     printf("=======tNewVrC after V'@T, block_idx: %d, thread_idx: %d=======\n", blk, thread_idx);
+      //     cute::print_tensor(tNewVrC);
+      //   }
+      // }
+      DPRINTF0_WG("compute: v_pipeline.consumer_release: smem_pipe_read:%d\n", v_smem_pipe_read.index());
+      ++v_smem_pipe_read;  // NOTE: if we delay this increment after consumer_release, race condition happens,
+                           // why?
+      v_pipeline.consumer_release(v_smem_pipe_read);
+
+      kk_pipeline.consumer_release(kk_smem_pipe_read);
+      ++kk_smem_pipe_read;
+      beta_pipeline.consumer_release(beta_smem_pipe_read);
+      ++beta_smem_pipe_read;
+
+      /////////////////////////////////////////////////////////////////////////
+      // 2. compute qkv
+      // 2.2 QK @ V, NOTE: use old KV here and QK is scaled
+      qk_pipeline.consumer_wait(qk_smem_pipe_read);
+      auto tOrV_or_tKVrV = make_acc_into_op<Element>(tNewVrC, typename TiledMmaKV::LayoutA_TV{});
+      warpgroup_fence_operand(tOrV_or_tKVrV);
+      warpgroup_fence_operand(tOrO);
+      math_barriers.ordered_or_wait(warpgroup_idx);
+      warpgroup_arrive();
+      // (V_new)^T @ QK
+      if constexpr (is_first_block) {
+        gemm_zero_acc(o2_tiled_mma, tOrV_or_tKVrV, tOrQK(_, _, _, qk_smem_pipe_read.index()), tOrO);
+      } else {
+        gemm(o2_tiled_mma, tOrV_or_tKVrV, tOrQK(_, _, _, qk_smem_pipe_read.index()), tOrO);
+      }
+      warpgroup_commit_batch();  // qk@v batch
+      math_barriers.notify_next_blocked(warpgroup_idx);
+      warpgroup_wait<0>();  // qk@v batch
+      // if (blk <= 6 && thread_idx == 0) {
+      //   printf("\n");
+      //   printf("=======O_intra after NewV@QK, block_idx: %d, thread_idx: %d=======\n", blk, thread_idx);
+      //   cute::print_tensor(tOrO);
+      // }
+      qk_pipeline.consumer_release(qk_smem_pipe_read);
+      ++qk_smem_pipe_read;
+      o_store(tOrO);
+
+      /////////////////////////////////////////////////////////////////////////
+      // 3. update KV
+      Tensor tKVsK = kv_thr_mma.partition_B(sQ_K_scaled_Kt);
+      Tensor tKVrK = kv_thr_mma.make_fragment_B(tKVsK);
+
+      if constexpr (NeedsAlpha) {
+        alpha_last_pipeline.consumer_wait(alpha_last_smem_pipe_read);
+        cutlass::arch::fence_view_async_shared();
+      }
+      s_decay(tKVrKV, alpha_last_smem_pipe_read);
+
+      // synchronize 2 WGs before rewriting sQ_K_scaled
+      cutlass::arch::NamedBarrier::arrive_and_wait(NumStateMmaThreads, KdaNamedBarriers::StateMath);
+      // exp(alpha_last - alpha) * K
+      // Each WG iterates over 2 slices of 32 elements each.
+      // WG0 (thread_idx < 128): wg_idx=0, alpha_last indices {0,1}, K/output dim1=0
+      // WG1 (thread_idx >= 128): wg_idx=1, alpha_last indices {2,3}, K/output dim1=1
+      {
+        int wg_idx = thread_idx / 128;  // 0 or 1
+        int alpha_base = wg_idx * 2;    // 0 or 2
+
+        // Allocate K/Alpha register fragments once (reused across slices)
+        auto tQKrK_wg = qk_thr_mma_rs_quar.partition_fragment_A(sKqk_slice(_, _, _0{}, make_coord(_0{}, _0{})));
+        auto tArA_wg = make_fragment_like<ElementAlpha>(tQKrK_wg);
+
+        for (int s = 0; s < 2; ++s) {
+          // S2R Alpha
+          int alpha_col = alpha_base + s;
+          auto sA_cur = sAqkq_slice(_, _, _0{}, make_coord(0, alpha_col));
+          auto tAsA_cur = qk_thr_mma_rs_quar.partition_A(sA_cur);
+          copy(CopyAlphaAtom{}, tAsA_cur, tArA_wg);
+
+          // S2R K
+          auto sKqk_cur = sKqk_slice(_, _, _0{}, make_coord(s, wg_idx));
+          auto tQKsK_cur = thr_load_qk_quar.partition_S(sKqk_cur);
+          auto tQKrK_cv = thr_load_qk_quar.retile_D(tQKrK_wg);
+          copy(tiled_load_qk_quar, tQKsK_cur, tQKrK_cv);
+
+          // element-wise: exp(alpha_last - alpha) * K
+          int alast_idx = alpha_base + s;
+          auto alpha_last_cur = sAlast_slice(_, alast_idx);
+          for_each(make_int_sequence<size(tQcMq_quar)>{}, [&](auto i) {
+            auto coord = tQcMq_quar(i);
+            auto [seq, t] = coord;
+            auto alpha = tArA_wg(i);
+            auto k = tQKrK_wg(i);
+            auto alpha_last = alpha_last_cur(t);
+            auto k_scaled = Element(exp2f(alpha_last - alpha) * float(k));
+            tQKrK_wg(i) = k_scaled;
+            if constexpr (is_final_block) {
+              if (seq >= B) {
+                tQKrK_wg(i) = Element(0.0f);
+              }
+            }
+          });
+
+          // R2S K -> stage 0 (reuse for KV update)
+          auto sQ_scaled_cur = sQ_scaled_slice(_, _, _0{}, make_coord(s, wg_idx));
+          auto tQKsK_out = thr_store_qk_quar.partition_D(sQ_scaled_cur);
+          auto tQKrK_out_cv = thr_store_qk_quar.retile_S(tQKrK_wg);
+          copy(tiled_store_qk_quar, tQKrK_out_cv, tQKsK_out);
+        }
+      }
+      // wait for smemq_k_scaled ready
+      cutlass::arch::NamedBarrier::arrive_and_wait(NumStateMmaThreads, KdaNamedBarriers::StateMath);
+      // fence to produce data for WGMMA async proxy
+      cutlass::arch::fence_view_async_shared();
+
+      if constexpr (NeedsAlpha) {
+        alpha_last_pipeline.consumer_release(alpha_last_smem_pipe_read);
+        ++alpha_last_smem_pipe_read;
+      }
+
+      DPRINTF0_WG("[%d,%d,%d,%d]** dispatch KV WGMMA\n", seq_idx, q_head_idx, k_head_idx, v_head_idx);
+      warpgroup_fence_operand(tOrV_or_tKVrV);
+      warpgroup_fence_operand(tKVrKV);
+
+      math_barriers.ordered_or_wait(warpgroup_idx);
+      warpgroup_arrive();
+      gemm(kv_tiled_mma, tOrV_or_tKVrV, tKVrK(_, _, _, 0), tKVrKV);
+      warpgroup_commit_batch();  // k@v batch
+      math_barriers.notify_next_blocked(warpgroup_idx);
+      warpgroup_wait<0>();
+      // if constexpr (is_final_block) {
+      //   if (thread_idx == 0) {
+      //     printf("\n");
+      //     printf("=======After K^T@NewV, block_idx: %d, thread_idx: %d=======\n", blk, thread_idx);
+      //     printf("tKVrKV\n");
+      //     cute::print_tensor(tKVrKV);
+      //   }
+      // }
+
+      if constexpr (NeedsAlpha) {
+        alpha_pipeline.consumer_release(alpha_smem_pipe_read);
+        ++alpha_smem_pipe_read;
+      }
+
+      DPRINTF0_WG("compute: k_pipeline.consumer_release: smem_pipe_read:%d\n", k_smem_pipe_read.index());
+      k_pipeline.consumer_release(k_smem_pipe_read);
+      ++k_smem_pipe_read;
+
+      // if (blk <= 6 && thread_idx == 0) {
+      //   printf("\n");
+      //   printf("=======After S epilogue, block_idx: %d, thread_idx: %d, head_idx: %d=======\n", blk,
+      //   thread_idx, q_head_idx); printf("tKVrKV\n"); cute::print_tensor(tKVrKV);
+      // }
+    };
+
+    if constexpr (!kInitStateFromInput) {
+      clear(tKVrKV);
+      compute_loop_body(0, /*is_first_block_=*/cute::true_type{}, /*is_final_block_=*/cute::false_type{});
+    } else {
+      kv_load(tKVrKV);  // GMEM -> Register, only once at the beginning
+      compute_loop_body(0, /*is_first_block_=*/cute::false_type{}, /*is_final_block_=*/cute::false_type{});
+    }
+    CUTE_NO_UNROLL
+    for (int blk = 1; blk < num_blocks - 1; ++blk) {
+      compute_loop_body(blk, /*is_first_block_=*/cute::false_type{}, /*is_final_block_=*/cute::false_type{});
+    }
+    if (num_blocks != 1) {
+      compute_loop_body(
+          num_blocks - 1,
+          /*is_first_block_=*/cute::false_type{},
+          /*is_final_block_=*/cute::true_type{});
+    }
+    kv_store();
+  }
+
+  template <class ProblemShape, class WorkDesc>
+  CUTE_DEVICE void compute_aux_safe(
+      Params const& params,
+      ProblemShape const& problem_size,
+      WorkDesc const& work_desc,
+      MainloopQPipeline& q_pipeline,
+      QPipelineState& q_smem_pipe_read,
+      MainloopKPipeline& k_pipeline,
+      KPipelineState& k_smem_pipe_read,
+      MainloopQKPipeline& qk_pipeline,
+      QKPipelineState& qk_smem_pipe_write,
+      MainloopKKPipeline& kk_pipeline,
+      KKPipelineState& kk_smem_pipe_write,
+      MainloopAlphaPipeline& alpha_pipeline,
+      AlphaPipelineState& alpha_smem_pipe_read,
+      MainloopBetaPipeline& beta_pipeline,
+      BetaPipelineState& beta_smem_pipe_read,
+      MainloopAlphaLastPipeline& alpha_last_pipeline,
+      AlphaLastPipelineState& alpha_last_smem_pipe_write,
+      SharedStorage& storage) {
+    using TileShape_SubChunk = Shape<_16, _16, _32>;
+    int thread_idx = threadIdx.x % cutlass::NumThreadsPerWarpGroup;
+
+    float scale = params.scale;
+
+    Tensor Beta = make_tensor(make_smem_ptr(storage.smem_beta.data()), SmemLayoutBeta{});
+
+    Tensor sQqk = make_tensor(make_smem_ptr(storage.smem_q.data()), QKSmemLayoutQ{});
+    Tensor sKqk = make_tensor(make_smem_ptr(storage.smem_k.data()), QKSmemLayoutK{});
+
+    Tensor sAqkq = make_tensor(make_smem_ptr(storage.smem_alpha.data()), QKQSmemLayoutAlpha{});
+    Tensor sAqkk = make_tensor(make_smem_ptr(storage.smem_alpha.data()), QKKSmemLayoutAlpha{});
+    Tensor sAlast = make_tensor(make_smem_ptr(storage.smem_alpha_last.data()), SmemLayoutAlphaLast{});
+
+    Tensor sKkv = make_tensor(make_smem_ptr(storage.smem_k.data()), KVSmemLayoutK{});
+    Tensor sVkv = make_tensor(make_smem_ptr(storage.smem_v.data()), KVSmemLayoutV{});
+    Tensor sQK = make_tensor(make_smem_ptr(storage.smem_qk.data()), SmemLayoutQK{});
+    Tensor sO = make_tensor(make_smem_ptr(storage.smem_o.data()), SmemLayoutO{});
+
+    static_assert(sizeof(InverseType) == sizeof(Element));
+    Tensor sKK_inv = make_tensor(make_smem_ptr(storage.smem_kk.data()), SmemLayoutKK{});
+    Tensor sKK_opd = make_tensor(make_smem_ptr(reinterpret_cast<Element*>(storage.smem_kk.data())), SmemLayoutKK{});
+
+    constexpr int BK = 32;  // should be same as TileShape_SubChunk
+    constexpr int NK = 128 / BK;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Q@K
+    auto qk_tiled_mma_rs = TiledMmaQK_RS{};
+    auto qk_thr_mma_rs = qk_tiled_mma_rs.get_thread_slice(thread_idx);
+
+    auto cMqk = make_identity_tensor(select<0, 1>(TileShapeQK{}));  // (QTok, KTok)
+    auto tQKcMqk = qk_thr_mma_rs.partition_C(cMqk);                 // (idx) -> (tok_q, tok_k)
+    auto cMq = make_identity_tensor(select<0, 2>(TileShapeQK{}));   // (QTok, HeadDim)
+    auto tQcMq = qk_thr_mma_rs.partition_A(cMq);                    // (idx) -> (tok_q, head_dim)
+
+    auto const seq_idx = work_desc.seq_idx;
+    auto const q_head_idx = work_desc.q_head_idx();
+    auto const k_head_idx = work_desc.k_head_idx();
+    auto const v_head_idx = work_desc.v_head_idx();
+
+    auto qk_kk_subchunk_mma_and_store = [&](int blk) INLINE_LAMBDA {
+      using CopyOp_R2S = SM90_U32x2_STSM_N;
+      using CopyAlphaAtom = Copy_Atom<AutoVectorizingCopyWithAssumedAlignment<128>, ElementAlpha>;
+      // Q/K S2R: use BF16 MMA's LDSM tiled copy for efficient shared memory loads,
+      // then convert register layout to TF32 MMA layout via warp shuffles.
+      // This replaces the previous AutoVectorizingCopy<16> which caused 50% more smem traffic.
+      using CopyQKAtom_LDSM = Copy_Atom<SM75_U32x4_LDSM_N, Element>;
+      // TF32 MMA: float(Element) → tf32 → MMA, better precision than fp16/bf16 MMA
+      using MMA = SM80_16x8x8_F32TF32TF32F32_TN;
+      using TiledMma_SubChunk = decltype(make_tiled_mma(MMA{}, Layout<Shape<_1, _2, _1>>{}, TileShape_SubChunk{}));
+      // BF16 MMA (same shape 16x8x8) used only for creating LDSM-compatible tiled copies
+      using MMA_BF16 = SM80_16x8x8_F32BF16BF16F32_TN;
+      using TiledMma_BF16_SubChunk =
+          decltype(make_tiled_mma(MMA_BF16{}, Layout<Shape<_1, _2, _1>>{}, TileShape_SubChunk{}));
+
+      int local_thread_idx = thread_idx % 64;
+      auto tiledmma_subchunk = TiledMma_SubChunk{};
+      auto thr_mma_subchunk = tiledmma_subchunk.get_thread_slice(local_thread_idx);
+      auto tiledmma_bf16_subchunk = TiledMma_BF16_SubChunk{};
+      auto thr_mma_bf16_subchunk = tiledmma_bf16_subchunk.get_thread_slice(local_thread_idx);
+
+      // Alpha S2R: load in BF16 MMA layout so gating happens before the layout shuffle,
+      // reducing register pressure (alpha can be freed before the shuffle).
+      // BF16-layout alpha copies for operand A and B (for element-wise gating)
+      auto alpha_Q_bf16_tiled_copy = make_tiled_copy_A(CopyAlphaAtom{}, tiledmma_bf16_subchunk);
+      auto alpha_Kt_bf16_tiled_copy = make_tiled_copy_B(CopyAlphaAtom{}, tiledmma_bf16_subchunk);
+      // Q/K S2R: LDSM copies using BF16 MMA layout for efficient ldmatrix loads
+      auto Q_tiled_copy = make_tiled_copy_A(CopyQKAtom_LDSM{}, tiledmma_bf16_subchunk);
+      auto Kt_tiled_copy = make_tiled_copy_B(CopyQKAtom_LDSM{}, tiledmma_bf16_subchunk);
+      // R2S copies for accumulators (C layout, same for all MMA types with same output)
+      auto O_tiled_copy = make_tiled_copy_C(Copy_Atom<CopyOp_R2S, Element>{}, tiledmma_subchunk);
+      auto O_tiled_copy_kk = make_tiled_copy_C(Copy_Atom<CopyOp_R2S, InverseType>{}, tiledmma_subchunk);
+
+      auto alpha_Q_bf16_thr_copy = alpha_Q_bf16_tiled_copy.get_thread_slice(local_thread_idx);
+      auto alpha_Kt_bf16_thr_copy = alpha_Kt_bf16_tiled_copy.get_thread_slice(local_thread_idx);
+      auto Q_thr_copy = Q_tiled_copy.get_thread_slice(local_thread_idx);
+      auto Kt_thr_copy = Kt_tiled_copy.get_thread_slice(local_thread_idx);
+      auto O_thr_copy = O_tiled_copy.get_thread_slice(local_thread_idx);
+      auto O_thr_copy_kk = O_tiled_copy_kk.get_thread_slice(local_thread_idx);
+
+      // index tensor
+      auto cMqk_subchunk = make_identity_tensor(select<0, 1>(TileShape_SubChunk{}));
+      auto tQKcMqk_subchunk = thr_mma_subchunk.partition_C(cMqk_subchunk);
+
+      // do MMA at the granularity of 16x16x64 with two warps
+      constexpr auto tiler_subchunk_alpha = Shape<_16, Shape<_32, _1>>{};
+      constexpr auto tiler_subchunk_qk = Shape<_16, Shape<_32, _1>>{};
+      constexpr auto tiler_subchunk_beta = Shape<_16>{};
+      auto sQqk_curr = sQqk(_, _, q_smem_pipe_read.index());
+      auto sKqk_curr = sKqk(_, _, k_smem_pipe_read.index());
+      auto sAqkq_curr = sAqkq(_, _, alpha_smem_pipe_read.index());
+      Tensor sBeta_curr = Beta(_, beta_smem_pipe_read.index());
+
+      // (_16,(_32,_1),_4,(_2,_2)):(_64,(_1,_0),_1024,(_32,_4096))
+      auto sQqk_slice = flat_divide(sQqk_curr, tiler_subchunk_qk);
+      auto sKqk_slice = flat_divide(sKqk_curr, tiler_subchunk_qk);
+      // (_16,(_32,_1),_4,(_1,_4)):(_32,(_1,_0),_512,(_0,_2048))
+      auto sAqkq_slice = flat_divide(sAqkq_curr, tiler_subchunk_alpha);
+      auto sBeta_slice = flat_divide(sBeta_curr, tiler_subchunk_beta);
+
+      // Acc results
+      constexpr auto tiler_acc_qk_kk = Shape<_16, _16>{};
+      static_assert(sizeof(Element) == 2);
+      auto sQK_curr = sQK(_, _, qk_smem_pipe_write.index());
+      auto sQK_slice = flat_divide(sQK_curr, tiler_acc_qk_kk);
+      auto sKK_inv_curr = sKK_inv(_, _, kk_smem_pipe_write.index());
+      auto sKK_inv_slice = flat_divide(sKK_inv_curr, tiler_acc_qk_kk);
+
+      // used for make_fragment_like in Alpha and S2R (TF32 MMA layout)
+      Tensor sQqk_1_0 = sQqk_slice(_, _, _1{}, make_coord(_0{}, _0{}));
+      Tensor sKqk_1_0 = sKqk_slice(_, _, _1{}, make_coord(_0{}, _0{}));
+      Tensor tQKrQ_1_0 = thr_mma_subchunk.partition_fragment_A(sQqk_1_0);
+      Tensor tQKrKt_1_0 = thr_mma_subchunk.partition_fragment_B(sKqk_1_0);
+      auto tv_layout_mma_A = tQKrQ_1_0.layout();
+      auto tv_layout_mma_B = tQKrKt_1_0.layout();
+
+      // BF16 MMA fragment layouts for LDSM-based S2R loads (same shape, different TV mapping)
+      Tensor tQKrQ_bf16_1_0 = thr_mma_bf16_subchunk.partition_fragment_A(sQqk_1_0);
+      Tensor tQKrKt_bf16_1_0 = thr_mma_bf16_subchunk.partition_fragment_B(sKqk_1_0);
+      auto tv_layout_bf16_mma_A = tQKrQ_bf16_1_0.layout();
+      auto tv_layout_bf16_mma_B = tQKrKt_bf16_1_0.layout();
+
+      // S2R Q/K/G for operand A at row r, head dim slice j, and element-wise compute.
+      // Loads alpha once in BF16 MMA layout, derives g_first via warp shuffle (8 shuffles,
+      // replaces 1 S2R load), gates Q/K before the BF16→TF32 layout conversion.
+      // Also extracts g_first in operand B layout for free (broadcast → register copy).
+      // j0 = j % 2, j1 = j / 2: precomputed by caller to avoid redundant div/mod.
+      // returns (tQKrQ, tQKrK, tArAfirst_kt) = (Q * exp2(g - g_first), K * exp2(g - g_first), g_first in B
+      // layout)
+      auto s2r_compute_subchunk_operandA = [&](auto r_, int j, int j0, int j1) INLINE_LAMBDA {
+        // S2R g_r_j in BF16 MMA operand A layout (single load)
+        Tensor sAqkq_r_j = sAqkq_slice(_, _, r_, make_coord(_0{}, j));
+        Tensor tAsA_r_j = alpha_Q_bf16_thr_copy.partition_S(sAqkq_r_j);
+        Tensor tArA_r_j = make_fragment_like<ElementAlpha>(tv_layout_bf16_mma_A);
+        Tensor tArA_r_j_cv = alpha_Q_bf16_thr_copy.retile_D(tArA_r_j);
+        copy(alpha_Q_bf16_tiled_copy, tAsA_r_j, tArA_r_j_cv);
+
+        // Derive g_first (alpha[row=0, :]) from tArA_r_j via warp shuffle,
+        // directly into operand B layout (8 values instead of 16).
+        // g_first is broadcast (all M rows identical), so operand B only needs the
+        // v1=0 subset of operand A. We shuffle v1=0 values from t1=0 thread and
+        // output directly as operand B fragment, saving 8 float registers.
+        Tensor tArAfirst_r_j_kt = make_fragment_like<ElementAlpha>(tv_layout_bf16_mma_B);
+        broadcast_row0_operandA_to_operandB_bf16_layout(tArA_r_j, tArAfirst_r_j_kt, local_thread_idx);
+
+        // gqn_r_j = exp2(g_r_j - g_r_j_first[None, :]) in BF16 MMA A layout.
+        // g_first per k-iter is in tArAfirst_r_j_kt: frag_B(2j)=K_lo, frag_B(2j+1)=K_hi.
+        // In A layout: v1=0 indices (4j+0, 4j+1) have same K as v1=1 indices (4j+2, 4j+3),
+        // so g_first for index 4j+{0,2} = frag_B(2j), for 4j+{1,3} = frag_B(2j+1).
+        CUTE_UNROLL
+        for (int k = 0; k < 4; k++) {
+          auto gf_lo = tArAfirst_r_j_kt(2 * k);                      // g_first at K = 2*t0
+          auto gf_hi = tArAfirst_r_j_kt(2 * k + 1);                  // g_first at K = 2*t0+1
+          tArA_r_j(4 * k + 0) = exp2f(tArA_r_j(4 * k + 0) - gf_lo);  // v0=0, v1=0
+          tArA_r_j(4 * k + 1) = exp2f(tArA_r_j(4 * k + 1) - gf_hi);  // v0=1, v1=0
+          tArA_r_j(4 * k + 2) = exp2f(tArA_r_j(4 * k + 2) - gf_lo);  // v0=0, v1=1
+          tArA_r_j(4 * k + 3) = exp2f(tArA_r_j(4 * k + 3) - gf_hi);  // v0=1, v1=1
+        }
+
+        Tensor sQqk_r_j = sQqk_slice(_, _, r_, make_coord(j0, j1));
+        Tensor sKqk_r_j = sKqk_slice(_, _, r_, make_coord(j0, j1));
+
+        // --- Process Q ---
+        // S2R Q in BF16 MMA layout
+        Tensor tQKrQ_r_j_bf16 = make_fragment_like<Element>(tv_layout_bf16_mma_A);
+        Tensor tQKsQ_r_j = Q_thr_copy.partition_S(sQqk_r_j);
+        Tensor tQKrQ_r_j_bf16_cv = Q_thr_copy.retile_D(tQKrQ_r_j_bf16);
+        copy(Q_tiled_copy, tQKsQ_r_j, tQKrQ_r_j_bf16_cv);
+        // gate: Q * exp2(g - g_first) in BF16 MMA layout, producing float
+        Tensor tQKrQ_r_j_float = make_fragment_like<float>(tv_layout_bf16_mma_A);
+        cute::transform(tQKrQ_r_j_bf16, tArA_r_j, tQKrQ_r_j_float, [&](auto q, auto g) { return float(q) * g; });
+        // convert BF16 MMA layout → TF32 MMA layout in-place via warp shuffles
+        convert_bf16_to_tf32_operandA_layout(tQKrQ_r_j_float, local_thread_idx);
+        // NOTE: triton tl.dot also lets MMA hardware for truncation
+        // recast float storage as tf32 view (zero cost, same 32-bit registers; MMA hw truncates)
+        auto tQKrQ_r_j = recast<ElementGatedMMA>(tQKrQ_r_j_float);
+
+        // --- Process K (sequential, after Q is done to reduce peak reg usage) ---
+        Tensor tQKrK_r_j_bf16 = make_fragment_like<Element>(tv_layout_bf16_mma_A);
+        Tensor tQKsK_r_j = Q_thr_copy.partition_S(sKqk_r_j);
+        Tensor tQKrK_r_j_bf16_cv = Q_thr_copy.retile_D(tQKrK_r_j_bf16);
+        copy(Q_tiled_copy, tQKsK_r_j, tQKrK_r_j_bf16_cv);
+        Tensor tQKrK_r_j_float = make_fragment_like<float>(tv_layout_bf16_mma_A);
+        cute::transform(tQKrK_r_j_bf16, tArA_r_j, tQKrK_r_j_float, [&](auto k, auto g) { return float(k) * g; });
+        // convert BF16 MMA layout → TF32 MMA layout in-place via warp shuffles
+        convert_bf16_to_tf32_operandA_layout(tQKrK_r_j_float, local_thread_idx);
+        auto tQKrK_r_j = recast<ElementGatedMMA>(tQKrK_r_j_float);
+
+        return cute::make_tuple(tQKrQ_r_j, tQKrK_r_j, tArAfirst_r_j_kt);
+      };
+
+      // S2R K/G for operand B at column c, head dim slice j, and element-wise compute
+      // Loads alpha in BF16 MMA B layout, gates K in BF16 MMA B layout (before shuffle),
+      // then converts gated result to TF32 MMA B layout.
+      // tArAfirst_kt: pre-loaded g_first register tensor (BF16 MMA B layout) for computing gktn = exp2(g_first -
+      // g_c) returns tQKrKt = K_c * exp2(g_first - g_c)
+      auto s2r_compute_subchunk_operandB = [&](auto c_, int j, int j0, int j1, auto const& tArAfirst_kt) INLINE_LAMBDA {
+        // S2R g_c_j in BF16 MMA operand B layout
+        Tensor sAqkq_c_j = sAqkq_slice(_, _, c_, make_coord(_0{}, j));
+        Tensor tAsA_c_j = alpha_Kt_bf16_thr_copy.partition_S(sAqkq_c_j);
+        Tensor tArA_c_j = make_fragment_like<ElementAlpha>(tv_layout_bf16_mma_B);
+        Tensor tArA_c_j_cv = alpha_Kt_bf16_thr_copy.retile_D(tArA_c_j);
+        copy(alpha_Kt_bf16_tiled_copy, tAsA_c_j, tArA_c_j_cv);
+
+        // compute gktn_c_j = exp2(g_first - g_c_j) in BF16 MMA B layout
+        cute::transform(tArA_c_j, tArAfirst_kt, tArA_c_j, [&](auto g, auto g_first) { return exp2f(g_first - g); });
+
+        // S2R k_c_j using BF16 LDSM
+        Tensor sKqk_c_j = sKqk_slice(_, _, c_, make_coord(j0, j1));
+        Tensor tQKrKt_c_j_bf16 = make_fragment_like<Element>(tv_layout_bf16_mma_B);
+        Tensor tQKsKt_c_j = Kt_thr_copy.partition_S(sKqk_c_j);
+        Tensor tQKrKt_c_j_bf16_cv = Kt_thr_copy.retile_D(tQKrKt_c_j_bf16);
+        copy(Kt_tiled_copy, tQKsKt_c_j, tQKrKt_c_j_bf16_cv);
+
+        // convert bf16 → float in BF16 MMA B layout
+        Tensor tQKrKt_c_j_float = make_fragment_like<float>(tv_layout_bf16_mma_B);
+        // gate in BF16 MMA B layout (alpha and K are in the same layout)
+        cute::transform(tQKrKt_c_j_bf16, tArA_c_j, tQKrKt_c_j_float, [&](auto k, auto g) { return float(k) * g; });
+
+        // convert BF16 MMA layout → TF32 MMA layout in-place via warp shuffles
+        convert_bf16_to_tf32_operandB_layout(tQKrKt_c_j_float, local_thread_idx);
+        auto tQKrKt_c_j = recast<ElementGatedMMA>(tQKrKt_c_j_float);
+
+        return tQKrKt_c_j;
+      };
+
+      // R2S (register to shared memory) store for subchunk accumulator results
+      // Stores both tQKrQK (QK accumulator, fp32 -> Element) and tKKrKK (KK accumulator, fp32 -> InverseType)
+      // into their respective shared memory tiles at position (r_, c_)
+      auto r2s_subchunk_acc = [&](auto r_, auto c_, auto const& tQKrQK, auto const& tKKrKK) INLINE_LAMBDA {
+        // R2S KK
+        Tensor sKK_inv_r_c = sKK_inv_slice(_, _, r_, c_);
+        Tensor tKKsKK_r_c = O_thr_copy_kk.partition_D(sKK_inv_r_c);
+        Tensor tKKrKK_cv = O_thr_copy_kk.retile_S(tKKrKK);
+        auto tKKrKK_cvt_cv = make_fragment_like<InverseType>(tKKrKK_cv);
+        cute::transform(tKKrKK_cv, tKKrKK_cvt_cv, [](auto v) { return InverseType(v); });
+        copy(O_tiled_copy_kk, tKKrKK_cvt_cv, tKKsKK_r_c);
+
+        // R2S QK
+        Tensor sQK_r_c = sQK_slice(_, _, r_, c_);
+        Tensor tQKsQK_r_c = O_thr_copy.partition_D(sQK_r_c);
+        Tensor tQKrQK_cv = O_thr_copy.retile_S(tQKrQK);
+        auto tQKrQK_cvt_cv = make_fragment_like<Element>(tQKrQK_cv);
+        cute::transform(tQKrQK_cv, tQKrQK_cvt_cv, [](auto v) { return Element(v); });
+        copy(O_tiled_copy, tQKrQK_cvt_cv, tQKsQK_r_c);
+      };
+
+      // do tensor core GEMM with single 16x16x128
+      // NOTE: should use safe_gate with lower_bound >= -5, otherwise overflow issues
+      auto gemm_tensor_core_1x16x16x128 =
+          [&](auto r_, auto c_, auto is_diagonal_, auto is_first_subchunk_) INLINE_LAMBDA {
+            constexpr bool is_first_subchunk = decltype(is_first_subchunk_)::value;
+
+            // allocate acc_r_c [16, 16]
+            Tensor tQKrQK_r_c = partition_fragment_C(tiledmma_subchunk, select<0, 1>(TileShape_SubChunk{}));
+            Tensor tKKrKK_r_c = partition_fragment_C(tiledmma_subchunk, select<0, 1>(TileShape_SubChunk{}));
+            clear(tQKrQK_r_c);
+            clear(tKKrKK_r_c);
+            // wait for data ready
+            if constexpr (is_first_subchunk) {
+              q_pipeline.consumer_wait(q_smem_pipe_read);
+              k_pipeline.consumer_wait(k_smem_pipe_read);
+              if constexpr (NeedsAlpha) {
+                alpha_pipeline.consumer_wait(alpha_smem_pipe_read);
+              }
+            }
+
+            // for loop head dim
+            CUTE_NO_UNROLL
+            for (int j = 0; j < NK; ++j) {
+              int j0 = j % 2, j1 = j / 2;
+              // S2R Q/K/G/g_first for operand A and element-wise compute
+              auto [tQKrQ_r_j, tQKrK_r_j, tArAfirst_r_j_kt] = s2r_compute_subchunk_operandA(r_, j, j0, j1);
+              // S2R K/G for operand B and element-wise compute
+              auto tQKrKt_c_j = s2r_compute_subchunk_operandB(c_, j, j0, j1, tArAfirst_r_j_kt);
+
+              // q_r_j/k_r_j @ k_c_j, accumulate acc_r_c
+              gemm(tiledmma_subchunk, tQKrQ_r_j, tQKrKt_c_j, tQKrQK_r_c);
+              gemm(tiledmma_subchunk, tQKrK_r_j, tQKrKt_c_j, tKKrKK_r_c);
+            }
+
+            // S2R beta_j (maybe resident in register?)
+            // epilogue: qk^t * scale
+            cute::transform(tQKrQK_r_c, [scale](auto v) { return v * scale; });
+            // epilogue: kk^t * beta_r
+            if constexpr (is_first_subchunk) {
+              beta_pipeline.consumer_wait(beta_smem_pipe_read);
+              cutlass::arch::fence_view_async_shared();
+            }
+            Tensor sBeta_r = sBeta_slice(_, r_);
+            for_each(make_int_sequence<size(tQKcMqk_subchunk)>{}, [&](auto i) {
+              auto coord = tQKcMqk_subchunk(i);
+              auto [s, t] = coord;
+              tKKrKK_r_c(i) *= sBeta_r(s);
+            });
+
+            // R2S qk_r_c, kk_r_c, wait for current QK/KK free
+            if constexpr (is_first_subchunk) {
+              kk_pipeline.producer_acquire(kk_smem_pipe_write);
+            }
+            if constexpr (is_first_subchunk) {
+              qk_pipeline.producer_acquire(qk_smem_pipe_write);
+            }
+            r2s_subchunk_acc(r_, c_, tQKrQK_r_c, tKKrKK_r_c);
+          };
+
+      // zero fill for upper triangular of QK and KK, because smem is randomly initialized
+      auto zero_fill = [&](int row, int col) INLINE_LAMBDA {
+        auto sQK_r_c = sQK_slice(_, _, row, col);
+        auto sKK_r_c = sKK_inv_slice(_, _, row, col);
+        // allocate regs
+        Tensor tQKrQK_r_c = partition_fragment_C(tiledmma_subchunk, select<0, 1>(TileShape_SubChunk{}));
+        Tensor tQKsQK_r_c = O_thr_copy.partition_D(sQK_r_c);
+        Tensor tQKrQK_r_c_cv = O_thr_copy.retile_S(tQKrQK_r_c);
+        Tensor tKKsKK_r_c = O_thr_copy_kk.partition_D(sKK_r_c);
+        Tensor tKKrKK_r_c_cv = O_thr_copy_kk.retile_S(tQKrQK_r_c);
+        auto tQKrQK_r_c_cvt_cv = make_fragment_like<Element>(tQKrQK_r_c_cv);
+        auto tKKrKK_r_c_cvt_cv = make_fragment_like<InverseType>(tKKrKK_r_c_cv);
+        // zero fill
+        clear(tQKrQK_r_c_cvt_cv);
+        clear(tKKrKK_r_c_cvt_cv);
+        // R2S
+        copy(O_tiled_copy, tQKrQK_r_c_cvt_cv, tQKsQK_r_c);
+        copy(O_tiled_copy_kk, tKKrKK_r_c_cvt_cv, tKKsKK_r_c);
+      };
+
+      // g_i_j/q_i_j/k_i_j: the j-th head dim slice of the i-th subchunk
+      if (thread_idx < 64) {
+        // Q/K0@K0, Q/K3@K3, Q/K3@K0, Q/K3@K1, Q/K3@K2
+
+        // NOTE: tensor core MMA for safe gate with lower_bound >= -5
+        gemm_tensor_core_1x16x16x128(
+            Int<0>{},
+            Int<0>{},
+            /*is_diagonal_=*/cute::true_type{},
+            /*is_first_subchunk_=*/cute::true_type{});
+
+        // Q/K3@K0, Q/K3@K1, Q/K3@K2
+        // allocate acc_3_0, acc_3_1, acc_3_2 [16, 16]
+        Tensor tQKrQK_3_0 = partition_fragment_C(tiledmma_subchunk, select<0, 1>(TileShape_SubChunk{}));
+        Tensor tKKrKK_3_0 = partition_fragment_C(tiledmma_subchunk, select<0, 1>(TileShape_SubChunk{}));
+        Tensor tQKrQK_3_1 = partition_fragment_C(tiledmma_subchunk, select<0, 1>(TileShape_SubChunk{}));
+        Tensor tKKrKK_3_1 = partition_fragment_C(tiledmma_subchunk, select<0, 1>(TileShape_SubChunk{}));
+        Tensor tQKrQK_3_2 = partition_fragment_C(tiledmma_subchunk, select<0, 1>(TileShape_SubChunk{}));
+        Tensor tKKrKK_3_2 = partition_fragment_C(tiledmma_subchunk, select<0, 1>(TileShape_SubChunk{}));
+        Tensor tQKrQK_3_3 = partition_fragment_C(tiledmma_subchunk, select<0, 1>(TileShape_SubChunk{}));
+        Tensor tKKrKK_3_3 = partition_fragment_C(tiledmma_subchunk, select<0, 1>(TileShape_SubChunk{}));
+        clear(tQKrQK_3_0);
+        clear(tKKrKK_3_0);
+        clear(tQKrQK_3_1);
+        clear(tKKrKK_3_1);
+        clear(tQKrQK_3_2);
+        clear(tKKrKK_3_2);
+        clear(tQKrQK_3_3);
+        clear(tKKrKK_3_3);
+
+        // for loop head dim
+        CUTE_NO_UNROLL
+        for (int j = 0; j < NK; ++j) {
+          int j0 = j % 2, j1 = j / 2;
+          // S2R Q/K/G/g_first for operand A (row 3) and element-wise compute
+          auto [tQKrQ_3_j, tQKrK_3_j, tArAfirst_3_j_kt] = s2r_compute_subchunk_operandA(_3{}, j, j0, j1);
+
+          // S2R K/G for operand B (col 0) and element-wise compute
+          auto tQKrKt_0_j = s2r_compute_subchunk_operandB(_0{}, j, j0, j1, tArAfirst_3_j_kt);
+          // q_3_j/k_3_j @ k_0_j, accumulate acc_3_0
+          gemm(tiledmma_subchunk, tQKrQ_3_j, tQKrKt_0_j, tQKrQK_3_0);
+          gemm(tiledmma_subchunk, tQKrK_3_j, tQKrKt_0_j, tKKrKK_3_0);
+
+          // S2R K/G for operand B (col 1) and element-wise compute
+          auto tQKrKt_1_j = s2r_compute_subchunk_operandB(_1{}, j, j0, j1, tArAfirst_3_j_kt);
+          // q_3_j/k_3_j @ k_1_j, accumulate acc_3_1
+          gemm(tiledmma_subchunk, tQKrQ_3_j, tQKrKt_1_j, tQKrQK_3_1);
+          gemm(tiledmma_subchunk, tQKrK_3_j, tQKrKt_1_j, tKKrKK_3_1);
+
+          // S2R K/G for operand B (col 2) and element-wise compute
+          auto tQKrKt_2_j = s2r_compute_subchunk_operandB(_2{}, j, j0, j1, tArAfirst_3_j_kt);
+          // q_3_j/k_3_j @ k_2_j, accumulate acc_3_2
+          gemm(tiledmma_subchunk, tQKrQ_3_j, tQKrKt_2_j, tQKrQK_3_2);
+          gemm(tiledmma_subchunk, tQKrK_3_j, tQKrKt_2_j, tKKrKK_3_2);
+
+          // S2R K/G for operand B (col 3) and element-wise compute
+          auto tQKrKt_3_j = s2r_compute_subchunk_operandB(_3{}, j, j0, j1, tArAfirst_3_j_kt);
+          // q_3_j/k_3_j @ k_3_j, accumulate acc_3_3
+          gemm(tiledmma_subchunk, tQKrQ_3_j, tQKrKt_3_j, tQKrQK_3_3);
+          gemm(tiledmma_subchunk, tQKrK_3_j, tQKrKt_3_j, tKKrKK_3_3);
+        }
+
+        // S2R beta (maybe resident in register?)
+        // epilogue: qk^t * scale
+        cute::transform(tQKrQK_3_0, [scale](auto v) { return v * scale; });
+        cute::transform(tQKrQK_3_1, [scale](auto v) { return v * scale; });
+        cute::transform(tQKrQK_3_2, [scale](auto v) { return v * scale; });
+        cute::transform(tQKrQK_3_3, [scale](auto v) { return v * scale; });
+        // epilogue: kk^t * beta_3
+        Tensor sBeta_3 = sBeta_slice(_, _3{});
+        for_each(make_int_sequence<size(tQKcMqk_subchunk)>{}, [&](auto i) {
+          auto coord = tQKcMqk_subchunk(i);
+          auto [s, t] = coord;
+          auto b = sBeta_3(s);
+          tKKrKK_3_0(i) *= b;
+          tKKrKK_3_1(i) *= b;
+          tKKrKK_3_2(i) *= b;
+          tKKrKK_3_3(i) *= b;
+        });
+
+        // R2S qk_3_0, kk_3_0, wait for current QK/KK free
+        r2s_subchunk_acc(_3{}, _0{}, tQKrQK_3_0, tKKrKK_3_0);
+        // R2S qk_3_1, kk_3_1
+        r2s_subchunk_acc(_3{}, _1{}, tQKrQK_3_1, tKKrKK_3_1);
+        // R2S qk_3_2, kk_3_2
+        r2s_subchunk_acc(_3{}, _2{}, tQKrQK_3_2, tKKrKK_3_2);
+        // R2S qk_3_3, kk_3_3
+        r2s_subchunk_acc(_3{}, _3{}, tQKrQK_3_3, tKKrKK_3_3);
+      } else {
+        // Q/K1@K0, Q/K2@K0, Q/K2@K1, Q/K2@K2, Q/K1@K1
+
+        // Q/K1@K0
+        // allocate acc_1_0 [16, 16]
+        Tensor tQKrQK_1_0 = partition_fragment_C(tiledmma_subchunk, select<0, 1>(TileShape_SubChunk{}));
+        Tensor tKKrKK_1_0 = partition_fragment_C(tiledmma_subchunk, select<0, 1>(TileShape_SubChunk{}));
+        Tensor tQKrQK_1_1 = partition_fragment_C(tiledmma_subchunk, select<0, 1>(TileShape_SubChunk{}));
+        Tensor tKKrKK_1_1 = partition_fragment_C(tiledmma_subchunk, select<0, 1>(TileShape_SubChunk{}));
+        clear(tQKrQK_1_0);
+        clear(tKKrKK_1_0);
+        clear(tQKrQK_1_1);
+        clear(tKKrKK_1_1);
+        // wait for data ready
+        q_pipeline.consumer_wait(q_smem_pipe_read);
+        k_pipeline.consumer_wait(k_smem_pipe_read);
+        if constexpr (NeedsAlpha) {
+          alpha_pipeline.consumer_wait(alpha_smem_pipe_read);
+        }
+
+        // for loop head dim
+        CUTE_NO_UNROLL
+        for (int j = 0; j < NK; ++j) {
+          int j0 = j % 2, j1 = j / 2;
+          // S2R Q/K/G/g_first for operand A (row 1) and element-wise compute
+          auto [tQKrQ_1_j, tQKrK_1_j, tArAfirst_1_j_kt] = s2r_compute_subchunk_operandA(_1{}, j, j0, j1);
+
+          // S2R K/G for operand B (col 0) and element-wise compute
+          auto tQKrKt_0_j = s2r_compute_subchunk_operandB(_0{}, j, j0, j1, tArAfirst_1_j_kt);
+          // q_1_j/k_1_j @ k_0_j, accumulate acc_1_0
+          gemm(tiledmma_subchunk, tQKrQ_1_j, tQKrKt_0_j, tQKrQK_1_0);
+          gemm(tiledmma_subchunk, tQKrK_1_j, tQKrKt_0_j, tKKrKK_1_0);
+
+          // S2R K/G for operand B (col 1) and element-wise compute
+          auto tQKrKt_1_j = s2r_compute_subchunk_operandB(_1{}, j, j0, j1, tArAfirst_1_j_kt);
+          // q_1_j/k_1_j @ k_1_j, accumulate acc_1_1
+          gemm(tiledmma_subchunk, tQKrQ_1_j, tQKrKt_1_j, tQKrQK_1_1);
+          gemm(tiledmma_subchunk, tQKrK_1_j, tQKrKt_1_j, tKKrKK_1_1);
+        }
+
+        // S2R beta_j (maybe resident in register?)
+        // epilogue: qk^t * scale
+        cute::transform(tQKrQK_1_0, [scale](auto v) { return v * scale; });
+        cute::transform(tQKrQK_1_1, [scale](auto v) { return v * scale; });
+        // epilogue: kk^t * beta_1
+        beta_pipeline.consumer_wait(beta_smem_pipe_read);
+        cutlass::arch::fence_view_async_shared();
+        Tensor sBeta_1 = sBeta_slice(_, _1{});
+        for_each(make_int_sequence<size(tQKcMqk_subchunk)>{}, [&](auto i) {
+          auto coord = tQKcMqk_subchunk(i);
+          auto [s, t] = coord;
+          tKKrKK_1_0(i) *= sBeta_1(s);
+          tKKrKK_1_1(i) *= sBeta_1(s);
+        });
+
+        // R2S qk_1_0, kk_1_0, wait for current QK/KK free
+        kk_pipeline.producer_acquire(kk_smem_pipe_write);
+        qk_pipeline.producer_acquire(qk_smem_pipe_write);
+
+        r2s_subchunk_acc(_1{}, _0{}, tQKrQK_1_0, tKKrKK_1_0);
+        // R2S qk_1_1, kk_1_1
+        r2s_subchunk_acc(_1{}, _1{}, tQKrQK_1_1, tKKrKK_1_1);
+
+        // Q/K2@K0, Q/K2@K1
+        // allocate acc_2_0, acc_2_1 [16, 16]
+        Tensor tQKrQK_2_0 = partition_fragment_C(tiledmma_subchunk, select<0, 1>(TileShape_SubChunk{}));
+        Tensor tKKrKK_2_0 = partition_fragment_C(tiledmma_subchunk, select<0, 1>(TileShape_SubChunk{}));
+        Tensor tQKrQK_2_1 = partition_fragment_C(tiledmma_subchunk, select<0, 1>(TileShape_SubChunk{}));
+        Tensor tKKrKK_2_1 = partition_fragment_C(tiledmma_subchunk, select<0, 1>(TileShape_SubChunk{}));
+        Tensor tQKrQK_2_2 = partition_fragment_C(tiledmma_subchunk, select<0, 1>(TileShape_SubChunk{}));
+        Tensor tKKrKK_2_2 = partition_fragment_C(tiledmma_subchunk, select<0, 1>(TileShape_SubChunk{}));
+        clear(tQKrQK_2_0);
+        clear(tKKrKK_2_0);
+        clear(tQKrQK_2_1);
+        clear(tKKrKK_2_1);
+        clear(tQKrQK_2_2);
+        clear(tKKrKK_2_2);
+
+        // for loop head dim
+        CUTE_NO_UNROLL
+        for (int j = 0; j < NK; ++j) {
+          int j0 = j % 2, j1 = j / 2;
+          // S2R Q/K/G/g_first for operand A (row 2) and element-wise compute
+          auto [tQKrQ_2_j, tQKrK_2_j, tArAfirst_2_j_kt] = s2r_compute_subchunk_operandA(_2{}, j, j0, j1);
+
+          // S2R K/G for operand B (col 0) and element-wise compute
+          auto tQKrKt_0_j = s2r_compute_subchunk_operandB(_0{}, j, j0, j1, tArAfirst_2_j_kt);
+          // q_2_j/k_2_j @ k_0_j, accumulate acc_2_0
+          gemm(tiledmma_subchunk, tQKrQ_2_j, tQKrKt_0_j, tQKrQK_2_0);
+          gemm(tiledmma_subchunk, tQKrK_2_j, tQKrKt_0_j, tKKrKK_2_0);
+
+          // S2R K/G for operand B (col 1) and element-wise compute
+          auto tQKrKt_1_j = s2r_compute_subchunk_operandB(_1{}, j, j0, j1, tArAfirst_2_j_kt);
+          // q_2_j/k_2_j @ k_1_j, accumulate acc_2_1
+          gemm(tiledmma_subchunk, tQKrQ_2_j, tQKrKt_1_j, tQKrQK_2_1);
+          gemm(tiledmma_subchunk, tQKrK_2_j, tQKrKt_1_j, tKKrKK_2_1);
+
+          // S2R K/G for operand B (col 2) and element-wise compute
+          auto tQKrKt_2_j = s2r_compute_subchunk_operandB(_2{}, j, j0, j1, tArAfirst_2_j_kt);
+          // q_2_j/k_2_j @ k_2_j, accumulate acc_2_2
+          gemm(tiledmma_subchunk, tQKrQ_2_j, tQKrKt_2_j, tQKrQK_2_2);
+          gemm(tiledmma_subchunk, tQKrK_2_j, tQKrKt_2_j, tKKrKK_2_2);
+        }
+
+        // S2R beta (maybe resident in register?)
+        // epilogue: qk^t * scale
+        cute::transform(tQKrQK_2_0, [scale](auto v) { return v * scale; });
+        cute::transform(tQKrQK_2_1, [scale](auto v) { return v * scale; });
+        cute::transform(tQKrQK_2_2, [scale](auto v) { return v * scale; });
+        // epilogue: kk^t * beta_2
+        Tensor sBeta_2 = sBeta_slice(_, 2);
+        for_each(make_int_sequence<size(tQKcMqk_subchunk)>{}, [&](auto i) {
+          auto coord = tQKcMqk_subchunk(i);
+          auto [s, t] = coord;
+          auto b = sBeta_2(s);
+          tKKrKK_2_0(i) *= b;
+          tKKrKK_2_1(i) *= b;
+          tKKrKK_2_2(i) *= b;
+        });
+
+        // R2S qk_2_0, kk_2_0, wait for current QK/KK free
+        r2s_subchunk_acc(_2{}, _0{}, tQKrQK_2_0, tKKrKK_2_0);
+        // R2S qk_2_1, kk_2_1
+        r2s_subchunk_acc(_2{}, _1{}, tQKrQK_2_1, tKKrKK_2_1);
+        // R2S qk_2_2, kk_2_2
+        r2s_subchunk_acc(_2{}, _2{}, tQKrQK_2_2, tKKrKK_2_2);
+      }
+    };
+
+    auto qk_and_kk_epi = [&](auto is_final_block_, auto B /*valid seqlen*/) INLINE_LAMBDA {
+      using CopyOpS2R_Chunk = SM75_U32x4_LDSM_N;
+      using CopyOpR2S_Chunk = SM90_U32x4_STSM_N;
+      // S2R QK/KK
+      auto sQK_curr = sQK(_, _, qk_smem_pipe_write.index());
+      auto sKK_inv_curr = sKK_inv(_, _, kk_smem_pipe_write.index());
+      Tensor tQKrQK_ref = partition_fragment_C(TiledMmaQK_RS{}, select<0, 1>(TileShapeQK{}));
+      auto tiled_load_qk = make_tiled_copy_C(Copy_Atom<CopyOpS2R_Chunk, Element>{}, qk_tiled_mma_rs);
+      auto thr_load_qk = tiled_load_qk.get_thread_slice(thread_idx);
+      auto tiled_load_kk = make_tiled_copy_C(Copy_Atom<CopyOpS2R_Chunk, InverseType>{}, qk_tiled_mma_rs);
+      auto thr_load_kk = tiled_load_kk.get_thread_slice(thread_idx);
+
+      auto tQKrQK_cv = thr_load_qk.retile_D(tQKrQK_ref);
+      auto tQKrQK = make_fragment_like<Element>(tQKrQK_cv);
+      auto tKKrKK = make_fragment_like<InverseType>(tQKrQK_cv);
+      copy(tiled_load_qk, thr_load_qk.partition_S(sQK_curr), tQKrQK);
+      copy(tiled_load_kk, thr_load_kk.partition_S(sKK_inv_curr), tKKrKK);
+
+      // triangular mask and boundary mask
+      constexpr bool is_final_block = decltype(is_final_block_)::value;
+      for_each(make_int_sequence<size(tQKcMqk)>{}, [&](auto i) {
+        auto coord = tQKcMqk(i);
+        auto [s, t] = coord;
+        bool pred = s >= t;
+        tQKrQK(i) = pred ? tQKrQK(i) : Element(0.0f);
+        tKKrKK(i) = pred ? tKKrKK(i) : InverseType(0.0f);  // diagonal is garbage filled, will process during inversion
+        if constexpr (is_final_block) {
+          bool pred = s < B && t < B;
+          tQKrQK(i) = pred ? tQKrQK(i) : Element(0.0f);
+          tKKrKK(i) = pred ? tKKrKK(i) : InverseType(0.0f);
+        }
+      });
+
+      // R2S QK/KK
+      auto tiled_store_qk = make_tiled_copy_C(Copy_Atom<CopyOpR2S_Chunk, Element>{}, qk_tiled_mma_rs);
+      auto thr_store_qk = tiled_store_qk.get_thread_slice(thread_idx);
+      auto tiled_store_kk = make_tiled_copy_C(Copy_Atom<CopyOpR2S_Chunk, InverseType>{}, qk_tiled_mma_rs);
+      auto thr_store_kk = tiled_store_kk.get_thread_slice(thread_idx);
+
+      copy(tiled_store_qk, thr_store_qk.retile_S(tQKrQK), thr_store_qk.partition_D(sQK_curr));
+      copy(tiled_store_kk, thr_store_kk.retile_S(tKKrKK), thr_store_kk.partition_D(sKK_inv_curr));
+    };
+
+    auto compute_aux_loop_body = [&](int blk, auto is_final_block_) INLINE_LAMBDA {
+      constexpr bool is_final_block = decltype(is_final_block_)::value;
+
+      int B = is_final_block ? valid_seq_len(work_desc, blk) : BlkSeqKV;
+
+      // ====DEBUG=====
+      // maintain pipeline correctness while removing subchunk
+      // wait for data ready
+      // q_pipeline.consumer_wait(q_smem_pipe_read);
+      // k_pipeline.consumer_wait(k_smem_pipe_read);
+      // if constexpr (NeedsAlpha) { alpha_pipeline.consumer_wait(alpha_smem_pipe_read); }
+      // beta_pipeline.consumer_wait(beta_smem_pipe_read);
+      // cutlass::arch::fence_view_async_shared();
+
+      // qk_pipeline.producer_acquire(qk_smem_pipe_write);
+      // kk_pipeline.producer_acquire(kk_smem_pipe_write);
+
+      // SubChunk MMA for QK^T and KK^T for numerical stability
+      // FIXME: use g_half as anchor in the diagonal subchunk to align with FLA for smaller numerical differences
+      qk_kk_subchunk_mma_and_store(blk);
+      // wait for QK/KK ready
+      cutlass::arch::NamedBarrier::arrive_and_wait(cutlass::NumThreadsPerWarpGroup, KdaNamedBarriers::AuxMath);
+      qk_and_kk_epi(is_final_block_, B);
+      // =====DEBUG======
+      // cutlass::arch::NamedBarrier::arrive_and_wait(cutlass::NumThreadsPerWarpGroup, KdaNamedBarriers::AuxMath);
+      // if constexpr (is_final_block) {
+      //   if (thread_idx == 0) {
+      //     printf("sQK\n");
+      //     cute::print_tensor(sQK(_, _, qk_smem_pipe_write.index()));
+      //     printf("sKK_inv\n");
+      //     cute::print_tensor(sKK_inv(_, _, kk_smem_pipe_write.index()));
+      //   }
+      // }
+
+      // QK/KK is ready to consume
+      cutlass::arch::fence_view_async_shared();
+      qk_pipeline.producer_commit(qk_smem_pipe_write);
+      ++qk_smem_pipe_write;
+      kk_pipeline.producer_commit(kk_smem_pipe_write);
+      ++kk_smem_pipe_write;
+
+      k_pipeline.consumer_release(k_smem_pipe_read);
+      ++k_smem_pipe_read;
+      q_pipeline.consumer_release(q_smem_pipe_read);
+      ++q_smem_pipe_read;
+      if constexpr (NeedsAlpha) {
+        alpha_pipeline.consumer_release(alpha_smem_pipe_read);
+        ++alpha_smem_pipe_read;
+      }
+
+      if constexpr (NeedsBeta) {
+        beta_pipeline.consumer_release(beta_smem_pipe_read);
+        ++beta_smem_pipe_read;
+      }
+    };
+
+    int32_t num_blocks = ceil_div(work_desc.seq_len, get<0>(TileShape{}));
+    CUTE_NO_UNROLL
+    for (int blk = 0; blk < num_blocks - 1; ++blk) {
+      compute_aux_loop_body(blk, /*is_final_block_=*/cute::false_type{});
+    }
+    compute_aux_loop_body(num_blocks - 1, /*is_final_block_=*/cute::true_type{});
+  }
+
+  template <typename WorkDesc>
+  CUTE_DEVICE int valid_seq_len(WorkDesc work_desc, int blk_idx) {
+    int remain_len = work_desc.seq_len - BlkSeqKV * blk_idx;
+    return remain_len <= BlkSeqKV ? remain_len : BlkSeqKV;
+  }
+};
+
+}  // namespace kda::sm90::collective

--- a/sgl-kernel/csrc/kda/sm90/collective/named_barriers.hpp
+++ b/sgl-kernel/csrc/kda/sm90/collective/named_barriers.hpp
@@ -1,0 +1,44 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace kda::sm90::collective {
+
+struct FlatSharedNamedBarriers {
+  static constexpr int AllMmaThreadsSync = 0;
+  static constexpr int AllLdStThreadsSync = 1;
+  static constexpr int MmaCooperativeStore = 2;
+
+ protected:
+  static constexpr int NumBarriersUsed = 4;
+};
+
+}  // namespace kda::sm90::collective

--- a/sgl-kernel/csrc/kda/sm90/collective/store_tma.hpp
+++ b/sgl-kernel/csrc/kda/sm90/collective/store_tma.hpp
@@ -1,0 +1,302 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cutlass/cutlass.h>
+
+#include <cuda/ptx>
+#include <cute/tensor.hpp>
+#include <cutlass/epilogue/collective/collective_builder.hpp>
+
+#include "kda/sm90/utils/debug.hpp"
+#include "kerutils/kerutils.cuh"
+
+namespace kda::sm90::collective {
+
+using ku::alignment_for_swizzle;
+using namespace cute;
+
+/*
+NOTE: what we need is as follows
+
+  using DefaultOperation = cutlass::epilogue::fusion::LinearCombination<ElementO, ElementAccumulatorO, void>;
+  using CollectiveStoreO = typename cutlass::epilogue::collective::CollectiveBuilder<
+      cutlass::arch::Sm90, cutlass::arch::OpClassTensorOp,
+      TileShapeO1, ClusterShape, cutlass::epilogue::collective::EpilogueTileAuto,
+      ElementAccumulatorO, ElementAccumulatorO,
+      void, LayoutO, Alignment,                                 // C, not exists
+      ElementO, decltype(select<1,0,2>(LayoutO{})), Alignment,  // D
+      cutlass::epilogue::TmaWarpSpecializedCooperative, DefaultOperation>::CollectiveOp;
+
+but unfortunately the required type alias is only useful for our purpose is private so we roll out our own.
+*/
+
+CUTE_DEVICE uint32_t smid() {
+#ifdef __CUDA_ARCH__
+  uint32_t virtual_smid;
+  asm("mov.u32 %0, %%smid;" : "=r"(virtual_smid));
+  return virtual_smid;
+#else
+  return 0;
+#endif
+}
+
+template <
+    typename TileShape_MNK_,
+    typename ClusterShape,
+    typename ElementO,
+    typename ElementAccumulator,
+    typename SmemElementO,
+    typename StrideO,
+    int Stages>
+struct CollectiveStoreTma {
+  static_assert(size_v<ClusterShape> == 1);
+  using TileShape_MNK = TileShape_MNK_;
+  using TileShape_MN =
+      decltype(select<0, 1>(TileShape_MNK{}));      // Collective work on TileShape_MN, it is also the OutputTile
+  using SizeM = decltype(get<0>(TileShape_MNK{}));  // head_size
+  using SizeN = decltype(get<1>(TileShape_MNK{}));  // seqlen
+
+  constexpr static bool is_m_major_O = cutlass::epilogue::collective::detail::is_m_major<StrideO>();
+
+#if 0
+  // NOTE: the following derived layout is a bit slower than the manual one, will evaluate it later
+  using SmemLayoutAtom = decltype(cutlass::epilogue::collective::detail::sm90_get_epilogue_smem_swizzle_layout_atom<
+                                  StrideO, ElementO, TileShape_MN>());
+#else
+  static_assert(sizeof(SmemElementO) == 2);
+  using SmemLayoutAtom = GMMA::Layout_MN_SW32_Atom<SmemElementO>;
+#endif
+
+  using SmemLayoutO = decltype(tile_to_shape(
+      SmemLayoutAtom{},
+      make_shape(SizeM{}, SizeN{}, Int<Stages>{}),
+      cute::conditional_t<is_m_major_O, Step<_2, _1, _3>, Step<_1, _2, _3>>{}));
+
+  constexpr static uint32_t TmaTransactionBytes =
+      (size(take<0, 2>(SmemLayoutO{})) * static_cast<uint32_t>(sizeof_bits<SmemElementO>::value)) / 8;
+
+  using CopyOpR2S = decltype(cutlass::epilogue::collective::detail::
+                                 sm90_get_smem_store_op_for_accumulator<StrideO, ElementO, TileShape_MN>());
+  using CopyAtomR2S = Copy_Atom<CopyOpR2S, SmemElementO>;
+
+  using CopyOpS2G = SM90_TMA_STORE;
+
+  using SharedStorage =
+      cute::array_aligned<SmemElementO, cute::cosize_v<SmemLayoutO>, alignment_for_swizzle(SmemLayoutO{})>;
+  using Pipeline = cutlass::PipelineAsync<Stages>;  // NOT PipelineTmaStore!
+  using PipelineState = cutlass::PipelineState<Stages>;
+
+  struct Arguments {
+    ElementO* ptr_O;
+    StrideO dO;
+    void* workspace;
+  };
+
+  struct Params {
+    using TMA_O = decltype(make_tma_copy(
+        CopyOpS2G{},
+        make_tensor(make_gmem_ptr<ElementO>(nullptr), repeat_like(StrideO{}, int32_t(0)), StrideO{}),
+        take<0, 2>(SmemLayoutO{}),
+        TileShape_MN{},
+        _1{}));
+
+    TMA_O tma_store_o;
+    uint32_t tma_transaction_bytes = TmaTransactionBytes;
+    void* tensormaps;
+  };
+  using TMA = typename Params::TMA_O;
+
+  CUTE_DEVICE
+  CollectiveStoreTma(TMA const& tma_store, Pipeline& pipeline, SharedStorage& storage, void* tensormaps)
+      : tma_store_(tma_store), pipeline_(pipeline), storage_(storage), tensormaps_(tensormaps) {}
+
+  template <class ProblemSize>
+  static Params to_underlying_arguments(ProblemSize const& problem_size, Arguments const& args, void* workspace) {
+    auto problem_size_MNKL = append<4>(problem_size, 1);
+    auto [M, N, K, L] = problem_size_MNKL;
+
+    Tensor tensor_o = make_tensor(make_gmem_ptr<ElementO>(args.ptr_O), make_layout(make_shape(M, N, L), args.dO));
+    TMA tma_store_o = make_tma_copy_C_sm90(CopyOpS2G{}, tensor_o, take<0, 2>(SmemLayoutO{}), TileShape_MN{});
+
+    return {
+        .tma_store_o = tma_store_o,
+        .tma_transaction_bytes = TmaTransactionBytes,
+        .tensormaps = workspace,
+    };
+  }
+
+  static size_t get_workspace_size(/*Arguments const& args,*/ int sm_count) {
+    // only use additional TMA desc for output tail tiles
+    size_t num_bytes = sizeof(cute::TmaDescriptor) * sm_count;
+    DPRINTF("workspace num_bytes:%zu\n", num_bytes);
+    return num_bytes;
+  }
+
+  template <class ProblemShape>
+  static cutlass::Status initialize_workspace(
+      ProblemShape const& problem_shape,
+      /*Arguments const& args,*/ void* workspace,
+      cudaStream_t stream) {
+    return cutlass::Status::kSuccess;
+  }
+
+  CUTE_DEVICE static void prefetch_tma_descriptors(Params const& params) {
+    cute::prefetch_tma_descriptor(params.tma_store_o.get_tma_descriptor());
+  }
+
+  template <class ProblemSize, class TileShape, class WorkDesc>
+  CUTE_DEVICE auto
+  partition_SD(ProblemSize const& problem_size, TileShape const& tile_shape, WorkDesc const& work_desc) {
+    constexpr auto BlkSeqQ = decltype(get<0>(tile_shape))::value;
+    constexpr auto HeadSize = decltype(get<2>(tile_shape))::value;
+
+    Tensor g = [&] {
+      DPRINTF0_W(
+          "slice view GMEM O: seq_idx:%d head_idx:%d tok_offset:%lld\n",
+          work_desc.seq_idx,
+          work_desc.o_head_idx(),
+          work_desc.tok_offset);
+      Tensor m_varlen_head = tma_store_.get_tma_tensor(make_shape(
+          problem_size.head_size,
+          problem_size.total_seqlen,
+          problem_size.num_heads));                                   // global view to the packed varlen sequence
+      Tensor m_varlen = m_varlen_head(_, _, work_desc.o_head_idx());  // slice into current head_idx
+      Tensor m_offset = domain_offset(
+          make_coord(_0{}, work_desc.tok_offset),
+          m_varlen);  // offset to start of the current sequence
+      Tensor g_full = local_tile(m_offset, make_tile(HeadSize, BlkSeqQ), make_coord(_0{}, _));  // (d, blk, iter_blk)
+      return g_full;
+    }();
+    Tensor s = make_tensor(make_smem_ptr(storage_.data()), SmemLayoutO{});
+
+    auto block_tma = tma_store_.get_slice(_0{});  // do not support cluster
+    return make_tuple(block_tma.partition_S(s), block_tma.partition_D(g));
+  }
+
+  template <typename ProblemSize, typename WorkDesc>
+  CUTE_DEVICE static bool
+  can_process(ProblemSize const& problem_size, WorkDesc const& work_desc, int blk, int num_blocks) {
+    if (blk < num_blocks - 1) {
+      // intermediate full tiles, always use TMA
+      return true;
+    } else if (work_desc.seq_len % SizeN{} == 0 || work_desc.seq_idx == problem_size.num_seqs - 1) {
+      // 1. last tile but full, also use TMA
+      // 2. last tile but last seq, oob can be handled by TMA
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  template <bool kAcquireBarrier = true, typename ProblemSize, typename WorkDesc, typename SrcDst>
+  CUTE_DEVICE void step(
+      ProblemSize const& problem_size,
+      WorkDesc const& work_desc,
+      SrcDst const& src_dst,
+      PipelineState& src_pipe,
+      int dst_iter,
+      int num_iters,
+      uint32_t lane_predicate) {
+    auto src = get<0>(src_dst);
+    auto dst = get<1>(src_dst);
+
+    if (dst_iter == 0) {
+      bool can_process_tail = can_process(problem_size, work_desc, num_iters - 1, num_iters);
+      if (!can_process_tail) {
+        create_tensormap_for_tail(work_desc, lane_predicate);
+      }
+    }
+
+    DPRINTF0_WG("pipeline.producer_acquire smem_pipe_read:%d\n", src_pipe.index());
+    if constexpr (kAcquireBarrier) {
+      pipeline_.consumer_wait(src_pipe);
+    }
+
+    if (can_process(problem_size, work_desc, dst_iter, num_iters)) {
+      DPRINTF0_W("store src_pipe:%d -> blk:%d\n", src_pipe.index(), dst_iter);
+      if (lane_predicate == 1) {
+        copy(tma_store_, src(_, _, _, src_pipe.index()), dst(_, _, _, dst_iter));
+      }
+    } else {
+      cute::TmaDescriptor* tensormap = acquire_tensormap_for_tail();
+      DPRINTF0_W("store tail with tensormap:%p src_pipe:%d -> blk:%d\n", tensormap, src_pipe.index(), dst_iter);
+      if (lane_predicate == 1) {
+        copy(tma_store_.with(tensormap), src(_, _, _, src_pipe.index()), dst(_, _, _, dst_iter));
+      }
+    }
+
+    if constexpr (kAcquireBarrier) {
+      pipeline_.consumer_release(src_pipe);
+    }
+    ++src_pipe;
+  }
+
+  template <typename WorkDesc>
+  CUTE_DEVICE void create_tensormap_for_tail(WorkDesc const& work_desc, uint32_t lane_predicate) {
+    namespace ptx = cuda::ptx;
+    constexpr int num_of_16B = sizeof(cute::TmaDescriptor) / sizeof(uint128_t);
+
+    cute::TmaDescriptor* tensormap = static_cast<cute::TmaDescriptor*>(tensormaps_) + smid();
+
+    auto lane_idx = cutlass::canonical_lane_idx();
+    if (lane_idx < num_of_16B) {
+      auto src = reinterpret_cast<uint128_t const*>(tma_store_.get_tma_descriptor());
+      auto dst = reinterpret_cast<uint128_t*>(tensormap);
+
+      dst[lane_idx] = src[lane_idx];
+    }
+    __syncwarp();
+
+    if (lane_predicate == 1) {
+      uint32_t new_total_seqlen = work_desc.tok_offset + work_desc.seq_len;
+      ptx::tensormap_replace_global_dim(ptx::space_global, tensormap, /*ord=*/ptx::n32_t<1>{}, new_total_seqlen);
+    }
+    __syncwarp();
+
+    ptx::fence_proxy_tensormap_generic(ptx::sem_release, ptx::scope_cta);
+  }
+
+  CUTE_DEVICE cute::TmaDescriptor* acquire_tensormap_for_tail() {
+    namespace ptx = cuda::ptx;
+    cute::TmaDescriptor* tensormap = static_cast<cute::TmaDescriptor*>(tensormaps_) + smid();
+    ptx::fence_proxy_tensormap_generic(ptx::sem_acquire, ptx::scope_cta, tensormap, /*size=*/ptx::n32_t<128>{});
+    return tensormap;
+  }
+
+ private:
+  TMA const& tma_store_;
+  Pipeline& pipeline_;
+  SharedStorage& storage_;
+  void* tensormaps_;
+};
+
+}  // namespace kda::sm90::collective

--- a/sgl-kernel/csrc/kda/sm90/device/device_universal.hpp
+++ b/sgl-kernel/csrc/kda/sm90/device/device_universal.hpp
@@ -1,0 +1,232 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// common
+#include <cutlass/cutlass.h>
+#include <cutlass/device_kernel.h>
+
+#if !defined(__CUDACC_RTC__)
+#include <cutlass/trace.h>
+
+#include <cutlass/cluster_launch.hpp>
+#endif  // !defined(__CUDACC_RTC__)
+
+namespace cutlass::device {
+
+template <class Kernel_>
+class Universal {
+ public:
+  using Kernel = Kernel_;
+
+  static int const kThreadCount = Kernel::MaxThreadsPerBlock;
+
+  /// Argument structure: User API
+  using Arguments = typename Kernel::Arguments;
+  /// Argument structure: Kernel API
+  using Params = typename Kernel::Params;
+
+ private:
+  /// Kernel API parameters object
+  Params params_;
+
+ public:
+  /// Access the Params structure
+  Params const& params() const {
+    return params_;
+  }
+
+  /// Determines whether the GEMM can execute the given problem.
+  static Status can_implement(Arguments const& args) {
+    if (Kernel::can_implement(args)) {
+      return Status::kSuccess;
+    } else {
+      return Status::kInvalid;
+    }
+  }
+
+  /// Gets the workspace size
+  static size_t get_workspace_size(Arguments const& args) {
+    size_t workspace_bytes = 0;
+    workspace_bytes += Kernel::get_workspace_size(args);
+    return workspace_bytes;
+  }
+
+  /// Computes the grid shape
+  static dim3 get_grid_shape(Params const& params) {
+    return Kernel::get_grid_shape(params);
+  }
+
+  /// Computes the maximum number of active blocks per multiprocessor
+  static int maximum_active_blocks(int /* smem_capacity */ = -1) {
+    CUTLASS_TRACE_HOST("Universal::maximum_active_blocks()");
+    int max_active_blocks = -1;
+    int smem_size = Kernel::SharedStorageSize;
+
+    // first, account for dynamic smem capacity if needed
+    cudaError_t result;
+    if (smem_size >= (48 << 10)) {
+      CUTLASS_TRACE_HOST("  Setting smem size to " << smem_size);
+      result = cudaFuncSetAttribute(device_kernel<Kernel>, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+      if (cudaSuccess != result) {
+        result = cudaGetLastError();  // to clear the error bit
+        CUTLASS_TRACE_HOST("  cudaFuncSetAttribute() returned error: " << cudaGetErrorString(result));
+        return -1;
+      }
+    }
+
+    // query occupancy after setting smem size
+    result = cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+        &max_active_blocks, device_kernel<Kernel>, Kernel::MaxThreadsPerBlock, smem_size);
+
+    if (cudaSuccess != result) {
+      result = cudaGetLastError();  // to clear the error bit
+      CUTLASS_TRACE_HOST(
+          "  cudaOccupancyMaxActiveBlocksPerMultiprocessor() returned error: " << cudaGetErrorString(result));
+      return -1;
+    }
+
+    CUTLASS_TRACE_HOST("  max_active_blocks: " << max_active_blocks);
+    return max_active_blocks;
+  }
+
+  /// Initializes GEMM state from arguments.
+  Status initialize(Arguments const& args, void* workspace = nullptr, cudaStream_t stream = nullptr) {
+    CUTLASS_TRACE_HOST(
+        "Universal::initialize() - workspace " << workspace << ", stream: " << (stream ? "non-null" : "null"));
+
+    // Initialize the workspace
+    Status status = Kernel::initialize_workspace(args, workspace, stream);
+    if (status != Status::kSuccess) {
+      return status;
+    }
+
+    // Initialize the Params structure
+    params_ = Kernel::to_underlying_arguments(args, workspace);
+
+    // account for dynamic smem capacity if needed
+    int smem_size = Kernel::SharedStorageSize;
+    if (smem_size >= (48 << 10)) {
+      CUTLASS_TRACE_HOST("  Setting smem size to " << smem_size);
+      cudaError_t result =
+          cudaFuncSetAttribute(device_kernel<Kernel>, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+      if (cudaSuccess != result) {
+        result = cudaGetLastError();  // to clear the error bit
+        CUTLASS_TRACE_HOST("  cudaFuncSetAttribute() returned error: " << cudaGetErrorString(result));
+        return Status::kErrorInternal;
+      }
+    }
+
+    return Status::kSuccess;
+  }
+
+  /// Update API is preserved in 3.0, but does not guarantee a lightweight update of params.
+  Status update(Arguments const& args, void* workspace = nullptr) {
+    CUTLASS_TRACE_HOST("Universal()::update() - workspace: " << workspace);
+
+    size_t workspace_bytes = get_workspace_size(args);
+    if (workspace_bytes > 0 && nullptr == workspace) {
+      return Status::kErrorWorkspaceNull;
+    }
+
+    params_ = Kernel::to_underlying_arguments(args, workspace);
+    return Status::kSuccess;
+  }
+
+  /// Primary run() entry point API that is static allowing users to create and manage their own params.
+  /// Supplied params struct must be construct by calling Kernel::to_underling_arguments()
+  static Status run(Params& params, cudaStream_t stream = nullptr) {
+    CUTLASS_TRACE_HOST("Universal::run()");
+    dim3 const block = Kernel::get_block_shape();
+    dim3 const grid = get_grid_shape(params);
+
+    // configure smem size and carveout
+    int smem_size = Kernel::SharedStorageSize;
+
+    Status launch_result;
+    // Use extended launch API only for mainloops that use it
+    if constexpr (Kernel::ArchTag::kMinComputeCapability >= 90) {
+      dim3 cluster(
+          cute::size<0>(typename Kernel::ClusterShape{}),
+          cute::size<1>(typename Kernel::ClusterShape{}),
+          cute::size<2>(typename Kernel::ClusterShape{}));
+      void const* kernel = (void const*)device_kernel<Kernel>;
+      void* kernel_params[] = {&params};
+      launch_result = ClusterLauncher::launch(grid, cluster, block, smem_size, stream, kernel, kernel_params);
+    } else {
+      launch_result = Status::kSuccess;
+      cutlass::arch::synclog_setup();
+      device_kernel<Kernel><<<grid, block, smem_size, stream>>>(params);
+    }
+
+    cudaError_t result = cudaGetLastError();
+    if (cudaSuccess == result && Status::kSuccess == launch_result) {
+      return Status::kSuccess;
+    } else {
+      CUTLASS_TRACE_HOST("  Kernel launch failed. Reason: " << result);
+      return Status::kErrorInternal;
+    }
+  }
+
+  //
+  // Non-static launch overloads that first create and set the internal params struct of this kernel handle.
+  //
+
+  /// Launches the kernel after first constructing Params internal state from supplied arguments.
+  Status run(Arguments const& args, void* workspace = nullptr, cudaStream_t stream = nullptr) {
+    Status status = initialize(args, workspace, stream);
+    if (Status::kSuccess == status) {
+      status = run(params_, stream);
+    }
+    return status;
+  }
+
+  /// Launches the kernel after first constructing Params internal state from supplied arguments.
+  Status operator()(Arguments const& args, void* workspace = nullptr, cudaStream_t stream = nullptr) {
+    return run(args, workspace, stream);
+  }
+
+  /// Overload that allows a user to re-launch the same kernel without updating internal params struct.
+  Status run(cudaStream_t stream = nullptr) {
+    return run(params_, stream);
+  }
+
+  /// Overload that allows a user to re-launch the same kernel without updating internal params struct.
+  Status operator()(cudaStream_t stream = nullptr) {
+    return run(params_, stream);
+  }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+}  // namespace cutlass::device
+
+////////////////////////////////////////////////////////////////////////////////

--- a/sgl-kernel/csrc/kda/sm90/kda_fwd_sm90.cu
+++ b/sgl-kernel/csrc/kda/sm90/kda_fwd_sm90.cu
@@ -1,0 +1,142 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Dispatch function only — does NOT include the .cuh to avoid
+// implicit instantiation of all kernel variants in one TU.
+// Each SafeGate variant is explicitly instantiated in its own .cu file.
+
+#include <cutlass/arch/arch.h>
+
+#include <cute/numeric/numeric_types.hpp>
+
+namespace kda::sm90 {
+
+using namespace cute;
+
+// Forward declaration of the per-variant launcher (defined in .cuh, instantiated in separate TUs)
+template <
+    bool NeedsBeta,
+    bool NeedsAlpha,
+    bool InitStateFromInput,
+    bool SafeGate,
+    typename ArchTag,
+    typename TO,
+    typename TQKV,
+    typename TState>
+void launch_kda_fwd_prefill_kernel_gbai(
+    cudaStream_t stream,
+    TO* output,
+    TState* output_state,
+    TQKV const* q,
+    TQKV const* k,
+    TQKV const* v,
+    TState const* input_state,
+    float const* alpha,
+    float const* beta,
+    int32_t const* cu_seqlens,
+    uint8_t* workspace_buffer,
+    int32_t num_seqs,
+    int32_t num_heads,
+    int32_t head_size,
+    int64_t total_seqlen,
+    float scale,
+    int32_t sm_count);
+
+template <
+    typename ArchTag,  // TODO: hide this
+    typename TO,
+    typename TQKV,
+    typename TState>
+void launch_kda_fwd_prefill_kernel(
+    cudaStream_t stream,
+    TO* output,
+    TState* output_state,
+    TQKV const* q,
+    TQKV const* k,
+    TQKV const* v,
+    TState const* input_state,
+    float const* alpha,
+    float const* beta,
+    int32_t const* cu_seqlens,
+    uint8_t* workspace_buffer,
+    int32_t num_seqs,
+    int32_t num_heads,
+    int32_t head_size,
+    int64_t total_seqlen,
+    float scale,
+    bool safe_gate,
+    int32_t sm_count = 0) {
+  bool needs_beta = beta != nullptr;
+  bool needs_alpha = alpha != nullptr;
+  bool init_state = input_state != nullptr;
+
+#define LAUNCH(needs_beta, needs_alpha, init_state, safe_gate)                                 \
+  launch_kda_fwd_prefill_kernel_gbai<needs_beta, needs_alpha, init_state, safe_gate, ArchTag>( \
+      stream,                                                                                  \
+      output,                                                                                  \
+      output_state,                                                                            \
+      q,                                                                                       \
+      k,                                                                                       \
+      v,                                                                                       \
+      input_state,                                                                             \
+      alpha,                                                                                   \
+      beta,                                                                                    \
+      cu_seqlens,                                                                              \
+      workspace_buffer,                                                                        \
+      num_seqs,                                                                                \
+      num_heads,                                                                               \
+      head_size,                                                                               \
+      total_seqlen,                                                                            \
+      scale,                                                                                   \
+      sm_count);
+  if (init_state) {
+    if (needs_beta && needs_alpha && safe_gate) {
+      LAUNCH(true, true, true, true);
+    } else {
+      throw std::runtime_error("unreachable");
+    }
+  } else {
+    if (needs_beta && needs_alpha && safe_gate) {
+      LAUNCH(true, true, false, true);
+    } else {
+      throw std::runtime_error("unreachable");
+    }
+  }
+
+#undef LAUNCH
+}
+
+using bf16 = cute::bfloat16_t;
+
+template void launch_kda_fwd_prefill_kernel<cutlass::arch::Sm90, bf16, bf16, float>(
+    cudaStream_t stream,
+    bf16* output,
+    float* state,
+    bf16 const* q,
+    bf16 const* k,
+    bf16 const* v,
+    float const* input_state,
+    float const* alpha,
+    float const* beta,
+    int32_t const* cu_seqlens,
+    uint8_t* workspace_buffer,
+    int32_t num_seqs,
+    int32_t num_heads,
+    int32_t head_size,
+    int64_t total_seqlen,
+    float scale,
+    bool safe_gate,
+    int32_t sm_count);
+
+}  // namespace kda::sm90

--- a/sgl-kernel/csrc/kda/sm90/kda_fwd_sm90_safe_gate.cu
+++ b/sgl-kernel/csrc/kda/sm90/kda_fwd_sm90_safe_gate.cu
@@ -1,0 +1,67 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cutlass/arch/arch.h>
+
+#include <cute/numeric/numeric_types.hpp>
+
+#include "kda/sm90/prefill_kernel_kda_fwd_sm90.cuh"
+#include "kda/sm90/utils/common.hpp"
+
+namespace kda::sm90 {
+
+using namespace cute;
+using bf16 = cute::bfloat16_t;
+
+// SafeGate=true, InitState=false
+template void launch_kda_fwd_prefill_kernel_gbai<true, true, false, true, cutlass::arch::Sm90, bf16, bf16, float>(
+    cudaStream_t,
+    bf16*,
+    float*,
+    bf16 const*,
+    bf16 const*,
+    bf16 const*,
+    float const*,
+    float const*,
+    float const*,
+    int32_t const*,
+    uint8_t*,
+    int32_t,
+    int32_t,
+    int32_t,
+    int64_t,
+    float,
+    int32_t);
+
+// SafeGate=true, InitState=true
+template void launch_kda_fwd_prefill_kernel_gbai<true, true, true, true, cutlass::arch::Sm90, bf16, bf16, float>(
+    cudaStream_t,
+    bf16*,
+    float*,
+    bf16 const*,
+    bf16 const*,
+    bf16 const*,
+    float const*,
+    float const*,
+    float const*,
+    int32_t const*,
+    uint8_t*,
+    int32_t,
+    int32_t,
+    int32_t,
+    int64_t,
+    float,
+    int32_t);
+
+}  // namespace kda::sm90

--- a/sgl-kernel/csrc/kda/sm90/kernel/builder_kda_fwd.hpp
+++ b/sgl-kernel/csrc/kda/sm90/kernel/builder_kda_fwd.hpp
@@ -1,0 +1,80 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "kda/sm90/collective/mainloop_kda_fwd.hpp"
+#include "kda/sm90/kernel/kernel_kda_fwd.hpp"
+#include "kda/sm90/kernel/options.hpp"
+#include "kda/sm90/kernel/tile_scheduler.hpp"
+#include "kda/sm90/utils/type_traits.hpp"
+
+namespace kda::sm90::kernel {
+
+template <
+    class Element_,
+    class ElementAccumulatorQK_,
+    class ElementAccumulatorPV_,
+    class TileShape_,  // BlkSeqQO, BlkSeqKV, HeadSize
+    class LayoutQ_,
+    class LayoutK_,
+    class LayoutV_,
+    class LayoutO_,
+    class DispatchPolicy,
+    class Options = DefaultOptions>
+struct FlatBuilderKdaFwd;
+
+template <
+    class Element,
+    class ElementAccumulatorQK,
+    class ElementAccumulatorPV,
+    class TileShape,  // BlkSeqQO, BlkSeqKV, HeadSize
+    class LayoutQ,
+    class LayoutK,
+    class LayoutV,
+    class LayoutO,
+    class Options>
+struct FlatBuilderKdaFwd<
+    Element,
+    ElementAccumulatorQK,
+    ElementAccumulatorPV,
+    TileShape,
+    LayoutQ,
+    LayoutK,
+    LayoutV,
+    LayoutO,
+    cutlass::gemm::KernelTmaWarpSpecializedCooperative,
+    Options> {
+  using CollectiveMainloop = kda::sm90::collective::FlatMainloopTmaWarpSpecializedKdaFwd<
+      Element,
+      ElementAccumulatorQK,
+      ElementAccumulatorPV,
+      TileShape,
+      LayoutQ,
+      LayoutK,
+      LayoutV,
+      LayoutO,
+      Options>;
+
+  static constexpr bool kIsPersistent = find_option_t<Tag::kIsPersistent, false_type, Options>::value;
+  static_assert(!kIsPersistent, "not implemented");
+
+  using TileScheduler = kda::sm90::kernel::IndividualTileScheduler;
+  // using TileScheduler = std::conditional_t<kIsPersistent, kda::sm90::kernel::PersistentTileScheduler,
+  // kda::sm90::kernel::IndividualTileScheduler>;
+
+  using Kernel = kda::sm90::kernel::FlatKernelTmaWarpSpecializedKdaFwd<CollectiveMainloop, TileScheduler, Options>;
+};
+
+}  // namespace kda::sm90::kernel

--- a/sgl-kernel/csrc/kda/sm90/kernel/kernel_kda_fwd.hpp
+++ b/sgl-kernel/csrc/kda/sm90/kernel/kernel_kda_fwd.hpp
@@ -1,0 +1,620 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cutlass/arch/arch.h>
+#include <cutlass/arch/reg_reconfig.h>
+#include <cutlass/cutlass.h>
+
+#include <cutlass/pipeline/pipeline.hpp>
+
+#include "kda/sm90/kernel/options.hpp"
+#include "kda/sm90/utils/common.hpp"
+#include "kda/sm90/utils/unused.hpp"
+
+namespace kda::sm90::kernel {
+
+using namespace cute;
+
+template <typename T1, typename T2>
+constexpr T1 round_down(T1 a, T2 b) {
+  return (a / b) * b;
+}
+
+constexpr std::tuple<uint32_t, uint32_t, uint32_t> get_register_requirements(
+    uint32_t max_threads_per_block,
+    uint32_t min_blocks_per_multiprocessor,
+    uint32_t num_state_mma_warp_groups  // state related mma
+) {
+  uint32_t reg_alloc_granularity = 8;
+
+#if !defined(FLAT_DEBUG_PRINT) || !FLAT_DEBUG_PRINT
+  uint32_t load_registers = 40 - 2 * reg_alloc_granularity;
+#else
+  uint32_t load_registers = 40;
+#endif
+  // TODO: better tuning
+  uint32_t total_aux_load_budget = 176;
+  uint32_t aux_registers = total_aux_load_budget - load_registers;  // (24 + X) or (40 + X)
+
+  uint32_t total_registers =
+      round_down(64 * 1024 / min_blocks_per_multiprocessor, max_threads_per_block * reg_alloc_granularity) /
+      cutlass::NumThreadsPerWarpGroup;
+  uint32_t mma_registers =
+      round_down((total_registers - load_registers - aux_registers) / num_state_mma_warp_groups, reg_alloc_granularity);
+
+  // max reg is 255, 248 round to multiple of reg_alloc_granularity;
+  return {cute::min(248, load_registers), cute::min(248, mma_registers), cute::min(248, aux_registers)};
+}
+
+template <class CollectiveMainloop, class TileScheduler, class Options>
+struct FlatKernelTmaWarpSpecializedKdaFwd {
+  using ArchTag = cutlass::arch::Sm90;
+
+  static const int NumLoadWarpGroups = 1;
+  static constexpr int NumStateMmaWarpGroups = CollectiveMainloop::NumStateMmaWarpGroups;
+  static constexpr int NumAuxMmaWarpGroups = CollectiveMainloop::NumAuxMmaWarpGroups;
+
+  static constexpr int NeedsAlpha = CollectiveMainloop::NeedsAlpha;
+  static constexpr int NeedsBeta = CollectiveMainloop::NeedsBeta;
+  static constexpr int SafeGate = CollectiveMainloop::SafeGate;
+
+  using TileShape = typename CollectiveMainloop::TileShape;
+  using ClusterShape = typename CollectiveMainloop::ClusterShape;
+
+  using MainloopQPipeline = typename CollectiveMainloop::MainloopQPipeline;
+  using MainloopKPipeline = typename CollectiveMainloop::MainloopKPipeline;
+  using MainloopVPipeline = typename CollectiveMainloop::MainloopVPipeline;
+  using MainloopOPipeline = typename CollectiveMainloop::MainloopOPipeline;
+
+  using MainloopQKPipeline = typename CollectiveMainloop::MainloopQKPipeline;
+  using MainloopKKPipeline = typename CollectiveMainloop::MainloopKKPipeline;
+
+  using MainloopAlphaLastPipeline = typename CollectiveMainloop::MainloopAlphaLastPipeline;
+
+  using MainloopAlphaPipeline = typename CollectiveMainloop::MainloopAlphaPipeline;
+  using MainloopBetaPipeline = typename CollectiveMainloop::MainloopBetaPipeline;
+
+  using OrderedMathBarriers = typename CollectiveMainloop::OrderedMathBarriers;
+
+  static constexpr uint32_t StagesPerMathWarpGroup = 2;
+
+  using MathWarpGroupOrderBarrier = cutlass::OrderedSequenceBarrier<StagesPerMathWarpGroup, NumStateMmaWarpGroups>;
+
+  struct TensorStorage {
+    typename CollectiveMainloop::SharedStorage mainloop;
+  };
+
+  struct SharedStorage {
+    TensorStorage tensors;
+
+    using QPipelineStorage = typename MainloopQPipeline::SharedStorage;
+    using KPipelineStorage = typename MainloopKPipeline::SharedStorage;
+    using VPipelineStorage = typename MainloopVPipeline::SharedStorage;
+    using OPipelineStorage = typename MainloopOPipeline::SharedStorage;
+
+    alignas(16) QPipelineStorage q_pipeline_storage;
+    alignas(16) KPipelineStorage k_pipeline_storage;
+    alignas(16) VPipelineStorage v_pipeline_storage;
+    alignas(16) OPipelineStorage o_pipeline_storage;
+
+    using QKPipelineStorage = typename MainloopQKPipeline::SharedStorage;
+    using KKPipelineStorage = typename MainloopKKPipeline::SharedStorage;
+
+    alignas(16) QKPipelineStorage qk_pipeline_storage;
+    alignas(16) KKPipelineStorage kk_pipeline_storage;
+
+    using AlphaLastPipelineStorage = typename MainloopAlphaLastPipeline::SharedStorage;
+
+    alignas(16) AlphaLastPipelineStorage alpha_last_pipeline_storage;
+
+    using AlphaPipelineStorage = typename MainloopAlphaPipeline::SharedStorage;
+    using BetaPipelineStorage = typename MainloopBetaPipeline::SharedStorage;
+    alignas(16) AlphaPipelineStorage alpha_pipeline_storage;
+    alignas(16) BetaPipelineStorage beta_pipeline_storage;
+
+    alignas(16) cutlass::arch::ClusterBarrier load_warp_barrier;
+  };
+
+  static constexpr int SharedStorageSize = sizeof(SharedStorage);
+
+  struct VarlenProblemShape {
+    int32_t const* cu_seqlens;
+    int64_t total_seqlen;
+    int32_t num_seqs;
+    int32_t num_heads;  // Q, K, V, O all share the same head count in KDA
+    int32_t head_size;  // d
+  };
+  using ProblemShape = VarlenProblemShape;
+
+  struct Arguments {
+    ProblemShape problem_size;
+    typename CollectiveMainloop::Arguments mainloop;
+    cutlass::KernelHardwareInfo hw_info;
+  };
+
+  struct Params {
+    ProblemShape problem_size;
+    typename CollectiveMainloop::Params mainloop;
+    typename TileScheduler::Params scheduler;
+  };
+
+  using QPipelineParams = typename MainloopQPipeline::Params;
+  using QPipelineState = typename cutlass::PipelineState<MainloopQPipeline::Stages>;
+
+  using KPipelineParams = typename MainloopKPipeline::Params;
+  using KPipelineState = typename cutlass::PipelineState<MainloopKPipeline::Stages>;
+
+  using VPipelineParams = typename MainloopVPipeline::Params;
+  using VPipelineState = typename cutlass::PipelineState<MainloopVPipeline::Stages>;
+
+  using OPipelineParams = typename MainloopOPipeline::Params;
+  using OPipelineState = typename cutlass::PipelineState<MainloopOPipeline::Stages>;
+
+  using QKPipelineParams = typename MainloopQKPipeline::Params;
+  using QKPipelineState = typename cutlass::PipelineState<MainloopQKPipeline::Stages>;
+
+  using KKPipelineParams = typename MainloopKKPipeline::Params;
+  using KKPipelineState = typename cutlass::PipelineState<MainloopKKPipeline::Stages>;
+
+  using AlphaLastPipelineParams = std::conditional_t<NeedsAlpha, typename MainloopAlphaLastPipeline::Params, Unused>;
+  using AlphaLastPipelineState =
+      std::conditional_t<NeedsAlpha, cutlass::PipelineState<MainloopAlphaLastPipeline::Stages>, Unused>;
+
+  using AlphaPipelineParams = std::conditional_t<NeedsAlpha, typename MainloopAlphaPipeline::Params, Unused>;
+  using AlphaPipelineState =
+      std::conditional_t<NeedsAlpha, cutlass::PipelineState<MainloopAlphaPipeline::Stages>, Unused>;
+
+  using BetaPipelineParams = std::conditional_t<NeedsBeta, typename MainloopBetaPipeline::Params, Unused>;
+  using BetaPipelineState = std::conditional_t<NeedsBeta, cutlass::PipelineState<MainloopBetaPipeline::Stages>, Unused>;
+
+  static constexpr int MinBlocksPerMultiprocessor = 1;
+  static constexpr int MaxThreadsPerBlock =
+      (NumLoadWarpGroups + NumStateMmaWarpGroups + NumAuxMmaWarpGroups) * cutlass::NumThreadsPerWarpGroup;
+
+  static constexpr auto RegisterRequirements =
+      get_register_requirements(MaxThreadsPerBlock, MinBlocksPerMultiprocessor, NumStateMmaWarpGroups);
+  static constexpr uint32_t LdStRegisterRequirement = get<0>(RegisterRequirements);
+  static constexpr uint32_t StateMmaRegisterRequirement = get<1>(RegisterRequirements);
+  static constexpr uint32_t AuxMmaRegisterRequirement = get<2>(RegisterRequirements);
+
+  static size_t get_workspace_size(Arguments const& args) {
+    return CollectiveMainloop::get_workspace_size(args.mainloop, args.hw_info.sm_count);
+  }
+
+  static cutlass::Status initialize_workspace(Arguments const& args, void* workspace, cudaStream_t stream) {
+    return CollectiveMainloop::initialize_workspace(args.problem_size, args.mainloop, workspace, stream);
+  }
+
+  static bool can_implement(Arguments const& args) {
+    return CollectiveMainloop::can_implement(args.problem_size, args.mainloop);
+  }
+
+  static dim3 get_grid_shape(Params const& params) {
+    return TileScheduler::get_grid_shape(params.scheduler);
+  }
+
+  static dim3 get_block_shape() {
+    dim3 block(MaxThreadsPerBlock, 1, 1);
+    return block;
+  }
+
+  static Params to_underlying_arguments(Arguments const& args, void* workspace) {
+    return Params{
+        args.problem_size,
+        CollectiveMainloop::to_underlying_arguments(args.problem_size, args.mainloop, workspace),
+        TileScheduler::to_underlying_arguments(args.problem_size, args.hw_info, ClusterShape{}, TileShape{})};
+  }
+
+  CUTE_DEVICE void operator()(const Params& params, char* smem) {
+    enum class WarpGroupRole {
+      LdSt = 0,
+      Math0 = 1,
+      Math1 = 2,
+      MathA = 3,  // auxiliary math WG
+    };
+
+    // NOTE: CollectiveInverse will have more utilization on warp 0&1
+    //       so we put beta and alpha preprocessing on warp 2&3
+    enum class LdStWarpRole {
+      LoadQKV = 0,
+      StoreO = 1,
+      LoadBeta = 2,
+      LoadAlpha = 3,
+    };
+
+    TileScheduler scheduler{params.scheduler};
+
+    // Shared memory.
+    auto& storage = *reinterpret_cast<SharedStorage*>(smem);
+
+    int lane_idx = cutlass::canonical_lane_idx();
+    int warp_idx = cutlass::canonical_warp_idx_sync();
+    int warp_idx_in_wg = warp_idx % cutlass::NumWarpsPerWarpGroup;
+    int warp_group_idx = cutlass::canonical_warp_group_idx();
+    auto warp_group_role = WarpGroupRole(warp_group_idx);
+    auto ldst_warp_role = LdStWarpRole(warp_idx_in_wg);
+
+    int lane_predicate = cute::elect_one_sync();
+    uint32_t block_rank_in_cluster = cute::block_rank_in_cluster();
+
+    // Issue Tma Descriptor Prefetch from a single thread
+    if ((warp_idx == 0) && lane_predicate) {
+      CollectiveMainloop::prefetch_tma_descriptors(params.mainloop);
+    }
+
+    constexpr int NumStateMathThreads = NumStateMmaWarpGroups * cutlass::NumThreadsPerWarpGroup;
+    constexpr int NumAuxMathThreads = NumAuxMmaWarpGroups * cutlass::NumThreadsPerWarpGroup;
+
+    QPipelineParams q_pipeline_params;
+    q_pipeline_params.transaction_bytes = CollectiveMainloop::LoadQBytes;
+    q_pipeline_params.is_leader = lane_predicate && (ldst_warp_role == LdStWarpRole::LoadQKV);
+    q_pipeline_params.num_consumers = NumStateMathThreads + NumAuxMathThreads;
+
+    KPipelineParams k_pipeline_params;
+    k_pipeline_params.transaction_bytes = CollectiveMainloop::LoadKBytes;
+    k_pipeline_params.is_leader = lane_predicate && (ldst_warp_role == LdStWarpRole::LoadQKV);
+    k_pipeline_params.num_consumers = NumStateMathThreads + NumAuxMathThreads;
+
+    VPipelineParams v_pipeline_params;
+    v_pipeline_params.transaction_bytes = CollectiveMainloop::LoadVBytes;
+    v_pipeline_params.is_leader = lane_predicate && (ldst_warp_role == LdStWarpRole::LoadQKV);
+    v_pipeline_params.num_consumers = NumStateMathThreads;
+
+    AlphaPipelineParams alpha_pipeline_params;
+    if constexpr (NeedsAlpha) {
+      alpha_pipeline_params.transaction_bytes = CollectiveMainloop::LoadAlphaBytes;
+      alpha_pipeline_params.is_leader = lane_predicate && (ldst_warp_role == LdStWarpRole::LoadQKV);
+      alpha_pipeline_params.num_consumers = NumStateMathThreads + NumAuxMathThreads + cutlass::NumThreadsPerWarp;
+    }
+
+    OPipelineParams o_pipeline_params;
+    o_pipeline_params.producer_arv_count = NumStateMathThreads;
+    o_pipeline_params.consumer_arv_count = cutlass::NumThreadsPerWarp;
+
+    QKPipelineParams qk_pipeline_params;
+    qk_pipeline_params.producer_arv_count = NumAuxMathThreads;
+    qk_pipeline_params.consumer_arv_count = NumStateMathThreads;
+
+    KKPipelineParams kk_pipeline_params;
+    kk_pipeline_params.producer_arv_count = NumAuxMathThreads;
+    kk_pipeline_params.consumer_arv_count = NumStateMathThreads;
+
+    AlphaLastPipelineParams alpha_last_pipeline_params;
+    if constexpr (NeedsAlpha) {
+      alpha_last_pipeline_params.producer_arv_count = cutlass::NumThreadsPerWarp;
+      alpha_last_pipeline_params.consumer_arv_count = NumStateMathThreads;
+    }
+
+    BetaPipelineParams beta_pipeline_params;
+    if constexpr (NeedsBeta) {
+      beta_pipeline_params.producer_arv_count = cutlass::NumThreadsPerWarp;
+      beta_pipeline_params.consumer_arv_count = NumAuxMathThreads + NumStateMathThreads;
+    }
+
+    OrderedMathBarriers math_barriers;
+
+    if (warp_group_role == WarpGroupRole::LdSt && ldst_warp_role == LdStWarpRole::LoadQKV) {
+      DPRINTF0_W("ldst_warp_role: LoadQKV Alpha\n");
+      q_pipeline_params.role = MainloopQPipeline::ThreadCategory::Producer;
+      k_pipeline_params.role = MainloopKPipeline::ThreadCategory::Producer;
+      v_pipeline_params.role = MainloopVPipeline::ThreadCategory::Producer;
+      if constexpr (NeedsAlpha) {
+        alpha_pipeline_params.role = MainloopAlphaPipeline::ThreadCategory::Producer;
+      }
+    }
+    if (warp_group_role == WarpGroupRole::LdSt && ldst_warp_role == LdStWarpRole::StoreO) {
+      DPRINTF0_W("ldst_warp_role: StoreO\n");
+      o_pipeline_params.role = MainloopOPipeline::ThreadCategory::Consumer;
+    }
+    if (warp_group_role == WarpGroupRole::LdSt && ldst_warp_role == LdStWarpRole::LoadBeta) {
+      if constexpr (NeedsBeta) {
+        beta_pipeline_params.role = MainloopBetaPipeline::ThreadCategory::Producer;
+      }
+    }
+    if (warp_group_role == WarpGroupRole::LdSt && ldst_warp_role == LdStWarpRole::LoadAlpha) {
+      // LoadAlpha warp consumes alpha_pipeline (reads last row) and produces alpha_last_pipeline
+      if constexpr (NeedsAlpha) {
+        alpha_pipeline_params.role = MainloopAlphaPipeline::ThreadCategory::Consumer;
+      }
+      alpha_last_pipeline_params.role = MainloopAlphaLastPipeline::ThreadCategory::Producer;
+    }
+    if (warp_group_role == WarpGroupRole::Math0 || warp_group_role == WarpGroupRole::Math1) {
+      DPRINTF0_WG("warp_group_role: MathX\n");
+      q_pipeline_params.role = MainloopQPipeline::ThreadCategory::Consumer;
+      k_pipeline_params.role = MainloopKPipeline::ThreadCategory::Consumer;
+      v_pipeline_params.role = MainloopVPipeline::ThreadCategory::Consumer;
+      o_pipeline_params.role = MainloopOPipeline::ThreadCategory::Producer;
+
+      qk_pipeline_params.role = MainloopQKPipeline::ThreadCategory::Consumer;
+      kk_pipeline_params.role = MainloopKKPipeline::ThreadCategory::Consumer;
+
+      if constexpr (NeedsAlpha) {
+        alpha_pipeline_params.role = MainloopAlphaPipeline::ThreadCategory::Consumer;
+        alpha_last_pipeline_params.role = MainloopAlphaLastPipeline::ThreadCategory::Consumer;
+      }
+      if constexpr (NeedsBeta) {
+        beta_pipeline_params.role = MainloopBetaPipeline::ThreadCategory::Consumer;
+      }
+
+      math_barriers.init(warp_group_idx - 1);
+    }
+    if (warp_group_role == WarpGroupRole::MathA) {
+      DPRINTF0_WG("warp_group_role: MathA\n");
+      q_pipeline_params.role = MainloopQPipeline::ThreadCategory::Consumer;
+      k_pipeline_params.role = MainloopKPipeline::ThreadCategory::Consumer;
+
+      qk_pipeline_params.role = MainloopQKPipeline::ThreadCategory::Producer;
+      kk_pipeline_params.role = MainloopKKPipeline::ThreadCategory::Producer;
+
+      if constexpr (NeedsAlpha) {
+        alpha_pipeline_params.role = MainloopAlphaPipeline::ThreadCategory::Consumer;
+      }
+      if constexpr (NeedsBeta) {
+        beta_pipeline_params.role = MainloopBetaPipeline::ThreadCategory::Consumer;
+      }
+    }
+
+    MainloopQPipeline q_pipeline(storage.q_pipeline_storage, q_pipeline_params, ClusterShape{});
+    MainloopKPipeline k_pipeline(storage.k_pipeline_storage, k_pipeline_params, ClusterShape{});
+    MainloopVPipeline v_pipeline(storage.v_pipeline_storage, v_pipeline_params, ClusterShape{});
+    MainloopAlphaPipeline alpha_pipeline(storage.alpha_pipeline_storage, alpha_pipeline_params, ClusterShape{});
+    MainloopOPipeline o_pipeline(storage.o_pipeline_storage, o_pipeline_params, /*InitBarriers=*/cute::true_type{});
+
+    MainloopAlphaLastPipeline alpha_last_pipeline(
+        storage.alpha_last_pipeline_storage,
+        alpha_last_pipeline_params,
+        /*InitBarriers=*/cute::true_type{});
+
+    MainloopQKPipeline qk_pipeline(
+        storage.qk_pipeline_storage,
+        qk_pipeline_params,
+        /*InitBarriers=*/cute::true_type{});
+    MainloopKKPipeline kk_pipeline(
+        storage.kk_pipeline_storage,
+        kk_pipeline_params,
+        /*InitBarriers=*/cute::true_type{});
+
+    // MainloopAlphaPipeline alpha_pipeline(storage.alpha_pipeline_storage, alpha_pipeline_params,
+    // /*InitBarriers=*/cute::true_type{});
+    MainloopBetaPipeline beta_pipeline(
+        storage.beta_pipeline_storage,
+        beta_pipeline_params,
+        /*InitBarriers=*/cute::true_type{});
+
+    QPipelineState q_smem_pipe_read;
+    QPipelineState q_smem_pipe_write = cutlass::make_producer_start_state<MainloopQPipeline>();
+    KPipelineState k_smem_pipe_read;
+    KPipelineState k_smem_pipe_write = cutlass::make_producer_start_state<MainloopKPipeline>();
+    VPipelineState v_smem_pipe_read;
+    VPipelineState v_smem_pipe_write = cutlass::make_producer_start_state<MainloopVPipeline>();
+    OPipelineState o_smem_pipe_read;
+    OPipelineState o_smem_pipe_write = cutlass::make_producer_start_state<MainloopOPipeline>();
+
+    AlphaLastPipelineState alpha_last_smem_pipe_read;
+    AlphaLastPipelineState alpha_last_smem_pipe_write;
+    if constexpr (NeedsAlpha) {
+      alpha_last_smem_pipe_write = cutlass::make_producer_start_state<MainloopAlphaLastPipeline>();
+    }
+
+    QKPipelineState qk_smem_pipe_read;
+    QKPipelineState qk_smem_pipe_write = cutlass::make_producer_start_state<MainloopQKPipeline>();
+    KKPipelineState kk_smem_pipe_read;
+    KKPipelineState kk_smem_pipe_write = cutlass::make_producer_start_state<MainloopKKPipeline>();
+
+    AlphaPipelineState alpha_smem_pipe_read;
+    AlphaPipelineState alpha_smem_pipe_write;
+    if constexpr (NeedsAlpha) {
+      alpha_smem_pipe_write = cutlass::make_producer_start_state<MainloopAlphaPipeline>();
+    }
+    BetaPipelineState beta_smem_pipe_read;
+    BetaPipelineState beta_smem_pipe_write;
+    if constexpr (NeedsBeta) {
+      beta_smem_pipe_write = cutlass::make_producer_start_state<MainloopBetaPipeline>();
+    }
+
+    // barrier sm or cluster level for initialization
+    if constexpr (size(ClusterShape{}) > 1) {
+      cute::cluster_arrive_relaxed();
+      cute::cluster_wait();
+    } else {
+      __syncthreads();
+    }
+    DPRINTF0_WG("warpspecialized grid initialized\n");
+
+    CollectiveMainloop collective_mainloop;
+
+    if (warp_group_role == WarpGroupRole::LdSt) {
+      DPRINTF0_WG("LsSt warp_group_idx:%d, RegisterRequirement:%d\n", warp_group_idx, LdStRegisterRequirement);
+      cutlass::arch::warpgroup_reg_dealloc<LdStRegisterRequirement>();
+      if (ldst_warp_role == LdStWarpRole::LoadQKV) {
+        auto work_desc = scheduler.get_next_work(params.scheduler, params.problem_size);
+        CUTE_NO_UNROLL
+        for (; work_desc.is_valid(params.scheduler);
+             work_desc = scheduler.get_next_work(params.scheduler, params.problem_size)) {
+          DPRINTF0_WG(
+              "LsSt working on LoadQ/K/V, seq_idx:%d, q/k/v_head_idx:(%d,%d,%d), seq_len:%lld)\n",
+              work_desc.seq_idx,
+              work_desc.q_head_idx(),
+              work_desc.k_head_idx(),
+              work_desc.v_head_idx(),
+              work_desc.seq_len);
+          auto tile_shape = typename CollectiveMainloop::TileShape{};
+          collective_mainloop.load_qkv(
+              params.mainloop,
+              params.problem_size,
+              tile_shape,
+              work_desc,
+              q_pipeline,
+              q_smem_pipe_write,
+              k_pipeline,
+              k_smem_pipe_write,
+              v_pipeline,
+              v_smem_pipe_write,
+              alpha_pipeline,
+              alpha_smem_pipe_write,
+              storage.tensors.mainloop);
+        }
+      } else if (ldst_warp_role == LdStWarpRole::LoadBeta) {
+        if constexpr (NeedsBeta) {
+          auto work_desc = scheduler.get_next_work(params.scheduler, params.problem_size);
+          CUTE_NO_UNROLL
+          for (; work_desc.is_valid(params.scheduler);
+               work_desc = scheduler.get_next_work(params.scheduler, params.problem_size)) {
+            DPRINTF0_WG(
+                "LsSt working on LoadBeta, seq_idx:%d, sab_head_idx:%d, seq_len:%lld)\n",
+                work_desc.seq_idx,
+                work_desc.o_head_idx(),
+                work_desc.seq_len);
+            auto tile_shape = typename CollectiveMainloop::TileShape{};
+            collective_mainloop.load_beta(
+                params.mainloop,
+                params.problem_size,
+                tile_shape,
+                work_desc,
+                beta_pipeline,
+                beta_smem_pipe_write,
+                storage.tensors.mainloop);
+          }
+        }
+      } else if (ldst_warp_role == LdStWarpRole::LoadAlpha) {
+        // produce the last row of Alpha
+        if constexpr (NeedsAlpha) {
+          auto work_desc = scheduler.get_next_work(params.scheduler, params.problem_size);
+          CUTE_NO_UNROLL
+          for (; work_desc.is_valid(params.scheduler);
+               work_desc = scheduler.get_next_work(params.scheduler, params.problem_size)) {
+            DPRINTF0_WG(
+                "LsSt working on LoadAlpha+ExtractLast, seq_idx:%d, sab_head_idx:%d, seq_len:%lld)\n",
+                work_desc.seq_idx,
+                work_desc.o_head_idx(),
+                work_desc.seq_len);
+            auto tile_shape = typename CollectiveMainloop::TileShape{};
+            collective_mainloop.extract_alpha_last(
+                params.mainloop,
+                params.problem_size,
+                tile_shape,
+                work_desc,
+                alpha_pipeline,
+                alpha_smem_pipe_read,
+                alpha_last_pipeline,
+                alpha_last_smem_pipe_write,
+                storage.tensors.mainloop);
+          }
+        }
+      } else if (ldst_warp_role == LdStWarpRole::StoreO) {
+        auto work_desc = scheduler.get_next_work(params.scheduler, params.problem_size);
+        DPRINTF0_WG(
+            "LsSt working on StoreO, seq_idx:%d, o_head_idx:%d, seq_len:%lld)\n",
+            work_desc.seq_idx,
+            work_desc.o_head_idx(),
+            work_desc.seq_len);
+        auto tile_shape = typename CollectiveMainloop::TileShape{};
+        collective_mainloop.store(
+            params.mainloop.tma_store_o,
+            params.mainloop.tensormaps,
+            params.problem_size,
+            tile_shape,
+            work_desc,
+            o_pipeline,
+            o_smem_pipe_read,
+            storage.tensors.mainloop.smem_o);
+      }
+    } else if (warp_group_role == WarpGroupRole::Math0 || warp_group_role == WarpGroupRole::Math1) {
+      DPRINTF0_WG(
+          "Compute[state]: warp_group_idx:%d, RegisterRequirement:%d\n", warp_group_idx, StateMmaRegisterRequirement);
+      cutlass::arch::warpgroup_reg_alloc<StateMmaRegisterRequirement>();
+      auto work_desc = scheduler.get_next_work(params.scheduler, params.problem_size);
+      CUTE_NO_UNROLL
+      for (; work_desc.is_valid(params.scheduler);
+           work_desc = scheduler.get_next_work(params.scheduler, params.problem_size)) {
+        DPRINTF0_WG(
+            "Compute[state]: seq_idx:%d, qk/v/o_head_idx:(%d,%d,%d,%d), seq_len:%lld)\n",
+            work_desc.seq_idx,
+            work_desc.q_head_idx(),
+            work_desc.k_head_idx(),
+            work_desc.v_head_idx(),
+            work_desc.o_head_idx(),
+            work_desc.seq_len);
+        collective_mainloop.compute(
+            params.mainloop,
+            params.problem_size,
+            work_desc,
+            q_pipeline,
+            q_smem_pipe_read,
+            k_pipeline,
+            k_smem_pipe_read,
+            v_pipeline,
+            v_smem_pipe_read,
+            o_pipeline,
+            o_smem_pipe_write,
+            qk_pipeline,
+            qk_smem_pipe_read,
+            kk_pipeline,
+            kk_smem_pipe_read,
+            alpha_pipeline,
+            alpha_smem_pipe_read,
+            beta_pipeline,
+            beta_smem_pipe_read,
+            alpha_last_pipeline,
+            alpha_last_smem_pipe_read,
+            math_barriers,
+            storage.tensors.mainloop);
+      }
+    } else if (warp_group_role == WarpGroupRole::MathA) {
+      DPRINTF0_WG(
+          "Compute[aux]: warp_group_idx:%d, RegisterRequirement:%d\n", warp_group_idx, AuxMmaRegisterRequirement);
+      cutlass::arch::warpgroup_reg_alloc<AuxMmaRegisterRequirement>();
+      auto work_desc = scheduler.get_next_work(params.scheduler, params.problem_size);
+      CUTE_NO_UNROLL
+      for (; work_desc.is_valid(params.scheduler);
+           work_desc = scheduler.get_next_work(params.scheduler, params.problem_size)) {
+        DPRINTF0_WG(
+            "Compute[aux]: seq_idx:%d, qk/v/o_head_idx:(%d,%d,%d,%d), seq_len:%lld)\n",
+            work_desc.seq_idx,
+            work_desc.q_head_idx(),
+            work_desc.k_head_idx(),
+            work_desc.v_head_idx(),
+            work_desc.o_head_idx(),
+            work_desc.seq_len);
+        collective_mainloop.compute_aux_safe(
+            params.mainloop,
+            params.problem_size,
+            work_desc,
+            q_pipeline,
+            q_smem_pipe_read,
+            k_pipeline,
+            k_smem_pipe_read,
+            qk_pipeline,
+            qk_smem_pipe_write,
+            kk_pipeline,
+            kk_smem_pipe_write,
+            alpha_pipeline,
+            alpha_smem_pipe_read,
+            beta_pipeline,
+            beta_smem_pipe_read,
+            alpha_last_pipeline,
+            alpha_last_smem_pipe_write,
+            storage.tensors.mainloop);
+      }
+    } else {
+      DPRINTF0_WG("Unknown warp role, warp_group_idx:%d\n", warp_group_idx);
+    }
+
+    __syncthreads();
+  }
+};
+
+}  // namespace kda::sm90::kernel

--- a/sgl-kernel/csrc/kda/sm90/kernel/options.hpp
+++ b/sgl-kernel/csrc/kda/sm90/kernel/options.hpp
@@ -1,0 +1,85 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cutlass/cutlass.h>
+
+#include <tuple>
+
+namespace kda::sm90::kernel {
+
+template <auto kTag, class Value>
+struct Option {
+  static constexpr auto tag = kTag;
+  using option_value = Value;
+};
+
+using DefaultOptions = std::tuple<>;
+
+namespace detail {
+
+template <auto kTag, typename Default, typename... Options>
+struct find_option_impl;
+
+template <auto kTag, typename Default>
+struct find_option_impl<kTag, Default> {
+  using option_value = Default;
+};
+
+template <auto kTag, typename Default>
+struct find_option_impl<kTag, Default, void> : find_option_impl<kTag, Default> {};
+
+template <auto kTag, typename Default, typename Option, typename... Options>
+struct find_option_impl<kTag, Default, Option, Options...>
+    : std::conditional_t<Option::tag == kTag, Option, find_option_impl<kTag, Default, Options...>> {};
+
+template <auto kTag, typename Default, typename... Options>
+struct find_option_impl<kTag, Default, std::tuple<Options...>> : find_option_impl<kTag, Default, Options...> {};
+
+template <typename NewOption, typename... Options>
+struct add_option_impl;
+
+template <typename NewOption, typename... Options>
+struct add_option_impl<NewOption, std::tuple<Options...>> {
+  using options = std::tuple<Options..., NewOption>;
+};
+
+}  // namespace detail
+
+template <auto kTag, typename Default, typename... Options>
+using find_option_t = typename detail::find_option_impl<kTag, Default, std::tuple<Options...>>::option_value;
+
+template <auto kTag, typename Value, typename... Options>
+using add_option_t = typename detail::add_option_impl<Option<kTag, Value>, std::tuple<Options...>>::options;
+
+template <auto kTag, typename Value, typename... Options>
+constexpr auto add_option(Option<kTag, Value> new_option, std::tuple<Options...> options_tuple) {
+  return add_option_t<kTag, Value, Options...>();
+}
+
+enum class Tag {
+  kIsDeltaRule,
+  kIsPersistent,
+  kNumMmaWarpGroups,
+  kStagesQ,
+  kStagesK,
+  kStagesV,
+  kNeedsAlpha,          // gated delta rule
+  kNeedsBeta,           // delta rule
+  kInitStateFromInput,  // if true, initialize state by reading global memory instead of zero initialization.
+  kSafeGate,            // KDA
+};
+
+}  // namespace kda::sm90::kernel

--- a/sgl-kernel/csrc/kda/sm90/kernel/tile_scheduler.hpp
+++ b/sgl-kernel/csrc/kda/sm90/kernel/tile_scheduler.hpp
@@ -1,0 +1,129 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cutlass/cutlass.h>
+#include <cutlass/fast_math.h>
+#include <cutlass/kernel_hardware_info.h>
+
+namespace kda::sm90::kernel {
+
+using namespace cute;
+
+struct WorkDesc {
+  // coord
+  int32_t seq_idx;
+  int32_t head_idx;
+  int64_t tok_offset;  // offset to the start of the start
+
+  // shape
+  int64_t seq_len;
+
+  // update by mainloop
+  int32_t tile_idx = 0;
+
+  template <typename Params>
+  CUTE_DEVICE bool is_valid(Params const& params) {
+    return seq_idx >= 0 && seq_idx < params.num_seqs;
+  }
+
+  CUTE_DEVICE int32_t q_head_idx() const {
+    return head_idx;
+  }
+  CUTE_DEVICE int32_t k_head_idx() const {
+    return head_idx;
+  }
+  CUTE_DEVICE int32_t v_head_idx() const {
+    return head_idx;
+  }
+  CUTE_DEVICE int32_t o_head_idx() const {
+    return head_idx;
+  }
+
+  // compatible interface, for work without ChunkWiseParallel, chunk_len equals to seq_len
+  CUTE_DEVICE int32_t chunk_len() const {
+    return seq_len;
+  }
+};
+
+struct IndividualTileScheduler {
+  struct Params {
+    dim3 grid;
+    int32_t num_seqs;
+    int32_t num_heads;
+  };
+
+  bool scheduled = false;  // a once flag
+
+  CUTE_DEVICE
+  IndividualTileScheduler(Params const& params) {}
+
+  template <typename ProblemSize, typename ClusterShape, typename TileShape>
+  static Params to_underlying_arguments(
+      ProblemSize const& problem_size,
+      cutlass::KernelHardwareInfo const& hw_info,
+      ClusterShape const& cluster_shape,
+      TileShape const& tile_shape) {
+    dim3 grid(0, 1, 1);
+    grid.x = problem_size.num_seqs * problem_size.num_heads;
+    DPRINTF(
+        "to_underlying_arguments: grid:{.x:%d, .y:%d, .z:%d}, num_seqs:%d, num_heads:%d\n",
+        grid.x,
+        grid.y,
+        grid.z,
+        problem_size.num_seqs,
+        problem_size.num_heads);
+    return {
+        .grid = grid,
+        .num_seqs = problem_size.num_seqs,
+        .num_heads = problem_size.num_heads,
+    };
+  }
+
+  static dim3 get_grid_shape(Params const& params) {
+    return params.grid;
+  }
+
+  template <typename ProblemSize>
+  CUTE_DEVICE WorkDesc get_next_work(Params params, ProblemSize const& problem_size) {
+    int32_t seq_idx = blockIdx.x / params.num_heads;
+    int32_t head_idx = blockIdx.x % params.num_heads;
+
+    int32_t s = problem_size.cu_seqlens[seq_idx];
+    int32_t e = problem_size.cu_seqlens[seq_idx + 1];
+    int32_t seq_len = e - s;
+
+    if (scheduled) {
+      seq_idx = -1;
+    } else {
+      scheduled = true;
+      DPRINTF0_W(
+          "get_next_work: this_work={seq_idx:%d head_idx:%d tok_offset:%lld seq_len:%lld}\n",
+          seq_idx,
+          head_idx,
+          s,
+          seq_len);
+    }
+
+    return {
+        .seq_idx = seq_idx,
+        .head_idx = head_idx,
+        .tok_offset = s,
+        .seq_len = seq_len,
+    };
+  }
+};
+
+}  // namespace kda::sm90::kernel

--- a/sgl-kernel/csrc/kda/sm90/prefill_kernel.hpp
+++ b/sgl-kernel/csrc/kda/sm90/prefill_kernel.hpp
@@ -1,0 +1,48 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cuda_runtime_api.h>
+
+#include <cstdint>
+
+namespace kda::sm90 {
+
+template <
+    typename ArchTag,  // TODO: hide this
+    typename TO,
+    typename TQKV,
+    typename TState>
+void launch_kda_fwd_prefill_kernel(
+    cudaStream_t stream,
+    TO* output,
+    TState* output_state,
+    TQKV const* q,
+    TQKV const* k,
+    TQKV const* v,
+    TState const* input_state,
+    float const* alpha,
+    float const* beta,
+    int32_t const* cu_seqlens,
+    uint8_t* workspace_buffer,
+    int32_t num_seqs,
+    int32_t num_heads,
+    int32_t head_size,
+    int64_t total_seqlen,
+    float scale,
+    bool safe_gate,
+    int32_t sm_count = 0);
+
+}  // namespace kda::sm90

--- a/sgl-kernel/csrc/kda/sm90/prefill_kernel_kda_fwd_sm90.cuh
+++ b/sgl-kernel/csrc/kda/sm90/prefill_kernel_kda_fwd_sm90.cuh
@@ -1,0 +1,154 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cutlass/cutlass.h>
+#include <cutlass/kernel_hardware_info.h>
+#include <cutlass/util/device_memory.h>
+
+#include <cstdio>
+#include <cute/tensor.hpp>
+
+#include "kda/sm90/device/device_universal.hpp"
+#include "kda/sm90/kernel/builder_kda_fwd.hpp"
+#include "kda/sm90/utils/common.hpp"
+
+namespace kda::sm90 {
+
+using namespace cute;
+
+template <
+    bool NeedsBeta,
+    bool NeedsAlpha,
+    bool InitStateFromInput,
+    bool SafeGate,
+    typename ArchTag,
+    typename TO,
+    typename TQKV,
+    typename TState>
+void launch_kda_fwd_prefill_kernel_gbai(
+    cudaStream_t stream,
+    TO* output,
+    TState* output_state,
+    TQKV const* q,
+    TQKV const* k,
+    TQKV const* v,
+    TState const* input_state,
+    float const* alpha,
+    float const* beta,
+    int32_t const* cu_seqlens,
+    uint8_t* workspace_buffer,
+    int32_t num_seqs,
+    int32_t num_heads,
+    int32_t head_size,
+    int64_t total_seqlen,
+    float scale,
+    int32_t sm_count) {
+#if defined(SGL_KDA_SM90A_ENABLED)
+  constexpr bool HopperSupported = true;
+#else
+  constexpr bool HopperSupported = false;
+#endif
+
+  if constexpr (HopperSupported) {
+    static_assert(std::is_same_v<TQKV, TO>);
+
+    using namespace kda::sm90::kernel;
+    using T = map_to_cutlass_t<TQKV>;
+
+    cutlass::KernelHardwareInfo hw_info;
+    hw_info.sm_count = sm_count;
+
+    using SafeGateType = std::conditional_t<SafeGate, cute::true_type, cute::false_type>;
+    using NeedsBetaType = std::conditional_t<NeedsBeta, cute::true_type, cute::false_type>;
+    using NeedsAlphaType = std::conditional_t<NeedsAlpha, cute::true_type, cute::false_type>;
+    using InitStateType = std::conditional_t<InitStateFromInput, cute::true_type, cute::false_type>;
+    using Options = decltype(add_option(
+        Option<Tag::kSafeGate, SafeGateType>{},
+        add_option(
+            Option<Tag::kInitStateFromInput, InitStateType>{},
+            add_option(
+                Option<Tag::kNeedsAlpha, NeedsAlphaType>{},
+                add_option(
+                    Option<Tag::kNeedsBeta, NeedsBetaType>{},
+                    add_option(Option<Tag::kIsDeltaRule, cute::true_type>{}, DefaultOptions{}))))));
+
+    using TileShape = Shape<_64, _64, _128>;
+    using Scheduler = cutlass::gemm::KernelTmaWarpSpecializedCooperative;
+    using Operation = cutlass::device::Universal<typename kda::sm90::kernel::FlatBuilderKdaFwd<
+        T,
+        float,
+        float,
+        TileShape,
+        /*LayoutQ=*/cute::tuple<int64_t, _1, int32_t>,
+        /*LayoutK=*/cute::tuple<int64_t, _1, int32_t>,
+        /*LayoutV=*/cute::tuple<int64_t, _1, int32_t>,
+        /*LayoutO=*/cute::tuple<int64_t, _1, int32_t>,
+        Scheduler,
+        Options>::Kernel>;
+    using Arguments = typename Operation::Arguments;
+
+    // NOTE: LayoutQ/K/V in (seq, head_size, (b,h)) coordinate semantics
+
+    int32_t tok_stride = num_heads * head_size;
+    int32_t head_stride = head_size;
+
+    Operation op;
+    Arguments arguments{
+        .problem_size =
+            {
+                .cu_seqlens = cu_seqlens,
+                .total_seqlen = total_seqlen,
+                .num_seqs = num_seqs,
+                .num_heads = num_heads,
+                .head_size = head_size,
+            },
+        .mainloop =
+            {
+                // clang-format off
+                .ptr_Q = (T*)q,      .dQ = {tok_stride, _1{}, head_stride},
+                .ptr_K = (T*)k,      .dK = {tok_stride, _1{}, head_stride},
+                .ptr_V = (T*)v,      .dV = {tok_stride, _1{}, head_stride},
+                .ptr_O = (T*)output, .dO = {tok_stride, _1{}, head_stride},
+                .ptr_Alpha = alpha,  .dAlpha = {tok_stride, _1{}, head_stride},
+                .ptr_output_state = (float*)output_state,
+                .ptr_input_state  = (float*)input_state,
+                .scale = scale,
+                .beta_ptr  = beta,  .beta_stride  = {num_heads, 1},
+        },  // clang-format on
+        .hw_info = hw_info};
+
+    cutlass::Status status;
+    status = op.can_implement(arguments);
+    if (status != cutlass::Status::kSuccess) {
+      throw std::runtime_error("can_implement failed");
+    }
+
+    status = op.initialize(arguments, workspace_buffer, stream);
+    if (status != cutlass::Status::kSuccess) {
+      throw std::runtime_error("initialize failed");
+    }
+
+    status = op.run(stream);
+    if (status != cutlass::Status::kSuccess) {
+      throw std::runtime_error("run failed");
+    }
+
+  } else {
+    throw std::runtime_error("hopper not supported");
+  }
+}
+
+};  // namespace kda::sm90

--- a/sgl-kernel/csrc/kda/sm90/utils/common.hpp
+++ b/sgl-kernel/csrc/kda/sm90/utils/common.hpp
@@ -1,0 +1,58 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+
+#include "kda/sm90/utils/debug.hpp"
+
+#define FLAT_UNUSED_PARAMETER(x) (void)x
+
+#define CHECK(expr, msg)                                                                           \
+  do {                                                                                             \
+    if (!(expr)) {                                                                                 \
+      std::string buffer(1024, '\0');                                                              \
+      sprintf(buffer.data(), "Failed to check %s, %s at %s:%d\n", ##expr, msg __FILE__, __LINE__); \
+      throw std::runtime_error(buffer.c_str());                                                    \
+    }                                                                                              \
+  } while (0)
+
+#define CUDA_CHECK(expr)                                                                                             \
+  do {                                                                                                               \
+    cudaError_t err = (expr);                                                                                        \
+    if (err != cudaSuccess) {                                                                                        \
+      std::string buffer(1024, '\0');                                                                                \
+      sprintf(buffer.data(), "CUDA Error: %s, Code: %d at %s:%d\n", cudaGetErrorName(err), err, __FILE__, __LINE__); \
+      throw std::runtime_error(buffer.c_str());                                                                      \
+    }                                                                                                                \
+  } while (0)

--- a/sgl-kernel/csrc/kda/sm90/utils/debug.hpp
+++ b/sgl-kernel/csrc/kda/sm90/utils/debug.hpp
@@ -1,0 +1,146 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cute/config.hpp>
+
+#if DEBUG_PIPE
+#define PIPE_DEBUG_PRINTF(fmt, ...) \
+  if (threadIdx.x == 0) printf("%s:%d " fmt, __FILE__, __LINE__, ##__VA_ARGS__)
+#else
+#define PIPE_DEBUG_PRINTF(...)
+#endif
+
+#ifndef FLAT_DEBUG_PRINT
+#define FLAT_DEBUG_PRINT 0
+#endif
+
+#if FLAT_DEBUG_PRINT
+#define IS_PRINT_BLOCK cute::block(1)
+#define DPRINTF(fmt, ...) \
+  if (IS_PRINT_BLOCK) printf("%s:%d " fmt, __FILE__, __LINE__, ##__VA_ARGS__)
+#define DPRINTF0(fmt, ...) \
+  if (IS_PRINT_BLOCK && threadIdx.x == 0) printf("%s:%d " fmt, __FILE__, __LINE__, ##__VA_ARGS__)
+#define DPRINTF_W(fmt, ...)            \
+  if (IS_PRINT_BLOCK)                  \
+  printf(                              \
+      "%s:%d [WG%d][W%d][T%-3d] " fmt, \
+      __FILE__,                        \
+      __LINE__,                        \
+      threadIdx.x / 128,               \
+      threadIdx.x / 32,                \
+      threadIdx.x,                     \
+      ##__VA_ARGS__)
+#define DPRINTF0_W(fmt, ...)                   \
+  if (IS_PRINT_BLOCK && threadIdx.x % 32 == 0) \
+  printf(                                      \
+      "%s:%d [WG%d][W%d][T%-3d] " fmt,         \
+      __FILE__,                                \
+      __LINE__,                                \
+      threadIdx.x / 128,                       \
+      threadIdx.x / 32,                        \
+      threadIdx.x,                             \
+      ##__VA_ARGS__)
+#define DPRINTF_WG(fmt, ...)           \
+  if (IS_PRINT_BLOCK)                  \
+  printf(                              \
+      "%s:%d [WG%d][W%d][T%-3d] " fmt, \
+      __FILE__,                        \
+      __LINE__,                        \
+      threadIdx.x / 128,               \
+      threadIdx.x / 32,                \
+      threadIdx.x,                     \
+      ##__VA_ARGS__)
+#define DPRINTF0_WG(fmt, ...)                   \
+  if (IS_PRINT_BLOCK && threadIdx.x % 128 == 0) \
+  printf(                                       \
+      "%s:%d [WG%d][W%d][T%-3d] " fmt,          \
+      __FILE__,                                 \
+      __LINE__,                                 \
+      threadIdx.x / 128,                        \
+      threadIdx.x / 32,                         \
+      threadIdx.x,                              \
+      ##__VA_ARGS__)
+#else
+#define DPRINTF(...)
+#define DPRINTF0(...)
+#define DPRINTF_W(...)
+#define DPRINTF0_W(...)
+#define DPRINTF_WG(...)
+#define DPRINTF0_WG(...)
+#endif
+
+#if FLAT_DEBUG_PRINT
+#define DPRINT_TMA_DESC(tma_dess_addr)                             \
+  do {                                                             \
+    auto p = reinterpret_cast<const unsigned int*>(tma_dess_addr); \
+    DPRINTF(                                                       \
+        "\n"                                                       \
+        "%08X%08X %08X%08X %08X%08X %08X%08X\n"                    \
+        "%08X%08X %08X%08X %08X%08X %08X%08X\n"                    \
+        "%08X%08X %08X%08X %08X%08X %08X%08X\n"                    \
+        "%08X%08X %08X%08X %08X%08X %08X%08X\n",                   \
+        p[0],                                                      \
+        p[1],                                                      \
+        p[2],                                                      \
+        p[3],                                                      \
+        p[4],                                                      \
+        p[5],                                                      \
+        p[6],                                                      \
+        p[7],                                                      \
+        p[8],                                                      \
+        p[9],                                                      \
+        p[10],                                                     \
+        p[11],                                                     \
+        p[12],                                                     \
+        p[13],                                                     \
+        p[14],                                                     \
+        p[15],                                                     \
+        p[16],                                                     \
+        p[17],                                                     \
+        p[18],                                                     \
+        p[19],                                                     \
+        p[20],                                                     \
+        p[21],                                                     \
+        p[22],                                                     \
+        p[23],                                                     \
+        p[24],                                                     \
+        p[25],                                                     \
+        p[26],                                                     \
+        p[27],                                                     \
+        p[28],                                                     \
+        p[29],                                                     \
+        p[30],                                                     \
+        p[31]);                                                    \
+  } while (0)
+#else
+#define DPRINT_TMA_DESC(tma_dess_addr)
+#endif

--- a/sgl-kernel/csrc/kda/sm90/utils/math.hpp
+++ b/sgl-kernel/csrc/kda/sm90/utils/math.hpp
@@ -1,0 +1,51 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cute/config.hpp>
+
+namespace kda::sm90 {
+
+namespace detail {
+
+template <typename T>
+CUTE_HOST_DEVICE constexpr T ceil_log2(T n) {
+  return n <= 1 ? 0 : 1 + ceil_log2((n + 1) / 2);
+}
+
+}  // namespace detail
+
+template <typename T>
+CUTE_HOST_DEVICE constexpr T next_power_of_two(T n) {
+  return static_cast<T>(1) << detail::ceil_log2(n);
+}
+
+}  // namespace kda::sm90

--- a/sgl-kernel/csrc/kda/sm90/utils/math_order_barrier.hpp
+++ b/sgl-kernel/csrc/kda/sm90/utils/math_order_barrier.hpp
@@ -1,0 +1,111 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cutlass/arch/barrier.h>
+#include <cutlass/cutlass.h>
+
+namespace kda::sm90 {
+
+// cutlass' OrderedSequenceBarrier uses mbarrier
+template <
+    bool UseReservedNB_,           // treat nb_id as cutlass::ReservedNamedBarriers
+    uint32_t... WGIdToNBIdMapping  // say 6,4 is passed, means wg0 use nb6 and wg1 use nb4
+    >
+struct OrderedNamedBarriers {
+  static constexpr bool UseReservedNB = UseReservedNB_;
+  static constexpr int NumWG = sizeof...(WGIdToNBIdMapping);
+  using NBId_t = std::conditional_t<UseReservedNB, cutlass::arch::ReservedNamedBarriers, uint32_t>;
+
+  CUTE_DEVICE
+  OrderedNamedBarriers() : mapping_{NBId_t(WGIdToNBIdMapping)...} {}
+
+  CUTE_DEVICE
+  void init(int wg_idx) {  // wg_idx in among all WG participants
+    for (int i = wg_idx; i > 0; --i) {
+      cutlass::arch::NamedBarrier::arrive(cutlass::NumThreadsPerWarpGroup * NumWG, mapping_[i - 1]);
+    }
+    // with 3 WGs, init to namedbarrier_id:(arrived_wg,expected_wg)
+    // 0:(2,3)
+    // 1:(1,3)
+    // 2:(0,3)
+  }
+
+  CUTE_DEVICE
+  ~OrderedNamedBarriers() {
+    // FIXME: this will be a problem for persistent scheduler
+  }
+
+  CUTE_DEVICE
+  void ordered_or_wait(int wg_idx) {  // wg_idx in participants
+    // during first call, before
+    // 0:(2,3)
+    // 1:(1,3)
+    // 2:(0,3)
+    cutlass::arch::NamedBarrier::sync(cutlass::NumThreadsPerWarpGroup * NumWG, mapping_[wg_idx]);
+    // after
+    // 0:(3,3) immediately unblock wg0, and named barrier automatically reset to (0,3)
+    // 1:(2,3)
+    // 2:(1,3)
+  }
+
+  CUTE_DEVICE
+  void notify_next_blocked(int wg_idx) {  // wg_idx in participants
+    // always call this after ordered_or_wait
+    // during first call, before
+    // 0:(0,3)
+    // 1:(2,3)
+    // 2:(1,3)
+    CUTE_UNROLL
+    for (int i = 1; i < NumWG; ++i) {
+      cutlass::arch::NamedBarrier::arrive(cutlass::NumThreadsPerWarpGroup * NumWG, mapping_[(wg_idx + i) % NumWG]);
+    }
+    // after wg0 called this function
+    // 0:(0,3), wg0 has not reached on second ordered_or_wait() or (1,3) wg0 wait on second ordered_or_wait() call
+    // 1:(0,3), unblocked wg1's first ordered_or_wait() and reset nb1
+    // 2:(2,3), still wait on first ordered_or_wait() call
+    //
+    // after wg1 called this function
+    // 0:(1,3), wg0 has not reached on second ordered_or_wait() or (2,3) wg0 wait on second ordered_or_wait() call
+    // 1:(0,3), wg1 has not reached on second ordered_or_wait() or (1,3) wg1 wait on second ordered_or_wait() call
+    // 2:(0,3), unblocked wg2's first ordered_or_wait() and reset nb2
+    //
+    // after wg2 called this function
+    // 0:(2,3), wg0 has not reached on second ordered_or_wait() or (0,3) wg0 wait on second ordered_or_wait() call,
+    // unblocked 1:(1,3), wg1 has not reached on second ordered_or_wait() or (2,3) wg1 wait on second
+    // ordered_or_wait() call, still block 2:(0,3), unblock wg0 ordered_or_wait() and reset
+    //
+  }
+
+ private:
+  cute::array<NBId_t, NumWG> mapping_;
+};
+}  // namespace kda::sm90

--- a/sgl-kernel/csrc/kda/sm90/utils/type_traits.hpp
+++ b/sgl-kernel/csrc/kda/sm90/utils/type_traits.hpp
@@ -1,0 +1,66 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cutlass/numeric_types.h>
+
+#include <type_traits>
+
+namespace kda::sm90 {
+
+// clang-format off
+template <typename T> struct map_to_cutlass;
+template<> struct map_to_cutlass<cutlass::half_t>             { using type = cutlass::half_t;                    };
+template<> struct map_to_cutlass<cutlass::bfloat16_t>         { using type = cutlass::bfloat16_t;                };
+template<> struct map_to_cutlass<half>                        { using type = cutlass::half_t;                    };
+template<> struct map_to_cutlass<nv_bfloat16>                 { using type = cutlass::bfloat16_t;                };
+
+template <typename T> using map_to_cutlass_t = typename map_to_cutlass<T>::type;
+// clang-format on
+
+template <typename... Ts>
+struct first_non_void {
+  static_assert(sizeof...(Ts) > 0, "all voids is not allowed");
+  using type = void;
+};
+
+template <typename T, typename... Ts>
+struct first_non_void<T, Ts...> {
+  using type = T;
+};
+
+template <typename... Ts>
+struct first_non_void<void, Ts...> : first_non_void<Ts...> {};
+
+template <typename... Ts>
+using first_non_void_t = typename first_non_void<Ts...>::type;
+
+}  // namespace kda::sm90

--- a/sgl-kernel/csrc/kda/sm90/utils/unused.hpp
+++ b/sgl-kernel/csrc/kda/sm90/utils/unused.hpp
@@ -1,0 +1,51 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cute/config.hpp>
+
+namespace kda::sm90 {
+
+struct Unused {
+  using Params = Unused;
+  using SharedStorage = char;
+  static constexpr uint32_t Stages = 0;
+
+  template <typename... Ts>
+  CUTE_HOST_DEVICE Unused(Ts... vs) {}
+
+  template <typename T>
+  CUTE_HOST_DEVICE Unused operator=(T&& v) {
+    return Unused{};
+  }
+};
+
+}  // namespace kda::sm90

--- a/sgl-kernel/csrc/kerutils/include/kerutils/common/common.h
+++ b/sgl-kernel/csrc/kerutils/include/kerutils/common/common.h
@@ -1,0 +1,39 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdio>
+#include <cstdlib>
+
+namespace kerutils {}
+
+#define KU_PRINTLN(fmt, ...)         \
+  {                                  \
+    cute::print(fmt, ##__VA_ARGS__); \
+    print("\n");                     \
+  }
+
+#define CHECK_CUDA(call)                                                                            \
+  do {                                                                                              \
+    cudaError_t status_ = call;                                                                     \
+    if (status_ != cudaSuccess) {                                                                   \
+      fprintf(stderr, "CUDA error (%s:%d): %s\n", __FILE__, __LINE__, cudaGetErrorString(status_)); \
+      exit(1);                                                                                      \
+    }                                                                                               \
+  } while (0)
+
+#define CHECK_CUDA_KERNEL_LAUNCH() CHECK_CUDA(cudaGetLastError())
+
+namespace ku = kerutils;

--- a/sgl-kernel/csrc/kerutils/include/kerutils/common/cute_ext.hpp
+++ b/sgl-kernel/csrc/kerutils/include/kerutils/common/cute_ext.hpp
@@ -1,0 +1,68 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cute/tensor.hpp>
+#include <cutlass/detail/layout.hpp>
+
+namespace kerutils {
+
+using namespace cute;
+
+template <int... Is, typename Layout>
+__forceinline__ __host__ __device__ constexpr auto select_layout(Layout&& l) {
+  if constexpr (is_composed_layout<Layout>::value) {
+    return make_composed_layout(l.layout_a(), l.offset(), select<Is...>(l.layout_b()));
+  } else {
+    return select<Is...>(l);
+  }
+}
+
+template <int... Is, typename Tensor>
+__forceinline__ __host__ __device__ constexpr auto select_tensor(Tensor&& t) {
+  if constexpr (is_composed_layout<decltype(t.layout())>::value) {
+    return make_tensor(
+        std::forward<Tensor>(t).data(),
+        make_composed_layout(
+            std::forward<Tensor>(t).layout().layout_a(),
+            std::forward<Tensor>(t).layout().offset(),
+            select<Is...>(std::forward<Tensor>(t).layout().layout_b())));
+  } else {
+    return make_tensor(std::forward<Tensor>(t).data(), select<Is...>(t.layout()));
+  }
+}
+
+template <class Layout>
+CUTE_DEVICE constexpr size_t alignment_for_swizzle(Layout&& layout) {
+  return cutlass::detail::alignment_for_swizzle(std::forward<Layout>(layout));
+}
+
+}  // namespace kerutils

--- a/sgl-kernel/csrc/kerutils/include/kerutils/device/common.h
+++ b/sgl-kernel/csrc/kerutils/include/kerutils/device/common.h
@@ -1,0 +1,94 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cuda_bf16.h>
+#include <cutlass/arch/barrier.h>
+#include <cutlass/bfloat16.h>
+#include <cutlass/tfloat32.h>
+
+#include <cute/config.hpp>
+
+namespace kerutils {
+
+using nvbf16 = __nv_bfloat16;
+using nvbf16x2 = __nv_bfloat162;
+
+using tf32 = cutlass::tfloat32_t;
+using bf16 = cutlass::bfloat16_t;
+using fp16 = cutlass::half_t;
+using transac_bar_t = cutlass::arch::ClusterTransactionBarrier;
+
+struct bf16x4 {
+  bf16 a, b, c, d;
+};
+
+struct nvbf16x4 {
+  __nv_bfloat162 a, b;
+};
+
+struct tf32x4 {
+  tf32 a, b, c, d;
+};
+
+struct bf16x8 {
+  __nv_bfloat162 a01;
+  __nv_bfloat162 a23;
+  __nv_bfloat162 a45;
+  __nv_bfloat162 a67;
+};
+
+struct bf16x16 {
+  __nv_bfloat162 a0;
+  __nv_bfloat162 a1;
+  __nv_bfloat162 a2;
+  __nv_bfloat162 a3;
+  __nv_bfloat162 a4;
+  __nv_bfloat162 a5;
+  __nv_bfloat162 a6;
+  __nv_bfloat162 a7;
+};
+
+}  // namespace kerutils
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800))
+#define KERUTILS_ENABLE_SM80
+#elif (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800))
+static_assert(false, "kerutils doesn't support SM architectures below SM80");
+#endif
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+#define KERUTILS_ENABLE_SM90
+#endif
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900 && __CUDA_ARCH__ < 1000))
+#define KERUTILS_ENABLE_SM90A
+#endif
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000))
+#define KERUTILS_ENABLE_SM100
+#endif
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000 && __CUDA_ARCH__ < 1200))
+#define KERUTILS_ENABLE_SM100A
+#endif
+
+#if (defined(__CLION_IDE__) || defined(__VSCODE_IDE__))
+#define KERUTILS_ENABLE_SM80
+#define KERUTILS_ENABLE_SM90
+#define KERUTILS_ENABLE_SM90A
+#define KERUTILS_ENABLE_SM100
+#define KERUTILS_ENABLE_SM100A
+#endif

--- a/sgl-kernel/csrc/kerutils/include/kerutils/device/device.cuh
+++ b/sgl-kernel/csrc/kerutils/include/kerutils/device/device.cuh
@@ -1,0 +1,24 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "common.h"
+#include "kerutils/common/common.h"
+#include "kerutils/common/cute_ext.hpp"
+#include "sm100/helpers.cuh"
+#include "sm100/intrinsics.cuh"
+#include "sm80/collective_inverse.hpp"
+#include "sm80/helpers.cuh"
+#include "sm90/helpers.cuh"

--- a/sgl-kernel/csrc/kerutils/include/kerutils/device/sm100/helpers.cuh
+++ b/sgl-kernel/csrc/kerutils/include/kerutils/device/sm100/helpers.cuh
@@ -1,0 +1,84 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Copyright (c) 2025 DeepSeek. All Rights Reserved.
+ *
+ * Licensed under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <cute/tensor.hpp>
+
+#include "kerutils/device/common.h"
+
+namespace kerutils {
+
+// Perform SS UTCMMA
+// sA and sB should be shared memory tensors (i.e. make_tensor(make_shared_ptr(XXX), XXX)) while tC_frag should be tmem
+// fragment
+template <typename TiledMMA, typename TensorA, typename TensorB, typename TensorFragC>
+CUTE_DEVICE void utcmma_ss(TiledMMA& tiled_mma, TensorA sA, TensorB sB, TensorFragC tC_frag, bool clear_accum) {
+  using namespace cute;
+  tiled_mma.accumulate_ = clear_accum ? UMMA::ScaleOut::Zero : UMMA::ScaleOut::One;
+  ThrMMA thr_mma = tiled_mma.get_slice(_0{});  // Since A/B/C are already CTA-local tiles, this number does not matter
+  auto sA_frag = thr_mma.partition_fragment_A(sA);
+  auto sB_frag = thr_mma.partition_fragment_B(sB);
+  static_assert(size<2>(sA_frag) == size<2>(sB_frag));
+  static_assert(size<1>(sA_frag) == size<1>(tC_frag));
+  static_assert(size<1>(sB_frag) == size<2>(tC_frag));
+  CUTE_UNROLL
+  for (int k = 0; k < size<2>(sA_frag); ++k) {
+    cute::gemm(tiled_mma, sA_frag(_, _, k), sB_frag(_, _, k), tC_frag);
+    tiled_mma.accumulate_ = UMMA::ScaleOut::One;
+  }
+}
+
+// Perform TS UTCMMA
+// sB should be shared memory tensors (i.e. make_tensor(make_shared_ptr(XXX), XXX)) while tA_frag and tC_frag should be
+// tmem fragment
+template <typename TiledMMA, typename TensorA, typename TensorB, typename TensorFragC>
+CUTE_DEVICE void utcmma_ts(TiledMMA& tiled_mma, TensorA tA_frag, TensorB sB, TensorFragC tC_frag, bool clear_accum) {
+  using namespace cute;
+  tiled_mma.accumulate_ = clear_accum ? UMMA::ScaleOut::Zero : UMMA::ScaleOut::One;
+  ThrMMA thr_mma = tiled_mma.get_slice(_0{});  // Since A/B/C are already CTA-local tiles, this number does not matter
+  auto sB_frag = thr_mma.partition_fragment_B(sB);
+  static_assert(size<2>(tA_frag) == size<2>(sB_frag));
+  CUTE_UNROLL
+  for (int k = 0; k < size<2>(tA_frag); ++k) {
+    cute::gemm(tiled_mma, tA_frag(_, _, k), sB_frag(_, _, k), tC_frag);
+    tiled_mma.accumulate_ = UMMA::ScaleOut::One;
+  }
+}
+
+}  // namespace kerutils

--- a/sgl-kernel/csrc/kerutils/include/kerutils/device/sm100/intrinsics.cuh
+++ b/sgl-kernel/csrc/kerutils/include/kerutils/device/sm100/intrinsics.cuh
@@ -1,0 +1,262 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Copyright (c) 2025 DeepSeek. All Rights Reserved.
+ *
+ * Licensed under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <cute/tensor.hpp>
+
+#include "kerutils/device/common.h"
+
+// Adapted from
+// https://github.com/deepseek-ai/FlashMLA/blob/main/csrc/kerutils/include/kerutils/device/sm100/intrinsics.cuh
+namespace kerutils {
+
+// ============================================================
+// TMA gather4 intrinsics (SM100)
+// ============================================================
+
+// tma gather4
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#data-movement-and-conversion-instructions-cp-async-bulk-tensor)
+// Please pay attention that the coordinates of TMA gather4 are int32, which may lead to overflow under some scenarios
+CUTE_DEVICE
+void tma_gather4(
+    const void* desc_ptr, transac_bar_t& mbar_ptr, void* smem_ptr, int col_idx, int4 row_idxs, int64_t cache_hint) {
+  uint32_t smem_addr = cute::cast_smem_ptr_to_uint(smem_ptr);
+  uint32_t mbar_addr = cute::cast_smem_ptr_to_uint(&mbar_ptr);
+  asm volatile(
+      "cp.async.bulk.tensor.2d.shared::cta.global.tile::gather4.mbarrier::complete_tx::bytes.cta_group::1.L2::cache_"
+      "hint [%0], [%1, {%2, %3, %4, %5, %6}], [%7], %8;\n"
+      :
+      : "r"(smem_addr),
+        "l"(desc_ptr),
+        "r"(col_idx),
+        "r"(row_idxs.x),
+        "r"(row_idxs.y),
+        "r"(row_idxs.z),
+        "r"(row_idxs.w),
+        "r"(mbar_addr),
+        "l"(cache_hint)
+      : "memory");
+}
+
+// tma gather4 prefetch
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#data-movement-and-conversion-instructions-cp-async-bulk-prefetch-tensor)
+// Please pay attention that the coordinates of TMA gather4 are int32, which may lead to overflow under some scenarios
+CUTE_DEVICE
+void tma_gather4_prefetch(const void* desc_ptr, int col_idx, int4 row_idxs, int64_t cache_hint) {
+  asm volatile(
+      "cp.async.bulk.prefetch.tensor.2d.L2.global.tile::gather4.L2::cache_hint [%0, {%1, %2, %3, %4, %5}], %6;\n"
+      :
+      : "l"(desc_ptr),
+        "r"(col_idx),
+        "r"(row_idxs.x),
+        "r"(row_idxs.y),
+        "r"(row_idxs.z),
+        "r"(row_idxs.w),
+        "l"(cache_hint));
+}
+
+// tma gather4 with cta_group::2, allowing for synchronization across CTAs within a pair of CTAs
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#data-movement-and-conversion-instructions-cp-async-bulk-tensor)
+template <bool USE_CTA0_MBAR = false>
+CUTE_DEVICE void tma_gather4_cta_group_2(
+    const void* desc_ptr, transac_bar_t& mbar_ptr, void* smem_ptr, int col_idx, int4 row_idxs, int64_t cache_hint) {
+  uint32_t smem_addr = cute::cast_smem_ptr_to_uint(smem_ptr);
+  uint32_t mbar_addr = cute::cast_smem_ptr_to_uint(&mbar_ptr);
+  if constexpr (USE_CTA0_MBAR) {
+    mbar_addr &= cute::Sm100MmaPeerBitMask;
+  }
+  asm volatile(
+      "cp.async.bulk.tensor.2d.shared::cta.global.tile::gather4.mbarrier::complete_tx::bytes.cta_group::2.L2::cache_"
+      "hint [%0], [%1, {%2, %3, %4, %5, %6}], [%7], %8;\n"
+      :
+      : "r"(smem_addr),
+        "l"(desc_ptr),
+        "r"(col_idx),
+        "r"(row_idxs.x),
+        "r"(row_idxs.y),
+        "r"(row_idxs.z),
+        "r"(row_idxs.w),
+        "r"(mbar_addr),
+        "l"(cache_hint)
+      : "memory");
+}
+
+// ============================================================
+// Vectorized float2 arithmetic
+// ============================================================
+
+// Vectorized addition for float32
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#floating-point-instructions-add)
+CUTE_DEVICE
+float2 float2_add(const float2& a, const float2& b) {
+  float2 c;
+  asm volatile("add.f32x2 %0, %1, %2;\n"
+               : "=l"(reinterpret_cast<uint64_t&>(c))
+               : "l"(reinterpret_cast<uint64_t const&>(a)), "l"(reinterpret_cast<uint64_t const&>(b)));
+  return c;
+}
+
+// Vectorized subtraction for float32
+CUTE_DEVICE
+float2 float2_sub(const float2& a, const float2& b) {
+  float2 c;
+  asm volatile("sub.f32x2 %0, %1, %2;\n"
+               : "=l"(reinterpret_cast<uint64_t&>(c))
+               : "l"(reinterpret_cast<uint64_t const&>(a)), "l"(reinterpret_cast<uint64_t const&>(b)));
+  return c;
+}
+
+// Vectorized multiplication for float32
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#floating-point-instructions-mul)
+CUTE_DEVICE
+float2 float2_mul(const float2& a, const float2& b) {
+  float2 c;
+  asm volatile("mul.f32x2 %0, %1, %2;\n"
+               : "=l"(reinterpret_cast<uint64_t&>(c))
+               : "l"(reinterpret_cast<uint64_t const&>(a)), "l"(reinterpret_cast<uint64_t const&>(b)));
+  return c;
+}
+
+// Vectorized fused multiply-add for float32
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#floating-point-instructions-fma)
+CUTE_DEVICE
+float2 float2_fma(const float2& a, const float2& b, const float2& c) {
+  // return a*b+c
+  float2 d;
+  asm volatile("fma.rn.f32x2 %0, %1, %2, %3;\n"
+               : "=l"(reinterpret_cast<uint64_t&>(d))
+               : "l"(reinterpret_cast<uint64_t const&>(a)),
+                 "l"(reinterpret_cast<uint64_t const&>(b)),
+                 "l"(reinterpret_cast<uint64_t const&>(c)));
+  return d;
+}
+
+// Vectorized negation for float32
+CUTE_DEVICE
+float2 float2_neg(const float2& a) {
+  float2 t = {-1.0f, -1.0f};
+  return float2_mul(a, t);
+}
+
+// ============================================================
+// tcgen05 fence intrinsics (SM100)
+// ============================================================
+
+// tcgen05.fence::before_thread_sync
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#tcgen05-special-sync-operations-fence)
+__device__ __forceinline__ void tcgen05_before_thread_sync() {
+  asm volatile("tcgen05.fence::before_thread_sync;");
+}
+
+// tcgen05.fence::after_thread_sync
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#tcgen05-special-sync-operations-fence)
+__device__ __forceinline__ void tcgen05_after_thread_sync() {
+  asm volatile("tcgen05.fence::after_thread_sync;");
+}
+
+// ============================================================
+// Tensor memory (TMEM) load/store intrinsics (SM100)
+// ============================================================
+
+// Load from tensor memory, 32 data path lanes, 32-bit pattern, repeated N times.
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#tcgen05-instructions-tcgen05-ld)
+template <int kNumElements>
+__device__ __forceinline__ void tmem_ld_32dp32bNx(uint32_t tmem_start, void* data_) {
+  uint32_t* data = (uint32_t*)data_;
+  static_assert(
+      kNumElements == 1 || kNumElements == 2 || kNumElements == 4 || kNumElements == 8 || kNumElements == 16 ||
+          kNumElements == 32 || kNumElements == 64 || kNumElements == 128,
+      "Invalid kNumElements");
+  // NOTE The following code crashes VSCode intellisense engine, so we disable it
+#ifndef __VSCODE_IDE__
+  [&]<size_t... Is>(cute::index_sequence<Is...>) {
+    if constexpr (kNumElements == 1) {
+      cute::SM100_TMEM_LOAD_32dp32b1x::copy(tmem_start, data[Is]...);
+    } else if constexpr (kNumElements == 2) {
+      cute::SM100_TMEM_LOAD_32dp32b2x::copy(tmem_start, data[Is]...);
+    } else if constexpr (kNumElements == 4) {
+      cute::SM100_TMEM_LOAD_32dp32b4x::copy(tmem_start, data[Is]...);
+    } else if constexpr (kNumElements == 8) {
+      cute::SM100_TMEM_LOAD_32dp32b8x::copy(tmem_start, data[Is]...);
+    } else if constexpr (kNumElements == 16) {
+      cute::SM100_TMEM_LOAD_32dp32b16x::copy(tmem_start, data[Is]...);
+    } else if constexpr (kNumElements == 32) {
+      cute::SM100_TMEM_LOAD_32dp32b32x::copy(tmem_start, data[Is]...);
+    } else if constexpr (kNumElements == 64) {
+      cute::SM100_TMEM_LOAD_32dp32b64x::copy(tmem_start, data[Is]...);
+    } else if constexpr (kNumElements == 128) {
+      cute::SM100_TMEM_LOAD_32dp32b128x::copy(tmem_start, data[Is]...);
+    }
+  }(cute::make_index_sequence<kNumElements>{});
+#endif
+}
+
+// Store into tensor memory, 32 data path lanes, 32-bit pattern, repeated N times.
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#tcgen05-instructions-tcgen05-st)
+template <int kNumElements>
+__device__ __forceinline__ void tmem_st_32dp32bNx(uint32_t tmem_start, void const* data_) {
+  uint32_t const* data = (uint32_t const*)data_;
+  static_assert(
+      kNumElements == 1 || kNumElements == 2 || kNumElements == 4 || kNumElements == 8 || kNumElements == 16 ||
+          kNumElements == 32 || kNumElements == 64 || kNumElements == 128,
+      "Invalid kNumElements");
+#ifndef __VSCODE_IDE__
+  [&]<size_t... Is>(cute::index_sequence<Is...>) {
+    if constexpr (kNumElements == 1) {
+      cute::SM100_TMEM_STORE_32dp32b1x::copy(data[Is]..., tmem_start);
+    } else if constexpr (kNumElements == 2) {
+      cute::SM100_TMEM_STORE_32dp32b2x::copy(data[Is]..., tmem_start);
+    } else if constexpr (kNumElements == 4) {
+      cute::SM100_TMEM_STORE_32dp32b4x::copy(data[Is]..., tmem_start);
+    } else if constexpr (kNumElements == 8) {
+      cute::SM100_TMEM_STORE_32dp32b8x::copy(data[Is]..., tmem_start);
+    } else if constexpr (kNumElements == 16) {
+      cute::SM100_TMEM_STORE_32dp32b16x::copy(data[Is]..., tmem_start);
+    } else if constexpr (kNumElements == 32) {
+      cute::SM100_TMEM_STORE_32dp32b32x::copy(data[Is]..., tmem_start);
+    } else if constexpr (kNumElements == 64) {
+      cute::SM100_TMEM_STORE_32dp32b64x::copy(data[Is]..., tmem_start);
+    } else if constexpr (kNumElements == 128) {
+      cute::SM100_TMEM_STORE_32dp32b128x::copy(data[Is]..., tmem_start);
+    }
+  }(cute::make_index_sequence<kNumElements>{});
+#endif
+}
+
+}  // namespace kerutils

--- a/sgl-kernel/csrc/kerutils/include/kerutils/device/sm80/collective_inverse.hpp
+++ b/sgl-kernel/csrc/kerutils/include/kerutils/device/sm80/collective_inverse.hpp
@@ -1,0 +1,1129 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cutlass/arch/barrier.h>
+#include <cutlass/cutlass.h>
+
+#include <cute/tensor.hpp>
+
+#include "kerutils/common/cute_ext.hpp"
+
+namespace kerutils {
+
+using namespace cute;
+
+template <int dim, typename Layout>
+constexpr bool is_contiguous(Layout&& layout) {
+  auto dim_layout = get<dim>(layout);
+  if constexpr (rank(dim_layout) == 0) {
+    return stride(dim_layout) == 1;
+  } else {
+    return stride<0>(dim_layout) == 1;
+  }
+}
+
+namespace detail::SM80 {
+
+// ============================================================================
+// convert_c_layout_to_a_layout — Compile-time layout reshape: C-fragment → A-fragment
+// ============================================================================
+// The C-fragment (accumulator) layout is (FragAtomC, MMA_M, MMA_N).
+// The A-fragment (operand A) layout is  (FragAtomA, MMA_M, MMA_K).
+//
+// When FragAtomA > FragAtomC (e.g. SM80_16x8x16 where A has 8 vals/atom but
+// C has 4 vals/atom, ratio=2), the N-dimension is split: MMA_N → (ratio, MMA_N/ratio),
+// and the "ratio" factor is folded into the value (FragAtom) dimension:
+//   C: ((2,2), MMA_M, MMA_N) → ((2,2,ratio), MMA_M, MMA_N/ratio)
+//
+// For SM80_16x8x8 TF32 (used in the inverse), FragAtomA == FragAtomC == 4,
+// so ratio=1 and this function returns the C-layout unchanged. The function is
+// still called to maintain a uniform code path and to reinterpret the fragment's
+// rank-3 indexing in A-operand terms for the per-k-atom shuffle loop.
+//
+template <typename CLayout, typename TiledMMA>
+CUTE_DEVICE constexpr auto convert_c_layout_to_a_layout(CLayout const& c, TiledMMA const& tiled_mma) {
+  constexpr auto c_frag_atom_size = size<0>(CLayout{});  // values per C atom (4 for SM80_16x8)
+  constexpr auto a_frag_atom_size = size<1>(typename TiledMMA::AtomLayoutA_TV{});  // values per A atom
+  static_assert(a_frag_atom_size % c_frag_atom_size == 0);
+  constexpr auto ratio = a_frag_atom_size / c_frag_atom_size;  // 1 for 16x8x8, 2 for 16x8x16
+  if constexpr (ratio == 1) {
+    // SM80_16x8x8: C and A have the same value count per atom → no reshape needed
+    return CLayout{};
+  } else {
+    // SM80_16x8x16: A atom has 2× more values than C atom.
+    // Split N-dimension by ratio, fold the extra factor into the value dimension:
+    //   C: (FragAtom, MMA_M, MMA_N)
+    //   → logical_divide by (_, _, ratio): (FragAtom, MMA_M, (ratio, MMA_N/ratio))
+    //   → flatten first + third[0]: ((FragAtom, ratio), MMA_M, MMA_N/ratio)
+    constexpr auto tiler = make_shape(_, _, Int<ratio>{});      // keep FragAtom and MMA_M, split MMA_N
+    constexpr auto divided = logical_divide(CLayout{}, tiler);  // (FragAtom, MMA_M, (ratio, MMA_N/ratio))
+
+    return make_layout(flatten(make_layout(get<0>(divided), get<2, 0>(divided))), get<1>(divided), get<2, 1>(divided));
+  }
+}
+
+// ============================================================================
+// make_acc_into_op — Generic acc→operand conversion (FP16 path only)
+// ============================================================================
+// Works for FP16 MMA because C-layout and A-layout have the SAME thread-to-K
+// mapping ({2*t0, 2*t0+1} for both). A simple in-thread element copy suffices.
+// For TF32 MMA, thread-to-K mappings DIFFER between C and A layouts, so this
+// function is INCORRECT for TF32. Use convert_fp32_acc_to_tf32_operandA_layout
+// instead, which performs cross-thread __shfl_sync shuffles.
+template <class Element, class Accumulator, class TiledMMA>
+CUTE_DEVICE auto make_acc_into_op(Accumulator const& acc, TiledMMA const& tiled_mma) {
+  Tensor operand = make_fragment_like<Element>(convert_c_layout_to_a_layout(acc.layout(), tiled_mma));
+  Tensor operand_as_acc = make_tensor(operand.data(), acc.layout());
+  cute::copy(acc, operand_as_acc);
+  return operand;
+}
+
+// ============================================================================
+// convert_fp32_acc_to_tf32_operandA_layout — Cross-thread shuffle: C-layout → A-layout (TF32)
+// ============================================================================
+// Converts an MMA accumulator fragment (C-layout, float) into an A-operand fragment
+// (A-layout, float or tf32) via warp-level __shfl_sync shuffles.
+//
+// Why this is needed:
+//   The SM80 TF32 MMA (16x8x8) has different thread-value (TV) mappings for
+//   C-layout vs A-layout. Specifically, the K-dimension ownership differs:
+//     C-layout: t0 selects M-row group (stride 32), v0/v1 select M sub-rows
+//     A-layout: t0 selects K-column pair {t0, t0+4}, v0 selects M-half, v1 selects K-half
+//   This means values must be redistributed ACROSS threads (not just within a thread).
+//
+// Algorithm overview (per k-atom, 4 values each):
+//   1. Read all 4 src values into locals (avoid read-after-write hazard)
+//   2. For each M-half (v0_tf32 ∈ {0,1}):
+//      a. Select the 2 source values for this M-half (maps to v1_bf16 in C-layout)
+//      b. Shuffle from source threads: src_lane = t0/2 (K-lo) or t0/2+2 (K-hi)
+//      c. Select v0_bf16=0 or v0_bf16=1 based on t0 parity (even/odd)
+//   3. Write 4 output values (with optional TF32 rounding)
+//
+// Cost: 8 __shfl_sync per k-atom (2 M-halves × 4 shuffles each).
+//
+// Template parameters:
+//   NumKAtoms   — number of K-atoms to process (1, 2, or 4)
+//   RoundingTF32 — if true, output is tfloat32_t with explicit rounding;
+//                  if false, output is float and MMA hardware truncates
+template <int NumKAtoms = 4, bool RoundingTF32 = false, class FragSrc, class FragDst, class TiledMMA>
+CUTE_DEVICE void convert_fp32_acc_to_tf32_operandA_layout(
+    const FragSrc& frag_src, FragDst& frag_dst, TiledMMA const& tiled_mma, int lane_id) {
+  using ElemSrc = typename cute::remove_cvref_t<FragSrc>::value_type;
+  using ElemDst = typename cute::remove_cvref_t<FragDst>::value_type;
+  static_assert(cute::is_same_v<ElemSrc, float>, "Fragment input must be float with acc data dtype");
+  static_assert(
+      RoundingTF32 || cute::is_same_v<ElemDst, float>,
+      "Fragment must be float with no rounding; tf32 truncation is done by MMA hardware");
+  static_assert(
+      !RoundingTF32 || cute::is_same_v<ElemDst, cutlass::tfloat32_t>,
+      "Fragment must be tfloat32 with rounding; tf32 truncation is done manually");
+
+  // Reinterpret the source fragment with A-layout indexing.
+  // For SM80_16x8x8 TF32, ratio=1 so this is effectively a no-op (same shape).
+  // For SM80_16x8x16, this would reshape (4, M, N) → (8, M, N/2) to align k-atoms.
+  auto frag_src_cvt = make_tensor(frag_src.data(), convert_c_layout_to_a_layout(frag_src.layout(), tiled_mma));
+
+  // Thread decomposition within a warp of 32 threads.
+  // tid = t0 + 4*t1, where t0 ∈ [0,4) indexes K-groups, t1 ∈ [0,8) indexes M-rows.
+  int tid = lane_id;
+  int t0 = tid % 4;
+  // Parity of t0 determines which v0_bf16 value to select after shuffle:
+  //   even t0 → needs v0_bf16=0 (K = 2*(t0/2) = t0)
+  //   odd  t0 → needs v0_bf16=1 (K = 2*(t0/2)+1 = t0)
+  bool sel_odd = (t0 & 1);
+
+  // Compute source lane IDs for the K-dimension shuffle.
+  // In C-layout, thread with t0_src holds K = {2*t0_src, 2*t0_src+1}.
+  // We need K = t0 (from t0_src = t0/2) and K = t0+4 (from t0_src = t0/2+2).
+  // The upper bits of lane_id (t1 portion) stay the same: (tid & ~3).
+  int src_lane_lo = (t0 / 2) + (tid & ~3);      // source for K = t0     (v1_tf32=0)
+  int src_lane_hi = (t0 / 2 + 2) + (tid & ~3);  // source for K = t0 + 4 (v1_tf32=1)
+
+  // Process each k-atom independently. Each atom has 4 values indexed as:
+  //   C-layout: [4j+0]=(v0=0,v1=0), [4j+1]=(v0=1,v1=0), [4j+2]=(v0=0,v1=1), [4j+3]=(v0=1,v1=1)
+  //     where v0 selects K sub-position, v1 selects M sub-row
+  //   A-layout: [4j+0]=(v0=0,v1=0), [4j+1]=(v0=1,v1=0), [4j+2]=(v0=0,v1=1), [4j+3]=(v0=1,v1=1)
+  //     where v0 selects M half (0 or +8), v1 selects K half (lo or hi)
+  CUTE_UNROLL
+  for (int j = 0; j < NumKAtoms; j++) {
+    // Step 1: Read all 4 input values BEFORE writing any output.
+    // This prevents read-after-write hazard when src and dst share storage
+    // (output positions overlap with input positions within the same k-atom).
+    float in0 = frag_src_cvt(0 + 4 * j);  // C-layout: (v0=0, v1=0) → K-lo, M-row-0
+    float in1 = frag_src_cvt(1 + 4 * j);  // C-layout: (v0=1, v1=0) → K-hi, M-row-0
+    float in2 = frag_src_cvt(2 + 4 * j);  // C-layout: (v0=0, v1=1) → K-lo, M-row-1
+    float in3 = frag_src_cvt(3 + 4 * j);  // C-layout: (v0=1, v1=1) → K-hi, M-row-1
+
+    // Step 2: Process each M-half (v0_tf32) independently.
+    // v0_tf32=0 (M-half 0) needs data from v1_bf16=0 → (in0, in1)
+    // v0_tf32=1 (M-half 1) needs data from v1_bf16=1 → (in2, in3)
+    float out_vals[4];
+    CUTE_UNROLL
+    for (int v0_tf32 = 0; v0_tf32 < 2; v0_tf32++) {
+      // Select the two source values for this M-half.
+      // In C-layout, v1 selects M-row; in A-layout, v0 selects M-half.
+      // So v0_tf32 maps to v1_bf16 for M-row selection.
+      float val0 = (v0_tf32 == 0) ? in0 : in2;  // v0_bf16=0 at chosen M-half
+      float val1 = (v0_tf32 == 0) ? in1 : in3;  // v0_bf16=1 at chosen M-half
+
+      // Step 3: Cross-thread shuffle for K-dimension remapping.
+      // Fetch both v0_bf16 values (=0 and =1) from the source threads,
+      // then select the correct one based on t0 parity.
+      float recv0_lo = __shfl_sync(0xFFFFFFFF, val0, src_lane_lo);  // v0_bf16=0 from K-lo source
+      float recv1_lo = __shfl_sync(0xFFFFFFFF, val1, src_lane_lo);  // v0_bf16=1 from K-lo source
+      float recv0_hi = __shfl_sync(0xFFFFFFFF, val0, src_lane_hi);  // v0_bf16=0 from K-hi source
+      float recv1_hi = __shfl_sync(0xFFFFFFFF, val1, src_lane_hi);  // v0_bf16=1 from K-hi source
+
+      // Step 4: Select correct value based on t0 parity.
+      // Even t0 needs v0_bf16=0 (recv0), odd t0 needs v0_bf16=1 (recv1).
+      out_vals[v0_tf32 + 0] = sel_odd ? recv1_lo : recv0_lo;  // v1_tf32=0 (K-lo half)
+      out_vals[v0_tf32 + 2] = sel_odd ? recv1_hi : recv0_hi;  // v1_tf32=1 (K-hi half)
+    }
+
+    // Step 5: Write output values in A-layout order.
+    // If RoundingTF32: explicit cast to tfloat32_t applies rounding (x += 0x1000u).
+    // If !RoundingTF32: store as float; MMA hardware truncates to TF32 precision.
+    if constexpr (RoundingTF32) {
+      frag_dst(0 + 4 * j) = (ElemDst)out_vals[0];  // (v0_tf32=0, v1_tf32=0) → M-half-0, K-lo
+      frag_dst(1 + 4 * j) = (ElemDst)out_vals[1];  // (v0_tf32=1, v1_tf32=0) → M-half-1, K-lo
+      frag_dst(2 + 4 * j) = (ElemDst)out_vals[2];  // (v0_tf32=0, v1_tf32=1) → M-half-0, K-hi
+      frag_dst(3 + 4 * j) = (ElemDst)out_vals[3];  // (v0_tf32=1, v1_tf32=1) → M-half-1, K-hi
+    } else {
+      frag_dst(0 + 4 * j) = out_vals[0];
+      frag_dst(1 + 4 * j) = out_vals[1];
+      frag_dst(2 + 4 * j) = out_vals[2];
+      frag_dst(3 + 4 * j) = out_vals[3];
+    }
+  }
+}
+
+}  // namespace detail::SM80
+
+template <class Element, bool GarbageFilledDiagonal, bool GarbageFilledUpperTriangular, bool RoundingTF32 = false>
+struct CollectiveInverseTF32 {
+  static_assert(std::is_same_v<Element, cutlass::tfloat32_t>);
+  using ElementView = std::conditional_t<RoundingTF32, Element, float>;
+
+  CUTE_DEVICE
+  CollectiveInverseTF32(int wg_sync_named_barrier_id) : wg_sync_named_barrier_id_(wg_sync_named_barrier_id) {}
+
+  template <typename TensorT>
+  CUTE_DEVICE void compute(TensorT&& sT) {
+    constexpr auto L = typename std::remove_const_t<std::remove_reference_t<TensorT>>::layout_type{};
+    static_assert(rank(L) == 2);
+    static_assert(size<0>(L) == 64);
+    static_assert(size<1>(L) == 64);
+
+    int thread_idx = threadIdx.x % cutlass::NumThreadsPerWarpGroup;
+
+    auto sT_view = recast<ElementView>(sT);
+    auto t16X16sT = flat_divide(sT_view, Shape<_16, _16>{});
+
+    if (thread_idx < 64) {  // compute 16x16 inverse on diagnal directly
+      compute_diagonal_inverse_NxN<16>(t16X16sT(_, _, thread_idx / 16, thread_idx / 16), thread_idx % 16);
+    }
+    cutlass::arch::NamedBarrier::arrive_and_wait(cutlass::NumThreadsPerWarpGroup, wg_sync_named_barrier_id_);
+
+    auto t32X32sT = flat_divide(sT_view, Shape<_32, _32>{});
+    if (thread_idx < 64) {  // two warps for 16x16 -> 32x32
+      blockwise_diagonal_inversed_16x16_to_32x32(t32X32sT(_, _, thread_idx / 32, thread_idx / 32));
+    }
+
+    cutlass::arch::NamedBarrier::arrive_and_wait(cutlass::NumThreadsPerWarpGroup, wg_sync_named_barrier_id_);
+    // one warpgroup for 32x32 -> 64x64
+    blockwise_diagonal_inversed_32x32_to_64x64(sT_view);
+  }
+
+ private:
+  template <int N, typename TensorT>
+  CUTE_DEVICE void compute_diagonal_inverse_NxN(TensorT&& mat, int tid_in_group) {  // group_size = N
+    constexpr auto L = typename std::remove_const_t<std::remove_reference_t<TensorT>>::layout_type{};
+    static_assert(rank(L) == 2);
+    static_assert(size<0>(L) == N);
+    static_assert(size<1>(L) == N);
+
+    using ElementCompute = float;
+
+    using CopyOp = Copy_Atom<AutoVectorizingCopyWithAssumedAlignment<128>, ElementView>;
+
+    auto load_row = [&](int y) {
+      auto row = make_tensor<ElementView>(Shape<Int<N>>{});
+      copy(CopyOp{}, std::forward<TensorT>(mat)(y, _), row);
+
+      auto row_cvt = [&]() {
+        if constexpr (RoundingTF32) {
+          return make_tensor_like<ElementCompute>(row);
+        } else {
+          return row;
+        }
+      }();
+      if constexpr (RoundingTF32) {
+        copy(row, row_cvt);
+      }
+
+      if constexpr (GarbageFilledDiagonal || GarbageFilledUpperTriangular) {
+        CUTE_UNROLL
+        for (int i = 0; i < N; ++i) {
+          row_cvt(i) = i == y ? 1.0f : (i > y ? 0.0f : row_cvt(i));
+        }
+      }
+      return row_cvt;
+    };
+
+    auto store_row = [&](int y, auto row) {
+      auto row_cvt = [&]() {
+        if constexpr (RoundingTF32) {
+          return make_tensor_like<ElementView>(row);
+        } else {
+          return row;
+        }
+      }();
+      if constexpr (RoundingTF32) {
+        copy(row, row_cvt);
+      }
+      copy(CopyOp{}, row_cvt, std::forward<TensorT>(mat)(y, _));
+    };
+
+    auto row = load_row(tid_in_group);
+#define LOAD(y, x) __shfl_sync(0xffffffff, row(x), y, N)
+
+    CUTE_UNROLL
+    for (int src_row = 0; src_row < N - 1; ++src_row) {  // idx of src row to eliminate
+      auto row_scale = -row(src_row);                    // scale the src row
+      CUTE_UNROLL
+      for (int i = 0; i < src_row; ++i) {
+        auto src_row_value = LOAD(src_row, i);
+        row(i) = tid_in_group > src_row ? row_scale * src_row_value + row(i) : row(i);
+      }
+      row(src_row) = tid_in_group > src_row ? row_scale : row(src_row);
+    }
+
+#undef LOAD
+
+    store_row(tid_in_group, row);
+  }
+
+  /*
+  blockwise inverse has relation as follows
+  inv(| A 0 |)     = |          inv(A)       0  |
+      | C D |        | -inv(D)C inv(A)   inv(D) |
+  */
+
+  // not used
+  template <typename TensorT>
+  CUTE_DEVICE void blockwise_diagonal_inversed_8x8_to_16x16(TensorT&& mat) {
+    constexpr auto L = typename std::remove_const_t<std::remove_reference_t<TensorT>>::layout_type{};
+    static_assert(rank(L) == 2);
+    static_assert(size<0>(L) == 16);
+    static_assert(size<1>(L) == 16);
+
+    static_assert(is_contiguous<0>(L) == 1 || is_contiguous<1>(L) == 1);
+    constexpr bool is_col_major = is_contiguous<0>(L);
+
+    auto mat_8x8_2x2 = flat_divide(std::forward<TensorT>(mat), Shape<_8, _8>{});
+    using MMA = SM80_16x8x8_F32TF32TF32F32_TN;
+    using TiledMMA = decltype(make_tiled_mma(MMA{}, Layout<Shape<_1, _1>>{}, Shape<_16, _8, _8>{}));
+
+    using CopyOpTF32 = AutoVectorizingCopyWithAssumedAlignment<128>;
+    using CopyOpD_S2R = CopyOpTF32;
+    using CopyOpC_S2R = CopyOpTF32;
+    using CopyOpA_S2R = CopyOpTF32;
+#ifdef CUTE_ARCH_STSM_SM90_ENABLED
+    using CopyOpO_R2S = CopyOpTF32;
+#else
+    using CopyOpO_R2S = UniversalCopy<ElementView, ElementView>;
+#endif
+
+    int lane_id = cutlass::canonical_lane_idx();
+    auto tiled_mma = TiledMMA{};
+    auto thr_mma = tiled_mma.get_thread_slice(lane_id);
+
+    auto D_tiled_copy = make_tiled_copy_A(Copy_Atom<CopyOpD_S2R, ElementView>{}, tiled_mma);
+    auto C_tiled_copy = make_tiled_copy_B(Copy_Atom<CopyOpC_S2R, ElementView>{}, tiled_mma);
+    auto A_tiled_copy = make_tiled_copy_B(Copy_Atom<CopyOpA_S2R, ElementView>{}, tiled_mma);
+    auto O_tiled_copy = make_tiled_copy_C(Copy_Atom<CopyOpO_R2S, ElementView>{}, tiled_mma);
+
+    auto D_thr_copy = D_tiled_copy.get_thread_slice(lane_id);
+    auto C_thr_copy = C_tiled_copy.get_thread_slice(lane_id);
+    auto A_thr_copy = A_tiled_copy.get_thread_slice(lane_id);
+    auto O_thr_copy = O_tiled_copy.get_thread_slice(lane_id);
+
+    Tensor sDinv = mat_8x8_2x2(_, _, _1{}, _1{});
+    Tensor sC = select_tensor<1, 0>(mat_8x8_2x2(_, _, _1{}, _0{}));
+    Tensor sAinv = select_tensor<1, 0>(mat_8x8_2x2(_, _, _0{}, _0{}));
+    Tensor sO = mat_8x8_2x2(_, _, _1{}, _0{});
+
+    Tensor sDinv_m_bcast = make_tensor(sDinv.data(), logical_product(sDinv.layout(), Tile<Layout<_2, _0>>{}));
+    Tensor sO_m_bcast = make_tensor(sO.data(), logical_product(sO.layout(), Tile<Layout<_2, _0>>{}));
+
+    Tensor tOrDinv = make_fragment_like<ElementView>(partition_shape_A(tiled_mma, Shape<_16, _8>{}));
+    Tensor tOrC = make_fragment_like<ElementView>(partition_shape_B(tiled_mma, Shape<_8, _8>{}));
+    // Tensor tOrC    = thr_mma.partition_fragment_B(sC);
+    Tensor tOrAinv = make_fragment_like<ElementView>(partition_shape_B(tiled_mma, Shape<_8, _8>{}));
+    // Tensor tOrAinv = thr_mma.partition_fragment_B(sAinv);
+
+    Tensor tDCrDC = partition_fragment_C(tiled_mma, Shape<_16, _8>{});  // output of -inv(D)C
+    Tensor tOrO = partition_fragment_C(tiled_mma, Shape<_16, _8>{});    // output of -inv(D)C inv(A)
+
+    Tensor tOsDinv = D_thr_copy.partition_S(sDinv_m_bcast);
+    Tensor tOrDinv_cv = D_thr_copy.retile_D(tOrDinv);
+    Tensor tOsC = C_thr_copy.partition_S(sC);
+    Tensor tOrC_cv = C_thr_copy.retile_D(tOrC);
+    Tensor tOsAinv = A_thr_copy.partition_S(sAinv);
+    Tensor tOrAinv_cv = A_thr_copy.retile_D(tOrAinv);
+    Tensor tOsO = O_thr_copy.partition_D(sO_m_bcast);
+    Tensor tOrO_cv = O_thr_copy.retile_S(tOrO);
+
+    /////////////////////////////////////////////////////////////////////////////
+    // -inv(D)C
+    copy(D_tiled_copy, tOsDinv, tOrDinv_cv);
+    copy(C_tiled_copy, tOsC, tOrC_cv);
+
+    clear(tDCrDC);
+    auto tOrDinv_mma = [&]() {
+      if constexpr (!RoundingTF32) {
+        return recast<Element>(tOrDinv);
+      } else {
+        return tOrDinv;
+      }
+    }();
+    auto tOrC_mma = [&]() {
+      if constexpr (!RoundingTF32) {
+        return recast<Element>(tOrC);
+      } else {
+        return tOrC;
+      }
+    }();
+    gemm(tiled_mma, tOrDinv_mma, tOrC_mma, tDCrDC);
+    transform(tDCrDC, [](auto v) { return -v; });
+
+    /////////////////////////////////////////////////////////////////////////////
+    // -inv(D)C inv(A)
+    Tensor tOrDC = make_fragment_like<ElementView>(partition_shape_A(tiled_mma, Shape<_16, _8>{}));
+    // Tensor tOrDC = detail::SM80::make_acc_into_op<Element>(tDCrDC, tiled_mma);
+    detail::SM80::convert_fp32_acc_to_tf32_operandA_layout<1, RoundingTF32>(tDCrDC, tOrDC, tiled_mma, lane_id);
+    auto tOrDC_mma = [&]() {
+      if constexpr (!RoundingTF32) {
+        return recast<Element>(tOrDC);
+      } else {
+        return tOrDC;
+      }
+    }();
+
+    copy(A_tiled_copy, tOsAinv, tOrAinv_cv);
+
+    clear(tOrO);
+    auto tOrAinv_mma = [&]() {
+      if constexpr (!RoundingTF32) {
+        return recast<Element>(tOrAinv);
+      } else {
+        return tOrAinv;
+      }
+    }();
+    gemm(tiled_mma, tOrDC_mma, tOrAinv_mma, tOrO);
+
+    if constexpr (!RoundingTF32) {
+      // no need for conversion
+      copy(O_tiled_copy, tOrO_cv, tOsO);
+    } else {
+      auto tOrO_cv_cvt = make_tensor_like<Element>(tOrO_cv);
+      transform(tOrO_cv, tOrO_cv_cvt, [](auto v) { return Element(v); });
+      copy(O_tiled_copy, tOrO_cv_cvt, tOsO);
+    }
+  }
+
+  template <typename TensorT>
+  CUTE_DEVICE void blockwise_diagonal_inversed_16x16_to_32x32(TensorT&& mat) {
+    constexpr auto L = typename std::remove_const_t<std::remove_reference_t<TensorT>>::layout_type{};
+    static_assert(rank(L) == 2);
+    static_assert(size<0>(L) == 32);
+    static_assert(size<1>(L) == 32);
+
+    static_assert(is_contiguous<0>(L) == 1 || is_contiguous<1>(L) == 1);
+    // row-major
+    constexpr bool is_col_major = is_contiguous<0>(L);
+
+    using TileShape = Shape<_16, _16, _16>;
+    auto mat_16x16_2x2 = flat_divide(std::forward<TensorT>(mat), select<0, 1>(TileShape{}));
+
+    using MMA = SM80_16x8x8_F32TF32TF32F32_TN;
+    using TiledMMA = decltype(make_tiled_mma(MMA{}, Layout<Shape<_1, _1>>{}, TileShape{}));
+
+    using CopyOpTF32 = AutoVectorizingCopyWithAssumedAlignment<128>;
+    using CopyOpD_S2R = CopyOpTF32;
+    using CopyOpC_S2R = CopyOpTF32;
+    using CopyOpA_S2R = CopyOpTF32;
+#ifdef CUTE_ARCH_STSM_SM90_ENABLED
+    using CopyOpO_R2S = CopyOpTF32;
+#else
+    using CopyOpO_R2S = UniversalCopy<ElementView, ElementView>;
+#endif
+
+    int lane_id = cutlass::canonical_lane_idx();
+    auto tiled_mma = TiledMMA{};
+    auto thr_mma = tiled_mma.get_thread_slice(lane_id);
+
+    auto D_tiled_copy = make_tiled_copy_A(Copy_Atom<CopyOpD_S2R, ElementView>{}, tiled_mma);
+    auto C_tiled_copy = make_tiled_copy_B(Copy_Atom<CopyOpC_S2R, ElementView>{}, tiled_mma);
+    auto A_tiled_copy = make_tiled_copy_B(Copy_Atom<CopyOpA_S2R, ElementView>{}, tiled_mma);
+    auto O_tiled_copy = make_tiled_copy_C(Copy_Atom<CopyOpO_R2S, ElementView>{}, tiled_mma);
+
+    auto D_thr_copy = D_tiled_copy.get_thread_slice(lane_id);
+    auto C_thr_copy = C_tiled_copy.get_thread_slice(lane_id);
+    auto A_thr_copy = A_tiled_copy.get_thread_slice(lane_id);
+    auto O_thr_copy = O_tiled_copy.get_thread_slice(lane_id);
+
+    Tensor sDinv = mat_16x16_2x2(_, _, _1{}, _1{});
+    Tensor sC = select_tensor<1, 0>(mat_16x16_2x2(_, _, _1{}, _0{}));
+    Tensor sAinv = select_tensor<1, 0>(mat_16x16_2x2(_, _, _0{}, _0{}));
+    Tensor sO = mat_16x16_2x2(_, _, _1{}, _0{});
+
+    Tensor tOrDinv = make_fragment_like<ElementView>(partition_shape_A(tiled_mma, select<0, 2>(TileShape{})));
+    Tensor tOrC = make_fragment_like<ElementView>(partition_shape_B(tiled_mma, select<1, 2>(TileShape{})));
+    Tensor tOrAinv = make_fragment_like<ElementView>(partition_shape_B(tiled_mma, select<1, 2>(TileShape{})));
+
+    Tensor tDCrDC = partition_fragment_C(tiled_mma, select<0, 1>(TileShape{}));  // output of -inv(D)C
+    Tensor tOrO = partition_fragment_C(tiled_mma, select<0, 1>(TileShape{}));    // output of -inv(D)C inv(A)
+
+    Tensor tOsDinv = D_thr_copy.partition_S(sDinv);
+    Tensor tOrDinv_cv = D_thr_copy.retile_D(tOrDinv);
+    Tensor tOsC = C_thr_copy.partition_S(sC);
+    Tensor tOrC_cv = C_thr_copy.retile_D(tOrC);
+    Tensor tOsAinv = A_thr_copy.partition_S(sAinv);
+    Tensor tOrAinv_cv = A_thr_copy.retile_D(tOrAinv);
+    Tensor tOsO = O_thr_copy.partition_D(sO);
+    Tensor tOrO_cv = O_thr_copy.retile_S(tOrO);
+
+    /////////////////////////////////////////////////////////////////////////////
+    // -inv(D)C
+    copy(D_tiled_copy, tOsDinv, tOrDinv_cv);
+    copy(C_tiled_copy, tOsC, tOrC_cv);
+
+    clear(tDCrDC);
+    auto tOrDinv_mma = [&]() {
+      if constexpr (!RoundingTF32) {
+        return recast<Element>(tOrDinv);
+      } else {
+        return tOrDinv;
+      }
+    }();
+    auto tOrC_mma = [&]() {
+      if constexpr (!RoundingTF32) {
+        return recast<Element>(tOrC);
+      } else {
+        return tOrC;
+      }
+    }();
+    gemm(tiled_mma, tOrDinv_mma, tOrC_mma, tDCrDC);
+    transform(tDCrDC, [](auto v) { return -v; });
+
+    /////////////////////////////////////////////////////////////////////////////
+    // -inv(D)C inv(A)
+    Tensor tOrDC = make_fragment_like<ElementView>(partition_shape_A(tiled_mma, Shape<_16, _16>{}));
+    // Tensor tOrDC = detail::SM80::make_acc_into_op<Element>(tDCrDC, tiled_mma);
+    detail::SM80::convert_fp32_acc_to_tf32_operandA_layout<2, RoundingTF32>(tDCrDC, tOrDC, tiled_mma, lane_id);
+    auto tOrDC_mma = [&]() {
+      if constexpr (!RoundingTF32) {
+        return recast<Element>(tOrDC);
+      } else {
+        return tOrDC;
+      }
+    }();
+
+    copy(A_tiled_copy, tOsAinv, tOrAinv_cv);
+    clear(tOrO);
+
+    auto tOrAinv_mma = [&]() {
+      if constexpr (!RoundingTF32) {
+        return recast<Element>(tOrAinv);
+      } else {
+        return tOrAinv;
+      }
+    }();
+    gemm(tiled_mma, tOrDC_mma, tOrAinv_mma, tOrO);
+
+    if constexpr (!RoundingTF32) {
+      // no need for conversion: MMA hardware truncates float→tf32
+      copy(O_tiled_copy, tOrO_cv, tOsO);
+    } else {
+      // Explicit rounding: convert float→tfloat32_t before store to SMEM
+      auto tOrO_cv_cvt = make_tensor_like<Element>(tOrO_cv);
+      transform(tOrO_cv, tOrO_cv_cvt, [](auto v) { return Element(v); });
+      copy(O_tiled_copy, tOrO_cv_cvt, tOsO);
+    }
+  }
+
+  template <typename TensorT>
+  CUTE_DEVICE void blockwise_diagonal_inversed_32x32_to_64x64(TensorT&& mat) {
+    constexpr auto L = typename std::remove_const_t<std::remove_reference_t<TensorT>>::layout_type{};
+    static_assert(rank(L) == 2);
+    static_assert(size<0>(L) == 64);
+    static_assert(size<1>(L) == 64);
+
+    static_assert(is_contiguous<0>(L) == 1 || is_contiguous<1>(L) == 1);
+    constexpr bool is_col_major = is_contiguous<0>(L);
+
+    auto mat_32x32_2x2 = flat_divide(std::forward<TensorT>(mat), select<0, 1>(Shape<_32, _32>{}));
+    auto mat_16x2X16x2_2x2 = logical_divide(mat_32x32_2x2, Shape<_16, _16>{});
+
+    using MMA = SM80_16x8x8_F32TF32TF32F32_TN;
+    using TiledMMA1 = decltype(make_tiled_mma(MMA{}, Layout<Shape<_1, _1>>{}, Shape<_16, _16, _32>{}));
+    using TiledMMA2 = decltype(make_tiled_mma(MMA{}, Layout<Shape<_1, _1>>{}, Shape<_16, _32, _16>{}));
+
+    using CopyOpTF32 = AutoVectorizingCopyWithAssumedAlignment<128>;
+    using CopyOpD_S2R = CopyOpTF32;
+    using CopyOpC_S2R = CopyOpTF32;
+    using CopyOpA_S2R = CopyOpTF32;
+    using CopyOpO_S2R = CopyOpTF32;
+#ifdef CUTE_ARCH_STSM_SM90_ENABLED
+    using CopyOpO_R2S = CopyOpTF32;
+#else
+    using CopyOpO_R2S = UniversalCopy<ElementView, ElementView>;
+#endif
+
+    int warp_id_in_wg =
+        cutlass::canonical_warp_idx() - cutlass::NumWarpsPerWarpGroup * cutlass::canonical_warp_group_idx();
+    int x = warp_id_in_wg / 2;
+    int y = warp_id_in_wg % 2;
+
+    int lane_id = cutlass::canonical_lane_idx();
+    auto tiled_mma1 = TiledMMA1{};
+    auto thr_mma1 = tiled_mma1.get_thread_slice(lane_id);
+
+    auto tiled_mma2 = TiledMMA2{};
+    auto thr_mma2 = tiled_mma2.get_thread_slice(lane_id);
+
+    auto D_tiled_copy = make_tiled_copy_A(Copy_Atom<CopyOpD_S2R, ElementView>{}, tiled_mma1);
+    auto C_tiled_copy = make_tiled_copy_B(Copy_Atom<CopyOpC_S2R, ElementView>{}, tiled_mma1);
+    auto A_tiled_copy = make_tiled_copy_B(Copy_Atom<CopyOpA_S2R, ElementView>{}, tiled_mma2);
+    auto O_tiled_s2r = make_tiled_copy_C(Copy_Atom<CopyOpO_S2R, ElementView>{}, tiled_mma2);
+    auto O_tiled_r2s = make_tiled_copy_C(Copy_Atom<CopyOpO_R2S, ElementView>{}, tiled_mma2);
+
+    auto D_thr_copy = D_tiled_copy.get_thread_slice(lane_id);
+    auto C_thr_copy = C_tiled_copy.get_thread_slice(lane_id);
+    auto A_thr_copy = A_tiled_copy.get_thread_slice(lane_id);
+    auto O_thr_s2r = O_tiled_s2r.get_thread_slice(lane_id);
+    auto O_thr_r2s = O_tiled_r2s.get_thread_slice(lane_id);
+
+    Tensor sDinv = mat_16x2X16x2_2x2(make_coord(_, y), _, _1{}, _1{});
+    Tensor sC = select_tensor<1, 0>(mat_16x2X16x2_2x2(_, make_coord(_, x), _1{}, _0{}));
+    Tensor sAinv = select_tensor<1, 0>(mat_16x2X16x2_2x2(make_coord(_, x), _, _0{}, _0{}));  // NOTE: not y!
+    Tensor sO = mat_16x2X16x2_2x2(make_coord(_, y), _, _1{}, _0{});  // needs cross-warp reduction
+
+    Tensor tOrDinv = make_fragment_like<ElementView>(partition_shape_A(tiled_mma1, Shape<_16, _32>{}));
+    Tensor tOrC = make_fragment_like<ElementView>(partition_shape_B(tiled_mma1, Shape<_16, _32>{}));
+    Tensor tOrAinv = make_fragment_like<ElementView>(partition_shape_B(tiled_mma2, Shape<_32, _16>{}));
+
+    Tensor tDCrDC = partition_fragment_C(tiled_mma1, Shape<_16, _16>{});  // output of -inv(D)C
+    Tensor tOrO = partition_fragment_C(tiled_mma2, Shape<_16, _32>{});    // output of -inv(D)C inv(A)
+
+    Tensor tOsDinv = D_thr_copy.partition_S(sDinv);
+    Tensor tOrDinv_cv = D_thr_copy.retile_D(tOrDinv);
+    Tensor tOsC = C_thr_copy.partition_S(sC);
+    Tensor tOrC_cv = C_thr_copy.retile_D(tOrC);
+    Tensor tOsAinv = A_thr_copy.partition_S(sAinv);
+    Tensor tOrAinv_cv = A_thr_copy.retile_D(tOrAinv);
+
+    /////////////////////////////////////////////////////////////////////////////
+    // -inv(D)C
+    copy(D_tiled_copy, tOsDinv, tOrDinv_cv);
+    copy(C_tiled_copy, tOsC, tOrC_cv);
+
+    clear(tDCrDC);
+    auto tOrDinv_mma = [&]() {
+      if constexpr (!RoundingTF32) {
+        return recast<Element>(tOrDinv);
+      } else {
+        return tOrDinv;
+      }
+    }();
+    auto tOrC_mma = [&]() {
+      if constexpr (!RoundingTF32) {
+        return recast<Element>(tOrC);
+      } else {
+        return tOrC;
+      }
+    }();
+    gemm(tiled_mma1, tOrDinv_mma, tOrC_mma, tDCrDC);
+    transform(tDCrDC, [](auto v) { return -v; });
+
+    /////////////////////////////////////////////////////////////////////////////
+    // -inv(D)C inv(A)
+    Tensor tOrDC = make_fragment_like<ElementView>(partition_shape_A(tiled_mma2, Shape<_16, _16>{}));
+    detail::SM80::convert_fp32_acc_to_tf32_operandA_layout<2, RoundingTF32>(tDCrDC, tOrDC, tiled_mma2, lane_id);
+    auto tOrDC_mma = [&]() {
+      if constexpr (!RoundingTF32) {
+        return recast<Element>(tOrDC);
+      } else {
+        return tOrDC;
+      }
+    }();
+
+    copy(A_tiled_copy, tOsAinv, tOrAinv_cv);
+    clear(tOrO);
+
+    auto tOrAinv_mma = [&]() {
+      if constexpr (!RoundingTF32) {
+        return recast<Element>(tOrAinv);
+      } else {
+        return tOrAinv;
+      }
+    }();
+    gemm(tiled_mma2, tOrDC_mma, tOrAinv_mma, tOrO);
+
+    auto tOrO_cvt = [&]() {
+      if constexpr (!RoundingTF32) {
+        return tOrO;
+      } else {
+        return make_tensor_like<Element>(tOrO);
+      }
+    }();
+    if constexpr (RoundingTF32) {
+      transform(tOrO, tOrO_cvt, [](auto v) { return Element(v); });
+    }
+
+    // ensure tOsC consumed, tOsC and tOsO are the same buffer
+    cutlass::arch::NamedBarrier::arrive_and_wait(cutlass::NumThreadsPerWarpGroup, wg_sync_named_barrier_id_);
+
+    Tensor tOsO = O_thr_r2s.partition_D(sO);
+    Tensor tOrO_cvt_cv = O_thr_r2s.retile_S(tOrO_cvt);
+    if (x == 0) {
+      copy(O_tiled_r2s, tOrO_cvt_cv, tOsO);
+    }
+    cutlass::arch::NamedBarrier::arrive_and_wait(cutlass::NumThreadsPerWarpGroup, wg_sync_named_barrier_id_);
+    if (x == 1) {
+      Tensor tOrO_red = make_tensor_like(tOrO_cvt);
+      Tensor tOsO_s = O_thr_s2r.partition_S(sO);
+      Tensor tOrO_red_cv = O_thr_s2r.retile_D(tOrO_red);
+      copy(O_tiled_s2r, tOsO_s, tOrO_red_cv);
+      transform(tOrO_cvt, tOrO_red, tOrO_cvt, [](auto a, auto b) { return a + b; });
+      copy(O_tiled_r2s, tOrO_cvt_cv, tOsO);
+    }
+  }
+
+ private:
+  int wg_sync_named_barrier_id_;
+};
+
+// Adapted from
+// https://github.com/flashinfer-ai/flashinfer/blob/main/include/flashinfer/flat/ampere/collective/flat_collective_inverse.hpp
+template <class Element, bool GarbageFilledDiagonal, bool GarbageFilledUpperTriangular>
+struct CollectiveInverse {
+  // FIXME: precision is not good due to half
+  static_assert(std::is_same_v<Element, half> || std::is_same_v<Element, cutlass::half_t>, "only half is implemented");
+
+  CUTE_DEVICE
+  CollectiveInverse(int wg_sync_named_barrier_id) : wg_sync_named_barrier_id_(wg_sync_named_barrier_id) {}
+
+  template <typename TensorT>
+  CUTE_DEVICE void compute(TensorT&& sT) {
+    constexpr auto L = typename std::remove_const_t<std::remove_reference_t<TensorT>>::layout_type{};
+    static_assert(rank(L) == 2);
+    static_assert(size<0>(L) == 64);
+    static_assert(size<1>(L) == 64);
+
+    int thread_idx = threadIdx.x % cutlass::NumThreadsPerWarpGroup;
+
+    auto t8X8sT = flat_divide(sT, Shape<_8, _8>{});
+    if (thread_idx < 64) {  // compute 8x8 inverse on diagnal directly
+      compute_diagonal_inverse_NxN<8>(t8X8sT(_, _, thread_idx / 8, thread_idx / 8), thread_idx % 8);
+    }
+
+    cutlass::arch::NamedBarrier::arrive_and_wait(cutlass::NumThreadsPerWarpGroup, wg_sync_named_barrier_id_);
+
+    auto t16X16sT = flat_divide(sT, Shape<_16, _16>{});
+    // four warps for 8x8 -> 16x16
+    blockwise_diagonal_inversed_8x8_to_16x16(t16X16sT(_, _, thread_idx / 32, thread_idx / 32));
+
+    cutlass::arch::NamedBarrier::arrive_and_wait(cutlass::NumThreadsPerWarpGroup, wg_sync_named_barrier_id_);
+
+    auto t32X32sT = flat_divide(sT, Shape<_32, _32>{});
+    if (thread_idx < 64) {  // two warps for 16x16 -> 32x32
+      blockwise_diagonal_inversed_16x16_to_32x32(t32X32sT(_, _, thread_idx / 32, thread_idx / 32));
+    }
+    cutlass::arch::NamedBarrier::arrive_and_wait(cutlass::NumThreadsPerWarpGroup, wg_sync_named_barrier_id_);
+
+    // one warpgroup for 32x32 -> 64x64
+    blockwise_diagonal_inversed_32x32_to_64x64(sT);
+  }
+
+ private:
+  template <int N, typename TensorT>
+  CUTE_DEVICE void compute_diagonal_inverse_NxN(TensorT&& mat, int tid_in_group) {  // group_size = N
+    constexpr auto L = typename std::remove_const_t<std::remove_reference_t<TensorT>>::layout_type{};
+    static_assert(rank(L) == 2);
+    static_assert(size<0>(L) == N);
+    static_assert(size<1>(L) == N);
+
+    using ElementCompute = float;
+
+    using CopyOp = Copy_Atom<AutoVectorizingCopyWithAssumedAlignment<sizeof(Element) * 8 * N>, Element>;
+
+    auto load_row = [&](int y) {
+      auto row = make_tensor<Element>(Shape<Int<N>>{});
+      copy(CopyOp{}, std::forward<TensorT>(mat)(y, _), row);
+
+      auto row_cvt = make_tensor_like<ElementCompute>(row);
+      copy(row, row_cvt);
+
+      if constexpr (GarbageFilledDiagonal || GarbageFilledUpperTriangular) {
+        CUTE_UNROLL
+        for (int i = 0; i < N; ++i) {
+          row_cvt(i) = i == y ? 1.0f : (i > y ? 0.0f : row_cvt(i));
+        }
+      }
+      return row_cvt;
+    };
+
+    auto store_row = [&](int y, auto row) {
+      auto row_cvt = make_tensor_like<Element>(row);
+      copy(row, row_cvt);
+      copy(CopyOp{}, row_cvt, std::forward<TensorT>(mat)(y, _));
+    };
+
+    auto row = load_row(tid_in_group);
+#define LOAD(y, x) __shfl_sync(0xffffffff, row(x), y, N)
+
+    CUTE_UNROLL
+    for (int src_row = 0; src_row < N - 1; ++src_row) {  // idx of src row to eliminate
+      auto row_scale = -row(src_row);                    // scale the src row
+      CUTE_UNROLL
+      for (int i = 0; i < src_row; ++i) {
+        auto src_row_value = LOAD(src_row, i);
+        row(i) = tid_in_group > src_row ? row_scale * src_row_value + row(i) : row(i);
+      }
+      row(src_row) = tid_in_group > src_row ? row_scale : row(src_row);
+    }
+
+#undef LOAD
+
+    store_row(tid_in_group, row);
+  }
+
+  /*
+  blockwise inverse has relation as follows
+  inv(| A 0 |)     = |          inv(A)       0  |
+      | C D |        | -inv(D)C inv(A)   inv(D) |
+  */
+
+  template <typename TensorT>
+  CUTE_DEVICE void blockwise_diagonal_inversed_4x4_to_8x8(TensorT&& mat) {
+    constexpr auto L = typename std::remove_const_t<std::remove_reference_t<TensorT>>::layout_type{};
+    static_assert(rank(L) == 2);
+    static_assert(size<0>(L) == 8);
+    static_assert(size<1>(L) == 8);
+    auto mat_NxN_2x2 = flat_divide(std::forward<TensorT>(mat), Shape<_4, _4>{});
+
+    // FIXME: implement
+  }
+
+  template <typename TensorT>
+  CUTE_DEVICE void blockwise_diagonal_inversed_8x8_to_16x16(TensorT&& mat) {
+    constexpr auto L = typename std::remove_const_t<std::remove_reference_t<TensorT>>::layout_type{};
+    static_assert(rank(L) == 2);
+    static_assert(size<0>(L) == 16);
+    static_assert(size<1>(L) == 16);
+
+    static_assert(is_contiguous<0>(L) == 1 || is_contiguous<1>(L) == 1);
+    constexpr bool is_col_major = is_contiguous<0>(L);
+
+    auto mat_8x8_2x2 = flat_divide(std::forward<TensorT>(mat), Shape<_8, _8>{});
+    using MMA = SM80_16x8x8_F32F16F16F32_TN;
+    using TiledMMA = decltype(make_tiled_mma(MMA{}, Layout<Shape<_1, _1>>{}, Shape<_16, _8, _8>{}));
+
+    using CopyOpD_S2R = std::conditional_t<is_col_major, SM75_U16x2_LDSM_T, SM75_U32x1_LDSM_N>;
+    using CopyOpC_S2R = std::conditional_t<is_col_major, SM75_U32x1_LDSM_N, SM75_U16x2_LDSM_T>;
+    using CopyOpA_S2R = std::conditional_t<is_col_major, SM75_U32x1_LDSM_N, SM75_U16x2_LDSM_T>;
+#ifdef CUTE_ARCH_STSM_SM90_ENABLED
+    using CopyOpO_R2S = std::conditional_t<is_col_major, SM90_U16x2_STSM_T, SM90_U32x1_STSM_N>;
+#else
+    using CopyOpO_R2S = UniversalCopy<Element, Element>;
+#endif
+
+    int lane_id = cutlass::canonical_lane_idx();
+    auto tiled_mma = TiledMMA{};
+    auto thr_mma = tiled_mma.get_thread_slice(lane_id);
+
+    auto D_tiled_copy = make_tiled_copy_A(Copy_Atom<CopyOpD_S2R, Element>{}, tiled_mma);
+    auto C_tiled_copy = make_tiled_copy_B(Copy_Atom<CopyOpC_S2R, Element>{}, tiled_mma);
+    auto A_tiled_copy = make_tiled_copy_B(Copy_Atom<CopyOpA_S2R, Element>{}, tiled_mma);
+    auto O_tiled_copy = make_tiled_copy_C(Copy_Atom<CopyOpO_R2S, Element>{}, tiled_mma);
+
+    auto D_thr_copy = D_tiled_copy.get_thread_slice(lane_id);
+    auto C_thr_copy = C_tiled_copy.get_thread_slice(lane_id);
+    auto A_thr_copy = A_tiled_copy.get_thread_slice(lane_id);
+    auto O_thr_copy = O_tiled_copy.get_thread_slice(lane_id);
+
+    Tensor sDinv = mat_8x8_2x2(_, _, _1{}, _1{});
+    Tensor sC = select_tensor<1, 0>(mat_8x8_2x2(_, _, _1{}, _0{}));
+    Tensor sAinv = select_tensor<1, 0>(mat_8x8_2x2(_, _, _0{}, _0{}));
+    Tensor sO = mat_8x8_2x2(_, _, _1{}, _0{});
+
+    Tensor sDinv_m_bcast = make_tensor(sDinv.data(), logical_product(sDinv.layout(), Tile<Layout<_2, _0>>{}));
+    Tensor sO_m_bcast = make_tensor(sO.data(), logical_product(sO.layout(), Tile<Layout<_2, _0>>{}));
+
+    Tensor tOrDinv = make_fragment_like<Element>(partition_shape_A(tiled_mma, Shape<_16, _8>{}));
+    Tensor tOrC = thr_mma.partition_fragment_B(sC);
+    Tensor tOrAinv = thr_mma.partition_fragment_B(sAinv);
+
+    Tensor tDCrDC = partition_fragment_C(tiled_mma, Shape<_16, _8>{});  // output of -inv(D)C
+    Tensor tOrO = partition_fragment_C(tiled_mma, Shape<_16, _8>{});    // output of -inv(D)C inv(A)
+
+    Tensor tOsDinv = D_thr_copy.partition_S(sDinv_m_bcast);
+    Tensor tOrDinv_cv = D_thr_copy.retile_D(tOrDinv);
+    Tensor tOsC = C_thr_copy.partition_S(sC);
+    Tensor tOrC_cv = C_thr_copy.retile_D(tOrC);
+    Tensor tOsAinv = A_thr_copy.partition_S(sAinv);
+    Tensor tOrAinv_cv = A_thr_copy.retile_D(tOrAinv);
+    Tensor tOsO = O_thr_copy.partition_D(sO_m_bcast);
+    Tensor tOrO_cv = O_thr_copy.retile_S(tOrO);
+
+    /////////////////////////////////////////////////////////////////////////////
+    // -inv(D)C
+    copy(D_tiled_copy, tOsDinv(make_coord(_, _0{}), _, _), tOrDinv_cv(make_coord(_, _0{}), _, _));
+    copy(C_tiled_copy, tOsC, tOrC_cv);
+
+    clear(tDCrDC);
+    gemm(tiled_mma, tOrDinv, tOrC, tDCrDC);
+    transform(tDCrDC(make_coord(_, _0{}), _, _), [](auto v) { return -v; });
+
+    /////////////////////////////////////////////////////////////////////////////
+    // -inv(D)C inv(A)
+    Tensor tOrDC = detail::SM80::make_acc_into_op<Element>(tDCrDC, tiled_mma);
+
+    copy(A_tiled_copy, tOsAinv, tOrAinv_cv);
+
+    clear(tOrO);
+    gemm(tiled_mma, tOrDC, tOrAinv, tOrO);
+
+    auto tOrO_cv_cvt = make_tensor_like<Element>(tOrO_cv(make_coord(_, _0{}), _, _));
+    transform(tOrO_cv(make_coord(_, _0{}), _, _), tOrO_cv_cvt, [](auto v) { return Element(v); });
+    copy(O_tiled_copy, tOrO_cv_cvt, tOsO(make_coord(_, _0{}), _, _));
+  }
+
+  template <typename TensorT>
+  CUTE_DEVICE void blockwise_diagonal_inversed_16x16_to_32x32(TensorT&& mat) {
+    constexpr auto L = typename std::remove_const_t<std::remove_reference_t<TensorT>>::layout_type{};
+    static_assert(rank(L) == 2);
+    static_assert(size<0>(L) == 32);
+    static_assert(size<1>(L) == 32);
+
+    static_assert(is_contiguous<0>(L) == 1 || is_contiguous<1>(L) == 1);
+    constexpr bool is_col_major = is_contiguous<0>(L);
+
+    using TileShape = Shape<_16, _16, _16>;
+    auto mat_16x16_2x2 = flat_divide(std::forward<TensorT>(mat), select<0, 1>(TileShape{}));
+
+    using MMA = SM80_16x8x16_F32F16F16F32_TN;
+    using TiledMMA = decltype(make_tiled_mma(MMA{}, Layout<Shape<_1, _1>>{}, TileShape{}));
+
+    using CopyOpD_S2R = std::conditional_t<is_col_major, SM75_U16x4_LDSM_T, SM75_U32x2_LDSM_N>;
+    using CopyOpC_S2R = std::conditional_t<is_col_major, SM75_U32x2_LDSM_N, SM75_U16x4_LDSM_T>;
+    using CopyOpA_S2R = std::conditional_t<is_col_major, SM75_U32x2_LDSM_N, SM75_U16x4_LDSM_T>;
+#ifdef CUTE_ARCH_STSM_SM90_ENABLED
+    using CopyOpO_R2S = std::conditional_t<is_col_major, SM90_U16x4_STSM_T, SM90_U32x2_STSM_N>;
+#else
+    using CopyOpO_R2S = UniversalCopy<Element, Element>;
+#endif
+
+    int lane_id = cutlass::canonical_lane_idx();
+    auto tiled_mma = TiledMMA{};
+    auto thr_mma = tiled_mma.get_thread_slice(lane_id);
+
+    auto D_tiled_copy = make_tiled_copy_A(Copy_Atom<CopyOpD_S2R, Element>{}, tiled_mma);
+    auto C_tiled_copy = make_tiled_copy_B(Copy_Atom<CopyOpC_S2R, Element>{}, tiled_mma);
+    auto A_tiled_copy = make_tiled_copy_B(Copy_Atom<CopyOpA_S2R, Element>{}, tiled_mma);
+    auto O_tiled_copy = make_tiled_copy_C(Copy_Atom<CopyOpO_R2S, Element>{}, tiled_mma);
+
+    auto D_thr_copy = D_tiled_copy.get_thread_slice(lane_id);
+    auto C_thr_copy = C_tiled_copy.get_thread_slice(lane_id);
+    auto A_thr_copy = A_tiled_copy.get_thread_slice(lane_id);
+    auto O_thr_copy = O_tiled_copy.get_thread_slice(lane_id);
+
+    Tensor sDinv = mat_16x16_2x2(_, _, _1{}, _1{});
+    Tensor sC = select_tensor<1, 0>(mat_16x16_2x2(_, _, _1{}, _0{}));
+    Tensor sAinv = select_tensor<1, 0>(mat_16x16_2x2(_, _, _0{}, _0{}));
+    Tensor sO = mat_16x16_2x2(_, _, _1{}, _0{});
+
+    Tensor tOrDinv = thr_mma.partition_fragment_A(sDinv);
+    Tensor tOrC = thr_mma.partition_fragment_B(sC);
+    Tensor tOrAinv = thr_mma.partition_fragment_B(sAinv);
+
+    Tensor tDCrDC = partition_fragment_C(tiled_mma, select<0, 1>(TileShape{}));  // output of -inv(D)C
+    Tensor tOrO = partition_fragment_C(tiled_mma, select<0, 1>(TileShape{}));    // output of -inv(D)C inv(A)
+
+    Tensor tOsDinv = D_thr_copy.partition_S(sDinv);
+    Tensor tOrDinv_cv = D_thr_copy.retile_D(tOrDinv);
+    Tensor tOsC = C_thr_copy.partition_S(sC);
+    Tensor tOrC_cv = C_thr_copy.retile_D(tOrC);
+    Tensor tOsAinv = A_thr_copy.partition_S(sAinv);
+    Tensor tOrAinv_cv = A_thr_copy.retile_D(tOrAinv);
+    Tensor tOsO = O_thr_copy.partition_D(sO);
+    Tensor tOrO_cv = O_thr_copy.retile_S(tOrO);
+
+    /////////////////////////////////////////////////////////////////////////////
+    // -inv(D)C
+    copy(D_tiled_copy, tOsDinv, tOrDinv_cv);
+    copy(C_tiled_copy, tOsC, tOrC_cv);
+
+    clear(tDCrDC);
+    gemm(tiled_mma, tOrDinv, tOrC, tDCrDC);
+    transform(tDCrDC, [](auto v) { return -v; });
+
+    /////////////////////////////////////////////////////////////////////////////
+    // -inv(D)C inv(A)
+    Tensor tOrDC = detail::SM80::make_acc_into_op<Element>(tDCrDC, tiled_mma);
+
+    copy(A_tiled_copy, tOsAinv, tOrAinv_cv);
+    clear(tOrO);
+    gemm(tiled_mma, tOrDC, tOrAinv, tOrO);
+
+    auto tOrO_cv_cvt = make_tensor_like<Element>(tOrO_cv);
+    transform(tOrO_cv, tOrO_cv_cvt, [](auto v) { return Element(v); });
+    copy(O_tiled_copy, tOrO_cv_cvt, tOsO);
+  }
+
+  template <typename TensorT>
+  CUTE_DEVICE void blockwise_diagonal_inversed_32x32_to_64x64(TensorT&& mat) {
+    constexpr auto L = typename std::remove_const_t<std::remove_reference_t<TensorT>>::layout_type{};
+    static_assert(rank(L) == 2);
+    static_assert(size<0>(L) == 64);
+    static_assert(size<1>(L) == 64);
+
+    static_assert(is_contiguous<0>(L) == 1 || is_contiguous<1>(L) == 1);
+    constexpr bool is_col_major = is_contiguous<0>(L);
+
+    auto mat_32x32_2x2 = flat_divide(std::forward<TensorT>(mat), select<0, 1>(Shape<_32, _32>{}));
+    auto mat_16x2X16x2_2x2 = logical_divide(mat_32x32_2x2, Shape<_16, _16>{});
+
+    using MMA = SM80_16x8x16_F32F16F16F32_TN;
+    using TiledMMA1 = decltype(make_tiled_mma(MMA{}, Layout<Shape<_1, _1>>{}, Shape<_16, _16, _32>{}));
+    using TiledMMA2 = decltype(make_tiled_mma(MMA{}, Layout<Shape<_1, _1>>{}, Shape<_16, _32, _16>{}));
+
+    using CopyOpD_S2R = std::conditional_t<is_col_major, SM75_U16x8_LDSM_T, SM75_U32x4_LDSM_N>;
+    using CopyOpC_S2R = std::conditional_t<is_col_major, SM75_U32x4_LDSM_N, SM75_U16x8_LDSM_T>;
+    using CopyOpA_S2R = std::conditional_t<is_col_major, SM75_U32x2_LDSM_N, SM75_U16x4_LDSM_T>;
+    using CopyOpO_S2R = std::conditional_t<is_col_major, SM75_U16x8_LDSM_T, SM75_U32x4_LDSM_N>;
+    using CopyOpO_S2R = std::conditional_t<is_col_major, SM75_U16x8_LDSM_T, SM75_U32x4_LDSM_N>;
+#ifdef CUTE_ARCH_STSM_SM90_ENABLED
+    using CopyOpO_R2S = std::conditional_t<is_col_major, SM90_U16x8_STSM_T, SM90_U32x4_STSM_N>;
+#else
+    using CopyOpO_R2S = UniversalCopy<Element, Element>;
+#endif
+
+    int warp_id_in_wg =
+        cutlass::canonical_warp_idx() - cutlass::NumWarpsPerWarpGroup * cutlass::canonical_warp_group_idx();
+    int x = warp_id_in_wg / 2;
+    int y = warp_id_in_wg % 2;
+
+    int lane_id = cutlass::canonical_lane_idx();
+    auto tiled_mma1 = TiledMMA1{};
+    auto thr_mma1 = tiled_mma1.get_thread_slice(lane_id);
+
+    auto tiled_mma2 = TiledMMA2{};
+    auto thr_mma2 = tiled_mma2.get_thread_slice(lane_id);
+
+    auto D_tiled_copy = make_tiled_copy_A(Copy_Atom<CopyOpD_S2R, Element>{}, tiled_mma1);
+    auto C_tiled_copy = make_tiled_copy_B(Copy_Atom<CopyOpC_S2R, Element>{}, tiled_mma1);
+    auto A_tiled_copy = make_tiled_copy_B(Copy_Atom<CopyOpA_S2R, Element>{}, tiled_mma2);
+    auto O_tiled_s2r = make_tiled_copy_C(Copy_Atom<CopyOpO_S2R, Element>{}, tiled_mma2);
+    auto O_tiled_r2s = make_tiled_copy_C(Copy_Atom<CopyOpO_R2S, Element>{}, tiled_mma2);
+
+    auto D_thr_copy = D_tiled_copy.get_thread_slice(lane_id);
+    auto C_thr_copy = C_tiled_copy.get_thread_slice(lane_id);
+    auto A_thr_copy = A_tiled_copy.get_thread_slice(lane_id);
+    auto O_thr_s2r = O_tiled_s2r.get_thread_slice(lane_id);
+    auto O_thr_r2s = O_tiled_r2s.get_thread_slice(lane_id);
+
+    Tensor sDinv = mat_16x2X16x2_2x2(make_coord(_, y), _, _1{}, _1{});
+    Tensor sC = select_tensor<1, 0>(mat_16x2X16x2_2x2(_, make_coord(_, x), _1{}, _0{}));
+    Tensor sAinv = select_tensor<1, 0>(mat_16x2X16x2_2x2(make_coord(_, x), _, _0{}, _0{}));  // NOTE: not y!
+    Tensor sO = mat_16x2X16x2_2x2(make_coord(_, y), _, _1{}, _0{});  // needs cross-warp reduction
+
+    Tensor tOrDinv = thr_mma1.partition_fragment_A(sDinv);
+    Tensor tOrC = thr_mma1.partition_fragment_B(sC);
+    Tensor tOrAinv = thr_mma2.partition_fragment_B(sAinv);
+
+    Tensor tDCrDC = partition_fragment_C(tiled_mma1, Shape<_16, _16>{});  // output of -inv(D)C
+    Tensor tOrO = partition_fragment_C(tiled_mma2, Shape<_16, _32>{});    // output of -inv(D)C inv(A)
+
+    Tensor tOsDinv = D_thr_copy.partition_S(sDinv);
+    Tensor tOrDinv_cv = D_thr_copy.retile_D(tOrDinv);
+    Tensor tOsC = C_thr_copy.partition_S(sC);
+    Tensor tOrC_cv = C_thr_copy.retile_D(tOrC);
+    Tensor tOsAinv = A_thr_copy.partition_S(sAinv);
+    Tensor tOrAinv_cv = A_thr_copy.retile_D(tOrAinv);
+
+    /////////////////////////////////////////////////////////////////////////////
+    // -inv(D)C
+    copy(D_tiled_copy, tOsDinv, tOrDinv_cv);
+    copy(C_tiled_copy, tOsC, tOrC_cv);
+
+    clear(tDCrDC);
+    gemm(tiled_mma1, tOrDinv, tOrC, tDCrDC);
+    transform(tDCrDC, [](auto v) { return -v; });
+
+    /////////////////////////////////////////////////////////////////////////////
+    // -inv(D)C inv(A)
+    Tensor tOrDC = detail::SM80::make_acc_into_op<Element>(tDCrDC, tiled_mma2);
+
+    copy(A_tiled_copy, tOsAinv, tOrAinv_cv);
+    clear(tOrO);
+    gemm(tiled_mma2, tOrDC, tOrAinv, tOrO);
+
+    auto tOrO_cvt = make_tensor_like<Element>(tOrO);
+    transform(tOrO, tOrO_cvt, [](auto v) { return Element(v); });
+
+    // ensure tOsC consumed, tOsC and tOsO are the same buffer
+    cutlass::arch::NamedBarrier::arrive_and_wait(cutlass::NumThreadsPerWarpGroup, wg_sync_named_barrier_id_);
+
+    Tensor tOsO = O_thr_r2s.partition_D(sO);
+    Tensor tOrO_cvt_cv = O_thr_r2s.retile_S(tOrO_cvt);
+    if (x == 0) {
+      copy(O_tiled_r2s, tOrO_cvt_cv, tOsO);
+    }
+    cutlass::arch::NamedBarrier::arrive_and_wait(cutlass::NumThreadsPerWarpGroup, wg_sync_named_barrier_id_);
+    if (x == 1) {
+      Tensor tOrO_red = make_tensor_like(tOrO_cvt);
+      Tensor tOsO_s = O_thr_s2r.partition_S(sO);
+      Tensor tOrO_red_cv = O_thr_s2r.retile_D(tOrO_red);
+      copy(O_tiled_s2r, tOsO_s, tOrO_red_cv);
+      transform(tOrO_cvt, tOrO_red, tOrO_cvt, [](auto a, auto b) { return a + b; });
+      copy(O_tiled_r2s, tOrO_cvt_cv, tOsO);
+    }
+  }
+
+ private:
+  int wg_sync_named_barrier_id_;
+};
+
+}  // namespace kerutils

--- a/sgl-kernel/csrc/kerutils/include/kerutils/device/sm80/helpers.cuh
+++ b/sgl-kernel/csrc/kerutils/include/kerutils/device/sm80/helpers.cuh
@@ -1,0 +1,154 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/******************************************************************************
+ * Copyright (c) 2024, Tri Dao.
+ ******************************************************************************/
+
+#pragma once
+
+#include <cute/tensor.hpp>
+
+#include "kerutils/device/common.h"
+
+namespace kerutils {
+
+// ============================================================
+// Global / shared memory store intrinsics
+// ============================================================
+
+CUTE_DEVICE
+void _store_256b(
+    uint32_t const& src0,
+    uint32_t const& src1,
+    uint32_t const& src2,
+    uint32_t const& src3,
+    uint32_t const& src4,
+    uint32_t const& src5,
+    uint32_t const& src6,
+    uint32_t const& src7,
+    void* gmem_addr) {
+  asm volatile(
+      "st.global.L1::no_allocate.v8.f32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};\n" ::"l"(gmem_addr),
+      "r"(src0),
+      "r"(src1),
+      "r"(src2),
+      "r"(src3),
+      "r"(src4),
+      "r"(src5),
+      "r"(src6),
+      "r"(src7));
+}
+
+// reference: https://github.com/NVIDIA/cutlass/blob/main/include/cute/arch/copy_sm100.hpp#L70
+CUTE_DEVICE
+void store_256b(void* src, void* dst) {
+  uint32_t* src_ptr = reinterpret_cast<uint32_t*>(src);
+  _store_256b(src_ptr[0], src_ptr[1], src_ptr[2], src_ptr[3], src_ptr[4], src_ptr[5], src_ptr[6], src_ptr[7], dst);
+}
+
+template <typename T>
+CUTE_DEVICE void store_128b(void* smem_ptr, const T& data) {
+  static_assert(sizeof(T) == 16);
+  *(__int128*)smem_ptr = *(__int128*)&data;
+}
+
+// Predicated copy helper (generic, works on SM80+)
+// Supports predication on both MN and K dimensions with optional OOB clearing.
+template <
+    bool Is_even_MN = true,
+    bool Is_even_K = true,
+    bool Clear_OOB_MN = false,
+    bool Clear_OOB_K = true,
+    class CopyAtom,
+    class TV,
+    class Tiler,
+    typename Engine0,
+    typename Layout0,
+    typename Engine1,
+    typename Layout1,
+    typename Engine2,
+    typename Layout2,
+    typename Engine3,
+    typename Layout3>
+CUTLASS_DEVICE void copy_pred(
+    cute::TiledCopy<CopyAtom, TV, Tiler> const& tiled_copy,
+    cute::Tensor<Engine0, Layout0> const& S,
+    cute::Tensor<Engine1, Layout1>& D,
+    cute::Tensor<Engine2, Layout2> const& identity_MN,
+    cute::Tensor<Engine3, Layout3> const& predicate_K,
+    const int max_MN = 0) {
+  using namespace cute;
+  // Decay TiledCopy to CopyAtom
+  auto copy_atom = static_cast<CopyAtom const&>(tiled_copy);
+  CUTE_STATIC_ASSERT_V(rank(S) == Int<3>{});
+  CUTE_STATIC_ASSERT_V(rank(D) == Int<3>{});
+  CUTE_STATIC_ASSERT_V(size<0>(S) == size<0>(D));  // MMA
+  CUTE_STATIC_ASSERT_V(size<1>(S) == size<1>(D));  // MMA_M
+  CUTE_STATIC_ASSERT_V(size<2>(S) == size<2>(D));  // MMA_K
+  // There's no case where !Clear_OOB_K && Clear_OOB_MN
+  static_assert(!(Clear_OOB_MN && !Clear_OOB_K));
+  auto has_with_bool =
+      cute::is_valid([](auto t) -> void_t<decltype(declval<typename decltype(t)::Traits>().with(true))> {}, copy_atom);
+#pragma unroll
+  for (int m = 0; m < size<1>(S); ++m) {
+    bool predicate_mn = Is_even_MN || get<0>(identity_MN(_0{}, m, _0{})) < max_MN;
+    // NOTE: currently only this predicate is true because we set Clear_OOB_MN=false
+    if constexpr (Is_even_MN || !Clear_OOB_MN) {
+      if (Is_even_MN || predicate_mn) {
+#pragma unroll
+        for (int k = 0; k < size<2>(S); ++k) {
+          if constexpr (Is_even_K || !Clear_OOB_K) {
+            if (Is_even_K || predicate_K(k)) {
+              cute::copy(copy_atom, S(_, m, k), D(_, m, k));
+            }
+          } else {  // Clear_OOB_K == true && Is_even_K == false
+            // If copy traits can be transformed with a predicate value, do it, otherwise branch here
+            if constexpr (has_with_bool) {
+              cute::copy(copy_atom.with(predicate_K(k)), S(_, m, k), D(_, m, k));
+            } else {
+              if (predicate_K(k)) {
+                cute::copy(copy_atom, S(_, m, k), D(_, m, k));
+              } else {
+                cute::clear(D(_, m, k));
+              }
+            }
+          }
+        }
+      }
+    } else {  // Clear_OOB_MN == true && Is_even_MN == false, also implies Clear_OOB_K == true
+      if constexpr (!has_with_bool) {
+        if (predicate_mn) {
+#pragma unroll
+          for (int k = 0; k < size<2>(S); ++k) {
+            if (Is_even_K || predicate_K(k)) {
+              cute::copy(copy_atom, S(_, m, k), D(_, m, k));
+            } else if (Clear_OOB_K) {
+              cute::clear(D(_, m, k));
+            }
+          }
+        } else {
+          cute::clear(D(_, m, _));
+        }
+      } else {  // combine the mn predicate with the k predicate
+#pragma unroll
+        for (int k = 0; k < size<2>(S); ++k) {
+          cute::copy(copy_atom.with(predicate_mn && (Is_even_K || predicate_K(k))), S(_, m, k), D(_, m, k));
+        }
+      }
+    }
+  }
+}
+
+}  // namespace kerutils

--- a/sgl-kernel/csrc/kerutils/include/kerutils/device/sm90/helpers.cuh
+++ b/sgl-kernel/csrc/kerutils/include/kerutils/device/sm90/helpers.cuh
@@ -1,0 +1,151 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Copyright (c) 2025 DeepSeek. All Rights Reserved.
+ *
+ * Licensed under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <cute/tensor.hpp>
+
+#include "kerutils/device/common.h"
+
+// Adapted from https://github.com/deepseek-ai/FlashMLA/blob/main/csrc/kerutils/include/kerutils/device/sm90/helpers.cuh
+namespace kerutils {
+
+// TMA copy helper with optional multicast support
+template <typename TMA, typename Tensor0, typename Tensor1>
+CUTE_DEVICE void launch_tma_copy(
+    const TMA& tma_copy,
+    Tensor0 src,
+    Tensor1 dst,
+    uint64_t& bar,
+    const cute::TMA::CacheHintSm90& cache_hint = cute::TMA::CacheHintSm90::EVICT_NORMAL,
+    const uint16_t& multicast_mask = 0) {
+  auto thr_tma = tma_copy.get_slice(cute::_0{});
+  cute::copy(tma_copy.with(bar, multicast_mask, cache_hint), thr_tma.partition_S(src), thr_tma.partition_D(dst));
+}
+
+// In the layout of fragment A and fragment C during WGMMA, data each thread holds resides in two particular rows. This
+// function converts the local_row_idx (0~2) to the actual row_idx You may refer to this link for the detailed layout:
+// https://docs.nvidia.com/cuda/parallel-thread-execution/#wgmma-64n16-a
+CUTE_DEVICE
+int get_AorC_row_idx(int local_row_idx, int idx_in_warpgroup) {
+  int row_idx = (idx_in_warpgroup / 32) * 16 + local_row_idx * 8 + (idx_in_warpgroup % 32 / 4);
+  return row_idx;
+}
+
+// In the layout of fragment A and fragment C during WGMMA, data each thread holds resides in some rows. This function
+// converts the local_elem_idx to the actual col_idx You may refer to this link for the detailed layout:
+// https://docs.nvidia.com/cuda/parallel-thread-execution/#wgmma-64n16-a
+CUTE_DEVICE
+int get_AorC_col_idx(int local_elem_idx, int idx_in_warpgroup) {
+  int col_idx = 8 * (local_elem_idx / 4) + (idx_in_warpgroup % 4) * 2 + (local_elem_idx & 1);
+  return col_idx;
+}
+
+template <bool commit = true, typename Tensor0, typename Tensor1, typename Tensor2, typename TiledMma>
+CUTE_DEVICE void wgmma(TiledMma& tiled_mma, Tensor0 const& tCrA, Tensor1 const& tCrB, Tensor2& tCrC, bool zero_init) {
+  using namespace cute;
+  constexpr bool Is_RS = !cute::is_base_of<cute::GMMA::DescriptorIterator, typename TiledMma::FrgTypeA>::value;
+  // Need to cast away const on tCrA since warpgroup_fence_operand doesn't take const
+  if constexpr (Is_RS) {
+    cute::warpgroup_fence_operand(const_cast<Tensor0&>(tCrA));
+  }
+  warpgroup_fence_operand(tCrC);
+  warpgroup_arrive();
+  tiled_mma.accumulate_ = zero_init ? GMMA::ScaleOut::Zero : GMMA::ScaleOut::One;
+  // Unroll the K mode manually to set scale D to 1
+  CUTLASS_PRAGMA_UNROLL
+  for (int k_block = 0; k_block < size<2>(tCrA); ++k_block) {
+    cute::gemm(tiled_mma, tCrA(_, _, k_block), tCrB(_, _, k_block), tCrC);
+    tiled_mma.accumulate_ = GMMA::ScaleOut::One;
+  }
+  if constexpr (commit) {
+    warpgroup_commit_batch();
+  }
+  warpgroup_fence_operand(tCrC);
+  if constexpr (Is_RS) {
+    warpgroup_fence_operand(const_cast<Tensor0&>(tCrA));
+  }
+}
+
+template <typename Tensor0, typename Tensor1, typename Tensor2, typename TiledMma>
+CUTE_DEVICE void wgmma_ss(
+    bool clear_accum,
+    TiledMma tiled_mma,
+    Tensor0 const& sA,
+    Tensor1 const& sB,
+    Tensor2& rC_frag,
+    int idx_in_warpgroup) {
+  using namespace cute;
+  ThrMMA thr_mma = tiled_mma.get_slice(idx_in_warpgroup);
+  Tensor sA_frag = thr_mma.partition_fragment_A(sA);
+  Tensor sB_frag = thr_mma.partition_fragment_B(sB);
+  static_assert(size<2>(sA_frag) == size<2>(sB_frag));
+
+  warpgroup_fence_operand(rC_frag);
+  warpgroup_arrive();
+  tiled_mma.accumulate_ = clear_accum ? GMMA::ScaleOut::Zero : GMMA::ScaleOut::One;
+  CUTLASS_PRAGMA_UNROLL
+  for (int k = 0; k < size<2>(sA_frag); ++k) {
+    cute::gemm(tiled_mma, sA_frag(_, _, k), sB_frag(_, _, k), rC_frag);
+    tiled_mma.accumulate_ = GMMA::ScaleOut::One;
+  }
+  warpgroup_fence_operand(rC_frag);
+}
+
+template <typename Tensor0, typename Tensor1, typename Tensor2, typename TiledMma>
+CUTE_DEVICE void wgmma_rs(
+    bool clear_accum, TiledMma tiled_mma, Tensor0 rA_frag, Tensor1 const& sB, Tensor2& rC_frag, int idx_in_warpgroup) {
+  using namespace cute;
+  ThrMMA thr_mma = tiled_mma.get_slice(idx_in_warpgroup);
+  Tensor sB_frag = thr_mma.partition_fragment_B(sB);
+  static_assert(size<2>(rA_frag) == size<2>(sB_frag));
+
+  warpgroup_fence_operand(const_cast<Tensor0&>(rA_frag));
+  warpgroup_fence_operand(rC_frag);
+  warpgroup_arrive();
+  tiled_mma.accumulate_ = clear_accum ? GMMA::ScaleOut::Zero : GMMA::ScaleOut::One;
+  CUTLASS_PRAGMA_UNROLL
+  for (int k = 0; k < size<2>(rA_frag); ++k) {
+    cute::gemm(tiled_mma, rA_frag(_, _, k), sB_frag(_, _, k), rC_frag);
+    tiled_mma.accumulate_ = GMMA::ScaleOut::One;
+  }
+  warpgroup_fence_operand(rC_frag);
+  warpgroup_fence_operand(const_cast<Tensor0&>(rA_frag));
+}
+
+}  // namespace kerutils

--- a/sgl-kernel/csrc/kerutils/include/kerutils/host/host.h
+++ b/sgl-kernel/csrc/kerutils/include/kerutils/host/host.h
@@ -1,0 +1,105 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Copyright (c) 2025 DeepSeek. All Rights Reserved.
+ *
+ * Licensed under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <cuda_runtime_api.h>
+
+#include <exception>
+#include <sstream>
+#include <string>
+
+#include "kerutils/common/common.h"
+
+namespace kerutils {
+
+class KUException final : public std::exception {
+  std::string message = {};
+
+ public:
+  template <typename... Args>
+  explicit KUException(const char* name, const char* file, const int line, Args&&... args) {
+    std::ostringstream oss;
+
+    oss << name << " error (" << file << ":" << line << "): ";
+    (oss << ... << args);
+    message = oss.str();
+  }
+
+  const char* what() const noexcept override {
+    return message.c_str();
+  }
+};
+
+#define THROW_KU_EXCEPTION(name, ...) throw kerutils::KUException(name, __FILE__, __LINE__, __VA_ARGS__)
+
+#define KU_CUDA_CHECK(call)                                                                         \
+  do {                                                                                              \
+    cudaError_t status_ = call;                                                                     \
+    if (status_ != cudaSuccess) {                                                                   \
+      fprintf(stderr, "CUDA error (%s:%d): %s\n", __FILE__, __LINE__, cudaGetErrorString(status_)); \
+      THROW_KU_EXCEPTION("CUDA", "CUDA error: ", cudaGetErrorString(status_));                      \
+    }                                                                                               \
+  } while (0)
+
+// This `KU_ASSERT` is triggered no matter if the code is compiled with `-DNDEBUG` or not.
+#define KU_ASSERT(cond, ...)                                                         \
+  do {                                                                               \
+    if (not(cond)) {                                                                 \
+      fprintf(stderr, "Assertion `%s` failed (%s:%d): ", #cond, __FILE__, __LINE__); \
+      if constexpr (sizeof(#__VA_ARGS__) > 1) {                                      \
+        fprintf(stderr, ", " __VA_ARGS__);                                           \
+      }                                                                              \
+      fprintf(stderr, "\n");                                                         \
+      THROW_KU_EXCEPTION("Assertion", "Assertion `", #cond, "` failed.");            \
+    }                                                                                \
+  } while (0)
+
+#define KU_CHECK_KERNEL_LAUNCH() KU_CUDA_CHECK(cudaGetLastError())
+
+template <typename T>
+inline __host__ __device__ constexpr T ceil_div(const T& a, const T& b) {
+  return (a + b - 1) / b;
+}
+
+template <typename T>
+inline __host__ __device__ constexpr T ceil(const T& a, const T& b) {
+  return (a + b - 1) / b * b;
+}
+
+}  // namespace kerutils

--- a/sgl-kernel/csrc/kerutils/include/kerutils/kerutils.cuh
+++ b/sgl-kernel/csrc/kerutils/include/kerutils/kerutils.cuh
@@ -1,0 +1,18 @@
+// Copyright 2025-2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "device/device.cuh"
+#include "host/host.h"

--- a/sgl-kernel/python/sgl_kernel/__init__.py
+++ b/sgl-kernel/python/sgl_kernel/__init__.py
@@ -108,6 +108,11 @@ from sgl_kernel.top_k import (
 )
 from sgl_kernel.version import __version__
 
+try:
+    from sgl_kernel.kda import kda_fwd_prefill
+except ImportError:
+    pass
+
 if torch.version.hip is not None:
     from sgl_kernel.elementwise import gelu_quick
 

--- a/sgl-kernel/python/sgl_kernel/kda.py
+++ b/sgl-kernel/python/sgl_kernel/kda.py
@@ -1,0 +1,55 @@
+from typing import Optional, Tuple
+
+import torch
+
+# Import triggers TORCH_LIBRARY_FRAGMENT registration for sgl_kernel ops
+from sgl_kernel import cula_kda_ops  # noqa: F401
+
+
+def kda_fwd_prefill(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    workspace_buffer: torch.Tensor,
+    scale: float,
+    safe_gate: bool = True,
+    output: Optional[torch.Tensor] = None,
+    output_state: Optional[torch.Tensor] = None,
+    input_state: Optional[torch.Tensor] = None,
+    alpha: Optional[torch.Tensor] = None,
+    beta: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """cuLA SM90 fully-fused KDA forward prefill kernel.
+
+    Args:
+        q: [packed_seq, H, K], bf16
+        k: [packed_seq, H, K], bf16
+        v: [packed_seq, H, V], bf16
+        cu_seqlens: [N+1], int32
+        workspace_buffer: [sm_count * 128], uint8
+        scale: attention scale factor
+        safe_gate: whether gate values are in safe range [-5, 0)
+        output: optional pre-allocated output [packed_seq, H, V], bf16
+        output_state: optional pre-allocated output state [N, H, K, V], fp32
+        input_state: optional input state [N, H, K, V], fp32
+        alpha: optional gate cumsum [packed_seq, H, K], fp32
+        beta: optional beta [packed_seq, H], fp32
+
+    Returns:
+        (output, output_state) tuple
+    """
+    return torch.ops.sgl_kernel.kda_fwd_prefill(
+        output,
+        output_state,
+        q,
+        k,
+        v,
+        input_state,
+        alpha,
+        beta,
+        cu_seqlens,
+        workspace_buffer,
+        scale,
+        safe_gate,
+    )

--- a/sgl-kernel/tests/test_kda_cula.py
+++ b/sgl-kernel/tests/test_kda_cula.py
@@ -1,0 +1,225 @@
+"""Unit tests for cuLA SM90 KDA prefill kernel.
+
+Compares cuLA kernel output against Triton chunk_kda reference.
+"""
+
+import pytest
+import torch
+
+# Skip all tests if not on SM90 GPU
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] != 9,
+    reason="cuLA KDA requires SM90 (Hopper) GPU",
+)
+
+
+def _try_import_cula():
+    try:
+        from sgl_kernel import kda_fwd_prefill
+
+        return kda_fwd_prefill
+    except ImportError:
+        pytest.skip("sgl_kernel.kda_fwd_prefill not available (cula_kda_ops not built)")
+
+
+def _try_import_triton_ref():
+    try:
+        from sglang.srt.layers.attention.fla.cumsum import chunk_local_cumsum
+        from sglang.srt.layers.attention.fla.kda import chunk_kda
+        from sglang.srt.layers.attention.fla.l2norm import l2norm_fwd
+
+        return chunk_kda, l2norm_fwd, chunk_local_cumsum
+    except ImportError:
+        pytest.skip("Triton reference (sglang) not available")
+
+
+def _make_cu_seqlens(batch_size, seq_len, device):
+    """Create uniform cu_seqlens for batch_size sequences of seq_len."""
+    seqlens = [seq_len] * batch_size
+    cu_seqlens = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    for i, l in enumerate(seqlens):
+        cu_seqlens[i + 1] = cu_seqlens[i] + l
+    return cu_seqlens
+
+
+def _run_cula_vs_triton(B, T, H, D, device="cuda"):
+    """Run cuLA and Triton KDA, compare outputs."""
+    kda_fwd_prefill = _try_import_cula()
+    chunk_kda, l2norm_fwd, chunk_local_cumsum = _try_import_triton_ref()
+
+    torch.manual_seed(42)
+    packed_seq = B * T
+
+    # Generate inputs in [1, packed_seq, H, D] format (SGLang convention)
+    q = torch.randn(1, packed_seq, H, D, dtype=torch.bfloat16, device=device)
+    k = torch.randn(1, packed_seq, H, D, dtype=torch.bfloat16, device=device)
+    v = torch.randn(1, packed_seq, H, D, dtype=torch.bfloat16, device=device)
+    # Gate values in safe range [-5, 0)
+    g = torch.rand(1, packed_seq, H, D, dtype=torch.bfloat16, device=device) * (-4.9)
+    beta = torch.randn(1, packed_seq, H, dtype=torch.bfloat16, device=device)
+
+    # Initial state in KV layout [N, H, K, V] for cuLA
+    initial_state_kv = (
+        torch.randn(B, H, D, D, dtype=torch.float32, device=device) * 0.01
+    )
+    # Same state in VK layout [N, H, V, K] for Triton
+    initial_state_vk = initial_state_kv.transpose(-1, -2).contiguous()
+
+    cu_seqlens = _make_cu_seqlens(B, T, device)
+
+    # --- Triton reference ---
+    triton_out = chunk_kda(
+        q=q.clone(),
+        k=k.clone(),
+        v=v.clone().contiguous(),
+        g=g.clone(),
+        beta=beta.clone(),
+        initial_state=initial_state_vk.clone(),
+        initial_state_indices=torch.arange(B, device=device),
+        use_qk_l2norm_in_kernel=True,
+        cu_seqlens=cu_seqlens.long(),
+    )
+
+    # --- cuLA kernel ---
+    # Preprocess: l2norm Q, K
+    q_norm = l2norm_fwd(q.clone().contiguous())
+    k_norm = l2norm_fwd(k.clone().contiguous())
+
+    # Gate cumsum
+    g_cum = chunk_local_cumsum(g.clone(), chunk_size=64, cu_seqlens=cu_seqlens.long())
+
+    # Reshape for C++ kernel: [packed_seq, H, D]
+    q_packed = q_norm.reshape(packed_seq, H, D).contiguous()
+    k_packed = k_norm.reshape(packed_seq, H, D).contiguous()
+    v_packed = v.reshape(packed_seq, H, D).contiguous()
+    g_packed = g_cum.reshape(packed_seq, H, D).contiguous()
+    beta_packed = beta.reshape(packed_seq, H).contiguous()
+
+    sm_count = torch.cuda.get_device_properties(device).multi_processor_count
+    workspace = torch.zeros(sm_count * 128, dtype=torch.uint8, device=device)
+
+    scale = D**-0.5
+
+    cula_output, cula_state = kda_fwd_prefill(
+        q=q_packed,
+        k=k_packed,
+        v=v_packed,
+        cu_seqlens=cu_seqlens,
+        workspace_buffer=workspace,
+        scale=scale,
+        safe_gate=True,
+        input_state=initial_state_kv.clone(),
+        alpha=g_packed,
+        beta=beta_packed,
+    )
+
+    # Reshape cuLA output back to [1, packed_seq, H, D]
+    cula_output = cula_output.reshape(1, packed_seq, H, D)
+
+    # Compare outputs
+    # Use relaxed tolerance for bf16 + fused kernel differences
+    atol = 5e-2
+    rtol = 5e-2
+    torch.testing.assert_close(cula_output, triton_out, atol=atol, rtol=rtol)
+
+
+@pytest.mark.parametrize(
+    "B,T,H,D",
+    [
+        (1, 63, 1, 128),
+        (2, 500, 3, 128),
+        (4, 1024, 4, 128),
+        (4, 2048, 8, 128),
+    ],
+)
+def test_cula_vs_triton(B, T, H, D):
+    _run_cula_vs_triton(B, T, H, D)
+
+
+def test_cula_varlen():
+    """Test with variable-length sequences."""
+    kda_fwd_prefill = _try_import_cula()
+
+    torch.manual_seed(42)
+    device = "cuda"
+    H, D = 4, 128
+    seqlens = [63, 128, 256]
+    B = len(seqlens)
+    packed_seq = sum(seqlens)
+
+    cu_seqlens = torch.zeros(B + 1, dtype=torch.int32, device=device)
+    for i, l in enumerate(seqlens):
+        cu_seqlens[i + 1] = cu_seqlens[i] + l
+
+    q = torch.randn(packed_seq, H, D, dtype=torch.bfloat16, device=device)
+    k = torch.randn(packed_seq, H, D, dtype=torch.bfloat16, device=device)
+    v = torch.randn(packed_seq, H, D, dtype=torch.bfloat16, device=device)
+    g = torch.rand(packed_seq, H, D, dtype=torch.float32, device=device) * (-4.9)
+    beta = torch.randn(packed_seq, H, dtype=torch.float32, device=device)
+    initial_state = torch.randn(B, H, D, D, dtype=torch.float32, device=device) * 0.01
+
+    sm_count = torch.cuda.get_device_properties(device).multi_processor_count
+    workspace = torch.zeros(sm_count * 128, dtype=torch.uint8, device=device)
+
+    scale = D**-0.5
+
+    output, output_state = kda_fwd_prefill(
+        q=q,
+        k=k,
+        v=v,
+        cu_seqlens=cu_seqlens,
+        workspace_buffer=workspace,
+        scale=scale,
+        safe_gate=True,
+        input_state=initial_state,
+        alpha=g,
+        beta=beta,
+    )
+
+    # Basic shape checks
+    assert output.shape == (packed_seq, H, D)
+    assert output_state.shape == (B, H, D, D)
+    assert not torch.isnan(output).any(), "Output contains NaN"
+    assert not torch.isinf(output).any(), "Output contains Inf"
+
+
+def test_cula_no_initial_state():
+    """Test without initial state (should allocate zeros internally)."""
+    kda_fwd_prefill = _try_import_cula()
+
+    torch.manual_seed(42)
+    device = "cuda"
+    B, T, H, D = 2, 256, 4, 128
+    packed_seq = B * T
+
+    cu_seqlens = _make_cu_seqlens(B, T, device)
+    q = torch.randn(packed_seq, H, D, dtype=torch.bfloat16, device=device)
+    k = torch.randn(packed_seq, H, D, dtype=torch.bfloat16, device=device)
+    v = torch.randn(packed_seq, H, D, dtype=torch.bfloat16, device=device)
+    g = torch.rand(packed_seq, H, D, dtype=torch.float32, device=device) * (-4.9)
+    beta = torch.randn(packed_seq, H, dtype=torch.float32, device=device)
+
+    sm_count = torch.cuda.get_device_properties(device).multi_processor_count
+    workspace = torch.zeros(sm_count * 128, dtype=torch.uint8, device=device)
+
+    scale = D**-0.5
+
+    output, output_state = kda_fwd_prefill(
+        q=q,
+        k=k,
+        v=v,
+        cu_seqlens=cu_seqlens,
+        workspace_buffer=workspace,
+        scale=scale,
+        safe_gate=True,
+        alpha=g,
+        beta=beta,
+    )
+
+    assert output.shape == (packed_seq, H, D)
+    assert output_state.shape == (B, H, D, D)
+    assert not torch.isnan(output).any(), "Output contains NaN"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/sgl-kernel/tests/test_kda_cula.py
+++ b/sgl-kernel/tests/test_kda_cula.py
@@ -3,8 +3,14 @@
 Compares cuLA kernel output against Triton chunk_kda reference.
 """
 
+import math
+
 import pytest
 import torch
+import torch.nn.functional as F
+
+# cuLA kernel uses exp2() internally, gates must be in log-base-2 space.
+RCP_LN2 = 1.0 / math.log(2.0)
 
 # Skip all tests if not on SM90 GPU
 pytestmark = pytest.mark.skipif(
@@ -54,9 +60,13 @@ def _run_cula_vs_triton(B, T, H, D, device="cuda"):
     q = torch.randn(1, packed_seq, H, D, dtype=torch.bfloat16, device=device)
     k = torch.randn(1, packed_seq, H, D, dtype=torch.bfloat16, device=device)
     v = torch.randn(1, packed_seq, H, D, dtype=torch.bfloat16, device=device)
-    # Gate values in safe range [-5, 0)
-    g = torch.rand(1, packed_seq, H, D, dtype=torch.bfloat16, device=device) * (-4.9)
-    beta = torch.randn(1, packed_seq, H, dtype=torch.bfloat16, device=device)
+    # Gate values: logsigmoid produces values in (-inf, 0), clamp to safe range [-5, 0]
+    g = F.logsigmoid(
+        torch.randn(1, packed_seq, H, D, dtype=torch.float32, device=device)
+    )
+    g = g.clamp(-5, 0).to(torch.bfloat16)
+    # Beta: sigmoid constrains to (0, 1) range (matches model behavior)
+    beta = torch.randn(1, packed_seq, H, dtype=torch.float32, device=device).sigmoid()
 
     # Initial state in KV layout [N, H, K, V] for cuLA
     initial_state_kv = (
@@ -68,6 +78,7 @@ def _run_cula_vs_triton(B, T, H, D, device="cuda"):
     cu_seqlens = _make_cu_seqlens(B, T, device)
 
     # --- Triton reference ---
+    # chunk_kda does its own cumsum internally (base-e, no scale)
     triton_out = chunk_kda(
         q=q.clone(),
         k=k.clone(),
@@ -85,8 +96,10 @@ def _run_cula_vs_triton(B, T, H, D, device="cuda"):
     q_norm = l2norm_fwd(q.clone().contiguous())
     k_norm = l2norm_fwd(k.clone().contiguous())
 
-    # Gate cumsum
-    g_cum = chunk_local_cumsum(g.clone(), chunk_size=64, cu_seqlens=cu_seqlens.long())
+    # Gate cumsum with RCP_LN2 scale (cuLA uses exp2 internally)
+    g_cum = chunk_local_cumsum(
+        g.clone(), chunk_size=64, scale=RCP_LN2, cu_seqlens=cu_seqlens.long()
+    )
 
     # Reshape for C++ kernel: [packed_seq, H, D]
     q_packed = q_norm.reshape(packed_seq, H, D).contiguous()
@@ -151,11 +164,20 @@ def test_cula_varlen():
     for i, l in enumerate(seqlens):
         cu_seqlens[i + 1] = cu_seqlens[i] + l
 
-    q = torch.randn(packed_seq, H, D, dtype=torch.bfloat16, device=device)
-    k = torch.randn(packed_seq, H, D, dtype=torch.bfloat16, device=device)
+    # L2-normalize Q, K (required for numerical stability, matches model usage)
+    q = F.normalize(
+        torch.randn(packed_seq, H, D, dtype=torch.float32, device=device), p=2, dim=-1
+    ).bfloat16()
+    k = F.normalize(
+        torch.randn(packed_seq, H, D, dtype=torch.float32, device=device), p=2, dim=-1
+    ).bfloat16()
     v = torch.randn(packed_seq, H, D, dtype=torch.bfloat16, device=device)
-    g = torch.rand(packed_seq, H, D, dtype=torch.float32, device=device) * (-4.9)
-    beta = torch.randn(packed_seq, H, dtype=torch.float32, device=device)
+    # Gate values in safe range [-5, 0) (pre-cumsum'd for direct kernel call)
+    g = F.logsigmoid(
+        torch.randn(packed_seq, H, D, dtype=torch.float32, device=device)
+    ).clamp(-5, 0)
+    # Beta must be in (0, 1) via sigmoid (matches model behavior)
+    beta = torch.randn(packed_seq, H, dtype=torch.float32, device=device).sigmoid()
     initial_state = torch.randn(B, H, D, D, dtype=torch.float32, device=device) * 0.01
 
     sm_count = torch.cuda.get_device_properties(device).multi_processor_count
@@ -193,11 +215,20 @@ def test_cula_no_initial_state():
     packed_seq = B * T
 
     cu_seqlens = _make_cu_seqlens(B, T, device)
-    q = torch.randn(packed_seq, H, D, dtype=torch.bfloat16, device=device)
-    k = torch.randn(packed_seq, H, D, dtype=torch.bfloat16, device=device)
+    # L2-normalize Q, K (required for numerical stability, matches model usage)
+    q = F.normalize(
+        torch.randn(packed_seq, H, D, dtype=torch.float32, device=device), p=2, dim=-1
+    ).bfloat16()
+    k = F.normalize(
+        torch.randn(packed_seq, H, D, dtype=torch.float32, device=device), p=2, dim=-1
+    ).bfloat16()
     v = torch.randn(packed_seq, H, D, dtype=torch.bfloat16, device=device)
-    g = torch.rand(packed_seq, H, D, dtype=torch.float32, device=device) * (-4.9)
-    beta = torch.randn(packed_seq, H, dtype=torch.float32, device=device)
+    # Gate values in safe range [-5, 0)
+    g = F.logsigmoid(
+        torch.randn(packed_seq, H, D, dtype=torch.float32, device=device)
+    ).clamp(-5, 0)
+    # Beta must be in (0, 1) via sigmoid
+    beta = torch.randn(packed_seq, H, dtype=torch.float32, device=device).sigmoid()
 
     sm_count = torch.cuda.get_device_properties(device).multi_processor_count
     workspace = torch.zeros(sm_count * 128, dtype=torch.uint8, device=device)

--- a/sgl-kernel/tests/test_kda_cula.py
+++ b/sgl-kernel/tests/test_kda_cula.py
@@ -68,12 +68,10 @@ def _run_cula_vs_triton(B, T, H, D, device="cuda"):
     # Beta: sigmoid constrains to (0, 1) range (matches model behavior)
     beta = torch.randn(1, packed_seq, H, dtype=torch.float32, device=device).sigmoid()
 
-    # Initial state in KV layout [N, H, K, V] for cuLA
-    initial_state_kv = (
+    # Initial state in VK layout [N, H, V, K] (SGLang convention, used by both paths)
+    initial_state_vk = (
         torch.randn(B, H, D, D, dtype=torch.float32, device=device) * 0.01
     )
-    # Same state in VK layout [N, H, V, K] for Triton
-    initial_state_vk = initial_state_kv.transpose(-1, -2).contiguous()
 
     cu_seqlens = _make_cu_seqlens(B, T, device)
 
@@ -121,7 +119,7 @@ def _run_cula_vs_triton(B, T, H, D, device="cuda"):
         workspace_buffer=workspace,
         scale=scale,
         safe_gate=True,
-        input_state=initial_state_kv.clone(),
+        input_state=initial_state_vk.clone(),
         alpha=g_packed,
         beta=beta_packed,
     )

--- a/test/srt/test_kda_cula_backend.py
+++ b/test/srt/test_kda_cula_backend.py
@@ -1,0 +1,66 @@
+"""Integration test for cuLA KDA prefill backend.
+
+Launches an SGLang server with --linear-attn-prefill-backend cula
+and verifies inference produces reasonable outputs.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+
+@unittest.skipIf(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] != 9,
+    "cuLA KDA backend requires SM90 (Hopper) GPU",
+)
+class TestKDACulaBackend(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = "moonshotai/Kimi-Linear-48B-A3B-Instruct"
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--tp-size",
+                "2",
+                "--trust-remote",
+                "--linear-attn-prefill-backend",
+                "cula",
+                "--linear-attn-decode-backend",
+                "triton",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="gsm8k",
+            api="completion",
+            max_tokens=512,
+            num_examples=200,
+            num_threads=128,
+        )
+        metrics = run_eval(args)
+        print(f"{metrics=}")
+        self.assertGreater(metrics["score"], 0.85)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

##   Summary

  Integrate the [cuLA](https://github.com/inclusionAI/cuLA/) SM90 fully-fused KDA (Kimi Delta Attention) prefill kernel into SGLang as a new cula backend option for --linear-attn-prefill-backend.

  cuLA provides a CUTLASS-based, TMA-accelerated, 4-warpgroup-specialized KDA prefill kernel targeting Hopper (SM90a) GPUs. This PR ports the kernel source into sgl-kernel, adds the Python integration layer, and wires it into SGLang's linear attention backend system.

  Note: cuLA only provides a KDA prefill kernel. It does not have a KDA decode kernel — the KDA decode operation requires per-element gating with delta-rule state updates (h += β·(k⊗v − k⊗(kᵀh))), which is fundamentally different from the simpler Lightning Attention decode (h = decay·h + k⊗v) that cuLA does support. When using --linear-attn-prefill-backend cula, decode automatically falls back to --linear-attn-decode-backend triton.

<!-- Describe the purpose and goals of this pull request. -->

## Architecture
```
  User flag: --linear-attn-prefill-backend cula --linear-attn-decode-backend triton
                          │                                    │
                          ▼                                    ▼
                KDAKernelDispatcher                  KDAKernelDispatcher
                ┌─────────────────┐                  ┌─────────────────┐
                │  extend_kernel  │                  │  decode_kernel  │
                │  = CulaKDAKernel│                  │  = TritonKDA    │
                └───────┬─────────┘                  └─────────────────┘
                        │
            ┌───────────┼───────────┐
            │ Guard 1   │ Guard 2   │ Guards pass?
            │ seq < 64? │ gate < -8?│
            ▼           ▼           ▼
       ┌─────────┐ ┌─────────┐ ┌──────────────────┐
       │ Triton  │ │ Triton  │ │ cuLA C++ kernel  │
       │fallback │ │fallback │ │ (kda_fwd_prefill)│
       └─────────┘ └─────────┘ └──────────────────┘
```

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

##   Test Plan

  - sgl-kernel/tests/test_kda_cula.py — 6 unit tests pass on SM90 (H100), comparing cuLA output against Triton chunk_kda reference with atol=5e-2, rtol=5e-2
  - test/srt/test_kda_cula_backend.py — End-to-end GSM8K eval (200 examples) with moonshotai/Kimi-Linear-48B-A3B-Instruct, TP=2, score = 0.875 (threshold > 0.85)

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
