### PR TITLE
[Bugfix] Fix Qwen3.5 linear_attn quantization guard for compressed-tensors NVFP4 checkpoints

### DIFF
--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -509,9 +509,17 @@ class Qwen3_5LinearDecoderLayer(nn.Module):
         self.config = config
         self.layer_id = layer_id
 
+        _ignores_linear_attn = quant_config is not None and any(
+            "linear_attn" in entry
+            for entry in getattr(quant_config, "ignore", None) or []
+        )
         linear_attn_quant_config = (
             None
-            if quant_config and quant_config.get_name() == "modelopt_fp4"
+            if quant_config
+            and (
+                quant_config.get_name() == "modelopt_fp4"
+                or _ignores_linear_attn
+            )
             else quant_config
         )
         self.linear_attn = Qwen3_5GatedDeltaNet(
@@ -681,9 +689,17 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
             dtype=torch.get_default_dtype(),
         )
 
+        _ignores_self_attn = quant_config is not None and any(
+            "self_attn" in entry
+            for entry in getattr(quant_config, "ignore", None) or []
+        )
         attn_quant_config = (
             None
-            if quant_config and quant_config.get_name() == "modelopt_fp4"
+            if quant_config
+            and (
+                quant_config.get_name() == "modelopt_fp4"
+                or _ignores_self_attn
+            )
             else quant_config
         )
 

--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -51,7 +51,13 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
             config = config.text_config
 
         # The MTP model is unquantized in the nvfp4 checkpoint.
-        if quant_config and quant_config.get_name() == "modelopt_fp4":
+        _ignores_linear_attn = quant_config is not None and any(
+            "linear_attn" in entry
+            for entry in getattr(quant_config, "ignore", None) or []
+        )
+        if quant_config and (
+            quant_config.get_name() == "modelopt_fp4" or _ignores_linear_attn
+        ):
             quant_config = None
 
         self.config = config


### PR DESCRIPTION
## What's broken?

Loading RedHatAI/Qwen3.5-35B-A3B-NVFP4 or RedHatAI/Qwen3.5-122B-A10B-NVFP4 (llm-compressor NVFP4 checkpoints) produces garbage output and crashes with a CUDA assertion on `torch.multinomial`. The weights for all `linear_attn` (GatedDeltaNet) layers are silently dropped during loading.

## Who is affected?

Anyone loading Qwen3.5 hybrid models with **llm-compressor (compressed-tensors) NVFP4 checkpoints**. NVIDIA ModelOpt FP4 checkpoints (`modelopt_fp4`) are NOT affected — they work correctly.

Affected checkpoints:
- `RedHatAI/Qwen3.5-35B-A3B-NVFP4`
- `RedHatAI/Qwen3.5-122B-A10B-NVFP4`

## When does it trigger?

Triggers every time on model load — 100% reproducible. No workaround exists without code changes.

## Where is the bug?

`python/sglang/srt/models/qwen3_5.py`, `Qwen3_5LinearDecoderLayer.__init__` (line ~512):

```python
linear_attn_quant_config = (
    None
    if quant_config and quant_config.get_name() == "modelopt_fp4"
    else quant_config
)
```

Same pattern at `Qwen3_5AttentionDecoderLayer.__init__` (line ~684) and `qwen3_5_mtp.py` (line ~54).

## Why does it happen?

The guard was introduced in PR #18937 to handle NVIDIA FP4 checkpoints where GDN/attention layers store weights as BF16 (not quantized). The guard passes `quant_config=None` to these layers so they create unquantized `ColumnParallelLinear` modules.

The bug: llm-compressor NVFP4 checkpoints use `quant_method = "compressed-tensors"`, not `"modelopt_fp4"`. `CompressedTensorsConfig.get_name()` returns `"compressed_tensors"`, so the guard never fires. The GDN layers receive a `CompressedTensorsConfig`, create FP4 quant wrappers, but the actual weights are BF16 — causing silent weight drop → garbage activations → invalid logits → CUDA crash at `torch.multinomial`.

The checkpoint's `quantization_config.ignore` list explicitly marks all `linear_attn` paths as excluded from quantization (270 entries for 35B, 180 for 122B), but the model code never checks this list.

## How did we fix it?

Extended the guard to also check the quant config's `ignore` list for `linear_attn` / `self_attn` entries:

```python
_ignores_linear_attn = quant_config is not None and any(
    "linear_attn" in e for e in getattr(quant_config, "ignore", None) or []
)
linear_attn_quant_config = (
    None
    if (quant_config and quant_config.get_name() == "modelopt_fp4")
    or _ignores_linear_attn
    else quant_config
)
```

**Why this approach over hard-coding `"compressed_tensors"`:**
- More precise — only fires when the checkpoint actually excludes GDN layers
- Forward-compatible — works for any future quant method that marks `linear_attn` in its ignore list
- Won't break non-NVFP4 compressed-tensors checkpoints

Applied to:
- `qwen3_5.py`: both `linear_attn` guard and `self_attn` guard
- `qwen3_5_mtp.py`: MTP model guard

**Not included** (separate PR scope): `qwen3_next.py` has a related but structurally different issue.

## How do we know it works?

- `python -m py_compile` passes for both modified files
- The fix is semantically identical to the workaround validated by the issue reporter on NVIDIA DGX Spark with both 35B and 122B models
- Existing `modelopt_fp4` guard logic is preserved unchanged — no regression for ModelOpt checkpoints
- The `getattr(quant_config, "ignore", None) or []` pattern safely handles quant configs that lack an `ignore` attribute or have `ignore=None`

Fixes #22287

cc @ch-wan @hlu1
