### PR TITLE
fix: replace bare except with except ImportError in minicpmo.py

### DIFF
--- a/python/sglang/srt/models/minicpmo.py
+++ b/python/sglang/srt/models/minicpmo.py
@@ -61,7 +61,7 @@ try:
     from vector_quantize_pytorch import GroupedResidualFSQ
 
     _tts_deps = True
-except:
+except ImportError:
     LogitsWarper = None
     _tts_deps = False
 


### PR DESCRIPTION
## Summary

Fixes #22946

Replace bare `except:` with `except ImportError:` in the optional TTS dependency import block in `python/sglang/srt/models/minicpmo.py`.

## Problem

The current code uses a bare `except:` clause:

```python
try:
    from transformers import LogitsWarper
    from vector_quantize_pytorch import GroupedResidualFSQ

    _tts_deps = True
except:          # catches everything!
    LogitsWarper = None
    _tts_deps = False
```

A bare `except:` catches **all** exceptions, including:
- `KeyboardInterrupt` — swallows Ctrl-C, making the process uninterruptible during import
- `SystemExit` — prevents clean shutdown
- `MemoryError` — hides OOM conditions

## Fix

```python
except ImportError:
    LogitsWarper = None
    _tts_deps = False
```

Only `ImportError` (and its subclass `ModuleNotFoundError`) should be caught here, since the intent is to handle the case where the optional TTS packages are not installed.

## Notes

- No functional change for the common case (missing packages)
- Consistent with PEP 8 style guidelines which explicitly discourage bare `except:` clauses