### PR TITLE
trim_overshoot: cap swa_evicted_seqlen + unit test

### DIFF
--- a/python/sglang/srt/mem_cache/session_aware_cache.py
+++ b/python/sglang/srt/mem_cache/session_aware_cache.py
@@ -299,6 +299,7 @@ class SessionAwareCache(BasePrefixCache):
         self._free_kv_aligned(req.req_pool_idx, target, req.kv_allocated_len)
         req.kv_allocated_len = min(req.kv_allocated_len, target)
         req.kv_committed_len = min(req.kv_committed_len, target)
+        req.swa_evicted_seqlen = min(req.swa_evicted_seqlen, target)
         req.output_ids = req.output_ids[:finished_len]
 
     def _free_kv_aligned(self, pool_idx: int, target: int, end: int):

--- a/python/sglang/srt/mem_cache/session_aware_cache.py
+++ b/python/sglang/srt/mem_cache/session_aware_cache.py
@@ -263,6 +263,11 @@ class SessionAwareCache(BasePrefixCache):
             slot = SessionSlot()
             self.slots[session_id] = slot
 
+        finished_len = (
+            req.finished_len if req.finished_len is not None else len(req.output_ids)
+        )
+        self._trim_overshoot(req, finished_len)
+
         slot.save_from_req(req, is_first=is_first)
 
         # Update req_nodes to this successfully finished request.
@@ -271,31 +276,46 @@ class SessionAwareCache(BasePrefixCache):
         self._mark_kv_freed(req)
 
     def _free_tail(self, slot: SessionSlot, req: Req, prefix_len: int):
