### PR TITLE
Remove flaky TestToolChoiceLfm2Moe from test_tool_choice

### DIFF
--- a/test/registered/openai_server/function_call/test_tool_choice.py
+++ b/test/registered/openai_server/function_call/test_tool_choice.py
@@ -888,33 +888,5 @@ class TestToolChoiceLfm2(TestToolChoiceLlama32):
         cls.tokenizer = get_tokenizer(cls.model)
 
 
-class TestToolChoiceLfm2Moe(TestToolChoiceLlama32):
-    """Test tool_choice functionality with LiquidAI LFM2-MoE model"""
-
-    @classmethod
-    def setUpClass(cls):
-        cls.flaky_tests = {
-            "test_multi_tool_scenario_auto",
-            "test_multi_tool_scenario_required",
-        }
-
-        cls.model = "LiquidAI/LFM2-8B-A1B"
-        cls.base_url = DEFAULT_URL_FOR_TEST
-        cls.api_key = "sk-123456"
-
-        cls.process = popen_launch_server(
-            cls.model,
-            cls.base_url,
-            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            api_key=cls.api_key,
-            other_args=[
-                "--tool-call-parser",
-                "lfm2",
-            ],
-        )
-        cls.base_url += "/v1"
-        cls.tokenizer = get_tokenizer(cls.model)
-
-
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Remove `TestToolChoiceLfm2Moe` from `test_tool_choice.py`.

`LiquidAI/LFM2-8B-A1B` is unreliable for tool calling — `test_tool_choice_specific_function_non_streaming` flakes on it regularly (e.g. https://github.com/sgl-project/sglang/actions/runs/23984641093/job/69954483711).

This class uses the same `lfm2` parser and identical test methods/flaky_tests config as `TestToolChoiceLfm2` (LFM2.5-1.2B-Instruct), so they hit the same server-side code paths. The lfm2 parser logic is also independently covered by unit tests in `test_function_call_parser.py`. No coverage is lost.

## Test plan
- [ ] CI passes without the removed test class