### PR TITLE
Simplify test_chunked_prefill; remove redundant tests

### DIFF
--- a/test/registered/scheduler/test_chunked_prefill.py
+++ b/test/registered/scheduler/test_chunked_prefill.py
@@ -15,9 +15,6 @@ class TestChunkedPrefill(CustomTestCase):
     def test_mixed_chunked_prefill(self):
         run_mmlu_test(disable_radix_cache=False, enable_mixed_chunk=True)
 
-    def test_chunked_prefill_without_radix_cache(self):
-        run_mmlu_test(disable_radix_cache=True, enable_mixed_chunk=False)
-
     def test_mixed_chunked_prefill_without_radix_cache(self):
         run_mmlu_test(disable_radix_cache=True, enable_mixed_chunk=True)
 

--- a/test/registered/scheduler/test_chunked_prefill.py
+++ b/test/registered/scheduler/test_chunked_prefill.py
@@ -12,9 +12,6 @@ register_amd_ci(est_time=312, suite="stage-b-test-1-gpu-small-amd")
 
 
 class TestChunkedPrefill(CustomTestCase):
-    def test_chunked_prefill(self):
-        run_mmlu_test(disable_radix_cache=False, enable_mixed_chunk=False)
-
     def test_mixed_chunked_prefill(self):
         run_mmlu_test(disable_radix_cache=False, enable_mixed_chunk=True)
 

--- a/test/registered/scheduler/test_chunked_prefill.py
+++ b/test/registered/scheduler/test_chunked_prefill.py
@@ -5,7 +5,7 @@ python3 -m unittest test_chunked_prefill.TestChunkedPrefill.test_mixed_chunked_p
 import unittest
 
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
-from sglang.test.test_utils import CustomTestCase, run_mmlu_test, run_mulit_request_test
+from sglang.test.test_utils import CustomTestCase, run_mmlu_test
 
 register_cuda_ci(est_time=360, suite="stage-b-test-1-gpu-small")
 register_amd_ci(est_time=312, suite="stage-b-test-1-gpu-small-amd")
@@ -17,12 +17,6 @@ class TestChunkedPrefill(CustomTestCase):
 
     def test_mixed_chunked_prefill_without_radix_cache(self):
         run_mmlu_test(disable_radix_cache=True, enable_mixed_chunk=True)
-
-    def test_mixed_chunked_prefill_multi_requests(self):
-        run_mulit_request_test(
-            enable_mixed_chunk=True,
-            chunked_prefill_size=2048,
-        )
 
 
 if __name__ == "__main__":

--- a/test/registered/scheduler/test_mixed_chunked_prefill.py
+++ b/test/registered/scheduler/test_mixed_chunked_prefill.py
@@ -1,5 +1,5 @@
 """
-python3 -m unittest test_chunked_prefill.TestChunkedPrefill.test_mixed_chunked_prefill_without_radix_cache
+python3 -m unittest test_mixed_chunked_prefill.TestMixedChunkedPrefill.test_mixed_chunked_prefill_without_radix_cache
 """
 
 import unittest
@@ -11,7 +11,7 @@ register_cuda_ci(est_time=360, suite="stage-b-test-1-gpu-small")
 register_amd_ci(est_time=312, suite="stage-b-test-1-gpu-small-amd")
 
 
-class TestChunkedPrefill(CustomTestCase):
+class TestMixedChunkedPrefill(CustomTestCase):
     def test_mixed_chunked_prefill(self):
         run_mmlu_test(disable_radix_cache=False, enable_mixed_chunk=True)
 

