### PR TITLE
[NVIDIA] Support flashinfer a2a with flashinfer_trtllm_routed moe

### DIFF
--- a/docs_new/docs/advanced_features/expert_parallelism.mdx
+++ b/docs_new/docs/advanced_features/expert_parallelism.mdx
@@ -112,12 +112,12 @@ Currently, DeepEP, Mooncake, NIXL-EP, `ascend_fuseep` and MORI only support case
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>flashinfer_trtllm_routed</code></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>FlashInfer integrated with TensorRT-LLM for accelerated routed MoE computations, consuming SGLang-computed top-k expert assignments and weights.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>FlashInfer integrated with TensorRT-LLM for accelerated routed MoE computations, consuming SGLang-computed top-k expert assignments and weights. Compatible with flashinfer all-to-all.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Blackwell with TRT-LLM.</td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`flashinfer_cutlass`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>FlashInfer combined with CUTLASS for high-performance grouped GEMMs in MoE layers, handling FP4/FP8 quantization efficiently.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>FlashInfer combined with CUTLASS for high-performance grouped GEMMs in MoE layers, handling FP4/FP8 quantization efficiently.  Compatible with flashinfer all-to-all.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Blackwell with FP4/FP8 models.</td>
     </tr>
     <tr>
@@ -127,7 +127,7 @@ Currently, DeepEP, Mooncake, NIXL-EP, `ascend_fuseep` and MORI only support case
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`flashinfer_cutedsl`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>FlashInfer with a custom DSL for flexible and efficient MoE kernel generation, integrated with ModelOpt FP4 quantization.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>FlashInfer with a custom DSL for flexible and efficient MoE kernel generation, integrated with ModelOpt FP4 quantization. Compatible with flashinfer all-to-all.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Low-precision models with NVFP4.</td>
     </tr>
   </tbody>

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -96,6 +96,10 @@ if TYPE_CHECKING:
         StandardCombineInput,
         StandardDispatchOutput,
     )
+    from sglang.srt.layers.moe.token_dispatcher.flashinfer import (
+        FlashinferCombineInput,
+        FlashinferDispatchOutput,
+    )
 
 if is_flashinfer_available():
     from sglang.srt.layers.quantization.fp4_utils import fp4_quantize
