### PR TITLE
[release] install rust toolchain in release docker images

### DIFF
--- a/docker/diffusion.Dockerfile
+++ b/docker/diffusion.Dockerfile
@@ -34,6 +34,13 @@ ENV CUDA_HOME=/usr/local/cuda-12.8
 ENV PATH=${CUDA_HOME}/bin:${PATH}
 ENV LD_LIBRARY_PATH=${CUDA_HOME}/lib64:$LD_LIBRARY_PATH
 
+# Install Rust toolchain (for setuptools-rust-built extensions, e.g. sglang-grpc).
+# Minimum supported version: 1.85 (first stable with edition 2024).
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN curl --proto '=https' --tlsv1.2 --retry 3 --retry-delay 2 -sSf https://sh.rustup.rs \
+        | sh -s -- -y --no-modify-path \
+    && rustc --version && cargo --version
+
 # Install uv and source its environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
     echo 'source $HOME/.local/bin/env' >> /root/.zshrc

--- a/docker/npu.Dockerfile
+++ b/docker/npu.Dockerfile
@@ -69,6 +69,12 @@ ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 
+# Install Rust toolchain (for setuptools-rust-built extensions, e.g. sglang-grpc).
+# Minimum supported version: 1.85 (first stable with edition 2024).
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN curl --proto '=https' --tlsv1.2 --retry 3 --retry-delay 2 -sSf https://sh.rustup.rs \
+        | sh -s -- -y --no-modify-path \
+    && rustc --version && cargo --version
 
 ### Install MemFabric
 RUN ${PIP_INSTALL} memfabric-hybrid==1.0.5

--- a/docker/xeon.Dockerfile
+++ b/docker/xeon.Dockerfile
@@ -23,6 +23,13 @@ RUN apt-get update && \
 
 WORKDIR /opt
 
+# Install Rust toolchain (for setuptools-rust-built extensions, e.g. sglang-grpc).
+# Minimum supported version: 1.85 (first stable with edition 2024).
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN curl --proto '=https' --tlsv1.2 --retry 3 --retry-delay 2 -sSf https://sh.rustup.rs \
+        | sh -s -- -y --no-modify-path \
+    && rustc --version && cargo --version
+
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
     source $HOME/.local/bin/env && \
     uv venv --python 3.12

--- a/docker/xpu.Dockerfile
+++ b/docker/xpu.Dockerfile
@@ -50,6 +50,14 @@ RUN --mount=type=secret,id=github_token \
     conda activate py${PYTHON_VERSION} && \
     pip3 install torch==2.11.0+xpu torchao torchvision torchaudio==2.11.0+xpu --index-url https://download.pytorch.org/whl/xpu
 
+# Install Rust toolchain (for setuptools-rust-built extensions, e.g. sglang-grpc).
+# Minimum supported version: 1.85 (first stable with edition 2024).
+# Installed as user 'sdp' so $HOME/.cargo is writable without root.
+ENV PATH="/home/sdp/.cargo/bin:${PATH}"
+RUN curl --proto '=https' --tlsv1.2 --retry 3 --retry-delay 2 -sSf https://sh.rustup.rs \
+        | sh -s -- -y --no-modify-path \
+    && rustc --version && cargo --version
+
 RUN --mount=type=secret,id=github_token \
     cd /home/sdp && \
     . /home/sdp/miniforge3/bin/activate && \


### PR DESCRIPTION
## Summary

Adds a rustup install to the four release-image Dockerfiles that perform a source install of sglang at image build time:

- \`docker/diffusion.Dockerfile\`
- \`docker/npu.Dockerfile\`
- \`docker/xeon.Dockerfile\`
- \`docker/xpu.Dockerfile\`

Images that already install rust (\`docker/rocm.Dockerfile\`, \`docker/gateway.Dockerfile\`) are left untouched; \`docker/sagemaker.Dockerfile\` inherits from the main image.

## Why

Once the native Rust gRPC crate is bundled into the main sglang wheel via \`setuptools-rust\`, each of the release image builds invokes \`cargo\` during \`pip install .\` (or the \`[all_npu]\` / \`[diffusion]\` variants). Without \`rustc\`/\`cargo\` on \`PATH\` the image build fails with:

\`\`\`
error: can't find Rust compiler
\`\`\`

This is a paired change with the main-image PR (adds rust to \`docker/Dockerfile\`). Split so each Dockerfile change is independently reviewable and the release-image nightly workflows can be re-run separately.

## Test plan

- [ ] Rebuild each affected image and confirm \`rustc --version\` / \`cargo --version\` succeed in the final image.
- [ ] Verify a \`pip install\` path that pulls in a setuptools-rust-built crate succeeds inside each image.

Note: the NPU nightly currently has a pre-existing transient \`libgl1-mesa-glx\` apt issue that may cause re-runs to flake; unrelated to this PR.