### PR TITLE
[gateway] Add inflight request counter logging to PD router

### DIFF
--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -1,4 +1,10 @@
-use std::{sync::Arc, time::Instant};
+use std::{
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    time::Instant,
+};
 
 use async_trait::async_trait;
 use axum::{
@@ -13,7 +19,51 @@ use reqwest::Client;
 use serde::Serialize;
 use serde_json::{json, Value};
 use tokio_stream::wrappers::UnboundedReceiverStream;
-use tracing::{debug, error, warn};
+use tracing::{debug, enabled, error, warn, Level};
+
+static REQ_SENT: AtomicU64 = AtomicU64::new(0);
+static REQ_DONE: AtomicU64 = AtomicU64::new(0);
+
+struct InflightGuard {
+    active: bool,
+}
+
+impl InflightGuard {
+    fn new() -> Self {
+        let sent = REQ_SENT.fetch_add(1, Ordering::Relaxed) + 1;
+        let done = REQ_DONE.load(Ordering::Relaxed);
+        debug!(
+            "[REQ_SENT] sent={} done={} inflight={}",
+            sent,
+            done,
+            sent - done
+        );
+        Self { active: true }
+    }
+
+    fn done_only() -> Self {
+        Self { active: true }
+    }
+
+    fn disarm(mut self) {
+        self.active = false;
+    }
+}
+
+impl Drop for InflightGuard {
+    fn drop(&mut self) {
+        if self.active {
+            let done = REQ_DONE.fetch_add(1, Ordering::Relaxed) + 1;
+            let sent = REQ_SENT.load(Ordering::Relaxed);
+            debug!(
+                "[REQ_DONE] sent={} done={} inflight={}",
+                sent,
+                done,
+                sent - done
+            );
+        }
+    }
+}
 
 use super::pd_types::api_path;
 use crate::{
@@ -570,6 +620,8 @@ impl PDRouter {
 
         // Send both requests concurrently and wait for both
         // Note: Using borrowed references avoids heap allocation
+        let _inflight = enabled!(Level::DEBUG).then(InflightGuard::new);
+
         events::RequestPDSentEvent {
             prefill_url: prefill.url(),
             decode_url: decode.url(),
@@ -625,7 +677,10 @@ impl PDRouter {
                 };
 
                 if context.is_stream {
-                    // Streaming response
+                    // Streaming: disarm guard, spawned task will handle REQ_DONE
+                    if let Some(g) = _inflight {
+                        g.disarm();
+                    }
                     let prefill_logprobs = if context.return_logprob {
                         prefill_body
                             .as_ref()
@@ -651,7 +706,7 @@ impl PDRouter {
                     )
                 } else {
                     // Non-streaming response
-                    if context.return_logprob {
+                    let response = if context.return_logprob {
                         self.process_non_streaming_response(
                             res,
                             status,
@@ -679,7 +734,9 @@ impl PDRouter {
                                 )
                             }
                         }
-                    }
+                    };
+                    // _inflight guard drops here, auto-increments REQ_DONE
+                    response
                 }
             }
             Err(e) => {
@@ -846,7 +903,9 @@ impl PDRouter {
 
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
 
+        let _stream_guard = enabled!(Level::DEBUG).then(InflightGuard::done_only);
         tokio::spawn(async move {
+            let _guard = _stream_guard;
             futures_util::pin_mut!(stream);
             while let Some(chunk_result) = stream.next().await {
                 match chunk_result {
@@ -877,6 +936,7 @@ impl PDRouter {
                     }
                 }
             }
+            // _guard drops here, auto-increments REQ_DONE
         });
 
         let stream = UnboundedReceiverStream::new(rx);


### PR DESCRIPTION
## Summary

Add debug-level inflight request counter logging to the PD router, allowing operators to see how many requests are currently in-flight through the gateway.

- Two atomic counters (`REQ_SENT` / `REQ_DONE`) track the request lifecycle
- Each log line prints `sent`, `done`, and `inflight = sent - done`
- Guarded by `enabled!(Level::DEBUG)`: at default `--log-level info`, no atomic ops, no formatting — zero overhead

## How to use

```bash
# Start router with debug level to see inflight counters
python3 -m sglang_router.launch_router \
  --pd-disaggregation --port 30000 \
  --prefill http://prefill:8000 --decode http://decode:8000 \
  --log-level debug
```

No flags needed to disable — at the default `--log-level info`, the counters are completely skipped.

## Log output

**`--log-level info` (default)** — no extra output:

```
[2026-04-10 08:09:03] INFO  Starting router on 0.0.0.0:30000
[2026-04-10 08:09:04] INFO  Activated 1 worker(s) (marked as healthy)
```

**`--log-level debug`** — 3 sequential streaming requests:

```
[2026-04-10 08:19:02] DEBUG [REQ_SENT] sent=1 done=0 inflight=1
[2026-04-10 08:19:03] DEBUG [REQ_DONE] sent=1 done=1 inflight=0
[2026-04-10 08:19:03] DEBUG [REQ_SENT] sent=2 done=1 inflight=1
[2026-04-10 08:19:03] DEBUG [REQ_DONE] sent=2 done=2 inflight=0
[2026-04-10 08:19:03] DEBUG [REQ_SENT] sent=3 done=2 inflight=1
[2026-04-10 08:19:03] DEBUG [REQ_DONE] sent=3 done=3 inflight=0
```

**`--log-level debug` + `SGLANG_LOG_MS=true`** — with millisecond timestamps:

```
[2026-04-10 07:32:33.173] DEBUG [REQ_SENT] sent=1 done=0 inflight=1
[2026-04-10 07:32:33.751] DEBUG [REQ_DONE] sent=1 done=1 inflight=0
[2026-04-10 07:32:33.758] DEBUG [REQ_SENT] sent=2 done=1 inflight=1
[2026-04-10 07:32:34.330] DEBUG [REQ_DONE] sent=2 done=2 inflight=0
[2026-04-10 07:32:34.336] DEBUG [REQ_SENT] sent=3 done=2 inflight=1
[2026-04-10 07:32:34.680] DEBUG [REQ_DONE] sent=3 done=3 inflight=0
```

Per-request latency can be read directly from timestamps:

| Request | REQ_SENT | REQ_DONE | Latency |
|---------|----------|----------|---------|
| 1 | 33.173 | 33.751 | 578ms |
| 2 | 33.758 | 34.330 | 572ms |
| 3 | 34.336 | 34.680 | 344ms |