### PR TITLE
[VLM] Support ViT Cuda Graph for Qwen2-VL

### DIFF
--- a/python/sglang/srt/models/qwen2_vl.py
+++ b/python/sglang/srt/models/qwen2_vl.py
@@ -442,15 +442,7 @@ class Qwen2VisionTransformer(nn.Module):
             emb.sin().to(x.device, x.dtype),
         )
 
-        # compute cu_seqlens on GPU as int32
-        cu_seqlens = torch.cat(
-            [
-                torch.tensor([0], device=x.device, dtype=torch.int32),
-                (grid_thw[:, 0] * grid_thw[:, 1] * grid_thw[:, 2])
-                .cumsum(dim=0)
-                .to(device=x.device, dtype=torch.int32),
-            ]
-        )
+        cu_seqlens = compute_cu_seqlens_from_grid_numpy(grid_thw).to(x.device)
 
         return self.cuda_graph_runner.run(
             x=x,

--- a/python/sglang/srt/models/qwen2_vl.py
+++ b/python/sglang/srt/models/qwen2_vl.py
@@ -33,6 +33,7 @@ from einops import rearrange
 from transformers import Qwen2VLConfig
 from transformers.models.qwen2_vl.configuration_qwen2_vl import Qwen2VLVisionConfig
 
+from sglang.srt.environ import envs
 from sglang.srt.layers.activation import QuickGELU
 from sglang.srt.layers.attention.vision import VisionAttention
 from sglang.srt.layers.conv import Conv3dLayer
@@ -50,8 +51,11 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.qwen2 import Qwen2Model
 from sglang.srt.models.utils import WeightsMapper, compute_cu_seqlens_from_grid_numpy
-from sglang.srt.utils import add_prefix, is_npu
+from sglang.srt.multimodal.vit_cuda_graph_runner import ViTCudaGraphRunner
+from sglang.srt.utils import add_prefix, is_cuda, is_npu
 from sglang.srt.utils.hf_transformers_utils import get_processor
+
+_is_cuda = is_cuda()
 
 logger = logging.getLogger(__name__)
 
@@ -162,6 +166,7 @@ class Qwen2VisionBlock(nn.Module):
         x: torch.Tensor,
         cu_seqlens: torch.Tensor,
         position_embeddings: torch.Tensor,
+        output_ws: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         hidden_states = self.norm1(x)
         hidden_states = rearrange(hidden_states, "s b ... -> b s ...")
@@ -169,6 +174,7 @@ class Qwen2VisionBlock(nn.Module):
             hidden_states,
             cu_seqlens=cu_seqlens,
             position_embeddings=position_embeddings,
+            output_ws=output_ws,
         )
         attn = rearrange(attn, "b s ... -> s b ...")
         x = x + attn
@@ -292,6 +298,7 @@ class Qwen2VisionTransformer(nn.Module):
         norm_eps: float = 1e-6,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        max_context_len: Optional[int] = None,
     ) -> None:
         super().__init__()
 
@@ -337,6 +344,13 @@ class Qwen2VisionTransformer(nn.Module):
             quant_config=quant_config,
             prefix=add_prefix("merger", prefix),
         )
+
+        self.max_context_len = max_context_len
+        self.enable_cg = _is_cuda and envs.SGLANG_VIT_ENABLE_CUDA_GRAPH.get()
+
+        self.cuda_graph_runner: Optional[ViTCudaGraphRunner] = None
+        if self.enable_cg:
+            self.cuda_graph_runner = ViTCudaGraphRunner(self)
 
     @property
     def dtype(self) -> torch.dtype:
@@ -384,6 +398,9 @@ class Qwen2VisionTransformer(nn.Module):
         x: torch.Tensor,
         grid_thw: torch.Tensor,
     ) -> torch.Tensor:
+        if self.enable_cg:
+            return self.forward_with_cuda_graph(x, grid_thw)
+
         # patchify
         x = x.to(device=self.device, dtype=self.dtype)
         x = self.patch_embed(x)
