### PR TITLE
fix: GPTQ Marlin MoE scale dtype should use params_dtype

### DIFF
--- a/python/sglang/srt/layers/quantization/gptq.py
+++ b/python/sglang/srt/layers/quantization/gptq.py
@@ -1353,7 +1353,7 @@ class GPTQMarlinMoEMethod(FusedMoEMethodBase):
                 num_experts,
                 scales_size13,
                 2 * intermediate_size_per_partition,
-                dtype=torch.half,
+                dtype=params_dtype,
             ),
             requires_grad=False,
         )
@@ -1361,7 +1361,7 @@ class GPTQMarlinMoEMethod(FusedMoEMethodBase):
         set_weight_attrs(w13_scales, extra_weight_attrs)
         # down_proj scales
         w2_scales = torch.nn.Parameter(
-            torch.empty(num_experts, scales_size2, hidden_size, dtype=torch.half),
+            torch.empty(num_experts, scales_size2, hidden_size, dtype=params_dtype),
             requires_grad=False,
         )
         layer.register_parameter("w2_scales", w2_scales)

--- a/test/registered/quant/test_marlin_moe.py
+++ b/test/registered/quant/test_marlin_moe.py
@@ -436,6 +436,56 @@ class TestFusedMarlinMoe(CustomTestCase):
                         marlin_output, torch_output, atol=5e-2, rtol=0
                     )
 
+    def test_gptq_marlin_moe_scale_dtype_matches_params(self):
+        """Regression test: GPTQMarlinMoEMethod must allocate scales in params_dtype.
+
+        Previously, scales were hardcoded as torch.half regardless of params_dtype,
+        causing AssertionError when running GPTQ MoE models with --dtype bfloat16.
+        See https://github.com/sgl-project/sglang/issues/20599
+        """
+        from sglang.srt.layers.quantization.gptq import (
+            GPTQMarlinConfig,
+            GPTQMarlinMoEMethod,
+        )
+
+        for params_dtype in [torch.float16, torch.bfloat16]:
+            with self.subTest(params_dtype=params_dtype):
+                config = GPTQMarlinConfig(
+                    weight_bits=4,
+                    group_size=128,
+                    desc_act=False,
+                    is_sym=True,
+                    lm_head_quantized=False,
+                    dynamic={},
+                    full_config={},
+                )
+                method = GPTQMarlinMoEMethod(config)
+
+                layer = torch.nn.Module()
+                layer.moe_tp_size = 1
+                layer.intermediate_size_per_partition = 128
+                layer.group_size_div_factor = 1
+
+                method.create_weights(
+                    layer=layer,
+                    num_experts=4,
+                    hidden_size=256,
+                    intermediate_size_per_partition=128,
+                    params_dtype=params_dtype,
+                    weight_loader=lambda *a, **kw: None,
+                )
+
+                self.assertEqual(
+                    layer.w13_scales.dtype,
+                    params_dtype,
+                    f"w13_scales should be {params_dtype} but got {layer.w13_scales.dtype}",
+                )
+                self.assertEqual(
+                    layer.w2_scales.dtype,
+                    params_dtype,
+                    f"w2_scales should be {params_dtype} but got {layer.w2_scales.dtype}",
+                )
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- `GPTQMarlinMoEMethod.create_weights()` hardcoded `w13_scales` and `w2_scales` as `dtype=torch.half`, ignoring `params_dtype`
- When running GPTQ MoE models with `--dtype bfloat16`, this caused: `AssertionError: moe_wna16_marlin_gemm assumes hidden_states.dtype (torch.bfloat16) == w1_scale.dtype (torch.float16)`
- Fix: use `params_dtype` for scale allocation, consistent with `MoeWNA16Method` and the `qzeros` allocation in the same function

Fixes #20599

## Test plan
- [ ] Added `test_gptq_marlin_moe_scale_dtype_matches_params` — directly exercises `create_weights()` with both fp16 and bf16 `params_dtype`, asserts scale tensors match
- [ ] All 3 tests in `test_marlin_moe.py` pass (289s on DGX Spark)
- [ ] Reproduced original bug: Qwen3.5-35B-A3B-GPTQ-Int4 with `--dtype bfloat16` crashes with assertion error (unpatched)
- [ ] Verified fix: same model starts successfully and generates correct output at 415 tok/s aggregate (24 concurrent)
- [ ] Pre-commit (black, isort, ruff) passes

**Hardware:** DGX Spark (GB10, sm_121a, CUDA 13.0.88, Driver 580.142)
**Model:** Qwen/Qwen3.5-35B-A3B-GPTQ-Int4 with `--dtype bfloat16`