### PR TITLE
[sglang-miles] chore: add bias for base layer with lora

### DIFF
--- a/python/sglang/srt/lora/layers.py
+++ b/python/sglang/srt/lora/layers.py
@@ -36,6 +36,8 @@ class BaseLayerWithLoRA(nn.Module):
         self.lora_backend: BaseLoRABackend = lora_backend
         if hasattr(self.base_layer, "weight"):
             self.weight = self.base_layer.weight
+        if hasattr(self.base_layer, "bias") and self.base_layer.bias is not None:
+            self.bias = self.base_layer.bias
 
     def forward(self, x: torch.Tensor):
         return self.base_layer.forward(x)


### PR DESCRIPTION
## Summary
- Expose `bias` attribute on `BaseLayerWithLoRA` when the base layer has a non-None bias, mirroring the existing `weight` forwarding pattern.
related PR: 
- https://github.com/sgl-project/sglang/pull/22169