### PR TITLE
Use dedicated runner label for deepep 8-GPU tests

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1162,7 +1162,7 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    runs-on: 8-gpu-h200
+    runs-on: 8-gpu-h200-deepep
     timeout-minutes: 240
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- Change `stage-c-test-deepep-8-gpu-h200` job from `runs-on: 8-gpu-h200` to `runs-on: 8-gpu-h200-deepep`
- DeepEP tests require working RDMA/nvshmem for inter-GPU communication
- Ion H200 machines have intermittent RDMA port failures (PORT_DOWN states), causing `ibv_modify_qp` timeouts and nvshmem initialization failures

## Root cause
Ion H200 machines have RDMA ports in PORT_DOWN state:
- ion-3: `mlx5_3` PORT_DOWN
- ion-4: `rocep68s0` and `rocep40s0f1` PORT_DOWN

This causes `ibv_modify_qp failed` errors when nvshmem tries to establish QP connections for DeepEP.

Example failures:
- ion-4: https://github.com/sgl-project/sglang/actions/runs/24058178208/job/70184303962
- ion-3: https://github.com/sgl-project/sglang/actions/runs/23956885485/job/69903352422

## Fix
Use a dedicated `8-gpu-h200-deepep` label so deepep tests only run on machines with verified RDMA connectivity (e.g., GMI H200). The `8-gpu-h200-deepep` label needs to be manually added to the target runner(s).

## Test plan
- [x] Manually add `8-gpu-h200-deepep` label to GMI H200 runner
- [ ] DeepEP 8-GPU tests run only on GMI and pass consistently