### PR TITLE
test: fix flaky required function calling assertion

### DIFF
--- a/test/registered/openai_server/function_call/test_openai_function_calling.py
+++ b/test/registered/openai_server/function_call/test_openai_function_calling.py
@@ -416,8 +416,10 @@ class TestOpenAIServerFunctionCalling(CustomTestCase):
 
     def test_function_call_required(self):
         """
-        Test: Whether tool_choice: "required" works as expected
-        - When tool_choice == "required", the model should return one or more tool_calls.
+        Test: Whether tool_choice: "required" works as expected.
+        - When tool_choice == "required", the model MUST return one or more tool_calls.
+        - The model may choose ANY of the provided tools; we only verify that
+          a tool call exists and the selected name is among the candidates.
         """
         client = openai.Client(api_key=self.api_key, base_url=self.base_url)
 
@@ -459,53 +461,39 @@ class TestOpenAIServerFunctionCalling(CustomTestCase):
                         },
                         "required": ["city"],
                     },
+                    "strict": True,
                 },
             },
         ]
 
-        messages = [{"role": "user", "content": "What is the capital of France?"}]
-        # strict=True ensures constrained decoding enforces the parameter schema.
-        # Without it, tool_choice="required" only guarantees a tool call is made
-        # but arguments are best-effort (may be empty on small models).
-        for tool in tools:
-            tool["function"]["strict"] = True
+        valid_tool_names = {t["function"]["name"] for t in tools}
+
+        messages = [{"role": "user", "content": "Tell me about Paris"}]
         response = client.chat.completions.create(
             model=self.model,
             max_tokens=2048,
             messages=messages,
-            temperature=0.8,
-            top_p=0.8,
+            temperature=0,
             stream=False,
             tools=tools,
             tool_choice="required",
         )
 
         tool_calls = response.choices[0].message.tool_calls
-        self.assertIsNotNone(tool_calls, "No tool_calls in the response")
+        self.assertIsNotNone(tool_calls, "tool_choice='required' must produce tool_calls")
+        self.assertGreater(len(tool_calls), 0, "tool_calls list should be non-empty")
+
         function_name = tool_calls[0].function.name
+        self.assertIn(
+            function_name,
+            valid_tool_names,
+            f"Function name '{function_name}' is not among the provided tools: {valid_tool_names}",
+        )
+
+        # Verify the arguments are parseable JSON
         arguments = tool_calls[0].function.arguments
         args_obj = json.loads(arguments)
-
-        self.assertEqual(
-            function_name,
-            "get_weather",
-            f"Function name should be 'get_weather', got: {function_name}",
-        )
-        self.assertIn(
-            "city", args_obj, f"Function arguments should have 'city', got: {args_obj}"
-        )
-
-        # Make the test more robust by checking type and accepting valid responses
-        city_value = args_obj["city"]
-        self.assertIsInstance(
-            city_value,
-            str,
-            f"Parameter city should be a string, got: {type(city_value)}",
-        )
-        self.assertTrue(
-            "Paris" in city_value or "France" in city_value,
-            f"Parameter city should contain either 'Paris' or 'France', got: {city_value}",
-        )
+        self.assertIsInstance(args_obj, dict, "Function arguments should be a JSON object")
 
     def test_function_call_specific(self):
         """

--- a/test/registered/openai_server/function_call/test_openai_function_calling.py
+++ b/test/registered/openai_server/function_call/test_openai_function_calling.py
@@ -480,7 +480,9 @@ class TestOpenAIServerFunctionCalling(CustomTestCase):
         )
 
         tool_calls = response.choices[0].message.tool_calls
-        self.assertIsNotNone(tool_calls, "tool_choice='required' must produce tool_calls")
+        self.assertIsNotNone(
+            tool_calls, "tool_choice='required' must produce tool_calls"
+        )
         self.assertGreater(len(tool_calls), 0, "tool_calls list should be non-empty")
 
         function_name = tool_calls[0].function.name
@@ -493,7 +495,9 @@ class TestOpenAIServerFunctionCalling(CustomTestCase):
         # Verify the arguments are parseable JSON
         arguments = tool_calls[0].function.arguments
         args_obj = json.loads(arguments)
-        self.assertIsInstance(args_obj, dict, "Function arguments should be a JSON object")
+        self.assertIsInstance(
+            args_obj, dict, "Function arguments should be a JSON object"
+        )
 
     def test_function_call_specific(self):
         """


### PR DESCRIPTION
## Summary
- fix the flaky `test_function_call_required` semantics around `tool_choice="required"`
- assert that a tool call is produced and that the chosen tool is one of the provided candidates
- reduce sampling randomness to make the test deterministic

## Root cause

`tool_choice="required"` only guarantees the model **must call some tool** — it does not specify *which* tool. The old test hard-coded `assertEqual(function_name, "get_weather")`, but at `temperature=0.8` with constrained decoding (`strict=True`), `Llama-3.2-1B` occasionally selects `sub` instead.

This flaky was introduced by #21593 (changed `tool_choice="required"` protocol semantics). #22586 fixed the 30% empty-argument failure (`'city' not found in {}`) by adding `strict=True`, but did **not** fix the tool-selection flaky (`got: sub`).

## Evidence of flakiness (before this PR)

| Run | PR | Failure |
|-----|-----|---------|
| [job/71373855817](https://github.com/sgl-project/sglang/actions/runs/24393739160/job/71373855817?pr=22702) | #22702 | `Function name should be 'get_weather', got: sub` (twice, including retry) |
| [run/24278712753](https://github.com/sgl-project/sglang/actions/runs/24278712753) | #22586 evidence | 1st try: `'city' not found in {}`; retry: `got: sub` |

## This fix
1. `temperature=0` — eliminate sampling randomness
2. Assert `function_name in valid_tool_names` — only verify the semantic contract of `tool_choice="required"` (any provided tool is valid)
3. Only verify arguments are parseable JSON, not specific content

## Validation

Ran `test_openai_function_calling.py` via `/rerun-test` on this PR — **3/3 pass**:

| # | Run | Result |
|---|-----|--------|
| 1 | [run/24499351599](https://github.com/sgl-project/sglang/actions/runs/24499351599) | ✅ pass (11 tests, 89.8s) |
| 2 | [run/24500160080](https://github.com/sgl-project/sglang/actions/runs/24500160080) | ✅ pass (11 tests, 90.4s) |
| 3 | [run/24500163392](https://github.com/sgl-project/sglang/actions/runs/24500163392) | ✅ pass (11 tests, 90.2s) |