### PR TITLE
Extend kimi2 fused moe gate kernel to support GLM-5 (256 experts) via JIT compilation

### DIFF
--- a/python/sglang/jit_kernel/csrc/moe/moe_fused_gate_ungrouped.cu
+++ b/python/sglang/jit_kernel/csrc/moe/moe_fused_gate_ungrouped.cu
@@ -1,0 +1,338 @@
+/* Copyright 2025 SGLang Team. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/utils.cuh>
+
+#include <tvm/ffi/container/tensor.h>
+
+#include <cfloat>
+#include <cstdint>
+
+#ifndef WARP_SIZE
+#define WARP_SIZE 32
+#endif
+
+namespace moe {
+
+// Common constants
+static constexpr int WARPS_PER_CTA = 6;
+static constexpr int SMALL_TOKEN_THRESHOLD = 512;
+static constexpr int VEC_SIZE = 4;
+
+// Small token optimized kernel: Each block handles 1 token, NUM_EXPERTS threads collaborate
+// to find top-k using iterative warp-level reduction.
+// output_stride: row stride in output/indices tensors (>= topk, allows reserved slots for shared experts)
+template <int NUM_EXPERTS>
+__global__ void moe_fused_gate_ungrouped_kernel_small_token(
+    float* input,
+    float* bias,
+    float* output_ptr,
+    int32_t* indices_ptr,
+    int64_t num_rows,
+    int64_t topk,
+    int64_t output_stride,
+    bool renormalize,
+    double routed_scaling_factor,
+    bool apply_routed_scaling_factor_on_output) {
+  static constexpr int WARPS_PER_TOKEN_SMALL = NUM_EXPERTS / WARP_SIZE;
+
+  int64_t row_idx = blockIdx.x;
+  if (row_idx >= num_rows) return;
+
+  int tid = threadIdx.x;
+  int warp_id = tid / WARP_SIZE;
+  int lane_id = tid % WARP_SIZE;
+
+  __shared__ float shared_scores[NUM_EXPERTS];
+  __shared__ float shared_original_scores[NUM_EXPERTS];
+  __shared__ int selected_experts[8];
+  __shared__ float selected_vals[8];
+  __shared__ float warp_maxs[WARPS_PER_TOKEN_SMALL];
+  __shared__ int warp_experts[WARPS_PER_TOKEN_SMALL];
+
+  // Load data: all NUM_EXPERTS threads load one expert each
+  if (tid < NUM_EXPERTS) {
+    float input_val = input[row_idx * NUM_EXPERTS + tid];
+    float bias_val = bias[tid];
+    float sigmoid_val = 1.0f / (1.0f + expf(-input_val));
+    float biased_val = sigmoid_val + bias_val;
+    shared_scores[tid] = biased_val;
+    shared_original_scores[tid] = sigmoid_val;
+  }
+
+  __syncthreads();
+
+  // Find top-k using iterative selection
+  for (int k = 0; k < topk; k++) {
+    float my_val = (tid < NUM_EXPERTS) ? shared_scores[tid] : -FLT_MAX;
+    int my_expert = tid;
+
+    // Warp-level reduction
+    float warp_max_val = my_val;
+    int warp_max_expert = my_expert;
+
+#pragma unroll
+    for (int offset = 16; offset > 0; offset /= 2) {
+      float other_val = __shfl_down_sync(0xFFFFFFFF, warp_max_val, offset);
+      int other_expert = __shfl_down_sync(0xFFFFFFFF, warp_max_expert, offset);
+      if (other_val > warp_max_val) {
+        warp_max_val = other_val;
+        warp_max_expert = other_expert;
+      }
+    }
+
+    if (lane_id == 0) {
+      warp_maxs[warp_id] = warp_max_val;
+      warp_experts[warp_id] = warp_max_expert;
+    }
+
+    __syncthreads();
+
+    // Final reduction among warps (done by first warp)
+    if (warp_id == 0) {
+      float final_max = (lane_id < WARPS_PER_TOKEN_SMALL) ? warp_maxs[lane_id] : -FLT_MAX;
+      int final_expert = (lane_id < WARPS_PER_TOKEN_SMALL) ? warp_experts[lane_id] : -1;
+
+#pragma unroll
+      for (int offset = 16; offset > 0; offset /= 2) {
+        float other_val = __shfl_down_sync(0xFFFFFFFF, final_max, offset);
+        int other_expert = __shfl_down_sync(0xFFFFFFFF, final_expert, offset);
+        if (other_val > final_max) {
+          final_max = other_val;
+          final_expert = other_expert;
+        }
+      }
+
+      if (lane_id == 0) {
+        selected_experts[k] = final_expert;
+        selected_vals[k] = final_max;
+      }
+    }
+
+    __syncthreads();
+
+    // Mark the selected expert as used
+    int selected = selected_experts[k];
+    if (tid == selected) {
+      shared_scores[tid] = -FLT_MAX;
+    }
+
+    __syncthreads();
+  }
+
+  // Write output (done by thread 0)
+  if (tid == 0) {
+    for (int k = 0; k < topk; k++) {
+      int expert_id = selected_experts[k];
+      if (expert_id >= 0 && expert_id < NUM_EXPERTS) {
+        output_ptr[row_idx * output_stride + k] = shared_original_scores[expert_id];
+        indices_ptr[row_idx * output_stride + k] = expert_id;
+      } else {
+        output_ptr[row_idx * output_stride + k] = 0.0f;
+        indices_ptr[row_idx * output_stride + k] = 0;
+      }
+    }
+
+    if (renormalize) {
+      float sum = 0.0f;
+      for (int k = 0; k < topk; k++) {
+        sum += output_ptr[row_idx * output_stride + k];
+      }
+
+      if (sum > 0.0f) {
+        for (int k = 0; k < topk; k++) {
+          int64_t idx = row_idx * output_stride + k;
+          output_ptr[idx] /= sum;
+          if (apply_routed_scaling_factor_on_output) {
+            output_ptr[idx] *= static_cast<float>(routed_scaling_factor);
+          }
+        }
+      }
+    }
+  }
+}
+
+// Large token kernel: Each warp handles one token with vectorized loads
+// output_stride: row stride in output/indices tensors (>= topk, allows reserved slots for shared experts)
+template <int NUM_EXPERTS>
+__global__ void moe_fused_gate_ungrouped_kernel(
+    float* input,
+    float* bias,
+    float* output_ptr,
+    int32_t* indices_ptr,
+    int64_t num_rows,
+    int64_t topk,
+    int64_t output_stride,
+    bool renormalize,
+    double routed_scaling_factor,
+    bool apply_routed_scaling_factor_on_output) {
+  static constexpr int VPT = NUM_EXPERTS / WARP_SIZE;
+
+  int64_t row_idx = blockIdx.x * WARPS_PER_CTA + threadIdx.y;
+  if (row_idx >= num_rows) return;
+
+  int lane_id = threadIdx.x;
+  int warp_id = threadIdx.y;
+
+  __shared__ float shared_scores[NUM_EXPERTS * WARPS_PER_CTA];
+  __shared__ float shared_original_scores[NUM_EXPERTS * WARPS_PER_CTA];
+
+  float* warp_scores = shared_scores + warp_id * NUM_EXPERTS;
+  float* warp_original_scores = shared_original_scores + warp_id * NUM_EXPERTS;
+
+  // Vectorized loading
+  static constexpr int VEC_PER_LANE = VPT / VEC_SIZE;
+  float4* input_vec = reinterpret_cast<float4*>(input + row_idx * NUM_EXPERTS);
+  float4* bias_vec = reinterpret_cast<float4*>(bias);
+
+#pragma unroll
+  for (int i = 0; i < VEC_PER_LANE; i++) {
+    int vec_idx = lane_id * VEC_PER_LANE + i;
+    float4 input_val = input_vec[vec_idx];
+    float4 bias_val = bias_vec[vec_idx];
+
+#pragma unroll
+    for (int j = 0; j < VEC_SIZE; j++) {
+      int expert = vec_idx * VEC_SIZE + j;
+      float inp = ((float*)&input_val)[j];
+      float b = ((float*)&bias_val)[j];
+      float sigmoid_val = 1.0f / (1.0f + expf(-inp));
+      float biased_val = sigmoid_val + b;
+      warp_scores[expert] = biased_val;
+      warp_original_scores[expert] = sigmoid_val;
+    }
+  }
+
+  __syncthreads();
+
+  for (int k = 0; k < topk; k++) {
+    float max_val = -FLT_MAX;
+    int max_expert = -1;
+
+    for (int expert = lane_id; expert < NUM_EXPERTS; expert += WARP_SIZE) {
+      if (warp_scores[expert] > max_val) {
+        max_val = warp_scores[expert];
+        max_expert = expert;
+      }
+    }
+
+    for (int offset = WARP_SIZE / 2; offset > 0; offset /= 2) {
+      float other_val = __shfl_down_sync(0xFFFFFFFF, max_val, offset);
+      int other_expert = __shfl_down_sync(0xFFFFFFFF, max_expert, offset);
+
+      if (other_val > max_val || (other_val == max_val && other_expert < max_expert)) {
+        max_val = other_val;
+        max_expert = other_expert;
+      }
+    }
+
+    if (lane_id == 0) {
+      int64_t output_idx = row_idx * output_stride + k;
+      if (max_expert != -1) {
+        output_ptr[output_idx] = warp_original_scores[max_expert];
+        indices_ptr[output_idx] = max_expert;
+        warp_scores[max_expert] = -FLT_MAX;
+      } else {
+        output_ptr[output_idx] = 0.0f;
+        indices_ptr[output_idx] = 0;
+      }
+    }
+
+    __syncwarp();
+  }
+
+  __syncthreads();
+
+  if (renormalize && lane_id == 0) {
+    float sum = 0.0f;
+    for (int k = 0; k < topk; k++) {
+      sum += output_ptr[row_idx * output_stride + k];
+    }
+
+    if (sum > 0.0f) {
+      for (int k = 0; k < topk; k++) {
+        int64_t idx = row_idx * output_stride + k;
+        output_ptr[idx] /= sum;
+        if (apply_routed_scaling_factor_on_output) {
+          output_ptr[idx] *= static_cast<float>(routed_scaling_factor);
+        }
+      }
+    }
+  }
+}
+
+}  // namespace moe
+
+namespace {
+
+template <int NUM_EXPERTS>
+struct MoeFusedGateUngroupedKernel {
+  static void
+  run(tvm::ffi::TensorView input,
+      tvm::ffi::TensorView bias,
+      tvm::ffi::TensorView output,
+      tvm::ffi::TensorView indices,
+      int64_t topk,
+      bool renormalize,
+      double routed_scaling_factor,
+      bool apply_routed_scaling_factor_on_output) {
+    using namespace host;
+
+    auto device = input.device();
+    const cudaStream_t stream = LaunchKernel::resolve_device(device);
+
+    int64_t num_rows = input.size(0);
+    int64_t output_stride = output.size(1);
+
+    float* input_ptr = static_cast<float*>(input.data_ptr());
+    float* bias_ptr = static_cast<float*>(bias.data_ptr());
+    float* output_ptr = static_cast<float*>(output.data_ptr());
+    int32_t* indices_ptr = static_cast<int32_t*>(indices.data_ptr());
+
+    if (num_rows <= moe::SMALL_TOKEN_THRESHOLD) {
+      LaunchKernel(dim3(num_rows), dim3(NUM_EXPERTS), stream)(
+          moe::moe_fused_gate_ungrouped_kernel_small_token<NUM_EXPERTS>,
+          input_ptr,
+          bias_ptr,
+          output_ptr,
+          indices_ptr,
+          num_rows,
+          topk,
+          output_stride,
+          renormalize,
+          routed_scaling_factor,
+          apply_routed_scaling_factor_on_output);
+    } else {
+      int64_t num_blocks = (num_rows + moe::WARPS_PER_CTA - 1) / moe::WARPS_PER_CTA;
+      LaunchKernel(dim3(num_blocks), dim3(WARP_SIZE, moe::WARPS_PER_CTA), stream)(
+          moe::moe_fused_gate_ungrouped_kernel<NUM_EXPERTS>,
+          input_ptr,
+          bias_ptr,
+          output_ptr,
+          indices_ptr,
+          num_rows,
+          topk,
+          output_stride,
+          renormalize,
+          routed_scaling_factor,
+          apply_routed_scaling_factor_on_output);
+    }
+  }
+};
+
+}  // namespace

--- a/python/sglang/jit_kernel/csrc/moe/moe_fused_gate_ungrouped.cu
+++ b/python/sglang/jit_kernel/csrc/moe/moe_fused_gate_ungrouped.cu
@@ -184,7 +184,9 @@ __global__ void moe_fused_gate_ungrouped_kernel(
   static constexpr int VPT = NUM_EXPERTS / WARP_SIZE;
 
   int64_t row_idx = blockIdx.x * WARPS_PER_CTA + threadIdx.y;
-  if (row_idx >= num_rows) return;
+  // Use valid-row predicate instead of early return to avoid __syncthreads deadlock
+  // when num_rows is not divisible by WARPS_PER_CTA.
+  bool valid_row = (row_idx < num_rows);
 
   int lane_id = threadIdx.x;
   int warp_id = threadIdx.y;
@@ -195,26 +197,28 @@ __global__ void moe_fused_gate_ungrouped_kernel(
   float* warp_scores = shared_scores + warp_id * NUM_EXPERTS;
   float* warp_original_scores = shared_original_scores + warp_id * NUM_EXPERTS;
 
-  // Vectorized loading
-  static constexpr int VEC_PER_LANE = VPT / VEC_SIZE;
-  float4* input_vec = reinterpret_cast<float4*>(input + row_idx * NUM_EXPERTS);
-  float4* bias_vec = reinterpret_cast<float4*>(bias);
+  // Vectorized loading (only for valid rows)
+  if (valid_row) {
+    static constexpr int VEC_PER_LANE = VPT / VEC_SIZE;
+    float4* input_vec = reinterpret_cast<float4*>(input + row_idx * NUM_EXPERTS);
+    float4* bias_vec = reinterpret_cast<float4*>(bias);
 
 #pragma unroll
-  for (int i = 0; i < VEC_PER_LANE; i++) {
-    int vec_idx = lane_id * VEC_PER_LANE + i;
-    float4 input_val = input_vec[vec_idx];
-    float4 bias_val = bias_vec[vec_idx];
+    for (int i = 0; i < VEC_PER_LANE; i++) {
+      int vec_idx = lane_id * VEC_PER_LANE + i;
+      float4 input_val = input_vec[vec_idx];
+      float4 bias_val = bias_vec[vec_idx];
 
 #pragma unroll
-    for (int j = 0; j < VEC_SIZE; j++) {
-      int expert = vec_idx * VEC_SIZE + j;
-      float inp = ((float*)&input_val)[j];
-      float b = ((float*)&bias_val)[j];
-      float sigmoid_val = 1.0f / (1.0f + expf(-inp));
-      float biased_val = sigmoid_val + b;
-      warp_scores[expert] = biased_val;
-      warp_original_scores[expert] = sigmoid_val;
+      for (int j = 0; j < VEC_SIZE; j++) {
+        int expert = vec_idx * VEC_SIZE + j;
+        float inp = ((float*)&input_val)[j];
+        float b = ((float*)&bias_val)[j];
+        float sigmoid_val = 1.0f / (1.0f + expf(-inp));
+        float biased_val = sigmoid_val + b;
+        warp_scores[expert] = biased_val;
+        warp_original_scores[expert] = sigmoid_val;
+      }
     }
   }
 
@@ -224,10 +228,12 @@ __global__ void moe_fused_gate_ungrouped_kernel(
     float max_val = -FLT_MAX;
     int max_expert = -1;
 
-    for (int expert = lane_id; expert < NUM_EXPERTS; expert += WARP_SIZE) {
-      if (warp_scores[expert] > max_val) {
-        max_val = warp_scores[expert];
-        max_expert = expert;
+    if (valid_row) {
+      for (int expert = lane_id; expert < NUM_EXPERTS; expert += WARP_SIZE) {
+        if (warp_scores[expert] > max_val) {
+          max_val = warp_scores[expert];
+          max_expert = expert;
+        }
       }
     }
 
@@ -241,7 +247,7 @@ __global__ void moe_fused_gate_ungrouped_kernel(
       }
     }
 
-    if (lane_id == 0) {
+    if (valid_row && lane_id == 0) {
       int64_t output_idx = row_idx * output_stride + k;
       if (max_expert != -1) {
         output_ptr[output_idx] = warp_original_scores[max_expert];
@@ -258,7 +264,7 @@ __global__ void moe_fused_gate_ungrouped_kernel(
 
   __syncthreads();
 
-  if (renormalize && lane_id == 0) {
+  if (valid_row && renormalize && lane_id == 0) {
     float sum = 0.0f;
     for (int k = 0; k < topk; k++) {
       sum += output_ptr[row_idx * output_stride + k];

--- a/python/sglang/jit_kernel/moe_fused_gate_ungrouped.py
+++ b/python/sglang/jit_kernel/moe_fused_gate_ungrouped.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING
 
 import torch
 
 from sglang.jit_kernel.utils import cache_once, load_jit, make_cpp_args
+from sglang.srt.utils.custom_op import register_custom_op
 
 if TYPE_CHECKING:
     from tvm_ffi.module import Module
@@ -26,6 +27,24 @@ def _jit_moe_fused_gate_ungrouped_module(num_experts: int) -> Module:
     )
 
 
+def _moe_fused_gate_ungrouped_fake(
+    input: torch.Tensor,
+    bias: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    routed_scaling_factor: float,
+    apply_routed_scaling_factor_on_output: bool,
+    output: torch.Tensor,
+    indices: torch.Tensor,
+) -> None:
+    pass
+
+
+@register_custom_op(
+    op_name="moe_fused_gate_ungrouped",
+    mutates_args=["output", "indices"],
+    fake_impl=_moe_fused_gate_ungrouped_fake,
+)
 def moe_fused_gate_ungrouped(
     input: torch.Tensor,
     bias: torch.Tensor,
@@ -33,22 +52,20 @@ def moe_fused_gate_ungrouped(
     renormalize: bool,
     routed_scaling_factor: float,
     apply_routed_scaling_factor_on_output: bool,
-    output: torch.Tensor = None,
-    indices: torch.Tensor = None,
-) -> Tuple[torch.Tensor, torch.Tensor]:
+    output: torch.Tensor,
+    indices: torch.Tensor,
+) -> None:
     """Fused sigmoid + bias + topk gate for ungrouped MoE (num_expert_group=1).
 
-    If output/indices are provided, the kernel writes into them using
-    output.size(1) as the row stride (supports pre-reserved shared expert slots).
-    Otherwise, tensors of shape (num_rows, topk) are allocated.
+    The kernel writes into output/indices using output.size(1) as the row stride
+    (supports pre-reserved shared expert slots).
     """
-    num_rows = input.size(0)
-    num_experts = input.size(1)
+    assert topk <= 8, f"topk must be <= 8 (kernel shared memory constraint), got {topk}"
 
-    if output is None:
-        output = torch.empty((num_rows, topk), dtype=torch.float32, device=input.device)
-    if indices is None:
-        indices = torch.empty((num_rows, topk), dtype=torch.int32, device=input.device)
+    num_experts = input.size(1)
+    assert (
+        num_experts % 128 == 0
+    ), f"num_experts must be divisible by 128 (WARP_SIZE * VEC_SIZE), got {num_experts}"
 
     module = _jit_moe_fused_gate_ungrouped_module(num_experts)
     module.moe_fused_gate_ungrouped(
@@ -61,4 +78,3 @@ def moe_fused_gate_ungrouped(
         routed_scaling_factor if routed_scaling_factor is not None else 1.0,
         apply_routed_scaling_factor_on_output,
     )
-    return output, indices

--- a/python/sglang/jit_kernel/moe_fused_gate_ungrouped.py
+++ b/python/sglang/jit_kernel/moe_fused_gate_ungrouped.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Tuple
+
+import torch
+
+from sglang.jit_kernel.utils import cache_once, load_jit, make_cpp_args
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+@cache_once
+def _jit_moe_fused_gate_ungrouped_module(num_experts: int) -> Module:
+    args = make_cpp_args(num_experts)
+    return load_jit(
+        "moe_fused_gate_ungrouped",
+        *args,
+        cuda_files=["moe/moe_fused_gate_ungrouped.cu"],
+        cuda_wrappers=[
+            (
+                "moe_fused_gate_ungrouped",
+                f"MoeFusedGateUngroupedKernel<{args}>::run",
+            ),
+        ],
+    )
+
+
+def moe_fused_gate_ungrouped(
+    input: torch.Tensor,
+    bias: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    routed_scaling_factor: float,
+    apply_routed_scaling_factor_on_output: bool,
+    output: torch.Tensor = None,
+    indices: torch.Tensor = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Fused sigmoid + bias + topk gate for ungrouped MoE (num_expert_group=1).
+
+    If output/indices are provided, the kernel writes into them using
+    output.size(1) as the row stride (supports pre-reserved shared expert slots).
+    Otherwise, tensors of shape (num_rows, topk) are allocated.
+    """
+    num_rows = input.size(0)
+    num_experts = input.size(1)
+
+    if output is None:
+        output = torch.empty((num_rows, topk), dtype=torch.float32, device=input.device)
+    if indices is None:
+        indices = torch.empty((num_rows, topk), dtype=torch.int32, device=input.device)
+
+    module = _jit_moe_fused_gate_ungrouped_module(num_experts)
+    module.moe_fused_gate_ungrouped(
+        input,
+        bias,
+        output,
+        indices,
+        topk,
+        renormalize,
+        routed_scaling_factor if routed_scaling_factor is not None else 1.0,
+        apply_routed_scaling_factor_on_output,
+    )
+    return output, indices

--- a/python/sglang/jit_kernel/tests/test_moe_fused_gate_ungrouped.py
+++ b/python/sglang/jit_kernel/tests/test_moe_fused_gate_ungrouped.py
@@ -1,0 +1,196 @@
+import sys
+
+import pytest
+import torch
+
+from sglang.jit_kernel.moe_fused_gate_ungrouped import moe_fused_gate_ungrouped
+from sglang.srt.layers.moe.topk import kimi_k2_biased_topk_impl
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=60, suite="stage-b-kernel-unit-1-gpu-large")
+
+
+@pytest.mark.parametrize(
+    "seq_length",
+    list(range(1, 10))
+    + [16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536],
+)
+@pytest.mark.parametrize(
+    "num_experts,topk,routed_scaling_factor",
+    [
+        (384, 6, 2.872),  # Kimi K2: 384 experts, topk=6
+        (256, 8, 2.5),  # GLM5: 256 experts, topk=8
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32])
+@pytest.mark.parametrize("apply_routed_scaling_factor_on_output", [False, True])
+def test_moe_fused_gate_ungrouped(
+    seq_length,
+    num_experts,
+    topk,
+    routed_scaling_factor,
+    dtype,
+    apply_routed_scaling_factor_on_output,
+):
+    renormalize = True
+
+    torch.manual_seed(seq_length)
+    tensor = torch.rand((seq_length, num_experts), dtype=dtype, device="cuda")
+    scores = tensor.clone()
+    bias = torch.rand(num_experts, dtype=dtype, device="cuda")
+
+    output, indices = moe_fused_gate_ungrouped(
+        tensor,
+        bias,
+        topk=topk,
+        renormalize=renormalize,
+        routed_scaling_factor=routed_scaling_factor,
+        apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
+    )
+
+    ref_output, ref_indices = kimi_k2_biased_topk_impl(
+        scores,
+        scores,
+        bias,
+        topk=topk,
+        renormalize=renormalize,
+        routed_scaling_factor=routed_scaling_factor,
+        apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
+    )
+
+    output_check = torch.allclose(
+        ref_output.sort()[0].to(torch.float32),
+        output.sort()[0].to(torch.float32),
+        rtol=1e-02,
+        atol=1e-03,
+    )
+
+    assert output_check, (
+        f"Output mismatch at seq_length {seq_length}, dtype {dtype}, "
+        f"num_experts {num_experts}, topk {topk}, "
+        f"apply_routed_scaling_factor_on_output {apply_routed_scaling_factor_on_output}"
+    )
+
+
+@pytest.mark.parametrize("seq_length", [1, 64, 512, 1024, 4096])
+@pytest.mark.parametrize(
+    "num_experts,routed_topk,routed_scaling_factor",
+    [
+        (384, 6, 2.872),  # Kimi K2
+        (256, 8, 2.5),  # GLM5
+    ],
+)
+def test_moe_fused_gate_ungrouped_output_stride(
+    seq_length, num_experts, routed_topk, routed_scaling_factor
+):
+    """Test output_stride: kernel writes routed_topk columns into a wider pre-allocated tensor."""
+    dtype = torch.float32
+    renormalize = True
+    total_topk = routed_topk + 1  # 1 extra slot for shared expert
+
+    torch.manual_seed(42)
+    tensor = torch.rand((seq_length, num_experts), dtype=dtype, device="cuda")
+    scores = tensor.clone()
+    bias = torch.rand(num_experts, dtype=dtype, device="cuda")
+
+    # Pre-allocate wider tensors
+    output = torch.empty((seq_length, total_topk), dtype=torch.float32, device="cuda")
+    indices = torch.empty((seq_length, total_topk), dtype=torch.int32, device="cuda")
+
+    moe_fused_gate_ungrouped(
+        tensor,
+        bias,
+        topk=routed_topk,
+        renormalize=renormalize,
+        routed_scaling_factor=routed_scaling_factor,
+        apply_routed_scaling_factor_on_output=False,
+        output=output,
+        indices=indices,
+    )
+
+    # Verify routed columns match reference
+    ref_output, ref_indices = kimi_k2_biased_topk_impl(
+        scores,
+        scores,
+        bias,
+        topk=routed_topk,
+        renormalize=renormalize,
+        routed_scaling_factor=routed_scaling_factor,
+        apply_routed_scaling_factor_on_output=False,
+    )
+
+    routed_output = output[:, :routed_topk]
+    output_check = torch.allclose(
+        ref_output.sort()[0].to(torch.float32),
+        routed_output.sort()[0].to(torch.float32),
+        rtol=1e-02,
+        atol=1e-03,
+    )
+    assert output_check, "Routed weights mismatch with output_stride"
+
+    assert output.shape == (seq_length, total_topk)
+    assert indices.shape == (seq_length, total_topk)
+
+
+@pytest.mark.parametrize("seq_length", [1024, 4096])
+@pytest.mark.parametrize(
+    "num_experts,topk,routed_scaling_factor",
+    [
+        (384, 6, 2.872),  # Kimi K2
+        (256, 8, 2.5),  # GLM5
+    ],
+)
+def test_moe_fused_gate_ungrouped_specific(
+    seq_length, num_experts, topk, routed_scaling_factor
+):
+    """Test for supported configurations: 384 experts (Kimi K2) and 256 experts (GLM5)"""
+    dtype = torch.float32
+    renormalize = True
+
+    torch.manual_seed(42)
+    tensor = torch.rand((seq_length, num_experts), dtype=dtype, device="cuda")
+    scores = tensor.clone()
+    bias = torch.rand(num_experts, dtype=dtype, device="cuda")
+
+    output, indices = moe_fused_gate_ungrouped(
+        tensor,
+        bias,
+        topk=topk,
+        renormalize=renormalize,
+        routed_scaling_factor=routed_scaling_factor,
+        apply_routed_scaling_factor_on_output=False,
+    )
+
+    ref_output, ref_indices = kimi_k2_biased_topk_impl(
+        scores,
+        scores,
+        bias,
+        topk=topk,
+        renormalize=renormalize,
+        routed_scaling_factor=routed_scaling_factor,
+        apply_routed_scaling_factor_on_output=False,
+    )
+
+    assert output.shape == (seq_length, topk)
+    assert indices.shape == (seq_length, topk)
+    assert output.dtype == torch.float32
+    assert indices.dtype == torch.int32
+
+    if renormalize:
+        weight_sums = output.sum(dim=-1)
+        assert torch.allclose(
+            weight_sums, torch.ones_like(weight_sums), rtol=1e-3, atol=1e-4
+        )
+
+    output_check = torch.allclose(
+        ref_output.sort()[0].to(torch.float32),
+        output.sort()[0].to(torch.float32),
+        rtol=1e-02,
+        atol=1e-03,
+    )
+
+    assert output_check, "Output mismatch for specific case"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__]))

--- a/python/sglang/jit_kernel/tests/test_moe_fused_gate_ungrouped.py
+++ b/python/sglang/jit_kernel/tests/test_moe_fused_gate_ungrouped.py
@@ -1,13 +1,121 @@
 import sys
+from typing import Optional
 
 import pytest
 import torch
 
 from sglang.jit_kernel.moe_fused_gate_ungrouped import moe_fused_gate_ungrouped
-from sglang.srt.layers.moe.topk import kimi_k2_biased_topk_impl
 from sglang.test.ci.ci_register import register_cuda_ci
 
+
+def _reference_biased_topk(
+    hidden_states: torch.Tensor,
+    gating_output: torch.Tensor,
+    correction_bias: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    routed_scaling_factor: Optional[float] = None,
+    apply_routed_scaling_factor_on_output: Optional[bool] = False,
+    num_fused_shared_experts: int = 0,
+):
+    """Reference implementation mirroring biased_grouped_topk_impl (num_expert_group=1).
+    Kept as a local copy so the reference is not affected by source code changes.
+    """
+    assert hidden_states.shape[0] == gating_output.shape[0], "Number of tokens mismatch"
+
+    scores = gating_output.sigmoid()
+    num_token = scores.shape[0]
+    num_experts = scores.shape[1]
+
+    tmp_scores = scores.view(num_token, -1) + correction_bias.unsqueeze(0)
+    _, topk_ids = torch.topk(
+        tmp_scores,
+        k=topk,
+        dim=-1,
+        sorted=(num_fused_shared_experts > 0),
+    )
+    topk_weights = scores.gather(1, topk_ids)
+
+    # Fill shared expert slots (mirrors biased_grouped_topk_impl)
+    if num_fused_shared_experts > 0:
+        topk_ids[:, -num_fused_shared_experts:] = torch.randint(
+            low=num_experts,
+            high=num_experts + num_fused_shared_experts,
+            size=(num_token, num_fused_shared_experts),
+            dtype=topk_ids.dtype,
+            device=topk_ids.device,
+        )
+        if routed_scaling_factor is not None:
+            routed_topk = topk - num_fused_shared_experts
+            topk_weights[:, -num_fused_shared_experts:] = (
+                topk_weights[:, :routed_topk].sum(dim=-1, keepdim=True)
+                / routed_scaling_factor
+            )
+
+    if renormalize:
+        if num_fused_shared_experts == 0:
+            topk_weights_sum = topk_weights.sum(dim=-1, keepdim=True)
+        else:
+            routed_topk = topk - num_fused_shared_experts
+            topk_weights_sum = topk_weights[:, :routed_topk].sum(dim=-1, keepdim=True)
+        topk_weights = topk_weights / topk_weights_sum
+        if apply_routed_scaling_factor_on_output:
+            topk_weights *= routed_scaling_factor
+
+    topk_weights, topk_ids = topk_weights.to(torch.float32), topk_ids.to(torch.int32)
+    return topk_weights, topk_ids
+
+
 register_cuda_ci(est_time=60, suite="stage-b-kernel-unit-1-gpu-large")
+
+
+def _call_kernel(
+    tensor,
+    bias,
+    topk,
+    renormalize,
+    routed_scaling_factor,
+    apply_routed_scaling_factor_on_output,
+    num_fused_shared_experts=0,
+    output=None,
+    indices=None,
+):
+    """Helper mirroring _biased_grouped_topk_ungrouped: kernel + shared expert fill."""
+    num_rows = tensor.size(0)
+    num_experts = tensor.size(1)
+    routed_topk = topk - num_fused_shared_experts
+
+    if output is None:
+        output = torch.empty(
+            (num_rows, topk), dtype=torch.float32, device=tensor.device
+        )
+    if indices is None:
+        indices = torch.empty((num_rows, topk), dtype=torch.int32, device=tensor.device)
+
+    moe_fused_gate_ungrouped(
+        tensor,
+        bias,
+        routed_topk,
+        renormalize,
+        routed_scaling_factor,
+        apply_routed_scaling_factor_on_output,
+        output,
+        indices,
+    )
+
+    # Fill shared expert slots (mirrors _biased_grouped_topk_ungrouped)
+    if num_fused_shared_experts > 0:
+        sf = routed_scaling_factor if routed_scaling_factor is not None else 1.0
+        output[:, routed_topk:] = output[:, :routed_topk].sum(dim=-1, keepdim=True) / sf
+        indices[:, routed_topk:] = torch.randint(
+            low=num_experts,
+            high=num_experts + num_fused_shared_experts,
+            size=(num_rows, num_fused_shared_experts),
+            dtype=torch.int32,
+            device=tensor.device,
+        )
+
+    return output, indices
 
 
 @pytest.mark.parametrize(
@@ -18,12 +126,13 @@ register_cuda_ci(est_time=60, suite="stage-b-kernel-unit-1-gpu-large")
 @pytest.mark.parametrize(
     "num_experts,topk,routed_scaling_factor",
     [
-        (384, 6, 2.872),  # Kimi K2: 384 experts, topk=6
+        (384, 6, 2.827),  # Kimi K2: 384 experts, topk=6
         (256, 8, 2.5),  # GLM5: 256 experts, topk=8
     ],
 )
 @pytest.mark.parametrize("dtype", [torch.float32])
 @pytest.mark.parametrize("apply_routed_scaling_factor_on_output", [False, True])
+@pytest.mark.parametrize("renormalize", [False, True])
 def test_moe_fused_gate_ungrouped(
     seq_length,
     num_experts,
@@ -31,15 +140,15 @@ def test_moe_fused_gate_ungrouped(
     routed_scaling_factor,
     dtype,
     apply_routed_scaling_factor_on_output,
+    renormalize,
 ):
-    renormalize = True
 
     torch.manual_seed(seq_length)
     tensor = torch.rand((seq_length, num_experts), dtype=dtype, device="cuda")
     scores = tensor.clone()
     bias = torch.rand(num_experts, dtype=dtype, device="cuda")
 
-    output, indices = moe_fused_gate_ungrouped(
+    output, indices = _call_kernel(
         tensor,
         bias,
         topk=topk,
@@ -48,7 +157,7 @@ def test_moe_fused_gate_ungrouped(
         apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
     )
 
-    ref_output, ref_indices = kimi_k2_biased_topk_impl(
+    ref_output, ref_indices = _reference_biased_topk(
         scores,
         scores,
         bias,
@@ -71,125 +180,96 @@ def test_moe_fused_gate_ungrouped(
         f"apply_routed_scaling_factor_on_output {apply_routed_scaling_factor_on_output}"
     )
 
-
-@pytest.mark.parametrize("seq_length", [1, 64, 512, 1024, 4096])
-@pytest.mark.parametrize(
-    "num_experts,routed_topk,routed_scaling_factor",
-    [
-        (384, 6, 2.872),  # Kimi K2
-        (256, 8, 2.5),  # GLM5
-    ],
-)
-def test_moe_fused_gate_ungrouped_output_stride(
-    seq_length, num_experts, routed_topk, routed_scaling_factor
-):
-    """Test output_stride: kernel writes routed_topk columns into a wider pre-allocated tensor."""
-    dtype = torch.float32
-    renormalize = True
-    total_topk = routed_topk + 1  # 1 extra slot for shared expert
-
-    torch.manual_seed(42)
-    tensor = torch.rand((seq_length, num_experts), dtype=dtype, device="cuda")
-    scores = tensor.clone()
-    bias = torch.rand(num_experts, dtype=dtype, device="cuda")
-
-    # Pre-allocate wider tensors
-    output = torch.empty((seq_length, total_topk), dtype=torch.float32, device="cuda")
-    indices = torch.empty((seq_length, total_topk), dtype=torch.int32, device="cuda")
-
-    moe_fused_gate_ungrouped(
-        tensor,
-        bias,
-        topk=routed_topk,
-        renormalize=renormalize,
-        routed_scaling_factor=routed_scaling_factor,
-        apply_routed_scaling_factor_on_output=False,
-        output=output,
-        indices=indices,
-    )
-
-    # Verify routed columns match reference
-    ref_output, ref_indices = kimi_k2_biased_topk_impl(
-        scores,
-        scores,
-        bias,
-        topk=routed_topk,
-        renormalize=renormalize,
-        routed_scaling_factor=routed_scaling_factor,
-        apply_routed_scaling_factor_on_output=False,
-    )
-
-    routed_output = output[:, :routed_topk]
-    output_check = torch.allclose(
-        ref_output.sort()[0].to(torch.float32),
-        routed_output.sort()[0].to(torch.float32),
-        rtol=1e-02,
-        atol=1e-03,
-    )
-    assert output_check, "Routed weights mismatch with output_stride"
-
-    assert output.shape == (seq_length, total_topk)
-    assert indices.shape == (seq_length, total_topk)
+    # After renormalization, weights should sum to ~1.0
+    if renormalize and not apply_routed_scaling_factor_on_output:
+        weight_sums = output.sum(dim=-1)
+        assert torch.allclose(
+            weight_sums, torch.ones_like(weight_sums), rtol=1e-3, atol=1e-4
+        ), f"Weight sums mismatch at seq_length {seq_length}"
 
 
-@pytest.mark.parametrize("seq_length", [1024, 4096])
+@pytest.mark.parametrize("seq_length", [1, 64, 512, 513, 515, 1024, 4096])
 @pytest.mark.parametrize(
     "num_experts,topk,routed_scaling_factor",
     [
-        (384, 6, 2.872),  # Kimi K2
-        (256, 8, 2.5),  # GLM5
+        (128, 5, 1.0),  # Minimal: 128 experts, topk=4+1 shared
+        (384, 7, 2.827),  # Kimi K2: 384 experts, topk=6+1 shared
+        (256, 8, 2.5),  # GLM5: 256 experts, topk=7+1 shared (topk<=8 constraint)
     ],
 )
-def test_moe_fused_gate_ungrouped_specific(
-    seq_length, num_experts, topk, routed_scaling_factor
+@pytest.mark.parametrize("apply_routed_scaling_factor_on_output", [False, True])
+@pytest.mark.parametrize("renormalize", [False, True])
+def test_moe_fused_gate_ungrouped_shared_experts(
+    seq_length,
+    num_experts,
+    topk,
+    routed_scaling_factor,
+    apply_routed_scaling_factor_on_output,
+    renormalize,
 ):
-    """Test for supported configurations: 384 experts (Kimi K2) and 256 experts (GLM5)"""
+    """End-to-end test mirroring _biased_grouped_topk_ungrouped vs biased_grouped_topk_impl
+    with num_fused_shared_experts=1."""
     dtype = torch.float32
-    renormalize = True
+    num_fused_shared_experts = 1
+    routed_topk = topk - num_fused_shared_experts
 
     torch.manual_seed(42)
     tensor = torch.rand((seq_length, num_experts), dtype=dtype, device="cuda")
     scores = tensor.clone()
     bias = torch.rand(num_experts, dtype=dtype, device="cuda")
 
-    output, indices = moe_fused_gate_ungrouped(
+    # Kernel path (mirrors _biased_grouped_topk_ungrouped)
+    output, indices = _call_kernel(
         tensor,
         bias,
         topk=topk,
         renormalize=renormalize,
         routed_scaling_factor=routed_scaling_factor,
-        apply_routed_scaling_factor_on_output=False,
+        apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
+        num_fused_shared_experts=num_fused_shared_experts,
     )
 
-    ref_output, ref_indices = kimi_k2_biased_topk_impl(
+    # Reference path (mirrors biased_grouped_topk_impl)
+    ref_output, ref_indices = _reference_biased_topk(
         scores,
         scores,
         bias,
         topk=topk,
         renormalize=renormalize,
         routed_scaling_factor=routed_scaling_factor,
-        apply_routed_scaling_factor_on_output=False,
+        apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
+        num_fused_shared_experts=num_fused_shared_experts,
     )
 
     assert output.shape == (seq_length, topk)
     assert indices.shape == (seq_length, topk)
-    assert output.dtype == torch.float32
-    assert indices.dtype == torch.int32
 
-    if renormalize:
-        weight_sums = output.sum(dim=-1)
-        assert torch.allclose(
-            weight_sums, torch.ones_like(weight_sums), rtol=1e-3, atol=1e-4
-        )
-
-    output_check = torch.allclose(
-        ref_output.sort()[0].to(torch.float32),
-        output.sort()[0].to(torch.float32),
+    # Compare routed weights (shared expert IDs are random, so compare weights only)
+    routed_output = output[:, :routed_topk]
+    ref_routed_output = ref_output[:, :routed_topk]
+    assert torch.allclose(
+        ref_routed_output.sort()[0],
+        routed_output.sort()[0],
         rtol=1e-02,
         atol=1e-03,
-    )
+    ), "Routed weights mismatch"
 
-    assert output_check, "Output mismatch for specific case"
+    # Compare shared expert weights
+    shared_weights = output[:, routed_topk:]
+    ref_shared_weights = ref_output[:, routed_topk:]
+    assert torch.allclose(
+        shared_weights,
+        ref_shared_weights,
+        rtol=1e-03,
+        atol=1e-04,
+    ), f"Shared expert weight mismatch: kernel={shared_weights[0].item():.6f}, ref={ref_shared_weights[0].item():.6f}"
+
+    # Verify shared expert IDs are in valid range
+    shared_ids = indices[:, routed_topk:]
+    assert (shared_ids >= num_experts).all(), "Shared expert IDs must be >= num_experts"
+    assert (
+        shared_ids < num_experts + num_fused_shared_experts
+    ).all(), "Shared expert IDs must be < num_experts + num_fused_shared_experts"
 
 
 if __name__ == "__main__":

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -65,7 +65,6 @@ from sglang.srt.utils import (
     is_npu,
     is_xpu,
 )
-from sglang.srt.utils.patch_torch import register_fake_if_exists
 
 if TYPE_CHECKING:
     from sglang.srt.layers.quantization import QuantizationConfig
@@ -120,9 +119,11 @@ if _is_cuda:
         fused_topk_deepseek = None
 
     try:
-        from sgl_kernel import kimi_k2_moe_fused_gate
-    except ImportError as e:
-        pass
+        from sglang.jit_kernel.moe_fused_gate_ungrouped import (
+            moe_fused_gate_ungrouped,
+        )
+    except ImportError:
+        moe_fused_gate_ungrouped = None
 
 if _is_cuda or _is_hip or _is_xpu:
     from sgl_kernel import topk_softmax
@@ -698,24 +699,28 @@ def biased_grouped_topk_impl(
     num_token = scores.shape[0]
     num_experts = scores.shape[1]
     scores_for_choice = scores.view(num_token, -1) + correction_bias.unsqueeze(0)
-    group_scores = (
-        scores_for_choice.view(num_token, num_expert_group, -1)
-        .topk(2, dim=-1)[0]
-        .sum(dim=-1)
-    )  # [n, n_group]
-    group_idx = torch.topk(group_scores, k=topk_group, dim=-1, sorted=False)[
-        1
-    ]  # [n, top_k_group]
-    group_mask = torch.zeros_like(group_scores)  # [n, n_group]
-    group_mask.scatter_(1, group_idx, 1)  # [n, n_group]
-    score_mask = (
-        group_mask.unsqueeze(-1)
-        .expand(num_token, num_expert_group, scores.shape[-1] // num_expert_group)
-        .reshape(num_token, -1)
-    )  # [n, e]
-    tmp_scores = scores_for_choice.masked_fill(
-        ~score_mask.bool(), float("-inf")
-    )  # [n, e]
+
+    # Optimized path for num_expert_group=1: skip group masking
+    if num_expert_group == 1:
+        tmp_scores = scores_for_choice
+    else:
+        group_scores = (
+            scores_for_choice.view(num_token, num_expert_group, -1)
+            .topk(2, dim=-1)[0]
+            .sum(dim=-1)
+        )  # [n, n_group]
+        group_idx = torch.topk(group_scores, k=topk_group, dim=-1, sorted=False)[
+            1
+        ]  # [n, top_k_group]
+        group_mask = torch.zeros_like(group_scores)  # [n, n_group]
+        group_mask.scatter_(1, group_idx, 1)  # [n, n_group]
+        score_mask = (
+            group_mask.unsqueeze(-1)
+            .expand(num_token, num_expert_group, scores.shape[-1] // num_expert_group)
+            .reshape(num_token, -1)
+        )  # [n, e]
+        tmp_scores = scores_for_choice.masked_fill(~score_mask.bool(), float("-inf"))
+
     _, topk_ids = torch.topk(
         tmp_scores,
         k=topk,
@@ -773,6 +778,54 @@ def _biased_grouped_topk_postprocess(
     topk_ids = topk_ids_logical_to_physical(topk_ids, expert_location_dispatch_info)
     _mask_topk_ids_padded_region(topk_ids, num_token_non_padded)
     return topk_ids
+
+
+def _biased_grouped_topk_ungrouped(
+    gating_output: torch.Tensor,
+    correction_bias: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    num_fused_shared_experts: int,
+    routed_scaling_factor: Optional[float],
+    apply_routed_scaling_factor_on_output: Optional[bool],
+):
+    num_rows = gating_output.shape[0]
+    num_experts = gating_output.shape[1]
+    routed_topk = topk - num_fused_shared_experts
+
+    # Pre-allocate full-size tensors (routed + shared expert slots)
+    # Kernel uses output.size(1) as row stride, only fills first routed_topk columns
+    output = torch.empty(
+        (num_rows, topk), dtype=torch.float32, device=gating_output.device
+    )
+    indices = torch.empty(
+        (num_rows, topk), dtype=torch.int32, device=gating_output.device
+    )
+
+    moe_fused_gate_ungrouped(
+        gating_output.to(dtype=torch.float32),
+        correction_bias,
+        topk=routed_topk,
+        renormalize=renormalize,
+        routed_scaling_factor=routed_scaling_factor,
+        apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
+        output=output,
+        indices=indices,
+    )
+
+    # Fill shared expert slots in-place (no cat needed)
+    if num_fused_shared_experts > 0:
+        sf = routed_scaling_factor if routed_scaling_factor is not None else 1.0
+        output[:, routed_topk:] = output[:, :routed_topk].sum(dim=-1, keepdim=True) / sf
+        indices[:, routed_topk:] = torch.randint(
+            low=num_experts,
+            high=num_experts + num_fused_shared_experts,
+            size=(num_rows, num_fused_shared_experts),
+            dtype=torch.int32,
+            device=gating_output.device,
+        )
+
+    return output, indices
 
 
 def biased_grouped_topk_gpu(
@@ -890,16 +943,21 @@ def biased_grouped_topk_gpu(
         )
         return topk_weights, topk_ids
     else:
-        # Use optimized path for Kimi K2 (384 experts with num_expert_group=1)
-        num_experts = gating_output.shape[1]
-        if _is_cuda and num_experts == 384 and num_expert_group == 1:
-            return kimi_k2_moe_fused_gate(
-                gating_output.to(dtype=torch.float32),
+        # Use optimized path for ungrouped MoE (num_expert_group=1) with 256 or 384 experts
+        if (
+            _is_cuda
+            and moe_fused_gate_ungrouped is not None
+            and num_expert_group == 1
+            and num_experts in (256, 384)
+        ):
+            return _biased_grouped_topk_ungrouped(
+                gating_output,
                 correction_bias,
-                topk=topk,
-                renormalize=renormalize,
-                routed_scaling_factor=routed_scaling_factor,
-                apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
+                topk,
+                renormalize,
+                num_fused_shared_experts,
+                routed_scaling_factor,
+                apply_routed_scaling_factor_on_output,
             )
         else:
             return biased_grouped_topk_impl(
@@ -1208,27 +1266,5 @@ if _is_cuda:
         )
         topk_ids = torch.empty(
             (num_rows, topk), dtype=torch.int32, device=input_tensor.device
-        )
-        return topk_weights, topk_ids
-
-    @register_fake_if_exists("sgl_kernel::kimi_k2_moe_fused_gate")
-    def _kimi_k2_moe_fused_gate(
-        input_tensor,
-        bias,
-        topk,
-        renormalize,
-        routed_scaling_factor,
-        apply_routed_scaling_factor_on_output,
-    ):
-        num_rows = input_tensor.shape[0]
-        topk_weights = input_tensor.new_empty(
-            num_rows,
-            topk,
-            dtype=torch.float32,
-        )
-        topk_ids = input_tensor.new_empty(
-            num_rows,
-            topk,
-            dtype=torch.int32,
         )
         return topk_weights, topk_ids

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -1070,15 +1070,19 @@ def _biased_grouped_topk_ungrouped(
     moe_fused_gate_ungrouped(
         gating_output.to(dtype=torch.float32),
         correction_bias,
-        topk=routed_topk,
-        renormalize=renormalize,
-        routed_scaling_factor=routed_scaling_factor,
-        apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
-        output=output,
-        indices=indices,
+        routed_topk,
+        renormalize,
+        routed_scaling_factor if routed_scaling_factor is not None else 1.0,
+        apply_routed_scaling_factor_on_output,
+        output,
+        indices,
     )
 
-    # Fill shared expert slots in-place (no cat needed)
+    # Fill shared expert slots in-place (no cat needed).
+    # Shared expert weight = sum(routed_weights) / routed_scaling_factor.
+    # After kernel renormalization, sum(routed) = 1.0 (or *= rsf when
+    # apply_routed_scaling_factor_on_output is True), so shared weight equals
+    # 1/sf (or rsf/sf = 1.0), matching biased_grouped_topk_impl's semantics.
     if num_fused_shared_experts > 0:
         sf = routed_scaling_factor if routed_scaling_factor is not None else 1.0
         output[:, routed_topk:] = output[:, :routed_topk].sum(dim=-1, keepdim=True) / sf
@@ -1223,12 +1227,13 @@ def biased_grouped_topk_gpu(
             apply_routed_scaling_factor_on_output,
         )
     else:
-        # Use optimized path for ungrouped MoE (num_expert_group=1) with 256 or 384 experts
+        # Use optimized path for ungrouped MoE (num_expert_group=1)
         if (
             _is_cuda
             and moe_fused_gate_ungrouped is not None
             and num_expert_group == 1
-            and num_experts in (256, 384)
+            and num_experts % 128 == 0
+            and topk_routed <= 8
         ):
             return _biased_grouped_topk_ungrouped(
                 gating_output,

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -111,7 +111,6 @@ from sglang.srt.utils import (
     is_npu,
     is_xpu,
 )
-from sglang.srt.utils.patch_torch import register_fake_if_exists
 
 if TYPE_CHECKING:
     from sglang.srt.layers.quantization import QuantizationConfig
@@ -167,9 +166,11 @@ if _is_cuda:
         fused_topk_deepseek = None
 
     try:
-        from sgl_kernel import kimi_k2_moe_fused_gate
-    except ImportError as e:
-        pass
+        from sglang.jit_kernel.moe_fused_gate_ungrouped import (
+            moe_fused_gate_ungrouped,
+        )
+    except ImportError:
+        moe_fused_gate_ungrouped = None
 
 if _is_cuda or _is_hip or _is_xpu:
     from sgl_kernel import topk_softmax
@@ -959,24 +960,28 @@ def biased_grouped_topk_impl(
     num_token = scores.shape[0]
     num_experts = scores.shape[1]
     scores_for_choice = scores.view(num_token, -1) + correction_bias.unsqueeze(0)
-    group_scores = (
-        scores_for_choice.view(num_token, num_expert_group, -1)
-        .topk(2, dim=-1)[0]
-        .sum(dim=-1)
-    )  # [n, n_group]
-    group_idx = torch.topk(group_scores, k=topk_group, dim=-1, sorted=False)[
-        1
-    ]  # [n, top_k_group]
-    group_mask = torch.zeros_like(group_scores)  # [n, n_group]
-    group_mask.scatter_(1, group_idx, 1)  # [n, n_group]
-    score_mask = (
-        group_mask.unsqueeze(-1)
-        .expand(num_token, num_expert_group, scores.shape[-1] // num_expert_group)
-        .reshape(num_token, -1)
-    )  # [n, e]
-    tmp_scores = scores_for_choice.masked_fill(
-        ~score_mask.bool(), float("-inf")
-    )  # [n, e]
+
+    # Optimized path for num_expert_group=1: skip group masking
+    if num_expert_group == 1:
+        tmp_scores = scores_for_choice
+    else:
+        group_scores = (
+            scores_for_choice.view(num_token, num_expert_group, -1)
+            .topk(2, dim=-1)[0]
+            .sum(dim=-1)
+        )  # [n, n_group]
+        group_idx = torch.topk(group_scores, k=topk_group, dim=-1, sorted=False)[
+            1
+        ]  # [n, top_k_group]
+        group_mask = torch.zeros_like(group_scores)  # [n, n_group]
+        group_mask.scatter_(1, group_idx, 1)  # [n, n_group]
+        score_mask = (
+            group_mask.unsqueeze(-1)
+            .expand(num_token, num_expert_group, scores.shape[-1] // num_expert_group)
+            .reshape(num_token, -1)
+        )  # [n, e]
+        tmp_scores = scores_for_choice.masked_fill(~score_mask.bool(), float("-inf"))
+
     _, topk_ids = torch.topk(
         tmp_scores,
         k=topk,
@@ -1038,6 +1043,54 @@ def _biased_grouped_topk_postprocess(
     topk_ids = topk_ids_logical_to_physical(topk_ids, expert_location_dispatch_info)
     _mask_topk_ids_padded_region(topk_ids, num_token_non_padded)
     return topk_ids
+
+
+def _biased_grouped_topk_ungrouped(
+    gating_output: torch.Tensor,
+    correction_bias: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    num_fused_shared_experts: int,
+    routed_scaling_factor: Optional[float],
+    apply_routed_scaling_factor_on_output: Optional[bool],
+):
+    num_rows = gating_output.shape[0]
+    num_experts = gating_output.shape[1]
+    routed_topk = topk - num_fused_shared_experts
+
+    # Pre-allocate full-size tensors (routed + shared expert slots)
+    # Kernel uses output.size(1) as row stride, only fills first routed_topk columns
+    output = torch.empty(
+        (num_rows, topk), dtype=torch.float32, device=gating_output.device
+    )
+    indices = torch.empty(
+        (num_rows, topk), dtype=torch.int32, device=gating_output.device
+    )
+
+    moe_fused_gate_ungrouped(
+        gating_output.to(dtype=torch.float32),
+        correction_bias,
+        topk=routed_topk,
+        renormalize=renormalize,
+        routed_scaling_factor=routed_scaling_factor,
+        apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
+        output=output,
+        indices=indices,
+    )
+
+    # Fill shared expert slots in-place (no cat needed)
+    if num_fused_shared_experts > 0:
+        sf = routed_scaling_factor if routed_scaling_factor is not None else 1.0
+        output[:, routed_topk:] = output[:, :routed_topk].sum(dim=-1, keepdim=True) / sf
+        indices[:, routed_topk:] = torch.randint(
+            low=num_experts,
+            high=num_experts + num_fused_shared_experts,
+            size=(num_rows, num_fused_shared_experts),
+            dtype=torch.int32,
+            device=gating_output.device,
+        )
+
+    return output, indices
 
 
 def biased_grouped_topk_gpu(
@@ -1170,16 +1223,21 @@ def biased_grouped_topk_gpu(
             apply_routed_scaling_factor_on_output,
         )
     else:
-        # Use optimized path for Kimi K2 (384 experts with num_expert_group=1)
-        num_experts = gating_output.shape[1]
-        if _is_cuda and num_experts == 384 and num_expert_group == 1:
-            return kimi_k2_moe_fused_gate(
-                gating_output.to(dtype=torch.float32),
+        # Use optimized path for ungrouped MoE (num_expert_group=1) with 256 or 384 experts
+        if (
+            _is_cuda
+            and moe_fused_gate_ungrouped is not None
+            and num_expert_group == 1
+            and num_experts in (256, 384)
+        ):
+            return _biased_grouped_topk_ungrouped(
+                gating_output,
                 correction_bias,
-                topk=topk,
-                renormalize=renormalize,
-                routed_scaling_factor=routed_scaling_factor,
-                apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
+                topk,
+                renormalize,
+                num_fused_shared_experts,
+                routed_scaling_factor,
+                apply_routed_scaling_factor_on_output,
             )
         elif (
             _is_cuda
@@ -1566,27 +1624,5 @@ if _is_cuda:
         )
         topk_ids = torch.empty(
             (num_rows, topk), dtype=torch.int32, device=input_tensor.device
-        )
-        return topk_weights, topk_ids
-
-    @register_fake_if_exists("sgl_kernel::kimi_k2_moe_fused_gate")
-    def _kimi_k2_moe_fused_gate(
-        input_tensor,
-        bias,
-        topk,
-        renormalize,
-        routed_scaling_factor,
-        apply_routed_scaling_factor_on_output,
-    ):
-        num_rows = input_tensor.shape[0]
-        topk_weights = input_tensor.new_empty(
-            num_rows,
-            topk,
-            dtype=torch.float32,
-        )
-        topk_ids = input_tensor.new_empty(
-            num_rows,
-            topk,
-            dtype=torch.int32,
         )
         return topk_weights, topk_ids


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

GLM-5 uses a MoE architecture with 256 experts and `num_expert_group=1`, which shares the same ungrouped gating pattern as Kimi K2 (384 experts). However, the previous PyTorch implementation in `biased_grouped_topk_impl` performs two sequential `torch.topk` calls (group-level topk + expert-level topk), which is unnecessarily expensive when `num_expert_group=1` — the group-level topk is redundant since there is only one group.

This PR:
1. Generalizes the `kimi_k2_moe_fused_gate` fused CUDA kernel to support both 256 (GLM-5) and 384 (Kimi K2) experts via template specialization, replacing the two `torch.topk` calls with a single fused sigmoid + bias + topk kernel.
2. Ports the kernel from `sgl-kernel` (AOT) to `jit_kernel` (JIT) for faster iteration — no separate package release needed.
3. Adds `output_stride` support to pre-allocate shared expert slots in the output tensor.


## Modifications

- **New**: `python/sglang/jit_kernel/csrc/moe/moe_fused_gate_ungrouped.cu` — Templated CUDA kernel (`NUM_EXPERTS=256/384`) with two variants: small-token path (multi-warp collaborative topk, ≤512 tokens) and large-token path (vectorized float4 loads, one warp per token). Supports `output_stride` for pre-reserved shared expert slots.
- **New**: `python/sglang/jit_kernel/moe_fused_gate_ungrouped.py` — Python JIT wrapper with `@cache_once` per-expert-count compilation and optional pre-allocated output tensors.
- **New**: `python/sglang/jit_kernel/tests/test_moe_fused_gate_ungrouped.py` — Tests covering both expert counts, small/large token paths, output_stride mode, and shared expert verification.
- **Modified**: `python/sglang/srt/layers/moe/topk.py` — Added `moe_fused_gate_ungrouped` JIT kernel path for `num_expert_group=1` with 256/384 experts; extracted `_biased_grouped_topk_ungrouped` helper with in-place shared expert slot filling.

## Accuracy Tests

**GSM8K** (GLM-5, cp8, mtp):
```
Accuracy: 0.950
Invalid: 0.000
Latency: 267.619 s
Output throughput: 505.042 token/s
```

**MMLU** (GLM-5, cp8, mtp):
```
subject: abstract_algebra, #q:100, acc: 0.870
subject: anatomy, #q:135, acc: 0.874
subject: astronomy, #q:152, acc: 0.941
subject: business_ethics, #q:100, acc: 0.870
subject: clinical_knowledge, #q:265, acc: 0.925
subject: college_biology, #q:144, acc: 0.972
subject: college_chemistry, #q:100, acc: 0.660
subject: college_computer_science, #q:100, acc: 0.870
subject: college_mathematics, #q:100, acc: 0.780
subject: college_medicine, #q:173, acc: 0.873
subject: college_physics, #q:102, acc: 0.912
subject: computer_security, #q:100, acc: 0.890
subject: conceptual_physics, #q:235, acc: 0.928
subject: econometrics, #q:114, acc: 0.807
subject: electrical_engineering, #q:145, acc: 0.897
subject: elementary_mathematics, #q:378, acc: 0.937
subject: formal_logic, #q:126, acc: 0.778
subject: global_facts, #q:100, acc: 0.740
subject: high_school_biology, #q:310, acc: 0.965
subject: high_school_chemistry, #q:203, acc: 0.847
subject: high_school_computer_science, #q:100, acc: 0.940
subject: high_school_european_history, #q:165, acc: 0.891
subject: high_school_geography, #q:198, acc: 0.955
subject: high_school_government_and_politics, #q:193, acc: 0.984
subject: high_school_macroeconomics, #q:390, acc: 0.921
subject: high_school_mathematics, #q:270, acc: 0.726
subject: high_school_microeconomics, #q:238, acc: 0.966
subject: high_school_physics, #q:151, acc: 0.834
subject: high_school_psychology, #q:545, acc: 0.952
subject: high_school_statistics, #q:216, acc: 0.880
subject: high_school_us_history, #q:204, acc: 0.941
subject: high_school_world_history, #q:237, acc: 0.941
subject: human_aging, #q:223, acc: 0.852
subject: human_sexuality, #q:131, acc: 0.908
subject: international_law, #q:121, acc: 0.942
subject: jurisprudence, #q:108, acc: 0.898
subject: logical_fallacies, #q:163, acc: 0.926
subject: machine_learning, #q:112, acc: 0.839
subject: management, #q:103, acc: 0.922
subject: marketing, #q:234, acc: 0.949
subject: medical_genetics, #q:100, acc: 0.970
subject: miscellaneous, #q:783, acc: 0.964
subject: moral_disputes, #q:346, acc: 0.864
subject: moral_scenarios, #q:895, acc: 0.840
subject: nutrition, #q:306, acc: 0.915
subject: philosophy, #q:311, acc: 0.900
subject: prehistory, #q:324, acc: 0.932
subject: professional_accounting, #q:282, acc: 0.826
subject: professional_law, #q:1534, acc: 0.716
subject: professional_medicine, #q:272, acc: 0.945
subject: professional_psychology, #q:612, acc: 0.908
subject: public_relations, #q:110, acc: 0.800
subject: security_studies, #q:245, acc: 0.869
subject: sociology, #q:201, acc: 0.935
subject: us_foreign_policy, #q:100, acc: 0.930
subject: virology, #q:166, acc: 0.602
subject: world_religions, #q:171, acc: 0.936
Total latency: 1274.834
Average accuracy: 0.877
```

## Speed Tests and Profiling

Benchmark config: cp8, mtp, input 64K/128K tokens, output 128 tokens, concurrency 1, 100 requests.

| Input Length | TTFT Before (ms) | TTFT After (ms) | TPOT Before (ms) | TPOT After (ms) |
|:---:|:---:|:---:|:---:|:---:|
| 64K | 6515.79 | 6241.90 (**-4.2%**) | 9.48 | 9.04 (**-4.6%**) |
| 128K | 15400.02 | 14864.32 (**-3.5%**) | 10.21 | 9.73 (**-4.7%**) |

The improvement comes from replacing two `torch.topk` calls (group-level + expert-level) with a single fused CUDA kernel that combines sigmoid activation, bias addition, and topk selection in one pass.

Before PR:
<img width="2326" height="772" alt="image" src="https://github.com/user-attachments/assets/4a2a1273-6dcf-457a-a5e2-a8e98428c81e" />

After PR:
<img width="2076" height="440" alt="image" src="https://github.com/user-attachments/assets/de8ff3bc-d541-48c4-89d9-d2c9d5035f69" />

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26505014082](https://github.com/sgl-project/sglang/actions/runs/26505014082)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26505014215](https://github.com/sgl-project/sglang/actions/runs/26505014215)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->