### PR TITLE
fix(sm120): NVFP4 NaN from E4M3 scale overflow + 3D tensor shape crashes

### DIFF
--- a/python/sglang/jit_kernel/nvfp4.py
+++ b/python/sglang/jit_kernel/nvfp4.py
@@ -136,11 +136,21 @@ def cutlass_scaled_fp4_mm(
     alpha: torch.Tensor,
     out_dtype: torch.dtype,
 ) -> torch.Tensor:
+    # Handle 3D tensors (e.g. [batch, seq, hidden]) by flattening to 2D for CUTLASS
+    orig_shape = a.shape
+    if a.ndim == 3:
+        a = a.reshape(-1, a.shape[-1])
+        block_scale_a = block_scale_a.reshape(-1, block_scale_a.shape[-1])
+    if b.ndim == 3:
+        b = b.reshape(-1, b.shape[-1])
+        block_scale_b = block_scale_b.reshape(-1, block_scale_b.shape[-1])
     assert a.ndim == 2 and b.ndim == 2
     m, n = a.shape[0], b.shape[0]
     out = torch.empty((m, n), dtype=out_dtype, device=a.device)
     module = _jit_nvfp4_scaled_mm_module()
     module.cutlass_scaled_fp4_mm(out, a, b, block_scale_a, block_scale_b, alpha)
+    if len(orig_shape) == 3:
+        out = out.reshape(orig_shape[0], -1, n)
     return out
 
 

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -138,7 +138,8 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsLinearScheme):
     ) -> torch.Tensor:
         output_dtype = x.dtype
         w_n, _ = layer.weight_packed.shape
-        output_shape = [x.shape[0], w_n]
+        # Preserve all leading dims for 3D+ inputs (e.g. [batch, seq, hidden])
+        output_shape = list(x.shape[:-1]) + [w_n]
 
         # quantize BF16 or FP16 to (FP4 and interleaved block scale)
         x_fp4, x_blockscale = fp4_quantize(x, layer.input_global_scale)
@@ -168,4 +169,4 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsLinearScheme):
         )
         if bias is not None:
             out = out + bias
-        return out.view(*output_shape)
+        return out.reshape(*output_shape)

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -138,17 +138,18 @@ def fp4_gemm(
     out_dtype: torch.dtype,
     out_features: int,
 ) -> torch.Tensor:
+    # SM120 (RTX 5090 / Blackwell) CUTLASS FP4 GEMM NaN fix:
+    # E4M3 scale factor with uint8 value 127 (max representable = 448.0) triggers
+    # NaN in the CUTLASS kernel. Clamp to 126 (= 416.0, <2% precision loss).
+    # Using unconditional clamp instead of conditional .max() check also avoids
+    # GPU-to-CPU synchronization that would break CUDA graph capture.
+    input_sf = input_sf.view(torch.uint8).clamp(max=126).view(torch.float8_e4m3fn)
+    weight_sf = weight_sf.view(torch.uint8).clamp(max=126).view(torch.float8_e4m3fn)
+
     fp4_backend = get_fp4_gemm_runner_backend()
     if fp4_backend.is_cutlass() and cutlass_fp4_gemm is not None:
-        # flashinfer.fp4_quantize returns scale factors as uint8 (e4m3fn bits
-        # stored in uint8 memory). The JIT kernel requires float8_e4m3fn dtype.
-        if input_sf.dtype != torch.float8_e4m3fn:
-            input_sf = input_sf.view(torch.float8_e4m3fn)
-        if weight_sf.dtype != torch.float8_e4m3fn:
-            weight_sf = weight_sf.view(torch.float8_e4m3fn)
         return cutlass_fp4_gemm(input, weight, input_sf, weight_sf, alpha, out_dtype)
     elif enable_flashinfer_fp4_gemm:
