### PR TITLE
[Apple Silicon] [MLX] MLX overlap scheduling

### DIFF
--- a/python/sglang/bench_one_batch.py
+++ b/python/sglang/bench_one_batch.py
@@ -98,6 +98,7 @@ def start_profile(profile_activities, profile_record_shapes=False, rank_print=pr
     """
     if use_mlx():
         import mlx.core as mx
+
         # Start capturing to a temp file. We will rename it in stop_profile.
         mx.metal.start_capture("sglang_tmp.gputrace")
         rank_print("MLX Metal capture started")
@@ -142,8 +143,9 @@ def stop_profile(
     Optionally saves trace results and prints completion messages.
     """
     if profiler == "mlx":
-        import mlx.core as mx
         import shutil
+
+        import mlx.core as mx
 
         mx.metal.stop_capture()
 

--- a/python/sglang/bench_one_batch.py
+++ b/python/sglang/bench_one_batch.py
@@ -66,6 +66,7 @@ import torch.distributed as dist
 from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.distributed.parallel_state import destroy_distributed_environment
 from sglang.srt.entrypoints.engine import _set_envs_and_config
+from sglang.srt.layers.dp_attention import get_attention_tp_size
 from sglang.srt.layers.moe import initialize_moe_config
 from sglang.srt.layers.quantization.fp4_utils import initialize_fp4_gemm_config
 from sglang.srt.layers.quantization.fp8_utils import initialize_fp8_gemm_config
@@ -481,7 +482,8 @@ def _maybe_prepare_mlp_sync_batch(batch: ScheduleBatch, model_runner):
         prepare_mlp_sync_batch_raw(
             batch,
             dp_size=model_runner.server_args.dp_size,
-            attn_tp_size=1,
+            attn_tp_size=get_attention_tp_size(),
+            attn_cp_size=model_runner.attn_cp_size,
             tp_group=model_runner.tp_group,
             get_idle_batch=None,
             disable_cuda_graph=model_runner.server_args.disable_cuda_graph,

--- a/python/sglang/bench_one_batch.py
+++ b/python/sglang/bench_one_batch.py
@@ -66,7 +66,6 @@ import torch.distributed as dist
 from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.distributed.parallel_state import destroy_distributed_environment
 from sglang.srt.entrypoints.engine import _set_envs_and_config
-from sglang.srt.layers.dp_attention import get_attention_tp_size
 from sglang.srt.layers.moe import initialize_moe_config
 from sglang.srt.layers.quantization.fp4_utils import initialize_fp4_gemm_config
 from sglang.srt.layers.quantization.fp8_utils import initialize_fp8_gemm_config
@@ -97,6 +96,13 @@ def start_profile(profile_activities, profile_record_shapes=False, rank_print=pr
     Abstracted function to start profiling based on profile_activities.
     Returns profiler object (or None).
     """
+    if use_mlx():
+        import mlx.core as mx
+        # Start capturing to a temp file. We will rename it in stop_profile.
+        mx.metal.start_capture("sglang_tmp.gputrace")
+        rank_print("MLX Metal capture started")
+        return "mlx"
+
     if "CUDA_PROFILER" in profile_activities:
         try:
             torch.cuda.cudart().cudaProfilerStart()
@@ -135,6 +141,25 @@ def stop_profile(
     Abstracted function to stop profiling based on profile_activities.
     Optionally saves trace results and prints completion messages.
     """
+    if profiler == "mlx":
+        import mlx.core as mx
+        import shutil
+
+        mx.metal.stop_capture()
+
+        if save_trace and trace_filename:
+            # Change SGLang's default torch extension to Apple's .gputrace extension
+            mlx_trace_filename = trace_filename.replace(".trace.json.gz", ".gputrace")
+
+            # Replace existing trace if it exists, otherwise shutil.move might fail on Mac directories
+            if os.path.exists(mlx_trace_filename):
+                shutil.rmtree(mlx_trace_filename)
+
+            shutil.move("sglang_tmp.gputrace", mlx_trace_filename)
+            stage_desc = f"for {stage}" if stage else ""
+            rank_print(f"MLX Metal gputrace {stage_desc} saved to {mlx_trace_filename}")
+        return
+
     if "CUDA_PROFILER" in profile_activities:
         try:
             torch.cuda.cudart().cudaProfilerStop()
@@ -454,8 +479,7 @@ def _maybe_prepare_mlp_sync_batch(batch: ScheduleBatch, model_runner):
         prepare_mlp_sync_batch_raw(
             batch,
             dp_size=model_runner.server_args.dp_size,
-            attn_tp_size=get_attention_tp_size(),
-            attn_cp_size=model_runner.attn_cp_size,
+            attn_tp_size=1,
             tp_group=model_runner.tp_group,
             get_idle_batch=None,
             disable_cuda_graph=model_runner.server_args.disable_cuda_graph,

--- a/python/sglang/srt/hardware_backend/mlx/model_runner.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner.py
@@ -29,6 +29,26 @@ class MlxRequestState:
     generated_tokens: int = 0
 
 
+# Named tuple-like container returned by the async start methods.
+@dataclass
+class MlxPendingDecode:
+    """Lazy decode state to be finalized after mx.eval()."""
+
+    lazy_tokens: mx.array
+    batch_cache: list
+    decode_reqs: list  # list[tuple[str, MlxRequestState]]
+
+
+@dataclass
+class MlxPendingPrefill:
+    """Lazy prefill state to be finalized after mx.eval()."""
+
+    lazy_token: mx.array
+    cache: list
+    req_id: str
+    token_ids: list[int]
+
+
 def _merge_kv_caches(
     caches_list: list[list],
 ) -> list:
@@ -88,6 +108,9 @@ class MlxModelRunner:
         self.trust_remote_code = trust_remote_code
         self.model = None
         self._request_states: dict[str, MlxRequestState] = {}
+        # Counter used to trigger periodic mx.clear_cache() calls.
+        self._decode_step_ct: int = 0
+        self.generation_stream: mx.Stream = mx.new_stream(mx.default_device())
 
         self._load_model()
 
@@ -296,6 +319,183 @@ class MlxModelRunner:
             state.generated_tokens += 1
 
         return next_tokens
+
+    # ------------------------------------------------------------------
+    # Async (lazy-eval) API for overlap scheduling
+    # ------------------------------------------------------------------
+
+    def prefill_start(self, req_id: str, token_ids: list[int]) -> MlxPendingPrefill:
+        """Queue a prefill forward pass without evaluating.
+
+        Returns an :class:`MlxPendingPrefill` containing the lazy next-token
+        ``mx.array``.  Call ``mx.async_eval(pending.lazy_token)`` to kick off
+        GPU work, then :meth:`prefill_finalize`.
+        """
+        with mx.stream(self.generation_stream):
+            existing_state = self._request_states.get(req_id)
+            if existing_state is not None:
+                cached_input_len = (
+                    len(existing_state.token_ids) - existing_state.generated_tokens
+                )
+                new_tokens = token_ids[cached_input_len:]
+                cache = existing_state.cache
+            else:
+                new_tokens = token_ids
+                cache = make_prompt_cache(self.model)
+
+            input_ids = mx.array([new_tokens], dtype=mx.int32)
+            model_output = self.model(input_ids, cache=cache)
+            logits = self._extract_logits(model_output)
+            lazy_token = mx.argmax(logits[:, -1, :], axis=-1)
+
+            return MlxPendingPrefill(
+                lazy_token=lazy_token,
+                cache=cache,
+                req_id=req_id,
+                token_ids=token_ids,
+            )
+
+    def prefill_finalize(self, pending: MlxPendingPrefill) -> int:
+        """Materialise a pending prefill and store per-request state.
+
+        Must be called *after* ``mx.async_eval(pending.lazy_token)`` has been called.
+        """
+        with mx.stream(self.generation_stream):
+            # Evaluate lazy tokens/sync MLX computation graph
+            next_token = int(pending.lazy_token.item())
+            self._request_states[pending.req_id] = MlxRequestState(
+                token_ids=list(pending.token_ids) + [next_token],
+                cache=pending.cache,
+                generated_tokens=1,
+            )
+            return next_token
+
+    def decode_batch_start(self, req_ids: list[str]) -> MlxPendingDecode:
+        """Queue a decode forward pass without evaluating.
+
+        Returns an :class:`MlxPendingDecode` containing the lazy ``mx.array``
+        of next-token indices plus the references needed by
+        :meth:`decode_batch_finalize`.  The caller should call
+        ``mx.async_eval(pending.lazy_tokens)`` to kick off GPU computation,
+        then do CPU scheduling work, then call :meth:`decode_batch_finalize`
+        (after ``mx.eval``) to materialise the tokens and update state.
+        """
+        with mx.stream(self.generation_stream):
+            if len(req_ids) == 1:
+                req_id = req_ids[0]
+                state = self._request_states[req_id]
+                last_token = state.token_ids[-1]
+                input_ids = mx.array([[last_token]], dtype=mx.int32)
+                model_output = self.model(input_ids, cache=state.cache)
+                logits = self._extract_logits(model_output)
+                lazy_token = mx.argmax(logits[:, -1, :], axis=-1)
+                return MlxPendingDecode(
+                    lazy_tokens=lazy_token,
+                    batch_cache=state.cache,
+                    decode_reqs=[(req_id, state)],
+                )
+
+            decode_reqs = [(rid, self._request_states[rid]) for rid in req_ids]
+            last_tokens = [state.token_ids[-1] for _, state in decode_reqs]
+            caches_list = [state.cache for _, state in decode_reqs]
+            batch_cache = _merge_kv_caches(caches_list)
+
+            batched_input = mx.array(last_tokens, dtype=mx.int32)[:, None]
+            model_output = self.model(batched_input, cache=batch_cache)
+            logits = self._extract_logits(model_output)
+            lazy_tokens = mx.argmax(logits[:, -1, :], axis=-1)
+
+            return MlxPendingDecode(
+                lazy_tokens=lazy_tokens,
+                batch_cache=batch_cache,
+                decode_reqs=decode_reqs,
+            )
+
+    def decode_batch_start_chained(
+        self,
+        prev: MlxPendingDecode,
+    ) -> MlxPendingDecode:
+        """Build the next decode step on top of a still-lazy previous decode.
+
+        We feed ``prev.lazy_tokens`` (an unevaluated ``mx.array`` of shape
+        ``(B,)``) directly as the next step's input ids, reusing
+        ``prev.batch_cache`` in-place so that the KV cache updates from
+        step N and step N+1 live in the same tensors. MLX tracks the full
+        dependency graph, so once ``mx.async_eval`` is called the GPU
+        executes N+1 immediately after N with no gap.
+
+        Caller contract:
+        * ``prev`` MUST refer to the same set of requests as the batch the
+          caller intends to run next (no composition change).
+        * After calling this, finalize ``prev`` BEFORE finalizing the
+          returned pending: state bookkeeping for step N has to happen
+          before step N+1's bookkeeping.
+        * Only the FINAL pending in the chain may extract per-request
+          caches (see ``decode_batch_finalize``'s ``extract_cache`` flag),
+          because the ``batch_cache`` is shared across all chained steps
+          and reflects the latest state after every chained call.
+        """
+        with mx.stream(self.generation_stream):
+            # prev.lazy_tokens has shape (B,) — add seq dim to get (B, 1)
+            batched_input = prev.lazy_tokens[:, None]  # still a graph node
+            model_output = self.model(
+                batched_input, cache=prev.batch_cache
+            )  # update batch_cache
+            logits = self._extract_logits(model_output)
+            next_lazy = mx.argmax(logits[:, -1, :], axis=-1)
+
+            return MlxPendingDecode(
+                lazy_tokens=next_lazy,
+                batch_cache=prev.batch_cache,  # shared across the chain
+                decode_reqs=prev.decode_reqs,  # identical req set
+            )
+
+    def decode_batch_finalize(
+        self,
+        pending: MlxPendingDecode,
+        extract_cache: bool = True,
+    ) -> list[int]:
+        """Materialise a pending decode and update per-request state.
+
+        The call to ``pending.lazy_tokens.tolist()`` below implicitly blocks
+        until that specific lazy array is evaluated, so the caller does NOT
+        need to call ``mx.eval`` ahead of time. It only needs to have
+        previously handed the pending's outputs to ``mx.async_eval`` (or
+        trust that something downstream in the MLX graph will).
+
+        Args:
+            pending: The lazy decode returned by :meth:`decode_batch_start`
+                or :meth:`decode_batch_start_chained`.
+            extract_cache: If True, snapshot the batched KV cache back into
+                each request's ``state.cache``. Pass ``False`` when this
+                pending is mid-chain — i.e. another step has already been
+                built on top of ``pending.batch_cache`` via
+                :meth:`decode_batch_start_chained` — because the shared
+                ``batch_cache`` now reflects the later step's state, not
+                this one's. Only the tail of a chain should extract.
+        """
+        with mx.stream(self.generation_stream):
+            # Evaluate lazy tokens/sync MLX computation graph
+            raw = pending.lazy_tokens.tolist()
+            if not isinstance(raw, list):
+                raw = [raw]
+            # Extract next tokens for each batch
+            next_tokens = [int(t) for t in raw]
+
+            is_batched = len(pending.decode_reqs) > 1
+            # Update each batch's state
+            for i, (_, state) in enumerate(pending.decode_reqs):
+                if is_batched and extract_cache:
+                    state.cache = _extract_kv_cache(pending.batch_cache, i)
+                state.token_ids.append(next_tokens[i])
+                state.generated_tokens += 1
+
+            # Clear KV cache after enough decode passes
+            self._decode_step_ct += 1
+            if self._decode_step_ct % 256 == 0:
+                mx.clear_cache()
+
+            return next_tokens
 
     def remove_request(self, req_id: str):
         """Clean up state for a completed request."""

--- a/python/sglang/srt/hardware_backend/mlx/tp_worker.py
+++ b/python/sglang/srt/hardware_backend/mlx/tp_worker.py
@@ -11,10 +11,15 @@ is managed internally by the MLX model runner.
 """
 
 import logging
-from typing import Optional
+from typing import Optional, Union
 
+import mlx.core as mx
 import torch
 
+from sglang.srt.hardware_backend.mlx.model_runner import (
+    MlxPendingDecode,
+    MlxPendingPrefill,
+)
 from sglang.srt.managers.schedule_batch import ModelWorkerBatch
 from sglang.srt.managers.tp_worker import TpModelWorker
 from sglang.srt.managers.utils import GenerationBatchResult
@@ -169,6 +174,230 @@ class MlxTpModelWorker(TpModelWorker):
             next_token_ids_list, dtype=torch.long, device="cpu"
         )
 
+        return GenerationBatchResult(
+            logits_output=LogitsProcessorOutput(next_token_logits=None),
+            next_token_ids=next_token_ids,
+            can_run_cuda_graph=False,
+        )
+
+    def async_forward_batch_generation_mlx(
+        self,
+        model_worker_batch: ModelWorkerBatch,
+    ) -> tuple[
+        Union[mx.array, None],
+        Optional[list[MlxPendingPrefill]],
+        Optional[MlxPendingDecode],
+        str,
+    ]:
+        """Start an async (lazy) forward pass through the MLX model runner.
+
+        Returns ``(lazy_tokens, pending_state, decode_reqs, mode)`` where
+        ``lazy_tokens`` is an unevaluated ``mx.array``.  The caller should
+        call ``mx.async_eval(lazy_tokens)`` to kick off GPU work, do CPU
+        scheduling, then call :meth:`finalize_mlx_result` to materialise.
+
+        For idle batches all four values are ``None / "idle"``.
+        """
+        forward_mode = model_worker_batch.forward_mode
+        reqs = model_worker_batch.reqs
+
+        if forward_mode.is_idle():
+            return None, None, None, "idle"
+
+        # Auto-cleanup stale requests
+        current_rids = {req.rid for req in reqs}
+        stale_rids = self._mlx_active_rids - current_rids
+        for rid in stale_rids:
+            self._mlx_runner.remove_request(rid)
+        self._mlx_active_rids = current_rids
+
+        if forward_mode.is_decode():
+            req_ids = [req.rid for req in reqs]
+            pending_decode = self._mlx_runner.decode_batch_start(req_ids)
+            mx.async_eval(pending_decode.lazy_tokens, *pending_decode.batch_cache)
+            return pending_decode.lazy_tokens, None, pending_decode, "decode"
+
+        elif forward_mode.is_extend():
+            # Prefill (EXTEND or MIXED): start each new request lazily and
+            # collect the lazy tokens + KV cache states for async eval.
+
+            # We must include cache states in mx.async_eval, not just the
+            # logit token. The KV cache is updated as a side effect of the
+            # model call; mx.async_eval on only the token does NOT guarantee
+            # cache state is materialised before the next decode step reads it.
+            input_ids_cpu = model_worker_batch.input_ids.cpu().tolist()
+            extend_seq_lens = model_worker_batch.extend_seq_lens
+            offset = 0
+            pending_prefills: list[MlxPendingPrefill] = []
+            mixed_decode_rids: list[str] = []
+
+            # Process requests
+            for i, req in enumerate(reqs):
+                seq_len = extend_seq_lens[i]
+                req_token_ids = input_ids_cpu[offset : offset + seq_len]
+                offset += seq_len
+                if req.rid in self._mlx_runner._request_states:
+                    # MIXED mode: already has KV state -> decode lazily.
+                    mixed_decode_rids.append(req.rid)
+                else:
+                    # Add prefill forward pass without evaluating
+                    pending_prefills.append(
+                        self._mlx_runner.prefill_start(req.rid, req_token_ids)
+                    )
+
+            # Start mixed-mode decode lazily so it can overlap with CPU scheduling
+            pending_mixed_decode: Optional[MlxPendingDecode] = None
+            if mixed_decode_rids:
+                pending_mixed_decode = self._mlx_runner.decode_batch_start(
+                    mixed_decode_rids
+                )
+
+            # Kick off GPU work
+            # Prefill requests present
+            if pending_prefills:
+                # Stack prefill tokens
+                lazy_stacked = mx.stack(
+                    [p.lazy_token for p in pending_prefills], axis=0
+                )
+                # Collect every cache layer state so the GPU also materialises
+                # the KV cache before the next decode step starts.
+                cache_states = [c.state for p in pending_prefills for c in p.cache]
+                # Decode requests present
+                if pending_mixed_decode is not None:
+                    mx.async_eval(
+                        lazy_stacked,
+                        pending_mixed_decode.lazy_tokens,
+                        *cache_states,
+                        *pending_mixed_decode.batch_cache,
+                    )
+                # All requests are prefills
+                else:
+                    mx.async_eval(lazy_stacked, *cache_states)
+            # All requests are mixed-mode decodes; no prefills
+            elif pending_mixed_decode is not None:
+                mx.async_eval(
+                    pending_mixed_decode.lazy_tokens, *pending_mixed_decode.batch_cache
+                )
+                lazy_stacked = None
+            # No requests present
+            else:
+                lazy_stacked = None
+
+            return lazy_stacked, pending_prefills, pending_mixed_decode, "extend"
+
+        raise ValueError(
+            f"MLX async runner does not support forward mode: {forward_mode}"
+        )
+
+    def async_chained_decode_mlx(
+        self,
+        prev_pending: MlxPendingDecode,
+    ) -> tuple[mx.array, None, MlxPendingDecode, str]:
+        """Launch a decode step that chains off a still-lazy previous decode.
+
+        This is the "no idle gap" pipelining primitive: we build the next
+        decode's compute graph using ``prev_pending.lazy_tokens`` (still
+        unevaluated) as its input ids, kick the combined graph off with
+        ``mx.async_eval``, and return. The GPU runs the new step immediately
+        after ``prev_pending`` with no scheduling gap, while the caller is
+        free to block on ``prev_pending`` and run CPU-side bookkeeping.
+
+        Preconditions (caller must ensure):
+        * ``prev_pending`` was produced by a previous decode start (either
+          :meth:`async_forward_batch_generation_mlx` in decode mode or a
+          previous :meth:`async_chained_decode_mlx`) and has NOT yet been
+          finalised with ``extract_cache=True``.
+        * The batch composition for this step is identical to
+          ``prev_pending`` — same requests, same order. Composition changes
+          (finished reqs, new prefills) must break the chain instead.
+
+        Returns a 4-tuple matching the shape of
+        :meth:`async_forward_batch_generation_mlx` for the decode case:
+        ``(lazy_tokens, None, pending_decode, "decode")``. The ``None`` slot
+        is the prefill list, which is always absent for chained decodes.
+        """
+        # Pass in previous decode request and build computation graph for next decode
+        pending = self._mlx_runner.decode_batch_start_chained(prev_pending)
+        mx.async_eval(pending.lazy_tokens, *pending.batch_cache)
+        return pending.lazy_tokens, None, pending, "decode"
+
+    def finalize_mlx_result(
+        self,
+        prefill: Optional[list[MlxPendingPrefill]],
+        decode: Optional[MlxPendingDecode],
+        mode: str,
+        reqs: list,
+        extract_cache: bool = True,
+    ) -> GenerationBatchResult:
+        """Materialise a lazy MLX result into a :class:`GenerationBatchResult`.
+
+        The blocking wait happens inside ``decode_batch_finalize`` /
+        ``prefill_finalize`` via ``.tolist()`` / ``.item()`` on the specific
+        lazy outputs.
+
+        Args:
+            prefill: List of ``MlxPendingPrefill`` to finalise (extend mode).
+            decode: The ``MlxPendingDecode`` to finalise (decode or mixed
+                mode).
+            mode: One of ``"decode"``, ``"extend"``, ``"idle"``.
+            reqs: The request list in the original batch order, used to
+                reassemble per-request next tokens for mixed extend batches.
+            extract_cache: Forwarded to :meth:`MlxModelRunner.decode_batch_finalize`.
+                Pass ``False`` when this pending is mid-chain (another
+                chained decode has already been launched on top of its
+                shared ``batch_cache``); pass ``True`` for the tail of a
+                chain so per-request caches are snapshotted before any
+                non-chained op runs on them.
+        """
+        from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+
+        if mode == "idle":
+            return GenerationBatchResult(
+                logits_output=LogitsProcessorOutput(next_token_logits=None),
+                can_run_cuda_graph=False,
+            )
+
+        if mode == "decode":
+            next_tokens_list = self._mlx_runner.decode_batch_finalize(
+                decode, extract_cache=extract_cache
+            )
+
+        elif mode == "extend":
+            # Finalise each prefill
+            if prefill:
+                prefill_tokens: list[int] = []
+                for pending_p in prefill:
+                    tok = self._mlx_runner.prefill_finalize(pending_p)
+                    prefill_tokens.append(tok)
+                prefill_map = {p.req_id: t for p, t in zip(prefill, prefill_tokens)}
+            else:
+                prefill_map = {}
+
+            # Finalize mixed-mode decodes and update per-request state
+            if decode:
+                decode_results: dict[str, int] = {}
+                if decode is not None:
+                    mixed_tokens = self._mlx_runner.decode_batch_finalize(
+                        decode, extract_cache=extract_cache
+                    )
+                    decode_results = {
+                        rid: tok
+                        for (rid, _), tok in zip(decode.decode_reqs, mixed_tokens)
+                    }
+            else:
+                decode_results = {}
+
+            next_tokens_list = []
+            for req in reqs:
+                if req.rid in prefill_map:
+                    next_tokens_list.append(prefill_map[req.rid])
+                else:
+                    next_tokens_list.append(decode_results[req.rid])
+
+        else:
+            raise ValueError(f"Unknown MLX async mode: {mode}")
+
+        next_token_ids = torch.tensor(next_tokens_list, dtype=torch.long, device="cpu")
         return GenerationBatchResult(
             logits_output=LogitsProcessorOutput(next_token_logits=None),
             next_token_ids=next_token_ids,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1387,46 +1387,199 @@ class Scheduler(
             tmp_batch, tmp_result = self.result_queue.popleft()
             self.process_batch_result(tmp_batch, tmp_result)
 
+        if use_mlx() and self.is_generation:
+            self._event_loop_overlap_mlx()
+        else:
+            while True:
+                # Receive requests
+                recv_reqs = self.recv_requests()
+                self.process_input_requests(recv_reqs)
+                if self._engine_paused:
+                    continue
+
+                # Get the next batch to run
+                batch = self.get_next_batch_to_run()
+                self.cur_batch = batch
+                disable_overlap_for_batch = self.is_disable_overlap_for_batch(batch)
+
+                # If we do not need to overlap the current batch with the last batch,
+                # we can process the last batch immediately.
+                if disable_overlap_for_batch:
+                    pop_and_process()
+
+                # Launch the current batch
+                if batch:
+                    batch_result = self.run_batch(batch)
+                    self.result_queue.append((batch.copy(), batch_result))
+                else:
+                    batch_result = None
+                    self.cancel_bubble_timer()
+
+                # Process the last batch
+                if self.last_batch:
+                    if not disable_overlap_for_batch:
+                        pop_and_process()
+                elif batch is None:
+                    # When the server is idle, do self-check and re-init some states
+                    self.self_check_during_idle()
+
+                # Run sample of the current batch
+                # It depends on the result of the last batch (e.g., grammar), so we run it after the last batch is processed.
+                if self.is_generation:
+                    self.launch_batch_sample_if_needed(batch_result)
+
+                # Update last_batch
+                self.last_batch = batch
+                if envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.get():
+                    self.self_check_during_busy()
+
+    def _event_loop_overlap_mlx(self):
+        """MLX-specific overlap loop modelled on ``mlx_lm.generate.generate_step``.
+
+        At steady state we keep TWO in-flight MLX graphs on the generation
+        stream:
+
+        * ``pending_curr`` — the step whose tokens we are about to block on
+          and feed into the scheduler's bookkeeping.
+        * ``pending_next`` — the step that was built on top of
+          ``pending_curr``'s still-lazy output tokens via
+          ``async_chained_decode_mlx`` and has already been handed to
+          ``mx.async_eval``. Because MLX tracks the full dependency graph,
+          the GPU will execute ``pending_next`` back-to-back with
+          ``pending_curr`` — there is no scheduling gap on the device.
+
+        Bookkeeping timeline for a steady-state decode loop:
+
+            iter k:
+              build pending_next  (CPU graph build + mx.async_eval; cheap)
+              block on pending_curr via .tolist() (wait only on curr's tokens)
+              process_batch_result(pending_curr)   <-- GPU is running pending_next
+              pending_curr = pending_next
+
+        The chain is broken (we fall back to a "schedule + launch" step)
+        whenever any of the following holds:
+
+        * ``pending_curr`` is not a pure decode (e.g. prefill/extend).
+        * The waiting queue has new requests that need prefill.
+        * Any req in ``pending_curr`` just finished this iteration, so the
+          composition for ``pending_next`` would need to shrink.
+
+        When the chain breaks mid-flight we still finalise the already-
+        launched ``pending_next`` normally (its tokens are valid for all
+        surviving reqs). We pass ``extract_cache=True`` to the LAST finalise
+        in a chain so per-request caches get snapshotted back into
+        ``state.cache`` before any non-chained op runs on them.
+        """
+        # ``pending_*`` tuple layout:
+        #   (lazy_tokens, prefill, decode, mode, batch_copy, reqs)
+        pending_curr: Optional[tuple] = None
+        pending_next: Optional[tuple] = None
+
+        def _finalize(pending: tuple, extract_cache: bool):
+            _, pref, dec, mode, batch_copy, reqs_snapshot = pending
+            result = self.tp_worker.finalize_mlx_result(
+                pref,
+                dec,
+                mode,
+                reqs_snapshot,
+                extract_cache=extract_cache,
+            )
+            if result.next_token_ids is not None:
+                batch_copy.output_ids = result.next_token_ids
+            self.process_batch_result(batch_copy, result)
+
+        def _launch_fresh(batch: ScheduleBatch) -> tuple:
+            mwb = batch.get_model_worker_batch()
+            lazy_tokens, pref, dec, mode = (
+                self.tp_worker.async_forward_batch_generation_mlx(mwb)
+            )
+            return (
+                lazy_tokens,
+                pref,
+                dec,
+                mode,
+                batch.copy(),
+                list(batch.reqs),
+            )
+
+        def _launch_chained(prev: tuple) -> tuple:
+            prev_decode = prev[2]  # MlxPendingDecode
+            prev_batch_copy = prev[4]
+            prev_reqs = prev[5]
+            lazy_tokens, pref, dec, mode = self.tp_worker.async_chained_decode_mlx(
+                prev_decode
+            )
+            # Composition is identical to prev: reuse a fresh batch copy
+            # of the same underlying ScheduleBatch so process_batch_result
+            # updates the same req objects with the new token.
+            return (
+                lazy_tokens,
+                pref,
+                dec,
+                mode,
+                prev_batch_copy.copy(),
+                prev_reqs,
+            )
+
         while True:
-            # Receive requests
             recv_reqs = self.recv_requests()
             self.process_input_requests(recv_reqs)
             if self._engine_paused:
                 continue
 
-            # Get the next batch to run
-            batch = self.get_next_batch_to_run()
-            self.cur_batch = batch
-            disable_overlap_for_batch = self.is_disable_overlap_for_batch(batch)
+            # 1. If pending_curr is a pure decode AND no new prefill is waiting,
+            #    build pending_next on top of it NOW — before we block on curr.
+            can_chain = (
+                pending_curr is not None
+                and pending_curr[3] == "decode"
+                and not self.waiting_queue
+            )
+            if can_chain and pending_next is None:
+                # Build + launch the chained step BEFORE we block on
+                # pending_curr — this is the "no idle gap" trick.
+                pending_next = _launch_chained(
+                    pending_curr
+                )  # GPU now has 2 steps queued
 
-            # If we do not need to overlap the current batch with the last batch,
-            # we can process the last batch immediately.
-            if disable_overlap_for_batch:
-                pop_and_process()
+            # 2. Finalize/process on pending_curr's tokens. Because pending_next is still
+            #    referencing curr's batch_cache, extract_cache=False.
+            if pending_curr is not None:
+                _finalize(pending_curr, extract_cache=(pending_next is None))
+                pending_curr = None
+            # ^ while this block returns, GPU is executing pending_next.
 
-            # Launch the current batch
-            if batch:
-                batch_result = self.run_batch(batch)
-                self.result_queue.append((batch.copy(), batch_result))
+            # 3. Decide whether pending_next is still valid and promote it.
+            finished_any = any(
+                req.finished() for req in (pending_next[5] if pending_next else [])
+            )
+            new_prefill_waiting = bool(self.waiting_queue)
+            if (
+                pending_next is not None
+                and not finished_any
+                and not new_prefill_waiting
+            ):
+                pending_curr = pending_next
+                pending_next = None
+                self.cur_batch = pending_curr[4]
+                self.last_batch = pending_curr[4]
+                if envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.get():
+                    self.self_check_during_busy()
+                continue
+
+            # 4. Chain is broken. Finalise pending_next (if any) with extract_cache=True
+            #    so per-req caches get snapshotted back, then schedule fresh.
+            if pending_next is not None:
+                _finalize(pending_next, extract_cache=True)
+                pending_next = None
+            next_batch = self.get_next_batch_to_run()
+            self.cur_batch = next_batch
+            if next_batch:
+                pending_curr = _launch_fresh(next_batch)
             else:
-                batch_result = None
                 self.cancel_bubble_timer()
-
-            # Process the last batch
-            if self.last_batch:
-                if not disable_overlap_for_batch:
-                    pop_and_process()
-            elif batch is None:
-                # When the server is idle, do self-check and re-init some states
                 self.self_check_during_idle()
 
-            # Run sample of the current batch
-            # It depends on the result of the last batch (e.g., grammar), so we run it after the last batch is processed.
-            if self.is_generation:
-                self.launch_batch_sample_if_needed(batch_result)
-
-            # Update last_batch
-            self.last_batch = batch
+            self.last_batch = next_batch
             if envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.get():
                 self.self_check_during_busy()
 
@@ -2731,7 +2884,8 @@ class Scheduler(
                 model_worker_batch.sampling_info = (
                     model_worker_batch.sampling_info.copy_for_forward()
                 )
-
+                # MLX overlap scheduling is handled entirely in event_loop_overlap
+                # and never routes through run_batch, so this block is CUDA-only.
                 bs = len(model_worker_batch.seq_lens)
                 future_indices = self.future_map.alloc_future_indices(bs)
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -778,7 +778,6 @@ class ServerArgs:
         self._handle_hpu_backends()
         self._handle_cpu_backends()
         self._handle_npu_backends()
-        self._handle_mps_backends()
         self._handle_xpu_backends()
 
         # Handle piecewise CUDA graph.
@@ -1088,10 +1087,6 @@ class ServerArgs:
                     "piecewise_cuda_graph_compiler='eager', change piecewise_cuda_graph_compiler to 'eager'."
                 )
                 self.piecewise_cuda_graph_compiler = "eager"
-
-    def _handle_mps_backends(self):
-        if self.device == "mps":
-            self.disable_overlap_schedule = True
 
     def _handle_xpu_backends(self):
         if self.device == "xpu":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fixes #22114 

The MLX backend implementation was written in a way that caused the CPU to synchronize with the GPU on every decode pass as seen in this picture. These idle gaps in the GPU led to lower throughput and could be optimized in way done in the CUDA version seen [here](https://www.lmsys.org/blog/2024-12-04-sglang-v0-4/).
<img width="2072" height="280" alt="image" src="https://github.com/user-attachments/assets/474af1c3-68d3-474f-9c55-9947a984afb8" />

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

The `scheduler` has a new _event_loop_overlap_mlx that only runs when MLX is available (and is turned on by default). It introduces a new mechanism where up to 2 MLX computational graphs are maintained (if decoding workloads can be chained). It takes advantage of MLX's lazy evaluation as seen in [MLX-LM](https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/generate.py#L429). 

The `MlxTpModelWorker` was also updated with new functions that support async evaluation of MLX arrays.

The `MlxModelRunner` was also updated to support creation of MLX arrays without evaluating them (just to build the computational graph).

The arrays are evaluated when they are needed in `MlxModelRunner.decode_batch_finalize()` and `MlxModelRunner.prefill_finalize()`.

### How the chain works                                                                                                                                                                                                 
                  
At steady state the scheduler holds two pending MLX graphs: `pending_curr` (about to be finalised for tokens + bookkeeping) and `pending_next` (built on top of `pending_curr`'s still-lazy output via `decode_batch_start_chained`, already handed to `mx.async_eval`). `pending_next` reuses `pending_curr.batch_cache` in place, so KV writes from both steps land in shared tensors and MLX tracks the full dependency graph. The GPU runs them back-to-back with no scheduling gap. CPU-side bookkeeping for step N (`process_batch_result`, `recv_requests`, building step N+2's graph) happens in parallel with the GPU executing step N+1.
                  
### When the chain breaks

The chain falls back to the standard `get_next_batch_to_run` → `_launch_fresh` path whenever:                                                                                                                           
  
1. `pending_curr` is not a pure decode (prefill / extend).                                                                                                                                                              
2. `self.waiting_queue` has new requests needing prefill (we prioritise serving them).
3. Any req in `pending_curr` just finished (composition for `pending_next` would need to shrink).                                                                                                                       
                                                                                                                                                                                                                          
When case 2 or 3 fires mid-flight, the already-launched `pending_next` is NOT discarded — it's finalised normally with `extract_cache=True` so surviving reqs still get its tokens. The chain then re-forms with one non-chained warmup step on the next iteration.                                                                                                                                                                          
                                                                                                                                                                                                                          
### Subtleties worth flagging for review                                                                                                                                                                                
- **`extract_cache` flag on `decode_batch_finalize`.** The shared `batch_cache` in a chain always reflects the *latest* step's state, so mid-chain finalises must pass `extract_cache=False` to avoid snapshotting future state back into per-request `state.cache`. Only the tail of a chain extracts. Without this, the next non-chained op would read stale/inconsistent KV state.                                                                                                                  
- **Bug fix in the mixed prefill+decode branch of `async_forward_batch_generation_mlx`.** Previously only prefill `cache_states` were included in `mx.async_eval`; the mixed decode's `batch_cache` was missing. KV cache updates are a side effect of the forward pass, so omitting them could let the next step read unmaterialised cache tensors. Now both are included.                                                                 
                  
## Limitations / Follow-ups   
- Only **decode → decode** is chained. Prefill and batch composition changes break the chain.                                                                                                                           
- Up to **one wasted decode step** per EOS: when a req finishes, `pending_next` was speculatively launched for it; its extra token is discarded downstream.
- Scheduler-side preemption / KV pressure checks only run at chain breaks, not on every chained iteration. Fine at 2-deep; revisit if we ever grow the pipeline depth.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

### Before
Command: `SGLANG_USE_MLX=1 uv run python -m sglang.bench_offline_throughput --model-path Qwen/Qwen3-0.6B --num-prompts 1 --port 43440`
```
====== Offline Throughput Benchmark Result =======
Backend:                                 engine    
Successful requests:                     1         
Benchmark duration (s):                  1.76      
Total input tokens:                      17        
Total generated tokens:                  244       
Last generation throughput (tok/s):      141.03    
Request throughput (req/s):              0.57      
Input token throughput (tok/s):          9.66      
Output token throughput (tok/s):         138.61    
Total token throughput (tok/s):          148.27    
==================================================
```
<img width="1482" height="688" alt="image" src="https://github.com/user-attachments/assets/d1da9be7-1bb6-4418-9c99-7764b19b55bb" />


### After
Command: `SGLANG_USE_MLX=1 uv run python -m sglang.bench_offline_throughput --model-path Qwen/Qwen3-0.6B --num-prompts 1 --port 43440`
```
====== Offline Throughput Benchmark Result =======
Backend:                                 engine    
Successful requests:                     1         
Benchmark duration (s):                  1.48      
Total input tokens:                      17        
Total generated tokens:                  244       
Last generation throughput (tok/s):      165.71    
Request throughput (req/s):              0.68      
Input token throughput (tok/s):          11.50     
Output token throughput (tok/s):         165.04    
Total token throughput (tok/s):          176.54    
==================================================
```
<img width="1485" height="692" alt="image" src="https://github.com/user-attachments/assets/35c512df-1536-4eeb-83dd-35878275107d" />

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

## AI Usage
The main code logic was written by me. Claude Code was used to polish the code and write comments/docstrings in the code (as well as parts of the PR description). Everything was verified and understood by me.