### PR TITLE
Add AutoSpec to Support Automatic Runtime Speculative Inference Parameter Tuning for Different Batchsizes (Support SpecV2)

### DIFF
--- a/benchmark/auto_spec/README.md
+++ b/benchmark/auto_spec/README.md
@@ -1,0 +1,167 @@
+# Auto-Spec Benchmark
+
+Benchmark toolkit for **auto-spec** (adaptive speculative decoding), which dynamically adjusts the number of speculative decoding steps at runtime based on acceptance rate and batch size.
+
+## Overview
+
+- `prepare_mix_dataset.py` -- Downloads and merges GSM8K, HumanEval, MT-Bench, ShareGPT (and optionally HotpotQA, SQuAD, DROP, MBPP) into a single JSONL file.
+- `bench_auto_spec.py` -- Self-contained HTTP benchmark that sends concurrent requests to `/v1/completions`, collects throughput, latency, and TTFT.
+
+## Quick Start
+
+### 1. Prepare Dataset
+
+The script auto-downloads small datasets (GSM8K, HumanEval, MT-Bench, MBPP, SQuAD). For large datasets (ShareGPT, HotpotQA), you may need to download them manually first (see [Manual Download](#manual-download) below).
+
+```bash
+# Quick start: base datasets only (auto-downloads ~5MB total, no ShareGPT)
+python benchmark/auto_spec/prepare_mix_dataset.py \
+    --output mix_spec_dataset.jsonl \
+    --datasets gsm8k,humaneval,mtbench
+
+# Full base datasets including ShareGPT (requires manual download, see below)
+python benchmark/auto_spec/prepare_mix_dataset.py \
+    --output mix_spec_dataset.jsonl \
+    --sharegpt-path /path/to/ShareGPT_V3_unfiltered_cleaned_split.json
+
+# All 8 datasets (base + medium-length)
+python benchmark/auto_spec/prepare_mix_dataset.py \
+    --output mix_spec_dataset.jsonl \
+    --include-medium-length \
+    --sharegpt-path /path/to/ShareGPT_V3_unfiltered_cleaned_split.json \
+    --hotpotqa-path /path/to/hotpot_dev_fullwiki_v1.json
+```
+
+If a download fails, the script skips that dataset and continues with the rest.
+
+### Manual Download
+
+Some datasets are large or hosted on slow servers. Download them manually if auto-download fails:
+
+**ShareGPT** (~400MB) -- Required for realistic multi-turn conversation prompts:
+```bash
+# Option 1: wget
+wget -O ShareGPT_V3_unfiltered_cleaned_split.json \
+    "https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json"
+
+# Option 2: huggingface-cli (if installed)
+huggingface-cli download anon8231489123/ShareGPT_Vicuna_unfiltered \
+    ShareGPT_V3_unfiltered_cleaned_split.json --repo-type dataset \
+    --local-dir .
+```
+
+**HotpotQA** (~45MB) -- Multi-hop reasoning QA with long contexts:
+```bash
+wget -O hotpot_dev_fullwiki_v1.json \
+    "http://curtis.ml.cmu.edu/datasets/hotpot/hotpot_dev_fullwiki_v1.json"
+```
+
+Then pass the local paths:
+```bash
+python benchmark/auto_spec/prepare_mix_dataset.py \
+    --output mix_spec_dataset.jsonl \
+    --sharegpt-path ./ShareGPT_V3_unfiltered_cleaned_split.json \
+    --hotpotqa-path ./hotpot_dev_fullwiki_v1.json \
+    --include-medium-length
+```
+
+### 2. Start SGLang Server with Auto-Spec
+
+```bash
+# Qwen3-235B-A22B (SpecV2 + auto-spec)
+SGLANG_ENABLE_SPEC_V2=True python -m sglang.launch_server \
+    --model Qwen/Qwen3-235B-A22B \
+    --speculative-algorithm EAGLE \
+    --speculative-draft-model-path /path/to/eagle-model \
+    --speculative-num-steps 3 \
+    --auto-spec \
+    --port 30000 \
+    --tp 4
+
+# GLM-4.7-FP8 (SpecV2 + auto-spec)
+SGLANG_ENABLE_SPEC_V2=True python -m sglang.launch_server \
+    --model /path/to/glm-4-9b-chat-hf-fp8 \
+    --speculative-algorithm EAGLE \
+    --speculative-draft-model-path /path/to/eagle-model \
+    --speculative-num-steps 3 \
+    --auto-spec \
+    --port 30000 \
+    --tp 1
+```
+
+### 3. Run Benchmark
+
+```bash
+# Basic run
+python benchmark/auto_spec/bench_auto_spec.py \
+    --port 30000 \
+    --dataset-path mix_spec_dataset.jsonl \
+    --max-concurrency 16
+
+# Sweep over concurrency levels (simulates different batch sizes)
+python benchmark/auto_spec/bench_auto_spec.py \
+    --port 30000 \
+    --dataset-path mix_spec_dataset.jsonl \
+    --batch-sizes 1,4,8,16,32 \
+    --num-prompts-each 32
+
+# Filter to specific source datasets
+python benchmark/auto_spec/bench_auto_spec.py \
+    --port 30000 \
+    --dataset-path mix_spec_dataset.jsonl \
+    --source-filter gsm8k,humaneval \
+    --num-prompts 50
+
+# Fixed output length
+python benchmark/auto_spec/bench_auto_spec.py \
+    --port 30000 \
+    --dataset-path mix_spec_dataset.jsonl \
+    --output-len 256
+```
+
+## Arguments
+
+### prepare_mix_dataset.py
+
+| Argument | Description |
+|---|---|
+| `--output` | Output JSONL path (default: `./mix_spec_dataset.jsonl`) |
+| `--num-gsm8k` | Number of GSM8K samples (default: all ~1319) |
+| `--num-humaneval` | Number of HumanEval samples (default: all 164) |
+| `--num-mtbench` | Number of MT-Bench samples (default: all 80) |
+| `--num-sharegpt` | Number of ShareGPT samples (default: all) |
+| `--include-medium-length` | Also include HotpotQA, SQuAD, DROP, MBPP |
+| `--datasets` | Comma-separated list to select specific datasets |
+| `--sharegpt-path` | Path to locally downloaded ShareGPT JSON file |
+| `--hotpotqa-path` | Path to locally downloaded HotpotQA JSON file |
+| `--cache-dir` | Directory to cache downloaded datasets |
+
+### bench_auto_spec.py
+
+| Argument | Description |
+|---|---|
+| `--host` | Server host (default: `127.0.0.1`) |
+| `--port` | Server port (default: `30000`) |
+| `--dataset-path` | Path to mix-spec JSONL dataset |
+| `--num-prompts` | Total number of prompts (default: all) |
+| `--max-concurrency` | Max concurrent requests (default: 16) |
+| `--output-len` | Fixed output length for all requests |
+| `--source-filter` | Comma-separated source filter (e.g., `gsm8k,humaneval`) |
+| `--num-prompts-each` | Number of prompts per source dataset |
+| `--batch-sizes` | Comma-separated concurrency sweep (e.g., `1,4,8,16,32`) |
+
+## Metrics
+
+- **Throughput (tok/s)**: Total output tokens / wall clock time.
+- **Latency**: End-to-end time per request (avg, p50, p99, max).
+- **TTFT**: Time to first token (avg, p50, p99, max).
+- **Per-source breakdown**: Metrics broken down by dataset source.
+
+## Dataset Format
+
+Each line in the JSONL file is:
+```json
+{"prompt": "...", "expected_output_len": 256, "source": "gsm8k"}
+```
+
+The `source` field indicates which dataset the prompt came from, enabling per-source analysis and filtering.

--- a/benchmark/auto_spec/bench_auto_spec.py
+++ b/benchmark/auto_spec/bench_auto_spec.py
@@ -1,0 +1,438 @@
+"""
+Self-contained HTTP benchmark for auto-spec (adaptive speculative decoding).
+
+Sends concurrent requests to an SGLang server's /v1/completions endpoint,
+measures throughput, latency, and TTFT. No dependency on sglang benchmark
+internals -- just asyncio + aiohttp.
+
+Usage:
+    # Basic usage
+    python bench_auto_spec.py --port 30000 --dataset-path mix_spec_dataset.jsonl
+
+    # Control concurrency and prompts
+    python bench_auto_spec.py --port 30000 --dataset-path mix_spec_dataset.jsonl \
+        --max-concurrency 16 --num-prompts 100
+
+    # Filter by source dataset
+    python bench_auto_spec.py --port 30000 --dataset-path mix_spec_dataset.jsonl \
+        --source-filter gsm8k,humaneval
+
+    # Sweep over batch sizes (controls --max-concurrency per run)
+    python bench_auto_spec.py --port 30000 --dataset-path mix_spec_dataset.jsonl \
+        --batch-sizes 1,4,8,16,32 --num-prompts-each 32
+
+    # Fixed output length
+    python bench_auto_spec.py --port 30000 --dataset-path mix_spec_dataset.jsonl \
+        --output-len 256
+"""
+
+import argparse
+import asyncio
+import json
+import statistics
+import sys
+import time
+from typing import Dict, List, Optional, Tuple
+
+
+def load_dataset(
+    dataset_path: str,
+    num_prompts: Optional[int] = None,
+    source_filter: Optional[List[str]] = None,
+) -> List[Dict]:
+    """Load mix-spec JSONL dataset directly.
+
+    Each line is a JSON object with keys: prompt, expected_output_len, source.
+    """
+    records = []
+    with open(dataset_path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            record = json.loads(line)
+            if source_filter and record.get("source") not in source_filter:
+                continue
+            records.append(record)
+
+    if num_prompts is not None and num_prompts < len(records):
+        records = records[:num_prompts]
+
+    return records
+
+
+async def send_request(
+    session,
+    url: str,
+    prompt: str,
+    max_tokens: int,
+    request_id: int,
+) -> Dict:
+    """Send a single completion request and measure timing."""
+    payload = {
+        "model": "default",
+        "prompt": prompt,
+        "max_tokens": max_tokens,
+        "temperature": 0,
+        "stream": True,
+    }
+
+    start_time = time.perf_counter()
+    first_token_time = None
+    output_tokens = 0
+    full_text = ""
+
+    try:
+        async with session.post(url, json=payload) as resp:
+            if resp.status != 200:
+                error_text = await resp.text()
+                return {
+                    "request_id": request_id,
+                    "success": False,
+                    "error": f"HTTP {resp.status}: {error_text[:200]}",
+                    "latency": 0,
+                    "ttft": 0,
+                    "output_tokens": 0,
+                }
+
+            async for line in resp.content:
+                decoded = line.decode("utf-8").strip()
+                if not decoded or not decoded.startswith("data:"):
+                    continue
+                data_str = decoded[len("data:") :].strip()
+                if data_str == "[DONE]":
+                    break
+                try:
+                    data = json.loads(data_str)
+                    choices = data.get("choices", [])
+                    if choices:
+                        text = choices[0].get("text", "")
+                        if text and first_token_time is None:
+                            first_token_time = time.perf_counter()
+                        full_text += text
+                except json.JSONDecodeError:
+                    continue
+
+    except Exception as e:
+        return {
+            "request_id": request_id,
+            "success": False,
+            "error": str(e),
+            "latency": 0,
+            "ttft": 0,
+            "output_tokens": 0,
+        }
+
+    end_time = time.perf_counter()
+    latency = end_time - start_time
+    ttft = (first_token_time - start_time) if first_token_time else latency
+
+    # Estimate output tokens from text length (rough: 1 token ~ 4 chars)
+    # This is approximate; exact count would need tokenizer
+    output_tokens = max(len(full_text) // 4, 1)
+
+    return {
+        "request_id": request_id,
+        "success": True,
+        "latency": latency,
+        "ttft": ttft,
+        "output_tokens": output_tokens,
+        "output_len": len(full_text),
+    }
+
+
+async def run_benchmark(
+    host: str,
+    port: int,
+    records: List[Dict],
+    max_concurrency: int,
+    output_len: Optional[int] = None,
+) -> Tuple[List[Dict], float]:
+    """Run benchmark with controlled concurrency."""
+    try:
+        import aiohttp
+    except ImportError:
+        print("ERROR: aiohttp is required. Install with: pip install aiohttp")
+        sys.exit(1)
+
+    url = f"http://{host}:{port}/v1/completions"
+    semaphore = asyncio.Semaphore(max_concurrency)
+    results = []
+
+    async def bounded_request(session, record, idx):
+        async with semaphore:
+            max_tokens = (
+                output_len if output_len else record.get("expected_output_len", 256)
+            )
+            max_tokens = min(max_tokens, 4096)  # cap at 4096
+            result = await send_request(session, url, record["prompt"], max_tokens, idx)
+            result["source"] = record.get("source", "unknown")
+            return result
+
+    connector = aiohttp.TCPConnector(limit=max_concurrency + 10)
+    timeout = aiohttp.ClientTimeout(total=600)
+
+    print(f"Sending {len(records)} requests (max_concurrency={max_concurrency})...")
+    bench_start = time.perf_counter()
+
+    async with aiohttp.ClientSession(connector=connector, timeout=timeout) as session:
+        tasks = [
+            bounded_request(session, record, i) for i, record in enumerate(records)
+        ]
+        results = await asyncio.gather(*tasks)
+
+    bench_end = time.perf_counter()
+    wall_time = bench_end - bench_start
+
+    return list(results), wall_time
+
+
+def print_summary(results: List[Dict], wall_time: float, label: str = ""):
+    """Print benchmark summary statistics."""
+    successful = [r for r in results if r["success"]]
+    failed = [r for r in results if not r["success"]]
+
+    if not successful:
+        print(f"\n{'='*60}")
+        if label:
+            print(f"  {label}")
+        print(f"  All {len(results)} requests failed!")
+        for r in failed[:5]:
+            print(f"    Request {r['request_id']}: {r['error']}")
+        return
+
+    latencies = [r["latency"] for r in successful]
+    ttfts = [r["ttft"] for r in successful]
+    output_tokens = sum(r["output_tokens"] for r in successful)
+
+    throughput = output_tokens / wall_time if wall_time > 0 else 0
+    req_throughput = len(successful) / wall_time if wall_time > 0 else 0
+
+    print(f"\n{'='*60}")
+    if label:
+        print(f"  {label}")
+    print(f"{'='*60}")
+    print(f"  Requests:        {len(successful)} succeeded, {len(failed)} failed")
+    print(f"  Wall time:       {wall_time:.2f}s")
+    print(f"  Throughput:      {throughput:.1f} tok/s  ({req_throughput:.1f} req/s)")
+    print(f"  Output tokens:   {output_tokens}")
+    print(
+        f"  Latency (s):     avg={statistics.mean(latencies):.3f}  "
+        f"p50={statistics.median(latencies):.3f}  "
+        f"p99={sorted(latencies)[int(len(latencies)*0.99)]:.3f}  "
+        f"max={max(latencies):.3f}"
+    )
+    print(
+        f"  TTFT (s):        avg={statistics.mean(ttfts):.3f}  "
+        f"p50={statistics.median(ttfts):.3f}  "
+        f"p99={sorted(ttfts)[int(len(ttfts)*0.99)]:.3f}  "
+        f"max={max(ttfts):.3f}"
+    )
+
+    # Per-source breakdown
+    sources = set(r["source"] for r in successful)
+    if len(sources) > 1:
+        print(f"\n  Per-source breakdown:")
+        for source in sorted(sources):
+            source_results = [r for r in successful if r["source"] == source]
+            source_tokens = sum(r["output_tokens"] for r in source_results)
+            source_lat = [r["latency"] for r in source_results]
+            print(
+                f"    {source:12s}: {len(source_results):4d} reqs, "
+                f"{source_tokens:6d} tokens, "
+                f"avg_lat={statistics.mean(source_lat):.3f}s"
+            )
+
+    if failed:
+        print(f"\n  Failed requests ({len(failed)}):")
+        for r in failed[:3]:
+            print(f"    Request {r['request_id']}: {r['error']}")
+        if len(failed) > 3:
+            print(f"    ... and {len(failed) - 3} more")
+
+    print(f"{'='*60}")
+
+
+async def check_server(host: str, port: int) -> bool:
+    """Check if the server is ready."""
+    try:
+        import aiohttp
+    except ImportError:
+        print("ERROR: aiohttp is required. Install with: pip install aiohttp")
+        sys.exit(1)
+
+    url = f"http://{host}:{port}/health"
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, timeout=aiohttp.ClientTimeout(total=5)) as resp:
+                return resp.status == 200
+    except Exception:
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Self-contained HTTP benchmark for auto-spec speculative decoding"
+    )
+    parser.add_argument(
+        "--host", type=str, default="127.0.0.1", help="Server host. Default: 127.0.0.1"
+    )
+    parser.add_argument(
+        "--port", type=int, default=30000, help="Server port. Default: 30000"
+    )
+    parser.add_argument(
+        "--dataset-path",
+        type=str,
+        required=True,
+        help="Path to mix-spec JSONL dataset file.",
+    )
+    parser.add_argument(
+        "--num-prompts",
+        type=int,
+        default=None,
+        help="Total number of prompts to use. Default: all in dataset.",
+    )
+    parser.add_argument(
+        "--max-concurrency",
+        type=int,
+        default=16,
+        help="Maximum number of concurrent requests. Default: 16.",
+    )
+    parser.add_argument(
+        "--output-len",
+        type=int,
+        default=None,
+        help="Fixed output length for all requests. Default: use dataset's expected_output_len.",
+    )
+    parser.add_argument(
+        "--source-filter",
+        type=str,
+        default=None,
+        help="Comma-separated list of source datasets to include (e.g., 'gsm8k,humaneval').",
+    )
+    parser.add_argument(
+        "--num-prompts-each",
+        type=int,
+        default=None,
+        help="Number of prompts from each source dataset. Overrides --num-prompts.",
+    )
+    parser.add_argument(
+        "--batch-sizes",
+        type=str,
+        default=None,
+        help="Comma-separated list of batch sizes (concurrency levels) to sweep. "
+        "Runs benchmark once per batch size. E.g., '1,4,8,16,32'.",
+    )
+
+    args = parser.parse_args()
+
+    # Parse source filter
+    source_filter = None
+    if args.source_filter:
+        source_filter = [s.strip() for s in args.source_filter.split(",")]
+
+    # Load dataset
+    print(f"Loading dataset from {args.dataset_path}...")
+    all_records = load_dataset(args.dataset_path, source_filter=source_filter)
+    print(f"  Total records after filtering: {len(all_records)}")
+
+    if not all_records:
+        print("ERROR: No records loaded. Check dataset path and source filter.")
+        sys.exit(1)
+
+    # If --num-prompts-each is set, sample from each source
+    if args.num_prompts_each:
+        sources = {}
+        for r in all_records:
+            src = r.get("source", "unknown")
+            if src not in sources:
+                sources[src] = []
+            sources[src].append(r)
+
+        records = []
+        for src in sorted(sources.keys()):
+            src_records = sources[src][: args.num_prompts_each]
+            records.extend(src_records)
+            print(f"  {src}: {len(src_records)} prompts")
+        all_records = records
+    elif args.num_prompts:
+        all_records = all_records[: args.num_prompts]
+
+    # Source distribution
+    source_counts = {}
+    for r in all_records:
+        src = r.get("source", "unknown")
+        source_counts[src] = source_counts.get(src, 0) + 1
+    print(f"  Source distribution: {source_counts}")
+    print(f"  Total prompts: {len(all_records)}")
+
+    # Check server
+    if not asyncio.run(check_server(args.host, args.port)):
+        print(f"\nWARNING: Server at {args.host}:{args.port} is not responding.")
+        print("Make sure the server is running. Proceeding anyway...\n")
+
+    # Run benchmark
+    if args.batch_sizes:
+        # Sweep over batch sizes
+        batch_sizes = [int(b.strip()) for b in args.batch_sizes.split(",")]
+        all_summaries = []
+
+        for bs in batch_sizes:
+            print(f"\n{'#'*60}")
+            print(f"  Batch size (concurrency): {bs}")
+            print(f"{'#'*60}")
+
+            results, wall_time = asyncio.run(
+                run_benchmark(args.host, args.port, all_records, bs, args.output_len)
+            )
+            print_summary(results, wall_time, label=f"Batch Size = {bs}")
+
+            successful = [r for r in results if r["success"]]
+            if successful:
+                output_tokens = sum(r["output_tokens"] for r in successful)
+                throughput = output_tokens / wall_time if wall_time > 0 else 0
+                avg_lat = statistics.mean([r["latency"] for r in successful])
+                avg_ttft = statistics.mean([r["ttft"] for r in successful])
+                all_summaries.append(
+                    {
+                        "batch_size": bs,
+                        "throughput": throughput,
+                        "avg_latency": avg_lat,
+                        "avg_ttft": avg_ttft,
+                        "succeeded": len(successful),
+                        "failed": len(results) - len(successful),
+                    }
+                )
+
+        # Print comparison table
+        if all_summaries:
+            print(f"\n{'='*80}")
+            print(f"  BATCH SIZE COMPARISON")
+            print(f"{'='*80}")
+            print(
+                f"  {'BS':>4s}  {'Throughput':>12s}  {'Avg Latency':>12s}  "
+                f"{'Avg TTFT':>10s}  {'OK/Fail':>8s}"
+            )
+            print(f"  {'-'*4}  {'-'*12}  {'-'*12}  {'-'*10}  {'-'*8}")
+            for s in all_summaries:
+                print(
+                    f"  {s['batch_size']:>4d}  "
+                    f"{s['throughput']:>9.1f} t/s  "
+                    f"{s['avg_latency']:>10.3f}s  "
+                    f"{s['avg_ttft']:>8.3f}s  "
+                    f"{s['succeeded']:>3d}/{s['failed']:<3d}"
+                )
+            print(f"{'='*80}")
+
+    else:
+        # Single run
+        results, wall_time = asyncio.run(
+            run_benchmark(
+                args.host, args.port, all_records, args.max_concurrency, args.output_len
+            )
+        )
+        print_summary(results, wall_time)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/auto_spec/prepare_mix_dataset.py
+++ b/benchmark/auto_spec/prepare_mix_dataset.py
@@ -1,0 +1,713 @@
+"""
+Prepare a mixed benchmark dataset by downloading and integrating
+GSM8K, HumanEval, MT-Bench, ShareGPT, and medium-length datasets into a single JSONL file.
+
+The data order is: GSM8K -> HumanEval -> MT-Bench -> ShareGPT -> Medium-length datasets (not shuffled).
+
+Usage:
+    python prepare_mix_dataset.py --output mix_spec_dataset.jsonl
+
+    # Control per-dataset sample count
+    python prepare_mix_dataset.py --output mix_spec_dataset.jsonl \
+        --num-gsm8k 200 --num-humaneval 164 --num-mtbench 80 --num-sharegpt 500
+
+    # Use locally downloaded files (when remote URLs are not accessible)
+    python prepare_mix_dataset.py --output mix_spec_dataset.jsonl \
+        --gsm8k-path /path/to/test.jsonl \
+        --humaneval-path /path/to/HumanEval.jsonl \
+        --mtbench-path /path/to/question.jsonl \
+        --sharegpt-path /path/to/ShareGPT_V3_unfiltered_cleaned_split.json
+
+    # Include medium-length datasets with local files
+    python prepare_mix_dataset.py --output mix_spec_dataset.jsonl \
+        --include-medium-length \
+        --hotpotqa-path /path/to/hotpot_dev_fullwiki_v1.json \
+        --squad-path /path/to/dev-v2.0.json \
+        --drop-path /path/to/drop_dataset \
+        --mbpp-path /path/to/mbpp.jsonl
+"""
+
+import argparse
+import gzip
+import json
+import os
+
+import requests
+from tqdm import tqdm
+
+# Dataset download URLs
+GSM8K_URL = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl"
+HUMANEVAL_URL = (
+    "https://github.com/openai/human-eval/raw/master/data/HumanEval.jsonl.gz"
+)
+MTBENCH_URL = "https://raw.githubusercontent.com/lm-sys/FastChat/main/fastchat/llm_judge/data/mt_bench/question.jsonl"
+SHAREGPT_URL = "https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json"
+
+# Medium-length dataset URLs (1k-10k tokens) covering different aspects:
+# Reasoning/QA - HotpotQA (multi-hop reasoning)
+HOTPOTQA_URL = "http://curtis.ml.cmu.edu/datasets/hotpot/hotpot_dev_fullwiki_v1.json"
+# Reading Comprehension - SQuAD (Stanford QA)
+SQUAD_URL = "https://rajpurkar.github.io/SQuAD-explorer/dataset/dev-v2.0.json"
+# Numerical Reasoning - DROP (Discrete Reasoning Over Paragraphs)
+DROP_URL = "https://s3-us-west-2.amazonaws.com/allennlp/datasets/drop/drop_dataset.zip"
+# Code - MBPP (Mostly Basic Python Problems)
+MBPP_URL = "https://raw.githubusercontent.com/google-research/google-research/master/mbpp/mbpp.jsonl"
+
+# Default cache directory
+CACHE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data_cache")
+
+
+def download_file(url, filename, desc=None):
+    """Download a file from a URL with progress bar. Returns the local path or None on failure."""
+    os.makedirs(os.path.dirname(filename), exist_ok=True)
+    if os.path.exists(filename):
+        print(f"  [Cached] {filename}")
+        return filename
+
+    print(f"  Downloading from {url}")
+    print(f"  Saving to {filename}")
+
+    try:
+        response = requests.get(url, stream=True, timeout=120)
+        response.raise_for_status()
+    except (requests.RequestException, ConnectionError) as e:
+        print(f"\n  WARNING: Failed to download from {url}")
+        print(f"  Error: {e}")
+        print(f"  Skipping this dataset. To include it, manually download and use:")
+        print(f"    wget -O {filename} '{url}'")
+        print(f"  See README.md for manual download instructions.")
+        return None
+
+    total_size = int(response.headers.get("content-length", 0))
+    with open(filename, "wb") as f, tqdm(
+        desc=desc or os.path.basename(filename),
+        total=total_size,
+        unit="B",
+        unit_scale=True,
+        unit_divisor=1024,
+    ) as bar:
+        for chunk in response.iter_content(chunk_size=8192):
+            f.write(chunk)
+            bar.update(len(chunk))
+
+    return filename
+
+
+def load_gsm8k(path, num_samples=None, cache_dir=CACHE_DIR):
+    """Load GSM8K dataset and convert to unified format."""
+    print("\n[1/4] Loading GSM8K dataset...")
+    if not path or not os.path.exists(path):
+        path = download_file(
+            GSM8K_URL,
+            os.path.join(cache_dir, "gsm8k_test.jsonl"),
+            desc="GSM8K",
+        )
+    if not path:
+        return []
+
+    records = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            data = json.loads(line)
+            prompt = "Question: " + data["question"] + "\nAnswer:"
+            records.append(
+                {
+                    "prompt": prompt,
+                    "expected_output_len": 512,
+                    "source": "gsm8k",
+                }
+            )
+
+    if num_samples is not None and num_samples < len(records):
+        records = records[:num_samples]
+
+    print(f"  Loaded {len(records)} GSM8K samples")
+    return records
+
+
+def load_humaneval(path, num_samples=None, cache_dir=CACHE_DIR):
+    """Load HumanEval dataset and convert to unified format."""
+    print("\n[2/4] Loading HumanEval dataset...")
+    if not path or not os.path.exists(path):
+        gz_path = os.path.join(cache_dir, "HumanEval.jsonl.gz")
+        jsonl_path = os.path.join(cache_dir, "HumanEval.jsonl")
+
+        # Check if already decompressed
+        if os.path.exists(jsonl_path):
+            path = jsonl_path
+        else:
+            result = download_file(HUMANEVAL_URL, gz_path, desc="HumanEval")
+            if not result:
+                return []
+            # Decompress .gz file
+            print("  Decompressing HumanEval.jsonl.gz...")
+            with gzip.open(gz_path, "rt", encoding="utf-8") as gz_f:
+                with open(jsonl_path, "w", encoding="utf-8") as out_f:
+                    out_f.write(gz_f.read())
+            path = jsonl_path
+
+    records = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            data = json.loads(line)
+            # Use the prompt field (function signature + docstring)
+            prompt = (
+                "Read the following function signature and docstring, "
+                "and fully implement the function described. "
+                "Your response should only contain the code for this function.\n\n"
+                + data["prompt"]
+            )
+            records.append(
+                {
+                    "prompt": prompt,
+                    "expected_output_len": 512,
+                    "source": "human_eval",
+                }
+            )
+
+    if num_samples is not None and num_samples < len(records):
+        records = records[:num_samples]
+
+    print(f"  Loaded {len(records)} HumanEval samples")
+    return records
+
+
+def load_mtbench(path, num_samples=None, cache_dir=CACHE_DIR):
+    """Load MT-Bench dataset and convert to unified format."""
+    print("\n[3/4] Loading MT-Bench dataset...")
+    if not path or not os.path.exists(path):
+        path = download_file(
+            MTBENCH_URL,
+            os.path.join(cache_dir, "mt_bench_question.jsonl"),
+            desc="MT-Bench",
+        )
+    if not path:
+        return []
+
+    records = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            data = json.loads(line)
+            # Use the first turn question as prompt
+            prompt = data["turns"][0]
+            records.append(
+                {
+                    "prompt": prompt,
+                    "expected_output_len": 256,
+                    "source": "mtbench",
+                }
+            )
+
+    if num_samples is not None and num_samples < len(records):
+        records = records[:num_samples]
+
+    print(f"  Loaded {len(records)} MT-Bench samples")
+    return records
+
+
+def load_sharegpt(path, num_samples=None, cache_dir=CACHE_DIR):
+    """Load ShareGPT dataset and convert to unified format."""
+    print("\n[4/4] Loading ShareGPT dataset...")
+    if not path or not os.path.exists(path):
+        path = download_file(
+            SHAREGPT_URL,
+            os.path.join(cache_dir, "ShareGPT_V3_unfiltered_cleaned_split.json"),
+            desc="ShareGPT",
+        )
+    if not path:
+        return []
+
+    with open(path, "r", encoding="utf-8") as f:
+        dataset = json.load(f)
+
+    # Filter out conversations with less than 2 turns
+    dataset = [
+        data
+        for data in dataset
+        if len(data.get("conversations", data.get("conversation", []))) >= 2
+    ]
+
+    records = []
+    for data in dataset:
+        convos = data.get("conversations", data.get("conversation", []))
+        prompt = convos[0]["value"]
+        completion = convos[1]["value"]
+
+        if not prompt or not completion:
+            continue
+
+        # Estimate output length based on completion text
+        # Use character count / 4 as a rough token estimate
+        estimated_output_len = max(len(completion) // 4, 16)
+
+        records.append(
+            {
+                "prompt": prompt,
+                "expected_output_len": estimated_output_len,
+                "source": "sharegpt",
+            }
+        )
+
+    if num_samples is not None and num_samples < len(records):
+        records = records[:num_samples]
+
+    print(f"  Loaded {len(records)} ShareGPT samples")
+    return records
+
+
+def load_hotpotqa(path, num_samples=None, cache_dir=CACHE_DIR):
+    """Load HotpotQA dataset and convert to unified format.
+
+    HotpotQA is a multi-hop reasoning QA dataset with contexts typically 1k-5k tokens.
+    """
+    print("\n[5/8] Loading HotpotQA dataset...")
+    if not path or not os.path.exists(path):
+        path = download_file(
+            HOTPOTQA_URL,
+            os.path.join(cache_dir, "hotpot_dev_fullwiki_v1.json"),
+            desc="HotpotQA",
+        )
+    if not path:
+        return []
+
+    with open(path, "r", encoding="utf-8") as f:
+        dataset = json.load(f)
+
+    records = []
+    for data in dataset:
+        # Combine question with context paragraphs
+        question = data.get("question", "")
+        context = data.get("context", [])
+
+        # Build context text from paragraphs
+        context_texts = []
+        for ctx in context:
+            if isinstance(ctx, list) and len(ctx) > 1:
+                context_texts.append(" ".join(ctx[1]))
+
+        context_str = "\n\n".join(context_texts)
+        prompt = f"Context:\n{context_str}\n\nQuestion: {question}\nAnswer:"
+
+        # Estimate output length (answer is typically short)
+        answer = data.get("answer", "")
+        estimated_output_len = max(len(answer) // 4, 32)
+
+        records.append(
+            {
+                "prompt": prompt,
+                "expected_output_len": estimated_output_len,
+                "source": "hotpotqa",
+            }
+        )
+
+    if num_samples is not None and num_samples < len(records):
+        records = records[:num_samples]
+
+    print(f"  Loaded {len(records)} HotpotQA samples")
+    return records
+
+
+def load_squad(path, num_samples=None, cache_dir=CACHE_DIR):
+    """Load SQuAD dataset and convert to unified format.
+
+    SQuAD is a reading comprehension dataset with contexts typically 1k-3k tokens.
+    """
+    print("\n[6/8] Loading SQuAD dataset...")
+    if not path or not os.path.exists(path):
+        path = download_file(
+            SQUAD_URL,
+            os.path.join(cache_dir, "dev-v2.0.json"),
+            desc="SQuAD",
+        )
+    if not path:
+        return []
+
+    with open(path, "r", encoding="utf-8") as f:
+        dataset = json.load(f)
+
+    records = []
+    for article in dataset.get("data", []):
+        for paragraph in article.get("paragraphs", []):
+            context = paragraph.get("context", "")
+            for qa in paragraph.get("qas", []):
+                question = qa.get("question", "")
+
+                prompt = f"Context:\n{context}\n\nQuestion: {question}\nAnswer:"
+
+                # Estimate output length from answers
+                answers = qa.get("answers", [])
+                if answers:
+                    answer_text = answers[0].get("text", "")
+                    estimated_output_len = max(len(answer_text) // 4, 32)
+                else:
+                    estimated_output_len = 64
+
+                records.append(
+                    {
+                        "prompt": prompt,
+                        "expected_output_len": estimated_output_len,
+                        "source": "squad",
+                    }
+                )
+
+    if num_samples is not None and num_samples < len(records):
+        records = records[:num_samples]
+
+    print(f"  Loaded {len(records)} SQuAD samples")
+    return records
+
+
+def load_drop(path, num_samples=None, cache_dir=CACHE_DIR):
+    """Load DROP dataset and convert to unified format.
+
+    DROP is a discrete reasoning dataset with numerical reasoning over paragraphs.
+    Contexts are typically 1k-4k tokens.
+    """
+    print("\n[7/8] Loading DROP dataset...")
+    if not path or not os.path.exists(path):
+        zip_path = os.path.join(cache_dir, "drop_dataset.zip")
+        json_path = os.path.join(cache_dir, "drop_dataset", "drop_dataset_train.json")
+
+        if os.path.exists(json_path):
+            path = json_path
+        else:
+            result = download_file(DROP_URL, zip_path, desc="DROP")
+            if not result:
+                return []
+            # Extract zip file
+            import zipfile
+
+            print("  Extracting DROP dataset...")
+            with zipfile.ZipFile(zip_path, "r") as zip_ref:
+                zip_ref.extractall(cache_dir)
+            path = json_path
+
+    with open(path, "r", encoding="utf-8") as f:
+        dataset = json.load(f)
+
+    records = []
+    for passage_id, passage_data in dataset.items():
+        passage_text = passage_data.get("passage", "")
+        for qa_pair in passage_data.get("qa_pairs", []):
+            question = qa_pair.get("question", "")
+
+            prompt = f"Passage:\n{passage_text}\n\nQuestion: {question}\nAnswer:"
+
+            # Estimate output length from answer
+            answer = qa_pair.get("answer", "")
+            if isinstance(answer, dict):
+                answer_text = answer.get("number", "") or str(answer)
+            else:
+                answer_text = str(answer)
+            estimated_output_len = max(len(answer_text) // 4, 16)
+
+            records.append(
+                {
+                    "prompt": prompt,
+                    "expected_output_len": estimated_output_len,
+                    "source": "drop",
+                }
+            )
+
+    if num_samples is not None and num_samples < len(records):
+        records = records[:num_samples]
+
+    print(f"  Loaded {len(records)} DROP samples")
+    return records
+
+
+def load_mbpp(path, num_samples=None, cache_dir=CACHE_DIR):
+    """Load MBPP dataset and convert to unified format.
+
+    MBPP (Mostly Basic Python Problems) is a code generation dataset.
+    Prompts are typically 500-2k tokens.
+    """
+    print("\n[8/8] Loading MBPP dataset...")
+    if not path or not os.path.exists(path):
+        path = download_file(
+            MBPP_URL,
+            os.path.join(cache_dir, "mbpp.jsonl"),
+            desc="MBPP",
+        )
+    if not path:
+        return []
+
+    records = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            data = json.loads(line)
+
+            text = data.get("text", "")
+            test_list = data.get("test_list", [])
+
+            # Create a code generation prompt
+            prompt = f"""{text}
+
+Your code should pass these tests:
+"""
+            for test in test_list[:3]:  # Include up to 3 test cases
+                prompt += f"{test}\n"
+
+            prompt += "\nProvide your solution:"
+
+            # Estimate output length from reference code
+            code = data.get("code", "")
+            estimated_output_len = max(len(code) // 4, 128)
+
+            records.append(
+                {
+                    "prompt": prompt,
+                    "expected_output_len": estimated_output_len,
+                    "source": "mbpp",
+                }
+            )
+
+    if num_samples is not None and num_samples < len(records):
+        records = records[:num_samples]
+
+    print(f"  Loaded {len(records)} MBPP samples")
+    return records
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Prepare mixed benchmark dataset (GSM8K + HumanEval + MT-Bench + ShareGPT + Medium-length datasets)"
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "mix_spec_dataset.jsonl"
+        ),
+        help="Output JSONL file path. Default: ./mix_spec_dataset.jsonl",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=str,
+        default=CACHE_DIR,
+        help="Directory to cache downloaded datasets.",
+    )
+
+    # Per-dataset sample count
+    parser.add_argument(
+        "--num-gsm8k",
+        type=int,
+        default=None,
+        help="Number of GSM8K samples to include. Default: all (1319 test samples).",
+    )
+    parser.add_argument(
+        "--num-humaneval",
+        type=int,
+        default=None,
+        help="Number of HumanEval samples to include. Default: all (164 samples).",
+    )
+    parser.add_argument(
+        "--num-mtbench",
+        type=int,
+        default=None,
+        help="Number of MT-Bench samples to include. Default: all (80 samples).",
+    )
+    parser.add_argument(
+        "--num-sharegpt",
+        type=int,
+        default=None,
+        help="Number of ShareGPT samples to include. Default: all.",
+    )
+
+    # Medium-length datasets (1k-10k tokens)
+    parser.add_argument(
+        "--num-hotpotqa",
+        type=int,
+        default=None,
+        help="Number of HotpotQA samples to include (multi-hop reasoning QA, 1k-5k tokens). Default: 0 (skip).",
+    )
+    parser.add_argument(
+        "--num-squad",
+        type=int,
+        default=None,
+        help="Number of SQuAD samples to include (reading comprehension, 1k-3k tokens). Default: 0 (skip).",
+    )
+    parser.add_argument(
+        "--num-drop",
+        type=int,
+        default=None,
+        help="Number of DROP samples to include (numerical reasoning, 1k-4k tokens). Default: 0 (skip).",
+    )
+    parser.add_argument(
+        "--num-mbpp",
+        type=int,
+        default=None,
+        help="Number of MBPP samples to include (Python code generation, 500-2k tokens). Default: 0 (skip).",
+    )
+
+    # Per-dataset local file paths (for manual download)
+    parser.add_argument(
+        "--gsm8k-path",
+        type=str,
+        default="",
+        help="Path to locally downloaded GSM8K test.jsonl.",
+    )
+    parser.add_argument(
+        "--humaneval-path",
+        type=str,
+        default="",
+        help="Path to locally downloaded HumanEval.jsonl (decompressed).",
+    )
+    parser.add_argument(
+        "--mtbench-path",
+        type=str,
+        default="",
+        help="Path to locally downloaded MT-Bench question.jsonl.",
+    )
+    parser.add_argument(
+        "--sharegpt-path",
+        type=str,
+        default="",
+        help="Path to locally downloaded ShareGPT JSON file.",
+    )
+    parser.add_argument(
+        "--hotpotqa-path",
+        type=str,
+        default="",
+        help="Path to locally downloaded HotpotQA JSON file.",
+    )
+    parser.add_argument(
+        "--squad-path",
+        type=str,
+        default="",
+        help="Path to locally downloaded SQuAD dev-v2.0.json file.",
+    )
+    parser.add_argument(
+        "--drop-path",
+        type=str,
+        default="",
+        help="Path to locally downloaded DROP dataset directory.",
+    )
+    parser.add_argument(
+        "--mbpp-path",
+        type=str,
+        default="",
+        help="Path to locally downloaded MBPP jsonl file.",
+    )
+
+    # Dataset selection flags
+    parser.add_argument(
+        "--include-medium-length",
+        action="store_true",
+        help="Include all medium-length datasets (HotpotQA, SQuAD, DROP, MBPP).",
+    )
+    parser.add_argument(
+        "--datasets",
+        type=str,
+        default="",
+        help="Comma-separated list of datasets to include (e.g., 'gsm8k,humaneval,hotpotqa'). "
+        "If set, only these datasets will be included. Options: gsm8k, humaneval, mtbench, sharegpt, "
+        "hotpotqa, squad, drop, mbpp",
+    )
+
+    args = parser.parse_args()
+
+    cache_dir = args.cache_dir
+
+    # Determine which datasets to include
+    selected_datasets = None
+    if args.datasets:
+        selected_datasets = [s.strip().lower() for s in args.datasets.split(",")]
+
+    def should_include(name):
+        if selected_datasets is not None:
+            return name in selected_datasets
+        return True
+
+    print("=" * 60)
+    print("Preparing mixed benchmark dataset (mix-spec)")
+    print(
+        "Order: GSM8K -> HumanEval -> MT-Bench -> ShareGPT -> HotpotQA -> SQuAD -> DROP -> MBPP"
+    )
+    print("=" * 60)
+
+    all_records = []
+    dataset_counts = {}
+
+    # Load base datasets
+    if should_include("gsm8k"):
+        gsm8k_records = load_gsm8k(args.gsm8k_path, args.num_gsm8k, cache_dir)
+        all_records.extend(gsm8k_records)
+        dataset_counts["GSM8K"] = len(gsm8k_records)
+
+    if should_include("humaneval"):
+        humaneval_records = load_humaneval(
+            args.humaneval_path, args.num_humaneval, cache_dir
+        )
+        all_records.extend(humaneval_records)
+        dataset_counts["HumanEval"] = len(humaneval_records)
+
+    if should_include("mtbench"):
+        mtbench_records = load_mtbench(args.mtbench_path, args.num_mtbench, cache_dir)
+        all_records.extend(mtbench_records)
+        dataset_counts["MT-Bench"] = len(mtbench_records)
+
+    if should_include("sharegpt"):
+        sharegpt_records = load_sharegpt(
+            args.sharegpt_path, args.num_sharegpt, cache_dir
+        )
+        all_records.extend(sharegpt_records)
+        dataset_counts["ShareGPT"] = len(sharegpt_records)
+
+    # Load medium-length datasets
+    if should_include("hotpotqa") and (args.include_medium_length or args.num_hotpotqa):
+        hotpotqa_records = load_hotpotqa(
+            args.hotpotqa_path, args.num_hotpotqa, cache_dir
+        )
+        all_records.extend(hotpotqa_records)
+        dataset_counts["HotpotQA"] = len(hotpotqa_records)
+
+    if should_include("squad") and (args.include_medium_length or args.num_squad):
+        squad_records = load_squad(args.squad_path, args.num_squad, cache_dir)
+        all_records.extend(squad_records)
+        dataset_counts["SQuAD"] = len(squad_records)
+
+    if should_include("drop") and (args.include_medium_length or args.num_drop):
+        drop_records = load_drop(args.drop_path, args.num_drop, cache_dir)
+        all_records.extend(drop_records)
+        dataset_counts["DROP"] = len(drop_records)
+
+    if should_include("mbpp") and (args.include_medium_length or args.num_mbpp):
+        mbpp_records = load_mbpp(args.mbpp_path, args.num_mbpp, cache_dir)
+        all_records.extend(mbpp_records)
+        dataset_counts["MBPP"] = len(mbpp_records)
+
+    # Write to output JSONL
+    os.makedirs(os.path.dirname(os.path.abspath(args.output)), exist_ok=True)
+    with open(args.output, "w", encoding="utf-8") as f:
+        for record in all_records:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    print("\n" + "=" * 60)
+    print(f"Mixed dataset written to: {args.output}")
+    print(f"Total samples: {len(all_records)}")
+    for name, count in dataset_counts.items():
+        if count > 0:
+            print(f"  - {name}: {count}")
+        else:
+            print(f"  - {name}: 0 (skipped, download failed)")
+
+    if len(all_records) == 0:
+        print("\nWARNING: No samples were loaded. Check download errors above.")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/advanced_features/auto_spec.md
+++ b/docs/advanced_features/auto_spec.md
@@ -1,0 +1,169 @@
+# Auto-Spec: Adaptive Speculative Decoding
+
+Auto-Spec dynamically adjusts the speculative decoding depth (`num_steps`) at runtime based on acceptance rate feedback. Instead of using a fixed speculation depth for all workloads, it monitors how well the draft model's predictions are accepted and tunes the depth per batch size to maximize throughput.
+
+## Quick Start
+
+```bash
+# Basic usage: add --auto-spec to any EAGLE speculative decoding launch
+python -m sglang.launch_server \
+    --model-path meta-llama/Llama-3.1-8B-Instruct \
+    --speculative-algorithm EAGLE \
+    --speculative-draft-model-path path/to/eagle-model \
+    --speculative-num-steps 3 \
+    --auto-spec
+```
+
+The `--speculative-num-steps` value serves as the initial default. Auto-Spec will adjust it up or down during inference.
+
+## How It Works
+
+```
+                    ┌─────────────────────────┐
+                    │   AutoSpecEngine        │
+                    │                         │
+ accept rate ──────►│  EMA tracker per BS     │
+ feedback           │  threshold comparison   │
+                    │  step adjustment        │
+                    └───────────┬─────────────┘
+                                │ best num_steps
+                                ▼
+                    ┌─────────────────────────┐
+                    │  EAGLEWorker /          │
+                    │  EAGLEWorkerV2          │
+                    │                         │
+                    │  switch CUDA graphs     │
+                    │  switch attn backends   │
+                    └─────────────────────────┘
+```
+
+1. **Startup**: For each candidate `num_steps` value, the system captures a set of CUDA graphs (draft, draft-extend, verify) and attention backends.
+2. **Runtime**: After each decode batch, the scheduler feeds the acceptance rate to the engine.
+3. **Decision**: The engine uses EMA-smoothed acceptance rates per batch size to decide:
+   - **Rate ≥ increase threshold** → try a larger `num_steps` (more aggressive speculation)
+   - **Rate < decrease threshold** → fall back to a smaller `num_steps` (more conservative)
+4. **Switching**: Before each decode forward pass, the worker checks the engine's recommendation and hot-swaps CUDA graphs + attention backends if the optimal `num_steps` has changed.
+
+## Command-Line Arguments
+
+| Argument | Type | Default | Description |
+|---|---|---|---|
+| `--auto-spec` | flag | `false` | Enable adaptive speculative decoding |
+| `--speculative-config-file` | `str` | `None` | Path to JSON config with per-model step ranges |
+| `--pos-threshold` | `float...` | built-in | Acceptance rate thresholds for *increasing* num_steps, one per BS bucket |
+| `--neg-threshold` | `float...` | built-in | Acceptance rate thresholds for *decreasing* num_steps, one per BS bucket |
+
+### Threshold Arguments
+
+The `--pos-threshold` and `--neg-threshold` accept space-separated floats, one per batch size bucket in ascending order. The default batch size buckets are `[1, 2, 4, 8, 16, 32, 64, 128]`.
+
+```bash
+# Example: custom thresholds for 8 batch size buckets
+python -m sglang.launch_server \
+    --model-path ... \
+    --speculative-algorithm EAGLE \
+    --speculative-draft-model-path ... \
+    --auto-spec \
+    --pos-threshold 0.55 0.55 0.60 0.80 0.95 0.91 0.95 0.95 \
+    --neg-threshold 0.50 0.50 0.50 0.50 0.60 0.66 0.65 0.65
+```
+
+- **pos-threshold**: If the EMA acceptance rate exceeds this value, `num_steps` is increased.
+- **neg-threshold**: If the EMA acceptance rate drops below this value, `num_steps` is decreased.
+- Higher thresholds make the tuner more conservative (less likely to increase steps).
+
+## Speculative Config File
+
+You can define per-model step ranges in a JSON file:
+
+```json
+{
+    "meta-llama/Llama-3.1-8B-Instruct": {
+        "1": [3, 4, 5, 6],
+        "2": [3, 4, 5, 6],
+        "4": [3, 4, 5, 6],
+        "8": [2, 3, 4],
+        "16": [2, 3, 4],
+        "32": [2, 3, 4],
+        "64": [1, 2, 3],
+        "128": [1, 2]
+    }
+}
+```
+
+Each key is a batch size, and the value is the list of `num_steps` values the engine is allowed to choose from for that batch size. Use with:
+
+```bash
+--speculative-config-file /path/to/config.json
+```
+
+If the file is not provided or the model name is not found, built-in defaults are used.
+
+## Default Step Ranges
+
+| Batch Size | Allowed num_steps | Initial num_steps |
+|---|---|---|
+| 1 | 3, 4, 5, 6 | 5 |
+| 2 | 3, 4, 5, 6 | 5 |
+| 4 | 3, 4, 5, 6 | 5 |
+| 8 | 2, 3, 4 | 4 |
+| 16 | 2, 3, 4 | 3 |
+| 32 | 2, 3, 4 | 3 |
+| 64 | 1, 2, 3, 4 | 3 |
+| 128 | 1, 2, 3, 4 | 1 |
+
+The intuition: small batches benefit from deeper speculation (more tokens drafted per step), while large batches should speculate conservatively (draft overhead grows linearly with batch size).
+
+## Compatibility
+
+- **Speculative algorithms**: EAGLE, EAGLE3
+- **topk**: Auto-Spec enforces `topk=1` (required for multi-step graph switching)
+- **Spec V1 and V2**: Both `EAGLEWorker` (V1) and `EAGLEWorkerV2` (V2/SpecV2) are supported
+- **CUDA graphs**: Required (auto-spec pre-captures graphs for each step count)
+- **Tensor parallelism**: Supported
+- **Data parallelism**: Supported
+
+## Memory Considerations
+
+Auto-Spec captures CUDA graphs for multiple `num_steps` values, which increases GPU memory usage. The engine automatically limits the number of step variants based on available memory at startup (~2GB per additional step set).
+
+If memory is tight, you can reduce the step range via the config file:
+
+```json
+{
+    "my-model": {
+        "1": [3, 5],
+        "8": [2, 3],
+        "32": [2, 3],
+        "128": [1, 2]
+    }
+}
+```
+
+## Example: Full Deployment
+
+```bash
+python -m sglang.launch_server \
+    --model-path meta-llama/Llama-3.1-70B-Instruct \
+    --speculative-algorithm EAGLE \
+    --speculative-draft-model-path path/to/eagle-70b \
+    --speculative-num-steps 4 \
+    --auto-spec \
+    --tp 4 \
+    --max-running-requests 128 \
+    --speculative-config-file ./spec_config.json
+```
+
+## Troubleshooting
+
+**Q: Startup is slow with auto-spec enabled.**
+A: This is expected. Auto-spec captures CUDA graphs for each `num_steps` variant at startup. You can reduce the number of variants in the config file to speed up startup.
+
+**Q: How do I know which num_steps is being used?**
+A: The decode log line already prints `accept len` and `accept rate`. The engine adjusts based on these metrics. You can also check the server logs for `AutoSpec` messages that show initialization parameters.
+
+**Q: Auto-spec makes throughput worse for my workload.**
+A: This can happen if the default thresholds don't suit your model/dataset. Try:
+1. Adjusting `--pos-threshold` / `--neg-threshold`
+2. Narrowing the step range in the config file
+3. Running with a fixed `--speculative-num-steps` that you've benchmarked as optimal

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -368,6 +368,10 @@ class Scheduler(
         self.enable_hisparse = server_args.enable_hisparse
         self.hisparse_coordinator: Optional[HiSparseCoordinator] = None
 
+        # Auto-speculative decoding
+        self.auto_spec = server_args.auto_spec
+        self.auto_spec_engine = None
+
         # Distributed rank info
         self.attn_tp_rank, self.attn_tp_size, self.attn_dp_rank = (
             compute_dp_attention_world_info(
@@ -662,6 +666,18 @@ class Scheduler(
         else:
             self.external_corpus_manager = None
 
+    def _init_auto_spec(self):
+        """Initialize the auto-spec engine and pass it to the model worker."""
+        from sglang.srt.speculative.auto_spec_engine import AutoSpecEngine
+
+        self.auto_spec_engine = AutoSpecEngine(self.server_args)
+        self.auto_spec_engine.initialize(self.gpu_id)
+
+        # Pass the engine to the model worker for multi-step graph capture
+        if hasattr(self.model_worker, "init_auto_spec"):
+            self.model_worker.init_auto_spec(self.auto_spec_engine)
+        logger.info("AutoSpec engine initialized and attached to model worker.")
+
     def init_model_worker(self):
         self.init_tp_model_worker()
         self.maybe_init_draft_worker()
@@ -671,6 +687,10 @@ class Scheduler(
             self.model_worker = self.tp_worker
         else:
             self.model_worker = self.draft_worker
+
+        # Initialize auto-spec if enabled
+        if self.auto_spec and not self.spec_algorithm.is_none():
+            self._init_auto_spec()
 
         # Get token and memory info from the model worker
         (

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -668,9 +668,8 @@ class Scheduler(
 
     def _init_auto_spec(self):
         """Initialize the auto-spec engine and pass it to the model worker."""
-        from sglang.srt.speculative.auto_spec_engine import AutoSpecEngine
-
         from sglang.srt.environ import envs
+        from sglang.srt.speculative.auto_spec_engine import AutoSpecEngine
 
         self.auto_spec_engine = AutoSpecEngine(self.server_args)
         is_spec_v2 = envs.SGLANG_ENABLE_SPEC_V2.get()

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -670,8 +670,11 @@ class Scheduler(
         """Initialize the auto-spec engine and pass it to the model worker."""
         from sglang.srt.speculative.auto_spec_engine import AutoSpecEngine
 
+        from sglang.srt.environ import envs
+
         self.auto_spec_engine = AutoSpecEngine(self.server_args)
-        self.auto_spec_engine.initialize(self.gpu_id)
+        is_spec_v2 = envs.SGLANG_ENABLE_SPEC_V2.get()
+        self.auto_spec_engine.initialize(self.gpu_id, is_spec_v2=is_spec_v2)
 
         # Pass the engine to the model worker for multi-step graph capture
         if hasattr(self.model_worker, "init_auto_spec"):

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -411,13 +411,20 @@ class SchedulerOutputProcessorMixin:
 
         self.num_generated_tokens += len(batch.reqs)
         if not batch.spec_algorithm.is_none():
-            self.update_spec_metrics(batch.batch_size(), result.num_accepted_tokens)
+            num_draft_tokens_per_req = getattr(
+                self.model_worker, "speculative_num_draft_tokens", 0
+            )
+            self.update_spec_metrics(
+                batch.batch_size(),
+                result.num_accepted_tokens,
+                num_draft_tokens_per_req,
+            )
             # Auto-spec: feed acceptance data to the tuning engine
             if self.auto_spec and self.auto_spec_engine is not None:
                 self.auto_spec_engine.update(
                     batch.batch_size(),
                     result.num_accepted_tokens,
-                    self.model_worker.speculative_num_draft_tokens,
+                    num_draft_tokens_per_req,
                 )
         if self.enable_metrics:
             self.metrics_collector.increment_decode_cuda_graph_pass(

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -420,7 +420,7 @@ class SchedulerOutputProcessorMixin:
                 num_draft_tokens_per_req,
             )
             # Auto-spec: feed acceptance data to the tuning engine
-            if self.auto_spec and self.auto_spec_engine is not None:
+            if self.auto_spec and self.auto_spec_engine is not None and self.auto_spec_engine.enable_watch:
                 self.auto_spec_engine.update(
                     batch.batch_size(),
                     result.num_accepted_tokens,

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -420,7 +420,11 @@ class SchedulerOutputProcessorMixin:
                 num_draft_tokens_per_req,
             )
             # Auto-spec: feed acceptance data to the tuning engine
-            if self.auto_spec and self.auto_spec_engine is not None and self.auto_spec_engine.enable_watch:
+            if (
+                self.auto_spec
+                and self.auto_spec_engine is not None
+                and self.auto_spec_engine.enable_watch
+            ):
                 self.auto_spec_engine.update(
                     batch.batch_size(),
                     result.num_accepted_tokens,

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -412,6 +412,13 @@ class SchedulerOutputProcessorMixin:
         self.num_generated_tokens += len(batch.reqs)
         if not batch.spec_algorithm.is_none():
             self.update_spec_metrics(batch.batch_size(), result.num_accepted_tokens)
+            # Auto-spec: feed acceptance data to the tuning engine
+            if self.auto_spec and self.auto_spec_engine is not None:
+                self.auto_spec_engine.update(
+                    batch.batch_size(),
+                    result.num_accepted_tokens,
+                    self.model_worker.speculative_num_draft_tokens,
+                )
         if self.enable_metrics:
             self.metrics_collector.increment_decode_cuda_graph_pass(
                 value=can_run_cuda_graph

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -488,6 +488,46 @@ def get_batch_sizes_to_capture(model_runner: ModelRunner, num_tokens_per_bs=1):
     return capture_bs, compile_bs
 
 
+def get_batch_sizes_to_capture_for_steps(
+    model_runner: "ModelRunner",
+    batch_sizes: Optional[List[int]] = None,
+    num_tokens_per_bs: int = 1,
+):
+    """Get batch sizes to capture for a specific auto-spec step.
+
+    Similar to get_batch_sizes_to_capture but allows overriding which
+    batch sizes to capture, useful when different steps only need
+    graphs for certain batch sizes.
+    """
+    server_args = model_runner.server_args
+    if batch_sizes is not None:
+        capture_bs = list(batch_sizes)
+    else:
+        capture_bs = list(server_args.cuda_graph_bs)
+
+    if max(capture_bs) > model_runner.req_to_token_pool.size:
+        capture_bs.append(model_runner.req_to_token_pool.size)
+
+    mul_base = 1
+    if server_args.enable_two_batch_overlap:
+        mul_base *= 2
+    if require_gathered_buffer(server_args):
+        mul_base *= get_attention_tp_size()
+    if mul_base % get_attention_cp_size() != 0:
+        mul_base *= get_attention_cp_size()
+
+    capture_bs = [bs for bs in capture_bs if bs * num_tokens_per_bs % mul_base == 0]
+    capture_bs = [bs for bs in capture_bs if bs <= model_runner.req_to_token_pool.size]
+    capture_bs = list(sorted(set(capture_bs)))
+    assert len(capture_bs) > 0 and capture_bs[0] > 0, f"{capture_bs=}"
+    compile_bs = (
+        [bs for bs in capture_bs if bs <= server_args.torch_compile_max_bs]
+        if server_args.enable_torch_compile
+        else []
+    )
+    return capture_bs, compile_bs
+
+
 # Reuse this memory pool across all cuda graph runners.
 global_graph_memory_pool = None
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2501,6 +2501,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
     def init_device_graphs(self):
         """Capture device graphs."""
         self.graph_runner = None
+        self.graph_runner_for_steps = {}  # For auto_spec: step -> CudaGraphRunner
         self.graph_mem_usage = 0
 
         if not self.is_generation:
@@ -2541,6 +2542,75 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self.graph_mem_usage = before_mem - after_mem
         logger.info(
             f"Capture {graph_backend[self.device]} end. Time elapsed: {time.perf_counter() - tic:.2f} s. "
+            f"mem usage={self.graph_mem_usage:.2f} GB. avail mem={after_mem:.2f} GB."
+        )
+
+    def init_attention_backend_for_steps(self, step_range: list):
+        """Init attention backends for each speculative step (auto_spec verify side)."""
+        self.attn_backend_for_steps = {}
+        saved_num_steps = self.server_args.speculative_num_steps
+        saved_num_draft = self.server_args.speculative_num_draft_tokens
+
+        for num_steps in step_range:
+            self.server_args.speculative_num_steps = num_steps
+            self.server_args.speculative_num_draft_tokens = num_steps + 1
+            self.attn_backend_for_steps[num_steps] = self._get_attention_backend()
+            logger.info(
+                f"AutoSpec: init verify attention backend for num_steps={num_steps}"
+            )
+
+        # Restore and set initial
+        initial_step = step_range[-1]
+        self.server_args.speculative_num_steps = saved_num_steps
+        self.server_args.speculative_num_draft_tokens = saved_num_draft
+        self.attn_backend = self.attn_backend_for_steps[initial_step]
+
+    def init_device_graphs_for_steps(self, step_range: list):
+        """Capture device graphs for each speculative step (auto_spec verify side)."""
+        if not self.is_generation or self.server_args.disable_cuda_graph:
+            return
+
+        saved_num_steps = self.server_args.speculative_num_steps
+        saved_num_draft = self.server_args.speculative_num_draft_tokens
+
+        tic = time.perf_counter()
+        before_mem = get_available_gpu_memory(self.device, self.gpu_id)
+        logger.info(
+            f"AutoSpec: capture verify cuda graphs begin. avail mem={before_mem:.2f} GB"
+        )
+
+        graph_runners = defaultdict(
+            lambda: CudaGraphRunner,
+            {
+                "cpu": CPUGraphRunner,
+                "npu": NPUGraphRunner,
+            },
+        )
+
+        for num_steps in step_range:
+            self.server_args.speculative_num_steps = num_steps
+            self.server_args.speculative_num_draft_tokens = num_steps + 1
+            self.attn_backend = self.attn_backend_for_steps[num_steps]
+            step_before = get_available_gpu_memory(self.device, self.gpu_id)
+            self.graph_runner_for_steps[num_steps] = graph_runners[self.device](self)
+            step_after = get_available_gpu_memory(self.device, self.gpu_id)
+            logger.info(
+                f"AutoSpec: captured verify graph for num_steps={num_steps}, "
+                f"mem usage={step_before - step_after:.2f} GB"
+            )
+
+        # Restore and set initial
+        initial_step = step_range[-1]
+        self.server_args.speculative_num_steps = saved_num_steps
+        self.server_args.speculative_num_draft_tokens = saved_num_draft
+        self.attn_backend = self.attn_backend_for_steps[initial_step]
+        self.graph_runner = self.graph_runner_for_steps[initial_step]
+
+        after_mem = get_available_gpu_memory(self.device, self.gpu_id)
+        self.graph_mem_usage = before_mem - after_mem
+        logger.info(
+            f"AutoSpec: capture verify cuda graphs end. "
+            f"Time elapsed: {time.perf_counter() - tic:.2f} s. "
             f"mem usage={self.graph_mem_usage:.2f} GB. avail mem={after_mem:.2f} GB."
         )
 

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -103,7 +103,9 @@ class SchedulerMetricsMixin:
         # The number of accepted tokens and forward ct for the recent `decode_log_interval` batches (for logging)
         self.spec_num_accepted_tokens = 0
         self.spec_num_forward_ct = 0
-        self.spec_num_draft_tokens = 0  # Total draft tokens (for accurate accept_rate with auto-spec)
+        self.spec_num_draft_tokens = (
+            0  # Total draft tokens (for accurate accept_rate with auto-spec)
+        )
         # The total number of accepted tokens and forward ct for the whole server lifetime
         self.spec_total_num_accepted_tokens = 0
         self.spec_total_num_forward_ct = 0
@@ -629,9 +631,12 @@ class SchedulerMetricsMixin:
             if self.spec_num_draft_tokens > 0:
                 total_draft_tokens = self.spec_num_draft_tokens
             else:
-                draft_tokens_fallback = (self.server_args.speculative_num_steps or 0) + 1
+                draft_tokens_fallback = (
+                    self.server_args.speculative_num_steps or 0
+                ) + 1
                 num_draft_tokens = (
-                    self.server_args.speculative_num_draft_tokens or draft_tokens_fallback
+                    self.server_args.speculative_num_draft_tokens
+                    or draft_tokens_fallback
                 )
                 total_draft_tokens = self.spec_num_forward_ct * num_draft_tokens
 

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -103,6 +103,7 @@ class SchedulerMetricsMixin:
         # The number of accepted tokens and forward ct for the recent `decode_log_interval` batches (for logging)
         self.spec_num_accepted_tokens = 0
         self.spec_num_forward_ct = 0
+        self.spec_num_draft_tokens = 0  # Total draft tokens (for accurate accept_rate with auto-spec)
         # The total number of accepted tokens and forward ct for the whole server lifetime
         self.spec_total_num_accepted_tokens = 0
         self.spec_total_num_forward_ct = 0
@@ -177,10 +178,17 @@ class SchedulerMetricsMixin:
                 kv_events_config, self.attn_dp_rank
             )
 
-    def update_spec_metrics(self: Scheduler, bs: int, num_accepted_tokens: int):
+    def update_spec_metrics(
+        self: Scheduler,
+        bs: int,
+        num_accepted_tokens: int,
+        num_draft_tokens_per_req: int = 0,
+    ):
         self.spec_num_accepted_tokens += num_accepted_tokens + bs
         self.spec_num_forward_ct += bs
         self.num_generated_tokens += num_accepted_tokens
+        if num_draft_tokens_per_req > 0:
+            self.spec_num_draft_tokens += bs * num_draft_tokens_per_req
 
     def _init_estimated_perf_constants(self: Scheduler) -> None:
         model_config = self.model_config
@@ -320,6 +328,7 @@ class SchedulerMetricsMixin:
         self.num_generated_tokens = 0
         self.spec_num_accepted_tokens = 0
         self.spec_num_forward_ct = 0
+        self.spec_num_draft_tokens = 0
         self.spec_total_num_accepted_tokens = 0
         self.spec_total_num_forward_ct = 0
 
@@ -615,11 +624,16 @@ class SchedulerMetricsMixin:
                 self.spec_num_accepted_tokens / self.spec_num_forward_ct
             )
             # Calculate acceptance rate: accepted tokens / total draft tokens
-            draft_tokens_fallback = (self.server_args.speculative_num_steps or 0) + 1
-            num_draft_tokens = (
-                self.server_args.speculative_num_draft_tokens or draft_tokens_fallback
-            )
-            total_draft_tokens = self.spec_num_forward_ct * num_draft_tokens
+            # Use accumulated draft tokens when available (accurate with auto-spec),
+            # otherwise fall back to server_args (fixed num_steps).
+            if self.spec_num_draft_tokens > 0:
+                total_draft_tokens = self.spec_num_draft_tokens
+            else:
+                draft_tokens_fallback = (self.server_args.speculative_num_steps or 0) + 1
+                num_draft_tokens = (
+                    self.server_args.speculative_num_draft_tokens or draft_tokens_fallback
+                )
+                total_draft_tokens = self.spec_num_forward_ct * num_draft_tokens
 
             spec_accept_rate = (
                 self.spec_num_accepted_tokens / total_draft_tokens
@@ -629,6 +643,7 @@ class SchedulerMetricsMixin:
             self.spec_total_num_accepted_tokens += self.spec_num_accepted_tokens
             self.spec_total_num_forward_ct += self.spec_num_forward_ct
             self.spec_num_accepted_tokens = self.spec_num_forward_ct = 0
+            self.spec_num_draft_tokens = 0
             msg += f"accept len: {spec_accept_length:.2f}, accept rate: {spec_accept_rate:.2f}, "
         cache_hit_rate = 0.0
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3252,7 +3252,10 @@ class ServerArgs:
                 or self.decode_attention_backend == "trtllm_mha"
                 or self.prefill_attention_backend == "trtllm_mha"
             ):
-                if self.speculative_eagle_topk > 1:
+                if (
+                    self.speculative_eagle_topk is not None
+                    and self.speculative_eagle_topk > 1
+                ):
                     raise ValueError(
                         "trtllm_mha backend only supports topk = 1 for speculative decoding."
                     )
@@ -3267,7 +3270,8 @@ class ServerArgs:
                 self.speculative_num_draft_tokens = self.speculative_num_steps + 1
 
             if (
-                self.speculative_eagle_topk > 1
+                self.speculative_eagle_topk is not None
+                and self.speculative_eagle_topk > 1
                 and self.page_size > 1
                 and self.attention_backend not in ["flashinfer", "fa3"]
             ):
@@ -3328,7 +3332,8 @@ class ServerArgs:
             )
 
             if (
-                self.speculative_eagle_topk > 1
+                self.speculative_eagle_topk is not None
+                and self.speculative_eagle_topk > 1
                 and self.page_size > 1
                 and self.attention_backend != "flashinfer"
             ):

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -521,6 +521,12 @@ class ServerArgs:
     speculative_ngram_external_corpus_max_tokens: int = 10000000
     enable_multi_layer_eagle: bool = False
 
+    # Auto-speculative decoding: dynamically adjust num_steps based on acceptance rate
+    auto_spec: bool = False
+    speculative_config_file: Optional[str] = None
+    pos_threshold: Optional[List[float]] = None
+    neg_threshold: Optional[List[float]] = None
+
     # Expert parallelism
     ep_size: int = 1
     moe_a2a_backend: Literal[
@@ -3269,6 +3275,13 @@ class ServerArgs:
                     "speculative_eagle_topk > 1 with page_size > 1 is unstable and produces incorrect results for paged attention backends. This combination is only supported for the 'flashinfer' backend."
                 )
 
+            if self.auto_spec:
+                # Auto-spec requires topk=1 and sets initial defaults
+                self.speculative_eagle_topk = 1
+                if self.speculative_num_steps is None or self.speculative_num_steps < 1:
+                    self.speculative_num_steps = 3
+                self.speculative_num_draft_tokens = self.speculative_num_steps + 1
+
         if self.speculative_algorithm == "NGRAM":
             if not self.device.startswith("cuda"):
                 raise ValueError(
@@ -5136,6 +5149,31 @@ class ServerArgs:
             "--enable-multi-layer-eagle",
             action="store_true",
             help="Enable multi-layer Eagle speculative decoding.",
+        )
+
+        # Auto-speculative decoding
+        parser.add_argument(
+            "--auto-spec",
+            action="store_true",
+            help="Enable dynamic adjustment of speculative decoding parameters (num_steps) based on runtime acceptance rate.",
+        )
+        parser.add_argument(
+            "--speculative-config-file",
+            type=str,
+            default=ServerArgs.speculative_config_file,
+            help="Path to a JSON file containing per-model speculative decoding step configurations.",
+        )
+        parser.add_argument(
+            "--pos-threshold",
+            type=float,
+            nargs="+",
+            help="Acceptance rate thresholds for increasing num_steps, one per batch size bucket.",
+        )
+        parser.add_argument(
+            "--neg-threshold",
+            type=float,
+            nargs="+",
+            help="Acceptance rate thresholds for decreasing num_steps, one per batch size bucket.",
         )
 
         # Expert parallelism

--- a/python/sglang/srt/speculative/auto_spec_engine.py
+++ b/python/sglang/srt/speculative/auto_spec_engine.py
@@ -250,33 +250,39 @@ class AutoSpecEngine:
         # EMA acceptance rate tracker per batch size
         self.ema_accept_rate: Dict[int, float] = {bs: 0.5 for bs in self.bs_list}
 
-    def prune_by_graph_capacity(self, step_max_bs: Dict[int, int]):
-        """Remove BS->step mappings where the draft graph can't handle that BS.
+    def sync_with_graph_capacity(self, step_max_bs: Dict[int, int]):
+        """Sync BS->step mappings with actual CUDA graph capacity.
 
-        After CUDA graphs are captured, the draft graph runner for each step has a
-        max_bs limit. If a batch size exceeds that limit, it would fall to eager mode
-        which can cause illegal memory access. This method prunes such mappings.
+        After CUDA graphs are captured, each step's graph runner has a max_bs.
+        This method:
+        1. Expands: allows every BS to use any step whose graph supports it
+        2. Prunes: removes BS->step mappings where the graph can't handle that BS
+
+        This ensures all batch sizes can use all capable steps (maximizing
+        auto-spec flexibility) while preventing eager mode fallback.
 
         Args:
             step_max_bs: Mapping from num_steps -> max batch size supported by graphs.
         """
-        pruned = False
-        for bs in list(self.bs_steps_mapping.keys()):
-            original = self.bs_steps_mapping[bs]
-            filtered = [s for s in original if bs <= step_max_bs.get(s, 0)]
-            if not filtered:
-                # Keep at least the step with the largest max_bs for this entry
-                best_step = max(original, key=lambda s: step_max_bs.get(s, 0))
-                filtered = [best_step]
-            if filtered != original:
-                pruned = True
-                self.bs_steps_mapping[bs] = filtered
+        changed = False
+        all_steps = sorted(step_max_bs.keys())
 
-        if pruned:
+        for bs in list(self.bs_steps_mapping.keys()):
+            # Expand: include all steps whose graph can handle this BS
+            expanded = sorted(s for s in all_steps if bs <= step_max_bs.get(s, 0))
+            if not expanded:
+                # Fallback: keep the step with the largest max_bs
+                best_step = max(all_steps, key=lambda s: step_max_bs.get(s, 0))
+                expanded = [best_step]
+            if expanded != self.bs_steps_mapping[bs]:
+                changed = True
+                self.bs_steps_mapping[bs] = expanded
+
+        if changed:
             self._build_reverse_mapping()
             self._init_current_params()
             logger.info(
-                f"AutoSpecEngine: pruned bs_steps_mapping by graph capacity: "
+                f"AutoSpecEngine: synced bs_steps_mapping with graph capacity: "
                 f"{self.bs_steps_mapping}"
             )
 

--- a/python/sglang/srt/speculative/auto_spec_engine.py
+++ b/python/sglang/srt/speculative/auto_spec_engine.py
@@ -87,8 +87,8 @@ class AutoSpecEngine:
         )
 
         # EMA smoothing factor for acceptance rate tracking
-        # self.ema_alpha = 0.3
-        self.ema_alpha = 1.0
+        self.ema_alpha = 0.3
+        # self.ema_alpha = 1.0
 
         # Load or build bs -> steps mapping
         self._init_bs_steps_mapping()

--- a/python/sglang/srt/speculative/auto_spec_engine.py
+++ b/python/sglang/srt/speculative/auto_spec_engine.py
@@ -285,6 +285,7 @@ class AutoSpecEngine:
         inc_threshold = self.increase_thresholds.get(bs, 0.55)
         dec_threshold = self.decrease_thresholds.get(bs, 0.50)
 
+        new_steps = current_steps
         if current_rate >= inc_threshold:
             # Try to increase steps
             higher = [s for s in available_steps if s > current_steps]
@@ -297,6 +298,21 @@ class AutoSpecEngine:
             if lower:
                 new_steps = lower[-1]  # largest step smaller than current
                 self.current_params[bs] = SpecParams(num_steps=new_steps)
+
+        if new_steps != current_steps:
+            logger.info(
+                f"AutoSpecEngine: bs={batch_size}(mapped={bs}) step change "
+                f"{current_steps}->{new_steps}, "
+                f"ema_rate={current_rate:.4f}, "
+                f"thresholds=({inc_threshold:.2f},{dec_threshold:.2f})"
+            )
+        elif logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                f"AutoSpecEngine: bs={batch_size}(mapped={bs}) "
+                f"accept_rate={accept_rate:.4f}, ema={current_rate:.4f}, "
+                f"steps={current_steps}, "
+                f"thresholds=({inc_threshold:.2f},{dec_threshold:.2f})"
+            )
 
     def _format_params(self) -> str:
         parts = []

--- a/python/sglang/srt/speculative/auto_spec_engine.py
+++ b/python/sglang/srt/speculative/auto_spec_engine.py
@@ -101,16 +101,31 @@ class AutoSpecEngine:
         # Will be finalized in initialize() after GPU memory is known
         self._initialized = False
 
-    def initialize(self, gpu_id: int):
-        """Must be called after model loading to finalize based on available GPU memory."""
+    def initialize(self, gpu_id: int, is_spec_v2: bool = False):
+        """Must be called after model loading to finalize based on available GPU memory.
+
+        Args:
+            gpu_id: The GPU device index.
+            is_spec_v2: If True, use more conservative memory estimates for SpecV2
+                which captures both draft and verify CUDA graphs per step.
+        """
         from sglang.srt.utils.common import get_available_gpu_memory
 
         available_memory = get_available_gpu_memory(self.device_id, gpu_id, empty_cache=False)
-        # Reserve 4GB safety margin, ~2GB per step for CUDA graphs
-        max_num_graphs = int((available_memory - 4) // 2)
+        # SpecV2 captures both draft + verify graphs per step (~3.5GB each),
+        # while V1 only captures draft graphs (~2GB each).
+        # Reserve safety margin for inference runtime allocations (MoE, etc).
+        if is_spec_v2:
+            safety_margin = 6.0  # GB reserved for runtime
+            cost_per_step = 3.5  # GB per step (draft + verify graphs)
+        else:
+            safety_margin = 4.0
+            cost_per_step = 2.0
+        max_num_graphs = int((available_memory - safety_margin) // cost_per_step)
         max_num_graphs = max(max_num_graphs, 1)
         logger.info(
             f"AutoSpecEngine: available_memory={available_memory:.1f}GB, "
+            f"safety_margin={safety_margin}GB, cost_per_step={cost_per_step}GB, "
             f"max graph sets={max_num_graphs}"
         )
 
@@ -234,6 +249,36 @@ class AutoSpecEngine:
 
         # EMA acceptance rate tracker per batch size
         self.ema_accept_rate: Dict[int, float] = {bs: 0.5 for bs in self.bs_list}
+
+    def prune_by_graph_capacity(self, step_max_bs: Dict[int, int]):
+        """Remove BS->step mappings where the draft graph can't handle that BS.
+
+        After CUDA graphs are captured, the draft graph runner for each step has a
+        max_bs limit. If a batch size exceeds that limit, it would fall to eager mode
+        which can cause illegal memory access. This method prunes such mappings.
+
+        Args:
+            step_max_bs: Mapping from num_steps -> max batch size supported by graphs.
+        """
+        pruned = False
+        for bs in list(self.bs_steps_mapping.keys()):
+            original = self.bs_steps_mapping[bs]
+            filtered = [s for s in original if bs <= step_max_bs.get(s, 0)]
+            if not filtered:
+                # Keep at least the step with the largest max_bs for this entry
+                best_step = max(original, key=lambda s: step_max_bs.get(s, 0))
+                filtered = [best_step]
+            if filtered != original:
+                pruned = True
+                self.bs_steps_mapping[bs] = filtered
+
+        if pruned:
+            self._build_reverse_mapping()
+            self._init_current_params()
+            logger.info(
+                f"AutoSpecEngine: pruned bs_steps_mapping by graph capacity: "
+                f"{self.bs_steps_mapping}"
+            )
 
     def _find_closest_bs(self, target: int) -> int:
         """Find the closest batch size in our configured list."""

--- a/python/sglang/srt/speculative/auto_spec_engine.py
+++ b/python/sglang/srt/speculative/auto_spec_engine.py
@@ -87,7 +87,8 @@ class AutoSpecEngine:
         )
 
         # EMA smoothing factor for acceptance rate tracking
-        self.ema_alpha = 0.3
+        # self.ema_alpha = 0.3
+        self.ema_alpha = 1.0
 
         # Load or build bs -> steps mapping
         self._init_bs_steps_mapping()
@@ -145,6 +146,7 @@ class AutoSpecEngine:
         if self.speculative_config_file and os.path.exists(
             self.speculative_config_file
         ):
+            logger.info(f"AutoSpecEngine: loading speculative config from {self.speculative_config_file}")
             try:
                 with open(self.speculative_config_file, "r") as f:
                     config = json.load(f)
@@ -154,7 +156,9 @@ class AutoSpecEngine:
                     for bs_str, steps in model_config.items():
                         try:
                             self.bs_steps_mapping[int(bs_str)] = sorted(steps)
+                            logger.info("AutoSpecEngine: speculative config loaded from file.")
                         except ValueError:
+                            logger.info("AutoSpecEngine: speculative config failed to load from file.")
                             pass
                     if self.bs_steps_mapping:
                         logger.info(
@@ -165,6 +169,8 @@ class AutoSpecEngine:
                 logger.warning(
                     f"AutoSpecEngine: failed to load config: {e}, using defaults"
                 )
+        else:
+            logger.info(f"AutoSpecEngine: speculative config not found in {self.speculative_config_file}")
 
         self.bs_steps_mapping = {k: list(v) for k, v in DEFAULT_BS_STEPS_MAPPING.items()}
 
@@ -196,6 +202,7 @@ class AutoSpecEngine:
             for i, bs in enumerate(sorted(self.bs_steps_mapping.keys())):
                 if i < len(neg_threshold):
                     self.decrease_thresholds[bs] = neg_threshold[i]
+        logger.info(f"AutoSpecEngine: initialised increase_thresholds={self.increase_thresholds}, decrease_thresholds={self.decrease_thresholds}")
 
     def _trim_steps_by_memory(self, max_num_graphs: int):
         """Reduce number of unique steps if GPU memory is limited."""
@@ -234,6 +241,7 @@ class AutoSpecEngine:
                 self.steps_bs_mapping[step].append(bs)
         for step in self.steps_bs_mapping:
             self.steps_bs_mapping[step].sort()
+        logger.info(f"AutoSpecEngine: initialised steps_bs_mapping={self.steps_bs_mapping}")
 
     def _init_current_params(self):
         """Initialize current best parameters for each batch size."""
@@ -246,6 +254,7 @@ class AutoSpecEngine:
                 # Pick closest available
                 initial_steps = min(available, key=lambda s: abs(s - initial_steps))
             self.current_params[bs] = SpecParams(num_steps=initial_steps)
+        logger.info(f"AutoSpecEngine: initialised current_params={self._format_params()}")
 
         # EMA acceptance rate tracker per batch size
         self.ema_accept_rate: Dict[int, float] = {bs: 0.5 for bs in self.bs_list}
@@ -285,6 +294,7 @@ class AutoSpecEngine:
                 f"AutoSpecEngine: synced bs_steps_mapping with graph capacity: "
                 f"{self.bs_steps_mapping}"
             )
+        logger.info(f"AutoSpecEngine: synced bs_steps_mapping: {self.bs_steps_mapping}\n steps_bs_mapping: {self.steps_bs_mapping}\n current_params: {self._format_params()}")
 
     def _find_closest_bs(self, target: int) -> int:
         """Find the closest batch size in our configured list."""
@@ -321,6 +331,7 @@ class AutoSpecEngine:
 
         bs = self._find_closest_bs(batch_size)
         available_steps = self.bs_steps_mapping[bs]
+        # logger.info(f"AutoSpecEngine: batch size {bs}, available_steps: {available_steps}")
 
         # Compute acceptance rate for this step
         avg_accept_length = (num_accepted_tokens + batch_size) / batch_size
@@ -332,6 +343,7 @@ class AutoSpecEngine:
 
         current_rate = self.ema_accept_rate[bs]
         current_steps = self.current_params[bs].num_steps
+        # logger.info(f"AutoSpecEngine: batch size {bs}, accept_rate: {accept_rate}, current_rate: {current_rate}, current_steps: {current_steps}")
 
         inc_threshold = self.increase_thresholds.get(bs, 0.55)
         dec_threshold = self.decrease_thresholds.get(bs, 0.50)
@@ -339,16 +351,20 @@ class AutoSpecEngine:
         new_steps = current_steps
         if current_rate >= inc_threshold:
             # Try to increase steps
+            # logger.info(f"AutoSpecEngine: current_rate({current_rate}) >= inc_threshold({inc_threshold})")
             higher = [s for s in available_steps if s > current_steps]
             if higher:
                 new_steps = higher[0]  # smallest step larger than current
                 self.current_params[bs] = SpecParams(num_steps=new_steps)
+                # logger.info(f"AutoSpecEngine: new_steps: {new_steps}")
         elif current_rate < dec_threshold:
             # Try to decrease steps
+            # logger.info(f"AutoSpecEngine: current_rate({current_rate}) < inc_threshold({inc_threshold})")
             lower = [s for s in available_steps if s < current_steps]
             if lower:
                 new_steps = lower[-1]  # largest step smaller than current
                 self.current_params[bs] = SpecParams(num_steps=new_steps)
+                # logger.info(f"AutoSpecEngine: new_steps: {new_steps}")
 
         if new_steps != current_steps:
             logger.info(

--- a/python/sglang/srt/speculative/auto_spec_engine.py
+++ b/python/sglang/srt/speculative/auto_spec_engine.py
@@ -85,7 +85,6 @@ class AutoSpecEngine:
 
         # EMA smoothing factor for acceptance rate tracking
         self.ema_alpha = 0.3
-        # self.ema_alpha = 1.0
 
         # Load or build bs -> steps mapping
         self._init_bs_steps_mapping()
@@ -159,20 +158,23 @@ class AutoSpecEngine:
             try:
                 with open(self.speculative_config_file, "r") as f:
                     config = json.load(f)
-                if self.model_name and self.model_name in config:
+                if not isinstance(config, dict):
+                    logger.warning(
+                        "AutoSpecEngine: config file is not a JSON object, using defaults."
+                    )
+                elif self.model_name and self.model_name in config:
                     model_config = config[self.model_name]
                     self.bs_steps_mapping = {}
                     for bs_str, steps in model_config.items():
                         try:
-                            self.bs_steps_mapping[int(bs_str)] = sorted(steps)
-                            logger.info(
-                                "AutoSpecEngine: speculative config loaded from file."
-                            )
+                            bs = int(bs_str)
+                            if not isinstance(steps, list) or not steps:
+                                continue
+                            self.bs_steps_mapping[bs] = sorted(steps)
                         except ValueError:
-                            logger.info(
-                                "AutoSpecEngine: speculative config failed to load from file."
+                            logger.warning(
+                                f"AutoSpecEngine: invalid batch size key '{bs_str}' in config file."
                             )
-                            pass
                     if self.bs_steps_mapping:
                         logger.info(
                             f"AutoSpecEngine: loaded config for '{self.model_name}'"
@@ -220,7 +222,7 @@ class AutoSpecEngine:
                 if i < len(neg_threshold):
                     self.decrease_thresholds[bs] = neg_threshold[i]
         logger.info(
-            f"AutoSpecEngine: initialised increase_thresholds={self.increase_thresholds}, decrease_thresholds={self.decrease_thresholds}"
+            f"AutoSpecEngine: initialized increase_thresholds={self.increase_thresholds}, decrease_thresholds={self.decrease_thresholds}"
         )
 
     def _trim_steps_by_memory(self, max_num_graphs: int):
@@ -263,7 +265,7 @@ class AutoSpecEngine:
         for step in self.steps_bs_mapping:
             self.steps_bs_mapping[step].sort()
         logger.info(
-            f"AutoSpecEngine: initialised steps_bs_mapping={self.steps_bs_mapping}"
+            f"AutoSpecEngine: initialized steps_bs_mapping={self.steps_bs_mapping}"
         )
 
     def _init_current_params(self):
@@ -278,7 +280,7 @@ class AutoSpecEngine:
                 initial_steps = min(available, key=lambda s: abs(s - initial_steps))
             self.current_params[bs] = SpecParams(num_steps=initial_steps)
         logger.info(
-            f"AutoSpecEngine: initialised current_params={self._format_params()}"
+            f"AutoSpecEngine: initialized current_params={self._format_params()}"
         )
 
         # EMA acceptance rate tracker per batch size
@@ -358,7 +360,6 @@ class AutoSpecEngine:
 
         bs = self._find_closest_bs(batch_size)
         available_steps = self.bs_steps_mapping[bs]
-        # logger.info(f"AutoSpecEngine: batch size {bs}, available_steps: {available_steps}")
 
         # Compute acceptance rate for this step
         avg_accept_length = (num_accepted_tokens + batch_size) / batch_size
@@ -376,7 +377,6 @@ class AutoSpecEngine:
 
         current_rate = self.ema_accept_rate[bs]
         current_steps = self.current_params[bs].num_steps
-        # logger.info(f"AutoSpecEngine: batch size {bs}, accept_rate: {accept_rate}, current_rate: {current_rate}, current_steps: {current_steps}")
 
         inc_threshold = self.increase_thresholds.get(bs, 0.55)
         dec_threshold = self.decrease_thresholds.get(bs, 0.50)
@@ -384,20 +384,16 @@ class AutoSpecEngine:
         new_steps = current_steps
         if current_rate >= inc_threshold:
             # Try to increase steps
-            # logger.info(f"AutoSpecEngine: current_rate({current_rate}) >= inc_threshold({inc_threshold})")
             higher = [s for s in available_steps if s > current_steps]
             if higher:
                 new_steps = higher[0]  # smallest step larger than current
                 self.current_params[bs] = SpecParams(num_steps=new_steps)
-                # logger.info(f"AutoSpecEngine: new_steps: {new_steps}")
         elif current_rate < dec_threshold:
             # Try to decrease steps
-            # logger.info(f"AutoSpecEngine: current_rate({current_rate}) < inc_threshold({inc_threshold})")
             lower = [s for s in available_steps if s < current_steps]
             if lower:
                 new_steps = lower[-1]  # largest step smaller than current
                 self.current_params[bs] = SpecParams(num_steps=new_steps)
-                # logger.info(f"AutoSpecEngine: new_steps: {new_steps}")
 
         if new_steps != current_steps:
             logger.info(

--- a/python/sglang/srt/speculative/auto_spec_engine.py
+++ b/python/sglang/srt/speculative/auto_spec_engine.py
@@ -102,6 +102,8 @@ class AutoSpecEngine:
         # Will be finalized in initialize() after GPU memory is known
         self._initialized = False
 
+        self.enable_watch = True
+
     def initialize(self, gpu_id: int, is_spec_v2: bool = False):
         """Must be called after model loading to finalize based on available GPU memory.
 
@@ -140,6 +142,10 @@ class AutoSpecEngine:
             f"bs_steps_mapping={self.bs_steps_mapping}, "
             f"initial params={self._format_params()}"
         )
+
+        if all(len(value) == 1 for value in self.bs_steps_mapping.values()):
+            self.enable_watch = False
+            logger.info(f"AutoSpecEngine: disable metrics watch for {self.bs_steps_mapping}")
 
     def _init_bs_steps_mapping(self):
         """Load batch-size to step mappings from config file or defaults."""

--- a/python/sglang/srt/speculative/auto_spec_engine.py
+++ b/python/sglang/srt/speculative/auto_spec_engine.py
@@ -8,12 +8,9 @@ acceptance rates and increases/decreases the speculation depth accordingly.
 import bisect
 import json
 import logging
-import math
 import os
-from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
-
-import torch
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Dict, List, Tuple
 
 if TYPE_CHECKING:
     from sglang.srt.server_args import ServerArgs
@@ -114,7 +111,9 @@ class AutoSpecEngine:
         """
         from sglang.srt.utils.common import get_available_gpu_memory
 
-        available_memory = get_available_gpu_memory(self.device_id, gpu_id, empty_cache=False)
+        available_memory = get_available_gpu_memory(
+            self.device_id, gpu_id, empty_cache=False
+        )
         # SpecV2 captures both draft + verify graphs per step (~3.5GB each),
         # while V1 only captures draft graphs (~2GB each).
         # Reserve safety margin for inference runtime allocations (MoE, etc).
@@ -145,14 +144,18 @@ class AutoSpecEngine:
 
         if all(len(value) == 1 for value in self.bs_steps_mapping.values()):
             self.enable_watch = False
-            logger.info(f"AutoSpecEngine: disable metrics watch for {self.bs_steps_mapping}")
+            logger.info(
+                f"AutoSpecEngine: disable metrics watch for {self.bs_steps_mapping}"
+            )
 
     def _init_bs_steps_mapping(self):
         """Load batch-size to step mappings from config file or defaults."""
         if self.speculative_config_file and os.path.exists(
             self.speculative_config_file
         ):
-            logger.info(f"AutoSpecEngine: loading speculative config from {self.speculative_config_file}")
+            logger.info(
+                f"AutoSpecEngine: loading speculative config from {self.speculative_config_file}"
+            )
             try:
                 with open(self.speculative_config_file, "r") as f:
                     config = json.load(f)
@@ -162,9 +165,13 @@ class AutoSpecEngine:
                     for bs_str, steps in model_config.items():
                         try:
                             self.bs_steps_mapping[int(bs_str)] = sorted(steps)
-                            logger.info("AutoSpecEngine: speculative config loaded from file.")
+                            logger.info(
+                                "AutoSpecEngine: speculative config loaded from file."
+                            )
                         except ValueError:
-                            logger.info("AutoSpecEngine: speculative config failed to load from file.")
+                            logger.info(
+                                "AutoSpecEngine: speculative config failed to load from file."
+                            )
                             pass
                     if self.bs_steps_mapping:
                         logger.info(
@@ -176,9 +183,13 @@ class AutoSpecEngine:
                     f"AutoSpecEngine: failed to load config: {e}, using defaults"
                 )
         else:
-            logger.info(f"AutoSpecEngine: speculative config not found in {self.speculative_config_file}")
+            logger.info(
+                f"AutoSpecEngine: speculative config not found in {self.speculative_config_file}"
+            )
 
-        self.bs_steps_mapping = {k: list(v) for k, v in DEFAULT_BS_STEPS_MAPPING.items()}
+        self.bs_steps_mapping = {
+            k: list(v) for k, v in DEFAULT_BS_STEPS_MAPPING.items()
+        }
 
     def _init_thresholds(self, server_args: "ServerArgs"):
         """Initialize acceptance rate thresholds per batch size."""
@@ -208,11 +219,15 @@ class AutoSpecEngine:
             for i, bs in enumerate(sorted(self.bs_steps_mapping.keys())):
                 if i < len(neg_threshold):
                     self.decrease_thresholds[bs] = neg_threshold[i]
-        logger.info(f"AutoSpecEngine: initialised increase_thresholds={self.increase_thresholds}, decrease_thresholds={self.decrease_thresholds}")
+        logger.info(
+            f"AutoSpecEngine: initialised increase_thresholds={self.increase_thresholds}, decrease_thresholds={self.decrease_thresholds}"
+        )
 
     def _trim_steps_by_memory(self, max_num_graphs: int):
         """Reduce number of unique steps if GPU memory is limited."""
-        all_steps = sorted(set(s for steps in self.bs_steps_mapping.values() for s in steps))
+        all_steps = sorted(
+            set(s for steps in self.bs_steps_mapping.values() for s in steps)
+        )
 
         if len(all_steps) <= max_num_graphs:
             self.step_range = all_steps
@@ -220,7 +235,7 @@ class AutoSpecEngine:
 
         # Prioritize keeping smaller steps (more frequently used) + largest step
         if max_num_graphs >= 2:
-            kept = all_steps[:max_num_graphs - 1] + [all_steps[-1]]
+            kept = all_steps[: max_num_graphs - 1] + [all_steps[-1]]
         else:
             kept = [all_steps[len(all_steps) // 2]]
         self.step_range = sorted(set(kept))
@@ -247,7 +262,9 @@ class AutoSpecEngine:
                 self.steps_bs_mapping[step].append(bs)
         for step in self.steps_bs_mapping:
             self.steps_bs_mapping[step].sort()
-        logger.info(f"AutoSpecEngine: initialised steps_bs_mapping={self.steps_bs_mapping}")
+        logger.info(
+            f"AutoSpecEngine: initialised steps_bs_mapping={self.steps_bs_mapping}"
+        )
 
     def _init_current_params(self):
         """Initialize current best parameters for each batch size."""
@@ -260,7 +277,9 @@ class AutoSpecEngine:
                 # Pick closest available
                 initial_steps = min(available, key=lambda s: abs(s - initial_steps))
             self.current_params[bs] = SpecParams(num_steps=initial_steps)
-        logger.info(f"AutoSpecEngine: initialised current_params={self._format_params()}")
+        logger.info(
+            f"AutoSpecEngine: initialised current_params={self._format_params()}"
+        )
 
         # EMA acceptance rate tracker per batch size
         self.ema_accept_rate: Dict[int, float] = {bs: 0.5 for bs in self.bs_list}
@@ -300,7 +319,9 @@ class AutoSpecEngine:
                 f"AutoSpecEngine: synced bs_steps_mapping with graph capacity: "
                 f"{self.bs_steps_mapping}"
             )
-        logger.info(f"AutoSpecEngine: synced bs_steps_mapping: {self.bs_steps_mapping}\n steps_bs_mapping: {self.steps_bs_mapping}\n current_params: {self._format_params()}")
+        logger.info(
+            f"AutoSpecEngine: synced bs_steps_mapping: {self.bs_steps_mapping}\n steps_bs_mapping: {self.steps_bs_mapping}\n current_params: {self._format_params()}"
+        )
 
     def _find_closest_bs(self, target: int) -> int:
         """Find the closest batch size in our configured list."""
@@ -341,11 +362,17 @@ class AutoSpecEngine:
 
         # Compute acceptance rate for this step
         avg_accept_length = (num_accepted_tokens + batch_size) / batch_size
-        accept_rate = avg_accept_length / num_draft_tokens_per_req if num_draft_tokens_per_req > 0 else 0.0
+        accept_rate = (
+            avg_accept_length / num_draft_tokens_per_req
+            if num_draft_tokens_per_req > 0
+            else 0.0
+        )
 
         # Update EMA
         old_ema = self.ema_accept_rate[bs]
-        self.ema_accept_rate[bs] = self.ema_alpha * accept_rate + (1 - self.ema_alpha) * old_ema
+        self.ema_accept_rate[bs] = (
+            self.ema_alpha * accept_rate + (1 - self.ema_alpha) * old_ema
+        )
 
         current_rate = self.ema_accept_rate[bs]
         current_steps = self.current_params[bs].num_steps

--- a/python/sglang/srt/speculative/auto_spec_engine.py
+++ b/python/sglang/srt/speculative/auto_spec_engine.py
@@ -1,0 +1,306 @@
+"""Auto-speculative decoding engine.
+
+Dynamically adjusts speculative decoding parameters (num_steps, num_draft_tokens)
+based on runtime acceptance rate feedback. The engine monitors per-batch-size
+acceptance rates and increases/decreases the speculation depth accordingly.
+"""
+
+import bisect
+import json
+import logging
+import math
+import os
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+
+import torch
+
+if TYPE_CHECKING:
+    from sglang.srt.server_args import ServerArgs
+
+logger = logging.getLogger(__name__)
+
+# Default batch size to step mappings
+DEFAULT_BS_STEPS_MAPPING: Dict[int, List[int]] = {
+    1: [3, 4, 5, 6],
+    2: [3, 4, 5, 6],
+    4: [3, 4, 5, 6],
+    8: [2, 3, 4],
+    16: [2, 3, 4],
+    32: [2, 3, 4],
+    64: [1, 2, 3, 4],
+    128: [1, 2, 3, 4],
+}
+
+# Default initial num_steps for each batch size
+DEFAULT_INITIAL_STEPS: Dict[int, int] = {
+    1: 5,
+    2: 5,
+    4: 5,
+    8: 4,
+    16: 3,
+    32: 3,
+    64: 3,
+    128: 1,
+}
+
+# Default acceptance rate thresholds (increase_threshold, decrease_threshold)
+DEFAULT_THRESHOLDS: Dict[int, Tuple[float, float]] = {
+    1: (0.55, 0.50),
+    2: (0.55, 0.50),
+    4: (0.60, 0.50),
+    8: (0.80, 0.50),
+    16: (0.95, 0.60),
+    32: (0.91, 0.66),
+    64: (0.95, 0.65),
+    128: (0.95, 0.65),
+}
+
+
+@dataclass
+class SpecParams:
+    """Speculative decoding parameters for a given configuration."""
+
+    num_steps: int
+    topk: int = 1
+    num_draft_tokens: int = -1  # auto-computed from num_steps + 1
+
+    def __post_init__(self):
+        if self.num_draft_tokens < 0:
+            self.num_draft_tokens = self.num_steps + 1
+
+
+class AutoSpecEngine:
+    """Engine for dynamically adjusting speculative decoding parameters.
+
+    Monitors acceptance rates per batch size and adjusts num_steps up or down
+    based on configurable thresholds. Uses EMA (exponential moving average)
+    for smooth acceptance rate tracking.
+    """
+
+    def __init__(self, server_args: "ServerArgs"):
+        self.cuda_graph_bs = server_args.cuda_graph_bs
+        self.device_id = server_args.device
+        self.model_name = server_args.served_model_name or server_args.model_path
+        self.speculative_config_file = getattr(
+            server_args, "speculative_config_file", None
+        )
+
+        # EMA smoothing factor for acceptance rate tracking
+        self.ema_alpha = 0.3
+
+        # Load or build bs -> steps mapping
+        self._init_bs_steps_mapping()
+
+        # Build sorted batch size list and closest-bs lookup
+        self.bs_list = sorted(self.bs_steps_mapping.keys())
+
+        # Build thresholds per batch size
+        self._init_thresholds(server_args)
+
+        # Will be finalized in initialize() after GPU memory is known
+        self._initialized = False
+
+    def initialize(self, gpu_id: int):
+        """Must be called after model loading to finalize based on available GPU memory."""
+        from sglang.srt.utils.common import get_available_gpu_memory
+
+        available_memory = get_available_gpu_memory(self.device_id, gpu_id, empty_cache=False)
+        # Reserve 4GB safety margin, ~2GB per step for CUDA graphs
+        max_num_graphs = int((available_memory - 4) // 2)
+        max_num_graphs = max(max_num_graphs, 1)
+        logger.info(
+            f"AutoSpecEngine: available_memory={available_memory:.1f}GB, "
+            f"max graph sets={max_num_graphs}"
+        )
+
+        self._trim_steps_by_memory(max_num_graphs)
+        self._build_reverse_mapping()
+        self._init_current_params()
+        self._initialized = True
+
+        logger.info(
+            f"AutoSpecEngine initialized: step_range={self.step_range}, "
+            f"bs_steps_mapping={self.bs_steps_mapping}, "
+            f"initial params={self._format_params()}"
+        )
+
+    def _init_bs_steps_mapping(self):
+        """Load batch-size to step mappings from config file or defaults."""
+        if self.speculative_config_file and os.path.exists(
+            self.speculative_config_file
+        ):
+            try:
+                with open(self.speculative_config_file, "r") as f:
+                    config = json.load(f)
+                if self.model_name and self.model_name in config:
+                    model_config = config[self.model_name]
+                    self.bs_steps_mapping = {}
+                    for bs_str, steps in model_config.items():
+                        try:
+                            self.bs_steps_mapping[int(bs_str)] = sorted(steps)
+                        except ValueError:
+                            pass
+                    if self.bs_steps_mapping:
+                        logger.info(
+                            f"AutoSpecEngine: loaded config for '{self.model_name}'"
+                        )
+                        return
+            except (json.JSONDecodeError, IOError) as e:
+                logger.warning(
+                    f"AutoSpecEngine: failed to load config: {e}, using defaults"
+                )
+
+        self.bs_steps_mapping = {k: list(v) for k, v in DEFAULT_BS_STEPS_MAPPING.items()}
+
+    def _init_thresholds(self, server_args: "ServerArgs"):
+        """Initialize acceptance rate thresholds per batch size."""
+        pos_threshold = getattr(server_args, "pos_threshold", None)
+        neg_threshold = getattr(server_args, "neg_threshold", None)
+
+        self.increase_thresholds: Dict[int, float] = {}
+        self.decrease_thresholds: Dict[int, float] = {}
+
+        sorted_default_bs = sorted(DEFAULT_THRESHOLDS.keys())
+
+        for bs in self.bs_steps_mapping.keys():
+            # Find closest default threshold
+            idx = bisect.bisect_right(sorted_default_bs, bs) - 1
+            idx = max(0, min(idx, len(sorted_default_bs) - 1))
+            closest_bs = sorted_default_bs[idx]
+            inc_t, dec_t = DEFAULT_THRESHOLDS[closest_bs]
+            self.increase_thresholds[bs] = inc_t
+            self.decrease_thresholds[bs] = dec_t
+
+        # Override with user-specified thresholds if provided
+        if pos_threshold is not None and len(pos_threshold) > 0:
+            for i, bs in enumerate(sorted(self.bs_steps_mapping.keys())):
+                if i < len(pos_threshold):
+                    self.increase_thresholds[bs] = pos_threshold[i]
+        if neg_threshold is not None and len(neg_threshold) > 0:
+            for i, bs in enumerate(sorted(self.bs_steps_mapping.keys())):
+                if i < len(neg_threshold):
+                    self.decrease_thresholds[bs] = neg_threshold[i]
+
+    def _trim_steps_by_memory(self, max_num_graphs: int):
+        """Reduce number of unique steps if GPU memory is limited."""
+        all_steps = sorted(set(s for steps in self.bs_steps_mapping.values() for s in steps))
+
+        if len(all_steps) <= max_num_graphs:
+            self.step_range = all_steps
+            return
+
+        # Prioritize keeping smaller steps (more frequently used) + largest step
+        if max_num_graphs >= 2:
+            kept = all_steps[:max_num_graphs - 1] + [all_steps[-1]]
+        else:
+            kept = [all_steps[len(all_steps) // 2]]
+        self.step_range = sorted(set(kept))
+
+        # Update bs_steps_mapping to only include available steps
+        for bs in list(self.bs_steps_mapping.keys()):
+            available = [s for s in self.bs_steps_mapping[bs] if s in self.step_range]
+            if not available:
+                available = list(self.step_range)
+            self.bs_steps_mapping[bs] = available
+
+        logger.info(
+            f"AutoSpecEngine: trimmed to step_range={self.step_range} "
+            f"due to memory constraint (max_graphs={max_num_graphs})"
+        )
+
+    def _build_reverse_mapping(self):
+        """Build step -> batch_sizes reverse mapping."""
+        self.steps_bs_mapping: Dict[int, List[int]] = {}
+        for bs, steps in self.bs_steps_mapping.items():
+            for step in steps:
+                if step not in self.steps_bs_mapping:
+                    self.steps_bs_mapping[step] = []
+                self.steps_bs_mapping[step].append(bs)
+        for step in self.steps_bs_mapping:
+            self.steps_bs_mapping[step].sort()
+
+    def _init_current_params(self):
+        """Initialize current best parameters for each batch size."""
+        self.current_params: Dict[int, SpecParams] = {}
+        for bs in self.bs_list:
+            initial_steps = DEFAULT_INITIAL_STEPS.get(bs, 3)
+            # Clamp to available steps
+            available = self.bs_steps_mapping[bs]
+            if initial_steps not in available:
+                # Pick closest available
+                initial_steps = min(available, key=lambda s: abs(s - initial_steps))
+            self.current_params[bs] = SpecParams(num_steps=initial_steps)
+
+        # EMA acceptance rate tracker per batch size
+        self.ema_accept_rate: Dict[int, float] = {bs: 0.5 for bs in self.bs_list}
+
+    def _find_closest_bs(self, target: int) -> int:
+        """Find the closest batch size in our configured list."""
+        if target <= 0:
+            return self.bs_list[0]
+        idx = bisect.bisect_left(self.bs_list, target)
+        if idx == 0:
+            return self.bs_list[0]
+        if idx == len(self.bs_list):
+            return self.bs_list[-1]
+        left, right = self.bs_list[idx - 1], self.bs_list[idx]
+        return left if (target - left) <= (right - target) else right
+
+    def get_spec_params(self, batch_size: int) -> SpecParams:
+        """Get the current best speculative parameters for a given batch size."""
+        bs = self._find_closest_bs(batch_size)
+        return self.current_params[bs]
+
+    def update(
+        self,
+        batch_size: int,
+        num_accepted_tokens: int,
+        num_draft_tokens_per_req: int,
+    ):
+        """Update the tuner with acceptance feedback from one decode step.
+
+        Args:
+            batch_size: Number of requests in the batch.
+            num_accepted_tokens: Total number of accepted tokens across all requests.
+            num_draft_tokens_per_req: Number of draft tokens per request.
+        """
+        if batch_size <= 0:
+            return
+
+        bs = self._find_closest_bs(batch_size)
+        available_steps = self.bs_steps_mapping[bs]
+
+        # Compute acceptance rate for this step
+        avg_accept_length = (num_accepted_tokens + batch_size) / batch_size
+        accept_rate = avg_accept_length / num_draft_tokens_per_req if num_draft_tokens_per_req > 0 else 0.0
+
+        # Update EMA
+        old_ema = self.ema_accept_rate[bs]
+        self.ema_accept_rate[bs] = self.ema_alpha * accept_rate + (1 - self.ema_alpha) * old_ema
+
+        current_rate = self.ema_accept_rate[bs]
+        current_steps = self.current_params[bs].num_steps
+
+        inc_threshold = self.increase_thresholds.get(bs, 0.55)
+        dec_threshold = self.decrease_thresholds.get(bs, 0.50)
+
+        if current_rate >= inc_threshold:
+            # Try to increase steps
+            higher = [s for s in available_steps if s > current_steps]
+            if higher:
+                new_steps = higher[0]  # smallest step larger than current
+                self.current_params[bs] = SpecParams(num_steps=new_steps)
+        elif current_rate < dec_threshold:
+            # Try to decrease steps
+            lower = [s for s in available_steps if s < current_steps]
+            if lower:
+                new_steps = lower[-1]  # largest step smaller than current
+                self.current_params[bs] = SpecParams(num_steps=new_steps)
+
+    def _format_params(self) -> str:
+        parts = []
+        for bs in sorted(self.current_params.keys()):
+            p = self.current_params[bs]
+            parts.append(f"bs{bs}:steps={p.num_steps}")
+        return ", ".join(parts)

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import bisect
+import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Callable, List, Optional
 
 import torch
 
@@ -12,6 +13,7 @@ from sglang.srt.model_executor.cuda_graph_runner import (
     CudaGraphRunner,
     DeepEPCudaGraphRunnerAdapter,
     get_batch_sizes_to_capture,
+    get_batch_sizes_to_capture_for_steps,
     get_global_graph_memory_pool,
     model_capture_mode,
     set_global_graph_memory_pool,
@@ -34,6 +36,8 @@ from sglang.srt.utils import (
 
 if TYPE_CHECKING:
     from sglang.srt.speculative.eagle_worker import EAGLEWorker
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -430,3 +434,124 @@ class EAGLEDraftCudaGraphRunner:
                 forward_batch.seq_lens_cpu = buffers.seq_lens_cpu[:raw_bs]
 
         return out
+
+
+class EAGLEDraftCudaGraphRunnerAuto(EAGLEDraftCudaGraphRunner):
+    """CUDA graph runner for auto-spec that captures graphs for a specific num_steps.
+
+    Overrides __init__ to accept speculative_num_steps and use step-specific
+    batch sizes and attention backends.
+    """
+
+    def __init__(
+        self,
+        eagle_worker: "EAGLEWorker",
+        speculative_num_steps: int,
+        batch_sizes: Optional[List[int]] = None,
+        draft_attn_backend=None,
+    ):
+        # Parse args
+        self.eagle_worker = eagle_worker
+        if not hasattr(eagle_worker, "model_runner"):
+            self.model_runner = model_runner = eagle_worker.draft_runner
+        else:
+            self.model_runner = model_runner = eagle_worker.model_runner
+        self.graphs = {}
+        self.output_buffers = {}
+        self.enable_torch_compile = model_runner.server_args.enable_torch_compile
+        self.disable_padding = model_runner.server_args.disable_cuda_graph_padding
+        self.require_gathered_buffer = require_gathered_buffer(model_runner.server_args)
+        self.require_mlp_tp_gather = require_mlp_tp_gather(model_runner.server_args)
+        self.require_mlp_sync = require_mlp_sync(model_runner.server_args)
+        self.require_attn_tp_gather = require_attn_tp_gather(model_runner.server_args)
+        self.tp_size = self.model_runner.tp_size
+        self.dp_size = self.model_runner.dp_size
+        self.speculative_num_steps = speculative_num_steps
+        self.topk = 1
+        self.enable_profile_cuda_graph = (
+            model_runner.server_args.enable_profile_cuda_graph
+        )
+        self.enable_pdmux = False
+        self.deepep_adapter = DeepEPCudaGraphRunnerAdapter()
+
+        # Batch sizes to capture
+        self.capture_bs, self.compile_bs = get_batch_sizes_to_capture_for_steps(
+            model_runner, batch_sizes
+        )
+
+        # Attention backend
+        self.num_tokens_per_bs = self.topk
+        self.max_bs = max(self.capture_bs)
+        self.max_num_token = self.max_bs * self.num_tokens_per_bs
+
+        # Use the provided draft_attn_backend or fall back to the model_runner's
+        attn_backend = draft_attn_backend or self.model_runner.draft_attn_backend
+        attn_backend.init_cuda_graph_state(self.max_bs, self.max_num_token)
+        self.seq_len_fill_value = attn_backend.attn_backends[
+            0
+        ].get_cuda_graph_seq_len_fill_value()
+        self.seq_lens_cpu = torch.full(
+            (self.max_bs,), self.seq_len_fill_value, dtype=torch.int32
+        )
+        self.extend_seq_lens_cpu = [self.seq_len_fill_value] * self.max_bs
+
+        if self.enable_torch_compile:
+            set_torch_compile_config()
+
+        # Graph inputs
+        self._init_graph_inputs(model_runner)
+
+        # Capture
+        try:
+            with model_capture_mode():
+                self.capture()
+        except RuntimeError as e:
+            raise Exception(
+                f"Capture cuda graph failed: {e}\n{CUDA_GRAPH_CAPTURE_FAILED_MSG}"
+            )
+
+        logger.info(
+            f"EAGLEDraftCudaGraphRunnerAuto: captured graphs for "
+            f"num_steps={self.speculative_num_steps}, "
+            f"capture_bs={self.capture_bs}"
+        )
+
+    def _init_graph_inputs(self, model_runner):
+        """Initialize graph input tensors."""
+        with torch.device(model_runner.device):
+            self.input_ids = torch.zeros((self.max_num_token,), dtype=torch.int64)
+            self.req_pool_indices = torch.zeros((self.max_bs,), dtype=torch.int32)
+            self.out_cache_loc = torch.zeros(
+                (self.max_num_token * self.speculative_num_steps,), dtype=torch.int64
+            )
+            self.positions = torch.zeros((self.max_num_token,), dtype=torch.int64)
+            self.mrope_positions = torch.zeros(
+                (3, self.max_num_token), dtype=torch.int64
+            )
+            self.seq_lens = torch.full(
+                (self.max_bs,), self.seq_len_fill_value, dtype=torch.int32
+            )
+            self.extend_seq_lens = torch.ones((self.max_bs,), dtype=torch.int32)
+            self.topk_p = torch.zeros((self.max_bs, self.topk), dtype=torch.float32)
+            self.topk_index = torch.zeros((self.max_bs, self.topk), dtype=torch.int64)
+            self.hidden_states = torch.zeros(
+                (self.max_bs, self.model_runner.model_config.hidden_size),
+                dtype=self.model_runner.dtype,
+            )
+            if self.require_gathered_buffer:
+                if self.require_mlp_tp_gather:
+                    self.global_num_tokens_gpu = torch.zeros(
+                        (self.dp_size,), dtype=torch.int32
+                    )
+                    self.global_num_tokens_for_logprob_gpu = torch.zeros(
+                        (self.dp_size,), dtype=torch.int32
+                    )
+                else:
+                    assert self.require_attn_tp_gather
+                    self.global_num_tokens_gpu = torch.zeros((1,), dtype=torch.int32)
+                    self.global_num_tokens_for_logprob_gpu = torch.zeros(
+                        (1,), dtype=torch.int32
+                    )
+            else:
+                self.global_num_tokens_gpu = None
+                self.global_num_tokens_for_logprob_gpu = None

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -526,9 +526,7 @@ class EAGLEDraftCudaGraphRunnerAuto(EAGLEDraftCudaGraphRunner):
                 dtype=self._cache_loc_dtype(),
             )
             positions = torch.zeros((self.max_num_token,), dtype=torch.int64)
-            mrope_positions = torch.zeros(
-                (3, self.max_num_token), dtype=torch.int64
-            )
+            mrope_positions = torch.zeros((3, self.max_num_token), dtype=torch.int64)
             seq_lens = torch.full(
                 (self.max_bs,), self.seq_len_fill_value, dtype=torch.int32
             )

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -517,41 +517,59 @@ class EAGLEDraftCudaGraphRunnerAuto(EAGLEDraftCudaGraphRunner):
         )
 
     def _init_graph_inputs(self, model_runner):
-        """Initialize graph input tensors."""
+        """Initialize graph input tensors and create the buffers dataclass."""
         with torch.device(model_runner.device):
-            self.input_ids = torch.zeros((self.max_num_token,), dtype=torch.int64)
-            self.req_pool_indices = torch.zeros((self.max_bs,), dtype=torch.int32)
-            self.out_cache_loc = torch.zeros(
-                (self.max_num_token * self.speculative_num_steps,), dtype=torch.int64
+            input_ids = torch.zeros((self.max_num_token,), dtype=torch.int64)
+            req_pool_indices = torch.zeros((self.max_bs,), dtype=torch.int64)
+            out_cache_loc = torch.zeros(
+                (self.max_num_token * self.speculative_num_steps,),
+                dtype=self._cache_loc_dtype(),
             )
-            self.positions = torch.zeros((self.max_num_token,), dtype=torch.int64)
-            self.mrope_positions = torch.zeros(
+            positions = torch.zeros((self.max_num_token,), dtype=torch.int64)
+            mrope_positions = torch.zeros(
                 (3, self.max_num_token), dtype=torch.int64
             )
-            self.seq_lens = torch.full(
+            seq_lens = torch.full(
                 (self.max_bs,), self.seq_len_fill_value, dtype=torch.int32
             )
-            self.extend_seq_lens = torch.ones((self.max_bs,), dtype=torch.int32)
-            self.topk_p = torch.zeros((self.max_bs, self.topk), dtype=torch.float32)
-            self.topk_index = torch.zeros((self.max_bs, self.topk), dtype=torch.int64)
-            self.hidden_states = torch.zeros(
+            extend_seq_lens = torch.ones((self.max_bs,), dtype=torch.int32)
+            topk_p = torch.zeros((self.max_bs, self.topk), dtype=torch.float32)
+            topk_index = torch.zeros((self.max_bs, self.topk), dtype=torch.int64)
+            hidden_states = torch.zeros(
                 (self.max_bs, self.model_runner.model_config.hidden_size),
                 dtype=self.model_runner.dtype,
             )
             if self.require_gathered_buffer:
                 if self.require_mlp_tp_gather:
-                    self.global_num_tokens_gpu = torch.zeros(
+                    global_num_tokens_gpu = torch.zeros(
                         (self.dp_size,), dtype=torch.int32
                     )
-                    self.global_num_tokens_for_logprob_gpu = torch.zeros(
+                    global_num_tokens_for_logprob_gpu = torch.zeros(
                         (self.dp_size,), dtype=torch.int32
                     )
                 else:
                     assert self.require_attn_tp_gather
-                    self.global_num_tokens_gpu = torch.zeros((1,), dtype=torch.int32)
-                    self.global_num_tokens_for_logprob_gpu = torch.zeros(
+                    global_num_tokens_gpu = torch.zeros((1,), dtype=torch.int32)
+                    global_num_tokens_for_logprob_gpu = torch.zeros(
                         (1,), dtype=torch.int32
                     )
             else:
-                self.global_num_tokens_gpu = None
-                self.global_num_tokens_for_logprob_gpu = None
+                global_num_tokens_gpu = None
+                global_num_tokens_for_logprob_gpu = None
+
+        self.buffers = EagleDraftInputBuffers(
+            input_ids=input_ids,
+            req_pool_indices=req_pool_indices,
+            out_cache_loc=out_cache_loc,
+            positions=positions,
+            mrope_positions=mrope_positions,
+            seq_lens=seq_lens,
+            seq_lens_cpu=self.seq_lens_cpu,
+            extend_seq_lens=extend_seq_lens,
+            topk_p=topk_p,
+            topk_index=topk_index,
+            hidden_states=hidden_states,
+            global_num_tokens_gpu=global_num_tokens_gpu,
+            global_num_tokens_for_logprob_gpu=global_num_tokens_for_logprob_gpu,
+        )
+        self.buffers.share_buffers()

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import bisect
+import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Callable, List, Optional
 
 import torch
 
@@ -13,6 +14,7 @@ from sglang.srt.model_executor.cuda_graph_runner import (
     DeepEPCudaGraphRunnerAdapter,
     LogitsProcessorOutput,
     get_batch_sizes_to_capture,
+    get_batch_sizes_to_capture_for_steps,
     get_global_graph_memory_pool,
     model_capture_mode,
     set_global_graph_memory_pool,
@@ -36,6 +38,8 @@ from sglang.srt.utils import (
 
 if TYPE_CHECKING:
     from sglang.srt.speculative.eagle_worker import EAGLEWorker
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -529,3 +533,161 @@ class EAGLEDraftExtendCudaGraphRunner:
             out.topk_p = out_copy.topk_p[:unpadding_bs]
             out.topk_index = out_copy.topk_index[:unpadding_bs]
         return out
+
+
+class EAGLEDraftExtendCudaGraphRunnerAuto(EAGLEDraftExtendCudaGraphRunner):
+    """Draft extend CUDA graph runner for auto-spec with specific num_steps."""
+
+    def __init__(
+        self,
+        eagle_worker: "EAGLEWorker",
+        speculative_num_steps: int,
+        batch_sizes: Optional[List[int]] = None,
+    ):
+        # Parse args
+        self.eagle_worker = eagle_worker
+        if not hasattr(eagle_worker, "model_runner"):
+            self.model_runner = model_runner = eagle_worker.draft_runner
+            self.forward_mode = ForwardMode.DRAFT_EXTEND_V2
+        else:
+            self.model_runner = model_runner = eagle_worker.model_runner
+            self.forward_mode = ForwardMode.DRAFT_EXTEND
+
+        self.graphs = {}
+        self.output_buffers = {}
+        self.enable_torch_compile = model_runner.server_args.enable_torch_compile
+        self.disable_padding = model_runner.server_args.disable_cuda_graph_padding
+        self.require_gathered_buffer = require_gathered_buffer(model_runner.server_args)
+        self.require_mlp_tp_gather = require_mlp_tp_gather(model_runner.server_args)
+        self.require_mlp_sync = require_mlp_sync(model_runner.server_args)
+        self.require_attn_tp_gather = require_attn_tp_gather(model_runner.server_args)
+        self.tp_size = self.model_runner.tp_size
+        self.dp_size = self.model_runner.dp_size
+        self.speculative_num_steps = speculative_num_steps
+        self.topk = 1
+        self.enable_profile_cuda_graph = (
+            model_runner.server_args.enable_profile_cuda_graph
+        )
+        self.enable_pdmux = False
+        self.deepep_adapter = DeepEPCudaGraphRunnerAdapter()
+
+        self.capture_bs, self.compile_bs = get_batch_sizes_to_capture_for_steps(
+            model_runner, batch_sizes
+        )
+        self.padded_static_len = -1
+
+        # Attention backend
+        self.num_tokens_per_bs = self.speculative_num_steps + 1
+        self.max_bs = max(self.capture_bs)
+        self.max_num_token = self.max_bs * self.num_tokens_per_bs
+
+        self.eagle_worker.draft_extend_attn_backend.init_cuda_graph_state(
+            self.max_bs, self.max_num_token
+        )
+        self.seq_len_fill_value = (
+            self.eagle_worker.draft_extend_attn_backend.get_cuda_graph_seq_len_fill_value()
+        )
+        self.seq_lens_cpu = torch.full(
+            (self.max_bs,), self.seq_len_fill_value, dtype=torch.int32
+        )
+        self.extend_seq_lens_cpu = [self.num_tokens_per_bs] * self.max_bs
+
+        if self.enable_torch_compile:
+            set_torch_compile_config()
+
+        # Graph inputs
+        self._init_graph_inputs(model_runner)
+
+        # Capture
+        try:
+            with model_capture_mode():
+                self.capture()
+        except RuntimeError as e:
+            raise Exception(
+                f"Capture cuda graph failed: {e}\n{CUDA_GRAPH_CAPTURE_FAILED_MSG}"
+            )
+
+        logger.info(
+            f"EAGLEDraftExtendCudaGraphRunnerAuto: captured graphs for "
+            f"num_steps={self.speculative_num_steps}, "
+            f"capture_bs={self.capture_bs}"
+        )
+
+    def _init_graph_inputs(self, model_runner):
+        """Initialize graph input tensors."""
+        with torch.device(model_runner.device):
+            self.input_ids = torch.zeros((self.max_num_token,), dtype=torch.int64)
+            self.req_pool_indices = torch.zeros((self.max_bs,), dtype=torch.int32)
+            self.out_cache_loc = torch.ones((self.max_num_token,), dtype=torch.int64)
+            self.positions = torch.zeros((self.max_num_token,), dtype=torch.int64)
+            self.mrope_positions = torch.zeros(
+                (3, self.max_num_token), dtype=torch.int64
+            )
+
+            if self.eagle_worker.speculative_algorithm.is_eagle3():
+                hidden_dim = (
+                    self.model_runner.model_config.hf_config.target_hidden_size * 3
+                    if hasattr(
+                        self.model_runner.model_config.hf_config,
+                        "target_hidden_size",
+                    )
+                    else self.model_runner.model_config.hidden_size * 3
+                )
+            else:
+                hidden_dim = self.model_runner.model_config.hidden_size
+
+            self.hidden_states = torch.zeros(
+                (self.max_num_token, hidden_dim),
+                dtype=self.model_runner.dtype,
+            )
+            self.seq_len_fill_value = (
+                self.model_runner.attn_backend.get_cuda_graph_seq_len_fill_value()
+            )
+            self.seq_lens = torch.full(
+                (self.max_bs,), self.seq_len_fill_value, dtype=torch.int32
+            )
+            self.extend_seq_lens = torch.ones((self.max_bs,), dtype=torch.int32)
+            self.accept_length = torch.full(
+                (self.max_bs,), self.num_tokens_per_bs, dtype=torch.int32
+            )
+
+            if self.require_gathered_buffer:
+                if self.require_mlp_tp_gather:
+                    self.global_num_tokens_gpu = torch.zeros(
+                        (self.dp_size,), dtype=torch.int32
+                    )
+                    self.global_num_tokens_for_logprob_gpu = torch.zeros(
+                        (self.dp_size,), dtype=torch.int32
+                    )
+                else:
+                    assert self.require_attn_tp_gather
+                    self.global_num_tokens_gpu = torch.zeros((1,), dtype=torch.int32)
+                    self.global_num_tokens_for_logprob_gpu = torch.zeros(
+                        (1,), dtype=torch.int32
+                    )
+            else:
+                self.global_num_tokens_gpu = None
+                self.global_num_tokens_for_logprob_gpu = None
+
+            if hasattr(
+                self.model_runner.model_config.hf_config, "draft_vocab_size"
+            ):
+                vocab_size = self.model_runner.model_config.hf_config.draft_vocab_size
+            elif hasattr(
+                self.model_runner.model_config.hf_config, "hot_vocab_size"
+            ):
+                vocab_size = self.model_runner.model_config.hf_config.hot_vocab_size
+            else:
+                vocab_size = self.model_runner.model_config.vocab_size
+
+            self.next_token_logits_buffer = torch.zeros(
+                (
+                    (
+                        self.max_bs * self.num_tokens_per_bs
+                        if self.forward_mode == ForwardMode.DRAFT_EXTEND_V2
+                        else self.max_bs
+                    ),
+                    vocab_size,
+                ),
+                dtype=torch.float,
+            )

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -614,13 +614,13 @@ class EAGLEDraftExtendCudaGraphRunnerAuto(EAGLEDraftExtendCudaGraphRunner):
         )
 
     def _init_graph_inputs(self, model_runner):
-        """Initialize graph input tensors."""
+        """Initialize graph input tensors and create the buffers dataclass."""
         with torch.device(model_runner.device):
-            self.input_ids = torch.zeros((self.max_num_token,), dtype=torch.int64)
-            self.req_pool_indices = torch.zeros((self.max_bs,), dtype=torch.int32)
-            self.out_cache_loc = torch.ones((self.max_num_token,), dtype=torch.int64)
-            self.positions = torch.zeros((self.max_num_token,), dtype=torch.int64)
-            self.mrope_positions = torch.zeros(
+            input_ids = torch.zeros((self.max_num_token,), dtype=torch.int64)
+            req_pool_indices = torch.zeros((self.max_bs,), dtype=torch.int32)
+            out_cache_loc = torch.ones((self.max_num_token,), dtype=torch.int64)
+            positions = torch.zeros((self.max_num_token,), dtype=torch.int64)
+            mrope_positions = torch.zeros(
                 (3, self.max_num_token), dtype=torch.int64
             )
 
@@ -636,38 +636,40 @@ class EAGLEDraftExtendCudaGraphRunnerAuto(EAGLEDraftExtendCudaGraphRunner):
             else:
                 hidden_dim = self.model_runner.model_config.hidden_size
 
-            self.hidden_states = torch.zeros(
+            hidden_states = torch.zeros(
                 (self.max_num_token, hidden_dim),
                 dtype=self.model_runner.dtype,
             )
             self.seq_len_fill_value = (
                 self.model_runner.attn_backend.get_cuda_graph_seq_len_fill_value()
             )
-            self.seq_lens = torch.full(
+            seq_lens = torch.full(
                 (self.max_bs,), self.seq_len_fill_value, dtype=torch.int32
             )
-            self.extend_seq_lens = torch.ones((self.max_bs,), dtype=torch.int32)
-            self.accept_length = torch.full(
+            extend_seq_lens = torch.full(
+                (self.max_bs,), self.num_tokens_per_bs, dtype=torch.int32
+            )
+            accept_length = torch.full(
                 (self.max_bs,), self.num_tokens_per_bs, dtype=torch.int32
             )
 
             if self.require_gathered_buffer:
                 if self.require_mlp_tp_gather:
-                    self.global_num_tokens_gpu = torch.zeros(
+                    global_num_tokens_gpu = torch.zeros(
                         (self.dp_size,), dtype=torch.int32
                     )
-                    self.global_num_tokens_for_logprob_gpu = torch.zeros(
+                    global_num_tokens_for_logprob_gpu = torch.zeros(
                         (self.dp_size,), dtype=torch.int32
                     )
                 else:
                     assert self.require_attn_tp_gather
-                    self.global_num_tokens_gpu = torch.zeros((1,), dtype=torch.int32)
-                    self.global_num_tokens_for_logprob_gpu = torch.zeros(
+                    global_num_tokens_gpu = torch.zeros((1,), dtype=torch.int32)
+                    global_num_tokens_for_logprob_gpu = torch.zeros(
                         (1,), dtype=torch.int32
                     )
             else:
-                self.global_num_tokens_gpu = None
-                self.global_num_tokens_for_logprob_gpu = None
+                global_num_tokens_gpu = None
+                global_num_tokens_for_logprob_gpu = None
 
             if hasattr(
                 self.model_runner.model_config.hf_config, "draft_vocab_size"
@@ -680,7 +682,7 @@ class EAGLEDraftExtendCudaGraphRunnerAuto(EAGLEDraftExtendCudaGraphRunner):
             else:
                 vocab_size = self.model_runner.model_config.vocab_size
 
-            self.next_token_logits_buffer = torch.zeros(
+            next_token_logits_buffer = torch.zeros(
                 (
                     (
                         self.max_bs * self.num_tokens_per_bs
@@ -691,3 +693,20 @@ class EAGLEDraftExtendCudaGraphRunnerAuto(EAGLEDraftExtendCudaGraphRunner):
                 ),
                 dtype=torch.float,
             )
+
+        self.buffers = EagleDraftExtendInputBuffers(
+            input_ids=input_ids,
+            req_pool_indices=req_pool_indices,
+            out_cache_loc=out_cache_loc,
+            positions=positions,
+            mrope_positions=mrope_positions,
+            hidden_states=hidden_states,
+            seq_lens=seq_lens,
+            seq_lens_cpu=self.seq_lens_cpu,
+            extend_seq_lens=extend_seq_lens,
+            accept_length=accept_length,
+            next_token_logits_buffer=next_token_logits_buffer,
+            global_num_tokens_gpu=global_num_tokens_gpu,
+            global_num_tokens_for_logprob_gpu=global_num_tokens_for_logprob_gpu,
+        )
+        self.buffers.share_buffers()

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -617,14 +617,17 @@ class EAGLEDraftExtendCudaGraphRunnerAuto(EAGLEDraftExtendCudaGraphRunner):
         """Initialize graph input tensors and create the buffers dataclass."""
         with torch.device(model_runner.device):
             input_ids = torch.zeros((self.max_num_token,), dtype=torch.int64)
-            req_pool_indices = torch.zeros((self.max_bs,), dtype=torch.int32)
-            out_cache_loc = torch.ones((self.max_num_token,), dtype=torch.int64)
+            req_pool_indices = torch.zeros((self.max_bs,), dtype=torch.int64)
+            out_cache_loc = torch.ones((self.max_num_token,), dtype=self._cache_loc_dtype())
             positions = torch.zeros((self.max_num_token,), dtype=torch.int64)
             mrope_positions = torch.zeros(
                 (3, self.max_num_token), dtype=torch.int64
             )
 
-            if self.eagle_worker.speculative_algorithm.is_eagle3():
+            if (
+                self.eagle_worker.speculative_algorithm.is_eagle3()
+                and self.eagle_worker.eagle_use_aux_hidden_state
+            ):
                 hidden_dim = (
                     self.model_runner.model_config.hf_config.target_hidden_size * 3
                     if hasattr(

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -618,11 +618,11 @@ class EAGLEDraftExtendCudaGraphRunnerAuto(EAGLEDraftExtendCudaGraphRunner):
         with torch.device(model_runner.device):
             input_ids = torch.zeros((self.max_num_token,), dtype=torch.int64)
             req_pool_indices = torch.zeros((self.max_bs,), dtype=torch.int64)
-            out_cache_loc = torch.ones((self.max_num_token,), dtype=self._cache_loc_dtype())
-            positions = torch.zeros((self.max_num_token,), dtype=torch.int64)
-            mrope_positions = torch.zeros(
-                (3, self.max_num_token), dtype=torch.int64
+            out_cache_loc = torch.ones(
+                (self.max_num_token,), dtype=self._cache_loc_dtype()
             )
+            positions = torch.zeros((self.max_num_token,), dtype=torch.int64)
+            mrope_positions = torch.zeros((3, self.max_num_token), dtype=torch.int64)
 
             if (
                 self.eagle_worker.speculative_algorithm.is_eagle3()
@@ -674,13 +674,9 @@ class EAGLEDraftExtendCudaGraphRunnerAuto(EAGLEDraftExtendCudaGraphRunner):
                 global_num_tokens_gpu = None
                 global_num_tokens_for_logprob_gpu = None
 
-            if hasattr(
-                self.model_runner.model_config.hf_config, "draft_vocab_size"
-            ):
+            if hasattr(self.model_runner.model_config.hf_config, "draft_vocab_size"):
                 vocab_size = self.model_runner.model_config.hf_config.draft_vocab_size
-            elif hasattr(
-                self.model_runner.model_config.hf_config, "hot_vocab_size"
-            ):
+            elif hasattr(self.model_runner.model_config.hf_config, "hot_vocab_size"):
                 vocab_size = self.model_runner.model_config.hf_config.hot_vocab_size
             else:
                 vocab_size = self.model_runner.model_config.vocab_size

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -315,11 +315,15 @@ class EAGLEWorker(TpModelWorker):
 
                 logger.info(f"AutoSpec: capturing draft graphs for num_steps={num_steps}")
 
-                # Save and update server_args for this step
+                # Save and update server_args + worker attrs for this step
                 saved_steps = self.draft_model_runner.server_args.speculative_num_steps
                 saved_draft = self.draft_model_runner.server_args.speculative_num_draft_tokens
+                saved_worker_steps = self.speculative_num_steps
+                saved_worker_draft = self.speculative_num_draft_tokens
                 self.draft_model_runner.server_args.speculative_num_steps = num_steps
                 self.draft_model_runner.server_args.speculative_num_draft_tokens = num_steps + 1
+                self.speculative_num_steps = num_steps
+                self.speculative_num_draft_tokens = num_steps + 1
 
                 # Create attention backend for this step
                 draft_backend_factory = DraftBackendFactory(
@@ -361,6 +365,8 @@ class EAGLEWorker(TpModelWorker):
                 # Restore
                 self.draft_model_runner.server_args.speculative_num_steps = saved_steps
                 self.draft_model_runner.server_args.speculative_num_draft_tokens = saved_draft
+                self.speculative_num_steps = saved_worker_steps
+                self.speculative_num_draft_tokens = saved_worker_draft
 
         # Also init verify-side multi-step graphs on the target model runner
         target_runner = self.target_worker.model_runner

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -320,6 +320,7 @@ class EAGLEWorker(TpModelWorker):
                 saved_draft = self.draft_model_runner.server_args.speculative_num_draft_tokens
                 saved_worker_steps = self.speculative_num_steps
                 saved_worker_draft = self.speculative_num_draft_tokens
+                saved_draft_attn = self.draft_attn_backend
                 self.draft_model_runner.server_args.speculative_num_steps = num_steps
                 self.draft_model_runner.server_args.speculative_num_draft_tokens = num_steps + 1
                 self.speculative_num_steps = num_steps
@@ -338,6 +339,7 @@ class EAGLEWorker(TpModelWorker):
                 self.draft_attn_backend_for_steps[num_steps] = draft_attn
                 self.draft_extend_attn_backend_for_steps[num_steps] = draft_extend_attn
                 self.draft_model_runner.draft_attn_backend = draft_attn
+                self.draft_attn_backend = draft_attn
 
                 # Capture draft CUDA graph for this step
                 if num_steps > 1:
@@ -367,6 +369,8 @@ class EAGLEWorker(TpModelWorker):
                 self.draft_model_runner.server_args.speculative_num_draft_tokens = saved_draft
                 self.speculative_num_steps = saved_worker_steps
                 self.speculative_num_draft_tokens = saved_worker_draft
+                self.draft_attn_backend = saved_draft_attn
+                self.draft_model_runner.draft_attn_backend = saved_draft_attn
 
         # Also init verify-side multi-step graphs on the target model runner
         target_runner = self.target_worker.model_runner

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -313,16 +313,22 @@ class EAGLEWorker(TpModelWorker):
                 if num_steps == default_step:
                     continue
 
-                logger.info(f"AutoSpec: capturing draft graphs for num_steps={num_steps}")
+                logger.info(
+                    f"AutoSpec: capturing draft graphs for num_steps={num_steps}"
+                )
 
                 # Save and update server_args + worker attrs for this step
                 saved_steps = self.draft_model_runner.server_args.speculative_num_steps
-                saved_draft = self.draft_model_runner.server_args.speculative_num_draft_tokens
+                saved_draft = (
+                    self.draft_model_runner.server_args.speculative_num_draft_tokens
+                )
                 saved_worker_steps = self.speculative_num_steps
                 saved_worker_draft = self.speculative_num_draft_tokens
                 saved_draft_attn = self.draft_attn_backend
                 self.draft_model_runner.server_args.speculative_num_steps = num_steps
-                self.draft_model_runner.server_args.speculative_num_draft_tokens = num_steps + 1
+                self.draft_model_runner.server_args.speculative_num_draft_tokens = (
+                    num_steps + 1
+                )
                 self.speculative_num_steps = num_steps
                 self.speculative_num_draft_tokens = num_steps + 1
 
@@ -368,7 +374,9 @@ class EAGLEWorker(TpModelWorker):
 
                 # Restore
                 self.draft_model_runner.server_args.speculative_num_steps = saved_steps
-                self.draft_model_runner.server_args.speculative_num_draft_tokens = saved_draft
+                self.draft_model_runner.server_args.speculative_num_draft_tokens = (
+                    saved_draft
+                )
                 self.speculative_num_steps = saved_worker_steps
                 self.speculative_num_draft_tokens = saved_worker_draft
                 self.draft_attn_backend = saved_draft_attn
@@ -381,7 +389,9 @@ class EAGLEWorker(TpModelWorker):
 
         # Restore current backends to the default step
         self.draft_attn_backend = self.draft_attn_backend_for_steps[default_step]
-        self.draft_extend_attn_backend = self.draft_extend_attn_backend_for_steps[default_step]
+        self.draft_extend_attn_backend = self.draft_extend_attn_backend_for_steps[
+            default_step
+        ]
         self.draft_model_runner.draft_attn_backend = self.draft_attn_backend
         self.cuda_graph_runner = self.cuda_graph_runner_for_steps[default_step]
         self.cuda_graph_runner_for_draft_extend = (
@@ -407,7 +417,9 @@ class EAGLEWorker(TpModelWorker):
 
         # Switch draft-side
         self.draft_attn_backend = self.draft_attn_backend_for_steps[num_steps]
-        self.draft_extend_attn_backend = self.draft_extend_attn_backend_for_steps.get(num_steps)
+        self.draft_extend_attn_backend = self.draft_extend_attn_backend_for_steps.get(
+            num_steps
+        )
         self.draft_model_runner.draft_attn_backend = self.draft_attn_backend
         self.cuda_graph_runner = self.cuda_graph_runner_for_steps.get(num_steps)
         self.cuda_graph_runner_for_draft_extend = (

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -33,9 +33,11 @@ from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.draft_utils import DraftBackendFactory
 from sglang.srt.speculative.eagle_draft_cuda_graph_runner import (
     EAGLEDraftCudaGraphRunner,
+    EAGLEDraftCudaGraphRunnerAuto,
 )
 from sglang.srt.speculative.eagle_draft_extend_cuda_graph_runner import (
     EAGLEDraftExtendCudaGraphRunner,
+    EAGLEDraftExtendCudaGraphRunnerAuto,
 )
 from sglang.srt.speculative.eagle_info import (
     EagleDraftInput,
@@ -102,6 +104,10 @@ class EAGLEWorker(TpModelWorker):
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )
+
+        # Auto-spec support
+        self.auto_spec = server_args.auto_spec
+        self.auto_spec_engine = None  # Set later by scheduler
 
         # Override the context length of the draft model to be the same as the target model.
         server_args.context_length = target_worker.model_runner.model_config.context_len
@@ -205,6 +211,10 @@ class EAGLEWorker(TpModelWorker):
             self.init_attention_backend()
             self.init_cuda_graphs()
 
+        # Auto-spec: additional initialization for multi-step graphs
+        # (must be done after normal init completes)
+        self._auto_spec_initialized = False
+
         # Some dummy tensors
         self.num_new_pages_per_topk = torch.empty(
             (), dtype=torch.int64, device=self.device
@@ -272,6 +282,138 @@ class EAGLEWorker(TpModelWorker):
                 f"Capture draft extend cuda graph end. Time elapsed: {time.perf_counter() - tic:.2f} s. mem usage={(before_mem - after_mem):.2f} GB. avail mem={after_mem:.2f} GB."
             )
 
+    def init_auto_spec(self, auto_spec_engine):
+        """Initialize auto-spec multi-step CUDA graphs and attention backends.
+
+        Must be called after init_cuda_graphs() completes and after
+        auto_spec_engine.initialize() is called.
+        """
+        if not self.auto_spec or self._auto_spec_initialized:
+            return
+
+        self.auto_spec_engine = auto_spec_engine
+        step_range = auto_spec_engine.step_range
+
+        # Store the default (already-captured) graphs for the initial num_steps
+        default_step = self.speculative_num_steps
+        self.draft_attn_backend_for_steps = {default_step: self.draft_attn_backend}
+        self.draft_extend_attn_backend_for_steps = {
+            default_step: self.draft_extend_attn_backend
+        }
+        self.cuda_graph_runner_for_steps = {default_step: self.cuda_graph_runner}
+        self.cuda_graph_runner_for_draft_extend_for_steps = {
+            default_step: self.cuda_graph_runner_for_draft_extend
+        }
+
+        # Capture additional graphs for other steps
+        with self.draft_tp_context(
+            self.draft_model_runner.tp_group
+        ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
+            for num_steps in step_range:
+                if num_steps == default_step:
+                    continue
+
+                logger.info(f"AutoSpec: capturing draft graphs for num_steps={num_steps}")
+
+                # Save and update server_args for this step
+                saved_steps = self.draft_model_runner.server_args.speculative_num_steps
+                saved_draft = self.draft_model_runner.server_args.speculative_num_draft_tokens
+                self.draft_model_runner.server_args.speculative_num_steps = num_steps
+                self.draft_model_runner.server_args.speculative_num_draft_tokens = num_steps + 1
+
+                # Create attention backend for this step
+                draft_backend_factory = DraftBackendFactory(
+                    self.server_args,
+                    self.draft_model_runner,
+                    self.topk,
+                    num_steps,
+                )
+                draft_attn = draft_backend_factory.create_decode_backend()
+                draft_extend_attn = draft_backend_factory.create_draft_extend_backend()
+
+                self.draft_attn_backend_for_steps[num_steps] = draft_attn
+                self.draft_extend_attn_backend_for_steps[num_steps] = draft_extend_attn
+                self.draft_model_runner.draft_attn_backend = draft_attn
+
+                # Capture draft CUDA graph for this step
+                if num_steps > 1:
+                    bs_for_step = auto_spec_engine.steps_bs_mapping.get(num_steps)
+                    self.cuda_graph_runner_for_steps[num_steps] = (
+                        EAGLEDraftCudaGraphRunnerAuto(
+                            self,
+                            num_steps,
+                            batch_sizes=bs_for_step,
+                            draft_attn_backend=draft_attn,
+                        )
+                    )
+                else:
+                    self.cuda_graph_runner_for_steps[num_steps] = None
+
+                # Capture draft extend CUDA graph
+                if draft_extend_attn and not _is_npu:
+                    self.draft_extend_attn_backend = draft_extend_attn
+                    self.cuda_graph_runner_for_draft_extend_for_steps[num_steps] = (
+                        EAGLEDraftExtendCudaGraphRunnerAuto(self, num_steps)
+                    )
+                else:
+                    self.cuda_graph_runner_for_draft_extend_for_steps[num_steps] = None
+
+                # Restore
+                self.draft_model_runner.server_args.speculative_num_steps = saved_steps
+                self.draft_model_runner.server_args.speculative_num_draft_tokens = saved_draft
+
+        # Also init verify-side multi-step graphs on the target model runner
+        target_runner = self.target_worker.model_runner
+        target_runner.init_attention_backend_for_steps(step_range)
+        target_runner.init_device_graphs_for_steps(step_range)
+
+        # Restore current backends to the default step
+        self.draft_attn_backend = self.draft_attn_backend_for_steps[default_step]
+        self.draft_extend_attn_backend = self.draft_extend_attn_backend_for_steps[default_step]
+        self.draft_model_runner.draft_attn_backend = self.draft_attn_backend
+        self.cuda_graph_runner = self.cuda_graph_runner_for_steps[default_step]
+        self.cuda_graph_runner_for_draft_extend = (
+            self.cuda_graph_runner_for_draft_extend_for_steps[default_step]
+        )
+
+        self._auto_spec_initialized = True
+        logger.info(
+            f"AutoSpec V1 initialized: step_range={step_range}, "
+            f"default_step={default_step}"
+        )
+
+    def _switch_to_step(self, num_steps: int):
+        """Switch all CUDA graph runners and attention backends to a given num_steps."""
+        if num_steps == self.speculative_num_steps:
+            return
+
+        self.speculative_num_steps = num_steps
+        self.speculative_num_draft_tokens = num_steps + 1
+
+        # Switch draft-side
+        self.draft_attn_backend = self.draft_attn_backend_for_steps[num_steps]
+        self.draft_extend_attn_backend = self.draft_extend_attn_backend_for_steps.get(num_steps)
+        self.draft_model_runner.draft_attn_backend = self.draft_attn_backend
+        self.cuda_graph_runner = self.cuda_graph_runner_for_steps.get(num_steps)
+        self.cuda_graph_runner_for_draft_extend = (
+            self.cuda_graph_runner_for_draft_extend_for_steps.get(num_steps)
+        )
+
+        # Update draft server_args (needed for get_eagle_info in ForwardBatch)
+        self.draft_model_runner.server_args.speculative_num_steps = num_steps
+        self.draft_model_runner.server_args.speculative_num_draft_tokens = num_steps + 1
+
+        # Switch verify-side
+        target_runner = self.target_worker.model_runner
+        if num_steps in target_runner.graph_runner_for_steps:
+            target_runner.graph_runner = target_runner.graph_runner_for_steps[num_steps]
+        if num_steps in target_runner.attn_backend_for_steps:
+            target_runner.attn_backend = target_runner.attn_backend_for_steps[num_steps]
+
+        # Update target server_args
+        target_runner.server_args.speculative_num_steps = num_steps
+        target_runner.server_args.speculative_num_draft_tokens = num_steps + 1
+
     @property
     def draft_model_runner(self):
         return self.model_runner
@@ -312,6 +454,12 @@ class EAGLEWorker(TpModelWorker):
                 can_run_cuda_graph=can_run_cuda_graph,
             )
         else:
+            # Auto-spec: switch to the best num_steps for this batch size
+            if self.auto_spec and self._auto_spec_initialized:
+                best = self.auto_spec_engine.get_spec_params(batch.batch_size())
+                if best.num_steps != self.speculative_num_steps:
+                    self._switch_to_step(best.num_steps)
+
             with self.draft_tp_context(
                 self.draft_model_runner.tp_group
             ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
@@ -613,7 +761,7 @@ class EAGLEWorker(TpModelWorker):
             retrive_cum_len=None,
             spec_steps=self.speculative_num_steps,
             topk=self.topk,
-            draft_token_num=self.server_args.speculative_num_draft_tokens,
+            draft_token_num=self.speculative_num_draft_tokens,
             capture_hidden_mode=CaptureHiddenMode.FULL,
             seq_lens_sum=forward_batch.seq_lens_sum,
             seq_lens_cpu=forward_batch.seq_lens_cpu,

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -359,7 +359,9 @@ class EAGLEWorker(TpModelWorker):
                 if draft_extend_attn and not _is_npu:
                     self.draft_extend_attn_backend = draft_extend_attn
                     self.cuda_graph_runner_for_draft_extend_for_steps[num_steps] = (
-                        EAGLEDraftExtendCudaGraphRunnerAuto(self, num_steps)
+                        EAGLEDraftExtendCudaGraphRunnerAuto(
+                            self, num_steps, batch_sizes=bs_for_step
+                        )
                     )
                 else:
                     self.cuda_graph_runner_for_draft_extend_for_steps[num_steps] = None

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -348,8 +348,8 @@ class EAGLEWorker(TpModelWorker):
                 self.draft_attn_backend = draft_attn
 
                 # Capture draft CUDA graph for this step
+                bs_for_step = auto_spec_engine.steps_bs_mapping.get(num_steps)
                 if num_steps > 1:
-                    bs_for_step = auto_spec_engine.steps_bs_mapping.get(num_steps)
                     self.cuda_graph_runner_for_steps[num_steps] = (
                         EAGLEDraftCudaGraphRunnerAuto(
                             self,

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -399,6 +399,9 @@ class EAGLEWorker(TpModelWorker):
         if num_steps == self.speculative_num_steps:
             return
 
+        logger.info(
+            f"AutoSpec V1: switching num_steps {self.speculative_num_steps}->{num_steps}"
+        )
         self.speculative_num_steps = num_steps
         self.speculative_num_draft_tokens = num_steps + 1
 

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -437,6 +437,11 @@ class EagleDraftWorker(BaseDraftWorker):
         if num_steps == self.speculative_num_steps:
             return
 
+        logger.info(
+            f"AutoSpec V2 DraftWorker: switching num_steps "
+            f"{self.speculative_num_steps}->{num_steps}"
+        )
+
         self.speculative_num_steps = num_steps
         self.speculative_num_draft_tokens = num_steps + 1
 
@@ -855,6 +860,11 @@ class EAGLEWorkerV2(BaseSpecWorker):
         """Switch to a different speculative step count."""
         if num_steps == self.speculative_num_steps:
             return
+
+        logger.info(
+            f"AutoSpec V2: switching num_steps "
+            f"{self.speculative_num_steps}->{num_steps}"
+        )
 
         self.speculative_num_steps = num_steps
         self.speculative_num_draft_tokens = num_steps + 1

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -363,7 +363,9 @@ class EagleDraftWorker(BaseDraftWorker):
                 saved_worker_draft = self.speculative_num_draft_tokens
                 saved_draft_attn = self.draft_attn_backend
                 self.draft_runner.server_args.speculative_num_steps = num_steps
-                self.draft_runner.server_args.speculative_num_draft_tokens = num_steps + 1
+                self.draft_runner.server_args.speculative_num_draft_tokens = (
+                    num_steps + 1
+                )
                 self.speculative_num_steps = num_steps
                 self.speculative_num_draft_tokens = num_steps + 1
 

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -33,9 +33,11 @@ from sglang.srt.speculative.base_spec_worker import BaseDraftWorker, BaseSpecWor
 from sglang.srt.speculative.draft_utils import DraftBackendFactory
 from sglang.srt.speculative.eagle_draft_cuda_graph_runner import (
     EAGLEDraftCudaGraphRunner,
+    EAGLEDraftCudaGraphRunnerAuto,
 )
 from sglang.srt.speculative.eagle_draft_extend_cuda_graph_runner import (
     EAGLEDraftExtendCudaGraphRunner,
+    EAGLEDraftExtendCudaGraphRunnerAuto,
 )
 from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
 from sglang.srt.speculative.eagle_info_v2 import (
@@ -115,6 +117,11 @@ class EagleDraftWorker(BaseDraftWorker):
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )
+
+        # Auto-spec support
+        self.auto_spec = server_args.auto_spec
+        self.auto_spec_engine = None  # Set later
+        self._auto_spec_initialized = False
 
         # Do not capture cuda graph in `TpModelWorker` init,
         # will capture later with init_cuda_graphs()
@@ -316,6 +323,125 @@ class EagleDraftWorker(BaseDraftWorker):
             logger.info(
                 f"Capture draft extend cuda graph end. Time elapsed: {time.perf_counter() - tic:.2f} s. mem usage={(before_mem - after_mem):.2f} GB. avail mem={after_mem:.2f} GB."
             )
+
+    def init_auto_spec(self, auto_spec_engine):
+        """Initialize auto-spec multi-step CUDA graphs and attention backends.
+
+        Must be called after init_cuda_graphs() and auto_spec_engine.initialize().
+        """
+        if not self.auto_spec or self._auto_spec_initialized:
+            return
+
+        self.auto_spec_engine = auto_spec_engine
+        step_range = auto_spec_engine.step_range
+
+        # Store the default graphs
+        default_step = self.speculative_num_steps
+        self.draft_attn_backend_for_steps = {default_step: self.draft_attn_backend}
+        self.draft_extend_attn_backend_for_steps = {
+            default_step: self.draft_extend_attn_backend
+        }
+        self.cuda_graph_runner_for_steps = {default_step: self.cuda_graph_runner}
+        self.cuda_graph_runner_for_draft_extend_for_steps = {
+            default_step: self.cuda_graph_runner_for_draft_extend
+        }
+
+        with self.draft_tp_context(
+            self.draft_runner.tp_group
+        ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
+            for num_steps in step_range:
+                if num_steps == default_step:
+                    continue
+
+                logger.info(
+                    f"AutoSpec V2: capturing draft graphs for num_steps={num_steps}"
+                )
+
+                saved_steps = self.draft_runner.server_args.speculative_num_steps
+                saved_draft = self.draft_runner.server_args.speculative_num_draft_tokens
+                self.draft_runner.server_args.speculative_num_steps = num_steps
+                self.draft_runner.server_args.speculative_num_draft_tokens = num_steps + 1
+
+                # Create attention backend for this step
+                draft_backend_factory = DraftBackendFactory(
+                    self.server_args,
+                    self.draft_runner,
+                    self.topk,
+                    num_steps,
+                )
+                draft_attn = draft_backend_factory.create_decode_backend()
+                draft_extend_attn = draft_backend_factory.create_draft_extend_backend()
+
+                self.draft_attn_backend_for_steps[num_steps] = draft_attn
+                self.draft_extend_attn_backend_for_steps[num_steps] = draft_extend_attn
+                self.draft_runner.draft_attn_backend = draft_attn
+
+                # Capture draft CUDA graph
+                if num_steps > 1:
+                    bs_for_step = auto_spec_engine.steps_bs_mapping.get(num_steps)
+                    self.cuda_graph_runner_for_steps[num_steps] = (
+                        EAGLEDraftCudaGraphRunnerAuto(
+                            self,
+                            num_steps,
+                            batch_sizes=bs_for_step,
+                            draft_attn_backend=draft_attn,
+                        )
+                    )
+                else:
+                    self.cuda_graph_runner_for_steps[num_steps] = None
+
+                # Capture draft extend CUDA graph
+                if draft_extend_attn and not _is_npu:
+                    self.draft_extend_attn_backend = draft_extend_attn
+                    self.cuda_graph_runner_for_draft_extend_for_steps[num_steps] = (
+                        EAGLEDraftExtendCudaGraphRunnerAuto(self, num_steps)
+                    )
+                else:
+                    self.cuda_graph_runner_for_draft_extend_for_steps[num_steps] = None
+
+                # Restore
+                self.draft_runner.server_args.speculative_num_steps = saved_steps
+                self.draft_runner.server_args.speculative_num_draft_tokens = saved_draft
+
+        # Restore current backends
+        self.draft_attn_backend = self.draft_attn_backend_for_steps[default_step]
+        self.draft_extend_attn_backend = self.draft_extend_attn_backend_for_steps[
+            default_step
+        ]
+        self.draft_runner.draft_attn_backend = self.draft_attn_backend
+        self.cuda_graph_runner = self.cuda_graph_runner_for_steps[default_step]
+        self.cuda_graph_runner_for_draft_extend = (
+            self.cuda_graph_runner_for_draft_extend_for_steps[default_step]
+        )
+
+        self._auto_spec_initialized = True
+        logger.info(
+            f"AutoSpec V2 DraftWorker initialized: step_range={step_range}, "
+            f"default_step={default_step}"
+        )
+
+    def _switch_to_step(self, num_steps: int):
+        """Switch all CUDA graph runners and attention backends to a given num_steps."""
+        if num_steps == self.speculative_num_steps:
+            return
+
+        self.speculative_num_steps = num_steps
+        self.speculative_num_draft_tokens = num_steps + 1
+
+        # Switch draft-side
+        self.draft_attn_backend = self.draft_attn_backend_for_steps[num_steps]
+        self.draft_extend_attn_backend = self.draft_extend_attn_backend_for_steps.get(
+            num_steps
+        )
+        self.draft_runner.draft_attn_backend = self.draft_attn_backend
+        self.cuda_graph_runner = self.cuda_graph_runner_for_steps.get(num_steps)
+        self.cuda_graph_runner_for_draft_extend = (
+            self.cuda_graph_runner_for_draft_extend_for_steps.get(num_steps)
+        )
+
+        # Update draft server_args
+        self.draft_runner.server_args.speculative_num_steps = num_steps
+        self.draft_runner.server_args.speculative_num_draft_tokens = num_steps + 1
 
     def draft(self, model_worker_batch: ModelWorkerBatch):
         draft_input: EagleDraftInput = model_worker_batch.spec_info
@@ -668,6 +794,11 @@ class EAGLEWorkerV2(BaseSpecWorker):
             target_worker,
         )
 
+        # Auto-spec support
+        self.auto_spec = server_args.auto_spec
+        self.auto_spec_engine = None  # Set later by scheduler
+        self._auto_spec_initialized = False
+
         # Some dummy tensors
         self.num_new_pages_per_topk = torch.empty(
             (), dtype=torch.int64, device=self.device
@@ -687,6 +818,46 @@ class EAGLEWorkerV2(BaseSpecWorker):
     def clear_cache_pool(self):
         # allocator and kv cache pool are shared with target worker, which are cleared in scheduler
         pass
+
+    def init_auto_spec(self, auto_spec_engine):
+        """Initialize auto-spec for V2 path."""
+        if not self.auto_spec or self._auto_spec_initialized:
+            return
+
+        self.auto_spec_engine = auto_spec_engine
+
+        # Initialize the draft worker's multi-step graphs
+        self._draft_worker.init_auto_spec(auto_spec_engine)
+
+        # Initialize the verify-side multi-step graphs
+        target_runner = self._target_worker.model_runner
+        target_runner.init_attention_backend_for_steps(auto_spec_engine.step_range)
+        target_runner.init_device_graphs_for_steps(auto_spec_engine.step_range)
+
+        self._auto_spec_initialized = True
+        logger.info(
+            f"AutoSpec V2 initialized: step_range={auto_spec_engine.step_range}"
+        )
+
+    def _switch_to_step(self, num_steps: int):
+        """Switch to a different speculative step count."""
+        if num_steps == self.speculative_num_steps:
+            return
+
+        self.speculative_num_steps = num_steps
+        self.speculative_num_draft_tokens = num_steps + 1
+
+        # Switch draft worker
+        self._draft_worker._switch_to_step(num_steps)
+
+        # Switch verify-side
+        target_runner = self._target_worker.model_runner
+        if num_steps in target_runner.graph_runner_for_steps:
+            target_runner.graph_runner = target_runner.graph_runner_for_steps[num_steps]
+        if num_steps in target_runner.attn_backend_for_steps:
+            target_runner.attn_backend = target_runner.attn_backend_for_steps[num_steps]
+        target_runner.server_args.speculative_num_steps = num_steps
+        target_runner.server_args.speculative_num_draft_tokens = num_steps + 1
 
     def forward_batch_generation(self, model_worker_batch: ModelWorkerBatch):
         if (
@@ -714,6 +885,13 @@ class EAGLEWorkerV2(BaseSpecWorker):
                 )
                 return batch_output
         else:
+            # Auto-spec: switch to the best num_steps for this batch size
+            if self.auto_spec and self._auto_spec_initialized:
+                bs = len(model_worker_batch.seq_lens)
+                best = self.auto_spec_engine.get_spec_params(bs)
+                if best.num_steps != self.speculative_num_steps:
+                    self._switch_to_step(best.num_steps)
+
             if model_worker_batch.spec_info is None:
                 model_worker_batch.spec_info = EagleDraftInput.create_idle_input(
                     device=self.device,

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -361,6 +361,7 @@ class EagleDraftWorker(BaseDraftWorker):
                 saved_draft = self.draft_runner.server_args.speculative_num_draft_tokens
                 saved_worker_steps = self.speculative_num_steps
                 saved_worker_draft = self.speculative_num_draft_tokens
+                saved_draft_attn = self.draft_attn_backend
                 self.draft_runner.server_args.speculative_num_steps = num_steps
                 self.draft_runner.server_args.speculative_num_draft_tokens = num_steps + 1
                 self.speculative_num_steps = num_steps
@@ -379,6 +380,7 @@ class EagleDraftWorker(BaseDraftWorker):
                 self.draft_attn_backend_for_steps[num_steps] = draft_attn
                 self.draft_extend_attn_backend_for_steps[num_steps] = draft_extend_attn
                 self.draft_runner.draft_attn_backend = draft_attn
+                self.draft_attn_backend = draft_attn
 
                 # Capture draft CUDA graph
                 if num_steps > 1:
@@ -408,6 +410,8 @@ class EagleDraftWorker(BaseDraftWorker):
                 self.draft_runner.server_args.speculative_num_draft_tokens = saved_draft
                 self.speculative_num_steps = saved_worker_steps
                 self.speculative_num_draft_tokens = saved_worker_draft
+                self.draft_attn_backend = saved_draft_attn
+                self.draft_runner.draft_attn_backend = saved_draft_attn
 
         # Restore current backends
         self.draft_attn_backend = self.draft_attn_backend_for_steps[default_step]

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -400,7 +400,9 @@ class EagleDraftWorker(BaseDraftWorker):
                 if draft_extend_attn and not _is_npu:
                     self.draft_extend_attn_backend = draft_extend_attn
                     self.cuda_graph_runner_for_draft_extend_for_steps[num_steps] = (
-                        EAGLEDraftExtendCudaGraphRunnerAuto(self, num_steps)
+                        EAGLEDraftExtendCudaGraphRunnerAuto(
+                            self, num_steps, batch_sizes=bs_for_step
+                        )
                     )
                 else:
                     self.cuda_graph_runner_for_draft_extend_for_steps[num_steps] = None

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -428,11 +428,14 @@ class EagleDraftWorker(BaseDraftWorker):
         )
 
         # Sync bs_steps_mapping with actual CUDA graph capacity.
-        # Since we capture graphs for all batch sizes (batch_sizes=None),
-        # every step should support all BS, enabling full auto-spec flexibility
-        # and eliminating eager mode fallback entirely.
+        # Only include steps in step_range (not the default step if it's outside
+        # step_range), because verify-side graphs are only captured for step_range.
+        # Including the default step would let auto-spec switch to it, but the
+        # verify graph buffers would have wrong sizes, causing tensor mismatch.
         step_max_bs = {}
         for num_steps, runner in self.cuda_graph_runner_for_steps.items():
+            if num_steps not in step_range:
+                continue
             if runner is not None:
                 step_max_bs[num_steps] = runner.max_bs
             else:

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -382,14 +382,15 @@ class EagleDraftWorker(BaseDraftWorker):
                 self.draft_runner.draft_attn_backend = draft_attn
                 self.draft_attn_backend = draft_attn
 
-                # Capture draft CUDA graph
+                # Capture draft CUDA graph with ALL batch sizes from cuda_graph_bs,
+                # not just the subset from steps_bs_mapping. This ensures every step
+                # has graphs for all batch sizes, eliminating eager mode fallback.
                 if num_steps > 1:
-                    bs_for_step = auto_spec_engine.steps_bs_mapping.get(num_steps)
                     self.cuda_graph_runner_for_steps[num_steps] = (
                         EAGLEDraftCudaGraphRunnerAuto(
                             self,
                             num_steps,
-                            batch_sizes=bs_for_step,
+                            batch_sizes=None,  # Use full cuda_graph_bs
                             draft_attn_backend=draft_attn,
                         )
                     )
@@ -401,7 +402,7 @@ class EagleDraftWorker(BaseDraftWorker):
                     self.draft_extend_attn_backend = draft_extend_attn
                     self.cuda_graph_runner_for_draft_extend_for_steps[num_steps] = (
                         EAGLEDraftExtendCudaGraphRunnerAuto(
-                            self, num_steps, batch_sizes=bs_for_step
+                            self, num_steps, batch_sizes=None  # Use full cuda_graph_bs
                         )
                     )
                 else:
@@ -426,9 +427,10 @@ class EagleDraftWorker(BaseDraftWorker):
             self.cuda_graph_runner_for_draft_extend_for_steps[default_step]
         )
 
-        # Prune bs_steps_mapping: only keep BS->step combinations where
-        # the draft graph runner can handle that BS (avoid eager mode fallback
-        # which can cause illegal memory access with large batches).
+        # Sync bs_steps_mapping with actual CUDA graph capacity.
+        # Since we capture graphs for all batch sizes (batch_sizes=None),
+        # every step should support all BS, enabling full auto-spec flexibility
+        # and eliminating eager mode fallback entirely.
         step_max_bs = {}
         for num_steps, runner in self.cuda_graph_runner_for_steps.items():
             if runner is not None:
@@ -436,7 +438,7 @@ class EagleDraftWorker(BaseDraftWorker):
             else:
                 # step=1 has no graph runner, allow any BS
                 step_max_bs[num_steps] = max(auto_spec_engine.bs_list)
-        auto_spec_engine.prune_by_graph_capacity(step_max_bs)
+        auto_spec_engine.sync_with_graph_capacity(step_max_bs)
 
         self._auto_spec_initialized = True
         logger.info(

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -426,6 +426,18 @@ class EagleDraftWorker(BaseDraftWorker):
             self.cuda_graph_runner_for_draft_extend_for_steps[default_step]
         )
 
+        # Prune bs_steps_mapping: only keep BS->step combinations where
+        # the draft graph runner can handle that BS (avoid eager mode fallback
+        # which can cause illegal memory access with large batches).
+        step_max_bs = {}
+        for num_steps, runner in self.cuda_graph_runner_for_steps.items():
+            if runner is not None:
+                step_max_bs[num_steps] = runner.max_bs
+            else:
+                # step=1 has no graph runner, allow any BS
+                step_max_bs[num_steps] = max(auto_spec_engine.bs_list)
+        auto_spec_engine.prune_by_graph_capacity(step_max_bs)
+
         self._auto_spec_initialized = True
         logger.info(
             f"AutoSpec V2 DraftWorker initialized: step_range={step_range}, "
@@ -456,9 +468,9 @@ class EagleDraftWorker(BaseDraftWorker):
             self.cuda_graph_runner_for_draft_extend_for_steps.get(num_steps)
         )
 
-        # Update draft server_args
-        self.draft_runner.server_args.speculative_num_steps = num_steps
-        self.draft_runner.server_args.speculative_num_draft_tokens = num_steps + 1
+        # NOTE: Do NOT update draft_runner.server_args.speculative_num_steps here.
+        # server_args is set to the max step in init_auto_spec so that
+        # get_alloc_len_per_decode() always allocates enough KV cache slots.
 
     def draft(self, model_worker_batch: ModelWorkerBatch):
         draft_input: EagleDraftInput = model_worker_batch.spec_info
@@ -843,6 +855,14 @@ class EAGLEWorkerV2(BaseSpecWorker):
 
         self.auto_spec_engine = auto_spec_engine
 
+        # Update global server_args to use the max step in auto-spec range.
+        # This ensures get_alloc_len_per_decode() allocates enough KV cache
+        # slots for the worst-case step count, preventing memory leaks when
+        # switching between steps at runtime.
+        max_step = max(auto_spec_engine.step_range)
+        self.server_args.speculative_num_steps = max_step
+        self.server_args.speculative_num_draft_tokens = max_step + 1
+
         # Initialize the draft worker's multi-step graphs
         self._draft_worker.init_auto_spec(auto_spec_engine)
 
@@ -878,8 +898,9 @@ class EAGLEWorkerV2(BaseSpecWorker):
             target_runner.graph_runner = target_runner.graph_runner_for_steps[num_steps]
         if num_steps in target_runner.attn_backend_for_steps:
             target_runner.attn_backend = target_runner.attn_backend_for_steps[num_steps]
-        target_runner.server_args.speculative_num_steps = num_steps
-        target_runner.server_args.speculative_num_draft_tokens = num_steps + 1
+        # NOTE: Do NOT update server_args.speculative_num_steps here.
+        # server_args is set to the max step in init_auto_spec so that
+        # get_alloc_len_per_decode() always allocates enough KV cache slots.
 
     def forward_batch_generation(self, model_worker_batch: ModelWorkerBatch):
         if (

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -441,7 +441,7 @@ class EagleDraftWorker(BaseDraftWorker):
             else:
                 # step=1 has no graph runner, allow any BS
                 step_max_bs[num_steps] = max(auto_spec_engine.bs_list)
-        auto_spec_engine.sync_with_graph_capacity(step_max_bs)
+        # auto_spec_engine.sync_with_graph_capacity(step_max_bs)
 
         self._auto_spec_initialized = True
         logger.info(

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -359,8 +359,12 @@ class EagleDraftWorker(BaseDraftWorker):
 
                 saved_steps = self.draft_runner.server_args.speculative_num_steps
                 saved_draft = self.draft_runner.server_args.speculative_num_draft_tokens
+                saved_worker_steps = self.speculative_num_steps
+                saved_worker_draft = self.speculative_num_draft_tokens
                 self.draft_runner.server_args.speculative_num_steps = num_steps
                 self.draft_runner.server_args.speculative_num_draft_tokens = num_steps + 1
+                self.speculative_num_steps = num_steps
+                self.speculative_num_draft_tokens = num_steps + 1
 
                 # Create attention backend for this step
                 draft_backend_factory = DraftBackendFactory(
@@ -402,6 +406,8 @@ class EagleDraftWorker(BaseDraftWorker):
                 # Restore
                 self.draft_runner.server_args.speculative_num_steps = saved_steps
                 self.draft_runner.server_args.speculative_num_draft_tokens = saved_draft
+                self.speculative_num_steps = saved_worker_steps
+                self.speculative_num_draft_tokens = saved_worker_draft
 
         # Restore current backends
         self.draft_attn_backend = self.draft_attn_backend_for_steps[default_step]

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -443,7 +443,6 @@ class EagleDraftWorker(BaseDraftWorker):
             else:
                 # step=1 has no graph runner, allow any BS
                 step_max_bs[num_steps] = max(auto_spec_engine.bs_list)
-        # auto_spec_engine.sync_with_graph_capacity(step_max_bs)
 
         self._auto_spec_initialized = True
         logger.info(


### PR DESCRIPTION
## Motivation

In speculative decoding, the optimal `num_speculative_steps` varies significantly with batch size and draft model accuracy — but users must currently pick a single fixed value at server startup. For example, Qwen3-235B-A22B performs best with step=4 at BS=1 but step=2 at BS=64; GLM-4.7-FP8 performs best with step=7 at BS=1 but step=3 at BS=64. Picking any fixed config leaves throughput on the table:

AutoSpec eliminates this dilemma by dynamically selecting the optimal step count based on the current batch size at runtime. This PR supports AutoSpec on both **Spec** and **SpecV2 (overlap scheduler)** path.

Previously implemented this feature in https://github.com/sgl-project/sglang/pull/17749, now adding support for SpecV2. RFC for previous implementation: https://github.com/sgl-project/sglang/issues/15319.

### Key Advantages

- **Free throughput with zero tuning effort.** Against the common default `num_steps=3`, AutoSpec delivers +3.4% average improvement on Qwen and +6.2% on GLM — up to +12.8% at individual batch sizes.
- **Makes speculative decoding plug-and-play.** Removes the hardest knob to tune — the batch-size-dependent step count — so users don't need to understand the throughput-vs-accept-length trade-off.
- **Adapts to real production traffic.** Continuously adapts to fluctuating concurrency without server restarts.
- **Minimal code footprint.** Hooks into the existing CUDA graph infrastructure with a config-driven step selector. No changes to core scheduling or verification paths.

## Usage

**Basic — add `--auto-spec` to any EAGLE/EAGLE3 launch:**

```bash
python -m sglang.launch_server \
    --model-path Qwen/Qwen3-235B-A22B \
    --speculative-algorithm EAGLE3 \
    --speculative-draft-model-path path/to/eagle-model \
    --speculative-num-steps 3 \
    --auto-spec
```

**With a config file — specify per-batch-size step candidates:**

```bash
python -m sglang.launch_server \
    --model-path Qwen/Qwen3-235B-A22B \
    --speculative-algorithm EAGLE3 \
    --speculative-draft-model-path path/to/eagle-model \
    --auto-spec \
    --speculative-config-file spec_config.json
```

Config file format (`spec_config.json`):

```json
{
    "<path/to/your/model>": {
        "1": [3, 4, 5, 6],
        "2": [3, 4, 5, 6],
        "4": [3, 4, 5, 6],
        "8": [2, 3, 4],
        "16": [2, 3],
        "32": [2, 3],
        "64": [1, 2, 3],
        "128": [1, 2]
    }
}
```

Each key is a batch size, and the value is the list of `num_steps` candidates AutoSpec can choose from. If no config file is provided, built-in defaults are used.

## Modifications

`python/sglang/srt/server_args.py`:

- Add `--auto-spec` flag to enable adaptive speculative decoding
- Add `--speculative-config-file` to load per-batch-size step candidates from a JSON config
- Add `--save-tune-results` to save runtime tuning results to file

`python/sglang/srt/speculative/auto_spec_engine.py` (new):

- Core AutoSpec engine: initialize parameter tuner with per-BS step candidates
- Tune `num_speculative_steps` at runtime based on acceptance rate using EMA metrics
- Memory-aware graph set management: estimate cost per step, trim candidates when GPU memory is insufficient
- Disable metrics calculation when only 1 step candidate is configured per batch size

`python/sglang/srt/speculative/eagle_worker.py` (SpecV1):

- Init attention backends for different `speculative_num_steps`
- Init CUDA graphs for different `speculative_num_steps`
- Update speculative decoding parameters and swap graphs on each decode step

`python/sglang/srt/speculative/eagle_worker_v2.py` (SpecV2):

- Init attention backends for different `speculative_num_steps`
- Init CUDA graphs for different `speculative_num_steps`
- Update speculative decoding parameters and swap graphs on each decode step
- Sync step range with graph capacity to prevent crashes

`python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py`:

- Add `EAGLEDraftCudaGraphRunnerAuto`: manage multiple graph sets indexed by step count
- Swap active graph set when `speculative_num_steps` changes

`python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py`:

- Add `EAGLEDraftExtendCudaGraphRunnerAuto`: manage multiple extend graph sets indexed by step count
- Match parent's buffer dtypes during graph capture

`python/sglang/srt/model_executor/model_runner.py`:

- Init attention backends for different `speculative_num_steps`
- Init CUDA graphs for different `speculative_num_steps`

`python/sglang/srt/model_executor/cuda_graph_runner.py`:

- Support capturing and storing multiple graph sets for auto-spec

`python/sglang/srt/managers/scheduler.py`:

- Integrate AutoSpec engine into the scheduling loop
- Pass batch size info to auto-spec for step selection

`python/sglang/srt/managers/scheduler_output_processor_mixin.py`:

- Collect acceptance rate metrics for auto-spec tuning
- Fix accept_rate logging to use actual draft tokens in auto-spec mode

`docs/advanced_features/auto_spec.md` (new):

- Usage documentation for AutoSpec

## Speed Tests and Profiling

### Benchmark Setup

Parameter | Qwen3-235B-A22B | GLM-4.7-FP8
-- | -- | --
Draft model | EAGLE3  | EAGLE 
Tensor Parallelism | TP8 | TP8
GPUs | 8× | 8×
Dataset | mix dataset (sharegpt, hotpotqa, mtbench, squad) | mix dataset
Output length | 1024 | 1024
Batch sizes | 1, 2, 4, 8, 16, 32, 64 | 1, 2, 4, 8, 16, 32, 64
Runs per config | 3 | 3
Static configs tested | 6 (steps 1–6) | 7 (steps 1–7)

### Results: Qwen3-235B-A22B + EAGLE3

**Raw Throughput (tok/s) — 3-run average:**
Config | BS=1 | BS=2 | BS=4 | BS=8 | BS=16 | BS=32 | BS=64
-- | -- | -- | -- | -- | -- | -- | --
Static 1_1_2 | 162 | 289 | 528 | 823 | 1268 | 2143 | 3353
Static 2_1_3 | 188 | 332 | 568 | 903 | 1451 | 2297 | 3693
Static 3_1_4 | 195 | 332 | 572 | 896 | 1531 | 2352 | 3555
Static 4_1_5 | 199 | 333 | 572 | 911 | 1537 | 2348 | 3400
Static 5_1_6 | 199 | 331 | 569 | 905 | 1464 | 2316 | 3222
Static 6_1_7 | 188 | 311 | 549 | 883 | 1413 | 2239 | 3054
**AutoSpec** | **207** | **351** | **593** | **917** | **1550** | **2348** | **3728**

PS: Static 1_1_2 means: speculative_num_steps=1, topk=1, num_draft=2

**Plots: Throughput & Improvement**
<img width="2986" height="1034" alt="image" src="https://github.com/user-attachments/assets/b7e4bba1-dc14-4964-9597-0b04fc49e561" />

### Results: GLM-4.7-FP8 + EAGLE

**Raw Throughput (tok/s) — 3-run average:**
Config | BS=1 | BS=2 | BS=4 | BS=8 | BS=16 | BS=32 | BS=64
-- | -- | -- | -- | -- | -- | -- | --
Static 1_1_2 | 130 | 236 | 469 | 795 | 1265 | 2090 | 3391
Static 2_1_3 | 167 | 286 | 581 | 972 | 1540 | 2497 | 3836
Static 3_1_4 | 195 | 350 | 648 | 1075 | 1766 | 2761 | 4106
Static 4_1_5 | 204 | 371 | 709 | 1113 | 1704 | 2707 | 3954
Static 5_1_6 | 210 | 377 | 724 | 1124 | 1757 | 2780 | 3987
Static 6_1_7 | 217 | 366 | 721 | 1104 | 1803 | 2748 | 3661
Static 7_1_8 | 219 | 371 | 720 | 1093 | 1796 | 2676 | 3569
**AutoSpec** | **220** | **372** | **727** | **1139** | **1803** | **2832** | **4175**

**Plots: Throughput & Improvement**
<img width="2986" height="1034" alt="image" src="https://github.com/user-attachments/assets/e59d99cf-db91-4214-8ac4-c18199071ee3" />

### Benchmark Conclusion

1. **AutoSpec vs single static config (current user experience).** Users typically pick one fixed `num_steps` (e.g., 3) for all batch sizes. Against this baseline, AutoSpec delivers **+3.4% average on Qwen** and **+6.2% on GLM** (up to +12.8%), because the optimal step shifts from 4→3→2 (Qwen) and 7→5→3 (GLM) as concurrency increases.

2. **AutoSpec vs best-per-BS static (oracle comparison).** Even against the best static config selected independently at each BS — requiring exhaustive benchmarking — AutoSpec matches or wins at 6/7 batch sizes for both models (+2.2% avg Qwen, +0.6% avg GLM), by exploring among candidates at runtime.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
3. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
4. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
5. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
