### PR TITLE
[Disagg][NIXL] Support Mamba state slice transfer for heterogeneous TP (Step 2/2 for Qwen3.5)

### DIFF
--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -84,6 +84,8 @@ class KVArgsRegisterInfo:
     decode_tp_size: int
     decode_tp_rank: int
     dst_kv_item_len: int
+    dst_state_item_lens: list[int] = dataclasses.field(default_factory=list)
+    dst_state_dim_per_tensor: list[int] = dataclasses.field(default_factory=list)
 
     @classmethod
     def from_zmq(cls, msg: List[bytes]):
@@ -92,6 +94,17 @@ class KVArgsRegisterInfo:
             dst_state_data_ptrs = list(struct.unpack(f"{len(msg[7]) // 8}Q", msg[7]))
         else:
             dst_state_data_ptrs = []
+
+        dst_state_item_lens = []
+        dst_state_dim_per_tensor = []
+        if len(msg) > 12 and len(msg[12]) > 0:
+            dst_state_item_lens = list(
+                struct.unpack(f"{len(msg[12]) // 4}I", msg[12])
+            )
+        if len(msg) > 13 and len(msg[13]) > 0:
+            dst_state_dim_per_tensor = list(
+                struct.unpack(f"{len(msg[13]) // 4}I", msg[13])
+            )
 
         return cls(
             room=str(msg[0].decode("ascii")),
@@ -106,6 +119,8 @@ class KVArgsRegisterInfo:
             decode_tp_size=int(msg[9].decode("ascii")),
             decode_tp_rank=int(msg[10].decode("ascii")),
             dst_kv_item_len=int(msg[11].decode("ascii")),
+            dst_state_item_lens=dst_state_item_lens,
+            dst_state_dim_per_tensor=dst_state_dim_per_tensor,
         )
 
 
@@ -671,6 +686,108 @@ class NixlKVManager(CommonKVManager):
             raise Exception("Failed to post Mamba state transfer")
         return xfer_handle
 
