### PR TITLE
Move runai model loader test to nightly suite

### DIFF
--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -71,6 +71,8 @@ jobs:
 
       - name: Run test
         timeout-minutes: 60
+        env:
+          RUNAI_STREAMER_MEMORY_LIMIT: 0
         run: |
           cd test
           python3 run_suite.py --hw cuda --suite nightly-1-gpu --nightly --continue-on-error

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -706,7 +706,6 @@ jobs:
         timeout-minutes: 30
         env:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
-          RUNAI_STREAMER_MEMORY_LIMIT: 0
         run: |
           source /etc/profile.d/sglang-ci.sh
           cd test/

--- a/test/registered/model_loading/test_runai_model_loader.py
+++ b/test/registered/model_loading/test_runai_model_loader.py
@@ -5,7 +5,7 @@ from sglang.srt.environ import temp_set_env
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_cuda_ci(est_time=120, suite="stage-b-test-1-gpu-small")
+register_cuda_ci(est_time=380, suite="nightly-1-gpu", nightly=True)
 
 TEST_GCS_MODEL = "gs://vertex-model-garden-public-us/codegemma/codegemma-2b/"
 


### PR DESCRIPTION
## Summary
- Move `test_runai_model_loader.py` from `stage-b-test-1-gpu-small` to `nightly-1-gpu` suite
- The test downloads a model from GCS via the Runai Model Streamer, which is slow (~380s avg) and flaky (hangs on semaphore wait in `libstreamer.so`). Not suitable for per-PR CI.
- Add `RUNAI_STREAMER_MEMORY_LIMIT=0` env to `nightly-test-nvidia.yml` (same workaround as pr-test.yml)

## Test plan
- [ ] Verify nightly CI picks up the test
- [ ] Verify `stage-b-test-1-gpu-small` no longer runs this test