### PR TITLE
fix(jit_kernel): add missing <cassert> include   in awq_dequantize.cuh

### DIFF
--- a/python/sglang/jit_kernel/csrc/gemm/awq_dequantize.cuh
+++ b/python/sglang/jit_kernel/csrc/gemm/awq_dequantize.cuh
@@ -3,7 +3,9 @@
 #pragma once
 
 #include <sgl_kernel/tensor.h>
+
 #include <cassert>
+
 #include <sgl_kernel/utils.cuh>
 
 namespace device::awq {

--- a/python/sglang/jit_kernel/csrc/gemm/awq_dequantize.cuh
+++ b/python/sglang/jit_kernel/csrc/gemm/awq_dequantize.cuh
@@ -6,7 +6,6 @@
 #include <cassert>
 #include <sgl_kernel/utils.cuh>
 
-
 namespace device::awq {
 
 template <int lut>

--- a/python/sglang/jit_kernel/csrc/gemm/awq_dequantize.cuh
+++ b/python/sglang/jit_kernel/csrc/gemm/awq_dequantize.cuh
@@ -3,8 +3,9 @@
 #pragma once
 
 #include <sgl_kernel/tensor.h>
-
+#include <cassert>
 #include <sgl_kernel/utils.cuh>
+
 
 namespace device::awq {
 

--- a/python/sglang/jit_kernel/csrc/gemm/awq_dequantize.cuh
+++ b/python/sglang/jit_kernel/csrc/gemm/awq_dequantize.cuh
@@ -4,9 +4,9 @@
 
 #include <sgl_kernel/tensor.h>
 
-#include <cassert>
-
 #include <sgl_kernel/utils.cuh>
+
+#include <cassert>
 
 namespace device::awq {
 


### PR DESCRIPTION
## Summary
`awq_dequantize.cuh` uses `assert(false)` as a fallback for unsupported CUDA architectures (lines 73 and 102), but the `<cassert>` header is not included. This causes JIT compilation failures when loading AWQ quantized models in certain environments (e.g., specific GCC/CUDA toolchain versions where `assert` is not transitively included).

## Motivation
When loading AWQ quantized models (e.g., `Qwen2.5-72B-Instruct-AWQ`) with SGLang, the JIT compilation of `awq_dequantize.cuh` fails with an `identifier "assert" is undefined` error. 

This issue was identified during a deployment on NVIDIA A800-SXM4-80GB. Adding the explicit include ensures the kernel compiles correctly across all standard-compliant toolchains.

## Modifications
- Added `#include <cassert>` to `python/sglang/jit_kernel/csrc/gemm/awq_dequantize.cuh`.
- This is a header-only fix with no behavioral or logic changes.

## Accuracy Tests
N/A. This fix only resolves a compilation error and does not affect numerical outputs.

## Speed Tests and Profiling
N/A. No changes to the kernel logic or execution flow.

## Checklist
- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests (N/A: Compilation fix).
- [x] Update documentation (N/A).
- [x] Provide accuracy and speed benchmark results (N/A).
- [x] Follow the SGLang code style guidance.