### PR TITLE
fix(runai): unsigned S3 for RunAI object storage

### DIFF
--- a/docs/advanced_features/object_storage.md
+++ b/docs/advanced_features/object_storage.md
@@ -16,6 +16,17 @@ When loading models from object storage, SGLang uses a two-phase approach:
 3. **Azure Blob**: `az://some-azure-container/path/`
 4. **S3 compatible**: `s3://bucket-name/path/to/model/`
 
+### Anonymous (unsigned) S3 / MinIO
+
+`boto3` signs S3 requests by default. For **public** buckets or endpoints that do not expect SigV4 (typical **local MinIO** or custom S3-compatible storage with anonymous read), SGLang may patch boto3 so **only** `s3` clients use `signature_version=UNSIGNED`.
+
+This is applied **automatically** when **both** are true:
+
+1. **No standard AWS credentials** are detected (no `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, no web identity / container credential env vars, and no static keys in the shared credentials file — default `~/.aws/credentials` or `AWS_SHARED_CREDENTIALS_FILE`).
+2. **EC2 instance metadata is disabled**: `AWS_EC2_METADATA_DISABLED=true` (or `1` / `yes`), so boto3 will not resolve an IAM role via IMDS.
+
+If metadata is left enabled on EC2, unsigned mode is **not** applied, so IAM role credentials continue to work.
+
 ## Quick Start
 
 ### Basic Usage

--- a/python/sglang/srt/utils/runai_utils.py
+++ b/python/sglang/srt/utils/runai_utils.py
@@ -3,11 +3,138 @@
 import hashlib
 import logging
 import os
+import threading
 from pathlib import Path
+from typing import Any
 
 from sglang.srt.environ import envs
 
 logger = logging.getLogger(__name__)
+
+_BOTO3_S3_UNSIGNED_PATCH_LOCK = threading.Lock()
+_BOTO3_S3_UNSIGNED_PATCH_APPLIED = False
+
+
+def _env_nonempty(name: str) -> bool:
+    v = os.environ.get(name)
+    return v is not None and str(v).strip() != ""
+
+
+def _aws_shared_credentials_file_has_static_keys() -> bool:
+    """True if the shared credentials file looks like it defines access keys."""
+    path = os.environ.get("AWS_SHARED_CREDENTIALS_FILE") or os.path.expanduser(
+        "~/.aws/credentials"
+    )
+    try:
+        if not os.path.isfile(path):
+            return False
+        with open(path, encoding="utf-8", errors="ignore") as f:
+            body = f.read()
+    except OSError:
+        return False
+    lower = body.lower()
+    return "[" in body and (
+        "aws_access_key_id" in lower or "aws_secret_access_key" in lower
+    )
+
+
+def _has_standard_aws_credentials() -> bool:
+    """Whether boto3 is likely to resolve credentials without UNSIGNED (heuristic)."""
+    if _env_nonempty("AWS_ACCESS_KEY_ID") and _env_nonempty("AWS_SECRET_ACCESS_KEY"):
+        return True
+    if _env_nonempty("AWS_WEB_IDENTITY_TOKEN_FILE") and _env_nonempty("AWS_ROLE_ARN"):
+        return True
+    if _env_nonempty("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") or _env_nonempty(
+        "AWS_CONTAINER_CREDENTIALS_FULL_URI"
+    ):
+        return True
+    if _aws_shared_credentials_file_has_static_keys():
+        return True
+    return False
+
+
+def _ec2_metadata_disabled() -> bool:
+    """EC2 instance metadata service disabled (common for local MinIO / custom S3)."""
+    v = os.environ.get("AWS_EC2_METADATA_DISABLED", "").strip().lower()
+    return v in ("true", "1", "yes")
+
+
+def _should_use_unsigned_s3_for_runai() -> bool:
+    """Use UNSIGNED S3 only when there are no explicit creds and IMDS is off.
+
+    If IMDS is left enabled, boto3 may still obtain an IAM role; forcing UNSIGNED
+    would break that path. Typical public-bucket + MinIO setup: no keys on disk,
+    ``AWS_EC2_METADATA_DISABLED=true``.
+    """
+    if _has_standard_aws_credentials():
+        return False
+    if not _ec2_metadata_disabled():
+        return False
+    return True
+
+
+def _install_boto3_s3_unsigned_patch(boto3: Any, Config: Any, UNSIGNED: Any) -> None:
+    """Merge UNSIGNED into config for boto3 S3 clients only (idempotent install)."""
+
+    def _merge_unsigned(cfg: Any) -> Any:
+        unsigned_cfg = Config(signature_version=UNSIGNED)
+        if cfg is None:
+            return unsigned_cfg
+        return cfg.merge(unsigned_cfg)
+
+    _orig_client = boto3.client
+    _orig_session_client = boto3.session.Session.client
+
+    def _client(*args: Any, **kwargs: Any) -> Any:
+        if args and args[0] == "s3":
+            kwargs = dict(kwargs)
+            kwargs["config"] = _merge_unsigned(kwargs.get("config"))
+        return _orig_client(*args, **kwargs)
+
+    def _session_client(self: Any, *args: Any, **kwargs: Any) -> Any:
+        if args and args[0] == "s3":
+            kwargs = dict(kwargs)
+            kwargs["config"] = _merge_unsigned(kwargs.get("config"))
+        return _orig_session_client(self, *args, **kwargs)
+
+    boto3.client = _client
+    boto3.session.Session.client = _session_client
+
+
+def _maybe_patch_boto3_s3_unsigned() -> None:
+    """Patch boto3 so new S3 clients use UNSIGNED when appropriate.
+
+    Enabled when no standard AWS credentials are configured and
+    ``AWS_EC2_METADATA_DISABLED`` is true (anonymous / public buckets, MinIO, etc.).
+    Safe to call multiple times; only S3 clients are affected.
+    """
+    if not _should_use_unsigned_s3_for_runai():
+        return
+
+    global _BOTO3_S3_UNSIGNED_PATCH_APPLIED
+
+    with _BOTO3_S3_UNSIGNED_PATCH_LOCK:
+        if _BOTO3_S3_UNSIGNED_PATCH_APPLIED:
+            return
+        try:
+            import boto3
+            from botocore import UNSIGNED
+            from botocore.config import Config
+        except ImportError as e:
+            logger.warning(
+                "RunAI unsigned S3: boto3/botocore not available (%s); "
+                "install boto3 for S3 object storage, or provide AWS credentials",
+                e,
+            )
+            return
+
+        _install_boto3_s3_unsigned_patch(boto3, Config, UNSIGNED)
+        _BOTO3_S3_UNSIGNED_PATCH_APPLIED = True
+        logger.info(
+            "RunAI object storage: S3 clients use signature_version=UNSIGNED "
+            "(no static credentials, AWS_EC2_METADATA_DISABLED)"
+        )
+
 
 SUPPORTED_SCHEMES = ["s3://", "gs://", "az://"]
 
@@ -38,6 +165,7 @@ def list_safetensors(path: str = "") -> list[str]:
     Returns:
         list[str]: List of full object storage paths allowed by the pattern
     """
+    _maybe_patch_boto3_s3_unsigned()
     from runai_model_streamer import list_safetensors as runai_list_safetensors
 
     return runai_list_safetensors(path)
@@ -67,6 +195,7 @@ class ObjectStorageModel:
     """
 
     def __init__(self, url: str) -> None:
+        _maybe_patch_boto3_s3_unsigned()
         self.dir = ObjectStorageModel.get_path(url)
 
         from runai_model_streamer import ObjectStorageModel as RunaiObjectStorageModel

--- a/test/registered/unit/model_loader/test_runai_unsigned_s3.py
+++ b/test/registered/unit/model_loader/test_runai_unsigned_s3.py
@@ -1,0 +1,152 @@
+"""Unit tests for RunAI object storage unsigned S3 (boto3 UNSIGNED patch).
+
+No Run:AI wheel required — mocks only.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+import sglang.srt.utils.runai_utils as runai_utils
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+
+
+def _reset_unsigned_patch_state() -> None:
+    runai_utils._BOTO3_S3_UNSIGNED_PATCH_APPLIED = False
+
+
+class TestRunaiUnsignedS3Heuristics(CustomTestCase):
+    def test_should_unsigned_true_without_creds_and_metadata_disabled(self):
+        with patch.object(
+            runai_utils, "_has_standard_aws_credentials", return_value=False
+        ):
+            with patch.dict(os.environ, {"AWS_EC2_METADATA_DISABLED": "true"}):
+                self.assertTrue(runai_utils._should_use_unsigned_s3_for_runai())
+
+    def test_should_unsigned_false_without_metadata_disabled(self):
+        with patch.object(
+            runai_utils, "_has_standard_aws_credentials", return_value=False
+        ):
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("AWS_EC2_METADATA_DISABLED", None)
+                self.assertFalse(runai_utils._should_use_unsigned_s3_for_runai())
+
+    def test_should_unsigned_false_when_env_has_access_keys(self):
+        with patch.dict(
+            os.environ,
+            {
+                "AWS_ACCESS_KEY_ID": "AKIATEST",
+                "AWS_SECRET_ACCESS_KEY": "secret",
+                "AWS_EC2_METADATA_DISABLED": "true",
+            },
+        ):
+            self.assertFalse(runai_utils._should_use_unsigned_s3_for_runai())
+
+
+class TestRunaiUnsignedS3Patch(CustomTestCase):
+    def tearDown(self):
+        _reset_unsigned_patch_state()
+        super().tearDown()
+
+    @patch.object(runai_utils, "_should_use_unsigned_s3_for_runai", return_value=False)
+    def test_maybe_patch_skips_when_heuristic_false(self, _):
+        _reset_unsigned_patch_state()
+        with patch.object(
+            runai_utils, "_install_boto3_s3_unsigned_patch"
+        ) as mock_install:
+            runai_utils._maybe_patch_boto3_s3_unsigned()
+            mock_install.assert_not_called()
+
+    @patch.object(runai_utils, "_should_use_unsigned_s3_for_runai", return_value=True)
+    def test_maybe_patch_calls_install_once(self, _):
+        _reset_unsigned_patch_state()
+        with patch.object(
+            runai_utils, "_install_boto3_s3_unsigned_patch"
+        ) as mock_install:
+            runai_utils._maybe_patch_boto3_s3_unsigned()
+            runai_utils._maybe_patch_boto3_s3_unsigned()
+            mock_install.assert_called_once()
+
+    def test_list_safetensors_triggers_maybe_patch(self):
+        _reset_unsigned_patch_state()
+        with patch.object(runai_utils, "_maybe_patch_boto3_s3_unsigned") as mock_maybe:
+            with patch(
+                "runai_model_streamer.list_safetensors",
+                return_value=["a.safetensors"],
+            ):
+                out = runai_utils.list_safetensors("s3://b/p/")
+        mock_maybe.assert_called_once()
+        self.assertEqual(out, ["a.safetensors"])
+
+    def test_object_storage_model_init_triggers_maybe_patch(self):
+        _reset_unsigned_patch_state()
+        with patch.object(runai_utils, "_maybe_patch_boto3_s3_unsigned") as mock_maybe:
+            with patch.object(
+                runai_utils.ObjectStorageModel,
+                "get_path",
+                return_value="/tmp/fake-cache",
+            ):
+                with patch(
+                    "runai_model_streamer.ObjectStorageModel",
+                    MagicMock(),
+                ):
+                    runai_utils.ObjectStorageModel(url="s3://b/m/")
+        mock_maybe.assert_called_once()
+
+    def test_install_merges_unsigned_for_s3_only(self):
+        calls: list[tuple[str, tuple, dict]] = []
+
+        def orig_client(*args, **kwargs):
+            calls.append(("client", args, dict(kwargs)))
+            return MagicMock()
+
+        class _SessionClass:
+            def client(self, *args, **kwargs):
+                calls.append(("session", args, dict(kwargs)))
+                return MagicMock()
+
+        class _SessMod:
+            Session = _SessionClass
+
+        boto3_mod = MagicMock()
+        boto3_mod.client = orig_client
+        boto3_mod.session = _SessMod()
+
+        UNSIGNED = object()
+
+        class _FakeConfig:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+            def merge(self, other):
+                merged = _FakeConfig()
+                merged.kwargs = {**self.kwargs, **other.kwargs}
+                return merged
+
+        runai_utils._install_boto3_s3_unsigned_patch(boto3_mod, _FakeConfig, UNSIGNED)
+
+        boto3_mod.client("ec2", region_name="us-east-1")
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][1][0], "ec2")
+        self.assertNotIn("config", calls[0][2] or {})
+
+        boto3_mod.client("s3", region_name="us-east-1")
+        self.assertEqual(calls[-1][1][0], "s3")
+        cfg = calls[-1][2]["config"]
+        self.assertIsInstance(cfg, _FakeConfig)
+        self.assertIs(cfg.kwargs.get("signature_version"), UNSIGNED)
+
+        boto3_mod.session.Session().client("s3", region_name="us-east-1")
+        self.assertEqual(calls[-1][1][0], "s3")
+        cfg2 = calls[-1][2]["config"]
+        self.assertIsInstance(cfg2, _FakeConfig)
+        self.assertIs(cfg2.kwargs.get("signature_version"), UNSIGNED)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

## Motivation

The `runai_streamer` load path ([Run:AI Model Streamer](https://github.com/run-ai/runai-model-streamer)) uses **boto3** for S3-compatible object storage. By default boto3 **signs** every S3 request, which breaks **anonymous** access to **public** buckets and many **S3-compatible** endpoints (e.g. **local MinIO**) where operators intentionally provide no AWS keys.

This PR does **not** add new SGLang `environ.py` flags (no `RUNAI_STREAMER_NO_SIGN_REQUEST`). Instead it enables `signature_version=UNSIGNED` for **S3 clients only** when **both** are true:

1. **No standard AWS credentials** are detected (no `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, no web-identity / container credential env vars, and no static keys in the shared credentials file — default `~/.aws/credentials` or `AWS_SHARED_CREDENTIALS_FILE`).
2. **`AWS_EC2_METADATA_DISABLED`** is set to a true value (`true` / `1` / `yes`), matching common Run:AI / MinIO setups and ensuring we **do not** override **EC2 IAM role** resolution via IMDS when metadata is still enabled.

