### PR TITLE
[Anthropic] support search_result blocks and built-in web search tools

### DIFF
--- a/python/sglang/srt/entrypoints/anthropic/protocol.py
+++ b/python/sglang/srt/entrypoints/anthropic/protocol.py
@@ -3,7 +3,44 @@
 import uuid
 from typing import Any, Literal, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+ANTHROPIC_WEB_SEARCH_TOOL_TYPES = frozenset(
+    {"web_search_20250305", "web_search_20260209"}
+)
+
+
+def validate_search_result_parts(
+    source: object, title: object, content: object
+) -> list[str]:
+    if not isinstance(source, str):
+        raise ValueError("search_result source must be a string")
+    if not source:
+        raise ValueError("search_result source must be non-empty")
+    if not isinstance(title, str):
+        raise ValueError("search_result title must be a string")
+    if not title:
+        raise ValueError("search_result title must be non-empty")
+    if not isinstance(content, list):
+        raise ValueError("search_result content must be a list")
+
+    text_parts: list[str] = []
+    for item in content:
+        if not isinstance(item, dict):
+            raise ValueError("search_result content blocks must be dictionaries")
+        if item.get("type") != "text":
+            raise ValueError("search_result content blocks must be text")
+        text = item.get("text")
+        if not isinstance(text, str):
+            raise ValueError("search_result text must be a string")
+        if not text:
+            raise ValueError("search_result text must be non-empty")
+        text_parts.append(text)
+
+    if not text_parts:
+        raise ValueError("search_result content must include at least one text block")
+
+    return text_parts
 
 
 class AnthropicError(BaseModel):
@@ -33,11 +70,18 @@ class AnthropicContentBlock(BaseModel):
     """Content block in message"""
 
     type: Literal[
-        "text", "image", "tool_use", "tool_result", "thinking", "redacted_thinking"
+        "text",
+        "image",
+        "tool_use",
+        "tool_result",
+        "thinking",
+        "redacted_thinking",
+        "search_result",
     ]
     text: Optional[str] = None
     # For image content
-    source: Optional[dict[str, Any]] = None
+    source: Optional[dict[str, Any] | str] = None
+    title: Optional[str] = None
     # For tool use/result
     id: Optional[str] = None
     tool_use_id: Optional[str] = None
@@ -48,6 +92,14 @@ class AnthropicContentBlock(BaseModel):
     # For thinking content
     thinking: Optional[str] = None
     signature: Optional[str] = None
+
+    @model_validator(mode="after")
+    def validate_search_result(self) -> "AnthropicContentBlock":
+        if self.type != "search_result":
+            return self
+
+        validate_search_result_parts(self.source, self.title, self.content)
+        return self
 
 
 class AnthropicMessage(BaseModel):
@@ -62,16 +114,40 @@ class AnthropicTool(BaseModel):
 
     name: str
     description: Optional[str] = None
-    input_schema: dict[str, Any]
+    type: Optional[str] = None
+    input_schema: Optional[dict[str, Any]] = None
+    allowed_callers: Optional[list[str]] = None
+    allowed_domains: Optional[list[str]] = None
+    blocked_domains: Optional[list[str]] = None
+    cache_control: Optional[dict[str, Any]] = None
+    defer_loading: Optional[bool] = None
+    max_uses: Optional[int] = None
+    strict: Optional[bool] = None
+    user_location: Optional[dict[str, Any]] = None
 
     @field_validator("input_schema")
     @classmethod
-    def validate_input_schema(cls, v):
+    def validate_input_schema(cls, v: object) -> dict[str, Any] | None:
+        if v is None:
+            return v
         if not isinstance(v, dict):
             raise ValueError("input_schema must be a dictionary")
         if "type" not in v:
             v["type"] = "object"
         return v
+
+    @model_validator(mode="after")
+    def validate_tool_shape(self) -> "AnthropicTool":
+        if not self.name:
+            raise ValueError("tool name must be non-empty")
+
+        if self.type in ANTHROPIC_WEB_SEARCH_TOOL_TYPES:
+            return self
+
+        if self.input_schema is None:
+            raise ValueError("input_schema is required for custom tools")
+
+        return self
 
 
 class AnthropicToolChoice(BaseModel):

