### PR TITLE
[codex] diffusion: fuse ERNIE scale shift

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/dits/ernie_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/ernie_image.py
@@ -19,6 +19,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from diffusers.models.embeddings import TimestepEmbedding, Timesteps
 
+from sglang.jit_kernel.diffusion.triton.scale_shift import fuse_scale_shift_kernel
 from sglang.multimodal_gen.configs.models.dits.ernie_image import (
     ErnieImageDitConfig,
 )
@@ -241,11 +242,11 @@ class ErnieImageSharedAdaLNBlock(nn.Module):
         gate_mlp: torch.Tensor,
     ) -> torch.Tensor:
         residual = x
-        x = self.adaLN_sa_ln(x) * (1 + scale_msa) + shift_msa
+        x = fuse_scale_shift_kernel(self.adaLN_sa_ln(x), scale_msa, shift_msa)
         x = residual + gate_msa * self.self_attention(x, rotary_pos_emb)
 
         residual = x
-        x = self.adaLN_mlp_ln(x) * (1 + scale_mlp) + shift_mlp
+        x = fuse_scale_shift_kernel(self.adaLN_mlp_ln(x), scale_mlp, shift_mlp)
         x = residual + gate_mlp * self.mlp(x)
 
         return x
@@ -463,7 +464,9 @@ class ErnieImageTransformer2DModel(CachableDiT, OffloadableDiTMixin):
             )
 
         scale, shift = self.final_norm["linear"](c).chunk(2, dim=-1)
-        x = self.final_norm["norm"](x) * (1 + scale.unsqueeze(1)) + shift.unsqueeze(1)
+        x = fuse_scale_shift_kernel(
+            self.final_norm["norm"](x), scale.unsqueeze(1), shift.unsqueeze(1)
+        )
 
         patches, _ = self.final_linear(x[:, :N_img, :])
 


### PR DESCRIPTION
## What

Use the existing Triton `fuse_scale_shift_kernel` for ERNIE-Image SharedAdaLN scale/shift modulation and final norm modulation.

## Why

The ERNIE DiT hot path currently materializes `norm(x) * (1 + scale) + shift` as separate elementwise ops. Reusing the existing diffusion fused scale/shift kernel is a small, contained kernel optimization.

## H100 Perf

Benchmark: H100 80GB, ERNIE-Image-Turbo, 512x512, 10 steps, `use_pe=false`, warmup enabled, native SGLang backend. Perf/image artifacts were generated for validation and are shown here, but the generated PNG/JSON files are not committed in this PR.

| metric | before | after | delta |
|---|---:|---:|---:|
| total request | 777.118 ms | 751.123 ms | -3.34% |
| text encoding | 20.015 ms | 20.065 ms | +0.25% |
| denoising | 746.346 ms | 719.968 ms | -3.53% |
| avg denoise step | 74.391 ms | 71.657 ms | -3.68% |
| peak allocated | 31557.84 MB | 31557.84 MB | +0.00 MB |
| wall time | 35 s | 37 s | +2 s |

## Result Images

Before:

![before](https://raw.githubusercontent.com/BBuf/sglang/877cb19252134ed7fa4db1d16fdcb8c095f2990d/docs/assets/benchmarks/ernie_scale_shift/before.png)

After:

![after](https://raw.githubusercontent.com/BBuf/sglang/877cb19252134ed7fa4db1d16fdcb8c095f2990d/docs/assets/benchmarks/ernie_scale_shift/after.png)

## Checks

- H100: `PYTHONPATH=python python -c 'from sglang.multimodal_gen.runtime.models.dits.ernie_image import ErnieImageSharedAdaLNBlock'` -> ok
- H100: `sglang generate` ERNIE-Image-Turbo before/after, recorded perf metrics and result images
- Format: project pre-commit hooks on changed code file -> passed
