### PR TITLE
[sgl-kernel][cpu] Remove unnecessary __AMX_BF16__ guard from CPU_CAPABILITY_AVX512

### DIFF
--- a/sgl-kernel/csrc/cpu/vec.h
+++ b/sgl-kernel/csrc/cpu/vec.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(__AVX512F__) && defined(__AVX512BF16__) && defined(__AMX_BF16__)
+#if defined(__AVX512F__) && defined(__AVX512BF16__)
 #define CPU_CAPABILITY_AVX512
 #endif
 


### PR DESCRIPTION
## Motivation

The `CPU_CAPABILITY_AVX512` macro in `sgl-kernel/csrc/cpu/vec.h` currently requires all three flags:

```c
#if defined(__AVX512F__) && defined(__AVX512BF16__) && defined(__AMX_BF16__)
```

However, **none of the gated code uses AMX tile intrinsics** (`_tile_dpbf16ps`, `_tile_loadd`, `_tile_stored`, `_tile_zero`, etc.). The actual intrinsics used throughout the CPU kernels are:

- **AVX-512 BF16**: `_mm512_dpbf16_ps`, `_mm512_cvtne2ps_pbh`, `_mm512_cvtneps_pbh`
- **AVX-512 VNNI**: `_mm512_dpbusd_epi32`, `_mm512_dpbusds_epi32`

These are all 512-bit vector instructions, not AMX tile instructions.

## Impact

The unnecessary `__AMX_BF16__` guard prevents all optimized CPU kernels from running on CPUs that have AVX-512 BF16 but lack AMX:

| CPU | AVX512F | AVX512-BF16 | AMX-BF16 | Before | After |
|-----|---------|-------------|----------|--------|-------|
| Intel Cooper Lake (3rd gen Xeon) | ✅ | ✅ | ❌ | ❌ Scalar fallback | ✅ Optimized |
| Intel Ice Lake Server | ✅ | ✅ | ❌ | ❌ Scalar fallback | ✅ Optimized |
| AMD EPYC Genoa/Turin (Zen 4/5) | ✅ | ✅ | ❌ | ❌ Scalar fallback | ✅ Optimized |
| Intel Sapphire Rapids+ (4th gen+) | ✅ | ✅ | ✅ | ✅ Optimized | ✅ Optimized (no change) |

## Changes

One-line change in `sgl-kernel/csrc/cpu/vec.h`:

```diff
-#if defined(__AVX512F__) && defined(__AVX512BF16__) && defined(__AMX_BF16__)
+#if defined(__AVX512F__) && defined(__AVX512BF16__)
```

## Verification

Searched all files under `sgl-kernel/csrc/cpu/` for AMX tile intrinsics — none found:

```
grep -rn '_tile_loadd\|_tile_stored\|_tile_dpbf16ps\|_tile_dpbusd\|_tile_zero\|_tile_loadconfig\|_tile_release' sgl-kernel/csrc/cpu/
# (no results)
```

The `__AMX_BF16__` flag is only referenced in `vec.h` line 3, confirming this is the sole gate.

## Test plan

- [ ] Verify builds on Intel Sapphire Rapids+ (should be no-op, all three flags still defined)
- [ ] Verify builds and runs on Intel Ice Lake / Cooper Lake (AVX512-BF16 without AMX)
- [ ] Verify builds and runs on AMD EPYC Genoa/Turin (AVX512-BF16 without AMX)
- [ ] Run existing CPU inference benchmarks to confirm no regression

🤖 Generated with [Claude Code](https://claude.ai/code)