### PR TITLE
fix: support Anthropic web_search built-in tools in /v1/messages

### DIFF
--- a/python/sglang/srt/entrypoints/anthropic/protocol.py
+++ b/python/sglang/srt/entrypoints/anthropic/protocol.py
@@ -33,11 +33,18 @@ class AnthropicContentBlock(BaseModel):
     """Content block in message"""
 
     type: Literal[
-        "text", "image", "tool_use", "tool_result", "thinking", "redacted_thinking"
+        "text",
+        "image",
+        "tool_use",
+        "tool_result",
+        "thinking",
+        "redacted_thinking",
+        "search_result",
     ]
     text: Optional[str] = None
-    # For image content
-    source: Optional[dict[str, Any]] = None
+    # For image content (dict) and search_result source URL (str)
+    source: Optional[dict[str, Any] | str] = None
+    title: Optional[str] = None
     # For tool use/result
     id: Optional[str] = None
     tool_use_id: Optional[str] = None
@@ -62,11 +69,14 @@ class AnthropicTool(BaseModel):
 
     name: str
     description: Optional[str] = None
-    input_schema: dict[str, Any]
+    input_schema: Optional[dict[str, Any]] = None
+    type: Optional[str] = None
 
     @field_validator("input_schema")
     @classmethod
     def validate_input_schema(cls, v):
+        if v is None:
+            return v
         if not isinstance(v, dict):
             raise ValueError("input_schema must be a dictionary")
         if "type" not in v:

--- a/python/sglang/srt/entrypoints/anthropic/serving.py
+++ b/python/sglang/srt/entrypoints/anthropic/serving.py
@@ -232,6 +232,25 @@ class AnthropicServing:
                             }
                         )
 
+                elif block.type == "search_result":
+                    # Anthropic web_search tool returns search_result blocks
+                    # with source URL, title, and content. Flatten to text.
+                    parts = []
+                    if block.title:
+                        parts.append(block.title)
+                    if isinstance(block.source, str):
+                        parts.append(block.source)
+                    if isinstance(block.content, list):
+                        for item in block.content:
+                            if isinstance(item, dict) and item.get("text"):
+                                parts.append(item["text"])
+                    elif isinstance(block.content, str) and block.content:
+                        parts.append(block.content)
+                    if parts:
+                        content_parts.append(
+                            {"type": "text", "text": "\n".join(parts)}
+                        )
+
             # Attach tool calls to assistant messages
             if tool_calls:
                 openai_msg["tool_calls"] = tool_calls
@@ -270,10 +289,12 @@ class AnthropicServing:
 
         chat_request = ChatCompletionRequest(**request_data)
 
-        # Convert tools
+        # Convert tools (skip built-in tools like web_search that have no schema)
         if anthropic_request.tools:
             tools = []
             for tool in anthropic_request.tools:
+                if tool.input_schema is None:
+                    continue
                 tools.append(
                     Tool(
                         type="function",
@@ -284,7 +305,8 @@ class AnthropicServing:
                         },
                     )
                 )
-            chat_request.tools = tools
+            if tools:
+                chat_request.tools = tools
 
         # Convert tool choice
         if anthropic_request.tool_choice is not None:


### PR DESCRIPTION
## Summary

Fixes #22655 — Anthropic's `/v1/messages` endpoint rejects requests containing built-in `web_search` tools and `search_result` content blocks.

Built-in tools like `web_search_20250305` omit `input_schema`, and their results include `search_result` content blocks with `source` URL, `title`, and nested text content.  Both cause Pydantic validation errors in the current Anthropic compatibility layer.

## Changes

**`protocol.py`**
- `AnthropicTool.input_schema`: make optional (built-in tools don't always carry a schema)
- `AnthropicTool.type`: add optional field (Anthropic sends `type` for built-in tools)
- `AnthropicContentBlock.type`: add `"search_result"` literal
- `AnthropicContentBlock.source`: widen to accept URL strings alongside image source dicts
- `AnthropicContentBlock.title`: new optional field for search result titles

**`serving.py`**
- Skip tools without `input_schema` during OpenAI tool conversion (instead of crashing)
- Flatten `search_result` blocks into text content for the underlying model

## Test plan

- [ ] Send a request with `web_search_20250305` tool to the Anthropic endpoint — should no longer return 422
- [ ] Verify search_result blocks in conversation history are flattened to text
- [ ] Verify normal tool_use / tool_result flow still works unchanged