### PR TITLE
[Misc] Add @cache_once to is_arch_support_pdl in jit_kernel

### DIFF
--- a/python/sglang/jit_kernel/utils.py
+++ b/python/sglang/jit_kernel/utils.py
@@ -52,7 +52,7 @@ def cache_once(fn: F) -> F:
 
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
-        key = (args, tuple(sorted(kwargs.items(), key=lambda x: x[0])))
+        key = (args, tuple(sorted(kwargs.items())))
         if key not in result_map:
             result_map[key] = fn(*args, **kwargs)
         return result_map[key]
@@ -305,6 +305,7 @@ def get_jit_cuda_arch() -> ArchInfo:
     return _CUDA_ARCH
 
 
+@cache_once
 def is_arch_support_pdl() -> bool:
     if is_hip_runtime():
         return False


### PR DESCRIPTION
## Summary
- Add `@cache_once` decorator to `jit_kernel`'s `is_arch_support_pdl` so the result is cached
- Remove redundant `key=lambda` from `sorted(kwargs.items())` in `cache_once`

## Test plan
- [ ] Existing CI tests pass
