### PR TITLE
Add bfloat16 KV cache validation for HiSparse

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6464,6 +6464,12 @@ class ServerArgs:
                         f"Please use --nsa-{label}-backend=flashmla_sparse or omit it."
                     )
 
+            if self.kv_cache_dtype != "bfloat16":
+                raise ValueError(
+                    f"HiSparse requires bfloat16 KV cache, but got --kv-cache-dtype={self.kv_cache_dtype}. "
+                    f"Please use --kv-cache-dtype=bfloat16."
+                )
+
         assert (
             self.schedule_conservativeness >= 0
         ), "schedule_conservativeness must be non-negative"


### PR DESCRIPTION
## Summary

Add validation to fail fast when HiSparse is enabled with non-bfloat16 KV cache, as e.g., NVFP4 models default to FP8

cc @xiezhq-hermann @hzh0425 @huangtingwei9988 