### PR TITLE
[Docker] Fix Trivy CVEs, cubin download 403s, and kernels command order

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -218,8 +218,18 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     && if [ "$INSTALL_FLASHINFER_JIT_CACHE" = "1" ]; then \
         python3 -m pip install flashinfer-jit-cache==${FLASHINFER_VERSION} --index-url https://flashinfer.ai/whl/cu${CUINDEX} ; \
     fi \
-    && FLASHINFER_CUBIN_DOWNLOAD_THREADS=${BUILD_AND_DOWNLOAD_PARALLEL} FLASHINFER_LOGGING_LEVEL=warning python3 -m flashinfer --download-cubin \
-    && kernels download python \
+    && ( success=0; for i in 1 2 3; do \
+        echo "Attempt $i/3: downloading flashinfer cubins..." && \
+        FLASHINFER_CUBIN_DOWNLOAD_THREADS=${BUILD_AND_DOWNLOAD_PARALLEL} FLASHINFER_LOGGING_LEVEL=warning python3 -m flashinfer --download-cubin && \
+        success=1 && break; \
+        echo "flashinfer cubin download failed, retrying in 30s..." && sleep 30; \
+    done; [ "$success" = "1" ] ) \
+    && ( success=0; for i in 1 2 3; do \
+        echo "Attempt $i/3: downloading sgl-kernel cubins..." && \
+        kernels download python && \
+        success=1 && break; \
+        echo "sgl-kernel cubin download failed, retrying in 30s..." && sleep 30; \
+    done; [ "$success" = "1" ] ) \
     && kernels lock python \
     && mv python/kernels.lock /root/.cache/sglang
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -219,12 +219,6 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         python3 -m pip install flashinfer-jit-cache==${FLASHINFER_VERSION} --index-url https://flashinfer.ai/whl/cu${CUINDEX} ; \
     fi \
     && ( success=0; for i in 1 2 3; do \
-        echo "Attempt $i/3: downloading flashinfer cubins..." && \
-        FLASHINFER_CUBIN_DOWNLOAD_THREADS=${BUILD_AND_DOWNLOAD_PARALLEL} FLASHINFER_LOGGING_LEVEL=warning python3 -m flashinfer --download-cubin && \
-        success=1 && break; \
-        echo "flashinfer cubin download failed, retrying in 30s..." && sleep 30; \
-    done; [ "$success" = "1" ] ) \
-    && ( success=0; for i in 1 2 3; do \
         echo "Attempt $i/3: downloading sgl-kernel cubins..." && \
         kernels download python && \
         success=1 && break; \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -453,7 +453,24 @@ RUN if [ "${CUDA_VERSION%%.*}" = "13" ] && [ -d /usr/local/lib/python3.12/dist-p
         ln -s /usr/local/cuda/bin/ptxas /usr/local/lib/python3.12/dist-packages/triton/backends/nvidia/bin/ptxas; \
     fi
 
+# Fix Trivy-reported CVEs
+# pip:             urllib3 (CVE-2025-43859), pillow (CVE-2026-25990)
+# binutils family: CVE-2025-{1147,1148,3198,5244,5245,7545,7546,8225,11082,11083,11412,11413,11414,11494,11839,11840}
+# libgnutls30t64:  CVE-2025-{9820,14831}
+# libpam:          CVE-2024-10963
+# libsqlite3-0:    CVE-2025-{6965,7709}
+# libtasn1-6:      CVE-2025-13151
+# dpkg:            CVE-2025-6297
 RUN python3 -m pip install --upgrade "urllib3>=2.6.3" "pillow>=12.1.1"
+RUN --mount=type=cache,target=/var/cache/apt,id=framework-apt \
+    apt-get update && apt-get install -y --only-upgrade \
+    binutils binutils-common binutils-x86-64-linux-gnu libbinutils \
+    libctf0 libctf-nobfd0 libgprofng0 libsframe1 \
+    libgnutls30t64 \
+    libpam-modules libpam-modules-bin libpam-runtime libpam0g \
+    libsqlite3-0 libtasn1-6 \
+    dpkg dpkg-dev libdpkg-perl \
+    && rm -rf /var/lib/apt/lists/*
 
 # Set workspace directory
 WORKDIR /sgl-workspace/sglang
@@ -557,6 +574,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends locales \
 ENV LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en \
     LC_ALL=en_US.UTF-8
+
+# Fix Trivy-reported CVEs (see framework stage for full CVE list)
+RUN --mount=type=cache,target=/var/cache/apt,id=runtime-apt \
+    apt-get update && apt-get install -y --only-upgrade \
+    binutils binutils-common binutils-x86-64-linux-gnu libbinutils \
+    libctf0 libctf-nobfd0 libgprofng0 libsframe1 \
+    libgnutls30t64 \
+    libpam-modules libpam-modules-bin libpam-runtime libpam0g \
+    libsqlite3-0 libtasn1-6 \
+    dpkg dpkg-dev libdpkg-perl \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy Python site-packages from framework (contains all built packages)
 COPY --from=framework /usr/local/lib/python3.12/dist-packages /usr/local/lib/python3.12/dist-packages

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -218,13 +218,13 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     && if [ "$INSTALL_FLASHINFER_JIT_CACHE" = "1" ]; then \
         python3 -m pip install flashinfer-jit-cache==${FLASHINFER_VERSION} --index-url https://flashinfer.ai/whl/cu${CUINDEX} ; \
     fi \
+    && kernels lock python \
     && ( success=0; for i in 1 2 3; do \
         echo "Attempt $i/3: downloading sgl-kernel cubins..." && \
         kernels download python && \
         success=1 && break; \
         echo "sgl-kernel cubin download failed, retrying in 30s..." && sleep 30; \
     done; [ "$success" = "1" ] ) \
-    && kernels lock python \
     && mv python/kernels.lock /root/.cache/sglang
 
 # DeepEP

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -218,9 +218,9 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     && if [ "$INSTALL_FLASHINFER_JIT_CACHE" = "1" ]; then \
         python3 -m pip install flashinfer-jit-cache==${FLASHINFER_VERSION} --index-url https://flashinfer.ai/whl/cu${CUINDEX} ; \
     fi \
-    && FLASHINFER_CUBIN_DOWNLOAD_THREADS=${BUILD_AND_DOWNLOAD_PARALLEL} FLASHINFER_LOGGING_LEVEL=warning python3 -m flashinfer --download-cubin
-    && kernels download python
-    && kernels lock python
+    && FLASHINFER_CUBIN_DOWNLOAD_THREADS=${BUILD_AND_DOWNLOAD_PARALLEL} FLASHINFER_LOGGING_LEVEL=warning python3 -m flashinfer --download-cubin \
+    && kernels download python \
+    && kernels lock python \
     && mv python/kernels.lock /root/.cache/sglang
 
 # DeepEP


### PR DESCRIPTION
## Summary
- **Fix Trivy-reported CVEs**: Add targeted `apt-get install --only-upgrade` layers to patch vulnerable OS packages. Uses `--only-upgrade` to avoid accidentally upgrading NVIDIA CUDA packages.
- **Remove redundant flashinfer cubin download**: The `python3 -m flashinfer --download-cubin` step was downloading ~10,564 cubins individually from NVIDIA's CDN, causing 403 rate-limiting errors that fail the Docker release CI. The `flashinfer_cubin` pip wheel (294 MB, installed as a dependency via `pyproject.toml`) already bundles all cubins — flashinfer automatically detects and uses them. This step was fully redundant.
- **Fix `kernels lock`/`download` order**: `kernels download python` requires an existing lockfile, but was running before `kernels lock python` which generates it. Swapped the order.
- **Fix Dockerfile syntax**: Add missing line continuation backslashes for the `kernels` commands.

### Trivy CVEs addressed
| Package family | # CVEs | Example CVEs |
|---|---|---|
| binutils (libsframe1, libctf0, libgprofng0, etc.) | 16 | CVE-2025-8225, CVE-2025-1147 |
| libgnutls30t64 | 2 | CVE-2025-9820, CVE-2025-14831 |
| libpam | 1 | CVE-2024-10963 |
| libsqlite3-0 | 2 | CVE-2025-6965, CVE-2025-7709 |
| libtasn1-6 | 1 | CVE-2025-13151 |
| dpkg | 1 | CVE-2025-6297 |

Follow-up to #21789.

## Test plan
- [x] Docker image builds successfully (verified on H200 with `--build-arg CUDA_VERSION=12.8.1 --build-arg INSTALL_FLASHINFER_JIT_CACHE=1`)
- [x] All 10,564 flashinfer cubins present via `get_artifacts_status()` — sourced from pip wheel, no CDN download needed
- [x] `kernels lock` + `kernels download` complete successfully in correct order
- [ ] Run Trivy scan on built image to confirm CVEs are resolved
- [ ] Verify no NVIDIA/CUDA packages were changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)