### PR TITLE
[Optimization] Strip thinking tokens from radix cache for reasoning models

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -242,6 +242,9 @@ class ModelConfig:
         self.hf_eos_token_id = self._get_hf_eos_token_id()
         # Set by scheduler when reasoning_parser is enabled
         self.think_end_id: Optional[int] = None
+        # Whether to strip thinking tokens from radix cache on completion.
+        # Controlled per-parser; False for minimax-append-think.
+        self.strip_thinking_from_cache: bool = True
 
         # multimodal
         self.image_token_id = getattr(

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -643,6 +643,9 @@ class Req(ReqDllmMixin):
         # State indicating whether the reasoning phase has finished (only meaningful when require_reasoning is True)
         self._is_reasoning_over = False
         self.reasoning_tokens = 0
+        # Per-request flag: whether to strip thinking tokens from cache.
+        # Set from model_config by scheduler; defaults True for safety.
+        self.strip_thinking_from_cache: bool = True
 
         # Sampling info
         if isinstance(sampling_params.custom_params, dict):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -572,6 +572,9 @@ class Scheduler(
             self.model_config.think_end_id = self.tokenizer.encode(
                 reasoning_parser.detector.think_end_token, add_special_tokens=False
             )[0]
+            self.model_config.strip_thinking_from_cache = (
+                reasoning_parser.detector.strip_thinking_from_cache
+            )
 
     def init_mamba_backend(self) -> None:
         initialize_mamba_selective_state_update_backend(self.server_args)
@@ -2013,6 +2016,8 @@ class Scheduler(
                 )
 
     def _add_request_to_queue(self, req: Req, is_retracted: bool = False):
+        # Propagate per-parser cache stripping flag to request
+        req.strip_thinking_from_cache = self.model_config.strip_thinking_from_cache
         if self.disaggregation_mode == DisaggregationMode.NULL:
             if not self._set_or_validate_priority(req):
                 return

--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -530,6 +530,17 @@ class MambaRadixCache(BasePrefixCache):
             req.req_pool_idx, :kv_committed_len
         ]
 
+        # Strip thinking tokens: their KV entries are unreachable in multi-turn
+        # and answer tokens have wrong RoPE positions for cache reuse.
+        # Gated by strip_thinking_from_cache: some parsers (e.g.
+        # minimax-append-think) need thinking tokens in the cache.
+        if is_insert and req.reasoning_tokens > 0 and req.strip_thinking_from_cache:
+            prompt_len = min(len(req.origin_input_ids), len(token_ids))
+            # Free output token KV entries that won't be inserted into the cache
+            self.token_to_kv_pool_allocator.free(kv_indices[prompt_len:])
+            token_ids = token_ids[:prompt_len]
+            kv_indices = kv_indices[:prompt_len]
+
         if is_insert:
             cache_len = (
                 req.mamba_last_track_seqlen
@@ -538,6 +549,8 @@ class MambaRadixCache(BasePrefixCache):
             )
             if cache_len is None:
                 cache_len = 0
+            # Clamp to truncated length after thinking token strip
+            cache_len = min(cache_len, len(token_ids))
             if cache_len != len(token_ids):
                 cache_end_idx = max(cache_len, req.cache_protected_len)
                 self.token_to_kv_pool_allocator.free(kv_indices[cache_end_idx:])

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -479,6 +479,17 @@ class RadixCache(BasePrefixCache):
             req.req_pool_idx, : len(token_ids)
         ]
 
+        # Strip thinking tokens: their KV entries are unreachable in multi-turn
+        # and answer tokens have wrong RoPE positions for cache reuse.
+        # Gated by strip_thinking_from_cache: some parsers (e.g.
+        # minimax-append-think) need thinking tokens in the cache.
+        if is_insert and req.reasoning_tokens > 0 and req.strip_thinking_from_cache:
+            prompt_len = min(len(req.origin_input_ids), len(token_ids))
+            # Free output token KV entries that won't be inserted into the cache
+            self.token_to_kv_pool_allocator.free(kv_indices[prompt_len:])
+            token_ids = token_ids[:prompt_len]
+            kv_indices = kv_indices[:prompt_len]
+
         # Maybe convert to bigram keys for EAGLE
         keys = convert_to_bigram_key(token_ids) if self.is_eagle else token_ids
         keys = page_align_keys(keys, self.page_size)

--- a/python/sglang/srt/mem_cache/radix_cache_cpp.py
+++ b/python/sglang/srt/mem_cache/radix_cache_cpp.py
@@ -177,6 +177,18 @@ class RadixCacheCpp(BasePrefixCache):
             req.req_pool_idx, :kv_committed_len
         ].to(dtype=torch.int64, copy=True)
 
+        # Strip thinking tokens: their KV entries are unreachable in multi-turn
+        # and answer tokens have wrong RoPE positions for cache reuse.
+        # Gated by strip_thinking_from_cache: some parsers (e.g.
+        # minimax-append-think) need thinking tokens in the cache.
+        if is_insert and req.reasoning_tokens > 0 and req.strip_thinking_from_cache:
+            prompt_len = min(len(req.origin_input_ids), len(token_ids))
+            # Free output token KV entries that won't be inserted into the cache
+            self.token_to_kv_pool_allocator.free(kv_indices[prompt_len:])
+            token_ids = token_ids[:prompt_len]
+            kv_indices = kv_indices[:prompt_len]
+            kv_committed_len = prompt_len
+
         # NOTE: our C++ implementation don't need `token_ids` and `kv_indices` to be page-aligned
         # it will automatically align them, but length of them should be equal
         old_prefix_len = len(req.prefix_indices) // self.page_size * self.page_size

--- a/python/sglang/srt/mem_cache/storage/lmcache/lmc_radix_cache.py
+++ b/python/sglang/srt/mem_cache/storage/lmcache/lmc_radix_cache.py
@@ -235,6 +235,14 @@ class LMCRadixCache(RadixCache):
             req.req_pool_idx, :kv_committed_len
         ]
 
+        # Strip thinking tokens: consistent with radix tree truncation in base
+        # class. Output KV entries are already freed by super(), so we must not
+        # pass stale indices to LMCache.
+        if is_insert and req.reasoning_tokens > 0 and req.strip_thinking_from_cache:
+            prompt_len = min(len(req.origin_input_ids), len(token_ids))
+            token_ids = token_ids[:prompt_len]
+            kv_indices = kv_indices[:prompt_len]
+
         match_result = self.match_prefix(
             MatchPrefixParams(key=RadixKey(token_ids, req.extra_key))
         )

--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
@@ -456,6 +456,17 @@ class SWARadixCache(BasePrefixCache):
             req.req_pool_idx, :kv_committed_len
         ]
 
