### PR TITLE
ci: fix torch CUDA major version mismatch with system toolkit

### DIFF
--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -341,11 +341,10 @@ if [ -n "$SYSTEM_CUDA_VER" ]; then
         TARGET_CU="cu$(echo "$SYSTEM_CUDA_VER" | tr -d '.')"
         TORCH_VER=$(pip show torch 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed 's/+.*//')
         echo "System CUDA major ($SYSTEM_CUDA_MAJOR) != torch CUDA major ($TORCH_CUDA_MAJOR). Reinstalling torch==${TORCH_VER} from ${TARGET_CU} index..."
-        $PIP_CMD install "torch==${TORCH_VER}+${TARGET_CU}" "torchaudio==${TORCH_VER}+${TARGET_CU}" \
-            --index-url "https://download.pytorch.org/whl/${TARGET_CU}" --force-reinstall --no-deps $PIP_INSTALL_SUFFIX
         TORCHVISION_VER=$(pip show torchvision 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed 's/+.*//')
-        $PIP_CMD install "torchvision==${TORCHVISION_VER}+${TARGET_CU}" \
-            --index-url "https://download.pytorch.org/whl/${TARGET_CU}" --force-reinstall --no-deps $PIP_INSTALL_SUFFIX
+        TORCHAUDIO_VER=$(pip show torchaudio 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed 's/+.*//')
+        $PIP_CMD install "torch==${TORCH_VER}+${TARGET_CU}" "torchaudio==${TORCHAUDIO_VER}+${TARGET_CU}" "torchvision==${TORCHVISION_VER}+${TARGET_CU}" \
+            --index-url "https://download.pytorch.org/whl/${TARGET_CU}" --force-reinstall $PIP_INSTALL_SUFFIX
         # Re-detect after reinstall
         TORCH_CUDA_VER=$(python3 -c "import torch; v=torch.version.cuda; parts=v.split('.'); print(f'cu{parts[0]}{parts[1]}')")
         echo "After fix: torch CUDA version: ${TORCH_CUDA_VER}"

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -323,13 +323,41 @@ mark_step_done "Install extra dependency"
 # ------------------------------------------------------------------------------
 # Fix other dependencies
 # ------------------------------------------------------------------------------
+# Fix torch CUDA major version mismatch with system CUDA toolkit.
+# After PR #21441 (cu130 upgrade), uv may resolve torch to a different CUDA version than the
+# container's base image (e.g. cu128 torch on CUDA 13.0 base, or cu130 torch on CUDA 12.8 base).
+# This causes dual-runtime conflicts: deep_gemm SIGFPE (multiProcessorCount=0), nvrtc builtins
+# not found, or libcublas.so.12 missing. Fix: if torch's CUDA major version doesn't match the
+# system toolkit, reinstall torch from the correct PyTorch index.
+SYSTEM_CUDA_VER=$(nvcc --version 2>/dev/null | grep -oP 'V\K[0-9]+\.[0-9]+' || echo "")
+TORCH_CUDA_VER=$(python3 -c "import torch; v=torch.version.cuda; parts=v.split('.'); print(f'cu{parts[0]}{parts[1]}')")
+echo "Detected torch CUDA version: ${TORCH_CUDA_VER}, system CUDA: ${SYSTEM_CUDA_VER}"
+
+if [ -n "$SYSTEM_CUDA_VER" ]; then
+    SYSTEM_CUDA_MAJOR=$(echo "$SYSTEM_CUDA_VER" | cut -d. -f1)
+    TORCH_CUDA_MAJOR=$(python3 -c "import torch; print(torch.version.cuda.split('.')[0])")
+    if [ "$SYSTEM_CUDA_MAJOR" != "$TORCH_CUDA_MAJOR" ]; then
+        # Derive target CU_VERSION from system CUDA (e.g. 13.0 → cu130, 12.8 → cu128)
+        TARGET_CU="cu$(echo "$SYSTEM_CUDA_VER" | tr -d '.')"
+        TORCH_VER=$(pip show torch 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed 's/+.*//')
+        echo "System CUDA major ($SYSTEM_CUDA_MAJOR) != torch CUDA major ($TORCH_CUDA_MAJOR). Reinstalling torch==${TORCH_VER} from ${TARGET_CU} index..."
+        $PIP_CMD install "torch==${TORCH_VER}+${TARGET_CU}" "torchaudio==${TORCH_VER}+${TARGET_CU}" \
+            --index-url "https://download.pytorch.org/whl/${TARGET_CU}" --force-reinstall --no-deps $PIP_INSTALL_SUFFIX
+        TORCHVISION_VER=$(pip show torchvision 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed 's/+.*//')
+        $PIP_CMD install "torchvision==${TORCHVISION_VER}+${TARGET_CU}" \
+            --index-url "https://download.pytorch.org/whl/${TARGET_CU}" --force-reinstall --no-deps $PIP_INSTALL_SUFFIX
+        # Re-detect after reinstall
+        TORCH_CUDA_VER=$(python3 -c "import torch; v=torch.version.cuda; parts=v.split('.'); print(f'cu{parts[0]}{parts[1]}')")
+        echo "After fix: torch CUDA version: ${TORCH_CUDA_VER}"
+    fi
+fi
+
 # Fix CUDA version mismatch between torch and torchaudio.
