### PR TITLE
fix: normalize tool message content for GLM5.1 chat template

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -457,6 +457,28 @@ class OpenAIServingChat(OpenAIServingBase):
                     modalities,
                 )
 
+                # Normalize tool role content: OpenAI clients may send content
+                # as a list of content parts (e.g. [{"type":"text","text":"..."}])
+                # but most chat templates expect a plain string for tool messages.
+                # Only flatten when ALL items are pure OpenAI text parts; preserve
+                # lists with tool-semantic fields (e.g. "name", "output") that some
+                # templates intentionally iterate over.
+                if processed_msg["role"] == "tool" and isinstance(
+                    processed_msg.get("content"), list
+                ):
+                    parts = processed_msg["content"]
+                    is_openai_text_parts = all(
+                        (isinstance(p, dict) and p.get("type") == "text")
+                        or isinstance(p, str)
+                        for p in parts
+                    )
+                    if is_openai_text_parts:
+                        text_parts = [
+                            p.get("text", "") if isinstance(p, dict) else p
+                            for p in parts
+                        ]
+                        processed_msg["content"] = "\n".join(text_parts)
+
                 # per the Transformers docs & maintainers, tool call arguments in
                 # assistant-role messages with tool_calls need to be dicts not JSON str -
                 # this is how tool-use chat templates will expect them moving forwards

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -60,6 +60,28 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def normalize_tool_content(role: str, content):
+    """Normalize tool message content from OpenAI array format to plain string.
+
+    OpenAI clients may send tool content as a list of content parts
+    (e.g. [{"type":"text","text":"..."}]) but most chat templates expect
+    a plain string for tool messages. Only flatten when ALL items are
+    pure OpenAI text parts; preserve lists containing non-text-type items
+    that some templates intentionally iterate over.
+    """
+    if role != "tool" or not isinstance(content, list):
+        return content
+    parts = content
+    is_openai_text_parts = all(
+        (isinstance(p, dict) and p.get("type") == "text") or isinstance(p, str)
+        for p in parts
+    )
+    if is_openai_text_parts:
+        text_parts = [p.get("text", "") if isinstance(p, dict) else p for p in parts]
+        return " ".join(text_parts)
+    return content
+
+
 def _extract_max_dynamic_patch(request: ChatCompletionRequest):
     img_vals = []
     vid_vals = []
@@ -457,27 +479,9 @@ class OpenAIServingChat(OpenAIServingBase):
                     modalities,
                 )
 
-                # Normalize tool role content: OpenAI clients may send content
-                # as a list of content parts (e.g. [{"type":"text","text":"..."}])
-                # but most chat templates expect a plain string for tool messages.
-                # Only flatten when ALL items are pure OpenAI text parts; preserve
-                # lists with tool-semantic fields (e.g. "name", "output") that some
-                # templates intentionally iterate over.
-                if processed_msg["role"] == "tool" and isinstance(
-                    processed_msg.get("content"), list
-                ):
-                    parts = processed_msg["content"]
-                    is_openai_text_parts = all(
-                        (isinstance(p, dict) and p.get("type") == "text")
-                        or isinstance(p, str)
-                        for p in parts
-                    )
-                    if is_openai_text_parts:
-                        text_parts = [
-                            p.get("text", "") if isinstance(p, dict) else p
-                            for p in parts
-                        ]
-                        processed_msg["content"] = "\n".join(text_parts)
+                processed_msg["content"] = normalize_tool_content(
+                    processed_msg["role"], processed_msg.get("content")
+                )
 
                 # per the Transformers docs & maintainers, tool call arguments in
                 # assistant-role messages with tool_calls need to be dicts not JSON str -

--- a/test/registered/openai_server/basic/test_serving_chat.py
+++ b/test/registered/openai_server/basic/test_serving_chat.py
@@ -19,7 +19,10 @@ from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionRequest,
     MessageProcessingResult,
 )
-from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
+from sglang.srt.entrypoints.openai.serving_chat import (
+    OpenAIServingChat,
+    normalize_tool_content,
+)
 from sglang.srt.managers.io_struct import GenerateReqInput
 from sglang.srt.utils import get_or_create_event_loop
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
@@ -892,6 +895,43 @@ class TestProcessToolCallsWithRequiredToolChoice(unittest.TestCase):
         )
 
         self.assertIsNone(tool_calls)
