### PR TITLE
[WIP] Fix streaming reasoning parser

### DIFF
--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -101,6 +101,28 @@ class BaseReasoningFormatDetector:
             # think_end_token is in self.previous_content for continue_final_message=True case
             return StreamingParseResult(normal_text=processed_text)
 
+    @staticmethod
+    def _split_trailing_partial_token(text: str, tokens: list[str]) -> tuple[str, str]:
+        """Split text into processable content and a trailing partial token.
+
+        Streaming chunks can end with the beginning of a control token, e.g.
+        ``"...<chan"`` before the rest of ``"<channel|>"`` arrives. We must keep
+        that suffix buffered instead of leaking it to the caller.
+        """
+        longest_partial = ""
+        for token in tokens:
+            max_prefix_len = min(len(text), len(token) - 1)
+            for prefix_len in range(max_prefix_len, 0, -1):
+                suffix = text[-prefix_len:]
+                if token.startswith(suffix):
+                    if prefix_len > len(longest_partial):
+                        longest_partial = suffix
+                    break
+
+        if not longest_partial:
+            return text, ""
+        return text[: -len(longest_partial)], longest_partial
+
     def parse_streaming_increment(self, new_text: str) -> StreamingParseResult:
         """
         Streaming incremental parsing for reasoning content.
@@ -120,10 +142,11 @@ class BaseReasoningFormatDetector:
         tokens_to_check = [think_start_text, self.think_end_token]
         if self.tool_start_token:
             tokens_to_check.append(self.tool_start_token)
-        if any(
-            token.startswith(current_text) and token != current_text
-            for token in tokens_to_check
-        ):
+
+        current_text, trailing_partial = self._split_trailing_partial_token(
+            current_text, tokens_to_check
+        )
+        if not current_text and trailing_partial:
             return StreamingParseResult()
 
         # Strip `<think>` token if present
@@ -138,7 +161,7 @@ class BaseReasoningFormatDetector:
 
             reasoning_text = current_text[:end_idx]
 
-            self._buffer = ""
+            self._buffer = trailing_partial
             self._in_reasoning = False
             normal_text = current_text[end_idx + len(self.think_end_token) :]
 
@@ -154,21 +177,21 @@ class BaseReasoningFormatDetector:
                 reasoning_text = current_text[:tool_idx]
                 # Preserve tool_start_token in normal text
                 normal_text = current_text[tool_idx:]
-                self._buffer = ""
+                self._buffer = trailing_partial
                 self._in_reasoning = False
                 return StreamingParseResult(
                     normal_text=normal_text, reasoning_text=reasoning_text
                 )
             if self.stream_reasoning:
                 # Stream the content immediately
-                self._buffer = ""
+                self._buffer = trailing_partial
                 return StreamingParseResult(reasoning_text=current_text)
             else:
                 return StreamingParseResult()
 
         # If we're not in a reasoning block return as normal text
         if not self._in_reasoning:
-            self._buffer = ""
+            self._buffer = trailing_partial
             return StreamingParseResult(normal_text=current_text)
 
         return StreamingParseResult()

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -38,6 +38,16 @@ class BaseReasoningFormatDetector:
         self._buffer = ""
         self.stripped_think_start = False
         self.think_start_self_label = ""
+        # When True we expect the next characters in the buffer to *optionally*
+        # begin with ``think_start_token + think_start_self_label`` and must be
+        # consumed before any reasoning content is surfaced. This covers the
+        # case where ``force_reasoning=True`` but the model still emits an
+        # explicit start token (e.g. Gemma-4 with ``enable_thinking=True``,
+        # DeepSeek-R1-0528).
+        self._awaiting_start_strip = force_reasoning
+        # Reasoning content buffered when ``stream_reasoning=False``; flushed
+        # when a reasoning block ends.
+        self._pending_reasoning = ""
 
         self.continue_final_message = continue_final_message
         if self.continue_final_message:
@@ -102,99 +112,184 @@ class BaseReasoningFormatDetector:
             return StreamingParseResult(normal_text=processed_text)
 
     @staticmethod
-    def _split_trailing_partial_token(text: str, tokens: list[str]) -> tuple[str, str]:
-        """Split text into processable content and a trailing partial token.
+    def _split_trailing_partial_token(
+        text: str, tokens: Tuple[str, ...]
+    ) -> Tuple[str, str]:
+        """Split ``text`` into processable content and a trailing partial-token suffix.
 
         Streaming chunks can end with the beginning of a control token, e.g.
-        ``"...<chan"`` before the rest of ``"<channel|>"`` arrives. We must keep
-        that suffix buffered instead of leaking it to the caller.
-        """
-        longest_partial = ""
-        for token in tokens:
-            max_prefix_len = min(len(text), len(token) - 1)
-            for prefix_len in range(max_prefix_len, 0, -1):
-                suffix = text[-prefix_len:]
-                if token.startswith(suffix):
-                    if prefix_len > len(longest_partial):
-                        longest_partial = suffix
-                    break
+        ``"...<chan"`` before the rest of ``"<channel|>"`` arrives. Returning the
+        ``<chan`` as output would leak a delimiter fragment to the caller.
+        This helper finds the longest suffix of ``text`` that is a STRICT
+        prefix of any of ``tokens`` (never the full token — full matches are
+        handled by the caller via ``find``). The returned pair is
+        ``(head, partial)`` such that ``head + partial == text``.
 
