### PR TITLE
Restore Qwen3 rope config fallback

### DIFF
--- a/python/sglang/srt/models/qwen3.py
+++ b/python/sglang/srt/models/qwen3.py
@@ -316,8 +316,16 @@ class Qwen3DecoderLayer(nn.Module):
     ) -> None:
         super().__init__()
         self.hidden_size = config.hidden_size
-        rope_theta = config.rope_parameters["rope_theta"]
-        rope_scaling = config.rope_parameters
+        if (
+            hasattr(config, "rope_parameters")
+            and config.rope_parameters
+            and "rope_theta" in config.rope_parameters
+        ):
+            rope_theta = config.rope_parameters["rope_theta"]
+            rope_scaling = config.rope_parameters
+        else:
+            rope_theta = getattr(config, "rope_theta", 1000000)
+            rope_scaling = getattr(config, "rope_scaling", None)
         max_position_embeddings = getattr(config, "max_position_embeddings", 32768)
         head_dim = getattr(config, "head_dim", None)
         self.self_attn = Qwen3Attention(


### PR DESCRIPTION
## Repro

This happens when Qwen3 is launched with a JSON model override that provides `rope_scaling`. That makes `config.rope_parameters` exist, but it may not contain `rope_theta`.

Minimal repro shape:

```bash
python3 -m sglang.launch_server \
  --model-path /path/to/Qwen3-32B \
  --trust-remote-code \
  --json-model-override-args '{"rope_scaling":{"rope_type":"yarn","factor":4.0,"original_max_position_embeddings":32768},"max_position_embeddings":131072}'
```

Pre-fix error:

```text
KeyError: 'rope_theta'
```

## Before

`Qwen3DecoderLayer.__init__` read `config.rope_parameters["rope_theta"]` unconditionally.

## After

Fall back to `getattr(config, "rope_theta", 1000000)` and `getattr(config, "rope_scaling", None)` when `rope_theta` is missing from `rope_parameters`.

## Validation

- `python3 -m py_compile python/sglang/srt/models/qwen3.py`

This is intentionally narrow to the Qwen3 model path only.
