### PR TITLE
fix: sync plan_stream before reading draft-dependent data in EAGLE v2

### DIFF
--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -1066,6 +1066,7 @@ class CudaGraphRunner:
         self,
         forward_batch: ForwardBatch,
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
+        plan_sync_event=None,
     ):
         buffers = self.buffers
         self.recapture_if_needed(forward_batch)
@@ -1086,6 +1087,13 @@ class CudaGraphRunner:
         else:
             index = bisect.bisect_left(self.capture_bs, raw_bs)
         bs = self.capture_bs[index]
+
+        # Wait for main_stream to finish writing draft-dependent data
+        # (draft_token, positions, tree_mask) before D2D copies read them.
+        if plan_sync_event is not None:
+            torch.get_device_module(self.device).current_stream().wait_event(
+                plan_sync_event
+            )
 
         buffers.populate_from_forward_batch(
             forward_batch=forward_batch,

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -216,6 +216,7 @@ class EagleVerifyInputV2Mixin:
         req_to_token_pool: ReqToTokenPool,
         batch: ModelWorkerBatch,
         target_worker: TpModelWorker,
+        plan_sync_event=None,
     ):
         if not batch.forward_mode.is_idle():
             # Assign cache locations
@@ -258,9 +259,16 @@ class EagleVerifyInputV2Mixin:
             and target_worker.model_runner.graph_runner.can_run(verify_forward_batch)
         )
         if can_run_cuda_graph:
-            target_worker.model_runner.graph_runner.replay_prepare(verify_forward_batch)
+            target_worker.model_runner.graph_runner.replay_prepare(
+                verify_forward_batch, plan_sync_event=plan_sync_event
+            )
         else:
             if not batch.forward_mode.is_idle():
+                # Wait for main_stream to finish writing draft-dependent data
+                if plan_sync_event is not None:
+                    torch.get_device_module(
+                        batch.input_ids.device
+                    ).current_stream().wait_event(plan_sync_event)
                 target_worker.model_runner.attn_backend.init_forward_metadata(
                     verify_forward_batch
                 )

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -752,13 +752,21 @@ class EAGLEWorkerV2(BaseSpecWorker):
         bs = len(batch.seq_lens)
 
         # Batch 1: Target verify
-        # Prepare for target verify in a separate stream
+        # Prepare for target verify in a separate stream.
+        # Record an event on main_stream so plan_stream can synchronize
+        # before reading draft-dependent data (draft_token, positions, etc.).
+        plan_sync_event = None
+        if self.plan_stream:
+            plan_sync_event = torch.get_device_module(self.device).Event()
+            plan_sync_event.record()
+
         with self.plan_stream_ctx:
             verify_forward_batch, can_run_cuda_graph = (
                 verify_input.prepare_for_v2_verify(
                     self.req_to_token_pool,
                     batch,
                     self.target_worker,
+                    plan_sync_event=plan_sync_event,
                 )
             )
 

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -678,13 +678,21 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
         bs = len(batch.seq_lens)
 
         # Batch 1: Target verify
-        # Prepare for target verify in a separate stream
+        # Prepare for target verify in a separate stream.
+        # Record an event on main_stream so plan_stream can synchronize
+        # before reading draft-dependent data (draft_token, positions, etc.).
+        plan_sync_event = None
+        if self.plan_stream:
+            plan_sync_event = torch.get_device_module(self.device).Event()
+            plan_sync_event.record()
+
         with self.plan_stream_ctx:
             verify_forward_batch, can_run_cuda_graph = (
                 verify_input.prepare_for_v2_verify(
                     self.req_to_token_pool,
                     batch,
                     self.target_worker,
+                    plan_sync_event=plan_sync_event,
                 )
             )
 


### PR DESCRIPTION
fix issue [#21942](https://github.com/sgl-project/sglang/issues/21942)
On AMD MI355X (gfx950) with 304 CUs across 8 XCDs, CUDA/HIP streams achieve true cross-stream kernel parallelism. This exposes a race condition in EAGLE v2 speculative decoding when plan_stream overlap is enabled (SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1):

  main_stream: build_tree_kernel_efficient WRITES draft_token, positions, tree_mask
  plan_stream: populate_from_forward_batch READS these tensors via D2D copies

Without explicit synchronization, plan_stream's D2D copies may read partially-written draft data, causing corrupted positions and eventual crashes in the attention kernel (_fused_qk_rope_cat_and_cache_mla_kernel).

Fix: Record a CUDA/HIP event on main_stream after draft completes, then wait on that event in plan_stream before populate_from_forward_batch() performs D2D copies of draft-dependent tensors. This preserves overlap for draft-independent Python-side preparation (ForwardBatch.init_new, padded bs calculation) while ensuring correctness for GPU operations.

Experimentally verified with 7 targeted sync experiments on MI355X+DP=8:
- No sync → CRASH
- Sync before populate → PASS
- Sync after populate → CRASH Confirming populate_from_forward_batch as the precise race location.

The CUDA/HIP specifications do not guarantee execution ordering across streams — this race condition exists on both platforms. It simply happens not to trigger on NVIDIA due to hardware scheduling characteristics, whereas the MI355X's distributed XCD architecture genuinely exposes it. This event synchronization is the specification-correct approach and should be added for NVIDIA as well (the performance impact is negligible).

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.956|±  |0.0056|
|     |       |strict-match    |     5|exact_match|↑  |0.956|±  |0.0056|

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
