### PR TITLE
NSA Indexer: extend skip_logits fast path to speculative modes

### DIFF
--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -699,7 +699,6 @@ class Indexer(MultiPlatformOp):
         metadata: BaseIndexerMetadata,
         return_indices: bool = True,
     ) -> Optional[torch.Tensor]:
-        assert forward_batch.forward_mode.is_extend_without_speculative()
         x_meta = x[0] if isinstance(x, tuple) else x
 
         # Fast path: only compute and store k cache, skip all q and weights ops
@@ -1050,10 +1049,13 @@ class Indexer(MultiPlatformOp):
         if metadata is None:
             return None
 
-        # Determine if should skip topk based on sequence length
-        # We can only skip the logits computation if cuda graph is not involved
+        # When max_kv_len <= index_topk, every block is selected and the topk
+        # result is trivially deterministic.  Skip the expensive Q projection,
+        # logits GEMM, and head-gate computation; only store K and return
+        # trivial indices.  Decode is excluded because it runs under cuda graphs
+        # which require a fixed execution path.
         skip_logits_computation = False
-        if forward_batch.forward_mode.is_extend_without_speculative():
+        if not forward_batch.forward_mode.is_decode_or_idle():
             if forward_batch.seq_lens_cpu is not None:
                 max_kv_len = forward_batch.seq_lens_cpu.max().item()
                 skip_logits_computation = max_kv_len <= self.index_topk


### PR DESCRIPTION
When max_kv_len <= index_topk every KV block is trivially selected, making the full Q projection, head-gate, and fp8_paged_mqa_logits GEMM redundant — the topk result is deterministic regardless of scores.

Previously this fast path (_forward_cuda_k_only) was restricted to is_extend_without_speculative().  Widen it to also cover target_verify and draft_extend, which share the same non-cuda-graph execution model and benefit from the shortcut during early steps when sequences are short.

Decode remains excluded: it runs under CUDA graphs with a fixed replay path.

Changes:
- Remove the is_extend_without_speculative() assert from _forward_cuda_k_only. The method only computes K, stores it, and returns trivial indices via topk_transform; none of that is extend-specific.
- Broaden the skip_logits_computation guard from is_extend_without_speculative() to not is_decode_or_idle().
- Expand the comment to document the trivial-topk condition and why decode is excluded.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
