### PR TITLE
[Step3p5] Optimize allreduce in MoE layers 

### DIFF
--- a/python/sglang/srt/models/step3p5.py
+++ b/python/sglang/srt/models/step3p5.py
@@ -690,6 +690,10 @@ class Step3p5DecoderLayer(nn.Module):
                 hidden_states = tensor_model_parallel_all_reduce(hidden_states)
         else:
             hidden_states = self.mlp(hidden_states)
+            # Dense MLP uses reduce_results=True, so the output is already
+            # all-reduced.  Do NOT set the fusion flag — otherwise the next
+            # layer would all-reduce again, multiplying values by world_size.
+            should_allreduce_fusion = False
         self._dump_tensor("mlp_output", hidden_states, dump_step)
 
         if should_allreduce_fusion:

--- a/python/sglang/srt/models/step3p5.py
+++ b/python/sglang/srt/models/step3p5.py
@@ -662,7 +662,7 @@ class Step3p5DecoderLayer(nn.Module):
             residual,
             forward_batch,
         )
-        self._dump_tensor("post_attn_residual", hidden_states, dump_step)
+        self._dump_tensor("post_attn_residual", residual, dump_step)
         self._dump_tensor("mlp_input", hidden_states, dump_step)
 
         should_allreduce_fusion = (

--- a/python/sglang/srt/models/step3p5.py
+++ b/python/sglang/srt/models/step3p5.py
@@ -492,8 +492,7 @@ class Step3p5DecoderLayer(nn.Module):
         rope_theta = config.rope_theta
         max_position_embeddings = config.max_position_embeddings
         head_dim = config.head_dim
-        moe_layers_list = [int(x) for x in config.moe_layers_enum.split(",")]
-        moe_layers_set = set(moe_layers_list)
+        moe_layers_set = {int(x) for x in config.moe_layers_enum.split(",")}
         self.num_attention_heads = config.num_attention_heads
         self.num_key_value_heads = config.num_attention_groups
         self.is_moe_layer = layer_id in moe_layers_set
@@ -552,20 +551,15 @@ class Step3p5DecoderLayer(nn.Module):
                 quant_config=quant_config,
                 prefix=add_prefix("mlp", prefix),
             )
-            # Use reduce_results=False so the share_expert output stays
-            # unreduced.  It is combined with the (also unreduced) MoE output
-            # and a single all-reduce covers both — saving one full-TP
-            # all-reduce per layer vs reducing each independently.
-            share_expert_tp_size = None
-            share_expert_tp_rank = None
+            # reduce_results=False: share_expert output stays unreduced and is
+            # combined with the (also unreduced) MoE output, then a single
+            # all-reduce covers both — saving one full-TP all-reduce per layer.
             self.share_expert = Step3p5MLP(
                 hidden_size=self.hidden_size,
                 intermediate_size=config.share_expert_dim,
                 swiglu_limit=swiglu_limit_shared,
                 quant_config=quant_config,
                 prefix=add_prefix("share_expert", prefix),
-                tp_size=share_expert_tp_size,
-                tp_rank=share_expert_tp_rank,
                 reduce_results=False,
             )
             self.use_moe = True

--- a/python/sglang/srt/models/step3p5.py
+++ b/python/sglang/srt/models/step3p5.py
@@ -69,6 +69,9 @@ class Step3p5MLP(nn.Module):
         swiglu_limit: Optional[float] = None,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        tp_size: Optional[int] = None,
+        tp_rank: Optional[int] = None,
+        reduce_results: bool = True,
     ) -> None:
         super().__init__()
         self.hidden_size = hidden_size
@@ -79,6 +82,8 @@ class Step3p5MLP(nn.Module):
             bias=False,
             quant_config=quant_config,
             prefix=add_prefix("gate_up_proj", prefix),
