### PR TITLE
[Whisper] Batch encoder forward for concurrent prefill requests

### DIFF
--- a/python/sglang/srt/models/whisper.py
+++ b/python/sglang/srt/models/whisper.py
@@ -442,30 +442,31 @@ class WhisperForConditionalGeneration(torch.nn.Module):
                 forward_batch.encoder_cached if forward_batch.encoder_cached else []
             )
 
-            encoder_list = []
-            for i, (mm_input, cached) in enumerate(
-                zip(mm_inputs_list, encoder_cached_list)
-            ):
+            # Collect features from all uncached requests for batched encoding
+            features_to_encode = []
+            for mm_input, cached in zip(mm_inputs_list, encoder_cached_list):
                 if cached or mm_input is None or not mm_input.mm_items:
                     continue
-
                 features = mm_input.mm_items[0].feature
                 if features.ndim == 2:
                     features = features.unsqueeze(0)
+                features_to_encode.append(features.to(dtype))
 
-                encoder_len = features.shape[-1] // 2
+            if features_to_encode:
+                # Batch all features and run encoder once instead of sequentially
+                features_batch = torch.cat(features_to_encode, dim=0)
+                encoder_len = features_batch.shape[-1] // 2
                 encoder_position_ids = torch.arange(encoder_len).to(
-                    features.device, non_blocking=True
+                    features_batch.device, non_blocking=True
                 )
 
-                req_encoder_output = self.encoder(
-                    features.to(dtype), encoder_position_ids, forward_batch
+                batched_output = self.encoder(
+                    features_batch, encoder_position_ids, forward_batch
                 )
-                req_encoder_output = req_encoder_output.squeeze(0)
-                encoder_list.append(req_encoder_output)
-
-            if encoder_list:
-                encoder_hidden_states = torch.cat(encoder_list, dim=0)
+                # Flatten [N, seq_len, dim] → [N*seq_len, dim] for cross-attention
+                encoder_hidden_states = batched_output.reshape(
+                    -1, batched_output.shape[-1]
+                )
 
         decoder_outputs = self.decoder(
             input_ids, encoder_hidden_states, forward_batch, positions

--- a/python/sglang/srt/models/whisper.py
+++ b/python/sglang/srt/models/whisper.py
@@ -292,6 +292,10 @@ class WhisperEncoder(torch.nn.Module):
         position_ids: torch.Tensor,
         forward_batch: ForwardBatch,
     ):
+        device = self.conv1.weight.device
+        input_features = input_features.to(device=device)
+        position_ids = position_ids.to(device=device)
+
         inputs_embeds = torch.nn.functional.gelu(self.conv1(input_features))
         inputs_embeds = torch.nn.functional.gelu(self.conv2(inputs_embeds))
 
@@ -456,8 +460,8 @@ class WhisperForConditionalGeneration(torch.nn.Module):
                 # Batch all features and run encoder once instead of sequentially
                 features_batch = torch.cat(features_to_encode, dim=0)
                 encoder_len = features_batch.shape[-1] // 2
-                encoder_position_ids = torch.arange(encoder_len).to(
-                    features_batch.device, non_blocking=True
+                encoder_position_ids = torch.arange(
+                    encoder_len, device=features_batch.device
                 )
 
                 batched_output = self.encoder(


### PR DESCRIPTION
## Motivation

When a prefill batch contains N new Whisper requests, the encoder currently runs N times sequentially in a for-loop. Each encoder call takes ~7ms on B200 / ~18ms on GB300, so a prefill batch with 5 requests blocks the scheduler for 35-90ms — during which no decode batches can execute.

Profiling shows the encoder is the dominant cost during prefill (35% of scheduler time at high concurrency), and the sequential execution directly limits throughput scaling.

## Modifications

Collect all uncached audio features into a single batch tensor and run the encoder **once** per prefill batch instead of once per request. The encoder is fully batch-compatible: Conv1d, embed_positions, all 32 transformer layers with `scaled_dot_product_attention`, and LayerNorm all operate along the batch dimension without cross-request interaction. The batched output is reshaped to `[N*seq_len, dim]` for the downstream cross-attention KV cache.

Includes cherry-pick of #22293 (device placement fix).

## Benchmark

Controlled A/B on the same GPU, back-to-back, `openai/whisper-large-v3`, 511 samples. Baseline is main + #22293 device fix.

### B200 (183 GB), same GPU 0, back-to-back

| Concurrency | Baseline (req/s) | Batched (req/s) | Change |
|:-----------:|:--------------:|:-------------:|:------:|
| 1 | 10.02 | 10.01 | 0% |
| 4 | 23.33 | 23.75 | +2% |
| 16 | 37.43 | 38.12 | +2% |
| 64 | 43.28 | 44.63 | +3% |

### GB300 (GKE, 1 GPU), same pod, back-to-back

| Concurrency | Baseline (req/s) | Batched (req/s) | Change |
|:-----------:|:--------------:|:-------------:|:------:|
| 1 | 7.43 | 7.80 | +5.0% |
| 4 | 13.87 | 14.99 | +8.0% |
| 16 | 21.61 | 26.50 | **+22.6%** |
| 64 | 24.96 | 32.17 | **+28.9%** |

WER: 12.77-12.78% across all configs (unchanged).

The improvement is small on B200 (encoder is only 7ms/req, batching saves little) but significant on GB300 where encoder dispatch overhead is higher.

### Encoder timing (from server logs, GB300)

**Before** (sequential):
```
n_requests=4  total=72ms  avg=18ms/req   (4 x 18ms serial)
```

**After** (batched):
```
batch_size=4  encoder=19.1ms
batch_size=3  encoder=15.8ms
batch_size=2  encoder=16.0ms
```

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Provide accuracy and speed benchmark results.