### PR TITLE
[Fix] Fix mm_input_embeds missing in CUDA graph runner

### DIFF
--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -737,6 +737,7 @@ class PiecewiseCudaGraphRunner:
             lora_ids=forward_batch.lora_ids,
             sampling_info=forward_batch.sampling_info,
             mm_inputs=forward_batch.mm_inputs,
+            mm_input_embeds=forward_batch.mm_input_embeds,
             temp_scaled_logprobs=forward_batch.temp_scaled_logprobs,
             temperature=forward_batch.temperature,
             top_p_normalized_logprobs=forward_batch.top_p_normalized_logprobs,
@@ -789,6 +790,7 @@ class PiecewiseCudaGraphRunner:
                             if output.hidden_states is not None
                             else None
                         ),
+                        mm_input_embeds=output.mm_input_embeds,
                     )
                 elif isinstance(output, EmbeddingPoolerOutput):
                     return output


### PR DESCRIPTION
## Summary
- Pass `mm_input_embeds` field through `CudaGraphRunBatchData` construction and output forwarding in `PiecewiseCudaGraphRunner`
- Fix multimodal input embeddings being lost during CUDA graph execution

## Test plan
- [ ] Verify multimodal model inference with CUDA graph enabled
- [ ] Confirm `mm_input_embeds` is correctly propagated through the CUDA graph path

🤖 Generated with [Claude Code](https://claude.com/claude-code)