### PR TITLE
feat(scheduler): adaptive warm reserve for chunked prefill

### DIFF
--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -862,6 +862,14 @@ class PrefillAdder:
                     ),
                 )
             else:
+                # Enforce the chunked_req singleton invariant. The scheduler assumes
+                # at most one chunked_req per step; creating a second would trip the
+                # assertion in get_new_batch_prefill. Historically this was guaranteed
+                # by add_chunked_req consuming the full rem_chunk_tokens, but with the
+                # adaptive warm-reserve feature there can be leftover budget here.
+                if has_chunked_req:
+                    return AddReqResult.OTHER
+
                 # Make sure at least one page is available
                 trunc_len = self.rem_chunk_tokens // self.page_size * self.page_size
 

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -625,7 +625,17 @@ class PrefillAdder:
             else AddReqResult.CONTINUE
         )
 
-    def add_chunked_req(self, req: Req):
+    def add_chunked_req(self, req: Req, max_chunk_tokens: Optional[int] = None):
+        """Admit the next chunk of an in-flight chunked-prefill request.
+
+        Args:
+            req: the in-flight chunked request.
+            max_chunk_tokens: optional cap on how many tokens this chunk may
+                consume. When set, it takes effect only if strictly smaller
+                than the natural chunk budget (rem_chunk_tokens / rem_total /
+                rem_swa). Used by the adaptive warm-reserve feature to leave
+                budget for waiting warm requests.
+        """
         if self.dllm_config is not None:
             _rem_tokens = self._get_dllm_remain_tokens()
         else:
@@ -636,6 +646,13 @@ class PrefillAdder:
             # Therefore, in certain cases where _rem_tokens <= 0, it should be replaced with rem_chunk_tokens.
             if _rem_tokens <= 0:
                 _rem_tokens = self.rem_chunk_tokens
+
+        if max_chunk_tokens is not None:
+            # Floor at 1 so the chunked_req always makes forward progress even
+            # if the caller asked for an aggressive cap. Callers are expected
+            # to respect page alignment; we do not enforce it here because the
+            # remaining paths already page-align via _update_prefill_budget.
+            _rem_tokens = min(_rem_tokens, max(1, max_chunk_tokens))
 
         truncated = req.extend_input_len > _rem_tokens
         req.set_extend_input_len(min(req.extend_input_len, _rem_tokens))

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -686,7 +686,7 @@ class PrefillAdder:
             else:
                 self.tree_cache.dec_lock_ref(last_node)
 
-    def add_one_req_ignore_eos(self, req: Req):
+    def add_one_req_ignore_eos(self, req: Req, has_chunked_req: bool = False):
         paged_input = self.ceil_paged_tokens(req.extend_input_len)
         if paged_input > min(self.cur_rem_tokens, self.rem_total_tokens):
             return AddReqResult.NO_TOKEN
@@ -760,6 +760,12 @@ class PrefillAdder:
                 min(req.sampling_params.max_new_tokens, CLIP_MAX_NEW_TOKENS),
             )
         else:
+            # Same chunked_req singleton invariant protection as add_one_req.
+            # The scheduler asserts at most one chunked_req per step; creating a
+            # second would trip the assertion in get_new_batch_prefill.
+            if has_chunked_req:
+                return AddReqResult.OTHER
+
             if self.rem_chunk_tokens <= 0:
                 return AddReqResult.OTHER
 
@@ -798,7 +804,7 @@ class PrefillAdder:
             return AddReqResult.OTHER
 
         if req.sampling_params.ignore_eos and getattr(self.tree_cache, "disable", True):
