### PR TITLE
[Scheduler] Replace batch_is_full flag with dynamic token budget watermark

### DIFF
--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -371,10 +371,6 @@ class SchedulerDisaggregationPrefillMixin:
     def get_next_disagg_prefill_batch_to_run(
         self: Scheduler,
     ) -> Optional[ScheduleBatch]:
-        # HACK (byronhsu): reset the batch_is_full flag because we never enter update_running_batch which resets it
-        # Otherwise, it hangs under high concurrency
-        self.running_batch.batch_is_full = False
-
         self.process_prefill_chunk()
 
         batch = self.get_new_batch_prefill()
@@ -732,7 +728,6 @@ class SchedulerDisaggregationPrefillMixin:
                 )
             else:
                 self.send_kv_chunk(self.chunked_req)
-            self.running_batch.batch_is_full = False
 
         if self.last_batch and self.last_batch.forward_mode.is_extend():
             if self.last_batch.chunked_req:
@@ -740,12 +735,9 @@ class SchedulerDisaggregationPrefillMixin:
                 # We need to discard it.
                 chunked_req_to_exclude.add(self.last_batch.chunked_req)
 
-            last_bs = self.last_batch.batch_size()
             self.last_batch.filter_batch(
                 chunked_req_to_exclude=list(chunked_req_to_exclude)
             )
