### PR TITLE
Fix #22693: [Feature] Relax `tool-call-parser` validation for nullabl...

### DIFF
--- a/python/sglang/srt/function_call/function_call_parser.py
+++ b/python/sglang/srt/function_call/function_call_parser.py
@@ -35,6 +35,7 @@ from sglang.srt.function_call.step3_detector import Step3Detector
 from sglang.srt.function_call.trinity_detector import TrinityDetector
 from sglang.srt.function_call.utils import (
     _get_tool_schema_defs,
+    _sanitize_tool_parameters_schema,
     get_json_schema_constraint,
 )
 
@@ -182,7 +183,11 @@ class FunctionCallParser:
             is_strict = (
                 function.strict or self.tool_strict_level >= ToolStrictLevel.PARAMETER
             )
-            schema = function.parameters if is_strict else {}
+            schema = (
+                _sanitize_tool_parameters_schema(function.parameters)
+                if is_strict and function.parameters
+                else {}
+            )
 
             tool_structures.append(
                 StructuresResponseFormat(

--- a/python/sglang/srt/function_call/utils.py
+++ b/python/sglang/srt/function_call/utils.py
@@ -76,26 +76,54 @@ def _get_tool_schema_defs(tools: List[Tool]) -> dict:
             continue
         defs = tool.function.parameters.get("$defs", {})
         for def_name, def_schema in defs.items():
-            if def_name in all_defs and all_defs[def_name] != def_schema:
+            sanitized_schema = _sanitize_tool_parameters_schema(def_schema)
+            if def_name in all_defs and all_defs[def_name] != sanitized_schema:
                 raise ValueError(
                     f"Tool definition '{def_name}' has "
                     "multiple schemas, which is not "
                     "supported."
                 )
             else:
-                all_defs[def_name] = def_schema
+                all_defs[def_name] = sanitized_schema
     return all_defs
 
 
+_NULLABLE_ARRAY_SCHEMA_FIELDS = frozenset(
+    {"required", "enum", "allOf", "anyOf", "oneOf"}
+)
+
+
+def _sanitize_tool_parameters_schema(schema: Any) -> Any:
+    """Normalize a user-provided JSON Schema so grammar backends can compile it.
+
+    Some clients send array-typed JSON Schema fields (e.g. ``required``) with
+    a ``null`` value to mean "no entries". JSON Schema requires these fields
+    to be arrays, so strict validators such as the one used by xgrammar reject
+    the whole tool call. Other inference engines (e.g. vLLM) silently tolerate
+    this shape; this helper brings sglang in line by dropping such
+    ``null``-valued fields so the schema's default (empty) semantics apply.
+    """
+    if isinstance(schema, dict):
+        return {
+            key: _sanitize_tool_parameters_schema(value)
+            for key, value in schema.items()
+            if not (key in _NULLABLE_ARRAY_SCHEMA_FIELDS and value is None)
+        }
+    if isinstance(schema, list):
+        return [_sanitize_tool_parameters_schema(item) for item in schema]
+    return schema
+
+
 def _get_tool_schema(tool: Tool) -> dict:
+    parameters = tool.function.parameters
+    if parameters:
+        parameters = _sanitize_tool_parameters_schema(parameters)
+    else:
+        parameters = {"type": "object", "properties": {}}
     return {
         "properties": {
             "name": {"type": "string", "enum": [tool.function.name]},
-            "parameters": (
-                tool.function.parameters
-                if tool.function.parameters
-                else {"type": "object", "properties": {}}
-            ),
+            "parameters": parameters,
         },
         "required": ["name", "parameters"],
     }

--- a/test/registered/unit/function_call/test_json_schema_constraint.py
+++ b/test/registered/unit/function_call/test_json_schema_constraint.py
@@ -622,5 +622,74 @@ class TestJsonSchemaConstraint(unittest.TestCase):
         self.assertIn("UnusedType", schema["$defs"])
 
 
+    def test_required_null_is_dropped(self):
+        """`required: null` from lenient clients must not reach the grammar backend.
+
+        Some clients (matching vLLM's permissive behavior) send ``required: null``
+        to mean "no required fields". JSON Schema requires ``required`` to be an
+        array, so strict validators such as xgrammar reject the whole tool call.
+        sglang should normalize this to the default (empty) semantics so the
+        tool call still works. See sgl-project/sglang#22693.
+        """
+        tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_current_weather",
+                    description="Get the current weather in a given location",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "location": {"type": "string"},
+                            "unit": {"type": "string"},
+                        },
+                        "required": None,
+                    },
+                ),
+            ),
+        ]
+
+        schema = get_json_schema_constraint(tools, "required")
+        self.assertIsNotNone(schema)
+        # Should no longer contain a null `required` anywhere — otherwise the
+        # next stop (xgrammar) would raise on schema compilation.
+        jsonschema.Draft202012Validator.check_schema(schema)
+
+        params = schema["items"]["anyOf"][0]["properties"]["parameters"]
+        self.assertNotIn("required", params)
+
+    def test_nested_required_null_is_dropped(self):
+        """`required: null` inside nested subschemas must also be normalized."""
+        tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="nested_tool",
+                    description="Nested schema with required: null inside $defs",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "user": {"$ref": "#/$defs/User"},
+                        },
+                        "required": ["user"],
+                        "$defs": {
+                            "User": {
+                                "type": "object",
+                                "properties": {"name": {"type": "string"}},
+                                "required": None,
+                            },
+                        },
+                    },
+                ),
+            ),
+        ]
+
+        schema = get_json_schema_constraint(tools, "required")
+        self.assertIsNotNone(schema)
+        jsonschema.Draft202012Validator.check_schema(schema)
+        user_def = schema["$defs"]["User"]
+        self.assertNotIn("required", user_def)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes #22693. Some OpenAI-compatible clients (matching vLLM's permissive behavior) send JSON Schema fields such as `required` with a value of `null` to mean "no required fields". Strict validators — including the one used by xgrammar when compiling tool call constraints — reject the whole schema and the tool call is aborted with a validation error. sglang currently propagates user-supplied `tool.function.parameters` directly into the grammar backend, so any such request fails.

## The fix

Normalize user-provided tool parameter schemas by recursively stripping `null`-valued array-typed fields (`required`, `enum`, `allOf`, `anyOf`, `oneOf`) before the schema is handed to the grammar backend. The default semantics of these fields when absent are exactly what `null` was meant to encode ("no entries"), so dropping them is a safe, minimal normalization.

Applied in all three call sites that forward the raw user schema:

- `_get_tool_schema` — used for `tool_choice=\"required\"` / named tool choice JSON schema constraints.
- `_get_tool_schema_defs` — applied to `\$defs` entries too, so the same shape inside nested subschemas is normalized.
- `FunctionCallParser.get_structure_tag` — used when a structural-tag-capable detector attaches the user schema in strict mode.

## Why this matches vLLM

The reporter noted that the same LangChain request (which ends up with `required: null`) completes fine against vLLM. vLLM's schema normalization similarly drops invalid/null-valued keywords before constraint compilation. This change brings sglang's tool-call-parser to the same level of client-compatibility without changing behavior for well-formed schemas.

## Tests

Added two unit tests in `test/registered/unit/function_call/test_json_schema_constraint.py`:

- `test_required_null_is_dropped` — covers the exact reproducer from the issue (`required: null` at the top level of `parameters`). Asserts the generated schema now passes `Draft202012Validator.check_schema` and no longer contains a `required` key.
- `test_nested_required_null_is_dropped` — covers `required: null` inside a `\$defs` subschema.

All existing tests in the file continue to pass locally.