### PR TITLE
Apply HF transformers patches from sglang init

### DIFF
--- a/python/sglang/__init__.py
+++ b/python/sglang/__init__.py
@@ -24,6 +24,11 @@ if _sys.platform == "darwin":
         pass
 del _sys
 
+from sglang.srt.utils.hf_transformers_patches import apply_all as _apply_hf_patches
+
+_apply_hf_patches()
+del _apply_hf_patches
+
 # Frontend Language APIs
 from sglang.global_config import global_config
 from sglang.lang.api import (

--- a/python/sglang/srt/utils/hf_transformers/__init__.py
+++ b/python/sglang/srt/utils/hf_transformers/__init__.py
@@ -14,18 +14,16 @@
 """Hugging Face Transformers utilities.
 
 This package provides HF Transformers helpers, split into submodules
-(common, compat, config, tokenizer, processor, mistral_utils).
+(common, config, tokenizer, processor, mistral_utils).  Compatibility
+monkey-patches live in the sibling ``sglang.srt.utils.hf_transformers_patches``
+module and are applied at sglang import time.
 All public symbols are re-exported here for convenience.  The old import
 path ``sglang.srt.utils.hf_transformers_utils`` is preserved by a
 separate shim module.
 """
 
-from ..hf_transformers_patches import apply_all as _apply_hf_patches
-
-_apply_hf_patches()
-
-from ..hf_transformers_patches import normalize_rope_scaling_compat  # noqa: E402
-from .common import (  # noqa: E402
+from ..hf_transformers_patches import normalize_rope_scaling_compat
+from .common import (
     CONTEXT_LENGTH_KEYS,
     AutoConfig,
     attach_additional_stop_token_ids,
@@ -38,9 +36,9 @@ from .common import (  # noqa: E402
     get_sparse_attention_config,
     get_tokenizer_from_processor,
 )
-from .config import get_config  # noqa: E402
-from .processor import get_processor  # noqa: E402
-from .tokenizer import (  # noqa: E402
+from .config import get_config
+from .processor import get_processor
+from .tokenizer import (
     _fix_added_tokens_encoding,
     _fix_v5_add_bos_eos_token,
     get_tokenizer,

--- a/python/sglang/srt/utils/hf_transformers/__init__.py
+++ b/python/sglang/srt/utils/hf_transformers/__init__.py
@@ -20,10 +20,11 @@ path ``sglang.srt.utils.hf_transformers_utils`` is preserved by a
 separate shim module.
 """
 
-from .compat import apply_all as _apply_compat
+from ..hf_transformers_patches import apply_all as _apply_hf_patches
 
-_apply_compat()
+_apply_hf_patches()
 
+from ..hf_transformers_patches import normalize_rope_scaling_compat  # noqa: E402
 from .common import (  # noqa: E402
     CONTEXT_LENGTH_KEYS,
     AutoConfig,
@@ -37,7 +38,6 @@ from .common import (  # noqa: E402
     get_sparse_attention_config,
     get_tokenizer_from_processor,
 )
-from .compat import normalize_rope_scaling_compat  # noqa: E402
 from .config import get_config  # noqa: E402
 from .processor import get_processor  # noqa: E402
 from .tokenizer import (  # noqa: E402

--- a/python/sglang/srt/utils/hf_transformers/common.py
+++ b/python/sglang/srt/utils/hf_transformers/common.py
@@ -52,7 +52,7 @@ from sglang.srt.configs.deepseek_ocr import DeepseekVLV2Config
 from sglang.srt.configs.internvl import InternVLChatConfig
 from sglang.srt.utils import get_bool_env_var, logger, lru_cache_frozenset
 
-from .compat import normalize_rope_scaling_compat
+from ..hf_transformers_patches import normalize_rope_scaling_compat
 
 if get_bool_env_var("SGLANG_USE_MODELSCOPE"):
     from modelscope import AutoConfig, GenerationConfig

--- a/python/sglang/srt/utils/hf_transformers/config.py
+++ b/python/sglang/srt/utils/hf_transformers/config.py
@@ -23,6 +23,7 @@ from sglang.srt.connector import create_remote_connector
 from sglang.srt.utils import is_remote_url, logger, lru_cache_frozenset
 from sglang.srt.utils.runai_utils import ObjectStorageModel, is_runai_obj_uri
 
+from ..hf_transformers_patches import _ensure_gguf_version
 from .common import (
     _CONFIG_REGISTRY,
     AutoConfig,
@@ -34,7 +35,6 @@ from .common import (
     check_gguf_file,
     get_hf_text_config,
 )
-from .compat import _ensure_gguf_version
 from .mistral_utils import is_mistral_model, load_mistral_config
 
 

--- a/python/sglang/srt/utils/hf_transformers/tokenizer.py
+++ b/python/sglang/srt/utils/hf_transformers/tokenizer.py
@@ -30,12 +30,12 @@ from sglang.srt.utils import is_remote_url, logger
 from sglang.srt.utils.patch_tokenizer import patch_tokenizer
 from sglang.srt.utils.runai_utils import ObjectStorageModel, is_runai_obj_uri
 
+from ..hf_transformers_patches import _ensure_gguf_version
 from .common import (
     _resolve_local_or_cached_file,
     attach_additional_stop_token_ids,
     check_gguf_file,
 )
-from .compat import _ensure_gguf_version, patch_is_base_mistral_in_ci
 from .mistral_utils import (
     _MISTRAL_TOKENIZER_REDIRECTS,
     patch_mistral_common_tokenizer,
@@ -462,7 +462,6 @@ def get_tokenizer(
             kwargs["use_fast"] = True
 
     tokenizer_name = _resolve_tokenizer_name(tokenizer_name, kwargs)
-    patch_is_base_mistral_in_ci()
 
     common_kwargs = dict(
         trust_remote_code=trust_remote_code,

--- a/python/sglang/srt/utils/hf_transformers_patches.py
+++ b/python/sglang/srt/utils/hf_transformers_patches.py
@@ -11,21 +11,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Compatibility patches for transformers v5.x.
+"""Monkey-patches on transformers internals.
 
-This module applies monkey-patches to work around breaking changes in
-transformers v5.  Each patch is tagged with the upstream issue it works
-around so it can be removed once the upstream fix lands.
+Mix of backward-compat shims (re-add symbols removed in v5), workarounds
+for transformers v5 bugs, fixes for remote-model-code (trust_remote_code)
+that hasn't been updated for v5 yet, and CI-only patches (e.g. neutralize
+HF API calls to avoid rate limits).
 
 Import this module early (before any ``from_pretrained`` call) to activate
 all patches.  It is safe to import multiple times -- patches are idempotent.
-
-Patches fall into two categories:
-
-1. **Transformers bugs / regressions** -- issues in transformers itself.
-2. **Remote-model-code compat** -- remote model code (trust_remote_code)
-   that hasn't been updated for v5 yet.  These should be removed once
-   the model authors publish fixes.
 """
 
 import inspect
@@ -44,9 +38,18 @@ def apply_all():
     """Apply all transformers compatibility patches (idempotent).
 
     Call this once at import time.  It is safe to call multiple times.
+
+    No-op when the ``transformers`` package is not installed -- frontend-only
+    sglang users should not be forced to install transformers just to import
+    the top-level ``sglang`` package.
     """
     global _applied
     if _applied:
+        return
+    try:
+        import transformers  # noqa: F401
+    except ImportError:
+        _applied = True
         return
     _applied = True
 
@@ -61,6 +64,9 @@ def apply_all():
     # v5 general patches
     _ensure_clean_up_tokenization_compat()
     _ensure_is_torch_fx_available_compat()
+
+    # CI-only: neutralize HF API calls inside tokenizer from_pretrained
+    patch_is_base_mistral_in_ci()
 
     logger.debug("transformers compatibility patches applied")
 

--- a/test/registered/unit/utils/test_hf_transformers.py
+++ b/test/registered/unit/utils/test_hf_transformers.py
@@ -20,8 +20,8 @@ from sglang.srt.utils.hf_transformers.common import (
     get_hf_text_config,
     get_rope_config,
 )
-from sglang.srt.utils.hf_transformers.compat import normalize_rope_scaling_compat
 from sglang.srt.utils.hf_transformers.tokenizer import _fix_special_tokens_pattern
+from sglang.srt.utils.hf_transformers_patches import normalize_rope_scaling_compat
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=5, suite="stage-a-test-cpu")


### PR DESCRIPTION
## Summary
- Apply transformers monkey-patches at `sglang` import time (instead of lazy on first `get_tokenizer` call) so every `AutoTokenizer.from_pretrained` path is covered
- Move `hf_transformers/compat.py` to sibling `hf_transformers_patches.py` so eager apply avoids dragging the full `hf_transformers` subpackage (common/tokenizer/processor) into `sglang/__init__.py`
- Add `patch_is_base_mistral_in_ci` to `apply_all()` and drop the redundant late calls in `hf_transformers/__init__.py` and `tokenizer.py`

## Background
- transformers 5.5 added `PreTrainedTokenizerFast._patch_mistral_regex`, which unconditionally calls `is_base_mistral` → `model_info(model_id)` → HF API on every `AutoTokenizer.from_pretrained` (regardless of whether the model is Mistral or cached locally)
- After #21569 bumped transformers to 5.5.3, CI started hitting HF's `3000 req / 5min` team quota across parallel jobs → 429s in `test_hicache_variants`, `test_hicache_storage_file_backend`, etc.
- Previous patch (#21586, #21729) neutralized `_patch_mistral_regex` but only inside `sglang.srt.utils.hf_transformers.get_tokenizer`. Paths like `sglang.benchmark.utils.get_tokenizer` (used by hicache tests) and the ~20 other callers of `AutoTokenizer.from_pretrained` directly bypassed it

## Fix
- Call `apply_all()` from `sglang/__init__.py` so the patch takes effect as soon as anything imports `sglang` (covers all downstream `from_pretrained` calls)
- `apply_all()` gates on `try: import transformers` and no-ops when transformers is missing, preserving frontend-only installs
- Rename `hf_transformers/compat.py` → `hf_transformers_patches.py` (sibling of the subpackage) so the eager import doesn't pull in `common/tokenizer/processor` (which import transformers at module top); updates internal `from .compat` imports accordingly

Fixes CI HF 429 rate-limit regression after #21569.
