### PR TITLE
[diffusion] fix: use non-empty prompt for I2I warmup requests

### DIFF
--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -214,7 +214,7 @@ class Scheduler:
                         data_type=task_type.data_type(),
                         width=width,
                         height=height,
-                        prompt="",
+                        prompt=" ",
                         negative_prompt="",
                         image_path=[warmup_input_path],
                     )


### PR DESCRIPTION
## Motivation

Warmup requests for I2I/TI2I tasks (introduced in #16922) are created with `prompt=""`. This causes Qwen image-edit models (`qwen-image-edit-2511`) to crash during warmup:

```
TypeError: argument of type 'NoneType' is not iterable
  File "transformers/models/qwen2_vl/processing_qwen2_vl.py", line 107
    while self.image_token in text[i]:
```

The chain:
1. `scheduler.py` creates warmup `Req` with `prompt=""`
2. `QwenImageEditPlusPipelineConfig.prepare_image_processor_kwargs` checks `if not prompt:` → returns `{}` (no text)
3. `image_encoding.py` passes `texts=None` to the Qwen2VL processor
4. Processor crashes iterating over `None`

All 3 warmup resolutions fail, so torch.compile warmup never runs for these models.

## Modifications

Use `prompt=" "` (single space) instead of `prompt=""` for I2I/TI2I warmup requests. A single space is a valid minimal prompt that passes through the processor without crashing, matching the pattern used by `QwenImageLayeredSamplingParams` which defaults prompt to `" "`.

## Checklist
- [x] Format: `pre-commit run --all-files`
- [x] Issue: one-line fix, no tests affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)