### PR TITLE
fix(config): Add from_dict() for Qwen3VL config classes

### DIFF
--- a/python/sglang/srt/configs/__init__.py
+++ b/python/sglang/srt/configs/__init__.py
@@ -25,6 +25,7 @@ from sglang.srt.configs.olmo3 import Olmo3Config
 from sglang.srt.configs.qwen3_5 import Qwen3_5Config, Qwen3_5MoeConfig
 from sglang.srt.configs.qwen3_asr import Qwen3ASRConfig
 from sglang.srt.configs.qwen3_next import Qwen3NextConfig
+from sglang.srt.configs.qwen3_vl import Qwen3VLConfig, Qwen3VLMoeConfig
 from sglang.srt.configs.step3_vl import (
     Step3TextConfig,
     Step3VisionEncoderConfig,
@@ -65,4 +66,6 @@ __all__ = [
     "JetVLMConfig",
     "Step3p5Config",
     "Qwen3ASRConfig",
+    "Qwen3VLConfig",
+    "Qwen3VLMoeConfig",
 ]

--- a/python/sglang/srt/configs/qwen3_5.py
+++ b/python/sglang/srt/configs/qwen3_5.py
@@ -78,6 +78,17 @@ class Qwen3_5Config(PretrainedConfig):
     }
     keys_to_ignore_at_inference = ["past_key_values"]
 
+    @classmethod
+    def from_dict(cls, config_dict, **kwargs):
+        config = super().from_dict(config_dict, **kwargs)
+        if isinstance(getattr(config, "vision_config", None), dict):
+            config.vision_config = cls.sub_configs["vision_config"](
+                **config.vision_config
+            )
+        if isinstance(getattr(config, "text_config", None), dict):
+            config.text_config = cls.sub_configs["text_config"](**config.text_config)
+        return config
+
     def __init__(
         self,
         text_config=None,
@@ -112,6 +123,55 @@ class Qwen3_5MoeVisionConfig(Qwen3_5VisionConfig):
 
 class Qwen3_5MoeTextConfig(Qwen3_5TextConfig):
     model_type = "qwen3_5_moe_text"
+    base_config_key = "text_config"
+
+    def __init__(self, **kwargs):
+        # Save MoE kwargs before calling parent, then pass them through
+        norm_topk_prob = kwargs.pop("norm_topk_prob", None)
+        decoder_sparse_step = kwargs.pop("decoder_sparse_step", None)
+        num_experts = kwargs.pop("num_experts", None)
+        num_experts_per_tok = kwargs.pop("num_experts_per_tok", None)
+        moe_intermediate_size = kwargs.pop("moe_intermediate_size", None)
+        mlp_only_layers = kwargs.pop("mlp_only_layers", None)
+        router_aux_loss_coef = kwargs.pop("router_aux_loss_coef", None)
+        shared_expert_intermediate_size = kwargs.pop(
+            "shared_expert_intermediate_size", None
+        )
+        layer_types = kwargs.pop("layer_types", None)
+        mtp_num_hidden_layers = kwargs.pop("mtp_num_hidden_layers", None)
+        mtp_use_dedicated_embeddings = kwargs.pop("mtp_use_dedicated_embeddings", None)
+        attn_output_gate = kwargs.pop("attn_output_gate", None)
+        full_attention_interval = kwargs.pop("full_attention_interval", None)
+
+        super().__init__(**kwargs)
+
+        # Assign MoE attributes after parent init
+        if norm_topk_prob is not None:
+            self.norm_topk_prob = norm_topk_prob
+        if decoder_sparse_step is not None:
+            self.decoder_sparse_step = decoder_sparse_step
+        if num_experts is not None:
+            self.num_experts = num_experts
+        if num_experts_per_tok is not None:
+            self.num_experts_per_tok = num_experts_per_tok
+        if moe_intermediate_size is not None:
+            self.moe_intermediate_size = moe_intermediate_size
+        if mlp_only_layers is not None:
+            self.mlp_only_layers = mlp_only_layers
+        if router_aux_loss_coef is not None:
+            self.router_aux_loss_coef = router_aux_loss_coef
+        if shared_expert_intermediate_size is not None:
+            self.shared_expert_intermediate_size = shared_expert_intermediate_size
+        if layer_types is not None:
+            self.layer_types = layer_types
+        if mtp_num_hidden_layers is not None:
+            self.mtp_num_hidden_layers = mtp_num_hidden_layers
+        if mtp_use_dedicated_embeddings is not None:
+            self.mtp_use_dedicated_embeddings = mtp_use_dedicated_embeddings
+        if attn_output_gate is not None:
+            self.attn_output_gate = attn_output_gate
+        if full_attention_interval is not None:
+            self.full_attention_interval = full_attention_interval
 
 
 class Qwen3_5MoeConfig(Qwen3_5Config):
@@ -120,3 +180,14 @@ class Qwen3_5MoeConfig(Qwen3_5Config):
         "vision_config": Qwen3_5MoeVisionConfig,
         "text_config": Qwen3_5MoeTextConfig,
     }
