### PR TITLE
[Model] Add EXAONE-4.5 vision-language model support

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -21,6 +21,8 @@ from pathlib import Path
 from typing import Any, List, Optional, Set, Union
 
 import torch
+from transformers import PretrainedConfig
+
 from sglang.srt.environ import envs
 from sglang.srt.layers.quantization import QUANTIZATION_METHODS
 from sglang.srt.server_args import ServerArgs
@@ -34,7 +36,6 @@ from sglang.srt.utils.hf_transformers_utils import (
 )
 from sglang.srt.utils.runai_utils import ObjectStorageModel, is_runai_obj_uri
 from sglang.utils import is_in_ci
-from transformers import PretrainedConfig
 
 logger = logging.getLogger(__name__)
 

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -21,8 +21,6 @@ from pathlib import Path
 from typing import Any, List, Optional, Set, Union
 
 import torch
-from transformers import PretrainedConfig
-
 from sglang.srt.environ import envs
 from sglang.srt.layers.quantization import QUANTIZATION_METHODS
 from sglang.srt.server_args import ServerArgs
@@ -36,6 +34,7 @@ from sglang.srt.utils.hf_transformers_utils import (
 )
 from sglang.srt.utils.runai_utils import ObjectStorageModel, is_runai_obj_uri
 from sglang.utils import is_in_ci
+from transformers import PretrainedConfig
 
 logger = logging.getLogger(__name__)
 
@@ -361,6 +360,12 @@ class ModelConfig:
         if is_draft_model and self.hf_config.architectures[0] == "ExaoneMoEForCausalLM":
             self.hf_config.architectures[0] = "ExaoneMoEForCausalLMMTP"
             self.hf_config.num_nextn_predict_layers = 1
+
+        if (
+            is_draft_model
+            and self.hf_config.architectures[0] == "Exaone4_5_ForConditionalGeneration"
+        ):
+            self.hf_config.architectures[0] = "Exaone4_5_MTP"
 
         if is_draft_model and self.hf_config.architectures[0] == "NemotronHForCausalLM":
             self.hf_config.architectures[0] = "NemotronHForCausalLMMTP"
@@ -730,7 +735,6 @@ class ModelConfig:
             if not is_local:
                 # Conditional import based on SGLANG_USE_MODELSCOPE environment variable
                 if envs.SGLANG_USE_MODELSCOPE.get():
-
                     from modelscope import HubApi, model_file_download
 
                     hf_api = HubApi()
@@ -1443,8 +1447,7 @@ def compute_mla_mscale_scaling(rope_scaling: dict, base_scaling: float) -> float
     mscale_all_dim = rope_scaling.get("mscale_all_dim", False)
     if "factor" not in rope_scaling:
         logger.warning(
-            "rope_scaling missing 'factor', defaulting to 1.0. "
-            "Check model accuracy.",
+            "rope_scaling missing 'factor', defaulting to 1.0. Check model accuracy.",
         )
     scaling_factor = rope_scaling.get("factor", 1.0)
     mscale = yarn_get_mscale(scaling_factor, float(mscale_all_dim))

--- a/python/sglang/srt/layers/attention/vision.py
+++ b/python/sglang/srt/layers/attention/vision.py
@@ -758,6 +758,7 @@ class VisionAttention(nn.Module):
         prefix: str = "",
         proj_bias: bool = True,
         num_dummy_heads: int = 0,
+        num_kv_heads: Optional[int] = None,
         qkv_bias: bool = True,
         qk_normalization: bool = False,
         qk_normalization_by_head_size: bool = False,
@@ -779,11 +780,16 @@ class VisionAttention(nn.Module):
         self.hidden_size_per_attention_head = dist_utils.divide(
             projection_size, num_heads
         )
+        # Default to MHA (num_kv_heads == num_heads) when not specified, so
+        # existing callers are unaffected. Pass num_kv_heads explicitly to
+        # enable grouped-query attention (GQA).
+        if num_kv_heads is None:
+            num_kv_heads = num_heads
         self.num_attention_heads_per_partition = dist_utils.divide(
             num_dummy_heads + num_heads, self.tp_size
         )
         self.num_attention_kv_heads_per_partition = dist_utils.divide(
-            num_dummy_heads + num_heads, self.tp_size
+            num_dummy_heads + num_kv_heads, self.tp_size
         )
 
         self.q_size = self.num_attention_heads_per_partition * self.head_size
@@ -837,7 +843,7 @@ class VisionAttention(nn.Module):
                 hidden_size=embed_dim,
                 head_size=self.head_size,
                 total_num_heads=num_dummy_heads + num_heads,
-                total_num_kv_heads=num_dummy_heads + num_heads,
+                total_num_kv_heads=num_dummy_heads + num_kv_heads,
                 bias=qkv_bias,
                 quant_config=quant_config,
                 tp_rank=self.tp_rank,
@@ -1069,19 +1075,20 @@ class VisionAttention(nn.Module):
             sin = rotary_pos_emb_sin
 
         if cos is not None and sin is not None:
-            original_shape = q.shape
+            original_q_shape = q.shape
+            original_k_shape = k.shape
 
-            # [total_tokens, head, head_size]
+            # [total_tokens, head, head_size] / [total_tokens, kv_head, head_size]
             q = q.view(-1, head, self.head_size)
-            k = k.view(-1, head, self.head_size)
+            k = k.view(-1, kv_head, self.head_size)
 
             if cos.size(-1) * 2 == self.head_size:
                 cos = torch.cat([cos, cos], dim=-1)
                 sin = torch.cat([sin, sin], dim=-1)
 
             q, k = apply_rotary_pos_emb(q, k, cos, sin)
-            q = q.view(original_shape)
-            k = k.view(original_shape)
+            q = q.view(original_q_shape)
+            k = k.view(original_k_shape)
 
         if q.dim() == 4:
             # [b, s, head, head_size] --> [b * s, head, head_size]

