### PR TITLE
R3 Support on PD Disaggregation (mini_lb)

### DIFF
--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -629,6 +629,8 @@ class SchedulerDisaggregationPrefillMixin:
             if poll in [KVPoll.WaitingForInput, KVPoll.Transferring]:
                 undone_reqs.append(req)
             elif poll == KVPoll.Success:  # transfer done
+                if req.return_routed_experts:
+                    self.maybe_collect_routed_experts(req)
                 release_kv_cache(req, self.tree_cache)  # unlock the tree
                 req.finished_reason = FINISH_LENGTH(length=0)
                 # FIXME: clean up req's data in transfer engine

--- a/sgl-model-gateway/bindings/python/pyproject.toml
+++ b/sgl-model-gateway/bindings/python/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "setproctitle",
     "aiohttp",
     "orjson",
+    "pybase64",
     "uvicorn",
     "fastapi",
 ]

--- a/sgl-model-gateway/bindings/python/src/sglang_router/mini_lb.py
+++ b/sgl-model-gateway/bindings/python/src/sglang_router/mini_lb.py
@@ -14,6 +14,7 @@ from typing import Optional
 
 import aiohttp
 import orjson
+import pybase64
 import uvicorn
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import ORJSONResponse, Response, StreamingResponse
@@ -32,6 +33,43 @@ def maybe_wrap_ipv6_address(address: str) -> str:
         return f"[{address}]"
     except ValueError:
         return address
+
+
+def _merge_routed_experts(prefill: dict, decode: dict):
+    if "routed_experts" not in prefill or "routed_experts" not in decode:
+        return False
+
+    prefill_bytes = pybase64.b64decode(prefill["routed_experts"], validate=True)
+    decode_bytes = pybase64.b64decode(decode["routed_experts"], validate=True)
+    decode["routed_experts"] = pybase64.b64encode(
+        prefill_bytes + decode_bytes[len(prefill_bytes) :]
+    ).decode("utf-8")
+    return True
+
+
+def _merge_input_token_logprobs(prefill_meta: dict, decode_meta: dict):
+    if (
+        "input_token_logprobs" not in prefill_meta
+        or "input_token_logprobs" not in decode_meta
+    ):
+        return
+
+    decode_meta["input_token_logprobs"] = (
+        prefill_meta["input_token_logprobs"] + decode_meta["input_token_logprobs"]
+    )
+
+def _merge_prefill_json(prefill_json, decode_json):
+    if "meta_info" in prefill_json and "meta_info" in decode_json:
+        prefill_meta = prefill_json["meta_info"]
+        decode_meta = decode_json["meta_info"]
+        _merge_input_token_logprobs(prefill_meta, decode_meta)
+        _merge_routed_experts(prefill_meta, decode_meta)
+
+    if "sglext" not in prefill_json:
+        return
+
+    if "sglext" in decode_json:
+        _merge_routed_experts(prefill_json["sglext"], decode_json["sglext"])
 
 
 class MiniLoadBalancer:
@@ -140,18 +178,10 @@ class MiniLoadBalancer:
             # Wait for both responses to complete. Prefill should end first.
             prefill_response, decode_response = await asyncio.gather(*tasks)
 
-            if "return_logprob" in modified_request:
-
+            if "return_logprob" in modified_request or "return_routed_experts" in modified_request:
                 prefill_json = await prefill_response.json()
                 ret_json = await decode_response.json()
-
-                # merge `meta_info.input_token_logprobs` from prefill to decode
-                if "meta_info" in ret_json:
-                    if "input_token_logprobs" in ret_json["meta_info"]:
-                        ret_json["meta_info"]["input_token_logprobs"] = (
-                            prefill_json["meta_info"]["input_token_logprobs"]
-                            + ret_json["meta_info"]["input_token_logprobs"]
-                        )
+                _merge_prefill_json(prefill_json, ret_json)
             else:
                 ret_json = await decode_response.json()
 

--- a/sgl-model-gateway/bindings/python/src/sglang_router/mini_lb.py
+++ b/sgl-model-gateway/bindings/python/src/sglang_router/mini_lb.py
@@ -58,6 +58,7 @@ def _merge_input_token_logprobs(prefill_meta: dict, decode_meta: dict):
         prefill_meta["input_token_logprobs"] + decode_meta["input_token_logprobs"]
     )
 
+
 def _merge_prefill_json(prefill_json, decode_json):
     if "meta_info" in prefill_json and "meta_info" in decode_json:
         prefill_meta = prefill_json["meta_info"]
@@ -178,7 +179,10 @@ class MiniLoadBalancer:
             # Wait for both responses to complete. Prefill should end first.
             prefill_response, decode_response = await asyncio.gather(*tasks)
 
-            if "return_logprob" in modified_request or "return_routed_experts" in modified_request:
+            if (
+                "return_logprob" in modified_request
+                or "return_routed_experts" in modified_request
+            ):
                 prefill_json = await prefill_response.json()
                 ret_json = await decode_response.json()
                 _merge_prefill_json(prefill_json, ret_json)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Support R3 in PD Disaggregation.
