### PR TITLE
[Fix] Mixed chunk query_start_loc and mamba_cache_indices to the prefill-only prefix so that the tracking helpers see a consistent, prefill-only view.

### DIFF
--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -1,4 +1,5 @@
 import logging
+import types
 from typing import Optional, Union
 
 import torch
@@ -205,8 +206,26 @@ class MambaAttnBackendBase(AttentionBackend):
                     forward_batch.mamba_track_mask is not None
                     and forward_batch.mamba_track_mask.any()
                 ):
+                    # In MIXED mode (enable_mixed_chunk), slice query_start_loc and
+                    # mamba_cache_indices to the prefill-only prefix so that the
+                    # tracking helpers see a consistent, prefill-only view.
+                    if forward_batch.forward_mode.is_mixed():
+                        num_prefills = forward_batch.mamba_track_mask.shape[0]
+                        query_start_loc_for_track = query_start_loc[: num_prefills + 1]
+                        mamba_cache_indices_for_track = mamba_cache_indices[:num_prefills]
+                        prefill_proxy = types.SimpleNamespace(
+                            mamba_track_mask=forward_batch.mamba_track_mask,
+                            mamba_track_seqlens=forward_batch.mamba_track_seqlens,
+                            mamba_track_indices=forward_batch.mamba_track_indices,
+                            extend_seq_lens=forward_batch.extend_seq_lens[:num_prefills],
+                            extend_prefix_lens=forward_batch.extend_prefix_lens[:num_prefills],
+                        )
+                    else:
+                        query_start_loc_for_track = query_start_loc
+                        mamba_cache_indices_for_track = mamba_cache_indices
+                        prefill_proxy = forward_batch
                     track_conv_indices = self._init_track_conv_indices(
-                        query_start_loc, forward_batch
+                        query_start_loc_for_track, prefill_proxy
                     )
 
                     (
@@ -214,7 +233,7 @@ class MambaAttnBackendBase(AttentionBackend):
                         track_ssm_h_dst,
                         track_ssm_final_src,
                         track_ssm_final_dst,
-                    ) = self._init_track_ssm_indices(mamba_cache_indices, forward_batch)
+                    ) = self._init_track_ssm_indices(mamba_cache_indices_for_track, prefill_proxy)
         else:
             raise ValueError(f"Invalid forward mode: {forward_batch.forward_mode=}")
 

--- a/python/sglang/srt/layers/attention/mamba/mamba2_metadata.py
+++ b/python/sglang/srt/layers/attention/mamba/mamba2_metadata.py
@@ -195,14 +195,21 @@ class Mamba2Metadata(ForwardMetadata):
                 is_target_verify=forward_batch.forward_mode.is_target_verify(),
                 draft_token_num=draft_token_num,
             )
-        num_prefills = len(forward_batch.extend_seq_lens)
-        num_prefill_tokens = forward_batch.extend_num_tokens
-        num_decodes = len(forward_batch.seq_lens) - num_prefills
+        # In MIXED mode (enable_mixed_chunk),We derive num_prefills by subtracting the number
+        # of decode requests (= total seq_lens count - extend_seq_lens count) from
+        # the total extend count.  In non-MIXED mode the two counts are equal.
+        num_extend_reqs = len(forward_batch.extend_seq_lens)
+        num_decodes = len(forward_batch.seq_lens) - num_extend_reqs
+        num_prefills = num_extend_reqs - num_decodes
+        num_prefill_tokens = int(
+            forward_metadata.query_start_loc[num_prefills].item()
+        )
         context_lens_tensor = forward_batch.extend_prefix_lens
         assert context_lens_tensor is not None
         # precompute flag to avoid device syncs later
-        has_initial_states = context_lens_tensor > 0
-        prep_initial_states = torch.any(has_initial_states[:num_prefills]).item()
+        # Only look at the prefix lengths of REAL prefill requests.
+        has_initial_states = context_lens_tensor[:num_prefills] > 0
+        prep_initial_states = torch.any(has_initial_states).item()
 
         query_start_loc = forward_metadata.query_start_loc[: num_prefills + 1]
         seq_idx = torch.repeat_interleave(
@@ -213,6 +220,12 @@ class Mamba2Metadata(ForwardMetadata):
             output_size=num_prefill_tokens,
         )
         seq_idx.unsqueeze_(0)
+        # Only pass seq lens for REAL prefill requests to causal_conv1d kernels.
+        extend_seq_lens_cpu_prefill = (
+            forward_batch.extend_seq_lens_cpu[:num_prefills]
+            if forward_batch.extend_seq_lens_cpu is not None
+            else None
+        )
 
         # We compute metadata for chunked prefill once at the top level model
         # forward and reuse them in mamba layers. If not needed, they will be
