### PR TITLE
[Docs] Move imports to their first-use cells across tutorial notebooks

### DIFF
--- a/docs/advanced_features/lora.ipynb
+++ b/docs/advanced_features/lora.ipynb
@@ -82,7 +82,7 @@
     "import requests\n",
     "\n",
     "from sglang.test.doc_patch import launch_server_cmd\n",
-    "from sglang.utils import wait_for_server, terminate_process"
+    "from sglang.utils import wait_for_server"
    ]
   },
   {
@@ -135,6 +135,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import terminate_process\n",
+    "\n",
     "terminate_process(server_process)"
    ]
   },

--- a/docs/advanced_features/separate_reasoning.ipynb
+++ b/docs/advanced_features/separate_reasoning.ipynb
@@ -64,7 +64,7 @@
     "import requests\n",
     "from openai import OpenAI\n",
     "from sglang.test.doc_patch import launch_server_cmd\n",
-    "from sglang.utils import wait_for_server, print_highlight, terminate_process\n",
+    "from sglang.utils import wait_for_server\n",
     "\n",
     "server_process, port = launch_server_cmd(\n",
     "    \"python3 -m sglang.launch_server --model-path deepseek-ai/DeepSeek-R1-Distill-Qwen-7B --host 0.0.0.0 --reasoning-parser deepseek-r1 --log-level warning\"\n",
@@ -123,6 +123,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import print_highlight\n",
+    "\n",
     "response_non_stream = client.chat.completions.create(\n",
     "    model=model_name,\n",
     "    messages=messages,\n",
@@ -151,6 +153,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import print_highlight\n",
+    "\n",
     "response_stream = client.chat.completions.create(\n",
     "    model=model_name,\n",
     "    messages=messages,\n",
@@ -188,6 +192,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import print_highlight\n",
+    "\n",
     "response_stream = client.chat.completions.create(\n",
     "    model=model_name,\n",
     "    messages=messages,\n",
@@ -226,6 +232,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import print_highlight\n",
+    "\n",
     "response_non_stream = client.chat.completions.create(\n",
     "    model=model_name,\n",
     "    messages=messages,\n",