+            tp_size=tp_size,
+            tp_rank=tp_rank,
         )
         self.down_proj = RowParallelLinear(
             intermediate_size,
@@ -86,6 +91,9 @@ class Step3p5MLP(nn.Module):
             bias=False,
             quant_config=quant_config,
             prefix=add_prefix("down_proj", prefix),
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            reduce_results=reduce_results,
         )
         self.act_fn = SiluAndMul()
         self.limit = swiglu_limit
@@ -392,6 +400,7 @@ class Step3p5Attention(nn.Module):
             quant_config=quant_config,
             tp_rank=attn_tp_rank,
             tp_size=attn_tp_size,
+            reduce_results=False,
             prefix=add_prefix("o_proj", prefix),
         )
 
@@ -484,9 +493,12 @@ class Step3p5DecoderLayer(nn.Module):
         max_position_embeddings = config.max_position_embeddings
         head_dim = config.head_dim
         moe_layers_list = [int(x) for x in config.moe_layers_enum.split(",")]
+        moe_layers_set = set(moe_layers_list)
         self.num_attention_heads = config.num_attention_heads
         self.num_key_value_heads = config.num_attention_groups
-        self.is_moe_layer = layer_id in moe_layers_list
+        self.is_moe_layer = layer_id in moe_layers_set
+        self.is_previous_layer_sparse = (layer_id - 1) in moe_layers_set
+        self.is_next_layer_sparse = (layer_id + 1) in moe_layers_set
         num_hidden_layers = config.num_hidden_layers
 
         if (
@@ -540,12 +552,21 @@ class Step3p5DecoderLayer(nn.Module):
                 quant_config=quant_config,
                 prefix=add_prefix("mlp", prefix),
             )
+            # Use reduce_results=False so the share_expert output stays
+            # unreduced.  It is combined with the (also unreduced) MoE output
+            # and a single all-reduce covers both — saving one full-TP
+            # all-reduce per layer vs reducing each independently.
+            share_expert_tp_size = None
+            share_expert_tp_rank = None
             self.share_expert = Step3p5MLP(
                 hidden_size=self.hidden_size,
                 intermediate_size=config.share_expert_dim,
                 swiglu_limit=swiglu_limit_shared,
                 quant_config=quant_config,
                 prefix=add_prefix("share_expert", prefix),
+                tp_size=share_expert_tp_size,
+                tp_rank=share_expert_tp_rank,
+                reduce_results=False,
             )
             self.use_moe = True
         else:
@@ -567,14 +588,16 @@ class Step3p5DecoderLayer(nn.Module):
             num_layers=(
                 config.num_hidden_layers if layer_id < config.num_hidden_layers else 1
             ),  # 1 is for mtp
-            is_layer_sparse=False,
-            is_previous_layer_sparse=False,
-            is_next_layer_sparse=False,
+            is_layer_sparse=self.is_moe_layer,
+            is_previous_layer_sparse=self.is_previous_layer_sparse,
+            is_next_layer_sparse=self.is_next_layer_sparse,
         )
         self.layer_communicator = LayerCommunicator(
             layer_scatter_modes=self.layer_scatter_modes,
             input_layernorm=self.input_layernorm,
             post_attention_layernorm=self.post_attention_layernorm,
+            allow_reduce_scatter=True,
+            is_last_layer=(layer_id == config.num_hidden_layers - 1),
         )
 
         self.layer_id = layer_id
@@ -634,26 +657,47 @@ class Step3p5DecoderLayer(nn.Module):
             )
         self._dump_tensor("attn_output", hidden_states, dump_step)
         # Fully Connected
-        # hidden_states, residual = self.layer_communicator.prepare_mlp(
-        #     hidden_states,
-        #     residual,
-        #     forward_batch,
-        # )
-        hidden_states = residual + hidden_states
-        residual = hidden_states
+        hidden_states, residual = self.layer_communicator.prepare_mlp(
+            hidden_states,
+            residual,
+            forward_batch,
+        )
         self._dump_tensor("post_attn_residual", hidden_states, dump_step)
