### PR TITLE
[AMD] Optimize _append_shared_to_topk_output by a single fused Triton kernel for Qwen3.5

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe_triton_kernels.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe_triton_kernels.py
@@ -1194,3 +1194,79 @@ def fused_append_shared_experts(
         num_warps=1,
     )
     return out_ids, out_weights
+
+
+@triton.jit
+def _fused_append_shared_experts_with_weights_kernel(
+    topk_ids_ptr,
+    topk_weights_ptr,
+    shared_weights_ptr,
+    out_ids_ptr,
+    out_weights_ptr,
+    N_BASE,
+    K: tl.constexpr,
+    S: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    BLOCK_S: tl.constexpr,
+):
+    pid = tl.program_id(0)
+
+    ids_row_ptr = pid * K
+    out_row_ptr = pid * (K + S)
+
+    offs_k = tl.arange(0, BLOCK_K)
+    mask_k = offs_k < K
+    ids = tl.load(topk_ids_ptr + ids_row_ptr + offs_k, mask=mask_k)
+    ws = tl.load(topk_weights_ptr + ids_row_ptr + offs_k, mask=mask_k)
+
+    tl.store(out_ids_ptr + out_row_ptr + offs_k, ids, mask=mask_k)
+    tl.store(out_weights_ptr + out_row_ptr + offs_k, ws, mask=mask_k)
+
+    offs_s = tl.arange(0, BLOCK_S)
+    mask_s = offs_s < S
+    shared_ids = tl.cast(N_BASE + offs_s, ids.dtype)
+    shared_ws = tl.load(shared_weights_ptr + pid * S + offs_s, mask=mask_s)
+
+    tl.store(out_ids_ptr + out_row_ptr + K + offs_s, shared_ids, mask=mask_s)
+    tl.store(out_weights_ptr + out_row_ptr + K + offs_s, shared_ws, mask=mask_s)
+
+
+def fused_append_shared_experts_with_weights(
+    topk_ids, topk_weights, shared_weights, num_fused_shared_experts, N=None
+):
+    """Like fused_append_shared_experts but accepts per-token shared weights tensor."""
+    assert N is not None, "N (shared expert base id) must be provided"
+    m, k = topk_ids.shape
+    s = int(num_fused_shared_experts)
+    if s <= 0:
+        return topk_ids, topk_weights
+
+    shared_weights_2d = shared_weights.to(topk_weights.dtype)
+    if shared_weights_2d.ndim == 1:
+        shared_weights_2d = shared_weights_2d.unsqueeze(-1)
+    if shared_weights_2d.shape[1] < s:
+        shared_weights_2d = shared_weights_2d.expand(m, s)
+    shared_weights_2d = shared_weights_2d.contiguous()
+
+    out_ids = torch.empty((m, k + s), dtype=topk_ids.dtype, device=topk_ids.device)
+    out_weights = torch.empty(
+        (m, k + s), dtype=topk_weights.dtype, device=topk_weights.device
+    )
+
+    block_k = triton.next_power_of_2(k)
+    block_s = triton.next_power_of_2(s)
+
+    _fused_append_shared_experts_with_weights_kernel[(m,)](
+        topk_ids,
+        topk_weights,
+        shared_weights_2d,
+        out_ids,
+        out_weights,
+        N_BASE=N,
+        K=k,
+        S=s,
+        BLOCK_K=block_k,
+        BLOCK_S=block_s,
+        num_warps=1,
+    )
+    return out_ids, out_weights

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -208,9 +208,8 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
             # n_shared_experts is not defined, but shared_expert_intermediate_size is defined, so we use 1 as the number of shared experts
             self.num_shared_experts = 1
 
-        self.enable_shared_expert_fusion = False  # default to False
+        self.enable_shared_expert_fusion = False
         if _use_aiter:
-            # enable shared expert fusion when use aiter
             self.enable_shared_expert_fusion = (
                 support_shared_expert_fusion and can_fuse_shared_expert(config)
             )
@@ -323,20 +322,17 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
         shared_weights = self._get_shared_expert_weights(hidden_states)
         if shared_weights is None:
             return topk_output
