### PR TITLE
[CI] Relax gpt-oss 4GPU accuracy threshold from 0.60 to 0.58

### DIFF
--- a/test/registered/4-gpu-models/test_gpt_oss_4gpu.py
+++ b/test/registered/4-gpu-models/test_gpt_oss_4gpu.py
@@ -13,7 +13,7 @@ class TestGptOss4Gpu(BaseTestGptOss):
             model_variant="120b",
             quantization="bf16",
             expected_score_of_reasoning_effort={
-                "low": 0.59,
+                "low": 0.58,
             },
             other_args=["--tp", "4", "--cuda-graph-max-bs", "200"],
         )
@@ -23,7 +23,7 @@ class TestGptOss4Gpu(BaseTestGptOss):
             model_variant="120b",
             quantization="mxfp4",
             expected_score_of_reasoning_effort={
-                "low": 0.59,
+                "low": 0.58,
             },
             other_args=[
                 "--tp",

--- a/test/registered/4-gpu-models/test_gpt_oss_4gpu.py
+++ b/test/registered/4-gpu-models/test_gpt_oss_4gpu.py
@@ -13,7 +13,7 @@ class TestGptOss4Gpu(BaseTestGptOss):
             model_variant="120b",
             quantization="bf16",
             expected_score_of_reasoning_effort={
-                "low": 0.60,
+                "low": 0.59,
             },
             other_args=["--tp", "4", "--cuda-graph-max-bs", "200"],
         )
@@ -23,7 +23,7 @@ class TestGptOss4Gpu(BaseTestGptOss):
             model_variant="120b",
             quantization="mxfp4",
             expected_score_of_reasoning_effort={
-                "low": 0.60,
+                "low": 0.59,
             },
             other_args=[
                 "--tp",


### PR DESCRIPTION
## Summary
- Lower `expected_score` for both `test_bf16_120b` and `test_mxfp4_120b` from 0.60 to 0.58
- 21% failure rate on both B200 and H100 runners at the 0.60 threshold

## Score Trend Data (40 scheduled runs, Mar 28 – Apr 6)

| Runner | Runs | Mean | Min | Fails (<0.60) | Fail Rate |
|--------|------|------|-----|---------------|-----------|
| B200 | 28 | 0.616 | 0.556 | 6 | 21% |
| H100 | 39 | 0.618 | 0.551 | 8 | 21% |

The score naturally fluctuates between ~0.55–0.67. The 0.58 threshold provides margin while still catching real regressions.

<img width="2083" height="1484" alt="gpt_oss_4gpu_score_trend" src="https://github.com/user-attachments/assets/333d293b-ce2d-4cf1-8a87-4b4ecb0ebec9" />

Example failures:
- https://github.com/sgl-project/sglang/actions/runs/24021871164/job/70069355736
- https://github.com/sgl-project/sglang/actions/runs/23877591623/job/69623865713

## Test plan
- [x] Threshold change only, no logic changes
- [x] Analyzed 67 scheduled CI runs across B200 and H100 runners