### PR TITLE
fix: enable custom all-reduce coexistence with NCCL symmetric memory

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -577,18 +577,30 @@ class GroupCoordinator:
         if self.npu_communicator is not None and not self.npu_communicator.disabled:
             return self.npu_communicator.all_reduce(input_)
 
-        if self.pynccl_comm is not None and self.is_symmetric_memory_enabled():
-            self.debug_check_symmetric_mempool(self, {"input": input_}, "all_reduce")
-            with self.pynccl_comm.change_state(enable=True):
-                self.pynccl_comm.all_reduce(input_)
-                return input_
-
         outplace_all_reduce_method = None
-        if (
+        if self.pynccl_comm is not None and self.is_symmetric_memory_enabled():
+            # When symmetric memory is enabled, default to NCCL symm-mem.
+            # Optionally allow Custom AR for small tensors when
+            # SGLANG_ENABLE_CA_WITH_SYMM=1 (for decode latency optimization).
+            if (
+                _ENABLE_CA_WITH_SYMM
+                and self.ca_comm is not None
+                and not self.ca_comm.disabled
+                and self.ca_comm.should_custom_ar(input_)
+            ):
+                outplace_all_reduce_method = "ca"
+            else:
+                # Default: NCCL symmetric memory allreduce.
+                self.debug_check_symmetric_mempool(self, {"input": input_}, "all_reduce")
+                with self.pynccl_comm.change_state(enable=True):
+                    self.pynccl_comm.all_reduce(input_)
+                    return input_
+        elif (
             self.ca_comm is not None
             and not self.ca_comm.disabled
             and self.ca_comm.should_custom_ar(input_)
         ):
+            # No symm-mem: normal Custom AR path.
             outplace_all_reduce_method = "ca"
         elif (
             self.qr_comm is not None
@@ -1547,6 +1559,7 @@ logger = logging.getLogger(__name__)
 _ENABLE_CUSTOM_ALL_REDUCE = True
 _ENABLE_MSCCLPP_ALL_REDUCE = False
 _ENABLE_TORCH_SYMM_MEM_ALL_REDUCE = False
+_ENABLE_CA_WITH_SYMM = os.environ.get("SGLANG_ENABLE_CA_WITH_SYMM", "0") == "1"
 
 
 def set_custom_all_reduce(enable: bool):

--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -333,11 +333,7 @@ def is_allreduce_allocation_symmetric() -> bool:
 
     if torch.cuda.is_current_stream_capturing():
         tp_group = get_tp_group()
-        if (
-            tp_group is not None
-            and tp_group.ca_comm is not None
-            and not tp_group.ca_comm.disabled
-        ):
+        if tp_group and tp_group.ca_comm and not tp_group.ca_comm.disabled:
             return False
     return is_allocation_symmetric()
 

--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -316,6 +316,32 @@ def is_allocation_symmetric() -> bool:
     return not is_dp_attention_enabled() or is_dp_max_padding()
 
 
+def is_allreduce_allocation_symmetric() -> bool:
+    """Whether to use symmetric memory for tensors that flow into all-reduce.
+
+    When custom AR is active during CUDA graph capture, the input tensors
+    must be from cudaMalloc (not ncclMemAlloc) so that register_graph_buffers()
+    can IPC-register them via cudaIpcGetMemHandle. In eager mode (prefill),
+    symm-mem allocation is fine because custom AR uses the unregistered path
+    which does not require IPC on input tensors.
+
+    Returns False only during graph capture with custom AR enabled.
+    """
+    import torch
+
+    from sglang.srt.distributed.parallel_state import get_tp_group
+
+    if torch.cuda.is_current_stream_capturing():
+        tp_group = get_tp_group()
+        if (
+            tp_group is not None
+            and tp_group.ca_comm is not None
+            and not tp_group.ca_comm.disabled
+        ):
+            return False
+    return is_allocation_symmetric()
+
+
 def get_attention_tp_group() -> GroupCoordinator:
     return get_attn_tp_group()
 

--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -319,19 +319,23 @@ def is_allocation_symmetric() -> bool:
 def is_allreduce_allocation_symmetric() -> bool:
     """Whether to use symmetric memory for tensors that flow into all-reduce.
 
-    When custom AR is active during CUDA graph capture, the input tensors
-    must be from cudaMalloc (not ncclMemAlloc) so that register_graph_buffers()
-    can IPC-register them via cudaIpcGetMemHandle. In eager mode (prefill),
-    symm-mem allocation is fine because custom AR uses the unregistered path
-    which does not require IPC on input tensors.
+    When SGLANG_ENABLE_CA_WITH_SYMM=1 and custom AR is active during CUDA
+    graph capture, the input tensors must be from cudaMalloc (not ncclMemAlloc)
+    so that register_graph_buffers() can IPC-register them via
+    cudaIpcGetMemHandle. In eager mode (prefill), symm-mem allocation is fine.
 
-    Returns False only during graph capture with custom AR enabled.
+    Returns False only during graph capture with CA-with-symm enabled.
     """
+    import os
+
     import torch
 
     from sglang.srt.distributed.parallel_state import get_tp_group
 
-    if torch.cuda.is_current_stream_capturing():
+    if (
+        os.environ.get("SGLANG_ENABLE_CA_WITH_SYMM", "0") == "1"
+        and torch.cuda.is_current_stream_capturing()
+    ):
         tp_group = get_tp_group()
         if tp_group and tp_group.ca_comm and not tp_group.ca_comm.disabled:
             return False

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -25,6 +25,7 @@ from sglang.srt.distributed.device_communicators.pynccl_allocator import (
 )
 from sglang.srt.layers.dp_attention import (
     get_attention_tp_group,
+    is_allocation_symmetric,
     is_allreduce_allocation_symmetric,
 )
 from sglang.srt.layers.parameter import (

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -25,7 +25,7 @@ from sglang.srt.distributed.device_communicators.pynccl_allocator import (
 )
 from sglang.srt.layers.dp_attention import (
     get_attention_tp_group,
-    is_allocation_symmetric,
+    is_allreduce_allocation_symmetric,
 )
 from sglang.srt.layers.parameter import (
     BasevLLMParameter,

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -24,7 +24,7 @@ from sglang.srt.distributed.device_communicators.pynccl_allocator import (
     use_symmetric_memory,
 )
 from sglang.srt.eplb.expert_location import get_global_expert_location_metadata
-from sglang.srt.layers.dp_attention import is_allocation_symmetric
+from sglang.srt.layers.dp_attention import is_allreduce_allocation_symmetric
 from sglang.srt.layers.moe import (
     MoeRunnerConfig,
     get_deepep_mode,
@@ -1018,7 +1018,7 @@ class FusedMoE(torch.nn.Module):
         )
 
         with use_symmetric_memory(
-            get_tp_group(), disabled=not is_allocation_symmetric()
+            get_tp_group(), disabled=not is_allreduce_allocation_symmetric()
         ):
             final_hidden_states = self.dispatcher.combine(combine_input=combine_input)
 

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -12,7 +12,7 @@ from sglang.srt.distributed import get_tp_group
 from sglang.srt.distributed.device_communicators.pynccl_allocator import (
     use_symmetric_memory,
 )
-from sglang.srt.layers.dp_attention import is_allocation_symmetric
+from sglang.srt.layers.dp_attention import is_allreduce_allocation_symmetric
 from sglang.srt.layers.moe.flashinfer_trtllm_moe import (
     trtllm_fp8_block_scale_moe_wrapper,
     trtllm_fp8_block_scale_routed_moe_wrapper,
@@ -396,7 +396,7 @@ def fused_experts_none_to_flashinfer_trtllm_fp8(
 
         # Allocate output inside symmetric memory context
         with use_symmetric_memory(
-            get_tp_group(), disabled=not is_allocation_symmetric()
+            get_tp_group(), disabled=not is_allreduce_allocation_symmetric()
         ):
             symm_output = torch.empty(
                 hidden_states.shape[0],
@@ -498,7 +498,7 @@ def fused_experts_none_to_flashinfer_trtllm_fp8(
 
         # Allocate output inside symmetric memory context
         with use_symmetric_memory(
-            get_tp_group(), disabled=not is_allocation_symmetric()
+            get_tp_group(), disabled=not is_allreduce_allocation_symmetric()
         ):
             symm_output = torch.empty(
                 hidden_states.shape[0],
@@ -637,7 +637,9 @@ def fused_experts_none_to_flashinfer_trtllm_fp4(
         *hs_scale_linear.shape[:-1], -1
     )
 
-    with use_symmetric_memory(get_tp_group(), disabled=not is_allocation_symmetric()):
+    with use_symmetric_memory(
+        get_tp_group(), disabled=not is_allreduce_allocation_symmetric()
+    ):
         num_tokens = hs_fp4.shape[0]
         hidden_size = (
             hs_fp4.shape[-1] * 2 if hs_fp4.dtype == torch.uint8 else hs_fp4.shape[-1]
@@ -795,7 +797,9 @@ def fused_experts_none_to_flashinfer_trtllm_bf16(
     hidden_states = dispatch_output.hidden_states
     topk_output = dispatch_output.topk_output
 
-    with use_symmetric_memory(get_tp_group(), disabled=not is_allocation_symmetric()):
+    with use_symmetric_memory(
+        get_tp_group(), disabled=not is_allreduce_allocation_symmetric()
+    ):
         if use_routed_topk:
             assert (
                 runner_config.top_k is not None

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -19,7 +19,7 @@ from sglang.srt.layers.amx_utils import (
     CPUQuantMethod,
     _amx_process_weight_after_loading,
 )
-from sglang.srt.layers.dp_attention import is_allocation_symmetric
+from sglang.srt.layers.dp_attention import is_allreduce_allocation_symmetric
 from sglang.srt.layers.moe import MoeRunner, MoeRunnerBackend, MoeRunnerConfig
 from sglang.srt.layers.moe.moe_runner.deep_gemm import DeepGemmMoeQuantInfo
 from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
@@ -1564,7 +1564,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             from sglang.srt.layers.moe.cutlass_moe import cutlass_fused_experts_fp8
 
             with use_symmetric_memory(
-                get_tp_group(), disabled=not is_allocation_symmetric()
+                get_tp_group(), disabled=not is_allreduce_allocation_symmetric()
             ):
                 symm_output = torch.empty_like(x)
 

--- a/python/sglang/srt/layers/vocab_parallel_embedding.py
+++ b/python/sglang/srt/layers/vocab_parallel_embedding.py
@@ -23,7 +23,7 @@ from sglang.srt.layers.dp_attention import (
     attn_tp_all_reduce,
     get_attention_tp_rank,
     get_attention_tp_size,
-    is_allocation_symmetric,
+    is_allreduce_allocation_symmetric,
 )
 from sglang.srt.layers.parameter import BasevLLMParameter
 from sglang.srt.layers.quantization.base_config import (
@@ -484,7 +484,7 @@ class VocabParallelEmbedding(torch.nn.Module):
 
         # Get the embeddings.
         with use_symmetric_memory(
-            get_tp_group(), disabled=not is_allocation_symmetric()
+            get_tp_group(), disabled=not is_allreduce_allocation_symmetric()
         ):
             output_parallel = self.quant_method.embedding(self, masked_input.long())
 

--- a/python/sglang/srt/models/glm4_moe.py
+++ b/python/sglang/srt/models/glm4_moe.py
@@ -49,7 +49,7 @@ from sglang.srt.layers.communicator import (
 from sglang.srt.layers.dp_attention import (
     get_attention_tp_rank,
     get_attention_tp_size,
-    is_allocation_symmetric,
+    is_allreduce_allocation_symmetric,
     is_dp_attention_enabled,
 )
 from sglang.srt.layers.layernorm import RMSNorm
@@ -622,7 +622,8 @@ class Glm4MoeSparseMoeBlock(nn.Module):
             final_hidden_states *= self.routed_scaling_factor
         if shared_output is not None:
             with use_symmetric_memory(
-                parallel_state.get_tp_group(), disabled=not is_allocation_symmetric()
+                parallel_state.get_tp_group(),
+                disabled=not is_allreduce_allocation_symmetric(),
             ):
                 final_hidden_states_out = torch.empty_like(final_hidden_states)
             torch.add(final_hidden_states, shared_output, out=final_hidden_states_out)

--- a/test/registered/backends/test_symm_mem_custom_ar_coexistence.py
+++ b/test/registered/backends/test_symm_mem_custom_ar_coexistence.py
@@ -1,0 +1,78 @@
+"""Test that custom all-reduce can coexist with NCCL symmetric memory.
+
+When --enable-symm-mem is set, the default behavior is to use NCCL symm-mem
+for all allreduce operations. Setting SGLANG_ENABLE_CA_WITH_SYMM=1 allows
+custom AR to handle small tensors (decode) while NCCL symm-mem handles the rest.
+
+This test verifies that the opt-in CA-with-symm mode does not crash and
+maintains accuracy.
+"""
+
+import os
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+    try_cached_model,
+)
+
+register_cuda_ci(est_time=600, suite="nightly-8-gpu-h200", nightly=True)
+
+MODEL_PATH = "meta-llama/Llama-3.1-70B-Instruct"
+SERVER_LAUNCH_TIMEOUT = 600
+
+
+class TestSymmMemCustomARCoexistence(CustomTestCase):
+    """Launch server with symm-mem + CA-with-symm enabled, verify accuracy."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = try_cached_model(MODEL_PATH)
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        # Enable CA-with-symm via environment variable
+        os.environ["SGLANG_ENABLE_CA_WITH_SYMM"] = "1"
+        other_args = [
+            "--tensor-parallel-size",
+            "8",
+            "--enable-symm-mem",
+            # custom all-reduce is enabled by default (not passing --disable-custom-all-reduce)
+            "--mem-fraction-static",
+            "0.85",
+            "--disable-radix-cache",
+        ]
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=SERVER_LAUNCH_TIMEOUT,
+            other_args=other_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+        os.environ.pop("SGLANG_ENABLE_CA_WITH_SYMM", None)
+
+    def test_gsm8k_accuracy(self):
+        """GSM8K accuracy should be >= 0.80 with symm-mem + CA-with-symm."""
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="gsm8k",
+            api="completion",
+            max_tokens=512,
+            num_examples=200,
+            num_threads=64,
+        )
+        metrics = run_eval(args)
+        print(f"Eval accuracy of GSM8K (symm-mem + CA-with-symm): {metrics=}")
+        self.assertGreater(metrics["score"], 0.80)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Background
When we enable nccl-symm, custom allreduce will be disabled. But sometimes we want to use nccl-symm for prefill and custom allreduce for decode, which is good for perf.

## Why custom allreduce is incompatible with nccl-symm in current version
When --enable-symm-mem is on, custom all-reduce (CA) was completely bypassed because the symm-mem pynccl path had unconditional priority. This patch enables CA to work alongside symmetric memory in both eager and CUDA graph modes.

## Core idea
introduce is_allreduce_allocation_symmetric() that returns False during CUDA graph capture when CA is active, ensuring allreduce input tensors use cudaMalloc (IPC-compatible) instead of ncclMemAlloc (cuMem, IPC-incompatible). Non-allreduce paths (all-gather etc.) keep using symmetric memory allocation unchanged.

## Changes
- dp_attention.py: add is_allreduce_allocation_symmetric()
- parallel_state.py: reorder dispatch so CA has priority over symm-mem
- linear.py, vocab_parallel_embedding.py, fused_moe_triton/layer.py, flashinfer_trtllm.py, fp8.py, glm4_moe.py: use the new function for allreduce input allocations

## Accuracy
Verified on B200, H200, H20 (TP4, Qwen3.5-35B-A3B-FP8):
- CUDA graph capture: 72-2916 addresses registered successfully
- Accuracy: GSM8K 97.1-97.4% (identical to baseline)

## Potential impact on different GPUs
B200: no much affect. Decode uses trtllm-one-shot-allreduce-fusion by default, no matter symm enable/disable.
H200: no much affect. Decode uses trtllm-one-shot-allreduce-fusion by default, no matter symm enable/disable.
H20 previously priority: nccl symm allreduce (perf bad for decode) > custom allreduce > nccl allreduce
H20 currently priority: custom allreduce > nccl symm allreduce (perf bad for decode) > nccl allreduce

## H20 Perf analysis
ISL=8k, Decode batchsize=4
### Kernel Perf Comparison
custom all reduce=5us(no bubble)
nccl symm=6.4us(but bubbles also takes 7us), total~13us. 
<img width="652" height="299" alt="image" src="https://github.com/user-attachments/assets/9cbc677d-03f1-464f-bd00-49193268fbca" />
<img width="864" height="180" alt="image" src="https://github.com/user-attachments/assets/e2826e13-557b-4d57-b9c6-cc651d28b896" />

### Decode Step Perf Comparison
custom all reduce=3.6ms
nccl symm=4ms
Delta=4ms-3.6ms=400us, match with estimated delta=8us * 2 (#call per layer) * 40 layers = 640us per step.
<img width="406" height="139" alt="image" src="https://github.com/user-attachments/assets/56a3a6f3-7f6b-4ef1-a089-5bb6ea165995" />
<img width="428" height="248" alt="image" src="https://github.com/user-attachments/assets/1bedf7d2-3601-4c6b-83bd-6ab39f1059f5" />



## Proof: All modified `is_allreduce_allocation_symmetric()` call sites flow into all-reduce

Every call site changed from `is_allocation_symmetric()` to `is_allreduce_allocation_symmetric()` allocates a tensor that ends up as input to `tensor_model_parallel_all_reduce()` or equivalent. No all-gather, reduce-scatter, or other collective paths are affected.

### Call site → all-reduce trace

| # | File | Line | Tensor allocated | Path to all-reduce | Type |
|---|------|------|-----------------|-------------------|------|
| 1 | `linear.py` | 1509 | `output_parallel` = matmul output | → `all_reduce(output_parallel)` at L1513/1515 | **Direct** |
| 2 | `vocab_parallel_embedding.py` | 489 | `output_parallel` = embedding output | → `all_reduce(output_parallel)` at L496/499 | **Direct** |
| 3 | `moe/fused_moe_triton/layer.py` | 1019 | `final_hidden_states` = MoE combine output | → `all_reduce(final_hidden_states)` at L1027 | **Direct** |
| 4 | `moe/moe_runner/flashinfer_trtllm.py` | 409 | `symm_output` = expert output buffer | → MoE kernel writes into it → `combine()` returns same tensor → `all_reduce()` at layer.py:1027 | Same addr |
| 5 | `moe/moe_runner/flashinfer_trtllm.py` | 511 | `symm_output` = expert output buffer | Same as #4 | Same addr |
| 6 | `moe/moe_runner/flashinfer_trtllm.py` | 650 | `symm_output` = expert output buffer | Same as #4 | Same addr |
| 7 | `moe/moe_runner/flashinfer_trtllm.py` | 818 | `symm_output` = expert output buffer | Same as #4 | Same addr |
| 8 | `quantization/fp8.py` | 1543 | `symm_output` = CUTLASS expert output buffer | → `cutlass_fused_experts_fp8(output=symm_output)` → `StandardCombineInput` → `combine()` returns same tensor → `all_reduce()` at layer.py:1027 | Same addr |
| 9 | `models/glm4_moe.py` | 626 | `final_hidden_states_out` | → `torch.add(..., out=final_hidden_states_out)` → `all_reduce(final_hidden_states)` at L635 | **Direct** |

### Why #4-#8 are "same addr"

`combine()` in `token_dispatcher/standard.py:194` does **not** create a new tensor — it returns `hidden_states` from the input `StandardCombineInput` as-is:

```python
def combine(self, combine_input: StandardCombineInput) -> torch.Tensor:
    (hidden_states,) = combine_input
    ...
    return hidden_states  # same tensor, same address
```

So the `symm_output` buffer allocated in the MoE runner **is** the tensor that reaches `all_reduce()`.

### Unchanged call sites (non-allreduce paths)

These files still use the original `is_allocation_symmetric()` and are **not modified**:

| File | Line | Purpose | Why not changed |
|------|------|---------|----------------|
| `parallel_state.py` | 868 | all-gather output buffer | Feeds into `all_gather`, not all-reduce |
| `communicator.py` | 733 | all-gather output buffer for TP_ATTN_FULL | Feeds into `all_gather` |
| `communicator.py` | 858 | layernorm before gather | Feeds into DP gather, not all-reduce |
| `dp_attention.py` | 127, 137 | DP global buffer allocation | Used for all-gather destination |
| `moe/topk.py` | 343 | expert selection (routing) | Routing metadata, not collective input |
| `moe/topk.py` | 395 | empty TopK output | Empty dummy tensors |
| `moe/token_dispatcher/standard.py` | 119 | FP4 quantize before all-gatherv | Feeds into `all_gatherv`, not all-reduce |
| `attention/nsa/utils.py` | 313, 370 | CP all-gather output | Feeds into context-parallel all-gather |
| `quantization/mxfp4.py` | 796 | Expert output buffer | Returns `StandardCombineInput`, handled by layer.py:1017 (already changed) |
| `quantization/modelopt_quant.py` | 1064, 1977 | Expert output buffer | Same as above |
| `compressed_tensors/*.py` | various | Expert output buffer | Same as above |


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
