### PR TITLE
[CI] GB200 nightly: on-demand PR/branch image build and config filter

### DIFF
--- a/.github/workflows/nightly-72-gpu-gb200.yml
+++ b/.github/workflows/nightly-72-gpu-gb200.yml
@@ -9,9 +9,17 @@ on:
   workflow_dispatch:  # allow manual trigger; gated by gb200-ci environment
     inputs:
       image:
-        description: 'SGLang Docker image to benchmark'
+        description: 'SGLang Docker image to benchmark (mutually exclusive with sglang_branch)'
         required: false
         default: 'lmsysorg/sglang:dev-cu13'
+      sglang_branch:
+        description: 'SGLang branch to build from. If set, builds a fresh image from this branch (ARM64, CUDA 13) and uses it for the run. Mutually exclusive with image.'
+        required: false
+        default: ''
+      configs:
+        description: 'Optional comma-separated matrix entry names to run (e.g. "dsr1-fp8-1k1k-max-tpt"). Leave empty to run all configs. Names are defined in scripts/ci/slurm/nightly-configs.yaml.'
+        required: false
+        default: ''
 
 concurrency:
   group: nightly-test-gb200
@@ -22,8 +30,27 @@ env:
   SRT_SLURM_BRANCH: sglang-nightly-regression
   SLURM_PARTITION: batch
   SLURM_ACCOUNT: sglang
+  # Package name for ephemeral branch-build images on GHCR
+  CI_IMAGE_PACKAGE: sglang-nightly-ci
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # Reject conflicting inputs early. `image` and `sglang_branch` are mutually
+  # exclusive: one selects a pre-built image, the other triggers a fresh build.
+  # ---------------------------------------------------------------------------
+  validate-inputs:
+    if: github.repository == 'sgl-project/sglang' && github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject conflicting inputs
+        run: |
+          BRANCH="${{ inputs.sglang_branch }}"
+          IMAGE="${{ inputs.image }}"
+          if [ -n "$BRANCH" ] && [ -n "$IMAGE" ] && [ "$IMAGE" != "lmsysorg/sglang:dev-cu13" ]; then
+            echo "::error::Specify either 'image' or 'sglang_branch', not both. Got image='$IMAGE' and sglang_branch='$BRANCH'."
+            exit 1
+          fi
+
   # ---------------------------------------------------------------------------
   # Reads scripts/ci/slurm/nightly-configs.yaml and generates one matrix entry
   # per recipe YAML. Each job runs the full concurrency sweep defined in the
@@ -41,29 +68,144 @@ jobs:
 
       - name: Generate benchmark matrix
         id: generate
+        env:
+          CONFIGS_FILTER: ${{ inputs.configs }}
         run: |
           pip install pyyaml -q
-          MATRIX=$(python3 scripts/ci/slurm/generate_matrix.py scripts/ci/slurm/nightly-configs.yaml --runner gb200)
+          FILTER_ARG=()
+          if [ -n "$CONFIGS_FILTER" ]; then
+            FILTER_ARG=(--filter "$CONFIGS_FILTER")
+          fi
+          MATRIX=$(python3 scripts/ci/slurm/generate_matrix.py \
+            scripts/ci/slurm/nightly-configs.yaml --runner gb200 "${FILTER_ARG[@]}")
           echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+
+  # ---------------------------------------------------------------------------
+  # When sglang_branch is provided, build an ARM64 (GB200) image from that
+  # branch and push it to GHCR. The image is deleted by `cleanup-image` at the
+  # end of the run. This job is skipped for nightly (cron) runs and any manual
+  # run that doesn't specify sglang_branch.
+  # ---------------------------------------------------------------------------
+  build-image:
+    needs: [validate-inputs, setup]
+    if: github.repository == 'sgl-project/sglang' && github.event_name == 'workflow_dispatch' && inputs.sglang_branch != ''
+    runs-on: arm-docker-build-node
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image_ref: ${{ steps.build.outputs.image_ref }}
+      version_id: ${{ steps.resolve.outputs.version_id }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sglang_branch }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push ARM64 image
+        id: build
+        run: |
+          SANITIZED_BRANCH=$(echo "${{ inputs.sglang_branch }}" | tr '/' '-' | tr -cd '[:alnum:]._-')
+          TAG="${SANITIZED_BRANCH}-${{ github.run_id }}"
+          IMAGE_REF="ghcr.io/sgl-project/${CI_IMAGE_PACKAGE}:${TAG}"
+          echo "Building ${IMAGE_REF} from branch ${{ inputs.sglang_branch }}"
+
+          docker buildx build \
+            --platform linux/arm64 \
+            --output type=image,name=${IMAGE_REF},push=true \
+            --target framework_final \
+            -f docker/Dockerfile \
+            --build-arg CUDA_VERSION=13.0.1 \
+            --build-arg BUILD_TYPE=all \
+            --build-arg CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) \
+            --build-arg GRACE_BLACKWELL=1 \
+            --build-arg BRANCH_TYPE=local \
+            --build-arg INSTALL_FLASHINFER_JIT_CACHE=1 \
+            --no-cache \
+            .
+
+          echo "image_ref=${IMAGE_REF}" >> $GITHUB_OUTPUT
+          echo "image_tag=${TAG}" >> $GITHUB_OUTPUT
+
+      - name: Resolve GHCR package version id (for cleanup)
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.build.outputs.image_tag }}
+        run: |
+          # Retry: GHCR may take a few seconds to index a freshly pushed tag.
+          VERSION_ID=""
+          for i in 1 2 3 4 5; do
+            VERSION_ID=$(gh api "/orgs/sgl-project/packages/container/${CI_IMAGE_PACKAGE}/versions" \
+              --jq "[.[] | select(.metadata.container.tags[]? == \"${TAG}\")][0].id" || true)
+            if [ -n "$VERSION_ID" ] && [ "$VERSION_ID" != "null" ]; then
+              break
+            fi
+            echo "Version id not yet available (attempt $i), retrying..."
+            sleep 5
+          done
+          if [ -z "$VERSION_ID" ] || [ "$VERSION_ID" = "null" ]; then
+            echo "::warning::Could not resolve GHCR version id for tag ${TAG}; cleanup will be skipped."
+            VERSION_ID=""
+          fi
+          echo "version_id=${VERSION_ID}" >> $GITHUB_OUTPUT
 
   # ---------------------------------------------------------------------------
   # Import Docker images to Lustre squash files once before all benchmark jobs.
   # This avoids parallel jobs racing to enroot import the same image.
