### PR TITLE
[Ray] Auto-create placement group in RayEngine when none is detected

### DIFF
--- a/python/sglang/srt/ray/engine.py
+++ b/python/sglang/srt/ray/engine.py
@@ -100,10 +100,32 @@ class RayEngine(Engine):
         """
         pg = ray.util.get_current_placement_group()
         if pg is None:
-            raise RuntimeError(
-                "use_ray=True requires a placement group, but none was detected. "
-                "Schedule the Engine actor onto a placement group"
+            from ray.util.placement_group import (
+                placement_group as create_placement_group,
             )
+
+            if server_args.enable_dp_attention:
+                total_gpus = server_args.tp_size * server_args.pp_size
+            else:
+                total_gpus = (
+                    server_args.dp_size * server_args.tp_size * server_args.pp_size
+                )
+
+            nnodes = server_args.nnodes
+            gpus_per_node = total_gpus // nnodes
+            strategy = "STRICT_PACK" if nnodes == 1 else "SPREAD"
+
+            logger.info(
+                "No placement group detected. Auto-creating one with "
+                f"{nnodes} bundle(s), {gpus_per_node} GPU(s)/bundle, "
+                "placement group explicitly and schedule the Engine onto it."
+            )
+
+            pg = create_placement_group(
+                [{"CPU": 1, "GPU": gpus_per_node}] * nnodes,
+                strategy=strategy,
+            )
+            ray.get(pg.ready())
 
         nnodes = server_args.nnodes
 


### PR DESCRIPTION
## Summary
- When `RayEngine` is launched without an enclosing placement group, it previously raised `RuntimeError` and forced the caller to construct one.
- This change derives the required GPU count from `server_args` (accounting for DP attention vs. plain DP) and auto-creates a placement group sized as `nnodes` bundles of `(1 CPU, total_gpus / nnodes GPUs)`.
- Strategy: `STRICT_PACK` for single-node deployments (all bundles co-located), `SPREAD` for multi-node (bundles distributed across nodes).

## Stacking note
Stacked on top of #21887 (`ray-dp-support`). Until that lands, this PR's diff will include the parent's commits as well; the auto-PG-specific commits are the top two:
- `Auto-create placement group in RayEngine when none is detected`
- `Use STRICT_PACK for single-node, SPREAD for multi-node auto PG`

## Test plan
- [ ] Launch `RayEngine` outside of any placement group on a single node and confirm it auto-creates a `STRICT_PACK` PG and starts schedulers.
- [ ] Launch `RayEngine` outside of any placement group on multiple nodes and confirm it auto-creates a `SPREAD` PG.
- [ ] Launch `RayEngine` inside an existing placement group and confirm it still uses the provided PG (no regression).
- [ ] Verify both branches with `enable_dp_attention=True` and `enable_dp_attention=False`.