### PR TITLE
[Diffusion][CI] Fix nunchaku unit test broken by #22365

### DIFF
--- a/python/sglang/multimodal_gen/test/unit/test_transformer_quant.py
+++ b/python/sglang/multimodal_gen/test/unit/test_transformer_quant.py
@@ -127,8 +127,13 @@ class TestTransformerQuantHelpers(unittest.TestCase):
     @patch(
         "sglang.multimodal_gen.runtime.loader.transformer_load_utils.get_metadata_from_safetensors_file"
     )
+    @patch(
+        "sglang.multimodal_gen.runtime.loader.transformer_load_utils.maybe_download_model",
+        side_effect=lambda path, **kw: path,
+    )
     def test_resolve_transformer_quant_load_spec_keeps_nunchaku_hook(
         self,
+        _mock_download,
         mock_metadata,
         _mock_quant_metadata,
         _mock_nvfp4,


### PR DESCRIPTION
## Summary
- Mock `maybe_download_model` in `test_resolve_transformer_quant_load_spec_keeps_nunchaku_hook` to prevent it from trying to download a fake local path (`/tmp/svdq-int4_r32.safetensors`) as an HF repo
- #22365 added `_resolve_quant_config_from_transformer_override` which calls `maybe_download_model` on the transformer weights path, but the test uses a non-existent `/tmp` path that fails HF Hub validation
- [CI failure example](https://github.com/sgl-project/sglang/actions/runs/24257571982/job/70866905056)

## Test plan
- [ ] `multimodal-gen-unit-test` CI job passes