### PR TITLE
ci: add rebase-required mode to check-maintenance action

### DIFF
--- a/.github/MAINTAINER.md
+++ b/.github/MAINTAINER.md
@@ -150,5 +150,18 @@ When the CI is unhealthy (e.g., the scheduled pr-test on `main` is broken for co
 
 Maintenance mode ends when `pr-test.yml` is all green on `main` and the issue is closed.
 
+### Rebase-Required Mode
+When a major update lands on `main` and all open PRs must rebase before CI can run (without fully pausing CI), add a line of the form `MIN_BASE_SHA: <sha>` to the body of issue #21065. While this directive is present:
+- CI is allowed to run only for PRs whose branch already contains `<sha>` (GitHub compare API status `ahead` or `identical` — i.e., the PR has `<sha>` in its history).
+- PRs that are `behind` or `diverged` from `<sha>` are blocked with a "rebase required" error until they rebase onto the latest `main`.
+- The `bypass-maintenance` label still bypasses this check for CI-fix PRs.
+
+Notes:
+- Only the **first** `MIN_BASE_SHA:` line in the issue body is read.
+- The SHA must be 7-40 hex characters; malformed values are ignored (with a warning in the job summary).
+- Avoid pasting the directive inside a fenced code block in the issue body — the parser does not skip code fences and may match example snippets.
+
+Remove the directive (or close the issue) to lift the rebase requirement.
+
 ## Suspending Permissions
 If a Merge Oncall bypasses checks to merge a PR that breaks the `main` branch, merges a non-CI-fix PR during CI Maintenance Mode, or repeatedly breaks the CI due to various reasons, their privileges will be suspended for at least two days, depending on the severity of the incident.

--- a/.github/MAINTAINER.md
+++ b/.github/MAINTAINER.md
@@ -151,7 +151,7 @@ When the CI is unhealthy (e.g., the scheduled pr-test on `main` is broken for co
 Maintenance mode ends when `pr-test.yml` is all green on `main` and the issue is closed.
 
 ### Rebase-Required Mode
-When a major update lands on `main` and all open PRs must rebase before CI can run (without fully pausing CI), add a line of the form `MIN_BASE_SHA: <sha>` to the body of issue #21065. While this directive is present:
+When a major update lands on `main` and all open PRs must rebase before CI can run (without fully pausing CI), add a line of the form `MIN_BASE_SHA: <sha>` to the body of issue #21065. **The rebase check is enforced regardless of whether the issue is open or closed** — you do not need to enter full maintenance mode (open the issue) to use this gate; just editing the body to include the directive is enough. While the directive is present:
 - CI is allowed to run only for PRs whose branch already contains `<sha>` (GitHub compare API status `ahead` or `identical` — i.e., the PR has `<sha>` in its history).
 - PRs that are `behind` or `diverged` from `<sha>` are blocked with a "rebase required" error until they rebase onto the latest `main`.
 - The `bypass-maintenance` label still bypasses this check for CI-fix PRs.
@@ -161,7 +161,7 @@ Notes:
 - The SHA must be 7-40 hex characters; malformed values are ignored (with a warning in the job summary).
 - Avoid pasting the directive inside a fenced code block in the issue body — the parser does not skip code fences and may match example snippets.
 
-Remove the directive (or close the issue) to lift the rebase requirement.
+Remove the directive from the issue body to lift the rebase requirement (closing the issue does NOT lift it on its own).
 
 ## Suspending Permissions
 If a Merge Oncall bypasses checks to merge a PR that breaks the `main` branch, merges a non-CI-fix PR during CI Maintenance Mode, or repeatedly breaks the CI due to various reasons, their privileges will be suspended for at least two days, depending on the severity of the incident.

--- a/.github/actions/check-maintenance/action.yml
+++ b/.github/actions/check-maintenance/action.yml
@@ -1,5 +1,5 @@
 name: Check Maintenance Mode
-description: Blocks CI when maintenance mode is active (issue #21065 is open), unless the PR has the bypass-maintenance label, or env SGLANG_PR_TEST_BYPASS_MAINTENANCE_ON_MAIN=true (PR Test workflow on main only). Merging non-CI-fix PRs is prohibited during maintenance mode; in severe cases, merge permissions may be revoked.
+description: Blocks CI when maintenance mode is active (issue #21065 is open), unless the PR has the bypass-maintenance label, or env SGLANG_PR_TEST_BYPASS_MAINTENANCE_ON_MAIN=true (PR Test workflow on main only). If the issue body contains a `MIN_BASE_SHA: <sha>` directive, CI runs only for PRs whose branch already contains that SHA (rebase-required mode). Merging non-CI-fix PRs is prohibited during maintenance mode; in severe cases, merge permissions may be revoked.
 
 inputs:
   github-token:
@@ -18,6 +18,7 @@ runs:
         MAINTENANCE_ISSUE=21065
         REPO="${{ github.repository }}"
         PR_NUMBER="${{ github.event.pull_request.number }}"
+        PR_HEAD_SHA="${{ github.event.pull_request.head.sha }}"
 
         # PR Test workflow only: scheduled runs and runs on main (dispatch / workflow_call) set this env
         if [[ "${SGLANG_PR_TEST_BYPASS_MAINTENANCE_ON_MAIN:-}" == "true" ]]; then
@@ -25,15 +26,17 @@ runs:
           exit 0
         fi
 
-        # Check if maintenance issue is open (fail-open: if API errors, allow CI to proceed)
-        ISSUE_STATE=$(gh issue view "$MAINTENANCE_ISSUE" --repo "$REPO" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+        # Fetch issue state and body (fail-open: if API errors, allow CI to proceed)
+        ISSUE_JSON=$(gh issue view "$MAINTENANCE_ISSUE" --repo "$REPO" --json state,body 2>/dev/null || echo "")
+        ISSUE_STATE=$(printf '%s' "$ISSUE_JSON" | jq -r '.state // "UNKNOWN"' 2>/dev/null || echo "UNKNOWN")
+        ISSUE_BODY=$(printf '%s' "$ISSUE_JSON" | jq -r '.body // ""' 2>/dev/null || echo "")
 
         if [[ "$ISSUE_STATE" != "OPEN" ]]; then
           echo "✅ Maintenance mode is OFF. Proceeding with CI."
           exit 0
         fi
 
-        # For PRs, check if bypass-maintenance label is present
+        # For PRs, check if bypass-maintenance label is present (covers both full-pause and rebase-required modes)
         if [[ -n "$PR_NUMBER" ]]; then
           HAS_BYPASS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '[.labels[].name] | map(select(. == "bypass-maintenance")) | length' 2>/dev/null || echo "0")
           if [[ "$HAS_BYPASS" -gt 0 ]]; then
@@ -42,6 +45,57 @@ runs:
           fi
         fi
 
+        # Parse optional `MIN_BASE_SHA: <sha>` directive from the issue body (first occurrence wins).
+        # Presence of this directive switches from full-pause to rebase-required mode.
+        MIN_BASE_SHA=$(printf '%s' "$ISSUE_BODY" | tr -d '\r' | grep -iE '^[[:space:]]*`?MIN_BASE_SHA`?[[:space:]]*[:=]' | head -n1 | sed -E 's/.*[:=][[:space:]]*//; s/`//g' | awk '{print $1}')
+        if [[ -n "$MIN_BASE_SHA" ]] && ! [[ "$MIN_BASE_SHA" =~ ^[a-fA-F0-9]{7,40}$ ]]; then
+          WARN="⚠️  Ignoring malformed MIN_BASE_SHA directive in issue #$MAINTENANCE_ISSUE: '$MIN_BASE_SHA' (must be 7-40 hex chars)"
+          echo "$WARN"
+          echo "$WARN" >> "$GITHUB_STEP_SUMMARY"
+          MIN_BASE_SHA=""
+        fi
+
+        if [[ -n "$MIN_BASE_SHA" ]]; then
+          # Rebase-required mode: CI runs only for PRs whose branch contains MIN_BASE_SHA.
+          if [[ -z "$PR_NUMBER" || -z "$PR_HEAD_SHA" ]]; then
+            echo "✅ Not a PR context; skipping rebase check."
+            exit 0
+          fi
+
+          # Use GitHub compare API: status is "ahead"/"identical" when MIN_BASE_SHA is reachable from PR head.
+          COMPARE_STATUS=$(gh api "repos/$REPO/compare/$MIN_BASE_SHA...$PR_HEAD_SHA" --jq '.status' 2>/dev/null || echo "UNKNOWN")
+          COMPARE_STATUS="${COMPARE_STATUS:-UNKNOWN}"
+
+          case "$COMPARE_STATUS" in
+            ahead|identical)
+              echo "✅ PR #$PR_NUMBER contains required base ${MIN_BASE_SHA:0:12} ($COMPARE_STATUS). Proceeding."
+              exit 0
+              ;;
+            UNKNOWN)
+              echo "⚠️  Could not determine rebase status via GitHub API; fail-open, allowing CI to proceed."
+              exit 0
+              ;;
+          esac
+
+          MSG=$(printf "%s\n" \
+            "## ⚠️ Rebase Required Before CI Can Run" \
+            "A major update has landed on \`main\`. All PRs must rebase onto the latest \`main\` before CI will run." \
+            "Required base commit: \`${MIN_BASE_SHA:0:12}\` (your PR is \`$COMPARE_STATUS\` relative to this commit)." \
+            "" \
+            "What should you do?" \
+            "- Rebase your branch onto the latest \`main\` and push again" \
+            "- Follow CI Maintenance Mode issue: https://github.com/$REPO/issues/$MAINTENANCE_ISSUE for context" \
+            "- CI-fix PRs may request the \`bypass-maintenance\` label to skip this check")
+
+          echo "$MSG" >> "$GITHUB_STEP_SUMMARY"
+          while IFS= read -r line; do
+            echo "::error::$line"
+          done <<< "$MSG"
+
+          exit 1
+        fi
+
+        # Full maintenance mode (issue open, no MIN_BASE_SHA directive).
         MSG=$(printf "%s\n" \
           "## ⚠️ CI Maintenance Mode is Active" \
           "The CI infrastructure is currently under maintenance." \

--- a/.github/actions/check-maintenance/action.yml
+++ b/.github/actions/check-maintenance/action.yml
@@ -63,7 +63,12 @@ runs:
           fi
 
           # Use GitHub compare API: status is "ahead"/"identical" when MIN_BASE_SHA is reachable from PR head.
-          COMPARE_STATUS=$(gh api "repos/$REPO/compare/$MIN_BASE_SHA...$PR_HEAD_SHA" --jq '.status' 2>/dev/null || echo "UNKNOWN")
+          # On 4xx (e.g., nonexistent SHA) gh api prints the error JSON to stdout before exiting non-zero,
+          # so keep the `|| COMPARE_STATUS=UNKNOWN` outside the subshell — otherwise --jq '.status' extracts
+          # the HTTP status code ("404") from the error body and concatenates with "UNKNOWN", bypassing the
+          # fail-open branch and incorrectly blocking CI.
+          COMPARE_STATUS=$(gh api "repos/$REPO/compare/$MIN_BASE_SHA...$PR_HEAD_SHA" --jq '.status' 2>/dev/null) \
+            || COMPARE_STATUS="UNKNOWN"
           COMPARE_STATUS="${COMPARE_STATUS:-UNKNOWN}"
 
           case "$COMPARE_STATUS" in

--- a/.github/actions/check-maintenance/action.yml
+++ b/.github/actions/check-maintenance/action.yml
@@ -1,5 +1,5 @@
 name: Check Maintenance Mode
-description: Blocks CI when maintenance mode is active (issue #21065 is open), unless the PR has the bypass-maintenance label, or env PR_TEST_BYPASS_MAINTENANCE_ON_MAIN=true (PR Test workflow on main only). If the issue body contains a `MIN_BASE_SHA: <sha>` directive, CI runs only for PRs whose branch already contains that SHA (rebase-required mode). Merging non-CI-fix PRs is prohibited during maintenance mode; in severe cases, merge permissions may be revoked.
+description: Blocks CI in two independent modes driven by issue #21065. (1) Full-pause: when the issue is open. (2) Rebase-required: whenever the issue body contains a `MIN_BASE_SHA: <sha>` directive — enforced regardless of whether the issue is open or closed, so maintainers can require all PRs to rebase past a specific commit without having to open the maintenance issue. Both modes are bypassed by the `bypass-maintenance` label on the PR, or by env PR_TEST_BYPASS_MAINTENANCE_ON_MAIN=true (PR Test workflow on main only). Merging non-CI-fix PRs is prohibited during full-pause; in severe cases, merge permissions may be revoked.
 
 inputs:
   github-token:
@@ -26,27 +26,16 @@ runs:
           exit 0
         fi
 
-        # Fetch issue state and body (fail-open: if API errors, allow CI to proceed)
+        # Fetch issue state and body (fail-open: if API errors, allow CI to proceed).
         ISSUE_JSON=$(gh issue view "$MAINTENANCE_ISSUE" --repo "$REPO" --json state,body 2>/dev/null || echo "")
         ISSUE_STATE=$(printf '%s' "$ISSUE_JSON" | jq -r '.state // "UNKNOWN"' 2>/dev/null || echo "UNKNOWN")
         ISSUE_BODY=$(printf '%s' "$ISSUE_JSON" | jq -r '.body // ""' 2>/dev/null || echo "")
 
-        if [[ "$ISSUE_STATE" != "OPEN" ]]; then
-          echo "✅ Maintenance mode is OFF. Proceeding with CI."
-          exit 0
-        fi
-
-        # For PRs, check if bypass-maintenance label is present (covers both full-pause and rebase-required modes)
-        if [[ -n "$PR_NUMBER" ]]; then
-          HAS_BYPASS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '[.labels[].name] | map(select(. == "bypass-maintenance")) | length' 2>/dev/null || echo "0")
-          if [[ "$HAS_BYPASS" -gt 0 ]]; then
-            echo "✅ PR #$PR_NUMBER has 'bypass-maintenance' label. Bypassing maintenance mode."
-            exit 0
-          fi
-        fi
-
-        # Parse optional `MIN_BASE_SHA: <sha>` directive from the issue body (first occurrence wins).
-        # Presence of this directive switches from full-pause to rebase-required mode.
+        # Parse optional `MIN_BASE_SHA: <sha>` directive from the issue body
+        # (first occurrence wins). Whenever this directive is present, the
+        # rebase check is enforced regardless of whether the issue is open
+        # or closed — so maintainers can require all PRs to rebase past a
+        # specific commit without having to open the maintenance issue.
         MIN_BASE_SHA=$(printf '%s' "$ISSUE_BODY" | tr -d '\r' | grep -iE '^[[:space:]]*`?MIN_BASE_SHA`?[[:space:]]*[:=]' | head -n1 | sed -E 's/.*[:=][[:space:]]*//; s/`//g' | awk '{print $1}')
         if [[ -n "$MIN_BASE_SHA" ]] && ! [[ "$MIN_BASE_SHA" =~ ^[a-fA-F0-9]{7,40}$ ]]; then
           WARN="⚠️  Ignoring malformed MIN_BASE_SHA directive in issue #$MAINTENANCE_ISSUE: '$MIN_BASE_SHA' (must be 7-40 hex chars)"
@@ -55,68 +44,82 @@ runs:
           MIN_BASE_SHA=""
         fi
 
-        if [[ -n "$MIN_BASE_SHA" ]]; then
-          # Rebase-required mode: CI runs only for PRs whose branch contains MIN_BASE_SHA.
-          if [[ -z "$PR_NUMBER" || -z "$PR_HEAD_SHA" ]]; then
-            echo "✅ Not a PR context; skipping rebase check."
+        # If neither gate is active (no MIN_BASE_SHA, issue not open), nothing to do.
+        if [[ -z "$MIN_BASE_SHA" && "$ISSUE_STATE" != "OPEN" ]]; then
+          echo "✅ Maintenance mode is OFF and no MIN_BASE_SHA directive. Proceeding with CI."
+          exit 0
+        fi
+
+        # bypass-maintenance label bypasses both gates.
+        if [[ -n "$PR_NUMBER" ]]; then
+          HAS_BYPASS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '[.labels[].name] | map(select(. == "bypass-maintenance")) | length' 2>/dev/null || echo "0")
+          if [[ "$HAS_BYPASS" -gt 0 ]]; then
+            echo "✅ PR #$PR_NUMBER has 'bypass-maintenance' label. Bypassing maintenance + rebase checks."
             exit 0
           fi
+        fi
 
-          # Use GitHub compare API: status is "ahead"/"identical" when MIN_BASE_SHA is reachable from PR head.
-          # On 4xx (e.g., nonexistent SHA) gh api prints the error JSON to stdout before exiting non-zero,
-          # so keep the `|| COMPARE_STATUS=UNKNOWN` outside the subshell — otherwise --jq '.status' extracts
-          # the HTTP status code ("404") from the error body and concatenates with "UNKNOWN", bypassing the
-          # fail-open branch and incorrectly blocking CI.
-          COMPARE_STATUS=$(gh api "repos/$REPO/compare/$MIN_BASE_SHA...$PR_HEAD_SHA" --jq '.status' 2>/dev/null) \
-            || COMPARE_STATUS="UNKNOWN"
-          COMPARE_STATUS="${COMPARE_STATUS:-UNKNOWN}"
+        # Rebase-required gate (independent of issue open/closed state).
+        if [[ -n "$MIN_BASE_SHA" ]]; then
+          if [[ -z "$PR_NUMBER" || -z "$PR_HEAD_SHA" ]]; then
+            echo "✅ Not a PR context; skipping rebase check."
+          else
+            # Use GitHub compare API: status is "ahead"/"identical" when MIN_BASE_SHA is reachable from PR head.
+            # On 4xx (e.g., nonexistent SHA) gh api prints the error JSON to stdout before exiting non-zero,
+            # so keep the `|| COMPARE_STATUS=UNKNOWN` outside the subshell — otherwise --jq '.status' extracts
+            # the HTTP status code ("404") from the error body and concatenates with "UNKNOWN", bypassing the
+            # fail-open branch and incorrectly blocking CI.
+            COMPARE_STATUS=$(gh api "repos/$REPO/compare/$MIN_BASE_SHA...$PR_HEAD_SHA" --jq '.status' 2>/dev/null) \
+              || COMPARE_STATUS="UNKNOWN"
+            COMPARE_STATUS="${COMPARE_STATUS:-UNKNOWN}"
 
-          case "$COMPARE_STATUS" in
-            ahead|identical)
-              echo "✅ PR #$PR_NUMBER contains required base ${MIN_BASE_SHA:0:12} ($COMPARE_STATUS). Proceeding."
-              exit 0
-              ;;
-            UNKNOWN)
-              echo "⚠️  Could not determine rebase status via GitHub API; fail-open, allowing CI to proceed."
-              exit 0
-              ;;
-          esac
+            case "$COMPARE_STATUS" in
+              ahead|identical)
+                echo "✅ PR #$PR_NUMBER contains required base ${MIN_BASE_SHA:0:12} ($COMPARE_STATUS)."
+                ;;
+              UNKNOWN)
+                echo "⚠️  Could not determine rebase status via GitHub API; fail-open, allowing rebase check to pass."
+                ;;
+              *)
+                MSG=$(printf "%s\n" \
+                  "## ⚠️ Rebase Required Before CI Can Run" \
+                  "A major update has landed on \`main\`. All PRs must rebase onto the latest \`main\` before CI will run." \
+                  "Required base commit: \`${MIN_BASE_SHA:0:12}\` (your PR is \`$COMPARE_STATUS\` relative to this commit)." \
+                  "" \
+                  "What should you do?" \
+                  "- Rebase your branch onto the latest \`main\` and push again" \
+                  "- Follow CI Maintenance Mode issue: https://github.com/$REPO/issues/$MAINTENANCE_ISSUE for context" \
+                  "- CI-fix PRs may request the \`bypass-maintenance\` label to skip this check")
+                echo "$MSG" >> "$GITHUB_STEP_SUMMARY"
+                while IFS= read -r line; do
+                  echo "::error::$line"
+                done <<< "$MSG"
+                exit 1
+                ;;
+            esac
+          fi
+        fi
 
