### PR TITLE
[Bug Fix] Fix gemma4_detector parallel tool call streaming index

### DIFF
--- a/python/sglang/srt/function_call/gemma4_detector.py
+++ b/python/sglang/srt/function_call/gemma4_detector.py
@@ -286,11 +286,11 @@ class Gemma4Detector(BaseFormatDetector):
                 return StreamingParseResult(normal_text=text)
 
             tool_indices = self._get_tool_indices(tools)
-            for func_name, args_str in matches:
+            for i, (func_name, args_str) in enumerate(matches):
                 arguments = _parse_gemma4_args(args_str)
                 calls.append(
                     ToolCallItem(
-                        tool_index=tool_indices.get(func_name, -1),
+                        tool_index=i,
                         name=func_name,
                         parameters=json.dumps(arguments, ensure_ascii=False),
                     )
@@ -377,9 +377,7 @@ class Gemma4Detector(BaseFormatDetector):
 
                                 calls.append(
                                     ToolCallItem(
-                                        tool_index=self._tool_indices.get(
-                                            func_name, -1
-                                        ),
+                                        tool_index=self.current_tool_id,
                                         name=func_name,
                                         parameters="",
                                     )
@@ -408,9 +406,7 @@ class Gemma4Detector(BaseFormatDetector):
 
                             calls.append(
                                 ToolCallItem(
-                                    tool_index=self._tool_indices.get(
-                                        self.current_func_name, -1
-                                    ),
+                                    tool_index=self.current_tool_id,
                                     parameters=json.dumps(
                                         arguments, ensure_ascii=False
                                     ),

--- a/python/sglang/srt/function_call/gemma4_detector.py
+++ b/python/sglang/srt/function_call/gemma4_detector.py
@@ -285,7 +285,6 @@ class Gemma4Detector(BaseFormatDetector):
             if not matches:
                 return StreamingParseResult(normal_text=text)
 
-            tool_indices = self._get_tool_indices(tools)
             for i, (func_name, args_str) in enumerate(matches):
                 arguments = _parse_gemma4_args(args_str)
                 calls.append(


### PR DESCRIPTION
## Motivation

When Gemma 4 emits multiple parallel calls to the same tool (e.g., 3× `web_search`), all streaming chunks receive the same `index` value — the tool's position in the tool definition list — instead of sequential indices (0, 1, 2). OpenAI-compatible clients that group streaming chunks by index merge all parallel same-tool calls into a single call with corrupted (concatenated) arguments.

## Bug Details

`Gemma4Detector.parse_streaming_increment` sets `tool_index` to `self._tool_indices.get(func_name, -1)` (tool-list position), while the correct pattern — used by `BaseFormatDetector` and other detectors fixed in #6715 — is `self.current_tool_id` (sequential counter).

The detector already increments `self.current_tool_id` correctly (line 374) but never uses it for `tool_index`. The same issue exists in the non-streaming `detect_and_parse` path.

**Observed streaming output (before fix):**
```
chunk: index=23  name=web_search  args=''
chunk: index=23  args='{"query": "A"}'
chunk: index=23  name=web_search  args=''
chunk: index=23  args='{"query": "B"}'
```

**After fix:**
```
chunk: index=0  name=web_search  args=''
chunk: index=0  args='{"query": "A"}'
chunk: index=1  name=web_search  args=''
chunk: index=1  args='{"query": "B"}'
```

## Fixes

Three locations in `gemma4_detector.py`:
- `detect_and_parse`: use `enumerate` index instead of `tool_indices.get()`
- `parse_streaming_increment` (name emit): use `self.current_tool_id` instead of `self._tool_indices.get()`
- `parse_streaming_increment` (args emit): same

Same fix class as #6715 (BaseFormatDetector refactor). `Gemma4Detector` overrides `parse_streaming_increment` entirely due to its non-JSON token format, so the base class fix does not apply.