### PR TITLE
[VLM] fix Kimi-VL deployment

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -507,6 +507,18 @@ class ModelConfig:
             self.qk_rope_head_dim = self.hf_text_config.qk_rope_head_dim
             self.v_head_dim = self.hf_text_config.v_head_dim
             self.qk_nope_head_dim = self.hf_text_config.qk_nope_head_dim
+            self.scaling = 1 / math.sqrt(self.qk_nope_head_dim + self.qk_rope_head_dim)
+            rope_scaling = getattr(self.hf_text_config, "rope_scaling", None)
+            if rope_scaling:
+                rope_type = (
+                    rope_scaling.get("rope_type")
+                    or rope_scaling.get("type")
+                    or "default"
+                )
+                if rope_type != "default":
+                    self.scaling = compute_mla_mscale_scaling(
+                        rope_scaling, self.scaling
+                    )
         elif "KimiLinearForCausalLM" in self.hf_config.architectures:
             self.head_dim = 72
             self.attention_arch = AttentionArch.MLA

--- a/python/sglang/srt/models/kimi_vl_moonvit.py
+++ b/python/sglang/srt/models/kimi_vl_moonvit.py
@@ -142,24 +142,37 @@ def sdpa_attention(
     """
     # Unified format legal check
     assert q.dim() == k.dim() == v.dim() == 3, "q, k, v must have 3 dims"
+
+    # Fast path for a single packed segment.
+    if q_cu_seqlens is None or len(q_cu_seqlens) <= 2:
+        q_ = q.transpose(0, 1).unsqueeze(0)
+        k_ = k.transpose(0, 1).unsqueeze(0)
+        v_ = v.transpose(0, 1).unsqueeze(0)
+        attn_output = F.scaled_dot_product_attention(q_, k_, v_, dropout_p=0.0)
+        return attn_output.squeeze(0).transpose(0, 1).reshape(q.shape[0], -1)
+
     assert q_cu_seqlens[-1] == q.shape[0], "q_cu_seqlens must sum to q.shape[0]"
-    seq_length = q.shape[0]
-    attention_mask = torch.zeros(
-        [1, seq_length, seq_length], device=q.device, dtype=torch.bool
-    )
+    assert (
+        k_cu_seqlens is not None and k_cu_seqlens[-1] == k.shape[0]
+    ), "k_cu_seqlens must sum to k.shape[0]"
+    assert len(q_cu_seqlens) == len(
+        k_cu_seqlens
+    ), "q_cu_seqlens and k_cu_seqlens must have the same batch size"
+
+    # Memory-safe path: compute SDPA segment-by-segment. Building a single
+    # (sum(L_i), sum(L_i)) block mask can trigger OOM when multiple images
+    # are packed together because memory scales with total_length^2.
+    outputs = []
     for i in range(1, len(q_cu_seqlens)):
-        attention_mask[
-            ...,
-            q_cu_seqlens[i - 1] : q_cu_seqlens[i],
-            q_cu_seqlens[i - 1] : q_cu_seqlens[i],
-        ] = True
-    q = q.transpose(0, 1)
-    k = k.transpose(0, 1)
-    v = v.transpose(0, 1)
-    attn_output = F.scaled_dot_product_attention(q, k, v, attention_mask, dropout_p=0.0)
-    attn_output = attn_output.transpose(0, 1)
-    attn_output = attn_output.reshape(seq_length, -1)
-    return attn_output
+        q_start, q_end = q_cu_seqlens[i - 1].item(), q_cu_seqlens[i].item()
+        k_start, k_end = k_cu_seqlens[i - 1].item(), k_cu_seqlens[i].item()
+        q_i = q[q_start:q_end].transpose(0, 1).unsqueeze(0)
+        k_i = k[k_start:k_end].transpose(0, 1).unsqueeze(0)
+        v_i = v[k_start:k_end].transpose(0, 1).unsqueeze(0)
+        out_i = F.scaled_dot_product_attention(q_i, k_i, v_i, dropout_p=0.0)
+        outputs.append(out_i.squeeze(0).transpose(0, 1))
+
+    return torch.cat(outputs, dim=0).reshape(q.shape[0], -1)
 
 
 VL_VISION_ATTENTION_FUNCTIONS = {

--- a/python/sglang/srt/utils/hf_transformers_utils.py
+++ b/python/sglang/srt/utils/hf_transformers_utils.py
@@ -190,6 +190,64 @@ def _patch_text_config(parent_config: PretrainedConfig, text_config):
     return text_config
 
 
+def _ensure_processing_utils_compat() -> bool:
+    """Backfill removed private helpers used by old remote processor code."""
+    try:
+        import transformers.processing_utils as processing_utils
+    except Exception:
+        return False
+
+    if hasattr(processing_utils, "_validate_images_text_input_order"):
+        return False
+
+    def _validate_images_text_input_order(images, text):
+        # Keep argument order as-is. Older remote processors call this helper
+        # even when not relying on its validation logic.
+        return images, text
+
+    setattr(
+        processing_utils,
+        "_validate_images_text_input_order",
+        _validate_images_text_input_order,
+    )
+    return True
+
+
+def _load_auto_processor_with_compat(
+    tokenizer_name: str,
+    *args,
+    trust_remote_code: bool = False,
+    revision: Optional[str] = None,
+    **kwargs,
+):
+    """Load AutoProcessor, retrying once with compatibility patch if needed."""
+    try:
+        return AutoProcessor.from_pretrained(
+            tokenizer_name,
+            *args,
+            trust_remote_code=trust_remote_code,
+            revision=revision,
+            **kwargs,
+        )
+    except ImportError as e:
+        if "_validate_images_text_input_order" not in str(e):
+            raise
+        patched = _ensure_processing_utils_compat()
+        if patched:
+            logger.warning(
+                "Injected transformers.processing_utils._validate_images_text_input_order "
+                "for backward-compatible remote processor loading: %s",
+                tokenizer_name,
+            )
+        return AutoProcessor.from_pretrained(
+            tokenizer_name,
+            *args,
+            trust_remote_code=trust_remote_code,
+            revision=revision,
+            **kwargs,
+        )
+
+
 def get_hf_text_config(config: PretrainedConfig):
     """Get the "sub" config relevant to llm for multi modal models.
     No op for pure text models.
@@ -1288,7 +1346,7 @@ def get_processor(
                     **kwargs,
                 )
             else:
-                processor = AutoProcessor.from_pretrained(
+                processor = _load_auto_processor_with_compat(
                     tokenizer_name,
                     *args,
                     trust_remote_code=trust_remote_code,
@@ -1303,7 +1361,7 @@ def get_processor(
                 f"Processor {tokenizer_name} does not have a slow version. Automatically use fast version"
             )
             kwargs["use_fast"] = True
-            processor = AutoProcessor.from_pretrained(
+            processor = _load_auto_processor_with_compat(
                 tokenizer_name,
                 *args,
                 trust_remote_code=trust_remote_code,
@@ -1320,7 +1378,7 @@ def get_processor(
             )
             kwargs.pop("use_fast", None)
             kwargs.pop("_from_auto", None)
-            processor = AutoProcessor.from_pretrained(
+            processor = _load_auto_processor_with_compat(
                 tokenizer_name,
                 *args,
                 revision=revision,

--- a/python/sglang/srt/utils/hf_transformers_utils.py
+++ b/python/sglang/srt/utils/hf_transformers_utils.py
@@ -190,64 +190,6 @@ def _patch_text_config(parent_config: PretrainedConfig, text_config):
     return text_config
 
 
-def _ensure_processing_utils_compat() -> bool:
-    """Backfill removed private helpers used by old remote processor code."""
-    try:
-        import transformers.processing_utils as processing_utils
-    except Exception:
-        return False
-
-    if hasattr(processing_utils, "_validate_images_text_input_order"):
-        return False
-
-    def _validate_images_text_input_order(images, text):
-        # Keep argument order as-is. Older remote processors call this helper
-        # even when not relying on its validation logic.
-        return images, text
-
-    setattr(
-        processing_utils,
-        "_validate_images_text_input_order",
-        _validate_images_text_input_order,
-    )
-    return True
-
-
-def _load_auto_processor_with_compat(
-    tokenizer_name: str,
-    *args,
-    trust_remote_code: bool = False,
-    revision: Optional[str] = None,
-    **kwargs,
-):
-    """Load AutoProcessor, retrying once with compatibility patch if needed."""
-    try:
-        return AutoProcessor.from_pretrained(
-            tokenizer_name,
-            *args,
-            trust_remote_code=trust_remote_code,
-            revision=revision,
-            **kwargs,
-        )
-    except ImportError as e:
-        if "_validate_images_text_input_order" not in str(e):
-            raise
-        patched = _ensure_processing_utils_compat()
-        if patched:
-            logger.warning(
-                "Injected transformers.processing_utils._validate_images_text_input_order "
-                "for backward-compatible remote processor loading: %s",
-                tokenizer_name,
-            )
-        return AutoProcessor.from_pretrained(
-            tokenizer_name,
-            *args,
-            trust_remote_code=trust_remote_code,
-            revision=revision,
-            **kwargs,
-        )
-
-
 def get_hf_text_config(config: PretrainedConfig):
     """Get the "sub" config relevant to llm for multi modal models.
     No op for pure text models.
@@ -1346,7 +1288,7 @@ def get_processor(
                     **kwargs,
                 )
             else:
-                processor = _load_auto_processor_with_compat(
+                processor = AutoProcessor.from_pretrained(
                     tokenizer_name,
                     *args,
                     trust_remote_code=trust_remote_code,
@@ -1361,7 +1303,7 @@ def get_processor(
                 f"Processor {tokenizer_name} does not have a slow version. Automatically use fast version"
             )
             kwargs["use_fast"] = True
-            processor = _load_auto_processor_with_compat(
+            processor = AutoProcessor.from_pretrained(
                 tokenizer_name,
                 *args,
                 trust_remote_code=trust_remote_code,
@@ -1378,7 +1320,7 @@ def get_processor(
             )
             kwargs.pop("use_fast", None)
             kwargs.pop("_from_auto", None)
-            processor = _load_auto_processor_with_compat(
+            processor = AutoProcessor.from_pretrained(
                 tokenizer_name,
                 *args,
                 revision=revision,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Kimi-VL deployment hit runtime blockers that prevented stable serving in SGLang:
- **Scheduler init failure for Kimi-VL MLA path**: `ModelConfig` for `KimiVLForConditionalGeneration` did not set `scaling`, causing `AttributeError` during FlashMLA backend initialization.
- **OOM on multi-image requests**: Kimi-VL vision SDPA path built a global `(sum(L_i), sum(L_i))` attention mask, leading to quadratic memory growth (especially with 2+ images).

This PR improves Kimi-VL runtime stability and multi-image memory safety.

## Modifications

<!-- Detail the changes made in this pull request. -->

1. **Fix missing MLA scaling in Kimi-VL model config**
   - File: `python/sglang/srt/configs/model_config.py`
   - In `KimiVLForConditionalGeneration` branch of `_derive_model_shapes()`, added:
     - default MLA scaling initialization: `1 / sqrt(qk_nope_head_dim + qk_rope_head_dim)`
     - optional rope-based rescaling via `compute_mla_mscale_scaling(...)` for non-default rope types.
   - Resolves `AttributeError: 'ModelConfig' object has no attribute 'scaling'`.

2. **Memory-safe SDPA for Kimi-VL vision encoder**
   - File: `python/sglang/srt/models/kimi_vl_moonvit.py`
   - Refactored `sdpa_attention(...)`:
     - keep a fast path for single packed segment,
     - for multi-segment packed inputs, compute attention per segment and concatenate outputs.
   - Avoids constructing a large global block-diagonal mask and reduces peak memory in multi-image scenarios, preventing OOM observed on two-image requests.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
