### PR TITLE
[Test] Fix flaky `test_function_call_required` by adding `strict=True`

### DIFF
--- a/test/registered/openai_server/function_call/test_openai_function_calling.py
+++ b/test/registered/openai_server/function_call/test_openai_function_calling.py
@@ -464,6 +464,11 @@ class TestOpenAIServerFunctionCalling(CustomTestCase):
         ]
 
         messages = [{"role": "user", "content": "What is the capital of France?"}]
+        # strict=True ensures constrained decoding enforces the parameter schema.
+        # Without it, tool_choice="required" only guarantees a tool call is made
+        # but arguments are best-effort (may be empty on small models).
+        for tool in tools:
+            tool["function"]["strict"] = True
         response = client.chat.completions.create(
             model=self.model,
             max_tokens=2048,


### PR DESCRIPTION
## Summary
- Add `strict=True` to `test_function_call_required` in `test_openai_function_calling.py`
- After #21593, `tool_choice="required"` + `strict=false` (default) no longer enforces parameter schema via constrained decoding — only guarantees a tool call is produced, arguments are best-effort
- Small models (Llama-3.2-1B) occasionally generate empty `{}` arguments without schema constraint, causing ~30% flakiness

Regression introduced by #21593 which correctly changed the protocol semantics but missed updating this test file (only `test_tool_choice.py` was updated with `strict=True`).

## Evidence

Ran `test_openai_function_calling.py` 10 times at each commit via `gh workflow run`:

**Before #21593** (`c2821dfbe`) — **10/10 pass**:
[1](https://github.com/sgl-project/sglang/actions/runs/24278705473) [2](https://github.com/sgl-project/sglang/actions/runs/24278706099) [3](https://github.com/sgl-project/sglang/actions/runs/24278706602) [4](https://github.com/sgl-project/sglang/actions/runs/24278707132) [5](https://github.com/sgl-project/sglang/actions/runs/24278707715) [6](https://github.com/sgl-project/sglang/actions/runs/24278708198) [7](https://github.com/sgl-project/sglang/actions/runs/24278708659) [8](https://github.com/sgl-project/sglang/actions/runs/24278709172) [9](https://github.com/sgl-project/sglang/actions/runs/24278709788) [10](https://github.com/sgl-project/sglang/actions/runs/24278710478)

**After #21593** (`7c6db4054`) — **7/10 pass (30% fail)**:
[1 fail](https://github.com/sgl-project/sglang/actions/runs/24278711052) [2](https://github.com/sgl-project/sglang/actions/runs/24278711643) [3](https://github.com/sgl-project/sglang/actions/runs/24278712249) [4 fail](https://github.com/sgl-project/sglang/actions/runs/24278712753) [5](https://github.com/sgl-project/sglang/actions/runs/24278713258) [6](https://github.com/sgl-project/sglang/actions/runs/24278713822) [7](https://github.com/sgl-project/sglang/actions/runs/24278714391) [8](https://github.com/sgl-project/sglang/actions/runs/24278714963) [9](https://github.com/sgl-project/sglang/actions/runs/24278715459) [10 fail](https://github.com/sgl-project/sglang/actions/runs/24278715995)

**This fix** (`8789744c5`) — **10/10 pass**:
[1](https://github.com/sgl-project/sglang/actions/runs/24278890838) [2](https://github.com/sgl-project/sglang/actions/runs/24278891088) [3](https://github.com/sgl-project/sglang/actions/runs/24278891380) [4](https://github.com/sgl-project/sglang/actions/runs/24278891659) [5](https://github.com/sgl-project/sglang/actions/runs/24278891991) [6](https://github.com/sgl-project/sglang/actions/runs/24278892393) [7](https://github.com/sgl-project/sglang/actions/runs/24278892637) [8](https://github.com/sgl-project/sglang/actions/runs/24278892937) [9](https://github.com/sgl-project/sglang/actions/runs/24278893338) [10](https://github.com/sgl-project/sglang/actions/runs/24278893698)

## Test plan
- [x] 10/10 pass on this PR (see above)