### PR TITLE
Lower TestPiecewiseCudaGraphQwen25VL gsm8k threshold to 0.80

### DIFF
--- a/test/registered/piecewise_cuda_graph/test_piecewise_cuda_graph_support_1_gpu.py
+++ b/test/registered/piecewise_cuda_graph/test_piecewise_cuda_graph_support_1_gpu.py
@@ -53,7 +53,7 @@ class TestPiecewiseCudaGraphQwen25VL(CustomTestCase):
         metrics = run_eval(args)
         print(f"GSM8K Accuracy: {metrics['score']:.3f}")
 
-        self.assertGreaterEqual(metrics["score"], 0.82)
+        self.assertGreaterEqual(metrics["score"], 0.80)
 
 
 class TestPiecewiseCudaGraphInternVL25(CustomTestCase):


### PR DESCRIPTION
Lower the GSM8K accuracy threshold for `TestPiecewiseCudaGraphQwen25VL::test_gsm8k_accuracy` from `0.82` to `0.80`.

The current threshold sits right on the edge of the test's natural variance, causing flaky failures on scheduled CI.

## Data (scheduled CI, 2026-04-03 to 2026-04-17, 27 valid runs)

| Stat | All runs | Fail only |
|---|---|---|
| min | 0.807 | 0.807 |
| median | 0.822 | — |
| mean | 0.821 | 0.814 |
| max | 0.828 | 0.819 |

- **Failure rate**: 4/27 = 14.8%
- **Failure scores**: [0.811, 0.817, 0.807, 0.819] — all narrow misses, max 1.3 pp below 0.82
- Failure band [0.807, 0.819] overlaps with pass band [0.820, 0.828] -- the threshold is inside the test's natural variance

Threshold 0.80 gives ~0.7 pp margin below observed worst case (0.807) while still catching real regressions.