### PR TITLE
[diffusion] split ModelOpt FP8 skill and tools from runtime PR

### DIFF
--- a/docs/diffusion/quantization.md
+++ b/docs/diffusion/quantization.md
@@ -81,6 +81,8 @@ sglang generate \
 - `dit_cpu_offload` and `dit_layerwise_offload` are automatically disabled for
   ModelOpt FP8 checkpoints because the runtime expects the transformed FP8
   weights to remain GPU-resident in their column-major layout.
+- To build the converted checkpoint yourself from a ModelOpt diffusers export,
+  use `python -m sglang.multimodal_gen.tools.convert_modelopt_fp8_checkpoint`.
 
 ## NVFP4
 

--- a/python/sglang/multimodal_gen/.claude/skills/sglang-diffusion-modelopt-quant/SKILL.md
+++ b/python/sglang/multimodal_gen/.claude/skills/sglang-diffusion-modelopt-quant/SKILL.md
@@ -1,0 +1,289 @@
+---
+name: sglang-diffusion-modelopt-quant
+description: Use when quantizing a diffusion DiT with NVIDIA ModelOpt and making the resulting FP8 or NVFP4 checkpoint loadable, verifiable, and benchmarkable in SGLang Diffusion.
+---
+
+# SGLang Diffusion ModelOpt Quant
+
+Use this skill when the task is:
+- quantize a diffusion transformer with NVIDIA ModelOpt
+- adapt the exported checkpoint to SGLang Diffusion
+- validate that quality remains acceptable
+- benchmark whether the quantized checkpoint is actually faster
+
+This skill owns the ModelOpt-to-SGLang bridge. It is not a generic kernel-tuning skill.
+
+## Core Rules
+
+- Use ModelOpt's official `quantize.py` as the source of truth for PTQ.
+- Keep the workflow generic. Put model-specific constraints in short notes, not in the main procedure.
+- Benchmark only when BF16 and quantized commands are identical except for the checkpoint override being tested.
+- For diffusion FP8, pin `dit_cpu_offload=false` and `dit_layerwise_offload=false`.
+- For multi-transformer pipelines, use per-component overrides if different components need different checkpoints.
+
+## Read First
+
+Read these sources before changing code:
+- NVIDIA ModelOpt diffusers guide: `examples/diffusers/README.md`
+- ModelOpt quantization entrypoint: `examples/diffusers/quantization/quantize.py`
+- ModelOpt diffusers quant presets: `examples/diffusers/quantization/config.py`
+- SGLang diffusion quant runtime:
+  - `python/sglang/multimodal_gen/runtime/layers/quantization/modelopt_quant.py`
+  - `python/sglang/multimodal_gen/runtime/utils/quantization_utils.py`
+  - `python/sglang/multimodal_gen/runtime/loader/transformer_load_utils.py`
+- Existing FLUX.2 NVFP4 reference: `https://github.com/sgl-project/sglang/pull/20137`
+
+## What SGLang Supports Here
+
+This repo now contains:
+- flat `quant_method=modelopt` plus `quant_algo=FP8/NVFP4` resolution
+- diffusion-side ModelOpt FP8 linear loading
+- diffusion-side NVFP4 loading from ModelOpt exports
+- FLUX.2 packed-QKV detection that distinguishes packed NVFP4 checkpoints from standard diffusers exports
+- automatic protection against incompatible FP8 offload modes
+- FP8 export conversion:
+  [`python/sglang/multimodal_gen/tools/convert_modelopt_fp8_checkpoint.py`](../../../tools/convert_modelopt_fp8_checkpoint.py)
+- trajectory similarity validation:
+  [`python/sglang/multimodal_gen/tools/compare_diffusion_trajectory_similarity.py`](../../../tools/compare_diffusion_trajectory_similarity.py)
+
+## FP8 Vs NVFP4
+
+FP8 and NVFP4 are not wired into SGLang in exactly the same way.
+
+FP8:
+- the validated ModelOpt diffusers FP8 export still needs an extra SGLang-side conversion step
+- SGLang expects explicit `weight_scale` and `input_scale`
+- the validated path also materializes SGLang-native `float8_e4m3fn` weights from `backbone.pt`
+
+NVFP4:
+- the official diffusers export often already contains the packed FP4 weights, scale tensors, and enough safetensors metadata for SGLang to rebuild the quant config
+- in that case SGLang mainly needs to detect the checkpoint family and rearrange tensors into the runtime layout
+- this is why NVFP4 often does not need an extra offline conversion pass like FP8 does
+
+Important caveat:
+- "often" does not mean "always"
+- the exact load path still depends on the checkpoint family, especially whether a model uses a packed-QKV layout
+
+## Generic Workflow
+
+### 1. Verify The BF16 Baseline First
+
+Before quantizing anything:
+- run the original BF16 model in SGLang
+- fix the prompt, seed, size, steps, and GPU topology
+- save the output and `perf.json`
+
+Do not start quantization work until the BF16 path is already healthy.
+
+### 2. Quantize With Official ModelOpt
+
+Use ModelOpt's official script. Generic template:
+
+```bash
+python quantize.py \
+  --model <model-name> \
+  --override-model-path <hf-repo-or-local-model> \
+  --model-dtype <Half|BFloat16> \
+  --format <fp8|nvfp4> \
+  --batch-size 1 \
+  --calib-size <calib-size> \
+  --n-steps <calib-steps> \
+  --quantize-mha \
+  --prompts-file <prompt-file> \
+  --quantized-torch-ckpt-save-path <out>/ckpt \
+  --hf-ckpt-dir <out>/hf
+```
+
+For multi-transformer models, quantize each backbone deliberately:
+- if ModelOpt supports quantizing all target backbones in one run, use that
+- otherwise quantize/export per backbone and keep each output directory separate
+
+Keep these outputs:
+- `backbone.pt`
+- `hf/<component>`
+
+### 3. Convert FP8 Exports For SGLang
+
+FP8 requires an extra conversion step:
+
+```bash
+PYTHONPATH=python python3 -m sglang.multimodal_gen.tools.convert_modelopt_fp8_checkpoint \
+  --modelopt-hf-dir <out>/hf \
+  --modelopt-backbone-ckpt <out>/ckpt/backbone.pt \
+  --base-transformer-dir <base-model-transformer-dir> \
+  --output-dir <out>/sglang_transformer \
+  --overwrite
+```
+
+What the converter does:
+- reads `weight_quantizer._amax` and `input_quantizer._amax` from `backbone.pt`
+- writes `weight_scale` and `input_scale`
+- materializes eligible FP8 weights as `float8_e4m3fn`
+- preserves ModelOpt `ignore` layers as BF16
+
+For multi-transformer models:
+- run the converter once per exported backbone
+- keep each converted component in its own output directory
+
+### 4. Load The Quantized Checkpoint In SGLang
+
+Single-transformer example:
+
+```bash
+sglang generate \
+  --model-path <base-model> \
+  --transformer-path <quantized-transformer> \
+  --prompt "<prompt>" \
+  --seed <seed> \
+  --save-output
+```
+
+Multi-transformer example:
+
+```bash
+sglang generate \
+  --model-path <base-model> \
+  --transformer-path <quantized-transformer> \
+  --transformer-2-path <another-transformer-or-bf16-override> \
+  --prompt "<prompt>" \
+  --seed <seed> \
+  --save-output
+```
+
+Guideline:
+- use the global `--transformer-path` only when the model effectively has one transformer override to apply
+- use per-component overrides when different backbones need different checkpoints
+- the preferred CLI form is `--<component>-path`
+- config-expanded forms such as `--component_paths.transformer_2=...` also resolve to the same internal override map
+
+### 5. Validate Accuracy
+
+Use two levels of validation.
+
+Reduced deterministic validation:
+- use a small fixed configuration first
+- compare BF16 and quantized runs with identical prompt and seed
+- capture denoising trajectories
+- compare:
+  - per-step latent cosine similarity
+  - latent MAE / RMSE
+  - final image or frame PSNR / MAE
+
+Tool:
+
+```bash
+PYTHONPATH=python python3 -m sglang.multimodal_gen.tools.compare_diffusion_trajectory_similarity \
+  ...
+```
+
+Full-output validation:
+- run the same user-facing generation config in BF16 and quantized mode
+- inspect the output visually
+- for images, compare the final image directly
+- for videos, compare representative frames and, when practical, aggregate all-frame metrics
+
+### 6. Benchmark Correctly
+
+Benchmark only when these match between BF16 and quantized:
+- prompt
+- seed
+- width and height
+- number of frames
+- number of inference steps
+- GPU count and topology
+- offload flags
+- compile settings
+- profiler settings
+
+Only the quantized checkpoint path should differ.
+
+Interpretation rule:
+- the primary expected gain is in denoising
+- text-encoding and VAE differences are secondary and should not be over-attributed unless they were quantized too
+
+## FP8 Offload Constraint
+
+Current diffusion ModelOpt FP8 support requires:
+- `dit_cpu_offload=false`
+- `dit_layerwise_offload=false`
+
+Reason:
+- the FP8 linear path depends on a CUTLASS-compatible weight layout after loading
+- the offload and restore path does not preserve that layout
+- in particular, layerwise offload can flatten and rebuild FP8 weights in a way that breaks the column-major requirement used by the FP8 GEMM path
+
+Runtime behavior:
+- SGLang currently force-disables these two flags when it detects `modelopt_fp8`
+- benchmark commands should still pin them explicitly so the command line itself makes the comparison rule obvious
+
+## Reference Examples
+
+Keep examples short and treat them as references, not as the main workflow.
+
+### FLUX.2
+
+Validated reference for:
+- ModelOpt FP8
+- ModelOpt NVFP4
+
+Base model:
+- `black-forest-labs/FLUX.2-dev`
+
+Published SGLang-ready FP8 override:
+- `https://huggingface.co/BBuf/flux2-dev-modelopt-fp8-sglang-transformer`
+
+Typical load pattern:
+
+```bash
+sglang generate \
+  --model-path black-forest-labs/FLUX.2-dev \
+  --transformer-path BBuf/flux2-dev-modelopt-fp8-sglang-transformer \
+  ...
+```
+
+### WAN2.2
+
+Validated benchmarked path:
+- quantized primary `transformer`
+- BF16 `transformer_2`
+
+Base model:
+- `Wan-AI/Wan2.2-T2V-A14B-Diffusers`
+
+Published SGLang-ready FP8 override:
+- `https://huggingface.co/BBuf/wan22-t2v-a14b-modelopt-fp8-sglang-transformer`
+
+Typical load pattern:
+
+```bash
+sglang generate \
+  --model-path Wan-AI/Wan2.2-T2V-A14B-Diffusers \
+  --transformer-path BBuf/wan22-t2v-a14b-modelopt-fp8-sglang-transformer \
+  --dit-cpu-offload false \
+  --dit-layerwise-offload false \
+  ...
+```
+
+If you later validate dual-transformer quantization:
+- keep `transformer` and `transformer_2` outputs separate
+- load them with per-component overrides
+- do not describe that as equivalent to the current single-transformer benchmarked path unless it was benchmarked separately
+
+## Claim Discipline
+
+When documenting results:
+- claim only scopes that were actually validated end-to-end
+- do not collapse "primary-transformer FP8" into "full model FP8"
+- do not call a practical deployment comparison a benchmark if BF16 and quantized commands used different offload behavior
+
+## Current Code Areas
+
+| File | Role |
+| --- | --- |
+| `runtime/layers/quantization/__init__.py` | registers diffusion quant methods |
+| `runtime/layers/quantization/modelopt_quant.py` | ModelOpt FP8 and NVFP4 runtime loading |
+| `runtime/utils/quantization_utils.py` | resolves flat ModelOpt configs and reconstructs NVFP4 config from metadata |
+| `runtime/loader/transformer_load_utils.py` | guards incompatible FP8 offload modes |
+| `runtime/models/dits/flux_2.py` | packed-QKV handling for the packed FLUX.2 NVFP4 family |
+| `tools/convert_modelopt_fp8_checkpoint.py` | FP8 offline conversion into SGLang-native layout |
+| `tools/compare_diffusion_trajectory_similarity.py` | reduced deterministic BF16-vs-quantized validation |