+  # When build-image ran, we import the freshly built GHCR image; otherwise we
+  # use the `image` input (or its default).
   # ---------------------------------------------------------------------------
   prepare-image:
-    needs: setup
-    if: github.repository == 'sgl-project/sglang'
+    needs: [setup, build-image]
+    if: |
+      always() && github.repository == 'sgl-project/sglang'
+      && needs.setup.result == 'success'
+      && (needs.build-image.result == 'success' || needs.build-image.result == 'skipped')
     environment: ${{ github.event_name == 'workflow_dispatch' && 'gb200-ci' || '' }}
     runs-on: 72-gpu-gb200
     outputs:
       squash_file: ${{ steps.import.outputs.squash_file }}
       nginx_squash_file: ${{ steps.import.outputs.nginx_squash_file }}
+      image: ${{ steps.resolve.outputs.image }}
     env:
-      IMAGE: ${{ inputs.image || 'lmsysorg/sglang:dev-cu13' }}
       NGINX_IMAGE: nginx:1.27.4
     steps:
+      - name: Resolve image to import
+        id: resolve
+        run: |
+          BUILT_IMAGE="${{ needs.build-image.outputs.image_ref }}"
+          if [ -n "$BUILT_IMAGE" ]; then
+            echo "Using freshly built image: $BUILT_IMAGE"
+            echo "image=$BUILT_IMAGE" >> $GITHUB_OUTPUT
+          else
+            IMAGE="${{ inputs.image || 'lmsysorg/sglang:dev-cu13' }}"
+            echo "Using pre-existing image: $IMAGE"
+            echo "image=$IMAGE" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Configure enroot credentials for GHCR
+        if: needs.build-image.outputs.image_ref != ''
+        run: |
+          mkdir -p "$HOME/.config/enroot"
+          CRED="$HOME/.config/enroot/.credentials"
+          echo "machine ghcr.io login ${{ github.actor }} password ${{ secrets.GITHUB_TOKEN }}" > "$CRED"
+          chmod 600 "$CRED"
+
       - name: Import Docker images to Lustre
         id: import
+        env:
+          IMAGE: ${{ steps.resolve.outputs.image }}
         run: |
           SQUASH_FILE="/mnt/lustre01/users-public/sglang-ci/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g')_$(date +%Y%m%d).sqsh"
           NGINX_SQUASH_FILE="/mnt/lustre01/users-public/sglang-ci/$(echo "$NGINX_IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
@@ -82,6 +224,10 @@ jobs:
 
           echo "squash_file=$SQUASH_FILE" >> $GITHUB_OUTPUT
           echo "nginx_squash_file=$NGINX_SQUASH_FILE" >> $GITHUB_OUTPUT
+
+      - name: Remove GHCR credentials
+        if: always() && needs.build-image.outputs.image_ref != ''
+        run: rm -f "$HOME/.config/enroot/.credentials"
 
   nightly-gb200-benchmark:
     needs: [setup, prepare-image]
@@ -204,3 +350,24 @@ jobs:
         run: |
           pip install tabulate -q
           python3 scripts/ci/slurm/summarize.py results/ >> $GITHUB_STEP_SUMMARY
+
+  # ---------------------------------------------------------------------------
+  # Delete the ephemeral GHCR image built by `build-image`. Runs after all
+  # benchmark jobs complete (success or failure) so the image doesn't linger.
+  # No-op when build-image was skipped.
+  # ---------------------------------------------------------------------------
+  cleanup-image:
+    needs: [build-image, nightly-gb200-benchmark]
+    if: always() && needs.build-image.result == 'success' && needs.build-image.outputs.version_id != ''
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Delete GHCR image version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION_ID: ${{ needs.build-image.outputs.version_id }}
+        run: |
+          echo "Deleting GHCR package version ${VERSION_ID} (${{ needs.build-image.outputs.image_ref }})"
+          gh api --method DELETE \
+            "/orgs/sgl-project/packages/container/${CI_IMAGE_PACKAGE}/versions/${VERSION_ID}"

--- a/.github/workflows/nightly-72-gpu-gb200.yml
+++ b/.github/workflows/nightly-72-gpu-gb200.yml
@@ -144,6 +144,16 @@ jobs:
           # Otherwise fall back to the branch name on sgl-project/sglang.
           ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || inputs.sglang_branch }}
 
