### PR TITLE
fix: correct YaRN RoPE mscale calculation for models with mscale/msca…

### DIFF
--- a/python/sglang/srt/layers/rotary_embedding/factory.py
+++ b/python/sglang/srt/layers/rotary_embedding/factory.py
@@ -242,7 +242,14 @@ def get_rope(
                 k: v
                 for k, v in rope_scaling.items()
                 if k
-                in ("extrapolation_factor", "attn_factor", "beta_fast", "beta_slow")
+                in (
+                    "extrapolation_factor",
+                    "attn_factor",
+                    "beta_fast",
+                    "beta_slow",
+                    "mscale",
+                    "mscale_all_dim",
+                )
             }
             extra_kwargs["truncate"] = rope_scaling.get("truncate", True)
             if "mrope_section" in rope_scaling:

--- a/python/sglang/srt/layers/rotary_embedding/mrope.py
+++ b/python/sglang/srt/layers/rotary_embedding/mrope.py
@@ -15,6 +15,7 @@ from sglang.srt.layers.rotary_embedding.triton_kernels import (
 from sglang.srt.layers.rotary_embedding.utils import apply_rotary_emb
 from sglang.srt.layers.rotary_embedding.yarn import (
     yarn_find_correction_range,
+    yarn_get_mscale,
     yarn_get_mscale_simple,
     yarn_linear_ramp_mask,
 )
@@ -388,6 +389,8 @@ class YaRNScalingMRotaryEmbedding(MRotaryEmbedding):
         beta_fast: int = 32,
         beta_slow: int = 1,
         truncate: bool = True,
+        mscale: float = None,
+        mscale_all_dim: float = None,
     ) -> None:
         self.scaling_factor = scaling_factor
         self.extrapolation_factor = extrapolation_factor
@@ -395,7 +398,17 @@ class YaRNScalingMRotaryEmbedding(MRotaryEmbedding):
         self.beta_fast = beta_fast
         self.beta_slow = beta_slow
         self.truncate = truncate
-        self.mscale = float(yarn_get_mscale_simple(self.scaling_factor) * attn_factor)
+        # Match HuggingFace's logic: if both mscale and mscale_all_dim are provided,
+        # compute the ratio; otherwise fall back to the simple formula.
+        if mscale is not None and mscale_all_dim is not None:
+            self.mscale = float(
+                yarn_get_mscale(scaling_factor, mscale)
+                / yarn_get_mscale(scaling_factor, mscale_all_dim)
+            )
+        else:
+            self.mscale = float(
+                yarn_get_mscale_simple(self.scaling_factor) * attn_factor
+            )
         super().__init__(
             head_size,
             rotary_dim,

--- a/python/sglang/srt/layers/rotary_embedding/yarn.py
+++ b/python/sglang/srt/layers/rotary_embedding/yarn.py
@@ -83,6 +83,8 @@ class YaRNScalingRotaryEmbedding(RotaryEmbedding):
         beta_fast: int = 32,
         beta_slow: int = 1,
         truncate: bool = True,
+        mscale: float = None,
+        mscale_all_dim: float = None,
     ) -> None:
         self.scaling_factor = scaling_factor
         self.extrapolation_factor = extrapolation_factor
@@ -91,7 +93,17 @@ class YaRNScalingRotaryEmbedding(RotaryEmbedding):
         self.beta_slow = beta_slow
         self.truncate = truncate
         # Get n-d magnitude scaling corrected for interpolation
-        self.mscale = float(yarn_get_mscale_simple(self.scaling_factor) * attn_factor)
+        # Match HuggingFace's logic: if both mscale and mscale_all_dim are provided,
+        # compute the ratio; otherwise fall back to the simple formula.
+        if mscale is not None and mscale_all_dim is not None:
+            self.mscale = float(
+                yarn_get_mscale(scaling_factor, mscale)
+                / yarn_get_mscale(scaling_factor, mscale_all_dim)
+            )
+        else:
+            self.mscale = float(
+                yarn_get_mscale_simple(self.scaling_factor) * attn_factor
+            )
         super().__init__(
             head_size, rotary_dim, max_position_embeddings, base, is_neox_style, dtype
         )


### PR DESCRIPTION
## Motivation

When deploying Ministral3ForCausalLM (e.g., `baidu/ERNIE-T2I-PE`) via the SRT engine, the model produces repetitive output ("repeater" phenomenon). The same model works correctly when loaded through HuggingFace's `AutoModelForCausalLM` in the `multimodal_gen` pipeline.

Root cause: The SRT engine's `YaRNScalingRotaryEmbedding` ignores the `mscale` and `mscale_all_dim` parameters from `rope_parameters` in the model config. For Ministral3 (`mscale=1.0`, `mscale_all_dim=1.0`, `factor=16.0`), HuggingFace correctly computes `attention_factor = get_mscale(16, 1.0) / get_mscale(16, 1.0) = 1.0`, but the SRT engine was computing `mscale = yarn_get_mscale_simple(16.0) ≈ 1.277`, incorrectly scaling positional encodings by 27.7% and causing degraded attention quality and repetitive generation.

## Modifications

- **`factory.py`**: Added `"mscale"` and `"mscale_all_dim"` to the `extra_kwargs` extraction in the `yarn` branch, so these parameters are passed through to `YaRNScalingRotaryEmbedding` and `YaRNScalingMRotaryEmbedding`.
- **`yarn.py`**: `YaRNScalingRotaryEmbedding.__init__` now accepts `mscale` and `mscale_all_dim` parameters. When both are provided, computes `mscale = yarn_get_mscale(factor, mscale) / yarn_get_mscale(factor, mscale_all_dim)` matching HuggingFace's logic. Falls back to the original `yarn_get_mscale_simple(scaling_factor) * attn_factor` when neither is provided, ensuring full backward compatibility.
- **`mrope.py`**: `YaRNScalingMRotaryEmbedding` synced with the same fix. Added `yarn_get_mscale` to imports.

## Accuracy Tests

Deployed `ERNIE-T2I-PE` on a single H800 GPU with the fix applied:

```bash
curl http://localhost:8877/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "ERNIE-T2I-PE",
    "messages": [{"role": "user", "content": "{\"prompt\": \"a cat sitting on a windowsill\", \"width\": 1024, \"height\": 1024}"}],
    "max_tokens": 512, "temperature": 0.6, "top_p": 0.95
  }'
```

Results:
- **Before fix**: Model produces repetitive/looping text output
- **After fix**: Model generates coherent, detailed visual descriptions without repetition. `finish_reason: "stop"` at EOS token correctly
- Tested with multiple prompts (cat, sports car, sunset) and different temperatures (0.6, 1.0) — all produce correct output

## Speed Tests and Profiling

This fix only changes the mscale value used in the RoPE cos/sin cache computation (computed once at initialization). No impact on inference speed.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).