### PR TITLE
fix(sm120): MoE GEGLU activation support + FP4 block scale NaN clamp

### DIFF
--- a/python/sglang/srt/layers/moe/cutlass_moe.py
+++ b/python/sglang/srt/layers/moe/cutlass_moe.py
@@ -18,6 +18,7 @@ if _is_cuda:
         prepare_moe_input,
         shuffle_rows,
         silu_and_mul,
+        gelu_tanh_and_mul,
     )
 
     from sglang.jit_kernel.nvfp4 import (
@@ -359,6 +360,7 @@ def cutlass_moe_fp4(
     topk_ids: torch.Tensor,
     params: CutlassMoEParams,
     apply_router_weight_on_input: bool = False,
+    activation: str = "silu",
 ):
     """
     MoE implementation for FP4 Inputs
@@ -456,6 +458,8 @@ def cutlass_moe_fp4(
         num_topk,
         expert_map=a_map,
     )
+    # SM120 FP4 bug: clamp E4M3 block scale uint8=127 -> 126 to prevent NaN
+    rep_a_blockscale.view(torch.uint8).clamp_(max=126)
     c1 = cutlass_fp4_group_mm(
         rep_a_fp4,
         w1_fp4,
@@ -467,11 +471,14 @@ def cutlass_moe_fp4(
     )
     del rep_a_fp4, rep_a_blockscale
 
-    # hidden size dimension is split to one halfpytho sized tensor.
+    # hidden size dimension is split to one half sized tensor.
     intermediate = torch.empty(
         (m_a * num_topk, w1_fp4.shape[1] // 2), device=device, dtype=out_dtype
     )
-    silu_and_mul(c1, intermediate)
+    if activation == "gelu_tanh":
+        gelu_tanh_and_mul(c1, intermediate)
+    else:
+        silu_and_mul(c1, intermediate)
 
     int_fp4, int_blockscale = scaled_fp4_experts_quant(
         intermediate,
@@ -480,6 +487,8 @@ def cutlass_moe_fp4(
         params.blockscale_offsets,
         num_topk,
     )
+    # SM120 FP4 bug: clamp E4M3 block scale uint8=127 -> 126 to prevent NaN
+    int_blockscale.view(torch.uint8).clamp_(max=126)
     c2 = cutlass_fp4_group_mm(
         int_fp4,
         w2_fp4,

--- a/python/sglang/srt/layers/moe/cutlass_moe.py
+++ b/python/sglang/srt/layers/moe/cutlass_moe.py
@@ -475,7 +475,7 @@ def cutlass_moe_fp4(
     intermediate = torch.empty(
         (m_a * num_topk, w1_fp4.shape[1] // 2), device=device, dtype=out_dtype
     )
-    if activation == "gelu_tanh":
+    if "gelu" in activation:
         gelu_tanh_and_mul(c1, intermediate)
     else:
         silu_and_mul(c1, intermediate)


### PR DESCRIPTION
## Summary

Two fixes for `cutlass_moe_fp4()` that affect NVFP4 MoE models on SM120 GPUs (RTX 5090, RTX PRO 6000):

### 1. GEGLU Activation Support
`cutlass_moe_fp4()` hardcodes `silu_and_mul()` as the activation function. Models that use GEGLU (like Gemma 4 26B MoE) produce incorrect output from every MoE layer because the wrong activation is applied between GEMM1 and GEMM2.

**Fix:** Add `activation` parameter to `cutlass_moe_fp4()`. When `activation="gelu_tanh"`, uses `gelu_tanh_and_mul()` instead. Defaults to `"silu"` for backward compatibility.

### 2. MoE Block Scale NaN Clamp
Same E4M3 uint8=127 NaN bug as in linear layers, but in the MoE path. Block scales from `scaled_fp4_experts_quant()` can contain uint8 value 127 which triggers NaN in the CUTLASS FP4 group GEMM kernel on SM120.

**Fix:** Clamp block scales to uint8 126 after both `scaled_fp4_experts_quant()` calls (GEMM1 activation scales and GEMM2 intermediate scales).

## Benchmark (RTX 5090, Gemma 4 26B MoE NVFP4)

Without these fixes, Gemma 4 NVFP4 MoE layers produce garbage output (wrong activation) and/or NaN (unclamped scales). With fixes applied:

| Config | Single User | 30 Concurrent Users |
|--------|-------------|-------------------|
| **NVFP4 fused MoE + CUDA graphs** | **143 tok/s** | **2,783 tok/s aggregate, p95 3.2s** |

## Test Plan

- [x] Tested on RTX 5090 (SM120) with `RedHatAI/gemma-4-26B-A4B-it-NVFP4`
- [x] Verified coherent output (correct GEGLU activation)
- [x] No NaN with block scale clamping across extended generation
- [x] 30 concurrent users benchmark passes
- [ ] Needs testing on non-SM120 to verify no regression
- [ ] Needs testing with SiLU-based MoE models to verify default path unchanged
