### PR TITLE
Defer KV cache release until after streaming output

### DIFF
--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -171,6 +171,7 @@ class SchedulerOutputProcessorMixin:
 
             # Check finish conditions
             logprob_pt = 0
+            deferred_release_reqs = []
 
             for i, (req, next_token_id) in enumerate(zip(batch.reqs, next_token_ids)):
                 if req.finished() or req.is_retracted:
@@ -188,7 +189,7 @@ class SchedulerOutputProcessorMixin:
                     req.check_finished()
                     if req.finished():
                         self.maybe_collect_routed_experts(req)
-                        release_kv_cache(req, self.tree_cache)
+                        deferred_release_reqs.append(req)
                         req.time_stats.set_completion_time()
                     elif not batch.decoding_reqs or req not in batch.decoding_reqs:
                         self.tree_cache.cache_unfinished_req(req)
@@ -301,6 +302,7 @@ class SchedulerOutputProcessorMixin:
                     embeddings = [tensor.tolist() for tensor in embeddings]
 
             # Check finish conditions
+            deferred_release_reqs = []
             for i, req in enumerate(batch.reqs):
                 if req.is_retracted:
                     continue
@@ -313,7 +315,7 @@ class SchedulerOutputProcessorMixin:
                     req.check_finished()
 
                     if req.finished():
-                        release_kv_cache(req, self.tree_cache)
+                        deferred_release_reqs.append(req)
                         req.time_stats.set_completion_time()
                     else:
                         self.tree_cache.cache_unfinished_req(req)
@@ -322,7 +324,12 @@ class SchedulerOutputProcessorMixin:
                     req.is_chunked -= 1
                     req.time_stats.set_last_chunked_prefill_finish_time()
 
+        # Stream output before releasing KV cache so results are returned ASAP.
         self.stream_output(batch.reqs, batch.return_logprob, skip_stream_req)
+
+        # Deferred KV cache release after streaming results.
+        for req in deferred_release_reqs:
+            release_kv_cache(req, self.tree_cache)
 
         can_run_cuda_graph = getattr(result, "can_run_cuda_graph", False)
         self.report_prefill_stats(


### PR DESCRIPTION
## Motivation

Defer `release_kv_cache` calls to after `stream_output` so that results are returned to clients before freeing KV cache entries, reducing perceived latency.

## Modifications

- Collect finished requests into `deferred_release_reqs` list instead of releasing KV cache immediately.
- Release KV cache after `stream_output` completes, for both the LLM decoding path and the embedding model path.

## Speed Tests and Profiling

H100, Qwen-0.6B, batch=16, seq_len=256

| Config | Avg Latency | Throughput | Delta |
|---|---|---|---|
| Baseline (`main`, `disable_overlap`) | 15.42 ms | 266K tok/s | — |
| + deferred KV release only | 14.55 ms | 281K tok/s | **-0.87 ms (-5.6%)** |

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
