### PR TITLE
[sglang-miles]: gateway adapt to smg-wasm 1.0.1

### DIFF
--- a/sgl-model-gateway/src/app_context.rs
+++ b/sgl-model-gateway/src/app_context.rs
@@ -515,8 +515,7 @@ impl AppContextBuilder {
     fn with_wasm_manager(mut self, config: &RouterConfig) -> Result<Self, String> {
         self.wasm_manager = if config.enable_wasm {
             Some(Arc::new(
-                WasmModuleManager::new(WasmRuntimeConfig::default())
-                    .map_err(|e| format!("Failed to initialize WASM module manager: {}", e))?,
+                WasmModuleManager::new(WasmRuntimeConfig::default()),
             ))
         } else {
             None

--- a/sgl-model-gateway/src/core/steps/wasm_module_registration.rs
+++ b/sgl-model-gateway/src/core/steps/wasm_module_registration.rs
@@ -501,7 +501,7 @@ impl StepExecutor<WasmRegistrationWorkflowData> for RegisterModuleStep {
                 last_accessed_at: now,
                 access_count: 0,
                 attach_points: descriptor.attach_points.clone(),
-                wasm_bytes,
+                wasm_bytes: Arc::new(wasm_bytes),
             },
         };
 

--- a/sgl-model-gateway/tests/wasm_test.rs
+++ b/sgl-model-gateway/tests/wasm_test.rs
@@ -43,10 +43,10 @@ use uuid::Uuid;
 async fn create_test_context_with_wasm() -> Arc<AppContext> {
     let config = RouterConfig::default();
 
-    // Initialize WASM manager first
-    let wasm_manager = Arc::new(
-        WasmModuleManager::with_default_config().expect("Failed to create WASM module manager"),
-    );
+    // Initialize WASM manager first. `with_default_config` is infallible in
+    // the current smg-wasm release — the `.expect(...)` dance no longer
+    // compiles, so we drop it here.
+    let wasm_manager = Arc::new(WasmModuleManager::with_default_config());
 
     // Create AppContext with wasm_manager from the start
     let client = reqwest::Client::new();


### PR DESCRIPTION
Upd: closed. Move to https://github.com/radixark/sgl-router-for-miles

generated by cc and reviewed by me.

## Problem

`sgl-model-gateway/Cargo.toml` declares `smg-wasm = "~1.0.0"`, which Cargo now resolves to `1.0.1`. That release introduced two breaking-but-not-major API changes:

1. `WasmModuleManager::new(config)` and `with_default_config()` now return `Self` instead of `Result<Self, _>` (infallible constructors). (`smg-wasm-1.0.1/src/module_manager.rs:34,47`)
2. `WasmModule.wasm_bytes` field type changed from `Vec<u8>` to `Arc<Vec<u8>>`. (`smg-wasm-1.0.1/src/module.rs:168`)

Three call sites still use the old signatures, causing the branch to fail `cargo build` outright:

```
error[E0599]: no method named `map_err` found for struct `WasmModuleManager`
  --> sgl-model-gateway/src/app_context.rs:519

error[E0308]: mismatched types  (expected `Arc<Vec<u8>>`, found `Vec<u8>`)
  --> sgl-model-gateway/src/core/steps/wasm_module_registration.rs:504

error[E0599]: no method named `expect` found for struct `WasmModuleManager`
  --> sgl-model-gateway/tests/wasm_test.rs:48
```

## Motivation

Align the three call sites with the `smg-wasm 1.0.1` API so the branch compiles and tests can run again. This is a **pure call-site adaptation with no behavioral change**.

| File | Old code | New code | Why |
|---|---|---|---|
| `src/app_context.rs:518` | `WasmModuleManager::new(...).map_err(...)?` | `WasmModuleManager::new(...)` | Constructor is now infallible; `?` / `map_err` no longer compile |
| `src/core/steps/wasm_module_registration.rs:504` | `wasm_bytes,` | `wasm_bytes: Arc::new(wasm_bytes),` | Field type changed from `Vec<u8>` to `Arc<Vec<u8>>` |
| `tests/wasm_test.rs:47-49` | `...with_default_config().expect(...)` | `...with_default_config()` | Same as first — `.expect()` is not defined on non-`Result` |

## What happens if we don't do this

The entire `sgl-model-gateway` branch fails `cargo build` / `cargo check` / `cargo test` — no development, no CI, no release. The only alternative is pinning `smg-wasm = "=1.0.0"` in `Cargo.toml` plus editing `Cargo.lock`, which introduces tech debt (locking to a stale version) and defers the same fix to whoever eventually lifts the pin. The crate is maintained by the same team, so fighting the upstream API evolution is counterproductive.

## Verification

- `cargo build --all-targets` passes
- `cargo clippy --all-targets -- -D warnings` passes
- Experimentally confirmed: reverting the three edits and running `cargo check --all-targets` reproduces the E0599 / E0308 errors above.

## Relationship to the chat-extras PR

This PR is **fully orthogonal** to the SGLang chat typed-extras PR (which touches router, server, and test files but no WASM code). The two PRs share no files and can be reviewed and merged independently. However, **this one should land first** — the chat-extras branch is stacked on top, so its CI also depends on the WASM fix being present.
