### PR TITLE
[CI] Move manual-only nightly tests out of test/registered/

### DIFF
--- a/test/manual/test_deepseek_v31.py
+++ b/test/manual/test_deepseek_v31.py
@@ -1,48 +1,53 @@
 import unittest
 
 from sglang.test.accuracy_test_runner import AccuracyTestParams
-from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.performance_test_runner import PerformanceTestParams
 from sglang.test.run_combined_tests import run_combined_tests
 from sglang.test.test_utils import ModelLaunchSettings
 
-# Runs on both H200 and B200 via nightly-8-gpu-common suite
-register_cuda_ci(est_time=1800, suite="nightly-8-gpu-common", nightly=True)
-
-GLM_4_6_FP8_MODEL_PATH = "zai-org/GLM-4.6-FP8"
+DEEPSEEK_V31_MODEL_PATH = "deepseek-ai/DeepSeek-V3.1"
 
 
-class TestGLM46FP8(unittest.TestCase):
-    """Unified test class for GLM-4.6-FP8 performance and accuracy.
+class TestDeepseekV31(unittest.TestCase):
+    """Unified test class for DeepSeek-V3.1 performance and accuracy.
 
-    Single variant with simple TP=8 configuration.
-    Runs BOTH:
+    Two variants:
+    - basic: Standard TP=8
+    - mtp: TP=8 + EAGLE speculative decoding
+
+    Each variant runs BOTH:
     - Performance test (using NightlyBenchmarkRunner)
     - Accuracy test (using run_eval with mgsm_en)
     """
 
-    def test_glm_46_fp8_all_variants(self):
-        """Run performance and accuracy for GLM-4.6-FP8."""
+    def test_deepseek_v31_all_variants(self):
+        """Run performance and accuracy for all DeepSeek-V3.1 variants."""
+        # Define base arguments shared by most variants
         base_args = [
             "--tp=8",
             "--trust-remote-code",
+            "--model-loader-extra-config",
+            '{"enable_multithread_load": true}',
         ]
         mtp_args = [
             "--speculative-algorithm=EAGLE",
             "--speculative-num-steps=3",
             "--speculative-eagle-topk=1",
             "--speculative-num-draft-tokens=4",
+            "--mem-frac=0.7",
         ]
 
         variants = [
+            # Variant: "basic" - Standard TP=8
             ModelLaunchSettings(
-                GLM_4_6_FP8_MODEL_PATH,
+                DEEPSEEK_V31_MODEL_PATH,
                 tp_size=8,
                 extra_args=base_args,
                 variant="TP8",
             ),
+            # Variant: "mtp" - TP=8 + EAGLE speculative decoding
             ModelLaunchSettings(
-                GLM_4_6_FP8_MODEL_PATH,
+                DEEPSEEK_V31_MODEL_PATH,
                 tp_size=8,
                 extra_args=base_args + mtp_args,
                 env={"SGLANG_ENABLE_SPEC_V2": "1"},
@@ -52,10 +57,12 @@ class TestGLM46FP8(unittest.TestCase):
 
         run_combined_tests(
             models=variants,
-            test_name="GLM-4.6-FP8",
-            accuracy_params=AccuracyTestParams(dataset="gsm8k", baseline_accuracy=0.80),
+            test_name="DeepSeek-V3.1",
+            accuracy_params=AccuracyTestParams(
+                dataset="gsm8k", baseline_accuracy=0.935
+            ),
             performance_params=PerformanceTestParams(
-                profile_dir="performance_profiles_glm_4_6_fp8",
+                profile_dir="performance_profiles_deepseek_v31",
             ),
         )
 

--- a/test/manual/test_glm_46_fp8.py
+++ b/test/manual/test_glm_46_fp8.py
@@ -1,57 +1,44 @@
 import unittest
 
 from sglang.test.accuracy_test_runner import AccuracyTestParams
-from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.performance_test_runner import PerformanceTestParams
 from sglang.test.run_combined_tests import run_combined_tests
 from sglang.test.test_utils import ModelLaunchSettings
 
-# Runs on both H200 and B200 via nightly-8-gpu-common suite
-register_cuda_ci(est_time=5400, suite="nightly-8-gpu-common", nightly=True)
-
-DEEPSEEK_V31_MODEL_PATH = "deepseek-ai/DeepSeek-V3.1"
+GLM_4_6_FP8_MODEL_PATH = "zai-org/GLM-4.6-FP8"
 
 
-class TestDeepseekV31(unittest.TestCase):
-    """Unified test class for DeepSeek-V3.1 performance and accuracy.
+class TestGLM46FP8(unittest.TestCase):
+    """Unified test class for GLM-4.6-FP8 performance and accuracy.
 
-    Two variants:
-    - basic: Standard TP=8
-    - mtp: TP=8 + EAGLE speculative decoding
-
-    Each variant runs BOTH:
+    Single variant with simple TP=8 configuration.
+    Runs BOTH:
     - Performance test (using NightlyBenchmarkRunner)
     - Accuracy test (using run_eval with mgsm_en)
     """
 
