### PR TITLE
[release] install rust toolchain in main dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -472,6 +472,13 @@ RUN --mount=type=cache,target=/var/cache/apt,id=framework-apt \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
+# Install Rust toolchain (for setuptools-rust-built extensions, e.g. sglang-grpc).
+# Minimum supported version: 1.85 (first stable with edition 2024).
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN curl --proto '=https' --tlsv1.2 --retry 3 --retry-delay 2 -sSf https://sh.rustup.rs \
+        | sh -s -- -y --no-modify-path \
+    && rustc --version && cargo --version
+
 # Install NVIDIA development tools
 RUN --mount=type=cache,target=/var/cache/apt,id=framework-apt \
     apt update -y \


### PR DESCRIPTION
## Summary

- Add rustup install to `docker/Dockerfile` (framework stage)
- Images that already install rust are left untouched: `docker/rocm.Dockerfile` (line 264), `docker/gateway.Dockerfile` (line 46). `docker/sagemaker.Dockerfile` inherits from the main image.
- Toolchain is installed via \`sh.rustup.rs\` with \`--no-modify-path\` (PATH is set explicitly via \`ENV\`).

## Why

https://github.com/sgl-project/sglang/pull/22736 breaks CI. The native gRPC crate under \`rust/sglang-grpc/\` is bundled into the main \`sglang\` wheel via setuptools-rust. Any source install (editable or non-editable) invokes \`cargo\` at build time, so \`rustc\`/\`cargo\` must be on \`PATH\` in the container. Today they are not, which causes \`pip install\` to fail with \`error: can't find Rust compiler\` when a Rust extension is present.

Minimum supported version is 1.85 (first stable with edition 2024); the default stable channel is well above that.

## Test plan

- [x] Rebuild each affected image and confirm \`rustc --version\` / \`cargo --version\` succeed in the final image.
- [x] Verify pip install of a setuptools-rust-bearing \`sglang\` tree succeeds inside each image.