@@ -253,6 +261,7 @@
    "outputs": [],
    "source": [
     "from transformers import AutoTokenizer\n",
+    "from sglang.utils import print_highlight\n",
     "\n",
     "tokenizer = AutoTokenizer.from_pretrained(\"deepseek-ai/DeepSeek-R1-Distill-Qwen-7B\")\n",
     "input = tokenizer.apply_chat_template(\n",

--- a/docs/advanced_features/structured_outputs.ipynb
+++ b/docs/advanced_features/structured_outputs.ipynb
@@ -45,7 +45,7 @@
     "import os\n",
     "\n",
     "from sglang.test.doc_patch import launch_server_cmd\n",
-    "from sglang.utils import wait_for_server, print_highlight, terminate_process\n",
+    "from sglang.utils import wait_for_server\n",
     "\n",
     "os.environ[\"TOKENIZERS_PARALLELISM\"] = \"false\"\n",
     "\n",
@@ -81,6 +81,7 @@
    "outputs": [],
    "source": [
     "from pydantic import BaseModel, Field\n",
+    "from sglang.utils import print_highlight\n",
     "\n",
     "\n",
     "# Define the schema using Pydantic\n",
@@ -129,6 +130,7 @@
    "outputs": [],
    "source": [
     "import json\n",
+    "from sglang.utils import print_highlight\n",
     "\n",
     "json_schema = json.dumps(\n",
     "    {\n",
@@ -173,6 +175,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import print_highlight\n",
+    "\n",
     "ebnf_grammar = \"\"\"\n",
     "root ::= city | description\n",
     "city ::= \"London\" | \"Paris\" | \"Berlin\" | \"Rome\"\n",
@@ -211,6 +215,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import print_highlight\n",
+    "\n",
     "response = client.chat.completions.create(\n",
     "    model=\"meta-llama/Meta-Llama-3.1-8B-Instruct\",\n",
     "    messages=[\n",
@@ -237,6 +243,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import print_highlight\n",
+    "\n",
     "tool_get_current_weather = {\n",
     "    \"type\": \"function\",\n",
     "    \"function\": {\n",
@@ -355,6 +363,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import print_highlight\n",
+    "\n",
     "# Support for XGrammar latest structural tag format\n",
     "# <https://xgrammar.mlc.ai/docs/tutorials/structural_tag.html>\n",
     "response = client.chat.completions.create(\n",

--- a/docs/advanced_features/structured_outputs_for_reasoning_models.ipynb
+++ b/docs/advanced_features/structured_outputs_for_reasoning_models.ipynb
@@ -41,7 +41,7 @@
     "import os\n",
     "\n",
     "from sglang.test.doc_patch import launch_server_cmd\n",
-    "from sglang.utils import wait_for_server, print_highlight, terminate_process\n",
+    "from sglang.utils import wait_for_server\n",
     "\n",
     "os.environ[\"TOKENIZERS_PARALLELISM\"] = \"false\"\n",
     "\n",
@@ -77,6 +77,7 @@
    "outputs": [],
    "source": [
     "from pydantic import BaseModel, Field\n",
+    "from sglang.utils import print_highlight\n",
     "\n",
     "\n",
     "# Define the schema using Pydantic\n",
@@ -124,6 +125,7 @@
    "outputs": [],
    "source": [
     "import json\n",
+    "from sglang.utils import print_highlight\n",
     "\n",
     "json_schema = json.dumps(\n",
     "    {\n",
@@ -170,6 +172,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import print_highlight\n",
+    "\n",
     "ebnf_grammar = \"\"\"\n",
     "root ::= city | description\n",
     "city ::= \"London\" | \"Paris\" | \"Berlin\" | \"Rome\"\n",
@@ -210,6 +214,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import print_highlight\n",
+    "\n",
     "response = client.chat.completions.create(\n",
     "    model=\"deepseek-ai/DeepSeek-R1-Distill-Qwen-7B\",\n",
     "    messages=[\n",
@@ -238,6 +244,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import print_highlight\n",
+    "\n",
     "tool_get_current_weather = {\n",
     "    \"type\": \"function\",\n",
     "    \"function\": {\n",
@@ -387,6 +395,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import print_highlight\n",
+    "\n",
     "import requests\n",
     "from pydantic import BaseModel, Field\n",
     "from transformers import AutoTokenizer\n",

--- a/docs/advanced_features/tool_parser.ipynb
+++ b/docs/advanced_features/tool_parser.ipynb
@@ -54,7 +54,7 @@
    "source": [
     "import json\n",
     "from sglang.test.doc_patch import launch_server_cmd\n",
-    "from sglang.utils import wait_for_server, print_highlight, terminate_process\n",
+    "from sglang.utils import wait_for_server\n",
     "from openai import OpenAI\n",
     "\n",
     "server_process, port = launch_server_cmd(\n",
@@ -543,7 +543,7 @@
    "outputs": [],
    "source": [
     "from openai import OpenAI\n",
-    "from sglang.utils import wait_for_server, print_highlight, terminate_process\n",
+    "from sglang.utils import wait_for_server\n",
     "from sglang.test.doc_patch import launch_server_cmd\n",
     "\n",
     "# Start a new server session for tool choice examples\n",

--- a/docs/basic_usage/native_api.ipynb
+++ b/docs/basic_usage/native_api.ipynb
@@ -43,7 +43,7 @@
    "outputs": [],
    "source": [
     "from sglang.test.doc_patch import launch_server_cmd\n",
-    "from sglang.utils import wait_for_server, print_highlight, terminate_process\n",
+    "from sglang.utils import wait_for_server\n",
     "\n",
     "server_process, port = launch_server_cmd(\n",
     "    \"python3 -m sglang.launch_server --model-path qwen/qwen2.5-0.5b-instruct --host 0.0.0.0 --log-level warning\"\n",
@@ -67,6 +67,7 @@
    "outputs": [],
    "source": [
     "import requests\n",
+    "from sglang.utils import print_highlight\n",
     "\n",
     "url = f\"http://localhost:{port}/generate\"\n",
     "data = {\"text\": \"What is the capital of France?\"}\n",
@@ -100,6 +101,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import print_highlight\n",
+    "\n",
     "url = f\"http://localhost:{port}/get_model_info\"\n",
     "\n",
     "response = requests.get(url)\n",
@@ -140,6 +143,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import print_highlight\n",
+    "\n",
     "url = f\"http://localhost:{port}/server_info\"\n",
     "\n",
     "response = requests.get(url)\n",
@@ -161,6 +166,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import print_highlight\n",
+    "\n",
     "url = f\"http://localhost:{port}/health_generate\"\n",
     "\n",
     "response = requests.get(url)\n",
@@ -173,6 +180,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import print_highlight\n",
+    "\n",
     "url = f\"http://localhost:{port}/health\"\n",
     "\n",
     "response = requests.get(url)\n",
@@ -202,6 +211,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import print_highlight\n",
+    "\n",
     "url = f\"http://localhost:{port}/flush_cache\"\n",
     "\n",
     "response = requests.post(url)\n",
@@ -225,6 +236,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import print_highlight\n",
+    "\n",
     "# successful update with same architecture and size\n",
     "\n",
     "url = f\"http://localhost:{port}/update_weights_from_disk\"\n",
@@ -242,6 +255,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import print_highlight\n",
+    "\n",
     "# failed update with different parameter size or wrong name\n",
     "\n",
     "url = f\"http://localhost:{port}/update_weights_from_disk\"\n",
@@ -264,6 +279,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import terminate_process\n",
+    "\n",
     "terminate_process(server_process)"
    ]
   },
@@ -313,6 +330,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import terminate_process\n",
+    "\n",
     "terminate_process(embedding_process)"
    ]
   },
@@ -368,6 +387,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import terminate_process\n",
+    "\n",
     "terminate_process(reranker_process)"
    ]
   },
@@ -437,6 +458,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import terminate_process\n",
+    "\n",
     "terminate_process(score_process)"
    ]
   },
@@ -502,6 +525,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import terminate_process\n",
+    "\n",
     "terminate_process(reward_process)"
    ]
   },
