### PR TITLE
perf(vit): thread pre-computed max_seqlen to eliminate per-layer .item() sync

### DIFF
--- a/python/sglang/srt/layers/attention/vision.py
+++ b/python/sglang/srt/layers/attention/vision.py
@@ -421,8 +421,10 @@ class VisionFlash3Attention(nn.Module):
         else:
             cu_seqlens = resolve_seqlens(cu_seqlens, bsz, seq_len, device=q.device)
             cu_seqlens = cu_seqlens.to(dtype=torch.int32).to(q.device)
-            seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
-            max_seqlen = seq_lens.max().item()
+            max_seqlen = kwargs.get("max_seqlen", None)
+            if max_seqlen is None:
+                seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
+                max_seqlen = seq_lens.max().item()
 
             output = flash_attn_varlen_func(
                 q,
@@ -474,8 +476,10 @@ class VisionFlash4Attention(nn.Module):
             cu_seqlens = cu_seqlens.get_data()
 
         cu_seqlens = cu_seqlens.to(dtype=torch.int32).to(q.device)
-        seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
-        max_seqlen = seq_lens.max().item()
+        max_seqlen = kwargs.get("max_seqlen", None)
+        if max_seqlen is None:
+            seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
+            max_seqlen = seq_lens.max().item()
 
         output = flash_attn_varlen_func(
             q,

--- a/python/sglang/srt/models/kimi_k25.py
+++ b/python/sglang/srt/models/kimi_k25.py
@@ -158,6 +158,7 @@ class MoonViTEncoderLayer(nn.Module):
             hidden_states,
             cu_seqlens=cu_seqlens,
             position_embeddings=rope_freqs_cis,
+            max_seqlen=max_seqlen,
         )
 
         hidden_states = residual + hidden_states
@@ -477,7 +478,7 @@ class MoonViT3dEncoder(nn.Module):
             )
         )
 
-        max_seqlen = lengths.max()
+        max_seqlen = int(lengths.max().item())
         cu_seqlens = lengths.to(hidden_states.device).cumsum(dim=0, dtype=torch.int32)
 
         for block in self.blocks:


### PR DESCRIPTION


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

In the ViT attention path, `max_seqlen` was computed on every attention layer via `seq_lens.max().item()`, which triggers a GPU-CPU synchronization each time. This is redundant since `max_seqlen` is the same across all layers and can be computed once upfront.

## Modifications

- **`python/sglang/srt/models/kimi_k25.py`**
  - In `MoonViT3dEncoder.forward()`, change `max_seqlen = lengths.max()` to `max_seqlen = int(lengths.max().item())` so `max_seqlen` is pre-computed as a Python int once, rather than leaving it as a GPU tensor.
  - In `MoonViTEncoderLayer.forward()`, pass `max_seqlen=max_seqlen` to `self.attn()` so the pre-computed value is propagated down.

- **`python/sglang/srt/layers/attention/vision.py`**
  - In `VisionFlash3Attention.forward()` and `VisionFlash4Attention.forward()`, first attempt to retrieve `max_seqlen` from `kwargs.get("max_seqlen", None)`. Only fall back to computing it from `cu_seqlens` when the kwarg is not provided, maintaining backward compatibility.

## Accuracy Tests

This change does not alter any computation logic — `max_seqlen` remains the same value regardless of whether it is pre-computed or computed per-layer. No accuracy impact expected.

## Speed Tests and Profiling
with item:
<img width="1534" height="456" alt="d5f6de3a4b7e2d3425519eeb305d5d4d" src="https://github.com/user-attachments/assets/635649be-c718-4401-9ed9-b771e2255bf8" />

no item:
<img width="1728" height="548" alt="f1a66d6e92058390110a9261504cbc7d" src="https://github.com/user-attachments/assets/a3c8a506-ed5d-41f2-b951-0c13f58a2dbf" />

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