-        hidden_states = self.post_attention_layernorm(hidden_states)
         self._dump_tensor("mlp_input", hidden_states, dump_step)
+
+        should_allreduce_fusion = (
+            self.layer_communicator.should_fuse_mlp_allreduce_with_next_layer(
+                forward_batch
+            )
+        )
+        use_reduce_scatter = self.layer_communicator.should_use_reduce_scatter(
+            forward_batch
+        )
+
         if self.use_moe:
+            # Both share_expert and MoE return unreduced (TP-partial) outputs.
+            # Combine them first, then do a single all-reduce — saving one
+            # full-TP all-reduce per layer.
             share_output = self.share_expert(hidden_states)
-            moe_output = self.moe(hidden_states)
+            moe_output = self.moe(
+                hidden_states,
+                forward_batch,
+                should_allreduce_fusion=True,
+                use_reduce_scatter=use_reduce_scatter,
+            )
             hidden_states = moe_output + share_output
+            if not should_allreduce_fusion and not use_reduce_scatter:
+                hidden_states = tensor_model_parallel_all_reduce(hidden_states)
         else:
             hidden_states = self.mlp(hidden_states)
         self._dump_tensor("mlp_output", hidden_states, dump_step)
-        hidden_states, residual = self.layer_communicator.postprocess_layer(
-            hidden_states, residual, forward_batch
-        )
+
+        if should_allreduce_fusion:
+            hidden_states._sglang_needs_allreduce_fusion = True
+        else:
+            hidden_states, residual = self.layer_communicator.postprocess_layer(
+                hidden_states, residual, forward_batch
+            )
         self._dump_tensor("layer_output", hidden_states, dump_step)
         return hidden_states, residual
 

--- a/python/sglang/srt/models/step3p5.py
+++ b/python/sglang/srt/models/step3p5.py
@@ -1,5 +1,3 @@
-import logging
-import os
 from typing import Any, Dict, Iterable, Optional, Tuple, Union
 
 import torch
@@ -57,7 +55,6 @@ from sglang.srt.utils import add_prefix, is_cuda, is_non_idle_and_non_empty, mak
 
 Step3p5Config = None
 
-logger = logging.getLogger(__name__)
 _is_cuda = is_cuda()
 
 
@@ -595,33 +592,6 @@ class Step3p5DecoderLayer(nn.Module):
         )
 
         self.layer_id = layer_id
-        self.dump_intermediate = (
-            os.environ.get("SGLANG_DUMP_STEP3P5_INTERMEDIATE") == "1"
-        )
-        self._dump_step = 0
-
-    def _dump_tensor(
-        self,
-        name: str,
-        tensor: Optional[torch.Tensor],
-        step_id: Optional[int] = None,
-    ) -> None:
-        if not self.dump_intermediate or tensor is None or not torch.is_tensor(tensor):
-            return
-        dump_dir = "/sgl-workspace/sgl"
-        try:
-            os.makedirs(dump_dir, exist_ok=True)
-            tp_rank = get_tensor_model_parallel_rank()
-            step_part = f"_step{step_id}" if step_id is not None else ""
-            path = os.path.join(
-                dump_dir,
-                f"step3p5_layer{self.layer_id}{step_part}_{name}_tp{tp_rank}.pt",
-            )
-            torch.save(tensor.detach().cpu(), path)
-        except Exception:
-            logger.exception(
-                "Failed to dump tensor %s for layer %s", name, self.layer_id
-            )
 
     def forward(
         self,
@@ -638,26 +608,18 @@ class Step3p5DecoderLayer(nn.Module):
             forward_batch,
             post_residual_addition=post_residual_addition,
         )
-        dump_step = None
-        if self.dump_intermediate:
-            dump_step = self._dump_step
-            self._dump_step += 1
-            self._dump_tensor("attn_input", hidden_states, dump_step)
         if hidden_states.shape[0] != 0:
             hidden_states = self.self_attn(
                 positions=positions,
                 hidden_states=hidden_states,
                 forward_batch=forward_batch,
             )