@@ -557,6 +582,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import terminate_process\n",
+    "\n",
     "terminate_process(expert_record_server_process)"
    ]
   },
@@ -653,6 +680,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import terminate_process\n",
+    "\n",
     "terminate_process(tokenizer_free_server_process)"
    ]
   }

--- a/docs/basic_usage/openai_api_completions.ipynb
+++ b/docs/basic_usage/openai_api_completions.ipynb
@@ -33,7 +33,7 @@
    "outputs": [],
    "source": [
     "from sglang.test.doc_patch import launch_server_cmd\n",
-    "from sglang.utils import wait_for_server, print_highlight, terminate_process\n",
+    "from sglang.utils import wait_for_server\n",
     "\n",
     "server_process, port = launch_server_cmd(\n",
     "    \"python3 -m sglang.launch_server --model-path qwen/qwen2.5-0.5b-instruct --host 0.0.0.0 --log-level warning\"\n",
@@ -63,6 +63,7 @@
    "outputs": [],
    "source": [
     "import openai\n",
+    "from sglang.utils import print_highlight\n",
     "\n",
     "client = openai.Client(base_url=f\"http://127.0.0.1:{port}/v1\", api_key=\"None\")\n",
     "\n",
@@ -530,6 +531,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import terminate_process\n",
+    "\n",
     "terminate_process(server_process)"
    ]
   }

