### PR TITLE
fix prefill tps log accuracy

### DIFF
--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -95,7 +95,6 @@ class SchedulerMetricsMixin:
         self.num_generated_tokens = 0
         self.last_decode_stats_tic = time.perf_counter()
         self.last_prefill_stats_tic = time.perf_counter()
-        self.last_prefill_tokens = 0
         self.last_gen_throughput: float = 0.0
         self.last_input_throughput: float = 0.0
         self.step_time_dict = defaultdict(list)  # Dict[batch size -> step time]
@@ -335,10 +334,12 @@ class SchedulerMetricsMixin:
         ):
             return
 
-        gap_latency = time.perf_counter() - self.last_prefill_stats_tic
-        self.last_prefill_stats_tic = time.perf_counter()
-        self.last_input_throughput = self.last_prefill_tokens / gap_latency
-        self.last_prefill_tokens = prefill_stats.log_input_tokens
+        now = time.perf_counter()
+        gap_latency = now - self.last_prefill_stats_tic
+        self.last_prefill_stats_tic = now
+        self.last_input_throughput = (
+            prefill_stats.log_input_tokens / gap_latency if gap_latency > 0 else 0.0
+        )
 
         # TODO: generalize this for various memory pools
         msg_parts = []


### PR DESCRIPTION
## Summary

Fix prefill `input throughput (token/s)` log metric which was using the **previous** batch's token count with the **current** batch's time interval, producing spurious TPS spikes up to 3x and incorrect readings after idle periods.

## Background

The prefill input throughput metric has gone through three stages:

### Stage 1: Always zero (before #7245)

The original code used an accumulator pattern similar to the decode side, but **never actually incremented** the accumulator:

```python
self.num_prefill_tokens = 0  # init

# In report_prefill_stats:
self.last_input_throughput = self.num_prefill_tokens / gap_latency  # always 0
self.num_prefill_tokens = 0  # reset (was already 0)
```

There was no `self.num_prefill_tokens += ...` anywhere in the codebase, so `input throughput` was always printed as `0.00`.

### Stage 2: Token/time misalignment (#7245, c4943867)

PR #7245 ("minor fix") noticed the TPS was always zero and applied a quick workaround — instead of fixing the missing accumulation, it stored the current batch's token count and used it in the **next** call:

```python
# report_prefill_stats is called once per prefill batch
self.last_input_throughput = self.last_prefill_tokens / gap_latency  # prev batch tokens ÷ current interval
self.last_prefill_tokens = prefill_stats.log_input_tokens  # save for next time
```

This made TPS non-zero, but introduced a **numerator/denominator misalignment**: the token count comes from batch N-1, while `gap_latency` measures the wall-clock interval of batch N. When consecutive batches have different `#new-token` counts (which is common in prefill), the reported TPS becomes inaccurate.

### Stage 3: This PR — align token count with time interval

```python
now = time.perf_counter()
gap_latency = now - self.last_prefill_stats_tic
self.last_prefill_stats_tic = now
self.last_input_throughput = (
    prefill_stats.log_input_tokens / gap_latency if gap_latency > 0 else 0.0
)
```

Use the **current** batch's `log_input_tokens` divided by the **current** `gap_latency`. This is consistent with how decode's `gen throughput` works (accumulated tokens ÷ accumulated time over `decode_log_interval` steps).

Also removes the now-unused `self.last_prefill_tokens` field.

## Why the old formula produces spikes

Consider two consecutive prefill batches:

| Batch | #new-token | Actual duration |
|---|---|---|
| N-1 | 12288 | 1.0s |
| N | 1024 | 0.08s |

- **Old formula**: `12288 / 0.08 = 153,600 token/s` (reports prev batch's 12288 tokens over current batch's 0.08s interval — **15x overshoot**)
- **New formula**: `1024 / 0.08 = 12,800 token/s` (correct: current batch's tokens over current interval)

The reverse also happens — if batch N has many tokens but batch N-1 had few, the old formula **underreports**.

## Validation

Tested on 1P1D PD disaggregation (DeepSeek-R1 MXFP4, EP4 prefill + EP8 decode, ISL=1024, OSL=1024, 10240 prompts):

| Metric | Before | After (this PR) |
|---|---|---|
| Mean TPS | 6,331 | 6,025 |
| Median TPS | 3,657 | 3,754 |
| P95 TPS | 19,684 | 18,198 |
| P99 TPS | 31,998 | 30,625 |
| **Max TPS** | **90,527** (spurious) | **39,666** |

- **Median/Mean are nearly identical** — in steady state where consecutive batches have similar token counts, both formulas converge
- **Max drops from 90K to 40K** — the 90K spike was entirely spurious (token/time misalignment); the 40K max is a legitimate instantaneous rate for small single-request batches (~1K tokens in ~30ms event loop on MI355X EP4)

## Test plan

- [x] Ran identical benchmark (same machines, same config) with and without the fix — confirms spikes are eliminated while steady-state values unchanged
- [x] Verified on 1P1D PD disaggregation (EP4 prefill + EP8 decode, DeepSeek-R1, ISL=1024/OSL=1024, 10240 prompts)
- [x] No impact on actual computation, only log/metric accuracy
- [x] Pre-commit hooks pass (isort, ruff, black, codespell)
