### PR TITLE
Fix PD disaggregation prefill warmup 400 error for VLM models

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1886,7 +1886,13 @@ def _execute_server_warmup(server_args: ServerArgs):
     # Construct a warmup request
     is_vlm = bool(model_info.get("has_image_understanding", False))
     if model_info["is_generation"]:
-        if is_vlm and not server_args.skip_tokenizer_init:
+        # For PD disaggregation mode, use /generate endpoint to avoid
+        # chat/completions format incompatibility with bootstrap fields
+        if (
+            is_vlm
+            and not server_args.skip_tokenizer_init
+            and server_args.disaggregation_mode == "null"
+        ):
             request_name = "/v1/chat/completions"
         else:
             request_name = "/generate"


### PR DESCRIPTION
## Summary

Fix warmup request failing with HTTP 400 when launching a server in PD disaggregation mode with a model that is detected as having image understanding (VLM).

- In `_execute_server_warmup()`, the warmup endpoint was selected as `/v1/chat/completions` for VLM models, but the disaggregation warmup payload uses the `/generate` format (with `bootstrap_host`, `bootstrap_room`, `input_ids` fields)
- The `/v1/chat/completions` endpoint does not accept these disaggregation-specific fields, causing a 400 Bad Request
- Fix: restrict `/v1/chat/completions` warmup to non-disaggregation mode only (`disaggregation_mode == "null"`), so PD disaggregation always uses the `/generate` endpoint

Closes #22871