### PR TITLE
[Gateway] Bump llm-tokenizer to 1.1.0 to fix HF_TOKEN authentication

### DIFF
--- a/sgl-model-gateway/Cargo.toml
+++ b/sgl-model-gateway/Cargo.toml
@@ -78,7 +78,7 @@ anyhow = "1.0"
 reasoning-parser = "=1.0.0"
 openai-protocol = { version = "=1.0.0", features = ["axum"] }
 tool-parser = "=1.0.0"
-llm-tokenizer = "=1.0.0"
+llm-tokenizer = "=1.1.0"
 smg-auth = "=1.0.0"
 wfaas = "=1.0.0"
 data-connector = "=1.0.0"


### PR DESCRIPTION
## Motivation

The gateway fails to download tokenizers from private/gated HuggingFace repositories with `401 Unauthorized`, even when `HF_TOKEN` is set as an environment variable. This breaks cache-aware routing for any model using a private tokenizer, as the gateway silently falls back to round-robin without the tokenizer. This was fixed in llm-tokenizer v1.1.0 via [lightseekorg/smg#192](https://github.com/lightseekorg/smg/pull/192).

Fixes #22803

## Modifications

Bump llm-tokenizer from `"=1.0.0"` to `"=1.1.0"` in `sgl-model-gateway/Cargo.toml`.

## Accuracy Tests

Ran `cargo test`: 91 passed, 1 failed (pre-existing redis test failure, unrelated).
