### PR TITLE
[Bugfix] Fix GLM-4.7-FP8 EAGLE accept_len=1.00 due to draft model loading with incorrect quant_config

### DIFF
--- a/python/sglang/srt/models/glm4_moe_nextn.py
+++ b/python/sglang/srt/models/glm4_moe_nextn.py
@@ -36,7 +36,7 @@ from sglang.srt.layers.vocab_parallel_embedding import (
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.models.glm4_moe import Glm4MoeDecoderLayer, Glm4MoeForCausalLM
 from sglang.srt.server_args import get_global_server_args
-from sglang.srt.utils import add_prefix
+from sglang.srt.utils import add_prefix, is_npu
 
 logger = logging.getLogger(__name__)
 
@@ -128,10 +128,12 @@ class Glm4MoeForCausalLMNextN(Glm4MoeForCausalLM):
         nn.Module.__init__(self)
         self.config = config
         self.tp_size = get_tensor_model_parallel_world_size()
-        self.needs_quant_draft = (
-            get_global_server_args().speculative_draft_model_quantization
-        )
-        quant_config = quant_config if self.needs_quant_draft else None
+        self.needs_quant_draft = True
+        if is_npu():
+            self.needs_quant_draft = (
+                get_global_server_args().speculative_draft_model_quantization
+            )
+            quant_config = quant_config if self.needs_quant_draft else None
         self.model = Glm4MoeModelNextN(
             config, quant_config, prefix=add_prefix("model", prefix)
         )


### PR DESCRIPTION
## Motivation

PR #19246 (`[NPU] optimize glm4.7`) introduced support for running unquantized draft models on NPU by conditionally setting `quant_config = None` in `Glm4MoeForCausalLMNextN`. However, this breaks GLM-4.7-FP8 EAGLE speculative decoding on GPU: when the user does not explicitly pass `--speculative-draft-model-quantization`, the flag evaluates to falsy (`None`), causing the FP8 draft model to load with `quant_config = None`. This makes all draft predictions garbage, resulting in `spec_accept_length ≈ 1.0` (all draft tokens rejected).

## Fix

  Guard the `quant_config` override behind `is_npu()` so it only takes effect on NPU. On GPU, the draft model always inherits the target model's `quant_config` as originally intended.

## Modifications

`python/sglang/srt/models/glm4_moe_nextn.py`:
  - Only override `quant_config` when running on NPU (`is_npu()`), preserving the original behavior on GPU.

## Test Results

  GLM-4.7-FP8 + EAGLE, `--speculative-num-steps 3 --speculative-eagle-topk 1`, TP8:

  | Version | BS=1 accept_length | BS=8 accept_length |
  |---|---|---|
  | Before fix | 1.00, 1.00, 1.00 | 1.00 (all 8 requests) |
  | After fix | 2.88, 3.08, 2.98 | 2.75 ~ 3.08 |

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
