### PR TITLE
Qwen3next flashinfer allreduce auto enable

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2171,7 +2171,8 @@ class ServerArgs:
             )
 
         # TRTLLM AllReduce Fusion supports SM90/100, enable it by default
-        # for models with explicit support (DeepseekV3, GptOss, Glm4Moe, Qwen3Moe)
+        # for models with explicit support (DeepseekV3, GptOss, Glm4Moe,
+        # Qwen3/Qwen3Next/Qwen3.5 MoE families)
         # TODO: currently, it is only supported in the single node scenario. https://github.com/flashinfer-ai/flashinfer/issues/2006
         # TODO: there is currently a bug on H20 device specifically, https://github.com/flashinfer-ai/flashinfer/issues/2204
         device_name = get_device_name()
@@ -2189,6 +2190,7 @@ class ServerArgs:
                 "Glm4MoeForCausalLM",
                 "Glm4MoeLiteForCausalLM",
                 "Qwen3MoeForCausalLM",
+                "Qwen3NextForCausalLM",
                 "KimiK25ForConditionalGeneration",
                 "Qwen3_5MoeForConditionalGeneration",
                 "Qwen3_5ForConditionalGeneration",

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1,7 +1,6 @@
 import json
 import tempfile
 import unittest
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from sglang.srt.server_args import PortArgs, ServerArgs, prepare_server_args
@@ -232,69 +231,6 @@ class TestSSLArgs(unittest.TestCase):
         self.assertEqual(server_args.ssl_certfile, "cert.pem")
         self.assertEqual(server_args.ssl_ca_certs, "ca.pem")
         self.assertEqual(server_args.ssl_keyfile_password, "secret")
-
-
-class TestModelSpecificAdjustments(unittest.TestCase):
-    def _make_qwen3_next_server_args(self, **overrides):
-        server_args = ServerArgs(model_path="dummy", **overrides)
-        server_args.tp_size = 4
-        server_args.nnodes = 1
-        server_args.attn_cp_size = 1
-        server_args.enable_dp_attention = False
-        server_args.moe_a2a_backend = "none"
-        return server_args
-
-    @patch("sglang.srt.server_args.get_device_name", return_value="NVIDIA H100")
-    @patch("sglang.srt.server_args.is_sm100_supported", return_value=False)
-    @patch("sglang.srt.server_args.is_sm90_supported", return_value=True)
-    @patch.object(ServerArgs, "_handle_mamba_radix_cache")
-    @patch.object(
-        ServerArgs,
-        "get_model_config",
-        return_value=SimpleNamespace(
-            hf_config=SimpleNamespace(architectures=["Qwen3NextForCausalLM"])
-        ),
-    )
-    def test_qwen3_next_auto_enables_flashinfer_allreduce_fusion(
-        self,
-        _mock_get_model_config,
-        _mock_handle_mamba_radix_cache,
-        _mock_is_sm90_supported,
-        _mock_is_sm100_supported,
-        _mock_get_device_name,
-    ):
-        server_args = self._make_qwen3_next_server_args()
-
-        server_args._handle_model_specific_adjustments()
-
-        self.assertTrue(server_args.enable_flashinfer_allreduce_fusion)
-
-    @patch("sglang.srt.server_args.get_device_name", return_value="NVIDIA H100")
-    @patch("sglang.srt.server_args.is_sm100_supported", return_value=False)
-    @patch("sglang.srt.server_args.is_sm90_supported", return_value=True)
-    @patch.object(ServerArgs, "_handle_mamba_radix_cache")
-    @patch.object(
-        ServerArgs,
-        "get_model_config",
-        return_value=SimpleNamespace(
-            hf_config=SimpleNamespace(architectures=["Qwen3NextForCausalLM"])
-        ),
-    )
-    def test_qwen3_next_enforce_disable_overrides_auto_enable(
-        self,
-        _mock_get_model_config,
-        _mock_handle_mamba_radix_cache,
-        _mock_is_sm90_supported,
-        _mock_is_sm100_supported,
-        _mock_get_device_name,
-    ):
-        server_args = self._make_qwen3_next_server_args(
-            enforce_disable_flashinfer_allreduce_fusion=True
-        )
-
-        server_args._handle_model_specific_adjustments()
-
-        self.assertFalse(server_args.enable_flashinfer_allreduce_fusion)
 
     def test_ssl_verify_without_ssl(self):
         server_args = ServerArgs(model_path="dummy")

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1,6 +1,7 @@
 import json
 import tempfile
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from sglang.srt.server_args import PortArgs, ServerArgs, prepare_server_args
@@ -231,6 +232,69 @@ class TestSSLArgs(unittest.TestCase):
         self.assertEqual(server_args.ssl_certfile, "cert.pem")
         self.assertEqual(server_args.ssl_ca_certs, "ca.pem")
         self.assertEqual(server_args.ssl_keyfile_password, "secret")
