### PR TITLE
[Feature][JIT Kernel] Softmax (with claude)

### DIFF
--- a/python/sglang/jit_kernel/benchmark/bench_softmax.py
+++ b/python/sglang/jit_kernel/benchmark/bench_softmax.py
@@ -1,0 +1,75 @@
+"""Benchmark for softmax sampling kernel vs torch.softmax and flashinfer.softmax."""
+
+import itertools
+
+import torch
+import triton
+import triton.testing
+from flashinfer.sampling import softmax as fi_softmax
+
+from sglang.jit_kernel.benchmark.utils import (
+    DEFAULT_DEVICE,
+    get_benchmark_range,
+    run_benchmark,
+)
+from sglang.jit_kernel.softmax import softmax_sampling
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, suite="stage-b-kernel-benchmark-1-gpu-large")
+
+DTYPE = torch.bfloat16
+
+VOCAB_SIZES = get_benchmark_range(
+    full_range=[32000, 65536, 128256, 151936, 262144],
+    ci_range=[32000, 128256],
+)
+BATCH_SIZES = get_benchmark_range(
+    full_range=[1, 2, 4, 8, 16, 32, 64, 128, 256, 512],
+    ci_range=[1, 64],
+)
+NUM_REPEAT = 4
+
+configs = list(itertools.product(VOCAB_SIZES, BATCH_SIZES))
+
+
+def _torch_softmax(logits: torch.Tensor, temperatures: torch.Tensor) -> torch.Tensor:
+    scaled = logits / temperatures.unsqueeze(1)
+    return torch.softmax(scaled, dim=-1)
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["vocab_size", "batch_size"],
+        x_vals=configs,
+        line_arg="provider",
+        line_vals=["jit", "flashinfer", "torch"],
+        line_names=["SGL JIT Softmax", "FlashInfer", "PyTorch"],
+        styles=[("blue", "-"), ("green", "-."), ("red", "--")],
+        ylabel="us",
+        plot_name="softmax-sampling-performance",
+        args={},
+    )
+)
+def benchmark(vocab_size: int, batch_size: int, provider: str):
+    logits = torch.randn(
+        (NUM_REPEAT, batch_size, vocab_size), dtype=DTYPE, device=DEFAULT_DEVICE
+    )
+    temperatures = torch.ones(
+        (NUM_REPEAT, batch_size), dtype=torch.float32, device=DEFAULT_DEVICE
+    )
+    FN_MAP = {
+        "jit": softmax_sampling,
+        "flashinfer": fi_softmax,
+        "torch": _torch_softmax,
+    }
+
+    def f() -> None:
+        fn = FN_MAP[provider]
+        for i in range(NUM_REPEAT):
+            fn(logits[i], temperatures[i])
+
+    return run_benchmark(f, scale=NUM_REPEAT)
+
+
+if __name__ == "__main__":
+    benchmark.run(print_data=True)

--- a/python/sglang/jit_kernel/benchmark/bench_softmax.py
+++ b/python/sglang/jit_kernel/benchmark/bench_softmax.py
@@ -15,7 +15,7 @@ from sglang.jit_kernel.benchmark.utils import (
 from sglang.jit_kernel.softmax import softmax_sampling
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=10, suite="stage-b-kernel-benchmark-1-gpu-large")
+register_cuda_ci(est_time=20, suite="stage-b-kernel-benchmark-1-gpu-large")
 
 DTYPE = torch.bfloat16
 
@@ -25,13 +25,14 @@ VOCAB_SIZES = get_benchmark_range(
 )
 BATCH_SIZES = get_benchmark_range(
     full_range=[1, 2, 4, 8, 16, 32, 64, 128, 256, 512],
-    ci_range=[1, 64],
+    ci_range=[1, 64, 512],
 )
 NUM_REPEAT = 4
 
 configs = list(itertools.product(VOCAB_SIZES, BATCH_SIZES))
 
 
+@torch.compile
 def _torch_softmax(logits: torch.Tensor, temperatures: torch.Tensor) -> torch.Tensor:
     scaled = logits / temperatures.unsqueeze(1)
     return torch.softmax(scaled, dim=-1)

