### PR TITLE
Replace all-reduce + dp_scatter with reduce_scatterv for DP attention

### DIFF
--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -47,6 +47,7 @@ from sglang.srt.layers.dp_attention import (
     get_attention_dp_size,
     get_attention_tp_rank,
     get_attention_tp_size,
+    get_dp_global_num_tokens,
     get_global_dp_buffer,
     get_local_dp_buffer,
     is_allocation_symmetric,
@@ -55,6 +56,7 @@ from sglang.srt.layers.dp_attention import (
 from sglang.srt.layers.flashinfer_comm_fusion import is_flashinfer_allreduce_unavailable
 from sglang.srt.layers.moe import (
     get_moe_a2a_backend,
+    should_use_dp_reduce_scatterv,
     should_use_flashinfer_cutlass_moe_fp4_allgather,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
@@ -1003,15 +1005,21 @@ class CommunicateSummableTensorPairFn:
         context: CommunicateContext,
         allow_reduce_scatter: bool = False,
     ):
-        hidden_states, global_hidden_states = (
-            get_local_dp_buffer(),
-            hidden_states,
-        )
-        if allow_reduce_scatter and forward_batch.dp_padding_mode.is_max_len():
-            # When using padding, all_reduce is skipped after MLP and MOE and reduce scatter is used here instead.
-            dp_reduce_scatter_tensor(hidden_states, global_hidden_states)
+        if should_use_dp_reduce_scatterv():
+            global_hidden_states = hidden_states
+            hidden_states = get_tp_group().reduce_scatterv(
+                global_hidden_states,
+                sizes=get_dp_global_num_tokens(),
+            )
         else:
-            dp_scatter(hidden_states, global_hidden_states, forward_batch)
+            hidden_states, global_hidden_states = (
+                get_local_dp_buffer(),
+                hidden_states,
+            )
+            if allow_reduce_scatter and forward_batch.dp_padding_mode.is_max_len():
+                dp_reduce_scatter_tensor(hidden_states, global_hidden_states)
+            else:
+                dp_scatter(hidden_states, global_hidden_states, forward_batch)
         return hidden_states, residual
 
     @staticmethod

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -1005,21 +1005,20 @@ class CommunicateSummableTensorPairFn:
         context: CommunicateContext,
         allow_reduce_scatter: bool = False,
     ):
+        hidden_states, global_hidden_states = (
+            get_local_dp_buffer(),
+            hidden_states,
+        )
         if should_use_dp_reduce_scatterv():
-            global_hidden_states = hidden_states
-            hidden_states = get_tp_group().reduce_scatterv(
+            get_tp_group().reduce_scatterv(
                 global_hidden_states,
+                output=hidden_states,
                 sizes=get_dp_global_num_tokens(),
             )
+        elif allow_reduce_scatter and forward_batch.dp_padding_mode.is_max_len():
+            dp_reduce_scatter_tensor(hidden_states, global_hidden_states)
         else:
-            hidden_states, global_hidden_states = (
-                get_local_dp_buffer(),
-                hidden_states,
-            )
-            if allow_reduce_scatter and forward_batch.dp_padding_mode.is_max_len():
-                dp_reduce_scatter_tensor(hidden_states, global_hidden_states)
-            else:
-                dp_scatter(hidden_states, global_hidden_states, forward_batch)
+            dp_scatter(hidden_states, global_hidden_states, forward_batch)
         return hidden_states, residual
 
     @staticmethod

--- a/python/sglang/srt/layers/moe/__init__.py
+++ b/python/sglang/srt/layers/moe/__init__.py
@@ -10,6 +10,7 @@ from sglang.srt.layers.moe.utils import (
     get_tbo_token_distribution_threshold,
     initialize_moe_config,
     is_tbo_enabled,
+    should_use_dp_reduce_scatterv,
     should_use_flashinfer_cutlass_moe_fp4_allgather,
 )
 
@@ -23,6 +24,7 @@ __all__ = [
     "get_moe_a2a_backend",
     "get_moe_runner_backend",
     "get_deepep_mode",
+    "should_use_dp_reduce_scatterv",
     "should_use_flashinfer_cutlass_moe_fp4_allgather",
     "is_tbo_enabled",
     "get_tbo_token_distribution_threshold",

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -289,6 +289,21 @@ def should_use_flashinfer_cutlass_moe_fp4_allgather():
     )
 
 
+def should_use_dp_reduce_scatterv():
+    """
+    Use reduce_scatterv in the standard dispatcher's combine() for DP attention
+    with EP, replacing the default all-reduce + dp_scatter path.
+    Only changes the combine (post-kernel) communication; dispatch is unchanged.
+    """
+    return (
+        not should_use_flashinfer_cutlass_moe_fp4_allgather()
+        and get_moe_a2a_backend().is_none()
+        and is_dp_attention_enabled()
+        and get_attention_dp_size() > 1
+        and get_moe_expert_parallel_world_size() == get_attention_dp_size()
+    )
+
+
 @contextmanager
 def speculative_moe_backend_context():
     """

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -57,6 +57,7 @@ from sglang.srt.layers.linear import (
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.moe import (
     get_moe_a2a_backend,
+    should_use_dp_reduce_scatterv,
     should_use_flashinfer_cutlass_moe_fp4_allgather,
 )
 from sglang.srt.layers.moe.ep_moe.layer import get_moe_impl_class
@@ -352,6 +353,7 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
             and not should_allreduce_fusion
             and not use_reduce_scatter
             and not should_use_flashinfer_cutlass_moe_fp4_allgather()
+            and not should_use_dp_reduce_scatterv()
         ):
             final_hidden_states = tensor_model_parallel_all_reduce(final_hidden_states)
 


### PR DESCRIPTION
## Motivation

For DP attention with Expert Parallelism (EP), the default MoE communication path performs two separate operations after the MoE kernel:

1. `tensor_model_parallel_all_reduce` — reduces expert outputs across all DP workers
2. `dp_scatter` — extracts each worker's local token slice from the global result

This is functionally equivalent to a single `reduce_scatterv`, which fuses the reduce and scatter into one NCCL collective, cutting the number of communication rounds in half.

## Modifications

**4 files changed, ~35 lines added**

- **`python/sglang/srt/layers/moe/utils.py`**: Added `should_use_dp_reduce_scatterv()` — activates when DP attention + EP is enabled, no DeepEP or FP4 allgather path is active, and `ep_size == dp_size`.
- **`python/sglang/srt/models/qwen2_moe.py`**: Skip `tensor_model_parallel_all_reduce` when `should_use_dp_reduce_scatterv()` is true (the reduction is deferred to the communicator).
- **`python/sglang/srt/layers/communicator.py`**: In `CommunicateSummableTensorPairFn._scatter_hidden_states`, use `reduce_scatterv` (via `get_tp_group().reduce_scatterv`) instead of `dp_scatter` when the flag is active. Output is allocated from `get_local_dp_buffer()` for symmetric memory compatibility.
- **`python/sglang/srt/layers/moe/__init__.py`**: Export the new utility function.

The dispatch phase and kernel inputs are completely untouched — only the post-kernel communication (combine/scatter) is changed.

## Accuracy Tests

GSM8K 8-shot on **Qwen3.5-397B-A17B-FP8**, DP4 EP4, 1319 examples, max_tokens=16384:

| Configuration | GSM8K Score | std |
|---|---|---|
| **reduce_scatterv (this PR)** | **97.86%** | 0.1446 |
| baseline (all-reduce + dp_scatter) | 97.86% | 0.1446 |

Accuracy is identical — the optimization is mathematically equivalent (reduce + scatter = reduce_scatter).

## Speed Tests and Profiling

### Throughput

Max-throughput benchmark on **Qwen3.5-397B-A17B-FP8**, 1×GB200 node (4 GPUs), DP4 EP4 TP4, ISL=1000 OSL=1, concurrency=4096:

| Configuration | Throughput (tok/s) | Change |
|---|---|---|
| baseline (all-reduce + dp_scatter) | 53,006 | — |
| **reduce_scatterv (this PR)** | **57,115** | **+7.7%** |
<img width="1474" height="838" alt="image" src="https://github.com/user-attachments/assets/7420f9eb-6d62-40a6-a5c8-726aed8c2a78" />

### Profiling (100 decode steps, Torch Profiler)

**NCCL communication summary (DP0, TP0):**

| Metric | Baseline | reduce_scatterv | Change |
|---|---|---|---|
| Total NCCL time | 8,326ms | 7,193ms | **−13.6%** |
| AllReduce count | 4,920 (~49/step) | 2,460 (~25/step) | **−50%** |
| AllReduce total time | 8,324ms | 4,385ms | **−47.3%** |
| Reduce (scatterv) count | 0 | 2,460 (~25/step) | new |
| Reduce (scatterv) total time | 0ms | 2,806ms | new |
| Comm / Compute ratio | 105.5% | 97.3% | comm no longer bottleneck |

**Per-kernel latency (single decode step, steady state):**

| Kernel | Duration | Note |
|---|---|---|
| `ncclDevKernel_Reduce_Sum_bf16` (reduce_scatterv) | **~161µs** | replaces AllReduce for MoE layers |
| `ncclDevKernel_AllReduce_Sum_bf16` (baseline) | ~257µs | original MoE post-kernel comm |

<img width="1282" height="412" alt="image" src="https://github.com/user-attachments/assets/c9328203-befa-4e26-96ec-4f31178dc29b" />

<img width="1144" height="420" alt="image" src="https://github.com/user-attachments/assets/6324cbe4-b720-4fd6-93a2-283ebff562e6" />

**Why reduce_scatterv is faster:**

`AllReduce` = `ReduceScatter` + `AllGather`: it reduces data across all ranks *and* broadcasts the full result back to every rank. In DP attention, each rank only needs its own token subset for the next attention layer — the AllGather half is wasted work.

`reduce_scatterv` performs only the reduce-scatter phase, delivering each rank exactly the tokens it owns. This cuts the communication volume roughly in half (~37% per-kernel latency reduction, ~13.6% total NCCL time reduction), directly translating to the **+7.7% end-to-end throughput gain**.


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
