### PR TITLE
Add NVFP4 per-expert weight loading for Gemma 4 MoE models

### DIFF
--- a/python/sglang/srt/models/gemma4_causal.py
+++ b/python/sglang/srt/models/gemma4_causal.py
@@ -905,6 +905,27 @@ class Gemma4ForCausalLM(PreTrainedModel):
         ]
         num_experts = self.config.num_experts
 
+        # NVFP4 per-expert unfused weight mappings.
+        # NVFP4 checkpoints store per-expert tensors:
+        #   moe.experts.{id}.{gate_proj,up_proj,down_proj}.{weight,weight_scale,...}
+        # SGLang expects fused format: moe.experts.w13_{suffix} / w2_{suffix}
+        nvfp4_expert_params_mapping = []
+        for expert_id in range(num_experts):
+            for shard_id, weight_name in [
+                ("w1", "gate_proj"),
+                ("w2", "down_proj"),
+                ("w3", "up_proj"),
+            ]:
+                param_prefix = (
+                    "experts.w13_"
+                    if shard_id in ("w1", "w3")
+                    else "experts.w2_"
+                )
+                ckpt_prefix = f"experts.{expert_id}.{weight_name}."
+                nvfp4_expert_params_mapping.append(
+                    (param_prefix, ckpt_prefix, expert_id, shard_id)
+                )
+
         k_eq_v_layers = self._get_k_eq_v_layers()
 
         params_dict = dict(self.named_parameters())
@@ -936,9 +957,34 @@ class Gemma4ForCausalLM(PreTrainedModel):
                 and int(m.group(1)) in k_eq_v_layers
             )
 
+            # NVFP4 per-expert weights (unfused, one expert at a time).
+            # Must be checked before fused expert_params_mapping.
+            orig_name = name
+            nvfp4_matched = False
+            for param_prefix, ckpt_prefix, expert_id, shard_id in (
+                nvfp4_expert_params_mapping
+            ):
+                if ckpt_prefix not in orig_name:
+                    continue
+                pname = (
+                    orig_name.split(ckpt_prefix)[0]
+                    + param_prefix
+                    + orig_name.split(ckpt_prefix)[1]
+                )
+                if pname not in params_dict:
+                    continue
+                param = params_dict[pname]
+                weight_loader = param.weight_loader
+                weight_loader(param, loaded_weight, pname, shard_id, expert_id)
+                loaded_params.add(pname)
+                nvfp4_matched = True
+                break
+            if nvfp4_matched:
+                loaded_params.add(orig_name)
+                continue
+
             # MoE expert weights checked first (gate_up_proj contains "up_proj"
             # which would false-match the stacked dense MLP mapping).
-            orig_name = name
             for param_name, weight_name, shard_ids in expert_params_mapping:
                 name = orig_name
                 if weight_name not in name:

--- a/python/sglang/srt/models/gemma4_mm.py
+++ b/python/sglang/srt/models/gemma4_mm.py
@@ -721,6 +721,27 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
             ("experts.w2_weight", "experts.down_proj", ("w2",)),
         ]
 
+        # NVFP4 per-expert unfused weight mappings.
+        # NVFP4 checkpoints store per-expert tensors:
+        #   moe.experts.{id}.{gate_proj,up_proj,down_proj}.{weight,weight_scale,...}
+        # SGLang expects fused format: moe.experts.w13_{suffix} / w2_{suffix}
+        nvfp4_expert_params_mapping = []
+        for expert_id in range(num_experts):
+            for shard_id, weight_name in [
+                ("w1", "gate_proj"),
+                ("w2", "down_proj"),
+                ("w3", "up_proj"),
+            ]:
+                param_prefix = (
+                    "experts.w13_"
+                    if shard_id in ("w1", "w3")
+                    else "experts.w2_"
+                )
+                ckpt_prefix = f"experts.{expert_id}.{weight_name}."
+                nvfp4_expert_params_mapping.append(
+                    (param_prefix, ckpt_prefix, expert_id, shard_id)
+                )
+
         params_dict = dict(self.named_parameters())
         params_dict.update(dict(self.named_buffers()))
         non_persistent_buffers: Set[str] = set()
@@ -767,9 +788,34 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
                 and int(m.group(1)) in k_eq_v_layers
             )
 
+            # NVFP4 per-expert weights (unfused, one expert at a time).
+            # Must be checked before fused expert_params_mapping.
+            orig_name = name
+            nvfp4_matched = False
+            for param_prefix, ckpt_prefix, expert_id, shard_id in (
+                nvfp4_expert_params_mapping
+            ):
+                if ckpt_prefix not in orig_name:
+                    continue
+                pname = (
+                    orig_name.split(ckpt_prefix)[0]
+                    + param_prefix
+                    + orig_name.split(ckpt_prefix)[1]
+                )
+                if pname not in params_dict:
+                    continue
+                param = params_dict[pname]
+                weight_loader = param.weight_loader
+                weight_loader(param, loaded_weight, pname, shard_id, expert_id)
+                loaded_params.add(pname)
+                nvfp4_matched = True
+                break
+            if nvfp4_matched:
+                loaded_params.add(orig_name)
+                continue
+
             # MoE expert weights checked first (gate_up_proj contains "up_proj"
             # which would false-match the stacked dense MLP mapping).
-            orig_name = name
             for param_name, weight_name, shard_ids in expert_params_mapping:
                 name = orig_name
                 if weight_name not in name:


### PR DESCRIPTION
## Summary

Adds NVFP4 per-expert weight loading for Gemma 4 MoE models in both `gemma4_mm.py` and `gemma4_causal.py`.

### Problem

NVFP4 checkpoints (e.g. `RedHatAI/gemma-4-26B-A4B-it-NVFP4`) store MoE expert weights in unfused per-expert format:
```
moe.experts.{id}.{gate_proj,up_proj,down_proj}.{weight,weight_scale,weight_scale_2,input_scale}
```

SGLang's existing `expert_params_mapping` only handles the fused format (`experts.gate_up_proj`, `experts.down_proj`). Without the per-expert mapping, NVFP4 expert weights silently fail to load, resulting in uninitialized weights and garbage output.

### Fix

Add `nvfp4_expert_params_mapping` that maps per-expert checkpoint tensors to SGLang's fused `w13_`/`w2_` parameter format. The mapping runs before the existing fused expert mapping so it doesn't interfere with standard checkpoints.

Applied to both model files:
- `gemma4_mm.py` (multimodal variant)
- `gemma4_causal.py` (text-only variant)

### Files Changed
- `python/sglang/srt/models/gemma4_mm.py`
- `python/sglang/srt/models/gemma4_causal.py`

## Test Plan

- [x] Tested with `RedHatAI/gemma-4-26B-A4B-it-NVFP4` on RTX 5090
- [x] All expert weights load correctly (no "weights not initialized" warnings for MoE params)
- [x] Model produces coherent output
- [x] Standard (non-NVFP4) checkpoints still load correctly via existing fused mapping
