### PR TITLE
[Misc] Migrate SGLANG_SET_CPU_AFFINITY to envs and refactor model config building

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -379,10 +379,6 @@ class Scheduler(
             )
         )
 
-        self.enable_kv_cache_events = bool(
-            server_args.kv_events_config and self.attn_tp_rank == 0
-        )
-
         # Init model configs
         self.init_model_config()
 
@@ -3688,12 +3684,11 @@ def run_scheduler_process(
     dp_rank = configure_scheduler(
         server_args, tp_rank, attn_cp_rank, moe_dp_rank, moe_ep_rank, pp_rank, dp_rank
     )
-
     kill_itself_when_parent_died()
     parent_process = psutil.Process().parent()
 
     # Set cpu affinity to this gpu process
-    if get_bool_env_var("SGLANG_SET_CPU_AFFINITY"):
+    if envs.SGLANG_SET_CPU_AFFINITY.get():
         set_gpu_proc_affinity(
             server_args.pp_size, server_args.tp_size, server_args.nnodes, gpu_id
         )

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -360,7 +360,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self.dflash_draft_num_layers = None
         if self.spec_algorithm.is_eagle3() and not self.is_draft_worker:
             # load draft config
-            draft_model_config = ModelConfig.from_server_args(
+            draft_model_config = self._build_model_config(
                 server_args,
                 model_path=(server_args.speculative_draft_model_path),
                 model_revision=server_args.speculative_draft_model_revision,
@@ -389,7 +389,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             )
 
             # Select target layers to capture for building DFlash context features.
-            draft_model_config = ModelConfig.from_server_args(
+            draft_model_config = self._build_model_config(
                 server_args,
                 model_path=(server_args.speculative_draft_model_path),
                 model_revision=server_args.speculative_draft_model_revision,
@@ -494,6 +494,16 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # For weight updates
         self._model_update_group = {}
         self._weights_send_group = {}
+
+    def _build_model_config(
+        self, server_args, model_path=None, model_revision=None, is_draft_model=False
+    ):
+        return ModelConfig.from_server_args(
+            server_args,
+            model_path=model_path,
+            model_revision=model_revision,
+            is_draft_model=is_draft_model,
+        )
 
     def init_mindspore_runner(self):
         # Init the mindspore runner

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -174,9 +174,7 @@ class SchedulerMetricsMixin:
         )
 
     def init_kv_events(self: Scheduler, kv_events_config: Optional[str]):
-        self.enable_kv_cache_events = bool(
-            kv_events_config and self.attn_tp_rank == 0
-        )
+        self.enable_kv_cache_events = bool(kv_events_config and self.attn_tp_rank == 0)
 
         if self.enable_kv_cache_events:
             self.kv_event_publisher = EventPublisherFactory.create(

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -166,8 +166,7 @@ class SchedulerMetricsMixin:
                     reporter=self.metrics_collector.increment_gpu_overlap_wait_seconds,
                 )
 
-        if self.enable_kv_cache_events:
-            self.init_kv_events(self.server_args.kv_events_config)
+        self.init_kv_events(self.server_args.kv_events_config)
 
         self.scheduler_status_logger = SchedulerStatusLogger.maybe_create(
             enable_metrics=self.enable_metrics

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -174,6 +174,10 @@ class SchedulerMetricsMixin:
         )
 
     def init_kv_events(self: Scheduler, kv_events_config: Optional[str]):
+        self.enable_kv_cache_events = bool(
+            kv_events_config and self.attn_tp_rank == 0
+        )
+
         if self.enable_kv_cache_events:
             self.kv_event_publisher = EventPublisherFactory.create(
                 kv_events_config, self.attn_dp_rank


### PR DESCRIPTION
## Summary
- Use `envs.SGLANG_SET_CPU_AFFINITY.get()` instead of `get_bool_env_var()` in scheduler
- Move `enable_kv_cache_events` initialization into `SchedulerMetricsMixin.init_kv_events()`
- Extract `_build_model_config` helper in `ModelRunner` to wrap `ModelConfig.from_server_args`

## Test plan
- [ ] Existing CI tests pass (no behavioral change)