### PR TITLE
add MNNVL support for nixl backend

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -163,7 +163,6 @@ class Envs:
     SGLANG_USE_MODELSCOPE = EnvBool(False)
     SGLANG_SORT_WEIGHT_FILES = EnvBool(False)
     SGLANG_DISABLED_MODEL_ARCHS = EnvTuple(tuple())
-    SGLANG_PREFETCH_BLOCK_SIZE_MB = EnvInt(16)
 
     # Logging Options
     SGLANG_LOG_GC = EnvBool(False)
@@ -244,7 +243,6 @@ class Envs:
     SGLANG_DISAGGREGATION_WAITING_TIMEOUT = EnvInt(300)
     SGLANG_DISAGGREGATION_NIXL_BACKEND = EnvStr("UCX")
     SGLANG_DISAGGREGATION_ALL_CP_RANKS_TRANSFER = EnvBool(False)
-    SGLANG_DISAGGREGATION_FORCE_QUERY_PREFILL_DP_RANK = EnvBool(False)
     # Extra slots in req_to_token_pool for decode workers (only effective when
     # max_num_reqs > 32). Increases pool capacity so more KV cache transfers
     # can overlap with decode execution without raising max_running_requests.
@@ -296,6 +294,9 @@ class Envs:
     SGLANG_STAGING_USE_TORCH = EnvBool(False)
     # Mooncake KV Transfer
     SGLANG_MOONCAKE_CUSTOM_MEM_POOL = EnvStr(None)
+    # Standalone CUDA VMM allocator for MNNVL-compatible KV cache allocation.
+    # Set to 1/true to enable. Use with NIXL backend + UCX_CUDA_IPC_ENABLE_MNNVL=yes.
+    SGLANG_NIXL_VMM_MEM_POOL = EnvBool(False)
     ENABLE_ASCEND_TRANSFER_WITH_MOONCAKE = EnvBool(False)
     ASCEND_NPU_PHY_ID = EnvInt(-1)
     SGLANG_MOONCAKE_SEND_AUX_TCP = EnvBool(False)
@@ -316,10 +317,8 @@ class Envs:
 
     # AMD & ROCm
     SGLANG_USE_AITER = EnvBool(False)
-    SGLANG_USE_AITER_UNIFIED_ATTN = EnvBool(False)
     SGLANG_ROCM_FUSED_DECODE_MLA = EnvBool(False)
     SGLANG_ROCM_DISABLE_LINEARQUANT = EnvBool(False)
-    SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK = EnvInt(4096)
 
     # MPS (Apple Silicon)
     SGLANG_USE_MLX = EnvBool(False)
@@ -470,7 +469,7 @@ class Envs:
     # VLM Item CUDA IPC Transport
     SGLANG_USE_CUDA_IPC_TRANSPORT = EnvBool(False)
     SGLANG_USE_IPC_POOL_HANDLE_CACHE = EnvBool(False)
-    SGLANG_MM_FEATURE_CACHE_MB = EnvInt(1 * 1024)
+    SGLANG_MM_FEATURE_CACHE_MB = EnvInt(4 * 1024)
     SGLANG_MM_ITEM_MEM_POOL_RECYCLE_INTERVAL_SEC = EnvFloat(0.05)
 
     # Mamba