+      - name: Verify checkout
+        run: |
+          echo "Resolved ref: $(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo 'detached HEAD')"
+          echo "Commit SHA:   $(git rev-parse HEAD)"
+          echo "Author:       $(git log -1 --format='%an <%ae>')"
+          echo "Date:         $(git log -1 --format='%aI')"
+          echo "Subject:      $(git log -1 --format='%s')"
+          echo ""
+          echo "Cross-check against: https://github.com/sgl-project/sglang/pull/${{ inputs.pr_number }}/commits"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/nightly-72-gpu-gb200.yml
+++ b/.github/workflows/nightly-72-gpu-gb200.yml
@@ -37,6 +37,8 @@ jobs:
   # ---------------------------------------------------------------------------
   # Reject conflicting inputs early. `image` and `sglang_branch` are mutually
   # exclusive: one selects a pre-built image, the other triggers a fresh build.
+  # Only runs on manual dispatch; all downstream jobs chain through this so
+  # invalid inputs halt the pipeline before cluster resources are reserved.
   # ---------------------------------------------------------------------------
   validate-inputs:
     if: github.repository == 'sgl-project/sglang' && github.event_name == 'workflow_dispatch'
@@ -46,7 +48,7 @@ jobs:
         run: |
           BRANCH="${{ inputs.sglang_branch }}"
           IMAGE="${{ inputs.image }}"
-          if [ -n "$BRANCH" ] && [ -n "$IMAGE" ] && [ "$IMAGE" != "lmsysorg/sglang:dev-cu13" ]; then
+          if [ -n "$BRANCH" ] && [ -n "$IMAGE" ]; then
             echo "::error::Specify either 'image' or 'sglang_branch', not both. Got image='$IMAGE' and sglang_branch='$BRANCH'."
             exit 1
           fi
@@ -58,7 +60,11 @@ jobs:
   # To add/remove configs, edit nightly-configs.yaml only.
   # ---------------------------------------------------------------------------
   setup:
-    if: github.repository == 'sgl-project/sglang'
+    needs: validate-inputs
+    # Run if validate-inputs succeeded (dispatch) or was skipped (cron).
+    if: |
+      always() && github.repository == 'sgl-project/sglang'
+      && (needs.validate-inputs.result == 'success' || needs.validate-inputs.result == 'skipped')
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.generate.outputs.matrix }}

--- a/.github/workflows/nightly-72-gpu-gb200.yml
+++ b/.github/workflows/nightly-72-gpu-gb200.yml
@@ -145,14 +145,22 @@ jobs:
           ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || inputs.sglang_branch }}
 
       - name: Verify checkout
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+          BRANCH: ${{ inputs.sglang_branch }}
         run: |
-          echo "Resolved ref: $(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo 'detached HEAD')"
-          echo "Commit SHA:   $(git rev-parse HEAD)"
-          echo "Author:       $(git log -1 --format='%an <%ae>')"
-          echo "Date:         $(git log -1 --format='%aI')"
-          echo "Subject:      $(git log -1 --format='%s')"
+          SHA=$(git rev-parse HEAD)
+          echo "Commit SHA: $SHA"
+          echo "Author:     $(git log -1 --format='%an <%ae>')"
+          echo "Date:       $(git log -1 --format='%aI')"
+          echo "Subject:    $(git log -1 --format='%s')"
           echo ""
-          echo "Cross-check against: https://github.com/sgl-project/sglang/pull/${{ inputs.pr_number }}/commits"
+          if [ -n "$PR_NUMBER" ]; then
+            echo "Cross-check: https://github.com/sgl-project/sglang/pull/${PR_NUMBER}/commits"
+          else
+            echo "Cross-check: https://github.com/sgl-project/sglang/commits/${BRANCH}"
+          fi
+          echo "Commit URL:  https://github.com/sgl-project/sglang/commit/${SHA}"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/nightly-72-gpu-gb200.yml
+++ b/.github/workflows/nightly-72-gpu-gb200.yml
@@ -9,11 +9,15 @@ on:
   workflow_dispatch:  # allow manual trigger; gated by gb200-ci environment
     inputs:
       image:
-        description: 'Optional. SGLang Docker image to benchmark. Leave as default for the nightly image. Mutually exclusive with sglang_branch.'
+        description: 'Optional. SGLang Docker image to benchmark. Leave empty for the default nightly image. Mutually exclusive with pr_number and sglang_branch.'
+        required: false
+        default: ''
+      pr_number:
+        description: 'Optional. PR number to build from (works for PRs from forks too, via refs/pull/<N>/head). Preferred over sglang_branch when a PR exists. Mutually exclusive with image and sglang_branch.'
         required: false
         default: ''
       sglang_branch:
-        description: 'Optional. SGLang branch to build from. If set, builds a fresh image from this branch (ARM64, CUDA 13) and uses it for the run. Mutually exclusive with image.'
+        description: 'Optional. Branch name on sgl-project/sglang to build from (use when no PR is open yet). For fork branches, open a PR and use pr_number instead. Mutually exclusive with image and pr_number.'
         required: false
         default: ''
       configs:
@@ -35,10 +39,10 @@ env:
 
 jobs:
   # ---------------------------------------------------------------------------