-        if not longest_partial:
+        Example (tokens include ``"<channel|>"``):
+            ``_split_trailing_partial_token("hello<chan", (..., "<channel|>"))``
+            → ``("hello", "<chan")``
+        """
+        best_partial_len = 0
+        for token in tokens:
+            if not token:
+                continue
+            # Strict prefixes only: ``prefix_len < len(token)``. Full-token
+            # matches must be consumed by ``find`` so the state machine can
+            # actually transition.
+            max_len = min(len(text), len(token) - 1)
+            for prefix_len in range(max_len, best_partial_len, -1):
+                if token.startswith(text[-prefix_len:]):
+                    best_partial_len = prefix_len
+                    break
+        if best_partial_len == 0:
             return text, ""
-        return text[: -len(longest_partial)], longest_partial
+        return text[:-best_partial_len], text[-best_partial_len:]
 
     def parse_streaming_increment(self, new_text: str) -> StreamingParseResult:
-        """
-        Streaming incremental parsing for reasoning content.
-        Handles partial reasoning tags and content.
+        """Streaming incremental parse of reasoning content.
 
-        If stream_reasoning is False:
-            Accumulates reasoning content until the end tag is found
-        If stream_reasoning is True:
-            Streams reasoning content as it arrives
+        Implements an explicit two-state machine ({outside, inside}-reasoning)
+        that loops until it either consumes the full buffer or needs more
+        input. This guarantees:
+
+        * Delimiter strings (``<|channel>``, ``<channel|>``, ``<think>``, etc.)
+          never leak into emitted text, even when split across chunk
+          boundaries — only the longest trailing *strict* prefix of a control
+          token is retained in the internal buffer.
+        * Normal text preceding a ``think_start_token`` in the same chunk is
+          correctly routed to ``normal_text`` (not absorbed into reasoning).
+        * Multiple reasoning blocks in a single response are handled
+          idempotently; each block's boundaries are stripped.
+        * With ``force_reasoning=True`` we start inside reasoning but still
+          consume an optional leading start token if the model emits one.
+
+        If ``stream_reasoning`` is False, reasoning content is buffered in
+        ``_pending_reasoning`` and flushed (rstripped) only when the block's
+        end token is seen.
         """
         self._buffer += new_text
-        current_text = self._buffer
 
         think_start_text = self.think_start_token + self.think_start_self_label
+        reasoning_parts = []
+        normal_parts = []
 
