### PR TITLE
Fix triton and wave attention backends for mamba-hybrid models

### DIFF
--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -108,12 +108,9 @@ class TritonAttnBackend(AttentionBackend):
         if self.sliding_window_size is not None and swa_v_head_dim != full_v_head_dim:
             self.v_head_dim = full_v_head_dim
             self.swa_v_head_dim = swa_v_head_dim
-        elif (
-            model_runner.hybrid_gdn_config is not None
-            or model_runner.kimi_linear_config is not None
-            or model_runner.linear_attn_model_spec is not None
-        ):
-            # For hybrid linear models, layer_id = 0 may not be full attention
+        elif hasattr(model_runner.token_to_kv_pool, "get_v_head_dim"):
+            # For hybrid models (Mamba+attention, GDN, Kimi linear),
+            # layer_id=0 may not be a full attention layer
             self.v_head_dim = model_runner.token_to_kv_pool.get_v_head_dim()
             self.swa_v_head_dim = None
         else:

--- a/python/sglang/srt/layers/attention/wave_backend.py
+++ b/python/sglang/srt/layers/attention/wave_backend.py
@@ -150,7 +150,12 @@ class WaveAttnBackend(AttentionBackend):
             "SGLANG_TRITON_DECODE_ATTN_STATIC_KV_SPLITS", "false"
         )
         self.max_kv_splits = model_runner.server_args.triton_attention_num_kv_splits
-        self.v_head_dim = model_runner.token_to_kv_pool.get_value_buffer(0).shape[-1]
+        if hasattr(model_runner.token_to_kv_pool, "get_v_head_dim"):
+            # For hybrid models (Mamba+attention, GDN, Kimi linear),
+            # layer_id=0 may not be a full attention layer
+            self.v_head_dim = model_runner.token_to_kv_pool.get_v_head_dim()
+        else:
+            self.v_head_dim = model_runner.token_to_kv_pool.get_value_buffer(0).shape[-1]
 
         self.forward_metadata: ForwardMetadata = None
 


### PR DESCRIPTION
## Motivation

The triton and wave attention backends crash during initialization when loading Granite 4.0 hybrid models that have mamba layers (e.g. `ibm-granite/granite-4.0-h-350m`, `granite-4.0-h-tiny`, `granite-4.0-h-small`, `granite-4.0-h-1b`). These models use `GraniteMoeHybridForCausalLM` with `layer_types` containing both `"mamba"` and `"attention"` entries, where layer 0 is a mamba layer.

The error:
```
ValueError: layer_id=0 not in full attention layers: dict_keys([10, 13, 17, 27])
```

**Root cause:** Both backends call `get_value_buffer(0)` to determine `v_head_dim` during init, assuming layer 0 is always a full attention layer. For Granite hybrid models, layer 0 is a mamba layer with no KV cache entry, so `HybridLinearPool._transfer_full_attention_id(0)` raises `ValueError`.

The triton backend had a guard for some hybrid model types (`hybrid_gdn_config`, `kimi_linear_config`, `linear_attn_model_spec`) but missed mamba2-based hybrids like Granite. The wave backend had no guard at all.

## Changes

Replace the explicit config-type enumeration in `triton_backend.py` with `hasattr(model_runner.token_to_kv_pool, "get_v_head_dim")`, which catches all hybrid model types. This matches the approach already used by `aiter_backend.py`. Apply the same fix to `wave_backend.py`.

**Files changed:**
- `python/sglang/srt/layers/attention/triton_backend.py` — replace config enumeration with `hasattr` check
- `python/sglang/srt/layers/attention/wave_backend.py` — add `hasattr` guard before `get_value_buffer(0)`

## Test results

All tests run on 8xH100 node with SGLang installed from source (upstream main `78043d4` + this fix).

### Previously broken (triton backend), now fixed:
| Model | Layers (mamba/attn) | Before | After |
|---|---|---|---|
| `ibm-granite/granite-4.0-h-350m` | 32 (28/4) | `ValueError: layer_id=0 not in {10,13,17,27}` | PASS |
| `ibm-granite/granite-4.0-h-tiny` | 40 (36/4) | `ValueError: layer_id=0 not in {5,15,25,35}` | PASS |
| `ibm-granite/granite-4.0-h-small` | 40 (36/4) | `ValueError: layer_id=0 not in {5,15,25,35}` | PASS (tp=2) |
| `ibm-granite/granite-4.0-h-1b` | 40 (36/4) | `ValueError: layer_id=0 not in {5,15,25,35}` | PASS (tp=2) |

### Regression tests (triton backend, still passing):
| Model | Architecture | Result |
|---|---|---|
| `ibm-granite/granite-4.0-micro` | GraniteMoeHybrid (all attention, no mamba) | PASS |
| `ibm-granite/granite-3.3-2b-instruct` | GraniteForCausalLM (dense) | PASS |
| `ibm-granite/granite-3.0-1b-a400m-instruct` | GraniteMoeForCausalLM (MoE) | PASS |
| `Qwen/Qwen3-0.6B` | Qwen3ForCausalLM (non-granite) | PASS |

### Regression tests (flashinfer backend, still passing):
| Model | Result |
|---|---|
| `ibm-granite/granite-4.0-h-350m` (mamba hybrid) | PASS |
| `ibm-granite/granite-3.3-2b-instruct` (dense) | PASS |
| `Qwen/Qwen3-0.6B` (non-granite) | PASS |

### Wave backend
The wave backend has the same `get_value_buffer(0)` bug — confirmed by installing `wave_lang` and reproducing the identical `ValueError: layer_id=0 not in full attention layers` crash on upstream. With our fix applied, the `v_head_dim` initialization passes successfully. However, we could not fully end-to-end test the wave backend because it requires AMD ROCm/HIP hardware (the IREE compiler fails with `Unknown HIP target` on our NVIDIA node). The fix is the same `hasattr` pattern as triton and is definitely needed since the crash is confirmed.