### PR TITLE
[Feature] Add return_token_ids to /v1/chat/completions and /v1/completions

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -275,6 +275,7 @@ class CompletionRequest(BaseModel):
     return_hidden_states: bool = False
     return_routed_experts: bool = False
     return_cached_tokens_details: bool = False
+    return_token_ids: bool = False
 
     # Extra parameters for SRT backend only and will be ignored by OpenAI models.
     top_k: int = -1
@@ -341,6 +342,8 @@ class SglExt(BaseModel):
 
     routed_experts: Optional[str] = None
     cached_tokens_details: Optional[CachedTokensDetails] = None
+    prompt_token_ids: Optional[List[int]] = None
+    completion_token_ids: Optional[List[List[int]]] = None
 
     @model_serializer(mode="wrap")
     def _serialize(self, handler):
@@ -590,6 +593,7 @@ class ChatCompletionRequest(BaseModel):
     return_hidden_states: bool = False
     return_routed_experts: bool = False
     return_cached_tokens_details: bool = False
+    return_token_ids: bool = False
     reasoning_effort: Optional[Literal["none", "low", "medium", "high"]] = Field(
         default=None,
         description="Constrains effort on reasoning for reasoning models. "

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -661,6 +661,7 @@ class OpenAIServingChat(OpenAIServingBase):
         cached_tokens = {}
         hidden_states = {}
         routed_experts = {}
+        output_ids_accum: Dict[int, List[int]] = {}
 
         stream_started = False
         try:
@@ -684,6 +685,12 @@ class OpenAIServingChat(OpenAIServingBase):
                 cached_tokens[index] = content["meta_info"].get("cached_tokens", 0)
                 hidden_states[index] = content["meta_info"].get("hidden_states", None)
                 routed_experts[index] = content["meta_info"].get("routed_experts", None)
+
+                # Accumulate output token IDs for return_token_ids feature.
+                # output_ids is always cumulative in non-incremental streaming
+                # (same as routed_experts — just overwrite each chunk).
+                if request.return_token_ids:
+                    output_ids_accum[index] = list(content.get("output_ids") or [])
 
                 # Handle logprobs
                 choice_logprobs = None
@@ -894,6 +901,31 @@ class OpenAIServingChat(OpenAIServingBase):
                     )
                     yield f"data: {routed_experts_chunk.model_dump_json()}\n\n"
 
+            # Send token IDs if requested (covers all choices after generation is complete)
+            if request.return_token_ids and output_ids_accum:
+                n_choices = request.n or 1
+                prompt_ids = getattr(adapted_request, "input_ids", None)
+                # Only include prompt_ids for non-multimodal requests (flat list of ints)
+                if (
+                    isinstance(prompt_ids, list)
+                    and prompt_ids
+                    and isinstance(prompt_ids[0], list)
+                ):
+                    prompt_ids = None
+                token_ids_chunk = ChatCompletionStreamResponse(
+                    id=content["meta_info"]["id"],
+                    created=int(time.time()),
+                    choices=[],
+                    model=request.model,
+                    sglext=SglExt(
+                        completion_token_ids=[
+                            output_ids_accum.get(i, []) for i in range(n_choices)
+                        ],
+                        prompt_token_ids=prompt_ids,
+                    ),
+                )
+                yield f"data: {token_ids_chunk.model_dump_json()}\n\n"
+
             # Additional usage chunk
             if include_usage:
                 usage = UsageProcessor.calculate_streaming_usage(
@@ -938,10 +970,22 @@ class OpenAIServingChat(OpenAIServingBase):
         if not isinstance(ret, list):
             ret = [ret]
 
+        prompt_token_ids = None
+        if request.return_token_ids:
+            input_ids = getattr(adapted_request, "input_ids", None)
+            # Only include for non-multimodal requests (flat list of ints)
+            if (
+                isinstance(input_ids, list)
+                and input_ids
+                and not isinstance(input_ids[0], list)
+            ):
+                prompt_token_ids = input_ids
+
         response = self._build_chat_response(
             request,
             ret,
             int(time.time()),
+            prompt_token_ids=prompt_token_ids,
         )
 
         return response
@@ -951,6 +995,7 @@ class OpenAIServingChat(OpenAIServingBase):
         request: ChatCompletionRequest,
         ret: List[Dict[str, Any]],
         created: int,
+        prompt_token_ids: Optional[List[int]] = None,
     ) -> Union[ChatCompletionResponse, ORJSONResponse]:
         """Build chat completion response from generation results"""
         choices = []
@@ -962,10 +1007,17 @@ class OpenAIServingChat(OpenAIServingBase):
             first_ret, request
         )
         response_sglext = None
