### PR TITLE
feat(metrics): expose raw KV cache pool token counts as prometheus gauges

### DIFF
--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -114,6 +114,9 @@ class PoolStats:
             stats.swa_token_usage = self.swa_token_usage
         if self.is_hybrid_ssm:
             stats.mamba_usage = self.mamba_usage
+        stats.kv_available_tokens = self.full_available_size
+        stats.kv_evictable_tokens = self.full_evictable_size
+        stats.kv_used_tokens = self.full_num_used
 
 
 class SchedulerRuntimeCheckerMixin:

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -94,6 +94,9 @@ class SchedulerStats:
     cache_hit_rate: float = 0.0
 
     max_total_num_tokens: int = 0
+    kv_available_tokens: int = 0
+    kv_evictable_tokens: int = 0
+    kv_used_tokens: int = 0
 
     # Speculative decoding
     spec_accept_length: float = 0.0
@@ -275,6 +278,25 @@ class SchedulerMetricsCollector:
         self.max_total_num_tokens = Gauge(
             name="sglang:max_total_num_tokens",
             documentation="Maximum total number of tokens in the KV cache pool.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+
+        self.kv_available_tokens = Gauge(
+            name="sglang:kv_available_tokens",
+            documentation="Number of free token slots in the KV cache pool.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+        self.kv_evictable_tokens = Gauge(
+            name="sglang:kv_evictable_tokens",
+            documentation="Number of evictable (radix-cached) token slots in the KV cache pool.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+        self.kv_used_tokens = Gauge(
+            name="sglang:kv_used_tokens",
+            documentation="Number of actively used token slots in the KV cache pool.",
             labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
         )
@@ -1014,6 +1036,9 @@ class SchedulerMetricsCollector:
         self._log_gauge(self.cache_hit_rate, stats.cache_hit_rate)
 
         self._log_gauge(self.max_total_num_tokens, stats.max_total_num_tokens)
+        self._log_gauge(self.kv_available_tokens, stats.kv_available_tokens)
+        self._log_gauge(self.kv_evictable_tokens, stats.kv_evictable_tokens)
+        self._log_gauge(self.kv_used_tokens, stats.kv_used_tokens)
 
         # Speculative decoding
         self._log_gauge(self.spec_accept_length, stats.spec_accept_length)


### PR DESCRIPTION
## Summary

Expose three Prometheus gauges for the raw KV cache pool token counts:

- `sglang:kv_available_tokens` -- free pool slots
- `sglang:kv_evictable_tokens` -- radix-cached, reclaimable slots
- `sglang:kv_used_tokens` -- actively pinned slots

## Motivation

The existing `sglang:token_usage` metric reports only non-evictable tokens (active requests + pinned sessions). Evictable radix cache nodes are excluded, making the pool appear emptier than it is. This matters for agentic workloads where subagent KV lingers in the radix tree after completion -- `token_usage` shows ~2% while physical GPU memory is 72% consumed.

Exposing the raw counts at the most natural granularity lets operators derive any ratio they need in PromQL/Grafana, e.g.:

- Physical usage: `1 - (kv_available_tokens / (kv_available_tokens + kv_evictable_tokens + kv_used_tokens))`
- Evictable fraction: `kv_evictable_tokens / (kv_available_tokens + kv_evictable_tokens + kv_used_tokens)`

## Changes

- `metrics_collector.py`: Add `kv_available_tokens`, `kv_evictable_tokens`, `kv_used_tokens` fields to `SchedulerStats`, add Gauges to `SchedulerMetricsCollector`, log in `log_stats()`
- `scheduler_runtime_checker_mixin.py`: Plumb raw counts from `PoolStats.update_scheduler_stats()`