### PR TITLE
[docker] Fix stray backslash dropping sgl-model-gateway COPY

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -623,7 +623,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     done; [ "$success" = "1" ] ) \
     && mkdir -p /root/.cache/sglang \
     && mv python/kernels.lock /root/.cache/sglang/ \
-    && find /usr/local/lib/python3.12/dist-packages -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true \
+    && find /usr/local/lib/python3.12/dist-packages -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
 
 
 # Install pre-built gateway artifacts from parallel builder


### PR DESCRIPTION
## Summary
- Remove a stray trailing backslash in `docker/Dockerfile` (line 626) that was silently consuming the subsequent `COPY --from=gateway_builder /build/sgl-model-gateway-bin /usr/local/bin/sgl-model-gateway` as shell tokens appended to the preceding `RUN`.
- Because the RUN ended with `|| true \`, the shell error was masked; `framework_final` built successfully but without the gateway binary, causing the later `runtime` stage COPY to fail.

## Failure Signature
BuildKit warned: `NoEmptyContinuation: Empty continuation line (line 630)`.

Build error:
```
COPY --from=framework_final /usr/local/bin/sgl-model-gateway /usr/local/bin/sgl-model-gateway:
ERROR: failed to calculate checksum of ref ...: "/usr/local/bin/sgl-model-gateway": not found
```

In the BuildKit trace you can see the RUN literally ended with:
```
... || true COPY --from=gateway_builder /build/sgl-model-gateway-bin /usr/local/bin/sgl-model-gateway
```
confirming the COPY was swallowed into the RUN.

## Fix
Drop the trailing backslash so the `RUN` terminates and both gateway `COPY --from=gateway_builder ...` instructions are honored as real Dockerfile directives.

## Test plan
- [ ] `docker build` of the full Dockerfile (runtime target) completes without the `sgl-model-gateway: not found` checksum error.
- [ ] Resulting runtime image contains `/usr/local/bin/sgl-model-gateway` and `sgl-router` Python bindings installed from `/build/gateway_wheels`.
- [ ] BuildKit no longer emits the `NoEmptyContinuation` warning for this line.