### PR TITLE
Fix Qwen3.5 video processing when passing video_data in "processor_output" format

### DIFF
--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -162,7 +162,7 @@ async def preprocess_video(
     # preprocessed video
     is_video_obj = isinstance(vr, VideoDecoderWrapper)
     if not is_video_obj:
-        return vr
+        return vr, None
     entry_time = time.perf_counter()
 
     total_frames, video_fps = len(vr), vr.avg_fps


### PR DESCRIPTION
## Motivation

Currently, the video preprocessing function of Qwen3.5 requires two return values:
https://github.com/sgl-project/sglang/blob/ef6bfc1197ab45290e33941881f23c39fbf30ad9/python/sglang/srt/multimodal/processors/qwen_vl.py#L514-L518

However, when using `processor_output` format, the loaded video (the `vr` argument in `preprocess_video`) is a dict, resulting in only a single return value.

https://github.com/sgl-project/sglang/blob/ef6bfc1197ab45290e33941881f23c39fbf30ad9/python/sglang/srt/multimodal/processors/qwen_vl.py#L157-L165

This will result in the following error:
```
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/multimodal/processors/qwen_vl.py", line 521, in process_mm_data_async
    base_output.videos, video_metadata = map(list, zip(*videos_processed))
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: too many values to unpack (expected 2)
```

## Modifications

```python
async def preprocess_video(
    vr,
    image_factor: int = IMAGE_FACTOR,
    video_config: dict = {},
) -> torch.Tensor:
    # preprocessed video
    is_video_obj = isinstance(vr, VideoDecoderWrapper)
    if not is_video_obj:
        return vr, None  # return vr -> return vr, None
```

## Accuracy Tests

The following is a simple test script that verifies the expected behavior when passing the processor's output as video data.

```python
import sglang as sgl
from transformers import AutoProcessor


def main():
    conversation = [
        {
            'role': 'user',
            'content': [
                {'type': 'video', 'video': 'https://raw.githubusercontent.com/DAMO-NLP-SG/VideoLLaMA3/refs/heads/main/assets/cat_and_chicken.mp4'},
                {'type': 'text', 'text': 'Describe the video.'}
            ],
        }
    ]

    model_path = "Qwen/Qwen3.5-0.8B"
    llm = sgl.Engine(model_path=model_path)
    processor = AutoProcessor.from_pretrained(model_path)


    ###############################################################
    # Use processor output
    ###############################################################
    model_inputs = processor.apply_chat_template(
        conversation,
        add_generation_prompt=True,
        tokenize=True,
        return_dict=True,
        return_tensors="pt",
    )

    image_data, video_data = {"format": "processor_output"}, {"format": "processor_output"}
    for name, data in model_inputs.items():
        if name in processor.image_processor.model_input_names:
            image_data[name] = data
        if name in processor.video_processor.model_input_names:
            video_data[name] = data

    if len(image_data) == 1:
        image_data = None
    if len(video_data) == 1:
        video_data = None

    output = llm.generate(
        input_ids=model_inputs["input_ids"].tolist(),
        image_data=image_data,
        video_data=video_data,
        sampling_params={"temperature": 0.0},
    )
    print(output)


    ###############################################################
    # Use raw video path
    ###############################################################
    prompt = processor.apply_chat_template(
        conversation,
        add_generation_prompt=True,
        tokenize=False,
    )

    image_data, video_data = [], []
    for message in conversation:
        if message['role'] == 'user':
            for content in message['content']:
                if content['type'] == 'image':
                    image_data.append(content['image'])
                elif content['type'] == 'video':
                    video_data.append(content['video'])

    output = llm.generate(
        prompt=prompt,
        image_data=image_data,
        video_data=video_data,
        sampling_params={"temperature": 0.0},
    )
    print(output)


if __name__ == '__main__':
    main()
```

## Speed Tests and Profiling

N/A

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