@@ -248,6 +261,6 @@ class Mamba2Metadata(ForwardMetadata):
                 seq_idx=seq_idx,
                 chunk_indices=chunk_indices,
                 chunk_offsets=chunk_offsets,
-                extend_seq_lens_cpu=forward_batch.extend_seq_lens_cpu,
+                extend_seq_lens_cpu=extend_seq_lens_cpu_prefill,
             ),
         )

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1946,7 +1946,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         input_ids = torch.cat([self.input_ids, running_batch.input_ids])
         out_cache_loc = torch.cat([self.out_cache_loc, running_batch.out_cache_loc])
 
-        self.merge_batch(running_batch)
+        self.merge_batch(running_batch, self.mamba_track_indices, self.mamba_track_mask, self.mamba_track_seqlens)
         self.input_ids = input_ids
         self.out_cache_loc = out_cache_loc
 
@@ -2341,7 +2341,13 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 has_been_filtered=has_been_filtered,
             )
 
-    def merge_batch(self, other: "ScheduleBatch"):
+    def merge_batch(
+        self, 
+        other: "ScheduleBatch", 
+        mamba_track_indices: torch.Tensor = None,
+        mamba_track_mask: torch.Tensor = None,
+        mamba_track_seqlens: torch.Tensor = None,
+    ):
         # In the regular scheduler path:
         # 1) self is always prefill, whose seq_lens is not a future
         # 2) other is always decode, which is finished in previous step
@@ -2370,9 +2376,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.seq_lens_sum += other.seq_lens_sum
         if self.output_ids is not None:
             self.output_ids = torch.cat([self.output_ids, other.output_ids])
-        self.mamba_track_indices = None
-        self.mamba_track_mask = None
-        self.mamba_track_seqlens = None
+        self.mamba_track_indices = mamba_track_indices
+        self.mamba_track_mask = mamba_track_mask
+        self.mamba_track_seqlens = mamba_track_seqlens
         if self.return_logprob and other.return_logprob:
             self.top_logprobs_nums.extend(other.top_logprobs_nums)
             self.token_ids_logprobs.extend(other.token_ids_logprobs)


### PR DESCRIPTION

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
In recent tests, it was found that when both
--enable-mixed-chunk and
--mamba-scheduler-strategy extra_buffer are enabled, the model exhibits a drop in accuracy under concurrent request scenarios. Specifically, on the GSM8K benchmark, accuracy degrades from 93.8% to 87.6%.
In this PR（[#22876](https://github.com/sgl-project/sglang/pull/22876)），I tried adding a ValueError to indicate that the combination of --enable-mixed-chunk and --mamba-scheduler-strategy extra_buffer is currently not supported. After analysis and experimentation, I found that the root cause is that under mixed-chunk mode, query_start_loc and mamba_cache_indices become polluted by data from decode requests, causing anomalies when writing Mamba conv/SSM to the radix cache for prefill requests.This PR fixes the issue. After the fix, under 16-concurrency inference, the model achieves a normal test result of 93.8% on the GSM8K benchmark.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
### both --enable-mixed-chunk and --mamba-scheduler-strategy extra_buffer are enabled
+---------+-----------+----------+----------+-------+---------+---------+
| Model   | Dataset   | Metric   | Subset   |   Num |   Score | Cat.0   |
+=========+===========+==========+==========+=======+=========+=========+
| qwen3.5 | gsm8k     | mean_acc | main     |  1000 |   0.938 | default |
+---------+-----------+----------+----------+-------+---------+---------+ 

Gsm8k script command:
evalscope eval
--model qwen3.5
--api-url http://127.0.0.1:8000/v1
--api-key EMPTY
--eval-type openai_api
--eval-batch-size 16
--datasets gsm8k
--limit 1000
--generation-config '{"temperature":0.0,"max_tokens":500,"extra_body": {"chat_template_kwargs":{"enable_thinking": false}}}'

Here is the full model startup command I used:
SGLANG_ENABLE_SPEC_V2=1 \
python3 -m sglang.launch_server \
  --model-path /opt/ml/input/nas_new/llm_model_save/Qwen3.5-35B-A3B \
  --host 0.0.0.0 \
  --port 8000 \
  --enable-flashinfer-allreduce-fusion \
  --mamba-scheduler-strategy extra_buffer \
  --page-size 64 \
  --prefill-attention-backend flashinfer \
  --decode-attention-backend flashinfer \
  --enable-metrics \
  --max-running-requests 32 \
  --tp-size 2 \
  --mem-fraction-static 0.5 \
  --context-length 128000 \
  --reasoning-parser qwen3 \
  --tool-call-parser qwen3_coder \
  --enable-mixed-chunk \
  --chunked-prefill-size 4096

##Modifications
python\sglang\srt\managers\schedule_batch.py
python\sglang\srt\layers\attention\mamba\mamba2_metadata.py
python\sglang\srt\layers\attention\hybrid_linear_attn_backend.py

