### PR TITLE
Fix: forward continue_final_message kwargs in Glm45Detector

### DIFF
--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -314,13 +314,21 @@ class Glm45Detector(BaseReasoningFormatDetector):
             If True, streams reasoning content as it arrives.
     """
 
-    def __init__(self, stream_reasoning: bool = True, force_reasoning: bool = False):
+    def __init__(
+        self,
+        stream_reasoning: bool = True,
+        force_reasoning: bool = False,
+        continue_final_message: bool = False,
+        previous_content: str = "",
+    ):
         super().__init__(
             "<think>",
             "</think>",
             force_reasoning=force_reasoning,
             stream_reasoning=stream_reasoning,
             tool_start_token="<tool_call>",
+            continue_final_message=continue_final_message,
+            previous_content=previous_content,
         )
 
 

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -518,6 +518,39 @@ class TestGlm45Detector(CustomTestCase):
         self.assertEqual(result.reasoning_text, "More reasoning")
         self.assertEqual(result.normal_text, "<tool_call>tool call")
 
+    def test_continue_final_message_accepts_kwargs(self):
+        """Regression: Glm45Detector must accept continue_final_message and
+        previous_content kwargs (forwarded by ReasoningParser when the request
+        sets continue_final_message=True with a trailing assistant message)."""
+        detector = Glm45Detector(
+            continue_final_message=True,
+            previous_content="<think>prior reasoning</think>prior answer",
+        )
+        self.assertTrue(detector.continue_final_message)
+        self.assertEqual(
+            detector.previous_content, "<think>prior reasoning</think>prior answer"
+        )
+
+    def test_continue_final_message_think_start_in_previous(self):
+        """previous_content ending mid-reasoning should start in reasoning mode."""
+        detector = Glm45Detector(
+            continue_final_message=True,
+            previous_content="<think>unfinished thought",
+        )
+        self.assertTrue(detector._in_reasoning)
+
+    def test_continue_final_message_think_end_in_previous(self):
+        """previous_content with closed </think> should not start in reasoning mode,
+        and continuation text should be parsed as normal_text."""
+        detector = Glm45Detector(
+            continue_final_message=True,
+            previous_content="<think>done</think>prior answer",
+        )
+        self.assertFalse(detector._in_reasoning)
+        result = detector.detect_and_parse("continuation text")
+        self.assertEqual(result.normal_text, "continuation text")
+        self.assertEqual(result.reasoning_text, "")
+
 
 class TestNemotron3Detector(CustomTestCase):
     def setUp(self):
@@ -1247,6 +1280,30 @@ class TestReasoningParserAdvanced(CustomTestCase):
         )
         parser = ReasoningParser("qwen3", request=request)
         self.assertTrue(parser.detector.continue_final_message)
+
+    def test_continue_final_message_with_request_glm45(self):
+        """Regression: building a ReasoningParser for glm45 with a request that
+        sets continue_final_message=True must not raise. Previously raised
+        TypeError because Glm45Detector.__init__ did not accept the
+        continue_final_message / previous_content kwargs."""
+        from sglang.srt.entrypoints.openai.protocol import (
+            ChatCompletionMessageGenericParam,
+            ChatCompletionMessageUserParam,
+            ChatCompletionRequest,
+        )
+
+        request = ChatCompletionRequest(
+            model="test",
+            messages=[
+                ChatCompletionMessageUserParam(role="user", content="春天"),
+                ChatCompletionMessageGenericParam(role="assistant", content="春眠"),
+            ],
+            continue_final_message=True,
+        )
+        parser = ReasoningParser("glm45", request=request)
+        self.assertIsInstance(parser.detector, Glm45Detector)
+        self.assertTrue(parser.detector.continue_final_message)
+        self.assertEqual(parser.detector.previous_content, "春眠")
 
     def test_force_nonempty_content_via_chat_template_kwargs(self):
         """Test that force_nonempty_content is passed via chat_template_kwargs."""


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

`Glm45Detector.__init__` does not accept `continue_final_message` or `previous_content`, while `ReasoningParser.__init__` passes these kwargs whenever the request has `continue_final_message=True` with a trailing assistant message (`python/sglang/srt/parser/reasoning_parser.py:533-540`).

As a result, every GLM-4.5 / GLM-5 chat completion with `continue_final_message=true` fails with:

```
HTTP 500 Internal Server Error
Reasoning parsing error: Glm45Detector.__init__() got an unexpected keyword argument 'continue_final_message'
```

`DeepseekR1Detector`, `Qwen3Detector`, `KimiDetector`, `KimiK2Detector`, and `GptOssDetector` already accept and forward these kwargs to the base class; this aligns `Glm45Detector` with them.

**Reproduction** (`GLM-5-NVFP4-MTP`, `--reasoning-parser glm45`):

```
POST /v1/chat/completions  ... "continue_final_message": true
→ HTTP 500  {"message": "Failed to parse reasoning content"}
```

After this fix the same request returns HTTP 200 with a correct continuation of the trailing assistant message.

## Modifications

- `python/sglang/srt/parser/reasoning_parser.py`: add `continue_final_message` and `previous_content` parameters to `Glm45Detector.__init__` and forward them to `super().__init__`.
- `test/registered/unit/parser/test_reasoning_parser.py`: add four regression tests:
  - `TestGlm45Detector.test_continue_final_message_accepts_kwargs` — direct regression for the `TypeError`.
  - `TestGlm45Detector.test_continue_final_message_think_start_in_previous` — `_in_reasoning=True` when `<think>` is in `previous_content`.
  - `TestGlm45Detector.test_continue_final_message_think_end_in_previous` — `_in_reasoning=False` and continuation parsed as `normal_text` when `</think>` is in `previous_content`.
  - `TestReasoningParserAdvanced.test_continue_final_message_with_request_glm45` — end-to-end via `ReasoningParser("glm45", request=...)`, mirroring the real failing path.

All 114 tests in `test_reasoning_parser.py` pass.

## Accuracy Tests

N/A — this change is purely a parameter-forwarding fix in the reasoning parser's constructor; it does not touch model outputs, tokenization, or decoding.

## Speed Tests and Profiling

N/A — no hot-path code change; same call sequence, same allocations.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). _(No user-facing API/docs change.)_
- [ ] Provide accuracy and speed benchmark results. _(N/A, see sections above.)_
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
