### PR TITLE
[metrics] Add avg_request_queue_latency gauge for real-time queue monitoring (#6357)

### DIFF
--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -92,6 +92,7 @@ class SchedulerStats:
     num_grammar_queue_reqs: int = 0
     num_running_reqs_offline_batch: int = 0
     cache_hit_rate: float = 0.0
+    avg_request_queue_latency: float = 0.0
 
     max_total_num_tokens: int = 0
 
@@ -262,6 +263,12 @@ class SchedulerMetricsCollector:
         self.cache_hit_rate = Gauge(
             name="sglang:cache_hit_rate",
             documentation="The prefix cache hit rate.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+        self.avg_request_queue_latency = Gauge(
+            name="sglang:avg_request_queue_latency",
+            documentation="The average time in seconds that requests currently in the waiting queue have been waiting.",
             labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
         )
@@ -991,6 +998,7 @@ class SchedulerMetricsCollector:
             self.num_running_reqs_offline_batch, stats.num_running_reqs_offline_batch
         )
         self._log_gauge(self.cache_hit_rate, stats.cache_hit_rate)
+        self._log_gauge(self.avg_request_queue_latency, stats.avg_request_queue_latency)
 
         self._log_gauge(self.max_total_num_tokens, stats.max_total_num_tokens)
 

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -422,6 +422,15 @@ class SchedulerMetricsMixin:
             )
             self.stats.num_grammar_queue_reqs = len(self.grammar_manager)
             self.stats.cache_hit_rate = cache_hit_rate
+            now = time.perf_counter()
+            queue_waits = [
+                now - r.time_stats.wait_queue_entry_time
+                for r in self.waiting_queue
+                if r.time_stats.wait_queue_entry_time > 0
+            ]
+            self.stats.avg_request_queue_latency = (
+                sum(queue_waits) / len(queue_waits) if queue_waits else 0.0
+            )
 
             self.stats.max_total_num_tokens = self.max_total_num_tokens
 
@@ -599,6 +608,15 @@ class SchedulerMetricsMixin:
             )
             self.stats.num_grammar_queue_reqs = len(self.grammar_manager)
             self.stats.cache_hit_rate = cache_hit_rate
+            now = time.perf_counter()
+            queue_waits = [
+                now - r.time_stats.wait_queue_entry_time
+                for r in self.waiting_queue
+                if r.time_stats.wait_queue_entry_time > 0
+            ]
+            self.stats.avg_request_queue_latency = (
+                sum(queue_waits) / len(queue_waits) if queue_waits else 0.0
+            )
 
             self.stats.max_total_num_tokens = self.max_total_num_tokens
 

--- a/test/registered/observability/test_metrics.py
+++ b/test/registered/observability/test_metrics.py
@@ -175,6 +175,7 @@ class TestEnableMetrics(CustomTestCase):
             "sglang:num_unique_running_routing_keys",
             "sglang:routing_key_running_req_count",
             "sglang:routing_key_all_req_count",
+            "sglang:avg_request_queue_latency",
         ]
         mfu_metrics = [
             "sglang:estimated_flops_per_gpu_total",


### PR DESCRIPTION
## Motivation

Closes #6357

The existing `sglang:queue_time_seconds` histogram records queue time of
**completed** requests — it answers "how long DID requests wait?" (historical
distribution, useful for SLO percentile tracking).

Production Grafana/alerting setups also need to answer a different question:
**"how long ARE requests waiting RIGHT NOW?"** This requires a Gauge that
snapshots the current queue state at each stats interval. The two metric
types are fundamentally non-redundant:

| Metric | Type | Measures | Use case |
|---|---|---|---|
| `sglang:queue_time_seconds` | Histogram | Completed requests' queue time | SLO p50/p99 tracking |
| `sglang:avg_request_queue_latency` *(new)* | Gauge | Mean wait-so-far of requests **currently in queue** | Real-time alerting, autoscaling triggers |

A histogram cannot replace a gauge for real-time queue health because:
- Histogram values are only recorded **after** a request leaves the queue
- During a traffic spike, the histogram stays flat while queued requests
  silently accumulate — the gauge immediately reflects queue buildup
- Grafana threshold alerts need instantaneous gauge values

## Modifications

- Add `avg_request_queue_latency` field to `SchedulerStats` dataclass
- Add corresponding Prometheus `Gauge` to `PrometheusMetricsCollector`
- Compute the average wait time of currently-queued requests in both
  `report_prefill_stats()` and `report_decode_stats()`, using the existing
  `wait_queue_entry_time` timestamps (zero-cost when queue is empty)
- Log the gauge via `_log_gauge()` in `log_stats()`
- Add to `essential_metrics` test list

## Prior art

- #6574 and #20159 attempted to fix this but stalled (conflicts / no review)
- #8627 previously added this metric; it was removed in #11123 during a
  broader metrics cleanup. This PR re-introduces it with clear documentation
  of why it is semantically distinct from the existing histogram.

## How do we know it works?

- All pre-commit checks pass (isort, ruff, black, codespell, ast)
- `sglang:avg_request_queue_latency` added to `essential_metrics` in
  `test_metrics.py` — CI will verify the metric is emitted by the server
- Computation uses the same `time.perf_counter()` clock as
  `set_wait_queue_entry_time()`, ensuring consistency
- The `> 0` guard filters uninitialized entries (default `0.0`), matching
  the established pattern in `req_time_stats.py`

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results as needed (N/A — gauge update is O(queue_size) per stats interval, negligible).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
