### PR TITLE
[Bugfix] Fix dead code in marlin atomicAdd control and add 8-bit GPTQ test coverage

### DIFF
--- a/python/sglang/jit_kernel/tests/test_gptq_marlin.py
+++ b/python/sglang/jit_kernel/tests/test_gptq_marlin.py
@@ -22,10 +22,11 @@ MNK_FACTORS = [
 
 @pytest.mark.parametrize("k_chunk", [128])
 @pytest.mark.parametrize("n_chunk", [64, 256])
-@pytest.mark.parametrize("quant_type", [scalar_types.uint4, scalar_types.uint4b8])
+@pytest.mark.parametrize("quant_type", [scalar_types.uint4, scalar_types.uint4b8, scalar_types.uint8b128])
 @pytest.mark.parametrize("group_size", [-1, 128])
 @pytest.mark.parametrize("mnk_factors", MNK_FACTORS)
 @pytest.mark.parametrize("act_order", [False, True])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 def test_gptq_marlin_gemm(
     k_chunk,
     n_chunk,
@@ -33,6 +34,7 @@ def test_gptq_marlin_gemm(
     group_size,
     mnk_factors,
     act_order,
+    dtype,
 ):
     m_factor, n_factor, k_factor = mnk_factors
     has_zp = quant_type in [scalar_types.uint4, scalar_types.uint8]
@@ -52,8 +54,8 @@ def test_gptq_marlin_gemm(
     if size_k % group_size != 0:
         return
 
-    a_input = torch.randn((size_m, size_k), dtype=torch.float16, device="cuda")
-    b_weight = torch.randn((size_k, size_n), dtype=torch.float16, device="cuda")
+    a_input = torch.randn((size_m, size_k), dtype=dtype, device="cuda")
+    b_weight = torch.randn((size_k, size_n), dtype=dtype, device="cuda")
 
     if has_zp:
         w_ref, marlin_q_w, marlin_s, marlin_zp = awq_marlin_quantize(

--- a/python/sglang/jit_kernel/tests/test_gptq_marlin_repack.py
+++ b/python/sglang/jit_kernel/tests/test_gptq_marlin_repack.py
@@ -33,7 +33,7 @@ MNK_FACTORS = [
 
 @pytest.mark.parametrize("k_chunk", MARLIN_K_CHUNKS)
 @pytest.mark.parametrize("n_chunk", MARLIN_N_CHUNKS)
-@pytest.mark.parametrize("quant_type", [scalar_types.uint4b8])
+@pytest.mark.parametrize("quant_type", [scalar_types.uint4b8, scalar_types.uint8b128])
 @pytest.mark.parametrize("group_size", [-1, 32, 64, 128])
 @pytest.mark.parametrize("act_order", [False, True])
 @pytest.mark.parametrize("mnk_factors", MNK_FACTORS)

--- a/python/sglang/srt/layers/quantization/marlin_utils.py
+++ b/python/sglang/srt/layers/quantization/marlin_utils.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -423,16 +424,14 @@ def maybe_warn_marlin_atomic_add(device, dtype):
 def maybe_warn_marlin_atomic_add_env():
     if torch.compiler.is_dynamo_compiling():
         return
-    # TODO(yiyun): Need to add sglang's MARLIN_USE_ATOMIC_ADD: bool = False
-    if True:
+    use_atomic_add = os.environ.get("SGLANG_MARLIN_USE_ATOMIC_ADD", "0") == "1"
+    if use_atomic_add:
         return
-    # if envs.VLLM_MARLIN_USE_ATOMIC_ADD:
-    #     return
     logger.info_once(
         "Marlin kernel can achieve better performance for small size_n "
         "with experimental use_atomic_add feature. "
         "You can consider set environment variable "
-        "VLLM_MARLIN_USE_ATOMIC_ADD to 1 if possible."
+        "SGLANG_MARLIN_USE_ATOMIC_ADD to 1 if possible."
     )
 
 
@@ -446,9 +445,9 @@ def should_use_atomic_add_reduce(
         return False
 
     # disable atomicAdd reduce by default,
-    # one can enable it with VLLM_MARLIN_USE_ATOMIC_ADD=1
-    # TODO: Need to add sglang's MARLIN_USE_ATOMIC_ADD: bool = False
-    if not True:
+    # one can enable it with SGLANG_MARLIN_USE_ATOMIC_ADD=1
+    use_atomic_add = os.environ.get("SGLANG_MARLIN_USE_ATOMIC_ADD", "0") == "1"
+    if not use_atomic_add:
         maybe_warn_marlin_atomic_add_env()
         return False
 


### PR DESCRIPTION
## Motivation

Related to #22242.

8-bit GPTQ models (e.g., Qwen3-14B quantized with GPTQModel at `bits=8, sym=true`) produce garbled output (repeated `<think>` tokens) when auto-converted to `gptq_marlin` at runtime. The same checkpoint works correctly in vLLM. Multiple users confirmed on L20 and 4090 GPUs.

This PR addresses two issues found during investigation:

1. **Dead code in atomicAdd control** -- `marlin_utils.py` has `if not True:` (dead code from vLLM decoupling commit `c28ad199`) that makes atomicAdd always enabled, deviating from vLLM's default (disabled). While this does not directly affect configs where `n >= 2048` (most LLM layers), it is a correctness bug for SM>=90 + small-n workloads.

2. **Zero 8-bit GPTQ test coverage** -- JIT kernel GEMM and repack tests only covered 4-bit types. The 8-bit marlin path was never verified, which is likely where the root cause lies.

## Modifications

1. **`python/sglang/srt/layers/quantization/marlin_utils.py`**:
   - Fixed `maybe_warn_marlin_atomic_add_env()`: replaced `if True: return` stub with `SGLANG_MARLIN_USE_ATOMIC_ADD` env var check (default `0` = disabled)
   - Fixed `should_use_atomic_add_reduce()`: replaced `if not True:` dead code with proper env var check, matching vLLM's default behavior
   - Cleaned up stale vLLM references in comments and log messages
   - Added `import os`

2. **`python/sglang/jit_kernel/tests/test_gptq_marlin.py`**:
   - Added `scalar_types.uint8b128` to GEMM test quant types
   - Added `dtype` parametrize (`float16` + `bfloat16`)

3. **`python/sglang/jit_kernel/tests/test_gptq_marlin_repack.py`**:
   - Added `scalar_types.uint8b128` to repack test quant types

## How do we know it works?

- The atomicAdd fix restores the intended behavior documented in the original TODO comments
- The 8-bit + bfloat16 test additions will verify the JIT kernel produces correct numerical results for `uint8b128` -- if the kernel has an 8-bit-specific bug, these tests will fail in CI
- Existing 4-bit tests continue to pass (no behavioral change for 4-bit models)

## Workaround

Users hitting garbled output with 8-bit GPTQ can pass `--quantization gptq` to bypass the `gptq_marlin` auto-conversion until the root cause is fully resolved.

cc @BBuf @Fridge003
