### PR TITLE
skip TP narrow when w2 scales already match shard size (#22421)

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -529,9 +529,10 @@ class FusedMoE(torch.nn.Module):
             if not is_bias and not self.use_presharded_weights:
                 if self.use_triton_kernels:
                     loaded_weight = loaded_weight.transpose(-2, -1)
-                loaded_weight = loaded_weight.narrow(
-                    shard_dim, shard_size * tp_rank, shard_size
-                )
+                if loaded_weight.shape[shard_dim] != shard_size:
+                    loaded_weight = loaded_weight.narrow(
+                        shard_dim, shard_size * tp_rank, shard_size
+                    )
 
         # w2, down_proj: Load into only logical weight of w2.
         expert_data.copy_(loaded_weight)


### PR DESCRIPTION
## Summary
Guard the `narrow()` call in `_load_w2()` to skip TP slicing when the loaded weight already matches the parameter shard size. Fixes `IndexError: start out of range` when loading GPTQ-Int4 MoE models with `desc_act=False` and `tp_size > 1`.

Closes #22421.