### PR TITLE
[AMD][HIP] NSA: bf16 passthrough from RMSNorm to eliminate FP8 dequantization

### DIFF
--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -21,6 +21,7 @@ from sglang.srt.utils import (
     ceil_align,
     get_bool_env_var,
     is_cuda,
+    is_gfx95_supported,
     is_hip,
     is_npu,
 )
@@ -31,6 +32,8 @@ _is_hip = is_hip()
 _is_npu = is_npu()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 _is_fp8_fnuz = is_fp8_fnuz()
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
+_is_gfx95_supported = is_gfx95_supported()
 if _is_cuda:
     try:
         import deep_gemm
@@ -254,10 +257,10 @@ class Indexer(MultiPlatformOp):
     def _weights_proj_bf16_in_fp32_out(
         self, x: Union[torch.Tensor, Tuple[torch.Tensor, ...]]
     ) -> torch.Tensor:
-        # HIP (ROCm) with aiter: extract the passthrough bf16 tensor from the
+        # aiter (ROCm gfx95): extract the passthrough bf16 tensor from the
         # 3-tuple (fp8, scale, bf16) produced by fused_rms_fp8_group_quant,
         # avoiding an expensive FP8-to-bf16 dequantization.
-        if _is_hip and isinstance(x, tuple) and len(x) == 3:
+        if _use_aiter and _is_gfx95_supported and isinstance(x, tuple) and len(x) == 3:
             x = x[2]
         if deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM:
             weight = self.weights_proj.weight
@@ -1144,11 +1147,16 @@ class Indexer(MultiPlatformOp):
                     act_quant=act_quant,
                 )
 
-            # HIP (ROCm) with aiter: the 3-tuple (fp8, scale, bf16) from
+            # aiter (ROCm gfx95): the 3-tuple (fp8, scale, bf16) from
             # fused_rms_fp8_group_quant is passed directly to _get_logits_head_gate,
             # which extracts the bf16 tensor via _weights_proj_bf16_in_fp32_out,
             # completely skipping the FP8 dequantization path below.
-            if _is_hip and isinstance(x, tuple) and len(x) == 3:
+            if (
+                _use_aiter
+                and _is_gfx95_supported
+                and isinstance(x, tuple)
+                and len(x) == 3
+            ):
                 x_for_gate = x
             elif isinstance(x, tuple):
                 assert len(x) in (

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -251,7 +251,12 @@ class Indexer(MultiPlatformOp):
         else:
             yield
 
-    def _weights_proj_bf16_in_fp32_out(self, x) -> torch.Tensor:
+    def _weights_proj_bf16_in_fp32_out(
+        self, x: Union[torch.Tensor, Tuple[torch.Tensor, ...]]
+    ) -> torch.Tensor:
+        # HIP (ROCm) with aiter: extract the passthrough bf16 tensor from the
+        # 3-tuple (fp8, scale, bf16) produced by fused_rms_fp8_group_quant,
+        # avoiding an expensive FP8-to-bf16 dequantization.
         if _is_hip and isinstance(x, tuple) and len(x) == 3:
             x = x[2]
         if deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM:
@@ -270,7 +275,9 @@ class Indexer(MultiPlatformOp):
         return weights.float()
 
     @torch.compile(dynamic=True)
-    def _project_and_scale_head_gates(self, x: torch.Tensor):
+    def _project_and_scale_head_gates(
+        self, x: Union[torch.Tensor, Tuple[torch.Tensor, ...]]
+    ):
         weights = self._weights_proj_bf16_in_fp32_out(x)
         weights = weights * self.n_heads**-0.5
         return weights
@@ -1137,9 +1144,10 @@ class Indexer(MultiPlatformOp):
                     act_quant=act_quant,
                 )
 
-            # On HIP with 3-tuple (fp8, scale, bf16), pass directly to
-            # _get_logits_head_gate which extracts the bf16 tensor via
-            # _weights_proj_bf16_in_fp32_out, skipping FP8 dequantization.
+            # HIP (ROCm) with aiter: the 3-tuple (fp8, scale, bf16) from
+            # fused_rms_fp8_group_quant is passed directly to _get_logits_head_gate,
+            # which extracts the bf16 tensor via _weights_proj_bf16_in_fp32_out,
+            # completely skipping the FP8 dequantization path below.
             if _is_hip and isinstance(x, tuple) and len(x) == 3:
                 x_for_gate = x
             elif isinstance(x, tuple):

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import contextlib
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import torch
 from einops import rearrange
@@ -251,7 +251,9 @@ class Indexer(MultiPlatformOp):
         else:
             yield
 
