### PR TITLE
streaming session: trim spec v2 overshoot in cache_finished_req

### DIFF
--- a/python/sglang/srt/mem_cache/session_aware_cache.py
+++ b/python/sglang/srt/mem_cache/session_aware_cache.py
@@ -263,6 +263,11 @@ class SessionAwareCache(BasePrefixCache):
             slot = SessionSlot()
             self.slots[session_id] = slot
 
+        finished_len = (
+            req.finished_len if req.finished_len is not None else len(req.output_ids)
+        )
+        self._trim_overshoot(req, finished_len)
+
         slot.save_from_req(req, is_first=is_first)
 
         # Update req_nodes to this successfully finished request.
@@ -271,31 +276,46 @@ class SessionAwareCache(BasePrefixCache):
         self._mark_kv_freed(req)
 
     def _free_tail(self, slot: SessionSlot, req: Req, prefix_len: int):
-        """Free KV in [prefix_len, kv_allocated_len) before the next
-        alloc_for_extend overwrites it. The gap appears when spec
-        decoding pushes allocated above committed, or when retract
-        retry's logit-reserve pulls prefix_len below committed.
-        Free start is ceil-aligned to page_size: PagedTokenToKVPoolAllocator
-        frees by whole pages, so partial-page free would corrupt pages
-        still holding committed tokens; the gap stays attached until
-        release_session.
+        """match_prefix path: free orphaned KV in [prefix_len, kv_allocated_len)
+        before alloc_for_extend overwrites it. The gap appears when spec
+        decoding pushes allocated above committed, or when retract retry's
+        logit-reserve pulls prefix_len below committed.
         """
-        if prefix_len >= slot.kv_allocated_len:
-            return
-        free_start = prefix_len
-        if self.page_size > 1:
-            free_start = ceil_align(free_start, self.page_size)
-        if free_start < slot.kv_allocated_len:
-            tail_indices = self.req_to_token_pool.req_to_token[
-                slot.req_pool_idx, free_start : slot.kv_allocated_len
-            ]
-            self.token_to_kv_pool_allocator.free(tail_indices)
+        self._free_kv_aligned(slot.req_pool_idx, prefix_len, slot.kv_allocated_len)
         slot.kv_allocated_len = prefix_len
         slot.kv_committed_len = min(slot.kv_committed_len, prefix_len)
         slot.swa_evicted_seqlen = min(slot.swa_evicted_seqlen, prefix_len)
         req.kv_allocated_len = prefix_len
         req.kv_committed_len = min(req.kv_committed_len, prefix_len)
         req.swa_evicted_seqlen = min(req.swa_evicted_seqlen, prefix_len)
+
+    def _trim_overshoot(self, req: Req, finished_len: int):
+        """Trim slot KV to finished_len boundary. Spec v2 may overshoot
+        max_new_tokens (verify round commits M+1 at a time); next turn's
+        input is output_ids[:finished_len], so positions past that must
+        be released to avoid token/KV mismatch.
+        """
+        target = len(req.origin_input_ids) + finished_len
+        self._free_kv_aligned(req.req_pool_idx, target, req.kv_allocated_len)
+        req.kv_allocated_len = min(req.kv_allocated_len, target)
+        req.kv_committed_len = min(req.kv_committed_len, target)
+        req.output_ids = req.output_ids[:finished_len]
+
+    def _free_kv_aligned(self, pool_idx: int, target: int, end: int):
+        """Free req_to_token[pool_idx, ceil_align(target):end). Page-aligned
+        because PagedTokenToKVPoolAllocator.free returns whole pages
+        (free_index // page_size), so partial-page free would corrupt pages
+        still holding committed tokens. The range [target, ceil_align(target))
+        stays attached until release_session frees the whole page.
+        """
+        if end <= target:
+            return
+        start = target
+        if self.page_size > 1:
+            start = ceil_align(start, self.page_size)
+        if start < end:
+            tail = self.req_to_token_pool.req_to_token[pool_idx, start:end]
+            self.token_to_kv_pool_allocator.free(tail)
 
     @staticmethod
     def _mark_kv_freed(req: Req):


### PR DESCRIPTION
## Problem

Because spec accepts multiple tokens per round, the finishing round (the one whose post first trips `len(output_ids) >= max_new_tokens`) **may** commit overshoot ("bad") tokens — depending on how much of `accept_lens` falls past the boundary. It can also land exactly on `finished_len`, in which case there is no overshoot.

> Note: this is **the finishing round itself**, not the extra round that overlap scheduling speculatively launches afterward. The overshoot enters `committed` before any next-iter post fires, so it doesn't matter whether overlap is on/off or whether the extra round runs at all — trim is needed purely because of the atomic resolve-then-check ordering inside the finishing round's own post.

```
finishing round post:
  _resolve_spec_overlap_token_ids:
    committed   += accept_lens     <- overshoot enters here
    output_ids  += accept_lens
  check_finished:
    if len(output_ids) >= max_new:
      finished_len = max_new       <- API boundary set, but
                                      committed/output_ids
                                      already past it
  cache_finished_req(req)          <- save runs with overshoot baked in
```

Slot KV layout after a finishing round with overshoot (`O = origin_input_len`, `F = finished_len`, `C = committed - origin`, `C > F`):

```
positions:  0 ........ O-1 | O .......... O+F-1 | O+F ........ O+C-1
            [--- input ---]   [--- kept output ---]  [--- overshoot ---]
                                                      stale; next turn's
                                                      input has DIFFERENT
                                                      tokens at these pos
            <-- inherited correctly by next turn -->
                                                      ^^^^^^^^^^^^^^^^^^^
                                                      if match_prefix
                                                      grants prefix_len
                                                      this far, attention
                                                      reads wrong KV
```

`session_controller` builds the next turn's input from `output_ids[:F]`, so positions `[O+F, O+C)` will hold *different* tokens next turn. If `match_prefix` returns `prefix_len > O+F`, attention reads stale overshoot KV against the new tokens.

This PR is a general correctness guard against overshoot at finish time. Spec v2 is the only path that triggers it today, but the trim is unconditional — any future scheduler path that lets a finishing round commit past `finished_len` is covered automatically.

## Fix

In `cache_finished_req`, trim the slot's KV state to the `finished_len` boundary before `save_from_req`:

- Free the page-aligned tail at `[origin+finished_len, kv_allocated_len)`
- Cap `kv_allocated_len` and `kv_committed_len` at `origin+finished_len`
- Truncate `output_ids` to `finished_len` (already capped for response, but the in-memory list still held overshoot tokens)

Postcondition (always holds after `cache_finished_req` returns):

```
slot.kv_committed_len  <= origin + finished_len
slot.kv_allocated_len  <= origin + finished_len
len(req.output_ids)    == finished_len
```

So next turn's `match_prefix` returns `prefix_len <= origin + finished_len` — the previous turn's API boundary. Overshoot is fully contained within the finishing round.



<details>
<summary><strong>Appendix: spec v2 + streaming session — reference analysis</strong></summary>

This appendix is the single reference for the streaming-session + spec v2 correctness work. It builds a vocabulary first, then derives every case from it — so future reviewers / bots can reason from definitions instead of reassembling facts from #22790 / #22862 / #22897 / #22900 / #22651.

### Definitions

- **`committed_len`** (`req.kv_committed_len`): number of sequence positions whose KV has been materialized in `req_to_token`. Invariant: `committed_len = origin + output_ids_len - 1` during spec v2 decode (the `-1` is the bonus lag, defined below).
- **`allocated_len`** (`req.kv_allocated_len`): number of sequence positions the allocator has reserved slots for. Always `>= committed_len` during decode (over-allocation for upcoming drafts).
- **`finished_len`** (`req.finished_len`): the API-visible output length, set by `check_finished` when `len(output_ids) >= max_new_tokens` (or a stop condition hits). For `FINISH_LENGTH`, `finished_len == max_new_tokens`.
- **`target`**: `origin + finished_len`. The slot boundary after trim.
- **Bonus token**: the `+1` in `accept_lens = num_drafts + 1`. Sampled from target logits at the last verify position. Its KV is **not** written in this round's target forward; it becomes `draft_token[0]` of the next round and its KV is written there.
- **Bonus lag**: the always-true fact `len(output_ids) == committed_len - origin + 1`. The last output token (always a bonus) has no KV yet.
- **Finishing round**: the round whose post first trips `len(output_ids) >= max_new_tokens`. Called `batch_F`.
- **Extra round**: `batch_{F+1}`. In overlap mode, the scheduler plans it **before** `batch_F`'s post has detected finish, so the req is still included. Its forward runs and writes KV; its post-loop hits `if overlap and req.finished(): continue` → output_ids / check_finished are skipped but `_resolve_spec_overlap_token_ids` already bumped `committed` at the top of post.
- **Valid tokens**: `output_ids[:finished_len]` — what the API returned.
- **Invalid tokens** (aka **overshoot tokens**): `output_ids[finished_len:]` — committed by `_resolve` but discarded by the API boundary.

### Case analysis for the finishing round

Let `k = accept_lens_F` (this round's accept count). The finishing round's post atomically runs:

```
_resolve_spec_overlap_token_ids:
  committed  += k
  output_ids += k tokens
check_finished:
  if len(output_ids) >= max_new: set finished_len, finished_reason
cache_finished_req(req)   # fires if finished
```

Three cases by how many of the `k` new tokens fall past `max_new_tokens`:

1. **Exact match** (`len(output_ids)_after == max_new`): 0 invalid tokens. `committed == target - 1` (bonus lag). `allocated >= target`.
2. **Overshoot by `j` (1 ≤ j ≤ k - 1)**: `j` invalid tokens. `committed == target + j - 1`. `allocated >= target + j - 1`.
3. **No finish this round**: not the finishing round; skip.

In every finishing-round case, `committed` is **non-monotonic** relative to `target`: it can be below (case 1) or above (case 2). Both need corrective action at `cache_finished_req`.

### The role of the extra round (overlap only)

In overlap mode, the extra round always runs for the finishing req (scheduler planned it ahead). Effects:

- Its target forward materializes the bonus token's KV at position `origin + output_ids_len_after_F - 1` (i.e. at `target - 1` in the exact-match case, or `target + j - 1` in the overshoot case). This is what turns the "bonus lag" into actual KV.
- Its `_resolve_spec_overlap_token_ids` bumps `committed` by `accept_lens_{F+1}`. This fires **after** `batch_F`'s post — specifically after `cache_finished_req` has already called `save_from_req`.
- The rest of its post-loop is skipped (`continue`) so `output_ids` / `check_finished` state is untouched.

Without a separate fix, `save_from_req` captures the pre-extra-round `committed`, so the slot stores `committed = target + j - 1` (case 2) or `target - 1` (case 1).

In non-overlap mode (spec v1, `--disable-overlap-schedule`), the extra round does not exist. Bonus KV is never materialized → next turn inherits 1 position short → `kv_inherit_offset = -1`.

### Implications per case, with and without each fix

Using `T = target = origin + finished_len`. Each column is the saved `slot.kv_committed_len` after the fix is applied (and earlier fixes in the chain).

| Case | Pre-all-fixes save | + overshoot trim (this PR) | + SWA cap (#22900) | + bonus accounting (#22651) |
|---|---|---|---|---|
| Exact match, overlap on | `T - 1` | `T - 1` | `T - 1` | **`T`** |
| Overshoot by j, overlap on | `T + j - 1` (stale KV past T) | **`T`** (stale tail freed) | `T` (SWA cursor also capped) | `T` |
| Exact match, overlap off (spec v1) | `T - 1` | `T - 1` | `T - 1` | `T - 1` (bonus never materialized; offset=-1 is correct) |
| Overshoot, overlap off | `T + j - 1` | **`T - 1`** (trim clamps; no extra round → offset=-1) | `T - 1` | `T - 1` |

Key takeaways:
- Overshoot trim is needed **regardless of overlap** — purely a consequence of atomic `_resolve` before `check_finished`.
- SWA cap rides on trim (one extra `min()`) to keep the eviction cursor consistent with the post-trim boundary.
- Bonus accounting only shifts the timing of the `+1` committed bump; it does not create or destroy KV. Overlap-off paths still need `kv_inherit_offset = -1`.

### Invalid tokens and KV at their positions

After trim (`_free_kv_aligned(req_to_token[pool, T:alloc])`) the positions `[T, alloc_before_trim)` are released from the KV pool. Whatever KV was written at those positions in the finishing round's target forward — for draft tokens at positions the accept logic ended up rejecting, or for the overshoot drafts — becomes unreachable. The invalid tokens (as token IDs in `output_ids[T-origin:]`) are also truncated. Next turn's match_prefix can grant at most `T` tokens of inheritance, regardless of what the finishing round happened to verify.

### Retract is orthogonal

Retract retries the same req with the same token IDs, so `reset_for_retract` leaves the slot's prefix as a valid ancestor. The only fix on the retract side is page-aligned `_free_tail` (#22862) — partial-page free would corrupt pages still holding committed tokens. Retract does not interact with bonus lag or overshoot, because retract fires during decode, not at finish.

### Summary: one postcondition, four fixes

After all fixes are in place, every streaming-session slot save guarantees:

```
slot.kv_committed_len   == origin + finished_len
slot.kv_allocated_len   <= origin + finished_len
slot.swa_evicted_seqlen <= origin + finished_len
len(req.output_ids)     == finished_len
```

| Fix | PR | One-liner |
|---|---|---|
| Overshoot trim | #22897 (this) | Clamp down from `T + j - 1` to `T` and free stale tail. |
| SWA cap | #22900 | Cap `swa_evicted_seqlen` at `T` to stop the cursor leaking past. |
| Bonus accounting | #22651 | Pre-claim the bonus slot in `prepare_for_decode` so `committed` reaches `T` upfront (not post-facto in the extra round). |
| Page-aligned tail free | #22862 | Avoid partial-page free corrupting committed pages on the `match_prefix` path. |

---

*This appendix was drafted with Claude Code assistance.*

</details>