+        # Full-pause maintenance gate (only when issue is open).
+        if [[ "$ISSUE_STATE" == "OPEN" ]]; then
           MSG=$(printf "%s\n" \
-            "## ⚠️ Rebase Required Before CI Can Run" \
-            "A major update has landed on \`main\`. All PRs must rebase onto the latest \`main\` before CI will run." \
-            "Required base commit: \`${MIN_BASE_SHA:0:12}\` (your PR is \`$COMPARE_STATUS\` relative to this commit)." \
+            "## ⚠️ CI Maintenance Mode is Active" \
+            "The CI infrastructure is currently under maintenance." \
+            "All PR CI runs are paused until maintenance is complete." \
+            "**Merging non-CI-fix PRs is prohibited during maintenance mode.** In severe cases, merge permissions may be revoked." \
+            "You might also experience unexpected failures during this period." \
+            "The team is working on the issue and will update the status as soon as possible." \
             "" \
             "What should you do?" \
-            "- Rebase your branch onto the latest \`main\` and push again" \
-            "- Follow CI Maintenance Mode issue: https://github.com/$REPO/issues/$MAINTENANCE_ISSUE for context" \
-            "- CI-fix PRs may request the \`bypass-maintenance\` label to skip this check")
+            "- **Do NOT merge non-CI-fix PRs** until maintenance mode is lifted" \
+            "- Check back later (~12 hours)" \
+            "- Follow CI Maintenance Mode issue: https://github.com/$REPO/issues/$MAINTENANCE_ISSUE for status updates")
 
           echo "$MSG" >> "$GITHUB_STEP_SUMMARY"
           while IFS= read -r line; do
             echo "::error::$line"
           done <<< "$MSG"