+
+
+class TestModelSpecificAdjustments(unittest.TestCase):
+    def _make_qwen3_next_server_args(self, **overrides):
+        server_args = ServerArgs(model_path="dummy", **overrides)
+        server_args.tp_size = 4
+        server_args.nnodes = 1
+        server_args.attn_cp_size = 1
+        server_args.enable_dp_attention = False
+        server_args.moe_a2a_backend = "none"
+        return server_args
+
+    @patch("sglang.srt.server_args.get_device_name", return_value="NVIDIA H100")
+    @patch("sglang.srt.server_args.is_sm100_supported", return_value=False)
+    @patch("sglang.srt.server_args.is_sm90_supported", return_value=True)
+    @patch.object(ServerArgs, "_handle_mamba_radix_cache")
+    @patch.object(
+        ServerArgs,
+        "get_model_config",
+        return_value=SimpleNamespace(
+            hf_config=SimpleNamespace(architectures=["Qwen3NextForCausalLM"])
+        ),
+    )
+    def test_qwen3_next_auto_enables_flashinfer_allreduce_fusion(
+        self,
+        _mock_get_model_config,
+        _mock_handle_mamba_radix_cache,
+        _mock_is_sm90_supported,
+        _mock_is_sm100_supported,
+        _mock_get_device_name,
+    ):
+        server_args = self._make_qwen3_next_server_args()
+
+        server_args._handle_model_specific_adjustments()
+
+        self.assertTrue(server_args.enable_flashinfer_allreduce_fusion)
+
+    @patch("sglang.srt.server_args.get_device_name", return_value="NVIDIA H100")
+    @patch("sglang.srt.server_args.is_sm100_supported", return_value=False)
+    @patch("sglang.srt.server_args.is_sm90_supported", return_value=True)
+    @patch.object(ServerArgs, "_handle_mamba_radix_cache")
+    @patch.object(
+        ServerArgs,
+        "get_model_config",
+        return_value=SimpleNamespace(
+            hf_config=SimpleNamespace(architectures=["Qwen3NextForCausalLM"])
+        ),
+    )
+    def test_qwen3_next_enforce_disable_overrides_auto_enable(
+        self,
+        _mock_get_model_config,
+        _mock_handle_mamba_radix_cache,
+        _mock_is_sm90_supported,
+        _mock_is_sm100_supported,
+        _mock_get_device_name,
+    ):
+        server_args = self._make_qwen3_next_server_args(
+            enforce_disable_flashinfer_allreduce_fusion=True
+        )
+
+        server_args._handle_model_specific_adjustments()
+
+        self.assertFalse(server_args.enable_flashinfer_allreduce_fusion)
 
     def test_ssl_verify_without_ssl(self):
         server_args = ServerArgs(model_path="dummy")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

Made with @Codex

## Summary

Enable FlashInfer allreduce fusion by default for `Qwen3NextForCausalLM` on supported single-node SM90/SM100 TP runs.

## Why

`Qwen/Qwen3-Coder-Next` was running with `enable_flashinfer_allreduce_fusion=false` on H100, and profiler traces showed prefill time dominated by unfused cross-device reduce kernels.

## Change

- add `Qwen3NextForCausalLM` to the existing FlashInfer allreduce auto-enable whitelist

## H100 Evidence

Model: `Qwen/Qwen3-Coder-Next`

Command:

```bash
python -m sglang.launch_server --model-path Qwen/Qwen3-Coder-Next --tp 4 --port 31080
```

Server args:

- baseline: `enable_flashinfer_allreduce_fusion=false`
- patch: `enable_flashinfer_allreduce_fusion=true`

Benchmark (`sglang.bench_serving`, `random 2048/256`, `128 prompts`, `max_concurrency=32`):

| Metric | Baseline | Patch | Delta |
| --- | ---: | ---: | ---: |
| Request throughput (req/s) | 5.49 | 9.41 | +71.4% |
| Mean TTFT (ms) | 456.24 | 167.54 | -63.3% |
| Mean TPOT (ms) | 50.41 | 25.49 | -49.4% |

Full accuracy:

| Eval | Baseline | Patch | Delta |
| --- | ---: | ---: | ---: |
| MMLU (14042) | 0.8745905 | 0.8714571 | -0.31 pp |
| GSM8K (1314) | 0.9627093 | 0.9687976 | +0.61 pp |

Profiler (`TP-0 EXTEND`):

- baseline: `cross_device_reduce_2stage 136.171 ms (21.89%)`
- patch: `allreduce_fusion_kernel_oneshot_lamport 57.661 ms (10.41%)`

This change activates the fused allreduce path and removes the previous dominant unfused reduce hotspot.

## Validation

- H100 before/after throughput benchmark
- H100 before/after `sglang.profiler`
- H100 before/after full `MMLU` and full `GSM8K` server eval


<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
