### PR TITLE
[Diffusion] Sequential Per-Output Execution for Multi-Output Diffusion Generation

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/executors/parallel_executor.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/executors/parallel_executor.py
@@ -126,15 +126,12 @@ class ParallelExecutor(PipelineExecutor):
             else:
                 output_batches.append(
                     OutputBatch(
-                        output=getattr(result, "output", None)
-                        or getattr(result, "latents", None),
-                        trajectory_timesteps=getattr(
-                            result, "trajectory_timesteps", None
-                        ),
-                        trajectory_latents=getattr(result, "trajectory_latents", None),
-                        trajectory_decoded=getattr(result, "trajectory_decoded", None),
-                        metrics=getattr(result, "metrics", None),
-                        noise_pred=getattr(result, "noise_pred", None),
+                        output=result.output or result.latents,
+                        trajectory_timesteps=result.trajectory_timesteps,
+                        trajectory_latents=result.trajectory_latents,
+                        trajectory_decoded=None,
+                        metrics=result.metrics,
+                        noise_pred=result.noise_pred,
                     )
                 )
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/executors/parallel_executor.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/executors/parallel_executor.py
@@ -126,8 +126,15 @@ class ParallelExecutor(PipelineExecutor):
             else:
                 output_batches.append(
                     OutputBatch(
-                        output=getattr(result, "output", None),
+                        output=getattr(result, "output", None)
+                        or getattr(result, "latents", None),
+                        trajectory_timesteps=getattr(
+                            result, "trajectory_timesteps", None
+                        ),
+                        trajectory_latents=getattr(result, "trajectory_latents", None),
+                        trajectory_decoded=getattr(result, "trajectory_decoded", None),
                         metrics=getattr(result, "metrics", None),
+                        noise_pred=getattr(result, "noise_pred", None),
                     )
                 )
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/executors/parallel_executor.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/executors/parallel_executor.py
@@ -13,6 +13,9 @@ from sglang.multimodal_gen.runtime.distributed.parallel_state import (
 from sglang.multimodal_gen.runtime.pipelines_core import Req
 from sglang.multimodal_gen.runtime.pipelines_core.executors.pipeline_executor import (
     PipelineExecutor,
+    _merge_output_batches,
+    _prepare_single_output_batch,
+    _split_stages_by_per_output,
 )
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch
 from sglang.multimodal_gen.runtime.pipelines_core.stages.base import (
@@ -98,5 +101,35 @@ class ParallelExecutor(PipelineExecutor):
         batch: Req,
         server_args: ServerArgs,
     ) -> OutputBatch:
-        batch = self._execute(stages, batch, server_args)
-        return batch
+        num_outputs = batch.num_outputs_per_prompt
+
+        if num_outputs <= 1:
+            return self._execute(stages, batch, server_args)
+
+        shared_stages, per_output_stages = _split_stages_by_per_output(stages)
+        if not per_output_stages:
+            return self._execute(stages, batch, server_args)
+
+        logger.info("Multi-output mode: %d outputs requested.", num_outputs)
+
+        # Phase 1: shared stages (e.g. text encoding) run once
+        batch = self._execute(shared_stages, batch, server_args)
+
+        # Phase 2: per-output stages loop N times with batch_size=1
+        output_batches: List[OutputBatch] = []
+        for i in range(num_outputs):
+            sub_batch = _prepare_single_output_batch(batch, i)
+            result = self._execute(per_output_stages, sub_batch, server_args)
+
+            if isinstance(result, OutputBatch):
+                output_batches.append(result)
+            else:
+                output_batches.append(
+                    OutputBatch(
+                        output=getattr(result, "output", None),
+                        metrics=getattr(result, "metrics", None),
+                    )
+                )
+
+        # Phase 3: merge
+        return _merge_output_batches(output_batches)

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/executors/pipeline_executor.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/executors/pipeline_executor.py
@@ -88,10 +88,7 @@ def _merge_output_batches(output_batches: List[OutputBatch]) -> OutputBatch:
 
     # Cat into (N, ...) tensor so enumerate() yields per-sample slices.
     if outputs and all(isinstance(o, torch.Tensor) for o in outputs):
-        try:
-            outputs = torch.cat(outputs, dim=0)
-        except Exception:
-            pass
+        outputs = torch.cat(outputs, dim=0)
 
     # Bool check safe for both list and tensor.
     has_outputs = (

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/executors/pipeline_executor.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/executors/pipeline_executor.py
@@ -6,8 +6,8 @@ Base class for all pipeline executors.
 """
 
 import contextlib
+import copy
 from abc import ABC, abstractmethod
-from copy import deepcopy
 from typing import TYPE_CHECKING, List
 
 import torch
@@ -59,8 +59,8 @@ def _split_stages_by_per_output(
 
 
 def _prepare_single_output_batch(batch: Req, output_index: int) -> Req:
-    """Create a deep copy of batch configured for a single output."""
-    sub_batch = deepcopy(batch)
+    """Create a shallow copy of batch configured for a single output."""
+    sub_batch = copy.copy(batch)
 
     if isinstance(batch.generator, list) and len(batch.generator) > 1:
         sub_batch.generator = [batch.generator[output_index]]
@@ -98,16 +98,37 @@ def _merge_output_batches(output_batches: List[OutputBatch]) -> OutputBatch:
         outputs.numel() > 0 if isinstance(outputs, torch.Tensor) else bool(outputs)
     )
 
+    # Merge trajectory data across outputs.
+    # trajectory_timesteps are identical for every output – take the first.
     merged_trajectory_timesteps = None
-    merged_trajectory_latents = None
-    merged_trajectory_decoded = None
     for ob in output_batches:
         if ob.trajectory_timesteps is not None:
             merged_trajectory_timesteps = ob.trajectory_timesteps
-        if ob.trajectory_latents is not None:
-            merged_trajectory_latents = ob.trajectory_latents
-        if ob.trajectory_decoded is not None:
-            merged_trajectory_decoded = ob.trajectory_decoded
+            break
+
+    # trajectory_latents: concatenate along batch dim (dim 0).
+    merged_trajectory_latents = None
+    traj_latent_parts = [
+        ob.trajectory_latents
+        for ob in output_batches
+        if ob.trajectory_latents is not None
+    ]
+    if traj_latent_parts:
+        merged_trajectory_latents = torch.cat(traj_latent_parts, dim=0)
+
+    # trajectory_decoded: list[Tensor] per timestep, each shaped [B_i, ...].
+    # Concatenate along batch dim so the merged list keeps the same timesteps.
+    merged_trajectory_decoded = None
+    traj_decoded_parts = [
+        ob.trajectory_decoded
+        for ob in output_batches
+        if ob.trajectory_decoded is not None
+    ]
+    if traj_decoded_parts:
+        merged_trajectory_decoded = [
+            torch.cat([part[t] for part in traj_decoded_parts], dim=0)
+            for t in range(len(traj_decoded_parts[0]))
+        ]
 
     return OutputBatch(
         output=outputs if has_outputs else None,

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/executors/pipeline_executor.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/executors/pipeline_executor.py
@@ -95,8 +95,7 @@ def _merge_output_batches(output_batches: List[OutputBatch]) -> OutputBatch:
 
     # Bool check safe for both list and tensor.
     has_outputs = (
-        outputs.numel() > 0 if isinstance(outputs, torch.Tensor)
-        else bool(outputs)
+        outputs.numel() > 0 if isinstance(outputs, torch.Tensor) else bool(outputs)
     )
 
     merged_trajectory_timesteps = None

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/executors/pipeline_executor.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/executors/pipeline_executor.py
@@ -7,7 +7,10 @@ Base class for all pipeline executors.
 
 import contextlib
 from abc import ABC, abstractmethod
+from copy import deepcopy
 from typing import TYPE_CHECKING, List
+
+import torch
 
 from sglang.multimodal_gen.runtime.distributed import get_world_rank
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch, Req
@@ -33,6 +36,75 @@ class Timer(StageProfiler):
         super().__init__(
             stage_name=name, logger=logger, metrics=None, log_stage_start_end=True
         )
+
+
+def _split_stages_by_per_output(
+    stages: List["PipelineStage"],
+) -> tuple[List["PipelineStage"], List["PipelineStage"]]:
+    """Split stages into shared and per-output groups.
+
+    Once the first per-output stage is hit, all subsequent stages
+    are treated as per-output to preserve execution order.
+    """
+    shared: List["PipelineStage"] = []
+    per_output: List["PipelineStage"] = []
+    hit = False
+    for stage in stages:
+        if not hit and not stage.requires_per_output_execution:
+            shared.append(stage)
+        else:
+            hit = True
+            per_output.append(stage)
+    return shared, per_output
+
+
+def _prepare_single_output_batch(batch: Req, output_index: int) -> Req:
+    """Create a deep copy of batch configured for a single output."""
+    sub_batch = deepcopy(batch)
+
+    if isinstance(batch.generator, list) and len(batch.generator) > 1:
+        sub_batch.generator = [batch.generator[output_index]]
+    if batch.seeds is not None and len(batch.seeds) > 1:
+        sub_batch.seeds = [batch.seeds[output_index]]
+
+    sub_batch.latents = None
+    sub_batch.num_outputs_per_prompt = 1
+    sub_batch._current_output_index = output_index
+    return sub_batch
+
+
+def _merge_output_batches(output_batches: List[OutputBatch]) -> OutputBatch:
+    """Merge multiple single-output OutputBatch objects into one."""
+    if len(output_batches) == 1:
+        return output_batches[0]
+
+    outputs = []
+    for ob in output_batches:
+        if ob.output is not None:
+            if isinstance(ob.output, (list, tuple)):
+                outputs.extend(ob.output)
+            elif isinstance(ob.output, torch.Tensor):
+                outputs.append(ob.output)
+
+    merged_trajectory_timesteps = None
+    merged_trajectory_latents = None
+    merged_trajectory_decoded = None
+    for ob in output_batches:
+        if ob.trajectory_timesteps is not None:
+            merged_trajectory_timesteps = ob.trajectory_timesteps
+        if ob.trajectory_latents is not None:
+            merged_trajectory_latents = ob.trajectory_latents
+        if ob.trajectory_decoded is not None:
+            merged_trajectory_decoded = ob.trajectory_decoded
+
+    return OutputBatch(
+        output=outputs if outputs else None,
+        trajectory_timesteps=merged_trajectory_timesteps,
+        trajectory_latents=merged_trajectory_latents,
+        trajectory_decoded=merged_trajectory_decoded,
+        metrics=output_batches[0].metrics,
+        noise_pred=None,
+    )
 
 
 class PipelineExecutor(ABC):

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/executors/pipeline_executor.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/executors/pipeline_executor.py
@@ -86,6 +86,19 @@ def _merge_output_batches(output_batches: List[OutputBatch]) -> OutputBatch:
             elif isinstance(ob.output, torch.Tensor):
                 outputs.append(ob.output)
 
+    # Cat into (N, ...) tensor so enumerate() yields per-sample slices.
+    if outputs and all(isinstance(o, torch.Tensor) for o in outputs):
+        try:
+            outputs = torch.cat(outputs, dim=0)
+        except Exception:
+            pass
+
+    # Bool check safe for both list and tensor.
+    has_outputs = (
+        outputs.numel() > 0 if isinstance(outputs, torch.Tensor)
+        else bool(outputs)
+    )
+
     merged_trajectory_timesteps = None
     merged_trajectory_latents = None
     merged_trajectory_decoded = None
@@ -98,7 +111,7 @@ def _merge_output_batches(output_batches: List[OutputBatch]) -> OutputBatch:
             merged_trajectory_decoded = ob.trajectory_decoded
 
     return OutputBatch(
-        output=outputs if outputs else None,
+        output=outputs if has_outputs else None,
         trajectory_timesteps=merged_trajectory_timesteps,
         trajectory_latents=merged_trajectory_latents,
         trajectory_decoded=merged_trajectory_decoded,

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/base.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/base.py
@@ -110,6 +110,11 @@ class PipelineStage(ABC):
         #     return StageParallelismType.MAIN_RANK_ONLY
         return StageParallelismType.REPLICATED
 
+    @property
+    def requires_per_output_execution(self) -> bool:
+        """Whether this stage must run once per output when num_outputs_per_prompt > 1."""
+        return False
+
     def verify_output(self, batch: Req, server_args: ServerArgs) -> VerificationResult:
         """
         Verify the output for the stage.

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/decoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/decoding.py
@@ -58,6 +58,7 @@ class DecodingStage(PipelineStage):
 
     @property
     def requires_per_output_execution(self) -> bool:
+        # This stage's result differs per output and cannot be shared.
         return True
 
     def __init__(self, vae, pipeline=None, component_name: str = "vae") -> None:

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/decoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/decoding.py
@@ -56,6 +56,10 @@ class DecodingStage(PipelineStage):
     output format (e.g., pixel values).
     """
 
+    @property
+    def requires_per_output_execution(self) -> bool:
+        return True
+
     def __init__(self, vae, pipeline=None, component_name: str = "vae") -> None:
         super().__init__()
         self.vae: ParallelTiledVAE = vae

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -97,6 +97,10 @@ class DenoisingStage(PipelineStage):
     the initial noise into the final output.
     """
 
+    @property
+    def requires_per_output_execution(self) -> bool:
+        return True
+
     def __init__(
         self, transformer, scheduler, pipeline=None, transformer_2=None, vae=None
     ) -> None:

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -99,6 +99,7 @@ class DenoisingStage(PipelineStage):
 
     @property
     def requires_per_output_execution(self) -> bool:
+        # This stage's result differs per output and cannot be shared.
         return True
 
     def __init__(

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -1022,6 +1022,7 @@ class DenoisingStage(PipelineStage):
         # to avoid device-sync caused by timestep comparison
         is_warmup = batch.is_warmup
         self.scheduler.set_begin_index(0)
+        self.scheduler._step_index = None
         timesteps_cpu = timesteps.cpu()
         num_timesteps = timesteps_cpu.shape[0]
         with torch.autocast(

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/latent_preparation.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/latent_preparation.py
@@ -32,6 +32,10 @@ class LatentPreparationStage(PipelineStage):
     denoised during the diffusion process.
     """
 
+    @property
+    def requires_per_output_execution(self) -> bool:
+        return True
+
     def __init__(self, scheduler, transformer) -> None:
         super().__init__()
         self.scheduler = scheduler

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/latent_preparation.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/latent_preparation.py
@@ -34,6 +34,7 @@ class LatentPreparationStage(PipelineStage):
 
     @property
     def requires_per_output_execution(self) -> bool:
+        # This stage's result differs per output and cannot be shared.
         return True
 
     def __init__(self, scheduler, transformer) -> None:

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/glm_image.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/glm_image.py
@@ -127,6 +127,10 @@ class GlmImageBeforeDenoisingStage(PipelineStage):
             A scheduler to be used in combination with `transformer` to denoise the encoded image latents.
     """
 
+    @property
+    def requires_per_output_execution(self) -> bool:
+        return True
+
     def __init__(
         self,
         tokenizer,


### PR DESCRIPTION
## Motivation

The current multi-output generation (controlled by `num_outputs_per_prompt`) assembles all outputs into a single batch at the denoising stage level. While functional for a few models (e.g., Flux, Wan-T2V), this approach has three significant problems( thanks to @MikukuOvO ):

1. **Poor model generalization.** Every model must be individually adapted to handle batched multi-output execution inside its denoising loop. Models that were not explicitly modified fail in various ways:
   - Qwen-Image — text/latent batch dimension mismatch.
   - Z-Image — model code hardcodes single-sample assumptions.
   - Hunyuan3D — code explicitly rejects batch size > 1.
   - Helios / GLM-Image — `batch_size=1` is hardcoded throughout; the entire processing path never accounts for batch > 1 and would require a full rewrite to support it.

2. **Excessive memory consumption.** Internal batch size equals `num_outputs_per_prompt`, linearly scaling activation memory. This causes OOM in RL rollout scenarios that require many outputs, while providing no throughput benefit since denoising is already compute-bound on a single sample.

3. **Training–inference inconsistency risk in RL.** Running with `batch_size = N` during rollout may trigger different operator implementations or kernel dispatches compared to training, risking numerical divergence in RL reward signals.

This PR introduces a **sequential per-output execution** strategy at the **executor layer**. By looping over outputs at the orchestration level instead of inside each model's denoising code.

## Modifications

### Core Design: Stage-Level `requires_per_output_execution` Property

A new boolean property `requires_per_output_execution` is added to the `PipelineStage` base class (default `False`). Stages that are seed-/noise-dependent override it to `True`:

| Stage                    | `requires_per_output_execution` | Rationale |
|--------------------------|:-------------------------------:|-----------|
| `LatentPreparationStage` | `True`  | Generates unique noise per output |
| `DenoisingStage`         | `True`  | Iterative denoising is seed-specific |
| `DecodingStage`          | `True`  | VAE decode operates on per-output latents |
| `GlmImageBeforeDenoisingStage` | `True` | Model-specific pre-denoising prep that is output-dependent |
| All other stages (e.g., text encoding) | `False` | Shared across all outputs |

### Executor-Level Sequential Loop

The execution flow in both `PipelineExecutor` and `ParallelExecutor` is extended with a three-phase strategy when `num_outputs_per_prompt > 1`:

1. **Phase 1 — Shared stages**: Stages before the first `requires_per_output_execution = True` stage (e.g., text encoding) execute **once**.
2. **Phase 2 — Per-output loop**: Stages from the first per-output stage onward are executed **N times** sequentially, each with an independent `Req` copy carrying its own seed/generator and `num_outputs_per_prompt = 1`.
3. **Phase 3 — Merge**: The N `OutputBatch` results are concatenated back into a single `OutputBatch`.

Key helper functions added to `pipeline_executor.py`:

- **`_split_stages_by_per_output(stages)`** — Partitions stages into shared and per-output groups. Once the first per-output stage is encountered, all subsequent stages are treated as per-output to preserve execution order.
- **`_prepare_single_output_batch(batch, output_index)`** — Deep-copies the batch, selects the correct generator/seed for the given output index, clears latents, and sets `num_outputs_per_prompt = 1`.
- **`_merge_output_batches(output_batches)`** — Concatenates output tensors from N runs into a single `(N, ...)` tensor.


### Invasiveness & Maintainability

- **Minimal invasiveness**: No changes to any model forward passes or denoising loops.  For models with custom pre-denoising stages, only a one-line property override is needed.
- **Backward compatible**: When `num_outputs_per_prompt ≤ 1` (default), the original `_execute()` path is taken — zero overhead.
- **Easy to extend**: Supporting a new stage requires only a one-line property override.

## Accuracy Tests

With this implementation, the following models all correctly support single-prompt multi-output generation **without any model-specific modifications**:

| Model | Status | Notes |
|-------|--------|-------|
| **Flux** | ✅ Pass | Previously supported (batched); now works sequentially |
| **Qwen-Image** | ✅ Pass | Previously failed (batch dim mismatch) |
| **Z-Image** | ✅ Pass | Previously failed (single-sample hardcoded) |
| **Wan-T2V** | ✅ Pass | Previously supported (batched); now works sequentially |
| **Wan-I2V** | ✅ Pass | Now works with sequential execution |
| **GLM-Image** | ✅ Pass | Previously failed (hardcoded `batch_size=1`); fixed by marking `GlmImageBeforeDenoisingStage` as per-output |

Each model was tested with `num_outputs_per_prompt = 4` and results were visually verified for correctness and diversity (different seeds producing different outputs). The screenshots below demonstrate the tests conducted on qwen-image.

<img width="1141" height="720" alt="20260406160754" src="https://github.com/user-attachments/assets/b5073097-d274-40bc-af2d-43c3cda38906" />
<img width="838" height="228" alt="20260406175632" src="https://github.com/user-attachments/assets/55f58ef6-44b5-4c67-abe7-c3c0c3fdab76" />

## Speed Tests and Profiling

Benchmarked on **Flux (FLUX.1-dev)** on a single **H200** GPU with `num_outputs_per_prompt = 4`.

**Command:**
```bash
sglang generate \
  --model-path black-forest-labs/FLUX.1-dev \
  --prompt "A curious raccoon sitting on a mossy rock in a sunlit forest, photorealistic, 8k" \
  --width 1024 --height 1024 \
  --num-outputs-per-prompt 4 \
  --num-inference-steps 28 \
  --guidance-scale 3.5 \
  --save-output --output-path ./test_outputs/flux1 \
  --log-level debug --warmup
```

**Results:**

| Metric | Batched (before) | Sequential (after) | Delta |
|--------|:-----------------:|:-------------------:|:-----:|
| DiT time | 15.2041 s | 15.4286 s | +1.4% |
| Peak GPU memory | 57,104 MB | **32,042 MB** | **↓ 43.9%** |

The screenshot below shows the execution log before the modification.
<img width="1172" height="542" alt="20260406165831" src="https://github.com/user-attachments/assets/590acf63-c32d-4c49-972c-a931b684ca43" />
The screenshot below shows the modified execution log.
<img width="1153" height="764" alt="20260406171154" src="https://github.com/user-attachments/assets/5ab08e10-bfae-40a6-8193-0c7d5f48a5b3" />


**Key takeaways:**
- The DiT (denoising transformer) time difference of +1.4% is within normal variance on H200 and does not represent a meaningful regression.
- Peak memory reduction **scales with the number of outputs** — since activations are never held for more than one output at a time, memory stays constant regardless of N. With N=4, peak VRAM dropped from 57.1 GB to 32.0 GB (**↓ 43.9%**).
- Critically, the batched approach **fails with OOM** at higher output counts, whereas the sequential approach can handle **arbitrarily large N** with the same memory footprint as a single generation. This makes it viable for RL rollout scenarios that require many outputs per prompt.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
