### PR TITLE
[fix]sglang-miles fully async deadlock

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -325,11 +325,19 @@ class Fp8LinearMethod(LinearMethodBase):
                         f"{input_size_per_partition} is not divisible by "
                         f"weight quantization block_k = {block_k}."
                     )
-            # Required by column parallel or enabling merged weights
-            if (
+            # Required by column parallel or enabling merged weights.
+            is_tp_split = (
                 tp_size > 1 and output_size // output_size_per_partition == tp_size
-            ) or len(output_partition_sizes) > 1:
-                for output_partition_size in output_partition_sizes:
+            )
+            is_merged_gemm = len(output_partition_sizes) > 1
+            if is_tp_split or is_merged_gemm:
+                sizes_to_check = output_partition_sizes
+                if not is_tp_split and is_merged_gemm:
+                    # Match validate_fp8_block_shape: merged weights may have a
+                    # ragged final logical matrix, and scale tensors are already
+                    # allocated with ceil-divided block counts.
+                    sizes_to_check = output_partition_sizes[:-1]
+                for output_partition_size in sizes_to_check:
                     if output_partition_size % block_n != 0:
                         raise ValueError(
                             f"Weight output_partition_size = "

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -490,7 +490,8 @@ class Scheduler(
                     [
                         self.recv_from_tokenizer,
                         self.recv_from_rpc,
-                    ]
+                    ],
+                    can_empty_cache=lambda: not self._engine_paused,
                 )
         else:
             self.recv_from_tokenizer = None
