### PR TITLE
docs: fix incorrect default max-payload-size in gateway config reference

### DIFF
--- a/docs/advanced_features/sgl_model_gateway.md
+++ b/docs/advanced_features/sgl_model_gateway.md
@@ -1645,7 +1645,7 @@ groups:
 | `--policy` | str | cache_aware | Routing policy |
 | `--max-concurrent-requests` | int | -1 | Concurrency limit (-1 disables) |
 | `--request-timeout-secs` | int | 600 | Request timeout |
-| `--max-payload-size` | int | 256MB | Maximum request payload |
+| `--max-payload-size` | int | 512MB | Maximum request payload |
 
 ### Prefill/Decode
 


### PR DESCRIPTION
## Motivation

The [Configuration Reference](https://docs.sglang.ai/advanced_features/sgl_model_gateway.html#configuration-reference) table documents the default value of `--max-payload-size` as 256 MB, but the actual default in both the Python bindings (`router_args.py`) and the Rust config (`config/types.rs`) is **512 MB**.

This caused confusion for users troubleshooting payload size issues (see #6622, #10800).

## Modifications

- Fix `--max-payload-size` default value in the Configuration Reference table: `256MB` → `512MB`

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit). *(docs-only change, no Python files modified)*
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci). *(not applicable)*
- [x] Update documentation / docstrings / example tutorials as needed. *(this is the documentation fix)*