### PR TITLE
[AMD] Replace triton rotary_emb with aiter rotary_emb for Wan2.2 denoise

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
@@ -65,12 +65,8 @@ from sglang.srt.utils import add_prefix
 logger = init_logger(__name__)
 _is_cuda = current_platform.is_cuda()
 
-try:
+if _use_aiter:
     from aiter.ops.rope import rope_cached_2c_fwd_inplace
-
-    _has_aiter_rope = True
-except ImportError:
-    _has_aiter_rope = False
 
 
 class WanImageEmbedding(torch.nn.Module):
@@ -557,7 +553,7 @@ class WanTransformerBlock(nn.Module):
             query, key = apply_flashinfer_rope_qk_inplace(
                 query, key, cos_sin_cache, is_neox=False
             )
-        elif _use_aiter and _has_aiter_rope:
+        elif _use_aiter:
             query_shape = query.shape
             key_shape = key.shape
             num_tokens = query.shape[:-2].numel()
@@ -803,7 +799,7 @@ class WanTransformerBlock_VSA(nn.Module):
             query, key = apply_flashinfer_rope_qk_inplace(
                 query, key, cos_sin_cache, is_neox=False
             )
-        elif _use_aiter and _has_aiter_rope:
+        elif _use_aiter:
             query_shape = query.shape
             key_shape = key.shape
             num_tokens = query.shape[:-2].numel()

--- a/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
@@ -50,6 +50,9 @@ from sglang.multimodal_gen.runtime.layers.visual_embedding import (
 )
 from sglang.multimodal_gen.runtime.managers.forward_context import get_forward_context
 from sglang.multimodal_gen.runtime.models.dits.base import CachableDiT