-        # If the current text is a prefix of the think token, keep buffering
-        tokens_to_check = [think_start_text, self.think_end_token]
-        if self.tool_start_token:
-            tokens_to_check.append(self.tool_start_token)
+        while self._buffer:
+            if not self._in_reasoning:
+                # Look for a complete start sequence.
+                idx = self._buffer.find(think_start_text)
+                if idx >= 0:
+                    if idx > 0:
+                        normal_parts.append(self._buffer[:idx])
+                    self._buffer = self._buffer[idx + len(think_start_text) :]
+                    self._in_reasoning = True
+                    self.stripped_think_start = True
+                    self._awaiting_start_strip = False
+                    continue
 
-        current_text, trailing_partial = self._split_trailing_partial_token(
-            current_text, tokens_to_check
-        )
-        if not current_text and trailing_partial:
-            return StreamingParseResult()
-
-        # Strip `<think>` token if present
-        if not self.stripped_think_start and think_start_text in current_text:
-            current_text = current_text.replace(think_start_text, "", 1)
-            self.stripped_think_start = True
-            self._in_reasoning = True
-
-        # Handle end of reasoning block
-        if self._in_reasoning and self.think_end_token in current_text:
-            end_idx = current_text.find(self.think_end_token)
-
-            reasoning_text = current_text[:end_idx]
-
-            self._buffer = trailing_partial
-            self._in_reasoning = False
-            normal_text = current_text[end_idx + len(self.think_end_token) :]
-
-            return StreamingParseResult(
-                normal_text=normal_text, reasoning_text=reasoning_text.rstrip()
-            )
-
-        # Continue with reasoning content
-        if self._in_reasoning:
-            # Check for tool_start_token interruption
-            if self.tool_start_token and self.tool_start_token in current_text:
-                tool_idx = current_text.find(self.tool_start_token)
-                reasoning_text = current_text[:tool_idx]
-                # Preserve tool_start_token in normal text
-                normal_text = current_text[tool_idx:]
-                self._buffer = trailing_partial
-                self._in_reasoning = False
-                return StreamingParseResult(
-                    normal_text=normal_text, reasoning_text=reasoning_text
+                # No full start token. Flush everything except a trailing
+                # partial start-token (or partial end-token, which is unlikely
+                # outside reasoning but handled for symmetry).
+                head, partial = self._split_trailing_partial_token(
+                    self._buffer, (think_start_text, self.think_end_token)
                 )
-            if self.stream_reasoning:
-                # Stream the content immediately
-                self._buffer = trailing_partial
-                return StreamingParseResult(reasoning_text=current_text)
+                if head:
+                    normal_parts.append(head)
+                self._buffer = partial
+                break
+
+            # Inside a reasoning block.
+            if self._awaiting_start_strip:
+                # ``force_reasoning=True`` entry: the model may still emit a
+                # leading start token (e.g. Gemma-4 with enable_thinking=True
+                # emits ``<|channel>thought\\n``). Consume it if present or
+                # partially present; otherwise just clear the flag and
+                # proceed.
+                if self._buffer.startswith(think_start_text):
+                    self._buffer = self._buffer[len(think_start_text) :]
+                    self.stripped_think_start = True
+                    self._awaiting_start_strip = False
+                    continue
+                if think_start_text.startswith(self._buffer):
+                    # Buffer is a strict prefix of the start sequence; wait
+                    # for more data so we don't mis-classify it as reasoning.
+                    break
+                # Buffer does not start with (nor is a prefix of) the start
+                # sequence — treat as raw reasoning (DeepSeek-R1 style).
+                self._awaiting_start_strip = False
+
+            # Find the first boundary: end-token or tool-token (if any).
+            end_idx = self._buffer.find(self.think_end_token)
+            tool_idx = (
+                self._buffer.find(self.tool_start_token)
+                if self.tool_start_token
+                else -1
+            )
+            # Smallest non-negative index wins.
+            candidate = -1
+            candidate_kind = None
+            if end_idx >= 0:
+                candidate, candidate_kind = end_idx, "end"
+            if tool_idx >= 0 and (candidate < 0 or tool_idx < candidate):
+                candidate, candidate_kind = tool_idx, "tool"
+
+            if candidate >= 0:
+                if candidate > 0:
+                    piece = self._buffer[:candidate]
+                    # Match historical behavior: rstrip the reasoning chunk
+                    # that closes the block.
+                    if candidate_kind == "end":
+                        piece = piece.rstrip()
+                    if piece:
+                        reasoning_parts.append(piece)
+                if candidate_kind == "end":
+                    self._buffer = self._buffer[candidate + len(self.think_end_token) :]
+                    self._in_reasoning = False
+                else:  # tool
+                    # Tool delimiter is preserved in normal text so downstream
+                    # function-call parsers can see it.
+                    normal_parts.append(self._buffer[candidate:])
+                    self._buffer = ""
+                    self._in_reasoning = False
+                continue
+
+            # No boundary in buffer. Flush reasoning content minus any
+            # trailing partial delimiter.
+            partial_tokens = [self.think_end_token]
+            if self.tool_start_token:
+                partial_tokens.append(self.tool_start_token)
+            head, partial = self._split_trailing_partial_token(
+                self._buffer, tuple(partial_tokens)
+            )
+            # Also retain trailing whitespace in the buffer: it either gets
+            # rstripped away when the end-token actually arrives, or it will
+            # be flushed alongside the next non-whitespace reasoning content.
+            # Without this, per-chunk arrivals of ``"...\n"`` followed by
+            # ``"</think>"`` would emit a stray newline that single-shot
+            # parsing correctly strips.
+            trailing_ws_len = len(head) - len(head.rstrip())
+            if trailing_ws_len:
+                partial = head[-trailing_ws_len:] + partial
+                head = head[:-trailing_ws_len]
+            if head:
+                reasoning_parts.append(head)
+            self._buffer = partial
+            break
+
+        reasoning_text = "".join(reasoning_parts)
+        normal_text = "".join(normal_parts)
+
+        if not self.stream_reasoning:
+            # Accumulate reasoning until a boundary closes the block.
+            self._pending_reasoning += reasoning_text
+            if not self._in_reasoning and self._pending_reasoning:
+                reasoning_text = self._pending_reasoning.rstrip()
+                self._pending_reasoning = ""
             else:
-                return StreamingParseResult()
+                reasoning_text = ""
 
-        # If we're not in a reasoning block return as normal text
-        if not self._in_reasoning:
-            self._buffer = trailing_partial
-            return StreamingParseResult(normal_text=current_text)
-
-        return StreamingParseResult()
+        return StreamingParseResult(
+            normal_text=normal_text, reasoning_text=reasoning_text
+        )
 
 
 class DeepSeekR1Detector(BaseReasoningFormatDetector):

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -678,6 +678,34 @@ class TestGemma4Detector(CustomTestCase):
         self.assertFalse(self.detector._in_reasoning)
         self.assertIn("final answer", result2.normal_text)
 
+    def test_streaming_partial_start_after_prefix_text(self):
+        """Test buffering a partial Gemma4 start token after normal text."""
+        chunks = ["\n<|channel>", "thought\nreasoning", "<channel|>final answer"]
+
+        all_reasoning = ""
+        all_normal = ""
+        for chunk in chunks:
+            result = self.detector.parse_streaming_increment(chunk)
+            all_reasoning += result.reasoning_text
+            all_normal += result.normal_text
+
+        self.assertEqual(all_reasoning, "reasoning")
+        self.assertEqual(all_normal, "\nfinal answer")
+
+    def test_streaming_partial_end_after_reasoning_text(self):
+        """Test buffering a partial Gemma4 end token after reasoning text."""
+        chunks = ["<|channel>thought\nhello<chan", "nel|>final answer"]
+
+        all_reasoning = ""
+        all_normal = ""
+        for chunk in chunks:
+            result = self.detector.parse_streaming_increment(chunk)
+            all_reasoning += result.reasoning_text
+            all_normal += result.normal_text
+
+        self.assertEqual(all_reasoning, "hello")
+        self.assertEqual(all_normal, "final answer")
+
     def test_streaming_self_label_split_across_chunks(self):
         """Test self_label ('thought\\n') arriving separately from start token."""
         result1 = self.detector.parse_streaming_increment("<|channel>")

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -486,13 +486,11 @@ class TestGlm45Detector(CustomTestCase):
         self.assertEqual(result.reasoning_text, "")
         self.assertEqual(result.normal_text, "")
 
-        # Tool interruption should still work - flushes buffered reasoning.
-        # Note: when stream_reasoning=False, the <think> tag is stripped from the
-        # local `current_text` variable but NOT from `self._buffer` (which is never
-        # cleared in the non-streaming path). So the flushed reasoning content
-        # includes the raw <think> tag.
+        # Tool interruption flushes buffered reasoning. The ``<think>`` start
+        # token must be stripped — it is a control delimiter, not part of the
+        # reasoning payload.
         result = detector.parse_streaming_increment("<tool_call>tool call")
-        self.assertEqual(result.reasoning_text, "<think>thinking")
+        self.assertEqual(result.reasoning_text, "thinking")
         self.assertEqual(result.normal_text, "<tool_call>tool call")
 
     def test_streaming_empty_reasoning_with_tool(self):
@@ -748,6 +746,184 @@ class TestGemma4Detector(CustomTestCase):
         result = detector.detect_and_parse(text)
         self.assertEqual(result.reasoning_text, "This should be reasoning")
         self.assertEqual(result.normal_text, "The answer.")
+
+    # ------------------------------------------------------------------
+    # Regression tests for the three streaming bugs that caused Gemma-4
+    # ``<|channel>`` / ``<channel|>`` delimiters to leak into ``normal_text``
+    # (see PR #22902 and follow-up fix).
+    # ------------------------------------------------------------------
+
+    LEAK_MARKERS = ("<|channel>", "<channel|>", "<|channel", "channel|>")
+
+    def _feed_chunks(self, chunks, detector=None):
+        detector = detector or Gemma4Detector()
+        reasoning, normal = "", ""
+        for chunk in chunks:
+            result = detector.parse_streaming_increment(chunk)
+            reasoning += result.reasoning_text
+            normal += result.normal_text
+        return reasoning, normal, detector
+
+    def _assert_no_leak(self, reasoning, normal):
+        for marker in self.LEAK_MARKERS:
+            self.assertNotIn(marker, normal, f"{marker!r} leaked into normal_text")
+            self.assertNotIn(
+                marker, reasoning, f"{marker!r} leaked into reasoning_text"
+            )
+
+    def test_multiple_reasoning_blocks_no_leak(self):
+        """Multi-hop Gemma-4 responses emit several reasoning blocks in a row.
+
+        The parser must strip *every* block's delimiters, not just the first.
+        Regression test for the ``stripped_think_start`` one-shot latch.
+        """
+        raw = (
+            "<|channel>thought\nfirst hop reasoning\n<channel|>"
+            "first answer.\n"
+            "<|channel>thought\nsecond hop reasoning\n<channel|>"
+            "second answer."
+        )
+        reasoning, normal, _ = self._feed_chunks([raw])
+        self._assert_no_leak(reasoning, normal)
+        self.assertIn("first hop reasoning", reasoning)
+        self.assertIn("second hop reasoning", reasoning)
+        self.assertEqual(normal, "first answer.\nsecond answer.")
+
+    def test_multiple_reasoning_blocks_per_character_no_leak(self):
+        """Same multi-block scenario but streamed one character at a time.
+
+        Exercises the interaction between the one-shot-latch bug and
+        chunk-boundary partial-token buffering.
+        """
+        raw = (
+            "<|channel>thought\nhop one\n<channel|>A."
+            "<|channel>thought\nhop two\n<channel|>B."
+        )
+        reasoning, normal, detector = self._feed_chunks(list(raw))
+        self._assert_no_leak(reasoning, normal)
+        self.assertEqual(normal, "A.B.")
+        # ``_in_reasoning`` should land back in the outside-reasoning state.
+        self.assertFalse(detector._in_reasoning)
+
+    def test_start_token_split_across_chunks_no_leak(self):
+        """Start delimiter split across chunk boundaries must be buffered.
+
+        Previously the tail-prefix check only buffered when the *entire*
+        buffer was a prefix of a control token, so ``"hi<|chan"`` would be
+        flushed as normal text with ``"<|chan"`` leaked.
+        """
+        reasoning, normal, _ = self._feed_chunks(
+            ["hi<|chan", "nel>thought\n", "reasoned.<channel|>done."]
+        )
+        self._assert_no_leak(reasoning, normal)
+        self.assertEqual(normal, "hidone.")
+        self.assertEqual(reasoning, "reasoned.")
+
+    def test_end_token_split_across_chunks_no_leak(self):
+        """End delimiter split across chunks must not leak into reasoning."""
+        chunks = [
+            "<|channel>thought\n",
+            "reasoning body",
+            "<chan",
+            "nel|>",
+            "final answer",
+        ]
+        reasoning, normal, _ = self._feed_chunks(chunks)
+        self._assert_no_leak(reasoning, normal)
+        self.assertEqual(reasoning, "reasoning body")
+        self.assertEqual(normal, "final answer")
+
+    def test_normal_text_before_start_not_absorbed(self):
+        """Text preceding the start token must be routed to ``normal_text``.
+
+        The legacy implementation ``replace(think_start_text, "", 1)`` ran
+        over the whole buffer, so anything before the start delimiter was
+        swallowed into the reasoning block.
+        """
+        raw = "preamble text <|channel>thought\nreasoning<channel|>the answer"
+        reasoning, normal, _ = self._feed_chunks([raw])
+        self._assert_no_leak(reasoning, normal)
+        self.assertEqual(reasoning, "reasoning")
+        self.assertEqual(normal, "preamble text the answer")
+
+    def test_normal_text_before_start_streamed_no_leak(self):
+        """Per-character variant of the normal-text-before-start test."""
+        raw = "hello <|channel>thought\nwork<channel|>world"
+        reasoning, normal, _ = self._feed_chunks(list(raw))
+        self._assert_no_leak(reasoning, normal)
+        self.assertEqual(reasoning, "work")
+        self.assertEqual(normal, "hello world")
+
+    def test_partial_end_token_tail_buffered(self):
+        """Ending a chunk with a strict prefix of the end token must not leak.
+
+        The buffer should retain ``"<chan"`` and emit nothing until the
+        remainder of ``<channel|>`` arrives.
+        """
+        detector = Gemma4Detector()
+        detector.parse_streaming_increment("<|channel>thought\n")
+        detector.parse_streaming_increment("body ")
+
+        result = detector.parse_streaming_increment("<chan")
+        self.assertEqual(result.reasoning_text, "")
+        self.assertEqual(result.normal_text, "")
+        self.assertTrue(detector._in_reasoning)
+
+        result = detector.parse_streaming_increment("nel|>done")
+        self.assertFalse(detector._in_reasoning)
+        self.assertEqual(result.reasoning_text, "")
+        self.assertEqual(result.normal_text, "done")
+
+    def test_partial_start_token_tail_buffered(self):
+        """Strict prefix of the start token at chunk tail must be buffered."""
+        detector = Gemma4Detector()
+        result = detector.parse_streaming_increment("hello <|chan")
+        self.assertEqual(result.normal_text, "hello ")
+        self.assertFalse(detector._in_reasoning)
+        result = detector.parse_streaming_increment("nel>thought\nreasoning")
+        self.assertTrue(detector._in_reasoning)
+        self.assertEqual(result.reasoning_text, "reasoning")
+        self.assertEqual(result.normal_text, "")
+
+    def test_force_reasoning_with_self_generated_start_stripped(self):
+        """``force_reasoning=True`` + model self-emits ``<|channel>thought\\n``.
+
+        This is the Gemma-4 continuation-after-tool-response scenario: the
+        chat template primes a reasoning turn, then the model re-emits its
+        own start delimiter, which must be stripped idempotently.
+        """
+        detector = Gemma4Detector(force_reasoning=True)
+        result = detector.parse_streaming_increment("<|channel>thought\nreasoning")
+        self.assertEqual(result.reasoning_text, "reasoning")
+        self.assertEqual(result.normal_text, "")
+        result = detector.parse_streaming_increment("<channel|>answer")
+        self.assertEqual(result.normal_text, "answer")
+        self.assertFalse(detector._in_reasoning)
+
+    def test_force_reasoning_without_self_generated_start(self):
+        """``force_reasoning=True`` + no self-emitted start token (DeepSeek-R1
+        style) must still stream reasoning directly.
+        """
+        detector = Gemma4Detector(force_reasoning=True)
+        result = detector.parse_streaming_increment("raw reasoning")
+        self.assertEqual(result.reasoning_text, "raw reasoning")
+        result = detector.parse_streaming_increment(" more<channel|>answer")
+        self.assertEqual(result.reasoning_text, " more")
+        self.assertEqual(result.normal_text, "answer")
+
+    def test_force_reasoning_partial_self_generated_start(self):
+        """``force_reasoning=True`` with the start token split across chunks.
+
+        The first chunk is ``"<|cha"`` (strict prefix of the start sequence)
+        so the parser must buffer it rather than emit as reasoning.
+        """
+        detector = Gemma4Detector(force_reasoning=True)
+        result = detector.parse_streaming_increment("<|cha")
+        self.assertEqual(result.reasoning_text, "")
+        self.assertEqual(result.normal_text, "")
+        result = detector.parse_streaming_increment("nnel>thought\nbody<channel|>x")
+        self.assertEqual(result.reasoning_text, "body")
+        self.assertEqual(result.normal_text, "x")
 
 
 class TestReasoningParser(CustomTestCase):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Using OSS models (Gemma 4) on Claude Code sometime leak reasoning block like this
```
 <|channel>thought                                                                                                                                                
  <channel|>                                                                                                                                                       
                                                                                                                                                                   
  Searched for 1 pattern (ctrl+o to expand)                                                                                                                        
                                                                                                                                                                   
⏺ <|channel>thought                                                                                                                                                
  <channel|>                                                                                                                                                       
                                                                                                                                                                   
  Searched for 1 pattern (ctrl+o to expand)                                                                                                                        
                                                                                                                                                                   
⏺ <|channel>thought                                                                                                                                                
  <channel|>                                                                                                                                                       
                                                                                                                                                                   
  Searched for 1 pattern (ctrl+o to expand)                                                                                                                        
                                                                                                                                                                   
⏺ <|channel>thought                                                                                                                                                
  <channel|>I scanned the repository for "gemma 4" and found several related files and some internal technical debt markers.
 ```

## Modifications

<!-- Detail the changes made in this pull request. -->
- Fix reasoning leakage in streaming when a reasoning delimiter is split across text chunks.
- Root cause: the parser consumes streamed text deltas, so delimiter sequences can cross chunk boundaries even if tokenizer tokens do not.
- Solution: buffer trailing partial delimiters in BaseReasoningFormatDetector until the full sequence arrives.
Added regression tests for split start and end delimiter cases.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

Verified with Claude Code. Added the new unit test
## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
N/A

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
