### PR TITLE
[Hotfix] DeepSeek Stacked Parameter drop fused qkv

### DIFF
--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -247,7 +247,12 @@ class ReplicatedLinear(LinearBase):
         else:
             self.register_parameter("bias", None)
 
-    def weight_loader(self, param: Parameter, loaded_weight: torch.Tensor):
+    def weight_loader(
+        self, param: Parameter, loaded_weight: torch.Tensor, shard_id=None
+    ):
+        # shard_id is accepted but unused: ReplicatedLinear is not sharded,
+        # but callers like deepseek_weight_loader pass it via stacked_params_mapping.
+
         # If the weight on disk does not have a shape, give it one
         # (such scales for AutoFp8).
         if len(loaded_weight.shape) == 0:
@@ -376,7 +381,9 @@ class ColumnParallelLinear(LinearBase):
         else:
             self.register_parameter("bias", None)
 
-    def weight_loader(self, param: Parameter, loaded_weight: torch.Tensor):
+    def weight_loader(
+        self, param: Parameter, loaded_weight: torch.Tensor, shard_id=None
+    ):
         output_dim = getattr(param, "output_dim", None)
         param_data = param.data
 
@@ -1396,7 +1403,9 @@ class RowParallelLinear(LinearBase):
         else:
             self.register_parameter("bias", None)
 
-    def weight_loader(self, param: Parameter, loaded_weight: torch.Tensor):
+    def weight_loader(
+        self, param: Parameter, loaded_weight: torch.Tensor, shard_id=None
+    ):
         input_dim = getattr(param, "input_dim", None)
         use_bitsandbytes_4bit = getattr(param, "use_bitsandbytes_4bit", False)
 

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -271,7 +271,11 @@ class ReplicatedLinear(LinearBase):
                     param.dtype == loaded_weight.dtype
                 ), "init para dtype and loaded weight dtype should be the same"
 
-        assert param.size() == loaded_weight.size()
+        assert param.size() == loaded_weight.size(), (
+            f"ReplicatedLinear weight shape mismatch: "
+            f"param {param.size()} vs loaded {loaded_weight.size()}"
+            f"{f' (shard_id={shard_id})' if shard_id is not None else ''}"
+        )
         param.data.copy_(loaded_weight)
 
     def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2165,15 +2165,13 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
             ("gate_up_proj", "gate_proj", 0),
             ("gate_up_proj", "up_proj", 1),
         ]
-        # Add A-proj fusion mapping when q_lora_rank is enabled
-        # q_a_proj + kv_a_proj_with_mqa -> fused_qkv_a_proj_with_mqa
-        if self.fuse_qkv_a_proj:
-            self.stacked_params_mapping.extend(
-                [
-                    ("fused_qkv_a_proj_with_mqa", "q_a_proj", 0),
-                    ("fused_qkv_a_proj_with_mqa", "kv_a_proj_with_mqa", 1),
-                ]
-            )
+        # NOTE: Do NOT add fused_qkv_a_proj_with_mqa entries here.
+        # q_a_proj + kv_a_proj_with_mqa fusion is handled by the
+        # cached_a_proj path in do_load_weights() (deepseek_weight_loader.py),
+        # which concatenates the two weights and loads the fused result.
+        # Adding them to stacked_params_mapping would bypass that path
+        # and call ReplicatedLinear.weight_loader with a shard_id it
+        # cannot handle, causing an assertion error on shape mismatch.
         self.expert_params_mapping = FusedMoE.make_expert_params_mapping(
             ckpt_gate_proj_name="gate_proj",
             ckpt_down_proj_name="down_proj",


### PR DESCRIPTION
 **Summary**

  Removes fused_qkv_a_proj_with_mqa entries from stacked_params_mapping in DeepseekV2ForCausalLM.__init__().
Despite being a stacked parameter, it uses a different mechanism for weight loading that relies on in-process cache.  


  _Problem_

  The recently added fused_qkv_a_proj_with_mqa entries in stacked_params_mapping cause do_load_weights() to route q_a_proj and kv_a_proj_with_mqa through the stacked-params code path, which calls:

  param.weight_loader(param, loaded_weight, shard_id)

  However, fused_qkv_a_proj_with_mqa is a ReplicatedLinear, and ReplicatedLinear.weight_loader() does not accept a shard_id parameter — it expects the full fused weight. This results in a TypeError / assertion failure at load time.

  _Fix_

  Remove the fused_qkv_a_proj_with_mqa entries from stacked_params_mapping. The existing cached_a_proj path in do_load_weights() (in deepseek_weight_loader.py) already handles this fusion correctly:

  1. Caches q_a_proj and kv_a_proj_with_mqa as they arrive
  2. Once both are present, torch.cats them into the full fused weight
  3. Loads via weight_loader(param, fused_weight) — no shard_id needed

  This was the working behavior before the stacked_params_mapping entries were added.

  Test plan

  - Verified E2E transfer work 
