### PR TITLE
[Doc] correct the HTTP endpoint for stopping profiling in `benchmark_and_profiling.md`

### DIFF
--- a/docs/developer_guide/benchmark_and_profiling.md
+++ b/docs/developer_guide/benchmark_and_profiling.md
@@ -155,7 +155,7 @@ curl -X POST http://127.0.0.1:30000/start_profile \
 **Parameters:**
 
 - `output_dir` (optional): Directory where profile traces will be saved. If not specified, uses `SGLANG_TORCH_PROFILER_DIR` environment variable, or `/tmp` as the default
-- `num_steps` (optional): Number of steps to profile. If not specified, profiling continues until manually stopped with `/end_profile`
+- `num_steps` (optional): Number of steps to profile. If not specified, profiling continues until manually stopped with `/stop_profile`
 - `start_step` (optional): Step number at which to start profiling (inclusive). Useful for skipping warmup iterations
 - `activities` (optional): List of activities to profile, e.g., `["CPU", "GPU"]`. Default is `["CPU", "GPU"]`
 - `merge_profiles` (optional): Whether to merge distributed traces. Default is `false`
@@ -179,17 +179,17 @@ curl -X POST http://127.0.0.1:30000/start_profile \
 **Continuous profiling (manual stop):**
 
 ```bash
-# Start profiling without num_steps - must manually stop with /end_profile
+# Start profiling without num_steps - must manually stop with /stop_profile
 curl -X POST http://127.0.0.1:30000/start_profile
 ```
 
-#### Using `/end_profile` endpoint
+#### Using `/stop_profile` endpoint
 
-The `/end_profile` endpoint stops an ongoing profiling session and saves the trace file.
+The `/stop_profile` endpoint stops an ongoing profiling session and saves the trace file.
 
 ```bash
 # Stop profiling and save traces
-curl -X POST http://127.0.0.1:30000/end_profile
+curl -X POST http://127.0.0.1:30000/stop_profile
 ```
 
 This is only needed when you start profiling without specifying `num_steps`. If `num_steps` is specified, profiling will automatically stop after that many steps.
@@ -212,7 +212,7 @@ curl -X POST http://127.0.0.1:30000/start_profile \
 python -m sglang.bench_serving --backend sglang --num-prompts 100
 
 # Terminal 2: Stop profiling when done
-curl -X POST http://127.0.0.1:30000/end_profile
+curl -X POST http://127.0.0.1:30000/stop_profile
 ```
 
 ### Profiler Trace Merger for Distributed Traces
@@ -406,10 +406,10 @@ This method allows you to control exactly when profiling starts/stops via HTTP A
 
    ```bash
    # Terminal 2: Only needed if num_steps was not specified
-   curl -X POST http://127.0.0.1:30000/end_profile
+   curl -X POST http://127.0.0.1:30000/stop_profile
    ```
 
-The `--capture-range=cudaProfilerApi` option tells Nsight Systems to only capture data between `cudaProfilerStart()` and `cudaProfilerStop()` calls (triggered by `/start_profile` and `/end_profile`), reducing overhead and file size. The `start_step` parameter skips the first 3 steps to avoid capturing warmup overhead.
+The `--capture-range=cudaProfilerApi` option tells Nsight Systems to only capture data between `cudaProfilerStart()` and `cudaProfilerStop()` calls (triggered by `/start_profile` and `/stop_profile`), reducing overhead and file size. The `start_step` parameter skips the first 3 steps to avoid capturing warmup overhead.
 
 **Method 2: Simpler approach without `/start_profile` API**
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Modifications

Doc fix: correct the HTTP endpoint for stopping profiling in `developer_guide/benchmark_and_profiling.md` to `/stop_profile`

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