@@ -406,6 +423,41 @@ class Qwen2VisionTransformer(nn.Module):
         # adapter
         x = self.merger(x)
         return x
+
+    def forward_with_cuda_graph(
+        self,
+        x: torch.Tensor,
+        grid_thw: torch.Tensor,
+    ) -> torch.Tensor:
+        # patchify
+        x = x.to(device=self.device, dtype=self.dtype)
+        x = self.patch_embed(x)
+
+        # compute position embedding
+        rotary_pos_emb = self.rot_pos_emb(grid_thw)
+        rotary_pos_emb = rotary_pos_emb.to(device=x.device, dtype=x.dtype)
+        emb = torch.cat((rotary_pos_emb, rotary_pos_emb), dim=-1)
+        position_embeddings = (
+            emb.cos().to(x.device, x.dtype),
+            emb.sin().to(x.device, x.dtype),
+        )
+
+        # compute cu_seqlens on GPU as int32
+        cu_seqlens = torch.cat(
+            [
+                torch.tensor([0], device=x.device, dtype=torch.int32),
+                (grid_thw[:, 0] * grid_thw[:, 1] * grid_thw[:, 2])
+                .cumsum(dim=0)
+                .to(device=x.device, dtype=torch.int32),
+            ]
+        )
+
+        return self.cuda_graph_runner.run(
+            x=x,
+            position_embeddings=position_embeddings,
+            cu_seqlens=cu_seqlens,
+            cu_window_seqlens=cu_seqlens,
+        )
 
 
 cached_get_processor = lru_cache(get_processor)
@@ -462,6 +514,7 @@ class Qwen2VLForConditionalGeneration(nn.Module):
             # Other quantization methods (e.g., GPTQ, AWQ) are untested and may not be supported.
             quant_config=quant_config,
             prefix=add_prefix("visual", prefix),
