### PR TITLE
fix(model_loader): RunAI streamer quant_config and distributed tensor clones

### DIFF
--- a/docs/advanced_features/object_storage.md
+++ b/docs/advanced_features/object_storage.md
@@ -84,6 +84,7 @@ python -m sglang.launch_server \
 | `concurrency` | int | Number of concurrent download streams. Higher values can improve throughput for large models. | 4 |
 | `memory_limit` | int | Memory limit (in bytes) for the streaming buffer. | System-dependent |
 
+With `distributed` streaming, SGLang clones each weight tensor from the Run:AI iterator so loaders never retain views into reused internal buffers.
 
 ## Performance Considerations
 

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -3089,11 +3089,13 @@ class RunaiModelStreamerLoader(BaseModelLoader):
             self.target_device_str = "cpu"
 
         target_device = torch.device(device_config.device)
+        quant_config = _get_quantization_config(model_config, self.load_config)
         with set_default_torch_dtype(model_config.dtype):
             with target_device:
                 model = _initialize_model(
                     model_config,
                     self.load_config,
+                    quant_config,
                 )
 
             DefaultModelLoader.load_weights_and_postprocess(

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -1120,7 +1120,11 @@ def runai_safetensors_weights_iterator(
             mininterval=2,
         )
 
-        yield from tensor_iter
+        if is_distributed:
+            for name, tensor in tensor_iter:
+                yield name, tensor.clone()
+        else:
+            yield from tensor_iter
 
 
 def set_runai_streamer_env(load_config: LoadConfig):

--- a/test/registered/unit/model_loader/test_runai_streamer_loader.py
+++ b/test/registered/unit/model_loader/test_runai_streamer_loader.py
@@ -93,7 +93,9 @@ class TestRunaiSafetensorsWeightsIterator(CustomTestCase):
 
     @patch("sglang.srt.model_loader.weight_utils.tqdm", side_effect=lambda x, **k: x)
     def test_distributed_always_clones_tensors(self, _tqdm):
-        from sglang.srt.model_loader.weight_utils import runai_safetensors_weights_iterator
+        from sglang.srt.model_loader.weight_utils import (
+            runai_safetensors_weights_iterator,
+        )
 
         t = torch.tensor([1.0, 2.0])
         self._streamer_instance._set_tensors([("w", t)])
@@ -107,7 +109,9 @@ class TestRunaiSafetensorsWeightsIterator(CustomTestCase):
 
     @patch("sglang.srt.model_loader.weight_utils.tqdm", side_effect=lambda x, **k: x)
     def test_non_distributed_yields_same_tensor(self, _tqdm):
-        from sglang.srt.model_loader.weight_utils import runai_safetensors_weights_iterator
+        from sglang.srt.model_loader.weight_utils import (
+            runai_safetensors_weights_iterator,
+        )
 
         t = torch.tensor([3.0])
         self._streamer_instance._set_tensors([("w", t)])

--- a/test/registered/unit/model_loader/test_runai_streamer_loader.py
+++ b/test/registered/unit/model_loader/test_runai_streamer_loader.py
@@ -1,0 +1,122 @@
+"""Unit tests for RunAI streamer loading (quant_config + distributed tensor clone).
+
+No server, no real model weights — mocks only.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.configs.device_config import DeviceConfig
+from sglang.srt.configs.load_config import LoadConfig, LoadFormat
+from sglang.srt.model_loader.loader import RunaiModelStreamerLoader
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+
+
+class TestRunaiModelStreamerLoaderQuantConfig(CustomTestCase):
+    def test_load_model_passes_quantization_config_to_initialize(self):
+        load_config = LoadConfig(load_format=LoadFormat.RUNAI_STREAMER)
+        loader = RunaiModelStreamerLoader(load_config)
+        mock_model = MagicMock()
+        qcfg = object()
+        model_config = MagicMock()
+        model_config.modelopt_quant = False
+        model_config.dtype = torch.float16
+        device_config = DeviceConfig(device="cpu", gpu_id=-1)
+
+        with (
+            patch(
+                "sglang.srt.model_loader.loader._get_quantization_config",
+                return_value=qcfg,
+            ) as mock_get_q,
+            patch(
+                "sglang.srt.model_loader.loader._initialize_model",
+                return_value=mock_model,
+            ) as mock_init,
+            patch(
+                "sglang.srt.model_loader.loader.DefaultModelLoader.load_weights_and_postprocess"
+            ),
+            patch.object(
+                loader,
+                "_get_all_weights",
+                return_value=iter(()),
+            ),
+        ):
+            out = loader.load_model(
+                model_config=model_config, device_config=device_config
+            )
+
+        mock_get_q.assert_called_once_with(model_config, load_config)
+        mock_init.assert_called_once_with(model_config, load_config, qcfg)
+        self.assertIs(out, mock_model)
+
+
+class TestRunaiSafetensorsWeightsIterator(CustomTestCase):
+    """Stub ``runai_model_streamer`` so CI does not need the optional wheel."""
+
+    def setUp(self):
+        super().setUp()
+        self._saved_runai = sys.modules.pop("runai_model_streamer", None)
+        stub = types.ModuleType("runai_model_streamer")
+
+        def _mock_streamer_factory():
+            mock_streamer = MagicMock()
+            mock_streamer.files_to_tensors_metadata = {"dummy.safetensors": [{}]}
+
+            def _set_tensors(tensors):
+                mock_streamer.get_tensors.return_value = iter(tensors)
+                mock_streamer.__enter__ = MagicMock(return_value=mock_streamer)
+                mock_streamer.__exit__ = MagicMock(return_value=False)
+                return mock_streamer
+
+            mock_streamer._set_tensors = _set_tensors
+            return mock_streamer
+
+        self._streamer_instance = _mock_streamer_factory()
+        stub.SafetensorsStreamer = MagicMock(return_value=self._streamer_instance)
+        sys.modules["runai_model_streamer"] = stub
+
+    def tearDown(self):
+        if self._saved_runai is not None:
+            sys.modules["runai_model_streamer"] = self._saved_runai
+        else:
+            sys.modules.pop("runai_model_streamer", None)
+        super().tearDown()
+
+    @patch("sglang.srt.model_loader.weight_utils.tqdm", side_effect=lambda x, **k: x)
+    def test_distributed_always_clones_tensors(self, _tqdm):
+        from sglang.srt.model_loader.weight_utils import runai_safetensors_weights_iterator
+
+        t = torch.tensor([1.0, 2.0])
+        self._streamer_instance._set_tensors([("w", t)])
+
+        name, got = next(
+            iter(runai_safetensors_weights_iterator(["p"], is_distributed=True))
+        )
+        self.assertEqual(name, "w")
+        self.assertTrue(torch.equal(got, t))
+        self.assertIsNot(got.untyped_storage(), t.untyped_storage())
+
+    @patch("sglang.srt.model_loader.weight_utils.tqdm", side_effect=lambda x, **k: x)
+    def test_non_distributed_yields_same_tensor(self, _tqdm):
+        from sglang.srt.model_loader.weight_utils import runai_safetensors_weights_iterator
+
+        t = torch.tensor([3.0])
+        self._streamer_instance._set_tensors([("w", t)])
+
+        name, got = next(
+            iter(runai_safetensors_weights_iterator(["p"], is_distributed=False))
+        )
+        self.assertIs(got, t)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

## Motivation

The `runai_streamer` load path ([Run:AI Model Streamer](https://github.com/run-ai/runai-model-streamer)) used for object storage (S3/GCS/Azure) had two problems:

1. **`RunaiModelStreamerLoader.load_model`** called `_initialize_model` without `quant_config`, unlike `DefaultModelLoader`. For FP8 / MoE models (e.g. DeepSeek-V3.x) the model skeleton was built as non-quantized, causing very high VRAM use or OOM in `unquant.py` before weights finished loading.

2. **`runai_safetensors_weights_iterator`** used `yield from` over the streamer iterator. With **distributed** streaming, Run:AI may reuse staging buffers across iterator steps; SGLang weight loaders retain references to yielded tensors, which can **silently corrupt weights**. Run:AI’s [usage.md (distributed streaming)](https://github.com/run-ai/runai-model-streamer/blob/master/docs/src/usage.md) states that consumers holding tensors beyond one `get_tensors()` step must clone. We therefore `clone()` each tensor when `is_distributed` is true.

## Modifications

- **`RunaiModelStreamerLoader`**: pass `quant_config` from `_get_quantization_config(model_config, self.load_config)` into `_initialize_model` (same pattern as `DefaultModelLoader`).
- **`runai_safetensors_weights_iterator`**: when `is_distributed`, iterate and `yield name, tensor.clone()`; otherwise keep `yield from` (no extra copy on the common non-distributed path).
- **`docs/advanced_features/object_storage.md`**: document that distributed streaming triggers per-tensor clones to avoid stale views into Run:AI internal buffers.
- **`test/registered/unit/model_loader/test_runai_streamer_loader.py`**: unit tests with a stub `runai_model_streamer` module (no Run:AI wheel required in CI); covers `quant_config` wiring and clone behavior. Registered with `register_cpu_ci`.

**Related:** may overlap with older RunAI-related PRs (e.g. #19047); resolve conflicts in `loader.py` / `weight_utils.py` if any.

## Accuracy Tests

**Not applicable** to the usual GSM8K-style check: this PR does not change forward kernels, sampling, or logits math. It fixes **weight loading** for `load_format=runai_streamer` (especially FP8 MoE + distributed streaming).

**Suggested manual validation** (maintainers / author with suitable hardware): load a large FP8 MoE model from object storage with `--model-loader-extra-config '{"distributed": true}'` and multi-GPU; verify sane generations vs. baseline (`distributed: false` or local checkpoint).

## Speed Tests and Profiling

**Not required** for merge: changes affect **load time / peak CPU memory** only (`clone` when `is_distributed`). Steady-state prefill/decode is unchanged. Optional: compare wall-clock load with distributed streaming before/after (expected small overhead from clones vs. correctness fix).

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). *(Tests added in this PR; please run `pytest` / CI.)*
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). *( `docs/advanced_features/object_storage.md` )*
- [x] Provide accuracy and speed benchmark results — **N/A** (see sections above; loader correctness fix, not forward-path performance).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance). *(Pending pre-commit / CI.)*

