### PR TITLE
[Test] Fix flaky test_function_call_specific by adding strict=True

### DIFF
--- a/test/registered/openai_server/function_call/test_openai_function_calling.py
+++ b/test/registered/openai_server/function_call/test_openai_function_calling.py
@@ -552,6 +552,7 @@ class TestOpenAIServerFunctionCalling(CustomTestCase):
                         },
                         "required": ["city"],
                     },
+                    "strict": True,
                 },
             },
         ]


### PR DESCRIPTION
## Summary
- Add `strict=True` to the `get_weather` tool in `test_function_call_specific`, matching the fix in #22586 for `test_function_call_required`
- Without `strict=True`, `tool_choice` with a specific function only guarantees a tool call is made but arguments are best-effort (no constrained decoding on parameter schema)
- On Llama-3.2-1B with `temperature=0.8`, this causes ~30% flaky rate where the model generates empty `{}` arguments, failing `assertIn("city", args_obj)`

## Evidence

Ran `test_openai_function_calling.py` 10 times at each commit via `gh workflow run`:

**Before #21593** ([c2821dfbe](https://github.com/sgl-project/sglang/commit/c2821dfbe)) — 10/10 pass:
[1](https://github.com/sgl-project/sglang/actions/runs/24301521423) [2](https://github.com/sgl-project/sglang/actions/runs/24301521829) [3](https://github.com/sgl-project/sglang/actions/runs/24301522220) [4](https://github.com/sgl-project/sglang/actions/runs/24301522618) [5](https://github.com/sgl-project/sglang/actions/runs/24301523007) [6](https://github.com/sgl-project/sglang/actions/runs/24301523390) [7](https://github.com/sgl-project/sglang/actions/runs/24301523725) [8](https://github.com/sgl-project/sglang/actions/runs/24301524036) [9](https://github.com/sgl-project/sglang/actions/runs/24301524398) [10](https://github.com/sgl-project/sglang/actions/runs/24301524709)

**After #21593** ([7c6db4054](https://github.com/sgl-project/sglang/commit/7c6db4054)) — 7/10 pass (30% fail):
[1](https://github.com/sgl-project/sglang/actions/runs/24301526032) [2](https://github.com/sgl-project/sglang/actions/runs/24301526295) [3](https://github.com/sgl-project/sglang/actions/runs/24301526646) [4](https://github.com/sgl-project/sglang/actions/runs/24301526997) [fail](https://github.com/sgl-project/sglang/actions/runs/24301527317) [5](https://github.com/sgl-project/sglang/actions/runs/24301527557) [fail](https://github.com/sgl-project/sglang/actions/runs/24301527761) [fail](https://github.com/sgl-project/sglang/actions/runs/24301528031) [6](https://github.com/sgl-project/sglang/actions/runs/24301528259) [7](https://github.com/sgl-project/sglang/actions/runs/24301528540)

**This fix** ([225dd6f6b](https://github.com/sgl-project/sglang/commit/225dd6f6b)) — 11/11 pass:
[1](https://github.com/sgl-project/sglang/actions/runs/24301447787) [2](https://github.com/sgl-project/sglang/actions/runs/24301533031) [3](https://github.com/sgl-project/sglang/actions/runs/24301533327) [4](https://github.com/sgl-project/sglang/actions/runs/24301533661) [5](https://github.com/sgl-project/sglang/actions/runs/24301533974) [6](https://github.com/sgl-project/sglang/actions/runs/24301534280) [7](https://github.com/sgl-project/sglang/actions/runs/24301534570) [8](https://github.com/sgl-project/sglang/actions/runs/24301534938) [9](https://github.com/sgl-project/sglang/actions/runs/24301535215) [10](https://github.com/sgl-project/sglang/actions/runs/24301535519) [11](https://github.com/sgl-project/sglang/actions/runs/24301535925)

## Test plan
- [x] Local flaky rate test: 25% fail without fix → 0% with fix (20 runs each)
- [x] CI evidence: 30% fail at regression commit → 0% fail with this fix (10 runs each)
- [x] CI: `stage-b-test-1-gpu-large` passes