### PR TITLE
[MUSA][18/N] Add MUSA-optimized kernel implementations for hot ops

### DIFF
--- a/sgl-kernel/csrc/allreduce/custom_all_reduce.cuh
+++ b/sgl-kernel/csrc/allreduce/custom_all_reduce.cuh
@@ -17,7 +17,24 @@
 
 namespace sglang {
 
+#ifndef USE_MUSA
 constexpr int kMaxBlocks = 36;
+constexpr int kDefaultThreads = 512;
+constexpr int kDefaultBlockLimit = 36;
+constexpr int kMaxThreadsPerBlock = 512;
+#else
+constexpr int kMaxBlocks = 60;
+constexpr int kDefaultThreads = 1024;
+constexpr int kDefaultBlockLimit = 60;
+constexpr int kMaxThreadsPerBlock = 1024;
+#endif
+
+// Allreduce algorithm selection thresholds
+constexpr int kAllReduceGPUSmall = 4;
+constexpr int kAllReduceGPULarge = 8;
+constexpr size_t kAllReduceSmallThreshold = 512 * 1024;  // 512KB
+constexpr size_t kAllReduceLargeThreshold = 256 * 1024;  // 256KB
+
 // Counter may overflow, but it's fine since unsigned int overflow is
 // well-defined behavior.
 using FlagType = uint32_t;
@@ -134,7 +151,9 @@ DINLINE O downcast(array_t<float, O::size> val) {
 }
 
 static DINLINE void st_flag_release(FlagType* flag_addr, FlagType flag) {
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
+#ifdef USE_MUSA
+  volatile_store((uint32_t)flag, (uint32_t*)flag_addr);
+#elif defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
   asm volatile("st.release.sys.global.u32 [%1], %0;" ::"r"(flag), "l"(flag_addr));
 #else
   asm volatile("membar.sys; st.volatile.global.u32 [%1], %0;" ::"r"(flag), "l"(flag_addr));
@@ -142,6 +161,11 @@ static DINLINE void st_flag_release(FlagType* flag_addr, FlagType flag) {
 }
 
 static DINLINE FlagType ld_flag_acquire(FlagType* flag_addr) {
+#ifdef USE_MUSA
+  flushInv_byp();
+  return (uint32_t)volatile_load((uint32_t*)flag_addr);
+#endif
+
   FlagType flag;
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
   asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(flag) : "l"(flag_addr));
@@ -167,7 +191,12 @@ static DINLINE FlagType ld_flag_volatile(FlagType* flag_addr) {
 // barrier.
 template <int ngpus, bool is_start, bool need_fence = false>
 DINLINE void multi_gpu_barrier(const RankSignals& sg, Signal* self_sg, int rank) {
-  if constexpr (!is_start) __syncthreads();
+  if constexpr (!is_start)
+#ifndef USE_MUSA
+    __syncthreads();
+#else
+    __syncthreads_lm();
+#endif
   static_assert(!(is_start && need_fence));  // Start barrier shouldn't need fence.
   if (threadIdx.x < ngpus) {
     // Increment the counter. Technically we only need one counter, but we use
@@ -187,7 +216,12 @@ DINLINE void multi_gpu_barrier(const RankSignals& sg, Signal* self_sg, int rank)
         ;
     }
   }
-  if constexpr (is_start || need_fence) __syncthreads();
+  if constexpr (is_start || need_fence)
+#ifndef USE_MUSA
+    __syncthreads();
+#else
+    __syncthreads_lm();
+#endif
 }
 
 template <typename P, int ngpus, typename A>
@@ -201,7 +235,7 @@ DINLINE P packed_reduce(const P* ptrs[], int idx) {
 }
 
 template <typename T, int ngpus>
-__global__ void __launch_bounds__(512, 1) cross_device_reduce_1stage(
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1) cross_device_reduce_1stage(
     RankData* _dp, RankSignals sg, Signal* self_sg, T* __restrict__ result, int rank, int size) {
   using P = typename packed_t<T>::P;
   using A = typename packed_t<T>::A;
@@ -221,8 +255,132 @@ DINLINE P* get_tmp_buf(Signal* sg) {
   return (P*)(((Signal*)sg) + 1);
 }
 
+#ifdef USE_MUSA
+template <typename T, int32_t nranks, int32_t vlen = 8>
+DINLINE void shfl_reduce(float* res) {
+  if constexpr (nranks >= 4) {
+#pragma unroll
+    for (int32_t i = 0; i < vlen; i++) {
+      res[i] += __shfl_xor_sync(0xffffffff, res[i], 16);
+    }
+  }
+#pragma unroll
+  for (int32_t i = 0; i < vlen; i++) {
+    res[i] += __shfl_xor_sync(0xffffffff, res[i], 8);
+  }
+}
+
+template <typename T, int32_t nranks, int32_t vlen = 8>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1) custom_all_reduce_2shot(
+    RankData* _dp, RankSignals sg, Signal* self_sg, T* __restrict__ result, int32_t local_rank, int32_t size) {
+  constexpr int32_t nranks_sft = (nranks >> 1) - (nranks >> 3);  // 8->3, 4->2, 2->1
+  constexpr int32_t coalesce_num = 8;
+  constexpr int32_t coalesce_sft = 3;                     // 8 threads per rank in group
+  constexpr int32_t group_size = nranks << coalesce_sft;  // tp 8 -> 64 threads, tp 4 -> 32 threads, tp 2 -> 16 threads
+  constexpr int32_t group_stride_sft = nranks_sft + coalesce_sft;
+  const int32_t tidx = threadIdx.x;
+  const int32_t bidx = blockIdx.x;
+  const int32_t thread_num = blockDim.x;
+  const int32_t lane_idx = tidx & 31;
+  const int32_t warp_idx = tidx >> 5;
+  const int32_t group_num = thread_num >> group_stride_sft;
+  const int32_t target_rank = (tidx >> coalesce_sft) & (nranks - 1);
+  const int32_t group_id = tidx >> group_stride_sft;
+  const int32_t coalesce_tid = tidx & (coalesce_num - 1);
+
+  typedef int16_t Vec __attribute__((vector_size(16)));
+
+  const int32_t stride = gridDim.x * thread_num;
+  int32_t idx_base = bidx * thread_num;
+  int32_t idx_in_blk = coalesce_tid + (local_rank << coalesce_sft) + (group_id << group_stride_sft);
+
+  // first sync barrier
+  FlagType* target_barrier = nullptr;
+  FlagType* local_barrier = nullptr;
+  FlagType flag;
+  if (tidx < nranks) {
+    flag = atomicAdd(&(self_sg->self_counter[bidx][tidx]), 1);
+    target_barrier = &sg.signals[tidx]->peer_counter[flag & 1][bidx][local_rank];
+    local_barrier = &self_sg->peer_counter[flag & 1][bidx][tidx];
+    atomicExch(target_barrier, flag);
+    while (atomicAdd(local_barrier, 0) != flag) {
+    }
+  }
+  __syncthreads_lm();
+
+  // reduce scatter
+  Vec* target_ptr = (Vec*)_dp->ptrs[target_rank];
+  Vec* buffer_ptr = get_tmp_buf<Vec>(sg.signals[local_rank]);
+  do {
+    int32_t idx = idx_in_blk + idx_base;
+    float temp_res[vlen] = {0};
+    if (idx < size) {
+      T* data = reinterpret_cast<T*>(&(target_ptr[idx]));
+#pragma unroll
+      for (int32_t i = 0; i < vlen; i++) {
+        temp_res[i] = upcast_s(data[i]);
+      }
+    }
+    shfl_reduce<T, nranks, vlen>(temp_res);
+    // reduce cross warp, only trigger when tp 8
+    if constexpr (nranks == 8) {
+      __shared__ float smem[kMaxThreadsPerBlock << 1];
+      if (lane_idx < coalesce_num) {
+#pragma unroll
+        for (int32_t i = 0; i < vlen; i++) {
+          smem[warp_idx * vlen * coalesce_num + coalesce_tid * vlen + i] = temp_res[i];
+        }
+      }
+      __syncthreads_lm();
+#pragma unroll
+      for (int32_t i = 0; i < vlen; i++) {
+        temp_res[i] += smem[(warp_idx ^ 1) * vlen * coalesce_num + coalesce_tid * vlen + i];
+      }
+    }
+
+    if (local_rank == target_rank && idx < size) {
+      Vec res;
+#pragma unroll
+      for (int32_t i = 0; i < vlen; i++) {
+        reinterpret_cast<T*>(&res)[i] = downcast_s<T>(temp_res[i]);
+      }
+      buffer_ptr[idx] = res;
+    }
+    idx_base += stride;
+  } while (idx_base < size);
+  // make sure buffer_ptr data ready
+  __musa_barrier_slc();
+  __syncthreads_lm();
+  if (tidx == 0) {
+    __threadfence_system_noflush();
+  }
+  buffer_ptr = get_tmp_buf<Vec>(sg.signals[target_rank]);
+  // second sync barrier
+  if (tidx < nranks) {
+    flag = atomicAdd(&(self_sg->self_counter[bidx][tidx]), 1);
+    target_barrier = &sg.signals[tidx]->peer_counter[flag & 1][bidx][local_rank];
+    local_barrier = &self_sg->peer_counter[flag & 1][bidx][tidx];
+    atomicExch(target_barrier, flag);
+    while (atomicAdd(local_barrier, 0) != flag) {
+    }
+  }
+  __syncthreads_lm();
+
+  // all gather
+  idx_in_blk = coalesce_tid + (target_rank << coalesce_sft) + (group_id << group_stride_sft);
+  idx_base = bidx * thread_num;
+  do {
+    int32_t idx = idx_in_blk + idx_base;
+    if (idx < size) {
+      reinterpret_cast<Vec*>(result)[idx] = buffer_ptr[idx];
+    }
+    idx_base += stride;
+  } while (idx_base < size);
+}
+#endif  // USE_MUSA
+
 template <typename T, int ngpus>
-__global__ void __launch_bounds__(512, 1) cross_device_reduce_2stage(
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1) cross_device_reduce_2stage(
     RankData* _dp, RankSignals sg, Signal* self_sg, T* __restrict__ result, int rank, int size) {
   int tid = blockIdx.x * blockDim.x + threadIdx.x;
   int stride = gridDim.x * blockDim.x;
@@ -414,7 +572,13 @@ class CustomAllreduce {
    * guess is that too many SMs will cause contention on NVLink bus.
    */
   template <typename T>
-  void allreduce(cudaStream_t stream, T* input, T* output, int size, int threads = 512, int block_limit = 36) {
+  void allreduce(
+      cudaStream_t stream,
+      T* input,
+      T* output,
+      int size,
+      int threads = kDefaultThreads,
+      int block_limit = kDefaultBlockLimit) {
     auto d = packed_t<T>::P::size;
     if (size % d != 0)
       throw std::runtime_error(
@@ -462,26 +626,43 @@ class CustomAllreduce {
 #define KL(ngpus, name) name<T, ngpus><<<blocks, threads, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, size);
     // TODO(hanzhi713): Threshold is different for A100 and H100.
     // Add per device threshold.
-#define REDUCE_CASE(ngpus)                                                                          \
-  case ngpus: {                                                                                     \
-    if (force_1stage) {                                                                             \
-      KL(ngpus, cross_device_reduce_1stage);                                                        \
-    } else if (force_2stage) {                                                                      \
-      KL(ngpus, cross_device_reduce_2stage);                                                        \
-    } else {                                                                                        \
-      if (world_size_ == 2) {                                                                       \
-        KL(ngpus, cross_device_reduce_1stage);                                                      \
-      } else if (full_nvlink_) {                                                                    \
-        if ((world_size_ <= 4 && bytes < 512 * 1024) || (world_size_ <= 8 && bytes < 256 * 1024)) { \
-          KL(ngpus, cross_device_reduce_1stage);                                                    \
-        } else {                                                                                    \
-          KL(ngpus, cross_device_reduce_2stage);                                                    \
-        }                                                                                           \
-      }                                                                                             \
-    }                                                                                               \
-    break;                                                                                          \
+#ifndef USE_MUSA
+#define REDUCE_CASE(ngpus)                                                             \
+  case ngpus: {                                                                        \
+    if (force_1stage) {                                                                \
+      KL(ngpus, cross_device_reduce_1stage);                                           \
+    } else if (force_2stage) {                                                         \
+      KL(ngpus, cross_device_reduce_2stage);                                           \
+    } else {                                                                           \
+      if (world_size_ == 2) {                                                          \
+        KL(ngpus, cross_device_reduce_1stage);                                         \
+      } else if (full_nvlink_) {                                                       \
+        if ((world_size_ <= kAllReduceGPUSmall && bytes < kAllReduceSmallThreshold) || \
+            (world_size_ <= kAllReduceGPULarge && bytes < kAllReduceLargeThreshold)) { \
+          KL(ngpus, cross_device_reduce_1stage);                                       \
+        } else {                                                                       \
+          KL(ngpus, cross_device_reduce_2stage);                                       \
+        }                                                                              \
+      }                                                                                \
+    }                                                                                  \
+    break;                                                                             \
   }
-
+#else
+#define REDUCE_CASE(ngpus)                                                                                         \
+  case ngpus: {                                                                                                    \
+    if constexpr (!std::is_same<T, float>::value) {                                                                \
+      custom_all_reduce_2shot<T, ngpus><<<blocks, threads, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, size); \
+    } else {                                                                                                       \
+      if ((world_size_ <= kAllReduceGPUSmall && bytes < kAllReduceSmallThreshold) ||                               \
+          (world_size_ <= kAllReduceGPULarge && bytes < kAllReduceLargeThreshold)) {                               \
+        KL(ngpus, cross_device_reduce_1stage);                                                                     \
+      } else {                                                                                                     \
+        KL(ngpus, cross_device_reduce_2stage);                                                                     \
+      }                                                                                                            \
+    }                                                                                                              \
+    break;                                                                                                         \
+  }
+#endif
     switch (world_size_) {
       REDUCE_CASE(2)
       REDUCE_CASE(4)

--- a/sgl-kernel/csrc/common_extension_musa.cc
+++ b/sgl-kernel/csrc/common_extension_musa.cc
@@ -21,12 +21,250 @@ limitations under the License.
 
 TORCH_LIBRARY_EXPAND(sgl_kernel, m) {
   /*
+   * From csrc/allreduce
+   */
+  m.def("get_graph_buffer_ipc_meta", &get_graph_buffer_ipc_meta);
+  m.def("register_graph_buffers", &register_graph_buffers);
+  m.def("dispose", &dispose);
+  m.def("meta_size", &meta_size);
+  m.def("register_buffer", &register_buffer);
+
+  m.def(
+      "init_custom_ar(int[] ipc_tensors, Tensor rank_data, "
+      "int rank, bool full_nvlink) -> int");
+  m.impl("init_custom_ar", torch::kMUSA, &init_custom_ar);
+
+  m.def(
+      "all_reduce(int fa, Tensor inp, Tensor! out, int reg_buffer, "
+      "int reg_buffer_sz_bytes) -> ()");
+  m.impl("all_reduce", torch::kMUSA, &all_reduce);
+
+  /*
+   * From csrc/attention
+   */
+  m.def("merge_state_v2(Tensor v_a, Tensor s_a, Tensor v_b, Tensor s_b, Tensor! v_merged, Tensor! s_merged) -> ()");
+  m.impl("merge_state_v2", torch::kMUSA, &merge_state_v2);
+
+  /*
+   * From csrc/elementwise
+   */
+  m.def("rmsnorm(Tensor! output, Tensor input, Tensor weight, float eps, bool enable_pdl) -> ()");
+  m.impl("rmsnorm", torch::kMUSA, &rmsnorm);
+
+  m.def("fused_add_rmsnorm(Tensor! input, Tensor! residual, Tensor weight, float eps, bool enable_pdl) -> ()");
+  m.impl("fused_add_rmsnorm", torch::kMUSA, &musa_fused_add_rms_norm);
+
+  m.def("gemma_rmsnorm(Tensor! output, Tensor input, Tensor weight, float eps, bool enable_pdl) -> ()");
+  m.impl("gemma_rmsnorm", torch::kMUSA, &gemma_rmsnorm);
+
+  m.def("gemma_fused_add_rmsnorm(Tensor! input, Tensor! residual, Tensor weight, float eps, bool enable_pdl) -> ()");
+  m.impl("gemma_fused_add_rmsnorm", torch::kMUSA, &gemma_fused_add_rmsnorm);
+
+  m.def("silu_and_mul(Tensor! out, Tensor input) -> ()");
+  m.impl("silu_and_mul", torch::kMUSA, &silu_and_mul);
+
+  m.def("gelu_tanh_and_mul(Tensor! out, Tensor input) -> ()");
+  m.impl("gelu_tanh_and_mul", torch::kMUSA, &gelu_tanh_and_mul);
+
+  m.def("gelu_and_mul(Tensor! out, Tensor input) -> ()");
+  m.impl("gelu_and_mul", torch::kMUSA, &gelu_and_mul);
+
+  m.def("concat_mla_k(Tensor! k, Tensor k_nope, Tensor k_rope) -> ()");
+  m.impl("concat_mla_k", torch::kMUSA, &concat_mla_k);
+
+  /*
+   * From csrc/gemm
+   */
+  m.def("awq_dequantize(Tensor qweight, Tensor scales, Tensor qzeros) -> Tensor");
+  m.impl("awq_dequantize", torch::kMUSA, &awq_dequantize);
+
+  m.def(
+      "sgl_per_token_group_quant_8bit(Tensor input, Tensor output_q, Tensor output_s, int group_size,"
+      " float eps, float fp8_min, float fp8_max, bool scale_ue8m0) -> ()");
+  m.impl("sgl_per_token_group_quant_8bit", torch::kMUSA, &sgl_per_token_group_quant_8bit);
+
+  m.def(
+      "sgl_per_token_group_quant_8bit_v2(Tensor input, Tensor output_q, Tensor output_s, int group_size,"
+      " float eps, float fp8_min, float fp8_max, bool scale_ue8m0, bool fuse_silu_and_mul, Tensor? masked_m) -> ()");
+  m.impl("sgl_per_token_group_quant_8bit_v2", torch::kMUSA, &sgl_per_token_group_quant_8bit_v2);
+
+  m.def("sgl_per_token_quant_fp8(Tensor input, Tensor output_q, Tensor output_s) -> ()");
+  m.impl("sgl_per_token_quant_fp8", torch::kMUSA, &sgl_per_token_quant_fp8);
+
+  m.def("dsv3_fused_a_gemm(Tensor! output, Tensor mat_a, Tensor mat_b) -> ()");
+  m.impl("dsv3_fused_a_gemm", torch::kMUSA, &dsv3_fused_a_gemm);
+
+  m.def("dsv3_router_gemm(Tensor! output, Tensor mat_a, Tensor mat_b) -> ()");
+  m.impl("dsv3_router_gemm", torch::kMUSA, &dsv3_router_gemm);
+
+  /*
+   * From csrc/moe
+   */
+  m.def(
+      "moe_align_block_size(Tensor topk_ids, int num_experts, int block_size, Tensor! sorted_token_ids, Tensor! "
+      "experts_ids, Tensor! num_tokens_post_pad, Tensor! cumsum_buffer, bool "
+      "pad_sorted_token_ids) -> ()");
+  m.impl("moe_align_block_size", torch::kMUSA, &moe_align_block_size);
+
+  m.def(
+      "topk_softmax(Tensor! topk_weights, Tensor! topk_indices, Tensor gating_output, bool renormalize, float "
+      "moe_softcapping, Tensor? correction_bias) -> ()");
+  m.impl("topk_softmax", torch::kMUSA, &topk_softmax);
+
+  m.def("moe_sum_reduce(Tensor input, Tensor output, float routed_scaling_factor) -> ()");
+  m.impl("moe_sum_reduce", torch::kMUSA, &moe_sum_reduce);
+
+  m.def("moe_sum(Tensor input, Tensor! output) -> ()");
+  m.impl("moe_sum", torch::kMUSA, &moe_sum);
+
+  m.def(
+      "moe_fused_gate(Tensor input, Tensor bias, int num_expert_group, int topk_group, int topk, int "
+      "num_fused_shared_experts, float routed_scaling_factor, bool apply_routed_scaling_factor_on_output) -> "
+      "(Tensor[])");
+  m.impl("moe_fused_gate", torch::kMUSA, &moe_fused_gate);
+
+  m.def(
+      "kimi_k2_moe_fused_gate(Tensor input, Tensor bias, int topk, bool renormalize, "
+      "float routed_scaling_factor, bool apply_routed_scaling_factor_on_output) -> "
+      "(Tensor[])");
+  m.impl("kimi_k2_moe_fused_gate", torch::kMUSA, &kimi_k2_moe_fused_gate);
+
+  /*
+   * From csrc/speculative
+   */
+  m.def(
+      "tree_speculative_sampling_target_only(Tensor! predicts, Tensor! accept_index, Tensor! accept_token_num, "
+      "Tensor candidates, Tensor retrive_index, Tensor retrive_next_token, Tensor retrive_next_sibling, "
+      "Tensor uniform_samples, Tensor uniform_samples_for_final_sampling, Tensor target_probs, Tensor draft_probs, "
+      "float threshold_single, float threshold_acc, "
+      "bool deterministic) -> ()");
+  m.impl("tree_speculative_sampling_target_only", torch::kMUSA, &tree_speculative_sampling_target_only);
+
+  m.def(
+      "verify_tree_greedy(Tensor! predicts, Tensor! accept_index, Tensor! accept_token_num, "
+      "Tensor candidates, Tensor retrive_index, Tensor retrive_next_token, Tensor retrive_next_sibling, "
+      "Tensor target_predict) -> ()");
+  m.impl("verify_tree_greedy", torch::kMUSA, &verify_tree_greedy);
+
+  m.def(
+      "reconstruct_indices_from_tree_mask(Tensor tree_mask, Tensor verified_seq_len, Tensor positions, "
+      "Tensor retrive_index, Tensor retrive_next_token, Tensor retrive_next_sibling, "
+      "int batch_size, int draft_token_num) -> ()");
+  m.impl("reconstruct_indices_from_tree_mask", torch::kMUSA, &reconstruct_indices_from_tree_mask);
+
+  m.def(
+      "build_tree_kernel_efficient(Tensor parent_list, Tensor selected_index, Tensor verified_seq_len, "
+      "Tensor! tree_mask, Tensor! positions, Tensor! retrive_index, Tensor! retrive_next_token, "
+      "Tensor! retrive_next_sibling, int topk, int depth, int draft_token_num, int tree_mask_mode) -> "
+      "()");
+  m.impl("build_tree_kernel_efficient", torch::kMUSA, &build_tree_kernel_efficient);
+
+  /*
+   * From csrc/grammar
+   */
+  m.def("apply_token_bitmask_inplace_cuda(Tensor logits, Tensor bitmask, Tensor? indices=None) -> ()");
+  m.impl("apply_token_bitmask_inplace_cuda", &ApplyTokenBitmaskInplace);
+
+  /*
+   * From csrc/quantization/gguf
+   */
+  m.def(
+      "ggml_dequantize(Tensor W, int type, SymInt m, SymInt n, ScalarType? "
+      "dtype) -> Tensor");
+  m.impl("ggml_dequantize", torch::kMUSA, &ggml_dequantize);
+
+  m.def(
+      "ggml_mul_mat_vec_a8(Tensor W, Tensor X, int type, SymInt row) "
+      "-> Tensor");
+  m.impl("ggml_mul_mat_vec_a8", torch::kMUSA, &ggml_mul_mat_vec_a8);
+
+  m.def("ggml_mul_mat_a8(Tensor W, Tensor X, int type, SymInt row) -> Tensor");
+  m.impl("ggml_mul_mat_a8", torch::kMUSA, &ggml_mul_mat_a8);
+
+  m.def(
+      "ggml_moe_a8(Tensor X, Tensor W, "
+      "Tensor sorted_token_ids, Tensor expert_ids, Tensor "
+      "num_tokens_post_padded, "
+      "int type, SymInt row, SymInt top_k, SymInt tokens) -> Tensor");
+  m.impl("ggml_moe_a8", torch::kMUSA, &ggml_moe_a8);
+
+  m.def(
+      "ggml_moe_a8_vec(Tensor X, Tensor W, "
+      "Tensor topk_ids, int top_k, "
+      "int type, SymInt row, SymInt tokens) -> Tensor");
+  m.impl("ggml_moe_a8_vec", torch::kMUSA, &ggml_moe_a8_vec);
+
+  m.def("ggml_moe_get_block_size(int type) -> int");
+  m.impl("ggml_moe_get_block_size", torch::kMUSA, &ggml_moe_get_block_size);
+
+  /*
+   * From csrc/kvcacheio
+   */
+  m.def(
+      "transfer_kv_per_layer(Tensor src_k, Tensor dst_k, Tensor src_v, Tensor dst_v, Tensor src_indices, Tensor "
+      "dst_indices, int item_size, int block_quota, int num_warps_per_block) -> ()");
+  m.impl("transfer_kv_per_layer", torch::kMUSA, &transfer_kv_per_layer);
+  m.def(
+      "transfer_kv_per_layer_pf_lf(Tensor src_k, Tensor dst_k, Tensor src_v, Tensor dst_v, Tensor src_indices, Tensor "
+      "dst_indices, int layer_id, int item_size, int src_layout_dim, int block_quota, int num_warps_per_block) -> ()");
+  m.impl("transfer_kv_per_layer_pf_lf", torch::kMUSA, &transfer_kv_per_layer_pf_lf);
+  m.def(
+      "transfer_kv_per_layer_ph_lf(Tensor src_k, Tensor dst_k, Tensor src_v, Tensor dst_v, Tensor src_indices, Tensor "
+      "dst_indices, int layer_id, int item_size, int src_layout_dim, int page_size, int head_num, int block_quota, int "
+      "num_warps_per_block) -> ()");
+  m.impl("transfer_kv_per_layer_ph_lf", torch::kMUSA, &transfer_kv_per_layer_ph_lf);
+  m.def(
+      "transfer_kv_all_layer(Tensor src_k_layers, Tensor dst_k_layers, Tensor src_v_layers, Tensor dst_v_layers, "
+      "Tensor src_indices, Tensor dst_indices, int item_size, int num_layers, int block_quota, int "
+      "num_warps_per_block) -> ()");
+  m.impl("transfer_kv_all_layer", torch::kMUSA, &transfer_kv_all_layer);
+  m.def(
+      "transfer_kv_all_layer_lf_pf(Tensor src_k_layers, Tensor dst_k, Tensor src_v_layers, Tensor dst_v, "
+      "Tensor src_indices, Tensor dst_indices, int item_size, int dst_layout_dim, int num_layers, int block_quota, int "
+      "num_warps_per_block) -> ()");
+  m.impl("transfer_kv_all_layer_lf_pf", torch::kMUSA, &transfer_kv_all_layer_lf_pf);
+  m.def(
+      "transfer_kv_all_layer_lf_ph(Tensor src_k_layers, Tensor dst_k, Tensor src_v_layers, Tensor dst_v, "
+      "Tensor src_indices, Tensor dst_indices, int item_size, int dst_layout_dim, int num_layers, int page_size, int "
+      "head_num, int block_quota, int num_warps_per_block) -> ()");
+  m.impl("transfer_kv_all_layer_lf_ph", torch::kMUSA, &transfer_kv_all_layer_lf_ph);
+  m.def(
+      "transfer_kv_per_layer_mla(Tensor src, Tensor dst, Tensor src_indices, Tensor dst_indices, int item_size, int "
+      "block_quota, int num_warps_per_block) -> ()");
+  m.impl("transfer_kv_per_layer_mla", torch::kMUSA, &transfer_kv_per_layer_mla);
+  m.def(
+      "transfer_kv_per_layer_mla_pf_lf(Tensor src, Tensor dst, Tensor src_indices, Tensor dst_indices, int layer_id, "
+      "int item_size, int src_layout_dim, int block_quota, int num_warps_per_block) -> ()");
+  m.impl("transfer_kv_per_layer_mla_pf_lf", torch::kMUSA, &transfer_kv_per_layer_mla_pf_lf);
+  m.def(
+      "transfer_kv_all_layer_mla(Tensor src_layers, Tensor dst_layers, Tensor src_indices, Tensor dst_indices, int "
+      "item_size, int num_layers, int block_quota, int num_warps_per_block) -> ()");
+  m.impl("transfer_kv_all_layer_mla", torch::kMUSA, &transfer_kv_all_layer_mla);
+  m.def(
+      "transfer_kv_all_layer_mla_lf_pf(Tensor src_layers, Tensor dst, Tensor src_indices, Tensor dst_indices, "
+      "int item_size, int dst_layout_dim, int num_layers, int block_quota, int num_warps_per_block) -> ()");
+  m.impl("transfer_kv_all_layer_mla_lf_pf", torch::kMUSA, &transfer_kv_all_layer_mla_lf_pf);
+  m.def(
+      "transfer_kv_direct(Tensor[] src_layers, Tensor[] dst_layers, Tensor src_indices, Tensor dst_indices, int "
+      "page_size) -> ()");
+  m.impl("transfer_kv_direct", torch::kMUSA, &transfer_kv_direct);
+  m.def(
+      "transfer_kv_per_layer_direct_pf_lf(Tensor[] src_ptrs, Tensor[] dst_ptrs, Tensor src_indices, "
+      "Tensor dst_indices, int layer_id, int page_size)->() ");
+  m.impl("transfer_kv_per_layer_direct_pf_lf", torch::kMUSA, &transfer_kv_per_layer_direct_pf_lf);
+  m.def(
+      "transfer_kv_all_layer_direct_lf_pf(Tensor[] src_ptrs, Tensor[] dst_ptrs, Tensor src_indices, "
+      "Tensor dst_indices, int page_size) ->() ");
+  m.impl("transfer_kv_all_layer_direct_lf_pf", torch::kMUSA, &transfer_kv_all_layer_direct_lf_pf);
+
+  /*
    * From FlashInfer
    */
   m.def(
-      "min_p_sampling_from_probs(Tensor probs, Tensor output, Tensor? maybe_indices, Tensor? maybe_min_p_arr, float "
-      "min_p_val, bool deterministic, Generator? gen) -> ()");
-  m.impl("min_p_sampling_from_probs", torch::kMUSA, &min_p_sampling_from_probs);
+      "bmm_fp8(Tensor A, Tensor B, Tensor! D, Tensor A_scale, Tensor B_scale, Tensor workspace_buffer, "
+      "int cublas_handle) -> ()",
+      {at::Tag::needs_fixed_stride_order});
+  m.impl("bmm_fp8", torch::kMUSA, &bmm_fp8);
 
   m.def("top_k_renorm_probs(Tensor probs, Tensor! renorm_probs, Tensor? maybe_top_k_arr, int top_k_val) -> ()");
   m.impl("top_k_renorm_probs", torch::kMUSA, &top_k_renorm_probs);
@@ -34,15 +272,11 @@ TORCH_LIBRARY_EXPAND(sgl_kernel, m) {
   m.def("top_p_renorm_probs(Tensor probs, Tensor! renorm_probs, Tensor? maybe_top_p_arr, float top_p_val) -> ()");
   m.impl("top_p_renorm_probs", torch::kMUSA, &top_p_renorm_probs);
 
-  m.def(
-      "top_p_sampling_from_probs(Tensor probs, Tensor output, Tensor? maybe_indices, Tensor? "
-      "maybe_top_p_arr, float top_p_val, bool deterministic, Generator? gen) -> ()");
-  m.impl("top_p_sampling_from_probs", torch::kMUSA, &top_p_sampling_from_probs);
-
-  m.def(
-      "top_k_top_p_sampling_from_probs(Tensor probs, Tensor output, Tensor? maybe_indices, Tensor? maybe_top_k_arr, "
-      "float top_k_val, Tensor? maybe_top_p_arr, float top_p_val, bool deterministic, Generator? gen) -> ()");
-  m.impl("top_k_top_p_sampling_from_probs", torch::kMUSA, &top_k_top_p_sampling_from_probs);
+  /*
+   * From csrc/memory
+   */
+  m.def("weak_ref_tensor(Tensor tensor) -> Tensor");
+  m.impl("weak_ref_tensor", torch::kMUSA, &weak_ref_tensor);
 }
 
 REGISTER_EXTENSION(common_ops)

--- a/sgl-kernel/csrc/common_extension_musa.cc
+++ b/sgl-kernel/csrc/common_extension_musa.cc
@@ -273,6 +273,47 @@ TORCH_LIBRARY_EXPAND(sgl_kernel, m) {
   m.impl("top_p_renorm_probs", torch::kMUSA, &top_p_renorm_probs);
 
   /*
+   * From csrc/musa
+   */
+  m.def(
+      "musa_batched_rotary_embedding_contiguous(Tensor! positions, Tensor! query, Tensor! key, "
+      "int head_size, Tensor! cos_sin_cache, bool is_neox, int rot_dim, Tensor! cos_sin_cache_offsets) -> ()");
+  m.impl("musa_batched_rotary_embedding_contiguous", torch::kMUSA, &batched_rotary_embedding_contiguous);
+
+  m.def(
+      "musa_rotary_embedding_contiguous(Tensor! positions, Tensor! query, Tensor! key, "
+      "int head_size, Tensor! cos_sin_cache, bool is_neox) -> ()");
+  m.impl("musa_rotary_embedding_contiguous", torch::kMUSA, &rotary_embedding_contiguous);
+
+  m.def(
+      "musa_mudnn_w8a8_scaled_mm(Tensor! c, Tensor! a, Tensor! b, "
+      "Tensor! a_scales,Tensor! b_scales, Tensor? bias=None) -> ()");
+  m.impl("musa_mudnn_w8a8_scaled_mm", torch::kMUSA, &mudnn_w8a8_scaled_mm);
+
+  m.def(
+      "fused_moe_gemv(Tensor! A, Tensor! B, Tensor! C, Tensor? A_scale, Tensor? B_scale,"
+      "Tensor! topk_weights, Tensor! topk_ids, bool mul_routed_weight, int topk, bool use_int4_w4a16,"
+      "bool use_swigelu) -> ()");
+  m.impl("fused_moe_gemv", torch::kMUSA, &fused_moe_gemv);
+
+  m.def(
+      "musa_fused_gemv(Tensor! A, Tensor! B, Tensor! C, Tensor? A_scale, Tensor? B_scale,"
+      "bool use_int4_w4a16, bool use_swigelu, bool use_rms_norm, Tensor? gamma,"
+      "float eps) -> ()");
+  m.impl("musa_fused_gemv", torch::kMUSA, &musa_fused_gemv);
+
+  m.def(
+      "musa_fused_mul_add(Tensor! output, Tensor! self, Tensor! bias,"
+      "float scale) -> ()");
+  m.impl("musa_fused_mul_add", torch::kMUSA, &fused_mul_add);
+
+  m.def(
+      "musa_top_k_top_p_sampling_from_probs(Tensor probs, Tensor output, Tensor? maybe_indices, Tensor? "
+      "maybe_top_k_arr, "
+      "float top_k_val, Tensor? maybe_top_p_arr, float top_p_val, bool deterministic, Generator? gen) -> ()");
+  m.impl("musa_top_k_top_p_sampling_from_probs", torch::kMUSA, &musa_top_k_top_p_sampling_from_probs);
+
+  /*
    * From csrc/memory
    */
   m.def("weak_ref_tensor(Tensor tensor) -> Tensor");

--- a/sgl-kernel/csrc/elementwise/fused_add_rms_norm_kernel.mu
+++ b/sgl-kernel/csrc/elementwise/fused_add_rms_norm_kernel.mu
@@ -1,0 +1,529 @@
+/* Copyright @2020-2026 Moore Threads Technology Co., Ltd("Moore Threads"). All
+ * rights reserved.
+ *
+ * This software ("this software and its documentations" or "the software") is
+ * protected by Copyright and the information contained herein is confidential.
+ *
+ * The software contained herein is PROPRIETARY to Moore Threads and is being
+ * provided under the terms and conditions of a form of Moore Threads software
+ * license agreement by and between Moore Threads and Licensee ("License
+ * Agreement") or electronically accepted by Licensee. Notwithstanding any
+ * terms or conditions to the contrary in the License Agreement, copy or
+ * disclosure of the software to any third party without the express written
+ * consent of Moore Threads is prohibited.
+ *
+ * NOTWITHSTANDING ANY TERMS OR CONDITIONS TO THE CONTRARY IN THE LICENSE
+ * AGREEMENT, MOORE THREADS MAKES NO REPRESENTATION ABOUT ANY WARRANTIES,
+ * INCLUDING BUT NOT LIMITED TO THE SUITABILITY OF THE SOFTWARE FOR ANY
+ * PURPOSE. IT IS PROVIDED "AS IS" WITHOUT EXPRESS OR IMPLIED WARRANTY OF
+ * ANY KIND. MOORE THREADS DISCLAIMS ALL WARRANTIES WITH REGARD TO THE
+ * SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY,
+ * NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE.
+ * NOTWITHSTANDING ANY TERMS OR CONDITIONS TO THE CONTRARY IN THE
+ * LICENSE AGREEMENT, IN NO EVENT SHALL MOORE THREADS BE LIABLE FOR ANY
+ * SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, OR ANY
+ * DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+ * WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+ * ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+ * OF THE SOFTWARE.
+ */
+
+ #include "musa.h"
+ #include <iostream>
+ #include <vector>
+ #include <cmath>
+ #include <musa_runtime.h>
+ #include <musa_fp16.h>
+ #include "musa_bf16.h"
+ #include <musa_robust.h>
+ #include <torch/torch.h>
+ #include "torch_musa/csrc/core/MUSAGuard.h"
+ #include "torch_musa/csrc/core/MUSAStream.h"
+
+ typedef __half float16_t;
+ typedef __mt_bfloat16 bfloat16_t;
+
+ #define DEVICE_INLINE __device__ __forceinline__
+ template <typename T, int width>
+ __device__ __forceinline__ T mudnn_shfl_down_sync(T val, unsigned int delta) {
+   return __shfl_down_sync(0xffffffff, val, delta, width);
+ }
+
+ __device__ __host__ __forceinline__ constexpr int ceil_div(int a, int b) {
+   return (a + b - 1) / b;
+ }
+
+ __device__ __host__ __forceinline__ constexpr int64_t ceil_div(int64_t a,
+                                                                int64_t b) {
+   return (a + b - 1) / b;
+ }
+
+ #define WARP_THREADS 32
+ #define SMEM_STOP (WARP_THREADS / 2)
+ #define SHFL_START min(WARP_THREADS / 2, BLOCK_X / 2)
+ #define __SYNCTHREADS_LM __syncthreads_lm()
+ #define MACRO_UNROLL _Pragma("unroll")
+ #define LD_BYP_SLC(_BITS, _BYTES)                                   \
+   VecType dst;                                                      \
+   const BaseType* addr = ptr + idx;                                 \
+   asm volatile("LSU.LD.B" #_BITS " %0, %1, _, " #_BYTES             \
+                ", 1, 1, inner_persist=0, "                          \
+                "outer_persist=2, chrnt=l2_l3, slc=byp, persist=0, " \
+                "stride_add_first=0"                                 \
+                : "=R"(dst)                                          \
+                : "R"(addr));                                        \
+   return dst;
+
+     #define ATTR_ALIGNED(v) __attribute__((aligned(v)))
+     #define SELF_VEC_DEF(BASE_TYPE, VEC_TYPE_V2, VEC_TYPE_V4)                  \
+       struct ATTR_ALIGNED(sizeof(BASE_TYPE) * 2) VEC_TYPE_V2 {                 \
+         __device__ VEC_TYPE_V2() {}                                            \
+         __device__ VEC_TYPE_V2(const VEC_TYPE_V2& t) {                         \
+           this->x = t.x;                                                       \
+           this->y = t.y;                                                       \
+         }                                                                      \
+         BASE_TYPE x, y;                                                        \
+       };                                                                       \
+                                                                                \
+       __device__ __forceinline__ VEC_TYPE_V2 make_##VEC_TYPE_V2(BASE_TYPE x,   \
+                                                                 BASE_TYPE y) { \
+         VEC_TYPE_V2 t;                                                         \
+         t.x = x, t.y = y;                                                      \
+         return t;                                                              \
+       }                                                                        \
+                                                                                \
+       struct ATTR_ALIGNED(sizeof(BASE_TYPE) * 4) VEC_TYPE_V4 {                 \
+         __device__ VEC_TYPE_V4() {}                                            \
+         __device__ VEC_TYPE_V4(const VEC_TYPE_V4& t) {                         \
+           this->x = t.x;                                                       \
+           this->y = t.y;                                                       \
+           this->z = t.z;                                                       \
+           this->w = t.w;                                                       \
+         }                                                                      \
+         BASE_TYPE x, y, z, w;                                                  \
+       };                                                                       \
+                                                                                \
+       __device__ __forceinline__ VEC_TYPE_V4 make_##VEC_TYPE_V4(               \
+           BASE_TYPE x, BASE_TYPE y, BASE_TYPE z, BASE_TYPE w) {                \
+         VEC_TYPE_V4 t;                                                         \
+         t.x = x, t.y = y, t.z = z, t.w = w;                                    \
+         return t;                                                              \
+       }
+
+     SELF_VEC_DEF(float16_t, Half2, Half4)
+     SELF_VEC_DEF(bfloat16_t, Bhalf2, Bhalf4)
+
+     #define GEN_VECTYPE(_CTYPE, _VECTYPE, _BYTES, _VLEN) \
+       struct ATTR_ALIGNED(_BYTES) _VECTYPE {             \
+         __device__ _VECTYPE() {}                         \
+         __device__ _VECTYPE(const _VECTYPE& t) {         \
+           MACRO_UNROLL                                   \
+           for (int i = 0; i < _VLEN; i++) {              \
+             this->arr[i] = t.arr[i];                     \
+           }                                              \
+         }                                                \
+         _CTYPE arr[_VLEN];                               \
+       }
+
+ GEN_VECTYPE(float16_t, Half8, 16, 8);
+ GEN_VECTYPE(bfloat16_t, Bhalf8, 16, 8);
+ template <typename type>
+ class Dtype;
+
+ #define INST(_type, _vec2, _vec4)                                        \
+   template <>                                                            \
+   class Dtype<_type> {                                                   \
+    public:                                                               \
+     using Scalar = _type;                                                \
+     using Vec2 = _vec2;                                                  \
+     using Vec4 = _vec4;                                                  \
+     static __device__ __forceinline__ Vec2 make_vec2(_type x, _type y) { \
+       return make_##_vec2(x, y);                                         \
+     }                                                                    \
+     static __device__ __forceinline__ Vec4 make_vec4(_type x, _type y,   \
+                                                      _type z, _type w) { \
+       return make_##_vec4(x, y, z, w);                                   \
+     }                                                                    \
+   }
+
+ INST(float, float2, float4);
+ INST(bfloat16_t, Bhalf2, Bhalf4);
+
+ template <typename T, int bits = 16 * 8>
+ struct VecType;
+
+ template <typename T>
+ struct DeduceVectorizedType {
+   using Type = T;
+ };
+
+ template <>
+ struct DeduceVectorizedType<half> {
+   using Type = _Float16;
+ };
+
+ template <>
+ struct DeduceVectorizedType<bfloat16_t> {
+   using Type = _Float16;
+ };
+
+ #define DEF_VECT(_CTYPE, _VECTYPE)                                            \
+     template <>                                                               \
+     struct VecType<_CTYPE, sizeof(_VECTYPE) * 8> {                            \
+     static constexpr int vec_bytes = sizeof(_VECTYPE);                        \
+     static constexpr int bit_per_byte = 8;                                    \
+     using BaseType = _CTYPE;                                                  \
+     using RobustTypePtr = __musa::robust_ptr<_CTYPE>;                         \
+     using Ttype = _VECTYPE;                                                   \
+     static constexpr int bits = vec_bytes * bit_per_byte;                     \
+     static constexpr int vlen = bits / (sizeof(BaseType) * bit_per_byte);     \
+     using VectorizedType = typename DeduceVectorizedType<BaseType>::Type;     \
+     typedef VectorizedType VxTy __attribute__((vector_size(vec_bytes)));      \
+     template <typename OffsetType>                                            \
+     static __device__ __forceinline__ VecType load(const BaseType* ptr,       \
+                                                     OffsetType idx) {         \
+         return *(VecType*)(ptr + idx);                                        \
+     }                                                                         \
+     template <typename OffsetType>                                            \
+     static __device__ __forceinline__ VecType                                 \
+     load_byp_slc(const BaseType* ptr, OffsetType idx) {                       \
+         if constexpr (vec_bytes == 16) {                                      \
+         LD_BYP_SLC(128, 16);                                                  \
+         } else if constexpr (vec_bytes == 8) {                                \
+         LD_BYP_SLC(64, 8);                                                    \
+         } else if constexpr (vec_bytes == 4) {                                \
+         LD_BYP_SLC(32, 4);                                                    \
+         } else if constexpr (vec_bytes == 2) {                                \
+         LD_BYP_SLC(16, 2);                                                    \
+         } else {                                                              \
+         LD_BYP_SLC(8, 1);                                                     \
+         }                                                                     \
+     }                                                                         \
+     template <typename OffsetType>                                            \
+     static __device__ __forceinline__ VecType                                 \
+     robust_load(const RobustTypePtr ptr, OffsetType idx) {                    \
+         return __musa::robust_load<VecType, BaseType>(ptr, idx);              \
+     }                                                                         \
+                                                                               \
+     template <typename OffsetType>                                            \
+     static __device__ __forceinline__ void store(BaseType* ptr,               \
+                                                     OffsetType idx,           \
+                                                     const VecType& dst) {     \
+         *(VecType*)(ptr + idx) = dst;                                         \
+     }                                                                         \
+     template <typename OffsetType>                                            \
+     static __device__ __forceinline__ void robust_store(RobustTypePtr ptr,    \
+                                                         OffsetType idx,       \
+                                                         const VecType& dst) { \
+         __musa::robust_store<VecType, BaseType>(dst, ptr, idx);               \
+     }                                                                         \
+                                                                               \
+     __device__ VecType() {                                                    \
+         MACRO_UNROLL                                                          \
+         for (int i = 0; i < sizeof(Ttype) / sizeof(BaseType); i++) {          \
+         this->val_.elem[i] = 0;                                               \
+         }                                                                     \
+     }                                                                         \
+     __device__ VecType(const VecType& t) {                                    \
+         MACRO_UNROLL                                                          \
+         for (int i = 0; i < sizeof(Ttype) / sizeof(BaseType); i++) {          \
+         this->val_.elem[i] = t.val_.elem[i];                                  \
+         }                                                                     \
+     }                                                                         \
+     __device__ VecType& operator=(const VecType& t) {                         \
+         MACRO_UNROLL                                                          \
+         for (int i = 0; i < sizeof(Ttype) / sizeof(BaseType); i++) {          \
+         this->val_.elem[i] = t.val_.elem[i];                                  \
+         }                                                                     \
+         return *this;                                                         \
+     }                                                                         \
+     __device__ VecType(_CTYPE val) {                                          \
+         MACRO_UNROLL                                                          \
+         for (int i = 0; i < sizeof(Ttype) / sizeof(BaseType); i++) {          \
+         this->val_.elem[i] = val;                                             \
+         }                                                                     \
+     }                                                                         \
+     template <typename SrcVecType>                                            \
+     friend __device__ VecType operator+(VecType lhs, const SrcVecType& rhs) { \
+         MACRO_UNROLL                                                          \
+         for (int i = 0; i < sizeof(Ttype) / sizeof(BaseType); i++) {          \
+         lhs.val_.elem[i] += static_cast<BaseType>(rhs.val_.elem[i]);          \
+         }                                                                     \
+         return lhs;                                                           \
+     }                                                                         \
+     friend __device__ VecType operator+(VecType lhs, const _CTYPE& rhs) {     \
+         MACRO_UNROLL                                                          \
+         for (int i = 0; i < sizeof(Ttype) / sizeof(BaseType); i++) {          \
+         lhs.val_.elem[i] += rhs;                                              \
+         }                                                                     \
+         return lhs;                                                           \
+     }                                                                         \
+     friend __device__ VecType operator-(VecType lhs, const VecType& rhs) {    \
+         MACRO_UNROLL                                                          \
+         for (int i = 0; i < sizeof(Ttype) / sizeof(BaseType); i++) {          \
+         lhs.val_.elem[i] -= rhs.val_.elem[i];                                 \
+         }                                                                     \
+         return lhs;                                                           \
+     }                                                                         \
+     friend __device__ VecType operator*(VecType lhs, const VecType& rhs) {    \
+         MACRO_UNROLL                                                          \
+         for (int i = 0; i < sizeof(Ttype) / sizeof(BaseType); i++) {          \
+         lhs.val_.elem[i] *= rhs.val_.elem[i];                                 \
+         }                                                                     \
+         return lhs;                                                           \
+     }                                                                         \
+     template <typename Func>                                                  \
+     __device__ VecType& apply() {                                             \
+         MACRO_UNROLL                                                          \
+         for (int i = 0; i < sizeof(Ttype) / sizeof(BaseType); i++) {          \
+         this->val_.elem[i] = Func::apply(this->val_.elem[i]);                 \
+         }                                                                     \
+         return *this;                                                         \
+     }                                                                         \
+     template <typename SrcVecType>                                            \
+     static __device__ VecType cvt(const SrcVecType& src) {                    \
+         VecType dst;                                                          \
+         MACRO_UNROLL                                                          \
+         for (int i = 0; i < sizeof(Ttype) / sizeof(BaseType); i++) {          \
+         dst.val_.elem[i] = (BaseType)(src.val_.elem[i]);                      \
+         }                                                                     \
+         return dst;                                                           \
+     }                                                                         \
+     union U {                                                                 \
+         __device__ U() {                                                      \
+         MACRO_UNROLL                                                          \
+         for (int i = 0; i < sizeof(Ttype) / sizeof(BaseType); i++) {          \
+             this->elem[i] = 0;                                                \
+         }                                                                     \
+         }                                                                     \
+         Ttype storage;                                                        \
+         BaseType elem[sizeof(Ttype) / sizeof(BaseType)];                      \
+         VxTy vt_elem;                                                         \
+     };                                                                        \
+     U val_{};                                                                 \
+     }
+ DEF_VECT(float16_t, float16_t);
+ DEF_VECT(float16_t, Half2);
+ DEF_VECT(bfloat16_t, bfloat16_t);
+ DEF_VECT(bfloat16_t, Bhalf2);
+ DEF_VECT(bfloat16_t, Bhalf8);
+ DEF_VECT(float16_t, Half8);
+ DEF_VECT(float, float4);
+
+ enum class VarUpdateMode { WELFORD, WELFORD_ONLY_MEAN, CHAN, CHAN_ONLY_MEAN };
+
+ static __device__ __forceinline__ float fast_rcpf(float x) {
+   float y = __frcp_rn(x);
+   y = y * (2.0 - x * y);
+   return y;
+ }
+
+ static __device__ __forceinline__ float fast_divf(float a, float b) {
+   return a * fast_rcpf(b);
+ }
+
+ static __device__ __forceinline__ float fast_rsqrtf(float a) {
+   float x = 0.5 * a;
+   float y = __frsqrt_rn(a);
+   y = y * (1.5 - x * y * y);
+   return y;
+ }
+
+ template <typename T, VarUpdateMode Mode>
+ struct VarUpdate;
+
+ template <typename T>
+ struct VarUpdate<T, VarUpdateMode::WELFORD_ONLY_MEAN> {
+     DEVICE_INLINE void apply(T curr, T* mu, T* cnt) {
+     *cnt += 1;
+     T delta = curr - *mu;
+     *mu += fast_divf(delta, *cnt);
+     }
+ };
+
+ template <typename T>
+ struct VarUpdate<T, VarUpdateMode::CHAN_ONLY_MEAN> {
+   DEVICE_INLINE void apply(T mu_B, T cnt_B, T* mu, T* cnt) {
+     if (cnt_B > 0) {
+       T n_AB = cnt_B + (*cnt);
+       T delta = mu_B - (*mu);
+       *mu += delta * fast_divf(cnt_B, n_AB);
+       *cnt = n_AB;
+     }
+   }
+ };
+
+ template <typename ComputeType, int BLOCK_X, int BLOCK_Y,int Vlen>
+ struct AllReduceOp {
+   DEVICE_INLINE void apply(ComputeType* sum, int tx, int ty) {
+     __shared__ ComputeType __attribute__((aligned(16)))
+     smem[BLOCK_X * BLOCK_Y * Vlen];
+     ComputeType* smem_sum = &smem[0];
+
+       static_assert(Vlen == 1,
+                     "Axis COLUMN doesn't support vlen greater than 1");
+ #pragma unroll
+       for (int offset = BLOCK_X / 2; offset > SMEM_STOP; offset /= 2) {
+         if (tx >= offset && tx < 2 * offset) {
+           smem_sum[ty * BLOCK_X + tx] = *sum;
+         }
+         __SYNCTHREADS_LM;
+         if (tx < offset) {
+           *sum += smem_sum[ty * BLOCK_X + tx + offset];
+         }
+       }
+ #if ((defined __MUSA_ARCH__) && (__MUSA_ARCH__ >= 220))
+ #pragma unroll
+       for (int offset = SHFL_START; offset > 0; offset /= 2) {
+         *sum += mudnn_shfl_down_sync<ComputeType, 32>(*sum, offset);
+       }
+ #endif
+       if (tx == 0) {
+         smem_sum[ty * BLOCK_X + tx] = *sum;
+       }
+       __SYNCTHREADS_LM;
+       *sum = smem_sum[ty * BLOCK_X];
+   }
+ };
+
+  template <typename SrcDtype, typename ComputeType, int BLOCK_X, int BLOCK_Y, int vlen>
+  __global__ void LayerNormGlobalKernelVlen(
+     SrcDtype* input, SrcDtype* residual, const SrcDtype* weight,
+      const size_t M, const size_t N, const ComputeType eps) {
+    size_t tx = threadIdx.x;
+    size_t ty = threadIdx.y;
+    size_t m_idx = blockIdx.x * blockDim.y + ty;
+    size_t n_idx = tx * vlen;
+    size_t n_step = (size_t)blockDim.x * vlen;
+
+    using SrcVec = VecType<SrcDtype, vlen * sizeof(SrcDtype) * 8>;
+
+    ComputeType var = 0;
+    const SrcDtype* __restrict p_src = input + m_idx * N;
+    SrcDtype* __restrict p_res = residual + m_idx * N;  // residual ptr
+
+    // TODO(wuke): use robust_load, robust_store
+    bool m_valid = m_idx < M;
+    if (m_valid) {
+      for (size_t j = n_idx; j < N; j += n_step) {
+        SrcVec curr, res_vec, fused_vec;
+        #if ((defined __MUSA_ARCH__) && (__MUSA_ARCH__ == 220))
+            curr = *(SrcVec *)(p_src+j);
+            res_vec = *(SrcVec *)(p_res+j);
+        #elif ((defined __MUSA_ARCH__) && (__MUSA_ARCH__ == 310))
+            curr = SrcVec::load_byp_slc(p_src, j);
+            res_vec = SrcVec::load_byp_slc(p_res, j);
+        #endif
+        #pragma unroll
+        for (int k = 0; k < vlen; k++) {
+         fused_vec.val_.elem[k] = curr.val_.elem[k] + res_vec.val_.elem[k];
+         var += (ComputeType)fused_vec.val_.elem[k] * (ComputeType)fused_vec.val_.elem[k];
+        }
+        *(SrcVec*)(p_res + j) = fused_vec;
+      }
+    }
+    AllReduceOp<ComputeType, BLOCK_X, BLOCK_Y, 1> all_reduce_op;
+    all_reduce_op.apply(&var, tx, ty);
+    if (m_valid) {
+      ComputeType inv_var = fast_rsqrtf(var / N + eps);
+      SrcDtype* __restrict p_dst = input + m_idx * N;
+      bool with_weight = (weight != NULL);
+      if (with_weight) {
+        for (size_t j = n_idx; j < N; j += n_step) {
+          SrcVec fused_vec, weight_val, dst;
+          #if ((defined __MUSA_ARCH__) && (__MUSA_ARCH__ == 220))
+            fused_vec = *(SrcVec *)(p_res+j);
+            weight_val = *(SrcVec *)(weight+j);
+          #elif ((defined __MUSA_ARCH__) && (__MUSA_ARCH__ == 310))
+            fused_vec = SrcVec::load_byp_slc(p_res, j);
+            weight_val = SrcVec::load_byp_slc(weight, j);
+          #endif
+  #pragma unroll
+          for (int k = 0; k < vlen; k++) {
+             dst.val_.elem[k] = (SrcDtype)((ComputeType)fused_vec.val_.elem[k] * inv_var *
+                             (ComputeType)weight_val.val_.elem[k]);
+          }
+          *(SrcVec*)(p_dst + j) = dst;
+        }
+      }
+    }
+  }
+
+ #define CALL_KERN(_SRC_DTYPE,_KERN, _BLKX, _BLKY, _VLEN)                      \
+ {                                                                             \
+     const uint32_t block_x = _BLKX;                                           \
+     const uint32_t block_y = _BLKY;                                           \
+     const uint32_t nr_blocks = ceil_div(m, (size_t)block_y);                  \
+     dim3 block_size{block_x, block_y, 1};                                     \
+     dim3 grid_size{nr_blocks, 1, 1};                                          \
+     LayerNorm##_KERN##KernelVlen<_SRC_DTYPE, float,                           \
+                                      block_x, block_y, _VLEN>                 \
+             <<<grid_size, block_size, 0, stream>>>(                           \
+                 static_cast<_SRC_DTYPE*>(input),                              \
+                 static_cast<_SRC_DTYPE*>(residual),                           \
+                 static_cast<_SRC_DTYPE*>(weight),                             \
+                 m, n, static_cast<float>(epsilon));                           \
+ }
+
+ #define DISPATCH_KERNEL(_KERN, _BLKX, _BLKY)                                 \
+   if constexpr (std::is_same_v<SrcDtype,float16_t>) {                        \
+      CALL_KERN(float16_t, _KERN, _BLKX, _BLKY, 8);                           \
+   } else if constexpr (std::is_same_v<SrcDtype, bfloat16_t>) {               \
+     CALL_KERN(bfloat16_t, _KERN, _BLKX, _BLKY, 8);                           \
+   } else if constexpr (std::is_same_v<SrcDtype, float>) {                    \
+     CALL_KERN(float, _KERN, _BLKX, _BLKY, 4);                                \
+   }
+
+ template <typename SrcDtype>
+ void rms_fused_add_rms_norm(SrcDtype* input, SrcDtype* residual, SrcDtype* weight, int m, int n, double epsilon) {
+   auto stream = c10::musa::getCurrentMUSAStream().stream();
+   DISPATCH_KERNEL(Global, 1024, 1);
+ }
+
+void musa_fused_add_rms_norm(
+    torch::Tensor &input,
+    torch::Tensor &residual,
+    torch::Tensor &weight,
+    double epsilon,
+    bool enable_pdl) {
+
+    int m = input.size(0);
+    int n = input.size(1);
+
+    const at::musa::OptionalMUSAGuard device_guard(device_of(input));
+
+    if (input.scalar_type() == at::ScalarType::BFloat16)
+    {
+        rms_fused_add_rms_norm<__mt_bfloat16>(
+            static_cast<__mt_bfloat16*>(input.data_ptr()),
+            static_cast<__mt_bfloat16*>(residual.data_ptr()),
+            static_cast<__mt_bfloat16*>(weight.data_ptr()),
+            m,
+            n,
+            epsilon);
+    }
+    else if (input.scalar_type() == at::ScalarType::Half)
+    {
+        rms_fused_add_rms_norm<__half>(
+            static_cast<__half*>(input.data_ptr()),
+            static_cast<__half*>(residual.data_ptr()),
+            static_cast<__half*>(weight.data_ptr()),
+            m,
+            n,
+            epsilon);
+    }
+    else if (input.scalar_type() == at::ScalarType::Float)
+    {
+        rms_fused_add_rms_norm<float>(
+            static_cast<float*>(input.data_ptr()),
+            static_cast<float*>(residual.data_ptr()),
+            static_cast<float*>(weight.data_ptr()),
+            m,
+            n,
+            epsilon);
+    }
+    else
+    {
+        TORCH_CHECK(false, "only support Float32, Half and BFloat16 dtype");
+    }
+}

--- a/sgl-kernel/csrc/elementwise/utils.cuh
+++ b/sgl-kernel/csrc/elementwise/utils.cuh
@@ -7,11 +7,18 @@
 
 #include <cstdint>
 
+#ifndef USE_MUSA
 __forceinline__ __device__ int get_lane_id() {
   int lane_id;
   asm("mov.s32 %0, %laneid;" : "=r"(lane_id));
   return lane_id;
 }
+#else
+constexpr int WarpSize = 32;
+__forceinline__ __device__ int get_lane_id() {
+  return threadIdx.x % WarpSize;
+}
+#endif
 
 int ceil_div(int a, int b) {
   return (a + b - 1) / b;

--- a/sgl-kernel/csrc/gemm/dsv3_fused_a_gemm.cu
+++ b/sgl-kernel/csrc/gemm/dsv3_fused_a_gemm.cu
@@ -652,7 +652,11 @@ void dsv3_fused_a_gemm(torch::Tensor& output, torch::Tensor const& mat_a, torch:
   TORCH_CHECK(output.scalar_type() == torch::kBFloat16, "Only BFloat16 output dtype is supported")
 
   auto const sm = getSMVersion();
+#ifndef USE_MUSA
   TORCH_CHECK(sm >= 90, "required CUDA ARCH >= SM_90");
+#else
+  TORCH_CHECK(sm >= 22, "required MUSA ARCH >= MP_22");
+#endif
 
   auto stream = at::cuda::getCurrentCUDAStream(mat_a.get_device());
   if (num_tokens <= 8) {

--- a/sgl-kernel/csrc/gemm/dsv3_router_gemm_entry.cu
+++ b/sgl-kernel/csrc/gemm/dsv3_router_gemm_entry.cu
@@ -121,7 +121,11 @@ void dsv3_router_gemm(
       output.dtype() == torch::kFloat32 || output.dtype() == torch::kBFloat16, "output must be float32 or bf16");
 
   auto const sm = getSMVersion();
+#ifndef USE_MUSA
   TORCH_CHECK(sm >= 90, "required CUDA ARCH >= SM_90");
+#else
+  TORCH_CHECK(sm >= 22, "required MUSA ARCH >= MP_22");
+#endif
 
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 

--- a/sgl-kernel/csrc/gemm/per_token_group_quant_8bit_v2.cu
+++ b/sgl-kernel/csrc/gemm/per_token_group_quant_8bit_v2.cu
@@ -90,16 +90,25 @@ __forceinline__ __device__ OUT_DTYPE_T extract_required_scale_format(float value
 }
 
 __device__ __forceinline__ void st_global(const int4* ptr, const int4& value) {
+#ifndef USE_MUSA
   asm volatile(
       "st.global.v4.s32 [%0], {%1, %2, %3, %4};" ::"l"(ptr), "r"(value.x), "r"(value.y), "r"(value.z), "r"(value.w));
+#else
+  int4* p = const_cast<int4*>(ptr);
+  *p = value;
+#endif
 }
 
 __device__ __forceinline__ int4 ld_global_nc(const int4* ptr) {
+#ifndef USE_MUSA
   int4 ret;
   asm volatile("ld.global.nc.v4.s32 {%0, %1, %2, %3}, [%4];"
                : "=r"(ret.x), "=r"(ret.y), "=r"(ret.z), "=r"(ret.w)
                : "l"(ptr));
   return ret;
+#else
+  return *ptr;
+#endif
 }
 
 template <typename T>

--- a/sgl-kernel/csrc/kvcacheio/transfer.cu
+++ b/sgl-kernel/csrc/kvcacheio/transfer.cu
@@ -7,7 +7,7 @@
 #include <limits>
 #include <vector>
 
-#ifndef USE_ROCM
+#if !defined(USE_ROCM) && !defined(USE_MUSA)
 #include <dlfcn.h>
 #define WARP_SIZE 32
 #include "pytorch_extension_utils.h"
@@ -24,7 +24,7 @@ transfer_item_warp(int32_t lane_id, const void* src_addr, void* dst_addr, int64_
 
 #pragma unroll
   for (int j = lane_id; j < total_chunks; j += WARP_SIZE) {
-#ifndef USE_ROCM
+#if !defined(USE_ROCM) && !defined(USE_MUSA)
     uint64_t tmp;
     asm volatile("ld.global.nc.b64 %0,[%1];" : "=l"(tmp) : "l"(src + j) : "memory");
     asm volatile("st.global.cg.b64 [%0],%1;" ::"l"(dst + j), "l"(tmp) : "memory");

--- a/sgl-kernel/csrc/moe/moe_fused_gate_musa.cu
+++ b/sgl-kernel/csrc/moe/moe_fused_gate_musa.cu
@@ -1,0 +1,840 @@
+#include <musa_runtime.h>
+#include <mutlass/array.h>
+#include <mutlass/mutlass.h>
+#include <mutlass/numeric_types.h>
+#include <stdio.h>
+#include <torch/all.h>
+
+#include <cfloat>
+#include <type_traits>
+
+#include "torch_musa/csrc/aten/musa/MUSAContext.h"
+template <typename T, int N>
+using AlignedArray = mutlass::AlignedArray<T, N>;
+using bfloat16_t = mutlass::bfloat16_t;
+using float16_t = mutlass::half_t;
+using float32_t = float;
+
+constexpr float log2ef = 1.4426950408889634074f;
+
+static __device__ __forceinline__ float fast_expf(float a) {
+  return __musa_exp2_f(a * log2ef);
+}
+
+static __device__ __forceinline__ float fast_rcpf(float x) {
+  float y = __frcp_rn(x);
+  y = y * (2.f - x * y);
+  return y;
+}
+
+// QQ NOTE: to handle the case for at::Half, error: more than one operator ">"
+// matches these operands: built-in operator "arithmetic > arithmetic" function
+// "operator>(const __half &, const __half &)"
+template <typename T>
+__device__ inline bool cmp_gt(const T& a, const T& b) {
+  if constexpr (std::is_same<T, at::Half>::value) {
+    // at::Half (or float16_t in our native case) causes ambiguity, so we cast
+    // to float.
+    return static_cast<float>(a) > static_cast<float>(b);
+  } else {
+    // For types like float, at::BFloat16, or mutlass::half_t /
+    // mutlass::bfloat16_t, assume operator> works as expected.
+    return a > b;
+  }
+}
+
+template <typename T>
+__device__ inline bool cmp_eq(const T& a, const T& b) {
+  if constexpr (std::is_same<T, at::Half>::value) {
+    return static_cast<float>(a) == static_cast<float>(b);
+  } else {
+    return a == b;
+  }
+}
+
+template <typename T>
+__device__ inline bool cmp_ge(const T& a, const T& b, const int& x, const int& y) {
+  return (x > y && a == b) || a < b;
+}
+
+// Fixed constants common to both dynamic and static template versions:
+static constexpr int WARP_SIZE = 32;
+static constexpr int WARPS_PER_CTA = 16;
+static constexpr int MAX_VPT = 32;  // maximum VPT we support, > params.VPT = num_expert / num_expert_group
+
+// Create an alias for Array using AlignedArray
+template <typename T, int N>
+using Array = AlignedArray<T, N>;
+// QQ: NOTE expression must have a constant value, this has to be > params.VPT
+template <typename T>
+using AccessType = AlignedArray<T, MAX_VPT>;
+
+template <typename T, typename Params>
+__device__ void moe_fused_gate_impl_dynamic(
+    void* input,
+    void* bias,
+    float* output_ptr,
+    int32_t* indices_ptr,
+    int64_t num_rows,
+    int64_t topk_group,
+    int64_t topk,
+    int64_t num_fused_shared_experts,
+    double routed_scaling_factor,
+    bool apply_routed_scaling_factor_on_output,
+    Params params) {
+  int tidx = threadIdx.x;
+  int64_t thread_row =
+      blockIdx.x * params.ROWS_PER_CTA + threadIdx.y * params.ROWS_PER_WARP + tidx / params.THREADS_PER_ROW;
+  // Calculate topk_excluding_share_expert_fusion from topk
+  int64_t topk_excluding_share_expert_fusion = topk - num_fused_shared_experts;
+
+  // Cast pointers to type T:
+  auto* input_ptr = reinterpret_cast<T*>(input);
+  auto* bias_ptr = reinterpret_cast<T*>(bias);
+  auto* thread_row_ptr = input_ptr + thread_row * params.NUM_EXPERTS;
+
+  int thread_group_idx = tidx % params.THREADS_PER_ROW;
+  int first_elt_read_by_thread = thread_group_idx * params.VPT;
+
+  // Create local arrays for the row chunk and bias chunk and then reinterpret
+  // the address of row_chunk as a pointer to AccessType.
+  T* thread_read_ptr = thread_row_ptr + first_elt_read_by_thread;
+  Array<T, MAX_VPT> row_chunk;
+  AccessType<T> const* vec_thread_read_ptr = reinterpret_cast<AccessType<T> const*>(thread_read_ptr);
+
+  T* bias_thread_read_ptr = bias_ptr + first_elt_read_by_thread;
+  Array<T, MAX_VPT> bias_chunk;
+  AccessType<T> const* vec_bias_thread_read_ptr = reinterpret_cast<AccessType<T> const*>(bias_thread_read_ptr);
+
+  // QQ NOTE: doing the follow will be slower than loop assign and more
+  // importantly have misaligned address issue when params.VPT < 8 and mismatch
+  // with MAX_VPT AccessType<T>* row_chunk_vec_ptr =
+  // reinterpret_cast<AccessType<T>*>(&row_chunk); row_chunk_vec_ptr[0] =
+  // vec_thread_read_ptr[0];
+  if (thread_row < num_rows) {
+#pragma unroll
+    for (int ii = 0; ii < params.VPT; ++ii) {
+      row_chunk[ii] = vec_thread_read_ptr[0][ii];
+      bias_chunk[ii] = vec_bias_thread_read_ptr[0][ii];
+    }
+  }
+
+  ////////////////////// Sigmoid //////////////////////
+  if (thread_row < num_rows) {
+#pragma unroll
+    for (int ii = 0; ii < params.VPT; ++ii) {
+      row_chunk[ii] = static_cast<T>(fast_rcpf(1.0f + fast_expf(-float(row_chunk[ii]))));
+    }
+  }
+
+  ////////////////////// Add Bias //////////////////////
+  if (thread_row < num_rows) {
+#pragma unroll
+    for (int ii = 0; ii < params.VPT; ++ii) {
+      bias_chunk[ii] = row_chunk[ii] + bias_chunk[ii];
+    }
+  }
+
+  ////////////////////// Exclude Groups //////////////////////
+  if (thread_row < num_rows) {
+#pragma unroll
+    for (int k_idx = 0; k_idx < params.THREADS_PER_ROW - topk_group;
+         ++k_idx) {  // QQ NOTE Here params.THREADS_PER_ROW = num_expert_group
+      int expert = first_elt_read_by_thread;
+      // local argmax
+      T max_val = static_cast<T>(-FLT_MAX);
+      T max_val_second = static_cast<T>(-FLT_MAX);
+#pragma unroll
+      for (int ii = 0; ii < params.VPT; ++ii) {
+        T val = bias_chunk[ii];
+
+        if (cmp_gt(val, max_val)) {
+          max_val_second = max_val;
+          max_val = val;
+        } else if (cmp_gt(val, max_val_second)) {
+          max_val_second = val;
+        }
+      }
+
+      // QQ NOTE: currently fixed to pick top2 sigmoid weight value in each
+      // expert group and sum them as the group weight to select expert groups
+      T max_sum = max_val + max_val_second;
+
+// argmin reduce
+#pragma unroll
+      for (int mask = params.THREADS_PER_ROW / 2; mask > 0; mask /= 2) {
+        T other_max_sum =
+            static_cast<T>(__shfl_xor_sync(0xFFFFFFFF, static_cast<float>(max_sum), mask, params.THREADS_PER_ROW));
+        int other_expert = __shfl_xor_sync(0xFFFFFFFF, expert, mask, params.THREADS_PER_ROW);
+
+        // higher indices win
+        if (cmp_gt(max_sum, other_max_sum) || (cmp_eq(other_max_sum, max_sum) && other_expert > expert)) {
+          max_sum = other_max_sum;
+          expert = other_expert;
+        }
+      }
+
+      // clear the max value in the thread
+      if (k_idx < params.THREADS_PER_ROW - topk_group) {
+        int const thread_to_clear_in_group = expert / params.VPT;
+
+        if (thread_group_idx == thread_to_clear_in_group) {
+#pragma unroll
+          for (int ii = 0; ii < params.VPT; ++ii) {
+            bias_chunk[ii] = static_cast<T>(FLT_MAX);
+          }
+        }
+      }
+    }
+  }
+
+  ////////////////////// Topk //////////////////////
+  float output_sum = 0.0f;
+  for (int k_idx = 0; k_idx < topk_excluding_share_expert_fusion; ++k_idx) {
+    if (thread_row < num_rows) {
+      // local argmax
+      T max_val = bias_chunk[0];
+      int expert = first_elt_read_by_thread;
+
+      if (!cmp_eq(max_val, static_cast<T>(FLT_MAX))) {
+#pragma unroll
+        for (int ii = 1; ii < params.VPT; ++ii) {
+          T val = bias_chunk[ii];
+          if (cmp_gt(val, max_val)) {
+            max_val = val;
+            expert = first_elt_read_by_thread + ii;
+          }
+        }
+      } else {
+        max_val = static_cast<T>(-FLT_MAX);
+      }
+
+      // argmax reduce
+#pragma unroll
+      for (int mask = params.THREADS_PER_ROW / 2; mask > 0; mask /= 2) {
+        T other_max =
+            static_cast<T>(__shfl_xor_sync(0xFFFFFFFF, static_cast<float>(max_val), mask, params.THREADS_PER_ROW));
+        int other_expert = __shfl_xor_sync(0xFFFFFFFF, expert, mask, params.THREADS_PER_ROW);
+
+        // lower indices to win
+        if (cmp_gt(other_max, max_val) || (cmp_eq(other_max, max_val) && other_expert < expert)) {
+          max_val = other_max;
+          expert = other_expert;
+        }
+      }
+
+      int thread_to_clear_in_group = expert / params.VPT;
+      int64_t idx = topk * thread_row + k_idx;
+
+      if (thread_group_idx == thread_to_clear_in_group) {
+        int expert_to_clear_in_thread = expert % params.VPT;
+
+#pragma unroll
+        for (int v = 0; v < MAX_VPT; v++) {
+          if (v < params.VPT && expert_to_clear_in_thread == v) {
+            // clear the max value in the thread
+            bias_chunk[v] = static_cast<T>(-FLT_MAX);
+            // store output
+            output_ptr[idx] = static_cast<float>(row_chunk[v]);
+          }
+        }
+        indices_ptr[idx] = static_cast<int32_t>(expert);
+      }
+
+      __threadfence_block();
+      // accumulate sum for all elements
+      if (thread_group_idx == 0) {
+        output_sum += output_ptr[idx];
+      }
+    }
+  }
+
+  if (thread_row < num_rows) {
+    if (thread_group_idx == 0 && num_fused_shared_experts > 0) {
+      int64_t last_idx = topk * thread_row + topk_excluding_share_expert_fusion;
+      int64_t expert_offset = 0;
+      indices_ptr[last_idx] = static_cast<int32_t>(params.NUM_EXPERTS + expert_offset);
+
+      // Set the weight to the sum of all weights divided by
+      // routed_scaling_factor
+      output_ptr[last_idx] = output_sum / routed_scaling_factor;
+
+      if (num_fused_shared_experts > 1) {
+        for (int i = 1; i < num_fused_shared_experts; ++i) {
+          ++last_idx;
+          ++expert_offset;
+          indices_ptr[last_idx] = static_cast<int32_t>(params.NUM_EXPERTS + expert_offset);
+          // Set the weight to the sum of all weights divided by
+          // routed_scaling_factor
+          output_ptr[last_idx] = output_sum / routed_scaling_factor;
+        }
+      }
+    }
+  }
+  __threadfence_block();
+
+  ////////////////////// Rescale Output //////////////////////
+  if (thread_row < num_rows) {
+    if (thread_group_idx == 0) {
+#pragma unroll
+      for (int ii = 0; ii < topk; ++ii) {
+        int64_t const idx = topk * thread_row + ii;
+        output_ptr[idx] = output_ptr[idx] / output_sum;
+        if (apply_routed_scaling_factor_on_output) {
+          output_ptr[idx] *= routed_scaling_factor;
+        }
+      }
+    }
+  }
+}
+
+template <typename T, typename Params, int Vlen>
+__device__ void moe_fused_gate_impl_static(
+    void* input,
+    void* bias,
+    float* output_ptr,
+    int32_t* indices_ptr,
+    int64_t num_rows,
+    int64_t topk_group,
+    int64_t topk,
+    int64_t num_fused_shared_experts,
+    double routed_scaling_factor,
+    bool apply_routed_scaling_factor_on_output,
+    float last_val,
+    Params params) {
+  using ArrayVal = AlignedArray<T, Vlen>;
+  using ArrayIndex = AlignedArray<int, Vlen>;
+
+  int tidx = threadIdx.x % (params.NUM_EXPERTS / Vlen) * Vlen;
+  int tidy = threadIdx.x / (params.NUM_EXPERTS / Vlen);
+  int64_t thread_row = blockIdx.x * params.ROWS_PER_CTA + tidy;
+
+  constexpr int NR_EXPERTS = params.NUM_EXPERTS;
+  constexpr int NR_ROWS_PER_CTA = params.ROWS_PER_CTA;
+  constexpr int NR_EXPERT_GRPS = params.NUM_EXPERTS / params.VPT;
+  constexpr int NR_EXPERT_PER_GRP = params.VPT;
+  constexpr int NR_THREADS_PER_GRP = NR_EXPERT_PER_GRP / Vlen;
+  __shared__ int smem_grp_flag[NR_ROWS_PER_CTA * NR_EXPERT_GRPS];
+  __shared__ float smem_grp_max_sum[NR_ROWS_PER_CTA * NR_EXPERT_GRPS];
+  __shared__ T smem_score[NR_ROWS_PER_CTA * NR_EXPERTS];
+  __shared__ int smem_idx[NR_ROWS_PER_CTA * NR_EXPERTS];
+  __shared__ T smem_bias[NR_EXPERTS];
+
+  static_assert(Vlen <= NR_EXPERT_PER_GRP);
+
+  // Calculate topk_excluding_share_expert_fusion from topk
+  int topk_excluding_share_expert_fusion = topk - num_fused_shared_experts;
+
+  // Cast pointers to type T:
+  auto* input_ptr = reinterpret_cast<T*>(input);
+  auto* bias_ptr = reinterpret_cast<T*>(bias);
+  auto* thread_row_ptr = input_ptr + thread_row * params.NUM_EXPERTS;
+
+  int grp_idx = tidx / NR_EXPERT_PER_GRP;
+  int exp_idx_in_grp = tidx % NR_EXPERT_PER_GRP;
+
+  ArrayVal row_chunk;
+  ArrayVal bias_chunk;
+  ArrayIndex idx_chunk;
+  if (thread_row < num_rows) {
+    row_chunk = *(ArrayVal*)(thread_row_ptr + tidx);
+    bias_chunk = *(ArrayVal*)(bias_ptr + tidx);
+  }
+
+#pragma unroll
+  for (int v = 0; v < Vlen; v++) {
+    ////////////////////// Sigmoid //////////////////////
+    row_chunk[v] = static_cast<T>(fast_rcpf(1.0f + fast_expf(-float(row_chunk[v]))));
+    if (tidy == 0) {
+      smem_bias[tidx + v] = bias_chunk[v];
+    }
+    bias_chunk[v] = row_chunk[v] + bias_chunk[v];
+    idx_chunk[v] = tidx + v;
+  }
+
+  int max_idx = exp_idx_in_grp;
+  T max_val = bias_chunk[0];
+  float max_sum = 0.f;
+
+  ////////////////////// top 1 //////////////////////
+#pragma unroll
+  for (int v = 1; v < Vlen; v++) {
+    // per-thread max
+    if (bias_chunk[v] > max_val) {
+      max_val = bias_chunk[v];
+      max_idx = exp_idx_in_grp + v;
+    }
+  }
+#pragma unroll
+  for (int mask = NR_THREADS_PER_GRP / 2; mask > 0; mask /= 2) {
+    T peer_max_val = static_cast<T>(__shfl_xor_sync(0xFFFFFFFF, static_cast<float>(max_val), mask, NR_THREADS_PER_GRP));
+    int peer_idx = __shfl_xor_sync(0xFFFFFFFF, max_idx, mask, NR_THREADS_PER_GRP);
+    if (cmp_gt(peer_max_val, max_val)) {
+      max_val = peer_max_val;
+      max_idx = peer_idx;
+    }
+  }
+  int top1_max_idx = __shfl_sync(0xFFFFFFFF, static_cast<float>(max_idx), 0, NR_THREADS_PER_GRP);
+  max_sum += max_val;
+
+  ////////////////////// top 2 //////////////////////
+  max_val = static_cast<T>(-FLT_MAX);
+  for (int v = 0; v < Vlen; v++) {
+    // per-thread reset
+    if (bias_chunk[v] > max_val && exp_idx_in_grp + v != top1_max_idx) {
+      max_val = bias_chunk[v];
+    }
+  }
+#pragma unroll
+  for (int mask = NR_THREADS_PER_GRP / 2; mask > 0; mask /= 2) {
+    T peer_max_val = static_cast<T>(__shfl_xor_sync(0xFFFFFFFF, static_cast<float>(max_val), mask, NR_THREADS_PER_GRP));
+    if (cmp_gt(peer_max_val, max_val)) {
+      max_val = peer_max_val;
+    }
+  }
+  max_sum += max_val;
+
+  ////////////////////// sort groups by max_sum //////////////////////
+  if (exp_idx_in_grp == 0) {
+    smem_grp_max_sum[tidy * NR_EXPERT_GRPS + grp_idx] = max_sum;
+    smem_grp_flag[tidy * NR_EXPERT_GRPS + grp_idx] = grp_idx;
+  }
+  __syncthreads_lm();
+  int cur_grp_rank = 0;
+  if (exp_idx_in_grp == 0) {
+    float cur_grp_max = max_sum;
+#pragma unroll
+    for (int i = 0; i < NR_EXPERT_GRPS; i++) {
+      float other_grp_max = smem_grp_max_sum[tidy * NR_EXPERT_GRPS + i];
+      int other_grp_idx = smem_grp_flag[tidy * NR_EXPERT_GRPS + i];
+      if (cmp_ge(cur_grp_max, other_grp_max, grp_idx, other_grp_idx)) {
+        cur_grp_rank++;
+      }
+    }
+  }
+  __syncthreads_lm();
+  if (exp_idx_in_grp == 0) {
+    smem_grp_flag[tidy * NR_EXPERT_GRPS + grp_idx] = cur_grp_rank;
+  }
+  __syncthreads_lm();
+
+  ////////////////////// TopK experts //////////////////////
+  cur_grp_rank = smem_grp_flag[tidy * NR_EXPERT_GRPS + grp_idx];
+
+#pragma unroll
+  for (int v = 0; v < Vlen; v++) {
+    if (cur_grp_rank >= topk_group) {
+      bias_chunk[v] = static_cast<T>(-FLT_MAX);
+    }
+  }
+
+  float output_sum = 0.f;
+  for (int i = 0; i < topk_excluding_share_expert_fusion; i++) {
+    T thread_max_val = static_cast<T>(-FLT_MAX);
+    int thread_max_idx = idx_chunk[0];
+#pragma unroll
+    for (int v = 0; v < Vlen; v++) {
+      if (bias_chunk[v] > thread_max_val) {
+        thread_max_val = bias_chunk[v];
+        thread_max_idx = idx_chunk[v];
+      }
+    }
+
+#pragma unroll
+    for (int mask = WARP_SIZE / 2; mask > 0; mask /= 2) {
+      T peer_max_val = static_cast<T>(__shfl_xor_sync(0xFFFFFFFF, static_cast<float>(thread_max_val), mask, WARP_SIZE));
+      int peer_idx = __shfl_xor_sync(0xFFFFFFFF, thread_max_idx, mask, WARP_SIZE);
+      if (cmp_ge(thread_max_val, peer_max_val, thread_max_idx, peer_idx)) {
+        thread_max_val = peer_max_val;
+        thread_max_idx = peer_idx;
+      }
+    }
+    int warp_max_idx = __shfl_sync(0xFFFFFFFF, thread_max_idx, 0, WARP_SIZE);
+
+    if (tidx == 0) {
+      // restore row_chunk
+      float restored_val = (float)thread_max_val - (float)smem_bias[thread_max_idx];
+      output_sum += restored_val;
+      smem_score[tidy * NR_EXPERTS + i] = (T)restored_val;
+      smem_idx[tidy * NR_EXPERTS + i] = thread_max_idx;
+    }
+
+#pragma unroll
+    for (int v = 0; v < Vlen; v++) {
+      if (warp_max_idx == idx_chunk[v]) {
+        bias_chunk[v] = static_cast<T>(-FLT_MAX);
+      }
+    }
+  }
+
+  __syncthreads_lm();
+  output_sum = __shfl_sync(0xFFFFFFFF, output_sum, 0, WARP_SIZE);
+
+  ////////////////////// store output //////////////////////
+  int64_t out_idx = thread_row * topk;
+  int tid_st_x = threadIdx.x % WARP_SIZE;
+  if (thread_row < num_rows) {
+    for (int i = tid_st_x; i < topk_excluding_share_expert_fusion; i += WARP_SIZE) {
+      float output_val = smem_score[tidy * NR_EXPERTS + i] * fast_rcpf(output_sum);
+      if (apply_routed_scaling_factor_on_output) {
+        output_val *= routed_scaling_factor;
+      }
+      output_ptr[out_idx + i] = output_val;
+      indices_ptr[out_idx + i] = smem_idx[tidy * NR_EXPERTS + i];
+    }
+  }
+
+  ////////////////////// handle shared experts //////////////////////
+  if (thread_row < num_rows && tidx == 0 && num_fused_shared_experts > 0) {
+    int64_t last_idx = thread_row * topk + topk_excluding_share_expert_fusion;
+    int64_t expert_offset = 0;
+    // Set the weight to the sum of all weights divided by routed_scaling_factor
+    indices_ptr[last_idx] = static_cast<int32_t>(NR_EXPERTS + expert_offset);
+    output_ptr[last_idx] = last_val;
+
+    if (num_fused_shared_experts > 1) {
+      for (int i = 1; i < num_fused_shared_experts; ++i) {
+        ++last_idx;
+        ++expert_offset;
+        indices_ptr[last_idx] = static_cast<int32_t>(NR_EXPERTS + expert_offset);
+        output_ptr[last_idx] = last_val;
+      }
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+// Templated Kernel Version (using compile-time constants)
+//------------------------------------------------------------------------------
+template <int VPT_, int NUM_EXPERTS_, int ROWS_PER_CTA_>
+struct KernelParams {
+  static constexpr int VPT = VPT_;
+  static constexpr int NUM_EXPERTS = NUM_EXPERTS_;
+  static constexpr int ROWS_PER_CTA = ROWS_PER_CTA_;
+};
+
+template <typename T, int VPT, int NUM_EXPERTS, int ROWS_PER_CTA, int Vlen>
+__global__ void moe_fused_gate_kernel_static(
+    void* input,
+    void* bias,
+    float* output_ptr,
+    int32_t* indices_ptr,
+    int64_t num_rows,
+    int64_t topk_group,
+    int64_t topk,
+    int64_t num_fused_shared_experts,
+    double routed_scaling_factor,
+    bool apply_routed_scaling_factor_on_output,
+    float last_val) {
+  KernelParams<VPT, NUM_EXPERTS, ROWS_PER_CTA> params;
+  moe_fused_gate_impl_static<T, KernelParams<VPT, NUM_EXPERTS, ROWS_PER_CTA>, Vlen>(
+      input,
+      bias,
+      output_ptr,
+      indices_ptr,
+      num_rows,
+      topk_group,
+      topk,
+      num_fused_shared_experts,
+      routed_scaling_factor,
+      apply_routed_scaling_factor_on_output,
+      last_val,
+      params);
+}
+
+// Macro to compute compile-time constants and launch the kernel.
+#define LAUNCH_MOE_GATE_CONFIG(T, EXPERTS, EXPERT_GROUP)                                                       \
+  do {                                                                                                         \
+    constexpr int vlen = EXPERTS / WARP_SIZE;                                                                  \
+    int block_x = num_experts / vlen;                                                                          \
+    int block_y = block_size / block_x;                                                                        \
+    int64_t num_blocks = (num_rows + block_y - 1) / block_y;                                                   \
+    dim3 block_dim(block_size, 1, 1);                                                                          \
+    constexpr int VPT = (EXPERTS) / (EXPERT_GROUP);                                                            \
+    constexpr int ROWS_PER_CTA = block_size / (EXPERTS / vlen);                                                \
+    moe_fused_gate_kernel_static<T, VPT, (EXPERTS), ROWS_PER_CTA, vlen><<<num_blocks, block_dim, 0, stream>>>( \
+        input.data_ptr(),                                                                                      \
+        bias.data_ptr(),                                                                                       \
+        output.data_ptr<float>(),                                                                              \
+        indices.data_ptr<int32_t>(),                                                                           \
+        num_rows,                                                                                              \
+        topk_group,                                                                                            \
+        topk,                                                                                                  \
+        num_fused_shared_experts,                                                                              \
+        routed_scaling_factor,                                                                                 \
+        apply_routed_scaling_factor_on_output,                                                                 \
+        last_val);                                                                                             \
+    dispatched = true;                                                                                         \
+  } while (0);
+
+//------------------------------------------------------------------------------
+// Dynamic Kernel Version (parameters computed at runtime)
+//------------------------------------------------------------------------------
+struct KernelParamsDynamic {
+  int VPT;
+  int NUM_EXPERTS;
+  int THREADS_PER_ROW;
+  int ROWS_PER_WARP;
+  int ROWS_PER_CTA;
+  int WARPS_PER_CTA;
+};
+
+template <typename T>
+__global__ void moe_fused_gate_kernel_dynamic(
+    void* input,
+    void* bias,
+    float* output_ptr,
+    int32_t* indices_ptr,
+    int64_t num_rows,
+    int64_t num_experts,
+    int64_t num_expert_group,
+    int64_t topk_group,
+    int64_t topk,
+    int64_t num_fused_shared_experts,
+    double routed_scaling_factor,
+    bool apply_routed_scaling_factor_on_output) {
+  KernelParamsDynamic params;
+  params.NUM_EXPERTS = num_experts;             // e.g, for deepseek v3, this is 256
+  params.VPT = num_experts / num_expert_group;  // e.g., for deepseek v3, this is 256 / 8 = 32
+  params.THREADS_PER_ROW = num_expert_group;    // fixed as num_expert_group, e.g., for deepseek v3,
+                                                // this is 8
+  params.WARPS_PER_CTA = WARPS_PER_CTA;         // fixed as 6
+  params.ROWS_PER_WARP = std::max<int64_t>(1, WARP_SIZE / num_expert_group);  // WARP_SIZE is fixed as 32
+  params.ROWS_PER_CTA = params.WARPS_PER_CTA * params.ROWS_PER_WARP;
+
+  moe_fused_gate_impl_dynamic<T>(
+      input,
+      bias,
+      output_ptr,
+      indices_ptr,
+      num_rows,
+      topk_group,
+      topk,
+      num_fused_shared_experts,
+      routed_scaling_factor,
+      apply_routed_scaling_factor_on_output,
+      params);
+}
+
+void dispatch_moe_fuse_gate_dynamic(
+    at::Tensor& output,
+    at::Tensor& indices,
+    at::Tensor& input,
+    at::Tensor& bias,
+    int64_t num_rows,
+    int64_t num_experts,
+    int64_t num_expert_group,
+    int64_t topk_group,
+    int64_t topk,
+    int64_t num_fused_shared_experts,
+    double routed_scaling_factor,
+    bool apply_routed_scaling_factor_on_output) {
+  // Compute grid dimensions based on runtime value for num_expert_group.
+  int64_t rows_per_warp = std::max<int64_t>(1, WARP_SIZE / num_expert_group);
+  int64_t num_warps = (num_rows + rows_per_warp - 1) / rows_per_warp;
+  int64_t num_blocks = (num_warps + WARPS_PER_CTA - 1) / WARPS_PER_CTA;
+  const musaStream_t stream = at::musa::getCurrentMUSAStream();
+  dim3 block_dim(WARP_SIZE, WARPS_PER_CTA);
+
+  // Fallback to the dynamic kernel if none of the supported combinations match.
+  // currently only support num_experts / num_expert_group <= 32 for dynamic
+  // kernels
+  if (input.scalar_type() == at::kBFloat16) {
+    moe_fused_gate_kernel_dynamic<bfloat16_t><<<num_blocks, block_dim, 0, stream>>>(
+        input.data_ptr(),
+        bias.data_ptr(),
+        output.data_ptr<float>(),
+        indices.data_ptr<int32_t>(),
+        num_rows,
+        num_experts,
+        num_expert_group,
+        topk_group,
+        topk,
+        num_fused_shared_experts,
+        routed_scaling_factor,
+        apply_routed_scaling_factor_on_output);
+  } else if (input.scalar_type() == at::kHalf) {
+    moe_fused_gate_kernel_dynamic<float16_t><<<num_blocks, block_dim, 0, stream>>>(
+        input.data_ptr(),
+        bias.data_ptr(),
+        output.data_ptr<float>(),
+        indices.data_ptr<int32_t>(),
+        num_rows,
+        num_experts,
+        num_expert_group,
+        topk_group,
+        topk,
+        num_fused_shared_experts,
+        routed_scaling_factor,
+        apply_routed_scaling_factor_on_output);
+  } else if (input.scalar_type() == at::kFloat) {
+    moe_fused_gate_kernel_dynamic<float32_t><<<num_blocks, block_dim, 0, stream>>>(
+        input.data_ptr(),
+        bias.data_ptr(),
+        output.data_ptr<float>(),
+        indices.data_ptr<int32_t>(),
+        num_rows,
+        num_experts,
+        num_expert_group,
+        topk_group,
+        topk,
+        num_fused_shared_experts,
+        routed_scaling_factor,
+        apply_routed_scaling_factor_on_output);
+  } else {
+    TORCH_CHECK(false, "Unsupported data type for moe_fused_gate");
+  }
+}
+
+bool dispatch_moe_fuse_gate_static(
+    at::Tensor& output,
+    at::Tensor& indices,
+    at::Tensor& input,
+    at::Tensor& bias,
+    int64_t num_rows,
+    int64_t num_experts,
+    int64_t num_expert_group,
+    int64_t topk_group,
+    int64_t topk,
+    int64_t num_fused_shared_experts,
+    double routed_scaling_factor,
+    bool apply_routed_scaling_factor_on_output) {
+  const musaStream_t stream = at::musa::getCurrentMUSAStream();
+  bool dispatched = false;
+  float last_val = apply_routed_scaling_factor_on_output ? 1.f : 1.f / routed_scaling_factor;
+  // Dispatch to templated kernel for known compile-time configurations.
+  // We currently only support for:
+  //   Case 1: 256 experts, with 8 or 16 groups.
+  //   Case 2: 128 experts, with 4 or 8 groups.
+  //   Case 3: other cases, require 8 <= num_experts / num_expert_group <= 32
+  constexpr int block_size = 256;
+  switch (num_experts) {
+    case 256:
+      if (num_expert_group == 8) {
+        // This is deepseek v3 case. Here VPT = 256/8 = 32, ROWS_PER_WARP = 32/8
+        // = 4, ROWS_PER_CTA = 6 * 4 = 24.
+        if (input.scalar_type() == at::kBFloat16) {
+          LAUNCH_MOE_GATE_CONFIG(bfloat16_t, 256, 8);
+        } else if (input.scalar_type() == at::kHalf) {
+          LAUNCH_MOE_GATE_CONFIG(float16_t, 256, 8);
+        } else if (input.scalar_type() == at::kFloat) {
+          LAUNCH_MOE_GATE_CONFIG(float32_t, 256, 8);
+        }
+      } else if (num_expert_group == 16) {
+        //   Here VPT = 256/16 = 16, ROWS_PER_WARP = 32/16 = 2, ROWS_PER_CTA
+        //   = 6 * 2 = 12.
+        if (input.scalar_type() == at::kBFloat16) {
+          LAUNCH_MOE_GATE_CONFIG(bfloat16_t, 256, 16);
+        } else if (input.scalar_type() == at::kHalf) {
+          LAUNCH_MOE_GATE_CONFIG(float16_t, 256, 16);
+        } else if (input.scalar_type() == at::kFloat) {
+          LAUNCH_MOE_GATE_CONFIG(float32_t, 256, 16);
+        }
+      }
+      break;
+    case 128:
+      if (num_expert_group == 4) {
+        // VPT = 128/4 = 32, ROWS_PER_WARP = 32/16 = 2, ROWS_PER_CTA = 6 * 2
+        // = 12.
+        if (input.scalar_type() == at::kBFloat16) {
+          LAUNCH_MOE_GATE_CONFIG(bfloat16_t, 128, 4);
+        } else if (input.scalar_type() == at::kHalf) {
+          LAUNCH_MOE_GATE_CONFIG(float16_t, 128, 4);
+        } else if (input.scalar_type() == at::kFloat) {
+          LAUNCH_MOE_GATE_CONFIG(float32_t, 128, 4);
+        }
+      } else if (num_expert_group == 8) {
+        // VPT = 128/8 = 16, ROWS_PER_WARP = 32/8 = 4, ROWS_PER_CTA = 6 * 4
+        //   = 24.
+        if (input.scalar_type() == at::kBFloat16) {
+          LAUNCH_MOE_GATE_CONFIG(bfloat16_t, 128, 8);
+        } else if (input.scalar_type() == at::kHalf) {
+          LAUNCH_MOE_GATE_CONFIG(float16_t, 128, 8);
+        } else if (input.scalar_type() == at::kFloat) {
+          LAUNCH_MOE_GATE_CONFIG(float32_t, 128, 8);
+        }
+      }
+      break;
+    default:
+      break;
+  }
+
+  return dispatched;
+}
+
+#undef LAUNCH_MOE_GATE_CONFIG
+
+//------------------------------------------------------------------------------
+// Host Launcher Function
+//------------------------------------------------------------------------------
+std::vector<at::Tensor> moe_fused_gate(
+    at::Tensor& input,
+    at::Tensor& bias,
+    int64_t num_expert_group,
+    int64_t topk_group,
+    int64_t topk,
+    int64_t num_fused_shared_experts,
+    double routed_scaling_factor,
+    bool apply_routed_scaling_factor_on_output) {
+  TORCH_CHECK(input.dtype() == bias.dtype(), "input and bias should have the same dtype");
+  int64_t num_rows = input.size(0);
+  int32_t num_experts = input.size(1);
+  auto options = torch::TensorOptions().dtype(torch::kFloat32).device(input.device());
+  auto output = torch::empty({num_rows, topk}, options);
+  auto indices = torch::empty({num_rows, topk}, options.dtype(torch::kInt32));
+
+  // Check 1: Ensure that num_experts is a power of 2.
+  TORCH_CHECK((num_experts & (num_experts - 1)) == 0, "num_experts must be a power of 2, but got ", num_experts);
+
+  // Check 2: Ensure that num_experts is divisible by num_expert_group. (this
+  // also means num_expert_group is power of 2)
+  TORCH_CHECK(
+      num_experts % num_expert_group == 0,
+      "num_experts must be divisible by num_expert_group, but got ",
+      num_experts,
+      " / ",
+      num_expert_group);
+
+  int computed_vpt = num_experts / num_expert_group;
+  // Check 3: Ensure that num_experts/num_expert_group does not exceed
+  // MAX_VPT=32. Maximum VPT indicate max value per threads we can process.
+  TORCH_CHECK(
+      computed_vpt <= MAX_VPT,
+      "Per group experts: num_experts / num_expert_group = (",
+      computed_vpt,
+      ") exceeds the maximum supported (",
+      MAX_VPT,
+      ")");
+
+  bool static_dispatched = dispatch_moe_fuse_gate_static(
+      output,
+      indices,
+      input,
+      bias,
+      num_rows,
+      num_experts,
+      num_expert_group,
+      topk_group,
+      topk,
+      num_fused_shared_experts,
+      routed_scaling_factor,
+      apply_routed_scaling_factor_on_output);
+
+  if (!static_dispatched) {
+    dispatch_moe_fuse_gate_dynamic(
+        output,
+        indices,
+        input,
+        bias,
+        num_rows,
+        num_experts,
+        num_expert_group,
+        topk_group,
+        topk,
+        num_fused_shared_experts,
+        routed_scaling_factor,
+        apply_routed_scaling_factor_on_output);
+  }
+
+  return {output, indices};
+}

--- a/sgl-kernel/csrc/moe/moe_topk_softmax_kernels.cu
+++ b/sgl-kernel/csrc/moe/moe_topk_softmax_kernels.cu
@@ -23,7 +23,9 @@ limitations under the License.
 #ifndef USE_ROCM
 #include <cub/cub.cuh>
 #include <cub/util_type.cuh>
+#ifndef USE_MUSA
 #include <cuda/functional>
+#endif
 #else
 #include <hipcub/hipcub.hpp>
 #include <hipcub/util_type.hpp>

--- a/sgl-kernel/csrc/musa/common.muh
+++ b/sgl-kernel/csrc/musa/common.muh
@@ -1,0 +1,27 @@
+#pragma once
+#include "dtype.muh"
+#include <functional>
+#include <iostream>
+#include <musa_runtime.h>
+#include <sstream>
+#include <string>
+
+using namespace musa::dnn;
+
+
+/// Returns the ceiling of (a / b)
+__device__ __host__ __forceinline__ constexpr int ceil_div(int a, int b) {
+  return (a + b - 1) / b;
+}
+
+template <typename T> __device__ __host__ inline T sigmoid(T x) {
+  return 1.f / (1.f + __expf(-x));
+}
+
+#define MUDNN_ATTR_INLINE inline __attribute__((always_inline))
+
+#if defined(__MUSA_ARCH__) && __MUSA_ARCH__ == 310 // MUSIFY_EXCL_LINE
+#define __SYNCTHREADS_LM __syncthreads_lm()
+#else
+#define __SYNCTHREADS_LM __syncthreads()
+#endif

--- a/sgl-kernel/csrc/musa/dtype.muh
+++ b/sgl-kernel/csrc/musa/dtype.muh
@@ -1,0 +1,511 @@
+/* Copyright @2020-2024 Moore Threads Technology Co., Ltd("Moore Threads"). All
+ * rights reserved.
+ *
+ * This software ("this software and its documentations" or "the software") is
+ * protected by Copyright and the information contained herein is confidential.
+ *
+ * The software contained herein is PROPRIETARY to Moore Threads and is being
+ * provided under the terms and conditions of a form of Moore Threads software
+ * license agreement by and between Moore Threads and Licensee ("License
+ * Agreement") or electronically accepted by Licensee. Notwithstanding any
+ * terms or conditions to the contrary in the License Agreement, copy or
+ * disclosure of the software to any third party without the express written
+ * consent of Moore Threads is prohibited.
+ *
+ * NOTWITHSTANDING ANY TERMS OR CONDITIONS TO THE CONTRARY IN THE LICENSE
+ * AGREEMENT, MOORE THREADS MAKES NO REPRESENTATION ABOUT ANY WARRANTIES,
+ * INCLUDING BUT NOT LIMITED TO THE SUITABILITY OF THE SOFTWARE FOR ANY
+ * PURPOSE. IT IS PROVIDED "AS IS" WITHOUT EXPRESS OR IMPLIED WARRANTY OF
+ * ANY KIND. MOORE THREADS DISCLAIMS ALL WARRANTIES WITH REGARD TO THE
+ * SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY,
+ * NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE.
+ * NOTWITHSTANDING ANY TERMS OR CONDITIONS TO THE CONTRARY IN THE
+ * LICENSE AGREEMENT, IN NO EVENT SHALL MOORE THREADS BE LIABLE FOR ANY
+ * SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, OR ANY
+ * DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+ * WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+ * ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+ * OF THE SOFTWARE.
+ */
+
+#pragma once
+#include <musa_runtime.h>
+#include <stdint.h>
+
+// #include "mudnn_config.h"
+// #include "mudnn/api/impl_base.h"
+#include "musa/ai_qint8.h"
+#include "musa/integer_subbyte.h"
+
+#ifdef __MTGPU__
+#include <musa_robust.h>
+#endif
+
+#include "musa_fp16.h"
+#include "musa_bf16.h"
+#include "musa_fp8.h"
+#include <torch/all.h>
+
+namespace musa {
+namespace dnn {
+
+template <typename T> struct sizeof_bits {
+  static constexpr size_t value = sizeof(T) * 8;
+};
+
+
+template <int Bits, bool Signed>
+struct sizeof_bits<integer_subbyte<Bits, Signed>> {
+  static constexpr size_t value = Bits;
+};
+
+template <typename T>
+static constexpr int sizeof_bits_v = sizeof_bits<T>::value;
+
+typedef __half float16_t;
+#if defined(__MUSACC__) && (__MUSA_ARCH__ >= 220 || !defined(__MUSA_ARCH__))
+typedef __mt_bfloat16 bfloat16_t;
+#else
+typedef int16_t bfloat16_t;
+#endif
+
+#define MACRO_UNROLL _Pragma("unroll")
+
+#define ATTR_ALIGNED(v) __attribute__((aligned(v)))
+#define SELF_VEC_DEF(BASE_TYPE, VEC_TYPE_V2, VEC_TYPE_V4)                      \
+  struct ATTR_ALIGNED(sizeof(BASE_TYPE) * 2) VEC_TYPE_V2 {                     \
+    __device__ VEC_TYPE_V2() {}                                                \
+    __device__ VEC_TYPE_V2(const VEC_TYPE_V2 &t) {                             \
+      this->x = t.x;                                                           \
+      this->y = t.y;                                                           \
+    }                                                                          \
+    BASE_TYPE x, y;                                                            \
+  };                                                                           \
+                                                                               \
+  __device__ __forceinline__ VEC_TYPE_V2 make_##VEC_TYPE_V2(BASE_TYPE x,       \
+                                                            BASE_TYPE y) {     \
+    VEC_TYPE_V2 t;                                                             \
+    t.x = x, t.y = y;                                                          \
+    return t;                                                                  \
+  }                                                                            \
+                                                                               \
+  struct ATTR_ALIGNED(sizeof(BASE_TYPE) * 4) VEC_TYPE_V4 {                     \
+    __device__ VEC_TYPE_V4() {}                                                \
+    __device__ VEC_TYPE_V4(const VEC_TYPE_V4 &t) {                             \
+      this->x = t.x;                                                           \
+      this->y = t.y;                                                           \
+      this->z = t.z;                                                           \
+      this->w = t.w;                                                           \
+    }                                                                          \
+    BASE_TYPE x, y, z, w;                                                      \
+  };                                                                           \
+                                                                               \
+  __device__ __forceinline__ VEC_TYPE_V4 make_##VEC_TYPE_V4(                   \
+      BASE_TYPE x, BASE_TYPE y, BASE_TYPE z, BASE_TYPE w) {                    \
+    VEC_TYPE_V4 t;                                                             \
+    t.x = x, t.y = y, t.z = z, t.w = w;                                        \
+    return t;                                                                  \
+  }
+
+SELF_VEC_DEF(float16_t, Half2, Half4)
+#if defined(__MUSACC__) && (__MUSA_ARCH__ >= 220 || !defined(__MUSA_ARCH__))
+SELF_VEC_DEF(bfloat16_t, Bhalf2, Bhalf4)
+#endif
+// #if defined(__MUSACC__) && (__MUSA_ARCH__ >= 310 || !defined(__MUSA_ARCH__))
+// SELF_VEC_DEF(fp8_e5m2_t, E5m2x2, E5m2x4)
+// SELF_VEC_DEF(fp8_e4m3_t, E4m3x2, E4m3x4)
+// #endif
+
+#define GEN_VECTYPE(_CTYPE, _VECTYPE, _BYTES, _VLEN)                           \
+  struct ATTR_ALIGNED(_BYTES) _VECTYPE {                                       \
+    __device__ _VECTYPE() {}                                                   \
+    __device__ _VECTYPE(const _VECTYPE &t) {                                   \
+      MACRO_UNROLL                                                             \
+      for (int i = 0; i < _VLEN; i++) {                                        \
+        this->arr[i] = t.arr[i];                                               \
+      }                                                                        \
+    }                                                                          \
+    _CTYPE arr[_VLEN];                                                         \
+  }
+GEN_VECTYPE(float16_t, Half8, 16, 8);
+GEN_VECTYPE(signed char, Char8, 8, 8);
+GEN_VECTYPE(uint8_t, Uint8, 8, 8);
+GEN_VECTYPE(int16_t, Short8, 16, 8);
+GEN_VECTYPE(int16_t, Short16, 32, 16);
+GEN_VECTYPE(uint16_t, Ushort8, 16, 8);
+GEN_VECTYPE(uint32_t, UInt8, 32, 8);
+GEN_VECTYPE(uint32_t, UInt16, 64, 16);
+GEN_VECTYPE(uint64_t, ULong8, 64, 8);
+GEN_VECTYPE(uint64_t, ULong16, 128, 16);
+GEN_VECTYPE(float, Float8, 32, 8);
+#if defined(__MUSACC__) && (__MUSA_ARCH__ >= 220 || !defined(__MUSA_ARCH__))
+GEN_VECTYPE(bfloat16_t, Bhalf8, 16, 8);
+GEN_VECTYPE(bfloat16_t, Bhalf16, 32, 16);
+GEN_VECTYPE(bfloat16_t, Bhalf32, 64, 32);
+#endif
+// #if defined(__MUSACC__) && (__MUSA_ARCH__ >= 310 || !defined(__MUSA_ARCH__))
+// GEN_VECTYPE(fp8_e4m3_t, E4m3x8, 8, 8);
+// GEN_VECTYPE(fp8_e4m3_t, E4m3x16, 16, 16);
+// GEN_VECTYPE(fp8_e4m3_t, E4m3x32, 32, 32);
+// GEN_VECTYPE(fp8_e5m2_t, E5m2x8, 8, 8);
+// GEN_VECTYPE(fp8_e5m2_t, E5m2x16, 16, 16);
+// GEN_VECTYPE(fp8_e5m2_t, E5m2x32, 32, 32);
+// #endif
+GEN_VECTYPE(int32_t, Int8, 32, 8);
+GEN_VECTYPE(int64_t, Long8, 64, 8);
+GEN_VECTYPE(int64_t, Long16, 128, 16);
+GEN_VECTYPE(signed char, Char16, 16, 16);
+GEN_VECTYPE(float16_t, Half16, 32, 16);
+GEN_VECTYPE(float, Float16, 64, 16);
+GEN_VECTYPE(int32_t, Int16, 64, 16);
+
+template <typename type> class Dtype;
+
+#define INST(_type, _vec2, _vec4)                                              \
+  template <> class Dtype<_type> {                                             \
+  public:                                                                      \
+    using Scalar = _type;                                                      \
+    using Vec2 = _vec2;                                                        \
+    using Vec4 = _vec4;                                                        \
+    static __device__ __forceinline__ Vec2 make_vec2(_type x, _type y) {       \
+      return make_##_vec2(x, y);                                               \
+    }                                                                          \
+    static __device__ __forceinline__ Vec4 make_vec4(_type x, _type y,         \
+                                                     _type z, _type w) {       \
+      return make_##_vec4(x, y, z, w);                                         \
+    }                                                                          \
+  }
+
+INST(float, float2, float4);
+INST(float16_t, Half2, Half4);
+#if defined(__MUSACC__) && (__MUSA_ARCH__ >= 220 || !defined(__MUSA_ARCH__))
+INST(bfloat16_t, Bhalf2, Bhalf4);
+#endif
+// #if defined(__MUSACC__) && (__MUSA_ARCH__ >= 310 || !defined(__MUSA_ARCH__))
+// INST(fp8_e5m2_t, E5m2x2, E5m2x4);
+// INST(fp8_e4m3_t, E4m3x2, E4m3x4);
+// #endif
+INST(int32_t, int2, int4);
+INST(uint32_t, uint2, uint4);
+INST(int8_t, char2, char4);
+INST(uint8_t, uchar2, uchar4);
+INST(int16_t, short2, short4);
+INST(uint16_t, ushort2, ushort4);
+INST(int64_t, long2, long4);
+INST(uint64_t, ulong2, ulong4);
+INST(double, double2, double4);
+
+#undef INST
+
+template <typename T> struct DeduceVectorizedType {
+  using Type = T;
+};
+
+template <> struct DeduceVectorizedType<bool> {
+  using Type = int8_t;
+};
+
+template <> struct DeduceVectorizedType<half> {
+  using Type = _Float16;
+};
+
+#if defined(__MUSACC__) && (__MUSA_ARCH__ >= 220 || !defined(__MUSA_ARCH__))
+template <> struct DeduceVectorizedType<bfloat16_t> {
+  using Type = _Float16;
+};
+#endif
+// #if defined(__MUSACC__) && (__MUSA_ARCH__ >= 310 || !defined(__MUSA_ARCH__))
+// template <> struct DeduceVectorizedType<fp8_e4m3_t> {
+//   using Type = int8_t;
+// };
+// template <> struct DeduceVectorizedType<fp8_e5m2_t> {
+//   using Type = int8_t;
+// };
+// #endif
+template <> struct DeduceVectorizedType<qint8_t> {
+  using Type = int8_t;
+};
+
+#if defined(__MUSA_ARCH__) && __MUSA_ARCH__ == 310 // MUSIFY_EXCL_LINE
+#define LD_BYP_SLC(_BITS, _BYTES)                                              \
+  VecType dst;                                                                 \
+  const BaseType *addr = ptr + idx;                                            \
+  __lsu_ld_cache_hint(addr,0,2,1,1)                                                   \
+  return dst;
+#else
+#define LD_BYP_SLC(_BITS, _BYTES) return *(VecType *)(ptr + idx);
+#endif
+
+template <typename T, int bits = 16 * 8> struct VecType;
+
+#define DEF_VECT(_CTYPE, _VECTYPE)                                             \
+  template <> struct VecType<_CTYPE, sizeof(_VECTYPE) * 8> {                   \
+    static constexpr int vec_bytes = sizeof(_VECTYPE);                         \
+    static constexpr int bit_per_byte = 8;                                     \
+    using BaseType = _CTYPE;                                                   \
+    using RobustTypePtr = __musa::robust_ptr<_CTYPE>;                          \
+    using Ttype = _VECTYPE;                                                    \
+    static constexpr int bits = vec_bytes * bit_per_byte;                      \
+    static constexpr int vlen = bits / (sizeof(BaseType) * bit_per_byte);      \
+    using VectorizedType = typename DeduceVectorizedType<BaseType>::Type;      \
+    typedef VectorizedType VxTy __attribute__((vector_size(vec_bytes)));       \
+    template <typename OffsetType>                                             \
+    static __device__ __forceinline__ VecType load(const BaseType *ptr,        \
+                                                   OffsetType idx) {           \
+      return *(VecType *)(ptr + idx);                                          \
+    }                                                                          \
+    template <typename OffsetType>                                             \
+    static __device__ __forceinline__ VecType                                  \
+    load_byp_slc(const BaseType *ptr, OffsetType idx) {                        \
+      if constexpr (vec_bytes == 16) {                                         \
+        LD_BYP_SLC(128, 16);                                                   \
+      } else if constexpr (vec_bytes == 8) {                                   \
+        LD_BYP_SLC(64, 8);                                                     \
+      } else if constexpr (vec_bytes == 4) {                                   \
+        LD_BYP_SLC(32, 4);                                                     \
+      } else if constexpr (vec_bytes == 2) {                                   \
+        LD_BYP_SLC(16, 2);                                                     \
+      } else {                                                                 \
+        LD_BYP_SLC(8, 1);                                                      \
+      }                                                                        \
+    }                                                                          \
+    template <typename OffsetType>                                             \
+    static __device__ __forceinline__ VecType                                  \
+    robust_load(const RobustTypePtr ptr, OffsetType idx) {                     \
+      return __musa::robust_load<VecType, BaseType>(ptr, idx);                 \
+    }                                                                          \
+                                                                               \
+    template <typename OffsetType>                                             \
+    static __device__ __forceinline__ void                                     \
+    store(BaseType *ptr, OffsetType idx, const VecType &dst) {                 \
+      *(VecType *)(ptr + idx) = dst;                                           \
+    }                                                                          \
+    template <typename OffsetType>                                             \
+    static __device__ __forceinline__ void                                     \
+    robust_store(RobustTypePtr ptr, OffsetType idx, const VecType &dst) {      \
+      __musa::robust_store<VecType, BaseType>(dst, ptr, idx);                  \
+    }                                                                          \
+                                                                               \
+    __device__ VecType() {                                                     \
+      MACRO_UNROLL                                                             \
+      for (int i = 0; i < sizeof(Ttype) / sizeof(BaseType); i++) {             \
+        this->val_.elem[i] = 0;                                                \
+      }                                                                        \
+    }                                                                          \
+    __device__ VecType(const VecType &t) {                                     \
+      MACRO_UNROLL                                                             \
+      for (int i = 0; i < sizeof(Ttype) / sizeof(BaseType); i++) {             \
+        this->val_.elem[i] = t.val_.elem[i];                                   \
+      }                                                                        \
+    }                                                                          \
+    __device__ VecType &operator=(const VecType &t) {                          \
+      MACRO_UNROLL                                                             \
+      for (int i = 0; i < sizeof(Ttype) / sizeof(BaseType); i++) {             \
+        this->val_.elem[i] = t.val_.elem[i];                                   \
+      }                                                                        \
+      return *this;                                                            \
+    }                                                                          \
+    __device__ VecType(_CTYPE val) {                                           \
+      MACRO_UNROLL                                                             \
+      for (int i = 0; i < sizeof(Ttype) / sizeof(BaseType); i++) {             \
+        this->val_.elem[i] = val;                                              \
+      }                                                                        \
+    }                                                                          \
+    template <typename SrcVecType>                                             \
+    friend __device__ VecType operator+(VecType lhs, const SrcVecType &rhs) {  \
+      MACRO_UNROLL                                                             \
+      for (int i = 0; i < sizeof(Ttype) / sizeof(BaseType); i++) {             \
+        lhs.val_.elem[i] += static_cast<BaseType>(rhs.val_.elem[i]);           \
+      }                                                                        \
+      return lhs;                                                              \
+    }                                                                          \
+    friend __device__ VecType operator+(VecType lhs, const _CTYPE &rhs) {      \
+      MACRO_UNROLL                                                             \
+      for (int i = 0; i < sizeof(Ttype) / sizeof(BaseType); i++) {             \
+        lhs.val_.elem[i] += rhs;                                               \
+      }                                                                        \
+      return lhs;                                                              \
+    }                                                                          \
+    friend __device__ VecType operator-(VecType lhs, const VecType &rhs) {     \
+      MACRO_UNROLL                                                             \
+      for (int i = 0; i < sizeof(Ttype) / sizeof(BaseType); i++) {             \
+        lhs.val_.elem[i] -= rhs.val_.elem[i];                                  \
+      }                                                                        \
+      return lhs;                                                              \
+    }                                                                          \
+    friend __device__ VecType operator*(VecType lhs, const VecType &rhs) {     \
+      MACRO_UNROLL                                                             \
+      for (int i = 0; i < sizeof(Ttype) / sizeof(BaseType); i++) {             \
+        lhs.val_.elem[i] *= rhs.val_.elem[i];                                  \
+      }                                                                        \
+      return lhs;                                                              \
+    }                                                                          \
+    template <typename Func> __device__ VecType &apply() {                     \
+      MACRO_UNROLL                                                             \
+      for (int i = 0; i < sizeof(Ttype) / sizeof(BaseType); i++) {             \
+        this->val_.elem[i] = Func::apply(this->val_.elem[i]);                  \
+      }                                                                        \
+      return *this;                                                            \
+    }                                                                          \
+    template <typename SrcVecType>                                             \
+    static __device__ VecType cvt(const SrcVecType &src) {                     \
+      VecType dst;                                                             \
+      MACRO_UNROLL                                                             \
+      for (int i = 0; i < sizeof(Ttype) / sizeof(BaseType); i++) {             \
+        dst.val_.elem[i] = (BaseType)(src.val_.elem[i]);                       \
+      }                                                                        \
+      return dst;                                                              \
+    }                                                                          \
+    union U {                                                                  \
+      __device__ U() {                                                         \
+        MACRO_UNROLL                                                           \
+        for (int i = 0; i < sizeof(Ttype) / sizeof(BaseType); i++) {           \
+          this->elem[i] = 0;                                                   \
+        }                                                                      \
+      }                                                                        \
+      Ttype storage;                                                           \
+      BaseType elem[sizeof(Ttype) / sizeof(BaseType)];                         \
+      VxTy vt_elem;                                                            \
+    };                                                                         \
+    U val_{};                                                                  \
+  }
+DEF_VECT(float16_t, float16_t);
+DEF_VECT(float16_t, Half2);
+DEF_VECT(float16_t, Half4);
+DEF_VECT(float16_t, Half8);
+DEF_VECT(float16_t, Half16);
+#if defined(__MUSACC__) && (__MUSA_ARCH__ >= 220 || !defined(__MUSA_ARCH__))
+DEF_VECT(bfloat16_t, bfloat16_t);
+DEF_VECT(bfloat16_t, Bhalf2);
+DEF_VECT(bfloat16_t, Bhalf4);
+DEF_VECT(bfloat16_t, Bhalf8);
+DEF_VECT(bfloat16_t, Bhalf16);
+DEF_VECT(bfloat16_t, Bhalf32);
+#endif
+// #if defined(__MUSACC__) && (__MUSA_ARCH__ >= 310 || !defined(__MUSA_ARCH__))
+// DEF_VECT(fp8_e4m3_t, fp8_e4m3_t);
+// DEF_VECT(fp8_e4m3_t, E4m3x2);
+// DEF_VECT(fp8_e4m3_t, E4m3x4);
+// DEF_VECT(fp8_e4m3_t, E4m3x8);
+// DEF_VECT(fp8_e4m3_t, E4m3x16);
+// DEF_VECT(fp8_e4m3_t, E4m3x32);
+// DEF_VECT(fp8_e5m2_t, fp8_e5m2_t);
+// DEF_VECT(fp8_e5m2_t, E5m2x2);
+// DEF_VECT(fp8_e5m2_t, E5m2x4);
+// DEF_VECT(fp8_e5m2_t, E5m2x8);
+// DEF_VECT(fp8_e5m2_t, E5m2x16);
+// DEF_VECT(fp8_e5m2_t, E5m2x32);
+// #endif
+DEF_VECT(bool, char);
+DEF_VECT(bool, char2);
+DEF_VECT(bool, char3);
+DEF_VECT(bool, char4);
+DEF_VECT(bool, Char8);
+DEF_VECT(bool, Char16);
+DEF_VECT(int8_t, int8_t);
+DEF_VECT(int8_t, char2);
+DEF_VECT(int8_t, char3);
+DEF_VECT(int8_t, char4);
+DEF_VECT(int8_t, Char8);
+DEF_VECT(int8_t, Char16);
+DEF_VECT(qint8_t, int8_t);
+DEF_VECT(qint8_t, char2);
+DEF_VECT(qint8_t, char3);
+DEF_VECT(qint8_t, char4);
+DEF_VECT(qint8_t, Char8);
+DEF_VECT(qint8_t, Char16);
+DEF_VECT(uint8_t, uint8_t);
+DEF_VECT(uint8_t, uchar2);
+DEF_VECT(uint8_t, uchar3);
+DEF_VECT(uint8_t, uchar4);
+DEF_VECT(uint8_t, uint4);
+DEF_VECT(uint8_t, Uint8);
+DEF_VECT(int16_t, int16_t);
+DEF_VECT(int16_t, short2);
+DEF_VECT(int16_t, short3);
+DEF_VECT(int16_t, short4);
+DEF_VECT(int16_t, Short8);
+DEF_VECT(int16_t, Short16);
+DEF_VECT(uint16_t, ushort);
+DEF_VECT(uint16_t, ushort2);
+DEF_VECT(uint16_t, ushort3);
+DEF_VECT(uint16_t, ushort4);
+DEF_VECT(uint16_t, Ushort8);
+DEF_VECT(int32_t, int);
+DEF_VECT(int32_t, int2);
+DEF_VECT(int32_t, int3);
+DEF_VECT(int32_t, int4);
+DEF_VECT(int32_t, Int8);
+DEF_VECT(int32_t, Int16);
+DEF_VECT(uint32_t, uint);
+DEF_VECT(uint32_t, uint2);
+DEF_VECT(uint32_t, uint3);
+DEF_VECT(uint32_t, uint4);
+DEF_VECT(uint32_t, UInt8);
+DEF_VECT(uint32_t, UInt16);
+DEF_VECT(uint64_t, uint64_t);
+DEF_VECT(uint64_t, ulong2);
+DEF_VECT(uint64_t, ulong3);
+DEF_VECT(uint64_t, ulong4);
+DEF_VECT(uint64_t, ULong8);
+DEF_VECT(uint64_t, ULong16);
+DEF_VECT(int64_t, int64_t);
+DEF_VECT(int64_t, long2);
+DEF_VECT(int64_t, long3);
+DEF_VECT(int64_t, long4);
+DEF_VECT(int64_t, Long8);
+DEF_VECT(int64_t, Long16);
+DEF_VECT(float, float);
+DEF_VECT(float, float2);
+DEF_VECT(float, float3);
+DEF_VECT(float, float4);
+DEF_VECT(float, Float8);
+DEF_VECT(float, Float16);
+
+DEF_VECT(double, double);
+DEF_VECT(double, double2);
+DEF_VECT(double, double3);
+DEF_VECT(double, double4);
+
+#undef DEF_VECT
+#undef MACRO_UNROLL
+template <typename T> struct ComputeDType {
+  using Type = typename std::conditional<
+      (sizeof(T) >= 4), T,
+      typename std::conditional<
+          std::is_integral<T>::value,
+          typename std::conditional<std::is_unsigned<T>::value, uint32_t,
+                                    int32_t>::type,
+          float>::type>::type;
+};
+template <> struct ComputeDType<bool> {
+  using Type = bool;
+};
+// qint type calculate as float
+template <> struct ComputeDType<qint8_t> {
+  using Type = float;
+};
+
+// static inline bool check_qint8_only_scale(CTR x) {
+//   if (x.type == TensorImpl::Type::QINT8) {
+//     size_t zp_size = x.quant_desc.zero_point.size();
+//     return zp_size == 0 || (zp_size == 1 && x.quant_desc.zero_point[0] == 0);
+//   }
+//   return true;
+// }
+
+template <typename T, typename... Types>
+bool check_qint8_only_scale(T x0, Types... xn) {
+  bool ok = check_qint8_only_scale(x0);
+  return ok && check_qint8_only_scale(xn...);
+}
+#define CHECK_QINT8(ARGS...)                                                   \
+  {                                                                            \
+    if (!check_qint8_only_scale(ARGS)) {                                       \
+      return fail::NOT_SUPPORTED() << "qint8 only support zero_point==0";      \
+    }                                                                          \
+  }
+
+
+} // namespace dnn
+} // namespace musa

--- a/sgl-kernel/csrc/musa/matmul_mudnn.cpp
+++ b/sgl-kernel/csrc/musa/matmul_mudnn.cpp
@@ -1,0 +1,53 @@
+#include <mudnn.h>
+#include <torch/all.h>
+#include <torch/csrc/utils/pycfunction_helpers.h>
+#include <torch/extension.h>
+#include <torch_musa/csrc/aten/utils/Context.h>
+#include <torch_musa/csrc/aten/utils/Utils.h>
+#include <torch_musa/csrc/core/MUSAGuard.h>
+
+#include <optional>
+#include <vector>
+
+using at::musa::GetComputeModeFromCtx;
+using at::musa::muTensor;
+
+void mudnn_w8a8_scaled_mm(
+    torch::Tensor& c,
+    torch::Tensor const& a,
+    torch::Tensor const& b,
+    torch::Tensor const& a_scales,
+    torch::Tensor const& b_scales,
+    std::optional<torch::Tensor> const& bias) {
+  TORCH_CHECK(a.dim() == 2 && b.dim() == 2 && c.dim() == 2);
+  TORCH_CHECK(c.size(0) == a.size(0) && a.size(1) == b.size(1) && b.size(0) == c.size(1));
+
+  if (bias) {
+    TORCH_CHECK(bias->numel() == b.size(1) && bias->is_contiguous() && bias->dim() == 1);
+  }
+
+  at::musa::OptionalMUSAGuard const device_guard(device_of(a));
+
+  const auto a_type = a.scalar_type();
+
+  muTensor a_mu = at::musa::CreateMUTensor(a);
+  muTensor b_mu = at::musa::CreateMUTensor(b);
+  muTensor out_mu = at::musa::CreateMUTensor(c);
+  torch::Tensor bias_ = bias.value_or(torch::Tensor());
+  muTensor bias_mu = at::musa::CreateMUTensor(bias_);
+
+  muTensor a_scales_mu = at::musa::CreateMUTensor(a_scales);
+  muTensor b_scales_mu = at::musa::CreateMUTensor(b_scales);
+
+  auto& handle = at::GetMudnnHandle();
+  ::musa::dnn::BatchMatMul op;
+  ::musa::dnn::MatMulLtParam param;
+
+  CHECK_MUDNN_STATUS(param.SetScale(a_scales_mu, b_scales_mu, muTensor(), muTensor(), 128), "SetScale");
+  CHECK_MUDNN_STATUS(op.SetTranspose(false, true), "SetTranspose");
+  CHECK_MUDNN_STATUS(op.SetDeterministic(false), "SetDeterministic");
+  CHECK_MUDNN_STATUS(op.SetComputeMode(GetComputeModeFromCtx(a_type)), "SetComputeMode");
+  CHECK_MUDNN_STATUS(op.SetBeta(0.0), "SetBeta");
+
+  CHECK_MUDNN_STATUS(op.RunLt(handle, out_mu, a_mu, b_mu, out_mu, bias_mu, param, at::musa::InternalMemAlloc), "RunLt");
+}

--- a/sgl-kernel/csrc/musa/moe_gemv_swiglu.mu
+++ b/sgl-kernel/csrc/musa/moe_gemv_swiglu.mu
@@ -1,0 +1,825 @@
+#include <musa_runtime.h>
+#include <cassert>
+#include <mutex>
+#include <musa_bf16.h>
+#include <musa_fp16.h>
+
+#include "common.muh"
+#include "dtype.muh"
+#include "torch_musa/csrc/core/MUSAGuard.h"
+#include "torch_musa/csrc/core/MUSAStream.h"
+#include "torch_musa/csrc/aten/musa/MUSAContext.h"
+
+using namespace musa::dnn;
+
+#if defined(__MUSA_ARCH__) && __MUSA_ARCH__ == 310
+#define ThreadNumPerWarp 32
+#else
+#define ThreadNumPerWarp 128
+#endif
+
+#define SYNC_IF_NEEDED() \
+    if constexpr (BLOCK_N * BLOCK_K > ThreadNumPerWarp) { \
+        __SYNCTHREADS_LM; \
+    }
+
+#define CAL_MOE_GEMV_FP8(_ADTYPE, _BDTYPE, _CDTYPE, _TOPK_WEIGHT_DTYPE, _SCALE_DTYPE, _IS_MUL_ROUTED_WEIGHT, _IS_SWGELU, _IS_FP8, _IS_RMSNORM) \
+    if (scale_k_group_tile == 128) { \
+        musa_gemv_kernel<_ADTYPE, _BDTYPE, _CDTYPE, _TOPK_WEIGHT_DTYPE, _SCALE_DTYPE, block_n, block_k, iobit, _IS_MUL_ROUTED_WEIGHT, _IS_SWGELU, false, false, _IS_FP8, 128, _IS_RMSNORM> \
+            <<<grid_size, block_size, shmem_size, stream>>>( \
+                static_cast<_CDTYPE*>(C.data_ptr()), \
+                static_cast<_ADTYPE*>(A.data_ptr()), \
+                static_cast<_BDTYPE*>(B.data_ptr()), \
+                static_cast<int*>(topk_ids_ptr), \
+                static_cast<_TOPK_WEIGHT_DTYPE*>(topk_weights_ptr), \
+                static_cast<_SCALE_DTYPE*>(a_scale_ptr), \
+                static_cast<_SCALE_DTYPE*>(b_scale_ptr), \
+                topk, expert_offset_stride, nr_n, hidden_size, num_experts, half_n_idx, scale_k_len, \
+                static_cast<bfloat16_t*>(rms_gamma_ptr), static_cast<float*>(rms_sum_out_ptr), static_cast<int*>(rms_count_ptr), eps); \
+    } else { \
+        musa_gemv_kernel<_ADTYPE, _BDTYPE, _CDTYPE, _TOPK_WEIGHT_DTYPE, _SCALE_DTYPE, block_n, block_k, iobit, _IS_MUL_ROUTED_WEIGHT, _IS_SWGELU, false, false, _IS_FP8, 64, _IS_RMSNORM> \
+            <<<grid_size, block_size, shmem_size, stream>>>( \
+                static_cast<_CDTYPE*>(C.data_ptr()), \
+                static_cast<_ADTYPE*>(A.data_ptr()), \
+                static_cast<_BDTYPE*>(B.data_ptr()), \
+                static_cast<int*>(topk_ids_ptr), \
+                static_cast<_TOPK_WEIGHT_DTYPE*>(topk_weights_ptr), \
+                static_cast<_SCALE_DTYPE*>(a_scale_ptr), \
+                static_cast<_SCALE_DTYPE*>(b_scale_ptr), \
+                topk, expert_offset_stride, nr_n, hidden_size, num_experts, half_n_idx, scale_k_len, \
+                static_cast<bfloat16_t*>(rms_gamma_ptr), static_cast<float*>(rms_sum_out_ptr), static_cast<int*>(rms_count_ptr), eps); \
+    } \
+    return;
+
+#define RUN_SCALE_ROUTE_FP8(_ADTYPE, _BDTYPE, _CDTYPE, _TOPK_WEIGHT_DTYPE, _SCALE_DTYPE, _IS_FP8) \
+    if (mul_routed_weight) { \
+        if (use_swigelu) { \
+            CAL_MOE_GEMV_FP8(_ADTYPE, _BDTYPE, _CDTYPE, _TOPK_WEIGHT_DTYPE, _SCALE_DTYPE, true, true, _IS_FP8, false) \
+        } else if(use_rms_norm) { \
+            CAL_MOE_GEMV_FP8(_ADTYPE, _BDTYPE, _CDTYPE, _TOPK_WEIGHT_DTYPE, _SCALE_DTYPE, true, false, _IS_FP8, true) \
+        } else { \
+            CAL_MOE_GEMV_FP8(_ADTYPE, _BDTYPE, _CDTYPE, _TOPK_WEIGHT_DTYPE, _SCALE_DTYPE, true, false, _IS_FP8, false) \
+        } \
+    } else { \
+        if (use_swigelu) { \
+            CAL_MOE_GEMV_FP8(_ADTYPE, _BDTYPE, _CDTYPE, _TOPK_WEIGHT_DTYPE, _SCALE_DTYPE, false, true, _IS_FP8, false) \
+        } else if (use_rms_norm) { \
+            CAL_MOE_GEMV_FP8(_ADTYPE, _BDTYPE, _CDTYPE, _TOPK_WEIGHT_DTYPE, _SCALE_DTYPE, false, false, _IS_FP8, true) \
+        } else { \
+            CAL_MOE_GEMV_FP8(_ADTYPE, _BDTYPE, _CDTYPE, _TOPK_WEIGHT_DTYPE, _SCALE_DTYPE, false, false, _IS_FP8, false) \
+        } \
+    }
+
+#define CAL_MOE_GEMV_W4A16(_ADTYPE, _BDTYPE, _TOPK_WEIGHT_DTYPE, _SCALE_DTYPE, _IS_MUL_ROUTED_WEIGHT, _IS_SWGELU, _IS_RMS_NROM) \
+    if (is_pergroup_scale) { \
+        if (scale_k_group_tile == 128) { \
+            musa_gemv_kernel<_ADTYPE, _BDTYPE, _ADTYPE, _TOPK_WEIGHT_DTYPE, _SCALE_DTYPE, block_n, block_k, iobit, _IS_MUL_ROUTED_WEIGHT, _IS_SWGELU, true, true, false, 128, _IS_RMS_NROM> \
+                <<<grid_size, block_size, shmem_size, stream>>>( \
+                    static_cast<_ADTYPE*>(C.data_ptr()), \
+                    static_cast<_ADTYPE*>(A.data_ptr()), \
+                    static_cast<_BDTYPE*>(B.data_ptr()), \
+                    static_cast<int*>(topk_ids_ptr), \
+                    static_cast<_TOPK_WEIGHT_DTYPE*>(topk_weights_ptr), \
+                    static_cast<_SCALE_DTYPE*>(a_scale_ptr), \
+                    static_cast<_SCALE_DTYPE*>(b_scale_ptr), \
+                    topk, expert_offset_stride, nr_n, hidden_size, num_experts, half_n_idx, scale_k_len, \
+                    static_cast<bfloat16_t*>(rms_gamma_ptr), static_cast<float*>(rms_sum_out_ptr), static_cast<int*>(rms_count_ptr), eps); \
+            return; \
+        } else { \
+            musa_gemv_kernel<_ADTYPE, _BDTYPE, _ADTYPE, _TOPK_WEIGHT_DTYPE, _SCALE_DTYPE, block_n, block_k, iobit, _IS_MUL_ROUTED_WEIGHT, _IS_SWGELU, true, true, false, 64, _IS_RMS_NROM> \
+                <<<grid_size, block_size, shmem_size, stream>>>( \
+                    static_cast<_ADTYPE*>(C.data_ptr()), \
+                    static_cast<_ADTYPE*>(A.data_ptr()), \
+                    static_cast<_BDTYPE*>(B.data_ptr()), \
+                    static_cast<int*>(topk_ids_ptr), \
+                    static_cast<_TOPK_WEIGHT_DTYPE*>(topk_weights_ptr), \
+                    static_cast<_SCALE_DTYPE*>(a_scale_ptr), \
+                    static_cast<_SCALE_DTYPE*>(b_scale_ptr), \
+                    topk, expert_offset_stride, nr_n, hidden_size, num_experts, half_n_idx, scale_k_len, \
+                    static_cast<bfloat16_t*>(rms_gamma_ptr), static_cast<float*>(rms_sum_out_ptr), static_cast<int*>(rms_count_ptr), eps); \
+            return; \
+        } \
+    } else { \
+        musa_gemv_kernel<_ADTYPE, _BDTYPE, _ADTYPE, _TOPK_WEIGHT_DTYPE, _SCALE_DTYPE, block_n, block_k, iobit, _IS_MUL_ROUTED_WEIGHT, _IS_SWGELU, true, false, false, 1, _IS_RMS_NROM> \
+            <<<grid_size, block_size, shmem_size, stream>>>( \
+                static_cast<_ADTYPE*>(C.data_ptr()), \
+                static_cast<_ADTYPE*>(A.data_ptr()), \
+                static_cast<_BDTYPE*>(B.data_ptr()), \
+                static_cast<int*>(topk_ids_ptr), \
+                static_cast<_TOPK_WEIGHT_DTYPE*>(topk_weights_ptr), \
+                static_cast<_SCALE_DTYPE*>(a_scale_ptr), \
+                static_cast<_SCALE_DTYPE*>(b_scale_ptr), \
+                topk, expert_offset_stride, nr_n, hidden_size, num_experts, half_n_idx, scale_k_len, \
+                static_cast<bfloat16_t*>(rms_gamma_ptr), static_cast<float*>(rms_sum_out_ptr), static_cast<int*>(rms_count_ptr), eps); \
+        return; \
+    }
+
+#define CAL_MOE_GEMV(_ADTYPE, _BDTYPE, _TOPK_WEIGHT_DTYPE, _SCALE_DTYPE, _IS_MUL_ROUTED_WEIGHT, _IS_SWGELU, _IS_RMS_NROM) \
+    musa_gemv_kernel<_ADTYPE, _BDTYPE, _ADTYPE, _TOPK_WEIGHT_DTYPE, _SCALE_DTYPE, block_n, block_k, iobit, _IS_MUL_ROUTED_WEIGHT, _IS_SWGELU, false, false, false, 1, _IS_RMS_NROM> \
+        <<<grid_size, block_size, shmem_size, stream>>>( \
+            static_cast<_ADTYPE*>(C.data_ptr()), \
+            static_cast<_ADTYPE*>(A.data_ptr()), \
+            static_cast<_BDTYPE*>(B.data_ptr()), \
+            static_cast<int*>(topk_ids_ptr), \
+            static_cast<_TOPK_WEIGHT_DTYPE*>(topk_weights_ptr), \
+            nullptr, \
+            nullptr, \
+            topk, expert_offset_stride, nr_n, hidden_size, num_experts, half_n_idx, scale_k_len, \
+            static_cast<bfloat16_t*>(rms_gamma_ptr), static_cast<float*>(rms_sum_out_ptr), static_cast<int*>(rms_count_ptr), eps); \
+    return;
+
+#define RUN_SCALE_ROUTE(_ADTYPE, _BDTYPE, _TOPK_WEIGHT_DTYPE, _SCALE_DTYPE, _CAL_FUNC) \
+    if (mul_routed_weight) { \
+        if (use_swigelu) { \
+            _CAL_FUNC(_ADTYPE, _BDTYPE, _TOPK_WEIGHT_DTYPE, _SCALE_DTYPE, true, true, false) \
+        } else if (use_rms_norm) { \
+            _CAL_FUNC(_ADTYPE, _BDTYPE, _TOPK_WEIGHT_DTYPE, _SCALE_DTYPE, true, false, true) \
+        } else { \
+            _CAL_FUNC(_ADTYPE, _BDTYPE, _TOPK_WEIGHT_DTYPE, _SCALE_DTYPE, true, false, false) \
+        } \
+    } else { \
+        if (use_swigelu) { \
+            _CAL_FUNC(_ADTYPE, _BDTYPE, _TOPK_WEIGHT_DTYPE, _SCALE_DTYPE, false, true, false) \
+        } else if (use_rms_norm) { \
+            _CAL_FUNC(_ADTYPE, _BDTYPE, _TOPK_WEIGHT_DTYPE, _SCALE_DTYPE, false, false, true) \
+        } else { \
+            _CAL_FUNC(_ADTYPE, _BDTYPE, _TOPK_WEIGHT_DTYPE, _SCALE_DTYPE, false, false, false) \
+        } \
+    }
+
+#define RUN_ROUNTE_WEIGHT(_ADTYPE, _BDTYPE, _TOPK_WEIGHT_DTYPE, _CAL_FUNC) \
+    if (!B_scale.has_value() || B_scale->scalar_type() == at::ScalarType::Float) { \
+        RUN_SCALE_ROUTE(_ADTYPE, _BDTYPE, _TOPK_WEIGHT_DTYPE, float, _CAL_FUNC) \
+    } else if (B_scale.has_value() && B_scale->scalar_type() == at::ScalarType::BFloat16) { \
+        RUN_SCALE_ROUTE(_ADTYPE, _BDTYPE, _TOPK_WEIGHT_DTYPE, bfloat16_t, _CAL_FUNC) \
+    } else if (B_scale.has_value() && B_scale->scalar_type() == at::ScalarType::Half) { \
+        RUN_SCALE_ROUTE(_ADTYPE, _BDTYPE, _TOPK_WEIGHT_DTYPE, float16_t, _CAL_FUNC) \
+    }
+
+#define GEN_LAUNCH_KERN_GEMV(_BLK_N, _BLK_K) \
+    { \
+        launch_kernel = [&]() { \
+            constexpr int block_n = _BLK_N; \
+            constexpr int block_k = _BLK_K; \
+            TORCH_CHECK(nr_n % block_n == 0, "gemv n need align"); \
+            TORCH_CHECK(hidden_size % block_k == 0, "gemv k need align"); \
+            dim3 block_size{block_n * block_k, 1, 1}; \
+            dim3 grid_size{(uint32_t)ceil_div(reduce_size, block_n), (uint32_t)topk, (uint32_t)bseqlen}; \
+            int shmem_size = block_n * sizeof(float) * block_k; \
+            if (use_int4_w4a16) { \
+                if (A.scalar_type() == at::ScalarType::BFloat16) { \
+                    RUN_ROUNTE_WEIGHT(bfloat16_t, int8_t, float, CAL_MOE_GEMV_W4A16) \
+                } else if (A.scalar_type() == at::ScalarType::Half) { \
+                    RUN_ROUNTE_WEIGHT(float16_t, int8_t, float, CAL_MOE_GEMV_W4A16) \
+                } \
+            } else if (is_fp8) { \
+                if (A.dtype() == at::ScalarType::BFloat16) { \
+                    RUN_SCALE_ROUTE_FP8(bfloat16_t, __mt_fp8_e4m3, bfloat16_t, float, float, true) \
+                } else { \
+                    RUN_SCALE_ROUTE_FP8(__mt_fp8_e4m3, __mt_fp8_e4m3, bfloat16_t, float, float, true) \
+                } \
+            } else { \
+                if (A.scalar_type() == at::ScalarType::BFloat16) { \
+                    RUN_ROUNTE_WEIGHT(bfloat16_t, bfloat16_t, float, CAL_MOE_GEMV) \
+                } else if (A.scalar_type() == at::ScalarType::Half) { \
+                    RUN_ROUNTE_WEIGHT(float16_t, float16_t, float, CAL_MOE_GEMV) \
+                } \
+            } \
+            printf("no support on moe gemv\n"); \
+            assert(false); \
+        }; \
+    }
+
+#define GEN_LAUNCH_KERN(_BLK_N, _BLK_K) \
+    { \
+        launch_kernel = [&]() { \
+            constexpr int block_n = _BLK_N; \
+            constexpr int block_k = _BLK_K; \
+            TORCH_CHECK(nr_n % block_n == 0, "gemv n need align"); \
+            TORCH_CHECK(hidden_size % block_k == 0, "gemv k need align"); \
+            dim3 block_size{block_n * block_k, 1, 1}; \
+            dim3 grid_size{(uint32_t)ceil_div(reduce_size, block_n), (uint32_t)topk, (uint32_t)bseqlen}; \
+            int shmem_size = block_n * sizeof(float) * block_k; \
+            if (use_int4_w4a16) { \
+                if (A.scalar_type() == at::ScalarType::BFloat16) { \
+                    if (topk_weights.scalar_type() == at::ScalarType::Float) { \
+                        RUN_ROUNTE_WEIGHT(bfloat16_t, int8_t, float, CAL_MOE_GEMV_W4A16) \
+                    } else if (topk_weights.scalar_type() == at::ScalarType::BFloat16) { \
+                        RUN_ROUNTE_WEIGHT(bfloat16_t, int8_t, bfloat16_t, CAL_MOE_GEMV_W4A16) \
+                    } \
+                } else if (A.scalar_type() == at::ScalarType::Half) { \
+                    if (topk_weights.scalar_type() == at::ScalarType::Float) { \
+                        RUN_ROUNTE_WEIGHT(float16_t, int8_t, float, CAL_MOE_GEMV_W4A16) \
+                    } else if (topk_weights.scalar_type() == at::ScalarType::Half) { \
+                        RUN_ROUNTE_WEIGHT(float16_t, int8_t, float16_t, CAL_MOE_GEMV_W4A16) \
+                    } \
+                } \
+            } else if (is_fp8) { \
+                if (A.dtype() == at::ScalarType::BFloat16) { \
+                    RUN_SCALE_ROUTE_FP8(bfloat16_t, __mt_fp8_e4m3, bfloat16_t, float, float, true) \
+                } else { \
+                    RUN_SCALE_ROUTE_FP8(__mt_fp8_e4m3, __mt_fp8_e4m3, bfloat16_t, float, float, true) \
+                } \
+            } else { \
+                if (A.scalar_type() == at::ScalarType::BFloat16) { \
+                    if (topk_weights.scalar_type() == at::ScalarType::Float) { \
+                        RUN_ROUNTE_WEIGHT(bfloat16_t, bfloat16_t, float, CAL_MOE_GEMV) \
+                    } else if (topk_weights.scalar_type() == at::ScalarType::BFloat16) { \
+                        RUN_ROUNTE_WEIGHT(bfloat16_t, bfloat16_t, bfloat16_t, CAL_MOE_GEMV) \
+                    } \
+                } else if (A.scalar_type() == at::ScalarType::Half) { \
+                    if (topk_weights.scalar_type() == at::ScalarType::Float) { \
+                        RUN_ROUNTE_WEIGHT(float16_t, float16_t, float, CAL_MOE_GEMV) \
+                    } else if (topk_weights.scalar_type() == at::ScalarType::Half) { \
+                        RUN_ROUNTE_WEIGHT(float16_t, float16_t, float16_t, CAL_MOE_GEMV) \
+                    } \
+                } \
+            } \
+            printf("no support on moe gemv\n"); \
+            assert(false); \
+        }; \
+    }
+
+template <typename AType, typename BType, typename CType, typename ScoreType, typename ScaleType,
+          int BLOCK_N, int BLOCK_K, int iobit, bool mul_routed_weight, bool is_swigelu,
+          bool is_w4a16, bool is_per_group_scale, bool is_fp8, int scale_block, bool use_rms_norm>
+__global__ void musa_gemv_kernel(
+    CType *c_ptr,
+    const AType *a_ptr,
+    const BType *b_ptr,
+    int *expert_idx_table,
+    ScoreType *score_ptr,
+    ScaleType *scale_a,
+    ScaleType *scale_b,
+    int topk,
+    int expert_offset_stride,
+    int n, int k,
+    int nr_expert,
+    int half_n_idx,
+    int scale_k_len,
+    bfloat16_t *gamma,
+    float* sum_out,
+    volatile int *count,
+    float eps) {
+
+    constexpr int bits_of_byte = 8;
+    constexpr int half_blockn = BLOCK_N / 2;
+    constexpr int b_vec_bits = 128;
+    constexpr int Vlen = is_w4a16 ? b_vec_bits / 4 : b_vec_bits / (sizeof(BType) * bits_of_byte);
+    constexpr int w4a16_shift = is_w4a16 ? 2 : 1;
+    constexpr int scale_k_load_cntdown_init = ceil_div(scale_block, (BLOCK_K * Vlen));
+    constexpr bool fuse_castfp8 = (is_fp8 && !std::is_same_v<AType, __mt_fp8_e4m3>);
+
+    using AVecSType = std::conditional_t<std::is_same_v<AType, __mt_fp8_e4m3>, uint8_t, AType>;
+    using BVecSType = std::conditional_t<is_fp8, uint8_t, BType>;
+    using v16f32_t = float __attribute__((vector_size(64)));
+    using v8f32_t = float __attribute__((vector_size(32)));
+    using AVec = typename std::conditional_t<
+        is_w4a16,
+        v16f32_t,
+        typename std::conditional_t<
+            fuse_castfp8,
+            v8f32_t,
+            typename VecType<AVecSType, 128>::Ttype
+        >
+    >;
+    using BVec = typename VecType<BVecSType, b_vec_bits>::Ttype;
+
+    int token_idx = blockIdx.z;
+    int expert_idx = blockIdx.y;
+    int real_expert_idx = 0;
+    int t_n_idx = threadIdx.x / BLOCK_K;
+    int t_k_idx = threadIdx.x % BLOCK_K;
+    int n_idx = blockIdx.x * BLOCK_N + t_n_idx;
+
+    if (expert_idx_table != nullptr) {
+        real_expert_idx = expert_idx_table[token_idx * topk + expert_idx];
+        if (real_expert_idx < 0 || real_expert_idx >= nr_expert) {
+              if constexpr (is_swigelu) {
+                if (n_idx < half_n_idx) {
+                  int offsets = (token_idx * topk + expert_idx) * half_n_idx + n_idx;
+                  c_ptr[offsets] = 0;
+                }
+              } else {
+                int offsets = (token_idx * topk + expert_idx) * half_n_idx * 2 + n_idx;
+                c_ptr[offsets] = 0;
+              }
+            return;
+        }
+    }
+
+    constexpr int thread_sum_len = is_fp8 ? Vlen / 4 : Vlen;
+    float cur_thread_sum[thread_sum_len];
+    int scale_k_load_cntdown = scale_k_load_cntdown_init;
+
+    extern __shared__ float shared_array[];
+
+    if constexpr (is_swigelu) {
+        if (t_n_idx < half_blockn) {
+            n_idx = blockIdx.x * half_blockn + t_n_idx;
+        } else {
+            n_idx = blockIdx.x * half_blockn + t_n_idx - half_blockn + half_n_idx;
+        }
+    }
+
+
+    #pragma unroll
+    for (int i = 0; i < thread_sum_len; i++) {
+        cur_thread_sum[i] = 0.0f;
+    }
+
+    float scale_a_val = 1.0f;
+    float scale_b_val = 1.0f;
+    int scale_a_offset = 0;
+    int scale_b_offset = 0;
+
+    if constexpr (is_w4a16) {
+        scale_b_offset = (real_expert_idx * n + n_idx) * scale_k_len + t_k_idx * Vlen / scale_block;
+        if constexpr (is_swigelu) {
+            scale_b_offset = (real_expert_idx * 2 * n + n_idx) * scale_k_len + t_k_idx * Vlen / scale_block;
+        }
+        scale_b_val = scale_b[scale_b_offset];
+        scale_k_load_cntdown -= 1;
+    } else if (is_fp8) {
+        scale_a_offset = token_idx * scale_k_len + t_k_idx * Vlen / scale_block;
+        scale_b_offset = (real_expert_idx * n + n_idx) / scale_block * scale_k_len + t_k_idx * Vlen / scale_block;
+        if constexpr (is_swigelu) {
+            scale_b_offset = (real_expert_idx * 2 * n + n_idx) / scale_block * scale_k_len + t_k_idx * Vlen / scale_block;
+        }
+        if constexpr (!fuse_castfp8) {
+            scale_a_val = scale_a[scale_a_offset];
+        }
+        scale_b_val = scale_b[scale_b_offset];
+        scale_k_load_cntdown -= 1;
+    }
+
+    const BType *b_base_ptr = b_ptr + ((size_t)real_expert_idx * expert_offset_stride + n_idx * k + t_k_idx * Vlen) / w4a16_shift;
+
+    for (int k_idx = 0; k_idx < k; k_idx += Vlen * BLOCK_K) {
+        AType a_reg[Vlen];
+        BType b_reg[Vlen / w4a16_shift];
+        *(AVec *)(a_reg) = *(AVec *)(a_ptr + token_idx * k + t_k_idx * Vlen + k_idx);
+        *(BVec *)(b_reg) = *(BVec *)(b_base_ptr + k_idx / w4a16_shift);
+
+        if constexpr (is_w4a16 && !is_fp8) {
+            float b_reg_float[Vlen];
+            #pragma unroll
+            for (int i = 0; i < Vlen / 2; i++) {
+                if constexpr (is_per_group_scale) {
+                    uint8_t read_u8 = b_reg[i];
+                    b_reg_float[i * 2 + 0] = scale_b_val * ((float)(read_u8 & 0xF) - 8.f);
+                    b_reg_float[i * 2 + 1] = scale_b_val * ((float)(read_u8 >> 4) - 8.f);
+                } else {
+                    int8_t read_s8 = b_reg[i];
+                    b_reg_float[i * 2 + 0] = scale_b_val * (float)((int8_t)(read_s8 << 4));
+                    b_reg_float[i * 2 + 1] = scale_b_val * (float)((int8_t)(read_s8 & 0xF0));
+                }
+            }
+            if constexpr (is_per_group_scale) {
+                if (scale_k_load_cntdown == 0 && (k_idx + Vlen * BLOCK_K) < k) {
+                    scale_b_offset += ceil_div(BLOCK_K * Vlen, scale_block);
+                    scale_b_val = scale_b[scale_b_offset];
+                    scale_k_load_cntdown = scale_k_load_cntdown_init;
+                }
+                scale_k_load_cntdown -= 1;
+            }
+            #pragma unroll
+            for (int i = 0; i < thread_sum_len; i++) {
+                cur_thread_sum[i] += b_reg_float[i] * (float)a_reg[i];
+            }
+        } else if constexpr (is_fp8) {
+            float scale_val = scale_a_val * scale_b_val;
+            if (scale_k_load_cntdown == 0 && (k_idx + Vlen * BLOCK_K) < k) {
+                scale_a_offset += ceil_div(BLOCK_K * Vlen, scale_block);
+                scale_b_offset += ceil_div(BLOCK_K * Vlen, scale_block);
+                if constexpr (!fuse_castfp8) {
+                    scale_a_val = scale_a[scale_a_offset];
+                }
+                scale_b_val = scale_b[scale_b_offset];
+                scale_k_load_cntdown = scale_k_load_cntdown_init;
+            }
+            scale_k_load_cntdown -= 1;
+            for (int i = 0; i < thread_sum_len; i++) {
+                typedef _Float16 _half_v4 __attribute__((ext_vector_type(4)));
+                typedef _Float32 _float_v4 __attribute__((ext_vector_type(4)));
+                _half_v4 a_halfv4;
+                _half_v4 b_halfv4;
+                _float_v4 a_float4;
+                _float_v4 b_float4;
+                if constexpr (fuse_castfp8) {
+                    b_halfv4 = __musa_e4m32f16_rn_bst4(reinterpret_cast<const fp8x4_vec*>(b_reg)[i]);
+                    #pragma unroll
+                    for (int j = 0; j < 4; j++) {
+                        cur_thread_sum[i] += scale_val * float(a_reg[i * 4 + j]) * (b_halfv4[j]);
+                    }
+                } else {
+                    a_halfv4 = __musa_e4m32f16_rn_bst4(reinterpret_cast<const fp8x4_vec*>(a_reg)[i]);
+                    b_halfv4 = __musa_e4m32f16_rn_bst4(reinterpret_cast<const fp8x4_vec*>(b_reg)[i]);
+                    #pragma unroll
+                    for (int j = 0; j < 4; j++) {
+                        cur_thread_sum[i] += scale_val * (a_halfv4[j]) * (b_halfv4[j]);
+                    }
+                }
+            }
+        } else {
+            #pragma unroll
+            for (int i = 0; i < thread_sum_len; i++) {
+                cur_thread_sum[i] += (float)b_reg[i] * (float)a_reg[i];
+            }
+        }
+    }
+
+    float rst = 0;
+    #pragma unroll
+    for (int i = 0; i < thread_sum_len; i++) {
+        rst += cur_thread_sum[i];
+    }
+
+    if constexpr (is_w4a16 && !is_per_group_scale) {
+        rst = rst / 16.f;
+    }
+
+    if constexpr (BLOCK_K > 1) {
+        shared_array[threadIdx.x] = rst;
+        SYNC_IF_NEEDED()
+        if (threadIdx.x < BLOCK_N) {
+            rst = 0;
+            #pragma unroll
+            for (int i = 0; i < BLOCK_K; i++) {
+                rst += shared_array[threadIdx.x * BLOCK_K + i];
+            }
+        }
+        if constexpr (is_swigelu) {
+            SYNC_IF_NEEDED()
+        }
+    }
+
+    if (BLOCK_N > ThreadNumPerWarp) {
+        printf("BLOCK_N must less than ThreadNumPerWarp\n");
+        return;
+    }
+
+    if (threadIdx.x < BLOCK_N) {
+        int dst_n_idx = blockIdx.x * BLOCK_N + threadIdx.x;
+        if constexpr (is_swigelu) {
+            dst_n_idx = blockIdx.x * half_blockn + threadIdx.x;
+        }
+
+        if constexpr (mul_routed_weight) {
+            float score = (float)score_ptr[token_idx * topk + expert_idx];
+            rst = rst * score;
+        }
+
+        if constexpr (is_swigelu) {
+            shared_array[threadIdx.x] = rst;
+            if (threadIdx.x < half_blockn) {
+                float b = shared_array[threadIdx.x + half_blockn];
+                rst = rst * sigmoid(rst) * b;
+                c_ptr[token_idx * topk * n + expert_idx * n + dst_n_idx] = rst;
+            }
+        } else if constexpr (use_rms_norm) {
+            float rms = rst * rst;
+            int count_val = 0;
+
+            for (int offset = 1; offset < BLOCK_N; offset *= 2) {
+                float peer = __shfl_xor_sync(BLOCK_N, rms, offset);
+                rms += peer;
+            }
+
+            if (threadIdx.x == 0) {
+                atomicAdd(sum_out, rms);
+                __threadfence_block();
+                atomicAdd((int*)(count), 1);
+            }
+
+            while (count_val < gridDim.x) {
+                count_val = count[0];
+            }
+
+            rms = sum_out[0];
+            rst = rst * rsqrtf(rms / n + eps) * float(gamma[dst_n_idx]);
+            c_ptr[token_idx * topk * n + expert_idx * n + dst_n_idx] = rst;
+        } else {
+            c_ptr[token_idx * topk * n + expert_idx * n + dst_n_idx] = rst;
+        }
+    }
+}
+
+struct BlockConfig {
+    int block_n;
+    int block_k;
+    float score;
+    bool valid;
+};
+
+void musa_fused_gemv(
+    torch::Tensor &A,
+    torch::Tensor &B,
+    torch::Tensor &C,
+    const c10::optional<torch::Tensor> &A_scale,
+    const c10::optional<torch::Tensor> &B_scale,
+    bool use_int4_w4a16,
+    bool use_swigelu,
+    bool use_rms_norm,
+    const c10::optional<torch::Tensor> &gamma,
+    double eps) {
+
+    TORCH_CHECK(A.dim() == 2, "A must be dim 2.")
+    TORCH_CHECK(B.dim() == 2, "B must be dim 2.")
+
+    bool mul_routed_weight = false;
+    int topk = 1;
+    int32_t bseqlen = A.size(0);
+    int32_t hidden_size = A.size(1);
+    int32_t num_experts = 1;
+    int32_t reduce_size = B.size(0);
+    bool is_fp8 = false;
+
+    if (B.dtype() == torch::kFloat8_e4m3fn) {
+        is_fp8 = true;
+    }
+
+    int current_arch = at::musa::getMUSAArch();
+    if (current_arch < 300) {
+        if (is_fp8) {
+            TORCH_CHECK(false, "gemv moe not support Float8_e4m3fn on MUSA arch ", current_arch);
+        }
+    }
+
+    const at::musa::OptionalMUSAGuard device_guard(device_of(A));
+    musaStream_t stream = at::musa::getCurrentMUSAStream();
+
+    void *topk_ids_ptr = nullptr;
+    void *topk_weights_ptr = nullptr;
+    void *a_scale_ptr = nullptr;
+    void *b_scale_ptr = nullptr;
+
+    if (A_scale.has_value()) {
+        a_scale_ptr = A_scale.value().data_ptr();
+    }
+    if (B_scale.has_value()) {
+        b_scale_ptr = B_scale.value().data_ptr();
+    }
+
+    void *rms_gamma_ptr = nullptr;
+    void *rms_sum_out_ptr = nullptr;
+    void *rms_count_ptr = nullptr;
+
+    if (use_rms_norm && gamma.has_value()) {
+        torch::Tensor sum_out = torch::zeros({1}, A.options().dtype(torch::kFloat));
+        torch::Tensor count = torch::zeros({1}, A.options().dtype(torch::kInt));
+        rms_gamma_ptr = gamma.value().data_ptr();
+        rms_sum_out_ptr = sum_out.data_ptr();
+        rms_count_ptr = count.data_ptr();
+    }
+
+    int device;
+    musaGetDevice(&device);
+    musaDeviceProp device_prop;
+    musaGetDeviceProperties(&device_prop, device);
+    int num_mp = device_prop.multiProcessorCount;
+    int expert_offset_stride = reduce_size * hidden_size;
+    int half_n_idx = reduce_size / 2;
+    int scale_k_len = 1;
+    int scale_k_group_tile = 128;
+
+    if (use_int4_w4a16 || is_fp8) {
+        scale_k_len = B_scale->size(1);
+        if (scale_k_len != 1) {
+            scale_k_group_tile = ceil_div(hidden_size, scale_k_len);
+            TORCH_CHECK(scale_k_group_tile == 128 || scale_k_group_tile == 64, "scale_k_group_tile only support 128 or 64");
+        }
+    }
+
+    bool is_pergroup_scale = scale_k_len != 1;
+    int nr_n = use_swigelu ? reduce_size / 2 : reduce_size;
+
+    std::function<void()> launch_kernel;
+
+    BlockConfig configs[] = {
+        {8, 16, 0.f, false},
+        {16, 8, 0.f, false},
+        {32, 4, 0.f, false},
+        {4, 32, 0.f, false},
+    };
+
+    constexpr int iobit = 128;
+    const int bits_of_byte = 8;
+    const int vlen = use_int4_w4a16 ?
+                      (iobit / 4):
+                      (iobit / (torch::elementSize(B.scalar_type()) * bits_of_byte));
+
+    float target_ratio = static_cast<float>(reduce_size) / hidden_size;
+
+    for (auto& config : configs) {
+        int load_size = config.block_k * vlen;
+        config.valid = (reduce_size % config.block_n == 0) && (hidden_size % load_size == 0) && (load_size % scale_k_group_tile == 0);
+
+        if (config.valid) {
+            float block_ratio = static_cast<float>(config.block_n) / config.block_k;
+            config.score = 1.0f / (1.0f + fabsf(block_ratio - target_ratio));
+        }
+    }
+
+    BlockConfig* best_config = new BlockConfig{32, 1, -1.0f, false};
+    if (current_arch < 300) {
+        best_config = new BlockConfig{128, 1, -1.0f, false};
+    }
+    for (auto& config : configs) {
+        if (config.valid && config.score > best_config->score) {
+            best_config = &config;
+        }
+    }
+
+    switch (best_config->block_n) {
+        case 4:
+            switch (best_config->block_k) {
+                case 32: GEN_LAUNCH_KERN_GEMV(4, 32); break;
+                default: TORCH_CHECK(false, "Unsupported block_k for block_n=4");
+            }
+            break;
+        case 8:
+            switch (best_config->block_k) {
+                case 16: GEN_LAUNCH_KERN_GEMV(8, 16); break;
+                default: TORCH_CHECK(false, "Unsupported block_k for block_n=8");
+            }
+            break;
+        case 16:
+            switch (best_config->block_k) {
+                case 8: GEN_LAUNCH_KERN_GEMV(16, 8); break;
+                default: TORCH_CHECK(false, "Unsupported block_k for block_n=16");
+            }
+            break;
+        case 32:
+            switch (best_config->block_k) {
+                case 4: GEN_LAUNCH_KERN_GEMV(32, 4); break;
+                case 1: GEN_LAUNCH_KERN_GEMV(32, 1); break;
+                default: TORCH_CHECK(false, "Unsupported block_k for block_n=32");
+            }
+            break;
+        case 128:
+            switch (best_config->block_k) {
+                case 1: GEN_LAUNCH_KERN_GEMV(128, 1);
+                    break;
+                default: TORCH_CHECK(false, "Unsupported block_k for block_n=128");
+            }
+            break;
+        default:
+            TORCH_CHECK(false, "Unsupported block configuration");
+    }
+
+    launch_kernel();
+}
+
+void fused_moe_gemv(
+    torch::Tensor &A,
+    torch::Tensor &B,
+    torch::Tensor &C,
+    const c10::optional<torch::Tensor> &A_scale,
+    const c10::optional<torch::Tensor> &B_scale,
+    torch::Tensor &topk_weights,
+    torch::Tensor &topk_ids,
+    bool mul_routed_weight,
+    int64_t topk,
+    bool use_int4_w4a16,
+    bool use_swigelu) {
+
+    TORCH_CHECK(A.dim() == 2, "A must be dim 2.")
+    TORCH_CHECK(B.dim() == 3, "B must be dim 3.")
+
+    int32_t bseqlen = A.size(0);
+    bool is_fp8 = false;
+    if (B.dtype() == torch::kFloat8_e4m3fn) {
+        is_fp8 = true;
+    }
+
+    bool use_rms_norm = false;
+    void *rms_gamma_ptr = nullptr;
+    void *rms_sum_out_ptr = nullptr;
+    void *rms_count_ptr = nullptr;
+    float eps = 1e-6;
+
+    int current_arch = at::musa::getMUSAArch();
+    if (current_arch < 300) {
+        if (is_fp8) {
+            TORCH_CHECK(false, "gemv moe not support Float8_e4m3fn on MUSA arch ", current_arch);
+        }
+    }
+
+    int32_t hidden_size = A.size(1);
+    int32_t num_experts = B.size(0);
+    int32_t reduce_size = B.size(1);
+
+    const at::musa::OptionalMUSAGuard device_guard(device_of(A));
+    musaStream_t stream = at::musa::getCurrentMUSAStream();
+
+    void *topk_ids_ptr = topk_ids.data_ptr();
+    void *topk_weights_ptr = topk_weights.data_ptr();
+    void *a_scale_ptr = nullptr;
+    void *b_scale_ptr = nullptr;
+
+    if (A_scale.has_value()) {
+        a_scale_ptr = A_scale.value().data_ptr();
+    }
+    if (B_scale.has_value()) {
+        b_scale_ptr = B_scale.value().data_ptr();
+    }
+
+    int device;
+    musaGetDevice(&device);
+    musaDeviceProp device_prop;
+    musaGetDeviceProperties(&device_prop, device);
+    int num_mp = device_prop.multiProcessorCount;
+    int expert_offset_stride = reduce_size * hidden_size;
+    int half_n_idx = reduce_size / 2;
+    int scale_k_len = 1;
+    int scale_k_group_tile = 128;
+
+    bool is_pergroup_scale = false;
+    if (use_int4_w4a16 || is_fp8) {
+        scale_k_len = B_scale->size(2);
+        if (scale_k_len != 1) {
+            is_pergroup_scale = true;
+            scale_k_group_tile = ceil_div(hidden_size, scale_k_len);
+            TORCH_CHECK(scale_k_group_tile == 128 || scale_k_group_tile == 64, "scale_k_group_tile only support 128 or 64");
+        }
+    }
+
+    int nr_n = use_swigelu ? reduce_size / 2 : reduce_size;
+
+    std::function<void()> launch_kernel;
+
+    BlockConfig configs[] = {
+        {8, 16, 0.f, false},
+        {16, 8, 0.f, false},
+        {32, 4, 0.f, false},
+        {4, 32, 0.f, false},
+    };
+
+    constexpr int iobit = 128;
+    const int bits_of_byte = 8;
+    const int vlen = use_int4_w4a16 ?
+                      (iobit / 4):
+                      (iobit / (torch::elementSize(B.scalar_type()) * bits_of_byte));
+
+    float target_ratio = static_cast<float>(reduce_size) / hidden_size;
+
+    for (auto& config : configs) {
+        int load_size = config.block_k * vlen;
+        config.valid = (reduce_size % config.block_n == 0) && (hidden_size % load_size == 0) && (load_size % scale_k_group_tile == 0);
+
+        if (config.valid) {
+            float block_ratio = static_cast<float>(config.block_n) / config.block_k;
+            config.score = 1.0f / (1.0f + fabsf(block_ratio - target_ratio));
+        }
+    }
+
+    BlockConfig* best_config = new BlockConfig{32, 1, -1.0f, false};
+    if (current_arch < 300) {
+        best_config = new BlockConfig{128, 1, -1.0f, false};
+    }
+
+    for (auto& config : configs) {
+        if (config.valid && config.score > best_config->score) {
+            best_config = &config;
+        }
+    }
+
+    switch (best_config->block_n) {
+        case 4:
+            switch (best_config->block_k) {
+                case 32: GEN_LAUNCH_KERN(4, 32); break;
+                default: TORCH_CHECK(false, "Unsupported block_k for block_n=4");
+            }
+            break;
+        case 8:
+            switch (best_config->block_k) {
+                case 16: GEN_LAUNCH_KERN(8, 16); break;
+                default: TORCH_CHECK(false, "Unsupported block_k for block_n=8");
+            }
+            break;
+        case 16:
+            switch (best_config->block_k) {
+                case 8: GEN_LAUNCH_KERN(16, 8); break;
+                default: TORCH_CHECK(false, "Unsupported block_k for block_n=16");
+            }
+            break;
+        case 32:
+            switch (best_config->block_k) {
+                case 4: GEN_LAUNCH_KERN(32, 4); break;
+                case 1: GEN_LAUNCH_KERN(32, 1); break;
+                default: TORCH_CHECK(false, "Unsupported block_k for block_n=32");
+            }
+            break;
+        case 128:
+            switch (best_config->block_k) {
+                case 1: GEN_LAUNCH_KERN(128, 1); break;
+                default: TORCH_CHECK(false, "Unsupported block_k for block_n=128");
+            }
+            break;
+        default:
+            TORCH_CHECK(false, "Unsupported block configuration");
+    }
+
+    launch_kernel();
+}

--- a/sgl-kernel/csrc/musa/pos_encoding_contiguous.mu
+++ b/sgl-kernel/csrc/musa/pos_encoding_contiguous.mu
@@ -1,0 +1,247 @@
+#include <torch/all.h>
+
+#include "musa.h"
+#include "musa/dispatch_utils.h"
+#include "torch_musa/csrc/core/MUSAGuard.h"
+#include "torch_musa/csrc/core/MUSAStream.h"
+
+template <typename scalar_t, bool IS_NEOX>
+inline __device__ void apply_token_rotary_embedding_contiguous(
+    scalar_t* __restrict__ arr, const scalar_t* __restrict__ cos_ptr,
+    const scalar_t* __restrict__ sin_ptr, int rot_offset, int embed_dim,
+    int64_t head_stride) {
+  int x_index, y_index;
+  scalar_t cos, sin;
+  if (IS_NEOX) {
+    // GPT-NeoX style rotary embedding.
+    x_index = rot_offset;
+    y_index = embed_dim + rot_offset;
+    cos = MUSA_LDG(cos_ptr + x_index);
+    sin = MUSA_LDG(sin_ptr + x_index);
+  } else {
+    // GPT-J style rotary embedding.
+    x_index = 2 * rot_offset;
+    y_index = 2 * rot_offset + 1;
+    cos = MUSA_LDG(cos_ptr + x_index / 2);
+    sin = MUSA_LDG(sin_ptr + x_index / 2);
+  }
+
+  scalar_t* x_ptr = arr + x_index * head_stride;
+  scalar_t* y_ptr = arr + y_index * head_stride;
+
+  const scalar_t x = *x_ptr;
+  const scalar_t y = *y_ptr;
+  *x_ptr = x * cos - y * sin;
+  *y_ptr = y * cos + x * sin;
+}
+
+template <typename scalar_t, bool IS_NEOX>
+inline __device__ void apply_rotary_embedding_contiguous(
+    scalar_t* __restrict__ query,  // [num_tokens, num_heads, head_size]
+    scalar_t* __restrict__ key,    // [num_tokens, num_kv_heads, head_size]
+    const scalar_t* cache_ptr, const int head_size, const int num_heads,
+    const int num_kv_heads, const int rot_dim, const int token_idx,
+    const int64_t query_token_stride, const int64_t query_head_stride,
+    const int64_t query_dim_stride,
+    const int64_t key_token_stride, const int64_t key_head_stride,
+    const int64_t key_dim_stride) {
+  const int embed_dim = rot_dim / 2;
+  const scalar_t* cos_ptr = cache_ptr;
+  const scalar_t* sin_ptr = cache_ptr + embed_dim;
+
+  const int nq = num_heads * embed_dim;
+  for (int i = threadIdx.x; i < nq; i += blockDim.x) {
+    const int head_idx = i / embed_dim;
+    const int rot_offset = i % embed_dim;
+
+    scalar_t* head_query = query +
+                           token_idx * query_token_stride +
+                           head_idx * query_head_stride;
+
+    apply_token_rotary_embedding_contiguous<scalar_t, IS_NEOX>(
+        head_query, cos_ptr, sin_ptr, rot_offset, embed_dim, query_dim_stride);
+  }
+
+  const int nk = num_kv_heads * embed_dim;
+  for (int i = threadIdx.x; i < nk; i += blockDim.x) {
+    const int head_idx = i / embed_dim;
+    const int rot_offset = i % embed_dim;
+
+    scalar_t* head_key = key +
+                         token_idx * key_token_stride +
+                         head_idx * key_head_stride;
+
+    apply_token_rotary_embedding_contiguous<scalar_t, IS_NEOX>(
+        head_key, cos_ptr, sin_ptr, rot_offset, embed_dim, key_dim_stride);
+  }
+}
+
+template <typename scalar_t, bool IS_NEOX>
+__global__ void rotary_embedding_kernel_contiguous(
+    const int64_t* __restrict__ positions,  // [num_tokens]
+    scalar_t* __restrict__ query,           // [num_tokens, num_heads, head_size]
+    scalar_t* __restrict__ key,             // [num_tokens, num_kv_heads, head_size]
+    const scalar_t* __restrict__ cos_sin_cache,  // [max_position, 2, rot_dim // 2]
+    const int rot_dim,
+    const int64_t query_token_stride, const int64_t query_head_stride,
+    const int64_t query_dim_stride,
+    const int64_t key_token_stride, const int64_t key_head_stride,
+    const int64_t key_dim_stride,
+    const int num_heads, const int num_kv_heads, const int head_size) {
+  // Each thread block is responsible for one token.
+  const int token_idx = blockIdx.x;
+  int64_t pos = positions[token_idx];
+  const scalar_t* cache_ptr = cos_sin_cache + pos * rot_dim;
+
+  apply_rotary_embedding_contiguous<scalar_t, IS_NEOX>(
+      query, key, cache_ptr, head_size, num_heads, num_kv_heads, rot_dim,
+      token_idx,
+      query_token_stride, query_head_stride, query_dim_stride,
+      key_token_stride, key_head_stride, key_dim_stride);
+}
+
+template <typename scalar_t, bool IS_NEOX>
+__global__ void batched_rotary_embedding_kernel_contiguous(
+    const int64_t* __restrict__ positions,  // [num_tokens]
+    scalar_t* __restrict__ query,           // [num_tokens, num_heads, head_size]
+    scalar_t* __restrict__ key,             // [num_tokens, num_kv_heads, head_size]
+    const scalar_t* __restrict__ cos_sin_cache,  // [max_position, 2, rot_dim // 2]
+    const int64_t* __restrict__ cos_sin_cache_offsets,  // [num_tokens]
+    const int rot_dim,
+    const int64_t query_token_stride, const int64_t query_head_stride,
+    const int64_t query_dim_stride,  // 添加各维度步长
+    const int64_t key_token_stride, const int64_t key_head_stride,
+    const int64_t key_dim_stride,
+    const int num_heads, const int num_kv_heads, const int head_size) {
+  // Each thread block is responsible for one token.
+  const int token_idx = blockIdx.x;
+  int64_t pos = positions[token_idx];
+  int64_t cos_sin_cache_offset = cos_sin_cache_offsets[token_idx];
+  const scalar_t* cache_ptr =
+      cos_sin_cache + (cos_sin_cache_offset + pos) * rot_dim;
+
+  apply_rotary_embedding_contiguous<scalar_t, IS_NEOX>(
+      query, key, cache_ptr, head_size, num_heads, num_kv_heads, rot_dim,
+      token_idx,
+      query_token_stride, query_head_stride, query_dim_stride,
+      key_token_stride, key_head_stride, key_dim_stride);
+}
+
+
+void rotary_embedding_contiguous(
+    torch::Tensor& positions,  // [num_tokens]
+    torch::Tensor& query,      // [num_tokens, num_heads, head_size]
+    torch::Tensor& key,        // [num_tokens, num_kv_heads, head_size]
+    int64_t head_size,
+    torch::Tensor& cos_sin_cache,  // [max_position, rot_dim]
+    bool is_neox) {
+  int64_t num_tokens = positions.size(0);
+
+  TORCH_CHECK(query.dim() == 3, "query must be 3D [num_tokens, num_heads, head_size]");
+  TORCH_CHECK(key.dim() == 3, "key must be 3D [num_tokens, num_kv_heads, head_size]");
+  TORCH_CHECK(query.size(0) == num_tokens && key.size(0) == num_tokens,
+              "query, key and positions must have the same number of tokens");
+
+  int64_t query_token_stride = query.stride(0);
+  int64_t query_head_stride = query.stride(1);
+  int64_t query_dim_stride = query.stride(2);
+
+  int64_t key_token_stride = key.stride(0);
+  int64_t key_head_stride = key.stride(1);
+  int64_t key_dim_stride = key.stride(2);
+
+  int num_heads = query.size(1);
+  int num_kv_heads = key.size(1);
+  int rot_dim = cos_sin_cache.size(1);
+
+  dim3 grid(num_tokens);
+  dim3 block(std::min<int64_t>(num_heads * rot_dim / 2, 512));
+
+  const at::musa::OptionalMUSAGuard device_guard(device_of(query));
+  const musaStream_t stream = at::musa::getCurrentMUSAStream();
+
+  MUSA_DISPATCH_FLOATING_TYPES(query.scalar_type(), "rotary_embedding_contiguous", [&] {
+    if (is_neox) {
+      rotary_embedding_kernel_contiguous<scalar_t, true><<<grid, block, 0, stream>>>(
+          positions.data_ptr<int64_t>(),
+          query.data_ptr<scalar_t>(),
+          key.data_ptr<scalar_t>(),
+          cos_sin_cache.data_ptr<scalar_t>(),
+          rot_dim,
+          query_token_stride, query_head_stride, query_dim_stride,
+          key_token_stride, key_head_stride, key_dim_stride,
+          num_heads, num_kv_heads, head_size);
+    } else {
+      rotary_embedding_kernel_contiguous<scalar_t, false><<<grid, block, 0, stream>>>(
+          positions.data_ptr<int64_t>(),
+          query.data_ptr<scalar_t>(),
+          key.data_ptr<scalar_t>(),
+          cos_sin_cache.data_ptr<scalar_t>(),
+          rot_dim,
+          query_token_stride, query_head_stride, query_dim_stride,
+          key_token_stride, key_head_stride, key_dim_stride,
+          num_heads, num_kv_heads, head_size);
+    }
+  });
+}
+
+void batched_rotary_embedding_contiguous(
+    torch::Tensor& positions,  // [num_tokens]
+    torch::Tensor& query,      // [num_tokens, num_heads, head_size]
+    torch::Tensor& key,        // [num_tokens, num_kv_heads, head_size]
+    int64_t head_size,
+    torch::Tensor& cos_sin_cache,  // [max_position, rot_dim]
+    bool is_neox, int64_t rot_dim,
+    torch::Tensor& cos_sin_cache_offsets  // [num_tokens]
+) {
+  int64_t num_tokens = cos_sin_cache_offsets.size(0);
+
+
+  TORCH_CHECK(positions.size(0) == num_tokens,
+              "positions must have the same num_tokens as cos_sin_cache_offsets");
+  TORCH_CHECK(query.dim() == 3, "query must be 3D [num_tokens, num_heads, head_size]");
+  TORCH_CHECK(key.dim() == 3, "key must be 3D [num_tokens, num_kv_heads, head_size]");
+
+  int64_t query_token_stride = query.stride(0);
+  int64_t query_head_stride = query.stride(1);
+  int64_t query_dim_stride = query.stride(2);
+
+  int64_t key_token_stride = key.stride(0);
+  int64_t key_head_stride = key.stride(1);
+  int64_t key_dim_stride = key.stride(2);
+
+  int num_heads = query.size(1);
+  int num_kv_heads = key.size(1);
+
+  dim3 grid(num_tokens);
+  dim3 block(std::min<int64_t>(num_heads * rot_dim / 2, 512));
+
+  const at::musa::OptionalMUSAGuard device_guard(device_of(query));
+  const musaStream_t stream = at::musa::getCurrentMUSAStream();
+
+  MUSA_DISPATCH_FLOATING_TYPES(query.scalar_type(), "batched_rotary_embedding_contiguous", [&] {
+    if (is_neox) {
+      batched_rotary_embedding_kernel_contiguous<scalar_t, true><<<grid, block, 0, stream>>>(
+          positions.data_ptr<int64_t>(),
+          query.data_ptr<scalar_t>(),
+          key.data_ptr<scalar_t>(),
+          cos_sin_cache.data_ptr<scalar_t>(),
+          cos_sin_cache_offsets.data_ptr<int64_t>(),
+          rot_dim,
+          query_token_stride, query_head_stride, query_dim_stride,
+          key_token_stride, key_head_stride, key_dim_stride,
+          num_heads, num_kv_heads, head_size);
+    } else {
+      batched_rotary_embedding_kernel_contiguous<scalar_t, false><<<grid, block, 0, stream>>>(
+          positions.data_ptr<int64_t>(),
+          query.data_ptr<scalar_t>(),
+          key.data_ptr<scalar_t>(),
+          cos_sin_cache.data_ptr<scalar_t>(),
+          cos_sin_cache_offsets.data_ptr<int64_t>(),
+          rot_dim,
+          query_token_stride, query_head_stride, query_dim_stride,
+          key_token_stride, key_head_stride, key_dim_stride,
+          num_heads, num_kv_heads, head_size);
+    }
+  });
+}

--- a/sgl-kernel/csrc/musa/ternary.mu
+++ b/sgl-kernel/csrc/musa/ternary.mu
@@ -1,0 +1,106 @@
+#include <torch/all.h>
+
+#include "musa/dispatch_utils.h"
+#include "musa.h"
+#include "torch_musa/csrc/aten/musa/MUSADtype.muh"
+#include "torch_musa/csrc/core/MUSAGuard.h"
+#include "torch_musa/csrc/core/MUSAStream.h"
+
+
+typedef __half float16_t;
+typedef __mt_bfloat16 bfloat16_t;
+
+__device__ __host__ __forceinline__ constexpr int64_t ceil_div(int64_t a,
+                                                               int64_t b) {
+  return (a + b - 1) / b;
+}
+
+template <typename scalar_t, int64_t vlen, int iobit = 128>
+__global__ void FusedMulAdd(scalar_t *out, scalar_t *self, scalar_t *bias,
+                            const scalar_t scale, const int64_t elem) {
+  constexpr int bits_of_byte = 8;
+  using Vec =
+      at::musa::VecType<scalar_t, vlen * sizeof(scalar_t) * bits_of_byte>;
+
+  int64_t tid = (int64_t)blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t grid_stride = (int64_t)gridDim.x * blockDim.x;
+  int64_t grid_stride_vec = grid_stride * vlen;
+
+  for (int64_t offset = tid * vlen; offset < elem; offset += grid_stride_vec) {
+    Vec t = Vec::load(self, offset);
+    Vec b = Vec::load(bias, offset);
+    Vec o;
+#pragma unroll
+    for (int k = 0; k < vlen; ++k) {
+      o.val_.elem[k] = b.val_.elem[k] + t.val_.elem[k] * scale;
+    }
+    Vec::store(out, offset, o);
+  }
+}
+
+void fused_mul_add(torch::Tensor &output, torch::Tensor &self,
+                    torch::Tensor &bias, const double scale) {
+  TORCH_CHECK(self.sizes() == output.sizes(),
+              "self and output shape don't match");
+  TORCH_CHECK(self.sizes() == bias.sizes(), "self and bias shape don't match");
+  TORCH_CHECK(self.scalar_type() == bias.scalar_type(),
+              "self and bias should be same type");
+  TORCH_CHECK(self.scalar_type() == output.scalar_type(),
+              "self and output should be same type");
+  TORCH_CHECK(self.scalar_type() == at::ScalarType::Float ||
+                  self.scalar_type() == at::ScalarType::BFloat16 ||
+                  self.scalar_type() == at::ScalarType::Half,
+              "self's dtype should be in float/half/bfloat16");
+
+  // device guard
+  const at::musa::OptionalMUSAGuard device_guard(device_of(self));
+
+  // Suppose the uncontiguous elementwise is much slower
+  if C10_UNLIKELY (!self.is_contiguous()) {
+    self = self.contiguous();
+  }
+  if C10_UNLIKELY (!bias.is_contiguous()) {
+    bias = bias.contiguous();
+  }
+
+  // follow mudnn config for arch==22
+  const int64_t max_load_vec =
+      self.scalar_type() == at::ScalarType::Float ? 4 : 8;
+  const int64_t numel = self.numel();
+  size_t thread_per_block = 512;
+  if (ceil_div(numel, max_load_vec) <= 128) {
+    thread_per_block = 128;
+  } else if (ceil_div(numel, max_load_vec) <= 256) {
+    thread_per_block = 256;
+  }
+  size_t nr_block = ceil_div(numel, max_load_vec * thread_per_block);
+
+  const musaStream_t stream = at::musa::getCurrentMUSAStream();
+
+  switch (self.scalar_type()) {
+  case at::ScalarType::Float:
+    FusedMulAdd<float, 4><<<nr_block, thread_per_block, 0, stream>>>(
+        static_cast<float *>(output.data_ptr()),
+        static_cast<float *>(self.data_ptr()),
+        static_cast<float *>(bias.data_ptr()), scale, numel);
+    break;
+  case at::ScalarType::Half:
+    FusedMulAdd<float16_t, 8>
+        <<<nr_block, thread_per_block, 0, stream>>>(
+            static_cast<float16_t *>(output.data_ptr()),
+            static_cast<float16_t *>(self.data_ptr()),
+            static_cast<float16_t *>(bias.data_ptr()),
+            static_cast<float16_t>(scale), numel);
+    break;
+  case at::ScalarType::BFloat16:
+    FusedMulAdd<bfloat16_t, 8>
+        <<<nr_block, thread_per_block, 0, stream>>>(
+            static_cast<bfloat16_t *>(output.data_ptr()),
+            static_cast<bfloat16_t *>(self.data_ptr()),
+            static_cast<bfloat16_t *>(bias.data_ptr()),
+            static_cast<bfloat16_t>(scale), numel);
+    break;
+  default:
+    break;
+  }
+}

--- a/sgl-kernel/csrc/musa/top_k_top_p_sampling.mu
+++ b/sgl-kernel/csrc/musa/top_k_top_p_sampling.mu
@@ -1,0 +1,365 @@
+#include <ATen/Utils.h>
+#include <ATen/core/Generator.h>
+#include "torch_musa/csrc/aten/musa/MUSAGeneratorImpl.h"
+#include <torch/all.h>
+
+#include "torch_musa/csrc/aten/musa/UnpackRaw.muh"
+#include <flashinfer/sampling.muh>
+#include <mutex>
+
+#include "musa.h"
+#include "musa/dispatch_utils.h"
+#include "pytorch_extension_utils.h"
+#include "torch_musa/csrc/core/MUSAGuard.h"
+#include "torch_musa/csrc/core/MUSAStream.h"
+
+namespace musa {
+namespace sampling {
+
+#define kRmemEles 16        // should not too large, otherwise it will cause register spilling
+// reuse code of flashinfer
+using namespace flashinfer;
+using namespace flashinfer::sampling;
+
+template <uint32_t VEC_SIZE, uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
+          BlockReduceAlgorithm REDUCE_ALGORITHM, bool DETERMINISTIC, typename Predicate>
+__device__ __forceinline__ void DeviceSamplingFromProbWithOffset(
+    uint32_t i, uint32_t d, Predicate pred, float u, vec_t<float, VEC_SIZE> prob_vec,
+    float& aggregate,
+    SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>* temp_storage,
+    int offset = 0) {
+  const uint32_t tx = threadIdx.x;
+  float prob_greater_than_threshold[VEC_SIZE];
+  float inclusive_cdf[VEC_SIZE];
+  bool greater_than_u[VEC_SIZE], valid[VEC_SIZE];
+#pragma unroll
+  for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+    prob_greater_than_threshold[j] = pred(prob_vec[j]) ? prob_vec[j] : 0;
+    valid[j] = pred(prob_vec[j]) && (offset + (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d);
+  }
+  float aggregate_local =
+      BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage->block_prim.reduce)
+          .template Sum<VEC_SIZE>(prob_greater_than_threshold);
+  if (tx == 0) {
+    temp_storage->block_aggregate.value = aggregate_local;
+  }
+  __syncthreads();
+  aggregate_local = temp_storage->block_aggregate.value;
+
+  if (aggregate + aggregate_local > u) {
+    if constexpr (DETERMINISTIC) {
+      DeterministicInclusiveSum<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>(
+          prob_greater_than_threshold, inclusive_cdf, temp_storage);
+    } else {
+      BlockScan<float, BLOCK_THREADS, SCAN_ALGORITHM>(temp_storage->block_prim.scan)
+          .template InclusiveSum<VEC_SIZE>(prob_greater_than_threshold, inclusive_cdf);
+
+      __syncthreads();
+    }
+
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+      greater_than_u[j] = (inclusive_cdf[j] + aggregate > u) && valid[j];
+    }
+
+    bool greater_than_u_diff[VEC_SIZE];
+#ifdef FLASHINFER_CUB_SUBTRACTLEFT_DEFINED
+    BlockAdjacentDifference<bool, BLOCK_THREADS>(temp_storage->block_prim.adj_diff)
+        .SubtractLeft<VEC_SIZE>(greater_than_u, greater_than_u_diff, BoolDiffOp());
+#else
+    BlockAdjacentDifference<bool, BLOCK_THREADS>(temp_storage->block_prim.adj_diff)
+        .template FlagHeads<VEC_SIZE>(greater_than_u_diff, greater_than_u, BoolDiffOp(), 0);
+#endif
+    __syncthreads();
+
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+      if (greater_than_u_diff[j]) {
+        atomicMin(&(temp_storage->sampled_id), offset + (i * BLOCK_THREADS + tx) * VEC_SIZE + j);
+      }
+    }
+    __syncthreads();
+  }
+
+  // update the last valid index
+  int valid_index[VEC_SIZE];
+#pragma unroll
+  for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+    if (valid[j]) {
+      valid_index[j] = offset + (i * BLOCK_THREADS + tx) * VEC_SIZE + j;
+    } else {
+      valid_index[j] = -1;
+    }
+  }
+  int max_valid_index =
+      BlockReduce<int, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage->block_prim.reduce_int)
+          .Reduce(valid_index, MaxReduceOp{});
+  if (tx == 0 && max_valid_index != -1) {
+    temp_storage->last_valid_id = max_valid_index;
+  }
+  __syncthreads();
+  aggregate += aggregate_local;
+}
+
+template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
+          BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
+          typename DType, typename IdType>
+__global__ void TopKTopPSamplingFromProbKernel(DType* probs, IdType* top_k_arr, float* top_p_arr,
+                                               IdType* output, IdType* indices, IdType top_k_val,
+                                               float top_p_val, uint32_t d, uint64_t philox_seed,
+                                               uint64_t philox_offset) {
+  const uint32_t batch_size = gridDim.x;
+  const uint32_t bx = blockIdx.x, tx = threadIdx.x;
+  murandStatePhilox4_32_10_t state;
+  murand_init(philox_seed, bx, philox_offset, &state);
+  const uint32_t row_idx = indices == nullptr ? bx : indices[bx];
+  const uint32_t k = top_k_arr == nullptr ? top_k_val : top_k_arr[row_idx];
+  const float p = top_p_arr == nullptr ? top_p_val : top_p_arr[row_idx];
+  extern __shared__ __align__(alignof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>))
+      uint8_t smem_sampling[];
+  auto& temp_storage =
+      reinterpret_cast<SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>&>(smem_sampling);
+
+  vec_t<float, kRmemEles> rprobs;  // persistent
+  vec_t<float, VEC_SIZE> rprobs_d;
+  // elements of one row will be split into three stages by the address it will be stored
+  // [rprobs, probs_vec]
+  // rprobs will be persistent to reuse those elements instead of reload
+  int real_r_size = d > (BLOCK_THREADS * kRmemEles) ? BLOCK_THREADS * kRmemEles : d;
+  int real_rd_size = d > (BLOCK_THREADS * kRmemEles) ? d - BLOCK_THREADS * kRmemEles : 0;
+
+  probs = probs + row_idx * d;
+  DType* global_rprobs = probs;
+  DType* global_rprobs_d = probs + real_r_size;
+
+  // fisrtly, we load some elements to register
+  rprobs.fill(0);
+  if (tx * kRmemEles < real_r_size) {
+    rprobs.cast_load(global_rprobs + tx * kRmemEles);
+    int valid_size = real_r_size - tx * kRmemEles;
+    // mask invalid data
+    for (int i = valid_size; i < kRmemEles; ++i) {
+      rprobs[i] = 0.0;
+    }
+  }
+
+  float aggregate;
+  float q = 1;
+  double low = 0, high = 1.f;
+  int sampled_id;
+
+  // sample and check
+  do {
+    temp_storage.sampled_id = d;
+    __syncthreads();
+    float u = murand_uniform(&state) * q;
+    aggregate = 0;
+
+    // fisrtly, sample from rprobs
+    DeviceSamplingFromProbWithOffset<kRmemEles, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM, DETERMINISTIC>(
+        0, d, [&](float x) { return x > low; }, u, rprobs, aggregate, &temp_storage);
+
+    if (aggregate <= u) {
+      // secondly, sample from rprobs_d
+      for (uint32_t i = 0; i < ceil_div(real_rd_size, BLOCK_THREADS * VEC_SIZE); ++i) {
+        rprobs_d.fill(0);
+        if ((i * BLOCK_THREADS + tx) * VEC_SIZE + real_r_size < d) {
+          rprobs_d.cast_load(global_rprobs_d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+        }
+
+        DeviceSamplingFromProbWithOffset<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM, DETERMINISTIC>(
+            i, d, [&](float x) { return x > low; }, u, rprobs_d, aggregate, &temp_storage, real_r_size);
+        if (aggregate > u) {
+          break;
+        }
+      }
+    }
+
+    // id is sampled
+    __syncthreads();
+    sampled_id = temp_storage.sampled_id;
+    if (sampled_id == d) {
+      // NOTE(Zihao): this would happen when u is very close to 1
+      // and the sum of probabilities is smaller than u
+      // In this case, we use the last valid index as the sampled id
+      sampled_id = temp_storage.last_valid_id;
+    }
+    double pivot_0 = probs[sampled_id];
+    double pivot_1 = (pivot_0 + high) / 2;
+
+    ValueCount<float> aggregate_gt_pivot_0{0, 0}, aggregate_gt_pivot_1{0, 0};
+    // check in rprobs
+    ValueCount<float> probs_gt_pivot_0[VEC_SIZE], probs_gt_pivot_1[VEC_SIZE];
+#pragma unroll
+    for (int i = 0; i < VEC_SIZE; ++i) {
+      probs_gt_pivot_0[i] = {0, 0};
+      probs_gt_pivot_1[i] = {0, 0};
+    }
+
+    // init to 0
+    for (uint32_t j = 0; j < kRmemEles; j += VEC_SIZE) {
+#pragma unroll
+      for (uint32_t k = 0; k < VEC_SIZE; ++k) {
+        probs_gt_pivot_0[k] +=
+            {(rprobs[j + k] > pivot_0) ? rprobs[j + k] : 0, (rprobs[j + k] > pivot_0 && (tx)*kRmemEles + j + k < d)};
+        probs_gt_pivot_1[k] +=
+            {(rprobs[j + k] > pivot_1) ? rprobs[j + k] : 0, (rprobs[j + k] > pivot_1 && (tx)*kRmemEles + j + k < d)};
+      }
+    }
+
+    // check in rprobs_d
+    for (uint32_t i = 0; i < ceil_div(real_rd_size, BLOCK_THREADS * VEC_SIZE); ++i) {
+      rprobs_d.fill(0);
+      if ((i * BLOCK_THREADS + tx) * VEC_SIZE + real_r_size < d) {
+        rprobs_d.cast_load(global_rprobs_d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+      }
+
+#pragma unroll
+      for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+        probs_gt_pivot_0[j] +=
+            {(rprobs_d[j] > pivot_0) ? rprobs_d[j] : 0,
+             (rprobs_d[j] > pivot_0 && (i * BLOCK_THREADS + tx) * VEC_SIZE + j + real_r_size < d)};
+        probs_gt_pivot_1[j] +=
+            {(rprobs_d[j] > pivot_1) ? rprobs_d[j] : 0,
+             (rprobs_d[j] > pivot_1 && (i * BLOCK_THREADS + tx) * VEC_SIZE + j + real_r_size < d)};
+      }
+    }
+
+    aggregate_gt_pivot_0 = BlockReduce<ValueCount<float>, BLOCK_THREADS>(temp_storage.block_prim.reduce_value_count)
+                               .template Sum<VEC_SIZE>(probs_gt_pivot_0);
+    if (tx == 0) {
+      temp_storage.block_aggregate.pair = aggregate_gt_pivot_0;
+    }
+    __syncthreads();
+    aggregate_gt_pivot_0 = temp_storage.block_aggregate.pair;
+
+    aggregate_gt_pivot_1 = BlockReduce<ValueCount<float>, BLOCK_THREADS>(temp_storage.block_prim.reduce_value_count)
+                               .template Sum<VEC_SIZE>(probs_gt_pivot_1);
+    if (tx == 0) {
+      temp_storage.block_aggregate.pair = aggregate_gt_pivot_1;
+    }
+    __syncthreads();
+    aggregate_gt_pivot_1 = temp_storage.block_aggregate.pair;
+
+    if (aggregate_gt_pivot_0.count < k && aggregate_gt_pivot_0.value < p) {
+      // case 1: pivot_0 accepted
+      break;
+    }
+    if (aggregate_gt_pivot_1.count < k && aggregate_gt_pivot_1.value < p) {
+      // case 2: pivot_0 rejected, pivot_1 accepted
+      low = pivot_0;
+      high = pivot_1;
+      q = aggregate_gt_pivot_0.value;
+    } else {
+      // case 3: pivot_0 rejected, pivot_1 rejected
+      low = pivot_1;
+      q = aggregate_gt_pivot_1.value;
+    }
+  } while (low < high);
+  __syncthreads();
+  if (tx == 0) {
+    output[bx] = sampled_id;
+  }
+}
+}  // namespace sampling
+}  // namespace musa
+
+template <typename T, typename IdType>
+musaError_t MusaTopKTopPSamplingFromProb(T* probs, IdType* top_k_arr, T* top_p_arr, IdType* output,
+                                     IdType* indices, uint32_t batch_size, IdType top_k_val,
+                                     T top_p_val, uint32_t d, bool deterministic,
+                                     uint64_t philox_seed, uint64_t philox_offset,
+                                     musaStream_t stream = 0) {
+  const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
+  using namespace flashinfer;
+  using namespace flashinfer::sampling;
+  auto compute_capacity = GetCudaComputeCapability();
+
+  DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, {
+    const uint32_t smem_size = sizeof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
+    dim3 nblks(batch_size);
+    dim3 nthrs(BLOCK_THREADS);
+    void* args[] = {
+        &probs, &top_k_arr, &top_p_arr, &output, &indices, &top_k_val, &top_p_val, &d, &philox_seed, &philox_offset};
+    // fall back to flashinfer implementation
+    if (d < BLOCK_THREADS * kRmemEles) {
+      DISPATCH_ALIGNED_VEC_SIZE(
+          vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
+            auto kernel = TopKTopPSamplingFromProbKernel<
+                BLOCK_THREADS,
+                SCAN_ALGO,
+                REDUCE_ALGO,
+                VEC_SIZE,
+                DETERMINISTIC,
+                T,
+                IdType>;
+            FLASHINFER_CUDA_CALL(musaFuncSetAttribute(kernel, musaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+            FLASHINFER_CUDA_CALL(musaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+          })});
+    } else {
+      DISPATCH_ALIGNED_VEC_SIZE(
+          vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
+            auto kernel = musa::sampling::TopKTopPSamplingFromProbKernel<
+                BLOCK_THREADS,
+                SCAN_ALGO,
+                REDUCE_ALGO,
+                VEC_SIZE,
+                DETERMINISTIC,
+                T,
+                IdType>;
+            FLASHINFER_CUDA_CALL(musaFuncSetAttribute(kernel, musaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+            FLASHINFER_CUDA_CALL(musaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+          })});
+    }
+    return musaSuccess;
+  });
+}
+
+void musa_top_k_top_p_sampling_from_probs(
+    at::Tensor probs,
+    at::Tensor output,
+    std::optional<at::Tensor> maybe_indices,
+    std::optional<at::Tensor> maybe_top_k_arr,
+    double top_k_val,
+    std::optional<at::Tensor> maybe_top_p_arr,
+    double top_p_val,
+    bool deterministic,
+    std::optional<at::Generator> gen_) {
+  CHECK_INPUT(probs);
+  CHECK_INPUT(output);
+  auto device = probs.device();
+  CHECK_EQ(output.device(), device);
+  CHECK_EQ(probs.dtype(), torch::kFloat);
+  CHECK_DIM(2, probs);   // probs: (batch_size, vocab_size)
+  CHECK_DIM(1, output);  // output: (batch_size)
+  unsigned int batch_size = output.size(0);
+  unsigned int vocab_size = probs.size(1);
+  bool has_top_k_arr = maybe_top_k_arr.has_value();
+  bool has_top_p_arr = maybe_top_p_arr.has_value();
+  uint64_t philox_seed, philox_offset;
+  auto gen = at::get_generator_or_default<at::MUSAGeneratorImpl>(gen_, at::musa::detail::getDefaultMUSAGenerator());
+  std::lock_guard<std::mutex> lock(gen->mutex_);
+  at::PhiloxMusaState rng_engine_inputs = gen->philox_musa_state(32 * batch_size);
+  philox_seed = rng_engine_inputs.seed_.val;
+  philox_offset = rng_engine_inputs.offset_.val;
+
+  const c10::musa::OptionalMUSAGuard device_guard(device);
+  auto stream = at::musa::getCurrentMUSAStream();
+  musaError_t status = MusaTopKTopPSamplingFromProb<float, int>(
+      static_cast<float*>(probs.data_ptr()),
+      has_top_k_arr ? static_cast<int*>(maybe_top_k_arr->data_ptr()) : nullptr,
+      has_top_p_arr ? static_cast<float*>(maybe_top_p_arr->data_ptr()) : nullptr,
+      static_cast<int*>(output.data_ptr()),
+      maybe_indices.has_value() ? static_cast<int*>(maybe_indices->data_ptr()) : nullptr,
+      batch_size,
+      top_k_val,
+      top_p_val,
+      vocab_size,
+      deterministic,
+      philox_seed,
+      philox_offset,
+      stream);
+  TORCH_CHECK(
+      status == musaSuccess,
+      "MusaTopKTopPSamplingFromProb failed with error code " + std::string(musaGetErrorString(status)));
+}

--- a/sgl-kernel/csrc/quantization/gguf/ggml-common.h
+++ b/sgl-kernel/csrc/quantization/gguf/ggml-common.h
@@ -964,11 +964,11 @@ static __device__ __forceinline__ dst_t convert_from_half(half val) {
 
 template <>
 __device__ __forceinline__ c10::BFloat16 convert_from_half<c10::BFloat16>(half val) {
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800 || defined(USE_MUSA)
   return __float2bfloat16(__half2float(val));
 #else
   return __half2float(val);
-#endif  // defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+#endif  // defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800 || defined(USE_MUSA)
 }
 
 template <>

--- a/sgl-kernel/csrc/quantization/gguf/vecdotq.cuh
+++ b/sgl-kernel/csrc/quantization/gguf/vecdotq.cuh
@@ -48,7 +48,7 @@ static __device__ __forceinline__ int get_int_from_uint8_aligned(const uint8_t* 
 template <int vdr>
 static __device__ __forceinline__ float
 vec_dot_q4_0_q8_1_impl(const int* v, const int* u, const float& d4, const half2& ds8) {
-#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM || defined USE_MUSA
   int sumi = 0;
 
 #pragma unroll
@@ -74,7 +74,7 @@ vec_dot_q4_0_q8_1_impl(const int* v, const int* u, const float& d4, const half2&
 template <int vdr>
 static __device__ __forceinline__ float
 vec_dot_q4_1_q8_1_impl(const int* v, const int* u, const half2& dm4, const half2& ds8) {
-#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM || defined USE_MUSA
   int sumi = 0;
 
 #pragma unroll
@@ -102,7 +102,7 @@ vec_dot_q4_1_q8_1_impl(const int* v, const int* u, const half2& dm4, const half2
 template <int vdr>
 static __device__ __forceinline__ float
 vec_dot_q5_0_q8_1_impl(const int* vl, const int* vh, const int* u, const float& d5, const half2& ds8) {
-#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM || defined USE_MUSA
   int sumi = 0;
 
 #pragma unroll
@@ -135,7 +135,7 @@ vec_dot_q5_0_q8_1_impl(const int* vl, const int* vh, const int* u, const float& 
 template <int vdr>
 static __device__ __forceinline__ float
 vec_dot_q5_1_q8_1_impl(const int* vl, const int* vh, const int* u, const half2& dm5, const half2& ds8) {
-#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM || defined USE_MUSA
   int sumi = 0;
 
 #pragma unroll
@@ -170,7 +170,7 @@ vec_dot_q5_1_q8_1_impl(const int* vl, const int* vh, const int* u, const half2& 
 template <int vdr>
 static __device__ __forceinline__ float
 vec_dot_q8_0_q8_1_impl(const int* v, const int* u, const float& d8_0, const float& d8_1) {
-#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM || defined USE_MUSA
   int sumi = 0;
 
 #pragma unroll
@@ -185,7 +185,7 @@ vec_dot_q8_0_q8_1_impl(const int* v, const int* u, const float& d8_0, const floa
 template <int vdr>
 static __device__ __forceinline__ float
 vec_dot_q8_1_q8_1_impl(const int* v, const int* u, const half2& dm8, const half2& ds8) {
-#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM || defined USE_MUSA
 
   int sumi = 0;
 
@@ -214,7 +214,7 @@ static __device__ __forceinline__ float vec_dot_q2_K_q8_1_impl_mmvq(
     const uint8_t* __restrict__ scales,
     const half2& dm2,
     const float* __restrict__ d8) {
-#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM || defined USE_MUSA
   float sumf_d = 0.0f;
   float sumf_m = 0.0f;
 
@@ -245,7 +245,7 @@ static __device__ __forceinline__ float vec_dot_q2_K_q8_1_impl_mmq(
     const uint8_t* __restrict__ scales,
     const half2& dm2,
     const float& d8) {
-#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM || defined USE_MUSA
   int sumi_d = 0;
   int sumi_m = 0;
 
@@ -287,7 +287,7 @@ static __device__ __forceinline__ float vec_dot_q3_K_q8_1_impl_mmvq(
     const int& scale_offset,
     const float& d3,
     const float* __restrict__ d8) {
-#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM || defined USE_MUSA
 
   float sumf = 0.0f;
 
@@ -324,7 +324,7 @@ static __device__ __forceinline__ float vec_dot_q3_K_q8_1_impl_mmq(
     const int8_t* __restrict__ scales,
     const float& d3,
     const float& d8) {
-#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM || defined USE_MUSA
   int sumi = 0;
 
 #pragma unroll
@@ -353,7 +353,7 @@ static __device__ __forceinline__ float vec_dot_q4_K_q8_1_impl_vmmq(
     const uint8_t* __restrict__ m,
     const half2& dm4,
     const float* __restrict__ d8) {
-#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM || defined USE_MUSA
 
   float sumf_d = 0.0f;
   float sumf_m = 0.0f;
@@ -382,7 +382,7 @@ static __device__ __forceinline__ float vec_dot_q4_K_q8_1_impl_mmq(
     const uint8_t* __restrict__ m,
     const half2& dm4,
     const half2* __restrict__ ds8) {
-#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM || defined USE_MUSA
   float sumf_d = 0.0f;
   float sumf_m = 0.0f;
 
@@ -418,7 +418,7 @@ static __device__ __forceinline__ float vec_dot_q5_K_q8_1_impl_vmmq(
     const uint8_t* __restrict__ m,
     const half2& dm5,
     const float* __restrict__ d8) {
-#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM || defined USE_MUSA
 
   float sumf_d = 0.0f;
   float sumf_m = 0.0f;
@@ -453,7 +453,7 @@ static __device__ __forceinline__ float vec_dot_q5_K_q8_1_impl_mmq(
     const uint8_t* __restrict__ m,
     const half2& dm4,
     const half2* __restrict__ ds8) {
-#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM || defined USE_MUSA
   float sumf_d = 0.0f;
   float sumf_m = 0.0f;
 
@@ -489,7 +489,7 @@ static __device__ __forceinline__ float vec_dot_q6_K_q8_1_impl_mmvq(
     const int8_t* __restrict__ scales,
     const float& d,
     const float* __restrict__ d8) {
-#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM || defined USE_MUSA
   float sumf = 0.0f;
 
 #pragma unroll
@@ -512,7 +512,7 @@ static __device__ __forceinline__ float vec_dot_q6_K_q8_1_impl_mmq(
     const int8_t* __restrict__ sc,
     const float& d6,
     const float* __restrict__ d8) {
-#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM || defined USE_MUSA
   float sumf_d = 0.0f;
 
 #pragma unroll
@@ -1807,7 +1807,7 @@ vec_dot_iq2_xs_q8_1(const void* __restrict__ vbq, const block_q8_1* __restrict__
 
 static __device__ __forceinline__ float
 vec_dot_iq2_s_q8_1(const void* __restrict__ vbq, const block_q8_1* __restrict__ bq8_1, const int& iqs) {
-#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM || defined USE_MUSA
   const block_iq2_s* bq2 = (const block_iq2_s*)vbq;
 
   const int ib32 = iqs;
@@ -1846,7 +1846,7 @@ vec_dot_iq2_s_q8_1(const void* __restrict__ vbq, const block_q8_1* __restrict__ 
 
 static __device__ __forceinline__ float
 vec_dot_iq3_xxs_q8_1(const void* __restrict__ vbq, const block_q8_1* __restrict__ bq8_1, const int& iqs) {
-#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM || defined USE_MUSA
   const block_iq3_xxs* bq2 = (const block_iq3_xxs*)vbq;
 
   const int ib32 = iqs;
@@ -1873,7 +1873,7 @@ vec_dot_iq3_xxs_q8_1(const void* __restrict__ vbq, const block_q8_1* __restrict_
 
 static __device__ __forceinline__ float
 vec_dot_iq3_s_q8_1(const void* __restrict__ vbq, const block_q8_1* __restrict__ bq8_1, const int& iqs) {
-#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM || defined USE_MUSA
   const block_iq3_s* bq2 = (const block_iq3_s*)vbq;
 
   const int ib32 = iqs;
@@ -1899,7 +1899,7 @@ vec_dot_iq3_s_q8_1(const void* __restrict__ vbq, const block_q8_1* __restrict__ 
 
 static __device__ __forceinline__ float
 vec_dot_iq1_s_q8_1(const void* __restrict__ vbq, const block_q8_1* __restrict__ bq8_1, const int& iqs) {
-#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM || defined USE_MUSA
   const block_iq1_s* bq1 = (const block_iq1_s*)vbq;
 
   const int qs_packed = get_int_b2(bq1->qs, iqs);
@@ -1931,7 +1931,7 @@ vec_dot_iq1_s_q8_1(const void* __restrict__ vbq, const block_q8_1* __restrict__ 
 
 static __device__ __forceinline__ float
 vec_dot_iq1_m_q8_1(const void* __restrict__ vbq, const block_q8_1* __restrict__ bq8_1, const int& iqs) {
-#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM || defined USE_MUSA
 
   const block_iq1_m* bq1 = (const block_iq1_m*)vbq;
 
@@ -1991,7 +1991,7 @@ get_int_from_table_16(const uint32_t& q4, const uint8_t* values, int& val1, int&
 
 static __device__ __forceinline__ float
 vec_dot_iq4_nl_q8_1(const void* __restrict__ vbq, const block_q8_1* __restrict__ bq8_1, const int& iqs) {
-#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM || defined USE_MUSA
 
   const block_iq4_nl* bq = (const block_iq4_nl*)vbq;
 
@@ -2015,7 +2015,7 @@ vec_dot_iq4_nl_q8_1(const void* __restrict__ vbq, const block_q8_1* __restrict__
 
 static __device__ __forceinline__ float
 vec_dot_iq4_xs_q8_1(const void* __restrict__ vbq, const block_q8_1* __restrict__ bq8_1, const int& iqs) {
-#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM || defined USE_MUSA
   const block_iq4_xs* bq4 = (const block_iq4_xs*)vbq;
   const uint8_t* values = (const uint8_t*)kvalues_iq4nl;
 

--- a/sgl-kernel/csrc/speculative/eagle_utils.cu
+++ b/sgl-kernel/csrc/speculative/eagle_utils.cu
@@ -17,7 +17,7 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 
-#ifndef USE_ROCM
+#if !defined(USE_ROCM) && !defined(USE_MUSA)
 #include "pytorch_extension_utils.h"
 #else
 #include "pytorch_extension_utils_rocm.h"

--- a/sgl-kernel/include/musa/ai_qint8.h
+++ b/sgl-kernel/include/musa/ai_qint8.h
@@ -1,0 +1,79 @@
+/* Copyright @2020-2024 Moore Threads Technology Co., Ltd("Moore Threads"). All
+ * rights reserved.
+ *
+ * This software ("this software and its documentations" or "the software") is
+ * protected by Copyright and the information contained herein is confidential.
+ *
+ * The software contained herein is PROPRIETARY to Moore Threads and is being
+ * provided under the terms and conditions of a form of Moore Threads software
+ * license agreement by and between Moore Threads and Licensee ("License
+ * Agreement") or electronically accepted by Licensee. Notwithstanding any
+ * terms or conditions to the contrary in the License Agreement, copy or
+ * disclosure of the software to any third party without the express written
+ * consent of Moore Threads is prohibited.
+ *
+ * NOTWITHSTANDING ANY TERMS OR CONDITIONS TO THE CONTRARY IN THE LICENSE
+ * AGREEMENT, MOORE THREADS MAKES NO REPRESENTATION ABOUT ANY WARRANTIES,
+ * INCLUDING BUT NOT LIMITED TO THE SUITABILITY OF THE SOFTWARE FOR ANY
+ * PURPOSE. IT IS PROVIDED "AS IS" WITHOUT EXPRESS OR IMPLIED WARRANTY OF
+ * ANY KIND. MOORE THREADS DISCLAIMS ALL WARRANTIES WITH REGARD TO THE
+ * SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY,
+ * NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE.
+ * NOTWITHSTANDING ANY TERMS OR CONDITIONS TO THE CONTRARY IN THE
+ * LICENSE AGREEMENT, IN NO EVENT SHALL MOORE THREADS BE LIABLE FOR ANY
+ * SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, OR ANY
+ * DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+ * WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+ * ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+ * OF THE SOFTWARE.
+ */
+#ifndef INCLUDE_MUDNN_API_AI_QINT8_H_
+#define INCLUDE_MUDNN_API_AI_QINT8_H_
+
+class qint8_t {
+  int8_t _;
+
+ public:
+  __device__ int8_t as_int8() const {
+    return _;
+  }
+
+  __host__ __device__ qint8_t(int8_t val) : _(val) {}
+  __host__ __device__ qint8_t() : _(0) {}
+  __host__ __device__ qint8_t(const qint8_t& b) {
+    _ = b._;
+  }
+  __host__ __device__ qint8_t(const int& b) {
+    _ = b;
+  }
+  __host__ __device__ qint8_t(const char& b) {
+    _ = b;
+  }
+  __host__ __device__ operator char() const {
+    return _;
+  }
+  __host__ __device__ qint8_t operator+=(const qint8_t& b) {
+    return _ += b._;
+  }
+  __host__ __device__ qint8_t operator-=(const qint8_t& b) {
+    return _ -= b._;
+  }
+  __host__ __device__ qint8_t operator*=(const qint8_t& b) {
+    return _ *= b._;
+  }
+
+  bool operator<(const qint8_t& b) const {
+    return _ < b._;
+  }
+  bool operator>(const qint8_t& b) const {
+    return _ > b._;
+  }
+  bool operator==(const qint8_t& b) const {
+    return _ == b._;
+  }
+  bool operator!=(const qint8_t& b) const {
+    return _ != b._;
+  }
+};
+
+#endif  // INCLUDE_MUDNN_API_AI_QINT8_H_

--- a/sgl-kernel/include/musa/dispatch_utils.h
+++ b/sgl-kernel/include/musa/dispatch_utils.h
@@ -1,0 +1,17 @@
+/*
+ * Adapted from
+ * https://github.com/pytorch/pytorch/blob/v2.0.1/aten/src/ATen/Dispatch.h
+ */
+#pragma once
+
+#include <torch/all.h>
+
+#define MUSA_LDG(arg) __ldg(arg)
+
+#define MUSA_DISPATCH_CASE_FLOATING_TYPES(...)         \
+  AT_DISPATCH_CASE(at::ScalarType::Float, __VA_ARGS__) \
+  AT_DISPATCH_CASE(at::ScalarType::Half, __VA_ARGS__)  \
+  AT_DISPATCH_CASE(at::ScalarType::BFloat16, __VA_ARGS__)
+
+#define MUSA_DISPATCH_FLOATING_TYPES(TYPE, NAME, ...) \
+  AT_DISPATCH_SWITCH(TYPE, NAME, MUSA_DISPATCH_CASE_FLOATING_TYPES(__VA_ARGS__))

--- a/sgl-kernel/include/musa/integer_subbyte.h
+++ b/sgl-kernel/include/musa/integer_subbyte.h
@@ -1,0 +1,65 @@
+/* Copyright @2020-2024 Moore Threads Technology Co., Ltd("Moore Threads"). All
+ * rights reserved.
+ *
+ * This software ("this software and its documentations" or "the software") is
+ * protected by Copyright and the information contained herein is confidential.
+ *
+ * The software contained herein is PROPRIETARY to Moore Threads and is being
+ * provided under the terms and conditions of a form of Moore Threads software
+ * license agreement by and between Moore Threads and Licensee ("License
+ * Agreement") or electronically accepted by Licensee. Notwithstanding any
+ * terms or conditions to the contrary in the License Agreement, copy or
+ * disclosure of the software to any third party without the express written
+ * consent of Moore Threads is prohibited.
+ *
+ * NOTWITHSTANDING ANY TERMS OR CONDITIONS TO THE CONTRARY IN THE LICENSE
+ * AGREEMENT, MOORE THREADS MAKES NO REPRESENTATION ABOUT ANY WARRANTIES,
+ * INCLUDING BUT NOT LIMITED TO THE SUITABILITY OF THE SOFTWARE FOR ANY
+ * PURPOSE. IT IS PROVIDED "AS IS" WITHOUT EXPRESS OR IMPLIED WARRANTY OF
+ * ANY KIND. MOORE THREADS DISCLAIMS ALL WARRANTIES WITH REGARD TO THE
+ * SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY,
+ * NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE.
+ * NOTWITHSTANDING ANY TERMS OR CONDITIONS TO THE CONTRARY IN THE
+ * LICENSE AGREEMENT, IN NO EVENT SHALL MOORE THREADS BE LIABLE FOR ANY
+ * SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, OR ANY
+ * DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+ * WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+ * ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+ * OF THE SOFTWARE.
+ */
+
+#ifndef INCLUDE_MUDNN_API_INTEGER_SUBBYTE_H_
+#define INCLUDE_MUDNN_API_INTEGER_SUBBYTE_H_
+
+#include <limits>
+#include <type_traits>
+
+namespace musa::dnn {
+
+// cutlass integer_subbyte class
+template <int Bits, bool Signed = true>
+struct integer_subbyte {
+  using Storage = uint8_t;
+
+  static_assert(Bits <= 8 * sizeof(Storage), "Require a subbyte of bits in integer_subbyte");
+
+  using xint_t = typename std::conditional<Signed, int, unsigned>::type;
+
+  static constexpr Storage bits_mask_ = Storage((1 << Bits) - 1);
+
+  static constexpr Storage sign_mask_ = Storage((Signed ? 1 : 0) << (Bits - 1));
+
+  Storage storage;
+
+  __host__ __device__ constexpr integer_subbyte() {}
+
+  __host__ __device__ constexpr integer_subbyte(int value)
+      : storage(reinterpret_cast<Storage const&>(value) & bits_mask_) {}
+
+  __host__ __device__ constexpr integer_subbyte(unsigned value)
+      : storage(reinterpret_cast<Storage const&>(value) & bits_mask_) {}
+};
+
+}  // namespace musa::dnn
+
+#endif  // INCLUDE_MUDNN_API_INTEGER_SUBBYTE_H_

--- a/sgl-kernel/include/sgl_kernel_ops.h
+++ b/sgl-kernel/include/sgl_kernel_ops.h
@@ -127,6 +127,8 @@ int64_t cutlass_mla_get_workspace_size(
 void rmsnorm(at::Tensor& output, at::Tensor& input, at::Tensor& weight, double eps, bool enable_pdl);
 void sgl_fused_add_rmsnorm(
     torch::Tensor input, torch::Tensor residual, torch::Tensor weight, double eps, bool enable_pdl);
+void musa_fused_add_rms_norm(
+    torch::Tensor& input, torch::Tensor& residual, torch::Tensor& weight, double epsilon, bool enable_pdl);
 void gemma_rmsnorm(at::Tensor& output, at::Tensor& input, at::Tensor& weight, double eps, bool enable_pdl);
 void gemma_fused_add_rmsnorm(at::Tensor& input, at::Tensor& residual, at::Tensor& weight, double eps, bool enable_pdl);
 void silu_and_mul(at::Tensor& out, at::Tensor& input);

--- a/sgl-kernel/include/sgl_kernel_ops.h
+++ b/sgl-kernel/include/sgl_kernel_ops.h
@@ -593,6 +593,73 @@ void top_k_renorm_probs(
 void top_p_renorm_probs(
     at::Tensor probs, at::Tensor renorm_probs, std::optional<at::Tensor> maybe_top_p_arr, double top_p_val);
 
+/*
+ * From csrc/musa
+ */
+void batched_rotary_embedding_contiguous(
+    torch::Tensor& positions,
+    torch::Tensor& query,
+    torch::Tensor& key,
+    int64_t head_size,
+    torch::Tensor& cos_sin_cache,
+    bool is_neox,
+    int64_t rot_dim,
+    torch::Tensor& cos_sin_cache_offsets);
+
+void rotary_embedding_contiguous(
+    torch::Tensor& positions,
+    torch::Tensor& query,
+    torch::Tensor& key,
+    int64_t head_size,
+    torch::Tensor& cos_sin_cache,
+    bool is_neox);
+
+void mudnn_w8a8_scaled_mm(
+    torch::Tensor& c,
+    const torch::Tensor& a,
+    const torch::Tensor& b,
+    const torch::Tensor& a_scales,
+    const torch::Tensor& b_scales,
+    const std::optional<torch::Tensor>& bias);
+
+void fused_moe_gemv(
+    torch::Tensor& A,
+    torch::Tensor& B,
+    torch::Tensor& C,
+    const c10::optional<torch::Tensor>& A_scale,
+    const c10::optional<torch::Tensor>& B_scale,
+    torch::Tensor& topk_weights,
+    torch::Tensor& topk_ids,
+    bool mul_routed_weight,
+    int64_t topk,
+    bool use_int4_w4a16,
+    bool use_swigelu);
+
+void musa_fused_gemv(
+    torch::Tensor& A,
+    torch::Tensor& B,
+    torch::Tensor& C,
+    const c10::optional<torch::Tensor>& A_scale,
+    const c10::optional<torch::Tensor>& B_scale,
+    bool use_int4_w4a16,
+    bool use_swigelu,
+    bool use_rms_norm,
+    const c10::optional<torch::Tensor>& gamma,
+    double eps);
+
+void fused_mul_add(torch::Tensor& output, torch::Tensor& self, torch::Tensor& bias, double scale);
+
+void musa_top_k_top_p_sampling_from_probs(
+    at::Tensor probs,
+    at::Tensor output,
+    std::optional<at::Tensor> maybe_indices,
+    std::optional<at::Tensor> maybe_top_k_arr,
+    double top_k_val,
+    std::optional<at::Tensor> maybe_top_p_arr,
+    double top_p_val,
+    bool deterministic,
+    std::optional<at::Generator> gen);
+
 namespace flash {
 /*
  * From fa2 sparse

--- a/sgl-kernel/python/sgl_kernel/__init__.py
+++ b/sgl-kernel/python/sgl_kernel/__init__.py
@@ -111,6 +111,16 @@ from sgl_kernel.version import __version__
 if torch.version.hip is not None:
     from sgl_kernel.elementwise import gelu_quick
 
+if torch.version.musa is not None:
+    from sgl_kernel.musa import (
+        musa_batched_rotary_embedding_contiguous,
+        musa_fused_gemv,
+        musa_fused_moe_gemv,
+        musa_fused_mul_add,
+        musa_mudnn_w8a8_scaled_mm,
+        musa_rotary_embedding_contiguous,
+    )
+
 
 _DEBUG_EXPORT_NAMES = [
     "apply_shuffle_mul_sum",

--- a/sgl-kernel/python/sgl_kernel/musa.py
+++ b/sgl-kernel/python/sgl_kernel/musa.py
@@ -1,0 +1,192 @@
+from typing import Optional
+
+import torch
+
+
+def musa_batched_rotary_embedding_contiguous(
+    positions: torch.Tensor,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    head_size: int,
+    cos_sin_cache: torch.Tensor,
+    is_neox: bool,
+    rot_dim: int,
+    cos_sin_cache_offsets: torch.Tensor,
+) -> None:
+    return torch.ops.sgl_kernel.musa_batched_rotary_embedding_contiguous(
+        positions,
+        query,
+        key,
+        head_size,
+        cos_sin_cache,
+        is_neox,
+        rot_dim,
+        cos_sin_cache_offsets,
+    )
+
+
+def musa_rotary_embedding_contiguous(
+    positions: torch.Tensor,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    head_size: int,
+    cos_sin_cache: torch.Tensor,
+    is_neox: bool,
+) -> None:
+    return torch.ops.sgl_kernel.musa_rotary_embedding_contiguous(
+        positions,
+        query,
+        key,
+        head_size,
+        cos_sin_cache,
+        is_neox,
+    )
+
+
+def musa_mudnn_w8a8_scaled_mm(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+    out_dtype: torch.dtype,
+    bias: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    assert b.shape[0] % 16 == 0 and b.shape[1] % 16 == 0
+    assert out_dtype is torch.bfloat16 or out_dtype is torch.float16
+    assert bias is None or bias.shape[0] == b.shape[1] and bias.dtype == out_dtype
+
+    m = a.shape[0]
+    n = b.shape[0]
+
+    out = torch.empty((m, n), dtype=out_dtype, device=a.device)
+    torch.ops.sgl_kernel.musa_mudnn_w8a8_scaled_mm(out, a, b, scale_a, scale_b, bias)
+    return out
+
+
+def musa_fused_moe_gemv(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    A_scale,
+    B_scale,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    mul_routed_weight: bool,
+    topk: int,
+    use_int4_w4a16: bool,
+    use_swigelu: bool,
+) -> None:
+    return torch.ops.sgl_kernel.fused_moe_gemv(
+        A,
+        B,
+        C,
+        A_scale,
+        B_scale,
+        topk_weights,
+        topk_ids,
+        mul_routed_weight,
+        topk,
+        use_int4_w4a16,
+        use_swigelu,
+    )
+
+
+def musa_fused_gemv(
+    x: torch.Tensor,
+    qweight: torch.Tensor,
+    x_scales: Optional[torch.Tensor] = None,
+    qweight_scales: Optional[torch.Tensor] = None,
+    use_swigelu: bool = False,
+    use_rms_norm: bool = False,
+    gamma: Optional[torch.Tensor] = None,
+    eps: float = 1e-6,
+):
+    use_int4_w4a16 = False
+    out_shape = x.shape[:-1] + (
+        qweight.shape[0] if not use_swigelu else qweight.shape[0] // 2,
+    )
+    assert not (
+        use_swigelu and use_rms_norm
+    ), "gemv only fused one activation (swigelu or rms_norm)!"
+
+    if use_rms_norm:
+        if gamma is None:
+            assert False, "rms_norm gamma is None!"
+
+    # fp8 grouped matmul
+    if qweight.dtype == torch.float8_e4m3fn:
+        assert (
+            qweight.dtype == torch.float8_e4m3fn
+        ), "FP8 grouped matmul weight only support float8_e4m3fn!"
+        assert qweight_scales is not None, "FP8 grouped matmul weight scales is None!"
+        output = torch.empty(out_shape, device=x.device, dtype=torch.bfloat16)
+        torch.ops.sgl_kernel.musa_fused_gemv(
+            x,
+            qweight,
+            output,
+            x_scales,
+            qweight_scales,
+            use_int4_w4a16,
+            use_swigelu,
+            use_rms_norm,
+            gamma,
+            eps,
+        )
+        return output
+    # w4a16 gemv
+    elif qweight_scales is not None:
+        assert (
+            x.dtype == torch.bfloat16 or x.dtype == torch.float16
+        ), "W4A16 gemv only support bfloat16 or float16!"
+        use_int4_w4a16 = True
+        out_shape = x.shape[:-1] + (
+            qweight.shape[0] if not use_swigelu else qweight.shape[0] // 2,
+        )
+        output = torch.empty(out_shape, device=x.device, dtype=x.dtype)
+        torch.ops.sgl_kernel.musa_fused_gemv(
+            x,
+            qweight,
+            output,
+            None,
+            qweight_scales,
+            use_int4_w4a16,
+            use_swigelu,
+            use_rms_norm,
+            gamma,
+            eps,
+        )
+        return output
+    # general gemv
+    else:
+        output = torch.empty(out_shape, device=x.device, dtype=x.dtype)
+        torch.ops.sgl_kernel.musa_fused_gemv(
+            x,
+            qweight,
+            output,
+            None,
+            None,
+            use_int4_w4a16,
+            use_swigelu,
+            use_rms_norm,
+            gamma,
+            eps,
+        )
+        return output
+
+
+def musa_fused_mul_add(
+    self: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    scale: Optional[float],
+    accurate: bool = True,
+):
+    # if accurate == False, then we call inplace op: bias += (self * scale)
+    if not accurate:
+        bias.add_(self, alpha=scale)
+        return bias
+
+    # otherwise, we call custom outplace op, act: output = self * scale + bias
+    output = torch.empty_like(self)
+    torch.ops.sgl_kernel.musa_fused_mul_add(output, self, bias, scale)
+
+    return output

--- a/sgl-kernel/setup_musa.py
+++ b/sgl-kernel/setup_musa.py
@@ -76,10 +76,37 @@ include_dirs = [
 ]
 
 sources = [
+    "csrc/allreduce/custom_all_reduce.cu",
+    "csrc/attention/merge_attn_states.cu",
     "csrc/common_extension_musa.cc",
+    "csrc/elementwise/activation.cu",
+    "csrc/elementwise/concat_mla.cu",
+    "csrc/elementwise/fused_add_rms_norm_kernel.mu",
+    "csrc/grammar/apply_token_bitmask_inplace_cuda.cu",
+    "csrc/moe/moe_align_kernel.cu",
+    "csrc/moe/moe_fused_gate_musa.cu",
+    "csrc/moe/kimi_k2_moe_fused_gate.cu",
+    "csrc/moe/moe_sum.cu",
+    "csrc/moe/moe_sum_reduce.cu",
+    "csrc/moe/moe_topk_softmax_kernels.cu",
+    "csrc/quantization/gguf/gguf_kernel.cu",
+    "csrc/speculative/eagle_utils.cu",
+    "csrc/speculative/ngram_utils.cu",
+    "csrc/speculative/packbit.cu",
+    "csrc/speculative/speculative_sampling.cu",
+    "csrc/kvcacheio/transfer.cu",
+    "csrc/gemm/awq_kernel.cu",
+    "csrc/gemm/bmm_fp8.cu",
+    "csrc/gemm/dsv3_fused_a_gemm.cu",
+    "csrc/gemm/dsv3_router_gemm_bf16_out.cu",
+    "csrc/gemm/dsv3_router_gemm_entry.cu",
+    "csrc/gemm/dsv3_router_gemm_float_out.cu",
+    "csrc/gemm/per_token_quant_fp8.cu",
+    "csrc/gemm/per_token_group_quant_8bit.cu",
+    "csrc/gemm/per_token_group_quant_8bit_v2.cu",
+    "csrc/memory/weak_ref_tensor.cpp",
     str(_FLASHINFER_REPO.source_dir / "csrc/norm.cu"),
     str(_FLASHINFER_REPO.source_dir / "csrc/renorm.cu"),
-    str(_FLASHINFER_REPO.source_dir / "csrc/sampling.cu"),
 ]
 
 cxx_flags = ["force_mcc"]

--- a/sgl-kernel/setup_musa.py
+++ b/sgl-kernel/setup_musa.py
@@ -107,6 +107,12 @@ sources = [
     "csrc/memory/weak_ref_tensor.cpp",
     str(_FLASHINFER_REPO.source_dir / "csrc/norm.cu"),
     str(_FLASHINFER_REPO.source_dir / "csrc/renorm.cu"),
+    # XXX (MUSA): The following files contain MUSA-specific implementations.
+    "csrc/musa/pos_encoding_contiguous.mu",
+    "csrc/musa/matmul_mudnn.cpp",
+    "csrc/musa/moe_gemv_swiglu.mu",
+    "csrc/musa/ternary.mu",
+    "csrc/musa/top_k_top_p_sampling.mu",
 ]
 
 cxx_flags = ["force_mcc"]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR continues the ongoing effort (tracked in https://github.com/sgl-project/sglang/issues/16565) to add full support for Moore Threads GPUs in SGLang by leveraging MUSA (Meta-computing Unified System Architecture) for LLM inference.

The primary goal of this pr is to add MUSA-specific kernel support to `sgl-kernel`. 

It focuses only on the MUSA kernel path so that `sgl-kernel` can build successfully with `setup_musa.py` and be used to
run SGLang on the MUSA platform.

## Modifications

- Copied MUSA kernel sources into upstream `sgl-kernel`:
    - `sgl-kernel/csrc/musa/`
    - `sgl-kernel/include/musa/`
  - Updated `sgl-kernel/setup_musa.py` to include the MUSA-specific kernel sources:
    - `csrc/musa/pos_encoding_contiguous.mu`
    - `csrc/musa/matmul_mudnn.cpp`
    - `csrc/musa/moe_gemv_swiglu.mu`
    - `csrc/musa/ternary.mu`
    - `csrc/musa/top_k_top_p_sampling.mu`
  - Updated `sgl-kernel/csrc/common_extension_musa.cc` to register the added MUSA ops, including:
    - rotary embedding kernels
    - MuDNN int8/fp8 matmul kernel
    - fused MoE GEMV kernels
    - fused mul-add kernel
    - top-k/top-p sampling kernel
  - Updated `sgl-kernel/include/sgl_kernel_ops.h` with the corresponding declarations needed by the MUSA extension registration.

## Accuracy Tests

Tested in torch_musa container:

<details>
<summary><===Click to expand log details===></summary>

```
root@76bc994cd332:/ws/sglang/sgl-kernel# python setup_musa.py install
026-04-16 10:38:10 | dist | 140394461865792 | INFO : running build
2026-04-16 10:38:10 | dist | 140394461865792 | INFO : running build_py
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/attention.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/spatial.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/gemm.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/__init__.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/sampling.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/musa.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/sparse_flash_attn.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/cutlass_moe.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/test_utils.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/memory.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/elementwise.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/flash_mla.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/expert_specialization.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/debug_utils.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/flash_attn.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/utils.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/kvcacheio.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/version.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/mamba.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/top_k.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/moe.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/allreduce.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/load_utils.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/grammar.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/speculative.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/scalar_type.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/testing/rotary_embedding.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel/testing
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/testing/__init__.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel/testing
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/quantization/__init__.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel/quantization
2026-04-16 10:38:10 | file_util | 140394461865792 | INFO : copying python/sgl_kernel/quantization/gguf.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel/quantization
2026-04-16 10:38:10 | dist | 140394461865792 | INFO : running egg_info
2026-04-16 10:38:10 | egg_info | 140394461865792 | INFO : writing python/sglang_kernel.egg-info/PKG-INFO
2026-04-16 10:38:10 | egg_info | 140394461865792 | INFO : writing dependency_links to python/sglang_kernel.egg-info/dependency_links.txt
2026-04-16 10:38:10 | egg_info | 140394461865792 | INFO : writing top-level names to python/sglang_kernel.egg-info/top_level.txt
```
```
oot@76bc994cd332:/ws/sglang# python3
Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sgl_kernel
>>> dir(sgl_kernel)
['List', 'Optional', 'Tuple', '__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', '__spec__', '__version__', '_load_architecture_specific_ops', '_preload_cuda_library', 'all_reduce', 'allreduce', 'apply_shuffle_mul_sum', 'apply_token_bitmask_inplace_cuda', 'attention', 'awq_dequantize', 'bmm_fp8', 'build_tree_kernel_efficient', 'causal_conv1d_fn_cpu', 'causal_conv1d_fwd', 'causal_conv1d_update', 'causal_conv1d_update_cpu', 'chunk_gated_delta_rule_cpu', 'common_ops', 'concat_mla_absorb_q', 'concat_mla_k', 'copy_to_gpu_no_ce', 'create_greenctx_stream_by_value', 'cutlass_mla_decode', 'cutlass_mla_get_workspace_size', 'cutlass_moe', 'cutlass_w4a8_moe_mm', 'debug_utils', 'dispose', 'dsv3_fused_a_gemm', 'dsv3_router_gemm', 'elementwise', 'es_fp8_blockwise_scaled_grouped_mm', 'es_sm100_mxfp8_blockscaled_grouped_mm', 'es_sm100_mxfp8_blockscaled_grouped_quant', 'expert_specialization', 'fast_topk', 'fast_topk_transform_fused', 'fast_topk_transform_ragged_fused', 'fast_topk_v2', 'fp8_blockwise_scaled_grouped_mm', 'fp8_blockwise_scaled_mm', 'fp8_scaled_mm', 'fused_add_rmsnorm', 'fused_qk_norm_rope', 'gelu_and_mul', 'gelu_tanh_and_mul', 'gemm', 'gemma_fused_add_rmsnorm', 'gemma_rmsnorm', 'get_cutlass_w4a8_moe_mm_data', 'get_graph_buffer_ipc_meta', 'get_sm_available', 'ggml_dequantize', 'ggml_moe_a8', 'ggml_moe_a8_vec', 'ggml_moe_get_block_size', 'ggml_mul_mat_a8', 'ggml_mul_mat_vec_a8', 'gptq_gemm', 'gptq_shuffle', 'grammar', 'init_custom_ar', 'int8_scaled_mm', 'kimi_k2_moe_fused_gate', 'kvcacheio', 'load_utils', 'mamba', 'maybe_wrap_debug_kernel', 'memory', 'merge_state_v2', 'meta_size', 'moe', 'moe_align_block_size', 'moe_fused_gate', 'moe_sum', 'moe_sum_reduce', 'mscclpp_allreduce', 'mscclpp_generate_unique_id', 'mscclpp_init_context', 'musa', 'musa_batched_rotary_embedding_contiguous', 'musa_fused_gemv', 'musa_fused_moe_gemv', 'musa_fused_mul_add', 'musa_mudnn_w8a8_scaled_mm', 'musa_rotary_embedding_contiguous', 'prepare_moe_input', 'qserve_w4a8_per_chn_gemm', 'qserve_w4a8_per_group_gemm', 'quantization', 'reconstruct_indices_from_tree_mask', 'register_buffer', 'register_graph_buffers', 'rmsnorm', 'rotary_embedding', 'sampling', 'segment_packbits', 'sgl_per_token_group_quant_8bit', 'sgl_per_token_group_quant_fp8', 'sgl_per_token_group_quant_int8', 'sgl_per_token_quant_fp8', 'shuffle_rows', 'silu_and_mul', 'speculative', 'top_k', 'top_k_renorm_prob', 'top_p_renorm_prob', 'topk_sigmoid', 'topk_softmax', 'torch', 'transfer_kv_all_layer', 'transfer_kv_all_layer_mla', 'transfer_kv_per_layer', 'transfer_kv_per_layer_mla', 'tree_speculative_sampling_target_only', 'utils', 'verify_tree_greedy', 'version', 'weak_ref_tensor']
>>>
```

</details>
Launch sglang server:

```
python3 -m sglang.launch_server \
    --model-path /home/dist/Qwen3-0.6B/ \
    --served-model-name base-model \
    --disable-radix-cache \
    --trust-remote-code \
    --host 0.0.0.0 \
    --port 31000 \
    --tp-size 2 \
    --dp-size 2 \
    --enable-dp-attention \
    --cuda-graph-max-bs 10
```

## Speed Tests and Profiling

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