-# PyPI's torch 2.9.1 bundles cu128 but torchaudio from pytorch.org/cu129 uses cu129.
+# PyPI's torch bundles a specific CUDA version but torchaudio from pytorch.org/cu130 may use a different one.
 # This mismatch causes torchaudio's C extension to fail loading, producing:
 #   "partially initialized module 'torchaudio' has no attribute 'lib'"
-# We cannot replace torch with cu129 (breaks sgl_kernel ABI), so instead we reinstall
-# torchaudio/torchvision from an index matching torch's CUDA version.
-TORCH_CUDA_VER=$(python3 -c "import torch; v=torch.version.cuda; parts=v.split('.'); print(f'cu{parts[0]}{parts[1]}')")
+# After the system CUDA major version fix above, this handles remaining minor version mismatches
+# (e.g. torch cu129 vs CU_VERSION cu130 — same major version, different minor).
 echo "Detected torch CUDA version: ${TORCH_CUDA_VER}"
 if [ "${TORCH_CUDA_VER}" != "${CU_VERSION}" ]; then
     # Pin versions to match what was installed by pyproject.toml (strip +cuXYZ suffix)

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -273,6 +273,17 @@ else
     fi
 fi
 
+# If system CUDA is 13.x, reinstall sgl-kernel from the cu130 index.
+# The default PyPI sgl-kernel is compiled for cu12 (links against libcublas.so.12).
+# On CUDA 13.0 base images, libcublas.so.12 isn't in the system path, so sgl-kernel
+# can't load. The cu130 sgl-kernel links against libcublas.so.13 which the system provides.
+if [ -n "${SYSTEM_CUDA_MAJOR:-}" ] && [ "$SYSTEM_CUDA_MAJOR" = "13" ]; then
+    echo "System CUDA is 13.x — reinstalling sgl-kernel from cu130 index..."
+    $PIP_CMD install sglang-kernel==${SGL_KERNEL_VERSION_FROM_SRT} \
+        --index-url https://docs.sglang.ai/whl/cu130/ --force-reinstall $PIP_INSTALL_SUFFIX || \
+        echo "Warning: cu130 sgl-kernel not available, keeping cu12 version"
+fi
+
 mark_step_done "Install sglang-kernel"
 
 # ------------------------------------------------------------------------------
@@ -337,14 +348,13 @@ if [ -n "$SYSTEM_CUDA_VER" ]; then
     SYSTEM_CUDA_MAJOR=$(echo "$SYSTEM_CUDA_VER" | cut -d. -f1)
     TORCH_CUDA_MAJOR=$(python3 -c "import torch; print(torch.version.cuda.split('.')[0])")
     if [ "$SYSTEM_CUDA_MAJOR" != "$TORCH_CUDA_MAJOR" ]; then
