### PR TITLE
Add fast-fail to multimodal-gen CI

### DIFF
--- a/.github/workflows/pr-test-multimodal-gen.yml
+++ b/.github/workflows/pr-test-multimodal-gen.yml
@@ -175,6 +175,7 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
+      - uses: ./.github/actions/check-stage-health
 
       - uses: ./.github/actions/check-maintenance
 

--- a/python/sglang/multimodal_gen/test/run_suite.py
+++ b/python/sglang/multimodal_gen/test/run_suite.py
@@ -174,12 +174,14 @@ def collect_test_items(files, filter_expr=None):
     return test_items
 
 
-def run_pytest(files, filter_expr=None):
+def run_pytest(files, filter_expr=None, exitfirst=False):
     if not files:
         print("No files to run.")
         return 0
 
     base_cmd = [sys.executable, "-m", "pytest", "-s", "-v"]
+    if exitfirst:
+        base_cmd.append("-x")
 
     # Add pytest -k filter if provided
     if filter_expr:
@@ -349,7 +351,8 @@ def main():
     print(f"Running {len(my_items)} items in this shard: {', '.join(my_items)}")
 
     # 4. execute with the specific test items
-    exit_code = run_pytest(my_items)
+    # Fast-fail: stop on first failure unless --continue-on-error is set
+    exit_code = run_pytest(my_items, exitfirst=not args.continue_on_error)
 
     # Print tests again at the end for visibility
     msg = "\n" + tabulate.tabulate(rows, headers=headers, tablefmt="psql") + "\n"


### PR DESCRIPTION
## Summary
- Add missing `check-stage-health` step to `multimodal-gen-test-1-b200` job (the only multimodal-gen job without it)
- Add pytest `-x` (exitfirst) to `run_suite.py` when `--continue-on-error` is not set, so PR runs stop on first test failure instead of running all tests

## Test plan
- [ ] Verify `multimodal-gen-test-1-b200` job now includes `check-stage-health` step
- [ ] Verify pytest `-x` is passed in PR runs (no `--continue-on-error`)
- [ ] Verify scheduled runs still use `--continue-on-error` (no `-x`)