--- a/python/sglang/srt/mem_cache/nixl_vmm_allocator.py
+++ b/python/sglang/srt/mem_cache/nixl_vmm_allocator.py
@@ -1,0 +1,245 @@
+# Copyright 2025 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""
+Standalone CUDA VMM (Virtual Memory Management) allocator for MNNVL-compatible
+KV cache allocation.
+
+Uses cuMemCreate with CU_MEM_HANDLE_TYPE_FABRIC so the allocated pages are
+addressable over the NVLink fabric (MNNVL), enabling zero-copy KV cache
+transfers between nodes via UCX or other MNNVL-aware transports.
+
+Activated by setting: SGLANG_NIXL_VMM_MEM_POOL=1
+"""
+
+import logging
+import os
+import tempfile
+from typing import Optional, Tuple
+
+import torch
+from torch.cuda.memory import CUDAPluggableAllocator
+
+logger = logging.getLogger(__name__)
+
+# C++ source for the VMM allocator compiled at first use via
+# torch.utils.cpp_extension.load_inline.
+_VMM_ALLOCATOR_SOURCE = r"""
+#include <cuda.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+extern "C" {
+
+/* 128 matches the maximum number of CUDA devices supported per system
+ * (CUDA driver limit; also covers NVL72's 72-GPU configuration). */
+#define VMM_MAX_DEVICES 128
+
+static size_t g_granularity[VMM_MAX_DEVICES];
+static int    g_initialized[VMM_MAX_DEVICES];
+
+/*
+ * Query and cache the allocation granularity for a device.
+ * Tries CU_MEM_HANDLE_TYPE_FABRIC first (required for MNNVL / NVLink fabric),
+ * falls back to CU_MEM_HANDLE_TYPE_NONE if FABRIC is not supported.
+ */
+static size_t vmm_get_granularity(int device) {
+    if (device < 0 || device >= VMM_MAX_DEVICES) {
+        return 2UL * 1024 * 1024;  /* safe fallback for out-of-range device */
+    }
+    if (!g_initialized[device]) {
+        CUmemAllocationProp prop;
+        memset(&prop, 0, sizeof(prop));
+        prop.type                   = CU_MEM_ALLOCATION_TYPE_PINNED;
+        prop.location.type          = CU_MEM_LOCATION_TYPE_DEVICE;
+        prop.location.id            = device;
+        prop.requestedHandleTypes   = CU_MEM_HANDLE_TYPE_FABRIC;
+
+        size_t gran = 0;
+        CUresult r = cuMemGetAllocationGranularity(
+            &gran, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM);
+
+        if (r != CUDA_SUCCESS || gran == 0) {
+            /* FABRIC not supported — fall back to no handle type */
+            prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_NONE;
+            r = cuMemGetAllocationGranularity(
+                &gran, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM);
+        }
+
+        g_granularity[device] = (r == CUDA_SUCCESS && gran > 0)
+                                 ? gran
+                                 : (2UL * 1024 * 1024);  /* 2 MB fallback */
+        g_initialized[device] = 1;
+    }
+    return g_granularity[device];
+}
+
+static size_t vmm_align_up(size_t size, size_t gran) {
+    return ((size + gran - 1) / gran) * gran;
+}
+
+/*
+ * Allocate size bytes of VMM-backed GPU memory on device.
+ * Physical pages are created with CU_MEM_HANDLE_TYPE_FABRIC when the
+ * platform supports it, making them accessible via the NVLink fabric.
+ */
+void* nixl_vmm_alloc(size_t size, int device, void* stream) {
+    CUresult r;
+    size_t gran       = vmm_get_granularity(device);
+    size_t alloc_size = vmm_align_up(size, gran);
+
+    /* 1. Reserve virtual address space */
+    CUdeviceptr ptr = 0;
+    r = cuMemAddressReserve(&ptr, alloc_size, gran, 0, 0);
+    if (r != CUDA_SUCCESS) {
+        fprintf(stderr, "[nixl_vmm] cuMemAddressReserve failed: %d (size=%zu)\n",
+                r, alloc_size);
+        return NULL;
+    }
+
+    /* 2. Create physical allocation — prefer FABRIC handle for MNNVL */
+    CUmemAllocationProp prop;
+    memset(&prop, 0, sizeof(prop));
+    prop.type                 = CU_MEM_ALLOCATION_TYPE_PINNED;
+    prop.location.type        = CU_MEM_LOCATION_TYPE_DEVICE;
+    prop.location.id          = device;
+    prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
+
+    CUmemGenericAllocationHandle handle;
+    r = cuMemCreate(&handle, alloc_size, &prop, 0);
+    if (r != CUDA_SUCCESS) {
+        /* FABRIC not available — fall back */
+        prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_NONE;
+        r = cuMemCreate(&handle, alloc_size, &prop, 0);
+        if (r != CUDA_SUCCESS) {
+            fprintf(stderr, "[nixl_vmm] cuMemCreate failed: %d\n", r);
+            cuMemAddressFree(ptr, alloc_size);
+            return NULL;
+        }
+    }
+
+    /* 3. Map physical pages into the reserved VA range */
+    r = cuMemMap(ptr, alloc_size, 0, handle, 0);
+    if (r != CUDA_SUCCESS) {
+        fprintf(stderr, "[nixl_vmm] cuMemMap failed: %d\n", r);
+        cuMemRelease(handle);        /* no mapping holds pages; release frees them */
+        cuMemAddressFree(ptr, alloc_size);
+        return NULL;
+    }
+    /* Mapping is live; drop handle ref-count (mapping keeps pages alive) */
+    cuMemRelease(handle);
+
+    /* 4. Grant read-write access to the owning device */
+    CUmemAccessDesc access;
+    memset(&access, 0, sizeof(access));
+    access.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+    access.location.id   = device;
+    access.flags         = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+    r = cuMemSetAccess(ptr, alloc_size, &access, 1);
+    if (r != CUDA_SUCCESS) {
+        fprintf(stderr, "[nixl_vmm] cuMemSetAccess failed: %d\n", r);
+        cuMemUnmap(ptr, alloc_size);
+        cuMemAddressFree(ptr, alloc_size);
+        return NULL;
+    }
+
+    return (void*)ptr;
+}
+
+/*
+ * Free a VMM allocation.  size must be the same value passed to nixl_vmm_alloc
+ * (torch.cuda.MemPool guarantees this).
+ */
+void nixl_vmm_free(void* ptr, size_t size, int device, void* stream) {
+    if (!ptr) return;
+    CUdeviceptr cu_ptr = (CUdeviceptr)ptr;
+    size_t gran        = vmm_get_granularity(device);
+    size_t alloc_size  = vmm_align_up(size, gran);
+    cuMemUnmap(cu_ptr, alloc_size);
+    cuMemAddressFree(cu_ptr, alloc_size);
+}
+
+} /* extern "C" */
+"""
+
+_vmm_allocator = None
+_vmm_mem_pool: Optional[torch.cuda.MemPool] = None
+
+
+def init_nixl_vmm_mem_pool(device: str) -> Tuple[bool, Optional[torch.cuda.MemPool]]:
+    """
+    Compile (once) and return a torch.cuda.MemPool backed by a CUDA VMM
+    (cuMemCreate) allocator.
+
+    The pool allocates pages with CU_MEM_HANDLE_TYPE_FABRIC when supported,
+    making them addressable over the NVLink fabric for MNNVL transfers.
+
+    Args:
+        device: CUDA device string, e.g. "cuda:0"  (used for logging only;
+                the C allocator receives the device index from PyTorch).
+
+    Returns:
+        (True, mem_pool) on success, (False, None) on failure.
+    """
+    global _vmm_allocator, _vmm_mem_pool
+
+    if _vmm_mem_pool is not None:
+        return True, _vmm_mem_pool
+
+    try:
+        import torch.utils.cpp_extension
+
+        out_dir = os.path.join(tempfile.gettempdir(), "nixl_vmm_allocator")
+        os.makedirs(out_dir, exist_ok=True)
+
+        # Remove stale lock file left by a previously crashed compilation so
+        # the next startup does not hang waiting on a lock that will never clear.
+        try:
+            os.remove(os.path.join(out_dir, "lock"))
+        except FileNotFoundError:
+            pass
+        if torch.distributed.is_available() and torch.distributed.is_initialized():
+            torch.distributed.barrier()
+
+        lib_name = "nixl_vmm_allocator"
+        torch.utils.cpp_extension.load_inline(
+            name=lib_name,
+            cpp_sources=_VMM_ALLOCATOR_SOURCE,
+            with_cuda=True,          # adds CUDA include paths automatically
+            extra_ldflags=["-lcuda"],  # link against CUDA driver library
+            verbose=False,
+            is_python_module=False,
+            build_directory=out_dir,
+        )
+
+        so_path = os.path.join(out_dir, f"{lib_name}.so")
+        _vmm_allocator = CUDAPluggableAllocator(
+            so_path, "nixl_vmm_alloc", "nixl_vmm_free"
+        ).allocator()
+        _vmm_mem_pool = torch.cuda.MemPool(_vmm_allocator)
+        logger.info(
+            "Initialized NIXL VMM memory pool on %s "
+            "(cuMemCreate + CU_MEM_HANDLE_TYPE_FABRIC, MNNVL-compatible)",
+            device,
+        )
+        return True, _vmm_mem_pool
+
+    except Exception as e:
+        logger.warning(
+            "Failed to initialize NIXL VMM memory pool on %s: %s. "
+            "Falling back to cudaMalloc.",
+            device,
+            e,
+        )
+        return False, None

--- a/python/sglang/srt/mem_cache/utils.py
+++ b/python/sglang/srt/mem_cache/utils.py
@@ -337,12 +337,20 @@ def maybe_init_custom_mem_pool(
     Returns:
         Tuple of (enable_custom_mem_pool, custom_mem_pool, custom_mem_pool_type)
     """
