### PR TITLE
Add failfast flag to rerun-test workflow

### DIFF
--- a/.github/workflows/rerun-test.yml
+++ b/.github/workflows/rerun-test.yml
@@ -87,7 +87,7 @@ jobs:
           echo "${{ inputs.test_command }}" | while IFS= read -r cmd; do
             [ -z "$cmd" ] && continue
             echo ">>> Running: python3 $cmd"
-            python3 $cmd || exit 1
+            python3 $cmd -f || exit 1
           done
 
       - uses: ./.github/actions/upload-cuda-coredumps
@@ -132,5 +132,5 @@ jobs:
           echo "${{ inputs.test_command }}" | while IFS= read -r cmd; do
             [ -z "$cmd" ] && continue
             echo ">>> Running: python3 $cmd"
-            python3 $cmd || exit 1
+            python3 $cmd -f || exit 1
           done


### PR DESCRIPTION
## Summary
- Add `-f` (unittest `--failfast`) to `python3 $cmd` in `rerun-test.yml` for both CUDA and CPU jobs
- Without this, a `setUpClass` failure (e.g. OOM during model load) only skips that class's tests — unittest continues running subsequent test classes, wasting GPU time on a broken runner

`run_suite.py` already passes `-f` (see `ci_utils.py:163`), but `/rerun-test` bypasses `run_suite.py` and runs files directly.

## Test plan
- [x] Change is 2 lines in a YAML workflow — no runtime code affected