### PR TITLE
[HiCache]Fix CP support for hybrid model 

### DIFF
--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -162,6 +162,8 @@ class HybridCacheController(BaseHiCacheController):
         storage_backend_extra_config: Optional[dict] = None,
         pp_rank: int = 0,
         pp_size: int = 1,
+        attn_cp_rank: int = 0,
+        attn_cp_size: int = 1,
         transfer_layer_num: Optional[int] = None,
         enable_storage_metrics: bool = False,
     ):
@@ -180,6 +182,8 @@ class HybridCacheController(BaseHiCacheController):
             storage_backend_extra_config=storage_backend_extra_config,
             pp_rank=pp_rank,
             pp_size=pp_size,
+            attn_cp_rank=attn_cp_rank,
+            attn_cp_size=attn_cp_size,
             enable_storage_metrics=enable_storage_metrics,
         )
         # Override layer_num: hybrid models transfer all layers (For example, Linear Model (KV + Mamba)),

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -92,6 +92,8 @@ def build_nsa_hybrid_stack(
             storage_backend_extra_config=extra_config,
             pp_rank=radix_cache.pp_rank,
             pp_size=radix_cache.pp_size,
+            attn_cp_rank=params.attn_cp_rank,
+            attn_cp_size=params.attn_cp_size,
             transfer_layer_num=layer_num,
             enable_storage_metrics=enable_storage_metrics,
         )
@@ -190,6 +192,8 @@ def build_mamba_hybrid_stack(
             storage_backend_extra_config=extra_config,
             pp_rank=params.pp_rank,
             pp_size=params.pp_size,
+            attn_cp_rank=params.attn_cp_rank,
+            attn_cp_size=params.attn_cp_size,
             transfer_layer_num=transfer_layer_num,
             enable_storage_metrics=enable_storage_metrics,
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
mmlu
```
#python3 -m sglang.test.run_eval \
> --port 8188 \
> --eval-name mmlu \
> --num-examples 1369 \
> --num-threads 64 \
> --chat-template-kwargs '{"enable_thinking": false}'
ChatCompletionSampler initialized with self.system_message=None self.temperature=0.0 self.max_tokens=2048 self.reasoning_effort=None self.extra_body={'chat_template_kwargs': {'enable_thinking': False}}
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1369/1369 [04:15<00:00,  5.36it/s]
Total latency: 255.454 s
Score: 0.844
Output throughput: 3168.584 token/s
[METRIC] mmlu_score=0.8444119795471147 labels={"model": "/root/.cache/modelscope/hub/models/Qwen/Qwen3.5-9B", "eval": "mmlu"}
[METRIC] mmlu_latency=255.4541785158217 labels={"model": "/root/.cache/modelscope/hub/models/Qwen/Qwen3.5-9B", "eval": "mmlu"}
Writing report to /tmp/mmlu__root_.cache_modelscope_hub_models_Qwen_Qwen3.5-9B.html
{'other': np.float64(0.857566765578635), 'other:std': np.float64(0.34949393149757757), 'score:std': np.float64(0.36246432699568915), 'stem': np.float64(0.9220338983050848), 'stem:std': np.float64(0.26811823638352794), 'humanities': np.float64(0.755011135857461), 'humanities:std': np.float64(0.4300805977821919), 'social_sciences': np.float64(0.8888888888888888), 'social_sciences:std': np.float64(0.3142696805273545), 'score': np.float64(0.8444119795471147), 'latency': 255.4541785158217, 'output_throughput': 3168.5839108318505}
Writing results to /tmp/mmlu__root_.cache_modelscope_hub_models_Qwen_Qwen3.5-9B.json

[root@gpulingjun010013003162.et117 /home/shenghai.htw]
#python3 -m sglang.srt.mem_cache.flush_cache --url http://localhost:8188

[root@gpulingjun010013003162.et117 /home/shenghai.htw]
#python3 -m sglang.test.run_eval --port 8188 --eval-name mmlu --num-examples 1369 --num-threads 64 --chat-template-kwargs '{"enable_thinking": false}'
ChatCompletionSampler initialized with self.system_message=None self.temperature=0.0 self.max_tokens=2048 self.reasoning_effort=None self.extra_body={'chat_template_kwargs': {'enable_thinking': False}}
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1369/1369 [04:01<00:00,  5.66it/s]
Total latency: 241.979 s
Score: 0.847
Output throughput: 3365.292 token/s
[METRIC] mmlu_score=0.8473338203067933 labels={"model": "/root/.cache/modelscope/hub/models/Qwen/Qwen3.5-9B", "eval": "mmlu"}
[METRIC] mmlu_latency=241.9789794124663 labels={"model": "/root/.cache/modelscope/hub/models/Qwen/Qwen3.5-9B", "eval": "mmlu"}
Writing report to /tmp/mmlu__root_.cache_modelscope_hub_models_Qwen_Qwen3.5-9B.html
{'other': np.float64(0.857566765578635), 'other:std': np.float64(0.34949393149757757), 'score:std': np.float64(0.359665424069493), 'stem': np.float64(0.9288135593220339), 'stem:std': np.float64(0.25713601720017465), 'humanities': np.float64(0.7616926503340757), 'humanities:std': np.float64(0.42604806860391603), 'social_sciences': np.float64(0.8854166666666666), 'social_sciences:std': np.float64(0.318518434404597), 'score': np.float64(0.8473338203067933), 'latency': 241.9789794124663, 'output_throughput': 3365.2923157921514}
Writing results to /tmp/mmlu__root_.cache_modelscope_hub_models_Qwen_Qwen3.5-9B.json
```

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
