### PR TITLE
fix: deprecated interfaces after dump

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -717,8 +717,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             )
             return
 
-        from sglang.srt.utils import get_local_ip_auto
-
         self.remote_instance_transfer_engine = TransferEngine()
         local_ip = get_local_ip_auto()
         self.remote_instance_transfer_engine.initialize(

--- a/python/sglang/srt/models/qwen3.py
+++ b/python/sglang/srt/models/qwen3.py
@@ -32,6 +32,7 @@ from sglang.srt.models.qwen2 import Qwen2Model
 from sglang.srt.models.utils import apply_qk_norm
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import add_prefix, get_bool_env_var, is_cuda, is_hip, is_npu
+from sglang.srt.utils.hf_transformers_utils import get_rope_config
 
 Qwen3Config = None
 
@@ -316,8 +317,7 @@ class Qwen3DecoderLayer(nn.Module):
     ) -> None:
         super().__init__()
         self.hidden_size = config.hidden_size
-        rope_theta = config.rope_parameters["rope_theta"]
-        rope_scaling = config.rope_parameters
+        rope_theta, rope_scaling = get_rope_config(config)
         max_position_embeddings = getattr(config, "max_position_embeddings", 32768)
         head_dim = getattr(config, "head_dim", None)
         self.self_attn = Qwen3Attention(


### PR DESCRIPTION
## Motivation

Fix two issues encountered when running Qwen3 with the P2P weight update transfer engine in miles:

1. `ImportError: cannot import name 'get_local_ip_auto' from 'sglang.srt.utils'` — the function existed in `sglang/srt/utils/network.py` but was never re-exported from the package's `__init__.py`.

2. `AttributeError: 'Qwen3Config' object has no attribute 'rope_parameters'` — Qwen3's decoder layer initialization used `config.rope_parameters`, a newer transformers API not present in the currently installed version of transformers, instead of the existing `get_rope_config(config)` helper used by every other model (Qwen2, Qwen3-MoE, GLM4, etc.).

## Modifications

**Fix 1: Remove redundant inline import of `get_local_ip_auto` in `model_runner.py`**

`python/sglang/srt/model_executor/model_runner.py`

```python
# Before (inside remote_instance_init_transfer_engine)
from sglang.srt.utils import get_local_ip_auto   # <-- wrong, fails at runtime
local_ip = get_local_ip_auto()

# After
local_ip = get_local_ip_auto()  # uses the file-level import at line 183
```

`get_local_ip_auto` was already correctly imported at the top of the file:
```python
from sglang.srt.utils.network import NetworkAddress, get_local_ip_auto
```
The inline `from sglang.srt.utils import get_local_ip_auto` inside `remote_instance_init_transfer_engine()` tried to re-import from the package root, which does not re-export it, causing the `ImportError`. Removing the redundant inline import lets the existing file-level import take effect.

---

**Fix 2: Use `get_rope_config` in Qwen3 decoder layer**

`python/sglang/srt/models/qwen3.py`

```python
# Before (in Qwen3DecoderLayer.__init__)
rope_theta = config.rope_parameters["rope_theta"]
rope_scaling = config.rope_parameters

# After
from sglang.srt.utils.hf_transformers_utils import get_rope_config
...
rope_theta, rope_scaling = get_rope_config(config)
```

`config.rope_parameters` is only available in newer versions of the transformers `Qwen3Config`. The installed version raises `AttributeError`. All other models in the codebase (Qwen2, Qwen3-MoE, GLM4, DeepSeek, etc.) already use `get_rope_config(config)` for this purpose.

## Accuracy Tests

No changes to model math or kernel logic. Both fixes are pure import / initialization path corrections.

## Speed Tests and Profiling

No performance impact.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
