### PR TITLE
[CI] Nightly comparison integration for vllm and lightx2v 

### DIFF
--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -670,6 +670,7 @@ jobs:
       - name: Install dependencies
         run: |
           bash scripts/ci/cuda/ci_install_dependency.sh diffusion
+          pip install slack_sdk
 
       - name: Run cross-framework comparison
         env:
@@ -703,6 +704,18 @@ jobs:
             --results comparison-results.json \
             --dashboard dashboard.md \
             --charts-dir comparison-charts
+
+      - name: Post diffusion comparison summary to Slack
+        if: always()
+        continue-on-error: true
+        env:
+          SGLANG_DIFFUSION_SLACK_TOKEN: ${{ secrets.SGLANG_DIFFUSION_SLACK_TOKEN }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+        run: |
+          python3 scripts/ci/utils/diffusion/post_diffusion_comparison_to_slack.py \
+            --results-file comparison-results.json
 
       - name: Upload comparison artifacts
         if: always()

--- a/scripts/ci/utils/diffusion/comparison_configs.json
+++ b/scripts/ci/utils/diffusion/comparison_configs.json
@@ -15,6 +15,10 @@
                 "sglang": {
                     "serve_args": "--enable-torch-compile --warmup --dit-layerwise-offload false",
                     "extra_env": {}
+                },
+                "vllm-omni": {
+                    "serve_args": "",
+                    "extra_env": {}
                 }
             }
         },
@@ -131,6 +135,12 @@
             "frameworks": {
                 "sglang": {
                     "serve_args": "--enable-torch-compile --warmup --enable-cfg-parallel --pipeline-class-name LTX2TwoStagePipeline",
+                    "extra_env": {}
+                },
+                "lightx2v": {
+                    "model_cls": "ltx2",
+                    "lightx2v_task": "t2av",
+                    "serve_args": "",
                     "extra_env": {}
                 }
             }

--- a/scripts/ci/utils/diffusion/generate_diffusion_dashboard.py
+++ b/scripts/ci/utils/diffusion/generate_diffusion_dashboard.py
@@ -235,6 +235,18 @@ def _sanitize_filename(name: str) -> str:
     return name.replace("/", "_").replace(" ", "_").replace(":", "_")
 
 
