### PR TITLE
[AMD][CI] Add GLM-5.1-MXFP4 nightly accuracy and performance benchmarks for MI30x and MI35x

### DIFF
--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -44,6 +44,7 @@ on:
           - nightly-8-gpu-qwen3-235b-rocm720
           - nightly-8-gpu-qwen35-rocm720
           - nightly-8-gpu-glm51-rocm720
+          - nightly-8-gpu-glm51-mxfp4-rocm720
           - nightly-8-gpu-minimax-m27-rocm720
           - nightly-1-gpu-zimage-turbo-rocm720
           - nightly-test-1-gpu-mi35x-rocm720
@@ -62,6 +63,7 @@ on:
           - nightly-8-gpu-mi35x-qwen35-rocm720
           - nightly-8-gpu-mi35x-glm51-rocm720
           - nightly-8-gpu-mi35x-glm5-mxfp4-rocm720
+          - nightly-8-gpu-mi35x-glm51-mxfp4-rocm720
       job_filter:
         description: 'Or type comma-separated job names (overrides dropdown if non-empty)'
         required: false
@@ -708,6 +710,57 @@ jobs:
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}
 
+  # 8-GPU GLM-5.1-MXFP4 (Accuracy + Performance combined) ROCm 7.2
+  nightly-8-gpu-glm51-mxfp4-rocm720:
+    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-glm51-mxfp4-rocm720,'))
+    runs-on: linux-mi325-8gpu-sglang
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Setup docker (ROCm 7.2)
+        run: |
+          touch github_summary.md
+          bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version rocm720
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Install dependencies
+        run: |
+          bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-test-time-deps
+          bash scripts/ci/amd/amd_ci_exec.sh pip install git+https://github.com/huggingface/transformers.git@96f807a33b75
+
+      - name: Pre-download model weights
+        timeout-minutes: 120
+        run: |
+          bash scripts/ci/amd/amd_ci_exec.sh \
+            python3 -c "from huggingface_hub import snapshot_download; snapshot_download('amd/GLM-5.1-MXFP4', max_workers=8)"
+
+      - name: Accuracy Test ROCm 7.2 (8-GPU GLM-5.1-MXFP4 NSA MoE)
+        timeout-minutes: 120
+        run: |
+          > github_summary.md
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e SGLANG_USE_AITER=1 \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-amd-accuracy-8-gpu-glm51-mxfp4 --nightly --timeout-per-file 3600 ${{ inputs.continue_on_error && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
+      - name: Performance Test ROCm 7.2 (8-GPU GLM-5.1-MXFP4)
+        timeout-minutes: 120
+        continue-on-error: true
+        run: |
+          > github_summary.md
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e SGLANG_USE_AITER=1 \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-perf-8-gpu-glm51-mxfp4 --nightly --timeout-per-file 5400 ${{ inputs.continue_on_error && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
   # 8-GPU MiniMax-M2.7 (Accuracy + Performance combined, replaces M2.5) ROCm 7.2
   nightly-8-gpu-minimax-m27-rocm720:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-minimax-m27-rocm720,'))
@@ -1331,6 +1384,56 @@ jobs:
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}
 
+  # MI35x 8-GPU GLM-5.1-MXFP4 (Accuracy + Performance combined) ROCm 7.2
+  nightly-8-gpu-mi35x-glm51-mxfp4-rocm720:
+    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-mi35x-glm51-mxfp4-rocm720,'))
+    runs-on: linux-mi35x-gpu-8
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Setup docker (ROCm 7.2)
+        run: |
+          touch github_summary.md
+          bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version rocm720
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Install dependencies
+        run: |
+          bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-test-time-deps
+          bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
+          bash scripts/ci/amd/amd_ci_exec.sh pip install git+https://github.com/huggingface/transformers.git@96f807a33b75
+
+      - name: Pre-download model weights
+        timeout-minutes: 120
+        run: |
+          bash scripts/ci/amd/amd_ci_exec.sh \
+            python3 -c "from huggingface_hub import snapshot_download; snapshot_download('amd/GLM-5.1-MXFP4', max_workers=8)"
+
+      - name: Accuracy Test MI35x ROCm 7.2 (8-GPU GLM-5.1-MXFP4 NSA MoE)
+        timeout-minutes: 180
+        run: |
+          > github_summary.md
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-glm51-mxfp4 --nightly --timeout-per-file 7200 ${{ inputs.continue_on_error && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
+      - name: Performance Test MI35x ROCm 7.2 (8-GPU GLM-5.1-MXFP4)
+        timeout-minutes: 120
+        continue-on-error: true
+        run: |
+          > github_summary.md
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-perf-8-gpu-mi35x-glm51-mxfp4 --nightly --timeout-per-file 5400 ${{ inputs.continue_on_error && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
   # MI35x 8-GPU GLM-5-MXFP4 (Accuracy + Performance combined) ROCm 7.2
   nightly-8-gpu-mi35x-glm5-mxfp4-rocm720:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-mi35x-glm5-mxfp4-rocm720,'))
@@ -1435,6 +1538,7 @@ jobs:
       - nightly-8-gpu-qwen3-235b-rocm720
       - nightly-8-gpu-qwen35-rocm720
       - nightly-8-gpu-glm51-rocm720
+      - nightly-8-gpu-glm51-mxfp4-rocm720
       - nightly-8-gpu-minimax-m27-rocm720
       # MI30x ROCm 7.2 Diffusion Tests
       - nightly-1-gpu-zimage-turbo-rocm720
@@ -1455,6 +1559,7 @@ jobs:
       - nightly-8-gpu-mi35x-qwen35-rocm720
       - nightly-8-gpu-mi35x-glm51-rocm720
       - nightly-8-gpu-mi35x-glm5-mxfp4-rocm720
+      - nightly-8-gpu-mi35x-glm51-mxfp4-rocm720
     runs-on: ubuntu-latest
     steps:
       - name: Check if any job failed

--- a/.github/workflows/nightly-test-amd.yml
+++ b/.github/workflows/nightly-test-amd.yml
@@ -44,6 +44,7 @@ on:
           - nightly-8-gpu-qwen3-235b
           - nightly-8-gpu-qwen35
           - nightly-8-gpu-glm51
+          - nightly-8-gpu-glm51-mxfp4
           - nightly-8-gpu-minimax-m27
           - nightly-1-gpu-zimage-turbo
           - nightly-test-1-gpu-mi35x
@@ -62,6 +63,7 @@ on:
           - nightly-8-gpu-mi35x-qwen35
           - nightly-8-gpu-mi35x-glm51
           - nightly-8-gpu-mi35x-glm5-mxfp4
+          - nightly-8-gpu-mi35x-glm51-mxfp4
       job_filter:
         description: 'Or type comma-separated job names (overrides dropdown if non-empty)'
         required: false
@@ -712,6 +714,57 @@ jobs:
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}
 
+  # 8-GPU GLM-5.1-MXFP4 (Accuracy + Performance combined)
+  nightly-8-gpu-glm51-mxfp4:
+    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-glm51-mxfp4,'))
+    runs-on: linux-mi325-8gpu-sglang
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Setup docker
+        run: |
+          touch github_summary.md
+          bash scripts/ci/amd/amd_ci_start_container.sh
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Install dependencies
+        run: |
+          bash scripts/ci/amd/amd_ci_install_dependency.sh
+          bash scripts/ci/amd/amd_ci_exec.sh pip install git+https://github.com/huggingface/transformers.git@96f807a33b75
+
+      - name: Pre-download model weights
+        timeout-minutes: 120
+        run: |
+          bash scripts/ci/amd/amd_ci_exec.sh \
+            python3 -c "from huggingface_hub import snapshot_download; snapshot_download('amd/GLM-5.1-MXFP4', max_workers=8)"
+
+      - name: Accuracy Test (8-GPU GLM-5.1-MXFP4 NSA MoE)
+        timeout-minutes: 120
+        run: |
+          > github_summary.md
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e SGLANG_USE_AITER=1 \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-amd-accuracy-8-gpu-glm51-mxfp4 --nightly --timeout-per-file 3600 ${{ inputs.continue_on_error && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
+      - name: Performance Test (8-GPU GLM-5.1-MXFP4)
+        timeout-minutes: 120
+        continue-on-error: true
+        run: |
+          > github_summary.md
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e SGLANG_USE_AITER=1 \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-perf-8-gpu-glm51-mxfp4 --nightly --timeout-per-file 5400 ${{ inputs.continue_on_error && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
   # 8-GPU MiniMax-M2.7 (Accuracy + Performance combined, replaces M2.5)
   nightly-8-gpu-minimax-m27:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-minimax-m27,'))
@@ -1338,6 +1391,56 @@ jobs:
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}
 
+  # MI35x 8-GPU GLM-5.1-MXFP4 (Accuracy + Performance combined)
+  nightly-8-gpu-mi35x-glm51-mxfp4:
+    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-mi35x-glm51-mxfp4,'))
+    runs-on: linux-mi35x-gpu-8
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Setup docker
+        run: |
+          touch github_summary.md
+          bash scripts/ci/amd/amd_ci_start_container.sh
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Install dependencies
+        run: |
+          bash scripts/ci/amd/amd_ci_install_dependency.sh
+          bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
+          bash scripts/ci/amd/amd_ci_exec.sh pip install git+https://github.com/huggingface/transformers.git@96f807a33b75
+
+      - name: Pre-download model weights
+        timeout-minutes: 120
+        run: |
+          bash scripts/ci/amd/amd_ci_exec.sh \
+            python3 -c "from huggingface_hub import snapshot_download; snapshot_download('amd/GLM-5.1-MXFP4', max_workers=8)"
+
+      - name: Accuracy Test MI35x (8-GPU GLM-5.1-MXFP4 NSA MoE)
+        timeout-minutes: 180
+        run: |
+          > github_summary.md
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-glm51-mxfp4 --nightly --timeout-per-file 7200 ${{ inputs.continue_on_error && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
+      - name: Performance Test MI35x (8-GPU GLM-5.1-MXFP4)
+        timeout-minutes: 120
+        continue-on-error: true
+        run: |
+          > github_summary.md
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-perf-8-gpu-mi35x-glm51-mxfp4 --nightly --timeout-per-file 5400 ${{ inputs.continue_on_error && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
   # MI35x 8-GPU GLM-5-MXFP4 (Accuracy + Performance combined)
   nightly-8-gpu-mi35x-glm5-mxfp4:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-mi35x-glm5-mxfp4,'))
@@ -1442,6 +1545,7 @@ jobs:
       - nightly-8-gpu-qwen3-235b
       - nightly-8-gpu-qwen35
       - nightly-8-gpu-glm51
+      - nightly-8-gpu-glm51-mxfp4
       - nightly-8-gpu-minimax-m27
       # MI30x Diffusion Tests
       - nightly-1-gpu-zimage-turbo
@@ -1460,6 +1564,7 @@ jobs:
       - nightly-8-gpu-mi35x-qwen35
       - nightly-8-gpu-mi35x-glm51
       - nightly-8-gpu-mi35x-glm5-mxfp4
+      - nightly-8-gpu-mi35x-glm51-mxfp4
       # MI35x perf jobs excluded from check - perf failures don't block CI
       # - nightly-perf-8-gpu-mi35x-deepseek-v32-basic
       # - nightly-perf-8-gpu-mi35x-deepseek-v32-mtp

--- a/test/registered/amd/accuracy/mi30x/test_glm51_mxfp4_eval_amd.py
+++ b/test/registered/amd/accuracy/mi30x/test_glm51_mxfp4_eval_amd.py
@@ -1,0 +1,240 @@
+"""AMD GLM-5.1-MXFP4 GSM8K Completion Evaluation Test (8-GPU)
+
+Tests GLM-5.1-MXFP4 (MoE, Quark MXFP4 quantized) with NSA attention backend
+using few-shot completion benchmark on MI325/MI300X.
+
+Registry: nightly-amd-accuracy-8-gpu-glm51-mxfp4 suite
+"""
+
+import ast
+import os
+import re
+import time
+import unittest
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    is_in_ci,
+    popen_launch_server,
+    write_github_step_summary,
+)
+from sglang.utils import download_and_cache_file, read_jsonl
+
+register_amd_ci(
+    est_time=3600,
+    suite="nightly-amd-accuracy-8-gpu-glm51-mxfp4",
+    nightly=True,
+)
+
+INVALID = -9999999
+
+
+@dataclass
+class ModelConfig:
+    model_path: str
+    tp_size: int = 8
+    accuracy_threshold: float = 0.50
+    other_args: List[str] = field(default_factory=list)
+    env_vars: dict = field(default_factory=dict)
+    timeout: Optional[int] = None
+    variant: Optional[str] = None
+
+    def get_display_name(self) -> str:
+        if self.variant:
+            return f"{self.model_path} ({self.variant})"
+        return self.model_path
+
+
+GLM51_MXFP4_MODELS = [
+    ModelConfig(
+        model_path="amd/GLM-5.1-MXFP4",
+        tp_size=8,
+        accuracy_threshold=0.93,
+        timeout=3600,
+        variant="nsa-moe-mxfp4",
+        other_args=[
+            "--trust-remote-code",
+            "--reasoning-parser",
+            "glm45",
+            "--tool-call-parser",
+            "glm47",
+            "--ep-size",
+            "8",
+            "--nsa-prefill-backend",
+            "tilelang",
+            "--nsa-decode-backend",
+            "tilelang",
+            "--chunked-prefill-size",
+            "131072",
+            "--mem-fraction-static",
+            "0.80",
+            "--model-loader-extra-config",
+            '{"enable_multithread_load": true}',
+            "--watchdog-timeout",
+            "1200",
+        ],
+        env_vars={"SGLANG_USE_AITER": "1"},
+    ),
+]
+
+
+def get_one_example(lines, i, include_answer):
+    ret = "Question: " + lines[i]["question"] + "\nAnswer:"
+    if include_answer:
+        ret += " " + lines[i]["answer"]
+    return ret
+
+
+def get_few_shot_examples(lines, k):
+    ret = ""
+    for i in range(k):
+        ret += get_one_example(lines, i, True) + "\n\n"
+    return ret
+
+
+def get_answer_value(answer_str):
+    answer_str = answer_str.replace(",", "")
+    numbers = re.findall(r"\d+", answer_str)
+    if len(numbers) < 1:
+        return INVALID
+    try:
+        return ast.literal_eval(numbers[-1])
+    except SyntaxError:
+        return INVALID
+
+
+def run_gsm8k_benchmark(
+    base_url: str,
+    num_questions: int = 200,
+    num_shots: int = 5,
+    parallel: int = 64,
+) -> Tuple[float, float, float]:
+    import sglang as sgl
+    from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
+
+    url = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl"
+    data_path = download_and_cache_file(url)
+    lines = list(read_jsonl(data_path))
+
+    few_shot_examples = get_few_shot_examples(lines, num_shots)
+
+    questions = []
+    labels = []
+    for i in range(len(lines[:num_questions])):
+        questions.append(get_one_example(lines, i, False))
+        labels.append(get_answer_value(lines[i]["answer"]))
+    assert all(l != INVALID for l in labels)
+    arguments = [{"question": q} for q in questions]
+
+    @sgl.function
+    def few_shot_gsm8k(s, question):
+        s += few_shot_examples + question
+        s += sgl.gen(
+            "answer", max_tokens=512, stop=["Question", "Assistant:", "<|separator|>"]
+        )
+
+    backend = RuntimeEndpoint(base_url)
+    sgl.set_default_backend(backend)
+
+    tic = time.perf_counter()
+    states = few_shot_gsm8k.run_batch(
+        arguments, temperature=0, num_threads=parallel, progress_bar=True
+    )
+    latency = time.perf_counter() - tic
+
+    preds = [get_answer_value(states[i]["answer"]) for i in range(len(states))]
+    acc = np.mean(np.array(preds) == np.array(labels))
+    invalid = np.mean(np.array(preds) == INVALID)
+
+    return float(acc), float(invalid), float(latency)
+
+
+class TestGLM51MXFP4EvalAMD(unittest.TestCase):
+    """GLM-5.1-MXFP4 GSM8K Completion Evaluation Test for AMD MI325/MI300X."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.models = GLM51_MXFP4_MODELS
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.num_questions = int(os.environ.get("GSM8K_NUM_QUESTIONS", "200"))
+
+    def test_glm51_mxfp4_accuracy(self):
+        all_results = []
+        summary = "### GLM-5.1-MXFP4 Models (MI325)\n\n"
+        summary += "| Model | Variant | TP | Accuracy | Threshold | Status |\n"
+        summary += "| ----- | ------- | -- | -------- | --------- | ------ |\n"
+
+        for config in self.models:
+            display_name = config.get_display_name()
+            with self.subTest(model=display_name):
+                print(f"\n{'='*60}")
+                print(f"Testing: {display_name}")
+                print(f"{'='*60}")
+
+                env = os.environ.copy()
+                for key, value in config.env_vars.items():
+                    env[key] = value
+
+                other_args = list(config.other_args)
+                other_args.extend(["--tp", str(config.tp_size)])
+                timeout = config.timeout or DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH
+
+                try:
+                    process = popen_launch_server(
+                        model=config.model_path,
+                        base_url=self.base_url,
+                        timeout=timeout,
+                        other_args=other_args,
+                        env=env,
+                    )
+
+                    try:
+                        acc, invalid, latency = run_gsm8k_benchmark(
+                            self.base_url, num_questions=self.num_questions
+                        )
+                        passed = acc >= config.accuracy_threshold
+                        status = "PASS" if passed else "FAIL"
+                        print(
+                            f"  accuracy={acc:.3f} threshold={config.accuracy_threshold} {status}"
+                        )
+
+                        all_results.append(
+                            {
+                                "model": display_name,
+                                "accuracy": acc,
+                                "passed": passed,
+                            }
+                        )
+                        summary += f"| {config.model_path} | {config.variant or 'N/A'} | {config.tp_size} | {acc:.3f} | {config.accuracy_threshold} | {status} |\n"
+
+                    finally:
+                        kill_process_tree(process.pid)
+
+                except Exception as e:
+                    summary += f"| {config.model_path} | {config.variant or 'N/A'} | {config.tp_size} | N/A | {config.accuracy_threshold} | ERROR |\n"
+                    all_results.append(
+                        {
+                            "model": display_name,
+                            "accuracy": None,
+                            "passed": False,
+                            "error": str(e),
+                        }
+                    )
+
+        if is_in_ci():
+            write_github_step_summary(summary)
+
+        failed = [r for r in all_results if not r["passed"]]
+        if failed:
+            raise AssertionError(f"Failed models: {[r['model'] for r in failed]}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/amd/accuracy/mi35x/test_glm51_mxfp4_eval_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_glm51_mxfp4_eval_mi35x.py
@@ -1,0 +1,244 @@
+"""MI35x GLM-5.1-MXFP4 GSM8K Completion Evaluation Test (8-GPU)
+
+Tests GLM-5.1-MXFP4 (MoE, Quark MXFP4 quantized) with NSA attention backend
+using few-shot completion benchmark on MI35x.
+
+Registry: nightly-amd-8-gpu-mi35x-glm51-mxfp4 suite
+"""
+
+import ast
+import os
+
+os.environ.setdefault("HF_HOME", "/data2/models/huggingface")
+os.environ.setdefault("HF_HUB_CACHE", "/data2/models/huggingface/hub")
+
+import re
+import time
+import unittest
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    is_in_ci,
+    popen_launch_server,
+    write_github_step_summary,
+)
+from sglang.utils import download_and_cache_file, read_jsonl
+
+register_amd_ci(
+    est_time=5400,
+    suite="nightly-amd-8-gpu-mi35x-glm51-mxfp4",
+    nightly=True,
+)
+
+INVALID = -9999999
+
+
+@dataclass
+class ModelConfig:
+    model_path: str
+    tp_size: int = 8
+    accuracy_threshold: float = 0.50
+    other_args: List[str] = field(default_factory=list)
+    env_vars: dict = field(default_factory=dict)
+    timeout: Optional[int] = None
+    variant: Optional[str] = None
+
+    def get_display_name(self) -> str:
+        if self.variant:
+            return f"{self.model_path} ({self.variant})"
+        return self.model_path
+
+
+MI35X_GLM51_MXFP4_MODELS = [
+    ModelConfig(
+        model_path="amd/GLM-5.1-MXFP4",
+        tp_size=8,
+        accuracy_threshold=0.93,
+        timeout=5400,
+        variant="nsa-moe-mxfp4",
+        other_args=[
+            "--trust-remote-code",
+            "--reasoning-parser",
+            "glm45",
+            "--tool-call-parser",
+            "glm47",
+            "--ep-size",
+            "8",
+            "--nsa-prefill-backend",
+            "tilelang",
+            "--nsa-decode-backend",
+            "tilelang",
+            "--chunked-prefill-size",
+            "131072",
+            "--mem-fraction-static",
+            "0.80",
+            "--model-loader-extra-config",
+            '{"enable_multithread_load": true}',
+            "--watchdog-timeout",
+            "1200",
+        ],
+        env_vars={},
+    ),
+]
+
+
+def get_one_example(lines, i, include_answer):
+    ret = "Question: " + lines[i]["question"] + "\nAnswer:"
+    if include_answer:
+        ret += " " + lines[i]["answer"]
+    return ret
+
+
+def get_few_shot_examples(lines, k):
+    ret = ""
+    for i in range(k):
+        ret += get_one_example(lines, i, True) + "\n\n"
+    return ret
+
+
+def get_answer_value(answer_str):
+    answer_str = answer_str.replace(",", "")
+    numbers = re.findall(r"\d+", answer_str)
+    if len(numbers) < 1:
+        return INVALID
+    try:
+        return ast.literal_eval(numbers[-1])
+    except SyntaxError:
+        return INVALID
+
+
+def run_gsm8k_benchmark(
+    base_url: str,
+    num_questions: int = 200,
+    num_shots: int = 5,
+    parallel: int = 64,
+) -> Tuple[float, float, float]:
+    import sglang as sgl
+    from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
+
+    url = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl"
+    data_path = download_and_cache_file(url)
+    lines = list(read_jsonl(data_path))
+
+    few_shot_examples = get_few_shot_examples(lines, num_shots)
+
+    questions = []
+    labels = []
+    for i in range(len(lines[:num_questions])):
+        questions.append(get_one_example(lines, i, False))
+        labels.append(get_answer_value(lines[i]["answer"]))
+    assert all(l != INVALID for l in labels)
+    arguments = [{"question": q} for q in questions]
+
+    @sgl.function
+    def few_shot_gsm8k(s, question):
+        s += few_shot_examples + question
+        s += sgl.gen(
+            "answer", max_tokens=512, stop=["Question", "Assistant:", "<|separator|>"]
+        )
+
+    backend = RuntimeEndpoint(base_url)
+    sgl.set_default_backend(backend)
+
+    tic = time.perf_counter()
+    states = few_shot_gsm8k.run_batch(
+        arguments, temperature=0, num_threads=parallel, progress_bar=True
+    )
+    latency = time.perf_counter() - tic
+
+    preds = [get_answer_value(states[i]["answer"]) for i in range(len(states))]
+    acc = np.mean(np.array(preds) == np.array(labels))
+    invalid = np.mean(np.array(preds) == INVALID)
+
+    return float(acc), float(invalid), float(latency)
+
+
+class TestGLM51MXFP4EvalMI35x(unittest.TestCase):
+    """GLM-5.1-MXFP4 GSM8K Completion Evaluation Test for AMD MI35x."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.models = MI35X_GLM51_MXFP4_MODELS
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.num_questions = int(os.environ.get("GSM8K_NUM_QUESTIONS", "200"))
+
+    def test_glm51_mxfp4_accuracy(self):
+        all_results = []
+        summary = "### GLM-5.1-MXFP4 Models (MI35x)\n\n"
+        summary += "| Model | Variant | TP | Accuracy | Threshold | Status |\n"
+        summary += "| ----- | ------- | -- | -------- | --------- | ------ |\n"
+
+        for config in self.models:
+            display_name = config.get_display_name()
+            with self.subTest(model=display_name):
+                print(f"\n{'='*60}")
+                print(f"Testing: {display_name}")
+                print(f"{'='*60}")
+
+                env = os.environ.copy()
+                for key, value in config.env_vars.items():
+                    env[key] = value
+
+                other_args = list(config.other_args)
+                other_args.extend(["--tp", str(config.tp_size)])
+                timeout = config.timeout or DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH
+
+                try:
+                    process = popen_launch_server(
+                        model=config.model_path,
+                        base_url=self.base_url,
+                        timeout=timeout,
+                        other_args=other_args,
+                        env=env,
+                    )
+
+                    try:
+                        acc, invalid, latency = run_gsm8k_benchmark(
+                            self.base_url, num_questions=self.num_questions
+                        )
+                        passed = acc >= config.accuracy_threshold
+                        status = "PASS" if passed else "FAIL"
+                        print(
+                            f"  accuracy={acc:.3f} threshold={config.accuracy_threshold} {status}"
+                        )
+
+                        all_results.append(
+                            {
+                                "model": display_name,
+                                "accuracy": acc,
+                                "passed": passed,
+                            }
+                        )
+                        summary += f"| {config.model_path} | {config.variant or 'N/A'} | {config.tp_size} | {acc:.3f} | {config.accuracy_threshold} | {status} |\n"
+
+                    finally:
+                        kill_process_tree(process.pid)
+
+                except Exception as e:
+                    summary += f"| {config.model_path} | {config.variant or 'N/A'} | {config.tp_size} | N/A | {config.accuracy_threshold} | ERROR |\n"
+                    all_results.append(
+                        {
+                            "model": display_name,
+                            "accuracy": None,
+                            "passed": False,
+                            "error": str(e),
+                        }
+                    )
+
+        if is_in_ci():
+            write_github_step_summary(summary)
+
+        failed = [r for r in all_results if not r["passed"]]
+        if failed:
+            raise AssertionError(f"Failed models: {[r['model'] for r in failed]}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/amd/perf/mi30x/test_glm51_mxfp4_perf_amd.py
+++ b/test/registered/amd/perf/mi30x/test_glm51_mxfp4_perf_amd.py
@@ -1,0 +1,138 @@
+"""Nightly performance benchmark for GLM-5.1-MXFP4 on MI30x.
+
+Tests GLM-5.1-MXFP4 (MoE, Quark MXFP4 quantized) with NSA attention backend
+using bench_one_batch on 8 GPUs with TP=8, EP=8.
+
+Model path can be configured via GLM51_MXFP4_MODEL_PATH environment variable.
+
+Registry: nightly-perf-8-gpu-glm51-mxfp4 suite
+"""
+
+import os
+import unittest
+from typing import List
+
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.nightly_bench_utils import BenchmarkResult
+from sglang.test.nightly_utils import NightlyBenchmarkRunner
+from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
+
+register_amd_ci(est_time=5400, suite="nightly-perf-8-gpu-glm51-mxfp4", nightly=True)
+
+
+def generate_simple_markdown_report(results: List[BenchmarkResult]) -> str:
+    model_header = results[0].model_path
+    if results[0].run_name and results[0].run_name != "default":
+        model_header += f" ({results[0].run_name})"
+
+    gpu_config = os.getenv("GPU_CONFIG", "MI325")
+    if gpu_config:
+        model_header += f" [{gpu_config}]"
+
+    summary = f"### {model_header}\n"
+    summary += "| batch size | input len | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |\n"
+    summary += "| ---------- | --------- | ----------- | ------------------------ | ------------------------- | -------- |\n"
+
+    report_results = (
+        results[1:]
+        if len(results) > 1 and results[0].batch_size == results[1].batch_size
+        else results
+    )
+
+    for result in report_results:
+        itl = 1 / (result.output_throughput / result.batch_size) * 1000
+        summary += f"| {result.batch_size} | {result.input_len} | {result.latency:.2f} | {result.input_throughput:.2f} | {result.output_throughput:.2f} | {itl:.2f} |\n"
+
+    return summary
+
+
+GLM51_MXFP4_MODEL_PATH = os.environ.get("GLM51_MXFP4_MODEL_PATH", "amd/GLM-5.1-MXFP4")
+PROFILE_DIR = "performance_profiles_glm51_mxfp4"
+
+
+class TestNightlyGLM51MXFP4Performance(unittest.TestCase):
+    """Nightly performance benchmark for GLM-5.1-MXFP4 on MI30x.
+
+    Tests GLM-5.1-MXFP4 (MoE) with NSA attention backend, TP=8, EP=8.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.batch_sizes = [1, 8, 16, 64]
+        cls.input_lens = tuple(_parse_int_list_env("NIGHTLY_INPUT_LENS", "4096"))
+        cls.output_lens = tuple(_parse_int_list_env("NIGHTLY_OUTPUT_LENS", "512"))
+
+        cls.model_config = {
+            "name": "glm51-mxfp4",
+            "model_path": GLM51_MXFP4_MODEL_PATH,
+            "other_args": [
+                "--trust-remote-code",
+                "--reasoning-parser",
+                "glm45",
+                "--tool-call-parser",
+                "glm47",
+                "--tp",
+                "8",
+                "--ep-size",
+                "8",
+                "--nsa-prefill-backend",
+                "tilelang",
+                "--nsa-decode-backend",
+                "tilelang",
+                "--chunked-prefill-size",
+                "131072",
+                "--mem-fraction-static",
+                "0.85",
+                "--model-loader-extra-config",
+                '{"enable_multithread_load": true}',
+                "--watchdog-timeout",
+                "1200",
+            ],
+            "env_vars": {
+                "SGLANG_USE_AITER": "1",
+            },
+        }
+
+        cls.runner = NightlyBenchmarkRunner(PROFILE_DIR, cls.__name__, cls.base_url)
+        cls.runner.setup_profile_directory()
+        cls.runner.full_report = f"## {cls.__name__}\n"
+
+    def test_bench_glm51_mxfp4(self):
+        old_env = {}
+        for key, value in self.model_config.get("env_vars", {}).items():
+            old_env[key] = os.environ.get(key)
+            os.environ[key] = value
+
+        try:
+            result_tuple = self.runner.run_benchmark_for_model(
+                model_path=self.model_config["model_path"],
+                batch_sizes=self.batch_sizes,
+                input_lens=self.input_lens,
+                output_lens=self.output_lens,
+                other_args=self.model_config["other_args"],
+                variant=self.model_config["name"],
+                extra_bench_args=["--trust-remote-code"],
+                enable_profile=False,
+                timeout=5400,
+            )
+            results = result_tuple[0]
+            success = result_tuple[1]
+
+            if results:
+                self.runner.full_report += (
+                    generate_simple_markdown_report(results) + "\n"
+                )
+
+            self.assertTrue(success, f"Benchmark failed for {GLM51_MXFP4_MODEL_PATH}")
+        finally:
+            for key, value in old_env.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+            self.runner.write_final_report()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/amd/perf/mi35x/test_glm51_mxfp4_perf_mi35x.py
+++ b/test/registered/amd/perf/mi35x/test_glm51_mxfp4_perf_mi35x.py
@@ -1,0 +1,149 @@
+"""MI35x Nightly performance benchmark for GLM-5.1-MXFP4.
+
+Tests GLM-5.1-MXFP4 (MoE, Quark MXFP4 quantized) with NSA attention backend
+using bench_one_batch on 8 GPUs with TP=8, EP=8.
+
+Registry: nightly-perf-8-gpu-mi35x-glm51-mxfp4 suite
+"""
+
+import os
+
+os.environ.setdefault("HF_HOME", "/data2/models/huggingface")
+os.environ.setdefault("HF_HUB_CACHE", "/data2/models/huggingface/hub")
+
+import unittest
+from typing import List
+
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.nightly_bench_utils import BenchmarkResult
+from sglang.test.nightly_utils import NightlyBenchmarkRunner
+from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
+
+register_amd_ci(
+    est_time=5400, suite="nightly-perf-8-gpu-mi35x-glm51-mxfp4", nightly=True
+)
+
+
+def generate_simple_markdown_report(results: List[BenchmarkResult]) -> str:
+    model_header = results[0].model_path
+    if results[0].run_name and results[0].run_name != "default":
+        model_header += f" ({results[0].run_name})"
+
+    gpu_config = os.getenv("GPU_CONFIG", "MI35x")
+    if gpu_config:
+        model_header += f" [{gpu_config}]"
+
+    summary = f"### {model_header}\n"
+    summary += "| batch size | input len | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |\n"
+    summary += "| ---------- | --------- | ----------- | ------------------------ | ------------------------- | -------- |\n"
+
+    report_results = (
+        results[1:]
+        if len(results) > 1 and results[0].batch_size == results[1].batch_size
+        else results
+    )
+
+    for result in report_results:
+        itl = 1 / (result.output_throughput / result.batch_size) * 1000
+        summary += f"| {result.batch_size} | {result.input_len} | {result.latency:.2f} | {result.input_throughput:.2f} | {result.output_throughput:.2f} | {itl:.2f} |\n"
+
+    return summary
+
+
+GLM51_MXFP4_MODEL_PATH = os.environ.get("GLM51_MXFP4_MODEL_PATH", "amd/GLM-5.1-MXFP4")
+PROFILE_DIR = "performance_profiles_glm51_mxfp4_mi35x"
+
+
+class TestGLM51MXFP4PerfMI35x(unittest.TestCase):
+    """Nightly performance benchmark for GLM-5.1-MXFP4 on MI35x.
+
+    Tests GLM-5.1-MXFP4 (MoE) with NSA attention backend, TP=8, EP=8.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.batch_sizes = [1, 8, 16, 64]
+        cls.input_lens = tuple(_parse_int_list_env("NIGHTLY_INPUT_LENS", "4096"))
+        cls.output_lens = tuple(_parse_int_list_env("NIGHTLY_OUTPUT_LENS", "512"))
+
+        cls.model_config = {
+            "name": "glm51-mxfp4-mi35x",
+            "model_path": GLM51_MXFP4_MODEL_PATH,
+            "other_args": [
+                "--trust-remote-code",
+                "--reasoning-parser",
+                "glm45",
+                "--tool-call-parser",
+                "glm47",
+                "--tp",
+                "8",
+                "--ep-size",
+                "8",
+                "--nsa-prefill-backend",
+                "tilelang",
+                "--nsa-decode-backend",
+                "tilelang",
+                "--chunked-prefill-size",
+                "131072",
+                "--mem-fraction-static",
+                "0.85",
+                "--model-loader-extra-config",
+                '{"enable_multithread_load": true, "num_threads": 8}',
+                "--watchdog-timeout",
+                "1200",
+            ],
+            "env_vars": {
+                "SGLANG_USE_AITER": "1",
+                "SGLANG_ROCM_FUSED_DECODE_MLA": "0",
+                "ROCM_QUICK_REDUCE_QUANTIZATION": "INT4",
+                "SAFETENSORS_FAST_GPU": "1",
+            },
+        }
+
+        os.environ.setdefault("SGLANG_BENCH_TIMEOUT", "3600")
+        cls.runner = NightlyBenchmarkRunner(PROFILE_DIR, cls.__name__, cls.base_url)
+        cls.runner.setup_profile_directory()
+        cls.runner.full_report = f"## {cls.__name__}\n"
+
+    def test_glm51_mxfp4_perf(self):
+        old_env = {}
+        for key, value in self.model_config.get("env_vars", {}).items():
+            old_env[key] = os.environ.get(key)
+            os.environ[key] = value
+
+        try:
+            result_tuple = self.runner.run_benchmark_for_model(
+                model_path=self.model_config["model_path"],
+                batch_sizes=self.batch_sizes,
+                input_lens=self.input_lens,
+                output_lens=self.output_lens,
+                other_args=self.model_config["other_args"],
+                variant=self.model_config["name"],
+                extra_bench_args=["--trust-remote-code"],
+                enable_profile=False,
+                timeout=5400,
+            )
+            results = result_tuple[0]
+            success = result_tuple[1]
+
+            if results:
+                self.runner.full_report += (
+                    generate_simple_markdown_report(results) + "\n"
+                )
+
+            self.assertTrue(
+                success,
+                f"Benchmark failed for {GLM51_MXFP4_MODEL_PATH} on MI35x",
+            )
+        finally:
+            for key, value in old_env.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+            self.runner.write_final_report()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add nightly CI tests for [`amd/GLM-5.1-MXFP4`](https://huggingface.co/amd/GLM-5.1-MXFP4), a 408B MoE model quantized with AMD Quark to MXFP4.

- **Accuracy tests**: GSM8K 5-shot completion evaluation with threshold 0.93 (model reports 0.9454 on HuggingFace card)
- **Performance tests**: `bench_one_batch` throughput benchmarks at batch sizes [1, 8, 16, 64] with 4096 input / 512 output tokens
- **Pre-download step**: Downloads the 425GB model (282 shards) via `snapshot_download` with 120-minute timeout before server launch

### Changes

| File | Description |
|------|-------------|
| `.github/workflows/nightly-test-amd.yml` | Add MI30x + MI35x MXFP4 jobs with pre-download |
| `.github/workflows/nightly-test-amd-rocm720.yml` | Add MI30x + MI35x MXFP4 jobs (ROCm 7.2) with pre-download |
| `test/registered/amd/accuracy/mi30x/test_glm51_mxfp4_eval_amd.py` | MI30x accuracy test |
| `test/registered/amd/accuracy/mi35x/test_glm51_mxfp4_eval_mi35x.py` | MI35x accuracy test |
| `test/registered/amd/perf/mi30x/test_glm51_mxfp4_perf_amd.py` | MI30x perf test |
| `test/registered/amd/perf/mi35x/test_glm51_mxfp4_perf_mi35x.py` | MI35x perf test |

### Server configuration

- **Model**: `amd/GLM-5.1-MXFP4` (base: `zai-org/GLM-5.1`)
- **Quantization**: OCP MXFP4 via AMD Quark (auto-detected)
- **Parallelism**: TP=8, EP=8 (MoE)
- **Attention**: NSA with tilelang prefill/decode backends
- **Environment**: `SGLANG_USE_AITER=1`
- **Other**: `--trust-remote-code`, `--chunked-prefill-size 131072`, `--mem-fraction-static 0.85`, `--watchdog-timeout 1200`

### Dependencies

- PR #22543 (merged) — `packed_modules_mapping` for Quark exclude-layer resolution + `quark_post_load_weights` guard for `GlmMoeDsaForCausalLM`

## CI runs

- **Default ROCm**: https://github.com/sgl-project/sglang/actions/runs/24616772273
- **ROCm 7.2**: https://github.com/sgl-project/sglang/actions/runs/24616772609

## Test plan

- [ ] Verify default ROCm CI passes (accuracy >= 0.93, perf completes)
- [ ] Verify ROCm 7.2 CI passes (accuracy >= 0.93, perf completes)
- [ ] Check GitHub step summary output includes accuracy and throughput tables