### PR TITLE
disable piecewise CUDA graph for hybrid Mamba models (#21938)

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2261,9 +2261,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             elif hasattr(layer, "mixer"):
                 if hasattr(layer.mixer, "attn"):
                     attn_layer = layer.mixer.attn
-                elif hasattr(layer, "_forward_mamba"):
-                    # Mamba layer with split op support - store the layer itself
-                    attn_layer = layer
 
             if attn_layer is not None:
                 self.attention_layers.append(attn_layer)


### PR DESCRIPTION
## Summary
Stop adding Mamba layers to `attention_layers` in `init_piecewise_cuda_graphs()`, restoring the guard that disables PCG when not all layers are standard GQA. Fixes NemotronH crash during CUDA graph capture.

Closes #21938.