-
           exit 1
         fi
 
-        # Full maintenance mode (issue open, no MIN_BASE_SHA directive).
-        MSG=$(printf "%s\n" \
-          "## ⚠️ CI Maintenance Mode is Active" \
-          "The CI infrastructure is currently under maintenance." \
-          "All PR CI runs are paused until maintenance is complete." \
-          "**Merging non-CI-fix PRs is prohibited during maintenance mode.** In severe cases, merge permissions may be revoked." \
-          "You might also experience unexpected failures during this period." \
-          "The team is working on the issue and will update the status as soon as possible." \
-          "" \
-          "What should you do?" \
-          "- **Do NOT merge non-CI-fix PRs** until maintenance mode is lifted" \
-          "- Check back later (~12 hours)" \
-          "- Follow CI Maintenance Mode issue: https://github.com/$REPO/issues/$MAINTENANCE_ISSUE for status updates")
-
-        echo "$MSG" >> "$GITHUB_STEP_SUMMARY"
-        while IFS= read -r line; do
-          echo "::error::$line"
-        done <<< "$MSG"
-
-        exit 1
+        echo "✅ Rebase check passed; full-pause not active. Proceeding with CI."

--- a/.github/actions/check-maintenance/action.yml
+++ b/.github/actions/check-maintenance/action.yml
@@ -1,5 +1,5 @@
 name: Check Maintenance Mode
