### PR TITLE
[CI] Add alexnails to CI_PERMISSIONS.json

### DIFF
--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -370,6 +370,13 @@
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
+    "alexnails": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "can_rerun_stage": true,
+        "cooldown_interval_minutes": 0,
+        "reason": "top contributor"
+    },
     "alisonshao": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,


### PR DESCRIPTION
## Summary
- Add `alexnails` to CI_PERMISSIONS.json with `can_tag_run_ci_label`, `can_rerun_failed_ci`, and `can_rerun_stage` permissions
- `/rerun-stage` was failing silently for alexnails because PR authors only get `can_rerun_failed_ci` and `can_rerun_test` automatically — `can_rerun_stage` requires an entry in CI_PERMISSIONS.json (see [failed run](https://github.com/sgl-project/sglang/actions/runs/24126548112))

Example failure: https://github.com/sgl-project/sglang/pull/22346#issuecomment-4204996212

## Test plan
- [ ] Verify alexnails can use `/rerun-stage` on a PR after this merges