### PR TITLE
fix(disagg): support per-GPU JSON mapping in --disaggregation-ib-device

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3610,16 +3610,28 @@ class ServerArgs:
         Validate IB devices before passing to mooncake.
 
         Args:
-            device_str: Comma-separated IB device names (e.g., "mlx5_0,mlx5_1")
+            device_str: Comma-separated IB device names (e.g., "mlx5_0,mlx5_1"),
+                OR a JSON per-GPU mapping (e.g., '{"0":"mlx5_4","1":"mlx5_5"}'),
+                OR a path to a .json file containing such a mapping.
+                JSON forms are parsed downstream by get_ib_devices_for_gpu()
+                in mooncake_transfer_engine.py.
 
         Returns:
-            Normalized comma-separated string of validated device names, or None if input is None.
+            Validated device string, or None if input is None.
         """
         if device_str is None:
             logger.warning(
                 "No IB devices specified for Mooncake backend, falling back to auto discovery."
             )
             return None
+
+        # Pass through JSON per-GPU mappings and .json file paths unchanged.
+        # get_ib_devices_for_gpu() in mooncake_transfer_engine.py already
+        # supports these formats for per-GPU rail alignment on multi-rail
+        # fabrics where GPU indices don't match NIC indices.
+        stripped = device_str.strip()
+        if stripped.startswith("{") or stripped.endswith(".json"):
+            return device_str
 
         # Strip whitespace from device names
         devices = [d.strip() for d in device_str.split(",") if d.strip()]


### PR DESCRIPTION
## Summary

- `_validate_ib_devices()` now passes through JSON per-GPU mappings and `.json` file paths to the downstream `get_ib_devices_for_gpu()` parser, which already supports these formats.
- Enables rail alignment on multi-rail HPC fabrics where GPU indices don't match NIC indices (standard on HGX H100/H200 platforms).
- Without this, users must pass a flat comma-separated list which gives every GPU access to all devices, causing mooncake's internal QP selection to pick NICs non-deterministically across peers, leading to cross-rail RDMA failures in PD disaggregation.

## Details

On rail-optimized clusters (e.g., 8-GPU + 8-NIC nodes), PCIe slot ordering (NICs) typically differs from NVLink group ordering (GPUs). For example, `nvidia-smi topo -m` on HGX-style nodes shows GPU 0 pairs with NIC 4 at PIX level, not NIC 0. The correct mapping for mooncake's RDMA transport is:

```
{"0":"mlx5_4","1":"mlx5_5","2":"mlx5_6","3":"mlx5_7","4":"mlx5_0","5":"mlx5_1","6":"mlx5_2","7":"mlx5_3"}
```

`get_ib_devices_for_gpu()` in `mooncake_transfer_engine.py` already parses this JSON format and resolves per-GPU device names. But `_validate_ib_devices()` in `server_args.py` runs first and rejects anything that isn't a literal IB device name after splitting on commas.

The fix adds a 2-line early return that detects JSON content (`{...}`) or `.json` file paths and passes them through unchanged.