-        self._dump_tensor("attn_output", hidden_states, dump_step)
         # Fully Connected
         hidden_states, residual = self.layer_communicator.prepare_mlp(
             hidden_states,
             residual,
             forward_batch,
         )
-        self._dump_tensor("post_attn_residual", residual, dump_step)
-        self._dump_tensor("mlp_input", hidden_states, dump_step)
 
         should_allreduce_fusion = (
             self.layer_communicator.should_fuse_mlp_allreduce_with_next_layer(
@@ -688,7 +650,6 @@ class Step3p5DecoderLayer(nn.Module):
             # all-reduced.  Do NOT set the fusion flag — otherwise the next
             # layer would all-reduce again, multiplying values by world_size.
             should_allreduce_fusion = False
-        self._dump_tensor("mlp_output", hidden_states, dump_step)
 
         if should_allreduce_fusion:
             hidden_states._sglang_needs_allreduce_fusion = True
@@ -696,7 +657,6 @@ class Step3p5DecoderLayer(nn.Module):
             hidden_states, residual = self.layer_communicator.postprocess_layer(
                 hidden_states, residual, forward_batch
             )
-        self._dump_tensor("layer_output", hidden_states, dump_step)
         return hidden_states, residual
 
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2189,6 +2189,7 @@ class ServerArgs:
                 "Glm4MoeForCausalLM",
                 "Glm4MoeLiteForCausalLM",
                 "Qwen3MoeForCausalLM",
+                "Step3p5ForCausalLM",
                 "KimiK25ForConditionalGeneration",
                 "Qwen3_5MoeForConditionalGeneration",
                 "Qwen3_5ForConditionalGeneration",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2189,7 +2189,6 @@ class ServerArgs:
                 "Glm4MoeForCausalLM",
                 "Glm4MoeLiteForCausalLM",
                 "Qwen3MoeForCausalLM",
-                "Step3p5ForCausalLM",
                 "KimiK25ForConditionalGeneration",
                 "Qwen3_5MoeForConditionalGeneration",
                 "Qwen3_5ForConditionalGeneration",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

  - Defer o_proj and share_expert all-reduce, combine with MoE output into a single all-reduce per layer (was 3 separate all-reduces)                                                  
  - Enable allreduce fusion and reduce-scatter for Step3p5                                                                           
  - Add Step3p5ForCausalLM to flashinfer allreduce fusion whitelist                                                                                                                    
                                                                   
  ## Performance

Good Perfermance Launch Command: 
H200x8 
63,213 TPS
```
  python3 -m sglang.launch_server \
      --model-path stepfun-ai/Step-3.5-Flash-FP8 \
      --tp 8 \
      --ep 4 \
      --trust-remote-code \
      --mem-fraction-static 0.75 \
      --chunked-prefill-size 16384 \
      --port 30000 \
      --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 64}'
```
         
  Prefill throughput (TP=8, EP=4, input_len=8192, output_len=1, 200 prompts):
  - Before: ~46k tok/s                                                                                                                                                                 
  - After: ~56k tok/s (+21%)                                                                                                                                                           

## Accuracy Tests

## GSM8K Full Test (1319 questions)

**Server command:**
```bash
python3 -m sglang.launch_server --model-path stepfun-ai/Step-3.5-Flash-FP8 --tp 8 --ep 4 --trust-remote-code --port 30000
```

**Benchmark command:**
```bash
python3 -m sglang.test.few_shot_gsm8k --num-q 1319 --port 30000
```

| Branch | Accuracy | Invalid |
|--------|----------|---------|
| main | 0.875 | 0.001 |
| PR (step3p5-optimize-allreduce) | 0.879 | 0.001 |

Difference is 0.4% (~5 questions), within normal sampling variance. No accuracy regression.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
