### PR TITLE
Streaming session: fix retract tail leak via _free_tail

### DIFF
--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -9,7 +9,6 @@ import triton.language as tl
 
 from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache, EvictParams
 from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool, ReqToTokenPool
-from sglang.srt.mem_cache.session_aware_cache import SessionAwareCache, _is_streaming
 from sglang.srt.mem_cache.swa_memory_pool import SWATokenToKVPoolAllocator
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import support_triton
@@ -477,50 +476,11 @@ def release_kv_cache(req: Req, tree_cache: BasePrefixCache, is_insert: bool = Tr
             req.mamba_pool_idx = None
         return
 
-    # Streaming sessions transfer req_pool ownership into SessionSlot objects.
-    # Trim any speculative tail before that transfer, otherwise later turns
-    # restore only the committed prefix and can strand unreachable KV pages.
-    #
-    # Aborted streaming-session requests (e.g. input too long) skip the
-    # streaming path entirely.  match_prefix did not restore the slot's KV
-    # state, so the request has a fresh pool slot that should be freed by
-    # cache_finished_req below (which also sets req_pool_idx = None).
-    from sglang.srt.managers.schedule_batch import FINISH_ABORT
-
-    is_streaming_session = isinstance(tree_cache, SessionAwareCache) and _is_streaming(
-        req
-    )
-    is_aborted_streaming = is_streaming_session and isinstance(
-        getattr(req, "finished_reason", None), FINISH_ABORT
-    )
-    if is_streaming_session and not is_aborted_streaming:
-        start_p, end_p = req.pop_overallocated_kv_cache()
-        page_size = get_global_server_args().page_size
-        if page_size > 1:
-            start_p = ceil_align(start_p, page_size)
-        if start_p < end_p:
-            indices_to_free = tree_cache.req_to_token_pool.req_to_token[
-                req.req_pool_idx
-            ][start_p:end_p]
-            tree_cache.token_to_kv_pool_allocator.free(indices_to_free)
-        req.kv_allocated_len = req.kv_committed_len
-
     tree_cache.cache_finished_req(req, is_insert=is_insert)
 
-    # SessionAwareCache.cache_finished_req sets req_pool_idx = None to transfer
-    # KV ownership to the SessionSlot, so the remaining cleanup is skipped.
-    # Streaming-session specific overalloc trimming must therefore happen
-    # before cache_finished_req above.
+    # SessionAwareCache.cache_finished_req handles speculative tail trim
+    # and bookkeeping flag sync internally, then sets req_pool_idx = None.
     if req.req_pool_idx is None:
-        if is_streaming_session:
-            # The request no longer owns any KV once SessionAwareCache either
-            # transfers it into the session slot or frees it on abort. Mark
-            # both bookkeeping flags so busy-time memory checks do not keep
-            # counting this finished request as uncached KV.
-            if not req.kv_committed_freed:
-                req.pop_committed_kv_cache()
-            if not req.kv_overallocated_freed:
-                req.pop_overallocated_kv_cache()
         return
 
     start_p, end_p = req.pop_overallocated_kv_cache()

--- a/python/sglang/srt/mem_cache/session_aware_cache.py
+++ b/python/sglang/srt/mem_cache/session_aware_cache.py
@@ -193,13 +193,9 @@ class SessionAwareCache(BasePrefixCache):
 
         slot.restore_to_req(req)
 
-        # init_next_round_input passes token_ids = fill_ids[:input_len-1],
-        # reserving 1 token for prefill so the forward pass can produce
-        # logits to sample the next token. We use token_ids length directly
-        # (no additional -1) — the reservation has already been applied.
-        # min is needed: on retract retry, kv_committed_len can exceed
-        # len(token_ids) by 1 due to the logit-reservation truncation
-        # (fill_ids[:input_len-1]).
+        # token_ids = fill_ids[:input_len-1] (1-token logit reserve already
+        # applied). min handles retract retry where committed_len can
+        # exceed len(token_ids) by 1.
         prefix_len = min(req.kv_committed_len, len(params.key.token_ids))
 
         # Streaming sessions are append-only (session_controller rollback

--- a/python/sglang/srt/mem_cache/session_aware_cache.py
+++ b/python/sglang/srt/mem_cache/session_aware_cache.py
@@ -272,11 +272,13 @@ class SessionAwareCache(BasePrefixCache):
 
     def _free_tail(self, slot: SessionSlot, req: Req, prefix_len: int):
         """Free KV in [prefix_len, kv_allocated_len) before the next
-        alloc_for_extend overwrites it (spec tail, alloc-commit gap, or
-        logit-reserve offset). Free start is ceil-aligned to page_size:
-        PagedTokenToKVPoolAllocator frees by whole pages, so partial-page
-        free would corrupt pages still holding committed tokens; the gap
-        stays attached until release_session.
+        alloc_for_extend overwrites it. The gap appears when spec
+        decoding pushes allocated above committed, or when retract
+        retry's logit-reserve pulls prefix_len below committed.
+        Free start is ceil-aligned to page_size: PagedTokenToKVPoolAllocator
+        frees by whole pages, so partial-page free would corrupt pages
+        still holding committed tokens; the gap stays attached until
+        release_session.
         """
         if prefix_len >= slot.kv_allocated_len:
             return

--- a/python/sglang/srt/mem_cache/session_aware_cache.py
+++ b/python/sglang/srt/mem_cache/session_aware_cache.py
@@ -193,10 +193,29 @@ class SessionAwareCache(BasePrefixCache):
 
         slot.restore_to_req(req)
 
-        # logprob_start_len is already forced to -1 for streaming sessions
-        # (in Req.init_next_round_input), so the prefix key is not truncated
-        # and we can directly reuse the committed KV length.
-        prefix_len = min(req.kv_committed_len, max(len(params.key.token_ids) - 1, 0))
+        # init_next_round_input passes token_ids = fill_ids[:input_len-1],
+        # reserving 1 token for prefill so the forward pass can produce
+        # logits to sample the next token. We use token_ids length directly
+        # (no additional -1) — the reservation has already been applied.
+        # min is needed: on retract retry, kv_committed_len can exceed
+        # len(token_ids) by 1 due to the logit-reservation truncation
+        # (fill_ids[:input_len-1]).
+        prefix_len = min(req.kv_committed_len, len(params.key.token_ids))
+
+        # Streaming sessions are append-only (session_controller rollback
+        # ensures req_nodes always points to the last successful req).
+        assert prefix_len >= slot.cache_protected_len, (
+            f"streaming session prefix shrank: {prefix_len=} < "
+            f"{slot.cache_protected_len=}"
+        )
+
+        # Free orphaned tail: alloc_for_extend will overwrite
+        # req_to_token[prefix_len:] with new indices. The range
+        # [prefix_len, kv_allocated_len) has stale indices from the
+        # previous turn's decode (e.g. alloc-commit gap on retract,
+        # or speculative draft tokens).
+        self._free_tail(slot, req, prefix_len)
+
         device_indices = self.req_to_token_pool.req_to_token[
             req.req_pool_idx, :prefix_len
         ].to(dtype=torch.int64)
@@ -255,6 +274,25 @@ class SessionAwareCache(BasePrefixCache):
 
         self._mark_kv_freed(req)
 
+    def _free_tail(self, slot: SessionSlot, req: Req, prefix_len: int):
+        """Free orphaned KV indices in [prefix_len, kv_allocated_len).
+
+        Covers spec draft tokens, decode alloc-commit gap, and the 1-token
+        logit-reserve offset on retract retry. No-op when no tail exists.
+        """
+        if prefix_len >= slot.kv_allocated_len:
+            return
+        tail_indices = self.req_to_token_pool.req_to_token[
+            slot.req_pool_idx, prefix_len : slot.kv_allocated_len
+        ]
+        self.token_to_kv_pool_allocator.free(tail_indices)
+        slot.kv_allocated_len = prefix_len
+        slot.kv_committed_len = min(slot.kv_committed_len, prefix_len)
+        slot.swa_evicted_seqlen = min(slot.swa_evicted_seqlen, prefix_len)
+        req.kv_allocated_len = prefix_len
+        req.kv_committed_len = min(req.kv_committed_len, prefix_len)
+        req.swa_evicted_seqlen = min(req.swa_evicted_seqlen, prefix_len)
+
     @staticmethod
     def _mark_kv_freed(req: Req):
         """Set bookkeeping flags so busy check skips this finished req."""
@@ -298,14 +336,7 @@ class SessionAwareCache(BasePrefixCache):
     # -- Session lifecycle --
 
     def release_session(self, session_id: str):
-        """Release all KV resources held by a streaming session.
-
-        `slot.last_node` + `slot.cache_protected_len` are trusted directly: radix
-        tree splits mutate TreeNode objects in place (see RadixCache._split_node),
-        so a saved TreeNode reference remains valid and the locked prefix length
-        is unchanged. No rematch needed -- and `match_prefix` here would cause
-        further splits that disturb accounting.
-        """
+        """Release all KV resources held by a streaming session."""
         slot = self.slots.pop(session_id, None)
         if slot is None:
             return

--- a/python/sglang/srt/mem_cache/session_aware_cache.py
+++ b/python/sglang/srt/mem_cache/session_aware_cache.py
@@ -279,13 +279,24 @@ class SessionAwareCache(BasePrefixCache):
 
         Covers spec draft tokens, decode alloc-commit gap, and the 1-token
         logit-reserve offset on retract retry. No-op when no tail exists.
+
+        Page-aligned: free_start is ceil-aligned to page_size so we never
+        free a partial page. PagedTokenToKVPoolAllocator.free returns whole
+        pages to the free list (free_index // page_size); freeing tokens
+        that share a page with still-committed tokens would corrupt the
+        page allocator. The tokens in [prefix_len, free_start) stay
+        attached to the slot until release_session frees the whole page.
         """
         if prefix_len >= slot.kv_allocated_len:
             return
-        tail_indices = self.req_to_token_pool.req_to_token[
-            slot.req_pool_idx, prefix_len : slot.kv_allocated_len
-        ]
-        self.token_to_kv_pool_allocator.free(tail_indices)
+        free_start = prefix_len
+        if self.page_size > 1:
+            free_start = ceil_align(free_start, self.page_size)
+        if free_start < slot.kv_allocated_len:
+            tail_indices = self.req_to_token_pool.req_to_token[
+                slot.req_pool_idx, free_start : slot.kv_allocated_len
+            ]
+            self.token_to_kv_pool_allocator.free(tail_indices)
         slot.kv_allocated_len = prefix_len
         slot.kv_committed_len = min(slot.kv_committed_len, prefix_len)
         slot.swa_evicted_seqlen = min(slot.swa_evicted_seqlen, prefix_len)

--- a/python/sglang/srt/mem_cache/session_aware_cache.py
+++ b/python/sglang/srt/mem_cache/session_aware_cache.py
@@ -271,17 +271,12 @@ class SessionAwareCache(BasePrefixCache):
         self._mark_kv_freed(req)
 
     def _free_tail(self, slot: SessionSlot, req: Req, prefix_len: int):
-        """Free orphaned KV indices in [prefix_len, kv_allocated_len).
-
-        Covers spec draft tokens, decode alloc-commit gap, and the 1-token
-        logit-reserve offset on retract retry. No-op when no tail exists.
-
-        Page-aligned: free_start is ceil-aligned to page_size so we never
-        free a partial page. PagedTokenToKVPoolAllocator.free returns whole
-        pages to the free list (free_index // page_size); freeing tokens
-        that share a page with still-committed tokens would corrupt the
-        page allocator. The tokens in [prefix_len, free_start) stay
-        attached to the slot until release_session frees the whole page.
+        """Free KV in [prefix_len, kv_allocated_len) before the next
+        alloc_for_extend overwrites it (spec tail, alloc-commit gap, or
+        logit-reserve offset). Free start is ceil-aligned to page_size:
+        PagedTokenToKVPoolAllocator frees by whole pages, so partial-page
+        free would corrupt pages still holding committed tokens; the gap
+        stays attached until release_session.
         """
         if prefix_len >= slot.kv_allocated_len:
             return


### PR DESCRIPTION
## Streaming session: free orphaned KV tail via `_free_tail`

Streaming sessions leak KV pool indices whenever the next turn's `prefix_len` is less than the slot's `kv_allocated_len`. The existing `common.py` spec-tail-trim only handles the speculative-decoding source. This PR replaces it with a single `_free_tail` call in `match_prefix` that handles every source by construction, plus the page-aligned cleanup needed for `PagedTokenToKVPoolAllocator`.

### Root cause

When a streaming session resumes, `alloc_for_extend` writes new pool indices into `req_to_token[pool_idx, prefix_len : seq_len]`. Old indices already in that range get overwritten — the allocator still tracks them as in-use, but no `req_to_token` entry references them. Pure leak.

The leaked range is always `[prefix_len, kv_allocated_len)`. Two mechanisms produce a non-empty gap:

- **Over-allocation pushes `allocated` above `committed`** — today this is speculative decoding (alloc `num_draft+1`, commit `num_accepted+1`); any future general over-allocation pattern produces the same gap.
- **Retract retry pulls `prefix_len` below `committed`** — `init_next_round_input` passes `fill_ids[:input_len-1]` on retract retry, so `len(token_ids)` is one short of the saved committed length, dropping `prefix_len` by 1.

### Old design and what it missed

`release_kv_cache` had a streaming-session branch that trimmed `[committed, allocated)` before `save_from_req`. Two gaps it didn't catch:

- **Logit-reserve off-by-1 leaks per turn** — the trim handles `committed < allocated` but not `prefix_len < committed`. Even when the slot saves with `committed == allocated = K`, the next turn computes `prefix_len = K-1` (logit reserve) and `alloc_for_extend` overwrites position `K-1`. Slow drip: 1 token per turn under retract or any path that triggers the reserve.
- **Couples streaming logic into `common.py`** — violates the decorator pattern. Reviewers of the generic release path have to remember the streaming special case, and the trim duplicates work that `match_prefix` is better positioned to do.

### New design: `_free_tail` in `match_prefix`

Runs once per turn, immediately after `restore_to_req` and before `alloc_for_extend`. Frees `[prefix_len, kv_allocated_len)`, then clamps slot + req lengths.

Why this location is correct, not just convenient:

- **`prefix_len` is the exact boundary `alloc_for_extend` will overwrite** — freeing `[prefix_len, kv_allocated_len)` matches the overwrite range. No leak, no over-free.
- **Single source covers every gap** — spec push, retract pull, future scenarios that produce `prefix_len < kv_allocated_len`. No per-source branching.
- **No-op in the common case** — non-spec, non-retract turns satisfy `prefix_len >= kv_allocated_len` and early-return. Zero overhead.
- **Decorator pattern preserved** — `common.py` has zero streaming-session awareness now.

### Page-aligned cleanup

`PagedTokenToKVPoolAllocator.free` returns whole pages to the free list (`free_index // page_size`), so freeing a partial page would corrupt pages that still hold committed tokens. `_free_tail` ceil-aligns `prefix_len` to `page_size` before freeing; the unaligned tail in `[prefix_len, free_start)` stays attached to the slot and is freed when `release_session` returns the whole page.

### Bonus

- Drop the buggy `prefix_len = min(committed, max(len(token_ids) - 1, 0))` to `prefix_len = min(committed, len(token_ids))`. The extra `-1` was double-counting the already-applied 1-token logit reserve.
- Add `assert prefix_len >= slot.cache_protected_len` — the append-only invariant established by #22790's `finish_req` pattern is now a checked property.
