### PR TITLE
fix(moe): add EP expert filtering to weight_loader_fused

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -943,6 +943,13 @@ class FusedMoE(torch.nn.Module):
         SHARD_ID_TO_SHARDED_DIM = {"w13": 1, "w2": 2}
         SHARD_ID_TO_SHARDED_DIM_TRANSPOSE = {"w13": 2, "w2": 1}
 
+        # Narrow to local experts for EP (mirrors weight_loader's
+        # _map_global_expert_id_to_local_expert_id filtering)
+        if self.moe_ep_size > 1:
+            loaded_weight = loaded_weight.narrow(
+                0, self.moe_ep_rank * self._num_local_routed, self._num_local_routed
+            )
+
         expert_data = param.data
         is_bias = expert_data.dim() == 2
 


### PR DESCRIPTION
## Motivation

`weight_loader_fused` loads all experts as a fused tensor (shape `[num_experts, ...]`) but does not narrow to local experts when EP > 1. This causes a tensor size mismatch crash:

```
RuntimeError: The size of tensor a (16) must match the size of tensor b (128) at non-singleton dimension 0
```

Reproduce: `sglang serve --model-path lmsys/gpt-oss-120b-bf16 --tp 8 --ep 8`

## Fix

Add EP expert filtering in `weight_loader_fused`, mirroring how the per-expert `weight_loader` path already handles this via `_map_global_expert_id_to_local_expert_id`. The narrow is applied on dim 0 of `loaded_weight` before TP sharding.

## Notes

- The per-expert `weight_loader` (used by DeepSeek models) is not affected — it already filters via `_map_global_expert_id_to_local_expert_id`.
- Only models using `weight_loader_fused` (gpt-oss) are affected.
- Tested with `lmsys/gpt-oss-120b-bf16 --tp 8 --ep 8` on 8x H200.

Fixes #22784