### PR TITLE
HotFix EAGLE3 target/draft global ServerArgs mix-up in chunked prefix cache path

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -617,6 +617,11 @@ class ChatCompletionRequest(BaseModel):
     separate_reasoning: bool = True
     stream_reasoning: bool = True
     chat_template_kwargs: Optional[Dict] = None
+    # Per-request override for the post-inference unclosed-reasoning recovery
+    # (Fallback B). When None, the server-side default (controlled by the
+    # `--auto-recover-unclosed-reasoning` CLI flag) is used. Set to True/False
+    # to override per request.
+    recover_unclosed_reasoning: Optional[bool] = None
 
     # SGLang multimodal tiling controls (extensions)
     max_dynamic_patch: Optional[int] = None

--- a/python/sglang/srt/entrypoints/openai/recover_unclosed_reasoning.py
+++ b/python/sglang/srt/entrypoints/openai/recover_unclosed_reasoning.py
@@ -58,7 +58,15 @@ def is_recovery_eligible_request(
         # n > 1 produces multiple ret items; this simplified recovery path
         # supports n == 1 only. (When n is None we treat it as 1.)
         return False
-    if request.tools and request.tool_choice != "none":
+    # Only hard-exclude when the caller FORCES a tool call ("required"): the
+    # model is contractually obliged to emit one, so an "empty content + only
+    # reasoning" response is expected and must not be overwritten by a
+    # follow-up generation.
+    # For tool_choice in {"auto", "none", <specific tool>} we defer the
+    # decision to the runtime check in should_recover_ret_item /
+    # mark_stream_state_tool_call, which inspects whether a tool call was
+    # actually produced.
+    if request.tools and request.tool_choice == "required":
         return False
     if request.continue_final_message:
         # User is already explicitly continuing; do not double-tap.
@@ -69,6 +77,9 @@ def is_recovery_eligible_request(
 def should_recover_ret_item(
     ret_item: Dict[str, Any],
     parser: ReasoningParser,
+    *,
+    tool_call_parser: Optional[str] = None,
+    tools: Optional[List[Any]] = None,
 ) -> bool:
     """True iff this ret item looks like an unclosed reasoning emission.
 
@@ -76,6 +87,9 @@ def should_recover_ret_item(
       - finish_reason.type == "stop" (length-stops are user-visible budget hits)
       - reasoning_text is non-empty after parsing
       - normal_text is empty (or whitespace only) after parsing
+      - when tools were offered: the normal_text does NOT already contain a
+        tool call (otherwise the "empty content" is intentional — the content
+        IS the tool call).
     """
     finish = (ret_item.get("meta_info") or {}).get("finish_reason") or {}
     if finish.get("type") != "stop":
@@ -90,6 +104,30 @@ def should_recover_ret_item(
         return False
     if (normal_text or "").strip():
         return False
+
+    # Only when tools were offered AND the caller configured a tool call
+    # parser do we bother checking for actual tool-call markers in the
+    # generated text. If any is found, skip recovery (the "empty content" is
+    # intentional — the model is calling a tool).
+    if tool_call_parser and tools:
+        try:
+            from sglang.srt.function_call.function_call_parser import (
+                FunctionCallParser,
+            )
+
+            fcp = FunctionCallParser(tools, tool_call_parser)
+            # Check the raw generated text, not the post-reasoning-parser
+            # normal_text, because some models emit the tool-call sigil
+            # inside the reasoning block's tail, or the tool-call parser's
+            # start tokens may themselves look like "reasoning". has_tool_call
+            # inspects the full unparsed text.
+            if fcp.has_tool_call(text):
+                return False
+        except Exception:
+            # Be conservative: if we can't tell, allow recovery. The worst
+            # case is the continuation generates extra text after what the
+            # model considered "done".
+            pass
     return True
 
 
@@ -221,6 +259,17 @@ def merge_continuation_into_ret(
         if isinstance(a, int) and isinstance(b, int):
             merged_meta[k] = a + b
 
+    # prompt_tokens: the follow-up's prefill already consumed (original prompt
+    # + first-pass output_ids + think_end bridge). Summing a+b would
+    # double-count the original prompt; taking max() reflects the true compute
+    # cost for billing without over-reporting.
+    a_pt = merged_meta.get("prompt_tokens")
+    b_pt = follow_meta.get("prompt_tokens")
+    if isinstance(a_pt, int) and isinstance(b_pt, int):
+        merged_meta["prompt_tokens"] = max(a_pt, b_pt)
+    elif isinstance(b_pt, int):
+        merged_meta["prompt_tokens"] = b_pt
+
     new_item = dict(original_ret_item)
     new_item["text"] = merged_text
     new_item["output_ids"] = merged_output_ids
@@ -274,6 +323,12 @@ async def maybe_recover_non_streaming(
         getattr(template_manager, "force_reasoning", False)
     ) or bool(handler._get_reasoning_from_request(request))
 
+    # Capture tool-call context for runtime judgement of "did the model
+    # actually emit a tool call?". When either is missing we fall through to
+    # the plain reasoning-only check.
+    tool_call_parser = getattr(handler, "tool_call_parser", None)
+    tools = getattr(request, "tools", None)
+
     if generate_request_fn is None:
 
         def generate_request_fn(req, rr):  # type: ignore[no-redef]
@@ -292,7 +347,12 @@ async def maybe_recover_non_streaming(
             new_ret_list.append(ret_item)
             continue
 
-        if not should_recover_ret_item(ret_item, parser):
+        if not should_recover_ret_item(
+            ret_item,
+            parser,
+            tool_call_parser=tool_call_parser,
+            tools=tools,
+        ):
             new_ret_list.append(ret_item)
             continue
 
@@ -379,13 +439,29 @@ def mark_stream_state_tool_call(state: Dict[str, Any]):
 
 
 def update_stream_state_meta(
-    state: Dict[str, Any], meta_info: Dict[str, Any], output_ids: List[int]
+    state: Dict[str, Any],
+    meta_info: Dict[str, Any],
+    output_ids: List[int],
+    *,
+    incremental: bool = False,
 ):
+    """Fold one stream chunk's meta / output_ids into the recovery state.
+
+    ``incremental`` MUST match the server's ``incremental_streaming_output``
+    setting:
+
+    - ``incremental=False`` (default): each chunk carries the cumulative
+      output_ids list so far; we overwrite.
+    - ``incremental=True``: each chunk carries only the delta; we append so
+      the continuation request's ``input_ids`` include ALL previously emitted
+      tokens, not just the last delta.
+    """
     state["last_meta_info"] = dict(meta_info or {})
     if output_ids:
-        # Whether streaming is incremental or cumulative is decided by the
-        # caller; we always store the latest snapshot they pass.
-        state["last_output_ids"] = list(output_ids)
+        if incremental:
+            state["last_output_ids"].extend(output_ids)
+        else:
+            state["last_output_ids"] = list(output_ids)
     fr = (meta_info or {}).get("finish_reason")
     if fr:
         state["finish_reason"] = fr
@@ -419,6 +495,7 @@ async def stream_recovery_chunks(
     reasoning_tokens_acc: int,
     completion_tokens_acc: int,
     generate_request_fn: Optional[Callable[..., Any]] = None,
+    on_meta_update: Optional[Callable[[Dict[str, Any]], None]] = None,
 ) -> AsyncGenerator[str, None]:
     """Issue the continuation generation as a stream and yield SSE chunks.
 
@@ -426,9 +503,36 @@ async def stream_recovery_chunks(
     chunks). After the continuation finishes a final ``finish_reason`` chunk
     is yielded with the continuation's finish_reason. Caller is responsible
     for the trailing ``[DONE]`` line and any usage chunks.
+
+    NOTE: Every early-return path (parser build fails, tokenizer encode
+    fails, continuation request shape invalid, ...) MUST still yield a
+    fallback finish_reason chunk before returning — otherwise the upstream
+    caller's ``continue`` will skip the normal finish chunk and the client
+    stream would lose its content-termination marker.
     """
+
+    def _fallback_finish_chunk() -> str:
+        fr = state.get("finish_reason")
+        fc = ChatCompletionStreamResponse(
+            id=request_id,
+            created=int(time.time()),
+            choices=[
+                ChatCompletionResponseStreamChoice(
+                    index=0,
+                    delta=DeltaMessage(),
+                    finish_reason=fr["type"] if fr else "stop",
+                    matched_stop=(
+                        fr.get("matched") if isinstance(fr, dict) else None
+                    ),
+                )
+            ],
+            model=request_model,
+        )
+        return f"data: {fc.model_dump_json()}\n\n"
+
     parser_name = handler.reasoning_parser
     if not parser_name:
+        yield _fallback_finish_chunk()
         return
 
     is_force_reasoning = bool(
@@ -443,6 +547,7 @@ async def stream_recovery_chunks(
             request=request,
         )
     except Exception:
+        yield _fallback_finish_chunk()
         return
     think_end_str = parser.detector.think_end_token
 
@@ -451,8 +556,10 @@ async def stream_recovery_chunks(
             think_end_str, add_special_tokens=False
         )
     except Exception:
+        yield _fallback_finish_chunk()
         return
     if not think_end_token_ids:
+        yield _fallback_finish_chunk()
         return
 
     pseudo_ret_item = {
@@ -466,6 +573,7 @@ async def stream_recovery_chunks(
         think_end_token_ids=think_end_token_ids,
     )
     if follow_req is None:
+        yield _fallback_finish_chunk()
         return
     # Streaming continuation: ask for incremental text deltas if available.
     follow_req.stream = True
@@ -480,10 +588,13 @@ async def stream_recovery_chunks(
     incremental_streaming = bool(
         getattr(handler.tokenizer_manager.server_args, "incremental_streaming_output", False)
     )
+    last_follow_meta: Dict[str, Any] = {}
 
     try:
         async for content in generate_request_fn(follow_req, raw_request):
             meta = content.get("meta_info") or {}
+            if meta:
+                last_follow_meta = meta
             text = content.get("text") or ""
             if incremental_streaming:
                 delta = text
@@ -504,6 +615,10 @@ async def stream_recovery_chunks(
                     model=request_model,
                 )
                 if continuous_usage_stats:
+                    # meta fields from the continuation are cumulative over
+                    # the continuation (completion_tokens == len(output_ids)
+                    # of the follow-up). Add onto the caller's first-pass
+                    # accumulator so per-chunk usage is monotone non-decreasing.
                     cur_completion = (
                         completion_tokens_acc + int(meta.get("completion_tokens") or 0)
                     )
@@ -523,6 +638,20 @@ async def stream_recovery_chunks(
             getattr(follow_req, "rid", "?"),
             e,
         )
+
+    # Push the final follow-up meta back to the caller so it can accumulate
+    # completion/cached/prompt_tokens for the terminal usage chunk. The meta
+    # fields are cumulative over the continuation, so we only need to flush
+    # once after the stream ends.
+    if on_meta_update is not None and last_follow_meta:
+        try:
+            on_meta_update(last_follow_meta)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning(
+                "stream_recovery_chunks on_meta_update failed (rid=%s): %s",
+                getattr(follow_req, "rid", "?"),
+                e,
+            )
 
     final_chunk = ChatCompletionStreamResponse(
         id=request_id,

--- a/python/sglang/srt/entrypoints/openai/recover_unclosed_reasoning.py
+++ b/python/sglang/srt/entrypoints/openai/recover_unclosed_reasoning.py
@@ -1,0 +1,567 @@
+"""Fallback B: post-inference auto-recovery for unclosed reasoning sections.
+
+When a chat completion finishes with non-empty reasoning_content but
+essentially empty content (and no tool calls), this module transparently
+issues a follow-up generation that appends the think_end token to the
+existing output_ids and continues, then merges the two responses before
+returning to the client.
+
+This acts as a safety net for the redirect logit processor (Path 1) and
+also works on multi-token think_end models for which Path 1 cannot run.
+
+The module is intentionally split into small pure helpers and a thin async
+orchestration function so it can be unit-tested without bringing up a real
+server.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import time
+import uuid
+from typing import Any, AsyncGenerator, Awaitable, Callable, Dict, List, Optional
+
+from sglang.srt.entrypoints.openai.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionResponseStreamChoice,
+    ChatCompletionStreamResponse,
+    DeltaMessage,
+)
+from sglang.srt.entrypoints.openai.usage_processor import UsageProcessor
+from sglang.srt.managers.io_struct import GenerateReqInput
+from sglang.srt.parser.reasoning_parser import ReasoningParser
+
+logger = logging.getLogger(__name__)
+
+
+# --- decision helpers ----------------------------------------------------
+
+
+def is_recovery_enabled(
+    request: ChatCompletionRequest, server_default: bool
+) -> bool:
+    """Per-request override > server-side default."""
+    user = request.recover_unclosed_reasoning
+    return server_default if user is None else bool(user)
+
+
+def is_recovery_eligible_request(
+    request: ChatCompletionRequest, reasoning_parser_name: Optional[str]
+) -> bool:
+    """Quick gating that does not depend on the actual generation result."""
+    if not reasoning_parser_name:
+        return False
+    if not request.separate_reasoning:
+        return False
+    if request.n is not None and request.n != 1:
+        # n > 1 produces multiple ret items; this simplified recovery path
+        # supports n == 1 only. (When n is None we treat it as 1.)
+        return False
+    if request.tools and request.tool_choice != "none":
+        return False
+    if request.continue_final_message:
+        # User is already explicitly continuing; do not double-tap.
+        return False
+    return True
+
+
+def should_recover_ret_item(
+    ret_item: Dict[str, Any],
+    parser: ReasoningParser,
+) -> bool:
+    """True iff this ret item looks like an unclosed reasoning emission.
+
+    Conditions:
+      - finish_reason.type == "stop" (length-stops are user-visible budget hits)
+      - reasoning_text is non-empty after parsing
+      - normal_text is empty (or whitespace only) after parsing
+    """
+    finish = (ret_item.get("meta_info") or {}).get("finish_reason") or {}
+    if finish.get("type") != "stop":
+        return False
+
+    text = ret_item.get("text") or ""
+    try:
+        reasoning_text, normal_text = parser.parse_non_stream(text)
+    except Exception:
+        return False
+    if not reasoning_text:
+        return False
+    if (normal_text or "").strip():
+        return False
+    return True
+
+
+# --- request building ----------------------------------------------------
+
+
+_REDIRECT_OWNED_KEYS = (
+    "think_end_token_id",
+    "think_start_token_id",
+    "redirect_eos_token_ids",
+    "force_reasoning",
+    "prob_threshold",
+)
+
+# Sentinel placed in the continuation request's `sampling_params.custom_params`
+# so that, in the (forbidden) case the orchestration helpers ever recursively
+# observe a follow-up generation, they immediately bail out instead of
+# launching another continuation. The key lives under `custom_params` because
+# the top-level `sampling_params` dict is forwarded to `SamplingParams(**…)`
+# which would reject an unknown kwarg, but `custom_params` is a free-form dict.
+_RECOVERY_SENTINEL_KEY = "_recover_unclosed_reasoning_attempted"
+
+
+def _has_recovery_sentinel(adapted_request: GenerateReqInput) -> bool:
+    sp = getattr(adapted_request, "sampling_params", None)
+    if isinstance(sp, list):
+        sp = sp[0] if sp else None
+    if not isinstance(sp, dict):
+        return False
+    cp = sp.get("custom_params")
+    return isinstance(cp, dict) and bool(cp.get(_RECOVERY_SENTINEL_KEY))
+
+
+def _strip_redirect_owned_keys(custom_params: Optional[Dict[str, Any]]):
+    """Remove the redirect processor's per-request keys from a custom_params
+    dict. Returns None if nothing meaningful remains."""
+    if not isinstance(custom_params, dict):
+        return None
+    cleaned = {k: v for k, v in custom_params.items() if k not in _REDIRECT_OWNED_KEYS}
+    return cleaned or None
+
+
+def build_continuation_request(
+    *,
+    adapted_request: GenerateReqInput,
+    ret_item: Dict[str, Any],
+    think_end_token_ids: List[int],
+    rid: Optional[str] = None,
+) -> Optional[GenerateReqInput]:
+    """Build the follow-up GenerateReqInput that continues with think_end.
+
+    Returns None if the request shape is not recoverable (text-mode prompt,
+    batched input, missing input_ids, etc.).
+    """
+    original_input_ids = getattr(adapted_request, "input_ids", None)
+    if not original_input_ids:
+        return None
+    if isinstance(original_input_ids[0], list):
+        # Batched input → multi-prompt request, not supported by this path.
+        return None
+
+    output_ids = ret_item.get("output_ids") or []
+    new_input_ids = (
+        list(original_input_ids) + list(output_ids) + list(think_end_token_ids)
+    )
+
+    new_sp = copy.deepcopy(getattr(adapted_request, "sampling_params", None) or {})
+    if isinstance(new_sp, list):
+        new_sp = new_sp[0] if new_sp else {}
+    if not isinstance(new_sp, dict):
+        new_sp = {}
+    cleaned_cp = _strip_redirect_owned_keys(new_sp.get("custom_params"))
+    sentinel_cp = dict(cleaned_cp) if isinstance(cleaned_cp, dict) else {}
+    sentinel_cp[_RECOVERY_SENTINEL_KEY] = True
+    new_sp["custom_params"] = sentinel_cp
+
+    extras: Dict[str, Any] = {}
+    for k in ("lora_path", "routed_dp_rank"):
+        v = getattr(adapted_request, k, None)
+        if v is not None:
+            extras[k] = v
+
+    return GenerateReqInput(
+        input_ids=new_input_ids,
+        sampling_params=new_sp,
+        return_logprob=False,
+        logprob_start_len=-1,
+        top_logprobs_num=0,
+        stream=False,
+        return_text_in_logprobs=False,
+        rid=rid or str(uuid.uuid4()),
+        # NOTE: explicitly do NOT carry custom_logit_processor — the redirect
+        # processor must not run on the continuation.
+        **extras,
+    )
+
+
+# --- response merging ----------------------------------------------------
+
+
+def merge_continuation_into_ret(
+    *,
+    original_ret_item: Dict[str, Any],
+    follow_ret_item: Dict[str, Any],
+    think_end_str: str,
+    think_end_token_ids: List[int],
+) -> Dict[str, Any]:
+    """Build a new ret_item that concatenates `original + bridge + follow`."""
+    merged_text = (
+        (original_ret_item.get("text") or "")
+        + think_end_str
+        + (follow_ret_item.get("text") or "")
+    )
+    merged_output_ids = (
+        list(original_ret_item.get("output_ids") or [])
+        + list(think_end_token_ids)
+        + list(follow_ret_item.get("output_ids") or [])
+    )
+
+    merged_meta = dict(original_ret_item.get("meta_info") or {})
+    follow_meta = follow_ret_item.get("meta_info") or {}
+
+    if "finish_reason" in follow_meta:
+        merged_meta["finish_reason"] = follow_meta["finish_reason"]
+
+    for k in ("completion_tokens", "cached_tokens", "reasoning_tokens"):
+        a = merged_meta.get(k)
+        b = follow_meta.get(k)
+        if isinstance(a, int) and isinstance(b, int):
+            merged_meta[k] = a + b
+
+    new_item = dict(original_ret_item)
+    new_item["text"] = merged_text
+    new_item["output_ids"] = merged_output_ids
+    new_item["meta_info"] = merged_meta
+    return new_item
+
+
+# --- async orchestration -------------------------------------------------
+
+
+async def maybe_recover_non_streaming(
+    *,
+    handler,
+    adapted_request: GenerateReqInput,
+    request: ChatCompletionRequest,
+    raw_request,
+    ret_list: List[Dict[str, Any]],
+    generate_request_fn: Optional[Callable[..., Awaitable]] = None,
+) -> List[Dict[str, Any]]:
+    """Apply Fallback B to a non-streaming response.
+
+    `handler` must expose:
+      - `tokenizer_manager.server_args.auto_recover_unclosed_reasoning`
+      - `tokenizer_manager.tokenizer` (must implement .encode())
+      - `tokenizer_manager.generate_request(...)` (async iterator)
+      - `template_manager.force_reasoning`
+      - `_get_reasoning_from_request(request)`
+      - `reasoning_parser` (str)
+
+    `generate_request_fn` is for testing — when None we use
+    `handler.tokenizer_manager.generate_request`.
+    """
+    server_default = bool(
+        getattr(
+            handler.tokenizer_manager.server_args,
+            "auto_recover_unclosed_reasoning",
+            False,
+        )
+    )
+    if not is_recovery_enabled(request, server_default):
+        return ret_list
+    if not is_recovery_eligible_request(request, handler.reasoning_parser):
+        return ret_list
+    # Anti-recursion: if this request is itself a continuation we issued
+    # earlier, never trigger another round.
+    if _has_recovery_sentinel(adapted_request):
+        return ret_list
+
+    template_manager = getattr(handler, "template_manager", None)
+    is_force_reasoning = bool(
+        getattr(template_manager, "force_reasoning", False)
+    ) or bool(handler._get_reasoning_from_request(request))
+
+    if generate_request_fn is None:
+
+        def generate_request_fn(req, rr):  # type: ignore[no-redef]
+            return handler.tokenizer_manager.generate_request(req, rr)
+
+    new_ret_list: List[Dict[str, Any]] = []
+    for ret_item in ret_list:
+        try:
+            parser = ReasoningParser(
+                model_type=handler.reasoning_parser,
+                stream_reasoning=False,
+                force_reasoning=is_force_reasoning,
+                request=request,
+            )
+        except Exception:
+            new_ret_list.append(ret_item)
+            continue
+
+        if not should_recover_ret_item(ret_item, parser):
+            new_ret_list.append(ret_item)
+            continue
+
+        think_end_str = parser.detector.think_end_token
+        try:
+            think_end_token_ids = handler.tokenizer_manager.tokenizer.encode(
+                think_end_str, add_special_tokens=False
+            )
+        except Exception:
+            new_ret_list.append(ret_item)
+            continue
+        if not think_end_token_ids:
+            new_ret_list.append(ret_item)
+            continue
+
+        follow_req = build_continuation_request(
+            adapted_request=adapted_request,
+            ret_item=ret_item,
+            think_end_token_ids=think_end_token_ids,
+        )
+        if follow_req is None:
+            new_ret_list.append(ret_item)
+            continue
+
+        try:
+            follow_ret = await generate_request_fn(
+                follow_req, raw_request
+            ).__anext__()
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning(
+                "Fallback B continuation failed (rid=%s): %s",
+                follow_req.rid,
+                e,
+            )
+            new_ret_list.append(ret_item)
+            continue
+
+        if isinstance(follow_ret, list):
+            follow_ret = follow_ret[0] if follow_ret else None
+        if not isinstance(follow_ret, dict):
+            new_ret_list.append(ret_item)
+            continue
+
+        merged = merge_continuation_into_ret(
+            original_ret_item=ret_item,
+            follow_ret_item=follow_ret,
+            think_end_str=think_end_str,
+            think_end_token_ids=think_end_token_ids,
+        )
+        new_ret_list.append(merged)
+
+    return new_ret_list
+
+
+# --- streaming Fallback B ------------------------------------------------
+
+
+def new_stream_recovery_state() -> Dict[str, Any]:
+    """Per-index state we track during a streaming request to decide whether
+    to issue a Fallback B continuation after the first stream finishes.
+    """
+    return {
+        "reasoning_text": "",
+        "content_text": "",
+        "has_tool_calls": False,
+        "finish_reason": None,
+        "last_output_ids": [],
+        "last_meta_info": {},
+    }
+
+
+def update_stream_state_with_reasoning(state: Dict[str, Any], delta: str):
+    if delta:
+        state["reasoning_text"] += delta
+
+
+def update_stream_state_with_content(state: Dict[str, Any], delta: str):
+    if delta:
+        state["content_text"] += delta
+
+
+def mark_stream_state_tool_call(state: Dict[str, Any]):
+    state["has_tool_calls"] = True
+
+
+def update_stream_state_meta(
+    state: Dict[str, Any], meta_info: Dict[str, Any], output_ids: List[int]
+):
+    state["last_meta_info"] = dict(meta_info or {})
+    if output_ids:
+        # Whether streaming is incremental or cumulative is decided by the
+        # caller; we always store the latest snapshot they pass.
+        state["last_output_ids"] = list(output_ids)
+    fr = (meta_info or {}).get("finish_reason")
+    if fr:
+        state["finish_reason"] = fr
+
+
+def should_recover_stream_state(state: Dict[str, Any]) -> bool:
+    """Mirrors should_recover_ret_item but works on accumulated stream text."""
+    fr = state.get("finish_reason") or {}
+    if fr.get("type") != "stop":
+        return False
+    if state.get("has_tool_calls"):
+        return False
+    if not state.get("reasoning_text"):
+        return False
+    if (state.get("content_text") or "").strip():
+        return False
+    return True
+
+
+async def stream_recovery_chunks(
+    *,
+    handler,
+    request: ChatCompletionRequest,
+    raw_request,
+    adapted_request: GenerateReqInput,
+    state: Dict[str, Any],
+    request_id: str,
+    request_model: str,
+    continuous_usage_stats: bool,
+    prompt_tokens: int,
+    reasoning_tokens_acc: int,
+    completion_tokens_acc: int,
+    generate_request_fn: Optional[Callable[..., Any]] = None,
+) -> AsyncGenerator[str, None]:
+    """Issue the continuation generation as a stream and yield SSE chunks.
+
+    The generated chunks are content deltas (no role chunk, no reasoning
+    chunks). After the continuation finishes a final ``finish_reason`` chunk
+    is yielded with the continuation's finish_reason. Caller is responsible
+    for the trailing ``[DONE]`` line and any usage chunks.
+    """
+    parser_name = handler.reasoning_parser
+    if not parser_name:
+        return
+
+    is_force_reasoning = bool(
+        getattr(getattr(handler, "template_manager", None), "force_reasoning", False)
+    ) or bool(handler._get_reasoning_from_request(request))
+
+    try:
+        parser = ReasoningParser(
+            model_type=parser_name,
+            stream_reasoning=False,
+            force_reasoning=is_force_reasoning,
+            request=request,
+        )
+    except Exception:
+        return
+    think_end_str = parser.detector.think_end_token
+
+    try:
+        think_end_token_ids = handler.tokenizer_manager.tokenizer.encode(
+            think_end_str, add_special_tokens=False
+        )
+    except Exception:
+        return
+    if not think_end_token_ids:
+        return
+
+    pseudo_ret_item = {
+        "output_ids": list(state.get("last_output_ids") or []),
+        "text": state.get("reasoning_text", ""),
+        "meta_info": state.get("last_meta_info") or {},
+    }
+    follow_req = build_continuation_request(
+        adapted_request=adapted_request,
+        ret_item=pseudo_ret_item,
+        think_end_token_ids=think_end_token_ids,
+    )
+    if follow_req is None:
+        return
+    # Streaming continuation: ask for incremental text deltas if available.
+    follow_req.stream = True
+
+    if generate_request_fn is None:
+
+        def generate_request_fn(req, rr):  # type: ignore[no-redef]
+            return handler.tokenizer_manager.generate_request(req, rr)
+
+    last_seen_text = ""
+    final_finish_reason = state.get("finish_reason")
+    incremental_streaming = bool(
+        getattr(handler.tokenizer_manager.server_args, "incremental_streaming_output", False)
+    )
+
+    try:
+        async for content in generate_request_fn(follow_req, raw_request):
+            meta = content.get("meta_info") or {}
+            text = content.get("text") or ""
+            if incremental_streaming:
+                delta = text
+            else:
+                delta = text[len(last_seen_text) :]
+                last_seen_text = text
+
+            if delta:
+                choice_data = ChatCompletionResponseStreamChoice(
+                    index=0,
+                    delta=DeltaMessage(content=delta),
+                    finish_reason=None,
+                )
+                chunk = ChatCompletionStreamResponse(
+                    id=request_id,
+                    created=int(time.time()),
+                    choices=[choice_data],
+                    model=request_model,
+                )
+                if continuous_usage_stats:
+                    cur_completion = (
+                        completion_tokens_acc + int(meta.get("completion_tokens") or 0)
+                    )
+                    chunk.usage = UsageProcessor.calculate_token_usage(
+                        prompt_tokens=prompt_tokens,
+                        reasoning_tokens=reasoning_tokens_acc,
+                        completion_tokens=cur_completion,
+                    )
+                yield f"data: {chunk.model_dump_json()}\n\n"
+
+            fr = meta.get("finish_reason")
+            if fr:
+                final_finish_reason = fr
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning(
+            "Streaming Fallback B continuation crashed (rid=%s): %s",
+            getattr(follow_req, "rid", "?"),
+            e,
+        )
+
+    final_chunk = ChatCompletionStreamResponse(
+        id=request_id,
+        created=int(time.time()),
+        choices=[
+            ChatCompletionResponseStreamChoice(
+                index=0,
+                delta=DeltaMessage(),
+                finish_reason=(
+                    final_finish_reason["type"] if final_finish_reason else "stop"
+                ),
+                matched_stop=(
+                    final_finish_reason.get("matched")
+                    if final_finish_reason and isinstance(final_finish_reason, dict)
+                    else None
+                ),
+            )
+        ],
+        model=request_model,
+    )
+    yield f"data: {final_chunk.model_dump_json()}\n\n"
+
+
+def is_stream_recovery_enabled_for_request(
+    handler, request: ChatCompletionRequest
+) -> bool:
+    """Combine server default + per-request override + eligibility gating."""
+    server_default = bool(
+        getattr(
+            handler.tokenizer_manager.server_args,
+            "auto_recover_unclosed_reasoning",
+            False,
+        )
+    )
+    if not is_recovery_enabled(request, server_default):
+        return False
+    if not is_recovery_eligible_request(request, handler.reasoning_parser):
+        return False
+    # The streaming entrypoint receives the user-facing GenerateReqInput, not
+    # a continuation, but check anyway in case some future caller forwards a
+    # follow-up here directly.
+    return True

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -890,6 +890,9 @@ class OpenAIServingChat(OpenAIServingBase):
                         _ensure_recovery_state(index),
                         content.get("meta_info") or {},
                         content.get("output_ids") or [],
+                        incremental=bool(
+                            self.tokenizer_manager.server_args.incremental_streaming_output
+                        ),
                     )
 
                 # Handle reasoning content
@@ -999,6 +1002,41 @@ class OpenAIServingChat(OpenAIServingBase):
                 if recovery_enabled:
                     state = recovery_states.get(idx)
                     if state is not None and should_recover_stream_state(state):
+                        # Closure to fold the continuation's final meta (usage
+                        # numbers) back into the per-index accumulators so the
+                        # terminal `usage` chunk reports first-pass + follow-up,
+                        # not just first-pass. completion_tokens / cached_tokens
+                        # are accumulated (sum). prompt_tokens uses max() because
+                        # the follow-up's prefill already covers the original
+                        # prompt + first-pass output_ids + think_end bridge —
+                        # summing would double-count.
+                        def _accumulate_followup_meta(
+                            meta: Dict[str, Any], _idx: int = idx
+                        ) -> None:
+                            try:
+                                c = meta.get("completion_tokens")
+                                if isinstance(c, int):
+                                    completion_tokens[_idx] = (
+                                        completion_tokens.get(_idx, 0) + c
+                                    )
+                                ca = meta.get("cached_tokens")
+                                if isinstance(ca, int):
+                                    cached_tokens[_idx] = (
+                                        cached_tokens.get(_idx, 0) + ca
+                                    )
+                                r = meta.get("reasoning_tokens")
+                                if isinstance(r, int):
+                                    reasoning_tokens[_idx] = (
+                                        reasoning_tokens.get(_idx, 0) + r
+                                    )
+                                p = meta.get("prompt_tokens")
+                                if isinstance(p, int):
+                                    prompt_tokens[_idx] = max(
+                                        prompt_tokens.get(_idx, 0), p
+                                    )
+                            except Exception:
+                                pass
+
                         try:
                             async for chunk in stream_recovery_chunks(
                                 handler=self,
@@ -1014,6 +1052,7 @@ class OpenAIServingChat(OpenAIServingBase):
                                 completion_tokens_acc=completion_tokens.get(
                                     idx, 0
                                 ),
+                                on_meta_update=_accumulate_followup_meta,
                             ):
                                 yield chunk
                             continue  # Skip the normal finish_reason chunk.

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -15,6 +15,17 @@ from fastapi.responses import ORJSONResponse, StreamingResponse
 from jsonschema import Draft202012Validator, SchemaError
 
 from sglang.srt.entrypoints.openai.encoding_dsv32 import encode_messages
+from sglang.srt.entrypoints.openai.recover_unclosed_reasoning import (
+    is_stream_recovery_enabled_for_request,
+    mark_stream_state_tool_call,
+    maybe_recover_non_streaming,
+    new_stream_recovery_state,
+    should_recover_stream_state,
+    stream_recovery_chunks,
+    update_stream_state_meta,
+    update_stream_state_with_content,
+    update_stream_state_with_reasoning,
+)
 from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionRequest,
     ChatCompletionResponse,
@@ -52,6 +63,12 @@ from sglang.srt.managers.io_struct import GenerateReqInput
 from sglang.srt.parser.conversation import generate_chat_conv
 from sglang.srt.parser.jinja_template_utils import process_content_for_template_format
 from sglang.srt.parser.reasoning_parser import ReasoningParser
+from sglang.srt.parser.reasoning_redirect_registry import (
+    build_redirect_config,
+)
+from sglang.srt.sampling.custom_logit_processor import (
+    ReasoningEosRedirectLogitProcessor,
+)
 
 if TYPE_CHECKING:
     from sglang.srt.managers.template_manager import TemplateManager
@@ -127,6 +144,106 @@ class OpenAIServingChat(OpenAIServingBase):
         )
 
         self.use_dpsk_v32_encoding = self._use_dpsk_v32_encoding()
+
+        # Reasoning unclosed-think auto-recover plumbing.
+        # `_redirect_cfg` is populated lazily on the first request that needs
+        # it: the tokenizer may not be ready at __init__ time on some load
+        # paths. None means path-1 is unsupported for this model.
+        self._redirect_cfg = None
+        self._redirect_cfg_built = False
+        self._redirect_processor_str = None
+
+    def _get_or_build_redirect_cfg(self):
+        if self._redirect_cfg_built:
+            return self._redirect_cfg
+        self._redirect_cfg_built = True
+        sa = self.tokenizer_manager.server_args
+        if not getattr(sa, "redirect_unclosed_reasoning", False):
+            return None
+        if not getattr(sa, "enable_custom_logit_processor", False):
+            logger.warning(
+                "redirect_unclosed_reasoning requires --enable-custom-logit-processor; "
+                "the redirect logit processor will NOT be installed."
+            )
+            return None
+        tokenizer = getattr(self.tokenizer_manager, "tokenizer", None)
+        cfg = build_redirect_config(self.reasoning_parser, tokenizer)
+        if cfg is None:
+            logger.info(
+                "Reasoning EOS redirect: model/parser=%r is not eligible "
+                "(unknown parser, multi-token think_end, or no EOS tokens). "
+                "Path-1 will be skipped; Fallback B is unaffected.",
+                self.reasoning_parser,
+            )
+        else:
+            self._redirect_processor_str = (
+                ReasoningEosRedirectLogitProcessor.to_str()
+            )
+            logger.info(
+                "Reasoning EOS redirect enabled: think_end=%d, eos_set=%s, "
+                "force_reasoning=%s, threshold=%.3f",
+                cfg.think_end_token_id,
+                cfg.redirect_eos_token_ids,
+                cfg.force_reasoning,
+                getattr(sa, "redirect_eos_prob_threshold", 0.5),
+            )
+        self._redirect_cfg = cfg
+        return cfg
+
+    def _maybe_attach_redirect_processor(
+        self,
+        request: ChatCompletionRequest,
+        sampling_params: Dict[str, Any],
+    ) -> Optional[str]:
+        """If eligible, attach the reasoning-EOS redirect processor to the
+        request and return the processor JSON string (to be set on the
+        GenerateReqInput). Returns None when the processor must not be
+        installed (per-request opt-out, user already set their own processor,
+        unsupported parser/tokenizer, etc.).
+
+        Side effect: mutates ``sampling_params['custom_params']`` in-place to
+        include the per-request redirect parameters when the processor is
+        installed.
+        """
+        cfg = self._get_or_build_redirect_cfg()
+        if cfg is None:
+            return None
+
+        # Coexistence with user-supplied custom logit processors: the SGLang
+        # sampling stack only supports a single processor per request, so we
+        # bail out (and warn) if the user already supplied one.
+        if request.custom_logit_processor is not None:
+            logger.debug(
+                "Reasoning EOS redirect skipped: request already carries a "
+                "custom_logit_processor."
+            )
+            return None
+
+        threshold = float(
+            getattr(
+                self.tokenizer_manager.server_args,
+                "redirect_eos_prob_threshold",
+                0.5,
+            )
+        )
+        redirect_params = {
+            "think_end_token_id": cfg.think_end_token_id,
+            "think_start_token_id": cfg.think_start_token_id,
+            "redirect_eos_token_ids": list(cfg.redirect_eos_token_ids),
+            "prob_threshold": threshold,
+            "force_reasoning": cfg.force_reasoning,
+        }
+
+        existing = sampling_params.get("custom_params") or {}
+        if not isinstance(existing, dict):
+            logger.warning(
+                "Reasoning EOS redirect skipped: request.custom_params is not a dict."
+            )
+            return None
+        # Caller-provided keys win on conflict so users can override threshold etc.
+        merged = {**redirect_params, **existing}
+        sampling_params["custom_params"] = merged
+        return self._redirect_processor_str
 
     def _handle_last_assistant_message(
         self,
@@ -275,6 +392,17 @@ class OpenAIServingChat(OpenAIServingBase):
             tool_call_constraint=processed_messages.tool_call_constraint,
         )
 
+        # Optionally install the reasoning-EOS redirect logit processor.
+        # Mutates sampling_params["custom_params"] in place when applicable.
+        injected_processor_str = self._maybe_attach_redirect_processor(
+            request, sampling_params
+        )
+        custom_logit_processor = (
+            request.custom_logit_processor
+            if injected_processor_str is None
+            else injected_processor_str
+        )
+
         # Handle single vs multiple requests
         if is_multimodal:
             prompt_kwargs = {"text": processed_messages.prompt}
@@ -323,7 +451,7 @@ class OpenAIServingChat(OpenAIServingBase):
             priority=request.priority,
             routing_key=self.extract_routing_key(raw_request),
             custom_labels=custom_labels,
-            custom_logit_processor=request.custom_logit_processor,
+            custom_logit_processor=custom_logit_processor,
             image_max_dynamic_patch=img_max_dynamic_patch,
             video_max_dynamic_patch=vid_max_dynamic_patch,
             max_dynamic_patch=getattr(request, "max_dynamic_patch", None),
@@ -662,6 +790,18 @@ class OpenAIServingChat(OpenAIServingBase):
         hidden_states = {}
         routed_experts = {}
 
+        # Per-index Fallback B accumulators (only populated when the feature
+        # is enabled for this request; cheap to keep otherwise).
+        recovery_enabled = is_stream_recovery_enabled_for_request(self, request)
+        recovery_states: Dict[int, Dict[str, Any]] = {}
+
+        def _ensure_recovery_state(index: int) -> Dict[str, Any]:
+            state = recovery_states.get(index)
+            if state is None:
+                state = new_stream_recovery_state()
+                recovery_states[index] = state
+            return state
+
         stream_started = False
         try:
             include_usage, continuous_usage_stats = should_include_usage(
@@ -745,11 +885,22 @@ class OpenAIServingChat(OpenAIServingBase):
                     delta = content["text"][len(stream_buffer) :]
                 stream_buffers[index] = stream_buffer + delta
 
+                if recovery_enabled:
+                    update_stream_state_meta(
+                        _ensure_recovery_state(index),
+                        content.get("meta_info") or {},
+                        content.get("output_ids") or [],
+                    )
+
                 # Handle reasoning content
                 if self.reasoning_parser and request.separate_reasoning:
                     reasoning_text, delta = self._process_reasoning_stream(
                         index, delta, reasoning_parser_dict, content, request
                     )
+                    if recovery_enabled:
+                        update_stream_state_with_reasoning(
+                            _ensure_recovery_state(index), reasoning_text or ""
+                        )
                     if reasoning_text:
                         choice_data = ChatCompletionResponseStreamChoice(
                             index=index,
@@ -790,6 +941,8 @@ class OpenAIServingChat(OpenAIServingBase):
                     ):
                         if chunk:
                             yield chunk
+                    if recovery_enabled and has_tool_calls.get(index, False):
+                        mark_stream_state_tool_call(_ensure_recovery_state(index))
 
                     # Send any remaining tool call arguments when generation finishes
                     if finish_reason_type is not None and index in parser_dict:
@@ -802,6 +955,10 @@ class OpenAIServingChat(OpenAIServingBase):
 
                 else:
                     # Regular content
+                    if recovery_enabled and delta:
+                        update_stream_state_with_content(
+                            _ensure_recovery_state(index), delta
+                        )
                     if delta:
                         choice_data = ChatCompletionResponseStreamChoice(
                             index=index,
@@ -835,6 +992,37 @@ class OpenAIServingChat(OpenAIServingBase):
                 final_finish_reason = finish_reason_type
                 if has_tool_calls.get(idx, False) and finish_reason_type == "stop":
                     final_finish_reason = "tool_calls"
+
+                # Fallback B: if this index has non-empty reasoning but empty
+                # content and we stopped naturally, run a continuation stream
+                # instead of emitting the original finish_reason chunk.
+                if recovery_enabled:
+                    state = recovery_states.get(idx)
+                    if state is not None and should_recover_stream_state(state):
+                        try:
+                            async for chunk in stream_recovery_chunks(
+                                handler=self,
+                                request=request,
+                                raw_request=raw_request,
+                                adapted_request=adapted_request,
+                                state=state,
+                                request_id=content["meta_info"]["id"],
+                                request_model=request.model,
+                                continuous_usage_stats=continuous_usage_stats,
+                                prompt_tokens=prompt_tokens.get(idx, 0),
+                                reasoning_tokens_acc=reasoning_tokens.get(idx, 0),
+                                completion_tokens_acc=completion_tokens.get(
+                                    idx, 0
+                                ),
+                            ):
+                                yield chunk
+                            continue  # Skip the normal finish_reason chunk.
+                        except Exception as e:
+                            logger.warning(
+                                "Streaming Fallback B failed; falling back to "
+                                "original finish_reason chunk: %s",
+                                e,
+                            )
 
                 finish_reason_chunk = ChatCompletionStreamResponse(
                     id=content["meta_info"][
@@ -941,6 +1129,24 @@ class OpenAIServingChat(OpenAIServingBase):
 
         if not isinstance(ret, list):
             ret = [ret]
+
+        # Fallback B: post-inference unclosed-reasoning recovery. No-op when
+        # the feature is disabled, the ret items already have content, or the
+        # request shape (n>1, tools, text mode, etc.) is not eligible.
+        try:
+            ret = await maybe_recover_non_streaming(
+                handler=self,
+                adapted_request=adapted_request,
+                request=request,
+                raw_request=raw_request,
+                ret_list=ret,
+            )
+        except Exception as e:
+            logger.warning(
+                "Reasoning recovery (Fallback B) crashed; returning original "
+                "response: %s",
+                e,
+            )
 
         response = self._build_chat_response(
             request,

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -933,7 +933,7 @@ class OpenAIServingChat(OpenAIServingBase):
                     and request.tools
                     and self.tool_call_parser
                 ):
-                    async for chunk in self._process_tool_call_stream(
+                    async for chunk, normal_text_delta in self._process_tool_call_stream(
                         index,
                         delta,
                         parser_dict,
@@ -944,6 +944,14 @@ class OpenAIServingChat(OpenAIServingBase):
                     ):
                         if chunk:
                             yield chunk
+                        # Fallback B accounting: feed the actually-yielded
+                        # content text into the recovery state so an unclosed
+                        # reasoning + real answer (no tool call) does NOT
+                        # spuriously trigger a continuation request.
+                        if recovery_enabled and normal_text_delta:
+                            update_stream_state_with_content(
+                                _ensure_recovery_state(index), normal_text_delta
+                            )
                     if recovery_enabled and has_tool_calls.get(index, False):
                         mark_stream_state_tool_call(_ensure_recovery_state(index))
 
@@ -1634,7 +1642,10 @@ class OpenAIServingChat(OpenAIServingBase):
         else:
             normal_text, calls = parser.parse_stream_chunk(delta)
 
-        # Yield normal text
+        # Yield normal text. Tuple form ``(sse_chunk, normal_text_delta)`` lets
+        # the caller feed the content accumulator used by Fallback B (streaming
+        # unclosed-reasoning recovery). ``normal_text_delta`` is None for
+        # tool-call chunks and a non-empty string for content chunks.
         if normal_text:
             choice_data = ChatCompletionResponseStreamChoice(
                 index=index,
@@ -1659,7 +1670,7 @@ class OpenAIServingChat(OpenAIServingBase):
                     reasoning_tokens=reasoning_tokens,
                 )
 
-            yield f"data: {chunk.model_dump_json()}\n\n"
+            yield f"data: {chunk.model_dump_json()}\n\n", normal_text
 
         # Yield tool calls
         history_tool_calls_cnt = self._get_history_tool_calls_cnt(request)
@@ -1711,7 +1722,7 @@ class OpenAIServingChat(OpenAIServingBase):
                     reasoning_tokens=reasoning_tokens,
                 )
 
-            yield f"data: {chunk.model_dump_json()}\n\n"
+            yield f"data: {chunk.model_dump_json()}\n\n", None
 
     def _check_for_unstreamed_tool_args(
         self,

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -52,6 +52,21 @@ class BaseReasoningFormatDetector:
         if self.think_end_token in self.previous_content:
             self._in_reasoning = False
 
+    def _strip_leading_think_end_tokens(self, text: str) -> str:
+        """Aggressively remove leading think_end tokens from a normal_text segment.
+
+        Useful when speculative decoding (or the reasoning-EOS redirect logit
+        processor) accidentally produces duplicate think_end tokens at the
+        boundary between reasoning and answer. Only leading occurrences are
+        stripped — any think_end that appears mid-content is left untouched.
+        """
+        if not text or not self.think_end_token:
+            return text
+        stripped = text.lstrip()
+        while stripped.startswith(self.think_end_token):
+            stripped = stripped[len(self.think_end_token) :].lstrip()
+        return stripped
+
     def detect_and_parse(self, text: str) -> StreamingParseResult:
         """
         One-time parsing: Detects and parses reasoning sections in the provided text.
@@ -92,7 +107,7 @@ class BaseReasoningFormatDetector:
         if self.think_end_token in processed_text:
             splits = processed_text.split(self.think_end_token, maxsplit=1)
             reasoning_text = splits[0]
-            normal_text = splits[1].strip()
+            normal_text = self._strip_leading_think_end_tokens(splits[1].strip())
 
             return StreamingParseResult(
                 normal_text=normal_text, reasoning_text=reasoning_text
@@ -140,7 +155,9 @@ class BaseReasoningFormatDetector:
 
             self._buffer = ""
             self._in_reasoning = False
-            normal_text = current_text[end_idx + len(self.think_end_token) :]
+            normal_text = self._strip_leading_think_end_tokens(
+                current_text[end_idx + len(self.think_end_token) :]
+            )
 
             return StreamingParseResult(
                 normal_text=normal_text, reasoning_text=reasoning_text.rstrip()
@@ -169,7 +186,9 @@ class BaseReasoningFormatDetector:
         # If we're not in a reasoning block return as normal text
         if not self._in_reasoning:
             self._buffer = ""
-            return StreamingParseResult(normal_text=current_text)
+            return StreamingParseResult(
+                normal_text=self._strip_leading_think_end_tokens(current_text)
+            )
 
         return StreamingParseResult()
 

--- a/python/sglang/srt/parser/reasoning_redirect_registry.py
+++ b/python/sglang/srt/parser/reasoning_redirect_registry.py
@@ -1,0 +1,181 @@
+"""Startup-time registry that decides whether the reasoning-EOS redirect logit
+processor (``ReasoningEosRedirectLogitProcessor``) can be used for a given
+reasoning parser + tokenizer combination.
+
+The processor relies on three things being true:
+
+1. The reasoning parser is in our whitelist (so we know the think-start /
+   think-end tokens and the relevant chat-end tokens).
+2. The tokenizer encodes the think_end token as a *single* token. The
+   processor edits one logit row per step, so multi-token think_end is not
+   supported (the request will silently fall back to Path B if enabled).
+3. We can resolve at least one chat-end token id to redirect away from.
+
+If any of these checks fail we return ``None`` and the caller leaves the
+request alone.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, List, Optional, Set
+
+from sglang.srt.parser.reasoning_parser import ReasoningParser
+
+
+@dataclass
+class ReasoningRedirectConfig:
+    think_start_token_id: Optional[int]
+    think_end_token_id: int
+    redirect_eos_token_ids: List[int]
+    force_reasoning: bool
+
+
+# Per-reasoning-parser whitelist + the additional chat-end tokens that we
+# want to treat as "EOS-class" for the redirect trigger. The model's primary
+# ``tokenizer.eos_token_id`` is always added on top of this.
+_REDIRECT_WHITELIST = {
+    "deepseek-r1": {
+        "force_reasoning": True,
+        "extra_chat_end_tokens": [],
+    },
+    "deepseek-v3": {
+        "force_reasoning": False,
+        "extra_chat_end_tokens": ["<|im_end|>", "<|end_of_sentence|>"],
+    },
+    "qwen3": {
+        "force_reasoning": False,
+        "extra_chat_end_tokens": ["<|im_end|>"],
+    },
+    "qwen3-thinking": {
+        "force_reasoning": True,
+        "extra_chat_end_tokens": ["<|im_end|>"],
+    },
+    "kimi": {
+        "force_reasoning": False,
+        "extra_chat_end_tokens": ["<|im_end|>", "[EOS]"],
+    },
+    "kimi_k2": {
+        "force_reasoning": False,
+        "extra_chat_end_tokens": ["<|im_end|>", "[EOS]"],
+    },
+    "glm45": {
+        "force_reasoning": False,
+        "extra_chat_end_tokens": ["<|user|>", "<|endoftext|>"],
+    },
+    "minimax": {
+        "force_reasoning": True,
+        "extra_chat_end_tokens": ["<|im_end|>"],
+    },
+    "minimax-append-think": {
+        "force_reasoning": False,
+        "extra_chat_end_tokens": ["<|im_end|>"],
+    },
+    "mimo": {
+        "force_reasoning": False,
+        "extra_chat_end_tokens": ["<|im_end|>"],
+    },
+    "interns1": {
+        "force_reasoning": False,
+        "extra_chat_end_tokens": ["<|im_end|>"],
+    },
+    "step3": {
+        "force_reasoning": True,
+        "extra_chat_end_tokens": ["<|im_end|>"],
+    },
+    "step3p5": {
+        "force_reasoning": True,
+        "extra_chat_end_tokens": ["<|im_end|>"],
+    },
+    "nemotron_3": {
+        "force_reasoning": False,
+        "extra_chat_end_tokens": ["<|im_end|>"],
+    },
+}
+
+
+def _encode_to_single_token(tokenizer: Any, text: Optional[str]) -> Optional[int]:
+    if not text or tokenizer is None:
+        return None
+    try:
+        ids = tokenizer.encode(text, add_special_tokens=False)
+    except Exception:
+        return None
+    if isinstance(ids, list) and len(ids) == 1 and isinstance(ids[0], int):
+        return ids[0]
+    return None
+
+
+def _collect_eos_ids(tokenizer: Any) -> Set[int]:
+    out: Set[int] = set()
+    eos = getattr(tokenizer, "eos_token_id", None)
+    if isinstance(eos, int):
+        out.add(eos)
+    elif isinstance(eos, (list, tuple, set)):
+        for v in eos:
+            if isinstance(v, int):
+                out.add(v)
+    return out
+
+
+def is_supported_reasoning_parser(name: Optional[str]) -> bool:
+    return bool(name) and name.lower() in _REDIRECT_WHITELIST
+
+
+def build_redirect_config(
+    reasoning_parser_name: Optional[str],
+    tokenizer: Any,
+    extra_chat_end_token_ids: Optional[Iterable[int]] = None,
+) -> Optional[ReasoningRedirectConfig]:
+    """Return a config the redirect processor can consume, or None.
+
+    Returning None means: do not enable the path-1 redirect processor for this
+    reasoning parser / tokenizer (multi-token think_end, unknown parser, etc.).
+    The caller can still enable Fallback B independently.
+    """
+    if reasoning_parser_name is None:
+        return None
+    name = reasoning_parser_name.lower()
+    entry = _REDIRECT_WHITELIST.get(name)
+    if entry is None:
+        return None
+
+    detector_cls = ReasoningParser.DetectorMap.get(name)
+    if detector_cls is None:
+        return None
+
+    # Construct detector with default kwargs only — we just need the tag strings.
+    try:
+        detector = detector_cls(stream_reasoning=True)
+    except Exception:
+        return None
+
+    think_end_id = _encode_to_single_token(tokenizer, detector.think_end_token)
+    if think_end_id is None:
+        return None
+    think_start_id = _encode_to_single_token(tokenizer, detector.think_start_token)
+
+    eos_ids: Set[int] = _collect_eos_ids(tokenizer)
+    for tok_str in entry.get("extra_chat_end_tokens", []):
+        tok_id = _encode_to_single_token(tokenizer, tok_str)
+        if tok_id is not None:
+            eos_ids.add(tok_id)
+
+    if extra_chat_end_token_ids:
+        for v in extra_chat_end_token_ids:
+            if isinstance(v, int):
+                eos_ids.add(v)
+
+    # Never include think_end itself in the EOS-redirect set — that would
+    # cause us to mask out the very token we want to keep.
+    eos_ids.discard(think_end_id)
+
+    if not eos_ids:
+        return None
+
+    return ReasoningRedirectConfig(
+        think_start_token_id=think_start_id,
+        think_end_token_id=think_end_id,
+        redirect_eos_token_ids=sorted(eos_ids),
+        force_reasoning=entry["force_reasoning"],
+    )

--- a/python/sglang/srt/sampling/custom_logit_processor.py
+++ b/python/sglang/srt/sampling/custom_logit_processor.py
@@ -186,8 +186,13 @@ class ReasoningEosRedirectLogitProcessor(CustomLogitProcessor):
             cur_ids = req.output_ids
             origin_ids = req.origin_input_ids
 
-            # Skip if the request has already left the reasoning section.
-            if think_end_id in cur_ids:
+            # Skip if the request has already left the reasoning section
+            # (either during generation or because the prompt already contained
+            # a closed <think>...</think> block). Checking origin_input_ids
+            # mirrors the saw_start logic below and avoids redirecting EOS to
+            # think_end on requests that have no reasoning section left to
+            # close.
+            if think_end_id in cur_ids or think_end_id in origin_ids:
                 continue
 
             # Skip if the request has not entered the reasoning section yet.

--- a/python/sglang/srt/sampling/custom_logit_processor.py
+++ b/python/sglang/srt/sampling/custom_logit_processor.py
@@ -136,6 +136,98 @@ class DeepSeekR1ThinkingBudgetLogitProcessor(ThinkingBudgetLogitProcessor):
     NEW_LINE_TOKEN_ID: int = 201
 
 
+class ReasoningEosRedirectLogitProcessor(CustomLogitProcessor):
+    """Redirect EOS-class tokens to the think_end token while a request is still
+    in the reasoning section.
+
+    Triggers when ``softmax(logits / temperature)[redirect_eos_token_ids].sum()``
+    exceeds ``prob_threshold``. When triggered, the processor surgically masks
+    the EOS class to ``-inf`` and lifts the think_end token to a strict argmax
+    so that the next step samples the think_end token. All other token logits
+    are left untouched.
+
+    Per-request params (passed via ``SamplingParams.custom_params``):
+
+    - ``think_end_token_id`` (int, required)
+    - ``think_start_token_id`` (Optional[int]): used to detect entry into the
+      reasoning section. Pass ``None`` together with ``force_reasoning=True``
+      for models whose chat template never prefills a think-start token (e.g.
+      original DeepSeek-R1).
+    - ``redirect_eos_token_ids`` (List[int], required, non-empty): the EOS /
+      chat-end token id set whose probability mass triggers the redirect.
+    - ``prob_threshold`` (float, default 0.5)
+    - ``force_reasoning`` (bool, default False)
+    """
+
+    def __call__(
+        self,
+        logits: torch.Tensor,
+        custom_param_list: Optional[List[Dict[str, Any]]] = None,
+    ) -> torch.Tensor:
+        if not custom_param_list:
+            return logits
+
+        for i, params in enumerate(custom_param_list):
+            if not params:
+                continue
+            req = params.get("__req__")
+            think_end_id = params.get("think_end_token_id")
+            eos_ids = params.get("redirect_eos_token_ids")
+            if req is None or think_end_id is None or not eos_ids:
+                continue
+
+            think_start_id = params.get("think_start_token_id")
+            try:
+                threshold = float(params.get("prob_threshold", 0.5))
+            except (TypeError, ValueError):
+                continue
+            force_reasoning = bool(params.get("force_reasoning", False))
+
+            cur_ids = req.output_ids
+            origin_ids = req.origin_input_ids
+
+            # Skip if the request has already left the reasoning section.
+            if think_end_id in cur_ids:
+                continue
+
+            # Skip if the request has not entered the reasoning section yet.
+            saw_start = force_reasoning or (
+                think_start_id is not None
+                and (think_start_id in cur_ids or think_start_id in origin_ids)
+            )
+            if not saw_start:
+                continue
+
+            row = logits[i]
+            temperature = (
+                getattr(req.sampling_params, "temperature", 1.0)
+                if req.sampling_params is not None
+                else 1.0
+            )
+            try:
+                temperature = float(temperature)
+            except (TypeError, ValueError):
+                temperature = 1.0
+            if temperature <= 0.0:
+                temperature = 1.0
+
+            scaled = row.float() / max(temperature, 1e-6)
+            probs = torch.softmax(scaled, dim=-1)
+            eos_indices = torch.as_tensor(
+                eos_ids, device=probs.device, dtype=torch.long
+            )
+            eos_prob_sum = probs.index_select(0, eos_indices).sum().item()
+            if eos_prob_sum < threshold:
+                continue
+
+            eos_max = row[eos_indices].max().item()
+            row[eos_indices] = -float("inf")
+            new_max = max(row.max().item(), eos_max)
+            row[think_end_id] = new_max + 1.0
+
+        return logits
+
+
 # Adapted from DeepSeek's implementation: https://github.com/deepseek-ai/DeepSeek-OCR/blob/main/DeepSeek-OCR-master/DeepSeek-OCR-vllm/process/ngram_norepeat.py
 class DeepseekOCRNoRepeatNGramLogitProcessor(CustomLogitProcessor):
     """Block n-gram repetitions within a sliding window for DeepSeek-OCR outputs."""

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -667,6 +667,10 @@ class ServerArgs:
     enable_draft_weights_cpu_backup: bool = False
     allow_auto_truncate: bool = False
     enable_custom_logit_processor: bool = False
+    # Reasoning unclosed-think auto-recover (default off)
+    redirect_unclosed_reasoning: bool = False
+    redirect_eos_prob_threshold: float = 0.5
+    auto_recover_unclosed_reasoning: bool = False
     flashinfer_mla_disable_ragged: bool = False
     disable_shared_experts_fusion: bool = False
     enforce_shared_experts_fusion: bool = False
@@ -5955,6 +5959,35 @@ class ServerArgs:
             "--enable-custom-logit-processor",
             action="store_true",
             help="Enable users to pass custom logit processors to the server (disabled by default for security)",
+        )
+        parser.add_argument(
+            "--redirect-unclosed-reasoning",
+            action="store_true",
+            default=ServerArgs.redirect_unclosed_reasoning,
+            help="When the model is still inside the reasoning section but the EOS-class "
+            "tokens accumulate enough probability, redirect the next sampled token to the "
+            "think_end token. Requires --enable-custom-logit-processor and a model whose "
+            "think_end is a single token (auto-detected on startup; otherwise this flag is "
+            "silently ignored for unsupported models).",
+        )
+        parser.add_argument(
+            "--redirect-eos-prob-threshold",
+            type=float,
+            default=ServerArgs.redirect_eos_prob_threshold,
+            help="Probability threshold (after temperature scaling) that the EOS-class "
+            "tokens must collectively exceed for the reasoning-EOS redirect logit "
+            "processor to fire. Only meaningful with --redirect-unclosed-reasoning.",
+        )
+        parser.add_argument(
+            "--auto-recover-unclosed-reasoning",
+            action="store_true",
+            default=ServerArgs.auto_recover_unclosed_reasoning,
+            help="If a chat completion finishes with non-empty reasoning_content but "
+            "essentially empty content (and no tool calls), transparently issue a "
+            "follow-up generation that appends the think_end token to the existing "
+            "output_ids and continues, then merge the two responses before returning to "
+            "the client. Acts as a safety net for the redirect logit processor and works "
+            "on multi-token think_end models too.",
         )
         parser.add_argument(
             "--flashinfer-mla-disable-ragged",

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1,6 +1,8 @@
 import contextlib
 import logging
 import time
+from copy import deepcopy
+from contextlib import contextmanager
 from typing import List, Optional, Tuple
 
 import torch
@@ -27,7 +29,11 @@ from sglang.srt.managers.schedule_batch import ModelWorkerBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardBatch
-from sglang.srt.server_args import ServerArgs
+from sglang.srt.server_args import (
+    ServerArgs,
+    get_global_server_args,
+    set_global_server_args_for_scheduler,
+)
 from sglang.srt.speculative.base_spec_worker import BaseDraftWorker, BaseSpecWorker
 from sglang.srt.speculative.draft_utils import DraftBackendFactory
 from sglang.srt.speculative.eagle_draft_cuda_graph_runner import (
@@ -95,7 +101,6 @@ class EagleDraftWorker(BaseDraftWorker):
         nccl_port: int,
         target_worker: TpModelWorker,
     ):
-        # copy args
         self.server_args = server_args
         self.gpu_id = gpu_id
         self.tp_rank = tp_rank
@@ -115,10 +120,15 @@ class EagleDraftWorker(BaseDraftWorker):
             server_args.speculative_algorithm
         )
 
+        # Draft and target workers should not mutate the same ServerArgs instance.
+        # EAGLE3 draft models can use a different attention architecture than the
+        # target model, and model-specific adjustments must stay local to the draft.
+        draft_server_args = deepcopy(server_args)
+
         # Do not capture cuda graph in `TpModelWorker` init,
         # will capture later with init_cuda_graphs()
-        backup_disable_cuda_graph = server_args.disable_cuda_graph
-        server_args.disable_cuda_graph = True
+        backup_disable_cuda_graph = draft_server_args.disable_cuda_graph
+        draft_server_args.disable_cuda_graph = True
 
         # Share the allocator with a target worker.
         # Draft and target worker own their own KV cache pools.
@@ -127,7 +137,7 @@ class EagleDraftWorker(BaseDraftWorker):
         )
 
         # Init draft worker
-        if server_args.enable_dp_attention and self.speculative_algorithm.is_eagle3():
+        if draft_server_args.enable_dp_attention and self.speculative_algorithm.is_eagle3():
             ctx = draft_tp_context(get_attention_tp_group())
         else:
             ctx = empty_context()
@@ -136,7 +146,7 @@ class EagleDraftWorker(BaseDraftWorker):
         ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
             # Init draft worker
             self.draft_worker = TpModelWorker(
-                server_args=server_args,
+                server_args=draft_server_args,
                 gpu_id=gpu_id,
                 tp_rank=tp_rank,
                 pp_rank=0,  # FIXME
@@ -167,7 +177,7 @@ class EagleDraftWorker(BaseDraftWorker):
         # Init attention backend and cuda graphs
         self.draft_runner.server_args.disable_cuda_graph = backup_disable_cuda_graph
         self.draft_tp_context = (
-            draft_tp_context if server_args.enable_dp_attention else empty_context
+            draft_tp_context if draft_server_args.enable_dp_attention else empty_context
         )
         with self.draft_tp_context(
             self.draft_runner.tp_group
@@ -666,6 +676,9 @@ class EAGLEWorkerV2(BaseSpecWorker):
             nccl_port,
             target_worker,
         )
+        self.target_server_args = target_worker.model_runner.server_args
+        self.draft_server_args = self._draft_worker.draft_runner.server_args
+        set_global_server_args_for_scheduler(self.target_server_args)
 
         # Some dummy tensors
         self.num_new_pages_per_topk = torch.empty(
@@ -687,6 +700,17 @@ class EAGLEWorkerV2(BaseSpecWorker):
         # allocator and kv cache pool are shared with target worker, which are cleared in scheduler
         pass
 
+    @contextmanager
+    def _use_server_args(self, server_args: ServerArgs):
+        prev_server_args = get_global_server_args()
+        if prev_server_args is not server_args:
+            set_global_server_args_for_scheduler(server_args)
+        try:
+            yield
+        finally:
+            if prev_server_args is not server_args:
+                set_global_server_args_for_scheduler(prev_server_args)
+
     def forward_batch_generation(self, model_worker_batch: ModelWorkerBatch):
         if (
             model_worker_batch.forward_mode.is_extend()
@@ -694,13 +718,14 @@ class EAGLEWorkerV2(BaseSpecWorker):
         ):
             # Target prefill
             model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
-            batch_output = self.target_worker.forward_batch_generation(
-                model_worker_batch
-            )
+            with self._use_server_args(self.target_server_args):
+                batch_output = self.target_worker.forward_batch_generation(
+                    model_worker_batch
+                )
 
             # Draft prefill
             model_worker_batch.capture_hidden_mode = CaptureHiddenMode.LAST
-            with self.draft_worker.draft_tp_context(
+            with self._use_server_args(self.draft_server_args), self.draft_worker.draft_tp_context(
                 self.draft_worker.draft_runner.tp_group
             ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
                 batch_output.next_draft_input = (
@@ -723,14 +748,14 @@ class EAGLEWorkerV2(BaseSpecWorker):
                 )
             with self.draft_worker.draft_tp_context(
                 self.draft_worker.draft_runner.tp_group
-            ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
+            ), self._use_server_args(self.draft_server_args), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
                 verify_input: EagleVerifyInput = self.draft_worker.draft(
                     model_worker_batch
                 )
             assert verify_input.is_verify_input()
             model_worker_batch.spec_info = verify_input
             batch_output = self.verify(model_worker_batch)
-            with self.draft_worker.draft_tp_context(
+            with self._use_server_args(self.draft_server_args), self.draft_worker.draft_tp_context(
                 self.draft_worker.draft_runner.tp_group
             ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
                 self.draft_worker._draft_extend_for_decode(
@@ -753,7 +778,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
 
         # Batch 1: Target verify
         # Prepare for target verify in a separate stream
-        with self.plan_stream_ctx:
+        with self._use_server_args(self.target_server_args), self.plan_stream_ctx:
             verify_forward_batch, can_run_cuda_graph = (
                 verify_input.prepare_for_v2_verify(
                     self.req_to_token_pool,
@@ -771,14 +796,15 @@ class EAGLEWorkerV2(BaseSpecWorker):
             # Some values such as custom_mask and position depend on the output of draft,
             # so the previous plan step used the wrong values. Here, we need to run the related
             # computation again to update them to the correct values.
-            self.target_worker.model_runner.attn_backend.update_verify_buffers_to_fill_after_draft(
-                verify_input,
-                (
-                    self.target_worker.model_runner.graph_runner.bs
-                    if can_run_cuda_graph
-                    else None
-                ),
-            )
+            with self._use_server_args(self.target_server_args):
+                self.target_worker.model_runner.attn_backend.update_verify_buffers_to_fill_after_draft(
+                    verify_input,
+                    (
+                        self.target_worker.model_runner.graph_runner.bs
+                        if can_run_cuda_graph
+                        else None
+                    ),
+                )
 
         # Prepare grammar data on CPU if needed
         if batch.has_grammar:
@@ -789,12 +815,13 @@ class EAGLEWorkerV2(BaseSpecWorker):
             ).cpu()
 
         # Run target verify batch in the main compute stream (GPU compute)
-        forward_batch_output = self.target_worker.forward_batch_generation(
-            model_worker_batch=None,
-            forward_batch=verify_forward_batch,
-            is_verify=True,
-            skip_attn_backend_init=True,
-        )
+        with self._use_server_args(self.target_server_args):
+            forward_batch_output = self.target_worker.forward_batch_generation(
+                model_worker_batch=None,
+                forward_batch=verify_forward_batch,
+                is_verify=True,
+                skip_attn_backend_init=True,
+            )
         logits_output = forward_batch_output.logits_output
 
         # Generate vocab mask for constrained decoding

--- a/recover-unclosed-think_d4a5b223.plan.md
+++ b/recover-unclosed-think_d4a5b223.plan.md
@@ -1,0 +1,370 @@
+---
+name: recover-unclosed-think
+overview: 给 SGLang 的 OpenAI Chat 服务端新增"未闭合 reasoning 自动补救"能力。主路径是在 sampling 层加一个 logit redirect processor：reasoning 阶段当 EOS/im_end 概率合计超过阈值时，把 EOS 集合 logit 屏蔽并把 think_end 顶到 strict max，单步内把"提前 EOS"重定向为"输出 think_end 后继续生成 content"；兜底路径是在 OpenAIServingChat 层做 post-inference 续写（直接走 GenerateReqInput.input_ids，不重过 chat template），覆盖 multi-token think_end 模型与路径 1 漏过、redirect 后立即 EOS 等场景。两层都是默认 off 的可选行为。
+todos:
+  - id: config
+    content: 新增 server_args 与 ChatCompletionRequest 配置字段（路径 1 开关 + 概率阈值 + 兜底开关 + per-request 覆盖）
+    status: pending
+  - id: redirect_processor
+    content: 实现 ReasoningEosRedirectLogitProcessor（基于 EOS 概率合计 + temperature 校准 + force_reasoning + spec-decode lookback）
+    status: pending
+  - id: registry
+    content: 启动期 think_end token 自检 + 模型白名单注册表，决定每个模型是否启用路径 1
+    status: pending
+  - id: inject_processor
+    content: 在 _convert_to_internal_request 中按白名单与开关合并注入 redirect processor，与用户自定义 processor 共存
+    status: pending
+  - id: parser_dedupe
+    content: 在 ReasoningParser 解析层去除 normal_text 起首的多余 think_end token（应对 spec decoding 重复 redirect）
+    status: pending
+  - id: fallback_b_nonstream
+    content: 非流式分支接入方案 B 兜底：触发条件激进，复用 GenerateReqInput.input_ids 续写并合并响应
+    status: pending
+  - id: fallback_b_stream
+    content: 流式分支接入方案 B 兜底：推迟 finish_reason，第二段流跳过 role chunk 并透传 content
+    status: pending
+  - id: tests
+    content: 新增覆盖路径 1 / 方案 B / spec decoding / tool call / thinking budget / multi-token 降级 / streaming 的测试矩阵
+    status: pending
+---
+
+# 未闭合 reasoning 自动补救（Reasoning EOS Redirect + Fallback Continuation）
+
+## 目标
+
+解决"模型在 reasoning 阶段没生成 think 闭合 token 就被 chat-end token (例如 `<|im_end|>` / `[EOS]`) 提前停掉"导致 content 为空的偶发问题，同时不影响 tool call、thinking budget、reasoning-only 合法空响应等正常行为。
+
+## 总体架构
+
+两层互补，默认全部 off，由 server_args 与 per-request 字段独立控制：
+
+- **路径 1（主，事中拦截，单次推理）**：仿造 [`ThinkingBudgetLogitProcessor`](python/sglang/srt/sampling/custom_logit_processor.py) 写一个 `ReasoningEosRedirectLogitProcessor`。每步对仍处于 reasoning 的请求计算 `softmax(logits/T)[eos_ids].sum()`，超过阈值就把 EOS 集合的 logit 设 -inf、把 `think_end` 的 logit 顶到 strict max，让本步精确"重定向"成 `think_end`，其它 token 完全不动。仅对 single-token think_end 的模型启用（启动期自检）。
+- **方案 B（兜底，事后续写）**：在 OpenAIServingChat 层，第一次响应解析后若仍命中"reasoning 非空 + content 完全空 + finish=stop + 无 tool_calls"，就用 `GenerateReqInput(input_ids = orig_ids + first_output_ids + think_end_token_ids)` 直接发起第二次 generate（不走 chat template，prefix cache 命中率最高），把第二段 content 与第一段 reasoning 合并后返回。**不**要求 detector 仍 in_reasoning（激进策略，覆盖路径 1 触发后又立刻 EOS 的场景）。
+
+```mermaid
+flowchart TD
+    Req["ChatCompletionRequest"] --> Adapt["_convert_to_internal_request"]
+    Adapt -->|"白名单 + 开关 on"| Inject["注入 ReasoningEosRedirectLogitProcessor"]
+    Adapt -->|"开关 off / 白名单外"| Skip["不注入"]
+    Inject --> Gen1["1st generate (target sampler 每步过 processor)"]
+    Skip --> Gen1
+    Gen1 --> Parse["reasoning_parser 解析<br/>(normal_text 起首去重 think_end)"]
+    Parse --> Cond{"reasoning 非空<br/>AND normal_text.strip 为空<br/>AND finish=stop<br/>AND 无 tool_calls<br/>AND n=1<br/>AND 兜底开关 on"}
+    Cond -- 否 --> Resp["原响应返回"]
+    Cond -- 是 --> Build["拼接 input_ids = orig + first_output + think_end_ids<br/>max_tokens 减去已用"]
+    Build --> Gen2["2nd generate"]
+    Gen2 --> Merge["合并 reasoning + content + usage"]
+    Merge --> Resp
+```
+
+## 详细改动清单
+
+### 1. 配置项
+
+- [python/sglang/srt/server_args.py](python/sglang/srt/server_args.py)：在 `ServerArgs`（约 L443，紧挨 `reasoning_parser`）新增：
+  - `redirect_unclosed_reasoning: bool = False`（路径 1 开关）
+  - `redirect_eos_prob_threshold: float = 0.5`（路径 1 触发阈值）
+  - `auto_recover_unclosed_reasoning: bool = False`（方案 B 开关）
+  - 在 `add_cli_args`（约 L4802）加对应 CLI flag。
+- [python/sglang/srt/entrypoints/openai/protocol.py](python/sglang/srt/entrypoints/openai/protocol.py) `ChatCompletionRequest`（L613 附近）新增：
+  - `recover_unclosed_reasoning: Optional[bool] = None`（per-request 覆盖方案 B 开关；路径 1 不做 per-request 覆盖，因为它是 sampling 层 batch 注入）。
+
+### 2. 路径 1：`ReasoningEosRedirectLogitProcessor`
+
+新增到 [python/sglang/srt/sampling/custom_logit_processor.py](python/sglang/srt/sampling/custom_logit_processor.py)：
+
+```python
+# 伪码
+class ReasoningEosRedirectLogitProcessor(CustomLogitProcessor):
+    def __call__(self, logits, custom_param_list):
+        for i, params in enumerate(custom_param_list):
+            if not params:
+                continue
+            req            = params["__req__"]
+            think_start_id = params.get("think_start_token_id")  # 可为 None
+            think_end_id  = params["think_end_token_id"]
+            eos_ids       = params["redirect_eos_token_ids"]   # list[int]
+            threshold     = params.get("prob_threshold", 0.5)
+            temperature   = params.get("temperature", 1.0)
+            force_reasoning = params.get("force_reasoning", False)
+            spec_lookback   = params.get("spec_lookback_window", 0)  # = draft_token_num*2
+
+            cur_ids = req.output_ids
+            origin_ids = req.origin_input_ids
+
+            # 1. in_reasoning 判定
+            saw_end = (think_end_id in cur_ids)
+            if saw_end:
+                continue
+            saw_start = (
+                force_reasoning
+                or (think_start_id is not None
+                    and (think_start_id in cur_ids or think_start_id in origin_ids))
+            )
+            if not saw_start:
+                continue
+
+            # 2. spec-decode 重复 redirect 保护：最近 spec_lookback 个 token 已含 think_end 则跳过
+            if spec_lookback > 0 and len(cur_ids) >= 1:
+                recent = cur_ids[-spec_lookback:]
+                if think_end_id in recent:
+                    continue
+
+            # 3. 触发判定：EOS 概率合计 > 阈值（temperature 校准）
+            row = logits[i]
+            scaled = row / max(temperature, 1e-6)
+            probs  = torch.softmax(scaled, dim=-1)
+            eos_prob_sum = probs[eos_ids].sum().item()
+            if eos_prob_sum < threshold:
+                continue
+
+            # 4. 定点 redirect：屏蔽 EOS 集合，把 think_end 顶到 strict max
+            eos_max = row[eos_ids].max().item()
+            row[eos_ids] = -float("inf")
+            row[think_end_id] = max(row.max().item(), eos_max) + 1.0
+        return logits
+```
+
+要点：
+- **temperature 校准**：从 `sampling_info.temperatures[i]` 取真实采样温度做缩放，避免 low-temp 下漏触发。需要在 `apply_custom_logit_processor` 调用时把 temperature 也下发到 custom_params；最干净的做法是在 [sampler.py L60-65](python/sglang/srt/layers/sampler.py) `_preprocess_logits` 中把 `sampling_info.temperatures` 透传，或在 processor 内通过 `params.setdefault("__sampling_info__", sampling_info)` 拿到（参考 `ThinkingBudgetLogitProcessor` 已通过 `__req__` 拿 req）。
+- **`force_reasoning`**：DeepSeek-R1 原生 chat template 不带 `<think>`，detector 直接 `_in_reasoning=True` 起手；processor 也要支持这种"无起始 token 但默认在 reasoning"的语义。
+- **spec_lookback_window**：取 `server_args.speculative_num_draft_tokens` 或类似值的 2 倍；`server_args.speculative_algorithm` 为空时取 0。在 `_convert_to_internal_request` 注入参数时一次填好。
+- **只改两类下标的 logits**：其它 token logit 完全不动，与 grammar mask、penalty 链路兼容（grammar mask 在 `_preprocess_logits` 之后才应用，若 grammar 强行不允许 think_end，最终采样不会是 think_end，但 EOS 已经 -inf，模型仍不会停 → 结果是模型按 grammar 走、不停）。
+
+### 3. 启动期自检 + 白名单注册
+
+新增轻量注册表（可放在 [python/sglang/srt/parser/reasoning_parser.py](python/sglang/srt/parser/reasoning_parser.py) 内或新建 `reasoning_token_registry.py`）：
+
+```python
+# 伪码
+REDIRECT_WHITELIST = {
+    "qwen3", "qwen3-thinking",
+    "glm45",
+    "deepseek-r1",
+    "kimi_k2",  # Kimi K2 / K2.5: </think> 单 token
+    "minimax",
+    # 不进入: "gpt-oss" (Harmony 特殊), "gemma4", "minimax-append-think"
+    #         "mistral" / "kimi" 视 tokenizer 自检结果
+}
+
+def build_redirect_config(server_args, tokenizer, reasoning_parser_name):
+    if not server_args.redirect_unclosed_reasoning: return None
+    if reasoning_parser_name not in REDIRECT_WHITELIST: 
+        logger.warning(...); return None
+    detector_cls = ReasoningParser.DetectorMap[reasoning_parser_name]
+    # 用一个临时实例拿 think_start/end token 字符串
+    tmp = detector_cls()
+    end_ids = tokenizer.encode(tmp.think_end_token, add_special_tokens=False)
+    if len(end_ids) != 1:
+        logger.warning("multi-token think_end, redirect disabled"); return None
+    start_ids = tokenizer.encode(tmp.think_start_token, add_special_tokens=False) \
+                if tmp.think_start_token else []
+    eos_ids = derive_chat_eos_ids(tokenizer, server_args)  # 见下
+    return {
+        "think_end_token_id": end_ids[0],
+        "think_start_token_id": start_ids[0] if len(start_ids) == 1 else None,
+        "redirect_eos_token_ids": eos_ids,
+        "force_reasoning": (reasoning_parser_name == "deepseek-r1"),
+        "prob_threshold": server_args.redirect_eos_prob_threshold,
+        "spec_lookback_window": (server_args.speculative_num_draft_tokens or 0) * 2,
+    }
+
+def derive_chat_eos_ids(tokenizer, server_args):
+    ids = set()
+    # generation_config.eos_token_id 可能是 int 或 list
+    eos = getattr(tokenizer, "eos_token_id", None)
+    if isinstance(eos, int): ids.add(eos)
+    elif isinstance(eos, (list, tuple)): ids.update(eos)
+    # 模型特有的 chat-end token
+    for name in ("<|im_end|>", "<|end|>", "<|eot_id|>", "<|endoftext|>", "[EOS]"):
+        try:
+            tid = tokenizer.convert_tokens_to_ids(name)
+            if isinstance(tid, int) and tid >= 0: ids.add(tid)
+        except Exception: pass
+    return sorted(ids)
+```
+
+调用位置：[python/sglang/srt/entrypoints/openai/serving_chat.py](python/sglang/srt/entrypoints/openai/serving_chat.py) `OpenAIServingChat.__init__`，把 `self._redirect_config = build_redirect_config(...)` 缓存好。
+
+### 4. 注入 processor 到 GenerateReqInput
+
+在 `_convert_to_internal_request`（约 [serving_chat.py L300-330](python/sglang/srt/entrypoints/openai/serving_chat.py)）：
+
+```python
+# 伪码
+if self._redirect_config is not None:
+    cfg = self._redirect_config
+    # 检查不与用户自定义 processor 冲突 / 共存
+    extra_proc_str = ReasoningEosRedirectLogitProcessor.to_str()
+    extra_params = dict(cfg)  # copy
+
+    if request.custom_logit_processor is None:
+        adapted_request.custom_logit_processor = extra_proc_str
+        adapted_request.custom_params = extra_params
+    else:
+        # 已有用户 processor: 走"链式 processor"路径
+        # SGLang 已支持 sampling_batch_info.custom_logit_processor 是 dict
+        # 但 GenerateReqInput 接口当前是单值；本期实现：如果用户已传，记录 warning 并跳过注入
+        logger.warning("user custom_logit_processor present, skip auto redirect injection for rid=%s", request.rid)
+```
+
+> 长期可以扩展 `GenerateReqInput.extra_custom_logit_processors: List[str]` 支持多 processor；本期保守处理。
+
+### 5. ReasoningParser 解析层去重（spec-decode 兜底）
+
+[python/sglang/srt/parser/reasoning_parser.py](python/sglang/srt/parser/reasoning_parser.py) `BaseReasoningFormatDetector.detect_and_parse` 在拿到 `normal_text` 之后激进过滤：
+
+```python
+# splits 后已有 normal_text = splits[1].strip()
+# 防御 spec-decoding 重复 redirect 留下的多余 think_end token
+while normal_text.startswith(self.think_end_token):
+    normal_text = normal_text[len(self.think_end_token):].lstrip()
+```
+
+`parse_streaming_increment` 同步：在 `current_text.find(self.think_end_token)` 切分后，对 `normal_text` 做同样 lstrip 循环。
+
+这样无论上游 redirect 是否漏过、spec-decode 是否多塞了一两个 think_end，最终用户拿到的 normal_text 都是干净的。
+
+### 6. 方案 B 兜底（非流式）
+
+`_handle_non_streaming_request`（[serving_chat.py L928](python/sglang/srt/entrypoints/openai/serving_chat.py)）改造：
+
+1. 拿到 `ret`、构造 `response = self._build_chat_response(...)` 之前，先做"是否需要兜底"判定：
+   ```python
+   def _should_recover_b(self, request, ret_item, parser, tool_calls):
+       if not (request.recover_unclosed_reasoning if request.recover_unclosed_reasoning is not None
+               else self.tokenizer_manager.server_args.auto_recover_unclosed_reasoning):
+           return False
+       fr = ret_item["meta_info"].get("finish_reason")
+       if not fr or fr.get("type") != "stop": return False
+       if request.n != 1: return False
+       if request.continue_final_message: return False
+       if tool_calls: return False
+       # 重新跑 parser 拿 (reasoning, normal)
+       reasoning_text, normal_text = parser.parse_non_stream(ret_item["text"])
+       if not reasoning_text: return False
+       if (normal_text or "").strip(): return False  # C 场景放宽：有非空白 content 就不兜底
+       return True
+   ```
+
+2. 满足条件就续写：
+   ```python
+   first_output_ids = ret_item["meta_info"]["output_ids"]  # 若没有则用 tokenizer.encode(ret_item["text"])
+   think_end_ids   = self._redirect_config["think_end_token_ids"] if self._redirect_config \
+                     else self.tokenizer_manager.tokenizer.encode(detector.think_end_token, add_special_tokens=False)
+   recovered_input_ids = list(adapted_request.input_ids) + list(first_output_ids) + list(think_end_ids)
+
+   recovered_sampling = copy.deepcopy(adapted_request.sampling_params)
+   used = ret_item["meta_info"]["completion_tokens"]
+   for k in ("max_new_tokens", "max_tokens"):
+       if recovered_sampling.get(k):
+           recovered_sampling[k] = max(1, recovered_sampling[k] - used - len(think_end_ids))
+           if recovered_sampling[k] <= 0: 
+               return response  # 预算耗尽，原样返回
+
+   recovered_adapted = GenerateReqInput(
+       input_ids=recovered_input_ids,
+       sampling_params=recovered_sampling,
+       stream=False,
+       rid=f"{request.rid}-recover" if request.rid else None,
+       bootstrap_host=adapted_request.bootstrap_host,
+       bootstrap_port=adapted_request.bootstrap_port,
+       bootstrap_room=adapted_request.bootstrap_room,
+       # ... 复用 lora_path / extra_key / image_data 等
+       require_reasoning=False,  # 已经离开 reasoning 阶段
+   )
+   ret2 = await self.tokenizer_manager.generate_request(recovered_adapted, raw_request).__anext__()
+   ```
+
+3. 合并：
+   - `content`：第二次 `ret2["text"]` 经 reasoning_parser 解析后的 normal_text（detector previous_content 含 think_end，自动当 normal_text）；
+   - `reasoning_content`：保留第一次的 reasoning_text；
+   - `usage.prompt_tokens`：第二次的（更准确反映总 prefill）；
+   - `usage.completion_tokens`、`usage.reasoning_tokens`：累加；
+   - `finish_reason`：第二次的；
+   - `logprobs / hidden_states / routed_experts`：以第二次为准并 log warning（合并复杂度过高，本期不做）。
+
+4. 防递归：第二次请求显式不再启用方案 B（在 `recovered_adapted` 上不挂 `recover_unclosed_reasoning` 标记，且对方案 B 的条件函数加 `not request.recover_unclosed_reasoning is False` 等价的早期 return）。最简洁的做法：在 `_should_recover_b` 顶部检查 `getattr(adapted_request, "_is_recovery_request", False)`，并在 `recovered_adapted` 上挂 `_is_recovery_request = True`（GenerateReqInput 加一个 internal-only 字段或者用 extra_key 透传都可以；首选加字段）。
+
+### 7. 方案 B 兜底（流式）
+
+`_generate_chat_stream`（[serving_chat.py L639](python/sglang/srt/entrypoints/openai/serving_chat.py)）改造：
+
+1. 主循环已经把每个 index 的原始 raw text 累积在 `stream_buffers[index]`、reasoning parser 缓存在 `reasoning_parser_dict[index]`、`finish_reasons[index]` 里有 finish_reason。
+2. 在 `# Send finish_reason chunks for each index that completed` 之前（[L831](python/sglang/srt/entrypoints/openai/serving_chat.py)），新增判定：仅当 `len(finish_reasons) == 1`、`request.n == 1`、且 `_should_recover_b_stream(...)` 通过时进入兜底流程：
+   - **不要**先 yield finish_reason chunk；
+   - 构造 `recovered_adapted`（同非流式逻辑，但 `stream=True`）；
+   - `async for c in self.tokenizer_manager.generate_request(recovered_adapted, raw_request)` 拿第二段流；
+   - 跳过第二次的 first role chunk；reasoning delta 一般为空（previous_content 含 think_end）；正常透传 content delta，每个 chunk 走 `DeltaMessage(content=...)`；
+   - 累加 prompt/completion/reasoning tokens；
+   - 第二段流结束后再 yield 真正的 `finish_reason_chunk` / hidden_states / usage chunk。
+3. 异常保护：`try/except` 包裹兜底流程，第二次请求抛错时回退到原 finish_reason chunk + warning，避免影响 `[DONE]`。
+4. 抽出内部 helper `_stream_recover_followup(...)` 保持主循环可读。
+
+### 8. 测试矩阵
+
+新增 [test/registered/openai_server/basic/test_recover_unclosed_reasoning.py](test/registered/openai_server/basic/test_recover_unclosed_reasoning.py) + 单元测试：
+
+- **路径 1 触发**：mock logits 让 EOS 概率 > 阈值，断言 sampling 结果 = think_end_id；其它场景下 logits 完全未改动。
+- **路径 1 不触发**：EOS 概率 < 阈值；`_in_reasoning=False`；force_reasoning=False 且 think_start 不在；spec_lookback 内已含 think_end。
+- **temperature 校准**：raw 0.4、temp=0.1（缩放后 ~0.95）应触发。
+- **EOS 集合默认推断**：Qwen3 / Kimi K2.5 tokenizer 自检后的 eos_ids 是否包含 `<|im_end|>` / `[EOS]`。
+- **方案 B 触发（场景 A）**：first response = `<think>thinking...<|im_end|>`，开关 on，断言最终响应有 `</think>` 后续 content。
+- **方案 B 触发（场景 B）**：first response = `<think>thinking...</think><|im_end|>`，开关 on（注意：normal_text strip 后为空），断言兜底续写。
+- **方案 B 不触发（场景 C）**：first response = `<think>...</think>好的<|im_end|>`，断言不兜底。
+- **方案 B 不触发（合法空响应 + 开关 off）**：默认配置下不兜底。
+- **Tool call 不兜底**：first response 含 tool_calls 解析结果。
+- **n>1 / continue_final_message=True 不兜底**。
+- **递归保护**：第二次请求不再触发方案 B，即使仍空 content。
+- **Spec decoding**：mock eagle3，draft 在位置 0/1 出 EOS：(a) 路径 1 启用：断言最终 normal_text 干净（无重复 think_end）；(b) 路径 1 + 重复 redirect 触发：断言 ReasoningParser lstrip 起作用。
+- **Multi-token 降级**：mock tokenizer 让 `</think>` 编码成 [t1, t2, t3]，启动期 redirect_config = None，开关 on 时方案 B 仍能续写。
+- **Streaming**：路径 1 触发后端到端流；方案 B 兜底流。
+- **Thinking budget 共存**：同时开启 `Qwen3ThinkingBudgetLogitProcessor` + redirect，budget 命中时 think_end 注入；redirect 不双重介入。
+- **Grammar / structured output**：JSON schema 限制下 redirect 不破坏约束（如有冲突，至少不崩溃）。
+
+## 配置示例
+
+```bash
+# 路径 1 + 方案 B 全开
+python -m sglang.launch_server \
+    --model-path moonshotai/Kimi-K2.5 \
+    --reasoning-parser kimi_k2 \
+    --redirect-unclosed-reasoning \
+    --redirect-eos-prob-threshold 0.5 \
+    --auto-recover-unclosed-reasoning
+```
+
+per-request 覆盖（仅控制方案 B）：
+
+```json
+{ "messages": [...], "recover_unclosed_reasoning": true }
+```
+
+## 已知限制（README / CLI help 文档化）
+
+1. **Logprobs 透露内部行为**：路径 1 触发的那一步，think_end 的 logprob 被人为顶到极高、EOS 被打到 -inf；用户开 `logprobs+top_logprobs` 能看到。本期不做"还原显示"，作为已知限制说明。
+2. **方案 B 二次 logprobs / hidden_states 合并**：以第二次为准，第一次部分丢弃并 log warning。
+3. **Spec decoding accept length**：路径 1 触发会让 verify 在该位置 reject，spec 加速比短期下降。
+4. **`max_tokens` 耗尽 (finish_reason=length)**：完全不介入，行为保持原样。
+5. **Harmony / Gemma4 / minimax-append-think**：不在路径 1 白名单；方案 B 因为依赖 `reasoning_parser.detector.think_end_token`，理论上能跑，但 Harmony 的 reasoning 边界不是简单字符串，建议这几个 parser 也跳过方案 B（在 `_should_recover_b` 加白名单 check）。
+6. **多 processor 链路**：用户已传 `custom_logit_processor` 时，本期跳过自动注入并 warning；后续可扩展 `GenerateReqInput.extra_custom_logit_processors`。
+7. **PD disaggregation**：custom_logit_processor / custom_params 已经支持随 req 跨节点；方案 B 第二次请求复制 bootstrap 字段；若 KV cache 已被释放则二次 prefill 只是缺一个 prefix cache 命中，不影响正确性。
+
+## 风险与对策（最终汇总）
+
+- **路径 1 误触发（temperature 极高）**：阈值 0.5 默认保守 + temperature 校准；可通过 `--redirect-eos-prob-threshold` 调高。
+- **路径 1 漏触发**：方案 B 兜底（场景 A/B 全覆盖）。
+- **路径 1 触发后立即又 EOS（场景 B）**：方案 B 激进策略覆盖。
+- **C 场景"几个空白字符然后 EOS"**：放宽不兜底（保留模型短回复的合法性）。
+- **Spec-decode verify 重复 redirect → 双 think_end**：双层防御：processor 内 `spec_lookback_window` + ReasoningParser 解析层 lstrip。
+- **multi-token think_end**：启动自检自动禁用路径 1，方案 B 接管。
+- **递归补救**：`_is_recovery_request` 标志 + 接口级保护。
+- **Tool call / thinking budget**：触发条件互斥，已分别在路径 1（`saw_end` 早返回）与方案 B（`if tool_calls: return False` + budget 命中后 detector 已收到 think_end）层校验。
+- **二次请求超 context 长度 / token 预算耗尽**：try/except 包裹，失败回退到原响应 + warning。
+- **gpt-oss / gemma4 / harmony**：双层都跳过。
+
+## 上线建议
+
+- 两个开关默认 off，渐进灰度；
+- 加结构化日志（rid + 触发场景 + EOS 概率 + 第二次 token 用量），便于评估触发率；
+- 测试矩阵中 spec decoding 用例必须通过后再合并主分支。

--- a/test/registered/unit/openai/test_recover_unclosed_reasoning_integration.py
+++ b/test/registered/unit/openai/test_recover_unclosed_reasoning_integration.py
@@ -290,34 +290,41 @@ class TestPath1AndFallbackBCoexist(CustomTestCase):
         self.assertIn("the actual content", merged["text"])
 
 
-# ----- Tool-call requests are skipped end-to-end ------------------------
+# ----- Tool-call eligibility / runtime judgement end-to-end -------------
 
 
 class TestToolCallSkipsRecovery(CustomTestCase):
-    def test_eligibility_excludes_tool_requests(self):
-        req = _basic_request(
-            tools=[
-                {
-                    "type": "function",
-                    "function": {
-                        "name": "f",
-                        "parameters": {"type": "object", "properties": {}},
-                    },
-                }
-            ]
-        )
+    def _tools(self):
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": "f",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+
+    def test_tool_choice_required_is_hard_excluded(self):
+        # tool_choice="required" is the only hard-exclude — the model is
+        # contractually obliged to emit a tool call.
+        req = _basic_request(tools=self._tools(), tool_choice="required")
         self.assertFalse(is_recovery_eligible_request(req, "qwen3"))
 
-    def test_recover_no_op_for_tool_call_requests(self):
-        adapted = GenerateReqInput(input_ids=[1, 2], sampling_params={})
+    def test_tools_with_auto_choice_is_eligible(self):
+        # Tools offered but tool_choice="auto" → runtime judgement,
+        # gate passes at the request-eligibility stage.
+        req = _basic_request(tools=self._tools(), tool_choice="auto")
+        self.assertTrue(is_recovery_eligible_request(req, "qwen3"))
 
+    def _fake_handler(self, tool_call_parser=None):
         class _FakeTok:
             eos_token_id = 200
 
             def encode(self, *a, **kw):
                 return [99]
 
-        handler = SimpleNamespace(
+        return SimpleNamespace(
             tokenizer_manager=SimpleNamespace(
                 tokenizer=_FakeTok(),
                 server_args=SimpleNamespace(
@@ -326,8 +333,15 @@ class TestToolCallSkipsRecovery(CustomTestCase):
             ),
             template_manager=SimpleNamespace(force_reasoning=False),
             reasoning_parser="qwen3",
+            tool_call_parser=tool_call_parser,
             _get_reasoning_from_request=lambda r: None,
         )
+
+    def test_recovery_fires_when_tools_offered_but_no_tool_call_emitted(self):
+        # Tools offered, model stops with unclosed <think> and no tool-call
+        # sigil in the text → runtime check passes → recovery continues.
+        adapted = GenerateReqInput(input_ids=[1, 2], sampling_params={})
+        handler = self._fake_handler(tool_call_parser="qwen25")
 
         called = {"count": 0}
 
@@ -335,7 +349,7 @@ class TestToolCallSkipsRecovery(CustomTestCase):
             called["count"] += 1
 
             async def _g():
-                yield {"text": "x", "output_ids": [1], "meta_info": {}}
+                yield {"text": " answer", "output_ids": [50], "meta_info": {}}
 
             return _g()
 
@@ -351,27 +365,69 @@ class TestToolCallSkipsRecovery(CustomTestCase):
                 handler=handler,
                 adapted_request=adapted,
                 request=_basic_request(
-                    tools=[
-                        {
-                            "type": "function",
-                            "function": {
-                                "name": "f",
-                                "parameters": {
-                                    "type": "object",
-                                    "properties": {},
-                                },
-                            },
-                        }
-                    ]
+                    tools=self._tools(), tool_choice="auto"
                 ),
                 raw_request=None,
                 ret_list=ret,
                 generate_request_fn=gen,
             )
         )
-        # Skipped — original ret is returned unchanged and no follow-up issued.
-        self.assertEqual(called["count"], 0)
-        self.assertEqual(out[0]["text"], "<think>thinking")
+        # Recovery was attempted (follow-up generation was called at least once).
+        self.assertGreaterEqual(called["count"], 1)
+        self.assertIn("answer", out[0]["text"])
+
+    def test_recovery_skipped_when_tool_call_actually_emitted(self):
+        # Tools offered AND the generated text already contains a tool call
+        # (mocked via FunctionCallParser.has_tool_call returning True).
+        # Recovery must NOT trigger.
+        import sglang.srt.function_call.function_call_parser as _fcp_mod
+
+        class _FakeFCP:
+            def __init__(self, *a, **kw):
+                pass
+
+            def has_tool_call(self, text):
+                return True
+
+        orig = _fcp_mod.FunctionCallParser
+        _fcp_mod.FunctionCallParser = _FakeFCP
+        try:
+            adapted = GenerateReqInput(input_ids=[1, 2], sampling_params={})
+            handler = self._fake_handler(tool_call_parser="qwen25")
+
+            called = {"count": 0}
+
+            def gen(req, raw):
+                called["count"] += 1
+
+                async def _g():
+                    yield {"text": "x", "output_ids": [1], "meta_info": {}}
+
+                return _g()
+
+            ret = [
+                {
+                    "text": "<think>thinking",
+                    "output_ids": [1, 2],
+                    "meta_info": {"finish_reason": {"type": "stop"}},
+                }
+            ]
+            out = asyncio.new_event_loop().run_until_complete(
+                maybe_recover_non_streaming(
+                    handler=handler,
+                    adapted_request=adapted,
+                    request=_basic_request(
+                        tools=self._tools(), tool_choice="auto"
+                    ),
+                    raw_request=None,
+                    ret_list=ret,
+                    generate_request_fn=gen,
+                )
+            )
+            self.assertEqual(called["count"], 0)
+            self.assertEqual(out[0]["text"], "<think>thinking")
+        finally:
+            _fcp_mod.FunctionCallParser = orig
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/openai/test_recover_unclosed_reasoning_integration.py
+++ b/test/registered/unit/openai/test_recover_unclosed_reasoning_integration.py
@@ -1,0 +1,378 @@
+"""Integration-level tests for the unclosed-reasoning recovery feature.
+
+These tests stitch together the registry, the redirect logit processor, the
+parser dedupe, and the Fallback B orchestration without bringing up a real
+SGLang server.
+
+Focus areas:
+- Recursion protection (continuation request is never recovered again).
+- Multi-token think_end models: Path-1 is correctly disabled at startup but
+  Fallback B still works because it only needs `tokenizer.encode(...)`.
+- Path-1 + Fallback B coexist: redirect succeeded but model still produced
+  empty content → Fallback B kicks in.
+- Tool-call requests are skipped end-to-end.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=4, suite="stage-a-test-cpu")
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
+from sglang.srt.entrypoints.openai.recover_unclosed_reasoning import (
+    _RECOVERY_SENTINEL_KEY,
+    build_continuation_request,
+    is_recovery_eligible_request,
+    maybe_recover_non_streaming,
+)
+from sglang.srt.managers.io_struct import GenerateReqInput
+from sglang.srt.parser.reasoning_redirect_registry import build_redirect_config
+from sglang.test.test_utils import CustomTestCase
+
+
+def _basic_request(**overrides):
+    base = {
+        "model": "test",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    base.update(overrides)
+    return ChatCompletionRequest(**base)
+
+
+# ----- Recursion protection ---------------------------------------------
+
+
+class TestRecursionProtection(CustomTestCase):
+    def test_continuation_request_carries_sentinel(self):
+        adapted = GenerateReqInput(input_ids=[1, 2], sampling_params={})
+        ret = {
+            "output_ids": [10, 11],
+            "text": "<think>x",
+            "meta_info": {"finish_reason": {"type": "stop"}},
+        }
+        follow = build_continuation_request(
+            adapted_request=adapted, ret_item=ret, think_end_token_ids=[99]
+        )
+        self.assertIsNotNone(follow)
+        sp = follow.sampling_params
+        if isinstance(sp, list):
+            sp = sp[0]
+        self.assertTrue(sp["custom_params"][_RECOVERY_SENTINEL_KEY])
+
+    def test_recover_skipped_when_sentinel_present(self):
+        # Simulate a "continuation" request being passed back into recovery.
+        adapted = GenerateReqInput(
+            input_ids=[1, 2, 99],
+            sampling_params={
+                "custom_params": {_RECOVERY_SENTINEL_KEY: True},
+            },
+        )
+
+        class _FakeTok:
+            eos_token_id = 0
+
+            def encode(self, t, add_special_tokens=False):
+                return [99]
+
+        handler = SimpleNamespace(
+            tokenizer_manager=SimpleNamespace(
+                tokenizer=_FakeTok(),
+                server_args=SimpleNamespace(
+                    auto_recover_unclosed_reasoning=True,
+                ),
+                generate_request=lambda *a, **kw: (_ for _ in ()),
+            ),
+            template_manager=SimpleNamespace(force_reasoning=False),
+            reasoning_parser="qwen3",
+            _get_reasoning_from_request=lambda r: None,
+        )
+
+        called = {"count": 0}
+
+        def gen(req, raw):
+            called["count"] += 1
+
+            async def _g():
+                yield {
+                    "text": "x",
+                    "output_ids": [1],
+                    "meta_info": {"finish_reason": {"type": "stop"}},
+                }
+
+            return _g()
+
+        ret = [
+            {
+                "text": "<think>still empty",
+                "output_ids": [1, 2],
+                "meta_info": {"finish_reason": {"type": "stop"}},
+            }
+        ]
+        out = asyncio.new_event_loop().run_until_complete(
+            maybe_recover_non_streaming(
+                handler=handler,
+                adapted_request=adapted,
+                request=_basic_request(recover_unclosed_reasoning=True),
+                raw_request=None,
+                ret_list=ret,
+                generate_request_fn=gen,
+            )
+        )
+        # Sentinel present → recovery is a no-op, no follow-up issued.
+        self.assertEqual(called["count"], 0)
+        self.assertEqual(out[0]["text"], "<think>still empty")
+
+
+# ----- Multi-token think_end downgrade ----------------------------------
+
+
+class _FakeMultiTokenTokenizer:
+    """`</think>` encodes as MULTIPLE tokens (e.g. 2 ids). Single `<|im_end|>`."""
+
+    eos_token_id = 200
+
+    def encode(self, text, add_special_tokens=False):
+        if text == "</think>":
+            return [123, 124]  # multi-token!
+        if text == "<|im_end|>":
+            return [200]
+        if text == "<think>":
+            return [125, 126]
+        return [9999, 9998]
+
+
+class TestMultiTokenDowngrade(CustomTestCase):
+    def test_path1_registry_returns_none_for_multi_token(self):
+        cfg = build_redirect_config("qwen3", _FakeMultiTokenTokenizer())
+        self.assertIsNone(cfg)
+
+    def test_fallback_b_still_works_for_multi_token(self):
+        # Even when Path-1 is unavailable, Fallback B can still close the
+        # reasoning section because it only requires `encode(</think>)` to
+        # return a non-empty list.
+        adapted = GenerateReqInput(input_ids=[1, 2, 3], sampling_params={})
+
+        handler = SimpleNamespace(
+            tokenizer_manager=SimpleNamespace(
+                tokenizer=_FakeMultiTokenTokenizer(),
+                server_args=SimpleNamespace(
+                    auto_recover_unclosed_reasoning=True,
+                ),
+            ),
+            template_manager=SimpleNamespace(force_reasoning=False),
+            reasoning_parser="qwen3",
+            _get_reasoning_from_request=lambda r: None,
+        )
+
+        captured_follow = {}
+
+        def gen(req, raw):
+            captured_follow["req"] = req
+
+            async def _g():
+                yield {
+                    "text": "and the answer is 42",
+                    "output_ids": [50, 51, 52, 53, 54],
+                    "meta_info": {
+                        "finish_reason": {"type": "stop"},
+                        "completion_tokens": 5,
+                    },
+                }
+
+            return _g()
+
+        ret = [
+            {
+                "text": "<think>thinking only no closer",
+                "output_ids": [10, 11, 12],
+                "meta_info": {
+                    "finish_reason": {"type": "stop"},
+                    "completion_tokens": 3,
+                },
+            }
+        ]
+        out = asyncio.new_event_loop().run_until_complete(
+            maybe_recover_non_streaming(
+                handler=handler,
+                adapted_request=adapted,
+                request=_basic_request(),
+                raw_request=None,
+                ret_list=ret,
+                generate_request_fn=gen,
+            )
+        )
+        merged = out[0]
+        self.assertIn("</think>", merged["text"])
+        self.assertIn("and the answer is 42", merged["text"])
+        # Continuation input_ids carry the BOTH think_end token ids.
+        follow_req = captured_follow["req"]
+        self.assertEqual(follow_req.input_ids, [1, 2, 3, 10, 11, 12, 123, 124])
+        # output_ids merged: original + think_end_ids + follow
+        self.assertEqual(
+            merged["output_ids"], [10, 11, 12, 123, 124, 50, 51, 52, 53, 54]
+        )
+
+
+# ----- Path-1 + Fallback B coexistence ----------------------------------
+
+
+class TestPath1AndFallbackBCoexist(CustomTestCase):
+    """Scene B in the design doc: redirect successfully wrote `</think>` into
+    output_ids but the model immediately produced an EOS token. The parsed
+    reasoning is non-empty and content is empty/whitespace, so Fallback B must
+    still trigger to actually generate the answer."""
+
+    def test_redirect_produced_think_end_then_eos_still_recovered(self):
+        adapted = GenerateReqInput(input_ids=[1, 2], sampling_params={})
+
+        class _FakeTok:
+            eos_token_id = 200
+
+            def encode(self, text, add_special_tokens=False):
+                if text == "</think>":
+                    return [99]
+                return [9999]
+
+        handler = SimpleNamespace(
+            tokenizer_manager=SimpleNamespace(
+                tokenizer=_FakeTok(),
+                server_args=SimpleNamespace(
+                    auto_recover_unclosed_reasoning=True,
+                ),
+            ),
+            template_manager=SimpleNamespace(force_reasoning=False),
+            reasoning_parser="qwen3",
+            _get_reasoning_from_request=lambda r: None,
+        )
+
+        def gen(req, raw):
+            async def _g():
+                yield {
+                    "text": "the actual content",
+                    "output_ids": [50, 51],
+                    "meta_info": {
+                        "finish_reason": {"type": "stop"},
+                        "completion_tokens": 2,
+                    },
+                }
+
+            return _g()
+
+        # Path-1 succeeded: text already contains `</think>` but content after
+        # it is empty (model emitted EOS right after the redirected think_end).
+        ret = [
+            {
+                "text": "<think>thinking</think>",
+                "output_ids": [10, 11, 99],
+                "meta_info": {
+                    "finish_reason": {"type": "stop"},
+                    "completion_tokens": 3,
+                },
+            }
+        ]
+        out = asyncio.new_event_loop().run_until_complete(
+            maybe_recover_non_streaming(
+                handler=handler,
+                adapted_request=adapted,
+                request=_basic_request(),
+                raw_request=None,
+                ret_list=ret,
+                generate_request_fn=gen,
+            )
+        )
+        merged = out[0]
+        # Note we still bridge a `</think>` between the two — the parser
+        # dedupe (Stage 2) will swallow the leading duplicate when the client
+        # parses the final text.
+        self.assertIn("the actual content", merged["text"])
+
+
+# ----- Tool-call requests are skipped end-to-end ------------------------
+
+
+class TestToolCallSkipsRecovery(CustomTestCase):
+    def test_eligibility_excludes_tool_requests(self):
+        req = _basic_request(
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "f",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ]
+        )
+        self.assertFalse(is_recovery_eligible_request(req, "qwen3"))
+
+    def test_recover_no_op_for_tool_call_requests(self):
+        adapted = GenerateReqInput(input_ids=[1, 2], sampling_params={})
+
+        class _FakeTok:
+            eos_token_id = 200
+
+            def encode(self, *a, **kw):
+                return [99]
+
+        handler = SimpleNamespace(
+            tokenizer_manager=SimpleNamespace(
+                tokenizer=_FakeTok(),
+                server_args=SimpleNamespace(
+                    auto_recover_unclosed_reasoning=True,
+                ),
+            ),
+            template_manager=SimpleNamespace(force_reasoning=False),
+            reasoning_parser="qwen3",
+            _get_reasoning_from_request=lambda r: None,
+        )
+
+        called = {"count": 0}
+
+        def gen(req, raw):
+            called["count"] += 1
+
+            async def _g():
+                yield {"text": "x", "output_ids": [1], "meta_info": {}}
+
+            return _g()
+
+        ret = [
+            {
+                "text": "<think>thinking",
+                "output_ids": [1, 2],
+                "meta_info": {"finish_reason": {"type": "stop"}},
+            }
+        ]
+        out = asyncio.new_event_loop().run_until_complete(
+            maybe_recover_non_streaming(
+                handler=handler,
+                adapted_request=adapted,
+                request=_basic_request(
+                    tools=[
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "f",
+                                "parameters": {
+                                    "type": "object",
+                                    "properties": {},
+                                },
+                            },
+                        }
+                    ]
+                ),
+                raw_request=None,
+                ret_list=ret,
+                generate_request_fn=gen,
+            )
+        )
+        # Skipped — original ret is returned unchanged and no follow-up issued.
+        self.assertEqual(called["count"], 0)
+        self.assertEqual(out[0]["text"], "<think>thinking")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/openai/test_recover_unclosed_reasoning_nonstream.py
+++ b/test/registered/unit/openai/test_recover_unclosed_reasoning_nonstream.py
@@ -78,7 +78,10 @@ class TestIsRecoveryEligibleRequest(CustomTestCase):
         req = _basic_request(n=3)
         self.assertFalse(is_recovery_eligible_request(req, "qwen3"))
 
-    def test_tools_not_eligible(self):
+    def test_tools_with_tool_choice_required_not_eligible(self):
+        # Only tool_choice="required" is hard-excluded: the model is
+        # contractually obliged to emit a tool call, so empty content is
+        # expected.
         req = _basic_request(
             tools=[
                 {
@@ -89,8 +92,26 @@ class TestIsRecoveryEligibleRequest(CustomTestCase):
                     },
                 }
             ],
+            tool_choice="required",
         )
         self.assertFalse(is_recovery_eligible_request(req, "qwen3"))
+
+    def test_tools_with_auto_tool_choice_is_eligible(self):
+        # Tools offered but tool_choice="auto" → we must defer to runtime
+        # inspection of the actual generated text.
+        req = _basic_request(
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "f",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+            tool_choice="auto",
+        )
+        self.assertTrue(is_recovery_eligible_request(req, "qwen3"))
 
     def test_continue_final_message_not_eligible(self):
         req = _basic_request(continue_final_message=True)
@@ -128,6 +149,66 @@ class TestShouldRecoverRetItem(CustomTestCase):
         # Pure normal output, no <think> at all → reasoning_text empty.
         item = self._ret(text="hello world")
         self.assertFalse(should_recover_ret_item(item, _qwen3_parser()))
+
+    def test_tools_offered_but_no_tool_call_emitted_triggers(self):
+        # Request declared tools (tool_choice="auto"), but the model produced
+        # only an unclosed <think> block and NOT a tool call. Recovery must
+        # trigger based on the generation result, not the request declaration.
+        item = self._ret(text="<think>partial reasoning")
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        self.assertTrue(
+            should_recover_ret_item(
+                item,
+                _qwen3_parser(),
+                tool_call_parser="qwen25",
+                tools=tools,
+            )
+        )
+
+    def test_tools_offered_and_tool_call_emitted_skips(self):
+        # Request declared tools AND the model actually produced a tool-call
+        # sigil. Recovery must NOT trigger — the "empty content" is intentional.
+        # We mock FunctionCallParser.has_tool_call to return True.
+        import sglang.srt.function_call.function_call_parser as _fcp_mod
+
+        class _FakeFCP:
+            def __init__(self, *a, **kw):
+                pass
+
+            def has_tool_call(self, text):
+                return True
+
+        orig = _fcp_mod.FunctionCallParser
+        _fcp_mod.FunctionCallParser = _FakeFCP
+        try:
+            item = self._ret(text="<think>partial reasoning")
+            tools = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ]
+            self.assertFalse(
+                should_recover_ret_item(
+                    item,
+                    _qwen3_parser(),
+                    tool_call_parser="qwen25",
+                    tools=tools,
+                )
+            )
+        finally:
+            _fcp_mod.FunctionCallParser = orig
 
 
 # ----- request building --------------------------------------------------
@@ -211,7 +292,15 @@ class TestBuildContinuationRequest(CustomTestCase):
         sp = follow.sampling_params
         if isinstance(sp, list):
             sp = sp[0]
-        self.assertEqual(sp["custom_params"], {"user_field": "keep_me"})
+        # The redirect-owned keys are stripped, user keys are preserved, and
+        # a recovery sentinel is injected for anti-recursion.
+        self.assertEqual(sp["custom_params"]["user_field"], "keep_me")
+        self.assertTrue(
+            sp["custom_params"].get("_recover_unclosed_reasoning_attempted")
+        )
+        self.assertNotIn("think_end_token_id", sp["custom_params"])
+        self.assertNotIn("redirect_eos_token_ids", sp["custom_params"])
+
 
     def test_text_mode_returns_none(self):
         adapted = GenerateReqInput(
@@ -274,6 +363,48 @@ class TestMergeContinuationIntoRet(CustomTestCase):
         # completion_tokens accumulate
         self.assertEqual(merged["meta_info"]["completion_tokens"], 5)
         self.assertEqual(merged["meta_info"]["cached_tokens"], 1)
+
+    def test_prompt_tokens_uses_max_not_sum(self):
+        # The follow-up's prefill covers (original_prompt + first_output_ids
+        # + think_end_bridge), so summing prompt_tokens would double-count the
+        # original prompt. merge_continuation_into_ret must take max().
+        original = {
+            "text": "<think>t",
+            "output_ids": [1],
+            "meta_info": {"prompt_tokens": 10, "completion_tokens": 1},
+        }
+        follow = {
+            "text": "ans",
+            "output_ids": [2],
+            "meta_info": {"prompt_tokens": 13, "completion_tokens": 1},
+        }
+        merged = merge_continuation_into_ret(
+            original_ret_item=original,
+            follow_ret_item=follow,
+            think_end_str="</think>",
+            think_end_token_ids=[99],
+        )
+        self.assertEqual(merged["meta_info"]["prompt_tokens"], 13)
+        self.assertEqual(merged["meta_info"]["completion_tokens"], 2)
+
+    def test_prompt_tokens_filled_when_only_followup_has_it(self):
+        original = {
+            "text": "<think>t",
+            "output_ids": [1],
+            "meta_info": {"completion_tokens": 1},
+        }
+        follow = {
+            "text": "ans",
+            "output_ids": [2],
+            "meta_info": {"prompt_tokens": 13, "completion_tokens": 1},
+        }
+        merged = merge_continuation_into_ret(
+            original_ret_item=original,
+            follow_ret_item=follow,
+            think_end_str="</think>",
+            think_end_token_ids=[99],
+        )
+        self.assertEqual(merged["meta_info"]["prompt_tokens"], 13)
 
     def test_does_not_mutate_inputs(self):
         original = {

--- a/test/registered/unit/openai/test_recover_unclosed_reasoning_nonstream.py
+++ b/test/registered/unit/openai/test_recover_unclosed_reasoning_nonstream.py
@@ -1,0 +1,477 @@
+"""Unit tests for the non-streaming Fallback B (post-inference unclosed
+reasoning recovery) helpers and async orchestration.
+
+We mock the tokenizer and tokenizer_manager.generate_request so no real
+server / model is involved.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=4, suite="stage-a-test-cpu")
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
+from sglang.srt.entrypoints.openai.recover_unclosed_reasoning import (
+    _strip_redirect_owned_keys,
+    build_continuation_request,
+    is_recovery_eligible_request,
+    is_recovery_enabled,
+    maybe_recover_non_streaming,
+    merge_continuation_into_ret,
+    should_recover_ret_item,
+)
+from sglang.srt.managers.io_struct import GenerateReqInput
+from sglang.srt.parser.reasoning_parser import ReasoningParser
+from sglang.test.test_utils import CustomTestCase
+
+
+def _basic_request(**overrides):
+    base = {
+        "model": "test",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    base.update(overrides)
+    return ChatCompletionRequest(**base)
+
+
+def _qwen3_parser(force=False):
+    return ReasoningParser(
+        model_type="qwen3", stream_reasoning=False, force_reasoning=force
+    )
+
+
+# ----- pure decision helpers --------------------------------------------
+
+
+class TestIsRecoveryEnabled(CustomTestCase):
+    def test_default_off(self):
+        self.assertFalse(is_recovery_enabled(_basic_request(), False))
+
+    def test_default_on(self):
+        self.assertTrue(is_recovery_enabled(_basic_request(), True))
+
+    def test_per_request_true_overrides_off(self):
+        req = _basic_request(recover_unclosed_reasoning=True)
+        self.assertTrue(is_recovery_enabled(req, False))
+
+    def test_per_request_false_overrides_on(self):
+        req = _basic_request(recover_unclosed_reasoning=False)
+        self.assertFalse(is_recovery_enabled(req, True))
+
+
+class TestIsRecoveryEligibleRequest(CustomTestCase):
+    def test_basic_qwen3_eligible(self):
+        self.assertTrue(is_recovery_eligible_request(_basic_request(), "qwen3"))
+
+    def test_no_parser_not_eligible(self):
+        self.assertFalse(is_recovery_eligible_request(_basic_request(), None))
+        self.assertFalse(is_recovery_eligible_request(_basic_request(), ""))
+
+    def test_separate_reasoning_off(self):
+        req = _basic_request(separate_reasoning=False)
+        self.assertFalse(is_recovery_eligible_request(req, "qwen3"))
+
+    def test_n_gt_1_not_eligible(self):
+        req = _basic_request(n=3)
+        self.assertFalse(is_recovery_eligible_request(req, "qwen3"))
+
+    def test_tools_not_eligible(self):
+        req = _basic_request(
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "f",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+        )
+        self.assertFalse(is_recovery_eligible_request(req, "qwen3"))
+
+    def test_continue_final_message_not_eligible(self):
+        req = _basic_request(continue_final_message=True)
+        self.assertFalse(is_recovery_eligible_request(req, "qwen3"))
+
+
+class TestShouldRecoverRetItem(CustomTestCase):
+    def _ret(self, *, text, finish_type="stop"):
+        return {
+            "text": text,
+            "output_ids": [1, 2, 3],
+            "meta_info": {"finish_reason": {"type": finish_type}},
+        }
+
+    def test_unclosed_reasoning_triggers(self):
+        # `<think>x</think>` would be properly closed; here we have no
+        # closing tag so reasoning is non-empty and normal_text is empty.
+        item = self._ret(text="<think>partial reasoning")
+        self.assertTrue(should_recover_ret_item(item, _qwen3_parser()))
+
+    def test_closed_reasoning_with_content_does_not_trigger(self):
+        item = self._ret(text="<think>r</think>real answer")
+        self.assertFalse(should_recover_ret_item(item, _qwen3_parser()))
+
+    def test_closed_reasoning_with_only_whitespace_triggers(self):
+        # Aggressive Scene B: redirect succeeded but content is empty/blank.
+        item = self._ret(text="<think>r</think>   \n  ")
+        self.assertTrue(should_recover_ret_item(item, _qwen3_parser()))
+
+    def test_finish_length_does_not_trigger(self):
+        item = self._ret(text="<think>partial reasoning", finish_type="length")
+        self.assertFalse(should_recover_ret_item(item, _qwen3_parser()))
+
+    def test_no_reasoning_does_not_trigger(self):
+        # Pure normal output, no <think> at all → reasoning_text empty.
+        item = self._ret(text="hello world")
+        self.assertFalse(should_recover_ret_item(item, _qwen3_parser()))
+
+
+# ----- request building --------------------------------------------------
+
+
+class TestStripRedirectOwnedKeys(CustomTestCase):
+    def test_drops_only_redirect_keys(self):
+        cp = {
+            "think_end_token_id": 7,
+            "think_start_token_id": 8,
+            "redirect_eos_token_ids": [5],
+            "force_reasoning": True,
+            "prob_threshold": 0.5,
+            "user_field": "keep_me",
+        }
+        out = _strip_redirect_owned_keys(cp)
+        self.assertEqual(out, {"user_field": "keep_me"})
+
+    def test_returns_none_when_only_redirect_keys(self):
+        cp = {
+            "think_end_token_id": 7,
+            "redirect_eos_token_ids": [5],
+        }
+        self.assertIsNone(_strip_redirect_owned_keys(cp))
+
+    def test_returns_none_for_none_or_non_dict(self):
+        self.assertIsNone(_strip_redirect_owned_keys(None))
+        self.assertIsNone(_strip_redirect_owned_keys("not-a-dict"))
+
+
+class TestBuildContinuationRequest(CustomTestCase):
+    def _adapted(self, **overrides):
+        kwargs = dict(
+            input_ids=[10, 11, 12],
+            sampling_params={"temperature": 0.7, "custom_params": None},
+            stream=False,
+        )
+        kwargs.update(overrides)
+        return GenerateReqInput(**kwargs)
+
+    def _ret(self, output_ids):
+        return {
+            "output_ids": list(output_ids),
+            "text": "doesn't matter",
+            "meta_info": {"finish_reason": {"type": "stop"}},
+        }
+
+    def test_input_ids_concatenation(self):
+        adapted = self._adapted()
+        ret = self._ret([20, 21])
+        follow = build_continuation_request(
+            adapted_request=adapted,
+            ret_item=ret,
+            think_end_token_ids=[99],
+        )
+        self.assertIsNotNone(follow)
+        self.assertEqual(follow.input_ids, [10, 11, 12, 20, 21, 99])
+        self.assertFalse(follow.stream)
+        self.assertFalse(follow.return_logprob)
+        # Crucially: no custom logit processor on the continuation.
+        self.assertIsNone(follow.custom_logit_processor)
+
+    def test_strips_our_redirect_custom_params(self):
+        adapted = self._adapted(
+            sampling_params={
+                "temperature": 0.7,
+                "custom_params": {
+                    "think_end_token_id": 99,
+                    "redirect_eos_token_ids": [5],
+                    "user_field": "keep_me",
+                },
+            }
+        )
+        ret = self._ret([20])
+        follow = build_continuation_request(
+            adapted_request=adapted, ret_item=ret, think_end_token_ids=[99]
+        )
+        self.assertIsNotNone(follow)
+        # follow.sampling_params is normalized into a list of len-1 by
+        # GenerateReqInput.normalize_batch_and_arguments(), so peek into it.
+        sp = follow.sampling_params
+        if isinstance(sp, list):
+            sp = sp[0]
+        self.assertEqual(sp["custom_params"], {"user_field": "keep_me"})
+
+    def test_text_mode_returns_none(self):
+        adapted = GenerateReqInput(
+            text="hello",
+            sampling_params={"temperature": 0.7},
+        )
+        ret = self._ret([20])
+        follow = build_continuation_request(
+            adapted_request=adapted, ret_item=ret, think_end_token_ids=[99]
+        )
+        self.assertIsNone(follow)
+
+    def test_batched_input_returns_none(self):
+        adapted = GenerateReqInput(
+            input_ids=[[10, 11], [12, 13]],
+            sampling_params=[
+                {"temperature": 0.7},
+                {"temperature": 0.7},
+            ],
+        )
+        ret = self._ret([20])
+        follow = build_continuation_request(
+            adapted_request=adapted, ret_item=ret, think_end_token_ids=[99]
+        )
+        self.assertIsNone(follow)
+
+
+# ----- merge -------------------------------------------------------------
+
+
+class TestMergeContinuationIntoRet(CustomTestCase):
+    def test_text_and_output_ids_concatenation(self):
+        original = {
+            "text": "<think>partial",
+            "output_ids": [1, 2],
+            "meta_info": {
+                "finish_reason": {"type": "stop"},
+                "completion_tokens": 2,
+                "cached_tokens": 0,
+            },
+        }
+        follow = {
+            "text": " continuation",
+            "output_ids": [50, 51, 52],
+            "meta_info": {
+                "finish_reason": {"type": "length"},
+                "completion_tokens": 3,
+                "cached_tokens": 1,
+            },
+        }
+        merged = merge_continuation_into_ret(
+            original_ret_item=original,
+            follow_ret_item=follow,
+            think_end_str="</think>",
+            think_end_token_ids=[99],
+        )
+        self.assertEqual(merged["text"], "<think>partial</think> continuation")
+        self.assertEqual(merged["output_ids"], [1, 2, 99, 50, 51, 52])
+        self.assertEqual(merged["meta_info"]["finish_reason"], {"type": "length"})
+        # completion_tokens accumulate
+        self.assertEqual(merged["meta_info"]["completion_tokens"], 5)
+        self.assertEqual(merged["meta_info"]["cached_tokens"], 1)
+
+    def test_does_not_mutate_inputs(self):
+        original = {
+            "text": "x",
+            "output_ids": [1],
+            "meta_info": {"finish_reason": {"type": "stop"}},
+        }
+        follow = {
+            "text": "y",
+            "output_ids": [2],
+            "meta_info": {"finish_reason": {"type": "length"}},
+        }
+        merge_continuation_into_ret(
+            original_ret_item=original,
+            follow_ret_item=follow,
+            think_end_str="|",
+            think_end_token_ids=[9],
+        )
+        self.assertEqual(original["text"], "x")
+        self.assertEqual(original["output_ids"], [1])
+        self.assertEqual(
+            original["meta_info"]["finish_reason"], {"type": "stop"}
+        )
+
+
+# ----- async orchestration ----------------------------------------------
+
+
+class _FakeTokenizer:
+    def __init__(self, mapping):
+        self.mapping = mapping
+
+    def encode(self, text, add_special_tokens=False):
+        if text in self.mapping:
+            return list(self.mapping[text])
+        return [9999, 9998]  # default multi-token
+
+
+class _FakeTemplateManager:
+    force_reasoning = False
+
+
+class _FakeTokenizerManager:
+    def __init__(self, tokenizer, server_args, follow_up_ret):
+        self.tokenizer = tokenizer
+        self.server_args = server_args
+        self._follow_up_ret = follow_up_ret
+        self.captured_follow_req = None
+
+    def generate_request(self, follow_req, raw_request):
+        self.captured_follow_req = follow_req
+        ret_value = self._follow_up_ret
+
+        async def _gen():
+            yield ret_value
+
+        return _gen()
+
+
+def _fake_handler(*, server_default, follow_up_ret, parser_name="qwen3"):
+    handler = SimpleNamespace()
+    handler.tokenizer_manager = _FakeTokenizerManager(
+        tokenizer=_FakeTokenizer({"</think>": [99]}),
+        server_args=SimpleNamespace(
+            auto_recover_unclosed_reasoning=server_default,
+        ),
+        follow_up_ret=follow_up_ret,
+    )
+    handler.template_manager = _FakeTemplateManager()
+    handler.reasoning_parser = parser_name
+    handler._get_reasoning_from_request = lambda req: None
+    return handler
+
+
+def _ret_unclosed():
+    return {
+        "text": "<think>thinking only",
+        "output_ids": [1, 2, 3],
+        "meta_info": {"finish_reason": {"type": "stop"}, "completion_tokens": 3},
+    }
+
+
+def _ret_normal():
+    return {
+        "text": "<think>r</think>real answer",
+        "output_ids": [1, 2, 3, 99, 4, 5],
+        "meta_info": {"finish_reason": {"type": "stop"}, "completion_tokens": 6},
+    }
+
+
+class TestMaybeRecoverNonStreaming(CustomTestCase):
+    def _run(self, coro):
+        return asyncio.new_event_loop().run_until_complete(coro)
+
+    def test_no_op_when_disabled(self):
+        handler = _fake_handler(server_default=False, follow_up_ret={"text": "X"})
+        adapted = GenerateReqInput(input_ids=[10, 11], sampling_params={})
+        original = [_ret_unclosed()]
+        out = self._run(
+            maybe_recover_non_streaming(
+                handler=handler,
+                adapted_request=adapted,
+                request=_basic_request(),
+                raw_request=None,
+                ret_list=original,
+            )
+        )
+        # Disabled → returned as-is, no follow-up issued.
+        self.assertIs(out, original)
+        self.assertIsNone(handler.tokenizer_manager.captured_follow_req)
+
+    def test_per_request_override_enables_recovery(self):
+        follow = {
+            "text": " here is the answer",
+            "output_ids": [200, 201],
+            "meta_info": {"finish_reason": {"type": "stop"}, "completion_tokens": 2},
+        }
+        handler = _fake_handler(server_default=False, follow_up_ret=follow)
+        adapted = GenerateReqInput(input_ids=[10, 11], sampling_params={})
+        out = self._run(
+            maybe_recover_non_streaming(
+                handler=handler,
+                adapted_request=adapted,
+                request=_basic_request(recover_unclosed_reasoning=True),
+                raw_request=None,
+                ret_list=[_ret_unclosed()],
+            )
+        )
+        self.assertEqual(len(out), 1)
+        merged = out[0]
+        # original text is "<think>thinking only", bridge "</think>", then follow text
+        self.assertIn("</think>", merged["text"])
+        self.assertIn("here is the answer", merged["text"])
+        # completion_tokens accumulate (3 + 2 = 5)
+        self.assertEqual(merged["meta_info"]["completion_tokens"], 5)
+        # follow-up was issued, with input_ids carrying think_end token
+        follow_req = handler.tokenizer_manager.captured_follow_req
+        self.assertIsNotNone(follow_req)
+        self.assertEqual(follow_req.input_ids, [10, 11, 1, 2, 3, 99])
+        # And the continuation must NOT carry our redirect processor.
+        self.assertIsNone(follow_req.custom_logit_processor)
+
+    def test_skips_when_finish_is_length(self):
+        handler = _fake_handler(server_default=True, follow_up_ret={"text": "X"})
+        adapted = GenerateReqInput(input_ids=[10, 11], sampling_params={})
+        original = [
+            {
+                "text": "<think>partial",
+                "output_ids": [1, 2, 3],
+                "meta_info": {
+                    "finish_reason": {"type": "length"},
+                    "completion_tokens": 3,
+                },
+            }
+        ]
+        out = self._run(
+            maybe_recover_non_streaming(
+                handler=handler,
+                adapted_request=adapted,
+                request=_basic_request(),
+                raw_request=None,
+                ret_list=original,
+            )
+        )
+        self.assertEqual(out[0]["text"], "<think>partial")
+        self.assertIsNone(handler.tokenizer_manager.captured_follow_req)
+
+    def test_skips_when_already_has_content(self):
+        handler = _fake_handler(server_default=True, follow_up_ret={"text": "X"})
+        adapted = GenerateReqInput(input_ids=[10, 11], sampling_params={})
+        out = self._run(
+            maybe_recover_non_streaming(
+                handler=handler,
+                adapted_request=adapted,
+                request=_basic_request(),
+                raw_request=None,
+                ret_list=[_ret_normal()],
+            )
+        )
+        self.assertEqual(out[0]["text"], "<think>r</think>real answer")
+        self.assertIsNone(handler.tokenizer_manager.captured_follow_req)
+
+    def test_text_mode_request_is_not_recovered(self):
+        handler = _fake_handler(server_default=True, follow_up_ret={"text": "X"})
+        adapted = GenerateReqInput(text="prompt text", sampling_params={})
+        out = self._run(
+            maybe_recover_non_streaming(
+                handler=handler,
+                adapted_request=adapted,
+                request=_basic_request(),
+                raw_request=None,
+                ret_list=[_ret_unclosed()],
+            )
+        )
+        # No input_ids → recovery cannot construct a follow-up.
+        self.assertEqual(out[0]["text"], "<think>thinking only")
+        self.assertIsNone(handler.tokenizer_manager.captured_follow_req)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/openai/test_recover_unclosed_reasoning_stream.py
+++ b/test/registered/unit/openai/test_recover_unclosed_reasoning_stream.py
@@ -74,6 +74,22 @@ class TestStreamStateHelpers(CustomTestCase):
         self.assertEqual(s["finish_reason"], {"type": "stop"})
         self.assertEqual(s["last_output_ids"], [1, 2, 3])
 
+    def test_update_meta_non_incremental_overwrites(self):
+        # Default (cumulative) mode: each chunk snapshots the full list so far.
+        s = new_stream_recovery_state()
+        update_stream_state_meta(s, {}, output_ids=[1, 2])
+        update_stream_state_meta(s, {}, output_ids=[1, 2, 3, 4, 5])
+        self.assertEqual(s["last_output_ids"], [1, 2, 3, 4, 5])
+
+    def test_update_meta_incremental_extends(self):
+        # Incremental mode (server flag incremental_streaming_output=True):
+        # each chunk carries only the delta and must be concatenated.
+        s = new_stream_recovery_state()
+        update_stream_state_meta(s, {}, output_ids=[1, 2], incremental=True)
+        update_stream_state_meta(s, {}, output_ids=[3], incremental=True)
+        update_stream_state_meta(s, {}, output_ids=[4, 5], incremental=True)
+        self.assertEqual(s["last_output_ids"], [1, 2, 3, 4, 5])
+
 
 class TestShouldRecoverStreamState(CustomTestCase):
     def _state(self, **overrides):
@@ -310,11 +326,14 @@ class TestStreamRecoveryChunks(CustomTestCase):
         self.assertEqual(len(chunks), 1)
         final = _parse_sse_line(chunks[0])
         self.assertEqual(final["choices"][0]["finish_reason"], "stop")
-        self.assertNotIn("content", final["choices"][0]["delta"] or {})
+        # Final finish chunk may include a `content` key but it must be empty/None.
+        self.assertFalse((final["choices"][0]["delta"] or {}).get("content"))
 
-    def test_yields_nothing_when_followup_request_cannot_be_built(self):
-        # text-mode adapted_request → build_continuation_request returns None
-        # → the helper yields nothing.
+    def test_yields_fallback_finish_when_followup_request_cannot_be_built(self):
+        # text-mode adapted_request → build_continuation_request returns None.
+        # Even on this early-return path, the helper MUST still yield a final
+        # finish_reason chunk so the caller's ``continue`` does not swallow
+        # the SSE stream's content-termination marker.
         handler = _make_handler()
         agen = stream_recovery_chunks(
             handler=handler,
@@ -331,7 +350,90 @@ class TestStreamRecoveryChunks(CustomTestCase):
             generate_request_fn=lambda *a, **kw: (_ for _ in ()),
         )
         chunks = self._run(agen)
-        self.assertEqual(chunks, [])
+        self.assertEqual(len(chunks), 1)
+        final = _parse_sse_line(chunks[0])
+        self.assertEqual(final["choices"][0]["finish_reason"], "stop")
+
+    def test_yields_fallback_finish_when_tokenizer_encode_returns_empty(self):
+        # Tokenizer returns empty list for </think> → early-return must still
+        # yield a finish chunk.
+        handler = _make_handler()
+
+        class _EmptyEncodeTok:
+            def encode(self, text, add_special_tokens=False):
+                return []
+
+        handler.tokenizer_manager.tokenizer = _EmptyEncodeTok()
+
+        agen = stream_recovery_chunks(
+            handler=handler,
+            request=_basic_request(recover_unclosed_reasoning=True),
+            raw_request=None,
+            adapted_request=self._adapted(),
+            state=self._state(),
+            request_id="x",
+            request_model="m",
+            continuous_usage_stats=False,
+            prompt_tokens=0,
+            reasoning_tokens_acc=0,
+            completion_tokens_acc=0,
+            generate_request_fn=lambda *a, **kw: (_ for _ in ()),
+        )
+        chunks = self._run(agen)
+        self.assertEqual(len(chunks), 1)
+        final = _parse_sse_line(chunks[0])
+        self.assertEqual(final["choices"][0]["finish_reason"], "stop")
+
+    def test_on_meta_update_called_with_final_followup_meta(self):
+        # The callback must be invoked exactly once, with the LAST meta seen
+        # in the continuation stream (usage fields from the follow-up are
+        # cumulative, so only the final snapshot matters for accounting).
+        handler = _make_handler()
+
+        def fake_generate(follow_req, raw):
+            async def _gen():
+                yield {
+                    "text": "ans",
+                    "meta_info": {"completion_tokens": 1, "prompt_tokens": 20},
+                }
+                yield {
+                    "text": "answer",
+                    "meta_info": {
+                        "completion_tokens": 7,
+                        "cached_tokens": 4,
+                        "prompt_tokens": 20,
+                        "finish_reason": {"type": "stop"},
+                    },
+                }
+
+            return _gen()
+
+        captured = []
+
+        def on_meta(meta):
+            captured.append(dict(meta))
+
+        agen = stream_recovery_chunks(
+            handler=handler,
+            request=_basic_request(recover_unclosed_reasoning=True),
+            raw_request=None,
+            adapted_request=self._adapted(),
+            state=self._state(),
+            request_id="chatcmpl-test",
+            request_model="m",
+            continuous_usage_stats=False,
+            prompt_tokens=10,
+            reasoning_tokens_acc=3,
+            completion_tokens_acc=3,
+            generate_request_fn=fake_generate,
+            on_meta_update=on_meta,
+        )
+        _ = self._run(agen)
+        self.assertEqual(len(captured), 1)
+        final_meta = captured[0]
+        self.assertEqual(final_meta["completion_tokens"], 7)
+        self.assertEqual(final_meta["cached_tokens"], 4)
+        self.assertEqual(final_meta["prompt_tokens"], 20)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/openai/test_recover_unclosed_reasoning_stream.py
+++ b/test/registered/unit/openai/test_recover_unclosed_reasoning_stream.py
@@ -140,6 +140,25 @@ class TestShouldRecoverStreamState(CustomTestCase):
         s = self._state(finish_reason={"type": "stop"})
         self.assertFalse(should_recover_stream_state(s))
 
+    def test_no_trigger_when_tool_branch_yielded_content(self):
+        # Regression for: tools offered with tool_choice="auto", reasoning
+        # produced, then the model produced real content (no tool call). The
+        # content delta is yielded via _process_tool_call_stream, and the
+        # caller MUST feed it back into state["content_text"] via
+        # update_stream_state_with_content — otherwise Fallback B would
+        # spuriously trigger a follow-up generation and the client would see
+        # a double-response. This test encodes the contract that updating
+        # content_text from the tool branch is sufficient to suppress
+        # recovery.
+        s = self._state(
+            reasoning_text="thinking about it",
+            finish_reason={"type": "stop"},
+        )
+        update_stream_state_with_content(s, "real answer part 1 ")
+        update_stream_state_with_content(s, "part 2")
+        self.assertEqual(s["content_text"], "real answer part 1 part 2")
+        self.assertFalse(should_recover_stream_state(s))
+
 
 class TestIsStreamRecoveryEnabledForRequest(CustomTestCase):
     def _handler(self, server_default, parser_name="qwen3"):

--- a/test/registered/unit/openai/test_recover_unclosed_reasoning_stream.py
+++ b/test/registered/unit/openai/test_recover_unclosed_reasoning_stream.py
@@ -1,0 +1,338 @@
+"""Unit tests for the streaming Fallback B helpers and async orchestration.
+
+Mocks tokenizer + tokenizer_manager.generate_request.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=4, suite="stage-a-test-cpu")
+
+import asyncio
+import json
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
+from sglang.srt.entrypoints.openai.recover_unclosed_reasoning import (
+    is_stream_recovery_enabled_for_request,
+    mark_stream_state_tool_call,
+    new_stream_recovery_state,
+    should_recover_stream_state,
+    stream_recovery_chunks,
+    update_stream_state_meta,
+    update_stream_state_with_content,
+    update_stream_state_with_reasoning,
+)
+from sglang.srt.managers.io_struct import GenerateReqInput
+from sglang.test.test_utils import CustomTestCase
+
+
+def _basic_request(**overrides):
+    base = {
+        "model": "test",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    base.update(overrides)
+    return ChatCompletionRequest(**base)
+
+
+class TestStreamStateHelpers(CustomTestCase):
+    def test_initial_state(self):
+        s = new_stream_recovery_state()
+        self.assertEqual(s["reasoning_text"], "")
+        self.assertEqual(s["content_text"], "")
+        self.assertFalse(s["has_tool_calls"])
+        self.assertIsNone(s["finish_reason"])
+        self.assertEqual(s["last_output_ids"], [])
+
+    def test_update_reasoning_concatenates(self):
+        s = new_stream_recovery_state()
+        update_stream_state_with_reasoning(s, "abc")
+        update_stream_state_with_reasoning(s, "def")
+        update_stream_state_with_reasoning(s, "")
+        update_stream_state_with_reasoning(s, None)
+        self.assertEqual(s["reasoning_text"], "abcdef")
+
+    def test_update_content_concatenates(self):
+        s = new_stream_recovery_state()
+        update_stream_state_with_content(s, "x")
+        update_stream_state_with_content(s, "y")
+        self.assertEqual(s["content_text"], "xy")
+
+    def test_mark_tool_call_flag(self):
+        s = new_stream_recovery_state()
+        mark_stream_state_tool_call(s)
+        self.assertTrue(s["has_tool_calls"])
+
+    def test_update_meta_updates_finish_and_output_ids(self):
+        s = new_stream_recovery_state()
+        update_stream_state_meta(
+            s,
+            {"finish_reason": {"type": "stop"}, "completion_tokens": 5},
+            output_ids=[1, 2, 3],
+        )
+        self.assertEqual(s["finish_reason"], {"type": "stop"})
+        self.assertEqual(s["last_output_ids"], [1, 2, 3])
+
+
+class TestShouldRecoverStreamState(CustomTestCase):
+    def _state(self, **overrides):
+        s = new_stream_recovery_state()
+        s.update(overrides)
+        return s
+
+    def test_triggers_with_reasoning_and_no_content_and_stop(self):
+        s = self._state(
+            reasoning_text="thinking",
+            finish_reason={"type": "stop"},
+        )
+        self.assertTrue(should_recover_stream_state(s))
+
+    def test_no_trigger_when_content_present(self):
+        s = self._state(
+            reasoning_text="thinking",
+            content_text="answer",
+            finish_reason={"type": "stop"},
+        )
+        self.assertFalse(should_recover_stream_state(s))
+
+    def test_no_trigger_when_only_whitespace_content(self):
+        # Aggressive Scene B: whitespace-only content still triggers recovery.
+        s = self._state(
+            reasoning_text="thinking",
+            content_text="   \n  ",
+            finish_reason={"type": "stop"},
+        )
+        self.assertTrue(should_recover_stream_state(s))
+
+    def test_no_trigger_when_finish_length(self):
+        s = self._state(
+            reasoning_text="thinking",
+            finish_reason={"type": "length"},
+        )
+        self.assertFalse(should_recover_stream_state(s))
+
+    def test_no_trigger_when_tool_calls(self):
+        s = self._state(
+            reasoning_text="thinking",
+            has_tool_calls=True,
+            finish_reason={"type": "stop"},
+        )
+        self.assertFalse(should_recover_stream_state(s))
+
+    def test_no_trigger_when_no_reasoning(self):
+        s = self._state(finish_reason={"type": "stop"})
+        self.assertFalse(should_recover_stream_state(s))
+
+
+class TestIsStreamRecoveryEnabledForRequest(CustomTestCase):
+    def _handler(self, server_default, parser_name="qwen3"):
+        h = SimpleNamespace()
+        h.tokenizer_manager = SimpleNamespace(
+            server_args=SimpleNamespace(
+                auto_recover_unclosed_reasoning=server_default,
+            )
+        )
+        h.reasoning_parser = parser_name
+        return h
+
+    def test_off_by_default(self):
+        self.assertFalse(
+            is_stream_recovery_enabled_for_request(
+                self._handler(False), _basic_request()
+            )
+        )
+
+    def test_on_by_server_default(self):
+        self.assertTrue(
+            is_stream_recovery_enabled_for_request(
+                self._handler(True), _basic_request()
+            )
+        )
+
+    def test_per_request_override(self):
+        h = self._handler(False)
+        self.assertTrue(
+            is_stream_recovery_enabled_for_request(
+                h, _basic_request(recover_unclosed_reasoning=True)
+            )
+        )
+
+    def test_disabled_when_no_parser(self):
+        h = self._handler(True, parser_name=None)
+        self.assertFalse(
+            is_stream_recovery_enabled_for_request(h, _basic_request())
+        )
+
+
+# ----- streaming generator ----------------------------------------------
+
+
+class _FakeTokenizer:
+    def encode(self, text, add_special_tokens=False):
+        if text == "</think>":
+            return [99]
+        return [9999, 9998]
+
+
+def _make_handler():
+    h = SimpleNamespace()
+    h.tokenizer_manager = SimpleNamespace(
+        tokenizer=_FakeTokenizer(),
+        server_args=SimpleNamespace(
+            auto_recover_unclosed_reasoning=True,
+            incremental_streaming_output=False,
+        ),
+    )
+    h.template_manager = SimpleNamespace(force_reasoning=False)
+    h.reasoning_parser = "qwen3"
+    h._get_reasoning_from_request = lambda req: None
+    return h
+
+
+def _parse_sse_line(line: str):
+    assert line.startswith("data: "), line
+    body = line[len("data: ") :]
+    if body.endswith("\n\n"):
+        body = body[:-2]
+    return json.loads(body)
+
+
+class TestStreamRecoveryChunks(CustomTestCase):
+    def _run(self, agen):
+        async def _drain():
+            return [c async for c in agen]
+
+        return asyncio.new_event_loop().run_until_complete(_drain())
+
+    def _state(self):
+        s = new_stream_recovery_state()
+        s["reasoning_text"] = "thinking only"
+        s["content_text"] = ""
+        s["finish_reason"] = {"type": "stop"}
+        s["last_output_ids"] = [1, 2, 3]
+        s["last_meta_info"] = {"finish_reason": {"type": "stop"}}
+        return s
+
+    def _adapted(self):
+        return GenerateReqInput(input_ids=[10, 11], sampling_params={})
+
+    def test_emits_content_delta_and_finish_chunk(self):
+        handler = _make_handler()
+        captured = {}
+
+        def fake_generate(follow_req, raw):
+            captured["follow_req"] = follow_req
+
+            async def _gen():
+                # Two deltas (cumulative text mode), then finish.
+                yield {
+                    "text": "the ",
+                    "meta_info": {"completion_tokens": 1},
+                }
+                yield {
+                    "text": "the answer",
+                    "meta_info": {"completion_tokens": 2},
+                }
+                yield {
+                    "text": "the answer.",
+                    "meta_info": {
+                        "completion_tokens": 3,
+                        "finish_reason": {"type": "stop"},
+                    },
+                }
+
+            return _gen()
+
+        agen = stream_recovery_chunks(
+            handler=handler,
+            request=_basic_request(recover_unclosed_reasoning=True),
+            raw_request=None,
+            adapted_request=self._adapted(),
+            state=self._state(),
+            request_id="chatcmpl-test",
+            request_model="m",
+            continuous_usage_stats=False,
+            prompt_tokens=10,
+            reasoning_tokens_acc=3,
+            completion_tokens_acc=3,
+            generate_request_fn=fake_generate,
+        )
+        chunks = self._run(agen)
+        # 3 content deltas + 1 final finish chunk
+        self.assertEqual(len(chunks), 4)
+        deltas = [_parse_sse_line(c) for c in chunks[:-1]]
+        self.assertEqual(deltas[0]["choices"][0]["delta"]["content"], "the ")
+        self.assertEqual(
+            deltas[1]["choices"][0]["delta"]["content"], "answer"
+        )
+        self.assertEqual(deltas[2]["choices"][0]["delta"]["content"], ".")
+        # All content deltas have no finish_reason
+        for d in deltas:
+            self.assertIsNone(d["choices"][0]["finish_reason"])
+
+        final = _parse_sse_line(chunks[-1])
+        self.assertEqual(final["choices"][0]["finish_reason"], "stop")
+        # Continuation request must NOT carry the redirect processor.
+        follow = captured["follow_req"]
+        self.assertIsNone(follow.custom_logit_processor)
+        # input_ids = original + last_output_ids + think_end_ids
+        self.assertEqual(follow.input_ids, [10, 11, 1, 2, 3, 99])
+
+    def test_no_yield_when_followup_returns_no_text(self):
+        handler = _make_handler()
+
+        def fake_generate(follow_req, raw):
+            async def _gen():
+                yield {
+                    "text": "",
+                    "meta_info": {"finish_reason": {"type": "stop"}},
+                }
+
+            return _gen()
+
+        agen = stream_recovery_chunks(
+            handler=handler,
+            request=_basic_request(recover_unclosed_reasoning=True),
+            raw_request=None,
+            adapted_request=self._adapted(),
+            state=self._state(),
+            request_id="chatcmpl-test",
+            request_model="m",
+            continuous_usage_stats=False,
+            prompt_tokens=10,
+            reasoning_tokens_acc=3,
+            completion_tokens_acc=3,
+            generate_request_fn=fake_generate,
+        )
+        chunks = self._run(agen)
+        # Only the final finish_reason chunk; no content delta.
+        self.assertEqual(len(chunks), 1)
+        final = _parse_sse_line(chunks[0])
+        self.assertEqual(final["choices"][0]["finish_reason"], "stop")
+        self.assertNotIn("content", final["choices"][0]["delta"] or {})
+
+    def test_yields_nothing_when_followup_request_cannot_be_built(self):
+        # text-mode adapted_request → build_continuation_request returns None
+        # → the helper yields nothing.
+        handler = _make_handler()
+        agen = stream_recovery_chunks(
+            handler=handler,
+            request=_basic_request(recover_unclosed_reasoning=True),
+            raw_request=None,
+            adapted_request=GenerateReqInput(text="hi", sampling_params={}),
+            state=self._state(),
+            request_id="x",
+            request_model="m",
+            continuous_usage_stats=False,
+            prompt_tokens=0,
+            reasoning_tokens_acc=0,
+            completion_tokens_acc=0,
+            generate_request_fn=lambda *a, **kw: (_ for _ in ()),
+        )
+        chunks = self._run(agen)
+        self.assertEqual(chunks, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/openai/test_serving_chat_redirect_inject.py
+++ b/test/registered/unit/openai/test_serving_chat_redirect_inject.py
@@ -1,0 +1,192 @@
+"""Unit tests for OpenAIServingChat._maybe_attach_redirect_processor.
+
+We avoid constructing a real OpenAIServingChat (which needs a tokenizer manager
++ template manager). Instead we exercise the helper directly through a thin
+subclass that bypasses __init__ and provides only the attributes the helper
+relies on.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="stage-a-test-cpu")
+
+import json
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
+from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
+from sglang.srt.parser.reasoning_redirect_registry import ReasoningRedirectConfig
+from sglang.srt.sampling.custom_logit_processor import (
+    ReasoningEosRedirectLogitProcessor,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+def _make_handler(
+    *,
+    redirect_unclosed_reasoning=True,
+    enable_custom_logit_processor=True,
+    cfg=None,
+    reasoning_parser="qwen3",
+    redirect_eos_prob_threshold=0.5,
+):
+    """Build an OpenAIServingChat without invoking __init__."""
+
+    handler = OpenAIServingChat.__new__(OpenAIServingChat)
+    handler.tokenizer_manager = SimpleNamespace(
+        server_args=SimpleNamespace(
+            redirect_unclosed_reasoning=redirect_unclosed_reasoning,
+            enable_custom_logit_processor=enable_custom_logit_processor,
+            redirect_eos_prob_threshold=redirect_eos_prob_threshold,
+        ),
+        tokenizer=SimpleNamespace(),  # placeholder; build_redirect_config is mocked via cfg
+    )
+    handler.reasoning_parser = reasoning_parser
+    # Pre-populate the lazy cache so build_redirect_config is not called.
+    handler._redirect_cfg = cfg
+    handler._redirect_cfg_built = True
+    handler._redirect_processor_str = (
+        ReasoningEosRedirectLogitProcessor.to_str() if cfg is not None else None
+    )
+    return handler
+
+
+def _basic_request(**overrides):
+    base = {
+        "model": "test",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    base.update(overrides)
+    return ChatCompletionRequest(**base)
+
+
+_DUMMY_CFG = ReasoningRedirectConfig(
+    think_start_token_id=151667,
+    think_end_token_id=151668,
+    redirect_eos_token_ids=[151645],
+    force_reasoning=False,
+)
+
+
+class TestRedirectInjection(CustomTestCase):
+    def test_attaches_processor_when_eligible(self):
+        handler = _make_handler(cfg=_DUMMY_CFG)
+        sampling_params = {"custom_params": None, "temperature": 1.0}
+        result = handler._maybe_attach_redirect_processor(
+            _basic_request(), sampling_params
+        )
+        self.assertIsNotNone(result)
+        # Round-trip the processor string and make sure it deserializes to
+        # ReasoningEosRedirectLogitProcessor.
+        from sglang.srt.sampling.custom_logit_processor import (
+            CustomLogitProcessor,
+        )
+
+        proc = CustomLogitProcessor.from_str(result)
+        self.assertIsInstance(proc, ReasoningEosRedirectLogitProcessor)
+
+        # custom_params merged with redirect params
+        cp = sampling_params["custom_params"]
+        self.assertEqual(cp["think_end_token_id"], 151668)
+        self.assertEqual(cp["think_start_token_id"], 151667)
+        self.assertEqual(cp["redirect_eos_token_ids"], [151645])
+        self.assertEqual(cp["prob_threshold"], 0.5)
+        self.assertFalse(cp["force_reasoning"])
+
+    def test_skips_when_cfg_is_none(self):
+        handler = _make_handler(cfg=None)
+        sampling_params = {"custom_params": None}
+        result = handler._maybe_attach_redirect_processor(
+            _basic_request(), sampling_params
+        )
+        self.assertIsNone(result)
+        self.assertIsNone(sampling_params["custom_params"])
+
+    def test_skips_when_user_already_has_custom_logit_processor(self):
+        handler = _make_handler(cfg=_DUMMY_CFG)
+        sampling_params = {"custom_params": None}
+        req = _basic_request(custom_logit_processor='{"callable": "custom"}')
+        result = handler._maybe_attach_redirect_processor(req, sampling_params)
+        self.assertIsNone(result)
+        # custom_params remains untouched (we did not inject our params).
+        self.assertIsNone(sampling_params["custom_params"])
+
+    def test_user_custom_params_take_precedence(self):
+        handler = _make_handler(cfg=_DUMMY_CFG, redirect_eos_prob_threshold=0.5)
+        sampling_params = {
+            "custom_params": {
+                "prob_threshold": 0.9,
+                "extra_user_field": "keep_me",
+            }
+        }
+        result = handler._maybe_attach_redirect_processor(
+            _basic_request(custom_params={"prob_threshold": 0.9}),
+            sampling_params,
+        )
+        self.assertIsNotNone(result)
+        cp = sampling_params["custom_params"]
+        # User override wins on the conflicting key.
+        self.assertEqual(cp["prob_threshold"], 0.9)
+        self.assertEqual(cp["extra_user_field"], "keep_me")
+        # Redirect-only fields are still present.
+        self.assertEqual(cp["think_end_token_id"], 151668)
+
+    def test_skips_when_custom_params_is_not_a_dict(self):
+        handler = _make_handler(cfg=_DUMMY_CFG)
+        sampling_params = {"custom_params": "not-a-dict"}
+        result = handler._maybe_attach_redirect_processor(
+            _basic_request(), sampling_params
+        )
+        self.assertIsNone(result)
+
+
+class TestLazyBuildPath(CustomTestCase):
+    """Cover the lazy build path: server flag off / enable_custom flag off."""
+
+    def _fresh_handler(self, **kwargs):
+        handler = OpenAIServingChat.__new__(OpenAIServingChat)
+        handler.tokenizer_manager = SimpleNamespace(
+            server_args=SimpleNamespace(
+                redirect_unclosed_reasoning=kwargs.get(
+                    "redirect_unclosed_reasoning", True
+                ),
+                enable_custom_logit_processor=kwargs.get(
+                    "enable_custom_logit_processor", True
+                ),
+                redirect_eos_prob_threshold=0.5,
+            ),
+            tokenizer=None,  # build_redirect_config sees None and bails
+        )
+        handler.reasoning_parser = kwargs.get("reasoning_parser", "qwen3")
+        handler._redirect_cfg = None
+        handler._redirect_cfg_built = False
+        handler._redirect_processor_str = None
+        return handler
+
+    def test_bails_when_redirect_flag_off(self):
+        h = self._fresh_handler(redirect_unclosed_reasoning=False)
+        self.assertIsNone(h._get_or_build_redirect_cfg())
+        self.assertTrue(h._redirect_cfg_built)
+
+    def test_bails_when_enable_custom_logit_off(self):
+        h = self._fresh_handler(enable_custom_logit_processor=False)
+        self.assertIsNone(h._get_or_build_redirect_cfg())
+        self.assertTrue(h._redirect_cfg_built)
+
+    def test_bails_when_tokenizer_missing(self):
+        # Even with all flags on, a None tokenizer means the registry
+        # cannot resolve token ids → cfg should be None.
+        h = self._fresh_handler()
+        self.assertIsNone(h._get_or_build_redirect_cfg())
+
+    def test_caches_result_after_first_call(self):
+        h = self._fresh_handler(redirect_unclosed_reasoning=False)
+        self.assertIsNone(h._get_or_build_redirect_cfg())
+        # Flip the flag — cached value should still be returned.
+        h.tokenizer_manager.server_args.redirect_unclosed_reasoning = True
+        self.assertIsNone(h._get_or_build_redirect_cfg())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/openai/test_tool_call_stream_content_delta.py
+++ b/test/registered/unit/openai/test_tool_call_stream_content_delta.py
@@ -1,0 +1,252 @@
+"""Regression test: _process_tool_call_stream now yields ``(sse_chunk,
+normal_text_delta)`` tuples so the caller can feed the content accumulator
+used by the streaming Fallback B (unclosed-reasoning recovery).
+
+Bug scenario this protects against:
+  - request has tools + tool_choice="auto"
+  - model emits: "<think>reasoning</think>real answer." (no tool call)
+  - stream loop enters the tool branch and yields "real answer." as a content
+    chunk via ``_process_tool_call_stream``
+  - BEFORE the fix: the tool branch never called
+    ``update_stream_state_with_content`` so ``state["content_text"]`` stayed
+    empty, ``should_recover_stream_state`` returned True, and Fallback B
+    issued a redundant continuation (double-response + wasted compute).
+  - AFTER the fix: each content chunk is co-yielded with its text delta so
+    the caller can fold it into ``state["content_text"]`` → recovery skipped.
+
+We bypass the full streaming machinery by calling ``_process_tool_call_stream``
+directly with a pre-populated ``parser_dict`` so no real FunctionCallParser /
+JsonArrayParser is constructed.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="stage-a-test-cpu")
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+from typing import Tuple
+
+from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
+from sglang.srt.entrypoints.openai.recover_unclosed_reasoning import (
+    new_stream_recovery_state,
+    should_recover_stream_state,
+    update_stream_state_with_content,
+    update_stream_state_with_reasoning,
+)
+from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
+from sglang.test.test_utils import CustomTestCase
+
+
+class _FakeToolCallParser:
+    """Drop-in for FunctionCallParser.parse_stream_chunk with scripted output."""
+
+    def __init__(self, scripted: list):
+        # Each item: (normal_text, calls_list). Consumed in order.
+        self._scripted = list(scripted)
+
+    def parse_stream_chunk(self, chunk_text: str) -> Tuple[str, list]:
+        if not self._scripted:
+            return "", []
+        return self._scripted.pop(0)
+
+
+def _basic_request(**overrides):
+    base = {
+        "model": "test",
+        "messages": [{"role": "user", "content": "hi"}],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "f",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+        "tool_choice": "auto",
+    }
+    base.update(overrides)
+    return ChatCompletionRequest(**base)
+
+
+def _make_handler():
+    handler = OpenAIServingChat.__new__(OpenAIServingChat)
+    handler.tool_call_parser = "qwen25"
+    handler.tokenizer_manager = SimpleNamespace(
+        server_args=SimpleNamespace(incremental_streaming_output=False)
+    )
+    return handler
+
+
+def _meta_content(token_id: str = "chatcmpl-test"):
+    return {
+        "meta_info": {
+            "id": token_id,
+            "prompt_tokens": 0,
+            "completion_tokens": 1,
+            "reasoning_tokens": 0,
+        }
+    }
+
+
+def _drain(agen):
+    async def _run():
+        return [item async for item in agen]
+
+    return asyncio.new_event_loop().run_until_complete(_run())
+
+
+class TestToolCallStreamYieldsTuple(CustomTestCase):
+    """Contract: each yield is a ``(str, Optional[str])`` tuple where the
+    second element is the content text delta (or None for tool-call chunks).
+    """
+
+    def test_yields_normal_text_delta_for_content_chunk(self):
+        handler = _make_handler()
+        parser_dict = {0: _FakeToolCallParser([("real answer.", [])])}
+
+        out = _drain(
+            handler._process_tool_call_stream(
+                index=0,
+                delta="real answer.",
+                parser_dict=parser_dict,
+                content=_meta_content(),
+                request=_basic_request(),
+                has_tool_calls={},
+            )
+        )
+        self.assertEqual(len(out), 1)
+        sse_chunk, normal_text_delta = out[0]
+        self.assertIsInstance(sse_chunk, str)
+        self.assertTrue(sse_chunk.startswith("data: "))
+        self.assertEqual(normal_text_delta, "real answer.")
+
+    def test_yields_none_delta_for_tool_call_chunk(self):
+        handler = _make_handler()
+
+        class _Call:
+            name = "f"
+            tool_index = 0
+            parameters = "{}"
+
+        parser_dict = {0: _FakeToolCallParser([("", [_Call()])])}
+        has_tool_calls: dict = {}
+
+        out = _drain(
+            handler._process_tool_call_stream(
+                index=0,
+                delta='<tool_call>{"name":"f"}',
+                parser_dict=parser_dict,
+                content=_meta_content(),
+                request=_basic_request(),
+                has_tool_calls=has_tool_calls,
+            )
+        )
+        self.assertEqual(len(out), 1)
+        sse_chunk, normal_text_delta = out[0]
+        self.assertIsInstance(sse_chunk, str)
+        self.assertIsNone(normal_text_delta)
+        self.assertTrue(has_tool_calls[0])
+
+    def test_no_normal_text_and_no_calls_yields_nothing(self):
+        handler = _make_handler()
+        parser_dict = {0: _FakeToolCallParser([("", [])])}
+        out = _drain(
+            handler._process_tool_call_stream(
+                index=0,
+                delta="partial",
+                parser_dict=parser_dict,
+                content=_meta_content(),
+                request=_basic_request(),
+                has_tool_calls={},
+            )
+        )
+        self.assertEqual(out, [])
+
+
+class TestToolBranchFeedsContentAccumulator(CustomTestCase):
+    """End-to-end: simulate the fixed caller glue.
+
+    Reasoning produced via the reasoning parser stream → then tool branch
+    yields real content (no tool call) → caller folds both into the recovery
+    state → ``should_recover_stream_state`` must return False.
+    """
+
+    def test_tool_branch_content_suppresses_recovery(self):
+        handler = _make_handler()
+        state = new_stream_recovery_state()
+
+        # 1) Reasoning phase (parser returned reasoning_text).
+        update_stream_state_with_reasoning(state, "thinking about it")
+
+        # 2) Tool branch yields real content (no tool call). Caller glue in
+        #    serving_chat.py now does exactly this: drain the (chunk,
+        #    normal_text_delta) tuples and feed delta into the accumulator.
+        parser_dict = {0: _FakeToolCallParser([("real answer.", [])])}
+        for _chunk, normal_text_delta in _drain(
+            handler._process_tool_call_stream(
+                index=0,
+                delta="real answer.",
+                parser_dict=parser_dict,
+                content=_meta_content(),
+                request=_basic_request(),
+                has_tool_calls={},
+            )
+        ):
+            if normal_text_delta:
+                update_stream_state_with_content(state, normal_text_delta)
+
+        # 3) Stream finished normally.
+        state["finish_reason"] = {"type": "stop"}
+
+        # With the fix: content_text is populated → recovery MUST NOT fire.
+        self.assertEqual(state["content_text"], "real answer.")
+        self.assertFalse(should_recover_stream_state(state))
+
+    def test_tool_branch_with_tool_call_and_no_content_still_recovers_correctly(
+        self,
+    ):
+        # Sanity: if the tool branch yields ONLY a tool-call chunk (no
+        # normal_text), and the stream state is then marked via
+        # mark_stream_state_tool_call, recovery still skips because
+        # has_tool_calls is True — independent of content_text.
+        from sglang.srt.entrypoints.openai.recover_unclosed_reasoning import (
+            mark_stream_state_tool_call,
+        )
+
+        handler = _make_handler()
+        state = new_stream_recovery_state()
+        update_stream_state_with_reasoning(state, "thinking")
+
+        class _Call:
+            name = "f"
+            tool_index = 0
+            parameters = "{}"
+
+        parser_dict = {0: _FakeToolCallParser([("", [_Call()])])}
+        has_tool_calls: dict = {}
+        for _chunk, normal_text_delta in _drain(
+            handler._process_tool_call_stream(
+                index=0,
+                delta='<tool_call>{"name":"f"}',
+                parser_dict=parser_dict,
+                content=_meta_content(),
+                request=_basic_request(),
+                has_tool_calls=has_tool_calls,
+            )
+        ):
+            if normal_text_delta:
+                update_stream_state_with_content(state, normal_text_delta)
+        if has_tool_calls.get(0):
+            mark_stream_state_tool_call(state)
+
+        state["finish_reason"] = {"type": "stop"}
+        self.assertEqual(state["content_text"], "")
+        self.assertTrue(state["has_tool_calls"])
+        self.assertFalse(should_recover_stream_state(state))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/parser/test_reasoning_parser_dedupe.py
+++ b/test/registered/unit/parser/test_reasoning_parser_dedupe.py
@@ -1,0 +1,159 @@
+"""Unit tests for the leading-think_end-token stripping behaviour added to
+BaseReasoningFormatDetector. This protects against duplicate `</think>` markers
+produced by speculative decoding or by the reasoning-EOS redirect logit
+processor triggering more than once.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="stage-a-test-cpu")
+
+import unittest
+
+from sglang.srt.parser.reasoning_parser import (
+    BaseReasoningFormatDetector,
+    DeepSeekR1Detector,
+    Qwen3Detector,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+def _make_qwen3():
+    return Qwen3Detector(stream_reasoning=True, force_reasoning=False)
+
+
+def _make_qwen3_force():
+    # force_reasoning=True so first chunk of stream is treated as in-reasoning
+    return Qwen3Detector(stream_reasoning=True, force_reasoning=True)
+
+
+class TestStripLeadingThinkEndHelper(CustomTestCase):
+    def setUp(self):
+        self.detector = BaseReasoningFormatDetector(
+            think_start_token="<think>",
+            think_end_token="</think>",
+        )
+
+    def test_no_change_when_no_leading_think_end(self):
+        self.assertEqual(
+            self.detector._strip_leading_think_end_tokens("hello world"),
+            "hello world",
+        )
+
+    def test_strips_single_leading_think_end(self):
+        self.assertEqual(
+            self.detector._strip_leading_think_end_tokens("</think>answer"),
+            "answer",
+        )
+
+    def test_strips_repeated_leading_think_end(self):
+        self.assertEqual(
+            self.detector._strip_leading_think_end_tokens("</think></think>answer"),
+            "answer",
+        )
+
+    def test_strips_with_whitespace_between(self):
+        self.assertEqual(
+            self.detector._strip_leading_think_end_tokens(
+                "  </think>\n</think>  real"
+            ),
+            "real",
+        )
+
+    def test_does_not_strip_mid_text_think_end(self):
+        # `</think>` appearing in the middle is preserved (rare, but allowed).
+        self.assertEqual(
+            self.detector._strip_leading_think_end_tokens(
+                "answer with </think> inside"
+            ),
+            "answer with </think> inside",
+        )
+
+    def test_handles_empty_text(self):
+        self.assertEqual(self.detector._strip_leading_think_end_tokens(""), "")
+
+
+class TestNonStreamingDedupe(CustomTestCase):
+    def test_single_think_end_is_unchanged(self):
+        d = _make_qwen3()
+        result = d.detect_and_parse("<think>reasoning</think>real answer")
+        self.assertEqual(result.reasoning_text, "reasoning")
+        self.assertEqual(result.normal_text, "real answer")
+
+    def test_duplicate_think_end_is_stripped(self):
+        d = _make_qwen3()
+        result = d.detect_and_parse("<think>reasoning</think></think>real answer")
+        self.assertEqual(result.reasoning_text, "reasoning")
+        self.assertEqual(result.normal_text, "real answer")
+
+    def test_triple_think_end_is_stripped(self):
+        d = _make_qwen3()
+        result = d.detect_and_parse(
+            "<think>reasoning</think></think>\n</think>real answer"
+        )
+        self.assertEqual(result.reasoning_text, "reasoning")
+        self.assertEqual(result.normal_text, "real answer")
+
+    def test_deepseek_r1_force_reasoning_dedupe(self):
+        # DeepSeek-R1 always force_reasoning=True; raw stream may not have
+        # think_start prepended.
+        d = DeepSeekR1Detector(stream_reasoning=True)
+        result = d.detect_and_parse("reasoning</think></think>answer")
+        self.assertEqual(result.reasoning_text, "reasoning")
+        self.assertEqual(result.normal_text, "answer")
+
+
+class TestStreamingDedupe(CustomTestCase):
+    def _drain(self, detector, chunks):
+        reasoning, normal = [], []
+        for chunk in chunks:
+            r = detector.parse_streaming_increment(chunk)
+            if r.reasoning_text:
+                reasoning.append(r.reasoning_text)
+            if r.normal_text:
+                normal.append(r.normal_text)
+        return "".join(reasoning), "".join(normal)
+
+    def test_streaming_duplicate_in_single_chunk(self):
+        d = _make_qwen3()
+        reasoning, normal = self._drain(
+            d, ["<think>reasoning</think></think>real answer"]
+        )
+        self.assertEqual(reasoning, "reasoning")
+        self.assertEqual(normal, "real answer")
+
+    def test_streaming_duplicate_across_chunks(self):
+        # First chunk closes reasoning normally; the second chunk arrives with
+        # an extra `</think>` (e.g. spec-decoding double redirect).
+        d = _make_qwen3_force()
+        chunks = [
+            "reasoning</think>part1 ",
+            "</think>part2",
+        ]
+        reasoning, normal = self._drain(d, chunks)
+        self.assertEqual(reasoning, "reasoning")
+        self.assertEqual(normal, "part1 part2")
+
+    def test_streaming_no_dedupe_for_legit_text(self):
+        d = _make_qwen3_force()
+        chunks = ["reasoning</think>", "real ", "answer"]
+        reasoning, normal = self._drain(d, chunks)
+        self.assertEqual(reasoning, "reasoning")
+        self.assertEqual(normal, "real answer")
+
+    def test_streaming_mid_text_think_end_is_preserved(self):
+        d = _make_qwen3_force()
+        chunks = [
+            "reasoning</think>before ",
+            "<code></think></code> after",
+        ]
+        reasoning, normal = self._drain(d, chunks)
+        self.assertEqual(reasoning, "reasoning")
+        # Mid-text </think> should NOT be stripped — only leading ones.
+        # The leading `<code>` does not match, so nothing is stripped from
+        # subsequent chunks. </think> in the middle is preserved.
+        self.assertIn("</think>", normal)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/parser/test_reasoning_redirect_registry.py
+++ b/test/registered/unit/parser/test_reasoning_redirect_registry.py
@@ -1,0 +1,167 @@
+"""Unit tests for reasoning_redirect_registry.build_redirect_config.
+
+Uses fake in-memory tokenizers so no real model has to be downloaded.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="stage-a-test-cpu")
+
+import unittest
+
+from sglang.srt.parser.reasoning_redirect_registry import (
+    ReasoningRedirectConfig,
+    build_redirect_config,
+    is_supported_reasoning_parser,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+class _FakeTokenizer:
+    """Tiny fake tokenizer that maps a fixed vocabulary string -> token id.
+
+    Strings that are not in the vocabulary encode to multiple "char" tokens so
+    the single-token check fails naturally. We store eos_token_id as either an
+    int or a list to mimic real HF tokenizers (some configs use a list).
+    """
+
+    def __init__(self, vocab, eos_token_id):
+        self._vocab = dict(vocab)
+        self.eos_token_id = eos_token_id
+
+    def encode(self, text, add_special_tokens=False):
+        if text in self._vocab:
+            return [self._vocab[text]]
+        # Fall back to per-character encoding so non-vocab strings become
+        # multi-token sequences. Specific id values don't matter — we only care
+        # that len > 1.
+        return [10_000 + i for i, _ in enumerate(text)]
+
+
+class TestIsSupportedReasoningParser(CustomTestCase):
+    def test_known_parsers(self):
+        for name in ("qwen3", "QWEN3", "deepseek-r1", "kimi_k2", "glm45"):
+            self.assertTrue(is_supported_reasoning_parser(name), name)
+
+    def test_unknown_parser(self):
+        self.assertFalse(is_supported_reasoning_parser("totally_random_parser"))
+
+    def test_none(self):
+        self.assertFalse(is_supported_reasoning_parser(None))
+
+    def test_empty_string(self):
+        self.assertFalse(is_supported_reasoning_parser(""))
+
+
+class TestBuildRedirectConfigQwen3(CustomTestCase):
+    def setUp(self):
+        # Qwen3-style: <think>=151667, </think>=151668, <|im_end|>=151645
+        self.tokenizer = _FakeTokenizer(
+            vocab={
+                "<think>": 151667,
+                "</think>": 151668,
+                "<|im_end|>": 151645,
+            },
+            eos_token_id=151645,  # Qwen3 EOS == im_end
+        )
+
+    def test_happy_path(self):
+        cfg = build_redirect_config("qwen3", self.tokenizer)
+        self.assertIsInstance(cfg, ReasoningRedirectConfig)
+        self.assertEqual(cfg.think_end_token_id, 151668)
+        self.assertEqual(cfg.think_start_token_id, 151667)
+        self.assertIn(151645, cfg.redirect_eos_token_ids)
+        # think_end never lands in the EOS redirect set
+        self.assertNotIn(151668, cfg.redirect_eos_token_ids)
+        self.assertFalse(cfg.force_reasoning)
+
+    def test_extra_chat_end_token_ids_are_added(self):
+        cfg = build_redirect_config(
+            "qwen3", self.tokenizer, extra_chat_end_token_ids=[999, 1000]
+        )
+        self.assertIn(999, cfg.redirect_eos_token_ids)
+        self.assertIn(1000, cfg.redirect_eos_token_ids)
+
+
+class TestBuildRedirectConfigDeepSeekR1(CustomTestCase):
+    def setUp(self):
+        self.tokenizer = _FakeTokenizer(
+            vocab={
+                "<think>": 128001,
+                "</think>": 128002,
+            },
+            eos_token_id=128009,
+        )
+
+    def test_force_reasoning_is_set(self):
+        cfg = build_redirect_config("deepseek-r1", self.tokenizer)
+        self.assertIsNotNone(cfg)
+        self.assertTrue(cfg.force_reasoning)
+        self.assertEqual(cfg.think_end_token_id, 128002)
+        self.assertIn(128009, cfg.redirect_eos_token_ids)
+
+
+class TestMultiTokenThinkEndDowngrade(CustomTestCase):
+    def test_multi_token_think_end_returns_none(self):
+        # think_end is NOT in the vocab → encode falls back to char-tokens
+        # → len > 1 → registry should refuse to enable path-1.
+        tok = _FakeTokenizer(vocab={"<|im_end|>": 200}, eos_token_id=200)
+        cfg = build_redirect_config("qwen3", tok)
+        self.assertIsNone(cfg)
+
+
+class TestUnknownParserReturnsNone(CustomTestCase):
+    def test_unknown(self):
+        tok = _FakeTokenizer(
+            vocab={"<think>": 1, "</think>": 2}, eos_token_id=3
+        )
+        self.assertIsNone(build_redirect_config("not-a-parser", tok))
+
+    def test_none_parser(self):
+        tok = _FakeTokenizer(
+            vocab={"<think>": 1, "</think>": 2}, eos_token_id=3
+        )
+        self.assertIsNone(build_redirect_config(None, tok))
+
+
+class TestNoEosTokensReturnsNone(CustomTestCase):
+    def test_no_eos_at_all(self):
+        # Nothing maps to a usable EOS id → registry refuses (would otherwise
+        # have nothing to redirect away from).
+        # NOTE: tokenizer.eos_token_id is None and "<|im_end|>" is missing.
+        tok = _FakeTokenizer(
+            vocab={"<think>": 1, "</think>": 2}, eos_token_id=None
+        )
+        cfg = build_redirect_config("qwen3", tok)
+        self.assertIsNone(cfg)
+
+
+class TestEosIdAsListIsAccepted(CustomTestCase):
+    def test_list_eos(self):
+        tok = _FakeTokenizer(
+            vocab={"<think>": 1, "</think>": 2, "<|im_end|>": 3},
+            eos_token_id=[3, 4, 5],
+        )
+        cfg = build_redirect_config("qwen3", tok)
+        self.assertIsNotNone(cfg)
+        for v in (3, 4, 5):
+            self.assertIn(v, cfg.redirect_eos_token_ids)
+
+
+class TestThinkEndExcludedFromEosSet(CustomTestCase):
+    def test_extra_chat_end_token_ids_does_not_re_add_think_end(self):
+        # Even if the caller mistakenly passes think_end_id into the extra
+        # set, we must drop it.
+        tok = _FakeTokenizer(
+            vocab={"<think>": 1, "</think>": 2, "<|im_end|>": 3}, eos_token_id=3
+        )
+        cfg = build_redirect_config(
+            "qwen3", tok, extra_chat_end_token_ids=[2, 4]
+        )
+        self.assertIsNotNone(cfg)
+        self.assertNotIn(2, cfg.redirect_eos_token_ids)
+        self.assertIn(4, cfg.redirect_eos_token_ids)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/sampling/test_reasoning_eos_redirect.py
+++ b/test/registered/unit/sampling/test_reasoning_eos_redirect.py
@@ -85,6 +85,19 @@ class TestReasoningEosRedirectTriggers(CustomTestCase):
         out = self.processor(logits.clone(), self._params(req))
         self.assertTrue(torch.equal(out, original))
 
+    def test_skip_when_think_end_already_in_prompt(self):
+        # Prompt already has a closed <think>...</think> block (e.g. Qwen3's
+        # enable_thinking=False path prefilling <think>\n\n</think>). The
+        # processor must NOT redirect EOS to think_end in this case.
+        logits = _make_logits({5: 5.0, 6: 5.0, 7: 0.0})
+        req = _make_req(
+            origin_input_ids=[8, 99, 7, 100],  # think_start=8, think_end=7 in prompt
+            output_ids=[200, 201],
+        )
+        original = logits.clone()
+        out = self.processor(logits.clone(), self._params(req))
+        self.assertTrue(torch.equal(out, original))
+
     def test_skip_when_not_yet_in_reasoning(self):
         # No think_start_id present anywhere, force_reasoning=False.
         logits = _make_logits({5: 5.0, 6: 5.0, 7: 0.0})
@@ -105,11 +118,11 @@ class TestReasoningEosRedirectTriggers(CustomTestCase):
 
     def test_temperature_scales_eos_probability(self):
         # Without temperature scaling (T=1):
-        #   logits {5:1.0, 7:0.0, 1:0.5, others:-10}
-        #   softmax mass on {5} is ~0.4 (below threshold 0.5).
-        # With T=0.1, logits effectively become {5:10.0, 7:0.0, 1:5.0, ...}
-        #   so EOS mass ~ 1.0 (well above 0.5). Should trigger.
-        logits = _make_logits({5: 1.0, 7: 0.0, 1: 0.5})
+        #   logits {5:1.0, 7:0.5, 1:0.3, others:-10}
+        #   softmax mass on {5} is ~0.476 (below threshold 0.5) → NO trigger.
+        # With T=0.1, logits effectively become {5:10.0, 7:5.0, 1:3.0, ...}
+        #   so EOS mass on {5} → ~1.0 (well above 0.5). Should trigger.
+        logits = _make_logits({5: 1.0, 7: 0.5, 1: 0.3})
         # First, verify the no-trigger case at T=1:
         req_t1 = _make_req(origin_input_ids=[8], temperature=1.0)
         out_t1 = self.processor(

--- a/test/registered/unit/sampling/test_reasoning_eos_redirect.py
+++ b/test/registered/unit/sampling/test_reasoning_eos_redirect.py
@@ -1,0 +1,232 @@
+"""Unit tests for ReasoningEosRedirectLogitProcessor.
+
+No server / no model loading. All tensors are CPU-only and tiny.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=4, suite="stage-a-test-cpu")
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.sampling.custom_logit_processor import (
+    CustomLogitProcessor,
+    ReasoningEosRedirectLogitProcessor,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+def _make_req(origin_input_ids=None, output_ids=None, temperature=1.0):
+    sampling_params = SimpleNamespace(temperature=temperature)
+    return SimpleNamespace(
+        origin_input_ids=list(origin_input_ids or []),
+        output_ids=list(output_ids or []),
+        sampling_params=sampling_params,
+    )
+
+
+def _make_logits(values, vocab=10, fill=-10.0):
+    """Build a (1, vocab) logits tensor with specific positions set."""
+    logits = torch.full((1, vocab), fill, dtype=torch.float32)
+    for tok, v in values.items():
+        logits[0, tok] = v
+    return logits
+
+
+class TestReasoningEosRedirectSerialization(CustomTestCase):
+    def test_to_str_round_trip(self):
+        s = ReasoningEosRedirectLogitProcessor.to_str()
+        proc = CustomLogitProcessor.from_str(s)
+        self.assertIsInstance(proc, ReasoningEosRedirectLogitProcessor)
+
+
+class TestReasoningEosRedirectTriggers(CustomTestCase):
+    def setUp(self):
+        self.processor = ReasoningEosRedirectLogitProcessor()
+        self.base_params = {
+            "think_end_token_id": 7,
+            "think_start_token_id": 8,
+            "redirect_eos_token_ids": [5, 6],
+            "prob_threshold": 0.5,
+        }
+
+    def _params(self, req, **overrides):
+        merged = dict(self.base_params)
+        merged.update(overrides)
+        merged["__req__"] = req
+        return [merged]
+
+    def test_redirect_triggers_when_eos_prob_above_threshold(self):
+        # EOS tokens dominate (logit 5.0 vs others -10/0), so softmax mass
+        # on {5,6} is ~1.0. Should trigger.
+        logits = _make_logits({5: 5.0, 6: 5.0, 7: 0.0, 1: 0.5})
+        req = _make_req(origin_input_ids=[8, 1, 2, 3])
+        out = self.processor(logits.clone(), self._params(req))
+        self.assertEqual(out[0, 5].item(), float("-inf"))
+        self.assertEqual(out[0, 6].item(), float("-inf"))
+        self.assertEqual(int(torch.argmax(out[0]).item()), 7)
+
+    def test_skip_when_eos_prob_below_threshold(self):
+        # Token 1 dominates; EOS mass is negligible.
+        logits = _make_logits({5: 0.0, 6: 0.0, 7: 0.0, 1: 5.0})
+        req = _make_req(origin_input_ids=[8])
+        original = logits.clone()
+        out = self.processor(logits.clone(), self._params(req))
+        self.assertTrue(torch.equal(out, original))
+
+    def test_skip_when_already_left_reasoning(self):
+        # think_end token already in output_ids → skip even if EOS dominates.
+        logits = _make_logits({5: 5.0, 6: 5.0, 7: 0.0})
+        req = _make_req(origin_input_ids=[8], output_ids=[7, 1, 2])
+        original = logits.clone()
+        out = self.processor(logits.clone(), self._params(req))
+        self.assertTrue(torch.equal(out, original))
+
+    def test_skip_when_not_yet_in_reasoning(self):
+        # No think_start_id present anywhere, force_reasoning=False.
+        logits = _make_logits({5: 5.0, 6: 5.0, 7: 0.0})
+        req = _make_req(origin_input_ids=[1, 2, 3], output_ids=[])
+        original = logits.clone()
+        out = self.processor(logits.clone(), self._params(req))
+        self.assertTrue(torch.equal(out, original))
+
+    def test_force_reasoning_triggers_without_think_start(self):
+        # Model with no think_start in chat template; force_reasoning=True.
+        logits = _make_logits({5: 5.0, 6: 5.0, 7: 0.0})
+        req = _make_req(origin_input_ids=[1, 2, 3], output_ids=[])
+        out = self.processor(
+            logits.clone(),
+            self._params(req, think_start_token_id=None, force_reasoning=True),
+        )
+        self.assertEqual(int(torch.argmax(out[0]).item()), 7)
+
+    def test_temperature_scales_eos_probability(self):
+        # Without temperature scaling (T=1):
+        #   logits {5:1.0, 7:0.0, 1:0.5, others:-10}
+        #   softmax mass on {5} is ~0.4 (below threshold 0.5).
+        # With T=0.1, logits effectively become {5:10.0, 7:0.0, 1:5.0, ...}
+        #   so EOS mass ~ 1.0 (well above 0.5). Should trigger.
+        logits = _make_logits({5: 1.0, 7: 0.0, 1: 0.5})
+        # First, verify the no-trigger case at T=1:
+        req_t1 = _make_req(origin_input_ids=[8], temperature=1.0)
+        out_t1 = self.processor(
+            logits.clone(),
+            [
+                {
+                    "__req__": req_t1,
+                    "think_end_token_id": 7,
+                    "think_start_token_id": 8,
+                    "redirect_eos_token_ids": [5],
+                    "prob_threshold": 0.5,
+                }
+            ],
+        )
+        self.assertNotEqual(out_t1[0, 5].item(), float("-inf"))
+
+        # Now with T=0.1, should trigger.
+        req_t01 = _make_req(origin_input_ids=[8], temperature=0.1)
+        out_t01 = self.processor(
+            logits.clone(),
+            [
+                {
+                    "__req__": req_t01,
+                    "think_end_token_id": 7,
+                    "think_start_token_id": 8,
+                    "redirect_eos_token_ids": [5],
+                    "prob_threshold": 0.5,
+                }
+            ],
+        )
+        self.assertEqual(out_t01[0, 5].item(), float("-inf"))
+        self.assertEqual(int(torch.argmax(out_t01[0]).item()), 7)
+
+    def test_think_start_in_origin_ids_counts_as_in_reasoning(self):
+        # Some chat templates prefill <think> in the prompt. Detection should
+        # use both origin_input_ids and output_ids.
+        logits = _make_logits({5: 5.0, 6: 5.0, 7: 0.0})
+        req = _make_req(origin_input_ids=[100, 8])  # think_start in prompt
+        out = self.processor(logits.clone(), self._params(req))
+        self.assertEqual(int(torch.argmax(out[0]).item()), 7)
+
+    def test_empty_eos_set_does_nothing(self):
+        logits = _make_logits({5: 5.0, 7: 0.0})
+        req = _make_req(origin_input_ids=[8])
+        original = logits.clone()
+        out = self.processor(
+            logits.clone(),
+            [
+                {
+                    "__req__": req,
+                    "think_end_token_id": 7,
+                    "think_start_token_id": 8,
+                    "redirect_eos_token_ids": [],
+                    "prob_threshold": 0.5,
+                }
+            ],
+        )
+        self.assertTrue(torch.equal(out, original))
+
+    def test_missing_required_params_skip_safely(self):
+        logits = _make_logits({5: 5.0, 7: 0.0})
+        req = _make_req(origin_input_ids=[8])
+        original = logits.clone()
+        # Missing think_end_token_id
+        out = self.processor(
+            logits.clone(),
+            [
+                {
+                    "__req__": req,
+                    "think_start_token_id": 8,
+                    "redirect_eos_token_ids": [5],
+                    "prob_threshold": 0.5,
+                }
+            ],
+        )
+        self.assertTrue(torch.equal(out, original))
+
+    def test_only_changes_eos_and_think_end_indices(self):
+        # All other token logits must be untouched.
+        logits = _make_logits({5: 5.0, 6: 5.0, 7: 0.0, 1: 0.5, 2: 0.3, 3: 0.1})
+        req = _make_req(origin_input_ids=[8])
+        out = self.processor(logits.clone(), self._params(req))
+        # Untouched indices keep original value
+        for tok in (1, 2, 3, 4, 8, 9):
+            self.assertAlmostEqual(out[0, tok].item(), logits[0, tok].item(), places=5)
+        # EOS is masked
+        self.assertEqual(out[0, 5].item(), float("-inf"))
+        self.assertEqual(out[0, 6].item(), float("-inf"))
+        # think_end is strictly the largest
+        self.assertEqual(int(torch.argmax(out[0]).item()), 7)
+
+    def test_batch_independent_processing(self):
+        # Two requests in one batch: only the first one should be redirected.
+        logits = torch.full((2, 10), -10.0, dtype=torch.float32)
+        # row 0: EOS dominates, in reasoning → trigger
+        logits[0, 5] = 5.0
+        logits[0, 6] = 5.0
+        logits[0, 7] = 0.0
+        # row 1: EOS dominates, but already past reasoning (output_ids has think_end)
+        logits[1, 5] = 5.0
+        logits[1, 6] = 5.0
+        logits[1, 7] = 0.0
+
+        req0 = _make_req(origin_input_ids=[8])
+        req1 = _make_req(origin_input_ids=[8], output_ids=[7])
+        params = [
+            {**self.base_params, "__req__": req0},
+            {**self.base_params, "__req__": req1},
+        ]
+        out = self.processor(logits.clone(), params)
+        # row 0 redirected
+        self.assertEqual(out[0, 5].item(), float("-inf"))
+        self.assertEqual(int(torch.argmax(out[0]).item()), 7)
+        # row 1 unchanged
+        self.assertEqual(out[1, 5].item(), 5.0)
+        self.assertEqual(out[1, 7].item(), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/server_args/test_recover_unclosed_reasoning_args.py
+++ b/test/registered/unit/server_args/test_recover_unclosed_reasoning_args.py
@@ -2,16 +2,14 @@
 flags + per-request override on ChatCompletionRequest.
 """
 
+import argparse
 import unittest
 from unittest.mock import patch
 
 from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
-from sglang.srt.server_args import ServerArgs, prepare_server_args
+from sglang.srt.server_args import ServerArgs
 from sglang.test.ci.ci_register import register_cpu_ci
-from sglang.test.test_utils import (
-    DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN,
-    CustomTestCase,
-)
+from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=2, suite="stage-a-test-cpu")
 
@@ -29,10 +27,19 @@ class TestServerArgsDefaults(CustomTestCase):
 
 
 class TestServerArgsCli(CustomTestCase):
+    """Exercise just the argparse layer for the new flags.
+
+    We avoid ``prepare_server_args`` / ``ServerArgs.from_cli_args`` here because
+    they try to load the HF model config in ``__post_init__`` (for piecewise
+    CUDA graph detection), which requires network access in CI-like envs.
+    Parsing the flags is what we actually want to test anyway.
+    """
+
     def _parse(self, *extra):
-        return prepare_server_args(
-            ["--model-path", DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN, *extra]
-        )
+        parser = argparse.ArgumentParser()
+        ServerArgs.add_cli_args(parser)
+        args = parser.parse_args(["--model-path", "dummy", *extra])
+        return args
 
     def test_redirect_flag_is_parsed(self):
         s = self._parse("--redirect-unclosed-reasoning")

--- a/test/registered/unit/server_args/test_recover_unclosed_reasoning_args.py
+++ b/test/registered/unit/server_args/test_recover_unclosed_reasoning_args.py
@@ -1,0 +1,90 @@
+"""Unit tests for the unclosed-reasoning recovery configuration: server CLI
+flags + per-request override on ChatCompletionRequest.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
+from sglang.srt.server_args import ServerArgs, prepare_server_args
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import (
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN,
+    CustomTestCase,
+)
+
+register_cpu_ci(est_time=2, suite="stage-a-test-cpu")
+
+_mock_device = patch("sglang.srt.server_args.get_device", return_value="cuda")
+_mock_device.start()
+
+
+class TestServerArgsDefaults(CustomTestCase):
+    def test_defaults_are_off(self):
+        # All three new fields default to safe / off values.
+        s = ServerArgs(model_path="dummy")
+        self.assertFalse(s.redirect_unclosed_reasoning)
+        self.assertEqual(s.redirect_eos_prob_threshold, 0.5)
+        self.assertFalse(s.auto_recover_unclosed_reasoning)
+
+
+class TestServerArgsCli(CustomTestCase):
+    def _parse(self, *extra):
+        return prepare_server_args(
+            ["--model-path", DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN, *extra]
+        )
+
+    def test_redirect_flag_is_parsed(self):
+        s = self._parse("--redirect-unclosed-reasoning")
+        self.assertTrue(s.redirect_unclosed_reasoning)
+
+    def test_threshold_flag_is_parsed(self):
+        s = self._parse("--redirect-eos-prob-threshold", "0.75")
+        self.assertAlmostEqual(s.redirect_eos_prob_threshold, 0.75)
+
+    def test_auto_recover_flag_is_parsed(self):
+        s = self._parse("--auto-recover-unclosed-reasoning")
+        self.assertTrue(s.auto_recover_unclosed_reasoning)
+
+    def test_all_flags_combined(self):
+        s = self._parse(
+            "--redirect-unclosed-reasoning",
+            "--redirect-eos-prob-threshold",
+            "0.6",
+            "--auto-recover-unclosed-reasoning",
+        )
+        self.assertTrue(s.redirect_unclosed_reasoning)
+        self.assertAlmostEqual(s.redirect_eos_prob_threshold, 0.6)
+        self.assertTrue(s.auto_recover_unclosed_reasoning)
+
+
+class TestChatCompletionRequestField(CustomTestCase):
+    """Covers the new per-request `recover_unclosed_reasoning` override."""
+
+    _MIN_REQ = {
+        "model": "test",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+
+    def test_default_is_none(self):
+        req = ChatCompletionRequest(**self._MIN_REQ)
+        self.assertIsNone(req.recover_unclosed_reasoning)
+
+    def test_explicit_true(self):
+        req = ChatCompletionRequest(**self._MIN_REQ, recover_unclosed_reasoning=True)
+        self.assertTrue(req.recover_unclosed_reasoning)
+
+    def test_explicit_false(self):
+        req = ChatCompletionRequest(**self._MIN_REQ, recover_unclosed_reasoning=False)
+        self.assertFalse(req.recover_unclosed_reasoning)
+
+    def test_field_round_trips_through_model_dump(self):
+        req = ChatCompletionRequest(**self._MIN_REQ, recover_unclosed_reasoning=True)
+        # Pydantic v2 model_dump() / json round-trip preserves the field.
+        as_dict = req.model_dump()
+        self.assertIn("recover_unclosed_reasoning", as_dict)
+        self.assertTrue(as_dict["recover_unclosed_reasoning"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #22780

## Summary

This PR fixes a bug in the EAGLE3 speculative decoding path where target-side execution can observe draft-side runtime configuration inside the same scheduler process.

This can break MLA target models such as `Kimi-K2.5` and eventually cause crashes like:

```text
AssertionError
...
assert not get_global_server_args().disable_chunked_prefix_cache
```

The investigation and local validation for this fix were done with the help of Codex.

## Root cause

The target model (`kimi_k25`) and the EAGLE3 draft model (`LlamaForCausalLMEagle3`) use different attention architectures.

- target model: MLA
- draft model: non-MLA

During draft worker initialization, `ModelRunner.model_specific_adjustment()` may set:

```python
server_args.disable_chunked_prefix_cache = True
```

The investigation showed two layers of the problem:

1. The draft worker could overwrite target-side settings when the same `ServerArgs` object was reused.
2. Even after isolating the draft worker with a copied `ServerArgs`, runtime forward paths still relied on `get_global_server_args()`, so target execution could still read draft-side configuration if the active process-global state was left pointing at the draft side.

Later, the target model could enter the chunked prefix cache path and hit a hard assertion because target execution was reading the wrong process-global runtime configuration.

## Fix

This PR applies a scoped fix in `eagle_worker_v2.py`:

- keep draft and target `ServerArgs` isolated
- restore the correct target-side global runtime configuration before entering target execution paths
- restore the correct draft-side global runtime configuration before entering draft execution paths

With this change:

- the draft worker can still apply its own model-specific adjustments
- those settings remain local to the draft side
- target execution runs with target-side global configuration
- draft execution runs with draft-side global configuration
- `disable_chunked_prefix_cache` is no longer incorrectly observed from the wrong side during target execution

## Why this is the minimal fix

The deeper architectural issue is that some runtime forward paths still depend on process-global `ServerArgs`. A broader cleanup would replace those global reads with runner-local configuration.

This PR intentionally does not attempt that larger refactor. Instead, it provides a focused and low-risk fix in `eagle_worker_v2.py` that prevents target/draft global configuration mix-ups in the observed failing path.

## User-visible impact

This prevents crashes for configurations such as:

- `Kimi-K2.5`
- `EAGLE3`
- long context
- high KV-cache pressure

In particular, it fixes the case where `kv cache full` is followed by a later assertion in the FlashAttention chunked-prefix path.[](url)

I use Codex to help prepare and verify the fix during local debugging.

