### PR TITLE
[CI] Fast-fail on lint check failure in check-stage-health

### DIFF
--- a/.github/actions/check-stage-health/action.yml
+++ b/.github/actions/check-stage-health/action.yml
@@ -1,5 +1,5 @@
 name: Check Stage Health
-description: Fail fast if any job in the current workflow run has already failed. Auto-skips for scheduled runs.
+description: Fail fast if any job in the current workflow run has already failed, or if the lint check (from lint.yml) has failed. Auto-skips for scheduled runs.
 
 inputs:
   github-token:
@@ -26,6 +26,24 @@ runs:
           // Skip for scheduled runs — they should collect all failures, not fast-fail
           if (context.eventName === 'schedule') {
             core.info('Skipping health check for scheduled run');
+            return;
+          }
+
+          // Check lint status from the separate Lint workflow (lint.yml).
+          // listJobsForWorkflowRun only sees jobs within the SAME run, so we use
+          // checks.listForRef which queries by commit SHA across ALL workflows.
+          const ref = context.payload.pull_request?.head?.sha || context.sha;
+          const { data } = await github.rest.checks.listForRef({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref: ref,
+            check_name: 'lint',
+          });
+          const lintRun = data.check_runs.find(
+            cr => cr.app?.slug === 'github-actions'
+          );
+          if (lintRun?.status === 'completed' && lintRun?.conclusion === 'failure') {
+            core.setFailed('Fast-fail: lint check failed');
             return;
           }
 

--- a/python/sglang/version.py
+++ b/python/sglang/version.py
@@ -1,3 +1,5 @@
+import json  # noqa: test lint failure
+
 try:
     from sglang._version import __version__, __version_tuple__
 except ImportError:

--- a/python/sglang/version.py
+++ b/python/sglang/version.py
@@ -1,5 +1,3 @@
-import json  # noqa: test lint failure
-
 try:
     from sglang._version import __version__, __version_tuple__
 except ImportError:


### PR DESCRIPTION
## Summary
- Add lint failure detection to the `check-stage-health` action so that PR test jobs fast-fail when the lint check (from the separate `lint.yml` workflow) has failed.
- Uses `checks.listForRef` API which queries by commit SHA across all workflows, since `listJobsForWorkflowRun` only sees jobs within the same workflow run.
- Respects existing skip guards (scheduled runs, `SKIP_STAGE_HEALTH_CHECK`).

## Test plan
- [ ] Open a PR with a lint violation and verify that `check-stage-health` fails with "Fast-fail: lint check failed"
- [ ] Open a clean PR and verify that health check passes through to the existing job-failure logic