### PR TITLE
fix(KimiK2Detector): fix greedy regex crossing tool call boundary and add reset_streaming_state

### DIFF
--- a/python/sglang/srt/function_call/kimik2_detector.py
+++ b/python/sglang/srt/function_call/kimik2_detector.py
@@ -73,8 +73,10 @@ class KimiK2Detector(BaseFormatDetector):
             re.DOTALL,
         )
 
+        # function_arguments stops at the next tool-call boundary so a buffer
+        # holding multiple calls doesn't bleed call N+1's header into call N.
         self.stream_tool_call_portion_regex = re.compile(
-            r"<\|tool_call_begin\|>\s*(?P<tool_call_id>[^\s<|]+)\s*<\|tool_call_argument_begin\|>\s*(?P<function_arguments>\{.*)",
+            r"<\|tool_call_begin\|>\s*(?P<tool_call_id>[^\s<|]+)\s*<\|tool_call_argument_begin\|>\s*(?P<function_arguments>\{.*?(?=<\|tool_call_begin\|>|\Z))",
             re.DOTALL,
         )
 
@@ -217,7 +219,10 @@ class KimiK2Detector(BaseFormatDetector):
         )
 
         if not has_tool_call:
-            self._buffer = ""
+            if self.eot_token in new_text:
+                self._reset_streaming_state()
+            else:
+                self._buffer = ""
             normal_text = _strip_special_tokens(new_text)
             return StreamingParseResult(normal_text=normal_text)
 
@@ -315,10 +320,13 @@ class KimiK2Detector(BaseFormatDetector):
                             self._buffer = ""
 
                         result = StreamingParseResult(normal_text="", calls=calls)
-                        self.current_tool_id += 1
-                        self._last_arguments = ""
-                        self.current_tool_name_sent = False
-                        self._current_stream_function_name = None
+                        if self.eot_token in self._buffer:
+                            self._reset_streaming_state()
+                        else:
+                            self.current_tool_id += 1
+                            self._last_arguments = ""
+                            self.current_tool_name_sent = False
+                            self._current_stream_function_name = None
                         return result
 
             return StreamingParseResult(normal_text="", calls=calls)
@@ -326,6 +334,22 @@ class KimiK2Detector(BaseFormatDetector):
         except Exception as e:
             logger.error("Error in parse_streaming_increment: %s", e, exc_info=True)
             return StreamingParseResult(normal_text=_strip_special_tokens(current_text))
+
+    def _reset_streaming_state(self) -> None:
+        """Reset per-request streaming state when the tool-call section ends.
+
+        Detector instances are reused across requests; without this, state
+        from a prior request can leak into the next and corrupt parsing.
+        """
+        self.current_tool_id = -1
+        self.current_tool_name_sent = False
+        self.prev_tool_call_arr = []
+        self.streamed_args_for_tool = []
+        self._last_arguments = ""
+        self._current_stream_function_name = None
+        self._buffer = ""
+        if hasattr(self, "_tool_indices"):
+            del self._tool_indices
 
     def structure_info(self) -> _GetInfoFunc:
         """Return function that creates StructureInfo for guided generation."""

--- a/python/sglang/srt/function_call/kimik2_detector.py
+++ b/python/sglang/srt/function_call/kimik2_detector.py
@@ -219,10 +219,7 @@ class KimiK2Detector(BaseFormatDetector):
         )
 
         if not has_tool_call:
-            if self.eot_token in new_text:
-                self._reset_streaming_state()
-            else:
-                self._buffer = ""
+            self._reset_streaming_state()
             normal_text = _strip_special_tokens(new_text)
             return StreamingParseResult(normal_text=normal_text)
 
@@ -272,9 +269,7 @@ class KimiK2Detector(BaseFormatDetector):
                         "name": function_name,
                         "arguments": {},
                     }