+def _framework_color(index: int) -> str:
+    palette = [
+        "#2563eb",
+        "#dc2626",
+        "#16a34a",
+        "#ea580c",
+        "#7c3aed",
+        "#0891b2",
+    ]
+    return palette[index % len(palette)]
+
+
 def generate_dashboard(
     current: dict,
     history: list[dict],
@@ -260,29 +272,6 @@ def generate_dashboard(
     current_cases = _extract_case_results(current)
     case_ids = list(current_cases.keys())
 
-    # ---- Regression detection ----
-    REGRESSION_THRESHOLD = 0.05  # 5%
-    regressions: list[str] = []
-    if history:
-        prev_cases = _extract_case_results(history[0])
-        for cid in case_ids:
-            for fw in ("sglang", "vllm-omni"):
-                cur = current_cases.get(cid, {}).get(fw)
-                prev = prev_cases.get(cid, {}).get(fw)
-                if cur and prev and prev > 0:
-                    pct = (cur - prev) / prev
-                    if pct > REGRESSION_THRESHOLD:
-                        regressions.append(
-                            f"**{cid}** ({fw}): {prev:.2f}s -> {cur:.2f}s "
-                            f"(+{pct*100:.1f}%)"
-                        )
-
-    if regressions:
-        lines.append("> [!WARNING]\n> **Performance Regression Detected**\n>")
-        for reg in regressions:
-            lines.append(f"> - {reg}")
-        lines.append("\n")
-
     # Discover all frameworks present in results
     all_frameworks = []
     seen_fw = set()
@@ -296,6 +285,29 @@ def generate_dashboard(
         all_frameworks.remove("sglang")
         all_frameworks.insert(0, "sglang")
     other_frameworks = [fw for fw in all_frameworks if fw != "sglang"]
+
+    # ---- Regression detection ----
+    REGRESSION_THRESHOLD = 0.05  # 5%
+    regressions: list[str] = []
+    if history:
+        prev_cases = _extract_case_results(history[0])
+        for cid in case_ids:
+            for fw in all_frameworks:
+                cur = current_cases.get(cid, {}).get(fw)
+                prev = prev_cases.get(cid, {}).get(fw)
+                if cur and prev and prev > 0:
+                    pct = (cur - prev) / prev
+                    if pct > REGRESSION_THRESHOLD:
+                        regressions.append(
+                            f"**{cid}** ({fw}): {prev:.2f}s -> {cur:.2f}s "
+                            f"(+{pct * 100:.1f}%)"
+                        )
+
+    if regressions:
+        lines.append("> [!WARNING]\n> **Performance Regression Detected**\n>")
+        for reg in regressions:
+            lines.append(f"> - {reg}")
+        lines.append("\n")
 
     # ---- Section 1: Cross-Framework Comparison (current run) ----
     lines.append("## Cross-Framework Performance Comparison\n")
@@ -347,26 +359,28 @@ def generate_dashboard(
 
     # ---- Section 2: Cross-Framework Speedup Trend (only if multiple frameworks) ----
     if history and other_frameworks:
-        lines.append("\n## SGLang vs vLLM-Omni Speedup Over Time\n")
-
-        header = "| Date |"
-        sep = "|------|"
-        for cid in case_ids:
-            header += f" {cid} |"
-            sep += "---------|"
-        lines.append(header)
-        lines.append(sep)
-
+        lines.append("\n## SGLang Speedup Over Time\n")
         all_runs = [current] + history
-        for run in all_runs:
-            run_cases = _extract_case_results(run)
-            date = _short_date(run.get("timestamp", ""))
-            row = f"| {date} |"
+
+        for competitor in other_frameworks:
+            lines.append(f"\n### SGLang vs {competitor}\n")
+            header = "| Date |"
+            sep = "|------|"
             for cid in case_ids:
-                sg = run_cases.get(cid, {}).get("sglang")
-                vl = run_cases.get(cid, {}).get("vllm-omni")
-                row += f" {_fmt_speedup(sg, vl)} |"
-            lines.append(row)
+                header += f" {cid} |"
+                sep += "---------|"
+            lines.append(header)
+            lines.append(sep)
+
+            for run in all_runs:
+                run_cases = _extract_case_results(run)
+                date = _short_date(run.get("timestamp", ""))
+                row = f"| {date} |"
+                for cid in case_ids:
+                    sg = run_cases.get(cid, {}).get("sglang")
+                    comp = run_cases.get(cid, {}).get(competitor)
+                    row += f" {_fmt_speedup(sg, comp)} |"
+                lines.append(row)
 
     # ---- Section 4: Matplotlib Trend Charts (saved as PNG files) ----
     if history and charts_dir:
@@ -388,68 +402,50 @@ def generate_dashboard(
             # Per-case latency trend charts
             for cid in case_ids:
                 labels = []
-                sg_vals = []
-                vl_vals = []
+                fw_vals: dict[str, list[float | None]] = {
+                    fw: [] for fw in all_frameworks
+                }
                 for run in all_runs:
                     run_cases = _extract_case_results(run)
                     sg = run_cases.get(cid, {}).get("sglang")
-                    vl = run_cases.get(cid, {}).get("vllm-omni")
                     if sg is None:
                         continue
                     labels.append(_chart_label(run))
-                    sg_vals.append(sg)
-                    vl_vals.append(vl)
+                    for fw in all_frameworks:
+                        fw_vals[fw].append(run_cases.get(cid, {}).get(fw))
 
-                if not sg_vals:
+                if not fw_vals.get("sglang"):
                     continue
 
-                has_vl = any(v is not None for v in vl_vals)
                 fig, ax = plt.subplots(figsize=(max(6, len(labels) * 1.2), 4))
 
-                # SGLang line
-                ax.plot(
-                    range(len(sg_vals)),
-                    sg_vals,
-                    "o-",
-                    color="#2563eb",
-                    linewidth=2,
-                    markersize=6,
-                    label="SGLang",
-                )
-                for i, v in enumerate(sg_vals):
-                    ax.annotate(
-                        f"{v:.2f}s",
-                        (i, v),
-                        textcoords="offset points",
-                        xytext=(0, 10),
-                        ha="center",
-                        fontsize=8,
-                        fontweight="bold",
-                        color="#2563eb",
-                    )
-
-                # vLLM-Omni line (if data exists)
-                if has_vl:
-                    vl_clean = [v if v is not None else float("nan") for v in vl_vals]
+                all_vals: list[float] = []
+                for fw_idx, fw in enumerate(all_frameworks):
+                    vals = fw_vals[fw]
+                    if not any(v is not None for v in vals):
+                        continue
+                    clean = [v if v is not None else float("nan") for v in vals]
+                    color = _framework_color(fw_idx)
                     ax.plot(
-                        range(len(vl_clean)),
-                        vl_clean,
-                        "s--",
-                        color="#dc2626",
+                        range(len(clean)),
+                        clean,
+                        "o-",
+                        color=color,
                         linewidth=2,
                         markersize=5,
-                        label="vLLM-Omni",
+                        label=fw,
                     )
-                    for i, v in enumerate(vl_vals):
+                    for i, v in enumerate(vals):
                         if v is not None:
+                            all_vals.append(v)
                             ax.annotate(
                                 f"{v:.2f}s",
                                 (i, v),
                                 textcoords="offset points",
-                                xytext=(0, -14),
+                                xytext=(0, 8 if fw == "sglang" else -12),
                                 ha="center",
-                                fontsize=8,
-                                color="#dc2626",
+                                fontsize=7,
+                                color=color,
                             )
 
                 ax.set_xticks(range(len(labels)))
@@ -458,7 +454,6 @@ def generate_dashboard(
                 ax.set_title(f"Latency Trend -- {cid}", fontsize=11, fontweight="bold")
                 ax.legend(loc="lower right", fontsize=8, framealpha=0.8)
                 ax.grid(True, alpha=0.3)
-                all_vals = sg_vals + [v for v in vl_vals if v is not None]
                 y_min = min(all_vals)
                 y_max = max(all_vals)
                 y_range = y_max - y_min if y_max > y_min else max(y_max * 0.1, 0.1)
@@ -477,28 +472,26 @@ def generate_dashboard(
                 lines.append(f"\n### Latency Trend: {cid}\n")
                 lines.append(f"![Latency Trend {cid}]({chart_url})\n")
 
-            # Speedup trend chart (only if multiple frameworks)
-            if other_frameworks:
+            # Speedup trend chart per competitor (only if multiple frameworks)
+            for competitor in other_frameworks:
                 fig, ax = plt.subplots(figsize=(max(6, len(all_runs) * 1.2), 4))
-                colors = ["#2563eb", "#dc2626", "#16a34a", "#ea580c"]
+                run_labels = [_chart_label(run) for run in all_runs]
                 for ci_idx, cid in enumerate(case_ids):
                     speedups = []
-                    run_labels = []
                     for run in all_runs:
                         run_cases = _extract_case_results(run)
                         sg = run_cases.get(cid, {}).get("sglang")
-                        vl = run_cases.get(cid, {}).get("vllm-omni")
-                        if sg and vl and sg > 0:
-                            speedups.append(vl / sg)
+                        comp = run_cases.get(cid, {}).get(competitor)
+                        if sg and comp and sg > 0:
+                            speedups.append(comp / sg)
                         else:
                             speedups.append(None)
-                        run_labels.append(_chart_label(run))
                     clean = [v if v is not None else float("nan") for v in speedups]
                     ax.plot(
                         range(len(clean)),
                         clean,
                         "o-",
-                        color=colors[ci_idx % len(colors)],
+                        color=_framework_color(ci_idx),
                         linewidth=2,
                         markersize=5,
                         label=cid,
@@ -508,21 +501,23 @@ def generate_dashboard(
                 ax.set_xticklabels(run_labels, fontsize=7)
                 ax.set_ylabel("Speedup (x)")
                 ax.set_title(
-                    "SGLang Speedup Over vLLM-Omni", fontsize=11, fontweight="bold"
+                    f"SGLang Speedup Over {competitor}",
+                    fontsize=11,
+                    fontweight="bold",
                 )
                 ax.axhline(y=1.0, color="gray", linestyle=":", alpha=0.5)
                 ax.legend(loc="upper left", fontsize=7)
                 ax.grid(True, alpha=0.3)
 
-                filename = "speedup_trend.png"
+                filename = f"speedup_trend_{_sanitize_filename(competitor)}.png"
                 chart_path = os.path.join(charts_dir, filename)
                 fig.savefig(chart_path, format="png", dpi=120, bbox_inches="tight")
                 plt.close(fig)
                 print(f"  Saved chart: {chart_path}")
 
                 chart_url = f"{CHARTS_RAW_BASE_URL}/{filename}"
-                lines.append("\n### Speedup Trend (SGLang vs vLLM-Omni)\n")
-                lines.append(f"![Speedup Trend]({chart_url})\n")
+                lines.append(f"\n### Speedup Trend (SGLang vs {competitor})\n")
+                lines.append(f"![Speedup Trend {competitor}]({chart_url})\n")
 
         except ImportError:
             lines.append("\n*Charts unavailable (matplotlib not installed)*\n")

--- a/scripts/ci/utils/diffusion/post_diffusion_comparison_to_slack.py
+++ b/scripts/ci/utils/diffusion/post_diffusion_comparison_to_slack.py
@@ -61,7 +61,9 @@ def _build_case_rows(results: list[dict]) -> list[str]:
         suffix = ""
         sglang = valid.get("sglang")
         if sglang is not None:
-            slower = [fw for fw, lat in valid.items() if fw != "sglang" and sglang > lat]
+            slower = [
+                fw for fw, lat in valid.items() if fw != "sglang" and sglang > lat
+            ]
             if slower:
                 suffix = f" | :warning: slower than {', '.join(sorted(slower))}"
         rows.append(
@@ -144,7 +146,9 @@ def post_diffusion_comparison_to_slack(results_file: str) -> bool:
         chunk = ""
         for row in body_lines:
             if len(chunk) + len(row) + 1 > 3800:
-                client.chat_postMessage(channel=channel, thread_ts=thread_ts, text=chunk)
+                client.chat_postMessage(
+                    channel=channel, thread_ts=thread_ts, text=chunk
+                )
                 chunk = row
             else:
                 chunk = f"{chunk}\n{row}" if chunk else row

--- a/scripts/ci/utils/diffusion/post_diffusion_comparison_to_slack.py
+++ b/scripts/ci/utils/diffusion/post_diffusion_comparison_to_slack.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Post diffusion cross-framework comparison summary to Slack.
+
+Reads ``comparison-results.json`` produced by ``run_comparison.py`` and posts a
+compact summary message to a Slack channel.
+"""
+
+import argparse
+import importlib
+import json
+import logging
+import os
+from datetime import datetime
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Diffusion CI channel.
+SLACK_CHANNEL_ID = "C0A02NDF7UY"
+
+# Published dashboard location in sglang-ci-data.
+DASHBOARD_URL = (
+    "https://github.com/sglang-bot/sglang-ci-data/blob/main/"
+    "diffusion-comparisons/dashboard.md"
+)
+
+
+def _short_sha(sha: str) -> str:
+    if not sha or sha == "unknown":
+        return "unknown"
+    return sha[:7]
+
+
+def _build_case_rows(results: list[dict]) -> list[str]:
+    """Build per-case summary rows for Slack."""
+    by_case: dict[str, dict[str, float | None]] = {}
+    case_errors: dict[str, dict[str, str]] = {}
+    for item in results:
+        cid = item.get("case_id", "unknown-case")
+        fw = item.get("framework", "unknown-fw")
+        by_case.setdefault(cid, {})[fw] = item.get("latency_s")
+        if item.get("error"):
+            case_errors.setdefault(cid, {})[fw] = str(item["error"])
+
+    rows: list[str] = []
+    for cid in sorted(by_case.keys()):
+        lat_map = by_case[cid]
+        err_map = case_errors.get(cid, {})
+        valid = {fw: lat for fw, lat in lat_map.items() if lat is not None}
+
+        if not valid:
+            details = []
+            for fw in sorted(lat_map.keys()):
+                err = err_map.get(fw, "N/A")
+                details.append(f"{fw}=ERR({err[:60]})")
+            rows.append(f"- `{cid}`: {' | '.join(details)}")
+            continue
+
+        fastest_fw, fastest_lat = min(valid.items(), key=lambda kv: kv[1])
+        parts = [f"{fw}={lat:.2f}s" for fw, lat in sorted(valid.items())]
+        suffix = ""
+        sglang = valid.get("sglang")
+        if sglang is not None:
+            slower = [fw for fw, lat in valid.items() if fw != "sglang" and sglang > lat]
+            if slower:
+                suffix = f" | :warning: slower than {', '.join(sorted(slower))}"
+        rows.append(
+            f"- `{cid}`: fastest `{fastest_fw}` {fastest_lat:.2f}s | "
+            f"{' | '.join(parts)}{suffix}"
+        )
+    return rows
+
+
+def post_diffusion_comparison_to_slack(results_file: str) -> bool:
+    """Post comparison summary to Slack."""
+    token = os.environ.get("SGLANG_DIFFUSION_SLACK_TOKEN")
+    if not token:
+        logger.info("Slack post skipped: no SGLANG_DIFFUSION_SLACK_TOKEN")
+        return True
+
+    WebClient = importlib.import_module("slack_sdk").WebClient
+
+    channel = os.environ.get("SGLANG_DIFFUSION_SLACK_CHANNEL_ID", SLACK_CHANNEL_ID)
+
+    result_missing = not os.path.exists(results_file)
+    if result_missing:
+        payload = {
+            "timestamp": "",
+            "commit_sha": os.environ.get("GITHUB_SHA", "unknown"),
+            "results": [],
+        }
+    else:
+        with open(results_file) as f:
+            payload = json.load(f)
+
+    results = payload.get("results", [])
+    timestamp = payload.get("timestamp", "")
+    sha = payload.get("commit_sha", "unknown")
+    run_id = os.environ.get("GITHUB_RUN_ID", "")
+    repo = os.environ.get("GITHUB_REPOSITORY", "sgl-project/sglang")
+    server_url = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+    run_url = f"{server_url}/{repo}/actions/runs/{run_id}" if run_id else ""
+
+    rows = _build_case_rows(results)
+    failed_entries = sum(1 for r in results if r.get("latency_s") is None)
+    has_failure = result_missing or failed_entries > 0
+    status_emoji = ":red_circle:" if has_failure else ":large_green_circle:"
+    color = "danger" if has_failure else "good"
+
+    lines = [
+        f"{status_emoji} *Diffusion cross-framework comparison*",
+        f"Commit: `{_short_sha(sha)}`",
+        f"Timestamp: `{timestamp}`" if timestamp else "",
+        f"Run: <{run_url}|GitHub Actions>" if run_url else "",
+        f"Dashboard: <{DASHBOARD_URL}|latest dashboard>",
+        f"Results: total `{len(results)}`, failed `{failed_entries}`",
+        f":warning: Results file missing: `{results_file}`" if result_missing else "",
+        "",
+        "*Case Summary*",
+        *(rows or ["- No comparison results found."]),
+    ]
+    text = "\n".join([line for line in lines if line])
+
+    # Slack message text limit safety.
+    if len(text) > 3900:
+        head = "\n".join(lines[:7])
+        body_lines = rows
+        text = head
+        client = WebClient(token=token, timeout=60)
+        resp = client.chat_postMessage(
+            channel=channel,
+            text=text,
+            attachments=[
+                {
+                    "color": color,
+                    "footer": f"SGLang diffusion comparison | {datetime.now().isoformat(timespec='seconds')}",
+                    "ts": int(datetime.now().timestamp()),
+                }
+            ],
+        )
+        thread_ts = resp.get("ts")
+        if not thread_ts:
+            return True
+        chunk = ""
+        for row in body_lines:
+            if len(chunk) + len(row) + 1 > 3800:
+                client.chat_postMessage(channel=channel, thread_ts=thread_ts, text=chunk)
+                chunk = row
+            else:
+                chunk = f"{chunk}\n{row}" if chunk else row
+        if chunk:
+            client.chat_postMessage(channel=channel, thread_ts=thread_ts, text=chunk)
+        return True
+
+    client = WebClient(token=token, timeout=60)
+    client.chat_postMessage(
+        channel=channel,
+        text=text,
+        attachments=[
+            {
+                "color": color,
+                "footer": f"SGLang diffusion comparison | {datetime.now().isoformat(timespec='seconds')}",
+                "ts": int(datetime.now().timestamp()),
+            }
+        ],
+    )
+    logger.info("Diffusion comparison summary posted to Slack")
+    return True
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Post diffusion comparison summary to Slack"
+    )
+    parser.add_argument(
+        "--results-file",
+        type=str,
+        required=True,
+        help="Path to comparison-results.json",
+    )
+    args = parser.parse_args()
+
+    success = post_diffusion_comparison_to_slack(args.results_file)
+    raise SystemExit(0 if success else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/utils/diffusion/run_comparison.py
+++ b/scripts/ci/utils/diffusion/run_comparison.py
@@ -15,6 +15,9 @@ Usage:
 
     # Run only specific framework(s)
     python3 scripts/ci/utils/diffusion/run_comparison.py --frameworks sglang
+
+    # Cleanup installed comparison framework venvs after run
+    python3 scripts/ci/utils/diffusion/run_comparison.py --cleanup-framework-venvs
 """
 
 import argparse
@@ -45,6 +48,7 @@ HEALTH_TIMEOUT = (
 )
 REQUEST_TIMEOUT = 1200  # seconds
 GPU_CLEAR_WAIT = 15  # seconds between framework runs
+FRAMEWORK_INSTALL_TIMEOUT = 1800  # seconds (source installs can be slow)
 
 # Frameworks that need separate installation (conflict with sglang's deps)
 INSTALLABLE_FRAMEWORKS = {"vllm-omni", "lightx2v"}
@@ -54,12 +58,29 @@ _cached_ref_image: bytes | None = None
 _cached_ref_image_path: str | None = None
 
 
+def _framework_executable(executable: str, framework_bin_dir: str | None) -> str:
+    """Return framework-scoped executable path when available."""
+    if framework_bin_dir:
+        return os.path.join(framework_bin_dir, executable)
+    return executable
+
+
+def _expected_framework_bin_dir(fw_name: str) -> str | None:
+    """Return expected framework venv bin directory for installable frameworks."""
+    if fw_name not in INSTALLABLE_FRAMEWORKS:
+        return None
+    venv_root = os.environ.get("COMPARISON_VENV_ROOT", "/tmp/sglang-comparison-venvs")
+    return os.path.join(venv_root, fw_name, "bin")
+
+
 # ---------------------------------------------------------------------------
 # Server lifecycle — command builders
 # ---------------------------------------------------------------------------
 
 
-def _build_sglang_cmd(case: dict, fw_cfg: dict, port: int) -> list[str]:
+def _build_sglang_cmd(
+    case: dict, fw_cfg: dict, port: int, framework_bin_dir: str | None = None
+) -> list[str]:
     cmd = [
         "sglang",
         "serve",
@@ -77,9 +98,11 @@ def _build_sglang_cmd(case: dict, fw_cfg: dict, port: int) -> list[str]:
     return cmd
 
 
-def _build_vllm_cmd(case: dict, fw_cfg: dict, port: int) -> list[str]:
+def _build_vllm_cmd(
+    case: dict, fw_cfg: dict, port: int, framework_bin_dir: str | None = None
+) -> list[str]:
     cmd = [
-        "vllm",
+        _framework_executable("vllm", framework_bin_dir),
         "serve",
         case["model"],
         "--omni",
@@ -107,19 +130,54 @@ def _resolve_hf_model_path(model_id: str) -> str:
         return model_id
 
 
-def _write_lightx2v_config(case: dict) -> str:
+def _write_lightx2v_config(case: dict, fw_cfg: dict, model_path: str) -> str:
     """Write a minimal LightX2V config JSON and return its path."""
+    guidance_scale = case.get("guidance_scale", 4.0)
     cfg = {
         "infer_steps": case.get("num_inference_steps", 50),
-        "guidance_scale": case.get("guidance_scale", 4.0),
+        "guidance_scale": guidance_scale,
         "seed": case.get("seed", 42),
     }
+    model_cls = fw_cfg.get("model_cls")
+    if model_cls == "ltx2":
+        # LTX2 scheduler requires these keys.
+        cfg["sample_shift"] = fw_cfg.get("sample_shift", [2.05, 0.95])
+        cfg["sample_guide_scale"] = fw_cfg.get("sample_guide_scale", guidance_scale)
+        # LTX2 runner accesses config["fps"] directly when deriving duration.
+        # Use case fps when provided; otherwise use the runner's common default.
+        cfg["fps"] = case.get("fps", fw_cfg.get("fps", 24))
+        # LTX2 runner also directly indexes audio config keys. Set stable
+        # defaults to avoid runtime KeyError when framework internals omit them.
+        cfg["audio_mel_bins"] = fw_cfg.get("audio_mel_bins", 16)
+        cfg["audio_sampling_rate"] = fw_cfg.get("audio_sampling_rate", 16000)
+        cfg["audio_hop_length"] = fw_cfg.get("audio_hop_length", 160)
+        cfg["audio_scale_factor"] = fw_cfg.get("audio_scale_factor", 4)
+        # LTX2 transformer weights require attn_type; use torch_sdpa as the
+        # most portable default when optional flash/sage kernels are absent.
+        cfg["attn_type"] = fw_cfg.get("attn_type", "torch_sdpa")
+        # Prefer a concrete checkpoint file to avoid loading metadata from a
+        # directory path (can fail on some environments/filesystems).
+        ltx_ckpt_candidates = [
+            fw_cfg.get("dit_original_ckpt"),
+            os.path.join(model_path, "ltx-2-19b-dev.safetensors"),
+            os.path.join(model_path, "ltx-2-19b-distilled.safetensors"),
+            os.path.join(model_path, "ltx-2-19b-dev-fp8.safetensors"),
+            os.path.join(model_path, "ltx-2-19b-dev-fp4.safetensors"),
+        ]
+        for ckpt in ltx_ckpt_candidates:
+            if ckpt and os.path.isfile(ckpt):
+                cfg["dit_original_ckpt"] = ckpt
+                break
+
     if "num_frames" in case:
         cfg["target_video_length"] = case["num_frames"]
     if "height" in case:
         cfg["height"] = case["height"]
+        # LTX2 runner reads target_height/target_width in request-time config.
+        cfg["target_height"] = case["height"]
     if "width" in case:
         cfg["width"] = case["width"]
+        cfg["target_width"] = case["width"]
 
     config_path = os.path.join(
         tempfile.gettempdir(), f"lightx2v_config_{case['id']}.json"
@@ -129,7 +187,13 @@ def _write_lightx2v_config(case: dict) -> str:
     return config_path
 
 
-def _build_lightx2v_cmd(case: dict, fw_cfg: dict, port: int) -> list[str]:
+def _build_lightx2v_cmd(
+    case: dict,
+    fw_cfg: dict,
+    port: int,
+    framework_bin_dir: str | None = None,
+    resolve_model_path: bool = True,
+) -> list[str]:
     """Build LightX2V server launch command.
 
     Single GPU:  python -m lightx2v.server --model_path ... --model_cls ... --task ... --port ...
@@ -140,8 +204,10 @@ def _build_lightx2v_cmd(case: dict, fw_cfg: dict, port: int) -> list[str]:
     model_cls = fw_cfg["model_cls"]
     task = fw_cfg["lightx2v_task"]
     num_gpus = case["num_gpus"]
-    model_path = _resolve_hf_model_path(case["model"])
-    config_path = _write_lightx2v_config(case)
+    model_path = (
+        _resolve_hf_model_path(case["model"]) if resolve_model_path else case["model"]
+    )
+    config_path = _write_lightx2v_config(case, fw_cfg, model_path)
 
     server_args = [
         "--model_path",
@@ -162,18 +228,29 @@ def _build_lightx2v_cmd(case: dict, fw_cfg: dict, port: int) -> list[str]:
 
     if num_gpus > 1:
         cmd = [
-            "torchrun",
+            _framework_executable("torchrun", framework_bin_dir),
             f"--nproc_per_node={num_gpus}",
             "-m",
             "lightx2v.server",
         ] + server_args
     else:
-        cmd = ["python3", "-m", "lightx2v.server"] + server_args
+        cmd = [
+            _framework_executable("python", framework_bin_dir),
+            "-m",
+            "lightx2v.server",
+        ] + server_args
 
     return cmd
 
 
-def build_server_cmd(framework: str, case: dict, fw_cfg: dict, port: int) -> list[str]:
+def build_server_cmd(
+    framework: str,
+    case: dict,
+    fw_cfg: dict,
+    port: int,
+    framework_bin_dir: str | None = None,
+    resolve_model_path: bool = True,
+) -> list[str]:
     builders = {
         "sglang": _build_sglang_cmd,
         "vllm-omni": _build_vllm_cmd,
@@ -182,7 +259,9 @@ def build_server_cmd(framework: str, case: dict, fw_cfg: dict, port: int) -> lis
     builder = builders.get(framework)
     if builder is None:
         raise ValueError(f"Unknown framework: {framework}")
-    return builder(case, fw_cfg, port)
+    if framework == "lightx2v":
+        return builder(case, fw_cfg, port, framework_bin_dir, resolve_model_path)
+    return builder(case, fw_cfg, port, framework_bin_dir)
 
 
 # ---------------------------------------------------------------------------
@@ -583,9 +662,9 @@ def send_request_lightx2v(base_url: str, case: dict, config: dict) -> float:
     """Send request via LightX2V's async task API."""
     task = case["task"]
     if task in ("text-to-image", "image-edit"):
-        endpoint = "/v1/tasks/image"
+        endpoint = "/v1/tasks/image/"
     else:
-        endpoint = "/v1/tasks/video"
+        endpoint = "/v1/tasks/video/"
 
     payload = {
         "prompt": case["prompt"],
@@ -597,8 +676,10 @@ def send_request_lightx2v(base_url: str, case: dict, config: dict) -> float:
         payload["target_video_length"] = case["num_frames"]
     if "height" in case:
         payload["height"] = case["height"]
+        payload["target_height"] = case["height"]
     if "width" in case:
         payload["width"] = case["width"]
+        payload["target_width"] = case["width"]
     if "guidance_scale" in case:
         payload["guidance_scale"] = case["guidance_scale"]
     if "fps" in case:
@@ -630,7 +711,9 @@ def send_request_lightx2v(base_url: str, case: dict, config: dict) -> float:
         poll_resp = requests.get(poll_url, timeout=30)
         poll_resp.raise_for_status()
         poll_data = poll_resp.json()
-        status = poll_data.get("task_status", "").upper()
+        status = (
+            poll_data.get("status") or poll_data.get("task_status") or ""
+        ).upper()
         if status == "COMPLETED":
             break
         elif status in ("FAILED", "CANCELLED"):
@@ -686,6 +769,7 @@ def run_single(
     port: int,
     log_dir: Path,
     config: dict | None = None,
+    framework_bin_dir: str | None = None,
 ) -> dict:
     """Run a single (case, framework) combination. Returns result dict."""
     result = {
@@ -697,10 +781,18 @@ def run_single(
         "error": None,
     }
 
-    cmd = build_server_cmd(framework, case, fw_cfg, port)
+    cmd = build_server_cmd(framework, case, fw_cfg, port, framework_bin_dir)
     print(f"\n  Command: {' '.join(cmd)}")
 
     env = os.environ.copy()
+    if framework_bin_dir:
+        # Isolate the venv: override PATH so the venv's bin comes first,
+        # and remove LD_LIBRARY_PATH / PYTHONPATH inherited from the host
+        # to prevent ABI mismatches (e.g. host PyTorch vs venv PyTorch).
+        env["PATH"] = framework_bin_dir + ":" + env.get("PATH", "")
+        env["VIRTUAL_ENV"] = os.path.dirname(framework_bin_dir)
+        env.pop("LD_LIBRARY_PATH", None)
+        env.pop("PYTHONPATH", None)
     env.update(fw_cfg.get("extra_env", {}))
 
     # perf_dump_path for SGLang server-side timing (passed in request, zero overhead when None)
@@ -724,13 +816,19 @@ def run_single(
             bufsize=1,
         )
 
-        # Tee server output to both log file and stdout (like test_server_utils)
+        # Tee server output to both log file and stdout (like test_server_utils).
+        # Once shutting_down is set, only write to the log file so that
+        # expected SIGTERM tracebacks (e.g. torchrun SignalException) don't
+        # clutter the console.
+        shutting_down = threading.Event()
+
         def _log_pipe(pipe, fh):
             try:
                 for line in iter(pipe.readline, ""):
-                    sys.stdout.write(f"  [server] {line}")
-                    sys.stdout.flush()
                     fh.write(line)
+                    if not shutting_down.is_set():
+                        sys.stdout.write(f"  [server] {line}")
+                        sys.stdout.flush()
             except ValueError:
                 pass  # pipe closed
 
@@ -768,6 +866,8 @@ def run_single(
         print(f"  ERROR: {e}")
     finally:
         if proc:
+            shutting_down.set()
+            print("  Stopping server (shutdown logs suppressed, see log file)...")
             kill_server(proc)
         if log_thread:
             log_thread.join(timeout=5)
@@ -776,26 +876,83 @@ def run_single(
     return result
 
 
-def _install_framework(fw_name: str, dry_run: bool = False) -> bool:
-    """Install a comparison framework via the install script. Returns True on success."""
+def _install_framework(fw_name: str, dry_run: bool = False) -> tuple[bool, str | None]:
+    """Install a framework and return (success, framework_bin_dir)."""
+    if fw_name not in INSTALLABLE_FRAMEWORKS:
+        return True, None
+    if not INSTALL_SCRIPT.exists():
+        print(f"  WARNING: Install script not found at {INSTALL_SCRIPT}")
+        return False, None
+    expected_bin_dir = _expected_framework_bin_dir(fw_name)
+    if dry_run:
+        print(f"  [DRY-RUN] Would install: bash {INSTALL_SCRIPT} {fw_name} install")
+        if expected_bin_dir:
+            print(f"  [DRY-RUN] Expected framework bin dir: {expected_bin_dir}")
+        return True, expected_bin_dir
+    print(f"\n{'='*60}")
+    print(f"Installing framework: {fw_name}")
+    print(f"{'='*60}")
+    ret = subprocess.run(
+        ["bash", str(INSTALL_SCRIPT), fw_name, "install"],
+        capture_output=True,
+        text=True,
+        timeout=FRAMEWORK_INSTALL_TIMEOUT,
+    )
+    if ret.returncode != 0:
+        print(f"  WARNING: {fw_name} installation failed (exit {ret.returncode})")
+        if ret.stdout:
+            print(ret.stdout.strip())
+        if ret.stderr:
+            print(ret.stderr.strip())
+        return False, None
+
+    framework_bin_dir = None
+    for line in f"{ret.stdout}\n{ret.stderr}".splitlines():
+        if line.startswith("FRAMEWORK_BIN_DIR="):
+            framework_bin_dir = line.split("=", 1)[1].strip()
+            break
+
+    if not framework_bin_dir:
+        if expected_bin_dir:
+            print(
+                f"  WARNING: {fw_name} install did not report bin dir; "
+                f"falling back to expected path {expected_bin_dir}"
+            )
+            framework_bin_dir = expected_bin_dir
+        else:
+            print(f"  WARNING: {fw_name} install succeeded but no bin dir reported")
+            return False, None
+
+    print(f"  Using framework bin dir: {framework_bin_dir}")
+    return True, framework_bin_dir
+
+
+def _cleanup_framework_venv(fw_name: str, dry_run: bool = False) -> bool:
+    """Remove framework venv via install script. Returns True on success."""
     if fw_name not in INSTALLABLE_FRAMEWORKS:
         return True
     if not INSTALL_SCRIPT.exists():
         print(f"  WARNING: Install script not found at {INSTALL_SCRIPT}")
         return False
     if dry_run:
-        print(f"  [DRY-RUN] Would install: bash {INSTALL_SCRIPT} {fw_name}")
+        print(f"  [DRY-RUN] Would cleanup: bash {INSTALL_SCRIPT} {fw_name} remove")
         return True
-    print(f"\n{'='*60}")
-    print(f"Installing framework: {fw_name}")
-    print(f"{'='*60}")
+
     ret = subprocess.run(
-        ["bash", str(INSTALL_SCRIPT), fw_name],
-        timeout=600,
+        ["bash", str(INSTALL_SCRIPT), fw_name, "remove"],
+        capture_output=True,
+        text=True,
+        timeout=120,
     )
     if ret.returncode != 0:
-        print(f"  WARNING: {fw_name} installation failed (exit {ret.returncode})")
+        print(f"  WARNING: failed to cleanup {fw_name} venv (exit {ret.returncode})")
+        if ret.stdout:
+            print(ret.stdout.strip())
+        if ret.stderr:
+            print(ret.stderr.strip())
         return False
+
+    print(f"  Cleaned up venv for framework: {fw_name}")
     return True
 
 
@@ -806,6 +963,7 @@ def run_comparison(
     port: int = DEFAULT_PORT,
     output: str = "comparison-results.json",
     dry_run: bool = False,
+    cleanup_framework_venvs: bool = False,
 ) -> dict:
     """Run all comparison cases, grouped by framework to minimize installs.
 
@@ -835,6 +993,7 @@ def run_comparison(
 
     results = []
     installed_fws: set[str] = set()
+    framework_bin_dirs: dict[str, str | None] = {"sglang": None}
 
     for fw_name in fw_order:
         pairs = fw_cases.get(fw_name, [])
@@ -843,7 +1002,8 @@ def run_comparison(
 
         # Install framework if needed (once per framework)
         if fw_name not in installed_fws and fw_name in INSTALLABLE_FRAMEWORKS:
-            if not _install_framework(fw_name, dry_run):
+            install_success, bin_dir = _install_framework(fw_name, dry_run)
+            if not install_success:
                 # Skip all cases for this framework
                 for case, _ in pairs:
                     results.append(
@@ -857,6 +1017,7 @@ def run_comparison(
                         }
                     )
                 continue
+            framework_bin_dirs[fw_name] = bin_dir
             installed_fws.add(fw_name)
 
         for case, fw_cfg in pairs:
@@ -865,7 +1026,14 @@ def run_comparison(
             print(f"{'='*60}")
 
             if dry_run:
-                cmd = build_server_cmd(fw_name, case, fw_cfg, port)
+                cmd = build_server_cmd(
+                    fw_name,
+                    case,
+                    fw_cfg,
+                    port,
+                    framework_bin_dirs.get(fw_name),
+                    resolve_model_path=False,
+                )
                 print(f"  [DRY-RUN] Would run: {' '.join(cmd)}")
                 results.append(
                     {
@@ -879,7 +1047,15 @@ def run_comparison(
                 )
                 continue
 
-            result = run_single(case, fw_name, fw_cfg, port, log_dir, config)
+            result = run_single(
+                case,
+                fw_name,
+                fw_cfg,
+                port,
+                log_dir,
+                config,
+                framework_bin_dirs.get(fw_name),
+            )
             results.append(result)
 
             # Wait for GPU memory to clear
@@ -905,6 +1081,15 @@ def run_comparison(
     for r in results:
         lat = f"{r['latency_s']:.2f}s" if r["latency_s"] else r.get("error", "N/A")
         print(f"  {r['case_id']:30s} | {r['framework']:12s} | {lat}")
+
+    if cleanup_framework_venvs:
+        cleanup_targets = [fw for fw in fw_order if fw in installed_fws]
+        if cleanup_targets:
+            print(f"\n{'='*60}")
+            print("CLEANUP FRAMEWORK VENVS")
+            print(f"{'='*60}")
+        for fw_name in cleanup_targets:
+            _cleanup_framework_venv(fw_name, dry_run=dry_run)
 
     return output_data
 
@@ -951,6 +1136,11 @@ def main():
         action="store_true",
         help="Parse config and print commands without launching servers",
     )
+    parser.add_argument(
+        "--cleanup-framework-venvs",
+        action="store_true",
+        help="Remove installed non-sglang comparison venvs after the run",
+    )
 
     args = parser.parse_args()
 
@@ -966,6 +1156,7 @@ def main():
         port=args.port,
         output=args.output,
         dry_run=args.dry_run,
+        cleanup_framework_venvs=args.cleanup_framework_venvs,
     )
 
 

--- a/scripts/ci/utils/diffusion/run_comparison.py
+++ b/scripts/ci/utils/diffusion/run_comparison.py
@@ -65,6 +65,46 @@ def _framework_executable(executable: str, framework_bin_dir: str | None) -> str
     return executable
 
 
+def _filter_ld_library_path_for_venv(ld: str | None) -> str | None:
+    """Keep CUDA-related entries so libcudart/NCCL resolve; drop other host paths.
+
+    Clearing LD_LIBRARY_PATH entirely avoids ABI mismatches from a host-built
+    PyTorch, but it also breaks typical CI/container setups where CUDA lives
+    only on LD_LIBRARY_PATH. We keep entries that look CUDA-related.
+
+    Note: ``source venv/bin/activate`` does **not** remove or replace
+    ``LD_LIBRARY_PATH`` — it mainly prepends the venv ``bin`` to ``PATH`` and
+    sets ``VIRTUAL_ENV``. So "activating the venv" is not a substitute for
+    deciding how much of the inherited ``LD_LIBRARY_PATH`` to keep; the dynamic
+    linker can still prefer host paths when loading ``.so`` files.
+    """
+    if not ld:
+        return None
+    keep: list[str] = []
+    for entry in ld.split(":"):
+        if not entry:
+            continue
+        lower = entry.lower()
+        if any(
+            token in lower
+            for token in (
+                "cuda",
+                "cudnn",
+                "nccl",
+                "nvidia",
+                "tensorrt",
+                "cublas",
+                "cusparse",
+                "cusolver",
+                "curand",
+                "nvjitlink",
+                "libcudnn",
+            )
+        ):
+            keep.append(entry)
+    return ":".join(keep) if keep else None
+
+
 def _expected_framework_bin_dir(fw_name: str) -> str | None:
     """Return expected framework venv bin directory for installable frameworks."""
     if fw_name not in INSTALLABLE_FRAMEWORKS:
@@ -79,8 +119,14 @@ def _expected_framework_bin_dir(fw_name: str) -> str | None:
 
 
 def _build_sglang_cmd(
-    case: dict, fw_cfg: dict, port: int, framework_bin_dir: str | None = None
+    case: dict,
+    fw_cfg: dict,
+    port: int,
+    framework_bin_dir: str | None = None,
+    *,
+    resolve_model_path: bool = True,
 ) -> list[str]:
+    # framework_bin_dir unused; resolve_model_path unused — kept for uniform builder signature.
     cmd = [
         "sglang",
         "serve",
@@ -99,8 +145,14 @@ def _build_sglang_cmd(
 
 
 def _build_vllm_cmd(
-    case: dict, fw_cfg: dict, port: int, framework_bin_dir: str | None = None
+    case: dict,
+    fw_cfg: dict,
+    port: int,
+    framework_bin_dir: str | None = None,
+    *,
+    resolve_model_path: bool = True,
 ) -> list[str]:
+    # resolve_model_path unused — kept for uniform builder signature.
     cmd = [
         _framework_executable("vllm", framework_bin_dir),
         "serve",
@@ -128,6 +180,22 @@ def _resolve_hf_model_path(model_id: str) -> str:
         return path
     except Exception:
         return model_id
+
+
+def _lightx2v_spatial_params(case: dict) -> dict:
+    """Height/width/frames mapping shared by LightX2V server config and HTTP payload."""
+    out: dict = {}
+    if "num_frames" in case:
+        out["target_video_length"] = case["num_frames"]
+    if "height" in case:
+        h = case["height"]
+        out["height"] = h
+        out["target_height"] = h
+    if "width" in case:
+        w = case["width"]
+        out["width"] = w
+        out["target_width"] = w
+    return out
 
 
 def _write_lightx2v_config(case: dict, fw_cfg: dict, model_path: str) -> str:
@@ -169,15 +237,7 @@ def _write_lightx2v_config(case: dict, fw_cfg: dict, model_path: str) -> str:
                 cfg["dit_original_ckpt"] = ckpt
                 break
 
-    if "num_frames" in case:
-        cfg["target_video_length"] = case["num_frames"]
-    if "height" in case:
-        cfg["height"] = case["height"]
-        # LTX2 runner reads target_height/target_width in request-time config.
-        cfg["target_height"] = case["height"]
-    if "width" in case:
-        cfg["width"] = case["width"]
-        cfg["target_width"] = case["width"]
+    cfg.update(_lightx2v_spatial_params(case))
 
     config_path = os.path.join(
         tempfile.gettempdir(), f"lightx2v_config_{case['id']}.json"
@@ -192,6 +252,7 @@ def _build_lightx2v_cmd(
     fw_cfg: dict,
     port: int,
     framework_bin_dir: str | None = None,
+    *,
     resolve_model_path: bool = True,
 ) -> list[str]:
     """Build LightX2V server launch command.
@@ -259,9 +320,9 @@ def build_server_cmd(
     builder = builders.get(framework)
     if builder is None:
         raise ValueError(f"Unknown framework: {framework}")
-    if framework == "lightx2v":
-        return builder(case, fw_cfg, port, framework_bin_dir, resolve_model_path)
-    return builder(case, fw_cfg, port, framework_bin_dir)
+    return builder(
+        case, fw_cfg, port, framework_bin_dir, resolve_model_path=resolve_model_path
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -671,15 +732,7 @@ def send_request_lightx2v(base_url: str, case: dict, config: dict) -> float:
         "seed": case.get("seed", 42),
         "infer_steps": case.get("num_inference_steps", 50),
     }
-    # LightX2V uses target_video_length for frames, height/width directly
-    if "num_frames" in case:
-        payload["target_video_length"] = case["num_frames"]
-    if "height" in case:
-        payload["height"] = case["height"]
-        payload["target_height"] = case["height"]
-    if "width" in case:
-        payload["width"] = case["width"]
-        payload["target_width"] = case["width"]
+    payload.update(_lightx2v_spatial_params(case))
     if "guidance_scale" in case:
         payload["guidance_scale"] = case["guidance_scale"]
     if "fps" in case:
@@ -706,6 +759,17 @@ def send_request_lightx2v(base_url: str, case: dict, config: dict) -> float:
 
     # Poll for completion
     poll_url = f"{base_url}/v1/tasks/{task_id}/status"
+    _KNOWN_ACTIVE = {
+        "PENDING",
+        "QUEUED",
+        "RUNNING",
+        "PROCESSING",
+        "IN_PROGRESS",
+        "STARTING",
+        "SUBMITTED",
+    }
+    unknown_streak = 0
+    max_unknown_streak = 30
     while True:
         time.sleep(1)
         poll_resp = requests.get(poll_url, timeout=30)
@@ -718,6 +782,15 @@ def send_request_lightx2v(base_url: str, case: dict, config: dict) -> float:
             break
         elif status in ("FAILED", "CANCELLED"):
             raise RuntimeError(f"LightX2V task {status}: {poll_data}")
+        elif status in _KNOWN_ACTIVE:
+            unknown_streak = 0
+        else:
+            unknown_streak += 1
+            if unknown_streak >= max_unknown_streak:
+                raise RuntimeError(
+                    f"LightX2V: {unknown_streak} consecutive unexpected status values "
+                    f"(last={status!r}): {poll_data}"
+                )
         if time.time() - start > REQUEST_TIMEOUT:
             raise TimeoutError(f"LightX2V task timed out after {REQUEST_TIMEOUT}s")
 
@@ -786,12 +859,21 @@ def run_single(
 
     env = os.environ.copy()
     if framework_bin_dir:
-        # Isolate the venv: override PATH so the venv's bin comes first,
-        # and remove LD_LIBRARY_PATH / PYTHONPATH inherited from the host
-        # to prevent ABI mismatches (e.g. host PyTorch vs venv PyTorch).
+        # Same effect as `source .../bin/activate` for running commands: venv bin
+        # first on PATH + VIRTUAL_ENV. That does not control LD_LIBRARY_PATH (see
+        # _filter_ld_library_path_for_venv docstring).
         env["PATH"] = framework_bin_dir + ":" + env.get("PATH", "")
         env["VIRTUAL_ENV"] = os.path.dirname(framework_bin_dir)
-        env.pop("LD_LIBRARY_PATH", None)
+        inherit_ld = os.environ.get("COMPARISON_INHERIT_LD_LIBRARY_PATH", "").strip().lower()
+        if inherit_ld in ("1", "true", "yes"):
+            # Optional: keep full host LD_LIBRARY_PATH (e.g. unusual CUDA layouts).
+            pass
+        else:
+            filtered_ld = _filter_ld_library_path_for_venv(env.get("LD_LIBRARY_PATH"))
+            if filtered_ld:
+                env["LD_LIBRARY_PATH"] = filtered_ld
+            else:
+                env.pop("LD_LIBRARY_PATH", None)
         env.pop("PYTHONPATH", None)
     env.update(fw_cfg.get("extra_env", {}))
 
@@ -892,22 +974,49 @@ def _install_framework(fw_name: str, dry_run: bool = False) -> tuple[bool, str |
     print(f"\n{'='*60}")
     print(f"Installing framework: {fw_name}")
     print(f"{'='*60}")
-    ret = subprocess.run(
+    proc = subprocess.Popen(
         ["bash", str(INSTALL_SCRIPT), fw_name, "install"],
-        capture_output=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
         text=True,
-        timeout=FRAMEWORK_INSTALL_TIMEOUT,
+        bufsize=1,
     )
-    if ret.returncode != 0:
-        print(f"  WARNING: {fw_name} installation failed (exit {ret.returncode})")
-        if ret.stdout:
-            print(ret.stdout.strip())
-        if ret.stderr:
-            print(ret.stderr.strip())
+    install_lines: list[str] = []
+
+    def _tee_install_output() -> None:
+        assert proc.stdout is not None
+        try:
+            for line in iter(proc.stdout.readline, ""):
+                install_lines.append(line)
+                sys.stdout.write(f"  [install] {line}")
+                sys.stdout.flush()
+        except ValueError:
+            pass
+
+    tee_thread = threading.Thread(target=_tee_install_output, daemon=True)
+    tee_thread.start()
+    try:
+        proc.wait(timeout=FRAMEWORK_INSTALL_TIMEOUT)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        try:
+            proc.wait(timeout=30)
+        except Exception:
+            pass
+        tee_thread.join(timeout=30)
+        print(
+            f"  WARNING: {fw_name} installation timed out after "
+            f"{FRAMEWORK_INSTALL_TIMEOUT}s"
+        )
+        return False, None
+    tee_thread.join(timeout=120)
+    if proc.returncode != 0:
+        print(f"  WARNING: {fw_name} installation failed (exit {proc.returncode})")
         return False, None
 
+    combined_out = "".join(install_lines)
     framework_bin_dir = None
-    for line in f"{ret.stdout}\n{ret.stderr}".splitlines():
+    for line in combined_out.splitlines():
         if line.startswith("FRAMEWORK_BIN_DIR="):
             framework_bin_dir = line.split("=", 1)[1].strip()
             break

--- a/scripts/ci/utils/diffusion/run_comparison.py
+++ b/scripts/ci/utils/diffusion/run_comparison.py
@@ -796,9 +796,7 @@ def send_request_lightx2v(base_url: str, case: dict, config: dict) -> float:
         poll_resp = requests.get(poll_url, timeout=30)
         poll_resp.raise_for_status()
         poll_data = poll_resp.json()
-        status = (
-            poll_data.get("status") or poll_data.get("task_status") or ""
-        ).upper()
+        status = (poll_data.get("status") or poll_data.get("task_status") or "").upper()
         if status == "COMPLETED":
             break
         elif status in ("FAILED", "CANCELLED"):
@@ -889,7 +887,9 @@ def run_single(
         # _filter_ld_library_path_for_venv docstring).
         env["PATH"] = framework_bin_dir + ":" + env.get("PATH", "")
         env["VIRTUAL_ENV"] = os.path.dirname(framework_bin_dir)
-        inherit_ld = os.environ.get("COMPARISON_INHERIT_LD_LIBRARY_PATH", "").strip().lower()
+        inherit_ld = (
+            os.environ.get("COMPARISON_INHERIT_LD_LIBRARY_PATH", "").strip().lower()
+        )
         if inherit_ld in ("1", "true", "yes"):
             # Optional: keep full host LD_LIBRARY_PATH (e.g. unusual CUDA layouts).
             pass

--- a/scripts/ci/utils/diffusion/run_comparison.py
+++ b/scripts/ci/utils/diffusion/run_comparison.py
@@ -1,7 +1,13 @@
 """Cross-framework comparison benchmark for diffusion serving.
 
 Launches servers (SGLang, vLLM-Omni, LightX2V) for each test case, sends a
-single request, measures end-to-end latency, and writes comparison-results.json.
+single request, measures latency, and writes comparison-results.json.
+
+Primary metric ``latency_s`` is **client wall-clock** time (submit through
+completion) for every framework so cross-framework speed comparisons are
+apples-to-apples. For SGLang, when ``perf_dump_path`` is used and the server
+writes a perf JSON, ``server_latency_s`` records server-reported duration as a
+separate optional field.
 
 Usage:
     # Full run (requires GPU)
@@ -492,8 +498,12 @@ def _read_perf_dump(perf_dump_path: str, timeout: float = 10.0) -> float | None:
 
 def send_image_request_sglang(
     base_url: str, case: dict, perf_dump_path: str | None = None
-) -> float:
-    """Send a single T2I request via SGLang's /v1/images/generations."""
+) -> tuple[float, float | None]:
+    """Send a single T2I request via SGLang's /v1/images/generations.
+
+    Returns (client_wall_clock_s, server_perf_dump_s_or_none). Primary latency
+    for cross-framework comparison is the client time; server time is optional.
+    """
     payload = _build_sglang_payload(case)
     if perf_dump_path:
         payload["perf_dump_path"] = perf_dump_path
@@ -510,22 +520,26 @@ def send_image_request_sglang(
     if "data" not in data or len(data["data"]) == 0:
         raise RuntimeError(f"Image request returned no data: {data}")
 
+    server_latency: float | None = None
     if perf_dump_path:
         server_latency = _read_perf_dump(perf_dump_path)
-        if server_latency is not None:
-            print(
-                f"  Image generated in {server_latency:.2f}s (server-side), "
-                f"client={client_latency:.2f}s"
-            )
-            return server_latency
-    print(f"  Image generated in {client_latency:.2f}s")
-    return client_latency
+    if server_latency is not None:
+        print(
+            f"  Image generated in {client_latency:.2f}s (client E2E), "
+            f"server perf_dump={server_latency:.2f}s"
+        )
+    else:
+        print(f"  Image generated in {client_latency:.2f}s (client E2E)")
+    return client_latency, server_latency
 
 
 def send_video_request_sglang(
     base_url: str, case: dict, perf_dump_path: str | None = None
-) -> float:
-    """Send a single T2V request via SGLang's /v1/videos (async)."""
+) -> tuple[float, float | None]:
+    """Send a single T2V request via SGLang's /v1/videos (async).
+
+    Returns (client_wall_clock_s, server_perf_dump_s_or_none).
+    """
     payload = _build_sglang_payload(case)
     if perf_dump_path:
         payload["perf_dump_path"] = perf_dump_path
@@ -561,22 +575,26 @@ def send_video_request_sglang(
 
     client_latency = time.time() - start
 
+    server_latency: float | None = None
     if perf_dump_path:
         server_latency = _read_perf_dump(perf_dump_path)
-        if server_latency is not None:
-            print(
-                f"  Video generated in {server_latency:.2f}s (server-side), "
-                f"client={client_latency:.2f}s"
-            )
-            return server_latency
-    print(f"  Video generated in {client_latency:.2f}s")
-    return client_latency
+    if server_latency is not None:
+        print(
+            f"  Video generated in {client_latency:.2f}s (client E2E), "
+            f"server perf_dump={server_latency:.2f}s"
+        )
+    else:
+        print(f"  Video generated in {client_latency:.2f}s (client E2E)")
+    return client_latency, server_latency
 
 
 def send_image_conditioned_request_sglang(
     base_url: str, case: dict, config: dict, perf_dump_path: str | None = None
-) -> float:
-    """Send an image-conditioned request (edit/I2V/TI2V) via SGLang multipart API."""
+) -> tuple[float, float | None]:
+    """Send an image-conditioned request (edit/I2V/TI2V) via SGLang multipart API.
+
+    Returns (client_wall_clock_s, server_perf_dump_s_or_none).
+    """
     task = case["task"]
     ref_bytes = _get_ref_image_bytes(config)
 
@@ -647,16 +665,19 @@ def send_image_conditioned_request_sglang(
 
     client_latency = time.time() - start
 
+    server_latency: float | None = None
     if perf_dump_path:
         server_latency = _read_perf_dump(perf_dump_path)
-        if server_latency is not None:
-            print(
-                f"  Generated in {server_latency:.2f}s (server-side), "
-                f"client={client_latency:.2f}s"
-            )
-            return server_latency
-    print(f"  Generated in {client_latency:.2f}s (sglang, image-conditioned)")
-    return client_latency
+    if server_latency is not None:
+        print(
+            f"  Generated in {client_latency:.2f}s (client E2E, image-conditioned), "
+            f"server perf_dump={server_latency:.2f}s"
+        )
+    else:
+        print(
+            f"  Generated in {client_latency:.2f}s (client E2E, sglang image-conditioned)"
+        )
+    return client_latency, server_latency
 
 
 # ---------------------------------------------------------------------------
@@ -710,7 +731,7 @@ def send_request_vllm_omni(base_url: str, case: dict, config: dict) -> float:
     choices = data.get("choices", [])
     if not choices:
         raise RuntimeError(f"vLLM-Omni request returned no choices: {data}")
-    print(f"  Generated in {latency:.2f}s (vllm-omni)")
+    print(f"  Generated in {latency:.2f}s (vllm-omni, client E2E)")
     return latency
 
 
@@ -795,7 +816,7 @@ def send_request_lightx2v(base_url: str, case: dict, config: dict) -> float:
             raise TimeoutError(f"LightX2V task timed out after {REQUEST_TIMEOUT}s")
 
     latency = time.time() - start
-    print(f"  Generated in {latency:.2f}s (lightx2v)")
+    print(f"  Generated in {latency:.2f}s (lightx2v, client E2E)")
     return latency
 
 
@@ -810,12 +831,16 @@ def send_request(
     framework: str = "sglang",
     config: dict | None = None,
     perf_dump_path: str | None = None,
-) -> float:
+) -> tuple[float, float | None]:
+    """Dispatch request; return (client_latency_s, server_latency_s_or_none).
+
+    ``server_latency_s`` is only set for SGLang when perf_dump is read successfully.
+    """
     config = config or {}
     if framework == "vllm-omni":
-        return send_request_vllm_omni(base_url, case, config)
+        return send_request_vllm_omni(base_url, case, config), None
     elif framework == "lightx2v":
-        return send_request_lightx2v(base_url, case, config)
+        return send_request_lightx2v(base_url, case, config), None
     # SGLang — use OpenAI-compatible endpoints with optional perf log
     task = case["task"]
     if case.get("reference_image"):
@@ -845,7 +870,7 @@ def run_single(
     framework_bin_dir: str | None = None,
 ) -> dict:
     """Run a single (case, framework) combination. Returns result dict."""
-    result = {
+    result: dict = {
         "case_id": case["id"],
         "framework": framework,
         "model": case["model"],
@@ -877,7 +902,7 @@ def run_single(
         env.pop("PYTHONPATH", None)
     env.update(fw_cfg.get("extra_env", {}))
 
-    # perf_dump_path for SGLang server-side timing (passed in request, zero overhead when None)
+    # perf_dump_path: SGLang writes perf JSON; we record server_latency_s alongside client E2E
     perf_dump_path = None
     if framework == "sglang":
         perf_dump_path = os.path.join(str(log_dir), f"perf_{case['id']}_measured.json")
@@ -934,14 +959,16 @@ def run_single(
             except Exception as e:
                 print(f"  Warmup request {wi} failed (non-fatal): {e}")
 
-        # Measured request — pass perf_dump_path for SGLang server-side timing
+        # Measured request — perf_dump_path yields optional server_latency_s for SGLang
         if perf_dump_path and os.path.exists(perf_dump_path):
             os.remove(perf_dump_path)
         print("  Sending measured request...")
-        latency = send_request(
+        client_lat, server_lat = send_request(
             base_url, case, framework, config, perf_dump_path=perf_dump_path
         )
-        result["latency_s"] = round(latency, 3)
+        result["latency_s"] = round(client_lat, 3)
+        if server_lat is not None:
+            result["server_latency_s"] = round(server_lat, 3)
 
     except Exception as e:
         result["error"] = str(e)
@@ -1188,7 +1215,13 @@ def run_comparison(
     print("SUMMARY")
     print(f"{'='*60}")
     for r in results:
-        lat = f"{r['latency_s']:.2f}s" if r["latency_s"] else r.get("error", "N/A")
+        if r["latency_s"] is not None:
+            lat = f"{r['latency_s']:.2f}s"
+            srv = r.get("server_latency_s")
+            if srv is not None:
+                lat += f" (srv {srv:.2f}s)"
+        else:
+            lat = r.get("error", "N/A")
         print(f"  {r['case_id']:30s} | {r['framework']:12s} | {lat}")
 
     if cleanup_framework_venvs:

--- a/scripts/ci/utils/install_comparison_frameworks.sh
+++ b/scripts/ci/utils/install_comparison_frameworks.sh
@@ -11,6 +11,20 @@ VENV_ROOT="${COMPARISON_VENV_ROOT:-/tmp/sglang-comparison-venvs}"
 USE_UV="${COMPARISON_USE_UV:-auto}"   # auto|always|never
 RESET_VENV="${COMPARISON_RESET_VENV:-0}"
 
+# ---------------------------------------------------------------------------
+# Pinned framework versions — do not track "latest" on PyPI or branch HEAD on git.
+# Bump these intentionally when upgrading; CI/nightly stays reproducible.
+# - vLLM / vLLM-Omni: exact PyPI versions (override with VLLM_PIN / VLLM_OMNI_PIN).
+# - LightX2V: install only from git at an immutable full commit SHA (override with
+#   LIGHTX2V_GIT_COMMIT). Never set LIGHTX2V_GIT_COMMIT to a branch name (e.g. main).
+# ---------------------------------------------------------------------------
+VLLM_PIN="${VLLM_PIN:-0.18.0}"
+VLLM_OMNI_PIN="${VLLM_OMNI_PIN:-0.18.0}"
+LIGHTX2V_GIT_COMMIT="${LIGHTX2V_GIT_COMMIT:-cc9087edb71b3b53ed7104f47deaacafee9100d4}"
+# flash-attn (import name: flash_attn). Pin for reproducibility, e.g. FLASH_ATTN_PACKAGE='flash-attn==2.7.4.post1'
+# Set COMPARISON_SKIP_FLASH_ATTN=1 only to skip (server will likely still fail to start).
+FLASH_ATTN_PACKAGE="${FLASH_ATTN_PACKAGE:-flash-attn}"
+
 if [[ -z "${FRAMEWORK}" ]]; then
     echo "Usage: $0 <vllm-omni|lightx2v> [install|remove]"
     exit 1
@@ -58,7 +72,10 @@ if [[ ! -d "${VENV_DIR}" || ! -x "${PYTHON_BIN}" ]]; then
     python3 -m venv "${VENV_DIR}"
 fi
 
-"${PYTHON_BIN}" -m pip install --upgrade pip wheel setuptools
+# Upgrade pip/wheel only — upgrading setuptools to the latest breaks vllm 0.18.x
+# on Python 3.12+ (requires setuptools>=77.0.3,<81.0.0). Framework blocks pin
+# setuptools when needed.
+"${PYTHON_BIN}" -m pip install --upgrade pip wheel
 
 # Best-effort install uv inside the isolated venv. If unavailable, we
 # gracefully fall back to pip commands below.
@@ -84,29 +101,59 @@ install_pkg() {
     fi
 }
 
-# Re-install framework package if marker is absent.
-if [[ ! -f "${MARKER_FILE}" ]]; then
+# Some packages (notably flash-attn) need access to already-installed torch
+# during build, but do not declare it correctly as a build dependency.
+# Use pip with --no-build-isolation so build backend can see venv packages.
+install_pkg_no_build_isolation() {
+    local package_spec="$1"
+    "${PYTHON_BIN}" -m pip install --no-build-isolation "${package_spec}"
+}
+
+case "${FRAMEWORK}" in
+    vllm-omni)
+        INSTALL_KEY="vllm==${VLLM_PIN}|vllm-omni==${VLLM_OMNI_PIN}|setuptools>=77,<81"
+        ;;
+    lightx2v)
+        INSTALL_KEY="lightx2v@git-${LIGHTX2V_GIT_COMMIT}|pyzmq|transformers==4.52.4|matplotlib|${FLASH_ATTN_PACKAGE}"
+        ;;
+esac
+
+# Re-install when the marker is absent or the install spec (pins/commits) changed.
+NEED_INSTALL=1
+if [[ -f "${MARKER_FILE}" ]]; then
+    SAVED_KEY=$(head -n 1 "${MARKER_FILE}")
+    if [[ "${SAVED_KEY}" == "${INSTALL_KEY}" ]]; then
+        NEED_INSTALL=0
+    fi
+fi
+
+if [[ "${NEED_INSTALL}" -eq 1 ]]; then
     case "${FRAMEWORK}" in
         vllm-omni)
+            # vllm 0.18.x declares setuptools>=77.0.3,<81.0.0 on Python 3.12+.
+            install_pkg "setuptools>=77.0.3,<81.0.0"
             # vLLM-Omni GPU install guide:
             #   uv pip install vllm --torch-backend=auto
             #   uv pip install vllm-omni
             # `--torch-backend=auto` is uv-specific and invalid for pip, so we
             # only use it when uv is present.
-            # Pin vllm to <0.19 because vllm-omni 0.18.x imports
-            # vllm.inputs.data which was removed in vllm 0.19.
+            # VLLM_PIN / VLLM_OMNI_PIN: keep vllm and vllm-omni on matching lines
+            # (vllm-omni 0.18.x expects vllm 0.18.x; vllm 0.19+ removed APIs vllm-omni uses).
             if have_uv; then
                 "${UV_BIN}" pip install --python "${PYTHON_BIN}"  \
-                    "vllm==0.18.0" --torch-backend=auto
+                    "vllm==${VLLM_PIN}" --torch-backend=auto
             else
-                install_pkg "vllm==0.18.0"
+                install_pkg "vllm==${VLLM_PIN}"
             fi
-            install_pkg "vllm-omni"
+            install_pkg "vllm-omni==${VLLM_OMNI_PIN}"
             ;;
         lightx2v)
-            # LightX2V quick start recommends source install (`pip install -e .`)
-            # after cloning the repo. For CI, install directly from GitHub.
-            install_pkg "git+https://github.com/ModelTC/LightX2V.git"
+            # PyPI does not publish lightx2v; install from GitHub at fixed full SHA only.
+            if [[ ! "${LIGHTX2V_GIT_COMMIT}" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
+                echo "ERROR: LIGHTX2V_GIT_COMMIT must be a git commit hash (7–40 hex chars), not a branch name." >&2
+                exit 1
+            fi
+            install_pkg "git+https://github.com/ModelTC/LightX2V.git@${LIGHTX2V_GIT_COMMIT}"
             # pyzmq is imported unconditionally by lightx2v but not declared
             # as a hard dependency.
             install_pkg "pyzmq"
@@ -114,10 +161,33 @@ if [[ ! -f "${MARKER_FILE}" ]]; then
             # Gemma3TextConfig.rope_local_base_freq, which is missing in
             # transformers 5.x.
             install_pkg "transformers==4.52.4"
+            # LightX2V imports worldmirror modules at package import time;
+            # those modules require matplotlib.
+            install_pkg "matplotlib"
+            # LightX2V imports worldmirror at package load; it requires flash_attn
+            # (PyPI: flash-attn). Without it: ModuleNotFoundError: flash_attn / flash_attn_interface.
+            if [[ "${COMPARISON_SKIP_FLASH_ATTN:-0}" == "1" ]]; then
+                echo "WARNING: COMPARISON_SKIP_FLASH_ATTN=1 — skipping flash-attn; lightx2v.server will likely fail to start." >&2
+            else
+                "${PYTHON_BIN}" -m pip install ninja packaging >/dev/null 2>&1 || true
+                if ! "${PYTHON_BIN}" -c "import torch" >/dev/null 2>&1; then
+                    echo "ERROR: torch is not importable in ${VENV_DIR}; cannot build flash-attn." >&2
+                    exit 1
+                fi
+                if ! install_pkg_no_build_isolation "${FLASH_ATTN_PACKAGE}"; then
+                    echo "ERROR: flash-attn failed to install (needs CUDA toolchain matching PyTorch; may compile from source)." >&2
+                    echo "  See: https://github.com/Dao-AILab/flash-attention/blob/main/README.md" >&2
+                    echo "  Hint: MAX_JOBS=4 ${PYTHON_BIN} -m pip install --no-build-isolation ${FLASH_ATTN_PACKAGE}" >&2
+                    exit 1
+                fi
+            fi
             ;;
     esac
 
-    date -u +"%Y-%m-%dT%H:%M:%SZ" > "${MARKER_FILE}"
+    {
+        echo "${INSTALL_KEY}"
+        echo "INSTALLED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    } > "${MARKER_FILE}"
 fi
 
 echo "FRAMEWORK=${FRAMEWORK}"

--- a/scripts/ci/utils/install_comparison_frameworks.sh
+++ b/scripts/ci/utils/install_comparison_frameworks.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install framework-specific dependencies into isolated venvs so we can reuse
+# the base environment prepared by ci_install_dependency.sh without global
+# package conflicts.
+
+FRAMEWORK="${1:-}"
+ACTION="${2:-install}"
+VENV_ROOT="${COMPARISON_VENV_ROOT:-/tmp/sglang-comparison-venvs}"
+USE_UV="${COMPARISON_USE_UV:-auto}"   # auto|always|never
+RESET_VENV="${COMPARISON_RESET_VENV:-0}"
+
+if [[ -z "${FRAMEWORK}" ]]; then
+    echo "Usage: $0 <vllm-omni|lightx2v> [install|remove]"
+    exit 1
+fi
+
+case "${FRAMEWORK}" in
+    vllm-omni|lightx2v)
+        ;;
+    *)
+        echo "Unsupported framework: ${FRAMEWORK}"
+        exit 1
+        ;;
+esac
+
+case "${ACTION}" in
+    install|remove)
+        ;;
+    *)
+        echo "Unsupported action: ${ACTION} (expected: install|remove)"
+        exit 1
+        ;;
+esac
+
+VENV_DIR="${VENV_ROOT}/${FRAMEWORK}"
+PYTHON_BIN="${VENV_DIR}/bin/python"
+MARKER_FILE="${VENV_DIR}/.framework_installed"
+UV_BIN="${VENV_DIR}/bin/uv"
+
+mkdir -p "${VENV_ROOT}"
+
+if [[ "${ACTION}" == "remove" ]]; then
+    rm -rf "${VENV_DIR}"
+    echo "FRAMEWORK=${FRAMEWORK}"
+    echo "ACTION=remove"
+    echo "FRAMEWORK_VENV_DIR=${VENV_DIR}"
+    echo "FRAMEWORK_BIN_DIR="
+    exit 0
+fi
+
+if [[ "${RESET_VENV}" == "1" && -d "${VENV_DIR}" ]]; then
+    rm -rf "${VENV_DIR}"
+fi
+
+if [[ ! -d "${VENV_DIR}" || ! -x "${PYTHON_BIN}" ]]; then
+    python3 -m venv "${VENV_DIR}"
+fi
+
+"${PYTHON_BIN}" -m pip install --upgrade pip wheel setuptools
+
+# Best-effort install uv inside the isolated venv. If unavailable, we
+# gracefully fall back to pip commands below.
+if [[ "${USE_UV}" != "never" && ! -x "${UV_BIN}" ]]; then
+    "${PYTHON_BIN}" -m pip install --upgrade uv >/dev/null 2>&1 || true
+fi
+
+have_uv() {
+    [[ -x "${UV_BIN}" ]]
+}
+
+if [[ "${USE_UV}" == "always" ]] && ! have_uv; then
+    echo "Failed to install uv in ${VENV_DIR} while COMPARISON_USE_UV=always"
+    exit 1
+fi
+
+install_pkg() {
+    local package_spec="$1"
+    if have_uv; then
+        "${UV_BIN}" pip install --python "${PYTHON_BIN}" "${package_spec}"
+    else
+        "${PYTHON_BIN}" -m pip install "${package_spec}"
+    fi
+}
+
+# Re-install framework package if marker is absent.
+if [[ ! -f "${MARKER_FILE}" ]]; then
+    case "${FRAMEWORK}" in
+        vllm-omni)
+            # vLLM-Omni GPU install guide:
+            #   uv pip install vllm --torch-backend=auto
+            #   uv pip install vllm-omni
+            # `--torch-backend=auto` is uv-specific and invalid for pip, so we
+            # only use it when uv is present.
+            # Pin vllm to <0.19 because vllm-omni 0.18.x imports
+            # vllm.inputs.data which was removed in vllm 0.19.
+            if have_uv; then
+                "${UV_BIN}" pip install --python "${PYTHON_BIN}"  \
+                    "vllm==0.18.0" --torch-backend=auto
+            else
+                install_pkg "vllm==0.18.0"
+            fi
+            install_pkg "vllm-omni"
+            ;;
+        lightx2v)
+            # LightX2V quick start recommends source install (`pip install -e .`)
+            # after cloning the repo. For CI, install directly from GitHub.
+            install_pkg "git+https://github.com/ModelTC/LightX2V.git"
+            # pyzmq is imported unconditionally by lightx2v but not declared
+            # as a hard dependency.
+            install_pkg "pyzmq"
+            # LightX2V's Gemma3 text encoder path expects
+            # Gemma3TextConfig.rope_local_base_freq, which is missing in
+            # transformers 5.x.
+            install_pkg "transformers==4.52.4"
+            ;;
+    esac
+
+    date -u +"%Y-%m-%dT%H:%M:%SZ" > "${MARKER_FILE}"
+fi
+
+echo "FRAMEWORK=${FRAMEWORK}"
+echo "ACTION=install"
+echo "FRAMEWORK_VENV_DIR=${VENV_DIR}"
+echo "FRAMEWORK_BIN_DIR=${VENV_DIR}/bin"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
This PR integrates nightly cross-framework diffusion comparison for **SGLang**, **vLLM-Omni**, and **LightX2V** to make benchmarking more reliable, reproducible, and actionable in CI.

Key goals are:
- Establish a single nightly pipeline for apples-to-apples framework comparison.
- Improve reproducibility by isolating framework environments and pinning dependency versions/commits.
- Reduce flaky failures caused by dependency conflicts, API mismatches, and host environment leakage.
- Clarify latency semantics for fair comparison (client E2E as primary metric, with optional server-side timing for SGLang diagnostics).
## Modifications
### `scripts/ci/utils/diffusion/comparison_configs.json`
- Added `vllm-omni` and `lightx2v` entries to diffusion comparison cases.
- Added LightX2V-specific fields (e.g., `model_cls`, `lightx2v_task`) for framework startup.

### `scripts/ci/utils/diffusion/run_comparison.py`
- Generalized runner logic to orchestrate SGLang, vLLM-Omni, and LightX2V in one flow.
- Framework-scoped executable/env handling so each framework runs in its own venv safely (with review-driven fixes for subprocess env hygiene and logging/timeouts).
- LightX2V config + request adaptation for stable API compatibility; optional uniform builder signatures per review.
- Installer integration (bin-dir detection, timeout/logging handling), optional venv cleanup (`--cleanup-framework-venvs`).
- **Standardized metrics:** `latency_s` = **client E2E** for all frameworks where applicable; optional `server_latency_s` for SGLang (does not replace the primary E2E metric for cross-framework reads).

### `scripts/ci/utils/install_comparison_frameworks.sh`
- Isolated framework venv installer/cleanup (`install` / `remove`).
- Pinning / markers for reproducible nightly runs (per ongoing review: version/commit drift and marker freshness).

### `scripts/ci/utils/diffusion/generate_diffusion_dashboard.py`
- Upgraded dashboard/reporting from fixed 2-framework mode to dynamic multi-framework mode.
- Added generic framework discovery/order, regression checks, and trend/speedup sections.
- Updated chart generation to support all frameworks with per-competitor speedup plots.

### `.github/workflows/nightly-test-nvidia.yml` and `scripts/ci/utils/post_diffusion_comparison_to_slack.py`

- **Slack integration:** nightly workflow hooks and a poster script to send diffusion comparison summaries to Slack (commit `ci: slack API integration`).

<!-- Detail the changes made in this pull request. -->
## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
Not applicable as a standalone “model accuracy” change: this PR is **CI and harness** work. Functional validation is **green comparison runs** (artifacts: JSON results + generated dashboard). Image/token-level accuracy benchmarking remains out of scope unless a future change adds golden outputs for specific cases.
## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
<img width="669" height="352" alt="762455f3fde53151798e99b4e40305f2" src="https://github.com/user-attachments/assets/1e4e1946-8df4-4186-818d-7decba87c536" />

### Cross-framework pairs (same `case_id`)
| Case ID | Task | Framework | `latency_s` (client E2E, s) | `server_latency_s` (SGLang only, s) |
| -------- | ------ | ---------- | --------------------------- | ----------------------------------- |
| `flux1_dev_t2i_1024` | text-to-image | SGLang | 6.835 | 6.613 |
| `flux1_dev_t2i_1024` | text-to-image | vLLM-Omni | 8.151 | — |
| `ltx2_twostage_t2v` | text-to-video | SGLang | 21.042 | 17.424 |
| `ltx2_twostage_t2v` | text-to-video | LightX2V | 28.060 | — |

Indicative deltas on this single local run (lower is better): **~16%** lower client E2E vs vLLM-Omni on FLUX.1-dev T2I; **~25%** lower vs LightX2V on LTX-2 two-stage T2V. **Reconfirm on nightly** with identical prompts, resolution, and seeds.
## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.