-        if routed_experts or cached_tokens_details:
+        if routed_experts or cached_tokens_details or request.return_token_ids:
+            completion_token_ids = None
+            if request.return_token_ids:
+                completion_token_ids = [
+                    ret_item.get("output_ids", []) for ret_item in ret
+                ]
             response_sglext = SglExt(
                 routed_experts=routed_experts,
                 cached_tokens_details=cached_tokens_details,
+                completion_token_ids=completion_token_ids,
+                prompt_token_ids=prompt_token_ids if request.return_token_ids else None,
             )
 
         for idx, ret_item in enumerate(ret):

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -224,6 +224,7 @@ class OpenAIServingCompletion(OpenAIServingBase):
         cached_tokens = {}
         hidden_states = {}
         routed_experts = {}
+        output_ids_accum = {}
 
         stream_started = False
         try:
@@ -248,6 +249,10 @@ class OpenAIServingCompletion(OpenAIServingBase):
                 cached_tokens[index] = content["meta_info"].get("cached_tokens", 0)
                 hidden_states[index] = content["meta_info"].get("hidden_states", None)
                 routed_experts[index] = content["meta_info"].get("routed_experts", None)
+
+                if request.return_token_ids:
+                    # output_ids is always cumulative in non-incremental streaming; just overwrite
+                    output_ids_accum[index] = list(content.get("output_ids") or [])
 
                 stream_buffer = stream_buffers.get(index, "")
                 # Handle echo for first chunk
@@ -389,6 +394,21 @@ class OpenAIServingCompletion(OpenAIServingBase):
                     )
                     yield f"data: {routed_experts_chunk.model_dump_json()}\n\n"
 
+            if request.return_token_ids and output_ids_accum:
+                n_choices = request.n or 1
+                completion_token_ids = [
+                    output_ids_accum.get(i, []) for i in range(n_choices)
+                ]
+                token_ids_chunk = CompletionStreamResponse(
+                    id=content["meta_info"]["id"],
+                    created=created,
+                    object="text_completion",
+                    choices=[],
+                    model=request.model,
+                    sglext=SglExt(completion_token_ids=completion_token_ids),
+                )
+                yield f"data: {token_ids_chunk.model_dump_json()}\n\n"
+
             # Handle final usage chunk
             if include_usage:
                 usage = UsageProcessor.calculate_streaming_usage(
@@ -435,10 +455,21 @@ class OpenAIServingCompletion(OpenAIServingBase):
         if not isinstance(ret, list):
             ret = [ret]
 
+        prompt_token_ids = None
+        if request.return_token_ids:
+            input_ids = getattr(adapted_request, "input_ids", None)
+            if (
+                input_ids is not None
+                and len(input_ids) > 0
+                and not isinstance(input_ids[0], list)
+            ):
+                prompt_token_ids = list(input_ids)
+
         response = self._build_completion_response(
             request,
             ret,
             int(time.time()),
+            prompt_token_ids=prompt_token_ids,
         )
 
         return response
@@ -448,6 +479,7 @@ class OpenAIServingCompletion(OpenAIServingBase):
         request: CompletionRequest,
         ret: List[Dict[str, Any]],
         created: int,
+        prompt_token_ids: Optional[List[int]] = None,
     ) -> CompletionResponse:
         """Build completion response from generation results"""
         choices = []
@@ -465,11 +497,18 @@ class OpenAIServingCompletion(OpenAIServingBase):
         cached_tokens_details = process_cached_tokens_details_from_ret(
             first_ret, request
         )
+        completion_token_ids = None
+        if request.return_token_ids:
+            completion_token_ids = [
+                list(ret_item.get("output_ids") or []) for ret_item in ret
+            ]
         response_sglext = None
-        if routed_experts or cached_tokens_details:
+        if routed_experts or cached_tokens_details or request.return_token_ids:
             response_sglext = SglExt(
                 routed_experts=routed_experts,
                 cached_tokens_details=cached_tokens_details,
+                prompt_token_ids=prompt_token_ids if request.return_token_ids else None,
+                completion_token_ids=completion_token_ids,
             )
 
         for idx, ret_item in enumerate(ret):

--- a/test/registered/openai_server/basic/test_protocol.py
+++ b/test/registered/openai_server/basic/test_protocol.py
@@ -26,6 +26,7 @@ from sglang.srt.entrypoints.openai.protocol import (
     CompletionRequest,
     ModelCard,
     ModelList,
+    SglExt,
     UsageInfo,
 )
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
@@ -372,6 +373,78 @@ class TestValidationEdgeCases(unittest.TestCase):
         self.assertEqual(restored_request.temperature, original_request.temperature)
         self.assertEqual(restored_request.max_tokens, original_request.max_tokens)
         self.assertEqual(len(restored_request.messages), len(original_request.messages))
