### PR TITLE
Refactor uvicorn server configuration and improve health check

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -2265,7 +2265,6 @@ def _setup_and_run_http_server(
                 "propagate": False,
             }
 
-
             if server_args.enable_ssl_refresh:
                 logger.warning(
                     "--enable-ssl-refresh is not supported with multiple "

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -146,7 +146,6 @@ from sglang.srt.managers.multi_tokenizer_mixin import (
     MultiTokenizerRouter,
     TokenizerWorker,
     get_main_process_id,
-    monkey_patch_uvicorn_multiprocessing,
     read_from_shared_memory,
     write_data_for_multi_tokenizer,
 )

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -2265,7 +2265,7 @@ def _setup_and_run_http_server(
                 "level": "INFO",
                 "propagate": False,
             }
-            monkey_patch_uvicorn_multiprocessing()
+
 
             if server_args.enable_ssl_refresh:
                 logger.warning(
@@ -2281,6 +2281,8 @@ def _setup_and_run_http_server(
                 root_path=server_args.fastapi_root_path,
                 log_level=server_args.log_level_http or server_args.log_level,
                 timeout_keep_alive=envs.SGLANG_TIMEOUT_KEEP_ALIVE.get(),
+                # use configurable timeout_worker_healthcheck instead of monkey patch uvicorn
+                timeout_worker_healthcheck=envs.SGLANG_TIMEOUT_WORKER_HEALTHCHECK.get(),
                 loop="uvloop",
                 workers=server_args.tokenizer_worker_num,
                 ssl_keyfile=server_args.ssl_keyfile,

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -491,6 +491,8 @@ class Envs:
 
     # HTTP Server
     SGLANG_TIMEOUT_KEEP_ALIVE = EnvInt(5)
+
+    # uvicorn multi worker health check
     SGLANG_TIMEOUT_WORKER_HEALTHCHECK = EnvInt(10)
 
     # HTTP/2 Server

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -491,6 +491,7 @@ class Envs:
 
     # HTTP Server
     SGLANG_TIMEOUT_KEEP_ALIVE = EnvInt(5)
+    SGLANG_TIMEOUT_WORKER_HEALTHCHECK = EnvInt(10)
 
     # HTTP/2 Server
     SGLANG_GRANIAN_PARENT_PID = EnvInt(None)


### PR DESCRIPTION
Currently, when launching multi-worker mode, the uvicorn worker liveness check (is_alive) is handled via monkey-patching, which simply raises the default timeout from 5s to 10s. On slower/lower-spec machines, 10s is still not sufficient for the worker to start up properly.

This PR makes the following changes:

Remove the monkey-patch approach — instead, use the native timeout_worker_healthcheck parameter provided by uvicorn directly.
Introduce a new environment variable SGLANG_TIMEOUT_WORKER_HEALTHCHECK — allowing users to configure the worker health check timeout to suit their own environment.