--- a/test/registered/scheduler/test_mixed_chunked_prefill.py
+++ b/test/registered/scheduler/test_mixed_chunked_prefill.py
@@ -29,7 +29,7 @@ class TestMixedChunkedPrefill(GSM8KMixin, CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
-        with envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.override(1):
+        with envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.override(2):
             cls.process = popen_launch_server(
                 cls.model,
                 cls.base_url,

--- a/test/registered/scheduler/test_mixed_chunked_prefill.py
+++ b/test/registered/scheduler/test_mixed_chunked_prefill.py
@@ -1,18 +1,54 @@
 import unittest
 
+from sglang.srt.environ import envs
+from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
-from sglang.test.test_utils import CustomTestCase, run_mmlu_test
+from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
+from sglang.test.test_utils import (
+    DEFAULT_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
 
-register_cuda_ci(est_time=360, suite="stage-b-test-1-gpu-small")
-register_amd_ci(est_time=312, suite="stage-b-test-1-gpu-small-amd")
+register_cuda_ci(est_time=160, suite="stage-b-test-1-gpu-small")
+register_amd_ci(est_time=140, suite="stage-b-test-1-gpu-small-amd")
 
 
-class TestMixedChunkedPrefill(CustomTestCase):
-    def test_mixed_chunked_prefill(self):
-        run_mmlu_test(disable_radix_cache=False, enable_mixed_chunk=True)
+class TestMixedChunkedPrefill(GSM8KMixin, CustomTestCase):
+    model = DEFAULT_MODEL_NAME_FOR_TEST
+    base_url = DEFAULT_URL_FOR_TEST
+    gsm8k_accuracy_thres = 0.62
 
-    def test_mixed_chunked_prefill_without_radix_cache(self):
-        run_mmlu_test(disable_radix_cache=True, enable_mixed_chunk=True)
+    extra_args = [
+        "--enable-mixed-chunk",
+        "--chunked-prefill-size",
+        "32",
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        with envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.override(1):
+            cls.process = popen_launch_server(
+                cls.model,
+                cls.base_url,
+                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                other_args=cls.extra_args,
+            )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+
+class TestMixedChunkedPrefillNoRadixCache(TestMixedChunkedPrefill):
+    extra_args = [
+        "--enable-mixed-chunk",
+        "--chunked-prefill-size",
+        "32",
+        "--disable-radix-cache",
+    ]
 
 
 if __name__ == "__main__":

--- a/test/registered/scheduler/test_mixed_chunked_prefill.py
+++ b/test/registered/scheduler/test_mixed_chunked_prefill.py
@@ -1,7 +1,3 @@
-"""
-python3 -m unittest test_mixed_chunked_prefill.TestMixedChunkedPrefill.test_mixed_chunked_prefill_without_radix_cache
-"""
-
 import unittest
 
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci

--- a/test/registered/scheduler/test_mixed_chunked_prefill.py
+++ b/test/registered/scheduler/test_mixed_chunked_prefill.py
@@ -12,8 +12,8 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=160, suite="stage-b-test-1-gpu-small")
-register_amd_ci(est_time=140, suite="stage-b-test-1-gpu-small-amd")
+register_cuda_ci(est_time=180, suite="stage-b-test-1-gpu-small")
+register_amd_ci(est_time=180, suite="stage-b-test-1-gpu-small-amd")
 
 
 class TestMixedChunkedPrefill(GSM8KMixin, CustomTestCase):


### PR DESCRIPTION
## Summary
Remove redundant tests in `test_chunked_prefill.py` to reduce CI time:

- `test_chunked_prefill` — default path (radix_cache=True, mixed_chunk=False), implicitly covered by all other MMLU integration tests
- `test_chunked_prefill_without_radix_cache` — disable_radix_cache path is already covered by `test_no_overlap_scheduler.py`
- `test_mixed_chunked_prefill_multi_requests` — no accuracy assertion (just `response.json()`); chunked_prefill_size=2048 rarely triggers chunking on short prompts

Keep:
- `test_mixed_chunked_prefill` — unique coverage of `enable_mixed_chunk=True` on default path
- `test_mixed_chunked_prefill_without_radix_cache` — unique coverage of `mixed_chunk + disable_radix_cache` combo

## Test plan
- [ ] CI: `test_chunked_prefill.py` passes with remaining 2 tests
- [ ] May need to adjust `est_time` (currently 360) after CI run