### PR TITLE
[CI] Update B200 est_times to prevent timeouts on slower machine

### DIFF
--- a/test/registered/4-gpu-models/test_gpt_oss_4gpu.py
+++ b/test/registered/4-gpu-models/test_gpt_oss_4gpu.py
@@ -4,7 +4,7 @@ from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.gpt_oss_common import BaseTestGptOss
 
 register_cuda_ci(est_time=328, suite="stage-c-test-4-gpu-h100")
-register_cuda_ci(est_time=312, suite="stage-c-test-4-gpu-b200")
+register_cuda_ci(est_time=740, suite="stage-c-test-4-gpu-b200")
 
 
 class TestGptOss4Gpu(BaseTestGptOss):

--- a/test/registered/4-gpu-models/test_nvidia_nemotron_3_super_nvfp4.py
+++ b/test/registered/4-gpu-models/test_nvidia_nemotron_3_super_nvfp4.py
@@ -11,7 +11,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=294, suite="stage-c-test-4-gpu-b200")
+register_cuda_ci(est_time=710, suite="stage-c-test-4-gpu-b200")
 
 NEMOTRON_3_SUPER_NVFP4_MODEL = "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4"
 

--- a/test/registered/attention/test_flash_attention_4.py
+++ b/test/registered/attention/test_flash_attention_4.py
@@ -13,7 +13,7 @@ from sglang.test.test_utils import (
 )
 
 # FlashAttention4 integration test (requires SM 100+ / Blackwell B200)
-register_cuda_ci(est_time=259, suite="stage-b-test-4-gpu-b200")
+register_cuda_ci(est_time=332, suite="stage-b-test-4-gpu-b200")
 
 
 @unittest.skipIf(get_device_sm() < 100, "Test requires CUDA SM 100 or higher")

--- a/test/registered/moe/test_cutedsl_moe.py
+++ b/test/registered/moe/test_cutedsl_moe.py
@@ -16,7 +16,7 @@ except ImportError:
     CuteDslMoEWrapper = None
     convert_sf_to_mma_layout = None
 
-register_cuda_ci(est_time=322, suite="stage-c-test-4-gpu-b200")
+register_cuda_ci(est_time=590, suite="stage-c-test-4-gpu-b200")
 
 SKIP_TEST = torch.cuda.get_device_capability() < (10, 0)
 SKIP_REASON = "Nvfp4 Requires compute capability of 10 or above."

--- a/test/registered/moe/test_cutedsl_moe.py
+++ b/test/registered/moe/test_cutedsl_moe.py
@@ -16,7 +16,7 @@ except ImportError:
     CuteDslMoEWrapper = None
     convert_sf_to_mma_layout = None
 
-register_cuda_ci(est_time=13, suite="stage-c-test-4-gpu-b200")
+register_cuda_ci(est_time=322, suite="stage-c-test-4-gpu-b200")
 
 SKIP_TEST = torch.cuda.get_device_capability() < (10, 0)
 SKIP_REASON = "Nvfp4 Requires compute capability of 10 or above."

--- a/test/registered/quant/test_deepseek_v3_fp4_4gpu.py
+++ b/test/registered/quant/test_deepseek_v3_fp4_4gpu.py
@@ -14,7 +14,7 @@ from sglang.test.test_utils import (
     write_github_step_summary,
 )
 
-register_cuda_ci(est_time=1146, suite="stage-c-test-4-gpu-b200")
+register_cuda_ci(est_time=1380, suite="stage-c-test-4-gpu-b200")
 
 FULL_DEEPSEEK_V3_FP4_MODEL_PATH = "nvidia/DeepSeek-V3-0324-FP4"
 SERVER_LAUNCH_TIMEOUT = 1200

--- a/test/registered/quant/test_fp8_blockwise_gemm.py
+++ b/test/registered/quant/test_fp8_blockwise_gemm.py
@@ -12,7 +12,7 @@ from sglang.test.test_utils import (
     try_cached_model,
 )
 
