### PR TITLE
Add test cases for NPU scenarios.

### DIFF
--- a/python/sglang/test/ascend/output_capturer.py
+++ b/python/sglang/test/ascend/output_capturer.py
@@ -1,0 +1,117 @@
+import os
+import select
+import threading
+
+
+class OutputCapturer:
+    """Capture all console print information
+
+    Class Description:
+        Capture console output using low-level file descriptor redirection.
+        Used to obtain print information from child processes, NPU processes,
+        and underlying C/C++ modules that are not logged in sglang logs for test assertion.
+        All captured output will be displayed normally in the console in real-time.
+    """
+
+    def __init__(self):
+        """Initialize all member variables of the capturer"""
+        self.old_stdout = None
+        self.old_stderr = None
+        self.pipe_out = None
+        self.pipe_in = None
+        self.pipe_err_out = None
+        self.pipe_err_in = None
+        self.captured_stdout = []
+        self.captured_stderr = []
+        self.stop_thread = False
+        self.thread = None
+
+    def start(self):
+        """Start console output capture"""
+        # Duplicate and save original stdout/stderr file descriptors
+        self.old_stdout = os.dup(1)
+        self.old_stderr = os.dup(2)
+
+        # Create anonymous pipes for output redirection
+        self.pipe_out, self.pipe_in = os.pipe()
+        self.pipe_err_out, self.pipe_err_in = os.pipe()
+
+        # Redirect system stdout/stderr to the write end of pipes
+        os.dup2(self.pipe_in, 1)
+        os.dup2(self.pipe_err_in, 2)
+
+        # Close unused pipe write ends
+        os.close(self.pipe_in)
+        os.close(self.pipe_err_in)
+
+        # Start daemon thread to read output in real time
+        self.stop_thread = False
+        self.thread = threading.Thread(target=self._read_loop, daemon=True)
+        self.thread.start()
+
+    def _read_loop(self):
+        """The background process reads and prints pipeline data records in a loop."""
+        read_fds = [self.pipe_out, self.pipe_err_out]
+        while not self.stop_thread:
+            try:
+                # select listens to multiple file descriptors simultaneously, waiting for data in a non-blocking manner
+                readable, _, exceptional = select.select(read_fds, [], read_fds, 0.01)
+
+                # Processing file descriptors containing data
+                for fd in readable:
+                    if fd == self.pipe_out:
+                        data = os.read(fd, 4096)
+                        if data:
+                            self.captured_stdout.append(data)
+                            os.write(self.old_stdout, data)
+                    elif fd == self.pipe_err_out:
+                        err_data = os.read(fd, 4096)
+                        if err_data:
+                            self.captured_stderr.append(err_data)
+                            os.write(self.old_stderr, err_data)
+
+                for fd in exceptional:
+                    if fd in read_fds:
+                        self.stop()
+
+            except OSError:
+                self.stop()
+                break
+
+    def get_all(self):
+        """Get all captured stdout and stderr as UTF-8 string
+
+        Return: Decoded stdout and stderr string (ignore decoding errors)
+        """
+        return self.get_output() + self.get_error()
+
+    def get_output(self):
+        """Get all captured stdout as UTF-8 string
+
+        Return: Decoded stdout string (ignore decoding errors)
+        """
+        return b"".join(self.captured_stdout).decode("utf-8", errors="ignore")
+
+    def get_error(self):
+        """Get all captured stderr as UTF-8 string
+
+        Return: Decoded stderr string (ignore decoding errors)
+        """
+        return b"".join(self.captured_stderr).decode("utf-8", errors="ignore")
+
+    def stop(self):
+        """Stop capture and restore system environment"""
+        self.stop_thread = True
+        if self.thread:
+            self.thread.join(timeout=0.5)
+
+        # Restore original output
+        os.dup2(self.old_stdout, 1)
+        os.dup2(self.old_stderr, 2)
+
+        # Close all file descriptors
+        for fd in [self.pipe_out, self.pipe_err_out, self.old_stdout, self.old_stderr]:
+            try:
+                os.close(fd)
+            except (OSError, IOError):
+                pass

--- a/python/sglang/test/ascend/test_npu_logging.py
+++ b/python/sglang/test/ascend/test_npu_logging.py
@@ -1,0 +1,153 @@
+import os
+import re
+import tempfile
+import time
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+
+class TestNPULoggingBase(CustomTestCase):
+    """Testcase：Test base class to verify whether the parameters in the logging function are correct.
+
+    Description:
+        Includes methods for initializing data and methods for verifying the correctness of the logging function.
+
+    [Test Category] Parameter
+    [Test Target] --log-requests; --log-requests-level; --log-requests-target; --uvicorn-access-log-exclude-prefixes;
+    --enable-metrics; --enable-metrics-for-all-scheduler;
+    --bucket-time-to-first-token; --bucket-inter-token-latency; --bucket-e2e-request-latency;
+    --collect-tokens-histogram; --prompt-tokens-buckets; --generation-tokens-buckets;
+    --tokenizer-metrics-custom-labels-header; --tokenizer-metrics-allowed-custom-labels;
+    --gc-warning-threshold-secs
+    """
+
+    @staticmethod
+    def get_lines_with_keyword(filename, keyword):
+        """Find and return lines matching a regex keyword from a specified file, with line numbers and content.
+
+        Function Description:
+            Reads the target file line by line, uses the input keyword as a regular expression pattern to match each line's content.
+            For each line that matches the regex pattern, encapsulates the line number (1-indexed) and content into a dictionary,
+            and finally returns a list of dictionaries containing all matched lines.
+
+        Args:
+            filename (str): Path to the file to be read
+            keyword (str): Regular expression pattern for matching
+
+        Returns:
+            List[Dict[str, Union[str, int]]]
+                List of dictionaries for matched lines, each dictionary contains two key-value pairs:
+                - "line_number": int - Line number of the matched line (starts from 1)
+                - "content": str - Full text content of the matched line
+        """
+        results = []
+        try:
+            with open(filename, "r", encoding="utf-8") as file:
+                for line_num, line in enumerate(file, 1):
+                    if re.match(keyword, line):
+                        results.append(
+                            {
+                                "line_number": line_num,
+                                "content": line.strip(),
+                            }
+                        )
+            return results
+        except Exception as e:
+            print(f"error:{e}")
+            return []
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.other_args = [
+            "--trust-remote-code",
+            "--mem-fraction-static",
+            "0.8",
+            "--attention-backend",
+            "ascend",
+            "--disable-cuda-graph",
+            "--log-requests",
+        ]
+        cls.out_log_file_obj = tempfile.NamedTemporaryFile(
+            mode="w+", encoding="utf-8", delete=False, suffix=".txt"
+        )
+        cls.out_log_name = cls.out_log_file_obj.name
+        cls.out_log_file = cls.out_log_file_obj
+        cls.err_log_file_obj = tempfile.NamedTemporaryFile(
+            mode="w+", encoding="utf-8", delete=False, suffix=".txt"
+        )
+        cls.err_log_name = cls.err_log_file_obj.name
+        cls.err_log_file = cls.err_log_file_obj
+        cls.process = None
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.process:
+            kill_process_tree(cls.process.pid)
+        cls.out_log_file.close()
+        os.remove(cls.out_log_name)
+        cls.err_log_file.close()
+        os.remove(cls.err_log_name)
+
+    @classmethod
+    def launch_server(cls):
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=cls.other_args,
+            return_stdout_stderr=(cls.out_log_file, cls.err_log_file),
+        )
+
+    def inference_once(self, max_tokens=32):
+        response = requests.post(
+            f"{self.base_url}/generate",
+            json={
+                "text": "The capital of France is",
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": max_tokens,
+                },
+            },
+        )
+
+        self.assertEqual(response.status_code, 200, "Failed to call generate API")
+        self.assertIn("Paris", response.text, "Inference out error.")
+
+    def wait_for_log_content(self, timeout=30):
+        """Wait for and return the content of the specified log file, with timeout handling.
+
+        Function Description:
+            Continuously reads the target log file in a loop within the set timeout period,
+            avoids assertion failures caused by reading the log too early before log writing is completed.
+            Returns the log content immediately once the file has non-empty content,
+            otherwise waits and retries reading at intervals until the timeout is reached.
+
+        Args:
+            timeout (int, optional): Maximum waiting time in seconds, default value is 30 seconds.
+
+        Returns:
+            str
+                Full text content read from the log file:
+                - Non-empty string if log content is detected within the timeout period
+                - Empty string if no log content is found after the timeout expires
+        """
+        start_time = time.time()
+        content = ""
+        while time.time() - start_time < timeout:
+            with open(self.out_log_file.name, "r", encoding="utf-8") as f:
+                content = f.read()
+            if content:
+                break
+            time.sleep(0.5)
+        return content

--- a/python/sglang/test/ascend/test_npu_logging.py
+++ b/python/sglang/test/ascend/test_npu_logging.py
@@ -20,14 +20,6 @@ class TestNPULoggingBase(CustomTestCase):
 
     Description:
         Includes methods for initializing data and methods for verifying the correctness of the logging function.
