### PR TITLE
feat(hip): add optional external LLMM1 fast path

### DIFF
--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import TYPE_CHECKING, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -50,6 +51,16 @@ _is_hip = is_hip()
 _is_cpu = is_cpu()
 _is_npu = is_npu()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
+_hip_external_llmm1_enabled = (
+    get_bool_env_var("SGLANG_HIP_EXTERNAL_LLMM1") and _is_hip
+)
+_hip_external_llmm1_rows_per_block = int(
+    os.getenv("SGLANG_HIP_EXTERNAL_LLMM1_ROWS_PER_BLOCK", "2")
+)
+_hip_external_llmm1_so_path = os.getenv("SGLANG_HIP_EXTERNAL_LLMM1_SO_PATH")
+_hip_external_llmm1_op = None
+_hip_external_llmm1_load_attempted = False
+_hip_external_llmm1_logged_shapes = set()
 
 if _use_aiter:
     from aiter import ActivationType
@@ -65,6 +76,70 @@ try:
     from flashinfer.fused_moe.core import ActivationType
 except ImportError:
     flashinfer_cutlass_fused_moe = None
+
+
+def _get_hip_external_llmm1_op():
+    global _hip_external_llmm1_enabled
+    global _hip_external_llmm1_load_attempted
+    global _hip_external_llmm1_op
+
+    if not _hip_external_llmm1_enabled:
+        return None
+    if _hip_external_llmm1_op is not None:
+        return _hip_external_llmm1_op
+    if _hip_external_llmm1_load_attempted:
+        return None
+
+    _hip_external_llmm1_load_attempted = True
+    try:
+        if not _hip_external_llmm1_so_path:
+            raise RuntimeError("SGLANG_HIP_EXTERNAL_LLMM1_SO_PATH is not set")
+        torch.ops.load_library(_hip_external_llmm1_so_path)
+        _hip_external_llmm1_op = torch.ops._rocm_C.LLMM1
+        logger.info(
+            "Enabled HIP external LLMM1 fast path with rows_per_block=%d",
+            _hip_external_llmm1_rows_per_block,
+        )
+        return _hip_external_llmm1_op
+    except Exception as e:
+        logger.warning("Disabled HIP external LLMM1 fast path: %s", e)
+        _hip_external_llmm1_enabled = False
+        return None
+
+
+def _maybe_apply_hip_external_llmm1(
+    layer: torch.nn.Module,
+    x: torch.Tensor,
+    bias: Optional[torch.Tensor],
+) -> Optional[torch.Tensor]:
+    llmm1_op = _get_hip_external_llmm1_op()
+    if (
+        llmm1_op is None
+        or bias is not None
+        or x.device.type != "cuda"
+        or x.dtype not in (torch.float16, torch.bfloat16)
+        or type(layer.weight.data) is not torch.Tensor
+    ):
+        return None
+
+    x_view = x.reshape(-1, x.shape[-1])
+    n = x_view.shape[0]
+    m = layer.weight.shape[0]
+    k = layer.weight.shape[1]
+    if n != 1 or m % 4 != 0 or k > 8192:
+        return None
+
+    key = (n, m, k, str(x.dtype))
+    if key not in _hip_external_llmm1_logged_shapes:
+        logger.info(
+            "Routing shape=%s through HIP external LLMM1 fast path with rows_per_block=%d",
+            key,
+            _hip_external_llmm1_rows_per_block,
+        )
+        _hip_external_llmm1_logged_shapes.add(key)
+
+    out = llmm1_op(layer.weight, x_view, _hip_external_llmm1_rows_per_block)
+    return out.reshape(*x.shape[:-1], layer.weight.shape[0])
 
 
 class UnquantizedEmbeddingMethod(QuantizeMethodBase):
@@ -154,7 +229,11 @@ class UnquantizedLinearMethod(LinearMethodBase):
                 output = output.view(x_shapes[0], x_shapes[1], -1)
             return output
 
-        elif _use_aiter and type(layer.weight.data) is torch.Tensor:
+        out = _maybe_apply_hip_external_llmm1(layer, x, bias)
+        if out is not None:
+            return out
+
+        if _use_aiter and type(layer.weight.data) is torch.Tensor:
             return tgemm.mm(x, layer.weight, bias, otype=x.dtype)
 
         return F.linear(x, layer.weight, bias)

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -51,9 +51,7 @@ _is_hip = is_hip()
 _is_cpu = is_cpu()
 _is_npu = is_npu()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
