### PR TITLE
[Spec][Ngram]: Add output-as-corpus and distractor corporas to benchmark dynamic spec tokens allocation

### DIFF
--- a/python/sglang/jit_kernel/csrc/ngram_corpus/ngram.cpp
+++ b/python/sglang/jit_kernel/csrc/ngram_corpus/ngram.cpp
@@ -85,8 +85,10 @@ void allocateLargestRemainder(size_t total_budget, std::vector<WeightedBudgetSou
       if (lhs.first != rhs.first) {
         return lhs.first > rhs.first;
       }
-      if ((*sources)[lhs.second].score != (*sources)[rhs.second].score) {
-        return (*sources)[lhs.second].score > (*sources)[rhs.second].score;
+      const auto& lhs_source = (*sources)[lhs.second];
+      const auto& rhs_source = (*sources)[rhs.second];
+      if (lhs_source.score != rhs_source.score) {
+        return lhs_source.score > rhs_source.score;
       }
       return lhs.second < rhs.second;
     });
@@ -150,7 +152,7 @@ Ngram::Ngram(size_t capacity, const Param& param) : param_(param) {
         "match_confidence_weight must be greater than or equal to 0, current value: " +
         std::to_string(param_.match_confidence_weight));
   }
-  if (!(param_.match_specificity_weight + param_.match_confidence_weight > 0.0)) {
+  if (param_.match_specificity_weight + param_.match_confidence_weight <= 0.0) {
     throw std::runtime_error("match quality weights must sum to a positive value");
   }
   for (auto config : param_.batch_draft_token_num) {

--- a/python/sglang/jit_kernel/csrc/ngram_corpus/ngram.cpp
+++ b/python/sglang/jit_kernel/csrc/ngram_corpus/ngram.cpp
@@ -1,11 +1,116 @@
 #include "ngram.h"
 
+#include <algorithm>
+#include <cmath>
 #include "trie.h"
 #include <limits>
 #include <stdexcept>
 #include <string>
 
 namespace ngram {
+
+namespace {
+
+struct WeightedBudgetSource {
+  double score = 0.0;
+  size_t cap = 0;
+  size_t budget = 0;
+};
+
+double computeSourceScore(const MatchQuality& quality, double source_prior, const Param& param) {
+  if (!quality.has_match) {
+    return 0.0;
+  }
+  const double total_weight = param.match_specificity_weight + param.match_confidence_weight;
+  if (total_weight <= 0.0) {
+    return 0.0;
+  }
+  // Implemented source-importance formula:
+  //   score = source_prior * (w_specificity * specificity + w_confidence * confidence)
+  //
+  // where:
+  // - specificity is normalized match depth / matched_len for the best anchor
+  // - confidence is normalized top-1 next-token mass at that anchor
+  // - the w_* terms are normalized from the user-provided match weights below
+  const double specificity_weight = param.match_specificity_weight / total_weight;
+  const double confidence_weight = param.match_confidence_weight / total_weight;
+  return source_prior * (specificity_weight * quality.specificity + confidence_weight * quality.confidence);
+}
+
+size_t ceilShare(double share, size_t total_budget) {
+  if (share <= 0.0 || total_budget == 0) {
+    return 0;
+  }
+  return std::min(total_budget, static_cast<size_t>(std::ceil(share * static_cast<double>(total_budget) - 1e-12)));
+}
+
+void allocateLargestRemainder(size_t total_budget, std::vector<WeightedBudgetSource>* sources) {
+  size_t remaining_budget = total_budget;
+  while (remaining_budget > 0) {
+    double total_score = 0.0;
+    std::vector<size_t> active;
+    active.reserve(sources->size());
+    for (size_t i = 0; i < sources->size(); ++i) {
+      const auto& source = (*sources)[i];
+      if (source.score > 0.0 && source.budget < source.cap) {
+        active.push_back(i);
+        total_score += source.score;
+      }
+    }
+    if (active.empty() || total_score <= 0.0) {
+      break;
+    }
+
+    std::vector<std::pair<double, size_t>> remainders;
+    remainders.reserve(active.size());
+    size_t distributed = 0;
+    for (const auto idx : active) {
+      auto& source = (*sources)[idx];
+      const auto remaining_cap = source.cap - source.budget;
+      const double ideal = static_cast<double>(remaining_budget) * source.score / total_score;
+      const auto whole = std::min(remaining_cap, static_cast<size_t>(ideal));
+      source.budget += whole;
+      distributed += whole;
+      if (source.budget < source.cap) {
+        remainders.emplace_back(ideal - static_cast<double>(whole), idx);
+      }
+    }
+
+    remaining_budget -= distributed;
+    if (remaining_budget == 0 || remainders.empty()) {
+      break;
+    }
+
+    std::sort(remainders.begin(), remainders.end(), [sources](const auto& lhs, const auto& rhs) {
+      if (lhs.first != rhs.first) {
+        return lhs.first > rhs.first;
+      }
+      if ((*sources)[lhs.second].score != (*sources)[rhs.second].score) {
+        return (*sources)[lhs.second].score > (*sources)[rhs.second].score;
+      }
+      return lhs.second < rhs.second;
+    });
+
+    size_t assigned = 0;
+    for (const auto& [_, idx] : remainders) {
+      if (remaining_budget == 0) {
+        break;
+      }
+      auto& source = (*sources)[idx];
+      if (source.budget >= source.cap) {
+        continue;
+      }
+      ++source.budget;
+      --remaining_budget;
+      ++assigned;
+    }
+    if (assigned == 0) {
+      break;
+    }
+  }
+}
+
+}  // namespace
 
 Ngram::Ngram(size_t capacity, const Param& param) : param_(param) {
   if (!(param_.max_trie_depth > 1)) {
@@ -25,6 +130,33 @@ Ngram::Ngram(size_t capacity, const Param& param) : param_(param) {
   if (!(param_.draft_token_num > 0)) {
     throw std::runtime_error(
         "draft_token_num must be greater than 0, current value: " + std::to_string(param_.draft_token_num));
+  }
+  if (param_.trie_source_prior < 0.0) {
+    throw std::runtime_error(
+        "trie_source_prior must be greater than or equal to 0, current value: " +
+        std::to_string(param_.trie_source_prior));
+  }
+  if (!(param_.min_trie_share >= 0.0 && param_.min_trie_share <= 1.0)) {
+    throw std::runtime_error(
+        "min_trie_share must be between 0 and 1, current value: " + std::to_string(param_.min_trie_share));
+  }
+  if (param_.match_specificity_weight < 0.0) {
+    throw std::runtime_error(
+        "match_specificity_weight must be greater than or equal to 0, current value: " +
+        std::to_string(param_.match_specificity_weight));
+  }
+  if (param_.match_confidence_weight < 0.0) {
+    throw std::runtime_error(
+        "match_confidence_weight must be greater than or equal to 0, current value: " +
+        std::to_string(param_.match_confidence_weight));
+  }
+  if (!(param_.match_specificity_weight + param_.match_confidence_weight > 0.0)) {
+    throw std::runtime_error("match quality weights must sum to a positive value");
+  }
+  if (!(param_.max_per_sam_share > 0.0 && param_.max_per_sam_share <= 1.0)) {
+    throw std::runtime_error(
+        "max_per_sam_share must be greater than 0 and less than or equal to 1, current value: " +
+        std::to_string(param_.max_per_sam_share));
   }
   for (auto config : param_.batch_draft_token_num) {
     if (config != std::numeric_limits<decltype(config)>::max()) {
@@ -149,17 +281,18 @@ Result Ngram::batchMatch(
 
   std::unique_lock<std::mutex> lock(mutex_);
 
-  using TrieResultBuildFn =
-      Result (Trie::*)(const int32_t*, size_t, int32_t, size_t, const Param&, MatchState&, size_t) const;
-  using SamResultBuildFn = Result (SuffixAutomaton::*)(const int32_t*, size_t, int32_t, size_t, const Param&) const;
-  TrieResultBuildFn trie_result_build_fn;
-  SamResultBuildFn sam_result_build_fn;
+  using TrieAnchoredBuildFn =
+      Result (Trie::*)(const std::vector<std::pair<const TrieNode*, int32_t>>&, int32_t, size_t, const Param&) const;
+  using SamAnchoredBuildFn =
+      Result (SuffixAutomaton::*)(const std::vector<SamAnchor>&, int32_t, size_t, const Param&) const;
+  TrieAnchoredBuildFn trie_anchored_build_fn;
+  SamAnchoredBuildFn sam_anchored_build_fn;
   if (param_.match_type == "BFS") {
-    trie_result_build_fn = &Trie::buildRecency;
-    sam_result_build_fn = &SuffixAutomaton::buildRecency;
+    trie_anchored_build_fn = &Trie::buildRecencyFromAnchors;
+    sam_anchored_build_fn = &SuffixAutomaton::buildRecencyFromAnchors;
   } else if (param_.match_type == "PROB") {
-    trie_result_build_fn = &Trie::buildFrequency;
-    sam_result_build_fn = &SuffixAutomaton::buildFrequency;
+    trie_anchored_build_fn = &Trie::buildFrequencyFromAnchors;
+    sam_anchored_build_fn = &SuffixAutomaton::buildFrequencyFromAnchors;
   } else {
     throw std::runtime_error("Unknown match_type: '" + param_.match_type + "'. Must be 'BFS' or 'PROB'.");
   }
@@ -167,10 +300,16 @@ Result Ngram::batchMatch(
   // All budget values are loop-invariant (mutex_ held, sams_ won't change).
   const size_t num_sams = sams_.size();
   const auto total_draft_token_num = param_.get_draft_token_num(tokens.size());
-  const size_t total_sam_budget =
+  const size_t max_total_sam_budget =
       num_sams > 0 ? std::min(param_.external_sam_budget, total_draft_token_num) : size_t{0};
-  const size_t per_sam_budget = num_sams > 0 ? total_sam_budget / num_sams : size_t{0};
-  const size_t trie_budget = total_draft_token_num - (per_sam_budget * num_sams);
+  const size_t trie_base_budget = total_draft_token_num - max_total_sam_budget;
+  std::vector<std::pair<std::string, const SuffixAutomaton*>> ordered_sams;
+  ordered_sams.reserve(sams_.size());
+  for (const auto& [corpus_id, sam] : sams_) {
+    ordered_sams.emplace_back(corpus_id, sam.get());
+  }
+  std::sort(
+      ordered_sams.begin(), ordered_sams.end(), [](const auto& lhs, const auto& rhs) { return lhs.first < rhs.first; });
 
   Result merged;
   for (size_t i = 0; i < state_ids.size(); ++i) {
@@ -180,21 +319,84 @@ Result Ngram::batchMatch(
     }
 
     auto& state = match_state_[state_ids[i]];
+    auto trie_anchors = trie_->match(suffix.data(), suffix.size(), state, total_lens[i]);
+    auto trie_quality = trie_->summarizeMatchQuality(trie_anchors, param_);
 
-    if (total_sam_budget == 0 || per_sam_budget == 0) {
-      auto res = (trie_.get()->*trie_result_build_fn)(
-          suffix.data(), suffix.size(), suffix.back(), total_draft_token_num, param_, state, total_lens[i]);
+    if (max_total_sam_budget == 0) {
+      auto res =
+          (trie_.get()->*trie_anchored_build_fn)(trie_anchors, suffix.back(), total_draft_token_num, param_);
       merged.token.insert(merged.token.end(), res.token.begin(), res.token.end());
       merged.mask.insert(merged.mask.end(), res.mask.begin(), res.mask.end());
       continue;
     }
 
-    auto combined = (trie_.get()->*trie_result_build_fn)(
-        suffix.data(), suffix.size(), suffix.back(), trie_budget, param_, state, total_lens[i]);
+    struct SamMatchView {
+      const SuffixAutomaton* sam = nullptr;
+      std::vector<SamAnchor> anchors;
+      MatchQuality quality;
+      size_t budget = 0;
+    };
 
-    for (const auto& [_, sam] : sams_) {
-      auto sam_res =
-          (sam.get()->*sam_result_build_fn)(suffix.data(), suffix.size(), suffix.back(), per_sam_budget, param_);
+    std::vector<SamMatchView> sam_matches;
+    sam_matches.reserve(ordered_sams.size());
+    for (const auto& [_, sam] : ordered_sams) {
+      auto anchors = sam->match(suffix.data(), suffix.size(), param_.max_trie_depth);
+      auto quality = sam->summarizeMatchQuality(anchors, param_);
+      sam_matches.push_back(SamMatchView{sam, std::move(anchors), quality, 0});
+    }
+
+    size_t trie_budget = trie_base_budget;
+    size_t flexible_budget = max_total_sam_budget;
+    if (trie_quality.has_match && flexible_budget > 0) {
+      const auto trie_floor_budget = std::max(trie_base_budget, ceilShare(param_.min_trie_share, total_draft_token_num));
+      const auto reserved_for_trie = std::min(flexible_budget, trie_floor_budget - trie_base_budget);
+      trie_budget += reserved_for_trie;
+      flexible_budget -= reserved_for_trie;
+    }
+
+    if (flexible_budget > 0) {
+      std::vector<WeightedBudgetSource> sources;
+      const auto no_source = std::numeric_limits<size_t>::max();
+      size_t trie_source_idx = no_source;
+      if (trie_quality.has_match) {
+        trie_source_idx = sources.size();
+        sources.push_back(WeightedBudgetSource{
+            computeSourceScore(trie_quality, param_.trie_source_prior, param_), flexible_budget, 0});
+      }
+
+      std::vector<size_t> sam_source_indices(sam_matches.size(), no_source);
+      const auto per_sam_cap =
+          max_total_sam_budget == 0 ? size_t{0}
+                                    : std::max<size_t>(1, ceilShare(param_.max_per_sam_share, max_total_sam_budget));
+      for (size_t sam_idx = 0; sam_idx < sam_matches.size(); ++sam_idx) {
+        const auto score = computeSourceScore(sam_matches[sam_idx].quality, 1.0, param_);
+        if (score <= 0.0) {
+          continue;
+        }
+        sam_source_indices[sam_idx] = sources.size();
+        sources.push_back(WeightedBudgetSource{score, std::min(flexible_budget, per_sam_cap), 0});
+      }
+
+      allocateLargestRemainder(flexible_budget, &sources);
+
+      if (trie_source_idx != no_source) {
+        trie_budget += sources[trie_source_idx].budget;
+      }
+      for (size_t sam_idx = 0; sam_idx < sam_matches.size(); ++sam_idx) {
+        const auto source_idx = sam_source_indices[sam_idx];
+        if (source_idx != no_source) {
+          sam_matches[sam_idx].budget = sources[source_idx].budget;
+        }
+      }
+    }
+
+    auto combined = (trie_.get()->*trie_anchored_build_fn)(trie_anchors, suffix.back(), trie_budget, param_);
+
+    for (const auto& sam_match : sam_matches) {
+      if (sam_match.budget == 0) {
+        continue;
+      }
+      auto sam_res = (sam_match.sam->*sam_anchored_build_fn)(sam_match.anchors, suffix.back(), sam_match.budget, param_);
       combined = combineRootResults_(suffix.back(), static_cast<int>(total_draft_token_num + 1), combined, sam_res);
     }
 

--- a/python/sglang/jit_kernel/csrc/ngram_corpus/ngram.cpp
+++ b/python/sglang/jit_kernel/csrc/ngram_corpus/ngram.cpp
@@ -2,20 +2,12 @@
 
 #include "trie.h"
 #include <algorithm>
-#include <cmath>
-#include <limits>
 #include <stdexcept>
 #include <string>
 
 namespace ngram {
 
 namespace {
-
-struct WeightedBudgetSource {
-  double score = 0.0;
-  size_t cap = 0;
-  size_t budget = 0;
-};
 
 double computeSourceScore(const MatchQuality& quality, double source_prior, const Param& param) {
   if (!quality.has_match) {
@@ -37,79 +29,8 @@ double computeSourceScore(const MatchQuality& quality, double source_prior, cons
   return source_prior * (specificity_weight * quality.specificity + confidence_weight * quality.confidence);
 }
 
-size_t ceilShare(double share, size_t total_budget) {
-  if (share <= 0.0 || total_budget == 0) {
-    return 0;
-  }
-  return std::min(total_budget, static_cast<size_t>(std::ceil(share * static_cast<double>(total_budget) - 1e-12)));
-}
-
-void allocateLargestRemainder(size_t total_budget, std::vector<WeightedBudgetSource>* sources) {
-  size_t remaining_budget = total_budget;
-  while (remaining_budget > 0) {
-    double total_score = 0.0;
-    std::vector<size_t> active;
-    active.reserve(sources->size());
-    for (size_t i = 0; i < sources->size(); ++i) {
-      const auto& source = (*sources)[i];
-      if (source.score > 0.0 && source.budget < source.cap) {
-        active.push_back(i);
-        total_score += source.score;
-      }
-    }
-    if (active.empty() || total_score <= 0.0) {
-      break;
-    }
-
-    std::vector<std::pair<double, size_t>> remainders;
-    remainders.reserve(active.size());
-    size_t distributed = 0;
-    for (const auto idx : active) {
-      auto& source = (*sources)[idx];
-      const auto remaining_cap = source.cap - source.budget;
-      const double ideal = static_cast<double>(remaining_budget) * source.score / total_score;
-      const auto whole = std::min(remaining_cap, static_cast<size_t>(ideal));
-      source.budget += whole;
-      distributed += whole;
-      if (source.budget < source.cap) {
-        remainders.emplace_back(ideal - static_cast<double>(whole), idx);
-      }
-    }
-
-    remaining_budget -= distributed;
-    if (remaining_budget == 0 || remainders.empty()) {
-      break;
-    }
-
-    std::sort(remainders.begin(), remainders.end(), [sources](const auto& lhs, const auto& rhs) {
-      if (lhs.first != rhs.first) {
-        return lhs.first > rhs.first;
-      }
-      const auto& lhs_source = (*sources)[lhs.second];
-      const auto& rhs_source = (*sources)[rhs.second];
-      if (lhs_source.score != rhs_source.score) {
-        return lhs_source.score > rhs_source.score;
-      }
-      return lhs.second < rhs.second;
-    });
-
-    size_t assigned = 0;
-    for (const auto& [_, idx] : remainders) {
-      if (remaining_budget == 0) {
-        break;
-      }
-      auto& source = (*sources)[idx];
-      if (source.budget >= source.cap) {
-        continue;
-      }
-      ++source.budget;
-      --remaining_budget;
-      ++assigned;
-    }
-    if (assigned == 0) {
-      break;
-    }
-  }
+double effectiveTrieSourcePrior(double source_prior) {
+  return source_prior > 0.0 ? source_prior : 1.0;
 }
 
 }  // namespace
@@ -137,10 +58,6 @@ Ngram::Ngram(size_t capacity, const Param& param) : param_(param) {
     throw std::runtime_error(
         "trie_source_prior must be greater than or equal to 0, current value: " +
         std::to_string(param_.trie_source_prior));
-  }
-  if (!(param_.min_trie_share >= 0.0 && param_.min_trie_share <= 1.0)) {
-    throw std::runtime_error(
-        "min_trie_share must be between 0 and 1, current value: " + std::to_string(param_.min_trie_share));
   }
   if (param_.match_specificity_weight < 0.0) {
     throw std::runtime_error(
@@ -294,12 +211,8 @@ Result Ngram::batchMatch(
     throw std::runtime_error("Unknown match_type: '" + param_.match_type + "'. Must be 'BFS' or 'PROB'.");
   }
 
-  // All budget values are loop-invariant (mutex_ held, sams_ won't change).
-  const size_t num_sams = sams_.size();
   const auto total_draft_token_num = param_.get_draft_token_num(tokens.size());
-  const size_t max_total_sam_budget =
-      num_sams > 0 ? std::min(param_.external_sam_budget, total_draft_token_num) : size_t{0};
-  const size_t trie_base_budget = total_draft_token_num - max_total_sam_budget;
+  const auto result_token_num = static_cast<int>(total_draft_token_num + 1);
   std::vector<std::pair<std::string, const SuffixAutomaton*>> ordered_sams;
   ordered_sams.reserve(sams_.size());
   for (const auto& [corpus_id, sam] : sams_) {
@@ -319,81 +232,50 @@ Result Ngram::batchMatch(
     auto trie_anchors = trie_->match(suffix.data(), suffix.size(), state, total_lens[i]);
     auto trie_quality = trie_->summarizeMatchQuality(trie_anchors, param_);
 
-    if (max_total_sam_budget == 0) {
+    if (ordered_sams.empty()) {
       auto res = (trie_.get()->*trie_anchored_build_fn)(trie_anchors, suffix.back(), total_draft_token_num, param_);
       merged.token.insert(merged.token.end(), res.token.begin(), res.token.end());
       merged.mask.insert(merged.mask.end(), res.mask.begin(), res.mask.end());
       continue;
     }
 
-    struct SamMatchView {
-      const SuffixAutomaton* sam = nullptr;
-      std::vector<SamAnchor> anchors;
-      MatchQuality quality;
-      size_t budget = 0;
+    struct RankedSourceResult {
+      double score = 0.0;
+      Result result;
     };
 
-    std::vector<SamMatchView> sam_matches;
-    sam_matches.reserve(ordered_sams.size());
+    std::vector<RankedSourceResult> source_results;
+    source_results.reserve(ordered_sams.size() + 1);
+    if (trie_quality.has_match) {
+      source_results.push_back(RankedSourceResult{
+          computeSourceScore(trie_quality, effectiveTrieSourcePrior(param_.trie_source_prior), param_),
+          (trie_.get()->*trie_anchored_build_fn)(trie_anchors, suffix.back(), total_draft_token_num, param_)});
+    }
+
     for (const auto& [_, sam] : ordered_sams) {
       auto anchors = sam->match(suffix.data(), suffix.size(), param_.max_trie_depth);
       auto quality = sam->summarizeMatchQuality(anchors, param_);
-      sam_matches.push_back(SamMatchView{sam, std::move(anchors), quality, 0});
-    }
-
-    size_t trie_budget = trie_base_budget;
-    size_t flexible_budget = max_total_sam_budget;
-    if (trie_quality.has_match && flexible_budget > 0) {
-      const auto trie_floor_budget =
-          std::max(trie_base_budget, ceilShare(param_.min_trie_share, total_draft_token_num));
-      const auto reserved_for_trie = std::min(flexible_budget, trie_floor_budget - trie_base_budget);
-      trie_budget += reserved_for_trie;
-      flexible_budget -= reserved_for_trie;
-    }
-
-    if (flexible_budget > 0) {
-      std::vector<WeightedBudgetSource> sources;
-      const auto no_source = std::numeric_limits<size_t>::max();
-      size_t trie_source_idx = no_source;
-      if (trie_quality.has_match) {
-        trie_source_idx = sources.size();
-        sources.push_back(
-            WeightedBudgetSource{
-                computeSourceScore(trie_quality, param_.trie_source_prior, param_), flexible_budget, 0});
-      }
-
-      std::vector<size_t> sam_source_indices(sam_matches.size(), no_source);
-      for (size_t sam_idx = 0; sam_idx < sam_matches.size(); ++sam_idx) {
-        const auto score = computeSourceScore(sam_matches[sam_idx].quality, 1.0, param_);
-        if (score <= 0.0) {
-          continue;
-        }
-        sam_source_indices[sam_idx] = sources.size();
-        sources.push_back(WeightedBudgetSource{score, flexible_budget, 0});
-      }
-
-      allocateLargestRemainder(flexible_budget, &sources);
-
-      if (trie_source_idx != no_source) {
-        trie_budget += sources[trie_source_idx].budget;
-      }
-      for (size_t sam_idx = 0; sam_idx < sam_matches.size(); ++sam_idx) {
-        const auto source_idx = sam_source_indices[sam_idx];
-        if (source_idx != no_source) {
-          sam_matches[sam_idx].budget = sources[source_idx].budget;
-        }
-      }
-    }
-
-    auto combined = (trie_.get()->*trie_anchored_build_fn)(trie_anchors, suffix.back(), trie_budget, param_);
-
-    for (const auto& sam_match : sam_matches) {
-      if (sam_match.budget == 0) {
+      const auto score = computeSourceScore(quality, 1.0, param_);
+      if (score <= 0.0) {
         continue;
       }
-      auto sam_res =
-          (sam_match.sam->*sam_anchored_build_fn)(sam_match.anchors, suffix.back(), sam_match.budget, param_);
-      combined = combineRootResults_(suffix.back(), static_cast<int>(total_draft_token_num + 1), combined, sam_res);
+      source_results.push_back(RankedSourceResult{
+          score, (sam->*sam_anchored_build_fn)(anchors, suffix.back(), total_draft_token_num, param_)});
+    }
+
+    Result combined;
+    if (source_results.empty()) {
+      combined = (trie_.get()->*trie_anchored_build_fn)(trie_anchors, suffix.back(), total_draft_token_num, param_);
+    } else {
+      // Merge stronger sources first so the final cap keeps their branches when the tree saturates.
+      std::stable_sort(source_results.begin(), source_results.end(), [](const auto& lhs, const auto& rhs) {
+        return lhs.score > rhs.score;
+      });
+      combined = std::move(source_results.front().result);
+      for (size_t source_idx = 1; source_idx < source_results.size(); ++source_idx) {
+        combined = combineRootResults_(
+            suffix.back(), result_token_num, combined, source_results[source_idx].result);
+      }
     }
 
     merged.token.insert(merged.token.end(), combined.token.begin(), combined.token.end());

--- a/python/sglang/jit_kernel/csrc/ngram_corpus/ngram.cpp
+++ b/python/sglang/jit_kernel/csrc/ngram_corpus/ngram.cpp
@@ -14,6 +14,7 @@ namespace ngram {
 // - specificity is normalized match depth / matched_len for the best anchor
 // - confidence is normalized top-1 next-token mass at that anchor
 // - the w_* terms are normalized from the user-provided match weights below
+namespace {
 double computeSourceScore(const MatchQuality& quality, double source_prior, const Param& param) {
   if (!quality.has_match) {
     return 0.0;
@@ -27,6 +28,11 @@ double computeSourceScore(const MatchQuality& quality, double source_prior, cons
   return source_prior * (specificity_weight * quality.specificity + confidence_weight * quality.confidence);
 }
 
+double effectiveTrieSourcePrior(double source_prior) {
+  return source_prior > 0.0 ? source_prior : 1.0;
+}
+
+}  // namespace
 Ngram::Ngram(size_t capacity, const Param& param) : param_(param) {
   if (!(param_.max_trie_depth > 1)) {
     throw std::runtime_error(
@@ -239,10 +245,9 @@ Result Ngram::batchMatch(
     std::vector<RankedSourceResult> source_results;
     source_results.reserve(ordered_sams.size() + 1);
     if (trie_quality.has_match) {
-      source_results.push_back(
-          RankedSourceResult{
-              computeSourceScore(trie_quality, param_.trie_source_prior > 0.0 ? param_.trie_source_prior : 1.0, param_),
-              (trie_.get()->*trie_anchored_build_fn)(trie_anchors, suffix.back(), total_draft_token_num, param_)});
+      source_results.push_back(RankedSourceResult{
+          computeSourceScore(trie_quality, effectiveTrieSourcePrior(param_.trie_source_prior), param_),
+          (trie_.get()->*trie_anchored_build_fn)(trie_anchors, suffix.back(), total_draft_token_num, param_)});
     }
 
     for (const auto& [_, sam] : ordered_sams) {
@@ -252,9 +257,8 @@ Result Ngram::batchMatch(
       if (score <= 0.0) {
         continue;
       }
-      source_results.push_back(
-          RankedSourceResult{
-              score, (sam->*sam_anchored_build_fn)(anchors, suffix.back(), total_draft_token_num, param_)});
+      source_results.push_back(RankedSourceResult{
+          score, (sam->*sam_anchored_build_fn)(anchors, suffix.back(), total_draft_token_num, param_)});
     }
 
     Result combined;
@@ -267,7 +271,8 @@ Result Ngram::batchMatch(
       });
       combined = std::move(source_results.front().result);
       for (size_t source_idx = 1; source_idx < source_results.size(); ++source_idx) {
-        combined = combineRootResults_(suffix.back(), result_token_num, combined, source_results[source_idx].result);
+        combined = combineRootResults_(
+            suffix.back(), result_token_num, combined, source_results[source_idx].result);
       }
     }
 

--- a/python/sglang/jit_kernel/csrc/ngram_corpus/ngram.cpp
+++ b/python/sglang/jit_kernel/csrc/ngram_corpus/ngram.cpp
@@ -7,8 +7,13 @@
 
 namespace ngram {
 
-namespace {
-
+// Implemented source-importance formula:
+//   score = source_prior * (w_specificity * specificity + w_confidence * confidence)
+//
+// where:
+// - specificity is normalized match depth / matched_len for the best anchor
+// - confidence is normalized top-1 next-token mass at that anchor
+// - the w_* terms are normalized from the user-provided match weights below
 double computeSourceScore(const MatchQuality& quality, double source_prior, const Param& param) {
   if (!quality.has_match) {
     return 0.0;
@@ -17,23 +22,10 @@ double computeSourceScore(const MatchQuality& quality, double source_prior, cons
   if (total_weight <= 0.0) {
     return 0.0;
   }
-  // Implemented source-importance formula:
-  //   score = source_prior * (w_specificity * specificity + w_confidence * confidence)
-  //
-  // where:
-  // - specificity is normalized match depth / matched_len for the best anchor
-  // - confidence is normalized top-1 next-token mass at that anchor
-  // - the w_* terms are normalized from the user-provided match weights below
   const double specificity_weight = param.match_specificity_weight / total_weight;
   const double confidence_weight = param.match_confidence_weight / total_weight;
   return source_prior * (specificity_weight * quality.specificity + confidence_weight * quality.confidence);
 }
-
-double effectiveTrieSourcePrior(double source_prior) {
-  return source_prior > 0.0 ? source_prior : 1.0;
-}
-
-}  // namespace
 
 Ngram::Ngram(size_t capacity, const Param& param) : param_(param) {
   if (!(param_.max_trie_depth > 1)) {
@@ -247,9 +239,10 @@ Result Ngram::batchMatch(
     std::vector<RankedSourceResult> source_results;
     source_results.reserve(ordered_sams.size() + 1);
     if (trie_quality.has_match) {
-      source_results.push_back(RankedSourceResult{
-          computeSourceScore(trie_quality, effectiveTrieSourcePrior(param_.trie_source_prior), param_),
-          (trie_.get()->*trie_anchored_build_fn)(trie_anchors, suffix.back(), total_draft_token_num, param_)});
+      source_results.push_back(
+          RankedSourceResult{
+              computeSourceScore(trie_quality, param_.trie_source_prior > 0.0 ? param_.trie_source_prior : 1.0, param_),
+              (trie_.get()->*trie_anchored_build_fn)(trie_anchors, suffix.back(), total_draft_token_num, param_)});
     }
 
     for (const auto& [_, sam] : ordered_sams) {
@@ -259,8 +252,9 @@ Result Ngram::batchMatch(
       if (score <= 0.0) {
         continue;
       }
-      source_results.push_back(RankedSourceResult{
-          score, (sam->*sam_anchored_build_fn)(anchors, suffix.back(), total_draft_token_num, param_)});
+      source_results.push_back(
+          RankedSourceResult{
+              score, (sam->*sam_anchored_build_fn)(anchors, suffix.back(), total_draft_token_num, param_)});
     }
 
     Result combined;
@@ -273,8 +267,7 @@ Result Ngram::batchMatch(
       });
       combined = std::move(source_results.front().result);
       for (size_t source_idx = 1; source_idx < source_results.size(); ++source_idx) {
-        combined = combineRootResults_(
-            suffix.back(), result_token_num, combined, source_results[source_idx].result);
+        combined = combineRootResults_(suffix.back(), result_token_num, combined, source_results[source_idx].result);
       }
     }
 

--- a/python/sglang/jit_kernel/csrc/ngram_corpus/ngram.cpp
+++ b/python/sglang/jit_kernel/csrc/ngram_corpus/ngram.cpp
@@ -1,8 +1,8 @@
 #include "ngram.h"
 
+#include "trie.h"
 #include <algorithm>
 #include <cmath>
-#include "trie.h"
 #include <limits>
 #include <stdexcept>
 #include <string>
@@ -152,11 +152,6 @@ Ngram::Ngram(size_t capacity, const Param& param) : param_(param) {
   }
   if (!(param_.match_specificity_weight + param_.match_confidence_weight > 0.0)) {
     throw std::runtime_error("match quality weights must sum to a positive value");
-  }
-  if (!(param_.max_per_sam_share > 0.0 && param_.max_per_sam_share <= 1.0)) {
-    throw std::runtime_error(
-        "max_per_sam_share must be greater than 0 and less than or equal to 1, current value: " +
-        std::to_string(param_.max_per_sam_share));
   }
   for (auto config : param_.batch_draft_token_num) {
     if (config != std::numeric_limits<decltype(config)>::max()) {
@@ -323,8 +318,7 @@ Result Ngram::batchMatch(
     auto trie_quality = trie_->summarizeMatchQuality(trie_anchors, param_);
 
     if (max_total_sam_budget == 0) {
-      auto res =
-          (trie_.get()->*trie_anchored_build_fn)(trie_anchors, suffix.back(), total_draft_token_num, param_);
+      auto res = (trie_.get()->*trie_anchored_build_fn)(trie_anchors, suffix.back(), total_draft_token_num, param_);
       merged.token.insert(merged.token.end(), res.token.begin(), res.token.end());
       merged.mask.insert(merged.mask.end(), res.mask.begin(), res.mask.end());
       continue;
@@ -348,7 +342,8 @@ Result Ngram::batchMatch(
     size_t trie_budget = trie_base_budget;
     size_t flexible_budget = max_total_sam_budget;
     if (trie_quality.has_match && flexible_budget > 0) {
-      const auto trie_floor_budget = std::max(trie_base_budget, ceilShare(param_.min_trie_share, total_draft_token_num));
+      const auto trie_floor_budget =
+          std::max(trie_base_budget, ceilShare(param_.min_trie_share, total_draft_token_num));
       const auto reserved_for_trie = std::min(flexible_budget, trie_floor_budget - trie_base_budget);
       trie_budget += reserved_for_trie;
       flexible_budget -= reserved_for_trie;
@@ -360,21 +355,19 @@ Result Ngram::batchMatch(
       size_t trie_source_idx = no_source;
       if (trie_quality.has_match) {
         trie_source_idx = sources.size();
-        sources.push_back(WeightedBudgetSource{
-            computeSourceScore(trie_quality, param_.trie_source_prior, param_), flexible_budget, 0});
+        sources.push_back(
+            WeightedBudgetSource{
+                computeSourceScore(trie_quality, param_.trie_source_prior, param_), flexible_budget, 0});
       }
 
       std::vector<size_t> sam_source_indices(sam_matches.size(), no_source);
-      const auto per_sam_cap =
-          max_total_sam_budget == 0 ? size_t{0}
-                                    : std::max<size_t>(1, ceilShare(param_.max_per_sam_share, max_total_sam_budget));
       for (size_t sam_idx = 0; sam_idx < sam_matches.size(); ++sam_idx) {
         const auto score = computeSourceScore(sam_matches[sam_idx].quality, 1.0, param_);
         if (score <= 0.0) {
           continue;
         }
         sam_source_indices[sam_idx] = sources.size();
-        sources.push_back(WeightedBudgetSource{score, std::min(flexible_budget, per_sam_cap), 0});
+        sources.push_back(WeightedBudgetSource{score, flexible_budget, 0});
       }
 
       allocateLargestRemainder(flexible_budget, &sources);
@@ -396,7 +389,8 @@ Result Ngram::batchMatch(
       if (sam_match.budget == 0) {
         continue;
       }
-      auto sam_res = (sam_match.sam->*sam_anchored_build_fn)(sam_match.anchors, suffix.back(), sam_match.budget, param_);
+      auto sam_res =
+          (sam_match.sam->*sam_anchored_build_fn)(sam_match.anchors, suffix.back(), sam_match.budget, param_);
       combined = combineRootResults_(suffix.back(), static_cast<int>(total_draft_token_num + 1), combined, sam_res);
     }
 

--- a/python/sglang/jit_kernel/csrc/ngram_corpus/ngram_corpus_ffi.cpp
+++ b/python/sglang/jit_kernel/csrc/ngram_corpus/ngram_corpus_ffi.cpp
@@ -158,7 +158,17 @@ void register_ngram_corpus() {
   namespace refl = tvm::ffi::reflection;
   refl::ObjectDef<NgramCorpusObj>()
       .def(
-          refl::init<int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, double, double, double>(),
+          refl::init<
+              int64_t,
+              int64_t,
+              int64_t,
+              int64_t,
+              int64_t,
+              int64_t,
+              int64_t,
+              double,
+              double,
+              double>(),
           "__init__")
       .def("async_insert", &NgramCorpusObj::async_insert)
       .def("batch_match_stateful", &NgramCorpusObj::batch_match_stateful)

--- a/python/sglang/jit_kernel/csrc/ngram_corpus/ngram_corpus_ffi.cpp
+++ b/python/sglang/jit_kernel/csrc/ngram_corpus/ngram_corpus_ffi.cpp
@@ -25,7 +25,12 @@ struct NgramCorpusObj : public tvm::ffi::Object {
       int64_t draft_token_num,
       int64_t match_type,
       int64_t external_sam_budget,
-      int64_t external_corpus_max_tokens) {
+      int64_t external_corpus_max_tokens,
+      double trie_source_prior,
+      double min_trie_share,
+      double match_specificity_weight,
+      double match_confidence_weight,
+      double max_per_sam_share) {
     ngram::Param param;
     param.enable = true;
     param.enable_router_mode = false;
@@ -36,6 +41,11 @@ struct NgramCorpusObj : public tvm::ffi::Object {
     param.match_type = (match_type == 0) ? "BFS" : "PROB";
     param.external_sam_budget = static_cast<size_t>(external_sam_budget);
     param.external_corpus_max_tokens = static_cast<size_t>(external_corpus_max_tokens);
+    param.trie_source_prior = trie_source_prior;
+    param.min_trie_share = min_trie_share;
+    param.match_specificity_weight = match_specificity_weight;
+    param.match_confidence_weight = match_confidence_weight;
+    param.max_per_sam_share = max_per_sam_share;
     ngram_ = std::make_unique<ngram::Ngram>(static_cast<size_t>(capacity), param);
   }
 
@@ -153,7 +163,10 @@ struct NgramCorpusObj : public tvm::ffi::Object {
 void register_ngram_corpus() {
   namespace refl = tvm::ffi::reflection;
   refl::ObjectDef<NgramCorpusObj>()
-      .def(refl::init<int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t>(), "__init__")
+      .def(
+          refl::init<int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, double, double, double,
+                     double, double>(),
+          "__init__")
       .def("async_insert", &NgramCorpusObj::async_insert)
       .def("batch_match_stateful", &NgramCorpusObj::batch_match_stateful)
       .def("erase_match_state", &NgramCorpusObj::erase_match_state)

--- a/python/sglang/jit_kernel/csrc/ngram_corpus/ngram_corpus_ffi.cpp
+++ b/python/sglang/jit_kernel/csrc/ngram_corpus/ngram_corpus_ffi.cpp
@@ -158,17 +158,7 @@ void register_ngram_corpus() {
   namespace refl = tvm::ffi::reflection;
   refl::ObjectDef<NgramCorpusObj>()
       .def(
-          refl::init<
-              int64_t,
-              int64_t,
-              int64_t,
-              int64_t,
-              int64_t,
-              int64_t,
-              int64_t,
-              double,
-              double,
-              double>(),
+          refl::init<int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, double, double, double>(),
           "__init__")
       .def("async_insert", &NgramCorpusObj::async_insert)
       .def("batch_match_stateful", &NgramCorpusObj::batch_match_stateful)

--- a/python/sglang/jit_kernel/csrc/ngram_corpus/ngram_corpus_ffi.cpp
+++ b/python/sglang/jit_kernel/csrc/ngram_corpus/ngram_corpus_ffi.cpp
@@ -24,10 +24,8 @@ struct NgramCorpusObj : public tvm::ffi::Object {
       int64_t max_bfs_breadth,
       int64_t draft_token_num,
       int64_t match_type,
-      int64_t external_sam_budget,
       int64_t external_corpus_max_tokens,
       double trie_source_prior,
-      double min_trie_share,
       double match_specificity_weight,
       double match_confidence_weight) {
     ngram::Param param;
@@ -38,10 +36,8 @@ struct NgramCorpusObj : public tvm::ffi::Object {
     param.max_bfs_breadth = static_cast<size_t>(max_bfs_breadth);
     param.draft_token_num = static_cast<size_t>(draft_token_num);
     param.match_type = (match_type == 0) ? "BFS" : "PROB";
-    param.external_sam_budget = static_cast<size_t>(external_sam_budget);
     param.external_corpus_max_tokens = static_cast<size_t>(external_corpus_max_tokens);
     param.trie_source_prior = trie_source_prior;
-    param.min_trie_share = min_trie_share;
     param.match_specificity_weight = match_specificity_weight;
     param.match_confidence_weight = match_confidence_weight;
     ngram_ = std::make_unique<ngram::Ngram>(static_cast<size_t>(capacity), param);
@@ -170,8 +166,6 @@ void register_ngram_corpus() {
               int64_t,
               int64_t,
               int64_t,
-              int64_t,
-              double,
               double,
               double,
               double>(),

--- a/python/sglang/jit_kernel/csrc/ngram_corpus/ngram_corpus_ffi.cpp
+++ b/python/sglang/jit_kernel/csrc/ngram_corpus/ngram_corpus_ffi.cpp
@@ -29,8 +29,7 @@ struct NgramCorpusObj : public tvm::ffi::Object {
       double trie_source_prior,
       double min_trie_share,
       double match_specificity_weight,
-      double match_confidence_weight,
-      double max_per_sam_share) {
+      double match_confidence_weight) {
     ngram::Param param;
     param.enable = true;
     param.enable_router_mode = false;
@@ -45,7 +44,6 @@ struct NgramCorpusObj : public tvm::ffi::Object {
     param.min_trie_share = min_trie_share;
     param.match_specificity_weight = match_specificity_weight;
     param.match_confidence_weight = match_confidence_weight;
-    param.max_per_sam_share = max_per_sam_share;
     ngram_ = std::make_unique<ngram::Ngram>(static_cast<size_t>(capacity), param);
   }
 
@@ -164,8 +162,19 @@ void register_ngram_corpus() {
   namespace refl = tvm::ffi::reflection;
   refl::ObjectDef<NgramCorpusObj>()
       .def(
-          refl::init<int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, double, double, double,
-                     double, double>(),
+          refl::init<
+              int64_t,
+              int64_t,
+              int64_t,
+              int64_t,
+              int64_t,
+              int64_t,
+              int64_t,
+              int64_t,
+              double,
+              double,
+              double,
+              double>(),
           "__init__")
       .def("async_insert", &NgramCorpusObj::async_insert)
       .def("batch_match_stateful", &NgramCorpusObj::batch_match_stateful)

--- a/python/sglang/jit_kernel/csrc/ngram_corpus/param.h
+++ b/python/sglang/jit_kernel/csrc/ngram_corpus/param.h
@@ -103,7 +103,8 @@ struct Param {
        << ", min_bfs_breadth = " << min_bfs_breadth << ", max_bfs_breadth = " << max_bfs_breadth
        << ", max_trie_depth = " << max_trie_depth << ", draft_token_num = " << draft_token_num
        << ", external_corpus_max_tokens = " << external_corpus_max_tokens
-       << ", trie_source_prior = " << trie_source_prior << ", match_specificity_weight = " << match_specificity_weight
+       << ", trie_source_prior = " << trie_source_prior << ", match_specificity_weight = "
+       << match_specificity_weight
        << ", match_confidence_weight = " << match_confidence_weight << ", match_type = " << match_type;
     ss << ", batch_draft_token_num(" << batch_draft_token_num.size() << ") = ";
     for (int i = 0; i < batch_draft_token_num.size(); ++i) {

--- a/python/sglang/jit_kernel/csrc/ngram_corpus/param.h
+++ b/python/sglang/jit_kernel/csrc/ngram_corpus/param.h
@@ -103,8 +103,7 @@ struct Param {
        << ", min_bfs_breadth = " << min_bfs_breadth << ", max_bfs_breadth = " << max_bfs_breadth
        << ", max_trie_depth = " << max_trie_depth << ", draft_token_num = " << draft_token_num
        << ", external_corpus_max_tokens = " << external_corpus_max_tokens
-       << ", trie_source_prior = " << trie_source_prior << ", match_specificity_weight = "
-       << match_specificity_weight
+       << ", trie_source_prior = " << trie_source_prior << ", match_specificity_weight = " << match_specificity_weight
        << ", match_confidence_weight = " << match_confidence_weight << ", match_type = " << match_type;
     ss << ", batch_draft_token_num(" << batch_draft_token_num.size() << ") = ";
     for (int i = 0; i < batch_draft_token_num.size(); ++i) {

--- a/python/sglang/jit_kernel/csrc/ngram_corpus/param.h
+++ b/python/sglang/jit_kernel/csrc/ngram_corpus/param.h
@@ -25,10 +25,8 @@ struct Param {
   size_t max_bfs_breadth;
   size_t max_trie_depth;
   size_t draft_token_num;
-  size_t external_sam_budget = 0;
   size_t external_corpus_max_tokens = 10000000;
   double trie_source_prior = 0.0;
-  double min_trie_share = 0.0;
   double match_specificity_weight = 0.7;
   double match_confidence_weight = 0.3;
   std::string match_type;
@@ -104,10 +102,9 @@ struct Param {
     ss << "enable = " << enable << ", enable_router_mode = " << enable_router_mode
        << ", min_bfs_breadth = " << min_bfs_breadth << ", max_bfs_breadth = " << max_bfs_breadth
        << ", max_trie_depth = " << max_trie_depth << ", draft_token_num = " << draft_token_num
-       << ", external_sam_budget = " << external_sam_budget
        << ", external_corpus_max_tokens = " << external_corpus_max_tokens
-       << ", trie_source_prior = " << trie_source_prior << ", min_trie_share = " << min_trie_share
-       << ", match_specificity_weight = " << match_specificity_weight
+       << ", trie_source_prior = " << trie_source_prior << ", match_specificity_weight = "
+       << match_specificity_weight
        << ", match_confidence_weight = " << match_confidence_weight << ", match_type = " << match_type;
     ss << ", batch_draft_token_num(" << batch_draft_token_num.size() << ") = ";
     for (int i = 0; i < batch_draft_token_num.size(); ++i) {

--- a/python/sglang/jit_kernel/csrc/ngram_corpus/param.h
+++ b/python/sglang/jit_kernel/csrc/ngram_corpus/param.h
@@ -12,6 +12,12 @@
 
 namespace ngram {
 
+struct MatchQuality {
+  bool has_match = false;
+  double specificity = 0.0;
+  double confidence = 0.0;
+};
+
 struct Param {
   bool enable;
   bool enable_router_mode;
@@ -21,6 +27,11 @@ struct Param {
   size_t draft_token_num;
   size_t external_sam_budget = 0;
   size_t external_corpus_max_tokens = 10000000;
+  double trie_source_prior = 0.0;
+  double min_trie_share = 0.0;
+  double match_specificity_weight = 0.7;
+  double match_confidence_weight = 0.3;
+  double max_per_sam_share = 1.0;
   std::string match_type;
 
   std::vector<size_t> batch_draft_token_num;
@@ -95,7 +106,11 @@ struct Param {
        << ", min_bfs_breadth = " << min_bfs_breadth << ", max_bfs_breadth = " << max_bfs_breadth
        << ", max_trie_depth = " << max_trie_depth << ", draft_token_num = " << draft_token_num
        << ", external_sam_budget = " << external_sam_budget
-       << ", external_corpus_max_tokens = " << external_corpus_max_tokens << ", match_type = " << match_type;
+       << ", external_corpus_max_tokens = " << external_corpus_max_tokens
+       << ", trie_source_prior = " << trie_source_prior << ", min_trie_share = " << min_trie_share
+       << ", match_specificity_weight = " << match_specificity_weight
+       << ", match_confidence_weight = " << match_confidence_weight
+       << ", max_per_sam_share = " << max_per_sam_share << ", match_type = " << match_type;
     ss << ", batch_draft_token_num(" << batch_draft_token_num.size() << ") = ";
     for (int i = 0; i < batch_draft_token_num.size(); ++i) {
       ss << i << "|" << batch_draft_token_num[i] << ",";

--- a/python/sglang/jit_kernel/csrc/ngram_corpus/param.h
+++ b/python/sglang/jit_kernel/csrc/ngram_corpus/param.h
@@ -31,7 +31,6 @@ struct Param {
   double min_trie_share = 0.0;
   double match_specificity_weight = 0.7;
   double match_confidence_weight = 0.3;
-  double max_per_sam_share = 1.0;
   std::string match_type;
 
   std::vector<size_t> batch_draft_token_num;
@@ -109,8 +108,7 @@ struct Param {
        << ", external_corpus_max_tokens = " << external_corpus_max_tokens
        << ", trie_source_prior = " << trie_source_prior << ", min_trie_share = " << min_trie_share
        << ", match_specificity_weight = " << match_specificity_weight
-       << ", match_confidence_weight = " << match_confidence_weight
-       << ", max_per_sam_share = " << max_per_sam_share << ", match_type = " << match_type;
+       << ", match_confidence_weight = " << match_confidence_weight << ", match_type = " << match_type;
     ss << ", batch_draft_token_num(" << batch_draft_token_num.size() << ") = ";
     for (int i = 0; i < batch_draft_token_num.size(); ++i) {
       ss << i << "|" << batch_draft_token_num[i] << ",";

--- a/python/sglang/jit_kernel/csrc/ngram_corpus/suffix_automaton.cpp
+++ b/python/sglang/jit_kernel/csrc/ngram_corpus/suffix_automaton.cpp
@@ -176,9 +176,40 @@ std::vector<SamAnchor> SuffixAutomaton::match(const int32_t* context, size_t len
   return anchors;
 }
 
-Result SuffixAutomaton::buildRecency(
-    const int32_t* context, size_t len, int32_t last_token, size_t draft_token_num, const Param& param) const {
-  auto anchors = match(context, len, param.max_trie_depth);
+MatchQuality SuffixAutomaton::summarizeMatchQuality(const std::vector<SamAnchor>& anchors, const Param& param) const {
+  MatchQuality quality;
+  if (anchors.empty()) {
+    return quality;
+  }
+
+  const auto& best_anchor = anchors.front();
+  quality.has_match = true;
+  quality.specificity =
+      std::min(1.0, static_cast<double>(best_anchor.matched_len) / std::max<size_t>(1, param.max_trie_depth));
+
+  const auto& children = states_[best_anchor.state].children_by_freq;
+  const int top_k = std::max(1, static_cast<int>(param.max_bfs_breadth));
+  double top_mass = 0.0;
+  double total_mass = 0.0;
+  int count = 0;
+  for (const auto& [_, child_state] : children) {
+    const auto mass = static_cast<double>(states_[child_state].occ_count);
+    if (count == 0) {
+      top_mass = mass;
+    }
+    total_mass += mass;
+    if (++count >= top_k) {
+      break;
+    }
+  }
+  if (total_mass > 0.0) {
+    quality.confidence = top_mass / total_mass;
+  }
+  return quality;
+}
+
+Result SuffixAutomaton::buildRecencyFromAnchors(
+    const std::vector<SamAnchor>& anchors, int32_t last_token, size_t draft_token_num, const Param& param) const {
   const auto max_match_depth = std::max<int32_t>(1, static_cast<int32_t>(param.max_trie_depth - 1));
   const double bfs_breadth_scale = double(param.max_bfs_breadth - param.min_bfs_breadth) / max_match_depth;
   std::vector<Node> tree(draft_token_num + 1);
@@ -212,9 +243,14 @@ Result SuffixAutomaton::buildRecency(
   return fillResult(last_token, draft_token_num + 1, tree, root);
 }
 
-Result SuffixAutomaton::buildFrequency(
+Result SuffixAutomaton::buildRecency(
     const int32_t* context, size_t len, int32_t last_token, size_t draft_token_num, const Param& param) const {
   auto anchors = match(context, len, param.max_trie_depth);
+  return buildRecencyFromAnchors(anchors, last_token, draft_token_num, param);
+}
+
+Result SuffixAutomaton::buildFrequencyFromAnchors(
+    const std::vector<SamAnchor>& anchors, int32_t last_token, size_t draft_token_num, const Param& param) const {
   struct CompareByProb {
     bool operator()(
         const std::tuple<int, int32_t, int, double>& lhs, const std::tuple<int, int32_t, int, double>& rhs) const {
@@ -278,6 +314,12 @@ Result SuffixAutomaton::buildFrequency(
     }
   }
   return fillResult(last_token, draft_token_num + 1, tree, root);
+}
+
+Result SuffixAutomaton::buildFrequency(
+    const int32_t* context, size_t len, int32_t last_token, size_t draft_token_num, const Param& param) const {
+  auto anchors = match(context, len, param.max_trie_depth);
+  return buildFrequencyFromAnchors(anchors, last_token, draft_token_num, param);
 }
 
 }  // namespace ngram

--- a/python/sglang/jit_kernel/csrc/ngram_corpus/suffix_automaton.cpp
+++ b/python/sglang/jit_kernel/csrc/ngram_corpus/suffix_automaton.cpp
@@ -243,12 +243,6 @@ Result SuffixAutomaton::buildRecencyFromAnchors(
   return fillResult(last_token, draft_token_num + 1, tree, root);
 }
 
-Result SuffixAutomaton::buildRecency(
-    const int32_t* context, size_t len, int32_t last_token, size_t draft_token_num, const Param& param) const {
-  auto anchors = match(context, len, param.max_trie_depth);
-  return buildRecencyFromAnchors(anchors, last_token, draft_token_num, param);
-}
-
 Result SuffixAutomaton::buildFrequencyFromAnchors(
     const std::vector<SamAnchor>& anchors, int32_t last_token, size_t draft_token_num, const Param& param) const {
   struct CompareByProb {
@@ -314,12 +308,6 @@ Result SuffixAutomaton::buildFrequencyFromAnchors(
     }
   }
   return fillResult(last_token, draft_token_num + 1, tree, root);
-}
-
-Result SuffixAutomaton::buildFrequency(
-    const int32_t* context, size_t len, int32_t last_token, size_t draft_token_num, const Param& param) const {
-  auto anchors = match(context, len, param.max_trie_depth);
-  return buildFrequencyFromAnchors(anchors, last_token, draft_token_num, param);
 }
 
 }  // namespace ngram

--- a/python/sglang/jit_kernel/csrc/ngram_corpus/suffix_automaton.h
+++ b/python/sglang/jit_kernel/csrc/ngram_corpus/suffix_automaton.h
@@ -49,11 +49,20 @@ class SuffixAutomaton {
   Result buildFrequency(
       const int32_t* context, size_t len, int32_t last_token, size_t draft_token_num, const Param& param) const;
 
+  std::vector<SamAnchor> match(const int32_t* context, size_t len, size_t max_depth) const;
+
+  MatchQuality summarizeMatchQuality(const std::vector<SamAnchor>& anchors, const Param& param) const;
+
+  Result buildRecencyFromAnchors(
+      const std::vector<SamAnchor>& anchors, int32_t last_token, size_t draft_token_num, const Param& param) const;
+
+  Result buildFrequencyFromAnchors(
+      const std::vector<SamAnchor>& anchors, int32_t last_token, size_t draft_token_num, const Param& param) const;
+
  private:
   void reset_();
   void extend_(int32_t token, int64_t pos);
   void propagateOccurrencesAndRecency_();
-  std::vector<SamAnchor> match(const int32_t* context, size_t len, size_t max_depth) const;
 
   std::vector<SamState> states_;
   int last_ = 0;

--- a/python/sglang/jit_kernel/csrc/ngram_corpus/suffix_automaton.h
+++ b/python/sglang/jit_kernel/csrc/ngram_corpus/suffix_automaton.h
@@ -42,13 +42,6 @@ class SuffixAutomaton {
   int64_t tokenCount() const {
     return pos_;
   }
-
-  Result buildRecency(
-      const int32_t* context, size_t len, int32_t last_token, size_t draft_token_num, const Param& param) const;
-
-  Result buildFrequency(
-      const int32_t* context, size_t len, int32_t last_token, size_t draft_token_num, const Param& param) const;
-
   std::vector<SamAnchor> match(const int32_t* context, size_t len, size_t max_depth) const;
 
   MatchQuality summarizeMatchQuality(const std::vector<SamAnchor>& anchors, const Param& param) const;

--- a/python/sglang/jit_kernel/csrc/ngram_corpus/trie.cpp
+++ b/python/sglang/jit_kernel/csrc/ngram_corpus/trie.cpp
@@ -288,18 +288,6 @@ Result Trie::buildRecencyFromAnchors(
   return fillResult(last_token, draft_token_num + 1, tree, root);
 }
 
-Result Trie::buildRecency(
-    const int32_t* context,
-    size_t len,
-    int32_t last_token,
-    size_t draft_token_num,
-    const Param& param,
-    MatchState& state,
-    size_t total_len) const {
-  auto anchors = match(context, len, state, total_len);
-  return buildRecencyFromAnchors(anchors, last_token, draft_token_num, param);
-}
-
 Result Trie::buildFrequencyFromAnchors(
     const std::vector<std::pair<const TrieNode*, int32_t>>& anchors,
     int32_t last_token,
@@ -361,18 +349,6 @@ Result Trie::buildFrequencyFromAnchors(
   }
 
   return fillResult(last_token, draft_token_num + 1, tree, root);
-}
-
-Result Trie::buildFrequency(
-    const int32_t* context,
-    size_t len,
-    int32_t last_token,
-    size_t draft_token_num,
-    const Param& param,
-    MatchState& state,
-    size_t total_len) const {
-  auto anchors = match(context, len, state, total_len);
-  return buildFrequencyFromAnchors(anchors, last_token, draft_token_num, param);
 }
 
 }  // namespace ngram

--- a/python/sglang/jit_kernel/csrc/ngram_corpus/trie.cpp
+++ b/python/sglang/jit_kernel/csrc/ngram_corpus/trie.cpp
@@ -215,15 +215,43 @@ Trie::match(const int32_t* context, size_t len, MatchState& state, size_t total_
   return getExpandableAnchors_(state);
 }
 
-Result Trie::buildRecency(
-    const int32_t* context,
-    size_t len,
+MatchQuality Trie::summarizeMatchQuality(
+    const std::vector<std::pair<const TrieNode*, int32_t>>& anchors, const Param& param) const {
+  MatchQuality quality;
+  if (anchors.empty()) {
+    return quality;
+  }
+
+  const auto& [best_node, best_depth] = anchors.front();
+  quality.has_match = true;
+  quality.specificity =
+      std::min(1.0, static_cast<double>(best_depth) / std::max<size_t>(1, param.max_trie_depth));
+
+  const int top_k = std::max(1, static_cast<int>(param.max_bfs_breadth));
+  double top_mass = 0.0;
+  double total_mass = 0.0;
+  int count = 0;
+  for (auto* child : best_node->sorted_children) {
+    const auto mass = static_cast<double>(child->freq);
+    if (count == 0) {
+      top_mass = mass;
+    }
+    total_mass += mass;
+    if (++count >= top_k) {
+      break;
+    }
+  }
+  if (total_mass > 0.0) {
+    quality.confidence = top_mass / total_mass;
+  }
+  return quality;
+}
+
+Result Trie::buildRecencyFromAnchors(
+    const std::vector<std::pair<const TrieNode*, int32_t>>& anchors,
     int32_t last_token,
     size_t draft_token_num,
-    const Param& param,
-    MatchState& state,
-    size_t total_len) const {
-  auto anchors = match(context, len, state, total_len);
+    const Param& param) const {
   const auto max_match_depth = std::max<int32_t>(1, static_cast<int32_t>(param.max_trie_depth - 1));
   double bfs_breadth_scale = double(param.max_bfs_breadth - param.min_bfs_breadth) / max_match_depth;
 
@@ -261,7 +289,7 @@ Result Trie::buildRecency(
   return fillResult(last_token, draft_token_num + 1, tree, root);
 }
 
-Result Trie::buildFrequency(
+Result Trie::buildRecency(
     const int32_t* context,
     size_t len,
     int32_t last_token,
@@ -270,6 +298,14 @@ Result Trie::buildFrequency(
     MatchState& state,
     size_t total_len) const {
   auto anchors = match(context, len, state, total_len);
+  return buildRecencyFromAnchors(anchors, last_token, draft_token_num, param);
+}
+
+Result Trie::buildFrequencyFromAnchors(
+    const std::vector<std::pair<const TrieNode*, int32_t>>& anchors,
+    int32_t last_token,
+    size_t draft_token_num,
+    const Param& param) const {
   struct CompareByLastDouble {
     bool operator()(
         const std::tuple<double, const TrieNode*, double>& a,
@@ -326,6 +362,18 @@ Result Trie::buildFrequency(
   }
 
   return fillResult(last_token, draft_token_num + 1, tree, root);
+}
+
+Result Trie::buildFrequency(
+    const int32_t* context,
+    size_t len,
+    int32_t last_token,
+    size_t draft_token_num,
+    const Param& param,
+    MatchState& state,
+    size_t total_len) const {
+  auto anchors = match(context, len, state, total_len);
+  return buildFrequencyFromAnchors(anchors, last_token, draft_token_num, param);
 }
 
 }  // namespace ngram

--- a/python/sglang/jit_kernel/csrc/ngram_corpus/trie.cpp
+++ b/python/sglang/jit_kernel/csrc/ngram_corpus/trie.cpp
@@ -215,8 +215,8 @@ Trie::match(const int32_t* context, size_t len, MatchState& state, size_t total_
   return getExpandableAnchors_(state);
 }
 
-MatchQuality Trie::summarizeMatchQuality(
-    const std::vector<std::pair<const TrieNode*, int32_t>>& anchors, const Param& param) const {
+MatchQuality
+Trie::summarizeMatchQuality(const std::vector<std::pair<const TrieNode*, int32_t>>& anchors, const Param& param) const {
   MatchQuality quality;
   if (anchors.empty()) {
     return quality;
@@ -224,8 +224,7 @@ MatchQuality Trie::summarizeMatchQuality(
 
   const auto& [best_node, best_depth] = anchors.front();
   quality.has_match = true;
-  quality.specificity =
-      std::min(1.0, static_cast<double>(best_depth) / std::max<size_t>(1, param.max_trie_depth));
+  quality.specificity = std::min(1.0, static_cast<double>(best_depth) / std::max<size_t>(1, param.max_trie_depth));
 
   const int top_k = std::max(1, static_cast<int>(param.max_bfs_breadth));
   double top_mass = 0.0;

--- a/python/sglang/jit_kernel/csrc/ngram_corpus/trie.h
+++ b/python/sglang/jit_kernel/csrc/ngram_corpus/trie.h
@@ -59,24 +59,6 @@ class Trie {
 
   void insert(const int32_t* tokens, size_t len);
 
-  Result buildRecency(
-      const int32_t* context,
-      size_t len,
-      int32_t last_token,
-      size_t draft_token_num,
-      const Param& param,
-      MatchState& state,
-      size_t total_len) const;
-
-  Result buildFrequency(
-      const int32_t* context,
-      size_t len,
-      int32_t last_token,
-      size_t draft_token_num,
-      const Param& param,
-      MatchState& state,
-      size_t total_len) const;
-
   // Stateful suffix matcher. If `state` still represents the previous step for
   // this request, infer the newly appended suffix from (`context`, `total_len`)
   // and advance anchors incrementally; otherwise rebuild the cached anchors from

--- a/python/sglang/jit_kernel/csrc/ngram_corpus/trie.h
+++ b/python/sglang/jit_kernel/csrc/ngram_corpus/trie.h
@@ -84,8 +84,8 @@ class Trie {
   std::vector<std::pair<const TrieNode*, int32_t>>
   match(const int32_t* context, size_t len, MatchState& state, size_t total_len) const;
 
-  MatchQuality summarizeMatchQuality(
-      const std::vector<std::pair<const TrieNode*, int32_t>>& anchors, const Param& param) const;
+  MatchQuality
+  summarizeMatchQuality(const std::vector<std::pair<const TrieNode*, int32_t>>& anchors, const Param& param) const;
 
   Result buildRecencyFromAnchors(
       const std::vector<std::pair<const TrieNode*, int32_t>>& anchors,

--- a/python/sglang/jit_kernel/csrc/ngram_corpus/trie.h
+++ b/python/sglang/jit_kernel/csrc/ngram_corpus/trie.h
@@ -77,17 +77,33 @@ class Trie {
       MatchState& state,
       size_t total_len) const;
 
-  void squeeze(size_t count);
-
-  void reset();
-
- private:
   // Stateful suffix matcher. If `state` still represents the previous step for
   // this request, infer the newly appended suffix from (`context`, `total_len`)
   // and advance anchors incrementally; otherwise rebuild the cached anchors from
   // `context`. Returns only the suffix matches that are currently expandable.
   std::vector<std::pair<const TrieNode*, int32_t>>
   match(const int32_t* context, size_t len, MatchState& state, size_t total_len) const;
+
+  MatchQuality summarizeMatchQuality(
+      const std::vector<std::pair<const TrieNode*, int32_t>>& anchors, const Param& param) const;
+
+  Result buildRecencyFromAnchors(
+      const std::vector<std::pair<const TrieNode*, int32_t>>& anchors,
+      int32_t last_token,
+      size_t draft_token_num,
+      const Param& param) const;
+
+  Result buildFrequencyFromAnchors(
+      const std::vector<std::pair<const TrieNode*, int32_t>>& anchors,
+      int32_t last_token,
+      size_t draft_token_num,
+      const Param& param) const;
+
+  void squeeze(size_t count);
+
+  void reset();
+
+ private:
   // Recompute all cached anchors from the current tail. After this, for every
   // d in [1, min(len, max_trie_depth)], anchors[d - 1] represents the suffix of
   // length d ending at context[len - 1].

--- a/python/sglang/jit_kernel/ngram_corpus.py
+++ b/python/sglang/jit_kernel/ngram_corpus.py
@@ -52,6 +52,11 @@ def get_ngram_corpus_cls():
             match_type: str,
             external_sam_budget: int = 0,
             external_corpus_max_tokens: int = 10000000,
+            trie_source_prior: float = 0.0,
+            min_trie_share: float = 0.0,
+            match_specificity_weight: float = 0.7,
+            match_confidence_weight: float = 0.3,
+            max_per_sam_share: float = 1.0,
         ) -> None:
             mt = _MATCH_TYPE_MAP.get(match_type)
             if mt is None:
@@ -67,6 +72,11 @@ def get_ngram_corpus_cls():
                 mt,
                 external_sam_budget,
                 external_corpus_max_tokens,
+                trie_source_prior,
+                min_trie_share,
+                match_specificity_weight,
+                match_confidence_weight,
+                max_per_sam_share,
             )
             self._draft_token_num = draft_token_num
 

--- a/python/sglang/jit_kernel/ngram_corpus.py
+++ b/python/sglang/jit_kernel/ngram_corpus.py
@@ -50,10 +50,8 @@ def get_ngram_corpus_cls():
             max_bfs_breadth: int,
             draft_token_num: int,
             match_type: str,
-            external_sam_budget: int = 0,
             external_corpus_max_tokens: int = 10000000,
             trie_source_prior: float = 0.0,
-            min_trie_share: float = 0.0,
             match_specificity_weight: float = 0.7,
             match_confidence_weight: float = 0.3,
         ) -> None:
@@ -69,10 +67,8 @@ def get_ngram_corpus_cls():
                 max_bfs_breadth,
                 draft_token_num,
                 mt,
-                external_sam_budget,
                 external_corpus_max_tokens,
                 trie_source_prior,
-                min_trie_share,
                 match_specificity_weight,
                 match_confidence_weight,
             )

--- a/python/sglang/jit_kernel/ngram_corpus.py
+++ b/python/sglang/jit_kernel/ngram_corpus.py
@@ -56,7 +56,6 @@ def get_ngram_corpus_cls():
             min_trie_share: float = 0.0,
             match_specificity_weight: float = 0.7,
             match_confidence_weight: float = 0.3,
-            max_per_sam_share: float = 1.0,
         ) -> None:
             mt = _MATCH_TYPE_MAP.get(match_type)
             if mt is None:
@@ -76,7 +75,6 @@ def get_ngram_corpus_cls():
                 min_trie_share,
                 match_specificity_weight,
                 match_confidence_weight,
-                max_per_sam_share,
             )
             self._draft_token_num = draft_token_num
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -523,6 +523,11 @@ class ServerArgs:
     speculative_ngram_external_corpus_path: Optional[str] = None
     speculative_ngram_external_sam_budget: int = 0
     speculative_ngram_external_corpus_max_tokens: int = 10000000
+    speculative_ngram_trie_source_prior: float = 0.0
+    speculative_ngram_min_trie_share: float = 0.0
+    speculative_ngram_match_specificity_weight: float = 0.7
+    speculative_ngram_match_confidence_weight: float = 0.3
+    speculative_ngram_max_per_sam_share: float = 1.0
     enable_multi_layer_eagle: bool = False
 
     # Expert parallelism
@@ -3368,6 +3373,34 @@ class ServerArgs:
                     "speculative_num_draft_tokens is set to 12 by default for ngram speculative decoding. "
                     "You can override this by explicitly setting --speculative-num-draft-tokens."
                 )
+            if self.speculative_ngram_trie_source_prior < 0:
+                raise ValueError(
+                    "--speculative-ngram-trie-source-prior must be greater than or equal to 0."
+                )
+            if not 0 <= self.speculative_ngram_min_trie_share <= 1:
+                raise ValueError(
+                    "--speculative-ngram-min-trie-share must be between 0 and 1."
+                )
+            if self.speculative_ngram_match_specificity_weight < 0:
+                raise ValueError(
+                    "--speculative-ngram-match-specificity-weight must be greater than or equal to 0."
+                )
+            if self.speculative_ngram_match_confidence_weight < 0:
+                raise ValueError(
+                    "--speculative-ngram-match-confidence-weight must be greater than or equal to 0."
+                )
+            if (
+                self.speculative_ngram_match_specificity_weight
+                + self.speculative_ngram_match_confidence_weight
+                <= 0
+            ):
+                raise ValueError(
+                    "The speculative ngram match weights must sum to a positive value."
+                )
+            if not 0 < self.speculative_ngram_max_per_sam_share <= 1:
+                raise ValueError(
+                    "--speculative-ngram-max-per-sam-share must be greater than 0 and less than or equal to 1."
+                )
             if self.speculative_ngram_external_corpus_path is not None:
                 if self.speculative_ngram_external_sam_budget <= 0:
                     raise ValueError(
@@ -5237,6 +5270,36 @@ class ServerArgs:
             type=int,
             default=ServerArgs.speculative_ngram_external_corpus_max_tokens,
             help="Fail startup if the tokenized external ngram corpus exceeds this many tokens. Tune this based on your CPU memory budget.",
+        )
+        parser.add_argument(
+            "--speculative-ngram-trie-source-prior",
+            type=float,
+            default=ServerArgs.speculative_ngram_trie_source_prior,
+            help="Relative prior for the live trie when weighting trie and external SAM draft budget.",
+        )
+        parser.add_argument(
+            "--speculative-ngram-min-trie-share",
+            type=float,
+            default=ServerArgs.speculative_ngram_min_trie_share,
+            help="Minimum fraction of the draft budget reserved for trie when it has an expandable continuation.",
+        )
+        parser.add_argument(
+            "--speculative-ngram-match-specificity-weight",
+            type=float,
+            default=ServerArgs.speculative_ngram_match_specificity_weight,
+            help="Weight assigned to suffix-match specificity when scoring trie and SAM importance.",
+        )
+        parser.add_argument(
+            "--speculative-ngram-match-confidence-weight",
+            type=float,
+            default=ServerArgs.speculative_ngram_match_confidence_weight,
+            help="Weight assigned to continuation sharpness when scoring trie and SAM importance.",
+        )
+        parser.add_argument(
+            "--speculative-ngram-max-per-sam-share",
+            type=float,
+            default=ServerArgs.speculative_ngram_max_per_sam_share,
+            help="Maximum fraction of the external SAM budget that a single SAM may receive after weighting.",
         )
 
         # Multi-layer Eagle speculative decoding

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -521,10 +521,8 @@ class ServerArgs:
     speculative_ngram_max_trie_depth: int = 18
     speculative_ngram_capacity: int = 10 * 1000 * 1000
     speculative_ngram_external_corpus_path: Optional[str] = None
-    speculative_ngram_external_sam_budget: int = 0
     speculative_ngram_external_corpus_max_tokens: int = 10000000
     speculative_ngram_trie_source_prior: float = 0.0
-    speculative_ngram_min_trie_share: float = 0.0
     speculative_ngram_match_specificity_weight: float = 0.7
     speculative_ngram_match_confidence_weight: float = 0.3
     enable_multi_layer_eagle: bool = False
@@ -3376,10 +3374,6 @@ class ServerArgs:
                 raise ValueError(
                     "--speculative-ngram-trie-source-prior must be greater than or equal to 0."
                 )
-            if not 0 <= self.speculative_ngram_min_trie_share <= 1:
-                raise ValueError(
-                    "--speculative-ngram-min-trie-share must be between 0 and 1."
-                )
             if self.speculative_ngram_match_specificity_weight < 0:
                 raise ValueError(
                     "--speculative-ngram-match-specificity-weight must be greater than or equal to 0."
@@ -3397,23 +3391,10 @@ class ServerArgs:
                     "The speculative ngram match weights must sum to a positive value."
                 )
             if self.speculative_ngram_external_corpus_path is not None:
-                if self.speculative_ngram_external_sam_budget <= 0:
-                    raise ValueError(
-                        "--speculative-ngram-external-sam-budget must be positive when "
-                        "--speculative-ngram-external-corpus-path is set."
-                    )
                 if self.speculative_ngram_external_corpus_max_tokens <= 0:
                     raise ValueError(
                         "--speculative-ngram-external-corpus-max-tokens must be positive when "
                         "--speculative-ngram-external-corpus-path is set."
-                    )
-                if (
-                    self.speculative_ngram_external_sam_budget
-                    > self.speculative_num_draft_tokens - 1
-                ):
-                    raise ValueError(
-                        "speculative_ngram_external_sam_budget must be less than or equal to "
-                        f"speculative_num_draft_tokens - 1 ({self.speculative_num_draft_tokens - 1})."
                     )
             logger.warning(
                 "The overlap scheduler and mixed chunked prefill are disabled because of "
@@ -5255,12 +5236,6 @@ class ServerArgs:
             help="Path to an external JSONL corpus to pre-load into SAM at startup. Additional corpora can be added at runtime via POST /add_external_corpus.",
         )
         parser.add_argument(
-            "--speculative-ngram-external-sam-budget",
-            type=int,
-            default=ServerArgs.speculative_ngram_external_sam_budget,
-            help="Number of draft nodes reserved for the external SAM subtree in ngram speculative decoding.",
-        )
-        parser.add_argument(
             "--speculative-ngram-external-corpus-max-tokens",
             type=int,
             default=ServerArgs.speculative_ngram_external_corpus_max_tokens,
@@ -5270,13 +5245,7 @@ class ServerArgs:
             "--speculative-ngram-trie-source-prior",
             type=float,
             default=ServerArgs.speculative_ngram_trie_source_prior,
-            help="Relative prior for the live trie when weighting trie and external SAM draft budget.",
-        )
-        parser.add_argument(
-            "--speculative-ngram-min-trie-share",
-            type=float,
-            default=ServerArgs.speculative_ngram_min_trie_share,
-            help="Minimum fraction of the draft budget reserved for trie when it has an expandable continuation.",
+            help="Relative priority multiplier for the live trie when ordering trie and external SAM merges. The default 0 uses the neutral baseline.",
         )
         parser.add_argument(
             "--speculative-ngram-match-specificity-weight",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -527,7 +527,6 @@ class ServerArgs:
     speculative_ngram_min_trie_share: float = 0.0
     speculative_ngram_match_specificity_weight: float = 0.7
     speculative_ngram_match_confidence_weight: float = 0.3
-    speculative_ngram_max_per_sam_share: float = 1.0
     enable_multi_layer_eagle: bool = False
 
     # Expert parallelism
@@ -3397,10 +3396,6 @@ class ServerArgs:
                 raise ValueError(
                     "The speculative ngram match weights must sum to a positive value."
                 )
-            if not 0 < self.speculative_ngram_max_per_sam_share <= 1:
-                raise ValueError(
-                    "--speculative-ngram-max-per-sam-share must be greater than 0 and less than or equal to 1."
-                )
             if self.speculative_ngram_external_corpus_path is not None:
                 if self.speculative_ngram_external_sam_budget <= 0:
                     raise ValueError(
@@ -5294,12 +5289,6 @@ class ServerArgs:
             type=float,
             default=ServerArgs.speculative_ngram_match_confidence_weight,
             help="Weight assigned to continuation sharpness when scoring trie and SAM importance.",
-        )
-        parser.add_argument(
-            "--speculative-ngram-max-per-sam-share",
-            type=float,
-            default=ServerArgs.speculative_ngram_max_per_sam_share,
-            help="Maximum fraction of the external SAM budget that a single SAM may receive after weighting.",
         )
 
         # Multi-layer Eagle speculative decoding

--- a/python/sglang/srt/speculative/cpp_ngram/ngram_corpus.py
+++ b/python/sglang/srt/speculative/cpp_ngram/ngram_corpus.py
@@ -20,10 +20,8 @@ class NgramCorpus:
         draft_token_num=8,
         match_type="BFS",
         capacity=1000000,
-        external_sam_budget=0,
         external_corpus_max_tokens=10000000,
         trie_source_prior=0.0,
-        min_trie_share=0.0,
         match_specificity_weight=0.7,
         match_confidence_weight=0.3,
     ) -> None:
@@ -35,10 +33,8 @@ class NgramCorpus:
             max_bfs_breadth=max_bfs_breadth,
             draft_token_num=draft_token_num,
             match_type=match_type,
-            external_sam_budget=external_sam_budget,
             external_corpus_max_tokens=external_corpus_max_tokens,
             trie_source_prior=trie_source_prior,
-            min_trie_share=min_trie_share,
             match_specificity_weight=match_specificity_weight,
             match_confidence_weight=match_confidence_weight,
         )

--- a/python/sglang/srt/speculative/cpp_ngram/ngram_corpus.py
+++ b/python/sglang/srt/speculative/cpp_ngram/ngram_corpus.py
@@ -22,6 +22,11 @@ class NgramCorpus:
         capacity=1000000,
         external_sam_budget=0,
         external_corpus_max_tokens=10000000,
+        trie_source_prior=0.0,
+        min_trie_share=0.0,
+        match_specificity_weight=0.7,
+        match_confidence_weight=0.3,
+        max_per_sam_share=1.0,
     ) -> None:
         cls = get_ngram_corpus_cls()
         self._obj = cls(
@@ -33,6 +38,11 @@ class NgramCorpus:
             match_type=match_type,
             external_sam_budget=external_sam_budget,
             external_corpus_max_tokens=external_corpus_max_tokens,
+            trie_source_prior=trie_source_prior,
+            min_trie_share=min_trie_share,
+            match_specificity_weight=match_specificity_weight,
+            match_confidence_weight=match_confidence_weight,
+            max_per_sam_share=max_per_sam_share,
         )
         self.default_mask = np.ones((1, 1), dtype=np.int64)
         self.draft_token_num = draft_token_num

--- a/python/sglang/srt/speculative/cpp_ngram/ngram_corpus.py
+++ b/python/sglang/srt/speculative/cpp_ngram/ngram_corpus.py
@@ -26,7 +26,6 @@ class NgramCorpus:
         min_trie_share=0.0,
         match_specificity_weight=0.7,
         match_confidence_weight=0.3,
-        max_per_sam_share=1.0,
     ) -> None:
         cls = get_ngram_corpus_cls()
         self._obj = cls(
@@ -42,7 +41,6 @@ class NgramCorpus:
             min_trie_share=min_trie_share,
             match_specificity_weight=match_specificity_weight,
             match_confidence_weight=match_confidence_weight,
-            max_per_sam_share=max_per_sam_share,
         )
         self.default_mask = np.ones((1, 1), dtype=np.int64)
         self.draft_token_num = draft_token_num

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -56,6 +56,11 @@ class NGRAMWorker:
             draft_token_num=server_args.speculative_num_draft_tokens,
             external_sam_budget=server_args.speculative_ngram_external_sam_budget,
             external_corpus_max_tokens=server_args.speculative_ngram_external_corpus_max_tokens,
+            trie_source_prior=server_args.speculative_ngram_trie_source_prior,
+            min_trie_share=server_args.speculative_ngram_min_trie_share,
+            match_specificity_weight=server_args.speculative_ngram_match_specificity_weight,
+            match_confidence_weight=server_args.speculative_ngram_match_confidence_weight,
+            max_per_sam_share=server_args.speculative_ngram_max_per_sam_share,
         )
         if server_args.speculative_ngram_external_corpus_path is not None:
             from sglang.srt.speculative.cpp_ngram.external_corpus import (

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -54,10 +54,8 @@ class NGRAMWorker:
             capacity=server_args.speculative_ngram_capacity,
             max_trie_depth=server_args.speculative_ngram_max_trie_depth,
             draft_token_num=server_args.speculative_num_draft_tokens,
-            external_sam_budget=server_args.speculative_ngram_external_sam_budget,
             external_corpus_max_tokens=server_args.speculative_ngram_external_corpus_max_tokens,
             trie_source_prior=server_args.speculative_ngram_trie_source_prior,
-            min_trie_share=server_args.speculative_ngram_min_trie_share,
             match_specificity_weight=server_args.speculative_ngram_match_specificity_weight,
             match_confidence_weight=server_args.speculative_ngram_match_confidence_weight,
         )

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -60,7 +60,6 @@ class NGRAMWorker:
             min_trie_share=server_args.speculative_ngram_min_trie_share,
             match_specificity_weight=server_args.speculative_ngram_match_specificity_weight,
             match_confidence_weight=server_args.speculative_ngram_match_confidence_weight,
-            max_per_sam_share=server_args.speculative_ngram_max_per_sam_share,
         )
         if server_args.speculative_ngram_external_corpus_path is not None:
             from sglang.srt.speculative.cpp_ngram.external_corpus import (

--- a/test/registered/spec/test_ngram_speculative_decoding.py
+++ b/test/registered/spec/test_ngram_speculative_decoding.py
@@ -71,23 +71,51 @@ class TestNgramSpeculativeDecodingTriton(TestNgramSpeculativeDecodingBase):
 
 
 class TestNgramSpeculativeDecodingFlashinfer(TestNgramSpeculativeDecodingBase):
+    TARGET_COUNTRIES = [
+        "France",
+        "Japan",
+        "Brazil",
+        "Egypt",
+        "Canada",
+    ]
+    DISTRACTOR_COUNTRY_FAMILIES = [
+        ["Spain", "South Korea", "Argentina", "Morocco", "Mexico"],
+        ["Italy", "Thailand", "Chile", "Algeria", "Australia"],
+        ["Germany", "Vietnam", "Peru", "Tunisia", "India"],
+        ["Portugal", "Indonesia", "Colombia", "Kenya", "Norway"],
+    ]
+    MAX_NEW_TOKENS = 96
+    NUM_ROUNDS = 2
+
     @classmethod
     def get_server_args(cls):
         return DEFAULT_SERVER_ARGS + ["--attention-backend", "flashinfer"]
 
-    def test_output_as_corpus_boosts_accept_length(self):
-        """Baseline → HTTP add corpus → verify accept length boost."""
-        prompts = [
-            "The capital of France is",
-            "In mathematics, the Pythagorean theorem states that",
-            "The speed of light in a vacuum is approximately",
-            "Water boils at a temperature of",
-            "The largest planet in our solar system is",
-        ]
-        max_new_tokens = 128
-        num_rounds = 3
+    @classmethod
+    def _make_country_card_prompts(cls, countries):
+        prompts = []
+        for country in countries:
+            prompts.append(
+                "Write a country reference card.\n"
+                "Return exactly 8 lines with these keys in this order and no extra text:\n"
+                "country:\n"
+                "continent:\n"
+                "capital:\n"
+                "currency:\n"
+                "language:\n"
+                "landmark:\n"
+                "famous_for:\n"
+                "summary:\n"
+                f"Country: {country}"
+            )
+        return prompts
 
-        def generate_batch():
+    def _generate_batch(self, prompts, max_new_tokens=None, rounds=1):
+        if max_new_tokens is None:
+            max_new_tokens = self.MAX_NEW_TOKENS
+
+        outputs = []
+        for _ in range(rounds):
             outputs = []
             for prompt in prompts:
                 resp = requests.post(
@@ -103,43 +131,146 @@ class TestNgramSpeculativeDecodingFlashinfer(TestNgramSpeculativeDecodingBase):
                 )
                 self.assertEqual(resp.status_code, 200, resp.text)
                 outputs.append(resp.json()["text"])
-            return outputs
+        return outputs
 
-        def get_accept_length():
-            info = requests.get(self.base_url + "/server_info").json()
-            return info["internal_states"][0]["avg_spec_accept_length"]
+    def _get_accept_length(self):
+        resp = requests.get(self.base_url + "/server_info", timeout=30)
+        self.assertEqual(resp.status_code, 200, resp.text)
+        info = resp.json()
+        if "decode" in info:
+            info = info["decode"][0]
 
-        # Phase 1: baseline — no SAM corpus loaded, only trie
-        generated_outputs = []
-        for _ in range(num_rounds):
-            generated_outputs = generate_batch()
-        baseline_accept_len = get_accept_length()
-        print(f"\n  Baseline accept length (no SAM): {baseline_accept_len:.2f}")
+        accept_lengths = []
+        for state in info.get("internal_states", []):
+            accept_length = state.get("avg_spec_accept_length")
+            if accept_length is None:
+                accept_length = state.get("spec_accept_length")
+            if accept_length is not None:
+                accept_lengths.append(accept_length)
 
-        # Flush cache so phase 2 starts clean
-        requests.post(self.base_url + "/flush_cache", timeout=30)
+        self.assertTrue(accept_lengths, f"No speculative accept length found in {info}")
+        return sum(accept_lengths) / len(accept_lengths)
 
-        # Phase 2: add generated outputs as corpus via HTTP API
+    def _flush_cache(self):
+        resp = requests.post(self.base_url + "/flush_cache", timeout=30)
+        self.assertEqual(resp.status_code, 200, resp.text)
+
+    def _reset_spec_stats(self):
+        # avg_spec_accept_length is cumulative, so reset it between benchmark phases.
+        resp = requests.post(
+            self.base_url + "/set_internal_state",
+            json={"server_args": {}},
+            timeout=30,
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        payload = resp.json()
+        self.assertTrue(all(payload), payload)
+
+    def _add_corpus(self, corpus_id, documents):
         resp = requests.post(
             self.base_url + "/add_external_corpus",
-            json={"corpus_id": "bench", "documents": generated_outputs},
+            json={"corpus_id": corpus_id, "documents": documents},
             timeout=120,
         )
         self.assertEqual(resp.status_code, 200, resp.text)
-        self.assertTrue(resp.json()["success"], resp.json().get("message"))
+        payload = resp.json()
+        self.assertTrue(payload["success"], payload.get("message"))
+        return payload
 
-        for _ in range(num_rounds):
-            generate_batch()
-        sam_accept_len = get_accept_length()
-        print(f"  SAM accept length (output as corpus): {sam_accept_len:.2f}")
-        print(f"  Speedup: {sam_accept_len / baseline_accept_len:.2f}x")
+    def _clear_external_corpora(self):
+        resp = requests.get(self.base_url + "/list_external_corpora", timeout=30)
+        self.assertEqual(resp.status_code, 200, resp.text)
+        payload = resp.json()
+        self.assertTrue(payload["success"], payload.get("message"))
+        for corpus_id in payload["corpus_ids"]:
+            remove_resp = requests.post(
+                self.base_url + "/remove_external_corpus",
+                json={"corpus_id": corpus_id},
+                timeout=30,
+            )
+            self.assertEqual(remove_resp.status_code, 200, remove_resp.text)
+            remove_payload = remove_resp.json()
+            self.assertTrue(remove_payload["success"], remove_payload.get("message"))
 
-        self.assertGreater(
-            sam_accept_len,
-            baseline_accept_len * 2.0,
-            f"SAM accept length ({sam_accept_len:.2f}) should be at least 2x "
-            f"baseline ({baseline_accept_len:.2f}) when corpus matches output",
-        )
+    def _measure_accept_length(self, prompts, rounds=None):
+        if rounds is None:
+            rounds = self.NUM_ROUNDS
+        self._flush_cache()
+        self._reset_spec_stats()
+        outputs = self._generate_batch(prompts, rounds=rounds)
+        return outputs, self._get_accept_length()
+
+    def test_weighted_sam_retains_accept_length_with_distractors(self):
+        """Benchmark weighted SAM allocation against the no-SAM and multi-SAM baselines."""
+        target_prompts = self._make_country_card_prompts(self.TARGET_COUNTRIES)
+        distractor_prompt_families = [
+            self._make_country_card_prompts(countries)
+            for countries in self.DISTRACTOR_COUNTRY_FAMILIES
+        ]
+
+        accept_length_by_num_distractors = {}
+        sam_only_accept_len = None
+
+        try:
+            self._clear_external_corpora()
+
+            sam_docs, baseline_accept_len = self._measure_accept_length(target_prompts)
+            print(f"\n  trieOnly accept length: {baseline_accept_len:.2f}")
+
+            distractor_corpora = [
+                self._generate_batch(prompts, rounds=1)
+                for prompts in distractor_prompt_families
+            ]
+
+            for num_distractors in (0, 2, 4):
+                with self.subTest(num_distractors=num_distractors):
+                    self._clear_external_corpora()
+                    self._add_corpus("sam", sam_docs)
+                    for idx in range(num_distractors):
+                        self._add_corpus(
+                            f"distractor-{idx}",
+                            distractor_corpora[idx],
+                        )
+
+                    _, accept_length = self._measure_accept_length(target_prompts)
+                    accept_length_by_num_distractors[num_distractors] = accept_length
+
+                    if num_distractors == 0:
+                        sam_only_accept_len = accept_length
+                        print(
+                            "  samOnly accept length: "
+                            f"{accept_length:.2f} ({accept_length / baseline_accept_len:.2f}x vs trieOnly)"
+                        )
+                        self.assertGreater(
+                            accept_length,
+                            baseline_accept_len * 2.0,
+                            f"samOnly accept length ({accept_length:.2f}) should be at least 2x "
+                            f"trieOnly ({baseline_accept_len:.2f})",
+                        )
+                    else:
+                        print(
+                            f"  samPlusDistractors[{num_distractors}] accept length: "
+                            f"{accept_length:.2f} "
+                            f"({accept_length / sam_only_accept_len:.2f}x vs samOnly)"
+                        )
+                        self.assertGreaterEqual(
+                            accept_length,
+                            sam_only_accept_len * 0.85,
+                            f"accept length with {num_distractors} distractors ({accept_length:.2f}) "
+                            f"should retain at least 85% of samOnly ({sam_only_accept_len:.2f})",
+                        )
+                        self.assertGreater(
+                            accept_length,
+                            baseline_accept_len * 1.5,
+                            f"accept length with {num_distractors} distractors ({accept_length:.2f}) "
+                            f"should still exceed trieOnly ({baseline_accept_len:.2f}) by 1.5x",
+                        )
+        finally:
+            self._clear_external_corpora()
+            self._flush_cache()
+            self._reset_spec_stats()
+
+        print(f"  acceptLengthByNumDistractors={accept_length_by_num_distractors}")
 
 
 class TestNgramSpeculativeDecodingPaged(TestNgramSpeculativeDecodingBase):

--- a/test/registered/spec/test_ngram_speculative_decoding.py
+++ b/test/registered/spec/test_ngram_speculative_decoding.py
@@ -201,7 +201,7 @@ class TestNgramSpeculativeDecodingFlashinfer(TestNgramSpeculativeDecodingBase):
         return outputs, self._get_accept_length()
 
     def test_weighted_sam_retains_accept_length_with_distractors(self):
-        """Benchmark weighted SAM allocation against the no-SAM and multi-SAM baselines."""
+        """Benchmark ranked trie/SAM matching against the no-SAM and multi-SAM baselines."""
         target_prompts = self._make_country_card_prompts(self.TARGET_COUNTRIES)
         distractor_prompt_families = [
             self._make_country_card_prompts(countries)

--- a/test/registered/spec/test_ngram_speculative_decoding.py
+++ b/test/registered/spec/test_ngram_speculative_decoding.py
@@ -73,12 +73,7 @@ class TestNgramSpeculativeDecodingTriton(TestNgramSpeculativeDecodingBase):
 class TestNgramSpeculativeDecodingFlashinfer(TestNgramSpeculativeDecodingBase):
     @classmethod
     def get_server_args(cls):
-        return DEFAULT_SERVER_ARGS + [
-            "--attention-backend",
-            "flashinfer",
-            "--speculative-ngram-external-sam-budget",
-            "8",
-        ]
+        return DEFAULT_SERVER_ARGS + ["--attention-backend", "flashinfer"]
 
     def test_output_as_corpus_boosts_accept_length(self):
         """Baseline → HTTP add corpus → verify accept length boost."""

--- a/test/registered/spec/test_ngram_speculative_decoding.py
+++ b/test/registered/spec/test_ngram_speculative_decoding.py
@@ -182,7 +182,7 @@ class TestNgramSpeculativeDecodingFlashinfer(TestNgramSpeculativeDecodingBase):
         self.assertEqual(resp.status_code, 200, resp.text)
         payload = resp.json()
         self.assertTrue(payload["success"], payload.get("message"))
-        for corpus_id in payload["corpus_ids"]:
+        for corpus_id in payload["corpus_token_counts"]:
             remove_resp = requests.post(
                 self.base_url + "/remove_external_corpus",
                 json={"corpus_id": corpus_id},

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1,3 +1,4 @@
+import os
 import json
 import tempfile
 import unittest
@@ -440,6 +441,16 @@ class TestNgramExternalSamArgs(CustomTestCase):
                 "4",
                 "--speculative-ngram-external-corpus-max-tokens",
                 "128",
+                "--speculative-ngram-trie-source-prior",
+                "1.5",
+                "--speculative-ngram-min-trie-share",
+                "0.2",
+                "--speculative-ngram-match-specificity-weight",
+                "0.6",
+                "--speculative-ngram-match-confidence-weight",
+                "0.4",
+                "--speculative-ngram-max-per-sam-share",
+                "0.8",
             ]
         )
         self.assertEqual(
@@ -448,6 +459,11 @@ class TestNgramExternalSamArgs(CustomTestCase):
         )
         self.assertEqual(server_args.speculative_ngram_external_sam_budget, 4)
         self.assertEqual(server_args.speculative_ngram_external_corpus_max_tokens, 128)
+        self.assertEqual(server_args.speculative_ngram_trie_source_prior, 1.5)
+        self.assertEqual(server_args.speculative_ngram_min_trie_share, 0.2)
+        self.assertEqual(server_args.speculative_ngram_match_specificity_weight, 0.6)
+        self.assertEqual(server_args.speculative_ngram_match_confidence_weight, 0.4)
+        self.assertEqual(server_args.speculative_ngram_max_per_sam_share, 0.8)
 
     def _make_dummy_ngram_args(self, **overrides):
         args = ServerArgs(model_path="dummy")
@@ -468,13 +484,43 @@ class TestNgramExternalSamArgs(CustomTestCase):
         self.assertIn("speculative_num_draft_tokens - 1", str(context.exception))
 
     def test_external_corpus_max_tokens_must_be_positive(self):
+        with patch.dict(os.environ, {"FLASHINFER_DISABLE_VERSION_CHECK": "1"}):
+            with self.assertRaises(ValueError) as context:
+                self._make_dummy_ngram_args(
+                    speculative_ngram_external_corpus_path="/tmp/ngram-corpus.jsonl",
+                    speculative_ngram_external_sam_budget=2,
+                    speculative_ngram_external_corpus_max_tokens=0,
+                )._handle_speculative_decoding()
+        self.assertIn("external-corpus-max-tokens", str(context.exception))
+
+    def test_min_trie_share_must_be_between_zero_and_one(self):
         with self.assertRaises(ValueError) as context:
             self._make_dummy_ngram_args(
-                speculative_ngram_external_corpus_path="/tmp/ngram-corpus.jsonl",
-                speculative_ngram_external_sam_budget=2,
-                speculative_ngram_external_corpus_max_tokens=0,
+                speculative_ngram_min_trie_share=1.1,
             )._handle_speculative_decoding()
-        self.assertIn("external-corpus-max-tokens", str(context.exception))
+        self.assertIn("min-trie-share", str(context.exception))
+
+    def test_match_weights_must_sum_positive(self):
+        with self.assertRaises(ValueError) as context:
+            self._make_dummy_ngram_args(
+                speculative_ngram_match_specificity_weight=0.0,
+                speculative_ngram_match_confidence_weight=0.0,
+            )._handle_speculative_decoding()
+        self.assertIn("match weights", str(context.exception))
+
+    def test_trie_source_prior_must_be_non_negative(self):
+        with self.assertRaises(ValueError) as context:
+            self._make_dummy_ngram_args(
+                speculative_ngram_trie_source_prior=-0.1,
+            )._handle_speculative_decoding()
+        self.assertIn("trie-source-prior", str(context.exception))
+
+    def test_max_per_sam_share_must_be_in_range(self):
+        with self.assertRaises(ValueError) as context:
+            self._make_dummy_ngram_args(
+                speculative_ngram_max_per_sam_share=1.1,
+            )._handle_speculative_decoding()
+        self.assertIn("max-per-sam-share", str(context.exception))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1,5 +1,5 @@
-import os
 import json
+import os
 import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
@@ -449,8 +449,6 @@ class TestNgramExternalSamArgs(CustomTestCase):
                 "0.6",
                 "--speculative-ngram-match-confidence-weight",
                 "0.4",
-                "--speculative-ngram-max-per-sam-share",
-                "0.8",
             ]
         )
         self.assertEqual(
@@ -463,7 +461,6 @@ class TestNgramExternalSamArgs(CustomTestCase):
         self.assertEqual(server_args.speculative_ngram_min_trie_share, 0.2)
         self.assertEqual(server_args.speculative_ngram_match_specificity_weight, 0.6)
         self.assertEqual(server_args.speculative_ngram_match_confidence_weight, 0.4)
-        self.assertEqual(server_args.speculative_ngram_max_per_sam_share, 0.8)
 
     def _make_dummy_ngram_args(self, **overrides):
         args = ServerArgs(model_path="dummy")
@@ -514,13 +511,6 @@ class TestNgramExternalSamArgs(CustomTestCase):
                 speculative_ngram_trie_source_prior=-0.1,
             )._handle_speculative_decoding()
         self.assertIn("trie-source-prior", str(context.exception))
-
-    def test_max_per_sam_share_must_be_in_range(self):
-        with self.assertRaises(ValueError) as context:
-            self._make_dummy_ngram_args(
-                speculative_ngram_max_per_sam_share=1.1,
-            )._handle_speculative_decoding()
-        self.assertIn("max-per-sam-share", str(context.exception))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -428,7 +428,7 @@ class TestHiCacheArgs(unittest.TestCase):
 
 
 class TestNgramExternalSamArgs(CustomTestCase):
-    def test_prepare_server_args_parses_external_sam_args(self):
+    def test_prepare_server_args_parses_external_corpus_args(self):
         server_args = prepare_server_args(
             [
                 "--model-path",
@@ -437,14 +437,10 @@ class TestNgramExternalSamArgs(CustomTestCase):
                 "NGRAM",
                 "--speculative-ngram-external-corpus-path",
                 "/tmp/ngram-corpus.jsonl",
-                "--speculative-ngram-external-sam-budget",
-                "4",
                 "--speculative-ngram-external-corpus-max-tokens",
                 "128",
                 "--speculative-ngram-trie-source-prior",
                 "1.5",
-                "--speculative-ngram-min-trie-share",
-                "0.2",
                 "--speculative-ngram-match-specificity-weight",
                 "0.6",
                 "--speculative-ngram-match-confidence-weight",
@@ -455,10 +451,8 @@ class TestNgramExternalSamArgs(CustomTestCase):
             server_args.speculative_ngram_external_corpus_path,
             "/tmp/ngram-corpus.jsonl",
         )
-        self.assertEqual(server_args.speculative_ngram_external_sam_budget, 4)
         self.assertEqual(server_args.speculative_ngram_external_corpus_max_tokens, 128)
         self.assertEqual(server_args.speculative_ngram_trie_source_prior, 1.5)
-        self.assertEqual(server_args.speculative_ngram_min_trie_share, 0.2)
         self.assertEqual(server_args.speculative_ngram_match_specificity_weight, 0.6)
         self.assertEqual(server_args.speculative_ngram_match_confidence_weight, 0.4)
 
@@ -467,35 +461,24 @@ class TestNgramExternalSamArgs(CustomTestCase):
         args.speculative_algorithm = "NGRAM"
         args.speculative_num_draft_tokens = 12
         args.device = "cuda"
+        args.page_size = 1
         for key, value in overrides.items():
             setattr(args, key, value)
         return args
 
-    def test_external_sam_budget_must_fit_draft_budget(self):
-        with self.assertRaises(ValueError) as context:
-            self._make_dummy_ngram_args(
-                speculative_num_draft_tokens=4,
-                speculative_ngram_external_corpus_path="/tmp/ngram-corpus.jsonl",
-                speculative_ngram_external_sam_budget=4,
-            )._handle_speculative_decoding()
-        self.assertIn("speculative_num_draft_tokens - 1", str(context.exception))
+    def test_external_corpus_path_does_not_require_budget_flag(self):
+        self._make_dummy_ngram_args(
+            speculative_ngram_external_corpus_path="/tmp/ngram-corpus.jsonl",
+            speculative_ngram_external_corpus_max_tokens=128,
+        )._handle_speculative_decoding()
 
     def test_external_corpus_max_tokens_must_be_positive(self):
-        with patch.dict(os.environ, {"FLASHINFER_DISABLE_VERSION_CHECK": "1"}):
-            with self.assertRaises(ValueError) as context:
-                self._make_dummy_ngram_args(
-                    speculative_ngram_external_corpus_path="/tmp/ngram-corpus.jsonl",
-                    speculative_ngram_external_sam_budget=2,
-                    speculative_ngram_external_corpus_max_tokens=0,
-                )._handle_speculative_decoding()
-        self.assertIn("external-corpus-max-tokens", str(context.exception))
-
-    def test_min_trie_share_must_be_between_zero_and_one(self):
         with self.assertRaises(ValueError) as context:
             self._make_dummy_ngram_args(
-                speculative_ngram_min_trie_share=1.1,
+                speculative_ngram_external_corpus_path="/tmp/ngram-corpus.jsonl",
+                speculative_ngram_external_corpus_max_tokens=0,
             )._handle_speculative_decoding()
-        self.assertIn("min-trie-share", str(context.exception))
+        self.assertIn("external-corpus-max-tokens", str(context.exception))
 
     def test_match_weights_must_sum_positive(self):
         with self.assertRaises(ValueError) as context:

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1,5 +1,4 @@
 import json
-import os
 import tempfile
 import unittest
 from unittest.mock import MagicMock, patch

--- a/test/registered/unit/spec/test_ngram_corpus.py
+++ b/test/registered/unit/spec/test_ngram_corpus.py
@@ -24,7 +24,6 @@ def _make_corpus(match_type="BFS", **kwargs):
         max_bfs_breadth=8,
         draft_token_num=8,
         capacity=100000,
-        external_sam_budget=0,
         external_corpus_max_tokens=10000000,
     )
     defaults.update(kwargs)
@@ -704,13 +703,12 @@ class TestNgramCorpusIncremental(CustomTestCase):
 
 
 class TestNgramCorpusExternalSam(CustomTestCase):
-    """Verify external SAM loading and fixed-budget composition."""
+    """Verify external SAM loading and score-ordered composition."""
 
     def test_external_corpus_iterator_streams_documents(self):
         corpus = _make_corpus(
             "BFS",
             draft_token_num=4,
-            external_sam_budget=3,
             external_corpus_max_tokens=8,
         )
         with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
@@ -737,7 +735,6 @@ class TestNgramCorpusExternalSam(CustomTestCase):
     def test_external_corpus_iterator_rejects_oversized_corpus(self):
         corpus = _make_corpus(
             "BFS",
-            external_sam_budget=2,
             external_corpus_max_tokens=4,
         )
         with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
@@ -758,7 +755,6 @@ class TestNgramCorpusExternalSam(CustomTestCase):
         corpus = _make_corpus(
             "BFS",
             draft_token_num=4,
-            external_sam_budget=3,
             external_corpus_documents=[[1, 2, 3, 4, 5]],
         )
 
@@ -771,7 +767,6 @@ class TestNgramCorpusExternalSam(CustomTestCase):
         corpus = _make_corpus(
             "BFS",
             draft_token_num=4,
-            external_sam_budget=3,
             external_corpus_documents=[[1, 2, 3], [4, 5, 6]],
         )
 
@@ -784,7 +779,6 @@ class TestNgramCorpusExternalSam(CustomTestCase):
         corpus = _make_corpus(
             "BFS",
             draft_token_num=6,
-            external_sam_budget=2,
             external_corpus_documents=[[1, 2, 3, 20, 21]],
         )
         corpus.batch_put([[1, 2, 3, 10, 11]])
@@ -801,7 +795,6 @@ class TestNgramCorpusExternalSam(CustomTestCase):
         corpus = _make_corpus(
             "BFS",
             draft_token_num=5,
-            external_sam_budget=2,
             external_corpus_documents=[[1, 2, 3, 10, 99]],
         )
         corpus.batch_put([[1, 2, 3, 10, 11]])
@@ -814,11 +807,10 @@ class TestNgramCorpusExternalSam(CustomTestCase):
         self.assertIn([3, 10, 11], leaf_paths)
         self.assertIn([3, 10, 99], leaf_paths)
 
-    def test_shared_prefix_merge_can_underfill_budget(self):
+    def test_shared_prefix_merge_can_leave_padding(self):
         corpus = _make_corpus(
             "BFS",
             draft_token_num=6,
-            external_sam_budget=2,
             external_corpus_documents=[[1, 2, 3, 10, 99]],
         )
         corpus.batch_put([[1, 2, 3, 10, 11]])
@@ -837,7 +829,6 @@ class TestNgramCorpusExternalSam(CustomTestCase):
             draft_token_num=2,
             min_bfs_breadth=1,
             max_bfs_breadth=1,
-            external_sam_budget=1,
             external_corpus_documents=[
                 [1, 2, 3, 10],
                 [1, 2, 3, 20],
@@ -854,7 +845,6 @@ class TestNgramCorpusExternalSam(CustomTestCase):
         weighted = _make_corpus(
             "BFS",
             trie_source_prior=3.0,
-            min_trie_share=1.0,
             match_specificity_weight=0.2,
             match_confidence_weight=0.8,
         )
@@ -867,6 +857,27 @@ class TestNgramCorpusExternalSam(CustomTestCase):
 
         np.testing.assert_array_equal(baseline_ids, weighted_ids)
         np.testing.assert_array_equal(baseline_masks, weighted_masks)
+
+    def test_unmatched_sam_batch_keeps_fixed_request_layout(self):
+        corpus = _make_corpus(
+            "BFS",
+            draft_token_num=6,
+            external_corpus_documents=[[100, 200, 300, 400]],
+        )
+        corpus.batch_put([[10, 20, 30, 40, 50]])
+        corpus.synchronize()
+
+        batch_queries = [[1, 2, 3], [10, 20, 30]]
+        batch_ids, batch_masks = _batch_get(corpus, batch_queries)
+        batch_ids = batch_ids.reshape(-1, 6)
+        batch_masks = batch_masks.reshape(-1, 6, 6)
+
+        expected = [_batch_get(corpus, [query]) for query in batch_queries]
+        expected_ids = np.stack([ids.reshape(6) for ids, _ in expected])
+        expected_masks = np.stack([masks.reshape(6, 6) for _, masks in expected])
+
+        np.testing.assert_array_equal(batch_ids, expected_ids)
+        np.testing.assert_array_equal(batch_masks, expected_masks)
 
 
 class TestNgramCorpusMatchBenchmark(CustomTestCase):
@@ -934,10 +945,10 @@ class TestNgramCorpusMatchBenchmark(CustomTestCase):
 
 
 class TestNgramCorpusMultiSam(CustomTestCase):
-    """Verify multi-SAM add/remove/list and budget splitting."""
+    """Verify multi-SAM add/remove/list and score-ordered merging."""
 
     def test_add_and_list(self):
-        corpus = _make_corpus("BFS", draft_token_num=4, external_sam_budget=3)
+        corpus = _make_corpus("BFS", draft_token_num=4)
         loaded_token_count = corpus.load_external_corpus_named("a", [[1, 2, 3, 4, 5]])
         corpus.commit_external_corpus_load("a", loaded_token_count)
         loaded_token_count = corpus.load_external_corpus_named(
@@ -950,7 +961,7 @@ class TestNgramCorpusMultiSam(CustomTestCase):
         self.assertEqual(token_counts["b"], 5)
 
     def test_remove(self):
-        corpus = _make_corpus("BFS", draft_token_num=4, external_sam_budget=3)
+        corpus = _make_corpus("BFS", draft_token_num=4)
         loaded_token_count = corpus.load_external_corpus_named("a", [[1, 2, 3, 4, 5]])
         corpus.commit_external_corpus_load("a", loaded_token_count)
         loaded_token_count = corpus.load_external_corpus_named(
@@ -961,12 +972,12 @@ class TestNgramCorpusMultiSam(CustomTestCase):
         self.assertEqual(list(corpus.list_external_corpora().keys()), ["b"])
 
     def test_remove_nonexistent_is_noop(self):
-        corpus = _make_corpus("BFS", draft_token_num=4, external_sam_budget=3)
+        corpus = _make_corpus("BFS", draft_token_num=4)
         corpus.remove_external_corpus("nonexistent")
         self.assertEqual(corpus.list_external_corpora(), {})
 
     def test_multi_sam_candidates(self):
-        corpus = _make_corpus("BFS", draft_token_num=6, external_sam_budget=4)
+        corpus = _make_corpus("BFS", draft_token_num=6)
         loaded_token_count = corpus.load_external_corpus_named("a", [[1, 2, 3, 10, 11]])
         corpus.commit_external_corpus_load("a", loaded_token_count)
         loaded_token_count = corpus.load_external_corpus_named("b", [[1, 2, 3, 20, 21]])
@@ -980,13 +991,11 @@ class TestNgramCorpusMultiSam(CustomTestCase):
         self.assertIn([3, 10, 11], leaf_paths)
         self.assertIn([3, 20, 21], leaf_paths)
 
-    def test_weighted_budget_favors_more_specific_sam(self):
+    def test_source_score_favors_more_specific_sam(self):
         corpus = _make_corpus(
             "BFS",
             max_trie_depth=4,
             draft_token_num=5,
-            external_sam_budget=4,
-            min_trie_share=0.0,
             match_specificity_weight=1.0,
             match_confidence_weight=0.0,
         )
@@ -1007,13 +1016,11 @@ class TestNgramCorpusMultiSam(CustomTestCase):
         self.assertIn([4, 60], leaf_paths)
         self.assertNotIn([4, 60, 61], leaf_paths)
 
-    def test_weighted_budget_uses_full_sam_budget_without_cap(self):
+    def test_single_sam_can_fill_full_tree(self):
         corpus = _make_corpus(
             "BFS",
             max_trie_depth=4,
             draft_token_num=5,
-            external_sam_budget=4,
-            min_trie_share=0.0,
             match_specificity_weight=1.0,
             match_confidence_weight=0.0,
         )
@@ -1028,13 +1035,10 @@ class TestNgramCorpusMultiSam(CustomTestCase):
         )
         self.assertIn([4, 50, 51, 52], leaf_paths)
 
-    def test_weighted_budget_preserves_trie_floor(self):
+    def test_trie_and_sam_coexist_when_tree_has_capacity(self):
         corpus = _make_corpus(
             "BFS",
             draft_token_num=6,
-            external_sam_budget=5,
-            trie_source_prior=0.0,
-            min_trie_share=0.4,
             match_specificity_weight=1.0,
             match_confidence_weight=0.0,
             external_corpus_documents=[[1, 2, 3, 20, 21, 22, 23, 24]],
@@ -1046,11 +1050,11 @@ class TestNgramCorpusMultiSam(CustomTestCase):
         leaf_paths = corpus.leaf_paths_from_mask(
             ids.tolist(), masks.reshape(6, 6).tolist()
         )
-        self.assertIn([3, 10, 11], leaf_paths)
-        self.assertIn([3, 20, 21, 22], leaf_paths)
+        self.assertTrue(any(path[:3] == [3, 10, 11] for path in leaf_paths), leaf_paths)
+        self.assertTrue(any(path[:3] == [3, 20, 21] for path in leaf_paths), leaf_paths)
 
     def test_remove_reduces_candidates(self):
-        corpus = _make_corpus("BFS", draft_token_num=6, external_sam_budget=4)
+        corpus = _make_corpus("BFS", draft_token_num=6)
         loaded_token_count = corpus.load_external_corpus_named("a", [[1, 2, 3, 10, 11]])
         corpus.commit_external_corpus_load("a", loaded_token_count)
         loaded_token_count = corpus.load_external_corpus_named("b", [[1, 2, 3, 20, 21]])
@@ -1070,7 +1074,6 @@ class TestNgramCorpusMultiSam(CustomTestCase):
         corpus = _make_corpus(
             "BFS",
             draft_token_num=4,
-            external_sam_budget=3,
             external_corpus_documents=[[1, 2, 3, 4, 5]],
         )
         token_counts = corpus.list_external_corpora()
@@ -1081,7 +1084,6 @@ class TestNgramCorpusMultiSam(CustomTestCase):
         corpus = _make_corpus(
             "BFS",
             draft_token_num=4,
-            external_sam_budget=3,
             external_corpus_max_tokens=10,
         )
         loaded_token_count = corpus.load_external_corpus_named("a", [[1, 2, 3, 4, 5]])
@@ -1105,7 +1107,6 @@ class TestNgramCorpusMultiSam(CustomTestCase):
         corpus = _make_corpus(
             "BFS",
             draft_token_num=4,
-            external_sam_budget=3,
             external_corpus_max_tokens=10,
         )
         loaded_token_count = corpus.load_external_corpus_named("a", [[1, 2, 3, 4, 5]])
@@ -1131,7 +1132,6 @@ class TestNgramCorpusMultiSam(CustomTestCase):
         corpus = _make_corpus(
             "BFS",
             draft_token_num=4,
-            external_sam_budget=3,
             external_corpus_max_tokens=10,
         )
         loaded_token_count = corpus.load_external_corpus_named("a", [[1, 2, 3, 4, 5]])

--- a/test/registered/unit/spec/test_ngram_corpus.py
+++ b/test/registered/unit/spec/test_ngram_corpus.py
@@ -849,6 +849,26 @@ class TestNgramCorpusExternalSam(CustomTestCase):
         ids, _ = _batch_get(corpus, [[1, 2, 3]])
         self.assertEqual(ids.tolist(), [3, 20])
 
+    def test_no_sam_behavior_ignores_weight_knobs(self):
+        baseline = _make_corpus("BFS")
+        weighted = _make_corpus(
+            "BFS",
+            trie_source_prior=3.0,
+            min_trie_share=1.0,
+            match_specificity_weight=0.2,
+            match_confidence_weight=0.8,
+            max_per_sam_share=0.4,
+        )
+        for corpus in (baseline, weighted):
+            corpus.batch_put(SEED_SEQUENCES)
+            corpus.synchronize()
+
+        baseline_ids, baseline_masks = _batch_get(baseline, QUERY_SEQUENCES)
+        weighted_ids, weighted_masks = _batch_get(weighted, QUERY_SEQUENCES)
+
+        np.testing.assert_array_equal(baseline_ids, weighted_ids)
+        np.testing.assert_array_equal(baseline_masks, weighted_masks)
+
 
 class TestNgramCorpusMatchBenchmark(CustomTestCase):
     """Benchmark incremental advance vs full rebuild in match()."""
@@ -960,6 +980,84 @@ class TestNgramCorpusMultiSam(CustomTestCase):
         # Both SAMs should contribute candidates
         self.assertIn([3, 10, 11], leaf_paths)
         self.assertIn([3, 20, 21], leaf_paths)
+
+    def test_weighted_budget_favors_more_specific_sam(self):
+        corpus = _make_corpus(
+            "BFS",
+            max_trie_depth=4,
+            draft_token_num=5,
+            external_sam_budget=4,
+            min_trie_share=0.0,
+            match_specificity_weight=1.0,
+            match_confidence_weight=0.0,
+            max_per_sam_share=1.0,
+        )
+        loaded_token_count = corpus.load_external_corpus_named(
+            "strong", [[1, 2, 3, 4, 50, 51, 52]]
+        )
+        corpus.commit_external_corpus_load("strong", loaded_token_count)
+        loaded_token_count = corpus.load_external_corpus_named(
+            "weak", [[3, 4, 60, 61, 62]]
+        )
+        corpus.commit_external_corpus_load("weak", loaded_token_count)
+
+        ids, masks = _batch_get(corpus, [[1, 2, 3, 4]])
+        leaf_paths = corpus.leaf_paths_from_mask(
+            ids.tolist(), masks.reshape(5, 5).tolist()
+        )
+        self.assertIn([4, 50, 51, 52], leaf_paths)
+        self.assertIn([4, 60], leaf_paths)
+        self.assertNotIn([4, 60, 61], leaf_paths)
+
+    def test_weighted_budget_respects_per_sam_cap(self):
+        corpus = _make_corpus(
+            "BFS",
+            max_trie_depth=4,
+            draft_token_num=5,
+            external_sam_budget=4,
+            min_trie_share=0.0,
+            match_specificity_weight=1.0,
+            match_confidence_weight=0.0,
+            max_per_sam_share=0.5,
+        )
+        loaded_token_count = corpus.load_external_corpus_named(
+            "strong", [[1, 2, 3, 4, 50, 51, 52]]
+        )
+        corpus.commit_external_corpus_load("strong", loaded_token_count)
+        loaded_token_count = corpus.load_external_corpus_named(
+            "weak", [[3, 4, 60, 61, 62]]
+        )
+        corpus.commit_external_corpus_load("weak", loaded_token_count)
+
+        ids, masks = _batch_get(corpus, [[1, 2, 3, 4]])
+        leaf_paths = corpus.leaf_paths_from_mask(
+            ids.tolist(), masks.reshape(5, 5).tolist()
+        )
+        self.assertIn([4, 50, 51], leaf_paths)
+        self.assertNotIn([4, 50, 51, 52], leaf_paths)
+        self.assertIn([4, 60, 61], leaf_paths)
+
+    def test_weighted_budget_preserves_trie_floor(self):
+        corpus = _make_corpus(
+            "BFS",
+            draft_token_num=6,
+            external_sam_budget=5,
+            trie_source_prior=0.0,
+            min_trie_share=0.4,
+            match_specificity_weight=1.0,
+            match_confidence_weight=0.0,
+            max_per_sam_share=1.0,
+            external_corpus_documents=[[1, 2, 3, 20, 21, 22, 23, 24]],
+        )
+        corpus.batch_put([[1, 2, 3, 10, 11, 12]])
+        corpus.synchronize()
+
+        ids, masks = _batch_get(corpus, [[1, 2, 3]])
+        leaf_paths = corpus.leaf_paths_from_mask(
+            ids.tolist(), masks.reshape(6, 6).tolist()
+        )
+        self.assertIn([3, 10, 11], leaf_paths)
+        self.assertIn([3, 20, 21, 22], leaf_paths)
 
     def test_remove_reduces_candidates(self):
         corpus = _make_corpus("BFS", draft_token_num=6, external_sam_budget=4)

--- a/test/registered/unit/spec/test_ngram_corpus.py
+++ b/test/registered/unit/spec/test_ngram_corpus.py
@@ -857,7 +857,6 @@ class TestNgramCorpusExternalSam(CustomTestCase):
             min_trie_share=1.0,
             match_specificity_weight=0.2,
             match_confidence_weight=0.8,
-            max_per_sam_share=0.4,
         )
         for corpus in (baseline, weighted):
             corpus.batch_put(SEED_SEQUENCES)
@@ -990,7 +989,6 @@ class TestNgramCorpusMultiSam(CustomTestCase):
             min_trie_share=0.0,
             match_specificity_weight=1.0,
             match_confidence_weight=0.0,
-            max_per_sam_share=1.0,
         )
         loaded_token_count = corpus.load_external_corpus_named(
             "strong", [[1, 2, 3, 4, 50, 51, 52]]
@@ -1009,7 +1007,7 @@ class TestNgramCorpusMultiSam(CustomTestCase):
         self.assertIn([4, 60], leaf_paths)
         self.assertNotIn([4, 60, 61], leaf_paths)
 
-    def test_weighted_budget_respects_per_sam_cap(self):
+    def test_weighted_budget_uses_full_sam_budget_without_cap(self):
         corpus = _make_corpus(
             "BFS",
             max_trie_depth=4,
@@ -1018,24 +1016,17 @@ class TestNgramCorpusMultiSam(CustomTestCase):
             min_trie_share=0.0,
             match_specificity_weight=1.0,
             match_confidence_weight=0.0,
-            max_per_sam_share=0.5,
         )
         loaded_token_count = corpus.load_external_corpus_named(
             "strong", [[1, 2, 3, 4, 50, 51, 52]]
         )
         corpus.commit_external_corpus_load("strong", loaded_token_count)
-        loaded_token_count = corpus.load_external_corpus_named(
-            "weak", [[3, 4, 60, 61, 62]]
-        )
-        corpus.commit_external_corpus_load("weak", loaded_token_count)
 
         ids, masks = _batch_get(corpus, [[1, 2, 3, 4]])
         leaf_paths = corpus.leaf_paths_from_mask(
             ids.tolist(), masks.reshape(5, 5).tolist()
         )
-        self.assertIn([4, 50, 51], leaf_paths)
-        self.assertNotIn([4, 50, 51, 52], leaf_paths)
-        self.assertIn([4, 60, 61], leaf_paths)
+        self.assertIn([4, 50, 51, 52], leaf_paths)
 
     def test_weighted_budget_preserves_trie_floor(self):
         corpus = _make_corpus(
@@ -1046,7 +1037,6 @@ class TestNgramCorpusMultiSam(CustomTestCase):
             min_trie_share=0.4,
             match_specificity_weight=1.0,
             match_confidence_weight=0.0,
-            max_per_sam_share=1.0,
             external_corpus_documents=[[1, 2, 3, 20, 21, 22, 23, 24]],
         )
         corpus.batch_put([[1, 2, 3, 10, 11, 12]])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Part of Ngram series https://github.com/sgl-project/sglang/issues/21052
Following https://github.com/sgl-project/sglang/pull/22538. Verify that allowing dynamic spec token allocation across Trie and SAMs bring benefit 

## Modifications

<!-- Detail the changes made in this pull request. -->
Add the benchmark 
- Added an end-to-end regression benchmark that compares three settings on the
  same prompt set: `trieOnly` (no external corpus loaded, draft tokens come only from Trie), `samOnly` (load strong matching external suffix-automaton corpus and rerun the same prompts), and `samPlusDistractors` (keep that matching SAM, then add extra irrelevant SAM corpora). The metric is `avg_spec_accept_length`, i.e. the average number of speculative tokens
  accepted per verify step.
- On the benchmark workload, `samOnly` improves accept length from `2.13` to `6.64` (`3.12x` vs. `trieOnly`).
- With 2 or 4 distractor SAM corpora, accept length stays at `5.90` / `5.92` (`~89%` of `samOnly`), showing the new trie/SAM ranking preserves the strong matching corpus instead of collapsing back toward the trie-only baseline.


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

This is the accuracy test for https://github.com/sgl-project/sglang/pull/22538

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
This is the speed test for https://github.com/sgl-project/sglang/pull/22538

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
