### PR TITLE
[diffusion] support parallel vae for LTX2 (WIP)

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/vaes/ltx_2_vae.py
+++ b/python/sglang/multimodal_gen/runtime/models/vaes/ltx_2_vae.py
@@ -130,6 +130,9 @@ class LTX2VideoCausalConv3d(nn.Module):
         return hidden_states
 
 
+LocalLTX2VideoCausalConv3d = LTX2VideoCausalConv3d
+
+
 # Like LTXVideoResnetBlock3d, but uses new causal Conv3d, normal Conv3d for the conv_shortcut, and the spatial padding
 # mode is configurable
 class LTX2VideoResnetBlock3d(nn.Module):
@@ -304,7 +307,8 @@ class LTXVideoDownsampler3d(nn.Module):
             self.stride[0] * self.stride[1] * self.stride[2]
         )
 
-        self.conv = LTX2VideoCausalConv3d(
+        # Downsampler gathers full height before this conv, so it must stay local.
+        self.conv = LocalLTX2VideoCausalConv3d(
             in_channels=in_channels,
             out_channels=out_channels,
             kernel_size=3,
@@ -1602,7 +1606,8 @@ class AutoencoderKLLTX2Video(ParallelTiledVAE):
                 The stride between two consecutive horizontal tiles. This is to ensure that there are no tiling
                 artifacts produced across the width dimension.
         """
-        if get_vae_parallel_world_size() > 1:
+        # TODO: need a better way to determine if tiling is supported
+        if get_vae_parallel_world_size() >= 8:
             self.use_tiling = False
             return
         self.use_tiling = True

--- a/python/sglang/multimodal_gen/runtime/models/vaes/ltx_2_vae.py
+++ b/python/sglang/multimodal_gen/runtime/models/vaes/ltx_2_vae.py
@@ -12,6 +12,26 @@ from diffusers.models.modeling_outputs import AutoencoderKLOutput
 
 from sglang.multimodal_gen.configs.models.vaes.ltx_video import LTXVideoVAEConfig
 from sglang.multimodal_gen.runtime.models.vaes.common import ParallelTiledVAE
+from sglang.multimodal_gen.runtime.models.vaes.parallel.ltx2_dist_utils import (
+    DistLTX2VideoCausalConv3d,
+)
+from sglang.multimodal_gen.runtime.models.vaes.parallel.parallel_utils import (
+    gather_tensor,
+    get_vae_parallel_world_size,
+    split_tensor,
+)
+
+_LTX2_VAE_PARALLEL_ENABLED = False
+
+
+def _maybe_enable_ltx2_vae_parallel() -> None:
+    global _LTX2_VAE_PARALLEL_ENABLED, LTX2VideoCausalConv3d
+    if _LTX2_VAE_PARALLEL_ENABLED:
+        return
+    if get_vae_parallel_world_size() <= 1:
+        return
+    LTX2VideoCausalConv3d = DistLTX2VideoCausalConv3d
+    _LTX2_VAE_PARALLEL_ENABLED = True
 
 
 class PerChannelRMSNorm(nn.Module):
@@ -272,6 +292,9 @@ class LTXVideoDownsampler3d(nn.Module):
     ) -> None:
         super().__init__()
 
+        _maybe_enable_ltx2_vae_parallel()
+        self._use_parallel = get_vae_parallel_world_size() > 1
+
         self.stride = stride if isinstance(stride, tuple) else (stride, stride, stride)
         self.group_size = (
             in_channels * stride[0] * stride[1] * stride[2]
@@ -290,6 +313,9 @@ class LTXVideoDownsampler3d(nn.Module):
         )
 
     def forward(self, hidden_states: torch.Tensor, causal: bool = True) -> torch.Tensor:
+        if self._use_parallel:
+            hidden_states = gather_tensor(hidden_states, dim=3)
+
         hidden_states = torch.cat(
             [hidden_states[:, :, : self.stride[0] - 1], hidden_states], dim=2
         )
@@ -312,6 +338,9 @@ class LTXVideoDownsampler3d(nn.Module):
         hidden_states = hidden_states.permute(0, 1, 3, 5, 7, 2, 4, 6).flatten(1, 4)
         hidden_states = hidden_states + residual
 
+        if self._use_parallel:
+            hidden_states = split_tensor(hidden_states, dim=3)
+
         return hidden_states
 
 
@@ -326,6 +355,9 @@ class LTXVideoUpsampler3d(nn.Module):
         spatial_padding_mode: str = "zeros",
     ) -> None:
         super().__init__()
+
+        _maybe_enable_ltx2_vae_parallel()
+        self._use_parallel = get_vae_parallel_world_size() > 1
 
         self.stride = stride if isinstance(stride, tuple) else (stride, stride, stride)
         self.residual = residual
@@ -871,6 +903,9 @@ class LTX2VideoEncoder3d(nn.Module):
     ):
         super().__init__()
 
+        _maybe_enable_ltx2_vae_parallel()
+        self._use_parallel = get_vae_parallel_world_size() > 1
+
         self.patch_size = patch_size
         self.patch_size_t = patch_size_t
         self.in_channels = in_channels * patch_size**2
@@ -955,6 +990,8 @@ class LTX2VideoEncoder3d(nn.Module):
         )
         # Thanks for driving me insane with the weird patching order :(
         hidden_states = hidden_states.permute(0, 1, 3, 7, 5, 2, 4, 6).flatten(1, 4)
+        if self._use_parallel:
+            hidden_states = split_tensor(hidden_states, dim=3)
         hidden_states = self.conv_in(hidden_states, causal=causal)
 
         if torch.is_grad_enabled() and self.gradient_checkpointing:
@@ -979,6 +1016,9 @@ class LTX2VideoEncoder3d(nn.Module):
         last_channel = hidden_states[:, -1:]
         last_channel = last_channel.repeat(1, hidden_states.size(1) - 2, 1, 1, 1)
         hidden_states = torch.cat([hidden_states, last_channel], dim=1)
+
+        if self._use_parallel:
+            hidden_states = gather_tensor(hidden_states, dim=3)
 
         return hidden_states
 
@@ -1030,6 +1070,9 @@ class LTX2VideoDecoder3d(nn.Module):
         spatial_padding_mode: str = "reflect",
     ) -> None:
         super().__init__()
+
+        _maybe_enable_ltx2_vae_parallel()
+        self._use_parallel = get_vae_parallel_world_size() > 1
 
         self.patch_size = patch_size
         self.patch_size_t = patch_size_t
@@ -1119,6 +1162,9 @@ class LTX2VideoDecoder3d(nn.Module):
     ) -> torch.Tensor:
         causal = causal or self.is_causal
 
+        if self._use_parallel:
+            hidden_states = split_tensor(hidden_states, dim=3)
+
         hidden_states = self.conv_in(hidden_states, causal=causal)
 
         if self.timestep_scale_multiplier is not None:
@@ -1156,6 +1202,9 @@ class LTX2VideoDecoder3d(nn.Module):
 
         hidden_states = self.conv_act(hidden_states)
         hidden_states = self.conv_out(hidden_states, causal=causal)
+
+        if self._use_parallel:
+            hidden_states = gather_tensor(hidden_states, dim=3)
 
         p = self.patch_size
         p_t = self.patch_size_t
@@ -1249,6 +1298,9 @@ class LTX23VideoDecoder3d(nn.Module):
     ) -> None:
         super().__init__()
 
+        _maybe_enable_ltx2_vae_parallel()
+        self._use_parallel = get_vae_parallel_world_size() > 1
+
         self.patch_size = patch_size
         self.patch_size_t = patch_size_t
         self.out_channels = out_channels * patch_size**2
@@ -1314,6 +1366,8 @@ class LTX23VideoDecoder3d(nn.Module):
         causal = self.is_causal if causal is None else causal
 
         hidden_states = self.per_channel_statistics.un_normalize(hidden_states)
+        if self._use_parallel:
+            hidden_states = split_tensor(hidden_states, dim=3)
         hidden_states = self.conv_in(hidden_states, causal=causal)
 
         if self.timestep_scale_multiplier is not None and temb is not None:
@@ -1345,6 +1399,9 @@ class LTX23VideoDecoder3d(nn.Module):
         hidden_states = self.conv_act(hidden_states)
         hidden_states = self.conv_out(hidden_states, causal=causal)
 
+        if self._use_parallel:
+            hidden_states = gather_tensor(hidden_states, dim=3)
+
         p = self.patch_size
         p_t = self.patch_size_t
         batch_size, _, num_frames, height, width = hidden_states.shape
@@ -1372,6 +1429,7 @@ class AutoencoderKLLTX2Video(ParallelTiledVAE):
 
     def __init__(self, config: LTXVideoVAEConfig):
         super().__init__(config=config)
+        _maybe_enable_ltx2_vae_parallel()
         in_channels = config.arch_config.in_channels
         latent_channels = config.arch_config.latent_channels
         out_channels = config.arch_config.out_channels
@@ -1544,6 +1602,9 @@ class AutoencoderKLLTX2Video(ParallelTiledVAE):
                 The stride between two consecutive horizontal tiles. This is to ensure that there are no tiling
                 artifacts produced across the width dimension.
         """
+        if get_vae_parallel_world_size() > 1:
+            self.use_tiling = False
+            return
         self.use_tiling = True
         self.tile_sample_min_height = (
             tile_sample_min_height or self.tile_sample_min_height

--- a/python/sglang/multimodal_gen/runtime/models/vaes/parallel/halo_exchange_utils.py
+++ b/python/sglang/multimodal_gen/runtime/models/vaes/parallel/halo_exchange_utils.py
@@ -1,0 +1,100 @@
+from typing import List
+
+import torch
+import torch.distributed as dist
+
+
+def calc_patch_height_index(patch_height_list: List[torch.Tensor]) -> torch.Tensor:
+    patch_heights = torch.stack(patch_height_list).view(-1)
+    return torch.cat([patch_heights.new_zeros(1), torch.cumsum(patch_heights, dim=0)])
+
+
+def calc_top_halo_size(
+    local_rank, world_size, patch_height_index, kernel_size, padding, stride
+):
+    assert kernel_size % 2 == 1, "kernel_size must be odd"
+    if local_rank == 0:
+        return 0
+    nstep_before_top = (
+        patch_height_index[local_rank] + padding - (kernel_size - 1) // 2 + stride - 1
+    ) // stride
+    top_halo_size = patch_height_index[local_rank] - (
+        nstep_before_top * stride - padding
+    )
+    return top_halo_size
+
+
+def calc_bottom_halo_size(
+    local_rank, world_size, patch_height_index, kernel_size, padding, stride
+):
+    assert kernel_size % 2 == 1, "kernel_size must be odd"
+    if local_rank == world_size - 1:
+        return 0
+    nstep_before_bottom = (
+        patch_height_index[local_rank + 1]
+        + padding
+        - (kernel_size - 1) // 2
+        + stride
+        - 1
+    ) // stride
+    bottom_halo_size = (
+        (nstep_before_bottom - 1) * stride
+        + kernel_size
+        - padding
+        - patch_height_index[local_rank + 1]
+    )
+    return bottom_halo_size
+
+
+def halo_exchange(
+    x: torch.Tensor,
+    *,
+    rank: int,
+    group,
+    prev_bottom_halo_size: int,
+    next_top_halo_size: int,
+    curr_top_halo_size: int,
+    curr_bottom_halo_size: int,
+) -> torch.Tensor:
+    b, c, t, _, w = x.shape
+    device = x.device
+
+    comm_ops = []
+    top_halo_recv = None
+    bottom_halo_recv = None
+
+    if prev_bottom_halo_size > 0:
+        top_halo_send = x[:, :, :, :prev_bottom_halo_size, :].contiguous()
+        comm_ops.append(dist.P2POp(dist.isend, top_halo_send, rank - 1, group=group))
+
+    if next_top_halo_size > 0:
+        bottom_halo_send = x[:, :, :, -next_top_halo_size:, :].contiguous()
+        comm_ops.append(dist.P2POp(dist.isend, bottom_halo_send, rank + 1, group=group))
+
+    if curr_top_halo_size > 0:
+        top_halo_recv = torch.empty(
+            [b, c, t, curr_top_halo_size, w], dtype=x.dtype, device=device
+        )
+        comm_ops.append(dist.P2POp(dist.irecv, top_halo_recv, rank - 1, group=group))
+    elif curr_top_halo_size < 0:
+        x = x[:, :, :, -curr_top_halo_size:, :]
+
+    if curr_bottom_halo_size > 0:
+        bottom_halo_recv = torch.empty(
+            [b, c, t, curr_bottom_halo_size, w], dtype=x.dtype, device=device
+        )
+        comm_ops.append(dist.P2POp(dist.irecv, bottom_halo_recv, rank + 1, group=group))
+    elif curr_bottom_halo_size < 0:
+        x = x[:, :, :, :curr_bottom_halo_size, :]
+
+    if comm_ops:
+        reqs = dist.batch_isend_irecv(comm_ops)
+        for req in reqs:
+            req.wait()
+
+    if top_halo_recv is not None:
+        x = torch.cat([top_halo_recv, x], dim=-2)
+    if bottom_halo_recv is not None:
+        x = torch.cat([x, bottom_halo_recv], dim=-2)
+
+    return x

--- a/python/sglang/multimodal_gen/runtime/models/vaes/parallel/ltx2_dist_utils.py
+++ b/python/sglang/multimodal_gen/runtime/models/vaes/parallel/ltx2_dist_utils.py
@@ -1,0 +1,161 @@
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+
+from sglang.multimodal_gen.runtime.models.vaes.parallel.halo_exchange_utils import (
+    calc_bottom_halo_size,
+    calc_patch_height_index,
+    calc_top_halo_size,
+    halo_exchange,
+)
+from sglang.multimodal_gen.runtime.models.vaes.parallel.parallel_utils import (
+    get_vae_group,
+    get_vae_parallel_rank,
+    get_vae_parallel_world_size,
+)
+
+
+class DistLTX2VideoCausalConv3d(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int | tuple[int, int, int] = 3,
+        stride: int | tuple[int, int, int] = 1,
+        dilation: int | tuple[int, int, int] = 1,
+        groups: int = 1,
+        spatial_padding_mode: str = "zeros",
+    ):
+        super().__init__()
+
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.kernel_size = (
+            kernel_size if isinstance(kernel_size, tuple) else (kernel_size,) * 3
+        )
+        self.stride = stride if isinstance(stride, tuple) else (stride,) * 3
+        self.dilation = dilation if isinstance(dilation, tuple) else (dilation, 1, 1)
+        self.groups = groups
+        self.spatial_padding_mode = spatial_padding_mode
+
+        height_pad = self.kernel_size[1] // 2
+        width_pad = self.kernel_size[2] // 2
+        self._spatial_padding = (width_pad, width_pad, height_pad, height_pad, 0, 0)
+
+        self.conv = nn.Conv3d(
+            in_channels,
+            out_channels,
+            self.kernel_size,
+            stride=self.stride,
+            dilation=self.dilation,
+            groups=groups,
+            padding=0,
+            padding_mode="zeros",
+        )
+
+        self.rank = get_vae_parallel_rank()
+        self.world_size = get_vae_parallel_world_size()
+        self.group = get_vae_group()
+
+    def _pad_spatial(self, x: torch.Tensor, padding: list[int]) -> torch.Tensor:
+        if self.spatial_padding_mode == "zeros":
+            return F.pad(x, padding)
+        return F.pad(x, padding, mode=self.spatial_padding_mode)
+
+    def forward(self, hidden_states: torch.Tensor, causal: bool = True) -> torch.Tensor:
+        time_kernel_size = self.kernel_size[0]
+
+        if causal:
+            pad_left = hidden_states[:, :, :1, :, :].repeat(
+                (1, 1, time_kernel_size - 1, 1, 1)
+            )
+            hidden_states = torch.concatenate([pad_left, hidden_states], dim=2)
+        else:
+            half = (time_kernel_size - 1) // 2
+            pad_left = hidden_states[:, :, :1, :, :].repeat((1, 1, half, 1, 1))
+            pad_right = hidden_states[:, :, -1:, :, :].repeat((1, 1, half, 1, 1))
+            hidden_states = torch.concatenate(
+                [pad_left, hidden_states, pad_right], dim=2
+            )
+
+        padding = list(self._spatial_padding)
+        if self.world_size <= 1 or self.group is None:
+            hidden_states = self._pad_spatial(hidden_states, padding)
+            return self.conv(hidden_states)
+
+        height = hidden_states.shape[-2]
+        device = hidden_states.device
+        patch_height_list = [
+            torch.zeros(1, dtype=torch.int64, device=device)
+            for _ in range(self.world_size)
+        ]
+        dist.all_gather(
+            patch_height_list,
+            torch.tensor([height], dtype=torch.int64, device=device),
+            group=self.group,
+        )
+        patch_height_index = calc_patch_height_index(patch_height_list)
+        self.patch_height_index = patch_height_index.cpu().tolist()
+
+        height_padding = self._spatial_padding[2]
+        self.curr_top_halo_size = calc_top_halo_size(
+            self.rank,
+            self.world_size,
+            self.patch_height_index,
+            self.kernel_size[1],
+            height_padding,
+            self.stride[1],
+        )
+
+        self.curr_bottom_halo_size = calc_bottom_halo_size(
+            self.rank,
+            self.world_size,
+            self.patch_height_index,
+            self.kernel_size[1],
+            height_padding,
+            self.stride[1],
+        )
+
+        self.prev_bottom_halo_size = 0
+        if self.rank != 0:
+            self.prev_bottom_halo_size = calc_bottom_halo_size(
+                self.rank - 1,
+                self.world_size,
+                self.patch_height_index,
+                self.kernel_size[1],
+                height_padding,
+                self.stride[1],
+            )
+
+        self.next_top_halo_size = 0
+        if self.rank != self.world_size - 1:
+            self.next_top_halo_size = calc_top_halo_size(
+                self.rank + 1,
+                self.world_size,
+                self.patch_height_index,
+                self.kernel_size[1],
+                height_padding,
+                self.stride[1],
+            )
+
+        hidden_states = halo_exchange(
+            hidden_states,
+            rank=self.rank,
+            group=self.group,
+            prev_bottom_halo_size=self.prev_bottom_halo_size,
+            next_top_halo_size=self.next_top_halo_size,
+            curr_top_halo_size=self.curr_top_halo_size,
+            curr_bottom_halo_size=self.curr_bottom_halo_size,
+        )
+
+        if self.rank == 0:
+            padding[3] = 0
+        elif self.rank == self.world_size - 1:
+            padding[2] = 0
+        else:
+            padding[2] = 0
+            padding[3] = 0
+
+        hidden_states = self._pad_spatial(hidden_states, padding)
+        return self.conv(hidden_states)

--- a/python/sglang/multimodal_gen/runtime/models/vaes/parallel/parallel_utils.py
+++ b/python/sglang/multimodal_gen/runtime/models/vaes/parallel/parallel_utils.py
@@ -1,0 +1,123 @@
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+
+from sglang.multimodal_gen.runtime.distributed import parallel_state as _ps
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+
+logger = init_logger(__name__)
+
+
+def get_vae_group():
+    if not dist.is_available() or not dist.is_initialized():
+        return None
+    if getattr(_ps, "_VAE", None) is None:
+        # Fallback to global group if no explicit VAE group is created.
+        if not getattr(get_vae_group, "_warned_fallback", False):
+            logger.warning(
+                "VAE group not initialized; falling back to global process group."
+            )
+            get_vae_group._warned_fallback = True
+        return dist.group.WORLD
+    return _ps.get_vae_parallel_group()
+
+
+def get_vae_parallel_world_size() -> int:
+    group = get_vae_group()
+    if group is None:
+        return 1
+    return dist.get_world_size(group=group)
+
+
+def get_vae_parallel_rank() -> int:
+    group = get_vae_group()
+    if group is None:
+        return 0
+    return dist.get_rank(group=group)
+
+
+def _pad_on_dim(x: torch.Tensor, dim: int, pad_size: int) -> torch.Tensor:
+    if pad_size <= 0:
+        return x
+    pad = [0] * (2 * x.dim())
+    pad[(x.dim() - 1 - dim) * 2 + 1] = pad_size
+    return F.pad(x, pad)
+
+
+def _normalize_dim(dim: int, ndim: int) -> int:
+    if dim < 0:
+        dim += ndim
+    if dim < 0 or dim >= ndim:
+        raise IndexError(f"dim {dim} out of range for tensor with {ndim} dims")
+    return dim
+
+
+def _get_shard_range(length: int, world_size: int, rank: int) -> tuple[int, int]:
+    base = length // world_size
+    remainder = length % world_size
+    start = rank * base + min(rank, remainder)
+    end = start + base + (1 if rank < remainder else 0)
+    return start, end
+
+
+def _slice_on_dim(x: torch.Tensor, dim: int, start: int, end: int) -> torch.Tensor:
+    slices = [slice(None)] * x.dim()
+    slices[dim] = slice(start, end)
+    return x[tuple(slices)].contiguous()
+
+
+def gather_tensor(
+    x: torch.Tensor,
+    dim: int = 3,
+    sizes: list[int] | None = None,
+    return_sizes: bool = False,
+) -> torch.Tensor | tuple[torch.Tensor, list[int] | None]:
+    group = get_vae_group()
+    world_size = get_vae_parallel_world_size()
+    if world_size <= 1 or group is None:
+        return (x, sizes) if return_sizes else x
+
+    dim = _normalize_dim(dim, x.dim())
+
+    if sizes is None:
+        device = x.device
+        size_value = torch.tensor([x.shape[dim]], device=device, dtype=torch.int64)
+        size_list = [torch.zeros_like(size_value) for _ in range(world_size)]
+        dist.all_gather(size_list, size_value, group=group)
+        sizes = [int(s.item()) for s in size_list]
+
+    max_size = max(sizes)
+    if x.shape[dim] < max_size:
+        x = _pad_on_dim(x, dim, max_size - x.shape[dim])
+
+    shards = [torch.empty_like(x) for _ in range(world_size)]
+    dist.all_gather(shards, x.contiguous(), group=group)
+    trimmed = [_slice_on_dim(t, dim, 0, sizes[i]) for i, t in enumerate(shards)]
+    gathered = torch.cat(trimmed, dim=dim)
+    return (gathered, sizes) if return_sizes else gathered
+
+
+def split_tensor(
+    x: torch.Tensor,
+    dim: int = 3,
+    sizes: list[int] | None = None,
+    return_sizes: bool = False,
+) -> torch.Tensor | tuple[torch.Tensor, list[int] | None]:
+    group = get_vae_group()
+    rank = get_vae_parallel_rank()
+    world_size = get_vae_parallel_world_size()
+    if world_size <= 1 or group is None:
+        return (x, sizes) if return_sizes else x
+
+    dim = _normalize_dim(dim, x.dim())
+    if sizes is None:
+        start, end = _get_shard_range(x.shape[dim], world_size, rank)
+        length = x.shape[dim]
+        base = length // world_size
+        remainder = length % world_size
+        sizes = [base + (1 if i < remainder else 0) for i in range(world_size)]
+    else:
+        start = sum(sizes[:rank])
+        end = start + sizes[rank]
+    shard = _slice_on_dim(x, dim, start, end)
+    return (shard, sizes) if return_sizes else shard

--- a/python/sglang/multimodal_gen/runtime/pipelines/ltx_2_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/ltx_2_pipeline.py
@@ -198,6 +198,29 @@ def _add_ltx2_decoding_stage(pipeline: ComposedPipelineBase):
 class LTX2FlowMatchScheduler(FlowMatchEulerDiscreteScheduler):
     """Override ``_time_shift_exponential`` to use torch f32 instead of numpy f64."""
 
+    def stretch_shift_to_terminal(self, t: torch.Tensor) -> torch.Tensor:
+        """
+        Guard against degenerate warmup schedules (e.g., num_inference_steps=1)
+        that can make scale_factor=0 and trigger divide-by-zero warnings.
+        """
+        one_minus_z = 1 - t
+        denom = 1 - self.config.shift_terminal
+        if denom == 0:
+            return t
+        scale_factor = one_minus_z[-1] / denom
+        if torch.is_tensor(scale_factor):
+            is_finite = torch.isfinite(scale_factor).item()
+            is_zero = scale_factor.item() == 0
+        else:
+            sf = float(scale_factor)
+            is_finite = math.isfinite(sf)
+            is_zero = sf == 0
+        # If scale_factor is 0 or non-finite, fall back to the original schedule.
+        if (not is_finite) or is_zero:
+            return t
+        stretched_t = 1 - (one_minus_z / scale_factor)
+        return stretched_t
+
     def set_timesteps(
         self,
         num_inference_steps=None,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

### TODO: 
The configuration method of the Parallel VAE group and whether it is left to the user's choice.
Refactor Wan Parallel VAE using the implementation approach of this PR.  
A better approach is needed to support the use of `parallel` and `tiling`.
1. For Wan, since its VAE operates in a streaming manner, tiling is not critical. However, for LTX2, if the degree of parallelism is not high, tiling is very necessary.
2. Should the choice and control of parallel and tiling be left to the user?

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

4xA800, Script:
```bash
sglang generate \
    --model-path LTX-2 \
    --pipeline-class-name LTX2TwoStagePipeline \
    --prompt "A beautiful sunset over the ocean" \
    --negative-prompt "shaky, glitchy, low quality, worst quality, deformed, distorted, disfigured, motion smear, motion artifacts, fused fingers, bad anatomy, weird hand, ugly, transition, static." \
    --width 1536 \
    --height 1024 \
    --num-frames 121 \
    --fps 24 \
    --seed 1234 \
    --enable-torch-compile \
    --warmup \
    --save-output \
    --dit-cpu-offload false \
    --dit-layerwise-offload false \
    --image-encoder-cpu-offload false \
    --vae-cpu-offload false \
    --num-gpus 4 \
    --ulysses-degree 4 \
```

### Before (tiling)
```
[04-09 10:13:55] [LTX2AVDecodingStage] started...
[04-09 10:14:04] [LTX2AVDecodingStage] finished in 8.3143 seconds
```

### After (tiling + parallel)
```
[04-10 14:19:02] [LTX2AVDecodingStage] started...
[04-10 14:19:08] [LTX2AVDecodingStage] finished in 5.7150 seconds
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
4. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
5. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