-    def _weights_proj_bf16_in_fp32_out(self, x: torch.Tensor) -> torch.Tensor:
+    def _weights_proj_bf16_in_fp32_out(self, x) -> torch.Tensor:
+        if _is_hip and isinstance(x, tuple) and len(x) == 3:
+            x = x[2]
         if deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM:
             weight = self.weights_proj.weight
             out = torch.empty(
@@ -274,7 +276,9 @@ class Indexer(MultiPlatformOp):
         return weights
 
     @torch.compile(dynamic=True)
-    def _get_logits_head_gate(self, x: torch.Tensor, q_scale: torch.Tensor):
+    def _get_logits_head_gate(
+        self, x: Union[torch.Tensor, Tuple[torch.Tensor, ...]], q_scale: torch.Tensor
+    ):
         weights = self._weights_proj_bf16_in_fp32_out(x)
         weights = weights * self.n_heads**-0.5
         weights = weights.unsqueeze(-1) * q_scale * self.softmax_scale
@@ -1133,9 +1137,12 @@ class Indexer(MultiPlatformOp):
                     act_quant=act_quant,
                 )
 
-            # `_get_logits_head_gate` expects a Tensor. For tuple activations, dequantize
-            # to a float tensor here (callsite), keeping `_get_logits_head_gate` backend-agnostic.
-            if isinstance(x, tuple):
+            # On HIP with 3-tuple (fp8, scale, bf16), pass directly to
+            # _get_logits_head_gate which extracts the bf16 tensor via
+            # _weights_proj_bf16_in_fp32_out, skipping FP8 dequantization.
+            if _is_hip and isinstance(x, tuple) and len(x) == 3:
+                x_for_gate = x
+            elif isinstance(x, tuple):
                 assert len(x) in (
                     2,
                     3,

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -485,6 +485,10 @@ class LayerCommunicator:
                             None,
                         )
                     elif _use_aiter and _is_gfx95_supported and ("fp8" in quant_format):
+                        # aiter (ROCm gfx95) fused RMSNorm + FP8 group quant.
+                        # When NSA is active, also preserve the unquantized bf16
+                        # output as a 3-tuple (fp8, scale, bf16) so the NSA
+                        # indexer can skip redundant FP8 dequantization.
                         _nsa_needs_bf16 = get_attn_tp_context().is_nsa
                         hidden_states, _unq_bf16, _, _res = fused_rms_fp8_group_quant(
                             hidden_states,
@@ -520,6 +524,9 @@ class LayerCommunicator:
                             residual,
                         )
                     elif _use_aiter and _is_gfx95_supported and ("fp8" in quant_format):
