### PR TITLE
【bugfix】fix draft quant cfg

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -887,7 +887,7 @@ class ModelConfig:
 
     # adapted from https://github.com/vllm-project/vllm/blob/v0.6.4.post1/vllm/config.py
     def _parse_quant_hf_config(self):
-        if self.is_draft_model and self.speculative_draft_model_quantization == "unquant":
+        if self.is_draft_model and self.quantization == "unquant":
             return None
         quant_cfg = getattr(self.hf_config, "quantization_config", None)
         if quant_cfg is not None and not isinstance(quant_cfg, dict):
@@ -987,7 +987,7 @@ class ModelConfig:
         return quant_cfg
 
     def _find_quant_modelslim_config(self):
-        if self.is_draft_model and self.speculative_draft_model_quantization == "unquant":
+        if self.is_draft_model:
             return None
         quant_config_file = Path(self.model_path, "quant_model_description.json")
         quant_cfg = None
@@ -1239,7 +1239,8 @@ class ModelConfig:
                 logger.warning(
                     "DeepGemm is enabled but the scale_fmt of checkpoint is not ue8m0. This might cause accuracy degradation on Blackwell."
                 )
-
+        if self.quantization == "unquant":
+            self.quantization = None
         if self.quantization is not None:
             if self.quantization not in supported_quantization:
                 raise ValueError(

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -887,7 +887,7 @@ class ModelConfig:
 
     # adapted from https://github.com/vllm-project/vllm/blob/v0.6.4.post1/vllm/config.py
     def _parse_quant_hf_config(self):
-        if self.is_draft_model:
+        if self.is_draft_model and self.quantization is None:
             return None
         quant_cfg = getattr(self.hf_config, "quantization_config", None)
         if quant_cfg is not None and not isinstance(quant_cfg, dict):
@@ -987,7 +987,7 @@ class ModelConfig:
         return quant_cfg
 
     def _find_quant_modelslim_config(self):
-        if self.is_draft_model:
+        if self.is_draft_model and self.quantization is None:
             return None
         quant_config_file = Path(self.model_path, "quant_model_description.json")
         quant_cfg = None

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -887,6 +887,8 @@ class ModelConfig:
 
     # adapted from https://github.com/vllm-project/vllm/blob/v0.6.4.post1/vllm/config.py
     def _parse_quant_hf_config(self):
+        if self.is_draft_model:
+            return None
         quant_cfg = getattr(self.hf_config, "quantization_config", None)
         if quant_cfg is not None and not isinstance(quant_cfg, dict):
             quant_cfg = quant_cfg.to_dict()

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -887,7 +887,7 @@ class ModelConfig:
 
     # adapted from https://github.com/vllm-project/vllm/blob/v0.6.4.post1/vllm/config.py
     def _parse_quant_hf_config(self):
-        if self.is_draft_model and self.quantization is None:
+        if self.is_draft_model and self.speculative_draft_model_quantization == "unquant":
             return None
         quant_cfg = getattr(self.hf_config, "quantization_config", None)
         if quant_cfg is not None and not isinstance(quant_cfg, dict):
@@ -987,7 +987,7 @@ class ModelConfig:
         return quant_cfg
 
     def _find_quant_modelslim_config(self):
-        if self.is_draft_model and self.quantization is None:
+        if self.is_draft_model and self.speculative_draft_model_quantization == "unquant":
             return None
         quant_config_file = Path(self.model_path, "quant_model_description.json")
         quant_cfg = None

--- a/python/sglang/srt/hardware_backend/npu/quantization/fused_moe_method_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/quantization/fused_moe_method_npu.py
@@ -279,9 +279,6 @@ def npu_fused_moe_without_routing_weights_bf16(
 ):
     from sgl_kernel_npu.activation.swiglu_quant import swiglu_quant
 
-    if hidden_states.dtype != torch.bfloat16:
-        hidden_states = hidden_states.to(torch.bfloat16)
-
     # gmm1: gate_up_proj
     hidden_states = torch.ops.npu.npu_grouped_matmul(
         x=[hidden_states],

--- a/python/sglang/srt/hardware_backend/npu/quantization/fused_moe_method_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/quantization/fused_moe_method_npu.py
@@ -279,6 +279,9 @@ def npu_fused_moe_without_routing_weights_bf16(
 ):
     from sgl_kernel_npu.activation.swiglu_quant import swiglu_quant
 
+    if hidden_states.dtype != torch.bfloat16:
+        hidden_states = hidden_states.to(torch.bfloat16)
+
     # gmm1: gate_up_proj
     hidden_states = torch.ops.npu.npu_grouped_matmul(
         x=[hidden_states],
@@ -292,6 +295,7 @@ def npu_fused_moe_without_routing_weights_bf16(
     hidden_states, _ = swiglu_quant(
         hidden_states, group_list, group_list_type, need_quant=False
     )
+
     # gmm2: down_proj
     hidden_states = torch.ops.npu.npu_grouped_matmul(
         x=[hidden_states],

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -690,6 +690,9 @@ class _DeepEPDispatcherImplLowLatency(_DeepEPDispatcherImplBase):
     ):
         input_global_scale = self.quant_config.get("input_global_scale", None)
 
+        if _is_npu and envs.SGLANG_DEEPEP_BF16_DISPATCH.get():
+            use_fp8 = False
+
         # round_scale / use_ue8m0 are FP8-DeepGEMM specific; they cause DeepEP
         # to return int32-packed UE8M0 scales that don't feed the flashinfer
         # cutedsl kernel.

--- a/python/sglang/srt/models/glm4_moe.py
+++ b/python/sglang/srt/models/glm4_moe.py
@@ -299,6 +299,7 @@ class Glm4MoeAttention(nn.Module):
         if (
             not _is_npu
             or forward_batch.forward_mode.is_extend_or_draft_extend_or_mixed()
+            or not self.use_qk_norm
         ):
             q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
             if self.use_qk_norm:

--- a/python/sglang/srt/models/glm4_moe_nextn.py
+++ b/python/sglang/srt/models/glm4_moe_nextn.py
@@ -129,7 +129,7 @@ class Glm4MoeForCausalLMNextN(Glm4MoeForCausalLM):
         self.config = config
         self.tp_size = get_tensor_model_parallel_world_size()
         self.needs_quant_draft = (
-            get_global_server_args().speculative_draft_model_quantization is not None
+            get_global_server_args().speculative_draft_model_quantization != "unquant"
             or quant_config is not None
         )
         quant_config = quant_config if self.needs_quant_draft else None

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1164,8 +1164,6 @@ class ServerArgs:
         # - Otherwise, the draft model defaults to the same quantization as the target model.
         if self.speculative_draft_model_quantization is None:
             self.speculative_draft_model_quantization = self.quantization
-        elif self.speculative_draft_model_quantization == "unquant":
-            self.speculative_draft_model_quantization = None
 
     def _handle_modelscope_paths(self):
         """Resolve model / tokenizer / speculative-draft paths from the local

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1160,8 +1160,6 @@ class ServerArgs:
             self.mamba_scheduler_strategy = "no_buffer"
 
         # In speculative scenario:
-        # - If `speculative_draft_model_quantization` is specified, the draft model uses this quantization method.
-        # - Otherwise, the draft model defaults to the same quantization as the target model.
         if self.speculative_draft_model_quantization is None:
             self.speculative_draft_model_quantization = self.quantization
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
1. Fixed the issue that the environment variable for controlling the quantization type was deleted.
2. Supported reading the configuration file from the weight to obtain the quantization configuration when the quantization type is not configured.

```shell
export SGLANG_SET_CPU_AFFINITY=1
#export PYTHONPATH=/home/l30022061/workspace/sglang/python:$PYTHONPATH
echo "-------------------> pythonpath is ${PYTHONPATH}"
unset http_proxy
unset https_proxy
unset HTTP_PROXY
unset HTTPS_PROXY
unset ASCEND_LAUNCH_BLOCKING

source /usr/local/Ascend/ascend-toolkit/set_env.sh
source /usr/local/Ascend/nnal/atb/set_env.sh

export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
export STREAMS_PER_DEVICE=32

export HCCL_SOCKET_IFNAME=lo
export GLOO_SOCKET_IFNAME=lo

export HCCL_BUFFSIZE=300

MODEL_PATH=/home/weight/GLM-4.7-W8A8-MTP

export ENABLE_ASCEND_MOE_NZ=1

export HCCL_OP_EXPANSION_MODE=AIV

export SGLANG_ENABLE_SPEC_V2=1
export SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1

export TASK_QUEUE_ENABLE=1
export SGLANG_NPU_PROFILING=0

export DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS=256
export DEEPEP_NORMAL_LONG_SEQ_ROUND=16
export DEEPEP_NORMAL_MODE_USE_INT8_QUANT=1
export HCCL_BUFFSIZE=550
export SGLANG_NPU_PREOFILING_STAGE="prefill"
export SGLANG_NPU_PROFILING_BS=1

export SGLANG_ENABLE_NO_PADDING=1
export SGLANG_NO_PAD_BS=20

python3 -m sglang.launch_server --model-path ${MODEL_PATH}  \
        --tp-size 16 \
        --quantization modelslim --trust-remote-code --attention-backend ascend --device npu \
        --watchdog-timeout 9000 --host 192.168.25.212 --port 18000 --mem-fraction-static 0.88 \
        --dtype bfloat16 \
        --chunked-prefill-size 16384 \
        --max-prefill-tokens 52000 \
        --cuda-graph-bs 8 \
        --max-running-requests 1024 \
        --speculative-algorithm NEXTN \
        --speculative-num-steps 3 \
        --speculative-eagle-topk 1 \
        --speculative-num-draft-tokens 4 \
        --skip-server-warmup \
        --moe-a2a-backend deepep --deepep-mode auto \
        --dp-size 2 --enable-dp-attention --load-balance-method round_robin  --enable-dp-lm-head \
        --speculative-draft-model-quantization unquant
```
<img width="2223" height="587" alt="image" src="https://github.com/user-attachments/assets/4c2bde1e-e696-4feb-9c51-73cd6c3be946" />

<!-- Describe the purpose and goals of this pull request. -->

## Modifications
```
# Fusing operators together cfg
python/sglang/srt/models/glm4_moe.py
# Fixed the issue that the environment variable for controlling the quantization type was deleted.
python/sglang/srt/layers/moe/token_dispatcher/deepep.py
# Supported reading the configuration file from the weight to obtain the quantization configuration when the 
# quantization type is not configured
python/sglang/srt/models/glm4_moe_nextn.py
python/sglang/srt/server_args.py
python/sglang/srt/configs/model_config.py
```
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->[Run #26025725859](https://github.com/sgl-project/sglang/actions/runs/26025725859)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** — add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->