-            return self.add_one_req_ignore_eos(req)
+            return self.add_one_req_ignore_eos(req, has_chunked_req=has_chunked_req)
 
         # Reserve page_size for page-alignment overhead. The paged allocator
         # may consume up to one extra page per request (see alloc_extend), and

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2398,7 +2398,7 @@ class Scheduler(
         uncached length fits under --prefill-warm-extend-threshold. Each
         candidate's contribution is ceil-page-aligned so the leftover budget
         handed to add_chunked_req is also page-aligned. The total reserve is
-        capped by --prefill-max-warm-reserve and by (chunked_prefill_size - 1)
+        capped by --prefill-max-warm-reserve and by (chunked_prefill_size - page_size)
         so the chunked request always makes forward progress.
 
         Returns 0 when the feature is disabled or no warm requests are waiting,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2390,6 +2390,47 @@ class Scheduler(
             res = min(res, self.req_to_token_pool.available_size())
         return res
 
+    def _compute_prefill_warm_reserve(self, chunked_prefill_size: int) -> int:
+        """Sum the page-aligned uncached-prefill length of top-K warm waiting requests.
+
+        Uses the prefix_indices already populated by SchedulePolicy.calc_priority,
+        so no extra radix lookup is done here. A request is "warm" if its
+        uncached length fits under --prefill-warm-extend-threshold. Each
+        candidate's contribution is ceil-page-aligned so the leftover budget
+        handed to add_chunked_req is also page-aligned. The total reserve is
+        capped by --prefill-max-warm-reserve and by (chunked_prefill_size - 1)
+        so the chunked request always makes forward progress.
+
+        Returns 0 when the feature is disabled or no warm requests are waiting,
+        so behavior is unchanged in the common case.
+        """
+        if not self.server_args.enable_prefill_warm_reserve:
+            return 0
+
+        threshold = self.server_args.prefill_warm_extend_threshold
+        max_reserve = self.server_args.prefill_max_warm_reserve
+        peek_k = self.server_args.prefill_warm_peek_k
+        page_size = self.page_size
+        upper_cap = max(0, chunked_prefill_size - page_size)
+
+        reserve = 0
+        for req in self.waiting_queue[:peek_k]:
+            # prefix_indices is set by calc_priority on CacheAwarePolicy paths;
+            # on FCFS/other agnostic paths it may be empty, which is fine —
+            # extend is then just len(origin_input_ids) and such long requests
+            # will not qualify as warm under the threshold.
+            extend = len(req.origin_input_ids) - len(req.prefix_indices)
+            if 0 < extend <= threshold:
+                # Ceil-page-align so the leftover handed to add_chunked_req
+                # stays a multiple of page_size, matching existing invariants.
+                page_aligned = -(-extend // page_size) * page_size
+                reserve += page_aligned
+                if reserve >= max_reserve:
+                    reserve = max_reserve
+                    break
+
+        return min(reserve, upper_cap)
+
     def get_new_batch_prefill(self) -> Optional[ScheduleBatch]:
         prefill_delayer_single_pass = None
         if self.prefill_delayer:
@@ -2481,7 +2522,13 @@ class Scheduler(
 
         if self.chunked_req is not None:
             self.chunked_req.init_next_round_input()
-            self.chunked_req = adder.add_chunked_req(self.chunked_req)
+            warm_reserve = self._compute_prefill_warm_reserve(chunked_prefill_size)
+            max_chunk_tokens = (
+                chunked_prefill_size - warm_reserve if warm_reserve > 0 else None
+            )
+            self.chunked_req = adder.add_chunked_req(
+                self.chunked_req, max_chunk_tokens=max_chunk_tokens
+            )
 
         if self.enable_lora:
             running_loras = {req.lora_id for req in self.running_batch.reqs}

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -314,6 +314,9 @@ def validate_dflash_request(req: Req) -> Optional[str]:
     return None
 
 
+_PREFILL_RESERVE_PEEK_K = 8
+
+
 class Scheduler(
     SchedulerOutputProcessorMixin,
     SchedulerUpdateWeightsMixin,
@@ -2390,46 +2393,35 @@ class Scheduler(
             res = min(res, self.req_to_token_pool.available_size())
         return res
 
-    def _compute_prefill_warm_reserve(self, chunked_prefill_size: int) -> int:
-        """Sum the page-aligned uncached-prefill length of top-K warm waiting requests.
+    def _compute_prefill_reserve(self, chunked_prefill_size: int) -> int:
+        """Return page-aligned total extend of top-K waiting reqs that fit in the reserve budget.
 
-        Uses the prefix_indices already populated by SchedulePolicy.calc_priority,
-        so no extra radix lookup is done here. A request is "warm" if its
-        uncached length fits under --prefill-warm-extend-threshold. Each
-        candidate's contribution is ceil-page-aligned so the leftover budget
-        handed to add_chunked_req is also page-aligned. The total reserve is
-        capped by --prefill-max-warm-reserve and by (chunked_prefill_size - page_size)
-        so the chunked request always makes forward progress.
-
-        Returns 0 when the feature is disabled or no warm requests are waiting,
-        so behavior is unchanged in the common case.
+        Uses prefix_indices populated by SchedulePolicy.calc_priority, so no extra
+        radix lookup. A waiting req contributes its ceil-page-aligned extend if,
+        together with prior contributions, it fits in --prefill-reserve-budget
+        (and in chunked_prefill_size minus one page, so the chunked req keeps
+        forward progress). Returns 0 when the feature is disabled or no req fits.
         """
-        if not self.server_args.enable_prefill_warm_reserve:
+        budget = self.server_args.prefill_reserve_budget
+        if budget <= 0:
             return 0
 
-        threshold = self.server_args.prefill_warm_extend_threshold
-        max_reserve = self.server_args.prefill_max_warm_reserve
-        peek_k = self.server_args.prefill_warm_peek_k
         page_size = self.page_size
-        upper_cap = max(0, chunked_prefill_size - page_size)
+        budget = min(budget, max(0, chunked_prefill_size - page_size))
+        if budget <= 0:
+            return 0
 
         reserve = 0
-        for req in self.waiting_queue[:peek_k]:
-            # prefix_indices is set by calc_priority on CacheAwarePolicy paths;
-            # on FCFS/other agnostic paths it may be empty, which is fine —
-            # extend is then just len(origin_input_ids) and such long requests
-            # will not qualify as warm under the threshold.
+        for req in self.waiting_queue[:_PREFILL_RESERVE_PEEK_K]:
             extend = len(req.origin_input_ids) - len(req.prefix_indices)
-            if 0 < extend <= threshold:
-                # Ceil-page-align so the leftover handed to add_chunked_req
-                # stays a multiple of page_size, matching existing invariants.
-                page_aligned = -(-extend // page_size) * page_size
-                reserve += page_aligned
-                if reserve >= max_reserve:
-                    reserve = max_reserve
-                    break
+            if extend <= 0:
+                continue
+            page_aligned = -(-extend // page_size) * page_size
+            if reserve + page_aligned > budget:
+                continue
+            reserve += page_aligned
 
-        return min(reserve, upper_cap)
+        return reserve
 
     def get_new_batch_prefill(self) -> Optional[ScheduleBatch]:
         prefill_delayer_single_pass = None
@@ -2522,10 +2514,8 @@ class Scheduler(
 
         if self.chunked_req is not None:
             self.chunked_req.init_next_round_input()
-            warm_reserve = self._compute_prefill_warm_reserve(chunked_prefill_size)
-            max_chunk_tokens = (
-                chunked_prefill_size - warm_reserve if warm_reserve > 0 else None
-            )
+            reserve = self._compute_prefill_reserve(chunked_prefill_size)
+            max_chunk_tokens = chunked_prefill_size - reserve if reserve > 0 else None
             self.chunked_req = adder.add_chunked_req(
                 self.chunked_req, max_chunk_tokens=max_chunk_tokens
             )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6548,6 +6548,21 @@ class ServerArgs:
                 self.chunked_prefill_size % self.page_size == 0
             ), "chunked_prefill_size must be divisible by page_size"
 
+        # Check prefill adaptive warm-reserve tunables
+        if self.enable_prefill_warm_reserve:
+            assert (
+                self.prefill_warm_extend_threshold > 0
+            ), "--prefill-warm-extend-threshold must be > 0"
+            assert (
+                self.prefill_max_warm_reserve > 0
+            ), "--prefill-max-warm-reserve must be > 0"
+            assert self.prefill_warm_peek_k > 0, "--prefill-warm-peek-k must be > 0"
+            if self.chunked_prefill_size is not None and self.chunked_prefill_size > 0:
+                assert self.prefill_max_warm_reserve < self.chunked_prefill_size, (
+                    "--prefill-max-warm-reserve must be < --chunked-prefill-size "
+                    "so the chunked request can still make progress"
+                )
+
         # Check pdmux
         if self.enable_pdmux:
             assert (

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -347,6 +347,15 @@ class ServerArgs:
     max_total_tokens: Optional[int] = None
     chunked_prefill_size: Optional[int] = None
     enable_dynamic_chunking: bool = False
+    # Adaptive warm-reserve for chunked prefill. When enabled, the scheduler
+    # caps the per-step chunk size of an in-flight chunked request to leave
+    # room for waiting requests with small uncached-prefill length (warm cache
+    # hits). Designed for multi-turn agentic workloads where shorter-compute
+    # requests should not be head-of-line blocked by a cold long request.
+    enable_prefill_warm_reserve: bool = False
+    prefill_warm_extend_threshold: int = 2048
+    prefill_max_warm_reserve: int = 4096
+    prefill_warm_peek_k: int = 8
     max_prefill_tokens: int = 16384
     prefill_max_requests: Optional[int] = None
     schedule_policy: str = "fcfs"
@@ -4263,6 +4272,38 @@ class ServerArgs:
             type=int,
             default=ServerArgs.chunked_prefill_size,
             help="The maximum number of tokens in a chunk for the chunked prefill. Setting this to -1 means disabling chunked prefill.",
+        )
+        parser.add_argument(
+            "--enable-prefill-warm-reserve",
+            action="store_true",
+            default=ServerArgs.enable_prefill_warm_reserve,
+            help="Enable adaptive warm-reserve for chunked prefill. When set, the "
+            "scheduler caps each per-step chunk of an in-flight chunked request "
+            "to leave room for waiting requests whose uncached-prefill length is "
+            "small enough to finish in the same forward pass. Useful for multi-turn "
+            "agentic workloads with a mix of cold and warm requests.",
+        )
+        parser.add_argument(
+            "--prefill-warm-extend-threshold",
+            type=int,
+            default=ServerArgs.prefill_warm_extend_threshold,
+            help="A waiting request is considered 'warm' only if its uncached-prefill "
+            "length (origin_input_ids minus matched prefix) is <= this many tokens. "
+            "Only warm requests are counted toward the reserve.",
+        )
+        parser.add_argument(
+            "--prefill-max-warm-reserve",
+            type=int,
+            default=ServerArgs.prefill_max_warm_reserve,
+            help="Maximum total tokens to reserve from the chunked-prefill budget for "
+            "warm waiting requests per step. Caps the throughput tax on the cold request.",
+        )
+        parser.add_argument(
+            "--prefill-warm-peek-k",
+            type=int,
+            default=ServerArgs.prefill_warm_peek_k,
+            help="How many of the top waiting-queue requests to examine when computing "
+            "the warm reserve. Keeps the per-step scan bounded.",
         )
         parser.add_argument(
             "--prefill-max-requests",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -347,15 +347,11 @@ class ServerArgs:
     max_total_tokens: Optional[int] = None
     chunked_prefill_size: Optional[int] = None
     enable_dynamic_chunking: bool = False
-    # Adaptive warm-reserve for chunked prefill. When enabled, the scheduler
-    # caps the per-step chunk size of an in-flight chunked request to leave
-    # room for waiting requests with small uncached-prefill length (warm cache
-    # hits). Designed for multi-turn agentic workloads where shorter-compute
-    # requests should not be head-of-line blocked by a cold long request.
-    enable_prefill_warm_reserve: bool = False
-    prefill_warm_extend_threshold: int = 2048
-    prefill_max_warm_reserve: int = 4096
-    prefill_warm_peek_k: int = 8
+    # Adaptive prefill reserve. Per-step token budget carved out of the
+    # chunked-prefill budget so that waiting requests whose uncached-prefill
+    # length fits can interleave into the same forward pass as an in-flight
+    # chunked (cold) request. 0 disables the feature.
+    prefill_reserve_budget: int = 0
     max_prefill_tokens: int = 16384
     prefill_max_requests: Optional[int] = None
     schedule_policy: str = "fcfs"
@@ -4274,36 +4270,14 @@ class ServerArgs:
             help="The maximum number of tokens in a chunk for the chunked prefill. Setting this to -1 means disabling chunked prefill.",
         )
         parser.add_argument(
-            "--enable-prefill-warm-reserve",
-            action="store_true",
-            default=ServerArgs.enable_prefill_warm_reserve,
-            help="Enable adaptive warm-reserve for chunked prefill. When set, the "
-            "scheduler caps each per-step chunk of an in-flight chunked request "
-            "to leave room for waiting requests whose uncached-prefill length is "
-            "small enough to finish in the same forward pass. Useful for multi-turn "
-            "agentic workloads with a mix of cold and warm requests.",
-        )
-        parser.add_argument(
-            "--prefill-warm-extend-threshold",
+            "--prefill-reserve-budget",
             type=int,
-            default=ServerArgs.prefill_warm_extend_threshold,
-            help="A waiting request is considered 'warm' only if its uncached-prefill "
-            "length (origin_input_ids minus matched prefix) is <= this many tokens. "
-            "Only warm requests are counted toward the reserve.",
-        )
-        parser.add_argument(
-            "--prefill-max-warm-reserve",
-            type=int,
-            default=ServerArgs.prefill_max_warm_reserve,
-            help="Maximum total tokens to reserve from the chunked-prefill budget for "
-            "warm waiting requests per step. Caps the throughput tax on the cold request.",
-        )
-        parser.add_argument(
-            "--prefill-warm-peek-k",
-            type=int,
-            default=ServerArgs.prefill_warm_peek_k,
-            help="How many of the top waiting-queue requests to examine when computing "
-            "the warm reserve. Keeps the per-step scan bounded.",
+            default=ServerArgs.prefill_reserve_budget,
+            help="Per-step token budget reserved from chunked prefill for waiting "
+            "requests that fit. 0 disables the feature. When > 0, the scheduler "
+            "caps the per-step chunk of an in-flight chunked request to leave this "
+            "much budget for small uncached-prefill-length waiters (typical of "
+            "multi-turn agentic workloads with high cache hit).",
         )
         parser.add_argument(
             "--prefill-max-requests",
@@ -6548,20 +6522,17 @@ class ServerArgs:
                 self.chunked_prefill_size % self.page_size == 0
             ), "chunked_prefill_size must be divisible by page_size"
 
-        # Check prefill adaptive warm-reserve tunables
-        if self.enable_prefill_warm_reserve:
-            assert (
-                self.prefill_warm_extend_threshold > 0
-            ), "--prefill-warm-extend-threshold must be > 0"
-            assert (
-                self.prefill_max_warm_reserve > 0
-            ), "--prefill-max-warm-reserve must be > 0"
-            assert self.prefill_warm_peek_k > 0, "--prefill-warm-peek-k must be > 0"
-            if self.chunked_prefill_size is not None and self.chunked_prefill_size > 0:
-                assert self.prefill_max_warm_reserve < self.chunked_prefill_size, (
-                    "--prefill-max-warm-reserve must be < --chunked-prefill-size "
-                    "so the chunked request can still make progress"
-                )
+        # Check prefill adaptive reserve tunable
+        assert self.prefill_reserve_budget >= 0, "--prefill-reserve-budget must be >= 0"
+        if (
+            self.prefill_reserve_budget > 0
+            and self.chunked_prefill_size is not None
+            and self.chunked_prefill_size > 0
+        ):
+            assert self.prefill_reserve_budget < self.chunked_prefill_size, (
+                "--prefill-reserve-budget must be < --chunked-prefill-size so the "
+                "chunked request retains budget"
+            )
 
         # Check pdmux
         if self.enable_pdmux:

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -522,6 +522,27 @@ class TestPrefillAdder(CustomTestCase):
         self.assertEqual(chunked.extend_input_len, 500)
         self.assertEqual(adder.rem_chunk_tokens, 8192 - 500)
 
+    def test_add_chunked_req_zero_cap_floors_at_one_token(self):
+        """max_chunk_tokens=0 must still admit at least one token so the chunked
+        request always makes forward progress (deliberate floor in add_chunked_req).
+        """
+        running_batch = self.create_running_batch([])
+        self.mock_token_allocator.full_available_size.return_value = 100_000
+        self.mock_token_allocator.available_size.return_value = 100_000
+        adder = self.create_adder(
+            running_batch,
+            rem_input_tokens=100_000,
+            rem_chunk_tokens=8192,
+        )
+
+        chunked = self.create_chunked_req("c1", remaining_extend=50_000)
+
+        remaining_req = adder.add_chunked_req(chunked, max_chunk_tokens=0)
+
+        self.assertIs(remaining_req, chunked, "req should remain chunked")
+        self.assertEqual(chunked.extend_input_len, 1, "floor at 1 must apply")
+        self.assertEqual(adder.rem_chunk_tokens, 8192 - 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -578,6 +578,39 @@ class TestPrefillAdder(CustomTestCase):
             adder.new_chunked_req, "must not promote to second chunked_req"
         )
 
+    def test_add_one_req_ignore_eos_with_has_chunked_req_refuses_second_chunked(self):
+        """Mirror of the add_one_req gate test, but through the ignore_eos + disabled
+        tree_cache path. Both sibling promotion paths must respect the chunked_req
+        singleton invariant.
+        """
+        self.mock_tree_cache.disable = True
+        running_batch = self.create_running_batch([])
+        self.mock_token_allocator.full_available_size.return_value = 100_000
+        self.mock_token_allocator.available_size.return_value = 100_000
+        adder = self.create_adder(
+            running_batch,
+            rem_input_tokens=100_000,
+            rem_chunk_tokens=3000,
+        )
+
+        new_req = self.create_mock_req("w1", priority=0, max_new_tokens=16)
+        new_req.extend_input_len = 5000
+        new_req.prefix_indices = []
+        new_req.fill_ids = [0] * 5000
+        new_req.origin_input_ids = [0] * 5000
+        new_req.host_hit_length = 0
+        new_req.last_node = MagicMock()
+        new_req.set_extend_input_len = lambda n: setattr(new_req, "extend_input_len", n)
+        new_req.cache_protected_len = 0
+        new_req.sampling_params.ignore_eos = True
+
+        result = adder.add_one_req(
+            new_req, has_chunked_req=True, truncation_align_size=None
+        )
+
+        self.assertEqual(result, AddReqResult.OTHER)
+        self.assertIsNone(adder.new_chunked_req, "must not promote via ignore_eos path")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -543,6 +543,41 @@ class TestPrefillAdder(CustomTestCase):
         self.assertEqual(chunked.extend_input_len, 1, "floor at 1 must apply")
         self.assertEqual(adder.rem_chunk_tokens, 8192 - 1)
 
+    def test_add_one_req_with_has_chunked_req_refuses_second_chunked(self):
+        """When a chunked_req is already in flight (has_chunked_req=True) and a
+        new waiting req is too big to fit in leftover rem_chunk_tokens, add_one_req
+        must return OTHER instead of promoting it to a second chunked_req. This
+        protects the chunked_req singleton invariant.
+        """
+        running_batch = self.create_running_batch([])
+        self.mock_token_allocator.full_available_size.return_value = 100_000
+        self.mock_token_allocator.available_size.return_value = 100_000
+        adder = self.create_adder(
+            running_batch,
+            rem_input_tokens=100_000,
+            rem_chunk_tokens=3000,  # simulating leftover after an earlier add_chunked_req
+        )
+
+        new_req = self.create_mock_req("w1", priority=0, max_new_tokens=16)
+        new_req.extend_input_len = 5000
+        new_req.prefix_indices = []
+        new_req.fill_ids = [0] * 5000
+        new_req.origin_input_ids = [0] * 5000
+        new_req.host_hit_length = 0
+        new_req.last_node = MagicMock()
+        new_req.set_extend_input_len = lambda n: setattr(new_req, "extend_input_len", n)
+        new_req.cache_protected_len = 0
+        new_req.sampling_params.ignore_eos = False
+
+        result = adder.add_one_req(
+            new_req, has_chunked_req=True, truncation_align_size=None
+        )
+
+        self.assertEqual(result, AddReqResult.OTHER)
+        self.assertIsNone(
+            adder.new_chunked_req, "must not promote to second chunked_req"
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -79,6 +79,20 @@ class TestPrefillAdder(CustomTestCase):
         req.finished.return_value = False
         return req
 
+    def create_chunked_req(self, rid, remaining_extend):
+        """Build a req that looks like a mid-chunk chunked_req.
+
+        remaining_extend is how many more tokens are left to prefill for this
+        request. The req will be handed to add_chunked_req which may consume
+        all or part of that amount depending on rem_chunk_tokens / max_chunk_tokens.
+        """
+        req = self.create_mock_req(rid, priority=0, max_new_tokens=16)
+        req.extend_input_len = remaining_extend
+        req.prefix_indices = []
+        req.fill_ids = [0] * remaining_extend
+        req.set_extend_input_len = lambda n: setattr(req, "extend_input_len", n)
+        return req
+
     def create_adder(self, running_batch, **kwargs):
         defaults = dict(
             page_size=1,
@@ -441,6 +455,72 @@ class TestPrefillAdder(CustomTestCase):
         self.assertEqual(len(adder2.can_run_list), 2)
         self.assertEqual(adder2.rem_chunk_tokens, 0)  # 3 - 3 = 0
         self.assertEqual(result3, AddReqResult.OTHER)
+
+    def test_add_chunked_req_default_consumes_full_budget(self):
+        """With max_chunk_tokens=None (default), add_chunked_req consumes the full
+        rem_chunk_tokens budget when the request still has more tokens to prefill.
+        """
+        running_batch = self.create_running_batch([])
+        self.mock_token_allocator.full_available_size.return_value = 100_000
+        self.mock_token_allocator.available_size.return_value = 100_000
+        adder = self.create_adder(
+            running_batch,
+            rem_input_tokens=100_000,
+            rem_chunk_tokens=8192,
+        )
+
+        chunked = self.create_chunked_req("c1", remaining_extend=50_000)
+
+        remaining_req = adder.add_chunked_req(chunked)
+
+        self.assertIs(
+            remaining_req, chunked, "req should remain truncated (not finished)"
+        )
+        self.assertEqual(chunked.extend_input_len, 8192)
+        self.assertEqual(adder.rem_chunk_tokens, 0)
+
+    def test_add_chunked_req_max_chunk_tokens_caps_consumption(self):
+        """When max_chunk_tokens is smaller than rem_chunk_tokens, the chunk is
+        capped and leftover rem_chunk_tokens is available for subsequent add_one_req
+        calls in the same step.
+        """
+        running_batch = self.create_running_batch([])
+        self.mock_token_allocator.full_available_size.return_value = 100_000
+        self.mock_token_allocator.available_size.return_value = 100_000
+        adder = self.create_adder(
+            running_batch,
+            rem_input_tokens=100_000,
+            rem_chunk_tokens=8192,
+        )
+
+        chunked = self.create_chunked_req("c1", remaining_extend=50_000)
+
+        remaining_req = adder.add_chunked_req(chunked, max_chunk_tokens=4915)
+
+        self.assertIs(remaining_req, chunked)
+        self.assertEqual(chunked.extend_input_len, 4915)
+        self.assertEqual(adder.rem_chunk_tokens, 8192 - 4915)
+
+    def test_add_chunked_req_cap_larger_than_remaining_finishes_req(self):
+        """If max_chunk_tokens exceeds the req's remaining extend, the req finishes
+        (add_chunked_req returns None) and only the actual extend is consumed.
+        """
+        running_batch = self.create_running_batch([])
+        self.mock_token_allocator.full_available_size.return_value = 100_000
+        self.mock_token_allocator.available_size.return_value = 100_000
+        adder = self.create_adder(
+            running_batch,
+            rem_input_tokens=100_000,
+            rem_chunk_tokens=8192,
+        )
+
+        chunked = self.create_chunked_req("c1", remaining_extend=500)
+
+        remaining_req = adder.add_chunked_req(chunked, max_chunk_tokens=4915)
+
+        self.assertIsNone(remaining_req, "req should finish, not remain chunked")
+        self.assertEqual(chunked.extend_input_len, 500)
+        self.assertEqual(adder.rem_chunk_tokens, 8192 - 500)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds `--prefill-reserve-budget N` so waiting requests with small uncached-prefill length can interleave into the **same forward pass** as an in-flight chunked cold-prefill request. 0 disables the feature; default is 0, so server behavior is unchanged out of the box.

**Motivation:** long-context multi-turn agentic workloads on PD-disaggregation prefill engines. When a cold long request enters chunked prefill, it monopolizes the per-step token budget via ``add_chunked_req``, head-of-line blocking short-compute waiters for many chunks. This change lets the scheduler reserve a slice of the budget so those waiters finish in one step.

**How it works:** before calling ``add_chunked_req``, the scheduler peeks at the top-K (8) waiting-queue requests and sums the page-aligned uncached-prefill length (``len(origin_input_ids) - len(prefix_indices)``) of any whose contribution fits in the reserve budget. The sum is passed as ``max_chunk_tokens`` to ``add_chunked_req``; the existing ``add_one_req`` loop then admits those waiters into the leftover budget. No changes to the PD state machine — ``KVSender`` / bootstrap / inflight queues are untouched and ``is_chunked`` is decremented per forward regardless of chunk size.

**Also in this PR:** defensive fix for the ``chunked_req`` singleton invariant. Prior to this change, the assertion in ``get_new_batch_prefill`` was satisfied only by the accident of ``add_chunked_req`` consuming the entire ``rem_chunk_tokens``. Once we leave leftover budget, both ``PrefillAdder.add_one_req`` and ``PrefillAdder.add_one_req_ignore_eos`` chunked-promotion branches must explicitly reject promotion when ``has_chunked_req=True``.

**Safety:**
- Reserve is ceil-page-aligned; effective budget is further floored at ``chunked_prefill_size - page_size`` so the chunked request always retains at least one page of forward progress.
- Config validation rejects ``prefill_reserve_budget >= chunked_prefill_size``.
- Disabled path (``prefill_reserve_budget = 0``) short-circuits on the first line of the helper — byte-identical to ``main`` scheduler decisions.

## Test plan
- [x] ``python -m pytest test/registered/unit/managers/test_prefill_adder.py -v`` — 14/14 passing (6 new + 8 existing). Verified on CPU-only venv.
- [ ] E2E on PD-disagg prefill: set ``--prefill-reserve-budget`` to a nonzero value, send a cold long request mid-chunk plus several short-context requests, confirm the short ones interleave in the same forward pass and cold progression slows by roughly ``chunked_prefill_size / (chunked_prefill_size - budget)``.
- [ ] Regression: run existing ``per-commit`` suite with flag at default (0); expect byte-identical scheduler decisions vs ``main``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)