@@ -1455,6 +1456,26 @@ class Scheduler(
                     except zmq.ZMQError:
                         break
                     recv_reqs.append(recv_rpc)
+
+                if self._engine_paused and len(recv_reqs) == 0:
+                    poller = zmq.Poller()
+                    poller.register(self.recv_from_tokenizer, zmq.POLLIN)
+                    poller.register(self.recv_from_rpc, zmq.POLLIN)
+
+                    while len(recv_reqs) == 0:
+                        events = dict(poller.poll())
+                        for socket in (self.recv_from_tokenizer, self.recv_from_rpc):
+                            if socket not in events:
+                                continue
+                            while True:
+                                try:
+                                    if self.recv_limit_reached(len(recv_reqs)):
+                                        break
+                                    recv_reqs.append(socket.recv_pyobj(zmq.NOBLOCK))
+                                except zmq.ZMQError:
+                                    break
+                            if self.recv_limit_reached(len(recv_reqs)):
+                                break
             else:
                 recv_reqs = None
         else:
@@ -2883,12 +2904,18 @@ class Scheduler(
 
         timeout_s = float(recv_req.timeout_s or 0.0)
         if timeout_s <= 0.0:
-            return FlushCacheReqOutput(success=self.flush_cache())
+            success = self.flush_cache()
+            if self.tp_cpu_group is not None:
+                barrier(group=self.tp_cpu_group)
+            return FlushCacheReqOutput(success=success)
 
         if self.is_fully_idle() or (
             self._engine_paused and self.running_batch.is_empty()
         ):
-            return FlushCacheReqOutput(success=self.flush_cache())
+            success = self.flush_cache()
+            if self.tp_cpu_group is not None:
+                barrier(group=self.tp_cpu_group)
+            return FlushCacheReqOutput(success=success)
 
         self._pending_flush = (recv_req, time.monotonic() + timeout_s)
         return None
@@ -3062,7 +3089,8 @@ class Scheduler(
                 self.draft_worker.clear_cache_pool()
 
             # TODO: allow optional empty cache
-            torch.cuda.empty_cache()
+            if not self._engine_paused:
+                torch.cuda.empty_cache()
             logger.info("Cache flushed successfully!")
             success = True
         else:
@@ -3435,9 +3463,10 @@ class IdleSleeper:
     data that needs handling immediately.
     """
 
-    def __init__(self, sockets):
+    def __init__(self, sockets, can_empty_cache=None):
         self.poller = zmq.Poller()
         self.last_empty_time = real_time()
+        self.can_empty_cache = can_empty_cache
         for s in sockets:
             self.poller.register(s, zmq.POLLIN)
 
@@ -3450,7 +3479,8 @@ class IdleSleeper:
             and real_time() - self.last_empty_time > self.empty_cache_interval
         ):
             self.last_empty_time = real_time()
-            torch.cuda.empty_cache()
+            if self.can_empty_cache is None or self.can_empty_cache():
+                torch.cuda.empty_cache()
 
 
 def is_health_check_generate_req(recv_req):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1457,7 +1457,20 @@ class Scheduler(
                         break
                     recv_reqs.append(recv_rpc)
 
-                if self._engine_paused and len(recv_reqs) == 0:
+                should_block_for_paused_rpc = True
+                if self.server_args.enable_dp_attention:
+                    # In DP-attention mode, control requests are broadcast via
+                    # tp_group below. Only the tp_group source should wait on
+                    # the RPC socket while paused; the other ranks must enter
+                    # the broadcast as receivers. If they block on ZMQ here,
+                    # pause/flush can deadlock the control broadcast.
+                    should_block_for_paused_rpc = self.tp_group.is_first_rank
+
+                if (
+                    self._engine_paused
+                    and len(recv_reqs) == 0
+                    and should_block_for_paused_rpc
+                ):
                     poller = zmq.Poller()
                     poller.register(self.recv_from_tokenizer, zmq.POLLIN)
                     poller.register(self.recv_from_rpc, zmq.POLLIN)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2850,7 +2850,9 @@ class Scheduler(
 
         pending_req, deadline = self._pending_flush
 
-        if self.is_fully_idle():
+        if self.is_fully_idle() or (
+            self._engine_paused and self.running_batch.is_empty()
+        ):
             success = self.flush_cache()
             self._pending_flush = None
             self.send_to_tokenizer.send_output(
@@ -2883,7 +2885,9 @@ class Scheduler(
         if timeout_s <= 0.0:
             return FlushCacheReqOutput(success=self.flush_cache())
 
-        if self.is_fully_idle():
+        if self.is_fully_idle() or (
+            self._engine_paused and self.running_batch.is_empty()
+        ):
             return FlushCacheReqOutput(success=self.flush_cache())
 
         self._pending_flush = (recv_req, time.monotonic() + timeout_s)
@@ -3042,7 +3046,10 @@ class Scheduler(
 
     def flush_cache(self):
         """Flush the memory pool and cache."""
-        if self.is_fully_idle():
+        can_flush = self.is_fully_idle() or (
+            self._engine_paused and self.running_batch.is_empty()
+        )
+        if can_flush:
             self.cur_batch = None
             self.last_batch = None
             self.tree_cache.reset()

--- a/python/sglang/srt/managers/scheduler_update_weights_mixin.py
+++ b/python/sglang/srt/managers/scheduler_update_weights_mixin.py
@@ -96,6 +96,7 @@ class SchedulerUpdateWeightsMixin:
                 assert flush_cache_success, "Cache flush failed after updating weights"
         else:
             logger.error(message)
+        torch.distributed.barrier(group=self.tp_cpu_group)
         return UpdateWeightsFromDistributedReqOutput(success, message)
 
     def update_weights_from_tensor(
@@ -137,6 +138,8 @@ class SchedulerUpdateWeightsMixin:
         """Optional post-processing for updated weights (e.g., Marlin conversion)."""
         self._quiesce_for_weight_update()
         success, message = self.tp_worker.post_process_weights(recv_req)
+        if self.tp_cpu_group is not None:
+            torch.distributed.barrier(group=self.tp_cpu_group)
         return PostProcessWeightsReqOutput(success, message)
 
     def get_weights_by_name(self: Scheduler, recv_req: GetWeightsByNameReqInput):

--- a/python/sglang/srt/managers/scheduler_update_weights_mixin.py
+++ b/python/sglang/srt/managers/scheduler_update_weights_mixin.py
@@ -46,6 +46,16 @@ logger = logging.getLogger(__name__)
 
 class SchedulerUpdateWeightsMixin:
 
+    def _quiesce_for_weight_update(self: Scheduler):
+        """Drain in-flight forward work before any NCCL weight mutation.
+        Synchronize forward_stream and schedule_stream to ensure all ranks are quiescent.
+        """
+        if self.enable_overlap:
+            self.forward_stream.synchronize()
+        self.schedule_stream.synchronize()
+        if self.tp_cpu_group is not None:
+            torch.distributed.barrier(group=self.tp_cpu_group)
+
     def update_weights_from_disk(
         self: Scheduler, recv_req: UpdateWeightFromDiskReqInput
     ):
@@ -78,6 +88,7 @@ class SchedulerUpdateWeightsMixin:
         recv_req: UpdateWeightsFromDistributedReqInput,
     ) -> Tuple[bool, str]:
         """Update the online model parameter."""
+        self._quiesce_for_weight_update()
         success, message = self.tp_worker.update_weights_from_distributed(recv_req)
         if success:
             if recv_req.flush_cache:
@@ -91,6 +102,7 @@ class SchedulerUpdateWeightsMixin:
         self: Scheduler, recv_req: UpdateWeightsFromTensorReqInput
     ):
         """Update the online model parameter from tensors."""
+        self._quiesce_for_weight_update()
         if recv_req.disable_draft_model:
             worker = self.tp_worker
         else:
@@ -110,6 +122,7 @@ class SchedulerUpdateWeightsMixin:
         self: Scheduler, recv_req: UpdateWeightsFromIPCReqInput
     ):
         """Update the online model parameter from IPC for checkpoint-engine integration."""
+        self._quiesce_for_weight_update()
         success, message = self.tp_worker.update_weights_from_ipc(recv_req)
         if success:
             if recv_req.flush_cache:
@@ -122,6 +135,7 @@ class SchedulerUpdateWeightsMixin:
 
     def post_process_weights(self, recv_req: PostProcessWeightsReqInput):
         """Optional post-processing for updated weights (e.g., Marlin conversion)."""
+        self._quiesce_for_weight_update()
         success, message = self.tp_worker.post_process_weights(recv_req)
         return PostProcessWeightsReqOutput(success, message)
 

--- a/python/sglang/srt/managers/tokenizer_communicator_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_communicator_mixin.py
@@ -6,6 +6,7 @@ import logging
 import time
 import uuid
 from collections import deque
+from contextlib import nullcontext
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -640,14 +641,13 @@ class TokenizerCommunicatorMixin:
 
         async with self.is_pause_cond:
             is_paused = self.is_pause
-            if is_paused:
-                results = await self.post_process_weights_communicator(obj)
 
-        if not is_paused:
-            async with self.model_update_lock.writer_lock:
-                results = await self.post_process_weights_communicator(obj)
-
-        return _Communicator.merge_results(results)
+        lock_context = (
+            self.model_update_lock.writer_lock if not is_paused else nullcontext()
+        )
+        async with lock_context:
+            results = await self.post_process_weights_communicator(obj)
+            return _Communicator.merge_results(results)
 
     async def _unload_lora_adapter_locked(
         self: TokenizerManager,


### PR DESCRIPTION
## Motivation

Miles fully-async training can deadlock during the pause/update/post-process/continue-generation sequence. The failure is not one isolated bug; it is an ordering issue across three boundaries:

1. in-flight SGLang forward CUDA/NCCL work vs. weight-update NCCL collectives
2. paused scheduler TP ranks vs. empty control-message broadcasts
3. tokenizer `model_update_lock` vs. `post_process_weights` during an already-paused update protocol

Together these can leave Miles waiting for a weight-update/post-process HTTP call to finish while SGLang TP ranks are stuck in scheduler control-message broadcast or NCCL synchronization.

## Root Cause and Fix

### Part 1: Drain forward work before mutating weights

In fully async mode, generation can still have work queued on `forward_stream` while the scheduler proceeds on `schedule_stream`. If Miles pauses generation and immediately starts `update_weights_from_distributed`, SGLang can enter weight-update NCCL collectives while previous inference NCCL work is still in flight.

This PR adds `_quiesce_for_weight_update()` before weight mutation paths:

- synchronize `forward_stream` when overlap is enabled
- synchronize `schedule_stream`
- run a TP CPU barrier before updating/post-processing weights

This prevents inference collectives and weight-update collectives from overlapping or being entered in incompatible rank order.

### Part 2: Keep paused TP scheduler ranks aligned on real control requests

When the engine is paused, the scheduler should still process control commands such as:

- `update_weights_from_distributed`
- `post_process_weights`
- `continue_generation`

Before this change, TP0 could repeatedly poll no request and broadcast an empty request list while paused. That made paused mode timing-sensitive: a real control request could arrive between empty broadcasts while non-source TP ranks were waiting in `broadcast_pyobj`.

This PR changes paused scheduler polling so TP0 blocks on tokenizer/RPC sockets until a real request arrives, then broadcasts that request to TP ranks. Paused mode becomes control-driven instead of empty-broadcast-driven.

### Part 3: Do not wait on tokenizer writer lock for post-process when already paused

`update_weights_from_distributed` already skips `model_update_lock.writer_lock` when the engine is paused, because `is_pause=True` blocks new generation requests and the pause protocol is the synchronization boundary.

`post_process_weights` did not follow the same rule and could wait behind lingering reader-lock state while the scheduler was already paused. That can stall the HTTP request and prevent `continue_generation` from ever being sent.

This PR makes `post_process_weights` match the existing paused update behavior: take the writer lock during normal serving, but skip it when the engine is already paused.

## Other Changes

- Allow cache flush when the engine is paused and `running_batch` is empty, which is needed by the retract flow.
- Avoid opportunistic `torch.cuda.empty_cache()` while the engine is paused, reducing allocator/CUDA activity inside the weight-update critical section.
- Add TP CPU barriers after distributed update and post-process so ranks leave those phases together.
- Remove a stale local import of `get_local_ip_auto` from `sglang.srt.utils`; the symbol is already imported from the correct module.

## Validation

Local syntax check:

```bash
python3 -m py_compile \
  python/sglang/srt/model_executor/model_runner.py \
  python/sglang/srt/managers/tokenizer_communicator_mixin.py \
  python/sglang/srt/managers/scheduler.py \
  python/sglang/srt/managers/scheduler_update_weights_mixin.py
```

Remote validation on H200 Kubernetes job with patched SGLang synced to all nodes:

- `retract + broadcast`, 10 steps: succeeded, steps `0..9`
- `retract + p2p`, 10 steps: succeeded, steps `0..9`
- `in_place + broadcast`, 10 steps: succeeded, steps `0..9`

Longer representative runs with `rollout_max_response_len=8192` and `num_rollout=100` were also launched:

- `in_place + broadcast`: still progressing when last checked, through step 13
- `retract + broadcast`: still progressing when last checked, through step 11