+
+    @classmethod
+    def from_dict(cls, config_dict, **kwargs):
+        config = super().from_dict(config_dict, **kwargs)
+        if isinstance(getattr(config, "vision_config", None), dict):
+            config.vision_config = cls.sub_configs["vision_config"](
+                **config.vision_config
+            )
+        if isinstance(getattr(config, "text_config", None), dict):
+            config.text_config = cls.sub_configs["text_config"](**config.text_config)
+        return config

--- a/python/sglang/srt/configs/qwen3_vl.py
+++ b/python/sglang/srt/configs/qwen3_vl.py
@@ -236,6 +236,17 @@ class Qwen3VLConfig(PretrainedConfig):
     }
     keys_to_ignore_at_inference = ["past_key_values"]
 
+    @classmethod
+    def from_dict(cls, config_dict, **kwargs):
+        config = super().from_dict(config_dict, **kwargs)
+        if isinstance(getattr(config, "vision_config", None), dict):
+            config.vision_config = cls.sub_configs["vision_config"](
+                **config.vision_config
+            )
+        if isinstance(getattr(config, "text_config", None), dict):
+            config.text_config = cls.sub_configs["text_config"](**config.text_config)
+        return config
+
     def __init__(
         self,
         text_config=None,
@@ -251,11 +262,15 @@ class Qwen3VLConfig(PretrainedConfig):
             self.vision_config = self.sub_configs["vision_config"](**vision_config)
         elif vision_config is None:
             self.vision_config = self.sub_configs["vision_config"]()
+        else:
+            self.vision_config = vision_config
 
         if isinstance(text_config, dict):
             self.text_config = self.sub_configs["text_config"](**text_config)
         elif text_config is None:
             self.text_config = self.sub_configs["text_config"]()
+        else:
+            self.text_config = text_config
 
         self.image_token_id = image_token_id
         self.video_token_id = video_token_id
@@ -543,6 +558,17 @@ class Qwen3VLMoeConfig(PretrainedConfig):
     }
     keys_to_ignore_at_inference = ["past_key_values"]
 
