### PR TITLE
Fix streaming session KV leak on aborted requests

### DIFF
--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -480,7 +480,21 @@ def release_kv_cache(req: Req, tree_cache: BasePrefixCache, is_insert: bool = Tr
     # Streaming sessions transfer req_pool ownership into SessionSlot objects.
     # Trim any speculative tail before that transfer, otherwise later turns
     # restore only the committed prefix and can strand unreachable KV pages.
-    if isinstance(tree_cache, SessionAwareCache) and getattr(req, "session", None) is not None:
+    #
+    # Aborted streaming-session requests (e.g. input too long) skip the
+    # streaming path entirely.  match_prefix did not restore the slot's KV
+    # state, so the request has a fresh pool slot that should be freed by
+    # cache_finished_req below (which also sets req_pool_idx = None).
+    from sglang.srt.managers.schedule_batch import FINISH_ABORT
+
+    is_streaming_session = (
+        isinstance(tree_cache, SessionAwareCache)
+        and getattr(req, "session", None) is not None
+    )
+    is_aborted_streaming = is_streaming_session and isinstance(
+        getattr(req, "finished_reason", None), FINISH_ABORT
+    )
+    if is_streaming_session and not is_aborted_streaming:
         start_p, end_p = req.pop_overallocated_kv_cache()
         page_size = get_global_server_args().page_size
         if page_size > 1:

--- a/python/sglang/srt/mem_cache/session_aware_cache.py
+++ b/python/sglang/srt/mem_cache/session_aware_cache.py
@@ -183,6 +183,16 @@ class SessionAwareCache(BasePrefixCache):
         if slot is None or slot.req_pool_idx is None:
             return self.inner.match_prefix(params)
 
+        # If the request is destined for abort (e.g. input too long),
+        # do NOT restore the slot's KV state.  set_finish_with_abort
+        # truncates origin_input_ids to [0], so alloc_for_extend would
+        # overwrite the slot's req_to_token row with a 1-token prefix,
+        # destroying the session's accumulated KV mapping.  By skipping
+        # restore, the request gets a fresh pool slot from alloc_for_extend
+        # and the session slot remains untouched.
+        if req.to_finish is not None:
+            return self.inner.match_prefix(params)
+
         slot.restore_to_req(req)
 
         # logprob_start_len is already forced to -1 for streaming sessions
@@ -204,9 +214,29 @@ class SessionAwareCache(BasePrefixCache):
         if not _is_streaming(req):
             return self.inner.cache_finished_req(req, is_insert=is_insert, **kwargs)
 
+        from sglang.srt.managers.schedule_batch import FINISH_ABORT
+
         session_id = req.session.session_id
         slot = self.slots.get(session_id)
         is_first = slot is None
+
+        # When an aborted streaming-session request was scheduled (e.g.
+        # input too long), match_prefix skipped restore_to_req so the
+        # request got a fresh pool slot from alloc_for_extend.  Don't
+        # overwrite the session slot -- free the transient KV and pool slot.
+        if not is_first and isinstance(req.finished_reason, FINISH_ABORT):
+            if req.req_pool_idx is not None:
+                # Free all KV pages allocated for this aborted request.
+                end = req.kv_allocated_len
+                if end > 0:
+                    kv_indices = self.req_to_token_pool.req_to_token[
+                        req.req_pool_idx, :end
+                    ]
+                    self.token_to_kv_pool_allocator.free(kv_indices)
+                self.req_to_token_pool.free_slots.append(req.req_pool_idx)
+                req.req_pool_idx = None
+            return
+
         if is_first:
             slot = SessionSlot()
             self.slots[session_id] = slot


### PR DESCRIPTION
## Summary

Fixes a memory leak in streaming sessions triggered when a request is aborted after accumulating context that exceeds the model's max context length.

**Root cause**: `set_finish_with_abort()` truncates `origin_input_ids` to `[0]` and sets `to_finish` (not `finished_reason`). For streaming sessions, `match_prefix` then restores the slot's `req_pool_idx` to the request. `alloc_for_extend` reuses the same pool slot, overwrites the `req_to_token` row with a 1-token prefix (`kv_committed_len=1`), and the request flows through the normal forward pass since `finished_reason` isn't set yet. After one generated token, `check_finished()` promotes `to_finish` -> `finished_reason`, and `cache_finished_req` saves the corrupted `kv_committed=1` back to the session slot -- destroying the slot's accumulated 32K+ tokens of KV.

The idle memory check then detects negative `session_held` and crashes:
```
ValueError: token_to_kv_pool_allocator memory leak detected!
session_held=-1664
```

**Fix** (3 coordinated changes across 2 files):

- `session_aware_cache.py` **`match_prefix`**: If `req.to_finish` is set, skip `restore_to_req`. The request gets a fresh pool slot from `alloc_for_extend` and the session slot remains untouched.
- `session_aware_cache.py` **`cache_finished_req`**: If the request is `FINISH_ABORT` and a slot already exists, free the request's transient KV and pool slot without saving to the slot.
- `common.py` **`release_kv_cache`**: Skip the streaming-session overalloc trim for aborted requests since their transient KV is handled entirely by `cache_finished_req`.

## Reproduction

```bash
python test/manual/test_streaming_session_small_repro.py \
    --model-path Qwen/Qwen2.5-1.5B-Instruct \
    --rounds 12 --sessions 4 --turns 6 \
    --mem-fraction-static 0.5
```

This accumulates ~32K tokens per session across turns until requests exceed the context window, triggering the abort path.

## Test plan

- [x] Normal streaming session operation (8 rounds, 5 turns) -- no leaks, sessions released cleanly
- [x] Context overflow scenario (12 rounds, 6 turns) -- server survives aborted requests, no leak
- [x] Normal operation after overflow (4 rounds, 4 turns) -- server still works, no leak
- [x] Existing unit test `test_streaming_release_kv_cache_trims_overallocated_tail` passes
- [x] All 3 scenarios run sequentially on same server instance with zero leak detections