+from sglang.multimodal_gen.runtime.models.utils import (
+    _use_aiter,
+)
 from sglang.multimodal_gen.runtime.platforms import (
     AttentionBackendEnum,
     current_platform,
@@ -61,6 +64,13 @@ from sglang.srt.utils import add_prefix
 
 logger = init_logger(__name__)
 _is_cuda = current_platform.is_cuda()
+
+try:
+    from aiter.ops.rope import rope_cached_2c_fwd_inplace
+
+    _has_aiter_rope = True
+except ImportError:
+    _has_aiter_rope = False
 
 
 class WanImageEmbedding(torch.nn.Module):
@@ -547,6 +557,25 @@ class WanTransformerBlock(nn.Module):
             query, key = apply_flashinfer_rope_qk_inplace(
                 query, key, cos_sin_cache, is_neox=False
             )
+        elif _use_aiter and _has_aiter_rope:
+            query_shape = query.shape
+            key_shape = key.shape
+            num_tokens = query.shape[:-2].numel()
+            q_sbhd = query.view(num_tokens, 1, query_shape[-2], query_shape[-1])
+            k_sbhd = key.view(num_tokens, 1, key_shape[-2], key_shape[-1])
+            cos_sbhd = cos.contiguous().view(num_tokens, 1, 1, -1)
+            sin_sbhd = sin.contiguous().view(num_tokens, 1, 1, -1)
+            rope_cached_2c_fwd_inplace(
+                q_sbhd,
+                k_sbhd,
+                cos_sbhd,
+                sin_sbhd,
+                1,  # GPTJ rotate style
+                True,  # reuse_freqs_front_part
+                False,  # nope_first
+            )
+            query = q_sbhd.view(query_shape)
+            key = k_sbhd.view(key_shape)
         else:
             query, key = _apply_rotary_emb(
                 query, cos, sin, is_neox_style=False
@@ -774,6 +803,25 @@ class WanTransformerBlock_VSA(nn.Module):
             query, key = apply_flashinfer_rope_qk_inplace(
                 query, key, cos_sin_cache, is_neox=False
             )
+        elif _use_aiter and _has_aiter_rope:
+            query_shape = query.shape
+            key_shape = key.shape
+            num_tokens = query.shape[:-2].numel()
+            q_sbhd = query.view(num_tokens, 1, query_shape[-2], query_shape[-1])
+            k_sbhd = key.view(num_tokens, 1, key_shape[-2], key_shape[-1])
+            cos_sbhd = cos.contiguous().view(num_tokens, 1, 1, -1)
+            sin_sbhd = sin.contiguous().view(num_tokens, 1, 1, -1)
+            rope_cached_2c_fwd_inplace(
+                q_sbhd,
+                k_sbhd,
+                cos_sbhd,
+                sin_sbhd,
+                1,  # GPTJ rotate style
+                True,  # reuse_freqs_front_part
+                False,  # nope_first
+            )
+            query = q_sbhd.view(query_shape)
+            key = k_sbhd.view(key_shape)
         else:
             query, key = _apply_rotary_emb(
                 query, cos, sin, is_neox_style=False

--- a/python/sglang/multimodal_gen/runtime/models/utils.py
+++ b/python/sglang/multimodal_gen/runtime/models/utils.py
@@ -8,6 +8,17 @@ from typing import Any
 
 import torch
 
+from sglang.srt.utils import (
+    get_bool_env_var,
+    is_gfx95_supported,
+    is_hip,
+)
+
+_is_hip = is_hip()
+_is_gfx95_supported = is_gfx95_supported()
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
+_use_aiter_gfx95 = _use_aiter and _is_gfx95_supported
+
 
 def set_weight_attrs(
     weight: torch.Tensor,


### PR DESCRIPTION
## Motivation

The WanVideo model's aiter RoPE path used `rope_cached_thd_positions_2c_fwd` (triton, non-inplace), which allocates two new output tensors per call and requires reshape/view_as around each invocation. This is suboptimal compared to the kernel available in aiter, which use single kernel to complete RoPE on both k and v.

## Modifications

- Switched WanVideo's aiter RoPE kernel from triton `rope_cached_thd_positions_2c_fwd` to HIP `rope_cached_2c_fwd_inplace` (sbhd format, in-place).

## Accuracy Tests

| Item | Value |
|------|-------|
| Frames used | 193 |
| CLIP mean/min | 0.9899 / 0.9794 (Pass (min >= 0.9)) |
| SSIM mean/min | 0.8657 / 0.8190 (Pass (min >= 0.81)) |
| PSNR mean/min | 27.03 / 22.56 dB (Pass (min >= 20.4 dB)) |
| MAD mean/max | 6.3446 / 8.9832 (Pass (max <= 10.0)) |
| LPIPS mean/max | 0.1313 / 0.1601 (informational) |

Ref baseline: wan2_2_ti2v_5b (`python/sglang/multimodal_gen/test/server/consistency_threshold.json`).

## Speed Tests and Profiling

**Kernel-level benchmark** (T = 176,400, H = 40, D = 128, fp16, MI355):

| Kernel | Time |
|--------|------|
| Before: `_apply_rotary_emb` (triton) | 1,461.1 μs × 2 calls = 2,922.2 μs |
| After: `kn_entry_2c_sbhd_cached_inplace` (HIP) | 1,334.6 μs × 1 call |

**End-to-end denoise step** (1× MI355, 720p, 193 frames, bf16):

| | Denoise time | Improvement |
|--|--------------|-------------|
| Before | 115.14 s | — |
| After | 114.68 s | ~0.5% |

## Other experiments

**Standalone kernel benchmark inside aiter** (`bench_rope_compare.py`):

There are three candidate kernels available, and rope_cached_2c_fwd_inplace kernel is chosen to be the best fit.

| Approach | Time | Speedup |
|----------|------|---------|
| `rope_cached_2c_fwd_inplace` (HIP, inplace) | 1.352 ms | 1.60× |
| `rope_cached_thd_positions_2c_fwd` (triton, non-inplace) | 2.160 ms | 1.0× |
| `rope_cached_thd_positions_2c_fwd_inplace` (triton, inplace) | 2.465 ms | 0.88× |

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
