### PR TITLE
[HiCache] Fix write_backup return type when parent not backed up

### DIFF
--- a/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
@@ -276,10 +276,10 @@ class HiMambaRadixCache(MambaRadixCache):
         )
         super().reset()
 
-    def write_backup(self, node: TreeNode, write_back=False):
+    def write_backup(self, node: TreeNode, write_back=False) -> int:
         # Backup invariant: parent must be backed up before child.
         if node.parent != self.root_node and not node.parent.backuped:
-            return
+            return 0
 
         # If mamba host slot already exists, refresh its LRU position.
         if node.mamba_value is not None and node.mamba_host_value is not None:

--- a/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
@@ -277,8 +277,13 @@ class HiMambaRadixCache(MambaRadixCache):
         super().reset()
 
     def write_backup(self, node: TreeNode, write_back=False) -> int:
-        # Backup invariant: parent must be backed up before child.
-        if node.parent != self.root_node and not node.parent.backuped:
+        # Write-through only: skip if parent not yet backed up to avoid
+        # gaps in the backup chain. Write-back ordering is handled by eviction.
+        if (
+            not write_back
+            and node.parent != self.root_node
+            and not node.parent.backuped
+        ):
             return 0
 
         # If mamba host slot already exists, refresh its LRU position.

--- a/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
@@ -280,7 +280,9 @@ class HiMambaRadixCache(MambaRadixCache):
         # Backup invariant (for write-through mode): backed-up nodes must form a
         # contiguous prefix from root — no gaps.  Skip if parent isn't backed
         # up yet;
-        if not write_back and (node.parent != self.root_node and not node.parent.backuped):
+        if not write_back and (
+            node.parent != self.root_node and not node.parent.backuped
+        ):
             return 0
 
         # If mamba host slot already exists, refresh its LRU position.

--- a/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
@@ -276,10 +276,10 @@ class HiMambaRadixCache(MambaRadixCache):
         )
         super().reset()
 
-    def write_backup(self, node: TreeNode, write_back=False) -> int:
+    def write_backup(self, node: TreeNode, write_back=False):
         # Backup invariant: parent must be backed up before child.
         if node.parent != self.root_node and not node.parent.backuped:
-            return 0
+            return
 
         # If mamba host slot already exists, refresh its LRU position.
         if node.mamba_value is not None and node.mamba_host_value is not None:

--- a/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
@@ -277,13 +277,10 @@ class HiMambaRadixCache(MambaRadixCache):
         super().reset()
 
     def write_backup(self, node: TreeNode, write_back=False) -> int:
-        # Write-through only: skip if parent not yet backed up to avoid
-        # gaps in the backup chain. Write-back ordering is handled by eviction.
-        if (
-            not write_back
-            and node.parent != self.root_node
-            and not node.parent.backuped
-        ):
+        # Backup invariant (for write-through mode): backed-up nodes must form a
+        # contiguous prefix from root — no gaps.  Skip if parent isn't backed
+        # up yet;
+        if not write_back and (node.parent != self.root_node and not node.parent.backuped):
             return 0
 
         # If mamba host slot already exists, refresh its LRU position.

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -608,13 +608,10 @@ class HiRadixCache(RadixCache):
             return False
 
     def write_backup(self, node: TreeNode, write_back=False) -> int:
