### PR TITLE
[Fix] Fix setuptools-scm version resolution for rc tags

### DIFF
--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -510,7 +510,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GPU_CONFIG: "1-gpu-h100"
 
-        timeout-minutes: 60
+        timeout-minutes: 90
         run: |
           cd python
           python3 sglang/multimodal_gen/test/run_suite.py \
@@ -568,7 +568,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GPU_CONFIG: "2-gpu-h100"
 
-        timeout-minutes: 60
+        timeout-minutes: 90
         run: |
           cd python
           python3 sglang/multimodal_gen/test/run_suite.py \

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -197,6 +197,6 @@ exclude = [
 [tool.setuptools_scm]
 root = ".."
 version_file = "sglang/_version.py"
-git_describe_command = ["bash", "-c", "git tag --list --sort=-version:refname 'v*.*.*' | head -1 | xargs git describe --tags --long"]
+git_describe_command = ["python3", "python/tools/get_version_tag.py"]
 # Allow editable installs even when .git metadata is not available.
 fallback_version = "0.0.0.dev0"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -138,6 +138,7 @@ test = [
   "matplotlib",
   "pandas",
   "parameterized",
+  "polars",
   "peft>=0.18.0",
   "pytest",
   "pytest-cov",

--- a/python/pyproject_xpu.toml
+++ b/python/pyproject_xpu.toml
@@ -134,6 +134,6 @@ exclude = [
 [tool.setuptools_scm]
 root = ".."
 version_file = "sglang/_version.py"
-git_describe_command = ["bash", "-c", "git tag --list --sort=-version:refname 'v*.*.*' | head -1 | xargs git describe --tags --long"]
+git_describe_command = ["python3", "python/tools/get_version_tag.py"]
 # Allow editable installs even when .git metadata is not available.
 fallback_version = "0.0.0.dev0"

--- a/python/sglang/multimodal_gen/test/slack_utils.py
+++ b/python/sglang/multimodal_gen/test/slack_utils.py
@@ -130,7 +130,7 @@ def upload_file_to_slack(
                 try:
                     suffix = os.path.splitext(urlparse(path).path)[1] or ".tmp"
                     with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tf:
-                        with urlopen(path) as response:
+                        with urlopen(path, timeout=30) as response:
                             tf.write(response.read())
                     temp_paths.append(tf.name)
                     final_origin_paths.append(tf.name)
@@ -155,7 +155,7 @@ def upload_file_to_slack(
             f"*Case ID:* `{case_id}`\n" f"*Model:* `{model}`\n" f"*Prompt:* {prompt}"
         )
 
-        client = WebClient(token=token)
+        client = WebClient(token=token, timeout=60)
         channel_id = "C0A02NDF7UY"
         thread_ts = None
 

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -1574,8 +1574,17 @@ def graph_capture(stream: Optional[torch.cuda.Stream] = None):
         stream=stream
     ) as context, get_pp_group().graph_capture(context):
         moe_ep = _MOE_EP
-        if moe_ep is not None and moe_ep is not _TP:
+        moe_tp = _MOE_TP
+        need_moe_ep = moe_ep is not None and moe_ep is not _TP
+        need_moe_tp = moe_tp is not None and moe_tp is not _TP and moe_tp is not moe_ep
+        if need_moe_ep and need_moe_tp:
+            with moe_ep.graph_capture(context), moe_tp.graph_capture(context):
+                yield context
+        elif need_moe_ep:
             with moe_ep.graph_capture(context):
+                yield context
+        elif need_moe_tp:
+            with moe_tp.graph_capture(context):
                 yield context
         else:
             yield context

--- a/python/tools/get_version_tag.py
+++ b/python/tools/get_version_tag.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Resolve the correct version tag for setuptools-scm.
+
+Called by setuptools-scm via git_describe_command in pyproject.toml.
+Outputs either a bare tag (e.g., "v0.5.10") for exact-match commits,
+or a `git describe --long` string (e.g., "v0.5.10-2-gabcdef0") for
+untagged commits. Both formats are accepted by setuptools-scm.
+
+This two-step approach avoids a strverscmp bug where
+`git tag --sort=-version:refname` sorts v0.5.10rc0 above v0.5.10,
+which would cause CI to build the wrong version.
+
+Strategy:
+1. If the current commit has an exact version tag, use it directly.
+   This handles CI release builds (both stable and rc).
+2. Otherwise, find the highest version tag across all branches
+   and describe relative to it. This handles local dev installs
+   from main where release tags only exist on release branches.
+"""
+
+import subprocess
+import sys
+
+
+def run_git(*args: str, allow_failure: bool = False) -> str:
+    """Run a git command and return stripped stdout.
+
+    Args:
+        allow_failure: If True, return "" on non-zero exit (expected for
+            commands like --exact-match that legitimately fail).
+            If False, log stderr on failure before returning "".
+    """
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            capture_output=True,
+            text=True,
+        )
+    except OSError as exc:
+        print(f"ERROR: Failed to run 'git {' '.join(args)}': {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if result.returncode != 0:
+        if not allow_failure:
+            stderr_msg = result.stderr.strip()
+            print(
+                f"WARNING: git {' '.join(args)} failed "
+                f"(exit {result.returncode}): {stderr_msg}",
+                file=sys.stderr,
+            )
+        return ""
+
+    return result.stdout.strip()
+
+
+def get_exact_version_tag() -> str:
+    """Return the version tag name if HEAD has an exact version tag, or empty string."""
+    return run_git(
+        "describe", "--tags", "--exact-match", "--match", "v*", allow_failure=True
+    )
+
+
+def get_latest_version_tag_describe() -> str:
+    """Find the highest version tag across all branches and describe relative to it.
+
+    Uses `git tag --sort=-version:refname` (which internally uses strverscmp).
+    Note: strverscmp sorts rc/alpha suffixes ABOVE the bare version
+    (e.g., v0.5.10rc0 > v0.5.10). This is acceptable for the fallback
+    path because it only runs for untagged dev commits where the exact
+    base version is less important (.devN+gHASH suffix is appended).
+    """
+    # List all version tags sorted descending by version. Try each one
+    # with git describe until we find one that is an ancestor of HEAD.
+    tags_raw = run_git("tag", "--list", "--sort=-version:refname", "v*.*.*")
+    if not tags_raw:
+        print("WARNING: No version tags (v*.*.*) found in repo", file=sys.stderr)
+        return ""
+    tag_list = tags_raw.splitlines()
+    for tag in tag_list:
+        result = run_git(
+            "describe", "--tags", "--long", "--match", tag, "HEAD", allow_failure=True
+        )
+        if result:
+            return result
+    print(
+        f"WARNING: Found {len(tag_list)} version tags but none are ancestors of HEAD. "
+        f"Is this a shallow clone? Try: git fetch --unshallow --tags",
+        file=sys.stderr,
+    )
+    return ""
+
+
+def get_version_describe() -> str:
+    """Main entry point: resolve the version describe string."""
+    # Prefer exact match — correct for both stable and pre-release tags
+    exact = get_exact_version_tag()
+    if exact:
+        return exact
+
+    # Fallback for untagged commits (e.g., dev install from main)
+    return get_latest_version_tag_describe()
+
+
+def main() -> None:
+    result = get_version_describe()
+    if not result:
+        print(
+            "ERROR: Could not determine version from git tags.\n"
+            "Possible causes:\n"
+            "  - No version tags (v*.*.*) exist: run 'git fetch --tags'\n"
+            "  - Shallow clone without tags: run 'git fetch --unshallow --tags'\n"
+            "  - Git safe.directory issue: run 'git config --global --add safe.directory <repo>'\n"
+            "  - Not inside a git repository\n"
+            "setuptools-scm will fall back to version 0.0.0.dev0",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tools/test_get_version_tag.py
+++ b/python/tools/test_get_version_tag.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Tests for get_version_tag.py using temporary git repos."""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from get_version_tag import (
+    get_exact_version_tag,
+    get_latest_version_tag_describe,
+    get_version_describe,
+    main,
+)
+
+SCRIPT_PATH = os.path.join(os.path.dirname(__file__), "get_version_tag.py")
+
+
+class GitRepoFixture:
+    """Context manager that creates a temporary git repo and chdir into it.
+
+    The temporary directory is cleaned up on exit.
+    """
+
+    def __init__(self):
+        self._tmpdir: str | None = None
+        self._orig_dir: str | None = None
+
+    def __enter__(self):
+        self._tmpdir = tempfile.mkdtemp(prefix="test_version_")
+        self._orig_dir = os.getcwd()
+        os.chdir(self._tmpdir)
+        self._run("git", "init", "-b", "main")
+        self._run("git", "config", "user.email", "test@test.com")
+        self._run("git", "config", "user.name", "Test")
+        return self
+
+    def __exit__(self, *args):
+        if self._orig_dir:
+            os.chdir(self._orig_dir)
+        if self._tmpdir:
+            shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def _run(self, *cmd: str):
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Command {cmd} failed (exit {result.returncode}):\n{result.stderr}"
+            )
+
+    def commit(self, msg="commit"):
+        self._run("git", "commit", "--allow-empty", "-m", msg)
+
+    def tag(self, name):
+        self._run("git", "tag", name)
+
+    def branch(self, name):
+        self._run("git", "checkout", "-b", name)
+
+    def checkout(self, ref):
+        self._run("git", "checkout", ref)
+
+
+class TestGetVersionTag(unittest.TestCase):
+    """Test version tag resolution logic."""
+
+    def test_exact_match_stable_tag(self):
+        """On a commit tagged v0.5.10, should return v0.5.10."""
+        with GitRepoFixture() as repo:
+            repo.commit("initial")
+            repo.tag("v0.5.9")
+            repo.commit("release")
+            repo.tag("v0.5.10")
+
+            result = get_version_describe()
+            self.assertEqual(result, "v0.5.10")
+
+    def test_exact_match_rc_tag(self):
+        """On a commit tagged v0.5.10rc0, should return v0.5.10rc0."""
+        with GitRepoFixture() as repo:
+            repo.commit("initial")
+            repo.tag("v0.5.9")
+            repo.commit("rc release")
+            repo.tag("v0.5.10rc0")
+
+            result = get_version_describe()
+            self.assertEqual(result, "v0.5.10rc0")
+
+    def test_stable_tag_when_rc_also_exists(self):
+        """On v0.5.10 commit, should return v0.5.10 even if v0.5.10rc0 exists."""
+        with GitRepoFixture() as repo:
+            repo.commit("initial")
+            repo.tag("v0.5.9")
+            repo.commit("rc")
+            repo.tag("v0.5.10rc0")
+            repo.commit("release")
+            repo.tag("v0.5.10")
+
+            result = get_version_describe()
+            self.assertEqual(result, "v0.5.10")
+
+    def test_rc_tag_when_stable_also_exists(self):
+        """On v0.5.10rc0 commit, should return v0.5.10rc0 even if v0.5.10 exists later."""
+        with GitRepoFixture() as repo:
+            repo.commit("initial")
+            repo.tag("v0.5.9")
+            repo.commit("rc")
+            repo.tag("v0.5.10rc0")
+            repo.commit("release")
+            repo.tag("v0.5.10")
+            # Go back to the rc commit
+            repo.checkout("v0.5.10rc0")
+
+            result = get_version_describe()
+            self.assertEqual(result, "v0.5.10rc0")
+
+    def test_untagged_commit_falls_back(self):
+        """On an untagged commit, should describe relative to the latest ancestor tag."""
+        with GitRepoFixture() as repo:
+            repo.commit("initial")
+            repo.tag("v0.5.9")
+            repo.commit("some work")
+            repo.commit("more work")
+
+            result = get_version_describe()
+            # Should be like "v0.5.9-2-g<hash>"
+            self.assertTrue(result.startswith("v0.5.9-2-g"), f"Got: {result}")
+
+    def test_untagged_commit_on_main_finds_nearest_ancestor_tag(self):
+        """Dev install from main should describe relative to the nearest ancestor tag,
+        even when newer tags exist on unreachable release branches."""
+        with GitRepoFixture() as repo:
+            repo.commit("initial")
+            repo.tag("v0.5.9")
+
+            # Create a release branch with a newer tag
+            repo.branch("release-0.5.10")
+            repo.commit("release work")
+            repo.tag("v0.5.10")
+
+            # Go back to main and add untagged commits
+            repo.checkout("main")
+            repo.commit("dev work on main")
+
+            result = get_version_describe()
+            # v0.5.10 is NOT an ancestor of main HEAD, so should use v0.5.9
+            self.assertTrue(
+                result.startswith("v0.5.9-1-g"),
+                f"Expected describe relative to v0.5.9 (ancestor of HEAD), got: {result}",
+            )
+
+    def test_post_release_tag(self):
+        """On a post-release tag like v0.5.8.post1, should return it exactly."""
+        with GitRepoFixture() as repo:
+            repo.commit("initial")
+            repo.tag("v0.5.8")
+            repo.commit("hotfix")
+            repo.tag("v0.5.8.post1")
+
+            result = get_version_describe()
+            self.assertEqual(result, "v0.5.8.post1")
+
+    def test_no_tags_at_all(self):
+        """With no version tags, should return empty string."""
+        with GitRepoFixture() as repo:
+            repo.commit("initial")
+
+            result = get_version_describe()
+            self.assertEqual(result, "")
+
+    def test_exact_match_preferred_over_fallback(self):
+        """Exact match should be used even if fallback would give a different result."""
+        with GitRepoFixture() as repo:
+            repo.commit("initial")
+            repo.tag("v0.5.9")
+            repo.commit("rc")
+            repo.tag("v0.5.10rc0")
+            repo.commit("release")
+            repo.tag("v0.5.10")
+            repo.commit("rc2 for next version")
+            repo.tag("v0.5.11rc0")
+
+            result = get_version_describe()
+            self.assertEqual(result, "v0.5.11rc0")
+
+    def test_multiple_tags_on_same_commit(self):
+        """If both v0.5.10 and v0.5.10rc0 are on the same commit, either is acceptable."""
+        with GitRepoFixture() as repo:
+            repo.commit("initial")
+            repo.tag("v0.5.9")
+            repo.commit("release")
+            repo.tag("v0.5.10rc0")
+            repo.tag("v0.5.10")
+
+            # git describe --exact-match has undefined ordering for multiple
+            # tags on the same commit, so either is acceptable
+            result = get_version_describe()
+            self.assertIn(result, ["v0.5.10", "v0.5.10rc0"])
+
+    def test_fallback_picks_highest_ancestor_tag(self):
+        """When multiple tags are ancestors, fallback should pick the highest version."""
+        with GitRepoFixture() as repo:
+            repo.commit("initial")
+            repo.tag("v0.5.8")
+            repo.commit("second")
+            repo.tag("v0.5.9")
+            repo.commit("untagged work")
+            repo.commit("more work")
+
+            result = get_version_describe()
+            self.assertTrue(
+                result.startswith("v0.5.9-2-g"),
+                f"Expected describe relative to v0.5.9 (highest ancestor), got: {result}",
+            )
+
+
+class TestGetExactVersionTag(unittest.TestCase):
+    """Test the exact-match helper in isolation."""
+
+    def test_returns_empty_on_untagged(self):
+        with GitRepoFixture() as repo:
+            repo.commit("initial")
+
+            self.assertEqual(get_exact_version_tag(), "")
+
+    def test_returns_tag_on_tagged(self):
+        with GitRepoFixture() as repo:
+            repo.commit("initial")
+            repo.tag("v1.0.0")
+
+            self.assertEqual(get_exact_version_tag(), "v1.0.0")
+
+    def test_ignores_non_version_tags(self):
+        with GitRepoFixture() as repo:
+            repo.commit("initial")
+            repo.tag("some-other-tag")
+
+            # --match v* should skip non-version tags
+            self.assertEqual(get_exact_version_tag(), "")
+
+
+class TestGetLatestVersionTagDescribe(unittest.TestCase):
+    """Test the fallback sorted-tag helper in isolation."""
+
+    def test_strverscmp_sorts_rc_above_stable(self):
+        """Document that strverscmp sorts rc above stable (known limitation)."""
+        with GitRepoFixture() as repo:
+            repo.commit("initial")
+            repo.tag("v0.5.10")
+            repo.commit("after")
+            repo.tag("v0.5.10rc0")
+            repo.commit("untagged")
+
+            result = get_latest_version_tag_describe()
+            # strverscmp puts v0.5.10rc0 first, so fallback describes
+            # relative to v0.5.10rc0 — this is the known limitation
+            # that exact-match avoids for tagged commits
+            self.assertTrue(
+                result.startswith("v0.5.10rc0-"),
+                f"Expected fallback to use rc0 due to strverscmp, got: {result}",
+            )
+
+    def test_ignores_non_version_tags(self):
+        """Non-version tags should not be picked up by the fallback path."""
+        with GitRepoFixture() as repo:
+            repo.commit("initial")
+            repo.tag("v1.0.0")
+            repo.commit("second")
+            repo.tag("release-candidate")
+            repo.commit("third")
+
+            result = get_latest_version_tag_describe()
+            self.assertTrue(
+                result.startswith("v1.0.0-2-g"),
+                f"Expected describe relative to v1.0.0, got: {result}",
+            )
+
+
+class TestMain(unittest.TestCase):
+    """Test the main() entry point behavior."""
+
+    def test_main_prints_version_to_stdout(self):
+        """main() should print the version to stdout on success."""
+        with GitRepoFixture() as repo:
+            repo.commit("initial")
+            repo.tag("v1.0.0")
+
+            result = subprocess.run(
+                [sys.executable, SCRIPT_PATH],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(result.stdout.strip(), "v1.0.0")
+
+    def test_main_exits_nonzero_when_no_tags(self):
+        """main() should exit(1) and print error to stderr when no tags exist."""
+        with GitRepoFixture() as repo:
+            repo.commit("initial")
+
+            result = subprocess.run(
+                [sys.executable, SCRIPT_PATH],
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("Could not determine version", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/8-gpu-models/test_kimi_k25.py
+++ b/test/registered/8-gpu-models/test_kimi_k25.py
@@ -10,19 +10,13 @@ from sglang.test.test_utils import ModelLaunchSettings
 register_cuda_ci(est_time=3600, suite="nightly-8-gpu-common", nightly=True)
 
 KIMI_K25_MODEL_PATH = "moonshotai/Kimi-K2.5"
-EAGLE3_DRAFT_MODEL_PATH = "AQ-MedAI/Kimi-K25-eagle3"
 
 
 class TestKimiK25(unittest.TestCase):
     """Unified test class for Kimi-K2.5 performance and accuracy.
 
-    Two variants:
-    - basic: TP=8 + tool/reasoning parsers
-    - eagle3: TP=8 + EAGLE3 speculative decoding with draft model
-
-    Each variant runs BOTH:
-    - Performance test (using NightlyBenchmarkRunner)
-    - Accuracy test (using run_eval with gsm8k)
+    Runs TP=8 with tool/reasoning parsers.
+    Runs BOTH performance test and accuracy test (gsm8k).
     """
 
     def test_kimi_k25(self):
@@ -31,15 +25,6 @@ class TestKimiK25(unittest.TestCase):
             "--trust-remote-code",
             "--tool-call-parser=kimi_k2",
             "--reasoning-parser=kimi_k2",
-        ]
-        eagle3_args = [
-            "--speculative-algorithm=EAGLE3",
-            f"--speculative-draft-model-path={EAGLE3_DRAFT_MODEL_PATH}",
-            "--speculative-num-steps=3",
-            "--speculative-eagle-topk=1",
-            "--speculative-num-draft-tokens=4",
-            "--model-loader-extra-config",
-            '{"enable_multithread_load": true, "num_threads": 64}',
         ]
 
         dp_attn_args = [
@@ -57,14 +42,8 @@ class TestKimiK25(unittest.TestCase):
             ModelLaunchSettings(
                 KIMI_K25_MODEL_PATH,
                 tp_size=8,
-                extra_args=base_args + eagle3_args,
-                variant="TP8+MTP",
-            ),
-            ModelLaunchSettings(
-                KIMI_K25_MODEL_PATH,
-                tp_size=8,
-                extra_args=base_args + dp_attn_args + eagle3_args,
-                variant="TP8+DP8+MTP",
+                extra_args=base_args + dp_attn_args,
+                variant="TP8+DP8",
             ),
         ]
 


### PR DESCRIPTION
## Summary

- `git tag --sort=-version:refname` uses `strverscmp` which sorts `v0.5.10rc0` **above** `v0.5.10`, causing the PyPI release workflow to build `sglang-0.5.10rc0` instead of `sglang-0.5.10` when both tags exist ([failed run](https://github.com/sgl-project/sglang/actions/runs/24006928727/attempts/1))
- Extract the version resolution logic into a Python script (`python/tools/get_version_tag.py`) that uses `git describe --exact-match` first (correct for CI tagged builds), then falls back to sorted-tag iteration with ancestor checking (for dev installs from main)
- 18 unit tests covering stable tags, rc tags, coexisting tags, post-release tags, cross-branch resolution, and the `strverscmp` edge case

## Test plan

- [x] `python3 python/tools/test_get_version_tag.py` — 18 tests pass
- [x] `pre-commit run --all-files` — all checks pass
- [ ] Verify next release tag build produces correct version

🤖 Generated with [Claude Code](https://claude.com/claude-code)