-    def test_deepseek_v31_all_variants(self):
-        """Run performance and accuracy for all DeepSeek-V3.1 variants."""
-        # Define base arguments shared by most variants
+    def test_glm_46_fp8_all_variants(self):
+        """Run performance and accuracy for GLM-4.6-FP8."""
         base_args = [
             "--tp=8",
             "--trust-remote-code",
-            "--model-loader-extra-config",
-            '{"enable_multithread_load": true}',
         ]
         mtp_args = [
             "--speculative-algorithm=EAGLE",
             "--speculative-num-steps=3",
             "--speculative-eagle-topk=1",
             "--speculative-num-draft-tokens=4",
-            "--mem-frac=0.7",
         ]
 
         variants = [
-            # Variant: "basic" - Standard TP=8
             ModelLaunchSettings(
-                DEEPSEEK_V31_MODEL_PATH,
+                GLM_4_6_FP8_MODEL_PATH,
                 tp_size=8,
                 extra_args=base_args,
                 variant="TP8",
             ),
-            # Variant: "mtp" - TP=8 + EAGLE speculative decoding
             ModelLaunchSettings(
-                DEEPSEEK_V31_MODEL_PATH,
+                GLM_4_6_FP8_MODEL_PATH,
                 tp_size=8,
                 extra_args=base_args + mtp_args,
                 env={"SGLANG_ENABLE_SPEC_V2": "1"},
@@ -61,12 +48,10 @@ class TestDeepseekV31(unittest.TestCase):
 
         run_combined_tests(
             models=variants,
-            test_name="DeepSeek-V3.1",
-            accuracy_params=AccuracyTestParams(
-                dataset="gsm8k", baseline_accuracy=0.935
-            ),
+            test_name="GLM-4.6-FP8",
+            accuracy_params=AccuracyTestParams(dataset="gsm8k", baseline_accuracy=0.80),
             performance_params=PerformanceTestParams(
-                profile_dir="performance_profiles_deepseek_v31",
+                profile_dir="performance_profiles_glm_4_6_fp8",
             ),
         )
 

--- a/test/manual/test_qwen3_235b.py
+++ b/test/manual/test_qwen3_235b.py
@@ -1,13 +1,9 @@
 import unittest
 
 from sglang.test.accuracy_test_runner import AccuracyTestParams
-from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.performance_test_runner import PerformanceTestParams
 from sglang.test.run_combined_tests import run_combined_tests
 from sglang.test.test_utils import ModelLaunchSettings, is_blackwell_system
-
-# Runs on both H200 and B200 via nightly-8-gpu-common suite
-register_cuda_ci(est_time=1800, suite="nightly-8-gpu-common", nightly=True)
 
 QWEN3_235B_FP8_MODEL_PATH = "Qwen/Qwen3-235B-A22B-Instruct-2507-FP8"
 QWEN3_235B_EAGLE3_MODEL_PATH = (


### PR DESCRIPTION
## Summary
- Move `test_qwen3_235b.py`, `test_deepseek_v31.py`, and `test_glm_46_fp8.py` from `test/registered/8-gpu-models/` to `test/manual/`
- Remove `register_cuda_ci()` calls from deepseek_v31 and glm_46_fp8
- These are manual-only nightly tests placed in `test/registered/` by #22288, breaking `collect_tests()` with `ValueError: No CI registry found`

## Test plan
- [x] File moves + registry removal, no logic changes