-  # Reject conflicting inputs early. `image` and `sglang_branch` are mutually
-  # exclusive: one selects a pre-built image, the other triggers a fresh build.
-  # Only runs on manual dispatch; all downstream jobs chain through this so
-  # invalid inputs halt the pipeline before cluster resources are reserved.
+  # Reject conflicting inputs early. At most one of `image`, `pr_number`,
+  # `sglang_branch` may be set — they select different image sources. Only runs
+  # on manual dispatch; all downstream jobs chain through this so invalid
+  # inputs halt the pipeline before cluster resources are reserved.
   # ---------------------------------------------------------------------------
   validate-inputs:
     if: github.repository == 'sgl-project/sglang' && github.event_name == 'workflow_dispatch'
@@ -46,10 +50,19 @@ jobs:
     steps:
       - name: Reject conflicting inputs
         run: |
-          BRANCH="${{ inputs.sglang_branch }}"
           IMAGE="${{ inputs.image }}"
-          if [ -n "$BRANCH" ] && [ -n "$IMAGE" ]; then
-            echo "::error::Specify either 'image' or 'sglang_branch', not both. Got image='$IMAGE' and sglang_branch='$BRANCH'."
+          PR="${{ inputs.pr_number }}"
+          BRANCH="${{ inputs.sglang_branch }}"
+          sources=0
+          [ -n "$IMAGE" ]  && sources=$((sources + 1))
+          [ -n "$PR" ]     && sources=$((sources + 1))
+          [ -n "$BRANCH" ] && sources=$((sources + 1))
+          if [ "$sources" -gt 1 ]; then
+            echo "::error::Specify at most one of 'image' ('$IMAGE'), 'pr_number' ('$PR'), or 'sglang_branch' ('$BRANCH')."
+            exit 1
+          fi
+          if [ -n "$PR" ] && ! echo "$PR" | grep -Eq '^[0-9]+$'; then
+            echo "::error::pr_number must be a positive integer, got '$PR'."
             exit 1
           fi
 
@@ -97,14 +110,17 @@ jobs:
           echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
 
   # ---------------------------------------------------------------------------
-  # When sglang_branch is provided, build an ARM64 (GB200) image from that
-  # branch and push it to GHCR. The image is deleted by `cleanup-image` at the
-  # end of the run. This job is skipped for nightly (cron) runs and any manual
-  # run that doesn't specify sglang_branch.
+  # When pr_number or sglang_branch is provided, build an ARM64 (GB200) image
+  # from that ref and push it to GHCR. Uses refs/pull/<N>/head for PRs so fork
+  # PRs work without cross-repo auth. The image is deleted by `cleanup-image`
+  # at the end of the run. Skipped on nightly (cron) runs and manual runs with
+  # neither pr_number nor sglang_branch.
   # ---------------------------------------------------------------------------
   build-image:
     needs: [validate-inputs, setup]
-    if: github.repository == 'sgl-project/sglang' && github.event_name == 'workflow_dispatch' && inputs.sglang_branch != ''
+    if: |
+      github.repository == 'sgl-project/sglang' && github.event_name == 'workflow_dispatch'
+      && (inputs.pr_number != '' || inputs.sglang_branch != '')
     runs-on: arm-docker-build-node
     permissions:
       contents: read
@@ -125,7 +141,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.sglang_branch }}
+          # PRs (including fork PRs) resolve via refs/pull/<N>/head on upstream.
+          # Otherwise fall back to the branch name on sgl-project/sglang.
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || inputs.sglang_branch }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -140,10 +158,16 @@ jobs:
       - name: Build and push ARM64 image
         id: build
         run: |
-          SANITIZED_BRANCH=$(echo "${{ inputs.sglang_branch }}" | tr '/' '-' | tr -cd '[:alnum:]._-')
-          TAG="${SANITIZED_BRANCH}-${{ github.run_id }}"
+          if [ -n "${{ inputs.pr_number }}" ]; then
+            TAG_STUB="pr-${{ inputs.pr_number }}"
+            SOURCE_DESC="PR #${{ inputs.pr_number }}"
+          else
+            TAG_STUB=$(echo "${{ inputs.sglang_branch }}" | tr '/' '-' | tr -cd '[:alnum:]._-')
+            SOURCE_DESC="branch ${{ inputs.sglang_branch }}"
+          fi
+          TAG="${TAG_STUB}-${{ github.run_id }}"
           IMAGE_REF="ghcr.io/sgl-project/${CI_IMAGE_PACKAGE}:${TAG}"
-          echo "Building ${IMAGE_REF} from branch ${{ inputs.sglang_branch }}"
+          echo "Building ${IMAGE_REF} from ${SOURCE_DESC}"
 
           docker buildx build \
             --platform linux/arm64 \

--- a/.github/workflows/nightly-72-gpu-gb200.yml
+++ b/.github/workflows/nightly-72-gpu-gb200.yml
@@ -127,7 +127,6 @@ jobs:
       packages: write
     outputs:
       image_ref: ${{ steps.build.outputs.image_ref }}
-      version_id: ${{ steps.resolve.outputs.version_id }}
     steps:
       # Self-hosted runners retain the workspace across jobs. Prior `docker buildx`
       # runs on this node leave root-owned build artifacts (e.g. sgl-kernel/build/)
