### PR TITLE
[mem] Fix idle token_usage missing mamba_usage; add FIXME for naming

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1981,6 +1981,8 @@ class GetLoadsReqOutput(BaseReq):
     max_total_num_tokens: int = field(
         metadata={"metric": ("gauge", "Maximum token capacity")}
     )
+    # FIXME: token_usage is actually max usage across all pools (KV, SWA, mamba),
+    # not just KV token usage. Rename requires API deprecation.
     token_usage: float = field(metadata={"metric": ("gauge", "Token pool usage ratio")})
     gen_throughput: float = field(
         metadata={"metric": ("gauge", "Generation throughput tokens/sec")}

--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -311,13 +311,14 @@ class SchedulerRuntimeCheckerMixin:
                 (
                     num_used,
                     _,
-                    token_usage,
-                    _,
+                    full_token_usage,
+                    mamba_usage,
                     _,
                     _,
                     _,
                     _,
                 ) = self._get_mamba_token_info()
+                token_usage = max(full_token_usage, mamba_usage)
             else:
                 num_used, token_usage, _, _ = self._get_token_info()
 

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -79,6 +79,8 @@ class SchedulerStats:
     # Basics
     num_running_reqs: QueueCount = field(default_factory=QueueCount)
     num_used_tokens: int = 0
+    # FIXME: token_usage is actually max usage across all pools (KV, SWA, mamba),
+    # not just KV token usage. Rename requires API deprecation.
     token_usage: float = 0.0
     full_token_usage: float = 0.0
     pending_prealloc_token_usage: float = 0.0


### PR DESCRIPTION
## Summary
- Fix `check_memory` idle path using only `full_token_usage` for `self.stats.token_usage` when `is_hybrid_ssm=True`, missing `mamba_usage`
- Now uses `max(full_token_usage, mamba_usage)` to match the prefill/decode stats paths
- Add FIXME comments on `token_usage` field definitions (`SchedulerStats`, `ServerMetrics`) noting it is actually max pool usage across all pools (KV, SWA, mamba), not just KV token usage

The idle path was introduced in #12014, and the prefill/decode paths were later refactored in #17862 to correctly include `mamba_usage`, but the idle path was not updated.

## Test plan
- [ ] CI: existing mamba tests