--- a/python/sglang/srt/models/exaone4_5.py
+++ b/python/sglang/srt/models/exaone4_5.py
@@ -30,13 +30,11 @@ from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import (
     ColumnParallelLinear,
     MergedColumnParallelLinear,
-    QKVParallelLinear,
     RowParallelLinear,
 )
 from sglang.srt.layers.logits_processor import LogitsProcessor, LogitsProcessorOutput
 from sglang.srt.layers.pooler import Pooler, PoolingType
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
-from sglang.srt.layers.rotary_embedding import apply_rotary_pos_emb
 from sglang.srt.managers.mm_utils import (
     MultiModalityDataPaddingPatternMultimodalTokens,
     general_mm_embed_routine,
@@ -94,17 +92,6 @@ class Exaone45VisionMLP(nn.Module):
         return x
 
 
-def _gqa_rope_applier(q, k, position_embeddings, x_shape):
-    """Apply rotary position embeddings for GQA where Q and K have different head counts."""
-    cos, sin = position_embeddings
-    if cos.size(-1) * 2 == q.shape[-1]:
-        cos = torch.cat([cos, cos], dim=-1)
-        sin = torch.cat([sin, sin], dim=-1)
-    q = apply_rotary_pos_emb(q, q, cos, sin)[0]
-    k = apply_rotary_pos_emb(k, k, cos, sin)[0]
-    return q, k
-
-
 class Exaone45VisionBlock(nn.Module):
     """Transformer block for EXAONE-4.5 vision encoder."""
 
@@ -122,62 +109,22 @@ class Exaone45VisionBlock(nn.Module):
         self.norm1 = RMSNorm(dim, eps=norm_eps)
         self.norm2 = RMSNorm(dim, eps=norm_eps)
 
-        # Use customized_position_embedding_applier for GQA compatibility
-        # VisionAttention's default RoPE path assumes Q and K have same head count
-        use_gqa = num_kv_heads != num_heads
-        rope_applier = _gqa_rope_applier if use_gqa else None
-
         self.attn = VisionAttention(
             embed_dim=dim,
             num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
             projection_size=dim,
             use_qkv_parallel=True,
             flatten_batch=True,
             quant_config=quant_config,
             prefix=add_prefix("attn", prefix),
-            customized_position_embedding_applier=rope_applier,
         )
-        if use_gqa:
-            self._setup_gqa(dim, num_heads, num_kv_heads, quant_config, prefix)
 
         self.mlp = Exaone45VisionMLP(
             dim,
             intermediate_size,
             quant_config=quant_config,
             prefix=add_prefix("mlp", prefix),
-        )
-
-    def _setup_gqa(
-        self,
-        dim: int,
-        num_heads: int,
-        num_kv_heads: int,
-        quant_config: Optional[QuantizationConfig],
-        prefix: str,
-    ):
-        """Replace the QKV projection with one that supports GQA."""
-        head_size = dim // num_heads
-        tp_size = self.attn.tp_size
-        tp_rank = self.attn.tp_rank
-
-        self.attn.num_attention_kv_heads_per_partition = max(1, num_kv_heads // tp_size)
-        self.attn.kv_size = self.attn.num_attention_kv_heads_per_partition * head_size
-
-        self.attn.qkv_proj = QKVParallelLinear(
-            hidden_size=dim,
-            head_size=head_size,
-            total_num_heads=num_heads,
-            total_num_kv_heads=num_kv_heads,
-            bias=True,
-            quant_config=quant_config,
-            tp_rank=tp_rank,
-            tp_size=tp_size,
-            prefix=add_prefix("attn.qkv_proj", prefix),
-        )
-
-        # Update the backend's kv head count
-        self.attn.qkv_backend.num_kv_heads = (
-            self.attn.num_attention_kv_heads_per_partition
         )
 
     def forward(

--- a/python/sglang/srt/models/exaone4_5.py
+++ b/python/sglang/srt/models/exaone4_5.py
@@ -21,6 +21,8 @@ from typing import Iterable, List, Optional, Tuple
 import torch
 import torch.nn as nn
 from einops import rearrange
+from transformers import PretrainedConfig
+
 from sglang.srt.layers.activation import SiluAndMul
 from sglang.srt.layers.attention.vision import VisionAttention
 from sglang.srt.layers.conv import Conv3dLayer
@@ -49,7 +51,6 @@ from sglang.srt.models.exaone4 import (
 from sglang.srt.models.utils import WeightsMapper, compute_cu_seqlens_from_grid_numpy
 from sglang.srt.utils import add_prefix, is_npu
 from sglang.srt.utils.hf_transformers_utils import get_processor
-from transformers import PretrainedConfig
 
 logger = logging.getLogger(__name__)
 
@@ -286,20 +287,10 @@ class Exaone45VisionRotaryEmbedding(nn.Module):
         if seqlen > self._seq_len_cached:
             seqlen *= 2
             self._seq_len_cached = seqlen
-            self.inv_freq = 1.0 / (
-                self.theta
-                ** (
-                    torch.arange(
-                        0, self.dim, 2, dtype=torch.float, device=self.inv_freq.device
-                    )
-                    / self.dim
-                )
-            )
             seq = torch.arange(
                 seqlen, device=self.inv_freq.device, dtype=self.inv_freq.dtype
             )
-            freqs = torch.outer(seq, self.inv_freq)
-            self._freqs_cached = freqs
+            self._freqs_cached = torch.outer(seq, self.inv_freq)
 
     def forward(self, seqlen: int) -> torch.Tensor:
         self.update_freqs_cache(seqlen)
@@ -521,12 +512,18 @@ class Exaone4_5_ForConditionalGeneration(nn.Module):
         model = self.language_model.model
 
         # Exaone4Model.get_input_embeddings(input_ids) takes an arg,
-        # but general_mm_embed_routine expects get_input_embeddings() -> nn.Embedding
+        # but general_mm_embed_routine expects get_input_embeddings() -> nn.Embedding.
+        # Support both signatures to avoid breaking internal calls.
         if not hasattr(self, "_lm_wrapper"):
-            wrapper = model
-            original_get_embed = model.get_input_embeddings
-            wrapper.get_input_embeddings = lambda: model.embed_tokens
-            self._lm_wrapper = wrapper
+            original_fn = model.get_input_embeddings
+
+            def flexible_get_input_embeddings(*args, **kwargs):
+                if args or kwargs:
+                    return original_fn(*args, **kwargs)
+                return model.embed_tokens
+
+            model.get_input_embeddings = flexible_get_input_embeddings
+            self._lm_wrapper = model
         return self._lm_wrapper
 
     def forward(

--- a/python/sglang/srt/models/exaone4_5.py
+++ b/python/sglang/srt/models/exaone4_5.py
@@ -1,0 +1,644 @@
+# Copyright 2025 The LG AI Research Team
+# Copyright 2023-2025 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Inference-only EXAONE-4.5 vision-language model."""
+
+import logging
+from functools import lru_cache
+from typing import Iterable, List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+from einops import rearrange
+from sglang.srt.layers.activation import SiluAndMul
+from sglang.srt.layers.attention.vision import VisionAttention
+from sglang.srt.layers.conv import Conv3dLayer
+from sglang.srt.layers.layernorm import RMSNorm
+from sglang.srt.layers.linear import (
+    ColumnParallelLinear,
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+    RowParallelLinear,
+)
+from sglang.srt.layers.logits_processor import LogitsProcessor, LogitsProcessorOutput
+from sglang.srt.layers.pooler import Pooler, PoolingType
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.rotary_embedding import apply_rotary_pos_emb
+from sglang.srt.managers.mm_utils import (
+    MultiModalityDataPaddingPatternMultimodalTokens,
+    general_mm_embed_routine,
+)
+from sglang.srt.managers.schedule_batch import MultimodalDataItem, MultimodalInputs
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_loader.weight_utils import default_weight_loader
+from sglang.srt.models.exaone4 import (
+    Exaone4ForCausalLM,
+    get_attention_sliding_window_size,
+)
+from sglang.srt.models.utils import WeightsMapper, compute_cu_seqlens_from_grid_numpy
+from sglang.srt.utils import add_prefix, is_npu
+from sglang.srt.utils.hf_transformers_utils import get_processor
+from transformers import PretrainedConfig
+
+logger = logging.getLogger(__name__)
+
+cached_get_processor = lru_cache(get_processor)
+
+
+# === Vision Encoder === #
+
+
+class Exaone45VisionMLP(nn.Module):
+    """Gated SiLU MLP for EXAONE-4.5 vision encoder."""
+
+    def __init__(
+        self,
+        in_features: int,
+        intermediate_size: int,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ):
+        super().__init__()
+        self.gate_up_proj = MergedColumnParallelLinear(
+            in_features,
+            [intermediate_size] * 2,
+            bias=True,
+            quant_config=quant_config,
+            prefix=add_prefix("gate_up_proj", prefix),
+        )
+        self.down_proj = RowParallelLinear(
+            intermediate_size,
+            in_features,
+            bias=True,
+            quant_config=quant_config,
+            prefix=add_prefix("down_proj", prefix),
+        )
+        self.act_fn = SiluAndMul()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        gate_up, _ = self.gate_up_proj(x)
+        x = self.act_fn(gate_up)
+        x, _ = self.down_proj(x)
+        return x
+
+
+def _gqa_rope_applier(q, k, position_embeddings, x_shape):
+    """Apply rotary position embeddings for GQA where Q and K have different head counts."""
+    cos, sin = position_embeddings
+    if cos.size(-1) * 2 == q.shape[-1]:
+        cos = torch.cat([cos, cos], dim=-1)
+        sin = torch.cat([sin, sin], dim=-1)
+    q = apply_rotary_pos_emb(q, q, cos, sin)[0]
+    k = apply_rotary_pos_emb(k, k, cos, sin)[0]
+    return q, k
+
+
+class Exaone45VisionBlock(nn.Module):
+    """Transformer block for EXAONE-4.5 vision encoder."""
+
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        intermediate_size: int,
+        norm_eps: float = 1e-6,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.norm1 = RMSNorm(dim, eps=norm_eps)
+        self.norm2 = RMSNorm(dim, eps=norm_eps)
+
+        # Use customized_position_embedding_applier for GQA compatibility
+        # VisionAttention's default RoPE path assumes Q and K have same head count
+        use_gqa = num_kv_heads != num_heads
+        rope_applier = _gqa_rope_applier if use_gqa else None
+
+        self.attn = VisionAttention(
+            embed_dim=dim,
+            num_heads=num_heads,
+            projection_size=dim,
+            use_qkv_parallel=True,
+            flatten_batch=True,
+            quant_config=quant_config,
+            prefix=add_prefix("attn", prefix),
+            customized_position_embedding_applier=rope_applier,
+        )
+        if use_gqa:
+            self._setup_gqa(dim, num_heads, num_kv_heads, quant_config, prefix)
+
+        self.mlp = Exaone45VisionMLP(
+            dim,
+            intermediate_size,
+            quant_config=quant_config,
+            prefix=add_prefix("mlp", prefix),
+        )
+
+    def _setup_gqa(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        quant_config: Optional[QuantizationConfig],
+        prefix: str,
+    ):
+        """Replace the QKV projection with one that supports GQA."""
+        head_size = dim // num_heads
+        tp_size = self.attn.tp_size
+        tp_rank = self.attn.tp_rank
+
+        self.attn.num_attention_kv_heads_per_partition = max(1, num_kv_heads // tp_size)
+        self.attn.kv_size = self.attn.num_attention_kv_heads_per_partition * head_size
+
+        self.attn.qkv_proj = QKVParallelLinear(
+            hidden_size=dim,
+            head_size=head_size,
+            total_num_heads=num_heads,
+            total_num_kv_heads=num_kv_heads,
+            bias=True,
+            quant_config=quant_config,
+            tp_rank=tp_rank,
+            tp_size=tp_size,
+            prefix=add_prefix("attn.qkv_proj", prefix),
+        )
+
+        # Update the backend's kv head count
+        self.attn.qkv_backend.num_kv_heads = (
+            self.attn.num_attention_kv_heads_per_partition
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        position_embeddings: torch.Tensor,
+    ) -> torch.Tensor:
+        hidden_states = self.norm1(x)
+        hidden_states = rearrange(hidden_states, "s b ... -> b s ...")
+        attn = self.attn(
+            hidden_states,
+            cu_seqlens=cu_seqlens,
+            position_embeddings=position_embeddings,
+        )
+        attn = rearrange(attn, "b s ... -> s b ...")
+        x = x + attn
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+
+class Exaone45VisionPatchEmbed(nn.Module):
+    """3D patch embedding for EXAONE-4.5 vision encoder."""
+
+    def __init__(
+        self,
+        patch_size: int = 14,
+        temporal_patch_size: int = 2,
+        in_chans: int = 3,
+        embed_dim: int = 2048,
+    ) -> None:
+        super().__init__()
+        self.patch_size = patch_size
+        self.temporal_patch_size = temporal_patch_size
+        self.embed_dim = embed_dim
+
+        kernel_size = [temporal_patch_size, patch_size, patch_size]
+        self.proj = Conv3dLayer(
+            in_chans, embed_dim, kernel_size=kernel_size, stride=kernel_size, bias=False
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        L, C = x.shape
+        x = x.view(L, -1, self.temporal_patch_size, self.patch_size, self.patch_size)
+        x = self.proj(x).view(L, self.embed_dim)
+        return x
+
+
+class Exaone45VisionPatchMerger(nn.Module):
+    """Spatial patch merger for EXAONE-4.5 vision encoder."""
+
+    def __init__(
+        self,
+        d_model: int,
+        context_dim: int,
+        spatial_merge_size: int = 2,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.hidden_size = context_dim * (spatial_merge_size**2)
+        self.ln_q = RMSNorm(context_dim, eps=1e-6)
+        self.mlp = nn.ModuleList(
+            [
+                ColumnParallelLinear(
+                    self.hidden_size,
+                    self.hidden_size,
+                    bias=True,
+                    quant_config=quant_config,
+                    prefix=add_prefix("mlp.0", prefix),
+                ),
+                nn.GELU(),
+                RowParallelLinear(
+                    self.hidden_size,
+                    d_model,
+                    bias=True,
+                    quant_config=quant_config,
+                    prefix=add_prefix("mlp.2", prefix),
+                ),
+            ]
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.ln_q(x)
+        x = x.view(-1, self.hidden_size)
+
+        mlp_fc1, mlp_act, mlp_fc2 = self.mlp
+        x_parallel, _ = mlp_fc1(x)
+        x_parallel = mlp_act(x_parallel)
+        out, _ = mlp_fc2(x_parallel)
+        return out
+
+
+class Exaone45VisionRotaryEmbedding(nn.Module):
+    """2D rotary position embedding for EXAONE-4.5 vision encoder."""
+
+    def __init__(self, dim: int, theta: float = 10000.0) -> None:
+        super().__init__()
+        self.dim = dim
+        self.theta = theta
+        inv_freq = 1.0 / (theta ** (torch.arange(0, dim, 2, dtype=torch.float) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._freqs_cached = None
+
+    def update_freqs_cache(self, seqlen: int) -> None:
+        if seqlen > self._seq_len_cached:
+            seqlen *= 2
+            self._seq_len_cached = seqlen
+            self.inv_freq = 1.0 / (
+                self.theta
+                ** (
+                    torch.arange(
+                        0, self.dim, 2, dtype=torch.float, device=self.inv_freq.device
+                    )
+                    / self.dim
+                )
+            )
+            seq = torch.arange(
+                seqlen, device=self.inv_freq.device, dtype=self.inv_freq.dtype
+            )
+            freqs = torch.outer(seq, self.inv_freq)
+            self._freqs_cached = freqs
+
+    def forward(self, seqlen: int) -> torch.Tensor:
+        self.update_freqs_cache(seqlen)
+        return self._freqs_cached[:seqlen]
+
+
+class Exaone45VisionTransformer(nn.Module):
+    """EXAONE-4.5 vision encoder transformer."""
+
+    def __init__(
+        self,
+        vision_config,
+        norm_eps: float = 1e-6,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+
+        self.spatial_merge_size = vision_config.spatial_merge_size
+
+        self.patch_embed = Exaone45VisionPatchEmbed(
+            patch_size=vision_config.patch_size,
+            temporal_patch_size=vision_config.temporal_patch_size,
+            in_chans=vision_config.in_channels,
+            embed_dim=vision_config.hidden_size,
+        )
+
+        head_dim = vision_config.hidden_size // vision_config.num_heads
+        self.rotary_pos_emb = Exaone45VisionRotaryEmbedding(head_dim // 2)
+
+        num_kv_heads = getattr(
+            vision_config, "num_key_value_heads", vision_config.num_heads
+        )
+        self.blocks = nn.ModuleList(
+            [
+                Exaone45VisionBlock(
+                    dim=vision_config.hidden_size,
+                    num_heads=vision_config.num_heads,
+                    num_kv_heads=num_kv_heads,
+                    intermediate_size=vision_config.intermediate_size,
+                    norm_eps=norm_eps,
+                    quant_config=quant_config,
+                    prefix=add_prefix(f"blocks.{i}", prefix),
+                )
+                for i in range(vision_config.depth)
+            ]
+        )
+        self.merger = Exaone45VisionPatchMerger(
+            d_model=vision_config.out_hidden_size,
+            context_dim=vision_config.hidden_size,
+            spatial_merge_size=vision_config.spatial_merge_size,
+            quant_config=quant_config,
+            prefix=add_prefix("merger", prefix),
+        )
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self.patch_embed.proj.weight.dtype
+
+    @property
+    def device(self) -> torch.device:
+        return self.blocks[0].mlp.down_proj.weight.device
+
+    def rot_pos_emb(self, grid_thw: torch.Tensor) -> torch.Tensor:
+        pos_ids = []
+        for i in range(grid_thw.size(0)):
+            t, h, w = grid_thw[i].tolist()
+            hpos_ids = torch.arange(h).unsqueeze(1).expand(-1, w)
+            wpos_ids = torch.arange(w).unsqueeze(0).expand(h, -1)
+            hpos_ids = (
+                hpos_ids.reshape(
+                    h // self.spatial_merge_size,
+                    self.spatial_merge_size,
+                    w // self.spatial_merge_size,
+                    self.spatial_merge_size,
+                )
+                .permute(0, 2, 1, 3)
+                .flatten()
+            )
+            wpos_ids = (
+                wpos_ids.reshape(
+                    h // self.spatial_merge_size,
+                    self.spatial_merge_size,
+                    w // self.spatial_merge_size,
+                    self.spatial_merge_size,
+                )
+                .permute(0, 2, 1, 3)
+                .flatten()
+            )
+            pos_ids.append(torch.stack([hpos_ids, wpos_ids], dim=-1).repeat(t, 1))
+        pos_ids = torch.cat(pos_ids, dim=0)
+        max_grid_size = grid_thw[:, 1:].max()
+        rotary_pos_emb_full = self.rotary_pos_emb(max_grid_size)
+        rotary_pos_emb = rotary_pos_emb_full[pos_ids].flatten(1)
+        return rotary_pos_emb
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        grid_thw: torch.Tensor,
+    ) -> torch.Tensor:
+        # patchify
+        x = x.to(device=self.device, dtype=self.dtype)
+        x = self.patch_embed(x)
+
+        # compute position embedding
+        rotary_pos_emb = self.rot_pos_emb(grid_thw)
+        emb = torch.cat((rotary_pos_emb, rotary_pos_emb), dim=-1)
+        position_embeddings = (emb.cos(), emb.sin())
+
+        # compute cu_seqlens
+        cu_seqlens = compute_cu_seqlens_from_grid_numpy(grid_thw)
+        if is_npu():
+            cu_seqlens = cu_seqlens.to("cpu")
+
+        # transformer blocks
+        x = x.unsqueeze(1)
+        for blk in self.blocks:
+            x = blk(x, cu_seqlens=cu_seqlens, position_embeddings=position_embeddings)
+
+        # merge spatial patches
+        x = self.merger(x)
+        return x
+
+
+# === VLM Wrapper === #
+
+
+class Exaone4_5_ForConditionalGeneration(nn.Module):
+    # BitandBytes specific attributes
+    default_bitsandbytes_target_modules = [
+        ".gate_proj.",
+        ".down_proj.",
+        ".up_proj.",
+        ".q_proj.",
+        ".k_proj.",
+        ".v_proj.",
+        ".o_proj.",
+    ]
+    bitsandbytes_stacked_params_mapping = {
+        "q_proj": ("qkv_proj", 0),
+        "k_proj": ("qkv_proj", 1),
+        "v_proj": ("qkv_proj", 2),
+        "gate_proj": ("gate_up_proj", 0),
+        "up_proj": ("gate_up_proj", 1),
+    }
+
+    # To ensure correct weight loading and mapping.
+    hf_to_sglang_mapper = WeightsMapper(
+        orig_to_new_substr={
+            "attn.qkv": "attn.qkv_proj",
+        },
+        orig_to_new_prefix={
+            "model.language_model.": "language_model.model.",
+            "model.visual.": "visual.",
+            "lm_head.": "language_model.lm_head.",
+        },
+    )
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = config
+
+        vision_config = config.vision_config
+        text_config = config.text_config
+
+        self.visual = Exaone45VisionTransformer(
+            vision_config,
+            norm_eps=getattr(text_config, "rms_norm_eps", 1e-6),
+            quant_config=quant_config,
+            prefix=add_prefix("visual", prefix),
+        )
+
+        self.language_model = Exaone4ForCausalLM(
+            text_config,
+            quant_config=quant_config,
+            prefix=add_prefix("language_model", prefix),
+        )
+
+        self.logits_processor = LogitsProcessor(text_config)
+        self.pooler = Pooler(pooling_type=PoolingType.LAST, normalize=True)
+
+    def pad_input_ids(self, input_ids: List[int], mm_inputs: MultimodalInputs):
+        pattern = MultiModalityDataPaddingPatternMultimodalTokens()
+        return pattern.pad_input_tokens(input_ids, mm_inputs)
+
+    def get_image_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
+        pixel_values = torch.cat([item.feature for item in items], dim=0).type(
+            self.visual.dtype
+        )
+        image_grid_thw = torch.concat([item.image_grid_thw for item in items], dim=0)
+        assert pixel_values.dim() == 2, pixel_values.dim()
+        assert image_grid_thw.dim() == 2, image_grid_thw.dim()
+        image_embeds = self.visual(pixel_values, grid_thw=image_grid_thw)
+        return image_embeds
+
+    def get_video_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
+        pixel_values = torch.cat([item.feature for item in items], dim=0).type(
+            self.visual.dtype
+        )
+        video_grid_thw = torch.concat([item.video_grid_thw for item in items], dim=0)
+        assert pixel_values.dim() == 2, pixel_values.dim()
+        assert video_grid_thw.dim() == 2, video_grid_thw.dim()
+        video_embeds = self.visual(pixel_values, grid_thw=video_grid_thw)
+        return video_embeds
+
+    def get_input_embeddings(self):
+        return self.language_model.model.embed_tokens
+
+    def _init_language_model_wrapper(self):
+        """Create a wrapper around Exaone4Model that is compatible with
+        general_mm_embed_routine (needs get_input_embeddings() -> nn.Embedding
+        and forward() -> hidden_states)."""
+        model = self.language_model.model
+
+        # Exaone4Model.get_input_embeddings(input_ids) takes an arg,
+        # but general_mm_embed_routine expects get_input_embeddings() -> nn.Embedding
+        if not hasattr(self, "_lm_wrapper"):
+            wrapper = model
+            original_get_embed = model.get_input_embeddings
+            wrapper.get_input_embeddings = lambda: model.embed_tokens
+            self._lm_wrapper = wrapper
+        return self._lm_wrapper
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds=None,
+        get_embedding: bool = False,
+    ) -> LogitsProcessorOutput:
+        lm_wrapper = self._init_language_model_wrapper()
+
+        hidden_states = general_mm_embed_routine(
+            input_ids=input_ids,
+            forward_batch=forward_batch,
+            language_model=lm_wrapper,
+            multimodal_model=self,
+            positions=positions,
+        )
+
+        if get_embedding:
+            return self.pooler(hidden_states, forward_batch)
+        else:
+            return self.logits_processor(
+                input_ids,
+                hidden_states,
+                self.language_model.lm_head,
+                forward_batch,
+            )
+
+    def get_attention_sliding_window_size(self):
+        return get_attention_sliding_window_size(self.config.text_config)
+
+    def _remap_weight_name(self, name: str) -> str:
+        """Remap HF weight names to SGLang parameter names."""
+        # Apply prefix remapping (longest prefix first)
+        prefix_map = [
+            ("model.language_model.", "language_model.model."),
+            ("model.visual.", "visual."),
+            ("lm_head.", "language_model.lm_head."),
+        ]
+        for old_prefix, new_prefix in prefix_map:
+            if name.startswith(old_prefix):
+                name = new_prefix + name[len(old_prefix) :]
+                break
+
+        # Vision attention QKV naming
+        if "visual" in name:
+            name = name.replace("attn.qkv.", "attn.qkv_proj.")
+
+        return name
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+
+        params_dict = dict(self.named_parameters(remove_duplicate=False))
+
+        for name, loaded_weight in weights:
+            # Skip MTP weights — loaded by exaone4_5_mtp.py
+            if name.startswith("mtp."):
+                continue
+            if "rotary_emb.inv_freq" in name:
+                continue
+            if self.config.text_config.tie_word_embeddings and "lm_head.weight" in name:
+                continue
+
+            # Remap HF weight names to SGLang parameter names
+            name = self._remap_weight_name(name)
+
+            # Vision QKV weights are already fused — skip stacked mapping
+            # to avoid false matches (e.g., "v_proj" matching inside "qkv_proj")
+            is_vision_qkv = "visual" in name and "qkv_proj" in name
+
+            if not is_vision_qkv:
+                for param_name, weight_name, shard_id in stacked_params_mapping:
+                    if weight_name not in name:
+                        continue
+                    name = name.replace(weight_name, param_name)
+
+                    if name.endswith(".bias") and name not in params_dict:
+                        break
+                    if name not in params_dict:
+                        break
+                    param = params_dict[name]
+                    weight_loader = param.weight_loader
+                    weight_loader(param, loaded_weight, shard_id)
+                    break
+                else:
+                    # No stacked match — load directly
+                    if name.endswith(".bias") and name not in params_dict:
+                        continue
+                    if name not in params_dict:
+                        continue
+                    param = params_dict[name]
+                    weight_loader = getattr(
+                        param, "weight_loader", default_weight_loader
+                    )
+                    weight_loader(param, loaded_weight)
+            else:
+                # Load vision QKV directly (already fused)
+                if name not in params_dict:
+                    continue
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+
+
+EntryClass = Exaone4_5_ForConditionalGeneration

--- a/python/sglang/srt/models/exaone4_5.py
+++ b/python/sglang/srt/models/exaone4_5.py
@@ -425,6 +425,12 @@ class Exaone4_5_ForConditionalGeneration(nn.Module):
         self.logits_processor = LogitsProcessor(text_config)
         self.pooler = Pooler(pooling_type=PoolingType.LAST, normalize=True)
 
+    def get_embed_and_head(self):
+        return self.language_model.get_embed_and_head()
+
+    def set_embed_and_head(self, embed, head):
+        return self.language_model.set_embed_and_head(embed, head)
+
     def pad_input_ids(self, input_ids: List[int], mm_inputs: MultimodalInputs):
         pattern = MultiModalityDataPaddingPatternMultimodalTokens()
         return pattern.pad_input_tokens(input_ids, mm_inputs)

--- a/python/sglang/srt/models/exaone4_5_mtp.py
+++ b/python/sglang/srt/models/exaone4_5_mtp.py
@@ -45,6 +45,13 @@ class Exaone4_5_MTP(Exaone4ForCausalLM):
     ) -> None:
         nn.Module.__init__(self)
         config = copy.deepcopy(config)
+        # EXAONE-4.5 exposes a multimodal wrapper config
+        # (Exaone4_5_Config with text_config / vision_config). For the MTP
+        # draft, only the text tower is needed, so unwrap to the inner
+        # text config when present — same pattern as qwen3_5_mtp.py.
+        self.is_multimodal = hasattr(config, "text_config")
+        if self.is_multimodal:
+            config = config.text_config
         self.config = config
         config.num_hidden_layers = 1
         self.tp_size = get_tensor_model_parallel_world_size()
@@ -77,6 +84,24 @@ class Exaone4_5_MTP(Exaone4ForCausalLM):
         input_embeds: Optional[torch.Tensor] = None,
         **kwargs,
     ):
+        # For VLM + MTP speculative decoding: pre-computed multimodal
+        # embeddings are forwarded from the target model via
+        # `forward_batch.mm_input_embeds`. Calling `embed_tokens(input_ids)`
+        # directly on multimodal pad tokens would produce incorrect
+        # embeddings (or IndexError when image/video pad ids are OOV),
+        # matching the pattern used by `qwen3_5_mtp.py`.
+        assert input_embeds is None
+        input_embeds = forward_batch.mm_input_embeds
+        if (
+            forward_batch.forward_mode.is_extend()
+            and forward_batch.contains_mm_inputs()
+            and not forward_batch.forward_mode.is_draft_extend(include_v2=True)
+        ):
+            assert input_embeds is not None
+            input_embeds = torch.cat(
+                [input_embeds[:-1], self.model.embed_tokens(input_ids[-1].unsqueeze(0))]
+            )
+
         if input_embeds is None:
             input_embeds = self.model.embed_tokens(input_ids)
 

--- a/python/sglang/srt/models/exaone4_5_mtp.py
+++ b/python/sglang/srt/models/exaone4_5_mtp.py
@@ -1,0 +1,149 @@
+# Copyright 2025 The LG AI Research Team
+# Copyright 2023-2025 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Inference-only EXAONE-4.5 MTP Speculative Decoding."""
+
+import logging
+from typing import Iterable, Optional, Tuple
+
+import torch
+from sglang.srt.distributed import get_pp_group, get_tensor_model_parallel_world_size
+from sglang.srt.layers.layernorm import RMSNorm
+from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_loader.weight_utils import default_weight_loader
+from sglang.srt.models.exaone4 import Exaone4ForCausalLM, Exaone4Model
+from sglang.srt.server_args import get_global_server_args
+from sglang.srt.utils import add_prefix
+from torch import nn
+from transformers import PretrainedConfig
+
+logger = logging.getLogger(__name__)
+
+
+class Exaone4_5_MTP(Exaone4ForCausalLM):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        nn.Module.__init__(self)
+        self.config = config
+        config.num_hidden_layers = 1
+        self.tp_size = get_tensor_model_parallel_world_size()
+        self.quant_config = quant_config
+        self.pp_group = get_pp_group()
+
+        self.fc = nn.Linear(2 * config.hidden_size, config.hidden_size, bias=False)
+        self.pre_fc_norm_embedding = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+        self.pre_fc_norm_hidden = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.model = Exaone4Model(
+            config, quant_config, prefix=add_prefix("model", prefix)
+        )
+        self.lm_head = ParallelLMHead(
+            config.vocab_size,
+            config.hidden_size,
+            quant_config=quant_config,
+            prefix=add_prefix("lm_head", prefix),
+            use_attn_tp_group=get_global_server_args().enable_dp_lm_head,
+        )
+        self.logits_processor = LogitsProcessor(config)
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: Optional[torch.Tensor] = None,
+        **kwargs,
+    ):
+        if input_embeds is None:
+            input_embeds = self.model.embed_tokens(input_ids)
+
+        hidden_states = forward_batch.spec_info.hidden_states
+
+        if not forward_batch.forward_mode.is_idle():
+            input_embeds = self.pre_fc_norm_embedding(input_embeds)
+            hidden_states = self.pre_fc_norm_hidden(hidden_states)
+        hidden_states = self.fc(torch.cat((input_embeds, hidden_states), dim=-1))
+
+        hidden_states = self.model(
+            input_ids,
+            positions,
+            forward_batch,
+            hidden_states,
+        )
+
+        return self.logits_processor(
+            input_ids, hidden_states, self.lm_head, forward_batch
+        )
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        stacked_params_mapping = [
+            (".qkv_proj", ".q_proj", "q"),
+            (".qkv_proj", ".k_proj", "k"),
+            (".qkv_proj", ".v_proj", "v"),
+            (".gate_up_proj", ".gate_proj", 0),
+            (".gate_up_proj", ".up_proj", 1),
+        ]
+
+        params_dict = dict(self.named_parameters())
+
+        for name, loaded_weight in weights:
+            # Only load MTP weights
+            if "mtp" not in name:
+                continue
+
+            # Remap mtp.* prefixes to match our parameter names
+            if name in [
+                "mtp.fc.weight",
+                "mtp.pre_fc_norm_embedding.weight",
+                "mtp.pre_fc_norm_hidden.weight",
+            ]:
+                name = name.replace("mtp.", "")
+            else:
+                name = name.replace("mtp", "model")
+
+            if "rotary_emb.inv_freq" in name:
+                continue
+
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                name = name.replace(weight_name, param_name)
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+                if name not in params_dict:
+                    continue
+                param = params_dict[name]
+                weight_loader = param.weight_loader
+                weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+                if name not in params_dict:
+                    continue
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+
+
+EntryClass = Exaone4_5_MTP

--- a/python/sglang/srt/models/exaone4_5_mtp.py
+++ b/python/sglang/srt/models/exaone4_5_mtp.py
@@ -14,10 +14,14 @@
 # ==============================================================================
 """Inference-only EXAONE-4.5 MTP Speculative Decoding."""
 
+import copy
 import logging
 from typing import Iterable, Optional, Tuple
 
 import torch
+from torch import nn
+from transformers import PretrainedConfig
+
 from sglang.srt.distributed import get_pp_group, get_tensor_model_parallel_world_size
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.logits_processor import LogitsProcessor
@@ -28,8 +32,6 @@ from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.exaone4 import Exaone4ForCausalLM, Exaone4Model
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import add_prefix
-from torch import nn
-from transformers import PretrainedConfig
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +44,7 @@ class Exaone4_5_MTP(Exaone4ForCausalLM):
         prefix: str = "",
     ) -> None:
         nn.Module.__init__(self)
+        config = copy.deepcopy(config)
         self.config = config
         config.num_hidden_layers = 1
         self.tp_size = get_tensor_model_parallel_world_size()

--- a/python/sglang/srt/multimodal/processors/exaone.py
+++ b/python/sglang/srt/multimodal/processors/exaone.py
@@ -1,0 +1,52 @@
+from typing import List, Union
+
+from sglang.srt.managers.schedule_batch import MultimodalProcessorOutput
+from sglang.srt.models.exaone4_5 import Exaone4_5_ForConditionalGeneration
+from sglang.srt.multimodal.processors.base_processor import (
+    BaseMultimodalProcessor,
+    MultimodalSpecialTokens,
+)
+
+
+class Exaone45MultimodalProcessor(BaseMultimodalProcessor):
+    models = [Exaone4_5_ForConditionalGeneration]
+
+    def __init__(self, hf_config, server_args, _processor, *args, **kwargs):
+        super().__init__(hf_config, server_args, _processor, *args, **kwargs)
+        self.IM_START_TOKEN_ID = hf_config.vision_start_token_id
+        self.IM_END_TOKEN_ID = hf_config.vision_end_token_id
+        self.IM_TOKEN_ID = hf_config.image_token_id
+        self.VIDEO_TOKEN_ID = hf_config.video_token_id
+        self.mm_tokens = MultimodalSpecialTokens(
+            image_token="<vision><|image_pad|></vision>",
+            image_token_id=self.IM_TOKEN_ID,
+            video_token_id=self.VIDEO_TOKEN_ID,
+        ).build(_processor)
+
+    async def process_mm_data_async(
+        self,
+        image_data: List[Union[str, bytes]],
+        input_text,
+        request_obj,
+        *args,
+        **kwargs,
+    ):
+        base_output = self.load_mm_data(
+            prompt=input_text,
+            image_data=image_data,
+            video_data=request_obj.video_data,
+            multimodal_tokens=self.mm_tokens,
+        )
+
+        mm_items, input_ids, _ = self.process_and_combine_mm_data(
+            base_output, self.mm_tokens
+        )
+
+        return MultimodalProcessorOutput(
+            input_ids=input_ids.tolist(),
+            mm_items=mm_items,
+            im_start_id=self.IM_START_TOKEN_ID,
+            im_end_id=self.IM_END_TOKEN_ID,
+            im_token_id=self.IM_TOKEN_ID,
+            video_token_id=self.VIDEO_TOKEN_ID,
+        )


### PR DESCRIPTION
## Motivation

Add support for [EXAONE-4.5-33B](https://huggingface.co/LGAI-EXAONE/EXAONE-4.5-33B), LG AI Research's first open-weight vision-language model (33B total: 31.7B LLM + 1.29B vision encoder).

The text backbone is identical to EXAONE 4.0 (already supported), so this PR reuses `Exaone4ForCausalLM` and adds the vision encoder + multimodal integration.

Reference: [vLLM PR #39388](https://github.com/vllm-project/vllm/pull/39388)

**Note:** Requires `transformers` from [LG AI's fork](https://github.com/nuxlear/transformers/tree/add-exaone4_5) until `exaone4_5` model type is merged into upstream transformers.

## Modifications

### New files
- `python/sglang/srt/models/exaone4_5.py` — Vision encoder (28-block ViT with GQA, gated SiLU MLP, 2D RoPE, spatial patch merger) + VLM wrapper reusing `Exaone4ForCausalLM`
- `python/sglang/srt/models/exaone4_5_mtp.py` — Multi-Token Prediction draft for speculative decoding
- `python/sglang/srt/multimodal/processors/exaone.py` — Multimodal processor for image/video inputs

### Modified
- `python/sglang/srt/layers/attention/vision.py` — Add native GQA support to `VisionAttention`:
  - New optional `num_kv_heads` parameter (defaults to `num_heads`, preserving MHA behavior for all 24 existing callers)
  - Fix RoPE path to use the KV head count when reshaping `k` (previously assumed Q/K same head count)
- `python/sglang/srt/configs/model_config.py` — MTP draft model architecture mapping

### Key design decisions
- **Reuses `Exaone4ForCausalLM`** for the language model backbone; VLM wrapper encapsulates it as `self.language_model` (same pattern as `kimi_k25.py`) and delegates `get_embed_and_head` / `set_embed_and_head` to it so speculative decoding works.
- **Vision encoder uses native `VisionAttention(num_kv_heads=...)`** — replaces the earlier workarounds (`_setup_gqa` post-hoc qkv_proj override, `_gqa_rope_applier` hook). The native path is mathematically identical to the workaround (verified bit-exact, see Accuracy Tests §3).
- **MTP draft unwraps `text_config`** in `__init__` and consumes `forward_batch.mm_input_embeds` in `forward` — matches the `qwen3_5_mtp.py` pattern so the VLM + MTP speculative-decoding path embeds multimodal tokens correctly instead of calling `embed_tokens(input_ids)` on raw image/video pad tokens.
- Full attention for all vision blocks (windowed attention optimization deferred to follow-up).

## Accuracy Tests

**Setup:** 2× A100 80GB, TP=2, `seed=42 temperature=0 top_p=1 --disable-radix-cache` for determinism where noted.

### 1. Backward-compat (MHA path untouched)

Qwen2.5-VL-3B (MHA) on TP=1 renders a text response normally — verifies `num_kv_heads=None` default preserves the previous behavior for all existing `VisionAttention` callers.

### 2. Text + image on EXAONE-4.5-33B (TP=2)

Five ad-hoc queries (Korean travel, Python one-liner, work-rate math, SGLang logo, long-form HTTP explanation) all produce coherent responses. The image query processes `prompt_tokens=2229` (vision patch tokens) on TP=2 — confirming vision encoder's native GQA path (KV head=8, 4/partition) works end-to-end.

Sample — image understanding:

```json
{
  "choices": [{
    "message": {
      "content": "The user wants me to describe what I see in the image.\n\n1. **Analyze the visual content:**\n    * **Dominant Color:** The background is a bright, sky blue.\n    * **Main Shapes:** There are overlapping geometric shapes, specifically circles or semi-circles, and some rectangular blocks.\n..."
    },
    "finish_reason": "length"
  }],
  "usage": {"prompt_tokens": 149, "total_tokens": 405, "completion_tokens": 256}
}
```

### 3. Bit-exact equivalence (native GQA ≡ previous workaround)

Same prompt, same greedy seed, two boots — one on `HEAD` (native GQA), one with only the three changed files reverted to commit `3bbb55288` (workaround):

```
Prompt: "Hello, what is SGLang?"
Completion (both):
  "Okay, the user asked, \"Hello, what is SGLang?\" Let me start by recalling
   what I know about SGLang. It's a framework related to large language models,
   right? I remember it's developed by researchers from Stanford, maybe? Wait,
   no, I think it's from the Stanford NLP group, but I should double-check
   that.\n\nFirst, I need to"

both: prompt_tokens=15, completion_tokens=64, finish_reason=length
diff: (empty)
```

Character-exact 64-token match — native GQA API is mathematically identical to the `_setup_gqa` / `_gqa_rope_applier` workaround.

### 4. MTP + multimodal ⚠️ blocked by upstream

Attempts to exercise the MTP draft + multimodal path end-to-end (flashinfer ± CUDA graph, triton) all fail in upstream SGLang code paths — `update_sliding_window: prefix_lens=None` in the EAGLE + SWA branch, unrelated to files changed in this PR. Config-unwrap fix (MTP commit) is indirectly verified (draft constructs without `AttributeError: hidden_size`); the `mm_input_embeds` consumption will be re-verified once the upstream EAGLE+SWA issue is resolved.

## Speed Tests and Profiling

N/A — no changes to existing inference paths. New model addition + native GQA support refactor only.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
