### PR TITLE
[Bugfix] Fix prepare_qkv_latent bypassing LoRA adapters in DeepSeek V2/V3

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1562,11 +1562,16 @@ class DeepseekV2AttentionMLA(
         self, hidden_states: torch.Tensor, forward_batch: ForwardBatch
     ):
         assert self.q_lora_rank is not None
+        # When LoRA adapters wrap the projection, the fused GEMM path reads
+        # .weight directly and would bypass the LoRA delta.  Detect this by
+        # checking for the ``base_layer`` attribute that all LoRA wrappers add.
+        is_lora_wrapped = hasattr(self.fused_qkv_a_proj_with_mqa, "base_layer")
         if (
             (not isinstance(hidden_states, tuple))
             and hidden_states.shape[0] >= 1
             and hidden_states.shape[0] <= 16
             and self.use_min_latency_fused_a_gemm
+            and not is_lora_wrapped
         ):
             qkv_latent = dsv3_fused_a_gemm(
                 hidden_states, self.fused_qkv_a_proj_with_mqa.weight.T


### PR DESCRIPTION
## Motivation

When LoRA adapters are applied to `fused_qkv_a_proj_with_mqa` in DeepSeek V2/V3 models, the fused GEMM optimization path in `prepare_qkv_latent` reads `.weight` directly from the module, completely bypassing the LoRA delta computation (`base(x) + lora_B(lora_A(x))`). This produces incorrect QKV latent values and results in broken inference for LoRA fine-tuned models.

## Root Cause

In `DeepseekV2AttentionMLA.prepare_qkv_latent()` (L1503-1518 of `deepseek_v2.py`):

```python
# Fused path — directly accesses base weight, skipping LoRA
qkv_latent = dsv3_fused_a_gemm(
    hidden_states, self.fused_qkv_a_proj_with_mqa.weight.T
)
```

When LoRA is active, `fused_qkv_a_proj_with_mqa` is wrapped by `BaseLayerWithLoRA`, which exposes `self.weight = self.base_layer.weight` (the original weight). The fused path uses this directly, never applying the LoRA adapters.

The non-fused path correctly goes through the module's `forward()`, which applies the full LoRA computation.

## Fix

Detect the LoRA wrapper by checking for the `base_layer` attribute (present on all `BaseLayerWithLoRA` subclasses) and skip the fused GEMM path when LoRA is active:

```python
is_lora_wrapped = hasattr(self.fused_qkv_a_proj_with_mqa, "base_layer")
if (
    ...
    and self.use_min_latency_fused_a_gemm
    and not is_lora_wrapped  # <-- new guard
):
```

This ensures:
- **Without LoRA**: no behavior change, fused path is used as before
- **With LoRA**: falls back to `forward()` which correctly applies base + LoRA

## Changes

| File | Change |
|------|--------|
| `python/sglang/srt/models/deepseek_v2.py` | Add LoRA detection guard to `prepare_qkv_latent` fused GEMM path |

**Diff**: 1 file, +5 lines

Fixes #22130