### PR TITLE
[Whisper] Fix audio feature device placement in encoder forward

### DIFF
--- a/python/sglang/srt/models/whisper.py
+++ b/python/sglang/srt/models/whisper.py
@@ -458,8 +458,12 @@ class WhisperForConditionalGeneration(torch.nn.Module):
                     features.device, non_blocking=True
                 )
 
+                # Move features to the same device as model weights
+                device = self.encoder.conv1.weight.device
                 req_encoder_output = self.encoder(
-                    features.to(dtype), encoder_position_ids, forward_batch
+                    features.to(device=device, dtype=dtype),
+                    encoder_position_ids.to(device),
+                    forward_batch,
                 )
                 req_encoder_output = req_encoder_output.squeeze(0)
                 encoder_list.append(req_encoder_output)


### PR DESCRIPTION
## Motivation

After #21190 enabled CUDA graph for Whisper, the server crashes on the first transcription request with:

```
RuntimeError: Expected all tensors to be on the same device, but got
weight is on cuda:0, different from other tensors on cpu
```

This happens because `features.to(dtype)` at line 462 of `whisper.py` only converts the dtype without moving the tensor to GPU. The multimodal processor returns `input_features` as a CPU tensor (via HuggingFace's feature extractor with `return_tensors="pt"`), and the default `keep_mm_feature_on_device=False` keeps them on CPU. When the encoder's `conv1` (on CUDA) receives a CPU input, `F.conv1d` fails.

Similarly, `encoder_position_ids` is created on `features.device` (CPU) via `torch.arange(...).to(features.device)`, so it also lands on CPU.

## Modifications

- Changed `features.to(dtype)` to `features.to(device=device, dtype=dtype)` where `device` is obtained from `self.encoder.conv1.weight.device`
- Added `encoder_position_ids.to(device)` to move position IDs to the same device

## Repro

```bash
# Terminal 1: launch server
python -m sglang.launch_server --model-path openai/whisper-large-v3 --port 30000

# Terminal 2: run benchmark (auto-downloads dataset, crashes on first request)
python benchmark/asr/bench_sglang.py \
  --base-url http://127.0.0.1:30000 \
  --model openai/whisper-large-v3 \
  --api-type transcription --language en --concurrency 1
```

Server crashes with:
```
File "sglang/srt/models/whisper.py", line 462, in forward
    req_encoder_output = self.encoder(
File "sglang/srt/models/whisper.py", line 295, in forward
    inputs_embeds = torch.nn.functional.gelu(self.conv1(input_features))
RuntimeError: Expected all tensors to be on the same device, but got
weight is on cuda:0, different from other tensors on cpu
```

## Benchmark (after fix)

Tested on NVIDIA GB300, `openai/whisper-large-v3`, dataset `D4nt3/esb-datasets-earnings22-validation-tiny-filtered` (511 samples), concurrency=1:

|                     | CUDA graph    | No CUDA graph |
|---------------------|---------------|---------------|
| default             | 4.74 req/s    | 1.01 req/s    |
| keep_mm_on_device   | 2.29 req/s    | 1.19 req/s    |

- **WER: 12.78%** across all configs (matches #21190)
- CUDA graph gives **4.7x** throughput improvement on B300

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Provide accuracy and speed benchmark results.