### PR TITLE
[Model] Support sliding window attention for Qwen3

### DIFF
--- a/python/sglang/srt/models/qwen3.py
+++ b/python/sglang/srt/models/qwen3.py
@@ -36,6 +36,17 @@ from sglang.srt.utils import add_prefix, get_bool_env_var, is_cuda, is_hip, is_n
 Qwen3Config = None
 
 logger = logging.getLogger(__name__)
+
+
+# Aligned with HF's implementation, using sliding window inclusive with the last token
+# SGLang assumes exclusive
+def get_attention_sliding_window_size(config):
+    if getattr(config, "sliding_window", None) is not None:
+        return config.sliding_window - 1
+    else:
+        return None
+
+
 _is_cuda = is_cuda()
 _is_hip = is_hip()
 _is_npu = is_npu()
@@ -71,6 +82,7 @@ class Qwen3Attention(nn.Module):
         quant_config: Optional[QuantizationConfig] = None,
         rms_norm_eps: float = None,
         attention_bias: bool = False,
+        sliding_window_size: Optional[int] = None,
         prefix: str = "",
         alt_stream: Optional[torch.cuda.Stream] = None,
     ) -> None:
@@ -147,6 +159,7 @@ class Qwen3Attention(nn.Module):
             self.scaling,
             num_kv_heads=self.num_kv_heads,
             layer_id=layer_id,
+            sliding_window_size=sliding_window_size,
             prefix=add_prefix("attn", prefix),
         )
         self.alt_stream = alt_stream
@@ -320,6 +333,18 @@ class Qwen3DecoderLayer(nn.Module):
         rope_scaling = config.rope_parameters
         max_position_embeddings = getattr(config, "max_position_embeddings", 32768)
         head_dim = getattr(config, "head_dim", None)
+        # Determine per-layer sliding window size
+        interleaved_sliding_window = get_attention_sliding_window_size(config)
+        layer_types = getattr(config, "layer_types", None)
+        max_window_layers = getattr(config, "max_window_layers", None)
+
+        is_sliding = False
+        if interleaved_sliding_window is not None:
+            if layer_types is not None and layer_id < len(layer_types):
+                is_sliding = layer_types[layer_id] == "sliding_attention"
+            elif max_window_layers is not None:
+                is_sliding = layer_id < max_window_layers
+
         self.self_attn = Qwen3Attention(
             hidden_size=self.hidden_size,
             num_heads=config.num_attention_heads,
@@ -332,6 +357,7 @@ class Qwen3DecoderLayer(nn.Module):
             quant_config=quant_config,
             rms_norm_eps=config.rms_norm_eps,
             attention_bias=config.attention_bias,
+            sliding_window_size=(interleaved_sliding_window if is_sliding else None),
             prefix=add_prefix("self_attn", prefix),
             alt_stream=alt_stream,
         )
@@ -492,6 +518,9 @@ class Qwen3ForCausalLM(nn.Module):
 
         # For EAGLE3 support
         self.capture_aux_hidden_states = False
+
+    def get_attention_sliding_window_size(self):
+        return get_attention_sliding_window_size(self.config)
 
     def get_input_embeddings(self) -> nn.Embedding:
         return self.model.get_input_embeddings()


### PR DESCRIPTION
## Summary
- Add interleaved sliding window attention (SWA) support for Qwen3 model
- Driven by HF config fields `layer_types` (primary) and `max_window_layers` (fallback), consistent with HuggingFace Transformers native support
- Standard Qwen3 models without these config fields remain completely unaffected

Closes #22528

## Changes
- Add `get_attention_sliding_window_size()` helper (HF-inclusive to SGLang-exclusive conversion)
- Determine per-layer sliding/full attention in `Qwen3DecoderLayer.__init__` using `layer_types` or `max_window_layers`
- Pass `sliding_window_size` through `Qwen3Attention` to `RadixAttention`
- Add `get_attention_sliding_window_size()` to `Qwen3ForCausalLM` for backend initialization

## Motivation
We are training a new model based on Qwen3 architecture with alternating sliding/full attention pattern (3:1 sliding:full). HuggingFace Transformers already supports this via `layer_types` config field. This PR brings SGLang in line with that support.

Example config.json:
```json
{
  "sliding_window": 512,
  "layer_types": ["sliding_attention", "sliding_attention", "sliding_attention", "full_attention", ...]
}
```

## Test plan
- [x] Verified layer assignment logic matches HF config for 3:1 pattern (27 sliding, 9 full across 36 layers)
- [x] Verified max_window_layers fallback works when layer_types is absent
- [x] Verified backward compatibility: models without sliding_window config are unaffected
- [x] Confirmed all attention backends (FlashInfer, Triton, FlashAttention, XPU, AIter, TRT-LLM) correctly handle per-layer sliding_window_size via existing RadixAttention dispatch