### PR TITLE
fix(entrypoints): return consistent predictions envelope for empty Vertex AI instances

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1784,7 +1784,7 @@ async def sagemaker_chat_completions(
 @app.post(os.environ.get("AIP_PREDICT_ROUTE", "/vertex_generate"))
 async def vertex_generate(vertex_req: VertexGenerateReqInput, raw_request: Request):
     if not vertex_req.instances:
-        return []
+        return ORJSONResponse({"predictions": []})
     inputs = {}
     for input_key in ("text", "input_ids", "input_embeds"):
         if vertex_req.instances[0].get(input_key):


### PR DESCRIPTION
## Summary

- `vertex_generate` returned a bare `[]` when `instances` is empty, but returns `ORJSONResponse({"predictions": ret})` for all non-empty requests
- Replace `return []` with `return ORJSONResponse({"predictions": []})` for a consistent response format

## Test plan

- [ ] `curl -X POST .../vertex_generate -d '{"instances": []}' ` → should return `{"predictions": []}` with `Content-Type: application/json`
- [ ] `curl -X POST .../vertex_generate -d '{"instances": [{"text": "hello"}]}'` → unchanged behaviour, returns `{"predictions": [...]}`

Fixes #22579

🤖 Generated with [Claude Code](https://claude.com/claude-code)