### PR TITLE
parameterize protocol in mooncake engine initialization to allow AWS EFA use

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/mooncake_transfer_engine.py
+++ b/python/sglang/srt/distributed/device_communicators/mooncake_transfer_engine.py
@@ -189,10 +189,12 @@ class MooncakeTransferEngine:
                 device_name if device_name is not None else "",
             )
         else:
+            protocol = envs.MOONCAKE_PROTOCOL.get()
+            engine_protocol = "rdma" if protocol == "tcp" else protocol
             ret_value = self.engine.initialize(
                 hostname,
                 "P2PHANDSHAKE",
-                "rdma",
+                engine_protocol,
                 device_name if device_name is not None else "",
             )
         if ret_value != 0:


### PR DESCRIPTION
hardcoding `rdma` prevents us from using AWS `efa`

related Mooncake PR to add support for AWS EFA https://github.com/kvcache-ai/Mooncake/pull/1509