### PR TITLE
[Bug Fix] Fix actor name and port collision in RayEngine for multi-replica deployments

### DIFF
--- a/python/sglang/srt/ray/engine.py
+++ b/python/sglang/srt/ray/engine.py
@@ -29,7 +29,8 @@ from sglang.srt.entrypoints.engine import (
     _compute_parallelism_ranks,
 )
 from sglang.srt.ray.scheduler_actor import SchedulerActor
-from sglang.srt.server_args import ZMQ_TCP_PORT_DELTA, PortArgs, ServerArgs
+from sglang.srt.server_args import PortArgs, ServerArgs
+from sglang.srt.utils.network import get_free_port
 
 logger = logging.getLogger(__name__)
 
@@ -126,7 +127,8 @@ class RayEngine(Engine):
         ]
 
         rank0_node_ip = engine_ip
-        dist_init_addr = f"{rank0_node_ip}:{server_args.port + ZMQ_TCP_PORT_DELTA}"
+        dist_init_port = get_free_port()
+        dist_init_addr = f"{rank0_node_ip}:{dist_init_port}"
         logger.info(f"dist_init_addr: {dist_init_addr}")
 
         scheduler_actors = []
@@ -149,7 +151,7 @@ class RayEngine(Engine):
                     actor = SchedulerActor.options(
                         num_cpus=0,
                         num_gpus=1,
-                        name=f"sglang_scheduler_rank0node={rank0_node_ip}_pp{pp_rank}_tp{tp_rank}",
+                        name=f"sglang_scheduler_rank0node={rank0_node_ip}:{dist_init_port}_pp{pp_rank}_tp{tp_rank}",
                         scheduling_strategy=PlacementGroupSchedulingStrategy(
                             placement_group=pg,
                             placement_group_bundle_index=bundle_idx,


### PR DESCRIPTION
## Motivation

When deploying multiple SGLangServer replicas on the same node via Ray Serve, two bugs cause replica initialization to fail:

1. **Actor name collision**: Named actors in `RayEngine` are keyed only on `rank0_node_ip + pp_rank + tp_rank`. When multiple replicas share the same host, they generate identical actor names, causing:

`ray.exceptions.ActorAlreadyExistsError: The name sglang_scheduler_rank0node=<IP>_pp0_tp0 is already taken.`

2. **Port collision**: The torch.distributed rendezvous port is derived from `server_args.port + ZMQ_TCP_PORT_DELTA`, which is the same across replicas on the same host, causing:

`torch.distributed.DistNetworkError: address already in use (EADDRINUSE)`

## Modifications

1. **Actor name**: Prefixed with `port{server_args.port}` — since each replica must listen on a unique HTTP port, this disambiguates actor names across replicas on the same node without requiring a UUID.

2. **Port collision**: Use `get_free_port()` to atomically grab a free OS port at `RayEngine` construction time, the same way `nccl_port` is already allocated.

## Tests

Validated on a single node with 2x A10G GPUs using Ray Serve with `min_replicas=2`, `max_replicas=2`. Both replicas initialize successfully on the same node with no actor name or port collisions.

Autoscaler and MultiNode test in progress.

![sglang-ray-multiserver](https://github.com/user-attachments/assets/df74464d-6149-47e0-afbb-5ae20b0f917d)

## Related
- Ray issue: https://github.com/ray-project/ray/issues/62480
- Ray PR: https://github.com/ray-project/ray/pull/62504