## Modifications

- **`python/sglang/srt/utils/runai_utils.py`**: add `_has_standard_aws_credentials()`, `_ec2_metadata_disabled()`, `_should_use_unsigned_s3_for_runai()`; once-per-process patch `boto3.client` / `boto3.session.Session.client` so only **`s3`** merges `UNSIGNED` into `config`.
- **Call sites**: `_maybe_patch_boto3_s3_unsigned()` at the start of `list_safetensors()` and `ObjectStorageModel.__init__()` before Run:AI uses S3.
- **`docs/advanced_features/object_storage.md`**: new subsection *Anonymous (unsigned) S3 / MinIO* describing the heuristic.
- **`test/registered/unit/model_loader/test_runai_unsigned_s3.py`**: unit tests (mocks; no Run:AI wheel); `register_cpu_ci`.

**Related:** complements [PR #22522](https://github.com/sgl-project/sglang/pull/22522) (quant_config + distributed clone); this PR is intentionally separate and smaller.

## Accuracy Tests

**Not applicable** to GSM8K-style checks: no change to forward pass, logits, or sampling. This only affects **how boto3 builds S3 clients** for object-storage metadata listing and Run:AI streaming when the heuristic applies.

**Suggested manual validation:** point `--model-path` at a **public** `s3://` (or MinIO) bucket with `AWS_EC2_METADATA_DISABLED=true` and **no** credentials files/vars; confirm listing/loading works. With real IAM on EC2 and IMDS enabled, confirm behavior is unchanged (no UNSIGNED patch).

## Speed Tests and Profiling

**Not required**: negligible overhead (one-time boto3 wrapper install per process).

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). *(Tests added in this PR; please run `pytest` / CI.)*
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). *( `docs/advanced_features/object_storage.md` )*
- [x] Provide accuracy and speed benchmark results — **N/A** (see sections above; boto3 / load-path configuration only).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance). *(Pending pre-commit / CI.)*