-        M = topk_output.topk_ids.shape[0]
-        shared_expert_id = self.num_experts
-        shared_ids = torch.full(
-            (M, self.num_fused_shared_experts),
-            shared_expert_id,
-            dtype=topk_output.topk_ids.dtype,
-            device=topk_output.topk_ids.device,
+
+        from sglang.srt.layers.moe.fused_moe_triton.fused_moe_triton_kernels import (
+            fused_append_shared_experts_with_weights,
         )
-        shared_weights = shared_weights.expand(M, self.num_fused_shared_experts).to(
-            topk_output.topk_weights.dtype
-        )
-        fused_topk_ids = torch.cat([topk_output.topk_ids, shared_ids], dim=-1)
-        fused_topk_weights = torch.cat(
-            [topk_output.topk_weights, shared_weights], dim=-1
+
+        fused_topk_ids, fused_topk_weights = fused_append_shared_experts_with_weights(
+            topk_output.topk_ids,
+            topk_output.topk_weights,
+            shared_weights,
+            self.num_fused_shared_experts,
+            N=self.num_experts,
         )
         return StandardTopKOutput(
             topk_weights=fused_topk_weights,

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -208,8 +208,9 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
             # n_shared_experts is not defined, but shared_expert_intermediate_size is defined, so we use 1 as the number of shared experts
             self.num_shared_experts = 1
 
-        self.enable_shared_expert_fusion = False
+        self.enable_shared_expert_fusion = False  # default to False
         if _use_aiter:
+            # enable shared expert fusion when use aiter
             self.enable_shared_expert_fusion = (
                 support_shared_expert_fusion and can_fuse_shared_expert(config)
             )


### PR DESCRIPTION
## Motivation

- `_append_shared_to_topk_output` previously used 4 separate kernel launches (2 elementwise + 2 concat) to append shared expert IDs and weights.
- This path is on the critical MoE routing path and adds avoidable launch overhead.
- Qwen3.5 requires per-token shared weights from learned `shared_expert_gate`, so the optimization must preserve token-wise weights.

## Modifications

- Added a fused Triton kernel in `python/sglang/srt/layers/moe/fused_moe_triton/fused_moe_triton_kernels.py`:
  - `_fused_append_shared_experts_with_weights_kernel`
  - `fused_append_shared_experts_with_weights(...)`
- The new helper performs all 4 operations in one kernel launch:
  - copy original `topk_ids`
  - copy original `topk_weights`
  - append shared expert IDs
  - append per-token shared expert weights
- Updated `python/sglang/srt/models/qwen2_moe.py` to replace the previous multi-op append logic with `fused_append_shared_experts_with_weights(...)`.

## Accuracy Tests

<details>
<summary>Server command</summary>

```bash
SGLANG_USE_AITER=1 python3 -m sglang.launch_server --model-path /data2/Qwen/Qwen3.5-397B-A17B-FP8/ --tp 8 --attention-backend aiter --trust-remote-code --model-loader-extra-config '{"enable_multithread_load": true}' --watchdog-timeout 1200 --mem-fraction-static 0.9 --host 0.0.0.0 --port 9000 --disable-radix-cache --enable-aiter-allreduce-fusion
```

</details>

<details>
<summary>GSM8K command</summary>

```bash
python3 benchmark/gsm8k/bench_sglang.py --num-questions 1319 --parallel 1319 --num-shots 5 --port 9000
```

</details>

- GSM8K accuracy is ~0.95 for both baseline and fused-kernel versions (no observable accuracy regression).

## Benchmarking and Profiling

### Serving Results

| Variant | ilen | olen | Conc | TTT (tok/s) | Median TTFT | Median TPOT | Median ITL | Median E2EL |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Fused kernel | 8192 | 8192 | 4 | 868.99 | 516.13 | 9.15 | 9.14 | 75495.40 |
| Baseline | 8192 | 8192 | 4 | 834.29 | 517.63 | 9.53 | 9.52 | 78586.48 |
| Improvement | - | - | 4 | +4.16% | +0.29% | +3.99% | +3.99% | +3.93% |
| Fused kernel | 8192 | 8192 | 8 | 1557.50 | 785.06 | 10.18 | 10.13 | 84175.86 |
| Baseline | 8192 | 8192 | 8 | 1528.04 | 784.88 | 10.37 | 10.33 | 85731.74 |
| Improvement | - | - | 8 | +1.93% | -0.02% | +1.83% | +1.94% | +1.81% |

- Improvement formula:
  - higher-is-better metric: `(candidate - baseline) / baseline * 100`
  - lower-is-better metric: `(baseline - candidate) / baseline * 100`

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

CC: @kkHuang-amd @HaiShaw 