### PR TITLE
[sgl-kernel] add SM100a/SM120a/SM103a gencode to FA3 flash_ops for Blackwell

### DIFF
--- a/sgl-kernel/CMakeLists.txt
+++ b/sgl-kernel/CMakeLists.txt
@@ -412,7 +412,7 @@ install(TARGETS common_ops_sm100_build LIBRARY DESTINATION sgl_kernel/sm100)
 
 # ============================ Optional Install: FA3 ============================= #
 # set flash-attention sources file
-# Now FA3 support sm80/sm86/sm90
+# Now FA3 support sm80/sm86/sm90/sm100
 if (SGL_KERNEL_ENABLE_FA3)
     set(SGL_FLASH_KERNEL_CUDA_FLAGS
         "-DNDEBUG"
@@ -436,6 +436,18 @@ if (SGL_KERNEL_ENABLE_FA3)
         "-Xcompiler=-Wconversion"
         "-Xcompiler=-fno-strict-aliasing"
     )
+
+    if ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "12.8" OR SGL_KERNEL_ENABLE_SM100A)
+        list(APPEND SGL_FLASH_KERNEL_CUDA_FLAGS
+            "-gencode=arch=compute_100a,code=sm_100a"
+            "-gencode=arch=compute_120a,code=sm_120a"
+        )
+        if ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "13.0")
+            list(APPEND SGL_FLASH_KERNEL_CUDA_FLAGS
+                "-gencode=arch=compute_103a,code=sm_103a"
+            )
+        endif()
+    endif()
 
     if (ENABLE_BELOW_SM90)
         list(APPEND SGL_FLASH_KERNEL_CUDA_FLAGS


### PR DESCRIPTION
## Problem

\`SGL_FLASH_KERNEL_CUDA_FLAGS\` (used to compile the \`flash_ops\` FA3 target) only targets \`sm_90a\`. \`SGL_KERNEL_CUDA_FLAGS\` already correctly gates \`sm_100a\`/\`sm_120a\`/\`sm_103a\` on \`CUDA >= 12.8\`, but \`SGL_FLASH_KERNEL_CUDA_FLAGS\` was never updated to match.

On Blackwell (B200, SM_100), any codepath that calls FA3 kernels crashes with:
\`\`\`
CUDA error (hopper/flash_fwd_launch_template.h:167):
no kernel image is available for execution on the device
\`\`\`

This affects EAGLE speculative decoding with models that have SWA layers (e.g. \`stepfun-ai/Step-3.5-Flash-FP8\`) even when \`--attention-backend fa4\` is explicitly set, because EAGLE graph capture invokes FA3 kernels from \`flash_ops\` during draft model initialization on the SWA layers.

## Fix

Mirror the existing \`SGL_KERNEL_CUDA_FLAGS\` SM100 conditional into \`SGL_FLASH_KERNEL_CUDA_FLAGS\`:

\`\`\`cmake
if ("\${CUDA_VERSION}" VERSION_GREATER_EQUAL "12.8" OR SGL_KERNEL_ENABLE_SM100A)
    list(APPEND SGL_FLASH_KERNEL_CUDA_FLAGS
        "-gencode=arch=compute_100a,code=sm_100a"
        "-gencode=arch=compute_120a,code=sm_120a"
    )
    if ("\${CUDA_VERSION}" VERSION_GREATER_EQUAL "13.0")
        list(APPEND SGL_FLASH_KERNEL_CUDA_FLAGS
            "-gencode=arch=compute_103a,code=sm_103a"
        )
    endif()
endif()
\`\`\`

## Test

Tested on 8x B200 (SM_100), CUDA 13.0, \`lmsysorg/sglang:dev-cu13\`, running \`stepfun-ai/Step-3.5-Flash-FP8\` with EAGLE speculative decoding TP8 EP8. Previously crashed on startup, works after this patch.