### PR TITLE
[session] support rewind / backtrack for streaming session

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -617,6 +617,7 @@ class Req(ReqDllmMixin):
         # For req-level memory management
         self.kv_committed_len = 0
         self.kv_allocated_len = 0
+        self.kv_reuse_len: Optional[int] = None
         self.kv_committed_freed = False
         self.kv_overallocated_freed = False
 

--- a/python/sglang/srt/managers/session_controller.py
+++ b/python/sglang/srt/managers/session_controller.py
@@ -119,22 +119,19 @@ class Session:
         return rid == latest_rid
 
     def _find_turn_record(self, rid: str) -> Optional[TurnRecord]:
-        for record in self.turn_history:
-            if record.rid == rid:
-                return record
-        return None
+        return self.turn_records.get(rid)
 
     def _save_turn_record(self, req: Req):
-        output_ids = req.output_ids[: req.sampling_params.max_new_tokens]
+        output_ids = list(req.output_ids)
         kv_end = len(req.origin_input_ids) + len(output_ids)
-        self.turn_history.append(
-            TurnRecord(
-                rid=req.rid,
-                origin_input_ids=list(req.origin_input_ids),
-                output_ids=list(output_ids),
-                kv_end_pos=kv_end,
-            )
+        record = TurnRecord(
+            rid=req.rid,
+            origin_input_ids=list(req.origin_input_ids),
+            output_ids=output_ids,
+            kv_end_pos=kv_end,
         )
+        self.turn_order.append(record.rid)
+        self.turn_records[record.rid] = record
 
     @staticmethod
     def _trim_bos(req: TokenizedGenerateReqInput, tokenizer):
@@ -230,8 +227,10 @@ class Session:
             input_ids = base_ids + req.input_ids
             input_ids_unpadded = base_ids + req.input_ids
 
-            idx = self.turn_history.index(backtrack_target)
-            self.turn_history = self.turn_history[: idx + 1]
+            idx = self.turn_order.index(backtrack_target.rid)
+            for removed_rid in self.turn_order[idx + 1 :]:
+                del self.turn_records[removed_rid]
+            self.turn_order = self.turn_order[: idx + 1]
 
         elif last_req is not None:
             self._trim_bos(req, tokenizer)

--- a/python/sglang/srt/managers/session_controller.py
+++ b/python/sglang/srt/managers/session_controller.py
@@ -15,8 +15,7 @@ from __future__ import annotations
 import logging
 import time
 import uuid
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, Optional
 
 from sglang.srt.managers.io_struct import (
     CloseSessionReqInput,
@@ -80,16 +79,6 @@ class SessionReqNode:
             return ret
 
 
-@dataclass
-class TurnRecord:
-    """Lightweight snapshot of a completed streaming turn for backtracking."""
-
-    rid: str
-    origin_input_ids: List[int]
-    output_ids: List[int]
-    kv_end_pos: int
-
-
 class Session:
     def __init__(
         self,
@@ -105,33 +94,11 @@ class Session:
         self.last_active_time: float = time.monotonic()
         self.req_nodes: Dict[str, SessionReqNode] = {}
         self.close_on_finish: bool = False
-        self.turn_history: List[TurnRecord] = []
 
     def is_timed_out(self) -> bool:
         if self.timeout is None:
             return False
         return time.monotonic() - self.last_active_time > self.timeout
-
-    def _is_current_streaming_rid(self, rid: str) -> bool:
-        if not self.req_nodes:
-            return False
-        latest_rid = next(iter(self.req_nodes))
-        return rid == latest_rid
-
-    def _find_turn_record(self, rid: str) -> Optional[TurnRecord]:
-        return self.turn_records.get(rid)
-
-    def _save_turn_record(self, req: Req):
-        output_ids = list(req.output_ids)
-        kv_end = len(req.origin_input_ids) + len(output_ids)
-        record = TurnRecord(
-            rid=req.rid,
-            origin_input_ids=list(req.origin_input_ids),
-            output_ids=output_ids,
-            kv_end_pos=kv_end,
-        )
-        self.turn_order.append(record.rid)
-        self.turn_records[record.rid] = record
 
     @staticmethod
     def _trim_bos(req: TokenizedGenerateReqInput, tokenizer):
@@ -170,18 +137,18 @@ class Session:
         last_req = None
         abort = False
         abort_message = ""
-        backtrack_target: Optional[TurnRecord] = None
         kv_reuse_len: Optional[int] = None
         if self.streaming:
-            target_rid = session_params.rid
-            if target_rid is not None and not self._is_current_streaming_rid(
-                target_rid
-            ):
-                backtrack_target = self._find_turn_record(target_rid)
-                if backtrack_target is None:
-                    abort = True
-                    abort_message = f"Invalid rid for streaming session: {target_rid}"
-            if not abort and self.req_nodes:
+            # Streaming sessions: simple appends + offset-based backtracking only.
+            if session_params.replace:
+                abort = True
+                abort_message = "Streaming sessions do not support replace."
+            elif session_params.drop_previous_output:
+                abort = True
+                abort_message = (
+                    "Streaming sessions do not support drop_previous_output."
+                )
+            elif self.req_nodes:
                 assert len(self.req_nodes) == 1
                 _, last_req_node = self.req_nodes.popitem()
                 last_req = last_req_node.req
@@ -211,28 +178,7 @@ class Session:
                         abort_message = "Session request is appending to a request that hasn't finished."
                         logging.warning(abort_message)
 
-        if self.streaming and backtrack_target is not None:
-            self._trim_bos(req, tokenizer)
-            base_ids = backtrack_target.origin_input_ids + backtrack_target.output_ids
-            kv_reuse_len = backtrack_target.kv_end_pos
-
-            if session_params.drop_previous_output:
-                base_ids = backtrack_target.origin_input_ids[:]
-                kv_reuse_len = len(backtrack_target.origin_input_ids)
-
-            if session_params.offset and session_params.offset != 0:
-                base_ids = base_ids[: session_params.offset]
-                kv_reuse_len = min(kv_reuse_len, session_params.offset)
-
-            input_ids = base_ids + req.input_ids
-            input_ids_unpadded = base_ids + req.input_ids
-
-            idx = self.turn_order.index(backtrack_target.rid)
-            for removed_rid in self.turn_order[idx + 1 :]:
-                del self.turn_records[removed_rid]
-            self.turn_order = self.turn_order[: idx + 1]
-
-        elif last_req is not None:
+        if last_req is not None:
             self._trim_bos(req, tokenizer)
 
             input_ids = (
@@ -262,11 +208,8 @@ class Session:
             else:
                 input_ids_unpadded += req.input_ids
 
-            if self.streaming and not session_params.replace:
-                kv_reuse_len = None
-                if session_params.drop_previous_output:
-                    kv_reuse_len = len(last_req.origin_input_ids)
-                elif session_params.offset and session_params.offset != 0:
+            if self.streaming:
+                if session_params.offset and session_params.offset != 0:
                     kv_reuse_len = session_params.offset
         else:
             input_ids = req.input_ids
@@ -306,8 +249,6 @@ class Session:
             new_req.set_finish_with_abort(abort_message)
         elif self.streaming:
             if last_req is not None:
-                if backtrack_target is None:
-                    self._save_turn_record(last_req)
                 last_req.session = None
             self.req_nodes[req.rid] = SessionReqNode(new_req)
         else:

--- a/python/sglang/srt/managers/session_controller.py
+++ b/python/sglang/srt/managers/session_controller.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import logging
 import time
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Optional
 
 from sglang.srt.managers.io_struct import (
@@ -87,7 +87,6 @@ class TurnRecord:
     rid: str
     origin_input_ids: List[int]
     output_ids: List[int]
-    max_new_tokens: int
     kv_end_pos: int
 
 
@@ -113,7 +112,7 @@ class Session:
             return False
         return time.monotonic() - self.last_active_time > self.timeout
 
-    def _is_latest_streaming_rid(self, rid: str) -> bool:
+    def _is_current_streaming_rid(self, rid: str) -> bool:
         if not self.req_nodes:
             return False
         latest_rid = next(iter(self.req_nodes))
@@ -126,15 +125,13 @@ class Session:
         return None
 
     def _save_turn_record(self, req: Req):
-        max_new = req.sampling_params.max_new_tokens
-        output_ids = req.output_ids[:max_new]
+        output_ids = req.output_ids[: req.sampling_params.max_new_tokens]
         kv_end = len(req.origin_input_ids) + len(output_ids)
         self.turn_history.append(
             TurnRecord(
                 rid=req.rid,
                 origin_input_ids=list(req.origin_input_ids),
                 output_ids=list(output_ids),
-                max_new_tokens=max_new,
                 kv_end_pos=kv_end,
             )
         )
@@ -158,8 +155,7 @@ class Session:
                                 "clamping to 0 after BOS strip"
                             )
                         item.offsets = [
-                            (max(0, s - 1), max(0, e - 1))
-                            for s, e in item.offsets
+                            (max(0, s - 1), max(0, e - 1)) for s, e in item.offsets
                         ]
 
     def create_req(
@@ -181,15 +177,13 @@ class Session:
         kv_reuse_len: Optional[int] = None
         if self.streaming:
             target_rid = session_params.rid
-            if target_rid is not None and not self._is_latest_streaming_rid(
+            if target_rid is not None and not self._is_current_streaming_rid(
                 target_rid
             ):
                 backtrack_target = self._find_turn_record(target_rid)
                 if backtrack_target is None:
                     abort = True
-                    abort_message = (
-                        f"Invalid rid for streaming session: {target_rid}"
-                    )
+                    abort_message = f"Invalid rid for streaming session: {target_rid}"
             if not abort and self.req_nodes:
                 assert len(self.req_nodes) == 1
                 _, last_req_node = self.req_nodes.popitem()
@@ -222,10 +216,7 @@ class Session:
 
         if self.streaming and backtrack_target is not None:
             self._trim_bos(req, tokenizer)
-            base_ids = (
-                backtrack_target.origin_input_ids
-                + backtrack_target.output_ids[: backtrack_target.max_new_tokens]
-            )
+            base_ids = backtrack_target.origin_input_ids + backtrack_target.output_ids
             kv_reuse_len = backtrack_target.kv_end_pos
 
             if session_params.drop_previous_output:

--- a/python/sglang/srt/managers/session_controller.py
+++ b/python/sglang/srt/managers/session_controller.py
@@ -15,7 +15,8 @@ from __future__ import annotations
 import logging
 import time
 import uuid
-from typing import TYPE_CHECKING, Dict, Optional
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 from sglang.srt.managers.io_struct import (
     CloseSessionReqInput,
@@ -79,6 +80,17 @@ class SessionReqNode:
             return ret
 
 
+@dataclass
+class TurnRecord:
+    """Lightweight snapshot of a completed streaming turn for backtracking."""
+
+    rid: str
+    origin_input_ids: List[int]
+    output_ids: List[int]
+    max_new_tokens: int
+    kv_end_pos: int
+
+
 class Session:
     def __init__(
         self,
@@ -94,11 +106,61 @@ class Session:
         self.last_active_time: float = time.monotonic()
         self.req_nodes: Dict[str, SessionReqNode] = {}
         self.close_on_finish: bool = False
+        self.turn_history: List[TurnRecord] = []
 
     def is_timed_out(self) -> bool:
         if self.timeout is None:
             return False
         return time.monotonic() - self.last_active_time > self.timeout
+
+    def _is_latest_streaming_rid(self, rid: str) -> bool:
+        if not self.req_nodes:
+            return False
+        latest_rid = next(iter(self.req_nodes))
+        return rid == latest_rid
+
+    def _find_turn_record(self, rid: str) -> Optional[TurnRecord]:
+        for record in self.turn_history:
+            if record.rid == rid:
+                return record
+        return None
+
+    def _save_turn_record(self, req: Req):
+        max_new = req.sampling_params.max_new_tokens
+        output_ids = req.output_ids[:max_new]
+        kv_end = len(req.origin_input_ids) + len(output_ids)
+        self.turn_history.append(
+            TurnRecord(
+                rid=req.rid,
+                origin_input_ids=list(req.origin_input_ids),
+                output_ids=list(output_ids),
+                max_new_tokens=max_new,
+                kv_end_pos=kv_end,
+            )
+        )
+
+    @staticmethod
+    def _trim_bos(req: TokenizedGenerateReqInput, tokenizer):
+        if (
+            tokenizer is not None
+            and req.input_ids
+            and req.input_ids[0] == tokenizer.bos_token_id
+        ):
+            req.input_ids = req.input_ids[1:]
+            # Adjust mm_item offsets since they were computed on
+            # the pre-strip sequence (with BOS at position 0)
+            if req.mm_inputs:
+                for item in req.mm_inputs.mm_items:
+                    if item.offsets:
+                        if any(s == 0 for s, _ in item.offsets):
+                            logging.warning(
+                                "mm_item offset starts at 0 (BOS position), "
+                                "clamping to 0 after BOS strip"
+                            )
+                        item.offsets = [
+                            (max(0, s - 1), max(0, e - 1))
+                            for s, e in item.offsets
+                        ]
 
     def create_req(
         self,
@@ -115,20 +177,20 @@ class Session:
         last_req = None
         abort = False
         abort_message = ""
+        backtrack_target: Optional[TurnRecord] = None
+        kv_reuse_len: Optional[int] = None
         if self.streaming:
-            # Streaming sessions: only simple appends allowed; reject otherwise.
-            if session_params.replace:
-                abort = True
-                abort_message = "Streaming sessions do not support replace."
-            elif session_params.drop_previous_output:
-                abort = True
-                abort_message = (
-                    "Streaming sessions do not support drop_previous_output."
-                )
-            elif session_params.offset and session_params.offset != 0:
-                abort = True
-                abort_message = "Streaming sessions do not support offset."
-            elif self.req_nodes:
+            target_rid = session_params.rid
+            if target_rid is not None and not self._is_latest_streaming_rid(
+                target_rid
+            ):
+                backtrack_target = self._find_turn_record(target_rid)
+                if backtrack_target is None:
+                    abort = True
+                    abort_message = (
+                        f"Invalid rid for streaming session: {target_rid}"
+                    )
+            if not abort and self.req_nodes:
                 assert len(self.req_nodes) == 1
                 _, last_req_node = self.req_nodes.popitem()
                 last_req = last_req_node.req
@@ -158,27 +220,30 @@ class Session:
                         abort_message = "Session request is appending to a request that hasn't finished."
                         logging.warning(abort_message)
 
-        if last_req is not None:
-            # trim bos token if it is an append
-            if (
-                tokenizer is not None
-                and req.input_ids
-                and req.input_ids[0] == tokenizer.bos_token_id
-            ):
-                req.input_ids = req.input_ids[1:]
-                # Adjust mm_item offsets since they were computed on
-                # the pre-strip sequence (with BOS at position 0)
-                if req.mm_inputs:
-                    for item in req.mm_inputs.mm_items:
-                        if item.offsets:
-                            if any(s == 0 for s, _ in item.offsets):
-                                logging.warning(
-                                    "mm_item offset starts at 0 (BOS position), "
-                                    "clamping to 0 after BOS strip"
-                                )
-                            item.offsets = [
-                                (max(0, s - 1), max(0, e - 1)) for s, e in item.offsets
-                            ]
+        if self.streaming and backtrack_target is not None:
+            self._trim_bos(req, tokenizer)
+            base_ids = (
+                backtrack_target.origin_input_ids
+                + backtrack_target.output_ids[: backtrack_target.max_new_tokens]
+            )
+            kv_reuse_len = backtrack_target.kv_end_pos
+
+            if session_params.drop_previous_output:
+                base_ids = backtrack_target.origin_input_ids[:]
+                kv_reuse_len = len(backtrack_target.origin_input_ids)
+
+            if session_params.offset and session_params.offset != 0:
+                base_ids = base_ids[: session_params.offset]
+                kv_reuse_len = min(kv_reuse_len, session_params.offset)
+
+            input_ids = base_ids + req.input_ids
+            input_ids_unpadded = base_ids + req.input_ids
+
+            idx = self.turn_history.index(backtrack_target)
+            self.turn_history = self.turn_history[: idx + 1]
+
+        elif last_req is not None:
+            self._trim_bos(req, tokenizer)
 
             input_ids = (
                 last_req.origin_input_ids
@@ -206,6 +271,13 @@ class Session:
                 )
             else:
                 input_ids_unpadded += req.input_ids
+
+            if self.streaming and not session_params.replace:
+                kv_reuse_len = None
+                if session_params.drop_previous_output:
+                    kv_reuse_len = len(last_req.origin_input_ids)
+                elif session_params.offset and session_params.offset != 0:
+                    kv_reuse_len = session_params.offset
         else:
             input_ids = req.input_ids
             input_ids_unpadded = req.input_ids
@@ -237,10 +309,15 @@ class Session:
             new_req.multimodal_inputs = last_req.multimodal_inputs
         new_req.tokenizer = tokenizer
 
+        if self.streaming:
+            new_req.kv_reuse_len = kv_reuse_len
+
         if abort:
             new_req.set_finish_with_abort(abort_message)
         elif self.streaming:
             if last_req is not None:
+                if backtrack_target is None:
+                    self._save_turn_record(last_req)
                 last_req.session = None
             self.req_nodes[req.rid] = SessionReqNode(new_req)
         else:

--- a/python/sglang/srt/mem_cache/session_aware_cache.py
+++ b/python/sglang/srt/mem_cache/session_aware_cache.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import torch
 
-from sglang.srt.managers.schedule_batch import FINISH_ABORT
 from sglang.srt.mem_cache.base_prefix_cache import (
     BasePrefixCache,
     DecLockRefParams,
@@ -187,11 +186,6 @@ class SessionAwareCache(BasePrefixCache):
         if not _is_streaming(req):
             return self.inner.match_prefix(params)
 
-        if isinstance(req.to_finish, FINISH_ABORT) or isinstance(
-            req.finished_reason, FINISH_ABORT
-        ):
-            return self.inner.match_prefix(params)
-
         session_id = req.session.session_id
         slot = self.slots.get(session_id)
         if slot is None or slot.req_pool_idx is None:
@@ -233,11 +227,7 @@ class SessionAwareCache(BasePrefixCache):
         if not _is_streaming(req):
             return self.inner.cache_finished_req(req, is_insert=is_insert, **kwargs)
 
-        if isinstance(req.to_finish, FINISH_ABORT) or isinstance(
-            req.finished_reason, FINISH_ABORT
-        ):
-            self.inner.cache_finished_req(req, is_insert=is_insert, **kwargs)
-            return
+        from sglang.srt.managers.schedule_batch import FINISH_ABORT
 
         session_id = req.session.session_id
         slot = self.slots.get(session_id)
@@ -326,19 +316,20 @@ class SessionAwareCache(BasePrefixCache):
 
         Tokens below cache_protected_len belong to the radix tree and must
         not be freed here (they are released via dec_lock_ref on session close).
+        The effective truncation length is clamped to cache_protected_len to
+        preserve the invariant kv_committed_len >= cache_protected_len.
         """
+        new_len = max(new_len, slot.cache_protected_len)
         old_allocated = slot.kv_allocated_len
-        free_start = max(new_len, slot.cache_protected_len)
-        if free_start < old_allocated:
+        if new_len < old_allocated:
             excess = self.req_to_token_pool.req_to_token[
-                req.req_pool_idx, free_start:old_allocated
+                req.req_pool_idx, new_len:old_allocated
             ]
             self.token_to_kv_pool_allocator.free(excess)
-        new_allocated = max(new_len, slot.cache_protected_len)
         slot.kv_committed_len = new_len
-        slot.kv_allocated_len = new_allocated
+        slot.kv_allocated_len = new_len
         req.kv_committed_len = new_len
-        req.kv_allocated_len = new_allocated
+        req.kv_allocated_len = new_len
 
     # -- Session lifecycle --
 

--- a/python/sglang/srt/mem_cache/session_aware_cache.py
+++ b/python/sglang/srt/mem_cache/session_aware_cache.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import torch
 
+from sglang.srt.managers.schedule_batch import FINISH_ABORT
 from sglang.srt.mem_cache.base_prefix_cache import (
     BasePrefixCache,
     DecLockRefParams,
@@ -186,8 +187,6 @@ class SessionAwareCache(BasePrefixCache):
         if not _is_streaming(req):
             return self.inner.match_prefix(params)
 
-        from sglang.srt.managers.schedule_batch import FINISH_ABORT
-
         if isinstance(req.to_finish, FINISH_ABORT) or isinstance(
             req.finished_reason, FINISH_ABORT
         ):
@@ -233,8 +232,6 @@ class SessionAwareCache(BasePrefixCache):
     def cache_finished_req(self, req: Req, is_insert: bool = True, **kwargs):
         if not _is_streaming(req):
             return self.inner.cache_finished_req(req, is_insert=is_insert, **kwargs)
-
-        from sglang.srt.managers.schedule_batch import FINISH_ABORT
 
         if isinstance(req.to_finish, FINISH_ABORT) or isinstance(
             req.finished_reason, FINISH_ABORT

--- a/python/sglang/srt/mem_cache/session_aware_cache.py
+++ b/python/sglang/srt/mem_cache/session_aware_cache.py
@@ -186,6 +186,13 @@ class SessionAwareCache(BasePrefixCache):
         if not _is_streaming(req):
             return self.inner.match_prefix(params)
 
+        from sglang.srt.managers.schedule_batch import FINISH_ABORT
+
+        if isinstance(req.to_finish, FINISH_ABORT) or isinstance(
+            req.finished_reason, FINISH_ABORT
+        ):
+            return self.inner.match_prefix(params)
+
         session_id = req.session.session_id
         slot = self.slots.get(session_id)
         if slot is None or slot.req_pool_idx is None:
@@ -203,10 +210,15 @@ class SessionAwareCache(BasePrefixCache):
 
         slot.restore_to_req(req)
 
+        max_reuse = req.kv_committed_len
+        if req.kv_reuse_len is not None and req.kv_reuse_len < max_reuse:
+            self._truncate_slot(slot, req, req.kv_reuse_len)
+            max_reuse = req.kv_reuse_len
+
         # logprob_start_len is already forced to -1 for streaming sessions
         # (in Req.init_next_round_input), so the prefix key is not truncated
         # and we can directly reuse the committed KV length.
-        prefix_len = min(req.kv_committed_len, max(len(params.key.token_ids) - 1, 0))
+        prefix_len = min(max_reuse, max(len(params.key.token_ids) - 1, 0))
         device_indices = self.req_to_token_pool.req_to_token[
             req.req_pool_idx, :prefix_len
         ].to(dtype=torch.int64)
@@ -223,6 +235,12 @@ class SessionAwareCache(BasePrefixCache):
             return self.inner.cache_finished_req(req, is_insert=is_insert, **kwargs)
 
         from sglang.srt.managers.schedule_batch import FINISH_ABORT
+
+        if isinstance(req.to_finish, FINISH_ABORT) or isinstance(
+            req.finished_reason, FINISH_ABORT
+        ):
+            self.inner.cache_finished_req(req, is_insert=is_insert, **kwargs)
+            return
 
         session_id = req.session.session_id
         slot = self.slots.get(session_id)
@@ -305,6 +323,25 @@ class SessionAwareCache(BasePrefixCache):
         if isinstance(node, _VirtualNode):
             return DecLockRefResult()
         return self.inner.dec_lock_ref(node, params)
+
+    def _truncate_slot(self, slot: SessionSlot, req: "Req", new_len: int):
+        """Truncate KV state to new_len, freeing excess entries.
+
+        Tokens below cache_protected_len belong to the radix tree and must
+        not be freed here (they are released via dec_lock_ref on session close).
+        """
+        old_allocated = slot.kv_allocated_len
+        free_start = max(new_len, slot.cache_protected_len)
+        if free_start < old_allocated:
+            excess = self.req_to_token_pool.req_to_token[
+                req.req_pool_idx, free_start:old_allocated
+            ]
+            self.token_to_kv_pool_allocator.free(excess)
+        new_allocated = max(new_len, slot.cache_protected_len)
+        slot.kv_committed_len = new_len
+        slot.kv_allocated_len = new_allocated
+        req.kv_committed_len = new_len
+        req.kv_allocated_len = new_allocated
 
     # -- Session lifecycle --
 

--- a/test/registered/sessions/test_streaming_session_backtrack.py
+++ b/test/registered/sessions/test_streaming_session_backtrack.py
@@ -1,0 +1,224 @@
+"""
+Streaming session backtracking tests: basic backtrack, drop_previous_output,
+offset, invalid rid rejection, and memory leak after repeated backtracks.
+
+All tests share a single server (DEFAULT_SMALL_MODEL) with streaming sessions
+and chunked prefill enabled.
+
+Usage:
+    python -m pytest test_streaming_backtrack.py -xvs
+    python -m unittest test_streaming_backtrack.TestStreamingBacktrack
+"""
+
+import time
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import (
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=60, suite="stage-b-test-1-gpu-large")
+
+
+class TestStreamingSessionBacktrack(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--enable-streaming-session",
+                "--chunked-prefill-size",
+                "512",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _open_session(self):
+        requests.post(self.base_url + "/flush_cache")
+        resp = requests.post(
+            self.base_url + "/open_session",
+            json={"capacity_of_str_len": 4096, "streaming": True},
+        )
+        self.assertEqual(resp.status_code, 200)
+        return resp.json()
+
+    def _close_session(self, session_id):
+        resp = requests.post(
+            self.base_url + "/close_session",
+            json={"session_id": session_id},
+        )
+        self.assertEqual(resp.status_code, 200)
+
+    def _generate(self, text, session_params=None, max_new_tokens=16):
+        payload = {
+            "text": text,
+            "sampling_params": {
+                "temperature": 0,
+                "max_new_tokens": max_new_tokens,
+                "no_stop_trim": True,
+            },
+        }
+        if session_params is not None:
+            payload["session_params"] = session_params
+        resp = requests.post(self.base_url + "/generate", json=payload, timeout=120)
+        self.assertEqual(resp.status_code, 200, f"Generate failed: {resp.text}")
+        return resp.json()
+
+    # ------------------------------------------------------------------
+    # Tests
+    # ------------------------------------------------------------------
+
+    def test_basic_backtrack(self):
+        """Backtrack to an earlier turn and branch; KV should be reused."""
+        sid = self._open_session()
+
+        r1 = self._generate("Hello world", session_params={"id": sid})
+        rid1 = r1["meta_info"]["id"]
+
+        r2 = self._generate(" How are you?", session_params={"id": sid, "rid": rid1})
+        rid2 = r2["meta_info"]["id"]
+        self.assertGreater(
+            r2["meta_info"]["cached_tokens"], 0, "Turn 2 should reuse KV"
+        )
+
+        # Backtrack to turn 1 — should still have cached KV
+        r3 = self._generate(
+            " What about France?", session_params={"id": sid, "rid": rid1}
+        )
+        self.assertGreater(
+            r3["meta_info"]["cached_tokens"],
+            0,
+            "Backtrack should reuse KV from turn 1",
+        )
+
+        self._close_session(sid)
+
+    def test_drop_previous_output(self):
+        """Backtrack with drop_previous_output reduces prompt tokens."""
+        sid = self._open_session()
+
+        r1 = self._generate("Hello world", session_params={"id": sid})
+        rid1 = r1["meta_info"]["id"]
+
+        self._generate(" Continue.", session_params={"id": sid, "rid": rid1})
+
+        # Backtrack with output kept
+        r_with = self._generate(" Summarize.", session_params={"id": sid, "rid": rid1})
+        # Backtrack with output dropped
+        r_drop = self._generate(
+            " Summarize.",
+            session_params={
+                "id": sid,
+                "rid": rid1,
+                "drop_previous_output": True,
+            },
+        )
+        self.assertLess(
+            r_drop["meta_info"]["prompt_tokens"],
+            r_with["meta_info"]["prompt_tokens"],
+            "drop_previous_output should produce fewer prompt tokens",
+        )
+
+        self._close_session(sid)
+
+    def test_offset(self):
+        """Backtrack with offset truncates the base context."""
+        sid = self._open_session()
+
+        r1 = self._generate("Hello world", session_params={"id": sid})
+        rid1 = r1["meta_info"]["id"]
+
+        r2 = self._generate(" Continue.", session_params={"id": sid, "rid": rid1})
+
+        # Backtrack with a small offset — fewer prompt tokens than full context
+        r_off = self._generate(
+            " Continue.",
+            session_params={"id": sid, "rid": rid1, "offset": 5},
+        )
+        continue_tokens = (
+            r2["meta_info"]["prompt_tokens"]
+            - r1["meta_info"]["prompt_tokens"]
+            - r1["meta_info"]["completion_tokens"]
+        )
+        self.assertEqual(
+            r_off["meta_info"]["prompt_tokens"],
+            5 + continue_tokens,
+            "prompt_tokens should be exactly offset + new input tokens",
+        )
+
+        self._close_session(sid)
+
+    def test_invalid_rid_after_backtrack(self):
+        """After backtrack, the superseded rid should be rejected."""
+        sid = self._open_session()
+
+        r1 = self._generate("Hello world", session_params={"id": sid})
+        rid1 = r1["meta_info"]["id"]
+
+        r2 = self._generate(" How are you?", session_params={"id": sid, "rid": rid1})
+        rid2 = r2["meta_info"]["id"]
+
+        # Backtrack to rid1 — this should invalidate rid2
+        self._generate(" What about France?", session_params={"id": sid, "rid": rid1})
+
+        # rid2 should now be rejected
+        resp = requests.post(
+            self.base_url + "/generate",
+            json={
+                "text": " Fail.",
+                "sampling_params": {"temperature": 0, "max_new_tokens": 8},
+                "session_params": {"id": sid, "rid": rid2},
+            },
+            timeout=120,
+        )
+        self.assertNotEqual(
+            resp.status_code,
+            200,
+            "Request with invalidated rid should be rejected",
+        )
+
+        self._close_session(sid)
+
+    def test_no_memory_leak(self):
+        """Multiple backtracks should not leak KV memory."""
+        sid = self._open_session()
+
+        r1 = self._generate("Hello world", session_params={"id": sid})
+        rid1 = r1["meta_info"]["id"]
+
+        # Several forward-then-backtrack cycles
+        for i in range(5):
+            self._generate(f" Turn {i}.", session_params={"id": sid, "rid": rid1})
+
+        self._close_session(sid)
+        requests.post(self.base_url + "/flush_cache")
+        time.sleep(3)
+        health = requests.get(self.base_url + "/health")
+        self.assertEqual(
+            health.status_code,
+            200,
+            "Server unhealthy after repeated backtracks — likely a KV memory leak.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/sessions/test_streaming_session_backtrack.py
+++ b/test/registered/sessions/test_streaming_session_backtrack.py
@@ -1,6 +1,6 @@
 """
-Streaming session backtracking tests: basic backtrack, drop_previous_output,
-offset, invalid rid rejection, and memory leak after repeated backtracks.
+Streaming session backtracking tests: offset-based backtrack, KV reuse,
+and memory leak verification.
 
 All tests share a single server (DEFAULT_SMALL_MODEL) with streaming sessions
 and chunked prefill enabled.
@@ -87,127 +87,79 @@ class TestStreamingSessionBacktrack(CustomTestCase):
     # Tests
     # ------------------------------------------------------------------
 
-    def test_basic_backtrack(self):
-        """Backtrack to an earlier turn and branch; KV should be reused."""
+    def test_basic_backtrack_with_offset(self):
+        """Backtrack via offset to an earlier position; KV should be reused."""
         sid = self._open_session()
 
+        # Turn 1
         r1 = self._generate("Hello world", session_params={"id": sid})
-        rid1 = r1["meta_info"]["id"]
+        turn1_end = (
+            r1["meta_info"]["prompt_tokens"] + r1["meta_info"]["completion_tokens"]
+        )
 
-        r2 = self._generate(" How are you?", session_params={"id": sid, "rid": rid1})
-        rid2 = r2["meta_info"]["id"]
+        # Turn 2 — appends to turn 1
+        r2 = self._generate(" How are you?", session_params={"id": sid})
         self.assertGreater(
             r2["meta_info"]["cached_tokens"], 0, "Turn 2 should reuse KV"
         )
 
-        # Backtrack to turn 1 — should still have cached KV
+        # Backtrack to end of turn 1 via offset — should still reuse KV
         r3 = self._generate(
-            " What about France?", session_params={"id": sid, "rid": rid1}
+            " What about France?",
+            session_params={"id": sid, "offset": turn1_end},
         )
-        self.assertGreater(
+        self.assertEqual(
             r3["meta_info"]["cached_tokens"],
-            0,
-            "Backtrack should reuse KV from turn 1",
+            turn1_end,
+            "Backtrack via offset should reuse exactly turn1's KV",
         )
 
         self._close_session(sid)
 
-    def test_drop_previous_output(self):
-        """Backtrack with drop_previous_output reduces prompt tokens."""
+    def test_offset_truncates_context(self):
+        """Offset truncates the base context to the specified position."""
         sid = self._open_session()
 
+        # Turn 1
         r1 = self._generate("Hello world", session_params={"id": sid})
-        rid1 = r1["meta_info"]["id"]
 
-        self._generate(" Continue.", session_params={"id": sid, "rid": rid1})
+        # Turn 2 — normal append
+        r2 = self._generate(" Continue.", session_params={"id": sid})
 
-        # Backtrack with output kept
-        r_with = self._generate(" Summarize.", session_params={"id": sid, "rid": rid1})
-        # Backtrack with output dropped
-        r_drop = self._generate(
-            " Summarize.",
-            session_params={
-                "id": sid,
-                "rid": rid1,
-                "drop_previous_output": True,
-            },
-        )
-        self.assertLess(
-            r_drop["meta_info"]["prompt_tokens"],
-            r_with["meta_info"]["prompt_tokens"],
-            "drop_previous_output should produce fewer prompt tokens",
-        )
-
-        self._close_session(sid)
-
-    def test_offset(self):
-        """Backtrack with offset truncates the base context."""
-        sid = self._open_session()
-
-        r1 = self._generate("Hello world", session_params={"id": sid})
-        rid1 = r1["meta_info"]["id"]
-
-        r2 = self._generate(" Continue.", session_params={"id": sid, "rid": rid1})
-
-        # Backtrack with a small offset — fewer prompt tokens than full context
-        r_off = self._generate(
+        # Turn 3 — backtrack with a small offset
+        r3 = self._generate(
             " Continue.",
-            session_params={"id": sid, "rid": rid1, "offset": 5},
+            session_params={"id": sid, "offset": 5},
         )
-        continue_tokens = (
+        append_tokens = (
             r2["meta_info"]["prompt_tokens"]
             - r1["meta_info"]["prompt_tokens"]
             - r1["meta_info"]["completion_tokens"]
         )
         self.assertEqual(
-            r_off["meta_info"]["prompt_tokens"],
-            5 + continue_tokens,
+            r3["meta_info"]["prompt_tokens"],
+            5 + append_tokens,
             "prompt_tokens should be exactly offset + new input tokens",
         )
 
         self._close_session(sid)
 
-    def test_invalid_rid_after_backtrack(self):
-        """After backtrack, the superseded rid should be rejected."""
-        sid = self._open_session()
-
-        r1 = self._generate("Hello world", session_params={"id": sid})
-        rid1 = r1["meta_info"]["id"]
-
-        r2 = self._generate(" How are you?", session_params={"id": sid, "rid": rid1})
-        rid2 = r2["meta_info"]["id"]
-
-        # Backtrack to rid1 — this should invalidate rid2
-        self._generate(" What about France?", session_params={"id": sid, "rid": rid1})
-
-        # rid2 should now be rejected with HTTP 400
-        resp = requests.post(
-            self.base_url + "/generate",
-            json={
-                "text": " Fail.",
-                "sampling_params": {"temperature": 0, "max_new_tokens": 8},
-                "session_params": {"id": sid, "rid": rid2},
-            },
-            timeout=120,
-        )
-        self.assertEqual(
-            resp.status_code,
-            400,
-            "Request with invalidated rid should be rejected with 400",
-        )
-
-        self._close_session(sid)
-
     def test_no_memory_leak(self):
-        """Multiple backtracks should not leak KV memory."""
+        """Multiple backtracks via offset should not leak KV memory."""
         sid = self._open_session()
 
+        # Turn 1
         r1 = self._generate("Hello world", session_params={"id": sid})
-        rid1 = r1["meta_info"]["id"]
+        turn1_end = (
+            r1["meta_info"]["prompt_tokens"] + r1["meta_info"]["completion_tokens"]
+        )
 
         # Several forward-then-backtrack cycles
         for i in range(5):
-            self._generate(f" Turn {i}.", session_params={"id": sid, "rid": rid1})
+            self._generate(
+                f" Turn {i}.",
+                session_params={"id": sid, "offset": turn1_end},
+            )
 
         self._close_session(sid)
         requests.post(self.base_url + "/flush_cache")

--- a/test/registered/sessions/test_streaming_session_backtrack.py
+++ b/test/registered/sessions/test_streaming_session_backtrack.py
@@ -6,8 +6,8 @@ All tests share a single server (DEFAULT_SMALL_MODEL) with streaming sessions
 and chunked prefill enabled.
 
 Usage:
-    python -m pytest test_streaming_backtrack.py -xvs
-    python -m unittest test_streaming_backtrack.TestStreamingBacktrack
+    python -m pytest test_streaming_session_backtrack.py -xvs
+    python -m unittest test_streaming_session_backtrack.TestStreamingSessionBacktrack
 """
 
 import time
@@ -180,7 +180,7 @@ class TestStreamingSessionBacktrack(CustomTestCase):
         # Backtrack to rid1 — this should invalidate rid2
         self._generate(" What about France?", session_params={"id": sid, "rid": rid1})
 
-        # rid2 should now be rejected
+        # rid2 should now be rejected with HTTP 400
         resp = requests.post(
             self.base_url + "/generate",
             json={
@@ -190,10 +190,10 @@ class TestStreamingSessionBacktrack(CustomTestCase):
             },
             timeout=120,
         )
-        self.assertNotEqual(
+        self.assertEqual(
             resp.status_code,
-            200,
-            "Request with invalidated rid should be rejected",
+            400,
+            "Request with invalidated rid should be rejected with 400",
         )
 
         self._close_session(sid)
@@ -212,12 +212,24 @@ class TestStreamingSessionBacktrack(CustomTestCase):
         self._close_session(sid)
         requests.post(self.base_url + "/flush_cache")
         time.sleep(3)
+
         health = requests.get(self.base_url + "/health")
         self.assertEqual(
             health.status_code,
             200,
             "Server unhealthy after repeated backtracks — likely a KV memory leak.",
         )
+
+        # After close + flush, a fresh session should start with 0 cached tokens.
+        # If KV was leaked, the old tokens would still occupy slots.
+        sid2 = self._open_session()
+        r = self._generate("Fresh start", session_params={"id": sid2})
+        self.assertEqual(
+            r["meta_info"]["cached_tokens"],
+            0,
+            "Fresh session after flush should have 0 cached tokens — KV may have leaked.",
+        )
+        self._close_session(sid2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Streaming sessions currently only support simple linear appends, which limits use cases of  rewind / backtrack, e.g., chatbot regeneration, where the user needs to branch from an earlier turn.

## Modifications

<!-- Detail the changes made in this pull request. -->

- `session_controller.py`
  Streaming sessions now accept `offset` in `session_params` to truncate KV to a given position before appending new input. The client manages turn boundaries; the server stays stateless regarding turn semantics.
- `session_aware_cache.py`
  Add `_truncate_slot()` to free excess KV on backtrack; guard `match_prefix`/`cache_finished_req` against `FINISH_ABORT` to prevent slot corruption.
- `schedule_batch.py`
  Add `kv_reuse_len` field on `Req` to communicate the KV truncation point from session controller to cache layer.
- `test_streaming_session_backtrack.py`
  Tests for offset-based backtrack with KV reuse and KV memory leak verification.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

Tested with https://github.com/sgl-project/sglang/blob/main/test/registered/sessions/test_session_latency.py

- main branch

```
  SUMMARY  (8 sessions x 150 turns)
Mode                 Avg (all)    Avg (last 10)    Speedup (all)    Speedup (last 10)
-----------------  -----------  ---------------  ---------------  -------------------
regular_session        139.6ms          192.8ms            1.00x                1.00x
streaming_session      109.4ms          110.9ms            1.28x                1.74x
```

- this PR

```
  SUMMARY  (8 sessions x 150 turns)
Mode                 Avg (all)    Avg (last 10)    Speedup (all)    Speedup (last 10)
-----------------  -----------  ---------------  ---------------  -------------------
regular_session        138.3ms          187.3ms            1.00x                1.00x
streaming_session      108.3ms          109.1ms            1.28x                1.72x
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
