### PR TITLE
fix: start bootstrap in followers for p2p training

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -508,9 +508,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 self.remote_instance_transfer_engine_weight_info = register_memory_region(
                     self.model, self.remote_instance_transfer_engine
                 )
-            if self.server_args.remote_instance_weight_loader_start_seed_via_transfer_engine:
-                # Register to bootstrap server so external callers for p2p training call
-                self._register_to_engine_info_bootstrap()
+            # Register to bootstrap server so external callers for p2p training call
+            self._register_to_engine_info_bootstrap()
 
         # Register parallelism config with the bootstrap server
         if (

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -502,13 +502,15 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         if (
             self.server_args.remote_instance_weight_loader_use_transfer_engine()
             and self.remote_instance_transfer_engine is not None
-            and self.remote_instance_transfer_engine_weight_info is None
         ):
-            # Register memory and upstream the transfer engine info to the bootstrap server
-            self.remote_instance_transfer_engine_weight_info = register_memory_region(
-                self.model, self.remote_instance_transfer_engine
-            )
-            self._register_to_engine_info_bootstrap()
+            if self.remote_instance_transfer_engine_weight_info is None:
+                # Seed path: loaded from disk, register memory regions now.
+                self.remote_instance_transfer_engine_weight_info = register_memory_region(
+                    self.model, self.remote_instance_transfer_engine
+                )
+            if self.server_args.remote_instance_weight_loader_start_seed_via_transfer_engine:
+                # Register to bootstrap server so external callers for p2p training call
+                self._register_to_engine_info_bootstrap()
 
         # Register parallelism config with the bootstrap server
         if (


### PR DESCRIPTION
## Motivation

When an engine acts as both an **rfork follower** (loading weights from a seed instane) and a **p2p weight-update target** (receiving updated weights from a training process via RDMA after each training step), the engine's transfer engine info is never registered with its bootstrap server, causing `/get_remote_instance_transfer_engine_info` to return
400 for that engine.

**Root cause:** `model_runner.py` only calls `_register_to_engine_info_bootstrap()` when
`remote_instance_transfer_engine_weight_info is None`:

```python
if (
    self.server_args.remote_instance_weight_loader_use_transfer_engine()
    and self.remote_instance_transfer_engine is not None
    and self.remote_instance_transfer_engine_weight_info is None   # <-- blocks registration
):
    self.remote_instance_transfer_engine_weight_info = register_memory_region(...)
    self._register_to_engine_info_bootstrap()
```

For an rfork follower, `RemoteInstanceModelLoader.load_model()` sets `self.remote_instance_transfer_engine_weight_info` during weight loading (it registers the destination memory regions so the RDMA read can proceed). The model runner copies this value, so by the time the registration block is reached, `weight_info` is already non-None and `_register_to_engine_info_bootstrap()` is never called.

## Modifications

Split the registration block in `model_runner.py` into two independent steps:

1. **Memory region registration** — only runs when `weight_info is None` (seed/disk-load path; rfork followers already registered their destination regions during loading).
2. **Bootstrap server registration** — runs whenever `start_seed_via_transfer_engine=True`, regardless of how `weight_info` was set. This ensures both seeds and rfork followers publish their transfer engine info so external callers (e.g. training-side p2p weight updates) can query it.


## Accuracy Tests

Verified with an end-to-end GRPO training test using Qwen3-4B on 8 GPUs:
```bash
cd miles && python tests/e2e/megatron/test_qwen3_4B_p2p.py
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