-        # Write-through only: skip if parent not yet backed up to avoid
-        # gaps in the backup chain. Write-back ordering is handled by eviction.
-        if (
-            not write_back
-            and node.parent != self.root_node
-            and not node.parent.backuped
-        ):
+        # Backup invariant (for write-through mode): backed-up nodes must form a
+        # contiguous prefix from root — no gaps.  Skip if parent isn't backed
+        # up yet;
+        if not write_back and (node.parent != self.root_node and not node.parent.backuped):
             return 0
 
         host_indices = self.cache_controller.write(

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -607,10 +607,10 @@ class HiRadixCache(RadixCache):
             logger.warning("Hierarchical cache storage backend is not enabled.")
             return False
 
-    def write_backup(self, node: TreeNode, write_back=False) -> int:
+    def write_backup(self, node: TreeNode, write_back=False):
         # Backup invariant: parent must be backed up before child.
         if node.parent != self.root_node and not node.parent.backuped:
-            return 0
+            return
 
         host_indices = self.cache_controller.write(
             device_indices=node.value,
@@ -800,8 +800,10 @@ class HiRadixCache(RadixCache):
             if not x.backuped:
                 if self.cache_controller.write_policy == "write_back":
                     # write to host if the node is not backuped
-                    num_evicted += self.write_backup(x, write_back=True)
-                    write_back_nodes.append(x)
+                    written = self.write_backup(x, write_back=True)
+                    if written is not None:
+                        num_evicted += written
+                        write_back_nodes.append(x)
                 else:
                     num_evicted += self._evict_regular(x)
             else:

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -607,10 +607,10 @@ class HiRadixCache(RadixCache):
             logger.warning("Hierarchical cache storage backend is not enabled.")
             return False
 
-    def write_backup(self, node: TreeNode, write_back=False):
+    def write_backup(self, node: TreeNode, write_back=False) -> int:
         # Backup invariant: parent must be backed up before child.
         if node.parent != self.root_node and not node.parent.backuped:
-            return
+            return 0
 
         host_indices = self.cache_controller.write(
             device_indices=node.value,
@@ -801,8 +801,8 @@ class HiRadixCache(RadixCache):
                 if self.cache_controller.write_policy == "write_back":
                     # write to host if the node is not backuped
                     written = self.write_backup(x, write_back=True)
-                    if written is not None:
-                        num_evicted += written
+                    num_evicted += written
+                    if written > 0:
                         write_back_nodes.append(x)
                 else:
                     num_evicted += self._evict_regular(x)

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -611,7 +611,9 @@ class HiRadixCache(RadixCache):
         # Backup invariant (for write-through mode): backed-up nodes must form a
         # contiguous prefix from root — no gaps.  Skip if parent isn't backed
         # up yet;
-        if not write_back and (node.parent != self.root_node and not node.parent.backuped):
+        if not write_back and (
+            node.parent != self.root_node and not node.parent.backuped
+        ):
             return 0
 
         host_indices = self.cache_controller.write(

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -607,10 +607,10 @@ class HiRadixCache(RadixCache):
             logger.warning("Hierarchical cache storage backend is not enabled.")
             return False
 
-    def write_backup(self, node: TreeNode, write_back=False):
+    def write_backup(self, node: TreeNode, write_back=False) -> int:
         # Backup invariant: parent must be backed up before child.
         if node.parent != self.root_node and not node.parent.backuped:
-            return
+            return 0
 
         host_indices = self.cache_controller.write(
             device_indices=node.value,

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -608,8 +608,13 @@ class HiRadixCache(RadixCache):
             return False
 
     def write_backup(self, node: TreeNode, write_back=False) -> int:
-        # Backup invariant: parent must be backed up before child.
-        if node.parent != self.root_node and not node.parent.backuped:
+        # Write-through only: skip if parent not yet backed up to avoid
+        # gaps in the backup chain. Write-back ordering is handled by eviction.
+        if (
+            not write_back
+            and node.parent != self.root_node
+            and not node.parent.backuped
+        ):
             return 0
 
         host_indices = self.cache_controller.write(


### PR DESCRIPTION
PR https://github.com/sgl-project/sglang/pull/22062 added a check to write the parent before the child, but the return value in this case is None.
At the same time, in one place, the return value of this method is interpreted as int and will now cause a TypeError:
https://github.com/sgl-project/sglang/blob/3178f3959fbf657bc0343529898d0b1f534890ad/python/sglang/srt/mem_cache/hiradix_cache.py#L801-L804

Added a type hint for the return value and changed it to 0 if the type check was triggered.