### PR TITLE
Auto-detect aiter decode attention backend for MLA models on ROCm

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1746,10 +1746,11 @@ class ServerArgs:
                 if (
                     self.attention_backend is None
                     and self.decode_attention_backend is None
+                    and importlib.util.find_spec("aiter")
                 ):
                     self.decode_attention_backend = "aiter"
                     logger.info(
-                        "Use aiter as decode attention backend on ROCm for DeepseekV3ForCausalLM (MLA)"
+                        f"Use aiter as decode attention backend on ROCm for {model_arch} (MLA)"
                     )
 
                 if (

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1744,6 +1744,15 @@ class ServerArgs:
                     )
 
                 if (
+                    self.attention_backend is None
+                    and self.decode_attention_backend is None
+                ):
+                    self.decode_attention_backend = "aiter"
+                    logger.info(
+                        "Use aiter as decode attention backend on ROCm for DeepseekV3ForCausalLM (MLA)"
+                    )
+
+                if (
                     self.quantization == "modelopt_fp4"
                     and self.speculative_algorithm == "EAGLE"
                     and (


### PR DESCRIPTION
> **Draft status:** retargeted to the correct `sglang-miles` base. The old insertion point conflicts with the branch's newer backend-resolution pipeline, so this is not ready for review as-is.

## Motivation

On MI355X, the AITER MLA decode backend materially reduced GLM-5.1 FP8 decode latency compared with the then-default backend. Automatically selecting it when the user has not chosen either attention backend could remove a manual tuning step for supported ROCm MLA models.

## Current blockers

- `sglang-miles` moved DeepSeek-family defaults into `python/sglang/srt/arg_groups/overrides.py`; mechanically resolving the old `server_args.py` hunk would restore code in the wrong layer.
- The original condition does not establish whether DSA models such as GLM-5.x should receive a raw `decode_attention_backend="aiter"` override after the newer `attention_backend="dsa"` resolution.
- `importlib.util.find_spec("aiter")` proves only that the package exists, not that the installed build, GPU, model shape, and decode mode are supported.
- The branch has no regression tests for default selection, explicit user overrides, or unavailable/unsupported AITER.
- The 42.6% result was measured on one MI355X GLM configuration and must not be generalized to every listed model or ROCm GPU without evidence.

## Required refresh before marking ready

- [x] Target `sglang-miles`, which is the branch Miles images consume.
- [ ] Re-implement the default in `_deepseek_family_overrides` or the appropriate current resolution pass.
- [ ] Add focused tests for default selection, both user override flags, missing AITER, DSA/non-DSA behavior, and unsupported capability.
- [ ] Rerun the GLM-5.1 MI355X benchmark against current `sglang-miles` and record exact commands.
- [ ] Smoke-test at least one additional supported MLA architecture or narrow the documented model scope.
- [ ] Run current lint and AMD CI.

The PR remains draft pending redesign and independent MI355X validation.