--- a/python/sglang/jit_kernel/csrc/elementwise/softmax.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/softmax.cuh
@@ -29,9 +29,7 @@
 namespace {
 
 constexpr uint32_t kBlockSize = 1024;
-constexpr uint32_t kNumWarps = kBlockSize / device::kWarpThreads;  // 32
 
-// Target occupancy is 2
 #define SGL_SOFTMAX_KERNEL __global__ void __launch_bounds__(kBlockSize, 2)
 
 // ============================================================================
@@ -58,37 +56,30 @@ struct SoftmaxParams {
 
 /// Warp-level online softmax merge across all 32 lanes.
 SGL_DEVICE fp32x2_t warp_online_softmax_merge(fp32x2_t ms) {
-  namespace math = device::math;
+  using namespace device;
   auto [m, s] = ms;
-#pragma unroll
-  for (int mask = 16; mask > 0; mask >>= 1) {
-    float om = __shfl_xor_sync(0xffffffffu, m, mask);
-    float os = __shfl_xor_sync(0xffffffffu, s, mask);
-    float nm = math::max(m, om);
-    s = s * math::exp(m - nm) + os * math::exp(om - nm);
-    m = nm;
-  }
-  return fp32x2_t{m, s};
+  const auto warp_max = warp::reduce_max(m);
+  const auto warp_sum = warp::reduce_sum(s * math::exp(m - warp_max));
+  return {warp_max, warp_sum};
 }
 
 /// CTA-level online softmax merge.
-/// smem must have at least 2 * kNumWarps floats.
-/// After return, all threads see the final (max, sum) in (m, s).
+/// smem_ms must have at least 32 fp32x2_t entries (caller-owned).
+/// num_warps is the number of active warps (blockDim.x / 32).
+/// After return, all threads see the final (max, sum).
 [[maybe_unused]]
-SGL_DEVICE fp32x2_t cta_online_softmax_merge(float m, float s) {
-  __shared__ fp32x2_t smem_ms[kNumWarps];
-
+SGL_DEVICE fp32x2_t cta_online_softmax_merge(float m, float s, fp32x2_t* smem_ms, uint32_t num_warps) {
   const uint32_t warp_id = threadIdx.x / device::kWarpThreads;
   const uint32_t lane_id = threadIdx.x % device::kWarpThreads;
 
   smem_ms[warp_id] = warp_online_softmax_merge({m, s});
   __syncthreads();
   if (warp_id == 0) {
-    const auto ms = lane_id < kNumWarps ? smem_ms[lane_id] : fp32x2_t{-FLT_MAX, 0.0f};
-    smem_ms[lane_id] = warp_online_softmax_merge(ms);
+    const auto ms = lane_id < num_warps ? smem_ms[lane_id] : fp32x2_t{-FLT_MAX, 0.0f};
+    smem_ms[0] = warp_online_softmax_merge(ms);
   }
   __syncthreads();
-  return smem_ms[warp_id];
+  return smem_ms[0];
 }
 
 // ============================================================================
@@ -119,16 +110,25 @@ SGL_SOFTMAX_KERNEL softmax_fused_kernel(const __grid_constant__ SoftmaxParams pa
   for (uint32_t vi = threadIdx.x; vi < n_vecs; vi += kBlockSize) {
     vec_t v;
     v.load(row_in, vi);
+    float cache[kVecN];
+    float vec_max = -FLT_MAX;
 #pragma unroll
     for (int i = 0; i < kVecN; ++i) {
-      float val = cast<fp32_t>(v[i]) * inv_temp;
-      float old_m = m;
-      m = math::max(m, val);
-      s = s * math::exp(old_m - m) + math::exp(val - m);
+      const auto val = cast<fp32_t>(v[i]) * inv_temp;
+      vec_max = (i == 0) ? val : math::max(vec_max, val);
+      cache[i] = val;
+    }
+    const auto old_max = m;
+    m = math::max(m, vec_max);
+    s *= math::exp(old_max - m);
+#pragma unroll
+    for (int i = 0; i < kVecN; ++i) {
+      s += math::exp(cache[i] - m);
     }
   }
 
-  const auto [global_max, global_sum] = cta_online_softmax_merge(m, s);
+  __shared__ fp32x2_t smem_ms[32];
+  const auto [global_max, global_sum] = cta_online_softmax_merge(m, s, smem_ms, kBlockSize / kWarpThreads);
   const float row_max = global_max;
   const float inv_sum = 1.0f / global_sum;
 
@@ -181,50 +181,40 @@ SGL_SOFTMAX_KERNEL softmax_split_kernel(const __grid_constant__ SoftmaxParams pa
   if (c_start >= vocab_size) return;
   const uint32_t c_len = c_end - c_start;
 
-  __shared__ float smem_max[kNumWarps];
+  __shared__ fp32x2_t smem_ms[32];
 
   const DType* c_in = row_in + c_start;
-  DType* c_out = row_out + c_start;
 
   const uint32_t n_vecs = c_len / kVecN;
 
   // --- local max ---
-  float tmax = -FLT_MAX;
+  float m = -FLT_MAX;
+  float s = 0.0f;
   for (uint32_t vi = threadIdx.x; vi < n_vecs; vi += kBlockSize) {
     vec_t v;
     v.load(c_in, vi);
+    float cache[kVecN];
+    float vec_max = -FLT_MAX;
 #pragma unroll
     for (int i = 0; i < kVecN; ++i) {
-      tmax = math::max(tmax, cast<fp32_t>(v[i]) * inv_temp);
+      const auto val = cast<fp32_t>(v[i]) * inv_temp;
+      vec_max = (i == 0) ? val : math::max(vec_max, val);
+      cache[i] = val;
     }
-  }
-
-  cta::reduce_max(tmax, smem_max, /*min_value=*/-FLT_MAX);
-  __syncthreads();
-  const float local_max = smem_max[0];
-
-  // --- local sum + write partial exp (as DType) ---
-  float tsum = 0.0f;
-  for (uint32_t vi = threadIdx.x; vi < n_vecs; vi += kBlockSize) {
-    vec_t v_in;
-    v_in.load(c_in, vi);
-    vec_t v_out;
+    const auto old_max = m;
+    m = math::max(m, vec_max);
+    s *= math::exp(old_max - m);
 #pragma unroll
     for (int i = 0; i < kVecN; ++i) {
-      float e = math::exp(cast<fp32_t>(v_in[i]) * inv_temp - local_max);
-      v_out[i] = cast<DType>(e);
-      tsum += e;
+      s += math::exp(cache[i] - m);
     }
-    v_out.store(c_out, vi);
-  }
-
-  cta::reduce_sum(tsum, smem_max);
-  __syncthreads();
-  if (threadIdx.x == 0) {
-    partial_ms[row * num_splits + sid] = fp32x2_t{local_max, smem_max[0]};
   }
 
   PDLTriggerSecondary<kUsePDL>();
+  const auto partial_result = cta_online_softmax_merge(m, s, smem_ms, kBlockSize / kWarpThreads);
+  if (threadIdx.x == 0) {
+    partial_ms[row * num_splits + sid] = partial_result;
+  }
 }
 
 // ============================================================================
@@ -240,8 +230,7 @@ SGL_SOFTMAX_KERNEL softmax_merge_kernel(const __grid_constant__ SoftmaxParams pa
   using namespace device;
   using vec_t = AlignedVector<DType, kVecN>;
 
-  PDLWaitPrimary<kUsePDL>();
-
+  const auto input = static_cast<const DType*>(params.input);
   const auto output = static_cast<DType*>(params.output);
   const auto partial_ms = static_cast<const fp32x2_t*>(params.workspace);
   const auto vocab_size = params.vocab_size;
@@ -249,7 +238,9 @@ SGL_SOFTMAX_KERNEL softmax_merge_kernel(const __grid_constant__ SoftmaxParams pa
 
   const uint32_t row = blockIdx.x;
   const uint32_t sid = blockIdx.y;
+  const DType* row_in = input + static_cast<uint64_t>(row) * vocab_size;
   DType* row_out = output + static_cast<uint64_t>(row) * vocab_size;
+  const float inv_temp = 1.0f / params.get_temperature(row);
 
   // Compute this block's chunk range (same formula as split kernel)
   const uint32_t chunk_raw = div_ceil(vocab_size, num_splits);
@@ -262,30 +253,32 @@ SGL_SOFTMAX_KERNEL softmax_merge_kernel(const __grid_constant__ SoftmaxParams pa
   const uint32_t lane = threadIdx.x % kWarpThreads;
   const uint32_t warp_id = threadIdx.x / kWarpThreads;
 
+  PDLWaitPrimary<kUsePDL>();
+
   // --- Warp 0: merge all partial (max, sum) -> correction for this chunk ---
-  __shared__ float shared_corr;  // correction = exp(local_max - global_max) / global_sum
-  const auto [local_max, local_sum] = partial_ms[row * num_splits + sid];
+  __shared__ fp32x2_t shared_result;
   if (warp_id == 0) {
     const auto ms = lane < num_splits ? partial_ms[row * num_splits + lane] : fp32x2_t{-FLT_MAX, 0.0f};
-    const auto [global_max, global_sum] = warp_online_softmax_merge(ms);
-    shared_corr = math::exp(local_max - global_max) / global_sum;
+    shared_result = warp_online_softmax_merge(ms);
   }
   __syncthreads();
+  const auto [row_max, row_sum] = shared_result;
 
   // --- All threads: apply uniform correction to this chunk ---
-  const float corr = shared_corr;
+  const DType* c_in = row_in + c_start;
   DType* c_out = row_out + c_start;
-
   const uint32_t n_vecs = c_len / kVecN;
 
   for (uint32_t vi = threadIdx.x; vi < n_vecs; vi += kBlockSize) {
     vec_t v;
-    v.load(c_out, vi);
+    v.load(c_in, vi);
+    vec_t v_out;
 #pragma unroll
     for (int i = 0; i < kVecN; ++i) {
-      v[i] = cast<DType>(cast<fp32_t>(v[i]) * corr);
+      const auto val = cast<fp32_t>(v[i]) * inv_temp;
+      v_out[i] = cast<DType>(math::exp(val - row_max) / row_sum);
     }
-    v.store(c_out, vi);
+    v_out.store(c_out, vi);
   }
 
   PDLTriggerSecondary<kUsePDL>();

--- a/python/sglang/jit_kernel/csrc/elementwise/softmax.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/softmax.cuh
@@ -159,8 +159,6 @@ SGL_SOFTMAX_KERNEL softmax_split_kernel(const __grid_constant__ SoftmaxParams pa
   using namespace device;
   using vec_t = AlignedVector<DType, kVecN>;
 
-  PDLWaitPrimary<kUsePDL>();
-
   const auto input = static_cast<const DType*>(params.input);
   const auto output = static_cast<DType*>(params.output);
   const auto partial_ms = static_cast<fp32x2_t*>(params.workspace);
@@ -171,15 +169,16 @@ SGL_SOFTMAX_KERNEL softmax_split_kernel(const __grid_constant__ SoftmaxParams pa
   const uint32_t sid = blockIdx.y;
   const DType* row_in = input + static_cast<uint64_t>(row) * vocab_size;
   DType* row_out = output + static_cast<uint64_t>(row) * vocab_size;
-  const float inv_temp = 1.0f / params.get_temperature(row);
 
   // Aligned chunk boundaries for vectorized loads
   const uint32_t chunk_raw = div_ceil(vocab_size, num_splits);
   const uint32_t chunk = div_ceil(chunk_raw, kVecN) * kVecN;
-  const uint32_t c_start = sid * chunk;
+  const uint32_t c_start = min(sid * chunk, vocab_size);
   const uint32_t c_end = min(c_start + chunk, vocab_size);
-  if (c_start >= vocab_size) return;
   const uint32_t c_len = c_end - c_start;
+
+  PDLWaitPrimary<kUsePDL>();
+  const float inv_temp = 1.0f / params.get_temperature(row);
 
   __shared__ fp32x2_t smem_ms[32];
 
@@ -245,9 +244,8 @@ SGL_SOFTMAX_KERNEL softmax_merge_kernel(const __grid_constant__ SoftmaxParams pa
   // Compute this block's chunk range (same formula as split kernel)
   const uint32_t chunk_raw = div_ceil(vocab_size, num_splits);
   const uint32_t chunk = div_ceil(chunk_raw, kVecN) * kVecN;
-  const uint32_t c_start = sid * chunk;
+  const uint32_t c_start = min(sid * chunk, vocab_size);
   const uint32_t c_end = min(c_start + chunk, vocab_size);
-  if (c_start >= vocab_size) return;
   const uint32_t c_len = c_end - c_start;
 
   const uint32_t lane = threadIdx.x % kWarpThreads;

--- a/python/sglang/jit_kernel/csrc/elementwise/softmax.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/softmax.cuh
@@ -1,0 +1,385 @@
+/// \file softmax.cuh
+/// \brief Softmax kernels for LLM sampling with large vocabulary sizes.
+///
+/// Unified launcher `SoftmaxKernel<kUsePDL, DType>::run` dispatches between:
+///   - **Fused** (num_splits is None): one CTA per row, online softmax
+///     (single-pass max+sum, then normalize+write)
+///   - **Split** (num_splits is set):  multi-CTA per row partial softmax +
+///     warp-level merge correction.  num_splits must be <= 32.
+///
+/// Output dtype matches input dtype.  All internal computation is in fp32.
+
+#include <sgl_kernel/ffi.h>
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/cta.cuh>
+#include <sgl_kernel/math.cuh>
+#include <sgl_kernel/runtime.cuh>
+#include <sgl_kernel/type.cuh>
+#include <sgl_kernel/utils.cuh>
+#include <sgl_kernel/vec.cuh>
+#include <sgl_kernel/warp.cuh>
+
+#include <tvm/ffi/container/tensor.h>
+#include <tvm/ffi/optional.h>
+
+#include <cfloat>
+
+namespace {
+
+constexpr uint32_t kBlockSize = 1024;
+constexpr uint32_t kNumWarps = kBlockSize / device::kWarpThreads;  // 32
+
+// Target occupancy is 2
+#define SGL_SOFTMAX_KERNEL __global__ void __launch_bounds__(kBlockSize, 2)
+
+// ============================================================================
+// Params struct shared by all kernels
+// ============================================================================
+
+struct SoftmaxParams {
+  const void* __restrict__ input;
+  void* __restrict__ output;
+  void* __restrict__ workspace;  // partial (max, sum) pairs for split path
+  const float* __restrict__ ts;  // per-row temperatures (null -> use scalar t)
+  float t;                       // scalar temperature fallback
+  uint32_t vocab_size;
+  uint32_t num_splits;  // 0 for fused, <=32 for split
+
+  SGL_DEVICE float get_temperature(uint32_t row) const {
+    return ts ? ts[row] : t;
+  }
+};
+
+// ============================================================================
+// Online softmax helpers
+// ============================================================================
+
+/// Warp-level online softmax merge across all 32 lanes.
+SGL_DEVICE fp32x2_t warp_online_softmax_merge(fp32x2_t ms) {
+  namespace math = device::math;
+  auto [m, s] = ms;
+#pragma unroll
+  for (int mask = 16; mask > 0; mask >>= 1) {
+    float om = __shfl_xor_sync(0xffffffffu, m, mask);
+    float os = __shfl_xor_sync(0xffffffffu, s, mask);
+    float nm = math::max(m, om);
+    s = s * math::exp(m - nm) + os * math::exp(om - nm);
+    m = nm;
+  }
+  return fp32x2_t{m, s};
+}
+
+/// CTA-level online softmax merge.
+/// smem must have at least 2 * kNumWarps floats.
+/// After return, all threads see the final (max, sum) in (m, s).
+[[maybe_unused]]
+SGL_DEVICE fp32x2_t cta_online_softmax_merge(float m, float s) {
+  __shared__ fp32x2_t smem_ms[kNumWarps];
+
+  const uint32_t warp_id = threadIdx.x / device::kWarpThreads;
+  const uint32_t lane_id = threadIdx.x % device::kWarpThreads;
+
+  smem_ms[warp_id] = warp_online_softmax_merge({m, s});
+  __syncthreads();
+  if (warp_id == 0) {
+    const auto ms = lane_id < kNumWarps ? smem_ms[lane_id] : fp32x2_t{-FLT_MAX, 0.0f};
+    smem_ms[lane_id] = warp_online_softmax_merge(ms);
+  }
+  __syncthreads();
+  return smem_ms[warp_id];
+}
+
+// ============================================================================
+// Kernel A: Single-block fused softmax (online: 1 pass for max+sum)
+// ============================================================================
+
+template <typename DType, int kVecN, bool kUsePDL>
+SGL_SOFTMAX_KERNEL softmax_fused_kernel(const __grid_constant__ SoftmaxParams params) {
+  using namespace device;
+  using vec_t = AlignedVector<DType, kVecN>;
+
+  PDLWaitPrimary<kUsePDL>();
+
+  const auto input = static_cast<const DType*>(params.input);
+  const auto output = static_cast<DType*>(params.output);
+  const auto vocab_size = params.vocab_size;
+
+  const uint32_t row = blockIdx.x;
+  const DType* row_in = input + static_cast<uint64_t>(row) * vocab_size;
+  DType* row_out = output + static_cast<uint64_t>(row) * vocab_size;
+  const float inv_temp = 1.0f / params.get_temperature(row);
+
+  const uint32_t n_vecs = vocab_size / kVecN;
+
+  // --- Pass 1: online softmax (single-pass max + sum) ---
+  float m = -FLT_MAX;
+  float s = 0.0f;
+  for (uint32_t vi = threadIdx.x; vi < n_vecs; vi += kBlockSize) {
+    vec_t v;
+    v.load(row_in, vi);
+#pragma unroll
+    for (int i = 0; i < kVecN; ++i) {
+      float val = cast<fp32_t>(v[i]) * inv_temp;
+      float old_m = m;
+      m = math::max(m, val);
+      s = s * math::exp(old_m - m) + math::exp(val - m);
+    }
+  }
+
+  const auto [global_max, global_sum] = cta_online_softmax_merge(m, s);
+  const float row_max = global_max;
+  const float inv_sum = 1.0f / global_sum;
+
+  // --- Pass 2: normalize & write (output dtype = input dtype) ---
+  for (uint32_t vi = threadIdx.x; vi < n_vecs; vi += kBlockSize) {
+    vec_t v_in;
+    v_in.load(row_in, vi);
+    vec_t v_out;
+#pragma unroll
+    for (int i = 0; i < kVecN; ++i) {
+      v_out[i] = cast<DType>(math::exp(cast<fp32_t>(v_in[i]) * inv_temp - row_max) * inv_sum);
+    }
+    v_out.store(row_out, vi);
+  }
+
+  PDLTriggerSecondary<kUsePDL>();
+}
+
+// ============================================================================
+// Kernel B1: Split partial softmax (map)
+// ============================================================================
+// Grid: (batch_size, num_splits).  Each block processes one chunk.
+// Writes partial exp(x/T - local_max) as DType to output, plus
+// (local_max, local_sum) to workspace as float2 pairs.
+
+template <typename DType, int kVecN, bool kUsePDL>
+SGL_SOFTMAX_KERNEL softmax_split_kernel(const __grid_constant__ SoftmaxParams params) {
+  using namespace device;
+  using vec_t = AlignedVector<DType, kVecN>;
+
+  PDLWaitPrimary<kUsePDL>();
+
+  const auto input = static_cast<const DType*>(params.input);
+  const auto output = static_cast<DType*>(params.output);
+  const auto partial_ms = static_cast<fp32x2_t*>(params.workspace);
+  const auto vocab_size = params.vocab_size;
+  const auto num_splits = params.num_splits;
+
+  const uint32_t row = blockIdx.x;
+  const uint32_t sid = blockIdx.y;
+  const DType* row_in = input + static_cast<uint64_t>(row) * vocab_size;
+  DType* row_out = output + static_cast<uint64_t>(row) * vocab_size;
+  const float inv_temp = 1.0f / params.get_temperature(row);
+
+  // Aligned chunk boundaries for vectorized loads
+  const uint32_t chunk_raw = div_ceil(vocab_size, num_splits);
+  const uint32_t chunk = div_ceil(chunk_raw, kVecN) * kVecN;
+  const uint32_t c_start = sid * chunk;
+  const uint32_t c_end = min(c_start + chunk, vocab_size);
+  if (c_start >= vocab_size) return;
+  const uint32_t c_len = c_end - c_start;
+
+  __shared__ float smem_max[kNumWarps];
+
+  const DType* c_in = row_in + c_start;
+  DType* c_out = row_out + c_start;
+
+  const uint32_t n_vecs = c_len / kVecN;
+
+  // --- local max ---
+  float tmax = -FLT_MAX;
+  for (uint32_t vi = threadIdx.x; vi < n_vecs; vi += kBlockSize) {
+    vec_t v;
+    v.load(c_in, vi);
+#pragma unroll
+    for (int i = 0; i < kVecN; ++i) {
+      tmax = math::max(tmax, cast<fp32_t>(v[i]) * inv_temp);
+    }
+  }
+
+  cta::reduce_max(tmax, smem_max, /*min_value=*/-FLT_MAX);
+  __syncthreads();
+  const float local_max = smem_max[0];
+
+  // --- local sum + write partial exp (as DType) ---
+  float tsum = 0.0f;
+  for (uint32_t vi = threadIdx.x; vi < n_vecs; vi += kBlockSize) {
+    vec_t v_in;
+    v_in.load(c_in, vi);
+    vec_t v_out;
+#pragma unroll
+    for (int i = 0; i < kVecN; ++i) {
+      float e = math::exp(cast<fp32_t>(v_in[i]) * inv_temp - local_max);
+      v_out[i] = cast<DType>(e);
+      tsum += e;
+    }
+    v_out.store(c_out, vi);
+  }
+
+  cta::reduce_sum(tsum, smem_max);
+  __syncthreads();
+  if (threadIdx.x == 0) {
+    partial_ms[row * num_splits + sid] = fp32x2_t{local_max, smem_max[0]};
+  }
+
+  PDLTriggerSecondary<kUsePDL>();
+}
+
+// ============================================================================
+// Kernel B2: Split merge + correction (reduce)
+// ============================================================================
+// Grid: (batch_size, num_splits).  Each block corrects one chunk.
+// Warp 0 in every block redundantly merges all partial (max, sum) - cheap
+// since num_splits <= 32.  Then all threads apply the uniform per-chunk
+// correction factor.
+
+template <typename DType, int kVecN, bool kUsePDL>
+SGL_SOFTMAX_KERNEL softmax_merge_kernel(const __grid_constant__ SoftmaxParams params) {
+  using namespace device;
+  using vec_t = AlignedVector<DType, kVecN>;
+
+  PDLWaitPrimary<kUsePDL>();
+
+  const auto output = static_cast<DType*>(params.output);
+  const auto partial_ms = static_cast<const fp32x2_t*>(params.workspace);
+  const auto vocab_size = params.vocab_size;
+  const auto num_splits = params.num_splits;
+
+  const uint32_t row = blockIdx.x;
+  const uint32_t sid = blockIdx.y;
+  DType* row_out = output + static_cast<uint64_t>(row) * vocab_size;
+
+  // Compute this block's chunk range (same formula as split kernel)
+  const uint32_t chunk_raw = div_ceil(vocab_size, num_splits);
+  const uint32_t chunk = div_ceil(chunk_raw, kVecN) * kVecN;
+  const uint32_t c_start = sid * chunk;
+  const uint32_t c_end = min(c_start + chunk, vocab_size);
+  if (c_start >= vocab_size) return;
+  const uint32_t c_len = c_end - c_start;
+
+  const uint32_t lane = threadIdx.x % kWarpThreads;
+  const uint32_t warp_id = threadIdx.x / kWarpThreads;
+
+  // --- Warp 0: merge all partial (max, sum) -> correction for this chunk ---
+  __shared__ float shared_corr;  // correction = exp(local_max - global_max) / global_sum
+  const auto [local_max, local_sum] = partial_ms[row * num_splits + sid];
+  if (warp_id == 0) {
+    const auto ms = lane < num_splits ? partial_ms[row * num_splits + lane] : fp32x2_t{-FLT_MAX, 0.0f};
+    const auto [global_max, global_sum] = warp_online_softmax_merge(ms);
+    shared_corr = math::exp(local_max - global_max) / global_sum;
+  }
+  __syncthreads();
+
+  // --- All threads: apply uniform correction to this chunk ---
+  const float corr = shared_corr;
+  DType* c_out = row_out + c_start;
+
+  const uint32_t n_vecs = c_len / kVecN;
+
+  for (uint32_t vi = threadIdx.x; vi < n_vecs; vi += kBlockSize) {
+    vec_t v;
+    v.load(c_out, vi);
+#pragma unroll
+    for (int i = 0; i < kVecN; ++i) {
+      v[i] = cast<DType>(cast<fp32_t>(v[i]) * corr);
+    }
+    v.store(c_out, vi);
+  }
+
+  PDLTriggerSecondary<kUsePDL>();
+}
+
+#undef SGL_SOFTMAX_KERNEL
+
+// ============================================================================
+// Unified host launcher
+// ============================================================================
+
+template <bool kUsePDL, typename DType>
+struct SoftmaxKernel {
+  static constexpr int kVecN = 16 / sizeof(DType);
+  static constexpr auto fused_kernel = softmax_fused_kernel<DType, kVecN, kUsePDL>;
+  static constexpr auto split_kernel = softmax_split_kernel<DType, kVecN, kUsePDL>;
+  static constexpr auto merge_kernel = softmax_merge_kernel<DType, kVecN, kUsePDL>;
+
+  static void
+  run(const tvm::ffi::TensorView input,
+      const tvm::ffi::TensorView output,
+      const tvm::ffi::Optional<tvm::ffi::TensorView> temperatures,
+      const float temperature,
+      uint32_t num_splits) {
+    using namespace host;
+
+    auto B = SymbolicSize{"batch_size"};
+    auto V = SymbolicSize{"vocab_size"};
+    auto device_ = SymbolicDevice{};
+    device_.set_options<kDLCUDA>();
+
+    TensorMatcher({B, V})  //
+        .with_dtype<DType>()
+        .with_device(device_)
+        .verify(input)
+        .verify(output);
+    if (temperatures.has_value()) {
+      TensorMatcher({B})  //
+          .with_dtype<fp32_t>()
+          .with_device(device_)
+          .verify(temperatures.value());
+    }
+
+    const auto batch_size = static_cast<uint32_t>(B.unwrap());
+    const auto vocab_size = static_cast<uint32_t>(V.unwrap());
+    const auto device = device_.unwrap();
+
+    if (batch_size == 0) return;
+    RuntimeCheck(vocab_size % kVecN == 0, "vocab_size must be a multiple of ", kVecN, ", got ", vocab_size);
+
+    if (num_splits == 0) {
+      static const auto kNumSM = runtime::get_sm_count(device.device_id);
+      // Find max splits (power-of-2) that can saturate 2 * kNumSM
+      num_splits = 1;
+      for (uint32_t s = 32; s > 1; s /= 2) {
+        if (batch_size * s <= 2 * kNumSM) {
+          num_splits = s;
+          break;
+        }
+      }
+    }
+
+    auto params = SoftmaxParams{
+        .input = input.data_ptr(),
+        .output = output.data_ptr(),
+        .workspace = nullptr,
+        .ts = temperatures.has_value() ? static_cast<const float*>(temperatures.value().data_ptr()) : nullptr,
+        .t = temperature,
+        .vocab_size = vocab_size,
+        .num_splits = num_splits,
+    };
+
+    if (num_splits <= 1) {
+      // ---- Fused path: one CTA per row ----
+      LaunchKernel(batch_size, kBlockSize, device)  //
+          .enable_pdl(kUsePDL)(fused_kernel, params);
+    } else {
+      // ---- Split path: multi-CTA per row ----
+      RuntimeCheck(num_splits <= 32, "num_splits must be <= 32 for split softmax");
+
+      // Allocate workspace: num_splits float2 pairs per row
+      const int64_t ws_elems = static_cast<int64_t>(batch_size) * num_splits * 2;
+      const auto workspace = ffi::empty({ws_elems}, get_dtype<float>(), device);
+      params.workspace = workspace.data_ptr();
+
+      // Kernel B1: partial softmax
+      LaunchKernel({batch_size, num_splits}, kBlockSize, device)  //
+          .enable_pdl(kUsePDL)(split_kernel, params);
+
+      // Kernel B2: merge + correction
+      LaunchKernel({batch_size, num_splits}, kBlockSize, device)  //
+          .enable_pdl(kUsePDL)(merge_kernel, params);
+    }
+  }
+};
+
+}  // namespace

--- a/python/sglang/jit_kernel/csrc/elementwise/softmax.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/softmax.cuh
@@ -57,7 +57,7 @@ struct SoftmaxParams {
 /// Warp-level online softmax merge across all 32 lanes.
 SGL_DEVICE fp32x2_t warp_online_softmax_merge(fp32x2_t ms) {
   using namespace device;
-  auto [m, s] = ms;
+  const auto [m, s] = ms;
   const auto warp_max = warp::reduce_max(m);
   const auto warp_sum = warp::reduce_sum(s * math::exp(m - warp_max));
   return {warp_max, warp_sum};

--- a/python/sglang/jit_kernel/csrc/elementwise/softmax.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/softmax.cuh
@@ -160,7 +160,6 @@ SGL_SOFTMAX_KERNEL softmax_split_kernel(const __grid_constant__ SoftmaxParams pa
   using vec_t = AlignedVector<DType, kVecN>;
 
   const auto input = static_cast<const DType*>(params.input);
-  const auto output = static_cast<DType*>(params.output);
   const auto partial_ms = static_cast<fp32x2_t*>(params.workspace);
   const auto vocab_size = params.vocab_size;
   const auto num_splits = params.num_splits;
@@ -168,7 +167,6 @@ SGL_SOFTMAX_KERNEL softmax_split_kernel(const __grid_constant__ SoftmaxParams pa
   const uint32_t row = blockIdx.x;
   const uint32_t sid = blockIdx.y;
   const DType* row_in = input + static_cast<uint64_t>(row) * vocab_size;
-  DType* row_out = output + static_cast<uint64_t>(row) * vocab_size;
 
   // Aligned chunk boundaries for vectorized loads
   const uint32_t chunk_raw = div_ceil(vocab_size, num_splits);

--- a/python/sglang/jit_kernel/include/sgl_kernel/cta.cuh
+++ b/python/sglang/jit_kernel/include/sgl_kernel/cta.cuh
@@ -25,14 +25,42 @@ namespace device::cta {
  */
 template <typename T>
 SGL_DEVICE void reduce_max(T value, float* smem, float min_value = 0.0f) {
-  const uint32_t warp_id = threadIdx.x / kWarpThreads;
+  const auto tx = threadIdx.x;
+  const uint32_t warp_id = tx / kWarpThreads;
   smem[warp_id] = warp::reduce_max(value);
   __syncthreads();
   if (warp_id == 0) {
-    const auto tx = threadIdx.x;
     const auto local_value = tx * kWarpThreads < blockDim.x ? smem[tx] : min_value;
     const auto max_value = warp::reduce_max(local_value);
     smem[0] = max_value;
+  }
+  // no extra sync; it is caller's responsibility to sync if needed
+}
+
+/**
+ * \brief Compute the sum of `value` across all threads in the CTA.
+ *
+ * Uses a two-level reduction: first within each warp via `warp::reduce_sum`,
+ * then across warps using shared memory. The final result is stored in
+ * `smem[0]`.
+ *
+ * \tparam T Numeric type (must be supported by `warp::reduce_sum`).
+ * \param value Per-thread input value.
+ * \param smem Shared memory buffer (must have at least `blockDim.x / 32`
+ *             elements).
+ * \note This function does NOT issue a trailing `__syncthreads()`.
+ *       Callers must synchronize before reading `smem[0]`.
+ */
+template <typename T>
+SGL_DEVICE void reduce_sum(T value, float* smem) {
+  const auto tx = threadIdx.x;
+  const uint32_t warp_id = tx / kWarpThreads;
+  smem[warp_id] = warp::reduce_sum(value);
+  __syncthreads();
+  if (warp_id == 0) {
+    const auto local_value = tx * kWarpThreads < blockDim.x ? smem[tx] : 0.0f;
+    const auto sum_value = warp::reduce_sum(local_value);
+    smem[0] = sum_value;
   }
   // no extra sync; it is caller's responsibility to sync if needed
 }

--- a/python/sglang/jit_kernel/include/sgl_kernel/tensor.h
+++ b/python/sglang/jit_kernel/include/sgl_kernel/tensor.h
@@ -591,4 +591,9 @@ struct TensorMatcher {
   bool m_has_device = false;
 };
 
+template <typename T>
+inline constexpr auto get_dtype() -> DLDataType {
+  return details::_dtype_trait<T>::value;
+}
+
 }  // namespace host

--- a/python/sglang/jit_kernel/softmax.py
+++ b/python/sglang/jit_kernel/softmax.py
@@ -32,6 +32,7 @@ def _jit_softmax_module(dtype: torch.dtype) -> Module:
         *args,
         cuda_files=["elementwise/softmax.cuh"],
         cuda_wrappers=[("softmax", f"SoftmaxKernel<{args}>::run")],
+        extra_cuda_cflags=["--use_fast_math"],
     )
 
 

--- a/python/sglang/jit_kernel/softmax.py
+++ b/python/sglang/jit_kernel/softmax.py
@@ -1,0 +1,76 @@
+"""Softmax kernel for LLM sampling with large vocabulary sizes.
+
+Two execution paths dispatched at runtime via `num_splits`:
+  - **Fused** (num_splits=None): single-block per row
+  - **Split** (num_splits>1): multi-block per row with merge
+
+out dtype matches input dtype.  All internal computation is in fp32.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.jit_kernel.utils import (
+    cache_once,
+    is_arch_support_pdl,
+    load_jit,
+    make_cpp_args,
+)
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+@cache_once
+def _jit_softmax_module(dtype: torch.dtype) -> Module:
+    args = make_cpp_args(is_arch_support_pdl(), dtype)
+    return load_jit(
+        "softmax",
+        *args,
+        cuda_files=["elementwise/softmax.cuh"],
+        cuda_wrappers=[("softmax", f"SoftmaxKernel<{args}>::run")],
+    )
+
+
+def can_use_softmax_sampling(logits: torch.Tensor) -> bool:
+    dtype = logits.dtype
+    return (
+        logits.is_cuda
+        and dtype in (torch.float16, torch.bfloat16, torch.float32)
+        and (logits.shape[-1] * dtype.itemsize) % 16 == 0
+    )
+
+
+def softmax_sampling(
+    logits: torch.Tensor,
+    temperatures: torch.Tensor,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Compute softmax with fused temperature scaling for sampling.
+
+    Parameters
+    ----------
+    logits : torch.Tensor
+        Input logits of shape ``(batch_size, vocab_size)``.
+        Supported dtypes: float16, bfloat16, float32.
+    temperatures : torch.Tensor
+        Per-row temperature of shape ``(batch_size,)`` in float32.
+        Must be > 0 for all elements.
+    out : torch.Tensor, optional
+        Pre-allocated out tensor of shape ``(batch_size, vocab_size)``
+        with the same dtype as logits. If None, one is allocated.
+
+    Returns
+    -------
+    torch.Tensor
+        Probability distribution of shape ``(batch_size, vocab_size)``
+        with the same dtype as logits.
+    """
+    if out is None:
+        out = torch.empty_like(logits)
+    module = _jit_softmax_module(logits.dtype)
+    module.softmax(logits, out, temperatures, 0.0, 0)
+    return out

--- a/python/sglang/jit_kernel/softmax.py
+++ b/python/sglang/jit_kernel/softmax.py
@@ -38,11 +38,17 @@ def _jit_softmax_module(dtype: torch.dtype) -> Module:
 
 def can_use_softmax_sampling(logits: torch.Tensor) -> bool:
     dtype = logits.dtype
-    return (
+    if not (
         logits.is_cuda
         and dtype in (torch.float16, torch.bfloat16, torch.float32)
         and (logits.shape[-1] * dtype.itemsize) % 16 == 0
-    )
+    ):
+        return False
+    try:
+        _jit_softmax_module(dtype)
+        return True
+    except RuntimeError:
+        return False
 
 
 def softmax_sampling(

--- a/python/sglang/jit_kernel/tests/test_softmax.py
+++ b/python/sglang/jit_kernel/tests/test_softmax.py
@@ -1,0 +1,94 @@
+"""Tests for the softmax sampling kernel."""
+
+import sys
+
+import pytest
+import torch
+
+from sglang.jit_kernel.softmax import softmax_sampling
+from sglang.jit_kernel.utils import get_ci_test_range
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=60, suite="stage-b-kernel-unit-1-gpu-large")
+register_cuda_ci(est_time=300, suite="nightly-kernel-1-gpu", nightly=True)
+
+
+DEVICE = "cuda"
+DTYPES = [torch.float16, torch.bfloat16, torch.float32]
+
+BATCH_SIZES = get_ci_test_range(
+    full_range=[2**x for x in range(10)] + [2**x + 1 for x in range(1, 10)],
+    ci_range=[1, 4, 7, 64, 128],
+)
+VOCAB_SIZES = get_ci_test_range(
+    full_range=[1024, 4096, 8192, 32000, 32768, 65536, 128256, 151936, 262144],
+    ci_range=[32000, 128256],
+)
+TEMPERATURES = [0.1, 0.6, 1.0, 2.0]
+
+
+def _ref_softmax(logits: torch.Tensor, temperatures: torch.Tensor) -> torch.Tensor:
+    """Reference implementation using PyTorch.  Returns same dtype as input."""
+    scaled = logits.float() / temperatures.unsqueeze(1)
+    return torch.softmax(scaled, dim=-1).to(logits.dtype)
+
+
+def _tolerances(dtype: torch.dtype) -> dict:
+    if dtype == torch.float32:
+        return dict(rtol=5e-4, atol=5e-5)
+    return dict(rtol=1e-2, atol=1e-3)
+
+
+@pytest.mark.parametrize("batch_size", BATCH_SIZES)
+@pytest.mark.parametrize("vocab_size", VOCAB_SIZES)
+@pytest.mark.parametrize("temperature", TEMPERATURES)
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_softmax(
+    batch_size: int, vocab_size: int, temperature: float, dtype: torch.dtype
+):
+    """Test that temperature scaling works correctly."""
+    torch.manual_seed(42)
+    logits = torch.randn(batch_size, vocab_size, dtype=dtype, device=DEVICE)
+    temperatures = torch.full(
+        (batch_size,), temperature, dtype=torch.float32, device=DEVICE
+    )
+    result = softmax_sampling(logits, temperatures)
+    expected = _ref_softmax(logits, temperatures)
+    torch.testing.assert_close(result, expected, **_tolerances(dtype))
+
+
+@pytest.mark.parametrize("batch_size", BATCH_SIZES)
+@pytest.mark.parametrize("vocab_size", VOCAB_SIZES)
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_softmax_per_row_temperature(
+    batch_size: int, vocab_size: int, dtype: torch.dtype
+):
+    """Test per-row (heterogeneous) temperature scaling."""
+    torch.manual_seed(42)
+    logits = torch.randn(batch_size, vocab_size, dtype=dtype, device=DEVICE)
+    temperatures = torch.rand(batch_size, dtype=torch.float32, device=DEVICE)
+    temperatures.clamp_(0.001, 2.0)
+    result = softmax_sampling(logits, temperatures)
+    expected = _ref_softmax(logits, temperatures)
+    torch.testing.assert_close(result, expected, **_tolerances(dtype))
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_softmax_math_properties(dtype: torch.dtype):
+    """Verify output probabilities sum to ~1.0 for each row."""
+    torch.manual_seed(42)
+    batch_size, vocab_size = 256, 128256
+    logits = torch.randn(batch_size, vocab_size, dtype=dtype, device=DEVICE)
+    temperatures = torch.ones(batch_size, dtype=torch.float32, device=DEVICE)
+    result = softmax_sampling(logits, temperatures)
+    row_sums = result.float().sum(dim=-1)
+    torch.testing.assert_close(
+        row_sums,
+        torch.ones(batch_size, dtype=torch.float32, device=DEVICE),
+        **_tolerances(torch.float32),
+    )
+    assert torch.all(result >= 0), "All probabilities must be non-negative"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))

--- a/python/sglang/jit_kernel/tests/test_softmax.py
+++ b/python/sglang/jit_kernel/tests/test_softmax.py
@@ -9,8 +9,8 @@ from sglang.jit_kernel.softmax import softmax_sampling
 from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=60, suite="stage-b-kernel-unit-1-gpu-large")
-register_cuda_ci(est_time=300, suite="nightly-kernel-1-gpu", nightly=True)
+register_cuda_ci(est_time=40, suite="stage-b-kernel-unit-1-gpu-large")
+register_cuda_ci(est_time=60, suite="nightly-kernel-1-gpu", nightly=True)
 
 
 DEVICE = "cuda"

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -5,6 +5,7 @@ import torch
 import torch.distributed as dist
 from torch import nn
 
+from sglang.jit_kernel.softmax import can_use_softmax_sampling, softmax_sampling
 from sglang.srt.distributed import get_tp_group
 from sglang.srt.layers.dp_attention import (
     get_attention_tp_group,
@@ -152,11 +153,17 @@ class Sampler(nn.Module):
                     logprobs = logprobs_via_logsoftmax_kernel
             else:
                 # Standard path: do softmax and sample from probs.
-                logits.div_(sampling_info.temperatures)
-
-                # In-place op to save memory
-                logits[:] = torch.softmax(logits, dim=-1)
+                if is_cuda() and can_use_softmax_sampling(logits):
+                    softmax_sampling(
+                        logits,
+                        sampling_info.temperatures,
+                        out=logits,
+                    )
+                else:
+                    logits.div_(sampling_info.temperatures)
+                    logits[:] = torch.softmax(logits, dim=-1)
                 probs = logits
+                del logits
 
                 batch_next_token_ids = self._sample_from_probs(
                     probs, sampling_info, positions, simple_sampling_case

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -156,7 +156,7 @@ class Sampler(nn.Module):
                 if is_cuda() and can_use_softmax_sampling(logits):
                     softmax_sampling(
                         logits,
-                        sampling_info.temperatures,
+                        sampling_info.temperatures.view(-1),
                         out=logits,
                     )
                 else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
#22166

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
```
softmax-sampling-performance:
    vocab_size  batch_size  SGL JIT Softmax  FlashInfer      PyTorch
0      32000.0         1.0         3.084171   11.206947    13.442613
1      32000.0         2.0         3.243761   12.058290    13.801857
2      32000.0         4.0         3.366917   12.020576    13.998493
3      32000.0         8.0         3.957169   12.247240    14.276432
4      32000.0        16.0         4.339635   12.755289    14.484571
5      32000.0        32.0         5.110417   13.695881    16.371741
6      32000.0        64.0         6.810125   18.436091    21.071408
7      32000.0       128.0        10.301315   31.093550    30.401784
8      32000.0       256.0        12.482902   49.231101    61.655146
9      32000.0       512.0        24.162666  100.382581   128.809948
10     65536.0         1.0         3.242419   14.751664    20.771610
11     65536.0         2.0         3.274547   14.782249    21.113668
12     65536.0         4.0         3.452984   14.961932    21.294367
13     65536.0         8.0         4.334260   15.527087    21.865960
14     65536.0        16.0         5.124802   16.483173    23.616605
15     65536.0        32.0         6.876927   21.229154    28.708663
16     65536.0        64.0        10.477877   32.677027    37.891219
17     65536.0       128.0        17.340179   62.404103    64.116112
18     65536.0       256.0        25.787621  105.810088   135.522856
19     65536.0       512.0        50.102489  212.159831   279.281420
20    128256.0         1.0         3.503183   20.091221    37.328508
21    128256.0         2.0         3.555637   19.598789    37.785088
22    128256.0         4.0         3.898115   20.807676    38.515903
23    128256.0         8.0         5.125130   21.757540    40.270034
24    128256.0        16.0         6.791556   26.285595    44.947359
25    128256.0        32.0        10.367776   37.369063    54.441025
26    128256.0        64.0        17.194513   66.813721    86.935114
27    128256.0       128.0        33.275491  121.306503   149.006747
28    128256.0       256.0        53.829175  207.280522   270.504673
29    128256.0       512.0       104.532424  406.804661   538.744900
30    151936.0         1.0         3.601991   22.189072    42.373730
31    151936.0         2.0         3.692815   22.545393    43.172880
32    151936.0         4.0         4.002354   23.060793    43.472550
33    151936.0         8.0         5.414781   25.436731    46.387806
34    151936.0        16.0         8.022874   31.991610    51.852522
35    151936.0        32.0        12.497505   45.870414    64.076711
36    151936.0        64.0        20.414978   79.690425   107.307291
37    151936.0       128.0        39.839934  141.961532   175.026072
38    151936.0       256.0        63.301896  243.794203   317.895206
39    151936.0       512.0       122.571599  479.038787   631.991999
40    262144.0         1.0         4.257468   31.082710    67.317012
41    262144.0         2.0         4.389752   31.722737    68.248115
42    262144.0         4.0         4.678528   32.721460    70.275058
43    262144.0         8.0         6.804133   37.031971    75.523686
44    262144.0        16.0        10.442610   48.774080    85.310212
45    262144.0        32.0        17.354472   81.367064   129.220969
46    262144.0        64.0        33.405232  132.166701   192.789917
47    262144.0       128.0        62.627593  235.273713   295.089006
48    262144.0       256.0       106.075064  412.020663   542.251560
49    262144.0       512.0       205.828001  814.714670  1078.521013
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
