### PR TITLE
[Observability] Add pending token count to prefill log and get_load

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1857,6 +1857,7 @@ class GetLoadReqOutput(BaseReq):
     num_reqs: int
     num_waiting_reqs: int
     num_tokens: int
+    num_pending_tokens: int
     ts_tic: float
 
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2579,9 +2579,18 @@ class Scheduler(
 
         new_batch.prepare_for_extend()
 
-        # Record prefill stats for logging after forward
+        # Record prefill stats for logging after forward.
+        # At scheduling time prefix_indices has not yet been updated to include
+        # the current chunk, so we pass extend_input_len as chunk_deduct.
         new_batch.prefill_stats = PrefillStats.from_adder(
-            adder, self.running_batch.reqs, self.enable_priority_scheduling
+            adder,
+            self.running_batch.reqs,
+            self.enable_priority_scheduling,
+            num_pending_tokens=self._get_num_pending_tokens(
+                chunk_deduct=self.chunked_req.extend_input_len
+                if self.chunked_req is not None
+                else 0
+            ),
         )
 
         # Mixed-style chunked prefill

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2580,8 +2580,6 @@ class Scheduler(
         new_batch.prepare_for_extend()
 
         # Record prefill stats for logging after forward.
-        # At scheduling time prefix_indices has not yet been updated to include
-        # the current chunk, so we pass extend_input_len as chunk_deduct.
         new_batch.prefill_stats = PrefillStats.from_adder(
             adder,
             self.running_batch.reqs,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2585,9 +2585,11 @@ class Scheduler(
             self.running_batch.reqs,
             self.enable_priority_scheduling,
             num_pending_tokens=self._get_num_pending_tokens(
-                chunk_deduct=self.chunked_req.extend_input_len
-                if self.chunked_req is not None
-                else 0
+                chunk_deduct=(
+                    self.chunked_req.extend_input_len
+                    if self.chunked_req is not None
+                    else 0
+                )
             ),
         )
 

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -866,9 +866,7 @@ class SchedulerMetricsMixin:
                     self.stats.token_usage / 0.9,
                 )
 
-    def _get_num_pending_tokens(
-        self: Scheduler, chunk_deduct: int = 0
-    ) -> int:
+    def _get_num_pending_tokens(self: Scheduler, chunk_deduct: int = 0) -> int:
         """Get the total number of tokens pending prefill.
 
         This includes tokens from waiting queue requests plus remaining tokens
@@ -885,9 +883,7 @@ class SchedulerMetricsMixin:
         num_pending_tokens = sum(req.seqlen for req in self.waiting_queue)
         if self.chunked_req is not None:
             req = self.chunked_req
-            num_pending_tokens += (
-                req.seqlen - len(req.prefix_indices) - chunk_deduct
-            )
+            num_pending_tokens += req.seqlen - len(req.prefix_indices) - chunk_deduct
         return num_pending_tokens
 
     def get_load(self: Scheduler, _: GetLoadReqInput = None) -> GetLoadReqOutput:

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -55,6 +55,7 @@ class PrefillStats:
     new_token_ratio: float
     num_running_reqs: QueueCount
     num_new_seqs: int  # len(can_run_list)
+    num_pending_tokens: int = 0
 
     @classmethod
     def from_adder(
@@ -62,6 +63,7 @@ class PrefillStats:
         adder: PrefillAdder,
         running_reqs: List[Req],
         enable_priority_scheduling: bool = False,
+        num_pending_tokens: int = 0,
     ):
         return cls(
             log_input_tokens=adder.log_input_tokens,
@@ -71,6 +73,7 @@ class PrefillStats:
                 running_reqs, enable_priority_scheduling
             ),
             num_new_seqs=len(adder.can_run_list),
+            num_pending_tokens=num_pending_tokens,
         )
 
 
@@ -393,6 +396,7 @@ class SchedulerMetricsMixin:
             f"{token_usage_msg}"
             f"#running-req: {prefill_stats.num_running_reqs.total}, "
             f"#queue-req: {len(self.waiting_queue)}, "
+            f"#pending-token: {prefill_stats.num_pending_tokens}, "
         )
 
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
@@ -862,6 +866,30 @@ class SchedulerMetricsMixin:
                     self.stats.token_usage / 0.9,
                 )
 
+    def _get_num_pending_tokens(
+        self: Scheduler, chunk_deduct: int = 0
+    ) -> int:
+        """Get the total number of tokens pending prefill.
+
+        This includes tokens from waiting queue requests plus remaining tokens
+        from the currently chunked request.
+
+        Args:
+            chunk_deduct: extra tokens to subtract from the chunked request's
+                remaining count.  At batch-scheduling time the current chunk
+                has been planned but ``prefix_indices`` does not yet include it,
+                so callers pass ``extend_input_len`` here.  At query time
+                (``get_load``) ``prefix_indices`` is already up-to-date, so
+                the default 0 is correct.
+        """
+        num_pending_tokens = sum(req.seqlen for req in self.waiting_queue)
+        if self.chunked_req is not None:
+            req = self.chunked_req
+            num_pending_tokens += (
+                req.seqlen - len(req.prefix_indices) - chunk_deduct
+            )
+        return num_pending_tokens
+
     def get_load(self: Scheduler, _: GetLoadReqInput = None) -> GetLoadReqOutput:
         if self.is_hybrid_swa:
             full_num_used, swa_num_used, *_ = self._get_swa_token_info()
@@ -871,7 +899,9 @@ class SchedulerMetricsMixin:
         else:
             num_tokens = self._get_token_info()[0]
 
-        # Tokens in waiting queue, bootstrap queue, prealloc queue
+        num_pending_tokens = self._get_num_pending_tokens()
+
+        # Tokens and request count in waiting queue, bootstrap queue, prealloc queue
         waiting_queues = [self.waiting_queue]
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
             waiting_queues.append(self.disagg_prefill_bootstrap_queue.queue)
@@ -888,6 +918,7 @@ class SchedulerMetricsMixin:
             num_reqs=len(self.running_batch.reqs) + num_waiting_reqs,
             num_waiting_reqs=num_waiting_reqs,
             num_tokens=num_tokens,
+            num_pending_tokens=num_pending_tokens,
             ts_tic=time.perf_counter(),
         )
 


### PR DESCRIPTION
## Motivation

For prefill requests, the engine log only shows `#queue-req` and `#running-req`, which is insufficient for understanding load — especially for long-context requests where a single request can have hundreds of thousands of tokens pending prefill across multiple chunks.

This PR adds a `#pending-token` metric that shows the total number of tokens still waiting to be prefilled. This is useful for:
- Monitoring chunked prefill progress in engine logs
- Balancing load across engines when handling long-context requests via `/get_load`

## Modifications

- **`PrefillStats`** (`scheduler_metrics_mixin.py`): Added `num_pending_tokens` field, snapshotted at batch-scheduling time for correct reporting under the overlap scheduler.
- **`_get_num_pending_tokens()`** (`scheduler_metrics_mixin.py`): New shared helper that computes pending tokens from the waiting queue plus remaining tokens of the currently chunked request. Accepts a `chunk_deduct` parameter to handle the timing difference between scheduling time (where `prefix_indices` has not yet been updated) and query time (`get_load`, where it has).
- **Prefill batch log** (`scheduler_metrics_mixin.py`): Added `#pending-token: {N}` to the log line.
- **`GetLoadReqOutput`** (`io_struct.py`): Added `num_pending_tokens` field returned by `/get_load`.
- **`get_load()`** (`scheduler_metrics_mixin.py`): Populates `num_pending_tokens` using the shared helper.
- **`get_new_batch_prefill()`** (`scheduler.py`): Snapshots `num_pending_tokens` into `PrefillStats` at scheduling time.

Example log output with a 30K-token chunked prefill (chunk size 8192):
```
Prefill batch, #new-seq: 1, #new-token: 8192, ..., #pending-token: 21825
Prefill batch, #new-seq: 1, #new-token: 8192, ..., #pending-token: 13633
Prefill batch, #new-seq: 1, #new-token: 8192, ..., #pending-token: 5441
Prefill batch, #new-seq: 1, #new-token: 5441, ..., #pending-token: 0
```

## Accuracy Tests

N/A — observability-only change, no model output affected.

## Speed Tests and Profiling

N/A — adds a lightweight sum over the waiting queue during logging and load queries.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).