### PR TITLE
Fix #21876: Parse hf_text_config instead of hf_config for multimodal

### DIFF
--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -38,6 +38,7 @@ from sglang.srt.lora.utils import (
     LoRAType,
     auto_detect_lora_target_modules,
     get_normalized_target_modules,
+    get_num_layers,
     get_target_module_name,
 )
 from sglang.srt.managers.io_struct import LoRAUpdateOutput
@@ -692,8 +693,9 @@ class LoRAManager:
 
     def init_lora_modules(self):
         # Look-up table that essentially maps (layer_index, module_name) to the corresponding LoRA module.
+        num_layers = get_num_layers(self.base_hf_config)
         self.lora_modules: List[Dict[str, BaseLayerWithLoRA]] = [
-            {} for _ in range(self.base_hf_config.num_hidden_layers)
+            {} for _ in range(num_layers)
         ]
 
         self.embed_tokens_module: Optional[BaseLayerWithLoRA] = None

--- a/python/sglang/srt/lora/mem_pool.py
+++ b/python/sglang/srt/lora/mem_pool.py
@@ -15,8 +15,10 @@ from sglang.srt.lora.utils import (
     ROW_PARALLELISM_LINEAR_LORA_NAMES,
     LoRAType,
     get_hidden_dim,
+    get_hidden_size,
     get_lm_head_lora_b_shard_size,
     get_normalized_target_modules,
+    get_num_layers,
     get_stacked_multiply,
     get_target_module_name,
 )
@@ -63,7 +65,7 @@ class LoRAMemoryPool:
         experts_shared_outer_loras: bool = False,
     ):
         self.base_hf_config: AutoConfig = base_hf_config
-        self.num_layer: int = base_hf_config.num_hidden_layers
+        self.num_layer: int = get_num_layers(base_hf_config)
         self.max_loras_per_batch: int = max_loras_per_batch
         self.dtype: torch.dtype = dtype
         self.tp_size: int = tp_size
@@ -90,7 +92,7 @@ class LoRAMemoryPool:
         self.lm_head_B_buffer: Dict[str, torch.Tensor] = {}
         self.new_embeddings_buffer: Dict[str, torch.Tensor] = {}
 
-        self.embedding_dim: int = self.base_hf_config.hidden_size
+        self.embedding_dim: int = get_hidden_size(base_hf_config)
 
         # Lora uid -> buffer idx in memory pool
         self.uid_to_buffer_id: Dict[Optional[str], int] = {}

--- a/python/sglang/srt/lora/utils.py
+++ b/python/sglang/srt/lora/utils.py
@@ -54,6 +54,44 @@ class LoRAType(Enum):
     LORA_B = 1
 
 
