### PR TITLE
[BugFix] Use terminal sigma for FlowUniPC sigma_min

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/schedulers/scheduling_flow_unipc_multistep.py
+++ b/python/sglang/multimodal_gen/runtime/models/schedulers/scheduling_flow_unipc_multistep.py
@@ -208,7 +208,7 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
             sigmas = shift * sigmas / (1 + (shift - 1) * sigmas)  # pyright: ignore
 
         if self.config.final_sigmas_type == "sigma_min":
-            sigma_last = ((1 - self.alphas_cumprod[0]) / self.alphas_cumprod[0]) ** 0.5
+            sigma_last = sigmas[-1]
         elif self.config.final_sigmas_type == "zero":
             sigma_last = 0
         else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

`FlowUniPCMultistepScheduler.set_timesteps()` uses `self.alphas_cumprod[0]` when `final_sigmas_type == "sigma_min"`, but  `FlowUniPCMultistepScheduler` does not define `alphas_cumprod`.    As a result, selecting `final_sigmas_type="sigma_min"` raises:      
```                                                                               
AttributeError: 'FlowUniPCMultistepScheduler' object has no attribute 'alphas_cumprod'   
```                                                      
                                                                                                                                                       
This scheduler already constructs its schedule directly in sigma space, so the terminal `"sigma_min"` value should come from the computed sigma schedule itself.     

## Modifications
- Replace the invalid `alphas_cumprod`-based computation in the `"sigma_min"` branch with `sigmas[-1]` 
- Keep the existing `"zero"` behavior unchanged  

This aligns `FlowUniPCMultistepScheduler` with the existing UniPC sigma handling, where `"sigma_min"` appends the terminal sigma from the current schedule.
                                                                         
## Accuracy Tests

This change does not modify model forward computation or kernel math, and it only fixes scheduler setup for the previously broken `final_sigmas_type="sigma_min"` branch

Verified with an inline Python repro that the old code raised `AttributeError`, and that after the change `set_timesteps(num_inference_steps=4)` completes successfully. Repro used for validation:
```
from sglang.multimodal_gen.runtime.models.schedulers.scheduling_flow_unipc_multistep import (
    FlowUniPCMultistepScheduler,
)

scheduler = FlowUniPCMultistepScheduler(final_sigmas_type="sigma_min")
scheduler.set_timesteps(num_inference_steps=4)
```

## Speed Tests and Profiling

No expected performance impact  

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
