### PR TITLE
fix: add padding handling in multi-layer EAGLE draft extend CUDA graph runner

### DIFF
--- a/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
@@ -500,6 +500,19 @@ class MultiLayerEagleDraftExtendCudaGraphRunner:
         self, forward_batch: ForwardBatch, bs: int, raw_bs: int, num_tokens: int
     ):
         buffers = self.buffers
+        # Pad buffers when bs > raw_bs to prevent stale values in padding region.
+        # Without this, init_forward_metadata_replay_cuda_graph() receives stale
+        # req_pool_indices causing OOB indexing in req_to_token lookup.
+        # Mirrors the padding logic in eagle_draft_extend_cuda_graph_runner.py.
+        if bs > raw_bs:
+            buffers.seq_lens.fill_(self.seq_len_fill_value)
+            buffers.out_cache_loc.zero_()
+            buffers.positions.zero_()
+            buffers.req_pool_indices.zero_()
+            if hasattr(buffers, "accept_length"):
+                buffers.accept_length.fill_(self.num_tokens_per_bs)
+            if hasattr(buffers, "extend_seq_lens"):
+                buffers.extend_seq_lens.fill_(self.num_tokens_per_bs)
         # Common inputs
         buffers.input_ids[:num_tokens].copy_(forward_batch.input_ids)
         buffers.seq_lens[:raw_bs].copy_(forward_batch.seq_lens)
@@ -526,6 +539,8 @@ class MultiLayerEagleDraftExtendCudaGraphRunner:
 
         if forward_batch.extend_seq_lens_cpu is not None:
             self.extend_seq_lens_cpu[:raw_bs] = forward_batch.extend_seq_lens_cpu
+            if bs > raw_bs:
+                self.extend_seq_lens_cpu[raw_bs:bs] = [self.num_tokens_per_bs] * (bs - raw_bs)
 
     def replay(self, forward_batch: ForwardBatch, init_state: bool = True):
         assert forward_batch.out_cache_loc is not None


### PR DESCRIPTION
## Motivation

The multi-layer EAGLE draft extend CUDA graph runner (`multi_layer_eagle_draft_extend_cuda_graph_runner.py`) lacks padding handling in `init_replay_state()` when the CUDA graph capture batch size (`bs`) exceeds the actual batch size (`raw_bs`). The single-layer version (`eagle_draft_extend_cuda_graph_runner.py`) already has this padding logic, but it was not ported to the multi-layer version.

When `bs > raw_bs`, the padding region `[raw_bs:bs]` in buffers like `req_pool_indices` retains stale values from previous calls, causing:

1. **IndexKernel.cu:111 assertion failure**: Stale `req_pool_indices` values cause out-of-bounds indexing in `req_to_token` lookup during `init_forward_metadata_replay_cuda_graph()`.
2. **Missing `extend_seq_lens_cpu` padding**: The `[raw_bs:bs]` region of `extend_seq_lens_cpu` is not filled, potentially causing incorrect attention metadata computation.

## Modifications

Added padding handling in `init_replay_state()` of `multi_layer_eagle_draft_extend_cuda_graph_runner.py` that mirrors the existing single-layer version:
- Fill `seq_lens` with `seq_len_fill_value`
- Zero `out_cache_loc`, `positions`, and `req_pool_indices`
- Fill `accept_length` and `extend_seq_lens` with `num_tokens_per_bs`
- Pad `extend_seq_lens_cpu` for the `[raw_bs:bs]` region

## Accuracy Tests

N/A - this fix only affects padding regions in CUDA graph buffers that are discarded after replay. The actual inference results (within `[:raw_bs]`) are unchanged.

## Speed Tests and Profiling

Tested with MiMo-V2-Flash + `--enable-multi-layer-eagle` (MTP=3) + PD disaggregation on 2x AWS P5EN (H200 x8 per node):

| Test | Configuration | Result |
|------|--------------|--------|
| Stability | 500 prompts x 10 rates (1-8), 16K/1K | **4000/4000 successful**, 0 crashes |
| Peak throughput | rate=8, 16K input/1K output | **4,004 tok/s** output |
| Throughput scaling | rate 1→8 | 987→4,004 tok/s (linear scaling) |

Without this fix, the server crashes within minutes of MTP decoding under load.

## Checklist

- [x] Format code
- [ ] Add unit tests (this is a padding/safety fix, testing requires multi-GPU MTP+PD setup)
- [ ] Update documentation
- [x] Benchmark results provided above
- [x] Follow SGLang code style