+    def _send_mamba_state_slice(
+        self,
+        peer_name: str,
+        prefill_state_indices: List[int],
+        dst_state_data_ptrs: list[int],
+        dst_state_indices: List[int],
+        dst_gpu_id: int,
+        notif: str,
+        dst_state_item_lens: list[int],
+        dst_state_dim_per_tensor: list[int],
+        decode_tp_size: int,
+        decode_tp_rank: int,
+    ):
+        """Transfer Mamba states with TP slice support via RDMA.
+
+        When prefill and decode have different attn_tp_size, we slice the
+        TP-sharded dimension (3rd dim) of conv_state and temporal_state
+        accordingly, mirroring Mooncake's _send_mamba_state_slice.
+        """
+        logger.warning_once(
+            "Using Mamba state slice transfer for different TP sizes. "
+            f"Prefill attn_tp_size={self.attn_tp_size}, "
+            f"Decode attn_tp_size={decode_tp_size}."
+        )
+        assert len(prefill_state_indices) == 1, "Mamba should have single state index"
+
+        prefill_state_data_ptrs = self.kv_args.state_data_ptrs
+        prefill_state_item_lens = self.kv_args.state_item_lens
+        src_state_dim_per_tensor = getattr(
+            self.kv_args, "state_dim_per_tensor", []
+        )
+
+        if not src_state_dim_per_tensor or not dst_state_dim_per_tensor:
+            return self._send_mamba_state(
+                peer_name,
+                prefill_state_indices,
+                dst_state_data_ptrs,
+                dst_state_indices,
+                dst_gpu_id,
+                notif,
+            )
+
+        local_tp_rank_in_group = self.kv_args.engine_rank % self.attn_tp_size
+        dst_tp_rank_in_group = decode_tp_rank % decode_tp_size
+
+        src_addrs = []
+        dst_addrs = []
+
+        for i, dst_state_ptr in enumerate(dst_state_data_ptrs):
+            src_item_len = prefill_state_item_lens[i]
+            dst_item_len = dst_state_item_lens[i]
+            src_dim = src_state_dim_per_tensor[i]
+            dst_dim = dst_state_dim_per_tensor[i]
+
+            src_bytes_per_dim = src_item_len // src_dim
+            dst_bytes_per_dim = dst_item_len // dst_dim
+
+            if self.attn_tp_size > decode_tp_size:
+                src_dim_start = 0
+                num_dims_to_send = src_dim
+                writers_per_decode = self.attn_tp_size // decode_tp_size
+                local_writer_idx = local_tp_rank_in_group % writers_per_decode
+                dst_dim_start = local_writer_idx * src_dim
+            else:
+                src_dim_start = (dst_tp_rank_in_group * dst_dim) % src_dim
+                num_dims_to_send = dst_dim
+                dst_dim_start = 0
+
+            src_dim_offset = src_dim_start * src_bytes_per_dim
+            dst_dim_offset = dst_dim_start * dst_bytes_per_dim
+            bytes_to_send = num_dims_to_send * src_bytes_per_dim
+
+            src_addr = (
+                prefill_state_data_ptrs[i]
+                + src_item_len * int(prefill_state_indices[0])
+                + src_dim_offset
+            )
+            dst_addr = (
+                dst_state_ptr
+                + dst_item_len * int(dst_state_indices[0])
+                + dst_dim_offset
+            )
+            src_addrs.append((src_addr, bytes_to_send, self.kv_args.gpu_id))
+            dst_addrs.append((dst_addr, bytes_to_send, dst_gpu_id))
+
+        src_descs = self.agent.get_xfer_descs(src_addrs, "VRAM")
+        dst_descs = self.agent.get_xfer_descs(dst_addrs, "VRAM")
+
+        xfer_handle = self.agent.initialize_xfer(
+            "WRITE",
+            src_descs,
+            dst_descs,
+            peer_name,
+            notif.encode("ascii"),
+        )
+        if not xfer_handle:
+            raise Exception("Failed to create Mamba state slice transfer")
+        state = self.agent.transfer(xfer_handle)
+        if state == "ERR":
+            raise Exception("Failed to post Mamba state slice transfer")
+        return xfer_handle
+
     def maybe_send_extra(
         self,
         peer_name: str,
@@ -680,14 +797,26 @@ class NixlKVManager(CommonKVManager):
         dst_gpu_id: int,
         notif: str,
         decode_tp_size: int,
+        decode_tp_rank: int = 0,
+        dst_state_item_lens: list[int] | None = None,
+        dst_state_dim_per_tensor: list[int] | None = None,
     ):
         """Send state or extra pool data with type-specific handling."""
         state_type = getattr(self.kv_args, "state_type", "none")
 
         if state_type == "mamba":
             if self.attn_tp_size != decode_tp_size:
-                raise RuntimeError(
-                    "PD Disaggregation does NOT support PD different TP sizes for hybrid mamba models yet."
+                return self._send_mamba_state_slice(
+                    peer_name,
+                    prefill_state_indices,
+                    dst_state_data_ptrs,
+                    dst_state_indices,
+                    dst_gpu_id,
+                    notif,
+                    dst_state_item_lens or [],
+                    dst_state_dim_per_tensor or [],
+                    decode_tp_size,
+                    decode_tp_rank,
                 )
             return self._send_mamba_state(
                 peer_name,
@@ -791,6 +920,9 @@ class NixlKVManager(CommonKVManager):
                         dst_info.gpu_id,
                         f"{req.room}_state_{self.kv_args.pp_rank}",
                         decode_tp_size,
+                        decode_tp_rank=dst_info.decode_tp_rank,
+                        dst_state_item_lens=dst_info.dst_state_item_lens,
+                        dst_state_dim_per_tensor=dst_info.dst_state_dim_per_tensor,
                     )
                     if state_xfer_handle is not None:
                         handles.append(state_xfer_handle)
@@ -1068,6 +1200,17 @@ class NixlKVReceiver(CommonKVReceiver):
                 struct.pack("Q", ptr) for ptr in self.kv_mgr.kv_args.state_data_ptrs
             )
 