--- a/python/sglang/multimodal_gen/tools/compare_diffusion_trajectory_similarity.py
+++ b/python/sglang/multimodal_gen/tools/compare_diffusion_trajectory_similarity.py
@@ -1,0 +1,487 @@
+"""Compare diffusion BF16 and quantized runs via trajectory-latent similarity.
+
+This tool runs two SGLang diffusion variants with the same prompt and seed,
+captures intermediate denoising latents via `return_trajectory_latents`, and
+reports cosine / error metrics for each timestep plus final frame metrics.
+
+The intended use is quant validation on reduced deterministic smoke settings:
+- same prompt / seed / resolution / step count for both variants
+- BF16 reference on the base model
+- FP8 candidate via `--candidate-transformer-path` and/or component overrides
+
+Example:
+
+    python -m sglang.multimodal_gen.tools.compare_diffusion_trajectory_similarity \
+        --model-path /path/to/model \
+        --prompt "A futuristic cyberpunk city at night" \
+        --width 512 --height 512 --num-inference-steps 8 --seed 42 \
+        --text-encoder-cpu-offload \
+        --candidate-transformer-path /tmp/modelopt_flux2_fp8/sglang_transformer \
+        --output-json /tmp/flux2_similarity.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any, Sequence
+
+import imageio.v3 as iio
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+
+def parse_component_overrides(entries: Sequence[str] | None) -> dict[str, str]:
+    overrides: dict[str, str] = {}
+    for entry in entries or []:
+        if "=" not in entry:
+            raise ValueError(
+                f"Invalid component override '{entry}'. Expected format component=path."
+            )
+        component, path = entry.split("=", 1)
+        component = component.strip().replace("-", "_")
+        path = path.strip()
+        if not component or not path:
+            raise ValueError(
+                f"Invalid component override '{entry}'. Expected format component=path."
+            )
+        overrides[component] = path
+    return overrides
+
+
+def _cosine_similarity(flat_a: torch.Tensor, flat_b: torch.Tensor) -> float:
+    norm_a = torch.linalg.vector_norm(flat_a).item()
+    norm_b = torch.linalg.vector_norm(flat_b).item()
+    if norm_a == 0.0 and norm_b == 0.0:
+        return 1.0
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return float(F.cosine_similarity(flat_a, flat_b, dim=0).item())
+
+
+def compute_tensor_metrics(lhs: Any, rhs: Any) -> dict[str, float]:
+    lhs_tensor = torch.as_tensor(lhs).detach().cpu().float()
+    rhs_tensor = torch.as_tensor(rhs).detach().cpu().float()
+    if lhs_tensor.shape != rhs_tensor.shape:
+        raise ValueError(
+            f"Metric shape mismatch: {tuple(lhs_tensor.shape)} vs {tuple(rhs_tensor.shape)}"
+        )
+
+    diff = lhs_tensor - rhs_tensor
+    mse = float(diff.square().mean().item())
+    rmse = float(math.sqrt(mse))
+    mae = float(diff.abs().mean().item())
+    max_abs = float(diff.abs().max().item())
+    l2 = float(torch.linalg.vector_norm(diff).item())
+    cosine = _cosine_similarity(lhs_tensor.reshape(-1), rhs_tensor.reshape(-1))
+    return {
+        "cosine_similarity": cosine,
+        "mae": mae,
+        "mse": mse,
+        "rmse": rmse,
+        "max_abs": max_abs,
+        "l2": l2,
+    }
+
+
+def compute_uint8_frame_metrics(lhs: Any, rhs: Any) -> dict[str, float]:
+    metrics = compute_tensor_metrics(lhs, rhs)
+    mse = metrics["mse"]
+    metrics["psnr_db"] = (
+        float("inf") if mse == 0.0 else 20 * math.log10(255.0) - 10 * math.log10(mse)
+    )
+    return metrics
+
+
+def _normalize_step_index(step_index: int, num_steps: int) -> int:
+    if num_steps <= 0:
+        raise ValueError("num_steps must be positive.")
+    if step_index < 0:
+        step_index += num_steps
+    if step_index < 0 or step_index >= num_steps:
+        raise IndexError(
+            f"Requested step index {step_index} is outside the valid range [0, {num_steps})."
+        )
+    return step_index
+
+
+def _maybe_scalar(timestep: torch.Tensor | None, index: int) -> float | None:
+    if timestep is None:
+        return None
+    value = timestep[index]
+    if isinstance(value, torch.Tensor):
+        value = value.detach().cpu()
+        if value.numel() == 1:
+            return float(value.item())
+    return float(value)
+
+
+def summarize_trajectory_metrics(
+    reference_latents: Any,
+    candidate_latents: Any,
+    *,
+    reference_timesteps: Any = None,
+    candidate_timesteps: Any = None,
+    step_index: int = -1,
+) -> dict[str, Any]:
+    ref = torch.as_tensor(reference_latents).detach().cpu().float()
+    cand = torch.as_tensor(candidate_latents).detach().cpu().float()
+    if ref.shape != cand.shape:
+        raise ValueError(
+            f"Trajectory shape mismatch: {tuple(ref.shape)} vs {tuple(cand.shape)}"
+        )
+    if ref.ndim < 2:
+        raise ValueError(
+            f"Expected trajectory latents with an explicit timestep dimension, got {tuple(ref.shape)}"
+        )
+
+    num_steps = ref.shape[1]
+    selected_step = _normalize_step_index(step_index, num_steps)
+    ref_t = (
+        torch.as_tensor(reference_timesteps).detach().cpu()
+        if reference_timesteps is not None
+        else None
+    )
+    cand_t = (
+        torch.as_tensor(candidate_timesteps).detach().cpu()
+        if candidate_timesteps is not None
+        else None
+    )
+
+    per_step: list[dict[str, Any]] = []
+    for idx in range(num_steps):
+        metrics = compute_tensor_metrics(ref[:, idx], cand[:, idx])
+        metrics["step_index"] = idx
+        metrics["reference_timestep"] = _maybe_scalar(ref_t, idx)
+        metrics["candidate_timestep"] = _maybe_scalar(cand_t, idx)
+        per_step.append(metrics)
+
+    return {
+        "trajectory_shape": list(ref.shape),
+        "num_steps": num_steps,
+        "selected_step_index": selected_step,
+        "selected_step_metrics": per_step[selected_step],
+        "per_step_metrics": per_step,
+    }
+
+
+def summarize_output_frame_metrics(
+    reference_frames: Sequence[Any],
+    candidate_frames: Sequence[Any],
+) -> dict[str, Any]:
+    if len(reference_frames) != len(candidate_frames):
+        raise ValueError(
+            f"Output frame count mismatch: {len(reference_frames)} vs {len(candidate_frames)}"
+        )
+    if not reference_frames:
+        raise ValueError("No output frames available for comparison.")
+
+    ref_stack = np.stack([np.asarray(frame) for frame in reference_frames], axis=0)
+    cand_stack = np.stack([np.asarray(frame) for frame in candidate_frames], axis=0)
+
+    frame0_metrics = compute_uint8_frame_metrics(ref_stack[0], cand_stack[0])
+    mid_index = len(reference_frames) // 2
+    mid_metrics = compute_uint8_frame_metrics(
+        ref_stack[mid_index], cand_stack[mid_index]
+    )
+    all_metrics = compute_uint8_frame_metrics(ref_stack, cand_stack)
+
+    return {
+        "num_frames": len(reference_frames),
+        "frame0_metrics": frame0_metrics,
+        "mid_frame_index": mid_index,
+        "mid_frame_metrics": mid_metrics,
+        "all_frames_metrics": all_metrics,
+    }
+
+
+def extract_result_frames(result: Any) -> list[np.ndarray]:
+    if result.frames is not None:
+        return [np.asarray(frame) for frame in result.frames]
+
+    sample = result.samples
+    if sample is None:
+        if result.output_file_path:
+            output_path = Path(result.output_file_path)
+            if not output_path.exists():
+                raise ValueError(
+                    "GenerationResult did not contain frames or samples, and its "
+                    f"output_file_path does not exist: {output_path}"
+                )
+            if output_path.suffix.lower() in {".png", ".jpg", ".jpeg", ".webp"}:
+                return [np.asarray(iio.imread(output_path))]
+            return [np.asarray(frame) for frame in iio.imiter(output_path)]
+        raise ValueError(
+            "GenerationResult did not contain frames, samples, or a readable output_file_path."
+        )
+
+    if isinstance(sample, torch.Tensor):
+        tensor = sample.detach().cpu().float()
+        if tensor.ndim == 3:
+            tensor = tensor.unsqueeze(1)
+        if tensor.ndim != 4:
+            raise ValueError(
+                f"Unsupported tensor sample shape for frame extraction: {tuple(tensor.shape)}"
+            )
+        tensor = (tensor * 255).clamp(0, 255).to(torch.uint8)
+        frames = tensor.permute(1, 2, 3, 0).contiguous().numpy()
+        return [frame for frame in frames]
+
+    array = np.asarray(sample)
+    if array.ndim == 2:
+        array = array[..., None]
+    if array.ndim == 3:
+        if array.shape[-1] in (1, 3, 4):
+            array = array[None, ...]
+        else:
+            array = array[..., None]
+    if array.ndim != 4:
+        raise ValueError(
+            f"Unsupported numpy sample shape for frame extraction: {tuple(array.shape)}"
+        )
+    if array.dtype != np.uint8:
+        array = (np.clip(array, 0.0, 1.0) * 255.0).astype(np.uint8)
+    return [frame for frame in array]
+
+
+def build_server_kwargs(args: argparse.Namespace, *, variant: str) -> dict[str, Any]:
+    component_paths = parse_component_overrides(
+        getattr(args, f"{variant}_component_path") or []
+    )
+    transformer_path = getattr(args, f"{variant}_transformer_path")
+
+    kwargs: dict[str, Any] = {
+        "model_path": args.model_path,
+        "num_gpus": args.num_gpus,
+        "dit_cpu_offload": args.dit_cpu_offload,
+        "dit_layerwise_offload": args.dit_layerwise_offload,
+        "text_encoder_cpu_offload": args.text_encoder_cpu_offload,
+        "vae_cpu_offload": args.vae_cpu_offload,
+        "pin_cpu_memory": args.pin_cpu_memory,
+        "enable_cfg_parallel": args.enable_cfg_parallel,
+        "ulysses_degree": args.ulysses_degree,
+    }
+    if args.sp_degree is not None:
+        kwargs["sp_degree"] = args.sp_degree
+    if transformer_path is not None:
+        kwargs["transformer_weights_path"] = transformer_path
+    if component_paths:
+        kwargs["component_paths"] = component_paths
+    return kwargs
+
+
+def build_sampling_kwargs(
+    args: argparse.Namespace, *, output_dir: str | None = None
+) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "prompt": args.prompt,
+        "width": args.width,
+        "height": args.height,
+        "num_inference_steps": args.num_inference_steps,
+        "guidance_scale": args.guidance_scale,
+        "seed": args.seed,
+        "return_frames": True,
+        "return_trajectory_latents": True,
+        "return_trajectory_decoded": args.return_trajectory_decoded,
+        "save_output": output_dir is not None,
+    }
+    if output_dir is not None:
+        kwargs["output_path"] = output_dir
+    if args.num_frames is not None:
+        kwargs["num_frames"] = args.num_frames
+    if args.guidance_scale_2 is not None:
+        kwargs["guidance_scale_2"] = args.guidance_scale_2
+    return kwargs
+
+
+def run_variant(
+    *,
+    server_kwargs: dict[str, Any],
+    sampling_kwargs: dict[str, Any],
+):
+    from sglang.multimodal_gen.runtime.entrypoints.diffusion_generator import (
+        DiffGenerator,
+    )
+
+    with DiffGenerator.from_pretrained(local_mode=True, **server_kwargs) as generator:
+        result = generator.generate(sampling_params_kwargs=sampling_kwargs)
+
+    if isinstance(result, list):
+        if len(result) != 1:
+            raise ValueError(
+                f"Expected a single generation result, got {len(result)} results."
+            )
+        result = result[0]
+    if result is None:
+        raise RuntimeError("Generation returned no result.")
+    return result
+
+
+def _to_jsonable(result: dict[str, Any]) -> dict[str, Any]:
+    return json.loads(json.dumps(result, allow_nan=True))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-path", required=True)
+    parser.add_argument("--prompt", required=True)
+    parser.add_argument("--output-json", required=True)
+    parser.add_argument("--width", type=int, required=True)
+    parser.add_argument("--height", type=int, required=True)
+    parser.add_argument("--num-frames", type=int)
+    parser.add_argument("--num-inference-steps", type=int, required=True)
+    parser.add_argument("--guidance-scale", type=float, required=True)
+    parser.add_argument("--guidance-scale-2", type=float)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--num-gpus", type=int, default=1)
+    parser.add_argument("--ulysses-degree", type=int, default=1)
+    parser.add_argument("--sp-degree", type=int)
+    parser.add_argument("--trajectory-step-index", type=int, default=-1)
+    parser.add_argument("--reference-transformer-path")
+    parser.add_argument("--candidate-transformer-path")
+    parser.add_argument(
+        "--reference-component-path",
+        action="append",
+        default=[],
+        help="Repeatable component override in the form component=path.",
+    )
+    parser.add_argument(
+        "--candidate-component-path",
+        action="append",
+        default=[],
+        help="Repeatable component override in the form component=path.",
+    )
+    parser.add_argument("--save-output-dir")
+    parser.add_argument(
+        "--return-trajectory-decoded",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+    )
+    parser.add_argument(
+        "--enable-cfg-parallel",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+    )
+    parser.add_argument(
+        "--text-encoder-cpu-offload",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+    )
+    parser.add_argument(
+        "--vae-cpu-offload",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+    )
+    parser.add_argument(
+        "--dit-cpu-offload",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+    )
+    parser.add_argument(
+        "--dit-layerwise-offload",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+    )
+    parser.add_argument(
+        "--pin-cpu-memory",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+    )
+    args = parser.parse_args()
+
+    output_json = Path(args.output_json).expanduser().resolve()
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+
+    save_root: Path | None = None
+    if args.save_output_dir:
+        save_root = Path(args.save_output_dir).expanduser().resolve()
+        save_root.mkdir(parents=True, exist_ok=True)
+
+    ref_server_kwargs = build_server_kwargs(args, variant="reference")
+    cand_server_kwargs = build_server_kwargs(args, variant="candidate")
+
+    ref_sampling_kwargs = build_sampling_kwargs(
+        args,
+        output_dir=str(save_root / "reference") if save_root else None,
+    )
+    cand_sampling_kwargs = build_sampling_kwargs(
+        args,
+        output_dir=str(save_root / "candidate") if save_root else None,
+    )
+
+    reference = run_variant(
+        server_kwargs=ref_server_kwargs,
+        sampling_kwargs=ref_sampling_kwargs,
+    )
+    candidate = run_variant(
+        server_kwargs=cand_server_kwargs,
+        sampling_kwargs=cand_sampling_kwargs,
+    )
+
+    result = {
+        "model_path": args.model_path,
+        "prompt": args.prompt,
+        "seed": args.seed,
+        "server_kwargs": {
+            "reference": ref_server_kwargs,
+            "candidate": cand_server_kwargs,
+        },
+        "sampling_kwargs": {
+            "width": args.width,
+            "height": args.height,
+            "num_frames": args.num_frames,
+            "num_inference_steps": args.num_inference_steps,
+            "guidance_scale": args.guidance_scale,
+            "guidance_scale_2": args.guidance_scale_2,
+        },
+        "reference_generation": {
+            "generation_time_s": reference.generation_time,
+            "peak_memory_mb": reference.peak_memory_mb,
+            "output_file_path": reference.output_file_path,
+        },
+        "candidate_generation": {
+            "generation_time_s": candidate.generation_time,
+            "peak_memory_mb": candidate.peak_memory_mb,
+            "output_file_path": candidate.output_file_path,
+        },
+        "trajectory_metrics": summarize_trajectory_metrics(
+            reference.trajectory_latents,
+            candidate.trajectory_latents,
+            reference_timesteps=reference.trajectory_timesteps,
+            candidate_timesteps=candidate.trajectory_timesteps,
+            step_index=args.trajectory_step_index,
+        ),
+        "output_metrics": summarize_output_frame_metrics(
+            extract_result_frames(reference),
+            extract_result_frames(candidate),
+        ),
+    }
+
+    output_json.write_text(
+        json.dumps(_to_jsonable(result), indent=2, sort_keys=True), encoding="utf-8"
+    )
+
+    selected = result["trajectory_metrics"]["selected_step_metrics"]
+    frame0 = result["output_metrics"]["frame0_metrics"]
+    print(
+        json.dumps(
+            {
+                "output_json": str(output_json),
+                "trajectory_selected_step": result["trajectory_metrics"][
+                    "selected_step_index"
+                ],
+                "trajectory_cosine": selected["cosine_similarity"],
+                "trajectory_mae": selected["mae"],
+                "frame0_psnr_db": frame0["psnr_db"],
+                "frame0_mae": frame0["mae"],
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sglang/multimodal_gen/tools/convert_modelopt_fp8_checkpoint.py
+++ b/python/sglang/multimodal_gen/tools/convert_modelopt_fp8_checkpoint.py
@@ -1,0 +1,468 @@
+"""Convert a ModelOpt diffusion FP8 export into an SGLang-loadable checkpoint.
+
+The core conversion path is model-agnostic:
+- read the ModelOpt diffusers transformer export
+- rebuild per-layer `weight_scale` / `input_scale` tensors from `backbone.pt`
+- materialize SGLang-native `float8_e4m3fn` weights
+- preserve ModelOpt `ignore` layers in their original dtype
+
+Some models still benefit from a small validated BF16 fallback set. Those
+fallback profiles are intentionally isolated so the generic FP8 conversion path
+remains reusable across future diffusion backbones.
+
+Example:
+
+    python -m sglang.multimodal_gen.tools.convert_modelopt_fp8_checkpoint \
+        --modelopt-hf-dir /tmp/modelopt_flux2_fp8/hf \
+        --modelopt-backbone-ckpt /tmp/modelopt_flux2_fp8/ckpt/backbone.pt \
+        --base-transformer-dir /path/to/FLUX.2-dev/transformer \
+        --output-dir /tmp/modelopt_flux2_fp8/sglang_transformer
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import os
+import re
+import shutil
+from collections import defaultdict
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import load_file, save_file
+
+INDEX_FILENAMES = [
+    "model.safetensors.index.json",
+    "diffusion_pytorch_model.safetensors.index.json",
+]
+FP8_E4M3_MAXBOUND = 448.0
+DEFAULT_FLUX2_KEEP_BF16_PATTERNS = [
+    r"^time_guidance_embed\.(timestep_embedder|guidance_embedder)\.linear_[12]$",
+    r"^double_stream_modulation_(img|txt)\.linear$",
+    r"^single_stream_modulation\.linear$",
+    r"^x_embedder$",
+    r"^context_embedder$",
+    r"^norm_out\.linear$",
+]
+
+
+def _resolve_transformer_dir(path: str) -> str:
+    candidate = Path(path).expanduser().resolve()
+    if (candidate / "config.json").is_file():
+        return str(candidate)
+    transformer_dir = candidate / "transformer"
+    if (transformer_dir / "config.json").is_file():
+        return str(transformer_dir)
+    raise FileNotFoundError(f"Could not resolve a transformer directory from: {path}")
+
+
+def _resolve_backbone_ckpt(path: str) -> str:
+    candidate = Path(path).expanduser().resolve()
+    if candidate.is_file():
+        return str(candidate)
+    backbone_path = candidate / "backbone.pt"
+    if backbone_path.is_file():
+        return str(backbone_path)
+    raise FileNotFoundError(f"Could not resolve backbone.pt from: {path}")
+
+
+def _find_index_file(model_dir: str) -> str | None:
+    for filename in INDEX_FILENAMES:
+        candidate = os.path.join(model_dir, filename)
+        if os.path.isfile(candidate):
+            return filename
+
+    matches = sorted(
+        filename
+        for filename in os.listdir(model_dir)
+        if filename.endswith(".safetensors.index.json")
+    )
+    return matches[0] if matches else None
+
+
+def _load_weight_map(model_dir: str) -> tuple[dict[str, str], str | None]:
+    index_filename = _find_index_file(model_dir)
+    if index_filename is not None:
+        with open(os.path.join(model_dir, index_filename), encoding="utf-8") as f:
+            index_data = json.load(f)
+        return dict(index_data["weight_map"]), index_filename
+
+    safetensors_files = sorted(
+        filename
+        for filename in os.listdir(model_dir)
+        if filename.endswith(".safetensors")
+    )
+    if len(safetensors_files) != 1:
+        raise ValueError(
+            f"Expected an index file or a single safetensors shard in {model_dir}, "
+            f"found {len(safetensors_files)} shard(s)."
+        )
+
+    shard_name = safetensors_files[0]
+    with safe_open(
+        os.path.join(model_dir, shard_name), framework="pt", device="cpu"
+    ) as f:
+        weight_map = {key: shard_name for key in f.keys()}
+    index_filename = f"{Path(shard_name).stem}.safetensors.index.json"
+    return weight_map, index_filename
+
+
+def _load_config(model_dir: str) -> dict:
+    config_path = os.path.join(model_dir, "config.json")
+    with open(config_path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def get_default_keep_bf16_patterns(
+    *, model_type: str, class_name: str | None
+) -> list[str]:
+    # Most diffusion backbones can run through the generic conversion path.
+    # Validated fallback profiles live here when a family needs a few BF16
+    # modules preserved for accuracy or loader compatibility.
+    if model_type == "flux2":
+        return list(DEFAULT_FLUX2_KEEP_BF16_PATTERNS)
+    if model_type == "none":
+        return []
+    if class_name == "Flux2Transformer2DModel":
+        return list(DEFAULT_FLUX2_KEEP_BF16_PATTERNS)
+    return []
+
+
+def should_keep_bf16(
+    weight_name: str,
+    keep_bf16_patterns: Sequence[str],
+) -> bool:
+    if not keep_bf16_patterns:
+        return False
+
+    module_name = weight_name[:-7] if weight_name.endswith(".weight") else weight_name
+    return any(re.search(pattern, module_name) for pattern in keep_bf16_patterns)
+
+
+def is_ignored_by_modelopt(
+    weight_name: str,
+    ignore_patterns: Sequence[str],
+) -> bool:
+    if not ignore_patterns:
+        return False
+
+    module_name = weight_name[:-7] if weight_name.endswith(".weight") else weight_name
+    for pattern in ignore_patterns:
+        regex_str = pattern.replace(".", r"\.").replace("*", r".*")
+        if re.fullmatch(regex_str, module_name):
+            return True
+    return False
+
+
+def build_fp8_scale_map(
+    model_state_dict: Mapping[str, torch.Tensor],
+    *,
+    maxbound: float = FP8_E4M3_MAXBOUND,
+) -> dict[str, dict[str, torch.Tensor]]:
+    scale_map: dict[str, dict[str, torch.Tensor]] = {}
+    for key, value in model_state_dict.items():
+        if key.endswith(".weight_quantizer._amax"):
+            layer_name = key[: -len(".weight_quantizer._amax")]
+            scale_map.setdefault(f"{layer_name}.weight", {})["weight_scale"] = (
+                value.detach().to(torch.float32).reshape(1).cpu() / maxbound
+            )
+        elif key.endswith(".input_quantizer._amax"):
+            layer_name = key[: -len(".input_quantizer._amax")]
+            scale_map.setdefault(f"{layer_name}.weight", {})["input_scale"] = (
+                value.detach().to(torch.float32).reshape(1).cpu() / maxbound
+            )
+
+    return {
+        weight_name: scale_tensors
+        for weight_name, scale_tensors in scale_map.items()
+        if {"weight_scale", "input_scale"} <= set(scale_tensors)
+    }
+
+
+def quantize_fp8_weight(
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+) -> torch.Tensor:
+    if weight.dtype == torch.float8_e4m3fn:
+        return weight.contiguous()
+
+    scale = weight_scale.to(weight.device, dtype=torch.float32)
+    if scale.numel() != 1:
+        raise ValueError(
+            f"Only per-tensor FP8 scales are supported for diffusion checkpoints, got shape {tuple(scale.shape)}."
+        )
+
+    quantized = (weight.to(torch.float32) / scale.reshape(1)).to(torch.float8_e4m3fn)
+    return quantized.cpu().contiguous()
+
+
+def _copy_non_shard_files(source_dir: str, output_dir: str) -> None:
+    ignored = set(INDEX_FILENAMES)
+    for entry in os.listdir(source_dir):
+        if entry.endswith(".safetensors") or entry in ignored:
+            continue
+        source_path = os.path.join(source_dir, entry)
+        output_path = os.path.join(output_dir, entry)
+        if os.path.isdir(source_path):
+            shutil.copytree(source_path, output_path, dirs_exist_ok=True)
+        else:
+            shutil.copy2(source_path, output_path)
+
+
+def _load_selected_tensors(
+    model_dir: str,
+    weight_map: Mapping[str, str],
+    tensor_names: Iterable[str],
+) -> dict[str, torch.Tensor]:
+    tensors: dict[str, torch.Tensor] = {}
+    names_by_file: dict[str, list[str]] = defaultdict(list)
+    for name in tensor_names:
+        names_by_file[weight_map[name]].append(name)
+
+    for filename, names in names_by_file.items():
+        shard_path = os.path.join(model_dir, filename)
+        with safe_open(shard_path, framework="pt", device="cpu") as f:
+            for name in names:
+                tensors[name] = f.get_tensor(name).contiguous()
+    return tensors
+
+
+def convert_modelopt_fp8_checkpoint(
+    *,
+    modelopt_hf_dir: str,
+    modelopt_backbone_ckpt: str,
+    output_dir: str,
+    base_transformer_dir: str | None = None,
+    model_type: str = "auto",
+    keep_bf16_patterns: Sequence[str] | None = None,
+    maxbound: float = FP8_E4M3_MAXBOUND,
+    overwrite: bool = False,
+) -> dict[str, int]:
+    source_dir = _resolve_transformer_dir(modelopt_hf_dir)
+    backbone_ckpt_path = _resolve_backbone_ckpt(modelopt_backbone_ckpt)
+    base_dir = (
+        _resolve_transformer_dir(base_transformer_dir) if base_transformer_dir else None
+    )
+
+    config = _load_config(source_dir)
+    quant_config = config.get("quantization_config")
+    if not isinstance(quant_config, dict):
+        raise ValueError(
+            "Expected a flat quantization_config dict in the ModelOpt export."
+        )
+    if (
+        quant_config.get("quant_method") != "modelopt"
+        or "FP8" not in str(quant_config.get("quant_algo", "")).upper()
+    ):
+        raise ValueError(
+            "This tool only supports ModelOpt diffusers FP8 exports "
+            "(quant_method=modelopt, quant_algo=FP8)."
+        )
+
+    class_name = config.get("_class_name")
+    ignore_patterns = list(quant_config.get("ignore", []) or [])
+    patterns = list(
+        get_default_keep_bf16_patterns(model_type=model_type, class_name=class_name)
+    )
+    if keep_bf16_patterns:
+        patterns.extend(keep_bf16_patterns)
+    if patterns and base_dir is None:
+        raise ValueError(
+            "BF16 fallback patterns are enabled, but --base-transformer-dir was not provided."
+        )
+
+    output_path = Path(output_dir).expanduser().resolve()
+    if output_path.exists():
+        if not overwrite:
+            raise FileExistsError(
+                f"Output directory already exists: {output_path}. Use --overwrite to replace it."
+            )
+        shutil.rmtree(output_path)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    _copy_non_shard_files(source_dir, str(output_path))
+
+    source_weight_map, index_filename = _load_weight_map(source_dir)
+    base_weight_map: dict[str, str] = {}
+    if base_dir is not None:
+        base_weight_map, _ = _load_weight_map(base_dir)
+
+    backbone_state = torch.load(backbone_ckpt_path, map_location="cpu")[
+        "model_state_dict"
+    ]
+    fp8_scale_map = build_fp8_scale_map(backbone_state, maxbound=maxbound)
+    serialized_quant_config = json.dumps(quant_config, sort_keys=True)
+
+    fallback_weight_names = sorted(
+        weight_name
+        for weight_name in source_weight_map
+        if weight_name.endswith(".weight") and should_keep_bf16(weight_name, patterns)
+    )
+    fallback_tensors = (
+        _load_selected_tensors(base_dir, base_weight_map, fallback_weight_names)
+        if fallback_weight_names
+        else {}
+    )
+
+    weights_by_file: dict[str, list[str]] = defaultdict(list)
+    for weight_name, filename in source_weight_map.items():
+        weights_by_file[filename].append(weight_name)
+
+    updated_weight_map: dict[str, str] = {}
+    total_size = 0
+    added_scale_count = 0
+    preserved_ignored_weight_count = 0
+
+    for filename, names in sorted(weights_by_file.items()):
+        shard_path = os.path.join(source_dir, filename)
+        shard_tensors = load_file(shard_path, device="cpu")
+
+        with safe_open(shard_path, framework="pt", device="cpu") as f:
+            metadata = dict(f.metadata() or {})
+
+        metadata.setdefault("format", "pt")
+        metadata["quantization_config"] = serialized_quant_config
+        metadata["_quantization_metadata"] = serialized_quant_config
+
+        for name in list(shard_tensors.keys()):
+            if name.endswith(".weight") and is_ignored_by_modelopt(
+                name, ignore_patterns
+            ):
+                preserved_ignored_weight_count += 1
+                continue
+            if name in fallback_tensors:
+                shard_tensors[name] = fallback_tensors[name]
+            if (
+                name.endswith(".weight")
+                and name in fp8_scale_map
+                and name not in fallback_tensors
+            ):
+                scale_tensors = fp8_scale_map[name]
+                shard_tensors[name] = quantize_fp8_weight(
+                    shard_tensors[name], scale_tensors["weight_scale"]
+                )
+                shard_tensors[name[:-7] + ".weight_scale"] = scale_tensors[
+                    "weight_scale"
+                ]
+                shard_tensors[name[:-7] + ".input_scale"] = scale_tensors["input_scale"]
+                added_scale_count += 2
+
+        save_file(shard_tensors, os.path.join(output_path, filename), metadata=metadata)
+
+        for name, tensor in shard_tensors.items():
+            updated_weight_map[name] = filename
+            total_size += tensor.element_size() * tensor.numel()
+
+        del shard_tensors
+        gc.collect()
+
+    with open(output_path / index_filename, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "metadata": {"total_size": total_size},
+                "weight_map": updated_weight_map,
+            },
+            f,
+            indent=2,
+            sort_keys=True,
+        )
+
+    return {
+        "quantized_weights": sum(
+            1
+            for name in source_weight_map
+            if name.endswith(".weight")
+            and name in fp8_scale_map
+            and not is_ignored_by_modelopt(name, ignore_patterns)
+        ),
+        "bf16_fallback_weights": len(fallback_weight_names),
+        "preserved_ignored_weights": preserved_ignored_weight_count,
+        "added_scale_tensors": added_scale_count,
+        "output_shards": len(weights_by_file),
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Inject FP8 scales from ModelOpt backbone.pt into a diffusers export so "
+            "SGLang diffusion can load it natively."
+        )
+    )
+    parser.add_argument(
+        "--modelopt-hf-dir",
+        required=True,
+        help="ModelOpt --hf-ckpt-dir output, or its transformer subdirectory.",
+    )
+    parser.add_argument(
+        "--modelopt-backbone-ckpt",
+        required=True,
+        help="Path to backbone.pt, or the directory that contains it.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Directory to write the converted SGLang transformer checkpoint.",
+    )
+    parser.add_argument(
+        "--base-transformer-dir",
+        help=(
+            "Original BF16 transformer directory (or parent model dir). Required when "
+            "BF16 fallback layers are enabled."
+        ),
+    )
+    parser.add_argument(
+        "--model-type",
+        choices=["auto", "flux2", "none"],
+        default="auto",
+        help=(
+            "Optional model-family BF16 fallback profile. 'none' uses the generic "
+            "conversion path. 'auto' only enables the validated FLUX.2 fallback "
+            "set when the export config says Flux2Transformer2DModel."
+        ),
+    )
+    parser.add_argument(
+        "--keep-bf16-pattern",
+        action="append",
+        default=[],
+        help=(
+            "Regex matched against module names without the trailing .weight. "
+            "Matching weights are copied from --base-transformer-dir instead of "
+            "staying in FP8."
+        ),
+    )
+    parser.add_argument(
+        "--maxbound",
+        type=float,
+        default=FP8_E4M3_MAXBOUND,
+        help="FP8 maxbound used to turn ModelOpt amax into a scale. E4M3 uses 448.",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Replace --output-dir if it already exists.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    stats = convert_modelopt_fp8_checkpoint(
+        modelopt_hf_dir=args.modelopt_hf_dir,
+        modelopt_backbone_ckpt=args.modelopt_backbone_ckpt,
+        output_dir=args.output_dir,
+        base_transformer_dir=args.base_transformer_dir,
+        model_type=args.model_type,
+        keep_bf16_patterns=args.keep_bf16_pattern,
+        maxbound=args.maxbound,
+        overwrite=args.overwrite,
+    )
+    print(json.dumps(stats, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Split the ModelOpt diffusion skill and its helper scripts out of #22365 into a stacked PR.

This PR contains only:
- `python/sglang/multimodal_gen/.claude/skills/sglang-diffusion-modelopt-quant/SKILL.md`
- `python/sglang/multimodal_gen/tools/convert_modelopt_fp8_checkpoint.py`
- `python/sglang/multimodal_gen/tools/compare_diffusion_trajectory_similarity.py`
- the matching ModelOpt FP8 doc note in `docs/diffusion/quantization.md`

## Why
The runtime / loader / test changes in #22365 are easier to review without the skill and workflow tooling mixed in.

## Note
This is a stacked PR with base branch `bbuf/modelopt-diffusion-fp8` so the diff stays focused on the skill/tooling split. After #22365 lands, this PR can be retargeted to `main`.