### PR TITLE
Fix broken streaming response with --incremental-streaming-output

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -736,7 +736,11 @@ class OpenAIServingChat(OpenAIServingBase):
                     stream_started = True
 
                 stream_buffer = stream_buffers.get(index, "")
-                delta = content["text"][len(stream_buffer) :]
+                if self.tokenizer_manager.server_args.incremental_streaming_output:
+                    # content["text"] is already the incremental delta
+                    delta = content["text"]
+                else:
+                    delta = content["text"][len(stream_buffer) :]
                 stream_buffers[index] = stream_buffer + delta
 
                 # Handle reasoning content

--- a/test/registered/openai_server/basic/test_serving_chat.py
+++ b/test/registered/openai_server/basic/test_serving_chat.py
@@ -784,6 +784,94 @@ class ServingChatTestCase(unittest.TestCase):
         self.assertEqual(len(chunks), 2)
         self.assertIn("error", chunks[0])
 
+    # ------------- incremental streaming output tests -------------
+    def test_incremental_streaming_output_delta(self):
+        """Test that streaming with incremental_streaming_output produces correct deltas.
+
+        When incremental_streaming_output is enabled, content["text"] is already the
+        incremental delta (not the full accumulated text). The delta computation must
+        use content["text"] directly instead of slicing by the accumulated buffer length.
+
+        Regression test for https://github.com/sgl-project/sglang/issues/22510.
+        """
+        # Enable incremental_streaming_output on the mock
+        self.tm.server_args.incremental_streaming_output = True
+
+        # Simulate incremental streaming: each yield has ONLY the new text (delta),
+        # NOT the full accumulated text.
+        incremental_chunks = [
+            ("I am", None),
+            (" a large", None),
+            (" language model", None),
+            (".", {"type": "stop", "matched": None}),
+        ]
+
+        async def _mock_generate_incremental():
+            for text, finish_reason in incremental_chunks:
+                yield {
+                    "text": text,
+                    "meta_info": {
+                        "id": "chatcmpl-incr-test",
+                        "prompt_tokens": 10,
+                        "completion_tokens": 5,
+                        "cached_tokens": 0,
+                        "finish_reason": finish_reason,
+                        "output_token_logprobs": None,
+                        "output_top_logprobs": None,
+                    },
+                    "index": 0,
+                }
+
+        self.tm.generate_request.return_value = _mock_generate_incremental()
+
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi?"}],
+            temperature=0.7,
+            max_tokens=100,
+            stream=True,
+        )
+
+        with patch(
+            "sglang.srt.entrypoints.openai.serving_chat.generate_chat_conv"
+        ) as conv_mock:
+            conv_ins = Mock()
+            conv_ins.get_prompt.return_value = "Test prompt"
+            conv_mock.return_value = conv_ins
+
+            adapted_request, _ = self.chat._convert_to_internal_request(
+                req, self.fastapi_request
+            )
+
+            async def run_stream():
+                chunks = []
+                async for chunk in self.chat._generate_chat_stream(
+                    adapted_request, req, self.fastapi_request
+                ):
+                    chunks.append(chunk)
+                return chunks
+
+        loop = get_or_create_event_loop()
+        chunks = loop.run_until_complete(run_stream())
+
+        # Extract content deltas from SSE chunks
+        deltas = []
+        for c in chunks:
+            if not c.startswith("data: ") or c.strip() == "data: [DONE]":
+                continue
+            data = json.loads(c[len("data: ") :])
+            if "choices" in data and data["choices"]:
+                content = data["choices"][0]["delta"].get("content")
+                if content:
+                    deltas.append(content)
+
+        joined = "".join(deltas)
+        self.assertEqual(
+            joined,
+            "I am a large language model.",
+            f"Streaming deltas produced broken text: {deltas!r}",
+        )
+
     # ------------- X-Data-Parallel-Rank header tests -------------
     def test_extract_routed_dp_rank_from_header_no_header(self):
         """Test that None is returned when no header is present."""


### PR DESCRIPTION
## Motivation

Fixes https://github.com/sgl-project/sglang/issues/22510

`--incremental-streaming-output` + `stream=True` produces garbled text for **all** models (not just Gemma 4).

**Root cause:** #21037 (c37200f5e) changed `tokenizer_manager.py` to emit incremental deltas (`state.text[last_text_offset:]`) instead of cumulative text (`state.text`) when `incremental_streaming_output` is enabled. `serving_chat.py` was not updated and still slices the already-incremental text by the accumulated buffer length, producing garbage fragments.

**Repro on any model:**
```bash
# Server
python3 -m sglang.launch_server --model-path Qwen/Qwen2.5-0.5B-Instruct --incremental-streaming-output --port 51000

# Client
curl -s http://127.0.0.1:51000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"default","messages":[{"role":"user","content":"Hello, who are you?"}],"stream":true}'

# Before fix: chunks = ['Hello', 'e', 'age', 's', 'g'] -> "Helloeagesg"
# After fix:  chunks = ['I', ' am', ' Q', 'wen', ',', ' a', ' large', ...] -> coherent text
```

## Modifications

- `serving_chat.py`: When `incremental_streaming_output` is enabled, use `content["text"]` directly as the delta instead of slicing by accumulated buffer length.
- `test_serving_chat.py`: Add regression test `test_incremental_streaming_output_delta`.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