+        # Strip thinking tokens: their KV entries are unreachable in multi-turn
+        # and answer tokens have wrong RoPE positions for cache reuse.
+        # Gated by strip_thinking_from_cache: some parsers (e.g.
+        # minimax-append-think) need thinking tokens in the cache.
+        if is_insert and req.reasoning_tokens > 0 and req.strip_thinking_from_cache:
+            prompt_len = min(len(req.origin_input_ids), len(token_ids))
+            # Free output token KV entries that won't be inserted into the cache
+            self.token_to_kv_pool_allocator.free(kv_indices[prompt_len:])
+            token_ids = token_ids[:prompt_len]
+            kv_indices = kv_indices[:prompt_len]
+
         # Maybe convert to bigram keys for EAGLE
         keys = self.key_convert_fn(token_ids)
         keys = page_align_keys(keys, self.page_size)

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -313,6 +313,11 @@ class UnifiedRadixCache(BasePrefixCache):
         if is_insert:
             insert_params = InsertParams(prev_prefix_len=req.cache_protected_len)
 
+            # TODO: Add strip_thinking_from_cache gating here when unified cache
+            # supports reasoning parsers. Without this, thinking tokens from
+            # deepseek-r1 style parsers will pollute the cache with unreachable
+            # entries (see radix_cache.py:486 for reference implementation).
+
             # components prepare insert data + return effective cache_len
             effective_cache_len = len(token_ids)
             for comp in self._components_tuple:

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -19,6 +19,13 @@ class StreamingParseResult:
 class BaseReasoningFormatDetector:
     """Base class providing two sets of interfaces: one-time and streaming incremental."""
 