+def get_num_layers(config: AutoConfig):
+    # Standard HF models
+    num_layers = getattr(config, "num_hidden_layers", None)
+    if num_layers is not None:
+        return num_layers
+
+    # multimodal models (like Qwen3_5_30B)
+    text_config = getattr(config, "text_config", None)
+    if text_config is not None:
+        num_layers = getattr(text_config, "num_hidden_layers", None)
+        if num_layers is not None:
+            return num_layers
+
+    raise AttributeError(
+        "num_hidden_layers not found in base_hf_config or text_config. "
+        "Model architecture may not be supported."
+    )
+
+
+def get_hidden_size(config: AutoConfig):
+    # Standard HF models
+    hidden_size = getattr(config, "hidden_size", None)
+    if hidden_size is not None:
+        return hidden_size
+
+    # multimodal models (like Qwen3_5_30B)
+    text_config = getattr(config, "text_config", None)
+    if text_config is not None:
+        hidden_size = getattr(text_config, "hidden_size", None)
+        if hidden_size is not None:
+            return hidden_size
+
+    raise AttributeError(
+        "hidden_size not found in base_hf_config or text_config. "
+        "Model architecture may not be supported."
+    )
+
+
 def get_hidden_dim(
     module_name: str,
     config: AutoConfig,
@@ -75,6 +113,10 @@ def get_hidden_dim(
         Please implement the function in the model class if it is not.
         You can reference this function in llama.py.
         """
+        # Resolve primary config for multimodal models (e.g. Qwen 3.5 Moe)
+        if hasattr(config, "text_config") and config.text_config is not None:
+            config = config.text_config
+
         head_dim = getattr(
             config, "head_dim", config.hidden_size // config.num_attention_heads
         )

--- a/test/registered/lora/test_lora_multimodal_config.py
+++ b/test/registered/lora/test_lora_multimodal_config.py
@@ -1,0 +1,89 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""
+Unit tests for LoRA utility functions that handle multimodal model configs
+(e.g., composite HF configs where num_hidden_layers/hidden_size live under
+text_config instead of the top-level config).
+
+Regression test for https://github.com/sgl-project/sglang/issues/21876
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.lora.utils import get_hidden_size, get_num_layers
+
+
+def _make_standard_config(**kwargs):
+    """Create a mock config mimicking a standard HF model (e.g., Llama)."""
+    defaults = {
+        "num_hidden_layers": 32,
+        "hidden_size": 4096,
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def _make_multimodal_config(text_kwargs=None, top_kwargs=None):
+    """Create a mock config mimicking a multimodal/composite HF model
+    (e.g., Qwen3-VL-30B-A3B) where text attributes live under text_config."""
+    text_defaults = {
+        "num_hidden_layers": 48,
+        "hidden_size": 3072,
+        "num_attention_heads": 16,
+        "num_key_value_heads": 4,
+        "intermediate_size": 8192,
+    }
+    if text_kwargs:
+        text_defaults.update(text_kwargs)
+
+    text_config = SimpleNamespace(**text_defaults)
+
+    top_defaults = {
+        "text_config": text_config,
+        "model_type": "qwen3_vl",
+    }
+    if top_kwargs:
+        top_defaults.update(top_kwargs)
+
+    return SimpleNamespace(**top_defaults)
+
+
+class TestGetNumLayers(unittest.TestCase):
+    """Tests for get_num_layers()."""
+
+    def test_standard_config(self):
+        config = _make_standard_config(num_hidden_layers=32)
+        self.assertEqual(get_num_layers(config), 32)
+
+    def test_multimodal_config(self):
+        config = _make_multimodal_config(text_kwargs={"num_hidden_layers": 48})
+        self.assertEqual(get_num_layers(config), 48)
+
+
+class TestGetHiddenSize(unittest.TestCase):
+    """Tests for get_hidden_size()."""
+
+    def test_standard_config(self):
+        config = _make_standard_config(hidden_size=4096)
+        self.assertEqual(get_hidden_size(config), 4096)
+
+    def test_multimodal_config(self):
+        config = _make_multimodal_config(text_kwargs={"hidden_size": 3072})
+        self.assertEqual(get_hidden_size(config), 3072)
+
+
+if __name__ == "__main__":
+    unittest.main(warnings="ignore", verbosity=2)


### PR DESCRIPTION


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

  Fixes #21876    

Multimodal models like Qwen3-VL-30B-A3B use a composite HF config where text model attributes (num_hidden_layers, hidden_size) are nested under config.text_config rather than the top-level config. The LoRA manager and memory pool accessed these attributes directly on the top-level config, causing AttributeError when initializing LoRA modules for these models.  

## Modifications

  - Added get_num_layers() helper in lora/utils.py that checks top-level config first, then falls back to text_config.num_hidden_layers                          
  - Added get_hidden_size() helper in lora/utils.py that checks top-level config first, then falls back to text_config.hidden_size
  - Updated lora_manager.py to use get_num_layers() instead of config.num_hidden_layers                                                                          
  - Updated mem_pool.py to use get_num_layers() and get_hidden_size() instead of direct attribute access                                                         
  - Updated get_hidden_dim() in lora/utils.py to resolve text_config before accessing text-model attributes                                                      
  - Added unit tests for the new config resolution helpers with both standard and multimodal configs  

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
