### PR TITLE
Add dump_metric to MMMU, lm-eval, and NeMo Skills eval paths

### DIFF
--- a/python/sglang/test/accuracy_test_runner.py
+++ b/python/sglang/test/accuracy_test_runner.py
@@ -8,6 +8,7 @@ from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
     ModelLaunchSettings,
+    dump_metric,
     popen_launch_server,
     write_github_step_summary,
 )
@@ -420,6 +421,12 @@ def _run_nemo_skills_eval(
 
         if score is None:
             return False, "Could not parse accuracy from ns eval output", None
+
+        dump_metric(
+            f"{dataset}_score",
+            score,
+            labels={"model": model.model_path, "eval": dataset, "api": "nemo-skills"},
+        )
 
         return True, None, {"score": score}
 

--- a/python/sglang/test/kits/lm_eval_kit.py
+++ b/python/sglang/test/kits/lm_eval_kit.py
@@ -12,6 +12,8 @@ import numpy as np
 import requests
 import yaml
 
+from sglang.test.test_utils import dump_metric
+
 
 @contextmanager
 def scoped_env_vars(new_env: dict[str, str] | None):
@@ -68,6 +70,15 @@ class LMEvalMixin:
                     f"{task['name']} | {metric['name']}: "
                     f"ground_truth={ground_truth:.3f} | "
                     f"measured={measured_value:.3f} | rtol={rtol}"
+                )
+                dump_metric(
+                    f"{task['name']}_{metric['name']}",
+                    measured_value,
+                    labels={
+                        "model": eval_config.get("model_name", ""),
+                        "eval": "lm-eval",
+                        "task": task["name"],
+                    },
                 )
                 success = success and np.isclose(
                     ground_truth, measured_value, rtol=rtol

--- a/python/sglang/test/kits/mmmu_vlm_kit.py
+++ b/python/sglang/test/kits/mmmu_vlm_kit.py
@@ -13,6 +13,7 @@ from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
+    dump_metric,
     popen_launch_server,
 )
 
@@ -216,6 +217,12 @@ class MMMUMixin:
             mmmu_accuracy = result["results"]["mmmu_val"]["mmmu_acc,none"]
             print(f"Model {self.model} achieved accuracy: {mmmu_accuracy:.4f}")
 
+            dump_metric(
+                "mmmu_score",
+                mmmu_accuracy,
+                labels={"model": self.model, "eval": "mmmu", "api": "lmms-eval"},
+            )
+
             # Assert performance meets expected threshold
             self.assertGreaterEqual(
                 mmmu_accuracy,
@@ -401,6 +408,12 @@ class MMMUMultiModelTestBase(CustomTestCase):
             mmmu_accuracy = result["results"]["mmmu_val"]["mmmu_acc,none"]
             print(
                 f"Model {model.model} achieved accuracy{test_name}: {mmmu_accuracy:.4f}"
+            )
+
+            dump_metric(
+                "mmmu_score",
+                mmmu_accuracy,
+                labels={"model": model.model, "eval": "mmmu", "api": "lmms-eval"},
             )
 
             # Capture server output if requested


### PR DESCRIPTION
## Summary

- Add `dump_metric` calls to three eval paths that were missing them: MMMU (lmms-eval), lm-eval harness, and NeMo Skills (mmmu-pro)
- All eval paths through `run_eval.py` already had `dump_metric`; this covers the remaining ones
- `dump_metric` is silent on failure — no risk to existing tests

This is Phase 2 of the eval unification plan started in #21667 (Phase 1: GSM8K unification). The goal is to ensure all eval paths emit `dump_metric` output, laying the groundwork for regression detection infrastructure in future phases.

## Changes

| File | What |
|------|------|
| `kits/mmmu_vlm_kit.py` | `MMMUMixin.test_mmmu` + `MMMUMultiModelTestBase._run_vlm_mmmu_test` |
| `kits/lm_eval_kit.py` | `LMEvalMixin.test_lm_eval` per task/metric |
| `accuracy_test_runner.py` | `_run_nemo_skills_eval` after score parsing |

## Test plan

- [ ] CI passes (no functional change — dump_metric is additive and silent-fail)