### PR TITLE
[Fix] use video_grid_thw&image_grid_thw from inputs

### DIFF
--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -581,8 +581,8 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
             ),
             # use the expanded token ids
             input_ids=input_ids.unsqueeze(0),
-            image_grid_thw=getattr(ret, "image_grid_thw", None),
-            video_grid_thw=getattr(ret, "video_grid_thw", None),
+            image_grid_thw=image_grid_thw,
+            video_grid_thw=video_grid_thw,
             second_per_grid_ts=second_per_grid_ts,
             use_audio_in_video=False,
             audio_seqlens=audio_feature_lengths,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When calling MRotaryEmbedding.get_rope_index in QwenVLImageProcessor, the image_grid_thw and video_grid_thw parameters were retrieved directly via getattr(ret, "image_grid_thw", None) and getattr(ret, "video_grid_thw", None) from the raw processor output.However, earlier in the same function, there is already logic that extracts and falls back image_grid_thw and video_grid_thw into local variables — including reading them from dict-format inputs (e.g., pre-processed inputs passed via image_data[0] or video_data[0]). The call to get_rope_index bypassed these already-resolved local variables and re-fetched directly from ret, causing get_rope_index to receive None when grid_thw info comes from dict-format inputs, which leads to incorrect mRoPE position computation.

## Modifications

In python/sglang/srt/multimodal/processors/qwen_vl.py, update the MRotaryEmbedding.get_rope_index call to use the already-resolved local variables instead of re-fetching from ret
This ensures that image_grid_thw and video_grid_thw are correctly resolved regardless of whether they come from the processor output directly or from dict-format pre-processed inputs.

## Accuracy Tests

This fix affects Qwen-VL series models (Qwen2-VL, Qwen2.5-VL, Qwen3-Omni, etc.) when image_grid_thw / video_grid_thw are provided via dict-format pre-processed inputs. Without this fix, mRoPE position indices are computed incorrectly, leading to wrong model outputs. After the fix, model outputs are restored to correctness.

## Speed Tests and Profiling

This is a correctness fix with no impact on inference speed.
## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
