### PR TITLE
[AMD][MI30X] Restore DeepSeek MLA MI300X paths after MLA refactor (#19122)

### DIFF
--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -66,6 +66,7 @@ if _use_aiter:
     from aiter.ops.triton.batched_gemm_a8w8_a_per_token_group_prequant_w_per_batched_tensor_quant import (
         batched_gemm_a8w8_a_per_token_group_prequant_w_per_batched_tensor_quant,
     )
+
     from sglang.srt.layers.rocm_linear_utils import fused_qk_rope_cat_and_cache_mla
 
 if _use_aiter_gfx95:

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -19,7 +19,6 @@ from sglang.srt.models.deepseek_common.utils import (
     _is_cpu,
     _is_cublas_ge_129,
     _is_cuda,
-    _is_gfx95_supported,
     _is_hip,
     _is_musa,
     _use_aiter,
@@ -67,6 +66,8 @@ if _use_aiter:
     from aiter.ops.triton.batched_gemm_a8w8_a_per_token_group_prequant_w_per_batched_tensor_quant import (
         batched_gemm_a8w8_a_per_token_group_prequant_w_per_batched_tensor_quant,
     )
+    from sglang.srt.layers.rocm_linear_utils import fused_qk_rope_cat_and_cache_mla
+
 if _use_aiter_gfx95:
     from aiter.ops.triton.fused_fp8_quant import (
         fused_flatten_fp8_group_quant,
@@ -78,7 +79,6 @@ if _use_aiter_gfx95:
         fused_flatten_mxfp4_quant,
         fused_rms_mxfp4_quant,
     )
-    from sglang.srt.layers.rocm_linear_utils import fused_qk_rope_cat_and_cache_mla
 
 
 class DeepseekMLAForwardMixin:
@@ -317,7 +317,7 @@ class DeepseekMLAForwardMixin:
             self.rotary_emb is not None
             and (not self._fuse_rope_for_trtllm_mla(forward_batch))
             and (not skip_rope_for_nsa_tilelang_fused)
-            and (not _use_aiter or not _is_gfx95_supported or self.use_nsa)
+            and (not _use_aiter or not _is_hip or self.use_nsa)
         ):
             q_pe, k_pe = self.rotary_emb(positions, q_pe, k_pe)
 
@@ -351,6 +351,8 @@ class DeepseekMLAForwardMixin:
         topk_indices,
         llama_4_scaling,
     ):
+        from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
+
         save_kv_cache = True
 
         if self.current_attention_backend in FORWARD_ABSORB_CORE_ATTENTION_BACKENDS:
@@ -418,7 +420,7 @@ class DeepseekMLAForwardMixin:
                     ),
                 )
         else:
-            if _use_aiter_gfx95:
+            if _use_aiter:
                 cos = self.rotary_emb.cos_cache
                 sin = self.rotary_emb.sin_cache
 
@@ -500,7 +502,11 @@ class DeepseekMLAForwardMixin:
                     attn_bmm_output,
                 )
             else:
-                if _use_aiter_gfx95 and self.w_kc.dtype == torch.float8_e4m3fn:
+                if (_use_aiter_gfx95 and self.w_kc.dtype == torch.float8_e4m3fn) or (
+                    get_is_capture_mode() and self.w_kc.dtype == torch.float8_e4m3fnuz
+                ):
+                    # fp8 Triton kernel: always on gfx950,
+                    # cudagraph-only on gfx942 (hides launch overhead)
                     attn_bmm_output = batched_gemm_a8w8_a_per_token_group_prequant_w_per_batched_tensor_quant(
                         X=attn_output,
                         WQ=self.w_vc.transpose(-1, -2),

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -169,9 +169,6 @@ if _use_aiter_gfx95:
         get_dsv3_gemm_output_zero_allocator_size,
     )
 
-if _use_aiter:
-    pass
-
 if _is_cuda:
     from flashinfer.gemm import mm_M1_16_K7168_N256 as _raw_dsv3_router_gemm
     from sgl_kernel import dsv3_fused_a_gemm, dsv3_router_gemm


### PR DESCRIPTION
## Motivation
Re-apply #18242 and #18624 behavior in forward_mla.py (logic moved out of deepseek_v2.py by #19122 but not fully carried over):

## Modifications
- Import fused_qk_rope_cat_and_cache_mla for all SGLANG_USE_AITER HIP builds.
- Skip eager rope in absorb prepare when using Aiter on HIP; run fused rope+KV in absorb core for _use_aiter (not only gfx95).
- Restore second MLA FP8 BMM (w_vc) Triton path under cudagraph capture + float8_e4m3fnuz on gfx942 (#18624 had only the first BMM after refactor).
- Remove stray no-op import block in deepseek_v2.py.

## Accuracy Test Results — Before/After

Test pattern: `test_deepseek_v3_basic.py` (GSM8K 8-shot completion + BS1 speed)
Server args: `--tp 8 --attention-backend aiter --chunked-prefill-size 131072 --disable-radix-cache --mem-fraction-static 0.85 --trust-remote-code`
Env: `SGLANG_USE_AITER=1`
Image: `lmsysorg/sglang-rocm:v0.5.10.post1-rocm700-mi30x-20260423`
Machine: 8x MI300X gfx942

### test_a_gsm8k

| Metric | Baseline | With PR | Δ |
|--------|----------|---------|---|
| Score | 0.975 | **0.980** | +0.005 |
| Latency (s) | 30.39 | **23.33** | **-23.2%** |
| Output Throughput (tok/s) | 697.21 | **894.79** | **+28.3%** |

**Image:** `lmsysorg/sglang-rocm:v0.5.10.post1-rocm700-mi30x-20260423`
**Machine:** 8x MI300X gfx942

Both baseline and PR runs used the same container; PR changes were applied in-place between runs. Accuracy maintained above 93% threshold. BS1 decode speed improved by ~21%.

## Speed Tests and Profiling

### Benchmark (MI300X, ROCm)
**Workload:** `sglang.bench_serving`, `dataset-name=random`, ISL **1024** / OSL **1024**, `random_range_ratio=0.8`, **640** prompts, `max_concurrency=64`, `request_rate=inf`, DeepSeek-R1-0528, `attention-backend aiter`, `kv-cache-dtype fp8_e4m3`, TP **8**.
Throughput numbers below are **aggregate server/client** token rates from `bench_serving` (not per-GPU unless noted).

| Metric | Parent | This branch | Δ |
|--------|----------------------|---------------------------|---|
| **Total token throughput (tok/s)** | 2532.34 | **3067.75** | **+535.4 (+21.1%)** |
| Input token throughput (tok/s) | 1268.10 | **1536.22** | +268.1 (+21.1%) |
| Output token throughput (tok/s) | 1264.24 | **1531.54** | +267.3 (+21.1%) |
| Benchmark duration (s) | 465.93 | **384.61** | −81.3 (−17.5%) |
| Mean E2E latency (ms) | 45707 | **37737** | −7970 |
| Mean TTFT (ms) | 1447 | **978** | −469 |
| Mean TPOT (ms) | 48.08 | **39.95** | −8.13 |
| P99 E2E latency (ms) | 85023 | **55507** | −29516 |

**Headline:** **~+21% higher total token throughput** on this run, with shorter wall time and lower latency.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
