### PR TITLE
[Misc] Fix version detection to use ancestor tags and strip .postN

### DIFF
--- a/python/tools/get_version_tag.py
+++ b/python/tools/get_version_tag.py
@@ -13,9 +13,17 @@ which would cause CI to build the wrong version.
 Strategy:
 1. If the current commit has an exact version tag, use it directly.
    This handles CI release builds (both stable and rc).
-2. Otherwise, find the highest version tag across all branches
-   and describe relative to it. This handles local dev installs
-   from main where release tags only exist on release branches.
+2. Otherwise, find the best tag to describe relative to:
+   a. Prefer ancestor tags (reachable from HEAD) so checking out a
+      commit between v0.5.10 and v0.5.11 reports 0.5.11.devN correctly.
+   b. Fall back to the globally highest tag via merge-base distance
+      when no ancestor tags exist (e.g., on main where release tags
+      live on separate release branches).
+3. When the chosen tag has a .postN suffix, strip it back to the base
+   release (e.g., v0.5.10.post1 -> v0.5.10). setuptools-scm's
+   guess-next-dev scheme bumps the last integer, so v0.5.10 becomes
+   0.5.11.devN (correct), whereas v0.5.10.post1 would become
+   0.5.10.post2.devN (wrong).
 """
 
 import re
@@ -87,42 +95,106 @@ def get_exact_version_tag() -> str:
     )
 
 
-def get_latest_version_tag_describe() -> str:
-    """Find the highest version tag and build a describe string relative to it.
+def strip_post_suffix(tag: str) -> str:
+    """Strip .postN suffix from a tag so setuptools-scm bumps correctly.
 
-    Uses PEP 440 version ordering so that stable releases sort above
-    pre-release tags (e.g., v0.5.10 > v0.5.10rc0).
-
-    The highest tag may live on a release branch and not be a direct
-    ancestor of HEAD (e.g., main diverged before the release tag was
-    created). In that case, we compute the commit distance from the
-    merge-base and build the describe string manually.
+    setuptools-scm's guess-next-dev increments the last integer:
+      v0.5.10       -> 0.5.11.devN   (correct)
+      v0.5.10.post1 -> 0.5.10.post2.devN  (wrong)
+    By stripping .postN we ensure the micro version gets bumped instead.
     """
-    tag = get_latest_version_tag()
-    if not tag:
-        print("WARNING: No version tags (v*.*.*) found in repo", file=sys.stderr)
-        return ""
+    return re.sub(r"\.post\d+$", "", tag)
 
-    # Fast path: tag is an ancestor of HEAD, git describe works directly
+
+def get_latest_ancestor_version_tag() -> str:
+    """Return the highest version tag that is an ancestor of HEAD.
+
+    Uses ``git tag --merged HEAD`` to restrict to reachable tags, then
+    sorts by PEP 440 ordering.  Returns empty string when no ancestor
+    tags exist (e.g., main diverged before any release tag was created).
+    """
+    tags_raw = run_git("tag", "--merged", "HEAD", "--list", "v*.*.*")
+    if not tags_raw:
+        return ""
+    tag_list = sorted(tags_raw.splitlines(), key=parse_version_tuple, reverse=True)
+    return tag_list[0] if tag_list else ""
+
+
+def _describe_from_tag(tag: str) -> str:
+    """Build a describe string relative to *tag*, stripping .postN.
+
+    If the tag is an ancestor of HEAD, uses ``git describe`` directly.
+    Otherwise computes the distance from the merge-base manually.
+
+    The .postN suffix is stripped so that setuptools-scm bumps the micro
+    version (0.5.10 -> 0.5.11.devN) instead of the post number.
+    """
+    base_tag = strip_post_suffix(tag)
+
+    # Fast path: base tag is an ancestor of HEAD
     result = run_git(
-        "describe", "--tags", "--long", "--match", tag, "HEAD", allow_failure=True
+        "describe",
+        "--tags",
+        "--long",
+        "--match",
+        base_tag,
+        "HEAD",
+        allow_failure=True,
     )
     if result:
         return result
 
-    # Tag is not an ancestor (e.g., release branch diverged from main).
+    # Tag is not an ancestor (release branch scenario).
     # Build describe string manually: {tag}-{distance}-g{hash}
     merge_base = run_git("merge-base", tag, "HEAD", allow_failure=True)
     if not merge_base:
-        print(
-            f"WARNING: No common ancestor between {tag} and HEAD. "
-            f"Is this a shallow clone? Try: git fetch --unshallow --tags",
-            file=sys.stderr,
-        )
         return ""
     distance = run_git("rev-list", "--count", f"{merge_base}..HEAD")
     short_hash = run_git("rev-parse", "--short", "HEAD")
