### PR TITLE
hot fix diffusion ci: isolate flux transformer quant unit test

### DIFF
--- a/python/sglang/multimodal_gen/test/unit/test_transformer_quant.py
+++ b/python/sglang/multimodal_gen/test/unit/test_transformer_quant.py
@@ -263,8 +263,18 @@ class TestTransformerQuantHelpers(unittest.TestCase):
     @patch(
         "sglang.multimodal_gen.runtime.layers.linear.get_tp_group", return_value=None
     )
+    @patch(
+        "sglang.multimodal_gen.runtime.layers.attention.layer.get_ring_parallel_world_size",
+        return_value=1,
+    )
+    @patch(
+        "sglang.multimodal_gen.runtime.layers.attention.selector.get_global_server_args",
+        return_value=SimpleNamespace(attention_backend=None),
+    )
     def test_flux_single_transformer_block_modelopt_excludes_use_full_prefix(
         self,
+        _mock_server_args,
+        _mock_ring_world_size,
         _mock_tp_group,
         _mock_group_size,
         _mock_group_rank,


### PR DESCRIPTION
In h100

<img width="2360" height="984" alt="h100_flux_ci_fix_pass" src="https://github.com/user-attachments/assets/b58e141d-a71b-4c48-a078-cc6659152e79" />


## What changed

This hot fix isolates `test_flux_single_transformer_block_modelopt_excludes_use_full_prefix` from unrelated global runtime state.

The test now mocks:
- `get_global_server_args()` so attention backend selection does not depend on process-wide diffusion server initialization
- `get_ring_parallel_world_size()` so the unit test does not require sequence-parallel groups to be initialized

## Root cause

After the FLUX.1 NVFP4 support landed, this unit test started instantiating a `FluxSingleTransformerBlock` path that reaches `USPAttention` construction.

In CI, that path implicitly depended on two pieces of global runtime state that unit tests do not initialize:
- global diffusion server args
- sequence-parallel group state

That caused the check to fail with:
- `ValueError: Global sgl_diffusion args is not set.`
- then, after mocking server args, `AssertionError: sequence parallel group is not initialized`

The production code path is fine; the test was over-coupled to runtime globals.

## Impact

This keeps the test focused on what it actually wants to validate:
- FLUX single-block ModelOpt exclude rules use the full module prefix
- the targeted layers fall back to `UnquantizedLinearMethod`

## Validation

- `pre-commit run --color=always --files python/sglang/multimodal_gen/test/unit/test_transformer_quant.py`
- H100:
  - `pytest -q python/sglang/multimodal_gen/test/unit/test_transformer_quant.py::TestTransformerQuantHelpers::test_flux_single_transformer_block_modelopt_excludes_use_full_prefix -q`
  - `pytest -q python/sglang/multimodal_gen/test/unit/test_transformer_quant.py -q`