-            if self.last_batch.batch_size() < last_bs:
-                self.running_batch.batch_is_full = False
 
     def send_kv_chunk(
         self: Scheduler,

--- a/python/sglang/srt/dllm/mixin/scheduler.py
+++ b/python/sglang/srt/dllm/mixin/scheduler.py
@@ -28,8 +28,6 @@ class SchedulerDllmMixin:
 
     def get_new_batch_dllm(self: Scheduler) -> Optional[ScheduleBatch]:
         """Generate a new batch for DLLM (Diffusion LLM) scheduling."""
-        if self.enable_priority_preemption:
-            self.running_batch.batch_is_full = False
 
         # Early exit if batch is full or no requests available
         if self._should_skip_prefill():
@@ -51,6 +49,10 @@ class SchedulerDllmMixin:
         can_run_list = adder.can_run_list
         if not can_run_list:
             return None
+
+        # A successful admission means conditions changed; clear the
+        # NO_TOKEN watermark so we re-evaluate on the next round.
+        self._available_size_at_last_no_token = -1
 
         # Record metrics and update state
         set_time_batch(can_run_list, "set_forward_entry_time")
@@ -113,20 +115,21 @@ class SchedulerDllmMixin:
 
     def _should_skip_prefill(self: Scheduler) -> bool:
         """Check if DLLM prefill should be skipped."""
-        if (
-            self.running_batch.batch_is_full or not self.waiting_queue
-        ) and self.dllm_manager.is_empty():
-            return True
+        # When DLLM manager has queued work or preemption is enabled,
+        # always enter the prefill path.
+        if not self.dllm_manager.is_empty() or self.enable_priority_preemption:
+            return False
 
-        running_bs = len(self.running_batch.reqs)
         if (
-            self.get_num_allocatable_reqs(running_bs) <= 0
-            and self.dllm_manager.is_empty()
-            and not self.enable_priority_preemption
+            self._available_size_at_last_no_token >= 0
+            and self._get_available_token_budget()
+            <= self._available_size_at_last_no_token
         ):
-            self.running_batch.batch_is_full = True
             return True
-
+        if not self.waiting_queue:
+            return True
+        if self.get_num_allocatable_reqs(len(self.running_batch.reqs)) <= 0:
+            return True
         return False
 
     def _create_dllm_prefill_adder(self: Scheduler, running_bs: int) -> PrefillAdder:
@@ -240,11 +243,12 @@ class SchedulerDllmMixin:
         for req in reqs:
             # Check if batch is full
             running_bs = len(self.running_batch.reqs)
-            if len(adder.can_run_list) >= self.get_num_allocatable_reqs(running_bs):
-                self.running_batch.batch_is_full = True
+            adder_is_full = len(adder.can_run_list) >= self.get_num_allocatable_reqs(
+                running_bs
+            )
 
             # Try preemption if batch is full
-            if self.running_batch.batch_is_full:
+            if adder_is_full:
                 if (
                     not self.enable_priority_preemption
                     or not adder.preempt_to_schedule(req, self.server_args)
@@ -261,7 +265,9 @@ class SchedulerDllmMixin:
 
             if res != AddReqResult.CONTINUE:
                 if res == AddReqResult.NO_TOKEN:
-                    self.running_batch.batch_is_full = True
+                    self._available_size_at_last_no_token = (
+                        self._get_available_token_budget()
+                    )
                 break
 
         return res

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1327,10 +1327,6 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     model_config: ModelConfig = None
     forward_mode: ForwardMode = None
     enable_overlap: bool = False
-    # Tell whether the current running batch is full so that we can skip
-    # the check of whether to prefill new requests.
-    # This is an optimization to reduce the overhead of the prefill check.
-    batch_is_full: bool = False
 
     # For chunked prefill in PP
     chunked_req: Optional[Req] = None
@@ -1490,6 +1486,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
     def is_empty(self):
         return len(self.reqs) == 0
+
+    def is_full(self):
+        return len(self.reqs) >= get_global_server_args().pp_max_micro_batch_size
 
     def is_dllm(self):
         return self.dllm_config is not None

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -58,6 +58,45 @@ CLIP_MAX_NEW_TOKENS = int(
     os.environ.get("SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION", "4096")
 )
 
+
+def compute_available_token_budget(
+    token_to_kv_pool_allocator,
+    tree_cache: BasePrefixCache,
+    running_reqs: list,
+    new_token_ratio: float,
+) -> int:
+    """Compute the effective token budget for prefill admission.
+
+    Returns available + evictable tokens minus the running batch's future
+    generation reservation.  This is the same value as
+    ``PrefillAdder.rem_total_tokens`` (before ``mixed_with_decode_tokens``
+    is applied)."""
+    if isinstance(token_to_kv_pool_allocator, SWATokenToKVPoolAllocator):
+        available_and_evictable = (
+            token_to_kv_pool_allocator.full_available_size()
+            + tree_cache.full_evictable_size()
+        )
+    elif tree_cache.supports_mamba():
+        available_and_evictable = (
+            token_to_kv_pool_allocator.available_size()
+            + tree_cache.full_evictable_size()
+        )
+    else:
+        available_and_evictable = (
+            token_to_kv_pool_allocator.available_size() + tree_cache.evictable_size()
+        )
+
+    offset = sum(
+        min(
+            r.sampling_params.max_new_tokens - len(r.output_ids),
+            CLIP_MAX_NEW_TOKENS,
+        )
+        * new_token_ratio
+        for r in running_reqs
+    )
+    return available_and_evictable - int(offset)
+
+
 # Threshold for in-batch prefix cache.
 # If a request has a matched prefix length (against existing cache) less than this value,
 # the scheduler runs the in-batch prefix caching check for this request.
@@ -415,14 +454,6 @@ class PrefillAdder:
         # TODO(lsyin): report the real input tokens excluding page alignment
         self.log_input_tokens = 0
 
-        if running_batch is not None:
-            self.rem_total_token_offset += sum(
-                [
-                    self._get_running_request_total_token_offset(r)
-                    for r in running_batch.reqs
-                ]
-            )
-
         self.is_hybrid_swa = isinstance(
             self.token_to_kv_pool_allocator, SWATokenToKVPoolAllocator
         )
@@ -457,22 +488,15 @@ class PrefillAdder:
 
     @property
     def rem_total_tokens(self):
-        if self.is_hybrid_swa:
-            available_and_evictable = (
-                self.token_to_kv_pool_allocator.full_available_size()
-                + self.tree_cache.full_evictable_size()
+        return (
+            compute_available_token_budget(
+                self.token_to_kv_pool_allocator,
+                self.tree_cache,
+                self.running_batch.reqs if self.running_batch is not None else [],
+                self.new_token_ratio,
             )
-        elif self.is_hybrid_ssm_cache:
-            available_and_evictable = (
-                self.token_to_kv_pool_allocator.available_size()
-                + self.tree_cache.full_evictable_size()
-            )
-        else:
-            available_and_evictable = (
-                self.token_to_kv_pool_allocator.available_size()
-                + self.tree_cache.evictable_size()
-            )
-        return available_and_evictable - self.rem_total_token_offset
+            - self.rem_total_token_offset
+        )
 
     @property
     def rem_swa_tokens(self):
@@ -949,9 +973,6 @@ class PrefillAdder:
         release_counter = 0
         for i, running_req in enumerate(self.running_batch.reqs):
             if running_req in preemptible_reqs:
-                self.rem_total_token_offset -= (
-                    self._get_running_request_total_token_offset(running_req)
-                )
                 release_counter += 1
                 self.running_batch.release_req(
                     i, len(self.running_batch.reqs) - release_counter, server_args

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -168,6 +168,7 @@ from sglang.srt.managers.schedule_policy import (
     AddReqResult,
     PrefillAdder,
     SchedulePolicy,
+    compute_available_token_budget,
 )
 from sglang.srt.managers.scheduler_dp_attn_mixin import SchedulerDPAttnMixin
 from sglang.srt.managers.scheduler_input_blocker import SchedulerInputBlocker
@@ -897,11 +898,15 @@ class Scheduler(
     def init_running_status(self):
         self.waiting_queue: List[Req] = []
         # The running decoding batch for continuous batching
-        self.running_batch: ScheduleBatch = ScheduleBatch(reqs=[], batch_is_full=False)
+        self.running_batch: ScheduleBatch = ScheduleBatch(reqs=[])
         # The current forward batch
         self.cur_batch: Optional[ScheduleBatch] = None
         # The last forward batch
         self.last_batch: Optional[ScheduleBatch] = None
+        # Records the token pool available size when the last prefill attempt
+        # failed due to NO_TOKEN. Avoids re-entering the expensive prefill path
+        # until decode frees tokens and available_size increases.
+        self._available_size_at_last_no_token: int = -1
         self.forward_ct = 0
         self.return_health_check_ipcs: Deque[Optional[str]] = deque()
         self._pending_flush: Optional[Tuple[FlushCacheReqInput, float]] = None
@@ -2013,6 +2018,9 @@ class Scheduler(
                 )
 
     def _add_request_to_queue(self, req: Req, is_retracted: bool = False):
+        # New request may fit where the previous one didn't; re-evaluate.
+        self._available_size_at_last_no_token = -1
+
         if self.disaggregation_mode == DisaggregationMode.NULL:
             if not self._set_or_validate_priority(req):
                 return
@@ -2284,8 +2292,6 @@ class Scheduler(
                 else:
                     self.running_batch.merge_batch(new_batch)
                 self.running_batch.hisparse_coordinator = self.hisparse_coordinator
-            # Reset batch_is_full so the scheduler can schedule more prefills.
-            self.running_batch.batch_is_full = False
 
         if (
             not self.enable_hisparse
@@ -2301,12 +2307,9 @@ class Scheduler(
                 chunked_req_to_exclude.update(self.last_batch.reqs)
 
             # Filter batch
-            last_bs = self.last_batch.batch_size()
             self.last_batch.filter_batch(
                 chunked_req_to_exclude=list(chunked_req_to_exclude)
             )
-            if self.last_batch.batch_size() < last_bs:
-                self.running_batch.batch_is_full = False
 
             # Merge the new batch into the running batch.
             if not self.last_batch.is_empty():
@@ -2369,6 +2372,15 @@ class Scheduler(
             res = min(res, self.req_to_token_pool.available_size())
         return res
 
+    def _get_available_token_budget(self) -> int:
+        """Return the effective token budget for prefill admission."""
+        return compute_available_token_budget(
+            self.token_to_kv_pool_allocator,
+            self.tree_cache,
+            self.running_batch.reqs,
+            self.new_token_ratio,
+        )
+
     def get_new_batch_prefill(self) -> Optional[ScheduleBatch]:
         prefill_delayer_single_pass = None
         if self.prefill_delayer:
@@ -2399,13 +2411,22 @@ class Scheduler(
         if self.enable_hierarchical_cache:
             self.tree_cache.check_hicache_events()
 
-        if self.enable_priority_preemption:
-            # Reset batch_is_full to try preemption with a prefill adder.
-            self.running_batch.batch_is_full = False
+        # Skip prefill if token budget was exhausted on the last attempt and
+        # no tokens have been freed since then (avoids expensive busy-loop).
+        if (
+            self._available_size_at_last_no_token >= 0
+            and self._get_available_token_budget()
+            <= self._available_size_at_last_no_token
+            and self.chunked_req is None
+            and not self.enable_priority_preemption
+        ):
+            return None
 
         if (
-            self.running_batch.batch_is_full or len(self.waiting_queue) == 0
-        ) and self.chunked_req is None:
+            (self.running_batch.is_full() or len(self.waiting_queue) == 0)
+            and self.chunked_req is None
+            and not self.enable_priority_preemption
+        ):
             return None
 
         running_bs = len(self.running_batch.reqs)
@@ -2420,7 +2441,6 @@ class Scheduler(
             and self.chunked_req is not None
             and not self.enable_priority_preemption
         ):
-            self.running_batch.batch_is_full = True
             return None
 
         # Get priority queue
@@ -2484,15 +2504,16 @@ class Scheduler(
                         continue
 
             running_bs = len(self.running_batch.reqs)
-            if len(adder.can_run_list) >= self.get_num_allocatable_reqs(running_bs):
-                self.running_batch.batch_is_full = True
+            adder_is_full = len(adder.can_run_list) >= self.get_num_allocatable_reqs(
+                running_bs
+            )
             if self.disaggregation_mode == DisaggregationMode.PREFILL:
                 # In prefill mode, prealloc queue and transfer queue can also take memory,
                 # so we need to check if the available size for the actual available size.
                 if len(adder.can_run_list) >= self.req_to_token_pool.available_size():
-                    self.running_batch.batch_is_full = True
+                    adder_is_full = True
 
-            if self.running_batch.batch_is_full:
+            if adder_is_full:
                 if (
                     not self.enable_priority_preemption
                     or not adder.preempt_to_schedule(req, self.server_args)
@@ -2521,13 +2542,9 @@ class Scheduler(
 
             if res != AddReqResult.CONTINUE:
                 if res == AddReqResult.NO_TOKEN:
-                    if self.enable_hierarchical_cache:
-                        # Set batch_is_full after making sure there are requests that can be served
-                        self.running_batch.batch_is_full = len(
-                            adder.can_run_list
-                        ) > 0 or (not self.running_batch.is_empty())
-                    else:
-                        self.running_batch.batch_is_full = True
+                    self._available_size_at_last_no_token = (
+                        self._get_available_token_budget()
+                    )
                 # revert matched mamba idx to avoid memory leak, if req is not added
                 added = len(adder.can_run_list) > 0 and req is adder.can_run_list[-1]
                 if not added and req.mamba_pool_idx is not None:
@@ -2541,6 +2558,10 @@ class Scheduler(
         can_run_list: List[Req] = adder.can_run_list
         if len(can_run_list) == 0:
             return None
+
+        # A successful admission means conditions changed; clear the
+        # NO_TOKEN watermark so we re-evaluate on the next round.
+        self._available_size_at_last_no_token = -1
 
         can_run_set = set(can_run_list)
         self.waiting_queue = [x for x in self.waiting_queue if x not in can_run_set]
@@ -2611,9 +2632,7 @@ class Scheduler(
                 self.running_batch.prepare_for_decode()
                 new_batch.mix_with_running(self.running_batch)
                 new_batch.decoding_reqs = self.running_batch.reqs
-            self.running_batch = ScheduleBatch(
-                reqs=[], batch_is_full=self.running_batch.batch_is_full
-            )
+            self.running_batch = ScheduleBatch(reqs=[])
         else:
             new_batch.decoding_reqs = None
 
@@ -2625,7 +2644,6 @@ class Scheduler(
 
         batch.filter_batch(v1_spec_info_filtered=True)
         if batch.is_empty():
-            batch.batch_is_full = False
             return batch
 
         # Eagerly release lock_ref on completed write-through nodes so they
@@ -2686,9 +2704,6 @@ class Scheduler(
                 self.new_token_ratio - self.new_token_ratio_decay,
                 self.min_new_token_ratio,
             )
-
-        if batch.batch_size() < initial_bs:
-            batch.batch_is_full = False
 
         if batch.is_empty():
             return batch
@@ -3413,7 +3428,6 @@ class Scheduler(
                 for req in retracted_reqs:
                     self._add_request_to_queue(req)
 
-            self.running_batch.batch_is_full = False
             self.chunked_req = None
 
     def continue_generation(self, recv_req: ContinueGenerationReqInput):

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -314,8 +314,6 @@ class SchedulerPPMixin:
                 release_rids = next_release_rids
                 consensus_bootstrapped_rids = next_consensus_bootstrapped_rids
 
-                self.running_batch.batch_is_full = False
-
             # When the server is idle, self-check and re-init some states
             if server_is_idle and len(self.disagg_prefill_inflight_queue) == 0:
                 self.on_idle()
@@ -496,8 +494,6 @@ class SchedulerPPMixin:
                 consensus_retract_rids = next_consensus_retract_rids
                 consensus_prealloc_rids = next_consensus_prealloc_rids
 
-                self.running_batch.batch_is_full = False
-
             # When the server is idle, self-check and re-init some states
             queue_size = (
                 len(self.waiting_queue)
@@ -518,10 +514,7 @@ class SchedulerPPMixin:
         )
         self.mbs = [None] * self.pp_loop_size
         self.last_mbs = [None] * self.pp_loop_size
-        self.running_mbs = [
-            ScheduleBatch(reqs=[], batch_is_full=False)
-            for _ in range(self.pp_loop_size)
-        ]
+        self.running_mbs = [ScheduleBatch(reqs=[]) for _ in range(self.pp_loop_size)]
         self.mb_metadata: List[Optional[PPBatchMetadata]] = [None] * self.pp_loop_size
         self.pp_outputs: Optional[PPProxyTensors] = None
         self.last_rank_comm_queue: deque[Tuple[torch.cuda.Event, PPProxyTensors]] = (

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -3,7 +3,11 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from sglang.srt.managers.schedule_batch import Req
-from sglang.srt.managers.schedule_policy import AddReqResult, PrefillAdder
+from sglang.srt.managers.schedule_policy import (
+    AddReqResult,
+    PrefillAdder,
+    compute_available_token_budget,
+)
 from sglang.srt.mem_cache.base_prefix_cache import (
     DecLockRefResult,
     IncLockRefResult,
@@ -33,6 +37,7 @@ class TestPrefillAdder(CustomTestCase):
         tree_cache.full_evictable_size.return_value = full_evictable_size
         tree_cache.swa_evictable_size.return_value = swa_evictable_size
         tree_cache.evictable_size.return_value = evictable_size
+        tree_cache.supports_mamba.return_value = False
         tree_cache.disable = False
         tree_cache.inc_lock_ref.return_value = IncLockRefResult()
         tree_cache.dec_lock_ref.return_value = DecLockRefResult()
@@ -55,7 +60,12 @@ class TestPrefillAdder(CustomTestCase):
         batch = MagicMock()
         batch.reqs = list(reqs or [])
         batch.release_req.return_value = None
-        batch.filter_batch.return_value = None
+
+        def _filter_batch(keep_indices=None, **kwargs):
+            if keep_indices is not None:
+                batch.reqs[:] = [batch.reqs[i] for i in keep_indices]
+
+        batch.filter_batch.side_effect = _filter_batch
         return batch
 
     def create_server_args(
@@ -110,7 +120,7 @@ class TestPrefillAdder(CustomTestCase):
         running_batch = self.create_running_batch(running_reqs)
         adder = self.create_adder(running_batch)
 
-        self.assertEqual(adder.rem_total_token_offset, 225)
+        self.assertEqual(adder.rem_total_tokens, -225)  # 0 - (50+75+100)
 
         self.mock_token_allocator.full_available_size.return_value = (
             225  # full occupation of GRam
@@ -123,7 +133,7 @@ class TestPrefillAdder(CustomTestCase):
 
         self.assertTrue(success)
         self.assertIn(running_reqs[0], adder.preempt_list)
-        self.assertEqual(adder.rem_total_token_offset, 175)  # 50 + 75 + 100 - 50 = 175
+        self.assertEqual(adder.rem_total_tokens, 50)  # 225 - (75+100)
         running_batch.release_req.assert_called_once()
 
     def test_preempt_success_low_priority_values_first(self):
@@ -142,7 +152,7 @@ class TestPrefillAdder(CustomTestCase):
         running_batch = self.create_running_batch(running_reqs)
         adder = self.create_adder(running_batch)
 
-        self.assertEqual(adder.rem_total_token_offset, 225)
+        self.assertEqual(adder.rem_total_tokens, -225)  # 0 - (50+75+100)
 
         self.mock_token_allocator.full_available_size.return_value = (
             225  # full occupation of GRam
@@ -155,7 +165,7 @@ class TestPrefillAdder(CustomTestCase):
 
         self.assertTrue(success)
         self.assertIn(running_reqs[2], adder.preempt_list)
-        self.assertEqual(adder.rem_total_token_offset, 125)  # 50 + 75 + 100 - 100 = 125
+        self.assertEqual(adder.rem_total_tokens, 100)  # 225 - (50+75)
         running_batch.release_req.assert_called_once()
 
     def test_preempt_fail_low_priority_values_first(self):
@@ -174,7 +184,7 @@ class TestPrefillAdder(CustomTestCase):
         running_batch = self.create_running_batch(running_reqs)
         adder = self.create_adder(running_batch)
 
-        self.assertEqual(adder.rem_total_token_offset, 225)
+        self.assertEqual(adder.rem_total_tokens, -225)  # 0 - (50+75+100)
 
         self.mock_token_allocator.full_available_size.return_value = (
             225  # full occupation of GRam
@@ -214,7 +224,7 @@ class TestPrefillAdder(CustomTestCase):
         running_batch = self.create_running_batch(running_reqs)
         adder = self.create_adder(running_batch)
 
-        self.assertEqual(adder.rem_total_token_offset, 225)
+        self.assertEqual(adder.rem_total_tokens, -225)  # 0 - (50+75+100)
 
         self.mock_token_allocator.full_available_size.return_value = (
             225  # full occupation of GRam
@@ -254,7 +264,7 @@ class TestPrefillAdder(CustomTestCase):
         running_batch = self.create_running_batch(running_reqs)
         adder = self.create_adder(running_batch)
 
-        self.assertEqual(adder.rem_total_token_offset, 225)
+        self.assertEqual(adder.rem_total_tokens, -225)  # 0 - (50+75+100)
 
         self.mock_token_allocator.full_available_size.return_value = 225
         self.mock_token_allocator.available_size.return_value = 225
@@ -266,7 +276,7 @@ class TestPrefillAdder(CustomTestCase):
         first_success = adder.preempt_to_schedule(first_req, mock_server_args)
         self.assertTrue(first_success)
         self.assertIn(running_reqs[0], adder.preempt_list)
-        self.assertEqual(adder.rem_total_token_offset, 175)
+        self.assertEqual(adder.rem_total_tokens, 50)  # 225 - (75+100)
         running_batch.release_req.assert_called_once()
 
         # Second call needs more tokens than currently free, so it would need to
@@ -277,7 +287,7 @@ class TestPrefillAdder(CustomTestCase):
         second_success = adder.preempt_to_schedule(second_req, mock_server_args)
 
         self.assertFalse(second_success)
-        self.assertEqual(adder.rem_total_token_offset, 175)
+        self.assertEqual(adder.rem_total_tokens, 50)  # unchanged, preemption failed
         self.assertEqual(adder.preempt_list.count(running_reqs[0]), 1)
         running_batch.release_req.assert_called_once()
 
@@ -299,7 +309,7 @@ class TestPrefillAdder(CustomTestCase):
         running_batch = self.create_running_batch(running_reqs)
         adder = self.create_adder(running_batch)
 
-        self.assertEqual(adder.rem_total_token_offset, 475)
+        self.assertEqual(adder.rem_total_tokens, -475)  # 0 - (50+75+100+125+125)
 
         self.mock_token_allocator.full_available_size.return_value = (
             475  # full occupation of GRam
@@ -311,9 +321,7 @@ class TestPrefillAdder(CustomTestCase):
         success = adder.preempt_to_schedule(new_req, mock_server_args)
         self.assertTrue(success)
         self.assertIn(running_reqs[2], adder.preempt_list)
-        self.assertEqual(
-            adder.rem_total_token_offset, 375
-        )  # 50 + 75 + 100 + 125 + 125 - 100 = 375
+        self.assertEqual(adder.rem_total_tokens, 100)  # 475 - (50+75+125+125)
         running_batch.release_req.assert_called_once()
 
     def test_preempt_success_low_priority_values_first_exact_twice(self):
@@ -334,7 +342,7 @@ class TestPrefillAdder(CustomTestCase):
         running_batch = self.create_running_batch(running_reqs)
         adder = self.create_adder(running_batch)
 
-        self.assertEqual(adder.rem_total_token_offset, 475)
+        self.assertEqual(adder.rem_total_tokens, -475)  # 0 - (50+75+100+125+125)
 
         self.mock_token_allocator.full_available_size.return_value = (
             475  # full occupation of GRam
@@ -347,9 +355,7 @@ class TestPrefillAdder(CustomTestCase):
         self.assertTrue(success)
         self.assertIn(running_reqs[2], adder.preempt_list)
         self.assertIn(running_reqs[3], adder.preempt_list)
-        self.assertEqual(
-            adder.rem_total_token_offset, 250
-        )  # 50 + 75 + 100 + 125 + 125 - 100 - 125 = 250
+        self.assertEqual(adder.rem_total_tokens, 225)  # 475 - (50+75+125)
         self.assertEqual(running_batch.release_req.call_count, 2)
 
     def test_mixed_chunk_prefill_budgets(self):
@@ -370,7 +376,7 @@ class TestPrefillAdder(CustomTestCase):
 
         self.assertEqual(adder.rem_input_tokens, 192)  # 200 - 8
         self.assertEqual(adder.rem_chunk_tokens, 56)  # 64 - 8
-        self.assertEqual(adder.rem_total_token_offset, 408)  # 8 + 8 * 50
+        self.assertEqual(adder.rem_total_tokens, 592)  # 1000 - 8*50 - 8
         self.assertEqual(adder.cur_rem_token_offset, 8)
         self.assertEqual(adder.budget_state(), AddReqResult.CONTINUE)
 
@@ -405,7 +411,7 @@ class TestPrefillAdder(CustomTestCase):
 
         self.assertEqual(adder2.rem_input_tokens, 195)  # 200 - 5
         self.assertEqual(adder2.rem_chunk_tokens, 59)  # 64 - 5
-        self.assertEqual(adder2.rem_total_token_offset, 255)  # 5 + 5 * 50
+        self.assertEqual(adder2.rem_total_tokens, 745)  # 1000 - 5*50 - 5
         self.assertEqual(adder2.budget_state(), AddReqResult.CONTINUE)
 
         # Same prefill no longer exhausts the chunk budget
@@ -441,6 +447,41 @@ class TestPrefillAdder(CustomTestCase):
         self.assertEqual(len(adder2.can_run_list), 2)
         self.assertEqual(adder2.rem_chunk_tokens, 0)  # 3 - 3 = 0
         self.assertEqual(result3, AddReqResult.OTHER)
+
+    def test_compute_available_token_budget(self):
+        """Test the shared token budget computation used by both
+        the scheduler watermark and PrefillAdder."""
+        reqs = [
+            self.create_mock_req("r1", 0, max_new_tokens=100),
+            self.create_mock_req("r2", 0, max_new_tokens=200, output_len=50),
+        ]
+        self.mock_token_allocator.available_size.return_value = 500
+
+        budget = compute_available_token_budget(
+            self.mock_token_allocator, self.mock_tree_cache, reqs, new_token_ratio=1.0
+        )
+        # 500 + 0(evictable) - 100 - 150(200-50) = 250
+        self.assertEqual(budget, 250)
+
+        # Evictable cache contributes to budget
+        cache = self.create_tree_cache(evictable_size=100)
+        budget2 = compute_available_token_budget(
+            self.mock_token_allocator, cache, reqs, new_token_ratio=1.0
+        )
+        self.assertEqual(budget2, 350)
+
+        # new_token_ratio scales the offset
+        budget3 = compute_available_token_budget(
+            self.mock_token_allocator, self.mock_tree_cache, reqs, new_token_ratio=0.5
+        )
+        # 500 - (100*0.5 + 150*0.5) = 500 - 125 = 375
+        self.assertEqual(budget3, 375)
+
+        # Empty running batch = no offset
+        budget4 = compute_available_token_budget(
+            self.mock_token_allocator, self.mock_tree_cache, [], new_token_ratio=1.0
+        )
+        self.assertEqual(budget4, 500)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_scheduler_pause_generation.py
+++ b/test/registered/unit/managers/test_scheduler_pause_generation.py
@@ -25,7 +25,7 @@ class TestSchedulerPauseGeneration(unittest.TestCase):
         scheduler.running_batch = MagicMock()
         scheduler.running_batch.reqs = []
         scheduler.running_batch.is_empty.return_value = True
-        scheduler.running_batch.batch_is_full = False
+        scheduler.running_batch.is_full.return_value = False
         scheduler.tree_cache = MagicMock()
         scheduler.tree_cache.protected_size.return_value = 0
         scheduler.req_to_token_pool = MagicMock()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

fixes #22518

the easy fix would've been to change sglang/srt/managers/scheduler.py, adding something like:
```
            if self.running_batch.is_empty():
                self.running_batch.batch_is_full = False
```
However, that would just mask the underlying issue:  batch_is_full flag is not working all that well and maintaining it is hard. Also, that fix would create a performance problem: hitting a full batch would require the batch to fully drain before any more work can be scheduled, thus eating into throughput under high load.

There are [other spots](https://github.com/sgl-project/sglang/blob/dc125afffbd585fd758a24de66f17b2fb2a9de91/python/sglang/srt/disaggregation/prefill.py#L376) where hacks have been applied to work around batch_is_full behavior.

That being said, I do realize that the above fix is a better first contribution: we can go back to that option.

## Modifications

Removed the stateful batch_is_full boolean from ScheduleBatch and replaced it with two mechanisms:

- ScheduleBatch.is_full(): a dynamic check against pp_max_micro_batch_size for request-slot admission control.
- _available_size_at_last_no_token: a self-resetting watermark that tracks he effective token budget (via compute_available_token_budget) when prefill admission fails with NO_TOKEN, avoiding expensive busy-loop re-entry into the PrefillAdder path.

The watermark self-resets when decode progress frees tokens, cache becomes evictable, or the running batch offset shrinks. It is also cleared on successful admission and when new requests enter the waiting queue.

This eliminates ~15 manual reset sites that were required to keep the old boolean consistent, reducing the surface area for scheduling bugs.


## Accuracy Tests

Should not affect model outputs (in ways other than the batching changes)

That being said, this PR results in the following result when running the prescribed test, using ```python3 -m sglang.launch_server --model Qwen/Qwen2-7B-Instruct``` for the server and ```python3 -m sglang.test.few_shot_gsm8k --num-questions 200``` for the test
```
Accuracy: 0.820
Invalid: 0.000
Latency: 21.377 s
Output throughput: 1361.292 token/s
```
Main branch:
```
Accuracy: 0.840
Invalid: 0.000
Latency: 30.887 s
Output throughput: 931.904 token/s
```

## Speed Tests and Profiling

I've used the same  ```python3 -m sglang.launch_server --model Qwen/Qwen2-7B-Instruct``` as for above
Using the ```python3 -m sglang.bench_serving --backend sglang --max-concurrency 16 --num-prompts 80 --random-input-len 256 --random-output-len 32 --dataset-name random``` command as per guide.
<details>
<summary>Test results</summary>
This PR:

```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 16
Successful requests:                     80
Benchmark duration (s):                  2.83
Total input tokens:                      10653
Total input text tokens:                 10653
Total generated tokens:                  1221
Total generated tokens (retokenized):    1221
Request throughput (req/s):              28.30
Input token throughput (tok/s):          3768.78
Output token throughput (tok/s):         431.96
Peak output token throughput (tok/s):    458.00
Peak concurrent requests:                44
Total token throughput (tok/s):          4200.74
Concurrency:                             14.70
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   519.35
Median E2E Latency (ms):                 455.91
P90 E2E Latency (ms):                    931.53
P99 E2E Latency (ms):                    1096.25
---------------Time to First Token----------------
Mean TTFT (ms):                          101.49
Median TTFT (ms):                        73.28
P99 TTFT (ms):                           283.30
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          28.98
Median TPOT (ms):                        30.30
P99 TPOT (ms):                           44.66
---------------Inter-Token Latency----------------
Mean ITL (ms):                           29.30
Median ITL (ms):                         17.56
P95 ITL (ms):                            86.99
P99 ITL (ms):                            114.72
Max ITL (ms):                            237.79
==================================================
```
Main branch:
```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 16
Successful requests:                     80
Benchmark duration (s):                  5.25
Total input tokens:                      10653
Total input text tokens:                 10653
Total generated tokens:                  1221
Total generated tokens (retokenized):    1221
Request throughput (req/s):              15.23
Input token throughput (tok/s):          2027.83
Output token throughput (tok/s):         232.42
Peak output token throughput (tok/s):    284.00
Peak concurrent requests:                33
Total token throughput (tok/s):          2260.25
Concurrency:                             14.78
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   970.55
Median E2E Latency (ms):                 906.00
P90 E2E Latency (ms):                    1724.22
P99 E2E Latency (ms):                    1984.67
---------------Time to First Token----------------
Mean TTFT (ms):                          183.36
Median TTFT (ms):                        141.78
P99 TTFT (ms):                           444.84
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          54.52
Median TPOT (ms):                        56.75
P99 TPOT (ms):                           90.12
---------------Inter-Token Latency----------------
Mean ITL (ms):                           55.19
Median ITL (ms):                         32.08
P95 ITL (ms):                            186.17
P99 ITL (ms):                            240.76
Max ITL (ms):                            421.38
==================================================
```

Running a slightly longer test with more concurrency to add more congestion:

PR branch:
```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 32
Successful requests:                     800
Benchmark duration (s):                  14.00
Total input tokens:                      103717
Total input text tokens:                 103717
Total generated tokens:                  13129
Total generated tokens (retokenized):    13107
Request throughput (req/s):              57.15
Input token throughput (tok/s):          7409.31
Output token throughput (tok/s):         937.91
Peak output token throughput (tok/s):    1007.00
Peak concurrent requests:                99
Total token throughput (tok/s):          8347.21
Concurrency:                             31.29
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   547.56
Median E2E Latency (ms):                 561.98
P90 E2E Latency (ms):                    976.07
P99 E2E Latency (ms):                    1104.37
---------------Time to First Token----------------
Mean TTFT (ms):                          50.20
Median TTFT (ms):                        49.33
P99 TTFT (ms):                           68.44
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          31.91
Median TPOT (ms):                        32.63
P99 TPOT (ms):                           49.60
---------------Inter-Token Latency----------------
Mean ITL (ms):                           32.27
Median ITL (ms):                         23.17
P95 ITL (ms):                            72.02
P99 ITL (ms):                            82.12
Max ITL (ms):                            87.57
==================================================
```
Main branch
```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 32
Successful requests:                     800
Benchmark duration (s):                  14.16
Total input tokens:                      103717
Total input text tokens:                 103717
Total generated tokens:                  13129
Total generated tokens (retokenized):    13107
Request throughput (req/s):              56.51
Input token throughput (tok/s):          7325.94
Output token throughput (tok/s):         927.35
Peak output token throughput (tok/s):    1007.00
Peak concurrent requests:                95
Total token throughput (tok/s):          8253.29
Concurrency:                             31.30
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   553.95
Median E2E Latency (ms):                 560.32
P90 E2E Latency (ms):                    994.74
P99 E2E Latency (ms):                    1121.61
---------------Time to First Token----------------
Mean TTFT (ms):                          51.11
Median TTFT (ms):                        50.27
P99 TTFT (ms):                           72.68
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          32.26
Median TPOT (ms):                        33.00
P99 TPOT (ms):                           51.24
---------------Inter-Token Latency----------------
Mean ITL (ms):                           32.63
Median ITL (ms):                         22.59
P95 ITL (ms):                            72.34
P99 ITL (ms):                            84.48
Max ITL (ms):                            95.07
==================================================
```

Really going for it with the concurrency
PR branch:
```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 512
Successful requests:                     800
Benchmark duration (s):                  4.47
Total input tokens:                      103717
Total input text tokens:                 103717
Total generated tokens:                  13129
Total generated tokens (retokenized):    13110
Request throughput (req/s):              179.12
Input token throughput (tok/s):          23222.11
Output token throughput (tok/s):         2939.57
Peak output token throughput (tok/s):    4281.00
Peak concurrent requests:                672
Total token throughput (tok/s):          26161.67
Concurrency:                             407.91
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   2277.30
Median E2E Latency (ms):                 2216.82
P90 E2E Latency (ms):                    3716.30
P99 E2E Latency (ms):                    3918.35
---------------Time to First Token----------------
Mean TTFT (ms):                          405.10
Median TTFT (ms):                        465.87
P99 TTFT (ms):                           552.58
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          156.80
Median TPOT (ms):                        133.75
P99 TPOT (ms):                           763.42
---------------Inter-Token Latency----------------
Mean ITL (ms):                           121.48
Median ITL (ms):                         76.62
P95 ITL (ms):                            264.42
P99 ITL (ms):                            761.77
Max ITL (ms):                            805.70
==================================================
```
Main Branch:
```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 512
Successful requests:                     800
Benchmark duration (s):                  4.66
Total input tokens:                      103717
Total input text tokens:                 103717
Total generated tokens:                  13129
Total generated tokens (retokenized):    13113
Request throughput (req/s):              171.56
Input token throughput (tok/s):          22241.72
Output token throughput (tok/s):         2815.46
Peak output token throughput (tok/s):    4168.00
Peak concurrent requests:                636
Total token throughput (tok/s):          25057.19
Concurrency:                             385.25
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   2245.62
Median E2E Latency (ms):                 2354.22
P90 E2E Latency (ms):                    3607.82
P99 E2E Latency (ms):                    3825.57
---------------Time to First Token----------------
Mean TTFT (ms):                          369.54
Median TTFT (ms):                        417.14
P99 TTFT (ms):                           567.30
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          148.00
Median TPOT (ms):                        133.84
P99 TPOT (ms):                           418.96
---------------Inter-Token Latency----------------
Mean ITL (ms):                           121.73
Median ITL (ms):                         81.94
P95 ITL (ms):                            416.64
P99 ITL (ms):                            555.20
Max ITL (ms):                            555.72
==================================================
```
</details>

In short: it _seems_ to have a little performance win in some cases, but it's really a coin toss. It seems a bit more stable though, but it might be just me running it on my workstation with other processes running and not on an isolated server.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