-    return f"{tag}-{distance}-g{short_hash}"
+    return f"{base_tag}-{distance}-g{short_hash}"
+
+
+def get_latest_version_tag_describe() -> str:
+    """Find the best version tag and build a describe string relative to it.
+
+    Uses PEP 440 version ordering so that stable releases sort above
+    pre-release tags (e.g., v0.5.10 > v0.5.10rc0).
+
+    Compares the highest ancestor tag with the globally highest tag:
+    - If the ancestor IS the global highest (or equivalent after stripping
+      .postN), use the ancestor — we're on or past the latest release.
+    - If the global tag is newer, use it via merge-base distance — this is
+      the main-branch case where release tags live on release branches and
+      we want ``pip install -e`` to show the upcoming release version.
+    """
+    global_tag = get_latest_version_tag()
+    if not global_tag:
+        print("WARNING: No version tags (v*.*.*) found in repo", file=sys.stderr)
+        return ""
+
+    ancestor_tag = get_latest_ancestor_version_tag()
+
+    # Pick the tag to describe relative to.
+    # Use the ancestor tag only when it represents the latest release
+    # (i.e., no newer global tag exists). Otherwise use the global tag
+    # so main shows the next dev version correctly.
+    if ancestor_tag and parse_version_tuple(ancestor_tag) >= parse_version_tuple(
+        global_tag
+    ):
+        tag = ancestor_tag
+    else:
+        tag = global_tag
+
+    result = _describe_from_tag(tag)
+    if result:
+        return result
+
+    print(
+        f"WARNING: No common ancestor between {tag} and HEAD. "
+        f"Is this a shallow clone? Try: git fetch --unshallow --tags",
+        file=sys.stderr,
+    )
+    return ""
 
 
 def get_version_describe() -> str:

--- a/test/registered/unit/tools/test_get_version_tag.py
+++ b/test/registered/unit/tools/test_get_version_tag.py
@@ -67,6 +67,140 @@ class TestGetVersionTag(unittest.TestCase):
                 self.assertNotIn(TAG_ONLY_DESCRIBE_COMMAND, content)
                 self.assertIn(FALLBACK_VERSION, content)
 
