### PR TITLE
feat(multimodal): AITER FP8 FMHA backend for ROCm (Wan / DiT)

### DIFF
--- a/python/sglang/multimodal_gen/configs/models/adapter/base.py
+++ b/python/sglang/multimodal_gen/configs/models/adapter/base.py
@@ -22,6 +22,7 @@ class AdapterArchConfig(ArchConfig):
             AttentionBackendEnum.SAGE_ATTN,
             AttentionBackendEnum.FA,
             AttentionBackendEnum.AITER,
+            AttentionBackendEnum.AITER_FP8,
             AttentionBackendEnum.AITER_SAGE,
             AttentionBackendEnum.TORCH_SDPA,
             AttentionBackendEnum.VIDEO_SPARSE_ATTN,

--- a/python/sglang/multimodal_gen/configs/models/dits/base.py
+++ b/python/sglang/multimodal_gen/configs/models/dits/base.py
@@ -29,6 +29,7 @@ class DiTArchConfig(ArchConfig):
             AttentionBackendEnum.SAGE_ATTN,
             AttentionBackendEnum.FA,
             AttentionBackendEnum.AITER,
+            AttentionBackendEnum.AITER_FP8,
             AttentionBackendEnum.AITER_SAGE,
             AttentionBackendEnum.TORCH_SDPA,
             AttentionBackendEnum.VIDEO_SPARSE_ATTN,

--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/aiter.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/aiter.py
@@ -71,16 +71,15 @@ class AITerImpl(AttentionImpl):
         Performs attention using aiter.flash_attn_func.
 
         Args:
-            query: Query tensor of shape [batch_size, num_heads, seq_len, head_dim]
-            key: Key tensor of shape [batch_size, num_heads, seq_len, head_dim]
-            value: Value tensor of shape [batch_size, num_heads, seq_len, head_dim]
+            query: Query tensor of shape [batch_size, seq_len, num_heads, head_dim]
+            key: Key tensor of shape [batch_size, seq_len, num_heads, head_dim]
+            value: Value tensor of shape [batch_size, seq_len, num_heads, head_dim]
             attn_metadata: Metadata for the attention operation (unused).
 
         Returns:
-            Output tensor of shape [batch_size, num_heads, seq_len, head_dim]
+            Output tensor of shape [batch_size, seq_len, num_heads, head_dim]
         """
-        # aiter.flash_attn_func expects tensors in [B, H, S, D] layout,
-        # which is what ring_attn provides.
+        # Matches :class:`USPAttention` and AITER ``flash_attn_func`` layout [B, S, H, D].
         output, _ = aiter.flash_attn_func(
             query,
             key,

--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/aiter_fp8.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/aiter_fp8.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""ROCm AITER FP8 FMHA using ``aiter.flash_attn_fp8_pertensor_func``."""
+
+from __future__ import annotations
+
+import os
+
+import torch
+
+import aiter
+from aiter import dtypes
+
+from sglang.multimodal_gen.runtime.layers.attention.backends.attention_backend import (
+    AttentionBackend,
+    AttentionImpl,
+    AttentionMetadata,
+    AttentionMetadataBuilder,
+)
+from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+
+logger = init_logger(__name__)
+
+_DISABLE_ENV = "SGLANG_ROCM_DISABLE_FMHA_FP8"
+
+
+class AITerFP8Backend(AttentionBackend):
+    @staticmethod
+    def get_enum() -> AttentionBackendEnum:
+        return AttentionBackendEnum.AITER_FP8
+
+    @staticmethod
+    def get_impl_cls() -> type["AITerFP8Impl"]:
+        return AITerFP8Impl
+
+    @staticmethod
+    def get_metadata_cls() -> type["AttentionMetadata"]:
+        return AttentionMetadata
+
+    @staticmethod
+    def get_builder_cls() -> type["AttentionMetadataBuilder"]:
+        raise NotImplementedError(
+            "AITER FP8 backend does not have a metadata builder."
+        )
+
+
+class AITerFP8Impl(AttentionImpl):
+    """
+    FP8 attention via AITER CK FMHA with per-tensor Q/K/V scales.
+
+    Expects ``query``/``key``/``value`` in **[batch, seq, heads, head_dim]** — the
+    same layout as :class:`USPAttention` and AITER's ``flash_attn_func`` docstring.
+    """
+
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        softmax_scale: float,
+        causal: bool = False,
+        num_kv_heads: int | None = None,
+        prefix: str = "",
+        dropout_p: float = 0.0,
+        **extra_impl_args,
+    ) -> None:
+        if num_kv_heads is not None and num_kv_heads != num_heads:
+            raise NotImplementedError(
+                "AITER FP8 backend does not support grouped-query attention yet."
+            )
+        self.causal = causal
+        self.dropout_p = dropout_p
+        self._softmax_scale = softmax_scale
+
+        fp8_fn = getattr(aiter, "flash_attn_fp8_pertensor_func", None)
+        if fp8_fn is None:
+            raise ImportError(
+                "aiter.flash_attn_fp8_pertensor_func is not available. "
+                "Install a ROCm AITER build that exports this API (see ROCm/aiter "
+                "``aiter/ops/mha.py``)."
+            )
+        self._flash_attn_fp8 = fp8_fn
+
+        try:
+            from aiter.ops.quant import per_tensor_quant
+        except ImportError as e:
+            raise ImportError(
+                "aiter.ops.quant.per_tensor_quant is required for AITER FP8 attention."
+            ) from e
+        self._per_tensor_quant = per_tensor_quant
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attn_metadata: AttentionMetadata | None = None,
+    ) -> torch.Tensor:
+        out_dtype = query.dtype
+        disable = os.environ.get(_DISABLE_ENV, "").lower() in ("1", "true", "yes")
+
+        if disable:
+            logger.info(
+                "%s set: using bf16/fp16 aiter.flash_attn_func instead of FP8 FMHA.",
+                _DISABLE_ENV,
+            )
+            output, _ = aiter.flash_attn_func(
+                query,
+                key,
+                value,
+                dropout_p=self.dropout_p,
+                causal=self.causal,
+                return_attn_probs=False,
+                return_lse=True,
+            )
+            return output
+
+        q8, q_descale = self._per_tensor_quant(query, quant_dtype=dtypes.fp8)
+        k8, k_descale = self._per_tensor_quant(key, quant_dtype=dtypes.fp8)
+        v8, v_descale = self._per_tensor_quant(value, quant_dtype=dtypes.fp8)
+
+        out = self._flash_attn_fp8(
+            q8,
+            k8,
+            v8,
+            q_descale,
+            k_descale,
+            v_descale,
+            causal=self.causal,
+            window_size=(-1, -1, 0),
+            softmax_scale=self._softmax_scale,
+            sink_ptr=None,
+        )
+        return out.to(out_dtype)

