### PR TITLE
[AMD] Add SGLANG_MORI_MOE_MAX_INPUT_TOKENS to truncate dispatch before MoE.

### DIFF
--- a/docs/references/environment_variables.md
+++ b/docs/references/environment_variables.md
@@ -83,6 +83,7 @@ SGLang supports various environment variables that can be used to configure its 
 | `SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK` | Maximum number of dispatch tokens per rank for MORI-EP buffer allocation | `4096` |
 | `SGLANG_MORI_DISPATCH_INTER_KERNEL_SWITCH_THRESHOLD` | Threshold for switching between `InterNodeV1` and `InterNodeV1LL` kernel types. `InterNodeV1LL` is used if `SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK` is less than or equal to this threshold; otherwise, `InterNodeV1` is used. | `256` |
 | `SGLANG_MORI_PREALLOC_MAX_RECV_TOKENS` | This argument devives `SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK` which indicates customized amount of tokens preallocated for a rank, valid range from 1 to world_size*SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK, by default `0` means maximum. Setting a smaller value will reduce memory footprint but too small value could cause buffer overflow. | `0` |
+| `SGLANG_MORI_MOE_MAX_INPUT_TOKENS` | Truncate the dispatch buffer to this many rows before MoE computation, reducing kernel overhead on padding tokens. The value must be >= the actual number of received tokens (`totalRecvTokenNum`); setting it too small causes incorrect results. `0` disables truncation (use full buffer). | `0` |
 | `SGLANG_MORI_QP_PER_TRANSFER` | Number of RDMA Queue Pairs (QPs) used per transfer operation | `1` |
 | `SGLANG_MORI_POST_BATCH_SIZE` | Number of RDMA work requests posted in a single batch to each QP | `-1` |
 | `SGLANG_MORI_NUM_WORKERS` | Number of worker threads in the RDMA executor thread pool | `1` |

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -39,7 +39,7 @@ from sglang.srt.layers.quantization.fp8 import Fp8Config, Fp8MoEMethod
 from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
 from sglang.srt.layers.quantization.quark.schemes import QuarkW4A4MXFp4MoE
 from sglang.srt.layers.quantization.w4afp8 import W4AFp8Config, W4AFp8MoEMethod
-from sglang.srt.utils import get_bool_env_var, is_hip, is_npu
+from sglang.srt.utils import get_bool_env_var, get_int_env_var, is_hip, is_npu
 
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher import (
@@ -635,6 +635,10 @@ class MoriEPMoE(DeepEPMoE):
         expert_end_idx = expert_start_idx + self.num_local_experts
         self.expert_mask[expert_start_idx:expert_end_idx] = 1
 
+        self.mori_moe_max_input_tokens = get_int_env_var(
+            "SGLANG_MORI_MOE_MAX_INPUT_TOKENS", 0
+        )
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -680,6 +684,19 @@ class MoriEPMoE(DeepEPMoE):
             dispatch_output.origin_topk_weights,
             dispatch_output.out_dtype,
         )
+
+        # Truncate dispatch tensors to reduce MoE computation on padding rows.
+        # dispatch_a1 has shape (M, hidden_size) where M is the full buffer size,
+        # but only the first dispatch_recv_token_num rows are valid.
+        # mori combine only reads [0, totalRecvTokenNum), so the truncated
+        # output can be passed directly without padding back.
+        if self.mori_moe_max_input_tokens > 0:
+            limit = self.mori_moe_max_input_tokens
+            dispatch_a1 = dispatch_a1[:limit]
+            if dispatch_scale is not None:
+                dispatch_scale = dispatch_scale[:limit]
+            dispatch_ids = dispatch_ids[:limit]
+            dispatch_weights = dispatch_weights[:limit]
 
         w13_weight = self.w13_weight
         w2_weight = self.w2_weight


### PR DESCRIPTION
## Motivation

In the MoriEP MoE path, `dispatch_a1` (the dispatch output hidden states) has a fixed first dimension of `SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK * ep_size` (or `SGLANG_MORI_PREALLOC_MAX_RECV_TOKENS`). However, the actual number of valid tokens (`totalRecvTokenNum`) is often much smaller than this buffer size.

`aiter.fused_moe` uses the first dimension of the input tensor (`dispatch_a1.shape[0]`) to select the kernel dispatch strategy. Because the padded buffer size is much larger than the actual `totalRecvTokenNum`, `aiter.fused_moe` selects a suboptimal kernel intended for large token counts, leading to degraded MoE performance.

This PR adds an environment variable `SGLANG_MORI_MOE_MAX_INPUT_TOKENS` to truncate the dispatch tensors before MoE computation, so that `aiter.fused_moe` sees a tensor size closer to the actual valid token count and selects the appropriate kernel.

## Modifications

- **`python/sglang/srt/layers/moe/ep_moe/layer.py`**:
  - Read `SGLANG_MORI_MOE_MAX_INPUT_TOKENS` env var in `MoriEPMoE.__init__` (default `0` = disabled).
  - In `run_moe_core`, if the env var is set and smaller than the buffer size, truncate `dispatch_a1`, `dispatch_scale`, `dispatch_ids`, and `dispatch_weights` to `[:limit]` before passing to `fused_moe`.
  - No padding back is needed: `mori_op.combine` only reads from positions `[0, totalRecvTokenNum)`, which are all within the truncated range when the env var is set correctly (>= `totalRecvTokenNum`).

- **`docs/references/environment_variables.md`**: Added documentation for the new env var.

**Usage**: Set `SGLANG_MORI_MOE_MAX_INPUT_TOKENS=<N>` where `N` >= your expected peak `totalRecvTokenNum`. The value must not be smaller than the actual received token count, otherwise results will be incorrect.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