-        # Use the remapping logic to convert SGLang backend names to FlashInfer API names
         backend = fp4_backend.get_flashinfer_backend()
         return flashinfer_fp4_gemm(
             input, weight, input_sf, weight_sf, alpha, out_dtype, backend=backend

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -138,16 +138,15 @@ def fp4_gemm(
     out_dtype: torch.dtype,
     out_features: int,
 ) -> torch.Tensor:
-    # SM120 (RTX 5090 / Blackwell) CUTLASS FP4 GEMM NaN fix:
-    # E4M3 scale factor with uint8 value 127 (max representable = 448.0) triggers
-    # NaN in the CUTLASS kernel. Clamp to 126 (= 416.0, <2% precision loss).
-    # Using unconditional clamp instead of conditional .max() check also avoids
-    # GPU-to-CPU synchronization that would break CUDA graph capture.
-    input_sf = input_sf.view(torch.uint8).clamp(max=126).view(torch.float8_e4m3fn)
-    weight_sf = weight_sf.view(torch.uint8).clamp(max=126).view(torch.float8_e4m3fn)
-
     fp4_backend = get_fp4_gemm_runner_backend()
     if fp4_backend.is_cutlass() and cutlass_fp4_gemm is not None:
+        # SM120 (RTX 5090 / Blackwell) CUTLASS FP4 GEMM NaN fix:
+        # E4M3 scale factor with uint8 value 127 (max representable = 448.0)
+        # triggers NaN in the CUTLASS kernel on SM120. Clamp to 126 (= 416.0,
+        # <2% precision loss). Using unconditional clamp instead of conditional
+        # .max() check avoids GPU-to-CPU sync that breaks CUDA graph capture.
+        input_sf = input_sf.contiguous().view(torch.uint8).clamp(max=126).view(torch.float8_e4m3fn)
+        weight_sf = weight_sf.contiguous().view(torch.uint8).clamp(max=126).view(torch.float8_e4m3fn)
         return cutlass_fp4_gemm(input, weight, input_sf, weight_sf, alpha, out_dtype)
     elif enable_flashinfer_fp4_gemm:
         backend = fp4_backend.get_flashinfer_backend()


### PR DESCRIPTION
## Summary

Three fixes for NVFP4 quantized models on SM120 GPUs (RTX 5090, RTX PRO 6000):

### 1. E4M3 Scale Factor NaN (`modelopt_quant.py`)
CUTLASS FP4 GEMM kernels on SM120 produce NaN when an E4M3 scale factor has uint8 value 127 (E4M3 max = 448.0). This affects all NVFP4 models on all SM120 hardware.

**Fix:** Clamp E4M3 scale factors to uint8 126 (= 416.0, <2% precision loss). Uses unconditional `.clamp()` instead of conditional `.max()` check, which also fixes CUDA graph capture (`.max()` forces GPU-to-CPU sync that crashes graph capture with `cudaErrorStreamCaptureUnsupported`).

### 2. 3D Tensor Output Shape (`compressed_tensors_w4a4_nvfp4.py`)
`output_shape = [x.shape[0], w_n]` assumes 2D input. During serving, inputs can be 3D `[batch, seq, hidden]`, causing `RuntimeError: shape '[1, 3456]' is invalid for input of size 8709120`.

**Fix:** `output_shape = list(x.shape[:-1]) + [w_n]` preserves all leading dimensions. Changed `.view()` to `.reshape()` for non-contiguous tensors.

### 3. CUTLASS FP4 MM 2D Assertion (`nvfp4.py`)
`assert a.ndim == 2` in `cutlass_scaled_fp4_mm()` crashes when tensors arrive as 3D during batch processing.

**Fix:** Reshape 3D inputs to 2D before the CUTLASS kernel call, reshape output back after.

## Benchmark (RTX 5090, Gemma 4 26B MoE NVFP4)

| Config | Single User | 30 Concurrent Users |
|--------|-------------|-------------------|
| Before (crashes) | N/A | N/A |
| **After (with CUDA graphs)** | **143 tok/s** | **2,783 tok/s aggregate, p95 3.2s** |

Tested with `RedHatAI/gemma-4-26B-A4B-it-NVFP4` on RTX 5090 32GB, `--quantization compressed-tensors --fp4-gemm-backend cutlass --moe-runner-backend flashinfer_cutlass --cuda-graph-bs 1 2 4 8 16`.

## Test Plan

- [x] Tested on RTX 5090 (SM120) with Gemma 4 26B MoE NVFP4
- [x] Single user generation: 143 tok/s, coherent output
- [x] 30 concurrent users: 2,783 tok/s aggregate, p95 latency 3.2s
- [x] CUDA graphs enabled and working
- [x] No NaN in outputs across extended generation
- [ ] Needs testing on non-SM120 hardware to verify no regression
