### PR TITLE
fix(sgl-kernel): CUDA 13 cudaMemcpyBatchAsync API compatibility

### DIFF
--- a/sgl-kernel/csrc/kvcacheio/transfer.cu
+++ b/sgl-kernel/csrc/kvcacheio/transfer.cu
@@ -806,8 +806,21 @@ inline void transfer_kv_page_first_direct_impl(
   }
 
   // Symbol gate: runtime may not expose cudaMemcpyBatchAsync in some environments.
+  // CUDA 13.0 removed the failIdx parameter and added const qualifiers.
+#if CUDA_VERSION >= 13000
+  using CudaMemcpyBatchAsyncFn = cudaError_t (*)(
+      void* const*,
+      const void* const*,
+      const size_t*,
+      size_t,
+      struct cudaMemcpyAttributes*,
+      size_t*,
+      size_t,
+      cudaStream_t);
+#else
   using CudaMemcpyBatchAsyncFn =
       cudaError_t (*)(void**, void**, size_t*, size_t, cudaMemcpyAttributes*, size_t*, size_t, size_t*, cudaStream_t);
+#endif
   static CudaMemcpyBatchAsyncFn cuda_memcpy_batch_async = []() {
     void* symbol = dlsym(RTLD_DEFAULT, "cudaMemcpyBatchAsync");
     return reinterpret_cast<CudaMemcpyBatchAsyncFn>(symbol);
@@ -916,6 +929,10 @@ inline void transfer_kv_page_first_direct_impl(
 
   TORCH_CHECK(batch_srcs.size() == num_copies, "Batch memcpy count mismatch");
   if (num_copies > 0) {
+#if CUDA_VERSION >= 13000
+    cudaError_t err = cuda_memcpy_batch_async(
+        batch_dsts.data(), batch_srcs.data(), batch_sizes.data(), num_copies, &attrs, attrs_idxs.data(), 1, stream);
+#else
     size_t fail_idx = std::numeric_limits<size_t>::max();
     cudaError_t err = cuda_memcpy_batch_async(
         batch_dsts.data(),
@@ -927,12 +944,17 @@ inline void transfer_kv_page_first_direct_impl(
         1,
         &fail_idx,
         stream);
+#endif
     if (err == cudaErrorNotSupported || err == cudaErrorCallRequiresNewerDriver) {
       fallback_to_page_copy();
       return;
     }
     if (err != cudaSuccess) {
+#if CUDA_VERSION >= 13000
+      TORCH_CHECK(false, "cudaMemcpyBatchAsync failed. error=", cudaGetErrorString(err));
+#else
       TORCH_CHECK(false, "cudaMemcpyBatchAsync failed. failIdx=", fail_idx, " error=", cudaGetErrorString(err));
+#endif
     }
   }
 #endif


### PR DESCRIPTION
## Summary
- CUDA 13.0 removed the `failIdx` parameter from `cudaMemcpyBatchAsync` and added const qualifiers (see [CUDA 13.0 release notes](https://docs.nvidia.com/cuda/archive/13.0.0/cuda-toolkit-release-notes/index.html))
- The existing 9-argument typedef caused segfaults on CUDA 13 because the stream argument landed in the wrong register position when called via `dlsym`
- Add `#if CUDA_VERSION >= 13000` guards for the typedef, call site, and error reporting while preserving CUDA 12.x compatibility

Fixes #21869

## Test plan
- [ ] Verified `CUDA_VERSION == 13000` from `/usr/local/cuda/include/cuda.h` on DGX Spark
- [ ] Verified new typedef matches `cudaMemcpyBatchAsync` signature in `/usr/local/cuda/include/cuda_runtime_api.h`
- [ ] Existing `sgl-kernel/tests/test_kvcacheio.py` covers runtime behavior
- [ ] Pre-commit (clang-format) passes

**Hardware:** DGX Spark (GB10, sm_121a, CUDA 13.0.88, Driver 580.142)