--- a/python/sglang/srt/entrypoints/anthropic/serving.py
+++ b/python/sglang/srt/entrypoints/anthropic/serving.py
@@ -16,6 +16,7 @@ from fastapi import Request
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from sglang.srt.entrypoints.anthropic.protocol import (
+    ANTHROPIC_WEB_SEARCH_TOOL_TYPES,
     AnthropicContentBlock,
     AnthropicCountTokensRequest,
     AnthropicCountTokensResponse,
@@ -25,7 +26,9 @@ from sglang.srt.entrypoints.anthropic.protocol import (
     AnthropicMessagesRequest,
     AnthropicMessagesResponse,
     AnthropicStreamEvent,
+    AnthropicTool,
     AnthropicUsage,
+    validate_search_result_parts,
 )
 from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionRequest,
@@ -53,6 +56,128 @@ STOP_REASON_MAP = {
 def _wrap_sse_event(data: str, event_type: str) -> str:
     """Format an Anthropic SSE event with event type and data lines."""
     return f"event: {event_type}\ndata: {data}\n\n"
+
+
+def _convert_anthropic_image_source_to_openai_part(source: Optional[dict]) -> Optional[dict]:
+    if not isinstance(source, dict):
+        return None
+
+    source_type = source.get("type")
+    if source_type == "base64":
+        media_type = source.get("media_type", "image/png")
+        data = source.get("data", "")
+        if not data:
+            return None
+        return {
+            "type": "image_url",
+            "image_url": {
+                "url": f"data:{media_type};base64,{data}",
+            },
+        }
+
+    url = source.get("url")
+    if not url:
+        return None
+    return {
+        "type": "image_url",
+        "image_url": {
+            "url": url,
+        },
+    }
+
+
+def _anthropic_search_result_to_openai_text(block: AnthropicContentBlock) -> str:
+    if block.type != "search_result":
+        raise ValueError("search result blocks must have type=search_result")
+
+    result_text = "\n".join(
+        validate_search_result_parts(block.source, block.title, block.content)
+    )
+    return "\n".join(
+        [
+            "[Search Result]",
+            f"Title: {block.title}",
+            f"Source: {block.source}",
+            "Content:",
+            result_text,
+        ]
+    )
+
+
+def _convert_tool_result_content(
+    content: Optional[str | list[dict[str, object]]],
+) -> tuple[str | list[dict], str]:
+    if isinstance(content, list):
+        tool_content_parts = []
+        tool_text_parts = []
+
+        for item in content:
+            if not isinstance(item, dict):
+                raise ValueError("tool_result content blocks must be dictionaries")
+
+            item_type = item.get("type")
+            if item_type == "text":
+                text = item.get("text")
+                if not isinstance(text, str):
+                    raise ValueError("tool_result text blocks must include string text")
+                tool_text_parts.append(text)
+                tool_content_parts.append({"type": "text", "text": text})
+            elif item_type == "search_result":
+                search_result = AnthropicContentBlock.model_validate(item)
+                search_result_text = _anthropic_search_result_to_openai_text(search_result)
+                tool_text_parts.append(search_result_text)
+                tool_content_parts.append({"type": "text", "text": search_result_text})
+            elif item_type == "image":
+                image_part = _convert_anthropic_image_source_to_openai_part(
+                    item.get("source")
+                )
+                if image_part is None:
+                    raise ValueError("tool_result image blocks must include a valid source")
+                tool_content_parts.append(image_part)
+            else:
+                raise ValueError(
+                    f"unsupported tool_result content block type: {item_type}"
+                )
+
+        tool_text = "\n".join(tool_text_parts)
+        if len(tool_content_parts) == 1 and tool_content_parts[0]["type"] == "text":
+            return tool_content_parts[0]["text"], tool_text
+        if tool_content_parts:
+            return tool_content_parts, tool_text
+        return "", tool_text
+
+    tool_text = str(content) if content else ""
+    return tool_text, tool_text
+
+
+def _convert_anthropic_tool_to_openai_tool(tool: AnthropicTool) -> Tool:
+    parameters = tool.input_schema
+    if parameters is None:
+        if tool.type not in ANTHROPIC_WEB_SEARCH_TOOL_TYPES:
+            raise ValueError(f"unsupported anthropic tool definition: {tool.type or tool.name}")
+        parameters = {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Search query",
+                }
+            },
+            "required": ["query"],
+        }
+
+    description = tool.description
+    if not description and tool.type in ANTHROPIC_WEB_SEARCH_TOOL_TYPES:
+        description = "Anthropic web search tool"
+
+    return Tool(
+        type="function",
+        function={
+            "name": tool.name,
+            "description": description or "",
+            "parameters": parameters,
+        },
+    )
 
 
 class AnthropicServing:
