### PR TITLE
[AMD] Fix `aiter` import failure in ROCm Docker images

### DIFF
--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -204,12 +204,12 @@ RUN cd aiter \
      && sed -i '/c1 = torch.empty((M, D, S1 + S3), dtype=dtype, device=x.device)/i\    config = dict(config)' aiter/ops/triton/gemm/fused/fused_gemm_afp4wfp4_split_cat.py \
      && if [ "$BUILD_AITER_ALL" = "1" ] && [ "$BUILD_LLVM" = "1" ]; then \
           sh -c "HIP_CLANG_PATH=/sgl-workspace/llvm-project/build/bin/ PREBUILD_KERNELS=1 GPU_ARCHS=$GPU_ARCH_LIST python setup.py build_ext --inplace" \
-          && sh -c "HIP_CLANG_PATH=/sgl-workspace/llvm-project/build/bin/ GPU_ARCHS=$GPU_ARCH_LIST pip install -e ."; \
+          && sh -c "HIP_CLANG_PATH=/sgl-workspace/llvm-project/build/bin/ GPU_ARCHS=$GPU_ARCH_LIST pip install --config-settings editable_mode=compat -e ."; \
         elif [ "$BUILD_AITER_ALL" = "1" ]; then \
           sh -c "PREBUILD_KERNELS=1 GPU_ARCHS=$GPU_ARCH_LIST python setup.py build_ext --inplace" \
-          && sh -c "GPU_ARCHS=$GPU_ARCH_LIST pip install -e ."; \
+          && sh -c "GPU_ARCHS=$GPU_ARCH_LIST pip install --config-settings editable_mode=compat -e ."; \
         else \
-          sh -c "GPU_ARCHS=$GPU_ARCH_LIST pip install -e ."; \
+          sh -c "GPU_ARCHS=$GPU_ARCH_LIST pip install --config-settings editable_mode=compat -e ."; \
         fi \
       && echo "export PYTHONPATH=/sgl-workspace/aiter:\${PYTHONPATH}" >> /etc/bash.bashrc
 


### PR DESCRIPTION
## Motivation

This should fix #22279.

### Problem
The `v0.5.10-rocm*-mi35x` Docker images fail on startup with error (when `SGLANG_USE_AITER=1`):
```
ImportError: cannot import name 'dynamic_per_tensor_quant' from 'aiter' (unknown location)
```

Both `rocm700` and `rocm720` images are affected in 0.5.10, because starting from #19203 (it was merged after 0.5.9 release) the images use the same `rocm.Dockerfile`.

### Root Cause
Commit 2e768241 (see #20195) changed `aiter` installation from `python setup.py develop` to `python setup.py build_ext --inplace` + `pip install -e .`.

The old `setup.py develop` used the egg-link mechanism, which added `/sgl-workspace/aiter` directly to `sys.path` via a `.pth` file. Modern `pip install -e .` (strict editable mode) instead registers a custom import finder appended to the end of `sys.meta_path`.

Since the image's `WORKDIR` is `/sgl-workspace`, the default `PathFinder` (which runs before the editable finder) discovers `/sgl-workspace/aiter/` - the git repo root directory - via `cwd` (`''` in `sys.path`). Because the repo root has no `__init__.py`, Python resolves it as a namespace package and stops searching. The editable finder, which has the correct mapping (`aiter → /sgl-workspace/aiter/aiter`), is never consulted.

The result: `aiter` imports as an empty namespace package (`__file__=None, loader=None`), and none of the actual package contents (including `dynamic_per_tensor_quant`) are available.

## Modifications

Use `pip install --config-settings editable_mode=compat -e .` instead of `pip install -e .`. Compat editable mode writes a simple `.pth` path entry (`/sgl-workspace/aiter`) into `site-packages`, which `PathFinder` processes before falling back to `cwd`. This makes `PathFinder` find `/sgl-workspace/aiter/aiter/__init__.py` correctly — the same reliable mechanism that `setup.py develop` used previously.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
