### PR TITLE
[Docker] Fix Trivy-reported CVEs in OS packages

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -453,7 +453,24 @@ RUN if [ "${CUDA_VERSION%%.*}" = "13" ] && [ -d /usr/local/lib/python3.12/dist-p
         ln -s /usr/local/cuda/bin/ptxas /usr/local/lib/python3.12/dist-packages/triton/backends/nvidia/bin/ptxas; \
     fi
 
+# Fix Trivy-reported CVEs
+# pip:             urllib3 (CVE-2025-43859), pillow (CVE-2026-25990)
+# binutils family: CVE-2025-{1147,1148,3198,5244,5245,7545,7546,8225,11082,11083,11412,11413,11414,11494,11839,11840}
+# libgnutls30t64:  CVE-2025-{9820,14831}
+# libpam:          CVE-2024-10963
+# libsqlite3-0:    CVE-2025-{6965,7709}
+# libtasn1-6:      CVE-2025-13151
+# dpkg:            CVE-2025-6297
 RUN python3 -m pip install --upgrade "urllib3>=2.6.3" "pillow>=12.1.1"
+RUN --mount=type=cache,target=/var/cache/apt,id=framework-apt \
+    apt-get update && apt-get install -y --only-upgrade \
+    binutils binutils-common binutils-x86-64-linux-gnu libbinutils \
+    libctf0 libctf-nobfd0 libgprofng0 libsframe1 \
+    libgnutls30t64 \
+    libpam-modules libpam-modules-bin libpam-runtime libpam0g \
+    libsqlite3-0 libtasn1-6 \
+    dpkg dpkg-dev libdpkg-perl \
+    && rm -rf /var/lib/apt/lists/*
 
 # Set workspace directory
 WORKDIR /sgl-workspace/sglang
@@ -557,6 +574,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends locales \
 ENV LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en \
     LC_ALL=en_US.UTF-8
+
+# Fix Trivy-reported CVEs (see framework stage for full CVE list)
+RUN --mount=type=cache,target=/var/cache/apt,id=runtime-apt \
+    apt-get update && apt-get install -y --only-upgrade \
+    binutils binutils-common binutils-x86-64-linux-gnu libbinutils \
+    libctf0 libctf-nobfd0 libgprofng0 libsframe1 \
+    libgnutls30t64 \
+    libpam-modules libpam-modules-bin libpam-runtime libpam0g \
+    libsqlite3-0 libtasn1-6 \
+    dpkg dpkg-dev libdpkg-perl \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy Python site-packages from framework (contains all built packages)
 COPY --from=framework /usr/local/lib/python3.12/dist-packages /usr/local/lib/python3.12/dist-packages


### PR DESCRIPTION
## Summary
- Add targeted `apt-get install --only-upgrade` layers to both framework and runtime Dockerfile stages to patch vulnerable OS packages
- Uses `--only-upgrade` instead of `apt-get upgrade` to avoid accidentally upgrading NVIDIA CUDA packages
- Consolidates existing pip CVE fixes (urllib3, pillow) under a unified comment block

### Affected packages
| Package family | # CVEs | Example CVEs |
|---|---|---|
| binutils (libsframe1, libctf0, libgprofng0, etc.) | 16 | CVE-2025-8225, CVE-2025-1147 |
| libgnutls30t64 | 2 | CVE-2025-9820, CVE-2025-14831 |
| libpam | 1 | CVE-2024-10963 |
| libsqlite3-0 | 2 | CVE-2025-6965, CVE-2025-7709 |
| libtasn1-6 | 1 | CVE-2025-13151 |
| dpkg | 1 | CVE-2025-6297 |

Follow-up to #21789.

## Test plan
- [ ] Verify Docker image builds successfully
- [ ] Run Trivy scan on built image to confirm CVEs are resolved
- [ ] Verify no NVIDIA/CUDA packages were changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)