### PR TITLE
Add GLM5.1 tool-result template override.

### DIFF
--- a/python/sglang/srt/managers/template_manager.py
+++ b/python/sglang/srt/managers/template_manager.py
@@ -124,6 +124,9 @@ class TemplateManager:
             if self._chat_template_name is None:
                 # Try HuggingFace template first
                 hf_template = self._resolve_hf_chat_template(tokenizer_manager)
+                hf_template = self._maybe_apply_glm51_tool_result_fix(
+                    hf_template, model_path
+                )
                 if hf_template:
                     # override the chat template
                     if tokenizer_manager.tokenizer:
@@ -240,6 +243,40 @@ class TemplateManager:
         logger.info(
             f"Detected user specified Jinja chat template with content format: {self._jinja_template_content_format}"
         )
+
+    def _should_apply_glm51_tool_result_fix(self, model_path: str) -> bool:
+        override = os.getenv("SGLANG_GLM51_TOOL_RESULT_TEMPLATE_FIX", "").lower()
+        if override in {"0", "false", "no", "off"}:
+            return False
+        if override in {"1", "true", "yes", "on"}:
+            return True
+        normalized = model_path.lower()
+        return "glm-5.1" in normalized or "glm5.1" in normalized
+
+    def _maybe_apply_glm51_tool_result_fix(
+        self, chat_template: Optional[str], model_path: str
+    ) -> Optional[str]:
+        if chat_template is None or not self._should_apply_glm51_tool_result_fix(
+            model_path
+        ):
+            return chat_template
+
+        template_path = os.path.join(
+            os.path.dirname(__file__),
+            "templates",
+            "glm5_1_tool_result_as_user.jinja",
+        )
+        if not os.path.exists(template_path):
+            logger.warning(
+                "GLM5.1 tool-result template override file is missing: %s",
+                template_path,
+            )
+            return chat_template
+
+        with open(template_path, "r", encoding="utf-8") as f:
+            fixed_template = f.read().strip("\n")
+        logger.info("Applying GLM5.1 tool-result template override")
+        return fixed_template
 
     def _load_json_chat_template(self, template_path: str) -> None:
         """Load a JSON chat template file."""