+    @classmethod
+    def from_dict(cls, config_dict, **kwargs):
+        config = super().from_dict(config_dict, **kwargs)
+        if isinstance(getattr(config, "vision_config", None), dict):
+            config.vision_config = cls.sub_configs["vision_config"](
+                **config.vision_config
+            )
+        if isinstance(getattr(config, "text_config", None), dict):
+            config.text_config = cls.sub_configs["text_config"](**config.text_config)
+        return config
+
     def __init__(
         self,
         text_config=None,
@@ -558,11 +584,15 @@ class Qwen3VLMoeConfig(PretrainedConfig):
             self.vision_config = self.sub_configs["vision_config"](**vision_config)
         elif vision_config is None:
             self.vision_config = self.sub_configs["vision_config"]()
+        else:
+            self.vision_config = vision_config
 
         if isinstance(text_config, dict):
             self.text_config = self.sub_configs["text_config"](**text_config)
         elif text_config is None:
             self.text_config = self.sub_configs["text_config"]()
+        else:
+            self.text_config = text_config
 
         self.image_token_id = image_token_id
         self.video_token_id = video_token_id

--- a/python/sglang/srt/utils/hf_transformers_utils.py
+++ b/python/sglang/srt/utils/hf_transformers_utils.py
@@ -87,6 +87,8 @@ from sglang.srt.configs import (
     Qwen3_5Config,
     Qwen3_5MoeConfig,
     Qwen3NextConfig,
+    Qwen3VLConfig,
+    Qwen3VLMoeConfig,
     Step3p5Config,
     Step3VLConfig,
 )
@@ -121,6 +123,8 @@ _CONFIG_REGISTRY: List[Type[PretrainedConfig]] = [
     DeepseekVLV2Config,
     Qwen3_5Config,
     Qwen3_5MoeConfig,
+    Qwen3VLConfig,
+    Qwen3VLMoeConfig,
     JetNemotronConfig,
     JetVLMConfig,
     KimiK25Config,

--- a/test/registered/unit/configs/test_qwen3_vl_config.py
+++ b/test/registered/unit/configs/test_qwen3_vl_config.py
@@ -1,0 +1,198 @@
+"""Unit tests for qwen3_vl and qwen3_5 config from_dict() handling.
+
+This tests the fix for transformers 5.5.0 compatibility where nested
+vision_config and text_config dicts need to be converted to config objects.
+"""
+
+import json
+import unittest
+
+from sglang.srt.configs.qwen3_5 import (
+    Qwen3_5Config,
+    Qwen3_5MoeConfig,
+    Qwen3_5MoeTextConfig,
+    Qwen3_5MoeVisionConfig,
+    Qwen3_5TextConfig,
+    Qwen3_5VisionConfig,
+)
+from sglang.srt.configs.qwen3_vl import (
+    Qwen3VLConfig,
+    Qwen3VLMoeConfig,
+    Qwen3VLMoeTextConfig,
+    Qwen3VLMoeVisionConfig,
+    Qwen3VLTextConfig,
+    Qwen3VLVisionConfig,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, suite="stage-a-test-cpu")
+
+
+class TestQwen3VLConfigFromDict(CustomTestCase):
+    """Test that Qwen3VLConfig.from_dict() converts nested dicts to config objects."""
+
+    def test_qwen3vl_config_dict_conversion(self):
+        """Test Qwen3VLConfig.from_dict() converts nested dicts to config objects."""
+        config_dict = {
+            "model_type": "qwen3_vl",
+            "vision_config": {
+                "hidden_size": 1152,
+                "num_heads": 16,
+                "depth": 27,
+            },
+            "text_config": {
+                "hidden_size": 4096,
+                "num_hidden_layers": 32,
+            },
+        }
+
+        config = Qwen3VLConfig.from_dict(config_dict)
+
+        # Verify types are converted
+        self.assertIsNotNone(config.vision_config)
+        self.assertIsNotNone(config.text_config)
+        self.assertNotIsInstance(config.vision_config, dict)
+        self.assertNotIsInstance(config.text_config, dict)
+
+        # Verify values are preserved
+        self.assertEqual(config.vision_config.hidden_size, 1152)
+        self.assertEqual(config.vision_config.num_heads, 16)
+        self.assertEqual(config.text_config.hidden_size, 4096)
+
+    def test_qwen3vl_config_with_object(self):
+        """Test Qwen3VLConfig handles existing config objects correctly."""
+        vision_obj = Qwen3VLVisionConfig(hidden_size=2048)
+        text_obj = Qwen3VLTextConfig(hidden_size=8192)
+
+        config = Qwen3VLConfig(vision_config=vision_obj, text_config=text_obj)
+
+        # Verify objects are preserved
+        self.assertIs(config.vision_config, vision_obj)
+        self.assertIs(config.text_config, text_obj)
+        self.assertEqual(config.vision_config.hidden_size, 2048)
+
+    def test_qwen3vl_moe_config_dict_conversion(self):
+        """Test Qwen3VLMoeConfig.from_dict() converts nested dicts."""
+        config_dict = {
+            "model_type": "qwen3_vl_moe",
+            "vision_config": {
+                "hidden_size": 1152,
+                "num_heads": 16,
+            },
+            "text_config": {
+                "hidden_size": 2048,
+                "num_experts": 60,
+            },
+        }
+
+        config = Qwen3VLMoeConfig.from_dict(config_dict)
+
+        self.assertIsInstance(config.vision_config, Qwen3VLMoeVisionConfig)
+        self.assertIsInstance(config.text_config, Qwen3VLMoeTextConfig)
+        self.assertEqual(config.vision_config.hidden_size, 1152)
+
+
+class TestQwen3_5ConfigFromDict(CustomTestCase):
+    """Test that Qwen3_5Config.from_dict() converts nested dicts to config objects."""
+
+    def test_qwen3_5_config_dict_conversion(self):
+        """Test Qwen3_5Config.from_dict() converts nested dicts."""
+        config_dict = {
+            "model_type": "qwen3_5",
+            "vision_config": {
+                "hidden_size": 1152,
+                "num_heads": 16,
+            },
+            "text_config": {
+                "hidden_size": 4096,
+                "num_hidden_layers": 32,
+            },
+        }
+
+        config = Qwen3_5Config.from_dict(config_dict)
+
+        self.assertIsInstance(config.vision_config, Qwen3_5VisionConfig)
+        self.assertIsInstance(config.text_config, Qwen3_5TextConfig)
+        self.assertEqual(config.vision_config.hidden_size, 1152)
+
+    def test_qwen3_5_moe_config_real_model(self):
+        """Test with actual Qwen3.5-122B model config."""
+        config_path = "/home/gm/projects/LLM/modelfile/qwen/Qwen3.5-122B-A10B-GPTQ-Int4/config.json"
+
+        with open(config_path) as f:
+            config_dict = json.load(f)
+
+        config = Qwen3_5MoeConfig.from_dict(config_dict)
+
+        # Verify nested configs are objects
+        self.assertIsInstance(config.vision_config, Qwen3_5MoeVisionConfig)
+        self.assertIsInstance(config.text_config, Qwen3_5MoeTextConfig)
+
+        # Verify MoE attributes are preserved
+        self.assertEqual(config.text_config.num_experts, 256)
+        self.assertEqual(config.text_config.num_experts_per_tok, 8)
+        self.assertEqual(config.text_config.moe_intermediate_size, 1024)
+        self.assertTrue(config.text_config.norm_topk_prob)
+
+        # Verify vision config
+        self.assertEqual(config.vision_config.hidden_size, 1152)
+        self.assertEqual(config.vision_config.num_heads, 16)
+
+    def test_qwen3_5_moe_text_config_attributes(self):
+        """Test Qwen3_5MoeTextConfig preserves all MoE attributes."""
+        config_dict = {
+            "model_type": "qwen3_5_moe_text",
+            "hidden_size": 3072,
+            "num_experts": 256,
+            "num_experts_per_tok": 8,
+            "moe_intermediate_size": 1024,
+            "norm_topk_prob": True,
+            "decoder_sparse_step": 1,
+            "layer_types": ["linear_attention", "full_attention"],
+        }
+
+        config = Qwen3_5MoeTextConfig(**config_dict)
+
+        self.assertEqual(config.num_experts, 256)
+        self.assertEqual(config.num_experts_per_tok, 8)
+        self.assertEqual(config.moe_intermediate_size, 1024)
+        self.assertTrue(config.norm_topk_prob)
+        self.assertEqual(config.decoder_sparse_step, 1)
+        self.assertEqual(config.layer_types, ["linear_attention", "full_attention"])
+
+
+class TestQwen3VLConfigBackwardCompatibility(CustomTestCase):
+    """Test backward compatibility with transformers 5.3.0."""
+
+    def test_qwen3vl_config_init_with_dict(self):
+        """Test __init__ with dict vision_config and text_config."""
+        config = Qwen3VLConfig(
+            vision_config={"hidden_size": 1152, "num_heads": 16},
+            text_config={"hidden_size": 4096},
+        )
+
+        self.assertIsInstance(config.vision_config, Qwen3VLVisionConfig)
+        self.assertIsInstance(config.text_config, Qwen3VLTextConfig)
+        self.assertEqual(config.vision_config.hidden_size, 1152)
+
+    def test_qwen3vl_config_init_with_none(self):
+        """Test __init__ with None creates default configs."""
+        config = Qwen3VLConfig(vision_config=None, text_config=None)
+
+        self.assertIsInstance(config.vision_config, Qwen3VLVisionConfig)
+        self.assertIsInstance(config.text_config, Qwen3VLTextConfig)
+
+    def test_qwen3vl_config_init_with_object(self):
+        """Test __init__ with config objects preserves them."""
+        vision_obj = Qwen3VLVisionConfig(hidden_size=2048)
+        text_obj = Qwen3VLTextConfig(hidden_size=8192)
+
+        config = Qwen3VLConfig(vision_config=vision_obj, text_config=text_obj)
+
+        self.assertIs(config.vision_config, vision_obj)
+        self.assertIs(config.text_config, text_obj)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fix Qwen3-VL and Qwen3.5 model loading with transformers 5.5.0+.

Transformers 5.5.0+ natively supports Qwen3-VL, causing `AutoConfig.from_pretrained()` to skip sglang's config conversion logic. This leaves nested `vision_config` and `text_config` as dicts instead of config objects.

## Modifications

| File | Changes |
|------|---------|
| `configs/__init__.py` | Export `Qwen3VLConfig`, `Qwen3VLMoeConfig` |
| `hf_transformers_utils.py` | Register in `_CONFIG_REGISTRY` |
| `configs/qwen3_vl.py` | Add `from_dict()` to `Qwen3VLConfig`, `Qwen3VLMoeConfig` |
| `configs/qwen3_5.py` | Add `from_dict()` + fix `Qwen3_5MoeTextConfig` MoE attributes |
| `test/.../test_qwen3_vl_config.py` | New file: 9 unit tests |

## Accuracy Tests

No accuracy changes - this is a config loading fix.

Verified:
- Qwen3.5-122B model loads successfully
- Unit tests: 9/9 pass

## Checklist

- [x] Format code with pre-commit
- [x] Add unit tests (9 tests)
- [x] Follow SGLang code style

## Testing

```bash
pytest test/registered/unit/configs/test_qwen3_vl_config.py -v
```

## Related Issues

Enables SGLang to work with transformers 5.5.0+ which natively supports Qwen3-VL.
