### PR TITLE
[Qwen3.5][Kernel] Fused linear+sigmoid+mul in shared_experts

### DIFF
--- a/python/sglang/srt/layers/fused_linear_sigmoid_mul_triton.py
+++ b/python/sglang/srt/layers/fused_linear_sigmoid_mul_triton.py
@@ -61,10 +61,11 @@ def fused_linear_sigmoid_mul(
     assert hidden_states.dim() == 2 and weight.dim() == 2 and shared_output.dim() == 2
     n, h = shared_output.shape
     assert hidden_states.shape == (n, h)
-    assert weight.shape == (1, h), "shared expert gate weight must be (1, hidden_size), no bias"
+    assert weight.shape == (
+        1,
+        h,
+    ), "shared expert gate weight must be (1, hidden_size), no bias"
     assert weight.device == hidden_states.device == shared_output.device
-    _dev = hidden_states.device
-    assert _dev.type in ("cuda", "hip"), "fused_linear_sigmoid_mul expects CUDA or HIP device"
 
     if out is None:
         out = torch.empty_like(shared_output)

--- a/python/sglang/srt/layers/fused_linear_sigmoid_mul_triton.py
+++ b/python/sglang/srt/layers/fused_linear_sigmoid_mul_triton.py
@@ -1,0 +1,95 @@
+"""Triton fused op: sigmoid(x @ w^T) * m for w shape (1, H)"""
+
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def fused_linear_sigmoid_mul_triton_kernel(
+    hidden_states_ptr,
+    weight_ptr,
+    shared_output_ptr,
+    output_ptr,
+    N,
+    H,
+    hidden_stride_row,
+    shared_output_stride_row,
+    output_stride_row,
+    BLOCK_H: tl.constexpr,
+):
+    """Per row: dot(x[n,:], w[0,:]) -> sigmoid -> multiply shared_output[n,:]."""
+    pid_n = tl.program_id(0)
+    row_start_h = pid_n * hidden_stride_row
+    row_start_m = pid_n * shared_output_stride_row
+    row_start_out = pid_n * output_stride_row
+    row_ok = pid_n < N
+
+    sum_q = 0.0
+    for i in range(0, H, BLOCK_H):
+        col_offsets = i + tl.arange(0, BLOCK_H)
+        col_mask = col_offsets < H
+        mask_1d = row_ok & col_mask
+        x = tl.load(
+            hidden_states_ptr + row_start_h + col_offsets, mask=mask_1d, other=0.0
+        )
+        w = tl.load(weight_ptr + col_offsets, mask=col_mask, other=0.0)
+        prod = x.to(tl.float32) * w.to(tl.float32)
+        sum_q = sum_q + tl.sum(prod)
+    sigmoid_x = 1.0 / (1.0 + tl.exp(-sum_q))
+
+    for i in range(0, H, BLOCK_H):
+        col_offsets = i + tl.arange(0, BLOCK_H)
+        col_mask = col_offsets < H
+        mask_2d = row_ok & col_mask[None, :]
+        y_ptrs = shared_output_ptr + row_start_m + col_offsets[None, :]
+        y = tl.load(y_ptrs, mask=mask_2d, other=0.0)
+        out = sigmoid_x * y.to(tl.float32)
+        out_ptrs = output_ptr + row_start_out + col_offsets[None, :]
+        tl.store(out_ptrs, out.to(output_ptr.dtype.element_ty), mask=mask_2d)
+
+
+def fused_linear_sigmoid_mul(
+    hidden_states: torch.Tensor,
+    weight: torch.Tensor,
+    shared_output: torch.Tensor,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Triton: sigmoid(sum_h x[n,h]*W[0,h]) * shared_output[n,:]."""
+    assert hidden_states.dim() == 2 and weight.dim() == 2 and shared_output.dim() == 2
+    n, h = shared_output.shape
+    assert hidden_states.shape == (n, h)
+    assert weight.shape == (1, h), "shared expert gate weight must be (1, hidden_size), no bias"
+    assert weight.device == hidden_states.device == shared_output.device
+    _dev = hidden_states.device
+    assert _dev.type in ("cuda", "hip"), "fused_linear_sigmoid_mul expects CUDA or HIP device"
+
+    if out is None:
+        out = torch.empty_like(shared_output)
+    else:
+        assert out.shape == shared_output.shape and out.dtype == shared_output.dtype
+
+    assert hidden_states.is_contiguous(), "hidden_states must be contiguous"
+    assert weight.is_contiguous(), "weight must be contiguous"
+    assert shared_output.is_contiguous(), "shared_output must be contiguous"
+    assert out.is_contiguous(), "out must be contiguous"
+
+    block_h = 2048
+    grid = (triton.cdiv(n, 1),)
+    fused_linear_sigmoid_mul_triton_kernel[grid](
+        hidden_states,
+        weight,
+        shared_output,
+        out,
+        n,
+        h,
+        hidden_states.stride(0),
+        shared_output.stride(0),
+        out.stride(0),
+        BLOCK_H=block_h,
+        num_warps=4,
+        num_stages=2,
+    )
+    return out

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -270,7 +270,7 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
                     )
                 elif (
                     fused_linear_sigmoid_mul_triton is not None
-                    and (hidden_states.is_cuda or hidden_states.device.type == "hip")
+                    and hidden_states.is_cuda
                     and self.shared_expert_gate.bias is None
                     and self.shared_expert_gate.weight.dim() == 2
                     and self.shared_expert_gate.weight.shape[0] == 1

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -89,6 +89,7 @@ from sglang.srt.utils import (
     cpu_has_amx_support,
     is_cpu,
     is_cuda,
+    is_cuda_alike,
     make_layers,
     use_intel_amx_backend,
 )
@@ -97,8 +98,19 @@ from sglang.srt.utils.hf_transformers_utils import get_rope_config
 logger = logging.getLogger(__name__)
 
 _is_cuda = is_cuda()
+_is_cuda_alike = is_cuda_alike()
 _is_cpu = is_cpu()
 _is_cpu_amx_available = cpu_has_amx_support()
+
+fused_linear_sigmoid_mul_triton = None
+# Only load Triton on CUDA/HIP hosts (see is_cuda_alike in utils); CPU skips import.
+if _is_cuda_alike:
+    try:
+        from sglang.srt.layers.fused_linear_sigmoid_mul_triton import (
+            fused_linear_sigmoid_mul as fused_linear_sigmoid_mul_triton,
+        )
+    except ImportError:
+        pass
 
 
 class Qwen2MoeMLP(nn.Module):
@@ -256,6 +268,23 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
                         self.shared_expert_gate.bias,
                         True,
                         shared_output,
+                    )
+                elif (
+                    fused_linear_sigmoid_mul_triton is not None
+                    and (hidden_states.is_cuda or hidden_states.device.type == "hip")
+                    and self.shared_expert_gate.bias is None
+                    and self.shared_expert_gate.weight.dim() == 2
+                    and self.shared_expert_gate.weight.shape[0] == 1
+                    and self.shared_expert_gate.weight.shape[1] == hidden_states.shape[1]
+                    and hidden_states.is_contiguous()
+                    and shared_output.is_contiguous()
+                    and self.shared_expert_gate.weight.is_contiguous()
+                ):
+                    fused_linear_sigmoid_mul_triton(
+                        hidden_states,
+                        self.shared_expert_gate.weight,
+                        shared_output,
+                        out=shared_output,
                     )
                 else:
                     shared_output = (

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -103,7 +103,6 @@ _is_cpu = is_cpu()
 _is_cpu_amx_available = cpu_has_amx_support()
 
 fused_linear_sigmoid_mul_triton = None
-# Only load Triton on CUDA/HIP hosts (see is_cuda_alike in utils); CPU skips import.
 if _is_cuda_alike:
     try:
         from sglang.srt.layers.fused_linear_sigmoid_mul_triton import (

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -274,7 +274,8 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
                     and self.shared_expert_gate.bias is None
                     and self.shared_expert_gate.weight.dim() == 2
                     and self.shared_expert_gate.weight.shape[0] == 1
-                    and self.shared_expert_gate.weight.shape[1] == hidden_states.shape[1]
+                    and self.shared_expert_gate.weight.shape[1]
+                    == hidden_states.shape[1]
                     and hidden_states.is_contiguous()
                     and shared_output.is_contiguous()
                     and self.shared_expert_gate.weight.is_contiguous()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
In this PR, I fused linear+sigmoid+mul (in shared_experts) into one triton kernel for Qwen3.5-397B-A17B
## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
### Before
```
local-completions ({'base_url': 'http://localhost:9000/v1/completions', 'model': 'Qwen/Qwen3.5-397B-A17B', 'num_concurrent': 64, 'max_retries': 10, 'max_gen_toks': 2048}), gen_kwargs: ({}), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9697|±  |0.0047|
|     |       |strict-match    |     5|exact_match|↑  |0.9697|±  |0.0047|
```
### After
```
local-completions ({'base_url': 'http://localhost:9000/v1/completions', 'model': 'Qwen/Qwen3.5-397B-A17B', 'num_concurrent': 64, 'max_retries': 10, 'max_gen_toks': 2048}), gen_kwargs: ({}), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9689|±  |0.0048|
|     |       |strict-match    |     5|exact_match|↑  |0.9697|±  |0.0047|
```

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
Measured on MI350X4

### Before
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 8         
Successful requests:                     128       
Benchmark duration (s):                  160.91    
Total input tokens:                      1024000   
Total input text tokens:                 1024000   
Total generated tokens:                  64000     
Total generated tokens (retokenized):    63849     
Request throughput (req/s):              0.80      
Input token throughput (tok/s):          6363.73   
Output token throughput (tok/s):         397.73    
Peak output token throughput (tok/s):    512.00    
Peak concurrent requests:                16        
Total token throughput (tok/s):          6761.47   
Concurrency:                             8.00      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   10052.82  
Median E2E Latency (ms):                 10058.07  
P90 E2E Latency (ms):                    10151.35  
P99 E2E Latency (ms):                    10226.53  
---------------Time to First Token----------------
Mean TTFT (ms):                          1316.75   
Median TTFT (ms):                        1337.87   
P99 TTFT (ms):                           2096.09   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          17.51     
Median TPOT (ms):                        17.47     
P99 TPOT (ms):                           19.46     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           17.51     
Median ITL (ms):                         16.13     
P95 ITL (ms):                            16.39     
P99 ITL (ms):                            16.67     
Max ITL (ms):                            1728.19   
==================================================
```

### After
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 8         
Successful requests:                     128       
Benchmark duration (s):                  152.34    
Total input tokens:                      1024000   
Total input text tokens:                 1024000   
Total generated tokens:                  64000     
Total generated tokens (retokenized):    60427     
Request throughput (req/s):              0.84      
Input token throughput (tok/s):          6722.02   
Output token throughput (tok/s):         420.13    
Peak output token throughput (tok/s):    664.00    
Peak concurrent requests:                16        
Total token throughput (tok/s):          7142.14   
Concurrency:                             8.00      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   9516.89   
Median E2E Latency (ms):                 9624.07   
P90 E2E Latency (ms):                    9678.25   
P99 E2E Latency (ms):                    9731.76   
---------------Time to First Token----------------
Mean TTFT (ms):                          1276.88   
Median TTFT (ms):                        1302.49   
P99 TTFT (ms):                           2013.24   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          16.51     
Median TPOT (ms):                        16.65     
P99 TPOT (ms):                           18.63     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           16.51     
Median ITL (ms):                         15.34     
P95 ITL (ms):                            15.59     
P99 ITL (ms):                            15.85     
Max ITL (ms):                            1649.70   
==================================================

```
### Profiling 
In the decode stage
#### Before
<img width="1127" height="751" alt="image" src="https://github.com/user-attachments/assets/259de7d9-d682-4159-b287-fb5006aa1bdd" />

#### After
<img width="874" height="538" alt="image" src="https://github.com/user-attachments/assets/8af74c3a-9750-4ff6-b057-d10367ffa6b5" />

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
