### PR TITLE
fix[glm4.7 flash]: properly detect `gfx95_quant_format`

### DIFF
--- a/python/sglang/srt/models/glm4_moe_lite.py
+++ b/python/sglang/srt/models/glm4_moe_lite.py
@@ -403,6 +403,8 @@ class Glm4MoeLiteDecoderLayer(DeepseekV2DecoderLayer):
             config.hidden_size, eps=config.rms_norm_eps
         )
 
+        self._gfx95_quant_format = self._detect_gfx95_quant_format()
+
         self.layer_communicator = LayerCommunicator(
             layer_scatter_modes=self.layer_scatter_modes,
             input_layernorm=self.input_layernorm,


### PR DESCRIPTION
Without this fix, glm 4.7 flash (and possibly the other glm models) cannot run due to 

```bash
  File "/ephemeral/dynamo/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ephemeral/dynamo/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ephemeral/sglang/python/sglang/srt/models/deepseek_v2.py", line 1754, in forward
    self._gfx95_quant_format,
    ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ephemeral/dynamo/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1964, in __getattr__
    raise AttributeError(
AttributeError: 'Glm4MoeLiteDecoderLayer' object has no attribute '_gfx95_quant_format'. Did you mean: '_detect_gfx95_quant_format'?
```

After this fix it loads in fine