+    # Whether to strip thinking tokens from the radix cache on completion.
+    # True for most parsers (e.g. deepseek-r1): thinking tokens create
+    # unreachable cache entries with wrong RoPE positions.
+    # Override to False for parsers like minimax-append-think where
+    # thinking tokens are part of the visible output and should be cached.
+    strip_thinking_from_cache: bool = True
+
     def __init__(
         self,
         think_start_token: str,
@@ -394,6 +401,10 @@ class MiniMaxAppendThinkDetector(BaseReasoningFormatDetector):
     """
     Append `<think>` token to the beginning of the text.
     """
+
+    # Thinking tokens are prepended to visible output and must be cached
+    # for correct multi-turn prefix matching.
+    strip_thinking_from_cache: bool = False
 
     def __init__(
         self,

--- a/test/registered/unit/mem_cache/test_radix_cache_thinking.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_thinking.py
@@ -1,0 +1,474 @@
+"""Regression tests for SGLang issue #22373.
+
+Problem: cache_finished_req() in radix_cache.py used to insert thinking
+tokens (<think>...</think>) AND subsequent answer tokens into the radix
+tree.  In multi-turn reasoning, Turn 2's prompt is [prompt + answer]
+(no thinking tokens), so the cached [prompt + thinking + answer] sequence
+creates unreachable dead entries that waste KV cache memory.  Worse,
+answer tokens after thinking have incorrect RoPE positions and cannot be
+reused.
+
+Fix: When req.reasoning_tokens > 0, cache_finished_req truncates
+token_ids and kv_indices to the prompt prefix (origin_input_ids) only,
+preventing BOTH thinking and answer tokens from being cached.
+
+These tests are CPU-only, no model or GPU required.
+Run with:
+    python -m pytest test/registered/unit/mem_cache/test_radix_cache_thinking.py -v
+"""
+
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=8, suite="stage-b-test-1-gpu-small")
+register_amd_ci(est_time=5, suite="stage-b-test-1-gpu-small-amd")
+
+import unittest
+
+import torch
+
+from sglang.srt.mem_cache.base_prefix_cache import (
+    MatchPrefixParams,
+)
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey
+
+# ---------------------------------------------------------------------------
+# Mock infrastructure
+# ---------------------------------------------------------------------------
+
+
+class _MockReqToTokenPool:
+    """Minimal mock matching the req_to_token_pool interface used by
+    cache_finished_req: ``pool.req_to_token[idx, :n]`` returns a tensor."""
+
+    def __init__(self, max_reqs: int = 4, max_seq_len: int = 128):
+        self.req_to_token = torch.zeros((max_reqs, max_seq_len), dtype=torch.int64)
+
+
+class _MockAllocator:
+    """Mock KV pool allocator that records every free() call."""
+
+    def __init__(self):
+        self.freed: list[torch.Tensor] = []
+        self.device = torch.device("cpu")
+
+    def alloc(self, n: int) -> torch.Tensor:
+        return torch.arange(n, dtype=torch.int64)
+
+    def free(self, indices: torch.Tensor):
+        if isinstance(indices, torch.Tensor) and indices.numel() > 0:
+            self.freed.append(indices.clone())
+
+    def available_size(self) -> int:
+        return 999_999
+
+
+class _MockReq:
+    """Simulated Req with all attributes accessed by cache_finished_req."""
+
+    def __init__(self):
+        self._kv_committed_len: int = 0
+        self.kv_committed_freed: bool = False
+        self.origin_input_ids: list[int] = []
+        self.output_ids: list[int] = []
+        self.req_pool_idx: int = 0
+        self.extra_key = None
+        self.last_node = None  # set to cache.root_node before use
+        self.cache_protected_len: int = 0
+        self.priority: int = 0
+
+        # Reasoning attributes (mirroring Req in schedule_batch.py)
+        self.require_reasoning: bool = False
+        self.reasoning_tokens: int = 0
+        self._is_reasoning_over: bool = False
+        self.strip_thinking_from_cache: bool = True
+
+    def pop_committed_kv_cache(self) -> int:
+        assert not self.kv_committed_freed
+        self.kv_committed_freed = True
+        return self._kv_committed_len
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Arbitrary token IDs — not tied to any real tokenizer.
+PROMPT_TOKENS = [10, 20, 30]
+THINKING_TOKENS = [50, 100, 101, 51]  # 4 thinking tokens
+ANSWER_TOKENS = [200, 201]
+OUTPUT_WITH_THINKING = THINKING_TOKENS + ANSWER_TOKENS  # 6 tokens
+
+
+def _make_cache() -> tuple[RadixCache, _MockReqToTokenPool, _MockAllocator]:
+    """Create a RadixCache wired to mock pool + allocator."""
+    allocator = _MockAllocator()
+    pool = _MockReqToTokenPool()
+    params = CacheInitParams(
+        disable=False,
+        req_to_token_pool=pool,
+        token_to_kv_pool_allocator=allocator,
+        page_size=1,
+    )
+    cache = RadixCache(params)
+    return cache, pool, allocator
+
+
+def _prepare_req(
+    cache: RadixCache,
+    pool: _MockReqToTokenPool,
+    prompt: list[int],
+    output: list[int],
+    *,
+    reasoning_tokens: int = 0,
+    require_reasoning: bool = False,
+    req_pool_idx: int = 0,
+    kv_base: int = 100,
+) -> _MockReq:
+    """Build a _MockReq, write KV indices into the pool, and return it.
+
+    KV indices are ``[kv_base, kv_base+1, ..., kv_base+total_len-1]`` so
+    each position has a unique, traceable value.
+    """
+    req = _MockReq()
+    req.origin_input_ids = list(prompt)
+    req.output_ids = list(output)
+    req.require_reasoning = require_reasoning
+    req.reasoning_tokens = reasoning_tokens
+    req.req_pool_idx = req_pool_idx
+
+    total_len = len(prompt) + len(output)
+    req._kv_committed_len = total_len
+
+    kv_indices = torch.arange(kv_base, kv_base + total_len, dtype=torch.int64)
+    pool.req_to_token[req_pool_idx, :total_len] = kv_indices
+
+    req.last_node = cache.root_node
+    return req
+
+
+def _all_freed(allocator: _MockAllocator) -> set[int]:
+    """Flatten every free() call into a single set of ints."""
+    result: set[int] = set()
+    for t in allocator.freed:
+        result.update(t.tolist())
+    return result
+
+
+# ===================================================================
+# Test Suite 1: Thinking tokens stripped — only prompt prefix cached
+# ===================================================================
+
+
+class TestThinkingStrip(unittest.TestCase):
+    """When reasoning_tokens > 0, cache_finished_req must cache ONLY the
+    prompt prefix (origin_input_ids).  Both thinking and answer tokens
+    are excluded because answer tokens have wrong RoPE positions."""
+
+    def test_thinking_tokens_stripped_from_cache(self):
+        """With reasoning_tokens > 0, only the prompt prefix is in the tree."""
+        cache, pool, alloc = _make_cache()
+        req = _prepare_req(
+            cache,
+            pool,
+            prompt=PROMPT_TOKENS,
+            output=OUTPUT_WITH_THINKING,
+            reasoning_tokens=len(THINKING_TOKENS),
+        )
+
+        cache.cache_finished_req(req, is_insert=True)
+
+        # Tree should contain exactly the prompt prefix
+        self.assertEqual(cache.total_size(), len(PROMPT_TOKENS))
+
+        # Match against prompt → full hit
+        match = cache.match_prefix(MatchPrefixParams(key=RadixKey(PROMPT_TOKENS)))
+        self.assertEqual(len(match.device_indices), len(PROMPT_TOKENS))
+
+        # Match against prompt + thinking → still only prompt hit
+        match = cache.match_prefix(
+            MatchPrefixParams(key=RadixKey(PROMPT_TOKENS + THINKING_TOKENS))
+        )
+        self.assertEqual(len(match.device_indices), len(PROMPT_TOKENS))
+
+        # Match against prompt + answer → still only prompt hit
+        match = cache.match_prefix(
+            MatchPrefixParams(key=RadixKey(PROMPT_TOKENS + ANSWER_TOKENS))
+        )
+        self.assertEqual(len(match.device_indices), len(PROMPT_TOKENS))
+
+    def test_cached_kv_indices_are_prompt_only(self):
+        """KV indices in the tree must correspond to prompt positions only."""
+        cache, pool, alloc = _make_cache()
+        req = _prepare_req(
+            cache,
+            pool,
+            prompt=PROMPT_TOKENS,
+            output=OUTPUT_WITH_THINKING,
+            reasoning_tokens=len(THINKING_TOKENS),
+            kv_base=100,
+        )
+
+        cache.cache_finished_req(req, is_insert=True)
+
+        match = cache.match_prefix(MatchPrefixParams(key=RadixKey(PROMPT_TOKENS)))
+        # Prompt positions 0,1,2 → KV indices 100,101,102
+        expected_kv = torch.tensor([100, 101, 102], dtype=torch.int64)
+        torch.testing.assert_close(match.device_indices, expected_kv)
+
+
+# ===================================================================
+# Test Suite 2: Multi-turn prefix matching
+# ===================================================================
+
+
+class TestMultiTurnPrefixMatch(unittest.TestCase):
+    """After stripping, Turn 2 should hit the cached prompt prefix."""
+
+    def test_multiturn_prefix_match_after_fix(self):
+        """Turn 1 caches only prompt.  Turn 2's match_prefix with
+        [prompt + answer + new_user_tokens] hits exactly the prompt."""
+        cache, pool, alloc = _make_cache()
+
+        # Turn 1: reasoning request
+        req1 = _prepare_req(
+            cache,
+            pool,
+            prompt=PROMPT_TOKENS,  # [10, 20, 30]
+            output=OUTPUT_WITH_THINKING,  # [50,100,101,51, 200,201]
+            reasoning_tokens=len(THINKING_TOKENS),
+        )
+        cache.cache_finished_req(req1, is_insert=True)
+
+        # Only prompt prefix should be cached
+        self.assertEqual(cache.total_size(), len(PROMPT_TOKENS))
+
+        # Turn 2: new request shares prompt prefix + answer + new user tokens
+        turn2_tokens = PROMPT_TOKENS + ANSWER_TOKENS + [40, 50]
+        match = cache.match_prefix(MatchPrefixParams(key=RadixKey(turn2_tokens)))
+        # Should match exactly the 3-token prompt prefix
+        self.assertEqual(len(match.device_indices), len(PROMPT_TOKENS))
+
+    def test_thinking_in_query_no_spurious_match(self):
+        """Thinking tokens in a lookup key don't match anything beyond prompt."""
+        cache, pool, alloc = _make_cache()
+        req1 = _prepare_req(
+            cache,
+            pool,
+            prompt=PROMPT_TOKENS,
+            output=OUTPUT_WITH_THINKING,
+            reasoning_tokens=len(THINKING_TOKENS),
+        )
+        cache.cache_finished_req(req1, is_insert=True)
+
+        # Wrong query that includes thinking tokens
+        wrong_query = PROMPT_TOKENS + OUTPUT_WITH_THINKING + [40, 50]
+        match = cache.match_prefix(MatchPrefixParams(key=RadixKey(wrong_query)))
+        self.assertEqual(
+            len(match.device_indices),
+            len(PROMPT_TOKENS),
+            "Thinking tokens in query should not extend match past prompt",
+        )
+
+
+# ===================================================================
+# Test Suite 3: Backward compatibility (no reasoning)
+# ===================================================================
+
+
+class TestBackwardCompat(unittest.TestCase):
+    """Non-reasoning requests must cache ALL tokens unchanged."""
+
+    def test_no_reasoning_tokens_caches_all(self):
+        """reasoning_tokens=0 → every token is cached."""
+        cache, pool, alloc = _make_cache()
+        all_tokens = PROMPT_TOKENS + OUTPUT_WITH_THINKING  # 9 tokens
+
+        req = _prepare_req(
+            cache,
+            pool,
+            prompt=PROMPT_TOKENS,
+            output=OUTPUT_WITH_THINKING,
+            reasoning_tokens=0,
+        )
+
+        cache.cache_finished_req(req, is_insert=True)
+
+        self.assertEqual(cache.total_size(), len(all_tokens))
+
+        match = cache.match_prefix(MatchPrefixParams(key=RadixKey(all_tokens)))
+        self.assertEqual(len(match.device_indices), len(all_tokens))
+
+    def test_zero_reasoning_tokens_with_require_reasoning_false(self):
+        """Non-reasoning request: reasoning_tokens=0, require_reasoning=False.
+        All tokens should be cached."""
+        cache, pool, alloc = _make_cache()
+        prompt = [10, 20, 30, 40]
+        output = [50, 60]
+        all_tokens = prompt + output
+
+        req = _prepare_req(
+            cache,
+            pool,
+            prompt=prompt,
+            output=output,
+            reasoning_tokens=0,
+            require_reasoning=False,
+        )
+
+        cache.cache_finished_req(req, is_insert=True)
+
+        self.assertEqual(cache.total_size(), len(all_tokens))
+
+        match = cache.match_prefix(MatchPrefixParams(key=RadixKey(all_tokens)))
+        self.assertEqual(len(match.device_indices), len(all_tokens))
+
+
+# ===================================================================
+# Test Suite 4: Edge cases
+# ===================================================================
+
+
+class TestEdgeCases(unittest.TestCase):
+
+    def test_all_output_is_thinking(self):
+        """Model stops mid-thinking: reasoning_tokens == len(output_ids).
+        Only prompt prefix should be cached."""
+        cache, pool, alloc = _make_cache()
+        thinking = [50, 100, 101, 102]
+
+        req = _prepare_req(
+            cache,
+            pool,
+            prompt=PROMPT_TOKENS,
+            output=thinking,
+            reasoning_tokens=len(thinking),
+        )
+
+        cache.cache_finished_req(req, is_insert=True)
+
+        self.assertEqual(cache.total_size(), len(PROMPT_TOKENS))
+
+        # Thinking tokens not reachable
+        match = cache.match_prefix(
+            MatchPrefixParams(key=RadixKey(PROMPT_TOKENS + thinking))
+        )
+        self.assertEqual(len(match.device_indices), len(PROMPT_TOKENS))
+
+    def test_empty_output(self):
+        """No output tokens, reasoning_tokens=0 — only prompt cached."""
+        cache, pool, alloc = _make_cache()
+
+        req = _prepare_req(
+            cache,
+            pool,
+            prompt=PROMPT_TOKENS,
+            output=[],
+            reasoning_tokens=0,
+        )
+
+        cache.cache_finished_req(req, is_insert=True)
+
+        self.assertEqual(cache.total_size(), len(PROMPT_TOKENS))
+
+        match = cache.match_prefix(MatchPrefixParams(key=RadixKey(PROMPT_TOKENS)))
+        self.assertEqual(len(match.device_indices), len(PROMPT_TOKENS))
+
+    def test_long_thinking_short_answer(self):
+        """Very long thinking block, single answer token.
+        Only prompt prefix cached."""
+        cache, pool, alloc = _make_cache()
+        long_think = [50] + list(range(1000, 1050)) + [51]
+        short_answer = [200]
+
+        req = _prepare_req(
+            cache,
+            pool,
+            prompt=PROMPT_TOKENS,
+            output=long_think + short_answer,
+            reasoning_tokens=len(long_think),
+        )
+
+        cache.cache_finished_req(req, is_insert=True)
+
+        # Only prompt prefix cached (answer also excluded due to RoPE mismatch)
+        self.assertEqual(cache.total_size(), len(PROMPT_TOKENS))
+
+        match = cache.match_prefix(MatchPrefixParams(key=RadixKey(PROMPT_TOKENS)))
+        self.assertEqual(len(match.device_indices), len(PROMPT_TOKENS))
+
+
+# ===================================================================
+# Test Suite 5: Cache size metrics
+# ===================================================================
+
+
+class TestCacheSize(unittest.TestCase):
+    """total_size() must reflect only cached tokens."""
+
+    def test_cache_size_prompt_only_with_thinking(self):
+        """With reasoning, cache size = prompt length only."""
+        cache, pool, alloc = _make_cache()
+        req = _prepare_req(
+            cache,
+            pool,
+            prompt=PROMPT_TOKENS,
+            output=OUTPUT_WITH_THINKING,
+            reasoning_tokens=len(THINKING_TOKENS),
+        )
+
+        cache.cache_finished_req(req, is_insert=True)
+
+        self.assertEqual(
+            cache.total_size(),
+            len(PROMPT_TOKENS),
+            "Cache size should equal prompt length when reasoning active",
+        )
+
+    def test_cache_size_all_tokens_without_reasoning(self):
+        """Without reasoning, cache size = all tokens."""
+        cache, pool, alloc = _make_cache()
+        req = _prepare_req(
+            cache,
+            pool,
+            prompt=PROMPT_TOKENS,
+            output=OUTPUT_WITH_THINKING,
+            reasoning_tokens=0,
+        )
+
+        cache.cache_finished_req(req, is_insert=True)
+
+        expected = len(PROMPT_TOKENS) + len(OUTPUT_WITH_THINKING)
+        self.assertEqual(cache.total_size(), expected)
+
+
+# ===================================================================
+# Test Suite 6: is_insert=False path
+# ===================================================================
+
+
+class TestInsertFalse(unittest.TestCase):
+    """When is_insert=False, nothing is inserted — only KV slots freed."""
+
+    def test_is_insert_false_frees_kv_and_empty_tree(self):
+        """is_insert=False → empty tree, KV slots freed."""
+        cache, pool, alloc = _make_cache()
+        req = _prepare_req(
+            cache,
+            pool,
+            prompt=PROMPT_TOKENS,
+            output=OUTPUT_WITH_THINKING,
+            reasoning_tokens=len(THINKING_TOKENS),
+        )
+
+        cache.cache_finished_req(req, is_insert=False)
+
+        self.assertEqual(cache.total_size(), 0, "is_insert=False → empty tree")
+
+        # KV slots should be freed (all non-protected)
+        freed = _all_freed(alloc)
+        self.assertGreater(len(freed), 0, "Some KV slots must be freed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_radix_cache_thinking_gated.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_thinking_gated.py
@@ -1,0 +1,683 @@
+"""Regression tests for gated thinking-token stripping (issue #22373, T2 fix).
+
+The T2 fix gates the thinking-token strip behind a per-parser flag
+``strip_thinking_from_cache``.  For most parsers (e.g. deepseek-r1) the
+flag is True: thinking tokens are stripped from the cache (same behaviour
+as the original fix).  For parsers like ``minimax-append-think``, the
+flag is False: thinking tokens are part of visible output and the full
+sequence is cached.
+
+These tests are CPU-only, no model or GPU required.
+Run with:
+    python -m pytest test/registered/unit/mem_cache/test_radix_cache_thinking_gated.py -v
+"""
+
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=8, suite="stage-b-test-1-gpu-small")
+register_amd_ci(est_time=5, suite="stage-b-test-1-gpu-small-amd")
+
+import unittest
+
+import torch
+
+from sglang.srt.mem_cache.base_prefix_cache import (
+    MatchPrefixParams,
+)
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey
+
+# ---------------------------------------------------------------------------
+# Mock infrastructure (mirrors test_radix_cache_thinking.py)
+# ---------------------------------------------------------------------------
+
+
+class _MockReqToTokenPool:
+    """Minimal mock matching the req_to_token_pool interface used by
+    cache_finished_req: ``pool.req_to_token[idx, :n]`` returns a tensor."""
+
+    def __init__(self, max_reqs: int = 4, max_seq_len: int = 256):
+        self.req_to_token = torch.zeros((max_reqs, max_seq_len), dtype=torch.int64)
+
+
+class _MockAllocator:
+    """Mock KV pool allocator that records every free() call."""
+
+    def __init__(self):
+        self.freed: list[torch.Tensor] = []
+        self.device = torch.device("cpu")
+
+    def alloc(self, n: int) -> torch.Tensor:
+        return torch.arange(n, dtype=torch.int64)
+
+    def free(self, indices: torch.Tensor):
+        if isinstance(indices, torch.Tensor) and indices.numel() > 0:
+            self.freed.append(indices.clone())
+
+    def available_size(self) -> int:
+        return 999_999
+
+
+class _MockReq:
+    """Simulated Req with all attributes accessed by cache_finished_req.
+
+    Extends the original mock with ``strip_thinking_from_cache`` — the new
+    per-request gating flag that controls whether thinking tokens are
+    stripped from the radix cache.
+    """
+
+    def __init__(self):
+        self._kv_committed_len: int = 0
+        self.kv_committed_freed: bool = False
+        self.origin_input_ids: list[int] = []
+        self.output_ids: list[int] = []
+        self.req_pool_idx: int = 0
+        self.extra_key = None
+        self.last_node = None
+        self.cache_protected_len: int = 0
+        self.priority: int = 0
+
+        # Reasoning attributes
+        self.require_reasoning: bool = False
+        self.reasoning_tokens: int = 0
+        self._is_reasoning_over: bool = False
+
+        # NEW: Parser-gated stripping flag.
+        # True  → strip thinking from cache (deepseek-r1, qwen3, etc.)
+        # False → keep thinking in cache   (minimax-append-think)
+        # Default is True (safe default: unknown parsers strip).
+        self.strip_thinking_from_cache: bool = True
+
+    def pop_committed_kv_cache(self) -> int:
+        assert not self.kv_committed_freed
+        self.kv_committed_freed = True
+        return self._kv_committed_len
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+PROMPT_TOKENS = [10, 20, 30]
+THINKING_TOKENS = [50, 100, 101, 51]  # 4 thinking tokens
+ANSWER_TOKENS = [200, 201]
+OUTPUT_WITH_THINKING = THINKING_TOKENS + ANSWER_TOKENS  # 6 tokens
+
+
+def _make_cache() -> tuple[RadixCache, _MockReqToTokenPool, _MockAllocator]:
+    """Create a RadixCache wired to mock pool + allocator."""
+    allocator = _MockAllocator()
+    pool = _MockReqToTokenPool()
+    params = CacheInitParams(
+        disable=False,
+        req_to_token_pool=pool,
+        token_to_kv_pool_allocator=allocator,
+        page_size=1,
+    )
+    cache = RadixCache(params)
+    return cache, pool, allocator
+
+
+def _prepare_req(
+    cache: RadixCache,
+    pool: _MockReqToTokenPool,
+    prompt: list[int],
+    output: list[int],
+    *,
+    reasoning_tokens: int = 0,
+    require_reasoning: bool = False,
+    strip_thinking_from_cache: bool = True,
+    req_pool_idx: int = 0,
+    kv_base: int = 100,
+) -> _MockReq:
+    """Build a _MockReq, write KV indices into the pool, and return it."""
+    req = _MockReq()
+    req.origin_input_ids = list(prompt)
+    req.output_ids = list(output)
+    req.require_reasoning = require_reasoning
+    req.reasoning_tokens = reasoning_tokens
+    req.strip_thinking_from_cache = strip_thinking_from_cache
+    req.req_pool_idx = req_pool_idx
+
+    total_len = len(prompt) + len(output)
+    req._kv_committed_len = total_len
+
+    kv_indices = torch.arange(kv_base, kv_base + total_len, dtype=torch.int64)
+    pool.req_to_token[req_pool_idx, :total_len] = kv_indices
+
+    req.last_node = cache.root_node
+    return req
+
+
+def _all_freed(allocator: _MockAllocator) -> set[int]:
+    """Flatten every free() call into a single set of ints."""
+    result: set[int] = set()
+    for t in allocator.freed:
+        result.update(t.tolist())
+    return result
+
+
+# ===================================================================
+# Test Suite 1: Gating — strip_thinking_from_cache=True (deepseek-r1)
+# ===================================================================
+
+
+class TestGatedStripTrue(unittest.TestCase):
+    """When strip_thinking_from_cache=True AND reasoning_tokens > 0,
+    thinking tokens ARE stripped — only prompt prefix is cached.
+    This is the deepseek-r1 / qwen3 / default behavior.
+
+    Status: Should PASS both before and after the fix (existing behavior).
+    """
+
+    def test_deepseek_style_strips_thinking(self):
+        """Parser=deepseek-r1 (strip=True): only prompt cached."""
+        cache, pool, alloc = _make_cache()
+        req = _prepare_req(
+            cache,
+            pool,
+            prompt=PROMPT_TOKENS,
+            output=OUTPUT_WITH_THINKING,
+            reasoning_tokens=len(THINKING_TOKENS),
+            strip_thinking_from_cache=True,  # deepseek-r1 behavior
+        )
+
+        cache.cache_finished_req(req, is_insert=True)
+
+        # Tree should contain exactly the prompt prefix
+        self.assertEqual(cache.total_size(), len(PROMPT_TOKENS))
+
+        # Thinking tokens not reachable
+        match = cache.match_prefix(
+            MatchPrefixParams(key=RadixKey(PROMPT_TOKENS + THINKING_TOKENS))
+        )
+        self.assertEqual(len(match.device_indices), len(PROMPT_TOKENS))
+
+    def test_deepseek_style_frees_output_kv(self):
+        """Parser=deepseek-r1 (strip=True): output KV indices are freed."""
+        cache, pool, alloc = _make_cache()
+        req = _prepare_req(
+            cache,
+            pool,
+            prompt=PROMPT_TOKENS,
+            output=OUTPUT_WITH_THINKING,
+            reasoning_tokens=len(THINKING_TOKENS),
+            strip_thinking_from_cache=True,
+            kv_base=100,
+        )
+
+        cache.cache_finished_req(req, is_insert=True)
+
+        # KV indices for output tokens (103..108) should be freed
+        freed = _all_freed(alloc)
+        prompt_len = len(PROMPT_TOKENS)
+        total_len = prompt_len + len(OUTPUT_WITH_THINKING)
+        expected_freed = set(range(100 + prompt_len, 100 + total_len))
+        self.assertTrue(
+            expected_freed.issubset(freed),
+            f"Output KV indices {expected_freed} should be freed, got {freed}",
+        )
+
+
+# ===================================================================
+# Test Suite 2: Gating — strip_thinking_from_cache=False (minimax)
+# ===================================================================
+
+
+class TestGatedStripFalse(unittest.TestCase):
+    """When strip_thinking_from_cache=False AND reasoning_tokens > 0,
+    thinking tokens are NOT stripped — the full sequence is cached.
+    This is the minimax-append-think behavior.
+
+    Status: FAIL before fix, PASS after fix.
+    Before fix: cache_finished_req ignores the flag and strips anyway.
+    """
+
+    def test_minimax_keeps_thinking_in_cache(self):
+        """Parser=minimax-append-think (strip=False): full output cached.
+
+        This is the core bug fix test. MiniMax includes thinking tokens
+        in its output, so they must remain in the cache for multi-turn
+        prefix matching to work.
+        """
+        cache, pool, alloc = _make_cache()
+        all_tokens = PROMPT_TOKENS + OUTPUT_WITH_THINKING  # 9 tokens
+
+        req = _prepare_req(
+            cache,
+            pool,
+            prompt=PROMPT_TOKENS,
+            output=OUTPUT_WITH_THINKING,
+            reasoning_tokens=len(THINKING_TOKENS),
+            strip_thinking_from_cache=False,  # minimax-append-think
+        )
+
+        cache.cache_finished_req(req, is_insert=True)
+
+        # Full sequence should be cached
+        self.assertEqual(
+            cache.total_size(),
+            len(all_tokens),
+            "minimax-append-think: full sequence (prompt+thinking+answer) "
+            "must be cached, not stripped",
+        )
+
+        # Full match against the complete sequence
+        match = cache.match_prefix(MatchPrefixParams(key=RadixKey(all_tokens)))
+        self.assertEqual(len(match.device_indices), len(all_tokens))
+
+    def test_minimax_kv_indices_are_complete(self):
+        """Parser=minimax-append-think: KV indices in tree span full sequence."""
+        cache, pool, alloc = _make_cache()
+        all_tokens = PROMPT_TOKENS + OUTPUT_WITH_THINKING
+
+        req = _prepare_req(
+            cache,
+            pool,
+            prompt=PROMPT_TOKENS,
+            output=OUTPUT_WITH_THINKING,
+            reasoning_tokens=len(THINKING_TOKENS),
+            strip_thinking_from_cache=False,
+            kv_base=100,
+        )
+
+        cache.cache_finished_req(req, is_insert=True)
+
+        match = cache.match_prefix(MatchPrefixParams(key=RadixKey(all_tokens)))
+        expected_kv = torch.arange(100, 100 + len(all_tokens), dtype=torch.int64)
+        torch.testing.assert_close(match.device_indices, expected_kv)
+
+    def test_minimax_no_output_kv_freed(self):
+        """Parser=minimax-append-think: NO output KV indices should be freed
+        (they're all inserted into the tree)."""
+        cache, pool, alloc = _make_cache()
+
+        req = _prepare_req(
+            cache,
+            pool,
+            prompt=PROMPT_TOKENS,
+            output=OUTPUT_WITH_THINKING,
+            reasoning_tokens=len(THINKING_TOKENS),
+            strip_thinking_from_cache=False,
+            kv_base=100,
+        )
+
+        cache.cache_finished_req(req, is_insert=True)
+
+        # The freed set should NOT contain any of the output KV indices
+        freed = _all_freed(alloc)
+        prompt_len = len(PROMPT_TOKENS)
+        total_len = prompt_len + len(OUTPUT_WITH_THINKING)
+        output_kv = set(range(100 + prompt_len, 100 + total_len))
+        wrongly_freed = freed & output_kv
+        self.assertEqual(
+            len(wrongly_freed),
+            0,
+            f"minimax-append-think: output KV indices should NOT be freed, "
+            f"but these were: {wrongly_freed}",
+        )
+
+
+# ===================================================================
+# Test Suite 3: MiniMax multi-turn prefix match
+# ===================================================================
+
+
+class TestMiniMaxMultiTurn(unittest.TestCase):
+    """MiniMax M2.5 multi-turn: Turn 2's prompt includes thinking tokens
+    from Turn 1 (they're part of the assistant message). The cache must
+    find a prefix match including those thinking tokens.
+
+    Status: FAIL before fix, PASS after fix.
+    """
+
+    def test_multiturn_thinking_prefix_match(self):
+        """Turn 1 caches [prompt + thinking + answer].
+        Turn 2 queries [prompt + thinking + answer + new_user_tokens].
+        Prefix match should cover the full Turn 1 output.
+
+        This directly tests the scenario described in issue #22373:
+        MiniMax appends thinking to the conversation, so Turn 2 sees
+        thinking tokens and expects them in the cache.
+        """
+        cache, pool, alloc = _make_cache()
+
+        # Turn 1: minimax-append-think request
+        req1 = _prepare_req(
+            cache,
+            pool,
+            prompt=PROMPT_TOKENS,
+            output=OUTPUT_WITH_THINKING,
+            reasoning_tokens=len(THINKING_TOKENS),
+            strip_thinking_from_cache=False,  # minimax-append-think
+        )
+        cache.cache_finished_req(req1, is_insert=True)
+
+        # Verify full Turn 1 is cached
+        turn1_all = PROMPT_TOKENS + OUTPUT_WITH_THINKING
+        self.assertEqual(cache.total_size(), len(turn1_all))
+
+        # Turn 2: new request extends the conversation
+        new_user_tokens = [300, 301, 302]
+        turn2_key = turn1_all + new_user_tokens
+        match = cache.match_prefix(MatchPrefixParams(key=RadixKey(turn2_key)))
+
+        # Should match the full Turn 1 sequence (9 tokens)
+        self.assertEqual(
+            len(match.device_indices),
+            len(turn1_all),
+            "Turn 2 should hit the full Turn 1 prefix including thinking",
+        )
+
+    def test_multiturn_thinking_stripped_no_match(self):
+        """Contrast: deepseek-r1 strips thinking → Turn 2 with thinking
+        tokens in key only matches the prompt prefix.
+
+        This shows the difference between the two parser behaviors.
+        """
+        cache, pool, alloc = _make_cache()
+
+        # Turn 1: deepseek-r1 request (strips thinking)
+        req1 = _prepare_req(
+            cache,
+            pool,
+            prompt=PROMPT_TOKENS,
+            output=OUTPUT_WITH_THINKING,
+            reasoning_tokens=len(THINKING_TOKENS),
+            strip_thinking_from_cache=True,  # deepseek-r1
+        )
+        cache.cache_finished_req(req1, is_insert=True)
+
+        # Only prompt cached
+        self.assertEqual(cache.total_size(), len(PROMPT_TOKENS))
+
+        # Turn 2 query with thinking → only prompt matches
+        turn2_key = PROMPT_TOKENS + OUTPUT_WITH_THINKING + [300]
+        match = cache.match_prefix(MatchPrefixParams(key=RadixKey(turn2_key)))
+        self.assertEqual(
+            len(match.device_indices),
+            len(PROMPT_TOKENS),
+            "deepseek-r1: Turn 2 sees only prompt prefix (thinking stripped)",
+        )
+
+
+# ===================================================================
+# Test Suite 4: Default safety — unknown parsers strip by default
+# ===================================================================
+
+
+class TestDefaultSafety(unittest.TestCase):
+    """The strip_thinking_from_cache flag defaults to True, so any
+    new/unknown parser gets the safe stripping behavior.
+
+    Status: Should PASS both before and after fix.
+    """
+
+    def test_default_flag_is_true(self):
+        """_MockReq.strip_thinking_from_cache defaults to True."""
+        req = _MockReq()
+        self.assertTrue(
+            req.strip_thinking_from_cache,
+            "Default must be True (strip) — safe for unknown parsers",
+        )
+
+    def test_unknown_parser_strips_thinking(self):
+        """A request with default strip_thinking_from_cache=True and
+        reasoning_tokens > 0 must strip thinking (safe default)."""
+        cache, pool, alloc = _make_cache()
+        req = _prepare_req(
+            cache,
+            pool,
+            prompt=PROMPT_TOKENS,
+            output=OUTPUT_WITH_THINKING,
+            reasoning_tokens=len(THINKING_TOKENS),
+            # strip_thinking_from_cache not set → defaults to True
+        )
+
+        cache.cache_finished_req(req, is_insert=True)
+
+        self.assertEqual(
+            cache.total_size(),
+            len(PROMPT_TOKENS),
+            "Unknown/default parser: must strip thinking (safe default)",
+        )
+
+
+# ===================================================================
+# Test Suite 5: Edge cases
+# ===================================================================
+
+
+class TestEdgeCases(unittest.TestCase):
+
+    def test_zero_reasoning_tokens_no_strip_regardless_of_flag(self):
+        """reasoning_tokens=0 → no stripping, even if strip flag is True.
+
+        Backward compatibility: non-reasoning requests always cache
+        the full sequence regardless of the flag setting.
+
+        Status: Should PASS both before and after fix.
+        """
+        cache, pool, alloc = _make_cache()
+        all_tokens = PROMPT_TOKENS + OUTPUT_WITH_THINKING
+
+        req = _prepare_req(
+            cache,
+            pool,
+            prompt=PROMPT_TOKENS,
+            output=OUTPUT_WITH_THINKING,
+            reasoning_tokens=0,  # no reasoning
+            strip_thinking_from_cache=True,  # flag is True but irrelevant
+        )
+
+        cache.cache_finished_req(req, is_insert=True)
+
+        self.assertEqual(
+            cache.total_size(),
+            len(all_tokens),
+            "reasoning_tokens=0 → all tokens cached, strip flag irrelevant",
+        )
+
+    def test_minimax_plain_parser_strips(self):
+        """Parser=minimax (NOT minimax-append-think) uses Qwen3Detector
+        which separates thinking from content. It SHOULD strip.
+
+        minimax → Qwen3Detector → strip_thinking_from_cache=True
+        minimax-append-think → MiniMaxAppendThinkDetector → False
+
+        Status: Should PASS both before and after fix.
+        """
+        cache, pool, alloc = _make_cache()
+        req = _prepare_req(
+            cache,
+            pool,
+            prompt=PROMPT_TOKENS,
+            output=OUTPUT_WITH_THINKING,
+            reasoning_tokens=len(THINKING_TOKENS),
+            strip_thinking_from_cache=True,  # minimax (plain) → strip
+        )
+
+        cache.cache_finished_req(req, is_insert=True)
+
+        self.assertEqual(
+            cache.total_size(),
+            len(PROMPT_TOKENS),
+            "minimax (plain) parser: must strip thinking like deepseek-r1",
+        )
+
+    def test_strip_flag_respected_per_request(self):
+        """Two sequential requests with different strip flags.
+        Verifies the flag is checked per-request, not cached globally.
+
+        Scenario: mixed deployment where parser might change between
+        requests (unusual but possible with dynamic routing).
+
+        Status: FAIL before fix (second req stripped), PASS after fix.
+        """
+        cache, pool, alloc = _make_cache()
+
+        # Request 1: strip=True (deepseek-r1 style)
+        req1 = _prepare_req(
+            cache,
+            pool,
+            prompt=[10, 20],
+            output=[50, 51, 200],  # 2 thinking + 1 answer
+            reasoning_tokens=2,
+            strip_thinking_from_cache=True,
+            req_pool_idx=0,
+            kv_base=100,
+        )
+        cache.cache_finished_req(req1, is_insert=True)
+
+        # Only prompt cached for req1
+        self.assertEqual(cache.total_size(), 2)
+
+        # Request 2: strip=False (minimax-append-think style), different prompt
+        req2 = _prepare_req(
+            cache,
+            pool,
+            prompt=[30, 40],
+            output=[60, 61, 201],  # 2 thinking + 1 answer
+            reasoning_tokens=2,
+            strip_thinking_from_cache=False,
+            req_pool_idx=1,
+            kv_base=200,
+        )
+        cache.cache_finished_req(req2, is_insert=True)
+
+        # req2's full sequence should be cached: prompt(2) + output(3) = 5
+        # Total: req1 prompt(2) + req2 full(5) = 7
+        self.assertEqual(
+            cache.total_size(),
+            7,
+            "Per-request flag: req1 stripped (2 tokens), req2 kept (5 tokens)",
+        )
+
+    def test_minimax_all_output_is_thinking(self):
+        """minimax-append-think: model outputs only thinking (no answer yet).
+        With strip=False, all tokens including thinking should be cached.
+
+        Status: FAIL before fix, PASS after fix.
+        """
+        cache, pool, alloc = _make_cache()
+        thinking_only = [50, 100, 101, 51]
+        all_tokens = PROMPT_TOKENS + thinking_only
+
+        req = _prepare_req(
+            cache,
+            pool,
+            prompt=PROMPT_TOKENS,
+            output=thinking_only,
+            reasoning_tokens=len(thinking_only),
+            strip_thinking_from_cache=False,  # minimax-append-think
+        )
+
+        cache.cache_finished_req(req, is_insert=True)
+
+        self.assertEqual(
+            cache.total_size(),
+            len(all_tokens),
+            "minimax-append-think: thinking-only output must be fully cached",
+        )
+
+    def test_zero_reasoning_minimax_caches_all(self):
+        """minimax-append-think with reasoning_tokens=0 (non-reasoning request).
+        Everything cached — same as any non-reasoning request.
+
+        Status: Should PASS both before and after fix.
+        """
+        cache, pool, alloc = _make_cache()
+        all_tokens = PROMPT_TOKENS + ANSWER_TOKENS
+
+        req = _prepare_req(
+            cache,
+            pool,
+            prompt=PROMPT_TOKENS,
+            output=ANSWER_TOKENS,
+            reasoning_tokens=0,
+            strip_thinking_from_cache=False,  # irrelevant when reasoning_tokens=0
+        )
+
+        cache.cache_finished_req(req, is_insert=True)
+
+        self.assertEqual(cache.total_size(), len(all_tokens))
+
+
+# ===================================================================
+# Test Suite 6: is_insert=False path with strip=False
+# ===================================================================
+
+
+class TestInsertFalseWithStripFalse(unittest.TestCase):
+    """When is_insert=False, nothing is inserted regardless of strip flag."""
+
+    def test_is_insert_false_ignores_strip_flag(self):
+        """is_insert=False → empty tree, KV slots freed, strip flag irrelevant.
+
+        Status: Should PASS both before and after fix.
+        """
+        cache, pool, alloc = _make_cache()
+        req = _prepare_req(
+            cache,
+            pool,
+            prompt=PROMPT_TOKENS,
+            output=OUTPUT_WITH_THINKING,
+            reasoning_tokens=len(THINKING_TOKENS),
+            strip_thinking_from_cache=False,  # would keep thinking if inserted
+        )
+
+        cache.cache_finished_req(req, is_insert=False)
+
+        self.assertEqual(cache.total_size(), 0, "is_insert=False → empty tree")
+
+        freed = _all_freed(alloc)
+        self.assertGreater(len(freed), 0, "Some KV slots must be freed")
+
+
+# ===================================================================
+# Test Suite 7: Detector class-level attribute verification
+# ===================================================================
+
+
+class TestDetectorClassAttributes(unittest.TestCase):
+    """Verify the strip_thinking_from_cache class attribute on detectors
+    and the ReasoningParser → detector → flag propagation chain."""
+
+    def test_base_detector_strip_is_true(self):
+        """BaseReasoningFormatDetector.strip_thinking_from_cache is True."""
+        from sglang.srt.parser.reasoning_parser import BaseReasoningFormatDetector
+
+        self.assertTrue(BaseReasoningFormatDetector.strip_thinking_from_cache)
+
+    def test_minimax_append_think_detector_strip_is_false(self):
+        """MiniMaxAppendThinkDetector.strip_thinking_from_cache is False."""
+        from sglang.srt.parser.reasoning_parser import MiniMaxAppendThinkDetector
+
+        self.assertFalse(MiniMaxAppendThinkDetector.strip_thinking_from_cache)
+
+    def test_minimax_parser_detector_strips(self):
+        """minimax → Qwen3Detector → inherits strip=True from base."""
+        from sglang.srt.parser.reasoning_parser import ReasoningParser
+
+        parser = ReasoningParser(model_type="minimax", stream_reasoning=False)
+        self.assertTrue(parser.detector.strip_thinking_from_cache)
+
+    def test_minimax_append_think_parser_detector_retains(self):
+        """minimax-append-think → MiniMaxAppendThinkDetector → strip=False."""
+        from sglang.srt.parser.reasoning_parser import ReasoningParser
+
+        parser = ReasoningParser(
+            model_type="minimax-append-think", stream_reasoning=False
+        )
+        self.assertFalse(parser.detector.strip_thinking_from_cache)
+
+    def test_deepseek_parser_detector_strips(self):
+        """deepseek-r1 → DeepSeekR1Detector → inherits strip=True."""
+        from sglang.srt.parser.reasoning_parser import ReasoningParser
+
+        parser = ReasoningParser(model_type="deepseek-r1", stream_reasoning=False)
+        self.assertTrue(parser.detector.strip_thinking_from_cache)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

When serving reasoning models (DeepSeek-R1, QwQ, etc.) with `--reasoning-parser`, all output tokens — including `<think>` tokens — are inserted into the radix tree on request completion. Since multi-turn prompts don't include thinking tokens (per [DeepSeek API docs](https://api-docs.deepseek.com/guides/thinking_mode) and SGLang's own chat completion behavior which drops `reasoning_content`), these cached entries create dead radix tree branches that:

