### PR TITLE
[AMD][Not-to-Merge] Cap KV cache tokens to avoid CK batch prefill int32 overflow

### DIFF
--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -868,6 +868,51 @@ class ModelRunnerKVCacheMixin:
 
         self._init_pools()
 
+    def _apply_ck_int32_cap(
+        self: ModelRunner,
+        token_capacity: int,
+        full_tokens: Optional[int],
+        swa_tokens: Optional[int],
+    ) -> tuple:
+        """Cap KV pool sizes so CK batch prefill int32 offsets don't overflow.
+
+        The CK kernel always receives a 3D KV tensor [tokens, heads, dim],
+        inferring page_block_size=1 regardless of ServerArgs.page_size.
+        With kPageBlockSize=1 < kN0(128), int32 offsets are used, limiting
+        per-layer KV cache to ~4 GB.
+        """
+        kv_heads = self.model_config.get_num_kv_heads(get_attention_tp_size())
+        max_dim = max(self.model_config.head_dim, self.model_config.v_head_dim)
+        stride = kv_heads * max_dim
+        if stride <= 0:
+            return token_capacity, full_tokens, swa_tokens
+
+        cap = (2**31 - 1) // stride
+
+        if token_capacity > cap:
+            logging.warning(
+                f"Capping max_total_tokens from {token_capacity} to {cap} "
+                f"to avoid CK batch prefill int32 overflow "
+                f"(stride={stride}, limit=INT32_MAX)."
+            )
+            token_capacity = cap
+
+        if full_tokens is not None and full_tokens > cap:
+            logging.warning(
+                f"Capping full_max_total_tokens from {full_tokens} to {cap} "
+                f"to avoid CK batch prefill int32 overflow."
+            )
+            full_tokens = cap
+
+        if swa_tokens is not None and swa_tokens > cap:
+            logging.warning(
+                f"Capping swa_max_total_tokens from {swa_tokens} to {cap} "
+                f"to avoid CK batch prefill int32 overflow."
+            )
+            swa_tokens = cap
+
+        return token_capacity, full_tokens, swa_tokens
+
     def _resolve_memory_pool_config(
         self: ModelRunner, pre_model_load_memory: int
     ) -> MemoryPoolConfig:
@@ -880,6 +925,11 @@ class ModelRunnerKVCacheMixin:
         if self.is_hybrid_swa:
             token_capacity, full_tokens, swa_tokens = self._resolve_hybrid_swa_tokens(
                 token_capacity
+            )
+
+        if self.server_args.attention_backend == "aiter":
+            token_capacity, full_tokens, swa_tokens = self._apply_ck_int32_cap(
+                token_capacity, full_tokens, swa_tokens
             )
 
         return MemoryPoolConfig(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
CK batch prefill kernel receives 3D KV tensors [tokens, heads, dim], always inferring page_block_size=1 (regardless of ServerArgs.page_size). With kPageBlockSize=1 < kN0(128), int32 offsets are used, which overflow when per-layer KV cache exceeds ~4GB. Cap all pool sizes (including hybrid SWA full/swa pools) so (tokens * stride) fits in int32. Only affects aiter attention backend (AMD ROCm).
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
Before:
<img width="2552" height="1721" alt="image" src="https://github.com/user-attachments/assets/671e2d1e-56f5-4f9e-a370-c8658d04d237" />
https://github.com/sgl-project/sglang/actions/runs/23945376301/job/69850218730#step:6:5547


After:
<img width="2108" height="713" alt="image" src="https://github.com/user-attachments/assets/7013653f-9956-4a25-acb1-4613a209d973" />
<img width="2603" height="1826" alt="image" src="https://github.com/user-attachments/assets/41cfe8f3-a2e0-48eb-9a09-96ab8be5275f" />
https://github.com/sgl-project/sglang/actions/runs/23952081831/job/69866032440#step:6:3828


<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