@@ -165,7 +164,9 @@ jobs:
             TAG_STUB=$(echo "${{ inputs.sglang_branch }}" | tr '/' '-' | tr -cd '[:alnum:]._-')
             SOURCE_DESC="branch ${{ inputs.sglang_branch }}"
           fi
-          TAG="${TAG_STUB}-${{ github.run_id }}"
+          # run_attempt disambiguates "Re-run jobs" so the squash filename
+          # (derived from the image URL) doesn't collide with a stale one.
+          TAG="${TAG_STUB}-${{ github.run_id }}-${{ github.run_attempt }}"
           IMAGE_REF="ghcr.io/sgl-project/${CI_IMAGE_PACKAGE}:${TAG}"
           echo "Building ${IMAGE_REF} from ${SOURCE_DESC}"
 
@@ -184,30 +185,6 @@ jobs:
             .
 
           echo "image_ref=${IMAGE_REF}" >> $GITHUB_OUTPUT
-          echo "image_tag=${TAG}" >> $GITHUB_OUTPUT
-
-      - name: Resolve GHCR package version id (for cleanup)
-        id: resolve
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.build.outputs.image_tag }}
-        run: |
-          # Retry: GHCR may take a few seconds to index a freshly pushed tag.
-          VERSION_ID=""
-          for i in 1 2 3 4 5; do
-            VERSION_ID=$(gh api "/orgs/sgl-project/packages/container/${CI_IMAGE_PACKAGE}/versions" \
-              --jq "[.[] | select(.metadata.container.tags[]? == \"${TAG}\")][0].id" || true)
-            if [ -n "$VERSION_ID" ] && [ "$VERSION_ID" != "null" ]; then
-              break
-            fi
-            echo "Version id not yet available (attempt $i), retrying..."
-            sleep 5
-          done
-          if [ -z "$VERSION_ID" ] || [ "$VERSION_ID" = "null" ]; then
-            echo "::warning::Could not resolve GHCR version id for tag ${TAG}; cleanup will be skipped."
-            VERSION_ID=""
-          fi
-          echo "version_id=${VERSION_ID}" >> $GITHUB_OUTPUT
 
   # ---------------------------------------------------------------------------
   # Import Docker images to Lustre squash files once before all benchmark jobs.
@@ -401,22 +378,26 @@ jobs:
           python3 scripts/ci/slurm/summarize.py results/ >> $GITHUB_STEP_SUMMARY
 
   # ---------------------------------------------------------------------------
-  # Delete the ephemeral GHCR image built by `build-image`. Runs after all
-  # benchmark jobs complete (success or failure) so the image doesn't linger.
-  # No-op when build-image was skipped.
+  # Delete the entire ephemeral GHCR package built by `build-image`. Safe to
+  # wipe everything because:
+  #   - `concurrency: nightly-test-gb200` serializes runs so nothing else is
+  #     using the package mid-run,
+  #   - the sqsh file is already on Lustre by the time this runs, so the
+  #     benchmark jobs no longer need the GHCR image,
+  #   - this package is CI-only — no human artifacts live here.
+  # Skipped when build-image was skipped.
   # ---------------------------------------------------------------------------
   cleanup-image:
     needs: [build-image, nightly-gb200-benchmark]
-    if: always() && needs.build-image.result == 'success' && needs.build-image.outputs.version_id != ''
+    if: always() && needs.build-image.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       packages: write
     steps:
-      - name: Delete GHCR image version
+      - name: Delete GHCR package
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION_ID: ${{ needs.build-image.outputs.version_id }}
+          IMAGE_REF: ${{ needs.build-image.outputs.image_ref }}
         run: |
-          echo "Deleting GHCR package version ${VERSION_ID} (${{ needs.build-image.outputs.image_ref }})"
-          gh api --method DELETE \
-            "/orgs/sgl-project/packages/container/${CI_IMAGE_PACKAGE}/versions/${VERSION_ID}"
+          echo "Deleting GHCR package ${CI_IMAGE_PACKAGE} (built image: ${IMAGE_REF})"
+          gh api --method DELETE "/orgs/sgl-project/packages/container/${CI_IMAGE_PACKAGE}"

--- a/.github/workflows/nightly-72-gpu-gb200.yml
+++ b/.github/workflows/nightly-72-gpu-gb200.yml
@@ -9,15 +9,15 @@ on:
   workflow_dispatch:  # allow manual trigger; gated by gb200-ci environment
     inputs:
       image:
-        description: 'SGLang Docker image to benchmark (mutually exclusive with sglang_branch)'
+        description: 'Optional. SGLang Docker image to benchmark. Leave as default for the nightly image. Mutually exclusive with sglang_branch.'
         required: false
-        default: 'lmsysorg/sglang:dev-cu13'
+        default: ''
       sglang_branch:
-        description: 'SGLang branch to build from. If set, builds a fresh image from this branch (ARM64, CUDA 13) and uses it for the run. Mutually exclusive with image.'
+        description: 'Optional. SGLang branch to build from. If set, builds a fresh image from this branch (ARM64, CUDA 13) and uses it for the run. Mutually exclusive with image.'
         required: false
         default: ''
       configs:
-        description: 'Optional comma-separated matrix entry names to run (e.g. "dsr1-fp8-1k1k-max-tpt"). Leave empty to run all configs. Names are defined in scripts/ci/slurm/nightly-configs.yaml.'
+        description: 'Optional. Comma-separated names to run only a subset. Format: {model-prefix}-{precision}-{isl}{osl}-{recipe}. E.g. "dsr1-fp8-1k1k-max-tpt" or "dsr1-fp8-1k1k-max-tpt,dsr1-fp4-1k1k-mid-curve". Leave empty to run all. Available names are listed in the setup job log.'
         required: false
         default: ''
 
