### PR TITLE
[CI] Reinstall flashinfer-jit-cache on CUDA version mismatch

### DIFF
--- a/scripts/ci/cuda/ci_download_flashinfer_jit_cache.sh
+++ b/scripts/ci/cuda/ci_download_flashinfer_jit_cache.sh
@@ -25,7 +25,7 @@ if [ "$FLASHINFER_JIT_CACHE_INSTALLED" = false ]; then
     FLASHINFER_CACHE_DIR="${HOME}/.cache/flashinfer-wheels"
     mkdir -p "${FLASHINFER_CACHE_DIR}"
 
-    FLASHINFER_WHEEL_PATTERN="flashinfer_jit_cache-${FLASHINFER_PYTHON_REQUIRED}*.whl"
+    FLASHINFER_WHEEL_PATTERN="flashinfer_jit_cache-${FLASHINFER_PYTHON_REQUIRED}+${CU_VERSION}*.whl"
     CACHED_WHEEL=$(find "${FLASHINFER_CACHE_DIR}" -name "${FLASHINFER_WHEEL_PATTERN}" -type f 2>/dev/null | head -n 1)
 
     if [ -n "$CACHED_WHEEL" ] && [ -f "$CACHED_WHEEL" ]; then

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -187,6 +187,7 @@ FLASHINFER_PYTHON_REQUIRED=$(grep -Po -m1 '(?<=flashinfer_python==)[0-9A-Za-z\.\
 FLASHINFER_CUBIN_REQUIRED=$(grep -Po -m1 '(?<=flashinfer_cubin==)[0-9A-Za-z\.\-]+' python/pyproject.toml || echo "")
 FLASHINFER_CUBIN_INSTALLED=$(pip show flashinfer-cubin 2>/dev/null | grep "^Version:" | awk '{print $2}' || echo "")
 FLASHINFER_JIT_INSTALLED=$(pip show flashinfer-jit-cache 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed 's/+.*//' || echo "")
+FLASHINFER_JIT_CU_VERSION=$(pip show flashinfer-jit-cache 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed -n 's/.*+//p' || echo "")
 
 UNINSTALL_CUBIN=true
 UNINSTALL_JIT_CACHE=true
@@ -203,6 +204,11 @@ if [ "$FLASHINFER_JIT_INSTALLED" = "$FLASHINFER_PYTHON_REQUIRED" ] && [ -n "$FLA
     UNINSTALL_JIT_CACHE=false
 else
     echo "flashinfer-jit-cache version mismatch (installed: ${FLASHINFER_JIT_INSTALLED:-none}, required: ${FLASHINFER_PYTHON_REQUIRED}), will reinstall"
+fi
+
+if [ "$UNINSTALL_JIT_CACHE" = false ] && [ "$FLASHINFER_JIT_CU_VERSION" != "$CU_VERSION" ]; then
+    echo "flashinfer-jit-cache CUDA version mismatch (installed: ${FLASHINFER_JIT_CU_VERSION:-none}, required: ${CU_VERSION}), will reinstall"
+    UNINSTALL_JIT_CACHE=true
 fi
 
 # Build uninstall list based on what needs updating


### PR DESCRIPTION
## Summary
- Extract the CUDA version suffix (e.g., `cu130`) from the installed `flashinfer-jit-cache` package version (e.g., `0.6.7+cu130`)
- Compare it against the runner's `CU_VERSION`; if they differ, force reinstall even when the base version matches
- Prevents using a jit cache built for the wrong CUDA version after a `CU_VERSION` change

## Test plan
- [ ] Verify on a runner where `CU_VERSION=cu129` but the cached jit-cache was built with `cu130` — should trigger reinstall
- [ ] Verify on a runner where both version and CUDA version match — should skip reinstall as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)