-        # Derive target CU_VERSION from system CUDA (e.g. 13.0 → cu130, 12.8 → cu128)
-        TARGET_CU="cu$(echo "$SYSTEM_CUDA_VER" | tr -d '.')"
         TORCH_VER=$(pip show torch 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed 's/+.*//')
-        echo "System CUDA major ($SYSTEM_CUDA_MAJOR) != torch CUDA major ($TORCH_CUDA_MAJOR). Reinstalling torch==${TORCH_VER} from ${TARGET_CU} index..."
-        TORCHVISION_VER=$(pip show torchvision 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed 's/+.*//')
-        TORCHAUDIO_VER=$(pip show torchaudio 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed 's/+.*//')
-        $PIP_CMD install "torch==${TORCH_VER}+${TARGET_CU}" "torchaudio==${TORCHAUDIO_VER}+${TARGET_CU}" "torchvision==${TORCHVISION_VER}+${TARGET_CU}" \
-            --index-url "https://download.pytorch.org/whl/${TARGET_CU}" --force-reinstall $PIP_INSTALL_SUFFIX
+        # Install plain PyPI torch (cu12 RPATH layout) so sgl-kernel can find libcublas.so.12.
+        # The +cu130 wheel from pytorch.org has cu13 RPATH that breaks sgl-kernel (compiled for cu12).
+        # Plain PyPI torch reports cuda=12.8 regardless of system CUDA, which is fine for all tests
+        # except DeepEP (which needs nvcc==torch.cuda — handled by running DeepEP on CUDA 12.8 base).
+        echo "System CUDA major ($SYSTEM_CUDA_MAJOR) != torch CUDA major ($TORCH_CUDA_MAJOR). Reinstalling torch==${TORCH_VER} from PyPI (cu12 RPATH)..."
+        $PIP_CMD install "torch==${TORCH_VER}" --force-reinstall --no-deps $PIP_INSTALL_SUFFIX
         # Re-detect after reinstall
         TORCH_CUDA_VER=$(python3 -c "import torch; v=torch.version.cuda; parts=v.split('.'); print(f'cu{parts[0]}{parts[1]}')")
         echo "After fix: torch CUDA version: ${TORCH_CUDA_VER}"


### PR DESCRIPTION
## Summary
- When uv resolves torch to a different CUDA major version than the container's base image (e.g. cu128 torch on CUDA 13.0 base, or cu130 torch on CUDA 12.8 base), detect the mismatch and reinstall torch + torchaudio + torchvision from the PyTorch index matching the system CUDA version
- Prevents dual-runtime conflicts that cause deep_gemm SIGFPE (`multiProcessorCount=0`), `nvrtc: failed to open libnvrtc-builtins.so.13.0`, or `libcublas.so.12: cannot open shared object file`
- Only triggers when CUDA **major** versions differ (e.g. 12 vs 13), so cu128 torch on CUDA 12.9 base is left alone

## Root Cause
After PR #21441 (cu130 upgrade), `CU_VERSION=cu130` and `--extra-index-url .../cu130` is passed to uv. But uv may resolve torch to cu128 (on containers that already had it) or cu130 (on fresh installs). When the torch CUDA version doesn't match the base image's CUDA toolkit, two CUDA runtimes get loaded into the same process, causing various crashes.

Example failures:
- deep_gemm SIGFPE on ion-h200-4: https://github.com/sgl-project/sglang/actions/runs/24374412581/job/71185047813
- nvrtc builtins on ion-h200-1: https://github.com/sgl-project/sglang/actions/runs/24417866008/job/71333251844
- libcublas.so.12 on GMI wk03: https://github.com/sgl-project/sglang/actions/runs/24418466268/job/71367547366

## Test plan
- [ ] Verify on CUDA 13.0 base runner (GMI, ion4) with cu128 torch — should detect mismatch and reinstall as cu130
- [ ] Verify on CUDA 12.8 base runner (ion 1-GPU) with cu130 torch — should detect mismatch and reinstall as cu128
- [ ] Verify on matching system (cu130 torch on CUDA 13.0 base) — should skip, no action