+
+
+class TestReturnTokenIds(unittest.TestCase):
+    """Test return_token_ids feature for /chat/completions"""
+
+    def test_return_token_ids_default_false(self):
+        """return_token_ids should default to False"""
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        self.assertFalse(request.return_token_ids)
+
+    def test_return_token_ids_can_be_enabled(self):
+        """return_token_ids can be set to True"""
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "Hello"}],
+            return_token_ids=True,
+        )
+        self.assertTrue(request.return_token_ids)
+
+    def test_sglext_token_id_fields_excluded_when_none(self):
+        """prompt_token_ids and completion_token_ids are excluded when None"""
+        sglext = SglExt()
+        data = sglext.model_dump()
+        self.assertNotIn("prompt_token_ids", data)
+        self.assertNotIn("completion_token_ids", data)
+
+    def test_sglext_token_id_fields_included_when_set(self):
+        """prompt_token_ids and completion_token_ids are serialized correctly"""
+        sglext = SglExt(
+            prompt_token_ids=[1, 2, 3],
+            completion_token_ids=[[4, 5, 6]],
+        )
+        data = sglext.model_dump()
+        self.assertEqual(data["prompt_token_ids"], [1, 2, 3])
+        self.assertEqual(data["completion_token_ids"], [[4, 5, 6]])
+
+    def test_sglext_token_ids_with_multiple_choices(self):
+        """completion_token_ids supports multiple choices (n>1)"""
+        sglext = SglExt(
+            prompt_token_ids=[10, 20],
+            completion_token_ids=[[100, 101], [200, 201]],
+        )
+        data = sglext.model_dump()
+        self.assertEqual(len(data["completion_token_ids"]), 2)
+        self.assertEqual(data["completion_token_ids"][0], [100, 101])
+        self.assertEqual(data["completion_token_ids"][1], [200, 201])
+
+    def test_sglext_token_ids_coexist_with_other_fields(self):
+        """token_ids fields coexist with other SglExt fields"""
+        sglext = SglExt(
+            prompt_token_ids=[1, 2],
+            completion_token_ids=[[3, 4]],
+            routed_experts="expert_data",
+        )
+        data = sglext.model_dump()
+        self.assertIn("prompt_token_ids", data)
+        self.assertIn("completion_token_ids", data)
+        self.assertIn("routed_experts", data)
+
+    def test_streaming_accumulation_last_chunk_wins(self):
+        """output_ids is cumulative per chunk; last chunk has the full list"""
+        # Simulate serving_chat.py / serving_completions.py accumulation logic:
+        # output_ids is always cumulative (full list each chunk), so overwrite each time.
+        output_ids_accum = {}
+        index = 0
+        chunks = [[101], [101, 102], [101, 102, 103], [101, 102, 103, 104]]
+        for chunk_ids in chunks:
+            output_ids_accum[index] = list(chunk_ids)
+        self.assertEqual(output_ids_accum[index], [101, 102, 103, 104])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Closes #18378

For RL training workflows, token consistency between inference and training requires the **exact token IDs** — retokenizing decoded text may not reproduce the same IDs. The `/generate` endpoint already returns `output_ids`; this PR brings the same capability to the OpenAI-compatible chat and completions endpoints.

Note: PR #18398 covers the same feature and has been open for 2+ months with no reviews. This is a fresh, minimal implementation that addresses correctness concerns and follows codebase conventions more closely.

## Changes

### `protocol.py`
- `ChatCompletionRequest` + `CompletionRequest`: add `return_token_ids: bool = False` (opt-in, off by default)
- `SglExt`: add `prompt_token_ids: Optional[List[int]]` and `completion_token_ids: Optional[List[List[int]]]`
  - `_serialize` already strips `None` fields → zero wire-format impact when disabled

### `serving_chat.py`
- **Streaming**: accumulate `output_ids` per choice (plain overwrite — `output_ids` is cumulative like `routed_experts`), emit one `choices=[]` sglext chunk after the stream loop
- **Non-streaming**: read `prompt_token_ids` from `adapted_request.input_ids` (guarded for multimodal), `completion_token_ids` from `ret` items

### `serving_completions.py`
- Same pattern as `serving_chat.py`
- Mirrors existing symmetry: all `return_*` fields appear in both `CompletionRequest` and `ChatCompletionRequest`

### `test/registered/openai_server/basic/test_protocol.py`
- 7 new unit tests in `TestReturnTokenIds`

## Usage

```python
response = client.chat.completions.create(
    model="...",
    messages=[{"role": "user", "content": "Hello!"}],
    extra_body={"return_token_ids": True},
)
sglext = response.model_extra.get("sglext", {})
print(sglext["prompt_token_ids"])       # [1, 2, 3, ...]
print(sglext["completion_token_ids"])   # [[4, 5, 6, ...]]  (one list per choice)
```

## Design notes
- Zero overhead when disabled (all logic gated on `return_token_ids`)
- Non-OAI-standard fields placed in `sglext` per existing convention
- Multimodal: `prompt_token_ids` returns `None` (nested `input_ids` not supported)
- Backend unchanged — `tokenizer_manager.py` already returns `output_ids` in every chunk

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
