### PR TITLE
[Ray] Bind scheduler actors to GPU-local NUMA node

### DIFF
--- a/python/sglang/srt/ray/scheduler_actor.py
+++ b/python/sglang/srt/ray/scheduler_actor.py
@@ -50,7 +50,12 @@ class SchedulerActor:
     ):
         import dataclasses
 
-        from sglang.srt.managers.scheduler import Scheduler, configure_scheduler
+        from sglang.srt.environ import envs
+        from sglang.srt.managers.scheduler import Scheduler, configure_scheduler_process
+        from sglang.srt.utils.numa_utils import (
+            get_numa_node_if_available,
+            numa_bind_to_node,
+        )
 
         # Override dist_init_addr if provided (for multi-node)
         if dist_init_addr:
@@ -72,8 +77,9 @@ class SchedulerActor:
             logger.info(f"[TP{tp_rank}] Using passed gpu_id: {gpu_id}")
 
         # Configure worker (logging, process title, etc.)
-        dp_rank = configure_scheduler(
+        dp_rank = configure_scheduler_process(
             server_args,
+            actual_gpu_id,
             tp_rank,
             attn_cp_rank,
             moe_dp_rank,
@@ -81,6 +87,18 @@ class SchedulerActor:
             pp_rank,
             dp_rank,
         )
+
+        # Ray actors can't use the numactl subprocess-wrapping approach
+        # (SGLANG_NUMA_BIND_V2's normal path), so bind in-process via libnuma.
+        # The V1 path inside configure_scheduler_process already handles
+        # SGLANG_NUMA_BIND_V2=False.
+        if envs.SGLANG_NUMA_BIND_V2.get():
+            numa_node = get_numa_node_if_available(server_args, actual_gpu_id)
+            if numa_node is not None:
+                numa_bind_to_node(numa_node)
+                logger.info(
+                    f"[TP{tp_rank}] Bound to NUMA node {numa_node} for GPU {actual_gpu_id}"
+                )
 
         # Create scheduler (loads model into GPU, initializes NCCL)
         self.scheduler = Scheduler(


### PR DESCRIPTION
## Summary
- Ray actors are spawned by Ray's raylet, not via `multiprocessing.spawn`, so the `numactl` subprocess-wrapping path that `SGLANG_NUMA_BIND_V2` uses (`configure_subprocess` in `python/sglang/srt/utils/numa_utils.py`) never applies to them. With the default `SGLANG_NUMA_BIND_V2=True`, scheduler actors were running entirely unbound, because `configure_scheduler_process` guards its V1 in-process bind behind `if not SGLANG_NUMA_BIND_V2`.
- Add an in-process libnuma bind inside `SchedulerActor.__init__` when V2 is enabled, reusing the existing `get_numa_node_if_available` / `numa_bind_to_node` helpers. It runs before `Scheduler(...)` is constructed, so weight allocation and NCCL init land on the correct NUMA node.
- The V1 path (`if not SGLANG_NUMA_BIND_V2` inside `configure_scheduler_process`) still handles the V2-disabled case, so the two paths are complementary — no double-bind, no gap.
- Also fix the worker-configuration call to use the renamed `configure_scheduler_process` and pass `actual_gpu_id`.

## Test plan
```
SGLANG_ENABLE_SPEC_V2=1 python -m sglang.launch_server \
  --model-path Qwen/Qwen3.5-397B-A17B-FP8 --tp 8 \
  --reasoning-parser qwen3 --tool-call-parser qwen3_coder \
  --speculative-algorithm EAGLE --speculative-num-steps 3 \
  --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 \
  --mamba-scheduler-strategy extra_buffer --page-size 64 \
  --enable-flashinfer-allreduce-fusion --mem-fraction-static 0.8 \
  --skip-server-warmup --host 0.0.0.0 --port 30000
  --use-ray
  ```
**NUMA binding (Ray+NUMA)** helps Qwen significantly at rate=8-16:
   - Mean E2E: -9% to -16%
   - Mean TTFT: -7% to -18%
   - Throughput at rate=16: **+6.9%** (1209 → 1292 tok/s)
   - At rate=32 (fully saturated): ~2% improvement