### PR TITLE
[Docs] Move ptxas sm_103a workaround into For CUDA 13 section

### DIFF
--- a/docs/get_started/install.md
+++ b/docs/get_started/install.md
@@ -38,6 +38,11 @@ uv pip install "https://github.com/sgl-project/whl/releases/download/vX.Y.Z/sgla
 uv pip install "https://github.com/sgl-project/whl/releases/download/vX.Y.Z/sglang_kernel-X.Y.Z+cu130-cp310-abi3-manylinux2014_aarch64.whl"
 ```
 
+4. If you encounter `ptxas fatal   : Value 'sm_103a' is not defined for option 'gpu-name'` on B300/GB300, fix it with:
+```bash
+export TRITON_PTXAS_PATH=/usr/local/cuda/bin/ptxas
+```
+
 ### **Quick fixes to common problems**
 - If you encounter `OSError: CUDA_HOME environment variable is not set`. Please set it to your CUDA install root with either of the following solutions:
   1. Use `export CUDA_HOME=/usr/local/cuda-<your-cuda-version>` to set the `CUDA_HOME` environment variable.
@@ -223,4 +228,3 @@ echo "Build and push completed successfully!"
 
 - [FlashInfer](https://github.com/flashinfer-ai/flashinfer) is the default attention kernel backend. It only supports sm75 and above. If you encounter any FlashInfer-related issues on sm75+ devices (e.g., T4, A10, A100, L4, L40S, H100), please switch to other kernels by adding `--attention-backend triton --sampling-backend pytorch` and open an issue on GitHub.
 - To reinstall flashinfer locally, use the following command: `pip3 install --upgrade flashinfer-python --force-reinstall --no-deps` and then delete the cache with `rm -rf ~/.cache/flashinfer`.
-- When encountering `ptxas fatal   : Value 'sm_103a' is not defined for option 'gpu-name'` on B300/GB300, fix it with `export TRITON_PTXAS_PATH=/usr/local/cuda/bin/ptxas`.


### PR DESCRIPTION
## Summary
- Move the `ptxas fatal: Value 'sm_103a' is not defined for option 'gpu-name'` workaround from "Common Notes" (bottom of the page) into the "For CUDA 13" section as step 4.
- This makes the fix more discoverable for users who pip install SGLang with CUDA 13 and run on B300/GB300 — they will see it right after the installation steps instead of having to scroll to the very end of the page.

## Test plan
- [ ] Verify the rendered docs page shows the warning as step 4 under "For CUDA 13"
- [ ] Verify the warning is removed from "Common Notes"

🤖 Generated with [Claude Code](https://claude.com/claude-code)