### PR TITLE
[fix] Fix writer lock deadlock in update_weights_from_ipc during pause_generation

### DIFF
--- a/python/sglang/srt/managers/tokenizer_communicator_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_communicator_mixin.py
@@ -712,8 +712,20 @@ class TokenizerCommunicatorMixin:
                 self.server_args.dp_size == 1 or self.server_args.enable_dp_attention
             ), "dp_size must be 1 or dp attention must be enabled for update weights from IPC"
             logger.info("Starting IPC weight update")
-            # This means that weight sync cannot run while requests are in progress.
-            async with self.model_update_lock.writer_lock:
+
+            # Skip the writer lock when paused: readers are blocked on
+            # is_pause_cond so no concurrent inference can race, and
+            # waiting for the writer lock would deadlock because existing
+            # readers are stuck waiting on the paused scheduler.
+            async with self.is_pause_cond:
+                is_paused = self.is_pause
+
+            lock_context = (
+                self.model_update_lock.writer_lock
+                if not is_paused
+                else nullcontext()
+            )
+            async with lock_context:
                 result = (await self.update_weights_from_ipc_communicator(obj))[0]
                 success, message = result.success, result.message
         except Exception as e:

--- a/python/sglang/srt/managers/tokenizer_communicator_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_communicator_mixin.py
@@ -721,9 +721,7 @@ class TokenizerCommunicatorMixin:
                 is_paused = self.is_pause
 
             lock_context = (
-                self.model_update_lock.writer_lock
-                if not is_paused
-                else nullcontext()
+                self.model_update_lock.writer_lock if not is_paused else nullcontext()
             )
             async with lock_context:
                 result = (await self.update_weights_from_ipc_communicator(obj))[0]


### PR DESCRIPTION
## Summary
- Fix writer lock deadlock in `update_weights_from_ipc` when scheduler is in `pause_generation` mode
- When the scheduler is paused, existing readers are blocked on `is_pause_cond`, so acquiring the writer lock would deadlock. This change skips the writer lock when paused (using `nullcontext()`) since no concurrent inference can race in that state.
- Port of sgl-project/sglang#22211 to main branch (only the deadlock fix, single file change)

## Test plan
- [ ] Verify IPC weight update completes without deadlock when scheduler is paused
- [ ] Verify normal (non-paused) weight updates still acquire the writer lock correctly
- [ ] Run existing e2e tests to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)