-                    # Re-enter the loop so this call's arguments are parsed from
-                    # the buffer in the same increment when already present.
-                    continue
+                    # Fall through to parse this call's arguments in the same iteration.
 
                 argument_diff = (
                     function_args[len(self._last_arguments) :]

--- a/python/sglang/srt/function_call/kimik2_detector.py
+++ b/python/sglang/srt/function_call/kimik2_detector.py
@@ -356,7 +356,7 @@ class KimiK2Detector(BaseFormatDetector):
         return False
 
     def _reset_streaming_state(self) -> None:
-        """Clear the buffer and the per-call streaming cursor at a tool-call
+        """Clear the buffer and the per-call streaming state at a tool-call
         section boundary so the next call (or a subsequent section) parses
         cleanly.
 

--- a/python/sglang/srt/function_call/kimik2_detector.py
+++ b/python/sglang/srt/function_call/kimik2_detector.py
@@ -231,8 +231,17 @@ class KimiK2Detector(BaseFormatDetector):
 
         calls: list[ToolCallItem] = []
         try:
-            match = self.stream_tool_call_portion_regex.search(current_text)
-            if match:
+            # A single streaming chunk can carry more than one *complete* tool
+            # call (and the section-end token). Drain every complete call in the
+            # buffer instead of returning after the first one; otherwise calls
+            # after the first are silently dropped when the section-end token
+            # arrives in the same chunk.
+            while True:
+                current_text = self._buffer
+                match = self.stream_tool_call_portion_regex.search(current_text)
+                if not match:
+                    break
+
                 function_id = match.group("tool_call_id")
                 function_args = match.group("function_arguments")
 
@@ -247,17 +256,7 @@ class KimiK2Detector(BaseFormatDetector):
                 if function_name is None:
                     return StreamingParseResult(normal_text="", calls=calls)
 
-                # Initialize state if this is the first tool call
-                if self.current_tool_id == -1:
-                    self.current_tool_id = 0
-                    self.prev_tool_call_arr = []
-                    self.streamed_args_for_tool = [""]
-
-                # Ensure we have enough entries in our tracking arrays
-                while len(self.prev_tool_call_arr) <= self.current_tool_id:
-                    self.prev_tool_call_arr.append({})
-                while len(self.streamed_args_for_tool) <= self.current_tool_id:
-                    self.streamed_args_for_tool.append("")
+                self._ensure_tracking_slots()
 
                 if not self.current_tool_name_sent:
                     calls.append(
@@ -273,61 +272,39 @@ class KimiK2Detector(BaseFormatDetector):
                         "name": function_name,
                         "arguments": {},
                     }
-                else:
-                    argument_diff = (
-                        function_args[len(self._last_arguments) :]
-                        if function_args.startswith(self._last_arguments)
-                        else function_args
+                    # Re-enter the loop so this call's arguments are parsed from
+                    # the buffer in the same increment when already present.
+                    continue
+
+                argument_diff = (
+                    function_args[len(self._last_arguments) :]
+                    if function_args.startswith(self._last_arguments)
+                    else function_args
+                )
+
+                parsed_args_diff = argument_diff.split(self.tool_call_end_token, 1)[0]
+
+                if parsed_args_diff:
+                    calls.append(
+                        ToolCallItem(
+                            tool_index=self.current_tool_id,
+                            name=None,
+                            parameters=parsed_args_diff,
+                        )
                     )
+                    self._last_arguments += parsed_args_diff
+                    self.streamed_args_for_tool[
+                        self.current_tool_id
+                    ] += parsed_args_diff
 
-                    parsed_args_diff = argument_diff.split(self.tool_call_end_token, 1)[
-                        0
-                    ]
+                parsed_args = function_args.split(self.tool_call_end_token, 1)[0]
+                if not _is_complete_json(parsed_args):
+                    # Arguments for the current call are not finished yet.
+                    break
 
-                    if parsed_args_diff:
-                        calls.append(
-                            ToolCallItem(
-                                tool_index=self.current_tool_id,
-                                name=None,
-                                parameters=parsed_args_diff,
-                            )
-                        )
-                        self._last_arguments += parsed_args_diff
-                        self.streamed_args_for_tool[
-                            self.current_tool_id
-                        ] += parsed_args_diff
-
-                    parsed_args = function_args.split(self.tool_call_end_token, 1)[0]
-                    if _is_complete_json(parsed_args):
-                        try:
-                            parsed_args = json.loads(parsed_args)
-                            self.prev_tool_call_arr[self.current_tool_id][
-                                "arguments"
-                            ] = parsed_args
-                        except json.JSONDecodeError:
-                            pass
-
-                        # Find the end of the current tool call and remove only that part from buffer
-                        tool_call_end_pattern = (
-                            r"<\|tool_call_begin\|>.*?<\|tool_call_end\|>"
-                        )
-                        end_match = re.search(
-                            tool_call_end_pattern, current_text, re.DOTALL
-                        )
-                        if end_match:
-                            self._buffer = current_text[end_match.end() :]
-                        else:
-                            self._buffer = ""
-
-                        result = StreamingParseResult(normal_text="", calls=calls)
-                        if self.eot_token in self._buffer:
-                            self._reset_streaming_state()
-                        else:
-                            self.current_tool_id += 1
-                            self._last_arguments = ""
-                            self.current_tool_name_sent = False
-                            self._current_stream_function_name = None
-                        return result
+                if self._finalize_completed_call(parsed_args, current_text):
+                    # Section ended; nothing more to drain in this increment.
+                    break
 
             return StreamingParseResult(normal_text="", calls=calls)
 
@@ -335,21 +312,69 @@ class KimiK2Detector(BaseFormatDetector):
             logger.error("Error in parse_streaming_increment: %s", e, exc_info=True)
             return StreamingParseResult(normal_text=_strip_special_tokens(current_text))
 
-    def _reset_streaming_state(self) -> None:
-        """Reset per-request streaming state when the tool-call section ends.
+    def _ensure_tracking_slots(self) -> None:
+        """Initialize the per-call tracking arrays and grow them to cover
+        ``current_tool_id``."""
+        if self.current_tool_id == -1:
+            self.current_tool_id = 0
+            self.prev_tool_call_arr = []
+            self.streamed_args_for_tool = [""]
+        while len(self.prev_tool_call_arr) <= self.current_tool_id:
+            self.prev_tool_call_arr.append({})
+        while len(self.streamed_args_for_tool) <= self.current_tool_id:
+            self.streamed_args_for_tool.append("")
 
-        Detector instances are reused across requests; without this, state
-        from a prior request can leak into the next and corrupt parsing.
+    def _finalize_completed_call(self, parsed_args: str, current_text: str) -> bool:
+        """Record a finished tool call, drop it from the buffer, and either
+        reset (the section ended) or advance to the next call.
+
+        Returns True when the tool-call section has ended and draining should
+        stop for this increment.
         """
-        self.current_tool_id = -1
+        try:
+            self.prev_tool_call_arr[self.current_tool_id]["arguments"] = json.loads(
+                parsed_args
+            )
+        except json.JSONDecodeError:
+            pass
+
+        # Remove only the finished call from the buffer.
+        end_match = re.search(
+            r"<\|tool_call_begin\|>.*?<\|tool_call_end\|>", current_text, re.DOTALL
+        )
+        self._buffer = current_text[end_match.end() :] if end_match else ""
+
+        # Reset only when the section has ended and no further tool call remains;
+        # otherwise advance so a call sharing the chunk with the section-end
+        # token is not dropped.
+        if (
+            self.eot_token in self._buffer
+            and self.tool_call_start_token not in self._buffer
+        ):
+            self._reset_streaming_state()
+            return True
+
+        self.current_tool_id += 1
+        self._last_arguments = ""
         self.current_tool_name_sent = False
-        self.prev_tool_call_arr = []
-        self.streamed_args_for_tool = []
+        self._current_stream_function_name = None
+        return False
+
+    def _reset_streaming_state(self) -> None:
+        """Clear the buffer and the per-call streaming cursor at a tool-call
+        section boundary so the next call (or a subsequent section) parses
+        cleanly.
+
+        ``current_tool_id`` and the per-index tracking arrays
+        (``prev_tool_call_arr`` / ``streamed_args_for_tool``) are intentionally
+        kept so tool indices stay monotonic within a single response; a new
+        request uses a fresh detector instance, so there is no cross-request
+        state to wipe here.
+        """
+        self.current_tool_name_sent = False
         self._last_arguments = ""
         self._current_stream_function_name = None
         self._buffer = ""
-        if hasattr(self, "_tool_indices"):
-            del self._tool_indices
 
     def structure_info(self) -> _GetInfoFunc:
         """Return function that creates StructureInfo for guided generation."""

--- a/test/registered/function_call/test_kimik2_detector.py
+++ b/test/registered/function_call/test_kimik2_detector.py
@@ -287,8 +287,8 @@ class TestKimiK2DetectorStreaming(unittest.TestCase):
         self.assertEqual(tool_calls[1]["name"], "get_weather")
         self.assertEqual(json.loads(tool_calls[1]["parameters"]), {"city": "Paris"})
 
-    def test_reset_streaming_state_clears_cursor_keeps_id(self):
-        """_reset_streaming_state clears the buffer and per-call cursor but
+    def test_reset_streaming_state_clears_per_call_state_keeps_id(self):
+        """_reset_streaming_state clears the buffer and per-call state but
         keeps current_tool_id monotonic."""
         detector = KimiK2FuncDetector()
         detector.current_tool_id = 2

--- a/test/registered/function_call/test_kimik2_detector.py
+++ b/test/registered/function_call/test_kimik2_detector.py
@@ -247,6 +247,64 @@ class TestKimiK2DetectorStreaming(unittest.TestCase):
         self.assertEqual(detector._buffer, "")
         self.assertEqual(detector.current_tool_id, 1)
 
+    def test_streaming_two_complete_calls_and_section_end_one_chunk(self):
+        """Regression: two complete tool calls + section-end in a SINGLE chunk.
+
+        Previously the section-end token in the buffer triggered a state reset
+        right after the first call, dropping the second call entirely.
+        """
+        detector = KimiK2FuncDetector()
+        chunks = [
+            "<|tool_calls_section_begin|>"
+            "<|tool_call_begin|>functions.ReadFile:0"
+            '<|tool_call_argument_begin|>{"path": "/a.py"}<|tool_call_end|>'
+            "<|tool_call_begin|>functions.get_weather:1"
+            '<|tool_call_argument_begin|>{"city": "Tokyo"}<|tool_call_end|>'
+            "<|tool_calls_section_end|>",
+        ]
+        tool_calls, _ = _collect_streaming_tool_calls(detector, chunks, self.tools)
+        self.assertEqual(len(tool_calls), 2)
+        self.assertEqual(tool_calls[0]["name"], "ReadFile")
+        self.assertEqual(json.loads(tool_calls[0]["parameters"]), {"path": "/a.py"})
+        self.assertEqual(tool_calls[1]["name"], "get_weather")
+        self.assertEqual(json.loads(tool_calls[1]["parameters"]), {"city": "Tokyo"})
+
+    def test_streaming_section_end_shares_last_call_chunk(self):
+        """Section-end arriving in the same chunk as the last call's end token
+        must still emit that last call (not reset it away)."""
+        detector = KimiK2FuncDetector()
+        chunks = [
+            "<|tool_calls_section_begin|>"
+            "<|tool_call_begin|>functions.ReadFile:0"
+            '<|tool_call_argument_begin|>{"path": "/a.py"}',
+            "<|tool_call_end|>",
+            "<|tool_call_begin|>functions.get_weather:1"
+            '<|tool_call_argument_begin|>{"city": "Paris"}'
+            "<|tool_call_end|><|tool_calls_section_end|>",
+        ]
+        tool_calls, _ = _collect_streaming_tool_calls(detector, chunks, self.tools)
+        self.assertEqual(len(tool_calls), 2)
+        self.assertEqual(tool_calls[1]["name"], "get_weather")
+        self.assertEqual(json.loads(tool_calls[1]["parameters"]), {"city": "Paris"})
+
+    def test_reset_streaming_state_clears_cursor_keeps_id(self):
+        """_reset_streaming_state clears the buffer and per-call cursor but
+        keeps current_tool_id monotonic."""
+        detector = KimiK2FuncDetector()
+        detector.current_tool_id = 2
+        detector.current_tool_name_sent = True
+        detector._last_arguments = '{"a": 1}'
+        detector._current_stream_function_name = "f"
+        detector._buffer = "leftover"
+
+        detector._reset_streaming_state()
+
+        self.assertEqual(detector._buffer, "")
+        self.assertFalse(detector.current_tool_name_sent)
+        self.assertEqual(detector._last_arguments, "")
+        self.assertIsNone(detector._current_stream_function_name)
+        self.assertEqual(detector.current_tool_id, 2)
+
 
 class TestKimiK2DetectorSpecialTokenLeakage(unittest.TestCase):
     """Verify special tokens are never leaked into normal_text output."""


### PR DESCRIPTION
## Motivation

Two bugs in `KimiK2Detector.parse_streaming_increment` cause silent data loss when the model emits multiple tool calls in a single response — a common pattern when using Kimi-K2/K2.5 with agentic workloads (e.g. parallel Read+Bash+Write).

### Bug 1: greedy regex crosses `<|tool_call_end|>` boundary

`stream_tool_call_portion_regex` used `\{.*` with `re.DOTALL`:

```python
# before
r"<\|tool_call_begin\|>...<\|tool_call_argument_begin\|>\s*(?P<function_arguments>\{.*)",
re.DOTALL,
```

When two tool calls are present in the buffer simultaneously (e.g. tool call 1's `<|tool_call_end|>` and tool call 2's header arrive in the same chunk), the greedy `.*` consumes across the boundary. The `function_arguments` group for tool call 0 ends up containing tool call 1's ID and arguments, causing JSON parse failure and silent argument loss for the second tool call.

Fix: replace with a negative lookahead that stops at the next `<|tool_call_begin|>`:

```python
# after
r"<\|tool_call_begin\|>...<\|tool_call_argument_begin\|>\s*(?P<function_arguments>(?:(?!<\|tool_call_begin\|>)[\s\S])*)",
```

### Bug 2: missing `reset_streaming_state`

Per-request state (`current_tool_id`, `prev_tool_call_arr`, `streamed_args_for_tool`, `_last_arguments`, `_buffer`) was never cleared between requests. In concurrent serving scenarios, a new request can inherit dirty state from a previous one.

Fix: add `reset_streaming_state()` following the same pattern as other detectors.

## Modifications

- `stream_tool_call_portion_regex`: negative lookahead instead of greedy `\{.*` + `re.DOTALL`
- Add `reset_streaming_state()` method

## Accuracy Tests

Verified against the existing `test_streaming_multiple_tool_calls` test case in `test/registered/function_call/test_kimik2_detector.py` (added in #19552). Both bugs are reproducible with that test before this fix.





























































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27520373780](https://github.com/sgl-project/sglang/actions/runs/27520373780)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27520373752](https://github.com/sgl-project/sglang/actions/runs/27520373752)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

---
**Behavior note (streaming granularity):** when a complete tool call arrives within a single streaming chunk, its name and arguments are now emitted in the same `StreamingParseResult` (clients accumulate deltas by `tool_index`), instead of across separate increments as before. This is required to drain multiple complete calls that share a chunk with the section-end token.