### PR TITLE
[NVIDIA] Relax previous restraints for using flashinfer gdn decode

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2188,19 +2188,6 @@ class ServerArgs:
                 not self.enable_mamba_extra_buffer()
             ), f"mamba extra_buffer is not supported for {model_arch} model"
 
-        # FlashInfer GDN decode is incompatible with no_buffer scheduling.
-        # See https://github.com/sgl-project/sglang/issues/20791
-        if (
-            self.linear_attn_decode_backend == "flashinfer"
-            and self.mamba_scheduler_strategy == "no_buffer"
-        ):
-            raise ValueError(
-                "FlashInfer GDN decode (--linear-attn-decode-backend flashinfer) is not "
-                "compatible with --mamba-scheduler-strategy no_buffer. "
-                "Please use --mamba-scheduler-strategy extra_buffer instead. "
-                "See https://github.com/sgl-project/sglang/issues/20791"
-            )
-
         if self.enable_mamba_extra_buffer():  # extra_buffer
             if self.disable_radix_cache:
                 raise ValueError(

--- a/test/registered/4-gpu-models/test_qwen35_models.py
+++ b/test/registered/4-gpu-models/test_qwen35_models.py
@@ -29,15 +29,11 @@ ACC_THRESHOLDS = {QWEN35_FP4_MODEL: {"gsm8k": 0.95}}
 
 class TestQwen35FP4(CustomTestCase):
     def test_gsm8k(self):
-        base_args = [
+        common_args = [
             "--tp-size",
             "4",
             "--chunked-prefill-size",
             "2048",
-            "--mamba-scheduler-strategy",
-            "extra_buffer",
-            "--mamba-track-interval",
-            "128",
             "--mamba-ssm-dtype",
             "bfloat16",
             "--max-running-requests",
@@ -51,19 +47,35 @@ class TestQwen35FP4(CustomTestCase):
             "--model-loader-extra-config",
             '{"enable_multithread_load": true,"num_threads": 64}',
         ]
+        extra_buffer_args = common_args + [
+            "--mamba-scheduler-strategy",
+            "extra_buffer",
+            "--mamba-track-interval",
+            "128",
+        ]
+        no_buffer_args = common_args + [
+            "--mamba-scheduler-strategy",
+            "no_buffer",
+        ]
 
         variants = [
             ModelLaunchSettings(
                 QWEN35_FP4_MODEL,
-                extra_args=base_args,
+                extra_args=extra_buffer_args,
                 variant="Triton",
             ),
-            # TODO: Fix this and re-enable it
-            # ModelLaunchSettings(
-            #     QWEN35_FP4_MODEL,
-            #     extra_args=base_args + ["--linear-attn-decode-backend", "flashinfer"],
-            #     variant="FlashInfer",
-            # ),
+            ModelLaunchSettings(
+                QWEN35_FP4_MODEL,
+                extra_args=extra_buffer_args
+                + ["--linear-attn-decode-backend", "flashinfer"],
+                variant="FlashInfer",
+            ),
+            ModelLaunchSettings(
+                QWEN35_FP4_MODEL,
+                extra_args=no_buffer_args
+                + ["--linear-attn-decode-backend", "flashinfer"],
+                variant="FlashInfer-NoBuffer",
+            ),
         ]
 
         run_combined_tests(


### PR DESCRIPTION
The combination of `--linear-attn-decode-backend flashinfer` and `--mamba-scheduler-strategy no_buffer` was previously blocked with a hard ValueError in `server_args.py`. The root cause was a bug in the FlashInfer bf16 CuTe-DSL kernel (SM100+/Blackwell): CUDA graph decode uses padded batches where padding slots have initial_state_indices = -1, but the kernel had no guard for negative indices. Now the flashinfer side has fixed it (https://github.com/flashinfer-ai/flashinfer/pull/2810, and later https://github.com/flashinfer-ai/flashinfer/pull/2679).

Also added tests and got the results below on 8xB200:
```
============================================================
Qwen3.5-397B-A17B-NVFP4 Results Summary
Dataset: gsm8k
Baseline: 0.95
============================================================

Model 1: nvidia/Qwen3.5-397B-A17B-NVFP4
  Accuracy: PASS
  Score: 0.990

Model 2: nvidia/Qwen3.5-397B-A17B-NVFP4
  Accuracy: PASS
  Score: 0.990

Model 3: nvidia/Qwen3.5-397B-A17B-NVFP4
  Accuracy: PASS
  Score: 0.995

============================================================
OVERALL: ALL TESTS PASSED
============================================================

.
----------------------------------------------------------------------
Ran 1 test in 940.944s

OK
```