+
+
+class TestNormalizeToolContent(unittest.TestCase):
+    """Unit tests for normalize_tool_content()."""
+
+    def test_openai_text_parts_flattened(self):
+        result = normalize_tool_content("tool", [{"type": "text", "text": "10525"}])
+        self.assertEqual(result, "10525")
+
+    def test_multiple_text_parts_joined(self):
+        result = normalize_tool_content(
+            "tool",
+            [{"type": "text", "text": "hello"}, {"type": "text", "text": "world"}],
+        )
+        self.assertEqual(result, "hello world")
+
+    def test_non_text_part_list_preserved(self):
+        content = [{"name": "func", "output": "result"}]
+        result = normalize_tool_content("tool", content)
+        self.assertIs(result, content)
+
+    def test_string_content_unchanged(self):
+        self.assertEqual(normalize_tool_content("tool", "hello"), "hello")
+
+    def test_empty_list_returns_empty_string(self):
+        self.assertEqual(normalize_tool_content("tool", []), "")
+
+    def test_non_tool_role_unchanged(self):
+        content = [{"type": "text", "text": "hi"}]
+        result = normalize_tool_content("user", content)
+        self.assertIs(result, content)
+
+    def test_mixed_str_and_dict_parts(self):
+        result = normalize_tool_content(
+            "tool", ["plain", {"type": "text", "text": "rich"}]
+        )
+        self.assertEqual(result, "plain rich")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Fix: Normalize tool message `content` from array format to string before applying chat template

### Problem

Per the [OpenAI API specification](https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create#(resource)%20chat.completions%20%3E%20(model)%20chat_completion_tool_message_param%20%3E%20(schema)%20%3E%20(property)%20content%20%3E%20(variant)%201), the `content` field of a tool message supports **two formats**:

1. **String**: `"content": "10525"`
2. **Array of content parts**: `"content": [{"type": "text", "text": "10525"}]`

Many OpenAI-compatible clients (e.g., Claude Code / Cursor) send tool results using the **array format**. However, most model chat templates (Jinja) only handle the **string format** correctly for tool messages.

### Root Cause

Taking [GLM-5's chat_template.jinja](https://huggingface.co/zai-org/GLM-5/blob/main/chat_template.jinja) as an example, the tool message rendering has two branches:

```jinja
{%- elif m.role == 'tool' -%}
{%- if m.content is string -%}
    {# ✅ String branch: renders correctly #}
    <|observation|>
    <tool_response>{{ m.content }}</tool_response>
{%- else -%}
    {# ❌ List branch: expects items with .output field, not OpenAI text parts #}
    <|observation|>{% for tr in m.content %}
    <tool_response>{{ tr.output if tr.output is defined else tr }}</tool_response>{% endfor %}
{% endif -%}
```

When `content` is `[{"type": "text", "text": "10525"}]`:
- It does **not** enter the `is string` branch
- In the `else` branch, `tr.output` is undefined, so it falls back to `tr`, which renders the **entire dict repr** (e.g., `{'type': 'text', 'text': '10525'}`) — not the clean result

[GLM-5.1's template](https://huggingface.co/zai-org/GLM-5.1/blob/main/chat_template.jinja) is even worse — its `else` branch iterates `m.content` trying to match `tr.name` against tool definitions, resulting in **completely empty** `<tool_response>` tags.

**Consequence**: The model cannot see the tool results → it keeps generating new tool calls in a loop instead of summarizing the results.

### Solution

Normalize tool message `content` from OpenAI array format to plain string in `serving_chat.py`, **before** passing messages to `apply_chat_template`:

```python
if processed_msg["role"] == "tool" and isinstance(processed_msg.get("content"), list):
    parts = processed_msg["content"]
    # Only flatten pure OpenAI text parts; preserve structured lists
    # (e.g. [{"name": "func", "output": "..."}]) that some templates
    # intentionally iterate over.
    is_openai_text_parts = all(
        (isinstance(p, dict) and p.get("type") == "text") or isinstance(p, str)
        for p in parts
    )
    if is_openai_text_parts:
        text_parts = [
            p.get("text", "") if isinstance(p, dict) else p
            for p in parts
        ]
        processed_msg["content"] = "\n".join(text_parts)
```

### Design Decisions

| Input format | Behavior |
|---|---|
| `"result"` (string) | No-op, templates handle correctly |
| `[{"type":"text","text":"result"}]` (OpenAI text parts) | **Flattened to** `"result"` |
| `[{"name":"Bash","output":"result"}]` (tool-semantic struct) | **Preserved as-is** for templates that iterate |
| `[]` (empty list) | Normalized to `""`, consistent with `content is None → ""` |

### Why fix in SGLang instead of chat templates?

- **One fix, all models benefit** — no need to patch every model's upstream Jinja template
- SGLang is the OpenAI-compatible API layer — it should accept all valid OpenAI formats
- The two content formats are **semantically equivalent** for tool messages (pure text results)

### Affected Models

Any model whose chat template does not handle the OpenAI array content format for tool messages, including but not limited to:
- GLM-5 ([chat_template.jinja](https://huggingface.co/zai-org/GLM-5/blob/main/chat_template.jinja))
- GLM-5.1 ([chat_template.jinja](https://huggingface.co/zai-org/GLM-5.1/blob/main/chat_template.jinja))