+    def test_strip_post_suffix(self):
+        """strip_post_suffix removes .postN so setuptools-scm bumps micro."""
+        strip = self.version_helper.strip_post_suffix
+        self.assertEqual(strip("v0.5.10.post1"), "v0.5.10")
+        self.assertEqual(strip("v0.5.10.post99"), "v0.5.10")
+        self.assertEqual(strip("v0.5.10"), "v0.5.10")
+        self.assertEqual(strip("v0.5.10rc1"), "v0.5.10rc1")
+
+    def test_ancestor_tag_excludes_non_ancestor_tags(self):
+        """Highest global tag (v0.5.11) should be ignored if not an ancestor."""
+
+        def fake_run_git(*args, **kwargs):
+            # git tag --merged HEAD --list v*.*.*  →  only ancestor tags
+            if "--merged" in args:
+                return "v0.5.9\nv0.5.10\nv0.5.6"
+            return ""
+
+        with patch.object(
+            self.version_helper,
+            "run_git",
+            side_effect=fake_run_git,
+        ):
+            result = self.version_helper.get_latest_ancestor_version_tag()
+            self.assertEqual(result, "v0.5.10")
+
+    def test_describe_uses_ancestor_tag_when_it_is_latest(self):
+        """Ancestor tag used when it matches global latest, with .postN stripped."""
+        with patch.object(
+            self.version_helper,
+            "get_latest_version_tag",
+            return_value="v0.5.10",
+        ), patch.object(
+            self.version_helper,
+            "get_latest_ancestor_version_tag",
+            return_value="v0.5.10",
+        ), patch.object(
+            self.version_helper,
+            "run_git",
+            return_value="v0.5.10-5-gabcdef0",
+        ):
+            result = self.version_helper.get_latest_version_tag_describe()
+            self.assertEqual(result, "v0.5.10-5-gabcdef0")
+
+    def test_describe_strips_post_suffix_from_ancestor_tag(self):
+        """v0.5.10.post1 ancestor → describe relative to v0.5.10.
+
+        setuptools-scm will then produce 0.5.11.devN (correct),
+        not 0.5.10.post2.devN (wrong).
+        """
+        with patch.object(
+            self.version_helper,
+            "get_latest_version_tag",
+            return_value="v0.5.10.post1",
+        ), patch.object(
+            self.version_helper,
+            "get_latest_ancestor_version_tag",
+            return_value="v0.5.10.post1",
+        ), patch.object(
+            self.version_helper,
+            "run_git",
+            return_value="v0.5.10-8-gabcdef0",
+        ):
+            result = self.version_helper.get_latest_version_tag_describe()
+            # Must be v0.5.10-based, NOT v0.5.10.post1-based
+            self.assertEqual(result, "v0.5.10-8-gabcdef0")
+
+    def test_describe_uses_global_tag_on_main_with_release_branches(self):
+        """On main where release tags live on release branches, use global tag.
+
+        main's highest ancestor tag is v0.5.6.post2 but the global latest
+        is v0.5.10.post1 (on release/v0.5.10).  The global tag wins because
+        it's newer, and .postN is stripped so setuptools-scm produces
+        0.5.11.devN.
+        """
+
+        def fake_run_git(*args, **kwargs):
+            # _describe_from_tag for global v0.5.10.post1:
+            #   git describe --match v0.5.10 HEAD → fails (not ancestor)
+            if "describe" in args:
+                return ""
+            #   merge-base v0.5.10.post1 HEAD → aaa111
+            if args == ("merge-base", "v0.5.10.post1", "HEAD"):
+                return "aaa111"
+            if args == ("rev-list", "--count", "aaa111..HEAD"):
+                return "3924"
+            if args == ("rev-parse", "--short", "HEAD"):
+                return "222eda1"
+            return ""
+
+        with patch.object(
+            self.version_helper,
+            "get_latest_version_tag",
+            return_value="v0.5.10.post1",
+        ), patch.object(
+            self.version_helper,
+            "get_latest_ancestor_version_tag",
+            return_value="v0.5.6.post2",
+        ), patch.object(
+            self.version_helper,
+            "run_git",
+            side_effect=fake_run_git,
+        ):
+            result = self.version_helper.get_latest_version_tag_describe()
+            # Global v0.5.10.post1 used, .post1 stripped → v0.5.10
+            self.assertEqual(result, "v0.5.10-3924-g222eda1")
+
+    def test_describe_falls_back_to_global_tag_when_no_ancestor_tags(self):
+        """When no ancestor tags exist, fall back to globally highest tag."""
+
+        def fake_run_git(*args, **kwargs):
+            if args == ("merge-base", "v0.5.11", "HEAD"):
+                return "aaa111"
+            if args == ("rev-list", "--count", "aaa111..HEAD"):
+                return "42"
+            if args == ("rev-parse", "--short", "HEAD"):
+                return "bbb222"
+            return ""
+
+        with patch.object(
+            self.version_helper,
+            "get_latest_version_tag",
+            return_value="v0.5.11",
+        ), patch.object(
+            self.version_helper,
+            "get_latest_ancestor_version_tag",
+            return_value="",
+        ), patch.object(
+            self.version_helper,
+            "run_git",
+            side_effect=fake_run_git,
+        ):
+            result = self.version_helper.get_latest_version_tag_describe()
+            self.assertEqual(result, "v0.5.11-42-gbbb222")
+
     def test_tag_only_cli_mode_remains_available_for_callers_that_need_latest_tag(self):
         with patch.object(
             sys, "argv", ["get_version_tag.py", "--tag-only"]


### PR DESCRIPTION
## Summary

Fixes #22034

Two fixes to `python/tools/get_version_tag.py` for correct setuptools-scm version resolution:

- **Use ancestor tags (`git tag --merged HEAD`)** instead of listing all tags globally. When the ancestor tag is the latest, use it directly (fixes checkout-between-releases showing wrong version). When a newer global tag exists (main branch where release tags live on release branches), use the global tag via merge-base distance.

- **Strip `.postN` suffixes** from tags before passing to setuptools-scm. The `guess-next-dev` scheme bumps the last integer, so `v0.5.10.post1` would produce `0.5.10.post2.devN` (wrong). Stripping to `v0.5.10` lets it produce `0.5.11.devN` (correct).

## E2E Test Results

| Scenario | Script output | pip version |
|---|---|---|
| Main HEAD — `pip install -e` | `v0.5.10-358-g...` | `0.5.11.dev358+g...` |
| Exact checkout `v0.5.9` | `v0.5.9` | `0.5.9` |
| Exact checkout `v0.5.10` | `v0.5.10` | `0.5.10` |
| Exact checkout `v0.5.10.post1` | `v0.5.10.post1` | `0.5.10.post1` |
| Release branch between v0.5.10 and v0.5.10.post1 | `v0.5.10-1-g...` | `0.5.11.dev1` |
| Main branch between v0.5.10 and v0.5.10.post1 dates | `v0.5.10-31-g...` | `0.5.11.dev31` |

Before: `pip install -e` on main shows `0.5.10.post2.dev3924`
After: `pip install -e` on main shows `0.5.11.dev358`

## Test plan

- [x] Unit tests pass (10/10) — both locally and in docker on remote GPU machine
- [x] E2E `pip install -e` on main HEAD produces `0.5.11.devN`
- [x] Exact tag checkouts (v0.5.9, v0.5.10, v0.5.10.post1) return correct version
- [x] Release branch between-tags commit returns v0.5.10-based version
- [x] Main branch between-tags commit returns v0.5.10-based version
- [x] `--tag-only` mode (CI scripts) unchanged
- [x] pre-commit passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)