### PR TITLE
[NPU] add split_qkv_tp_rmsnorm_rope ops for minimax2

### DIFF
--- a/python/sglang/srt/models/minimax_m2.py
+++ b/python/sglang/srt/models/minimax_m2.py
@@ -42,10 +42,10 @@ from sglang.srt.layers.communicator import (
 )
 from sglang.srt.layers.dp_attention import (
     attn_tp_all_reduce,
+    get_attention_tp_group,
     get_attention_tp_rank,
     get_attention_tp_size,
     is_dp_attention_enabled,
-    get_attention_tp_group,
 )
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import (
@@ -77,10 +77,10 @@ from sglang.srt.utils import (
     add_prefix,
     get_compiler_backend,
     is_non_idle_and_non_empty,
+    is_npu,
     make_layers,
 )
 from sglang.srt.utils.hf_transformers_utils import get_rope_config
-from sglang.srt.utils import is_npu
 
 _is_npu = is_npu()
 
@@ -685,7 +685,7 @@ class MiniMaxM2Attention(nn.Module):
         q, k = self.rotary_emb(positions, q, k)
         inner_state = q, k, v, forward_batch
         return None, forward_batch, inner_state
-    
+
     def forward_prepare_npu(
         self,
         positions: torch.Tensor,
@@ -696,9 +696,7 @@ class MiniMaxM2Attention(nn.Module):
         if self.use_qk_norm:
             # q = self.q_norm(q.contiguous())
             # k = self.k_norm(k.contiguous())
-            cos_sin = self.rotary_emb.cos_sin_cache.index_select(
-                0, positions.flatten()
-            )
+            cos_sin = self.rotary_emb.cos_sin_cache.index_select(0, positions.flatten())
             cos, sin = cos_sin.chunk(2, dim=-1)
             q, k, v = split_qkv_tp_rmsnorm_rope(
                 input=qkv,
@@ -721,7 +719,6 @@ class MiniMaxM2Attention(nn.Module):
 
         inner_state = q, k, v, forward_batch
         return None, forward_batch, inner_state
-
 
     def forward_core(self, intermediate_state):
         _, _, inner_state = intermediate_state

--- a/python/sglang/srt/models/minimax_m2.py
+++ b/python/sglang/srt/models/minimax_m2.py
@@ -17,7 +17,7 @@
 
 import logging
 from contextlib import nullcontext
-from typing import Iterable, Optional, Set, Tuple, Union
+from typing import Iterable, List, Optional, Set, Tuple, Union
 
 import torch
 import triton
@@ -770,6 +770,7 @@ class MiniMaxM2DecoderLayer(nn.Module):
         prefix: str = "",
     ) -> None:
         super().__init__()
+        self.config = config
         self.hidden_size = config.hidden_size
         self.layer_id = layer_id
 
@@ -812,6 +813,7 @@ class MiniMaxM2DecoderLayer(nn.Module):
             input_layernorm=self.input_layernorm,
             post_attention_layernorm=self.post_attention_layernorm,
             allow_reduce_scatter=True,
+            is_last_layer=(self.layer_id == self.config.num_hidden_layers - 1),
         )
 
     def forward(
@@ -820,10 +822,17 @@ class MiniMaxM2DecoderLayer(nn.Module):
         hidden_states: torch.Tensor,
         forward_batch: ForwardBatch,
         residual: Optional[torch.Tensor],
+        captured_last_layer_outputs: Optional[List[torch.Tensor]] = None,
+        **kwargs,
     ) -> torch.Tensor:
-        # Self Attention
-        hidden_states, residual = self.layer_communicator.prepare_attn(
-            hidden_states, residual, forward_batch
+        hidden_states, residual = (
+            self.layer_communicator.prepare_attn_and_capture_last_layer_outputs(
+                hidden_states,
+                residual,
+                forward_batch,
+                captured_last_layer_outputs=captured_last_layer_outputs,
+                **kwargs,
+            )
         )
         if not forward_batch.forward_mode.is_idle():
             hidden_states = self.self_attn(
@@ -1007,14 +1016,15 @@ class MiniMaxM2Model(nn.Module):
                     else get_global_expert_distribution_recorder().with_current_layer(i)
                 )
                 with ctx:
-                    if i in self.layers_to_capture:
-                        aux_hidden_states.append(hidden_states + residual)
                     layer = self.layers[i]
                     hidden_states, residual = layer(
                         positions=positions,
                         forward_batch=forward_batch,
                         hidden_states=hidden_states,
                         residual=residual,
+                        captured_last_layer_outputs=(
+                            aux_hidden_states if i in self.layers_to_capture else None
+                        ),
                     )
 
         if not self.pp_group.is_last_rank:

--- a/python/sglang/srt/models/minimax_m2.py
+++ b/python/sglang/srt/models/minimax_m2.py
@@ -45,6 +45,7 @@ from sglang.srt.layers.dp_attention import (
     get_attention_tp_rank,
     get_attention_tp_size,
     is_dp_attention_enabled,
+    get_attention_tp_group,
 )
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import (
@@ -79,6 +80,12 @@ from sglang.srt.utils import (
     make_layers,
 )
 from sglang.srt.utils.hf_transformers_utils import get_rope_config
+from sglang.srt.utils import is_npu
+
+_is_npu = is_npu()
+
+if _is_npu:
+    from sgl_kernel_npu.norm.split_qkv_tp_rmsnorm_rope import split_qkv_tp_rmsnorm_rope
 
 logger = logging.getLogger(__name__)
 
@@ -678,6 +685,43 @@ class MiniMaxM2Attention(nn.Module):
         q, k = self.rotary_emb(positions, q, k)
         inner_state = q, k, v, forward_batch
         return None, forward_batch, inner_state
+    
+    def forward_prepare_npu(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ):
+        qkv, _ = self.qkv_proj(hidden_states)
+        if self.use_qk_norm:
+            # q = self.q_norm(q.contiguous())
+            # k = self.k_norm(k.contiguous())
+            cos_sin = self.rotary_emb.cos_sin_cache.index_select(
+                0, positions.flatten()
+            )
+            cos, sin = cos_sin.chunk(2, dim=-1)
+            q, k, v = split_qkv_tp_rmsnorm_rope(
+                input=qkv,
+                cos=cos,
+                sin=sin,
+                q_weight=self.q_norm.weight,
+                k_weight=self.k_norm.weight,
+                q_hidden_size=self.q_size,
+                kv_hidden_size=self.kv_size,
+                head_dim=self.head_dim,
+                rotary_dim=self.rotary_dim,
+                eps=self.q_norm.variance_epsilon,
+                tp_world=self.q_norm.attn_tp_size,
+                tp_group=get_attention_tp_group().device_group,
+            )
+        else:
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+            q, k = q.contiguous(), k.contiguous()
+            q, k = self.rotary_emb(positions, q, k)
+
+        inner_state = q, k, v, forward_batch
+        return None, forward_batch, inner_state
+
 
     def forward_core(self, intermediate_state):
         _, _, inner_state = intermediate_state
@@ -691,11 +735,18 @@ class MiniMaxM2Attention(nn.Module):
         hidden_states: torch.Tensor,
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
-        s = self.forward_prepare(
-            positions=positions,
-            hidden_states=hidden_states,
-            forward_batch=forward_batch,
-        )
+        if _is_npu:
+            s = self.forward_prepare_npu(
+                positions=positions,
+                hidden_states=hidden_states,
+                forward_batch=forward_batch,
+            )
+        else:
+            s = self.forward_prepare(
+                positions=positions,
+                hidden_states=hidden_states,
+                forward_batch=forward_batch,
+            )
         return self.forward_core(s)
 
     def op_prepare(self, state):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
add split_qkv_tp_rmsnorm_rope ops for Minimax2
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
add split_qkv_tp_rmsnorm_rope ops for Minimax2
fix cudagraph+eagle3+dp-attention bs > 1 crash error
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
```
gsm8k dataset test
Accuracy: 0.940
Invalid: 0.000
Latency: 31.460 s
Output throughput: 707.537 token/s
```
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling
3.5K 1.5K test case
launch cmd
```
source /usr/local/Ascend/ascend-toolkit/set_env.sh
source /usr/local/Ascend/nnal/atb/set_env.sh

export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
export STREAMS_PER_DEVICE=32
export HCCL_SOCKET_IFNAME=lo
export GLOO_SOCKET_IFNAME=lo

export HCCL_OP_EXPANSION_MODE=AIV
export TASK_QUEUE_ENABLE=1

export HCCL_BUFFSIZE=800
export SGLANG_SET_CPU_AFFINITY=1
export SGLANG_NPU_FUSED_MOE_MODE=2
export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=28000

sglang serve \
   --model-path / $MODEL_PATH \
   --host 127.0.0.1 \
   --port 32000 \
   --tp-size 16 \
   --enable-dp-attention \
   --dp-size 16 \
   --ep-size 16 \
   --mem-fraction-static 0.8 \
   --max-running-requests 2048 \
   --disable-radix-cache \
   --prefill-delayer-max-delay-passes 200 \
   --enable-prefill-delayer \
   --chunked-prefill-size -1 --max-prefill-token 4096 \
   --cuda-graph-bs 1 2 8 16 24 32 48 \
   --moe-a2a-backend ascend_fuseep --deepep-mode auto --quantization modelslim \

```

before:
```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 256
Successful requests:                     256
Benchmark duration (s):                  135.56
Total input tokens:                      896000
Total input text tokens:                 896000
Total generated tokens:                  384000
Total generated tokens (retokenized):    351005
Request throughput (req/s):              1.89
Input token throughput (tok/s):          6609.41
Output token throughput (tok/s):         2832.60
Peak output token throughput (tok/s):    5888.00
Peak concurrent requests:                256
Total token throughput (tok/s):          9442.01
Concurrency:                             255.75
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   135430.94
Median E2E Latency (ms):                 135439.27
P90 E2E Latency (ms):                    135477.05
P99 E2E Latency (ms):                    135502.98
---------------Time to First Token----------------
Mean TTFT (ms):                          33314.26
Median TTFT (ms):                        30274.85
P99 TTFT (ms):                           64499.78
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          68.12
Median TPOT (ms):                        70.16
P99 TPOT (ms):                           88.68
---------------Inter-Token Latency----------------
Mean ITL (ms):                           68.13
Median ITL (ms):                         46.40
P95 ITL (ms):                            75.54
P99 ITL (ms):                            115.75
Max ITL (ms):                            61887.70
==================================================

```

after:
```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 256
Successful requests:                     256
Benchmark duration (s):                  83.69
Total input tokens:                      896000
Total input text tokens:                 896000
Total generated tokens:                  384000
Total generated tokens (retokenized):    363900
Request throughput (req/s):              3.06
Input token throughput (tok/s):          10705.72
Output token throughput (tok/s):         4588.16
Peak output token throughput (tok/s):    5888.00
Peak concurrent requests:                256
Total token throughput (tok/s):          15293.88
Concurrency:                             255.58
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   83557.15
Median E2E Latency (ms):                 83557.60
P90 E2E Latency (ms):                    83606.39
P99 E2E Latency (ms):                    83629.40
---------------Time to First Token----------------
Mean TTFT (ms):                          6383.28
Median TTFT (ms):                        5828.14
P99 TTFT (ms):                           12213.44
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          51.48
Median TPOT (ms):                        51.85
P99 TPOT (ms):                           54.23
---------------Inter-Token Latency----------------
Mean ITL (ms):                           51.48
Median ITL (ms):                         46.49
P95 ITL (ms):                            73.62
P99 ITL (ms):                            111.34
Max ITL (ms):                            9973.17
==================================================
```

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
