### PR TITLE
Fix Python 3.11 f-string lint error in deepgemm Blackwell benchmark

### DIFF
--- a/benchmark/kernels/deepseek/benchmark_deepgemm_dsv3_router_gemm_blackwell.py
+++ b/benchmark/kernels/deepseek/benchmark_deepgemm_dsv3_router_gemm_blackwell.py
@@ -147,7 +147,7 @@ def get_benchmark_plot_friendly(tp_sizes):
             line_names=["SGLang", "Flashinfer"],
             styles=[("blue", "-"), ("red", "-")],
             ylabel="us",
-            plot_name=f"fp8-gemm-performance-comparison-tp-{"-".join(str(tp) for tp in tp_sizes)}",
+            plot_name=f"fp8-gemm-performance-comparison-tp-{'-'.join(str(tp) for tp in tp_sizes)}",
             args={},
         )
     )
@@ -176,7 +176,7 @@ def get_benchmark(tp_sizes):
             line_names=["SGLang", "Flashinfer"],
             styles=[("blue", "-"), ("red", "-")],
             ylabel="us",
-            plot_name=f"fp8-gemm-performance-comparison-tp-{"-".join(str(tp) for tp in tp_sizes)}",
+            plot_name=f"fp8-gemm-performance-comparison-tp-{'-'.join(str(tp) for tp in tp_sizes)}",
             args={},
         )
     )


### PR DESCRIPTION
## Summary
Fix two Python 3.11-incompatible f-strings in `benchmark/kernels/deepseek/benchmark_deepgemm_dsv3_router_gemm_blackwell.py`.

This is an isolated hotfix branch cut from `main`, independent of the current working branch.
The syntax issue was introduced by #17707 and caused `pre-commit` hooks like `check-ast` and `debug-statements` to fail under CPython 3.11.

## Validation
- `python3 -m py_compile benchmark/kernels/deepseek/benchmark_deepgemm_dsv3_router_gemm_blackwell.py`
- `pre-commit run --color=always --all-files`