### PR TITLE
[Feature] Support eagle3 for qwen3-vl

### DIFF
--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -1130,6 +1130,9 @@ class Qwen3VLForConditionalGeneration(nn.Module):
         self.num_deepstack_embeddings = len(self.deepstack_visual_indexes)
         self.use_deepstack = {Modality.IMAGE: True, Modality.VIDEO: True}
 
+        # For EAGLE3 support
+        self.capture_aux_hidden_states = False
+
     def separate_deepstack_embeds(self, embedding):
         assert (
             embedding.shape[-1] % (1 + self.num_deepstack_embeddings) == 0
@@ -1246,6 +1249,10 @@ class Qwen3VLForConditionalGeneration(nn.Module):
             pp_proxy_tensors=pp_proxy_tensors,
         )
 
+        aux_hidden_states = None
+        if self.capture_aux_hidden_states:
+            hidden_states, aux_hidden_states = hidden_states
+
         if self.pp_group.is_last_rank:
             if not get_embedding:
                 return self.logits_processor(
@@ -1253,6 +1260,7 @@ class Qwen3VLForConditionalGeneration(nn.Module):
                     hidden_states,
                     self.lm_head,
                     forward_batch,
+                    aux_hidden_states,
                 )
             else:
                 return self.pooler(hidden_states, forward_batch)
@@ -1343,6 +1351,22 @@ class Qwen3VLForConditionalGeneration(nn.Module):
 
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
+
+    def get_embed_and_head(self):
+        return self.model.embed_tokens.weight, self.lm_head.weight
+
+    def set_eagle3_layers_to_capture(self, layer_ids: Optional[List[int]] = None):
+        self.capture_aux_hidden_states = True
+        self.model.capture_aux_hidden_states = True
+        if layer_ids is None:
+            num_layers = self.config.num_hidden_layers
+            self.model.layers_to_capture = [
+                2,
+                num_layers // 2,
+                num_layers - 3,
+            ]  # Specific layers for EAGLE3 support
+        else:
+            self.model.layers_to_capture = [val + 1 for val in layer_ids]
 
 
 EntryClass = Qwen3VLForConditionalGeneration


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Adapt Eagle3 capture for the Qwen3-VL model


## Modifications

<!-- Detail the changes made in this pull request. -->

Add `set_eagle3_layers_to_capture` function on `qwen3_vl.py`. 

Like: [qwen2_5_vl.py](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/models/qwen2_5_vl.py)

## Launch Script

```bash
export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
export STREAMS_PER_DEVICE=32
export HCCL_SOCKET_IFNAME=lo
export GLOO_SOCKET_IFNAME=lo
export HCCL_OP_EXPANSION_MODE=AIV
export HCCL_BUFFSIZE=200
export SGLANG_MM_SKIP_COMPUTE_HASH=1
export SGLANG_ENABLE_OVERLAP_PLAN_STREAM=0
export SGLANG_ENABLE_SPEC_V2=1
export SGLANG_VIT_ENABLE_CUDA_GRAPH=1

MODEL_PATH=/path/to/Qwen3-VL-30B-A3B-Instruct
DRAFT_MODEL_PATH=/path/to/Qwen3-VL-30B-A3B-Instruct_eagle3_AngelSlim

python -m sglang.launch_server \
    --model-path ${MODEL_PATH} \
    --host 127.0.0.1 --port 8880 \
    --trust-remote-code \
    --tp-size 4 --mem-fraction-static 0.78 \
    --attention-backend ascend --device npu \
    --max-running-requests 496 \
    --prefill-max-requests 16 \
    --chunked-prefill-size -1 --max-prefill-tokens 102400 \
    --enable-multimodal \
    --mm-attention-backend ascend_attn --sampling-backend ascend \
    --cuda-graph-bs 4 12 24 64 124 \
    --tokenizer-worker-num 4 --dtype bfloat16 \
    --disable-radix-cache \
    --model-loader-extra-config '{"enable_multithread_load": true}' \
    --dp-size 4 --enable-dp-attention --enable-dp-lm-head --enable-broadcast-mm-inputs-process \
    --speculative-algorithm EAGLE3 \
    --speculative-num-steps 1 \
    --speculative-eagle-topk 1 \
    --speculative-num-draft-tokens 2 \
    --speculative-draft-model-path ${DRAFT_MODEL_PATH} \
    --speculative-draft-model-quantization unquant
```


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

### gsm8k:

```bash
python3 -m sglang.test.few_shot_gsm8k \
        --num-shots 5 \
        --data-path /path/to/gsm8k.jsonl \
        --max-new-tokens 1024 \
        --parallel 520 \
        --host 127.0.0.1 \
        --port 8880
```

#### without eagle3:

<img width="1315" height="106" alt="image" src="https://github.com/user-attachments/assets/a8942989-843e-4f3f-ae01-1777590c07bc" />


#### with eagle3:

<img width="784" height="92" alt="image" src="https://github.com/user-attachments/assets/f38dce8b-4b86-4cb1-b825-dc2aa460fa92" />


### mmmu:

```bash
python benchmark/mmmu/bench_sglang.py --port 8880 --concurrency 400 --dataset-path /path/to/datasets/MMMU --temperature 0 --max-new-tokens 2048
```

#### without eagle3:

<img width="558" height="779" alt="image" src="https://github.com/user-attachments/assets/b2ffecfa-48fb-44c8-8495-826f4dcd68ee" />

#### with eagle3:

<img width="558" height="715" alt="image" src="https://github.com/user-attachments/assets/482a57c7-67af-45f0-9982-83f7c24d9410" />


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

### MMMU:

```bash
python3 -m sglang.bench_serving \
        --dataset-name mmmu \
        --random-input 0 \
        --random-output 1024 \
        --model /path/to/Qwen3-VL-30B-A3B-Instruct \
        --backend sglang \
        --max-concurrency 160 \
        --num-prompts 160 \
        --host 127.0.0.1 \
        --port 8880 \
        --seed 1000
```

#### without eagle3:

<img width="433" height="689" alt="image" src="https://github.com/user-attachments/assets/2bc5aa5d-c713-449b-b35d-7a45245f7be2" />



#### with eagle3:

<img width="418" height="708" alt="image" src="https://github.com/user-attachments/assets/48a322f1-5333-4e60-bebb-e2a695d55bb8" />




## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