1. **Waste GPU memory**: ~1.3-1.6 GB per dead branch (5000 thinking tokens × 256-320 KB/token)
2. **Block prefix matching**: Answer tokens stranded behind thinking branches are unreachable, forcing recomputation every turn

With 50 concurrent conversations, dead branches consume 65-80 GB competing with useful cache entries for eviction.

Fixes #22373.

## Modifications

When `req.reasoning_tokens > 0` (i.e., the request generated thinking tokens), truncate the cache insertion in `cache_finished_req` to the prompt prefix only (`origin_input_ids`), skipping all output tokens.

**Gated by parser type** (per @ishandhanani's feedback): only applied when the reasoning parser separates thinking from visible output. Models using interleaved thinking (e.g., `minimax-append-think` where `MiniMaxAppendThinkDetector` puts thinking into `normal_text`) are excluded — their thinking tokens ARE the visible content that appears in multi-turn prompts, so caching them is correct.

**Implementation**: Each `BaseReasoningFormatDetector` subclass declares `strip_thinking_from_cache: bool` (default `True`). The scheduler reads this at init, stores it on `model_config`, and propagates to each `Req`. Cache code checks `req.strip_thinking_from_cache` before truncating.

| Parser | Detector | Strips from cache? |
|--------|----------|-------------------|
| `deepseek-r1`, `qwen3`, `step3`, `kimi`, etc. | Standard detectors | ✅ Yes (thinking → `reasoning_text`, dropped from multi-turn) |
| `minimax-append-think` | `MiniMaxAppendThinkDetector` | ❌ No (thinking → `normal_text`, kept in multi-turn) |

**Why truncate to prompt prefix instead of splicing out thinking tokens and keeping answer tokens?**

Answer tokens' KV cache was computed with RoPE positional encoding at positions `[input_len + thinking_len, ...]`. In the next turn, the same answer tokens appear at positions `[input_len, ...]` (no thinking gap). This position mismatch means the cached KV would produce incorrect attention — so answer tokens cannot be safely reused across turns for reasoning models.

The prompt prefix positions are always consistent between requests, making it the only safely reusable portion.

**Files changed**:
- `python/sglang/srt/parser/reasoning_parser.py` — class-level `strip_thinking_from_cache` on detectors
- `python/sglang/srt/configs/model_config.py` — store flag
- `python/sglang/srt/managers/scheduler.py` — read from parser, propagate to req
- `python/sglang/srt/managers/schedule_batch.py` — per-request flag on `Req`
- `python/sglang/srt/mem_cache/radix_cache.py` — gate stripping
- `python/sglang/srt/mem_cache/radix_cache_cpp.py` — gate stripping
- `python/sglang/srt/mem_cache/swa_radix_cache.py` — gate stripping
- `python/sglang/srt/mem_cache/mamba_radix_cache.py` — gate stripping
- `python/sglang/srt/mem_cache/storage/lmcache/lmc_radix_cache.py` — gate stripping

Builds on @hnyls2002's `think_end_id` unification (#22148) which provides the `reasoning_tokens` counter infrastructure.

## Checklist
- [ ] Format: `pre-commit run --all-files`
- [ ] Unit tests added for thinking token stripping
- [x] Gated by parser type — interleaved-thinking models (`minimax-append-think`) excluded
- [ ] Backward compatible: `reasoning_tokens == 0` → existing behavior unchanged

## Test Plan

**Unit tests** (`test/registered/unit/mem_cache/test_radix_cache_thinking.py` — 12 tests):
- Thinking tokens stripped from cache; only prompt prefix retained
- KV indices for output tokens properly freed (no memory leak)
- Multi-turn prefix match works after fix (Turn 2 matches prompt prefix)
- Backward compatibility: `reasoning_tokens == 0` → all tokens cached as before
- Edge cases: empty output, all-thinking output, long thinking + short answer
- Cache size metrics reflect prompt-only entries
- `is_insert=False` path: all KV freed, empty tree

**Gating tests** (`test/registered/unit/mem_cache/test_radix_cache_thinking_gated.py`):
- `strip_thinking_from_cache=True` (deepseek-r1 style): thinking tokens stripped
- `strip_thinking_from_cache=False` (minimax-append-think style): full output cached
- Multi-turn prefix match with thinking tokens retained (MiniMax scenario)
- Default safety: unknown parser defaults to strip=True
- `minimax` vs `minimax-append-think` parser distinction
- Per-request flag respected correctly
- Edge cases: zero reasoning tokens + strip=False, all-thinking output + strip=False

**Compilation verified**: `py_compile` passes on all 6 modified/added files.
**Pre-commit**: isort, ruff, black, codespell all pass.

**Note**: Full integration tests require GPU + reasoning model (Linux CI).

## Notes
- `ChunkCache` is unaffected (no radix tree insertion)
- `SessionAwareCache` delegates to inner cache; fix propagates automatically
- `cache_unfinished_req` uses `fill_ids` (prompt tokens only during prefill) — unaffected
- Non-reasoning models: `reasoning_tokens` stays 0, no behavior change