+                        # aiter (ROCm gfx95) fused RMSNorm + FP8 group quant
+                        # with residual addition. When NSA is active, pack
+                        # the unquantized bf16 as a 3-tuple (fp8, scale, bf16).
                         _nsa_needs_bf16 = get_attn_tp_context().is_nsa
                         hidden_states, _unq_bf16, _, residual = (
                             fused_rms_fp8_group_quant(

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -195,8 +195,10 @@ class AttnTpContext:
         self.allow_input_scattered = False
         self.input_scattered_ = False
         self.attn_inputs_: Optional[AttentionInputs] = None
+        self.is_nsa = False
 
     def init_context(self, q_lora_rank, is_nsa):
+        self.is_nsa = is_nsa
         self.allow_input_scattered = (
             get_global_server_args().enable_attn_tp_input_scattered
             and (_is_cuda or _is_npu)
@@ -483,8 +485,8 @@ class LayerCommunicator:
                             None,
                         )
                     elif _use_aiter and _is_gfx95_supported and ("fp8" in quant_format):
-
-                        hidden_states, _, _, _res = fused_rms_fp8_group_quant(
+                        _nsa_needs_bf16 = get_attn_tp_context().is_nsa
+                        hidden_states, _unq_bf16, _, _res = fused_rms_fp8_group_quant(
                             hidden_states,
                             self.input_layernorm.weight,
                             self.input_layernorm.variance_epsilon,
@@ -494,8 +496,14 @@ class LayerCommunicator:
                             group_size=128,
                             dtype_quant=torch.float8_e4m3fn,
                             res1=None,
-                            output_unquantized_inp1=False,
+                            output_unquantized_inp1=_nsa_needs_bf16,
                         )
+                        if _nsa_needs_bf16:
+                            hidden_states = (
+                                hidden_states[0],
+                                hidden_states[1],
+                                _unq_bf16,
+                            )
 
                     else:
                         hidden_states = self.input_layernorm(hidden_states)
@@ -512,22 +520,27 @@ class LayerCommunicator:
                             residual,
                         )
                     elif _use_aiter and _is_gfx95_supported and ("fp8" in quant_format):
-                        # RMSNorm + FP8 per-group quant
-                        # return hidden_states：
-                        #   out_fp8  : FP8 activation →  a8w8 GEMM
-                        #   out_bs   : block-scale →  gemm_a8w8_blockscale.x_scale
-                        hidden_states, _, _, residual = fused_rms_fp8_group_quant(
-                            hidden_states,
-                            self.input_layernorm.weight,
-                            self.input_layernorm.variance_epsilon,
-                            inp2=None,
-                            inp2_weight=None,
-                            inp2_epsilon=None,
-                            group_size=128,
-                            dtype_quant=torch.float8_e4m3fn,
-                            res1=residual,
-                            output_unquantized_inp1=False,
+                        _nsa_needs_bf16 = get_attn_tp_context().is_nsa
+                        hidden_states, _unq_bf16, _, residual = (
+                            fused_rms_fp8_group_quant(
+                                hidden_states,
+                                self.input_layernorm.weight,
+                                self.input_layernorm.variance_epsilon,
+                                inp2=None,
+                                inp2_weight=None,
+                                inp2_epsilon=None,
+                                group_size=128,
+                                dtype_quant=torch.float8_e4m3fn,
+                                res1=residual,
+                                output_unquantized_inp1=_nsa_needs_bf16,
+                            )
                         )
+                        if _nsa_needs_bf16:
+                            hidden_states = (
+                                hidden_states[0],
+                                hidden_states[1],
+                                _unq_bf16,
+                            )
                     else:
                         hidden_states, residual = self.input_layernorm(
                             hidden_states,


### PR DESCRIPTION


## Motivation

When running GLM-5-FP8 on MI355X with FP8 quantization, the NSA indexer's head gate path (`weights_proj`) requires bf16 input. However, the upstream `fused_rms_fp8_group_quant` only outputs FP8 tensors, discarding the bf16 intermediate from RMSNorm. This forces a redundant FP8-to-bf16 dequantization (4 PyTorch eager kernels, ~18 us per layer) that reconstructs a value already computed inside RMSNorm.

## Modifications

- **`communicator.py`**: When NSA is active on gfx95 with FP8 quantization, set `output_unquantized_inp1=True` in `fused_rms_fp8_group_quant` to preserve the bf16 output at near-zero cost. Pack the result as a 3-tuple `(x_fp8, x_scale, x_bf16)`.
- **`nsa_indexer.py`**: In `_weights_proj_bf16_in_fp32_out`, extract `x[2]` (bf16) directly from the 3-tuple on HIP, completely bypassing dequantization. Skip the dequant block in `forward_cuda` for 3-tuple inputs. Also enable `torch.compile` on HIP for `_get_logits_head_gate` and `_project_and_scale_head_gates` (aligned with PR #22232).

The 3-tuple flows transparently through the existing tuple-handling paths: `Fp8LinearMethod.apply` uses only `x[0]` and `x[1]` for FP8 GEMMs (e.g., `self.wk`), so `x[2]` is naturally ignored by quantized layers.

This change affects the AMD HIP path only.
<img width="1421" height="809" alt="image" src="https://github.com/user-attachments/assets/c616c367-bd48-4e9d-8e2e-79b315ef30b2" />


## Accuracy Tests
GSM8K accuracy:
- GLM-5-FP8 on MI355X (TP8): 0.945
- GLM-5-FP8 on B200 (TP8): 0.949

## Speed Tests and Profiling

GLM-5-FP8 server cmd on MI355:
```
export SGLANG_ROCM_FUSED_DECODE_MLA=0
export ROCM_QUICK_REDUCE_QUANTIZATION=INT4
export SAFETENSORS_FAST_GPU=1
python3 -m sglang.launch_server \
  --model-path GLM-5-FP8 \
  --tp 8 \
  --port 9000 --trust-remote-code \
  --tool-call-parser glm47 --reasoning-parser glm45 \
  --mem-fraction-static 0.85 \
  --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 8}' \
  --nsa-prefill-backend tilelang --nsa-decode-backend tilelang --disable-radix-cache \
  --kv-cache-dtype fp8_e4m3
```

Benchmark on MI355X TP8, concurrency 4/8/16/32/64 averaged (baseline: sglang PR #22232 + aiter PR#2575):

- **ISL/OSL 1k/1k**: Throughput **+3.4%**, TPOT **+3.8%**
- **ISL/OSL 8k/1k**: Throughput **+2.8%**, TPOT **+1.0%**

Per-layer profiling:
- FP8 dequantization: ~18 us → **0 us** (4 kernels eliminated)

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

Made with [Cursor](https://cursor.com)