-description: Blocks CI when maintenance mode is active (issue #21065 is open), unless the PR has the bypass-maintenance label, or env PR_TEST_BYPASS_MAINTENANCE_ON_MAIN=true (PR Test workflow on main only). Merging non-CI-fix PRs is prohibited during maintenance mode; in severe cases, merge permissions may be revoked.
+description: Blocks CI when maintenance mode is active (issue #21065 is open), unless the PR has the bypass-maintenance label, or env PR_TEST_BYPASS_MAINTENANCE_ON_MAIN=true (PR Test workflow on main only). If the issue body contains a `MIN_BASE_SHA: <sha>` directive, CI runs only for PRs whose branch already contains that SHA (rebase-required mode). Merging non-CI-fix PRs is prohibited during maintenance mode; in severe cases, merge permissions may be revoked.
 
 inputs:
   github-token:
@@ -18,6 +18,7 @@ runs:
         MAINTENANCE_ISSUE=21065
         REPO="${{ github.repository }}"
         PR_NUMBER="${{ github.event.pull_request.number }}"
+        PR_HEAD_SHA="${{ github.event.pull_request.head.sha }}"
 
         # PR Test workflow only: scheduled runs and runs on main (dispatch / workflow_call) set this env
         if [[ "${PR_TEST_BYPASS_MAINTENANCE_ON_MAIN:-}" == "true" ]]; then
@@ -25,15 +26,17 @@ runs:
           exit 0
         fi
 
-        # Check if maintenance issue is open (fail-open: if API errors, allow CI to proceed)
-        ISSUE_STATE=$(gh issue view "$MAINTENANCE_ISSUE" --repo "$REPO" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+        # Fetch issue state and body (fail-open: if API errors, allow CI to proceed)
+        ISSUE_JSON=$(gh issue view "$MAINTENANCE_ISSUE" --repo "$REPO" --json state,body 2>/dev/null || echo "")
+        ISSUE_STATE=$(printf '%s' "$ISSUE_JSON" | jq -r '.state // "UNKNOWN"' 2>/dev/null || echo "UNKNOWN")
+        ISSUE_BODY=$(printf '%s' "$ISSUE_JSON" | jq -r '.body // ""' 2>/dev/null || echo "")
 
         if [[ "$ISSUE_STATE" != "OPEN" ]]; then
           echo "✅ Maintenance mode is OFF. Proceeding with CI."
           exit 0
         fi
 
-        # For PRs, check if bypass-maintenance label is present
+        # For PRs, check if bypass-maintenance label is present (covers both full-pause and rebase-required modes)
         if [[ -n "$PR_NUMBER" ]]; then
           HAS_BYPASS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '[.labels[].name] | map(select(. == "bypass-maintenance")) | length' 2>/dev/null || echo "0")
           if [[ "$HAS_BYPASS" -gt 0 ]]; then
@@ -42,6 +45,57 @@ runs:
           fi
         fi
 
+        # Parse optional `MIN_BASE_SHA: <sha>` directive from the issue body (first occurrence wins).
+        # Presence of this directive switches from full-pause to rebase-required mode.
+        MIN_BASE_SHA=$(printf '%s' "$ISSUE_BODY" | tr -d '\r' | grep -iE '^[[:space:]]*`?MIN_BASE_SHA`?[[:space:]]*[:=]' | head -n1 | sed -E 's/.*[:=][[:space:]]*//; s/`//g' | awk '{print $1}')
+        if [[ -n "$MIN_BASE_SHA" ]] && ! [[ "$MIN_BASE_SHA" =~ ^[a-fA-F0-9]{7,40}$ ]]; then
+          WARN="⚠️  Ignoring malformed MIN_BASE_SHA directive in issue #$MAINTENANCE_ISSUE: '$MIN_BASE_SHA' (must be 7-40 hex chars)"
+          echo "$WARN"
+          echo "$WARN" >> "$GITHUB_STEP_SUMMARY"
+          MIN_BASE_SHA=""
+        fi
+
+        if [[ -n "$MIN_BASE_SHA" ]]; then
+          # Rebase-required mode: CI runs only for PRs whose branch contains MIN_BASE_SHA.
+          if [[ -z "$PR_NUMBER" || -z "$PR_HEAD_SHA" ]]; then
+            echo "✅ Not a PR context; skipping rebase check."
+            exit 0
+          fi
+
+          # Use GitHub compare API: status is "ahead"/"identical" when MIN_BASE_SHA is reachable from PR head.
+          COMPARE_STATUS=$(gh api "repos/$REPO/compare/$MIN_BASE_SHA...$PR_HEAD_SHA" --jq '.status' 2>/dev/null || echo "UNKNOWN")
+          COMPARE_STATUS="${COMPARE_STATUS:-UNKNOWN}"
+
+          case "$COMPARE_STATUS" in
+            ahead|identical)
+              echo "✅ PR #$PR_NUMBER contains required base ${MIN_BASE_SHA:0:12} ($COMPARE_STATUS). Proceeding."
+              exit 0
+              ;;
+            UNKNOWN)
+              echo "⚠️  Could not determine rebase status via GitHub API; fail-open, allowing CI to proceed."
+              exit 0
+              ;;
+          esac
+
+          MSG=$(printf "%s\n" \
+            "## ⚠️ Rebase Required Before CI Can Run" \
+            "A major update has landed on \`main\`. All PRs must rebase onto the latest \`main\` before CI will run." \
+            "Required base commit: \`${MIN_BASE_SHA:0:12}\` (your PR is \`$COMPARE_STATUS\` relative to this commit)." \
+            "" \
+            "What should you do?" \
+            "- Rebase your branch onto the latest \`main\` and push again" \
+            "- Follow CI Maintenance Mode issue: https://github.com/$REPO/issues/$MAINTENANCE_ISSUE for context" \
+            "- CI-fix PRs may request the \`bypass-maintenance\` label to skip this check")
+
+          echo "$MSG" >> "$GITHUB_STEP_SUMMARY"
+          while IFS= read -r line; do
+            echo "::error::$line"
+          done <<< "$MSG"
+
+          exit 1
+        fi
+
+        # Full maintenance mode (issue open, no MIN_BASE_SHA directive).
         MSG=$(printf "%s\n" \
           "## ⚠️ CI Maintenance Mode is Active" \
           "The CI infrastructure is currently under maintenance." \


### PR DESCRIPTION
Extends the existing `check-maintenance` composite action with a **rebase-required mode** driven by issue #21065's body. The two gates (full-pause and rebase-required) are now independent — `MIN_BASE_SHA: <sha>` in the issue body fires the rebase check whether the issue is open or closed, so maintainers can require all PRs to rebase past a specific commit without entering full maintenance.

The rebase check uses the GitHub compare API: status `ahead`/`identical` passes, `behind`/`diverged` blocks with a "Rebase Required" error, API errors fail-open. The `bypass-maintenance` label bypasses both gates.

All workflows that already use `./.github/actions/check-maintenance` pick up the new logic automatically — no workflow edits needed.

## Behavior matrix
| Issue #21065 | `MIN_BASE_SHA` in body | PR contains SHA | Result |
|---|---|---|---|
| Closed | absent | — | CI runs |
| Closed | present | yes | CI runs |
| Closed | present | no | **Blocked: Rebase Required** |
| Open | absent | — | Full pause |
| Open | present | yes | Full pause (rebase OK, but issue still pauses) |
| Open | present | no | Blocked: Rebase Required |

## Verified end-to-end on PR #23109's own CI

- Pass path: `MIN_BASE_SHA: 6ecd6f84d` (CUDA 13 upgrade) → log: `✅ PR #23109 contains required base 6ecd6f84d (ahead).`  https://github.com/sgl-project/sglang/actions/runs/25191129170/job/73862804313
- Block path: `MIN_BASE_SHA: 340efca24` (PR #24162 merge — landed after PR's last rebase) → log: `## ⚠️ Rebase Required Before CI Can Run / Required base commit: 340efca24 (your PR is diverged...)` https://github.com/sgl-project/sglang/actions/runs/25191129170/job/73863188369

## Notes / sharp edges
- Only the **first** `MIN_BASE_SHA:` line in the issue body is read.
- The SHA must be 7-40 hex chars; malformed values are ignored with a warning in the step summary.
- The parser is line-anchored and doesn't skip fenced code blocks — keep the directive out of code blocks in the issue body.
- Setting `MIN_BASE_SHA` mid-day blocks queued jobs of in-flight runs immediately (already-running jobs that have passed `check-maintenance` finish normally). Use `bypass-maintenance` label to spare specific PRs.