### PR TITLE
[tiny] Fix TOCTOU race in pause-aware weight update locking

### DIFF
--- a/python/sglang/srt/managers/tokenizer_communicator_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_communicator_mixin.py
@@ -712,8 +712,20 @@ class TokenizerCommunicatorMixin:
                 self.server_args.dp_size == 1 or self.server_args.enable_dp_attention
             ), "dp_size must be 1 or dp attention must be enabled for update weights from IPC"
             logger.info("Starting IPC weight update")
-            # This means that weight sync cannot run while requests are in progress.
-            async with self.model_update_lock.writer_lock:
+
+            # Skip the writer lock when paused: readers are blocked on
+            # is_pause_cond so no concurrent inference can race, and
+            # waiting for the writer lock would deadlock because existing
+            # readers are stuck waiting on the paused scheduler.
+            async with self.is_pause_cond:
+                is_paused = self.is_pause
+
+            lock_context = (
+                self.model_update_lock.writer_lock
+                if not is_paused
+                else nullcontext()
+            )
+            async with lock_context:
                 result = (await self.update_weights_from_ipc_communicator(obj))[0]
                 success, message = result.success, result.message
         except Exception as e:

--- a/python/sglang/srt/managers/tokenizer_communicator_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_communicator_mixin.py
@@ -721,9 +721,7 @@ class TokenizerCommunicatorMixin:
                 is_paused = self.is_pause
 
             lock_context = (
-                self.model_update_lock.writer_lock
-                if not is_paused
-                else nullcontext()
+                self.model_update_lock.writer_lock if not is_paused else nullcontext()
             )
             async with lock_context:
                 result = (await self.update_weights_from_ipc_communicator(obj))[0]

--- a/python/sglang/srt/managers/tokenizer_communicator_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_communicator_mixin.py
@@ -623,10 +623,7 @@ class TokenizerCommunicatorMixin:
         if obj.abort_all_requests:
             self.abort_request(abort_all=True)
 
-        # When paused, hold is_pause_cond during the update to prevent
-        # unpause from racing (TOCTOU). In practice this race is near
-        # impossible since callers always do pause → update → resume
-        # sequentially, but holding the lock makes it correct by construction.
+        # Hold is_pause_cond while updating to prevent unpause from racing.
         async with self.is_pause_cond:
             is_paused = self.is_pause
             if is_paused:
@@ -714,8 +711,6 @@ class TokenizerCommunicatorMixin:
             ), "dp_size must be 1 or dp attention must be enabled for update weights from IPC"
             logger.info("Starting IPC weight update")
 
-            # When paused, hold is_pause_cond during the update so
-            # unpause cannot race between the check and the update.
             async with self.is_pause_cond:
                 is_paused = self.is_pause
                 if is_paused:

--- a/python/sglang/srt/managers/tokenizer_communicator_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_communicator_mixin.py
@@ -6,7 +6,6 @@ import logging
 import time
 import uuid
 from collections import deque
-from contextlib import nullcontext
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -624,15 +623,18 @@ class TokenizerCommunicatorMixin:
         if obj.abort_all_requests:
             self.abort_request(abort_all=True)
 
-        # Immediately update the weights if the engine is in paused state
+        # When paused, hold is_pause_cond during the update to prevent
+        # unpause from racing (TOCTOU). In practice this race is near
+        # impossible since callers always do pause → update → resume
+        # sequentially, but holding the lock makes it correct by construction.
         async with self.is_pause_cond:
             is_paused = self.is_pause
+            if is_paused:
+                results = await self.update_weights_from_distributed_communicator(obj)
 
-        lock_context = (
-            self.model_update_lock.writer_lock if not is_paused else nullcontext()
-        )
-        async with lock_context:
-            results = await self.update_weights_from_distributed_communicator(obj)
+        if not is_paused:
+            async with self.model_update_lock.writer_lock:
+                results = await self.update_weights_from_distributed_communicator(obj)
 
         success, message = _Communicator.merge_results(results)
         if success and obj.weight_version is not None:
@@ -682,15 +684,14 @@ class TokenizerCommunicatorMixin:
         if obj.abort_all_requests:
             self.abort_request(abort_all=True)
 
-        # Immediately update the weights if the engine is in paused state
         async with self.is_pause_cond:
             is_paused = self.is_pause
+            if is_paused:
+                results = await self.update_weights_from_tensor_communicator(obj)
 
-        lock_context = (
-            self.model_update_lock.writer_lock if not is_paused else nullcontext()
-        )
-        async with lock_context:
-            results = await self.update_weights_from_tensor_communicator(obj)
+        if not is_paused:
+            async with self.model_update_lock.writer_lock:
+                results = await self.update_weights_from_tensor_communicator(obj)
 
         success, message = _Communicator.merge_results(results)
         if success and obj.weight_version is not None:
@@ -713,19 +714,18 @@ class TokenizerCommunicatorMixin:
             ), "dp_size must be 1 or dp attention must be enabled for update weights from IPC"
             logger.info("Starting IPC weight update")
 
-            # Skip the writer lock when paused: readers are blocked on
-            # is_pause_cond so no concurrent inference can race, and
-            # waiting for the writer lock would deadlock because existing
-            # readers are stuck waiting on the paused scheduler.
+            # When paused, hold is_pause_cond during the update so
+            # unpause cannot race between the check and the update.
             async with self.is_pause_cond:
                 is_paused = self.is_pause
+                if is_paused:
+                    result = (await self.update_weights_from_ipc_communicator(obj))[0]
+                    success, message = result.success, result.message
 
-            lock_context = (
-                self.model_update_lock.writer_lock if not is_paused else nullcontext()
-            )
-            async with lock_context:
-                result = (await self.update_weights_from_ipc_communicator(obj))[0]
-                success, message = result.success, result.message
+            if not is_paused:
+                async with self.model_update_lock.writer_lock:
+                    result = (await self.update_weights_from_ipc_communicator(obj))[0]
+                    success, message = result.success, result.message
         except Exception as e:
             error_msg = f"IPC weight update failed: {str(e)}"
             logger.error(error_msg)


### PR DESCRIPTION
## Summary
Fix a theoretical TOCTOU (time-of-check to time-of-use) race in the pause-aware weight update locking pattern across `update_weights_from_distributed`, `update_weights_from_tensor`, and `update_weights_from_ipc`.

**Before**: `is_pause` was read under `is_pause_cond` lock, then the lock was released, then a lock decision was made based on the stale value. Between the read and the use, `resume_generation` could change `is_pause` to `False`, causing a weight update to run without the writer lock while inference resumes.

**After**: when paused, the weight update runs inside the `is_pause_cond` scope, so `resume_generation` cannot proceed until the update completes. This closes the TOCTOU window.

**In practice this race is near impossible** — callers always do `pause → update_weights → resume` sequentially, so there is no concurrent unpause. But holding the lock makes it correct by construction.

Also removes the now-unused `nullcontext` import.

## Test plan
- [ ] Existing weight update tests pass (same runtime behavior, just tighter locking)