### PR TITLE
[CI] No diffusers backend in lora case

### DIFF
--- a/python/sglang/multimodal_gen/test/server/test_server_common.py
+++ b/python/sglang/multimodal_gen/test/server/test_server_common.py
@@ -43,6 +43,10 @@ from sglang.multimodal_gen.test.test_utils import (
 logger = init_logger(__name__)
 
 
+def _is_lora_case(case: DiffusionTestCase) -> bool:
+    return bool(case.server_args.lora_path or case.server_args.dynamic_lora_path)
+
+
 @pytest.fixture
 def diffusion_server(case: DiffusionTestCase) -> ServerContext:
     """Start a diffusion server for a single case and tear it down afterwards."""
@@ -65,9 +69,9 @@ def diffusion_server(case: DiffusionTestCase) -> ServerContext:
     sampling_params = case.sampling_params
     extra_args = os.environ.get("SGLANG_TEST_SERVE_ARGS", "")
 
-    # In GT generation mode, force --backend diffusers
+    # Keep LoRA GT on the normal backend path so adapter state matches CI.
     if os.environ.get("SGLANG_GEN_GT", "0") == "1":
-        if "--backend" not in extra_args:
+        if not _is_lora_case(case) and "--backend" not in extra_args:
             extra_args = "--backend diffusers " + extra_args.strip()
 
     extra_args += f" --num-gpus {server_args.num_gpus}"
@@ -853,9 +857,8 @@ Consider updating perf_baselines.json with the snippets below:
         # Check if we're in GT generation mode
         is_gt_gen_mode = os.environ.get("SGLANG_GEN_GT", "0") == "1"
 
-        # Dynamic LoRA loading test - tests LayerwiseOffload + set_lora interaction
-        # Server starts WITHOUT lora_path, then set_lora is called after startup
-        if case.run_lora_dynamic_load_check and not is_gt_gen_mode:
+        # GT generation also needs the dynamic set_lora step before generation.
+        if case.run_lora_dynamic_load_check:
             self._test_dynamic_lora_loading(diffusion_server, case)
 
         generate_fn = get_generate_fn(

--- a/python/sglang/multimodal_gen/test/server/test_server_common.py
+++ b/python/sglang/multimodal_gen/test/server/test_server_common.py
@@ -44,7 +44,11 @@ logger = init_logger(__name__)
 
 
 def _is_lora_case(case: DiffusionTestCase) -> bool:
-    return bool(case.server_args.lora_path or case.server_args.dynamic_lora_path)
+    return bool(
+        case.server_args.lora_path
+        or case.server_args.dynamic_lora_path
+        or case.server_args.second_lora_path
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
## Motivation

Ground-truth generation for diffusion CI was inconsistent with normal CI inference for LoRA cases.

In GT mode, tests force `--backend diffusers`, but LoRA cases rely on the native SGLang LoRA path. For dynamic LoRA cases, GT mode also skipped the pre-generation `set_lora` step. This caused GT outputs for LoRA cases to be generated under a different execution path than the one used in normal CI.

## Modifications

- Added a unified LoRA-case check in `test_server_common.py`.
- Kept the existing GT behavior for non-LoRA cases: still force `--backend diffusers`.
- Excluded LoRA cases from the GT forced-diffusers path so they follow the normal backend path used by CI.
- Restored dynamic LoRA loading during GT generation by allowing the pre-generation `set_lora` step to run in GT mode.

This fixes both:
- startup LoRA GT mismatch
- dynamic LoRA GT mismatch


These checks verify that LoRA GT generation now follows the intended LoRA-enabled inference path.

## Speed Tests and Profiling

N/A. This change only affects diffusion CI GT generation control flow for LoRA cases and does not modify model forward/kernel execution.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).