@@ -92,73 +217,6 @@ class AnthropicServing:
         """Convert an Anthropic Messages request to an OpenAI ChatCompletion request."""
         openai_messages = []
 
-        def _convert_anthropic_image_source_to_openai_part(
-            source: Optional[dict],
-        ) -> Optional[dict]:
-            if not isinstance(source, dict):
-                return None
-
-            source_type = source.get("type")
-            if source_type == "base64":
-                media_type = source.get("media_type", "image/png")
-                data = source.get("data", "")
-                if not data:
-                    return None
-                return {
-                    "type": "image_url",
-                    "image_url": {
-                        "url": f"data:{media_type};base64,{data}",
-                    },
-                }
-
-            url = source.get("url")
-            if url:
-                return {
-                    "type": "image_url",
-                    "image_url": {
-                        "url": url,
-                    },
-                }
-
-            return None
-
-        def _convert_tool_result_content(
-            content: Optional[str | list[dict]],
-        ) -> tuple[str | list[dict], str]:
-            if isinstance(content, list):
-                tool_content_parts = []
-                tool_text_parts = []
-
-                for item in content:
-                    if not isinstance(item, dict):
-                        continue
-
-                    item_type = item.get("type")
-                    if item_type == "text":
-                        text = item.get("text", "")
-                        if text:
-                            tool_text_parts.append(text)
-                            tool_content_parts.append({"type": "text", "text": text})
-                    elif item_type == "image":
-                        image_part = _convert_anthropic_image_source_to_openai_part(
-                            item.get("source")
-                        )
-                        if image_part is not None:
-                            tool_content_parts.append(image_part)
-
-                tool_text = "\n".join(tool_text_parts)
-                if (
-                    len(tool_content_parts) == 1
-                    and tool_content_parts[0]["type"] == "text"
-                ):
-                    return tool_content_parts[0]["text"], tool_text
-                if tool_content_parts:
-                    return tool_content_parts, tool_text
-                return "", tool_text
-
-            tool_text = str(content) if content else ""
-            return tool_text, tool_text
-
         # Add system message if provided
         if anthropic_request.system:
             if isinstance(anthropic_request.system, str):
@@ -188,6 +246,10 @@ class AnthropicServing:
                 if block.type == "text" and block.text:
                     content_parts.append({"type": "text", "text": block.text})
 
+                elif block.type == "search_result":
+                    search_result_text = _anthropic_search_result_to_openai_text(block)
+                    content_parts.append({"type": "text", "text": search_result_text})
+
                 elif block.type == "image" and block.source:
                     image_part = _convert_anthropic_image_source_to_openai_part(
                         block.source
@@ -196,11 +258,15 @@ class AnthropicServing:
                         content_parts.append(image_part)
 
                 elif block.type == "tool_use":
+                    if not block.id:
+                        raise ValueError("tool_use must include id")
+                    if not block.name:
+                        raise ValueError("tool_use must include name")
                     tool_call = {
-                        "id": block.id or f"call_{uuid.uuid4().hex}",
+                        "id": block.id,
                         "type": "function",
                         "function": {
-                            "name": block.name or "",
+                            "name": block.name,
                             "arguments": json.dumps(block.input or {}),
                         },
                     }
@@ -211,10 +277,10 @@ class AnthropicServing:
                         block.content
                     )
 
