### PR TITLE
[Gateway] WebSocket Responses API — 14% faster multi-turn chains, 2.6x first-content, up to 55% tighter p95 tail latency 

### DIFF
--- a/.github/workflows/pr-benchmark-rust.yml
+++ b/.github/workflows/pr-benchmark-rust.yml
@@ -87,6 +87,13 @@ jobs:
             sccache_version: "v0.12.0"
             artifact_name: manual-policy-results
             artifact_path: criterion/manual_policy*/
+          - name: WS Response Hotpath
+            bench_name: ws_response_hotpath
+            bench_args: ""
+            runner: ubuntu-latest
+            sccache_version: "v0.12.0"
+            artifact_name: ws-response-hotpath-results
+            artifact_path: criterion/ws_response*/
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout code
@@ -184,6 +191,7 @@ jobs:
 
           generate_section "Request Processing" "request-processing-results" 60
           generate_section "Manual Policy (Sticky Sessions)" "manual-policy-results" 100
+          generate_section "WS Response Hotpath" "ws-response-hotpath-results" 100
 
           echo -e "---\n_Generated at $(date -u '+%Y-%m-%d %H:%M:%S UTC')_" >> summary.md
 

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -226,7 +226,7 @@ jobs:
             runner: 4-gpu-h100
             timeout: 32
             test_dirs: "e2e_test/benchmarks"
-            extra_deps: "genai-bench==0.0.3"
+            extra_deps: "genai-bench==0.0.3 websockets"
             env_vars: ""
             reruns: ""
             upload_benchmarks: true

--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+sgl-model-gateway/e2e_test/uv.lock
 
 # Spyder project settings
 .spyderproject

--- a/benchmark/multi_turn_chat/README.md
+++ b/benchmark/multi_turn_chat/README.md
@@ -25,6 +25,51 @@ Benchmark(long output)
 python3 bench_sglang.py --tokenizer meta-llama/Llama-2-7b-chat-hf --long
 ```
 
+### Benchmark Router Responses
+
+This adapter reuses the existing multi-turn workload generator against a router
+Responses endpoint without replacing the direct-server scripts above.
+
+HTTP SSE and WebSocket comparison on a regular gRPC-worker router:
+
+```
+python3 bench_router_responses.py \
+  --base-url http://127.0.0.1:30000 \
+  --model Qwen/Qwen2.5-72B-Instruct \
+  --tokenizer Qwen/Qwen2.5-72B-Instruct \
+  --client-transport both \
+  --chain-mode full_replay \
+  --store-mode true \
+  --worker-transport grpc \
+  --router-topology regular_grpc_worker
+```
+
+Persistent WebSocket continuation path with incremental `previous_response_id`
+chaining:
+
+```
+python3 bench_router_responses.py \
+  --base-url http://127.0.0.1:30000 \
+  --model Qwen/Qwen2.5-72B-Instruct \
+  --tokenizer Qwen/Qwen2.5-72B-Instruct \
+  --client-transport websocket \
+  --chain-mode previous_response_id \
+  --store-mode false \
+  --worker-transport grpc \
+  --router-topology regular_grpc_worker
+```
+
+Notes:
+
+- `full_replay` mirrors the direct multi-turn-chat shape by replaying the full
+  local conversation window each turn.
+- `previous_response_id` isolates the Responses continuation path instead.
+- HTTP SSE with `previous_response_id` requires `--store-mode true`; otherwise
+  the chain cannot continue across requests.
+- Add `--capture-event-trace` to record bounded per-turn event timing traces in
+  the JSON summary. This is useful when comparing HTTP `first_event` vs
+  `first_content` gaps against the persistent WebSocket path.
+
 ### Benchmark vLLM
 
 Run Llama-7B

--- a/benchmark/multi_turn_chat/bench_router_responses.py
+++ b/benchmark/multi_turn_chat/bench_router_responses.py
@@ -89,7 +89,9 @@ class ResponseTimingTracker:
             "request_to_first_event_ms": first_event_ms,
             "request_to_first_content_ms": first_content_ms,
             "request_to_completed_ms": completed_ms,
-            "first_event_to_first_content_ms": max(first_content_ms - first_event_ms, 0.0),
+            "first_event_to_first_content_ms": max(
+                first_content_ms - first_event_ms, 0.0
+            ),
             "first_content_to_completed_ms": max(completed_ms - first_content_ms, 0.0),
             "event_count": self.event_count,
             "output_text_delta_count": self.output_text_delta_count,
@@ -120,7 +122,9 @@ def _topology_overlay(router_topology: str) -> str:
     return "none"
 
 
-def _benchmark_contract(args: argparse.Namespace, client_transport: str) -> dict[str, str]:
+def _benchmark_contract(
+    args: argparse.Namespace, client_transport: str
+) -> dict[str, str]:
     return {
         "benchmark_family": "long_context_multiturn_qos",
         "run_class": "router_multiturn_adapter",
@@ -215,7 +219,9 @@ def _event_type(event: dict[str, Any]) -> str:
 
 def _parse_sse_event(lines: list[str]) -> dict[str, Any] | None:
     data_lines = [
-        line.removeprefix("data:").lstrip() for line in lines if line.startswith("data:")
+        line.removeprefix("data:").lstrip()
+        for line in lines
+        if line.startswith("data:")
     ]
     if not data_lines:
         return None
@@ -378,10 +384,15 @@ def _run_http_chain(
             "max_output_tokens": int(qa["new_tokens"]),
             "store": config.store,
         }
-        if config.chain_mode == "previous_response_id" and previous_response_id is not None:
+        if (
+            config.chain_mode == "previous_response_id"
+            and previous_response_id is not None
+        ):
             request["previous_response_id"] = previous_response_id
 
-        request_payload_bytes = len(json.dumps({**request, "stream": True}).encode("utf-8"))
+        request_payload_bytes = len(
+            json.dumps({**request, "stream": True}).encode("utf-8")
+        )
         response, metrics = _collect_http_response(config, request)
         assistant_text = _response_output_text_from_http_response(response)
         if config.chain_mode == "full_replay":
@@ -459,7 +470,9 @@ async def _run_ws_chain_async(
             )
             assistant_text = _response_output_text_from_ws_response(response)
             if config.chain_mode == "full_replay":
-                _append_full_replay_turn(conversation, str(qa["prompt"]), assistant_text)
+                _append_full_replay_turn(
+                    conversation, str(qa["prompt"]), assistant_text
+                )
             previous_response_id = response.get("id")
             total_request_payload_bytes += request_payload_bytes
 
@@ -525,7 +538,9 @@ def _summarize_transport(
         for turn in result["per_turn"]
     ]
     event_counts = [
-        float(turn["event_count"]) for result in chain_results for turn in result["per_turn"]
+        float(turn["event_count"])
+        for result in chain_results
+        for turn in result["per_turn"]
     ]
     output_text_delta_counts = [
         float(turn["output_text_delta_count"])
@@ -719,7 +734,12 @@ def parse_args() -> argparse.Namespace:
         "--router-topology",
         type=str,
         default="unknown",
-        choices=["unknown", "regular_http_worker", "regular_grpc_worker", "pd_http_workers"],
+        choices=[
+            "unknown",
+            "regular_http_worker",
+            "regular_grpc_worker",
+            "pd_http_workers",
+        ],
         help="Metadata label for the router topology.",
     )
     parser.add_argument("--parallel", type=int, default=1)

--- a/benchmark/multi_turn_chat/bench_router_responses.py
+++ b/benchmark/multi_turn_chat/bench_router_responses.py
@@ -1,0 +1,821 @@
+"""Multi-turn Responses API benchmark for sgl-model-gateway.
+
+Measures per-turn latency over HTTP SSE and WebSocket transports against a
+running gateway, reusing the existing multi-turn workload generator.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import statistics
+import sys
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+try:
+    from . import data_gen
+except ImportError:
+    import data_gen
+
+
+DEFAULT_API_KEY = "not-used"
+
+
+@dataclass(frozen=True)
+class ChainRuntimeConfig:
+    base_url: str
+    model: str
+    api_key: str
+    client_transport: str
+    chain_mode: str
+    store: bool
+    request_timeout_secs: float
+    capture_event_trace: bool
+    event_trace_limit: int
+
+
+@dataclass
+class ResponseTimingTracker:
+    request_started_at: float
+    capture_event_trace: bool
+    event_trace_limit: int
+    first_event_ms: float | None = None
+    first_content_ms: float | None = None
+    completed_ms: float | None = None
+    event_count: int = 0
+    output_text_delta_count: int = 0
+    event_trace: list[dict[str, Any]] = field(default_factory=list)
+
+    def observe(self, event: dict[str, Any], observed_at: float) -> None:
+        elapsed_ms = (observed_at - self.request_started_at) * 1000
+        event_type = _event_type(event)
+        if self.first_event_ms is None:
+            self.first_event_ms = elapsed_ms
+
+        delta_chars = 0
+        if event_type == "response.output_text.delta":
+            delta = event.get("delta")
+            if isinstance(delta, str) and delta:
+                self.output_text_delta_count += 1
+                delta_chars = len(delta)
+                if self.first_content_ms is None:
+                    self.first_content_ms = elapsed_ms
+
+        if event_type == "response.completed":
+            self.completed_ms = elapsed_ms
+
+        self.event_count += 1
+        if self.capture_event_trace and len(self.event_trace) < self.event_trace_limit:
+            self.event_trace.append(
+                {
+                    "event_type": event_type,
+                    "t_ms": elapsed_ms,
+                    "delta_chars": delta_chars,
+                }
+            )
+
+    def metrics(self) -> dict[str, Any]:
+        completed_ms = self.completed_ms or 0.0
+        first_event_ms = self.first_event_ms or 0.0
+        first_content_ms = self.first_content_ms or completed_ms
+        return {
+            "request_to_first_event_ms": first_event_ms,
+            "request_to_first_content_ms": first_content_ms,
+            "request_to_completed_ms": completed_ms,
+            "first_event_to_first_content_ms": max(first_content_ms - first_event_ms, 0.0),
+            "first_content_to_completed_ms": max(completed_ms - first_content_ms, 0.0),
+            "event_count": self.event_count,
+            "output_text_delta_count": self.output_text_delta_count,
+            "event_trace": self.event_trace if self.capture_event_trace else [],
+        }
+
+
+def _normalize_base_url(base_url: str) -> str:
+    if "://" not in base_url:
+        return f"http://{base_url.rstrip('/')}"
+    return base_url.rstrip("/")
+
+
+def _gateway_ws_url(base_url: str) -> str:
+    normalized = _normalize_base_url(base_url)
+    if normalized.startswith("https://"):
+        return f"wss://{normalized.removeprefix('https://')}/v1/responses"
+    return f"ws://{normalized.removeprefix('http://')}/v1/responses"
+
+
+def _store_mode_label(store: bool) -> str:
+    return "store_true" if store else "store_false"
+
+
+def _topology_overlay(router_topology: str) -> str:
+    if router_topology == "pd_http_workers":
+        return "pd"
+    return "none"
+
+
+def _benchmark_contract(args: argparse.Namespace, client_transport: str) -> dict[str, str]:
+    return {
+        "benchmark_family": "long_context_multiturn_qos",
+        "run_class": "router_multiturn_adapter",
+        "client_transport": client_transport,
+        "worker_transport": args.worker_transport,
+        "router_topology": args.router_topology,
+        "model_id": args.model,
+        "topology_overlay": _topology_overlay(args.router_topology),
+        "store_mode": _store_mode_label(args.store_mode == "true"),
+        "workload_kind": f"multi_turn_chat_{args.chain_mode}",
+    }
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = (len(ordered) - 1) * percentile
+    lower = int(rank)
+    upper = min(lower + 1, len(ordered) - 1)
+    weight = rank - lower
+    return ordered[lower] * (1 - weight) + ordered[upper] * weight
+
+
+def _user_message(text: str) -> dict[str, Any]:
+    return {
+        "type": "message",
+        "role": "user",
+        "content": [{"type": "input_text", "text": text}],
+    }
+
+
+def _assistant_message(text: str) -> dict[str, Any]:
+    return {
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": text}],
+    }
+
+
+def _prepare_turn_input(
+    chain_mode: str,
+    conversation: list[dict[str, Any]],
+    prompt: str,
+) -> list[dict[str, Any]] | str:
+    if chain_mode == "previous_response_id":
+        return prompt
+    return [*conversation, _user_message(prompt)]
+
+
+def _response_output_text_from_http_response(response: Any) -> str:
+    output_text = response.get("output_text")
+    if isinstance(output_text, str) and output_text.strip():
+        return output_text
+
+    for item in response.get("output", []):
+        if not isinstance(item, dict) or item.get("type") != "message":
+            continue
+        for content_part in item.get("content", []):
+            if not isinstance(content_part, dict):
+                continue
+            text = content_part.get("text")
+            if isinstance(text, str) and text.strip():
+                return text
+    return ""
+
+
+def _response_output_text_from_ws_response(response: dict[str, Any]) -> str:
+    for item in response.get("output", []):
+        if not isinstance(item, dict) or item.get("type") != "message":
+            continue
+        for content_part in item.get("content", []):
+            if not isinstance(content_part, dict):
+                continue
+            text = content_part.get("text")
+            if isinstance(text, str) and text.strip():
+                return text
+    return ""
+
+
+def _event_type(event: dict[str, Any]) -> str:
+    event_type = event.get("type")
+    if isinstance(event_type, str) and event_type:
+        return event_type
+    sse_event_name = event.get("_sse_event_name")
+    if isinstance(sse_event_name, str) and sse_event_name:
+        return sse_event_name
+    return "unknown"
+
+
+def _parse_sse_event(lines: list[str]) -> dict[str, Any] | None:
+    data_lines = [
+        line.removeprefix("data:").lstrip() for line in lines if line.startswith("data:")
+    ]
+    if not data_lines:
+        return None
+    payload_text = "\n".join(data_lines)
+    if payload_text == "[DONE]":
+        return None
+
+    event = json.loads(payload_text)
+    event_name = next(
+        (
+            line.removeprefix("event:").lstrip()
+            for line in lines
+            if line.startswith("event:")
+        ),
+        None,
+    )
+    if event_name and isinstance(event, dict) and "_sse_event_name" not in event:
+        event["_sse_event_name"] = event_name
+    return event
+
+
+def _http_stream_events(
+    base_url: str,
+    request: dict[str, Any],
+    timeout_secs: float,
+):
+    payload = {**request, "stream": True}
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        f"{_normalize_base_url(base_url)}/v1/responses",
+        data=data,
+        headers={
+            "Accept": "text/event-stream",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+
+    try:
+        response = urllib.request.urlopen(req, timeout=timeout_secs)
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(
+            f"HTTP response chain request failed status={exc.code} body={body}"
+        ) from exc
+
+    with response:
+        event_lines: list[str] = []
+
+        while True:
+            raw_line = response.readline()
+            if not raw_line:
+                if event_lines:
+                    event = _parse_sse_event(event_lines)
+                    if event is not None:
+                        yield event
+                break
+
+            line = raw_line.decode("utf-8", errors="replace").rstrip("\r\n")
+            if not line:
+                if not event_lines:
+                    continue
+                event = _parse_sse_event(event_lines)
+                event_lines = []
+                if event is not None:
+                    yield event
+                continue
+
+            if line.startswith(":"):
+                continue
+
+            event_lines.append(line)
+
+
+def _collect_http_response(
+    config: ChainRuntimeConfig,
+    request: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    request_started_at = time.perf_counter()
+    tracker = ResponseTimingTracker(
+        request_started_at=request_started_at,
+        capture_event_trace=config.capture_event_trace,
+        event_trace_limit=config.event_trace_limit,
+    )
+
+    for event in _http_stream_events(
+        config.base_url,
+        request,
+        config.request_timeout_secs,
+    ):
+        now = time.perf_counter()
+        tracker.observe(event, now)
+        event_type = _event_type(event)
+
+        if event_type in {"error", "response.failed", "response.incomplete"}:
+            raise RuntimeError(f"HTTP response chain failed with event={event_type}")
+
+        if event_type == "response.completed":
+            return event["response"], tracker.metrics()
+
+    raise RuntimeError("HTTP response stream ended without response.completed")
+
+
+async def _collect_ws_response(
+    websocket: Any,
+    config: ChainRuntimeConfig,
+    request: dict[str, Any],
+    timeout_secs: float,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    request_started_at = time.perf_counter()
+    await websocket.send(json.dumps({"type": "response.create", **request}))
+    tracker = ResponseTimingTracker(
+        request_started_at=request_started_at,
+        capture_event_trace=config.capture_event_trace,
+        event_trace_limit=config.event_trace_limit,
+    )
+
+    while True:
+        payload = await asyncio.wait_for(websocket.recv(), timeout=timeout_secs)
+        event = json.loads(payload)
+        now = time.perf_counter()
+        tracker.observe(event, now)
+
+        if event.get("type") == "error":
+            raise RuntimeError(f"WebSocket response chain failed with event={event}")
+
+        if event.get("type") == "response.completed":
+            return event["response"], tracker.metrics()
+
+
+def _append_full_replay_turn(
+    conversation: list[dict[str, Any]],
+    prompt: str,
+    assistant_text: str,
+) -> None:
+    conversation.append(_user_message(prompt))
+    conversation.append(_assistant_message(assistant_text))
+
+
+def _run_http_chain(
+    config: ChainRuntimeConfig,
+    qas: list[dict[str, int | str]],
+) -> dict[str, Any]:
+    conversation: list[dict[str, Any]] = []
+    previous_response_id: str | None = None
+    per_turn: list[dict[str, Any]] = []
+    total_request_payload_bytes = 0
+    chain_started_at = time.perf_counter()
+
+    for turn_index, qa in enumerate(qas, start=1):
+        turn_input = _prepare_turn_input(
+            config.chain_mode,
+            conversation,
+            str(qa["prompt"]),
+        )
+        request = {
+            "model": config.model,
+            "input": turn_input,
+            "temperature": 0,
+            "max_output_tokens": int(qa["new_tokens"]),
+            "store": config.store,
+        }
+        if config.chain_mode == "previous_response_id" and previous_response_id is not None:
+            request["previous_response_id"] = previous_response_id
+
+        request_payload_bytes = len(json.dumps({**request, "stream": True}).encode("utf-8"))
+        response, metrics = _collect_http_response(config, request)
+        assistant_text = _response_output_text_from_http_response(response)
+        if config.chain_mode == "full_replay":
+            _append_full_replay_turn(conversation, str(qa["prompt"]), assistant_text)
+        previous_response_id = response.get("id")
+        total_request_payload_bytes += request_payload_bytes
+
+        per_turn.append(
+            {
+                "turn_index": turn_index,
+                "prompt_len": len(str(qa["prompt"])),
+                "max_output_tokens": int(qa["new_tokens"]),
+                "response_id": previous_response_id,
+                "request_payload_bytes": request_payload_bytes,
+                "output_text": assistant_text,
+                **metrics,
+            }
+        )
+
+    return {
+        "turn_count": len(qas),
+        "total_chain_ms": (time.perf_counter() - chain_started_at) * 1000,
+        "connect_ms": 0.0,
+        "total_request_payload_bytes": total_request_payload_bytes,
+        "per_turn": per_turn,
+    }
+
+
+async def _run_ws_chain_async(
+    config: ChainRuntimeConfig,
+    qas: list[dict[str, int | str]],
+) -> dict[str, Any]:
+    import websockets
+
+    conversation: list[dict[str, Any]] = []
+    previous_response_id: str | None = None
+    per_turn: list[dict[str, Any]] = []
+    total_request_payload_bytes = 0
+    chain_started_at = time.perf_counter()
+    connect_started_at = time.perf_counter()
+
+    async with websockets.connect(
+        _gateway_ws_url(config.base_url),
+        open_timeout=30,
+        close_timeout=5,
+    ) as websocket:
+        connect_ms = (time.perf_counter() - connect_started_at) * 1000
+        for turn_index, qa in enumerate(qas, start=1):
+            turn_input = _prepare_turn_input(
+                config.chain_mode,
+                conversation,
+                str(qa["prompt"]),
+            )
+            request = {
+                "model": config.model,
+                "input": turn_input,
+                "temperature": 0,
+                "max_output_tokens": int(qa["new_tokens"]),
+                "store": config.store,
+            }
+            if (
+                config.chain_mode == "previous_response_id"
+                and previous_response_id is not None
+            ):
+                request["previous_response_id"] = previous_response_id
+
+            request_payload_bytes = len(
+                json.dumps({"type": "response.create", **request}).encode("utf-8")
+            )
+            response, metrics = await _collect_ws_response(
+                websocket,
+                config,
+                request,
+                config.request_timeout_secs,
+            )
+            assistant_text = _response_output_text_from_ws_response(response)
+            if config.chain_mode == "full_replay":
+                _append_full_replay_turn(conversation, str(qa["prompt"]), assistant_text)
+            previous_response_id = response.get("id")
+            total_request_payload_bytes += request_payload_bytes
+
+            per_turn.append(
+                {
+                    "turn_index": turn_index,
+                    "prompt_len": len(str(qa["prompt"])),
+                    "max_output_tokens": int(qa["new_tokens"]),
+                    "response_id": previous_response_id,
+                    "request_payload_bytes": request_payload_bytes,
+                    "output_text": assistant_text,
+                    **metrics,
+                }
+            )
+
+    return {
+        "turn_count": len(qas),
+        "total_chain_ms": (time.perf_counter() - chain_started_at) * 1000,
+        "connect_ms": connect_ms,
+        "total_request_payload_bytes": total_request_payload_bytes,
+        "per_turn": per_turn,
+    }
+
+
+def _run_ws_chain(
+    config: ChainRuntimeConfig,
+    qas: list[dict[str, int | str]],
+) -> dict[str, Any]:
+    return asyncio.run(_run_ws_chain_async(config, qas))
+
+
+def _summarize_transport(
+    *,
+    args: argparse.Namespace,
+    client_transport: str,
+    chain_results: list[dict[str, Any]],
+    wall_clock_ms: float,
+) -> dict[str, Any]:
+    chain_totals = [float(result["total_chain_ms"]) for result in chain_results]
+    turn_totals = [
+        float(turn["request_to_completed_ms"])
+        for result in chain_results
+        for turn in result["per_turn"]
+    ]
+    first_events = [
+        float(turn["request_to_first_event_ms"])
+        for result in chain_results
+        for turn in result["per_turn"]
+    ]
+    first_content = [
+        float(turn["request_to_first_content_ms"])
+        for result in chain_results
+        for turn in result["per_turn"]
+    ]
+    first_event_to_first_content = [
+        float(turn["first_event_to_first_content_ms"])
+        for result in chain_results
+        for turn in result["per_turn"]
+    ]
+    first_content_to_completed = [
+        float(turn["first_content_to_completed_ms"])
+        for result in chain_results
+        for turn in result["per_turn"]
+    ]
+    event_counts = [
+        float(turn["event_count"]) for result in chain_results for turn in result["per_turn"]
+    ]
+    output_text_delta_counts = [
+        float(turn["output_text_delta_count"])
+        for result in chain_results
+        for turn in result["per_turn"]
+    ]
+    connect_ms = [float(result.get("connect_ms", 0.0)) for result in chain_results]
+    request_payload_totals = [
+        float(result["total_request_payload_bytes"]) for result in chain_results
+    ]
+
+    return {
+        "benchmark_contract": _benchmark_contract(args, client_transport),
+        "chain_results": chain_results,
+        "summary": {
+            "chains": len(chain_results),
+            "turns": sum(int(result["turn_count"]) for result in chain_results),
+            "wall_clock_ms": wall_clock_ms,
+            "chain_ms_mean": statistics.fmean(chain_totals) if chain_totals else 0.0,
+            "chain_ms_p50": _percentile(chain_totals, 0.50),
+            "chain_ms_p95": _percentile(chain_totals, 0.95),
+            "turn_ms_mean": statistics.fmean(turn_totals) if turn_totals else 0.0,
+            "turn_ms_p50": _percentile(turn_totals, 0.50),
+            "turn_ms_p95": _percentile(turn_totals, 0.95),
+            "first_event_ms_p50": _percentile(first_events, 0.50),
+            "first_content_ms_p50": _percentile(first_content, 0.50),
+            "first_event_to_first_content_ms_p50": _percentile(
+                first_event_to_first_content, 0.50
+            ),
+            "first_content_to_completed_ms_p50": _percentile(
+                first_content_to_completed, 0.50
+            ),
+            "event_count_mean": statistics.fmean(event_counts) if event_counts else 0.0,
+            "output_text_delta_count_mean": (
+                statistics.fmean(output_text_delta_counts)
+                if output_text_delta_counts
+                else 0.0
+            ),
+            "connect_ms_mean": statistics.fmean(connect_ms) if connect_ms else 0.0,
+            "request_payload_bytes_total_mean": (
+                statistics.fmean(request_payload_totals)
+                if request_payload_totals
+                else 0.0
+            ),
+            "request_payload_bytes_total_p50": _percentile(
+                request_payload_totals, 0.50
+            ),
+            "request_payload_bytes_total_p95": _percentile(
+                request_payload_totals, 0.95
+            ),
+        },
+    }
+
+
+def _run_transport(
+    *,
+    args: argparse.Namespace,
+    client_transport: str,
+    workloads: list[dict[str, Any]],
+) -> dict[str, Any]:
+    config = ChainRuntimeConfig(
+        base_url=args.base_url,
+        model=args.model,
+        api_key=args.api_key,
+        client_transport=client_transport,
+        chain_mode=args.chain_mode,
+        store=args.store_mode == "true",
+        request_timeout_secs=args.request_timeout_secs,
+        capture_event_trace=args.capture_event_trace,
+        event_trace_limit=args.event_trace_limit,
+    )
+
+    chain_runner = _run_http_chain if client_transport == "http_sse" else _run_ws_chain
+    started_at = time.perf_counter()
+    chain_results: list[dict[str, Any]] = []
+    with ThreadPoolExecutor(max_workers=args.parallel) as executor:
+        futures = [
+            executor.submit(chain_runner, config, workload["qas"])
+            for workload in workloads
+        ]
+        for future in as_completed(futures):
+            chain_results.append(future.result())
+
+    wall_clock_ms = (time.perf_counter() - started_at) * 1000
+    return _summarize_transport(
+        args=args,
+        client_transport=client_transport,
+        chain_results=chain_results,
+        wall_clock_ms=wall_clock_ms,
+    )
+
+
+def _transport_targets(client_transport: str) -> list[str]:
+    if client_transport == "both":
+        return ["http_sse", "websocket"]
+    return [client_transport]
+
+
+def _build_workloads(args: argparse.Namespace) -> list[dict[str, Any]]:
+    data_gen.random.seed(args.seed)
+    try:
+        from vllm.transformers_utils.tokenizer import get_tokenizer
+
+        tokenizer = get_tokenizer(
+            args.tokenizer, trust_remote_code=args.trust_remote_code
+        )
+    except ModuleNotFoundError:
+        from transformers import AutoTokenizer
+
+        tokenizer = AutoTokenizer.from_pretrained(
+            args.tokenizer,
+            trust_remote_code=args.trust_remote_code,
+        )
+    return data_gen.gen_arguments(args, tokenizer)
+
+
+def _write_summary(path: str | None, payload: dict[str, Any]) -> None:
+    if not path:
+        return
+    out_path = Path(path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2))
+
+
+def _append_result_line(path: str | None, payload: dict[str, Any]) -> None:
+    if not path:
+        return
+    out_path = Path(path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("a") as fout:
+        fout.write(json.dumps(payload) + "\n")
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if args.parallel < 1:
+        raise ValueError("--parallel must be >= 1")
+    if getattr(args, "event_trace_limit", 1) < 1:
+        raise ValueError("--event-trace-limit must be >= 1")
+    if args.client_transport in {"http_sse", "both"}:
+        if args.chain_mode == "previous_response_id" and args.store_mode == "false":
+            raise ValueError(
+                "HTTP SSE with --chain-mode previous_response_id requires --store-mode true"
+            )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Benchmark the router Responses path using the existing multi-turn-chat "
+            "workload generator."
+        )
+    )
+    parser.add_argument("--base-url", type=str, required=True, help="Router base URL.")
+    parser.add_argument("--model", type=str, required=True, help="Responses model id.")
+    parser.add_argument("--tokenizer", type=str, required=True, help="Tokenizer id.")
+    parser.add_argument(
+        "--api-key",
+        type=str,
+        default=DEFAULT_API_KEY,
+        help="OpenAI-compatible API key value.",
+    )
+    parser.add_argument(
+        "--client-transport",
+        type=str,
+        default="both",
+        choices=["http_sse", "websocket", "both"],
+        help="Client-to-router transport to benchmark.",
+    )
+    parser.add_argument(
+        "--chain-mode",
+        type=str,
+        default="full_replay",
+        choices=["full_replay", "previous_response_id"],
+        help="Conversation chaining strategy.",
+    )
+    parser.add_argument(
+        "--store-mode",
+        type=str,
+        default="true",
+        choices=["true", "false"],
+        help="Whether to set store=true or store=false on Responses requests.",
+    )
+    parser.add_argument(
+        "--worker-transport",
+        type=str,
+        default="unknown",
+        choices=["unknown", "http", "grpc"],
+        help="Metadata label for the router-to-worker transport.",
+    )
+    parser.add_argument(
+        "--router-topology",
+        type=str,
+        default="unknown",
+        choices=["unknown", "regular_http_worker", "regular_grpc_worker", "pd_http_workers"],
+        help="Metadata label for the router topology.",
+    )
+    parser.add_argument("--parallel", type=int, default=1)
+    parser.add_argument("--turns", type=int, default=4)
+    parser.add_argument("--num-qa", type=int, default=20)
+    parser.add_argument("--min-len-q", type=int, default=256)
+    parser.add_argument("--max-len-q", type=int, default=512)
+    parser.add_argument("--min-len-a", type=int, default=4)
+    parser.add_argument("--max-len-a", type=int, default=8)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--request-timeout-secs", type=float, default=180)
+    parser.add_argument(
+        "--capture-event-trace",
+        action="store_true",
+        help="Capture a bounded per-turn event trace in the summary output.",
+    )
+    parser.add_argument(
+        "--event-trace-limit",
+        type=int,
+        default=12,
+        help="Maximum number of event trace entries to record per turn.",
+    )
+    parser.add_argument("--trust-remote-code", action="store_true")
+    parser.add_argument("--long", action="store_true")
+    parser.add_argument(
+        "--result-file",
+        type=str,
+        default=None,
+        help="JSONL file for compact run summaries (omit to skip file output).",
+    )
+    parser.add_argument(
+        "--summary-file",
+        type=str,
+        default=None,
+        help="JSON file for full run details (omit to skip file output).",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    args.base_url = _normalize_base_url(args.base_url)
+
+    if args.long:
+        args.min_len_a = 256
+        args.max_len_a = 512
+        args.num_qa = 20
+
+    _validate_args(args)
+    workloads = _build_workloads(args)
+
+    transport_results = {}
+    for client_transport in _transport_targets(args.client_transport):
+        transport_results[client_transport] = _run_transport(
+            args=args,
+            client_transport=client_transport,
+            workloads=workloads,
+        )
+
+    payload = {
+        "task": "multi_turn_chat_router_responses",
+        "router_url": args.base_url,
+        "model": args.model,
+        "tokenizer": args.tokenizer,
+        "chain_mode": args.chain_mode,
+        "store_mode": _store_mode_label(args.store_mode == "true"),
+        "parallel": args.parallel,
+        "num_requests": args.num_qa,
+        "num_turns": args.turns,
+        "request_length_range": [args.min_len_q, args.max_len_q],
+        "output_length_range": [args.min_len_a, args.max_len_a],
+        "results": transport_results,
+    }
+
+    _write_summary(args.summary_file, payload)
+    _append_result_line(
+        args.result_file,
+        {
+            "task": payload["task"],
+            "router_url": args.base_url,
+            "model": args.model,
+            "chain_mode": args.chain_mode,
+            "store_mode": payload["store_mode"],
+            "parallel": args.parallel,
+            "num_requests": args.num_qa,
+            "num_turns": args.turns,
+            "results": {
+                transport: result["summary"]
+                for transport, result in transport_results.items()
+            },
+        },
+    )
+
+    print(json.dumps(payload["results"], indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmark/multi_turn_chat/test_router_responses.py
+++ b/benchmark/multi_turn_chat/test_router_responses.py
@@ -51,7 +51,10 @@ def test_benchmark_contract_carries_router_axes():
 def test_prepare_turn_input_modes():
     conversation = [bench._user_message("first"), bench._assistant_message("reply")]
 
-    assert bench._prepare_turn_input("previous_response_id", conversation, "next") == "next"
+    assert (
+        bench._prepare_turn_input("previous_response_id", conversation, "next")
+        == "next"
+    )
     assert bench._prepare_turn_input("full_replay", conversation, "next") == [
         *conversation,
         bench._user_message("next"),
@@ -95,7 +98,11 @@ def test_response_timing_tracker_records_phase_gaps_and_trace():
     assert metrics["event_count"] == 3
     assert metrics["output_text_delta_count"] == 1
     assert metrics["event_trace"] == [
-        {"event_type": "response.created", "t_ms": pytest.approx(10.0), "delta_chars": 0},
+        {
+            "event_type": "response.created",
+            "t_ms": pytest.approx(10.0),
+            "delta_chars": 0,
+        },
         {
             "event_type": "response.output_text.delta",
             "t_ms": pytest.approx(40.0),

--- a/benchmark/multi_turn_chat/test_router_responses.py
+++ b/benchmark/multi_turn_chat/test_router_responses.py
@@ -1,0 +1,117 @@
+"""Unit tests for the router Responses benchmark adapter."""
+
+from __future__ import annotations
+
+from argparse import Namespace
+
+import pytest
+
+from benchmark.multi_turn_chat import bench_router_responses as bench
+
+
+def test_validate_args_rejects_http_previous_response_without_store():
+    args = Namespace(
+        parallel=1,
+        client_transport="http_sse",
+        chain_mode="previous_response_id",
+        store_mode="false",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="HTTP SSE with --chain-mode previous_response_id requires --store-mode true",
+    ):
+        bench._validate_args(args)
+
+
+def test_benchmark_contract_carries_router_axes():
+    args = Namespace(
+        model="Qwen/Qwen2.5-72B-Instruct",
+        worker_transport="grpc",
+        router_topology="regular_grpc_worker",
+        store_mode="true",
+        chain_mode="full_replay",
+    )
+
+    contract = bench._benchmark_contract(args, "websocket")
+
+    assert contract == {
+        "benchmark_family": "long_context_multiturn_qos",
+        "run_class": "router_multiturn_adapter",
+        "client_transport": "websocket",
+        "worker_transport": "grpc",
+        "router_topology": "regular_grpc_worker",
+        "model_id": "Qwen/Qwen2.5-72B-Instruct",
+        "topology_overlay": "none",
+        "store_mode": "store_true",
+        "workload_kind": "multi_turn_chat_full_replay",
+    }
+
+
+def test_prepare_turn_input_modes():
+    conversation = [bench._user_message("first"), bench._assistant_message("reply")]
+
+    assert bench._prepare_turn_input("previous_response_id", conversation, "next") == "next"
+    assert bench._prepare_turn_input("full_replay", conversation, "next") == [
+        *conversation,
+        bench._user_message("next"),
+    ]
+
+
+def test_parse_sse_event_preserves_event_name_and_multiline_payload():
+    event = bench._parse_sse_event(
+        [
+            "event: response.completed",
+            'data: {"type":"response.completed",',
+            'data: "response":{"id":"resp_123"}}',
+        ]
+    )
+
+    assert event == {
+        "type": "response.completed",
+        "response": {"id": "resp_123"},
+        "_sse_event_name": "response.completed",
+    }
+
+
+def test_response_timing_tracker_records_phase_gaps_and_trace():
+    tracker = bench.ResponseTimingTracker(
+        request_started_at=10.0,
+        capture_event_trace=True,
+        event_trace_limit=2,
+    )
+
+    tracker.observe({"type": "response.created"}, 10.010)
+    tracker.observe({"type": "response.output_text.delta", "delta": "hello"}, 10.040)
+    tracker.observe({"type": "response.completed"}, 10.070)
+
+    metrics = tracker.metrics()
+
+    assert metrics["request_to_first_event_ms"] == pytest.approx(10.0)
+    assert metrics["request_to_first_content_ms"] == pytest.approx(40.0)
+    assert metrics["request_to_completed_ms"] == pytest.approx(70.0)
+    assert metrics["first_event_to_first_content_ms"] == pytest.approx(30.0)
+    assert metrics["first_content_to_completed_ms"] == pytest.approx(30.0)
+    assert metrics["event_count"] == 3
+    assert metrics["output_text_delta_count"] == 1
+    assert metrics["event_trace"] == [
+        {"event_type": "response.created", "t_ms": pytest.approx(10.0), "delta_chars": 0},
+        {
+            "event_type": "response.output_text.delta",
+            "t_ms": pytest.approx(40.0),
+            "delta_chars": 5,
+        },
+    ]
+
+
+def test_validate_args_rejects_non_positive_event_trace_limit():
+    args = Namespace(
+        parallel=1,
+        client_transport="websocket",
+        chain_mode="full_replay",
+        store_mode="false",
+        event_trace_limit=0,
+    )
+
+    with pytest.raises(ValueError, match="--event-trace-limit must be >= 1"):
+        bench._validate_args(args)

--- a/python/sglang/srt/utils/__init__.py
+++ b/python/sglang/srt/utils/__init__.py
@@ -1,3 +1,5 @@
 # Temporarily do this to avoid changing all imports in the repo
 from sglang.srt.utils.common import *
-from sglang.srt.utils.network import get_zmq_socket  # noqa: F401  # re-export for smg-grpc-servicer compat
+from sglang.srt.utils.network import (  # noqa: F401  # re-export for smg-grpc-servicer compat
+    get_zmq_socket,
+)

--- a/python/sglang/srt/utils/__init__.py
+++ b/python/sglang/srt/utils/__init__.py
@@ -1,2 +1,3 @@
 # Temporarily do this to avoid changing all imports in the repo
 from sglang.srt.utils.common import *
+from sglang.srt.utils.network import get_zmq_socket  # noqa: F401  # re-export for smg-grpc-servicer compat

--- a/sgl-model-gateway/Cargo.toml
+++ b/sgl-model-gateway/Cargo.toml
@@ -141,6 +141,7 @@ opentelemetry-proto = { version = "0.27", features = ["gen-tonic"] }
 tonic-v12 = { version = "0.12.3", package = "tonic" }
 serial_test = "3.0"
 rsa = { version = "0.9", features = ["sha2"] }
+tokio-tungstenite = "0.27"
 
 [[bench]]
 name = "consistent_hash_bench"
@@ -163,6 +164,11 @@ harness = false
 name = "manual_policy_benchmark"
 harness = false
 path = "benches/manual_policy_benchmark.rs"
+
+[[bench]]
+name = "ws_response_hotpath"
+harness = false
+path = "benches/ws_response_hotpath.rs"
 
 [profile.release]
 opt-level = "z"     # Optimize for size

--- a/sgl-model-gateway/benches/ws_response_hotpath.rs
+++ b/sgl-model-gateway/benches/ws_response_hotpath.rs
@@ -1,0 +1,85 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use smg::bench_support;
+
+fn bench_frame_emission(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ws_frame_emission");
+
+    for (delta_events, delta_bytes) in [(16usize, 64usize), (64, 128), (128, 256)] {
+        let label = format!("{delta_events}x{delta_bytes}");
+        group.throughput(Throughput::Bytes((delta_events * delta_bytes) as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("ws", &label),
+            &(delta_events, delta_bytes),
+            |b, &(events, bytes)| {
+                b.iter(|| black_box(bench_support::bench_emit_ws_text_stream(events, bytes)));
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("sse", &label),
+            &(delta_events, delta_bytes),
+            |b, &(events, bytes)| {
+                b.iter(|| black_box(bench_support::bench_emit_sse_text_stream(events, bytes)));
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_cached_continuation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cached_continuation_shape");
+
+    for history_turns in [4usize, 16, 64] {
+        group.bench_with_input(
+            BenchmarkId::new("cached_to_items", history_turns),
+            &history_turns,
+            |b, &turns| {
+                b.iter(|| black_box(bench_support::bench_cached_response_to_items(turns, 256)));
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("cache_hit_merge", history_turns),
+            &history_turns,
+            |b, &turns| {
+                b.iter(|| {
+                    black_box(bench_support::bench_cached_continuation_shape(
+                        turns, 256, 4, 256,
+                    ))
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_incremental_input_shaping(c: &mut Criterion) {
+    let mut group = c.benchmark_group("incremental_input_shaping");
+
+    for item_count in [8usize, 32, 128, 512] {
+        group.bench_with_input(
+            BenchmarkId::new("normalize_items", item_count),
+            &item_count,
+            |b, &count| {
+                b.iter(|| {
+                    black_box(bench_support::bench_normalize_incremental_request(
+                        count, 256,
+                    ))
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    ws_response_hotpath,
+    bench_frame_emission,
+    bench_cached_continuation,
+    bench_incremental_input_shaping
+);
+criterion_main!(ws_response_hotpath);

--- a/sgl-model-gateway/bindings/python/tests/test_startup_sequence.py
+++ b/sgl-model-gateway/bindings/python/tests/test_startup_sequence.py
@@ -687,6 +687,7 @@ def _install_sglang_stubs(monkeypatch):
 
     http_server_mod.launch_server = launch_server
     server_args_mod.ServerArgs = ServerArgs
+    utils_mod.is_port_available = is_port_available
     network_mod.is_port_available = is_port_available
     utils_mod.network = network_mod
 

--- a/sgl-model-gateway/e2e_test/README.md
+++ b/sgl-model-gateway/e2e_test/README.md
@@ -1,0 +1,106 @@
+# SGL Model Gateway E2E Local Loop
+
+This test harness supports heavyweight multi-model coverage, but the fastest
+local iteration path on a single GPU should stay small and reproducible.
+
+## Recommended Local WS / Responses Smoke Setup
+
+Hardware target:
+
+- Single GPU with ≥12 GB VRAM
+
+Environment:
+
+```bash
+export HF_HOME="${HOME}/.cache/huggingface"
+export SHOW_WORKER_LOGS=1
+export SHOW_ROUTER_LOGS=1
+```
+
+Install local editable packages with `uv` so the router subprocesses see current
+gateway and `sglang` code:
+
+```bash
+cd sgl-model-gateway/e2e_test
+uv pip install -p .venv/bin/python -e ../../python -e ../bindings/python
+```
+
+Optional:
+
+```bash
+# Use local unpacked model paths when available.
+export ROUTER_LOCAL_MODEL_PATH=/path/to/local/model/root
+```
+
+## Small-Model Smoke Tests
+
+Preferred smoke models:
+
+- `llama-1b` -> `meta-llama/Llama-3.2-1B-Instruct` for text-only tests
+- `qwen-7b` -> `Qwen/Qwen2.5-7B-Instruct` for function-calling tests
+
+Run the local Responses smoke tier:
+
+```bash
+cd sgl-model-gateway/e2e_test
+uv run --python .venv/bin/python \
+  pytest --workers 1 --tests-per-worker 1 responses/test_local_smoke.py
+```
+
+Run a single test first if startup or model readiness is uncertain:
+
+```bash
+cd sgl-model-gateway/e2e_test
+uv run --python .venv/bin/python \
+  pytest --workers 1 --tests-per-worker 1 \
+  responses/test_local_smoke.py -k basic_response_creation
+```
+
+Run the real WebSocket smoke path:
+
+```bash
+cd sgl-model-gateway/e2e_test
+uv run --python .venv/bin/python \
+  pytest --workers 1 --tests-per-worker 1 \
+  responses/test_local_smoke.py -k websocket_response_create
+```
+
+## WS Microbenchmark
+
+Run the lightweight local WS benchmark harness:
+
+```bash
+cd sgl-model-gateway/e2e_test
+uv run --python .venv/bin/python \
+  pytest --workers 1 --tests-per-worker 1 benchmarks/test_ws_microbench.py -q
+```
+
+Optional profile overrides:
+
+```bash
+export SGLANG_WS_BENCH_CONCURRENCY=1,2,4
+export SGLANG_WS_BENCH_SAMPLES_PER_CONCURRENCY=2
+```
+
+## HTTP vs WS Comparison
+
+Run the apples-to-apples HTTP SSE versus WebSocket comparison on the same
+prompt shape and model:
+
+```bash
+cd sgl-model-gateway/e2e_test
+export SGLANG_HTTP_WS_COMPARE_SAMPLES=1
+uv run --python .venv/bin/python \
+  pytest --workers 1 --tests-per-worker 1 \
+  benchmarks/test_ws_microbench.py -k http_vs_ws_transport_compare -q
+```
+
+## Notes
+
+- The larger default e2e models such as `llama-8b`, `qwen-14b`, and `gpt-oss`
+  are not intended to be the first green path on a single mid-range developer GPU.
+- Keep the small-model smoke path green before expanding to heavier semantic
+  or compatibility coverage.
+- Normal pytest exit now tears down the pooled local worker automatically.
+- If a run is hard-killed, kill stale `sglang.launch_server` processes before
+  rerunning if the GPU appears unexpectedly full.

--- a/sgl-model-gateway/e2e_test/benchmarks/summarize.py
+++ b/sgl-model-gateway/e2e_test/benchmarks/summarize.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 from pathlib import Path
@@ -57,6 +58,10 @@ def generate_summary(base_dir: Path) -> str:
 
     for result_path, label in benchmarks:
         try:
+            with result_path.open() as f:
+                raw = json.load(f)
+            if "aggregated_metrics" not in raw:
+                continue  # Skip non-genai-bench results (e.g. WS benchmark JSON)
             result = BenchmarkResult.from_json(result_path)
         except Exception as e:
             print(f"Warning: Failed to parse {result_path}: {e}", file=sys.stderr)

--- a/sgl-model-gateway/e2e_test/benchmarks/test_ws_bench_helpers.py
+++ b/sgl-model-gateway/e2e_test/benchmarks/test_ws_bench_helpers.py
@@ -1,0 +1,57 @@
+"""Unit tests for WS benchmark helper functions.
+
+These tests validate the benchmark contract mapping and context construction
+logic without requiring GPU or model access.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from benchmarks.test_ws_microbench import (
+    _benchmark_context,
+    _benchmark_contract,
+)
+
+
+@pytest.mark.parametrize(
+    "backend_name, expected_worker_transport, expected_router_topology",
+    [
+        ("http", "http", "regular_http_worker"),
+        ("grpc", "grpc", "regular_grpc_worker"),
+        ("pd", "http", "pd_http_workers"),
+    ],
+)
+def test_benchmark_contract_maps_backend_axes(
+    backend_name: str,
+    expected_worker_transport: str,
+    expected_router_topology: str,
+):
+    contract = _benchmark_contract(
+        **_benchmark_context(
+            benchmark_family="transport_qos",
+            run_class="test_contract",
+            backend_name=backend_name,
+            model="Qwen/Qwen2.5-72B-Instruct",
+            store_mode="store_false",
+            workload_kind="single_turn_text",
+        ),
+        client_transport="websocket",
+    )
+
+    assert contract["worker_transport"] == expected_worker_transport
+    assert contract["router_topology"] == expected_router_topology
+    assert contract["client_transport"] == "websocket"
+    assert contract["model_id"] == "Qwen/Qwen2.5-72B-Instruct"
+
+
+def test_benchmark_context_rejects_unknown_backend():
+    with pytest.raises(ValueError, match="Unsupported benchmark backend"):
+        _benchmark_context(
+            benchmark_family="transport_qos",
+            run_class="test_contract",
+            backend_name="ws_worker",
+            model="Qwen/Qwen2.5-72B-Instruct",
+            store_mode="store_false",
+            workload_kind="single_turn_text",
+        )

--- a/sgl-model-gateway/e2e_test/benchmarks/test_ws_bench_helpers.py
+++ b/sgl-model-gateway/e2e_test/benchmarks/test_ws_bench_helpers.py
@@ -7,7 +7,6 @@ logic without requiring GPU or model access.
 from __future__ import annotations
 
 import pytest
-
 from benchmarks.test_ws_microbench import (
     _benchmark_context,
     _benchmark_contract,

--- a/sgl-model-gateway/e2e_test/benchmarks/test_ws_microbench.py
+++ b/sgl-model-gateway/e2e_test/benchmarks/test_ws_microbench.py
@@ -24,9 +24,7 @@ logger = logging.getLogger(__name__)
 # Allow CI and local CI-equivalent runs to swap this test model without editing code.
 # Default remains the original 1B model for parity with the plan, but this can be
 # overridden to any model id from MODEL_SPECS for environments without access.
-_WS_BENCHMARK_MODEL = os.environ.get(
-    "SGLANG_WS_BENCHMARK_MODEL", "llama-1b"
-)
+_WS_BENCHMARK_MODEL = os.environ.get("SGLANG_WS_BENCHMARK_MODEL", "llama-1b")
 
 # WebSocket benchmark coverage is scoped to grpc worker backends in the current
 # router configuration (responses WS is not supported over HTTP-backend worker links).
@@ -67,10 +65,7 @@ def _ws_request(**request_fields) -> dict:
 
 
 def _chain_turn_input(turn_index: int) -> str:
-    return (
-        f"Continuation turn {turn_index}. "
-        "Reply with the single word: hello."
-    )
+    return f"Continuation turn {turn_index}. " "Reply with the single word: hello."
 
 
 def _tool_output_chain_turn_input(turn_index: int) -> list[dict]:
@@ -122,9 +117,7 @@ def _response_output_text_from_response(response: dict) -> str:
 
 def _usage_token_totals(response: dict) -> tuple[int, int]:
     usage = response.get("usage", {})
-    input_tokens = int(
-        usage.get("input_tokens", usage.get("prompt_tokens", 0)) or 0
-    )
+    input_tokens = int(usage.get("input_tokens", usage.get("prompt_tokens", 0)) or 0)
     output_tokens = int(usage.get("output_tokens", 0) or 0)
     return input_tokens, output_tokens
 
@@ -204,7 +197,9 @@ def _collect_http_response_metrics(
     event_count = 0
     output_text_delta_count = 0
 
-    for event in _http_stream_events(base_url, "/v1/responses", request_payload, timeout_secs):
+    for event in _http_stream_events(
+        base_url, "/v1/responses", request_payload, timeout_secs
+    ):
         now = time.perf_counter()
         event_type = event.get("type")
         event_count += 1
@@ -302,7 +297,9 @@ async def _collect_ws_response_metrics(
             output_text_delta_count += 1
 
         if event_type == "error":
-            raise AssertionError(f"Unexpected websocket transcript benchmark error: {event}")
+            raise AssertionError(
+                f"Unexpected websocket transcript benchmark error: {event}"
+            )
 
         if event_type == "response.completed":
             completed_ms = (now - request_started_at) * 1000
@@ -396,7 +393,9 @@ async def _run_single_ws_sample(ws_url: str, model: str) -> dict[str, float | in
     request = _ws_request(**_benchmark_request_body(model))
 
     connect_started_at = time.perf_counter()
-    async with websockets.connect(ws_url, open_timeout=30, close_timeout=5) as websocket:
+    async with websockets.connect(
+        ws_url, open_timeout=30, close_timeout=5
+    ) as websocket:
         connected_at = time.perf_counter()
         await websocket.send(json.dumps(request))
         request_sent_at = time.perf_counter()
@@ -550,7 +549,9 @@ async def _run_ws_sample_batch(
 
 
 async def _collect_ws_terminal_event(websocket, request: dict) -> tuple[dict, float]:
-    return await _collect_ws_terminal_event_with_timeout(websocket, request, timeout_secs=90)
+    return await _collect_ws_terminal_event_with_timeout(
+        websocket, request, timeout_secs=90
+    )
 
 
 async def _collect_ws_terminal_event_with_timeout(
@@ -577,7 +578,9 @@ async def _run_ws_continuation_chain_sample(
     import websockets
 
     connect_started_at = time.perf_counter()
-    async with websockets.connect(ws_url, open_timeout=30, close_timeout=5) as websocket:
+    async with websockets.connect(
+        ws_url, open_timeout=30, close_timeout=5
+    ) as websocket:
         connected_at = time.perf_counter()
 
         per_turn_ms: list[float] = []
@@ -634,7 +637,9 @@ async def _run_ws_tool_output_chain_sample(
     import websockets
 
     connect_started_at = time.perf_counter()
-    async with websockets.connect(ws_url, open_timeout=30, close_timeout=5) as websocket:
+    async with websockets.connect(
+        ws_url, open_timeout=30, close_timeout=5
+    ) as websocket:
         connected_at = time.perf_counter()
 
         per_turn_ms: list[float] = []
@@ -995,7 +1000,8 @@ def _chain_transport_ratios(http_summary: dict, ws_summary: dict) -> dict[str, f
         return numerator / denominator
 
     total_ratio = ratio(
-        float(ws_summary["total_chain_ms_p50"]), float(http_summary["total_chain_ms_p50"])
+        float(ws_summary["total_chain_ms_p50"]),
+        float(http_summary["total_chain_ms_p50"]),
     )
     continuation_ratio = ratio(
         float(ws_summary["continuation_only_total_ms_p50"]),
@@ -1006,8 +1012,7 @@ def _chain_transport_ratios(http_summary: dict, ws_summary: dict) -> dict[str, f
         "ws_over_http_total_chain": total_ratio,
         "ws_over_http_continuation_only": continuation_ratio,
         "ws_vs_http_total_chain_delta_pct": (1.0 - total_ratio) * 100.0,
-        "ws_vs_http_continuation_only_delta_pct": (1.0 - continuation_ratio)
-            * 100.0,
+        "ws_vs_http_continuation_only_delta_pct": (1.0 - continuation_ratio) * 100.0,
     }
 
 
@@ -1025,7 +1030,9 @@ class TestWsMicrobench:
 
         concurrency_levels = [
             int(value)
-            for value in os.environ.get("SGLANG_WS_BENCH_CONCURRENCY", "1,2,4").split(",")
+            for value in os.environ.get("SGLANG_WS_BENCH_CONCURRENCY", "1,2,4").split(
+                ","
+            )
             if value.strip()
         ]
         samples_per_concurrency = int(
@@ -1174,9 +1181,7 @@ class TestResponsesContinuationChainCompare:
             workload_kind="incremental_text_continuation",
         )
 
-        timeout_secs = float(
-            os.environ.get("SGLANG_HTTP_WS_CHAIN_TIMEOUT_SECS", "90")
-        )
+        timeout_secs = float(os.environ.get("SGLANG_HTTP_WS_CHAIN_TIMEOUT_SECS", "90"))
         http_samples = [
             _run_http_continuation_chain_sample(
                 gateway.base_url, model, turns, timeout_secs

--- a/sgl-model-gateway/e2e_test/benchmarks/test_ws_microbench.py
+++ b/sgl-model-gateway/e2e_test/benchmarks/test_ws_microbench.py
@@ -1,0 +1,1311 @@
+"""Lightweight WebSocket microbenchmark for local gateway iteration.
+
+This is intentionally separate from the existing genai-bench HTTP controls.
+It measures the WebSocket Responses path directly on a small local model and
+writes a JSON summary for repeatable local regression checks.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import statistics
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+logger = logging.getLogger(__name__)
+
+# Allow CI and local CI-equivalent runs to swap this test model without editing code.
+# Default remains the original 1B model for parity with the plan, but this can be
+# overridden to any model id from MODEL_SPECS for environments without access.
+_WS_BENCHMARK_MODEL = os.environ.get(
+    "SGLANG_WS_BENCHMARK_MODEL", "llama-1b"
+)
+
+# WebSocket benchmark coverage is scoped to grpc worker backends in the current
+# router configuration (responses WS is not supported over HTTP-backend worker links).
+_WS_BENCH_BACKENDS = ["grpc"]
+
+
+def _gateway_ws_url(base_url: str) -> str:
+    if base_url.startswith("https://"):
+        return f"wss://{base_url.removeprefix('https://')}/v1/responses"
+    return f"ws://{base_url.removeprefix('http://')}/v1/responses"
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = (len(ordered) - 1) * percentile
+    lower = int(rank)
+    upper = min(lower + 1, len(ordered) - 1)
+    weight = rank - lower
+    return ordered[lower] * (1 - weight) + ordered[upper] * weight
+
+
+def _benchmark_request_body(model: str) -> dict:
+    return {
+        "model": model,
+        "input": "Reply with the single word: hello",
+        "temperature": 0,
+        "max_output_tokens": 16,
+        "store": False,
+    }
+
+
+def _ws_request(**request_fields) -> dict:
+    return {"type": "response.create", **request_fields}
+
+
+def _chain_turn_input(turn_index: int) -> str:
+    return (
+        f"Continuation turn {turn_index}. "
+        "Reply with the single word: hello."
+    )
+
+
+def _tool_output_chain_turn_input(turn_index: int) -> list[dict]:
+    return [
+        {
+            "type": "function_call_output",
+            "call_id": f"call_chain_{turn_index}",
+            "output": json.dumps(
+                {
+                    "step": turn_index,
+                    "status": "ok",
+                    "summary": f"tool result {turn_index}",
+                    "artifacts": [f"chunk_{turn_index}_{index}" for index in range(3)],
+                }
+            ),
+        },
+        {
+            "type": "message",
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_text",
+                    "text": (
+                        f"Tool step {turn_index} is complete. "
+                        "Reply with the single word: hello."
+                    ),
+                }
+            ],
+        },
+    ]
+
+
+def _response_output_text_from_response(response: dict) -> str:
+    output_text = response.get("output_text")
+    if isinstance(output_text, str) and output_text.strip():
+        return output_text
+
+    for item in response.get("output", []):
+        if not isinstance(item, dict) or item.get("type") != "message":
+            continue
+        for content_part in item.get("content", []):
+            if not isinstance(content_part, dict):
+                continue
+            text = content_part.get("text")
+            if isinstance(text, str) and text.strip():
+                return text
+    return ""
+
+
+def _usage_token_totals(response: dict) -> tuple[int, int]:
+    usage = response.get("usage", {})
+    input_tokens = int(
+        usage.get("input_tokens", usage.get("prompt_tokens", 0)) or 0
+    )
+    output_tokens = int(usage.get("output_tokens", 0) or 0)
+    return input_tokens, output_tokens
+
+
+def _http_stream_events(base_url: str, path: str, payload: dict, timeout_secs: float):
+    data = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        f"{base_url}{path}",
+        data=data,
+        headers={
+            "Accept": "text/event-stream",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+
+    try:
+        response = urllib.request.urlopen(request, timeout=timeout_secs)
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise AssertionError(
+            f"HTTP SSE benchmark request failed status={exc.code} body={body}"
+        ) from exc
+
+    with response:
+        event_lines: list[str] = []
+
+        def parse_event(lines: list[str]) -> dict | None:
+            data_lines = [
+                line.removeprefix("data:").lstrip()
+                for line in lines
+                if line.startswith("data:")
+            ]
+            if not data_lines:
+                return None
+            payload_text = "\n".join(data_lines)
+            if payload_text == "[DONE]":
+                return None
+            return json.loads(payload_text)
+
+        while True:
+            raw_line = response.readline()
+            if not raw_line:
+                if event_lines:
+                    event = parse_event(event_lines)
+                    if event is not None:
+                        yield event
+                break
+
+            line = raw_line.decode("utf-8", errors="replace").rstrip("\r\n")
+            if not line:
+                if not event_lines:
+                    continue
+                event = parse_event(event_lines)
+                event_lines = []
+                if event is not None:
+                    yield event
+                continue
+
+            if line.startswith(":"):
+                continue
+
+            event_lines.append(line)
+
+
+def _collect_http_response_metrics(
+    base_url: str, payload: dict, timeout_secs: float = 90
+) -> tuple[dict, dict[str, float | int]]:
+    request_payload = {**payload, "stream": True}
+    request_payload_bytes = len(json.dumps(request_payload).encode("utf-8"))
+    request_started_at = time.perf_counter()
+
+    first_event_ms: float | None = None
+    first_content_ms: float | None = None
+    completed_ms: float | None = None
+    response_payload_bytes = 0
+    event_count = 0
+    output_text_delta_count = 0
+
+    for event in _http_stream_events(base_url, "/v1/responses", request_payload, timeout_secs):
+        now = time.perf_counter()
+        event_type = event.get("type")
+        event_count += 1
+        response_payload_bytes += len(json.dumps(event).encode("utf-8"))
+
+        if first_event_ms is None:
+            first_event_ms = (now - request_started_at) * 1000
+
+        if (
+            first_content_ms is None
+            and event_type == "response.output_text.delta"
+            and isinstance(event.get("delta"), str)
+            and event["delta"]
+        ):
+            first_content_ms = (now - request_started_at) * 1000
+            output_text_delta_count += 1
+        elif (
+            event_type == "response.output_text.delta"
+            and isinstance(event.get("delta"), str)
+            and event["delta"]
+        ):
+            output_text_delta_count += 1
+
+        if event_type in {"error", "response.failed", "response.incomplete"}:
+            raise AssertionError(
+                f"HTTP transcript benchmark terminated with {event_type}: {event}"
+            )
+
+        if event_type == "response.completed":
+            completed_ms = (now - request_started_at) * 1000
+            response = event["response"]
+            if first_content_ms is None:
+                first_content_ms = completed_ms
+            input_tokens, output_tokens = _usage_token_totals(response)
+            return response, {
+                "request_payload_bytes": request_payload_bytes,
+                "response_payload_bytes": response_payload_bytes,
+                "request_to_first_event_ms": first_event_ms or 0.0,
+                "request_to_first_content_ms": first_content_ms or 0.0,
+                "request_to_completed_ms": completed_ms or 0.0,
+                "first_event_to_first_content_ms": max(
+                    (first_content_ms or 0.0) - (first_event_ms or 0.0), 0.0
+                ),
+                "first_content_to_completed_ms": max(
+                    (completed_ms or 0.0) - (first_content_ms or 0.0), 0.0
+                ),
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "event_count": event_count,
+                "output_text_delta_count": output_text_delta_count,
+            }
+
+    raise AssertionError("HTTP transcript benchmark ended without response.completed")
+
+
+async def _collect_ws_response_metrics(
+    websocket, request: dict, timeout_secs: float = 90
+) -> tuple[dict, dict[str, float | int]]:
+    payload = _ws_request(**request)
+    request_payload_bytes = len(json.dumps(payload).encode("utf-8"))
+    await websocket.send(json.dumps(payload))
+    request_started_at = time.perf_counter()
+
+    first_event_ms: float | None = None
+    first_content_ms: float | None = None
+    completed_ms: float | None = None
+    response_payload_bytes = 0
+    event_count = 0
+    output_text_delta_count = 0
+
+    while True:
+        message = await asyncio.wait_for(websocket.recv(), timeout=timeout_secs)
+        now = time.perf_counter()
+        event = json.loads(message)
+        event_type = event.get("type")
+        event_count += 1
+        response_payload_bytes += len(message.encode("utf-8"))
+
+        if first_event_ms is None:
+            first_event_ms = (now - request_started_at) * 1000
+
+        if (
+            first_content_ms is None
+            and event_type == "response.output_text.delta"
+            and isinstance(event.get("delta"), str)
+            and event["delta"]
+        ):
+            first_content_ms = (now - request_started_at) * 1000
+            output_text_delta_count += 1
+        elif (
+            event_type == "response.output_text.delta"
+            and isinstance(event.get("delta"), str)
+            and event["delta"]
+        ):
+            output_text_delta_count += 1
+
+        if event_type == "error":
+            raise AssertionError(f"Unexpected websocket transcript benchmark error: {event}")
+
+        if event_type == "response.completed":
+            completed_ms = (now - request_started_at) * 1000
+            response = event["response"]
+            if first_content_ms is None:
+                first_content_ms = completed_ms
+            input_tokens, output_tokens = _usage_token_totals(response)
+            return response, {
+                "request_payload_bytes": request_payload_bytes,
+                "response_payload_bytes": response_payload_bytes,
+                "request_to_first_event_ms": first_event_ms or 0.0,
+                "request_to_first_content_ms": first_content_ms or 0.0,
+                "request_to_completed_ms": completed_ms or 0.0,
+                "first_event_to_first_content_ms": max(
+                    (first_content_ms or 0.0) - (first_event_ms or 0.0), 0.0
+                ),
+                "first_content_to_completed_ms": max(
+                    (completed_ms or 0.0) - (first_content_ms or 0.0), 0.0
+                ),
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "event_count": event_count,
+                "output_text_delta_count": output_text_delta_count,
+            }
+
+
+def _summarize_samples(samples: list[dict[str, float | int]]) -> dict[str, float | int]:
+    def values(key: str) -> list[float]:
+        return [float(sample[key]) for sample in samples]
+
+    summary = {
+        "samples": len(samples),
+        "request_to_first_event_ms_p50": _percentile(
+            values("request_to_first_event_ms"), 0.50
+        ),
+        "request_to_first_event_ms_p95": _percentile(
+            values("request_to_first_event_ms"), 0.95
+        ),
+        "request_to_first_content_ms_p50": _percentile(
+            values("request_to_first_content_ms"), 0.50
+        ),
+        "request_to_first_content_ms_p95": _percentile(
+            values("request_to_first_content_ms"), 0.95
+        ),
+        "request_to_completed_ms_p50": _percentile(
+            values("request_to_completed_ms"), 0.50
+        ),
+        "request_to_completed_ms_p95": _percentile(
+            values("request_to_completed_ms"), 0.95
+        ),
+        "output_tokens_per_second_mean": statistics.fmean(
+            values("output_tokens_per_second")
+        ),
+    }
+
+    if "connect_ms" in samples[0]:
+        summary["connect_ms_p50"] = _percentile(values("connect_ms"), 0.50)
+        summary["connect_ms_p95"] = _percentile(values("connect_ms"), 0.95)
+
+    return summary
+
+
+def _summarize_chain_samples(
+    samples: list[dict[str, float | int | list[float] | list[dict[str, float]]]],
+) -> dict[str, float | int]:
+    def values(key: str) -> list[float]:
+        return [float(sample[key]) for sample in samples]
+
+    summary: dict[str, float | int] = {"samples": len(samples)}
+
+    for key in (
+        "total_chain_ms",
+        "first_turn_completed_ms",
+        "continuation_only_total_ms",
+    ):
+        summary[f"{key}_mean"] = statistics.fmean(values(key))
+        summary[f"{key}_p50"] = _percentile(values(key), 0.50)
+        summary[f"{key}_p95"] = _percentile(values(key), 0.95)
+
+    if "connect_ms" in samples[0]:
+        summary["connect_ms_mean"] = statistics.fmean(values("connect_ms"))
+        summary["connect_ms_p50"] = _percentile(values("connect_ms"), 0.50)
+        summary["connect_ms_p95"] = _percentile(values("connect_ms"), 0.95)
+
+    return summary
+
+
+async def _run_single_ws_sample(ws_url: str, model: str) -> dict[str, float | int]:
+    import websockets
+
+    request = _ws_request(**_benchmark_request_body(model))
+
+    connect_started_at = time.perf_counter()
+    async with websockets.connect(ws_url, open_timeout=30, close_timeout=5) as websocket:
+        connected_at = time.perf_counter()
+        await websocket.send(json.dumps(request))
+        request_sent_at = time.perf_counter()
+
+        first_event_ms: float | None = None
+        first_content_ms: float | None = None
+        completed_ms: float | None = None
+        output_tokens = 0
+
+        while True:
+            payload = await asyncio.wait_for(websocket.recv(), timeout=90)
+            event = json.loads(payload)
+            now = time.perf_counter()
+
+            if first_event_ms is None:
+                first_event_ms = (now - request_sent_at) * 1000
+
+            if (
+                first_content_ms is None
+                and event.get("type") == "response.output_text.delta"
+                and isinstance(event.get("delta"), str)
+                and event["delta"]
+            ):
+                first_content_ms = (now - request_sent_at) * 1000
+
+            if event.get("type") == "error":
+                raise AssertionError(f"Unexpected websocket benchmark error: {event}")
+
+            if event.get("type") == "response.completed":
+                completed_ms = (now - request_sent_at) * 1000
+                usage = event.get("response", {}).get("usage", {})
+                output_tokens = int(usage.get("output_tokens", 0) or 0)
+                if first_content_ms is None:
+                    first_content_ms = completed_ms
+                break
+
+    total_connect_ms = (connected_at - connect_started_at) * 1000
+    tokens_per_second = 0.0
+    if output_tokens > 0 and completed_ms and completed_ms > 0:
+        tokens_per_second = output_tokens / (completed_ms / 1000)
+
+    return {
+        "connect_ms": total_connect_ms,
+        "request_to_first_event_ms": first_event_ms or 0.0,
+        "request_to_first_content_ms": first_content_ms or 0.0,
+        "request_to_completed_ms": completed_ms or 0.0,
+        "output_tokens": output_tokens,
+        "output_tokens_per_second": tokens_per_second,
+    }
+
+
+def _run_single_http_sample(
+    base_url: str, model: str, timeout_secs: float = 90
+) -> dict[str, float | int]:
+    request_started_at = time.perf_counter()
+
+    first_event_ms: float | None = None
+    first_content_ms: float | None = None
+    completed_ms: float | None = None
+    output_tokens = 0
+
+    for event in _http_stream_events(
+        base_url,
+        "/v1/responses",
+        {
+            **_benchmark_request_body(model),
+            "stream": True,
+        },
+        timeout_secs,
+    ):
+        now = time.perf_counter()
+        event_type = event.get("type")
+
+        if first_event_ms is None:
+            first_event_ms = (now - request_started_at) * 1000
+
+        if (
+            first_content_ms is None
+            and event_type == "response.output_text.delta"
+            and isinstance(event.get("delta"), str)
+            and event["delta"]
+        ):
+            first_content_ms = (now - request_started_at) * 1000
+
+        if event_type in {"error", "response.failed", "response.incomplete"}:
+            raise AssertionError(
+                f"HTTP transport benchmark terminated with {event_type}: {event}"
+            )
+
+        if event_type == "response.completed":
+            completed_ms = (now - request_started_at) * 1000
+            usage = event.get("response", {}).get("usage", {})
+            output_tokens = int(usage.get("output_tokens", 0) or 0)
+            if first_content_ms is None:
+                first_content_ms = completed_ms
+            break
+
+    tokens_per_second = 0.0
+    if output_tokens > 0 and completed_ms and completed_ms > 0:
+        tokens_per_second = output_tokens / (completed_ms / 1000)
+
+    return {
+        "request_to_first_event_ms": first_event_ms or 0.0,
+        "request_to_first_content_ms": first_content_ms or 0.0,
+        "request_to_completed_ms": completed_ms or 0.0,
+        "output_tokens": output_tokens,
+        "output_tokens_per_second": tokens_per_second,
+    }
+
+
+async def _run_concurrency_profile(
+    ws_url: str,
+    model: str,
+    concurrency_levels: list[int],
+    samples_per_concurrency: int,
+) -> dict:
+    results = []
+    for concurrency in concurrency_levels:
+        samples: list[dict[str, float | int]] = []
+        for _ in range(samples_per_concurrency):
+            batch = await asyncio.gather(
+                *[_run_single_ws_sample(ws_url, model) for _ in range(concurrency)]
+            )
+            samples.extend(batch)
+
+        summary = _summarize_samples(samples)
+        logger.info("WS microbench concurrency=%s summary=%s", concurrency, summary)
+        results.append(
+            {
+                "concurrency": concurrency,
+                "samples": samples,
+                "summary": summary,
+            }
+        )
+
+    return {
+        "profile": {
+            "concurrency_levels": concurrency_levels,
+            "samples_per_concurrency": samples_per_concurrency,
+        },
+        "results": results,
+    }
+
+
+async def _run_ws_sample_batch(
+    ws_url: str, model: str, samples: int
+) -> list[dict[str, float | int]]:
+    return await asyncio.gather(
+        *[_run_single_ws_sample(ws_url, model) for _ in range(samples)]
+    )
+
+
+async def _collect_ws_terminal_event(websocket, request: dict) -> tuple[dict, float]:
+    return await _collect_ws_terminal_event_with_timeout(websocket, request, timeout_secs=90)
+
+
+async def _collect_ws_terminal_event_with_timeout(
+    websocket, request: dict, *, timeout_secs: float
+) -> tuple[dict, float]:
+    await websocket.send(json.dumps(request))
+    request_started_at = time.perf_counter()
+
+    while True:
+        payload = await asyncio.wait_for(websocket.recv(), timeout=timeout_secs)
+        event = json.loads(payload)
+        now = time.perf_counter()
+
+        if event.get("type") == "error":
+            raise AssertionError(f"Unexpected websocket chain benchmark error: {event}")
+
+        if event.get("type") == "response.completed":
+            return event, (now - request_started_at) * 1000
+
+
+async def _run_ws_continuation_chain_sample(
+    ws_url: str, model: str, turns: int
+) -> dict[str, float | int | list[float]]:
+    import websockets
+
+    connect_started_at = time.perf_counter()
+    async with websockets.connect(ws_url, open_timeout=30, close_timeout=5) as websocket:
+        connected_at = time.perf_counter()
+
+        per_turn_ms: list[float] = []
+        response, first_turn_ms = await _collect_ws_terminal_event(
+            websocket,
+            _ws_request(
+                model=model,
+                input=_chain_turn_input(1),
+                temperature=0,
+                max_output_tokens=16,
+                store=True,
+            ),
+        )
+        per_turn_ms.append(first_turn_ms)
+        previous_response_id = response["response"]["id"]
+
+        for turn_index in range(2, turns + 1):
+            response, completed_ms = await _collect_ws_terminal_event(
+                websocket,
+                _ws_request(
+                    model=model,
+                    input=_chain_turn_input(turn_index),
+                    temperature=0,
+                    max_output_tokens=16,
+                    store=True,
+                    previous_response_id=previous_response_id,
+                ),
+            )
+            per_turn_ms.append(completed_ms)
+            previous_response_id = response["response"]["id"]
+
+    continuation_turns = per_turn_ms[1:]
+    continuation_mean_ms = (
+        statistics.fmean(continuation_turns) if continuation_turns else 0.0
+    )
+    total_chain_ms = sum(per_turn_ms)
+
+    return {
+        "connect_ms": (connected_at - connect_started_at) * 1000,
+        "turns": turns,
+        "total_chain_ms": total_chain_ms,
+        "first_turn_completed_ms": per_turn_ms[0],
+        "continuation_turn_completed_ms_mean": continuation_mean_ms,
+        "continuation_turn_completed_ms_p50": _percentile(continuation_turns, 0.50),
+        "continuation_turn_completed_ms_p95": _percentile(continuation_turns, 0.95),
+        "continuation_only_total_ms": sum(continuation_turns),
+        "per_turn_completed_ms": per_turn_ms,
+    }
+
+
+async def _run_ws_tool_output_chain_sample(
+    ws_url: str, model: str, tool_turns: int
+) -> dict[str, float | int | list[float]]:
+    import websockets
+
+    connect_started_at = time.perf_counter()
+    async with websockets.connect(ws_url, open_timeout=30, close_timeout=5) as websocket:
+        connected_at = time.perf_counter()
+
+        per_turn_ms: list[float] = []
+        response, seed_turn_ms = await _collect_ws_terminal_event(
+            websocket,
+            _ws_request(
+                model=model,
+                input="Seed the tool-output continuation chain. Reply with hello.",
+                temperature=0,
+                max_output_tokens=16,
+                store=True,
+            ),
+        )
+        per_turn_ms.append(seed_turn_ms)
+        previous_response_id = response["response"]["id"]
+
+        for turn_index in range(1, tool_turns + 1):
+            response, completed_ms = await _collect_ws_terminal_event(
+                websocket,
+                _ws_request(
+                    model=model,
+                    input=_tool_output_chain_turn_input(turn_index),
+                    temperature=0,
+                    max_output_tokens=16,
+                    store=True,
+                    previous_response_id=previous_response_id,
+                ),
+            )
+            per_turn_ms.append(completed_ms)
+            previous_response_id = response["response"]["id"]
+
+    continuation_turns = per_turn_ms[1:]
+    continuation_mean_ms = (
+        statistics.fmean(continuation_turns) if continuation_turns else 0.0
+    )
+    total_chain_ms = sum(per_turn_ms)
+
+    return {
+        "connect_ms": (connected_at - connect_started_at) * 1000,
+        "turns": tool_turns + 1,
+        "tool_turns": tool_turns,
+        "total_chain_ms": total_chain_ms,
+        "first_turn_completed_ms": per_turn_ms[0],
+        "continuation_turn_completed_ms_mean": continuation_mean_ms,
+        "continuation_turn_completed_ms_p50": _percentile(continuation_turns, 0.50),
+        "continuation_turn_completed_ms_p95": _percentile(continuation_turns, 0.95),
+        "continuation_only_total_ms": sum(continuation_turns),
+        "per_turn_completed_ms": per_turn_ms,
+    }
+
+
+def _collect_http_completed_ms(
+    base_url: str, payload: dict, timeout_secs: float = 90
+) -> tuple[dict, float]:
+    request_started_at = time.perf_counter()
+    event_types: list[str] = []
+
+    for event in _http_stream_events(base_url, "/v1/responses", payload, timeout_secs):
+        event_type = str(event.get("type"))
+        event_types.append(event_type)
+        if event_type in {"error", "response.failed", "response.incomplete"}:
+            raise AssertionError(
+                f"HTTP continuation benchmark terminated with {event_type}: {event_types}"
+            )
+        if event_type == "response.completed":
+            return event["response"], (time.perf_counter() - request_started_at) * 1000
+
+    raise AssertionError(
+        "HTTP continuation benchmark ended without response.completed; "
+        f"events={event_types}"
+    )
+
+
+def _run_http_continuation_chain_sample(
+    base_url: str, model: str, turns: int, timeout_secs: float = 90
+) -> dict[str, float | int | list[float]]:
+    per_turn_ms: list[float] = []
+
+    response, completed_ms = _collect_http_completed_ms(
+        base_url,
+        {
+            "model": model,
+            "input": _chain_turn_input(1),
+            "temperature": 0,
+            "max_output_tokens": 16,
+            "store": True,
+            "stream": True,
+        },
+        timeout_secs,
+    )
+    per_turn_ms.append(completed_ms)
+    previous_response_id = response["id"]
+
+    for turn_index in range(2, turns + 1):
+        response, completed_ms = _collect_http_completed_ms(
+            base_url,
+            {
+                "model": model,
+                "input": _chain_turn_input(turn_index),
+                "previous_response_id": previous_response_id,
+                "temperature": 0,
+                "max_output_tokens": 16,
+                "store": True,
+                "stream": True,
+            },
+            timeout_secs,
+        )
+        per_turn_ms.append(completed_ms)
+        previous_response_id = response["id"]
+
+    continuation_turns = per_turn_ms[1:]
+    continuation_mean_ms = (
+        statistics.fmean(continuation_turns) if continuation_turns else 0.0
+    )
+    total_chain_ms = sum(per_turn_ms)
+
+    return {
+        "turns": turns,
+        "total_chain_ms": total_chain_ms,
+        "first_turn_completed_ms": per_turn_ms[0],
+        "continuation_turn_completed_ms_mean": continuation_mean_ms,
+        "continuation_turn_completed_ms_p50": _percentile(continuation_turns, 0.50),
+        "continuation_turn_completed_ms_p95": _percentile(continuation_turns, 0.95),
+        "continuation_only_total_ms": sum(continuation_turns),
+        "per_turn_completed_ms": per_turn_ms,
+    }
+
+
+def _run_http_tool_output_chain_sample(
+    base_url: str, model: str, tool_turns: int, timeout_secs: float = 90
+) -> dict[str, float | int | list[float]]:
+    per_turn_ms: list[float] = []
+
+    response, completed_ms = _collect_http_completed_ms(
+        base_url,
+        {
+            "model": model,
+            "input": "Seed the tool-output continuation chain. Reply with hello.",
+            "temperature": 0,
+            "max_output_tokens": 16,
+            "store": True,
+            "stream": True,
+        },
+        timeout_secs,
+    )
+    per_turn_ms.append(completed_ms)
+    previous_response_id = response["id"]
+
+    for turn_index in range(1, tool_turns + 1):
+        response, completed_ms = _collect_http_completed_ms(
+            base_url,
+            {
+                "model": model,
+                "input": _tool_output_chain_turn_input(turn_index),
+                "previous_response_id": previous_response_id,
+                "temperature": 0,
+                "max_output_tokens": 16,
+                "store": True,
+                "stream": True,
+            },
+            timeout_secs,
+        )
+        per_turn_ms.append(completed_ms)
+        previous_response_id = response["id"]
+
+    continuation_turns = per_turn_ms[1:]
+    continuation_mean_ms = (
+        statistics.fmean(continuation_turns) if continuation_turns else 0.0
+    )
+    total_chain_ms = sum(per_turn_ms)
+
+    return {
+        "turns": tool_turns + 1,
+        "tool_turns": tool_turns,
+        "total_chain_ms": total_chain_ms,
+        "first_turn_completed_ms": per_turn_ms[0],
+        "continuation_turn_completed_ms_mean": continuation_mean_ms,
+        "continuation_turn_completed_ms_p50": _percentile(continuation_turns, 0.50),
+        "continuation_turn_completed_ms_p95": _percentile(continuation_turns, 0.95),
+        "continuation_only_total_ms": sum(continuation_turns),
+        "per_turn_completed_ms": per_turn_ms,
+    }
+
+
+def _maybe_write_summary(label: str, payload: dict) -> None:
+    """Write JSON summary to disk only when SGLANG_WS_BENCH_OUTPUT_DIR is set."""
+    output_dir = os.environ.get("SGLANG_WS_BENCH_OUTPUT_DIR")
+    if not output_dir:
+        return
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    slug = label.lower().replace(" ", "_").replace("-", "_")
+    out_path = out_dir / f"{slug}.json"
+    out_path.write_text(json.dumps(payload, indent=2))
+    logger.info("Summary written to %s", out_path)
+
+
+def _print_transport_table(
+    label: str,
+    model: str,
+    http_summary: dict,
+    ws_summary: dict,
+    ratios: dict,
+) -> None:
+    """Print a formatted HTTP-vs-WS comparison table to stdout."""
+    rows = [
+        ("First Event (p50 ms)", "request_to_first_event_ms_p50"),
+        ("First Content (p50 ms)", "request_to_first_content_ms_p50"),
+        ("Completed (p50 ms)", "request_to_completed_ms_p50"),
+        ("Output tok/s (mean)", "output_tokens_per_second_mean"),
+    ]
+    hdr = f"\n{'=' * 70}\n  {label}  |  model: {model}\n{'=' * 70}"
+    print(hdr)
+    print(f"  {'Metric':<28} {'HTTP SSE':>12} {'WebSocket':>12} {'WS/HTTP':>10}")
+    print(f"  {'-' * 62}")
+    for name, key in rows:
+        h = http_summary.get(key, 0)
+        w = ws_summary.get(key, 0)
+        r = w / h if h > 0 else 0.0
+        print(f"  {name:<28} {h:>12.2f} {w:>12.2f} {r:>10.3f}")
+    print(f"  {'-' * 62}")
+    print(f"  Samples: {int(http_summary.get('samples', 0))}")
+    print(f"{'=' * 70}\n")
+
+
+def _print_chain_table(
+    label: str,
+    model: str,
+    http_summary: dict,
+    ws_summary: dict,
+    ratios: dict,
+) -> None:
+    """Print a formatted chain comparison table to stdout."""
+    rows = [
+        ("Total Chain (p50 ms)", "total_chain_ms_p50"),
+        ("First Turn (p50 ms)", "first_turn_completed_ms_p50"),
+        ("Continuation Only (p50 ms)", "continuation_only_total_ms_p50"),
+    ]
+    hdr = f"\n{'=' * 70}\n  {label}  |  model: {model}\n{'=' * 70}"
+    print(hdr)
+    print(f"  {'Metric':<28} {'HTTP SSE':>12} {'WebSocket':>12} {'WS/HTTP':>10}")
+    print(f"  {'-' * 62}")
+    for name, key in rows:
+        h = http_summary.get(key, 0)
+        w = ws_summary.get(key, 0)
+        r = w / h if h > 0 else 0.0
+        print(f"  {name:<28} {h:>12.2f} {w:>12.2f} {r:>10.3f}")
+    print(f"  {'-' * 62}")
+    delta_key = "ws_total_chain_delta_pct"
+    if delta_key in ratios:
+        print(f"  WS total chain delta: {ratios[delta_key]:+.2f}%")
+    print(f"  Samples: {int(http_summary.get('samples', 0))}")
+    print(f"{'=' * 70}\n")
+
+
+def _worker_transport_for_backend(backend_name: str) -> str:
+    if backend_name == "http":
+        return "http"
+    if backend_name == "grpc":
+        return "grpc"
+    if backend_name == "pd":
+        return "http"
+    raise ValueError(f"Unsupported benchmark backend: {backend_name}")
+
+
+def _router_topology_for_backend(backend_name: str) -> str:
+    if backend_name == "http":
+        return "regular_http_worker"
+    if backend_name == "grpc":
+        return "regular_grpc_worker"
+    if backend_name == "pd":
+        return "pd_http_workers"
+    raise ValueError(f"Unsupported benchmark backend: {backend_name}")
+
+
+def _topology_overlay_for_backend(backend_name: str) -> str:
+    if backend_name == "pd":
+        return "pd"
+    return "none"
+
+
+def _benchmark_context(
+    *,
+    benchmark_family: str,
+    run_class: str,
+    backend_name: str,
+    model: str,
+    store_mode: str,
+    workload_kind: str,
+) -> dict[str, str]:
+    return {
+        "benchmark_family": benchmark_family,
+        "run_class": run_class,
+        "worker_transport": _worker_transport_for_backend(backend_name),
+        "router_topology": _router_topology_for_backend(backend_name),
+        "model_id": model,
+        "topology_overlay": _topology_overlay_for_backend(backend_name),
+        "store_mode": store_mode,
+        "workload_kind": workload_kind,
+    }
+
+
+def _benchmark_contract(*, client_transport: str, **context: str) -> dict[str, str]:
+    return {
+        **context,
+        "client_transport": client_transport,
+    }
+
+
+def _transport_result(
+    *,
+    context: dict[str, str],
+    client_transport: str,
+    samples: list[dict],
+    summary: dict,
+) -> dict:
+    return {
+        "transport": client_transport,
+        "benchmark_contract": _benchmark_contract(
+            client_transport=client_transport,
+            **context,
+        ),
+        "samples": samples,
+        "summary": summary,
+    }
+
+
+def _transport_ratios(http_summary: dict, ws_summary: dict) -> dict[str, float]:
+    def ratio(numerator: float, denominator: float) -> float:
+        if denominator <= 0:
+            return 0.0
+        return numerator / denominator
+
+    return {
+        "ws_over_http_first_event_p50": ratio(
+            float(ws_summary["request_to_first_event_ms_p50"]),
+            float(http_summary["request_to_first_event_ms_p50"]),
+        ),
+        "ws_over_http_first_content_p50": ratio(
+            float(ws_summary["request_to_first_content_ms_p50"]),
+            float(http_summary["request_to_first_content_ms_p50"]),
+        ),
+        "ws_over_http_completed_p50": ratio(
+            float(ws_summary["request_to_completed_ms_p50"]),
+            float(http_summary["request_to_completed_ms_p50"]),
+        ),
+        "ws_over_http_output_tps_mean": ratio(
+            float(ws_summary["output_tokens_per_second_mean"]),
+            float(http_summary["output_tokens_per_second_mean"]),
+        ),
+    }
+
+
+def _chain_transport_ratios(http_summary: dict, ws_summary: dict) -> dict[str, float]:
+    def ratio(numerator: float, denominator: float) -> float:
+        if denominator <= 0:
+            return 0.0
+        return numerator / denominator
+
+    total_ratio = ratio(
+        float(ws_summary["total_chain_ms_p50"]), float(http_summary["total_chain_ms_p50"])
+    )
+    continuation_ratio = ratio(
+        float(ws_summary["continuation_only_total_ms_p50"]),
+        float(http_summary["continuation_only_total_ms_p50"]),
+    )
+
+    return {
+        "ws_over_http_total_chain": total_ratio,
+        "ws_over_http_continuation_only": continuation_ratio,
+        "ws_vs_http_total_chain_delta_pct": (1.0 - total_ratio) * 100.0,
+        "ws_vs_http_continuation_only_delta_pct": (1.0 - continuation_ratio)
+            * 100.0,
+    }
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+@pytest.mark.thread_unsafe(reason="Benchmark timing is only meaningful sequentially.")
+@pytest.mark.model(_WS_BENCHMARK_MODEL)
+@pytest.mark.gateway(extra_args=["--history-backend", "memory"])
+@pytest.mark.parametrize("setup_backend", _WS_BENCH_BACKENDS, indirect=True)
+class TestWsMicrobench:
+    """WebSocket benchmark for the Responses route on a single small model."""
+
+    def test_ws_microbench(self, setup_backend):
+        backend_name, model, _, gateway = setup_backend
+
+        concurrency_levels = [
+            int(value)
+            for value in os.environ.get("SGLANG_WS_BENCH_CONCURRENCY", "1,2,4").split(",")
+            if value.strip()
+        ]
+        samples_per_concurrency = int(
+            os.environ.get("SGLANG_WS_BENCH_SAMPLES_PER_CONCURRENCY", "2")
+        )
+        benchmark_context = _benchmark_context(
+            benchmark_family="transport_qos",
+            run_class="ws_microbench_profile",
+            backend_name=backend_name,
+            model=model,
+            store_mode="store_false",
+            workload_kind="single_turn_text",
+        )
+
+        payload = asyncio.run(
+            _run_concurrency_profile(
+                _gateway_ws_url(gateway.base_url),
+                model,
+                concurrency_levels,
+                samples_per_concurrency,
+            )
+        )
+        payload["benchmark_contract"] = _benchmark_contract(
+            client_transport="websocket",
+            **benchmark_context,
+        )
+        payload["worker_backend"] = backend_name
+        payload["router_url"] = gateway.base_url
+        payload["model"] = model
+        _maybe_write_summary("ws_microbench", payload)
+        print(f"\n{'=' * 50}")
+        print(f"  WS Microbenchmark  |  model: {model}")
+        print(f"{'=' * 50}")
+        for profile in payload.get("profiles", []):
+            c = profile.get("concurrency", "?")
+            s = profile.get("summary", {})
+            print(
+                f"  concurrency={c}  "
+                f"first_event_p50={s.get('request_to_first_event_ms_p50', 0):.1f}ms  "
+                f"completed_p50={s.get('request_to_completed_ms_p50', 0):.1f}ms"
+            )
+        print(f"{'=' * 50}\n")
+
+        for result in payload["results"]:
+            summary = result["summary"]
+            assert summary["samples"] > 0
+            assert summary["request_to_first_event_ms_p50"] > 0
+            assert summary["request_to_first_content_ms_p50"] > 0
+            assert summary["request_to_completed_ms_p50"] > 0
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+@pytest.mark.thread_unsafe(reason="Benchmark timing is only meaningful sequentially.")
+@pytest.mark.model(_WS_BENCHMARK_MODEL)
+@pytest.mark.gateway(extra_args=["--history-backend", "memory"])
+@pytest.mark.parametrize("setup_backend", _WS_BENCH_BACKENDS, indirect=True)
+class TestResponsesTransportCompare:
+    """Small-model transport comparison for HTTP SSE vs WebSocket Responses."""
+
+    def test_http_vs_ws_transport_compare(self, setup_backend):
+        backend_name, model, client, gateway = setup_backend
+
+        samples = int(os.environ.get("SGLANG_HTTP_WS_COMPARE_SAMPLES", "2"))
+        benchmark_context = _benchmark_context(
+            benchmark_family="transport_qos",
+            run_class="http_vs_ws_transport_compare",
+            backend_name=backend_name,
+            model=model,
+            store_mode="store_false",
+            workload_kind="single_turn_text",
+        )
+
+        timeout_secs = float(
+            os.environ.get("SGLANG_HTTP_WS_COMPARE_TIMEOUT_SECS", "90")
+        )
+        http_samples = [
+            _run_single_http_sample(gateway.base_url, model, timeout_secs)
+            for _ in range(samples)
+        ]
+        ws_samples = asyncio.run(
+            _run_ws_sample_batch(_gateway_ws_url(gateway.base_url), model, samples)
+        )
+
+        http_summary = _summarize_samples(http_samples)
+        ws_summary = _summarize_samples(ws_samples)
+
+        payload = {
+            "benchmark_context": benchmark_context,
+            "worker_backend": backend_name,
+            "router_url": gateway.base_url,
+            "model": model,
+            "samples_per_transport": samples,
+            "http": _transport_result(
+                context=benchmark_context,
+                client_transport="http_sse",
+                samples=http_samples,
+                summary=http_summary,
+            ),
+            "websocket": _transport_result(
+                context=benchmark_context,
+                client_transport="websocket",
+                samples=ws_samples,
+                summary=ws_summary,
+            ),
+            "ratios": _transport_ratios(http_summary, ws_summary),
+        }
+
+        _maybe_write_summary("http_vs_ws_transport_compare", payload)
+        _print_transport_table(
+            "HTTP vs WS Transport Compare",
+            model,
+            http_summary,
+            ws_summary,
+            payload["ratios"],
+        )
+
+        assert http_summary["samples"] > 0
+        assert ws_summary["samples"] > 0
+        assert http_summary["request_to_first_event_ms_p50"] > 0
+        assert ws_summary["request_to_first_event_ms_p50"] > 0
+        assert http_summary["request_to_completed_ms_p50"] > 0
+        assert ws_summary["request_to_completed_ms_p50"] > 0
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+@pytest.mark.thread_unsafe(reason="Benchmark timing is only meaningful sequentially.")
+@pytest.mark.model(_WS_BENCHMARK_MODEL)
+@pytest.mark.gateway(extra_args=["--history-backend", "memory"])
+@pytest.mark.parametrize("setup_backend", _WS_BENCH_BACKENDS, indirect=True)
+class TestResponsesContinuationChainCompare:
+    """Long-chain continuation comparison for HTTP vs persistent WS."""
+
+    def test_http_vs_ws_continuation_chain_compare(self, setup_backend):
+        backend_name, model, client, gateway = setup_backend
+
+        turns = int(os.environ.get("SGLANG_HTTP_WS_CHAIN_TURNS", "20"))
+        samples = int(os.environ.get("SGLANG_HTTP_WS_CHAIN_SAMPLES", "1"))
+        benchmark_context = _benchmark_context(
+            benchmark_family="continuation_qos",
+            run_class="http_vs_ws_continuation_compare",
+            backend_name=backend_name,
+            model=model,
+            store_mode="store_true",
+            workload_kind="incremental_text_continuation",
+        )
+
+        timeout_secs = float(
+            os.environ.get("SGLANG_HTTP_WS_CHAIN_TIMEOUT_SECS", "90")
+        )
+        http_samples = [
+            _run_http_continuation_chain_sample(
+                gateway.base_url, model, turns, timeout_secs
+            )
+            for _ in range(samples)
+        ]
+        ws_samples = [
+            asyncio.run(
+                _run_ws_continuation_chain_sample(
+                    _gateway_ws_url(gateway.base_url), model, turns
+                )
+            )
+            for _ in range(samples)
+        ]
+        http_summary = _summarize_chain_samples(http_samples)
+        ws_summary = _summarize_chain_samples(ws_samples)
+
+        payload = {
+            "benchmark_context": benchmark_context,
+            "worker_backend": backend_name,
+            "router_url": gateway.base_url,
+            "model": model,
+            "turns": turns,
+            "samples": samples,
+            "http": _transport_result(
+                context=benchmark_context,
+                client_transport="http_sse",
+                samples=http_samples,
+                summary=http_summary,
+            ),
+            "websocket": _transport_result(
+                context=benchmark_context,
+                client_transport="websocket",
+                samples=ws_samples,
+                summary=ws_summary,
+            ),
+            "ratios": _chain_transport_ratios(http_summary, ws_summary),
+        }
+
+        _maybe_write_summary("continuation_chain_compare", payload)
+        _print_chain_table(
+            "Continuation Chain Compare",
+            model,
+            http_summary,
+            ws_summary,
+            payload["ratios"],
+        )
+
+        assert http_samples[0]["turns"] == turns
+        assert ws_samples[0]["turns"] == turns
+        assert float(http_samples[0]["total_chain_ms"]) > 0
+        assert float(ws_samples[0]["total_chain_ms"]) > 0
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+@pytest.mark.thread_unsafe(reason="Benchmark timing is only meaningful sequentially.")
+@pytest.mark.model(_WS_BENCHMARK_MODEL)
+@pytest.mark.gateway(extra_args=["--history-backend", "memory"])
+@pytest.mark.parametrize("setup_backend", _WS_BENCH_BACKENDS, indirect=True)
+class TestResponsesToolOutputChainCompare:
+    """Tool-output-heavy continuation comparison for HTTP vs persistent WS."""
+
+    def test_http_vs_ws_tool_output_chain_compare(self, setup_backend):
+        backend_name, model, client, gateway = setup_backend
+
+        tool_turns = int(os.environ.get("SGLANG_HTTP_WS_TOOL_CHAIN_TURNS", "20"))
+        samples = int(os.environ.get("SGLANG_HTTP_WS_TOOL_CHAIN_SAMPLES", "1"))
+        benchmark_context = _benchmark_context(
+            benchmark_family="continuation_qos",
+            run_class="http_vs_ws_tool_output_compare",
+            backend_name=backend_name,
+            model=model,
+            store_mode="store_true",
+            workload_kind="incremental_tool_output_continuation",
+        )
+
+        timeout_secs = float(
+            os.environ.get("SGLANG_HTTP_WS_TOOL_CHAIN_TIMEOUT_SECS", "90")
+        )
+        http_samples = [
+            _run_http_tool_output_chain_sample(
+                gateway.base_url, model, tool_turns, timeout_secs
+            )
+            for _ in range(samples)
+        ]
+        ws_samples = [
+            asyncio.run(
+                _run_ws_tool_output_chain_sample(
+                    _gateway_ws_url(gateway.base_url), model, tool_turns
+                )
+            )
+            for _ in range(samples)
+        ]
+        http_summary = _summarize_chain_samples(http_samples)
+        ws_summary = _summarize_chain_samples(ws_samples)
+
+        payload = {
+            "benchmark_context": benchmark_context,
+            "worker_backend": backend_name,
+            "router_url": gateway.base_url,
+            "model": model,
+            "tool_turns": tool_turns,
+            "samples": samples,
+            "http": _transport_result(
+                context=benchmark_context,
+                client_transport="http_sse",
+                samples=http_samples,
+                summary=http_summary,
+            ),
+            "websocket": _transport_result(
+                context=benchmark_context,
+                client_transport="websocket",
+                samples=ws_samples,
+                summary=ws_summary,
+            ),
+            "ratios": _chain_transport_ratios(http_summary, ws_summary),
+        }
+
+        _maybe_write_summary("tool_output_chain_compare", payload)
+        _print_chain_table(
+            "Tool-Output Chain Compare",
+            model,
+            http_summary,
+            ws_summary,
+            payload["ratios"],
+        )
+
+        assert http_samples[0]["tool_turns"] == tool_turns
+        assert ws_samples[0]["tool_turns"] == tool_turns
+        assert float(http_samples[0]["total_chain_ms"]) > 0
+        assert float(ws_samples[0]["total_chain_ms"]) > 0

--- a/sgl-model-gateway/e2e_test/benchmarks/test_ws_microbench.py
+++ b/sgl-model-gateway/e2e_test/benchmarks/test_ws_microbench.py
@@ -18,6 +18,8 @@ import urllib.request
 from pathlib import Path
 
 import pytest
+from ws_utils import gateway_ws_url as _gateway_ws_url
+from ws_utils import percentile as _percentile_impl
 
 logger = logging.getLogger(__name__)
 
@@ -31,23 +33,9 @@ _WS_BENCHMARK_MODEL = os.environ.get("SGLANG_WS_BENCHMARK_MODEL", "llama-1b")
 _WS_BENCH_BACKENDS = ["grpc"]
 
 
-def _gateway_ws_url(base_url: str) -> str:
-    if base_url.startswith("https://"):
-        return f"wss://{base_url.removeprefix('https://')}/v1/responses"
-    return f"ws://{base_url.removeprefix('http://')}/v1/responses"
-
-
 def _percentile(values: list[float], percentile: float) -> float:
-    if not values:
-        return 0.0
-    ordered = sorted(values)
-    if len(ordered) == 1:
-        return ordered[0]
-    rank = (len(ordered) - 1) * percentile
-    lower = int(rank)
-    upper = min(lower + 1, len(ordered) - 1)
-    weight = rank - lower
-    return ordered[lower] * (1 - weight) + ordered[upper] * weight
+    """Wrapper to keep call-sites unchanged (0-1 scale -> 0-100 scale)."""
+    return _percentile_impl(values, percentile * 100)
 
 
 def _benchmark_request_body(model: str) -> dict:
@@ -512,6 +500,11 @@ async def _run_concurrency_profile(
     concurrency_levels: list[int],
     samples_per_concurrency: int,
 ) -> dict:
+    # Warmup: run a single request to exclude cold-start costs (model load,
+    # JIT compilation, connection pool init) from timed samples.
+    logger.info("Warmup: sending one request before timed samples")
+    await _run_single_ws_sample(ws_url, model)
+
     results = []
     for concurrency in concurrency_levels:
         samples: list[dict[str, float | int]] = []
@@ -1066,7 +1059,7 @@ class TestWsMicrobench:
         print(f"\n{'=' * 50}")
         print(f"  WS Microbenchmark  |  model: {model}")
         print(f"{'=' * 50}")
-        for profile in payload.get("profiles", []):
+        for profile in payload.get("results", []):
             c = profile.get("concurrency", "?")
             s = profile.get("summary", {})
             print(

--- a/sgl-model-gateway/e2e_test/conftest.py
+++ b/sgl-model-gateway/e2e_test/conftest.py
@@ -205,6 +205,8 @@ from fixtures import (
     pytest_collection_modifyitems,
     pytest_configure,
     pytest_runtest_setup,
+    pytest_sessionfinish,
+    pytest_unconfigure,
     setup_backend,
 )
 
@@ -216,6 +218,8 @@ __all__ = [
     "pytest_collection_finish",
     "pytest_configure",
     "pytest_runtest_setup",
+    "pytest_sessionfinish",
+    "pytest_unconfigure",
     # Fixtures
     "model_pool",
     "model_client",

--- a/sgl-model-gateway/e2e_test/fixtures/__init__.py
+++ b/sgl-model-gateway/e2e_test/fixtures/__init__.py
@@ -26,7 +26,13 @@ from .hooks import (
 from .markers import get_marker_kwargs, get_marker_value
 
 # Fixtures (imported by conftest.py)
-from .pool import model_base_url, model_client, model_pool
+from .pool import (
+    model_base_url,
+    model_client,
+    model_pool,
+    pytest_sessionfinish,
+    pytest_unconfigure,
+)
 from .setup_backend import backend_router, setup_backend
 
 __all__ = [
@@ -35,6 +41,8 @@ __all__ = [
     "pytest_collection_finish",
     "pytest_configure",
     "pytest_runtest_setup",
+    "pytest_sessionfinish",
+    "pytest_unconfigure",
     "get_pool_requirements",
     "validate_gpu_requirements",
     "is_parallel_execution",

--- a/sgl-model-gateway/e2e_test/fixtures/pool.py
+++ b/sgl-model-gateway/e2e_test/fixtures/pool.py
@@ -41,6 +41,22 @@ def _shutdown_model_pool() -> None:
         _model_pool = None
 
 
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """Ensure pooled model workers are released at pytest session end.
+
+    In the local single-GPU loop, relying only on ``atexit`` can leave a worker
+    behind if pytest-parallel or a threaded session exits in an unexpected
+    order. This hook gives pytest a deterministic cleanup point before process
+    teardown.
+    """
+    _shutdown_model_pool()
+
+
+def pytest_unconfigure(config: pytest.Config) -> None:
+    """Fallback cleanup hook for pytest shutdown paths."""
+    _shutdown_model_pool()
+
+
 @pytest.fixture(scope="session")
 def model_pool(request: pytest.FixtureRequest) -> "ModelPool":
     """Session-scoped fixture that manages SGLang worker processes.

--- a/sgl-model-gateway/e2e_test/infra/__init__.py
+++ b/sgl-model-gateway/e2e_test/infra/__init__.py
@@ -71,6 +71,7 @@ def run_eval(*args, **kwargs):
 
     return _run_eval(*args, **kwargs)
 
+
 __all__ = [
     # Enums and Identity
     "ConnectionMode",

--- a/sgl-model-gateway/e2e_test/infra/__init__.py
+++ b/sgl-model-gateway/e2e_test/infra/__init__.py
@@ -63,7 +63,13 @@ from .process_utils import (
     wait_for_health,
     wait_for_workers_ready,
 )
-from .run_eval import run_eval
+
+
+def run_eval(*args, **kwargs):
+    """Lazy-import the eval runner to keep non-eval test collection lightweight."""
+    from .run_eval import run_eval as _run_eval
+
+    return _run_eval(*args, **kwargs)
 
 __all__ = [
     # Enums and Identity

--- a/sgl-model-gateway/e2e_test/infra/gateway.py
+++ b/sgl-model-gateway/e2e_test/infra/gateway.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import logging
 import os
 import subprocess
+import sys
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -18,6 +20,26 @@ if TYPE_CHECKING:
     from .model_pool import ModelInstance
 
 logger = logging.getLogger(__name__)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SGLANG_PYTHON = _REPO_ROOT / "python"
+_GATEWAY_BINDINGS_SRC = _REPO_ROOT / "sgl-model-gateway" / "bindings" / "python" / "src"
+
+
+def _python_executable() -> str:
+    """Use the active interpreter so uv/venv installs are visible to subprocesses."""
+    return sys.executable
+
+
+def _build_subprocess_env(base_env: dict[str, str] | None = None) -> dict[str, str]:
+    """Expose local checkout modules to router subprocesses."""
+    env = (base_env or os.environ).copy()
+    parts = [str(_SGLANG_PYTHON), str(_GATEWAY_BINDINGS_SRC)]
+    existing = env.get("PYTHONPATH")
+    if existing:
+        parts.append(existing)
+    env["PYTHONPATH"] = os.pathsep.join(parts)
+    return env
 
 
 @dataclass
@@ -107,6 +129,9 @@ class Gateway:
         self.cloud_backend: str | None = None
         self._started: bool = False
         self._env: dict[str, str] | None = None  # Custom env for subprocess
+        self.launch_command: list[str] = []
+        self.stdout_log_path: str | None = None
+        self.stderr_log_path: str | None = None
 
     @property
     def is_running(self) -> bool:
@@ -132,6 +157,8 @@ class Gateway:
         timeout: float = DEFAULT_ROUTER_TIMEOUT,
         show_output: bool | None = None,
         extra_args: list[str] | None = None,
+        stdout_path: Path | None = None,
+        stderr_path: Path | None = None,
     ) -> None:
         """Start the gateway.
 
@@ -153,6 +180,8 @@ class Gateway:
             timeout: Startup timeout in seconds.
             show_output: Show subprocess output (env var override).
             extra_args: Additional router arguments.
+            stdout_path: Optional file path for router stdout capture.
+            stderr_path: Optional file path for router stderr capture.
 
         Raises:
             RuntimeError: If gateway is already started.
@@ -196,6 +225,8 @@ class Gateway:
                 timeout=timeout,
                 show_output=show_output,
                 extra_args=extra_args,
+                stdout_path=stdout_path,
+                stderr_path=stderr_path,
                 log_msg="IGW gateway (no workers)",
             )
         elif is_pd_mode:
@@ -216,6 +247,8 @@ class Gateway:
                 timeout=timeout,
                 show_output=show_output,
                 extra_args=extra_args,
+                stdout_path=stdout_path,
+                stderr_path=stderr_path,
                 log_msg=f"PD gateway ({len(prefills)} prefill, {len(decodes)} decode)",
             )
         elif is_cloud_mode:
@@ -257,6 +290,8 @@ class Gateway:
                 timeout=timeout,
                 show_output=show_output,
                 extra_args=extra_args,
+                stdout_path=stdout_path,
+                stderr_path=stderr_path,
                 log_msg=f"{cloud_backend} cloud gateway",
             )
         else:
@@ -272,6 +307,8 @@ class Gateway:
                 timeout=timeout,
                 show_output=show_output,
                 extra_args=extra_args,
+                stdout_path=stdout_path,
+                stderr_path=stderr_path,
                 num_workers=len(worker_urls),
                 log_msg=f"gateway with {len(worker_urls)} worker(s)",
             )
@@ -282,6 +319,8 @@ class Gateway:
         timeout: float,
         show_output: bool,
         extra_args: list[str] | None,
+        stdout_path: Path | None,
+        stderr_path: Path | None,
         num_workers: int | None = None,
         log_msg: str = "",
     ) -> None:
@@ -304,14 +343,36 @@ class Gateway:
 
         logger.info("Starting %s on port %d", log_msg or "gateway", self.port)
         logger.debug("Gateway command: %s", " ".join(cmd))
+        self.launch_command = list(cmd)
+        self.stdout_log_path = str(stdout_path) if stdout_path else None
+        self.stderr_log_path = str(stderr_path) if stderr_path else None
 
-        self.process = subprocess.Popen(
-            cmd,
-            env=self._env,  # Use custom env if set (e.g., for cloud mode API keys)
-            stdout=None if show_output else subprocess.PIPE,
-            stderr=None if show_output else subprocess.PIPE,
-            start_new_session=True,
-        )
+        stdout_target = None if show_output else subprocess.PIPE
+        stderr_target = None if show_output else subprocess.PIPE
+        stdout_handle = None
+        stderr_handle = None
+        if not show_output and stdout_path is not None:
+            stdout_path.parent.mkdir(parents=True, exist_ok=True)
+            stdout_handle = stdout_path.open("wb")
+            stdout_target = stdout_handle
+        if not show_output and stderr_path is not None:
+            stderr_path.parent.mkdir(parents=True, exist_ok=True)
+            stderr_handle = stderr_path.open("wb")
+            stderr_target = stderr_handle
+
+        try:
+            self.process = subprocess.Popen(
+                cmd,
+                env=_build_subprocess_env(self._env),
+                stdout=stdout_target,
+                stderr=stderr_target,
+                start_new_session=True,
+            )
+        finally:
+            if stdout_handle is not None:
+                stdout_handle.close()
+            if stderr_handle is not None:
+                stderr_handle.close()
 
         try:
             if num_workers is not None:
@@ -336,7 +397,7 @@ class Gateway:
     def _build_base_cmd(self) -> list[str]:
         """Build the base command for launching the router."""
         return [
-            "python3",
+            _python_executable(),
             "-m",
             "sglang_router.launch_router",
             "--host",

--- a/sgl-model-gateway/e2e_test/infra/model_pool.py
+++ b/sgl-model-gateway/e2e_test/infra/model_pool.py
@@ -622,9 +622,11 @@ class ModelPool:
                 env=env,
                 stdout=stdout_target,
                 stderr=stderr_target,
-                preexec_fn=_set_parent_death_signal
-                if sys.platform.startswith("linux")
-                else None,
+                preexec_fn=(
+                    _set_parent_death_signal
+                    if sys.platform.startswith("linux")
+                    else None
+                ),
                 start_new_session=True,
             )
         finally:

--- a/sgl-model-gateway/e2e_test/infra/model_pool.py
+++ b/sgl-model-gateway/e2e_test/infra/model_pool.py
@@ -6,9 +6,12 @@ import logging
 import os
 import signal
 import subprocess
+import sys
 import threading
 import time
+from ctypes import CDLL, c_int, get_errno
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import httpx
@@ -33,6 +36,42 @@ from .model_specs import MODEL_SPECS, get_model_spec
 from .process_utils import detect_ib_device
 
 logger = logging.getLogger(__name__)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SGLANG_PYTHON = _REPO_ROOT / "python"
+_GATEWAY_BINDINGS_SRC = _REPO_ROOT / "sgl-model-gateway" / "bindings" / "python" / "src"
+_PR_SET_PDEATHSIG = 1
+
+
+def _python_executable() -> str:
+    """Use the active interpreter so uv/venv installs are visible to subprocesses."""
+    return sys.executable
+
+
+def _extend_pythonpath(env: dict[str, str]) -> dict[str, str]:
+    """Expose local checkout modules to worker subprocesses."""
+    parts = [str(_SGLANG_PYTHON), str(_GATEWAY_BINDINGS_SRC)]
+    existing = env.get("PYTHONPATH")
+    if existing:
+        parts.append(existing)
+    env["PYTHONPATH"] = os.pathsep.join(parts)
+    return env
+
+
+def _set_parent_death_signal() -> None:
+    """Ensure worker subprocesses die if the pytest parent process exits.
+
+    Local E2E runs on a single GPU are painful when a benchmark or smoke test
+    exits without cleaning up the worker process tree. On Linux, use
+    ``PR_SET_PDEATHSIG`` so the launched server receives ``SIGTERM`` if the
+    parent process disappears unexpectedly.
+    """
+    if not sys.platform.startswith("linux"):
+        return
+
+    libc = CDLL(None, use_errno=True)
+    if libc.prctl(c_int(_PR_SET_PDEATHSIG), c_int(signal.SIGTERM), 0, 0, 0) != 0:
+        logger.debug("Failed to set PR_SET_PDEATHSIG (errno=%s)", get_errno())
 
 
 @dataclass(frozen=True)
@@ -103,6 +142,9 @@ class ModelInstance:
     key: str  # Unique instance key (e.g., "llama-8b:http:prefill_0")
     worker_type: WorkerType = WorkerType.REGULAR
     bootstrap_port: int | None = None  # For prefill workers in PD mode
+    launch_command: list[str] = field(default_factory=list)
+    stdout_log_path: str | None = None
+    stderr_log_path: str | None = None
     last_used: float = 0.0  # Timestamp for MRU eviction
     _healthy: bool = False  # Track if initial health check passed
 
@@ -310,16 +352,22 @@ class ModelPool:
         instance = pool.get("llama-8b", "http")  # Pre-launched or on-demand
     """
 
-    def __init__(self, allocator: GPUAllocator | None = None):
+    def __init__(
+        self,
+        allocator: GPUAllocator | None = None,
+        log_dir: Path | None = None,
+    ):
         """Initialize the model pool.
 
         Args:
             allocator: GPU allocator to use. If None, creates a new one.
+            log_dir: Optional directory for worker stdout/stderr capture.
         """
         self.allocator = allocator or GPUAllocator()
         self.instances: dict[str, ModelInstance] = {}  # key = "model_id:mode"
         self._startup_timeout = DEFAULT_STARTUP_TIMEOUT
         self._lock = threading.RLock()  # Protects instances dict
+        self.log_dir = log_dir
 
     def startup(
         self,
@@ -491,10 +539,11 @@ class ModelPool:
         env = os.environ.copy()
         if gpu_slot:
             env["CUDA_VISIBLE_DEVICES"] = gpu_slot.cuda_visible_devices()
+        env = _extend_pythonpath(env)
 
         # Build command
         cmd = [
-            "python3",
+            _python_executable(),
             "-m",
             "sglang.launch_server",
             "--model-path",
@@ -547,15 +596,42 @@ class ModelPool:
         logger.info("Launching %s on GPUs %s port %d", key, gpu_info, port)
 
         show_output = os.environ.get(ENV_SHOW_WORKER_LOGS, "0") == "1"
+        stdout_target = None if show_output else subprocess.PIPE
+        stderr_target = None if show_output else subprocess.PIPE
+        stdout_log_path: str | None = None
+        stderr_log_path: str | None = None
+        stdout_handle = None
+        stderr_handle = None
+
+        if not show_output and self.log_dir is not None:
+            self.log_dir.mkdir(parents=True, exist_ok=True)
+            safe_key = key.replace("/", "_").replace(":", "_")
+            stdout_log = self.log_dir / f"{safe_key}.stdout.log"
+            stderr_log = self.log_dir / f"{safe_key}.stderr.log"
+            stdout_handle = stdout_log.open("wb")
+            stderr_handle = stderr_log.open("wb")
+            stdout_target = stdout_handle
+            stderr_target = stderr_handle
+            stdout_log_path = str(stdout_log)
+            stderr_log_path = str(stderr_log)
 
         # Start the process
-        proc = subprocess.Popen(
-            cmd,
-            env=env,
-            stdout=None if show_output else subprocess.PIPE,
-            stderr=None if show_output else subprocess.PIPE,
-            start_new_session=True,
-        )
+        try:
+            proc = subprocess.Popen(
+                cmd,
+                env=env,
+                stdout=stdout_target,
+                stderr=stderr_target,
+                preexec_fn=_set_parent_death_signal
+                if sys.platform.startswith("linux")
+                else None,
+                start_new_session=True,
+            )
+        finally:
+            if stdout_handle is not None:
+                stdout_handle.close()
+            if stderr_handle is not None:
+                stderr_handle.close()
 
         base_url = f"http://{DEFAULT_HOST}:{port}"
         instance = ModelInstance(
@@ -569,6 +645,9 @@ class ModelPool:
             key=key,
             worker_type=worker_type,
             bootstrap_port=bootstrap_port,
+            launch_command=list(cmd),
+            stdout_log_path=stdout_log_path,
+            stderr_log_path=stderr_log_path,
             last_used=time.time(),
         )
         self.instances[key] = instance

--- a/sgl-model-gateway/e2e_test/pyproject.toml
+++ b/sgl-model-gateway/e2e_test/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "sgl-model-gateway-e2e-tests"
 version = "0.1.0"
@@ -11,6 +15,7 @@ dependencies = [
   "openai",
   "pytest",
   "pytest-rerunfailures",
+  "websockets",
 ]
 
 [project.optional-dependencies]
@@ -24,6 +29,9 @@ markers = [
   "e2e: mark test as end-to-end test requiring GPU workers",
   "slow: mark test as slow-running",
   "thread_unsafe: mark test as incompatible with parallel thread execution",
+  "model(name): specify which model spec to use for this test",
+  "gateway(**kwargs): configure gateway extra_args, policy, timeout",
+  "workers(**kwargs): configure worker count, prefill, decode topology",
 ]
 addopts = "-v -s"
 # Explicitly disable live log to avoid "---- live log ----" dividers
@@ -37,3 +45,7 @@ log_cli = false
 # eviction-bound across 5 model:mode combos. ModelPool / GPUAllocator
 # remain thread-safe so re-introducing parallelism (xdist or otherwise)
 # stays a tractable option.
+[tool.setuptools]
+# This test harness is a dependency-only project; disabling auto-discovery keeps
+# `uv pip install .` working in the flat repo layout.
+py-modules = []

--- a/sgl-model-gateway/e2e_test/responses/test_local_smoke.py
+++ b/sgl-model-gateway/e2e_test/responses/test_local_smoke.py
@@ -12,6 +12,7 @@ import os
 
 import openai
 import pytest
+from ws_utils import gateway_ws_url as _gateway_ws_url
 
 GET_WEATHER_FUNCTION = {
     "type": "function",
@@ -65,13 +66,6 @@ CALCULATE_CHAT_TOOL = {
 
 _TEXT_SMOKE_MODEL = os.environ.get("SGLANG_TEXT_SMOKE_MODEL", "llama-1b")
 _TOOL_SMOKE_MODEL = os.environ.get("SGLANG_TOOL_SMOKE_MODEL", "qwen-7b")
-
-
-def _gateway_ws_url(base_url: str) -> str:
-    """Convert the router base URL into a websocket endpoint URL."""
-    if base_url.startswith("https://"):
-        return f"wss://{base_url.removeprefix('https://')}/v1/responses"
-    return f"ws://{base_url.removeprefix('http://')}/v1/responses"
 
 
 def _ws_request(

--- a/sgl-model-gateway/e2e_test/responses/test_local_smoke.py
+++ b/sgl-model-gateway/e2e_test/responses/test_local_smoke.py
@@ -170,7 +170,9 @@ async def _collect_ws_events(ws_url: str, model: str) -> list[dict]:
     """Send one `response.create` request and collect events until terminal state."""
     import websockets
 
-    async with websockets.connect(ws_url, open_timeout=30, close_timeout=5) as websocket:
+    async with websockets.connect(
+        ws_url, open_timeout=30, close_timeout=5
+    ) as websocket:
         return await _send_ws_request_and_collect(
             websocket,
             _ws_request(
@@ -268,7 +270,9 @@ class TestResponsesLocalSmoke:
         """WebSocket Responses should complete end-to-end on the local smoke model."""
         _, model, _, gateway = setup_backend
 
-        events = asyncio.run(_collect_ws_events(_gateway_ws_url(gateway.base_url), model))
+        events = asyncio.run(
+            _collect_ws_events(_gateway_ws_url(gateway.base_url), model)
+        )
 
         event_types = [event["type"] for event in events]
         completed = events[-1]
@@ -293,7 +297,9 @@ class TestResponsesLocalSmoke:
 
         assert ws_event_types == http_event_types
 
-    def test_websocket_store_false_continuation_is_connection_local(self, setup_backend):
+    def test_websocket_store_false_continuation_is_connection_local(
+        self, setup_backend
+    ):
         """`store=false` should continue on the same socket and fail after reconnect."""
         _, model, _, gateway = setup_backend
 
@@ -564,7 +570,9 @@ class TestResponsesLocalSmoke:
         assert retrieved.store is True
         assert len(retrieved.output) > 0
 
-    def test_websocket_generate_false_returns_chainable_response_id(self, setup_backend):
+    def test_websocket_generate_false_returns_chainable_response_id(
+        self, setup_backend
+    ):
         """`generate=false` should return a response id that the same socket can chain from."""
         _, model, _, gateway = setup_backend
 
@@ -807,14 +815,18 @@ class TestResponsesLocalToolSmoke:
         assert "response.function_call_arguments.delta" in event_types
         assert "response.function_call_arguments.done" in event_types
 
-        completed_events = [event for event in events if event.type == "response.completed"]
+        completed_events = [
+            event for event in events if event.type == "response.completed"
+        ]
         assert len(completed_events) == 1
 
         completed = completed_events[0]
         assert completed.response.status == "in_progress"
 
         function_calls = _response_function_calls(completed.response.output)
-        assert function_calls, "expected a function call in the completed response payload"
+        assert (
+            function_calls
+        ), "expected a function call in the completed response payload"
         assert function_calls[0].name == "calculate"
         assert function_calls[0].call_id
         assert function_calls[0].arguments
@@ -834,7 +846,9 @@ class TestResponsesLocalToolSmoke:
         )
 
         function_calls = _response_function_calls(first.output)
-        assert function_calls, "expected a completed function call in the first HTTP turn"
+        assert (
+            function_calls
+        ), "expected a completed function call in the first HTTP turn"
         assert first.status == "in_progress"
         assert function_calls[0].name == "calculate"
         assert function_calls[0].arguments

--- a/sgl-model-gateway/e2e_test/responses/test_local_smoke.py
+++ b/sgl-model-gateway/e2e_test/responses/test_local_smoke.py
@@ -1,0 +1,917 @@
+"""Small-model local smoke tests for the Responses API.
+
+These tests are intentionally narrow. They exist to keep a single-GPU local
+development loop healthy before adding heavier semantic or compatibility suites.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+
+import openai
+import pytest
+
+GET_WEATHER_FUNCTION = {
+    "type": "function",
+    "name": "get_weather",
+    "description": "Get the current weather in a given location.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "location": {
+                "type": "string",
+                "description": "A city name such as Berlin.",
+            }
+        },
+        "required": ["location"],
+    },
+}
+
+CALCULATE_FUNCTION = {
+    "type": "function",
+    "name": "calculate",
+    "description": "Perform a mathematical calculation.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "expression": {
+                "type": "string",
+                "description": "The mathematical expression to evaluate.",
+            }
+        },
+        "required": ["expression"],
+    },
+}
+
+CALCULATE_CHAT_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "calculate",
+        "description": "Perform a mathematical calculation.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "expression": {
+                    "type": "string",
+                    "description": "The mathematical expression to evaluate.",
+                }
+            },
+            "required": ["expression"],
+        },
+    },
+}
+
+_TEXT_SMOKE_MODEL = os.environ.get("SGLANG_TEXT_SMOKE_MODEL", "llama-1b")
+_TOOL_SMOKE_MODEL = os.environ.get("SGLANG_TOOL_SMOKE_MODEL", "qwen-7b")
+
+
+def _gateway_ws_url(base_url: str) -> str:
+    """Convert the router base URL into a websocket endpoint URL."""
+    if base_url.startswith("https://"):
+        return f"wss://{base_url.removeprefix('https://')}/v1/responses"
+    return f"ws://{base_url.removeprefix('http://')}/v1/responses"
+
+
+def _ws_request(
+    model: str,
+    *,
+    input,
+    store: bool,
+    previous_response_id: str | None = None,
+    generate: bool | None = None,
+    temperature: float = 0,
+    max_output_tokens: int = 16,
+    tools: list[dict] | None = None,
+    tool_choice=None,
+) -> dict:
+    request = {
+        "type": "response.create",
+        "model": model,
+        "input": input,
+        "temperature": temperature,
+        "max_output_tokens": max_output_tokens,
+        "store": store,
+    }
+    if previous_response_id is not None:
+        request["previous_response_id"] = previous_response_id
+    if generate is not None:
+        request["generate"] = generate
+    if tools is not None:
+        request["tools"] = tools
+    if tool_choice is not None:
+        request["tool_choice"] = tool_choice
+    return request
+
+
+def _ws_error_code(event: dict) -> str | None:
+    error = event.get("error")
+    if isinstance(error, dict):
+        code = error.get("code")
+        if isinstance(code, str):
+            return code
+    code = event.get("code")
+    return code if isinstance(code, str) else None
+
+
+def _tool_output_chain_turn_input(turn_index: int) -> list[dict]:
+    return [
+        {
+            "type": "function_call_output",
+            "call_id": f"call_ws_smoke_{turn_index}",
+            "output": json.dumps(
+                {
+                    "step": turn_index,
+                    "status": "ok",
+                    "summary": f"tool result {turn_index}",
+                }
+            ),
+        },
+        {
+            "type": "message",
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_text",
+                    "text": "Continue from this tool result and reply with hello.",
+                }
+            ],
+        },
+    ]
+
+
+async def _send_ws_request_and_collect(
+    websocket,
+    request: dict,
+    *,
+    fail_on_error: bool = True,
+) -> list[dict]:
+    await websocket.send(json.dumps(request))
+
+    events: list[dict] = []
+    while True:
+        payload = await asyncio.wait_for(websocket.recv(), timeout=90)
+        event = json.loads(payload)
+        events.append(event)
+
+        if event.get("type") == "error":
+            if fail_on_error:
+                raise AssertionError(f"Unexpected websocket error: {event}")
+            break
+
+        if event.get("type") == "response.completed":
+            break
+
+    return events
+
+
+async def _collect_ws_events(ws_url: str, model: str) -> list[dict]:
+    """Send one `response.create` request and collect events until terminal state."""
+    import websockets
+
+    async with websockets.connect(ws_url, open_timeout=30, close_timeout=5) as websocket:
+        return await _send_ws_request_and_collect(
+            websocket,
+            _ws_request(
+                model,
+                input="Reply with the single word: hello",
+                store=False,
+            ),
+        )
+
+
+def _response_output_text(completed_event: dict) -> str:
+    """Best-effort extraction of assistant text from a completed response event."""
+    for item in completed_event.get("response", {}).get("output", []):
+        if item.get("type") != "message":
+            continue
+        for content_part in item.get("content", []):
+            text = content_part.get("text")
+            if isinstance(text, str) and text.strip():
+                return text
+    return ""
+
+
+def _response_function_calls(output) -> list:
+    return [item for item in output if item.type == "function_call"]
+
+
+def _completed_response_function_calls(completed_event: dict) -> list[dict]:
+    return [
+        item
+        for item in completed_event.get("response", {}).get("output", [])
+        if item.get("type") == "function_call"
+    ]
+
+
+def _collect_http_event_types(client, model: str) -> list[str]:
+    """Collect the logical event sequence from the HTTP streaming Responses path."""
+    response = client.responses.create(
+        model=model,
+        input="Reply with the single word: hello",
+        stream=True,
+        temperature=0,
+        max_output_tokens=16,
+        store=False,
+    )
+    return [event.type for event in response]
+
+
+@pytest.mark.e2e
+@pytest.mark.model(_TEXT_SMOKE_MODEL)
+@pytest.mark.gateway(extra_args=["--history-backend", "memory"])
+@pytest.mark.parametrize("setup_backend", ["grpc"], indirect=True)
+class TestResponsesLocalSmoke:
+    """Minimal local Responses checks on a small cached model."""
+
+    def test_basic_response_creation(self, setup_backend):
+        """Basic non-streaming response creation should succeed locally."""
+        _, model, client, gateway = setup_backend
+
+        resp = client.responses.create(
+            model=model,
+            input="Reply with the single word: hello",
+            temperature=0,
+            max_output_tokens=16,
+        )
+
+        assert resp.id is not None
+        assert resp.error is None
+        assert resp.status == "completed"
+        assert resp.usage is not None
+        assert len(resp.output_text) > 0
+
+    def test_streaming_response(self, setup_backend):
+        """Streaming should emit a normal response event flow."""
+        _, model, client, gateway = setup_backend
+
+        resp = client.responses.create(
+            model=model,
+            input="Count from 1 to 3.",
+            stream=True,
+            temperature=0,
+            max_output_tokens=32,
+        )
+
+        events = list(resp)
+        assert len(events) > 0
+
+        created = [event for event in events if event.type == "response.created"]
+        completed = [event for event in events if event.type == "response.completed"]
+
+        assert created, "Expected at least one response.created event"
+        assert completed, "Expected exactly one terminal completed event"
+        assert len(completed) == 1
+
+    def test_websocket_response_create(self, setup_backend):
+        """WebSocket Responses should complete end-to-end on the local smoke model."""
+        _, model, _, gateway = setup_backend
+
+        events = asyncio.run(_collect_ws_events(_gateway_ws_url(gateway.base_url), model))
+
+        event_types = [event["type"] for event in events]
+        completed = events[-1]
+
+        assert "response.created" in event_types
+        assert completed["type"] == "response.completed"
+        assert completed["response"]["status"] == "completed"
+        assert len(completed["response"]["output"]) > 0
+        assert _response_output_text(completed).strip()
+
+    def test_http_ws_event_type_parity(self, setup_backend):
+        """HTTP SSE and WS should expose the same logical event sequence locally."""
+        _, model, client, gateway = setup_backend
+
+        http_event_types = _collect_http_event_types(client, model)
+        ws_event_types = [
+            event["type"]
+            for event in asyncio.run(
+                _collect_ws_events(_gateway_ws_url(gateway.base_url), model)
+            )
+        ]
+
+        assert ws_event_types == http_event_types
+
+    def test_websocket_store_false_continuation_is_connection_local(self, setup_backend):
+        """`store=false` should continue on the same socket and fail after reconnect."""
+        _, model, _, gateway = setup_backend
+
+        async def run() -> tuple[list[dict], list[dict], list[dict]]:
+            import websockets
+
+            ws_url = _gateway_ws_url(gateway.base_url)
+            async with websockets.connect(
+                ws_url, open_timeout=30, close_timeout=5
+            ) as websocket:
+                first_events = await _send_ws_request_and_collect(
+                    websocket,
+                    _ws_request(
+                        model,
+                        input="First websocket turn. Reply with hello.",
+                        store=False,
+                    ),
+                )
+                response_id = first_events[-1]["response"]["id"]
+                second_events = await _send_ws_request_and_collect(
+                    websocket,
+                    _ws_request(
+                        model,
+                        input="Second websocket turn. Reply with hello again.",
+                        previous_response_id=response_id,
+                        store=False,
+                    ),
+                )
+
+            async with websockets.connect(
+                ws_url, open_timeout=30, close_timeout=5
+            ) as websocket:
+                reconnect_events = await _send_ws_request_and_collect(
+                    websocket,
+                    _ws_request(
+                        model,
+                        input="Reconnect websocket turn.",
+                        previous_response_id=response_id,
+                        store=False,
+                    ),
+                    fail_on_error=False,
+                )
+
+            return first_events, second_events, reconnect_events
+
+        first_events, second_events, reconnect_events = asyncio.run(run())
+
+        assert first_events[-1]["type"] == "response.completed"
+        assert second_events[-1]["type"] == "response.completed"
+        assert reconnect_events[-1]["type"] == "error"
+        assert _ws_error_code(reconnect_events[-1]) == "previous_response_not_found"
+
+    def test_websocket_only_latest_store_false_response_is_cached_per_connection(
+        self, setup_backend
+    ):
+        """WS keeps only the most recent `store=false` response in connection-local cache."""
+        _, model, _, gateway = setup_backend
+
+        async def run() -> tuple[list[dict], list[dict]]:
+            import websockets
+
+            ws_url = _gateway_ws_url(gateway.base_url)
+            async with websockets.connect(
+                ws_url, open_timeout=30, close_timeout=5
+            ) as websocket:
+                first_events = await _send_ws_request_and_collect(
+                    websocket,
+                    _ws_request(
+                        model,
+                        input="First store-false websocket turn.",
+                        store=False,
+                    ),
+                )
+                first_response_id = first_events[-1]["response"]["id"]
+
+                second_events = await _send_ws_request_and_collect(
+                    websocket,
+                    _ws_request(
+                        model,
+                        input="Second store-false websocket turn.",
+                        previous_response_id=first_response_id,
+                        store=False,
+                    ),
+                )
+                second_response_id = second_events[-1]["response"]["id"]
+
+                stale_retry_events = await _send_ws_request_and_collect(
+                    websocket,
+                    _ws_request(
+                        model,
+                        input="Retry the stale first response id.",
+                        previous_response_id=first_response_id,
+                        store=False,
+                    ),
+                    fail_on_error=False,
+                )
+
+                latest_retry_events = await _send_ws_request_and_collect(
+                    websocket,
+                    _ws_request(
+                        model,
+                        input="Retry the latest response id.",
+                        previous_response_id=second_response_id,
+                        store=False,
+                    ),
+                )
+
+            return stale_retry_events, latest_retry_events
+
+        stale_retry_events, latest_retry_events = asyncio.run(run())
+
+        assert stale_retry_events[-1]["type"] == "error"
+        assert _ws_error_code(stale_retry_events[-1]) == "previous_response_not_found"
+        assert latest_retry_events[-1]["type"] == "response.completed"
+
+    def test_websocket_invalid_previous_response_id_fails(self, setup_backend):
+        """Fresh websocket connections should reject unknown previous_response_id values."""
+        _, model, _, gateway = setup_backend
+
+        async def run() -> list[dict]:
+            import websockets
+
+            ws_url = _gateway_ws_url(gateway.base_url)
+            async with websockets.connect(
+                ws_url, open_timeout=30, close_timeout=5
+            ) as websocket:
+                return await _send_ws_request_and_collect(
+                    websocket,
+                    _ws_request(
+                        model,
+                        input="This should fail.",
+                        previous_response_id="resp_missing_ws",
+                        store=False,
+                    ),
+                    fail_on_error=False,
+                )
+
+        events = asyncio.run(run())
+
+        assert events[-1]["type"] == "error"
+        assert _ws_error_code(events[-1]) == "previous_response_not_found"
+
+    def test_websocket_store_true_continuation_survives_reconnect_and_is_retrievable(
+        self, setup_backend
+    ):
+        """Stored WS responses should survive reconnect and be retrievable over HTTP."""
+        _, model, client, gateway = setup_backend
+
+        async def run() -> tuple[dict, list[dict]]:
+            import websockets
+
+            ws_url = _gateway_ws_url(gateway.base_url)
+            async with websockets.connect(
+                ws_url, open_timeout=30, close_timeout=5
+            ) as websocket:
+                first_events = await _send_ws_request_and_collect(
+                    websocket,
+                    _ws_request(
+                        model,
+                        input="Persist this websocket turn.",
+                        store=True,
+                    ),
+                )
+                first_completed = first_events[-1]
+                response_id = first_completed["response"]["id"]
+
+            async with websockets.connect(
+                ws_url, open_timeout=30, close_timeout=5
+            ) as websocket:
+                reconnect_events = await _send_ws_request_and_collect(
+                    websocket,
+                    _ws_request(
+                        model,
+                        input="Continue after reconnect.",
+                        previous_response_id=response_id,
+                        store=False,
+                    ),
+                )
+
+            return first_completed, reconnect_events
+
+        first_completed, reconnect_events = asyncio.run(run())
+        stored_response_id = first_completed["response"]["id"]
+
+        assert reconnect_events[-1]["type"] == "response.completed"
+
+        retrieved = client.responses.retrieve(response_id=stored_response_id)
+        assert retrieved.id == stored_response_id
+        assert retrieved.status == "completed"
+        assert retrieved.store is True
+
+    def test_websocket_store_false_response_is_not_retrievable_over_http(
+        self, setup_backend
+    ):
+        """WS `store=false` responses should not become retrievable over HTTP APIs."""
+        _, model, client, gateway = setup_backend
+
+        async def run() -> str:
+            import websockets
+
+            ws_url = _gateway_ws_url(gateway.base_url)
+            async with websockets.connect(
+                ws_url, open_timeout=30, close_timeout=5
+            ) as websocket:
+                events = await _send_ws_request_and_collect(
+                    websocket,
+                    _ws_request(
+                        model,
+                        input="Do not persist this websocket response.",
+                        store=False,
+                    ),
+                )
+            return events[-1]["response"]["id"]
+
+        response_id = asyncio.run(run())
+
+        with pytest.raises(openai.NotFoundError):
+            client.responses.retrieve(response_id=response_id)
+
+    def test_websocket_function_call_output_continuation_survives_reconnect_when_stored(
+        self, setup_backend
+    ):
+        """Stored WS chains should accept incremental `function_call_output` items."""
+        _, model, client, gateway = setup_backend
+
+        async def run() -> tuple[str, dict]:
+            import websockets
+
+            ws_url = _gateway_ws_url(gateway.base_url)
+            async with websockets.connect(
+                ws_url, open_timeout=30, close_timeout=5
+            ) as websocket:
+                seed_events = await _send_ws_request_and_collect(
+                    websocket,
+                    _ws_request(
+                        model,
+                        input="Seed a tool-output websocket chain.",
+                        store=True,
+                    ),
+                )
+                seed_response_id = seed_events[-1]["response"]["id"]
+
+            async with websockets.connect(
+                ws_url, open_timeout=30, close_timeout=5
+            ) as websocket:
+                follow_up_events = await _send_ws_request_and_collect(
+                    websocket,
+                    _ws_request(
+                        model,
+                        input=_tool_output_chain_turn_input(1),
+                        previous_response_id=seed_response_id,
+                        store=True,
+                    ),
+                )
+
+            return seed_response_id, follow_up_events[-1]["response"]
+
+        seed_response_id, continued_response = asyncio.run(run())
+        continued_response_id = continued_response["id"]
+
+        seed_response = client.responses.retrieve(response_id=seed_response_id)
+        assert seed_response.id == seed_response_id
+        assert seed_response.store is True
+
+        retrieved = client.responses.retrieve(response_id=continued_response_id)
+        assert retrieved.id == continued_response_id
+        assert retrieved.status == "completed"
+        assert retrieved.store is True
+        assert len(retrieved.output) > 0
+
+    def test_websocket_generate_false_returns_chainable_response_id(self, setup_backend):
+        """`generate=false` should return a response id that the same socket can chain from."""
+        _, model, _, gateway = setup_backend
+
+        async def run() -> tuple[list[dict], list[dict]]:
+            import websockets
+
+            ws_url = _gateway_ws_url(gateway.base_url)
+            async with websockets.connect(
+                ws_url, open_timeout=30, close_timeout=5
+            ) as websocket:
+                warmup_events = await _send_ws_request_and_collect(
+                    websocket,
+                    _ws_request(
+                        model,
+                        input="Warm up this websocket request state.",
+                        store=False,
+                        generate=False,
+                    ),
+                )
+                warmup_response_id = warmup_events[-1]["response"]["id"]
+                follow_up_events = await _send_ws_request_and_collect(
+                    websocket,
+                    _ws_request(
+                        model,
+                        input="Now answer with the single word: warmed",
+                        previous_response_id=warmup_response_id,
+                        store=False,
+                    ),
+                )
+            return warmup_events, follow_up_events
+
+        warmup_events, follow_up_events = asyncio.run(run())
+
+        assert warmup_events[-1]["type"] == "response.completed"
+        assert warmup_events[-1]["response"]["output"] == []
+        assert follow_up_events[-1]["type"] == "response.completed"
+        assert _response_output_text(follow_up_events[-1]).strip()
+
+    def test_websocket_generate_false_store_false_is_not_retrievable_or_reconnectable(
+        self, setup_backend
+    ):
+        """Warmup responses with `store=false` stay socket-local and non-durable."""
+        _, model, client, gateway = setup_backend
+
+        async def run() -> tuple[str, list[dict]]:
+            import websockets
+
+            ws_url = _gateway_ws_url(gateway.base_url)
+            async with websockets.connect(
+                ws_url, open_timeout=30, close_timeout=5
+            ) as websocket:
+                warmup_events = await _send_ws_request_and_collect(
+                    websocket,
+                    _ws_request(
+                        model,
+                        input="Warm up without durable storage.",
+                        store=False,
+                        generate=False,
+                    ),
+                )
+                warmup_response_id = warmup_events[-1]["response"]["id"]
+
+            async with websockets.connect(
+                ws_url, open_timeout=30, close_timeout=5
+            ) as websocket:
+                reconnect_events = await _send_ws_request_and_collect(
+                    websocket,
+                    _ws_request(
+                        model,
+                        input="Continue from non-durable warmup.",
+                        previous_response_id=warmup_response_id,
+                        store=False,
+                    ),
+                    fail_on_error=False,
+                )
+
+            return warmup_response_id, reconnect_events
+
+        warmup_response_id, reconnect_events = asyncio.run(run())
+
+        assert reconnect_events[-1]["type"] == "error"
+        assert _ws_error_code(reconnect_events[-1]) == "previous_response_not_found"
+
+        with pytest.raises(openai.NotFoundError):
+            client.responses.retrieve(response_id=warmup_response_id)
+
+    def test_websocket_generate_false_store_true_survives_reconnect_and_is_retrievable(
+        self, setup_backend
+    ):
+        """Warmup responses with `store=true` should persist like normal WS responses."""
+        _, model, client, gateway = setup_backend
+
+        async def run() -> tuple[str, list[dict]]:
+            import websockets
+
+            ws_url = _gateway_ws_url(gateway.base_url)
+            async with websockets.connect(
+                ws_url, open_timeout=30, close_timeout=5
+            ) as websocket:
+                warmup_events = await _send_ws_request_and_collect(
+                    websocket,
+                    _ws_request(
+                        model,
+                        input="Warm up with durable storage.",
+                        store=True,
+                        generate=False,
+                    ),
+                )
+                warmup_response_id = warmup_events[-1]["response"]["id"]
+
+            async with websockets.connect(
+                ws_url, open_timeout=30, close_timeout=5
+            ) as websocket:
+                reconnect_events = await _send_ws_request_and_collect(
+                    websocket,
+                    _ws_request(
+                        model,
+                        input="Continue from stored warmup.",
+                        previous_response_id=warmup_response_id,
+                        store=False,
+                    ),
+                )
+
+            return warmup_response_id, reconnect_events
+
+        warmup_response_id, reconnect_events = asyncio.run(run())
+
+        retrieved = client.responses.retrieve(response_id=warmup_response_id)
+        assert retrieved.id == warmup_response_id
+        assert retrieved.status == "completed"
+        assert retrieved.store is True
+        assert retrieved.output == []
+
+        assert reconnect_events[-1]["type"] == "response.completed"
+        assert _response_output_text(reconnect_events[-1]).strip()
+
+    def test_http_invalid_previous_response_id_is_not_found(self, setup_backend):
+        """HTTP Responses should reject unknown previous_response_id values."""
+        _, model, client, _ = setup_backend
+
+        with pytest.raises(openai.NotFoundError):
+            client.responses.create(
+                model=model,
+                input="This should fail.",
+                previous_response_id="resp_missing_http",
+                max_output_tokens=16,
+            )
+
+
+@pytest.mark.e2e
+@pytest.mark.model(_TOOL_SMOKE_MODEL)
+@pytest.mark.gateway(
+    extra_args=["--tool-call-parser", "qwen", "--history-backend", "memory"]
+)
+@pytest.mark.parametrize("setup_backend", ["grpc"], indirect=True)
+class TestResponsesLocalToolSmoke:
+    """Function-tool Responses smoke on qwen-7b."""
+
+    def test_chat_streaming_function_call_first_turn(self, setup_backend):
+        """Local chat streaming should surface qwen tool-call deltas before Responses adapts them."""
+        _, model, client, _ = setup_backend
+
+        response = client.chat.completions.create(
+            model=model,
+            messages=[
+                {
+                    "role": "user",
+                    "content": "Calculate 42 * 17. Use the tool.",
+                }
+            ],
+            tools=[CALCULATE_CHAT_TOOL],
+            tool_choice="required",
+            stream=True,
+            stream_options={"include_usage": True},
+            temperature=0,
+            max_tokens=128,
+        )
+
+        tool_call_chunks = []
+        finish_reason = None
+
+        for chunk in response:
+            if not chunk.choices:
+                continue
+            choice = chunk.choices[0]
+            if choice.delta.tool_calls:
+                tool_call_chunks.extend(choice.delta.tool_calls)
+            if choice.finish_reason is not None:
+                finish_reason = choice.finish_reason
+
+        assert tool_call_chunks, "expected chat streaming to emit tool-call chunks"
+        assert finish_reason == "tool_calls"
+
+    def test_http_responses_function_call_first_turn(self, setup_backend):
+        """The router should emit a real function call via qwen-7b."""
+        _, model, client, _ = setup_backend
+
+        resp = client.responses.create(
+            model=model,
+            input="Calculate 15 * 23. Use the tool.",
+            tools=[CALCULATE_FUNCTION],
+            tool_choice="required",
+            stream=False,
+            temperature=0,
+            max_output_tokens=128,
+        )
+
+        assert resp.error is None
+        assert resp.status == "in_progress"
+
+        function_calls = _response_function_calls(resp.output)
+        assert function_calls, "expected at least one function call in the first turn"
+        assert function_calls[0].name == "calculate"
+        assert function_calls[0].call_id
+        assert function_calls[0].arguments
+
+        arguments = json.loads(function_calls[0].arguments)
+        assert "expression" in arguments
+        assert "15" in arguments["expression"]
+        assert "23" in arguments["expression"]
+
+    def test_http_streaming_function_call_first_turn(self, setup_backend):
+        """Streaming Responses should expose function-call events and final output."""
+        _, model, client, _ = setup_backend
+
+        events = list(
+            client.responses.create(
+                model=model,
+                input="Calculate 42 * 17. Use the tool.",
+                tools=[CALCULATE_FUNCTION],
+                tool_choice="required",
+                stream=True,
+                temperature=0,
+                max_output_tokens=128,
+            )
+        )
+
+        event_types = [event.type for event in events]
+        assert "response.created" in event_types
+        assert "response.function_call_arguments.delta" in event_types
+        assert "response.function_call_arguments.done" in event_types
+
+        completed_events = [event for event in events if event.type == "response.completed"]
+        assert len(completed_events) == 1
+
+        completed = completed_events[0]
+        assert completed.response.status == "in_progress"
+
+        function_calls = _response_function_calls(completed.response.output)
+        assert function_calls, "expected a function call in the completed response payload"
+        assert function_calls[0].name == "calculate"
+        assert function_calls[0].call_id
+        assert function_calls[0].arguments
+
+    def test_http_function_call_two_turn_continuation(self, setup_backend):
+        """HTTP Responses should continue from function_call_output-only turns."""
+        _, model, client, _ = setup_backend
+
+        first = client.responses.create(
+            model=model,
+            input="Calculate 15 * 23. Use the tool.",
+            tools=[CALCULATE_FUNCTION],
+            tool_choice="required",
+            stream=False,
+            temperature=0,
+            max_output_tokens=128,
+        )
+
+        function_calls = _response_function_calls(first.output)
+        assert function_calls, "expected a completed function call in the first HTTP turn"
+        assert first.status == "in_progress"
+        assert function_calls[0].name == "calculate"
+        assert function_calls[0].arguments
+
+        second = client.responses.create(
+            model=model,
+            input=[
+                {
+                    "type": "function_call_output",
+                    "call_id": function_calls[0].call_id,
+                    "output": json.dumps({"result": 345}),
+                }
+            ],
+            previous_response_id=first.id,
+            tools=[CALCULATE_FUNCTION],
+            tool_choice="auto",
+            temperature=0,
+            max_output_tokens=128,
+        )
+
+        assert second.status == "completed"
+        assert "345" in second.output_text
+
+    def test_websocket_function_call_two_turn_continuation(self, setup_backend):
+        """WS should support a first-turn function call and a second-turn tool result."""
+        _, model, _, gateway = setup_backend
+
+        async def run() -> tuple[dict, dict]:
+            import websockets
+
+            ws_url = _gateway_ws_url(gateway.base_url)
+            async with websockets.connect(
+                ws_url, open_timeout=30, close_timeout=5
+            ) as websocket:
+                first_events = await _send_ws_request_and_collect(
+                    websocket,
+                    _ws_request(
+                        model,
+                        input="Calculate 15 * 23. Use the tool.",
+                        store=False,
+                        tools=[CALCULATE_FUNCTION],
+                        tool_choice="required",
+                        max_output_tokens=128,
+                    ),
+                )
+                first_completed = first_events[-1]
+                function_call = _completed_response_function_calls(first_completed)[0]
+
+                second_events = await _send_ws_request_and_collect(
+                    websocket,
+                    _ws_request(
+                        model,
+                        input=[
+                            {
+                                "type": "function_call_output",
+                                "call_id": function_call["call_id"],
+                                "output": json.dumps({"result": 345}),
+                            }
+                        ],
+                        previous_response_id=first_completed["response"]["id"],
+                        store=False,
+                        tools=[CALCULATE_FUNCTION],
+                        tool_choice="auto",
+                        max_output_tokens=128,
+                    ),
+                )
+
+            return first_completed, second_events[-1]
+
+        first_completed, second_completed = asyncio.run(run())
+
+        function_calls = _completed_response_function_calls(first_completed)
+        assert function_calls, "expected a completed function call in the first WS turn"
+        assert first_completed["response"]["status"] == "in_progress"
+        assert function_calls[0]["name"] == "calculate"
+        assert function_calls[0]["arguments"]
+
+        assert second_completed["type"] == "response.completed"
+        assert second_completed["response"]["status"] == "completed"
+        assert "345" in _response_output_text(second_completed)

--- a/sgl-model-gateway/e2e_test/ws_utils.py
+++ b/sgl-model-gateway/e2e_test/ws_utils.py
@@ -1,0 +1,26 @@
+"""Shared WebSocket utilities for e2e tests and benchmarks."""
+
+
+def gateway_ws_url(base_url: str) -> str:
+    """Convert an HTTP gateway URL to the equivalent WebSocket URL."""
+    ws_url = base_url.replace("https://", "wss://").replace("http://", "ws://")
+    if not ws_url.startswith(("ws://", "wss://")):
+        ws_url = f"ws://{ws_url}"
+    return f"{ws_url}/v1/responses"
+
+
+def percentile(values: list[float], p: float) -> float:
+    """Linear-interpolation percentile (0-100 scale)."""
+    if not values:
+        return 0.0
+    sorted_vals = sorted(values)
+    n = len(sorted_vals)
+    if n == 1:
+        return sorted_vals[0]
+    k = (p / 100.0) * (n - 1)
+    f = int(k)
+    c = f + 1
+    if c >= n:
+        return sorted_vals[-1]
+    d = k - f
+    return sorted_vals[f] + d * (sorted_vals[c] - sorted_vals[f])

--- a/sgl-model-gateway/src/bench_support.rs
+++ b/sgl-model-gateway/src/bench_support.rs
@@ -1,0 +1,264 @@
+use axum::extract::ws::Message;
+use serde_json::json;
+use tokio::sync::mpsc;
+
+use crate::{
+    protocols::responses::{
+        ResponseContentPart, ResponseInput, ResponseInputOutputItem, ResponseOutputItem,
+        ResponseStatus, ResponsesRequest, ResponsesResponse, ServiceTier, StringOrContentParts,
+        Truncation,
+    },
+    routers::{
+        grpc::{
+            common::responses::streaming::{
+                OutputItemType, ResponseEventSink, ResponseStreamEventEmitter,
+                SseResponseEventSink, WsResponseEventSink,
+            },
+            regular::responses::normalize_request_input_items,
+        },
+        ws_responses::CachedWsResponse,
+    },
+};
+
+fn repeated_text(size: usize) -> String {
+    "x".repeat(size)
+}
+
+fn bench_request() -> ResponsesRequest {
+    ResponsesRequest {
+        background: Some(false),
+        include: None,
+        input: ResponseInput::Text("bench request".to_string()),
+        instructions: None,
+        max_output_tokens: Some(256),
+        max_tool_calls: None,
+        metadata: None,
+        model: "bench-model".to_string(),
+        parallel_tool_calls: Some(true),
+        previous_response_id: None,
+        reasoning: None,
+        service_tier: Some(ServiceTier::Auto),
+        store: Some(true),
+        stream: Some(true),
+        temperature: Some(0.0),
+        tool_choice: None,
+        tools: None,
+        top_logprobs: Some(0),
+        top_p: None,
+        truncation: Some(Truncation::Disabled),
+        text: None,
+        user: None,
+        request_id: Some("resp_bench".to_string()),
+        priority: 0,
+        frequency_penalty: Some(0.0),
+        presence_penalty: Some(0.0),
+        stop: None,
+        top_k: -1,
+        min_p: 0.0,
+        repetition_penalty: 1.0,
+        conversation: None,
+    }
+}
+
+fn bench_message_item(text: &str, item_id: &str) -> serde_json::Value {
+    json!({
+        "id": item_id,
+        "type": "message",
+        "role": "assistant",
+        "content": [{
+            "type": "text",
+            "text": text
+        }]
+    })
+}
+
+fn build_cached_response(history_turns: usize, text_bytes: usize) -> CachedWsResponse {
+    let mut input_items = Vec::with_capacity(history_turns);
+    let mut output_items = Vec::with_capacity(history_turns);
+    let text = repeated_text(text_bytes);
+
+    for turn in 0..history_turns {
+        input_items.push(ResponseInputOutputItem::Message {
+            id: format!("msg_user_{turn}"),
+            role: "user".to_string(),
+            content: vec![ResponseContentPart::InputText { text: text.clone() }],
+            status: Some("completed".to_string()),
+        });
+        output_items.push(ResponseOutputItem::Message {
+            id: format!("msg_assistant_{turn}"),
+            role: "assistant".to_string(),
+            content: vec![ResponseContentPart::OutputText {
+                text: text.clone(),
+                annotations: vec![],
+                logprobs: None,
+            }],
+            status: "completed".to_string(),
+        });
+    }
+
+    let response = ResponsesResponse::builder("resp_cached_bench", "bench-model")
+        .copy_from_request(&bench_request())
+        .status(ResponseStatus::Completed)
+        .output(output_items)
+        .build();
+
+    CachedWsResponse {
+        response,
+        input_items,
+    }
+}
+
+fn build_incremental_items(item_count: usize, text_bytes: usize) -> Vec<ResponseInputOutputItem> {
+    let mut items = Vec::with_capacity(item_count);
+    let text = repeated_text(text_bytes);
+
+    for index in 0..item_count {
+        if index % 2 == 0 {
+            items.push(ResponseInputOutputItem::SimpleInputMessage {
+                role: "user".to_string(),
+                content: StringOrContentParts::Array(vec![ResponseContentPart::InputText {
+                    text: text.clone(),
+                }]),
+                r#type: None,
+            });
+        } else {
+            items.push(ResponseInputOutputItem::FunctionCallOutput {
+                id: None,
+                call_id: format!("call_{index}"),
+                output: text.clone(),
+                status: None,
+            });
+        }
+    }
+
+    items
+}
+
+fn make_incremental_request(item_count: usize, text_bytes: usize) -> ResponsesRequest {
+    ResponsesRequest {
+        input: ResponseInput::Items(build_incremental_items(item_count, text_bytes)),
+        previous_response_id: Some("resp_prev_bench".to_string()),
+        ..bench_request()
+    }
+}
+
+fn emit_text_stream_batch(
+    sink: &impl ResponseEventSink,
+    delta_events: usize,
+    delta_bytes: usize,
+) -> usize {
+    let delta = repeated_text(delta_bytes);
+    let mut emitter = ResponseStreamEventEmitter::new(
+        "resp_bench_stream".to_string(),
+        "bench-model".to_string(),
+        0,
+    );
+    emitter.set_original_request(bench_request());
+
+    let created = emitter.emit_created();
+    emitter.send_event(&created, sink).unwrap();
+    let in_progress = emitter.emit_in_progress();
+    emitter.send_event(&in_progress, sink).unwrap();
+
+    let (output_index, item_id) = emitter.allocate_output_index(OutputItemType::Message);
+    let added_item = json!({
+        "id": item_id,
+        "type": "message",
+        "role": "assistant",
+        "content": []
+    });
+    let output_added = emitter.emit_output_item_added(output_index, &added_item);
+    emitter.send_event(&output_added, sink).unwrap();
+
+    let content_added = emitter.emit_content_part_added(output_index, &item_id, 0);
+    emitter.send_event(&content_added, sink).unwrap();
+
+    for _ in 0..delta_events {
+        let delta_event = emitter.emit_text_delta(&delta, output_index, &item_id, 0);
+        emitter.send_event(&delta_event, sink).unwrap();
+    }
+
+    let text_done = emitter.emit_text_done(output_index, &item_id, 0);
+    emitter.send_event(&text_done, sink).unwrap();
+    let content_done = emitter.emit_content_part_done(output_index, &item_id, 0);
+    emitter.send_event(&content_done, sink).unwrap();
+
+    let done_item = bench_message_item(&delta.repeat(delta_events), &item_id);
+    let output_done = emitter.emit_output_item_done(output_index, &done_item);
+    emitter.send_event(&output_done, sink).unwrap();
+    emitter.complete_output_item(output_index);
+
+    let completed = emitter.emit_completed(None);
+    emitter.send_event(&completed, sink).unwrap();
+
+    delta_events * delta_bytes
+}
+
+#[doc(hidden)]
+pub fn bench_emit_ws_text_stream(delta_events: usize, delta_bytes: usize) -> usize {
+    let (tx, mut rx) = mpsc::unbounded_channel::<Message>();
+    let sink = WsResponseEventSink::new(tx);
+    let payload_bytes = emit_text_stream_batch(&sink, delta_events, delta_bytes);
+    let mut drained = 0usize;
+    while let Ok(message) = rx.try_recv() {
+        drained += match message {
+            Message::Text(text) => text.len(),
+            Message::Binary(payload) => payload.len(),
+            Message::Ping(payload) | Message::Pong(payload) => payload.len(),
+            Message::Close(_) => 0,
+        };
+    }
+    payload_bytes + drained
+}
+
+#[doc(hidden)]
+pub fn bench_emit_sse_text_stream(delta_events: usize, delta_bytes: usize) -> usize {
+    let (tx, mut rx) = mpsc::unbounded_channel::<Result<bytes::Bytes, std::io::Error>>();
+    let sink = SseResponseEventSink::new(tx);
+    let payload_bytes = emit_text_stream_batch(&sink, delta_events, delta_bytes);
+    let mut drained = 0usize;
+    while let Ok(item) = rx.try_recv() {
+        drained += item.unwrap().len();
+    }
+    payload_bytes + drained
+}
+
+#[doc(hidden)]
+pub fn bench_cached_response_to_items(history_turns: usize, text_bytes: usize) -> usize {
+    let cached = build_cached_response(history_turns, text_bytes);
+    let items = cached.to_conversation_items();
+    items.len()
+        + items
+            .iter()
+            .map(|item| serde_json::to_string(item).unwrap().len())
+            .sum::<usize>()
+}
+
+#[doc(hidden)]
+pub fn bench_cached_continuation_shape(
+    history_turns: usize,
+    history_text_bytes: usize,
+    new_items: usize,
+    new_text_bytes: usize,
+) -> usize {
+    let cached = build_cached_response(history_turns, history_text_bytes);
+    let mut items = cached.to_conversation_items();
+    let request = make_incremental_request(new_items, new_text_bytes);
+    items.extend(normalize_request_input_items(&request));
+    items.len()
+        + items
+            .iter()
+            .map(|item| serde_json::to_string(item).unwrap().len())
+            .sum::<usize>()
+}
+
+#[doc(hidden)]
+pub fn bench_normalize_incremental_request(item_count: usize, text_bytes: usize) -> usize {
+    let request = make_incremental_request(item_count, text_bytes);
+    let items = normalize_request_input_items(&request);
+    items.len()
+        + items
+            .iter()
+            .map(|item| serde_json::to_string(item).unwrap().len())
+            .sum::<usize>()
+}

--- a/sgl-model-gateway/src/bench_support.rs
+++ b/sgl-model-gateway/src/bench_support.rs
@@ -196,7 +196,7 @@ fn emit_text_stream_batch(
 
 #[doc(hidden)]
 pub fn bench_emit_ws_text_stream(delta_events: usize, delta_bytes: usize) -> usize {
-    let (tx, mut rx) = mpsc::unbounded_channel::<Message>();
+    let (tx, mut rx) = mpsc::channel::<Message>(4096);
     let sink = WsResponseEventSink::new(tx);
     let payload_bytes = emit_text_stream_batch(&sink, delta_events, delta_bytes);
     let mut drained = 0usize;

--- a/sgl-model-gateway/src/lib.rs
+++ b/sgl-model-gateway/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod app_context;
 pub use smg_auth as auth;
+#[doc(hidden)]
+pub mod bench_support;
 pub mod config;
 pub mod core;
 pub mod middleware;

--- a/sgl-model-gateway/src/routers/grpc/common/responses/context.rs
+++ b/sgl-model-gateway/src/routers/grpc/common/responses/context.rs
@@ -57,4 +57,16 @@ impl ResponsesContext {
             requested_servers: Arc::new(StdRwLock::new(Vec::new())),
         }
     }
+
+    /// Clone the shared dependencies while creating a fresh per-request server-key buffer.
+    pub fn clone_for_request(&self) -> Self {
+        Self::new(
+            self.pipeline.clone(),
+            self.components.clone(),
+            self.response_storage.clone(),
+            self.conversation_storage.clone(),
+            self.conversation_item_storage.clone(),
+            self.mcp_manager.clone(),
+        )
+    }
 }

--- a/sgl-model-gateway/src/routers/grpc/common/responses/context.rs
+++ b/sgl-model-gateway/src/routers/grpc/common/responses/context.rs
@@ -33,7 +33,11 @@ pub(crate) struct ResponsesContext {
     /// MCP manager for tool support
     pub mcp_manager: Arc<McpManager>,
 
-    /// Server keys for MCP tools requested in this context
+    /// Server keys for MCP tools requested in this context.
+    ///
+    /// Safety: `clone_for_request()` creates a fresh lock per request, so this
+    /// is never shared across concurrent tasks.  The `StdRwLock` is adequate
+    /// because locks are only held for short, non-async operations.
     pub requested_servers: Arc<StdRwLock<Vec<String>>>,
 }
 

--- a/sgl-model-gateway/src/routers/grpc/common/responses/streaming.rs
+++ b/sgl-model-gateway/src/routers/grpc/common/responses/streaming.rs
@@ -161,11 +161,11 @@ impl ResponseEventSink for mpsc::UnboundedSender<Result<Bytes, std::io::Error>> 
 
 #[derive(Clone)]
 pub(crate) struct WsResponseEventSink {
-    tx: mpsc::UnboundedSender<Message>,
+    tx: mpsc::Sender<Message>,
 }
 
 impl WsResponseEventSink {
-    pub fn new(tx: mpsc::UnboundedSender<Message>) -> Self {
+    pub fn new(tx: mpsc::Sender<Message>) -> Self {
         Self { tx }
     }
 }
@@ -181,8 +181,10 @@ impl ResponseEventSink for WsResponseEventSink {
                 event_type, delta_chars, "forwarding responses stream event"
             );
         }
-        if self.tx.send(Message::Text(event_json.into())).is_err() {
-            return Err("Client disconnected".to_string());
+        // Use try_send to avoid blocking the tokio runtime from a sync context.
+        // A full channel means the client can't keep up; treat as disconnect.
+        if self.tx.try_send(Message::Text(event_json.into())).is_err() {
+            return Err("Client disconnected or outbound buffer full".to_string());
         }
 
         if response_event_timing_enabled() && should_log_response_event(event_type) {
@@ -201,10 +203,10 @@ impl ResponseEventSink for WsResponseEventSink {
     fn send_raw_json(&self, payload: &str) -> Result<(), String> {
         if self
             .tx
-            .send(Message::Text(payload.to_string().into()))
+            .try_send(Message::Text(payload.to_string().into()))
             .is_err()
         {
-            return Err("Client disconnected".to_string());
+            return Err("Client disconnected or outbound buffer full".to_string());
         }
         Ok(())
     }
@@ -923,8 +925,15 @@ impl ResponseStreamEventEmitter {
             // Check for finish_reason to emit completion events
             if let Some(reason) = &choice.finish_reason {
                 if reason == "stop" || reason == "length" {
-                    let output_index = self.current_message_output_index.unwrap();
-                    let item_id = self.current_item_id.clone().unwrap(); // Clone to avoid borrow checker issues
+                    // Guard: finish_reason can arrive without prior content
+                    // deltas (e.g. empty responses).  Skip completion events
+                    // if we never allocated an output slot.
+                    let (Some(output_index), Some(item_id)) = (
+                        self.current_message_output_index,
+                        self.current_item_id.clone(),
+                    ) else {
+                        return Ok(());
+                    };
                     let content_index = 0;
 
                     // Emit closing events

--- a/sgl-model-gateway/src/routers/grpc/common/responses/streaming.rs
+++ b/sgl-model-gateway/src/routers/grpc/common/responses/streaming.rs
@@ -1,13 +1,18 @@
 //! Streaming infrastructure for /v1/responses endpoint
 
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    sync::OnceLock,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
-use axum::{body::Body, http::StatusCode, response::Response};
+use axum::{body::Body, extract::ws::Message, http::StatusCode, response::Response};
 use bytes::Bytes;
 use serde_json::json;
 use smg_mcp as mcp;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
+use tracing::debug;
 use uuid::Uuid;
 
 use crate::{
@@ -24,6 +29,186 @@ use crate::{
     },
     routers::grpc::harmony::responses::ToolResult,
 };
+
+pub(crate) trait ResponseEventSink {
+    fn send_event(&self, event: &serde_json::Value) -> Result<(), String>;
+    fn send_raw_json(&self, payload: &str) -> Result<(), String>;
+    fn send_done(&self) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+fn response_event_timing_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("SMG_DEBUG_RESPONSE_EVENT_TIMING").is_some())
+}
+
+fn unix_timestamp_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn should_log_response_event(event_type: &str) -> bool {
+    matches!(
+        event_type,
+        "response.created"
+            | "response.in_progress"
+            | "response.output_text.delta"
+            | "response.output_text.done"
+            | "response.completed"
+            | "response.failed"
+            | "error"
+    )
+}
+
+fn response_event_log_fields(event: &serde_json::Value) -> (&str, usize) {
+    let event_type = event
+        .get("type")
+        .and_then(|value| value.as_str())
+        .unwrap_or("unknown");
+    let delta_chars = event
+        .get("delta")
+        .and_then(|value| value.as_str())
+        .map(|delta| delta.chars().count())
+        .unwrap_or(0);
+    (event_type, delta_chars)
+}
+
+#[derive(Clone)]
+pub(crate) struct SseResponseEventSink {
+    tx: mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
+}
+
+impl SseResponseEventSink {
+    pub fn new(tx: mpsc::UnboundedSender<Result<Bytes, std::io::Error>>) -> Self {
+        Self { tx }
+    }
+}
+
+impl ResponseEventSink for SseResponseEventSink {
+    fn send_event(&self, event: &serde_json::Value) -> Result<(), String> {
+        let event_json = serde_json::to_string(event)
+            .map_err(|e| format!("Failed to serialize event: {}", e))?;
+
+        let event_type = event
+            .get("type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("message");
+        if should_log_response_event(event_type) {
+            let (_, delta_chars) = response_event_log_fields(event);
+            debug!(
+                transport = "sse",
+                event_type, delta_chars, "forwarding responses stream event"
+            );
+        }
+        let sse_message = format!("event: {}\ndata: {}\n\n", event_type, event_json);
+
+        if self.tx.send(Ok(Bytes::from(sse_message))).is_err() {
+            return Err("Client disconnected".to_string());
+        }
+
+        if response_event_timing_enabled() && should_log_response_event(event_type) {
+            let (_, delta_chars) = response_event_log_fields(event);
+            tracing::info!(
+                wall_time_ms = unix_timestamp_ms(),
+                transport = "sse",
+                stage = "enqueue",
+                event_type,
+                delta_chars,
+                "queued responses stream event"
+            );
+        }
+
+        Ok(())
+    }
+
+    fn send_raw_json(&self, payload: &str) -> Result<(), String> {
+        if self
+            .tx
+            .send(Ok(Bytes::from(format!("data: {}\n\n", payload))))
+            .is_err()
+        {
+            return Err("Client disconnected".to_string());
+        }
+
+        Ok(())
+    }
+
+    fn send_done(&self) -> Result<(), String> {
+        if self.tx.send(Ok(Bytes::from("data: [DONE]\n\n"))).is_err() {
+            return Err("Client disconnected".to_string());
+        }
+
+        Ok(())
+    }
+}
+
+impl ResponseEventSink for mpsc::UnboundedSender<Result<Bytes, std::io::Error>> {
+    fn send_event(&self, event: &serde_json::Value) -> Result<(), String> {
+        SseResponseEventSink::new(self.clone()).send_event(event)
+    }
+
+    fn send_raw_json(&self, payload: &str) -> Result<(), String> {
+        SseResponseEventSink::new(self.clone()).send_raw_json(payload)
+    }
+
+    fn send_done(&self) -> Result<(), String> {
+        SseResponseEventSink::new(self.clone()).send_done()
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct WsResponseEventSink {
+    tx: mpsc::UnboundedSender<Message>,
+}
+
+impl WsResponseEventSink {
+    pub fn new(tx: mpsc::UnboundedSender<Message>) -> Self {
+        Self { tx }
+    }
+}
+
+impl ResponseEventSink for WsResponseEventSink {
+    fn send_event(&self, event: &serde_json::Value) -> Result<(), String> {
+        let event_json = serde_json::to_string(event)
+            .map_err(|e| format!("Failed to serialize event: {}", e))?;
+        let (event_type, delta_chars) = response_event_log_fields(event);
+        if should_log_response_event(event_type) {
+            debug!(
+                transport = "ws",
+                event_type, delta_chars, "forwarding responses stream event"
+            );
+        }
+        if self.tx.send(Message::Text(event_json.into())).is_err() {
+            return Err("Client disconnected".to_string());
+        }
+
+        if response_event_timing_enabled() && should_log_response_event(event_type) {
+            tracing::info!(
+                wall_time_ms = unix_timestamp_ms(),
+                transport = "ws",
+                stage = "enqueue",
+                event_type,
+                delta_chars,
+                "queued responses stream event"
+            );
+        }
+        Ok(())
+    }
+
+    fn send_raw_json(&self, payload: &str) -> Result<(), String> {
+        if self
+            .tx
+            .send(Message::Text(payload.to_string().into()))
+            .is_err()
+        {
+            return Err("Client disconnected".to_string());
+        }
+        Ok(())
+    }
+}
 
 pub(crate) enum OutputItemType {
     Message,
@@ -262,7 +447,11 @@ impl ResponseStreamEventEmitter {
         })
     }
 
-    pub fn emit_completed(&mut self, usage: Option<&serde_json::Value>) -> serde_json::Value {
+    pub fn emit_completed_with_status(
+        &mut self,
+        status: ResponseStatus,
+        usage: Option<&serde_json::Value>,
+    ) -> serde_json::Value {
         // Build output array from tracked items
         let output: Vec<serde_json::Value> = self
             .output_items
@@ -296,7 +485,7 @@ impl ResponseStreamEventEmitter {
             "id": self.response_id,
             "object": "response",
             "created_at": self.created_at,
-            "status": "completed",
+            "status": status,
             "model": self.model,
             "output": output
         });
@@ -344,6 +533,10 @@ impl ResponseStreamEventEmitter {
             "sequence_number": self.next_sequence(),
             "response": response_obj
         })
+    }
+
+    pub fn emit_completed(&mut self, usage: Option<&serde_json::Value>) -> serde_json::Value {
+        self.emit_completed_with_status(ResponseStatus::Completed, usage)
     }
 
     /// Helper to add optional fields to JSON object
@@ -594,7 +787,11 @@ impl ResponseStreamEventEmitter {
     ///
     /// This constructs the final ResponsesResponse from all accumulated output items
     /// for persistence. Should be called after streaming is complete.
-    pub fn finalize(&self, usage: Option<Usage>) -> ResponsesResponse {
+    pub fn finalize_with_status(
+        &self,
+        usage: Option<Usage>,
+        status: ResponseStatus,
+    ) -> ResponsesResponse {
         // Build output array from tracked items
         let output: Vec<ResponseOutputItem> = self
             .output_items
@@ -624,11 +821,15 @@ impl ResponseStreamEventEmitter {
         // Build response using builder
         ResponsesResponse::builder(&self.response_id, &self.model)
             .created_at(self.created_at as i64)
-            .status(ResponseStatus::Completed)
+            .status(status)
             .output(output)
             .maybe_copy_from_request(self.original_request.as_ref())
             .maybe_usage(responses_usage)
             .build()
+    }
+
+    pub fn finalize(&self, usage: Option<Usage>) -> ResponsesResponse {
+        self.finalize_with_status(usage, ResponseStatus::Completed)
     }
 
     /// Emit reasoning item wrapper events (added + done)
@@ -637,7 +838,7 @@ impl ResponseStreamEventEmitter {
     /// They don't have streaming content - just wrapper events with empty/null content.
     pub fn emit_reasoning_item(
         &mut self,
-        tx: &mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
+        sink: &impl ResponseEventSink,
         reasoning_content: Option<String>,
     ) -> Result<(), String> {
         // Allocate output index and generate ID
@@ -655,11 +856,11 @@ impl ResponseStreamEventEmitter {
 
         // Emit output_item.added
         let added_event = self.emit_output_item_added(output_index, &item);
-        self.send_event(&added_event, tx)?;
+        self.send_event(&added_event, sink)?;
 
         // Immediately emit output_item.done (no streaming for reasoning)
         let done_event = self.emit_output_item_done(output_index, &item);
-        self.send_event(&done_event, tx)?;
+        self.send_event(&done_event, sink)?;
 
         // Mark as completed
         self.complete_output_item(output_index);
@@ -671,7 +872,7 @@ impl ResponseStreamEventEmitter {
     pub fn process_chunk(
         &mut self,
         chunk: &ChatCompletionStreamResponse,
-        tx: &mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
+        sink: &impl ResponseEventSink,
     ) -> Result<(), String> {
         // Process content if present
         if let Some(choice) = chunk.choices.first() {
@@ -692,7 +893,7 @@ impl ResponseStreamEventEmitter {
 
                         // Emit output_item.added
                         let event = self.emit_output_item_added(output_index, &item);
-                        self.send_event(&event, tx)?;
+                        self.send_event(&event, sink)?;
                         self.has_emitted_output_item_added = true;
 
                         // Store for subsequent events
@@ -708,14 +909,14 @@ impl ResponseStreamEventEmitter {
                     if !self.has_emitted_content_part_added {
                         let event =
                             self.emit_content_part_added(output_index, &item_id, content_index);
-                        self.send_event(&event, tx)?;
+                        self.send_event(&event, sink)?;
                         self.has_emitted_content_part_added = true;
                     }
 
                     // Emit text delta
                     let event =
                         self.emit_text_delta(content, output_index, &item_id, content_index);
-                    self.send_event(&event, tx)?;
+                    self.send_event(&event, sink)?;
                 }
             }
 
@@ -729,10 +930,10 @@ impl ResponseStreamEventEmitter {
                     // Emit closing events
                     if self.has_emitted_content_part_added {
                         let event = self.emit_text_done(output_index, &item_id, content_index);
-                        self.send_event(&event, tx)?;
+                        self.send_event(&event, sink)?;
                         let event =
                             self.emit_content_part_done(output_index, &item_id, content_index);
-                        self.send_event(&event, tx)?;
+                        self.send_event(&event, sink)?;
                     }
 
                     if self.has_emitted_output_item_added {
@@ -747,7 +948,7 @@ impl ResponseStreamEventEmitter {
                             }]
                         });
                         let event = self.emit_output_item_done(output_index, &item);
-                        self.send_event(&event, tx)?;
+                        self.send_event(&event, sink)?;
                     }
 
                     // Mark item as completed
@@ -762,25 +963,9 @@ impl ResponseStreamEventEmitter {
     pub fn send_event(
         &self,
         event: &serde_json::Value,
-        tx: &mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
+        sink: &impl ResponseEventSink,
     ) -> Result<(), String> {
-        let event_json = serde_json::to_string(event)
-            .map_err(|e| format!("Failed to serialize event: {}", e))?;
-
-        // Extract event type from the JSON for SSE event field
-        let event_type = event
-            .get("type")
-            .and_then(|v| v.as_str())
-            .unwrap_or("message");
-
-        // Format as SSE with event: field
-        let sse_message = format!("event: {}\ndata: {}\n\n", event_type, event_json);
-
-        if tx.send(Ok(Bytes::from(sse_message))).is_err() {
-            return Err("Client disconnected".to_string());
-        }
-
-        Ok(())
+        sink.send_event(event)
     }
 
     /// Send event and log any errors (typically client disconnect)
@@ -791,9 +976,9 @@ impl ResponseStreamEventEmitter {
     pub fn send_event_best_effort(
         &self,
         event: &serde_json::Value,
-        tx: &mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
+        sink: &impl ResponseEventSink,
     ) -> bool {
-        match self.send_event(event, tx) {
+        match self.send_event(event, sink) {
             Ok(()) => true,
             Err(e) => {
                 tracing::debug!("Failed to send event (likely client disconnect): {}", e);
@@ -811,7 +996,7 @@ impl ResponseStreamEventEmitter {
         &mut self,
         error_msg: &str,
         error_code: Option<&str>,
-        tx: &mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
+        sink: &impl ResponseEventSink,
     ) {
         let event = json!({
             "type": "error",
@@ -820,8 +1005,7 @@ impl ResponseStreamEventEmitter {
             "param": null,
             "sequence_number": self.next_sequence()
         });
-        let sse_data = format!("data: {}\n\n", serde_json::to_string(&event).unwrap());
-        let _ = tx.send(Ok(Bytes::from(sse_data)));
+        let _ = sink.send_raw_json(&serde_json::to_string(&event).unwrap());
     }
 }
 

--- a/sgl-model-gateway/src/routers/grpc/harmony/responses/common.rs
+++ b/sgl-model-gateway/src/routers/grpc/harmony/responses/common.rs
@@ -302,6 +302,13 @@ pub(super) async fn load_previous_messages(
             )
         })?;
 
+    if chain.responses.is_empty() {
+        return Err(error::not_found(
+            "previous_response_not_found",
+            format!("Previous response '{}' not found.", prev_id_str),
+        ));
+    }
+
     // Build conversation history from stored responses
     let mut history_items = Vec::new();
 

--- a/sgl-model-gateway/src/routers/grpc/regular/responses/common.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/responses/common.rs
@@ -401,7 +401,10 @@ pub(crate) async fn load_conversation_history_with_cache(
                 modified_request.input = ResponseInput::Items(items);
             }
             Err(e) => {
-                warn!("Failed to load conversation history: {}", e);
+                return Err(error::internal_error(
+                    "load_conversation_history_failed",
+                    format!("Failed to load conversation history: {}", e),
+                ));
             }
         }
     }
@@ -497,38 +500,15 @@ pub(super) fn build_next_request(
     // Append all conversation history (function calls and outputs)
     input_items.extend_from_slice(&state.conversation_history);
 
-    // Build new request for next iteration
+    // Build new request for next iteration, inheriting all fields from the
+    // current request except the ones we explicitly override.
     ResponsesRequest {
         input: ResponseInput::Items(input_items),
-        model: current_request.model.clone(),
-        instructions: current_request.instructions.clone(),
-        tools: current_request.tools.clone(),
-        max_output_tokens: current_request.max_output_tokens,
-        temperature: current_request.temperature,
-        top_p: current_request.top_p,
-        stream: current_request.stream,
         store: Some(false), // Don't store intermediate responses
         background: Some(false),
-        max_tool_calls: current_request.max_tool_calls,
-        tool_choice: current_request.tool_choice.clone(),
-        parallel_tool_calls: current_request.parallel_tool_calls,
         previous_response_id: None,
         conversation: None,
-        user: current_request.user.clone(),
-        metadata: current_request.metadata.clone(),
-        include: current_request.include.clone(),
-        reasoning: current_request.reasoning.clone(),
-        service_tier: current_request.service_tier.clone(),
-        top_logprobs: current_request.top_logprobs,
-        truncation: current_request.truncation.clone(),
-        text: current_request.text.clone(),
         request_id: None,
-        priority: current_request.priority,
-        frequency_penalty: current_request.frequency_penalty,
-        presence_penalty: current_request.presence_penalty,
-        stop: current_request.stop.clone(),
-        top_k: current_request.top_k,
-        min_p: current_request.min_p,
-        repetition_penalty: current_request.repetition_penalty,
+        ..current_request.clone()
     }
 }

--- a/sgl-model-gateway/src/routers/grpc/regular/responses/common.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/responses/common.rs
@@ -24,7 +24,7 @@ use crate::{
             ResponseOutputItem, ResponsesRequest,
         },
     },
-    routers::{error, grpc::common::responses::ResponsesContext},
+    routers::{error, grpc::common::responses::ResponsesContext, ws_responses::CachedWsResponse},
 };
 
 // ============================================================================
@@ -232,62 +232,93 @@ pub(super) async fn load_conversation_history(
     ctx: &ResponsesContext,
     request: &ResponsesRequest,
 ) -> Result<ResponsesRequest, Response> {
+    load_conversation_history_with_cache(ctx, request, None, false).await
+}
+
+pub(crate) async fn load_conversation_history_with_cache(
+    ctx: &ResponsesContext,
+    request: &ResponsesRequest,
+    cached_response: Option<&CachedWsResponse>,
+    strict_missing_previous: bool,
+) -> Result<ResponsesRequest, Response> {
     let mut modified_request = request.clone();
     let mut conversation_items: Option<Vec<ResponseInputOutputItem>> = None;
 
     // Handle previous_response_id by loading response chain
     if let Some(ref prev_id_str) = modified_request.previous_response_id {
-        let prev_id = ResponseId::from(prev_id_str.as_str());
-        match ctx
-            .response_storage
-            .get_response_chain(&prev_id, None)
-            .await
-        {
-            Ok(chain) => {
-                let mut items = Vec::new();
-                for stored in chain.responses.iter() {
-                    // Convert input items from stored input (which is now a JSON array)
-                    if let Some(input_arr) = stored.input.as_array() {
-                        for item in input_arr {
-                            match serde_json::from_value::<ResponseInputOutputItem>(item.clone()) {
-                                Ok(input_item) => {
-                                    items.push(input_item);
-                                }
-                                Err(e) => {
-                                    warn!(
-                                        "Failed to deserialize stored input item: {}. Item: {}",
-                                        e, item
-                                    );
-                                }
-                            }
-                        }
+        if let Some(cached_response) = cached_response.filter(|cached| {
+            cached.response.id == *prev_id_str
+                && cached.response.status != responses::ResponseStatus::Failed
+        }) {
+            conversation_items = Some(cached_response.to_conversation_items());
+            modified_request.previous_response_id = None;
+        } else {
+            let prev_id = ResponseId::from(prev_id_str.as_str());
+            match ctx
+                .response_storage
+                .get_response_chain(&prev_id, None)
+                .await
+            {
+                Ok(chain) => {
+                    if chain.responses.is_empty() {
+                        return Err(missing_previous_response_response(
+                            prev_id_str,
+                            strict_missing_previous,
+                        ));
                     }
 
-                    // Convert output items from stored output (which is now a JSON array)
-                    if let Some(output_arr) = stored.output.as_array() {
-                        for item in output_arr {
-                            match serde_json::from_value::<ResponseInputOutputItem>(item.clone()) {
-                                Ok(output_item) => {
-                                    items.push(output_item);
+                    let mut items = Vec::new();
+                    for stored in chain.responses.iter() {
+                        // Convert input items from stored input (which is now a JSON array)
+                        if let Some(input_arr) = stored.input.as_array() {
+                            for item in input_arr {
+                                match serde_json::from_value::<ResponseInputOutputItem>(
+                                    item.clone(),
+                                ) {
+                                    Ok(input_item) => {
+                                        items.push(input_item);
+                                    }
+                                    Err(e) => {
+                                        warn!(
+                                            "Failed to deserialize stored input item: {}. Item: {}",
+                                            e, item
+                                        );
+                                    }
                                 }
-                                Err(e) => {
-                                    warn!(
-                                        "Failed to deserialize stored output item: {}. Item: {}",
-                                        e, item
-                                    );
+                            }
+                        }
+
+                        // Convert output items from stored output (which is now a JSON array)
+                        if let Some(output_arr) = stored.output.as_array() {
+                            for item in output_arr {
+                                match serde_json::from_value::<ResponseInputOutputItem>(
+                                    item.clone(),
+                                ) {
+                                    Ok(output_item) => {
+                                        items.push(output_item);
+                                    }
+                                    Err(e) => {
+                                        warn!(
+                                            "Failed to deserialize stored output item: {}. Item: {}",
+                                            e, item
+                                        );
+                                    }
                                 }
                             }
                         }
                     }
+                    conversation_items = Some(items);
+                    modified_request.previous_response_id = None;
                 }
-                conversation_items = Some(items);
-                modified_request.previous_response_id = None;
-            }
-            Err(e) => {
-                warn!(
-                    "Failed to load previous response chain for {}: {}",
-                    prev_id_str, e
-                );
+                Err(e) => {
+                    return Err(error::internal_error(
+                        "load_previous_response_chain_failed",
+                        format!(
+                            "Failed to load previous response chain for '{}': {}",
+                            prev_id_str, e
+                        ),
+                    ));
+                }
             }
         }
     }
@@ -412,6 +443,39 @@ pub(super) async fn load_conversation_history(
     );
 
     Ok(modified_request)
+}
+
+fn missing_previous_response_response(
+    previous_response_id: &str,
+    strict_missing_previous: bool,
+) -> Response {
+    let message = if strict_missing_previous {
+        format!(
+            "Previous response '{}' was not found in the current session or durable storage.",
+            previous_response_id
+        )
+    } else {
+        format!("Previous response '{}' not found.", previous_response_id)
+    };
+
+    error::not_found("previous_response_not_found", message)
+}
+
+pub(crate) fn normalize_request_input_items(
+    request: &ResponsesRequest,
+) -> Vec<ResponseInputOutputItem> {
+    match &request.input {
+        ResponseInput::Text(text) => vec![ResponseInputOutputItem::Message {
+            id: format!(
+                "msg_u_{}",
+                request.previous_response_id.as_deref().unwrap_or("new")
+            ),
+            role: "user".to_string(),
+            content: vec![ResponseContentPart::InputText { text: text.clone() }],
+            status: Some("completed".to_string()),
+        }],
+        ResponseInput::Items(items) => items.iter().map(responses::normalize_input_item).collect(),
+    }
 }
 
 /// Build next request with updated conversation history

--- a/sgl-model-gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -85,7 +85,7 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
                         messages.push(role_to_chat_message(role.as_str(), text));
                     }
                     ResponseInputOutputItem::FunctionToolCall {
-                        id,
+                        call_id,
                         name,
                         arguments,
                         output,
@@ -99,7 +99,7 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
                             content: None,
                             name: None,
                             tool_calls: Some(vec![ToolCall {
-                                id: id.clone(),
+                                id: call_id.clone(),
                                 tool_type: "function".to_string(),
                                 function: FunctionCallResponse {
                                     name: name.clone(),
@@ -113,7 +113,7 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
                         if let Some(output_text) = output {
                             messages.push(ChatMessage::Tool {
                                 content: MessageContent::Text(output_text.clone()),
-                                tool_call_id: id.clone(),
+                                tool_call_id: call_id.clone(),
                             });
                         }
                     }
@@ -366,7 +366,13 @@ pub(crate) fn chat_to_responses(
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+
     use super::*;
+    use crate::protocols::{
+        common::{Function, ToolChoice, ToolChoiceValue},
+        responses::{ResponseTool, ResponseToolType},
+    };
 
     #[test]
     fn test_text_input_conversion() {
@@ -424,5 +430,162 @@ mod tests {
         // Empty text should still create a user message, so this should succeed
         let result = responses_to_chat(&req);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_function_tools_serialize_like_chat_completions_tools() {
+        let req = ResponsesRequest {
+            input: ResponseInput::Text("What is the weather in Berlin?".to_string()),
+            model: "Qwen/Qwen2.5-3B-Instruct".to_string(),
+            max_output_tokens: Some(128),
+            parallel_tool_calls: Some(true),
+            tool_choice: Some(ToolChoice::Value(ToolChoiceValue::Required)),
+            tools: Some(vec![ResponseTool {
+                r#type: ResponseToolType::Function,
+                function: Some(Function {
+                    name: "get_weather".to_string(),
+                    description: Some("Get the weather for a city.".to_string()),
+                    parameters: json!({
+                        "type": "object",
+                        "properties": {
+                            "location": { "type": "string" }
+                        },
+                        "required": ["location"]
+                    }),
+                    strict: None,
+                }),
+                server_url: None,
+                authorization: None,
+                server_label: None,
+                server_description: None,
+                require_approval: None,
+                allowed_tools: None,
+            }]),
+            ..Default::default()
+        };
+
+        let chat_req = responses_to_chat(&req).unwrap();
+        let serialized = serde_json::to_value(&chat_req).unwrap();
+
+        assert_eq!(serialized["tool_choice"], "required");
+        assert_eq!(serialized["parallel_tool_calls"], true);
+        assert_eq!(serialized["tools"][0]["type"], "function");
+        assert_eq!(serialized["tools"][0]["function"]["name"], "get_weather");
+        assert_eq!(
+            serialized["tools"][0]["function"]["parameters"]["required"][0],
+            "location"
+        );
+    }
+
+    #[test]
+    fn test_streaming_request_shape_matches_manual_chat_request() {
+        let req = ResponsesRequest {
+            input: ResponseInput::Text("Calculate 42 * 17. Use the tool.".to_string()),
+            model: "Qwen/Qwen2.5-3B-Instruct".to_string(),
+            max_output_tokens: Some(128),
+            parallel_tool_calls: Some(true),
+            stream: Some(true),
+            temperature: Some(0.0),
+            tool_choice: Some(ToolChoice::Value(ToolChoiceValue::Required)),
+            tools: Some(vec![ResponseTool {
+                r#type: ResponseToolType::Function,
+                function: Some(Function {
+                    name: "calculate".to_string(),
+                    description: Some("Perform a mathematical calculation.".to_string()),
+                    parameters: json!({
+                        "type": "object",
+                        "properties": {
+                            "expression": { "type": "string" }
+                        },
+                        "required": ["expression"]
+                    }),
+                    strict: None,
+                }),
+                server_url: None,
+                authorization: None,
+                server_label: None,
+                server_description: None,
+                require_approval: None,
+                allowed_tools: None,
+            }]),
+            ..Default::default()
+        };
+
+        let converted = responses_to_chat(&req).unwrap();
+        let manual = ChatCompletionRequest {
+            messages: vec![ChatMessage::User {
+                content: MessageContent::Text("Calculate 42 * 17. Use the tool.".to_string()),
+                name: None,
+            }],
+            model: "Qwen/Qwen2.5-3B-Instruct".to_string(),
+            max_completion_tokens: Some(128),
+            parallel_tool_calls: Some(true),
+            stream: true,
+            stream_options: Some(StreamOptions {
+                include_usage: Some(true),
+            }),
+            temperature: Some(0.0),
+            tool_choice: Some(ToolChoice::Value(ToolChoiceValue::Required)),
+            tools: Some(vec![crate::protocols::common::Tool {
+                tool_type: "function".to_string(),
+                function: Function {
+                    name: "calculate".to_string(),
+                    description: Some("Perform a mathematical calculation.".to_string()),
+                    parameters: json!({
+                        "type": "object",
+                        "properties": {
+                            "expression": { "type": "string" }
+                        },
+                        "required": ["expression"]
+                    }),
+                    strict: None,
+                },
+            }]),
+            skip_special_tokens: true,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            serde_json::to_value(&converted).unwrap(),
+            serde_json::to_value(&manual).unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_historical_function_tool_call_uses_call_id_for_chat_resume() {
+        let req = ResponsesRequest {
+            input: ResponseInput::Items(vec![ResponseInputOutputItem::FunctionToolCall {
+                id: "fc_item_123".to_string(),
+                call_id: "call_abc".to_string(),
+                name: "calculate".to_string(),
+                arguments: r#"{"expression":"2+2"}"#.to_string(),
+                output: Some(r#"{"result":4}"#.to_string()),
+                status: Some("completed".to_string()),
+            }]),
+            model: "mock-model".to_string(),
+            ..Default::default()
+        };
+
+        let converted = responses_to_chat(&req).unwrap();
+        assert_eq!(converted.messages.len(), 2);
+
+        match &converted.messages[0] {
+            ChatMessage::Assistant {
+                tool_calls: Some(tool_calls),
+                ..
+            } => {
+                assert_eq!(tool_calls.len(), 1);
+                assert_eq!(tool_calls[0].id, "call_abc");
+                assert_eq!(tool_calls[0].function.name, "calculate");
+            }
+            other => panic!("expected assistant tool call message, got {:?}", other),
+        }
+
+        match &converted.messages[1] {
+            ChatMessage::Tool { tool_call_id, .. } => {
+                assert_eq!(tool_call_id, "call_abc");
+            }
+            other => panic!("expected tool response message, got {:?}", other),
+        }
     }
 }

--- a/sgl-model-gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -54,36 +54,38 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
             });
         }
         ResponseInput::Items(items) => {
-            // Structured items → convert each to appropriate chat message
+            // Structured items → convert each to appropriate chat message.
+            // Consecutive FunctionToolCall items are grouped into a single
+            // assistant message with multiple tool_calls so that backends
+            // that require parallel tool calls in one message work correctly.
+            let mut pending_tool_calls: Vec<ToolCall> = Vec::new();
+            let mut pending_tool_outputs: Vec<(String, String)> = Vec::new();
+
+            /// Flush accumulated parallel tool calls into `messages`.
+            fn flush_tool_calls(
+                messages: &mut Vec<ChatMessage>,
+                pending_tool_calls: &mut Vec<ToolCall>,
+                pending_tool_outputs: &mut Vec<(String, String)>,
+            ) {
+                if pending_tool_calls.is_empty() {
+                    return;
+                }
+                messages.push(ChatMessage::Assistant {
+                    content: None,
+                    name: None,
+                    tool_calls: Some(std::mem::take(pending_tool_calls)),
+                    reasoning_content: None,
+                });
+                for (call_id, output_text) in pending_tool_outputs.drain(..) {
+                    messages.push(ChatMessage::Tool {
+                        content: MessageContent::Text(output_text),
+                        tool_call_id: call_id,
+                    });
+                }
+            }
+
             for item in items {
                 match item {
-                    ResponseInputOutputItem::SimpleInputMessage { content, role, .. } => {
-                        // Convert SimpleInputMessage to chat message
-                        let text = match content {
-                            StringOrContentParts::String(s) => s.clone(),
-                            StringOrContentParts::Array(parts) => {
-                                // Extract text from content parts (only InputText supported)
-                                parts
-                                    .iter()
-                                    .filter_map(|part| match part {
-                                        ResponseContentPart::InputText { text } => {
-                                            Some(text.as_str())
-                                        }
-                                        _ => None,
-                                    })
-                                    .collect::<Vec<_>>()
-                                    .join(" ")
-                            }
-                        };
-
-                        messages.push(role_to_chat_message(role.as_str(), text));
-                    }
-                    ResponseInputOutputItem::Message { role, content, .. } => {
-                        // Extract text from content parts
-                        let text = extract_text_from_content(content);
-
-                        messages.push(role_to_chat_message(role.as_str(), text));
-                    }
                     ResponseInputOutputItem::FunctionToolCall {
                         call_id,
                         name,
@@ -91,62 +93,89 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
                         output,
                         ..
                     } => {
-                        // Tool call from history - add as assistant message with tool call
-                        // followed by tool response if output exists
-
-                        // Add assistant message with tool_calls (the LLM's decision)
-                        messages.push(ChatMessage::Assistant {
-                            content: None,
-                            name: None,
-                            tool_calls: Some(vec![ToolCall {
-                                id: call_id.clone(),
-                                tool_type: "function".to_string(),
-                                function: FunctionCallResponse {
-                                    name: name.clone(),
-                                    arguments: Some(arguments.clone()),
-                                },
-                            }]),
-                            reasoning_content: None,
+                        // Accumulate — will be flushed when a non-tool-call
+                        // item is encountered or at the end.
+                        pending_tool_calls.push(ToolCall {
+                            id: call_id.clone(),
+                            tool_type: "function".to_string(),
+                            function: FunctionCallResponse {
+                                name: name.clone(),
+                                arguments: Some(arguments.clone()),
+                            },
                         });
-
-                        // Add tool result message if output exists
                         if let Some(output_text) = output {
-                            messages.push(ChatMessage::Tool {
-                                content: MessageContent::Text(output_text.clone()),
-                                tool_call_id: call_id.clone(),
-                            });
+                            pending_tool_outputs.push((call_id.clone(), output_text.clone()));
                         }
                     }
-                    ResponseInputOutputItem::Reasoning { content, .. } => {
-                        // Reasoning content - add as assistant message with reasoning_content
-                        let reasoning_text = content
-                            .iter()
-                            .map(|c| match c {
-                                ReasoningText { text } => text.as_str(),
-                            })
-                            .collect::<Vec<_>>()
-                            .join("\n");
+                    other => {
+                        // Flush any pending parallel tool calls before
+                        // processing a non-tool-call item.
+                        flush_tool_calls(
+                            &mut messages,
+                            &mut pending_tool_calls,
+                            &mut pending_tool_outputs,
+                        );
 
-                        messages.push(ChatMessage::Assistant {
-                            content: None,
-                            name: None,
-                            tool_calls: None,
-                            reasoning_content: Some(reasoning_text),
-                        });
-                    }
-                    ResponseInputOutputItem::FunctionCallOutput {
-                        call_id, output, ..
-                    } => {
-                        // Function call output - add as tool message
-                        // Note: The function name is looked up from prev_outputs in Harmony path
-                        // For Chat path, we just use the call_id
-                        messages.push(ChatMessage::Tool {
-                            content: MessageContent::Text(output.clone()),
-                            tool_call_id: call_id.clone(),
-                        });
+                        match other {
+                            ResponseInputOutputItem::SimpleInputMessage {
+                                content, role, ..
+                            } => {
+                                let text = match content {
+                                    StringOrContentParts::String(s) => s.clone(),
+                                    StringOrContentParts::Array(parts) => parts
+                                        .iter()
+                                        .filter_map(|part| match part {
+                                            ResponseContentPart::InputText { text } => {
+                                                Some(text.as_str())
+                                            }
+                                            _ => None,
+                                        })
+                                        .collect::<Vec<_>>()
+                                        .join(" "),
+                                };
+                                messages.push(role_to_chat_message(role.as_str(), text));
+                            }
+                            ResponseInputOutputItem::Message { role, content, .. } => {
+                                let text = extract_text_from_content(content);
+                                messages.push(role_to_chat_message(role.as_str(), text));
+                            }
+                            ResponseInputOutputItem::Reasoning { content, .. } => {
+                                let reasoning_text = content
+                                    .iter()
+                                    .map(|c| match c {
+                                        ReasoningText { text } => text.as_str(),
+                                    })
+                                    .collect::<Vec<_>>()
+                                    .join("\n");
+
+                                messages.push(ChatMessage::Assistant {
+                                    content: None,
+                                    name: None,
+                                    tool_calls: None,
+                                    reasoning_content: Some(reasoning_text),
+                                });
+                            }
+                            ResponseInputOutputItem::FunctionCallOutput {
+                                call_id, output, ..
+                            } => {
+                                messages.push(ChatMessage::Tool {
+                                    content: MessageContent::Text(output.clone()),
+                                    tool_call_id: call_id.clone(),
+                                });
+                            }
+                            // FunctionToolCall is handled in the outer match arm
+                            ResponseInputOutputItem::FunctionToolCall { .. } => unreachable!(),
+                        }
                     }
                 }
             }
+
+            // Flush any remaining tool calls at end of items
+            flush_tool_calls(
+                &mut messages,
+                &mut pending_tool_calls,
+                &mut pending_tool_outputs,
+            );
         }
     }
 
@@ -227,8 +256,11 @@ fn role_to_chat_message(role: &str, text: String) -> ChatMessage {
             content: MessageContent::Text(text),
             name: None,
         },
-        _ => {
-            // Unknown role, treat as user message
+        other => {
+            tracing::warn!(
+                role = other,
+                "unknown message role in responses input, treating as user"
+            );
             ChatMessage::User {
                 content: MessageContent::Text(text),
                 name: None,

--- a/sgl-model-gateway/src/routers/grpc/regular/responses/mod.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/responses/mod.rs
@@ -15,6 +15,9 @@ mod conversions;
 mod handlers;
 mod non_streaming;
 mod streaming;
+mod websocket;
 
 // Public exports
+pub(crate) use common::normalize_request_input_items;
 pub(crate) use handlers::route_responses;
+pub(crate) use websocket::GrpcWsResponsesExecutor;

--- a/sgl-model-gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -6,13 +6,14 @@
 //! - Streaming accumulators for response building
 
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     sync::Arc,
     time::{Instant, SystemTime, UNIX_EPOCH},
 };
 
 use axum::{
     body::Body,
+    extract::ws::Message,
     http::{self, header, StatusCode},
     response::Response,
 };
@@ -48,7 +49,10 @@ use crate::{
     routers::{
         grpc::common::responses::{
             build_sse_response, persist_response_if_needed,
-            streaming::{OutputItemType, ResponseStreamEventEmitter},
+            streaming::{
+                OutputItemType, ResponseEventSink, ResponseStreamEventEmitter,
+                SseResponseEventSink, WsResponseEventSink,
+            },
             ResponsesContext,
         },
         mcp_utils::{extract_server_label, DEFAULT_MAX_ITERATIONS},
@@ -76,37 +80,23 @@ pub(super) async fn convert_chat_stream_to_responses_stream(
 ) -> Response {
     debug!("Converting chat SSE stream to responses SSE format");
 
-    // Get chat streaming response
-    let chat_response = ctx
-        .pipeline
-        .execute_chat(
-            chat_request.clone(),
-            headers,
-            model_id,
-            ctx.components.clone(),
-        )
-        .await;
-
-    // Extract body from chat response
-    let (_parts, body) = chat_response.into_parts();
-
     // Create channel for transformed SSE events
     let (tx, rx) = mpsc::unbounded_channel::<Result<Bytes, std::io::Error>>();
+    let sink = SseResponseEventSink::new(tx.clone());
 
     // Spawn background task to transform stream
     let original_request_clone = original_request.clone();
-    let response_storage = ctx.response_storage.clone();
-    let conversation_storage = ctx.conversation_storage.clone();
-    let conversation_item_storage = ctx.conversation_item_storage.clone();
+    let ctx_clone = ctx.clone();
+    let chat_request_clone = chat_request.clone();
 
     tokio::spawn(async move {
-        if let Err(e) = process_and_transform_sse_stream(
-            body,
+        if let Err(e) = execute_non_mcp_stream_with_sink(
+            &ctx_clone,
+            chat_request_clone,
             original_request_clone,
-            response_storage,
-            conversation_storage,
-            conversation_item_storage,
-            tx.clone(),
+            headers,
+            model_id,
+            &sink,
         )
         .await
         {
@@ -117,85 +107,130 @@ pub(super) async fn convert_chat_stream_to_responses_stream(
                     "type": "stream_error"
                 }
             });
-            let _ = tx.send(Ok(Bytes::from(format!("data: {}\n\n", error_event))));
+            let _ = sink.send_raw_json(&error_event.to_string());
         }
 
-        // Send final [DONE] event
-        let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n")));
+        let _ = sink.send_done();
     });
 
     // Build SSE response with transformed stream
     build_sse_response(rx)
 }
 
-/// Process chat SSE stream and transform to responses format
-async fn process_and_transform_sse_stream(
+pub(super) async fn execute_non_mcp_stream_with_sink(
+    ctx: &ResponsesContext,
+    chat_request: Arc<ChatCompletionRequest>,
+    original_request: ResponsesRequest,
+    headers: Option<http::HeaderMap>,
+    model_id: Option<String>,
+    sink: &impl ResponseEventSink,
+) -> Result<ResponsesResponse, String> {
+    let chat_response = ctx
+        .pipeline
+        .execute_chat(chat_request, headers, model_id, ctx.components.clone())
+        .await;
+    let (_parts, body) = chat_response.into_parts();
+
+    process_and_transform_stream(
+        body,
+        original_request,
+        ctx.response_storage.clone(),
+        ctx.conversation_storage.clone(),
+        ctx.conversation_item_storage.clone(),
+        sink,
+    )
+    .await
+}
+
+/// Process chat SSE stream and transform to responses format.
+async fn process_and_transform_stream(
     body: Body,
     original_request: ResponsesRequest,
     response_storage: Arc<dyn ResponseStorage>,
     conversation_storage: Arc<dyn ConversationStorage>,
     conversation_item_storage: Arc<dyn ConversationItemStorage>,
-    tx: mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
-) -> Result<(), String> {
-    // Create accumulator for final response
-    let mut accumulator = StreamingResponseAccumulator::new(&original_request);
-
-    // Create event emitter for OpenAI-compatible streaming
+    sink: &impl ResponseEventSink,
+) -> Result<ResponsesResponse, String> {
     let response_id = format!("resp_{}", Uuid::new_v4());
     let model = original_request.model.clone();
     let created_at = chrono::Utc::now().timestamp() as u64;
+
+    // Create accumulator for the persisted/final response. Seed it with the
+    // same response metadata the WS/SSE event emitter exposes so storage,
+    // cache, and retrieval all agree on the response id.
+    let mut accumulator = StreamingResponseAccumulator::new(
+        &original_request,
+        response_id.clone(),
+        model.clone(),
+        created_at as i64,
+    );
+
+    // Create event emitter for OpenAI-compatible streaming
     let mut event_emitter = ResponseStreamEventEmitter::new(response_id, model, created_at);
     event_emitter.set_original_request(original_request.clone());
 
     // Emit initial response.created and response.in_progress events
     let event = event_emitter.emit_created();
     event_emitter
-        .send_event(&event, &tx)
+        .send_event(&event, sink)
         .map_err(|_| "Failed to send response.created event".to_string())?;
 
     let event = event_emitter.emit_in_progress();
     event_emitter
-        .send_event(&event, &tx)
+        .send_event(&event, sink)
         .map_err(|_| "Failed to send response.in_progress event".to_string())?;
 
     // Convert body to data stream
     let mut stream = body.into_data_stream();
+    let mut upstream_error_forwarded = false;
+    let mut function_call_events = BTreeMap::new();
+    let mut pending_sse = String::new();
 
-    // Process stream chunks (each chunk is a complete SSE event)
-    while let Some(chunk_result) = stream.next().await {
+    // Process stream chunks, handling SSE records even when multiple events are
+    // coalesced into one body chunk or split across chunk boundaries.
+    'stream: while let Some(chunk_result) = stream.next().await {
         let chunk = chunk_result.map_err(|e| format!("Stream read error: {}", e))?;
+        let chunk_str = String::from_utf8_lossy(&chunk).replace("\r\n", "\n");
+        pending_sse.push_str(&chunk_str);
 
-        // Convert chunk to string
-        let event_str = String::from_utf8_lossy(&chunk);
-        let event = event_str.trim();
+        while let Some(record_end) = pending_sse.find("\n\n") {
+            let record = pending_sse[..record_end].to_string();
+            pending_sse = pending_sse[record_end + 2..].to_string();
 
-        // Check for end of stream
-        if event == "data: [DONE]" {
-            break;
-        }
-
-        // Parse SSE event (format: "data: {...}\n\n" or "data: {...}")
-        if let Some(json_str) = event.strip_prefix("data: ") {
-            let json_str = json_str.trim();
-
-            // Try to parse as ChatCompletionStreamResponse
-            match serde_json::from_str::<ChatCompletionStreamResponse>(json_str) {
-                Ok(chat_chunk) => {
-                    // Update accumulator
-                    accumulator.process_chunk(&chat_chunk);
-
-                    // Process chunk through event emitter (emits proper OpenAI events)
-                    event_emitter.process_chunk(&chat_chunk, &tx)?;
-                }
-                Err(_) => {
-                    // Not a valid chat chunk - might be error event, pass through
-                    debug!("Non-chunk SSE event, passing through: {}", event);
-                    if tx.send(Ok(Bytes::from(format!("{}\n\n", event)))).is_err() {
-                        return Err("Client disconnected".to_string());
-                    }
+            match process_non_mcp_sse_record(
+                &record,
+                &mut accumulator,
+                &mut event_emitter,
+                sink,
+                &mut function_call_events,
+            )? {
+                SseRecordOutcome::Continue => {}
+                SseRecordOutcome::StopStream => break 'stream,
+                SseRecordOutcome::UpstreamError => {
+                    upstream_error_forwarded = true;
+                    break 'stream;
                 }
             }
         }
+    }
+
+    if !upstream_error_forwarded && !pending_sse.trim().is_empty() {
+        if let SseRecordOutcome::UpstreamError = process_non_mcp_sse_record(
+            &pending_sse,
+            &mut accumulator,
+            &mut event_emitter,
+            sink,
+            &mut function_call_events,
+        )? {
+            upstream_error_forwarded = true;
+        }
+    }
+
+    if upstream_error_forwarded {
+        debug!(
+            "Upstream error payload was already forwarded; skipping synthetic response.completed"
+        );
+        return Ok(accumulator.finalize_with_status(ResponseStatus::Failed));
     }
 
     // Emit final response.completed event with accumulated usage
@@ -217,8 +252,10 @@ async fn process_and_transform_sse_stream(
         usage_obj
     });
 
-    let completed_event = event_emitter.emit_completed(usage_json.as_ref());
-    event_emitter.send_event(&completed_event, &tx)?;
+    let terminal_status = accumulator.response_status();
+    let completed_event =
+        event_emitter.emit_completed_with_status(terminal_status, usage_json.as_ref());
+    event_emitter.send_event(&completed_event, sink)?;
 
     // Finalize and persist accumulated response
     let final_response = accumulator.finalize();
@@ -230,6 +267,178 @@ async fn process_and_transform_sse_stream(
         &original_request,
     )
     .await;
+
+    Ok(final_response)
+}
+
+enum SseRecordOutcome {
+    Continue,
+    StopStream,
+    UpstreamError,
+}
+
+fn process_non_mcp_sse_record(
+    event: &str,
+    accumulator: &mut StreamingResponseAccumulator,
+    event_emitter: &mut ResponseStreamEventEmitter,
+    sink: &impl ResponseEventSink,
+    function_call_events: &mut BTreeMap<usize, FunctionCallEventState>,
+) -> Result<SseRecordOutcome, String> {
+    let event = event.trim();
+    if event.is_empty() {
+        return Ok(SseRecordOutcome::Continue);
+    }
+
+    if event == "data: [DONE]" {
+        return Ok(SseRecordOutcome::StopStream);
+    }
+
+    let Some(json_str) = event.strip_prefix("data: ") else {
+        return Ok(SseRecordOutcome::Continue);
+    };
+    let json_str = json_str.trim();
+
+    match serde_json::from_str::<ChatCompletionStreamResponse>(json_str) {
+        Ok(chat_chunk) => {
+            accumulator.process_chunk(&chat_chunk);
+
+            let has_tool_call_delta = chat_chunk
+                .choices
+                .first()
+                .and_then(|choice| choice.delta.tool_calls.as_ref())
+                .is_some_and(|tool_calls| !tool_calls.is_empty());
+            if has_tool_call_delta || !function_call_events.is_empty() {
+                process_non_mcp_function_call_chunk(
+                    &chat_chunk,
+                    event_emitter,
+                    sink,
+                    function_call_events,
+                )?;
+            } else {
+                event_emitter.process_chunk(&chat_chunk, sink)?;
+            }
+
+            Ok(SseRecordOutcome::Continue)
+        }
+        Err(_) => {
+            debug!("Non-chunk SSE event, passing through: {}", event);
+            sink.send_raw_json(json_str)?;
+
+            if is_upstream_error_payload(json_str) {
+                Ok(SseRecordOutcome::UpstreamError)
+            } else {
+                Ok(SseRecordOutcome::Continue)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct FunctionCallEventState {
+    output_index: usize,
+    item_id: String,
+    call_id: String,
+    name: String,
+    arguments: String,
+    completed: bool,
+}
+
+fn process_non_mcp_function_call_chunk(
+    chunk: &ChatCompletionStreamResponse,
+    emitter: &mut ResponseStreamEventEmitter,
+    sink: &impl ResponseEventSink,
+    function_call_events: &mut BTreeMap<usize, FunctionCallEventState>,
+) -> Result<(), String> {
+    let Some(choice) = chunk.choices.first() else {
+        return Ok(());
+    };
+
+    if let Some(tool_call_deltas) = &choice.delta.tool_calls {
+        for delta in tool_call_deltas {
+            let state = function_call_events
+                .entry(delta.index as usize)
+                .or_insert_with(|| {
+                    let (output_index, item_id) =
+                        emitter.allocate_output_index(OutputItemType::FunctionCall);
+
+                    FunctionCallEventState {
+                        output_index,
+                        item_id,
+                        call_id: String::new(),
+                        name: String::new(),
+                        arguments: String::new(),
+                        completed: false,
+                    }
+                });
+
+            if state.call_id.is_empty() {
+                if let Some(delta_id) = &delta.id {
+                    state.call_id = delta_id.clone();
+                }
+            } else if let Some(delta_id) = &delta.id {
+                state.call_id.push_str(delta_id);
+            }
+
+            if let Some(function) = &delta.function {
+                if let Some(delta_name) = &function.name {
+                    state.name.push_str(delta_name);
+                }
+
+                if let Some(delta_args) = &function.arguments {
+                    if !delta_args.is_empty() {
+                        if state.arguments.is_empty() {
+                            let item = json!({
+                                "id": state.item_id,
+                                "type": "function_call",
+                                "call_id": state.call_id,
+                                "name": state.name,
+                                "status": "in_progress",
+                                "arguments": ""
+                            });
+                            let event = emitter.emit_output_item_added(state.output_index, &item);
+                            emitter.send_event(&event, sink)?;
+                        }
+
+                        state.arguments.push_str(delta_args);
+                        let event = emitter.emit_function_call_arguments_delta(
+                            state.output_index,
+                            &state.item_id,
+                            delta_args,
+                        );
+                        emitter.send_event(&event, sink)?;
+                    }
+                }
+            }
+        }
+    }
+
+    if choice.finish_reason.as_deref() == Some("tool_calls") {
+        for state in function_call_events.values_mut() {
+            if state.completed {
+                continue;
+            }
+
+            let event = emitter.emit_function_call_arguments_done(
+                state.output_index,
+                &state.item_id,
+                &state.arguments,
+            );
+            emitter.send_event(&event, sink)?;
+
+            let item = json!({
+                "id": state.item_id,
+                "type": "function_call",
+                "call_id": state.call_id,
+                "name": state.name,
+                "status": "completed",
+                "arguments": state.arguments
+            });
+            let event = emitter.emit_output_item_done(state.output_index, &item);
+            emitter.send_event(&event, sink)?;
+            emitter.complete_output_item(state.output_index);
+            state.completed = true;
+        }
+    }
 
     Ok(())
 }
@@ -255,11 +464,16 @@ struct StreamingResponseAccumulator {
 }
 
 impl StreamingResponseAccumulator {
-    fn new(original_request: &ResponsesRequest) -> Self {
+    fn new(
+        original_request: &ResponsesRequest,
+        response_id: String,
+        model: String,
+        created_at: i64,
+    ) -> Self {
         Self {
-            response_id: String::new(),
-            model: String::new(),
-            created_at: 0,
+            response_id,
+            model,
+            created_at,
             content_buffer: String::new(),
             reasoning_buffer: String::new(),
             tool_calls: Vec::new(),
@@ -281,7 +495,9 @@ impl StreamingResponseAccumulator {
         if let Some(choice) = chunk.choices.first() {
             // Accumulate content
             if let Some(content) = &choice.delta.content {
-                self.content_buffer.push_str(content);
+                if self.tool_calls.is_empty() {
+                    self.content_buffer.push_str(content);
+                }
             }
 
             // Accumulate reasoning
@@ -310,6 +526,7 @@ impl StreamingResponseAccumulator {
                     // Update the tool call at this index
                     if let ResponseOutputItem::FunctionToolCall {
                         id,
+                        call_id,
                         name,
                         arguments,
                         ..
@@ -317,6 +534,7 @@ impl StreamingResponseAccumulator {
                     {
                         if let Some(delta_id) = &delta.id {
                             id.push_str(delta_id);
+                            call_id.push_str(delta_id);
                         }
                         if let Some(function) = &delta.function {
                             if let Some(delta_name) = &function.name {
@@ -342,7 +560,21 @@ impl StreamingResponseAccumulator {
         }
     }
 
+    fn response_status(&self) -> ResponseStatus {
+        match self.finish_reason.as_deref() {
+            Some("stop") | Some("length") => ResponseStatus::Completed,
+            Some("tool_calls") => ResponseStatus::InProgress,
+            Some("failed") | Some("error") => ResponseStatus::Failed,
+            _ => ResponseStatus::Completed,
+        }
+    }
+
     fn finalize(self) -> ResponsesResponse {
+        let status = self.response_status();
+        self.finalize_with_status(status)
+    }
+
+    fn finalize_with_status(self, status: ResponseStatus) -> ResponsesResponse {
         let mut output: Vec<ResponseOutputItem> = Vec::new();
 
         // Add message content if present
@@ -374,14 +606,6 @@ impl StreamingResponseAccumulator {
         // Add tool calls
         output.extend(self.tool_calls);
 
-        // Determine final status
-        let status = match self.finish_reason.as_deref() {
-            Some("stop") | Some("length") => ResponseStatus::Completed,
-            Some("tool_calls") => ResponseStatus::InProgress,
-            Some("failed") | Some("error") => ResponseStatus::Failed,
-            _ => ResponseStatus::Completed,
-        };
-
         // Convert usage
         let usage = self.usage.as_ref().map(|u| {
             let usage_info = UsageInfo {
@@ -407,6 +631,13 @@ impl StreamingResponseAccumulator {
     }
 }
 
+fn is_upstream_error_payload(payload: &str) -> bool {
+    serde_json::from_str::<Value>(payload)
+        .ok()
+        .and_then(|value| value.get("error").cloned())
+        .is_some()
+}
+
 // ============================================================================
 // MCP Streaming Path
 // ============================================================================
@@ -425,6 +656,7 @@ pub(super) async fn execute_tool_loop_streaming(
 ) -> Response {
     // Create SSE channel for client
     let (tx, rx) = mpsc::unbounded_channel::<Result<Bytes, std::io::Error>>();
+    let sink = SseResponseEventSink::new(tx.clone());
 
     // Clone data for background task
     let ctx_clone = ctx.clone();
@@ -438,7 +670,7 @@ pub(super) async fn execute_tool_loop_streaming(
             &original_request_clone,
             headers,
             model_id,
-            tx.clone(),
+            &sink,
         )
         .await;
 
@@ -450,11 +682,10 @@ pub(super) async fn execute_tool_loop_streaming(
                     "type": "tool_loop_error"
                 }
             });
-            let _ = tx.send(Ok(Bytes::from(format!("data: {}\n\n", error_event))));
+            let _ = sink.send_raw_json(&error_event.to_string());
         }
 
-        // Send [DONE]
-        let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n")));
+        let _ = sink.send_done();
     });
 
     // Build SSE response
@@ -482,6 +713,26 @@ pub(super) async fn execute_tool_loop_streaming(
     response
 }
 
+pub(super) async fn execute_tool_loop_streaming_with_sink(
+    ctx: &ResponsesContext,
+    current_request: ResponsesRequest,
+    original_request: &ResponsesRequest,
+    headers: Option<http::HeaderMap>,
+    model_id: Option<String>,
+    outbound_tx: mpsc::UnboundedSender<Message>,
+) -> Result<ResponsesResponse, String> {
+    let sink = WsResponseEventSink::new(outbound_tx);
+    execute_tool_loop_streaming_internal(
+        ctx,
+        current_request,
+        original_request,
+        headers,
+        model_id,
+        &sink,
+    )
+    .await
+}
+
 /// Internal streaming tool loop implementation
 async fn execute_tool_loop_streaming_internal(
     ctx: &ResponsesContext,
@@ -489,8 +740,8 @@ async fn execute_tool_loop_streaming_internal(
     original_request: &ResponsesRequest,
     headers: Option<http::HeaderMap>,
     model_id: Option<String>,
-    tx: mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
-) -> Result<(), String> {
+    sink: &impl ResponseEventSink,
+) -> Result<ResponsesResponse, String> {
     // Extract server label from original request tools
     let server_label = extract_server_label(original_request.tools.as_deref(), "request-mcp");
 
@@ -509,9 +760,9 @@ async fn execute_tool_loop_streaming_internal(
 
     // Emit initial response.created and response.in_progress events
     let event = emitter.emit_created();
-    emitter.send_event(&event, &tx)?;
+    emitter.send_event(&event, sink)?;
     let event = emitter.emit_in_progress();
-    emitter.send_event(&event, &tx)?;
+    emitter.send_event(&event, sink)?;
 
     // Get MCP tools and convert to chat format (do this once before loop)
     let mcp_tools = ctx.mcp_manager.list_tools();
@@ -567,15 +818,15 @@ async fn execute_tool_loop_streaming_internal(
 
             // Emit output_item.added
             let event = emitter.emit_output_item_added(output_index, &item);
-            emitter.send_event(&event, &tx)?;
+            emitter.send_event(&event, sink)?;
 
             // Emit mcp_list_tools.in_progress
             let event = emitter.emit_mcp_list_tools_in_progress(output_index);
-            emitter.send_event(&event, &tx)?;
+            emitter.send_event(&event, sink)?;
 
             // Emit mcp_list_tools.completed
             let event = emitter.emit_mcp_list_tools_completed(output_index, &mcp_tools);
-            emitter.send_event(&event, &tx)?;
+            emitter.send_event(&event, sink)?;
 
             // Build complete item with tools
             let item_done = json!({
@@ -588,7 +839,7 @@ async fn execute_tool_loop_streaming_internal(
 
             // Emit output_item.done
             let event = emitter.emit_output_item_done(output_index, &item_done);
-            emitter.send_event(&event, &tx)?;
+            emitter.send_event(&event, sink)?;
 
             emitter.complete_output_item(output_index);
             mcp_list_tools_emitted = true;
@@ -615,7 +866,7 @@ async fn execute_tool_loop_streaming_internal(
         // Convert chat stream to Responses API events while accumulating for tool call detection
         // Stream text naturally - it only appears on final iteration (tool iterations have empty content)
         let accumulated_response =
-            convert_and_accumulate_stream(response.into_body(), &mut emitter, &tx).await?;
+            convert_and_accumulate_stream(response.into_body(), &mut emitter, sink).await?;
 
         // Check for tool calls (extract all of them for parallel execution)
         let tool_calls = extract_all_tool_calls_from_chat(&accumulated_response);
@@ -656,7 +907,33 @@ async fn execute_tool_loop_streaming_internal(
                     max_tool_calls,
                     DEFAULT_MAX_ITERATIONS
                 );
-                break;
+
+                let mut final_response = emitter.finalize(accumulated_response.usage.clone());
+                final_response.incomplete_details = Some(json!({ "reason": "max_tool_calls" }));
+
+                let usage_json = accumulated_response.usage.as_ref().map(|u| {
+                    json!({
+                        "input_tokens": u.prompt_tokens,
+                        "output_tokens": u.completion_tokens,
+                        "total_tokens": u.total_tokens
+                    })
+                });
+                let mut event = emitter.emit_completed(usage_json.as_ref());
+                if let Some(response) = event.get_mut("response") {
+                    response["incomplete_details"] = json!({ "reason": "max_tool_calls" });
+                }
+                emitter.send_event(&event, sink)?;
+
+                persist_response_if_needed(
+                    ctx.conversation_storage.clone(),
+                    ctx.conversation_item_storage.clone(),
+                    ctx.response_storage.clone(),
+                    &final_response,
+                    original_request,
+                )
+                .await;
+
+                return Ok(final_response);
             }
 
             // Process each MCP tool call
@@ -687,11 +964,11 @@ async fn execute_tool_loop_streaming_internal(
 
                 // Emit output_item.added
                 let event = emitter.emit_output_item_added(output_index, &item);
-                emitter.send_event(&event, &tx)?;
+                emitter.send_event(&event, sink)?;
 
                 // Emit mcp_call.in_progress
                 let event = emitter.emit_mcp_call_in_progress(output_index, &item_id);
-                emitter.send_event(&event, &tx)?;
+                emitter.send_event(&event, sink)?;
 
                 // Emit mcp_call_arguments.delta (simulate streaming by sending full arguments)
                 let event = emitter.emit_mcp_call_arguments_delta(
@@ -699,7 +976,7 @@ async fn execute_tool_loop_streaming_internal(
                     &item_id,
                     &tool_call.arguments,
                 );
-                emitter.send_event(&event, &tx)?;
+                emitter.send_event(&event, sink)?;
 
                 // Emit mcp_call_arguments.done
                 let event = emitter.emit_mcp_call_arguments_done(
@@ -707,7 +984,7 @@ async fn execute_tool_loop_streaming_internal(
                     &item_id,
                     &tool_call.arguments,
                 );
-                emitter.send_event(&event, &tx)?;
+                emitter.send_event(&event, sink)?;
 
                 // Execute the MCP tool - manager handles parsing and type coercion
                 trace!(
@@ -725,7 +1002,7 @@ async fn execute_tool_loop_streaming_internal(
                         Ok(output) => {
                             // Emit mcp_call.completed
                             let event = emitter.emit_mcp_call_completed(output_index, &item_id);
-                            emitter.send_event(&event, &tx)?;
+                            emitter.send_event(&event, sink)?;
 
                             // Build complete item with output
                             let item_done = json!({
@@ -740,7 +1017,7 @@ async fn execute_tool_loop_streaming_internal(
 
                             // Emit output_item.done
                             let event = emitter.emit_output_item_done(output_index, &item_done);
-                            emitter.send_event(&event, &tx)?;
+                            emitter.send_event(&event, sink)?;
 
                             emitter.complete_output_item(output_index);
                             (output, true, None)
@@ -750,7 +1027,7 @@ async fn execute_tool_loop_streaming_internal(
                             warn!("{}", err);
                             // Emit mcp_call.failed
                             let event = emitter.emit_mcp_call_failed(output_index, &item_id, &err);
-                            emitter.send_event(&event, &tx)?;
+                            emitter.send_event(&event, sink)?;
 
                             // Build failed item
                             let item_done = json!({
@@ -765,7 +1042,7 @@ async fn execute_tool_loop_streaming_internal(
 
                             // Emit output_item.done
                             let event = emitter.emit_output_item_done(output_index, &item_done);
-                            emitter.send_event(&event, &tx)?;
+                            emitter.send_event(&event, sink)?;
 
                             emitter.complete_output_item(output_index);
                             let error_json = json!({ "error": &err }).to_string();
@@ -777,7 +1054,7 @@ async fn execute_tool_loop_streaming_internal(
                         warn!("Tool execution failed: {}", err_str);
                         // Emit mcp_call.failed
                         let event = emitter.emit_mcp_call_failed(output_index, &item_id, &err_str);
-                        emitter.send_event(&event, &tx)?;
+                        emitter.send_event(&event, sink)?;
 
                         // Build failed item
                         let item_done = json!({
@@ -792,7 +1069,7 @@ async fn execute_tool_loop_streaming_internal(
 
                         // Emit output_item.done
                         let event = emitter.emit_output_item_done(output_index, &item_done);
-                        emitter.send_event(&event, &tx)?;
+                        emitter.send_event(&event, sink)?;
 
                         emitter.complete_output_item(output_index);
                         let error_json = json!({ "error": &err_str }).to_string();
@@ -849,7 +1126,7 @@ async fn execute_tool_loop_streaming_internal(
 
                     // Emit output_item.added
                     let event = emitter.emit_output_item_added(output_index, &item);
-                    emitter.send_event(&event, &tx)?;
+                    emitter.send_event(&event, sink)?;
 
                     // Emit function_call_arguments.delta
                     let event = emitter.emit_function_call_arguments_delta(
@@ -857,7 +1134,7 @@ async fn execute_tool_loop_streaming_internal(
                         &item_id,
                         &tool_call.arguments,
                     );
-                    emitter.send_event(&event, &tx)?;
+                    emitter.send_event(&event, sink)?;
 
                     // Emit function_call_arguments.done
                     let event = emitter.emit_function_call_arguments_done(
@@ -865,7 +1142,7 @@ async fn execute_tool_loop_streaming_internal(
                         &item_id,
                         &tool_call.arguments,
                     );
-                    emitter.send_event(&event, &tx)?;
+                    emitter.send_event(&event, sink)?;
 
                     // Build complete item
                     let item_complete = json!({
@@ -879,13 +1156,36 @@ async fn execute_tool_loop_streaming_internal(
 
                     // Emit output_item.done
                     let event = emitter.emit_output_item_done(output_index, &item_complete);
-                    emitter.send_event(&event, &tx)?;
+                    emitter.send_event(&event, sink)?;
 
                     emitter.complete_output_item(output_index);
                 }
 
-                // Break loop to return response to caller
-                break;
+                let usage_json = accumulated_response.usage.as_ref().map(|u| {
+                    json!({
+                        "input_tokens": u.prompt_tokens,
+                        "output_tokens": u.completion_tokens,
+                        "total_tokens": u.total_tokens
+                    })
+                });
+                let event = emitter
+                    .emit_completed_with_status(ResponseStatus::InProgress, usage_json.as_ref());
+                emitter.send_event(&event, sink)?;
+
+                let final_response = emitter.finalize_with_status(
+                    accumulated_response.usage.clone(),
+                    ResponseStatus::InProgress,
+                );
+                persist_response_if_needed(
+                    ctx.conversation_storage.clone(),
+                    ctx.conversation_item_storage.clone(),
+                    ctx.response_storage.clone(),
+                    &final_response,
+                    original_request,
+                )
+                .await;
+
+                return Ok(final_response);
             }
 
             // Build next request with conversation history
@@ -906,7 +1206,7 @@ async fn execute_tool_loop_streaming_internal(
         // Emit reasoning item if present
         if let Some(reasoning) = reasoning_content {
             if !reasoning.is_empty() {
-                emitter.emit_reasoning_item(&tx, Some(reasoning))?;
+                emitter.emit_reasoning_item(sink, Some(reasoning))?;
             }
         }
 
@@ -922,19 +1222,27 @@ async fn execute_tool_loop_streaming_internal(
             })
         });
         let event = emitter.emit_completed(usage_json.as_ref());
-        emitter.send_event(&event, &tx)?;
+        emitter.send_event(&event, sink)?;
 
-        break;
+        let final_response = emitter.finalize(accumulated_response.usage.clone());
+        persist_response_if_needed(
+            ctx.conversation_storage.clone(),
+            ctx.conversation_item_storage.clone(),
+            ctx.response_storage.clone(),
+            &final_response,
+            original_request,
+        )
+        .await;
+
+        return Ok(final_response);
     }
-
-    Ok(())
 }
 
 /// Convert chat stream to Responses API events while accumulating for tool call detection
 async fn convert_and_accumulate_stream(
     body: Body,
     emitter: &mut ResponseStreamEventEmitter,
-    tx: &mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
+    sink: &impl ResponseEventSink,
 ) -> Result<ChatCompletionResponse, String> {
     let mut accumulator = ChatResponseAccumulator::new();
     let mut stream = body.into_data_stream();
@@ -954,7 +1262,7 @@ async fn convert_and_accumulate_stream(
             let json_str = json_str.trim();
             if let Ok(chat_chunk) = serde_json::from_str::<ChatCompletionStreamResponse>(json_str) {
                 // Convert chat chunk to Responses API events and emit
-                emitter.process_chunk(&chat_chunk, tx)?;
+                emitter.process_chunk(&chat_chunk, sink)?;
 
                 // Accumulate for tool call detection
                 accumulator.process_chunk(&chat_chunk);
@@ -1080,5 +1388,276 @@ impl ChatResponseAccumulator {
             }])
             .maybe_usage(self.usage)
             .build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use axum::body::Body;
+    use bytes::Bytes;
+    use data_connector::{
+        MemoryConversationItemStorage, MemoryConversationStorage, MemoryResponseStorage,
+        ResponseId, ResponseStorage,
+    };
+    use futures_util::stream;
+    use serde_json::Value;
+
+    use super::*;
+    use crate::protocols::responses::{ResponseInput, ServiceTier, Truncation};
+
+    #[derive(Clone, Default)]
+    struct RecordingSink {
+        events: Arc<Mutex<Vec<Value>>>,
+    }
+
+    impl RecordingSink {
+        fn events(&self) -> Vec<Value> {
+            self.events.lock().unwrap().clone()
+        }
+    }
+
+    impl ResponseEventSink for RecordingSink {
+        fn send_event(&self, event: &Value) -> Result<(), String> {
+            self.events.lock().unwrap().push(event.clone());
+            Ok(())
+        }
+
+        fn send_raw_json(&self, payload: &str) -> Result<(), String> {
+            let value = serde_json::from_str::<Value>(payload)
+                .map_err(|err| format!("failed to parse test payload: {}", err))?;
+            self.events.lock().unwrap().push(value);
+            Ok(())
+        }
+    }
+
+    fn test_responses_request() -> ResponsesRequest {
+        ResponsesRequest {
+            background: Some(false),
+            include: None,
+            input: ResponseInput::Text("trigger upstream error".to_string()),
+            instructions: None,
+            max_output_tokens: Some(64),
+            max_tool_calls: None,
+            metadata: None,
+            model: "mock-model".to_string(),
+            parallel_tool_calls: Some(true),
+            previous_response_id: None,
+            reasoning: None,
+            service_tier: Some(ServiceTier::Auto),
+            store: Some(true),
+            stream: Some(true),
+            temperature: Some(0.0),
+            tool_choice: None,
+            tools: None,
+            top_logprobs: Some(0),
+            top_p: None,
+            truncation: Some(Truncation::Disabled),
+            text: None,
+            user: None,
+            request_id: Some("resp_stream_upstream_error".to_string()),
+            priority: 0,
+            frequency_penalty: Some(0.0),
+            presence_penalty: Some(0.0),
+            stop: None,
+            top_k: -1,
+            min_p: 0.0,
+            repetition_penalty: 1.0,
+            conversation: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_process_and_transform_stream_does_not_emit_completed_after_upstream_error() {
+        let body = Body::from_stream(stream::iter(vec![
+            Ok::<_, std::io::Error>(Bytes::from(
+                "data: {\"error\":{\"message\":\"upstream exploded\",\"type\":\"internal_error\"}}\n\n",
+            )),
+            Ok(Bytes::from("data: [DONE]\n\n")),
+        ]));
+        let response_storage = Arc::new(MemoryResponseStorage::new());
+        let conversation_storage = Arc::new(MemoryConversationStorage::new());
+        let conversation_item_storage = Arc::new(MemoryConversationItemStorage::new());
+        let sink = RecordingSink::default();
+
+        let final_response = process_and_transform_stream(
+            body,
+            test_responses_request(),
+            response_storage.clone(),
+            conversation_storage,
+            conversation_item_storage,
+            &sink,
+        )
+        .await
+        .expect("stream processing should succeed after forwarding upstream error");
+
+        let events = sink.events();
+        let event_types: Vec<_> = events
+            .iter()
+            .filter_map(|event| event.get("type").and_then(|value| value.as_str()))
+            .collect();
+
+        assert_eq!(
+            event_types,
+            vec!["response.created", "response.in_progress"],
+            "only the synthetic start events should be emitted before the upstream error",
+        );
+        assert!(
+            events.iter().any(|event| event
+                .get("error")
+                .and_then(|error| error.get("message"))
+                .and_then(|value| value.as_str())
+                == Some("upstream exploded")),
+            "the upstream error payload should be forwarded as-is",
+        );
+        assert_eq!(final_response.status, ResponseStatus::Failed);
+
+        let response_id = ResponseId::from(final_response.id.as_str());
+        assert!(
+            response_storage
+                .get_response(&response_id)
+                .await
+                .expect("storage lookup should succeed")
+                .is_none(),
+            "failed upstream streams should not be persisted",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_process_and_transform_stream_emits_function_call_events_for_non_mcp_streams() {
+        let body = Body::from_stream(stream::iter(vec![
+            Ok::<_, std::io::Error>(Bytes::from(
+                "data: {\"id\":\"chatcmpl_test\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"mock-model\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_test\",\"function\":{\"name\":\"get_weather\"},\"type\":\"function\"}]},\"finish_reason\":null}]}\n\n",
+            )),
+            Ok(Bytes::from(
+                "data: {\"id\":\"chatcmpl_test\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"mock-model\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"location\\\":\\\"Berlin\\\"}\"}}]},\"finish_reason\":null}]}\n\n",
+            )),
+            Ok(Bytes::from(
+                "data: {\"id\":\"chatcmpl_test\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"mock-model\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\\n]\"},\"finish_reason\":null}]}\n\n",
+            )),
+            Ok(Bytes::from(
+                "data: {\"id\":\"chatcmpl_test\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"mock-model\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}],\"usage\":{\"prompt_tokens\":12,\"completion_tokens\":7,\"total_tokens\":19}}\n\n",
+            )),
+            Ok(Bytes::from("data: [DONE]\n\n")),
+        ]));
+        let response_storage = Arc::new(MemoryResponseStorage::new());
+        let conversation_storage = Arc::new(MemoryConversationStorage::new());
+        let conversation_item_storage = Arc::new(MemoryConversationItemStorage::new());
+        let sink = RecordingSink::default();
+
+        let final_response = process_and_transform_stream(
+            body,
+            test_responses_request(),
+            response_storage,
+            conversation_storage,
+            conversation_item_storage,
+            &sink,
+        )
+        .await
+        .expect("tool-call stream processing should succeed");
+
+        let events = sink.events();
+        let event_types: Vec<_> = events
+            .iter()
+            .filter_map(|event| event.get("type").and_then(|value| value.as_str()))
+            .collect();
+
+        assert_eq!(
+            event_types,
+            vec![
+                "response.created",
+                "response.in_progress",
+                "response.output_item.added",
+                "response.function_call_arguments.delta",
+                "response.function_call_arguments.done",
+                "response.output_item.done",
+                "response.completed",
+            ],
+        );
+        assert_eq!(events[2]["item"]["type"], "function_call");
+        assert_eq!(events[2]["item"]["call_id"], "call_test");
+        assert_eq!(events[3]["delta"], "{\"location\":\"Berlin\"}");
+        assert_eq!(
+            events.last().unwrap()["response"]["output"][0]["type"],
+            "function_call"
+        );
+        assert_eq!(
+            events.last().unwrap()["response"]["output"][0]["call_id"],
+            "call_test"
+        );
+        assert_eq!(
+            events.last().unwrap()["response"]["output"][0]["arguments"],
+            "{\"location\":\"Berlin\"}"
+        );
+        assert_eq!(events.last().unwrap()["response"]["status"], "in_progress");
+
+        assert_eq!(final_response.status, ResponseStatus::InProgress);
+        assert_eq!(final_response.output.len(), 1);
+        let serialized_output = serde_json::to_value(&final_response.output[0]).unwrap();
+        assert_eq!(serialized_output["type"], "function_call");
+        assert_eq!(serialized_output["call_id"], "call_test");
+        assert_eq!(serialized_output["arguments"], "{\"location\":\"Berlin\"}");
+    }
+
+    #[tokio::test]
+    async fn test_process_and_transform_stream_handles_coalesced_sse_records() {
+        let body = Body::from_stream(stream::iter(vec![Ok::<_, std::io::Error>(
+            Bytes::from(
+                concat!(
+                    "data: {\"id\":\"chatcmpl_test\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"mock-model\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_test\",\"function\":{\"name\":\"calculate\"},\"type\":\"function\"}]},\"finish_reason\":null}]}\n\n",
+                    "data: {\"id\":\"chatcmpl_test\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"mock-model\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"expression\\\":\\\"42 * 17\\\"}\"}}]},\"finish_reason\":null}]}\n\n",
+                    "data: {\"id\":\"chatcmpl_test\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"mock-model\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\\n]\"},\"finish_reason\":null}]}\n\n",
+                    "data: {\"id\":\"chatcmpl_test\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"mock-model\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}],\"usage\":{\"prompt_tokens\":8,\"completion_tokens\":6,\"total_tokens\":14}}\n\n",
+                    "data: [DONE]\n\n"
+                ),
+            ),
+        )]));
+        let response_storage = Arc::new(MemoryResponseStorage::new());
+        let conversation_storage = Arc::new(MemoryConversationStorage::new());
+        let conversation_item_storage = Arc::new(MemoryConversationItemStorage::new());
+        let sink = RecordingSink::default();
+
+        let final_response = process_and_transform_stream(
+            body,
+            test_responses_request(),
+            response_storage,
+            conversation_storage,
+            conversation_item_storage,
+            &sink,
+        )
+        .await
+        .expect("coalesced SSE record processing should succeed");
+
+        let events = sink.events();
+        let event_types: Vec<_> = events
+            .iter()
+            .filter_map(|event| event.get("type").and_then(|value| value.as_str()))
+            .collect();
+
+        assert_eq!(
+            event_types,
+            vec![
+                "response.created",
+                "response.in_progress",
+                "response.output_item.added",
+                "response.function_call_arguments.delta",
+                "response.function_call_arguments.done",
+                "response.output_item.done",
+                "response.completed",
+            ],
+        );
+        assert_eq!(events[3]["delta"], "{\"expression\":\"42 * 17\"}");
+        assert_eq!(events.last().unwrap()["response"]["status"], "in_progress");
+        assert_eq!(final_response.status, ResponseStatus::InProgress);
+        assert_eq!(final_response.output.len(), 1);
+        let serialized_output = serde_json::to_value(&final_response.output[0]).unwrap();
+        assert_eq!(serialized_output["type"], "function_call");
+        assert_eq!(serialized_output["call_id"], "call_test");
+        assert_eq!(serialized_output["name"], "calculate");
+        assert_eq!(
+            serialized_output["arguments"],
+            "{\"expression\":\"42 * 17\"}"
+        );
     }
 }

--- a/sgl-model-gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -59,6 +59,102 @@ use crate::{
     },
 };
 
+/// Generate a unique item ID with the given prefix (e.g. `"fc"` → `"fc_a1b2c3..."`).
+fn generate_item_id(prefix: &str) -> String {
+    format!("{}_{}", prefix, Uuid::new_v4().to_string().replace("-", ""))
+}
+
+// ============================================================================
+// Shared SSE body parser — single implementation for both MCP and non-MCP paths
+// ============================================================================
+
+/// What a parsed SSE `data:` line contains.
+enum SseDataRecord {
+    /// A parsed `ChatCompletionStreamResponse` chunk.
+    ChatChunk(ChatCompletionStreamResponse),
+    /// A raw JSON payload that did not parse as a chat chunk (e.g. upstream error).
+    RawJson(String),
+    /// The `data: [DONE]` sentinel.
+    Done,
+}
+
+/// Incrementally parse SSE records from an HTTP body stream.
+///
+/// Handles split and coalesced chunks using an internal pending buffer with
+/// offset-based compaction (O(n) amortised).  Both the non-MCP and MCP
+/// streaming paths use this so the SSE-byte-parsing logic lives in one place.
+struct SseBodyParser {
+    pending: String,
+    offset: usize,
+}
+
+impl SseBodyParser {
+    fn new() -> Self {
+        Self {
+            pending: String::new(),
+            offset: 0,
+        }
+    }
+
+    /// Append raw bytes from a body chunk.
+    fn push(&mut self, chunk: &[u8]) {
+        let text = String::from_utf8_lossy(chunk).replace("\r\n", "\n");
+        self.pending.push_str(&text);
+    }
+
+    /// Yield the next complete SSE `data:` record, if one is available.
+    fn next_record(&mut self) -> Option<SseDataRecord> {
+        let rel_end = self.pending[self.offset..].find("\n\n")?;
+        let record_end = self.offset + rel_end;
+
+        // Extract and advance offset before any compaction so we don't
+        // borrow `self.pending` across the mutation.
+        let record = self.pending[self.offset..record_end].trim().to_string();
+        self.offset = record_end + 2;
+
+        // Compact when consumed prefix exceeds half the buffer.
+        if self.offset > self.pending.len() / 2 {
+            self.pending = self.pending[self.offset..].to_string();
+            self.offset = 0;
+        }
+
+        if record.is_empty() {
+            return self.next_record();
+        }
+
+        if record == "data: [DONE]" {
+            return Some(SseDataRecord::Done);
+        }
+
+        let Some(json_str) = record.strip_prefix("data: ") else {
+            return self.next_record();
+        };
+        let json_str = json_str.trim();
+
+        match serde_json::from_str::<ChatCompletionStreamResponse>(json_str) {
+            Ok(chunk) => Some(SseDataRecord::ChatChunk(chunk)),
+            Err(_) => Some(SseDataRecord::RawJson(json_str.to_string())),
+        }
+    }
+
+    /// Flush any remaining partial data after the body stream ends.
+    fn flush(&mut self) -> Option<SseDataRecord> {
+        let remaining = self.pending[self.offset..].trim();
+        if remaining.is_empty() || remaining == "data: [DONE]" {
+            return None;
+        }
+        // Reset offset so we don't flush twice.
+        self.offset = self.pending.len();
+
+        let json_str = remaining.strip_prefix("data: ")?.trim();
+
+        match serde_json::from_str::<ChatCompletionStreamResponse>(json_str) {
+            Ok(chunk) => Some(SseDataRecord::ChatChunk(chunk)),
+            Err(_) => Some(SseDataRecord::RawJson(json_str.to_string())),
+        }
+    }
+}
+
 // ============================================================================
 // Non-MCP Streaming Path
 // ============================================================================
@@ -180,25 +276,19 @@ async fn process_and_transform_stream(
         .send_event(&event, sink)
         .map_err(|_| "Failed to send response.in_progress event".to_string())?;
 
-    // Convert body to data stream
+    // Parse SSE records from the body stream using the shared parser.
     let mut stream = body.into_data_stream();
     let mut upstream_error_forwarded = false;
     let mut function_call_events = BTreeMap::new();
-    let mut pending_sse = String::new();
+    let mut parser = SseBodyParser::new();
 
-    // Process stream chunks, handling SSE records even when multiple events are
-    // coalesced into one body chunk or split across chunk boundaries.
     'stream: while let Some(chunk_result) = stream.next().await {
         let chunk = chunk_result.map_err(|e| format!("Stream read error: {}", e))?;
-        let chunk_str = String::from_utf8_lossy(&chunk).replace("\r\n", "\n");
-        pending_sse.push_str(&chunk_str);
+        parser.push(&chunk);
 
-        while let Some(record_end) = pending_sse.find("\n\n") {
-            let record = pending_sse[..record_end].to_string();
-            pending_sse = pending_sse[record_end + 2..].to_string();
-
-            match process_non_mcp_sse_record(
-                &record,
+        while let Some(record) = parser.next_record() {
+            match process_non_mcp_sse_data_record(
+                record,
                 &mut accumulator,
                 &mut event_emitter,
                 sink,
@@ -214,15 +304,18 @@ async fn process_and_transform_stream(
         }
     }
 
-    if !upstream_error_forwarded && !pending_sse.trim().is_empty() {
-        if let SseRecordOutcome::UpstreamError = process_non_mcp_sse_record(
-            &pending_sse,
-            &mut accumulator,
-            &mut event_emitter,
-            sink,
-            &mut function_call_events,
-        )? {
-            upstream_error_forwarded = true;
+    // Flush any remaining partial record after the body stream ends.
+    if !upstream_error_forwarded {
+        if let Some(record) = parser.flush() {
+            if let SseRecordOutcome::UpstreamError = process_non_mcp_sse_data_record(
+                record,
+                &mut accumulator,
+                &mut event_emitter,
+                sink,
+                &mut function_call_events,
+            )? {
+                upstream_error_forwarded = true;
+            }
         }
     }
 
@@ -277,29 +370,17 @@ enum SseRecordOutcome {
     UpstreamError,
 }
 
-fn process_non_mcp_sse_record(
-    event: &str,
+/// Process a pre-parsed SSE data record on the non-MCP streaming path.
+fn process_non_mcp_sse_data_record(
+    record: SseDataRecord,
     accumulator: &mut StreamingResponseAccumulator,
     event_emitter: &mut ResponseStreamEventEmitter,
     sink: &impl ResponseEventSink,
     function_call_events: &mut BTreeMap<usize, FunctionCallEventState>,
 ) -> Result<SseRecordOutcome, String> {
-    let event = event.trim();
-    if event.is_empty() {
-        return Ok(SseRecordOutcome::Continue);
-    }
-
-    if event == "data: [DONE]" {
-        return Ok(SseRecordOutcome::StopStream);
-    }
-
-    let Some(json_str) = event.strip_prefix("data: ") else {
-        return Ok(SseRecordOutcome::Continue);
-    };
-    let json_str = json_str.trim();
-
-    match serde_json::from_str::<ChatCompletionStreamResponse>(json_str) {
-        Ok(chat_chunk) => {
+    match record {
+        SseDataRecord::Done => Ok(SseRecordOutcome::StopStream),
+        SseDataRecord::ChatChunk(chat_chunk) => {
             accumulator.process_chunk(&chat_chunk);
 
             let has_tool_call_delta = chat_chunk
@@ -320,11 +401,11 @@ fn process_non_mcp_sse_record(
 
             Ok(SseRecordOutcome::Continue)
         }
-        Err(_) => {
-            debug!("Non-chunk SSE event, passing through: {}", event);
-            sink.send_raw_json(json_str)?;
+        SseDataRecord::RawJson(json_str) => {
+            debug!("Non-chunk SSE event, passing through: {}", json_str);
+            sink.send_raw_json(&json_str)?;
 
-            if is_upstream_error_payload(json_str) {
+            if is_upstream_error_payload(&json_str) {
                 Ok(SseRecordOutcome::UpstreamError)
             } else {
                 Ok(SseRecordOutcome::Continue)
@@ -493,7 +574,10 @@ impl StreamingResponseAccumulator {
 
         // Process first choice (responses API doesn't support n>1)
         if let Some(choice) = chunk.choices.first() {
-            // Accumulate content
+            // Accumulate content only when no tool calls have been seen.
+            // When tool calls are present, content is typically empty or
+            // whitespace; including it would create a spurious Message
+            // output item alongside the FunctionToolCall items.
             if let Some(content) = &choice.delta.content {
                 if self.tool_calls.is_empty() {
                     self.content_buffer.push_str(content);
@@ -511,10 +595,11 @@ impl StreamingResponseAccumulator {
                     // Use index directly (it's a u32, not Option<u32>)
                     let index = delta.index as usize;
 
-                    // Ensure we have enough tool calls
+                    // Ensure we have enough tool calls.  The item `id` is
+                    // pre-generated so it remains stable across deltas.
                     while self.tool_calls.len() <= index {
                         self.tool_calls.push(ResponseOutputItem::FunctionToolCall {
-                            id: String::new(),
+                            id: generate_item_id("fc"),
                             call_id: String::new(),
                             name: String::new(),
                             arguments: String::new(),
@@ -525,16 +610,18 @@ impl StreamingResponseAccumulator {
 
                     // Update the tool call at this index
                     if let ResponseOutputItem::FunctionToolCall {
-                        id,
                         call_id,
                         name,
                         arguments,
                         ..
                     } = &mut self.tool_calls[index]
                     {
+                        // The tool call ID arrives on the first delta; assign
+                        // once rather than appending on every chunk.
                         if let Some(delta_id) = &delta.id {
-                            id.push_str(delta_id);
-                            call_id.push_str(delta_id);
+                            if call_id.is_empty() {
+                                call_id.clone_from(delta_id);
+                            }
                         }
                         if let Some(function) = &delta.function {
                             if let Some(delta_name) = &function.name {
@@ -719,7 +806,7 @@ pub(super) async fn execute_tool_loop_streaming_with_sink(
     original_request: &ResponsesRequest,
     headers: Option<http::HeaderMap>,
     model_id: Option<String>,
-    outbound_tx: mpsc::UnboundedSender<Message>,
+    outbound_tx: mpsc::Sender<Message>,
 ) -> Result<ResponsesResponse, String> {
     let sink = WsResponseEventSink::new(outbound_tx);
     execute_tool_loop_streaming_internal(
@@ -1238,7 +1325,10 @@ async fn execute_tool_loop_streaming_internal(
     }
 }
 
-/// Convert chat stream to Responses API events while accumulating for tool call detection
+/// Convert chat stream to Responses API events while accumulating for tool call detection.
+///
+/// Uses the shared `SseBodyParser` so the SSE-byte-parsing logic lives in one
+/// place (removing the architectural violation flagged in RFC 0001 / T0).
 async fn convert_and_accumulate_stream(
     body: Body,
     emitter: &mut ResponseStreamEventEmitter,
@@ -1246,28 +1336,31 @@ async fn convert_and_accumulate_stream(
 ) -> Result<ChatCompletionResponse, String> {
     let mut accumulator = ChatResponseAccumulator::new();
     let mut stream = body.into_data_stream();
+    let mut parser = SseBodyParser::new();
 
     while let Some(chunk_result) = stream.next().await {
         let chunk = chunk_result.map_err(|e| format!("Stream read error: {}", e))?;
+        parser.push(&chunk);
 
-        // Parse chunk
-        let event_str = String::from_utf8_lossy(&chunk);
-        let event = event_str.trim();
-
-        if event == "data: [DONE]" {
-            break;
-        }
-
-        if let Some(json_str) = event.strip_prefix("data: ") {
-            let json_str = json_str.trim();
-            if let Ok(chat_chunk) = serde_json::from_str::<ChatCompletionStreamResponse>(json_str) {
-                // Convert chat chunk to Responses API events and emit
-                emitter.process_chunk(&chat_chunk, sink)?;
-
-                // Accumulate for tool call detection
-                accumulator.process_chunk(&chat_chunk);
+        while let Some(record) = parser.next_record() {
+            match record {
+                SseDataRecord::Done => return Ok(accumulator.finalize()),
+                SseDataRecord::ChatChunk(chat_chunk) => {
+                    emitter.process_chunk(&chat_chunk, sink)?;
+                    accumulator.process_chunk(&chat_chunk);
+                }
+                SseDataRecord::RawJson(_) => {
+                    // MCP path ignores non-chat payloads (upstream errors are
+                    // handled at the tool-loop level).
+                }
             }
         }
+    }
+
+    // Flush any remaining partial record.
+    if let Some(SseDataRecord::ChatChunk(chat_chunk)) = parser.flush() {
+        emitter.process_chunk(&chat_chunk, sink)?;
+        accumulator.process_chunk(&chat_chunk);
     }
 
     Ok(accumulator.finalize())
@@ -1659,5 +1752,85 @@ mod tests {
             serialized_output["arguments"],
             "{\"expression\":\"42 * 17\"}"
         );
+    }
+
+    // ------------------------------------------------------------------
+    // T3: MCP path — coalesced / split SSE chunk handling
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_convert_and_accumulate_stream_handles_coalesced_sse_records() {
+        // All SSE records arrive in a single body chunk.
+        let body = Body::from_stream(stream::iter(vec![Ok::<_, std::io::Error>(Bytes::from(
+            concat!(
+                "data: {\"id\":\"chatcmpl_mcp\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"mock-model\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hel\"},\"finish_reason\":null}]}\n\n",
+                "data: {\"id\":\"chatcmpl_mcp\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"mock-model\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"lo\"},\"finish_reason\":null}]}\n\n",
+                "data: {\"id\":\"chatcmpl_mcp\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"mock-model\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":2,\"total_tokens\":7}}\n\n",
+                "data: [DONE]\n\n"
+            ),
+        ))]));
+
+        let sink = RecordingSink::default();
+        let mut emitter =
+            ResponseStreamEventEmitter::new("resp_mcp_test".into(), "mock-model".into(), 1);
+        let created = emitter.emit_created();
+        emitter.send_event(&created, &sink).unwrap();
+        let in_prog = emitter.emit_in_progress();
+        emitter.send_event(&in_prog, &sink).unwrap();
+
+        let result = convert_and_accumulate_stream(body, &mut emitter, &sink)
+            .await
+            .expect("coalesced MCP stream should succeed");
+
+        assert_eq!(result.choices[0].message.content.as_deref(), Some("hello"));
+        assert!(result.usage.is_some());
+
+        let events = sink.events();
+        let text_deltas: Vec<&str> = events
+            .iter()
+            .filter(|e| {
+                e.get("type").and_then(|t| t.as_str()) == Some("response.output_text.delta")
+            })
+            .filter_map(|e| e.get("delta").and_then(|d| d.as_str()))
+            .collect();
+        assert_eq!(text_deltas, vec!["hel", "lo"]);
+    }
+
+    #[tokio::test]
+    async fn test_convert_and_accumulate_stream_handles_split_sse_records() {
+        // One SSE record is split across two body chunks.
+        let first_half = "data: {\"id\":\"chatcmpl_split\",\"object\":\"chat.completion.chunk\",";
+        let second_half = "\"created\":1,\"model\":\"mock-model\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"split\"},\"finish_reason\":null}]}\n\n\
+                           data: {\"id\":\"chatcmpl_split\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"mock-model\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n\
+                           data: [DONE]\n\n";
+
+        let body = Body::from_stream(stream::iter(vec![
+            Ok::<_, std::io::Error>(Bytes::from(first_half)),
+            Ok(Bytes::from(second_half)),
+        ]));
+
+        let sink = RecordingSink::default();
+        let mut emitter =
+            ResponseStreamEventEmitter::new("resp_split_test".into(), "mock-model".into(), 1);
+        let created = emitter.emit_created();
+        emitter.send_event(&created, &sink).unwrap();
+        let in_prog = emitter.emit_in_progress();
+        emitter.send_event(&in_prog, &sink).unwrap();
+
+        let result = convert_and_accumulate_stream(body, &mut emitter, &sink)
+            .await
+            .expect("split MCP stream should succeed");
+
+        assert_eq!(result.choices[0].message.content.as_deref(), Some("split"));
+
+        let events = sink.events();
+        let text_deltas: Vec<&str> = events
+            .iter()
+            .filter(|e| {
+                e.get("type").and_then(|t| t.as_str()) == Some("response.output_text.delta")
+            })
+            .filter_map(|e| e.get("delta").and_then(|d| d.as_str()))
+            .collect();
+        assert_eq!(text_deltas, vec!["split"]);
     }
 }

--- a/sgl-model-gateway/src/routers/grpc/regular/responses/websocket.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/responses/websocket.rs
@@ -19,10 +19,7 @@ use super::{
 };
 use crate::{
     core::WorkerRegistry,
-    protocols::{
-        responses::{generate_id, ResponseStatus, ResponsesRequest, ResponsesResponse},
-        validated::Normalizable,
-    },
+    protocols::responses::{generate_id, ResponseStatus, ResponsesRequest, ResponsesResponse},
     routers::{
         error,
         grpc::{
@@ -63,10 +60,9 @@ impl WsResponsesExecutor for GrpcWsResponsesExecutor {
         mut request: ResponsesRequest,
         options: WsResponseCreateOptions,
         cached_response: Option<CachedWsResponse>,
-        outbound_tx: mpsc::UnboundedSender<Message>,
+        outbound_tx: mpsc::Sender<Message>,
     ) -> Result<CachedWsResponse, WsClientError> {
         let request_started_at = Instant::now();
-        request.normalize();
         // WebSocket Responses is inherently event-streamed, so force streaming
         // on the downstream chat pipeline regardless of the client payload.
         request.stream = Some(true);
@@ -182,7 +178,8 @@ async fn response_to_ws_error(response: axum::response::Response) -> WsClientErr
         .and_then(|value| value.to_str().ok())
         .unwrap_or("responses_ws_error")
         .to_string();
-    let body_bytes = to_bytes(response.into_body(), usize::MAX).await.ok();
+    // Cap error-body reads to 1 MiB to prevent OOM on malformed upstream responses.
+    let body_bytes = to_bytes(response.into_body(), 1_048_576).await.ok();
     let parsed_error = body_bytes
         .as_ref()
         .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(bytes).ok())
@@ -210,7 +207,7 @@ async fn warmup_response_create(
     ctx: &ResponsesContext,
     request: &ResponsesRequest,
     modified_request: &ResponsesRequest,
-    outbound_tx: mpsc::UnboundedSender<Message>,
+    outbound_tx: mpsc::Sender<Message>,
 ) -> Result<CachedWsResponse, WsClientError> {
     let response = ResponsesResponse::builder(generate_id("resp"), &request.model)
         .copy_from_request(request)
@@ -218,23 +215,19 @@ async fn warmup_response_create(
         .output(vec![])
         .build();
 
-    let created = json!({
-        "type": "response.created",
-        "response": {
-            "id": response.id,
-            "object": "response",
-            "status": "in_progress",
-            "model": response.model,
-            "output": []
-        }
-    });
-    send_ws_message(&outbound_tx, created)?;
-
-    let completed = json!({
-        "type": "response.completed",
-        "response": response.clone(),
-    });
-    send_ws_message(&outbound_tx, completed)?;
+    let in_progress_response = ResponsesResponse::builder(&response.id, &response.model)
+        .copy_from_request(request)
+        .status(ResponseStatus::InProgress)
+        .output(vec![])
+        .build();
+    send_ws_message(
+        &outbound_tx,
+        json!({ "type": "response.created", "response": in_progress_response }),
+    )?;
+    send_ws_message(
+        &outbound_tx,
+        json!({ "type": "response.completed", "response": response.clone() }),
+    )?;
 
     persist_response_if_needed(
         ctx.conversation_storage.clone(),
@@ -252,15 +245,15 @@ async fn warmup_response_create(
 }
 
 fn send_ws_message(
-    outbound_tx: &mpsc::UnboundedSender<Message>,
+    outbound_tx: &mpsc::Sender<Message>,
     payload: serde_json::Value,
 ) -> Result<(), WsClientError> {
     outbound_tx
-        .send(Message::Text(payload.to_string().into()))
+        .try_send(Message::Text(payload.to_string().into()))
         .map_err(|_| {
             WsClientError::new(
                 "client_disconnected",
-                "WebSocket client disconnected before response delivery.",
+                "WebSocket client disconnected or outbound buffer full.",
             )
             .with_status(499)
         })

--- a/sgl-model-gateway/src/routers/grpc/regular/responses/websocket.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/responses/websocket.rs
@@ -1,0 +1,325 @@
+//! WebSocket executor for the gRPC regular Responses backend.
+//!
+//! Bridges the transport-neutral [`WsResponsesExecutor`] trait to the existing
+//! gRPC regular Responses streaming pipeline so that WebSocket connections
+//! reuse the same event-emission, storage, and persistence logic as HTTP SSE.
+
+use std::{sync::Arc, time::Instant};
+
+use async_trait::async_trait;
+use axum::{body::to_bytes, extract::ws::Message, http::HeaderMap};
+use serde_json::json;
+use tokio::sync::mpsc;
+use tracing::debug;
+
+use super::{
+    common::{load_conversation_history_with_cache, normalize_request_input_items},
+    conversions,
+    streaming::{execute_non_mcp_stream_with_sink, execute_tool_loop_streaming_with_sink},
+};
+use crate::{
+    core::WorkerRegistry,
+    protocols::{
+        responses::{generate_id, ResponseStatus, ResponsesRequest, ResponsesResponse},
+        validated::Normalizable,
+    },
+    routers::{
+        error,
+        grpc::{
+            common::responses::{
+                ensure_mcp_connection,
+                utils::{persist_response_if_needed, validate_worker_availability},
+                ResponsesContext,
+            },
+            harmony::HarmonyDetector,
+        },
+        responses_validation::normalize_and_validate_responses_request,
+        ws_responses::{
+            CachedWsResponse, WsClientError, WsResponseCreateOptions, WsResponsesExecutor,
+        },
+    },
+};
+
+#[derive(Clone)]
+pub(crate) struct GrpcWsResponsesExecutor {
+    worker_registry: Arc<WorkerRegistry>,
+    responses_context: ResponsesContext,
+}
+
+impl GrpcWsResponsesExecutor {
+    pub fn new(worker_registry: Arc<WorkerRegistry>, responses_context: ResponsesContext) -> Self {
+        Self {
+            worker_registry,
+            responses_context,
+        }
+    }
+}
+
+#[async_trait]
+impl WsResponsesExecutor for GrpcWsResponsesExecutor {
+    async fn execute_response_create(
+        &self,
+        headers: HeaderMap,
+        mut request: ResponsesRequest,
+        options: WsResponseCreateOptions,
+        cached_response: Option<CachedWsResponse>,
+        outbound_tx: mpsc::UnboundedSender<Message>,
+    ) -> Result<CachedWsResponse, WsClientError> {
+        let request_started_at = Instant::now();
+        request.normalize();
+        // WebSocket Responses is inherently event-streamed, so force streaming
+        // on the downstream chat pipeline regardless of the client payload.
+        request.stream = Some(true);
+        request.background = Some(false);
+
+        normalize_and_validate_responses_request(&mut request)
+            .map_err(|err| WsClientError::new("invalid_request", err.to_string()))?;
+
+        if request.conversation.is_some() {
+            return Err(WsClientError::new(
+                "unsupported_parameter",
+                "The `conversation` field is not supported in WebSocket Responses V1.",
+            ));
+        }
+
+        if let Some(error_response) =
+            validate_worker_availability(&self.worker_registry, request.model.as_str())
+        {
+            return Err(response_to_ws_error(error_response).await);
+        }
+
+        if HarmonyDetector::is_harmony_model_in_registry(&self.worker_registry, &request.model) {
+            return Err(WsClientError::new(
+                "unsupported_model",
+                "Harmony-backed Responses are not supported on the WebSocket path in V1.",
+            ));
+        }
+
+        let ctx = self.responses_context.clone_for_request();
+        let had_cached_response = cached_response.is_some();
+        let modified_request = match load_conversation_history_with_cache(
+            &ctx,
+            &request,
+            cached_response.as_ref(),
+            true,
+        )
+        .await
+        {
+            Ok(modified_request) => modified_request,
+            Err(error_response) => return Err(response_to_ws_error(error_response).await),
+        };
+        debug!(
+            model = %request.model,
+            cached_response_hit = had_cached_response,
+            input_items = normalize_request_input_items(&modified_request).len(),
+            elapsed_ms = request_started_at.elapsed().as_secs_f64() * 1000.0,
+            "loaded websocket response conversation history"
+        );
+
+        if options.generate == Some(false) {
+            return warmup_response_create(&ctx, &request, &modified_request, outbound_tx).await;
+        }
+
+        let (has_mcp_tools, server_keys) =
+            match ensure_mcp_connection(&ctx.mcp_manager, request.tools.as_deref()).await {
+                Ok(result) => result,
+                Err(error_response) => return Err(response_to_ws_error(error_response).await),
+            };
+
+        {
+            let mut servers = ctx.requested_servers.write().unwrap();
+            *servers = server_keys;
+        }
+
+        let final_response = if has_mcp_tools {
+            execute_tool_loop_streaming_with_sink(
+                &ctx,
+                modified_request.clone(),
+                &request,
+                Some(headers),
+                Some(request.model.clone()),
+                outbound_tx,
+            )
+            .await
+            .map_err(|err| WsClientError::new("stream_execution_failed", err))?
+        } else {
+            let chat_request = conversions::responses_to_chat(&modified_request)
+                .map_err(|err| WsClientError::new("convert_request_failed", err.to_string()))?;
+
+            execute_non_mcp_stream_with_sink(
+                &ctx,
+                Arc::new(chat_request),
+                request.clone(),
+                Some(headers),
+                Some(request.model.clone()),
+                &crate::routers::grpc::common::responses::streaming::WsResponseEventSink::new(
+                    outbound_tx,
+                ),
+            )
+            .await
+            .map_err(|err| WsClientError::new("stream_execution_failed", err))?
+        };
+        debug!(
+            model = %request.model,
+            response_id = %final_response.id,
+            status = ?final_response.status,
+            elapsed_ms = request_started_at.elapsed().as_secs_f64() * 1000.0,
+            "finished websocket response execution"
+        );
+
+        Ok(CachedWsResponse {
+            response: final_response,
+            input_items: normalize_request_input_items(&modified_request),
+        })
+    }
+}
+
+async fn response_to_ws_error(response: axum::response::Response) -> WsClientError {
+    let status = response.status();
+    let header_code = response
+        .headers()
+        .get(error::HEADER_X_SMG_ERROR_CODE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("responses_ws_error")
+        .to_string();
+    let body_bytes = to_bytes(response.into_body(), usize::MAX).await.ok();
+    let parsed_error = body_bytes
+        .as_ref()
+        .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(bytes).ok())
+        .and_then(|value| value.get("error").cloned());
+
+    let error_code = parsed_error
+        .as_ref()
+        .and_then(|error| error.get("code"))
+        .and_then(|value| value.as_str())
+        .unwrap_or(&header_code)
+        .to_string();
+    let error_message = parsed_error
+        .as_ref()
+        .and_then(|error| error.get("message"))
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("WebSocket Responses request failed with status {}", status));
+
+    WsClientError::new(error_code, error_message)
+        .with_status(status.as_u16())
+        .with_param_if_previous_response_not_found()
+}
+
+async fn warmup_response_create(
+    ctx: &ResponsesContext,
+    request: &ResponsesRequest,
+    modified_request: &ResponsesRequest,
+    outbound_tx: mpsc::UnboundedSender<Message>,
+) -> Result<CachedWsResponse, WsClientError> {
+    let response = ResponsesResponse::builder(generate_id("resp"), &request.model)
+        .copy_from_request(request)
+        .status(ResponseStatus::Completed)
+        .output(vec![])
+        .build();
+
+    let created = json!({
+        "type": "response.created",
+        "response": {
+            "id": response.id,
+            "object": "response",
+            "status": "in_progress",
+            "model": response.model,
+            "output": []
+        }
+    });
+    send_ws_message(&outbound_tx, created)?;
+
+    let completed = json!({
+        "type": "response.completed",
+        "response": response.clone(),
+    });
+    send_ws_message(&outbound_tx, completed)?;
+
+    persist_response_if_needed(
+        ctx.conversation_storage.clone(),
+        ctx.conversation_item_storage.clone(),
+        ctx.response_storage.clone(),
+        &response,
+        request,
+    )
+    .await;
+
+    Ok(CachedWsResponse {
+        response,
+        input_items: normalize_request_input_items(modified_request),
+    })
+}
+
+fn send_ws_message(
+    outbound_tx: &mpsc::UnboundedSender<Message>,
+    payload: serde_json::Value,
+) -> Result<(), WsClientError> {
+    outbound_tx
+        .send(Message::Text(payload.to_string().into()))
+        .map_err(|_| {
+            WsClientError::new(
+                "client_disconnected",
+                "WebSocket client disconnected before response delivery.",
+            )
+            .with_status(499)
+        })
+}
+
+trait WsClientErrorExt {
+    fn with_param_if_previous_response_not_found(self) -> Self;
+}
+
+impl WsClientErrorExt for WsClientError {
+    fn with_param_if_previous_response_not_found(self) -> Self {
+        if self.code == "previous_response_not_found" {
+            self.with_param("previous_response_id")
+        } else {
+            self
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{body::Body, http::StatusCode, response::IntoResponse};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_response_to_ws_error_preserves_router_error_body_message() {
+        let err = response_to_ws_error(error::not_found(
+            "previous_response_not_found",
+            "Previous response 'resp_missing' was not found in the current session or durable storage.",
+        ))
+        .await;
+
+        assert_eq!(err.code, "previous_response_not_found");
+        assert_eq!(
+            err.message,
+            "Previous response 'resp_missing' was not found in the current session or durable storage."
+        );
+        assert_eq!(err.status, 404);
+        assert_eq!(err.param.as_deref(), Some("previous_response_id"));
+    }
+
+    #[tokio::test]
+    async fn test_response_to_ws_error_falls_back_for_non_json_error_body() {
+        let response = (
+            StatusCode::BAD_REQUEST,
+            [(error::HEADER_X_SMG_ERROR_CODE, "responses_ws_error")],
+            Body::from("plain text error"),
+        )
+            .into_response();
+
+        let err = response_to_ws_error(response).await;
+
+        assert_eq!(err.code, "responses_ws_error");
+        assert_eq!(
+            err.message,
+            "WebSocket Responses request failed with status 400 Bad Request"
+        );
+        assert_eq!(err.status, 400);
+        assert_eq!(err.param, None);
+    }
+}

--- a/sgl-model-gateway/src/routers/grpc/router.rs
+++ b/sgl-model-gateway/src/routers/grpc/router.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use axum::{
+    extract::ws::WebSocket,
     http::HeaderMap,
     response::{IntoResponse, Response},
 };
@@ -30,7 +31,7 @@ use crate::{
         generate::GenerateRequest,
         responses::{ResponsesGetParams, ResponsesRequest},
     },
-    routers::RouterTrait,
+    routers::{ws_responses::serve_responses_ws, RouterTrait},
 };
 
 /// gRPC router implementation for SGLang
@@ -399,6 +400,18 @@ impl RouterTrait for GrpcRouter {
         model_id: Option<&str>,
     ) -> Response {
         self.route_responses_impl(headers, body, model_id).await
+    }
+
+    fn supports_responses_ws(&self) -> bool {
+        true
+    }
+
+    async fn route_responses_ws(&self, headers: HeaderMap, socket: WebSocket) {
+        let executor = Arc::new(responses::GrpcWsResponsesExecutor::new(
+            self.worker_registry.clone(),
+            self.responses_context.clone(),
+        ));
+        serve_responses_ws(socket, headers, executor).await;
     }
 
     async fn get_response(

--- a/sgl-model-gateway/src/routers/grpc/router.rs
+++ b/sgl-model-gateway/src/routers/grpc/router.rs
@@ -285,16 +285,7 @@ impl GrpcRouter {
                 model_id.unwrap_or(UNKNOWN_MODEL_ID),
                 body.stream.unwrap_or(false)
             );
-            let harmony_ctx = ResponsesContext::new(
-                Arc::new(self.harmony_pipeline.clone()),
-                self.shared_components.clone(),
-                self.harmony_responses_context.response_storage.clone(),
-                self.harmony_responses_context.conversation_storage.clone(),
-                self.harmony_responses_context
-                    .conversation_item_storage
-                    .clone(),
-                self.harmony_responses_context.mcp_manager.clone(),
-            );
+            let harmony_ctx = self.harmony_responses_context.clone_for_request();
 
             if body.stream.unwrap_or(false) {
                 serve_harmony_responses_stream(&harmony_ctx, body.clone()).await

--- a/sgl-model-gateway/src/routers/mod.rs
+++ b/sgl-model-gateway/src/routers/mod.rs
@@ -5,10 +5,11 @@ use std::fmt::Debug;
 use async_trait::async_trait;
 use axum::{
     body::Body,
-    extract::Request,
+    extract::{ws::WebSocket, Request},
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
 };
+use futures_util::SinkExt;
 
 use crate::protocols::{
     chat::ChatCompletionRequest,
@@ -31,8 +32,10 @@ pub mod mesh;
 pub mod openai;
 pub mod parse;
 pub mod persistence_utils;
+pub mod responses_validation;
 pub mod router_manager;
 pub mod tokenize;
+pub mod ws_responses;
 
 pub use factory::RouterFactory;
 // Re-export HTTP routers for convenience
@@ -123,6 +126,16 @@ pub trait RouterTrait: Send + Sync + Debug {
             "Responses endpoint not implemented",
         )
             .into_response()
+    }
+
+    /// Whether this router supports the WebSocket Responses surface.
+    fn supports_responses_ws(&self) -> bool {
+        false
+    }
+
+    /// Handle a WebSocket-upgraded `/v1/responses` connection.
+    async fn route_responses_ws(&self, _headers: HeaderMap, mut socket: WebSocket) {
+        let _ = socket.close().await;
     }
 
     /// Retrieve a stored/background response by id

--- a/sgl-model-gateway/src/routers/responses_validation.rs
+++ b/sgl-model-gateway/src/routers/responses_validation.rs
@@ -1,0 +1,187 @@
+//! Shared request validation for the Responses API.
+//!
+//! Provides input normalization and validation that is shared across both the
+//! HTTP and WebSocket Responses paths.
+
+use axum::{
+    extract::{rejection::JsonRejection, FromRequest, Request},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde_json::json;
+use validator::{Validate, ValidationErrors, ValidationErrorsKind};
+
+use crate::protocols::{
+    responses::{ResponseInput, ResponseInputOutputItem, ResponsesRequest},
+    validated::Normalizable,
+};
+
+pub(crate) fn normalize_and_validate_responses_request(
+    request: &mut ResponsesRequest,
+) -> Result<(), ValidationErrors> {
+    request.normalize();
+
+    match request.validate() {
+        Ok(()) => Ok(()),
+        Err(errors) if allows_function_call_output_only_continuation(request, &errors) => Ok(()),
+        Err(errors) => Err(errors),
+    }
+}
+
+fn allows_function_call_output_only_continuation(
+    request: &ResponsesRequest,
+    errors: &ValidationErrors,
+) -> bool {
+    if request.previous_response_id.is_none() {
+        return false;
+    }
+
+    let ResponseInput::Items(items) = &request.input else {
+        return false;
+    };
+
+    if items.is_empty() {
+        return false;
+    }
+
+    if !items
+        .iter()
+        .all(|item| matches!(item, ResponseInputOutputItem::FunctionCallOutput { .. }))
+    {
+        return false;
+    }
+
+    let all_errors = errors.errors();
+    if all_errors.len() != 1 {
+        return false;
+    }
+
+    let Some(schema_errors) = all_errors.get("__all__") else {
+        return false;
+    };
+
+    let ValidationErrorsKind::Field(schema_errors) = schema_errors else {
+        return false;
+    };
+
+    schema_errors.len() == 1 && schema_errors[0].code == "input_missing_user_message"
+}
+
+fn json_rejection_response(err: JsonRejection) -> Response {
+    let error_message = match err {
+        JsonRejection::JsonDataError(e) => format!("Invalid JSON data: {}", e),
+        JsonRejection::JsonSyntaxError(e) => format!("JSON syntax error: {}", e),
+        JsonRejection::MissingJsonContentType(_) => {
+            "Missing Content-Type: application/json header".to_string()
+        }
+        _ => format!("Failed to parse JSON: {}", err),
+    };
+
+    (
+        StatusCode::BAD_REQUEST,
+        Json(json!({
+            "error": {
+                "message": error_message,
+                "type": "invalid_request_error",
+                "code": "json_parse_error"
+            }
+        })),
+    )
+        .into_response()
+}
+
+fn validation_error_response(validation_errors: ValidationErrors) -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(json!({
+            "error": {
+                "message": validation_errors.to_string(),
+                "type": "invalid_request_error",
+                "code": 400
+            }
+        })),
+    )
+        .into_response()
+}
+
+pub(crate) struct ValidatedResponsesJson(pub ResponsesRequest);
+
+impl<S> FromRequest<S> for ValidatedResponsesJson
+where
+    S: Send + Sync,
+{
+    type Rejection = Response;
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        let Json(mut data) = Json::<ResponsesRequest>::from_request(req, state)
+            .await
+            .map_err(json_rejection_response)?;
+
+        normalize_and_validate_responses_request(&mut data).map_err(validation_error_response)?;
+
+        Ok(Self(data))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_and_validate_responses_request;
+    use crate::protocols::responses::{ResponseInput, ResponseInputOutputItem, ResponsesRequest};
+
+    #[test]
+    fn allows_function_call_output_only_continuation_with_previous_response_id() {
+        let mut request = ResponsesRequest {
+            model: "mock-model".to_string(),
+            previous_response_id: Some("resp_prev".to_string()),
+            input: ResponseInput::Items(vec![ResponseInputOutputItem::FunctionCallOutput {
+                id: None,
+                call_id: "call_123".to_string(),
+                output: r#"{"result":345}"#.to_string(),
+                status: None,
+            }]),
+            ..Default::default()
+        };
+
+        assert!(normalize_and_validate_responses_request(&mut request).is_ok());
+    }
+
+    #[test]
+    fn still_rejects_function_call_output_only_without_previous_response_id() {
+        let mut request = ResponsesRequest {
+            model: "mock-model".to_string(),
+            input: ResponseInput::Items(vec![ResponseInputOutputItem::FunctionCallOutput {
+                id: None,
+                call_id: "call_123".to_string(),
+                output: r#"{"result":345}"#.to_string(),
+                status: None,
+            }]),
+            ..Default::default()
+        };
+
+        let error = normalize_and_validate_responses_request(&mut request).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("Input items must contain at least one message"));
+    }
+
+    #[test]
+    fn still_rejects_other_validation_errors_for_continuations() {
+        let mut request = ResponsesRequest {
+            model: "mock-model".to_string(),
+            previous_response_id: Some("resp_prev".to_string()),
+            input: ResponseInput::Items(vec![ResponseInputOutputItem::FunctionCallOutput {
+                id: None,
+                call_id: "call_123".to_string(),
+                output: String::new(),
+                status: None,
+            }]),
+            ..Default::default()
+        };
+
+        let error = normalize_and_validate_responses_request(&mut request).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("Function call output cannot be empty"));
+    }
+}

--- a/sgl-model-gateway/src/routers/responses_validation.rs
+++ b/sgl-model-gateway/src/routers/responses_validation.rs
@@ -98,7 +98,7 @@ fn validation_error_response(validation_errors: ValidationErrors) -> Response {
             "error": {
                 "message": validation_errors.to_string(),
                 "type": "invalid_request_error",
-                "code": 400
+                "code": "validation_error"
             }
         })),
     )

--- a/sgl-model-gateway/src/routers/router_manager.rs
+++ b/sgl-model-gateway/src/routers/router_manager.rs
@@ -10,11 +10,12 @@ use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use axum::{
     body::Body,
-    extract::Request,
+    extract::{ws::WebSocket, Request},
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
 };
 use dashmap::DashMap;
+use futures_util::SinkExt;
 use serde_json::Value;
 use tracing::{debug, info, warn};
 
@@ -396,6 +397,20 @@ impl RouterManager {
 
         best_router
     }
+
+    fn select_router_for_ws(&self, headers: &HeaderMap) -> Option<Arc<dyn RouterTrait>> {
+        if let Some(router) = self.select_router_for_request(Some(headers), None) {
+            if router.supports_responses_ws() {
+                return Some(router);
+            }
+        }
+
+        let routers_snapshot = self.routers_snapshot.load();
+        routers_snapshot
+            .iter()
+            .find(|router| router.supports_responses_ws())
+            .cloned()
+    }
 }
 
 #[async_trait]
@@ -611,6 +626,21 @@ impl RouterTrait for RouterManager {
                 "No router available to handle responses request",
             )
                 .into_response()
+        }
+    }
+
+    fn supports_responses_ws(&self) -> bool {
+        let routers_snapshot = self.routers_snapshot.load();
+        routers_snapshot
+            .iter()
+            .any(|router| router.supports_responses_ws())
+    }
+
+    async fn route_responses_ws(&self, headers: HeaderMap, mut socket: WebSocket) {
+        if let Some(router) = self.select_router_for_ws(&headers) {
+            router.route_responses_ws(headers, socket).await;
+        } else {
+            let _ = socket.close().await;
         }
     }
 

--- a/sgl-model-gateway/src/routers/router_manager.rs
+++ b/sgl-model-gateway/src/routers/router_manager.rs
@@ -10,7 +10,10 @@ use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use axum::{
     body::Body,
-    extract::{ws::WebSocket, Request},
+    extract::{
+        ws::{Message, WebSocket},
+        Request,
+    },
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
 };
@@ -615,7 +618,19 @@ impl RouterTrait for RouterManager {
         body: &ResponsesRequest,
         model_id: Option<&str>,
     ) -> Response {
-        let selected_model = model_id.or(Some(body.model.as_str()));
+        let effective_model_id = if self.enable_igw {
+            let model = model_id.or(Some(body.model.as_str()));
+            match self.resolve_model_id(model) {
+                Ok(id) => Some(id),
+                Err(err_response) => return *err_response,
+            }
+        } else {
+            None
+        };
+        let selected_model = effective_model_id
+            .as_deref()
+            .or(model_id)
+            .or(Some(body.model.as_str()));
         let router = self.select_router_for_request(headers, selected_model);
 
         if let Some(router) = router {
@@ -640,6 +655,15 @@ impl RouterTrait for RouterManager {
         if let Some(router) = self.select_router_for_ws(&headers) {
             router.route_responses_ws(headers, socket).await;
         } else {
+            let error = serde_json::json!({
+                "type": "error",
+                "error": {
+                    "type": "server_error",
+                    "code": "no_ws_router_available",
+                    "message": "No router supports WebSocket Responses for this request."
+                }
+            });
+            let _ = socket.send(Message::Text(error.to_string().into())).await;
             let _ = socket.close().await;
         }
     }

--- a/sgl-model-gateway/src/routers/ws_responses.rs
+++ b/sgl-model-gateway/src/routers/ws_responses.rs
@@ -1,0 +1,600 @@
+//! WebSocket transport for the Responses API.
+//!
+//! Implements `GET /v1/responses` WebSocket upgrade handling at the router
+//! layer.  Each connection owns a single-entry response cache and allows one
+//! in-flight `response.create` at a time.  Connections are capped at a
+//! configurable lifetime (default 60 minutes) with ping/pong liveness checks.
+
+use std::{
+    sync::{Arc, OnceLock},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+use async_trait::async_trait;
+use axum::{
+    extract::ws::{CloseFrame, Message, WebSocket},
+    http::HeaderMap,
+};
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{json, Value};
+use tokio::sync::{mpsc, Mutex};
+use tracing::{debug, info, warn};
+
+use crate::protocols::responses::{
+    ResponseInputOutputItem, ResponseStatus, ResponsesRequest, ResponsesResponse,
+};
+
+const DEFAULT_WS_SESSION_LIFETIME: Duration = Duration::from_secs(60 * 60);
+const ACTIVE_REQUEST_HANDOFF_TIMEOUT: Duration = Duration::from_millis(50);
+const ACTIVE_REQUEST_HANDOFF_POLL: Duration = Duration::from_millis(1);
+
+fn ws_writer_timing_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("SMG_DEBUG_WS_WRITE_TIMING").is_some())
+}
+
+fn ws_message_event_type(message: &Message) -> String {
+    match message {
+        Message::Text(text) => serde_json::from_str::<Value>(text)
+            .ok()
+            .and_then(|value| {
+                value
+                    .get("type")
+                    .and_then(|value| value.as_str())
+                    .map(str::to_owned)
+            })
+            .unwrap_or_else(|| "text".to_string()),
+        Message::Binary(_) => "binary".to_string(),
+        Message::Ping(_) => "ping".to_string(),
+        Message::Pong(_) => "pong".to_string(),
+        Message::Close(_) => "close".to_string(),
+    }
+}
+
+fn unix_timestamp_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[derive(Clone, Debug)]
+#[doc(hidden)]
+pub struct CachedWsResponse {
+    pub response: ResponsesResponse,
+    pub input_items: Vec<ResponseInputOutputItem>,
+}
+
+impl CachedWsResponse {
+    pub fn to_conversation_items(&self) -> Vec<ResponseInputOutputItem> {
+        let mut items = self.input_items.clone();
+
+        for output_item in &self.response.output {
+            let Ok(value) = serde_json::to_value(output_item) else {
+                continue;
+            };
+            let Ok(item) = serde_json::from_value::<ResponseInputOutputItem>(value) else {
+                continue;
+            };
+            items.push(item);
+        }
+
+        items
+    }
+}
+
+#[derive(Clone, Debug)]
+#[doc(hidden)]
+pub struct WsClientError {
+    pub code: String,
+    pub message: String,
+    pub status: u16,
+    pub error_type: String,
+    pub param: Option<String>,
+}
+
+impl WsClientError {
+    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+            status: 400,
+            error_type: "invalid_request_error".to_string(),
+            param: None,
+        }
+    }
+
+    pub fn with_status(mut self, status: u16) -> Self {
+        self.status = status;
+        self
+    }
+
+    pub fn with_type(mut self, error_type: impl Into<String>) -> Self {
+        self.error_type = error_type.into();
+        self
+    }
+
+    pub fn with_param(mut self, param: impl Into<String>) -> Self {
+        self.param = Some(param.into());
+        self
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+#[doc(hidden)]
+pub struct WsResponseCreateOptions {
+    pub generate: Option<bool>,
+}
+
+#[async_trait]
+#[doc(hidden)]
+pub trait WsResponsesExecutor: Send + Sync {
+    async fn execute_response_create(
+        &self,
+        headers: HeaderMap,
+        request: ResponsesRequest,
+        options: WsResponseCreateOptions,
+        cached_response: Option<CachedWsResponse>,
+        outbound_tx: mpsc::UnboundedSender<Message>,
+    ) -> Result<CachedWsResponse, WsClientError>;
+}
+
+#[derive(Default)]
+struct WsSessionState {
+    active_request: bool,
+    cached_response: Option<CachedWsResponse>,
+}
+
+#[derive(Clone, Debug)]
+#[doc(hidden)]
+pub struct WsRuntimeConfig {
+    pub max_session_lifetime: Duration,
+}
+
+impl Default for WsRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            max_session_lifetime: DEFAULT_WS_SESSION_LIFETIME,
+        }
+    }
+}
+
+fn format_duration_label(duration: Duration) -> String {
+    fn pluralize(value: u128, unit: &str) -> String {
+        if unit == "ms" {
+            return format!("{} ms", value);
+        }
+
+        if value == 1 {
+            format!("1 {}", unit)
+        } else {
+            format!("{} {}s", value, unit)
+        }
+    }
+
+    let millis = duration.as_millis();
+    let seconds = duration.as_secs();
+
+    if millis == 0 {
+        return "0 ms".to_string();
+    }
+
+    if millis < 1_000 {
+        return pluralize(millis, "ms");
+    }
+
+    if seconds < 60 {
+        return pluralize(seconds as u128, "second");
+    }
+
+    if seconds < 3_600 && seconds.is_multiple_of(60) {
+        return pluralize((seconds / 60) as u128, "minute");
+    }
+
+    if seconds.is_multiple_of(3_600) {
+        return pluralize((seconds / 3_600) as u128, "hour");
+    }
+
+    format!("{:.1} seconds", duration.as_secs_f64())
+}
+
+fn session_lifetime_message(duration: Duration) -> String {
+    format!(
+        "Responses websocket connection limit reached ({}). Create a new websocket connection to continue.",
+        format_duration_label(duration)
+    )
+}
+
+#[derive(Debug)]
+struct ParsedClientEvent {
+    event_type: String,
+    event_id: Option<String>,
+    request: Option<ResponsesRequest>,
+    options: WsResponseCreateOptions,
+}
+
+#[doc(hidden)]
+pub async fn serve_responses_ws(
+    socket: WebSocket,
+    headers: HeaderMap,
+    executor: Arc<dyn WsResponsesExecutor>,
+) {
+    serve_responses_ws_with_config(socket, headers, executor, WsRuntimeConfig::default()).await;
+}
+
+#[doc(hidden)]
+pub async fn serve_responses_ws_with_config(
+    socket: WebSocket,
+    headers: HeaderMap,
+    executor: Arc<dyn WsResponsesExecutor>,
+    runtime_config: WsRuntimeConfig,
+) {
+    let (mut sink, mut stream) = socket.split();
+    let (outbound_tx, mut outbound_rx) = mpsc::unbounded_channel::<Message>();
+    let session = Arc::new(Mutex::new(WsSessionState::default()));
+
+    let writer = tokio::spawn(async move {
+        let session_started_at = Instant::now();
+        while let Some(message) = outbound_rx.recv().await {
+            let event_type = ws_writer_timing_enabled().then(|| ws_message_event_type(&message));
+            let payload_len = match &message {
+                Message::Text(text) => text.len(),
+                Message::Binary(payload) => payload.len(),
+                Message::Ping(payload) | Message::Pong(payload) => payload.len(),
+                Message::Close(_) => 0,
+            };
+
+            if sink.send(message).await.is_err() {
+                break;
+            }
+
+            if let Some(event_type) = event_type {
+                info!(
+                    wall_time_ms = unix_timestamp_ms(),
+                    session_elapsed_ms = session_started_at.elapsed().as_secs_f64() * 1000.0,
+                    event_type,
+                    payload_len,
+                    "responses websocket writer flushed frame"
+                );
+            }
+        }
+    });
+
+    let session_timeout = {
+        let outbound_tx = outbound_tx.clone();
+        let max_session_lifetime = runtime_config.max_session_lifetime;
+        tokio::spawn(async move {
+            if max_session_lifetime.is_zero() {
+                return;
+            }
+
+            tokio::time::sleep(max_session_lifetime).await;
+            let message = session_lifetime_message(max_session_lifetime);
+            send_client_error_json(
+                &outbound_tx,
+                &WsClientError::new("websocket_connection_limit_reached", &message)
+                    .with_type("invalid_request_error"),
+                None,
+            );
+            let _ = outbound_tx.send(Message::Close(Some(CloseFrame {
+                code: axum::extract::ws::close_code::NORMAL,
+                reason: message.into(),
+            })));
+        })
+    };
+
+    while let Some(message_result) = stream.next().await {
+        let message = match message_result {
+            Ok(message) => message,
+            Err(err) => {
+                debug!("responses websocket receive error: {}", err);
+                break;
+            }
+        };
+
+        match message {
+            Message::Text(text) => {
+                handle_text_event(
+                    text.as_ref(),
+                    headers.clone(),
+                    executor.clone(),
+                    session.clone(),
+                    outbound_tx.clone(),
+                )
+                .await;
+            }
+            Message::Binary(_) => {
+                send_error_json(
+                    &outbound_tx,
+                    "unsupported_message_type",
+                    "Binary WebSocket messages are not supported on /v1/responses.",
+                    None,
+                );
+            }
+            Message::Ping(payload) => {
+                let _ = outbound_tx.send(Message::Pong(payload));
+            }
+            Message::Pong(_) => {}
+            Message::Close(_) => break,
+        }
+    }
+
+    session_timeout.abort();
+    drop(outbound_tx);
+    let _ = writer.await;
+}
+
+async fn handle_text_event(
+    payload: &str,
+    headers: HeaderMap,
+    executor: Arc<dyn WsResponsesExecutor>,
+    session: Arc<Mutex<WsSessionState>>,
+    outbound_tx: mpsc::UnboundedSender<Message>,
+) {
+    let raw_event = match parse_client_event(payload) {
+        Ok(raw_event) => raw_event,
+        Err(err) => {
+            send_client_error_json(&outbound_tx, &err, None);
+            return;
+        }
+    };
+
+    match raw_event.event_type.as_str() {
+        "response.create" => {
+            let Some(request) = raw_event.request else {
+                send_error_json(
+                    &outbound_tx,
+                    "missing_response",
+                    "The `response.create` event requires a valid Responses request body.",
+                    raw_event.event_id.as_deref(),
+                );
+                return;
+            };
+
+            if !acquire_request_slot(&session).await {
+                send_error_json(
+                    &outbound_tx,
+                    "concurrent_response_create",
+                    "Only one in-flight `response.create` is allowed per connection.",
+                    raw_event.event_id.as_deref(),
+                );
+                return;
+            }
+            let session_guard = session.lock().await;
+            let cached_response = session_guard.cached_response.clone();
+            drop(session_guard);
+
+            let event_id = raw_event.event_id.clone();
+            let options = raw_event.options.clone();
+            let referenced_previous_response_id = request.previous_response_id.clone();
+            let request_model = request.model.clone();
+            let request_store = request.store;
+            let request_started_at = Instant::now();
+            debug!(
+                event_id = event_id.as_deref().unwrap_or(""),
+                model = %request_model,
+                store = request_store,
+                has_previous_response = referenced_previous_response_id.is_some(),
+                generate = options.generate.unwrap_or(true),
+                "accepted websocket response.create request"
+            );
+            let session_clone = session.clone();
+            let outbound_clone = outbound_tx.clone();
+            tokio::spawn(async move {
+                let result = executor
+                    .execute_response_create(
+                        headers,
+                        request,
+                        options,
+                        cached_response,
+                        outbound_clone.clone(),
+                    )
+                    .await;
+
+                let mut session_guard = session_clone.lock().await;
+                session_guard.active_request = false;
+
+                match result {
+                    Ok(cached_response) => {
+                        debug!(
+                            event_id = event_id.as_deref().unwrap_or(""),
+                            response_id = %cached_response.response.id,
+                            status = ?cached_response.response.status,
+                            elapsed_ms = request_started_at.elapsed().as_secs_f64() * 1000.0,
+                            "completed websocket response.create request"
+                        );
+                        session_guard.cached_response = (cached_response.response.status
+                            != ResponseStatus::Failed)
+                            .then_some(cached_response);
+                    }
+                    Err(err) => {
+                        let should_evict_cached_response = referenced_previous_response_id
+                            .as_deref()
+                            .is_some_and(|previous_id| {
+                                session_guard
+                                    .cached_response
+                                    .as_ref()
+                                    .map(|cached| cached.response.id == previous_id)
+                                    .unwrap_or(false)
+                            });
+                        if should_evict_cached_response {
+                            session_guard.cached_response = None;
+                        }
+                        drop(session_guard);
+                        debug!(
+                            event_id = event_id.as_deref().unwrap_or(""),
+                            error_code = %err.code,
+                            elapsed_ms = request_started_at.elapsed().as_secs_f64() * 1000.0,
+                            "websocket response.create request failed"
+                        );
+                        send_client_error_json(&outbound_clone, &err, event_id.as_deref());
+                    }
+                }
+            });
+        }
+        other => {
+            send_error_json(
+                &outbound_tx,
+                "unsupported_event",
+                format!("Unsupported WebSocket client event type: {}", other),
+                raw_event.event_id.as_deref(),
+            );
+        }
+    }
+}
+
+async fn acquire_request_slot(session: &Arc<Mutex<WsSessionState>>) -> bool {
+    let deadline = Instant::now() + ACTIVE_REQUEST_HANDOFF_TIMEOUT;
+    loop {
+        let mut session_guard = session.lock().await;
+        if !session_guard.active_request {
+            session_guard.active_request = true;
+            return true;
+        }
+        drop(session_guard);
+
+        if Instant::now() >= deadline {
+            return false;
+        }
+
+        tokio::time::sleep(ACTIVE_REQUEST_HANDOFF_POLL).await;
+    }
+}
+
+fn parse_client_event(payload: &str) -> Result<ParsedClientEvent, WsClientError> {
+    let event_value = serde_json::from_str::<Value>(payload).map_err(|err| {
+        WsClientError::new(
+            "invalid_json",
+            format!("Failed to parse WebSocket client event JSON: {}", err),
+        )
+    })?;
+
+    let mut event_object = match event_value {
+        Value::Object(event_object) => event_object,
+        _ => {
+            return Err(WsClientError::new(
+                "invalid_json",
+                "WebSocket client event JSON must be an object.",
+            ))
+        }
+    };
+
+    let event_type = take_string_field(&mut event_object, "type").ok_or_else(|| {
+        WsClientError::new(
+            "invalid_json",
+            "WebSocket client event JSON must include a string `type` field.",
+        )
+    })?;
+    let event_id = take_string_field(&mut event_object, "event_id");
+
+    let (request, options) = match event_type.as_str() {
+        "response.create" => {
+            if let Some(mut request_value) = event_object.remove("response") {
+                let options = extract_request_options(&mut request_value)?;
+                let request =
+                    serde_json::from_value::<ResponsesRequest>(request_value).map_err(|err| {
+                        WsClientError::new(
+                            "invalid_request",
+                            format!("Failed to parse `response.create` payload: {}", err),
+                        )
+                    })?;
+                (Some(request), options)
+            } else {
+                if event_object.is_empty() {
+                    return Ok(ParsedClientEvent {
+                        event_type,
+                        event_id,
+                        request: None,
+                        options: WsResponseCreateOptions::default(),
+                    });
+                }
+
+                let mut request_value = Value::Object(event_object);
+                let options = extract_request_options(&mut request_value)?;
+                let request =
+                    serde_json::from_value::<ResponsesRequest>(request_value).map_err(|err| {
+                        WsClientError::new(
+                            "invalid_request",
+                            format!("Failed to parse `response.create` payload: {}", err),
+                        )
+                    })?;
+                (Some(request), options)
+            }
+        }
+        _ => (None, WsResponseCreateOptions::default()),
+    };
+
+    Ok(ParsedClientEvent {
+        event_type,
+        event_id,
+        request,
+        options,
+    })
+}
+
+fn extract_request_options(
+    request_value: &mut Value,
+) -> Result<WsResponseCreateOptions, WsClientError> {
+    let request_object = request_value.as_object_mut().ok_or_else(|| {
+        WsClientError::new(
+            "invalid_request",
+            "The `response.create` payload must be a JSON object.",
+        )
+    })?;
+
+    Ok(WsResponseCreateOptions {
+        generate: take_bool_field(request_object, "generate"),
+    })
+}
+
+fn take_string_field(object: &mut serde_json::Map<String, Value>, key: &str) -> Option<String> {
+    object
+        .remove(key)
+        .and_then(|value| value.as_str().map(str::to_owned))
+}
+
+fn take_bool_field(object: &mut serde_json::Map<String, Value>, key: &str) -> Option<bool> {
+    object.remove(key).and_then(|value| value.as_bool())
+}
+
+pub(crate) fn send_error_json(
+    outbound_tx: &mpsc::UnboundedSender<Message>,
+    code: &str,
+    message: impl Into<String>,
+    event_id: Option<&str>,
+) {
+    send_client_error_json(outbound_tx, &WsClientError::new(code, message), event_id);
+}
+
+pub(crate) fn send_client_error_json(
+    outbound_tx: &mpsc::UnboundedSender<Message>,
+    error: &WsClientError,
+    event_id: Option<&str>,
+) {
+    let mut error_json = json!({
+        "type": "error",
+        "status": error.status,
+        "error": {
+            "type": error.error_type,
+            "code": error.code,
+            "message": error.message,
+        },
+        "code": error.code,
+        "message": error.message,
+    });
+
+    if let Some(param) = &error.param {
+        error_json["error"]["param"] = Value::String(param.clone());
+    }
+
+    if let Some(event_id) = event_id {
+        error_json["event_id"] = Value::String(event_id.to_string());
+    }
+
+    if outbound_tx
+        .send(Message::Text(error_json.to_string().into()))
+        .is_err()
+    {
+        warn!("responses websocket client disconnected before error delivery");
+    }
+}

--- a/sgl-model-gateway/src/routers/ws_responses.rs
+++ b/sgl-model-gateway/src/routers/ws_responses.rs
@@ -6,7 +6,10 @@
 //! configurable lifetime (default 60 minutes) with ping/pong liveness checks.
 
 use std::{
-    sync::{Arc, OnceLock},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, OnceLock,
+    },
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
@@ -17,7 +20,7 @@ use axum::{
 };
 use futures_util::{SinkExt, StreamExt};
 use serde_json::{json, Value};
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{mpsc, Mutex, Notify};
 use tracing::{debug, info, warn};
 
 use crate::protocols::responses::{
@@ -25,8 +28,11 @@ use crate::protocols::responses::{
 };
 
 const DEFAULT_WS_SESSION_LIFETIME: Duration = Duration::from_secs(60 * 60);
+/// Bounded outbound channel capacity.  Large enough to absorb bursts from the
+/// LLM streaming pipeline while still providing backpressure if a client falls
+/// behind.
+const OUTBOUND_CHANNEL_CAPACITY: usize = 256;
 const ACTIVE_REQUEST_HANDOFF_TIMEOUT: Duration = Duration::from_millis(50);
-const ACTIVE_REQUEST_HANDOFF_POLL: Duration = Duration::from_millis(1);
 
 fn ws_writer_timing_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
@@ -71,9 +77,11 @@ impl CachedWsResponse {
 
         for output_item in &self.response.output {
             let Ok(value) = serde_json::to_value(output_item) else {
+                warn!("failed to serialize output item for conversation cache");
                 continue;
             };
             let Ok(item) = serde_json::from_value::<ResponseInputOutputItem>(value) else {
+                warn!("failed to deserialize output item into ResponseInputOutputItem for conversation cache");
                 continue;
             };
             items.push(item);
@@ -135,14 +143,25 @@ pub trait WsResponsesExecutor: Send + Sync {
         request: ResponsesRequest,
         options: WsResponseCreateOptions,
         cached_response: Option<CachedWsResponse>,
-        outbound_tx: mpsc::UnboundedSender<Message>,
+        outbound_tx: mpsc::Sender<Message>,
     ) -> Result<CachedWsResponse, WsClientError>;
 }
 
-#[derive(Default)]
 struct WsSessionState {
     active_request: bool,
     cached_response: Option<CachedWsResponse>,
+    /// Signalled when `active_request` transitions from true -> false.
+    request_done: Arc<Notify>,
+}
+
+impl Default for WsSessionState {
+    fn default() -> Self {
+        Self {
+            active_request: false,
+            cached_response: None,
+            request_done: Arc::new(Notify::new()),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -230,8 +249,9 @@ pub async fn serve_responses_ws_with_config(
     runtime_config: WsRuntimeConfig,
 ) {
     let (mut sink, mut stream) = socket.split();
-    let (outbound_tx, mut outbound_rx) = mpsc::unbounded_channel::<Message>();
+    let (outbound_tx, mut outbound_rx) = mpsc::channel::<Message>(OUTBOUND_CHANNEL_CAPACITY);
     let session = Arc::new(Mutex::new(WsSessionState::default()));
+    let closing = Arc::new(AtomicBool::new(false));
 
     let writer = tokio::spawn(async move {
         let session_started_at = Instant::now();
@@ -262,6 +282,7 @@ pub async fn serve_responses_ws_with_config(
 
     let session_timeout = {
         let outbound_tx = outbound_tx.clone();
+        let closing = closing.clone();
         let max_session_lifetime = runtime_config.max_session_lifetime;
         tokio::spawn(async move {
             if max_session_lifetime.is_zero() {
@@ -269,19 +290,26 @@ pub async fn serve_responses_ws_with_config(
             }
 
             tokio::time::sleep(max_session_lifetime).await;
+            closing.store(true, Ordering::Release);
             let message = session_lifetime_message(max_session_lifetime);
             send_client_error_json(
                 &outbound_tx,
                 &WsClientError::new("websocket_connection_limit_reached", &message)
                     .with_type("invalid_request_error"),
                 None,
-            );
-            let _ = outbound_tx.send(Message::Close(Some(CloseFrame {
-                code: axum::extract::ws::close_code::NORMAL,
-                reason: message.into(),
-            })));
+            )
+            .await;
+            let _ = outbound_tx
+                .send(Message::Close(Some(CloseFrame {
+                    code: axum::extract::ws::close_code::NORMAL,
+                    reason: message.into(),
+                })))
+                .await;
         })
     };
+
+    // Track the current executor task so we can abort it on disconnect.
+    let mut executor_handle: Option<tokio::task::JoinHandle<()>> = None;
 
     while let Some(message_result) = stream.next().await {
         let message = match message_result {
@@ -294,14 +322,20 @@ pub async fn serve_responses_ws_with_config(
 
         match message {
             Message::Text(text) => {
-                handle_text_event(
+                if closing.load(Ordering::Acquire) {
+                    break;
+                }
+                let handle = handle_text_event(
                     text.as_ref(),
-                    headers.clone(),
+                    &headers,
                     executor.clone(),
                     session.clone(),
                     outbound_tx.clone(),
                 )
                 .await;
+                if let Some(h) = handle {
+                    executor_handle = Some(h);
+                }
             }
             Message::Binary(_) => {
                 send_error_json(
@@ -309,33 +343,40 @@ pub async fn serve_responses_ws_with_config(
                     "unsupported_message_type",
                     "Binary WebSocket messages are not supported on /v1/responses.",
                     None,
-                );
+                )
+                .await;
             }
             Message::Ping(payload) => {
-                let _ = outbound_tx.send(Message::Pong(payload));
+                let _ = outbound_tx.send(Message::Pong(payload)).await;
             }
             Message::Pong(_) => {}
             Message::Close(_) => break,
         }
     }
 
+    // Client disconnected — abort any in-flight executor task to avoid wasted compute.
+    if let Some(handle) = executor_handle.take() {
+        handle.abort();
+    }
     session_timeout.abort();
     drop(outbound_tx);
     let _ = writer.await;
 }
 
+/// Handle an incoming text event.  Returns a [`JoinHandle`] when an executor
+/// task is spawned so the caller can abort it on disconnect.
 async fn handle_text_event(
     payload: &str,
-    headers: HeaderMap,
+    headers: &HeaderMap,
     executor: Arc<dyn WsResponsesExecutor>,
     session: Arc<Mutex<WsSessionState>>,
-    outbound_tx: mpsc::UnboundedSender<Message>,
-) {
+    outbound_tx: mpsc::Sender<Message>,
+) -> Option<tokio::task::JoinHandle<()>> {
     let raw_event = match parse_client_event(payload) {
         Ok(raw_event) => raw_event,
         Err(err) => {
-            send_client_error_json(&outbound_tx, &err, None);
-            return;
+            send_client_error_json(&outbound_tx, &err, None).await;
+            return None;
         }
     };
 
@@ -347,8 +388,9 @@ async fn handle_text_event(
                     "missing_response",
                     "The `response.create` event requires a valid Responses request body.",
                     raw_event.event_id.as_deref(),
-                );
-                return;
+                )
+                .await;
+                return None;
             };
 
             if !acquire_request_slot(&session).await {
@@ -357,8 +399,9 @@ async fn handle_text_event(
                     "concurrent_response_create",
                     "Only one in-flight `response.create` is allowed per connection.",
                     raw_event.event_id.as_deref(),
-                );
-                return;
+                )
+                .await;
+                return None;
             }
             let session_guard = session.lock().await;
             let cached_response = session_guard.cached_response.clone();
@@ -378,9 +421,10 @@ async fn handle_text_event(
                 generate = options.generate.unwrap_or(true),
                 "accepted websocket response.create request"
             );
+            let headers = headers.clone();
             let session_clone = session.clone();
             let outbound_clone = outbound_tx.clone();
-            tokio::spawn(async move {
+            let handle = tokio::spawn(async move {
                 let result = executor
                     .execute_response_create(
                         headers,
@@ -392,8 +436,8 @@ async fn handle_text_event(
                     .await;
 
                 let mut session_guard = session_clone.lock().await;
-                session_guard.active_request = false;
-
+                // Update cache *before* clearing active_request to prevent
+                // a TOCTOU race where a new request reads stale cache.
                 match result {
                     Ok(cached_response) => {
                         debug!(
@@ -420,17 +464,28 @@ async fn handle_text_event(
                         if should_evict_cached_response {
                             session_guard.cached_response = None;
                         }
+                        // Release lock before sending error to avoid holding
+                        // it while the bounded channel potentially blocks.
+                        let notify = session_guard.request_done.clone();
+                        session_guard.active_request = false;
                         drop(session_guard);
+                        notify.notify_waiters();
                         debug!(
                             event_id = event_id.as_deref().unwrap_or(""),
                             error_code = %err.code,
                             elapsed_ms = request_started_at.elapsed().as_secs_f64() * 1000.0,
                             "websocket response.create request failed"
                         );
-                        send_client_error_json(&outbound_clone, &err, event_id.as_deref());
+                        send_client_error_json(&outbound_clone, &err, event_id.as_deref()).await;
+                        return;
                     }
                 }
+                let notify = session_guard.request_done.clone();
+                session_guard.active_request = false;
+                drop(session_guard);
+                notify.notify_waiters();
             });
+            Some(handle)
         }
         other => {
             send_error_json(
@@ -438,26 +493,39 @@ async fn handle_text_event(
                 "unsupported_event",
                 format!("Unsupported WebSocket client event type: {}", other),
                 raw_event.event_id.as_deref(),
-            );
+            )
+            .await;
+            None
         }
     }
 }
 
 async fn acquire_request_slot(session: &Arc<Mutex<WsSessionState>>) -> bool {
-    let deadline = Instant::now() + ACTIVE_REQUEST_HANDOFF_TIMEOUT;
-    loop {
-        let mut session_guard = session.lock().await;
-        if !session_guard.active_request {
-            session_guard.active_request = true;
+    // Fast path: slot is free.
+    {
+        let mut guard = session.lock().await;
+        if !guard.active_request {
+            guard.active_request = true;
             return true;
         }
-        drop(session_guard);
+    }
 
-        if Instant::now() >= deadline {
-            return false;
+    // Slow path: wait for the in-flight request to complete.
+    let notify = {
+        let guard = session.lock().await;
+        guard.request_done.clone()
+    };
+
+    match tokio::time::timeout(ACTIVE_REQUEST_HANDOFF_TIMEOUT, notify.notified()).await {
+        Ok(()) => {
+            let mut guard = session.lock().await;
+            if !guard.active_request {
+                guard.active_request = true;
+                return true;
+            }
+            false
         }
-
-        tokio::time::sleep(ACTIVE_REQUEST_HANDOFF_POLL).await;
+        Err(_) => false,
     }
 }
 
@@ -557,17 +625,17 @@ fn take_bool_field(object: &mut serde_json::Map<String, Value>, key: &str) -> Op
     object.remove(key).and_then(|value| value.as_bool())
 }
 
-pub(crate) fn send_error_json(
-    outbound_tx: &mpsc::UnboundedSender<Message>,
+pub(crate) async fn send_error_json(
+    outbound_tx: &mpsc::Sender<Message>,
     code: &str,
     message: impl Into<String>,
     event_id: Option<&str>,
 ) {
-    send_client_error_json(outbound_tx, &WsClientError::new(code, message), event_id);
+    send_client_error_json(outbound_tx, &WsClientError::new(code, message), event_id).await;
 }
 
-pub(crate) fn send_client_error_json(
-    outbound_tx: &mpsc::UnboundedSender<Message>,
+pub(crate) async fn send_client_error_json(
+    outbound_tx: &mpsc::Sender<Message>,
     error: &WsClientError,
     event_id: Option<&str>,
 ) {
@@ -593,6 +661,7 @@ pub(crate) fn send_client_error_json(
 
     if outbound_tx
         .send(Message::Text(error_json.to_string().into()))
+        .await
         .is_err()
     {
         warn!("responses websocket client disconnected before error delivery");

--- a/sgl-model-gateway/src/server.rs
+++ b/sgl-model-gateway/src/server.rs
@@ -7,12 +7,13 @@ use std::{
 };
 
 use axum::{
-    extract::{Path, Query, Request, State},
+    extract::{ws::WebSocketUpgrade, FromRequestParts, Path, Query, Request, State},
     http::StatusCode,
     response::{IntoResponse, Response},
     routing::{delete, get, post},
     Json, Router,
 };
+use axum_server::accept::NoDelayAcceptor;
 use rustls::crypto::ring;
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -47,19 +48,20 @@ use crate::{
         generate::GenerateRequest,
         parser::{ParseFunctionCallRequest, SeparateReasoningRequest},
         rerank::V1RerankReqInput,
-        responses::{ResponsesGetParams, ResponsesRequest},
+        responses::ResponsesGetParams,
         tokenize::{AddTokenizerRequest, DetokenizeRequest, TokenizeRequest},
         validated::ValidatedJson,
         worker_spec::{WorkerConfigRequest, WorkerUpdateRequest},
     },
     routers::{
-        conversations,
+        conversations, error as router_error,
         mesh::{
             get_app_config, get_cluster_status, get_global_rate_limit, get_global_rate_limit_stats,
             get_mesh_health, get_policy_state, get_policy_states, get_worker_state,
             get_worker_states, set_global_rate_limit, trigger_graceful_shutdown, update_app_config,
         },
         parse,
+        responses_validation::ValidatedResponsesJson,
         router_manager::RouterManager,
         tokenize, RouterTrait,
     },
@@ -218,12 +220,37 @@ async fn v1_rerank(
 async fn v1_responses(
     State(state): State<Arc<AppState>>,
     headers: http::HeaderMap,
-    ValidatedJson(body): ValidatedJson<ResponsesRequest>,
+    ValidatedResponsesJson(body): ValidatedResponsesJson,
 ) -> Response {
     state
         .router
         .route_responses(Some(&headers), &body, Some(&body.model))
         .await
+}
+
+async fn v1_responses_ws(State(state): State<Arc<AppState>>, req: Request) -> Response {
+    if !state.router.supports_responses_ws() {
+        return router_error::not_implemented(
+            "responses_ws_not_supported",
+            "WebSocket Responses are not supported for this router.",
+        );
+    }
+
+    let (mut parts, _body) = req.into_parts();
+    let headers = parts.headers.clone();
+
+    let Ok(ws) = WebSocketUpgrade::from_request_parts(&mut parts, &()).await else {
+        return router_error::bad_request(
+            "websocket_upgrade_required",
+            "GET /v1/responses requires a WebSocket upgrade request.",
+        );
+    };
+
+    let router = state.router.clone();
+    ws.on_upgrade(move |socket| async move {
+        router.route_responses_ws(headers, socket).await;
+    })
+    .into_response()
 }
 
 async fn v1_embeddings(
@@ -546,7 +573,7 @@ pub fn build_app(
         .route("/v1/chat/completions", post(v1_chat_completions))
         .route("/v1/completions", post(v1_completions))
         .route("/v1/rerank", post(v1_rerank))
-        .route("/v1/responses", post(v1_responses))
+        .route("/v1/responses", get(v1_responses_ws).post(v1_responses))
         .route("/v1/embeddings", post(v1_embeddings))
         .route("/v1/classify", post(v1_classify))
         .route("/v1/responses/{response_id}", get(v1_responses_get))
@@ -1078,12 +1105,14 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
             .map_err(|e| format!("Failed to create TLS config: {}", e))?;
 
         axum_server::bind_rustls(addr, tls_config)
+            .acceptor(NoDelayAcceptor::new())
             .handle(handle)
             .serve(app.into_make_service())
             .await
             .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
     } else {
         axum_server::bind(addr)
+            .acceptor(NoDelayAcceptor::new())
             .handle(handle)
             .serve(app.into_make_service())
             .await

--- a/sgl-model-gateway/tests/api/api_endpoints_test.rs
+++ b/sgl-model-gateway/tests/api/api_endpoints_test.rs
@@ -648,6 +648,17 @@ mod responses_endpoint_tests {
 
     use super::*;
 
+    fn response_output_text(response: &serde_json::Value) -> Option<&str> {
+        response["output"]
+            .as_array()?
+            .first()?
+            .get("content")?
+            .as_array()?
+            .first()?
+            .get("text")?
+            .as_str()
+    }
+
     #[tokio::test]
     async fn test_v1_responses_non_streaming() {
         let ctx = AppTestContext::new(vec![MockWorkerConfig {
@@ -725,6 +736,147 @@ mod responses_endpoint_tests {
         assert!(ct.contains("text/event-stream"));
 
         // We don't fully consume the stream in this test harness.
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_v1_responses_accepts_function_call_output_only_continuation() {
+        let ctx = AppTestContext::new(vec![MockWorkerConfig {
+            port: 18955,
+            worker_type: WorkerType::Regular,
+            health_status: HealthStatus::Healthy,
+            response_delay_ms: 0,
+            fail_rate: 0.0,
+        }])
+        .await;
+
+        let app = ctx.create_app().await;
+
+        let seed_payload = json!({
+            "input": "Seed a stored response for continuation.",
+            "model": "mock-model",
+            "store": true,
+            "stream": false
+        });
+
+        let seed_req = Request::builder()
+            .method("POST")
+            .uri("/v1/responses")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&seed_payload).unwrap()))
+            .unwrap();
+
+        let seed_resp = app.clone().oneshot(seed_req).await.unwrap();
+        assert_eq!(seed_resp.status(), StatusCode::OK);
+        let seed_body = axum::body::to_bytes(seed_resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let seed_json: serde_json::Value = serde_json::from_slice(&seed_body).unwrap();
+        let response_id = seed_json["id"].as_str().expect("response id missing");
+
+        let continuation_payload = json!({
+            "input": [
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_123",
+                    "output": "{\"result\":345}"
+                }
+            ],
+            "model": "mock-model",
+            "previous_response_id": response_id,
+            "store": false,
+            "stream": false
+        });
+
+        let continuation_req = Request::builder()
+            .method("POST")
+            .uri("/v1/responses")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(
+                serde_json::to_string(&continuation_payload).unwrap(),
+            ))
+            .unwrap();
+
+        let continuation_resp = app.clone().oneshot(continuation_req).await.unwrap();
+        assert_eq!(continuation_resp.status(), StatusCode::OK);
+
+        let continuation_body = axum::body::to_bytes(continuation_resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let continuation_json: serde_json::Value =
+            serde_json::from_slice(&continuation_body).unwrap();
+        assert_eq!(continuation_json["object"], "response");
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_v1_responses_non_streaming_previous_response_continuation_returns_text() {
+        let ctx = AppTestContext::new(vec![MockWorkerConfig {
+            port: 18956,
+            worker_type: WorkerType::Regular,
+            health_status: HealthStatus::Healthy,
+            response_delay_ms: 0,
+            fail_rate: 0.0,
+        }])
+        .await;
+
+        let app = ctx.create_app().await;
+
+        let seed_payload = json!({
+            "input": "Seed a stored response for text continuation.",
+            "model": "mock-model",
+            "store": true,
+            "stream": false
+        });
+
+        let seed_req = Request::builder()
+            .method("POST")
+            .uri("/v1/responses")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&seed_payload).unwrap()))
+            .unwrap();
+
+        let seed_resp = app.clone().oneshot(seed_req).await.unwrap();
+        assert_eq!(seed_resp.status(), StatusCode::OK);
+        let seed_body = axum::body::to_bytes(seed_resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let seed_json: serde_json::Value = serde_json::from_slice(&seed_body).unwrap();
+        let response_id = seed_json["id"].as_str().expect("response id missing");
+
+        let continuation_payload = json!({
+            "input": "Continue this response chain with a second turn.",
+            "model": "mock-model",
+            "previous_response_id": response_id,
+            "store": true,
+            "stream": false
+        });
+
+        let continuation_req = Request::builder()
+            .method("POST")
+            .uri("/v1/responses")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(
+                serde_json::to_string(&continuation_payload).unwrap(),
+            ))
+            .unwrap();
+
+        let continuation_resp = app.clone().oneshot(continuation_req).await.unwrap();
+        assert_eq!(continuation_resp.status(), StatusCode::OK);
+
+        let continuation_body = axum::body::to_bytes(continuation_resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let continuation_json: serde_json::Value =
+            serde_json::from_slice(&continuation_body).unwrap();
+        assert_eq!(continuation_json["object"], "response");
+        assert_eq!(continuation_json["status"], "completed");
+        assert_eq!(
+            response_output_text(&continuation_json),
+            Some("This is a mock responses output.")
+        );
+
         ctx.shutdown().await;
     }
 

--- a/sgl-model-gateway/tests/api/mod.rs
+++ b/sgl-model-gateway/tests/api/mod.rs
@@ -4,4 +4,5 @@ mod api_endpoints_test;
 mod parser_endpoints_test;
 mod request_formats_test;
 mod responses_api_test;
+mod responses_ws_test;
 mod streaming_tests;

--- a/sgl-model-gateway/tests/api/responses_ws_test.rs
+++ b/sgl-model-gateway/tests/api/responses_ws_test.rs
@@ -66,7 +66,7 @@ impl WsResponsesExecutor for StubWsExecutor {
         request: ResponsesRequest,
         _options: WsResponseCreateOptions,
         _cached_response: Option<CachedWsResponse>,
-        outbound_tx: mpsc::UnboundedSender<Message>,
+        outbound_tx: mpsc::Sender<Message>,
     ) -> Result<CachedWsResponse, WsClientError> {
         let model = request.model.clone();
         let created = serde_json::json!({
@@ -79,7 +79,7 @@ impl WsResponsesExecutor for StubWsExecutor {
                 "output": []
             }
         });
-        let _ = outbound_tx.send(Message::Text(created.to_string().into()));
+        let _ = outbound_tx.try_send(Message::Text(created.to_string().into()));
 
         if let Some(gate) = &self.gate {
             gate.notified().await;
@@ -105,7 +105,7 @@ impl WsResponsesExecutor for StubWsExecutor {
             "type": "response.completed",
             "response": response,
         });
-        let _ = outbound_tx.send(Message::Text(completed.to_string().into()));
+        let _ = outbound_tx.try_send(Message::Text(completed.to_string().into()));
 
         Ok(CachedWsResponse {
             response: ResponsesResponse::builder("resp_ws_test", request.model.clone())
@@ -142,7 +142,7 @@ impl WsResponsesExecutor for DelayedReturnWsExecutor {
         request: ResponsesRequest,
         _options: WsResponseCreateOptions,
         _cached_response: Option<CachedWsResponse>,
-        outbound_tx: mpsc::UnboundedSender<Message>,
+        outbound_tx: mpsc::Sender<Message>,
     ) -> Result<CachedWsResponse, WsClientError> {
         let output_text = "delayed websocket output";
         let response = ResponsesResponse::builder("resp_ws_delayed", request.model.clone())
@@ -170,13 +170,13 @@ impl WsResponsesExecutor for DelayedReturnWsExecutor {
                 "output": []
             }
         });
-        let _ = outbound_tx.send(Message::Text(created.to_string().into()));
+        let _ = outbound_tx.try_send(Message::Text(created.to_string().into()));
 
         let completed = serde_json::json!({
             "type": "response.completed",
             "response": response.clone(),
         });
-        let _ = outbound_tx.send(Message::Text(completed.to_string().into()));
+        let _ = outbound_tx.try_send(Message::Text(completed.to_string().into()));
 
         tokio::time::sleep(self.return_delay).await;
 
@@ -198,7 +198,7 @@ impl WsResponsesExecutor for FunctionCallWsExecutor {
         request: ResponsesRequest,
         _options: WsResponseCreateOptions,
         _cached_response: Option<CachedWsResponse>,
-        outbound_tx: mpsc::UnboundedSender<Message>,
+        outbound_tx: mpsc::Sender<Message>,
     ) -> Result<CachedWsResponse, WsClientError> {
         let response_id = "resp_ws_tool_test";
         let item_id = "fc_ws_test";
@@ -217,7 +217,7 @@ impl WsResponsesExecutor for FunctionCallWsExecutor {
                 "output": []
             }
         });
-        let _ = outbound_tx.send(Message::Text(created.to_string().into()));
+        let _ = outbound_tx.try_send(Message::Text(created.to_string().into()));
 
         let output_item_added = serde_json::json!({
             "type": "response.output_item.added",
@@ -231,7 +231,7 @@ impl WsResponsesExecutor for FunctionCallWsExecutor {
                 "arguments": ""
             }
         });
-        let _ = outbound_tx.send(Message::Text(output_item_added.to_string().into()));
+        let _ = outbound_tx.try_send(Message::Text(output_item_added.to_string().into()));
 
         let args_delta = serde_json::json!({
             "type": "response.function_call_arguments.delta",
@@ -239,7 +239,7 @@ impl WsResponsesExecutor for FunctionCallWsExecutor {
             "item_id": item_id,
             "delta": arguments
         });
-        let _ = outbound_tx.send(Message::Text(args_delta.to_string().into()));
+        let _ = outbound_tx.try_send(Message::Text(args_delta.to_string().into()));
 
         let args_done = serde_json::json!({
             "type": "response.function_call_arguments.done",
@@ -247,7 +247,7 @@ impl WsResponsesExecutor for FunctionCallWsExecutor {
             "item_id": item_id,
             "arguments": arguments
         });
-        let _ = outbound_tx.send(Message::Text(args_done.to_string().into()));
+        let _ = outbound_tx.try_send(Message::Text(args_done.to_string().into()));
 
         let output_item_done = serde_json::json!({
             "type": "response.output_item.done",
@@ -261,7 +261,7 @@ impl WsResponsesExecutor for FunctionCallWsExecutor {
                 "arguments": arguments
             }
         });
-        let _ = outbound_tx.send(Message::Text(output_item_done.to_string().into()));
+        let _ = outbound_tx.try_send(Message::Text(output_item_done.to_string().into()));
 
         let response = ResponsesResponse::builder(response_id, request.model.clone())
             .copy_from_request(&request)
@@ -280,7 +280,7 @@ impl WsResponsesExecutor for FunctionCallWsExecutor {
             "type": "response.completed",
             "response": response,
         });
-        let _ = outbound_tx.send(Message::Text(completed.to_string().into()));
+        let _ = outbound_tx.try_send(Message::Text(completed.to_string().into()));
 
         Ok(CachedWsResponse {
             response: ResponsesResponse::builder(response_id, request.model.clone())
@@ -318,7 +318,7 @@ impl WsResponsesExecutor for FailedResponseWsExecutor {
         request: ResponsesRequest,
         _options: WsResponseCreateOptions,
         cached_response: Option<CachedWsResponse>,
-        outbound_tx: mpsc::UnboundedSender<Message>,
+        outbound_tx: mpsc::Sender<Message>,
     ) -> Result<CachedWsResponse, WsClientError> {
         if let Some(previous_id) = request.previous_response_id.as_deref() {
             if cached_response
@@ -374,13 +374,13 @@ impl WsResponsesExecutor for FailedResponseWsExecutor {
                 "output": []
             }
         });
-        let _ = outbound_tx.send(Message::Text(created.to_string().into()));
+        let _ = outbound_tx.try_send(Message::Text(created.to_string().into()));
 
         let completed = serde_json::json!({
             "type": "response.completed",
             "response": response.clone(),
         });
-        let _ = outbound_tx.send(Message::Text(completed.to_string().into()));
+        let _ = outbound_tx.try_send(Message::Text(completed.to_string().into()));
 
         Ok(CachedWsResponse {
             response,
@@ -567,7 +567,7 @@ impl WsResponsesExecutor for SemanticWsExecutor {
         request: ResponsesRequest,
         options: WsResponseCreateOptions,
         cached_response: Option<CachedWsResponse>,
-        outbound_tx: mpsc::UnboundedSender<Message>,
+        outbound_tx: mpsc::Sender<Message>,
     ) -> Result<CachedWsResponse, WsClientError> {
         if request.conversation.is_some() {
             return Err(WsClientError::new(
@@ -594,13 +594,13 @@ impl WsResponsesExecutor for SemanticWsExecutor {
                     "output": []
                 }
             });
-            let _ = outbound_tx.send(Message::Text(created.to_string().into()));
+            let _ = outbound_tx.try_send(Message::Text(created.to_string().into()));
 
             let completed = serde_json::json!({
                 "type": "response.completed",
                 "response": response,
             });
-            let _ = outbound_tx.send(Message::Text(completed.to_string().into()));
+            let _ = outbound_tx.try_send(Message::Text(completed.to_string().into()));
 
             return Ok(CachedWsResponse {
                 response: ResponsesResponse::builder(response_id, request.model.clone())
@@ -662,7 +662,7 @@ impl WsResponsesExecutor for SemanticWsExecutor {
                 "output": []
             }
         });
-        let _ = outbound_tx.send(Message::Text(created.to_string().into()));
+        let _ = outbound_tx.try_send(Message::Text(created.to_string().into()));
 
         let response = ResponsesResponse::builder(response_id.clone(), request.model.clone())
             .copy_from_request(&request)
@@ -683,7 +683,7 @@ impl WsResponsesExecutor for SemanticWsExecutor {
             "type": "response.completed",
             "response": response,
         });
-        let _ = outbound_tx.send(Message::Text(completed.to_string().into()));
+        let _ = outbound_tx.try_send(Message::Text(completed.to_string().into()));
 
         let cached = CachedWsResponse {
             response: response.clone(),
@@ -1416,4 +1416,188 @@ async fn test_v1_responses_ws_errors_echo_event_id() {
     assert_eq!(ws_error_code(error), "unsupported_parameter");
     assert_eq!(error["event_id"], "evt_ws_123");
     assert!(!ws_error_message(error).is_empty());
+}
+
+// ------------------------------------------------------------------
+// T1: WS backpressure / slow client test
+// ------------------------------------------------------------------
+
+/// Executor that floods the outbound channel with more messages than the
+/// bounded capacity (256) to exercise backpressure / try_send failure.
+#[derive(Clone)]
+struct FloodingWsExecutor {
+    message_count: usize,
+}
+
+#[async_trait]
+impl WsResponsesExecutor for FloodingWsExecutor {
+    async fn execute_response_create(
+        &self,
+        _headers: HeaderMap,
+        request: ResponsesRequest,
+        _options: WsResponseCreateOptions,
+        _cached_response: Option<CachedWsResponse>,
+        outbound_tx: mpsc::Sender<Message>,
+    ) -> Result<CachedWsResponse, WsClientError> {
+        let model = request.model.clone();
+
+        let created = serde_json::json!({
+            "type": "response.created",
+            "response": {
+                "id": "resp_flood",
+                "object": "response",
+                "status": "in_progress",
+                "model": model,
+                "output": []
+            }
+        });
+        let _ = outbound_tx.try_send(Message::Text(created.to_string().into()));
+
+        // Flood with delta events — more than the 256-slot channel capacity.
+        for i in 0..self.message_count {
+            let delta = serde_json::json!({
+                "type": "response.output_text.delta",
+                "delta": format!("tok_{}", i)
+            });
+            // try_send will fail once the channel is full — that's expected.
+            if outbound_tx
+                .try_send(Message::Text(delta.to_string().into()))
+                .is_err()
+            {
+                break;
+            }
+        }
+
+        let response = ResponsesResponse::builder("resp_flood", request.model.clone())
+            .copy_from_request(&request)
+            .status(ResponseStatus::Completed)
+            .output(vec![])
+            .build();
+
+        let completed = serde_json::json!({
+            "type": "response.completed",
+            "response": response.clone(),
+        });
+        let _ = outbound_tx.try_send(Message::Text(completed.to_string().into()));
+
+        Ok(CachedWsResponse {
+            response,
+            input_items: vec![],
+        })
+    }
+}
+
+#[tokio::test]
+async fn test_v1_responses_ws_backpressure_slow_client() {
+    let url = serve_app(
+        build_stub_app(Arc::new(FloodingWsExecutor {
+            // Well above the 256-slot bounded channel.
+            message_count: 512,
+        }))
+        .await,
+    )
+    .await;
+
+    let (mut socket, _) = connect_async(format!("{}/v1/responses", url))
+        .await
+        .unwrap();
+
+    // Send request then deliberately read slowly — the server should
+    // not OOM; try_send should drop excess messages gracefully.
+    socket
+        .send(tokio_tungstenite::tungstenite::Message::Text(
+            ws_create_request(serde_json::json!({
+                "model": "mock-model",
+                "input": "Slow reader backpressure test",
+                "store": false
+            }))
+            .to_string()
+            .into(),
+        ))
+        .await
+        .unwrap();
+
+    // Give the executor time to flood the channel.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Drain whatever we can — we may not get all 512 deltas, but the
+    // connection should be alive or cleanly closed, never a panic/OOM.
+    let mut received = 0;
+    while let Ok(Some(Ok(_msg))) = tokio::time::timeout(Duration::from_secs(2), socket.next()).await
+    {
+        received += 1;
+    }
+
+    // We should have received at least the initial `response.created`.
+    assert!(
+        received >= 1,
+        "should receive at least response.created, got {received}"
+    );
+    // And fewer than the total flood count (some dropped by backpressure).
+    assert!(
+        received <= 512 + 3, // +3 for created/completed/close
+        "received count should be bounded, got {received}"
+    );
+}
+
+// ------------------------------------------------------------------
+// T2: No-WS-router error test
+// ------------------------------------------------------------------
+
+/// A router that does NOT support WebSocket Responses.
+#[derive(Debug, Clone)]
+struct NoWsRouter;
+
+#[async_trait]
+impl RouterTrait for NoWsRouter {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    async fn route_chat(
+        &self,
+        _headers: Option<&HeaderMap>,
+        _body: &smg::protocols::chat::ChatCompletionRequest,
+        _model_id: Option<&str>,
+    ) -> Response {
+        StatusCode::NOT_IMPLEMENTED.into_response()
+    }
+
+    fn supports_responses_ws(&self) -> bool {
+        false
+    }
+
+    fn router_type(&self) -> &'static str {
+        "no-ws"
+    }
+}
+
+#[tokio::test]
+async fn test_v1_responses_ws_no_ws_router_returns_structured_error() {
+    // When no router supports WS, the server rejects the upgrade at the
+    // HTTP level (server.rs checks supports_responses_ws() before upgrade).
+    // Verify the HTTP error response contains structured JSON.
+    let ctx = create_test_app_context().await;
+    let app = create_test_app_with_context(Arc::new(NoWsRouter), ctx);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/responses")
+                .header("upgrade", "websocket")
+                .header("connection", "Upgrade")
+                .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+                .header("sec-websocket-version", "13")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
+    assert_eq!(
+        smg::routers::error::extract_error_code_from_response(&response),
+        "responses_ws_not_supported"
+    );
 }

--- a/sgl-model-gateway/tests/api/responses_ws_test.rs
+++ b/sgl-model-gateway/tests/api/responses_ws_test.rs
@@ -1,0 +1,1419 @@
+use std::{collections::HashMap, fmt, sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use axum::{
+    body::Body,
+    extract::ws::{Message, WebSocket},
+    http::{HeaderMap, Request, StatusCode},
+    response::{IntoResponse, Response},
+};
+use futures_util::{SinkExt, StreamExt};
+use smg::{
+    core::WorkerRegistry,
+    protocols::responses::{
+        ResponseContentPart, ResponseInputOutputItem, ResponseOutputItem, ResponseStatus,
+        ResponsesRequest, ResponsesResponse,
+    },
+    routers::{
+        router_manager::{router_ids, RouterManager},
+        ws_responses::{
+            serve_responses_ws_with_config, CachedWsResponse, WsClientError,
+            WsResponseCreateOptions, WsResponsesExecutor, WsRuntimeConfig,
+        },
+        RouterTrait,
+    },
+};
+use tokio::{
+    net::TcpListener,
+    sync::{mpsc, Notify},
+};
+use tokio_tungstenite::connect_async;
+use tower::ServiceExt;
+
+use crate::common::test_app::{create_test_app_context, create_test_app_with_context};
+
+#[derive(Clone)]
+struct StubWsExecutor {
+    gate: Option<Arc<Notify>>,
+}
+
+impl StubWsExecutor {
+    fn immediate() -> Self {
+        Self { gate: None }
+    }
+
+    fn gated(gate: Arc<Notify>) -> Self {
+        Self { gate: Some(gate) }
+    }
+}
+
+#[derive(Clone)]
+struct DelayedReturnWsExecutor {
+    return_delay: Duration,
+}
+
+impl DelayedReturnWsExecutor {
+    fn new(return_delay: Duration) -> Self {
+        Self { return_delay }
+    }
+}
+
+#[async_trait]
+impl WsResponsesExecutor for StubWsExecutor {
+    async fn execute_response_create(
+        &self,
+        _headers: HeaderMap,
+        request: ResponsesRequest,
+        _options: WsResponseCreateOptions,
+        _cached_response: Option<CachedWsResponse>,
+        outbound_tx: mpsc::UnboundedSender<Message>,
+    ) -> Result<CachedWsResponse, WsClientError> {
+        let model = request.model.clone();
+        let created = serde_json::json!({
+            "type": "response.created",
+            "response": {
+                "id": "resp_ws_test",
+                "object": "response",
+                "status": "in_progress",
+                "model": model,
+                "output": []
+            }
+        });
+        let _ = outbound_tx.send(Message::Text(created.to_string().into()));
+
+        if let Some(gate) = &self.gate {
+            gate.notified().await;
+        }
+
+        let output_text = "stub websocket output";
+        let response = ResponsesResponse::builder("resp_ws_test", request.model.clone())
+            .copy_from_request(&request)
+            .status(ResponseStatus::Completed)
+            .output(vec![ResponseOutputItem::Message {
+                id: "msg_ws_test".to_string(),
+                role: "assistant".to_string(),
+                content: vec![ResponseContentPart::OutputText {
+                    text: output_text.to_string(),
+                    annotations: vec![],
+                    logprobs: None,
+                }],
+                status: "completed".to_string(),
+            }])
+            .build();
+
+        let completed = serde_json::json!({
+            "type": "response.completed",
+            "response": response,
+        });
+        let _ = outbound_tx.send(Message::Text(completed.to_string().into()));
+
+        Ok(CachedWsResponse {
+            response: ResponsesResponse::builder("resp_ws_test", request.model.clone())
+                .copy_from_request(&request)
+                .status(ResponseStatus::Completed)
+                .output(vec![ResponseOutputItem::Message {
+                    id: "msg_ws_test".to_string(),
+                    role: "assistant".to_string(),
+                    content: vec![ResponseContentPart::OutputText {
+                        text: output_text.to_string(),
+                        annotations: vec![],
+                        logprobs: None,
+                    }],
+                    status: "completed".to_string(),
+                }])
+                .build(),
+            input_items: vec![ResponseInputOutputItem::Message {
+                id: "msg_user_ws_test".to_string(),
+                role: "user".to_string(),
+                content: vec![ResponseContentPart::InputText {
+                    text: "Hello websocket".to_string(),
+                }],
+                status: Some("completed".to_string()),
+            }],
+        })
+    }
+}
+
+#[async_trait]
+impl WsResponsesExecutor for DelayedReturnWsExecutor {
+    async fn execute_response_create(
+        &self,
+        _headers: HeaderMap,
+        request: ResponsesRequest,
+        _options: WsResponseCreateOptions,
+        _cached_response: Option<CachedWsResponse>,
+        outbound_tx: mpsc::UnboundedSender<Message>,
+    ) -> Result<CachedWsResponse, WsClientError> {
+        let output_text = "delayed websocket output";
+        let response = ResponsesResponse::builder("resp_ws_delayed", request.model.clone())
+            .copy_from_request(&request)
+            .status(ResponseStatus::Completed)
+            .output(vec![ResponseOutputItem::Message {
+                id: "msg_ws_delayed".to_string(),
+                role: "assistant".to_string(),
+                content: vec![ResponseContentPart::OutputText {
+                    text: output_text.to_string(),
+                    annotations: vec![],
+                    logprobs: None,
+                }],
+                status: "completed".to_string(),
+            }])
+            .build();
+
+        let created = serde_json::json!({
+            "type": "response.created",
+            "response": {
+                "id": response.id,
+                "object": "response",
+                "status": "in_progress",
+                "model": request.model,
+                "output": []
+            }
+        });
+        let _ = outbound_tx.send(Message::Text(created.to_string().into()));
+
+        let completed = serde_json::json!({
+            "type": "response.completed",
+            "response": response.clone(),
+        });
+        let _ = outbound_tx.send(Message::Text(completed.to_string().into()));
+
+        tokio::time::sleep(self.return_delay).await;
+
+        Ok(CachedWsResponse {
+            response,
+            input_items: vec![],
+        })
+    }
+}
+
+#[derive(Clone, Default)]
+struct FunctionCallWsExecutor;
+
+#[async_trait]
+impl WsResponsesExecutor for FunctionCallWsExecutor {
+    async fn execute_response_create(
+        &self,
+        _headers: HeaderMap,
+        request: ResponsesRequest,
+        _options: WsResponseCreateOptions,
+        _cached_response: Option<CachedWsResponse>,
+        outbound_tx: mpsc::UnboundedSender<Message>,
+    ) -> Result<CachedWsResponse, WsClientError> {
+        let response_id = "resp_ws_tool_test";
+        let item_id = "fc_ws_test";
+        let call_id = "call_ws_test";
+        let tool_name = "search_repo";
+        let arguments = r#"{"query":"fizz_buzz"}"#;
+        let model = request.model.clone();
+
+        let created = serde_json::json!({
+            "type": "response.created",
+            "response": {
+                "id": response_id,
+                "object": "response",
+                "status": "in_progress",
+                "model": model,
+                "output": []
+            }
+        });
+        let _ = outbound_tx.send(Message::Text(created.to_string().into()));
+
+        let output_item_added = serde_json::json!({
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": {
+                "id": item_id,
+                "type": "function_call",
+                "call_id": call_id,
+                "name": tool_name,
+                "status": "in_progress",
+                "arguments": ""
+            }
+        });
+        let _ = outbound_tx.send(Message::Text(output_item_added.to_string().into()));
+
+        let args_delta = serde_json::json!({
+            "type": "response.function_call_arguments.delta",
+            "output_index": 0,
+            "item_id": item_id,
+            "delta": arguments
+        });
+        let _ = outbound_tx.send(Message::Text(args_delta.to_string().into()));
+
+        let args_done = serde_json::json!({
+            "type": "response.function_call_arguments.done",
+            "output_index": 0,
+            "item_id": item_id,
+            "arguments": arguments
+        });
+        let _ = outbound_tx.send(Message::Text(args_done.to_string().into()));
+
+        let output_item_done = serde_json::json!({
+            "type": "response.output_item.done",
+            "output_index": 0,
+            "item": {
+                "id": item_id,
+                "type": "function_call",
+                "call_id": call_id,
+                "name": tool_name,
+                "status": "completed",
+                "arguments": arguments
+            }
+        });
+        let _ = outbound_tx.send(Message::Text(output_item_done.to_string().into()));
+
+        let response = ResponsesResponse::builder(response_id, request.model.clone())
+            .copy_from_request(&request)
+            .status(ResponseStatus::Completed)
+            .output(vec![ResponseOutputItem::FunctionToolCall {
+                id: item_id.to_string(),
+                call_id: call_id.to_string(),
+                name: tool_name.to_string(),
+                arguments: arguments.to_string(),
+                output: None,
+                status: "completed".to_string(),
+            }])
+            .build();
+
+        let completed = serde_json::json!({
+            "type": "response.completed",
+            "response": response,
+        });
+        let _ = outbound_tx.send(Message::Text(completed.to_string().into()));
+
+        Ok(CachedWsResponse {
+            response: ResponsesResponse::builder(response_id, request.model.clone())
+                .copy_from_request(&request)
+                .status(ResponseStatus::Completed)
+                .output(vec![ResponseOutputItem::FunctionToolCall {
+                    id: item_id.to_string(),
+                    call_id: call_id.to_string(),
+                    name: tool_name.to_string(),
+                    arguments: arguments.to_string(),
+                    output: None,
+                    status: "completed".to_string(),
+                }])
+                .build(),
+            input_items: vec![ResponseInputOutputItem::Message {
+                id: "msg_user_ws_tool_test".to_string(),
+                role: "user".to_string(),
+                content: vec![ResponseContentPart::InputText {
+                    text: "Call the search tool.".to_string(),
+                }],
+                status: Some("completed".to_string()),
+            }],
+        })
+    }
+}
+
+#[derive(Clone, Default)]
+struct FailedResponseWsExecutor;
+
+#[async_trait]
+impl WsResponsesExecutor for FailedResponseWsExecutor {
+    async fn execute_response_create(
+        &self,
+        _headers: HeaderMap,
+        request: ResponsesRequest,
+        _options: WsResponseCreateOptions,
+        cached_response: Option<CachedWsResponse>,
+        outbound_tx: mpsc::UnboundedSender<Message>,
+    ) -> Result<CachedWsResponse, WsClientError> {
+        if let Some(previous_id) = request.previous_response_id.as_deref() {
+            if cached_response
+                .as_ref()
+                .is_some_and(|cached| cached.response.id == previous_id)
+            {
+                return Ok(CachedWsResponse {
+                    response: ResponsesResponse::builder(
+                        "resp_ws_unexpected_cached_reuse",
+                        request.model.clone(),
+                    )
+                    .copy_from_request(&request)
+                    .status(ResponseStatus::Completed)
+                    .output(vec![ResponseOutputItem::Message {
+                        id: "msg_ws_unexpected_cached_reuse".to_string(),
+                        role: "assistant".to_string(),
+                        content: vec![ResponseContentPart::OutputText {
+                            text: "unexpected cached continuation".to_string(),
+                            annotations: vec![],
+                            logprobs: None,
+                        }],
+                        status: "completed".to_string(),
+                    }])
+                    .build(),
+                    input_items: vec![],
+                });
+            }
+
+            return Err(WsClientError::new(
+                "previous_response_not_found",
+                format!(
+                    "Previous response '{}' was not found in the current session or durable storage.",
+                    previous_id
+                ),
+            )
+            .with_param("previous_response_id"));
+        }
+
+        let response = ResponsesResponse::builder("resp_ws_failed", request.model.clone())
+            .copy_from_request(&request)
+            .status(ResponseStatus::Failed)
+            .output(vec![])
+            .build();
+        let response_model = request.model.clone();
+
+        let created = serde_json::json!({
+            "type": "response.created",
+            "response": {
+                "id": "resp_ws_failed",
+                "object": "response",
+                "status": "in_progress",
+                "model": response_model,
+                "output": []
+            }
+        });
+        let _ = outbound_tx.send(Message::Text(created.to_string().into()));
+
+        let completed = serde_json::json!({
+            "type": "response.completed",
+            "response": response.clone(),
+        });
+        let _ = outbound_tx.send(Message::Text(completed.to_string().into()));
+
+        Ok(CachedWsResponse {
+            response,
+            input_items: vec![],
+        })
+    }
+}
+
+#[derive(Clone)]
+struct StubWsRouter {
+    executor: Arc<dyn WsResponsesExecutor>,
+    runtime_config: WsRuntimeConfig,
+}
+
+impl fmt::Debug for StubWsRouter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("StubWsRouter")
+    }
+}
+
+#[async_trait]
+impl RouterTrait for StubWsRouter {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    async fn route_chat(
+        &self,
+        _headers: Option<&HeaderMap>,
+        _body: &smg::protocols::chat::ChatCompletionRequest,
+        _model_id: Option<&str>,
+    ) -> Response {
+        StatusCode::NOT_IMPLEMENTED.into_response()
+    }
+
+    fn supports_responses_ws(&self) -> bool {
+        true
+    }
+
+    async fn route_responses_ws(&self, headers: HeaderMap, socket: WebSocket) {
+        serve_responses_ws_with_config(
+            socket,
+            headers,
+            self.executor.clone(),
+            self.runtime_config.clone(),
+        )
+        .await;
+    }
+
+    fn router_type(&self) -> &'static str {
+        "stub-ws"
+    }
+}
+
+async fn build_stub_app(executor: Arc<dyn WsResponsesExecutor>) -> axum::Router {
+    build_stub_app_with_runtime_config(executor, WsRuntimeConfig::default()).await
+}
+
+async fn build_stub_app_with_runtime_config(
+    executor: Arc<dyn WsResponsesExecutor>,
+    runtime_config: WsRuntimeConfig,
+) -> axum::Router {
+    let ctx = create_test_app_context().await;
+    let router = Arc::new(StubWsRouter {
+        executor,
+        runtime_config,
+    });
+    create_test_app_with_context(router, ctx)
+}
+
+async fn serve_app(app: axum::Router) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("ws://{}", addr)
+}
+
+async fn recv_json(
+    socket: &mut tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+) -> serde_json::Value {
+    loop {
+        let message = tokio::time::timeout(Duration::from_secs(3), socket.next())
+            .await
+            .expect("timed out waiting for websocket message")
+            .expect("websocket stream ended")
+            .expect("websocket receive failed");
+
+        match message {
+            tokio_tungstenite::tungstenite::Message::Text(text) => {
+                return serde_json::from_str(text.as_ref()).expect("message should be valid JSON");
+            }
+            tokio_tungstenite::tungstenite::Message::Ping(_) => continue,
+            tokio_tungstenite::tungstenite::Message::Pong(_) => continue,
+            tokio_tungstenite::tungstenite::Message::Close(frame) => {
+                panic!("unexpected websocket close frame: {:?}", frame)
+            }
+            other => panic!("unexpected websocket message: {:?}", other),
+        }
+    }
+}
+
+async fn send_ws_request_and_collect(
+    socket: &mut tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+    request: serde_json::Value,
+) -> Vec<serde_json::Value> {
+    socket
+        .send(tokio_tungstenite::tungstenite::Message::Text(
+            request.to_string().into(),
+        ))
+        .await
+        .unwrap();
+
+    let mut events = Vec::new();
+    loop {
+        let event = recv_json(socket).await;
+        let is_terminal = matches!(
+            event["type"].as_str(),
+            Some("response.completed") | Some("error")
+        );
+        events.push(event);
+        if is_terminal {
+            break;
+        }
+    }
+
+    events
+}
+
+fn ws_create_request(response_fields: serde_json::Value) -> serde_json::Value {
+    let serde_json::Value::Object(mut request) = response_fields else {
+        panic!("response.create request fields must be a JSON object");
+    };
+    request.insert(
+        "type".to_string(),
+        serde_json::Value::String("response.create".to_string()),
+    );
+    serde_json::Value::Object(request)
+}
+
+fn ws_error_code(event: &serde_json::Value) -> &str {
+    event
+        .pointer("/error/code")
+        .and_then(|value| value.as_str())
+        .or_else(|| event.get("code").and_then(|value| value.as_str()))
+        .unwrap_or("")
+}
+
+fn ws_error_message(event: &serde_json::Value) -> &str {
+    event
+        .pointer("/error/message")
+        .and_then(|value| value.as_str())
+        .or_else(|| event.get("message").and_then(|value| value.as_str()))
+        .unwrap_or("")
+}
+
+fn ws_error_param(event: &serde_json::Value) -> Option<&str> {
+    event
+        .pointer("/error/param")
+        .and_then(|value| value.as_str())
+}
+
+#[derive(Clone, Default)]
+struct SemanticWsExecutor {
+    durable_store: Arc<std::sync::Mutex<HashMap<String, CachedWsResponse>>>,
+}
+
+impl SemanticWsExecutor {
+    fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl WsResponsesExecutor for SemanticWsExecutor {
+    async fn execute_response_create(
+        &self,
+        _headers: HeaderMap,
+        request: ResponsesRequest,
+        options: WsResponseCreateOptions,
+        cached_response: Option<CachedWsResponse>,
+        outbound_tx: mpsc::UnboundedSender<Message>,
+    ) -> Result<CachedWsResponse, WsClientError> {
+        if request.conversation.is_some() {
+            return Err(WsClientError::new(
+                "unsupported_parameter",
+                "The `conversation` field is not supported in WebSocket Responses V1.",
+            ));
+        }
+
+        if options.generate == Some(false) {
+            let response_id = format!("resp_ws_{}", uuid::Uuid::new_v4().simple());
+            let response = ResponsesResponse::builder(response_id.clone(), request.model.clone())
+                .copy_from_request(&request)
+                .status(ResponseStatus::Completed)
+                .output(vec![])
+                .build();
+
+            let created = serde_json::json!({
+                "type": "response.created",
+                "response": {
+                    "id": response_id.clone(),
+                    "object": "response",
+                    "status": "in_progress",
+                    "model": request.model.clone(),
+                    "output": []
+                }
+            });
+            let _ = outbound_tx.send(Message::Text(created.to_string().into()));
+
+            let completed = serde_json::json!({
+                "type": "response.completed",
+                "response": response,
+            });
+            let _ = outbound_tx.send(Message::Text(completed.to_string().into()));
+
+            return Ok(CachedWsResponse {
+                response: ResponsesResponse::builder(response_id, request.model.clone())
+                    .copy_from_request(&request)
+                    .status(ResponseStatus::Completed)
+                    .output(vec![])
+                    .build(),
+                input_items: vec![ResponseInputOutputItem::Message {
+                    id: "msg_user_ws_semantic".to_string(),
+                    role: "user".to_string(),
+                    content: vec![ResponseContentPart::InputText {
+                        text: "Hello websocket".to_string(),
+                    }],
+                    status: Some("completed".to_string()),
+                }],
+            });
+        }
+
+        let previous_response = if let Some(previous_id) = request.previous_response_id.as_deref() {
+            if let Some(cached) = cached_response.filter(|cached| cached.response.id == previous_id)
+            {
+                Some(cached)
+            } else {
+                self.durable_store
+                    .lock()
+                    .unwrap()
+                    .get(previous_id)
+                    .cloned()
+                    .ok_or_else(|| {
+                        WsClientError::new(
+                            "previous_response_not_found",
+                            format!(
+                                "Previous response '{}' was not found in the current session or durable storage.",
+                                previous_id
+                            ),
+                        )
+                        .with_param("previous_response_id")
+                    })?
+                    .into()
+            }
+        } else {
+            None
+        };
+
+        let response_id = format!("resp_ws_{}", uuid::Uuid::new_v4().simple());
+        let output_text = if previous_response.is_some() {
+            "stub websocket continuation output"
+        } else {
+            "stub websocket output"
+        };
+
+        let created = serde_json::json!({
+            "type": "response.created",
+            "response": {
+                "id": response_id,
+                "object": "response",
+                "status": "in_progress",
+                "model": request.model.clone(),
+                "output": []
+            }
+        });
+        let _ = outbound_tx.send(Message::Text(created.to_string().into()));
+
+        let response = ResponsesResponse::builder(response_id.clone(), request.model.clone())
+            .copy_from_request(&request)
+            .status(ResponseStatus::Completed)
+            .output(vec![ResponseOutputItem::Message {
+                id: "msg_ws_semantic".to_string(),
+                role: "assistant".to_string(),
+                content: vec![ResponseContentPart::OutputText {
+                    text: output_text.to_string(),
+                    annotations: vec![],
+                    logprobs: None,
+                }],
+                status: "completed".to_string(),
+            }])
+            .build();
+
+        let completed = serde_json::json!({
+            "type": "response.completed",
+            "response": response,
+        });
+        let _ = outbound_tx.send(Message::Text(completed.to_string().into()));
+
+        let cached = CachedWsResponse {
+            response: response.clone(),
+            input_items: vec![ResponseInputOutputItem::Message {
+                id: "msg_user_ws_semantic".to_string(),
+                role: "user".to_string(),
+                content: vec![ResponseContentPart::InputText {
+                    text: "Hello websocket".to_string(),
+                }],
+                status: Some("completed".to_string()),
+            }],
+        };
+
+        if request.store.unwrap_or(true) {
+            self.durable_store
+                .lock()
+                .unwrap()
+                .insert(cached.response.id.clone(), cached.clone());
+        }
+
+        Ok(cached)
+    }
+}
+
+#[tokio::test]
+async fn test_v1_responses_get_requires_websocket_upgrade() {
+    let app = build_stub_app(Arc::new(StubWsExecutor::immediate())).await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/responses")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        smg::routers::error::extract_error_code_from_response(&response),
+        "websocket_upgrade_required"
+    );
+}
+
+#[tokio::test]
+async fn test_v1_responses_ws_rejects_unknown_event_type() {
+    let url = serve_app(build_stub_app(Arc::new(StubWsExecutor::immediate())).await).await;
+    let (mut socket, _) = connect_async(format!("{}/v1/responses", url))
+        .await
+        .unwrap();
+
+    socket
+        .send(tokio_tungstenite::tungstenite::Message::Text(
+            serde_json::json!({ "type": "response.delete" })
+                .to_string()
+                .into(),
+        ))
+        .await
+        .unwrap();
+
+    let event = recv_json(&mut socket).await;
+    assert_eq!(event["type"], "error");
+    assert_eq!(ws_error_code(&event), "unsupported_event");
+}
+
+#[tokio::test]
+async fn test_v1_responses_ws_rejects_invalid_json() {
+    let url = serve_app(build_stub_app(Arc::new(StubWsExecutor::immediate())).await).await;
+    let (mut socket, _) = connect_async(format!("{}/v1/responses", url))
+        .await
+        .unwrap();
+
+    socket
+        .send(tokio_tungstenite::tungstenite::Message::Text(
+            "{\"type\":\"response.create\"".into(),
+        ))
+        .await
+        .unwrap();
+
+    let event = recv_json(&mut socket).await;
+    assert_eq!(event["type"], "error");
+    assert_eq!(ws_error_code(&event), "invalid_json");
+}
+
+#[tokio::test]
+async fn test_v1_responses_ws_rejects_binary_messages() {
+    let url = serve_app(build_stub_app(Arc::new(StubWsExecutor::immediate())).await).await;
+    let (mut socket, _) = connect_async(format!("{}/v1/responses", url))
+        .await
+        .unwrap();
+
+    socket
+        .send(tokio_tungstenite::tungstenite::Message::Binary(
+            vec![0xde, 0xad, 0xbe, 0xef].into(),
+        ))
+        .await
+        .unwrap();
+
+    let event = recv_json(&mut socket).await;
+    assert_eq!(event["type"], "error");
+    assert_eq!(ws_error_code(&event), "unsupported_message_type");
+}
+
+#[tokio::test]
+async fn test_v1_responses_ws_replies_to_ping_and_keeps_session_healthy() {
+    let url = serve_app(build_stub_app(Arc::new(StubWsExecutor::immediate())).await).await;
+    let (mut socket, _) = connect_async(format!("{}/v1/responses", url))
+        .await
+        .unwrap();
+
+    let ping_payload = vec![0x1, 0x2, 0x3, 0x4];
+    socket
+        .send(tokio_tungstenite::tungstenite::Message::Ping(
+            ping_payload.clone().into(),
+        ))
+        .await
+        .unwrap();
+
+    let pong = tokio::time::timeout(Duration::from_secs(3), socket.next())
+        .await
+        .expect("timed out waiting for pong")
+        .expect("websocket stream ended")
+        .expect("websocket receive failed");
+
+    match pong {
+        tokio_tungstenite::tungstenite::Message::Pong(payload) => {
+            assert_eq!(payload.as_ref(), ping_payload.as_slice());
+        }
+        other => panic!("expected pong after ping, got {:?}", other),
+    }
+
+    let events = send_ws_request_and_collect(
+        &mut socket,
+        ws_create_request(serde_json::json!({
+            "model": "mock-model",
+            "input": "Hello websocket after ping",
+            "store": false
+        })),
+    )
+    .await;
+
+    let completed = events.last().unwrap();
+    assert_eq!(completed["type"], "response.completed");
+}
+
+#[tokio::test]
+async fn test_v1_responses_ws_closes_when_session_lifetime_expires() {
+    let url = serve_app(
+        build_stub_app_with_runtime_config(
+            Arc::new(StubWsExecutor::immediate()),
+            WsRuntimeConfig {
+                max_session_lifetime: Duration::from_millis(50),
+            },
+        )
+        .await,
+    )
+    .await;
+    let (mut socket, _) = connect_async(format!("{}/v1/responses", url))
+        .await
+        .unwrap();
+
+    let error = recv_json(&mut socket).await;
+    assert_eq!(error["type"], "error");
+    assert_eq!(ws_error_code(&error), "websocket_connection_limit_reached");
+
+    let close_message = tokio::time::timeout(Duration::from_secs(2), socket.next())
+        .await
+        .expect("timed out waiting for websocket close")
+        .expect("websocket stream ended without close frame")
+        .expect("websocket receive failed");
+
+    match close_message {
+        tokio_tungstenite::tungstenite::Message::Close(frame) => {
+            let frame = frame.expect("expected server close frame");
+            assert_eq!(
+                frame.reason.to_string(),
+                "Responses websocket connection limit reached (50 ms). Create a new websocket connection to continue."
+            );
+        }
+        other => panic!("expected websocket close frame, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_v1_responses_ws_response_create_streams_events() {
+    let url = serve_app(build_stub_app(Arc::new(StubWsExecutor::immediate())).await).await;
+    let (mut socket, _) = connect_async(format!("{}/v1/responses", url))
+        .await
+        .unwrap();
+
+    socket
+        .send(tokio_tungstenite::tungstenite::Message::Text(
+            ws_create_request(serde_json::json!({
+                "model": "mock-model",
+                "input": "Hello websocket",
+                "store": false
+            }))
+            .to_string()
+            .into(),
+        ))
+        .await
+        .unwrap();
+
+    let created = recv_json(&mut socket).await;
+    let completed = recv_json(&mut socket).await;
+
+    assert_eq!(created["type"], "response.created");
+    assert_eq!(completed["type"], "response.completed");
+    assert_eq!(
+        completed["response"]["output"][0]["content"][0]["text"],
+        "stub websocket output"
+    );
+}
+
+#[tokio::test]
+async fn test_v1_responses_ws_function_call_events_stream_cleanly() {
+    let url = serve_app(build_stub_app(Arc::new(FunctionCallWsExecutor)).await).await;
+    let (mut socket, _) = connect_async(format!("{}/v1/responses", url))
+        .await
+        .unwrap();
+
+    let events = send_ws_request_and_collect(
+        &mut socket,
+        ws_create_request(serde_json::json!({
+            "model": "mock-model",
+            "input": "Call the tool",
+            "store": false
+        })),
+    )
+    .await;
+
+    let event_types: Vec<_> = events
+        .iter()
+        .map(|event| event["type"].as_str().unwrap_or(""))
+        .collect();
+
+    assert_eq!(
+        event_types,
+        vec![
+            "response.created",
+            "response.output_item.added",
+            "response.function_call_arguments.delta",
+            "response.function_call_arguments.done",
+            "response.output_item.done",
+            "response.completed",
+        ]
+    );
+    assert_eq!(events[1]["item"]["type"], "function_call");
+    assert_eq!(events[2]["delta"], r#"{"query":"fizz_buzz"}"#);
+    assert_eq!(events[3]["arguments"], r#"{"query":"fizz_buzz"}"#);
+    assert_eq!(events[4]["item"]["call_id"], "call_ws_test");
+    assert_eq!(events[4]["item"]["name"], "search_repo");
+    assert_eq!(
+        events.last().unwrap()["response"]["output"][0]["call_id"],
+        "call_ws_test"
+    );
+    assert_eq!(
+        events.last().unwrap()["response"]["output"][0]["arguments"],
+        r#"{"query":"fizz_buzz"}"#
+    );
+}
+
+#[tokio::test]
+async fn test_v1_responses_ws_accepts_top_level_response_create_payload() {
+    let url = serve_app(build_stub_app(Arc::new(StubWsExecutor::immediate())).await).await;
+    let (mut socket, _) = connect_async(format!("{}/v1/responses", url))
+        .await
+        .unwrap();
+
+    let events = send_ws_request_and_collect(
+        &mut socket,
+        ws_create_request(serde_json::json!({
+            "model": "mock-model",
+            "input": "Top level websocket request",
+            "store": false,
+            "tools": []
+        })),
+    )
+    .await;
+
+    let completed = events.last().unwrap();
+    assert_eq!(events[0]["type"], "response.created");
+    assert_eq!(completed["type"], "response.completed");
+}
+
+#[tokio::test]
+async fn test_v1_responses_ws_accepts_structured_input_items() {
+    let url = serve_app(build_stub_app(Arc::new(StubWsExecutor::immediate())).await).await;
+    let (mut socket, _) = connect_async(format!("{}/v1/responses", url))
+        .await
+        .unwrap();
+
+    let request = serde_json::json!({
+        "type": "response.create",
+        "model": "mock-model",
+        "input": [{
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "Say hello from a structured input."}]
+        }],
+        "store": false
+    });
+
+    let events = send_ws_request_and_collect(&mut socket, request).await;
+    let completed = events.last().unwrap();
+
+    assert_eq!(events[0]["type"], "response.created");
+    assert_eq!(completed["type"], "response.completed");
+}
+
+#[tokio::test]
+async fn test_v1_responses_ws_rejects_second_inflight_request() {
+    let gate = Arc::new(Notify::new());
+    let url = serve_app(build_stub_app(Arc::new(StubWsExecutor::gated(gate.clone()))).await).await;
+    let (mut socket, _) = connect_async(format!("{}/v1/responses", url))
+        .await
+        .unwrap();
+
+    let request = ws_create_request(serde_json::json!({
+        "model": "mock-model",
+        "input": "Hello websocket",
+        "store": false
+    }));
+
+    socket
+        .send(tokio_tungstenite::tungstenite::Message::Text(
+            request.to_string().into(),
+        ))
+        .await
+        .unwrap();
+
+    let created = recv_json(&mut socket).await;
+    assert_eq!(created["type"], "response.created");
+
+    socket
+        .send(tokio_tungstenite::tungstenite::Message::Text(
+            request.to_string().into(),
+        ))
+        .await
+        .unwrap();
+
+    let error = recv_json(&mut socket).await;
+    assert_eq!(error["type"], "error");
+    assert_eq!(ws_error_code(&error), "concurrent_response_create");
+
+    gate.notify_waiters();
+    let completed = recv_json(&mut socket).await;
+    assert_eq!(completed["type"], "response.completed");
+}
+
+#[tokio::test]
+async fn test_v1_responses_ws_via_router_manager_streams_events() {
+    let ctx = create_test_app_context().await;
+    let manager = Arc::new(RouterManager::new(Arc::new(WorkerRegistry::new())));
+    manager.register_router(
+        router_ids::GRPC_REGULAR,
+        Arc::new(StubWsRouter {
+            executor: Arc::new(StubWsExecutor::immediate()),
+            runtime_config: WsRuntimeConfig::default(),
+        }),
+    );
+
+    let app = create_test_app_with_context(manager as Arc<dyn RouterTrait>, ctx);
+    let url = serve_app(app).await;
+    let (mut socket, _) = connect_async(format!("{}/v1/responses", url))
+        .await
+        .unwrap();
+
+    socket
+        .send(tokio_tungstenite::tungstenite::Message::Text(
+            ws_create_request(serde_json::json!({
+                "model": "mock-model",
+                "input": "Hello websocket",
+                "store": false
+            }))
+            .to_string()
+            .into(),
+        ))
+        .await
+        .unwrap();
+
+    let created = recv_json(&mut socket).await;
+    let completed = recv_json(&mut socket).await;
+
+    assert_eq!(created["type"], "response.created");
+    assert_eq!(completed["type"], "response.completed");
+    assert_eq!(
+        completed["response"]["output"][0]["content"][0]["text"],
+        "stub websocket output"
+    );
+}
+
+#[tokio::test]
+async fn test_v1_responses_ws_same_connection_store_false_continuation_completes() {
+    let url = serve_app(build_stub_app(Arc::new(SemanticWsExecutor::new())).await).await;
+    let (mut socket, _) = connect_async(format!("{}/v1/responses", url))
+        .await
+        .unwrap();
+
+    let first_events = send_ws_request_and_collect(
+        &mut socket,
+        ws_create_request(serde_json::json!({
+            "model": "mock-model",
+            "input": "First websocket turn",
+            "store": false
+        })),
+    )
+    .await;
+    let first_completed = first_events.last().unwrap();
+    assert_eq!(first_completed["type"], "response.completed");
+
+    let response_id = first_completed["response"]["id"]
+        .as_str()
+        .expect("completed response should include id")
+        .to_string();
+
+    let second_events = send_ws_request_and_collect(
+        &mut socket,
+        ws_create_request(serde_json::json!({
+            "model": "mock-model",
+            "input": "Follow up websocket turn",
+            "previous_response_id": response_id,
+            "store": false
+        })),
+    )
+    .await;
+
+    let second_completed = second_events.last().unwrap();
+    assert_eq!(second_completed["type"], "response.completed");
+
+    let second_response_id = second_completed["response"]["id"]
+        .as_str()
+        .expect("completed response should include id")
+        .to_string();
+
+    let third_events = send_ws_request_and_collect(
+        &mut socket,
+        ws_create_request(serde_json::json!({
+            "model": "mock-model",
+            "input": "Third websocket turn",
+            "previous_response_id": second_response_id,
+            "store": false
+        })),
+    )
+    .await;
+
+    let third_completed = third_events.last().unwrap();
+    assert_eq!(third_completed["type"], "response.completed");
+}
+
+#[tokio::test]
+async fn test_v1_responses_ws_allows_immediate_follow_up_after_completed_event() {
+    let url = serve_app(
+        build_stub_app(Arc::new(DelayedReturnWsExecutor::new(
+            Duration::from_millis(20),
+        )))
+        .await,
+    )
+    .await;
+    let (mut socket, _) = connect_async(format!("{}/v1/responses", url))
+        .await
+        .unwrap();
+
+    let first_events = send_ws_request_and_collect(
+        &mut socket,
+        ws_create_request(serde_json::json!({
+            "model": "mock-model",
+            "input": "First delayed websocket turn",
+            "store": false
+        })),
+    )
+    .await;
+    let first_completed = first_events.last().unwrap();
+    assert_eq!(first_completed["type"], "response.completed");
+
+    let second_events = send_ws_request_and_collect(
+        &mut socket,
+        ws_create_request(serde_json::json!({
+            "model": "mock-model",
+            "input": "Immediate follow-up websocket turn",
+            "store": false
+        })),
+    )
+    .await;
+
+    let second_completed = second_events.last().unwrap();
+    assert_eq!(second_completed["type"], "response.completed");
+}
+
+#[tokio::test]
+async fn test_v1_responses_ws_store_true_continuation_survives_reconnect() {
+    let executor = Arc::new(SemanticWsExecutor::new());
+    let url = serve_app(build_stub_app(executor).await).await;
+
+    let (mut first_socket, _) = connect_async(format!("{}/v1/responses", url))
+        .await
+        .unwrap();
+    let first_events = send_ws_request_and_collect(
+        &mut first_socket,
+        ws_create_request(serde_json::json!({
+            "model": "mock-model",
+            "input": "Persist this websocket turn",
+            "store": true
+        })),
+    )
+    .await;
+    let first_completed = first_events.last().unwrap();
+    assert_eq!(first_completed["type"], "response.completed");
+    let response_id = first_completed["response"]["id"]
+        .as_str()
+        .expect("completed response should include id")
+        .to_string();
+    drop(first_socket);
+
+    let (mut second_socket, _) = connect_async(format!("{}/v1/responses", url))
+        .await
+        .unwrap();
+    let second_events = send_ws_request_and_collect(
+        &mut second_socket,
+        ws_create_request(serde_json::json!({
+            "model": "mock-model",
+            "input": "Reconnect follow up websocket turn",
+            "previous_response_id": response_id,
+            "store": false
+        })),
+    )
+    .await;
+
+    let second_completed = second_events.last().unwrap();
+    assert_eq!(second_completed["type"], "response.completed");
+}
+
+#[tokio::test]
+async fn test_v1_responses_ws_missing_previous_response_errors() {
+    let url = serve_app(build_stub_app(Arc::new(SemanticWsExecutor::new())).await).await;
+    let (mut socket, _) = connect_async(format!("{}/v1/responses", url))
+        .await
+        .unwrap();
+
+    let events = send_ws_request_and_collect(
+        &mut socket,
+        ws_create_request(serde_json::json!({
+            "model": "mock-model",
+            "input": "Missing previous response id",
+            "previous_response_id": "resp_missing_ws",
+            "store": false
+        })),
+    )
+    .await;
+
+    let error = events.last().unwrap();
+    assert_eq!(error["type"], "error");
+    assert_eq!(ws_error_code(error), "previous_response_not_found");
+    assert_eq!(ws_error_param(error), Some("previous_response_id"));
+}
+
+#[tokio::test]
+async fn test_v1_responses_ws_rejects_unsupported_parameters() {
+    let url = serve_app(build_stub_app(Arc::new(SemanticWsExecutor::new())).await).await;
+    let (mut socket, _) = connect_async(format!("{}/v1/responses", url))
+        .await
+        .unwrap();
+
+    let background_events = send_ws_request_and_collect(
+        &mut socket,
+        ws_create_request(serde_json::json!({
+            "model": "mock-model",
+            "input": "Background websocket request",
+            "background": true
+        })),
+    )
+    .await;
+    assert_eq!(
+        background_events.last().unwrap()["type"],
+        "response.completed"
+    );
+
+    let events = send_ws_request_and_collect(
+        &mut socket,
+        ws_create_request(serde_json::json!({
+            "model": "mock-model",
+            "input": "Conversation websocket request",
+            "conversation": "conv_test_123"
+        })),
+    )
+    .await;
+    let error = events.last().unwrap();
+    assert_eq!(error["type"], "error");
+    assert_eq!(ws_error_code(error), "unsupported_parameter");
+}
+
+#[tokio::test]
+async fn test_v1_responses_ws_accepts_generate_false_warmup() {
+    let url = serve_app(build_stub_app(Arc::new(SemanticWsExecutor::new())).await).await;
+    let (mut socket, _) = connect_async(format!("{}/v1/responses", url))
+        .await
+        .unwrap();
+
+    let warmup_events = send_ws_request_and_collect(
+        &mut socket,
+        ws_create_request(serde_json::json!({
+            "model": "mock-model",
+            "input": "Warm up websocket request",
+            "generate": false,
+            "store": false
+        })),
+    )
+    .await;
+
+    let completed = warmup_events.last().unwrap();
+    assert_eq!(completed["type"], "response.completed");
+    assert_eq!(
+        completed["response"]["output"]
+            .as_array()
+            .expect("warmup output should be an array")
+            .len(),
+        0
+    );
+}
+
+#[tokio::test]
+async fn test_v1_responses_ws_evicts_cached_response_after_failed_continuation() {
+    let url = serve_app(build_stub_app(Arc::new(SemanticWsExecutor::new())).await).await;
+    let (mut socket, _) = connect_async(format!("{}/v1/responses", url))
+        .await
+        .unwrap();
+
+    let first_events = send_ws_request_and_collect(
+        &mut socket,
+        ws_create_request(serde_json::json!({
+            "model": "mock-model",
+            "input": "First websocket turn",
+            "store": false
+        })),
+    )
+    .await;
+    let first_completed = first_events.last().unwrap();
+    let response_id = first_completed["response"]["id"]
+        .as_str()
+        .expect("completed response should include id")
+        .to_string();
+
+    let failed_events = send_ws_request_and_collect(
+        &mut socket,
+        ws_create_request(serde_json::json!({
+            "model": "mock-model",
+            "input": "Fail this continuation",
+            "previous_response_id": response_id,
+            "conversation": "conv_test_123",
+            "store": false
+        })),
+    )
+    .await;
+    let failed_error = failed_events.last().unwrap();
+    assert_eq!(failed_error["type"], "error");
+    assert_eq!(ws_error_code(failed_error), "unsupported_parameter");
+
+    let retry_events = send_ws_request_and_collect(
+        &mut socket,
+        ws_create_request(serde_json::json!({
+            "model": "mock-model",
+            "input": "Retry after failed continuation",
+            "previous_response_id": response_id,
+            "store": false
+        })),
+    )
+    .await;
+    let retry_error = retry_events.last().unwrap();
+    assert_eq!(retry_error["type"], "error");
+    assert_eq!(ws_error_code(retry_error), "previous_response_not_found");
+}
+
+#[tokio::test]
+async fn test_v1_responses_ws_does_not_reuse_failed_cached_response() {
+    let url = serve_app(build_stub_app(Arc::new(FailedResponseWsExecutor)).await).await;
+    let (mut socket, _) = connect_async(format!("{}/v1/responses", url))
+        .await
+        .unwrap();
+
+    let first_events = send_ws_request_and_collect(
+        &mut socket,
+        ws_create_request(serde_json::json!({
+            "model": "mock-model",
+            "input": "Produce a failed websocket response",
+            "store": false
+        })),
+    )
+    .await;
+    let first_completed = first_events.last().unwrap();
+    assert_eq!(first_completed["type"], "response.completed");
+    assert_eq!(first_completed["response"]["status"], "failed");
+
+    let retry_events = send_ws_request_and_collect(
+        &mut socket,
+        ws_create_request(serde_json::json!({
+            "model": "mock-model",
+            "input": "Retry after failed websocket response",
+            "previous_response_id": "resp_ws_failed",
+            "store": false
+        })),
+    )
+    .await;
+    let retry_error = retry_events.last().unwrap();
+    assert_eq!(retry_error["type"], "error");
+    assert_eq!(ws_error_code(retry_error), "previous_response_not_found");
+}
+
+#[tokio::test]
+async fn test_v1_responses_ws_errors_echo_event_id() {
+    let url = serve_app(build_stub_app(Arc::new(SemanticWsExecutor::new())).await).await;
+    let (mut socket, _) = connect_async(format!("{}/v1/responses", url))
+        .await
+        .unwrap();
+
+    let events = send_ws_request_and_collect(
+        &mut socket,
+        ws_create_request(serde_json::json!({
+            "event_id": "evt_ws_123",
+            "model": "mock-model",
+            "input": "Conversation websocket request",
+            "conversation": "conv_test_123"
+        })),
+    )
+    .await;
+
+    let error = events.last().unwrap();
+    assert_eq!(error["type"], "error");
+    assert_eq!(ws_error_code(error), "unsupported_parameter");
+    assert_eq!(error["event_id"], "evt_ws_123");
+    assert!(!ws_error_message(error).is_empty());
+}


### PR DESCRIPTION
## Motivation

The [OpenAI Responses API WebSocket mode](https://developers.openai.com/api/docs/guides/websocket-mode) enables persistent connections for multi-turn workflows, eliminating per-turn HTTP connection overhead. This PR adds WebSocket transport for the Responses API at the gateway layer (`sgl-model-gateway`), scoped to the gRPC regular worker backend.

Clients upgrade `GET /v1/responses` to WebSocket and send `response.create` events over the same socket. `previous_response_id` resolves from a connection-local cache before falling back to durable storage (`--history-backend memory|redis|oracle|postgres`). The WS handler reuses the existing `ResponseStreamEventEmitter` — no SSE re-parsing, shared streaming pipeline.

## Modifications

**Core gateway (Rust)**
- `ws_responses.rs` — WS connection lifecycle, `WsSession` with single-entry cache, ping/pong, 60m cap
- `grpc/regular/responses/websocket.rs` — gRPC regular WS executor bridging to existing streaming pipeline
- `responses_validation.rs` — shared request validation for HTTP and WS
- `mod.rs`, `router_manager.rs`, `grpc/router.rs` — `RouterTrait` WS extension + delegation
- `server.rs` — WS route registration at `GET /v1/responses`, `TCP_NODELAY`
- `streaming.rs` — transport-neutral event emission; populate `call_id` on non-MCP tool calls
- `conversions.rs` — use `call_id` (not item `id`) in responses-to-chat conversion
- `common.rs` — failed-response cache eviction per [OpenAI WS spec](https://developers.openai.com/api/docs/guides/websocket-mode)

**Tests (42 new tests)**
- `responses_ws_test.rs` — 21 stub-based protocol tests: streaming, rejection, continuation, store semantics, lifetime
- `test_local_smoke.py` — 19 GPU e2e tests (llama-1b + qwen-7b): HTTP/WS create, store, reconnect, tool continuation
- `api_endpoints_test.rs` — 2 WS upgrade validation tests

**Benchmarks**
- `ws_response_hotpath.rs` + `bench_support.rs` — Criterion: WS vs SSE frame emission, continuation shaping
- `test_ws_microbench.py` — 4 e2e benchmark classes: transport, chain, tool-output chain comparisons
- `bench_router_responses.py` — standalone CLI with HTTP/WS multi-turn modes


## Speed Tests and Profiling

### qwen-72b-tp2 | 2x RTX PRO 6000 Blackwell

**Single-turn (5 samples)**

| Metric                  | HTTP p50 | HTTP p95 | WS p50 | WS p95 | WS/HTTP p50 | WS/HTTP p95 | Winner                     |
|-------------------------|--------:|---------:|-------:|-------:|------------:|------------:|:---------------------------|
| TTFT (ms)               |  120.29 |   154.42 | 117.89 | 117.98 |       0.980 |       0.764 | **WS** (p50 +2%, p95 +24%) |
| E2E (ms)                |  174.59 |   208.50 | 172.23 | 172.40 |       0.986 |       0.827 | **WS** (p50 +1%, p95 +17%) |
| Output throughput (t/s) |   11.02 |       -- |  11.70 |     -- |       1.061 |          -- | **WS** (+6%)               |

**Multi-turn chains**

| Workload                    | HTTP (ms)    | WS (ms)      | WS Delta    | Winner                |
|-----------------------------|-------------:|-------------:|------------:|:----------------------|
| full_replay mean (5t)       |   10,783.95  |    9,241.92  | **+14.3%**  | **WS**                |
| prev_resp_id mean (5t)      |   10,599.97  |    9,292.36  | **+12.3%**  | **WS**                |
| First-content p50 (5t)      |      314.62  |      120.96  | **+61.5%**  | **WS** (2.6x)         |
| Long-chain total (40t)      |  158,739.65  |  147,271.26  |  **+7.2%**  | **WS**                |
| Long-chain first-content    |      333.97  |      125.40  | **+62.5%**  | **WS** (2.66x)        |
| Tool-output chain p50 (20t) |    3,674.39  |    3,664.93  |      +0.3%  | Parity                |

**p95 tail latency (20-turn chains, 3 samples)**

| Metric                  | HTTP p50   | HTTP p95   | WS p50   | WS p95   | WS/HTTP p95 | Winner           |
|-------------------------|----------:|-----------:|---------:|---------:|------------:|:-----------------|
| Tool-output chain (ms)  | 3,674.39  |  6,059.95  | 3,664.93 | 3,669.50 |       0.605 | **WS p95 +40%**  |
| Tool-output cont. (ms)  | 3,500.16  |  5,858.62  | 3,493.35 | 3,496.71 |       0.597 | **WS p95 +40%**  |
| Text chain (ms)         | 3,489.44  |  3,994.57  | 3,483.82 | 3,486.83 |       0.873 | **WS p95 +13%**  |

### qwen-7b | 4x A100-SXM4-80GB

**Single-turn (3 samples)**

| Metric                  | HTTP p50 | HTTP p95 | WS p50 | WS p95 | WS/HTTP p50 | WS/HTTP p95 | Winner                      |
|-------------------------|--------:|---------:|-------:|-------:|------------:|------------:|:----------------------------|
| TTFT (ms)               |   23.49 |    38.40 |  22.26 |  22.35 |       0.948 |       0.582 | **WS** (p50 +5%, p95 +42%)  |
| E2E (ms)                |   34.54 |    49.00 |  32.74 |  32.80 |       0.948 |       0.669 | **WS** (p50 +5%, p95 +33%)  |
| Output throughput (t/s) |   52.05 |       -- |  61.15 |     -- |       1.175 |          -- | **WS** (+17.5%)             |
| TPOT (derived ms/tok)   |   11.05 |       -- |  10.48 |     -- |       0.949 |          -- | **WS** (+5%)                |

**Multi-turn chains**

| Workload                    | HTTP (ms) | WS (ms) | WS Delta    | Winner   |
|-----------------------------|----------:|---------:|------------:|:---------|
| 20-turn text chain          |    671.06 |   653.45 |      +2.6%  | **WS**   |
| 20-turn tool chain          |    762.68 |   691.27 |   **+9.4%** | **WS**   |
| 20-turn tool cont. only     |    734.16 |   660.00 |  **+10.1%** | **WS**   |
| Per-turn tool cont. p50     |     36.38 |    32.97 |   **+9.4%** | **WS**   |
| Per-turn tool cont. p95     |     38.24 |    33.27 |  **+13.0%** | **WS**   |

### qwen-3b x2 workers | 2x RTX PRO 6000 Blackwell

**Single-turn (7 samples)**

| Metric                  | HTTP p50 | HTTP p95 | WS p50 | WS p95 | WS/HTTP p50 | WS/HTTP p95 | Winner                      |
|-------------------------|--------:|---------:|-------:|-------:|------------:|------------:|:----------------------------|
| TTFT (ms)               |   12.30 |    25.15 |  10.95 |  11.33 |       0.891 |       0.451 | **WS** (p50 +11%, p95 +55%) |
| E2E (ms)                |   17.85 |    30.29 |  16.63 |  17.04 |       0.931 |       0.563 | **WS** (p50 +7%, p95 +44%)  |
| Output throughput (t/s) |  104.24 |       -- | 119.60 |     -- |       1.147 |          -- | **WS** (+15%)               |

**Multi-turn (12 chains x 20t, parallel=2)**

| Metric             | HTTP      | WS        | WS Delta    | Winner   |
|--------------------|----------:|----------:|------------:|:---------|
| Chain p50 (ms)     |  1,266.23 |  1,177.62 |   **+7.0%** | **WS**   |
| Wall clock (ms)    |  7,657.33 |  7,191.27 |   **+6.1%** | **WS**   |
| First-content (ms) |     28.68 |     27.68 |      +3.5%  | **WS**   |

### llama-1b | A100 + H200

| Workload                | HTTP p50 (ms) | WS p50 (ms) | WS Delta | Winner                          |
|-------------------------|-------------:|------------:|---------:|:--------------------------------|
| Single-turn E2E (A100)  |        11.87 |       18.89 |   -59.1% | HTTP (WS handshake > inference) |
| Single-turn E2E (H200)  |         7.22 |       14.10 |   -95.3% | HTTP (same)                     |
| 20-turn chain (A100)    |       287.98 |      280.27 |    +2.7% | **WS**                          |
| 20-turn chain (H200)    |       174.75 |      170.40 |    +2.5% | **WS**                          |
| 20-turn 1st turn (A100) |        13.89 |       13.00 |    +6.4% | **WS**                          |

On llama-1b (~10ms inference), WS handshake dominates single requests. Reverses on multi-turn chains.

### Criterion (no GPU)

| Benchmark              | WS (us) | SSE (us) | Speedup      | Winner |
|------------------------|--------:|---------:|:-------------|:-------|
| Frame emission 16x64   |    61.4 |     67.4 | 1.17x (+14%) | **WS** |
| Frame emission 64x128  |   164.5 |    184.1 | 1.12x (+11%) | **WS** |
| Frame emission 128x256 |   364.8 |    399.7 | 1.12x (+11%) | **WS** |

### Cross-Hardware Summary

| Model        | Hardware      | TTFT p50    | TTFT p95    | E2E p50     | E2E p95     | Throughput   | Best Chain       | Overall              |
|:-------------|:--------------|:------------|:------------|:------------|:------------|:-------------|:-----------------|:---------------------|
| qwen-72b-tp2 | RTX PRO 6000 | **WS +2%**  | **WS +24%** | **WS +1%**  | **WS +17%** | **WS +6%**   | **+14.8%**       | **WS dominates**     |
| qwen-7b      | 4x A100      | **WS +5%**  | **WS +42%** | **WS +5%**  | **WS +33%** | **WS +18%**  | **+10.1%**       | **WS wins all**      |
| qwen-3b x2   | RTX PRO 6000 | **WS +11%** | **WS +55%** | **WS +7%**  | **WS +44%** | **WS +15%**  | **+7.0%**        | **WS wins all**      |
| llama-1b     | A100 / H200  | HTTP wins   | --          | HTTP wins   | --          | --           | **WS +2.5-2.7%** | WS multi-turn only   |

**p95 tail latency is where WS shines most** — HTTP SSE p95 has high variance from per-request connection setup jitter. WS eliminates that variance entirely. qwen-3b TTFT p95: **55% better** on WS.

**Architectural ceiling (~15%)**: The router expands `previous_response_id` into full context before the worker call, so WS only saves client-to-router overhead.

### Limitations

- **gRPC regular backend only** — HTTP-worker and Harmony backends return 501 on WS upgrade. This is deliberate, to limit the scope of this PR. Will be addressed in follow up PRs
- **One in-flight per connection** — must wait for `response.completed` before next turn (matches OpenAI spec)
- **Connection-local state** — `store=false` lost on disconnect; `store=true` persists via `--history-backend`
- **60-minute cap** — reconnect with `previous_response_id` to resume (matches OpenAI spec)
- **No `conversation` over WS** — multi-turn via `previous_response_id` only
- **WS overhead on tiny models** — single-turn llama-1b is 60% slower; reverses on multi-turn

## Checklist

- [x] Format: `pre-commit run --all-files` passes, `cargo clippy -D warnings` clean, `cargo +nightly fmt` clean
- [x] Tests: 42 new tests (21 Rust + 19 e2e + 2 endpoint), verified on 4xA100 and 2xH200
  ```
  cargo test                                       # 816 pass
  pytest responses/test_local_smoke.py -v          # 19/19 pass
  pytest benchmarks/test_ws_bench_helpers.py -v    # 2 pass
  cargo bench --bench ws_response_hotpath          # completes
  ```
- [x] Docs: `e2e_test/README.md`, `benchmark/multi_turn_chat/README.md`, `//!` and `"""` docstrings on all new files
- [x] Benchmarks: Criterion + e2e across 3 model sizes, 3 hardware configs. No accuracy impact — transport only.
- [x] Style: shared `ResponseStreamEventEmitter` (no duplication), no file >2K lines, stdout benchmarks, inline test data