-        """Free KV in [prefix_len, kv_allocated_len) before the next
-        alloc_for_extend overwrites it. The gap appears when spec
-        decoding pushes allocated above committed, or when retract
-        retry's logit-reserve pulls prefix_len below committed.
-        Free start is ceil-aligned to page_size: PagedTokenToKVPoolAllocator
-        frees by whole pages, so partial-page free would corrupt pages
-        still holding committed tokens; the gap stays attached until
-        release_session.
+        """match_prefix path: free orphaned KV in [prefix_len, kv_allocated_len)
+        before alloc_for_extend overwrites it. The gap appears when spec
+        decoding pushes allocated above committed, or when retract retry's
+        logit-reserve pulls prefix_len below committed.
         """
-        if prefix_len >= slot.kv_allocated_len:
-            return
-        free_start = prefix_len
-        if self.page_size > 1:
-            free_start = ceil_align(free_start, self.page_size)
-        if free_start < slot.kv_allocated_len:
-            tail_indices = self.req_to_token_pool.req_to_token[
-                slot.req_pool_idx, free_start : slot.kv_allocated_len
-            ]
-            self.token_to_kv_pool_allocator.free(tail_indices)
+        self._free_kv_aligned(slot.req_pool_idx, prefix_len, slot.kv_allocated_len)
         slot.kv_allocated_len = prefix_len
         slot.kv_committed_len = min(slot.kv_committed_len, prefix_len)
         slot.swa_evicted_seqlen = min(slot.swa_evicted_seqlen, prefix_len)
         req.kv_allocated_len = prefix_len
         req.kv_committed_len = min(req.kv_committed_len, prefix_len)
         req.swa_evicted_seqlen = min(req.swa_evicted_seqlen, prefix_len)
+
+    def _trim_overshoot(self, req: Req, finished_len: int):
+        """Trim slot KV to finished_len boundary. Spec v2 may overshoot
+        max_new_tokens (verify round commits M+1 at a time); next turn's
+        input is output_ids[:finished_len], so positions past that must
+        be released to avoid token/KV mismatch.
+        """
+        target = len(req.origin_input_ids) + finished_len
+        self._free_kv_aligned(req.req_pool_idx, target, req.kv_allocated_len)
+        req.kv_allocated_len = min(req.kv_allocated_len, target)
+        req.kv_committed_len = min(req.kv_committed_len, target)
+        req.output_ids = req.output_ids[:finished_len]
+
+    def _free_kv_aligned(self, pool_idx: int, target: int, end: int):
+        """Free req_to_token[pool_idx, ceil_align(target):end). Page-aligned
+        because PagedTokenToKVPoolAllocator.free returns whole pages
+        (free_index // page_size), so partial-page free would corrupt pages
+        still holding committed tokens. The range [target, ceil_align(target))
+        stays attached until release_session frees the whole page.
+        """
+        if end <= target:
+            return
+        start = target
+        if self.page_size > 1:
+            start = ceil_align(start, self.page_size)
+        if start < end:
+            tail = self.req_to_token_pool.req_to_token[pool_idx, start:end]
+            self.token_to_kv_pool_allocator.free(tail)
 
     @staticmethod
     def _mark_kv_freed(req: Req):

--- a/python/sglang/srt/mem_cache/session_aware_cache.py
+++ b/python/sglang/srt/mem_cache/session_aware_cache.py
@@ -299,7 +299,6 @@ class SessionAwareCache(BasePrefixCache):
         self._free_kv_aligned(req.req_pool_idx, target, req.kv_allocated_len)
         req.kv_allocated_len = min(req.kv_allocated_len, target)
         req.kv_committed_len = min(req.kv_committed_len, target)
-        req.swa_evicted_seqlen = min(req.swa_evicted_seqlen, target)
         req.output_ids = req.output_ids[:finished_len]
 
     def _free_kv_aligned(self, pool_idx: int, target: int, end: int):

--- a/test/registered/unit/mem_cache/test_streaming_session_unit.py
+++ b/test/registered/unit/mem_cache/test_streaming_session_unit.py
@@ -235,3 +235,39 @@ def test_nth_mid_abort_nukes_session_slot():
 # Shrink tests removed: streaming sessions are append-only after the
 # rollback fix in session_controller (rollback_aborted_req).  The shrink
 # code path in cache_finished_req no longer exists.
+
+
+def test_trim_overshoot_postcondition():
+    """`_trim_overshoot` postcondition: every per-req KV field is capped at
+    target = origin+finished_len, output_ids is truncated, and the tail
+    KV slots are freed. Covers both non-SWA fields (kv_committed_len,
+    kv_allocated_len, output_ids) and SWA bookkeeping (swa_evicted_seqlen)
+    in one shot — same invariant `_free_tail` enforces on the match_prefix
+    path.
+    """
+    page_size = 1
+    req_to_token = torch.arange(128, dtype=torch.int32).reshape(1, 128)
+    req_to_token_pool = SimpleNamespace(req_to_token=req_to_token, free_slots=[])
+    allocator = _FakeAllocator()
+    tree_cache = SessionAwareCache(
+        _FakeInnerCache(req_to_token_pool, allocator, page_size)
+    )
+
+    # Overshoot scenario: origin=26, finished_len=12 -> target=38.
+    # committed=40 (overshoot 2), allocated=44, swa_evicted=42 (> target),
+    # output_ids extended to 14 by the overshoot round.
+    req = _FakeReq("session-a", req_pool_idx=0, committed=40, allocated=44)
+    req.origin_input_ids = list(range(26))
+    req.output_ids = list(range(14))
+    req.swa_evicted_seqlen = 42
+
+    tree_cache._trim_overshoot(req, finished_len=12)
+
+    target = 38
+    assert req.kv_committed_len == target
+    assert req.kv_allocated_len == target
+    assert req.swa_evicted_seqlen == target
+    assert len(req.output_ids) == 12
+    # Tail [38, 44) freed by _free_kv_aligned.
+    assert len(allocator.freed) == 1
+    assert allocator.freed[0].tolist() == list(range(38, 44))


### PR DESCRIPTION
## Problem

`_trim_overshoot` (added in #22897) caps `kv_committed_len` and `kv_allocated_len` at `target = origin + finished_len`, but leaves `req.swa_evicted_seqlen` untouched. `_free_tail` (the match_prefix counterpart on the same `SessionAwareCache`) caps all three. The asymmetry causes a SWA pool leak when a finishing round overshoots while SWA was actively evicting.

`swa_evicted_seqlen` is a cursor — `_evict_swa` reads it as the start position for the next eviction sweep:

```python
new_swa_evicted = max(req.swa_evicted_seqlen, pre_len - W - P)
free_swa(req_to_token[swa_evicted : new_swa_evicted])  # frees [old_cursor, new_cursor)
req.swa_evicted_seqlen = new_swa_evicted
```

If overshoot pushed the cursor past the trim boundary (e.g. `swa_evicted = 42` but `target = 38`), `save_from_req` propagates the stale 42 into the slot and next turn's `restore_to_req` hands it back. Next turn's prefill writes new SWA slots at positions `[38, 42)`, but `_evict_swa` starts scanning from 42 — those slots are skipped forever and accumulate as a leak.

## Fix

One-line cap to mirror `_free_tail`:

```python
req.swa_evicted_seqlen = min(req.swa_evicted_seqlen, target)
```

This is the only other downward-cap site for `swa_evicted_seqlen` outside `_free_tail` (and `reset_for_retract`, which clears to 0). Both downward-moving paths now enforce the same invariant: `swa_evicted_seqlen <= origin + committed`.

## Test

Adds `test_trim_overshoot_postcondition` covering the full postcondition in one shot: `kv_committed_len`, `kv_allocated_len`, `swa_evicted_seqlen` all capped at target, `output_ids` truncated to `finished_len`, and the page-aligned tail freed. Without the swa cap, the test fails on `swa_evicted_seqlen == target` (assert 42 == 38).
