### PR TITLE
[CI] Set RUNAI_STREAMER_MEMORY_LIMIT=0 for stage-b-test-1-gpu-small

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -705,6 +705,7 @@ jobs:
         timeout-minutes: 30
         env:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+          RUNAI_STREAMER_MEMORY_LIMIT: 0
         run: |
           source /etc/profile.d/sglang-ci.sh
           cd test/


### PR DESCRIPTION
## Summary
- Set `RUNAI_STREAMER_MEMORY_LIMIT=0` env var for the `stage-b-test-1-gpu-small` CI job
- The runai model loader test streams CodeGemma 2B (5.6 GiB, 165 tensors) from a public GCS bucket. Without unlimited memory buffering, the streamer's default buffer cap causes it to block on consumption before prefetching, degrading throughput from ~3s/it to ~42s/it and taking **18 minutes** total at 5.3 MiB/s. This caused the [CI job to timeout](https://github.com/sgl-project/sglang/actions/runs/24119332733/job/70380386973?pr=20310)
- This matches what the `diffusion-ci-gt-gen` and `pr-test-multimodal-gen` workflows already do. Follow https://github.com/sgl-project/sglang/pull/17636

## Test plan
- [ ] Verify `stage-b-test-1-gpu-small` partition containing `test_runai_model_loader` completes within the 30-minute timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)