### PR TITLE
fix: restore CPU flash_attn test to use sgl_kernel directly

### DIFF
--- a/test/srt/cpu/test_flash_attn.py
+++ b/test/srt/cpu/test_flash_attn.py
@@ -1,11 +1,13 @@
 import unittest
 
+import sgl_kernel  # noqa: F401
 import torch
 import torch.nn.functional as F
 from utils import parametrize, precision
 
-from sglang.jit_kernel.flash_attention import flash_attn_varlen_func
 from sglang.test.test_utils import CustomTestCase
+
+flash_attn_varlen_func = torch.ops.sgl_kernel.flash_attn_varlen_func
 
 torch.manual_seed(1234)
 


### PR DESCRIPTION
## Summary
- Fix CPU CI failure (`cpu/test_flash_attn.py`) introduced by #20796
- PR #20796 changed the test to import `flash_attn_varlen_func` from `sglang.jit_kernel.flash_attention`, which routes through `flash_attention_v3.py` — that module checks `_is_fa3_supported()` requiring CUDA sm80+, so it raises `NotImplementedError` on CPU
- Restore the original import using `torch.ops.sgl_kernel.flash_attn_varlen_func` which is the CPU-native implementation

## Test plan
- [ ] `per-commit-cpu` CI suite should pass with `cpu/test_flash_attn.py` no longer failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)