### PR TITLE
[CI] Remove Slack notification from ci-auto-bisect workflow

### DIFF
--- a/.github/workflows/ci-auto-bisect.yml
+++ b/.github/workflows/ci-auto-bisect.yml
@@ -64,22 +64,3 @@ jobs:
           name: ci-auto-bisect-${{ github.run_number }}
           path: scripts/ci_monitor/bisect_results.json
           retention-days: 14
-
-      - name: Post to Slack
-        if: always()
-        env:
-          SGLANG_DIFFUSION_SLACK_TOKEN: ${{ secrets.SGLANG_DIFFUSION_SLACK_TOKEN }}
-        run: |
-          cd scripts/ci_monitor
-
-          # Report if the bisect step itself failed
-          if [ "${{ steps.bisect.outcome }}" = "failure" ]; then
-            echo "::error::Auto bisect analysis failed - check logs above"
-          fi
-
-          if [ -f bisect_results.json ] && [ -n "$SGLANG_DIFFUSION_SLACK_TOKEN" ]; then
-            pip install slack_sdk
-            python3 post_bisect_to_slack.py --report-file bisect_results.json
-          else
-            echo "Bisect results or Slack token not available, skipping notification"
-          fi


### PR DESCRIPTION
## Summary
- Remove the Slack notification step from the `ci-auto-bisect` workflow
- Bisect results are now displayed in the [CI failure dashboard](https://ci-monitor.tail134ba0.ts.net) which fetches the artifact directly from the workflow run
- The `post_bisect_to_slack.py` step is redundant

## Test plan
- [x] Bisect results artifact upload is preserved (unchanged)
- [x] Dashboard fetches and displays bisect results via `sync-bisect` command