### PR TITLE
Fix: Add token heuristic increment in total_tokens load balancing

### DIFF
--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -96,7 +96,7 @@ class DPBudget:
             self.total_requests[load.dp_rank] = load.num_reqs
             self.total_tokens[load.dp_rank] = load.num_tokens
 
-    def dispatch(self, method: LoadBalanceMethod):
+    def dispatch(self, method: LoadBalanceMethod, estimated_tokens: int = 0):
         if method == LoadBalanceMethod.TOTAL_REQUESTS:
             target_rank = self.total_requests.index(min(self.total_requests))
         elif method == LoadBalanceMethod.TOTAL_TOKENS:
@@ -110,6 +110,7 @@ class DPBudget:
 
         # Increment the load of that worker by one as a heuristic
         self.total_requests[target_rank] += 1
+        self.total_tokens[target_rank] += estimated_tokens
         return target_rank
 
 
@@ -576,7 +577,10 @@ class DataParallelController:
     def total_tokens_scheduler(self, req: Req):
         if self.maybe_external_dp_rank_routing(req):
             return
-        target_worker = self.dp_budget.dispatch(LoadBalanceMethod.TOTAL_TOKENS)
+        estimated_tokens = len(req.origin_input_ids)
+        target_worker = self.dp_budget.dispatch(
+            LoadBalanceMethod.TOTAL_TOKENS, estimated_tokens=estimated_tokens
+        )
         self.workers[target_worker].send_pyobj(req)
 
     def event_loop(self):

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -577,7 +577,7 @@ class DataParallelController:
     def total_tokens_scheduler(self, req: Req):
         if self.maybe_external_dp_rank_routing(req):
             return
-        estimated_tokens = len(req.origin_input_ids)
+        estimated_tokens = len(req.input_ids)
         target_worker = self.dp_budget.dispatch(
             LoadBalanceMethod.TOTAL_TOKENS, estimated_tokens=estimated_tokens
         )


### PR DESCRIPTION
# Fix: Add token heuristic increment in `total_tokens` load balancing

## Motivation

When using disaggregated (PD-separated) deployment with `--load-balance-method total_tokens` and multiple DP workers, we observed that prealloc requests can pile up on a single DP worker (e.g., `#prealloc-req: 21` on DP0) while other DP workers remain nearly idle.

**Production logs showing the imbalance:**

```
[DP0] #running-req: 1, #token: 106752, token_usage: 0.67, #prealloc-req: 21, #transfer-req: 0
[DP1] #running-req: 1, #token: 32064,  token_usage: 0.20, #prealloc-req: 0,  #transfer-req: 1
[DP2] #running-req: 1, #token: 25856,  token_usage: 0.16, #prealloc-req: 0,  #transfer-req: 0
[DP3] #running-req: 1, #token: 62592,  token_usage: 0.39, #prealloc-req: 0,  #transfer-req: 1
[DP4] #running-req: 1, #token: 14016,  token_usage: 0.09, #prealloc-req: 0,  #transfer-req: 0
[DP5] #running-req: 2, #token: 150272, token_usage: 0.94, #prealloc-req: 0,  #transfer-req: 0
```

DP0 accumulated 21 prealloc requests that could not proceed to transfer because KV memory was exhausted (`token_usage: 0.67` + prealloc overhead). Meanwhile, DP2/DP4/DP6 had plenty of free memory but received no new requests.

## Root Cause

In `DPBudget.dispatch()`, when using the `TOTAL_TOKENS` method, the code selects the DP worker with the fewest `total_tokens`. However, after dispatching, it only applies a heuristic increment to `total_requests` (+1) but **not** to `total_tokens`:

```python
# Before fix
def dispatch(self, method: LoadBalanceMethod):
    ...
    # Increment the load of that worker by one as a heuristic
    self.total_requests[target_rank] += 1
    # ❌ total_tokens[target_rank] is NOT incremented
    return target_rank
```

The `total_tokens` values are only updated when a real load snapshot arrives from the scheduler via `update_budget()`. Between two snapshots, if multiple requests arrive in quick succession, `total_tokens[i]` remains stale and the same DP worker keeps getting selected — causing all requests to pile up on one worker.

### Why prealloc requests get stuck

Once too many requests accumulate on one DP worker:
1. `pop_preallocated()` checks `allocatable_tokens` before pre-allocating KV memory
2. With insufficient free KV memory, it `break`s out of the loop — requests stay in the prealloc queue
3. `transfer-req: 0` confirms no request can proceed to KV transfer
4. The prealloc queue keeps growing because the DP controller continues routing to this worker

## Fix

Add a heuristic token increment (`len(req.input_ids)`) to `total_tokens` after each dispatch, matching the same metric that `get_load()` reports for queued requests:

```python
def dispatch(self, method: LoadBalanceMethod, estimated_tokens: int = 0):
    ...
    self.total_requests[target_rank] += 1
    self.total_tokens[target_rank] += estimated_tokens  # ✅ New
    return target_rank
```

```python
def total_tokens_scheduler(self, req):
    estimated_tokens = len(req.input_ids)
    target_worker = self.dp_budget.dispatch(
        LoadBalanceMethod.TOTAL_TOKENS, estimated_tokens=estimated_tokens
    )
    self.workers[target_worker].send_pyobj(req)
```

### Why this is safe

- **Self-correcting**: `update_budget()` uses assignment (`=`), not accumulation (`+=`). When the next real load snapshot arrives from the scheduler, `total_tokens[rank]` is overwritten with the true value. The heuristic increment only bridges the gap between snapshots and never drifts permanently.
- **Consistent metric**: `len(req.input_ids)` matches what `get_load()` reports for queued requests (`req.seqlen` = `len(origin_input_ids) + len(output_ids)`, and for new requests `output_ids` is empty).
- **Backward compatible**: `estimated_tokens` defaults to `0`, so other callers (`TOTAL_REQUESTS`, `ROUND_ROBIN`) are unaffected.


CC @ShangmingCai @hnyls2002 