### PR TITLE
fix: guard self.model access in Qwen3VLMoeForConditionalGeneration.load_weights

### DIFF
--- a/python/sglang/srt/models/qwen3_vl_moe.py
+++ b/python/sglang/srt/models/qwen3_vl_moe.py
@@ -235,6 +235,7 @@ class Qwen3VLMoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
             if (
                 "visual" not in name
                 and layer_id is not None
+                and hasattr(self, "model")
                 and hasattr(self.model, "start_layer")
                 and (
                     layer_id < self.model.start_layer


### PR DESCRIPTION
Fixes #23063

## Problem

When launching a Qwen3-VL-MoE model in `--encoder-only` mode, the server crashes during weight loading with `AttributeError: 'Qwen3VLMoeForConditionalGeneration' object has no attribute 'model'`.

In encoder-only mode, `self.model` is not initialized by the parent class (`Qwen3VLForConditionalGeneration.__init__` only sets `self.model` when `config.encoder_only` is `False`). However, `Qwen3VLMoeForConditionalGeneration.load_weights` unconditionally accessed `self.model` in:

```python
and hasattr(self.model, "start_layer")
```

Python evaluates `self.model` before `hasattr` can handle the missing attribute, causing the crash.

## Solution

Add `hasattr(self, "model")` check before accessing `self.model`, matching the pattern already used in the parent class `Qwen3VLForConditionalGeneration.load_weights` in `qwen3_vl.py` (line 1322):

```python
and hasattr(self, "model")
and hasattr(self.model, "start_layer")
```

## Testing

The fix is minimal (1 line added) and directly mirrors the existing guard pattern in the parent class. Encoder-only mode now safely skips the `start_layer`/`end_layer` layer-skipping logic when no language model is initialized, while normal (non-encoder-only) mode is unaffected.