### PR TITLE
Fix: Avoid downloading ModelScope weights when `--load-format=dummy` is used

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1025,7 +1025,15 @@ class ServerArgs:
                 **({"ignore_patterns": ignore_patterns} if ignore_patterns else {}),
             )
 
-        self.model_path = _resolve_or_download(self.model_path, revision=self.revision)
+        self.model_path = _resolve_or_download(
+            self.model_path,
+            revision=self.revision,
+            ignore_patterns=(
+                ["*.bin", "*.safetensors", "*.pt", "*.gguf"]
+                if self.load_format == "dummy"
+                else None
+            ),
+        )
         self.tokenizer_path = _resolve_or_download(
             self.tokenizer_path,
             ignore_patterns=["*.bin", "*.safetensors"],


### PR DESCRIPTION
## Motivation

When `SGLANG_USE_MODELSCOPE=1` is enabled, launching the server with `--load-format=dummy` still triggers a full model download from ModelScope, including weight files such as `model.safetensors`.

This behavior is unnecessary for dummy loading and is inconsistent with the HuggingFace path, where dummy load does not require downloading actual model weights.

This PR fixes the ModelScope code path to avoid downloading weight files when `--load-format=dummy` is used, **making its behavior consistent with HuggingFace and reducing unnecessary startup time**, and disk consumption.

## Modifications

- Detect the `--load-format=dummy` case in the ModelScope model preparation / resolution path.
- Skip downloading model weight files from ModelScope when dummy load is requested.
- Keep downloading only the minimal files required for model initialization if needed (e.g. config / tokenizer-related files), instead of fetching the full checkpoint.
- Align ModelScope behavior with the existing HuggingFace behavior for dummy load.

### Reproduction before this change

```bash
SGLANG_USE_MODELSCOPE=1 \
python -m sglang.launch_server \
    --load-format=dummy \
    --model-path Qwen/Qwen3-0.6B
```

Before this PR, the command still downloads full weights from ModelScope, including:

```text
Downloading [model.safetensors]: 100% ... 1.40G/1.40G
```

### Behavior after this change

With this PR, the same command no longer downloads model weight files under `--load-format=dummy`.

## Accuracy Tests

N/A

This change does not affect model forward logic, kernel computation, or numerical results. It only adjusts model artifact downloading behavior in the ModelScope dummy-load path.

## Speed Tests and Profiling

No inference benchmark is needed because this PR does not change runtime execution performance.

However, it improves startup behavior in the dummy-load scenario by avoiding unnecessary weight downloads from ModelScope, which significantly reduces:

- startup latency
- network traffic
- local cache / disk usage

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).