### PR TITLE
[Docker] Fix CI docker target after Dockerfile restructure

### DIFF
--- a/.github/workflows/release-docker-dev.yml
+++ b/.github/workflows/release-docker-dev.yml
@@ -96,7 +96,7 @@ jobs:
           docker buildx build \
             --platform ${{ matrix.platform }} \
             --output type=image,name=lmsysorg/sglang,push-by-digest=true,name-canonical=true,push=true \
-            --target framework \
+            --target framework_final \
             -f docker/Dockerfile \
             --build-arg CUDA_VERSION=${{ matrix.version }} \
             --build-arg BUILD_TYPE=${{ matrix.build_type }} \

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -83,7 +83,7 @@ jobs:
           version=${{ steps.version.outputs.version }}
 
           docker buildx build \
-            --target framework \
+            --target framework_final \
             --platform linux/amd64 \
             --output type=image,name=lmsysorg/sglang,push-by-digest=true,name-canonical=true,push=true \
             -f docker/Dockerfile \
@@ -106,7 +106,7 @@ jobs:
           version=${{ steps.version.outputs.version }}
 
           docker buildx build \
-            --target framework \
+            --target framework_final \
             --platform linux/amd64 \
             --output type=image,name=lmsysorg/sglang,push-by-digest=true,name-canonical=true,push=true \
             -f docker/Dockerfile \
@@ -180,7 +180,7 @@ jobs:
           version=${{ steps.version.outputs.version }}
 
           docker buildx build \
-            --target framework \
+            --target framework_final \
             --platform linux/arm64 \
             --output type=image,name=lmsysorg/sglang,push-by-digest=true,name-canonical=true,push=true \
             -f docker/Dockerfile \
@@ -203,7 +203,7 @@ jobs:
           version=${{ steps.version.outputs.version }}
 
           docker buildx build \
-            --target framework \
+            --target framework_final \
             --platform linux/arm64 \
             --output type=image,name=lmsysorg/sglang,push-by-digest=true,name-canonical=true,push=true \
             -f docker/Dockerfile \


### PR DESCRIPTION
## Summary

#22160 restructured the Dockerfile into parallel multi-stage builds, moving the source `COPY` and editable `pip install` into a new `framework_final` stage. The CI workflows still target the old `framework` stage, which no longer contains sglang source code.

**Impact**: Published dev and release framework images are missing the `sglang.srt` package entirely. `import sglang` works but `sglang serve` and all SRT functionality is broken.

**Fix**: Update `--target framework` to `--target framework_final` in:
- `release-docker.yml` (4 occurrences)
- `release-docker-dev.yml` (1 occurrence)

The `release-docker-runtime.yml` targets `runtime` which already depends on `framework_final`, so it is unaffected.

## Test plan

- [x] `grep -rn "\-\-target framework[^_]" .github/workflows/` returns no results
- [ ] Dev docker build produces image with working `sglang serve`