**Note**: only non-streaming `generate` and `/chat/completions` endpoints are supported.
Gateway version: https://github.com/radixark/sgl-router-for-miles/pull/4

## Modifications

Add `maybe_collect_routed_experts` on PD prefill side

## Accuracy Tests

### Launch commands

Deterministic flags shared by all services:

```bash
COMMON_FLAGS=(
  --model-path Qwen/Qwen3-30B-A3B
  --host 127.0.0.1
  --trust-remote-code
  --attention-backend fa3
  --tp 2
  --enable-deterministic-inference
  --disable-overlap-schedule
  --disable-cuda-graph
  --disable-radix-cache
  --enable-return-routed-experts
  --mem-fraction-static 0.9
)
```

#### Non-PD baseline on GPUs `4,5`:

```bash
PYTHONPATH=/data/sglang/python CUDA_VISIBLE_DEVICES=4,5 python -m sglang.launch_server \
  "${COMMON_FLAGS[@]}" \
  --port 28380
```

#### PD 
prefill worker on GPUs `4,5`:

```bash
PYTHONPATH=/data/sglang/python CUDA_VISIBLE_DEVICES=4,5 python -m sglang.launch_server \
  "${COMMON_FLAGS[@]}" \
  --port 28180 \
  --disaggregation-mode prefill \
  --disaggregation-transfer-backend mooncake \
  --disaggregation-bootstrap-port 28580 \
  --disaggregation-ib-device mlx5_6,mlx5_7
```

decode worker on GPUs `6,7`:

```bash
PYTHONPATH=/data/sglang/python CUDA_VISIBLE_DEVICES=6,7 python -m sglang.launch_server \
  "${COMMON_FLAGS[@]}" \
  --port 28280 \
  --disaggregation-mode decode \
  --disaggregation-transfer-backend mooncake \
  --disaggregation-bootstrap-port 28580 \
  --disaggregation-ib-device mlx5_8,mlx5_9
```

Router with `mini_lb.py`:

```bash
PYTHONPATH=/data/sglang/sgl-model-gateway/bindings/python/src \
python -m sglang_router.launch_router \
  --host 127.0.0.1 \
  --port 28080 \
  --pd-disaggregation \
  --mini-lb \
  --prefill http://127.0.0.1:28180 \
  --decode http://127.0.0.1:28280
```
### Send Request
#### Generate:

```bash
curl -s http://127.0.0.1:28380/generate -H 'Content-Type: application/json' -d '{
  "text": "Hello, my name is guapisolo.",
  "sampling_params": {"temperature": 0, "max_new_tokens": 32},
  "return_routed_experts": true
}' > ./baseline_generate.json

curl -s http://127.0.0.1:28080/generate -H 'Content-Type: application/json' -d '{
  "text": "Hello, my name is guapisolo.",
  "sampling_params": {"temperature": 0, "max_new_tokens": 32},
  "return_routed_experts": true
}' > ./pd_generate.json
```

#### Chat completions:

```bash
curl -s http://127.0.0.1:28380/v1/chat/completions -H 'Content-Type: application/json' -d '{
  "model": "Qwen/Qwen3-30B-A3B",
  "messages": [{"role": "user", "content": "Hello, my name is guapisolo."}],
  "temperature": 0,
  "max_tokens": 32,
  "stream": false,
  "return_routed_experts": true
}' > ./baseline_chat.json

curl -s http://127.0.0.1:28080/v1/chat/completions -H 'Content-Type: application/json' -d '{
  "model": "Qwen/Qwen3-30B-A3B",
  "messages": [{"role": "user", "content": "Hello, my name is guapisolo."}],
  "temperature": 0,
  "max_tokens": 32,
  "stream": false,
  "return_routed_experts": true
}' > ./pd_chat.json
```

### comparison script

```bash
python - <<'PY'
import base64, json, numpy as np

def load(path):
    with open(path) as f:
        return json.load(f)

def extract(obj, kind):
    if kind == "generate":
        text = obj["text"]
        blob = obj["meta_info"]["routed_experts"]
    else:
        text = obj["choices"][0]["message"]["content"]
        blob = obj["sglext"]["routed_experts"]
    arr = np.frombuffer(base64.b64decode(blob), dtype=np.int32)
    return text, arr

for kind, a_path, b_path in [
    ("generate", "./baseline_generate.json", "./pd_generate.json"),
    ("chat", "./baseline_chat.json", "./pd_chat.json"),
]:
    ta, aa = extract(load(a_path), kind)
    tb, bb = extract(load(b_path), kind)
    assert aa.shape == bb.shape, (kind, aa.shape, bb.shape)
    same = aa == bb
    print(kind)
    print("  same_text =", ta == tb)
    print("  exact_value_match_ratio =", float(same.mean()))
    print("  mismatch_count =", int((~same).sum()))
PY
```

### Result
```
generate
  same_text = True
  exact_value_match_ratio = 1.0
  mismatch_count = 0
chat
  same_text = True
  exact_value_match_ratio = 1.0
  mismatch_count = 0
```

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
