### PR TITLE
[PoC] Use Green Context SM partitioning for overlap schedule stream

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -682,6 +682,7 @@ class Scheduler(
             _,
             _,
             _,
+            self._greenctx_schedule_stream,
         ) = self.tp_worker.get_worker_info()
         if get_global_server_args().pp_max_micro_batch_size is None:
             get_global_server_args().pp_max_micro_batch_size = max(
@@ -1354,7 +1355,10 @@ class Scheduler(
         Sets up the schedule stream and dispatches to the appropriate event loop.
         The event loop blocks until shutdown.
         """
-        self.schedule_stream = self.device_module.Stream(priority=0)
+        if self._greenctx_schedule_stream is not None:
+            self.schedule_stream = self._greenctx_schedule_stream
+        else:
+            self.schedule_stream = self.device_module.Stream(priority=0)
         if self.device == "cpu":
             self.schedule_stream.synchronize = lambda: None  # No-op for CPU
         with self.device_module.StreamContext(self.schedule_stream):

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -424,6 +424,7 @@ class TpModelWorker(BaseTpWorker):
             self.model_runner.req_to_token_pool.size,
             self.model_runner.req_to_token_pool.max_context_len,
             self.model_runner.token_to_kv_pool.size,
+            self.model_runner.schedule_stream,
         )
 
     def is_dllm(self):

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -455,8 +455,11 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # Initialize MooncakeTransferEngine
         self.init_shared_mooncake_transfer_engine()
 
-        # Init forward stream for overlap schedule
-        self.forward_stream = torch.get_device_module(self.device).Stream()
+        # Init forward/schedule streams for overlap schedule.
+        # On supported GPUs, use Green Context to partition SMs so that the
+        # schedule stream always has dedicated SMs even when the forward
+        # stream runs CLC-persistent GEMM kernels that occupy all other SMs.
+        self.forward_stream, self.schedule_stream = self._create_overlap_streams()
 
         # CPU offload
         set_offloader(create_offloader_from_server_args(server_args, dp_rank=dp_rank))
@@ -975,6 +978,31 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                     f"where moe_tp_size is equal to tp_size ({self.tp_size}) divided by ep_size ({self.moe_ep_size}). "
                     f"You can fix this by setting arguments `--tp` and `--ep` correctly."
                 )
+
+    _GREENCTX_SCHEDULE_SMS = 8  # minimum partition size for CC >= 9.0
+
+    def _create_overlap_streams(self):
+        """Create forward and schedule streams, optionally with Green Context SM partitioning."""
+        device_mod = torch.get_device_module(self.device)
+        if not self.server_args.disable_overlap_schedule and self.device == "cuda":
+            try:
+                from sgl_kernel import spatial
+
+                total_sm = spatial.get_sm_available(self.gpu_id)
+                schedule_sm = self._GREENCTX_SCHEDULE_SMS
+                forward_sm = total_sm - schedule_sm
+                fwd, sched = spatial.create_greenctx_stream_by_value(
+                    forward_sm, schedule_sm, self.gpu_id
+                )
+                logger.info(
+                    "Green Context overlap streams: forward=%d SMs, schedule=%d SMs",
+                    forward_sm,
+                    schedule_sm,
+                )
+                return fwd, sched
+            except Exception as e:
+                logger.debug("Green Context unavailable, using plain streams: %s", e)
+        return device_mod.Stream(), None
 
     def init_torch_distributed(self):
         tic = time.perf_counter()


### PR DESCRIPTION
## Summary
- Use Green Context SM partitioning for overlap schedule stream to avoid schedule stream blocking by CLC-persistent GEMM on Blackwell.
- Reuse `sgl_kernel.spatial.create_greenctx_stream_by_value`; fallback to plain streams when unavailable.

## Test plan
- [ ] Verify on Blackwell: schedule stream kernels no longer blocked during forward GEMM
- [ ] Verify on Hopper: no regression