### PR TITLE
[XPU] Support apply_router_weight_on_input for Llama4 for fused_experts

### DIFF
--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -584,6 +584,9 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
             from sgl_kernel import fused_experts
 
             topk_weights, topk_ids, _ = topk_output
+            if moe_runner_config.apply_router_weight_on_input:
+                x = x * topk_weights.to(x.dtype)
+                topk_weights = torch.ones_like(topk_weights)
             output = fused_experts(
                 x,
                 layer.w13_weight,


### PR DESCRIPTION
When apply_router_weight_on_input is True (as used by Llama4's MoE architecture), apply router weights directly to the input tensor before calling fused_experts, and replace topk_weights with ones. This is needed because fused_experts does not natively handle this flag.

Enables Llama4 model support on XPU fused_experts() where apply_router_weight_on_input was previously unhandled.
```
SGLANG_USE_SGL_XPU=1 python3 -m sglang.launch_server --model models--meta-llama--Llama-4-Scout-17B-16E-Instruct/snapshots/92f3b1597a195b523d8d9e5700e57e4fbb8f20d3/ --tp 8 --mem-fraction-static 0.7 --attention-backend triton --cpu-offload-gb 20 --context-length 8192
```

**Before:**
```
# python benchmark/gsm8k/bench_sglang.py --num-questions 200 --num-shots 5 --host http://127.0.0.1 --port 30000
Accuracy: 0.935
Invalid: 0.000
Latency: 3394.296 s
Output throughput: 5.874 token/s
```
After
```
# python benchmark/gsm8k/bench_sglang.py --num-questions 200 --num-shots 5 --host http://127.0.0.1/ --port 30000
Accuracy: 0.945
Invalid: 0.000
Latency: 2413.049 s
Output throughput: 8.180 token/s
```