### PR TITLE
[sglang-miles] chat completion extra fields

### DIFF
--- a/sgl-model-gateway/benches/wasm_middleware_latency.rs
+++ b/sgl-model-gateway/benches/wasm_middleware_latency.rs
@@ -9,8 +9,9 @@ use axum::{
 use criterion::{criterion_group, criterion_main, Criterion};
 use http_body_util::BodyExt;
 use smg::{
-    app_context::AppContext, config::RouterConfig, middleware::wasm_middleware,
-    protocols::chat::ChatCompletionRequest, routers::RouterTrait, server::AppState,
+    app_context::AppContext, config::RouterConfig,
+    extended_chat::ExtendedChatCompletionRequest, middleware::wasm_middleware,
+    routers::RouterTrait, server::AppState,
 };
 use tokio::runtime::Runtime;
 use tower::{Layer, Service};
@@ -26,7 +27,7 @@ impl RouterTrait for MockRouter {
     async fn route_chat(
         &self,
         _headers: Option<&HeaderMap>,
-        _body: &ChatCompletionRequest,
+        _body: &ExtendedChatCompletionRequest,
         _model_id: Option<&str>,
     ) -> Response<Body> {
         StatusCode::OK.into_response()

--- a/sgl-model-gateway/src/app_context.rs
+++ b/sgl-model-gateway/src/app_context.rs
@@ -515,8 +515,7 @@ impl AppContextBuilder {
     fn with_wasm_manager(mut self, config: &RouterConfig) -> Result<Self, String> {
         self.wasm_manager = if config.enable_wasm {
             Some(Arc::new(
-                WasmModuleManager::new(WasmRuntimeConfig::default())
-                    .map_err(|e| format!("Failed to initialize WASM module manager: {}", e))?,
+                WasmModuleManager::new(WasmRuntimeConfig::default()),
             ))
         } else {
             None

--- a/sgl-model-gateway/src/core/steps/wasm_module_registration.rs
+++ b/sgl-model-gateway/src/core/steps/wasm_module_registration.rs
@@ -501,7 +501,7 @@ impl StepExecutor<WasmRegistrationWorkflowData> for RegisterModuleStep {
                 last_accessed_at: now,
                 access_count: 0,
                 attach_points: descriptor.attach_points.clone(),
-                wasm_bytes,
+                wasm_bytes: Arc::new(wasm_bytes),
             },
         };
 

--- a/sgl-model-gateway/src/extended_chat.rs
+++ b/sgl-model-gateway/src/extended_chat.rs
@@ -1,0 +1,108 @@
+//! SGLang-specific chat-completion fields that aren't modeled in the upstream
+//! `openai-protocol` crate.
+//!
+//! **HTTP-only by design.** These extras reach the sglang backend only through
+//! the HTTP transports (`http/router.rs`, `http/pd_router.rs`) because those
+//! paths re-serialize the whole wrapper to JSON and let the Python endpoint
+//! (`python/sglang/srt/entrypoints/openai/protocol.py` +
+//! `serving_chat.py::_convert_to_internal_format`) turn them into
+//! `GenerateReqInput` for the engine.
+//!
+//! The gRPC path forwards `&body.inner` and drops these fields intentionally:
+//! the scheduler protobuf `GenerateRequest`
+//! (`python/sglang/srt/grpc/sglang_scheduler_pb2.pyi:80-116`) has no slots for
+//! `return_routed_experts`, `return_cached_tokens_details`,
+//! `return_prompt_token_ids`, `return_meta_info`, and treats `input_ids` with
+//! different semantics (gateway-side tokenization rather than a client bypass).
+//! Supporting gRPC here would require protobuf schema changes and a tokenize
+//! pipeline rework, which is out of scope.
+//!
+//! Scope discipline: **only fields that `serving_chat._convert_to_internal_format`
+//! already consumes end-to-end** belong here. Do not add a new field without
+//! walking the Python path first and weighing the PD implications.
+
+use std::ops::{Deref, DerefMut};
+
+use openai_protocol::validated::Normalizable;
+use serde::{Deserialize, Serialize};
+use validator::Validate;
+
+use crate::protocols::chat::ChatCompletionRequest;
+use crate::protocols::common::GenerationRequest;
+
+/// `ChatCompletionRequest` augmented with SGLang-specific fields that the
+/// Python endpoint understands but the upstream `openai-protocol` crate does
+/// not model.  See the module doc for the transport-level guarantees.
+///
+/// `return_hidden_states` is **not** redeclared here because
+/// `openai_protocol::ChatCompletionRequest` already defines it
+/// (`src/chat.rs:357`); adding it here would create a duplicate-key clash
+/// under `#[serde(flatten)]`.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, Validate)]
+pub struct ExtendedChatCompletionRequest {
+    #[serde(flatten)]
+    #[validate(nested)]
+    pub inner: ChatCompletionRequest,
+
+    // Python protocol mirror: python/sglang/srt/entrypoints/openai/protocol.py:566-569.
+    // All five are forwarded to GenerateReqInput (serving_chat.py:307/318) or
+    // used at response-formatting time (serving_chat.py:985-990). PD-safe:
+    // prefill and decode receive the same JSON body, so the engines agree on
+    // behavior.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub return_routed_experts: bool,
+
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub return_cached_tokens_details: bool,
+
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub return_prompt_token_ids: bool,
+
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub return_meta_info: bool,
+
+    /// Pre-tokenized prompt. When set, `serving_chat.py:361-364` bypasses chat
+    /// template tokenization and uses these ids as `prompt_ids` directly.
+    /// Python types it as `Optional[List[int]]` (single sequence only); batched
+    /// tokenization goes through `/generate`, not chat.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_ids: Option<Vec<i64>>,
+}
+
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
+impl Deref for ExtendedChatCompletionRequest {
+    type Target = ChatCompletionRequest;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl DerefMut for ExtendedChatCompletionRequest {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl Normalizable for ExtendedChatCompletionRequest {
+    fn normalize(&mut self) {
+        self.inner.normalize();
+    }
+}
+
+impl GenerationRequest for ExtendedChatCompletionRequest {
+    fn is_stream(&self) -> bool {
+        self.inner.is_stream()
+    }
+
+    fn get_model(&self) -> Option<&str> {
+        self.inner.get_model()
+    }
+
+    fn extract_text_for_routing(&self) -> String {
+        self.inner.extract_text_for_routing()
+    }
+}

--- a/sgl-model-gateway/src/lib.rs
+++ b/sgl-model-gateway/src/lib.rs
@@ -5,6 +5,7 @@ pub mod core;
 pub mod middleware;
 pub mod observability;
 pub mod policies;
+pub mod extended_chat;
 pub use openai_protocol as protocols;
 pub use reasoning_parser;
 pub mod routers;

--- a/sgl-model-gateway/src/routers/grpc/pd_router.rs
+++ b/sgl-model-gateway/src/routers/grpc/pd_router.rs
@@ -13,6 +13,7 @@ use crate::{
         UNKNOWN_MODEL_ID,
     },
     observability::metrics::{metrics_labels, Metrics},
+    extended_chat::ExtendedChatCompletionRequest,
     protocols::{chat::ChatCompletionRequest, generate::GenerateRequest},
     routers::RouterTrait,
 };
@@ -232,10 +233,14 @@ impl RouterTrait for GrpcPDRouter {
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        body: &ChatCompletionRequest,
+        body: &ExtendedChatCompletionRequest,
         model_id: Option<&str>,
     ) -> Response {
-        self.route_chat_impl(headers, body, model_id).await
+        // gRPC PD intentionally drops the SGLang chat extras from
+        // ExtendedChatCompletionRequest. The scheduler protobuf doesn't model
+        // them — see the doc on ExtendedChatCompletionRequest. This path is
+        // HTTP-only by design.
+        self.route_chat_impl(headers, &body.inner, model_id).await
     }
 
     fn router_type(&self) -> &'static str {

--- a/sgl-model-gateway/src/routers/grpc/router.rs
+++ b/sgl-model-gateway/src/routers/grpc/router.rs
@@ -23,6 +23,7 @@ use crate::{
     config::types::RetryConfig,
     core::{is_retryable_status, RetryExecutor, WorkerRegistry, UNKNOWN_MODEL_ID},
     observability::metrics::{metrics_labels, Metrics},
+    extended_chat::ExtendedChatCompletionRequest,
     protocols::{
         chat::ChatCompletionRequest,
         classify::ClassifyRequest,
@@ -386,10 +387,16 @@ impl RouterTrait for GrpcRouter {
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        body: &ChatCompletionRequest,
+        body: &ExtendedChatCompletionRequest,
         model_id: Option<&str>,
     ) -> Response {
-        self.route_chat_impl(headers, body, model_id).await
+        // gRPC intentionally drops the SGLang chat extras from
+        // ExtendedChatCompletionRequest (return_routed_experts,
+        // return_cached_tokens_details, return_prompt_token_ids,
+        // return_meta_info, input_ids). The scheduler protobuf doesn't model
+        // them — see the doc on ExtendedChatCompletionRequest. This path is
+        // HTTP-only by design.
+        self.route_chat_impl(headers, &body.inner, model_id).await
     }
 
     async fn route_responses(

--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -28,6 +28,7 @@ use crate::{
         otel_trace::inject_trace_context_http,
     },
     policies::{LoadBalancingPolicy, PolicyRegistry, SelectWorkerInfo},
+    extended_chat::ExtendedChatCompletionRequest,
     protocols::{
         chat::{ChatCompletionRequest, ChatMessage, MessageContent},
         classify::ClassifyRequest,
@@ -1278,7 +1279,7 @@ impl RouterTrait for PDRouter {
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        body: &ChatCompletionRequest,
+        body: &ExtendedChatCompletionRequest,
         model_id: Option<&str>,
     ) -> Response {
         let is_stream = body.stream;

--- a/sgl-model-gateway/src/routers/http/router.rs
+++ b/sgl-model-gateway/src/routers/http/router.rs
@@ -25,8 +25,8 @@ use crate::{
         otel_trace::inject_trace_context_http,
     },
     policies::{PolicyRegistry, SelectWorkerInfo},
+    extended_chat::ExtendedChatCompletionRequest,
     protocols::{
-        chat::ChatCompletionRequest,
         classify::ClassifyRequest,
         common::GenerationRequest,
         completion::CompletionRequest,
@@ -748,7 +748,7 @@ impl RouterTrait for Router {
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        body: &ChatCompletionRequest,
+        body: &ExtendedChatCompletionRequest,
         model_id: Option<&str>,
     ) -> Response {
         self.route_typed_request(headers, body, "/v1/chat/completions", model_id)

--- a/sgl-model-gateway/src/routers/mod.rs
+++ b/sgl-model-gateway/src/routers/mod.rs
@@ -10,8 +10,8 @@ use axum::{
     response::{IntoResponse, Response},
 };
 
+use crate::extended_chat::ExtendedChatCompletionRequest;
 use crate::protocols::{
-    chat::ChatCompletionRequest,
     classify::ClassifyRequest,
     completion::CompletionRequest,
     embedding::EmbeddingRequest,
@@ -93,7 +93,7 @@ pub trait RouterTrait: Send + Sync + Debug {
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        body: &ChatCompletionRequest,
+        body: &ExtendedChatCompletionRequest,
         model_id: Option<&str>,
     ) -> Response;
 

--- a/sgl-model-gateway/src/routers/openai/router.rs
+++ b/sgl-model-gateway/src/routers/openai/router.rs
@@ -35,8 +35,8 @@ use crate::{
         RuntimeType, Worker, WorkerRegistry,
     },
     observability::metrics::{bool_to_static_str, metrics_labels, Metrics},
+    extended_chat::ExtendedChatCompletionRequest,
     protocols::{
-        chat::ChatCompletionRequest,
         responses::{
             generate_id, ResponseContentPart, ResponseInput, ResponseInputOutputItem,
             ResponsesGetParams, ResponsesRequest,
@@ -470,7 +470,7 @@ impl crate::routers::RouterTrait for OpenAIRouter {
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        body: &ChatCompletionRequest,
+        body: &ExtendedChatCompletionRequest,
         model_id: Option<&str>,
     ) -> Response {
         let start = Instant::now();
@@ -535,8 +535,11 @@ impl crate::routers::RouterTrait for OpenAIRouter {
             return error_responses::bad_request(format!("Provider transform error: {}", e));
         }
 
+        // Upstream OpenAI does not accept SGLang-specific fields; drop the
+        // extras from ExtendedChatCompletionRequest here and forward only the
+        // strict-OpenAI inner struct.
         let mut ctx = RequestContext::for_chat(
-            Arc::new(body.clone()),
+            Arc::new(body.inner.clone()),
             headers.cloned(),
             model_id.map(String::from),
             ComponentRefs::Shared(self.shared_components()),

--- a/sgl-model-gateway/src/routers/router_manager.rs
+++ b/sgl-model-gateway/src/routers/router_manager.rs
@@ -22,8 +22,8 @@ use crate::{
     app_context::AppContext,
     config::RoutingMode,
     core::{ConnectionMode, RuntimeType, WorkerRegistry, WorkerType},
+    extended_chat::ExtendedChatCompletionRequest,
     protocols::{
-        chat::ChatCompletionRequest,
         classify::ClassifyRequest,
         completion::CompletionRequest,
         embedding::EmbeddingRequest,
@@ -527,7 +527,7 @@ impl RouterTrait for RouterManager {
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        body: &ChatCompletionRequest,
+        body: &ExtendedChatCompletionRequest,
         model_id: Option<&str>,
     ) -> Response {
         // In IGW mode, resolve model_id and fail fast if not resolvable

--- a/sgl-model-gateway/src/server.rs
+++ b/sgl-model-gateway/src/server.rs
@@ -33,6 +33,7 @@ use crate::{
         worker_manager::WorkerManager,
         Job,
     },
+    extended_chat::ExtendedChatCompletionRequest,
     middleware::{self, AuthConfig, QueuedRequest},
     observability::{
         logging::{self, LoggingConfig},
@@ -40,7 +41,6 @@ use crate::{
         otel_trace,
     },
     protocols::{
-        chat::ChatCompletionRequest,
         classify::ClassifyRequest,
         completion::CompletionRequest,
         embedding::EmbeddingRequest,
@@ -184,7 +184,7 @@ async fn generate(
 async fn v1_chat_completions(
     State(state): State<Arc<AppState>>,
     headers: http::HeaderMap,
-    ValidatedJson(body): ValidatedJson<ChatCompletionRequest>,
+    ValidatedJson(body): ValidatedJson<ExtendedChatCompletionRequest>,
 ) -> Response {
     state
         .router

--- a/sgl-model-gateway/tests/routing/test_openai_routing.rs
+++ b/sgl-model-gateway/tests/routing/test_openai_routing.rs
@@ -20,8 +20,9 @@ use data_connector::{ResponseId, StoredResponse};
 use serde_json::json;
 use smg::{
     config::{ConfigError, HistoryBackend, OracleConfig, RouterConfig, RoutingMode},
+    extended_chat::ExtendedChatCompletionRequest,
     protocols::{
-        chat::{ChatCompletionRequest, ChatMessage, MessageContent},
+        chat::{ChatMessage, MessageContent},
         common::StringOrArray,
         completion::CompletionRequest,
         generate::GenerateRequest,
@@ -37,8 +38,10 @@ use tower::ServiceExt;
 
 use crate::common::mock_openai_server::MockOpenAIServer;
 
-/// Helper function to create a minimal chat completion request for testing
-fn create_minimal_chat_request() -> ChatCompletionRequest {
+/// Helper function to create a minimal chat completion request for testing.
+/// Returns the wrapper type so call sites can feed it directly into
+/// `RouterTrait::route_chat`.
+fn create_minimal_chat_request() -> ExtendedChatCompletionRequest {
     let val = json!({
         "model": "gpt-3.5-turbo",
         "messages": [
@@ -705,7 +708,7 @@ async fn test_openai_e2e_with_server() {
                     let body_bytes = axum::body::to_bytes(body, usize::MAX).await.unwrap();
                     let body_str = String::from_utf8(body_bytes.to_vec()).unwrap();
 
-                    let chat_request: ChatCompletionRequest =
+                    let chat_request: ExtendedChatCompletionRequest =
                         serde_json::from_str(&body_str).unwrap();
 
                     router
@@ -767,7 +770,7 @@ async fn test_openai_router_chat_streaming_with_mock() {
         "max_tokens": 10,
         "stream": true
     });
-    let chat_request: ChatCompletionRequest = serde_json::from_value(val).unwrap();
+    let chat_request: ExtendedChatCompletionRequest = serde_json::from_value(val).unwrap();
 
     let response = router.route_chat(None, &chat_request, None).await;
     assert_eq!(response.status(), StatusCode::OK);

--- a/sgl-model-gateway/tests/spec/extended_chat.rs
+++ b/sgl-model-gateway/tests/spec/extended_chat.rs
@@ -1,0 +1,149 @@
+use serde_json::json;
+use smg::extended_chat::ExtendedChatCompletionRequest;
+
+/// Every typed SGLang extra must survive a JSON → wrapper → JSON roundtrip and
+/// be accessible via direct field access (no HashMap lookup).
+#[test]
+fn test_typed_fields_roundtrip() {
+    let input = json!({
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "hello"}],
+        "temperature": 0.7,
+        // SGLang chat extras we explicitly support.
+        "return_routed_experts": true,
+        "return_cached_tokens_details": true,
+        "return_prompt_token_ids": true,
+        "return_meta_info": true,
+        "input_ids": [1, 2, 3, 4],
+    });
+
+    let extended: ExtendedChatCompletionRequest =
+        serde_json::from_value(input).expect("deserialization should succeed");
+
+    // Inner openai-protocol fields still populated correctly.
+    assert_eq!(extended.inner.model, "test-model");
+    assert_eq!(extended.inner.temperature, Some(0.7));
+
+    // All five extras populated as typed fields.
+    assert!(extended.return_routed_experts);
+    assert!(extended.return_cached_tokens_details);
+    assert!(extended.return_prompt_token_ids);
+    assert!(extended.return_meta_info);
+    assert_eq!(extended.input_ids.as_deref(), Some(&[1, 2, 3, 4][..]));
+
+    // Re-serialize: every extra appears at the top level, ready for downstream
+    // Python (serving_chat._convert_to_internal_format) to pick up.
+    let output = serde_json::to_value(&extended).expect("serialization should succeed");
+    let obj = output.as_object().expect("should be object");
+    assert_eq!(obj.get("model").and_then(|v| v.as_str()), Some("test-model"));
+    assert_eq!(
+        obj.get("return_routed_experts").and_then(|v| v.as_bool()),
+        Some(true)
+    );
+    assert_eq!(
+        obj.get("return_cached_tokens_details")
+            .and_then(|v| v.as_bool()),
+        Some(true)
+    );
+    assert_eq!(
+        obj.get("return_prompt_token_ids").and_then(|v| v.as_bool()),
+        Some(true)
+    );
+    assert_eq!(
+        obj.get("return_meta_info").and_then(|v| v.as_bool()),
+        Some(true)
+    );
+    assert_eq!(obj.get("input_ids"), Some(&json!([1, 2, 3, 4])));
+}
+
+/// `skip_serializing_if` must keep default values out of the forwarded JSON so
+/// we don't lie to downstreams about what the client asked for.
+#[test]
+fn test_defaults_when_absent() {
+    let input = json!({
+        "model": "test",
+        "messages": [{"role": "user", "content": "hello"}],
+    });
+
+    let extended: ExtendedChatCompletionRequest = serde_json::from_value(input).unwrap();
+
+    assert!(!extended.return_routed_experts);
+    assert!(!extended.return_cached_tokens_details);
+    assert!(!extended.return_prompt_token_ids);
+    assert!(!extended.return_meta_info);
+    assert!(extended.input_ids.is_none());
+
+    let output = serde_json::to_value(&extended).expect("serialize");
+    let obj = output.as_object().expect("object");
+    assert!(!obj.contains_key("return_routed_experts"));
+    assert!(!obj.contains_key("return_cached_tokens_details"));
+    assert!(!obj.contains_key("return_prompt_token_ids"));
+    assert!(!obj.contains_key("return_meta_info"));
+    assert!(!obj.contains_key("input_ids"));
+}
+
+/// Unknown JSON fields (fields we haven't typed) must be silently dropped.
+/// This guards against regression back to the old HashMap-flatten design,
+/// which accepted arbitrary fields and forwarded them to backends with no
+/// router-side awareness of router-owned collisions.
+#[test]
+fn test_unknown_field_silently_dropped() {
+    let input = json!({
+        "model": "test",
+        "messages": [{"role": "user", "content": "hello"}],
+        "priority": 5,
+        "cache_salt": "salt-abc",
+        "rid": "req-001",
+    });
+
+    let extended: ExtendedChatCompletionRequest = serde_json::from_value(input).unwrap();
+
+    let output = serde_json::to_value(&extended).expect("serialize");
+    let obj = output.as_object().expect("object");
+    assert!(!obj.contains_key("priority"));
+    assert!(!obj.contains_key("cache_salt"));
+    assert!(!obj.contains_key("rid"));
+}
+
+/// Deref gives downstream code transparent access to inner openai-protocol
+/// fields without requiring `.inner.` plumbing everywhere.
+#[test]
+fn test_deref_access() {
+    let input = json!({
+        "model": "my-model",
+        "messages": [{"role": "user", "content": "hi"}],
+        "stream": true,
+        "return_meta_info": true,
+    });
+
+    let extended: ExtendedChatCompletionRequest = serde_json::from_value(input).unwrap();
+    assert_eq!(extended.model, "my-model");
+    assert!(extended.stream);
+    // Typed extras are accessed directly on the wrapper.
+    assert!(extended.return_meta_info);
+}
+
+/// Validation must delegate to `inner.validate()` so the crate's schema-level
+/// checks (e.g. top_p ∈ [0, 1]) still fire on the wrapped request.
+#[test]
+fn test_validation_delegates_to_inner() {
+    use validator::Validate;
+
+    let bad = json!({
+        "model": "m",
+        "messages": [{"role": "user", "content": "hi"}],
+        "top_p": 2.0, // out of range per ChatCompletionRequest validation
+    });
+    let extended: ExtendedChatCompletionRequest = serde_json::from_value(bad).unwrap();
+    assert!(extended.validate().is_err(), "top_p=2.0 should fail");
+
+    let good = json!({
+        "model": "m",
+        "messages": [{"role": "user", "content": "hi"}],
+        "temperature": 0.5,
+        "return_meta_info": true,
+        "input_ids": [1, 2, 3],
+    });
+    let extended: ExtendedChatCompletionRequest = serde_json::from_value(good).unwrap();
+    assert!(extended.validate().is_ok(), "legal request should pass");
+}

--- a/sgl-model-gateway/tests/spec/mod.rs
+++ b/sgl-model-gateway/tests/spec/mod.rs
@@ -5,5 +5,6 @@
 mod chat_completion;
 mod chat_message;
 mod embedding;
+mod extended_chat;
 mod rerank;
 mod responses;

--- a/sgl-model-gateway/tests/wasm_test.rs
+++ b/sgl-model-gateway/tests/wasm_test.rs
@@ -43,10 +43,10 @@ use uuid::Uuid;
 async fn create_test_context_with_wasm() -> Arc<AppContext> {
     let config = RouterConfig::default();
 
-    // Initialize WASM manager first
-    let wasm_manager = Arc::new(
-        WasmModuleManager::with_default_config().expect("Failed to create WASM module manager"),
-    );
+    // Initialize WASM manager first. `with_default_config` is infallible in
+    // the current smg-wasm release — the `.expect(...)` dance no longer
+    // compiles, so we drop it here.
+    let wasm_manager = Arc::new(WasmModuleManager::with_default_config());
 
     // Create AppContext with wasm_manager from the start
     let client = reqwest::Client::new();


### PR DESCRIPTION
Upd: closed. Move to https://github.com/radixark/sgl-router-for-miles

generated by cc and reviewed by me.


## Problem

The Python `ChatCompletionRequest` (`python/sglang/srt/entrypoints/openai/protocol.py:565-569, 608`) carries six engine-specific fields that clients regularly need:

```
return_hidden_states: bool        (already in openai-protocol crate)
return_routed_experts: bool       ← missing from crate
return_cached_tokens_details: bool
return_prompt_token_ids: bool
return_meta_info: bool
input_ids: Optional[List[int]]    (client-supplied pre-tokenized prompt)
```

`serving_chat._convert_to_internal_format` (`serving_chat.py:306-319, 361-364`) copies these from `ChatCompletionRequest` into `GenerateReqInput` for the engine, or uses them at response-formatting time (`serving_chat.py:985-990`).

But `sgl-model-gateway` uses the `openai-protocol` crate's `ChatCompletionRequest`, which only models `return_hidden_states`. The HTTP PD path re-serializes the Rust struct before forwarding to prefill + decode (`http/pd_router.rs:331`), so any field not declared in the Rust struct is silently dropped by serde and never reaches the Python endpoint.

## Motivation

Replace the HashMap wrapper with a **typed struct carrying exactly the 5 missing fields** (the 6th, `return_hidden_states`, is already in the crate and must not be redeclared to avoid serde flatten key collision). This:

- Ensures the 5 fields survive the Rust serialize → JSON → Python pydantic roundtrip on HTTP PD, reaching both prefill and decode engines.
- Restores `ValidatedJson<ExtendedChatCompletionRequest>` so the chat endpoint returns the same structured 4xx errors as `/v1/rerank` and `/v1/responses`.
- Makes the gRPC / OpenAI-provider field drop **explicit** — code comments at every `&body.inner` call site point to the module doc explaining why (`sglang_scheduler_pb2.pyi:80-116` has no proto slots for four of the five fields; `input_ids` has different semantics on the gRPC path). This prevents future reviewers from mistaking the drop for a bug.

### Key design decisions

- **HTTP-only by design.** Supporting gRPC would require protobuf schema changes (`sglang_scheduler.proto`) plus gateway tokenize-pipeline rework — independent work, out of scope.
- **PD-safe.** HTTP PD dispatches the same JSON body to prefill and decode (`http/pd_router.rs:559,567`); only `bootstrap_*` is router-owned and already overridden via `.insert()`. None of the 5 new fields is router-owned. For `input_ids`, both sides run the same `serving_chat.py:361-364` bypass-template branch, so token sequences agree.
- **No collision filter needed.** The 5 fields are all client-controlled engine parameters; `bootstrap_*` safety is already ensured by the existing `.insert()` semantics.
- **External crate untouched.** `openai-protocol = "~1.0.0"` is maintained by the same team but its authors deliberately exclude routing/scheduling fields (upstream `1.7.0` also does not add them). Wrapping locally respects that boundary.

## What happens if we don't do this

| Scenario | Consequence |
|---|---|
| Do nothing | The 5 fields are silently dropped; `input_ids` bypass-template path never fires; `return_meta_info` and other response-shaping toggles have no effect. |
| Modify `openai-protocol` crate | PR author cannot publish the crate; upstream authors intentionally exclude these fields. |
| Vendor-fork the crate | Maintenance burden of rebasing upstream changes; same team maintaining both sides makes a fork counterproductive vs. a thin wrapper. |

## Changes

**Core (3 files)**
- `sgl-model-gateway/src/extended_chat.rs` — rewrite: HashMap → typed 5-field struct; module-level doc explaining HTTP-only design + gRPC limitations; implements `Deref`, `DerefMut`, `Normalizable`, `Validate(nested)`, `GenerationRequest`.
- `sgl-model-gateway/src/server.rs` — restore `ValidatedJson<ExtendedChatCompletionRequest>`; delete manual normalize + validate block.
- `sgl-model-gateway/tests/spec/extended_chat.rs` — 5 tests: typed roundtrip, defaults, unknown-field-dropped, deref, validation-delegates-to-inner.

**Router signature propagation + comments (7 files)**
- `src/routers/mod.rs`, `http/router.rs`, `http/pd_router.rs` — trait and HTTP impls use `&ExtendedChatCompletionRequest`; HTTP paths serialize the full wrapper, naturally flattening the 5 extras into JSON.
- `src/routers/grpc/router.rs`, `grpc/pd_router.rs` — keep `&body.inner`; **add comments** explaining the intentional drop.
- `src/routers/openai/router.rs` — keep `body.inner.clone()`; **add comment**.
- `src/routers/router_manager.rs` — signature-only forwarding.

**Test / bench adaptation (4 files)**
- `tests/routing/test_openai_routing.rs` — helper return type + 2 local `let` types updated to `ExtendedChatCompletionRequest`.
- `benches/wasm_middleware_latency.rs` — `MockRouter::route_chat` signature updated.
- `src/lib.rs` — add `pub mod extended_chat`.
- `tests/spec/mod.rs` — register `extended_chat` test module.

## Verification

Automated:
- `cargo build --all-targets` — pass
- `cargo clippy --all-targets -- -D warnings` — pass
- `cargo test --test spec_test` — 94/94 pass (including 5 new extended_chat tests)
- `cargo test --test routing_tests test_openai_router_chat` — 2/2 pass
- `cargo test --test routing_tests` — 90/91 pass (1 failure is missing `redis-server` in the dev environment, unrelated)

Manual PD end-to-end (recommended for reviewer / QA):
- Start gateway in HTTP PD mode with 1 prefill + 1 decode sglang worker.
- `curl` with `input_ids`, all `return_*` flags enabled, `stream: false`.
- Expect: both workers' Python logs show the 5 fields as non-default; response JSON includes `meta_info` / `prompt_token_ids` / `hidden_states` / `routed_experts` / `cached_tokens_details` per sglang semantics; no PD bootstrap-room mismatch errors.

## Relationship to the WASM-adapt PR

This PR is stacked on the `chore/smg-wasm-1.0.1-adapt` branch (the WASM PR should land first so CI compiles). The two PRs share **no files** and are logically orthogonal — they were originally mixed in a single local commit and are now split for cleaner review and independent rollback.