+            max_context_len=getattr(config, "max_position_embeddings", None),
         )
 
         self.model = Qwen2Model(

--- a/python/sglang/srt/multimodal/vit_cuda_graph_runner.py
+++ b/python/sglang/srt/multimodal/vit_cuda_graph_runner.py
@@ -24,6 +24,7 @@ import torch
 import torch.nn as nn
 
 from sglang.srt.distributed.parallel_state import get_tp_group
+from sglang.srt.environ import envs
 from sglang.srt.layers.attention.vision import VisionAttention
 from sglang.srt.server_args import get_global_server_args
 
@@ -116,6 +117,14 @@ class ViTCudaGraphRunner:
         # x_3d: [S, B, H], B=1, S as graph_key
         return x_3d.shape[0]
 
+    def _warmup_eager(self, graph_key: int, **kw):
+        """Eager forward to trigger all lazy init (torch.compile, Triton JIT, cuDNN)
+        before CUDA graph capture."""
+        kw = {k: v for k, v in kw.items() if v is not None}
+        with envs.SGLANG_VIT_ENABLE_CUDA_GRAPH.override(False):
+            y = self.block_input[graph_key]
+            self.vit.blocks[0](y, cu_seqlens=self.cu_full_len[graph_key], **kw)
+
     def _create_graph(
         self,
         graph_key: int,
@@ -125,6 +134,12 @@ class ViTCudaGraphRunner:
         rotary_pos_emb_cos: Optional[torch.Tensor] = None,
         rotary_pos_emb_sin: Optional[torch.Tensor] = None,
     ):
+        self._warmup_eager(
+            graph_key,
+            position_embeddings=position_embeddings,
+            rotary_pos_emb_cos=rotary_pos_emb_cos,
+            rotary_pos_emb_sin=rotary_pos_emb_sin,
+        )
 
         graph = torch.cuda.CUDAGraph()
         vit = self.vit


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Support ViT Cuda Graph for Qwen2-VL.

## Modifications

- Introduce ViT Cuda Graph into Qwen2-VL.
- Introduce a warmup stage before creating the graph to avoid occasional `torch.compile` errors.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

TTFT 622.86ms -> 596.06ms, drop 4.3%.

Server:
```bash
SGLANG_MM_FEATURE_CACHE_MB=4096 \
SGLANG_USE_CUDA_IPC_TRANSPORT=1 \
SGLANG_VLM_CACHE_SIZE_MB=0 \
SGLANG_VIT_ENABLE_CUDA_GRAPH=1 \
python3 -m sglang.launch_server --host 0.0.0.0 \
    --mem-fraction-static 0.7 \
    --port 30000 \
    --max-running-requests 64 \
    --chunked-prefill-size 8192 \
    --attention-backend fa3 \
    --mm-attention-backend fa3 \
    --enable-multimodal \
    --model Qwen/Qwen2-VL-2B-Instruct \
    --disable-radix-cache \
    --piecewise-cuda-graph-max-tokens 8192 \
    --enable-piecewise-cuda-graph \
    --piecewise-cuda-graph-compiler eager
```

Client:
```bash
python3 -m sglang.bench_serving \
  --backend sglang-oai-chat \
  --dataset-name image \
  --num-prompts 256 \
  --apply-chat-template \
  --random-input-len 128 \
  --random-output-len 32 \
  --image-resolution 560x560 \
  --image-format jpeg \
  --image-count 1 \
  --image-content random \
  --random-range-ratio 0.1 \
  --port 30000 \
  --warmup-requests 32 \
  --max-concurrency 32
```

PR:
```
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf       
Max request concurrency:                 32        
Successful requests:                     256       
Benchmark duration (s):                  13.14     
Total input tokens:                      126330    
Total input text tokens:                 23418     
Total input vision tokens:               102912    
Total generated tokens:                  4541      
Total generated tokens (retokenized):    4438      
Request throughput (req/s):              19.49     
Input token throughput (tok/s):          9617.05   
Output token throughput (tok/s):         345.69    
Peak output token throughput (tok/s):    466.00    
Peak concurrent requests:                72        
Total token throughput (tok/s):          9962.74   
Concurrency:                             31.47     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   1614.68   
Median E2E Latency (ms):                 1564.23   
P90 E2E Latency (ms):                    2545.79   
P99 E2E Latency (ms):                    3233.25   
---------------Time to First Token----------------
Mean TTFT (ms):                          596.06    
Median TTFT (ms):                        441.84    
P99 TTFT (ms):                           1484.85   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          58.54     
Median TPOT (ms):                        62.02     
P99 TPOT (ms):                           119.98    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           76.56     
Median ITL (ms):                         21.12     
P95 ITL (ms):                            376.63    
P99 ITL (ms):                            526.24    
Max ITL (ms):                            1167.82   
==================================================
```

Baseline:
```
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf       
Max request concurrency:                 32        
Successful requests:                     256       
Benchmark duration (s):                  14.06     
Total input tokens:                      126367    
Total input text tokens:                 23455     
Total input vision tokens:               102912    
Total generated tokens:                  4541      
Total generated tokens (retokenized):    4476      
Request throughput (req/s):              18.21     
Input token throughput (tok/s):          8988.72   
Output token throughput (tok/s):         323.01    
Peak output token throughput (tok/s):    401.00    
Peak concurrent requests:                61        
Total token throughput (tok/s):          9311.73   
Concurrency:                             31.56     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   1733.21   
Median E2E Latency (ms):                 1699.39   
P90 E2E Latency (ms):                    2757.07   
P99 E2E Latency (ms):                    3659.82   
---------------Time to First Token----------------
Mean TTFT (ms):                          622.86    
Median TTFT (ms):                        484.13    
P99 TTFT (ms):                           1603.19   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          62.92     
Median TPOT (ms):                        64.80     
P99 TPOT (ms):                           115.60    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           82.72     
Median ITL (ms):                         22.71     
P95 ITL (ms):                            438.17    
P99 ITL (ms):                            689.32    
Max ITL (ms):                            1256.07   
==================================================
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