-register_cuda_ci(est_time=302, suite="stage-c-test-4-gpu-b200")
+register_cuda_ci(est_time=630, suite="stage-c-test-4-gpu-b200")
 
 MODEL_PATH = "Qwen/Qwen3-4B-Instruct-2507-FP8"
 MXFP8_MODEL_PATH = "zianglih/Qwen3-4B-Instruct-2507-MXFP8"

--- a/test/registered/quant/test_nvfp4_gemm.py
+++ b/test/registered/quant/test_nvfp4_gemm.py
@@ -12,7 +12,7 @@ from sglang.test.test_utils import (
     try_cached_model,
 )
 
-register_cuda_ci(est_time=322, suite="stage-c-test-4-gpu-b200")
+register_cuda_ci(est_time=550, suite="stage-c-test-4-gpu-b200")
 
 MODEL_PATH = "nvidia/Llama-3.1-8B-Instruct-NVFP4"
 

--- a/test/registered/spec/eagle/test_deepseek_v3_fp4_mtp_small.py
+++ b/test/registered/spec/eagle/test_deepseek_v3_fp4_mtp_small.py
@@ -16,7 +16,7 @@ from sglang.test.test_utils import (
     write_github_step_summary,
 )
 
-register_cuda_ci(est_time=416, suite="stage-b-test-4-gpu-b200")
+register_cuda_ci(est_time=510, suite="stage-b-test-4-gpu-b200")
 
 FULL_DEEPSEEK_V3_FP4_MODEL_PATH = "nvidia/DeepSeek-V3-0324-FP4"
 SERVER_LAUNCH_TIMEOUT = 1200

--- a/test/registered/spec/eagle/test_eagle_infer_beta_dp_attention.py
+++ b/test/registered/spec/eagle/test_eagle_infer_beta_dp_attention.py
@@ -17,7 +17,7 @@ from sglang.test.test_utils import (
 )
 
 # EAGLE with DP attention on B200 (tp=2, dp=2, requires 4 B200 GPUs)
-register_cuda_ci(est_time=68, suite="stage-c-test-4-gpu-b200")
+register_cuda_ci(est_time=136, suite="stage-c-test-4-gpu-b200")
 
 
 def test_gsm8k(base_url: str, model: str):


### PR DESCRIPTION
## Summary
- Update `est_time` for 10 B200 tests based on actual elapsed times + 20% buffer
- The second B200 machine runs ~1.8x slower than the first due to hardware differences:

| Metric | Machine A | Machine B | Ratio |
|---|---|---|---|
| HBM bandwidth | 5528 GB/s | 3518 GB/s | **1.6x slower** |
| Host-to-Device PCIe | 56.9 GB/s | 55.2 GB/s | ~same |
| Matmul TFLOPS (bf16) | 1543 | 1499 | ~same |
| Disk read | 3667 MB/s | 1301 MB/s | **2.8x slower** |

- Tests pass on both machines but partitions time out on Machine B because est_times were calibrated on the faster Machine A

| Test | Old est | Machine B actual | New est |
|---|---|---|---|
| `test_nvfp4_gemm.py` | 322 | 459 | 550 |
| `test_gpt_oss_4gpu.py` | 312 | 615 | 740 |
| `test_fp8_blockwise_gemm.py` | 302 | 527 | 630 |
| `test_eagle_infer_beta_dp_attention.py` | 68 | 113 | 136 |
| `test_nvidia_nemotron_3_super_nvfp4.py` | 294 | 591 | 710 |
| `test_cutedsl_moe.py` | 13 | 491 | 590 |
| `test_deepseek_v3_fp4_4gpu.py` | 1146 | 1149 | 1380 |
| `test_deepseek_v3_fp4_mtp_small.py` | 416 | 424 | 510 |
| `test_flash_attention_4.py` | 259 | 276 | 332 |
| `test_lora_qwen3_30b...py` | 160 | 87 | (no change, faster) |

Example timeout: https://github.com/sgl-project/sglang/actions/runs/24288516804/job/70933367476

## Test plan
- [x] est_time changes only, no logic changes
- [x] Benchmarked both machines to confirm hardware difference (HBM bandwidth, disk I/O)