@@ -926,7 +930,14 @@ def fused_experts_none_to_flashinfer_trtllm_fp4(
     topk_output = dispatch_output.topk_output
 
     # Quantize hidden states to FP4
-    if quant_info.use_per_token_activation:
+    hidden_states_scale = dispatch_output.hidden_states_scale
+    per_token_scale = None
+    if hidden_states_scale is not None:
+        # NVFP4 dispatch, inputs are already quantized.
+        hs_fp4 = hidden_states
+        hs_scale_linear = hidden_states_scale
+    elif quant_info.use_per_token_activation:
+        #  Enable FlashInfer TRTLLM per-token NVFP4 activation scaling; ignores checkpoint activation FP32 scale by treating it as
         from flashinfer import SfLayout, nvfp4_quantize
 
         e4m3_max = 448.0
@@ -949,7 +960,6 @@ def fused_experts_none_to_flashinfer_trtllm_fp4(
             seq_len, hidden_size // 16
         )
     else:
-        per_token_scale = None
         hs_fp4, hs_scale_linear = quantize_hidden_states_fp4(
             hidden_states, quant_info.w13_input_scale_quant
         )
@@ -960,6 +970,48 @@ def fused_experts_none_to_flashinfer_trtllm_fp4(
         runner_config.activation, is_gated=runner_config.is_gated
     )
 
+<<<<<<< HEAD
+=======
+    # Build per-expert clamp-limit tensor from the per-layer scalar.
+    _clamp_val = runner_config.gemm1_clamp_limit
+    if _clamp_val is not None:
+        gemm1_clamp_limit = torch.full(
+            (quant_info.local_num_experts,),
+            _clamp_val,
+            dtype=torch.float32,
+            device=hs_fp4.device,
+        )
+    else:
+        gemm1_clamp_limit = None
+
+    num_tokens = hs_fp4.shape[0]
+    hidden_size = (
+        hs_fp4.shape[-1] * 2 if hs_fp4.dtype == torch.uint8 else hs_fp4.shape[-1]
+    )
+    output_dtype = (
+        hidden_states.dtype if hidden_states_scale is None else torch.bfloat16
+    )
+    _provided = _moe_output_buf.get()
+    _symm_required = is_allocation_symmetric()
+    if (
+        _provided is not None
+        and _provided.shape == (num_tokens, hidden_size)
+        and _provided.dtype == output_dtype
+        and _provided.device == hs_fp4.device
+        and (
+            not _symm_required
+            or not is_symmetric_memory_enabled()
+            or is_tensor_in_symmetric_mempool(_provided)
+        )
+    ):
+        symm_output = _provided
+    else:
+        with use_symmetric_memory(get_tp_group(), disabled=not _symm_required):
+            symm_output = torch.empty(
+                num_tokens, hidden_size, dtype=output_dtype, device=hs_fp4.device
+            )
+
+>>>>>>> c5de784adc (Support flashinfer_trtllm_routed with flashinfer a2a)
     # Fall back to routed path when topk was already materialized (e.g. sigmoid routing).
     if not use_routed_topk and TopKOutputChecker.format_is_standard(topk_output):
         use_routed_topk = True
@@ -1285,7 +1337,54 @@ def fused_experts_none_to_flashinfer_trtllm_routed(
     )
 
 
+<<<<<<< HEAD
 # Register the experimental experimental_sgl_trtllm MoE fused-func (MoeRunner needs it at
 # build time even for LoRA); gated by the master switch so the upstream path is untouched.
 if _SGLANG_EXPERIMENTAL_LORA_OPTI:
     from sglang.srt.lora.trtllm_lora_temp import sgl_backend  # noqa: E402,F401
+=======
+@register_fused_func("flashinfer", "flashinfer_trtllm_routed")
+def fused_experts_flashinfer_to_flashinfer_trtllm_routed(
+    dispatch_output: FlashinferDispatchOutput,
+    quant_info: MoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+) -> FlashinferCombineInput:
+    """Fused function for flashinfer A2A + flashinfer_trtllm_routed runner.
+
+    FlashinferDispatchOutput and StandardDispatchOutput share the same field
+    layout (hidden_states, hidden_states_scale, topk_output), so the existing
+    FP8/FP4/BF16 implementations work unchanged.  We wrap the returned
+    StandardCombineInput into a FlashinferCombineInput for the FlashinferDispatcher
+    combine path.
+    """
+    from sglang.srt.layers.moe.token_dispatcher.flashinfer import (
+        FlashinferCombineInput,
+    )
+
+    if isinstance(quant_info, FlashInferTrtllmFp4MoeQuantInfo):
+        result = fused_experts_none_to_flashinfer_trtllm_fp4(
+            dispatch_output,
+            quant_info,
+            runner_config,
+            use_routed_topk=True,
+        )
+    elif isinstance(quant_info, FlashInferTrtllmFp8MoeQuantInfo):
+        result = fused_experts_none_to_flashinfer_trtllm_fp8(
+            dispatch_output,
+            quant_info,
+            runner_config,
+            use_routed_topk=True,
+        )
+    elif isinstance(quant_info, FlashInferTrtllmBf16MoeQuantInfo):
+        result = fused_experts_none_to_flashinfer_trtllm_bf16(
+            dispatch_output,
+            quant_info,
+            runner_config,
+            use_routed_topk=True,
+        )
+    else:
+        raise TypeError(
+            f"Unexpected quant_info type for flashinfer a2a + flashinfer_trtllm_routed: {type(quant_info)}"
+        )
+    return FlashinferCombineInput(hidden_states=result.hidden_states)
+>>>>>>> c5de784adc (Support flashinfer_trtllm_routed with flashinfer a2a)

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -930,7 +930,7 @@ def fused_experts_none_to_flashinfer_trtllm_fp4(
     topk_output = dispatch_output.topk_output
 
     # Quantize hidden states to FP4
-    hidden_states_scale = dispatch_output.hidden_states_scale
+    hidden_states_scale = dispatch_output.hidden_states_scale if hasattr(dispatch_output, "hidden_states_scale") else None
     per_token_scale = None
     if hidden_states_scale is not None:
         # NVFP4 dispatch, inputs are already quantized.

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -930,7 +930,11 @@ def fused_experts_none_to_flashinfer_trtllm_fp4(
     topk_output = dispatch_output.topk_output
 
     # Quantize hidden states to FP4
-    hidden_states_scale = dispatch_output.hidden_states_scale if hasattr(dispatch_output, "hidden_states_scale") else None
+    hidden_states_scale = (
+        dispatch_output.hidden_states_scale
+        if hasattr(dispatch_output, "hidden_states_scale")
+        else None
+    )
     per_token_scale = None
     if hidden_states_scale is not None:
         # NVFP4 dispatch, inputs are already quantized.

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -970,48 +970,6 @@ def fused_experts_none_to_flashinfer_trtllm_fp4(
         runner_config.activation, is_gated=runner_config.is_gated
     )
 
-<<<<<<< HEAD
-=======
-    # Build per-expert clamp-limit tensor from the per-layer scalar.
-    _clamp_val = runner_config.gemm1_clamp_limit
-    if _clamp_val is not None:
-        gemm1_clamp_limit = torch.full(
-            (quant_info.local_num_experts,),
-            _clamp_val,
-            dtype=torch.float32,
-            device=hs_fp4.device,
-        )
-    else:
-        gemm1_clamp_limit = None
-
-    num_tokens = hs_fp4.shape[0]
-    hidden_size = (
-        hs_fp4.shape[-1] * 2 if hs_fp4.dtype == torch.uint8 else hs_fp4.shape[-1]
-    )
-    output_dtype = (
-        hidden_states.dtype if hidden_states_scale is None else torch.bfloat16
-    )
-    _provided = _moe_output_buf.get()
-    _symm_required = is_allocation_symmetric()
-    if (
-        _provided is not None
-        and _provided.shape == (num_tokens, hidden_size)
-        and _provided.dtype == output_dtype
-        and _provided.device == hs_fp4.device
-        and (
-            not _symm_required
-            or not is_symmetric_memory_enabled()
-            or is_tensor_in_symmetric_mempool(_provided)
-        )
-    ):
-        symm_output = _provided
-    else:
-        with use_symmetric_memory(get_tp_group(), disabled=not _symm_required):
-            symm_output = torch.empty(
-                num_tokens, hidden_size, dtype=output_dtype, device=hs_fp4.device
-            )
-
->>>>>>> c5de784adc (Support flashinfer_trtllm_routed with flashinfer a2a)
     # Fall back to routed path when topk was already materialized (e.g. sigmoid routing).
     if not use_routed_topk and TopKOutputChecker.format_is_standard(topk_output):
         use_routed_topk = True
@@ -1028,12 +986,15 @@ def fused_experts_none_to_flashinfer_trtllm_fp4(
         hidden_size = (
             hs_fp4.shape[-1] * 2 if hs_fp4.dtype == torch.uint8 else hs_fp4.shape[-1]
         )
+        output_dtype = (
+            hidden_states.dtype if hidden_states_scale is None else torch.bfloat16
+        )
         _provided = _moe_output_buf.get()
         _symm_required = is_allocation_symmetric()
         if (
             _provided is not None
             and _provided.shape == (num_tokens, hidden_size)
-            and _provided.dtype == hidden_states.dtype
+            and _provided.dtype == output_dtype
             and _provided.device == hs_fp4.device
             and (
                 not _symm_required
@@ -1047,7 +1008,7 @@ def fused_experts_none_to_flashinfer_trtllm_fp4(
                 symm_output = torch.empty(
                     hs_fp4.shape[0],
                     hidden_size,
-                    dtype=hidden_states.dtype,
+                    dtype=output_dtype,
                     device=hs_fp4.device,
                 )
 
@@ -1337,12 +1298,6 @@ def fused_experts_none_to_flashinfer_trtllm_routed(
     )
 
 
-<<<<<<< HEAD
-# Register the experimental experimental_sgl_trtllm MoE fused-func (MoeRunner needs it at
-# build time even for LoRA); gated by the master switch so the upstream path is untouched.
-if _SGLANG_EXPERIMENTAL_LORA_OPTI:
-    from sglang.srt.lora.trtllm_lora_temp import sgl_backend  # noqa: E402,F401
-=======
 @register_fused_func("flashinfer", "flashinfer_trtllm_routed")
 def fused_experts_flashinfer_to_flashinfer_trtllm_routed(
     dispatch_output: FlashinferDispatchOutput,
@@ -1387,4 +1342,9 @@ def fused_experts_flashinfer_to_flashinfer_trtllm_routed(
             f"Unexpected quant_info type for flashinfer a2a + flashinfer_trtllm_routed: {type(quant_info)}"
         )
     return FlashinferCombineInput(hidden_states=result.hidden_states)
->>>>>>> c5de784adc (Support flashinfer_trtllm_routed with flashinfer a2a)
+
+
+# Register the experimental experimental_sgl_trtllm MoE fused-func (MoeRunner needs it at
+# build time even for LoRA); gated by the master switch so the upstream path is untouched.
+if _SGLANG_EXPERIMENTAL_LORA_OPTI:
+    from sglang.srt.lora.trtllm_lora_temp import sgl_backend  # noqa: E402,F401

--- a/python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py
@@ -179,7 +179,16 @@ class FlashinferDispatcher(BaseDispatcher):
 
         global_scale = self.quant_config.get("input_global_scale", None)
         if global_scale is not None:
-            x, x_sf = fp4_quantize(x, global_scale, is_sf_swizzled_layout=False)
+            if x.shape[0] > 0:
+                x, x_sf = fp4_quantize(x, global_scale, is_sf_swizzled_layout=False)
+            else:
+                x_col = x.shape[1]
+                x = torch.zeros(
+                    0, x_col // 2, dtype=torch.uint8, device=x.device
+                )
+                x_sf = torch.zeros(
+                    0, x_col // 16, dtype=torch.uint8, device=x.device
+                )
 
         payloads = []
         payloads.append(x)

--- a/python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py
@@ -183,12 +183,8 @@ class FlashinferDispatcher(BaseDispatcher):
                 x, x_sf = fp4_quantize(x, global_scale, is_sf_swizzled_layout=False)
             else:
                 x_col = x.shape[1]
-                x = torch.zeros(
-                    0, x_col // 2, dtype=torch.uint8, device=x.device
-                )
-                x_sf = torch.zeros(
-                    0, x_col // 16, dtype=torch.uint8, device=x.device
-                )
+                x = torch.zeros(0, x_col // 2, dtype=torch.uint8, device=x.device)
+                x_sf = torch.zeros(0, x_col // 16, dtype=torch.uint8, device=x.device)
 
         payloads = []
         payloads.append(x)

--- a/python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py
@@ -97,7 +97,11 @@ class FlashinferDispatcher(BaseDispatcher):
         self.hidden_size = hidden_size
         self.num_experts = num_experts
         self.num_local_experts = num_local_experts
-
+        self.invalid_token_expert_id = (
+            -1
+            if get_moe_runner_backend().is_flashinfer_trtllm_routed()
+            else self.num_experts
+        )
         # TODO: Can other moe runners use payload_in_workspace too?
         self.payload_in_workspace = get_moe_runner_backend().is_flashinfer_cutlass()
 
@@ -214,7 +218,7 @@ class FlashinferDispatcher(BaseDispatcher):
             topk_ids,
             payloads,
             self.runtime_max_tokens_per_rank,
-            invalid_token_expert_id=self.num_experts,
+            invalid_token_expert_id=self.invalid_token_expert_id,
             expert_id_payload_index=expert_id_payload_index,
         )
         if x_sf is not None:

--- a/python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py
@@ -163,19 +163,6 @@ class FlashinferDispatcher(BaseDispatcher):
             mnnvl_config=MnnvlConfig(comm_backend=TorchDistributedCommBackend(group)),
         )
 
-        self.dummy_topk_ids = torch.full(
-            (1, self.router_topk), self.num_experts, dtype=torch.int32, device="cuda"
-        )
-        self.dummy_topk_ids_current_rank = torch.full(
-            (1, self.router_topk),
-            self.ep_rank * self.num_local_experts,
-            dtype=torch.int32,
-            device="cuda",
-        )
-        self.dummy_topk_weights = torch.zeros(
-            (1, self.router_topk), dtype=torch.float32, device="cuda"
-        )
-
     @debug_kernel_api
     def dispatch(
         self, hidden_states: torch.Tensor, topk_output: TopKOutput
@@ -185,12 +172,6 @@ class FlashinferDispatcher(BaseDispatcher):
         x_sf = None
         topk_ids = topk_output.topk_ids
         topk_weights = topk_output.topk_weights
-
-        self.has_dummy_token = x.shape[0] == 0
-        if self.has_dummy_token:
-            x = hidden_states.new_zeros((1, self.hidden_size))
-            topk_ids = self.dummy_topk_ids
-            topk_weights = self.dummy_topk_weights
 
         global_scale = self.quant_config.get("input_global_scale", None)
         if global_scale is not None:
@@ -222,8 +203,6 @@ class FlashinferDispatcher(BaseDispatcher):
             # in SP mode, full batch otherwise).  Avoids the pre-scatter
             # scheduler count which can exceed the workspace cap.
             self.runtime_max_tokens_per_rank = x.shape[0]
-        if self.has_dummy_token:
-            self.runtime_max_tokens_per_rank = max(self.runtime_max_tokens_per_rank, 1)
 
         # Passing topk_ids + invalid_token_expert_id triggers the sanitize step
         # inside moe_a2a. The recv buffer has shape
@@ -232,7 +211,7 @@ class FlashinferDispatcher(BaseDispatcher):
         # and waste downstream MoE compute. Sanitizing the padding to a
         # sentinel id is structural, not optional.
         recv_tensors = self.moe_a2a.dispatch(
-            self.dummy_topk_ids_current_rank if self.has_dummy_token else topk_ids,
+            topk_ids,
             payloads,
             self.runtime_max_tokens_per_rank,
             invalid_token_expert_id=self.num_experts,
@@ -275,9 +254,5 @@ class FlashinferDispatcher(BaseDispatcher):
             payload_in_workspace=self.payload_in_workspace,
         )
 
-        if self.has_dummy_token:
-            hidden_states = hidden_states[1:, :]
-
         del self.runtime_max_tokens_per_rank
-        del self.has_dummy_token
         return hidden_states

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -5524,7 +5524,10 @@ class ServerArgs:
             )
             if self.deepep_mode != "auto":
                 logger.warning("--deepep-mode is ignored for Flashinfer MoE A2A")
-            if not envs.SGLANG_MOE_NVFP4_DISPATCH.is_set():
+            if (
+                not envs.SGLANG_MOE_NVFP4_DISPATCH.is_set()
+                and self.quantization == "modelopt_fp4"
+            ):
                 envs.SGLANG_MOE_NVFP4_DISPATCH.set(True)
                 logger.warning(
                     "SGLANG_MOE_NVFP4_DISPATCH is set to True for Flashinfer MoE A2A"
@@ -5532,7 +5535,8 @@ class ServerArgs:
             assert self.moe_runner_backend in [
                 "flashinfer_cutlass",
                 "flashinfer_cutedsl",
-            ], "Flashinfer MoE A2A is only supported with flashinfer_cutlass or flashinfer_cutedsl moe runner backend"
+                "flashinfer_trtllm_routed",
+            ], "Flashinfer MoE A2A is only supported with flashinfer_cutlass, flashinfer_cutedsl or flashinfer_trtllm_routed moe runner backend"
 
         if self.moe_a2a_backend == "mori":
             self.ep_size = self.tp_size

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -5301,9 +5301,10 @@ class ServerArgs:
             ], "The expert parallel size must be 1 or the same as the tensor parallel size"
 
         if self.moe_runner_backend == "flashinfer_cutedsl":
-            assert self.quantization in [
-                "modelopt_fp4"
-            ], f"Invalid quantization '{self.quantization}'. \nFlashInfer CuteDSL MOE currently supports only: 'modelopt_fp4'."
+            assert (
+                self.quantization in ["modelopt_fp4"]
+                or self.get_model_config().nvfp4_moe_meta is not None
+            ), f"Invalid quantization '{self.quantization}'. \nFlashInfer CuteDSL MOE currently supports only: 'modelopt_fp4' or hybrid NVFP4 models."
             assert self.ep_size in [
                 1,
                 self.tp_size,
@@ -5524,9 +5525,9 @@ class ServerArgs:
             )
             if self.deepep_mode != "auto":
                 logger.warning("--deepep-mode is ignored for Flashinfer MoE A2A")
-            if (
-                not envs.SGLANG_MOE_NVFP4_DISPATCH.is_set()
-                and self.quantization == "modelopt_fp4"
+            if not envs.SGLANG_MOE_NVFP4_DISPATCH.is_set() and (
+                self.quantization == "modelopt_fp4"
+                or self.get_model_config().nvfp4_moe_meta is not None
             ):
                 envs.SGLANG_MOE_NVFP4_DISPATCH.set(True)
                 logger.warning(

--- a/test/registered/ep/test_flashinfer_a2a.py
+++ b/test/registered/ep/test_flashinfer_a2a.py
@@ -10,7 +10,12 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=900, suite="nightly-4-gpu-b200", nightly=True)
+register_cuda_ci(
+    est_time=900,
+    suite="nightly-4-gpu-b200",
+    nightly=True,
+    disabled="CI runner needs privileged for MNNVL",
+)
 
 DEEPSEEK_V3_FP4_MODEL = "nvidia/DeepSeek-V3-0324-FP4"
 QWEN3_FP8_MODEL = "Qwen/Qwen3-Next-80B-A3B-Instruct-FP8"

--- a/test/registered/ep/test_flashinfer_a2a.py
+++ b/test/registered/ep/test_flashinfer_a2a.py
@@ -10,12 +10,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(
-    est_time=900,
-    suite="nightly-4-gpu-b200",
-    nightly=True,
-    disabled="CI runner needs privileged for MNNVL",
-)
+register_cuda_ci(est_time=1800, stage="base-c", runner_config="4-gpu-gb300")
 
 DEEPSEEK_V3_FP4_MODEL = "nvidia/DeepSeek-V3-0324-FP4"
 QWEN3_FP8_MODEL = "Qwen/Qwen3-Next-80B-A3B-Instruct-FP8"

--- a/test/registered/ep/test_flashinfer_a2a.py
+++ b/test/registered/ep/test_flashinfer_a2a.py
@@ -47,6 +47,7 @@ class TestFlashinferA2ATrtllmRoutedFP4(CustomTestCase):
                 "flashinfer_trtllm_routed",
                 "--quantization",
                 "modelopt_fp4",
+                "--disable-flashinfer-autotune",
                 "--model-loader-extra-config",
                 '{"enable_multithread_load": true}',
             ],
@@ -101,6 +102,7 @@ class TestFlashinferA2ATrtllmRoutedFP8(CustomTestCase):
                 "0.7",
                 "--mamba-ssm-dtype",
                 "bfloat16",
+                "--disable-flashinfer-autotune",
             ],
         )
 

--- a/test/registered/ep/test_flashinfer_a2a.py
+++ b/test/registered/ep/test_flashinfer_a2a.py
@@ -1,0 +1,123 @@
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=900, suite="nightly-4-gpu-b200", nightly=True)
+
+DEEPSEEK_V3_FP4_MODEL = "nvidia/DeepSeek-V3-0324-FP4"
+QWEN3_FP8_MODEL = "Qwen/Qwen3-Next-80B-A3B-Instruct-FP8"
+SERVER_LAUNCH_TIMEOUT = 1000
+
+
+class TestFlashinferA2ATrtllmRoutedFP4(CustomTestCase):
+    """flashinfer A2A + flashinfer_trtllm_routed with modelopt_fp4 (DeepSeek V3)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEEPSEEK_V3_FP4_MODEL
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=SERVER_LAUNCH_TIMEOUT,
+            other_args=[
+                "--tp",
+                "4",
+                "--ep",
+                "4",
+                "--dp",
+                "4",
+                "--enable-dp-attention",
+                "--moe-a2a-backend",
+                "flashinfer",
+                "--moe-runner-backend",
+                "flashinfer_trtllm_routed",
+                "--quantization",
+                "modelopt_fp4",
+                "--model-loader-extra-config",
+                '{"enable_multithread_load": true}',
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process") and cls.process:
+            kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="gsm8k",
+            api="completion",
+            max_tokens=512,
+            num_examples=200,
+            num_threads=128,
+        )
+        metrics = run_eval(args)
+        print(f"{metrics=}")
+        self.assertGreater(metrics["score"], 0.90)
+
+
+class TestFlashinferA2ATrtllmRoutedFP8(CustomTestCase):
+    """flashinfer A2A + flashinfer_trtllm_routed with fp8 (Qwen3-Next)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = QWEN3_FP8_MODEL
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=SERVER_LAUNCH_TIMEOUT,
+            other_args=[
+                "--tp",
+                "4",
+                "--ep",
+                "4",
+                "--dp",
+                "4",
+                "--enable-dp-attention",
+                "--moe-a2a-backend",
+                "flashinfer",
+                "--moe-runner-backend",
+                "flashinfer_trtllm_routed",
+                "--attention-backend",
+                "triton",
+                "--mem-fraction-static",
+                "0.7",
+                "--mamba-ssm-dtype",
+                "bfloat16",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process") and cls.process:
+            kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="gsm8k",
+            api="completion",
+            max_tokens=512,
+            num_examples=200,
+            num_threads=128,
+        )
+        metrics = run_eval(args)
+        print(f"{metrics=}")
+        self.assertGreater(metrics["score"], 0.93)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ep/test_flashinfer_a2a.py
+++ b/test/registered/ep/test_flashinfer_a2a.py
@@ -10,7 +10,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=1800, stage="base-c", runner_config="4-gpu-gb300")
+register_cuda_ci(est_time=500, stage="base-c", runner_config="4-gpu-gb300")
 
 DEEPSEEK_V3_FP4_MODEL = "nvidia/DeepSeek-V3-0324-FP4"
 QWEN3_FP8_MODEL = "Qwen/Qwen3-Next-80B-A3B-Instruct-FP8"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Flashinfer a2a can now be used in combination with flashinfer_trtllm_routed moe.

## Modifications

* Adds "fused_func" for flashinfer dispatcher -> flashinfer_trtllm_routed moe runner
* Supports fp4 quantize before comm
* In Flashinfer dispatcher, remove dummy token workaround for zero local tokens - flashinfer a2a now supports this.
* Update server arg validation
* Add FP4 and FP8 e2e test

## Accuracy Tests

FP8
```
python3 -m sglang.launch_server   --model-path deepseek-ai/DeepSeek-R1-0528    --tp 4 --moe-a2a-backend flashinfer --moe-runner-backend flashinfer_trtllm_routed --ep 4 --dp 4 --enable-dp-attention --quantization fp8 --mem-fraction-static 0.95 --max-running-requests 512
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1209 --parallel 1209 --platinum
Accuracy: 0.984
Invalid: 0.000
Latency: 102.780 s
Output throughput: 1170.071 token/s
```

FP4
```
python3 -m sglang.launch_server   --model-path nvidia/DeepSeek-R1-0528-FP4-v2   --tp 4 --moe-a2a-backend flashinfer --moe-runner-backend flashinfer_trtllm_routed --ep 4 --dp 4 --enable-dp-attention --quantization modelopt_fp4
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1209 --parallel 1209 --platinum
Accuracy: 0.978
Invalid: 0.000
Latency: 16.056 s
Output throughput: 7645.199 token/s
```

## Speed Tests and Profiling

GB200 FP4 Disagg 4xDEP4 Prefill + 1xDEP32 Decode [srt-slurm config](https://github.com/trevor-m/srt-slurm/blob/flashinfer-a2a/recipes/gb200-fp4/1k1k/max-tpt-fi.yaml)
```
Maximum request concurrency: 512
============ Serving Benchmark Result ============
Successful requests:                     5120   
Benchmark duration (s):                  166.88
Total input tokens:                      4717859 
Total generated tokens:                  4722209  
Request throughput (req/s):              30.68
Output token throughput (tok/s):         28296.74
Total Token throughput (tok/s):          56567.42
---------------Time to First Token----------------
Mean TTFT (ms):                          818.76 
Median TTFT (ms):                        638.47 
P99 TTFT (ms):                           3433.44
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          16.44   
Median TPOT (ms):                        16.33   
P99 TPOT (ms):                           17.42   
---------------Inter-token Latency----------------
Mean ITL (ms):                           800.45
Median ITL (ms):                         805.71
P99 ITL (ms):                            1058.22
----------------End-to-end Latency----------------
Mean E2EL (ms):                          15969.19  
Median E2EL (ms):                        15930.51   
P99 E2EL (ms):                           19609.53  
==================================================

Maximum request concurrency: 2048
============ Serving Benchmark Result ============
Successful requests:                     20480
Benchmark duration (s):                  333.05
Total input tokens:                      18880692
Total generated tokens:                  18888974
Request throughput (req/s):              61.49
Output token throughput (tok/s):         56715.98
Total Token throughput (tok/s):          113407.09
---------------Time to First Token----------------
Mean TTFT (ms):                          1461.76
Median TTFT (ms):                        723.74
P99 TTFT (ms):                           12048.79
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          33.50
Median TPOT (ms):                        33.54
P99 TPOT (ms):                           35.81
---------------Inter-token Latency----------------
Mean ITL (ms):                           1631.86
Median ITL (ms):                         1695.71
P99 ITL (ms):                            2038.74
----------------End-to-end Latency----------------
Mean E2EL (ms):                          32327.96
Median E2EL (ms):                        31939.77
P99 E2EL (ms):                           45540.03
==================================================

Maximum request concurrency: 4096
============ Serving Benchmark Result ============
Successful requests:                     40960
Benchmark duration (s):                  513.58
Total input tokens:                      37769666
Total generated tokens:                  37742239
Request throughput (req/s):              79.75
Output token throughput (tok/s):         73488.77
Total Token throughput (tok/s):          147030.95
---------------Time to First Token----------------
Mean TTFT (ms):                          2173.38
Median TTFT (ms):                        771.77
P99 TTFT (ms):                           22110.64
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          51.97
Median TPOT (ms):                        52.47
P99 TPOT (ms):                           56.63
---------------Inter-token Latency----------------
Mean ITL (ms):                           2530.38
Median ITL (ms):                         2675.99
P99 ITL (ms):                            4023.23
----------------End-to-end Latency----------------
Mean E2EL (ms):                          50001.87
Median E2EL (ms):                        49519.06
P99 E2EL (ms):                           69921.02
==================================================
```

Baseline (deepep + flashinfer_cutedsl + SBO) [srt-slurm config](https://github.com/trevor-m/srt-slurm/blob/flashinfer-a2a/recipes/gb200-fp4/1k1k/max-tpt.yaml)
```
Maximum request concurrency: 512
============ Serving Benchmark Result ============
Successful requests:                     5120
Benchmark duration (s):                  154.96
Total input tokens:                      4717859
Total generated tokens:                  4722209
Request throughput (req/s):              33.04
Output token throughput (tok/s):         30473.36
Total Token throughput (tok/s):          60918.64
---------------Time to First Token----------------
Mean TTFT (ms):                          857.72
Median TTFT (ms):                        670.33
P99 TTFT (ms):                           3632.77
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          15.24
Median TPOT (ms):                        15.24
P99 TPOT (ms):                           15.66
---------------Inter-token Latency----------------
Mean ITL (ms):                           742.04
Median ITL (ms):                         759.97
P99 ITL (ms):                            920.63
----------------End-to-end Latency----------------
Mean E2EL (ms):                          14902.56
Median E2EL (ms):                        14830.25
P99 E2EL (ms):                           18559.29
==================================================
Maximum request concurrency: 2048        
============ Serving Benchmark Result ============
Successful requests:                     20480   
Benchmark duration (s):                  186.33  
Total input tokens:                      18880692
Total generated tokens:                  18888974 
Request throughput (req/s):              109.91
Output token throughput (tok/s):         101374.98
Total Token throughput (tok/s):          202705.51
---------------Time to First Token----------------
Mean TTFT (ms):                          1617.71
Median TTFT (ms):                        786.29
P99 TTFT (ms):                           11880.44
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          17.58   
Median TPOT (ms):                        17.56   
P99 TPOT (ms):                           18.43   
---------------Inter-token Latency----------------
Mean ITL (ms):                           856.31
Median ITL (ms):                         871.37
P99 ITL (ms):                            1543.57
----------------End-to-end Latency----------------
Mean E2EL (ms):                          17814.64  
Median E2EL (ms):                        17273.63  
P99 E2EL (ms):                           28485.44  
==================================================
Maximum request concurrency: 4096
============ Serving Benchmark Result ============
Successful requests:                     40960
Benchmark duration (s):                  324.86
Total input tokens:                      37769666
Total generated tokens:                  37742239
Request throughput (req/s):              126.08
Output token throughput (tok/s):         116179.28
Total Token throughput (tok/s):          232442.98
---------------Time to First Token----------------
Mean TTFT (ms):                          13768.68
Median TTFT (ms):                        15420.10
P99 TTFT (ms):                           22753.71
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          19.25
Median TPOT (ms):                        18.87
P99 TPOT (ms):                           25.37
---------------Inter-token Latency----------------
Mean ITL (ms):                           937.55
Median ITL (ms):                         884.23
P99 ITL (ms):                            2456.50
----------------End-to-end Latency----------------
Mean E2EL (ms):                          31489.99
Median E2EL (ms):                        31819.01
P99 E2EL (ms):                           44965.56
==================================================
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.























































































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #28403262062](https://github.com/sgl-project/sglang/actions/runs/28403262062)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28403262036](https://github.com/sgl-project/sglang/actions/runs/28403262036)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->