### PR TITLE
ci: install rust toolchain in ci_install_dependency.sh

### DIFF
--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -149,7 +149,12 @@ fi
 # Install protoc
 bash "${SCRIPT_DIR}/../utils/install_protoc.sh"
 
-mark_step_done "Python package site hygiene & install protoc"
+# Install Rust toolchain (needed by crates built via setuptools-rust, e.g. the
+# native gRPC extension bundled into the sglang wheel).
+bash "${SCRIPT_DIR}/../utils/install_rustup.sh"
+export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:${PATH}"
+
+mark_step_done "Python package site hygiene & install protoc + rust"
 
 # ------------------------------------------------------------------------------
 # Pip / uv toolchain & stale package cleanup

--- a/scripts/ci/npu/npu_ci_install_dependency.sh
+++ b/scripts/ci/npu/npu_ci_install_dependency.sh
@@ -32,6 +32,12 @@ export UV_NO_CACHE=true
 export UV_SYSTEM_PYTHON=true
 export UV_INDEX_STRATEGY=unsafe-best-match
 
+# Install Rust toolchain (needed by crates built via setuptools-rust, e.g. the
+# native gRPC extension bundled into the sglang wheel).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bash "${SCRIPT_DIR}/../utils/install_rustup.sh"
+export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:${PATH}"
+
 # Pin wheel to 0.45.1, REF: https://github.com/pypa/wheel/issues/662
 ${UV_PIP_INSTALL} wheel==0.45.1 pybind11 pyyaml decorator scipy attrs psutil
 

--- a/scripts/ci/utils/install_rustup.sh
+++ b/scripts/ci/utils/install_rustup.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Ensure a Rust toolchain (rustc/cargo) is installed for crates built from
+# source, e.g. the native gRPC extension bundled into the sglang wheel via
+# setuptools-rust. Minimum supported version is 1.85 (edition 2024).
+set -euxo pipefail
+
+# Pick up cargo if rustup was installed in a previous CI step.
+export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:${PATH}"
+
+if command -v cargo >/dev/null 2>&1 && command -v rustc >/dev/null 2>&1; then
+    echo "rust already installed: $(rustc --version), $(cargo --version)"
+    exit 0
+fi
+
+echo "rust not found, installing via rustup..."
+
+# rustup.rs requires curl — make sure it's present.
+if ! command -v curl >/dev/null 2>&1; then
+    if command -v apt-get &> /dev/null; then
+        apt-get update || true
+        apt-get install -y --no-install-recommends curl ca-certificates
+    elif command -v yum &> /dev/null; then
+        yum install -y curl ca-certificates
+    else
+        echo "ERROR: curl is required to install rustup, but no supported package manager was found"
+        exit 1
+    fi
+fi
+
+curl --proto '=https' --tlsv1.2 --retry 3 --retry-delay 2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --no-modify-path
+
+# Make cargo/rustc visible to the rest of this shell and to subsequent
+# GitHub Actions steps in the same job.
+export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:${PATH}"
+if [ -n "${GITHUB_PATH:-}" ]; then
+    echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "${GITHUB_PATH}"
+fi
+
+rustc --version
+cargo --version


### PR DESCRIPTION
## Summary

- Adds `scripts/ci/utils/install_rustup.sh` that installs rustup/cargo/rustc via `sh.rustup.rs` when not already present (mirrors the existing `install_protoc.sh` helper).
- Wires it into `scripts/ci/cuda/ci_install_dependency.sh` and NPU equiv right after `install_protoc.sh`, so the toolchain is guaranteed to be on `PATH` before `pip install -e .` runs.

## Why

The native Rust gRPC crate (`rust/sglang-grpc/`) is bundled into the main sglang wheel via `setuptools-rust`. Any source install — including the editable install CI performs — invokes `cargo`/`rustc` at build time. If they are not on `PATH` the install fails with:

```bash
error: can't find Rust compiler
```

This is a belt-and-braces fix that installs rust at CI-step time, so it works regardless of whether the runner image already carries a toolchain.

## Test plan

- [ ] PR-test stages reach \`pip install -e .\` without the "can't find Rust compiler" error.
- [ ] \`install_rustup.sh\` is a no-op when rust is already installed (exits early with the existing versions).

## Related

#23014 (main image) and #23016 (release images) both also do this, but can be landed later with other CI changes