### PR TITLE
[SM100] Fuse bias addition into fp8_blockwise_scaled_mm epilogue

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -59,6 +59,14 @@ _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 _use_aiter_gfx95 = _use_aiter and _is_gfx95_supported
 
 
+def _is_sm100_device(device: torch.device) -> bool:
+    if device.type != "cuda":
+        return False
+    device_id = torch.cuda.current_device() if device.index is None else device.index
+    major, _ = get_device_capability(device_id)
+    return major == 10
+
+
 def use_aiter_triton_gemm_w8a8_tuned_gfx950(n: int, k: int) -> bool:
     return (n, k) in [
         (1024, 8192),
@@ -104,7 +112,9 @@ if _is_cuda:
         return mat_a.new_empty((M, N), dtype=out_dtype)
 
     @register_fake_if_exists("sgl_kernel::fp8_blockwise_scaled_mm")
-    def _fp8_blockwise_scaled_mm_abstract(mat_a, mat_b, scales_a, scales_b, out_dtype):
+    def _fp8_blockwise_scaled_mm_abstract(
+        mat_a, mat_b, scales_a, scales_b, out_dtype, bias=None
+    ):
         # mat_a: [M, K], mat_b: [K, N] or [N, K] depending on callsite layout; output is [M, N].
         M = mat_a.shape[-2]
         N = mat_b.shape[-1]
@@ -627,10 +637,16 @@ def cutlass_w8a8_block_fp8_linear_with_fallback(
     q_input, x_scale = per_token_group_quant_fp8(
         input_2d, block_size[1], column_major_scales=True
     )
+    fuse_bias = bias is not None and _is_sm100_device(input_2d.device)
     output = fp8_blockwise_scaled_mm(
-        q_input, weight.T, x_scale, weight_scale.T, out_dtype=input_2d.dtype
+        q_input,
+        weight.T,
+        x_scale,
+        weight_scale.T,
+        out_dtype=input_2d.dtype,
+        bias=bias if fuse_bias else None,
     )
-    if bias is not None:
+    if bias is not None and not fuse_bias:
         output += bias
     return output.to(dtype=input_2d.dtype).view(*output_shape)
 

--- a/sgl-kernel/csrc/common_extension.cc
+++ b/sgl-kernel/csrc/common_extension.cc
@@ -124,7 +124,8 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.impl("fp8_scaled_mm", torch::kCUDA, &fp8_scaled_mm);
 
   m.def(
-      "fp8_blockwise_scaled_mm(Tensor mat_a, Tensor mat_b, Tensor scales_a, Tensor scales_b, ScalarType out_dtype) -> "
+      "fp8_blockwise_scaled_mm(Tensor mat_a, Tensor mat_b, Tensor scales_a, Tensor scales_b, ScalarType out_dtype, "
+      "Tensor? bias=None) -> "
       "Tensor");
   m.impl("fp8_blockwise_scaled_mm", torch::kCUDA, &fp8_blockwise_scaled_mm);
 

--- a/sgl-kernel/csrc/gemm/fp8_blockwise_gemm_kernel.cu
+++ b/sgl-kernel/csrc/gemm/fp8_blockwise_gemm_kernel.cu
@@ -171,27 +171,187 @@ void launch_sm100_fp8_blockwise_scaled_mm(
   TORCH_CHECK(status == cutlass::Status::kSuccess, cutlassGetStatusString(status))
 }
 
+template <
+    typename OutType,
+    typename MmaTileShape,
+    typename PerSmTileShape,
+    typename EpilogueTileShape,
+    typename ScalesPerTile,
+    int TileSizeM_ = 128,
+    class ClusterShape = Shape<_1, _1, _1>>
+void launch_sm100_fp8_blockwise_scaled_mm_with_bias(
+    torch::Tensor& out,
+    const torch::Tensor& a,
+    const torch::Tensor& b,
+    const torch::Tensor& scales_a,
+    const torch::Tensor& scales_b,
+    const torch::Tensor& bias) {
+  static constexpr int ScaleMsPerTile = size<0>(ScalesPerTile{});
+  static constexpr int ScaleGranularityM = size<0>(MmaTileShape{}) / ScaleMsPerTile;
+  static constexpr int ScaleGranularityN = size<1>(MmaTileShape{}) / size<1>(ScalesPerTile{});
+  static constexpr int ScaleGranularityK = size<2>(MmaTileShape{}) / size<2>(ScalesPerTile{});
+
+  using ElementAB = cutlass::float_e4m3_t;
+  using ElementA = ElementAB;
+  using ElementB = ElementAB;
+  using ElementD = OutType;
+  using ElementC = ElementD;
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::ColumnMajor;
+  using LayoutD = cutlass::layout::RowMajor;
+  using LayoutC = LayoutD;
+  // This means both SFA and SFB are column-major.
+  using ScaleConfig = cutlass::detail::Sm100BlockwiseScaleConfig<
+      ScaleGranularityM,
+      ScaleGranularityN,
+      ScaleGranularityK,
+      cute::UMMA::Major::MN,
+      cute::UMMA::Major::K>;
+  using LayoutSFA = decltype(ScaleConfig::deduce_layoutSFA());
+  using LayoutSFB = decltype(ScaleConfig::deduce_layoutSFB());
+
+  static constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementA>::value;
+  static constexpr int AlignmentB = 128 / cutlass::sizeof_bits<ElementB>::value;
+  static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
+  static constexpr int AlignmentC = AlignmentD;
+
+  using ElementAccumulator = float;
+  using ElementBlockScale = float;
+  using ElementCompute = float;
+  using ArchTag = cutlass::arch::Sm100;
+  using OperatorClass = cutlass::arch::OpClassTensorOp;
+
+  using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+      ArchTag,
+      cutlass::arch::OpClassTensorOp,
+      PerSmTileShape,
+      ClusterShape,
+      EpilogueTileShape,
+      ElementAccumulator,
+      ElementCompute,
+      ElementC,
+      LayoutC,
+      AlignmentC,
+      ElementD,
+      LayoutD,
+      AlignmentD,
+      cutlass::epilogue::TmaWarpSpecialized1Sm>::CollectiveOp;
+
+  using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+      ArchTag,
+      OperatorClass,
+      ElementA,
+      cute::tuple<LayoutA, LayoutSFA>,
+      AlignmentA,
+      ElementB,
+      cute::tuple<LayoutB, LayoutSFB>,
+      AlignmentB,
+      ElementAccumulator,
+      MmaTileShape,
+      ClusterShape,
+      cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+          sizeof(typename CollectiveEpilogue::SharedStorage))>,
+      cutlass::gemm::KernelTmaWarpSpecializedBlockwise1SmSm100>::CollectiveOp;
+
+  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+      Shape<int, int, int, int>,
+      CollectiveMainloop,
+      CollectiveEpilogue,
+      cutlass::gemm::PersistentScheduler>;
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+
+  Gemm gemm_op;
+
+  int m = a.size(0);
+  int k = a.size(1);
+  int n = b.size(1);
+
+  auto a_ptr = static_cast<ElementAB*>(a.data_ptr());
+  auto b_ptr = static_cast<ElementAB*>(b.data_ptr());
+  auto scales_a_ptr = static_cast<float*>(scales_a.data_ptr());
+  auto scales_b_ptr = static_cast<float*>(scales_b.data_ptr());
+  auto c_ptr = static_cast<ElementD*>(out.data_ptr());
+  auto bias_ptr = static_cast<ElementD*>(bias.data_ptr());
+
+  using StrideA = typename GemmKernel::StrideA;
+  using StrideB = typename GemmKernel::StrideB;
+  using StrideD = typename GemmKernel::StrideD;
+  using StrideC = typename GemmKernel::StrideC;
+
+  StrideA a_stride = cutlass::make_cute_packed_stride(StrideA{}, cute::make_shape(m, k, 1));
+  StrideB b_stride = cutlass::make_cute_packed_stride(StrideB{}, cute::make_shape(n, k, 1));
+  StrideD d_stride = cutlass::make_cute_packed_stride(StrideD{}, cute::make_shape(m, n, 1));
+  // Broadcast bias along M dimension: stride(M)=0 means same bias for each row,
+  // stride(N)=1 reads consecutive elements, stride(L)=0 for batch
+  StrideC bias_stride = cute::make_stride(int64_t(0), cute::C<1>{}, int64_t(0));
+  LayoutSFA layout_SFA = ScaleConfig::tile_atom_to_shape_SFA(make_shape(m, n, k, 1));
+  LayoutSFB layout_SFB = ScaleConfig::tile_atom_to_shape_SFB(make_shape(m, n, k, 1));
+
+  typename GemmKernel::MainloopArguments mainloop_args{
+      a_ptr, a_stride, b_ptr, b_stride, scales_a_ptr, layout_SFA, scales_b_ptr, layout_SFB};
+
+  typename GemmKernel::EpilogueArguments epilogue_args{{}, bias_ptr, bias_stride, c_ptr, d_stride};
+  epilogue_args.thread.alpha = 1.0f;
+  epilogue_args.thread.beta = 1.0f;
+
+  typename GemmKernel::Arguments args = {
+      cutlass::gemm::GemmUniversalMode::kGemm, {m, n, k, 1}, mainloop_args, epilogue_args};
+
+  auto can_implement = gemm_op.can_implement(args);
+  TORCH_CHECK(can_implement == cutlass::Status::kSuccess, cutlassGetStatusString(can_implement))
+
+  size_t workspace_size = gemm_op.get_workspace_size(args);
+  cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
+
+  auto init_status = gemm_op.initialize(args, workspace.get());
+  TORCH_CHECK(init_status == cutlass::Status::kSuccess, cutlassGetStatusString(init_status));
+
+  auto stream = at::cuda::getCurrentCUDAStream(a.get_device());
+
+  auto status = gemm_op.run(stream);
+  TORCH_CHECK(status == cutlass::Status::kSuccess, cutlassGetStatusString(status))
+}
+
 template <typename OutType>
 void sm100_fp8_blockwise_dispatch_shape(
     torch::Tensor& out,
     const torch::Tensor& a,
     const torch::Tensor& b,
     const torch::Tensor& scales_a,
-    const torch::Tensor& scales_b) {
+    const torch::Tensor& scales_b,
+    const c10::optional<torch::Tensor>& bias) {
   if (a.size(0) <= 128) {
     using MmaTileShape = Shape<_64, _128, _128>;
     using PerSmTileShape = Shape<_64, _128, _128>;
     using EpilogueTileShape = Shape<_64, _64>;
     using ScalesPerTile = Shape<_64, _1, _1>;
-    launch_sm100_fp8_blockwise_scaled_mm<OutType, MmaTileShape, PerSmTileShape, EpilogueTileShape, ScalesPerTile>(
-        out, a, b, scales_a, scales_b);
+    if (bias.has_value()) {
+      launch_sm100_fp8_blockwise_scaled_mm_with_bias<
+          OutType,
+          MmaTileShape,
+          PerSmTileShape,
+          EpilogueTileShape,
+          ScalesPerTile>(out, a, b, scales_a, scales_b, *bias);
+    } else {
+      launch_sm100_fp8_blockwise_scaled_mm<OutType, MmaTileShape, PerSmTileShape, EpilogueTileShape, ScalesPerTile>(
+          out, a, b, scales_a, scales_b);
+    }
   } else {
     using MmaTileShape = Shape<_128, _128, _128>;
     using PerSmTileShape = Shape<_128, _128, _128>;
     using EpilogueTileShape = Shape<_128, _64>;
     using ScalesPerTile = Shape<_128, _1, _1>;
-    launch_sm100_fp8_blockwise_scaled_mm<OutType, MmaTileShape, PerSmTileShape, EpilogueTileShape, ScalesPerTile>(
-        out, a, b, scales_a, scales_b);
+    if (bias.has_value()) {
+      launch_sm100_fp8_blockwise_scaled_mm_with_bias<
+          OutType,
+          MmaTileShape,
+          PerSmTileShape,
+          EpilogueTileShape,
+          ScalesPerTile>(out, a, b, scales_a, scales_b, *bias);
+    } else {
+      launch_sm100_fp8_blockwise_scaled_mm<OutType, MmaTileShape, PerSmTileShape, EpilogueTileShape, ScalesPerTile>(
+          out, a, b, scales_a, scales_b);
+    }
   }
 }
 
@@ -427,7 +587,8 @@ torch::Tensor fp8_blockwise_scaled_mm(
     const torch::Tensor& mat_b,
     const torch::Tensor& scales_a,
     const torch::Tensor& scales_b,
-    const torch::Dtype& out_dtype) {
+    const torch::Dtype& out_dtype,
+    const c10::optional<torch::Tensor>& bias) {
   TORCH_CHECK(mat_a.is_cuda(), "mat_a must be a CUDA tensor");
   TORCH_CHECK(mat_b.is_cuda(), "mat_b must be a CUDA tensor");
   TORCH_CHECK(mat_a.dim() == 2, "mat_a must be a 2D tensor");
@@ -472,6 +633,7 @@ torch::Tensor fp8_blockwise_scaled_mm(
 #if defined(CUTLASS_ARCH_MMA_SM90_SUPPORTED)
 #if defined CUDA_VERSION && CUDA_VERSION >= 12000
   if (sm_version == 90) {
+    TORCH_CHECK(!bias.has_value(), "fp8_blockwise_scaled_mm with bias is only supported on SM100, got SM", sm_version);
     torch::Tensor scales_b_contiguous = scales_b.contiguous();
     if (out_dtype == torch::kBFloat16) {
       cutlass_gemm_blockwise_sm90_fp8_dispatch<cutlass::bfloat16_t>(
@@ -492,11 +654,19 @@ torch::Tensor fp8_blockwise_scaled_mm(
       || sm_version == 103
 #endif
   ) {
+    if (bias.has_value()) {
+      TORCH_CHECK(bias->is_cuda(), "bias must be a CUDA tensor");
+      TORCH_CHECK(bias->dim() == 1, "bias must be a 1D tensor");
+      TORCH_CHECK(bias->size(0) == mat_b.size(1), "bias size must match N dimension (mat_b columns)");
+      TORCH_CHECK(bias->scalar_type() == out_dtype, "bias dtype must match out_dtype");
+      TORCH_CHECK(bias->is_contiguous(), "bias must be contiguous");
+    }
     if (out_dtype == torch::kBFloat16) {
       sm100_fp8_blockwise_dispatch_shape<cutlass::bfloat16_t>(
-          out_padded, mat_a_padded, mat_b, scales_a_padded, scales_b);
+          out_padded, mat_a_padded, mat_b, scales_a_padded, scales_b, bias);
     } else {
-      sm100_fp8_blockwise_dispatch_shape<cutlass::half_t>(out_padded, mat_a_padded, mat_b, scales_a_padded, scales_b);
+      sm100_fp8_blockwise_dispatch_shape<cutlass::half_t>(
+          out_padded, mat_a_padded, mat_b, scales_a_padded, scales_b, bias);
     }
     return out_padded.slice(0, 0, original_rows);
   }
@@ -506,6 +676,7 @@ torch::Tensor fp8_blockwise_scaled_mm(
 #if defined(CUTLASS_ARCH_MMA_SM120A_SUPPORTED) || defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED)
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 12080
   if (sm_version >= 120) {
+    TORCH_CHECK(!bias.has_value(), "fp8_blockwise_scaled_mm with bias is only supported on SM100, got SM", sm_version);
     if (out_dtype == torch::kBFloat16) {
       sm120_fp8_blockwise_dispatch_shape<cutlass::bfloat16_t>(
           out_padded, mat_a_padded, mat_b, scales_a_padded, scales_b);

--- a/sgl-kernel/include/sgl_kernel_ops.h
+++ b/sgl-kernel/include/sgl_kernel_ops.h
@@ -191,7 +191,8 @@ torch::Tensor fp8_blockwise_scaled_mm(
     const torch::Tensor& mat_b,
     const torch::Tensor& scales_a,
     const torch::Tensor& scales_b,
-    const torch::Dtype& out_dtype);
+    const torch::Dtype& out_dtype,
+    const c10::optional<torch::Tensor>& bias);
 void sgl_per_token_group_quant_8bit(
     at::Tensor input,
     at::Tensor output_q,

--- a/sgl-kernel/python/sgl_kernel/gemm.py
+++ b/sgl-kernel/python/sgl_kernel/gemm.py
@@ -21,13 +21,14 @@ def int8_scaled_mm(mat_a, mat_b, scales_a, scales_b, out_dtype, bias=None):
     )
 
 
-def fp8_blockwise_scaled_mm(mat_a, mat_b, scales_a, scales_b, out_dtype):
+def fp8_blockwise_scaled_mm(mat_a, mat_b, scales_a, scales_b, out_dtype, bias=None):
     return torch.ops.sgl_kernel.fp8_blockwise_scaled_mm.default(
         mat_a,
         mat_b,
         scales_a,
         scales_b,
         out_dtype,
+        bias,
     )
 
 

--- a/sgl-kernel/tests/test_fp8_blockwise_gemm.py
+++ b/sgl-kernel/tests/test_fp8_blockwise_gemm.py
@@ -60,7 +60,14 @@ def baseline_scaled_mm(
     return output
 
 
-def _test_accuracy_once(M, N, K, out_dtype, device):
+def _is_sm100():
+    if not torch.cuda.is_available():
+        return False
+    major, minor = torch.cuda.get_device_capability()
+    return major == 10 and minor in (0, 3)
+
+
+def _test_accuracy_once(M, N, K, out_dtype, device, use_bias=False):
     fp8_info = torch.finfo(torch.float8_e4m3fn)
     fp8_max, fp8_min = fp8_info.max, fp8_info.min
     a_fp32 = (torch.rand(M, K, dtype=torch.float32, device=device) - 0.5) * 2 * fp8_max
@@ -75,19 +82,32 @@ def _test_accuracy_once(M, N, K, out_dtype, device):
     scale_b = torch.randn(scale_b_shape, device=device, dtype=torch.float32) * 0.001
     scale_a = scale_a.t().contiguous().t()
     scale_b = scale_b.t().contiguous().t()
-    o = baseline_scaled_mm(a_fp8, b_fp8, scale_a, scale_b, out_dtype)
-    o1 = fp8_blockwise_scaled_mm(a_fp8, b_fp8, scale_a, scale_b, out_dtype)
+    bias = torch.randn(N, device=device, dtype=out_dtype) * 0.01 if use_bias else None
+    o = baseline_scaled_mm(a_fp8, b_fp8, scale_a, scale_b, out_dtype, bias=bias)
+    o1 = fp8_blockwise_scaled_mm(a_fp8, b_fp8, scale_a, scale_b, out_dtype, bias=bias)
     rtol = 0.02
     atol = 1
     torch.testing.assert_close(o, o1, rtol=rtol, atol=atol)
 
 
+@pytest.mark.parametrize(
+    "use_bias",
+    [
+        False,
+        pytest.param(
+            True,
+            marks=pytest.mark.skipif(
+                not _is_sm100(), reason="bias only supported on sm100 GPUs"
+            ),
+        ),
+    ],
+)
 @pytest.mark.parametrize("M", [1, 3, 5, 127, 128, 512, 1024, 4096])
 @pytest.mark.parametrize("N", [128, 512, 1024, 4096, 8192, 14080])
 @pytest.mark.parametrize("K", [512, 1024, 4096, 8192, 14080, 16384])
 @pytest.mark.parametrize("out_dtype", [torch.bfloat16, torch.float16])
-def test_accuracy(M, N, K, out_dtype):
-    _test_accuracy_once(M, N, K, out_dtype, "cuda")
+def test_accuracy(M, N, K, out_dtype, use_bias):
+    _test_accuracy_once(M, N, K, out_dtype, "cuda", use_bias=use_bias)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

In FP8 blockwise linear layers the bias addition (output += bias) is currently a separate element-wise kernel launch after GEMM, which incurs extra global memory round-trip and kernel launch overhead on SM100 GPUs. Fusing bias into the CUTLASS epilogue eliminates this overhead.

## Modifications

- **`sgl-kernel/csrc/gemm/fp8_blockwise_gemm_kernel.cu`**: Added `launch_sm100_fp8_blockwise_scaled_mm_with_bias` template function that uses `ElementC = ElementD` (non-void) in the CUTLASS `CollectiveBuilder`, passes bias pointer with broadcast stride `(0, 1, 0)` along M dimension, and sets `alpha=1.0, beta=1.0` in epilogue arguments. Updated `sm100_fp8_blockwise_dispatch_shape` to dispatch to the bias-fused variant when bias is provided. Added explicit rejection of bias for SM90 and SM120+ code paths.
- **`sgl-kernel/csrc/common_extension.cc`**: Extended `fp8_blockwise_scaled_mm` op schema with optional `Tensor? bias=None` parameter.
- **`sgl-kernel/include/sgl_kernel_ops.h`**: Updated C++ declaration accordingly.
- **`sgl-kernel/python/sgl_kernel/gemm.py`:** Forwarded new `bias` kwarg through Python binding.
- **`python/sglang/srt/layers/quantization/fp8_utils.py`**: In `cutlass_w8a8_block_fp8_linear_with_fallback`, detect SM100 via device capability and pass bias into the fused path; non-SM100 GPUs fall back to the existing separate `output += bias`.
- **`sgl-kernel/tests/test_fp8_blockwise_gemm.py`**: Added `_test_accuracy_once_with_bias` and parametrized `test_accuracy_with_bias` covering M ∈ {1,3,5,127,128,512,1024,4096}, N ∈ {128..14080}, K ∈ {512..16384}, both bf16 and fp16, gated by SM100 skip condition.

## Accuracy Tests

Added `test_accuracy_with_bias` test comparing fused-bias output against reference (`baseline_scaled_mm` with bias) at `rtol=0.02, atol=1`. Test is gated to run only on SM100 GPUs via `@pytest.mark.skipif`.
## Speed Tests and Profiling
running the following benchmark code using B200 gpu:
```python3
"""Benchmark: SM100 FP8 blockwise GEMM with fused bias vs. separate bias-add.

Compares two paths:
  - Fused:   fp8_blockwise_scaled_mm(..., bias=bias)          [epilogue alpha=1,beta=1]
  - Separate: out = fp8_blockwise_scaled_mm(...); out += bias  [two kernel launches]

Usage:
    python bench_bias_fusion.py
"""

import torch
import triton

from sgl_kernel import fp8_blockwise_scaled_mm


def _is_sm100():
    if not torch.cuda.is_available():
        return False
    major, minor = torch.cuda.get_device_capability()
    return major == 10 and minor in (0, 3)


def cdiv(a, b):
    return -(a // -b)


def scale_shape(shape, group_shape):
    return tuple(cdiv(shape[i], group_shape[i]) for i in range(len(group_shape)))


@triton.testing.perf_report(
    triton.testing.Benchmark(
        x_names=["M"],
        x_vals=[256, 512, 1024, 2048, 4096, 8192, 16384],
        x_log=True,
        line_arg="mode",
        line_vals=["fused", "separate"],
        line_names=["Fused (bias in epilogue)", "Separate (gemm + add)"],
        styles=[("green", "-"), ("red", "--")],
        ylabel="ms",
        plot_name="fp8_blockwise_gemm_bias_fusion",
        args={},
    )
)
def benchmark(mode, M, N, K, out_dtype):
    fp8_info = torch.finfo(torch.float8_e4m3fn)
    fp8_max, fp8_min = fp8_info.max, fp8_info.min

    a_fp32 = (torch.rand(M, K, dtype=torch.float32, device="cuda") - 0.5) * 2 * fp8_max
    a_fp8 = a_fp32.clamp(min=fp8_min, max=fp8_max).to(torch.float8_e4m3fn)

    b_fp32 = (torch.rand(N, K, dtype=torch.float32, device="cuda") - 0.5) * 2 * fp8_max
    b_fp8 = b_fp32.clamp(min=fp8_min, max=fp8_max).to(torch.float8_e4m3fn).t()

    scale_a_group_shape = (1, 128)
    scale_b_group_shape = (128, 128)
    scale_a_shape = scale_shape(a_fp8.shape, scale_a_group_shape)
    scale_b_shape = scale_shape(b_fp8.shape, scale_b_group_shape)

    scale_a = torch.randn(scale_a_shape, device="cuda", dtype=torch.float32) * 0.001
    scale_b = torch.randn(scale_b_shape, device="cuda", dtype=torch.float32) * 0.001
    scale_a = scale_a.t().contiguous().t()
    scale_b = scale_b.t().contiguous().t()

    bias = torch.randn(N, device="cuda", dtype=out_dtype) * 0.01

    # Warmup
    _ = fp8_blockwise_scaled_mm(a_fp8, b_fp8, scale_a, scale_b, out_dtype)
    _ = fp8_blockwise_scaled_mm(a_fp8, b_fp8, scale_a, scale_b, out_dtype, bias=bias)
    torch.cuda.synchronize()

    quantiles = [0.5, 0.2, 0.8]

    def run_fused():
        return fp8_blockwise_scaled_mm(
            a_fp8, b_fp8, scale_a, scale_b, out_dtype, bias=bias
        )

    def run_separate():
        out = fp8_blockwise_scaled_mm(
            a_fp8, b_fp8, scale_a, scale_b, out_dtype
        )
        out += bias
        return out

    if mode == "fused":
        ms, min_ms, max_ms = triton.testing.do_bench_cudagraph(
            run_fused, quantiles=quantiles
        )
    elif mode == "separate":
        ms, min_ms, max_ms = triton.testing.do_bench_cudagraph(
            run_separate, quantiles=quantiles
        )

    return ms * 1000, max_ms * 1000, min_ms * 1000


if __name__ == "__main__":
    if not _is_sm100():
        print("SKIP: bias fusion is only supported on SM100/SM103 GPUs")
        exit(0)

    test_shapes = [
        # (N, K, out_dtype) — representative DeepSeek-V3 MoE / Qwen FP8 shapes
        (7168, 7168, torch.bfloat16),
        (7168, 16384, torch.bfloat16),
        (16384, 7168, torch.float16),
        (14080, 16384, torch.bfloat16),  # typical FFN dim
        (8192, 8192, torch.float16),
    ]

    for N, K, out_dtype in test_shapes:
        print(f"\n{'='*60}")
        print(f"N={N}, K={K}, dtype={'bf16' if out_dtype==torch.bfloat16 else 'fp16'}")
        print(f"{'='*60}")
        try:
            benchmark.run(print_data=True, N=N, K=K, out_dtype=out_dtype)
        except Exception as e:
            print(f"  ERROR: {e}")

    print("\nBenchmark finished!")

```

here is the result:
```bash
============================================================
N=7168, K=7168, dtype=bf16
============================================================
fp8_blockwise_gemm_bias_fusion:
         M  Fused (bias in epilogue)  Separate (gemm + add)
0    256.0                 19.376838              23.838453
1    512.0                 35.659245              42.251312
2   1024.0                 67.925394              78.150920
3   2048.0                131.872603             146.603412
4   4096.0                263.217060             286.696246
5   8192.0                468.621148             579.818849
6  16384.0                918.596848            1141.510010

============================================================
N=7168, K=16384, dtype=bf16
============================================================
fp8_blockwise_gemm_bias_fusion:
         M  Fused (bias in epilogue)  Separate (gemm + add)
0    256.0                 43.785433              47.810112
1    512.0                 81.634298              86.983676
2   1024.0                153.299782             168.448712
3   2048.0                285.402742             303.855991
4   4096.0                583.059466             608.137285
5   8192.0               1082.428631            1297.316297
6  16384.0               2441.153844            2524.587359

============================================================
N=16384, K=7168, dtype=fp16
============================================================
fp8_blockwise_gemm_bias_fusion:
         M  Fused (bias in epilogue)  Separate (gemm + add)
0    256.0                 42.899774              49.212395
1    512.0                 78.094634              90.390543
2   1024.0                146.660226             167.952741
3   2048.0                293.780782             326.080557
4   4096.0                599.295009             651.446079
5   8192.0               1280.669912            1328.287951
6  16384.0               2664.572001            3237.196732

============================================================
N=14080, K=16384, dtype=bf16
============================================================
fp8_blockwise_gemm_bias_fusion:
         M  Fused (bias in epilogue)  Separate (gemm + add)
0    256.0                 84.381665              91.406007
1    512.0                139.445754             150.312793
2   1024.0                262.667424             285.423491
3   2048.0                534.803549             565.675649
4   4096.0               1135.408000            1194.958985
5   8192.0               2607.092023            2585.369246
6  16384.0               5389.096022            5207.893213

============================================================
N=8192, K=8192, dtype=fp16
============================================================
fp8_blockwise_gemm_bias_fusion:
         M  Fused (bias in epilogue)  Separate (gemm + add)
0    256.0                 23.325837              26.356896
1    512.0                 42.567962              49.080000
2   1024.0                 87.857144              97.445689
3   2048.0                166.243331             181.424160
4   4096.0                333.237237             362.018457
5   8192.0                652.479536             810.797899
6  16384.0               1271.440955            1512.180010

Benchmark finished!
```

## Checklist

- [ ✓] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [✓ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ✓] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ✓] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ✓] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