--- a/python/sglang/srt/managers/templates/glm5_1_tool_result_as_user.jinja
+++ b/python/sglang/srt/managers/templates/glm5_1_tool_result_as_user.jinja
@@ -1,0 +1,115 @@
+[gMASK]<sop>
+{%- if tools -%}
+{%- macro tool_to_json(tool) -%}
+    {%- set ns_tool = namespace(first=true) -%}
+    {{ '{' -}}
+    {%- for k, v in tool.items() -%}
+        {%- if k != 'defer_loading' and k != 'strict' -%}
+            {%- if not ns_tool.first -%}{{- ', ' -}}{%- endif -%}
+            {%- set ns_tool.first = false -%}
+            "{{ k }}": {{ v | tojson(ensure_ascii=False) }}
+        {%- endif -%}
+    {%- endfor -%}
+    {{- '}' -}}
+{%- endmacro -%}
+<|system|>
+# Tools
+
+You may call one or more functions to assist with the user query.
+
+You are provided with function signatures within <tools></tools> XML tags:
+<tools>
+{% for tool in tools %}
+{%- if 'function' in tool -%}
+    {%- set tool = tool['function'] -%}
+{%- endif -%}
+{% if tool.defer_loading is not defined or not tool.defer_loading %}
+{{ tool_to_json(tool) }}
+{% endif %}
+{% endfor %}
+</tools>
+
+For each function call, output the function name and arguments within the following XML format:
+<tool_call>{function-name}<arg_key>{arg-key-1}</arg_key><arg_value>{arg-value-1}</arg_value><arg_key>{arg-key-2}</arg_key><arg_value>{arg-value-2}</arg_value>...</tool_call>{%- endif -%}
+{%- macro visible_text(content) -%}
+    {%- if content is string -%}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping -%}
+        {%- for item in content -%}
+            {%- if item is mapping and item.type == 'text' -%}
+                {{- item.text }}
+            {%- elif item is string -%}
+                {{- item }}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- else -%}
+        {{- content }}
+    {%- endif -%}
+{%- endmacro -%}
+{%- set ns = namespace(last_user_index=-1, thinking_indices='') -%}
+{%- for m in messages %}
+    {%- if m.role == 'user' or m.role == 'tool' %}
+        {%- set ns.last_user_index = loop.index0 -%}
+    {%- elif m.role == 'assistant' %}
+        {%- if m.reasoning_content is string %}
+            {%- set ns.thinking_indices = ns.thinking_indices ~ ',' ~ ns.last_user_index ~ ',' -%}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- set ns.has_thinking = false -%}
+{%- for m in messages -%}
+{%- if m.role == 'user' -%}<|user|>{{ visible_text(m.content) }}{% set ns.has_thinking = (',' ~ loop.index0 ~ ',') in ns.thinking_indices -%}
+{%- elif m.role == 'assistant' -%}
+<|assistant|>
+{%- set content = visible_text(m.content) %}
+{%- if m.reasoning_content is string %}
+    {%- set reasoning_content = m.reasoning_content %}
+{%- elif '</think>' in content %}
+    {%- set reasoning_content = content.split('</think>')[0].split('<think>')[-1] %}
+    {%- set content = content.split('</think>')[-1] %}
+{%- elif loop.index0 > ns.last_user_index and not (enable_thinking is defined and not enable_thinking) %}
+    {%- set reasoning_content = '' %}
+{%- elif loop.index0 < ns.last_user_index and ns.has_thinking %}
+    {%- set reasoning_content = '' %}
+{%- endif %}
+{%- if ((clear_thinking is defined and not clear_thinking) or loop.index0 > ns.last_user_index) and reasoning_content is defined -%}
+{{ '<think>' + reasoning_content +  '</think>'}}
+{%- else -%}
+{{ '</think>' }}
+{%- endif -%}
+{%- if content.strip() -%}
+{{ content.strip() }}
+{%- endif -%}
+{% if m.tool_calls %}
+{% for tc in m.tool_calls %}
+{%- if tc.function %}
+    {%- set tc = tc.function %}
+{%- endif %}
+{{- '<tool_call>' + tc.name -}}
+{% set _args = tc.arguments %}{% for k, v in _args.items() %}<arg_key>{{ k }}</arg_key><arg_value>{{ v | tojson(ensure_ascii=False) if v is not string else v }}</arg_value>{% endfor %}</tool_call>{% endfor %}
+{% endif %}
+{%- elif m.role == 'tool' -%}
+<|user|>Here are the tool execution results. Continue the task using this information:
+{%- if m.content is string -%}
+{{- m.content -}}
+{%- elif m.content is iterable and m.content is not mapping and m.content and m.content.0.type == "tool_reference" -%}
+{% for tr in m.content %}
+    {%- for tool in tools -%}
+        {%- if 'function' in tool -%}
+            {%- set tool = tool['function'] -%}
+        {%- endif -%}
+        {%- if tool.name == tr.name -%}
+{{- tool_to_json(tool) + '\n' -}}
+        {%- endif -%}
+    {%- endfor -%}
+{% endfor %}
+{%- else -%}
+{{- visible_text(m.content) -}}
+{% endif -%}
+{%- elif m.role == 'system' -%}
+<|system|>{{ visible_text(m.content) }}
+{%- endif -%}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+    <|assistant|>{{- '</think>' if (enable_thinking is defined and not enable_thinking) else '<think>' -}}
+{%- endif -%}


### PR DESCRIPTION
Addresses #22922.
Load a GLM5.1-specific chat template override so tool result turns are rendered in a continuation format the model can reliably consume, while leaving other models on their existing templates.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

In local Cursor-style tool-use workflows, GLM5.1 could emit valid tool calls, but it often failed to continue from successful tool results. From the user side, this showed up as Cursor being unable to reliably use tools such as `Shell` to read code, because the model kept re-issuing low-value tool calls instead of consuming the returned results and moving on.
During debugging, we ruled out several alternative explanations:
- it was not a temperature issue
- tool calls were being emitted correctly
- Cursor was actually executing the tools
- tool results were successfully returned to the model
- the `glm47` tool-call parser was not corrupting the generated tool call

The key observation was that the same tool result content became usable immediately once it was fed back to GLM5.1 in a different continuation format.
This suggests the issue is not in tool execution itself, but in how GLM5.1 consumes tool-result turns in this workflow.


## Modifications

This PR adds a GLM5.1-specific chat template override so tool-result turns are rendered in a continuation-style format that works more reliably for GLM5.1 in Cursor-style OpenAI tool-use flows.
Specifically:
- add a GLM5.1-specific template override at `python/sglang/srt/managers/templates/glm5_1_tool_result_as_user.jinja`
- update `python/sglang/srt/managers/template_manager.py` to apply this override only for GLM5.1
- leave the existing HuggingFace chat template behavior unchanged for other models
- keep an environment variable gate `SGLANG_GLM51_TOOL_RESULT_TEMPLATE_FIX` so the behavior can be explicitly disabled if needed

This is intended as a targeted compatibility fix for GLM5.1 behavior in this workflow, and can serve as a practical workaround while a more semantically aligned tool-result template path is evaluated.

## Accuracy Tests

Manual debugging and behavior verification were performed in local Cursor-style tool-use testing. The following were confirmed:
- tool calls were emitted correctly
- tool execution succeeded
- tool results were returned to the model
- after this change, GLM5.1 was able to continue normally from tool results instead of repeatedly re-issuing similar tool calls


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
