### PR TITLE
[Observability] Add gpu_cache_usage_perc Prometheus metric for vLLM compatibility

### DIFF
--- a/docs/references/production_metrics.md
+++ b/docs/references/production_metrics.md
@@ -17,6 +17,9 @@ sglang:generation_tokens_total{model_name="meta-llama/Llama-3.1-8B-Instruct"} 7.
 # HELP sglang:token_usage The token usage
 # TYPE sglang:token_usage gauge
 sglang:token_usage{model_name="meta-llama/Llama-3.1-8B-Instruct"} 0.28
+# HELP sglang:gpu_cache_usage_perc GPU KV cache usage percentage (0.0-1.0). Compatible with vLLM's gpu_cache_usage_perc.
+# TYPE sglang:gpu_cache_usage_perc gauge
+sglang:gpu_cache_usage_perc{model_name="meta-llama/Llama-3.1-8B-Instruct"} 0.28
 # HELP sglang:cache_hit_rate The cache hit rate
 # TYPE sglang:cache_hit_rate gauge
 sglang:cache_hit_rate{model_name="meta-llama/Llama-3.1-8B-Instruct"} 0.007507552643049313

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -272,6 +272,12 @@ class SchedulerMetricsCollector:
             labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
         )
+        self.gpu_cache_usage_perc = Gauge(
+            name="sglang:gpu_cache_usage_perc",
+            documentation="GPU KV cache usage percentage (0.0-1.0). Compatible with vLLM's gpu_cache_usage_perc.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
 
         # Speculative decoding
         self.spec_accept_length = Gauge(
@@ -993,6 +999,7 @@ class SchedulerMetricsCollector:
         self._log_gauge(self.cache_hit_rate, stats.cache_hit_rate)
 
         self._log_gauge(self.max_total_num_tokens, stats.max_total_num_tokens)
+        self._log_gauge(self.gpu_cache_usage_perc, stats.token_usage)
 
         # Speculative decoding
         self._log_gauge(self.spec_accept_length, stats.spec_accept_length)

--- a/test/registered/observability/test_metrics.py
+++ b/test/registered/observability/test_metrics.py
@@ -158,6 +158,7 @@ class TestEnableMetrics(CustomTestCase):
             "sglang:num_running_reqs",
             "sglang:num_used_tokens",
             "sglang:token_usage",
+            "sglang:gpu_cache_usage_perc",
             "sglang:gen_throughput",
             "sglang:num_queue_reqs",
             "sglang:num_grammar_queue_reqs",


### PR DESCRIPTION
## What's broken? (Symptoms)

Users migrating from vLLM expect a `gpu_cache_usage_perc` Prometheus metric on the `/metrics` endpoint to monitor KV cache utilization. SGLang does not expose this metric, making it harder to build unified dashboards across vLLM and SGLang deployments.

## Who is affected?

- Users running SGLang with `--enable-metrics` who want to monitor KV cache pressure via Prometheus/Grafana
- Teams migrating from vLLM that have existing dashboards querying `gpu_cache_usage_perc`
- Not affected: users who don't use Prometheus monitoring, or who already use `sglang:token_usage` directly

## When does it trigger?

Always — the metric simply doesn't exist on the Prometheus `/metrics` endpoint. This is a feature gap, not a runtime bug.

## Where is the bug? (Code Location)

- `python/sglang/srt/observability/metrics_collector.py` — `SchedulerMetricsCollector` defines all Prometheus Gauges. No `gpu_cache_usage_perc` Gauge is defined.
- `python/sglang/srt/observability/scheduler_metrics_mixin.py` — `_emit_kv_metrics()` (line ~675) already sets `KvMetrics.gpu_cache_usage_perc = self.stats.token_usage` for the ZMQ path, but this value never reaches Prometheus.

## Why does it happen? (Root Cause)

The KV cache usage ratio is computed and exposed via two paths:
1. **ZMQ path** (`KvMetrics.gpu_cache_usage_perc`) — sent to tokenizer manager for internal routing. ✅ Exists.
2. **Prometheus path** (`/metrics` endpoint) — exposed as `sglang:token_usage`. ⚠️ Exists but has two issues:
   - The name `token_usage` is not discoverable for users expecting vLLM-compatible naming
   - Per the [FIXME comment](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/observability/metrics_collector.py), `token_usage` actually reports `max()` across ALL pools (KV, SWA, Mamba), not just KV cache

The gap: there is no `sglang:gpu_cache_usage_perc` on the Prometheus endpoint.

## How did we fix it?

Added `sglang:gpu_cache_usage_perc` as a new Prometheus Gauge in `SchedulerMetricsCollector`, mapping to `stats.token_usage` — the same value the ZMQ `KvMetrics` path already reports.

**Changes (3 files, ~12 lines added, 0 removed):**
1. `metrics_collector.py` — New `Gauge` definition + `_log_gauge()` call
2. `test_metrics.py` — Added to `essential_metrics` and positive-value check
3. `production_metrics.md` — Documented the new metric

**Design decisions:**
- **Additive, not rename**: No existing metric names changed → zero dashboard breakage
- **Maps to `token_usage`** (not `full_token_usage`): Matches the existing ZMQ `KvMetrics.gpu_cache_usage_perc` behavior for consistency. If the FIXME about `token_usage` semantics is resolved later, both ZMQ and Prometheus paths should update together.
- **vLLM-compatible name**: `sglang:gpu_cache_usage_perc` mirrors `vllm:gpu_cache_usage_perc`

**Related work:** PR #18476 proposes renaming existing metrics (e.g., `token_usage` → `kv_cache_usage_perc`). This PR takes an additive approach — new metric alongside existing ones — to avoid breaking dashboards. The two approaches are complementary.

## How do we know it works? (Testing)

- **Syntax check**: `py_compile` passed on all modified Python files
- **Pre-commit hooks**: isort, ruff, black, codespell — all passed
- **Test update**: Added `sglang:gpu_cache_usage_perc` to `essential_metrics` in `test_metrics.py` — the integration test will verify the metric appears in `/metrics` output when run on CI (requires GPU server)
- **Local validation**: Cannot run full integration test locally (requires `popen_launch_server` with GPU). Full test validation depends on CI.

Closes #5979

cc @hnyls2002 @sufeng-buaa @xiezhq-hermann @Kangyan-Zhou