--- a/python/sglang/multimodal_gen/runtime/platforms/cuda.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/cuda.py
@@ -326,6 +326,9 @@ class CudaPlatformBase(Platform):
         elif selected_backend == AttentionBackendEnum.AITER:
             logger.info("Using AITer backend")
             return "sglang.multimodal_gen.runtime.layers.attention.backends.aiter.AITerBackend"
+        elif selected_backend == AttentionBackendEnum.AITER_FP8:
+            logger.info("Using AITER FP8 backend (requires ROCm AITER with FP8 FMHA)")
+            return "sglang.multimodal_gen.runtime.layers.attention.backends.aiter_fp8.AITerFP8Backend"
         elif selected_backend == AttentionBackendEnum.TORCH_SDPA:
             logger.info("Using Torch SDPA backend")
             return "sglang.multimodal_gen.runtime.layers.attention.backends.sdpa.SDPABackend"

--- a/python/sglang/multimodal_gen/runtime/platforms/interface.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/interface.py
@@ -35,6 +35,7 @@ class AttentionBackendEnum(enum.Enum):
     SPARSE_VIDEO_GEN_2_ATTN = enum.auto()
     VMOBA_ATTN = enum.auto()
     AITER = enum.auto()
+    AITER_FP8 = enum.auto()
     AITER_SAGE = enum.auto()
     SLA_ATTN = enum.auto()
     SAGE_SLA_ATTN = enum.auto()

--- a/python/sglang/multimodal_gen/runtime/platforms/rocm.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/rocm.py
@@ -115,6 +115,16 @@ class RocmPlatform(Platform):
             logger.info("Using AITer backend on ROCm.")
             return "sglang.multimodal_gen.runtime.layers.attention.backends.aiter.AITerBackend"
 
+        elif selected_backend == AttentionBackendEnum.AITER_FP8:
+            if dtype not in (torch.float16, torch.bfloat16):
+                logger.warning(
+                    "AITER FP8 backend expects fp16/bf16 activations (quantized inside "
+                    "the kernel) but got dtype=%s.",
+                    dtype,
+                )
+            logger.info("Using AITER FP8 (per-tensor) FMHA backend on ROCm.")
+            return "sglang.multimodal_gen.runtime.layers.attention.backends.aiter_fp8.AITerFP8Backend"
+
         elif selected_backend == AttentionBackendEnum.AITER_SAGE:
             if dtype in (torch.float16, torch.bfloat16):
                 logger.info("Using AITER Sage backend on ROCm.")

--- a/python/sglang/multimodal_gen/runtime/platforms/xpu.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/xpu.py
@@ -176,6 +176,7 @@ class XpuPlatform(Platform):
             AttentionBackendEnum.VIDEO_SPARSE_ATTN,
             AttentionBackendEnum.VMOBA_ATTN,
             AttentionBackendEnum.AITER,
+            AttentionBackendEnum.AITER_FP8,
         ):
             logger.warning(
                 f"{selected_backend.name} is not supported on Intel XPU. "

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -579,7 +579,8 @@ class ServerArgs:
             default=None,
             help=(
                 "The attention backend to use. For SGLang-native pipelines, use "
-                "values like fa, torch_sdpa, sage_attn, etc. For diffusers pipelines, "
+                "values like fa, torch_sdpa, sage_attn, aiter, aiter_fp8, aiter_sage, "
+                "etc. For diffusers pipelines, "
                 "use diffusers attention backend names such as flash, _flash_3_hub, "
                 "sage, or xformers."
             ),


### PR DESCRIPTION
## Summary
Adds `AttentionBackendEnum.AITER_FP8` and an implementation that calls ROCm AITER `flash_attn_fp8_pertensor_func` with `per_tensor_quant` for Q/K/V. Tensor layout matches `USPAttention` and AITER `flash_attn_func`: **`[B, S, H, D]`**.

## Usage
- `--attention-backend aiter_fp8` on ROCm with an AITER build that exports `flash_attn_fp8_pertensor_func`.
- `SGLANG_ROCM_DISABLE_FMHA_FP8=1` forces the bf16/fp16 `aiter.flash_attn_func` path.

## Notes
- GQA is not supported (same as `AITerImpl` today).
- Ring attention remains limited to `fa` / `sage_attn`.
- `AITerImpl` docstrings are corrected to `[B, S, H, D]`.
- XPU: `aiter_fp8` falls back to SDPA like `aiter`.

Made with [Cursor](https://cursor.com)