### PR TITLE
[misc] Configure logging before ServerArgs.__post_init__

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6946,6 +6946,16 @@ def prepare_server_args(argv: List[str]) -> ServerArgs:
         argv = config_merger.merge_config_with_args(argv)
 
     raw_args = parser.parse_args(argv)
+
+    # Set up basic logging before ServerArgs.__post_init__ so that
+    # logger.info / logger.warning calls there are properly formatted.
+    logging.basicConfig(
+        level=getattr(logging, raw_args.log_level.upper()),
+        format="[%(asctime)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        force=True,
+    )
+
     return ServerArgs.from_cli_args(raw_args)
 
 


### PR DESCRIPTION
## Summary
- Set up basic logging in `prepare_server_args()` before `from_cli_args()` triggers `__post_init__`, so that `logger.info` / `logger.warning` calls during ServerArgs initialization are properly formatted with `[YYYY-MM-DD HH:MM:SS]` timestamps.

## Test plan
- [ ] Run `python -m sglang.launch_server --model-path <model>` and verify log lines from `__post_init__` show timestamps