### PR TITLE
[Feature] Add RVV kernels in sgl-kernel

### DIFF
--- a/sgl-kernel/csrc/cpu/riscv64/CMakeLists.txt
+++ b/sgl-kernel/csrc/cpu/riscv64/CMakeLists.txt
@@ -1,0 +1,167 @@
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
+project(sgl_kernel)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_package(Python COMPONENTS Interpreter Development.Module ${SKBUILD_SABI_COMPONENT} REQUIRED)
+
+execute_process(
+    COMMAND ${Python_EXECUTABLE}
+            -c "import torch; print(torch.utils.cmake_prefix_path)"
+    OUTPUT_VARIABLE TORCH_PY_PREFIX
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+message(STATUS ${TORCH_PY_PREFIX})
+list(APPEND CMAKE_PREFIX_PATH ${TORCH_PY_PREFIX}/Torch)
+find_package(Torch REQUIRED)
+
+# Paths relative to this file (csrc/cpu/riscv64/)
+get_filename_component(CPU_SRC_DIR  "${CMAKE_CURRENT_SOURCE_DIR}/.."   ABSOLUTE)
+get_filename_component(SGLKERNEL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../.." ABSOLUTE)
+
+include_directories(
+    ${TORCH_INCLUDE_DIRS}
+    ${TORCH_INSTALL_PREFIX}/include
+    ${Python_INCLUDE_DIRS}
+    ${SGLKERNEL_DIR}/csrc
+    ${SGLKERNEL_DIR}/include
+    ${CPU_SRC_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+link_directories("/usr/lib/riscv64-linux-gnu")
+
+# Conda / venv paths (no NUMA on RISC-V)
+if(DEFINED ENV{CONDA_PREFIX})
+    set(CONDA_LIB_DIR "$ENV{CONDA_PREFIX}/lib")
+    message(STATUS "Using Conda lib dir: ${CONDA_LIB_DIR}")
+    link_directories(${CONDA_LIB_DIR})
+    include_directories("$ENV{CONDA_PREFIX}/include")
+else()
+    if(DEFINED ENV{VIRTUAL_ENV})
+        set(VENV_LIB_DIR "$ENV{VIRTUAL_ENV}/lib")
+        message(STATUS "Using venv lib dir: ${VENV_LIB_DIR}")
+        link_directories(${VENV_LIB_DIR})
+        include_directories("$ENV{VIRTUAL_ENV}/include")
+    endif()
+endif()
+
+# Compiler check
+if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    message(FATAL_ERROR "RISC-V build requires Clang for RVV intrinsics. Current: ${CMAKE_CXX_COMPILER_ID}")
+elseif(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.0)
+    message(FATAL_ERROR "Clang >= 19.0 required for RVV. Found: ${CMAKE_CXX_COMPILER_VERSION}")
+endif()
+
+# Auto-detect VLEN and ISA extensions from /proc/cpuinfo
+set(RVV_HAS_ZVFH OFF)
+if(NOT DEFINED RVV_VECTOR_BITS)
+    if(EXISTS "/proc/cpuinfo")
+        file(READ "/proc/cpuinfo" _cpuinfo)
+        if(_cpuinfo MATCHES "zvfh")
+            set(RVV_HAS_ZVFH ON)
+        endif()
+        if(_cpuinfo MATCHES "zvl1024b")
+            set(RVV_VECTOR_BITS 1024)
+        elseif(_cpuinfo MATCHES "zvl512b")
+            set(RVV_VECTOR_BITS 512)
+        elseif(_cpuinfo MATCHES "zvl256b")
+            set(RVV_VECTOR_BITS 256)
+        elseif(_cpuinfo MATCHES "zvl128b")
+            set(RVV_VECTOR_BITS 128)
+        else()
+            set(RVV_VECTOR_BITS 256)
+        endif()
+    else()
+        set(RVV_VECTOR_BITS 256)
+    endif()
+else()
+    if(EXISTS "/proc/cpuinfo")
+        file(READ "/proc/cpuinfo" _cpuinfo)
+        if(_cpuinfo MATCHES "zvfh")
+            set(RVV_HAS_ZVFH ON)
+        endif()
+    endif()
+endif()
+message(STATUS "RISC-V: VLEN=${RVV_VECTOR_BITS} (-mrvv-vector-bits=${RVV_VECTOR_BITS})")
+message(STATUS "RISC-V: zvfh support = ${RVV_HAS_ZVFH}")
+
+# L1 cache size (KB) for K-tiling. Override: cmake -DRVV_L1_CACHE_KB=64
+if(NOT DEFINED RVV_L1_CACHE_KB)
+    set(RVV_L1_CACHE_KB 32)
+endif()
+message(STATUS "RISC-V: L1 cache = ${RVV_L1_CACHE_KB}KB (override: -DRVV_L1_CACHE_KB=N)")
+
+# Source collection
+# Top-level cpu/ files replaced by riscv64/ equivalents or not supported on RISC-V
+set(RISCV64_SKIP_TOPLEVEL
+    activation decode extend gemm gemm_int8 norm rope
+    moe moe_int8 moe_fp8 moe_int4
+    gemm_fp8 gemm_int4
+    bmm
+    qkv_proj preprocessor conv3d
+    shm interface flash_attn
+    torch_extension_cpu
+)
+
+file(GLOB_RECURSE SOURCES "${CPU_SRC_DIR}/*.cpp")
+# Exclude arch-specific subdirectories
+list(FILTER SOURCES EXCLUDE REGEX "${CPU_SRC_DIR}/(x86_64|aarch64|riscv64)/")
+# Exclude top-level files replaced by riscv64/ equivalents
+foreach(_basename IN LISTS RISCV64_SKIP_TOPLEVEL)
+    list(FILTER SOURCES EXCLUDE REGEX "${CPU_SRC_DIR}/${_basename}\\.cpp$")
+endforeach()
+# Add RVV-specific sources
+file(GLOB RVV_SOURCES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
+list(APPEND SOURCES ${RVV_SOURCES})
+
+# FP8 flush-to-zero
+if(NOT DEFINED ENV{SGLANG_CPU_FP8_CVT_FTZ})
+    set(ENV{SGLANG_CPU_FP8_CVT_FTZ} "1")
+endif()
+if("$ENV{SGLANG_CPU_FP8_CVT_FTZ}" STREQUAL "1")
+    message(STATUS "Enabling macro: SGLANG_CPU_FP8_CVT_FTZ")
+    add_compile_definitions(SGLANG_CPU_FP8_CVT_FTZ)
+endif()
+
+add_compile_options(-O3 -Wno-unknown-pragmas -fopenmp)
+if(RVV_HAS_ZVFH)
+    set(RVV_MARCH "rv64gcv_zvfh")
+    set(RVV_ZVFH_ENABLED "ON")
+    add_compile_options(-march=${RVV_MARCH} -mabi=lp64d -mrvv-vector-bits=${RVV_VECTOR_BITS})
+    add_compile_definitions(RVV_HAS_ZVFH=1)
+else()
+    set(RVV_MARCH "rv64gcv")
+    set(RVV_ZVFH_ENABLED "OFF")
+    add_compile_options(-march=${RVV_MARCH} -mabi=lp64d -mrvv-vector-bits=${RVV_VECTOR_BITS})
+endif()
+add_compile_definitions(CPU_CAPABILITY_RVV)
+add_compile_definitions(RVV_L1_CACHE_KB=${RVV_L1_CACHE_KB})
+
+message(STATUS "RVV configure summary:")
+message(STATUS "  march: ${RVV_MARCH}")
+message(STATUS "  mabi: lp64d")
+message(STATUS "  vector-bits: ${RVV_VECTOR_BITS}")
+message(STATUS "  zvfh enabled: ${RVV_ZVFH_ENABLED}")
+
+message(STATUS "Build Architecture: riscv64 (RVV enabled)")
+
+# Link libraries: PyTorch + OpenMP (no NUMA)
+set(LINK_LIBS ${TORCH_LIBRARIES})
+set(OMP_LIB_PATH "$ENV{RISCV_OMP_LIB_PATH}")
+if(EXISTS "${OMP_LIB_PATH}")
+    list(APPEND LINK_LIBS "${OMP_LIB_PATH}")
+else()
+    find_library(OMP_LIB omp)
+    if(OMP_LIB)
+        list(APPEND LINK_LIBS ${OMP_LIB})
+    endif()
+endif()
+
+Python_add_library(common_ops MODULE USE_SABI ${SKBUILD_SABI_VERSION} WITH_SOABI ${SOURCES})
+target_link_libraries(common_ops PRIVATE ${LINK_LIBS})
+target_include_directories(common_ops PRIVATE ${TORCH_INCLUDE_DIRS})
+
+install(TARGETS common_ops LIBRARY DESTINATION sgl_kernel)

--- a/sgl-kernel/csrc/cpu/riscv64/activation.cpp
+++ b/sgl-kernel/csrc/cpu/riscv64/activation.cpp
@@ -23,6 +23,7 @@ constexpr float kInvSqrt2 = 0.7071067811865476f;
 template <typename scalar_t>
 void act_silu_inner(
     scalar_t* __restrict__ out_ptr, const scalar_t* __restrict__ x_ptr, const scalar_t* __restrict__ y_ptr, int64_t d) {
+  alignas(64) float scratch[rvv_constants::MAX_VL_ELEMENTS_M4];
   const size_t max_vl = __riscv_vsetvlmax_e32m4();
   const int64_t max_vl_i = static_cast<int64_t>(max_vl);
   int64_t j = 0;
@@ -30,34 +31,34 @@ void act_silu_inner(
   // 2-way unrolled main loop (both chunks are full-width, no tail logic needed here)
   for (; j + 2 * max_vl_i <= d; j += 2 * max_vl_i) {
     // ---- chunk A: load + issue exp ----
-    vfloat32m4_t vxA = load_as_float_m4(x_ptr + j, max_vl, nullptr);
-    vfloat32m4_t vyA = load_as_float_m4(y_ptr + j, max_vl, nullptr);
+    vfloat32m4_t vxA = load_as_float_m4(x_ptr + j, max_vl, scratch);
+    vfloat32m4_t vyA = load_as_float_m4(y_ptr + j, max_vl, scratch);
     vfloat32m4_t vexpA = vfexp_f32m4(__riscv_vfneg_v_f32m4(vxA, max_vl), max_vl);
     // ---- chunk B: load while expA computes ----
-    vfloat32m4_t vxB = load_as_float_m4(x_ptr + j + max_vl_i, max_vl, nullptr);
-    vfloat32m4_t vyB = load_as_float_m4(y_ptr + j + max_vl_i, max_vl, nullptr);
+    vfloat32m4_t vxB = load_as_float_m4(x_ptr + j + max_vl_i, max_vl, scratch);
+    vfloat32m4_t vyB = load_as_float_m4(y_ptr + j + max_vl_i, max_vl, scratch);
     vfloat32m4_t vexpB = vfexp_f32m4(__riscv_vfneg_v_f32m4(vxB, max_vl), max_vl);
 
     vfloat32m4_t vdA = __riscv_vfadd_vf_f32m4(vexpA, 1.0f, max_vl);
     vfloat32m4_t voutA =
         __riscv_vfmul_vv_f32m4(__riscv_vfmul_vv_f32m4(vxA, vrec_f32m4(vdA, max_vl), max_vl), vyA, max_vl);
-    store_from_float_m4(out_ptr + j, voutA, max_vl, nullptr);
+    store_from_float_m4(out_ptr + j, voutA, max_vl, scratch);
 
     vfloat32m4_t vdB = __riscv_vfadd_vf_f32m4(vexpB, 1.0f, max_vl);
     vfloat32m4_t voutB =
         __riscv_vfmul_vv_f32m4(__riscv_vfmul_vv_f32m4(vxB, vrec_f32m4(vdB, max_vl), max_vl), vyB, max_vl);
-    store_from_float_m4(out_ptr + j + max_vl_i, voutB, max_vl, nullptr);
+    store_from_float_m4(out_ptr + j + max_vl_i, voutB, max_vl, scratch);
   }
 
   // tail: handles remainder (including d < 2*max_vl entirely)
   size_t vl;
   for (; j < d; j += vl) {
     vl = __riscv_vsetvl_e32m4(d - j);
-    vfloat32m4_t vx = load_as_float_m4(x_ptr + j, vl, nullptr);
-    vfloat32m4_t vy = load_as_float_m4(y_ptr + j, vl, nullptr);
+    vfloat32m4_t vx = load_as_float_m4(x_ptr + j, vl, scratch);
+    vfloat32m4_t vy = load_as_float_m4(y_ptr + j, vl, scratch);
     vfloat32m4_t vd = __riscv_vfadd_vf_f32m4(vfexp_f32m4(__riscv_vfneg_v_f32m4(vx, vl), vl), 1.0f, vl);
     store_from_float_m4(
-        out_ptr + j, __riscv_vfmul_vv_f32m4(__riscv_vfmul_vv_f32m4(vx, vrec_f32m4(vd, vl), vl), vy, vl), vl, nullptr);
+        out_ptr + j, __riscv_vfmul_vv_f32m4(__riscv_vfmul_vv_f32m4(vx, vrec_f32m4(vd, vl), vl), vy, vl), vl, scratch);
   }
 }
 
@@ -67,20 +68,21 @@ void act_silu_inner(
 template <typename scalar_t>
 void act_gelu_tanh_inner(
     scalar_t* __restrict__ out_ptr, const scalar_t* __restrict__ x_ptr, const scalar_t* __restrict__ y_ptr, int64_t d) {
+  alignas(64) float scratch[rvv_constants::MAX_VL_ELEMENTS_M4];
   size_t vl;
   for (int64_t j = 0; j < d; j += vl) {
     vl = __riscv_vsetvl_e32m4(d - j);
-    vfloat32m4_t vx = load_as_float_m4(x_ptr + j, vl, nullptr);
+    vfloat32m4_t vx = load_as_float_m4(x_ptr + j, vl, scratch);
     vfloat32m4_t vx2 = __riscv_vfmul_vv_f32m4(vx, vx, vl);
     vfloat32m4_t vx3 = __riscv_vfmul_vv_f32m4(vx2, vx, vl);
     vfloat32m4_t vinner = __riscv_vfmacc_vf_f32m4(vx, 0.044715f, vx3, vl);
     vfloat32m4_t vtanh_arg = __riscv_vfmul_vf_f32m4(vinner, kSqrt2DivPi, vl);
-    vfloat32m4_t vy = load_as_float_m4(y_ptr + j, vl, nullptr);
+    vfloat32m4_t vy = load_as_float_m4(y_ptr + j, vl, scratch);
     vfloat32m4_t vtanh = vftanh_f32m4(vtanh_arg, vl);
     // gelu = 0.5 * x * (1 + tanh) * vy
     vfloat32m4_t vgelu =
         __riscv_vfmul_vf_f32m4(__riscv_vfmul_vv_f32m4(vx, __riscv_vfadd_vf_f32m4(vtanh, 1.0f, vl), vl), 0.5f, vl);
-    store_from_float_m4(out_ptr + j, __riscv_vfmul_vv_f32m4(vgelu, vy, vl), vl, nullptr);
+    store_from_float_m4(out_ptr + j, __riscv_vfmul_vv_f32m4(vgelu, vy, vl), vl, scratch);
   }
 }
 
@@ -90,16 +92,17 @@ void act_gelu_tanh_inner(
 template <typename scalar_t>
 void act_gelu_inner(
     scalar_t* __restrict__ out_ptr, const scalar_t* __restrict__ x_ptr, const scalar_t* __restrict__ y_ptr, int64_t d) {
+  alignas(64) float scratch[rvv_constants::MAX_VL_ELEMENTS_M4];
   size_t vl;
   for (int64_t j = 0; j < d; j += vl) {
     vl = __riscv_vsetvl_e32m4(d - j);
-    vfloat32m4_t vx = load_as_float_m4(x_ptr + j, vl, nullptr);
+    vfloat32m4_t vx = load_as_float_m4(x_ptr + j, vl, scratch);
     vfloat32m4_t verf = vferf_f32m4(__riscv_vfmul_vf_f32m4(vx, kInvSqrt2, vl), vl);
-    vfloat32m4_t vy = load_as_float_m4(y_ptr + j, vl, nullptr);
+    vfloat32m4_t vy = load_as_float_m4(y_ptr + j, vl, scratch);
     // gelu = 0.5 * x * (1 + erf) * vy
     vfloat32m4_t vgelu =
         __riscv_vfmul_vf_f32m4(__riscv_vfmul_vv_f32m4(vx, __riscv_vfadd_vf_f32m4(verf, 1.0f, vl), vl), 0.5f, vl);
-    store_from_float_m4(out_ptr + j, __riscv_vfmul_vv_f32m4(vgelu, vy, vl), vl, nullptr);
+    store_from_float_m4(out_ptr + j, __riscv_vfmul_vv_f32m4(vgelu, vy, vl), vl, scratch);
   }
 }
 
@@ -107,7 +110,7 @@ void act_gelu_inner(
 
 // input   : {num_tokens, 2 * d}
 // output  : {num_tokens, d}
-at::Tensor silu_and_mul_cpu(at::Tensor& input) {
+at::Tensor silu_and_mul_cpu(const at::Tensor& input) {
   RECORD_FUNCTION("sgl-kernel::silu_and_mul_cpu", std::vector<c10::IValue>({input}));
   auto input_contig = input.contiguous();
   auto sizes = input.sizes().vec();

--- a/sgl-kernel/csrc/cpu/riscv64/activation.cpp
+++ b/sgl-kernel/csrc/cpu/riscv64/activation.cpp
@@ -1,0 +1,179 @@
+#if defined(CPU_CAPABILITY_RVV) && defined(__clang__)
+#pragma clang riscv intrinsic vector
+#endif
+
+#if defined(CPU_CAPABILITY_RVV)
+
+#include <cstdint>
+
+#include "common.h"
+#include "riscv64/vector_helpers.h"
+
+namespace {
+
+// sqrt(2 / pi), used in GELU tanh approximation
+constexpr float kSqrt2DivPi = 0.7978845608028654f;
+
+// 1 / sqrt(2), used in GELU exact (erf) formula
+constexpr float kInvSqrt2 = 0.7071067811865476f;
+
+// Inner loop: out[j] = silu(x[j]) * y[j]
+// SiLU(x) = x / (1 + exp(-x)) = x * rec(1 + exp(-x))
+
+template <typename scalar_t>
+void act_silu_inner(
+    scalar_t* __restrict__ out_ptr, const scalar_t* __restrict__ x_ptr, const scalar_t* __restrict__ y_ptr, int64_t d) {
+  const size_t max_vl = __riscv_vsetvlmax_e32m4();
+  const int64_t max_vl_i = static_cast<int64_t>(max_vl);
+  int64_t j = 0;
+
+  // 2-way unrolled main loop (both chunks are full-width, no tail logic needed here)
+  for (; j + 2 * max_vl_i <= d; j += 2 * max_vl_i) {
+    // ---- chunk A: load + issue exp ----
+    vfloat32m4_t vxA = load_as_float_m4(x_ptr + j, max_vl, nullptr);
+    vfloat32m4_t vyA = load_as_float_m4(y_ptr + j, max_vl, nullptr);
+    vfloat32m4_t vexpA = vfexp_f32m4(__riscv_vfneg_v_f32m4(vxA, max_vl), max_vl);
+    // ---- chunk B: load while expA computes ----
+    vfloat32m4_t vxB = load_as_float_m4(x_ptr + j + max_vl_i, max_vl, nullptr);
+    vfloat32m4_t vyB = load_as_float_m4(y_ptr + j + max_vl_i, max_vl, nullptr);
+    vfloat32m4_t vexpB = vfexp_f32m4(__riscv_vfneg_v_f32m4(vxB, max_vl), max_vl);
+
+    vfloat32m4_t vdA = __riscv_vfadd_vf_f32m4(vexpA, 1.0f, max_vl);
+    vfloat32m4_t voutA =
+        __riscv_vfmul_vv_f32m4(__riscv_vfmul_vv_f32m4(vxA, vrec_f32m4(vdA, max_vl), max_vl), vyA, max_vl);
+    store_from_float_m4(out_ptr + j, voutA, max_vl, nullptr);
+
+    vfloat32m4_t vdB = __riscv_vfadd_vf_f32m4(vexpB, 1.0f, max_vl);
+    vfloat32m4_t voutB =
+        __riscv_vfmul_vv_f32m4(__riscv_vfmul_vv_f32m4(vxB, vrec_f32m4(vdB, max_vl), max_vl), vyB, max_vl);
+    store_from_float_m4(out_ptr + j + max_vl_i, voutB, max_vl, nullptr);
+  }
+
+  // tail: handles remainder (including d < 2*max_vl entirely)
+  size_t vl;
+  for (; j < d; j += vl) {
+    vl = __riscv_vsetvl_e32m4(d - j);
+    vfloat32m4_t vx = load_as_float_m4(x_ptr + j, vl, nullptr);
+    vfloat32m4_t vy = load_as_float_m4(y_ptr + j, vl, nullptr);
+    vfloat32m4_t vd = __riscv_vfadd_vf_f32m4(vfexp_f32m4(__riscv_vfneg_v_f32m4(vx, vl), vl), 1.0f, vl);
+    store_from_float_m4(
+        out_ptr + j, __riscv_vfmul_vv_f32m4(__riscv_vfmul_vv_f32m4(vx, vrec_f32m4(vd, vl), vl), vy, vl), vl, nullptr);
+  }
+}
+
+// Inner loop: out[j] = gelu_tanh(x[j]) * y[j]
+// gelu_tanh(x) = 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
+
+template <typename scalar_t>
+void act_gelu_tanh_inner(
+    scalar_t* __restrict__ out_ptr, const scalar_t* __restrict__ x_ptr, const scalar_t* __restrict__ y_ptr, int64_t d) {
+  size_t vl;
+  for (int64_t j = 0; j < d; j += vl) {
+    vl = __riscv_vsetvl_e32m4(d - j);
+    vfloat32m4_t vx = load_as_float_m4(x_ptr + j, vl, nullptr);
+    vfloat32m4_t vx2 = __riscv_vfmul_vv_f32m4(vx, vx, vl);
+    vfloat32m4_t vx3 = __riscv_vfmul_vv_f32m4(vx2, vx, vl);
+    vfloat32m4_t vinner = __riscv_vfmacc_vf_f32m4(vx, 0.044715f, vx3, vl);
+    vfloat32m4_t vtanh_arg = __riscv_vfmul_vf_f32m4(vinner, kSqrt2DivPi, vl);
+    vfloat32m4_t vy = load_as_float_m4(y_ptr + j, vl, nullptr);
+    vfloat32m4_t vtanh = vftanh_f32m4(vtanh_arg, vl);
+    // gelu = 0.5 * x * (1 + tanh) * vy
+    vfloat32m4_t vgelu =
+        __riscv_vfmul_vf_f32m4(__riscv_vfmul_vv_f32m4(vx, __riscv_vfadd_vf_f32m4(vtanh, 1.0f, vl), vl), 0.5f, vl);
+    store_from_float_m4(out_ptr + j, __riscv_vfmul_vv_f32m4(vgelu, vy, vl), vl, nullptr);
+  }
+}
+
+// Inner loop: out[j] = gelu(x[j]) * y[j]
+// gelu(x) = 0.5 * x * (1 + erf(x / sqrt(2)))
+
+template <typename scalar_t>
+void act_gelu_inner(
+    scalar_t* __restrict__ out_ptr, const scalar_t* __restrict__ x_ptr, const scalar_t* __restrict__ y_ptr, int64_t d) {
+  size_t vl;
+  for (int64_t j = 0; j < d; j += vl) {
+    vl = __riscv_vsetvl_e32m4(d - j);
+    vfloat32m4_t vx = load_as_float_m4(x_ptr + j, vl, nullptr);
+    vfloat32m4_t verf = vferf_f32m4(__riscv_vfmul_vf_f32m4(vx, kInvSqrt2, vl), vl);
+    vfloat32m4_t vy = load_as_float_m4(y_ptr + j, vl, nullptr);
+    // gelu = 0.5 * x * (1 + erf) * vy
+    vfloat32m4_t vgelu =
+        __riscv_vfmul_vf_f32m4(__riscv_vfmul_vv_f32m4(vx, __riscv_vfadd_vf_f32m4(verf, 1.0f, vl), vl), 0.5f, vl);
+    store_from_float_m4(out_ptr + j, __riscv_vfmul_vv_f32m4(vgelu, vy, vl), vl, nullptr);
+  }
+}
+
+}  // namespace
+
+// input   : {num_tokens, 2 * d}
+// output  : {num_tokens, d}
+at::Tensor silu_and_mul_cpu(at::Tensor& input) {
+  RECORD_FUNCTION("sgl-kernel::silu_and_mul_cpu", std::vector<c10::IValue>({input}));
+  auto input_contig = input.contiguous();
+  auto sizes = input.sizes().vec();
+  int64_t last_dim = input.ndimension() - 1;
+  int64_t d = sizes[last_dim] / 2;
+  sizes[last_dim] = d;
+  int64_t num_tokens = input.numel() / input.size(-1);
+  at::Tensor out = at::empty(sizes, input.options());
+
+  AT_DISPATCH_REDUCED_FLOATING_TYPES(input_contig.scalar_type(), "silu_and_mul", [&] {
+    const scalar_t* in_ptr = input_contig.data_ptr<scalar_t>();
+    scalar_t* out_ptr = out.data_ptr<scalar_t>();
+    at::parallel_for(0, num_tokens, 0, [&](int64_t begin, int64_t end) {
+      for (int64_t i = begin; i < end; ++i) {
+        const scalar_t* x_ptr = in_ptr + i * 2 * d;
+        act_silu_inner(out_ptr + i * d, x_ptr, x_ptr + d, d);
+      }
+    });
+  });
+  return out;
+}
+
+at::Tensor gelu_tanh_and_mul_cpu(const at::Tensor& input) {
+  RECORD_FUNCTION("sgl-kernel::gelu_tanh_and_mul_cpu", std::vector<c10::IValue>({input}));
+  auto input_contig = input.contiguous();
+  auto sizes = input.sizes().vec();
+  int64_t last_dim = input.ndimension() - 1;
+  int64_t d = sizes[last_dim] / 2;
+  sizes[last_dim] = d;
+  int64_t num_tokens = input.numel() / input.size(-1);
+  at::Tensor out = at::empty(sizes, input.options());
+
+  AT_DISPATCH_REDUCED_FLOATING_TYPES(input_contig.scalar_type(), "gelu_tanh_and_mul", [&] {
+    const scalar_t* in_ptr = input_contig.data_ptr<scalar_t>();
+    scalar_t* out_ptr = out.data_ptr<scalar_t>();
+    at::parallel_for(0, num_tokens, 0, [&](int64_t begin, int64_t end) {
+      for (int64_t i = begin; i < end; ++i) {
+        const scalar_t* x_ptr = in_ptr + i * 2 * d;
+        act_gelu_tanh_inner(out_ptr + i * d, x_ptr, x_ptr + d, d);
+      }
+    });
+  });
+  return out;
+}
+
+at::Tensor gelu_and_mul_cpu(const at::Tensor& input) {
+  RECORD_FUNCTION("sgl-kernel::gelu_and_mul_cpu", std::vector<c10::IValue>({input}));
+  auto input_contig = input.contiguous();
+  auto sizes = input.sizes().vec();
+  int64_t last_dim = input.ndimension() - 1;
+  int64_t d = sizes[last_dim] / 2;
+  sizes[last_dim] = d;
+  int64_t num_tokens = input.numel() / input.size(-1);
+  at::Tensor out = at::empty(sizes, input.options());
+
+  AT_DISPATCH_REDUCED_FLOATING_TYPES(input_contig.scalar_type(), "gelu_and_mul", [&] {
+    const scalar_t* in_ptr = input_contig.data_ptr<scalar_t>();
+    scalar_t* out_ptr = out.data_ptr<scalar_t>();
+    at::parallel_for(0, num_tokens, 0, [&](int64_t begin, int64_t end) {
+      for (int64_t i = begin; i < end; ++i) {
+        const scalar_t* x_ptr = in_ptr + i * 2 * d;
+        act_gelu_inner(out_ptr + i * d, x_ptr, x_ptr + d, d);
+      }
+    });
+  });
+  return out;
+}
+
+#endif  // CPU_CAPABILITY_RVV

--- a/sgl-kernel/csrc/cpu/riscv64/decode.cpp
+++ b/sgl-kernel/csrc/cpu/riscv64/decode.cpp
@@ -18,7 +18,6 @@
 namespace {
 
 // Generic scalar fallback for tinygemm_kernel_nt: computes Q(M,K) @ B(N,K) → C(M,N).
-// Index gathering is handled by the caller; this struct is type-agnostic GEMM.
 template <typename scalar_t, typename kv_t, typename index_t, int BLOCK_M, int BLOCK_N>
 struct tinygemm_kernel_nt {
   static inline void apply(
@@ -115,6 +114,7 @@ struct tinygemm_kernel_nt<at::BFloat16, at::BFloat16, index_t, BLOCK_M, BLOCK_N>
   }
 };
 
+#if defined(__riscv_zvfh)
 template <typename index_t, int BLOCK_M, int BLOCK_N>
 struct tinygemm_kernel_nt<at::Half, at::Half, index_t, BLOCK_M, BLOCK_N> {
   static inline void apply(
@@ -184,6 +184,7 @@ struct tinygemm_kernel_nt<at::Half, at::Half, index_t, BLOCK_M, BLOCK_N> {
     Unroll<ROWS * COLS>{}(storec);
   }
 };
+#endif  // __riscv_zvfh
 
 #define LAUNCH_TINYGEMM_KERNEL_NT(MB_SIZE, NB_SIZE)                        \
   tinygemm_kernel_nt<scalar_t, kv_type, index_t, MB_SIZE, NB_SIZE>::apply( \

--- a/sgl-kernel/csrc/cpu/riscv64/decode.cpp
+++ b/sgl-kernel/csrc/cpu/riscv64/decode.cpp
@@ -1,0 +1,1436 @@
+#if defined(CPU_CAPABILITY_RVV) && defined(__clang__)
+#pragma clang riscv intrinsic vector
+#endif
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+#include <vector>
+
+#include "common.h"
+#include "riscv64/gemm.h"
+#include "vector_helpers.h"
+#include "vector_math.h"
+
+#if defined(CPU_CAPABILITY_RVV)
+
+namespace {
+
+// Generic scalar fallback for tinygemm_kernel_nt: computes Q(M,K) @ B(N,K) → C(M,N).
+// Index gathering is handled by the caller; this struct is type-agnostic GEMM.
+template <typename scalar_t, typename kv_t, typename index_t, int BLOCK_M, int BLOCK_N>
+struct tinygemm_kernel_nt {
+  static inline void apply(
+      const scalar_t* __restrict__ A,
+      const kv_t* __restrict__ B,
+      float* __restrict__ C,
+      const index_t* __restrict__ indices,
+      float scale,
+      int64_t lda,
+      int64_t ldb,
+      int64_t ldc,
+      int64_t K,
+      int64_t max_tokens) {
+    for (int64_t m = 0; m < BLOCK_M; ++m) {
+      for (int64_t n = 0; n < BLOCK_N; ++n) {
+        float sum = 0.f;
+        int64_t b_idx = indices[n];
+        TORCH_CHECK(b_idx < max_tokens, "token index out of scope!");
+        for (int64_t k = 0; k < K; ++k) {
+          float a_val = static_cast<float>(A[m * lda + k]);
+          float b_val = static_cast<float>(B[b_idx * ldb + k]);
+          sum += scale * a_val * b_val;
+        }
+        C[m * ldc + n] = sum;
+      }
+    }
+  }
+};
+
+template <typename index_t, int BLOCK_M, int BLOCK_N>
+struct tinygemm_kernel_nt<at::BFloat16, at::BFloat16, index_t, BLOCK_M, BLOCK_N> {
+  static inline void apply(
+      const at::BFloat16* __restrict__ A,
+      const at::BFloat16* __restrict__ B,
+      float* __restrict__ C,
+      const index_t* __restrict__ indices,
+      float scale,
+      int64_t lda,
+      int64_t ldb,
+      int64_t ldc,
+      int64_t K,
+      int64_t max_tokens) {
+    constexpr int ROWS = BLOCK_M;
+    constexpr int COLS = BLOCK_N;
+
+    size_t vl_max = __riscv_vsetvlmax_e32m1();
+
+    vf32m1_t vc[ROWS * COLS];
+
+    // Initialize accumulators with zero
+    auto init_c = [&](auto i) { vc[i] = __riscv_vfmv_v_f_f32m1(0.0f, vl_max); };
+    Unroll<ROWS * COLS>{}(init_c);
+
+    // Validate indices once
+    for (int n = 0; n < COLS; ++n) {
+      TORCH_CHECK(indices[n] < max_tokens, "token index out of scope!");
+    }
+
+    // Prefetch first 2 tokens before K loop (cache warmup)
+    if (COLS >= 1) __builtin_prefetch(B + indices[0] * ldb, 0, 3);
+    if (COLS >= 2) __builtin_prefetch(B + indices[1] * ldb, 0, 3);
+
+    size_t vl;
+    for (int64_t k = 0; k < K; k += vl) {
+      vl = __riscv_vsetvl_e32m1(K - k);
+
+      vf32m1_t vb[COLS];
+      for (int n = 0; n < COLS; ++n) {
+        int64_t b_idx = indices[n];
+        vb[n] = bf16_to_f32m1(reinterpret_cast<const uint16_t*>(B + b_idx * ldb + k), vl);
+
+        if (k + vl < K) {
+          __builtin_prefetch(B + b_idx * ldb + k + vl, 0, 1);
+        }
+        if (k == 0 && n + 2 < COLS) {
+          __builtin_prefetch(B + indices[n + 2] * ldb, 0, 2);
+        }
+      }
+
+      for (int m = 0; m < ROWS; ++m) {
+        vfloat32m1_t va = bf16_to_f32m1(reinterpret_cast<const uint16_t*>(A + m * lda + k), vl);
+        for (int n = 0; n < COLS; ++n) {
+          vc[m * COLS + n] = __riscv_vfmacc_vv_f32m1_tu(vc[m * COLS + n], va, vb[n], vl);
+        }
+      }
+    }
+
+    auto storec = [&](auto i) {
+      constexpr int row = i / COLS;
+      constexpr int col = i % COLS;
+      C[row * ldc + col] = reduce_sum_f32m1(vc[i], vl_max) * scale;
+    };
+    Unroll<ROWS * COLS>{}(storec);
+  }
+};
+
+template <typename index_t, int BLOCK_M, int BLOCK_N>
+struct tinygemm_kernel_nt<at::Half, at::Half, index_t, BLOCK_M, BLOCK_N> {
+  static inline void apply(
+      const at::Half* __restrict__ A,
+      const at::Half* __restrict__ B,
+      float* __restrict__ C,
+      const index_t* __restrict__ indices,
+      float scale,
+      int64_t lda,
+      int64_t ldb,
+      int64_t ldc,
+      int64_t K,
+      int64_t max_tokens) {
+    constexpr int ROWS = BLOCK_M;
+    constexpr int COLS = BLOCK_N;
+
+    size_t vl_max = __riscv_vsetvlmax_e32m1();
+
+    vf32m1_t vc[ROWS * COLS];
+
+    // Zero init accumulators
+    auto init_c = [&](auto i) { vc[i] = __riscv_vfmv_v_f_f32m1(0.0f, vl_max); };
+    Unroll<ROWS * COLS>{}(init_c);
+
+    // Validate indices once
+    for (int n = 0; n < COLS; ++n) {
+      TORCH_CHECK(indices[n] < max_tokens, "token index out of scope!");
+    }
+
+    // Prefetch first 2 tokens before K loop (cache warmup)
+    if (COLS >= 1) __builtin_prefetch(B + indices[0] * ldb, 0, 3);
+    if (COLS >= 2) __builtin_prefetch(B + indices[1] * ldb, 0, 3);
+
+    size_t vl;
+    for (int64_t k = 0; k < K; k += vl) {
+      vl = __riscv_vsetvl_e32m1(K - k);
+
+      vf32m1_t vb[COLS];
+      for (int n = 0; n < COLS; ++n) {
+        int64_t b_idx = indices[n];
+        vfloat16mf2_t vb_f16 = __riscv_vle16_v_f16mf2(reinterpret_cast<const _Float16*>(B + b_idx * ldb + k), vl);
+        vb[n] = __riscv_vfwcvt_f_f_v_f32m1(vb_f16, vl);
+
+        if (k + vl < K) {
+          __builtin_prefetch(B + b_idx * ldb + k + vl, 0, 1);
+        }
+        if (k == 0 && n + 2 < COLS) {
+          __builtin_prefetch(B + indices[n + 2] * ldb, 0, 2);
+        }
+      }
+
+      for (int m = 0; m < ROWS; ++m) {
+        vfloat16mf2_t va_f16 = __riscv_vle16_v_f16mf2(reinterpret_cast<const _Float16*>(A + m * lda + k), vl);
+        vfloat32m1_t va = __riscv_vfwcvt_f_f_v_f32m1(va_f16, vl);
+
+        for (int n = 0; n < COLS; ++n) {
+          vc[m * COLS + n] = __riscv_vfmacc_vv_f32m1_tu(vc[m * COLS + n], va, vb[n], vl);
+        }
+      }
+    }
+
+    auto storec = [&](auto i) {
+      constexpr int row = i / COLS;
+      constexpr int col = i % COLS;
+      C[row * ldc + col] = reduce_sum_f32m1(vc[i], vl_max) * scale;
+    };
+    Unroll<ROWS * COLS>{}(storec);
+  }
+};
+
+#define LAUNCH_TINYGEMM_KERNEL_NT(MB_SIZE, NB_SIZE)                        \
+  tinygemm_kernel_nt<scalar_t, kv_type, index_t, MB_SIZE, NB_SIZE>::apply( \
+      A + mb_start * lda, B, C + mb_start * ldc + nb_start, indices + nb_start, scale, lda, ldb, ldc, K, max_tokens);
+
+// Kernel: Value Aggregate (GEMM NN)
+// GEMM handles v' * scale + attn @ value (indexed)
+//   A : [M, K]
+//   B : [K, N] indexed
+//   C : [M, N]
+
+template <typename scalar_t, typename kv_t, typename index_t>
+inline void tinygemm_kernel_nn_scalar(
+    const float* __restrict__ A,
+    const kv_t* __restrict__ B,
+    float* __restrict__ C,
+    const index_t* __restrict__ indices,
+    const float* __restrict__ scale,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t lda,
+    int64_t ldb,
+    int64_t ldc,
+    int64_t max_tokens) {
+  // Validate all V-cache token indices once before entering the computation loops.
+  for (int64_t k = 0; k < K; ++k) {
+    TORCH_CHECK(indices[k] < max_tokens, "token index out of scope!");
+  }
+  for (int64_t m = 0; m < M; ++m) {
+    for (int64_t n = 0; n < N; ++n) {
+      C[m * ldc + n] *= scale[m];
+      for (int64_t k = 0; k < K; ++k) {
+        int64_t b_idx = indices[k];
+        float b_val = static_cast<float>(B[b_idx * ldb + n]);
+        C[m * ldc + n] += A[m * lda + k] * b_val;
+      }
+    }
+  }
+}
+// GEMM handles v' * scale + attn @ value (indexed)
+//   A : [M, K]
+//   B : [K, N] indexed
+//   C : [M, N]
+//
+// NOTE: C must be zero-initialized by the caller before the first call.
+// This kernel accumulates: C = C * scale + A @ B_indexed.
+// Callers must ensure zero-init via init_v_prime_split().
+//
+// Generic scalar fallback: delegates to tinygemm_kernel_nn_scalar.
+template <typename scalar_t, typename kv_t, typename index_t, int BLOCK_M, int BLOCK_N>
+struct tinygemm_kernel_nn {
+  static inline void apply(
+      const float* __restrict__ A,
+      const kv_t* __restrict__ B,
+      float* __restrict__ C,
+      const index_t* __restrict__ indices,
+      const float* __restrict__ scale,
+      int64_t lda,
+      int64_t ldb,
+      int64_t ldc,
+      int64_t K,
+      int64_t max_tokens) {
+    tinygemm_kernel_nn_scalar<scalar_t, kv_t, index_t>(
+        A, B, C, indices, scale, BLOCK_M, BLOCK_N, K, lda, ldb, ldc, max_tokens);
+  }
+};
+
+// RVV-optimized specialization for BFloat16
+template <typename index_t, int BLOCK_M, int BLOCK_N>
+struct tinygemm_kernel_nn<at::BFloat16, at::BFloat16, index_t, BLOCK_M, BLOCK_N> {
+  static inline void apply(
+      const float* __restrict__ A,
+      const at::BFloat16* __restrict__ B,
+      float* __restrict__ C,
+      const index_t* __restrict__ indices,
+      const float* __restrict__ scale,
+      int64_t lda,
+      int64_t ldb,
+      int64_t ldc,
+      int64_t K,
+      int64_t max_tokens) {
+    constexpr int ROWS = BLOCK_M;
+    constexpr int COLS = 4;  // 4 m1 vectors per tile
+
+    size_t vl_max = __riscv_vsetvlmax_e32m1();
+    int64_t tile_n = COLS * vl_max;
+
+    // Validate all V-cache token indices once before entering the tile loop.
+    for (int64_t k = 0; k < K; ++k) {
+      TORCH_CHECK(indices[k] < max_tokens, "token index out of scope!");
+    }
+
+    // Outer loop: Tiling over N
+    for (int64_t nb = 0; nb < BLOCK_N; nb += tile_n) {
+      vf32m1_t vc[ROWS * COLS];
+      size_t vls[COLS];
+
+      // 1. Pre-calculate VLs for this tile
+      for (int col = 0; col < COLS; ++col) {
+        int64_t n_curr = nb + col * vl_max;
+        if (n_curr < BLOCK_N) {
+          vls[col] = __riscv_vsetvl_e32m1(BLOCK_N - n_curr);
+        } else {
+          vls[col] = 0;
+        }
+      }
+
+      // 2. Load C and Scale
+      for (int m = 0; m < ROWS; ++m) {
+        float s = scale[m];
+        for (int col = 0; col < COLS; ++col) {
+          if (vls[col] > 0) {
+            int64_t n_curr = nb + col * vl_max;
+            vc[m * COLS + col] = __riscv_vle32_v_f32m1(C + m * ldc + n_curr, vls[col]);
+            vc[m * COLS + col] = __riscv_vfmul_vf_f32m1(vc[m * COLS + col], s, vls[col]);
+          }
+        }
+      }
+
+      // 3. Main Computation Loop (K)
+      for (int64_t k = 0; k < K; ++k) {
+        int64_t b_idx = indices[k];
+
+        // Prefetch next B row
+        if (k + 1 < K) {
+          __builtin_prefetch(B + indices[k + 1] * ldb + nb, 0, 1);
+        }
+
+        // 3a. Prepare B vectors (Load & Convert BF16 -> FP32)
+        vf32m1_t vb[COLS];
+        for (int col = 0; col < COLS; ++col) {
+          if (vls[col] > 0) {
+            int64_t n_curr = nb + col * vl_max;
+            // Helper from vector_helpers.h: bf16_to_f32m1
+            vb[col] = bf16_to_f32m1(reinterpret_cast<const uint16_t*>(B + b_idx * ldb + n_curr), vls[col]);
+          }
+        }
+
+        // 3b. FMA for each row
+        for (int m = 0; m < ROWS; ++m) {
+          float va = A[m * lda + k];
+          for (int col = 0; col < COLS; ++col) {
+            if (vls[col] > 0) {
+              vc[m * COLS + col] = __riscv_vfmacc_vf_f32m1(vc[m * COLS + col], va, vb[col], vls[col]);
+            }
+          }
+        }
+      }
+
+      // 4. Store Results
+      for (int m = 0; m < ROWS; ++m) {
+        for (int col = 0; col < COLS; ++col) {
+          if (vls[col] > 0) {
+            int64_t n_curr = nb + col * vl_max;
+            __riscv_vse32_v_f32m1(C + m * ldc + n_curr, vc[m * COLS + col], vls[col]);
+          }
+        }
+      }
+    }
+  }
+};
+
+template <typename index_t, int BLOCK_M, int BLOCK_N>
+struct tinygemm_kernel_nn<at::Half, at::Half, index_t, BLOCK_M, BLOCK_N> {
+  static inline void apply(
+      const float* __restrict__ A,
+      const at::Half* __restrict__ B,
+      float* __restrict__ C,
+      const index_t* __restrict__ indices,
+      const float* __restrict__ scale,
+      int64_t lda,
+      int64_t ldb,
+      int64_t ldc,
+      int64_t K,
+      int64_t max_tokens) {
+    constexpr int ROWS = BLOCK_M;
+    constexpr int COLS = 4;
+
+    size_t vl_max = __riscv_vsetvlmax_e32m1();
+    int64_t tile_n = COLS * vl_max;
+
+    // Validate all V-cache token indices once before entering the tile loop.
+    for (int64_t k = 0; k < K; ++k) {
+      TORCH_CHECK(indices[k] < max_tokens, "token index out of scope!");
+    }
+
+    // Outer loop: Tiling over N
+    for (int64_t nb = 0; nb < BLOCK_N; nb += tile_n) {
+      vf32m1_t vc[ROWS * COLS];
+      size_t vls[COLS];
+
+      // 1. Pre-calculate VLs
+      for (int col = 0; col < COLS; ++col) {
+        int64_t n_curr = nb + col * vl_max;
+        if (n_curr < BLOCK_N) {
+          vls[col] = __riscv_vsetvl_e32m1(BLOCK_N - n_curr);
+        } else {
+          vls[col] = 0;
+        }
+      }
+
+      // 2. Load C and Scale
+      for (int m = 0; m < ROWS; ++m) {
+        float s = scale[m];
+        for (int col = 0; col < COLS; ++col) {
+          if (vls[col] > 0) {
+            int64_t n_curr = nb + col * vl_max;
+            vc[m * COLS + col] = __riscv_vle32_v_f32m1(C + m * ldc + n_curr, vls[col]);
+            vc[m * COLS + col] = __riscv_vfmul_vf_f32m1(vc[m * COLS + col], s, vls[col]);
+          }
+        }
+      }
+
+      // 3. Main Computation Loop (K)
+      for (int64_t k = 0; k < K; ++k) {
+        int64_t b_idx = indices[k];
+
+        // Prefetch next B row
+        if (k + 1 < K) {
+          __builtin_prefetch(B + indices[k + 1] * ldb + nb, 0, 1);
+        }
+
+        // 3a. Prepare B vectors (Load FP16 -> Convert FP32)
+        vf32m1_t vb[COLS];
+        for (int col = 0; col < COLS; ++col) {
+          if (vls[col] > 0) {
+            int64_t n_curr = nb + col * vl_max;
+            vfloat16mf2_t vb_f16 =
+                __riscv_vle16_v_f16mf2(reinterpret_cast<const _Float16*>(B + b_idx * ldb + n_curr), vls[col]);
+            vb[col] = __riscv_vfwcvt_f_f_v_f32m1(vb_f16, vls[col]);
+          }
+        }
+
+        // 3b. FMA for each row
+        for (int m = 0; m < ROWS; ++m) {
+          float a_val = A[m * lda + k];
+          for (int col = 0; col < COLS; ++col) {
+            if (vls[col] > 0) {
+              vc[m * COLS + col] = __riscv_vfmacc_vf_f32m1(vc[m * COLS + col], a_val, vb[col], vls[col]);
+            }
+          }
+        }
+      }
+
+      // 4. Store Results
+      for (int m = 0; m < ROWS; ++m) {
+        for (int col = 0; col < COLS; ++col) {
+          if (vls[col] > 0) {
+            int64_t n_curr = nb + col * vl_max;
+            __riscv_vse32_v_f32m1(C + m * ldc + n_curr, vc[m * COLS + col], vls[col]);
+          }
+        }
+      }
+    }
+  }
+};
+
+#define LAUNCH_TINYGEMM_KERNEL_NN(MB_SIZE, NB_SIZE)                        \
+  tinygemm_kernel_nn<scalar_t, kv_type, index_t, MB_SIZE, NB_SIZE>::apply( \
+      A + mb_start * lda,                                                  \
+      B + nb_start,                                                        \
+      C + mb_start * ldc + nb_start,                                       \
+      indices,                                                             \
+      scale + mb_start,                                                    \
+      lda,                                                                 \
+      ldb,                                                                 \
+      ldc,                                                                 \
+      K,                                                                   \
+      max_tokens);
+
+template <typename scalar_t, typename kv_t, typename index_t>
+void index_gemm_kernel_nt(
+    const scalar_t* __restrict__ A,
+    const kv_t* __restrict__ B,
+    float* __restrict__ C,
+    const index_t* __restrict__ indices,
+    float scale,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t lda,
+    int64_t ldb,
+    int64_t ldc,
+    int64_t max_tokens) {
+  using kv_type = kv_t;
+  // pattern: 1-8-8 for decode (M==1)
+  if (M == 1) {
+    constexpr int64_t BLOCK_N = 8;
+    const int64_t NB = div_up(N, BLOCK_N);
+    // M==1: mb_start=0, so A+mb_start*lda==A and C+mb_start*ldc==C regardless
+    // of lda/ldc; the function-scope parameters are used directly via the macro.
+    int64_t mb_start = 0;
+
+    for (int64_t nb = 0; nb < NB; ++nb) {
+      int64_t nb_start = nb * BLOCK_N;
+      int64_t nb_size = std::min(BLOCK_N, N - nb_start);
+
+      switch (nb_size) {
+        case 1:
+          LAUNCH_TINYGEMM_KERNEL_NT(1, 1);
+          break;
+        case 2:
+          LAUNCH_TINYGEMM_KERNEL_NT(1, 2);
+          break;
+        case 3:
+          LAUNCH_TINYGEMM_KERNEL_NT(1, 3);
+          break;
+        case 4:
+          LAUNCH_TINYGEMM_KERNEL_NT(1, 4);
+          break;
+        case 5:
+          LAUNCH_TINYGEMM_KERNEL_NT(1, 5);
+          break;
+        case 6:
+          LAUNCH_TINYGEMM_KERNEL_NT(1, 6);
+          break;
+        case 7:
+          LAUNCH_TINYGEMM_KERNEL_NT(1, 7);
+          break;
+        case 8:
+          LAUNCH_TINYGEMM_KERNEL_NT(1, 8);
+          break;
+        default:
+          TORCH_CHECK(false, "Unexpected block size, 1x", nb_size);
+      }
+    }
+    return;
+  }
+  // Non-Half (BF16/FP32): BLOCK_M=4, BLOCK_N=6; dispatches 4x6=24 (mb,nb) tile cases.
+  // Half (FP16):          BLOCK_M=4, BLOCK_N=4; dispatches 4x4=16 (mb,nb) tile cases.
+  constexpr int64_t BLOCK_M = 4;
+  constexpr int64_t BLOCK_N = std::is_same_v<scalar_t, at::Half> ? 4 : 6;
+  const int64_t MB = div_up(M, BLOCK_M);
+  const int64_t NB = div_up(N, BLOCK_N);
+
+  for (int64_t mb = 0; mb < MB; ++mb) {
+    int64_t mb_start = mb * BLOCK_M;
+    int64_t mb_size = std::min(BLOCK_M, M - mb_start);
+    for (int64_t nb = 0; nb < NB; ++nb) {
+      int64_t nb_start = nb * BLOCK_N;
+      int64_t nb_size = std::min(BLOCK_N, N - nb_start);
+
+      switch (mb_size << 4 | nb_size) {
+        // mb_size = 1
+        case 0x11:
+          LAUNCH_TINYGEMM_KERNEL_NT(1, 1);
+          break;
+        case 0x12:
+          LAUNCH_TINYGEMM_KERNEL_NT(1, 2);
+          break;
+        case 0x13:
+          LAUNCH_TINYGEMM_KERNEL_NT(1, 3);
+          break;
+        case 0x14:
+          LAUNCH_TINYGEMM_KERNEL_NT(1, 4);
+          break;
+        case 0x15:
+          LAUNCH_TINYGEMM_KERNEL_NT(1, 5);
+          break;
+        case 0x16:
+          LAUNCH_TINYGEMM_KERNEL_NT(1, 6);
+          break;
+        // mb_size = 2
+        case 0x21:
+          LAUNCH_TINYGEMM_KERNEL_NT(2, 1);
+          break;
+        case 0x22:
+          LAUNCH_TINYGEMM_KERNEL_NT(2, 2);
+          break;
+        case 0x23:
+          LAUNCH_TINYGEMM_KERNEL_NT(2, 3);
+          break;
+        case 0x24:
+          LAUNCH_TINYGEMM_KERNEL_NT(2, 4);
+          break;
+        case 0x25:
+          LAUNCH_TINYGEMM_KERNEL_NT(2, 5);
+          break;
+        case 0x26:
+          LAUNCH_TINYGEMM_KERNEL_NT(2, 6);
+          break;
+        // mb_size = 3
+        case 0x31:
+          LAUNCH_TINYGEMM_KERNEL_NT(3, 1);
+          break;
+        case 0x32:
+          LAUNCH_TINYGEMM_KERNEL_NT(3, 2);
+          break;
+        case 0x33:
+          LAUNCH_TINYGEMM_KERNEL_NT(3, 3);
+          break;
+        case 0x34:
+          LAUNCH_TINYGEMM_KERNEL_NT(3, 4);
+          break;
+        case 0x35:
+          LAUNCH_TINYGEMM_KERNEL_NT(3, 5);
+          break;
+        case 0x36:
+          LAUNCH_TINYGEMM_KERNEL_NT(3, 6);
+          break;
+        // mb_size = 4
+        case 0x41:
+          LAUNCH_TINYGEMM_KERNEL_NT(4, 1);
+          break;
+        case 0x42:
+          LAUNCH_TINYGEMM_KERNEL_NT(4, 2);
+          break;
+        case 0x43:
+          LAUNCH_TINYGEMM_KERNEL_NT(4, 3);
+          break;
+        case 0x44:
+          LAUNCH_TINYGEMM_KERNEL_NT(4, 4);
+          break;
+        case 0x45:
+          LAUNCH_TINYGEMM_KERNEL_NT(4, 5);
+          break;
+        case 0x46:
+          LAUNCH_TINYGEMM_KERNEL_NT(4, 6);
+          break;
+        default:
+          TORCH_CHECK(false, "Unexpected block size, ", mb_size, "x", nb_size);
+      }
+    }
+  }
+}
+
+template <typename scalar_t, typename kv_t, typename index_t>
+void index_gemm_kernel_nn(
+    const float* __restrict__ A,
+    const kv_t* __restrict__ B,
+    float* __restrict__ C,
+    const index_t* __restrict__ indices,
+    float* __restrict__ scale,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t lda,
+    int64_t ldb,
+    int64_t ldc,
+    int64_t max_tokens) {
+  using kv_type = kv_t;
+  // kVecSize = vl_max_e32m1 = VLEN/32.
+  // __riscv_v_fixed_vlen is a compile-time constant injected by -mrvv-vector-bits=N,
+  constexpr int kVecSize = static_cast<int>(__riscv_v_fixed_vlen) / 32;
+  constexpr int kVecShift = __builtin_ctz(static_cast<unsigned int>(kVecSize));
+  // N must be a multiple of kVecSize; non-aligned sizes fall through to scalar path.
+  if ((N & (kVecSize - 1)) != 0) {
+    tinygemm_kernel_nn_scalar<scalar_t, kv_t, index_t>(A, B, C, indices, scale, M, N, K, lda, ldb, ldc, max_tokens);
+    return;
+  }
+
+  // pattern: 1-8-8 for decode (M==1)
+  if (M == 1) {
+    // BLOCK_N = 8 * kVecSize: 8 full vl_max-wide strips per tile.
+    constexpr int64_t BLOCK_N = 8 * kVecSize;
+    const int64_t NB = div_up(N, BLOCK_N);
+    // M==1: mb_start=0, so A+mb_start*lda==A and C+mb_start*ldc==C regardless
+    // of lda/ldc; the function-scope parameters are used directly via the macro.
+    int64_t mb_start = 0;
+
+    for (int64_t nb = 0; nb < NB; ++nb) {
+      int64_t nb_start = nb * BLOCK_N;
+      int64_t nb_size = std::min(BLOCK_N, N - nb_start);
+
+      switch (nb_size >> kVecShift) {
+        case 1:
+          LAUNCH_TINYGEMM_KERNEL_NN(1, kVecSize * 1);
+          break;
+        case 2:
+          LAUNCH_TINYGEMM_KERNEL_NN(1, kVecSize * 2);
+          break;
+        case 3:
+          LAUNCH_TINYGEMM_KERNEL_NN(1, kVecSize * 3);
+          break;
+        case 4:
+          LAUNCH_TINYGEMM_KERNEL_NN(1, kVecSize * 4);
+          break;
+        case 5:
+          LAUNCH_TINYGEMM_KERNEL_NN(1, kVecSize * 5);
+          break;
+        case 6:
+          LAUNCH_TINYGEMM_KERNEL_NN(1, kVecSize * 6);
+          break;
+        case 7:
+          LAUNCH_TINYGEMM_KERNEL_NN(1, kVecSize * 7);
+          break;
+        case 8:
+          LAUNCH_TINYGEMM_KERNEL_NN(1, kVecSize * 8);
+          break;
+        default:
+          TORCH_CHECK(false, "Unexpected block size, 1x", nb_size);
+      }
+    }
+    return;
+  }
+
+  // Batch pattern: BLOCK_M x BLOCK_N tiling.
+  // BLOCK_N = 6 * kVecSize: 6 full vl_max-wide strips per tile.
+  constexpr int64_t BLOCK_M = 4;
+  constexpr int64_t BLOCK_N = 6 * kVecSize;
+  const int64_t MB = div_up(M, BLOCK_M);
+  const int64_t NB = div_up(N, BLOCK_N);
+
+  for (int64_t mb = 0; mb < MB; ++mb) {
+    int64_t mb_start = mb * BLOCK_M;
+    int64_t mb_size = std::min(BLOCK_M, M - mb_start);
+    for (int64_t nb = 0; nb < NB; ++nb) {
+      int64_t nb_start = nb * BLOCK_N;
+      int64_t nb_size = std::min(BLOCK_N, N - nb_start);
+
+      // Upper nibble: mb_size (1–4); lower nibble: nb_size / kVecSize (1–6).
+      switch (mb_size << 4 | nb_size >> kVecShift) {
+        // mb_size = 1
+        case 0x11:
+          LAUNCH_TINYGEMM_KERNEL_NN(1, kVecSize * 1);
+          break;
+        case 0x12:
+          LAUNCH_TINYGEMM_KERNEL_NN(1, kVecSize * 2);
+          break;
+        case 0x13:
+          LAUNCH_TINYGEMM_KERNEL_NN(1, kVecSize * 3);
+          break;
+        case 0x14:
+          LAUNCH_TINYGEMM_KERNEL_NN(1, kVecSize * 4);
+          break;
+        case 0x15:
+          LAUNCH_TINYGEMM_KERNEL_NN(1, kVecSize * 5);
+          break;
+        case 0x16:
+          LAUNCH_TINYGEMM_KERNEL_NN(1, kVecSize * 6);
+          break;
+        // mb_size = 2
+        case 0x21:
+          LAUNCH_TINYGEMM_KERNEL_NN(2, kVecSize * 1);
+          break;
+        case 0x22:
+          LAUNCH_TINYGEMM_KERNEL_NN(2, kVecSize * 2);
+          break;
+        case 0x23:
+          LAUNCH_TINYGEMM_KERNEL_NN(2, kVecSize * 3);
+          break;
+        case 0x24:
+          LAUNCH_TINYGEMM_KERNEL_NN(2, kVecSize * 4);
+          break;
+        case 0x25:
+          LAUNCH_TINYGEMM_KERNEL_NN(2, kVecSize * 5);
+          break;
+        case 0x26:
+          LAUNCH_TINYGEMM_KERNEL_NN(2, kVecSize * 6);
+          break;
+        // mb_size = 3
+        case 0x31:
+          LAUNCH_TINYGEMM_KERNEL_NN(3, kVecSize * 1);
+          break;
+        case 0x32:
+          LAUNCH_TINYGEMM_KERNEL_NN(3, kVecSize * 2);
+          break;
+        case 0x33:
+          LAUNCH_TINYGEMM_KERNEL_NN(3, kVecSize * 3);
+          break;
+        case 0x34:
+          LAUNCH_TINYGEMM_KERNEL_NN(3, kVecSize * 4);
+          break;
+        case 0x35:
+          LAUNCH_TINYGEMM_KERNEL_NN(3, kVecSize * 5);
+          break;
+        case 0x36:
+          LAUNCH_TINYGEMM_KERNEL_NN(3, kVecSize * 6);
+          break;
+        // mb_size = 4
+        case 0x41:
+          LAUNCH_TINYGEMM_KERNEL_NN(4, kVecSize * 1);
+          break;
+        case 0x42:
+          LAUNCH_TINYGEMM_KERNEL_NN(4, kVecSize * 2);
+          break;
+        case 0x43:
+          LAUNCH_TINYGEMM_KERNEL_NN(4, kVecSize * 3);
+          break;
+        case 0x44:
+          LAUNCH_TINYGEMM_KERNEL_NN(4, kVecSize * 4);
+          break;
+        case 0x45:
+          LAUNCH_TINYGEMM_KERNEL_NN(4, kVecSize * 5);
+          break;
+        case 0x46:
+          LAUNCH_TINYGEMM_KERNEL_NN(4, kVecSize * 6);
+          break;
+        default:
+          TORCH_CHECK(false, "Unexpected block size, ", mb_size, "x", nb_size);
+      }
+    }
+  }
+}
+
+template <typename scalar_t>
+void decode_set_kv_buffer(
+    scalar_t* __restrict__ k_buffer,
+    scalar_t* __restrict__ v_buffer,
+    const scalar_t* __restrict__ key,
+    const scalar_t* __restrict__ value,
+    const int64_t* __restrict__ loc,
+    int64_t batches,
+    int64_t num_heads_kv,
+    int64_t head_size,
+    int64_t head_size_v,
+    int64_t k_strideN,
+    int64_t k_strideH,
+    int64_t v_strideN,
+    int64_t v_strideH,
+    int64_t nk_strideN,
+    int64_t nk_strideH,
+    int64_t nv_strideN,
+    int64_t nv_strideH) {
+  at::parallel_for(0, batches * num_heads_kv, 0, [&](int64_t begin, int64_t end) {
+    int64_t bs{0}, head_kv_id{0};
+    data_index_init(begin, bs, batches, head_kv_id, num_heads_kv);
+
+    for (int64_t i = begin; i < end; i++) {
+      int64_t loc_val = loc[bs];
+      scalar_t* k_buffer_ptr = k_buffer + loc_val * k_strideN + head_kv_id * k_strideH;
+      const scalar_t* new_key_ptr = key + bs * nk_strideN + head_kv_id * nk_strideH;
+
+      if (i + 1 < end) {
+        int64_t next_bs = bs, next_head = head_kv_id;
+        data_index_step(next_bs, batches, next_head, num_heads_kv);
+        __builtin_prefetch(key + next_bs * nk_strideN + next_head * nk_strideH, 0, 1);
+        __builtin_prefetch(value + next_bs * nv_strideN + next_head * nv_strideH, 0, 1);
+      }
+
+      copy_stub<scalar_t>(k_buffer_ptr, new_key_ptr, head_size);
+      scalar_t* v_buffer_ptr = v_buffer + loc_val * v_strideN + head_kv_id * v_strideH;
+      const scalar_t* new_value_ptr = value + bs * nv_strideN + head_kv_id * nv_strideH;
+      copy_stub<scalar_t>(v_buffer_ptr, new_value_ptr, head_size_v);
+      data_index_step(bs, batches, head_kv_id, num_heads_kv);
+    }
+  });
+}
+
+// Initialize a v_prime split slot: zero the value accumulator and write the
+// -inf sentinel so decode_accumulate_kv_splits can detect empty splits.
+inline void init_v_prime_split(float* __restrict__ vp, int64_t head_size_v) {
+  fill_stub(vp, 0.f, head_size_v);
+  vp[head_size_v] = -std::numeric_limits<float>::infinity();
+}
+
+template <typename scalar_t>
+inline void decode_accumulate_kv_splits(
+    scalar_t* __restrict__ output,
+    float* __restrict__ attn_logits,
+    int64_t batches,
+    int64_t num_heads,
+    int64_t head_size_v,
+    int64_t num_kv_splits,
+    int64_t l_stride1,
+    int64_t l_stride2) {
+  at::parallel_for(0, batches * num_heads, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t i = begin; i < end; ++i) {
+      float* __restrict__ acc = attn_logits + i * l_stride1;
+
+      float s_prime = 0.f;
+      float m_prime = -std::numeric_limits<float>::infinity();
+
+      for (int64_t kv_id = 0; kv_id < num_kv_splits; ++kv_id) {
+        float* __restrict__ tv = acc + kv_id * l_stride2;
+        const float tlogic = tv[head_size_v];
+
+        float m_i = std::max(tlogic, m_prime);
+        float m_delta = expf(m_prime - m_i);
+        float e_logic = expf(tlogic - m_i);
+
+        if (kv_id != 0) {
+          size_t vl_max = __riscv_vsetvlmax_e32m8();
+          for (int64_t d = 0; d < head_size_v; d += vl_max) {
+            size_t vl = __riscv_vsetvl_e32m8(head_size_v - d);
+            vfloat32m8_t vacc = __riscv_vle32_v_f32m8(acc + d, vl);
+            vfloat32m8_t vtv = __riscv_vle32_v_f32m8(tv + d, vl);
+
+            vacc = __riscv_vfmul_vf_f32m8(vacc, m_delta, vl);
+            vacc = __riscv_vfmacc_vf_f32m8(vacc, e_logic, vtv, vl);
+
+            __riscv_vse32_v_f32m8(acc + d, vacc, vl);
+          }
+        }
+
+        s_prime = s_prime * m_delta + e_logic;
+        m_prime = m_i;
+      }
+
+      float scale = (s_prime > 0.0f && std::isfinite(s_prime)) ? (1.0f / s_prime) : 0.0f;
+
+      size_t vl_max = __riscv_vsetvlmax_e32m8();
+      alignas(64) float scratch[rvv_constants::MAX_VL_ELEMENTS_M8];
+      // Assumes contiguous output: stride[0]=num_heads*head_size_v, stride[1]=head_size_v
+      scalar_t* o_ptr = output + i * head_size_v;
+      for (int64_t d = 0; d < head_size_v; d += vl_max) {
+        size_t vl = __riscv_vsetvl_e32m8(head_size_v - d);
+        vfloat32m8_t vacc = __riscv_vle32_v_f32m8(acc + d, vl);
+        vacc = __riscv_vfmul_vf_f32m8(vacc, scale, vl);
+
+        store_from_float_m8(o_ptr + d, vacc, vl, scratch);
+      }
+    }
+  });
+}
+
+template <typename scalar_t, typename kv_t, typename index_t>
+void decode_attention_kernel_impl(
+    scalar_t* __restrict__ output,
+    float* __restrict__ attn_logits,
+    const scalar_t* __restrict__ query,
+    const kv_t* __restrict__ k_buffer,
+    const kv_t* __restrict__ v_buffer,
+    const index_t* __restrict__ req_to_token,
+    const int64_t* __restrict__ req_pool_indices,
+    const int64_t* __restrict__ seq_lens,
+    int64_t batches,
+    int64_t num_heads,
+    int64_t num_heads_kv,
+    int64_t head_size,
+    int64_t head_size_v,
+    int64_t num_kv_splits,
+    int64_t q_strideM,
+    int64_t q_strideH,
+    int64_t k_strideN,
+    int64_t k_strideH,
+    int64_t v_strideN,
+    int64_t v_strideH,
+    float scaling,
+    float logit_cap,
+    int64_t max_num_reqs,
+    int64_t max_context_len,
+    int64_t max_total_num_tokens,
+    int64_t o_strideM,
+    int64_t o_strideH) {
+  // Strides for accumulation
+  // attn_logits layout: [batches, num_heads, num_kv_splits, head_size_v + 1]
+  const int64_t l_stride0 = num_heads * num_kv_splits * (head_size_v + 1);
+  const int64_t l_stride1 = num_kv_splits * (head_size_v + 1);
+  const int64_t l_stride2 = head_size_v + 1;
+
+  const bool has_logit_cap = logit_cap > 0;
+  float rlogit_cap = has_logit_cap ? 1 / logit_cap : 0.f;
+
+  // TARGET_BLOCK_N = 2 * vl_max_e32m4 = __riscv_v_fixed_vlen / 4 (compile-time).
+  // VLEN=128 → 32, VLEN=256 → 64, VLEN=512 → 128, VLEN=1024 → 256.
+  constexpr int64_t TARGET_BLOCK_N = rvv_constants::BLOCK_N;
+
+  at::parallel_for(0, batches * num_heads * num_kv_splits, 0, [&](int64_t begin, int64_t end) {
+    int64_t bs{0}, head_id{0}, kv_id{0};
+    data_index_init(begin, bs, batches, head_id, num_heads, kv_id, num_kv_splits);
+
+    alignas(64) float s_i[TARGET_BLOCK_N];
+
+    for (int64_t i = begin; i < end; ++i) {
+      const scalar_t* __restrict__ q_ptr = query + bs * q_strideM + head_id * q_strideH;
+
+      int64_t seq_len_kv = seq_lens[bs];
+      int64_t req_pool_id = req_pool_indices[bs];
+      TORCH_CHECK(seq_len_kv <= max_context_len, "seq_len_kv out of scope!");
+      TORCH_CHECK(req_pool_id < max_num_reqs, "req_pool_id out of scope!");
+      const int64_t SPLIT_SIZE = div_up(seq_len_kv, num_kv_splits);
+      const int64_t kv_start = kv_id * SPLIT_SIZE;
+      const int64_t kv_end = std::min(kv_start + SPLIT_SIZE, seq_len_kv);
+
+      float m_prime = -std::numeric_limits<float>::infinity();
+      float s_prime = 0.f;
+
+      // Use correct stride calculation: [bs, head_id, kv_id, d]
+      float* __restrict__ v_prime = attn_logits + bs * l_stride0 + head_id * l_stride1 + kv_id * l_stride2;
+      init_v_prime_split(v_prime, head_size_v);
+
+      // Loop over tokens in blocks
+      for (int64_t n = kv_start; n < kv_end; n += TARGET_BLOCK_N) {
+        int64_t n_size = std::min(TARGET_BLOCK_N, kv_end - n);
+
+        const index_t* cur_indices = req_to_token + req_pool_id * max_context_len + n;
+
+        // Calculate s_i <- scale * Q @ K using generic dispatch
+        index_gemm_kernel_nt<scalar_t, kv_t, index_t>(
+            /* A   */ q_ptr,
+            /* B   */ k_buffer + head_id * k_strideH,
+            /* C   */ s_i,
+            /* ind */ cur_indices,
+            /* scl */ scaling,
+            /* M   */ 1,
+            /* N   */ n_size,
+            /* K   */ head_size,
+            /* lda */ 1,
+            /* ldb */ k_strideN,
+            /* ldc */ 1,
+            /* mtt */ max_total_num_tokens);
+
+        // 2. Logit Cap & Softmax parts
+        if (has_logit_cap) {
+          size_t vl_max = __riscv_vsetvlmax_e32m4();
+          for (int64_t idx = 0; idx < n_size; idx += vl_max) {
+            size_t vl = __riscv_vsetvl_e32m4(n_size - idx);
+            vfloat32m4_t vx = __riscv_vle32_v_f32m4(s_i + idx, vl);
+            vx = __riscv_vfmul_vf_f32m4(vx, rlogit_cap, vl);
+            vx = vftanh_f32m4(vx, vl);
+            vx = __riscv_vfmul_vf_f32m4(vx, logit_cap, vl);
+            __riscv_vse32_v_f32m4(s_i + idx, vx, vl);
+          }
+        }
+
+        // m_i: max value across block
+        float m_i = rvv_reduce_max_f32(s_i, n_size);
+        m_i = std::max(m_i, m_prime);
+
+        // m_delta <- exp(m' - m_i)
+        float m_delta = expf(m_prime - m_i);
+
+        // s_delta <- exp(s_i - m_i), returns sum(s_delta)
+        float local_sum = exp_and_sum(s_i, n_size, m_i);
+
+        // s' <- s' * m_delta + sum(s_delta)
+        s_prime = s_prime * m_delta + local_sum;
+        m_prime = m_i;
+
+        // 3. V' <- V' * m_delta + s_delta @ V
+        index_gemm_kernel_nn<scalar_t, kv_t, index_t>(
+            /* A   */ s_i,
+            /* B   */ v_buffer + head_id * v_strideH,
+            /* C   */ v_prime,
+            /* ind */ cur_indices,
+            /* scl */ &m_delta,
+            /* M   */ 1,
+            /* N   */ head_size_v,
+            /* K   */ n_size,
+            /* lda */ 1,
+            /* ldb */ v_strideN,
+            /* ldc */ 1,
+            /* mtt */ max_total_num_tokens);
+      }
+
+      if (kv_end > kv_start) {
+        const float safe_s_prime = (s_prime > 1e-38f) ? s_prime : 1e-38f;
+        float s = 1.0f / safe_s_prime;
+        size_t vl_max = __riscv_vsetvlmax_e32m8();
+        for (int64_t d = 0; d < head_size_v; d += vl_max) {
+          size_t vl = __riscv_vsetvl_e32m8(head_size_v - d);
+          vfloat32m8_t vval = __riscv_vle32_v_f32m8(v_prime + d, vl);
+          vval = __riscv_vfmul_vf_f32m8(vval, s, vl);
+          __riscv_vse32_v_f32m8(v_prime + d, vval, vl);
+        }
+        v_prime[head_size_v] = m_prime + std::log(safe_s_prime);
+      }
+
+      data_index_step(bs, batches, head_id, num_heads, kv_id, num_kv_splits);
+    }
+  });
+
+  decode_accumulate_kv_splits(
+      output, attn_logits, batches, num_heads, head_size_v, num_kv_splits, l_stride1, l_stride2);
+}
+
+template <typename scalar_t, typename kv_t, typename index_t>
+void decode_attention_grouped_kernel_impl(
+    scalar_t* __restrict__ output,
+    float* __restrict__ attn_logits,
+    const scalar_t* __restrict__ query,
+    const kv_t* __restrict__ k_buffer,
+    const kv_t* __restrict__ v_buffer,
+    const index_t* __restrict__ req_to_token,
+    const int64_t* __restrict__ req_pool_indices,
+    const int64_t* __restrict__ seq_lens,
+    int64_t batches,
+    int64_t num_heads,
+    int64_t num_heads_kv,
+    int64_t head_size,
+    int64_t head_size_v,
+    int64_t num_kv_splits,
+    int64_t q_strideM,
+    int64_t q_strideH,
+    int64_t k_strideN,
+    int64_t k_strideH,
+    int64_t v_strideN,
+    int64_t v_strideH,
+    float scaling,
+    float logit_cap,
+    int64_t max_num_reqs,
+    int64_t max_context_len,
+    int64_t max_total_num_tokens,
+    int64_t o_strideM,
+    int64_t o_strideH) {
+  constexpr int64_t BLOCK_N = rvv_constants::BLOCK_N;
+  // Block length for heads - parallel on [batches, divup(num_heads, BLOCK_H), num_kv_splits]
+  constexpr int64_t kBLOCK_H = 16;
+  const int64_t BLOCK_H = std::min(4 * batches, kBLOCK_H);
+
+  // Strides for attn_logits
+  const int64_t l_stride0 = num_heads * num_kv_splits * (head_size_v + 1);
+  const int64_t l_stride1 = num_kv_splits * (head_size_v + 1);
+  const int64_t l_stride2 = head_size_v + 1;
+
+  const bool has_logit_cap = logit_cap > 0;
+  float rlogit_cap = has_logit_cap ? 1 / logit_cap : 0.f;
+
+  // Partition heads into blocks for parallel
+  const int64_t num_groups = num_heads / num_heads_kv;
+  const int64_t num_blocks = div_up(num_groups, BLOCK_H);
+
+  // Parallel on [batches, num_heads_kv, num_blocks, num_kv_splits]
+  at::parallel_for(0, batches * num_heads_kv * num_blocks * num_kv_splits, 0, [&](int64_t begin, int64_t end) {
+    int64_t bs{0}, head_kv_id{0}, block_id{0}, kv_id{0};
+    data_index_init(begin, bs, batches, head_kv_id, num_heads_kv, block_id, num_blocks, kv_id, num_kv_splits);
+
+    alignas(64) float s_i[kBLOCK_H * BLOCK_N];
+    float* __restrict__ s_delta = s_i;
+
+    alignas(64) float s_prime[kBLOCK_H];
+    alignas(64) float m_prime[kBLOCK_H];
+    alignas(64) float m_delta[kBLOCK_H];
+
+    for (int64_t i = begin; i < end; ++i) {
+      const int64_t h_start = head_kv_id * num_groups + block_id * BLOCK_H;
+      const int64_t h_end = head_kv_id * num_groups + std::min(block_id * BLOCK_H + BLOCK_H, num_groups);
+      const int64_t h_size = h_end - h_start;
+
+      // Get query
+      const scalar_t* __restrict__ q_ptr = query + bs * q_strideM + h_start * q_strideH;
+
+      int64_t seq_len_kv = seq_lens[bs];
+      int64_t req_pool_id = req_pool_indices[bs];
+      TORCH_CHECK(seq_len_kv <= max_context_len, "seq_len_kv out of scope!");
+      TORCH_CHECK(req_pool_id < max_num_reqs, "req_pool_id out of scope!");
+
+      const int64_t SPLIT_SIZE = div_up(seq_len_kv, num_kv_splits);
+      const int64_t kv_start = kv_id * SPLIT_SIZE;
+      const int64_t kv_end = std::min(kv_start + SPLIT_SIZE, seq_len_kv);
+
+      // Initialize accumulators
+      for (int64_t h = 0; h < h_size; ++h) {
+        s_prime[h] = 0.f;
+        m_prime[h] = -std::numeric_limits<float>::infinity();
+      }
+
+      // Get v_prime, and init to zero (sentinel -inf for decode_accumulate_kv_splits)
+      float* __restrict__ v_prime = attn_logits + bs * l_stride0 + h_start * l_stride1 + kv_id * l_stride2;
+      for (int64_t h = 0; h < h_size; ++h) {
+        init_v_prime_split(v_prime + h * l_stride1, head_size_v);
+      }
+
+      // Loop over K and V sequence with BLOCK_N
+      for (int64_t n = kv_start; n < kv_end; n += BLOCK_N) {
+        int64_t n_size = std::min(BLOCK_N, kv_end - n);
+
+        const index_t* cur_indices = req_to_token + req_pool_id * max_context_len + n;
+
+        // Calculate Q @ K using RVV dispatch
+        index_gemm_kernel_nt<scalar_t, kv_t, index_t>(
+            /* A   */ q_ptr,
+            /* B   */ k_buffer + head_kv_id * k_strideH,
+            /* C   */ s_i,
+            /* ind */ cur_indices,
+            /* scl */ scaling,
+            /* M   */ h_size,
+            /* N   */ n_size,
+            /* K   */ head_size,
+            /* lda */ q_strideH,
+            /* ldb */ k_strideN,
+            /* ldc */ BLOCK_N,
+            /* mtt */ max_total_num_tokens);
+
+        if (has_logit_cap) {
+          // Apply per-row, up to n_size only. h_size rows × BLOCK_N columns,
+          // but only n_size elements per row are valid (partial last block).
+          // Reading s_i[h*BLOCK_N + n_size..BLOCK_N-1] is C++ UB (uninitialized).
+          size_t vl_max = __riscv_vsetvlmax_e32m4();
+          for (int64_t h = 0; h < h_size; ++h) {
+            float* row = s_i + h * BLOCK_N;
+            for (int64_t idx = 0; idx < n_size; idx += vl_max) {
+              size_t vl = __riscv_vsetvl_e32m4(n_size - idx);
+              vfloat32m4_t vx = __riscv_vle32_v_f32m4(row + idx, vl);
+              vx = __riscv_vfmul_vf_f32m4(vx, rlogit_cap, vl);
+              vx = vftanh_f32m4(vx, vl);
+              vx = __riscv_vfmul_vf_f32m4(vx, logit_cap, vl);
+              __riscv_vse32_v_f32m4(row + idx, vx, vl);
+            }
+          }
+        }
+
+        // Update the scaling coefficients
+        for (int64_t h = 0; h < h_size; ++h) {
+          float* s_row = s_i + h * BLOCK_N;
+
+          // m_i: vectorized max reduction across row
+          float local_max = rvv_reduce_max_f32(s_row, n_size);
+          float m_i = std::max(local_max, m_prime[h]);
+
+          // m_delta <- exp(m' - m_i)
+          m_delta[h] = expf(m_prime[h] - m_i);
+
+          // s_delta <- exp(s_i - m_i) and sum
+          float row_sum = 0.0f;
+          size_t vl_max = __riscv_vsetvlmax_e32m4();
+          for (int64_t j = 0; j < n_size; j += vl_max) {
+            size_t vl = __riscv_vsetvl_e32m4(n_size - j);
+            vfloat32m4_t vx = __riscv_vle32_v_f32m4(s_row + j, vl);
+            vx = __riscv_vfsub_vf_f32m4(vx, m_i, vl);
+            vfloat32m4_t vex = vfexp_f32m4(vx, vl);
+            __riscv_vse32_v_f32m4(s_delta + h * BLOCK_N + j, vex, vl);
+
+            vfloat32m1_t vzero = __riscv_vfmv_s_f_f32m1(0.0f, 1);
+            vfloat32m1_t vsum = __riscv_vfredusum_vs_f32m4_f32m1(vex, vzero, vl);
+            row_sum += __riscv_vfmv_f_s_f32m1_f32(vsum);
+          }
+
+          // s' <- s' * m_delta + sum(s_delta)
+          s_prime[h] = s_prime[h] * m_delta[h] + row_sum;
+          m_prime[h] = m_i;
+        }
+
+        // Calculate V' <- s_delta @ V + V' * m_delta
+        index_gemm_kernel_nn<scalar_t, kv_t, index_t>(
+            /* A   */ s_delta,
+            /* B   */ v_buffer + head_kv_id * v_strideH,
+            /* C   */ v_prime,
+            /* ind */ cur_indices,
+            /* scl */ m_delta,
+            /* M   */ h_size,
+            /* N   */ head_size_v,
+            /* K   */ n_size,
+            /* lda */ BLOCK_N,
+            /* ldb */ v_strideN,
+            /* ldc */ l_stride1,
+            /* mtt */ max_total_num_tokens);
+      }  // loop with KV blocks
+
+      // Only update v' when kv_split_size > 0
+      if (kv_end > kv_start) {
+        for (int64_t h = 0; h < h_size; ++h) {
+          // Guard against division by very small numbers to prevent Inf
+          const float safe_s_prime = (s_prime[h] > 1e-38f) ? s_prime[h] : 1e-38f;
+          float s = 1.0f / safe_s_prime;
+          float* v_ptr = v_prime + h * l_stride1;
+
+          // Scale each element of v' by 1/s_prime to produce the normalized partial sum.
+          size_t vl_max = __riscv_vsetvlmax_e32m8();
+          for (int64_t d = 0; d < head_size_v; d += vl_max) {
+            size_t vl = __riscv_vsetvl_e32m8(head_size_v - d);
+            vfloat32m8_t vv = __riscv_vle32_v_f32m8(v_ptr + d, vl);
+            vv = __riscv_vfmul_vf_f32m8(vv, s, vl);
+            __riscv_vse32_v_f32m8(v_ptr + d, vv, vl);
+          }
+          v_ptr[head_size_v] = m_prime[h] + std::log(safe_s_prime);
+        }
+      }
+
+      data_index_step(bs, batches, head_kv_id, num_heads_kv, block_id, num_blocks, kv_id, num_kv_splits);
+    }
+  });
+
+  decode_accumulate_kv_splits(
+      output, attn_logits, batches, num_heads, head_size_v, num_kv_splits, l_stride1, l_stride2);
+}
+
+// Tensor shapes:
+//   query:            [num_tokens, num_heads, head_size]
+//   output:           [num_tokens, num_heads, head_size]
+//   k_buffer:         [max_total_num_tokens, num_heads, head_size]
+//   v_buffer:         [max_total_num_tokens, num_heads, head_size_v]
+//   attn_logits:      [num_seqs, num_heads, num_kv_splits, head_size_v + 1]
+//   req_to_token:     [max_num_reqs, max_context_len] int32 or int64
+//   req_pool_indices: [num_seqs] int64
+//   seq_lens:         [num_seqs] int64
+}  // anonymous namespace
+
+void decode_attention_cpu(
+    at::Tensor& query,
+    at::Tensor& k_buffer,
+    at::Tensor& v_buffer,
+    at::Tensor& output,
+    at::Tensor& key,
+    at::Tensor& value,
+    at::Tensor& loc,
+    at::Tensor& attn_logits,
+    at::Tensor& req_to_token,
+    at::Tensor& req_pool_indices,
+    at::Tensor& seq_lens,
+    double sm_scale,
+    double logit_cap) {
+  RECORD_FUNCTION(
+      "sgl-kernel::decode_attention_cpu",
+      std::vector<c10::IValue>(
+          {query, output, k_buffer, v_buffer, attn_logits, req_to_token, req_pool_indices, seq_lens}));
+
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(query);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(k_buffer);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(v_buffer);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(key);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(value);
+  CHECK_DIM(3, query);
+  CHECK_DIM(3, k_buffer);
+  CHECK_DIM(3, v_buffer);
+  CHECK_DIM(3, key);
+  CHECK_DIM(3, value);
+  CHECK_DIM(1, loc);
+  TORCH_CHECK(
+      query.scalar_type() == key.scalar_type() && query.scalar_type() == value.scalar_type() &&
+          query.scalar_type() == k_buffer.scalar_type() && query.scalar_type() == v_buffer.scalar_type(),
+      "decode_attention_cpu: expect query, key, value, k_buffer, and v_buffer to have the same dtype");
+
+  int64_t num_seqs = seq_lens.size(0);
+  int64_t max_num_reqs = req_to_token.size(0);
+  int64_t max_context_len = req_to_token.size(1);
+  int64_t max_total_num_tokens = k_buffer.size(0);
+
+  int64_t num_heads = query.size(1);
+  int64_t num_heads_kv = k_buffer.size(1);
+  int64_t head_size = query.size(2);
+  int64_t head_size_v = v_buffer.size(2);
+
+  TORCH_CHECK(
+      head_size <= MAX_HEAD_SIZE && head_size_v <= MAX_HEAD_SIZE,
+      "decode_attention_cpu: head_size (",
+      head_size,
+      ") or head_size_v (",
+      head_size_v,
+      ") exceeds MAX_HEAD_SIZE (",
+      MAX_HEAD_SIZE,
+      "). Recompile with a larger MAX_HEAD_SIZE to support this configuration.");
+
+  int64_t num_kv_splits = attn_logits.size(2);
+
+  CHECK_EQ(loc.numel(), num_seqs);
+  CHECK_EQ(attn_logits.size(0), num_seqs);
+  CHECK_EQ(attn_logits.size(1), num_heads);
+  CHECK_EQ(attn_logits.size(3), head_size_v + 1);
+  CHECK_EQ(attn_logits.scalar_type(), at::kFloat);
+  // decode_accumulate_kv_splits writes output as output + i*head_size_v
+  // (flat contiguous indexing). Verify the tensor is actually contiguous.
+  TORCH_CHECK(output.is_contiguous(), "decode_attention_cpu: output must be contiguous");
+
+  int64_t q_strideM = query.stride(0);
+  int64_t q_strideH = query.stride(1);
+  int64_t o_strideM = output.stride(0);
+  int64_t o_strideH = output.stride(1);
+  int64_t k_strideN = k_buffer.stride(0);
+  int64_t k_strideH = k_buffer.stride(1);
+  int64_t v_strideN = v_buffer.stride(0);
+  int64_t v_strideH = v_buffer.stride(1);
+  int64_t nk_strideN = key.stride(0);
+  int64_t nk_strideH = key.stride(1);
+  int64_t nv_strideN = value.stride(0);
+  int64_t nv_strideH = value.stride(1);
+
+  const auto index_dtype = req_to_token.scalar_type();
+  TORCH_CHECK(
+      index_dtype == at::kInt || index_dtype == at::kLong,
+      "decode: expect req_to_token to be int32 or int64, got ",
+      index_dtype);
+  TORCH_CHECK(seq_lens.scalar_type() == at::kLong, "decode: expect req_lens to be int64, got ", seq_lens.scalar_type());
+  TORCH_CHECK(
+      req_pool_indices.scalar_type() == at::kLong,
+      "decode: expect req_pool_indices to be int64, got ",
+      req_pool_indices.scalar_type());
+
+  void* k_buffer_data = k_buffer.data_ptr();
+  void* v_buffer_data = v_buffer.data_ptr();
+
+  int num_threads = at::get_num_threads();
+
+  AT_DISPATCH_REDUCED_FLOATING_TYPES(query.scalar_type(), "decode_attention_kernel", [&] {
+    AT_DISPATCH_INDEX_TYPES(index_dtype, "decode_attention_indices", [&] {
+      decode_set_kv_buffer(
+          (scalar_t*)k_buffer_data,
+          (scalar_t*)v_buffer_data,
+          key.data_ptr<scalar_t>(),
+          value.data_ptr<scalar_t>(),
+          loc.data_ptr<int64_t>(),
+          num_seqs,
+          num_heads_kv,
+          head_size,
+          head_size_v,
+          k_strideN,
+          k_strideH,
+          v_strideN,
+          v_strideH,
+          nk_strideN,
+          nk_strideH,
+          nv_strideN,
+          nv_strideH);
+
+      if (num_heads == num_heads_kv) {
+        decode_attention_kernel_impl<scalar_t, scalar_t, index_t>(
+            output.data_ptr<scalar_t>(),
+            attn_logits.data_ptr<float>(),
+            query.data_ptr<scalar_t>(),
+            (const scalar_t*)k_buffer_data,
+            (const scalar_t*)v_buffer_data,
+            req_to_token.data_ptr<index_t>(),
+            req_pool_indices.data_ptr<int64_t>(),
+            seq_lens.data_ptr<int64_t>(),
+            num_seqs,
+            num_heads,
+            num_heads_kv,
+            head_size,
+            head_size_v,
+            num_kv_splits,
+            q_strideM,
+            q_strideH,
+            k_strideN,
+            k_strideH,
+            v_strideN,
+            v_strideH,
+            sm_scale,
+            logit_cap,
+            max_num_reqs,
+            max_context_len,
+            max_total_num_tokens,
+            o_strideM,
+            o_strideH);
+      } else {
+        decode_attention_grouped_kernel_impl<scalar_t, scalar_t, index_t>(
+            output.data_ptr<scalar_t>(),
+            attn_logits.data_ptr<float>(),
+            query.data_ptr<scalar_t>(),
+            (const scalar_t*)k_buffer_data,
+            (const scalar_t*)v_buffer_data,
+            req_to_token.data_ptr<index_t>(),
+            req_pool_indices.data_ptr<int64_t>(),
+            seq_lens.data_ptr<int64_t>(),
+            num_seqs,
+            num_heads,
+            num_heads_kv,
+            head_size,
+            head_size_v,
+            num_kv_splits,
+            q_strideM,
+            q_strideH,
+            k_strideN,
+            k_strideH,
+            v_strideN,
+            v_strideH,
+            sm_scale,
+            logit_cap,
+            max_num_reqs,
+            max_context_len,
+            max_total_num_tokens,
+            o_strideM,
+            o_strideH);
+      }
+    });
+  });
+}
+
+#endif  // CPU_CAPABILITY_RVV

--- a/sgl-kernel/csrc/cpu/riscv64/extend.cpp
+++ b/sgl-kernel/csrc/cpu/riscv64/extend.cpp
@@ -1,0 +1,583 @@
+#if defined(CPU_CAPABILITY_RVV) && defined(__clang__)
+#pragma clang riscv intrinsic vector
+#endif
+
+#include "common.h"
+#include "vec.h"
+#include "vector_math.h"
+
+#if defined(CPU_CAPABILITY_RVV)
+
+#include <riscv_vector.h>
+
+#include <algorithm>
+#include <cstring>
+#include <limits>
+#include <vector>
+
+#include "riscv64/gemm.h"
+#include "vector_helpers.h"
+
+namespace {
+
+// EXTEND_BLOCK_N = VLEN/8: must equal vl_max_e64m8 so Stage-1 index gather fits in one vsetvl.
+static constexpr int EXTEND_BLOCK_N = static_cast<int>(__riscv_v_fixed_vlen / 8);
+
+// Score tile s_i[BLOCK_M × BLOCK_N] is kept at ~4 KB regardless of VLEN:
+//   BLOCK_M × EXTEND_BLOCK_N × sizeof(float) = (8192/VLEN) × (VLEN/8) × 4 = 4096 B
+// BLOCK_M is always a multiple of GEMM_TILE_M=4 since VLEN ≥ 128 is a power of 2.
+static constexpr int BLOCK_M = 1024 / EXTEND_BLOCK_N;
+
+static int compute_buffer_size_per_thread(int head_size, int head_size_v) {
+  constexpr int BLOCK_N = EXTEND_BLOCK_N;
+  // Allocation order in AlignedArena:
+  // 1. s_i: float[BLOCK_M * BLOCK_N]
+  // 2. v_prime: float[BLOCK_M * head_size_v]
+  // 3. Btmp: scalar_t[BLOCK_N * max(head_size, head_size_v)]
+  // 4. k_trans: scalar_t[head_size * BLOCK_N]
+  // 5. v_buf: scalar_t[BLOCK_N * head_size_v]
+
+  // Worst-case element size: sizeof(float)=4 covers BF16/FP16 (2) and FP32 paths.
+  constexpr int MAX_ELEM = sizeof(float);
+
+  int size = 0;
+  size += BLOCK_M * BLOCK_N * sizeof(float);                      // s_i score tile
+  size += BLOCK_M * head_size_v * sizeof(float);                  // v_prime accumulator
+  size += BLOCK_N * std::max(head_size, head_size_v) * MAX_ELEM;  // Btmp (Q@K and S@V)
+  size += MAX_HEAD_SIZE * BLOCK_N * MAX_ELEM;                     // k_trans transposed key
+  size += BLOCK_N * MAX_HEAD_SIZE * MAX_ELEM;                     // v_buf value gather
+
+  // 5 AlignedArena allocations above, each padded to 64-byte cache line alignment.
+  constexpr int NUM_ALLOCS = 5;
+  return size + 64 * NUM_ALLOCS;
+}
+
+inline void softmax_update_row(
+    float* row, float* vp_row, float& m_acc, float& l_acc, int n_size, int head_size_v, float logit_cap) {
+  size_t vl_max = __riscv_vsetvlmax_e32m8();
+  vfloat32m8_t v_max = __riscv_vfmv_v_f_f32m8(-INFINITY, vl_max);
+  for (int j = 0; j < n_size; j += vl_max) {
+    size_t vl = __riscv_vsetvl_e32m8(n_size - j);
+    vfloat32m8_t v_s = __riscv_vle32_v_f32m8(row + j, vl);
+    if (logit_cap > 0.0f) {
+      v_s = __riscv_vfmul_vf_f32m8(v_s, 1.0f / logit_cap, vl);
+      v_s = vftanh_f32m8(v_s, vl);
+      v_s = __riscv_vfmul_vf_f32m8(v_s, logit_cap, vl);
+    }
+    v_max = __riscv_vfmax_vv_f32m8_tu(v_max, v_max, v_s, vl);
+    __riscv_vse32_v_f32m8(row + j, v_s, vl);  // Store back potentially capped values
+  }
+  float m_block =
+      __riscv_vfmv_f_s_f32m1_f32(__riscv_vfredmax_vs_f32m8_f32m1(v_max, __riscv_vfmv_s_f_f32m1(-INFINITY, 1), vl_max));
+
+  float m_new = std::max(m_acc, m_block);
+  float alpha = expf(m_acc - m_new);
+  m_acc = m_new;
+
+  // Rescale accumulated v_prime by alpha = exp(m_old - m_new)
+  for (int d = 0; d < head_size_v; d += vl_max) {
+    size_t vl = __riscv_vsetvl_e32m8(head_size_v - d);
+    vfloat32m8_t v_vp = __riscv_vle32_v_f32m8(vp_row + d, vl);
+    v_vp = __riscv_vfmul_vf_f32m8(v_vp, alpha, vl);
+    __riscv_vse32_v_f32m8(vp_row + d, v_vp, vl);
+  }
+
+  vfloat32m8_t v_l_block = __riscv_vfmv_v_f_f32m8(0.0f, vl_max);
+  for (int j = 0; j < n_size; j += vl_max) {
+    size_t vl = __riscv_vsetvl_e32m8(n_size - j);
+    vfloat32m8_t v_s = __riscv_vle32_v_f32m8(row + j, vl);
+    v_s = __riscv_vfsub_vf_f32m8(v_s, m_new, vl);
+    vfloat32m8_t v_exp = vfexp_f32m8(v_s, vl);
+    __riscv_vse32_v_f32m8(row + j, v_exp, vl);
+    v_l_block = __riscv_vfadd_vv_f32m8_tu(v_l_block, v_l_block, v_exp, vl);
+  }
+  float l_block =
+      __riscv_vfmv_f_s_f32m1_f32(__riscv_vfredusum_vs_f32m8_f32m1(v_l_block, __riscv_vfmv_s_f_f32m1(0.0f, 1), vl_max));
+
+  l_acc = l_acc * alpha + l_block;
+}
+
+template <typename scalar_t, typename kv_t, typename index_t>
+void extend_attention_kernel_impl(
+    scalar_t* __restrict__ o_extend,
+    const scalar_t* __restrict__ q_extend,
+    const scalar_t* __restrict__ k_extend,
+    const scalar_t* __restrict__ v_extend,
+    const kv_t* __restrict__ k_buffer,
+    const kv_t* __restrict__ v_buffer,
+    const index_t* __restrict__ req_to_token,
+    const int64_t* __restrict__ req_pool_indices,
+    const int64_t* __restrict__ seq_lens,
+    const index_t* __restrict__ extend_seq_lens,
+    const index_t* __restrict__ extend_start_loc,
+    const void* __restrict__ buffer,
+    int batches,
+    int num_heads,
+    int num_heads_kv,
+    int head_size,
+    int head_size_v,
+    int o_strideM,
+    int o_strideH,
+    int q_strideM,
+    int q_strideH,
+    int ke_strideN,
+    int ke_strideH,
+    int ve_strideN,
+    int ve_strideH,
+    int k_strideN,
+    int k_strideH,
+    int v_strideN,
+    int v_strideH,
+    float scaling,
+    float logit_cap,
+    int64_t max_num_reqs,
+    int64_t max_context_len,
+    int64_t max_total_num_tokens,
+    int64_t max_len_extend,
+    int buffer_size_per_thread) {
+  TORCH_CHECK(
+      head_size <= MAX_HEAD_SIZE && head_size_v <= MAX_HEAD_SIZE,
+      "extend_attention: head_size (",
+      head_size,
+      ") or head_size_v (",
+      head_size_v,
+      ") exceeds MAX_HEAD_SIZE (",
+      MAX_HEAD_SIZE,
+      ")");
+
+  constexpr int BLOCK_N = EXTEND_BLOCK_N;
+
+  const int num_groups = num_heads / num_heads_kv;
+  int MB = static_cast<int>(div_up(max_len_extend, static_cast<int64_t>(BLOCK_M)));
+
+  at::parallel_for(0, batches * num_heads * MB, 0, [&](int64_t begin, int64_t end) {
+    int64_t b{0}, h{0}, mb{0};
+    int64_t batches_i64 = static_cast<int64_t>(batches);
+    int64_t num_heads_i64 = static_cast<int64_t>(num_heads);
+    int64_t MB_i64 = static_cast<int64_t>(MB);
+
+    data_index_init(begin, b, batches_i64, h, num_heads_i64, mb, MB_i64);
+
+    int tid = at::get_thread_num();
+    char* thread_buffer = reinterpret_cast<char*>(const_cast<void*>(buffer)) + tid * buffer_size_per_thread;
+
+    // Buffer allocation using AlignedArena
+    AlignedArena arena(thread_buffer);
+
+    // 1. Accumulation buffer (Score)
+    float* s_i = arena.alloc<float>(BLOCK_M * BLOCK_N);
+
+    // 2. Accumulation buffer (Value)
+    float* v_prime = arena.alloc<float>(BLOCK_M * head_size_v);
+
+    // 3. Temporary buffer for GEMM (B matrix)
+    // Size cover both head_size (for Q@K) and head_size_v (for S@V)
+    scalar_t* Btmp = arena.alloc<scalar_t>(BLOCK_N * std::max(head_size, head_size_v));
+
+    // 4. Transposed Key buffer
+    scalar_t* k_trans_buf_fp = arena.alloc<scalar_t>(MAX_HEAD_SIZE * BLOCK_N);
+
+    // 5. Value buffer
+    scalar_t* v_buf_fp = arena.alloc<scalar_t>(BLOCK_N * MAX_HEAD_SIZE);
+
+    // Thread-local softmax accumulators: one entry per query row in the current tile.
+    // Sized to BLOCK_M (= 8192/VLEN): VLEN=128→64, VLEN=256→32, VLEN=512→16, VLEN=1024→8.
+    alignas(64) float l_acc[BLOCK_M];
+    alignas(64) float m_acc[BLOCK_M];
+
+    for (int64_t i = begin; i < end; ++i) {
+      int head_kv_id = h / num_groups;
+      int64_t seq_len = seq_lens[b];
+      int64_t extend_len = static_cast<int64_t>(extend_seq_lens[b]);
+      int64_t prefix_len = seq_len - extend_len;
+      int64_t start_loc = static_cast<int64_t>(extend_start_loc[b]);
+      int64_t req_idx = req_pool_indices[b];
+
+      int m_start = mb * BLOCK_M;
+      int m_size = std::min((int64_t)BLOCK_M, extend_len - m_start);
+
+      if (m_size <= 0) {
+        data_index_step(b, batches_i64, h, num_heads_i64, mb, MB_i64);
+        continue;
+      }
+
+      const scalar_t* q_ptr = q_extend + h * q_strideH + (start_loc + m_start) * q_strideM;
+      scalar_t* o_ptr = o_extend + h * o_strideH + (start_loc + m_start) * o_strideM;
+
+      fill_stub<float>(l_acc, 0.0f, m_size);
+      fill_stub<float>(m_acc, -std::numeric_limits<float>::infinity(), m_size);
+      fill_stub<float>(v_prime, 0.0f, m_size * head_size_v);
+
+      // STAGE 1: PREFIX (KV Cache)
+      if (prefix_len > 0) {
+        for (int n_start = 0; n_start < prefix_len; n_start += BLOCK_N) {
+          int n_size = std::min((int64_t)BLOCK_N, prefix_len - n_start);
+
+          if (n_start + BLOCK_N < prefix_len) {
+            int next_idx = req_to_token[req_idx * max_context_len + n_start + BLOCK_N];
+            const kv_t* k_next = k_buffer + next_idx * k_strideN + head_kv_id * k_strideH;
+            __builtin_prefetch(k_next, 0, 1);
+          }
+
+          {
+            // Single vsetvl covers n_size <= BLOCK_N (vl_max_e64m8 == BLOCK_N for any VLEN)
+            size_t vl = __riscv_vsetvl_e64m8(n_size);
+            vuint64m8_t v_offsets;
+
+            if constexpr (sizeof(index_t) == 8) {
+              vint64m8_t v_idx =
+                  __riscv_vle64_v_i64m8((const int64_t*)&req_to_token[req_idx * max_context_len + n_start], vl);
+              v_offsets = __riscv_vreinterpret_v_i64m8_u64m8(v_idx);
+            } else {
+              // index_t is int32_t: zero-extend to 64-bit for byte-offset arithmetic
+              size_t vl_32 = __riscv_vsetvl_e32m4(n_size);
+              vint32m4_t v_idx32 =
+                  __riscv_vle32_v_i32m4((const int32_t*)&req_to_token[req_idx * max_context_len + n_start], vl_32);
+              vuint32m4_t v_u32 = __riscv_vreinterpret_v_i32m4_u32m4(v_idx32);
+              vuint64m8_t v_u64 = __riscv_vzext_vf2_u64m8(v_u32, vl);
+              v_offsets = v_u64;
+            }
+
+            size_t strideN_bytes = k_strideN * sizeof(kv_t);
+            size_t head_offset_bytes = head_kv_id * k_strideH * sizeof(kv_t);
+
+            v_offsets = __riscv_vmul_vx_u64m8(v_offsets, strideN_bytes, vl);
+            v_offsets = __riscv_vadd_vx_u64m8(v_offsets, head_offset_bytes, vl);
+
+            const kv_t* base_ptr = k_buffer;
+
+            for (int d = 0; d < head_size; ++d) {
+              if constexpr (sizeof(scalar_t) == 2) {
+                vuint16m2_t v_val = __riscv_vluxei64_v_u16m2((const uint16_t*)base_ptr, v_offsets, vl);
+                __riscv_vse16_v_u16m2(reinterpret_cast<uint16_t*>(k_trans_buf_fp + d * BLOCK_N), v_val, vl);
+              } else {
+                vfloat32m4_t v_val = __riscv_vluxei64_v_f32m4((const float*)base_ptr, v_offsets, vl);
+                __riscv_vse32_v_f32m4(k_trans_buf_fp + d * BLOCK_N, v_val, vl);
+              }
+
+              v_offsets = __riscv_vadd_vx_u64m8(v_offsets, sizeof(kv_t), vl);
+            }
+
+            gemm_nt_tiled_transposed(
+                q_ptr, k_trans_buf_fp, s_i, m_size, n_size, head_size, q_strideM, BLOCK_N, BLOCK_N, scaling);
+          }
+
+          for (int r = 0; r < m_size; ++r) {
+            softmax_update_row(
+                s_i + r * BLOCK_N, v_prime + r * head_size_v, m_acc[r], l_acc[r], n_size, head_size_v, logit_cap);
+          }
+
+          // GEMM: score @ V
+          for (int j = 0; j < n_size; ++j) {
+            int token_idx = req_to_token[req_idx * max_context_len + n_start + j];
+            const kv_t* v_src = v_buffer + token_idx * v_strideN + head_kv_id * v_strideH;
+            scalar_t* v_dst = v_buf_fp + j * head_size_v;
+            copy_stub(v_dst, v_src, head_size_v);
+          }
+          gemm_nn_tiled(s_i, v_buf_fp, v_prime, m_size, n_size, head_size_v, BLOCK_N, head_size_v);
+        }
+      }  // Stage 1 end
+
+      // STAGE 2: EXTEND (Self-Attention)
+      int num_keys = std::min((int64_t)(m_start + BLOCK_M), extend_len);
+      for (int n_start = 0; n_start < num_keys; n_start += BLOCK_N) {
+        int n_size = std::min(BLOCK_N, num_keys - n_start);
+
+        if (n_start + BLOCK_N < num_keys) {
+          const scalar_t* next_k =
+              k_extend + start_loc * ke_strideN + head_kv_id * ke_strideH + (n_start + BLOCK_N) * ke_strideN;
+          __builtin_prefetch(next_k, 0, 1);
+        }
+
+        const scalar_t* k_src_base = k_extend + start_loc * ke_strideN + head_kv_id * ke_strideH;
+
+        {
+          size_t stride_bytes = ke_strideN * sizeof(scalar_t);
+          if (head_size % 4 == 0) {
+            for (int d = 0; d < head_size; ++d) {
+              const scalar_t* src_d = k_src_base + n_start * ke_strideN + d;
+
+              if constexpr (sizeof(scalar_t) == 2) {
+                size_t vl_16 = __riscv_vsetvl_e16m2(n_size);
+                vuint16m2_t v_16 = __riscv_vlse16_v_u16m2((const uint16_t*)src_d, stride_bytes, vl_16);
+                __riscv_vse16_v_u16m2(reinterpret_cast<uint16_t*>(k_trans_buf_fp + d * BLOCK_N), v_16, vl_16);
+              } else {
+                size_t vl = __riscv_vsetvl_e32m4(n_size);
+                vfloat32m4_t v_col = __riscv_vlse32_v_f32m4((const float*)src_d, stride_bytes, vl);
+                __riscv_vse32_v_f32m4(k_trans_buf_fp + d * BLOCK_N, v_col, vl);
+              }
+            }
+          } else {
+            for (int j = 0; j < n_size; ++j) {
+              const scalar_t* src_tok = k_src_base + (n_start + j) * ke_strideN;
+              for (int d = 0; d < head_size; ++d) {
+                k_trans_buf_fp[d * BLOCK_N + j] = src_tok[d];
+              }
+            }
+          }
+        }
+
+        gemm_nt_tiled_transposed(
+            q_ptr, k_trans_buf_fp, s_i, m_size, n_size, head_size, q_strideM, BLOCK_N, BLOCK_N, scaling);
+
+        // Causal mask: key position must be <= query position.
+        for (int r = 0; r < m_size; ++r) {
+          int m_pos = m_start + r;
+          float* row = s_i + r * BLOCK_N;
+
+          // Step 1: apply logit cap to raw scores (all finite here).
+          if (logit_cap > 0.0f) {
+            size_t vl_max = __riscv_vsetvlmax_e32m8();
+            for (int c = 0; c < n_size; c += vl_max) {
+              size_t vl = __riscv_vsetvl_e32m8(n_size - c);
+              vfloat32m8_t v_s = __riscv_vle32_v_f32m8(row + c, vl);
+              v_s = __riscv_vfmul_vf_f32m8(v_s, 1.0f / logit_cap, vl);
+              v_s = vftanh_f32m8(v_s, vl);
+              v_s = __riscv_vfmul_vf_f32m8(v_s, logit_cap, vl);
+              __riscv_vse32_v_f32m8(row + c, v_s, vl);
+            }
+          }
+
+          // Step 2: apply causal mask (overwrites future positions with -inf).
+          size_t vl_max = __riscv_vsetvlmax_e32m2();
+          for (int c = 0; c < n_size; c += vl_max) {
+            size_t vl = __riscv_vsetvl_e32m2(n_size - c);
+
+            vuint32m2_t vid = __riscv_vid_v_u32m2(vl);
+            vuint32m2_t vn_pos = __riscv_vadd_vx_u32m2(vid, n_start + c, vl);
+
+            vbool16_t mask = __riscv_vmsgtu_vx_u32m2_b16(vn_pos, (uint32_t)m_pos, vl);
+            vfloat32m2_t v_inf = __riscv_vfmv_v_f_f32m2(-std::numeric_limits<float>::infinity(), vl);
+            vfloat32m2_t v_row = __riscv_vle32_v_f32m2(row + c, vl);
+            v_row = __riscv_vmerge_vvm_f32m2(v_row, v_inf, mask, vl);
+            __riscv_vse32_v_f32m2(row + c, v_row, vl);
+          }
+
+          // Step 3: online softmax — cap already applied, pass 0.0f to skip it.
+          softmax_update_row(
+              s_i + r * BLOCK_N, v_prime + r * head_size_v, m_acc[r], l_acc[r], n_size, head_size_v, 0.0f);
+        }
+
+        const scalar_t* v_src_base = v_extend + start_loc * ve_strideN + head_kv_id * ve_strideH;
+        for (int j = 0; j < n_size; ++j) {
+          const scalar_t* v_src = v_src_base + (n_start + j) * ve_strideN;
+          scalar_t* v_dst = v_buf_fp + j * head_size_v;
+          copy_stub(v_dst, v_src, head_size_v);
+        }
+
+        gemm_nn_tiled(s_i, v_buf_fp, v_prime, m_size, n_size, head_size_v, BLOCK_N, head_size_v);
+      }  // Stage 2 end
+
+      // Write Output
+      for (int r = 0; r < m_size; ++r) {
+        float l_val = l_acc[r];
+        // Guard against division by zero when all positions are masked (l_val ≈ 0).
+        // Threshold is well above FP32 underflow (~1e-38) but below any real sum.
+        float inv_l = (l_val > 1e-6f) ? 1.0f / l_val : 0.0f;
+        float* vp_row = v_prime + r * head_size_v;
+        scalar_t* o_row = o_ptr + r * o_strideM;
+
+        size_t vl_max = __riscv_vsetvlmax_e32m2();
+        for (int d = 0; d < head_size_v; d += vl_max) {
+          size_t vl = __riscv_vsetvl_e32m2(head_size_v - d);
+          vfloat32m2_t v = __riscv_vle32_v_f32m2(vp_row + d, vl);
+          v = __riscv_vfmul_vf_f32m2(v, inv_l, vl);
+          store_from_float_m2(o_row + d, v, vl, reinterpret_cast<float*>(Btmp));
+        }
+      }
+
+      data_index_step(b, batches_i64, h, num_heads_i64, mb, MB_i64);
+    }
+  });
+}
+
+// Shared validation and stride extraction for both entry functions below.
+struct ExtendBatchInfo {
+  int num_seqs;
+  int64_t max_num_reqs, max_context_len, max_total_num_tokens;
+  int num_heads, num_heads_kv, head_size, head_size_v;
+  int q_strideM, q_strideH;
+  int o_strideM, o_strideH;
+  int ke_strideN, ke_strideH;
+  int ve_strideN, ve_strideH;
+  int k_strideN, k_strideH;
+  int v_strideN, v_strideH;
+  at::ScalarType index_dtype;
+};
+
+static ExtendBatchInfo validate_extend_inputs(
+    const at::Tensor& q_extend,
+    const at::Tensor& k_extend,
+    const at::Tensor& v_extend,
+    const at::Tensor& o_extend,
+    const at::Tensor& k_buffer,
+    const at::Tensor& v_buffer,
+    const at::Tensor& req_to_token,
+    const at::Tensor& req_pool_indices,
+    const at::Tensor& seq_lens,
+    const at::Tensor& extend_seq_lens,
+    const at::Tensor& extend_start_loc) {
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(q_extend);
+  CHECK_INPUT(o_extend);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(k_extend);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(v_extend);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(k_buffer);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(v_buffer);
+
+  ExtendBatchInfo p;
+  p.num_seqs = seq_lens.size(0);
+  p.max_num_reqs = req_to_token.size(0);
+  p.max_context_len = req_to_token.size(1);
+  p.max_total_num_tokens = k_buffer.size(0);
+
+  p.num_heads = q_extend.size(1);
+  p.num_heads_kv = k_extend.size(1);
+  p.head_size = q_extend.size(2);
+  p.head_size_v = v_extend.size(2);
+
+  p.q_strideM = q_extend.stride(0);
+  p.q_strideH = q_extend.stride(1);
+  p.o_strideM = o_extend.stride(0);
+  p.o_strideH = o_extend.stride(1);
+  p.ke_strideN = k_extend.stride(0);
+  p.ke_strideH = k_extend.stride(1);
+  p.ve_strideN = v_extend.stride(0);
+  p.ve_strideH = v_extend.stride(1);
+  p.k_strideN = k_buffer.stride(0);
+  p.k_strideH = k_buffer.stride(1);
+  p.v_strideN = v_buffer.stride(0);
+  p.v_strideH = v_buffer.stride(1);
+
+  CHECK_EQ(req_pool_indices.size(0), p.num_seqs);
+  CHECK_EQ(extend_seq_lens.size(0), p.num_seqs);
+  CHECK_EQ(extend_start_loc.size(0), p.num_seqs);
+  CHECK_EQ(v_extend.size(1), p.num_heads_kv);
+  CHECK_EQ(k_buffer.size(1), v_buffer.size(1));
+
+  p.index_dtype = req_to_token.scalar_type();
+  TORCH_CHECK(
+      p.index_dtype == at::kInt || p.index_dtype == at::kLong,
+      "extend: expect req_to_token to be int32 or int64, got ",
+      p.index_dtype);
+  TORCH_CHECK(seq_lens.scalar_type() == at::kLong, "extend: expect req_lens to be int64, got ", seq_lens.scalar_type());
+  TORCH_CHECK(
+      req_pool_indices.scalar_type() == at::kLong,
+      "extend: expect req_pool_indices to be int64, got ",
+      req_pool_indices.scalar_type());
+  TORCH_CHECK(
+      extend_seq_lens.scalar_type() == p.index_dtype && extend_start_loc.scalar_type() == p.index_dtype,
+      "extend: expect extend_seq_lens and extend_start_loc to have same dtype as req_to_token.");
+
+  // EXTEND_BLOCK_N is VLEN/8 (compile-time). head_size must be a multiple so that
+  // the transposed K buffer (head_size × BLOCK_N) is indexed without padding.
+  TORCH_CHECK(
+      p.head_size % EXTEND_BLOCK_N == 0,
+      "invalid head_size ",
+      p.head_size,
+      " (must be a multiple of EXTEND_BLOCK_N=",
+      EXTEND_BLOCK_N,
+      " for this VLEN)");
+  TORCH_CHECK(
+      p.head_size_v % EXTEND_BLOCK_N == 0,
+      "invalid head_size_v ",
+      p.head_size_v,
+      " (must be a multiple of EXTEND_BLOCK_N=",
+      EXTEND_BLOCK_N,
+      " for this VLEN)");
+
+  return p;
+}
+
+}  // anonymous namespace
+
+void extend_attention_cpu(
+    at::Tensor& q_extend,          // [num_tokens,             num_heads,    head_size]
+    at::Tensor& k_extend,          // [num_extend_tokens,      num_heads_kv, head_size]
+    at::Tensor& v_extend,          // [num_extend_tokens,      num_heads_kv, head_size_v]
+    at::Tensor& o_extend,          // [num_tokens,             num_heads,    head_size_v]
+    at::Tensor& k_buffer,          // [max_total_num_tokens,   num_heads_kv, head_size]   — mem_manager prefix+extend
+    at::Tensor& v_buffer,          // [max_total_num_tokens,   num_heads_kv, head_size_v] — mem_manager prefix+extend
+    at::Tensor& req_to_token,      // [max_num_reqs, max_context_len] int32 or int64
+    at::Tensor& req_pool_indices,  // [num_seqs] int64
+    at::Tensor& seq_lens,          // [num_seqs] int64
+    at::Tensor& extend_seq_lens,   // [num_seqs]
+    at::Tensor& extend_start_loc,  // [num_seqs]
+    int64_t max_len_extend,
+    double sm_scale,
+    double logit_cap) {
+  RECORD_FUNCTION(
+      "sgl-kernel::extend_attention_cpu",
+      std::vector<c10::IValue>(
+          {q_extend,
+           k_extend,
+           v_extend,
+           o_extend,
+           k_buffer,
+           v_buffer,
+           req_to_token,
+           req_pool_indices,
+           seq_lens,
+           extend_seq_lens,
+           extend_start_loc}));
+
+  const auto p = validate_extend_inputs(
+      q_extend,
+      k_extend,
+      v_extend,
+      o_extend,
+      k_buffer,
+      v_buffer,
+      req_to_token,
+      req_pool_indices,
+      seq_lens,
+      extend_seq_lens,
+      extend_start_loc);
+
+  int buffer_size = compute_buffer_size_per_thread(p.head_size, p.head_size_v);
+  int num_threads = at::get_num_threads();
+  auto buffer = at::empty({num_threads, buffer_size}, q_extend.options().dtype(at::kChar));
+
+  AT_DISPATCH_RVV_TYPES(q_extend.scalar_type(), "extend_attention_kernel", [&] {
+    AT_DISPATCH_INDEX_TYPES(p.index_dtype, "extend_attention_kernel_indices", [&] {
+      extend_attention_kernel_impl<scalar_t, scalar_t, index_t>(
+          o_extend.data_ptr<scalar_t>(),
+          q_extend.data_ptr<scalar_t>(),
+          k_extend.data_ptr<scalar_t>(),
+          v_extend.data_ptr<scalar_t>(),
+          k_buffer.data_ptr<scalar_t>(),
+          v_buffer.data_ptr<scalar_t>(),
+          req_to_token.data_ptr<index_t>(),
+          req_pool_indices.data_ptr<int64_t>(),
+          seq_lens.data_ptr<int64_t>(),
+          extend_seq_lens.data_ptr<index_t>(),
+          extend_start_loc.data_ptr<index_t>(),
+          buffer.data_ptr(),
+          p.num_seqs,
+          p.num_heads,
+          p.num_heads_kv,
+          p.head_size,
+          p.head_size_v,
+          p.o_strideM,
+          p.o_strideH,
+          p.q_strideM,
+          p.q_strideH,
+          p.ke_strideN,
+          p.ke_strideH,
+          p.ve_strideN,
+          p.ve_strideH,
+          p.k_strideN,
+          p.k_strideH,
+          p.v_strideN,
+          p.v_strideH,
+          (float)sm_scale,
+          (float)logit_cap,
+          p.max_num_reqs,
+          p.max_context_len,
+          p.max_total_num_tokens,
+          max_len_extend,
+          buffer_size);
+    });
+  });
+}
+
+#endif  // CPU_CAPABILITY_RVV

--- a/sgl-kernel/csrc/cpu/riscv64/gemm.cpp
+++ b/sgl-kernel/csrc/cpu/riscv64/gemm.cpp
@@ -1,0 +1,641 @@
+#if defined(CPU_CAPABILITY_RVV) && defined(__clang__)
+#pragma clang riscv intrinsic vector
+#endif
+
+#include "riscv64/gemm.h"
+
+#include <ATen/core/Tensor.h>
+
+#include <cstdint>
+
+#include "common.h"
+#include "vector_helpers.h"
+#include "vector_math.h"
+
+#if defined(CPU_CAPABILITY_RVV)
+
+#include <riscv_vector.h>
+
+#include <algorithm>
+#include <cstring>
+
+namespace {
+
+template <typename scalar_t>
+void pack_weight(scalar_t* packed_w, const scalar_t* orig_w, int64_t N, int64_t K) {
+  constexpr int64_t BN = rvv_constants::BLOCK_N;
+  int64_t NB = (N + BN - 1) / BN;
+
+  at::parallel_for(0, NB * K, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t i = begin; i < end; ++i) {
+      const int64_t nb = i / K;
+      const int64_t k = i % K;
+      int64_t n_start = nb * BN;
+      int64_t n_size = std::min(BN, N - n_start);
+
+      scalar_t* dst = packed_w + nb * K * BN + k * BN;
+
+      if constexpr (std::is_same_v<scalar_t, at::Half>) {
+#if defined(__riscv_zvfh) || defined(__riscv_v)
+        size_t vl = 0;
+        for (int64_t j = 0; j < n_size; j += vl) {
+          vl = __riscv_vsetvl_e16m2(n_size - j);
+          vfloat16m2_t v_data = __riscv_vlse16_v_f16m2(
+              reinterpret_cast<const _Float16*>(orig_w + (n_start + j) * K + k), K * sizeof(_Float16), vl);
+          __riscv_vse16_v_f16m2(reinterpret_cast<_Float16*>(dst + j), v_data, vl);
+        }
+        if (n_size < BN) {
+          size_t vl_pad = __riscv_vsetvl_e16m2(BN - n_size);
+          vfloat16m2_t v_zero = __riscv_vfmv_v_f_f16m2((_Float16)0.0f, vl_pad);
+          __riscv_vse16_v_f16m2(reinterpret_cast<_Float16*>(dst + n_size), v_zero, vl_pad);
+        }
+#else
+        for (int64_t j = 0; j < n_size; ++j)
+          dst[j] = orig_w[(n_start + j) * K + k];
+        for (int64_t j = n_size; j < BN; ++j)
+          dst[j] = static_cast<scalar_t>(0);
+#endif
+      } else if constexpr (std::is_same_v<scalar_t, at::BFloat16>) {
+        size_t vl = 0;
+        for (int64_t j = 0; j < n_size; j += vl) {
+          vl = __riscv_vsetvl_e16m2(n_size - j);
+          vuint16m2_t v_data = __riscv_vlse16_v_u16m2(
+              reinterpret_cast<const uint16_t*>(orig_w + (n_start + j) * K + k), K * sizeof(uint16_t), vl);
+          __riscv_vse16_v_u16m2(reinterpret_cast<uint16_t*>(dst + j), v_data, vl);
+        }
+        if (n_size < BN) {
+          size_t vl_pad = __riscv_vsetvl_e16m2(BN - n_size);
+          vuint16m2_t v_zero = __riscv_vmv_v_x_u16m2(0, vl_pad);
+          __riscv_vse16_v_u16m2(reinterpret_cast<uint16_t*>(dst + n_size), v_zero, vl_pad);
+        }
+      } else {
+        for (int64_t j = 0; j < n_size; ++j) {
+          dst[j] = orig_w[(n_start + j) * K + k];
+        }
+        for (int64_t j = n_size; j < BN; ++j) {
+          dst[j] = static_cast<scalar_t>(0);
+        }
+      }
+    }
+  });
+}
+
+template <>
+void pack_weight<int8_t>(int8_t* packed_w, const int8_t* orig_w, int64_t N, int64_t K) {
+  pack_weight_int8_with_comp(packed_w, orig_w, N, K, rvv_constants::BLOCK_N);
+}
+
+template <typename scalar_t, bool has_bias, int BLOCK_M, int BLOCK_N>
+struct tinygemm_kernel_nn {
+  static_assert(BLOCK_M >= 1 && BLOCK_M <= 4, "BLOCK_M must be 1-4");
+  static_assert(
+      std::is_same_v<scalar_t, float> || std::is_same_v<scalar_t, at::Half> || std::is_same_v<scalar_t, at::BFloat16>,
+      "tinygemm_kernel_nn: only supports float, Half, and BFloat16");
+
+  static inline void apply(
+      const scalar_t* __restrict__ A,
+      const scalar_t* __restrict__ B,
+      scalar_t* __restrict__ C,
+      const float* __restrict__ bias,
+      int64_t K,
+      int64_t lda,
+      int64_t ldc,
+      int64_t n_size) {
+    size_t vl_max = __riscv_vsetvlmax_e32m4();
+
+    // Float accumulator: holds partial sums across k-tiles so the k-tile loop
+    // can be placed outside the j (N) loop.  n_size ≤ BLOCK_N (compile-time),
+    // so this is at most BLOCK_M × BLOCK_N × 4 B = 1 KB on stack.
+    alignas(64) float C_f32[BLOCK_M][BLOCK_N];
+    if constexpr (has_bias) {
+      for (int m = 0; m < BLOCK_M; ++m)
+        std::copy(bias, bias + n_size, C_f32[m]);
+    } else {
+      std::memset(C_f32, 0, sizeof(C_f32));
+    }
+
+    constexpr int64_t UNROLL = (BLOCK_M <= 3) ? 4 : 2;
+    constexpr int64_t PREFETCH_DIST = UNROLL * 2;
+    // K-tile size: fit A[BLOCK_M, KB] in L1 while all N-tiles are swept (loop order: k_tile → j → k).
+    // KB = L1_CACHE_BYTES / (BLOCK_N * sizeof(scalar_t)); BLOCK_N * sizeof = VLEN_bits/8 for fp32, /16 for fp16/bf16.
+    constexpr int64_t KB = std::is_same_v<scalar_t, float> ? (rvv_constants::L1_CACHE_BYTES / __riscv_v_fixed_vlen)
+                                                           : (rvv_constants::L1_CACHE_BYTES * 2 / __riscv_v_fixed_vlen);
+
+    for (int64_t k_tile = 0; k_tile < K; k_tile += KB) {
+      const int64_t k_end = std::min(k_tile + KB, K);
+
+      for (int64_t j = 0; j < n_size; j += (int64_t)vl_max) {
+        size_t vl = (j + (int64_t)vl_max <= n_size) ? vl_max : __riscv_vsetvl_e32m4(n_size - j);
+
+        const scalar_t* b_ptr_base = B + j;
+        auto load_b_as_f32 = [&](const scalar_t* ptr) -> vfloat32m4_t {
+          if constexpr (std::is_same_v<scalar_t, float>) {
+            return __riscv_vle32_v_f32m4(ptr, vl);
+          } else if constexpr (std::is_same_v<scalar_t, at::Half>) {
+#if defined(__riscv_zvfh) || defined(__riscv_v)
+            return __riscv_vfwcvt_f_f_v_f32m4(__riscv_vle16_v_f16m2(reinterpret_cast<const _Float16*>(ptr), vl), vl);
+#else
+            alignas(64) float tmp[rvv_constants::MAX_VL_ELEMENTS_M4];
+            for (size_t i = 0; i < vl; ++i)
+              tmp[i] = static_cast<float>(ptr[i]);
+            return __riscv_vle32_v_f32m4(tmp, vl);
+#endif
+          } else {
+            return bf16_to_f32m4(reinterpret_cast<const uint16_t*>(ptr), vl);
+          }
+        };
+
+        // Load partial sums from C_f32 into vector accumulators.
+        vfloat32m4_t v_acc0, v_acc1, v_acc2, v_acc3;
+        vfloat32m4_t* v_acc[4] = {&v_acc0, &v_acc1, &v_acc2, &v_acc3};
+        for (int m = 0; m < BLOCK_M; ++m)
+          *v_acc[m] = __riscv_vle32_v_f32m4(C_f32[m] + j, vl);
+
+        int64_t k = k_tile;
+        for (; k + UNROLL - 1 < k_end; k += UNROLL) {
+          if (k + PREFETCH_DIST < K) __builtin_prefetch(b_ptr_base + (k + PREFETCH_DIST) * BLOCK_N, 0, 1);
+          if constexpr (UNROLL == 4) {
+            vfloat32m4_t vb0 = load_b_as_f32(b_ptr_base + (k + 0) * BLOCK_N);
+            vfloat32m4_t vb1 = load_b_as_f32(b_ptr_base + (k + 1) * BLOCK_N);
+            vfloat32m4_t vb2 = load_b_as_f32(b_ptr_base + (k + 2) * BLOCK_N);
+            vfloat32m4_t vb3 = load_b_as_f32(b_ptr_base + (k + 3) * BLOCK_N);
+            for (int m = 0; m < BLOCK_M; ++m) {
+              *v_acc[m] = __riscv_vfmacc_vf_f32m4(*v_acc[m], static_cast<float>(A[m * lda + k + 0]), vb0, vl);
+              *v_acc[m] = __riscv_vfmacc_vf_f32m4(*v_acc[m], static_cast<float>(A[m * lda + k + 1]), vb1, vl);
+              *v_acc[m] = __riscv_vfmacc_vf_f32m4(*v_acc[m], static_cast<float>(A[m * lda + k + 2]), vb2, vl);
+              *v_acc[m] = __riscv_vfmacc_vf_f32m4(*v_acc[m], static_cast<float>(A[m * lda + k + 3]), vb3, vl);
+            }
+          } else {
+            vfloat32m4_t vb0 = load_b_as_f32(b_ptr_base + (k + 0) * BLOCK_N);
+            vfloat32m4_t vb1 = load_b_as_f32(b_ptr_base + (k + 1) * BLOCK_N);
+            for (int m = 0; m < BLOCK_M; ++m) {
+              *v_acc[m] = __riscv_vfmacc_vf_f32m4(*v_acc[m], static_cast<float>(A[m * lda + k + 0]), vb0, vl);
+              *v_acc[m] = __riscv_vfmacc_vf_f32m4(*v_acc[m], static_cast<float>(A[m * lda + k + 1]), vb1, vl);
+            }
+          }
+        }
+        for (; k < k_end; ++k) {
+          vfloat32m4_t v_b = load_b_as_f32(b_ptr_base + k * BLOCK_N);
+          for (int m = 0; m < BLOCK_M; ++m)
+            *v_acc[m] = __riscv_vfmacc_vf_f32m4(*v_acc[m], static_cast<float>(A[m * lda + k]), v_b, vl);
+        }
+
+        // Write partial sums back to C_f32.
+        for (int m = 0; m < BLOCK_M; ++m)
+          __riscv_vse32_v_f32m4(C_f32[m] + j, *v_acc[m], vl);
+      }
+    }
+
+    // Final pass: convert float C_f32 → scalar_t output C.
+    for (int m = 0; m < BLOCK_M; ++m) {
+      scalar_t* c_ptr = C + m * ldc;
+      for (int64_t j = 0; j < n_size; j += (int64_t)vl_max) {
+        size_t vl = (j + (int64_t)vl_max <= n_size) ? vl_max : __riscv_vsetvl_e32m4(n_size - j);
+        vfloat32m4_t v = __riscv_vle32_v_f32m4(C_f32[m] + j, vl);
+        if constexpr (std::is_same_v<scalar_t, float>) {
+          __riscv_vse32_v_f32m4(c_ptr + j, v, vl);
+        } else if constexpr (std::is_same_v<scalar_t, at::Half>) {
+#if defined(__riscv_zvfh) || defined(__riscv_v)
+          vfloat16m2_t v_f16 = f32m4_to_f16(v, vl);
+          __riscv_vse16_v_f16m2(reinterpret_cast<_Float16*>(c_ptr + j), v_f16, vl);
+#else
+          alignas(64) float tmp[rvv_constants::MAX_VL_ELEMENTS_M4];
+          __riscv_vse32_v_f32m4(tmp, v, vl);
+          for (size_t i = 0; i < vl; ++i)
+            c_ptr[j + i] = static_cast<scalar_t>(tmp[i]);
+#endif
+        } else {
+          vuint16m2_t v_bf16 = f32m4_to_bf16(v, vl);
+          __riscv_vse16_v_u16m2(reinterpret_cast<uint16_t*>(c_ptr + j), v_bf16, vl);
+        }
+      }
+    }
+  }
+};
+
+// GEMV specialization (M=1) using LMUL=8. BF16/FP16 use UNROLL=4; FP32 uses UNROLL=2.
+template <typename scalar_t, bool has_bias, int BLOCK_N>
+struct tinygemm_kernel_gemv_m8 {
+  static_assert(
+      std::is_same_v<scalar_t, float> || std::is_same_v<scalar_t, at::Half> || std::is_same_v<scalar_t, at::BFloat16>,
+      "tinygemm_kernel_gemv_m8: only supports float, Half, and BFloat16");
+
+  static inline void apply(
+      const scalar_t* __restrict__ A,
+      const scalar_t* __restrict__ B,
+      scalar_t* __restrict__ C,
+      const float* __restrict__ bias,
+      int64_t K,
+      int64_t lda,
+      int64_t ldc,
+      int64_t n_size) {
+    UNUSED(lda);
+    UNUSED(ldc);
+
+    const size_t vl_max = __riscv_vsetvlmax_e32m8();
+
+    // Float accumulator: n_size ≤ BLOCK_N (compile-time), max 64 × 4 = 256 B on stack.
+    alignas(64) float C_f32[BLOCK_N];
+    if constexpr (has_bias) {
+      std::copy(bias, bias + n_size, C_f32);
+    } else {
+      std::memset(C_f32, 0, sizeof(C_f32));
+    }
+
+    // UNROLL: FP32 uses m8 B-loads (8 regs each) → cap at 2.
+    // BF16/FP16 use m4 B-loads (4 regs each) → UNROLL=4.
+    constexpr int64_t UNROLL = std::is_same_v<scalar_t, float> ? 2 : 4;
+    constexpr int64_t PREFETCH_DIST = UNROLL * 2;
+
+    constexpr int64_t KB = std::is_same_v<scalar_t, float> ? (rvv_constants::L1_CACHE_BYTES / __riscv_v_fixed_vlen)
+                                                           : (rvv_constants::L1_CACHE_BYTES * 2 / __riscv_v_fixed_vlen);
+
+    for (int64_t k_tile = 0; k_tile < K; k_tile += KB) {
+      const int64_t k_end = std::min(k_tile + KB, K);
+
+      for (int64_t j = 0; j < n_size; j += (int64_t)vl_max) {
+        const size_t vl = (j + (int64_t)vl_max <= n_size) ? vl_max : __riscv_vsetvl_e32m8(n_size - j);
+        const scalar_t* b_ptr_base = B + j;
+
+        auto load_b_as_f32m8 = [&](const scalar_t* ptr) -> vfloat32m8_t {
+          alignas(64) float scratch[rvv_constants::MAX_VL_ELEMENTS_M8];
+          return load_as_float_m8<scalar_t>(ptr, vl, scratch);
+        };
+
+        vfloat32m8_t v_acc = __riscv_vle32_v_f32m8(C_f32 + j, vl);
+
+        int64_t k = k_tile;
+        for (; k + UNROLL - 1 < k_end; k += UNROLL) {
+          if (k + PREFETCH_DIST < K) __builtin_prefetch(b_ptr_base + (k + PREFETCH_DIST) * BLOCK_N, 0, 1);
+          if constexpr (UNROLL == 4) {
+            vfloat32m8_t vb0 = load_b_as_f32m8(b_ptr_base + (k + 0) * BLOCK_N);
+            vfloat32m8_t vb1 = load_b_as_f32m8(b_ptr_base + (k + 1) * BLOCK_N);
+            vfloat32m8_t vb2 = load_b_as_f32m8(b_ptr_base + (k + 2) * BLOCK_N);
+            vfloat32m8_t vb3 = load_b_as_f32m8(b_ptr_base + (k + 3) * BLOCK_N);
+            v_acc = __riscv_vfmacc_vf_f32m8(v_acc, static_cast<float>(A[k + 0]), vb0, vl);
+            v_acc = __riscv_vfmacc_vf_f32m8(v_acc, static_cast<float>(A[k + 1]), vb1, vl);
+            v_acc = __riscv_vfmacc_vf_f32m8(v_acc, static_cast<float>(A[k + 2]), vb2, vl);
+            v_acc = __riscv_vfmacc_vf_f32m8(v_acc, static_cast<float>(A[k + 3]), vb3, vl);
+          } else {
+            vfloat32m8_t vb0 = load_b_as_f32m8(b_ptr_base + (k + 0) * BLOCK_N);
+            vfloat32m8_t vb1 = load_b_as_f32m8(b_ptr_base + (k + 1) * BLOCK_N);
+            v_acc = __riscv_vfmacc_vf_f32m8(v_acc, static_cast<float>(A[k + 0]), vb0, vl);
+            v_acc = __riscv_vfmacc_vf_f32m8(v_acc, static_cast<float>(A[k + 1]), vb1, vl);
+          }
+        }
+        for (; k < k_end; ++k) {
+          vfloat32m8_t v_b = load_b_as_f32m8(b_ptr_base + k * BLOCK_N);
+          v_acc = __riscv_vfmacc_vf_f32m8(v_acc, static_cast<float>(A[k]), v_b, vl);
+        }
+
+        __riscv_vse32_v_f32m8(C_f32 + j, v_acc, vl);
+      }
+    }
+
+    // Final store with type conversion.
+    alignas(64) float scratch[rvv_constants::MAX_VL_ELEMENTS_M8];
+    for (int64_t j = 0; j < n_size; j += (int64_t)vl_max) {
+      const size_t vl = (j + (int64_t)vl_max <= n_size) ? vl_max : __riscv_vsetvl_e32m8(n_size - j);
+      vfloat32m8_t v = __riscv_vle32_v_f32m8(C_f32 + j, vl);
+      store_from_float_m8<scalar_t>(C + j, v, vl, scratch);
+    }
+  }
+};
+
+#define LAUNCH_TINYGEMM_KERNEL_NN(MB_SIZE, NB_SIZE)                \
+  tinygemm_kernel_nn<scalar_t, has_bias, MB_SIZE, NB_SIZE>::apply( \
+      A + mb_start * lda,                                          \
+      B + nb_start * K,                                            \
+      C + mb_start * ldc + nb_start,                               \
+      has_bias ? bias + nb_start : nullptr,                        \
+      K,                                                           \
+      lda,                                                         \
+      ldc,                                                         \
+      nb_size);
+
+template <typename scalar_t, bool has_bias>
+void tinygemm_kernel(
+    const scalar_t* __restrict__ A,
+    const scalar_t* __restrict__ B,
+    scalar_t* __restrict__ C,
+    const float* __restrict__ bias,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t lda,
+    int64_t ldc) {
+  constexpr int64_t BLOCK_M = GEMM_TILE_M;
+  constexpr int64_t BLOCK_N = rvv_constants::BLOCK_N;
+  const int64_t MB = div_up(M, BLOCK_M);
+  const int64_t NB = div_up(N, BLOCK_N);
+  for (int mb = 0; mb < MB; ++mb) {
+    int64_t mb_start = mb * BLOCK_M;
+    int64_t mb_size = std::min(BLOCK_M, M - mb_start);
+    for (int64_t nb = 0; nb < NB; ++nb) {
+      int64_t nb_start = nb * BLOCK_N;
+      int64_t nb_size = std::min(BLOCK_N, N - nb_start);
+
+      switch (mb_size) {
+        case 1:
+          tinygemm_kernel_gemv_m8<scalar_t, has_bias, BLOCK_N>::apply(
+              A + mb_start * lda,
+              B + nb_start * K,
+              C + mb_start * ldc + nb_start,
+              has_bias ? bias + nb_start : nullptr,
+              K,
+              lda,
+              ldc,
+              nb_size);
+          break;
+        case 2:
+          LAUNCH_TINYGEMM_KERNEL_NN(2, BLOCK_N);
+          break;
+        case 3:
+          LAUNCH_TINYGEMM_KERNEL_NN(3, BLOCK_N);
+          break;
+        case 4:
+          LAUNCH_TINYGEMM_KERNEL_NN(4, BLOCK_N);
+          break;
+        default:
+          TORCH_CHECK(false, "Unexpected mb_size: ", mb_size);
+      }
+    }
+  }
+}
+
+template <typename scalar_t>
+void weight_packed_linear_kernel_impl(
+    scalar_t* __restrict__ out,
+    const scalar_t* __restrict__ mat1,
+    const scalar_t* __restrict__ mat2,
+    const float* __restrict__ bias,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t mat1_strideM,
+    int64_t out_strideM) {
+  constexpr int64_t BLOCK_M = GEMM_TILE_M;
+  constexpr int64_t BLOCK_N = rvv_constants::BLOCK_N;
+  const int64_t MB = div_up(M, BLOCK_M);
+  const int64_t NB = div_up(N, BLOCK_N);
+
+  AT_DISPATCH_BOOL(bias != nullptr, has_bias, [&] {
+    at::parallel_for(0, MB * NB, 0, [&](int64_t begin, int64_t end) {
+      for (int64_t i = begin; i < end; ++i) {
+        const int64_t mb = i / NB;
+        const int64_t nb = i % NB;
+        int64_t mb_start = mb * BLOCK_M;
+        int64_t mb_size = std::min(M - mb_start, BLOCK_M);
+        int64_t nb_start = nb * BLOCK_N;
+        int64_t nb_size = std::min(N - nb_start, BLOCK_N);
+
+        tinygemm_kernel<scalar_t, has_bias>(
+            mat1 + mb_start * mat1_strideM,
+            mat2 + nb_start * K,
+            out + mb_start * out_strideM + nb_start,
+            bias ? bias + nb_start : nullptr,
+            mb_size,
+            nb_size,
+            K,
+            mat1_strideM,
+            out_strideM);
+      }
+    });
+  });
+}
+
+template <typename scalar_t>
+void weight_packed_linear_fma_kernel_impl(
+    scalar_t* __restrict__ out,
+    const scalar_t* __restrict__ mat1,
+    const float* __restrict__ mat2,
+    const float* __restrict__ bias,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t mat1_strideM,
+    int64_t out_strideM) {
+  const size_t vl_max = __riscv_vsetvlmax_e32m4();
+  const int64_t NB = div_up(N, (int64_t)vl_max);
+
+  // Parallel over M × NB so all 8 cores are used even when M < num_threads.
+  at::parallel_for(0, M * NB, 0, [&](int64_t begin, int64_t end) {
+    alignas(64) float linear_row[rvv_constants::MAX_VL_ELEMENTS_M4];
+    for (int64_t i = begin; i < end; ++i) {
+      const int64_t m = i / NB;
+      const int64_t nb = i % NB;
+      const int64_t n_start = nb * (int64_t)vl_max;
+      size_t vl = __riscv_vsetvl_e32m4(N - n_start);
+
+      const scalar_t* a_row = mat1 + m * mat1_strideM;
+      scalar_t* c_row = out + m * out_strideM;
+
+      // Initialize accumulator with bias or zero
+      vfloat32m4_t v_acc =
+          (bias != nullptr) ? __riscv_vle32_v_f32m4(bias + n_start, vl) : __riscv_vfmv_v_f_f32m4(0.0f, vl);
+
+      // K-loop: broadcast A scalar, load contiguous floats from B row
+      for (int64_t k = 0; k < K; ++k) {
+        const float a_val = static_cast<float>(a_row[k]);
+        const float* b_row = mat2 + k * N + n_start;
+        v_acc = __riscv_vfmacc_vf_f32m4(v_acc, a_val, __riscv_vle32_v_f32m4(b_row, vl), vl);
+      }
+
+      __riscv_vse32_v_f32m4(linear_row, v_acc, vl);
+      copy_stub(c_row + n_start, linear_row, vl);
+    }
+  });
+}
+
+}  // anonymous namespace
+
+template <typename scalar_t>
+void tinygemm_kernel(
+    const scalar_t* __restrict__ A,
+    const scalar_t* __restrict__ B,
+    scalar_t* __restrict__ C,
+    float* __restrict__ Ctmp,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t lda,
+    int64_t ldb,
+    int64_t ldc,
+    bool brg) {
+  UNUSED(Ctmp);
+  UNUSED(ldb);
+  TORCH_CHECK(!brg, "RVV does not use brgemm");
+  // Forward to internal implementation (no bias)
+  tinygemm_kernel<scalar_t, false>(A, B, C, nullptr, M, N, K, lda, ldc);
+}
+
+#define INSTANTIATE_TINYGEMM_TEMPLATE(TYPE) \
+  template void tinygemm_kernel<TYPE>(      \
+      const TYPE* __restrict__ A,           \
+      const TYPE* __restrict__ B,           \
+      TYPE* __restrict__ C,                 \
+      float* __restrict__ Ctmp,             \
+      int64_t M,                            \
+      int64_t N,                            \
+      int64_t K,                            \
+      int64_t lda,                          \
+      int64_t ldb,                          \
+      int64_t ldc,                          \
+      bool brg)
+
+INSTANTIATE_TINYGEMM_TEMPLATE(float);
+INSTANTIATE_TINYGEMM_TEMPLATE(at::BFloat16);
+INSTANTIATE_TINYGEMM_TEMPLATE(at::Half);
+
+at::Tensor convert_weight_packed(at::Tensor& weight) {
+  CHECK_INPUT(weight);
+
+  TORCH_CHECK(weight.ndimension() == 2, "expect weight to be 2d, got ", weight.ndimension(), "d tensor.");
+
+  constexpr int64_t BLOCK_N_RVV = rvv_constants::BLOCK_N;
+  // data [K, BLOCK_N] followed by one int32 compensation per output channel.
+  // The float32-transpose fallback is only valid for FP types.
+  const bool is_int8 = (weight.scalar_type() == at::kChar);
+  if (!is_int8 && (weight.size(0) < BLOCK_N_RVV || weight.size(0) % BLOCK_N_RVV != 0)) {
+    // Small OC shape: use fma linear path, which needs transpose not pack.
+    return weight.to(at::kFloat).t().contiguous();
+  }
+
+  const auto st = weight.scalar_type();
+  const int64_t OC = weight.size(0);
+  const int64_t IC = weight.size(1);
+  const int64_t NB = div_up(OC, BLOCK_N_RVV);
+
+  TORCH_CHECK(
+      st == at::kBFloat16 || st == at::kHalf || st == at::kChar, "expect weight to be bfloat16, float16, int8 ");
+
+  auto packed_weight = at::empty({}, weight.options());
+
+  CPU_DISPATCH_PACKED_TYPES_RVV(st, [&] {
+    const int64_t packed_block_size =
+        std::is_same_v<packed_t, int8_t> ? get_int8_packed_block_size(IC) : IC * BLOCK_N_RVV;
+    packed_weight.resize_({NB, packed_block_size});
+    packed_t* packed_data = packed_weight.data_ptr<packed_t>();
+    const packed_t* w_data = weight.data_ptr<packed_t>();
+
+    at::parallel_for(0, NB, 0, [&](int64_t begin, int64_t end) {
+      for (int64_t nb = begin; nb < end; ++nb) {
+        int64_t n = nb * BLOCK_N_RVV;
+        int64_t n_size = std::min(BLOCK_N_RVV, OC - n);
+        pack_weight<packed_t>(packed_data + nb * packed_block_size, w_data + n * IC, n_size, IC);
+      }
+    });
+  });
+  return packed_weight;
+}
+
+at::Tensor
+weight_packed_linear(at::Tensor& mat1, at::Tensor& mat2, const std::optional<at::Tensor>& bias, bool is_packed) {
+  RECORD_FUNCTION("sgl-kernel::weight_packed_linear", std::vector<c10::IValue>({mat1, mat2, bias}));
+
+  auto packed_w = is_packed ? mat2 : convert_weight_packed(mat2);
+  bool use_fma_gemm = false;
+  if (packed_w.scalar_type() == at::kFloat) {
+    use_fma_gemm = true;
+  }
+
+  int64_t M = mat1.size(0);
+  int64_t K = mat1.size(1);
+  int64_t N;
+  if (use_fma_gemm) {
+    N = packed_w.size(1);
+  } else {
+    if (is_packed) {
+      TORCH_CHECK(
+          packed_w.scalar_type() != at::kChar,
+          "weight_packed_linear: packed int8 weights are not supported through this API; ",
+          "use int8_scaled_mm_cpu/int8_scaled_mm_with_quant for RVV W8A8.");
+      // RVV packed int8 weight: [NB, BLOCK_N * (IC + sizeof(int32_t))].
+      // Floating-point packed weight remains [NB, IC * BLOCK_N].
+      TORCH_CHECK(packed_w.dim() == 2, "RVV packed weight must be 2D");
+      N = packed_w.size(0) * rvv_constants::BLOCK_N;
+    } else {
+      N = mat2.size(0);
+    }
+  }
+
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(mat1);
+  CHECK_INPUT(mat2);
+  CHECK_DIM(2, mat1);
+  if (!is_packed) {
+    CHECK_DIM(2, mat2);
+    if (!use_fma_gemm) {
+      CHECK_EQ(mat1.size(1), mat2.size(1));
+    }
+  }
+
+  if (use_fma_gemm) {
+    TORCH_CHECK(
+        packed_w.scalar_type() == at::kFloat,
+        "weight_packed_linear: float packed weights required for FMA path, got ",
+        packed_w.scalar_type());
+  } else {
+    TORCH_CHECK(
+        packed_w.scalar_type() == mat1.scalar_type(),
+        "weight_packed_linear: mat1 and weight must have the same dtype for RVV packed GEMM, got mat1=",
+        mat1.scalar_type(),
+        ", weight=",
+        packed_w.scalar_type());
+  }
+  if (is_packed && !use_fma_gemm && packed_w.scalar_type() != at::kChar) {
+    TORCH_CHECK(
+        packed_w.size(1) == K * rvv_constants::BLOCK_N,
+        "weight_packed_linear: packed floating weight must have shape [NB, K * BLOCK_N], expected second dim ",
+        K * rvv_constants::BLOCK_N,
+        ", got ",
+        packed_w.size(1));
+  }
+
+  auto dispatch_type = mat1.scalar_type();
+  auto out = at::empty({M, N}, mat1.options());
+  int64_t out_strideM = out.stride(0);
+  int64_t mat1_strideM = mat1.stride(0);
+
+  const bool has_bias = bias.has_value();
+  const float* bias_data = nullptr;
+  if (has_bias) {
+    CHECK_INPUT(bias.value());
+    CHECK_DIM(1, bias.value());
+    CHECK_EQ(bias.value().size(0), N);
+    TORCH_CHECK(
+        bias.value().scalar_type() == at::kFloat,
+        "weight_packed_linear: bias must be float32, got ",
+        bias.value().scalar_type());
+    bias_data = bias.value().data_ptr<float>();
+  }
+
+  AT_DISPATCH_RVV_TYPES(dispatch_type, "weight_packed_linear_kernel_impl", [&] {
+    if (use_fma_gemm) {
+      weight_packed_linear_fma_kernel_impl<scalar_t>(
+          out.data_ptr<scalar_t>(),
+          mat1.data_ptr<scalar_t>(),
+          packed_w.data_ptr<float>(),
+          bias_data,
+          M,
+          N,
+          K,
+          mat1_strideM,
+          out_strideM);
+    } else {
+      weight_packed_linear_kernel_impl<scalar_t>(
+          out.data_ptr<scalar_t>(),
+          mat1.data_ptr<scalar_t>(),
+          packed_w.data_ptr<scalar_t>(),
+          bias_data,
+          M,
+          N,
+          K,
+          mat1_strideM,
+          out_strideM);
+    }
+  });
+
+  return out;
+}
+
+#endif  // CPU_CAPABILITY_RVV

--- a/sgl-kernel/csrc/cpu/riscv64/gemm.h
+++ b/sgl-kernel/csrc/cpu/riscv64/gemm.h
@@ -1,0 +1,261 @@
+#pragma once
+
+#include <ATen/core/Tensor.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+
+#include "riscv64/vector_helpers.h"
+
+// 4 m4-accumulators × 4 phys-regs = 16 of 32 VRs; leaves 16 for operands.
+static constexpr int GEMM_TILE_M = 4;
+
+// Weight packing (RVV block-N format)
+at::Tensor convert_weight_packed(at::Tensor& weight);
+
+inline int64_t get_int8_packed_row_size(int64_t K) {
+  return K + static_cast<int64_t>(sizeof(int32_t));
+}
+
+inline int64_t get_int8_packed_block_size(int64_t K) {
+  return rvv_constants::BLOCK_N * get_int8_packed_row_size(K);
+}
+
+// GEMM Kernel Declarations
+
+template <typename scalar_t>
+void int8_scaled_mm_kernel(
+    scalar_t* __restrict__ out,
+    const uint8_t* __restrict__ mat1,
+    const int8_t* __restrict__ mat2,
+    const float* __restrict__ scales1,
+    const float* __restrict__ scales2,
+    const float* __restrict__ bias,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    bool is_packed);
+
+extern template void int8_scaled_mm_kernel<float>(
+    float* out,
+    const uint8_t* mat1,
+    const int8_t* mat2,
+    const float* scales1,
+    const float* scales2,
+    const float* bias,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    bool is_packed);
+
+extern template void int8_scaled_mm_kernel<at::Half>(
+    at::Half* out,
+    const uint8_t* mat1,
+    const int8_t* mat2,
+    const float* scales1,
+    const float* scales2,
+    const float* bias,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    bool is_packed);
+
+extern template void int8_scaled_mm_kernel<at::BFloat16>(
+    at::BFloat16* out,
+    const uint8_t* mat1,
+    const int8_t* mat2,
+    const float* scales1,
+    const float* scales2,
+    const float* bias,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    bool is_packed);
+
+// TinyGEMM Interface for RVV
+template <typename scalar_t>
+void tinygemm_kernel(
+    const scalar_t* __restrict__ A,
+    const scalar_t* __restrict__ B,
+    scalar_t* __restrict__ C,
+    float* __restrict__ Ctmp,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t lda,
+    int64_t ldb,
+    int64_t ldc,
+    bool brg);
+
+// TinyGEMM Interface for INT8 (RVV W8A8) - activation is uint8, weight is int8.
+template <typename scalar_t>
+void tinygemm_kernel(
+    const uint8_t* __restrict__ A,
+    const int8_t* __restrict__ B,
+    scalar_t* __restrict__ C,
+    const float* __restrict__ As,
+    const float* __restrict__ Bs,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t lda,
+    int64_t ldb,
+    int64_t ldc,
+    bool brg);
+
+// Inline Attention Kernels (Template Implementations)
+
+#if defined(CPU_CAPABILITY_RVV)
+#include <riscv_vector.h>
+
+#include "vector_math.h"
+
+template <typename scalar_t>
+inline void gemm_nt_tiled_transposed(
+    const scalar_t* __restrict__ Q,
+    const scalar_t* __restrict__ K_trans,
+    float* __restrict__ C,
+    int M,
+    int N,
+    int head_size,
+    int q_strideM,
+    int block_n,
+    int ldc,
+    float scale) {
+  size_t vl_max = __riscv_vsetvlmax_e32m4();
+
+  for (int m_base = 0; m_base < M; m_base += GEMM_TILE_M) {
+    int m_count = std::min(GEMM_TILE_M, M - m_base);
+
+    for (int n_base = 0; n_base < N; n_base += vl_max) {
+      size_t vl = __riscv_vsetvl_e32m4(N - n_base);
+
+      vfloat32m4_t acc0 = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+      vfloat32m4_t acc1 = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+      vfloat32m4_t acc2 = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+      vfloat32m4_t acc3 = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+
+      for (int k = 0; k < head_size; ++k) {
+        const scalar_t* k_ptr = K_trans + k * block_n + n_base;
+
+        vfloat16m2_t v_k_f16;
+        vfloat32m4_t v_k_f32;
+
+        if constexpr (std::is_same_v<scalar_t, at::Half>) {
+          v_k_f16 = __riscv_vle16_v_f16m2(reinterpret_cast<const _Float16*>(k_ptr), vl);
+        } else if constexpr (std::is_same_v<scalar_t, at::BFloat16>) {
+          v_k_f32 = bf16_to_f32m4(reinterpret_cast<const uint16_t*>(k_ptr), vl);
+        } else {
+          // scalar_t=float: identity cast, load directly
+          v_k_f32 = __riscv_vle32_v_f32m4(reinterpret_cast<const float*>(k_ptr), vl);
+        }
+
+        float q0 = 0.0f, q1 = 0.0f, q2 = 0.0f, q3 = 0.0f;
+        if (m_count > 0) q0 = static_cast<float>(Q[(m_base + 0) * q_strideM + k]);
+        if (m_count > 1) q1 = static_cast<float>(Q[(m_base + 1) * q_strideM + k]);
+        if (m_count > 2) q2 = static_cast<float>(Q[(m_base + 2) * q_strideM + k]);
+        if (m_count > 3) q3 = static_cast<float>(Q[(m_base + 3) * q_strideM + k]);
+
+        if constexpr (std::is_same_v<scalar_t, at::Half>) {
+          acc0 = vfwmacc_f16_scalar_to_f32m4(acc0, (_Float16)q0, v_k_f16, vl);
+          if (m_count > 1) acc1 = vfwmacc_f16_scalar_to_f32m4(acc1, (_Float16)q1, v_k_f16, vl);
+          if (m_count > 2) acc2 = vfwmacc_f16_scalar_to_f32m4(acc2, (_Float16)q2, v_k_f16, vl);
+          if (m_count > 3) acc3 = vfwmacc_f16_scalar_to_f32m4(acc3, (_Float16)q3, v_k_f16, vl);
+        } else {
+          acc0 = __riscv_vfmacc_vf_f32m4(acc0, q0, v_k_f32, vl);
+          if (m_count > 1) acc1 = __riscv_vfmacc_vf_f32m4(acc1, q1, v_k_f32, vl);
+          if (m_count > 2) acc2 = __riscv_vfmacc_vf_f32m4(acc2, q2, v_k_f32, vl);
+          if (m_count > 3) acc3 = __riscv_vfmacc_vf_f32m4(acc3, q3, v_k_f32, vl);
+        }
+      }
+
+      auto store = [&](int idx, vfloat32m4_t acc) {
+        if (idx < m_count) {
+          __riscv_vse32_v_f32m4(C + (m_base + idx) * ldc + n_base, __riscv_vfmul_vf_f32m4(acc, scale, vl), vl);
+        }
+      };
+
+      store(0, acc0);
+      store(1, acc1);
+      store(2, acc2);
+      store(3, acc3);
+    }
+  }
+}
+
+// NOTE: O must be zero-initialized by the caller before the first call.
+// This function accumulates (load-add-store) onto O across tiled K iterations.
+template <typename scalar_t>
+inline void gemm_nn_tiled(
+    const float* __restrict__ P,
+    const scalar_t* __restrict__ V,
+    float* __restrict__ O,
+    int M,
+    int N,
+    int head_size_v,
+    int p_strideN,
+    int v_strideH) {
+  for (int m_base = 0; m_base < M; m_base += GEMM_TILE_M) {
+    int m_count = std::min(GEMM_TILE_M, M - m_base);
+    size_t vl;
+    for (int d = 0; d < head_size_v; d += vl) {
+      vl = __riscv_vsetvl_e32m4(head_size_v - d);
+
+      vfloat32m4_t acc0 = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+      vfloat32m4_t acc1 = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+      vfloat32m4_t acc2 = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+      vfloat32m4_t acc3 = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+
+      for (int n = 0; n < N; ++n) {
+        const scalar_t* v_ptr = V + n * v_strideH + d;
+
+        float p0 = 0.0f, p1 = 0.0f, p2 = 0.0f, p3 = 0.0f;
+        if (m_count > 0) p0 = P[(m_base + 0) * p_strideN + n];
+        if (m_count > 1) p1 = P[(m_base + 1) * p_strideN + n];
+        if (m_count > 2) p2 = P[(m_base + 2) * p_strideN + n];
+        if (m_count > 3) p3 = P[(m_base + 3) * p_strideN + n];
+
+        if constexpr (std::is_same_v<scalar_t, at::Half>) {
+          vfloat16m2_t v_v = __riscv_vle16_v_f16m2(reinterpret_cast<const _Float16*>(v_ptr), vl);
+
+          acc0 = vfwmacc_f16_scalar_to_f32m4(acc0, (_Float16)p0, v_v, vl);
+          if (m_count > 1) acc1 = vfwmacc_f16_scalar_to_f32m4(acc1, (_Float16)p1, v_v, vl);
+          if (m_count > 2) acc2 = vfwmacc_f16_scalar_to_f32m4(acc2, (_Float16)p2, v_v, vl);
+          if (m_count > 3) acc3 = vfwmacc_f16_scalar_to_f32m4(acc3, (_Float16)p3, v_v, vl);
+        } else if constexpr (std::is_same_v<scalar_t, at::BFloat16>) {
+          vfloat32m4_t v_v = bf16_to_f32m4(reinterpret_cast<const uint16_t*>(v_ptr), vl);
+
+          acc0 = __riscv_vfmacc_vf_f32m4(acc0, p0, v_v, vl);
+          if (m_count > 1) acc1 = __riscv_vfmacc_vf_f32m4(acc1, p1, v_v, vl);
+          if (m_count > 2) acc2 = __riscv_vfmacc_vf_f32m4(acc2, p2, v_v, vl);
+          if (m_count > 3) acc3 = __riscv_vfmacc_vf_f32m4(acc3, p3, v_v, vl);
+        } else {
+          // scalar_t=float: identity cast, load directly
+          vfloat32m4_t v_v = __riscv_vle32_v_f32m4(reinterpret_cast<const float*>(v_ptr), vl);
+
+          acc0 = __riscv_vfmacc_vf_f32m4(acc0, p0, v_v, vl);
+          if (m_count > 1) acc1 = __riscv_vfmacc_vf_f32m4(acc1, p1, v_v, vl);
+          if (m_count > 2) acc2 = __riscv_vfmacc_vf_f32m4(acc2, p2, v_v, vl);
+          if (m_count > 3) acc3 = __riscv_vfmacc_vf_f32m4(acc3, p3, v_v, vl);
+        }
+      }
+
+      auto store_o = [&](int idx, vfloat32m4_t acc) {
+        if (idx < m_count) {
+          float* o_ptr = O + (m_base + idx) * head_size_v + d;
+          vfloat32m4_t old_o = __riscv_vle32_v_f32m4(o_ptr, vl);
+          acc = __riscv_vfadd_vv_f32m4(old_o, acc, vl);
+          __riscv_vse32_v_f32m4(o_ptr, acc, vl);
+        }
+      };
+
+      store_o(0, acc0);
+      store_o(1, acc1);
+      store_o(2, acc2);
+      store_o(3, acc3);
+    }
+  }
+}
+
+#endif  // CPU_CAPABILITY_RVV

--- a/sgl-kernel/csrc/cpu/riscv64/gemm_int8.cpp
+++ b/sgl-kernel/csrc/cpu/riscv64/gemm_int8.cpp
@@ -1,0 +1,679 @@
+#if defined(CPU_CAPABILITY_RVV) && defined(__clang__)
+#pragma clang riscv intrinsic vector
+#endif
+
+#include "common.h"
+#include "riscv64/gemm.h"
+#include "riscv64/vector_helpers.h"
+
+#if defined(CPU_CAPABILITY_RVV)
+#include <riscv_vector.h>
+
+#include <algorithm>
+#include <cmath>
+using namespace rvv_constants;
+
+namespace {
+
+template <typename scalar_t, bool has_bias>
+struct scale_C {
+  // Called with vl <= vl_max; operates on exactly vl elements (no inner loop).
+  static inline void apply(
+      scalar_t* __restrict__ C,
+      vint32m4_t v_acc_i32,
+      const float* __restrict__ bias,
+      float As,
+      const float* __restrict__ Bs,
+      size_t vl) {
+    vfloat32m4_t v_acc = __riscv_vfcvt_f_x_v_f32m4(v_acc_i32, vl);
+
+    // Dequantize: C * (As * Bs) — combine scales first for better precision.
+    vfloat32m4_t v_bs = __riscv_vle32_v_f32m4(Bs, vl);
+    vfloat32m4_t v_combined_scale = __riscv_vfmul_vf_f32m4(v_bs, As, vl);
+    v_acc = __riscv_vfmul_vv_f32m4(v_acc, v_combined_scale, vl);
+
+    if constexpr (has_bias) {
+      vfloat32m4_t v_bias = __riscv_vle32_v_f32m4(bias, vl);
+      v_acc = __riscv_vfadd_vv_f32m4(v_acc, v_bias, vl);
+    }
+
+    alignas(64) float scratch[rvv_constants::MAX_VL_ELEMENTS_M4];
+    store_from_float_m4(C, v_acc, vl, scratch);
+  }
+};
+
+// GEMV specialization (M=1) using int32 LMUL=8 and UNROLL=4.
+template <typename scalar_t, bool has_bias, int BLOCK_N>
+struct tinygemm_kernel_nn_gemv {
+  static inline void apply(
+      const uint8_t* __restrict__ A,
+      const int8_t* __restrict__ B,
+      scalar_t* __restrict__ C,
+      const float* __restrict__ As,
+      const float* __restrict__ Bs,
+      const float* __restrict__ bias,
+      int64_t K,
+      int64_t lda,
+      int64_t ldc,
+      int64_t nb,
+      int64_t n_size) {
+    if constexpr (has_bias) {
+      TORCH_CHECK(bias != nullptr);
+    }
+
+    const int64_t n_start = nb * BLOCK_N;
+    const int64_t packed_block_size = get_int8_packed_block_size(K);
+    size_t vl_max = __riscv_vsetvlmax_e32m8();
+    size_t vl = (n_size >= (int64_t)vl_max) ? vl_max : __riscv_vsetvl_e32m8(n_size);
+
+    constexpr int64_t UNROLL = 4;
+    constexpr int64_t PREFETCH_DIST = UNROLL * 2;
+    // KB: number of K-steps fitting in L1. For int8, each K-step loads BLOCK_N bytes.
+    // BLOCK_N = VLEN/4 bits / 8 = VLEN_bits/32 bytes. KB = L1 / BLOCK_N bytes.
+    constexpr int64_t KB = rvv_constants::L1_CACHE_BYTES * 4 / __riscv_v_fixed_vlen;
+
+    vint32m8_t v_acc = __riscv_vmv_v_x_i32m8(0, vl_max);
+    const int8_t* b_ptr_base = B + nb * packed_block_size;
+    alignas(64) int8_t a_signed_tile[KB];
+
+    for (int64_t k_tile = 0; k_tile < K; k_tile += KB) {
+      const int64_t k_end = std::min(k_tile + KB, K);
+      pretransform_u8_to_centered_i8(a_signed_tile, A + k_tile, k_end - k_tile);
+      int64_t k = k_tile;
+
+      for (; k + UNROLL - 1 < k_end; k += UNROLL) {
+        if (k + PREFETCH_DIST < K) __builtin_prefetch(b_ptr_base + (k + PREFETCH_DIST) * BLOCK_N, 0, 1);
+
+        vint8m2_t v_b0 = __riscv_vle8_v_i8m2(b_ptr_base + (k + 0) * BLOCK_N, vl);
+        v_acc = __riscv_vwmacc_vx_i32m8(
+            v_acc, static_cast<int16_t>(a_signed_tile[k + 0 - k_tile]), __riscv_vsext_vf2_i16m4(v_b0, vl), vl);
+
+        vint8m2_t v_b1 = __riscv_vle8_v_i8m2(b_ptr_base + (k + 1) * BLOCK_N, vl);
+        v_acc = __riscv_vwmacc_vx_i32m8(
+            v_acc, static_cast<int16_t>(a_signed_tile[k + 1 - k_tile]), __riscv_vsext_vf2_i16m4(v_b1, vl), vl);
+
+        vint8m2_t v_b2 = __riscv_vle8_v_i8m2(b_ptr_base + (k + 2) * BLOCK_N, vl);
+        v_acc = __riscv_vwmacc_vx_i32m8(
+            v_acc, static_cast<int16_t>(a_signed_tile[k + 2 - k_tile]), __riscv_vsext_vf2_i16m4(v_b2, vl), vl);
+
+        vint8m2_t v_b3 = __riscv_vle8_v_i8m2(b_ptr_base + (k + 3) * BLOCK_N, vl);
+        v_acc = __riscv_vwmacc_vx_i32m8(
+            v_acc, static_cast<int16_t>(a_signed_tile[k + 3 - k_tile]), __riscv_vsext_vf2_i16m4(v_b3, vl), vl);
+      }
+      for (; k < k_end; ++k) {
+        vint8m2_t v_b = __riscv_vle8_v_i8m2(b_ptr_base + k * BLOCK_N, vl);
+        v_acc = __riscv_vwmacc_vx_i32m8(
+            v_acc, static_cast<int16_t>(a_signed_tile[k - k_tile]), __riscv_vsext_vf2_i16m4(v_b, vl), vl);
+      }
+    }
+
+    // Dequantize: int32 → float → scale → (bias) → output dtype
+    vfloat32m8_t v_acc_f = __riscv_vfcvt_f_x_v_f32m8(v_acc, vl);
+    vfloat32m8_t v_bs = __riscv_vle32_v_f32m8(Bs + n_start, vl);
+    v_acc_f = __riscv_vfmul_vv_f32m8(v_acc_f, __riscv_vfmul_vf_f32m8(v_bs, As[0], vl), vl);
+
+    if constexpr (has_bias) {
+      v_acc_f = __riscv_vfadd_vv_f32m8(v_acc_f, __riscv_vle32_v_f32m8(bias + n_start, vl), vl);
+    }
+
+    alignas(64) float scratch[rvv_constants::MAX_VL_ELEMENTS_M8];
+    store_from_float_m8(C + n_start, v_acc_f, vl, scratch);
+  }
+};
+
+template <typename scalar_t, bool has_bias, int BLOCK_M, int BLOCK_N>
+struct tinygemm_kernel_nn {
+  static_assert(BLOCK_M >= 1 && BLOCK_M <= 4, "BLOCK_M must be 1-4");
+  static_assert(
+      std::is_same_v<scalar_t, float> || std::is_same_v<scalar_t, at::Half> || std::is_same_v<scalar_t, at::BFloat16>,
+      "tinygemm_kernel_nn: only supports float, Half, and BFloat16");
+
+  static inline void apply(
+      const uint8_t* __restrict__ A,
+      const int8_t* __restrict__ B,
+      scalar_t* __restrict__ C,
+      const float* __restrict__ As,
+      const float* __restrict__ Bs,
+      const float* __restrict__ bias,
+      int64_t K,
+      int64_t lda,
+      int64_t ldc,
+      int64_t nb,
+      int64_t n_size) {
+    TORCH_CHECK(n_size >= 0 && n_size <= BLOCK_N);
+    if constexpr (has_bias) {
+      TORCH_CHECK(bias != nullptr);
+    }
+
+    size_t vl_max = __riscv_vsetvlmax_e32m4();
+    const int64_t n_start = nb * BLOCK_N;
+
+    // UNROLL=2: safe for all BLOCK_M (peak regs: BLOCK_M*m4 + 2*m1 + 2*m2 ≤ 28 for M=4).
+    constexpr int64_t UNROLL = 2;
+    constexpr int64_t PREFETCH_DIST = UNROLL * 2;
+    constexpr int64_t KB = rvv_constants::L1_CACHE_BYTES * 4 / __riscv_v_fixed_vlen;
+    alignas(64) int8_t a_signed_tile[BLOCK_M][KB];
+
+    for (int64_t j = 0; j < n_size; j += vl_max) {
+      size_t vl = (j + vl_max <= (size_t)n_size) ? vl_max : __riscv_vsetvl_e32m4(n_size - j);
+
+      // Accumulators in i32
+      vint32m4_t v_acc0, v_acc1, v_acc2, v_acc3;
+      vint32m4_t* v_acc[4] = {&v_acc0, &v_acc1, &v_acc2, &v_acc3};
+      for (int m = 0; m < BLOCK_M; ++m) {
+        *v_acc[m] = __riscv_vmv_v_x_i32m4(0, vl);
+      }
+
+      // K loop: B layout is [NB, K, BLOCK_N]
+      // KB = L1_CACHE_BYTES / (BLOCK_N * sizeof(int8)) = L1 * 4 / VLEN_bits
+      // (BLOCK_N = VLEN/4 elements; each int8 element is 1 byte → BLOCK_N bytes per K-step)
+      // Override via cmake -DRVV_L1_CACHE_KB=N (default 32KB).
+      const int8_t* b_ptr_base = B + nb * get_int8_packed_block_size(K) + j;
+
+      for (int64_t k_tile = 0; k_tile < K; k_tile += KB) {
+        const int64_t k_end = std::min(k_tile + KB, K);
+        const int64_t k_span = k_end - k_tile;
+        for (int m = 0; m < BLOCK_M; ++m) {
+          pretransform_u8_to_centered_i8(a_signed_tile[m], A + m * lda + k_tile, k_span);
+        }
+        int64_t k = k_tile;
+
+        for (; k + UNROLL - 1 < k_end; k += UNROLL) {
+          if (k + PREFETCH_DIST < K) __builtin_prefetch(b_ptr_base + (k + PREFETCH_DIST) * BLOCK_N, 0, 1);
+
+          vint8m1_t v_b0_i8 = __riscv_vle8_v_i8m1(b_ptr_base + (k + 0) * BLOCK_N, vl);
+          vint16m2_t v_b0_i16 = __riscv_vsext_vf2_i16m2(v_b0_i8, vl);
+          vint8m1_t v_b1_i8 = __riscv_vle8_v_i8m1(b_ptr_base + (k + 1) * BLOCK_N, vl);
+          vint16m2_t v_b1_i16 = __riscv_vsext_vf2_i16m2(v_b1_i8, vl);
+
+          for (int m = 0; m < BLOCK_M; ++m) {
+            *v_acc[m] = __riscv_vwmacc_vx_i32m4(
+                *v_acc[m], static_cast<int16_t>(a_signed_tile[m][k + 0 - k_tile]), v_b0_i16, vl);
+            *v_acc[m] = __riscv_vwmacc_vx_i32m4(
+                *v_acc[m], static_cast<int16_t>(a_signed_tile[m][k + 1 - k_tile]), v_b1_i16, vl);
+          }
+        }
+        for (; k < k_end; ++k) {
+          vint8m1_t v_b_i8 = __riscv_vle8_v_i8m1(b_ptr_base + k * BLOCK_N, vl);
+          vint16m2_t v_b_i16 = __riscv_vsext_vf2_i16m2(v_b_i8, vl);
+          for (int m = 0; m < BLOCK_M; ++m) {
+            *v_acc[m] =
+                __riscv_vwmacc_vx_i32m4(*v_acc[m], static_cast<int16_t>(a_signed_tile[m][k - k_tile]), v_b_i16, vl);
+          }
+        }
+      }  // k_tile
+
+      // Dequantize and store each row
+      for (int m = 0; m < BLOCK_M; ++m) {
+        scale_C<scalar_t, has_bias>::apply(
+            C + m * ldc + n_start + j,
+            *v_acc[m],
+            has_bias ? (bias + n_start + j) : nullptr,
+            As[m],
+            Bs + n_start + j,
+            vl);
+      }
+    }
+  }
+};
+
+#define LAUNCH_TINYGEMM_KERNEL_NN(MB_SIZE, NB_SIZE)                \
+  tinygemm_kernel_nn<scalar_t, has_bias, MB_SIZE, NB_SIZE>::apply( \
+      A + mb_start * lda,                                          \
+      B,                                                           \
+      C + mb_start * ldc,                                          \
+      As + mb_start,                                               \
+      Bs,                                                          \
+      has_bias ? bias : nullptr,                                   \
+      K,                                                           \
+      lda,                                                         \
+      ldc,                                                         \
+      nb,                                                          \
+      nb_size);
+
+#define LAUNCH_TINYGEMM_KERNEL_NN_GEMV(NB_SIZE)                \
+  tinygemm_kernel_nn_gemv<scalar_t, has_bias, NB_SIZE>::apply( \
+      A + mb_start * lda,                                      \
+      B,                                                       \
+      C + mb_start * ldc,                                      \
+      As + mb_start,                                           \
+      Bs,                                                      \
+      has_bias ? bias : nullptr,                               \
+      K,                                                       \
+      lda,                                                     \
+      ldc,                                                     \
+      nb,                                                      \
+      nb_size);
+
+template <typename scalar_t, bool has_bias>
+void tinygemm_kernel(
+    const uint8_t* __restrict__ A,
+    const int8_t* __restrict__ B,
+    scalar_t* __restrict__ C,
+    const float* __restrict__ As,
+    const float* __restrict__ Bs,
+    const float* __restrict__ bias,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t lda,
+    int64_t ldc) {
+  constexpr int64_t BLOCK_M = GEMM_TILE_M;
+  constexpr int64_t BLOCK_N = rvv_constants::BLOCK_N;
+  const int64_t MB = div_up(M, BLOCK_M);
+  const int64_t NB = div_up(N, BLOCK_N);
+
+  for (int64_t mb = 0; mb < MB; ++mb) {
+    int64_t mb_start = mb * BLOCK_M;
+    int64_t mb_size = std::min(BLOCK_M, M - mb_start);
+    for (int64_t nb = 0; nb < NB; ++nb) {
+      int64_t nb_start = nb * BLOCK_N;
+      int64_t nb_size = std::min(BLOCK_N, N - nb_start);
+
+      switch (mb_size) {
+        case 1:
+          LAUNCH_TINYGEMM_KERNEL_NN_GEMV(BLOCK_N);
+          break;
+        case 2:
+          LAUNCH_TINYGEMM_KERNEL_NN(2, BLOCK_N);
+          break;
+        case 3:
+          LAUNCH_TINYGEMM_KERNEL_NN(3, BLOCK_N);
+          break;
+        case 4:
+          LAUNCH_TINYGEMM_KERNEL_NN(4, BLOCK_N);
+          break;
+        default:
+          TORCH_CHECK(false, "Unexpected mb_size: ", mb_size);
+      }
+    }
+  }
+}
+
+template <typename scalar_t>
+void int8_scaled_mm_kernel_impl(
+    scalar_t* __restrict__ out,
+    const uint8_t* __restrict__ mat1,
+    const int8_t* __restrict__ mat2,
+    const float* __restrict__ scales1,
+    const float* __restrict__ scales2,
+    const float* __restrict__ bias,
+    int64_t M,
+    int64_t N,
+    int64_t K) {
+  constexpr int64_t BLOCK_M = GEMM_TILE_M;
+  constexpr int64_t BLOCK_N = rvv_constants::BLOCK_N;
+  const int64_t MB = div_up(M, BLOCK_M);
+  const int64_t NB = div_up(N, BLOCK_N);
+
+  AT_DISPATCH_BOOL(bias != nullptr, has_bias, [&] {
+    at::parallel_for(0, NB, 0, [&](int64_t begin, int64_t end) {
+      for (int64_t nb = begin; nb < end; ++nb) {
+        int64_t nb_start = nb * BLOCK_N;
+        int64_t nb_size = std::min(BLOCK_N, N - nb_start);
+
+        for (int64_t mb = 0; mb < MB; ++mb) {
+          int64_t mb_start = mb * BLOCK_M;
+          int64_t mb_size = std::min(BLOCK_M, M - mb_start);
+
+          tinygemm_kernel<scalar_t, has_bias>(
+              /*      A */ mat1 + mb_start * K,
+              /*      B */ mat2 + nb * get_int8_packed_block_size(K),
+              /*      C */ out + mb_start * N + nb_start,
+              /*     As */ scales1 + mb_start,
+              /*     Bs */ scales2 + nb_start,
+              /*   bias */ has_bias ? (bias + nb_start) : nullptr,
+              /*      M */ mb_size,
+              /*      N */ nb_size,
+              /*      K */ K,
+              /*    lda */ K,
+              /*    ldc */ N);
+        }
+      }
+    });
+  });
+}
+
+}  // anonymous namespace
+
+std::tuple<at::Tensor, at::Tensor> per_token_quant_int8_cpu(at::Tensor& A) {
+  RECORD_FUNCTION("sgl-kernel::per_token_quant_int8_cpu", std::vector<c10::IValue>({A}));
+
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(A);
+  CHECK_DIM(2, A);
+
+  int64_t M = A.size(0);
+  int64_t K = A.size(1);
+  int64_t lda = A.stride(0);
+
+  const auto st = A.scalar_type();
+  TORCH_CHECK(st == at::kBFloat16 || st == at::kHalf, "per_token_quant_int8: expect A to be bfloat16 or half.");
+
+  auto Aq = at::empty({M, K}, A.options().dtype(at::kByte));
+  auto As = at::empty({M}, A.options().dtype(at::kFloat));
+
+  AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, st, "per_token_quant_int8_cpu", [&] {
+    const scalar_t* A_data = A.data_ptr<scalar_t>();
+    uint8_t* Aq_data = Aq.data_ptr<uint8_t>();
+    float* As_data = As.data_ptr<float>();
+
+    at::parallel_for(0, M, 1, [&](int64_t begin, int64_t end) {
+      for (int64_t m = begin; m < end; ++m) {
+        quantize_row_uint8_asymmetric_infer_scale<scalar_t>(Aq_data + m * K, As_data[m], A_data + m * lda, K);
+      }
+    });
+  });
+
+  return std::make_tuple(Aq, As);
+}
+
+at::Tensor int8_scaled_mm_cpu(
+    at::Tensor& mat1,
+    at::Tensor& mat2,
+    at::Tensor& scales1,
+    at::Tensor& scales2,
+    const std::optional<at::Tensor>& bias,
+    at::ScalarType out_dtype,
+    // is_packed: true = weight already in RVV block-N format, skip repacking.
+    // Declaration uses is_vnni for API consistency with x86 backend;
+    // renamed here because RVV has no VNNI hardware — is_vnni is misleading.
+    bool is_packed) {
+  RECORD_FUNCTION("sgl-kernel::int8_scaled_mm_cpu", std::vector<c10::IValue>({mat1, mat2, scales1, scales2, bias}));
+
+  CHECK_INPUT(mat1);
+  CHECK_INPUT(mat2);
+  CHECK_INPUT(scales1);
+  CHECK_INPUT(scales2);
+  CHECK_DIM(2, mat1);
+  if (!is_packed) {
+    CHECK_DIM(2, mat2);
+  }
+
+  int64_t M = mat1.size(0);
+  int64_t K = mat1.size(1);
+  int64_t N = mat2.size(0);
+
+  if (!is_packed) {
+    CHECK_EQ(mat2.size(1), K);
+  }
+
+  if (is_packed) {
+    N = scales2.numel();
+  } else {
+    CHECK_EQ(scales2.numel(), N);
+  }
+
+  auto packed_w = is_packed ? mat2 : convert_weight_packed(mat2);
+
+  TORCH_CHECK(mat1.scalar_type() == at::kByte, "int8_scaled_mm_cpu: expect mat1 to be uint8.");
+  TORCH_CHECK(mat2.scalar_type() == at::kChar, "int8_scaled_mm_cpu: expect mat2 to be int8.");
+  TORCH_CHECK(
+      scales1.scalar_type() == at::kFloat && scales2.scalar_type() == at::kFloat,
+      "int8_scaled_mm_cpu: expect scales to be float32.");
+
+  at::Tensor scales1_1d = scales1.dim() == 2 ? scales1.squeeze(-1) : scales1;
+  at::Tensor scales2_1d = scales2.dim() == 2 ? scales2.squeeze(-1) : scales2;
+
+  TORCH_CHECK(
+      scales1_1d.dim() == 1 && scales1_1d.numel() == M,
+      "int8_scaled_mm_cpu: scales1 must be 1D with M elements, got shape ",
+      scales1.sizes());
+  TORCH_CHECK(
+      scales2_1d.dim() == 1 && scales2_1d.numel() == N,
+      "int8_scaled_mm_cpu: scales2 must be 1D with N elements, got shape ",
+      scales2.sizes());
+  if (is_packed) {
+    const int64_t expected_nb = div_up(N, static_cast<int64_t>(rvv_constants::BLOCK_N));
+    TORCH_CHECK(mat2.dim() == 2, "int8_scaled_mm_cpu: packed mat2 must be 2D [NB, BLOCK_N*(K+4)].");
+    TORCH_CHECK(
+        mat2.size(1) == get_int8_packed_block_size(K),
+        "int8_scaled_mm_cpu: packed mat2 has invalid stride, expected ",
+        get_int8_packed_block_size(K),
+        ", got ",
+        mat2.size(1));
+    TORCH_CHECK(
+        mat2.size(0) == expected_nb,
+        "int8_scaled_mm_cpu: packed mat2 has invalid block count, expected ",
+        expected_nb,
+        ", got ",
+        mat2.size(0));
+  }
+
+  auto out = at::empty({M, N}, mat1.options().dtype(out_dtype));
+
+  const bool has_bias = bias.has_value();
+  const float* bias_data = nullptr;
+  if (has_bias) {
+    CHECK_INPUT(bias.value());
+    CHECK_DIM(1, bias.value());
+    CHECK_EQ(bias.value().size(0), N);
+    TORCH_CHECK(
+        bias.value().scalar_type() == at::kFloat,
+        "int8_scaled_mm_cpu: bias must be float32, got ",
+        bias.value().scalar_type());
+    bias_data = bias.value().data_ptr<float>();
+  }
+
+  AT_DISPATCH_RVV_TYPES(out_dtype, "int8_scaled_mm_kernel_impl", [&]() {
+    int8_scaled_mm_kernel_impl<scalar_t>(
+        out.data_ptr<scalar_t>(),
+        mat1.data_ptr<uint8_t>(),
+        packed_w.data_ptr<int8_t>(),
+        scales1_1d.data_ptr<float>(),
+        scales2_1d.data_ptr<float>(),
+        bias_data,
+        M,
+        N,
+        K);
+  });
+
+  return out;
+}
+
+at::Tensor int8_scaled_mm_with_quant(
+    at::Tensor& mat1,
+    at::Tensor& mat2,
+    at::Tensor& scales2,
+    const std::optional<at::Tensor>& bias,
+    at::ScalarType out_dtype,
+    // is_packed: true = weight already in RVV block-N format, skip repacking.
+    // Declaration uses is_vnni for API consistency with x86 backend;
+    // renamed here because RVV has no VNNI hardware — is_vnni is misleading.
+    bool is_packed) {
+  RECORD_FUNCTION("sgl-kernel::int8_scaled_mm_with_quant", std::vector<c10::IValue>({mat1, mat2, scales2, bias}));
+
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(mat1);
+  CHECK_INPUT(mat2);
+  CHECK_INPUT(scales2);
+  CHECK_DIM(2, mat1);
+  if (!is_packed) {
+    CHECK_DIM(2, mat2);
+  }
+
+  int64_t M = mat1.size(0);
+  int64_t K = mat1.size(1);
+  int64_t N = mat2.size(0);
+
+  if (!is_packed) {
+    CHECK_EQ(mat2.size(1), K);
+  }
+
+  if (is_packed) {
+    N = scales2.numel();
+  }
+
+  int64_t lda = mat1.stride(0);
+  CHECK_EQ(scales2.numel(), N);
+
+  auto packed_w = is_packed ? mat2 : convert_weight_packed(mat2);
+
+  const auto st = mat1.scalar_type();
+  TORCH_CHECK(st == at::kBFloat16 || st == at::kHalf, "int8_scaled_mm_with_quant: expect A to be bfloat16 or half.");
+  TORCH_CHECK(st == out_dtype, "int8_scaled_mm_with_quant: expect A has same dtype with out_dtype.");
+  TORCH_CHECK(mat2.scalar_type() == at::kChar, "int8_scaled_mm_with_quant: expect mat2 to be int8.");
+  TORCH_CHECK(scales2.scalar_type() == at::kFloat, "int8_scaled_mm_with_quant: expect scales to be float32.");
+  if (is_packed) {
+    const int64_t expected_nb = div_up(N, static_cast<int64_t>(rvv_constants::BLOCK_N));
+    TORCH_CHECK(mat2.dim() == 2, "int8_scaled_mm_with_quant: packed mat2 must be 2D [NB, BLOCK_N*(K+4)].");
+    TORCH_CHECK(
+        mat2.size(1) == get_int8_packed_block_size(K),
+        "int8_scaled_mm_with_quant: packed mat2 has invalid stride, expected ",
+        get_int8_packed_block_size(K),
+        ", got ",
+        mat2.size(1));
+    TORCH_CHECK(
+        mat2.size(0) == expected_nb,
+        "int8_scaled_mm_with_quant: packed mat2 has invalid block count, expected ",
+        expected_nb,
+        ", got ",
+        mat2.size(0));
+  }
+
+  // Round M*K up to a float boundary so As_data (placed after Aq) is float-aligned.
+  // alignof(float) == sizeof(float) == 4 on all supported targets.
+  constexpr int64_t kFloatAlign = static_cast<int64_t>(alignof(float));
+  const int64_t aq_bytes = ((M * K + kFloatAlign - 1) / kFloatAlign) * kFloatAlign;
+  const int64_t buffer_size = aq_bytes + M * static_cast<int64_t>(sizeof(float));
+  auto buffer = at::empty({buffer_size}, mat1.options().dtype(at::kByte));
+  auto out = at::empty({M, N}, mat1.options().dtype(out_dtype));
+
+  const bool has_bias = bias.has_value();
+  const float* bias_data = nullptr;
+  if (has_bias) {
+    CHECK_INPUT(bias.value());
+    CHECK_DIM(1, bias.value());
+    CHECK_EQ(bias.value().size(0), N);
+    TORCH_CHECK(
+        bias.value().scalar_type() == at::kFloat,
+        "int8_scaled_mm_with_quant: bias must be float32, got ",
+        bias.value().scalar_type());
+    bias_data = bias.value().data_ptr<float>();
+  }
+
+  AT_DISPATCH_RVV_TYPES(out_dtype, "int8_scaled_mm_with_quant_kernel_impl", [&]() {
+    uint8_t* __restrict__ buffer_ptr = buffer.data_ptr<uint8_t>();
+    uint8_t* __restrict__ Aq_data = buffer_ptr;
+    float* __restrict__ As_data = reinterpret_cast<float*>(buffer_ptr + aq_bytes);
+    const scalar_t* __restrict__ A_data = mat1.data_ptr<scalar_t>();
+
+    at::parallel_for(0, M, 0, [&](int64_t begin, int64_t end) {
+      for (int64_t m = begin; m < end; ++m) {
+        quantize_row_uint8_asymmetric_infer_scale<scalar_t>(Aq_data + m * K, As_data[m], A_data + m * lda, K);
+      }
+    });
+
+    int8_scaled_mm_kernel_impl<scalar_t>(
+        out.data_ptr<scalar_t>(),
+        Aq_data,
+        packed_w.data_ptr<int8_t>(),
+        As_data,
+        scales2.data_ptr<float>(),
+        bias_data,
+        M,
+        N,
+        K);
+  });
+  return out;
+}
+
+template <typename scalar_t>
+void tinygemm_kernel(
+    const uint8_t* __restrict__ A,
+    const int8_t* __restrict__ B,
+    scalar_t* __restrict__ C,
+    const float* __restrict__ As,
+    const float* __restrict__ Bs,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t lda,
+    int64_t ldb,
+    int64_t ldc,
+    bool brg) {
+  TORCH_CHECK(!brg, "RVV does not use brgemm");
+  TORCH_CHECK(lda == K, "tinygemm_kernel: A must be contiguous (lda == K)");
+  TORCH_CHECK(ldc == N, "tinygemm_kernel: C must be contiguous (ldc == N)");
+
+  UNUSED(ldb);
+  tinygemm_kernel<scalar_t, false>(
+      A,
+      B,
+      C,
+      As,
+      Bs,
+      nullptr,  // bias
+      M,
+      N,
+      K,
+      lda,
+      ldc);
+}
+
+#define INSTANTIATE_TINYGEMM_TEMPLATE_RVV(TYPE) \
+  template void tinygemm_kernel<TYPE>(          \
+      const uint8_t* __restrict__ A,            \
+      const int8_t* __restrict__ B,             \
+      TYPE* __restrict__ C,                     \
+      const float* __restrict__ As,             \
+      const float* __restrict__ Bs,             \
+      int64_t M,                                \
+      int64_t N,                                \
+      int64_t K,                                \
+      int64_t lda,                              \
+      int64_t ldb,                              \
+      int64_t ldc,                              \
+      bool brg)
+
+INSTANTIATE_TINYGEMM_TEMPLATE_RVV(at::BFloat16);
+INSTANTIATE_TINYGEMM_TEMPLATE_RVV(at::Half);
+
+template <typename scalar_t>
+void tinygemm_kernel(
+    const uint8_t* __restrict__ A,
+    const int8_t* __restrict__ B,
+    scalar_t* __restrict__ C,
+    int32_t* __restrict__ Ctmp,
+    const float* __restrict__ As,
+    const float* __restrict__ Bs,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t lda,
+    int64_t ldb,
+    int64_t ldc,
+    bool brg) {
+  UNUSED(Ctmp);
+  tinygemm_kernel<scalar_t>(A, B, C, As, Bs, M, N, K, lda, ldb, ldc, brg);
+}
+
+template void tinygemm_kernel<at::BFloat16>(
+    const uint8_t* __restrict__ A,
+    const int8_t* __restrict__ B,
+    at::BFloat16* __restrict__ C,
+    int32_t* __restrict__ Ctmp,
+    const float* __restrict__ As,
+    const float* __restrict__ Bs,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t lda,
+    int64_t ldb,
+    int64_t ldc,
+    bool brg);
+
+template void tinygemm_kernel<at::Half>(
+    const uint8_t* __restrict__ A,
+    const int8_t* __restrict__ B,
+    at::Half* __restrict__ C,
+    int32_t* __restrict__ Ctmp,
+    const float* __restrict__ As,
+    const float* __restrict__ Bs,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t lda,
+    int64_t ldb,
+    int64_t ldc,
+    bool brg);
+
+#endif  // CPU_CAPABILITY_RVV

--- a/sgl-kernel/csrc/cpu/riscv64/norm.cpp
+++ b/sgl-kernel/csrc/cpu/riscv64/norm.cpp
@@ -1,0 +1,611 @@
+#if defined(CPU_CAPABILITY_RVV) && defined(__clang__)
+#pragma clang riscv intrinsic vector
+#endif
+
+#if defined(CPU_CAPABILITY_RVV)
+
+#include <cmath>
+#include <cstdint>
+
+#include "common.h"
+#include "riscv64/vector_helpers.h"
+
+namespace {
+
+// L2 norm: out[d] = x[d] * rsqrt(sum(x^2) / N + eps)
+template <typename scalar_t>
+void l2norm_kernel_impl(
+    scalar_t* __restrict__ output,
+    const scalar_t* __restrict__ input,
+    int64_t batch_size,
+    int64_t hidden_size,
+    float eps) {
+  at::parallel_for(0, batch_size, 0, [&](int64_t begin, int64_t end) {
+    alignas(64) float scratch[rvv_constants::MAX_VL_ELEMENTS_M4];
+    for (int64_t i = begin; i < end; ++i) {
+      const scalar_t* in_ptr = input + i * hidden_size;
+      scalar_t* out_ptr = output + i * hidden_size;
+
+      // Pass 1: accumulate sum of squares
+      float sum_sq = 0.0f;
+      size_t vl = 0;
+      vfloat32m1_t vzero = __riscv_vfmv_s_f_f32m1(0.0f, 1);
+      for (int64_t j = 0; j < hidden_size; j += vl) {
+        vl = __riscv_vsetvl_e32m4(hidden_size - j);
+        vfloat32m4_t vx = load_as_float_m4(in_ptr + j, vl, scratch);
+        vfloat32m4_t vsq = __riscv_vfmul_vv_f32m4(vx, vx, vl);
+        sum_sq += __riscv_vfmv_f_s_f32m1_f32(__riscv_vfredusum_vs_f32m4_f32m1(vsq, vzero, vl));
+      }
+      float scale = 1.0f / std::sqrt(sum_sq / hidden_size + eps);
+
+      // Pass 2: scale and store
+      for (int64_t j = 0; j < hidden_size; j += vl) {
+        vl = __riscv_vsetvl_e32m4(hidden_size - j);
+        vfloat32m4_t vx = load_as_float_m4(in_ptr + j, vl, scratch);
+        store_from_float_m4(out_ptr + j, __riscv_vfmul_vf_f32m4(vx, scale, vl), vl, scratch);
+      }
+    }
+  });
+}
+
+// RMSNorm (plain and gemma variant via template bool):
+//   plain:  out[d] = x[d] * rsqrt_var * w[d]
+//   gemma:  out[d] = x[d] * rsqrt_var * (1 + w[d])
+template <typename scalar_t, bool is_gemma>
+void rmsnorm_kernel_impl(
+    scalar_t* __restrict__ output,
+    const scalar_t* __restrict__ input,
+    const scalar_t* __restrict__ weight,
+    int64_t batch_size,
+    int64_t hidden_size,
+    int64_t input_strideN,
+    float eps) {
+  at::parallel_for(0, batch_size, 0, [&](int64_t begin, int64_t end) {
+    alignas(64) float scratch[rvv_constants::MAX_VL_ELEMENTS_M4];
+    for (int64_t i = begin; i < end; ++i) {
+      const scalar_t* in_ptr = input + i * input_strideN;
+      scalar_t* out_ptr = output + i * hidden_size;
+
+      // Pass 1: sum x^2
+      float sum_sq = 0.0f;
+      size_t vl = 0;
+      vfloat32m1_t vzero = __riscv_vfmv_s_f_f32m1(0.0f, 1);
+      for (int64_t j = 0; j < hidden_size; j += vl) {
+        vl = __riscv_vsetvl_e32m4(hidden_size - j);
+        vfloat32m4_t vx = load_as_float_m4(in_ptr + j, vl, scratch);
+        vfloat32m4_t vsq = __riscv_vfmul_vv_f32m4(vx, vx, vl);
+        sum_sq += __riscv_vfmv_f_s_f32m1_f32(__riscv_vfredusum_vs_f32m4_f32m1(vsq, vzero, vl));
+      }
+      float rsqrt_var = 1.0f / std::sqrt(sum_sq / hidden_size + eps);
+
+      // Pass 2: out = x * rsqrt_var * w (or (1+w) for gemma)
+      for (int64_t j = 0; j < hidden_size; j += vl) {
+        vl = __riscv_vsetvl_e32m4(hidden_size - j);
+        vfloat32m4_t vx = load_as_float_m4(in_ptr + j, vl, scratch);
+        vfloat32m4_t vw = load_as_float_m4(weight + j, vl, scratch);
+        if constexpr (is_gemma) {
+          vw = __riscv_vfadd_vf_f32m4(vw, 1.0f, vl);
+        }
+        vfloat32m4_t vout = __riscv_vfmul_vv_f32m4(__riscv_vfmul_vf_f32m4(vx, rsqrt_var, vl), vw, vl);
+        store_from_float_m4(out_ptr + j, vout, vl, scratch);
+      }
+    }
+  });
+}
+
+// Gemma3 RMSNorm 4D: input [B, H, S, D] with arbitrary strides
+// Same as gemma rmsnorm but iterates over (B, H, S) with data_index_step.
+template <typename scalar_t>
+void gemma3_rmsnorm_kernel_4d_impl(
+    scalar_t* __restrict__ output,
+    const scalar_t* __restrict__ input,
+    const scalar_t* __restrict__ weight,
+    int64_t batch_size,
+    int64_t num_head,
+    int64_t seq_len,
+    int64_t hidden_size,
+    int64_t input_strideB,
+    int64_t input_strideH,
+    int64_t input_strideS,
+    int64_t output_strideB,
+    int64_t output_strideH,
+    int64_t output_strideS,
+    float eps) {
+  at::parallel_for(0, batch_size * num_head * seq_len, 0, [&](int64_t begin, int64_t end) {
+    alignas(64) float scratch[rvv_constants::MAX_VL_ELEMENTS_M4];
+    int64_t bi{0}, hi{0}, si{0};
+    data_index_init(begin, bi, batch_size, hi, num_head, si, seq_len);
+    for (int64_t i = begin; i < end; ++i) {
+      const scalar_t* in_ptr = input + bi * input_strideB + hi * input_strideH + si * input_strideS;
+      scalar_t* out_ptr = output + bi * output_strideB + hi * output_strideH + si * output_strideS;
+
+      // Pass 1: sum x^2
+      float sum_sq = 0.0f;
+      size_t vl = 0;
+      vfloat32m1_t vzero = __riscv_vfmv_s_f_f32m1(0.0f, 1);
+      for (int64_t j = 0; j < hidden_size; j += vl) {
+        vl = __riscv_vsetvl_e32m4(hidden_size - j);
+        vfloat32m4_t vx = load_as_float_m4(in_ptr + j, vl, scratch);
+        vfloat32m4_t vsq = __riscv_vfmul_vv_f32m4(vx, vx, vl);
+        sum_sq += __riscv_vfmv_f_s_f32m1_f32(__riscv_vfredusum_vs_f32m4_f32m1(vsq, vzero, vl));
+      }
+      float rsqrt_var = 1.0f / std::sqrt(sum_sq / hidden_size + eps);
+
+      // Pass 2: out = x * rsqrt_var * (1 + w)
+      for (int64_t j = 0; j < hidden_size; j += vl) {
+        vl = __riscv_vsetvl_e32m4(hidden_size - j);
+        vfloat32m4_t vx = load_as_float_m4(in_ptr + j, vl, scratch);
+        vfloat32m4_t vw = load_as_float_m4(weight + j, vl, scratch);
+        vw = __riscv_vfadd_vf_f32m4(vw, 1.0f, vl);
+        vfloat32m4_t vout = __riscv_vfmul_vv_f32m4(__riscv_vfmul_vf_f32m4(vx, rsqrt_var, vl), vw, vl);
+        store_from_float_m4(out_ptr + j, vout, vl, scratch);
+      }
+      data_index_step(bi, batch_size, hi, num_head, si, seq_len);
+    }
+  });
+}
+
+// Fused add-RMSNorm (+ gemma variant via template bool):
+//   Pass 1: vs = input[d] + residual[d];
+//           residual[d] = scalar_t(vs);   buffer[d] = float(vs);
+//           sum_sq += vs^2
+//   Pass 2: input[d] = buffer[d] * rsqrt_var * w[d] (or (1+w))
+template <typename scalar_t, bool is_gemma>
+void fused_add_rmsnorm_kernel_impl(
+    scalar_t* __restrict__ input,
+    scalar_t* __restrict__ residual,
+    const scalar_t* __restrict__ weight,
+    float* __restrict__ buffer,
+    int64_t batch_size,
+    int64_t hidden_size,
+    int64_t input_strideN,
+    float eps) {
+  at::parallel_for(0, batch_size, 0, [&](int64_t begin, int64_t end) {
+    alignas(64) float scratch[rvv_constants::MAX_VL_ELEMENTS_M4];
+    int tid = at::get_thread_num();
+    float* __restrict__ buf_ptr = buffer + tid * hidden_size;
+
+    for (int64_t i = begin; i < end; ++i) {
+      scalar_t* __restrict__ in_ptr = input + i * input_strideN;
+      scalar_t* __restrict__ res_ptr = residual + i * hidden_size;
+
+      // Pass 1: fused add → residual; fill float buffer; accumulate sum-sq
+      float sum_sq = 0.0f;
+      size_t vl = 0;
+      vfloat32m1_t vzero = __riscv_vfmv_s_f_f32m1(0.0f, 1);
+      for (int64_t j = 0; j < hidden_size; j += vl) {
+        vl = __riscv_vsetvl_e32m4(hidden_size - j);
+        vfloat32m4_t vx = load_as_float_m4(in_ptr + j, vl, scratch);
+        vfloat32m4_t vr = load_as_float_m4(res_ptr + j, vl, scratch);
+        vfloat32m4_t vs = __riscv_vfadd_vv_f32m4(vx, vr, vl);
+        // Write x+r to residual (converted to scalar_t)
+        store_from_float_m4(res_ptr + j, vs, vl, scratch);
+        // Keep float32 copy in buffer for Pass 2
+        __riscv_vse32_v_f32m4(buf_ptr + j, vs, vl);
+        vfloat32m4_t vsq = __riscv_vfmul_vv_f32m4(vs, vs, vl);
+        sum_sq += __riscv_vfmv_f_s_f32m1_f32(__riscv_vfredusum_vs_f32m4_f32m1(vsq, vzero, vl));
+      }
+      float rsqrt_var = 1.0f / std::sqrt(sum_sq / hidden_size + eps);
+
+      // Pass 2: input[d] = buffer[d] * rsqrt_var * w[d] (or (1+w))
+      for (int64_t j = 0; j < hidden_size; j += vl) {
+        vl = __riscv_vsetvl_e32m4(hidden_size - j);
+        vfloat32m4_t vbuf = __riscv_vle32_v_f32m4(buf_ptr + j, vl);
+        vfloat32m4_t vw = load_as_float_m4(weight + j, vl, scratch);
+        if constexpr (is_gemma) {
+          vw = __riscv_vfadd_vf_f32m4(vw, 1.0f, vl);
+        }
+        vfloat32m4_t vout = __riscv_vfmul_vv_f32m4(__riscv_vfmul_vf_f32m4(vbuf, rsqrt_var, vl), vw, vl);
+        store_from_float_m4(in_ptr + j, vout, vl, scratch);
+      }
+    }
+  });
+}
+
+// Fused RMSNorm+Gated: out = rms_norm(x) * w * silu(gate)
+// silu(g) = g * rec(1 + exp(-g))  — reuses vrec_f32m4 from vector_math.h
+template <typename scalar_t>
+void fused_rmsnorm_gated_kernel_impl(
+    scalar_t* __restrict__ output,
+    const scalar_t* __restrict__ input,
+    const scalar_t* __restrict__ weight,
+    const scalar_t* __restrict__ gate,
+    int64_t batch_size,
+    int64_t hidden_size,
+    int64_t input_strideN,
+    float eps) {
+  at::parallel_for(0, batch_size, 0, [&](int64_t begin, int64_t end) {
+    alignas(64) float scratch[rvv_constants::MAX_VL_ELEMENTS_M4];
+    for (int64_t i = begin; i < end; ++i) {
+      const scalar_t* in_ptr = input + i * input_strideN;
+      const scalar_t* gate_ptr = gate + i * hidden_size;
+      scalar_t* out_ptr = output + i * hidden_size;
+
+      // Pass 1: sum x^2
+      float sum_sq = 0.0f;
+      size_t vl = 0;
+      vfloat32m1_t vzero = __riscv_vfmv_s_f_f32m1(0.0f, 1);
+      for (int64_t j = 0; j < hidden_size; j += vl) {
+        vl = __riscv_vsetvl_e32m4(hidden_size - j);
+        vfloat32m4_t vx = load_as_float_m4(in_ptr + j, vl, scratch);
+        vfloat32m4_t vsq = __riscv_vfmul_vv_f32m4(vx, vx, vl);
+        sum_sq += __riscv_vfmv_f_s_f32m1_f32(__riscv_vfredusum_vs_f32m4_f32m1(vsq, vzero, vl));
+      }
+      float rsqrt_var = 1.0f / std::sqrt(sum_sq / hidden_size + eps);
+
+      // Pass 2: out = x * rsqrt_var * w * silu(g)
+      for (int64_t j = 0; j < hidden_size; j += vl) {
+        vl = __riscv_vsetvl_e32m4(hidden_size - j);
+        vfloat32m4_t vx = load_as_float_m4(in_ptr + j, vl, scratch);
+        vfloat32m4_t vw = load_as_float_m4(weight + j, vl, scratch);
+        vfloat32m4_t vg = load_as_float_m4(gate_ptr + j, vl, scratch);
+        // silu(g) = g / (1 + exp(-g)) = g * approx_rec(1 + exp(-g))
+        vfloat32m4_t vdenom = __riscv_vfadd_vf_f32m4(vfexp_f32m4(__riscv_vfneg_v_f32m4(vg, vl), vl), 1.0f, vl);
+        vfloat32m4_t vsilu = __riscv_vfmul_vv_f32m4(vg, vrec_f32m4(vdenom, vl), vl);
+        vfloat32m4_t vout = __riscv_vfmul_vv_f32m4(
+            __riscv_vfmul_vv_f32m4(__riscv_vfmul_vf_f32m4(vx, rsqrt_var, vl), vw, vl), vsilu, vl);
+        store_from_float_m4(out_ptr + j, vout, vl, scratch);
+      }
+    }
+  });
+}
+
+// Fused add-LayerNorm (residual may be nullptr for plain LayerNorm):
+//   Pass 1: x = input[d] + residual[d] (if any); save to residual and buffer;
+//           accumulate sum(x) and sum(x^2).
+//   Compute: mean = sum/N; variance = sum_sq/N - mean^2.
+//   Pass 2: input[d] = (buffer[d] - mean) * rsqrt(variance + eps) * weight[d].
+template <typename scalar_t>
+void fused_add_layernorm_kernel_impl(
+    scalar_t* __restrict__ input,
+    scalar_t* __restrict__ residual,  // nullable: plain layernorm passes nullptr
+    const scalar_t* __restrict__ weight,
+    float* __restrict__ buffer,
+    int64_t batch_size,
+    int64_t hidden_size,
+    int64_t input_strideN,
+    float eps) {
+  at::parallel_for(0, batch_size, 0, [&](int64_t begin, int64_t end) {
+    alignas(64) float scratch[rvv_constants::MAX_VL_ELEMENTS_M4];
+    int tid = at::get_thread_num();
+    float* __restrict__ buf_ptr = buffer + tid * hidden_size;
+
+    for (int64_t i = begin; i < end; ++i) {
+      scalar_t* __restrict__ in_ptr = input + i * input_strideN;
+      scalar_t* __restrict__ res_ptr = (residual != nullptr) ? residual + i * hidden_size : nullptr;
+
+      // Pass 1: optional fused add; fill buffer; accumulate sum and sum-sq
+      float sum_val = 0.0f, sum_sq = 0.0f;
+      size_t vl = 0;
+      vfloat32m1_t vzero = __riscv_vfmv_s_f_f32m1(0.0f, 1);
+      for (int64_t j = 0; j < hidden_size; j += vl) {
+        vl = __riscv_vsetvl_e32m4(hidden_size - j);
+        vfloat32m4_t vx = load_as_float_m4(in_ptr + j, vl, scratch);
+        if (res_ptr != nullptr) {
+          vfloat32m4_t vr = load_as_float_m4(res_ptr + j, vl, scratch);
+          vx = __riscv_vfadd_vv_f32m4(vx, vr, vl);
+          store_from_float_m4(res_ptr + j, vx, vl, scratch);
+        }
+        sum_val += __riscv_vfmv_f_s_f32m1_f32(__riscv_vfredusum_vs_f32m4_f32m1(vx, vzero, vl));
+        vfloat32m4_t vsq = __riscv_vfmul_vv_f32m4(vx, vx, vl);
+        sum_sq += __riscv_vfmv_f_s_f32m1_f32(__riscv_vfredusum_vs_f32m4_f32m1(vsq, vzero, vl));
+        __riscv_vse32_v_f32m4(buf_ptr + j, vx, vl);
+      }
+
+      // LayerNorm statistics: Var(X) = E(X²) - E(X)²
+      // Note: E(X²) - E(X)² can produce negative values due to FP cancellation when
+      // activations are large; clamp to 0 before adding eps to avoid sqrt(negative).
+      float mean = sum_val / hidden_size;
+      float mean_sq = sum_sq / hidden_size;
+      float variance = std::max(0.0f, mean_sq - mean * mean);
+      float rsqrt_var = 1.0f / std::sqrt(variance + eps);
+
+      // Pass 2: input[d] = (buffer[d] - mean) * rsqrt_var * weight[d]
+      for (int64_t j = 0; j < hidden_size; j += vl) {
+        vl = __riscv_vsetvl_e32m4(hidden_size - j);
+        vfloat32m4_t vbuf = __riscv_vle32_v_f32m4(buf_ptr + j, vl);
+        vfloat32m4_t vw = load_as_float_m4(weight + j, vl, scratch);
+        vfloat32m4_t vx = __riscv_vfsub_vf_f32m4(vbuf, mean, vl);
+        vfloat32m4_t vout = __riscv_vfmul_vv_f32m4(__riscv_vfmul_vf_f32m4(vx, rsqrt_var, vl), vw, vl);
+        store_from_float_m4(in_ptr + j, vout, vl, scratch);
+      }
+    }
+  });
+}
+
+}  // namespace
+
+// Public API from sgl-kernel/csrc/cpu/norm.cpp
+// input: {batch_size, hidden_size}
+at::Tensor l2norm_cpu(at::Tensor& input, double eps) {
+  RECORD_FUNCTION("sgl-kernel::l2norm_cpu", std::vector<c10::IValue>({input}));
+  CHECK_INPUT(input);
+  CHECK_DIM(2, input);
+  int64_t batch_size = input.size(0);
+  int64_t hidden_size = input.size(1);
+  at::Tensor output = at::empty_like(input);
+  AT_DISPATCH_REDUCED_FLOATING_TYPES(input.scalar_type(), "l2norm_kernel", [&] {
+    l2norm_kernel_impl<scalar_t>(
+        output.data_ptr<scalar_t>(), input.data_ptr<scalar_t>(), batch_size, hidden_size, static_cast<float>(eps));
+  });
+  return output;
+}
+
+// input : {batch_size, hidden_size}
+// weight: {hidden_size}
+at::Tensor rmsnorm_cpu(at::Tensor& input, at::Tensor& weight, double eps) {
+  RECORD_FUNCTION("sgl-kernel::rmsnorm_cpu", std::vector<c10::IValue>({input, weight}));
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(input);
+  CHECK_INPUT(weight);
+  CHECK_DIM(2, input);
+  CHECK_DIM(1, weight);
+  CHECK_EQ(input.size(1), weight.size(0));
+  int64_t batch_size = input.size(0);
+  int64_t hidden_size = input.size(1);
+  int64_t input_strideN = input.stride(0);
+  at::Tensor output = at::empty_like(input);
+  AT_DISPATCH_REDUCED_FLOATING_TYPES(input.scalar_type(), "rmsnorm_kernel", [&] {
+    rmsnorm_kernel_impl<scalar_t, false>(
+        output.data_ptr<scalar_t>(),
+        input.data_ptr<scalar_t>(),
+        weight.data_ptr<scalar_t>(),
+        batch_size,
+        hidden_size,
+        input_strideN,
+        static_cast<float>(eps));
+  });
+  return output;
+}
+
+// input : {batch_size, hidden_size}
+// weight: {hidden_size}
+// bias  : {hidden_size} (optional)
+at::Tensor
+layernorm_cpu(const at::Tensor& input, const at::Tensor& weight, const std::optional<at::Tensor>& bias, double eps) {
+  RECORD_FUNCTION("sgl-kernel::layernorm_cpu", std::vector<c10::IValue>({input, weight}));
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(input);
+  CHECK_INPUT(weight);
+  CHECK_DIM(2, input);
+  CHECK_DIM(1, weight);
+  CHECK_EQ(input.size(1), weight.size(0));
+  int64_t batch_size = input.size(0);
+  int64_t hidden_size = input.size(1);
+  int64_t num_threads = at::get_num_threads();
+  at::Tensor buffer = at::empty({num_threads, hidden_size}, input.options().dtype(at::kFloat));
+  // Clone input into output: materializes any non-contiguous input as contiguous,
+  // so the kernel always sees stride(0) == hidden_size (no separate strideN parameter needed).
+  at::Tensor output = input.clone();
+  AT_DISPATCH_REDUCED_FLOATING_TYPES(input.scalar_type(), "layernorm_kernel", [&] {
+    fused_add_layernorm_kernel_impl<scalar_t>(
+        output.data_ptr<scalar_t>(),
+        nullptr,
+        weight.data_ptr<scalar_t>(),
+        buffer.data_ptr<float>(),
+        batch_size,
+        hidden_size,
+        output.stride(0),
+        static_cast<float>(eps));
+  });
+  if (bias.has_value()) {
+    output.add_(bias.value());
+  }
+  return output;
+}
+
+// input : {batch_size, hidden_size}
+// weight: {hidden_size}  — scale = 1 + weight
+at::Tensor gemma_rmsnorm_cpu(at::Tensor& input, at::Tensor& weight, double eps) {
+  RECORD_FUNCTION("sgl-kernel::gemma_rmsnorm_cpu", std::vector<c10::IValue>({input, weight}));
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(input);
+  CHECK_INPUT(weight);
+  CHECK_DIM(2, input);
+  CHECK_DIM(1, weight);
+  CHECK_EQ(input.size(1), weight.size(0));
+  int64_t batch_size = input.size(0);
+  int64_t hidden_size = input.size(1);
+  int64_t input_strideN = input.stride(0);
+  at::Tensor output = at::empty_like(input);
+  AT_DISPATCH_REDUCED_FLOATING_TYPES(input.scalar_type(), "gemma_rmsnorm_kernel", [&] {
+    rmsnorm_kernel_impl<scalar_t, true>(
+        output.data_ptr<scalar_t>(),
+        input.data_ptr<scalar_t>(),
+        weight.data_ptr<scalar_t>(),
+        batch_size,
+        hidden_size,
+        input_strideN,
+        static_cast<float>(eps));
+  });
+  return output;
+}
+
+// input : {batch_size, hidden_size} or {batch_size, num_head, seq_len, head_dim}
+// weight: {hidden_size}  — scale = 1 + weight
+at::Tensor gemma3_rmsnorm_cpu(at::Tensor& input, at::Tensor& weight, double eps) {
+  RECORD_FUNCTION("sgl-kernel::gemma3_rmsnorm_cpu", std::vector<c10::IValue>({input, weight}));
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(input);
+  CHECK_INPUT(weight);
+  TORCH_CHECK(
+      input.dim() == 2 || input.dim() == 4, "gemma3_rmsnorm_cpu: input must be 2D or 4D, got ", input.dim(), "D");
+  CHECK_DIM(1, weight);
+  CHECK_EQ(input.size(-1), weight.size(0));
+  int64_t batch_size = input.size(0);
+  int64_t hidden_size = weight.size(0);
+  at::Tensor output = at::empty_like(input);
+  if (input.dim() == 2) {
+    int64_t input_strideN = input.stride(0);
+    AT_DISPATCH_REDUCED_FLOATING_TYPES(input.scalar_type(), "gemma3_rmsnorm_kernel", [&] {
+      rmsnorm_kernel_impl<scalar_t, true>(
+          output.data_ptr<scalar_t>(),
+          input.data_ptr<scalar_t>(),
+          weight.data_ptr<scalar_t>(),
+          batch_size,
+          hidden_size,
+          input_strideN,
+          static_cast<float>(eps));
+    });
+  } else {
+    int64_t input_strideB = input.stride(0);
+    int64_t input_strideH = input.stride(1);
+    int64_t input_strideS = input.stride(2);
+    int64_t output_strideB = output.stride(0);
+    int64_t output_strideH = output.stride(1);
+    int64_t output_strideS = output.stride(2);
+    int64_t num_head = input.size(1);
+    int64_t seq_len = input.size(2);
+    AT_DISPATCH_REDUCED_FLOATING_TYPES(input.scalar_type(), "gemma3_rmsnorm_kernel_4d", [&] {
+      gemma3_rmsnorm_kernel_4d_impl<scalar_t>(
+          output.data_ptr<scalar_t>(),
+          input.data_ptr<scalar_t>(),
+          weight.data_ptr<scalar_t>(),
+          batch_size,
+          num_head,
+          seq_len,
+          hidden_size,
+          input_strideB,
+          input_strideH,
+          input_strideS,
+          output_strideB,
+          output_strideH,
+          output_strideS,
+          static_cast<float>(eps));
+    });
+  }
+  return output;
+}
+
+// input : {batch_size, hidden_size}
+// weight: {hidden_size}, gate: {batch_size, hidden_size}
+at::Tensor fused_rmsnorm_gated_cpu(at::Tensor& input, at::Tensor& weight, at::Tensor& gate, double eps) {
+  RECORD_FUNCTION("sgl-kernel::fused_rmsnorm_gated_cpu", std::vector<c10::IValue>({input, weight, gate}));
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(input);
+  CHECK_INPUT(weight);
+  CHECK_INPUT(gate);
+  CHECK_DIM(2, input);
+  CHECK_DIM(1, weight);
+  CHECK_DIM(2, gate);
+  CHECK_EQ(input.size(1), weight.size(0));
+  CHECK_EQ(input.size(0), gate.size(0));
+  CHECK_EQ(input.size(1), gate.size(1));
+  int64_t batch_size = input.size(0);
+  int64_t hidden_size = input.size(1);
+  int64_t input_strideN = input.stride(0);
+  at::Tensor output = at::empty_like(input);
+  AT_DISPATCH_REDUCED_FLOATING_TYPES(input.scalar_type(), "fused_rmsnorm_gated_kernel", [&] {
+    fused_rmsnorm_gated_kernel_impl<scalar_t>(
+        output.data_ptr<scalar_t>(),
+        input.data_ptr<scalar_t>(),
+        weight.data_ptr<scalar_t>(),
+        gate.data_ptr<scalar_t>(),
+        batch_size,
+        hidden_size,
+        input_strideN,
+        static_cast<float>(eps));
+  });
+  return output;
+}
+
+// input   : {batch_size, hidden_size}
+// residual: {batch_size, hidden_size}
+// weight  : {hidden_size}
+void fused_add_rmsnorm_cpu(at::Tensor& input, at::Tensor& residual, at::Tensor& weight, double eps) {
+  RECORD_FUNCTION("sgl-kernel::fused_add_rmsnorm_cpu", std::vector<c10::IValue>({input, residual, weight}));
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(input);
+  CHECK_INPUT(residual);
+  CHECK_INPUT(weight);
+  CHECK_DIM(2, input);
+  CHECK_DIM(2, residual);
+  CHECK_DIM(1, weight);
+  CHECK_EQ(input.size(0), residual.size(0));
+  CHECK_EQ(input.size(1), residual.size(1));
+  CHECK_EQ(input.size(1), weight.size(0));
+  int64_t batch_size = input.size(0);
+  int64_t hidden_size = input.size(1);
+  int64_t input_strideN = input.stride(0);
+  int64_t num_threads = at::get_num_threads();
+  at::Tensor buffer = at::empty({num_threads, hidden_size}, input.options().dtype(at::kFloat));
+  AT_DISPATCH_REDUCED_FLOATING_TYPES(input.scalar_type(), "fused_add_rmsnorm_kernel", [&] {
+    fused_add_rmsnorm_kernel_impl<scalar_t, false>(
+        input.data_ptr<scalar_t>(),
+        residual.data_ptr<scalar_t>(),
+        weight.data_ptr<scalar_t>(),
+        buffer.data_ptr<float>(),
+        batch_size,
+        hidden_size,
+        input_strideN,
+        static_cast<float>(eps));
+  });
+}
+
+void gemma_fused_add_rmsnorm_cpu(at::Tensor& input, at::Tensor& residual, at::Tensor& weight, double eps) {
+  RECORD_FUNCTION("sgl-kernel::gemma_fused_add_rmsnorm_cpu", std::vector<c10::IValue>({input, residual, weight}));
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(input);
+  CHECK_INPUT(residual);
+  CHECK_INPUT(weight);
+  CHECK_DIM(2, input);
+  CHECK_DIM(2, residual);
+  CHECK_DIM(1, weight);
+  CHECK_EQ(input.size(0), residual.size(0));
+  CHECK_EQ(input.size(1), residual.size(1));
+  CHECK_EQ(input.size(1), weight.size(0));
+  int64_t batch_size = input.size(0);
+  int64_t hidden_size = input.size(1);
+  int64_t input_strideN = input.stride(0);
+  int64_t num_threads = at::get_num_threads();
+  at::Tensor buffer = at::empty({num_threads, hidden_size}, input.options().dtype(at::kFloat));
+  AT_DISPATCH_REDUCED_FLOATING_TYPES(input.scalar_type(), "gemma_fused_add_rmsnorm_kernel", [&] {
+    fused_add_rmsnorm_kernel_impl<scalar_t, true>(
+        input.data_ptr<scalar_t>(),
+        residual.data_ptr<scalar_t>(),
+        weight.data_ptr<scalar_t>(),
+        buffer.data_ptr<float>(),
+        batch_size,
+        hidden_size,
+        input_strideN,
+        static_cast<float>(eps));
+  });
+}
+
+// input   : {batch_size, hidden_size}
+// residual: {batch_size, hidden_size}
+// weight  : {hidden_size}
+// bias    : {hidden_size} (optional)
+at::Tensor fused_add_layernorm_cpu(
+    const at::Tensor& input,
+    at::Tensor& residual,
+    const at::Tensor& weight,
+    const std::optional<at::Tensor>& bias,
+    double eps) {
+  RECORD_FUNCTION("sgl-kernel::fused_add_layernorm_cpu", std::vector<c10::IValue>({input, residual, weight}));
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(input);
+  CHECK_INPUT(residual);
+  CHECK_INPUT(weight);
+  CHECK_DIM(2, input);
+  CHECK_DIM(2, residual);
+  CHECK_DIM(1, weight);
+  CHECK_EQ(input.size(0), residual.size(0));
+  CHECK_EQ(input.size(1), residual.size(1));
+  CHECK_EQ(input.size(1), weight.size(0));
+  int64_t batch_size = input.size(0);
+  int64_t hidden_size = input.size(1);
+  int64_t num_threads = at::get_num_threads();
+  at::Tensor buffer = at::empty({num_threads, hidden_size}, input.options().dtype(at::kFloat));
+  // Clone input into output; kernel writes normalized result in-place to output
+  at::Tensor output = input.clone();
+  AT_DISPATCH_REDUCED_FLOATING_TYPES(input.scalar_type(), "fused_add_layernorm_kernel", [&] {
+    fused_add_layernorm_kernel_impl<scalar_t>(
+        output.data_ptr<scalar_t>(),
+        residual.data_ptr<scalar_t>(),
+        weight.data_ptr<scalar_t>(),
+        buffer.data_ptr<float>(),
+        batch_size,
+        hidden_size,
+        output.stride(0),
+        static_cast<float>(eps));
+  });
+  if (bias.has_value()) {
+    output.add_(bias.value());
+  }
+  return output;
+}
+
+#endif  // CPU_CAPABILITY_RVV

--- a/sgl-kernel/csrc/cpu/riscv64/rope.cpp
+++ b/sgl-kernel/csrc/cpu/riscv64/rope.cpp
@@ -1,0 +1,389 @@
+#if defined(CPU_CAPABILITY_RVV) && defined(__clang__)
+#pragma clang riscv intrinsic vector
+#endif
+
+#if defined(CPU_CAPABILITY_RVV)
+
+#include <cmath>
+#include <cstdint>
+
+#include "common.h"
+#include "riscv64/vector_helpers.h"
+
+namespace {
+
+// 3D kernel: non-neox, out-of-place (query_out, key_out)
+// query shape: [num_tokens, num_heads, head_size]
+// key shape:   [num_tokens, 1, head_size]  (num_kv_heads == 1)
+// Rotation: adjacent pairs (h, h+1) with cos[h/2], sin[h/2]
+// Cache layout: [cos(rotary_dim/2) | sin(rotary_dim/2)] per position
+template <typename scalar_t>
+void rotary_embedding_3D_kernel_impl(
+    scalar_t* __restrict__ query_out,
+    scalar_t* __restrict__ key_out,
+    int64_t* __restrict__ positions,
+    scalar_t* __restrict__ query,
+    scalar_t* __restrict__ key,
+    scalar_t* __restrict__ cos_sin_cache,
+    int64_t num_tokens,
+    int64_t num_heads,
+    int64_t head_size,
+    int64_t rotary_dim,
+    int64_t query_stride_s,
+    int64_t query_out_stride_s,
+    int64_t key_out_stride_s,
+    int64_t key_stride_s,
+    int64_t query_stride_h,
+    int64_t query_out_stride_h) {
+  int64_t embed_dim = rotary_dim / 2;
+  const ptrdiff_t stride = 2 * static_cast<ptrdiff_t>(sizeof(scalar_t));
+
+  at::parallel_for(0, num_tokens * num_heads, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t idx = begin; idx < end; ++idx) {
+      int64_t seq = idx / num_heads;
+      int64_t head_id = idx % num_heads;
+      // Scratch only used by generic scalar fallback in load/store helpers; dead for BF16/FP16.
+      alignas(64) float scratch[rvv_constants::MAX_VL_ELEMENTS_M4];
+      int64_t p = positions[seq];
+      scalar_t* cos_ptr = cos_sin_cache + p * rotary_dim;
+      scalar_t* sin_ptr = cos_ptr + embed_dim;
+
+      // Vectorized adjacent-pair rotation for query (out-of-place).
+      scalar_t* q_in = query + seq * query_stride_s + head_id * query_stride_h;
+      scalar_t* q_out = query_out + seq * query_out_stride_s + head_id * query_out_stride_h;
+      size_t vl = 0;
+      for (int64_t j = 0; j < embed_dim; j += static_cast<int64_t>(vl)) {
+        vl = __riscv_vsetvl_e32m4(embed_dim - j);
+        vfloat32m4_t v_cos = load_as_float_m4(cos_ptr + j, vl, scratch);
+        vfloat32m4_t v_sin = load_as_float_m4(sin_ptr + j, vl, scratch);
+        vfloat32m4_t v_x = load_strided_as_float_m4(q_in + 2 * j, stride, vl, scratch);
+        vfloat32m4_t v_y = load_strided_as_float_m4(q_in + 2 * j + 1, stride, vl, scratch);
+        vfloat32m4_t v_out_x = __riscv_vfmul_vv_f32m4(v_x, v_cos, vl);
+        v_out_x = __riscv_vfnmsac_vv_f32m4(v_out_x, v_y, v_sin, vl);
+        vfloat32m4_t v_out_y = __riscv_vfmul_vv_f32m4(v_y, v_cos, vl);
+        v_out_y = __riscv_vfmacc_vv_f32m4(v_out_y, v_x, v_sin, vl);
+        store_strided_from_float_m4(q_out + 2 * j, stride, v_out_x, vl, scratch);
+        store_strided_from_float_m4(q_out + 2 * j + 1, stride, v_out_y, vl, scratch);
+      }
+      // Copy non-rotated tail of query.
+      for (int64_t h = rotary_dim; h < head_size; ++h)
+        q_out[h] = q_in[h];
+
+      // Key has only 1 head in 3D layout (num_kv_heads == 1, enforced by CHECK_EQ).
+      // Only the first query head writes the key output to avoid redundant stores.
+      if (head_id == 0) {
+        scalar_t* k_in = key + seq * key_stride_s;
+        scalar_t* k_out = key_out + seq * key_out_stride_s;
+        size_t vl_k = 0;
+        for (int64_t j = 0; j < embed_dim; j += static_cast<int64_t>(vl_k)) {
+          vl_k = __riscv_vsetvl_e32m4(embed_dim - j);
+          vfloat32m4_t v_cos = load_as_float_m4(cos_ptr + j, vl_k, scratch);
+          vfloat32m4_t v_sin = load_as_float_m4(sin_ptr + j, vl_k, scratch);
+          vfloat32m4_t v_x = load_strided_as_float_m4(k_in + 2 * j, stride, vl_k, scratch);
+          vfloat32m4_t v_y = load_strided_as_float_m4(k_in + 2 * j + 1, stride, vl_k, scratch);
+          vfloat32m4_t v_out_x = __riscv_vfmul_vv_f32m4(v_x, v_cos, vl_k);
+          v_out_x = __riscv_vfnmsac_vv_f32m4(v_out_x, v_y, v_sin, vl_k);
+          vfloat32m4_t v_out_y = __riscv_vfmul_vv_f32m4(v_y, v_cos, vl_k);
+          v_out_y = __riscv_vfmacc_vv_f32m4(v_out_y, v_x, v_sin, vl_k);
+          store_strided_from_float_m4(k_out + 2 * j, stride, v_out_x, vl_k, scratch);
+          store_strided_from_float_m4(k_out + 2 * j + 1, stride, v_out_y, vl_k, scratch);
+        }
+        // Copy non-rotated tail of key.
+        for (int64_t h = rotary_dim; h < head_size; ++h)
+          k_out[h] = k_in[h];
+      }
+    }
+  });
+}
+
+// Neox 4D kernel: in-place
+// Paired indices: (j, embed_dim + j) — front half / back half
+// Cache layout: [cos(rotary_dim/2) | sin(rotary_dim/2)] per position
+template <typename scalar_t>
+void rotary_embedding_neox_4D_kernel_impl(
+    int64_t* __restrict__ positions,
+    scalar_t* __restrict__ query,
+    scalar_t* __restrict__ key,
+    scalar_t* __restrict__ cos_sin_cache,
+    int64_t rotary_dim,
+    int64_t query_stride_b,
+    int64_t query_stride_s,
+    int64_t query_stride_h,
+    int64_t key_stride_b,
+    int64_t key_stride_s,
+    int64_t key_stride_h,
+    int64_t num_heads,
+    int64_t num_kv_heads,
+    int64_t head_size,
+    int64_t batch_size,
+    int64_t seq_len) {
+  int64_t embed_dim = rotary_dim / 2;
+
+  // scratch is per-call-site (inside lambda) to avoid data race under OMP parallel
+  auto compute_head = [&](scalar_t* cache_ptr, scalar_t* qk, int64_t token_head) {
+    alignas(64) float scratch[rvv_constants::MAX_VL_ELEMENTS_M4];
+    size_t vl = 0;
+    for (int64_t j = 0; j < embed_dim; j += vl) {
+      vl = __riscv_vsetvl_e32m4(embed_dim - j);
+      int64_t x_index = j;
+      int64_t y_index = embed_dim + j;
+
+      // Load cos, sin from cache
+      vfloat32m4_t v_cos = load_as_float_m4(cache_ptr + x_index, vl, scratch);
+      vfloat32m4_t v_sin = load_as_float_m4(cache_ptr + y_index, vl, scratch);
+
+      // Load x (front half) and y (back half) of head
+      vfloat32m4_t v_x = load_as_float_m4(qk + token_head + x_index, vl, scratch);
+      vfloat32m4_t v_y = load_as_float_m4(qk + token_head + y_index, vl, scratch);
+
+      // out_x = x * cos - y * sin
+      vfloat32m4_t v_out_x = __riscv_vfmul_vv_f32m4(v_x, v_cos, vl);
+      v_out_x = __riscv_vfnmsac_vv_f32m4(v_out_x, v_y, v_sin, vl);
+
+      // out_y = y * cos + x * sin
+      vfloat32m4_t v_out_y = __riscv_vfmul_vv_f32m4(v_y, v_cos, vl);
+      v_out_y = __riscv_vfmacc_vv_f32m4(v_out_y, v_x, v_sin, vl);
+
+      store_from_float_m4(qk + token_head + x_index, v_out_x, vl, scratch);
+      store_from_float_m4(qk + token_head + y_index, v_out_y, vl, scratch);
+    }
+  };
+
+  at::parallel_for(0, batch_size * seq_len, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t idx = begin; idx < end; ++idx) {
+      int64_t bs = idx / seq_len;
+      int64_t seq = idx % seq_len;
+      int64_t pos = positions[bs * seq_len + seq];
+      scalar_t* cache_ptr = cos_sin_cache + pos * rotary_dim;
+
+      for (int64_t i = 0; i < num_heads; ++i) {
+        int64_t token_head = bs * query_stride_b + seq * query_stride_s + i * query_stride_h;
+        compute_head(cache_ptr, query, token_head);
+      }
+
+      for (int64_t i = 0; i < num_kv_heads; ++i) {
+        int64_t token_head = bs * key_stride_b + seq * key_stride_s + i * key_stride_h;
+        compute_head(cache_ptr, key, token_head);
+      }
+    }
+  });
+}
+// Non-neox 4D kernel: in-place
+// Paired indices: (2j, 2j+1) — adjacent pairs
+// Cache layout: [cos(rotary_dim/2) | sin(rotary_dim/2)] per position
+template <typename scalar_t>
+void rotary_embedding_4D_kernel_impl(
+    int64_t* __restrict__ positions,
+    scalar_t* __restrict__ query,
+    scalar_t* __restrict__ key,
+    scalar_t* __restrict__ cos_sin_cache,
+    int64_t rotary_dim,
+    int64_t query_stride_b,
+    int64_t query_stride_s,
+    int64_t query_stride_h,
+    int64_t key_stride_b,
+    int64_t key_stride_s,
+    int64_t key_stride_h,
+    int64_t num_heads,
+    int64_t num_kv_heads,
+    int64_t head_size,
+    int64_t batch_size,
+    int64_t seq_len) {
+  int64_t embed_dim = rotary_dim / 2;
+
+  // Vectorized adjacent-pair rotation using stride-2 load/store.
+  // cache_ptr points to [cos(rotary_dim/2) | sin(rotary_dim/2)] for the token's position.
+  // head_ptr points to the start of one head: layout [x0, y0, x1, y1, ...].
+  // stride = 2 * sizeof(scalar_t) so strided loads pick up every other element.
+  auto compute_head = [&](scalar_t* cache_ptr, scalar_t* head_ptr) {
+    alignas(64) float scratch[rvv_constants::MAX_VL_ELEMENTS_M4];
+    scalar_t* cos_ptr = cache_ptr;
+    scalar_t* sin_ptr = cache_ptr + embed_dim;
+    const ptrdiff_t stride = 2 * static_cast<ptrdiff_t>(sizeof(scalar_t));
+    size_t vl = 0;
+    for (int64_t j = 0; j < embed_dim; j += static_cast<int64_t>(vl)) {
+      vl = __riscv_vsetvl_e32m4(embed_dim - j);
+      vfloat32m4_t v_cos = load_as_float_m4(cos_ptr + j, vl, scratch);
+      vfloat32m4_t v_sin = load_as_float_m4(sin_ptr + j, vl, scratch);
+      // Stride-2 load: x = head[0,2,4,...], y = head[1,3,5,...]
+      vfloat32m4_t v_x = load_strided_as_float_m4(head_ptr + 2 * j, stride, vl, scratch);
+      vfloat32m4_t v_y = load_strided_as_float_m4(head_ptr + 2 * j + 1, stride, vl, scratch);
+
+      // out_x = x * cos - y * sin
+      vfloat32m4_t v_out_x = __riscv_vfmul_vv_f32m4(v_x, v_cos, vl);
+      v_out_x = __riscv_vfnmsac_vv_f32m4(v_out_x, v_y, v_sin, vl);
+      // out_y = y * cos + x * sin
+      vfloat32m4_t v_out_y = __riscv_vfmul_vv_f32m4(v_y, v_cos, vl);
+      v_out_y = __riscv_vfmacc_vv_f32m4(v_out_y, v_x, v_sin, vl);
+
+      store_strided_from_float_m4(head_ptr + 2 * j, stride, v_out_x, vl, scratch);
+      store_strided_from_float_m4(head_ptr + 2 * j + 1, stride, v_out_y, vl, scratch);
+    }
+  };
+
+  at::parallel_for(0, batch_size * seq_len, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t idx = begin; idx < end; ++idx) {
+      int64_t bs = idx / seq_len;
+      int64_t seq = idx % seq_len;
+      int64_t pos = positions[bs * seq_len + seq];
+      scalar_t* cache_ptr = cos_sin_cache + pos * rotary_dim;
+      for (int64_t i = 0; i < num_heads; ++i) {
+        int64_t token_head = bs * query_stride_b + seq * query_stride_s + i * query_stride_h;
+        compute_head(cache_ptr, query + token_head);
+      }
+      for (int64_t i = 0; i < num_kv_heads; ++i) {
+        int64_t token_head = bs * key_stride_b + seq * key_stride_s + i * key_stride_h;
+        compute_head(cache_ptr, key + token_head);
+      }
+    }
+  });
+}
+
+}  // namespace
+
+// Top-level dispatch: rotary_embedding_cpu
+std::tuple<at::Tensor, at::Tensor> rotary_embedding_cpu(
+    at::Tensor& positions,
+    at::Tensor& query,
+    at::Tensor& key,
+    int64_t head_size,
+    at::Tensor& cos_sin_cache,
+    bool is_neox) {
+  RECORD_FUNCTION("sgl-kernel::rotary_embedding_cpu", std::vector<c10::IValue>({query, key}));
+  CHECK_DIM(1, positions);
+  const auto input_dim = query.dim();
+  const auto input_dtype = query.scalar_type();
+  TORCH_CHECK(
+      input_dim == 2 || input_dim == 3 || input_dim == 4,
+      " Query/Key must be 2D [num_tokens, num_heads*head_size] or 3D [num_tokens, num_heads, head_size] or 4D "
+      "[batch_size, seq_len, num_heads, head_size] tensor");
+  CHECK_DIM(2, cos_sin_cache);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(query);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(key);
+
+  int64_t rotary_dim = cos_sin_cache.size(1);
+  TORCH_CHECK(rotary_dim % 2 == 0, "rotary_dim must be even, got ", rotary_dim);
+  if (input_dim == 3) {
+    TORCH_CHECK(
+        query.size(-1) >= rotary_dim,
+        "3D rotary: head_size (",
+        query.size(-1),
+        ") must be >= rotary_dim (",
+        rotary_dim,
+        ")");
+    CHECK_EQ(key.size(1), 1);
+  }
+
+  int64_t num_tokens = positions.numel();
+  if (input_dim <= 3) {
+    CHECK_EQ(key.size(0), num_tokens);
+    CHECK_EQ(query.size(0), num_tokens);
+  }
+
+  TORCH_CHECK(positions.scalar_type() == at::kLong, "expect positions to be int64, got ", positions.scalar_type());
+  TORCH_CHECK(input_dtype == key.scalar_type(), "query and key must have the same data type");
+  TORCH_CHECK(input_dtype == cos_sin_cache.scalar_type(), "query and cos_sin_cache must have the same data type");
+
+  int64_t num_heads = input_dim == 2 ? query.size(-1) / head_size : query.size(-2);
+  int64_t num_kv_heads = input_dim == 2 ? key.size(-1) / head_size : key.size(-2);
+  int64_t key_stride_s = key.stride(0);
+  int64_t query_stride_s = query.stride(0);
+
+  int64_t query_stride_h = input_dim == 2 ? head_size : query.stride(-2);
+  int64_t key_stride_h = input_dim == 2 ? head_size : key.stride(-2);
+  // Output tensors: allocated here only for the 3D out-of-place path.
+  // 2D/4D in-place paths reassign query_out/key_out to the input tensors inside the dispatch.
+  at::Tensor query_out, key_out;
+  int64_t query_out_stride_s = 0, key_out_stride_s = 0, query_out_stride_h = 0;
+  if (input_dim == 3) {
+    query_out = at::empty_like(query);
+    key_out = at::empty_like(key);
+    query_out_stride_s = query_out.stride(0);
+    key_out_stride_s = key_out.stride(0);
+    query_out_stride_h = query_out.stride(1);
+  }
+  int64_t batch_size = 1;
+  int64_t seq_len = num_tokens;
+  int64_t query_stride_b = 0;
+  int64_t key_stride_b = 0;
+  if (input_dim == 4) {
+    batch_size = query.size(0);
+    seq_len = query.size(1);
+    query_stride_b = query.stride(0);
+    key_stride_b = key.stride(0);
+    query_stride_s = query.stride(1);
+    key_stride_s = key.stride(1);
+    CHECK_EQ(batch_size, key.size(0));
+    CHECK_EQ(seq_len, key.size(1));
+    CHECK_EQ(key.size(0) * key.size(1), num_tokens);
+    CHECK_EQ(query.size(0) * query.size(1), num_tokens);
+  }
+
+  AT_DISPATCH_REDUCED_FLOATING_TYPES(input_dtype, "rotary_embedding_cpu", [&] {
+    if (input_dim == 2 || input_dim == 4) {
+      if (is_neox) {
+        rotary_embedding_neox_4D_kernel_impl<scalar_t>(
+            positions.data_ptr<int64_t>(),
+            query.data_ptr<scalar_t>(),
+            key.data_ptr<scalar_t>(),
+            cos_sin_cache.data_ptr<scalar_t>(),
+            rotary_dim,
+            query_stride_b,
+            query_stride_s,
+            query_stride_h,
+            key_stride_b,
+            key_stride_s,
+            key_stride_h,
+            num_heads,
+            num_kv_heads,
+            head_size,
+            batch_size,
+            seq_len);
+      } else {
+        rotary_embedding_4D_kernel_impl<scalar_t>(
+            positions.data_ptr<int64_t>(),
+            query.data_ptr<scalar_t>(),
+            key.data_ptr<scalar_t>(),
+            cos_sin_cache.data_ptr<scalar_t>(),
+            rotary_dim,
+            query_stride_b,
+            query_stride_s,
+            query_stride_h,
+            key_stride_b,
+            key_stride_s,
+            key_stride_h,
+            num_heads,
+            num_kv_heads,
+            head_size,
+            batch_size,
+            seq_len);
+      }
+      query_out = query;
+      key_out = key;
+
+    } else {
+      TORCH_CHECK(
+          is_neox == false, " Query/Key with 3D [num_tokens, num_heads, head_size] does not support neox rope yet");
+      rotary_embedding_3D_kernel_impl<scalar_t>(
+          query_out.data_ptr<scalar_t>(),
+          key_out.data_ptr<scalar_t>(),
+          positions.data_ptr<int64_t>(),
+          query.data_ptr<scalar_t>(),
+          key.data_ptr<scalar_t>(),
+          cos_sin_cache.data_ptr<scalar_t>(),
+          num_tokens,
+          num_heads,
+          head_size,
+          rotary_dim,
+          query_stride_s,
+          query_out_stride_s,
+          key_out_stride_s,
+          key_stride_s,
+          query_stride_h,
+          query_out_stride_h);
+    }
+  });
+  return std::make_tuple(query_out, key_out);
+}
+
+#endif  // CPU_CAPABILITY_RVV

--- a/sgl-kernel/csrc/cpu/riscv64/torch_extension_riscv64.cpp
+++ b/sgl-kernel/csrc/cpu/riscv64/torch_extension_riscv64.cpp
@@ -13,7 +13,7 @@
 #include "sgl_kernel_ops.h"
 
 // silu_and_mul
-at::Tensor silu_and_mul_cpu(at::Tensor& input);
+at::Tensor silu_and_mul_cpu(const at::Tensor& input);
 
 // gelu_and_mul
 at::Tensor gelu_tanh_and_mul_cpu(const at::Tensor& input);
@@ -147,14 +147,16 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.def("gemma_fused_add_rmsnorm_cpu(Tensor(a!) input, Tensor(a!) residual, Tensor weight, float eps) -> ()");
   m.impl("gemma_fused_add_rmsnorm_cpu", torch::kCPU, &gemma_fused_add_rmsnorm_cpu);
   m.def(
-      "fused_add_layernorm_cpu(Tensor input, Tensor residual, Tensor weight, Tensor? bias, float eps) -> "
+      "fused_add_layernorm_cpu(Tensor input, Tensor(a!) residual, Tensor weight, Tensor? bias, float eps) -> "
       "Tensor");
   m.impl("fused_add_layernorm_cpu", torch::kCPU, &fused_add_layernorm_cpu);
 
   // decode
   m.def(
-      "decode_attention_cpu(Tensor query, Tensor k_cache, Tensor v_cache, Tensor(a!) output, Tensor key, Tensor value, "
-      "Tensor loc, Tensor attn_logits, Tensor req_to_token, Tensor req_pool_indices, Tensor seq_lens, float sm_scale, "
+      "decode_attention_cpu(Tensor query, Tensor(a!) k_cache, Tensor(a!) v_cache, Tensor(a!) output, Tensor key, "
+      "Tensor value, "
+      "Tensor loc, Tensor(a!) attn_logits, Tensor req_to_token, Tensor req_pool_indices, Tensor seq_lens, float "
+      "sm_scale, "
       "float logit_cap) -> ()");
   m.impl("decode_attention_cpu", torch::kCPU, &decode_attention_cpu);
 

--- a/sgl-kernel/csrc/cpu/riscv64/torch_extension_riscv64.cpp
+++ b/sgl-kernel/csrc/cpu/riscv64/torch_extension_riscv64.cpp
@@ -1,0 +1,203 @@
+#if defined(CPU_CAPABILITY_RVV) && defined(__clang__)
+#if defined(RVV_HAS_ZVFH)
+#pragma clang attribute push(__attribute__((target("arch=+v,+zvfh"))), apply_to = function)
+#else
+#pragma clang attribute push(__attribute__((target("arch=+v"))), apply_to = function)
+#endif
+#endif
+
+#include <ATen/ATen.h>
+#include <torch/all.h>
+#include <torch/library.h>
+
+#include "sgl_kernel_ops.h"
+
+// silu_and_mul
+at::Tensor silu_and_mul_cpu(at::Tensor& input);
+
+// gelu_and_mul
+at::Tensor gelu_tanh_and_mul_cpu(const at::Tensor& input);
+at::Tensor gelu_and_mul_cpu(const at::Tensor& input);
+
+// l2norm
+at::Tensor l2norm_cpu(at::Tensor& input, double eps);
+
+// rmsnorm
+at::Tensor rmsnorm_cpu(at::Tensor& input, at::Tensor& weight, double eps);
+at::Tensor gemma_rmsnorm_cpu(at::Tensor& input, at::Tensor& weight, double eps);
+at::Tensor gemma3_rmsnorm_cpu(at::Tensor& input, at::Tensor& weight, double eps);
+
+// layernorm
+at::Tensor
+layernorm_cpu(const at::Tensor& input, const at::Tensor& weight, const std::optional<at::Tensor>& bias, double eps);
+
+// fused_rmsnorm_gated
+at::Tensor fused_rmsnorm_gated_cpu(at::Tensor& input, at::Tensor& weight, at::Tensor& gate, double eps);
+
+// fused_add_rmsnorm
+void fused_add_rmsnorm_cpu(at::Tensor& input, at::Tensor& residual, at::Tensor& weight, double eps);
+void gemma_fused_add_rmsnorm_cpu(at::Tensor& input, at::Tensor& residual, at::Tensor& weight, double eps);
+
+// fused_add_layernorm
+at::Tensor fused_add_layernorm_cpu(
+    const at::Tensor& input,
+    at::Tensor& residual,
+    const at::Tensor& weight,
+    const std::optional<at::Tensor>& bias,
+    double eps);
+
+// decode attention
+void decode_attention_cpu(
+    at::Tensor& query,
+    at::Tensor& k_cache,
+    at::Tensor& v_cache,
+    at::Tensor& output,
+    at::Tensor& key,
+    at::Tensor& value,
+    at::Tensor& loc,
+    at::Tensor& attn_logits,
+    at::Tensor& req_to_token,
+    at::Tensor& req_pool_indices,
+    at::Tensor& seq_lens,
+    double sm_scale,
+    double logit_cap);
+
+// extend attention
+void extend_attention_cpu(
+    at::Tensor& q_extend,
+    at::Tensor& k_extend,
+    at::Tensor& v_extend,
+    at::Tensor& o_extend,
+    at::Tensor& k_buffer,
+    at::Tensor& v_buffer,
+    at::Tensor& req_to_token,
+    at::Tensor& req_pool_indices,
+    at::Tensor& seq_lens,
+    at::Tensor& extend_seq_lens,
+    at::Tensor& extend_start_loc,
+    int64_t max_len_extend,
+    double sm_scale,
+    double logit_cap);
+
+// weight prepack
+at::Tensor convert_weight_packed(at::Tensor& weight);
+
+// quant
+std::tuple<at::Tensor, at::Tensor> per_token_quant_int8_cpu(at::Tensor& A);
+
+// gemm
+at::Tensor
+weight_packed_linear(at::Tensor& mat1, at::Tensor& mat2, const std::optional<at::Tensor>& bias, bool is_packed);
+
+// igemm
+at::Tensor int8_scaled_mm_cpu(
+    at::Tensor& mat1,
+    at::Tensor& mat2,
+    at::Tensor& scales1,
+    at::Tensor& scales2,
+    const std::optional<at::Tensor>& bias,
+    at::ScalarType out_dtype,
+    bool is_packed);
+
+// quant + igemm
+at::Tensor int8_scaled_mm_with_quant(
+    at::Tensor& mat1,
+    at::Tensor& mat2,
+    at::Tensor& scales2,
+    const std::optional<at::Tensor>& bias,
+    at::ScalarType out_dtype,
+    bool is_packed);
+
+// rope
+std::tuple<at::Tensor, at::Tensor> rotary_embedding_cpu(
+    at::Tensor& positions,
+    at::Tensor& query,
+    at::Tensor& key,
+    int64_t head_size,
+    at::Tensor& cos_sin_cache,
+    bool is_neox);
+
+// [NOTE] When registering kernels, we should accurately describe the in-place information.
+// Taking fused_add_rmsnorm_cpu as an example, add `Tensor(a!)` modifier to all tensors that
+// will be modified in-place to avoid incorrect fusing and execution order on graph mode.
+TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
+  // activation
+  m.def("silu_and_mul_cpu(Tensor input) -> Tensor");
+  m.impl("silu_and_mul_cpu", torch::kCPU, &silu_and_mul_cpu);
+  m.def("gelu_tanh_and_mul_cpu(Tensor input) -> Tensor");
+  m.impl("gelu_tanh_and_mul_cpu", torch::kCPU, &gelu_tanh_and_mul_cpu);
+  m.def("gelu_and_mul_cpu(Tensor input) -> Tensor");
+  m.impl("gelu_and_mul_cpu", torch::kCPU, &gelu_and_mul_cpu);
+
+  // norm
+  m.def("rmsnorm_cpu(Tensor input, Tensor weight, float eps) -> Tensor");
+  m.impl("rmsnorm_cpu", torch::kCPU, &rmsnorm_cpu);
+  m.def("gemma_rmsnorm_cpu(Tensor input, Tensor weight, float eps) -> Tensor");
+  m.impl("gemma_rmsnorm_cpu", torch::kCPU, &gemma_rmsnorm_cpu);
+  m.def("gemma3_rmsnorm_cpu(Tensor input, Tensor weight, float eps) -> Tensor");
+  m.impl("gemma3_rmsnorm_cpu", torch::kCPU, &gemma3_rmsnorm_cpu);
+  m.def("layernorm_cpu(Tensor input, Tensor weight, Tensor? bias, float eps) -> Tensor");
+  m.impl("layernorm_cpu", torch::kCPU, &layernorm_cpu);
+  m.def("l2norm_cpu(Tensor input, float eps) -> Tensor");
+  m.impl("l2norm_cpu", torch::kCPU, &l2norm_cpu);
+  m.def("fused_rmsnorm_gated_cpu(Tensor input, Tensor weight, Tensor gate, float eps) -> Tensor");
+  m.impl("fused_rmsnorm_gated_cpu", torch::kCPU, &fused_rmsnorm_gated_cpu);
+  m.def("fused_add_rmsnorm_cpu(Tensor(a!) input, Tensor(a!) residual, Tensor weight, float eps) -> ()");
+  m.impl("fused_add_rmsnorm_cpu", torch::kCPU, &fused_add_rmsnorm_cpu);
+  m.def("gemma_fused_add_rmsnorm_cpu(Tensor(a!) input, Tensor(a!) residual, Tensor weight, float eps) -> ()");
+  m.impl("gemma_fused_add_rmsnorm_cpu", torch::kCPU, &gemma_fused_add_rmsnorm_cpu);
+  m.def(
+      "fused_add_layernorm_cpu(Tensor input, Tensor residual, Tensor weight, Tensor? bias, float eps) -> "
+      "Tensor");
+  m.impl("fused_add_layernorm_cpu", torch::kCPU, &fused_add_layernorm_cpu);
+
+  // decode
+  m.def(
+      "decode_attention_cpu(Tensor query, Tensor k_cache, Tensor v_cache, Tensor(a!) output, Tensor key, Tensor value, "
+      "Tensor loc, Tensor attn_logits, Tensor req_to_token, Tensor req_pool_indices, Tensor seq_lens, float sm_scale, "
+      "float logit_cap) -> ()");
+  m.impl("decode_attention_cpu", torch::kCPU, &decode_attention_cpu);
+
+  // extend
+  m.def(
+      "extend_attention_cpu(Tensor q_extend, Tensor k_extend, Tensor v_extend, Tensor(a!) o_extend, Tensor k_buffer, "
+      "Tensor v_buffer, Tensor req_to_token, Tensor req_pool_indices, Tensor seq_lens, Tensor extend_seq_lens, Tensor "
+      "extend_start_loc, int max_len_extend, float sm_scale, float logit_cap) -> ()");
+  m.impl("extend_attention_cpu", torch::kCPU, &extend_attention_cpu);
+
+  // weight prepack
+  m.def("convert_weight_packed(Tensor weight) -> Tensor");
+  m.impl("convert_weight_packed", torch::kCPU, &convert_weight_packed);
+
+  // quant
+  m.def("per_token_quant_int8_cpu(Tensor A) -> (Tensor, Tensor)");
+  m.impl("per_token_quant_int8_cpu", torch::kCPU, &per_token_quant_int8_cpu);
+
+  // gemm
+  m.def("weight_packed_linear(Tensor mat1, Tensor mat2, Tensor? bias, bool is_packed) -> Tensor");
+  m.impl("weight_packed_linear", torch::kCPU, &weight_packed_linear);
+
+  // igemm
+  m.def(
+      "int8_scaled_mm_cpu(Tensor mat1, Tensor mat2, Tensor scales1, Tensor scales2, Tensor? bias, ScalarType "
+      "out_dtype, bool is_packed) -> Tensor");
+  m.impl("int8_scaled_mm_cpu", torch::kCPU, &int8_scaled_mm_cpu);
+
+  // quant + igemm
+  m.def(
+      "int8_scaled_mm_with_quant(Tensor mat1, Tensor mat2, Tensor scales2, Tensor? bias, ScalarType out_dtype, bool "
+      "is_packed) -> Tensor");
+  m.impl("int8_scaled_mm_with_quant", torch::kCPU, &int8_scaled_mm_with_quant);
+
+  // rope
+  m.def(
+      "rotary_embedding_cpu(Tensor positions, Tensor query, Tensor key, int head_size, Tensor cos_sin_cache, "
+      "bool is_neox) -> (Tensor, Tensor)");
+  m.impl("rotary_embedding_cpu", torch::kCPU, &rotary_embedding_cpu);
+}
+
+#if defined(CPU_CAPABILITY_RVV) && defined(__clang__)
+#pragma clang attribute pop
+#endif
+
+REGISTER_EXTENSION(common_ops)

--- a/sgl-kernel/csrc/cpu/riscv64/vector_helpers.h
+++ b/sgl-kernel/csrc/cpu/riscv64/vector_helpers.h
@@ -1,0 +1,643 @@
+#pragma once
+
+#if defined(CPU_CAPABILITY_RVV)
+
+#include <c10/util/Half.h>
+#include <riscv_vector.h>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+#include "vector_math.h"
+
+namespace rvv_constants {
+// BLOCK_N = VLEN/4: weight packing tile size; each tile spans 2 vector iterations (m4).
+inline constexpr int BLOCK_N = __riscv_v_fixed_vlen / 4;
+// MAX_VL_ELEMENTS_M{4,8}: compile-time max VL for LMUL=4 and LMUL=8
+inline constexpr size_t MAX_VL_ELEMENTS_M4 = __riscv_v_fixed_vlen / 8;
+inline constexpr size_t MAX_VL_ELEMENTS_M8 = __riscv_v_fixed_vlen / 4;
+// L1 cache size for K-tiling. Set by -DRVV_L1_CACHE_KB=N at cmake time (default 32KB).
+// K-tile KB is derived as: L1_CACHE_BYTES * multiplier / VLEN
+#ifndef RVV_L1_CACHE_KB
+#define RVV_L1_CACHE_KB 32
+#endif
+inline constexpr int64_t L1_CACHE_BYTES = static_cast<int64_t>(RVV_L1_CACHE_KB) * 1024;
+}  // namespace rvv_constants
+
+// Fixed-width vector type: width follows __riscv_v_fixed_vlen (set at compile time via -mrvv-vector-bits=N).
+// Enables stack arrays of vector type (e.g., vf32m1_t arr[N]) in kernels that need them.
+typedef vfloat32m1_t vf32m1_t __attribute__((riscv_rvv_vector_bits(__riscv_v_fixed_vlen)));
+
+#ifndef MAX_HEAD_SIZE
+#define MAX_HEAD_SIZE 256
+#endif
+
+#define AT_DISPATCH_RVV_TYPES(TYPE, NAME, ...)                         \
+  [&] {                                                                \
+    at::ScalarType _st = TYPE;                                         \
+    switch (_st) {                                                     \
+      case at::ScalarType::Float: {                                    \
+        using scalar_t = float;                                        \
+        return __VA_ARGS__();                                          \
+      }                                                                \
+      case at::ScalarType::Half: {                                     \
+        using scalar_t = at::Half;                                     \
+        return __VA_ARGS__();                                          \
+      }                                                                \
+      case at::ScalarType::BFloat16: {                                 \
+        using scalar_t = at::BFloat16;                                 \
+        return __VA_ARGS__();                                          \
+      }                                                                \
+      default:                                                         \
+        AT_ERROR(#NAME, " not implemented for '", toString(_st), "'"); \
+    }                                                                  \
+  }()
+
+// Dispatch macro for packed types
+#define CPU_DISPATCH_PACKED_TYPES_RVV(TYPE, ...)                 \
+  [&] {                                                          \
+    switch (TYPE) {                                              \
+      case at::ScalarType::BFloat16: {                           \
+        using packed_t = at::BFloat16;                           \
+        return __VA_ARGS__();                                    \
+      }                                                          \
+      case at::ScalarType::Half: {                               \
+        using packed_t = at::Half;                               \
+        return __VA_ARGS__();                                    \
+      }                                                          \
+      case at::ScalarType::Char: {                               \
+        using packed_t = int8_t;                                 \
+        return __VA_ARGS__();                                    \
+      }                                                          \
+      default:                                                   \
+        TORCH_CHECK(false, "Unsupported floating data type.\n"); \
+    }                                                            \
+  }()
+
+// Type Conversion Helpers
+
+// BF16 to FP32
+// Shift-widening: BF16 and FP32 share exponent field, left-shift by 16 bits
+
+inline vfloat32m1_t bf16_to_f32m1(const uint16_t* ptr, size_t vl) {
+  vuint16mf2_t v_bf16 = __riscv_vle16_v_u16mf2(ptr, vl);
+  vuint32m1_t v_u32 = __riscv_vzext_vf2_u32m1(v_bf16, vl);
+  v_u32 = __riscv_vsll_vx_u32m1(v_u32, 16, vl);
+  return __riscv_vreinterpret_v_u32m1_f32m1(v_u32);
+}
+
+inline vfloat32m4_t bf16_to_f32m4(const uint16_t* ptr, size_t vl) {
+  vuint16m2_t v_bf16 = __riscv_vle16_v_u16m2(ptr, vl);
+  vuint32m4_t v_u32 = __riscv_vzext_vf2_u32m4(v_bf16, vl);
+  v_u32 = __riscv_vsll_vx_u32m4(v_u32, 16, vl);
+  return __riscv_vreinterpret_v_u32m4_f32m4(v_u32);
+}
+
+inline vfloat32m8_t bf16_to_f32m8(const uint16_t* ptr, size_t vl) {
+  vuint16m4_t v_bf16 = __riscv_vle16_v_u16m4(ptr, vl);
+  vuint32m8_t v_u32 = __riscv_vzext_vf2_u32m8(v_bf16, vl);
+  v_u32 = __riscv_vsll_vx_u32m8(v_u32, 16, vl);
+  return __riscv_vreinterpret_v_u32m8_f32m8(v_u32);
+}
+
+// FP32 to BF16
+// Extract upper 16 bits (sign + exp + upper 7 mantissa)
+
+#if defined(__riscv_zvfh)
+inline vfloat16m2_t f32m4_to_f16(vfloat32m4_t v, size_t vl) {
+  return __riscv_vfncvt_f_f_w_f16m2(v, vl);
+}
+#endif
+
+inline vuint16m2_t f32m4_to_bf16(vfloat32m4_t v_f32, size_t vl) {
+  vuint32m4_t v_u32 = __riscv_vreinterpret_v_f32m4_u32m4(v_f32);
+  return __riscv_vnsrl_wx_u16m2(v_u32, 16, vl);
+}
+
+inline vuint16m4_t f32m8_to_bf16(vfloat32m8_t v_f32, size_t vl) {
+  vuint32m8_t v_u32 = __riscv_vreinterpret_v_f32m8_u32m8(v_f32);
+  return __riscv_vnsrl_wx_u16m4(v_u32, 16, vl);
+}
+
+// Load / Store Helpers
+// scratch: caller-owned buffer (MIN MAX_VL_ELEMENTS_M4 floats, 64-byte aligned) used as a temporary store in scalar
+// fallback paths when Zvfh is absent.
+
+template <typename scalar_t>
+inline vfloat32m1_t load_as_float_m1(const scalar_t* ptr, size_t vl, float* scratch) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    return __riscv_vle32_v_f32m1(ptr, vl);
+  } else if constexpr (std::is_same_v<scalar_t, at::Half>) {
+#if defined(__riscv_zvfh)
+    vfloat16mf2_t v_f16 = __riscv_vle16_v_f16mf2(reinterpret_cast<const _Float16*>(ptr), vl);
+    return __riscv_vfwcvt_f_f_v_f32m1(v_f16, vl);
+#else
+    for (size_t i = 0; i < vl; ++i)
+      scratch[i] = static_cast<float>(ptr[i]);
+    return __riscv_vle32_v_f32m1(scratch, vl);
+#endif
+  } else if constexpr (std::is_same_v<scalar_t, at::BFloat16>) {
+    return bf16_to_f32m1(reinterpret_cast<const uint16_t*>(ptr), vl);
+  } else {
+    for (size_t i = 0; i < vl; ++i)
+      scratch[i] = static_cast<float>(ptr[i]);
+    return __riscv_vle32_v_f32m1(scratch, vl);
+  }
+}
+
+template <typename scalar_t>
+inline vfloat32m4_t load_as_float_m4(const scalar_t* ptr, size_t vl, float* scratch) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    return __riscv_vle32_v_f32m4(ptr, vl);
+  } else if constexpr (std::is_same_v<scalar_t, at::Half>) {
+#if defined(__riscv_zvfh)
+    vfloat16m2_t v_f16 = __riscv_vle16_v_f16m2(reinterpret_cast<const _Float16*>(ptr), vl);
+    return __riscv_vfwcvt_f_f_v_f32m4(v_f16, vl);
+#else
+    for (size_t i = 0; i < vl; ++i)
+      scratch[i] = static_cast<float>(ptr[i]);
+    return __riscv_vle32_v_f32m4(scratch, vl);
+#endif
+  } else if constexpr (std::is_same_v<scalar_t, at::BFloat16>) {
+    return bf16_to_f32m4(reinterpret_cast<const uint16_t*>(ptr), vl);
+  } else {
+    for (size_t i = 0; i < vl; ++i)
+      scratch[i] = static_cast<float>(ptr[i]);
+    return __riscv_vle32_v_f32m4(scratch, vl);
+  }
+}
+
+template <typename scalar_t>
+inline vfloat32m8_t load_as_float_m8(const scalar_t* ptr, size_t vl, float* scratch) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    return __riscv_vle32_v_f32m8(ptr, vl);
+  } else if constexpr (std::is_same_v<scalar_t, at::Half>) {
+#if defined(__riscv_zvfh)
+    vfloat16m4_t v_f16 = __riscv_vle16_v_f16m4(reinterpret_cast<const _Float16*>(ptr), vl);
+    return __riscv_vfwcvt_f_f_v_f32m8(v_f16, vl);
+#else
+    for (size_t i = 0; i < vl; ++i)
+      scratch[i] = static_cast<float>(ptr[i]);
+    return __riscv_vle32_v_f32m8(scratch, vl);
+#endif
+  } else if constexpr (std::is_same_v<scalar_t, at::BFloat16>) {
+    return bf16_to_f32m8(reinterpret_cast<const uint16_t*>(ptr), vl);
+  } else {
+    for (size_t i = 0; i < vl; ++i)
+      scratch[i] = static_cast<float>(ptr[i]);
+    return __riscv_vle32_v_f32m8(scratch, vl);
+  }
+}
+
+template <typename scalar_t>
+inline vfloat32m4_t load_strided_as_float_m4(const scalar_t* ptr, ptrdiff_t stride_byte, size_t vl, float* scratch) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    return __riscv_vlse32_v_f32m4(ptr, stride_byte, vl);
+  } else if constexpr (std::is_same_v<scalar_t, at::Half>) {
+#if defined(__riscv_zvfh)
+    vfloat16m2_t v_f16 = __riscv_vlse16_v_f16m2(reinterpret_cast<const _Float16*>(ptr), stride_byte, vl);
+    return __riscv_vfwcvt_f_f_v_f32m4(v_f16, vl);
+#else
+    for (size_t i = 0; i < vl; ++i) {
+      const scalar_t* elem_ptr =
+          reinterpret_cast<const scalar_t*>(reinterpret_cast<const char*>(ptr) + i * stride_byte);
+      scratch[i] = static_cast<float>(*elem_ptr);
+    }
+    return __riscv_vle32_v_f32m4(scratch, vl);
+#endif
+  } else if constexpr (std::is_same_v<scalar_t, at::BFloat16>) {
+    // Manual strided load + convert for BF16
+    vuint16m2_t v_bf16 = __riscv_vlse16_v_u16m2(reinterpret_cast<const uint16_t*>(ptr), stride_byte, vl);
+    vuint32m4_t v_u32 = __riscv_vzext_vf2_u32m4(v_bf16, vl);
+    v_u32 = __riscv_vsll_vx_u32m4(v_u32, 16, vl);
+    return __riscv_vreinterpret_v_u32m4_f32m4(v_u32);
+  } else {
+    for (size_t i = 0; i < vl; ++i) {
+      const scalar_t* elem_ptr =
+          reinterpret_cast<const scalar_t*>(reinterpret_cast<const char*>(ptr) + i * stride_byte);
+      scratch[i] = static_cast<float>(*elem_ptr);
+    }
+    return __riscv_vle32_v_f32m4(scratch, vl);
+  }
+}
+
+template <typename scalar_t>
+inline void
+store_strided_from_float_m4(scalar_t* ptr, ptrdiff_t stride_byte, vfloat32m4_t v, size_t vl, float* scratch) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    __riscv_vsse32_v_f32m4(ptr, stride_byte, v, vl);
+  } else if constexpr (std::is_same_v<scalar_t, at::Half>) {
+#if defined(__riscv_zvfh)
+    vfloat16m2_t v_f16 = __riscv_vfncvt_f_f_w_f16m2(v, vl);
+    __riscv_vsse16_v_f16m2(reinterpret_cast<_Float16*>(ptr), stride_byte, v_f16, vl);
+#else
+    __riscv_vse32_v_f32m4(scratch, v, vl);
+    for (size_t i = 0; i < vl; ++i) {
+      scalar_t* elem = reinterpret_cast<scalar_t*>(reinterpret_cast<char*>(ptr) + i * stride_byte);
+      *elem = static_cast<scalar_t>(scratch[i]);
+    }
+#endif
+  } else if constexpr (std::is_same_v<scalar_t, at::BFloat16>) {
+    vuint16m2_t v_bf16 = f32m4_to_bf16(v, vl);
+    __riscv_vsse16_v_u16m2(reinterpret_cast<uint16_t*>(ptr), stride_byte, v_bf16, vl);
+  } else {
+    __riscv_vse32_v_f32m4(scratch, v, vl);
+    for (size_t i = 0; i < vl; ++i) {
+      scalar_t* elem = reinterpret_cast<scalar_t*>(reinterpret_cast<char*>(ptr) + i * stride_byte);
+      *elem = static_cast<scalar_t>(scratch[i]);
+    }
+  }
+}
+
+template <typename scalar_t>
+inline void store_from_float_m1(scalar_t* ptr, vfloat32m1_t v, size_t vl, float* scratch) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    __riscv_vse32_v_f32m1(ptr, v, vl);
+  } else if constexpr (std::is_same_v<scalar_t, at::Half>) {
+#if defined(__riscv_zvfh)
+    vfloat16mf2_t v_f16 = __riscv_vfncvt_f_f_w_f16mf2(v, vl);
+    __riscv_vse16_v_f16mf2(reinterpret_cast<_Float16*>(ptr), v_f16, vl);
+#else
+    __riscv_vse32_v_f32m1(scratch, v, vl);
+    for (size_t i = 0; i < vl; ++i)
+      ptr[i] = static_cast<scalar_t>(scratch[i]);
+#endif
+  } else if constexpr (std::is_same_v<scalar_t, at::BFloat16>) {
+    vuint32m1_t v_u32 = __riscv_vreinterpret_v_f32m1_u32m1(v);
+    vuint16mf2_t v_bf16 = __riscv_vnsrl_wx_u16mf2(v_u32, 16, vl);
+    __riscv_vse16_v_u16mf2(reinterpret_cast<uint16_t*>(ptr), v_bf16, vl);
+  } else {
+    __riscv_vse32_v_f32m1(scratch, v, vl);
+    for (size_t i = 0; i < vl; ++i)
+      ptr[i] = static_cast<scalar_t>(scratch[i]);
+  }
+}
+
+template <typename scalar_t>
+inline void store_from_float_m2(scalar_t* ptr, vfloat32m2_t v, size_t vl, float* scratch) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    __riscv_vse32_v_f32m2(ptr, v, vl);
+  } else if constexpr (std::is_same_v<scalar_t, at::Half>) {
+#if defined(__riscv_zvfh)
+    vfloat16m1_t v_f16 = __riscv_vfncvt_f_f_w_f16m1(v, vl);
+    __riscv_vse16_v_f16m1(reinterpret_cast<_Float16*>(ptr), v_f16, vl);
+#else
+    __riscv_vse32_v_f32m2(scratch, v, vl);
+    for (size_t i = 0; i < vl; ++i)
+      ptr[i] = static_cast<scalar_t>(scratch[i]);
+#endif
+  } else if constexpr (std::is_same_v<scalar_t, at::BFloat16>) {
+    vuint32m2_t v_u32 = __riscv_vreinterpret_v_f32m2_u32m2(v);
+    vuint16m1_t v_bf16 = __riscv_vnsrl_wx_u16m1(v_u32, 16, vl);
+    __riscv_vse16_v_u16m1(reinterpret_cast<uint16_t*>(ptr), v_bf16, vl);
+  } else {
+    __riscv_vse32_v_f32m2(scratch, v, vl);
+    for (size_t i = 0; i < vl; ++i)
+      ptr[i] = static_cast<scalar_t>(scratch[i]);
+  }
+}
+
+template <typename scalar_t>
+inline void store_from_float_m4(scalar_t* ptr, vfloat32m4_t v, size_t vl, float* scratch) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    __riscv_vse32_v_f32m4(ptr, v, vl);
+  } else if constexpr (std::is_same_v<scalar_t, at::Half>) {
+#if defined(__riscv_zvfh)
+    vfloat16m2_t v_f16 = __riscv_vfncvt_f_f_w_f16m2(v, vl);
+    __riscv_vse16_v_f16m2(reinterpret_cast<_Float16*>(ptr), v_f16, vl);
+#else
+    __riscv_vse32_v_f32m4(scratch, v, vl);
+    for (size_t i = 0; i < vl; ++i)
+      ptr[i] = static_cast<scalar_t>(scratch[i]);
+#endif
+  } else if constexpr (std::is_same_v<scalar_t, at::BFloat16>) {
+    vuint16m2_t v_bf16 = f32m4_to_bf16(v, vl);
+    __riscv_vse16_v_u16m2(reinterpret_cast<uint16_t*>(ptr), v_bf16, vl);
+  } else {
+    __riscv_vse32_v_f32m4(scratch, v, vl);
+    for (size_t i = 0; i < vl; ++i)
+      ptr[i] = static_cast<scalar_t>(scratch[i]);
+  }
+}
+
+template <typename scalar_t>
+inline void store_from_float_m8(scalar_t* ptr, vfloat32m8_t v, size_t vl, float* scratch) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    __riscv_vse32_v_f32m8(ptr, v, vl);
+  } else if constexpr (std::is_same_v<scalar_t, at::Half>) {
+#if defined(__riscv_zvfh)
+    vfloat16m4_t v_f16 = __riscv_vfncvt_f_f_w_f16m4(v, vl);
+    __riscv_vse16_v_f16m4(reinterpret_cast<_Float16*>(ptr), v_f16, vl);
+#else
+    __riscv_vse32_v_f32m8(scratch, v, vl);
+    for (size_t i = 0; i < vl; ++i)
+      ptr[i] = static_cast<scalar_t>(scratch[i]);
+#endif
+  } else if constexpr (std::is_same_v<scalar_t, at::BFloat16>) {
+    vuint16m4_t v_bf16 = f32m8_to_bf16(v, vl);
+    __riscv_vse16_v_u16m4(reinterpret_cast<uint16_t*>(ptr), v_bf16, vl);
+  } else {
+    __riscv_vse32_v_f32m8(scratch, v, vl);
+    for (size_t i = 0; i < vl; ++i)
+      ptr[i] = static_cast<scalar_t>(scratch[i]);
+  }
+}
+
+// Memory Operations (Copy, Fill, Transpose)
+
+template <typename scalar_t>
+inline void fill_stub(scalar_t* __restrict__ out, float val, int64_t size) {
+  size_t vl = 0;
+
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    for (int64_t d = 0; d < size; d += vl) {
+      vl = __riscv_vsetvl_e32m4(size - d);
+      vfloat32m4_t v_val = __riscv_vfmv_v_f_f32m4(val, vl);
+      __riscv_vse32_v_f32m4(out + d, v_val, vl);
+    }
+  } else if constexpr (std::is_same_v<scalar_t, at::Half>) {
+#if defined(__riscv_zvfh)
+    // FP16: use hardware narrowing convert
+    for (int64_t d = 0; d < size; d += vl) {
+      vl = __riscv_vsetvl_e16m2(size - d);
+      vfloat32m4_t v_f32 = __riscv_vfmv_v_f_f32m4(val, vl);
+      vfloat16m2_t v_f16 = __riscv_vfncvt_f_f_w_f16m2(v_f32, vl);
+      __riscv_vse16_v_f16m2(reinterpret_cast<_Float16*>(out + d), v_f16, vl);
+    }
+#else
+    const scalar_t hval = static_cast<scalar_t>(val);
+    for (int64_t d = 0; d < size; d += vl) {
+      vl = __riscv_vsetvl_e16m2(size - d);
+      for (size_t i = 0; i < vl; ++i)
+        out[d + i] = hval;
+    }
+#endif
+  } else if constexpr (std::is_same_v<scalar_t, at::BFloat16>) {
+    // BF16: use bit-shift method (BF16 is upper 16 bits of FP32)
+    for (int64_t d = 0; d < size; d += vl) {
+      vl = __riscv_vsetvl_e16m2(size - d);
+      vfloat32m4_t v_f32 = __riscv_vfmv_v_f_f32m4(val, vl);
+      vuint16m2_t v_bf16 = f32m4_to_bf16(v_f32, vl);
+      __riscv_vse16_v_u16m2(reinterpret_cast<uint16_t*>(out + d), v_bf16, vl);
+    }
+  } else if constexpr (std::is_same_v<scalar_t, int32_t>) {
+    // int32: used by MoE for sorted_ids, expert_ids, total_cnts
+    int32_t ival = static_cast<int32_t>(val);
+    for (int64_t d = 0; d < size; d += vl) {
+      vl = __riscv_vsetvl_e32m4(size - d);
+      vint32m4_t v_val = __riscv_vmv_v_x_i32m4(ival, vl);
+      __riscv_vse32_v_i32m4(out + d, v_val, vl);
+    }
+  }
+}
+
+// Copy Stub Functions - Multiple Overloads
+
+// 1. Same-type copy: scalar_t -> scalar_t
+template <typename scalar_t>
+inline void copy_stub(scalar_t* __restrict__ out, const scalar_t* __restrict__ src, int64_t size) {
+  size_t vl = 0;  // Initialized to silence -Wuninitialized; always set before use in loop body.
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    for (int64_t d = 0; d < size; d += vl) {
+      vl = __riscv_vsetvl_e32m4(size - d);
+      vfloat32m4_t v_data = __riscv_vle32_v_f32m4(src + d, vl);
+      __riscv_vse32_v_f32m4(out + d, v_data, vl);
+    }
+  } else {
+    // 16-bit element copy (FP16, BF16): bitwise, no conversion needed.
+    for (int64_t d = 0; d < size; d += vl) {
+      vl = __riscv_vsetvl_e16m4(size - d);
+      vuint16m4_t v_data = __riscv_vle16_v_u16m4(reinterpret_cast<const uint16_t*>(src + d), vl);
+      __riscv_vse16_v_u16m4(reinterpret_cast<uint16_t*>(out + d), v_data, vl);
+    }
+  }
+}
+
+// 2. Type conversion with scale: (float * scale) -> scalar_t
+template <typename scalar_t>
+inline void copy_stub(scalar_t* __restrict__ out, const float* __restrict__ acc, float s, int64_t size) {
+  size_t vl;
+  alignas(64) float scratch[rvv_constants::MAX_VL_ELEMENTS_M4];
+
+  for (int64_t d = 0; d < size; d += vl) {
+    vl = __riscv_vsetvl_e32m4(size - d);
+    vfloat32m4_t v_acc = __riscv_vle32_v_f32m4(acc + d, vl);
+    vfloat32m4_t v_scaled = __riscv_vfmul_vf_f32m4(v_acc, s, vl);
+    store_from_float_m4(out + d, v_scaled, vl, scratch);
+  }
+}
+
+// 3. float -> scalar_t (no scale) — disabled when scalar_t=float to avoid ambiguity with overload 1
+template <typename scalar_t, std::enable_if_t<!std::is_same_v<scalar_t, float>, int> = 0>
+inline void copy_stub(scalar_t* __restrict__ out, const float* __restrict__ input, int64_t size) {
+  size_t vl_max = __riscv_vsetvlmax_e32m4();
+  alignas(64) float scratch[rvv_constants::MAX_VL_ELEMENTS_M4];
+
+  int64_t d = 0;
+  // Process in chunks of vl_max
+  for (; d + static_cast<int64_t>(vl_max) <= size; d += vl_max) {
+    vfloat32m4_t v_data = __riscv_vle32_v_f32m4(input + d, vl_max);
+    store_from_float_m4(out + d, v_data, vl_max, scratch);
+  }
+
+  // Handle remaining elements
+  if (d < size) {
+    size_t tail_vl = __riscv_vsetvl_e32m4(size - d);
+    vfloat32m4_t v_data = __riscv_vle32_v_f32m4(input + d, tail_vl);
+    store_from_float_m4(out + d, v_data, tail_vl, scratch);
+  }
+}
+
+// 4. scalar_t -> float — disabled when scalar_t=float to avoid ambiguity with overload 1
+template <typename scalar_t, std::enable_if_t<!std::is_same_v<scalar_t, float>, int> = 0>
+inline void copy_stub(float* __restrict__ out, const scalar_t* __restrict__ input, int64_t size) {
+  size_t vl_max = __riscv_vsetvlmax_e32m4();
+  alignas(64) float scratch[rvv_constants::MAX_VL_ELEMENTS_M4];
+
+  int64_t d = 0;
+  // Process in chunks of vl_max
+  for (; d + static_cast<int64_t>(vl_max) <= size; d += vl_max) {
+    vfloat32m4_t v_f32 = load_as_float_m4(input + d, vl_max, scratch);
+    __riscv_vse32_v_f32m4(out + d, v_f32, vl_max);
+  }
+
+  // Handle remaining elements
+  if (d < size) {
+    size_t tail_vl = __riscv_vsetvl_e32m4(size - d);
+    vfloat32m4_t v_f32 = load_as_float_m4(input + d, tail_vl, scratch);
+    __riscv_vse32_v_f32m4(out + d, v_f32, tail_vl);
+  }
+}
+
+// Quantization Operations
+
+template <typename scalar_t>
+inline void quantize_row_uint8_asymmetric_with_scale(
+    uint8_t* __restrict__ Aq, const scalar_t* __restrict__ A, int64_t K, float scale) {
+  const float safe_scale = (scale > 1e-9f) ? scale : 1e-9f;
+  const float inv_scale = 1.0f / safe_scale;
+  size_t vl;
+  alignas(64) float scratch[rvv_constants::MAX_VL_ELEMENTS_M4];
+
+  for (int64_t k = 0; k < K; k += vl) {
+    vl = __riscv_vsetvl_e32m4(K - k);
+
+    vfloat32m4_t v_val = load_as_float_m4(A + k, vl, scratch);
+    vfloat32m4_t v_scaled = __riscv_vfmul_vf_f32m4(v_val, inv_scale, vl);
+    vint32m4_t v_i32 = __riscv_vfcvt_x_f_v_i32m4(v_scaled, vl);
+    v_i32 = __riscv_vadd_vx_i32m4(v_i32, 128, vl);
+    v_i32 = __riscv_vmax_vx_i32m4(v_i32, 0, vl);
+    v_i32 = __riscv_vmin_vx_i32m4(v_i32, 255, vl);
+    vuint32m4_t v_u32 = __riscv_vreinterpret_v_i32m4_u32m4(v_i32);
+    vuint16m2_t v_u16 = __riscv_vnclipu_wx_u16m2(v_u32, 0, __RISCV_VXRM_RNU, vl);
+    vuint8m1_t v_u8 = __riscv_vnclipu_wx_u8m1(v_u16, 0, __RISCV_VXRM_RNU, vl);
+    __riscv_vse8_v_u8m1(Aq + k, v_u8, vl);
+  }
+}
+
+template <typename scalar_t>
+inline void quantize_row_uint8_asymmetric_infer_scale(
+    uint8_t* __restrict__ Aq, float& scale_out, const scalar_t* __restrict__ A, int64_t K, float eps = 1e-7f) {
+  float max_val = 0.f;
+  size_t vl;
+  alignas(64) float scratch[rvv_constants::MAX_VL_ELEMENTS_M4];
+  vfloat32m4_t v_max_acc = __riscv_vfmv_v_f_f32m4(0.0f, __riscv_vsetvlmax_e32m4());
+
+  for (int64_t k = 0; k < K; k += vl) {
+    vl = __riscv_vsetvl_e32m4(K - k);
+    vfloat32m4_t v_val = load_as_float_m4(A + k, vl, scratch);
+    vfloat32m4_t v_abs = __riscv_vfsgnjx_vv_f32m4(v_val, v_val, vl);
+    v_max_acc = __riscv_vfmax_vv_f32m4_tu(v_max_acc, v_max_acc, v_abs, vl);
+  }
+
+  vfloat32m1_t v_max_scalar =
+      __riscv_vfredmax_vs_f32m4_f32m1(v_max_acc, __riscv_vfmv_s_f_f32m1(0.0f, 1), __riscv_vsetvlmax_e32m4());
+  max_val = __riscv_vfmv_f_s_f32m1_f32(v_max_scalar);
+  max_val = std::max(max_val, eps);
+  const float scale = max_val / 127.0f;
+  quantize_row_uint8_asymmetric_with_scale(Aq, A, K, scale);
+  scale_out = scale;
+}
+
+inline void pretransform_u8_to_centered_i8(int8_t* __restrict__ dst, const uint8_t* __restrict__ src, int64_t size) {
+  size_t vl;
+  for (int64_t k = 0; k < size; k += vl) {
+    vl = __riscv_vsetvl_e8m1(size - k);
+    vuint8m1_t v_u8 = __riscv_vle8_v_u8m1(src + k, vl);
+    // Map uint8 [0, 255] into centered int8 [-128, 127] by flipping the sign bit.
+    v_u8 = __riscv_vxor_vx_u8m1(v_u8, 0x80, vl);
+    vint8m1_t v_i8 = __riscv_vreinterpret_v_u8m1_i8m1(v_u8);
+    __riscv_vse8_v_i8m1(dst + k, v_i8, vl);
+  }
+}
+
+inline void pack_weight_int8_with_comp(
+    int8_t* __restrict__ packed_w, const int8_t* __restrict__ orig_w, int64_t N, int64_t K, int64_t block_n) {
+  const int64_t packed_data_size = K * block_n;
+  int32_t* packed_comp = reinterpret_cast<int32_t*>(packed_w + packed_data_size);
+  size_t vl;
+
+  // Zero-initialize compensation buffer once, then accumulate while packing.
+  for (int64_t j = 0; j < block_n; j += vl) {
+    vl = __riscv_vsetvl_e32m4(block_n - j);
+    vint32m4_t v_zero = __riscv_vmv_v_x_i32m4(0, vl);
+    __riscv_vse32_v_i32m4(packed_comp + j, v_zero, vl);
+  }
+
+  for (int64_t k = 0; k < K; ++k) {
+    int8_t* dst = packed_w + k * block_n;
+    int64_t j = 0;
+    while (j < N) {
+      vl = __riscv_vsetvl_e8m1(N - j);
+      vint8m1_t v_data = __riscv_vlse8_v_i8m1(orig_w + (j * K + k), K, vl);
+      __riscv_vse8_v_i8m1(dst + j, v_data, vl);
+
+      vint16m2_t v_i16 = __riscv_vsext_vf2_i16m2(v_data, vl);
+      vint32m4_t v_i32 = __riscv_vsext_vf2_i32m4(v_i16, vl);
+      vint32m4_t v_acc = __riscv_vle32_v_i32m4(packed_comp + j, vl);
+      v_acc = __riscv_vadd_vv_i32m4(v_acc, v_i32, vl);
+      __riscv_vse32_v_i32m4(packed_comp + j, v_acc, vl);
+
+      j += vl;
+    }
+    while (j < block_n) {
+      vl = __riscv_vsetvl_e8m1(block_n - j);
+      vint8m1_t v_zero = __riscv_vmv_v_x_i8m1(0, vl);
+      __riscv_vse8_v_i8m1(dst + j, v_zero, vl);
+      j += vl;
+    }
+  }
+
+  // Finalize shared-CPU-compatible compensation: 128 * sum(weight_col).
+  for (int64_t j = 0; j < block_n; j += vl) {
+    vl = __riscv_vsetvl_e32m4(block_n - j);
+    vint32m4_t v_comp = __riscv_vle32_v_i32m4(packed_comp + j, vl);
+    v_comp = __riscv_vmul_vx_i32m4(v_comp, 128, vl);
+    __riscv_vse32_v_i32m4(packed_comp + j, v_comp, vl);
+  }
+}
+
+struct AlignedArena {
+  char* ptr;
+
+  explicit AlignedArena(void* base, size_t align = 64) {
+    auto addr = reinterpret_cast<uintptr_t>(base);
+    ptr = reinterpret_cast<char*>((addr + align - 1) & ~(align - 1));
+  }
+
+  template <typename T>
+  T* alloc(size_t count, size_t align = 64) {
+    auto addr = reinterpret_cast<uintptr_t>(ptr);
+    ptr = reinterpret_cast<char*>((addr + align - 1) & ~(align - 1));
+    T* result = reinterpret_cast<T*>(ptr);
+    ptr += count * sizeof(T);
+    return result;
+  }
+};
+
+// Softmax helper: in-place exp and sum (no normalization)
+// scores[i] = exp(scores[i] - max), returns sum = Σ scores[i]
+// NOTE: Does NOT normalize scores. Callers use unnormalized exp values for the online softmax.
+inline float exp_and_sum(float* __restrict__ scores, int n_size, float m_i) {
+  if (n_size <= 0) return 0.0f;
+
+  size_t vl_max = __riscv_vsetvlmax_e32m4();
+  float total_sum = 0.0f;
+
+  vfloat32m1_t vzero = __riscv_vfmv_s_f_f32m1(0.0f, 1);
+  for (int j = 0; j < n_size; j += vl_max) {
+    size_t vl = __riscv_vsetvl_e32m4(n_size - j);
+    vfloat32m4_t vx = __riscv_vle32_v_f32m4(scores + j, vl);
+    vx = __riscv_vfsub_vf_f32m4(vx, m_i, vl);
+    vfloat32m4_t vex = vfexp_f32m4(vx, vl);
+    __riscv_vse32_v_f32m4(scores + j, vex, vl);
+
+    vfloat32m1_t vsum = __riscv_vfredusum_vs_f32m4_f32m1(vex, vzero, vl);
+    total_sum += __riscv_vfmv_f_s_f32m1_f32(vsum);
+  }
+
+  return total_sum;
+}
+
+inline float rvv_reduce_max_f32(const float* data, int64_t len) {
+  if (len <= 0) return -std::numeric_limits<float>::infinity();
+
+  float max_val = -std::numeric_limits<float>::infinity();
+  int64_t remaining = len;
+
+  while (remaining > 0) {
+    size_t vl = __riscv_vsetvl_e32m8(remaining);
+    vfloat32m8_t vdata = __riscv_vle32_v_f32m8(data + (len - remaining), vl);
+
+    vfloat32m1_t vcurrent_max = __riscv_vfmv_s_f_f32m1(max_val, 1);
+    vfloat32m1_t vmax = __riscv_vfredmax_vs_f32m8_f32m1(vdata, vcurrent_max, vl);
+    max_val = __riscv_vfmv_f_s_f32m1_f32(vmax);
+
+    remaining -= vl;
+  }
+
+  return max_val;
+}
+
+#endif  // CPU_CAPABILITY_RVV

--- a/sgl-kernel/csrc/cpu/riscv64/vector_math.h
+++ b/sgl-kernel/csrc/cpu/riscv64/vector_math.h
@@ -1,0 +1,369 @@
+#pragma once
+
+#if defined(CPU_CAPABILITY_RVV)
+
+#include <riscv_vector.h>
+
+#include <limits>
+
+// Polynomial approximation: exp(x) = 2^(x*log2(e)
+constexpr float RVV_EXP_C0 = 1.0f;
+constexpr float RVV_EXP_C1 = 0.69314718056f;
+constexpr float RVV_EXP_C2 = 0.24022650695f;
+constexpr float RVV_EXP_C3 = 0.05550410866f;
+constexpr float RVV_EXP_C4 = 0.00961812910f;
+constexpr float RVV_EXP_C5 = 0.00133335581f;
+constexpr float RVV_LOG2_E = 1.44269504089f;
+
+// Generic Exp template for LMUL={1,2,4,8} — all four specializations are provided.
+template <int LMUL>
+struct RVVExpImpl;
+
+// Specialization: LMUL=1
+template <>
+struct RVVExpImpl<1> {
+  using VFloat = vfloat32m1_t;
+  using VInt = vint32m1_t;
+
+  static inline VFloat compute(VFloat vx, size_t vl) {
+    vx = __riscv_vfmax_vf_f32m1(vx, -87.0f, vl);  // Clamp to avoid denormals
+    vx = __riscv_vfmin_vf_f32m1(vx, 88.0f, vl);
+
+    VFloat vz = __riscv_vfmul_vf_f32m1(vx, RVV_LOG2_E, vl);
+    // vfcvt_x_f uses fcsr.frm (assumes RNE = default rounding mode)
+    VInt vn_int = __riscv_vfcvt_x_f_v_i32m1(vz, vl);
+    VFloat vn = __riscv_vfcvt_f_x_v_f32m1(vn_int, vl);
+    VFloat vf = __riscv_vfsub_vv_f32m1(vz, vn, vl);
+
+    // Horner's method: ((((C5*f + C4)*f + C3)*f + C2)*f + C1)*f + C0
+    // vfmadd(vd, vs1, vs2) = vd * vs1 + vs2 — vd is the multiplicand
+    VFloat vC0 = __riscv_vfmv_v_f_f32m1(RVV_EXP_C0, vl);
+    VFloat vC1 = __riscv_vfmv_v_f_f32m1(RVV_EXP_C1, vl);
+    VFloat vC2 = __riscv_vfmv_v_f_f32m1(RVV_EXP_C2, vl);
+    VFloat vC3 = __riscv_vfmv_v_f_f32m1(RVV_EXP_C3, vl);
+    VFloat vC4 = __riscv_vfmv_v_f_f32m1(RVV_EXP_C4, vl);
+
+    VFloat poly = __riscv_vfmv_v_f_f32m1(RVV_EXP_C5, vl);
+    poly = __riscv_vfmadd_vv_f32m1(poly, vf, vC4, vl);  // C5*f + C4
+    poly = __riscv_vfmadd_vv_f32m1(poly, vf, vC3, vl);  // (C5*f+C4)*f + C3
+    poly = __riscv_vfmadd_vv_f32m1(poly, vf, vC2, vl);
+    poly = __riscv_vfmadd_vv_f32m1(poly, vf, vC1, vl);
+    poly = __riscv_vfmadd_vv_f32m1(poly, vf, vC0, vl);
+
+    VInt v_exp = __riscv_vadd_vx_i32m1(vn_int, 127, vl);
+    v_exp = __riscv_vsll_vx_i32m1(v_exp, 23, vl);
+    VFloat v_pow2n = __riscv_vreinterpret_v_i32m1_f32m1(v_exp);
+
+    return __riscv_vfmul_vv_f32m1(poly, v_pow2n, vl);
+  }
+};
+
+// Specialization: LMUL=2
+template <>
+struct RVVExpImpl<2> {
+  using VFloat = vfloat32m2_t;
+  using VInt = vint32m2_t;
+
+  static inline VFloat compute(VFloat vx, size_t vl) {
+    vx = __riscv_vfmax_vf_f32m2(vx, -87.0f, vl);  // Clamp to avoid denormals
+    vx = __riscv_vfmin_vf_f32m2(vx, 88.0f, vl);
+
+    VFloat vz = __riscv_vfmul_vf_f32m2(vx, RVV_LOG2_E, vl);
+    // vfcvt_x_f uses fcsr.frm (assumes RNE = default rounding mode)
+    VInt vn_int = __riscv_vfcvt_x_f_v_i32m2(vz, vl);
+    VFloat vn = __riscv_vfcvt_f_x_v_f32m2(vn_int, vl);
+    VFloat vf = __riscv_vfsub_vv_f32m2(vz, vn, vl);
+
+    // Horner's method: ((((C5*f + C4)*f + C3)*f + C2)*f + C1)*f + C0
+    VFloat vC0 = __riscv_vfmv_v_f_f32m2(RVV_EXP_C0, vl);
+    VFloat vC1 = __riscv_vfmv_v_f_f32m2(RVV_EXP_C1, vl);
+    VFloat vC2 = __riscv_vfmv_v_f_f32m2(RVV_EXP_C2, vl);
+    VFloat vC3 = __riscv_vfmv_v_f_f32m2(RVV_EXP_C3, vl);
+    VFloat vC4 = __riscv_vfmv_v_f_f32m2(RVV_EXP_C4, vl);
+
+    VFloat poly = __riscv_vfmv_v_f_f32m2(RVV_EXP_C5, vl);
+    poly = __riscv_vfmadd_vv_f32m2(poly, vf, vC4, vl);  // C5*f + C4
+    poly = __riscv_vfmadd_vv_f32m2(poly, vf, vC3, vl);  // (C5*f+C4)*f + C3
+    poly = __riscv_vfmadd_vv_f32m2(poly, vf, vC2, vl);
+    poly = __riscv_vfmadd_vv_f32m2(poly, vf, vC1, vl);
+    poly = __riscv_vfmadd_vv_f32m2(poly, vf, vC0, vl);
+
+    VInt v_exp = __riscv_vadd_vx_i32m2(vn_int, 127, vl);
+    v_exp = __riscv_vsll_vx_i32m2(v_exp, 23, vl);
+    VFloat v_pow2n = __riscv_vreinterpret_v_i32m2_f32m2(v_exp);
+
+    return __riscv_vfmul_vv_f32m2(poly, v_pow2n, vl);
+  }
+};
+
+// Specialization: LMUL=4
+template <>
+struct RVVExpImpl<4> {
+  using VFloat = vfloat32m4_t;
+  using VInt = vint32m4_t;
+
+  static inline VFloat compute(VFloat vx, size_t vl) {
+    vx = __riscv_vfmax_vf_f32m4(vx, -87.0f, vl);  // Clamp to avoid denormals
+    vx = __riscv_vfmin_vf_f32m4(vx, 88.0f, vl);
+
+    VFloat vz = __riscv_vfmul_vf_f32m4(vx, RVV_LOG2_E, vl);
+    // vfcvt_x_f uses fcsr.frm (assumes RNE = default rounding mode)
+    VInt vn_int = __riscv_vfcvt_x_f_v_i32m4(vz, vl);
+    VFloat vn = __riscv_vfcvt_f_x_v_f32m4(vn_int, vl);
+    VFloat vf = __riscv_vfsub_vv_f32m4(vz, vn, vl);
+
+    // Horner's method: ((((C5*f + C4)*f + C3)*f + C2)*f + C1)*f + C0
+    // vfmadd(vd, vs1, vs2) = vd * vs1 + vs2 — vd is the multiplicand
+    VFloat vC0 = __riscv_vfmv_v_f_f32m4(RVV_EXP_C0, vl);
+    VFloat vC1 = __riscv_vfmv_v_f_f32m4(RVV_EXP_C1, vl);
+    VFloat vC2 = __riscv_vfmv_v_f_f32m4(RVV_EXP_C2, vl);
+    VFloat vC3 = __riscv_vfmv_v_f_f32m4(RVV_EXP_C3, vl);
+    VFloat vC4 = __riscv_vfmv_v_f_f32m4(RVV_EXP_C4, vl);
+
+    VFloat poly = __riscv_vfmv_v_f_f32m4(RVV_EXP_C5, vl);
+    poly = __riscv_vfmadd_vv_f32m4(poly, vf, vC4, vl);  // C5*f + C4
+    poly = __riscv_vfmadd_vv_f32m4(poly, vf, vC3, vl);  // (C5*f+C4)*f + C3
+    poly = __riscv_vfmadd_vv_f32m4(poly, vf, vC2, vl);
+    poly = __riscv_vfmadd_vv_f32m4(poly, vf, vC1, vl);
+    poly = __riscv_vfmadd_vv_f32m4(poly, vf, vC0, vl);
+
+    VInt v_exp = __riscv_vadd_vx_i32m4(vn_int, 127, vl);
+    v_exp = __riscv_vsll_vx_i32m4(v_exp, 23, vl);
+    VFloat v_pow2n = __riscv_vreinterpret_v_i32m4_f32m4(v_exp);
+
+    return __riscv_vfmul_vv_f32m4(poly, v_pow2n, vl);
+  }
+};
+
+// Specialization: LMUL=8
+template <>
+struct RVVExpImpl<8> {
+  using VFloat = vfloat32m8_t;
+  using VInt = vint32m8_t;
+
+  static inline VFloat compute(VFloat vx, size_t vl) {
+    vx = __riscv_vfmax_vf_f32m8(vx, -87.0f, vl);
+    vx = __riscv_vfmin_vf_f32m8(vx, 88.0f, vl);
+
+    VFloat vz = __riscv_vfmul_vf_f32m8(vx, RVV_LOG2_E, vl);
+    // vfcvt_x_f uses fcsr.frm (assumes RNE = default rounding mode)
+    VInt vn_int = __riscv_vfcvt_x_f_v_i32m8(vz, vl);
+    VFloat vn = __riscv_vfcvt_f_x_v_f32m8(vn_int, vl);
+    VFloat vf = __riscv_vfsub_vv_f32m8(vz, vn, vl);
+
+    // Horner's method: ((((C5*f + C4)*f + C3)*f + C2)*f + C1)*f + C0
+    // vfmadd(vd, vs1, vs2) = vd * vs1 + vs2 — vd is the multiplicand
+    VFloat vC0 = __riscv_vfmv_v_f_f32m8(RVV_EXP_C0, vl);
+    VFloat vC1 = __riscv_vfmv_v_f_f32m8(RVV_EXP_C1, vl);
+    VFloat vC2 = __riscv_vfmv_v_f_f32m8(RVV_EXP_C2, vl);
+    VFloat vC3 = __riscv_vfmv_v_f_f32m8(RVV_EXP_C3, vl);
+    VFloat vC4 = __riscv_vfmv_v_f_f32m8(RVV_EXP_C4, vl);
+
+    VFloat poly = __riscv_vfmv_v_f_f32m8(RVV_EXP_C5, vl);
+    poly = __riscv_vfmadd_vv_f32m8(poly, vf, vC4, vl);  // C5*f + C4
+    poly = __riscv_vfmadd_vv_f32m8(poly, vf, vC3, vl);  // (C5*f+C4)*f + C3
+    poly = __riscv_vfmadd_vv_f32m8(poly, vf, vC2, vl);
+    poly = __riscv_vfmadd_vv_f32m8(poly, vf, vC1, vl);
+    poly = __riscv_vfmadd_vv_f32m8(poly, vf, vC0, vl);
+
+    VInt v_exp = __riscv_vadd_vx_i32m8(vn_int, 127, vl);
+    v_exp = __riscv_vsll_vx_i32m8(v_exp, 23, vl);
+    VFloat v_pow2n = __riscv_vreinterpret_v_i32m8_f32m8(v_exp);
+
+    return __riscv_vfmul_vv_f32m8(poly, v_pow2n, vl);
+  }
+};
+
+// Wrapper functions (delegate to template implementations)
+inline vfloat32m1_t vfexp_f32m1(vfloat32m1_t vx, size_t vl) {
+  return RVVExpImpl<1>::compute(vx, vl);
+}
+
+inline vfloat32m2_t vfexp_f32m2(vfloat32m2_t vx, size_t vl) {
+  return RVVExpImpl<2>::compute(vx, vl);
+}
+
+inline vfloat32m4_t vfexp_f32m4(vfloat32m4_t vx, size_t vl) {
+  return RVVExpImpl<4>::compute(vx, vl);
+}
+
+inline vfloat32m8_t vfexp_f32m8(vfloat32m8_t vx, size_t vl) {
+  return RVVExpImpl<8>::compute(vx, vl);
+}
+
+// Fast reciprocal: ~1/vd via vfrec7 + one Newton-Raphson step (~14-bit accuracy).
+// NR: r <- r * (2 - d * r).  Safe for any d > 0 (which holds for all our use sites).
+// NOT suitable for full FP32 precision (24-bit); sufficient for fp16/bf16 outputs only.
+inline vfloat32m1_t vrec_f32m1(vfloat32m1_t vd, size_t vl) {
+  vfloat32m1_t vr = __riscv_vfrec7_v_f32m1(vd, vl);
+  vfloat32m1_t vdr = __riscv_vfmul_vv_f32m1(vd, vr, vl);
+  vfloat32m1_t vcorr = __riscv_vfrsub_vf_f32m1(vdr, 2.0f, vl);  // 2 - d*r
+  return __riscv_vfmul_vv_f32m1(vr, vcorr, vl);
+}
+
+inline vfloat32m2_t vrec_f32m2(vfloat32m2_t vd, size_t vl) {
+  vfloat32m2_t vr = __riscv_vfrec7_v_f32m2(vd, vl);
+  vfloat32m2_t vdr = __riscv_vfmul_vv_f32m2(vd, vr, vl);
+  vfloat32m2_t vcorr = __riscv_vfrsub_vf_f32m2(vdr, 2.0f, vl);  // 2 - d*r
+  return __riscv_vfmul_vv_f32m2(vr, vcorr, vl);
+}
+
+inline vfloat32m4_t vrec_f32m4(vfloat32m4_t vd, size_t vl) {
+  vfloat32m4_t vr = __riscv_vfrec7_v_f32m4(vd, vl);
+  vfloat32m4_t vdr = __riscv_vfmul_vv_f32m4(vd, vr, vl);
+  vfloat32m4_t vcorr = __riscv_vfrsub_vf_f32m4(vdr, 2.0f, vl);  // 2 - d*r
+  return __riscv_vfmul_vv_f32m4(vr, vcorr, vl);
+}
+
+inline vfloat32m8_t vrec_f32m8(vfloat32m8_t vd, size_t vl) {
+  vfloat32m8_t vr = __riscv_vfrec7_v_f32m8(vd, vl);
+  vfloat32m8_t vdr = __riscv_vfmul_vv_f32m8(vd, vr, vl);
+  vfloat32m8_t vcorr = __riscv_vfrsub_vf_f32m8(vdr, 2.0f, vl);
+  return __riscv_vfmul_vv_f32m8(vr, vcorr, vl);
+}
+
+// tanh(x) = (e^2x - 1) / (e^2x + 1).  Clamped to ±9: at |x|=9, FP32 tanh ≈ 1-6e-8
+// (within 1 ULP of 1.0). FP32 saturates to exactly ±1.0 at |x|>=10; ±9 is a
+// conservative bound that also keeps exp(2x) < 65M, avoiding approximation breakdown.
+inline vfloat32m1_t vftanh_f32m1(vfloat32m1_t vx, size_t vl) {
+  vx = __riscv_vfmax_vf_f32m1(vx, -9.0f, vl);
+  vx = __riscv_vfmin_vf_f32m1(vx, 9.0f, vl);
+  vfloat32m1_t v2x = __riscv_vfmul_vf_f32m1(vx, 2.0f, vl);
+  vfloat32m1_t vex = vfexp_f32m1(v2x, vl);
+  vfloat32m1_t v_num = __riscv_vfsub_vf_f32m1(vex, 1.0f, vl);
+  vfloat32m1_t v_denom = __riscv_vfadd_vf_f32m1(vex, 1.0f, vl);
+  return __riscv_vfmul_vv_f32m1(v_num, vrec_f32m1(v_denom, vl), vl);
+}
+
+inline vfloat32m2_t vftanh_f32m2(vfloat32m2_t vx, size_t vl) {
+  vx = __riscv_vfmax_vf_f32m2(vx, -9.0f, vl);
+  vx = __riscv_vfmin_vf_f32m2(vx, 9.0f, vl);
+  vfloat32m2_t v2x = __riscv_vfmul_vf_f32m2(vx, 2.0f, vl);
+  vfloat32m2_t vex = vfexp_f32m2(v2x, vl);
+  vfloat32m2_t v_num = __riscv_vfsub_vf_f32m2(vex, 1.0f, vl);
+  vfloat32m2_t v_denom = __riscv_vfadd_vf_f32m2(vex, 1.0f, vl);
+  return __riscv_vfmul_vv_f32m2(v_num, vrec_f32m2(v_denom, vl), vl);
+}
+
+inline vfloat32m4_t vftanh_f32m4(vfloat32m4_t vx, size_t vl) {
+  vx = __riscv_vfmax_vf_f32m4(vx, -9.0f, vl);
+  vx = __riscv_vfmin_vf_f32m4(vx, 9.0f, vl);
+  vfloat32m4_t v2x = __riscv_vfmul_vf_f32m4(vx, 2.0f, vl);
+  vfloat32m4_t vex = vfexp_f32m4(v2x, vl);
+  vfloat32m4_t v_num = __riscv_vfsub_vf_f32m4(vex, 1.0f, vl);
+  vfloat32m4_t v_denom = __riscv_vfadd_vf_f32m4(vex, 1.0f, vl);
+  return __riscv_vfmul_vv_f32m4(v_num, vrec_f32m4(v_denom, vl), vl);
+}
+
+inline vfloat32m8_t vftanh_f32m8(vfloat32m8_t vx, size_t vl) {
+  vx = __riscv_vfmax_vf_f32m8(vx, -9.0f, vl);
+  vx = __riscv_vfmin_vf_f32m8(vx, 9.0f, vl);
+  vfloat32m8_t v2x = __riscv_vfmul_vf_f32m8(vx, 2.0f, vl);
+  vfloat32m8_t vex = vfexp_f32m8(v2x, vl);
+  vfloat32m8_t v_num = __riscv_vfsub_vf_f32m8(vex, 1.0f, vl);
+  vfloat32m8_t v_denom = __riscv_vfadd_vf_f32m8(vex, 1.0f, vl);
+  return __riscv_vfmul_vv_f32m8(v_num, vrec_f32m8(v_denom, vl), vl);
+}
+
+// Polynomial approximation: erf(x) max error 1.5e-7
+// erf(x) = sign(x) * (1 - poly(t) * exp(-x^2))
+// where t = 1 / (1 + 0.3275911 * |x|)
+// poly(t) = ((((a5*t + a4)*t + a3)*t + a2)*t + a1)*t  (Horner form)
+// erf saturates to ±1 for |x| >= 4; |x| is clamped to 4 to avoid exp underflow.
+constexpr float RVV_ERF_P = 0.3275911f;
+constexpr float RVV_ERF_A1 = 0.254829592f;
+constexpr float RVV_ERF_A2 = -0.284496736f;
+constexpr float RVV_ERF_A3 = 1.421413741f;
+constexpr float RVV_ERF_A4 = -1.453152027f;
+constexpr float RVV_ERF_A5 = 1.061405429f;
+
+inline vfloat32m4_t vferf_f32m4(vfloat32m4_t vx, size_t vl) {
+  // |x|, clamped to 4 (erf saturates to ±1 beyond this)
+  vfloat32m4_t vabs = __riscv_vfabs_v_f32m4(vx, vl);
+  vabs = __riscv_vfmin_vf_f32m4(vabs, 4.0f, vl);
+
+  // t = 1 / (1 + p * |x|)
+  vfloat32m4_t vone = __riscv_vfmv_v_f_f32m4(1.0f, vl);
+  vfloat32m4_t vdenom = __riscv_vfmacc_vf_f32m4(vone, RVV_ERF_P, vabs, vl);
+  vfloat32m4_t vt = vrec_f32m4(vdenom, vl);  // ~1/(1 + p*|x|), replaces vfdiv
+
+  // Horner's method: ((((a5*t + a4)*t + a3)*t + a2)*t + a1)*t
+  vfloat32m4_t vpoly = __riscv_vfmv_v_f_f32m4(RVV_ERF_A5, vl);
+  vpoly = __riscv_vfmadd_vv_f32m4(vpoly, vt, __riscv_vfmv_v_f_f32m4(RVV_ERF_A4, vl), vl);
+  vpoly = __riscv_vfmadd_vv_f32m4(vpoly, vt, __riscv_vfmv_v_f_f32m4(RVV_ERF_A3, vl), vl);
+  vpoly = __riscv_vfmadd_vv_f32m4(vpoly, vt, __riscv_vfmv_v_f_f32m4(RVV_ERF_A2, vl), vl);
+  vpoly = __riscv_vfmadd_vv_f32m4(vpoly, vt, __riscv_vfmv_v_f_f32m4(RVV_ERF_A1, vl), vl);
+  vpoly = __riscv_vfmul_vv_f32m4(vpoly, vt, vl);  // final *t gives a1*t + ... + a5*t^5
+
+  // exp(-x^2)
+  vfloat32m4_t vx2 = __riscv_vfmul_vv_f32m4(vabs, vabs, vl);
+  vfloat32m4_t vexp = vfexp_f32m4(__riscv_vfneg_v_f32m4(vx2, vl), vl);
+
+  // result = 1 - poly * exp(-x^2); vfnmsac(vd, vs1, vs2) = vd - vs1 * vs2
+  vfloat32m4_t vresult = __riscv_vfnmsac_vv_f32m4(vone, vpoly, vexp, vl);
+
+  // Apply sign: erf(x) has the same sign as x.
+  // vfsgnjx(vd, vs) = vd with sign = sign(vd) XOR sign(vs).
+  // vresult >= 0 (sign bit = 0), so result sign = sign(vx).
+  return __riscv_vfsgnjx_vv_f32m4(vresult, vx, vl);
+}
+
+inline vfloat32m8_t vferf_f32m8(vfloat32m8_t vx, size_t vl) {
+  vfloat32m8_t vabs = __riscv_vfabs_v_f32m8(vx, vl);
+  vabs = __riscv_vfmin_vf_f32m8(vabs, 4.0f, vl);
+
+  vfloat32m8_t vone = __riscv_vfmv_v_f_f32m8(1.0f, vl);
+  vfloat32m8_t vdenom = __riscv_vfmacc_vf_f32m8(vone, RVV_ERF_P, vabs, vl);
+  vfloat32m8_t vt = vrec_f32m8(vdenom, vl);  // ~1/(1 + p*|x|), replaces vfdiv
+
+  vfloat32m8_t vpoly = __riscv_vfmv_v_f_f32m8(RVV_ERF_A5, vl);
+  vpoly = __riscv_vfmadd_vv_f32m8(vpoly, vt, __riscv_vfmv_v_f_f32m8(RVV_ERF_A4, vl), vl);
+  vpoly = __riscv_vfmadd_vv_f32m8(vpoly, vt, __riscv_vfmv_v_f_f32m8(RVV_ERF_A3, vl), vl);
+  vpoly = __riscv_vfmadd_vv_f32m8(vpoly, vt, __riscv_vfmv_v_f_f32m8(RVV_ERF_A2, vl), vl);
+  vpoly = __riscv_vfmadd_vv_f32m8(vpoly, vt, __riscv_vfmv_v_f_f32m8(RVV_ERF_A1, vl), vl);
+  vpoly = __riscv_vfmul_vv_f32m8(vpoly, vt, vl);
+
+  vfloat32m8_t vx2 = __riscv_vfmul_vv_f32m8(vabs, vabs, vl);
+  vfloat32m8_t vexp = vfexp_f32m8(__riscv_vfneg_v_f32m8(vx2, vl), vl);
+
+  vfloat32m8_t vresult = __riscv_vfnmsac_vv_f32m8(vone, vpoly, vexp, vl);
+  return __riscv_vfsgnjx_vv_f32m8(vresult, vx, vl);
+}
+
+// Reduction Wrappers for Different register configurations
+inline float reduce_sum_f32m4(vfloat32m4_t v_acc, size_t vl_max) {
+  vfloat32m1_t vzero = __riscv_vfmv_s_f_f32m1(0.0f, 1);
+  vfloat32m1_t vred = __riscv_vfredusum_vs_f32m4_f32m1(v_acc, vzero, vl_max);
+  return __riscv_vfmv_f_s_f32m1_f32(vred);
+}
+
+inline float reduce_sum_f32m1(vfloat32m1_t v_acc, size_t vl_max) {
+  vfloat32m1_t vzero = __riscv_vfmv_s_f_f32m1(0.0f, 1);
+  vfloat32m1_t vred = __riscv_vfredusum_vs_f32m1_f32m1(v_acc, vzero, vl_max);
+  return __riscv_vfmv_f_s_f32m1_f32(vred);
+}
+
+// Widening Multiply-Accumulate Support
+
+// FP16 Vector-Vector -> FP32 Accumulator
+inline vfloat32m4_t vfwmacc_f16_to_f32m4(vfloat32m4_t vd, vfloat16m2_t vs1, vfloat16m2_t vs2, size_t vl) {
+#if defined(__riscv_zvfh)
+  return __riscv_vfwmacc_vv_f32m4_tu(vd, vs1, vs2, vl);
+#else
+  vfloat32m4_t vs1_f32 = __riscv_vfwcvt_f_f_v_f32m4(vs1, vl);
+  vfloat32m4_t vs2_f32 = __riscv_vfwcvt_f_f_v_f32m4(vs2, vl);
+  return __riscv_vfmacc_vv_f32m4_tu(vd, vs1_f32, vs2_f32, vl);
+#endif
+}
+
+// FP16 Scalar-Vector -> FP32 Accumulator
+inline vfloat32m4_t vfwmacc_f16_scalar_to_f32m4(vfloat32m4_t vd, _Float16 scalar, vfloat16m2_t vs2, size_t vl) {
+#if defined(__riscv_zvfh)
+  return __riscv_vfwmacc_vf_f32m4_tu(vd, scalar, vs2, vl);
+#else
+  vfloat32m4_t vs2_f32 = __riscv_vfwcvt_f_f_v_f32m4(vs2, vl);
+  return __riscv_vfmacc_vf_f32m4_tu(vd, (float)scalar, vs2_f32, vl);
+#endif
+}
+
+#endif  // CPU_CAPABILITY_RVV

--- a/sgl-kernel/csrc/cpu/riscv64/vector_math.h
+++ b/sgl-kernel/csrc/cpu/riscv64/vector_math.h
@@ -344,26 +344,20 @@ inline float reduce_sum_f32m1(vfloat32m1_t v_acc, size_t vl_max) {
 }
 
 // Widening Multiply-Accumulate Support
+// These helpers require the Zvfh extension (vfloat16m2_t type is zvfh-only).
+
+#if defined(__riscv_zvfh)
 
 // FP16 Vector-Vector -> FP32 Accumulator
 inline vfloat32m4_t vfwmacc_f16_to_f32m4(vfloat32m4_t vd, vfloat16m2_t vs1, vfloat16m2_t vs2, size_t vl) {
-#if defined(__riscv_zvfh)
   return __riscv_vfwmacc_vv_f32m4_tu(vd, vs1, vs2, vl);
-#else
-  vfloat32m4_t vs1_f32 = __riscv_vfwcvt_f_f_v_f32m4(vs1, vl);
-  vfloat32m4_t vs2_f32 = __riscv_vfwcvt_f_f_v_f32m4(vs2, vl);
-  return __riscv_vfmacc_vv_f32m4_tu(vd, vs1_f32, vs2_f32, vl);
-#endif
 }
 
 // FP16 Scalar-Vector -> FP32 Accumulator
 inline vfloat32m4_t vfwmacc_f16_scalar_to_f32m4(vfloat32m4_t vd, _Float16 scalar, vfloat16m2_t vs2, size_t vl) {
-#if defined(__riscv_zvfh)
   return __riscv_vfwmacc_vf_f32m4_tu(vd, scalar, vs2, vl);
-#else
-  vfloat32m4_t vs2_f32 = __riscv_vfwcvt_f_f_v_f32m4(vs2, vl);
-  return __riscv_vfmacc_vf_f32m4_tu(vd, (float)scalar, vs2_f32, vl);
-#endif
 }
+
+#endif  // __riscv_zvfh
 
 #endif  // CPU_CAPABILITY_RVV

--- a/test/srt/cpu/rvv/rvv_utils.py
+++ b/test/srt/cpu/rvv/rvv_utils.py
@@ -1,0 +1,49 @@
+import importlib.util
+
+import torch
+
+
+def has_sgl_kernel_op(op_name: str) -> bool:
+    """Check if a specific operator is available in sgl_kernel."""
+    if not importlib.util.find_spec("sgl_kernel"):
+        return False
+    try:
+        getattr(torch.ops.sgl_kernel, op_name)
+        return True
+    except (AttributeError, RuntimeError):
+        return False
+
+
+# Numeric tolerances for shared RVV test paths: precision[key][dtype].
+precision = {
+    "pointwise_default": {
+        torch.bfloat16: 3e-2,
+        torch.float16: 1e-3,
+        torch.float32: 1e-5,
+    },
+    "norm_layer_bias": {
+        torch.bfloat16: 3e-2,
+        torch.float16: 1e-2,
+        torch.float32: 1e-5,
+    },
+    "linear_gemm": {torch.bfloat16: 1.5e-1, torch.float16: 1e-1},
+    "rotary_embedding": {torch.bfloat16: 3e-2, torch.float16: 1e-2},
+    "attention_decode_logit_cap": {torch.float16: 1e-2, torch.bfloat16: 1e-1},
+    "attention_decode": {
+        torch.bfloat16: 1e-1,
+        torch.float16: 7e-2,
+        torch.float32: 1e-5,
+    },
+    "attention_extend": {
+        torch.bfloat16: 1e-1,
+        torch.float16: 3e-3,
+        torch.float32: 1e-5,
+    },
+}
+
+
+def helper_non_contiguous(t: torch.Tensor) -> torch.Tensor:
+    """Return a non-contiguous view of t by striding the batch dimension 2x."""
+    buf = torch.empty(t.shape[0] * 2, *t.shape[1:], dtype=t.dtype)
+    buf[::2] = t
+    return buf[::2]

--- a/test/srt/cpu/rvv/test_rvv_activation.py
+++ b/test/srt/cpu/rvv/test_rvv_activation.py
@@ -1,0 +1,97 @@
+"""Unit tests for RVV activation kernels."""
+
+import itertools
+import unittest
+
+import torch
+
+from sglang.test.test_utils import CustomTestCase
+
+from ..utils import GeluAndMul, SiluAndMul
+from .rvv_utils import has_sgl_kernel_op, helper_non_contiguous, precision
+
+torch.manual_seed(1234)
+
+
+@unittest.skipUnless(
+    has_sgl_kernel_op("silu_and_mul_cpu"),
+    "sgl_kernel activation not available (non-RISC-V build)",
+)
+class TestRVVActivation(CustomTestCase):
+    """Test suite for RVV activation kernels."""
+
+    M = [1, 128, 129, 257]
+    N = [32, 64, 80, 128, 22016, 22018]
+    # Cover sub-VL, exact-VL, unrolled, and tail-heavy shapes.
+    dtype = [torch.float16, torch.bfloat16]
+
+    def _run_silu_mul(self, m, n, dtype):
+        x = torch.randn([m, n], dtype=dtype)
+        out = torch.ops.sgl_kernel.silu_and_mul_cpu(x)
+        ref = SiluAndMul(x)
+        atol = rtol = precision["pointwise_default"][dtype]
+        torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+    def _run_gelu_tanh_mul(self, m, n, dtype):
+        x = torch.randn([m, n], dtype=dtype)
+        out = torch.ops.sgl_kernel.gelu_tanh_and_mul_cpu(x)
+        ref = GeluAndMul(x, approximate="tanh")
+        atol = rtol = precision["pointwise_default"][dtype]
+        torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+    def _run_gelu_mul(self, m, n, dtype):
+        x = torch.randn([m, n], dtype=dtype)
+        out = torch.ops.sgl_kernel.gelu_and_mul_cpu(x)
+        ref = GeluAndMul(x, approximate="none")
+        atol = rtol = precision["pointwise_default"][dtype]
+        torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+    def test_silu_mul(self):
+        """Shape matrix includes sub-VL, exact-VL, unrolled, and tail-heavy sizes."""
+        for m, n, dt in itertools.product(self.M, self.N, self.dtype):
+            with self.subTest(m=m, n=n, dtype=dt):
+                self._run_silu_mul(m, n, dt)
+
+    def test_gelu_tanh_mul(self):
+        """Shape matrix includes sub-VL, exact-VL, unrolled, and tail-heavy sizes."""
+        for m, n, dt in itertools.product(self.M, self.N, self.dtype):
+            with self.subTest(m=m, n=n, dtype=dt):
+                self._run_gelu_tanh_mul(m, n, dt)
+
+    def test_gelu_mul(self):
+        """Shape matrix includes sub-VL, exact-VL, unrolled, and tail-heavy sizes."""
+        for m, n, dt in itertools.product(self.M, self.N, self.dtype):
+            with self.subTest(m=m, n=n, dtype=dt):
+                self._run_gelu_mul(m, n, dt)
+
+    def test_non_contiguous(self):
+        """Non-contiguous input must not silently read wrong elements due to stride errors."""
+        for dtype in self.dtype:
+            x = helper_non_contiguous(torch.randn(128, 64, dtype=dtype))
+            self.assertFalse(x.is_contiguous())
+            atol = rtol = precision["pointwise_default"][dtype]
+            with self.subTest(dtype=dtype, op="silu_and_mul"):
+                torch.testing.assert_close(
+                    SiluAndMul(x),
+                    torch.ops.sgl_kernel.silu_and_mul_cpu(x),
+                    atol=atol,
+                    rtol=rtol,
+                )
+            with self.subTest(dtype=dtype, op="gelu_tanh_and_mul"):
+                torch.testing.assert_close(
+                    GeluAndMul(x, approximate="tanh"),
+                    torch.ops.sgl_kernel.gelu_tanh_and_mul_cpu(x),
+                    atol=atol,
+                    rtol=rtol,
+                )
+            with self.subTest(dtype=dtype, op="gelu_and_mul"):
+                torch.testing.assert_close(
+                    GeluAndMul(x, approximate="none"),
+                    torch.ops.sgl_kernel.gelu_and_mul_cpu(x),
+                    atol=atol,
+                    rtol=rtol,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/cpu/rvv/test_rvv_decode.py
+++ b/test/srt/cpu/rvv/test_rvv_decode.py
@@ -1,0 +1,317 @@
+"""Unit tests for RVV decode attention kernel (FP16/BF16)."""
+
+import unittest
+
+import torch
+from torch.nn.functional import scaled_dot_product_attention
+
+from sglang.test.test_utils import CustomTestCase
+
+from .rvv_utils import has_sgl_kernel_op, precision
+
+torch.manual_seed(1234)
+
+
+def _run_sdpa_forward_decode(
+    query: torch.Tensor,
+    output: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    req_to_token: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    seq_lens: torch.Tensor,
+    scaling=None,
+    enable_gqa=False,
+    logit_cap=0.0,
+) -> torch.Tensor:
+    """Reference decode attention via PyTorch SDPA (supports logit_cap softcapping)."""
+    # [num_tokens, num_heads, head_size] -> [num_heads, num_tokens, head_size]
+    query = query.movedim(0, query.dim() - 2)
+
+    start_q = 0
+    for seq_idx in range(seq_lens.shape[0]):
+        seq_len_kv = seq_lens[seq_idx]
+        end_q = start_q + 1
+
+        per_req_query = query[:, start_q:end_q, :]
+        req_pool_idx = req_pool_indices[seq_idx]
+        per_req_tokens = req_to_token[req_pool_idx, :seq_len_kv]
+        per_req_key = k_cache[per_req_tokens].movedim(0, query.dim() - 2)
+        per_req_value = v_cache[per_req_tokens].movedim(0, query.dim() - 2)
+
+        if logit_cap > 0:
+            # Manual attention with tanh softcap (PyTorch SDPA has no logit_cap param).
+            # q: [H_Q, 1, D], k: [H_KV, Tk, D], v: [H_KV, Tk, D_V]
+            q = per_req_query.unsqueeze(0).float()
+            k = per_req_key.unsqueeze(0).float()
+            v = per_req_value.unsqueeze(0).float()
+            if enable_gqa:
+                G = q.size(1) // k.size(1)
+                k = k.repeat_interleave(G, dim=1)
+                v = v.repeat_interleave(G, dim=1)
+            scores = torch.matmul(q * scaling, k.transpose(-1, -2))
+            scores = logit_cap * torch.tanh(scores / logit_cap)
+            weights = torch.softmax(scores, dim=-1)
+            per_req_out = (
+                torch.matmul(weights, v)
+                .to(per_req_query.dtype)
+                .squeeze(0)
+                .movedim(query.dim() - 2, 0)
+            )
+        else:
+            per_req_out = (
+                scaled_dot_product_attention(
+                    per_req_query.unsqueeze(0),
+                    per_req_key.unsqueeze(0),
+                    per_req_value.unsqueeze(0),
+                    enable_gqa=enable_gqa,
+                    scale=scaling,
+                )
+                .squeeze(0)
+                .movedim(query.dim() - 2, 0)
+            )
+        output[start_q:end_q, :, :] = per_req_out
+        start_q = end_q
+
+    return output
+
+
+@unittest.skipUnless(
+    has_sgl_kernel_op("decode_attention_cpu"),
+    "decode_attention_cpu not available (non-RISC-V build)",
+)
+class TestRVVDecodeBase(CustomTestCase):
+    """Base class for RVV FP decode attention tests."""
+
+    def setUp(self):
+        super().setUp()
+        self.device = torch.device("cpu")
+        self.dtypes = [torch.float16, torch.bfloat16]
+
+    def _run_decode(
+        self,
+        B,
+        H_Q,
+        H_KV,
+        D,
+        D_V,
+        seq_len=1024,
+        dtype=torch.float16,
+        logit_cap=0.0,
+        num_kv_splits=2,
+    ):
+        device = self.device
+        gen = torch.Generator(device=device)
+        gen.manual_seed(1234)
+        total_tokens = B * seq_len
+        sm_scale = 1.0 / (D**0.5)
+        enable_gqa = H_Q != H_KV
+
+        q = torch.randn(B, H_Q, D, dtype=dtype, device=device, generator=gen)
+        k_buffer = torch.randn(
+            total_tokens, H_KV, D, dtype=dtype, device=device, generator=gen
+        )
+        v_buffer = torch.randn(
+            total_tokens, H_KV, D_V, dtype=dtype, device=device, generator=gen
+        )
+        key = torch.randn(B, H_KV, D, dtype=dtype, device=device, generator=gen)
+        value = torch.randn(B, H_KV, D_V, dtype=dtype, device=device, generator=gen)
+        loc = torch.randint(
+            0, total_tokens, (B,), dtype=torch.int64, device=device, generator=gen
+        )
+
+        k_buffer[loc] = key
+        v_buffer[loc] = value
+
+        o = torch.zeros(B, H_Q, D_V, dtype=dtype, device=device)
+        o_ref = torch.zeros(B, H_Q, D_V, dtype=dtype, device=device)
+
+        # Fragment the token map so cache access is not accidentally contiguous.
+        random_indices = torch.randperm(total_tokens, device=device, generator=gen)
+        req_to_token = random_indices.reshape(B, seq_len).to(torch.int32)
+
+        b_req_idx = torch.arange(B, device=device, dtype=torch.int64)
+        b_seq_len = torch.full((B,), seq_len, device=device, dtype=torch.int64)
+        attn_logits = torch.empty(
+            (B, H_Q, num_kv_splits, D_V + 1), dtype=torch.float32, device=device
+        )
+
+        # Feed non-contiguous views to match the kernel contract.
+        torch.ops.sgl_kernel.decode_attention_cpu(
+            q.transpose(0, 1).contiguous().transpose(0, 1),
+            k_buffer.transpose(0, 1).contiguous().transpose(0, 1),
+            v_buffer.transpose(0, 1).contiguous().transpose(0, 1),
+            o,
+            key.transpose(0, 1).contiguous().transpose(0, 1),
+            value.transpose(0, 1).contiguous().transpose(0, 1),
+            loc,
+            attn_logits,
+            req_to_token,
+            b_req_idx,
+            b_seq_len,
+            sm_scale,
+            logit_cap,
+        )
+
+        _run_sdpa_forward_decode(
+            q,
+            o_ref,
+            k_buffer,
+            v_buffer,
+            req_to_token,
+            b_req_idx,
+            b_seq_len,
+            scaling=sm_scale,
+            enable_gqa=enable_gqa,
+            logit_cap=logit_cap,
+        )
+
+        prec = (
+            precision["attention_decode_logit_cap"].get(
+                q.dtype, precision["attention_decode"][q.dtype]
+            )
+            if logit_cap > 0.0
+            else precision["attention_decode"][q.dtype]
+        )
+        cos_sim_threshold = (
+            0.98 if (logit_cap > 0.0 and q.dtype == torch.bfloat16) else 0.99
+        )
+        cos_sim = torch.nn.functional.cosine_similarity(
+            o.flatten(), o_ref.flatten(), dim=0
+        )
+        self.assertGreater(cos_sim.item(), cos_sim_threshold)
+        torch.testing.assert_close(o, o_ref, atol=prec, rtol=prec)
+
+
+class TestRVVDecodeMHA(TestRVVDecodeBase):
+    """MHA path tests for RVV FP decode attention."""
+
+    def test_mha(self):
+        """Varied shapes cover head-count and seq-len boundary conditions."""
+        configs = [
+            (1, 1, 1, 64, 64, 128),
+            (2, 8, 8, 128, 128, 63),
+            (2, 8, 8, 128, 128, 65),
+            (2, 8, 8, 128, 128, 129),
+            (2, 8, 8, 128, 128, 256),
+            (4, 16, 16, 64, 64, 512),
+            (2, 17, 17, 127, 127, 128),
+            (8, 8, 8, 128, 128, 128),
+            # Asymmetric Q/V head dim.
+            (2, 8, 8, 128, 64, 128),
+            # Non-power-of-2 head dims exercise vector tails.
+            (2, 8, 8, 33, 55, 64),
+            (2, 8, 8, 80, 80, 64),
+        ]
+        for B, H_Q, H_KV, D, D_V, seq_len in configs:
+            for dtype in self.dtypes:
+                with self.subTest(
+                    B=B, H_Q=H_Q, H_KV=H_KV, D=D, D_V=D_V, seq_len=seq_len, dtype=dtype
+                ):
+                    self._run_decode(B, H_Q, H_KV, D, D_V, seq_len=seq_len, dtype=dtype)
+
+    def test_seq_len_one(self):
+        """seq_len=1 hits the kv-split boundary: every split is empty or size-1."""
+        for dtype in self.dtypes:
+            with self.subTest(dtype=dtype):
+                self._run_decode(1, 1, 1, 64, 64, seq_len=1, dtype=dtype)
+
+
+class TestRVVDecodeGQA(TestRVVDecodeBase):
+    """GQA and MQA path tests for RVV FP decode attention."""
+
+    def test_gqa(self):
+        """GQA/MQA shapes verify the H_Q/H_KV ratio reduction is correct."""
+        configs = [
+            (2, 32, 8, 128, 128, 63),
+            (2, 32, 8, 128, 128, 129),
+            (2, 32, 8, 128, 128, 256),
+            (4, 16, 1, 128, 128, 128),
+            (2, 18, 3, 128, 128, 128),
+            (2, 21, 7, 128, 128, 128),
+            (1, 12, 3, 64, 64, 512),
+            # Asymmetric Q/V head dim with GQA.
+            (2, 32, 8, 128, 64, 128),
+        ]
+        for B, H_Q, H_KV, D, D_V, seq_len in configs:
+            for dtype in self.dtypes:
+                with self.subTest(
+                    B=B, H_Q=H_Q, H_KV=H_KV, D=D, D_V=D_V, seq_len=seq_len, dtype=dtype
+                ):
+                    self._run_decode(B, H_Q, H_KV, D, D_V, seq_len=seq_len, dtype=dtype)
+
+
+class TestRVVDecodeLogitCap(TestRVVDecodeBase):
+    """logit_cap (tanh softcapping) path tests."""
+
+    def test_logit_cap(self):
+        """logit_cap > 0 activates the tanh-cap branch; must match manual SDPA."""
+        for dtype in self.dtypes:
+            with self.subTest(dtype=dtype):
+                self._run_decode(
+                    2, 8, 8, 128, 128, seq_len=64, logit_cap=30.0, dtype=dtype
+                )
+                self._run_decode(
+                    2, 8, 2, 128, 128, seq_len=64, logit_cap=30.0, dtype=dtype
+                )
+
+
+class TestRVVDecodeKvSplits2(TestRVVDecodeBase):
+    """Production-default num_kv_splits=2 path for MHA and GQA."""
+
+    def test_kv_splits_2(self):
+        """num_kv_splits=2 is the production default; regression guard."""
+        for dtype in self.dtypes:
+            with self.subTest(dtype=dtype):
+                self._run_decode(
+                    2, 8, 8, 128, 128, seq_len=64, dtype=dtype, num_kv_splits=2
+                )
+                self._run_decode(
+                    2, 8, 2, 128, 128, seq_len=64, dtype=dtype, num_kv_splits=2
+                )
+
+
+@unittest.skipUnless(
+    has_sgl_kernel_op("decode_attention_cpu"),
+    "decode_attention_cpu not available (non-RISC-V build)",
+)
+class TestRVVDecodeValidation(CustomTestCase):
+    """TORCH_CHECK guard tests for decode_attention_cpu."""
+
+    def test_rejects_mixed_dtypes(self):
+        """Mismatched key/query dtypes must be caught early rather than silently corrupting output."""
+        q = torch.randn(1, 2, 32, dtype=torch.float16)
+        k_buffer = torch.randn(8, 2, 32, dtype=torch.float16)
+        v_buffer = torch.randn(8, 2, 32, dtype=torch.float16)
+        output = torch.zeros(1, 2, 32, dtype=torch.float16)
+        key = torch.randn(1, 2, 32, dtype=torch.bfloat16)
+        value = torch.randn(1, 2, 32, dtype=torch.bfloat16)
+        loc = torch.tensor([0], dtype=torch.int64)
+        attn_logits = torch.empty((1, 2, 1, 33), dtype=torch.float32)
+        req_to_token = torch.zeros((1, 4), dtype=torch.int32)
+        req_pool_indices = torch.tensor([0], dtype=torch.int64)
+        seq_lens = torch.tensor([1], dtype=torch.int64)
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "expect query, key, value, k_buffer, and v_buffer to have the same dtype",
+        ):
+            torch.ops.sgl_kernel.decode_attention_cpu(
+                q,
+                k_buffer,
+                v_buffer,
+                output,
+                key,
+                value,
+                loc,
+                attn_logits,
+                req_to_token,
+                req_pool_indices,
+                seq_lens,
+                1.0,
+                0.0,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/cpu/rvv/test_rvv_extend.py
+++ b/test/srt/cpu/rvv/test_rvv_extend.py
@@ -1,0 +1,381 @@
+"""Unit tests for RVV extend attention kernel (BF16/FP16)."""
+
+import unittest
+
+import torch
+from torch.nn.functional import scaled_dot_product_attention
+
+from sglang.test.test_utils import CustomTestCase
+
+from .rvv_utils import has_sgl_kernel_op, precision
+
+torch.manual_seed(1234)
+
+
+# Copied from python/sglang/srt/layers/attention/torch_native_backend.py
+# TorchNativeAttnBackend._run_sdpa_forward_extend
+def run_sdpa_forward_extend(
+    query: torch.Tensor,
+    output: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    req_to_token: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    seq_lens: torch.Tensor,
+    extend_prefix_lens: torch.Tensor,
+    extend_seq_lens: torch.Tensor,
+    scaling=None,
+    enable_gqa=False,
+    causal=False,
+):
+    assert seq_lens.shape[0] == extend_prefix_lens.shape[0]
+    assert seq_lens.shape[0] == extend_seq_lens.shape[0]
+
+    # [num_tokens, num_heads, head_size] -> [num_heads, num_tokens, head_size]
+    query = query.movedim(0, query.dim() - 2)
+
+    start_q, start_kv = 0, 0
+    for seq_idx in range(seq_lens.shape[0]):
+        # TODO: this loop process a sequence per iter, this is inefficient.
+        # Need optimize the performance later.
+
+        extend_seq_len_q = extend_seq_lens[seq_idx]
+        prefill_seq_len_q = extend_prefix_lens[seq_idx]
+
+        seq_len_kv = seq_lens[seq_idx]
+        end_q = start_q + extend_seq_len_q
+        end_kv = start_kv + seq_len_kv
+
+        per_req_query = query[:, start_q:end_q, :]
+        per_req_query_redudant = torch.empty(
+            (per_req_query.shape[0], seq_len_kv, per_req_query.shape[2]),
+            dtype=per_req_query.dtype,
+            device=per_req_query.device,
+        )
+
+        per_req_query_redudant[:, prefill_seq_len_q:, :] = per_req_query
+
+        # get key and value from cache. per_req_tokens contains the kv cache
+        # index for each token in the sequence.
+        req_pool_idx = req_pool_indices[seq_idx]
+        per_req_tokens = req_to_token[req_pool_idx, :seq_len_kv]
+        per_req_key = k_cache[per_req_tokens].movedim(0, query.dim() - 2)
+        per_req_value = v_cache[per_req_tokens].movedim(0, query.dim() - 2)
+
+        if not (per_req_query.dtype == per_req_key.dtype == per_req_value.dtype):
+            # scaled_dot_product_attention() expects query, key, and value to have the same dtype
+            per_req_key = per_req_key.to(per_req_query.dtype)
+            per_req_value = per_req_value.to(per_req_query.dtype)
+
+        per_req_out_redudant = (
+            scaled_dot_product_attention(
+                per_req_query_redudant.unsqueeze(0),
+                per_req_key.unsqueeze(0),
+                per_req_value.unsqueeze(0),
+                enable_gqa=enable_gqa,
+                scale=scaling,
+                is_causal=causal,
+            )
+            .squeeze(0)
+            .movedim(query.dim() - 2, 0)
+        )
+        output[start_q:end_q, :, :] = per_req_out_redudant[prefill_seq_len_q:, :, :]
+        start_q, start_kv = end_q, end_kv
+    return output
+
+
+@unittest.skipUnless(
+    has_sgl_kernel_op("extend_attention_cpu"),
+    "extend_attention_cpu not available (non-RISC-V build)",
+)
+class TestRVVExtendBase(CustomTestCase):
+    """Shared fixtures and helpers for RVV extend attention tests."""
+
+    def setUp(self):
+        super().setUp()
+        self.device = torch.device("cpu")
+        self.dtypes = [torch.float16, torch.bfloat16]
+
+    def _run_extend(
+        self,
+        B,
+        N_CTX,
+        H_Q,
+        H_KV,
+        D,
+        DV,
+        logit_cap=0.0,
+        force_prefix_zero=False,
+        dtype=torch.bfloat16,
+    ):
+        gen = torch.Generator(device=self.device)
+        gen.manual_seed(1234)
+        _hi = max(N_CTX // 2, 2)  # randint requires hi > lo=1; guard N_CTX=1
+        if force_prefix_zero:
+            b_seq_len_prefix = torch.zeros(B, dtype=torch.int32)
+            b_seq_len_extend = torch.randint(
+                1, _hi, (B,), dtype=torch.int32, generator=gen
+            )
+        else:
+            b_seq_len_prefix = torch.randint(
+                1, _hi, (B,), dtype=torch.int32, generator=gen
+            )
+            b_seq_len_extend = torch.randint(
+                1, _hi, (B,), dtype=torch.int32, generator=gen
+            )
+        b_seq_len = b_seq_len_prefix + b_seq_len_extend
+        max_len_in_batch = torch.max(b_seq_len, 0)[0].item()
+
+        b_req_idx = torch.arange(B, dtype=torch.int32)
+        req_to_tokens = torch.empty((B, max_len_in_batch), dtype=torch.int32)
+        b_start_loc = torch.zeros((B,), dtype=torch.int32)
+        b_start_loc[1:] = torch.cumsum(b_seq_len[:-1], 0)
+        b_start_loc_extend = torch.zeros((B,), dtype=torch.int32)
+        b_start_loc_extend[1:] = torch.cumsum(b_seq_len_extend[:-1], 0)
+
+        for i in range(B):
+            req_to_tokens[i, : b_seq_len[i]] = torch.arange(
+                b_start_loc[i], b_start_loc[i] + b_seq_len[i]
+            )
+
+        total_token_num = torch.sum(b_seq_len).item()
+        extend_token_num = torch.sum(b_seq_len_extend).item()
+
+        k_buffer = torch.randn((total_token_num, H_KV, D), dtype=dtype, generator=gen)
+        v_buffer = torch.randn((total_token_num, H_KV, DV), dtype=dtype, generator=gen)
+
+        k_extend = torch.empty((extend_token_num, H_KV, D), dtype=dtype)
+        v_extend = torch.empty((extend_token_num, H_KV, DV), dtype=dtype)
+        q_extend = torch.empty((extend_token_num, H_Q, D), dtype=dtype)
+
+        for i in range(B):
+            extend_start_in_buffer = b_start_loc[i] + b_seq_len_prefix[i]
+            extend_end_in_buffer = b_start_loc[i] + b_seq_len[i]
+            extend_start = b_start_loc_extend[i]
+            extend_end = b_start_loc_extend[i] + b_seq_len_extend[i]
+            k_extend[extend_start:extend_end] = k_buffer[
+                extend_start_in_buffer:extend_end_in_buffer
+            ]
+            v_extend[extend_start:extend_end] = v_buffer[
+                extend_start_in_buffer:extend_end_in_buffer
+            ]
+            q_extend[extend_start:extend_end] = torch.randn(
+                (b_seq_len_extend[i], H_Q, D), dtype=dtype, generator=gen
+            )
+
+        # Feed non-contiguous views to match the kernel path used in production.
+        q_extend_k = q_extend.transpose(0, 1).contiguous().transpose(0, 1)
+        k_extend_k = k_extend.transpose(0, 1).contiguous().transpose(0, 1)
+        v_extend_k = v_extend.transpose(0, 1).contiguous().transpose(0, 1)
+        k_buffer_k = k_buffer.transpose(0, 1).contiguous().transpose(0, 1)
+        v_buffer_k = v_buffer.transpose(0, 1).contiguous().transpose(0, 1)
+
+        b_seq_len_extend = b_seq_len - b_seq_len_prefix
+        b_start_loc_extend = torch.zeros_like(b_seq_len)
+        b_start_loc_extend[1:] = torch.cumsum(b_seq_len_extend[:-1], 0)
+        max_len_extend = torch.max(b_seq_len_extend, 0)[0].item()
+
+        sm_scale = 1.0 / (D**0.5)
+
+        b_req_idx = b_req_idx.to(torch.int64)
+        b_seq_len = b_seq_len.to(torch.int64)
+
+        enable_gqa = H_Q != H_KV
+        o_ref = torch.empty((extend_token_num, H_Q, DV), dtype=dtype)
+        run_sdpa_forward_extend(
+            q_extend,
+            o_ref,
+            k_buffer,
+            v_buffer,
+            req_to_tokens,
+            b_req_idx,
+            b_seq_len,
+            b_seq_len_prefix,
+            b_seq_len_extend,
+            scaling=sm_scale,
+            enable_gqa=enable_gqa,
+            causal=True,
+        )
+
+        o_extend = torch.empty((extend_token_num, H_Q, DV), dtype=dtype)
+        torch.ops.sgl_kernel.extend_attention_cpu(
+            q_extend_k,
+            k_extend_k,
+            v_extend_k,
+            o_extend,
+            k_buffer_k,
+            v_buffer_k,
+            req_to_tokens,
+            b_req_idx,
+            b_seq_len,
+            b_seq_len_extend,
+            b_start_loc_extend,
+            max_len_extend,
+            sm_scale,
+            logit_cap,
+        )
+
+        atol = rtol = (
+            precision["attention_decode_logit_cap"].get(
+                dtype, precision["attention_extend"][dtype]
+            )
+            if logit_cap > 0.0
+            else precision["attention_extend"][dtype]
+        )
+        torch.testing.assert_close(o_ref, o_extend, atol=atol, rtol=rtol)
+
+
+class TestRVVExtendMHA(TestRVVExtendBase):
+    """MHA path tests for RVV extend attention."""
+
+    def test_mha(self):
+        """Varied shapes cover head-count and prefix/extend length boundaries."""
+        configs = [
+            (2, 128, 16, 16, 128, 96, 0.0),
+            (2, 64, 8, 8, 32, 32, 0.0),
+            (4, 64, 8, 8, 128, 96, 0.0),
+            (2, 128, 16, 16, 128, 96, 50.0),
+            (1, 256, 4, 4, 64, 64, 0.0),
+        ]
+        for B, N_CTX, H_Q, H_KV, D, DV, logit_cap in configs:
+            for dtype in self.dtypes:
+                with self.subTest(
+                    B=B,
+                    N_CTX=N_CTX,
+                    H_Q=H_Q,
+                    H_KV=H_KV,
+                    D=D,
+                    DV=DV,
+                    logit_cap=logit_cap,
+                    dtype=dtype,
+                ):
+                    self._run_extend(
+                        B=B,
+                        N_CTX=N_CTX,
+                        H_Q=H_Q,
+                        H_KV=H_KV,
+                        D=D,
+                        DV=DV,
+                        dtype=dtype,
+                        logit_cap=logit_cap,
+                    )
+
+    def test_mha_zero_prefix(self):
+        """Zero prefix ensures Stage 1 (cached KV) is skipped entirely."""
+        configs = [
+            (2, 128, 16, 16, 128, 96, 0.0),
+            (1, 64, 8, 8, 64, 64, 0.0),
+            (4, 64, 8, 8, 128, 96, 0.0),
+        ]
+        for B, N_CTX, H_Q, H_KV, D, DV, logit_cap in configs:
+            for dtype in self.dtypes:
+                with self.subTest(
+                    B=B, N_CTX=N_CTX, H_Q=H_Q, H_KV=H_KV, D=D, DV=DV, dtype=dtype
+                ):
+                    self._run_extend(
+                        B=B,
+                        N_CTX=N_CTX,
+                        H_Q=H_Q,
+                        H_KV=H_KV,
+                        D=D,
+                        DV=DV,
+                        dtype=dtype,
+                        logit_cap=logit_cap,
+                        force_prefix_zero=True,
+                    )
+
+    def test_mha_single_token(self):
+        """N_CTX=1 hits the single-row BLOCK_M boundary; tiling must not OOB."""
+        for dtype in self.dtypes:
+            with self.subTest(dtype=dtype, force_prefix_zero=False):
+                self._run_extend(
+                    B=2,
+                    N_CTX=1,
+                    H_Q=8,
+                    H_KV=8,
+                    D=64,
+                    DV=64,
+                    dtype=dtype,
+                )
+            with self.subTest(dtype=dtype, force_prefix_zero=True):
+                self._run_extend(
+                    B=2,
+                    N_CTX=1,
+                    H_Q=8,
+                    H_KV=8,
+                    D=64,
+                    DV=64,
+                    dtype=dtype,
+                    force_prefix_zero=True,
+                )
+
+
+class TestRVVExtendGQA(TestRVVExtendBase):
+    """GQA path tests for RVV extend attention."""
+
+    def test_gqa(self):
+        """GQA shapes verify H_Q/H_KV ratio broadcasting is correct in both stages."""
+        configs = [
+            (2, 128, 32, 8, 128, 96),
+            (4, 128, 24, 4, 64, 64),
+            (1, 256, 16, 2, 128, 128),
+            (2, 64, 18, 3, 32, 32),
+        ]
+        for B, N_CTX, H_Q, H_KV, D, DV in configs:
+            for dtype in self.dtypes:
+                with self.subTest(
+                    B=B, N_CTX=N_CTX, H_Q=H_Q, H_KV=H_KV, D=D, DV=DV, dtype=dtype
+                ):
+                    self._run_extend(
+                        B=B,
+                        N_CTX=N_CTX,
+                        H_Q=H_Q,
+                        H_KV=H_KV,
+                        D=D,
+                        DV=DV,
+                        dtype=dtype,
+                    )
+
+    def test_gqa_logit_cap(self):
+        """GQA + logit_cap: tanh-softcap must interact correctly with GQA broadcasting."""
+        configs = [
+            (2, 128, 32, 8, 128, 96),
+            (1, 256, 16, 2, 128, 128),
+        ]
+        for B, N_CTX, H_Q, H_KV, D, DV in configs:
+            for dtype in self.dtypes:
+                with self.subTest(B=B, H_Q=H_Q, H_KV=H_KV, dtype=dtype):
+                    self._run_extend(
+                        B=B,
+                        N_CTX=N_CTX,
+                        H_Q=H_Q,
+                        H_KV=H_KV,
+                        D=D,
+                        DV=DV,
+                        logit_cap=50.0,
+                        dtype=dtype,
+                    )
+
+    def test_gqa_zero_prefix(self):
+        """GQA with no prefix: Stage 1 (cached KV) is skipped, only Stage 2 runs."""
+        configs = [
+            (2, 128, 32, 8, 128, 96),
+            (1, 256, 16, 2, 128, 128),
+        ]
+        for B, N_CTX, H_Q, H_KV, D, DV in configs:
+            for dtype in self.dtypes:
+                with self.subTest(B=B, H_Q=H_Q, H_KV=H_KV, dtype=dtype):
+                    self._run_extend(
+                        B=B,
+                        N_CTX=N_CTX,
+                        H_Q=H_Q,
+                        H_KV=H_KV,
+                        D=D,
+                        DV=DV,
+                        dtype=dtype,
+                        force_prefix_zero=True,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/cpu/rvv/test_rvv_gemm.py
+++ b/test/srt/cpu/rvv/test_rvv_gemm.py
@@ -1,0 +1,370 @@
+"""Unit tests for RVV GEMM kernels."""
+
+import itertools
+import unittest
+
+import torch
+
+from sglang.test.test_utils import CustomTestCase
+
+from .rvv_utils import has_sgl_kernel_op, helper_non_contiguous, precision
+
+torch.manual_seed(1234)
+
+
+def native_w8a8_per_token_matmul(A, B, As, Bs, bias, output_dtype=torch.bfloat16):
+    """RVV CPU W8A8 reference: activation is uint8, weight is int8."""
+    A = A.to(torch.int32) - 128
+    B = B.to(torch.int32)
+
+    assert A.shape[-1] == B.shape[-1], "Dimension mismatch"
+    assert B.ndim == 2 and B.is_contiguous(), "B must be a 2D contiguous tensor"
+
+    M = A.numel() // A.shape[-1]
+    K = A.shape[-1]
+    origin_C_shape = A.shape[:-1] + (B.shape[0],)
+    A = A.reshape(M, K)
+
+    C = torch.matmul(A, B.transpose(0, 1))
+
+    As = As.reshape(M, 1).to(torch.float32)
+    C = As * C.to(torch.float32) * Bs.view(1, -1).to(torch.float32)
+
+    if bias is not None:
+        C.add_(bias.view(1, -1).to(torch.float32))
+
+    return C.reshape(origin_C_shape).to(output_dtype)
+
+
+def _has_rvv_bf16_gemm_ops() -> bool:
+    return has_sgl_kernel_op("weight_packed_linear") and has_sgl_kernel_op(
+        "convert_weight_packed"
+    )
+
+
+def _has_rvv_int8_gemm_ops() -> bool:
+    return (
+        has_sgl_kernel_op("convert_weight_packed")
+        and has_sgl_kernel_op("per_token_quant_int8_cpu")
+        and has_sgl_kernel_op("int8_scaled_mm_cpu")
+        and has_sgl_kernel_op("int8_scaled_mm_with_quant")
+    )
+
+
+class TestRVVGemm(CustomTestCase):
+    M = [1, 2, 3, 4, 5, 101]
+    N = [16, 32, 48, 64, 80]
+    K = [100, 32 * 16]
+    has_bias = [False, True]
+    dtypes = [torch.float16, torch.bfloat16]
+
+    # Cover the FMA path once N exceeds a single vector-length chunk.
+    N_fma = [100, 300]
+
+    M_int8 = [1, 2, 3, 5, 128]  # Exercises the TILE_M=4 short-row path.
+    N_int8 = [16, 32 * 12, 80]  # Covers small-N, large-N, and tail handling.
+    K_int8 = [32 * 17]
+
+    def _run_bf16(self, M, N, K, has_bias, dtype):
+        mat1 = torch.randn(M, K, dtype=dtype)
+        mat2 = torch.randn(N, K, dtype=dtype)
+
+        ref = torch.matmul(mat1.float(), mat2.float().t())
+        if has_bias:
+            bias = torch.randn(N, dtype=torch.float32)
+            if dtype == torch.bfloat16:
+                ref.add_(bias.bfloat16())
+            else:
+                ref.add_(bias.half())
+
+        if dtype == torch.bfloat16:
+            ref = ref.bfloat16()
+        else:
+            ref = ref.half()
+
+        out = torch.ops.sgl_kernel.weight_packed_linear(
+            mat1, mat2, bias if has_bias else None, False
+        )
+
+        packed_mat2 = torch.ops.sgl_kernel.convert_weight_packed(mat2)
+        out2 = torch.ops.sgl_kernel.weight_packed_linear(
+            mat1, packed_mat2, bias if has_bias else None, True
+        )
+
+        atol = rtol = precision["linear_gemm"][dtype]
+
+        torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+        torch.testing.assert_close(ref, out2, atol=atol, rtol=rtol)
+
+    @unittest.skipUnless(_has_rvv_bf16_gemm_ops(), "RVV BF16 GEMM ops not available")
+    def test_bf16(self):
+        """Shape + bias matrix covers M-tail, N-chunk, and K-stride combinations."""
+        for params in itertools.product(
+            self.M,
+            self.N,
+            self.K,
+            self.has_bias,
+            self.dtypes,
+        ):
+            with self.subTest(
+                M=params[0],
+                N=params[1],
+                K=params[2],
+                has_bias=params[3],
+                dtype=params[4],
+            ):
+                self._run_bf16(*params)
+
+    @unittest.skipUnless(_has_rvv_bf16_gemm_ops(), "RVV BF16 GEMM ops not available")
+    def test_bf16_fma_path(self):
+        """Large N forces the multi-chunk FMA loop; exercises accumulation across chunks."""
+        for params in itertools.product(
+            self.M,
+            self.N_fma,
+            self.K,
+            self.has_bias,
+            self.dtypes,
+        ):
+            with self.subTest(
+                M=params[0],
+                N=params[1],
+                K=params[2],
+                has_bias=params[3],
+                dtype=params[4],
+            ):
+                self._run_bf16(*params)
+
+    def _run_int8(self, M, N, K, has_bias, dtype):
+        A = torch.randn((M, K), dtype=dtype) / 10
+
+        Aq, As = torch.ops.sgl_kernel.per_token_quant_int8_cpu(A)
+        self.assertEqual(Aq.dtype, torch.uint8)
+        self.assertEqual(As.dtype, torch.float32)
+        self.assertEqual(tuple(As.shape), (M,))
+
+        factor_for_scale = 1e-2
+        int8_max = 127
+        int8_min = -128
+
+        B = (torch.rand((N, K), dtype=torch.float32) - 0.5) * 2
+        Bq = (B * int8_max).clamp(min=int8_min, max=int8_max).to(torch.int8)
+        Bs = (torch.rand(N) * factor_for_scale).to(torch.float32)
+
+        bias = torch.randn(N) if has_bias else None
+
+        # Match the unpacked RVV math path first, then compare packed variants.
+        ref_out = native_w8a8_per_token_matmul(Aq, Bq, As, Bs, bias, dtype)
+
+        atol = rtol = precision["pointwise_default"][ref_out.dtype]
+
+        Bq_packed = torch.ops.sgl_kernel.convert_weight_packed(Bq)
+
+        out_unpacked = torch.ops.sgl_kernel.int8_scaled_mm_cpu(
+            Aq,
+            Bq,
+            As,
+            Bs,
+            bias if has_bias else None,
+            dtype,
+            False,
+        )
+
+        out_packed = torch.ops.sgl_kernel.int8_scaled_mm_cpu(
+            Aq,
+            Bq_packed,
+            As,
+            Bs,
+            bias if has_bias else None,
+            dtype,
+            True,
+        )
+
+        fused_out_unpacked = torch.ops.sgl_kernel.int8_scaled_mm_with_quant(
+            A,
+            Bq,
+            Bs,
+            bias if has_bias else None,
+            dtype,
+            False,
+        )
+
+        fused_out_packed = torch.ops.sgl_kernel.int8_scaled_mm_with_quant(
+            A,
+            Bq_packed,
+            Bs,
+            bias if has_bias else None,
+            dtype,
+            True,
+        )
+
+        torch.testing.assert_close(ref_out, out_unpacked, atol=atol, rtol=rtol)
+        torch.testing.assert_close(ref_out, out_packed, atol=atol, rtol=rtol)
+        torch.testing.assert_close(ref_out, fused_out_unpacked, atol=atol, rtol=rtol)
+        torch.testing.assert_close(ref_out, fused_out_packed, atol=atol, rtol=rtol)
+
+    @unittest.skipUnless(_has_rvv_int8_gemm_ops(), "RVV INT8 GEMM ops not available")
+    def test_int8(self):
+        """TILE_M=4 short-row path and scale dequantization across the full shape matrix."""
+        for params in itertools.product(
+            self.M_int8,
+            self.N_int8,
+            self.K_int8,
+            self.has_bias,
+            self.dtypes,
+        ):
+            with self.subTest(
+                M=params[0],
+                N=params[1],
+                K=params[2],
+                has_bias=params[3],
+                dtype=params[4],
+            ):
+                self._run_int8(*params)
+
+    def _run_bf16_small_oc(self, M, N, K, has_bias, dtype):
+        mat1 = torch.randn(M, K, dtype=dtype)
+        mat2 = torch.randn(N, K, dtype=dtype)
+
+        ref = torch.nn.functional.linear(mat1.float(), mat2.float())
+        if has_bias:
+            bias = torch.randn(N, dtype=torch.float32)
+            ref.add_(bias)
+
+        ref = ref.to(dtype)
+        out = torch.ops.sgl_kernel.weight_packed_linear(
+            mat1,
+            torch.ops.sgl_kernel.convert_weight_packed(mat2),
+            bias if has_bias else None,
+            True,
+        )
+        atol = rtol = precision["linear_gemm"][dtype]
+        torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+    @unittest.skipUnless(_has_rvv_bf16_gemm_ops(), "RVV BF16 GEMM ops not available")
+    def test_bf16_small_oc(self):
+        """N=1,12 exercises the scalar/sub-chunk output path that bypasses the main VL loop."""
+        for params in itertools.product(
+            [1, 8, 32, 1024], [12, 1], self.K, self.has_bias, self.dtypes
+        ):
+            with self.subTest(
+                M=params[0],
+                N=params[1],
+                K=params[2],
+                has_bias=params[3],
+                dtype=params[4],
+            ):
+                self._run_bf16_small_oc(*params)
+
+    @unittest.skipUnless(_has_rvv_bf16_gemm_ops(), "RVV BF16 GEMM ops not available")
+    def test_bf16_non_contiguous(self):
+        """Non-contiguous activation must be handled without silent stride corruption."""
+        M, N, K = 8, 64, 512
+        for dtype in self.dtypes:
+            with self.subTest(dtype=dtype):
+                mat2 = torch.randn(N, K, dtype=dtype)
+                mat1 = helper_non_contiguous(torch.randn(M, K, dtype=dtype))
+                self.assertFalse(mat1.is_contiguous())
+
+                ref = torch.matmul(mat1.float(), mat2.float().t()).to(dtype)
+                packed_mat2 = torch.ops.sgl_kernel.convert_weight_packed(mat2)
+                out = torch.ops.sgl_kernel.weight_packed_linear(
+                    mat1, packed_mat2, None, True
+                )
+                atol = rtol = precision["linear_gemm"][dtype]
+                torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+    @unittest.skipUnless(_has_rvv_int8_gemm_ops(), "RVV INT8 GEMM ops not available")
+    def test_int8_non_contiguous(self):
+        """Non-contiguous INT8 activation must not corrupt quantization or GEMM output."""
+        M, N, K = 5, 32, 32 * 17
+        for dtype in self.dtypes:
+            with self.subTest(dtype=dtype):
+                A = helper_non_contiguous(torch.randn(M, K, dtype=dtype) / 10)
+                self.assertFalse(A.is_contiguous())
+                Aq, As = torch.ops.sgl_kernel.per_token_quant_int8_cpu(A)
+                self.assertEqual(Aq.dtype, torch.uint8)
+
+                Bq = (
+                    (torch.rand(N, K, dtype=torch.float32) - 0.5)
+                    .mul(127)
+                    .clamp(-128, 127)
+                    .to(torch.int8)
+                )
+                Bs = (torch.rand(N) * 1e-2).to(torch.float32)
+                Bq_packed = torch.ops.sgl_kernel.convert_weight_packed(Bq)
+
+                ref = native_w8a8_per_token_matmul(Aq, Bq, As, Bs, None, dtype)
+                out_direct = torch.ops.sgl_kernel.int8_scaled_mm_cpu(
+                    Aq, Bq, As, Bs, None, dtype, False
+                )
+                out = torch.ops.sgl_kernel.int8_scaled_mm_with_quant(
+                    A, Bq_packed, Bs, None, dtype, True
+                )
+                atol = rtol = precision["pointwise_default"][dtype]
+                torch.testing.assert_close(ref, out_direct, atol=atol, rtol=rtol)
+                torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+    @unittest.skipUnless(_has_rvv_int8_gemm_ops(), "RVV INT8 GEMM ops not available")
+    def test_int8_rejects_k_mismatch(self):
+        """K-dim mismatch must raise rather than silently reading out-of-bounds."""
+        dtype = torch.float16
+        A = torch.randn(2, 64, dtype=dtype) / 10
+        Aq, As = torch.ops.sgl_kernel.per_token_quant_int8_cpu(A)
+        bad_Bq = torch.randint(-8, 8, (32, 63), dtype=torch.int8)
+        Bs = torch.rand(32, dtype=torch.float32) * 0.01
+
+        with self.assertRaises(RuntimeError):
+            torch.ops.sgl_kernel.int8_scaled_mm_cpu(
+                Aq,
+                bad_Bq,
+                As,
+                Bs,
+                None,
+                dtype,
+                False,
+            )
+
+        with self.assertRaises(RuntimeError):
+            torch.ops.sgl_kernel.int8_scaled_mm_with_quant(
+                A,
+                bad_Bq,
+                Bs,
+                None,
+                dtype,
+                False,
+            )
+
+    @unittest.skipUnless(_has_rvv_int8_gemm_ops(), "RVV INT8 GEMM ops not available")
+    def test_int8_rejects_packed_mismatch(self):
+        """Packed weight NB/scale count mismatch must raise instead of producing garbage."""
+        dtype = torch.float16
+        K = 64
+        A = torch.randn(2, K, dtype=dtype) / 10
+        Aq, As = torch.ops.sgl_kernel.per_token_quant_int8_cpu(A)
+        packed_Bq = torch.randint(-8, 8, (1, 32 * (K + 4)), dtype=torch.int8)
+        Bs = torch.rand(80, dtype=torch.float32) * 0.01
+
+        with self.assertRaises(RuntimeError):
+            torch.ops.sgl_kernel.int8_scaled_mm_cpu(
+                Aq,
+                packed_Bq,
+                As,
+                Bs,
+                None,
+                dtype,
+                True,
+            )
+
+        with self.assertRaises(RuntimeError):
+            torch.ops.sgl_kernel.int8_scaled_mm_with_quant(
+                A,
+                packed_Bq,
+                Bs,
+                None,
+                dtype,
+                True,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/cpu/rvv/test_rvv_norm.py
+++ b/test/srt/cpu/rvv/test_rvv_norm.py
@@ -1,0 +1,376 @@
+"""Unit tests for RVV norm kernels."""
+
+import itertools
+import unittest
+
+import torch
+
+from sglang.test.test_utils import CustomTestCase
+
+from .rvv_utils import has_sgl_kernel_op, helper_non_contiguous, precision
+
+torch.manual_seed(1234)
+
+
+def rmsnorm_native(x, weight, eps, residual=None):
+    """Reference RMSNorm: out = x * rsqrt(mean(x^2) + eps) * weight."""
+    orig_dtype = x.dtype
+    x = x.to(torch.float32)
+    if residual is not None:
+        x = x + residual.to(torch.float32)
+        residual = x.to(orig_dtype)
+    variance = x.pow(2).mean(dim=-1, keepdim=True)
+    x = x * torch.rsqrt(variance + eps)
+    x = x.to(orig_dtype) * weight
+    return x if residual is None else (x, residual)
+
+
+def gemma_rmsnorm_native(x, weight, eps, residual=None):
+    """Reference Gemma RMSNorm: scale = (1 + weight)."""
+    orig_dtype = x.dtype
+    if residual is not None:
+        x = x + residual
+        residual = x
+    x = x.float()
+    variance = x.pow(2).mean(dim=-1, keepdim=True)
+    x = x * torch.rsqrt(variance + eps)
+    x = x * (1.0 + weight.float())
+    x = x.to(orig_dtype)
+    return x if residual is None else (x, residual)
+
+
+def gemma3_rmsnorm_native(x, weight, eps):
+    """Reference Gemma3 RMSNorm: supports 2D and 4D inputs."""
+    output = x.float() * torch.rsqrt(x.float().pow(2).mean(-1, keepdim=True) + eps)
+    output = output * (1.0 + weight.float())
+    return output.type_as(x)
+
+
+def fused_rmsnorm_gated_native(x, weight, gate, eps):
+    """Reference fused gated RMSNorm: rms_norm(x) * weight * silu(gate)."""
+    input_dtype = x.dtype
+    x = x.to(torch.float32)
+    variance = x.pow(2).mean(-1, keepdim=True)
+    x = x * torch.rsqrt(variance + eps)
+    x = weight * x.to(input_dtype)
+    x = x * torch.nn.functional.silu(gate.to(torch.float32))
+    return x.to(input_dtype)
+
+
+def layernorm_native(x, weight, eps, residual=None):
+    """Reference LayerNorm: mean+var two pass."""
+    orig_dtype = x.dtype
+    x = x.to(torch.float32)
+    if residual is not None:
+        x = x + residual.to(torch.float32)
+        residual = x.to(orig_dtype)
+    variance, mean = torch.var_mean(x, dim=-1, keepdim=True, correction=0)
+    x = (x - mean) * torch.rsqrt(variance + eps)
+    x = x.to(orig_dtype) * weight
+    return x if residual is None else (x, residual)
+
+
+@unittest.skipUnless(
+    has_sgl_kernel_op("rmsnorm_cpu"),
+    "sgl_kernel norm not available (non-RISC-V build)",
+)
+class TestRVVNormCore(CustomTestCase):
+    """Test suite for RVV norm kernels."""
+
+    M = [128, 129, 257, 1024, 4096]
+    N = [4096, 4109]
+    dtype = [torch.float16, torch.bfloat16]
+
+    def _run_rmsnorm(self, m, n, x=None, dtype=torch.float16):
+        if x is None:
+            x = torch.randn([m, n], dtype=dtype)
+        weight = torch.randn(n, dtype=dtype)
+        eps = 1e-6
+
+        out = torch.ops.sgl_kernel.rmsnorm_cpu(x, weight, eps)
+        ref = rmsnorm_native(x, weight, eps)
+        atol = rtol = precision["pointwise_default"][dtype]
+        torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+    def _run_fused_add_rmsnorm(self, m, n, dtype):
+        x = torch.randn([m, n], dtype=dtype)
+        residual = torch.randn([m, n], dtype=dtype)
+        weight = torch.randn(n, dtype=dtype)
+        eps = 1e-6
+
+        ref_x = x.clone()
+        ref_residual = residual.clone()
+
+        torch.ops.sgl_kernel.fused_add_rmsnorm_cpu(x, residual, weight, eps)
+        ref_out, ref_res = rmsnorm_native(ref_x, weight, eps, ref_residual)
+
+        atol = rtol = precision["pointwise_default"][dtype]
+        torch.testing.assert_close(x, ref_out, atol=atol, rtol=rtol)
+        torch.testing.assert_close(residual, ref_res, atol=atol, rtol=rtol)
+
+    def _run_l2norm(self, m, n, dtype):
+        x = torch.randn([m, n], dtype=dtype)
+        eps = 1e-6
+
+        out = torch.ops.sgl_kernel.l2norm_cpu(x, eps)
+        # L2 norm matches RMSNorm with a unit weight vector.
+        fake_weight = torch.ones(n, dtype=dtype)
+        ref = rmsnorm_native(x, fake_weight, eps)
+
+        atol = rtol = precision["pointwise_default"][dtype]
+        torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+    def _run_gemma_rmsnorm(self, m, n, dtype):
+        x = torch.randn([m, n], dtype=dtype)
+        weight = torch.randn(n, dtype=dtype)
+        eps = 1e-6
+
+        out = torch.ops.sgl_kernel.gemma_rmsnorm_cpu(x, weight, eps)
+        ref = gemma_rmsnorm_native(x, weight, eps)
+        atol = rtol = precision["pointwise_default"][dtype]
+        torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+    def _run_gemma_fused_add(self, m, n, dtype):
+        x = torch.randn([m, n], dtype=dtype)
+        residual = torch.randn([m, n], dtype=dtype)
+        weight = torch.randn(n, dtype=dtype)
+        eps = 1e-6
+
+        ref_x = x.clone()
+        ref_residual = residual.clone()
+
+        torch.ops.sgl_kernel.gemma_fused_add_rmsnorm_cpu(x, residual, weight, eps)
+        ref_out, ref_res = gemma_rmsnorm_native(ref_x, weight, eps, ref_residual)
+
+        atol = rtol = precision["pointwise_default"][dtype]
+        torch.testing.assert_close(x, ref_out, atol=atol, rtol=rtol)
+        torch.testing.assert_close(residual, ref_res, atol=atol, rtol=rtol)
+
+    def _run_gemma3_rmsnorm(self, m, n, dtype):
+        x_2d = torch.randn([m, n], dtype=dtype)
+        weight = torch.randn(n, dtype=dtype)
+        eps = 1e-6
+
+        out_2d = torch.ops.sgl_kernel.gemma3_rmsnorm_cpu(x_2d, weight, eps)
+        ref_2d = gemma3_rmsnorm_native(x_2d, weight, eps)
+        atol = rtol = precision["pointwise_default"][dtype]
+        torch.testing.assert_close(ref_2d, out_2d, atol=atol, rtol=rtol)
+
+        # Also cover the 4D layout used by attention blocks.
+        x_4d = torch.randn([1, m, 2, n], dtype=dtype)
+        out_4d = torch.ops.sgl_kernel.gemma3_rmsnorm_cpu(x_4d, weight, eps)
+        ref_4d = gemma3_rmsnorm_native(x_4d, weight, eps)
+        torch.testing.assert_close(ref_4d, out_4d, atol=atol, rtol=rtol)
+
+    def test_rmsnorm(self):
+        """N+13 odd shape catches tail handling; M range covers VLEN=256 boundary."""
+        for m, n, dt in itertools.product(self.M, self.N, self.dtype):
+            with self.subTest(m=m, n=n, dtype=dt):
+                self._run_rmsnorm(m, n, dtype=dt)
+
+    def test_fused_add_rmsnorm(self):
+        """Both output tensors (normed x and updated residual) must match reference."""
+        for m, n, dt in itertools.product(self.M, self.N, self.dtype):
+            with self.subTest(m=m, n=n, dtype=dt):
+                self._run_fused_add_rmsnorm(m, n, dt)
+
+    def test_l2norm(self):
+        """L2Norm equals RMSNorm with unit weight; shared shape matrix catches tails."""
+        for m, n, dt in itertools.product(self.M, self.N, self.dtype):
+            with self.subTest(m=m, n=n, dtype=dt):
+                self._run_l2norm(m, n, dt)
+
+    def test_gemma_rmsnorm(self):
+        for m, n, dt in itertools.product(self.M, self.N, self.dtype):
+            with self.subTest(m=m, n=n, dtype=dt):
+                self._run_gemma_rmsnorm(m, n, dt)
+
+    def test_gemma_fused_add_rmsnorm(self):
+        for m, n, dt in itertools.product(self.M, self.N, self.dtype):
+            with self.subTest(m=m, n=n, dtype=dt):
+                self._run_gemma_fused_add(m, n, dt)
+
+    def test_gemma3_rmsnorm(self):
+        """Gemma3 adds (1 + w) scaling; both 2D and 4D layouts must match reference."""
+        for m, n, dt in itertools.product(self.M, self.N, self.dtype):
+            with self.subTest(m=m, n=n, dtype=dt):
+                self._run_gemma3_rmsnorm(m, n, dt)
+
+    def test_gemma3_rmsnorm_4d_multi_batch(self):
+        """Case: Gemma3 RMSNorm 4D with batch_size > 1."""
+        for dt in self.dtype:
+            n = 4096
+            x = torch.randn([2, 4, 3, n], dtype=dt)
+            weight = torch.randn(n, dtype=dt)
+            eps = 1e-6
+            out = torch.ops.sgl_kernel.gemma3_rmsnorm_cpu(x, weight, eps)
+            ref = gemma3_rmsnorm_native(x, weight, eps)
+            atol = rtol = precision["pointwise_default"][dt]
+            with self.subTest(dtype=dt):
+                torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+    def test_rmsnorm_non_contiguous(self):
+        """Case: RMSNorm with non-contiguous input tensors."""
+        for dt in self.dtype:
+            x = helper_non_contiguous(torch.randn(256, 4096, dtype=dt))
+            with self.subTest(dtype=dt, shape=x.shape):
+                self._run_rmsnorm(x.shape[0], x.shape[1], x=x, dtype=dt)
+
+    def test_fused_add_rmsnorm_non_contiguous(self):
+        """Case: fused-add-RMSNorm with non-contiguous input tensors."""
+        for dt in self.dtype:
+            x = helper_non_contiguous(torch.randn(256, 4096, dtype=dt))
+            residual = helper_non_contiguous(torch.randn(256, 4096, dtype=dt))
+            weight = torch.randn(4096, dtype=dt)
+            eps = 1e-6
+            ref_x, ref_res = rmsnorm_native(x.clone(), weight, eps, residual.clone())
+            x_copy, res_copy = x.clone(), residual.clone()
+            torch.ops.sgl_kernel.fused_add_rmsnorm_cpu(x_copy, res_copy, weight, eps)
+            atol = rtol = precision["pointwise_default"][dt]
+            with self.subTest(dtype=dt):
+                torch.testing.assert_close(x_copy, ref_x, atol=atol, rtol=rtol)
+                torch.testing.assert_close(res_copy, ref_res, atol=atol, rtol=rtol)
+
+    def test_rmsnorm_small_n(self):
+        """Case: RMSNorm with N smaller than one full m4 vector (< 8 for VLEN=256)."""
+        for n, dt in itertools.product([1, 4, 7], self.dtype):
+            with self.subTest(n=n, dtype=dt):
+                self._run_rmsnorm(4, n, dtype=dt)
+
+    def test_gemma_rmsnorm_non_contiguous(self):
+        """Case: Gemma RMSNorm with non-contiguous input tensors."""
+        for dt in self.dtype:
+            x = helper_non_contiguous(torch.randn(256, 4096, dtype=dt))
+            weight = torch.randn(4096, dtype=dt)
+            eps = 1e-6
+            out = torch.ops.sgl_kernel.gemma_rmsnorm_cpu(x, weight, eps)
+            ref = gemma_rmsnorm_native(x, weight, eps)
+            atol = rtol = precision["pointwise_default"][dt]
+            with self.subTest(dtype=dt):
+                torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+
+@unittest.skipUnless(
+    has_sgl_kernel_op("rmsnorm_cpu"),
+    "sgl_kernel norm not available (non-RISC-V build)",
+)
+class TestRVVNormLayer(CustomTestCase):
+    """Test suite for RVV LayerNorm kernels."""
+
+    M = [128, 129, 257, 1024, 4096]
+    N = [4096, 4109]
+    dtype = [torch.float16, torch.bfloat16]
+
+    def _run_layernorm(self, m, n, dtype):
+        x = torch.randn([m, n], dtype=dtype)
+        weight = torch.randn(n, dtype=dtype)
+        eps = 1e-6
+
+        out = torch.ops.sgl_kernel.layernorm_cpu(x, weight, None, eps)
+        ref = layernorm_native(x, weight, eps)
+
+        atol = rtol = precision["pointwise_default"][dtype]
+        torch.testing.assert_close(out, ref, atol=atol, rtol=rtol)
+
+    def _run_fused_add_layernorm(self, m, n, dtype):
+        x = torch.randn([m, n], dtype=dtype)
+        residual = torch.randn([m, n], dtype=dtype)
+        weight = torch.randn(n, dtype=dtype)
+        eps = 1e-6
+
+        ref_x = x.clone()
+        ref_residual = residual.clone()
+
+        out = torch.ops.sgl_kernel.fused_add_layernorm_cpu(
+            x, residual, weight, None, eps
+        )
+        ref_out, ref_res = layernorm_native(ref_x, weight, eps, ref_residual)
+
+        atol = rtol = precision["pointwise_default"][dtype]
+        torch.testing.assert_close(out, ref_out, atol=atol, rtol=rtol)
+        torch.testing.assert_close(residual, ref_res, atol=atol, rtol=rtol)
+
+    def test_layernorm(self):
+        for m, n, dt in itertools.product(self.M, self.N, self.dtype):
+            with self.subTest(m=m, n=n, dtype=dt):
+                self._run_layernorm(m, n, dt)
+
+    def test_layernorm_with_bias(self):
+        """Case: LayerNorm with non-None bias tensor."""
+        for m, n, dt in itertools.product([128, 257], [4096, 4109], self.dtype):
+            x = torch.randn([m, n], dtype=dt)
+            weight = torch.randn(n, dtype=dt)
+            bias = torch.randn(n, dtype=dt)
+            eps = 1e-6
+            out = torch.ops.sgl_kernel.layernorm_cpu(x, weight, bias, eps)
+            ref = layernorm_native(x, weight, eps)
+            ref = ref + bias
+            tol_map = precision.get("norm_layer_bias", precision["pointwise_default"])
+            atol = rtol = tol_map[dt]
+            if dt == torch.float16:
+                atol = rtol = max(atol, 1e-2)
+            with self.subTest(m=m, n=n, dtype=dt):
+                torch.testing.assert_close(out, ref, atol=atol, rtol=rtol)
+
+    def test_layernorm_non_contiguous(self):
+        """Case: LayerNorm with non-contiguous input tensors."""
+        for dt in self.dtype:
+            x = helper_non_contiguous(torch.randn(256, 4096, dtype=dt))
+            weight = torch.randn(4096, dtype=dt)
+            eps = 1e-6
+            out = torch.ops.sgl_kernel.layernorm_cpu(x, weight, None, eps)
+            ref = layernorm_native(x, weight, eps)
+            atol = rtol = precision["pointwise_default"][dt]
+            with self.subTest(dtype=dt):
+                torch.testing.assert_close(out, ref, atol=atol, rtol=rtol)
+
+    def test_fused_add_layernorm(self):
+        for m, n, dt in itertools.product(self.M, self.N, self.dtype):
+            with self.subTest(m=m, n=n, dtype=dt):
+                self._run_fused_add_layernorm(m, n, dt)
+
+
+@unittest.skipUnless(
+    has_sgl_kernel_op("rmsnorm_cpu"),
+    "sgl_kernel norm not available (non-RISC-V build)",
+)
+class TestRVVNormFusedGated(CustomTestCase):
+    """Test suite for RVV fused gated RMSNorm kernel."""
+
+    M = [128, 129, 257, 1024, 4096]
+    N = [4096, 4109]
+    dtype = [torch.float16, torch.bfloat16]
+
+    def _run_rmsnorm_gated(self, m, n, dtype):
+        x = torch.randn([m, n], dtype=dtype)
+        weight = torch.randn(n, dtype=dtype)
+        gate = torch.randn([m, n], dtype=dtype)
+        eps = 1e-6
+
+        out = torch.ops.sgl_kernel.fused_rmsnorm_gated_cpu(x, weight, gate, eps)
+        ref = fused_rmsnorm_gated_native(x, weight, gate, eps)
+
+        atol = rtol = precision["pointwise_default"][dtype] * 2
+        torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+    def test_fused_rmsnorm_gated(self):
+        for m, n, dt in itertools.product(self.M, self.N, self.dtype):
+            with self.subTest(m=m, n=n, dtype=dt):
+                self._run_rmsnorm_gated(m, n, dt)
+
+    def test_fused_rmsnorm_gated_non_contiguous(self):
+        """Case: fused gated RMSNorm with non-contiguous input tensors."""
+        for dt in self.dtype:
+            x = helper_non_contiguous(torch.randn(256, 4096, dtype=dt))
+            gate = torch.randn(256, 4096, dtype=dt)  # gate must be contiguous
+            weight = torch.randn(4096, dtype=dt)
+            eps = 1e-6
+            out = torch.ops.sgl_kernel.fused_rmsnorm_gated_cpu(x, weight, gate, eps)
+            ref = fused_rmsnorm_gated_native(x, weight, gate, eps)
+            atol = rtol = precision["pointwise_default"][dt] * 2
+            with self.subTest(dtype=dt):
+                torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/cpu/rvv/test_rvv_rope.py
+++ b/test/srt/cpu/rvv/test_rvv_rope.py
@@ -1,0 +1,249 @@
+"""Unit tests for RVV rotary embedding kernels."""
+
+import unittest
+
+import torch
+
+from sglang.srt.layers.rotary_embedding.base import RotaryEmbedding
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+from sglang.test.test_utils import CustomTestCase
+
+from .rvv_utils import has_sgl_kernel_op, helper_non_contiguous, precision
+
+torch.manual_seed(1234)
+
+
+@unittest.skipUnless(
+    has_sgl_kernel_op("rotary_embedding_cpu"),
+    "sgl_kernel rotary_embedding_cpu not available (non-RISC-V build)",
+)
+class TestRVVRopeCore(CustomTestCase):
+    """Test suite for RVV RoPE kernel compatibility checks."""
+
+    # (head_size, rotary_dim, max_pos, base, is_neox, dtype, device, batch, seq, q_heads, kv_heads)
+    test_config = [
+        (64, 64, 32, 8000, True, torch.bfloat16, "cpu", 32, 32, 1, 1),
+        (64, 64, 32, 8000, True, torch.float16, "cpu", 32, 32, 1, 1),  # FP16 neox
+        (256, 128, 4096, 10000, True, torch.bfloat16, "cpu", 2, 512, 32, 8),
+        (512, 128, 311, 10000, True, torch.bfloat16, "cpu", 3, 39, 4, 2),
+        (128, 128, 2048, 10000, False, torch.bfloat16, "cpu", 2, 512, 32, 8),
+        (128, 128, 2048, 10000, False, torch.float16, "cpu", 2, 512, 32, 8),
+        (128, 128, 2048, 10000, False, torch.bfloat16, "cpu", 2, 512, 16, 4),
+        (512, 128, 311, 10000, False, torch.bfloat16, "cpu", 3, 39, 4, 2),
+        # Non-neox tail case for partial-vector handling.
+        (128, 96, 2048, 10000, False, torch.bfloat16, "cpu", 2, 64, 8, 2),
+        (128, 96, 2048, 10000, False, torch.float16, "cpu", 2, 64, 8, 2),
+    ]
+
+    def _run_rope(
+        self,
+        head_size,
+        rotary_dim,
+        max_position_embeddings,
+        base,
+        batch_size,
+        seq_len,
+        num_q_heads,
+        num_kv_heads,
+        dims,
+        is_neox_style,
+        device,
+        dtype,
+    ):
+        """Run one RoPE case for either 2D or 4D tensor layout."""
+        set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
+        torch.manual_seed(100)
+        rope_ref = RotaryEmbedding(
+            head_size,
+            rotary_dim,
+            max_position_embeddings,
+            base,
+            is_neox_style,
+            dtype,
+        ).to(device)
+        pos_ids = torch.arange(seq_len, device=device).repeat(batch_size)
+        query = torch.randn(
+            batch_size * seq_len,
+            num_q_heads * head_size,
+            dtype=dtype,
+            device=device,
+        )
+        key = torch.randn(
+            batch_size * seq_len,
+            num_kv_heads * head_size,
+            dtype=dtype,
+            device=device,
+        )
+        if dims == 3:
+            # 3D layout requires num_kv_heads == 1.
+            query = query.view(batch_size * seq_len, num_q_heads, head_size)
+            key = key.view(batch_size * seq_len, num_kv_heads, head_size)
+        elif dims == 4:
+            query = query.view(batch_size, seq_len, num_q_heads, head_size)
+            key = key.view(batch_size, seq_len, num_kv_heads, head_size)
+        query_ref, key_ref = query.clone(), key.clone()
+        query_cpu, key_cpu = query.clone(), key.clone()
+
+        query_ref_out, key_ref_out = rope_ref.forward_native(
+            pos_ids, query_ref, key_ref
+        )
+        query_cpu_out, key_cpu_out = torch.ops.sgl_kernel.rotary_embedding_cpu(
+            pos_ids,
+            query_cpu,
+            key_cpu,
+            rope_ref.head_size,
+            rope_ref.cos_sin_cache.to(query.dtype),
+            rope_ref.is_neox_style,
+        )
+        atol = rtol = precision["rotary_embedding"][dtype]
+        torch.testing.assert_close(query_ref_out, query_cpu_out, atol=atol, rtol=rtol)
+        torch.testing.assert_close(key_ref_out, key_cpu_out, atol=atol, rtol=rtol)
+
+    def test_rope_2d(self):
+        """2D layout with varied head sizes, rotary dims, and neox/non-neox styles."""
+        for cfg in self.test_config:
+            hs, rd, mp, base, neox, dt, dev, bs, sl, qh, kvh = cfg
+            with self.subTest(
+                head_size=hs, rotary_dim=rd, is_neox=neox, batch=bs, seq=sl
+            ):
+                self._run_rope(
+                    head_size=hs,
+                    rotary_dim=rd,
+                    max_position_embeddings=mp,
+                    base=base,
+                    batch_size=bs,
+                    seq_len=sl,
+                    num_q_heads=qh,
+                    num_kv_heads=kvh,
+                    dims=2,
+                    is_neox_style=neox,
+                    device=dev,
+                    dtype=dt,
+                )
+
+    def test_rope_4d(self):
+        """4D layout adds a batch dimension; must produce identical output to 2D."""
+        for cfg in self.test_config:
+            hs, rd, mp, base, neox, dt, dev, bs, sl, qh, kvh = cfg
+            with self.subTest(
+                head_size=hs, rotary_dim=rd, is_neox=neox, batch=bs, seq=sl
+            ):
+                self._run_rope(
+                    head_size=hs,
+                    rotary_dim=rd,
+                    max_position_embeddings=mp,
+                    base=base,
+                    batch_size=bs,
+                    seq_len=sl,
+                    num_q_heads=qh,
+                    num_kv_heads=kvh,
+                    dims=4,
+                    is_neox_style=neox,
+                    device=dev,
+                    dtype=dt,
+                )
+
+    def test_rope_2d_non_contiguous(self):
+        """Non-contiguous Q/K must not read wrong positions due to stride errors."""
+        head_size, rotary_dim, max_pos = 128, 128, 2048
+        base, is_neox = 10000, False
+        device = "cpu"
+        batch_size, seq_len, num_q_heads, num_kv_heads = 4, 32, 8, 2
+
+        for dtype in [torch.bfloat16, torch.float16]:
+            with self.subTest(dtype=dtype):
+                set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
+                torch.manual_seed(100)
+                rope_ref = RotaryEmbedding(
+                    head_size, rotary_dim, max_pos, base, is_neox, dtype
+                ).to(device)
+                pos_ids = torch.arange(seq_len, device=device).repeat(batch_size)
+
+                query = helper_non_contiguous(
+                    torch.randn(
+                        batch_size * seq_len, num_q_heads * head_size, dtype=dtype
+                    )
+                )
+                key = helper_non_contiguous(
+                    torch.randn(
+                        batch_size * seq_len, num_kv_heads * head_size, dtype=dtype
+                    )
+                )
+                self.assertFalse(query.is_contiguous())
+
+                query_ref_out, key_ref_out = rope_ref.forward_native(
+                    pos_ids, query.clone(), key.clone()
+                )
+                query_out, key_out = torch.ops.sgl_kernel.rotary_embedding_cpu(
+                    pos_ids,
+                    query.clone(),
+                    key.clone(),
+                    rope_ref.head_size,
+                    rope_ref.cos_sin_cache.to(dtype),
+                    rope_ref.is_neox_style,
+                )
+                atol = rtol = precision["rotary_embedding"][dtype]
+                torch.testing.assert_close(
+                    query_ref_out, query_out, atol=atol, rtol=rtol
+                )
+                torch.testing.assert_close(key_ref_out, key_out, atol=atol, rtol=rtol)
+
+
+@unittest.skipUnless(
+    has_sgl_kernel_op("rotary_embedding_cpu"),
+    "sgl_kernel rotary_embedding_cpu not available (non-RISC-V build)",
+)
+class TestRVVRope3D(TestRVVRopeCore):
+    """Test suite for the 3D RoPE kernel path (num_kv_heads == 1, non-neox only)."""
+
+    # 3D requires num_kv_heads == 1.
+    test_config_3d = [
+        (128, 64, 2048, 10000, False, torch.bfloat16, "cpu", 2, 32, 8, 1),
+        (64, 64, 512, 8000, False, torch.float16, "cpu", 4, 16, 4, 1),
+        (128, 128, 2048, 10000, False, torch.bfloat16, "cpu", 2, 64, 16, 1),
+        # Tail case for partial-vector handling.
+        (128, 48, 2048, 10000, False, torch.bfloat16, "cpu", 2, 32, 4, 1),
+        (128, 48, 2048, 10000, False, torch.float16, "cpu", 2, 32, 4, 1),
+    ]
+
+    def test_rope_3d(self):
+        """3D layout (num_kv_heads=1) uses a different kernel path; must match 2D reference."""
+        for cfg in self.test_config_3d:
+            hs, rd, mp, base, neox, dt, dev, bs, sl, qh, kvh = cfg
+            with self.subTest(head_size=hs, rotary_dim=rd, batch=bs, seq=sl, dtype=dt):
+                self._run_rope(
+                    head_size=hs,
+                    rotary_dim=rd,
+                    max_position_embeddings=mp,
+                    base=base,
+                    batch_size=bs,
+                    seq_len=sl,
+                    num_q_heads=qh,
+                    num_kv_heads=kvh,
+                    dims=3,
+                    is_neox_style=neox,
+                    device=dev,
+                    dtype=dt,
+                )
+
+    def test_rope_3d_neox_raises(self):
+        """3D + neox=True is unsupported; must raise rather than silently produce wrong output."""
+        with self.assertRaises(RuntimeError):
+            self._run_rope(
+                head_size=128,
+                rotary_dim=64,
+                max_position_embeddings=2048,
+                base=10000,
+                batch_size=2,
+                seq_len=32,
+                num_q_heads=8,
+                num_kv_heads=1,
+                dims=3,
+                is_neox_style=True,
+                device="cpu",
+                dtype=torch.bfloat16,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

This pull request is a follow up on https://github.com/sgl-project/sglang/issues/18072.

This PR adds RISC-V Vector (RVV 1.0) kernel implementations for the `sgl-kernel` CPU backend.

I use the **SpacemiT K1** (VLEN=256, used in Banana Pi BPI-F3).

The existing CPU backend relies on generic PyTorch operations for all compute-intensive paths. By replacing hot loops with hand-written RVV 1.0 intrinsics compiled under Clang 19+, end-to-end throughput on **Qwen2.5-1.5B-Instruct** improves :

| Mode | Mean TPOT (ms) | TPOT Speedup |
|---|---|---|
| PyTorch native (baseline) | 7656.73 | 1× |
| RVV BF16 | 711.34 | **10.8×** |
| RVV W8A8(Qwen2.5-1.5B-quantized.w8a8 ) | 483.16 | **15.9×** |  

All kernels are guarded behind `CPU_CAPABILITY_RVV` compile-time detection and compile only on `riscv64` with Clang; other architectures are unaffected.

> **Note on CI:** There is currently no RISC-V CI runner available for this PR. All 63 unit tests have been manually verified on a physical SpacemiT K1 device (full output included in the Accuracy Tests section below).                                                                                             

---

## Modifications

This PR contains changes in C++ parts from `sgl-kernel/csrc/cpu/riscv64/` and we decide to upstream the C++ kernels first so as not to make the PR overwhelming. We will upstream changes to sglang python layers later on.

- **Phase 2 (#22219)**


### New directory: `sgl-kernel/csrc/cpu/riscv64/`

| File | Description |
|---|---|
| `vector_helpers.h` | Low-level RVV load/store/cast/reduce helpers. Shared across all kernels. |
| `vector_math.h` | Vectorized math: `vfexp`, `vftanh`, `vferf`, GELU/SiLU fused primitives via Horner polynomial approximation. |
| `CMakeLists.txt` | Standalone CMake build for the `riscv64` kernel library. Detects `Zvfh` extension and sets target attributes accordingly. |
| `torch_extension_riscv64.cpp` | Registers all ops into `torch.ops.sgl_kernel` via `TORCH_LIBRARY_IMPL`. |
| `decode.cpp` | Multi-head decode attention with paged KV cache. Supports BF16 / FP16 / FP32, logit cap,MHA GQA. |
| `extend.cpp` | Prefill (extend) attention with paged KV cache. Supports BF16 / FP16 / FP32, causal mask,MHA GQA. |
| `gemm.cpp` + `gemm.h` | Tiled BF16/FP16 GEMM using weight-prepacked layout (`convert_weight_packed`). |
| `gemm_int8.cpp` | W8A8 INT8 quantized GEMM (`int8_scaled_mm_cpu`, `int8_scaled_mm_with_quant`, `per_token_quant_int8_cpu`). |
| `norm.cpp` | RMSNorm, LayerNorm, L2Norm, Gemma/Gemma3 RMSNorm, fused-add variants. |
| `activation.cpp` | SiLU+Mul, GELU (tanh approx), GELU (exact). |
| `rope.cpp` | Rotary embeddings — NeoX-style and GPT-J-style (`rotary_embedding_cpu`). |


### Tests: `test/srt/cpu/rvv/`

Six Python unit test files compare RVV outputs against PyTorch CPU reference across dtypes, shapes, and edge cases (non-contiguous inputs, single-token decode, tail-handling shapes). Tests skip automatically on non-RISC-V platforms.

- `test_rvv_activation.py` — SiLU+Mul, GELU (tanh approx and exact), non-contiguous inputs
- `test_rvv_decode.py` — MHA, GQA decode attention, logit cap, kv-splits, dtype validation
- `test_rvv_extend.py` — MHA, GQA extend (prefill) attention, logit cap, zero-prefix edge cases
- `test_rvv_gemm.py` — BF16/FP16 packed GEMM, INT8 W8A8 GEMM, non-contiguous, shape edge cases
- `test_rvv_norm.py` — RMSNorm, LayerNorm, L2Norm, Gemma/Gemma3 variants, fused-add, non-contiguous
- `test_rvv_rope.py` — NeoX and GPT-J style RoPE, 2D/3D/4D layouts, non-contiguous inputs

> `test_rvv_backend_registration.py` (backend dispatch and Python layer integration tests) will be covered in a follow-up PR.


---

## Accuracy Tests

### Unit tests — SpacemiT K1 (VLEN=256)

```bash
python -m unittest discover -s test/srt/cpu/rvv -p "test_*.py" -t . -v
```

| Test File | Tests | Result |
|---|---|---|
| `test_rvv_activation` | 4 | OK |
| `test_rvv_backend_registration` | 14 | OK |
| `test_rvv_decode` | 6 | OK |
| `test_rvv_extend` | 6 | OK |
| `test_rvv_gemm` | 8 | OK |
| `test_rvv_norm` | 17 | OK |
| `test_rvv_rope` | 8 | OK |
| **Total** | **63** | **OK (395.1 s)** |

<details>

```

=== Running RVV Tests ===

/workspace/sglang/python/sglang/srt/layers/attention/fla/utils.py:223: UserWarning: Triton is not supported on current platform, roll back to CPU.
  warnings.warn(
[CI Test Method] TestRVVActivation.test_gelu_mul
test_gelu_mul (test.srt.cpu.rvv.test_rvv_activation.TestRVVActivation.test_gelu_mul)
Shape matrix includes sub-VL, exact-VL, unrolled, and tail-heavy sizes. ... ok
test_gelu_tanh_mul (test.srt.cpu.rvv.test_rvv_activation.TestRVVActivation.test_gelu_tanh_mul)
Shape matrix includes sub-VL, exact-VL, unrolled, and tail-heavy sizes. ... [CI Test Method] TestRVVActivation.test_gelu_tanh_mul
ok
test_non_contiguous (test.srt.cpu.rvv.test_rvv_activation.TestRVVActivation.test_non_contiguous)
Non-contiguous input must not silently read wrong elements due to stride errors. ... [CI Test Method] TestRVVActivation.test_non_contiguous
ok
test_silu_mul (test.srt.cpu.rvv.test_rvv_activation.TestRVVActivation.test_silu_mul)
Shape matrix includes sub-VL, exact-VL, unrolled, and tail-heavy sizes. ... [CI Test Method] TestRVVActivation.test_silu_mul
ok
test_decode_cross_attn_uses_encoder_loc (test.srt.cpu.rvv.test_rvv_backend_registration.TestRVVBackendCacheWiring.test_decode_cross_attn_uses_encoder_loc)
Cross-attention decode must use encoder_out_cache_loc, not out_cache_loc. ... ok
test_decode_self_attn_uses_out_loc (test.srt.cpu.rvv.test_rvv_backend_registration.TestRVVBackendCacheWiring.test_decode_self_attn_uses_out_loc)
Self-attention decode must use out_cache_loc, not the encoder variant. ... ok
test_extend_no_save_skips_cache (test.srt.cpu.rvv.test_rvv_backend_registration.TestRVVBackendCacheWiring.test_extend_no_save_skips_cache)
save_kv_cache=False must skip set_kv_buffer entirely; no stale writes. ... ok
test_extend_save_writes_cache (test.srt.cpu.rvv.test_rvv_backend_registration.TestRVVBackendCacheWiring.test_extend_save_writes_cache)
save_kv_cache=True must call set_kv_buffer exactly once per extend step. ... ok
test_cross_attn_uses_fallback (test.srt.cpu.rvv.test_rvv_backend_registration.TestRVVBackendFallbackSemantics.test_cross_attn_uses_fallback)
Cross-attention extend must never hit the RVV kernel path. ... [2026-04-05 23:53:57] WARNING logging.py:330: [RVV] forward_extend: cross-attention is not supported by the RVV extend kernel; falling back to TorchNative for cross-attention layers.
ok
test_decode_no_save_uses_fallback (test.srt.cpu.rvv.test_rvv_backend_registration.TestRVVBackendFallbackSemantics.test_decode_no_save_uses_fallback)
save_kv_cache=False bypasses RVV; must delegate to TorchNative fallback. ... ok
test_backend_selection (test.srt.cpu.rvv.test_rvv_backend_registration.TestRVVBackendInitAndRegistration.test_backend_selection)
Backend selection must match runtime platform capabilities (RVV or fallback). ... [2026-04-05 23:53:57] INFO rvv_backend.py:81: [RVV] Initialized. Mode=FLOAT
ok
test_registry_structure (test.srt.cpu.rvv.test_rvv_backend_registration.TestRVVBackendInitAndRegistration.test_registry_structure)
RVV backend must be registered so dispatchers can look it up by name. ... ok
test_metadata_rejects_oversized_batch (test.srt.cpu.rvv.test_rvv_backend_registration.TestRVVForwardMetadataGuards.test_metadata_rejects_oversized_batch)
Batch larger than the pool must fail loudly instead of silently slicing OOB. ... ok
test_metadata_tracks_max_extend_len (test.srt.cpu.rvv.test_rvv_backend_registration.TestRVVForwardMetadataGuards.test_metadata_tracks_max_extend_len)
max_extend_len must be cached so extend kernels know their iteration bound. ... ok
test_float32_lm_head_disables_backend (test.srt.cpu.rvv.test_rvv_backend_registration.TestRVVLMHeadPacking.test_float32_lm_head_disables_backend) ... ok
test_lm_head_lazy_pack_tracks_updates (test.srt.cpu.rvv.test_rvv_backend_registration.TestRVVLMHeadPacking.test_lm_head_lazy_pack_tracks_updates) ... ok
test_lora_lm_head_disables_backend (test.srt.cpu.rvv.test_rvv_backend_registration.TestRVVLMHeadPacking.test_lora_lm_head_disables_backend) ... ok
test_non_cpu_weights_skip_packing (test.srt.cpu.rvv.test_rvv_backend_registration.TestRVVLMHeadPacking.test_non_cpu_weights_skip_packing) ... ok
test_gqa (test.srt.cpu.rvv.test_rvv_decode.TestRVVDecodeGQA.test_gqa)
GQA/MQA shapes verify the H_Q/H_KV ratio reduction is correct. ... [CI Test Method] TestRVVDecodeGQA.test_gqa
ok
test_kv_splits_2 (test.srt.cpu.rvv.test_rvv_decode.TestRVVDecodeKvSplits2.test_kv_splits_2)
num_kv_splits=2 is the production default; regression guard. ... [CI Test Method] TestRVVDecodeKvSplits2.test_kv_splits_2
ok
test_logit_cap (test.srt.cpu.rvv.test_rvv_decode.TestRVVDecodeLogitCap.test_logit_cap)
logit_cap > 0 activates the tanh-cap branch; must match manual SDPA. ... [CI Test Method] TestRVVDecodeLogitCap.test_logit_cap
ok
test_mha (test.srt.cpu.rvv.test_rvv_decode.TestRVVDecodeMHA.test_mha)
Varied shapes cover head-count and seq-len boundary conditions. ... [CI Test Method] TestRVVDecodeMHA.test_mha
ok
test_seq_len_one (test.srt.cpu.rvv.test_rvv_decode.TestRVVDecodeMHA.test_seq_len_one)
seq_len=1 hits the kv-split boundary: every split is empty or size-1. ... [CI Test Method] TestRVVDecodeMHA.test_seq_len_one
ok
test_rejects_mixed_dtypes (test.srt.cpu.rvv.test_rvv_decode.TestRVVDecodeValidation.test_rejects_mixed_dtypes)
Mismatched key/query dtypes must be caught early rather than silently corrupting output. ... [CI Test Method] TestRVVDecodeValidation.test_rejects_mixed_dtypes
ok
[CI Test Method] TestRVVExtendGQA.test_gqa
test_gqa (test.srt.cpu.rvv.test_rvv_extend.TestRVVExtendGQA.test_gqa)
GQA shapes verify H_Q/H_KV ratio broadcasting is correct in both stages. ... ok
test_gqa_logit_cap (test.srt.cpu.rvv.test_rvv_extend.TestRVVExtendGQA.test_gqa_logit_cap)
GQA + logit_cap: tanh-softcap must interact correctly with GQA broadcasting. ... [CI Test Method] TestRVVExtendGQA.test_gqa_logit_cap
ok
test_gqa_zero_prefix (test.srt.cpu.rvv.test_rvv_extend.TestRVVExtendGQA.test_gqa_zero_prefix)
GQA with no prefix: Stage 1 (cached KV) is skipped, only Stage 2 runs. ... [CI Test Method] TestRVVExtendGQA.test_gqa_zero_prefix
ok
test_mha (test.srt.cpu.rvv.test_rvv_extend.TestRVVExtendMHA.test_mha)
Varied shapes cover head-count and prefix/extend length boundaries. ... [CI Test Method] TestRVVExtendMHA.test_mha
ok
test_mha_single_token (test.srt.cpu.rvv.test_rvv_extend.TestRVVExtendMHA.test_mha_single_token)
N_CTX=1 hits the single-row BLOCK_M boundary; tiling must not OOB. ... [CI Test Method] TestRVVExtendMHA.test_mha_single_token
ok
test_mha_zero_prefix (test.srt.cpu.rvv.test_rvv_extend.TestRVVExtendMHA.test_mha_zero_prefix)
Zero prefix ensures Stage 1 (cached KV) is skipped entirely. ... [CI Test Method] TestRVVExtendMHA.test_mha_zero_prefix
ok
test_bf16 (test.srt.cpu.rvv.test_rvv_gemm.TestRVVGemm.test_bf16)
Shape + bias matrix covers M-tail, N-chunk, and K-stride combinations. ... [CI Test Method] TestRVVGemm.test_bf16
ok
test_bf16_fma_path (test.srt.cpu.rvv.test_rvv_gemm.TestRVVGemm.test_bf16_fma_path)
Large N forces the multi-chunk FMA loop; exercises accumulation across chunks. ... [CI Test Method] TestRVVGemm.test_bf16_fma_path
ok
[CI Test Method] TestRVVGemm.test_bf16_non_contiguous
test_bf16_non_contiguous (test.srt.cpu.rvv.test_rvv_gemm.TestRVVGemm.test_bf16_non_contiguous)
Non-contiguous activation must be handled without silent stride corruption. ... ok
test_bf16_small_oc (test.srt.cpu.rvv.test_rvv_gemm.TestRVVGemm.test_bf16_small_oc)
N=1,12 exercises the scalar/sub-chunk output path that bypasses the main VL loop. ... [CI Test Method] TestRVVGemm.test_bf16_small_oc
ok
test_int8 (test.srt.cpu.rvv.test_rvv_gemm.TestRVVGemm.test_int8)
TILE_M=4 short-row path and scale dequantization across the full shape matrix. ... [CI Test Method] TestRVVGemm.test_int8
ok
test_int8_non_contiguous (test.srt.cpu.rvv.test_rvv_gemm.TestRVVGemm.test_int8_non_contiguous)
Non-contiguous INT8 activation must not corrupt quantization or GEMM output. ... [CI Test Method] TestRVVGemm.test_int8_non_contiguous
ok
test_int8_rejects_k_mismatch (test.srt.cpu.rvv.test_rvv_gemm.TestRVVGemm.test_int8_rejects_k_mismatch)
K-dim mismatch must raise rather than silently reading out-of-bounds. ... [CI Test Method] TestRVVGemm.test_int8_rejects_k_mismatch
ok
test_int8_rejects_packed_mismatch (test.srt.cpu.rvv.test_rvv_gemm.TestRVVGemm.test_int8_rejects_packed_mismatch)
Packed weight NB/scale count mismatch must raise instead of producing garbage. ... [CI Test Method] TestRVVGemm.test_int8_rejects_packed_mismatch
ok
test_fused_add_rmsnorm (test.srt.cpu.rvv.test_rvv_norm.TestRVVNormCore.test_fused_add_rmsnorm)
Both output tensors (normed x and updated residual) must match reference. ... [CI Test Method] TestRVVNormCore.test_fused_add_rmsnorm
ok
test_fused_add_rmsnorm_non_contiguous (test.srt.cpu.rvv.test_rvv_norm.TestRVVNormCore.test_fused_add_rmsnorm_non_contiguous)
Case: fused-add-RMSNorm with non-contiguous input tensors. ... [CI Test Method] TestRVVNormCore.test_fused_add_rmsnorm_non_contiguous
ok
test_gemma3_rmsnorm (test.srt.cpu.rvv.test_rvv_norm.TestRVVNormCore.test_gemma3_rmsnorm)
Gemma3 adds (1 + w) scaling; both 2D and 4D layouts must match reference.[CI Test Method] TestRVVNormCore.test_gemma3_rmsnorm
 ... ok
[CI Test Method] TestRVVNormCore.test_gemma3_rmsnorm_4d_multi_batch
test_gemma3_rmsnorm_4d_multi_batch (test.srt.cpu.rvv.test_rvv_norm.TestRVVNormCore.test_gemma3_rmsnorm_4d_multi_batch)
Case: Gemma3 RMSNorm 4D with batch_size > 1. ... ok
test_gemma_fused_add_rmsnorm (test.srt.cpu.rvv.test_rvv_norm.TestRVVNormCore.test_gemma_fused_add_rmsnorm) ... [CI Test Method] TestRVVNormCore.test_gemma_fused_add_rmsnorm
ok
test_gemma_rmsnorm (test.srt.cpu.rvv.test_rvv_norm.TestRVVNormCore.test_gemma_rmsnorm) ... [CI Test Method] TestRVVNormCore.test_gemma_rmsnorm
ok
test_gemma_rmsnorm_non_contiguous (test.srt.cpu.rvv.test_rvv_norm.TestRVVNormCore.test_gemma_rmsnorm_non_contiguous)
Case: Gemma RMSNorm with non-contiguous input tensors. ... [CI Test Method] TestRVVNormCore.test_gemma_rmsnorm_non_contiguous
ok
test_l2norm (test.srt.cpu.rvv.test_rvv_norm.TestRVVNormCore.test_l2norm)
L2Norm equals RMSNorm with unit weight; shared shape matrix catches tails. ... [CI Test Method] TestRVVNormCore.test_l2norm
ok
test_rmsnorm (test.srt.cpu.rvv.test_rvv_norm.TestRVVNormCore.test_rmsnorm)
N+13 odd shape catches tail handling; M range covers VLEN=256 boundary. ... [CI Test Method] TestRVVNormCore.test_rmsnorm
ok
test_rmsnorm_non_contiguous (test.srt.cpu.rvv.test_rvv_norm.TestRVVNormCore.test_rmsnorm_non_contiguous)
Case: RMSNorm with non-contiguous input tensors. ... [CI Test Method] TestRVVNormCore.test_rmsnorm_non_contiguous
ok
test_rmsnorm_small_n (test.srt.cpu.rvv.test_rvv_norm.TestRVVNormCore.test_rmsnorm_small_n)
Case: RMSNorm with N smaller than one full m4 vector (< 8 for VLEN=256). ... [CI Test Method] TestRVVNormCore.test_rmsnorm_small_n
ok
test_fused_rmsnorm_gated (test.srt.cpu.rvv.test_rvv_norm.TestRVVNormFusedGated.test_fused_rmsnorm_gated) ... [CI Test Method] TestRVVNormFusedGated.test_fused_rmsnorm_gated
ok
test_fused_rmsnorm_gated_non_contiguous (test.srt.cpu.rvv.test_rvv_norm.TestRVVNormFusedGated.test_fused_rmsnorm_gated_non_contiguous)
Case: fused gated RMSNorm with non-contiguous input tensors. ... [CI Test Method] TestRVVNormFusedGated.test_fused_rmsnorm_gated_non_contiguous
ok
test_fused_add_layernorm (test.srt.cpu.rvv.test_rvv_norm.TestRVVNormLayer.test_fused_add_layernorm) ... [CI Test Method] TestRVVNormLayer.test_fused_add_layernorm
ok
test_layernorm (test.srt.cpu.rvv.test_rvv_norm.TestRVVNormLayer.test_layernorm) ... [CI Test Method] TestRVVNormLayer.test_layernorm
ok
test_layernorm_non_contiguous (test.srt.cpu.rvv.test_rvv_norm.TestRVVNormLayer.test_layernorm_non_contiguous)
Case: LayerNorm with non-contiguous input tensors. ... [CI Test Method] TestRVVNormLayer.test_layernorm_non_contiguous
ok
test_layernorm_with_bias (test.srt.cpu.rvv.test_rvv_norm.TestRVVNormLayer.test_layernorm_with_bias)
Case: LayerNorm with non-None bias tensor. ... [CI Test Method] TestRVVNormLayer.test_layernorm_with_bias
ok
test_rope_2d (test.srt.cpu.rvv.test_rvv_rope.TestRVVRope3D.test_rope_2d)
2D layout with varied head sizes, rotary dims, and neox/non-neox styles. ... [CI Test Method] TestRVVRope3D.test_rope_2d
ok
test_rope_2d_non_contiguous (test.srt.cpu.rvv.test_rvv_rope.TestRVVRope3D.test_rope_2d_non_contiguous)
Non-contiguous Q/K must not read wrong positions due to stride errors. ... [CI Test Method] TestRVVRope3D.test_rope_2d_non_contiguous
ok
test_rope_3d (test.srt.cpu.rvv.test_rvv_rope.TestRVVRope3D.test_rope_3d)
3D layout (num_kv_heads=1) uses a different kernel path; must match 2D reference. ... [CI Test Method] TestRVVRope3D.test_rope_3d
ok
test_rope_3d_neox_raises (test.srt.cpu.rvv.test_rvv_rope.TestRVVRope3D.test_rope_3d_neox_raises)
3D + neox=True is unsupported; must raise rather than silently produce wrong output. ... [CI Test Method] TestRVVRope3D.test_rope_3d_neox_raises
ok
test_rope_4d (test.srt.cpu.rvv.test_rvv_rope.TestRVVRope3D.test_rope_4d)
4D layout adds a batch dimension; must produce identical output to 2D. ... [CI Test Method] TestRVVRope3D.test_rope_4d
ok
test_rope_2d (test.srt.cpu.rvv.test_rvv_rope.TestRVVRopeCore.test_rope_2d)
2D layout with varied head sizes, rotary dims, and neox/non-neox styles. ... [CI Test Method] TestRVVRopeCore.test_rope_2d
ok
test_rope_2d_non_contiguous (test.srt.cpu.rvv.test_rvv_rope.TestRVVRopeCore.test_rope_2d_non_contiguous)
Non-contiguous Q/K must not read wrong positions due to stride errors. ... [CI Test Method] TestRVVRopeCore.test_rope_2d_non_contiguous
ok
test_rope_4d (test.srt.cpu.rvv.test_rvv_rope.TestRVVRopeCore.test_rope_4d)
4D layout adds a batch dimension; must produce identical output to 2D. ... [CI Test Method] TestRVVRopeCore.test_rope_4d
ok

----------------------------------------------------------------------
Ran 63 tests in 395.115s

OK


```

</details>

### GSM8K (100 questions, 8-shot, SpacemiT K1)

| Model | Mode | Accuracy |
|---|---|---|
| Qwen2.5-1.5B-Instruct | RVV BF16 | 68.0% |
| Qwen2.5-1.5B-quantized.w8a8 | RVV W8A8 | 66.0% |
| Llama-3.2-1B-Instruct | RVV BF16 | 36.0% |

<details>
<summary>Details</summary>

```bash
# Qwen2.5-1.5B-Instruct (BF16)
python -m sglang.launch_server --model-path Qwen/Qwen2.5-1.5B-Instruct --device cpu --attention-backend rvv --trust-remote-code --mem-fraction-static 0.5 --max-total-tokens 2048 --host 127.0.0.1 --port 30000
python benchmark/gsm8k/bench_sglang.py --backend sglang --host 127.0.0.1 --port 30000 --num-questions 100 --num-shots 8 --max-new-tokens 512 --platinum

  Qwen2.5-1.5B-Instruct (100q, 8-shot, gsm8k-platinum)
    Accuracy:   0.680 (68.0%)
    Invalid:    0.000 (0.0%)
    Latency:    10889.889 s

# Qwen2.5-1.5B-quantized.w8a8 (W8A8)
python -m sglang.launch_server --model-path RedHatAI/Qwen2.5-1.5B-quantized.w8a8 --quantization w8a8_int8 --device cpu --attention-backend rvv --trust-remote-code --mem-fraction-static 0.5 --max-total-tokens 2048 --host 127.0.0.1 --port 30000
python benchmark/gsm8k/bench_sglang.py --backend sglang --host 127.0.0.1 --port 30000 --num-questions 100 --num-shots 8 --max-new-tokens 512 --platinum

  Qwen2.5-1.5B-quantized.w8a8 [w8a8_int8] (100q, 8-shot, gsm8k-platinum)
    Accuracy:   0.660 (66.0%)
    Invalid:    0.000 (0.0%)
    Latency:    8923.768 s

# Llama-3.2-1B-Instruct (BF16)
HF_TOKEN=<token> python -m sglang.launch_server --model-path meta-llama/Llama-3.2-1B-Instruct --device cpu --attention-backend rvv --trust-remote-code --mem-fraction-static 0.5 --max-total-tokens 2048 --host 127.0.0.1 --port 30000
python benchmark/gsm8k/bench_sglang.py --backend sglang --host 127.0.0.1 --port 30000 --num-questions 100 --num-shots 8 --max-new-tokens 512

  Llama-3.2-1B-Instruct (100q, 8-shot, gsm8k-platinum)
    Accuracy:   0.360 (36.0%)
    Invalid:    0.000 (0.0%)
    Latency:    5944.496 s
```

</details>

---

## Speed Tests and Profiling

Hardware: **SpacemiT K1** (8-core RISC-V, VLEN=256)  

 For BF16 and PyTorch-native runs, we used Qwen/Qwen2.5-1.5B-Instruct; for W8A8 runs, we used RedHatAI/Qwen2.5-1.5B-quantized.w8a8 with --quantization w8a8_int8.

bench_serving was run with the random dataset using 4 prompts, random_input_len=64, random_output_len=8, request_rate=0.1, and max_concurrency=1.

bench_one_batch_server and bench_one_batch were run with batch_size=1, input_len=64, and output_len=8.

### `bench_serving`

| Mode | Mean TPOT (ms) | Mean ITL (ms) | TPOT Speedup |
|---|---|---|---|
| PyTorch native | 7656.73 | 7733.10 | 1× |
| RVV BF16 | 711.34 | 731.22 | **10.8×** |
| RVV W8A8(Qwen2.5-1.5B-quantized.w8a8) | 483.16 | 494.50 | **15.9×** |

<details>
<summary>Details</summary>

```text
============================================================
Mode: PYTORCH_NATIVE
  model=Qwen/Qwen2.5-1.5B-Instruct
  quant=none
  kv_cache_dtype=bf16
  attention_backend=torch_native
  disable_rvv_kernels=1
============================================================
[server] python -m sglang.launch_server --model-path Qwen/Qwen2.5-1.5B-Instruct --device cpu --dtype bfloat16 --attention-backend torch_native --mem-fraction-static 0.28 --max-running-requests 4 --max-total-tokens 256 --host 127.0.0.1 --port 30000

============ Serving Benchmark Result ============
Benchmark duration (s):                  473.44
Total input tokens:                      104
Total generated tokens:                  20
Output token throughput (tok/s):         0.04
Mean E2E Latency (ms):                   118313.04
Median E2E Latency (ms):                 94749.78
Mean TTFT (ms):                          87380.50
Mean TPOT (ms):                          7656.73
Mean ITL (ms):                           7733.10
==================================================

============================================================
Mode: BF16
  model=Qwen/Qwen2.5-1.5B-Instruct
  quant=none
  kv_cache_dtype=bf16
  attention_backend=rvv
  disable_rvv_kernels=0
============================================================
[server] python -m sglang.launch_server --model-path Qwen/Qwen2.5-1.5B-Instruct --device cpu --dtype bfloat16 --attention-backend rvv --mem-fraction-static 0.28 --max-running-requests 4 --max-total-tokens 256 --host 127.0.0.1 --port 30000

============ Serving Benchmark Result ============
Benchmark duration (s):                  28.27
Total input tokens:                      104
Total generated tokens:                  20
Output token throughput (tok/s):         0.71
Mean E2E Latency (ms):                   7037.01
Median E2E Latency (ms):                 6710.60
Mean TTFT (ms):                          4112.05
Mean TPOT (ms):                          711.34
Mean ITL (ms):                           731.22
==================================================

============================================================
Mode: W8A8
  model=RedHatAI/Qwen2.5-1.5B-quantized.w8a8
  quant=w8a8_int8
  kv_cache_dtype=bf16
  attention_backend=rvv
  disable_rvv_kernels=0
============================================================
[server] python -m sglang.launch_server --model-path RedHatAI/Qwen2.5-1.5B-quantized.w8a8 --device cpu --dtype bfloat16 --attention-backend rvv --mem-fraction-static 0.28 --max-running-requests 4 --max-total-tokens 256 --host 127.0.0.1 --port 30000 --quantization w8a8_int8

============ Serving Benchmark Result ============
Benchmark duration (s):                  19.15
Total input tokens:                      104
Total generated tokens:                  20
Output token throughput (tok/s):         1.04
Mean E2E Latency (ms):                   4753.64
Median E2E Latency (ms):                 4528.08
Mean TTFT (ms):                          2775.53
Mean TPOT (ms):                          483.16
Mean ITL (ms):                           494.50
==================================================
```

</details>

### `bench_one_batch_server`

| Mode | Latency (s) | Output tok/s | Speedup |
|---|---|---|---|
| PyTorch native | 334.32 | 0.15 | 1× |
| RVV BF16 | 13.93 | 1.44 | **24× faster** |
| RVV W8A8(Qwen2.5-1.5B-quantized.w8a8 ) | 10.70 | 2.21 | **31× faster** |

<details>
<summary>Details</summary>

```text
============================================================
Mode: PYTORCH_NATIVE
  model=Qwen/Qwen2.5-1.5B-Instruct
  attention_backend=torch_native
  disable_rvv_kernels=1
============================================================
[server] python -m sglang.launch_server --model-path Qwen/Qwen2.5-1.5B-Instruct --device cpu --dtype bfloat16 --attention-backend torch_native --mem-fraction-static 0.28 --max-running-requests 4 --max-total-tokens 256 --host 127.0.0.1 --port 30000

batch size: 1 / input_len: 64 / output_len: 8
latency: 334.32 s
input throughput: 0.23 tok/s
output throughput: 0.15 tok/s
last_ttft: 281.41 s

============================================================
Mode: BF16
  model=Qwen/Qwen2.5-1.5B-Instruct
  attention_backend=rvv
  disable_rvv_kernels=0
============================================================
[server] python -m sglang.launch_server --model-path Qwen/Qwen2.5-1.5B-Instruct --device cpu --dtype bfloat16 --attention-backend rvv --mem-fraction-static 0.28 --max-running-requests 4 --max-total-tokens 256 --host 127.0.0.1 --port 30000

batch size: 1 / input_len: 64 / output_len: 8
latency: 13.93 s
input throughput: 7.66 tok/s
output throughput: 1.44 tok/s
last_ttft: 8.35 s

============================================================
Mode: W8A8
  model=RedHatAI/Qwen2.5-1.5B-quantized.w8a8
  attention_backend=rvv
  disable_rvv_kernels=0
============================================================
[server] python -m sglang.launch_server --model-path RedHatAI/Qwen2.5-1.5B-quantized.w8a8 --device cpu --dtype bfloat16 --attention-backend rvv --mem-fraction-static 0.28 --max-running-requests 4 --max-total-tokens 256 --host 127.0.0.1 --port 30000 --quantization w8a8_int8

batch size: 1 / input_len: 64 / output_len: 8
latency: 10.70 s
input throughput: 9.05 tok/s
output throughput: 2.21 tok/s
last_ttft: 7.07 s
```

</details>

### `bench_one_batch`

| Mode | Total Latency (s) | Median Decode Latency (s) | Median Decode tok/s | Speedup (decode) |
|---|---|---|---|---|
| PyTorch native | 323.87 | 6.911 | 0.14 | 1× |
| RVV BF16 | 15.04 | 0.776 | 1.29 | **8.9×** |
| RVV W8A8(Qwen2.5-1.5B-quantized.w8a8 ) | 10.10 | 0.454 | 2.20 | **15.2×** |

<details>
<summary>Details</summary>

```text
============================================================
Mode: PYTORCH_NATIVE
============================================================
[bench_one_batch] python -m sglang.bench_one_batch --model-path Qwen/Qwen2.5-1.5B-Instruct --device cpu --dtype bfloat16 --attention-backend torch_native --batch 1 --input-len 64 --output-len 8

Prefill. latency: 275.17920 s, throughput:  0.23 token/s
Decode 0. Batch size: 1, latency: 6.99377 s, throughput:  0.14 token/s
Decode 1. Batch size: 1, latency: 6.91146 s, throughput:  0.14 token/s
Decode 2. Batch size: 1, latency: 6.74558 s, throughput:  0.15 token/s
Decode 3. Batch size: 1, latency: 7.24278 s, throughput:  0.14 token/s
Decode 4. Batch size: 1, latency: 6.87036 s, throughput:  0.15 token/s
Decode.  median latency: 6.91146 s, median throughput:  0.14 token/s
Total. latency: 323.872 s, throughput:  0.22 token/s

============================================================
Mode: BF16
============================================================
[bench_one_batch] python -m sglang.bench_one_batch --model-path Qwen/Qwen2.5-1.5B-Instruct --device cpu --dtype bfloat16 --attention-backend rvv --batch 1 --input-len 64 --output-len 8

Prefill. latency: 9.66033 s, throughput:  6.63 token/s
Decode 0. Batch size: 1, latency: 0.81139 s, throughput:  1.23 token/s
Decode 1. Batch size: 1, latency: 0.89695 s, throughput:  1.11 token/s
Decode 2. Batch size: 1, latency: 0.69350 s, throughput:  1.44 token/s
Decode 3. Batch size: 1, latency: 0.61235 s, throughput:  1.63 token/s
Decode 4. Batch size: 1, latency: 0.71292 s, throughput:  1.40 token/s
Decode.  median latency: 0.77575 s, median throughput:  1.29 token/s
Total. latency: 15.038 s, throughput:  4.79 token/s

============================================================
Mode: W8A8
============================================================
[bench_one_batch] python -m sglang.bench_one_batch --model-path RedHatAI/Qwen2.5-1.5B-quantized.w8a8 --device cpu --dtype bfloat16 --attention-backend rvv --batch 1 --input-len 64 --output-len 8 --quantization w8a8_int8

Prefill. latency: 6.79141 s, throughput:  9.42 token/s
Decode 0. Batch size: 1, latency: 0.45395 s, throughput:  2.20 token/s
Decode 1. Batch size: 1, latency: 0.51323 s, throughput:  1.95 token/s
Decode 2. Batch size: 1, latency: 0.45330 s, throughput:  2.21 token/s
Decode 3. Batch size: 1, latency: 0.45342 s, throughput:  2.21 token/s
Decode 4. Batch size: 1, latency: 0.52560 s, throughput:  1.90 token/s
Decode.  median latency: 0.45395 s, median throughput:  2.20 token/s
Total. latency: 10.103 s, throughput:  7.13 token/s
```

</details>



> Note: Full end-to-end throughput requires the companion backend-integration PR which routes SGLang's attention/norm/GEMM dispatch to these RVV ops. This PR contributes the kernel implementations and unit tests.

---

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34856866252](https://github.com/sgl-project/sglang/actions/runs/34856866252)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34856865490](https://github.com/sgl-project/sglang/actions/runs/34856865490)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34856865824](https://github.com/sgl-project/sglang/actions/runs/34856865824)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->