+            packed_state_item_lens = b"".join(
+                struct.pack("I", item_len)
+                for item_len in self.kv_mgr.kv_args.state_item_lens
+            )
+            state_dim_per_tensor = getattr(
+                self.kv_mgr.kv_args, "state_dim_per_tensor", []
+            )
+            packed_state_dim_per_tensor = b"".join(
+                struct.pack("I", dim) for dim in state_dim_per_tensor
+            )
+
             with lock:
                 sock.send_multipart(
                     [
@@ -1084,6 +1227,8 @@ class NixlKVReceiver(CommonKVReceiver):
                         str(self.kv_mgr.attn_tp_size).encode("ascii"),
                         str(self.kv_mgr.kv_args.engine_rank).encode("ascii"),
                         str(self.kv_mgr.kv_args.kv_item_lens[0]).encode("ascii"),
+                        packed_state_item_lens,
+                        packed_state_dim_per_tensor,
                     ]
                 )
 

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -98,9 +98,7 @@ class KVArgsRegisterInfo:
         dst_state_item_lens = []
         dst_state_dim_per_tensor = []
         if len(msg) > 12 and len(msg[12]) > 0:
-            dst_state_item_lens = list(
-                struct.unpack(f"{len(msg[12]) // 4}I", msg[12])
-            )
+            dst_state_item_lens = list(struct.unpack(f"{len(msg[12]) // 4}I", msg[12]))
         if len(msg) > 13 and len(msg[13]) > 0:
             dst_state_dim_per_tensor = list(
                 struct.unpack(f"{len(msg[13]) // 4}I", msg[13])
@@ -714,9 +712,7 @@ class NixlKVManager(CommonKVManager):
 
         prefill_state_data_ptrs = self.kv_args.state_data_ptrs
         prefill_state_item_lens = self.kv_args.state_item_lens
-        src_state_dim_per_tensor = getattr(
-            self.kv_args, "state_dim_per_tensor", []
-        )
+        src_state_dim_per_tensor = getattr(self.kv_args, "state_dim_per_tensor", [])
 
         if not src_state_dim_per_tensor or not dst_state_dim_per_tensor:
             return self._send_mamba_state(


### PR DESCRIPTION

## Motivation

Depends on #22145.

The Mooncake backend already supports Mamba state slice transfer under heterogeneous TP (prefill TP ≠ decode TP), but NIXL lacks this capability and raises `RuntimeError`. This PR adds the same support for NIXL, enabling hybrid Mamba models (e.g., Qwen3.5) to run disaggregated inference with heterogeneous TP via NIXL.

## Modifications

Changes in `conn.py`:

- Add `dst_state_item_lens` and `dst_state_dim_per_tensor` fields to `KVArgsRegisterInfo` (ZMQ `msg[12]`/`msg[13]`)
- Implement `_send_mamba_state_slice()` that slices the TP-sharded dimension of conv_state/temporal_state based on prefill/decode TP ratio, mirroring Mooncake's implementation
- Update `maybe_send_extra()` to call `_send_mamba_state_slice()` instead of raising an error when TP sizes differ
- Send `state_item_lens` and `state_dim_per_tensor` metadata during decode-side registration

## Accuracy Tests

**Model**: Qwen3.5-397B-A17B-FP8  
**Config**: 1P1D, Prefill TP4 → Decode DEP4 (dp-attention, attn_tp=1), NIXL transfer, GB200  
**Container**: `lmsysorg/sglang:dev`

### Baseline (without this PR)

Without the mamba state slice fix, the prefill worker crashes immediately:

```
RuntimeError: PD Disaggregation does NOT support PD different TP sizes for hybrid mamba models yet.
```

### GSM8K

```
GSM8K Config: num_examples=1319; max_tokens=16000; num_threads=512; num_shots=8
Running GSM8K evaluation...
Total latency: 469.374 s
Score: 0.978
Output throughput: 269920.549 token/s
[METRIC] gsm8k_score=0.9778794813119756 labels={"model": "Qwen/Qwen3.5-397B-A17B-FP8", "eval": "gsm8k"}
[METRIC] gsm8k_latency=469.37385206102044 labels={"model": "Qwen/Qwen3.5-397B-A17B-FP8", "eval": "gsm8k"}
{'score:std': np.float64(0.14707549537906434), 'score': np.float64(0.9778794813119756), 'latency': 469.37385206102044, 'output_throughput': 269920.54935247934}
```

### GPQA

```
GPQA Config: num_examples=198; max_tokens=65536; repeat=8; num_threads=128
Running GPQA evaluation...
====================
Repeat: 8, mean: 0.857
Scores: ['0.864', '0.874', '0.823', '0.879', '0.854', '0.874', '0.828', '0.859']
Mean latency: 2659.583 s
====================
Output throughput: 74551.507 token/s
[METRIC] gpqa_mean_score=0.8566919191919191 labels={"model": "Qwen/Qwen3.5-397B-A17B-FP8", "eval": "gpqa", "repeat": 8}
{'chars': np.float64(2732238.242424242), 'chars:std': np.float64(3519606.4123803815), 'score:std': np.float64(0.3484482487002089), 'scores': ['0.864', '0.874', '0.823', '0.879', '0.854', '0.874', '0.828', '0.859'], 'mean_score': np.float64(0.8566919191919191), 'latency': 2659.582959950756, 'output_throughput': 74551.50665940167}
```

<details>
<summary>Test Config (GSM8K)</summary>

```yaml
resources:
  gpus_per_node: 4
  prefill_nodes: 1
  decode_nodes: 1
  prefill_workers: 1
  decode_workers: 1

backend:
  sglang_config:
    prefill:
      served-model-name: "Qwen/Qwen3.5-397B-A17B-FP8"
      model-path: "/model/"
      attention-backend: "trtllm_mha"
      kv-cache-dtype: "fp8_e4m3"
      tensor-parallel-size: 4
      mamba-scheduler-strategy: "no_buffer"
      disable-radix-cache: true
      disaggregation-mode: "prefill"
      disaggregation-transfer-backend: nixl
      mem-fraction-static: 0.80
      chunked-prefill-size: 16384

    decode:
      served-model-name: "Qwen/Qwen3.5-397B-A17B-FP8"
      model-path: "/model/"
      attention-backend: "trtllm_mha"
      quantization: "fp8"
      kv-cache-dtype: "fp8_e4m3"
      tp-size: 4
      dp-size: 4
      ep-size: 4
      enable-dp-attention: true
      enable-dp-lm-head: true
      moe-dense-tp-size: 1
      mamba-scheduler-strategy: "no_buffer"
      disable-radix-cache: true
      disaggregation-mode: "decode"
      disaggregation-transfer-backend: nixl
      mem-fraction-static: 0.80
      cuda-graph-max-bs: 1024

benchmark:
  type: "gsm8k"
  num_examples: 1319
  num_shots: 8
  max_tokens: 16000
  num_threads: 512
```

</details>

<details>
<summary>Test Config (GPQA)</summary>

```yaml
resources:
  gpus_per_node: 4
  prefill_nodes: 1
  decode_nodes: 1
  prefill_workers: 1
  decode_workers: 1

backend:
  sglang_config:
    prefill:
      served-model-name: "Qwen/Qwen3.5-397B-A17B-FP8"
      model-path: "/model/"
      attention-backend: "trtllm_mha"
      kv-cache-dtype: "fp8_e4m3"
      tensor-parallel-size: 4
      mamba-scheduler-strategy: "no_buffer"
      disable-radix-cache: true
      disaggregation-mode: "prefill"
      disaggregation-transfer-backend: nixl
      mem-fraction-static: 0.80
      chunked-prefill-size: 16384

    decode:
      served-model-name: "Qwen/Qwen3.5-397B-A17B-FP8"
      model-path: "/model/"
      attention-backend: "trtllm_mha"
      quantization: "fp8"
      kv-cache-dtype: "fp8_e4m3"
      tp-size: 4
      dp-size: 4
      ep-size: 4
      enable-dp-attention: true
      enable-dp-lm-head: true
      moe-dense-tp-size: 1
      mamba-scheduler-strategy: "no_buffer"
      disable-radix-cache: true
      disaggregation-mode: "decode"
      disaggregation-transfer-backend: nixl
      mem-fraction-static: 0.80
      cuda-graph-max-bs: 1024

benchmark:
  type: "gpqa"
  num_examples: 198
  max_tokens: 65536
  repeat: 8
  num_threads: 128
```

</details>

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