@@ -72,8 +72,18 @@ jobs:
           CONFIGS_FILTER: ${{ inputs.configs }}
         run: |
           pip install pyyaml -q
+
+          # List all available config names first so they're visible in logs
+          # even when a filter rejects an unknown name.
+          ALL_MATRIX=$(python3 scripts/ci/slurm/generate_matrix.py \
+            scripts/ci/slurm/nightly-configs.yaml --runner gb200)
+          echo "Available config names for runner gb200:"
+          echo "$ALL_MATRIX" | python3 -c "import json,sys; [print(f'  - {e[\"name\"]}') for e in json.load(sys.stdin)]"
+
           FILTER_ARG=()
           if [ -n "$CONFIGS_FILTER" ]; then
+            echo ""
+            echo "Filtering to: $CONFIGS_FILTER"
             FILTER_ARG=(--filter "$CONFIGS_FILTER")
           fi
           MATRIX=$(python3 scripts/ci/slurm/generate_matrix.py \

--- a/.github/workflows/nightly-72-gpu-gb200.yml
+++ b/.github/workflows/nightly-72-gpu-gb200.yml
@@ -34,8 +34,11 @@ env:
   SRT_SLURM_BRANCH: sglang-nightly-regression
   SLURM_PARTITION: batch
   SLURM_ACCOUNT: sglang
-  # Package name for ephemeral branch-build images on GHCR
-  CI_IMAGE_PACKAGE: sglang-nightly-ci
+  # Docker Hub repo for ephemeral branch/PR build images (kept separate from
+  # the released `lmsysorg/sglang` repo). Cleaned up by `cleanup-image`.
+  CI_IMAGE_REPO: lmsysorg/sglang-staging
+  # How many most recent staging tags to retain after each run.
+  CI_IMAGE_KEEP_TAGS: 60
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -111,10 +114,11 @@ jobs:
 
   # ---------------------------------------------------------------------------
   # When pr_number or sglang_branch is provided, build an ARM64 (GB200) image
-  # from that ref and push it to GHCR. Uses refs/pull/<N>/head for PRs so fork
-  # PRs work without cross-repo auth. The image is deleted by `cleanup-image`
-  # at the end of the run. Skipped on nightly (cron) runs and manual runs with
-  # neither pr_number nor sglang_branch.
+  # from that ref and push it to Docker Hub under lmsysorg/sglang-staging.
+  # Uses refs/pull/<N>/head for PRs so fork PRs work without cross-repo auth.
+  # Old staging tags are pruned by `cleanup-image` at the end of the run.
+  # Skipped on nightly (cron) runs and manual runs with neither pr_number nor
+  # sglang_branch.
   # ---------------------------------------------------------------------------
   build-image:
     needs: [validate-inputs, setup]
@@ -122,11 +126,9 @@ jobs:
       github.repository == 'sgl-project/sglang' && github.event_name == 'workflow_dispatch'
       && (inputs.pr_number != '' || inputs.sglang_branch != '')
     runs-on: arm-docker-build-node
-    permissions:
-      contents: read
-      packages: write
     outputs:
       image_ref: ${{ steps.build.outputs.image_ref }}
+      image_tag: ${{ steps.build.outputs.image_tag }}
     steps:
       # Self-hosted runners retain the workspace across jobs. Prior `docker buildx`
       # runs on this node leave root-owned build artifacts (e.g. sgl-kernel/build/)
@@ -165,12 +167,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to GHCR
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push ARM64 image
         id: build
@@ -185,7 +186,7 @@ jobs:
           # run_attempt disambiguates "Re-run jobs" so the squash filename
           # (derived from the image URL) doesn't collide with a stale one.
           TAG="${TAG_STUB}-${{ github.run_id }}-${{ github.run_attempt }}"
-          IMAGE_REF="ghcr.io/sgl-project/${CI_IMAGE_PACKAGE}:${TAG}"
+          IMAGE_REF="${CI_IMAGE_REPO}:${TAG}"
           echo "Building ${IMAGE_REF} from ${SOURCE_DESC}"
 
           docker buildx build \
@@ -203,12 +204,14 @@ jobs:
             .
 
           echo "image_ref=${IMAGE_REF}" >> $GITHUB_OUTPUT
+          echo "image_tag=${TAG}" >> $GITHUB_OUTPUT
 
   # ---------------------------------------------------------------------------
   # Import Docker images to Lustre squash files once before all benchmark jobs.
   # This avoids parallel jobs racing to enroot import the same image.
-  # When build-image ran, we import the freshly built GHCR image; otherwise we
-  # use the `image` input (or its default).
+  # When build-image ran, we import the freshly built Docker Hub staging image
+  # (lmsysorg/sglang-staging is public → no auth needed for enroot pull).
+  # Otherwise we use the `image` input (or its default public nightly image).
   # ---------------------------------------------------------------------------
   prepare-image:
     needs: [setup, build-image]
@@ -238,14 +241,6 @@ jobs:
             echo "image=$IMAGE" >> $GITHUB_OUTPUT
           fi
 
-      - name: Configure enroot credentials for GHCR
-        if: needs.build-image.outputs.image_ref != ''
-        run: |
-          mkdir -p "$HOME/.config/enroot"
-          CRED="$HOME/.config/enroot/.credentials"
-          echo "machine ghcr.io login ${{ github.actor }} password ${{ secrets.GITHUB_TOKEN }}" > "$CRED"
-          chmod 600 "$CRED"
-
       - name: Import Docker images to Lustre
         id: import
         env:
@@ -268,10 +263,6 @@ jobs:
 
           echo "squash_file=$SQUASH_FILE" >> $GITHUB_OUTPUT
           echo "nginx_squash_file=$NGINX_SQUASH_FILE" >> $GITHUB_OUTPUT
-
-      - name: Remove GHCR credentials
-        if: always() && needs.build-image.outputs.image_ref != ''
-        run: rm -f "$HOME/.config/enroot/.credentials"
 
   nightly-gb200-benchmark:
     needs: [setup, prepare-image]
@@ -402,26 +393,46 @@ jobs:
           python3 scripts/ci/slurm/summarize.py results/ >> $GITHUB_STEP_SUMMARY
 
   # ---------------------------------------------------------------------------
-  # Delete the entire ephemeral GHCR package built by `build-image`. Safe to
-  # wipe everything because:
-  #   - `concurrency: nightly-test-gb200` serializes runs so nothing else is
-  #     using the package mid-run,
-  #   - the sqsh file is already on Lustre by the time this runs, so the
-  #     benchmark jobs no longer need the GHCR image,
-  #   - this package is CI-only — no human artifacts live here.
-  # Skipped when build-image was skipped.
+  # Prune old tags in the staging repo, keeping only the most recent N. Mirrors
+  # the pattern used by release-docker-dev.yml. Runs after benchmarks so the
+  # freshly built image (whose sqsh is already on Lustre) becomes a regular
+  # aged-out tag over time. No-op when the repo has ≤ CI_IMAGE_KEEP_TAGS tags.
   # ---------------------------------------------------------------------------
   cleanup-image:
     needs: [build-image, nightly-gb200-benchmark]
     if: always() && needs.build-image.result == 'success'
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
     steps:
-      - name: Delete GHCR package
+      - name: Prune old staging tags on Docker Hub
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IMAGE_REF: ${{ needs.build-image.outputs.image_ref }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
-          echo "Deleting GHCR package ${CI_IMAGE_PACKAGE} (built image: ${IMAGE_REF})"
-          gh api --method DELETE "/orgs/sgl-project/packages/container/${CI_IMAGE_PACKAGE}"
+          TOKEN=$(curl -s -H "Content-Type: application/json" \
+            -X POST -d "{\"username\": \"${DOCKERHUB_USERNAME}\", \"password\": \"${DOCKERHUB_TOKEN}\"}" \
+            https://hub.docker.com/v2/users/login/ | jq -r .token)
+          if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+            echo "::error::Docker Hub login failed"
+            exit 1
+          fi
+
+          TAGS_RESPONSE=$(curl -s -H "Authorization: JWT $TOKEN" \
+            "https://hub.docker.com/v2/repositories/${CI_IMAGE_REPO}/tags/?page_size=100")
+
+          # Sort tags by last_updated (newest first), keep names only.
+          TAGS=$(echo "$TAGS_RESPONSE" | jq -r \
+            '.results[] | "\(.last_updated)|\(.name)"' \
+            | sort -r | cut -d'|' -f2)
+
+          TAG_COUNT=$(echo "$TAGS" | grep -c . || true)
+          if [ "$TAG_COUNT" -gt "$CI_IMAGE_KEEP_TAGS" ]; then
+            echo "Found $TAG_COUNT tags in ${CI_IMAGE_REPO}, keeping $CI_IMAGE_KEEP_TAGS most recent"
+            TAGS_TO_DELETE=$(echo "$TAGS" | tail -n +$((CI_IMAGE_KEEP_TAGS + 1)))
+            for tag in $TAGS_TO_DELETE; do
+              echo "Deleting ${CI_IMAGE_REPO}:${tag}"
+              curl -s -X DELETE -H "Authorization: JWT $TOKEN" \
+                "https://hub.docker.com/v2/repositories/${CI_IMAGE_REPO}/tags/${tag}/"
+            done
+          else
+            echo "Only $TAG_COUNT tags in ${CI_IMAGE_REPO}, no cleanup needed"
+          fi

--- a/.github/workflows/nightly-72-gpu-gb200.yml
+++ b/.github/workflows/nightly-72-gpu-gb200.yml
@@ -275,7 +275,13 @@ jobs:
 
   nightly-gb200-benchmark:
     needs: [setup, prepare-image]
-    if: github.repository == 'sgl-project/sglang'
+    # Use always() + explicit success checks so a skipped transitive upstream
+    # (e.g. build-image when neither pr_number nor sglang_branch is set) does
+    # not propagate a skip to this job. Direct deps must still have succeeded.
+    if: |
+      always() && github.repository == 'sgl-project/sglang'
+      && needs.setup.result == 'success'
+      && needs.prepare-image.result == 'success'
     runs-on: 72-gpu-gb200
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly-72-gpu-gb200.yml
+++ b/.github/workflows/nightly-72-gpu-gb200.yml
@@ -113,6 +113,15 @@ jobs:
       image_ref: ${{ steps.build.outputs.image_ref }}
       version_id: ${{ steps.resolve.outputs.version_id }}
     steps:
+      # Self-hosted runners retain the workspace across jobs. Prior `docker buildx`
+      # runs on this node leave root-owned build artifacts (e.g. sgl-kernel/build/)
+      # that actions/checkout cannot remove, causing EACCES on rmdir. Wipe them
+      # via a throwaway root container before checkout recreates the workspace.
+      - name: Clean workspace (remove root-owned files from prior runs)
+        run: |
+          docker run --rm -v "${{ github.workspace }}:/workspace" alpine:3 \
+            sh -c 'rm -rf /workspace/..?* /workspace/.[!.]* /workspace/*' || true
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:

--- a/scripts/ci/slurm/generate_matrix.py
+++ b/scripts/ci/slurm/generate_matrix.py
@@ -8,14 +8,17 @@ Output: JSON array written to stdout, consumed by the workflow setup job as
 a dynamic matrix via fromJson(needs.setup.outputs.matrix).
 
 Usage:
-    python3 generate_matrix.py <path-to-nightly-configs.yaml> --runner <label>
+    python3 generate_matrix.py <path-to-nightly-configs.yaml> --runner <label> [--filter NAMES]
 
 Example:
     python3 generate_matrix.py scripts/ci/slurm/nightly-configs.yaml --runner gb200
+    python3 generate_matrix.py scripts/ci/slurm/nightly-configs.yaml --runner gb200 \\
+        --filter dsr1-fp8-1k1k-max-tpt,dsr1-fp4-1k1k-mid-curve
 """
 
 import argparse
 import json
+import sys
 
 import yaml
 
@@ -34,6 +37,14 @@ def main():
         "--runner",
         required=True,
         help="Filter configs by runner label (e.g. gb200, b200)",
+    )
+    parser.add_argument(
+        "--filter",
+        default="",
+        help=(
+            "Optional comma-separated list of matrix entry names to include "
+            "(e.g. 'dsr1-fp8-1k1k-max-tpt'). Names must match exactly."
+        ),
     )
     args = parser.parse_args()
 
@@ -65,6 +76,19 @@ def main():
                         "config_file": config_file,
                     }
                 )
+
+    wanted = [n.strip() for n in args.filter.split(",") if n.strip()]
+    if wanted:
+        available = [e["name"] for e in matrix]
+        unknown = [n for n in wanted if n not in available]
+        if unknown:
+            print(
+                f"ERROR: unknown config name(s): {', '.join(unknown)}. "
+                f"Available for runner '{args.runner}': {', '.join(available)}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        matrix = [e for e in matrix if e["name"] in wanted]
 
     print(json.dumps(matrix))
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
The GB200 nightly pipeline could previously only run against published lmsysorg/sglang:dev-cu13 images. This made it impossible to:

  - Validate an unmerged PR on GB200 hardware.
  - Test a fork PR — fork contributors had no path to exercise their changes on the shared GB200 cluster.
  - Run a targeted benchmark — every manual dispatch ran the full matrix (~6 hours of cluster time), even when the tester only cared about one config.

  This PR adds three optional workflow_dispatch inputs to fix all three, with cluster access still gated by the existing gb200-ci environment (required-reviewer approval).

## Modifications

<!-- Detail the changes made in this pull request. -->
New workflow_dispatch inputs (all optional, mutually exclusive where appropriate):

| Input | Purpose |
  |---|---|
  | `pr_number` | Build a fresh ARM64/CUDA13 image from `refs/pull/<N>/head` (works for fork PRs via GitHub's virtual refs — no cross-repo auth needed) |
  | `sglang_branch` | Same flow for a branch on `sgl-project/sglang` without an open PR |
  | `configs` | Comma-separated matrix names (e.g. `dsr1-fp4-1k1k-mid-curve`) to run a subset of benchmark configs |
 
 New jobs in .github/workflows/nightly-72-gpu-gb200.yml:

  - validate-inputs — rejects conflicting inputs (e.g. image + pr_number) and non-numeric pr_number; failure halts the pipeline before cluster resources reserve
  - build-image — runs on arm-docker-build-node, builds ARM64/CUDA13 with BRANCH_TYPE=local + GRACE_BLACKWELL=1, pushes to lmsysorg/sglang-staging:<stub>-<run_id>-<run_attempt>
  - cleanup-image — retains the last 60 recent tags and deleted the older ones from lmsysorg/sglang-staging

Supporting changes:

  - prepare-image — chooses between the built image and a pre-existing image
  - setup — depends on validate-inputs; prints all available config names to the log so typos can be corrected on the next dispatch
  - scripts/ci/slurm/generate_matrix.py — new --filter flag; errors with a listing of valid names when an unknown name is supplied
  - Pre-checkout workspace-cleanup step on build-image to handle root-owned leftovers from prior self-hosted-runner jobs
  - Checkout verification step prints commit SHA, author, date, and cross-check links (PR commits page or branch commits page) right after checkout

  Nightly cron run is unaffected — new inputs default to empty; the cron path still produces exactly the same matrix against lmsysorg/sglang:dev-cu13 as before.


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
https://github.com/sgl-project/sglang/actions/runs/24576077428
https://github.com/sgl-project/sglang/actions/runs/24548042952
https://github.com/sgl-project/sglang/actions/runs/24791666471

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
