### PR TITLE
Fix get_version_tag.py to handle dot-separated post versions

### DIFF
--- a/python/tools/get_version_tag.py
+++ b/python/tools/get_version_tag.py
@@ -31,11 +31,11 @@ def parse_version_tuple(tag: str) -> tuple:
     - Pre-release suffix gets a lower sort key than bare version:
       v0.5.10rc0  -> (0, 5, 10, 0, 0)   # pre-release
       v0.5.10     -> (0, 5, 10, 1, 0)   # stable (sorts higher)
-      v0.5.10post1 -> (0, 5, 10, 2, 1)  # post-release (sorts highest)
+      v0.5.10.post1 -> (0, 5, 10, 2, 1)  # post-release (sorts highest)
     """
     v = tag.lstrip("v")
     # Split base version from suffix
-    m = re.match(r"^(\d+)\.(\d+)\.(\d+)(?:(rc|post)(\d+))?$", v)
+    m = re.match(r"^(\d+)\.(\d+)\.(\d+)(?:\.?(rc|post)(\d+))?$", v)
     if not m:
         return (0, 0, 0, 0, 0)
     major, minor, patch = int(m.group(1)), int(m.group(2)), int(m.group(3))


### PR DESCRIPTION
## Summary
- Fix regex in `parse_version_tuple()` to accept the dot before `post` in PEP 440 post-release tags (e.g., `v0.5.10.post1`)
- Previously, tags like `v0.5.10.post1` were unrecognized by the regex and sorted as `(0, 0, 0, 0, 0)`, making them rank lowest instead of highest
- The fix adds `\.?` (optional dot) to the regex: `(?:\.?(rc|post)(\d+))?`

Correct ordering is now: `0.5.10.post1 > 0.5.10 > 0.5.10rc0 > 0.5.9.post1`

## Test plan
- [x] `python python/tools/get_version_tag.py --tag-only` returns `v0.5.10.post1` on main
- [x] Verified sort order: `v0.5.10.post1 > v0.5.10 > v0.5.10rc0 > v0.5.9.post1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)