### PR TITLE
fix(deepseek_v2): remove fused_qkv_a_proj_with_mqa from stacked_param

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2165,15 +2165,6 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
             ("gate_up_proj", "gate_proj", 0),
             ("gate_up_proj", "up_proj", 1),
         ]
-        # Add A-proj fusion mapping when q_lora_rank is enabled
-        # q_a_proj + kv_a_proj_with_mqa -> fused_qkv_a_proj_with_mqa
-        if self.fuse_qkv_a_proj:
-            self.stacked_params_mapping.extend(
-                [
-                    ("fused_qkv_a_proj_with_mqa", "q_a_proj", 0),
-                    ("fused_qkv_a_proj_with_mqa", "kv_a_proj_with_mqa", 1),
-                ]
-            )
         self.expert_params_mapping = FusedMoE.make_expert_params_mapping(
             ckpt_gate_proj_name="gate_proj",
             ckpt_down_proj_name="down_proj",


### PR DESCRIPTION
fuse_qkv_a_proj uses a different mechanism at load time ---- It is in principle a sharded stack parameter, but it loads with a in-process cache instead; Making it incompatible with stacked_params_mapping. 

This is actually risky --- if user loads weight in very small chunks, the in-process cache may not have both shards at the same time. in reality the risk is small as they are often co-located.  This is a pre-existing issue. 

I will attempt to fix this properly upstream, ideally as part of https://github.com/sgl-project/sglang/pull/17326 





E2E tested working. 