-_hip_external_llmm1_enabled = (
-    get_bool_env_var("SGLANG_HIP_EXTERNAL_LLMM1") and _is_hip
-)
+_hip_external_llmm1_enabled = get_bool_env_var("SGLANG_HIP_EXTERNAL_LLMM1") and _is_hip
 _hip_external_llmm1_rows_per_block = int(
     os.getenv("SGLANG_HIP_EXTERNAL_LLMM1_ROWS_PER_BLOCK", "2")
 )

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -127,7 +127,7 @@ def _maybe_apply_hip_external_llmm1(
     if n != 1 or m % 4 != 0 or k > 8192:
         return None
 
-    key = (n, m, k, str(x.dtype))
+    key = (n, m, k, x.dtype)
     if key not in _hip_external_llmm1_logged_shapes:
         logger.info(
             "Routing shape=%s through HIP external LLMM1 fast path with rows_per_block=%d",


### PR DESCRIPTION
Related to #23058

# Draft PR Title

Add an optional HIP `LLMM1` fast path for `UnquantizedLinearMethod` decode shapes

## Summary

This PR adds an experimental, env-gated HIP fast path to `UnquantizedLinearMethod.apply()` for the narrow decode shapes that dominate `M=1` generation on Qwen3-30B-A3B-style workloads.

The fast path is:

- HIP-only
- lazy-loaded
- disabled by default
- safe to fall back from

It only activates when all of the following are true:

- `SGLANG_HIP_EXTERNAL_LLMM1=1`
- the external shared library path is provided
- `bias is None`
- input dtype is `fp16` or `bf16`
- input device is CUDA/HIP
- `n == 1`
- `m % 4 == 0`
- `k <= 8192`

Otherwise the code stays on the existing path.

## Motivation

On `gfx1151` ROCm, the remaining decode gap was not in the attention kernel path. Profiling and A/B experiments showed that the dominant remaining gap for `p1/g64` was the small-batch dense GEMM path.

The experimental `LLMM1` route was then validated in service-level runs:

- upstream-clean baseline (`r156`, `32768 + bf16 KV`):
  - `p220/g1 repeat = 1059.31 tok/s`
  - `p1/g64 repeat = 13.3591 tok/s`
- lazy-loaded source route (`r186`, same serving shape class):
  - `p220/g1 repeat = 1061.07 tok/s`
  - `p1/g64 repeat = 20.9811 tok/s`

That is:

- prefill: essentially unchanged
- decode: about `+57%`

The same route was also validated on a larger-capacity profile (`131072 + fp8 KV`) and still held decode around `20.36 tok/s`.

## What This PR Does

- adds a HIP-only helper to lazily load an external op
- routes only eligible `M=1` skinny-GEMM shapes into that op
- keeps all existing paths intact when the op is unavailable or the shape is not eligible
- logs the first enablement and the first seen eligible shapes

## What This PR Does Not Do

- no attention backend changes
- no MoE config changes
- no TunableOp changes
- no graph/scheduler changes
- no additional platform behavior outside this narrow HIP path

## Why It Is Safe

- disabled by default
- one-way fallback: failed load disables the path and continues on the baseline implementation
- shape-gated: does not affect larger GEMM shapes
- bias-gated: never overrides the bias path

## Proposed Env Contract

- `SGLANG_HIP_EXTERNAL_LLMM1=1`
- `SGLANG_HIP_EXTERNAL_LLMM1_ROWS_PER_BLOCK=2`
- `SGLANG_HIP_EXTERNAL_LLMM1_SO_PATH=/path/to/external_op.so`

## Testing

Suggested test coverage before merge:

1. unit: env disabled -> baseline path
2. unit: env enabled but `.so` missing -> baseline path after one failed load
3. unit: `bias is not None` -> baseline path
4. unit: non-HIP device -> baseline path
5. unit: ineligible shapes (`n != 1`, `k > 8192`, `m % 4 != 0`) -> baseline path
6. integration: eligible HIP shape calls the external op once loaded
7. integration: repeated eligible shapes do not spam logs

## Open Question For Maintainers

The one structural question is dependency policy.

This PR assumes SGLang is willing to expose an optional external HIP op hook and bind:

- `torch.ops._rocm_C.LLMM1`

If that is not an acceptable dependency boundary, then this patch should be treated as an RFC first and either:

- moved behind a more generic external-op interface, or
- replaced later by a SGLang-owned kernel/build path
