### PR TITLE
Reduce GPU memory for MoE parallel groups

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -609,7 +609,7 @@ class GroupCoordinator:
             and self.torch_symm_mem_comm.should_torch_symm_mem_allreduce(input_)
         ):
             outplace_all_reduce_method = "torch_symm_mem"
-        elif is_in_piecewise_cuda_graph():
+        elif is_in_piecewise_cuda_graph() and self.pynccl_comm is not None:
             # For piecewise cuda graph, we use pynccl outplace allreduce
             outplace_all_reduce_method = "pynccl"
         if outplace_all_reduce_method is not None:
@@ -1922,7 +1922,6 @@ def initialize_model_parallel(
     if moe_ep_size == tensor_model_parallel_size:
         _MOE_EP = _TP
     else:
-        # TODO(ch-wan): use split_group to save memory
         group_ranks = []
         for tp_group_idx in range(num_tensor_model_parallel_groups):
             for moe_dp_idx in range(moe_dp_size):
@@ -1939,6 +1938,8 @@ def initialize_model_parallel(
             group_ranks,
             get_world_group().local_rank,
             backend,
+            use_pynccl=False,
+            use_custom_allreduce=False,
             group_name="moe_ep",
         )
 
@@ -1947,7 +1948,6 @@ def initialize_model_parallel(
     if moe_tp_size == tensor_model_parallel_size:
         _MOE_TP = _TP
     else:
-        # TODO(ch-wan): use split_group to save memory
         group_ranks = []
         for tp_group_idx in range(num_tensor_model_parallel_groups):
             for ep_dp_combined_idx in range(moe_ep_size * moe_dp_size):
@@ -1965,6 +1965,8 @@ def initialize_model_parallel(
             group_ranks,
             get_world_group().local_rank,
             backend,
+            use_pynccl=False,
+            use_custom_allreduce=False,
             group_name="moe_tp",
         )
 


### PR DESCRIPTION
## Motivation

When expert parallelism (EP) is enabled, `initialize_model_parallel` creates MOE_EP and MOE_TP groups with full communicator stacks (pynccl + custom_allreduce), each costing ~700 MB of GPU memory. For example, with `--tp 8 --ep 4`, torch distributed init uses ~2.7 GB vs ~1.3 GB for pure `--tp 8` — a **1.4 GB overhead** from unnecessary communicators.

These MoE groups only use `all_reduce`, which works correctly via the standard `torch.distributed.all_reduce` (NCCL) fallback without pynccl or custom_allreduce.

## Modifications

1. **Disable pynccl and custom_allreduce for MOE_EP and MOE_TP groups** in `initialize_model_parallel` — pass `use_pynccl=False, use_custom_allreduce=False` to avoid allocating expensive communicators.

2. **Guard pynccl dispatch in `GroupCoordinator.all_reduce`** — add `self.pynccl_comm is not None` check on the piecewise CUDA graph path so groups without pynccl gracefully fall through to `torch.distributed.all_reduce` instead of crashing.

## Speed Tests and Profiling

Memory comparison on 8x H200 with `Qwen/Qwen3-30B-A3B-Thinking-2507-FP8`:

| Configuration | Before | After | Savings |
|---|---|---|---|
| `--tp 8` | 1.29 GB | 1.29 GB | — |
| `--tp 8 --ep 4` | **2.70 GB** | **1.29 GB** | **-1.41 GB** |

No performance impact: MoE all_reduce falls back to `torch.distributed.all_reduce` (NCCL), which is the same underlying backend.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).