### PR TITLE
Optimize LTX2 modulation and two-stage warmup

### DIFF
--- a/python/sglang/multimodal_gen/.claude/skills/sglang-diffusion-benchmark-profile/scripts/bench_diffusion_denoise.py
+++ b/python/sglang/multimodal_gen/.claude/skills/sglang-diffusion-benchmark-profile/scripts/bench_diffusion_denoise.py
@@ -206,6 +206,7 @@ MODELS = {
             "--num-inference-steps=30",
             "--guidance-scale=3.0",
             "--num-gpus=2",
+            "--warmup",
         ],
     },
     # 11. Skill-only extra preset
@@ -223,6 +224,7 @@ MODELS = {
             "--num-inference-steps=30",
             "--guidance-scale=3.0",
             "--num-gpus=2",
+            "--warmup",
         ],
     },
     # 12. Skill-only extra preset
@@ -343,7 +345,7 @@ def build_sglang_cmd(
 
     if save_output:
         cmd.append("--save-output")
-    if warmup:
+    if warmup and "--warmup" not in cmd:
         cmd.append("--warmup")
     if torch_compile:
         cmd.append("--enable-torch-compile")

--- a/python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py
@@ -381,10 +381,27 @@ def rms_norm(x: torch.Tensor, eps: float) -> torch.Tensor:
     return F.rms_norm(x, normalized_shape=(x.shape[-1],), eps=eps)
 
 
+def _ltx2_is_torch_compiling() -> bool:
+    try:
+        if hasattr(torch, "compiler") and hasattr(torch.compiler, "is_compiling"):
+            return bool(torch.compiler.is_compiling())
+        if hasattr(torch, "_dynamo") and hasattr(torch._dynamo, "is_compiling"):
+            return bool(torch._dynamo.is_compiling())
+    except Exception:
+        return False
+    return False
+
+
+def _ltx2_can_use_custom_modulation_kernel(x: torch.Tensor) -> bool:
+    # Under torch.compile, keep the raw PyTorch expression visible so Inductor can
+    # fuse modulation into the surrounding graph instead of calling small kernels.
+    return x.is_cuda and not _ltx2_is_torch_compiling()
+
+
 def _ltx2_can_use_fused_norm(x: torch.Tensor) -> bool:
     return (
         fused_norm_scale_shift is not None
-        and x.is_cuda
+        and _ltx2_can_use_custom_modulation_kernel(x)
         and x.ndim == 3
         and x.shape[-1] % 256 == 0
         and x.shape[-1] <= 8192
@@ -400,7 +417,7 @@ def _ltx2_scale_shift(
 ) -> torch.Tensor:
     if (
         fuse_scale_shift_kernel is not None
-        and x.is_cuda
+        and _ltx2_can_use_custom_modulation_kernel(x)
         and x.ndim == 3
         and scale.is_cuda
     ):
@@ -1051,7 +1068,6 @@ class LTX2TransformerBlock(nn.Module):
         v2a_cross_attn_perturbation_mask: Optional[torch.Tensor] = None,
         audio_replicated_for_sp: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-
         batch_size = hidden_states.size(0)
 
         # 1. Video and Audio Self-Attention
@@ -1671,7 +1687,6 @@ class LTX2VideoTransformer3DModel(CachableDiT, OffloadableDiTMixin):
         audio_replicated_for_sp: bool = False,
         **kwargs,
     ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
-
         batch_size = hidden_states.size(0)
         audio_timestep = audio_timestep if audio_timestep is not None else timestep
 

--- a/python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py
@@ -45,6 +45,7 @@ from sglang.multimodal_gen.runtime.layers.quantization.configs.base_config impor
 from sglang.multimodal_gen.runtime.layers.visual_embedding import timestep_embedding
 from sglang.multimodal_gen.runtime.models.dits.base import CachableDiT
 from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
+from sglang.multimodal_gen.runtime.utils.common import is_torch_compiling
 from sglang.multimodal_gen.runtime.utils.layerwise_offload import OffloadableDiTMixin
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
@@ -381,21 +382,10 @@ def rms_norm(x: torch.Tensor, eps: float) -> torch.Tensor:
     return F.rms_norm(x, normalized_shape=(x.shape[-1],), eps=eps)
 
 
-def _ltx2_is_torch_compiling() -> bool:
-    try:
-        if hasattr(torch, "compiler") and hasattr(torch.compiler, "is_compiling"):
-            return bool(torch.compiler.is_compiling())
-        if hasattr(torch, "_dynamo") and hasattr(torch._dynamo, "is_compiling"):
-            return bool(torch._dynamo.is_compiling())
-    except Exception:
-        return False
-    return False
-
-
 def _ltx2_can_use_custom_modulation_kernel(x: torch.Tensor) -> bool:
     # Under torch.compile, keep the raw PyTorch expression visible so Inductor can
     # fuse modulation into the surrounding graph instead of calling small kernels.
-    return x.is_cuda and not _ltx2_is_torch_compiling()
+    return x.is_cuda and not is_torch_compiling()
 
 
 def _ltx2_can_use_fused_norm(x: torch.Tensor) -> bool:

--- a/python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py
@@ -10,6 +10,18 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+try:
+    from sglang.jit_kernel.diffusion.cutedsl.scale_residual_norm_scale_shift import (
+        fused_norm_scale_shift,
+    )
+except ImportError:
+    fused_norm_scale_shift = None
+
+try:
+    from sglang.jit_kernel.diffusion.triton.scale_shift import fuse_scale_shift_kernel
+except ImportError:
+    fuse_scale_shift_kernel = None
+
 from sglang.multimodal_gen.configs.models.dits.ltx_2 import LTX2ArchConfig, LTX2Config
 from sglang.multimodal_gen.runtime.distributed import (
     get_sp_parallel_rank,
@@ -367,6 +379,74 @@ class LTX2AudioVideoRotaryPosEmbed(nn.Module):
 
 def rms_norm(x: torch.Tensor, eps: float) -> torch.Tensor:
     return F.rms_norm(x, normalized_shape=(x.shape[-1],), eps=eps)
+
+
+def _ltx2_can_use_fused_norm(x: torch.Tensor) -> bool:
+    return (
+        fused_norm_scale_shift is not None
+        and x.is_cuda
+        and x.ndim == 3
+        and x.shape[-1] % 256 == 0
+        and x.shape[-1] <= 8192
+    )
+
+
+def _ltx2_scale_shift(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    shift: torch.Tensor,
+    *,
+    scale_constant: float = 1.0,
+) -> torch.Tensor:
+    if (
+        fuse_scale_shift_kernel is not None
+        and x.is_cuda
+        and x.ndim == 3
+        and scale.is_cuda
+    ):
+        return fuse_scale_shift_kernel(
+            x.contiguous(),
+            scale.contiguous(),
+            shift.contiguous(),
+            scale_constant=scale_constant,
+        )
+    return x * (scale_constant + scale) + shift
+
+
+def _ltx2_norm_scale_shift(
+    x: torch.Tensor,
+    shift: torch.Tensor,
+    scale: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    if _ltx2_can_use_fused_norm(x):
+        return fused_norm_scale_shift(
+            x.contiguous(),
+            None,
+            None,
+            scale.contiguous(),
+            shift.contiguous(),
+            "rms",
+            eps,
+        )
+    return rms_norm(x, eps) * (1 + scale) + shift
+
+
+def _ltx2_norm(x: torch.Tensor, eps: float) -> torch.Tensor:
+    if _ltx2_can_use_fused_norm(x):
+        zero = x.new_zeros((1,))
+        return _ltx2_norm_scale_shift(x, zero, zero, eps)
+    return rms_norm(x, eps)
+
+
+def _ltx2_residual_add(
+    residual: torch.Tensor,
+    x: torch.Tensor,
+    gate: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if gate is None:
+        return residual + x
+    return _ltx2_scale_shift(x, gate, residual, scale_constant=0.0)
 
 
 class LTX2TextProjection(nn.Module):
@@ -978,8 +1058,8 @@ class LTX2TransformerBlock(nn.Module):
         vshift_msa, vscale_msa, vgate_msa = self.get_ada_values(
             self.scale_shift_table, batch_size, temb, slice(0, 3)
         )
-        norm_hidden_states = (
-            rms_norm(hidden_states, self.norm_eps) * (1 + vscale_msa) + vshift_msa
+        norm_hidden_states = _ltx2_norm_scale_shift(
+            hidden_states, vshift_msa, vscale_msa, self.norm_eps
         )
         attn_hidden_states = self.attn1(
             norm_hidden_states,
@@ -989,13 +1069,13 @@ class LTX2TransformerBlock(nn.Module):
             all_perturbed=skip_video_self_attn,
             gather_context_kv_for_sp=audio_replicated_for_sp,
         )
-        hidden_states = hidden_states + attn_hidden_states * vgate_msa
+        hidden_states = _ltx2_residual_add(hidden_states, attn_hidden_states, vgate_msa)
 
         ashift_msa, ascale_msa, agate_msa = self.get_ada_values(
             self.audio_scale_shift_table, batch_size, temb_audio, slice(0, 3)
         )
-        norm_audio_hidden_states = (
-            rms_norm(audio_hidden_states, self.norm_eps) * (1 + ascale_msa) + ashift_msa
+        norm_audio_hidden_states = _ltx2_norm_scale_shift(
+            audio_hidden_states, ashift_msa, ascale_msa, self.norm_eps
         )
         attn_audio_hidden_states = self.audio_attn1(
             norm_audio_hidden_states,
@@ -1005,7 +1085,9 @@ class LTX2TransformerBlock(nn.Module):
             all_perturbed=skip_audio_self_attn,
             skip_sequence_parallel_override=audio_replicated_for_sp,
         )
-        audio_hidden_states = audio_hidden_states + attn_audio_hidden_states * agate_msa
+        audio_hidden_states = _ltx2_residual_add(
+            audio_hidden_states, attn_audio_hidden_states, agate_msa
+        )
         # 2. Prompt Cross-Attention
         if self.cross_attention_adaln:
             # LTX2.3
@@ -1019,18 +1101,20 @@ class LTX2TransformerBlock(nn.Module):
             v_prompt_shift, v_prompt_scale = self.get_ada_values(
                 self.prompt_scale_shift_table, batch_size, temb_prompt, slice(None)
             )
-            norm_hidden_states = (
-                rms_norm(hidden_states, self.norm_eps) * (1 + vscale_q) + vshift_q
+            norm_hidden_states = _ltx2_norm_scale_shift(
+                hidden_states, vshift_q, vscale_q, self.norm_eps
             )
-            mod_encoder_hidden_states = (
-                encoder_hidden_states * (1 + v_prompt_scale) + v_prompt_shift
+            mod_encoder_hidden_states = _ltx2_scale_shift(
+                encoder_hidden_states, v_prompt_scale, v_prompt_shift
             )
             attn_hidden_states = self.attn2(
                 norm_hidden_states,
                 context=mod_encoder_hidden_states,
                 mask=encoder_attention_mask,
             )
-            hidden_states = hidden_states + attn_hidden_states * vgate_q
+            hidden_states = _ltx2_residual_add(
+                hidden_states, attn_hidden_states, vgate_q
+            )
 
             ashift_q, ascale_q, agate_q = self.get_ada_values(
                 self.audio_scale_shift_table, batch_size, temb_audio, slice(6, 9)
@@ -1041,39 +1125,41 @@ class LTX2TransformerBlock(nn.Module):
                 temb_audio_prompt,
                 slice(None),
             )
-            norm_audio_hidden_states = (
-                rms_norm(audio_hidden_states, self.norm_eps) * (1 + ascale_q) + ashift_q
+            norm_audio_hidden_states = _ltx2_norm_scale_shift(
+                audio_hidden_states, ashift_q, ascale_q, self.norm_eps
             )
-            mod_audio_encoder_hidden_states = (
-                audio_encoder_hidden_states * (1 + a_prompt_scale) + a_prompt_shift
+            mod_audio_encoder_hidden_states = _ltx2_scale_shift(
+                audio_encoder_hidden_states, a_prompt_scale, a_prompt_shift
             )
             attn_audio_hidden_states = self.audio_attn2(
                 norm_audio_hidden_states,
                 context=mod_audio_encoder_hidden_states,
                 mask=audio_encoder_attention_mask,
             )
-            audio_hidden_states = (
-                audio_hidden_states + attn_audio_hidden_states * agate_q
+            audio_hidden_states = _ltx2_residual_add(
+                audio_hidden_states, attn_audio_hidden_states, agate_q
             )
         else:
-            norm_hidden_states = rms_norm(hidden_states, self.norm_eps)
+            norm_hidden_states = _ltx2_norm(hidden_states, self.norm_eps)
             attn_hidden_states = self.attn2(
                 norm_hidden_states,
                 context=encoder_hidden_states,
                 mask=encoder_attention_mask,
             )
-            hidden_states = hidden_states + attn_hidden_states
+            hidden_states = _ltx2_residual_add(hidden_states, attn_hidden_states)
 
-            norm_audio_hidden_states = rms_norm(audio_hidden_states, self.norm_eps)
+            norm_audio_hidden_states = _ltx2_norm(audio_hidden_states, self.norm_eps)
             attn_audio_hidden_states = self.audio_attn2(
                 norm_audio_hidden_states,
                 context=audio_encoder_hidden_states,
                 mask=audio_encoder_attention_mask,
             )
-            audio_hidden_states = audio_hidden_states + attn_audio_hidden_states
+            audio_hidden_states = _ltx2_residual_add(
+                audio_hidden_states, attn_audio_hidden_states
+            )
         # 3. Audio-to-Video and Video-to-Audio Cross-Attention
-        norm_hidden_states = rms_norm(hidden_states, self.norm_eps)
-        norm_audio_hidden_states = rms_norm(audio_hidden_states, self.norm_eps)
+        norm_hidden_states = _ltx2_norm(hidden_states, self.norm_eps)
+        norm_audio_hidden_states = _ltx2_norm(audio_hidden_states, self.norm_eps)
 
         # Compute combined ada params
         video_per_layer_ca_scale_shift = self.video_a2v_cross_attn_scale_shift_table[
@@ -1134,11 +1220,11 @@ class LTX2TransformerBlock(nn.Module):
         v2a_gate = audio_ca_gate[0].squeeze(2)
 
         # A2V
-        mod_norm_hidden_states = (
-            norm_hidden_states * (1 + video_a2v_ca_scale) + video_a2v_ca_shift
+        mod_norm_hidden_states = _ltx2_scale_shift(
+            norm_hidden_states, video_a2v_ca_scale, video_a2v_ca_shift
         )
-        mod_norm_audio_hidden_states = (
-            norm_audio_hidden_states * (1 + audio_a2v_ca_scale) + audio_a2v_ca_shift
+        mod_norm_audio_hidden_states = _ltx2_scale_shift(
+            norm_audio_hidden_states, audio_a2v_ca_scale, audio_a2v_ca_shift
         )
 
         if not skip_a2v_cross_attn:
@@ -1154,14 +1240,16 @@ class LTX2TransformerBlock(nn.Module):
                 a2v_attn_hidden_states = (
                     a2v_attn_hidden_states * a2v_cross_attn_perturbation_mask
                 )
-            hidden_states = hidden_states + a2v_gate * a2v_attn_hidden_states
+            hidden_states = _ltx2_residual_add(
+                hidden_states, a2v_attn_hidden_states, a2v_gate
+            )
 
         # V2A
-        mod_norm_hidden_states = (
-            norm_hidden_states * (1 + video_v2a_ca_scale) + video_v2a_ca_shift
+        mod_norm_hidden_states = _ltx2_scale_shift(
+            norm_hidden_states, video_v2a_ca_scale, video_v2a_ca_shift
         )
-        mod_norm_audio_hidden_states = (
-            norm_audio_hidden_states * (1 + audio_v2a_ca_scale) + audio_v2a_ca_shift
+        mod_norm_audio_hidden_states = _ltx2_scale_shift(
+            norm_audio_hidden_states, audio_v2a_ca_scale, audio_v2a_ca_shift
         )
 
         if not skip_v2a_cross_attn:
@@ -1177,27 +1265,29 @@ class LTX2TransformerBlock(nn.Module):
                 v2a_attn_hidden_states = (
                     v2a_attn_hidden_states * v2a_cross_attn_perturbation_mask
                 )
-            audio_hidden_states = (
-                audio_hidden_states + v2a_gate * v2a_attn_hidden_states
+            audio_hidden_states = _ltx2_residual_add(
+                audio_hidden_states, v2a_attn_hidden_states, v2a_gate
             )
         # 4. Feedforward
         vshift_mlp, vscale_mlp, vgate_mlp = self.get_ada_values(
             self.scale_shift_table, batch_size, temb, slice(3, 6)
         )
-        norm_hidden_states = (
-            rms_norm(hidden_states, self.norm_eps) * (1 + vscale_mlp) + vshift_mlp
+        norm_hidden_states = _ltx2_norm_scale_shift(
+            hidden_states, vshift_mlp, vscale_mlp, self.norm_eps
         )
         ff_output = self.ff(norm_hidden_states)
-        hidden_states = hidden_states + ff_output * vgate_mlp
+        hidden_states = _ltx2_residual_add(hidden_states, ff_output, vgate_mlp)
 
         ashift_mlp, ascale_mlp, agate_mlp = self.get_ada_values(
             self.audio_scale_shift_table, batch_size, temb_audio, slice(3, 6)
         )
-        norm_audio_hidden_states = (
-            rms_norm(audio_hidden_states, self.norm_eps) * (1 + ascale_mlp) + ashift_mlp
+        norm_audio_hidden_states = _ltx2_norm_scale_shift(
+            audio_hidden_states, ashift_mlp, ascale_mlp, self.norm_eps
         )
         audio_ff_output = self.audio_ff(norm_audio_hidden_states)
-        audio_hidden_states = audio_hidden_states + audio_ff_output * agate_mlp
+        audio_hidden_states = _ltx2_residual_add(
+            audio_hidden_states, audio_ff_output, agate_mlp
+        )
         return hidden_states, audio_hidden_states
 
 

--- a/python/sglang/multimodal_gen/runtime/pipelines/ltx_2_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/ltx_2_pipeline.py
@@ -312,6 +312,14 @@ class LTX2TwoStagePipeline(_BaseLTX2Pipeline):
         self._stage1_lora_scale = float(server_args.lora_scale)
         self._active_lora_phase = None
 
+        if server_args.enable_torch_compile:
+            self._initialize_lora_state(server_args)
+            logger.info(
+                "Pre-converting LTX-2 two-stage transformer to LoRA layers before "
+                "torch.compile warmup"
+            )
+            self.convert_to_lora_layers()
+
     def switch_lora_phase(self, phase: str) -> None:
         if phase == self._active_lora_phase:
             return

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/lora_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/lora_pipeline.py
@@ -69,7 +69,27 @@ class LoRAPipeline(ComposedPipelineBase):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        # Initialize all mutable instance attributes to avoid sharing across instances
+        self._initialize_lora_state(self.server_args)
+
+        if self.lora_path is not None:
+            self.convert_to_lora_layers()
+            self.set_lora(
+                self.lora_nickname,
+                self.lora_path,
+                strength=self.server_args.lora_scale,  # type: ignore[union-attr]
+            )  # type: ignore[arg-type]
+
+    def _initialize_lora_state(self, server_args: ServerArgs | None = None) -> None:
+        if getattr(self, "_lora_state_initialized", False):
+            if server_args is not None:
+                self.exclude_lora_layers = (
+                    server_args.pipeline_config.dit_config.arch_config.exclude_lora_layers
+                )
+                self.lora_target_modules = server_args.lora_target_modules
+                self.lora_path = server_args.lora_path
+                self.lora_nickname = server_args.lora_nickname
+            return
+
         self.lora_adapters = defaultdict(dict)
         self.loaded_adapter_paths = {}
         self.cur_adapter_name = {}
@@ -87,19 +107,19 @@ class LoRAPipeline(ComposedPipelineBase):
         self.lora_path = None
         self.lora_nickname = "default"
 
-        # Initialize from server_args
         self.device = get_local_torch_device()
-        self.exclude_lora_layers = (
-            self.server_args.pipeline_config.dit_config.arch_config.exclude_lora_layers
-        )
-        self.lora_target_modules = self.server_args.lora_target_modules
-        self.lora_path = self.server_args.lora_path
-        self.lora_nickname = self.server_args.lora_nickname
-        if self.lora_path is not None:
-            self.convert_to_lora_layers()
-            self.set_lora(
-                self.lora_nickname, self.lora_path, strength=self.server_args.lora_scale  # type: ignore
-            )  # type: ignore
+        if server_args is not None:
+            self.exclude_lora_layers = (
+                server_args.pipeline_config.dit_config.arch_config.exclude_lora_layers
+            )
+            self.lora_target_modules = server_args.lora_target_modules
+            self.lora_path = server_args.lora_path
+            self.lora_nickname = server_args.lora_nickname
+        else:
+            self.exclude_lora_layers = []
+            self.lora_target_modules = None
+
+        self._lora_state_initialized = True
 
     def is_target_layer(self, module_name: str) -> bool:
         if self.lora_target_modules is None:

--- a/python/sglang/multimodal_gen/runtime/utils/common.py
+++ b/python/sglang/multimodal_gen/runtime/utils/common.py
@@ -18,6 +18,26 @@ import zmq
 logger = logging.getLogger(__name__)
 
 
+def is_torch_compiling() -> bool:
+    try:
+        compiler = getattr(torch, "compiler", None)
+        if compiler is not None:
+            is_compiling = getattr(compiler, "is_compiling", None)
+            if is_compiling is not None and bool(is_compiling()):
+                return True
+            is_dynamo_compiling = getattr(compiler, "is_dynamo_compiling", None)
+            if is_dynamo_compiling is not None and bool(is_dynamo_compiling()):
+                return True
+
+        dynamo = getattr(torch, "_dynamo", None)
+        is_compiling = getattr(dynamo, "is_compiling", None)
+        if is_compiling is not None and bool(is_compiling()):
+            return True
+    except Exception:
+        return False
+    return False
+
+
 def kill_process_tree(parent_pid, include_parent: bool = True, skip_pid: int = None):
     """Kill the process and all its child processes."""
     # Remove sigchld handler to avoid spammy logs.


### PR DESCRIPTION
## Summary

- fuse LTX2 per-block RMSNorm + scale/shift modulation with the existing CuTeDSL fused norm kernel
- fuse LTX2 residual + gate and standalone scale/shift modulation with the existing Triton scale-shift kernel
- make the LTX-2.3 one-stage and two-stage benchmark presets explicitly include `--warmup` and avoid duplicate warmup flags

## Benchmark

Workload: `Lightricks/LTX-2.3` one-stage T2V, 768x512, 121 frames, 24 fps, 30 steps, guidance scale 3.0, seed 1234, 2x H100, native `LTX2Pipeline`, `--warmup`, no `torch.compile`.

Command shape:

```bash
CUDA_VISIBLE_DEVICES=0,1 PYTHONPATH=python FLASHINFER_DISABLE_VERSION_CHECK=1 \
sglang generate \
  --model-path Lightricks/LTX-2.3 \
  --prompt "A beautiful sunset over the ocean" \
  --negative-prompt "shaky, glitchy, low quality, worst quality, deformed, distorted, disfigured, motion smear, motion artifacts, fused fingers, bad anatomy, weird hand, ugly, transition, static." \
  --seed 1234 \
  --width=768 --height=512 \
  --num-frames=121 --fps=24 \
  --num-inference-steps=30 --guidance-scale=3.0 \
  --num-gpus=2 --warmup \
  --output-file-path <out.mp4> \
  --perf-dump-path <perf.json>
```

| Metric | Baseline `origin/main` | This PR | Speedup |
| --- | ---: | ---: | ---: |
| End-to-end, warmup excluded | 37.684 s | 34.728 s | 7.84% |
| `LTX2AVDenoisingStage` | 33.921 s | 31.270 s | 7.81% |
| `LTX2AVDecodingStage` | 1.836 s | 1.507 s | 17.94% |
| `TextEncodingStage` | 1.758 s | 1.777 s | -1.05% |
| First denoise step | 1.124 s | 1.034 s | 8.03% |
| Median following denoise step | 1.131 s | 1.042 s | 7.83% |

Perf artifacts on the validation host:

- baseline: `/tmp/sglang_ltx2_fused_pr_bench_20260417_033638/baseline_origin_main.perf.json`
- this PR: `/tmp/sglang_ltx2_fused_pr_bench_20260417_033638/fused_pr.perf.json`

## Correctness / Validation

- `python3 -m py_compile python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py python/sglang/multimodal_gen/.claude/skills/sglang-diffusion-benchmark-profile/scripts/bench_diffusion_denoise.py`
- GPU helper smoke on H100 for hidden sizes 2048 and 4096:
  - `_ltx2_scale_shift`: max abs diff <= 0.03125 vs PyTorch BF16 expression
  - `_ltx2_norm_scale_shift`: max abs diff <= 0.03125 vs PyTorch BF16 expression
  - `_ltx2_norm`: max abs diff = 0.0 vs PyTorch BF16 RMSNorm
  - `_ltx2_residual_add`: max abs diff <= 0.015625 vs PyTorch BF16 expression
- Full LTX-2.3 one-stage generation completed before and after this PR with matching output metadata: 768x512, 24 fps, 121 frames, 5.041667 s.

Generated videos were copied locally for manual visual review:

main:

https://github.com/user-attachments/assets/9ca5fa99-0941-46e8-8dc9-fcb07d1f18ea

pr:

https://github.com/user-attachments/assets/6e1d6af3-a408-4c00-9d5c-f5bc3b0812e8



## Additional Benchmark: LTX2 Two-stage LoRA Pre-convert

Root cause: with `--enable-torch-compile --warmup`, `LTX2TwoStagePipeline` constructed and compiled the denoising stage before the transformer had LoRA wrapper modules. The warmup request compiled the base graph, then the two-stage LoRA switch wrapped/activated LoRA later, so the first real stage-1 denoise step paid a large Dynamo recompile. This PR pre-converts the two-stage transformer to disabled LoRA wrapper layers before stage construction when torch compile is enabled.

Workloads: native SGLang backend on H100, prompt/negative prompt/seed matching the preset runner, `--warmup --enable-torch-compile`.

| Workload | Metric | Before LoRA pre-convert | After LoRA pre-convert | Delta |
| --- | --- | ---: | ---: | ---: |
| `ltx23-two-stage` (`Lightricks/LTX-2.3`, 2x H100, 1536x1024, 121 frames, 30 steps) | End-to-end, warmup excluded | 71.895 s | 47.265 s | -34.3% |
| `ltx23-two-stage` | Denoise + refinement | 52.597 s | 33.288 s | -36.7% |
| `ltx23-two-stage` | First denoise step | 21.090 s | 1.801 s | -91.5% |
| `ltx23-two-stage` | Median following denoise step | 0.962 s | 0.961 s | -0.1% |
| `ltx2` (`Lightricks/LTX-2`, 1x H100, 1536x1024, 121 frames, 40 steps) | End-to-end, warmup excluded | 57.883 s | 46.911 s | -19.0% |
| `ltx2` | Denoise + refinement | 49.634 s | 38.709 s | -22.0% |
| `ltx2` | First denoise step | 11.154 s | 1.300 s | -88.3% |
| `ltx2` | Median following denoise step | 0.781 s | 0.780 s | -0.1% |

Perf artifacts on the validation host:

- `ltx23-two-stage` before: `/tmp/ltx_low_hanging/ltx23-two-stage_pr_lowfruit.json`
- `ltx23-two-stage` after: `/tmp/ltx_low_hanging_preconvert_rerun/ltx23-two-stage_preconvert_rerun.json`
- `ltx2` before: `/tmp/ltx_low_hanging/ltx2_pr_lowfruit.json`
- `ltx2` after: `/tmp/ltx_low_hanging_preconvert_rerun/ltx2_preconvert_rerun.json`

Additional validation:

- `python3 -m black ...`, `python3 -m isort ...`, `python3 -m py_compile ...`, and `python3 -m ruff check --select=F401,F821 ...` on the edited files.
- Full `ltx23-two-stage` and `ltx2` preset runs completed on the native SGLang pipeline with warmup enabled; no diffusers fallback.
