### PR TITLE
fix(server): clamp piecewise_cuda_graph_max_tokens to context_length

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1302,6 +1302,14 @@ class ServerArgs:
                     self.piecewise_cuda_graph_max_tokens, 4096
                 )
 
+        # Clamp to context_length if explicitly set — prevents PCG warmup
+        # from compiling graphs with more tokens than the model buffers
+        # can hold, which causes illegal memory access (#21112)
+        if self.context_length is not None:
+            self.piecewise_cuda_graph_max_tokens = min(
+                self.piecewise_cuda_graph_max_tokens, self.context_length
+            )
+
         if self.piecewise_cuda_graph_tokens is None:
             self.piecewise_cuda_graph_tokens = (
                 self._generate_piecewise_cuda_graph_tokens()

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1560,6 +1560,14 @@ class ServerArgs:
                     self.piecewise_cuda_graph_max_tokens, 4096
                 )
 
+        # Clamp to context_length if explicitly set — prevents PCG warmup
+        # from compiling graphs with more tokens than the model buffers
+        # can hold, which causes illegal memory access (#21112)
+        if self.context_length is not None:
+            self.piecewise_cuda_graph_max_tokens = min(
+                self.piecewise_cuda_graph_max_tokens, self.context_length
+            )
+
         if self.piecewise_cuda_graph_tokens is None:
             self.piecewise_cuda_graph_tokens = (
                 self._generate_piecewise_cuda_graph_tokens()


### PR DESCRIPTION
## Motivation

Fixes #21112.

When `--context-length` is set smaller than the default `piecewise_cuda_graph_max_tokens` (8192), model buffers are sized for the smaller context length but PCG `warmup_compile()` tries to compile graphs for up to 8192 tokens. This causes illegal memory access during warmup because the KV cache pools are too small for the requested token count.

For example:
```bash
sglang serve meta-llama/Llama-3.3-70B-Instruct \
  --tp 8 --context-length 2048
```
crashes during `PiecewiseCudaGraphRunner.__init__()` → `warmup_compile(num_tokens=8192)` with:
- Early sglang versions: `kvcache.cuh:196: CUDA error: an illegal memory access was encountered`
- Recent versions: `FusedAddRMSNorm failed with error code an illegal memory access was encountered`
- Or: `The expanded size of the tensor (2052) must match the existing size (8192)`

100% reproducible on H100 (FA3 backend); also affects other backends when context_length < 8192.

## Modifications

Clamp `piecewise_cuda_graph_max_tokens` to `context_length` when `--context-length` is explicitly set. This follows the same pattern as the existing `max_total_tokens` clamp (line 1293) and the Llama-2 4096 limit (line 1298).

The clamp is placed **outside** the `if self.piecewise_cuda_graph_max_tokens is None` block so it also applies when the user explicitly passes `--piecewise-cuda-graph-max-tokens` with a value exceeding `--context-length`.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Accuracy Tests

Tested on 8×H100 80GB with Llama-3.3-70B-Instruct, TP=8, FA3 backend:

| Precision | Without fix | With `--piecewise-cuda-graph-max-tokens 2048` |
|-----------|-------------|----------------------------------------------|
| bf16 | Crash (illegal memory access) | **Pass** |
| fp8 | Crash (illegal memory access) | **Pass** |

## Benchmarking and Profiling

N/A — this is a crash fix, not a performance change. The fix only constrains PCG warmup to stay within the model's allocated buffer size.

































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #26878637036](https://github.com/sgl-project/sglang/actions/runs/26878637036)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26878636984](https://github.com/sgl-project/sglang/actions/runs/26878636984)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->