### PR TITLE
[CI] Increase stage-c-test-4-gpu-b200 partitions from 4 to 5

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1230,7 +1230,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        part: [0, 1, 2, 3]
+        part: [0, 1, 2, 3, 4]
 
     steps:
       - name: Checkout code
@@ -1261,7 +1261,7 @@ jobs:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
         run: |
           cd test
-          python3 run_suite.py --hw cuda --suite stage-c-test-4-gpu-b200 --auto-partition-id ${{ matrix.part }} --auto-partition-size 4 --timeout-per-file 1800 $CONTINUE_ON_ERROR_FLAG
+          python3 run_suite.py --hw cuda --suite stage-c-test-4-gpu-b200 --auto-partition-id ${{ matrix.part }} --auto-partition-size 5 --timeout-per-file 1800 $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
         if: failure()


### PR DESCRIPTION
## Summary
- Increase partition count for `stage-c-test-4-gpu-b200` from 4 to 5 to fix step timeouts

The suite currently has 14 tests totaling 7010s (116.8 min) of est_time. With 4 partitions, the average is 29.2 min/partition — less than 1 minute of headroom against the 30-minute step timeout, which doesn't account for ~2 min of setup overhead (dep install, validation).

This caused [partition 2 to time out](https://github.com/sgl-project/sglang/actions/runs/24151775392/job/70480431729) mid-test (`test_update_weights_from_disk_mxfp8.py` was interrupted).

3 lora tests were recently added to this suite, contributing 620s (10.3 min):
| Test | est_time | PR |
|------|----------|-----|
| `test_lora_qwen3_30b_a3b_instruct_2507_logprob_diff.py` | 160s | #21466 |
| `test_lora_qwen3_vl_30b_a3b_instruct_logprob_diff.py` | 160s | #21469 |
| `test_lora_gpt_oss_20b_logprob_diff.py` | 300s | #21570 |

With 5 partitions the average drops to **23.4 min/partition**, providing ~6 min of headroom.

## Test plan
- [ ] Verify all 5 partitions run and complete within the 30 min step timeout