-                    # Use tool_use_id (per spec) with fallback to id
-                    tool_call_id = block.tool_use_id or block.id or ""
+                    tool_call_id = block.tool_use_id
+                    if not tool_call_id:
+                        raise ValueError("tool_result must include tool_use_id")
 
-                    # Tool results from user become separate tool messages
                     if msg.role == "user":
                         openai_messages.append(
                             {
@@ -273,16 +339,7 @@ class AnthropicServing:
         if anthropic_request.tools:
             tools = []
             for tool in anthropic_request.tools:
-                tools.append(
-                    Tool(
-                        type="function",
-                        function={
-                            "name": tool.name,
-                            "description": tool.description or "",
-                            "parameters": tool.input_schema,
-                        },
-                    )
-                )
+                tools.append(_convert_anthropic_tool_to_openai_tool(tool))
             chat_request.tools = tools
 
         # Convert tool choice

--- a/test/registered/openai_server/basic/test_anthropic_server.py
+++ b/test/registered/openai_server/basic/test_anthropic_server.py
@@ -35,53 +35,8 @@ register_cuda_ci(est_time=120, suite="stage-b-test-1-gpu-small")
 register_amd_ci(est_time=140, suite="stage-b-test-1-gpu-small-amd")
 
 
-class TestAnthropicServer(CustomTestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.model = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
-        cls.base_url = DEFAULT_URL_FOR_TEST
-        cls.api_key = "sk-123456"
-        cls.process = popen_launch_server(
-            cls.model,
-            cls.base_url,
-            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            api_key=cls.api_key,
-        )
-        cls.messages_url = cls.base_url + "/v1/messages"
-
-    @classmethod
-    def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
-
-    def _make_request(self, payload, stream=False):
-        """Send a request to the /v1/messages endpoint."""
-        headers = {
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {self.api_key}",
-        }
-        return requests.post(
-            self.messages_url,
-            headers=headers,
-            json=payload,
-            stream=stream,
-        )
-
-    def _default_payload(self, **overrides):
-        """Build a default Anthropic Messages request payload."""
-        payload = {
-            "model": self.model,
-            "max_tokens": 64,
-            "messages": [
-                {
-                    "role": "user",
-                    "content": "What is the capital of France? Answer in a few words.",
-                }
-            ],
-        }
-        payload.update(overrides)
-        return payload
-
-    # ---- Non-streaming tests ----
+class TestAnthropicRequestConversion(unittest.TestCase):
+    model = "test-model"
 
     def test_tool_result_image_content_conversion(self):
         """Tool-result image blocks should be preserved as OpenAI image_url content."""
@@ -146,6 +101,291 @@ class TestAnthropicServer(CustomTestCase):
             tool_message["content"][0]["image_url"]["url"],
             "data:image/png;base64,abcd",
         )
+
+    def test_search_result_content_conversion(self):
+        """search_result blocks should be flattened into deterministic text content."""
+        anthropic_request = AnthropicMessagesRequest(
+            model=self.model,
+            max_tokens=64,
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "search_result",
+                            "source": "https://example.com",
+                            "title": "Example Domain",
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": "Example Domain is for use in illustrative examples.",
+                                }
+                            ],
+                        },
+                        {"type": "text", "text": "Summarize this."},
+                    ],
+                }
+            ],
+        )
+
+        serving = AnthropicServing(openai_serving_chat=object())
+        chat_request = serving._convert_to_chat_completion_request(anthropic_request)
+        converted = chat_request.model_dump()
+
+        first_message = converted["messages"][0]
+        self.assertEqual(first_message["role"], "user")
+        self.assertIsInstance(first_message["content"], list)
+        self.assertEqual(first_message["content"][0]["type"], "text")
+        self.assertIn("Title: Example Domain", first_message["content"][0]["text"])
+        self.assertIn("Source: https://example.com", first_message["content"][0]["text"])
+        self.assertEqual(first_message["content"][1]["text"], "Summarize this.")
+
+    def test_search_result_tool_result_conversion(self):
+        """search_result blocks inside tool_result should become tool text content."""
+        anthropic_request = AnthropicMessagesRequest(
+            model=self.model,
+            max_tokens=64,
+            messages=[
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_1",
+                            "name": "web_search",
+                            "input": {"query": "example"},
+                        }
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "toolu_1",
+                            "content": [
+                                {
+                                    "type": "search_result",
+                                    "source": "https://example.com",
+                                    "title": "Example Domain",
+                                    "content": [
+                                        {
+                                            "type": "text",
+                                            "text": "Example Domain is for use in illustrative examples.",
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                },
+            ],
+        )
+
+        serving = AnthropicServing(openai_serving_chat=object())
+        chat_request = serving._convert_to_chat_completion_request(anthropic_request)
+        converted = chat_request.model_dump()
+
+        tool_message = converted["messages"][1]
+        self.assertEqual(tool_message["role"], "tool")
+        self.assertEqual(tool_message["tool_call_id"], "toolu_1")
+        self.assertIn("Title: Example Domain", tool_message["content"])
+        self.assertIn("Source: https://example.com", tool_message["content"])
+
+    def test_web_search_tool_without_input_schema_conversion(self):
+        """Anthropic built-in web_search tools should synthesize a query schema."""
+        anthropic_request = AnthropicMessagesRequest(
+            model=self.model,
+            max_tokens=64,
+            messages=[
+                {
+                    "role": "user",
+                    "content": "Search for example.com",
+                }
+            ],
+            tools=[
+                {
+                    "type": "web_search_20250305",
+                    "name": "web_search",
+                    "max_uses": 5,
+                }
+            ],
+        )
+
+        serving = AnthropicServing(openai_serving_chat=object())
+        chat_request = serving._convert_to_chat_completion_request(anthropic_request)
+        converted = chat_request.model_dump()
+
+        tool_definition = converted["tools"][0]["function"]
+        self.assertEqual(tool_definition["name"], "web_search")
+        self.assertEqual(tool_definition["parameters"]["required"], ["query"])
+        self.assertEqual(
+            tool_definition["parameters"]["properties"]["query"]["type"], "string"
+        )
+        self.assertEqual(converted["tool_choice"], "auto")
+
+    def test_custom_tool_without_input_schema_rejected(self):
+        """Custom Anthropic tools must provide input_schema."""
+        with self.assertRaises(ValueError):
+            AnthropicMessagesRequest(
+                model=self.model,
+                max_tokens=64,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": "Call the tool.",
+                    }
+                ],
+                tools=[
+                    {
+                        "name": "custom_tool",
+                    }
+                ],
+            )
+
+    def test_invalid_search_result_rejected(self):
+        """Malformed search_result blocks should fail validation."""
+        with self.assertRaises(ValueError):
+            AnthropicMessagesRequest(
+                model=self.model,
+                max_tokens=64,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "search_result",
+                                "source": "https://example.com",
+                                "title": "Example Domain",
+                                "content": [],
+                            }
+                        ],
+                    }
+                ],
+            )
+
+    def test_tool_use_requires_id(self):
+        """tool_use blocks must include an id."""
+        anthropic_request = AnthropicMessagesRequest(
+            model=self.model,
+            max_tokens=64,
+            messages=[
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "web_search",
+                            "input": {"query": "example"},
+                        }
+                    ],
+                }
+            ],
+        )
+
+        serving = AnthropicServing(openai_serving_chat=object())
+        with self.assertRaisesRegex(ValueError, "tool_use must include id"):
+            serving._convert_to_chat_completion_request(anthropic_request)
+
+    def test_tool_result_requires_tool_use_id(self):
+        """tool_result blocks must include tool_use_id."""
+        anthropic_request = AnthropicMessagesRequest(
+            model=self.model,
+            max_tokens=64,
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "content": "result",
+                        }
+                    ],
+                }
+            ],
+        )
+
+        serving = AnthropicServing(openai_serving_chat=object())
+        with self.assertRaisesRegex(ValueError, "tool_result must include tool_use_id"):
+            serving._convert_to_chat_completion_request(anthropic_request)
+
+    def test_tool_result_rejects_unknown_content_block(self):
+        """tool_result content blocks must use supported Anthropic types."""
+        anthropic_request = AnthropicMessagesRequest(
+            model=self.model,
+            max_tokens=64,
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "toolu_1",
+                            "content": [
+                                {
+                                    "type": "unknown",
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+        )
+
+        serving = AnthropicServing(openai_serving_chat=object())
+        with self.assertRaisesRegex(
+            ValueError, "unsupported tool_result content block type"
+        ):
+            serving._convert_to_chat_completion_request(anthropic_request)
+
+
+class TestAnthropicServer(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.api_key = "sk-123456"
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            api_key=cls.api_key,
+        )
+        cls.messages_url = cls.base_url + "/v1/messages"
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def _make_request(self, payload, stream=False):
+        """Send a request to the /v1/messages endpoint."""
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.api_key}",
+        }
+        return requests.post(
+            self.messages_url,
+            headers=headers,
+            json=payload,
+            stream=stream,
+        )
+
+    def _default_payload(self, **overrides):
+        """Build a default Anthropic Messages request payload."""
+        payload = {
+            "model": self.model,
+            "max_tokens": 64,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "What is the capital of France? Answer in a few words.",
+                }
+            ],
+        }
+        payload.update(overrides)
+        return payload
+
+    # ---- Non-streaming tests ----
 
     def test_simple_messages(self):
         """Test basic non-streaming message request."""
