### PR TITLE
[Bug Fix] Align Wan TI2V timestep expansion with SP local sequence length

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/wan_ti2v.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/wan_ti2v.py
@@ -145,7 +145,10 @@ def expand_wan_ti2v_timestep(
 
     local_seq_len = seq_len
     if get_sp_world_size() > 1 and getattr(batch, "did_sp_shard_latents", False):
-        local_seq_len = seq_len // get_sp_world_size()
+        # Time-sharded latents: per-rank length, same ceil-to-sp rounding as prepare_wan_ti2v_latents.
+        seq_len_rounded = int(
+            math.ceil(seq_len / get_sp_world_size())) * get_sp_world_size()
+        local_seq_len = seq_len_rounded // get_sp_world_size()
 
     if get_sp_parallel_rank() == 0 and reserved_frames_mask is not None:
         temp_ts = (reserved_frames_mask[0][:, ::2, ::2] * t_device_rounded).flatten()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
For **Wan 2.2 TI2V**, when video latents are **time-sharded across sequence-parallel (SP) ranks** (`batch.did_sp_shard_latents is True`), the DiT reshapes per-token `timestep_proj` to match the patch-flattened `hidden_states` layout under SP. A length mismatch can surface in `wanvideo.py` as:

`RuntimeError: shape '...' is invalid for input of size ...`

i.e. **`timestep_proj.numel()` does not match `batch_size * sp_size * local_seq_len * 6 * inner_dim`** for the intended `view`.

### Root cause

`expand_wan_ti2v_timestep` receives **`seq_len` from `prepare_wan_ti2v_latents`** (a **global** token count, already SP-aligned upward in that helper). When latents are **time-sharded** before denoising, each rank only sees a **local** temporal slice, so the expanded timestep tensor must have length **per rank** = `seq_len_rounded // sp_world_size`.

Using plain **`seq_len // sp_world_size`** truncates whenever the global count is not handled consistently with that SP rounding, so the timestep sequence can be **shorter or longer** than the token sequence the DiT actually uses after sharding/padding. That breaks the later `timestep_proj.view(batch, sp_size, local_seq_len, ...)`.

## Modifications

<!-- Detail the changes made in this pull request. -->
- When `get_sp_world_size() > 1` and `did_sp_shard_latents`, compute  
  `seq_len_rounded = ceil(seq_len / sp_world_size) * sp_world_size`  
  and **`local_seq_len = seq_len_rounded // sp_world_size`**, matching the same **ceil-to-multiple-of-SP** convention as `prepare_wan_ti2v_latents`.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Reproduction (example)

```bash
sglang generate \
  --model-path Wan-AI/Wan2.2-TI2V-5B-Diffusers \
  --prompt "..." \
  --image-path "..." \
  --negative-prompt "..." \
  --num-inference-steps 50 \
  --fps 121 \
  --width 1280 --height 704 --num-frames 81 \
  --guidance-scale 5.0 \
  --num-gpus 4 \
  --save-output \
  --attention-backend torch_sdpa
```

**Before:** Failure at `timestep_proj.view(...)` when the TI2V timestep length and SP-local token count diverge.  
**After:** Expanded timestep length stays consistent with the per-rank token count under time-sharded SP.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

