### PR TITLE
Remove compatibility restriction between Pipeline Parallelism and Mixed Chunked Prefill

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6467,8 +6467,7 @@ class ServerArgs:
             assert (
                 self.disable_overlap_schedule
                 and self.speculative_algorithm is None
-                and not self.enable_mixed_chunk
-            ), "Pipeline parallelism is not compatible with overlap schedule, speculative decoding, mixed chunked prefill."
+            ), "Pipeline parallelism is not compatible with overlap schedule, speculative decoding"
 
         assert not (
             self.dp_size > 1 and self.nnodes != 1 and not self.enable_dp_attention


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Previously, SGLang enforced a restriction that prevented using Pipeline Parallelism (PP) with Mixed Chunked Prefill (`--enable-mixed-chunk`). This limitation was enforced by an assertion in `server_args.py` that stated: "Pipeline parallelism is not compatible with overlap schedule, speculative decoding, mixed chunked prefill."

After removing this restriction and conducting extensive testing on a Qwen3-32B model (tp=2, pp-size=3, H800 GPUs, fa3 attention), we found that enabling mixed chunked prefill with PP not only works correctly but can also provide performance improvements in certain scenarios. The restriction appears to be overly conservative and prevents users from utilizing a potentially beneficial optimization.

## Modifications

This PR removes the` mixed chunked prefill` restriction from the PP compatibility check in `python/sglang/srt/server_args.py:6470`.

### Before:
```
if self.pp_size > 1:
    assert (
        self.disable_overlap_schedule
        and self.speculative_algorithm is None
        and not self.enable_mixed_chunk  # ← This line is removed
    ), "Pipeline parallelism is not compatible with overlap schedule, speculative decoding, mixed chunked prefill."
```
### After:
```
if self.pp_size > 1:
    assert (
        self.disable_overlap_schedule
        and self.speculative_algorithm is None
    ), "Pipeline parallelism is not compatible with overlap schedule, speculative decoding."
```
This change allows users to use` --enable-mixed-chunk `with` --pp-size > 1`, potentially improving throughput for PP workloads.

## Accuracy Tests
Tested with Qwen3-32B (tp=2, pp-size=3) on H800 GPUs, fa3 attention backend.

### Configurations:
 | Config | Parameter |
| :---: | :--- |
| **normal** | Baseline (no mixed chunk or dynamic chunking) |
 | **mix** | `--enable-mixed-chunk` |
 | **dynamic_chunking (mix+dc)** | `--enable-mixed-chunk --enable-dynamic-chunking` |
 | **dynamic_chunking (dc only)** | `--enable-dynamic-chunking` |

### GSM8K:
| Config | Accuracy | Invalid | Latency (s) | Throughput (token/s) |
| :---: | :---: | :---: | :---: | :---: |
| normal | 0.940 | 0.000 | 41.569 | 1583.224 |
| mix | **0.948** | 0.000 | **36.785** | **1794.200** |
| dc (mix+dc) | 0.942 | 0.000 | 42.939 | 1549.171 |
| dc (dc only) | 0.942 | 0.000 | 43.688 | 1506.540 |

### MMLU:
| Config| Avg Accuracy | Total Latency (s) |
| :---: | :---: | :---: |
| normal | 0.819 | 196.672 |
| mix | 0.819 | 198.493 |
| dc (mix+dc) | 0.819 | **193.022** |
| dc (dc only) | 0.819 | 200.323 |

### AIME 2025:
| Config| pass@1 (avg-of-4) | majority@4 | pass@4 | avg_tokens | gen_seconds |
| :---: | :---: | :---: | :---: | :---: | :---: |
| normal | 69.17% ± 7.39% | 76.67% | **86.67%** | 14759 | 2750 |
| mix | 72.50% ± 3.19% | **80.83%** | **86.67%** | 15710 | 3075 |
| dc (mix+dc) | 71.67% ± 1.92% | 77.50% | 83.33% | 15369 | 2904 |
| dc (dc only) | **74.17%** ± 4.19% | 80.00% | 83.33% | 15416 | 2987 |

### Key Findings:
- All configurations maintain accuracy parity (0.819 on MMLU across all configs)
- mix configuration achieves the best GSM8K accuracy (0.948) and lowest latency (36.785s)
- mix configuration achieves the highest throughput (1794 token/s on GSM8K)
- mix configuration achieves the best AIME majority@4 score (80.83%)
- No accuracy degradation observed when using mixed chunked prefill with PP

## Speed Tests and Profiling

### Throughput Comparison (GSM8K)

- **mix** achieves 13.3% higher throughput compared to baseline (1794 vs 1583 token/s)
- **mix** achieves 11.5% lower latency compared to baseline (36.785s vs 41.569s)

### Latency Comparison (MMLU)

- **mix+dc** achieves the lowest total latency (193.022s, 1.8% improvement over baseline)

These results demonstrate that mixed chunked prefill can provide meaningful performance improvements when used with Pipeline Parallelism, particularly for math reasoning workloads.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ]  Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ]  Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x]  Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x]  Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
