### PR TITLE
[Gateway] Optimize TTFT in PD Disaggregation: Decouple prefill response and decode streaming

### DIFF
--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -568,127 +568,217 @@ impl PDRouter {
             false,
         );
 
-        // Send both requests concurrently and wait for both
-        // Note: Using borrowed references avoids heap allocation
+        // Send both requests concurrently
         events::RequestPDSentEvent {
             prefill_url: prefill.url(),
             decode_url: decode.url(),
         }
         .emit();
 
-        let (prefill_result, decode_result) =
-            tokio::join!(prefill_request.send(), decode_request.send());
-
-        events::RequestReceivedEvent {}.emit();
-
-        // Process decode response
-        match decode_result {
-            Ok(res) => {
-                let status = StatusCode::from_u16(res.status().as_u16())
-                    .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-                debug!("Decode response status: {}", status);
-
-                if !status.is_success() {
-                    error!(
-                        "Decode server returned error status decode_url={} status={}",
-                        decode.url(),
-                        status
-                    );
-
-                    return self
-                        .handle_decode_error_response(res, &context, prefill, decode)
-                        .await;
+        // TTFT Optimization: For streaming requests without logprobs (the common case),
+        // fire prefill in background and only await decode's response.
+        // This avoids TTFT latency caused by prefill's event-loop blocking delay
+        // propagating through tokio::join! to the client.
+        //
+        // Root cause: In the original code, tokio::join! waits for BOTH prefill and decode
+        // HTTP responses. Prefill's response is gated by process_disagg_prefill_inflight_queue,
+        // which can only run between forward computations (~270ms each). Under load, this
+        // delays prefill's response by up to one full forward duration, blocking the router
+        // from proxying decode's already-ready stream to the client.
+        if context.is_stream && !context.return_logprob {
+            // Send prefill request in background — don't block decode's stream on it
+            let prefill_url_for_log = prefill.url().to_string();
+            tokio::spawn(async move {
+                match prefill_request.send().await {
+                    Ok(res) => {
+                        let status = res.status();
+                        if !status.is_success() {
+                            error!(
+                                "Prefill server returned error (background) prefill_url={} status={}",
+                                prefill_url_for_log, status
+                            );
+                        }
+                        // Consume response body to release the HTTP connection back to pool
+                        let _ = res.bytes().await;
+                    }
+                    Err(e) => {
+                        error!(
+                            "Prefill request failed (background) prefill_url={} error={}",
+                            prefill_url_for_log, e
+                        );
+                    }
                 }
+            });
 
-                // Process prefill response
-                let prefill_body = if context.return_logprob {
-                    match self
-                        .process_prefill_response(
-                            prefill_result,
-                            prefill.url(),
-                            context.return_logprob,
-                        )
-                        .await
-                    {
-                        Ok((_, body)) => body,
-                        Err(error_response) => return error_response,
-                    }
-                } else {
-                    // Even if we don't need logprobs, we should check prefill status
-                    match self
-                        .process_prefill_response(prefill_result, prefill.url(), false)
-                        .await
-                    {
-                        Ok((_, body)) => body,
-                        Err(error_response) => return error_response,
-                    }
-                };
+            // Only await decode response — start proxying immediately
+            let decode_result = decode_request.send().await;
 
-                if context.is_stream {
-                    // Streaming response
-                    let prefill_logprobs = if context.return_logprob {
-                        prefill_body
-                            .as_ref()
-                            .and_then(|body| serde_json::from_slice::<Value>(body).ok())
-                            .and_then(|json| {
-                                json.pointer("/meta_info/input_token_logprobs").cloned()
-                            })
-                    } else {
-                        None
-                    };
+            events::RequestReceivedEvent {}.emit();
+
+            match decode_result {
+                Ok(res) => {
+                    let status = StatusCode::from_u16(res.status().as_u16())
+                        .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+                    debug!("Decode response status (fast path): {}", status);
+
+                    if !status.is_success() {
+                        error!(
+                            "Decode server returned error decode_url={} status={}",
+                            decode.url(),
+                            status
+                        );
+                        return self
+                            .handle_decode_error_response(res, &context, prefill, decode)
+                            .await;
+                    }
 
                     let response_headers = header_utils::preserve_response_headers(res.headers());
 
                     self.create_streaming_response(
                         res.bytes_stream(),
                         status,
-                        prefill_logprobs,
-                        context.return_logprob,
+                        None,
+                        false,
                         None,
                         Some(response_headers),
                         prefill,
                         decode,
                     )
-                } else {
-                    // Non-streaming response
-                    if context.return_logprob {
-                        self.process_non_streaming_response(
-                            res,
-                            status,
-                            context.return_logprob,
-                            prefill_body,
-                        )
-                        .await
+                }
+                Err(e) => {
+                    error!(
+                        decode_url = %decode.url(),
+                        error = %e,
+                        "Decode request failed"
+                    );
+                    error::bad_gateway(
+                        "decode_server_error",
+                        format!("Decode server error: {}", e),
+                    )
+                }
+            }
+        } else {
+            // Original path: wait for both prefill and decode responses.
+            // Used for non-streaming requests and streaming requests with logprobs
+            // (which need prefill's response body for logprob merging).
+            let (prefill_result, decode_result) =
+                tokio::join!(prefill_request.send(), decode_request.send());
+
+            events::RequestReceivedEvent {}.emit();
+
+            // Process decode response
+            match decode_result {
+                Ok(res) => {
+                    let status = StatusCode::from_u16(res.status().as_u16())
+                        .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+                    debug!("Decode response status: {}", status);
+
+                    if !status.is_success() {
+                        error!(
+                            "Decode server returned error status decode_url={} status={}",
+                            decode.url(),
+                            status
+                        );
+
+                        return self
+                            .handle_decode_error_response(res, &context, prefill, decode)
+                            .await;
+                    }
+
+                    // Process prefill response
+                    let prefill_body = if context.return_logprob {
+                        match self
+                            .process_prefill_response(
+                                prefill_result,
+                                prefill.url(),
+                                context.return_logprob,
+                            )
+                            .await
+                        {
+                            Ok((_, body)) => body,
+                            Err(error_response) => return error_response,
+                        }
                     } else {
-                        // Direct passthrough when no logprobs needed
+                        // Even if we don't need logprobs, we should check prefill status
+                        match self
+                            .process_prefill_response(prefill_result, prefill.url(), false)
+                            .await
+                        {
+                            Ok((_, body)) => body,
+                            Err(error_response) => return error_response,
+                        }
+                    };
+
+                    if context.is_stream {
+                        // Streaming response with logprobs
+                        let prefill_logprobs = if context.return_logprob {
+                            prefill_body
+                                .as_ref()
+                                .and_then(|body| serde_json::from_slice::<Value>(body).ok())
+                                .and_then(|json| {
+                                    json.pointer("/meta_info/input_token_logprobs").cloned()
+                                })
+                        } else {
+                            None
+                        };
+
                         let response_headers =
                             header_utils::preserve_response_headers(res.headers());
 
-                        match res.bytes().await {
-                            Ok(decode_body) => {
-                                let mut response = Response::new(Body::from(decode_body));
-                                *response.status_mut() = status;
-                                *response.headers_mut() = response_headers;
-                                response
-                            }
-                            Err(e) => {
-                                error!("Failed to read decode response: {}", e);
-                                error::internal_error(
-                                    "read_response_failed",
-                                    "Failed to read response",
-                                )
+                        self.create_streaming_response(
+                            res.bytes_stream(),
+                            status,
+                            prefill_logprobs,
+                            context.return_logprob,
+                            None,
+                            Some(response_headers),
+                            prefill,
+                            decode,
+                        )
+                    } else {
+                        // Non-streaming response
+                        if context.return_logprob {
+                            self.process_non_streaming_response(
+                                res,
+                                status,
+                                context.return_logprob,
+                                prefill_body,
+                            )
+                            .await
+                        } else {
+                            // Direct passthrough when no logprobs needed
+                            let response_headers =
+                                header_utils::preserve_response_headers(res.headers());
+
+                            match res.bytes().await {
+                                Ok(decode_body) => {
+                                    let mut response = Response::new(Body::from(decode_body));
+                                    *response.status_mut() = status;
+                                    *response.headers_mut() = response_headers;
+                                    response
+                                }
+                                Err(e) => {
+                                    error!("Failed to read decode response: {}", e);
+                                    error::internal_error(
+                                        "read_response_failed",
+                                        "Failed to read response",
+                                    )
+                                }
                             }
                         }
                     }
                 }
-            }
-            Err(e) => {
-                error!(
-                    decode_url = %decode.url(),
-                    error = %e,
-                    "Decode request failed"
-                );
-                error::bad_gateway("decode_server_error", format!("Decode server error: {}", e))
+                Err(e) => {
+                    error!(
+                        decode_url = %decode.url(),
+                        error = %e,
+                        "Decode request failed"
+                    );
+                    error::bad_gateway(
+                        "decode_server_error",
+                        format!("Decode server error: {}", e),
+                    )
+                }
             }
         }
     }

--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -577,14 +577,7 @@ impl PDRouter {
 
         // TTFT Optimization: For streaming requests without logprobs (the common case),
         // fire prefill in background and only await decode's response.
-        // This avoids TTFT latency caused by prefill's event-loop blocking delay
-        // propagating through tokio::join! to the client.
-        //
-        // Root cause: In the original code, tokio::join! waits for BOTH prefill and decode
-        // HTTP responses. Prefill's response is gated by process_disagg_prefill_inflight_queue,
-        // which can only run between forward computations (~270ms each). Under load, this
-        // delays prefill's response by up to one full forward duration, blocking the router
-        // from proxying decode's already-ready stream to the client.
+        // This avoids blocking the decode stream proxy on prefill's HTTP response latency.
         if context.is_stream && !context.return_logprob {
             // Send prefill request in background — don't block decode's stream on it
             let prefill_url_for_log = prefill.url().to_string();
@@ -711,16 +704,12 @@ impl PDRouter {
 
                     if context.is_stream {
                         // Streaming response with logprobs
-                        let prefill_logprobs = if context.return_logprob {
-                            prefill_body
-                                .as_ref()
-                                .and_then(|body| serde_json::from_slice::<Value>(body).ok())
-                                .and_then(|json| {
-                                    json.pointer("/meta_info/input_token_logprobs").cloned()
-                                })
-                        } else {
-                            None
-                        };
+                        let prefill_logprobs = prefill_body
+                            .as_ref()
+                            .and_then(|body| serde_json::from_slice::<Value>(body).ok())
+                            .and_then(|json| {
+                                json.pointer("/meta_info/input_token_logprobs").cloned()
+                            });
 
                         let response_headers =
                             header_utils::preserve_response_headers(res.headers());


### PR DESCRIPTION
## Motivation
Fix #22853
This PR improves the TTFT of PD HTTP routing in the common streaming path.
In the previous implementation of `execute_dual_dispatch_internal`, the router waited for both prefill and decode HTTP responses before starting to proxy the decode stream. This adds avoidable latency to the first streamed token for the common case where:
* the request is streaming, and
* input logprobs are not requested.
Since input logprob merging is only needed when return_logprob=true, waiting for the prefill HTTP response in the no-logprob streaming path does not provide value on the critical path, but does delay stream startup.

The goal of this PR is to reduce that overhead and improve end-to-end streaming responsiveness in PD mode.

## Modifications

This PR updates the PD HTTP router in sgl-model-gateway/src/routers/http/pd_router.rs:

* Added a fast path in [execute_dual_dispatch_internal()](vscode-webview://03hgedb0gcobonia4pisqfi8qgriano10tbqlibain2qjqsl3mib/sgl-model-gateway/src/routers/http/pd_router.rs:533-794) for: context.is_stream == true context.return_logprob == false
* In this fast path: the prefill request is dispatched in the background; the router only waits for the decode response,
decode streaming is proxied to the client as soon as the decode side is ready.
* Kept the original behavior for: non-streaming requests and streaming requests with logprobs
* Preserved prefill response consumption in the background path so the HTTP connection can still be released back to the pool.
* Kept logprob-dependent behavior unchanged by continuing to use `process_prefill_response()` and the original dual-response path when return_logprob=true.

In short, this change narrows the optimization to the most common latency-sensitive streaming scenario while keeping the logprob path and non-streaming path behavior unchanged.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