@@ -532,6 +772,35 @@ class TestAnthropicServer(CustomTestCase):
             tokens_no_system,
             "Adding system message should increase token count",
         )
+
+    def test_count_tokens_accepts_web_search_tool(self):
+        """count_tokens should accept Anthropic built-in web_search tools."""
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.api_key}",
+        }
+        payload = {
+            "model": self.model,
+            "messages": [
+                {"role": "user", "content": "Search for example.com"},
+            ],
+            "tools": [
+                {
+                    "type": "web_search_20260209",
+                    "name": "web_search",
+                    "max_uses": 3,
+                }
+            ],
+        }
+        resp = requests.post(
+            self.base_url + "/v1/messages/count_tokens",
+            headers=headers,
+            json=payload,
+        )
+        self.assertEqual(resp.status_code, 200, f"Response: {resp.text}")
+        body = resp.json()
+        self.assertIn("input_tokens", body)
+        self.assertGreater(body["input_tokens"], 0)
 
     # ---- Helpers ----
 


### PR DESCRIPTION
## Summary
- support Anthropic `search_result` blocks in the Messages request path
- accept built-in Anthropic `web_search_*` tools without `input_schema`
- add focused conversion regressions and fail fast on malformed Anthropic tool payloads

## Why
Claude Code WebSearch surfaced an Anthropic compatibility gap in `/v1/messages`.
- Messages API: https://docs.anthropic.com/en/api/messages
- Web search tool: https://docs.anthropic.com/en/docs/build-with-claude/tool-use/web-search-tool

Fixes #22655.

## Repro
```bash
sglang serve --model-path Qwen/Qwen3-4B-Instruct-2507 --tool-call-parser qwen --host 0.0.0.0 --port 30000
```

```bash
ANTHROPIC_API_KEY=sk-test \
ANTHROPIC_BASE_URL=http://127.0.0.1:30000 \
claude -p --allowedTools WebSearch --permission-mode bypassPermissions \
  --model Qwen/Qwen3-4B-Instruct-2507 \
  'You must use WebSearch exactly once. Search for Python official website and then reply with only the first result title.'
```

## Validation
- patch commit: `09fbd6b`
- `PYTHONPATH=/home/steve/sglang /home/steve/venv/bin/python -m unittest openai_server.basic.test_anthropic_server.TestAnthropicRequestConversion`
- direct `/v1/messages` and `/v1/messages/count_tokens` checks passed on `mi300-do-1`
- fresh end-to-end Claude Code WebSearch rerun passed against patched SGLang using `Qwen/Qwen3-4B-Instruct-2507`

Made with [Cursor](https://cursor.com)