+    # NIXL VMM allocator: MNNVL-compatible KV cache allocation.
+    # Use with NIXL backend + UCX_CUDA_IPC_ENABLE_MNNVL=yes.
+    if envs.SGLANG_NIXL_VMM_MEM_POOL.get():
+        from sglang.srt.mem_cache.nixl_vmm_allocator import init_nixl_vmm_mem_pool
+
+        success, pool = init_nixl_vmm_mem_pool(device)
+        return success, pool, "NVLINK_VMM" if success else None
+
+    # Currently, only mooncake requires a custom mem pool for MNNVL/Barex PD disaggregation
     enable_custom_mem_pool = (
         True if envs.SGLANG_MOONCAKE_CUSTOM_MEM_POOL.get() is not None else False
     )
 
     if enable_custom_mem_pool:
-        # Currently, only mooncake requires a custom mem pool for MNNVL/Barex PD disaggregation
         from sglang.srt.disaggregation.mooncake.utils import (
             init_mooncake_custom_mem_pool,
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Add VMM allocator for NIXL. KVCache transfer can use NVLink in MNNVL.

## Modifications
export SGLANG_NIXL_VMM_MEM_POOL=yes
export UCX_CUDA_IPC_ENABLE_MNNVL=yes

python/sglang/srt/mem_cache/nixl_vmm_allocator.py
python/sglang/srt/environ.py
python/sglang/srt/mem_cache/utils.py

## Accuracy Tests
enable MNNVL in sglang and UCX for NIXL
export SGLANG_NIXL_VMM_MEM_POOL=yes
export UCX_CUDA_IPC_ENABLE_MNNVL=yes

1. start prefill and decode worker on 2 GB200 nodes. each work run on 1 GPU
2. do benchmark to the server
3. watch GPU0 nvlink activity. see KVCache sent over nvlink.
 Link 0: Data Tx: 0 KiB
         Link 0: Data Rx: 16004678 KiB
         Link 1: Data Tx: 0 KiB
         Link 1: Data Rx: 16004678 KiB
         Link 2: Data Tx: 0 KiB
         Link 2: Data Rx: 15996107 KiB
         Link 3: Data Tx: 0 KiB
         Link 3: Data Rx: 15996107 KiB
         Link 4: Data Tx: 0 KiB
         Link 4: Data Rx: 16015630 KiB
         Link 5: Data Tx: 0 KiB
         Link 5: Data Rx: 16015630 KiB
         Link 6: Data Tx: 0 KiB
         Link 6: Data Rx: 15997285 KiB
         Link 7: Data Tx: 0 KiB
         Link 7: Data Rx: 15997285 KiB
         Link 8: Data Tx: 0 KiB
         Link 8: Data Rx: 16016497 KiB
         Link 9: Data Tx: 0 KiB
         Link 9: Data Rx: 16016497 KiB
         Link 10: Data Tx: 0 KiB
         Link 10: Data Rx: 16005994 KiB
         Link 11: Data Tx: 0 KiB
         Link 11: Data Rx: 16005994 KiB
         Link 12: Data Tx: 0 KiB
         Link 12: Data Rx: 16016482 KiB
         Link 13: Data Tx: 0 KiB
         Link 13: Data Rx: 16016482 KiB
         Link 14: Data Tx: 0 KiB
         Link 14: Data Rx: 16005836 KiB
         Link 15: Data Tx: 0 KiB
         Link 15: Data Rx: 16005836 KiB
         Link 16: Data Tx: 0 KiB
         Link 16: Data Rx: 15996785 KiB
         Link 17: Data Tx: 0 KiB
         Link 17: Data Rx: 15996785 KiB


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
5. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
6. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
7. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
