### PR TITLE
fix: correct insert_sort logic in add_req_state for ignore_eos scheduling

### DIFF
--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -660,10 +660,11 @@ class PrefillAdder:
             if not insert_sort:
                 self.req_states.append((tokens_left, tokens_occupied))
             else:
-                i = 0
                 for i in range(len(self.req_states)):
                     if tokens_left <= self.req_states[i][0]:
                         break
+                else:
+                    i = len(self.req_states)
                 self.req_states.insert(i, (tokens_left, tokens_occupied))
 
         if self.req_states is None:


### PR DESCRIPTION
## Summary

Fix an off-by-one bug in `PrefillAdder.add_req_state()` where the `insert_sort` path fails to append elements that are larger than all existing elements in `self.req_states`.

## Bug

In `schedule_policy.py` lines 662-667, the sorted insertion logic uses a `for` loop to find the correct position:

```python
# Before (buggy)
i = 0
for i in range(len(self.req_states)):
    if tokens_left <= self.req_states[i][0]:
        break
self.req_states.insert(i, (tokens_left, tokens_occupied))
```

When the new `tokens_left` value is **larger than all existing elements**, the `for` loop completes without hitting `break`. In Python, `i` retains the value of the **last iteration** (i.e., `len(self.req_states) - 1`), so `insert(i, ...)` places the new element **before** the last element instead of **after** it.

### Example

Given `req_states = [(10, ...), (20, ...), (30, ...)]` and a new element with `tokens_left = 50`:

- The loop runs `i = 0, 1, 2` — the condition `50 <= req_states[i][0]` is never true
- `i` ends at `2` (last index)
- `insert(2, (50, ...))` produces `[(10, ...), (20, ...), (50, ...), (30, ...)]` — **wrong order**
- Expected: `[(10, ...), (20, ...), (30, ...), (50, ...)]`

## Fix

Use Python's `for/else` construct: the `else` block runs only when the loop completes without `break`, setting `i` to the end of the list:

```python
# After (fixed)
for i in range(len(self.req_states)):
    if tokens_left <= self.req_states[i][0]:
        break
else:
    i = len(self.req_states)
self.req_states.insert(i, (tokens_left, tokens_occupied))
```

## Impact

This bug affects `ignore_eos` requests during the incremental sorted insertion path (line 679). The corrupted sort order causes `_prefill_one_req` to use incorrect `tokens_left` values when estimating remaining token budget, potentially leading to:
- Over-scheduling prefills (underestimating memory needed)
- Under-scheduling prefills (overestimating memory needed)

The initial bulk sort on line 677 is unaffected since it uses Python's built-in `sort()`.