### PR TITLE
fix(pcg,mm): fix zeroing of input_embeds when replay PCG

### DIFF
--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -609,7 +609,7 @@ class PiecewiseCudaGraphRunner:
             buffers.input_ids[num_tokens:static_num_tokens].zero_()
             buffers.positions[num_tokens:static_num_tokens].zero_()
             if self.is_multimodal:
-                buffers.input_embeds[:, num_tokens:static_num_tokens].zero_()
+                buffers.input_embeds[num_tokens:static_num_tokens].zero_()
             if forward_batch.mrope_positions is not None:
                 buffers.mrope_positions[:, num_tokens:static_num_tokens].zero_()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Before PCG replay, there was an error in the buffer clearing logic for multimodal models. The shape of `buffers.input_embeds` is (num_tokens, num_dim), and existing code incorrectly cleared it using the second dimension index. In some cases (num_dim > static_num_tokens), this could cause `input_embeds` to retain content from the previous inference, potentially leading to incorrect inference results. This PR uses the correct clearing logic, indexing in the `tokens` dimension.

For maintainers: I'm unsure if this issue causes a decrease in multimodal model accuracy and is related to some issues. It seems that PCG for multimodal models is not enabled by default for all models. I tested Qwen 3.5-27B on a sglang build that fixes the graph recompile and was able to reproduce the issue mentioned in this PR. The shape of `input_embeds` is (4096, 5120), and `static_num_tokens = 4096`.

## Modifications

The logic for clearing `inputs_embeds` has been corrected before replaying the multimodal model PCG.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