--- a/docs/basic_usage/openai_api_embeddings.ipynb
+++ b/docs/basic_usage/openai_api_embeddings.ipynb
@@ -28,7 +28,7 @@
    "outputs": [],
    "source": [
     "from sglang.test.doc_patch import launch_server_cmd\n",
-    "from sglang.utils import wait_for_server, print_highlight, terminate_process\n",
+    "from sglang.utils import wait_for_server\n",
     "\n",
     "embedding_process, port = launch_server_cmd(\"\"\"\n",
     "python3 -m sglang.launch_server --model-path Alibaba-NLP/gte-Qwen2-1.5B-instruct \\\n",
@@ -52,6 +52,7 @@
    "outputs": [],
    "source": [
     "import subprocess, json\n",
+    "from sglang.utils import print_highlight\n",
     "\n",
     "text = \"Once upon a time\"\n",
     "\n",
@@ -82,6 +83,7 @@
    "outputs": [],
    "source": [
     "import requests\n",
+    "from sglang.utils import print_highlight\n",
     "\n",
     "text = \"Once upon a time\"\n",
     "\n",
@@ -109,6 +111,7 @@
    "outputs": [],
    "source": [
     "import openai\n",
+    "from sglang.utils import print_highlight\n",
     "\n",
     "client = openai.Client(base_url=f\"http://127.0.0.1:{port}/v1\", api_key=\"None\")\n",
     "\n",
@@ -140,6 +143,7 @@
     "import json\n",
     "import os\n",
     "from transformers import AutoTokenizer\n",
+    "from sglang.utils import print_highlight\n",
     "\n",
     "os.environ[\"TOKENIZERS_PARALLELISM\"] = \"false\"\n",
     "\n",
@@ -163,6 +167,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import terminate_process\n",
+    "\n",
     "terminate_process(embedding_process)"
    ]
   },

--- a/docs/basic_usage/openai_api_vision.ipynb
+++ b/docs/basic_usage/openai_api_vision.ipynb
@@ -31,7 +31,7 @@
    "outputs": [],
    "source": [
     "from sglang.test.doc_patch import launch_server_cmd\n",
-    "from sglang.utils import wait_for_server, print_highlight, terminate_process\n",
+    "from sglang.utils import wait_for_server\n",
     "\n",
     "example_image_url = \"https://raw.githubusercontent.com/sgl-project/sglang/main/examples/assets/example_image.png\"\n",
     "logo_image_url = (\n",
@@ -61,6 +61,7 @@
    "outputs": [],
    "source": [
     "import subprocess\n",
+    "from sglang.utils import print_highlight\n",
     "\n",
     "curl_command = f\"\"\"\n",
     "curl -s http://localhost:{port}/v1/chat/completions \\\\\n",
@@ -110,6 +111,7 @@
    "outputs": [],
    "source": [
     "import requests\n",
+    "from sglang.utils import print_highlight\n",
     "\n",
     "url = f\"http://localhost:{port}/v1/chat/completions\"\n",
     "\n",
@@ -148,6 +150,7 @@
    "outputs": [],
    "source": [
     "from openai import OpenAI\n",
+    "from sglang.utils import print_highlight\n",
     "\n",
     "client = OpenAI(base_url=f\"http://localhost:{port}/v1\", api_key=\"None\")\n",
     "\n",
@@ -190,6 +193,7 @@
    "outputs": [],
    "source": [
     "from openai import OpenAI\n",
+    "from sglang.utils import print_highlight\n",
     "\n",
     "client = OpenAI(base_url=f\"http://localhost:{port}/v1\", api_key=\"None\")\n",
     "\n",
@@ -231,6 +235,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import terminate_process\n",
+    "\n",
     "terminate_process(vision_process)"
    ]
   }

--- a/docs/basic_usage/send_request.ipynb
+++ b/docs/basic_usage/send_request.ipynb
@@ -26,7 +26,7 @@
    "outputs": [],
    "source": [
     "from sglang.test.doc_patch import launch_server_cmd\n",
-    "from sglang.utils import wait_for_server, print_highlight, terminate_process\n",
+    "from sglang.utils import wait_for_server\n",
     "\n",
     "# This is equivalent to running the following command in your terminal\n",
     "# python3 -m sglang.launch_server --model-path qwen/qwen2.5-0.5b-instruct --host 0.0.0.0\n",
@@ -53,6 +53,7 @@
    "outputs": [],
    "source": [
     "import subprocess, json\n",
+    "from sglang.utils import print_highlight\n",
     "\n",
     "curl_command = f\"\"\"\n",
     "curl -s http://localhost:{port}/v1/chat/completions \\\n",
@@ -78,6 +79,7 @@
    "outputs": [],
    "source": [
     "import requests\n",
+    "from sglang.utils import print_highlight\n",
     "\n",
     "url = f\"http://localhost:{port}/v1/chat/completions\"\n",
     "\n",
@@ -104,6 +106,7 @@
    "outputs": [],
    "source": [
     "import openai\n",
+    "from sglang.utils import print_highlight\n",
     "\n",
     "client = openai.Client(base_url=f\"http://127.0.0.1:{port}/v1\", api_key=\"None\")\n",
     "\n",
@@ -168,6 +171,7 @@
    "outputs": [],
    "source": [
     "import requests\n",
+    "from sglang.utils import print_highlight\n",
     "\n",
     "response = requests.post(\n",
     "    f\"http://localhost:{port}/generate\",\n",

--- a/docs/references/frontend/frontend_tutorial.ipynb
+++ b/docs/references/frontend/frontend_tutorial.ipynb
@@ -36,7 +36,7 @@
     "from sglang.lang.api import set_default_backend\n",
     "from sglang.srt.utils import load_image\n",
     "from sglang.test.doc_patch import launch_server_cmd\n",
-    "from sglang.utils import print_highlight, terminate_process, wait_for_server\n",
+    "from sglang.utils import wait_for_server\n",
     "\n",
     "server_process, port = launch_server_cmd(\n",
     "    \"python -m sglang.launch_server --model-path Qwen/Qwen2.5-7B-Instruct --host 0.0.0.0 --log-level warning\"\n",
@@ -90,6 +90,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sglang.utils import print_highlight\n",
+    "\n",
     "state = basic_qa(\"List 3 countries and their capitals.\")\n",
     "print_highlight(state[\"answer\"])"
    ]


### PR DESCRIPTION
## Motivation

Several tutorial notebooks import utilities such as `terminate_process`
and `print_highlight` in the server-launch cell, even though these
functions are only used in later cells.

This causes `NameError` when users execute cells in isolation (e.g.,
during debugging or when copying a specific section into a standalone
script), and reduces readability by placing imports far from their
actual usage.

## Modifications

Moved `terminate_process` and `print_highlight` imports to the cell
where each function is first used, across the following notebooks:

- `docs/basic_usage/send_request.ipynb`
- `docs/advanced_features/lora.ipynb`
- `docs/advanced_features/separate_reasoning.ipynb`
- (other affected notebooks)

No logic or API changes. Each diff is a one-line removal and a
one-line addition.

## Accuracy Tests

N/A — documentation-only change, no model or kernel code modified.

## Speed Tests and Profiling

N/A — documentation-only change, no inference path modified.

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] ~~Add unit tests~~ — N/A, documentation-only change.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] ~~Provide accuracy and speed benchmark results~~ — N/A, no code change.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).