-
-    [Test Category] Parameter
-    [Test Target] --log-requests; --log-requests-level; --log-requests-target; --uvicorn-access-log-exclude-prefixes;
-    --enable-metrics; --enable-metrics-for-all-scheduler;
-    --bucket-time-to-first-token; --bucket-inter-token-latency; --bucket-e2e-request-latency;
-    --collect-tokens-histogram; --prompt-tokens-buckets; --generation-tokens-buckets;
-    --tokenizer-metrics-custom-labels-header; --tokenizer-metrics-allowed-custom-labels;
-    --gc-warning-threshold-secs
     """
 
     @staticmethod

--- a/test/registered/ascend/basic_function/kernel_backends/test_npu_hybrid_attention_backend.py
+++ b/test/registered/ascend/basic_function/kernel_backends/test_npu_hybrid_attention_backend.py
@@ -1,0 +1,110 @@
+import os
+import unittest
+from types import SimpleNamespace
+from urllib.parse import urlparse
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=400, suite="nightly-1-npu-a3", nightly=True)
+
+GSM_DATASET_PATH = None
+
+# Default server arguments shared across all tests
+DEFAULT_SERVER_ARGS = [
+    "--trust-remote-code",
+    "--cuda-graph-max-bs",
+    "8",
+    "--prefill-attention-backend",
+    "ascend",
+    "--decode-attention-backend",
+    "ascend",
+    "--disable-cuda-graph",
+    "--mem-fraction-static",
+    0.9,
+    "--tp-size",
+    2,
+]
+
+
+class TestHybridAttnBackendBase(CustomTestCase):
+    """Testcase：Verify set --prefill-attention-backend, --decode-attention-backend, the inference request is successfully processed.
+
+    [Test Category] Parameter
+    [Test Target] --prefill-attention-backend, --decode-attention-backend
+    """
+
+    model = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+    base_url = DEFAULT_URL_FOR_TEST
+    accuracy_threshold = 0.36  # derived tests need to override this
+
+    @classmethod
+    def get_server_args(cls):
+        """Return the arguments for the server launch. Override in subclasses."""
+        return DEFAULT_SERVER_ARGS
+
+    @classmethod
+    def setUpClass(cls):
+        # disable deep gemm precompile to make launch server faster
+        # please don't do this if you want to make your inference workload faster
+        os.environ["SGL_JIT_DEEPGEMM_PRECOMPILE"] = "false"
+        os.environ["SGL_ENABLE_JIT_DEEPGEMM"] = "false"
+        model = cls.model
+        cls.process = popen_launch_server(
+            model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=cls.get_server_args(),
+        )
+        cls.host = urlparse(cls.base_url).hostname
+        cls.port = urlparse(cls.base_url).port
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        requests.get(self.base_url + "/flush_cache")
+
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="gsm8k",
+            api="completion",
+            max_tokens=512,
+            num_examples=200,
+            num_threads=64,
+            num_shots=8,
+        )
+        metrics = run_eval(args)
+
+        self.assertGreater(metrics["score"], self.accuracy_threshold)
+
+        response = requests.get(f"{self.base_url}/get_server_info")
+        self.assertEqual(
+            response.status_code, 200, "The request status code is not 200."
+        )
+        self.assertEqual(
+            response.json()["internal_states"][0]["prefill_attention_backend"],
+            "ascend",
+            "--prefill-attention-backend is not taking effect.",
+        )
+        self.assertEqual(
+            response.json()["internal_states"][0]["decode_attention_backend"],
+            "ascend",
+            "--decode-attention-backend is not taking effect.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/kernel_backends/test_npu_json_mode.py
+++ b/test/registered/ascend/basic_function/kernel_backends/test_npu_json_mode.py
@@ -1,0 +1,146 @@
+import json
+import logging
+import unittest
+
+import openai
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler()],
+)
+logger = logging.getLogger(__name__)
+
+register_npu_ci(est_time=400, suite="nightly-1-npu-a3", nightly=True)
+
+
+class TestJSONModeMixin:
+    """Mixin class containing JSON mode test methods"""
+
+    def test_json_mode_response(self):
+        """Test that response_format json_object (also known as "json mode") produces valid JSON, even without a system prompt that mentions JSON."""
+        response = self.client.chat.completions.create(
+            model=self.model,
+            messages=[
+                # We are deliberately omitting "That produces JSON" or similar phrases from the assistant prompt so that we don't have misleading test results
+                {
+                    "role": "system",
+                    "content": "You are a helpful AI assistant that gives a short answer.",
+                },
+                {"role": "user", "content": "What is the capital of Bulgaria?"},
+            ],
+            temperature=0,
+            max_tokens=128,
+            response_format={"type": "json_object"},
+        )
+        text = response.choices[0].message.content
+
+        logger.info("JSON mode response (%d characters): %s", len(text), text)
+
+        # Verify the response is valid JSON
+        try:
+            js_obj = json.loads(text)
+        except json.JSONDecodeError as e:
+            self.fail(f"Response is not valid JSON. Error: {e}. Response: {text}")
+
+        # Verify it's actually an object (dict)
+        self.assertIsInstance(js_obj, dict, f"Response is not a JSON object: {text}")
+
+    def test_json_mode_with_streaming(self):
+        """Test that streaming with json_object response (also known as "json mode") format works correctly, even without a system prompt that mentions JSON."""
+        stream = self.client.chat.completions.create(
+            model=self.model,
+            messages=[
+                # We are deliberately omitting "That produces JSON" or similar phrases from the assistant prompt so that we don't have misleading test results
+                {
+                    "role": "system",
+                    "content": "You are a helpful AI assistant that gives a short answer.",
+                },
+                {"role": "user", "content": "What is the capital of Bulgaria?"},
+            ],
+            temperature=0,
+            max_tokens=128,
+            response_format={"type": "json_object"},
+            stream=True,
+        )
+
+        # Collect all chunks
+        chunks = []
+        for chunk in stream:
+            if chunk.choices[0].delta.content is not None:
+                chunks.append(chunk.choices[0].delta.content)
+        full_response = "".join(chunks)
+
+        logger.info(
+            "Concatenated streamed JSON response (%d characters): %s",
+            len(full_response),
+            full_response,
+        )
+
+        # Verify the combined response is valid JSON
+        try:
+            js_obj = json.loads(full_response)
+        except json.JSONDecodeError as e:
+            self.fail(
+                f"Streamed response is not valid JSON. Error: {e}. Response: {full_response}"
+            )
+
+        self.assertIsInstance(js_obj, dict)
+
+
+class ServerWithGrammarBackend(CustomTestCase):
+    """Testcase: Base class for tests requiring a grammar backend server.
+
+    [Test Category] Parameter
+    [Test Target] --grammar-backend
+    """
+
+    backend = "xgrammar"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+
+        other_args = [
+            "--max-running-requests",
+            "10",
+            "--grammar-backend",
+            cls.backend,
+        ]
+
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+        )
+        cls.client = openai.Client(api_key="EMPTY", base_url=f"{cls.base_url}/v1")
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+
+class TestJSONModeXGrammar(ServerWithGrammarBackend, TestJSONModeMixin):
+    """Testcase: Verify JSON mode functionality with xgrammar grammar backend (non-streaming and streaming).
+
+    [Test Category] Parameter
+    [Test Target] --grammar-backend
+    """
+
+    backend = "xgrammar"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/kernel_backends/test_npu_mm_attention_backend.py
+++ b/test/registered/ascend/basic_function/kernel_backends/test_npu_mm_attention_backend.py
@@ -1,0 +1,59 @@
+import unittest
+
+from sglang.test.ascend.output_capturer import OutputCapturer
+from sglang.test.ascend.test_ascend_utils import GEMMA_3_4B_IT_WEIGHTS_PATH
+from sglang.test.ascend.vlm_utils import TestVLMModels
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(est_time=400, suite="nightly-4-npu-a3", nightly=True)
+
+
+class TestAscendMMAttentionBackend(TestVLMModels):
+    """Testcase: Verify MMMU dataset accuracy ≥0.2 for google/gemma-3-4b-it with --mm-attention-backend ascend_attn.
+
+    [Test Category] Parameter
+    [Test Target] --mm-attention-backend
+    """
+
+    mm_attention_backend = "ascend_attn"
+    model = GEMMA_3_4B_IT_WEIGHTS_PATH
+    mmmu_accuracy = 0.2
+    other_args = [
+        "--trust-remote-code",
+        "--cuda-graph-max-bs",
+        "32",
+        "--enable-multimodal",
+        "--mem-fraction-static",
+        0.35,
+        "--log-level",
+        "info",
+        "--attention-backend",
+        "ascend",
+        "--disable-cuda-graph",
+        "--tp-size",
+        4,
+        "--mm-attention-backend",
+        mm_attention_backend,
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.output = OutputCapturer()
+        cls.output.start()
+
+    def test_mmmu(self):
+        self._run_vlm_mmmu_test()
+        self.assertIn(
+            f"Using {self.mm_attention_backend} as multimodal attention backend.",
+            self.output.get_all(),
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        cls.output.stop()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/kernel_backends/test_npu_sampling_backend.py
+++ b/test/registered/ascend/basic_function/kernel_backends/test_npu_sampling_backend.py
@@ -1,0 +1,115 @@
+import unittest
+from types import SimpleNamespace
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=800, suite="nightly-1-npu-a3", nightly=True)
+
+
+class TestAscendSamplingBackend(CustomTestCase):
+    """Testcase：When --sampling-backend=pytorch or ascend, verify the MMLU dataset accuracy (>0.65) and greedy sampling consistency of the Llama-3.1-8B-Instruct mode
+
+    [Test Category] Parameter
+    [Test Target] --sampling-backend;
+    """
+
+    sampling_backend = "ascend"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+                "--sampling-backend",
+                cls.sampling_backend,
+                "--disable-radix-cache",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_mmlu(self):
+        """Verify MMLU dataset evaluation accuracy meets the minimum requirement (score ≥ 0.65)"""
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="mmlu",
+            num_examples=64,
+            num_threads=32,
+            temperature=0.1,
+        )
+
+        metrics = run_eval(args)
+        self.assertGreaterEqual(metrics["score"], 0.65)
+
+    def test_greedy(self):
+        """Verify greedy sampling consistency (identical results for single/batch requests with temperature=0)"""
+
+        first_text = None
+
+        # 1. Verify consistency of results for 5 consecutive single requests
+        for _ in range(5):
+            response_single = requests.post(
+                self.base_url + "/generate",
+                json={
+                    "text": "The capital of Germany is",
+                    "sampling_params": {
+                        "temperature": 0,
+                        "max_new_tokens": 32,
+                    },
+                },
+            ).json()
+            text = response_single["text"]
+            if first_text is None:
+                first_text = text
+
+            self.assertEqual(text, first_text)
+
+        first_text = None
+
+        # 2. Send a batch request with 10 identical prompts
+        response_batch = requests.post(
+            self.base_url + "/generate",
+            json={
+                "text": ["The capital of Germany is"] * 10,
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": 32,
+                },
+            },
+        ).json()
+
+        # 3. Verify consistency of results within the batch response
+        for i in range(10):
+            text = response_batch[i]["text"]
+            if first_text is None:
+                first_text = text
+            self.assertEqual(text, first_text)
+
+
+class TestPyTorchSamplingBackend(TestAscendSamplingBackend):
+    sampling_backend = "pytorch"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/logging/test_npu_crash_dump.py
+++ b/test/registered/ascend/basic_function/logging/test_npu_crash_dump.py
@@ -1,0 +1,123 @@
+import glob
+import os
+import pickle
+import tempfile
+import time
+import unittest
+
+import requests
+
+from sglang.srt.environ import envs
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import QWEN3_0_6B_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=40, suite="nightly-1-npu", nightly=True)
+
+
+class TestNPUCrashDump(CustomTestCase):
+    """Testcase: Verify crash dump generation when the server crashes and validates that crash dump files are created and contain expected request data.
+
+    [Test Category] Parameter
+    [Test Target] --crash-dump-folder
+    """
+
+    crash_dump_folder = None
+    MAX_NEW_TOKENS = 4
+    NUM_REQUESTS_BEFORE_CRASH = 5
+
+    @classmethod
+    def setUpClass(cls):
+        cls.crash_dump_folder = tempfile.mkdtemp(prefix="crash_dump_test_")
+
+        with envs.SGLANG_TEST_CRASH_AFTER_STREAM_OUTPUTS.override(
+            cls.NUM_REQUESTS_BEFORE_CRASH * cls.MAX_NEW_TOKENS + 10
+        ):
+            cls.process = popen_launch_server(
+                QWEN3_0_6B_WEIGHTS_PATH,
+                DEFAULT_URL_FOR_TEST,
+                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                other_args=[
+                    "--crash-dump-folder",
+                    cls.crash_dump_folder,
+                    "--skip-server-warmup",
+                ],
+            )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_crash_dump_generated(self):
+        """Test that crash dump file is generated after server crash."""
+        # Send multiple requests to trigger the crash
+        for i in range(self.NUM_REQUESTS_BEFORE_CRASH * 2):
+            try:
+                response = requests.post(
+                    DEFAULT_URL_FOR_TEST + "/generate",
+                    json={
+                        "text": f"Hello, this is request {i}.",
+                        "sampling_params": {
+                            "max_new_tokens": self.MAX_NEW_TOKENS,
+                            "temperature": 0,
+                        },
+                    },
+                    timeout=30,
+                )
+            except requests.exceptions.RequestException:
+                # Connection error expected after crash
+                pass
+
+        # Wait for crash dump to be written
+        time.sleep(5)
+
+        # Find the crash dump file
+        dump_pattern = os.path.join(self.crash_dump_folder, "*", "crash_dump_*.pkl")
+        dump_files = glob.glob(dump_pattern)
+
+        # Check that a dump file was created
+        self.assertTrue(
+            len(dump_files) > 0,
+            f"No crash dump file found in {self.crash_dump_folder}. "
+            f"Pattern: {dump_pattern}",
+        )
+
+        # Read the dump file and verify contents
+        dump_file = dump_files[0]
+        with open(dump_file, "rb") as f:
+            dump_data = pickle.load(f)
+
+        # Verify the dump structure
+        self.assertIn("server_args", dump_data)
+        self.assertIn("requests", dump_data)
+
+        # Check that there are more than 5 requests in the dump
+        requests_list = dump_data["requests"]
+        self.assertGreater(
+            len(requests_list),
+            self.NUM_REQUESTS_BEFORE_CRASH,
+            f"Expected more than {self.NUM_REQUESTS_BEFORE_CRASH} requests in dump, but got {len(requests_list)}",
+        )
+
+        # Verify each request tuple has the expected structure (obj, out, created_time, finish_time)
+        for i, req_tuple in enumerate(requests_list):
+            self.assertIsInstance(
+                req_tuple,
+                tuple,
+                f"Request {i} should be a tuple, got {type(req_tuple)}",
+            )
+            self.assertGreaterEqual(
+                len(req_tuple),
+                4,
+                f"Request {i} tuple should have at least 4 elements",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/logging/test_npu_decode_log_interval.py
+++ b/test/registered/ascend/basic_function/logging/test_npu_decode_log_interval.py
@@ -1,0 +1,44 @@
+import math
+import unittest
+
+from sglang.test.ascend.output_capturer import OutputCapturer
+from sglang.test.ascend.test_npu_logging import TestNPULoggingBase
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(est_time=100, suite="nightly-1-npu-a3", nightly=True)
+
+
+class TestDecodeLogInterval(TestNPULoggingBase):
+    """Testcase: Test configuration --decode-log-interval is set to 10, generating 52 decode batches.
+
+    [Test Category] Parameter
+    [Test Target] --decode-log-interval
+    """
+
+    decode_numbers = 10
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.output_capturer = OutputCapturer()
+        cls.output_capturer.start()
+        cls.other_args.extend(["--decode-log-interval", cls.decode_numbers])
+        cls.launch_server()
+
+    def test_decode_log_interval(self):
+        max_tokens = 512
+        self.inference_once(max_tokens=max_tokens)
+        self.out_log_file.seek(0)
+        self.err_log_file.seek(0)
+        content = self.out_log_file.read() + self.err_log_file.read()
+        decod_batch_count = content.count("Decode batch")
+        expected_decod_batch_count = math.floor((max_tokens + 9) / self.decode_numbers)
+        self.assertEqual(decod_batch_count, expected_decod_batch_count)
+
+
+class TestDecodeLogIntervalOther(TestDecodeLogInterval):
+    decode_numbers = 30
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/logging/test_npu_decode_log_interval.py
+++ b/test/registered/ascend/basic_function/logging/test_npu_decode_log_interval.py
@@ -9,7 +9,7 @@ register_npu_ci(est_time=100, suite="nightly-1-npu-a3", nightly=True)
 
 
 class TestDecodeLogInterval(TestNPULoggingBase):
-    """Testcase: Test configuration --decode-log-interval is set to 10, generating 52 decode batches.
+    """Testcase: Verify that configuration --decode-log-interval can correctly record decode information in batches.
 
     [Test Category] Parameter
     [Test Target] --decode-log-interval

--- a/test/registered/ascend/basic_function/logging/test_npu_enable_metrics_for_all_scheduler.py
+++ b/test/registered/ascend/basic_function/logging/test_npu_enable_metrics_for_all_scheduler.py
@@ -1,0 +1,57 @@
+import unittest
+
+import requests
+
+from sglang.test.ascend.test_npu_logging import TestNPULoggingBase
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(est_time=100, suite="nightly-2-npu-a3", nightly=True)
+
+
+class TestNPUEnableMetricsForAllScheduler(TestNPULoggingBase):
+    """Test case for verifying the functionality of the --enable-metrics-for-all-scheduler parameter
+
+    [Description]
+        When the --enable-metrics-for-all-scheduler parameter is configured, all TP rank instances will independently
+        record their own monitoring logs; when this parameter is not configured (default state), only the TP rank 0
+        instance will record logs, and other TPrank instances will not generate log output, ensuring the log
+        recording logic meets expectations.
+
+    [Test Category] Parameter
+    [Test Target] --enable-metrics-for-all-scheduler;
+    """
+
+    if_enable_metrics_for_all_scheduler = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.other_args.extend(["--enable-metrics"])
+        cls.other_args.extend(["--tp-size", 2])
+        if cls.if_enable_metrics_for_all_scheduler:
+            cls.other_args.extend(["--enable-metrics-for-all-scheduler"])
+        cls.launch_server()
+
+    def test_enable_metrics_for_all_scheduler(self):
+        response = requests.get(f"{self.base_url}/metrics", timeout=10)
+        message_0 = (
+            f'sglang:num_decode_transfer_queue_reqs{{engine_type="unified",model_name="{self.model}"'
+            f',moe_ep_rank="0",pp_rank="0",tp_rank="0"}}'
+        )
+        message_1 = (
+            f'sglang:num_decode_transfer_queue_reqs{{engine_type="unified",model_name="{self.model}"'
+            f',moe_ep_rank="0",pp_rank="0",tp_rank="1"}}'
+        )
+        self.assertIn(message_0, response.text)
+        if self.if_enable_metrics_for_all_scheduler:
+            self.assertIn(message_1, response.text)
+        else:
+            self.assertNotIn(message_1, response.text)
+
+
+class TestNPUDisableMetricsForAllScheduler(TestNPUEnableMetricsForAllScheduler):
+    if_enable_metrics_for_all_scheduler = False
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/logging/test_npu_enable_metrics_for_all_scheduler.py
+++ b/test/registered/ascend/basic_function/logging/test_npu_enable_metrics_for_all_scheduler.py
@@ -9,7 +9,7 @@ register_npu_ci(est_time=100, suite="nightly-2-npu-a3", nightly=True)
 
 
 class TestNPUEnableMetricsForAllScheduler(TestNPULoggingBase):
-    """Test case for verifying the functionality of the --enable-metrics-for-all-scheduler parameter
+    """Testcase: Verify that the functionality of the --enable-metrics-for-all-scheduler parameter
 
     [Description]
         When the --enable-metrics-for-all-scheduler parameter is configured, all TP rank instances will independently

--- a/test/registered/ascend/basic_function/logging/test_npu_enable_request_time_stats_logging.py
+++ b/test/registered/ascend/basic_function/logging/test_npu_enable_request_time_stats_logging.py
@@ -8,7 +8,7 @@ register_npu_ci(est_time=100, suite="nightly-1-npu-a3", nightly=True)
 
 
 class TestNPUEnableRequestTimeStatsLogging(TestNPULoggingBase):
-    """Testcase: Verify the functionality of --enable-request-time-stats-logging to generate Req Time Stats logs on Ascend backend with Llama-3.2-1B-Instruct model.
+    """Testcase: Verify the functionality of --enable-request-time-stats-logging to generate Req Time Stats logs.
 
     [Test Category] Parameter
     [Test Target] --enable-request-time-stats-logging

--- a/test/registered/ascend/basic_function/logging/test_npu_enable_request_time_stats_logging.py
+++ b/test/registered/ascend/basic_function/logging/test_npu_enable_request_time_stats_logging.py
@@ -1,0 +1,41 @@
+import unittest
+
+from sglang.test.ascend.output_capturer import OutputCapturer
+from sglang.test.ascend.test_npu_logging import TestNPULoggingBase
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(est_time=100, suite="nightly-1-npu-a3", nightly=True)
+
+
+class TestNPUEnableRequestTimeStatsLogging(TestNPULoggingBase):
+    """Testcase: Verify the functionality of --enable-request-time-stats-logging to generate Req Time Stats logs on Ascend backend with Llama-3.2-1B-Instruct model.
+
+    [Test Category] Parameter
+    [Test Target] --enable-request-time-stats-logging
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.output_capturer = OutputCapturer()
+        cls.output_capturer.start()
+        cls.other_args.extend(["--enable-request-time-stats-logging"])
+        cls.launch_server()
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        cls.output_capturer.stop()
+
+    def test_enable_request_time_stats_logging(self):
+        self.inference_once()
+
+        self.assertIn(
+            "Req Time Stats",
+            self.output_capturer.get_all(),
+            f"Keyword not found in server logs.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/logging/test_npu_gc_warning_threshold.py
+++ b/test/registered/ascend/basic_function/logging/test_npu_gc_warning_threshold.py
@@ -1,0 +1,82 @@
+import threading
+import unittest
+
+import requests
+
+from sglang.test.ascend.test_npu_logging import TestNPULoggingBase
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(est_time=100, suite="nightly-1-npu-a3", nightly=True)
+
+
+class TestNPUGCWarningThreshold(TestNPULoggingBase):
+    """Test case for verifying the functionality of the --gc-warning-threshold-secs parameter
+
+    [Description]
+        Verifies the alert threshold setting function of this parameter: this parameter configures the maximum allowed
+        duration threshold for Garbage Collection (GC) operations. When the actual execution duration of a GC operation
+        **exceeds** this threshold, the system must proactively log an alert-level message to indicate abnormal GC performance;
+        if the GC duration does not exceed the threshold, no such alert log should be generated, ensuring precise alert
+        rule triggering.
+
+    [Test Category] Parameter
+    [Test Target] --gc-warning-threshold-secs
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # overwrite other_args to reduce log printing by removing --log-requests
+        cls.other_args = [
+            "--trust-remote-code",
+            "--mem-fraction-static",
+            "0.8",
+            "--attention-backend",
+            "ascend",
+            "--disable-cuda-graph",
+        ]
+        # --gc-warning-threshold-secs=0.01 (a tiny value) is set to ensure GC duration exceeds the alarm threshold.
+        cls.other_args.extend(["--gc-warning-threshold-secs", "0.01"])
+        cls.launch_server()
+
+    def test_gc_warning_threshold(self):
+        """Validate SGLang logs GC warnings when GC duration exceeds --gc-warning-threshold-secs threshold.
+
+        Core Functionality:
+            1. Generate high-concurrency requests with long sequences to create large temporary objects in SGLang service
+            2. Trigger garbage collection (GC) by overwhelming the service with memory-intensive requests
+            3. Verify that when GC time exceeds the configured threshold, a specific GC warning log is recorded in the error log file
+        """
+        prompt_template = (
+            "just return me a string with of 10000 characters: " + "A" * 10000
+        )
+        max_token = 10000
+
+        def send_request():
+            requests.post(
+                f"{self.base_url}/generate",
+                json={
+                    "text": prompt_template,
+                    "sampling_params": {"temperature": 0, "max_new_tokens": max_token},
+                },
+            )
+
+        threads = []
+        for _ in range(2000):
+            t = threading.Thread(target=send_request)
+            t.start()
+            threads.append(t)
+
+        for t in threads:
+            t.join()
+
+        GC_info = "LONG GARBAGE COLLECTION DETECTED"
+        self.out_log_file.seek(0)
+        self.err_log_file.seek(0)
+        content = self.out_log_file.read() + self.err_log_file.read()
+        self.assertTrue(len(content) > 0)
+        self.assertIn(GC_info, content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/logging/test_npu_gc_warning_threshold.py
+++ b/test/registered/ascend/basic_function/logging/test_npu_gc_warning_threshold.py
@@ -10,7 +10,7 @@ register_npu_ci(est_time=100, suite="nightly-1-npu-a3", nightly=True)
 
 
 class TestNPUGCWarningThreshold(TestNPULoggingBase):
-    """Test case for verifying the functionality of the --gc-warning-threshold-secs parameter
+    """Testcase: Verify the functionality of the --gc-warning-threshold-secs parameter
 
     [Description]
         Verifies the alert threshold setting function of this parameter: this parameter configures the maximum allowed

--- a/test/registered/ascend/basic_function/logging/test_npu_log_exclude_prefixes.py
+++ b/test/registered/ascend/basic_function/logging/test_npu_log_exclude_prefixes.py
@@ -1,0 +1,58 @@
+import unittest
+
+import requests
+
+from sglang.test.ascend.test_npu_logging import TestNPULoggingBase
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(est_time=100, suite="nightly-1-npu-a3", nightly=True)
+
+
+class TestNPULogExcludePrefixes(TestNPULoggingBase):
+    """Test case class for verifying the --uvicorn-access-log-exclude-prefixes parameter.
+
+    Description:
+        Verifies that when the --uvicorn-access-log-exclude-prefixes parameter is configured with specified URL prefixes
+        during server startup, HTTP requests matching these prefixes will NOT be recorded in the uvicorn access logs.
+        Ensures the log filtering mechanism works correctly.
+
+    [Test Category] Parameter
+    [Test Target] --uvicorn-access-log-exclude-prefixes;
+    """
+
+    if_exclude_prefixes = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if cls.if_exclude_prefixes:
+            cls.other_args.extend(
+                ["--uvicorn-access-log-exclude-prefixes", "/health", "/get_server_info"]
+            )
+        cls.launch_server()
+
+    def test_log_exclude_prefixes(self):
+        response = requests.get(f"{self.base_url}/health", timeout=10)
+        self.assertEqual(response.status_code, 200)
+        response = requests.get(f"{self.base_url}/get_server_info", timeout=10)
+        self.assertEqual(response.status_code, 200)
+        self.out_log_file.seek(0)
+        content = self.out_log_file.read()
+        # The logs should not include health and server info request information when
+        # --uvicorn-access-log-exclude-prefixes is set with health and server info prefix
+        health_log = '"GET /health HTTP/1.1" 200 OK'
+        server_info_log = '"GET /get_server_info HTTP/1.1" 200 OK'
+        if self.if_exclude_prefixes:
+            self.assertNotIn(health_log, content)
+            self.assertNotIn(server_info_log, content)
+        else:
+            self.assertIn(health_log, content)
+            self.assertIn(server_info_log, content)
+
+
+class TestNPULogNotExcludePrefixes(TestNPULogExcludePrefixes, TestNPULoggingBase):
+    if_exclude_prefixes = False
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/logging/test_npu_log_exclude_prefixes.py
+++ b/test/registered/ascend/basic_function/logging/test_npu_log_exclude_prefixes.py
@@ -9,7 +9,7 @@ register_npu_ci(est_time=100, suite="nightly-1-npu-a3", nightly=True)
 
 
 class TestNPULogExcludePrefixes(TestNPULoggingBase):
-    """Test case class for verifying the --uvicorn-access-log-exclude-prefixes parameter.
+    """Testcase: Verify the functionality of the --uvicorn-access-log-exclude-prefixes parameter.
 
     Description:
         Verifies that when the --uvicorn-access-log-exclude-prefixes parameter is configured with specified URL prefixes

--- a/test/registered/ascend/basic_function/logging/test_npu_log_level.py
+++ b/test/registered/ascend/basic_function/logging/test_npu_log_level.py
@@ -1,0 +1,92 @@
+import os
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=400, suite="nightly-1-npu-a3", nightly=True)
+
+
+class TestLogLevel(CustomTestCase):
+    """Testcase：Verify set log-level parameter, the printed log level is the same as the configured log level and the inference request is successfully processed.
+
+    [Test Category] Parameter
+    [Test Target] --log-level
+    """
+
+    model = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+    OUT_LOG_PATH = "./out_log.txt"
+    ERR_LOG_PATH = "./err_log.txt"
+
+    def _launch_server_and_run_infer(self, other_args):
+        out_log_file = None
+        err_log_file = None
+        process = None
+        try:
+            out_log_file = open(self.OUT_LOG_PATH, "w+", encoding="utf-8")
+            err_log_file = open(self.ERR_LOG_PATH, "w+", encoding="utf-8")
+            process = popen_launch_server(
+                self.model,
+                DEFAULT_URL_FOR_TEST,
+                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                other_args=other_args,
+                return_stdout_stderr=(out_log_file, err_log_file),
+            )
+            health_resp = requests.get(f"{DEFAULT_URL_FOR_TEST}/health_generate")
+            self.assertEqual(health_resp.status_code, 200)
+            gen_resp = requests.post(
+                f"{DEFAULT_URL_FOR_TEST}/generate",
+                json={
+                    "text": "The capital of France is",
+                    "sampling_params": {"temperature": 0, "max_new_tokens": 32},
+                },
+            )
+            self.assertEqual(gen_resp.status_code, 200)
+            self.assertIn("Paris", gen_resp.text)
+            out_log_file.seek(0)
+            return out_log_file.read()
+        finally:
+            kill_process_tree(process.pid)
+            out_log_file.close()
+            err_log_file.close()
+            os.remove(self.OUT_LOG_PATH)
+            os.remove(self.ERR_LOG_PATH)
+
+    def test_log_level(self):
+        # Verify set --log-level=warning and not set --log-level-http, logs print only warning level (no HTTP info)
+        other_args = [
+            "--log-level",
+            "warning",
+            "--attention-backend",
+            "ascend",
+            "--disable-cuda-graph",
+        ]
+        log_content = self._launch_server_and_run_infer(other_args)
+        self.assertNotIn("POST /generate HTTP/1.1", log_content)
+
+    def test_log_http_level(self):
+        # Verify set --log-level=warning and set --log-level-http=info, log level print http info
+        other_args = [
+            "--log-level",
+            "warning",
+            "--log-level-http",
+            "info",
+            "--attention-backend",
+            "ascend",
+            "--disable-cuda-graph",
+        ]
+        log_content = self._launch_server_and_run_infer(other_args)
+        self.assertIn("POST /generate HTTP/1.1", log_content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/logging/test_npu_log_level.py
+++ b/test/registered/ascend/basic_function/logging/test_npu_log_level.py
@@ -17,7 +17,7 @@ register_npu_ci(est_time=400, suite="nightly-1-npu-a3", nightly=True)
 
 
 class TestLogLevel(CustomTestCase):
-    """Testcase：Verify set log-level parameter, the printed log level is the same as the configured log level and the inference request is successfully processed.
+    """Testcase: Verify set log-level parameter, the printed log level is the same as the configured log level and the inference request is successfully processed.
 
     [Test Category] Parameter
     [Test Target] --log-level

--- a/test/registered/ascend/basic_function/logging/test_npu_log_request_level.py
+++ b/test/registered/ascend/basic_function/logging/test_npu_log_request_level.py
@@ -10,8 +10,7 @@ register_npu_ci(est_time=100, suite="nightly-1-npu-a3", nightly=True)
 
 
 class TestNPULogRequestLevel0(TestNPULoggingBase):
-    """Test case class for verifying that the logs include request logs with the corresponding verbosity level when
-    --log-requests-level is set.
+    """Testcase: Verify that the logs include request logs with the corresponding verbosity level when --log-requests-level is set.
 
     [Test Category] Parameter
     [Test Target] --log-requests-level

--- a/test/registered/ascend/basic_function/logging/test_npu_log_request_level.py
+++ b/test/registered/ascend/basic_function/logging/test_npu_log_request_level.py
@@ -1,0 +1,130 @@
+import re
+import unittest
+
+import requests
+
+from sglang.test.ascend.test_npu_logging import TestNPULoggingBase
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(est_time=100, suite="nightly-1-npu-a3", nightly=True)
+
+
+class TestNPULogRequestLevel0(TestNPULoggingBase):
+    """Test case class for verifying that the logs include request logs with the corresponding verbosity level when
+    --log-requests-level is set.
+
+    [Test Category] Parameter
+    [Test Target] --log-requests-level
+    """
+
+    log_requests_level = 0
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.finish_message_level_dict = {
+            "0": r".*Finish: obj=GenerateReqInput\(.*rid='\w+', http_worker_ipc=None, video_data=None,.*",
+            "1": r".*Finish: obj=GenerateReqInput\(.*rid='\w+', http_worker_ipc=None, video_data=None, sampling_params=.*",
+            "2": r".*Finish: obj=GenerateReqInput\(.*rid='\w+', http_worker_ipc=None, text=.*, video_data=None.*, sampling_params=.*",
+            "3": r".*Finish: obj=GenerateReqInput\(.*rid='\w+', http_worker_ipc=None, text=.*, video_data=None.*, sampling_params=.*",
+        }
+        cls.finish_message = (
+            r".*Finish: obj=GenerateReqInput\(.*rid='\w+', http_worker_ipc=None, .*"
+        )
+        cls.keyword_output_id_start = (
+            "'output_ids': ["  # Start delimiter for token ID array
+        )
+        cls.keyword_output_id_end = "], 'meta_info'"
+
+        cls.other_args.extend(["--log-requests"])
+        cls.other_args.extend(["--log-requests-level", str(cls.log_requests_level)])
+        cls.launch_server()
+
+    def test_log_requests_level(self):
+        """
+        Validate that log content complies with expectations for different --log-requests-level configurations.
+
+        Core Functionality:
+            1. Send a request to the model to generate the longest possible string, with token generation limits optimized for efficiency:
+               - Max 100 new tokens for --log-requests-level ≤ 1 (reduce generation time for low-detail logging)
+               - Max 2500 new tokens for --log-requests-level ≥ 2 (exceeds 2048 to test truncation behavior)
+            2. Verify the log file contains level-specific keywords matching the target log_requests_level
+            3. Validate token count preservation rules in logs:
+               - Level 2: Logs are truncated to retain only 2048 tokens (partial input/output)
+               - Level 3: Logs retain all generated tokens (full input/output)
+               - Levels ≤1: No token count validation (only metadata/sampling params logged)
+        """
+        # Step 1: Send a request to the model to generate the longest possible string, with token generation limits optimized for efficiency:
+        max_new_token = 2500 if self.log_requests_level >= 2 else 100
+        response = requests.post(
+            f"{self.base_url}/generate",
+            json={
+                "text": f"just return me a long string, generate as much as possible.",
+                "sampling_params": {"temperature": 0, "max_new_tokens": max_new_token},
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+
+        # Step 2: Verify the log file contains level-specific keywords matching the target log_requests_level
+        self.out_log_file.seek(0)
+        content = self.wait_for_log_content()
+        self.assertTrue(len(content) > 0)
+        self.assertIsNotNone(
+            re.search(
+                self.finish_message_level_dict[str(self.log_requests_level)], content
+            )
+        )
+        # The total number of generated tokens should equal the configured maximum number of generated tokens
+        lines = self.get_lines_with_keyword(self.out_log_name, self.finish_message)
+        self.assertGreater(len(lines), 0, "Did not find finish message in log.")
+        finish_message = lines[-1]["content"]
+        self.assertIn(f"'completion_tokens': {max_new_token}", finish_message)
+
+        # Step 3: Validate token count preservation rules in logs:
+        if self.log_requests_level >= 2:
+            # Extract the content of output_ids to count the number of generated tokens recorded in the logs
+            output_ids_start_index = finish_message.find(
+                self.keyword_output_id_start
+            ) + len(self.keyword_output_id_start)
+            output_ids_end_index = finish_message.find(self.keyword_output_id_end)
+            output_ids_list_str = finish_message[
+                output_ids_start_index:output_ids_end_index
+            ].strip()
+            if self.log_requests_level == 2:
+                # When --log-requests-level=2, the log records a maximum of 2048 tokens (truncated content)
+                self.assertIn("] ... [", output_ids_list_str)
+                output_ids_list_str = output_ids_list_str.replace("] ... [", ", ")
+                token_id_count = len(
+                    [
+                        x.strip()
+                        for x in re.split(r",\s*", output_ids_list_str)
+                        if x.strip()
+                    ]
+                )
+                self.assertTrue(token_id_count == 2048)
+            else:
+                # When --log-requests_level=3, the log records all generated token content (no truncation)
+                token_id_count = len(
+                    [
+                        x.strip()
+                        for x in re.split(r",\s*", output_ids_list_str)
+                        if x.strip()
+                    ]
+                )
+                self.assertTrue(token_id_count == max_new_token)
+
+
+class TestNPULogRequestLevel1(TestNPULogRequestLevel0):
+    log_requests_level = 1
+
+
+class TestNPULogRequestLevel2(TestNPULogRequestLevel0):
+    log_requests_level = 2
+
+
+class TestNPULogRequestLevel3(TestNPULogRequestLevel0):
+    log_requests_level = 3
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/logging/test_npu_log_request_target.py
+++ b/test/registered/ascend/basic_function/logging/test_npu_log_request_target.py
@@ -1,0 +1,67 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from sglang.test.ascend.output_capturer import OutputCapturer
+from sglang.test.ascend.test_npu_logging import TestNPULoggingBase
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(est_time=100, suite="nightly-1-npu-a3", nightly=True)
+
+
+class TestNPULogRequestTarget(TestNPULoggingBase):
+    """Test case class for verifying that logs are stored in the target path by setting --log-requests-target
+
+    [Test Category] Parameter
+    [Test Target] --log-requests-target;
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._temp_dir_obj = tempfile.TemporaryDirectory()
+        cls.temp_dir = cls._temp_dir_obj.name
+        cls.temp_multi_level_dir = os.path.join(
+            cls.temp_dir, "level1", "level2", "level3"
+        )
+        os.makedirs(cls.temp_multi_level_dir, exist_ok=True)
+        cls.other_args.extend(
+            ["--log-requests-target", "stdout", cls.temp_dir, cls.temp_multi_level_dir]
+        )
+        cls.output_capturer = OutputCapturer()
+        cls.output_capturer.start()
+        cls.launch_server()
+
+    def test_log_requests_target(self):
+        """Validate that request logs are correctly output to the target files configured via --log-requests-target."""
+        self.inference_once()
+
+        # Standard output should include log information.
+        content = self.output_capturer.get_all()
+        self.assertIn("Receive:", content)
+        self.assertIn("Finish:", content)
+
+        # The target log file in a single-level directory should contain log information.
+        log_files = list(Path(self.temp_dir).glob("*.log"))
+        self.assertGreater(len(log_files), 0)
+        file_content = log_files[0].read_text()
+        self.assertIn("Receive:", file_content)
+        self.assertIn("Finish:", file_content)
+
+        # The target log file in a multi-level directory should contain log information.
+        log_files = list(Path(self.temp_multi_level_dir).glob("*.log"))
+        self.assertGreater(len(log_files), 0)
+        file_content = log_files[0].read_text()
+        self.assertIn("Receive:", file_content)
+        self.assertIn("Finish:", file_content)
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        cls.output_capturer.stop()
+        cls._temp_dir_obj.cleanup()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/logging/test_npu_log_request_target.py
+++ b/test/registered/ascend/basic_function/logging/test_npu_log_request_target.py
@@ -11,7 +11,7 @@ register_npu_ci(est_time=100, suite="nightly-1-npu-a3", nightly=True)
 
 
 class TestNPULogRequestTarget(TestNPULoggingBase):
-    """Test case class for verifying that logs are stored in the target path by setting --log-requests-target
+    """Testcase: Verify that logs are stored in the target path by setting --log-requests-target
 
     [Test Category] Parameter
     [Test Target] --log-requests-target;

--- a/test/registered/ascend/basic_function/logging/test_npu_log_requests_format.py
+++ b/test/registered/ascend/basic_function/logging/test_npu_log_requests_format.py
@@ -9,10 +9,10 @@ register_npu_ci(est_time=100, suite="nightly-1-npu-a3", nightly=True)
 
 
 class TestNPULogRequestsFormatText(TestNPULoggingBase):
-    """Testcase: Verify the functionality of --enable-request-time-stats-logging to generate Req Time Stats logs on Ascend backend with Llama-3.2-1B-Instruct model.
+    """Testcase: Verify the functionality of --log-requests-format to correctly generate formatted request logs.
 
     [Test Category] Parameter
-    [Test Target] --enable-request-time-stats-logging
+    [Test Target] --log-requests-format
     """
 
     log_requests_format = "text"

--- a/test/registered/ascend/basic_function/logging/test_npu_log_requests_format.py
+++ b/test/registered/ascend/basic_function/logging/test_npu_log_requests_format.py
@@ -1,0 +1,73 @@
+import json
+import unittest
+
+from sglang.test.ascend.output_capturer import OutputCapturer
+from sglang.test.ascend.test_npu_logging import TestNPULoggingBase
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(est_time=100, suite="nightly-1-npu-a3", nightly=True)
+
+
+class TestNPULogRequestsFormatText(TestNPULoggingBase):
+    """Testcase: Verify the functionality of --enable-request-time-stats-logging to generate Req Time Stats logs on Ascend backend with Llama-3.2-1B-Instruct model.
+
+    [Test Category] Parameter
+    [Test Target] --enable-request-time-stats-logging
+    """
+
+    log_requests_format = "text"
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.output_capturer = OutputCapturer()
+        cls.output_capturer.start()
+        cls.other_args.extend(["--log-requests-format", cls.log_requests_format])
+        cls.launch_server()
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        cls.output_capturer.stop()
+
+    def test_format(self):
+        self.inference_once()
+
+        content = self.output_capturer.get_all()
+        self.assertIn("Receive:", content, f"'Receive:' not found")
+        self.assertIn("Finish:", content, f"'Finish:' not found")
+
+
+class TestNPULogRequestsFormatJson(TestNPULogRequestsFormatText):
+    log_requests_format = "json"
+
+    def test_format(self):
+        self.inference_once()
+
+        content = self.output_capturer.get_all()
+        received_found = False
+        finished_found = False
+        for line in content.splitlines():
+            if not line.strip() or not line.startswith("{"):
+                continue
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            if data.get("event") == "request.received":
+                self.assertIn("rid", data)
+                self.assertIn("obj", data)
+                received_found = True
+            elif data.get("event") == "request.finished":
+                self.assertIn("rid", data)
+                self.assertIn("obj", data)
+                self.assertIn("out", data)
+                finished_found = True
+
+        self.assertTrue(received_found, f"request.received event not found")
+        self.assertTrue(finished_found, f"request.finished event not found")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/logging/test_npu_metrics.py
+++ b/test/registered/ascend/basic_function/logging/test_npu_metrics.py
@@ -1,0 +1,306 @@
+import unittest
+
+import requests
+
+from sglang.test.ascend.test_npu_logging import TestNPULoggingBase
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(est_time=100, suite="nightly-1-npu-a3", nightly=True)
+
+
+class TestNPUMetricsDefaultBucketBoundary(TestNPULoggingBase):
+    """Test case for verifying the functionality of the metrics-related parameter group.
+
+    [Description]
+        The metrics-related parameter group includes: --enable-metrics; --collect-tokens-histogram;
+        --bucket-inter-token-latency; --bucket-e2e-request-latency; --bucket-time-to-first-token;
+        --prompt-tokens-buckets; --generation-tokens-buckets
+
+        Verifies the cooperative effect of the parameter group and the independent function of each parameter, as follows:
+        1.  --enable-metrics: Core switch parameter; when configured, the service enables monitoring function and
+            supports obtaining various monitoring metrics through the metrics interface;
+        2.  --collect-tokens-histogram: When configured, it enables the statistical function of token count-related
+            metrics, including the statistics of prompt tokens and generation tokens;
+        3.  --bucket-time-to-first-token, --bucket-inter-token-latency, --bucket-e2e-request-latency:
+            Used to customize the statistical bucket boundaries of the corresponding latency-related metrics, which
+            correspond to time-to-first-token latency, inter-token latency, and end-to-end request latency respectively;
+        4.  --prompt-tokens-buckets, --generation-tokens-buckets:
+            Used to customize the bucket boundaries of token count statistical metrics, which correspond to the
+            statistical intervals of prompt tokens and generation tokens respectively.
+
+        Overall, verify that after parameter configuration, the monitoring function is normally enabled, the metric
+        statistics are accurate, the custom bucket boundaries take effect, and all configured monitoring information
+        can be obtained normally through the metrics interface.
+
+    [Test Category] Parameter
+    [Test Target] --enable-metrics; --bucket-time-to-first-token; --bucket-inter-token-latency; --bucket-e2e-request-latency;
+    --collect-tokens-histogram; --prompt-tokens-buckets; --generation-tokens-buckets;
+    """
+
+    @staticmethod
+    def _verify_metrics_and_bucket_boundary(
+        testcase,
+        model,
+        url,
+        expected_time_to_first_token_bucket=None,
+        expected_inter_token_latency_bucket=None,
+        expected_e2e_request_latency_bucket=None,
+        expected_prompt_tokens_bucket=None,
+        expected_generation_tokens_bucket=None,
+    ):
+        """Validate that metrics buckets align with expected boundaries when --enable-metrics and bucket configuration parameters are set."""
+        # Generate a sufficient number of tokens to monitor inter_token_latency_seconds_bucket
+        response = requests.post(
+            f"{url}/generate",
+            json={
+                "text": f"just return me a long string, generate as much as possible.",
+                "sampling_params": {"temperature": 0, "max_new_tokens": 1000},
+            },
+        )
+        testcase.assertEqual(response.status_code, 200)
+
+        response = requests.get(f"{url}/metrics", timeout=10)
+        testcase.assertEqual(response.status_code, 200)
+        metrics_content = response.text
+        if expected_time_to_first_token_bucket:
+            for le in expected_time_to_first_token_bucket:
+                message = f'sglang:time_to_first_token_seconds_bucket{{le="{le}",model_name="{model}"}}'
+                testcase.assertIn(message, metrics_content)
+        if expected_inter_token_latency_bucket:
+            for le in expected_inter_token_latency_bucket:
+                message = f'sglang:inter_token_latency_seconds_bucket{{le="{le}",model_name="{model}"}}'
+                testcase.assertIn(message, metrics_content)
+        if expected_e2e_request_latency_bucket:
+            for le in expected_e2e_request_latency_bucket:
+                message = f'sglang:e2e_request_latency_seconds_bucket{{le="{le}",model_name="{model}"}}'
+                testcase.assertIn(message, metrics_content)
+        if expected_prompt_tokens_bucket:
+            for le in expected_prompt_tokens_bucket:
+                message = f'sglang:prompt_tokens_histogram_bucket{{le="{le}",model_name="{model}"}}'
+                testcase.assertIn(message, metrics_content)
+        if expected_generation_tokens_bucket:
+            for le in expected_generation_tokens_bucket:
+                message = f'sglang:generation_tokens_histogram_bucket{{le="{le}",model_name="{model}"}}'
+                testcase.assertIn(message, metrics_content)
+        return metrics_content
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.other_args.extend(["--enable-metrics", "--collect-tokens-histogram"])
+        cls.set_default_bucket()
+        cls.launch_server()
+
+    @classmethod
+    def set_default_bucket(cls):
+        # Default bucket boundaries for time-to-first-token latency (seconds)
+        # Used if --bucket-time-to-first-token is not explicitly configured
+        cls.default_time_to_first_token_bucket = [
+            "0.1",
+            "0.2",
+            "0.4",
+            "0.6",
+            "0.8",
+            "1.0",
+            "2.0",
+            "4.0",
+            "6.0",
+            "8.0",
+            "10.0",
+            "20.0",
+            "40.0",
+            "60.0",
+            "80.0",
+            "100.0",
+            "200.0",
+            "400.0",
+        ]
+        # Default bucket boundaries for inter-token latency (seconds)
+        # Used if --bucket-inter-token-latency is not explicitly configured
+        cls.default_inter_token_latency_bucket = [
+            "0.002",
+            "0.004",
+            "0.006",
+            "0.008",
+            "0.01",
+            "0.015",
+            "0.02",
+            "0.025",
+            "0.03",
+            "0.035",
+            "0.04",
+            "0.06",
+            "0.08",
+            "0.1",
+            "0.2",
+            "0.4",
+            "0.6",
+            "0.8",
+            "1.0",
+            "2.0",
+            "4.0",
+            "6.0",
+            "8.0",
+        ]
+        # Default bucket boundaries for end-to-end (E2E) request latency (seconds)
+        # Used if --bucket-e2e-request-latency is not explicitly configured
+        cls.default_e2e_request_latency_bucket = [
+            "0.1",
+            "0.2",
+            "0.4",
+            "0.6",
+            "0.8",
+            "1.0",
+            "2.0",
+            "4.0",
+            "6.0",
+            "8.0",
+            "10.0",
+            "20.0",
+            "40.0",
+            "60.0",
+            "80.0",
+            "100.0",
+            "200.0",
+            "400.0",
+            "600.0",
+            "1200.0",
+            "1800.0",
+            "2400.0",
+        ]
+        # Default bucket boundaries for prompt/generation token count histograms
+        # Used if --prompt-tokens-buckets / --generation-tokens-bucket are not explicitly configured
+        # Note: Prompt and generation token buckets use identical default boundaries
+        cls.default_tokens_bucket = [
+            "100.0",
+            "300.0",
+            "500.0",
+            "700.0",
+            "1000.0",
+            "1500.0",
+            "2000.0",
+            "3000.0",
+            "4000.0",
+            "5000.0",
+            "6000.0",
+            "7000.0",
+            "8000.0",
+            "9000.0",
+            "10000.0",
+            "12000.0",
+            "15000.0",
+            "20000.0",
+            "22000.0",
+            "25000.0",
+            "30000.0",
+            "35000.0",
+            "40000.0",
+            "66000.0",
+            "99000.0",
+            "132000.0",
+            "300000.0",
+            "600000.0",
+            "900000.0",
+            "1.1e+06",
+        ]
+
+    def test_bucket_boundary(self):
+        TestNPUMetricsDefaultBucketBoundary._verify_metrics_and_bucket_boundary(
+            self,
+            self.model,
+            self.base_url,
+            expected_time_to_first_token_bucket=self.default_time_to_first_token_bucket,
+            expected_inter_token_latency_bucket=self.default_inter_token_latency_bucket,
+            expected_e2e_request_latency_bucket=self.default_e2e_request_latency_bucket,
+            expected_prompt_tokens_bucket=self.default_tokens_bucket,
+            expected_generation_tokens_bucket=self.default_tokens_bucket,
+        )
+
+
+class TestNPUMetricsCustomBucketBoundary(TestNPULoggingBase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.other_args.extend(["--enable-metrics"])
+        cls.other_args.extend(["--collect-tokens-histogram"])
+        cls.set_custom_bucket()
+        cls.other_args.extend(["--bucket-time-to-first-token", *cls.my_bucket])
+        cls.other_args.extend(["--bucket-inter-token-latency", *cls.my_bucket])
+        cls.other_args.extend(["--bucket-e2e-request-latency", *cls.my_bucket])
+        cls.other_args.extend(
+            ["--prompt-tokens-buckets", "custom", *cls.my_tokens_bucket]
+        )
+        cls.other_args.extend(
+            ["--generation-tokens-buckets", "custom", *cls.my_tokens_bucket]
+        )
+        cls.launch_server()
+
+    @classmethod
+    def set_custom_bucket(cls):
+        # Custom latency bucket boundaries (for testing non-default configurations)
+        cls.my_bucket = ["0.1", "0.5", "1.0", "5.0", "10.0"]
+        # Custom token count bucket boundaries (for testing custom configurations)
+        cls.my_tokens_bucket = [
+            "100.0",
+            "1000.0",
+            "10000.0",
+            "100000.0",
+            "300000.0",
+            "600000.0",
+            "900000.0",
+        ]
+
+    def test_bucket_boundary(self):
+        TestNPUMetricsDefaultBucketBoundary._verify_metrics_and_bucket_boundary(
+            self,
+            self.model,
+            self.base_url,
+            expected_time_to_first_token_bucket=self.my_bucket,
+            expected_inter_token_latency_bucket=self.my_bucket,
+            expected_e2e_request_latency_bucket=self.my_bucket,
+            expected_prompt_tokens_bucket=self.my_tokens_bucket,
+            expected_generation_tokens_bucket=self.my_tokens_bucket,
+        )
+
+
+class TestNPUMetricsTSEBucketBoundary(TestNPULoggingBase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.other_args.extend(["--enable-metrics"])
+        cls.other_args.extend(["--collect-tokens-histogram"])
+        cls.set_tse_bucket()
+        cls.other_args.extend(["--prompt-tokens-buckets", "tse", *cls.my_tse_set])
+        cls.other_args.extend(["--generation-tokens-buckets", "tse", *cls.my_tse_set])
+        cls.launch_server()
+
+    @classmethod
+    def set_tse_bucket(cls):
+        # Two-Sided Exponential (TSE) Bucket Strategy Configuration
+        # Format: [base_value, exponential_factor, number_of_steps]
+        cls.my_tse_set = ["1000", "2", "8"]
+        # Precomputed custom bucket boundaries using the TSE strategy
+        cls.my_tse_bucket = [
+            "984.0",
+            "992.0",
+            "996.0",
+            "998.0",
+            "1000.0",
+            "1002.0",
+            "1004.0",
+            "1008.0",
+            "1016.0",
+        ]
+
+    def test_bucket_boundary(self):
+        TestNPUMetricsDefaultBucketBoundary._verify_metrics_and_bucket_boundary(
+            self,
+            self.model,
+            self.base_url,
+            expected_prompt_tokens_bucket=self.my_tse_bucket,
+            expected_generation_tokens_bucket=self.my_tse_bucket,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/logging/test_npu_metrics.py
+++ b/test/registered/ascend/basic_function/logging/test_npu_metrics.py
@@ -9,7 +9,7 @@ register_npu_ci(est_time=100, suite="nightly-1-npu-a3", nightly=True)
 
 
 class TestNPUMetricsDefaultBucketBoundary(TestNPULoggingBase):
-    """Test case for verifying the functionality of the metrics-related parameter group.
+    """Testcase: Verify the functionality of the metrics-related parameter group.
 
     [Description]
         The metrics-related parameter group includes: --enable-metrics; --collect-tokens-histogram;

--- a/test/registered/ascend/basic_function/logging/test_npu_metrics_tokenizer_label.py
+++ b/test/registered/ascend/basic_function/logging/test_npu_metrics_tokenizer_label.py
@@ -1,0 +1,75 @@
+import unittest
+
+import requests
+
+from sglang.test.ascend.test_npu_logging import TestNPULoggingBase
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(est_time=100, suite="nightly-1-npu-a3", nightly=True)
+
+
+class TestNPUMetricsTokenizerLabel(TestNPULoggingBase):
+    """Test case for verifying the functionality of tokenizer-metrics custom label related parameters
+
+    [Description]
+        Parameters include: --tokenizer-metrics-custom-labels-header; --tokenizer-metrics-allowed-custom-labels
+        Verifies the cooperative effect of the two parameters and their independent functions, ensuring that the transmission
+        and verification of custom labels in tokenizer monitoring metrics take effect normally, as follows:
+        1.  --tokenizer-metrics-custom-labels-header: Used to set the name of the HTTP request header, which is used
+            by the client to pass custom labels to the server for tokenizer monitoring metrics statistics;
+        2.  --tokenizer-metrics-allowed-custom-labels: Used to set the list of custom labels allowed to be received by
+            the server; only the labels in this list will be recorded and counted by the tokenizer monitoring metrics,
+            and labels not in the list will be filtered out.
+        Overall, verify that after parameter configuration, the client can pass custom labels through the specified request
+        header, the server only receives and includes the allowed labels in monitoring statistics, filters illegal labels.
+        And verify monitoring grouped by custom tags.
+
+    [Test Category] Parameter
+    [Test Target] --tokenizer-metrics-custom-labels-header; --tokenizer-metrics-allowed-custom-labels;
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.other_args.extend(["--enable-metrics"])
+        # HTTP header name for custom metrics labels (--tokenizer-metrics-custom-labels-header)
+        cls.labels_header = "X-Metrics-Labels"
+        # Allowed custom label name (--tokenizer-metrics-allowed-custom-labels)
+        cls.my_label = "business_line"
+        cls.other_args.extend(
+            ["--tokenizer-metrics-custom-labels-header", cls.labels_header]
+        )
+        cls.other_args.extend(
+            ["--tokenizer-metrics-allowed-custom-labels", cls.my_label]
+        )
+        cls.launch_server()
+
+    def test_log_metrics_tokenizer_label(self):
+        """Validate independent statistical aggregation of requests with custom labels via tokenizer metrics label parameters."""
+        response = requests.post(
+            f"{self.base_url}/generate",
+            json={
+                "Content-Type": "application/json",
+                self.labels_header: f"{self.my_label}=customer_service",
+                "text": f"just return me a long string, generate as much as possible.",
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": 1000,
+                },
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+
+        response = requests.get(f"{self.base_url}/metrics", timeout=10)
+        self.assertEqual(response.status_code, 200)
+        metrics_content = response.text
+        message = f"sglang:time_to_first_token_seconds_bucket{{{self.my_label}="
+        self.assertIn(message, metrics_content)
+        message = f"sglang:inter_token_latency_seconds_bucket{{{self.my_label}="
+        self.assertIn(message, metrics_content)
+        message = f"sglang:e2e_request_latency_seconds_bucket{{{self.my_label}="
+        self.assertIn(message, metrics_content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/logging/test_npu_metrics_tokenizer_label.py
+++ b/test/registered/ascend/basic_function/logging/test_npu_metrics_tokenizer_label.py
@@ -9,7 +9,7 @@ register_npu_ci(est_time=100, suite="nightly-1-npu-a3", nightly=True)
 
 
 class TestNPUMetricsTokenizerLabel(TestNPULoggingBase):
-    """Test case for verifying the functionality of tokenizer-metrics custom label related parameters
+    """Testcase: Verify the functionality of tokenizer-metrics custom label related parameters
 
     [Description]
         Parameters include: --tokenizer-metrics-custom-labels-header; --tokenizer-metrics-allowed-custom-labels

--- a/test/registered/ascend/basic_function/parallel_strategy/data_parallelism/test_npu_load_balance_method.py
+++ b/test/registered/ascend/basic_function/parallel_strategy/data_parallelism/test_npu_load_balance_method.py
@@ -1,0 +1,120 @@
+import random
+import unittest
+from types import SimpleNamespace
+from urllib.parse import urlparse
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import DEEPSEEK_R1_0528_W8A8_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    is_in_ci,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=700, suite="nightly-16-npu-a3", nightly=True)
+
+
+class TestDPAttentionRoundBinLoadBalance(CustomTestCase):
+    """Testcase：Verify that the model accuracy did not decrease when --load-balance-method is set to round_robin, auto,
+    total_requests or total_tokens in PD mixed scenario
+
+    [Test Category] Parameter
+    [Test Target] --load-balance-method
+    """
+
+    mode = "round_robin"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model_path = DEEPSEEK_R1_0528_W8A8_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.url = urlparse(cls.base_url)
+        other_args = [
+            "--trust-remote-code",
+            "--tp",
+            "16",
+            "--enable-dp-attention",
+            "--dp",
+            "2",
+            "--enable-torch-compile",
+            "--torch-compile-max-bs",
+            "2",
+            "--load-balance-method",
+            cls.mode,
+            "--attention-backend",
+            "ascend",
+            "--disable-cuda-graph",
+            "--quantization",
+            "modelslim",
+            "--mem-fraction-static",
+            "0.75",
+        ]
+
+        cls.process = popen_launch_server(
+            cls.model_path,
+            cls.base_url,
+            timeout=3 * DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            num_shots=5,
+            data_path=None,
+            num_questions=200,
+            max_new_tokens=512,
+            parallel=128,
+            host=f"http://{self.url.hostname}",
+            port=int(self.url.port),
+        )
+
+        metrics = run_eval_few_shot_gsm8k(args)
+        self.assertGreaterEqual(
+            metrics["accuracy"],
+            0.95,
+        )
+
+    def test_server_info(self):
+        response = requests.get(f"{self.base_url}/get_server_info")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(self.mode, response.text)
+
+
+class _TestDPAttentionAutoLoadBalance(TestDPAttentionRoundBinLoadBalance):
+    mode = "auto"
+
+
+class _TestDPAttentionTotalRequestsLoadBalance(TestDPAttentionRoundBinLoadBalance):
+    mode = "total_requests"
+
+
+class _TestDPAttentionTotalTokensLoadBalance(TestDPAttentionRoundBinLoadBalance):
+    mode = "total_tokens"
+
+
+if __name__ == "__main__":
+    # To reduce the CI execution time.
+    if is_in_ci():
+        loader = unittest.TestLoader()
+        suite = unittest.TestSuite()
+        RUN_FLAG = [
+            TestDPAttentionRoundBinLoadBalance,
+            _TestDPAttentionAutoLoadBalance,
+            _TestDPAttentionTotalRequestsLoadBalance,
+            _TestDPAttentionTotalTokensLoadBalance,
+        ]
+        suite.addTests(loader.loadTestsFromTestCase(random.choice(RUN_FLAG)))
+        runner = unittest.TextTestRunner()
+        runner.run(suite)
+    else:
+        unittest.main()

--- a/test/registered/ascend/basic_function/parallel_strategy/data_parallelism/test_npu_load_balance_method_pd_disaggregation.py
+++ b/test/registered/ascend/basic_function/parallel_strategy/data_parallelism/test_npu_load_balance_method_pd_disaggregation.py
@@ -1,0 +1,208 @@
+import itertools
+import json
+import os
+import random
+import unittest
+from time import sleep
+from types import SimpleNamespace
+from typing import List, Type
+from urllib.parse import urlparse
+
+import requests
+
+from sglang.test.ascend.disaggregation_utils import TestDisaggregationBase
+from sglang.test.ascend.test_ascend_utils import (
+    QWEN3_30B_A3B_INSTRUCT_2507_WEIGHTS_PATH,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    is_in_ci,
+    popen_launch_pd_server,
+)
+
+register_npu_ci(est_time=3600, suite="nightly-4-npu-a3", nightly=True)
+
+load_balance_method_options = [
+    "auto",
+    "round_robin",
+    "total_requests",
+    "total_tokens",
+    "follow_bootstrap_room",
+]
+all_params = list(itertools.product(load_balance_method_options, repeat=2))
+
+
+class BaseTestNPULoadBalanceMethodDPDisaggregation(TestDisaggregationBase):
+    """Testcase：Verify that the model accuracy did not decrease when --load-balance-method is set to round_robin, auto,
+    total_requests, total_tokens or follow_bootstrap_room in PD disaggregation scenario
+
+    [Test Category] Parameter
+    [Test Target] --load-balance-method
+    """
+
+    params = ("auto", "auto")
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.prefill_load_balance_method, cls.decode_load_balance_method = cls.params
+        cls.model = QWEN3_30B_A3B_INSTRUCT_2507_WEIGHTS_PATH
+        os.environ["ASCEND_MF_STORE_URL"] = "tcp://127.0.0.1:24666"
+
+        # Non blocking start servers
+        cls.start_prefill()
+        cls.start_decode()
+
+        # Block until both
+        cls.wait_server_ready(cls.prefill_url + "/health")
+        cls.wait_server_ready(cls.decode_url + "/health")
+
+        cls.launch_lb()
+        cls.url = urlparse(cls.lb_url)
+
+    @classmethod
+    def start_prefill(cls):
+        prefill_args = [
+            "--disaggregation-mode",
+            "prefill",
+            "--tp-size",
+            "2",
+            "--enable-dp-attention",
+            "--dp",
+            "2",
+            "--load-balance-method",
+            cls.prefill_load_balance_method,
+            "--disaggregation-transfer-backend",
+            "ascend",
+            "--disable-cuda-graph",
+            "--attention-backend",
+            "ascend",
+            "--mem-fraction-static",
+            0.8,
+            "--dist-init-addr",
+            "127.0.0.1:10100",
+            "--base-gpu-id",
+            4,
+        ]
+
+        cls.process_prefill = popen_launch_pd_server(
+            cls.model,
+            cls.prefill_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=prefill_args,
+        )
+
+    @classmethod
+    def start_decode(cls):
+        decode_args = [
+            "--disaggregation-mode",
+            "decode",
+            "--base-gpu-id",
+            2,
+            "--tp-size",
+            "2",
+            "--enable-dp-attention",
+            "--dp",
+            "2",
+            "--load-balance-method",
+            cls.decode_load_balance_method,
+            "--disaggregation-transfer-backend",
+            "ascend",
+            "--disable-cuda-graph",
+            "--attention-backend",
+            "ascend",
+            "--mem-fraction-static",
+            0.8,
+            "--dist-init-addr",
+            "127.0.0.1:10000",
+        ]
+
+        cls.process_decode = popen_launch_pd_server(
+            cls.model,
+            cls.decode_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=decode_args,
+        )
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            num_shots=5,
+            data_path=None,
+            num_questions=200,
+            max_new_tokens=512,
+            parallel=128,
+            host=f"http://{self.url.hostname}",
+            port=int(self.url.port),
+        )
+
+        metrics = run_eval_few_shot_gsm8k(args)
+        self.assertGreaterEqual(
+            metrics["accuracy"],
+            # 0.95 with 0.02 tolerable fluctuation
+            0.93,
+        )
+
+    def test_server_info(self):
+        response = requests.get(f"{self.lb_url}/get_server_info")
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.text)
+        self.assertEqual(
+            (
+                "follow_bootstrap_room"
+                if self.prefill_load_balance_method == "auto"
+                else self.prefill_load_balance_method
+            ),
+            data.get("prefill")[0].get("load_balance_method"),
+        )
+        self.assertEqual(
+            (
+                "round_robin"
+                if self.decode_load_balance_method == "auto"
+                else self.decode_load_balance_method
+            ),
+            data.get("decode")[0].get("load_balance_method"),
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        os.environ.pop("ASCEND_MF_STORE_URL")
+        super().tearDownClass()
+        # wait for server release source
+        sleep(10)
+
+
+TestClassType = Type[BaseTestNPULoadBalanceMethodDPDisaggregation]
+all_test_classes: List[TestClassType] = [BaseTestNPULoadBalanceMethodDPDisaggregation]
+for index, param_tuple in enumerate(all_params):
+    if param_tuple == BaseTestNPULoadBalanceMethodDPDisaggregation.params:
+        continue
+
+    prefill_load_balance_method, decode_load_balance_method = param_tuple
+    class_name = f"Test_{index:02d}_prefill_{prefill_load_balance_method}_decode_{decode_load_balance_method}"
+    new_class = type(
+        class_name,
+        (BaseTestNPULoadBalanceMethodDPDisaggregation,),
+        {"params": param_tuple},
+    )
+
+    all_test_classes.append(new_class)
+
+if __name__ == "__main__":
+    if is_in_ci():
+        RUN_COUNT = 3
+        loader = unittest.TestLoader()
+        suite = unittest.TestSuite()
+
+        selected_classes = random.sample(
+            all_test_classes, min(RUN_COUNT, len(all_test_classes))
+        )
+
+        for cls in selected_classes:
+            suite.addTests(loader.loadTestsFromTestCase(cls))
+
+        runner = unittest.TextTestRunner(verbosity=2)
+        runner.run(suite)
+    else:
+        unittest.main()

--- a/test/registered/ascend/basic_function/quantization_and_data_type/test_npu_dtype.py
+++ b/test/registered/ascend/basic_function/quantization_and_data_type/test_npu_dtype.py
@@ -1,0 +1,58 @@
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=400, suite="nightly-1-npu-a3", nightly=True)
+
+
+class TestNPUDtype(CustomTestCase):
+    """Testcase：Verify set --dtype is half or float16 or bfloat16, request inference successful.
+
+    [Test Category] Parameter
+    [Test Target] --dtype
+    """
+
+    model = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+
+    def test_dtype_options(self):
+        for i in ["half", "float16", "bfloat16"]:
+            other_args = [
+                "--dtype",
+                i,
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+            ]
+            process = popen_launch_server(
+                self.model,
+                DEFAULT_URL_FOR_TEST,
+                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                other_args=other_args,
+            )
+            response = requests.post(
+                f"{DEFAULT_URL_FOR_TEST}/generate",
+                json={
+                    "text": "The capital of France is",
+                    "sampling_params": {
+                        "temperature": 0,
+                        "max_new_tokens": 32,
+                    },
+                },
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertIn("Paris", response.text)
+            kill_process_tree(process.pid)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/quantization_and_data_type/test_npu_enable_fp32_lm_head.py
+++ b/test/registered/ascend/basic_function/quantization_and_data_type/test_npu_enable_fp32_lm_head.py
@@ -1,0 +1,38 @@
+import unittest
+
+from sglang.test.ascend.gsm8k_ascend_mixin import GSM8KAscendMixin
+from sglang.test.ascend.test_ascend_utils import QWEN3_32B_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_npu_ci(
+    est_time=300,
+    suite="nightly-4-npu-a3",
+    nightly=True,
+)
+
+
+class TestNPUEnableFp32LmHead(GSM8KAscendMixin, CustomTestCase):
+    """Testcase: Verify that the inference accuracy on the GSM8K dataset does not decrease after --enable-fp32-lm-head is set.
+
+    [Test Category] Parameter
+    [Test Target] --enable-fp32-lm-head
+    """
+
+    model = QWEN3_32B_WEIGHTS_PATH
+    accuracy = 0.86
+    other_args = [
+        "--enable-fp32-lm-head",
+        "--trust-remote-code",
+        "--mem-fraction-static",
+        "0.8",
+        "--attention-backend",
+        "ascend",
+        "--disable-cuda-graph",
+        "--tp-size",
+        "4",
+    ]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/quantization_and_data_type/test_npu_kv_cache_dtype.py
+++ b/test/registered/ascend/basic_function/quantization_and_data_type/test_npu_kv_cache_dtype.py
@@ -1,0 +1,93 @@
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.output_capturer import OutputCapturer
+from sglang.test.ascend.test_ascend_utils import LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=150, suite="nightly-1-npu-a3", nightly=True)
+
+
+class TestNPUKVCacheDtype(CustomTestCase):
+    """Testcase: Verify set --kv_cache_dtype is auto, bf16 or bfloat16, request inference successful.
+
+    [Test Category] Parameter
+    [Test Target] --kv_cache_dtype
+    """
+
+    model = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+    kv_cache_dtype = "auto"
+    using_kv_cache_dtype = "torch.bfloat16"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.capturer = OutputCapturer()
+        cls.capturer.start()
+
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        other_args = [
+            "--dtype",
+            "auto",
+            "--attention-backend",
+            "ascend",
+            "--disable-cuda-graph",
+            "--kv-cache-dtype",
+            cls.kv_cache_dtype,
+        ]
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.process:
+            kill_process_tree(cls.process.pid)
+        cls.capturer.stop()
+
+    def test_dtype_options(self):
+        response = requests.post(
+            f"{self.base_url}/generate",
+            json={
+                "text": "The capital of France is",
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": 32,
+                },
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Paris", response.text)
+
+        response = requests.get(
+            f"{self.base_url}/server_info",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(f'"kv_cache_dtype":"{self.kv_cache_dtype}"', response.text)
+
+        output = (
+            self.__class__.capturer.get_output() + self.__class__.capturer.get_error()
+        )
+        self.assertIn(f"Using KV cache dtype: {self.using_kv_cache_dtype}", output)
+
+
+class TestNPUKVCacheDtypeBf16(TestNPUKVCacheDtype):
+    kv_cache_dtype = "bf16"
+
+
+class TestNPUKVCacheDtypeBfloat16(TestNPUKVCacheDtype):
+    kv_cache_dtype = "bfloat16"
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR aims to improve the test coverage of parameters under  logging, data parallelism, quantization and data type features on the Ascend NPU platform.
Covered features and parameters:.
feature: logging
--log-requests; --log-requests-level; --log-requests-target; --uvicorn-access-log-exclude-prefixes; --enable-metrics; --enable-metrics-for-all-scheduler; --bucket-time-to-first-token; --bucket-inter-token-latency; --bucket-e2e-request-latency; --collect-tokens-histogram; --prompt-tokens-buckets; --generation-tokens-buckets; --tokenizer-metrics-custom-labels-header; --tokenizer-metrics-allowed-custom-labels; --gc-warning-threshold-secs
feature: data parallelism
--load-balance-method
feature: quantization and data type
--enable-fp32-lm-head;--kv-cache-dtype

## Modifications

1、Add output_capturer.py: Capture console output using low-level file descriptor redirection to obtain print information from child processes, NPU processes.
2、Add test_npu_logging.py: Test base class to verify whether the parameters in the logging function are correct. Includes basic function.
3、Add test_npu_crash_dump.py: Verify crash dump generation when the server crashes and validates that crash dump files are created and contain expected request data.
4、Add test_npu_decode_log_interval.py: Verify that configuration --decode-log-interval can correctly record decode information in batches.
5、Add test_npu_dtype.py: Verify set --dtype is half or float16 or bfloat16, request inference successful.
6、Add test_npu_enable_fp32_lm_head.py: Verify that the inference accuracy on the GSM8K dataset does not decrease after --enable-fp32-lm-head is set.
7、Add test_npu_enable_metrics_for_all_scheduler.py: Verify that the functionality of the --enable-metrics-for-all-scheduler parameter
8、Add test_npu_enable_request_time_stats_logging.py: Verify the functionality of --enable-request-time-stats-logging to generate Req Time Stats logs.
9、Add test_npu_gc_warning_threshold.py: Verify the functionality of the --gc-warning-threshold-secs parameter
10、Add test_npu_hybrid_attention_backend.py: Verify set --prefill-attention-backend, --decode-attention-backend, the inference request is successfully processed.
11、Add test_npu_json_mode.py: Verify JSON mode functionality with xgrammar grammar backend (non-streaming and streaming).
12、Add test_npu_kv_cache_dtype.py: Verify set --kv_cache_dtype is auto, bf16 or bfloat16, request inference successful.
13、Add test_npu_load_balance_method.py: Verify that the model accuracy did not decrease when --load-balance-method is set to round_robin, auto,
14、Add test_npu_load_balance_method_pd_disaggregation.py: Verify that the model accuracy did not decrease when --load-balance-method is set to round_robin, auto,
15、Add test_npu_log_exclude_prefixes.py: Verify the functionality of the --uvicorn-access-log-exclude-prefixes parameter.
16、Add test_npu_log_level.py: Verify set log-level parameter, the printed log level is the same as the configured log level and the inference request is successfully processed.
17、Add test_npu_log_requests_format.py: Verify the functionality of --log-requests-format to correctly generate formatted request logs.
18、Add test_npu_log_request_level.py: Verify that the logs include request logs with the corresponding verbosity level when --log-requests-level is set.
19、Add test_npu_log_request_target.py: Verify that logs are stored in the target path by setting --log-requests-target
20、Add test_npu_metrics.py: Verify the functionality of the metrics-related parameter group.
21、Add test_npu_metrics_tokenizer_label.py: Verify the functionality of tokenizer-metrics custom label related parameters
22、Add test_npu_mm_attention_backend.py: Verify MMMU dataset accuracy ≥0.2 for google/gemma-3-4b-it with --mm-attention-backend ascend_attn.
23、Add test_npu_sampling_backend.py: When --sampling-backend=pytorch or ascend, verify the MMLU dataset accuracy (>0.65) and greedy sampling consistency of the Llama-3.1-8B-Instruct mode

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
