### PR TITLE
fix: handle None speculative_eagle_topk when speculative_num_steps is…

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3318,6 +3318,17 @@ class ServerArgs:
                     self.speculative_eagle_topk,
                     self.speculative_num_draft_tokens,
                 ) = auto_choose_speculative_params(self)
+            else:
+                # When the user manually sets speculative_num_steps but omits
+                # eagle_topk / num_draft_tokens, fill in safe defaults so that
+                # downstream comparisons (e.g. `topk > 1`) don't crash with
+                # TypeError: '>' not supported between NoneType and int.
+                if self.speculative_eagle_topk is None:
+                    self.speculative_eagle_topk = 1
+                if self.speculative_num_draft_tokens is None:
+                    self.speculative_num_draft_tokens = (
+                        self.speculative_num_steps + 1
+                    )
 
             if (
                 self.attention_backend == "trtllm_mha"


### PR DESCRIPTION
… manually set

When a user manually specifies --speculative-num-steps but does not specify --speculative-eagle-topk or --speculative-num-draft-tokens, the server crashes with:

TypeError: '>' not supported between instances of 'NoneType' and 'int'

This happens because auto_choose_speculative_params() is only called when speculative_num_steps is None. If the user explicitly sets --speculative-num-steps, this branch is skipped, leaving speculative_eagle_topk and speculative_num_draft_tokens as None.

Fix: Add an else branch to fill in safe defaults (eagle_topk=1, num_draft_tokens=num_steps+1) when the user manually sets speculative_num_steps but omits the other parameters.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When a user manually specifies `--speculative-num-steps` (e.g., for MTP models like Qwen3.5) but does **not** specify `--speculative-eagle-topk` or `--speculative-num-draft-tokens`, the server crashes during startup with:
TypeError: '>' not supported between instances of 'NoneType' and 'int'

Reproduction command:
```bash
SGLANG_ENABLE_SPEC_V2=1 python -m sglang.launch_server \
  --model-path <any-MTP-model> \
  --speculative-algorithm NEXTN \
  --speculative-num-steps 1 \
  --mamba-scheduler-strategy extra_buffer
```



## Modifications

In _handle_speculative_decoding(), auto_choose_speculative_params() is only called when speculative_num_steps is None. If the user explicitly sets --speculative-num-steps, this auto-fill branch is skipped entirely, leaving speculative_eagle_topk and speculative_num_draft_tokens as None.

Fix: Add an else branch to fill in safe defaults when the user manually sets speculative_num_steps but omits the other parameters:
- speculative_eagle_topk defaults to 1
- speculative_num_draft_tokens defaults to speculative_num_steps + 1
-These defaults are consistent with the values that auto_choose_speculative_params() would return for most model architectures.


## Accuracy Tests

N/A - This change only affects parameter initialization logic (filling None with safe defaults). It does not modify model forward code or inference output.


## Speed Tests and Profiling

N/A - No performance-sensitive code paths are affected.

## Checklist

- [ x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
