### PR TITLE
[Test] Add unit tests for Hermes, Qwen25, and Llama32 function call detectors

### DIFF
--- a/test/registered/unit/function_call/test_hermes_detector.py
+++ b/test/registered/unit/function_call/test_hermes_detector.py
@@ -1,0 +1,157 @@
+"""Unit tests for HermesDetector — no server, no model loading."""
+
+import json
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.hermes_detector import HermesDetector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "stage-a-test-cpu")
+
+
+class TestHermesDetector(CustomTestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_weather",
+                    description="Get weather information",
+                    parameters={
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                ),
+            ),
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_time",
+                    description="Get current time",
+                    parameters={
+                        "type": "object",
+                        "properties": {"timezone": {"type": "string"}},
+                        "required": ["timezone"],
+                    },
+                ),
+            ),
+        ]
+        self.detector = HermesDetector()
+
+    # ==================== has_tool_call ====================
+
+    def test_has_tool_call_true(self):
+        self.assertTrue(
+            self.detector.has_tool_call(
+                '<tool_call>{"name": "get_weather", "arguments": {"city": "Paris"}}</tool_call>'
+            )
+        )
+
+    def test_has_tool_call_false(self):
+        self.assertFalse(self.detector.has_tool_call("The weather is nice today."))
+
+    def test_has_tool_call_partial_tag(self):
+        self.assertFalse(self.detector.has_tool_call("<tool_cal"))
+
+    # ==================== detect_and_parse ====================
+
+    def test_single_tool_call(self):
+        text = '<tool_call>{"name": "get_weather", "arguments": {"city": "Paris"}}</tool_call>'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        self.assertEqual(result.calls[0].tool_index, 0)
+        params = json.loads(result.calls[0].parameters)
+        self.assertEqual(params["city"], "Paris")
+
+    def test_multiple_tool_calls(self):
+        text = (
+            '<tool_call>{"name": "get_weather", "arguments": {"city": "Paris"}}</tool_call>'
+            '<tool_call>{"name": "get_time", "arguments": {"timezone": "UTC"}}</tool_call>'
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 2)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        self.assertEqual(result.calls[1].name, "get_time")
+        self.assertEqual(result.calls[1].tool_index, 1)
+
+    def test_no_tool_call(self):
+        text = "The weather in Paris is sunny today."
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 0)
+        self.assertEqual(result.normal_text, text)
+
+    def test_normal_text_before_call(self):
+        text = 'Sure!<tool_call>{"name": "get_weather", "arguments": {"city": "Paris"}}</tool_call>'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertIn("Sure", result.normal_text)
+
+    def test_invalid_json_fallback(self):
+        text = "<tool_call>not valid json</tool_call>"
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 0)
+        self.assertEqual(result.normal_text, text)
+
+    def test_unknown_tool_skipped(self):
+        text = '<tool_call>{"name": "undefined_func", "arguments": {}}</tool_call>'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 0)
+
+    def test_parameters_key_accepted(self):
+        """parse_base_json accepts 'parameters' in addition to 'arguments'."""
+        text = '<tool_call>{"name": "get_weather", "parameters": {"city": "Berlin"}}</tool_call>'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        params = json.loads(result.calls[0].parameters)
+        self.assertEqual(params["city"], "Berlin")
+
+    # ==================== structure_info ====================
+
+    def test_structure_info(self):
+        get_info = self.detector.structure_info()
+        info = get_info("get_weather")
+        self.assertIn("<tool_call>", info.begin)
+        self.assertIn("get_weather", info.begin)
+        self.assertIn("</tool_call>", info.end)
+        self.assertEqual(info.trigger, "<tool_call>")
+
+    # ==================== Streaming ====================
+
+    def test_streaming_plain_text(self):
+        """Text with no tool markers is returned immediately as normal_text."""
+        result = self.detector.parse_streaming_increment("Hello, world!", self.tools)
+        self.assertEqual(result.normal_text, "Hello, world!")
+        self.assertEqual(result.calls, [])
+
+    def test_streaming_partial_bot_token_buffered(self):
+        """A chunk ending with a partial <tool_call> is held in the buffer."""
+        result = self.detector.parse_streaming_increment("<tool_ca", self.tools)
+        self.assertEqual(result.normal_text, "")
+        self.assertEqual(result.calls, [])
+
+    def test_streaming_normal_text_before_bot_token(self):
+        """Text before <tool_call> is emitted as normal_text; bot_token stays buffered."""
+        result = self.detector.parse_streaming_increment("Sure! <tool_call>", self.tools)
+        self.assertIn("Sure!", result.normal_text)
+
+    def test_streaming_eot_stripped_from_normal_text(self):
+        """</tool_call> appearing as normal text is stripped by _clean_normal_text."""
+        r1 = self.detector.parse_streaming_increment("After call: ", self.tools)
+        self.assertEqual(r1.normal_text, "After call: ")
+        r2 = self.detector.parse_streaming_increment("</tool_call>", self.tools)
+        self.assertNotIn("</tool_call>", r2.normal_text)
+
+    def test_streaming_partial_eot_buffered(self):
+        """A partial </tool_call> at the end of normal text is held until complete."""
+        result = self.detector.parse_streaming_increment("</tool_ca", self.tools)
+        self.assertNotIn("</tool_call>", result.normal_text)
+        # Partial was held — nothing output yet
+        self.assertEqual(result.normal_text, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/function_call/test_llama32_detector.py
+++ b/test/registered/unit/function_call/test_llama32_detector.py
@@ -1,0 +1,182 @@
+"""Unit tests for Llama32Detector — no server, no model loading."""
+
+import json
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.llama32_detector import Llama32Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "stage-a-test-cpu")
+
+
+class TestLlama32Detector(CustomTestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_weather",
+                    description="Get weather information",
+                    parameters={
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                ),
+            ),
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_time",
+                    description="Get current time",
+                    parameters={
+                        "type": "object",
+                        "properties": {"timezone": {"type": "string"}},
+                        "required": ["timezone"],
+                    },
+                ),
+            ),
+        ]
+        self.detector = Llama32Detector()
+
+    # ==================== has_tool_call ====================
+
+    def test_has_tool_call_python_tag(self):
+        self.assertTrue(
+            self.detector.has_tool_call(
+                '<|python_tag|>{"name": "get_weather", "arguments": {"city": "Paris"}}'
+            )
+        )
+
+    def test_has_tool_call_bare_json(self):
+        """Text starting with '{' is treated as a tool call (no python_tag needed)."""
+        self.assertTrue(
+            self.detector.has_tool_call(
+                '{"name": "get_weather", "arguments": {"city": "Paris"}}'
+            )
+        )
+
+    def test_has_tool_call_false(self):
+        self.assertFalse(self.detector.has_tool_call("The weather is nice today."))
+
+    def test_has_tool_call_false_json_not_at_start(self):
+        """JSON not at position 0 without python_tag is not a tool call."""
+        self.assertFalse(self.detector.has_tool_call('Sure! {"name": "get_weather"}'))
+
+    # ==================== detect_and_parse ====================
+
+    def test_single_tool_call_with_tag(self):
+        text = '<|python_tag|>{"name": "get_weather", "arguments": {"city": "Paris"}}'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        self.assertEqual(result.calls[0].tool_index, 0)
+        params = json.loads(result.calls[0].parameters)
+        self.assertEqual(params["city"], "Paris")
+
+    def test_single_tool_call_bare_json(self):
+        """Llama32 accepts a bare JSON object (no python_tag) as a tool call."""
+        text = '{"name": "get_weather", "arguments": {"city": "Paris"}}'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_weather")
+
+    def test_multiple_tool_calls_semicolon_separator(self):
+        """Multiple tool calls are separated by ';' (tool_call_separator)."""
+        text = (
+            '<|python_tag|>'
+            '{"name": "get_weather", "arguments": {"city": "Paris"}}'
+            ';'
+            '{"name": "get_time", "arguments": {"timezone": "UTC"}}'
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 2)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        self.assertEqual(result.calls[1].name, "get_time")
+        self.assertEqual(result.calls[1].tool_index, 1)
+
+    def test_no_tool_call(self):
+        text = "The weather in Paris is sunny today."
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 0)
+        self.assertEqual(result.normal_text, text)
+
+    def test_normal_text_before_python_tag(self):
+        text = 'Sure!<|python_tag|>{"name": "get_weather", "arguments": {"city": "Paris"}}'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertIn("Sure!", result.normal_text)
+
+    def test_python_dict_fallback(self):
+        """Single-quoted Python dict is converted to JSON via ast.literal_eval."""
+        text = "<|python_tag|>{'name': 'get_weather', 'arguments': {'city': 'Paris'}}"
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        params = json.loads(result.calls[0].parameters)
+        self.assertEqual(params["city"], "Paris")
+
+    def test_unknown_tool_skipped(self):
+        text = '<|python_tag|>{"name": "undefined_func", "arguments": {}}'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 0)
+
+    def test_parameters_key_accepted(self):
+        """parse_base_json accepts 'parameters' in addition to 'arguments'."""
+        text = '<|python_tag|>{"name": "get_weather", "parameters": {"city": "Berlin"}}'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        params = json.loads(result.calls[0].parameters)
+        self.assertEqual(params["city"], "Berlin")
+
+    def test_trailing_garbage_after_separator(self):
+        """Trailing garbage after a valid call is returned as normal_text via safe_idx."""
+        text = (
+            '<|python_tag|>'
+            '{"name": "get_weather", "arguments": {"city": "Paris"}}'
+            ';not json garbage'
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        self.assertIn("not json", result.normal_text)
+
+    # ==================== structure_info ====================
+
+    def test_structure_info(self):
+        get_info = self.detector.structure_info()
+        info = get_info("get_weather")
+        self.assertIn("<|python_tag|>", info.begin)
+        self.assertIn("get_weather", info.begin)
+        self.assertEqual(info.end, "}")
+        self.assertEqual(info.trigger, "<|python_tag|>")
+
+    # ==================== Streaming ====================
+
+    def test_streaming_plain_text(self):
+        """Text with no tool markers is returned immediately as normal_text."""
+        result = self.detector.parse_streaming_increment("Hello, world!", self.tools)
+        self.assertEqual(result.normal_text, "Hello, world!")
+        self.assertEqual(result.calls, [])
+
+    def test_streaming_partial_bot_token_buffered(self):
+        """A chunk ending with a partial <|python_tag|> is held in the buffer."""
+        result = self.detector.parse_streaming_increment("<|python_t", self.tools)
+        self.assertEqual(result.normal_text, "")
+        self.assertEqual(result.calls, [])
+
+    def test_streaming_python_dict_conversion(self):
+        """Python single-quote dict is regex-converted before base streaming parse."""
+        # Single-quote values are converted in the buffer before parsing.
+        # Sending a complete chunk allows the base streaming to parse the full call.
+        text = "<|python_tag|>{'name': 'get_weather', 'arguments': {'city': 'Paris'}}"
+        result = self.detector.parse_streaming_increment(text, self.tools)
+        # After regex conversion, the buffer becomes valid JSON and the call is parsed.
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_weather")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/function_call/test_qwen25_detector.py
+++ b/test/registered/unit/function_call/test_qwen25_detector.py
@@ -1,0 +1,156 @@
+"""Unit tests for Qwen25Detector — no server, no model loading."""
+
+import json
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.qwen25_detector import Qwen25Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "stage-a-test-cpu")
+
+
+class TestQwen25Detector(CustomTestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_weather",
+                    description="Get weather information",
+                    parameters={
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                ),
+            ),
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_time",
+                    description="Get current time",
+                    parameters={
+                        "type": "object",
+                        "properties": {"timezone": {"type": "string"}},
+                        "required": ["timezone"],
+                    },
+                ),
+            ),
+        ]
+        self.detector = Qwen25Detector()
+
+    # ==================== has_tool_call ====================
+
+    def test_has_tool_call_true(self):
+        text = '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Paris"}}\n</tool_call>'
+        self.assertTrue(self.detector.has_tool_call(text))
+
+    def test_has_tool_call_false(self):
+        self.assertFalse(self.detector.has_tool_call("The weather is nice today."))
+
+    def test_has_tool_call_requires_newline(self):
+        """<tool_call> without the trailing newline does not match bot_token."""
+        self.assertFalse(self.detector.has_tool_call("<tool_call>"))
+
+    # ==================== detect_and_parse ====================
+
+    def test_single_tool_call(self):
+        text = '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Paris"}}\n</tool_call>'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        self.assertEqual(result.calls[0].tool_index, 0)
+        params = json.loads(result.calls[0].parameters)
+        self.assertEqual(params["city"], "Paris")
+
+    def test_multiple_tool_calls(self):
+        text = (
+            '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Paris"}}\n</tool_call>'
+            '<tool_call>\n{"name": "get_time", "arguments": {"timezone": "UTC"}}\n</tool_call>'
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 2)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        self.assertEqual(result.calls[1].name, "get_time")
+        self.assertEqual(result.calls[1].tool_index, 1)
+
+    def test_no_tool_call(self):
+        text = "The weather in Paris is sunny today."
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 0)
+        self.assertEqual(result.normal_text, text)
+
+    def test_normal_text_before_call(self):
+        text = 'Sure!\n<tool_call>\n{"name": "get_weather", "arguments": {"city": "Paris"}}\n</tool_call>'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertIn("Sure", result.normal_text)
+
+    def test_invalid_json_skipped(self):
+        """A malformed JSON block inside <tool_call> is skipped with a warning."""
+        text = "<tool_call>\nnot valid json\n</tool_call>"
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 0)
+
+    def test_unknown_tool_skipped(self):
+        text = '<tool_call>\n{"name": "undefined_func", "arguments": {}}\n</tool_call>'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 0)
+
+    def test_parameters_key_accepted(self):
+        """parse_base_json accepts 'parameters' in addition to 'arguments'."""
+        text = '<tool_call>\n{"name": "get_weather", "parameters": {"city": "Berlin"}}\n</tool_call>'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        params = json.loads(result.calls[0].parameters)
+        self.assertEqual(params["city"], "Berlin")
+
+    # ==================== structure_info ====================
+
+    def test_structure_info(self):
+        get_info = self.detector.structure_info()
+        info = get_info("get_weather")
+        self.assertIn("<tool_call>", info.begin)
+        self.assertIn("get_weather", info.begin)
+        self.assertIn("</tool_call>", info.end)
+        self.assertEqual(info.trigger, "<tool_call>")
+
+    def test_structure_info_newlines(self):
+        """Qwen25 format uses newlines around the JSON body."""
+        get_info = self.detector.structure_info()
+        info = get_info("get_weather")
+        self.assertTrue(info.begin.startswith("<tool_call>\n"))
+        self.assertTrue(info.end.endswith("</tool_call>"))
+
+    # ==================== Streaming ====================
+
+    def test_streaming_plain_text(self):
+        """Text with no tool markers is returned immediately as normal_text."""
+        result = self.detector.parse_streaming_increment("Hello, world!", self.tools)
+        self.assertEqual(result.normal_text, "Hello, world!")
+        self.assertEqual(result.calls, [])
+
+    def test_streaming_partial_bot_token_buffered(self):
+        """A chunk ending with a partial <tool_call>\n is held in the buffer."""
+        result = self.detector.parse_streaming_increment("<tool_ca", self.tools)
+        self.assertEqual(result.normal_text, "")
+        self.assertEqual(result.calls, [])
+
+    def test_streaming_eot_stripped_from_normal_text(self):
+        """</tool_call> (without leading newline) appearing in normal text is stripped."""
+        r1 = self.detector.parse_streaming_increment("After call: ", self.tools)
+        self.assertEqual(r1.normal_text, "After call: ")
+        r2 = self.detector.parse_streaming_increment("</tool_call>", self.tools)
+        self.assertNotIn("</tool_call>", r2.normal_text)
+
+    def test_streaming_partial_eot_held(self):
+        """A partial </tool_call> at the end of normal text is buffered."""
+        result = self.detector.parse_streaming_increment("</tool_ca", self.tools)
+        # Partial eot must not appear in output
+        self.assertNotIn("</tool_call>", result.normal_text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds pure-unit tests for three function-call detector implementations, contributing to #20865.

Note: #21153 (by @adityakamat24) covers `function_call_utils.py`. This PR covers the three detector classes with no overlap.

## Detectors covered

| File | Tests |
|------|-------|
| `hermes_detector.py` | 15 |
| `qwen25_detector.py` | 14 |
| `llama32_detector.py` | 16 |

**Total: 45 tests**

## What is tested

For each detector:
- `has_tool_call` — positive, negative, and partial-token edge cases
- `detect_and_parse` — single call, multiple calls, no call, normal text before call, unknown tool skipped, `parameters` key accepted, invalid JSON handling
- `structure_info` — `begin`/`end`/`trigger` format correctness
- `parse_streaming_increment` — plain text pass-through, partial bot-token buffering, EOT stripping, format-specific quirks (Llama32 Python-dict conversion, Qwen25 newline-wrapped format)

## Properties

- No server, no model loading — pure unit tests
- All use `CustomTestCase` and `register_cpu_ci(1.0, "stage-a-test-cpu")`
- Stateless: each test gets a fresh detector via `setUp()`