### PR TITLE
Lazy import flash_attention_v4 to avoid loading flash_attn.cute at startup

### DIFF
--- a/python/sglang/jit_kernel/flash_attention.py
+++ b/python/sglang/jit_kernel/flash_attention.py
@@ -4,8 +4,6 @@ import torch
 
 from .flash_attention_v3 import flash_attn_varlen_func as fa3_flash_attn_varlen_func
 from .flash_attention_v3 import flash_attn_with_kvcache as fa3_flash_attn_with_kvcache
-from .flash_attention_v4 import flash_attn_varlen_func as fa4_flash_attn_varlen_func
-from .flash_attention_v4 import flash_attn_with_kvcache as fa4_flash_attn_with_kvcache
 
 
 def flash_attn_with_kvcache(
@@ -168,6 +166,10 @@ def flash_attn_with_kvcache(
             sinks=sinks,
         )
     elif ver == 4:
+        from .flash_attention_v4 import (
+            flash_attn_with_kvcache as fa4_flash_attn_with_kvcache,
+        )
+
         return fa4_flash_attn_with_kvcache(
             q,
             k_cache,
@@ -260,6 +262,10 @@ def flash_attn_varlen_func(
             sinks=sinks,
         )
     elif ver == 4:
+        from .flash_attention_v4 import (
+            flash_attn_varlen_func as fa4_flash_attn_varlen_func,
+        )
+
         return fa4_flash_attn_varlen_func(
             q,
             k,

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -551,9 +551,9 @@ def download_safetensors_index_file_from_hf(
         # If file not found on remote or locally, we should not fail since
         # only some models will have index_file.
         except huggingface_hub.utils.EntryNotFoundError:
-            logger.info("No %s found in remote.", index_file)
+            logger.debug("No %s found in remote.", index_file)
         except huggingface_hub.utils.LocalEntryNotFoundError:
-            logger.info("No %s found in local cache.", index_file)
+            logger.debug("No %s found in local cache.", index_file)
 
 
 # For models like Mistral-7B-v0.3, there are both sharded

--- a/python/sglang/srt/utils/numa_utils.py
+++ b/python/sglang/srt/utils/numa_utils.py
@@ -56,7 +56,7 @@ def _mp_set_executable(executable: str, debug_str: str):
 
     old_executable = os.fsdecode(multiprocessing.spawn.get_executable())
     multiprocessing.spawn.set_executable(executable)
-    logger.info(f"mp.set_executable {old_executable} -> {executable} ({debug_str})")
+    logger.debug(f"mp.set_executable {old_executable} -> {executable} ({debug_str})")
     try:
         yield
     finally:
@@ -64,7 +64,7 @@ def _mp_set_executable(executable: str, debug_str: str):
             os.fsdecode(multiprocessing.spawn.get_executable()) == executable
         ), f"{multiprocessing.spawn.get_executable()=}"
         multiprocessing.spawn.set_executable(old_executable)
-        logger.info(f"mp.set_executable revert to {old_executable}")
+        logger.debug(f"mp.set_executable revert to {old_executable}")
 
 
 def get_numa_node_if_available(server_args: ServerArgs, gpu_id: int) -> Optional[int]:


### PR DESCRIPTION
## Summary
- Move flash_attention_v4 imports from module level to inside the `ver==4` branches in `flash_attention.py`
- Prevents `flash_attn.cute` (and its 5 JIT cache inits + cutlass package walk) from being triggered during server startup when FA4 is not in use
- After the first call the import is just a `sys.modules` dict lookup with negligible overhead

## Motivation
During startup of any model (e.g. `Qwen/Qwen3-0.6B`), the model registry eagerly imports all model modules, which pulls in vision model files that import `vision.py`, which imports `flash_attention.py`, which eagerly imports `flash_attention_v4.py`, which triggers `from flash_attn.cute import ...`. This causes:
1. A CUTE_DSL WARNING about cutlass package walk errors
2. 10 lines of "Persistent cache disabled, using in-memory JIT cache" spam (5 JIT caches x 2 duplicate log handlers)

## Test plan
- [ ] Verify server startup with `--model-path Qwen/Qwen3-0.6B` no longer shows flash_attn.cute log spam
- [ ] Verify FA4 backend still works when explicitly selected
