### PR TITLE
Add hisparse staging + decode offload guards to is_fully_idle()

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3013,6 +3013,12 @@ class Scheduler(
             if self.disaggregation_mode == DisaggregationMode.DECODE:
                 idle &= len(self.disagg_decode_prealloc_queue.queue) == 0
                 idle &= len(self.disagg_decode_transfer_queue.queue) == 0
+                if self.decode_offload_manager is not None:
+                    idle &= len(self.decode_offload_manager.ongoing_offload) == 0
+
+            # HiSparse: staging requests transitioning prefill -> decode
+            if self.enable_hisparse:
+                idle &= not self.hisparse_coordinator.has_ongoing_staging()
 
             # HiCache: in-flight async ops (GPU↔Host↔L3) must drain before
             # destructive operations like attach/detach/flush_cache.


### PR DESCRIPTION
## Summary
- Add hisparse `ack_staging_queue` check to `is_fully_idle()` — staging requests have left `running_batch` but KV memory is still in transient state
- Add decode offload `ongoing_offload` check — KV pages moving between GPU and Host break pool invariant temporarily
- Both follow the existing HiCache pattern (in-flight async ops must drain before idle housekeeping)

## Motivation

`is_fully_idle()` was written before HiSparse (#20343) and decode KV offload were added. Those features put their idle guards in `self_check_during_idle` or individual event loops, but never propagated them to `is_fully_idle()`. This means other consumers of `is_fully_idle()` (flush_cache, hicache attach/detach, release_memory_occupation) could execute during transient pool states.

This PR adds the missing guards to `is_fully_idle()` under the `if not for_health_check:` branch, alongside the existing HiCache async-op checks. Health check path is unaffected.

## Test plan
- [ ] `test_scheduler_pause_generation.py` — CPU, mock path
- [ ] Existing hisparse / decode offload CI coverage