### PR TITLE
[Feature] Continuous decode 

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1465,7 +1465,7 @@ class Scheduler(
                     pop_and_process()
             elif current_batch is None:
                 # When the server is idle, do self-check and re-init some states
-                self.self_check_during_idle()
+                self.on_idle()
 
             # Run sample of the current batch
             # It depends on the result of the last batch (e.g., grammar), so we run it after the last batch is processed.

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -914,6 +914,9 @@ class Scheduler(
         init_mm_embedding_cache(embedding_cache_size * 1024 * 1024)
 
     def init_running_status(self):
+        self.num_continuous_decode_steps = max(
+            1, self.server_args.num_continuous_decode_steps
+        )
         self.waiting_queue: List[Req] = []
         # The running decoding batch for continuous batching
         self.running_batch: ScheduleBatch = ScheduleBatch(reqs=[], batch_is_full=False)
@@ -1397,6 +1400,21 @@ class Scheduler(
             if batch:
                 result = self.run_batch(batch)
                 self.process_batch_result(batch, result)
+
+                # Decode multiple steps to reduce scheduler overhead.
+                for _ in range(self.num_continuous_decode_steps - 1):
+                    if not self._can_run_continuous_decode(batch):
+                        break
+                    batch = self.update_running_batch(self.running_batch)
+                    if (
+                        batch is None
+                        or batch.is_empty()
+                        or not batch.forward_mode.is_decode()
+                    ):
+                        break
+                    self.cur_batch = batch
+                    result = self.run_batch(batch)
+                    self.process_batch_result(batch, result)
             else:
                 # When the server is idle, do self-check and re-init some states.
                 self.on_idle()
@@ -1418,6 +1436,40 @@ class Scheduler(
             tmp_batch, tmp_result = self.result_queue.popleft()
             self.process_batch_result(tmp_batch, tmp_result)
 
+        def run_one_overlap_step(
+            current_batch: Optional[ScheduleBatch],
+        ) -> None:
+            disable_overlap_for_batch = self.is_disable_overlap_for_batch(current_batch)
+
+            # If we do not need to overlap the current batch with the last batch,
+            # we can process the last batch immediately.
+            if disable_overlap_for_batch:
+                pop_and_process()
+
+            # Launch the current batch
+            if current_batch:
+                current_batch_result = self.run_batch(current_batch)
+                self.result_queue.append((current_batch.copy(), current_batch_result))
+            else:
+                current_batch_result = None
+                self.cancel_bubble_timer()
+
+            # Process the last batch
+            if self.last_batch:
+                if not disable_overlap_for_batch:
+                    pop_and_process()
+            elif current_batch is None:
+                # When the server is idle, do self-check and re-init some states
+                self.self_check_during_idle()
+
+            # Run sample of the current batch
+            # It depends on the result of the last batch (e.g., grammar), so we run it after the last batch is processed.
+            if self.is_generation:
+                self.launch_batch_sample_if_needed(current_batch_result)
+
+            # Update last_batch
+            self.last_batch = current_batch
+
         while True:
             # Receive requests
             recv_reqs = self.recv_requests()
@@ -1428,40 +1480,40 @@ class Scheduler(
             # Get the next batch to run
             batch = self.get_next_batch_to_run()
             self.cur_batch = batch
-            disable_overlap_for_batch = self.is_disable_overlap_for_batch(batch)
+            run_one_overlap_step(batch)
 
-            # If we do not need to overlap the current batch with the last batch,
-            # we can process the last batch immediately.
-            if disable_overlap_for_batch:
-                pop_and_process()
+            # Decode multiple steps to reduce scheduler overhead.
+            for _ in range(self.num_continuous_decode_steps - 1):
+                if not self._can_run_continuous_decode(batch):
+                    break
+                batch = self.update_running_batch(self.running_batch)
+                if (
+                    batch is None
+                    or batch.is_empty()
+                    or not batch.forward_mode.is_decode()
+                ):
+                    break
+                self.cur_batch = batch
+                run_one_overlap_step(batch)
 
-            # Launch the current batch
-            if batch:
-                batch_result = self.run_batch(batch)
-                self.result_queue.append((batch.copy(), batch_result))
-            else:
-                batch_result = None
-                self.cancel_bubble_timer()
-
-            # Process the last batch
-            if self.last_batch:
-                if not disable_overlap_for_batch:
-                    pop_and_process()
-            elif batch is None:
-                # When the server is idle, do self-check and re-init some states
-                self.on_idle()
-
-            # Run sample of the current batch
-            # It depends on the result of the last batch (e.g., grammar), so we run it after the last batch is processed.
-            if self.is_generation:
-                self.launch_batch_sample_if_needed(batch_result)
-
-            # Update last_batch
-            self.last_batch = batch
             if envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.get():
                 self.self_check_during_busy()
 
-    def is_disable_overlap_for_batch(self, batch: ScheduleBatch) -> bool:
+    def _can_run_continuous_decode(self, batch: Optional[ScheduleBatch]) -> bool:
+        if self.num_continuous_decode_steps <= 1:
+            return False
+        if batch is None or not batch.forward_mode.is_decode():
+            return False
+        if self._engine_paused:
+            return False
+        # Avoid hurting TTFT when there are pending requests waiting for prefill.
+        if self.waiting_queue:
+            return False
+        if self.chunked_req is not None:
+            return False
+        return True
+
+    def is_disable_overlap_for_batch(self, batch: Optional[ScheduleBatch]) -> bool:
         # For two consecutive prefill batches, we disable overlap to improve the TTFT of the first batch.
         # This might slightly hurt the throughput, so we use an environment variable to control it.
         # In DP attention mode, use the globally synchronized is_extend_in_batch

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1439,7 +1439,12 @@ class Scheduler(
         def run_one_overlap_step(
             current_batch: Optional[ScheduleBatch],
         ) -> None:
-            disable_overlap_for_batch = self.is_disable_overlap_for_batch(current_batch)
+            if current_batch is None:
+                disable_overlap_for_batch = False
+            else:
+                disable_overlap_for_batch = self.is_disable_overlap_for_batch(
+                    current_batch
+                )
 
             # If we do not need to overlap the current batch with the last batch,
             # we can process the last batch immediately.
@@ -1513,7 +1518,7 @@ class Scheduler(
             return False
         return True
 
-    def is_disable_overlap_for_batch(self, batch: Optional[ScheduleBatch]) -> bool:
+    def is_disable_overlap_for_batch(self, batch: ScheduleBatch) -> bool:
         # For two consecutive prefill batches, we disable overlap to improve the TTFT of the first batch.
         # This might slightly hurt the throughput, so we use an environment variable to control it.
         # In DP attention mode, use the globally synchronized is_extend_in_batch

--- a/test/registered/unit/managers/test_scheduler_continuous_decode.py
+++ b/test/registered/unit/managers/test_scheduler_continuous_decode.py
@@ -1,0 +1,83 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="stage-a-test-cpu")
+
+
+class TestSchedulerContinuousDecode(CustomTestCase):
+    def _new_scheduler(self) -> Scheduler:
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.num_continuous_decode_steps = 4
+        scheduler._engine_paused = False
+        scheduler.waiting_queue = []
+        scheduler.chunked_req = None
+        return scheduler
+
+    def _make_batch(self, is_decode: bool, is_empty: bool = False):
+        return SimpleNamespace(
+            forward_mode=SimpleNamespace(is_decode=lambda: is_decode),
+            is_empty=lambda: is_empty,
+        )
+
+    def test_can_run_continuous_decode_true_for_decode_batch(self):
+        scheduler = self._new_scheduler()
+        batch = self._make_batch(is_decode=True)
+
+        self.assertTrue(scheduler._can_run_continuous_decode(batch))
+
+    def test_can_run_continuous_decode_false_with_pending_waiting_queue(self):
+        scheduler = self._new_scheduler()
+        scheduler.waiting_queue = [object()]
+        batch = self._make_batch(is_decode=True)
+
+        self.assertFalse(scheduler._can_run_continuous_decode(batch))
+
+    def test_can_run_continuous_decode_false_when_disabled(self):
+        scheduler = self._new_scheduler()
+        scheduler.num_continuous_decode_steps = 1
+        batch = self._make_batch(is_decode=True)
+
+        self.assertFalse(scheduler._can_run_continuous_decode(batch))
+
+    def test_event_loop_normal_runs_multiple_continuous_decode_steps(self):
+        class _LoopExit(Exception):
+            pass
+
+        scheduler = self._new_scheduler()
+        scheduler.num_continuous_decode_steps = 4
+        scheduler.self_check_during_idle = MagicMock()
+        scheduler.self_check_during_busy = MagicMock()
+        scheduler.cancel_bubble_timer = MagicMock()
+        scheduler.process_input_requests = MagicMock()
+        scheduler.running_batch = MagicMock()
+
+        # First scheduler loop runs normally; second loop exits the infinite loop.
+        scheduler.recv_requests = MagicMock(side_effect=[[], _LoopExit()])
+
+        first_batch = self._make_batch(is_decode=True)
+        next_batches = [
+            self._make_batch(is_decode=True),
+            self._make_batch(is_decode=True),
+            self._make_batch(is_decode=True),
+        ]
+        scheduler.get_next_batch_to_run = MagicMock(return_value=first_batch)
+        scheduler.update_running_batch = MagicMock(side_effect=next_batches)
+        scheduler.run_batch = MagicMock(return_value=object())
+        scheduler.process_batch_result = MagicMock()
+
+        with self.assertRaises(_LoopExit):
+            scheduler.event_loop_normal()
+
+        # 1 initial decode + (num_continuous_decode_steps - 1) continuous decodes.
+        self.assertEqual(scheduler.run_batch.call_count, 4)
+        self.assertEqual(scheduler.process_batch_result.call_count, 4)
+        self.assertEqual(scheduler.update_running_batch.call_count, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

`num_continuous_decode_steps` is already exposed in the server arguments, but it was not fully wired into the scheduler runtime path. This PR implements and activates that option so the configured value actually takes effect during continuous decode scheduling.

## Modifications

- Added `num_continuous_decode_steps` initialization in scheduler runtime state.
- Implemented multi-step decode execution in `event_loop_normal()`:
  - After one decode step, the scheduler can run additional decode steps in the same loop (`steps - 1`) when conditions are safe.
- Implemented multi-step decode execution in `event_loop_overlap()` with the same guard logic.
- Added `_can_run_continuous_decode(...)` safety gate to avoid harmful cases:
  - disabled when steps <= 1
  - non-decode batch
  - engine paused
  - pending requests in waiting queue
  - chunked prefill in progress
- Refactored overlap-loop execution into `run_one_overlap_step(...)` to keep behavior consistent across repeated decode steps.
- Added unit tests in `test_scheduler_continuous_decode.py` for:
  - positive/negative `_can_run_continuous_decode` cases
  - verifying that `num_continuous_decode_steps > 1` actually triggers multiple decode runs

## Accuracy Tests

Unit tests:
  - `pytest -q test/registered/unit/managers/test_scheduler_continuous_decode.py`
  - Result: `4 passed`

Output consistency (deterministic decode params: `temperature=0, top_k=1, top_p=1`):
  - Sequential comparison (`steps=1` vs `steps=16`): `32/32` exact match (`100%`)

## Speed Tests and Profiling

Configuration:
- model: `Qwen2.5-7B-Instruct`
- GPUs: `2 x RTX 5090`
- attention backend: `triton`
- matrix: `overlap={on,off} x tp={1,2} x seed={123,456,789} x steps={1,2,4,8,16}`
- total runs: `60` (all present)
- profile: `num_prompts=480`, `input=512`, `output=128`, `range_ratio=0.5`, `request_rate=20`, `max_concurrency=64`, `warmup=32`
- shared args: `disable_stream=true`, `flush_cache=true`, `temperature=0`, `top_k=1`, `top_p=1`

Results (TP=1, mean over 3 seeds):
| steps | on req/s | on output tok/s | on mean TTFT (ms) | off req/s | off output tok/s | off mean TTFT (ms) | on-vs-off output | on-vs-off TTFT (ms) |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1  | 14.57 | 1397.23 | 4262.92 | 15.86 | 1520.84 | 3697.69 | `-8.13%`  | `+565.22` |
| 2  | 14.62 | 1402.51 | 4222.49 | 15.97 | 1531.47 | 3669.53 | `-8.42%`  | `+552.96` |
| 4  | 16.97 | 1627.00 | 3369.60 | 16.29 | 1562.35 | 3575.50 | `+4.14%`  | `-205.90` |
| 8  | 17.27 | 1656.24 | 3291.14 | 16.65 | 1596.73 | 3474.47 | `+3.73%`  | `-183.33` |
| 16 | 14.85 | 1425.17 | 4079.72 | 16.72 | 1603.20 | 3439.24 | `-11.10%` | `+640.48` |

Results (TP=2, mean over 3 seeds):
| steps | on req/s | on output tok/s | on mean TTFT (ms) | off req/s | off output tok/s | off mean TTFT (ms) | on-vs-off output | on-vs-off TTFT (ms) |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1  | 8.62 | 826.68 | 7106.29 | 8.31 | 797.38 | 7360.65 | `+3.68%` | `-254.37` |
| 2  | 8.92 | 855.85 | 6851.63 | 8.37 | 802.41 | 7315.21 | `+6.66%` | `-463.57` |
| 4  | 9.02 | 865.18 | 6770.47 | 8.47 | 812.38 | 7219.54 | `+6.50%` | `-449.07` |
| 8  | 9.13 | 875.62 | 6683.67 | 8.65 | 829.73 | 7060.52 | `+5.53%` | `-376.85` |
| 16 | 9.41 | 902.43 | 6472.93 | 8.79 | 843.33 | 6928.54 | `+7.01%` | `-455.61` |

Metric change summary (best step vs step=1):
- TP=1, overlap=on: best `step=8`, output `+18.54%`, mean TTFT `-971.78 ms`
- TP=1, overlap=off: best `step=16`, output `+5.42%`, mean TTFT `-258.45 ms`
- TP=2, overlap=on: best `step=16`, output `+9.16%`, mean TTFT `-633.36 ms`
- TP=2, overlap=off: best `step=16`, output `+5.76%`, mean TTFT `-432.12 ms`

Performance improves with higher num_continuous_decode_steps mainly because the scheduler control path is executed less frequently per generated token。
<img width="2027" height="365" alt="image" src="https://github.com/user-attachments/assets/77fb1d29-d240-4609-bcdd-9c4b956796cf" />
<img width="2027" height="365" alt="image" src="https://github.com/user-attachments/assets/9931433c-7a78-4f54-af3e-df3158d85fe1" />

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
