### PR TITLE
[MLX] Fix premature request-state cleanup causing decode KeyError

### DIFF
--- a/python/sglang/srt/hardware_backend/mlx/tp_worker.py
+++ b/python/sglang/srt/hardware_backend/mlx/tp_worker.py
@@ -64,11 +64,17 @@ class MlxTpModelWorker(TpModelWorker):
             model_path=self.server_args.model_path,
             trust_remote_code=self.server_args.trust_remote_code,
         )
-        self._mlx_active_rids: set[str] = set()
 
     def get_pad_input_ids_func(self):
         """Override since the stub ModelRunner has no real model."""
         return None
+
+    def cleanup_requests(self, req_ids: list[str]):
+        for req_id in req_ids:
+            self._mlx_runner.remove_request(req_id)
+
+    def clear_runtime_state(self):
+        self._mlx_runner.clear()
 
     def forward_batch_generation(
         self,
@@ -111,13 +117,9 @@ class MlxTpModelWorker(TpModelWorker):
                 can_run_cuda_graph=False,
             )
 
-        # Auto-cleanup: remove MLX state for requests no longer in the batch
-        current_rids = {req.rid for req in reqs}
-        stale_rids = self._mlx_active_rids - current_rids
-        for rid in stale_rids:
-            self._mlx_runner.remove_request(rid)
-        self._mlx_active_rids = current_rids
-
+        # A request can legitimately disappear from one scheduler batch and
+        # reappear in a later decode batch, so batch membership is not a safe
+        # signal for tearing down MLX request state.
         next_token_ids_list = []
 
         if forward_mode.is_extend():

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3138,6 +3138,7 @@ class Scheduler(
             self.req_to_token_pool.clear()
             self.token_to_kv_pool_allocator.clear()
             self.grammar_manager.clear()
+            self.tp_worker.clear_runtime_state()
             self.reset_metrics()
 
             if self.draft_worker:
@@ -3279,6 +3280,7 @@ class Scheduler(
                 and self.disaggregation_mode != DisaggregationMode.DECODE
             ):
                 release_kv_cache(req, self.tree_cache, is_insert=False)
+            self.tp_worker.cleanup_requests([req.rid])
             logger.debug(f"Abort queued request. {req.rid=}")
 
         # Delete the requests in the grammar queue
@@ -3326,6 +3328,7 @@ class Scheduler(
                         self.send_to_tokenizer.send_output(
                             AbortReq(rid=decode_req.rid), decode_req
                         )
+                        self.tp_worker.cleanup_requests([decode_req.rid])
                     else:
                         remaining_retracted.append(decode_req)
                 self.disagg_decode_prealloc_queue.retracted_queue = remaining_retracted

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -90,6 +90,7 @@ class SchedulerOutputProcessorMixin:
             if req.finished():
                 req.time_stats.set_quick_finish_time()
                 release_kv_cache(req, self.tree_cache)
+                self.tp_worker.cleanup_requests([req.rid])
 
         # Note: Logprobs should be handled on the prefill engine.
         self.stream_output(batch.reqs, batch.return_logprob)
@@ -189,6 +190,7 @@ class SchedulerOutputProcessorMixin:
                     if req.finished():
                         self.maybe_collect_routed_experts(req)
                         release_kv_cache(req, self.tree_cache)
+                        self.tp_worker.cleanup_requests([req.rid])
                         req.time_stats.set_completion_time()
                     elif not batch.decoding_reqs or req not in batch.decoding_reqs:
                         self.tree_cache.cache_unfinished_req(req)
@@ -314,6 +316,7 @@ class SchedulerOutputProcessorMixin:
 
                     if req.finished():
                         release_kv_cache(req, self.tree_cache)
+                        self.tp_worker.cleanup_requests([req.rid])
                         req.time_stats.set_completion_time()
                     else:
                         self.tree_cache.cache_unfinished_req(req)
@@ -551,6 +554,7 @@ class SchedulerOutputProcessorMixin:
                     self.hisparse_coordinator.request_finished(req)
                 release_kv_cache(req, self.tree_cache)
 
+            self.tp_worker.cleanup_requests([req.rid])
             req.time_stats.set_completion_time()
 
         self.maybe_collect_customized_info(i, req, logits_output)

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -426,6 +426,12 @@ class TpModelWorker(BaseTpWorker):
             self.model_runner.token_to_kv_pool.size,
         )
 
+    def cleanup_requests(self, req_ids: List[str]):
+        """Release backend-specific per-request runtime state."""
+
+    def clear_runtime_state(self):
+        """Release backend-specific runtime state for all requests."""
+
     def is_dllm(self):
         return self.dllm_algorithm is not None
 

--- a/test/registered/core/test_mlx_tp_worker.py
+++ b/test/registered/core/test_mlx_tp_worker.py
@@ -1,0 +1,192 @@
+import dataclasses
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+
+
+def _install_stub(fullname: str, **attrs):
+    module = types.ModuleType(fullname)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    sys.modules[fullname] = module
+    return module
+
+
+def _load_tp_worker_module():
+    @dataclasses.dataclass
+    class _StubGenerationBatchResult:
+        logits_output: object
+        next_token_ids: object = None
+        can_run_cuda_graph: bool = False
+
+    @dataclasses.dataclass
+    class _StubLogitsProcessorOutput:
+        next_token_logits: object
+
+    class _StubTpModelWorker:
+        def forward_batch_generation(self, *args, **kwargs):
+            raise NotImplementedError
+
+    _install_stub("sglang")
+    _install_stub("sglang.srt")
+    _install_stub("sglang.srt.managers")
+    _install_stub("sglang.srt.model_executor")
+    _install_stub("sglang.srt.layers")
+    _install_stub(
+        "sglang.srt.managers.schedule_batch",
+        ModelWorkerBatch=object,
+    )
+    _install_stub(
+        "sglang.srt.managers.tp_worker",
+        TpModelWorker=_StubTpModelWorker,
+    )
+    _install_stub(
+        "sglang.srt.managers.utils",
+        GenerationBatchResult=_StubGenerationBatchResult,
+    )
+    _install_stub(
+        "sglang.srt.model_executor.forward_batch_info",
+        ForwardBatch=object,
+        PPProxyTensors=object,
+    )
+    _install_stub(
+        "sglang.srt.layers.logits_processor",
+        LogitsProcessorOutput=_StubLogitsProcessorOutput,
+    )
+
+    module_path = (
+        Path(__file__).resolve().parents[3]
+        / "python/sglang/srt/hardware_backend/mlx/tp_worker.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "test_mlx_tp_worker_module", module_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeForwardMode:
+    def __init__(self, mode: str):
+        self.mode = mode
+
+    def is_idle(self):
+        return self.mode == "idle"
+
+    def is_extend(self):
+        return self.mode == "extend"
+
+    def is_decode(self):
+        return self.mode == "decode"
+
+
+class _FakeMlxRunner:
+    def __init__(self):
+        self._request_states = {}
+        self.removed_request_ids = []
+
+    def prefill(self, req_id: str, token_ids: list[int]) -> int:
+        next_token = token_ids[-1] + 1
+        self._request_states[req_id] = {
+            "token_ids": list(token_ids) + [next_token],
+        }
+        return next_token
+
+    def decode_batch(self, req_ids: list[str]) -> list[int]:
+        missing = [req_id for req_id in req_ids if req_id not in self._request_states]
+        if missing:
+            raise KeyError(missing[0])
+
+        next_tokens = []
+        for req_id in req_ids:
+            state = self._request_states[req_id]
+            next_token = state["token_ids"][-1] + 1
+            state["token_ids"].append(next_token)
+            next_tokens.append(next_token)
+        return next_tokens
+
+    def remove_request(self, req_id: str):
+        self.removed_request_ids.append(req_id)
+        self._request_states.pop(req_id, None)
+
+    def clear(self):
+        self._request_states.clear()
+
+
+class TestMlxTpModelWorker(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tp_worker_module = _load_tp_worker_module()
+
+    def _make_worker(self):
+        worker = object.__new__(self.tp_worker_module.MlxTpModelWorker)
+        worker._mlx_runner = _FakeMlxRunner()
+        return worker
+
+    @staticmethod
+    def _make_extend_batch(reqs_with_tokens: list[tuple[str, list[int]]]):
+        flat_input_ids = [
+            token_id for _, token_ids in reqs_with_tokens for token_id in token_ids
+        ]
+        return SimpleNamespace(
+            forward_mode=_FakeForwardMode("extend"),
+            reqs=[SimpleNamespace(rid=req_id) for req_id, _ in reqs_with_tokens],
+            input_ids=torch.tensor(flat_input_ids, dtype=torch.long),
+            extend_seq_lens=[len(token_ids) for _, token_ids in reqs_with_tokens],
+        )
+
+    @staticmethod
+    def _make_decode_batch(req_ids: list[str]):
+        return SimpleNamespace(
+            forward_mode=_FakeForwardMode("decode"),
+            reqs=[SimpleNamespace(rid=req_id) for req_id in req_ids],
+        )
+
+    def test_request_state_survives_batches_where_request_is_temporarily_absent(self):
+        worker = self._make_worker()
+
+        worker._forward_batch_generation_mlx(
+            self._make_extend_batch([("req-a", [10, 11, 12])])
+        )
+        self.assertIn("req-a", worker._mlx_runner._request_states)
+
+        worker._forward_batch_generation_mlx(
+            self._make_extend_batch([("req-b", [20, 21, 22])])
+        )
+        self.assertIn("req-a", worker._mlx_runner._request_states)
+        self.assertEqual(worker._mlx_runner.removed_request_ids, [])
+
+        result = worker._forward_batch_generation_mlx(
+            self._make_decode_batch(["req-a", "req-b"])
+        )
+
+        self.assertEqual(result.next_token_ids.tolist(), [14, 24])
+
+    def test_cleanup_hooks_remove_request_state_when_requested(self):
+        worker = self._make_worker()
+
+        worker._forward_batch_generation_mlx(
+            self._make_extend_batch([("req-a", [10, 11, 12]), ("req-b", [20, 21, 22])])
+        )
+        self.assertEqual(set(worker._mlx_runner._request_states), {"req-a", "req-b"})
+
+        worker.cleanup_requests(["req-a"])
+        self.assertEqual(set(worker._mlx_runner._request_states), {"req-b"})
+        self.assertEqual(worker._mlx_runner.removed_request_ids, ["req-a"])
+
+        worker.clear_runtime_state()
+        self.assertEqual(worker._mlx_runner._request_states, {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fix an MLX backend request lifecycle bug on Apple Silicon that can crash multi-request decoding with a `KeyError` in `MlxModelRunner.decode_batch()`.

The root cause is that the MLX worker treated "request is not present in the current batch" as "request has completed" and eagerly removed its per-request MLX state. In practice, SGLang's scheduler can temporarily exclude a still-live request from an intermediate batch and reintroduce it in a later decode batch. When that happened, the subsequent decode tried to access a request state that had already been removed.

This PR moves MLX request-state cleanup away from transient batch membership and back to actual request lifecycle events.

## Modifications

- Remove the batch-membership-based cleanup in `python/sglang/srt/hardware_backend/mlx/tp_worker.py`.
- Add backend-specific runtime cleanup hooks to `TpModelWorker`:
  - `cleanup_requests(...)`
  - `clear_runtime_state()`
- Implement those hooks in `MlxTpModelWorker` so they call into `MlxModelRunner.remove_request(...)` and `MlxModelRunner.clear()`.
- Invoke MLX request cleanup when requests actually finish in scheduler output processing.
- Invoke MLX request cleanup for aborted queued / retracted requests.
- Invoke MLX runtime cleanup from `flush_cache()`.
- Add a regression test covering:
  - a request temporarily disappearing from one batch and reappearing later without losing MLX state
  - explicit cleanup hook behavior

## Accuracy Tests

This PR does not change model math, sampling logic, or logits computation. It only fixes request-state lifecycle management in the MLX backend.

Validation performed:
- Reproduced the original failure locally with:
  - `SGLANG_USE_MLX=1 python -m sglang.bench_offline_throughput --model-path $MODEL --dataset-name sharegpt --dataset-path $DATASET --num-prompts 2`
- Confirmed the same workload completes successfully after the fix.
- Added and ran regression unit tests:
  - `python -m unittest discover -s test/registered/core -p 'test_mlx_tp_worker.py'`

## Speed Tests and Profiling

This PR is not intended as a performance optimization. It changes cleanup timing only.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

This addresses #22466.
