### PR TITLE
[KVCache] TurboQuant v2: fused Triton KV cache compression (3.88x, 93-105% decode throughput)

### DIFF
--- a/benchmark/turboquant/bench_niah_turboquant.py
+++ b/benchmark/turboquant/bench_niah_turboquant.py
@@ -1,0 +1,207 @@
+"""
+Needle-in-a-Haystack (NIAH) benchmark for TurboQuant KV cache.
+
+Tests whether the model can retrieve specific facts embedded in long contexts
+when using TurboQuant compressed KV cache.
+
+Features:
+- 5 different needle types (number, password, name, city, speed)
+- Multiple context lengths and insertion depths
+- Repeat testing with pass rate matrix
+- Fuzzy answer matching
+
+Usage:
+    # Start server first:
+    python -m sglang.launch_server --model-path <model> --port 30001 \
+        --kv-cache-dtype turboquant_3bit --disable-cuda-graph
+
+    # Quick test:
+    python bench_niah_turboquant.py --port 30001
+
+    # Full test with repeats:
+    python bench_niah_turboquant.py --port 30001 \
+        --context-lengths 512 1024 2048 4096 \
+        --depth-percents 10 25 50 75 90 \
+        --repeat 3 --verbose
+"""
+
+import argparse
+import json
+import re
+import time
+from collections import defaultdict
+
+import requests
+
+NEEDLES = [
+    {
+        "needle": "The special magic number is 9174826.",
+        "question": "What is the special magic number mentioned in the text? Reply with ONLY the number.",
+        "expected": ["9174826"],
+    },
+    {
+        "needle": "The secret password for the vault is 'crystalline-7842'.",
+        "question": "What is the secret password for the vault? Reply with ONLY the password.",
+        "expected": ["crystalline-7842"],
+    },
+    {
+        "needle": "The capital of the fictional country Zephyria is Windmere.",
+        "question": "What is the capital of Zephyria? Reply with ONLY the city name.",
+        "expected": ["Windmere", "windmere"],
+    },
+    {
+        "needle": "Dr. Elena Chen won the Nobel Prize in Physics in 2031.",
+        "question": "Who won the Nobel Prize in Physics in 2031? Reply with ONLY the full name.",
+        "expected": ["Elena Chen", "elena chen"],
+    },
+    {
+        "needle": "The maximum speed of the X-47 aircraft is 2,450 kilometers per hour.",
+        "question": "What is the maximum speed of the X-47 aircraft in km/h? Reply with ONLY the number.",
+        "expected": ["2450", "2,450"],
+    },
+]
+
+FILLER_PARAGRAPH = (
+    "The development of artificial intelligence has been one of the most significant "
+    "technological advances of the 21st century. Machine learning algorithms have "
+    "transformed industries ranging from healthcare to finance. Neural networks, "
+    "inspired by biological brain structures, can now process images, understand "
+    "natural language, and generate creative content. Researchers continue to push "
+    "the boundaries of what these systems can achieve, while also grappling with "
+    "important questions about safety, fairness, and alignment. The intersection "
+    "of AI with other fields like robotics, quantum computing, and biotechnology "
+    "promises even more transformative applications in the years ahead. "
+)
+
+
+def build_context(target_length: int, depth_percent: float, needle_text: str) -> str:
+    target_chars = target_length * 4
+    filler = FILLER_PARAGRAPH * (target_chars // len(FILLER_PARAGRAPH) + 1)
+
+    insert_pos = int(len(filler) * depth_percent / 100.0)
+    insert_pos = filler.rfind(". ", 0, insert_pos)
+    if insert_pos == -1:
+        insert_pos = 0
+    else:
+        insert_pos += 2
+
+    context = filler[:insert_pos] + needle_text + " " + filler[insert_pos:]
+    return context[:target_chars]
+
+
+def query_server(port: int, context: str, question: str, model: str) -> str:
+    url = f"http://localhost:{port}/v1/chat/completions"
+    messages = [
+        {"role": "user", "content": f"Read the following text carefully:\n\n{context}\n\n{question}"}
+    ]
+    payload = {"model": model, "messages": messages, "max_tokens": 64, "temperature": 0}
+    try:
+        resp = requests.post(url, json=payload, timeout=180)
+        resp.raise_for_status()
+        return resp.json()["choices"][0]["message"]["content"]
+    except Exception as e:
+        return f"ERROR: {e}"
+
+
+def check_answer(response: str, expected_list: list[str]) -> bool:
+    response_clean = re.sub(r"[^\w\s-]", "", response.lower().strip())
+    for expected in expected_list:
+        expected_clean = re.sub(r"[^\w\s-]", "", expected.lower().strip())
+        if expected_clean in response_clean:
+            return True
+    return False
+
+
+def main():
+    parser = argparse.ArgumentParser(description="NIAH benchmark for TurboQuant")
+    parser.add_argument("--port", type=int, default=30001)
+    parser.add_argument("--model", type=str, default="default")
+    parser.add_argument("--context-lengths", type=int, nargs="+", default=[512, 1024, 2048, 4096])
+    parser.add_argument("--depth-percents", type=int, nargs="+", default=[10, 25, 50, 75, 90])
+    parser.add_argument("--repeat", type=int, default=1, help="Repeat each test N times")
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+
+    print("NIAH Benchmark for TurboQuant")
+    print(f"Server: localhost:{args.port}")
+    print(f"Context lengths: {args.context_lengths}")
+    print(f"Depth percents: {args.depth_percents}")
+    print(f"Needles: {len(NEEDLES)} types, repeats: {args.repeat}")
+    print("=" * 80)
+
+    # results[ctx_len][depth] = (pass_count, total_count)
+    matrix = defaultdict(lambda: defaultdict(lambda: [0, 0]))
+    all_results = []
+    needle_idx = 0
+
+    for ctx_len in args.context_lengths:
+        for depth in args.depth_percents:
+            for rep in range(args.repeat):
+                needle = NEEDLES[needle_idx % len(NEEDLES)]
+                needle_idx += 1
+
+                context = build_context(ctx_len, depth, needle["needle"])
+                t0 = time.time()
+                response = query_server(args.port, context, needle["question"], args.model)
+                elapsed = time.time() - t0
+
+                is_correct = check_answer(response, needle["expected"])
+                matrix[ctx_len][depth][1] += 1
+                if is_correct:
+                    matrix[ctx_len][depth][0] += 1
+
+                status = "PASS" if is_correct else "FAIL"
+                print(f"  ctx={ctx_len:5d}  depth={depth:3d}%  rep={rep+1}  {status}  ({elapsed:.1f}s)")
+                if args.verbose or not is_correct:
+                    print(f"    Needle: {needle['needle'][:60]}...")
+                    print(f"    Response: {response[:200]}")
+
+                all_results.append({
+                    "context_length": ctx_len,
+                    "depth_percent": depth,
+                    "repeat": rep + 1,
+                    "needle": needle["needle"][:60],
+                    "correct": is_correct,
+                    "response": response[:500],
+                    "elapsed_s": round(elapsed, 2),
+                })
+
+    # Print pass rate matrix
+    print("\n" + "=" * 80)
+    print("NIAH Results Matrix:")
+    print()
+    header = f"{'depth%':>8s}"
+    for ctx_len in args.context_lengths:
+        header += f"  {ctx_len:>6d}"
+    print(header)
+
+    total_pass = 0
+    total_count = 0
+    for depth in args.depth_percents:
+        row = f"{depth:>7d}%"
+        for ctx_len in args.context_lengths:
+            p, t = matrix[ctx_len][depth]
+            total_pass += p
+            total_count += t
+            row += f"  {p:>2d}/{t:<2d} "
+        print(row)
+
+    print()
+    pct = 100 * total_pass / max(total_count, 1)
+    print(f"Overall: {total_pass}/{total_count} ({pct:.1f}%)")
+
+    # Save results
+    out_file = f"niah_results_{args.port}.json"
+    with open(out_file, "w") as f:
+        json.dump({
+            "port": args.port,
+            "model": args.model,
+            "repeat": args.repeat,
+            "results": all_results,
+            "score": f"{total_pass}/{total_count} ({pct:.1f}%)",
+        }, f, indent=2)
+    print(f"Results saved to {out_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sglang/jit_kernel/csrc/fast-hadamard-transform/fast_hadamard_transform.h
+++ b/python/sglang/jit_kernel/csrc/fast-hadamard-transform/fast_hadamard_transform.h
@@ -21,4 +21,10 @@ struct HadamardParamsBase {
   // Common data pointers.
   void* __restrict__ x_ptr;
   void* __restrict__ out_ptr;
+
+  // Optional per-element sign vectors for fused WHT rotation.
+  // When non-null, load multiplies by signs1 and store multiplies by signs2.
+  // Shape: (dim,) float32. Set to nullptr to skip.
+  const float* __restrict__ signs1_ptr;
+  const float* __restrict__ signs2_ptr;
 };

--- a/python/sglang/jit_kernel/csrc/fast-hadamard-transform/fast_hadamard_transform_common.h
+++ b/python/sglang/jit_kernel/csrc/fast-hadamard-transform/fast_hadamard_transform_common.h
@@ -176,6 +176,52 @@ inline __device__ void store_output(output_t* out, float out_vals[kNChunks][kNEl
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+// Fused WHT rotation variants: apply per-element signs during load/store
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <int kNChunks, int kNElts, typename input_t>
+inline __device__ void load_input_with_signs(input_t* x, float x_vals[kNChunks][kNElts], int dim,
+                                              const float* __restrict__ signs) {
+  using vec_t = typename BytesToType<sizeof(input_t) * kNElts>::Type;
+  input_t x_vals_load[kNChunks][kNElts] = {0};
+#pragma unroll
+  for (int c = 0; c < kNChunks; ++c) {
+    if ((c * blockDim.x + threadIdx.x) * kNElts < dim) {
+      reinterpret_cast<vec_t*>(x_vals_load)[c] = reinterpret_cast<const vec_t*>(x)[c * blockDim.x + threadIdx.x];
+    }
+  }
+#pragma unroll
+  for (int c = 0; c < kNChunks; ++c) {
+    int base_idx = (c * blockDim.x + threadIdx.x) * kNElts;
+#pragma unroll
+    for (int i = 0; i < kNElts; ++i) {
+      x_vals[c][i] = float(x_vals_load[c][i]) * signs[base_idx + i];
+    }
+  }
+}
+
+template <int kNChunks, int kNElts, typename output_t>
+inline __device__ void store_output_with_signs(output_t* out, float out_vals[kNChunks][kNElts], int dim,
+                                                float scale, const float* __restrict__ signs) {
+  using vec_t = typename BytesToType<sizeof(output_t) * kNElts>::Type;
+  output_t out_vals_store[kNChunks][kNElts];
+#pragma unroll
+  for (int c = 0; c < kNChunks; ++c) {
+    int base_idx = (c * blockDim.x + threadIdx.x) * kNElts;
+#pragma unroll
+    for (int i = 0; i < kNElts; ++i) {
+      out_vals_store[c][i] = out_vals[c][i] * signs[base_idx + i] * scale;
+    }
+  }
+#pragma unroll
+  for (int c = 0; c < kNChunks; ++c) {
+    if ((c * blockDim.x + threadIdx.x) * kNElts < dim) {
+      reinterpret_cast<vec_t*>(out)[c * blockDim.x + threadIdx.x] = reinterpret_cast<const vec_t*>(out_vals_store)[c];
+    }
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // Pre=true means the exchange before the hadamard_mult_warp, Pre=false means after.
 template <int kNChunks, int kChunksPerExchange, int kNElts, int kWarpSize, int kNWarps, bool Pre, typename vec_t>

--- a/python/sglang/jit_kernel/csrc/fast-hadamard-transform/hadamard_jit.cuh
+++ b/python/sglang/jit_kernel/csrc/fast-hadamard-transform/hadamard_jit.cuh
@@ -197,6 +197,89 @@ __global__ __launch_bounds__(Ktraits::kNThreads) void fast_hadamard_transform_ke
   store_output<kNChunks, kNElts, input_t>(out, x_vals, params.dim, params.scale);
 }
 
+// Fused WHT rotation kernel: out = signs2 * H(signs1 * x) * scale
+template <typename Ktraits>
+__global__ __launch_bounds__(Ktraits::kNThreads) void fast_hadamard_transform_with_signs_kernel(HadamardParamsBase params) {
+  constexpr int kNThreads = Ktraits::kNThreads;
+  constexpr int kNElts = Ktraits::kNElts;
+  constexpr int kNExchangePerVec = Ktraits::kNExchangePerVec;
+  constexpr int kNChunks = Ktraits::kNChunks;
+  using input_t = typename Ktraits::input_t;
+  using vec_t = typename Ktraits::vec_t;
+
+  constexpr int kLogNElts = cilog2(Ktraits::kNElts);
+  static_assert(1 << kLogNElts == kNElts, "kNElts must be a power of 2");
+
+  constexpr int kWarpSize = kNThreads < 32 ? kNThreads : 32;
+  constexpr int kLogWarpSize = cilog2(kWarpSize);
+  static_assert(1 << kLogWarpSize == kWarpSize, "Warp size must be a power of 2");
+
+  constexpr int kNWarps = kNThreads / kWarpSize;
+  constexpr int kLogNWarps = cilog2(kNWarps);
+  static_assert(1 << kLogNWarps == kNWarps, "kNWarps must be a power of 2");
+
+  constexpr int kChunksPerExchange = Ktraits::kSmemExchangeSize / (sizeof(vec_t) * kNExchangePerVec * kNThreads);
+  static_assert(kChunksPerExchange * sizeof(vec_t) * kNExchangePerVec * kNThreads == Ktraits::kSmemExchangeSize);
+  constexpr int kNExchanges = kNChunks / kChunksPerExchange;
+  static_assert(kNExchanges * kChunksPerExchange == kNChunks);
+
+  extern __shared__ char smem_[];
+  vec_t* smem_exchange = reinterpret_cast<vec_t*>(smem_);
+
+  const int batch_id = static_cast<int>(blockIdx.x);
+  input_t* x = reinterpret_cast<input_t*>(params.x_ptr) + batch_id * params.x_batch_stride;
+  input_t* out = reinterpret_cast<input_t*>(params.out_ptr) + batch_id * params.out_batch_stride;
+
+  float x_vals[kNChunks][kNElts];
+  // Fused: load + multiply by signs1
+  load_input_with_signs<kNChunks, kNElts, input_t>(x, x_vals, params.dim, params.signs1_ptr);
+
+  hadamard_mult_thread<kLogNElts, kNChunks>(x_vals);
+  hadamard_mult_warp<kLogWarpSize, 0, kNChunks, kNElts>(x_vals);
+
+  if constexpr (kNWarps > 1) {
+    exchange_smem_pre<kNChunks, kChunksPerExchange, kNElts, kWarpSize, kNWarps, true, vec_t>(x_vals, smem_exchange);
+    hadamard_mult_warp<kLogNWarps, 0, kNChunks, kNElts>(x_vals);
+    exchange_smem_pre<kNChunks, kChunksPerExchange, kNElts, kWarpSize, kNWarps, false, vec_t>(x_vals, smem_exchange);
+  }
+
+  if constexpr (kNChunks > 1) {
+    float x_vals_transposed[kNElts][kNChunks];
+#pragma unroll
+    for (int c = 0; c < kNChunks; ++c) {
+#pragma unroll
+      for (int i = 0; i < kNElts; ++i) {
+        x_vals_transposed[i][c] = x_vals[c][i];
+      }
+    }
+
+    if constexpr (kNChunks == 12) {
+      hadamard_mult_thread_chunk_12<kNElts>(x_vals_transposed);
+    } else if constexpr (kNChunks == 20) {
+      hadamard_mult_thread_chunk_20<kNElts>(x_vals_transposed);
+    } else if constexpr (kNChunks == 28) {
+      hadamard_mult_thread_chunk_28<kNElts>(x_vals_transposed);
+    } else if constexpr (kNChunks == 40) {
+      hadamard_mult_thread_chunk_40<kNElts>(x_vals_transposed);
+    } else {
+      constexpr int kLogNChunks = cilog2(kNChunks);
+      static_assert(1 << kLogNChunks == kNChunks, "kNChunks must be a power of 2");
+      hadamard_mult_thread<kLogNChunks, kNElts>(x_vals_transposed);
+    }
+
+#pragma unroll
+    for (int c = 0; c < kNChunks; ++c) {
+#pragma unroll
+      for (int i = 0; i < kNElts; ++i) {
+        x_vals[c][i] = x_vals_transposed[i][c];
+      }
+    }
+  }
+
+  // Fused: multiply by signs2 + scale + store
+  store_output_with_signs<kNChunks, kNElts, input_t>(out, x_vals, params.dim, params.scale, params.signs2_ptr);
+}
+
 template <typename Ktraits>
 inline void set_max_dynamic_smem() {
   constexpr int kSmemSize = Ktraits::kSmemSize;
@@ -476,6 +559,113 @@ template <typename DType>
 struct Hadamard40NKernel {
   static void run(const tvm::ffi::TensorView x, const tvm::ffi::TensorView out, float scale) {
     run_hadamard<40, DType>(x, out, scale);
+  }
+};
+
+
+// --- Fused WHT rotation: launch helpers ---
+
+template <typename Ktraits>
+inline void launch_kernel_with_signs(HadamardParamsBase& params, DLDevice device) {
+  constexpr int kSmemSize = Ktraits::kSmemSize;
+  set_max_dynamic_smem<Ktraits>();
+  auto kernel = &fast_hadamard_transform_with_signs_kernel<Ktraits>;
+  host::LaunchKernel(dim3(params.batch), dim3(Ktraits::kNThreads), device, kSmemSize)(kernel, params);
+  host::RuntimeDeviceCheck();
+}
+
+template <int kNThreads, int kLogN, typename input_t>
+inline void fast_hadamard_transform_with_signs_launch(HadamardParamsBase& params, DLDevice device) {
+  using Ktraits = FastHadamardKernelTraits<kNThreads, kLogN, input_t>;
+  launch_kernel_with_signs<Ktraits>(params, device);
+}
+
+template <typename input_t>
+inline void fast_hadamard_transform_with_signs_cuda(HadamardParamsBase& params, DLDevice device) {
+  if (params.log_N == 3) {
+    fast_hadamard_transform_with_signs_launch<1, 3, input_t>(params, device);
+  } else if (params.log_N == 4) {
+    fast_hadamard_transform_with_signs_launch<2, 4, input_t>(params, device);
+  } else if (params.log_N == 5) {
+    fast_hadamard_transform_with_signs_launch<4, 5, input_t>(params, device);
+  } else if (params.log_N == 6) {
+    fast_hadamard_transform_with_signs_launch<8, 6, input_t>(params, device);
+  } else if (params.log_N == 7) {
+    fast_hadamard_transform_with_signs_launch<16, 7, input_t>(params, device);
+  } else if (params.log_N == 8) {
+    fast_hadamard_transform_with_signs_launch<32, 8, input_t>(params, device);
+  } else if (params.log_N == 9) {
+    fast_hadamard_transform_with_signs_launch<32, 9, input_t>(params, device);
+  } else if (params.log_N == 10) {
+    fast_hadamard_transform_with_signs_launch<128, 10, input_t>(params, device);
+  } else if (params.log_N == 11) {
+    fast_hadamard_transform_with_signs_launch<256, 11, input_t>(params, device);
+  } else if (params.log_N == 12) {
+    fast_hadamard_transform_with_signs_launch<256, 12, input_t>(params, device);
+  } else if (params.log_N == 13) {
+    fast_hadamard_transform_with_signs_launch<256, 13, input_t>(params, device);
+  } else if (params.log_N == 14) {
+    fast_hadamard_transform_with_signs_launch<256, 14, input_t>(params, device);
+  } else if (params.log_N == 15) {
+    fast_hadamard_transform_with_signs_launch<256, 15, input_t>(params, device);
+  } else {
+    host::Panic("fast_hadamard_transform_with_signs: unsupported log_N=", params.log_N);
+  }
+}
+
+inline void set_hadamard_params_with_signs(
+    HadamardParamsBase& params,
+    int64_t batch,
+    int64_t dim,
+    int64_t multiple,
+    const tvm::ffi::TensorView x,
+    const tvm::ffi::TensorView out,
+    const tvm::ffi::TensorView signs1,
+    const tvm::ffi::TensorView signs2,
+    float scale) {
+  set_hadamard_params(params, batch, dim, multiple, x, out, scale);
+  params.signs1_ptr = reinterpret_cast<const float*>(signs1.data_ptr());
+  params.signs2_ptr = reinterpret_cast<const float*>(signs2.data_ptr());
+}
+
+template <int kMultiple, typename DType>
+inline void run_hadamard_with_signs(
+    const tvm::ffi::TensorView x, const tvm::ffi::TensorView out,
+    const tvm::ffi::TensorView signs1, const tvm::ffi::TensorView signs2,
+    float scale) {
+  using namespace host;
+
+  auto N = SymbolicSize{"batch"};
+  auto D = SymbolicSize{"dim"};
+  auto SX = SymbolicSize{"x_batch_stride"};
+  auto SO = SymbolicSize{"out_batch_stride"};
+  auto DS = SymbolicSize{"signs_dim"};
+  auto device = SymbolicDevice{};
+  device.set_options<kDLCUDA>();
+
+  TensorMatcher({N, D}).with_strides({SX, 1}).with_dtype<DType>().with_device(device).verify(x);
+  TensorMatcher({N, D}).with_strides({SO, 1}).with_dtype<DType>().with_device(device).verify(out);
+  TensorMatcher({DS}).with_dtype<float>().with_device(device).verify(signs1);
+  TensorMatcher({DS}).with_dtype<float>().with_device(device).verify(signs2);
+
+  const int64_t batch = N.unwrap();
+  const int64_t dim = D.unwrap();
+
+  RuntimeCheck(dim % 8 == 0, "fast_hadamard_transform_with_signs only supports hidden dim divisible by 8");
+  RuntimeCheck(dim <= 32768, "fast_hadamard_transform_with_signs only supports hidden dim <= 32768");
+  RuntimeCheck(DS.unwrap() == dim, "signs dim must match input dim");
+
+  HadamardParamsBase params;
+  set_hadamard_params_with_signs(params, batch, dim, kMultiple, x, out, signs1, signs2, scale);
+  fast_hadamard_transform_with_signs_cuda<DType>(params, device.unwrap());
+}
+
+template <typename DType>
+struct HadamardWithSignsKernel {
+  static void run(const tvm::ffi::TensorView x, const tvm::ffi::TensorView out,
+                  const tvm::ffi::TensorView signs1, const tvm::ffi::TensorView signs2,
+                  float scale) {
+    run_hadamard_with_signs<1, DType>(x, out, signs1, signs2, scale);
   }
 };
 

--- a/python/sglang/jit_kernel/csrc/tq_decode/tq4_decode_stage1.cu
+++ b/python/sglang/jit_kernel/csrc/tq_decode/tq4_decode_stage1.cu
@@ -1,0 +1,273 @@
+/*
+ * TQ4 Decode Attention Stage1 v2 — 3-Phase CUDA Kernel
+ *
+ * Phase 1 (QK):  lane→token, loop over packed_dim, compute qk per token
+ * Phase 2 (softmax): warp reduce max/sum, compute p, store to smem
+ * Phase 3 (V accum): lane→dimension, loop over tokens, load V + weighted accum
+ *
+ * This avoids per-token warp reductions for V and enables coalesced V loads.
+ */
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <float.h>
+#include <math.h>
+#include <stdint.h>
+#include <torch/extension.h>
+
+constexpr int HEAD_DIM = 128;
+constexpr int PACKED_DIM = 64;
+constexpr int BLOCK_N = 32;     // tokens per tile (doubled from Triton)
+constexpr int BLOCK_H = 4;
+constexpr int WARP_SIZE = 32;
+constexpr int NUM_WARPS = BLOCK_H;  // 1 warp per Q head
+constexpr int BLOCK_SIZE = NUM_WARPS * WARP_SIZE;  // 128
+constexpr int MIN_BLOCK_KV = 32;
+
+// packed positions per lane: PACKED_DIM / WARP_SIZE = 2
+constexpr int PP_PER_LANE = PACKED_DIM / WARP_SIZE;  // 2
+
+__device__ __forceinline__ float warp_reduce_sum(float val) {
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        val += __shfl_xor_sync(0xffffffff, val, offset);
+    return val;
+}
+
+__device__ __forceinline__ float warp_reduce_max(float val) {
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        val = fmaxf(val, __shfl_xor_sync(0xffffffff, val, offset));
+    return val;
+}
+
+__global__ void tq4_decode_stage1_v2(
+    const __nv_bfloat16* __restrict__ Q,
+    const uint8_t* __restrict__ K_packed,
+    const uint8_t* __restrict__ V_packed,
+    const __nv_bfloat16* __restrict__ K_dscale,
+    const __nv_bfloat16* __restrict__ V_dscale,
+    const int32_t* __restrict__ kv_indptr,
+    const int32_t* __restrict__ kv_indices,
+    const int32_t* __restrict__ num_kv_splits,
+    float* __restrict__ att_out,
+    float* __restrict__ att_lse,
+    const float* __restrict__ k_centroids,
+    const float* __restrict__ v_centroids,
+    float sm_scale,
+    int H_Q, int H_KV, int max_kv_splits,
+    int stride_q_batch, int stride_q_head,
+    int stride_kp_pool, int stride_kp_head,
+    int stride_vp_pool, int stride_vp_head,
+    int stride_kds_pool, int stride_vds_pool,
+    int stride_att_batch, int stride_att_head, int stride_att_split,
+    int kv_group_num
+) {
+    const int batch_id = blockIdx.x;
+    const int head_group_id = blockIdx.y;
+    const int split_id = blockIdx.z;
+    const int warp_id = threadIdx.x / WARP_SIZE;
+    const int lane_id = threadIdx.x % WARP_SIZE;
+
+    const int q_head = head_group_id * BLOCK_H + warp_id;
+    if (q_head >= H_Q) return;
+    const int kv_head = q_head / kv_group_num;
+
+    // KV split range
+    const int kv_start = kv_indptr[batch_id];
+    const int kv_end = kv_indptr[batch_id + 1];
+    const int kv_len = kv_end - kv_start;
+    const int n_splits = num_kv_splits[batch_id];
+    const int split_len = (kv_len + n_splits - 1) / n_splits;
+    const int aligned_len = ((split_len + MIN_BLOCK_KV - 1) / MIN_BLOCK_KV) * MIN_BLOCK_KV;
+    const int my_start = kv_start + split_id * aligned_len;
+    const int my_end = min(my_start + aligned_len, kv_end);
+
+    if (my_start >= kv_end) {
+        if (lane_id == 0) {
+            att_lse[batch_id * H_Q * max_kv_splits + q_head * max_kv_splits + split_id] = -FLT_MAX;
+        }
+        return;
+    }
+
+    // ---- Shared memory ----
+    __shared__ float s_k_cb[16];    // K codebook
+    __shared__ float s_v_cb[16];    // V codebook
+    // Q in shared memory: [BLOCK_H][PACKED_DIM] for even and odd
+    __shared__ float s_q_even[BLOCK_H][PACKED_DIM];
+    __shared__ float s_q_odd[BLOCK_H][PACKED_DIM];
+    // Per-tile: softmax weights and token indices
+    __shared__ float s_p[BLOCK_H][BLOCK_N];
+    __shared__ int s_kv_idx[BLOCK_N];
+    __shared__ float s_kds[BLOCK_N];  // K dequant scales
+    __shared__ float s_vds[BLOCK_N];  // V dequant scales
+
+    // Load codebook (first 16 threads)
+    if (threadIdx.x < 16) {
+        s_k_cb[threadIdx.x] = k_centroids[threadIdx.x];
+        s_v_cb[threadIdx.x] = v_centroids[threadIdx.x];
+    }
+
+    // Load Q to shared memory
+    // Each lane loads 2 positions for its warp's Q head
+    {
+        const __nv_bfloat16* q_ptr = Q + batch_id * stride_q_batch + q_head * stride_q_head;
+        for (int i = 0; i < PP_PER_LANE; i++) {
+            int pp = lane_id * PP_PER_LANE + i;
+            if (pp < PACKED_DIM) {
+                s_q_even[warp_id][pp] = __bfloat162float(q_ptr[2 * pp]);
+                s_q_odd[warp_id][pp] = __bfloat162float(q_ptr[2 * pp + 1]);
+            }
+        }
+    }
+    __syncthreads();
+
+    // Accumulators for V (lane→dimension mapping in phase 3)
+    // Each lane handles PP_PER_LANE=2 packed positions → 4 output values
+    float acc_even[PP_PER_LANE] = {0.0f, 0.0f};
+    float acc_odd[PP_PER_LANE] = {0.0f, 0.0f};
+    float e_max = -FLT_MAX;
+    float e_sum = 0.0f;
+
+    // Main loop over token tiles
+    for (int tok_start = my_start; tok_start < my_end; tok_start += BLOCK_N) {
+        const int n_valid = min(BLOCK_N, my_end - tok_start);
+
+        // Load token indices and dequant scales to shared memory
+        if (lane_id < BLOCK_N) {
+            int tok = tok_start + lane_id;
+            bool valid = tok < my_end;
+            int idx = valid ? kv_indices[tok] : 0;
+            s_kv_idx[lane_id] = idx;
+            s_kds[lane_id] = valid ? __bfloat162float(K_dscale[idx * stride_kds_pool + kv_head]) : 0.0f;
+            s_vds[lane_id] = valid ? __bfloat162float(V_dscale[idx * stride_vds_pool + kv_head]) : 0.0f;
+        }
+        __syncwarp();
+
+        // ======== Phase 1: QK computation (lane→token) ========
+        // Each lane handles 1 token, loops over packed_dim
+        float qk;
+        {
+            bool valid = lane_id < n_valid;
+            int kv_idx = s_kv_idx[lane_id];
+
+            float local_qk = 0.0f;
+            if (valid) {
+                const uint8_t* k_ptr = K_packed + kv_idx * stride_kp_pool + kv_head * stride_kp_head;
+                #pragma unroll 8
+                for (int p = 0; p < PACKED_DIM; p++) {
+                    uint8_t kb = k_ptr[p];
+                    float k_e = s_k_cb[kb & 0x0F];
+                    float k_o = s_k_cb[(kb >> 4) & 0x0F];
+                    local_qk += s_q_even[warp_id][p] * k_e + s_q_odd[warp_id][p] * k_o;
+                }
+                local_qk *= s_kds[lane_id] * sm_scale;
+            }
+            qk = valid ? local_qk : -FLT_MAX;
+        }
+
+        // ======== Phase 2: Online softmax ========
+        float tile_max = warp_reduce_max(qk);
+        float old_max = e_max;
+        e_max = fmaxf(e_max, tile_max);
+        float exp_correction = expf(old_max - e_max);
+
+        float p = expf(qk - e_max);
+        if (lane_id >= n_valid) p = 0.0f;
+
+        float p_sum = warp_reduce_sum(p);
+
+        // Rescale accumulators
+        #pragma unroll
+        for (int i = 0; i < PP_PER_LANE; i++) {
+            acc_even[i] *= exp_correction;
+            acc_odd[i] *= exp_correction;
+        }
+        e_sum = e_sum * exp_correction + p_sum;
+
+        // Store p * v_dscale to shared memory for phase 3
+        float p_scaled = (lane_id < n_valid) ? p * s_vds[lane_id] : 0.0f;
+        s_p[warp_id][lane_id] = p_scaled;
+        __syncwarp();
+
+        // ======== Phase 3: V accumulation (lane→dimension) ========
+        // Each lane handles PP_PER_LANE=2 packed positions, loops over n_valid tokens
+        for (int n = 0; n < n_valid; n++) {
+            float pn = s_p[warp_id][n];
+            if (pn == 0.0f) continue;
+
+            int kv_idx = s_kv_idx[n];
+            const uint8_t* v_ptr = V_packed + kv_idx * stride_vp_pool + kv_head * stride_vp_head;
+
+            #pragma unroll
+            for (int i = 0; i < PP_PER_LANE; i++) {
+                int pp = lane_id * PP_PER_LANE + i;
+                uint8_t vb = v_ptr[pp];
+                acc_even[i] += pn * s_v_cb[vb & 0x0F];
+                acc_odd[i] += pn * s_v_cb[(vb >> 4) & 0x0F];
+            }
+        }
+    }
+
+    // ======== Store output (interleaved) ========
+    float inv_sum = (e_sum > 0.0f) ? (1.0f / e_sum) : 0.0f;
+    int out_base = batch_id * stride_att_batch + q_head * stride_att_head + split_id * stride_att_split;
+
+    #pragma unroll
+    for (int i = 0; i < PP_PER_LANE; i++) {
+        int pp = lane_id * PP_PER_LANE + i;
+        att_out[out_base + 2 * pp] = acc_even[i] * inv_sum;
+        att_out[out_base + 2 * pp + 1] = acc_odd[i] * inv_sum;
+    }
+
+    // Store LSE
+    if (lane_id == 0) {
+        int lse_idx = batch_id * H_Q * max_kv_splits + q_head * max_kv_splits + split_id;
+        att_lse[lse_idx] = e_max + logf(fmaxf(e_sum, 1e-10f));
+    }
+}
+
+
+void tq4_decode_stage1(
+    torch::Tensor Q, torch::Tensor K_packed, torch::Tensor V_packed,
+    torch::Tensor K_dscale, torch::Tensor V_dscale,
+    torch::Tensor kv_indptr, torch::Tensor kv_indices,
+    torch::Tensor num_kv_splits_tensor,
+    torch::Tensor att_out, torch::Tensor att_lse,
+    torch::Tensor k_centroids, torch::Tensor v_centroids,
+    float sm_scale, int max_kv_splits
+) {
+    const int batch = Q.size(0);
+    const int h_q = Q.size(1);
+    const int h_kv = K_packed.size(1);
+    const int kv_group = h_q / h_kv;
+
+    dim3 grid(batch, (h_q + BLOCK_H - 1) / BLOCK_H, max_kv_splits);
+    dim3 block(BLOCK_SIZE);
+
+    tq4_decode_stage1_v2<<<grid, block>>>(
+        reinterpret_cast<const __nv_bfloat16*>(Q.data_ptr()),
+        K_packed.data_ptr<uint8_t>(),
+        V_packed.data_ptr<uint8_t>(),
+        reinterpret_cast<const __nv_bfloat16*>(K_dscale.data_ptr()),
+        reinterpret_cast<const __nv_bfloat16*>(V_dscale.data_ptr()),
+        kv_indptr.data_ptr<int32_t>(),
+        kv_indices.data_ptr<int32_t>(),
+        num_kv_splits_tensor.data_ptr<int32_t>(),
+        att_out.data_ptr<float>(),
+        att_lse.data_ptr<float>(),
+        k_centroids.data_ptr<float>(),
+        v_centroids.data_ptr<float>(),
+        sm_scale, h_q, h_kv, max_kv_splits,
+        Q.stride(0), Q.stride(1),
+        K_packed.stride(0), K_packed.stride(1),
+        V_packed.stride(0), V_packed.stride(1),
+        K_dscale.stride(0), V_dscale.stride(0),
+        att_out.stride(0), att_out.stride(1), att_out.stride(2),
+        kv_group
+    );
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("tq4_decode_stage1", &tq4_decode_stage1, "TQ4 decode attention stage1 v2");
+}

--- a/python/sglang/jit_kernel/hadamard.py
+++ b/python/sglang/jit_kernel/hadamard.py
@@ -20,6 +20,7 @@ def _jit_hadamard_module(dtype: torch.dtype) -> Module:
         cuda_files=["fast-hadamard-transform/hadamard_jit.cuh"],
         cuda_wrappers=[
             ("hadamard_transform", f"HadamardKernel<{args}>::run"),
+            ("hadamard_transform_with_signs", f"HadamardWithSignsKernel<{args}>::run"),
             ("hadamard_transform_12n", f"Hadamard12NKernel<{args}>::run"),
             ("hadamard_transform_20n", f"Hadamard20NKernel<{args}>::run"),
             ("hadamard_transform_28n", f"Hadamard28NKernel<{args}>::run"),
@@ -59,6 +60,46 @@ def _hadamard_transform_impl(
 def hadamard_transform(x: torch.Tensor, scale: float = 1.0) -> torch.Tensor:
     module = _jit_hadamard_module(x.dtype)
     return _hadamard_transform_impl(x, scale, 8, module.hadamard_transform)
+
+
+def hadamard_transform_with_signs(
+    x: torch.Tensor,
+    signs1: torch.Tensor,
+    signs2: torch.Tensor,
+    scale: float = 1.0,
+) -> torch.Tensor:
+    """Fused WHT rotation: out = signs2 * H(signs1 * x) * scale.
+
+    Fuses signs1 multiply, Hadamard transform, and signs2 multiply into a
+    single CUDA kernel launch, eliminating 2 elementwise kernel launches.
+
+    Args:
+        x: (..., dim) tensor, any dtype. Will be cast to float32 internally.
+        signs1: (dim,) float32 sign vector applied before Hadamard.
+        signs2: (dim,) float32 sign vector applied after Hadamard.
+        scale: scalar multiplier (typically 1/sqrt(dim)).
+
+    Returns:
+        out: same shape as x, float32.
+    """
+    if not x.is_cuda:
+        raise RuntimeError("hadamard_transform_with_signs only supports CUDA tensors")
+
+    shapes_og = x.size()
+    dim_og = x.size(-1)
+
+    x = x.reshape(-1, dim_og)
+    if x.stride(-1) != 1:
+        x = x.contiguous()
+
+    # Use x's native dtype — the CUDA kernel handles bf16/fp16 I/O
+    # with float32 computation internally (load converts to float,
+    # store converts back to input_t)
+    out = torch.empty_like(x)
+    module = _jit_hadamard_module(x.dtype)
+    module.hadamard_transform_with_signs(x, out, signs1, signs2, scale)
+
+    return out.reshape(shapes_og)
 
 
 def hadamard_transform_12n(x: torch.Tensor, scale: float = 1.0) -> torch.Tensor:

--- a/python/sglang/jit_kernel/tq_decode_attention.py
+++ b/python/sglang/jit_kernel/tq_decode_attention.py
@@ -1,0 +1,188 @@
+"""TQ4 CUDA native decode attention — Python wrapper + correctness test.
+
+Compiles the CUDA kernel and provides a drop-in replacement for
+_tq_decode_grouped_att_m_fwd's stage1 call.
+"""
+
+import os
+import math
+import torch
+from torch.utils.cpp_extension import load
+
+_module = None
+
+def _get_module():
+    global _module
+    if _module is None:
+        src_dir = os.path.join(os.path.dirname(__file__), "csrc", "tq_decode")
+        _module = load(
+            name="tq4_decode_cuda",
+            sources=[os.path.join(src_dir, "tq4_decode_stage1.cu")],
+            extra_cuda_cflags=["-O3", "--use_fast_math", "-arch=sm_90"],
+            verbose=False,
+        )
+    return _module
+
+
+def tq4_decode_stage1_cuda(
+    q, k_packed, v_packed, k_dscale, v_dscale,
+    k_centroids, v_centroids, att_out, att_lse,
+    kv_indptr, kv_indices, num_kv_splits, max_kv_splits,
+    sm_scale,
+):
+    """CUDA native TQ4 decode stage1 — drop-in replacement for Triton version."""
+    mod = _get_module()
+    mod.tq4_decode_stage1(
+        q, k_packed, v_packed, k_dscale, v_dscale,
+        kv_indptr, kv_indices, num_kv_splits,
+        att_out, att_lse,
+        k_centroids, v_centroids,
+        sm_scale, max_kv_splits,
+    )
+
+
+def test_correctness(batch=32, seq_len=512, q_heads=32, kv_heads=8, head_dim=128):
+    """Compare CUDA kernel output against Triton kernel output."""
+    import sys
+    sys.path.insert(0, '/workspace/sglang/python')
+
+    from sglang.srt.layers.attention.triton_ops.turboquant_decode_attention import (
+        tq_decode_attention_fwd,
+    )
+    from sglang.srt.layers.quantization.kv_turboquant import build_codebook
+
+    device = "cuda"
+    total_tokens = batch * seq_len
+    packed_dim = head_dim // 2
+    max_kv_splits = 8
+
+    torch.manual_seed(42)
+    q = torch.randn(batch, q_heads, head_dim, dtype=torch.bfloat16, device=device)
+    k_packed = torch.randint(0, 255, (total_tokens, kv_heads, packed_dim), dtype=torch.uint8, device=device)
+    v_packed = torch.randint(0, 255, (total_tokens, kv_heads, packed_dim), dtype=torch.uint8, device=device)
+    k_dscale = (torch.randn(total_tokens, kv_heads, dtype=torch.bfloat16, device=device).abs() + 0.1)
+    v_dscale = (torch.randn(total_tokens, kv_heads, dtype=torch.bfloat16, device=device).abs() + 0.1)
+
+    centroids, _ = build_codebook(4, head_dim)
+    k_centroids = torch.tensor(centroids, dtype=torch.float32, device=device)
+    v_centroids = torch.tensor(centroids, dtype=torch.float32, device=device)
+
+    kv_indptr = torch.arange(0, (batch + 1) * seq_len, seq_len, dtype=torch.int32, device=device)
+    kv_indices = torch.arange(0, total_tokens, dtype=torch.int32, device=device)
+    num_kv_splits_t = torch.full((batch,), 8, dtype=torch.int32, device=device)
+    sm_scale = 1.0 / math.sqrt(head_dim)
+
+    # --- Triton reference ---
+    o_triton = torch.zeros(batch, q_heads, head_dim, dtype=torch.bfloat16, device=device)
+    att_logits_triton = torch.zeros(batch, q_heads, max_kv_splits, head_dim, dtype=torch.float32, device=device)
+    att_lse_triton = torch.zeros(batch, q_heads, max_kv_splits, dtype=torch.float32, device=device)
+
+    tq_decode_attention_fwd(
+        q, k_packed, v_packed, k_dscale, v_dscale,
+        k_centroids, v_centroids, o_triton,
+        kv_indptr, kv_indices, att_logits_triton, att_lse_triton,
+        num_kv_splits_t, max_kv_splits, sm_scale,
+        k_bit_width=4, v_bit_width=4,
+    )
+
+    # --- CUDA kernel ---
+    att_logits_cuda = torch.zeros(batch, q_heads, max_kv_splits, head_dim, dtype=torch.float32, device=device)
+    att_lse_cuda = torch.zeros(batch, q_heads, max_kv_splits, dtype=torch.float32, device=device)
+
+    tq4_decode_stage1_cuda(
+        q, k_packed, v_packed, k_dscale, v_dscale,
+        k_centroids, v_centroids,
+        att_logits_cuda, att_lse_cuda,
+        kv_indptr, kv_indices, num_kv_splits_t, max_kv_splits,
+        sm_scale,
+    )
+
+    # Compare
+    valid_mask = att_lse_triton > -1e30
+    if valid_mask.any():
+        diff_logits = (att_logits_triton - att_logits_cuda).abs()
+        diff_lse = (att_lse_triton - att_lse_cuda).abs()
+        max_diff_logits = diff_logits[valid_mask.unsqueeze(-1).expand_as(diff_logits)].max().item()
+        max_diff_lse = diff_lse[valid_mask].max().item()
+        mean_diff_logits = diff_logits[valid_mask.unsqueeze(-1).expand_as(diff_logits)].mean().item()
+    else:
+        max_diff_logits = max_diff_lse = mean_diff_logits = 0
+
+    print(f"=== Correctness Test (batch={batch}, seq_len={seq_len}) ===")
+    print(f"  att_logits max diff:  {max_diff_logits:.6f}")
+    print(f"  att_logits mean diff: {mean_diff_logits:.6f}")
+    print(f"  att_lse max diff:     {max_diff_lse:.6f}")
+    print(f"  valid splits: {valid_mask.sum().item()}/{valid_mask.numel()}")
+    ok = max_diff_logits < 0.01 and max_diff_lse < 0.1
+    print(f"  PASS: {ok}")
+    return ok
+
+
+def benchmark(batch=32, seq_len=1024, q_heads=32, kv_heads=8, head_dim=128,
+              warmup=10, repeat=100):
+    """Timing comparison: CUDA vs Triton."""
+    import sys
+    sys.path.insert(0, '/workspace/sglang/python')
+
+    from sglang.srt.layers.attention.triton_ops.turboquant_decode_attention import (
+        tq_decode_attention_fwd,
+    )
+    from sglang.srt.layers.quantization.kv_turboquant import build_codebook
+
+    device = "cuda"
+    total_tokens = batch * seq_len
+    packed_dim = head_dim // 2
+    max_kv_splits = 8
+
+    torch.manual_seed(42)
+    q = torch.randn(batch, q_heads, head_dim, dtype=torch.bfloat16, device=device)
+    k_packed = torch.randint(0, 255, (total_tokens, kv_heads, packed_dim), dtype=torch.uint8, device=device)
+    v_packed = torch.randint(0, 255, (total_tokens, kv_heads, packed_dim), dtype=torch.uint8, device=device)
+    k_dscale = (torch.randn(total_tokens, kv_heads, dtype=torch.bfloat16, device=device).abs() + 0.1)
+    v_dscale = (torch.randn(total_tokens, kv_heads, dtype=torch.bfloat16, device=device).abs() + 0.1)
+
+    centroids, _ = build_codebook(4, head_dim)
+    k_centroids = torch.tensor(centroids, dtype=torch.float32, device=device)
+    v_centroids = torch.tensor(centroids, dtype=torch.float32, device=device)
+
+    kv_indptr = torch.arange(0, (batch + 1) * seq_len, seq_len, dtype=torch.int32, device=device)
+    kv_indices = torch.arange(0, total_tokens, dtype=torch.int32, device=device)
+    num_kv_splits_t = torch.full((batch,), 8, dtype=torch.int32, device=device)
+    sm_scale = 1.0 / math.sqrt(head_dim)
+
+    o = torch.zeros(batch, q_heads, head_dim, dtype=torch.bfloat16, device=device)
+    al = torch.zeros(batch, q_heads, max_kv_splits, head_dim, dtype=torch.float32, device=device)
+    lse = torch.zeros(batch, q_heads, max_kv_splits, dtype=torch.float32, device=device)
+
+    def run_triton():
+        tq_decode_attention_fwd(q, k_packed, v_packed, k_dscale, v_dscale,
+                                k_centroids, v_centroids, o, kv_indptr, kv_indices,
+                                al, lse, num_kv_splits_t, max_kv_splits, sm_scale)
+
+    def run_cuda():
+        tq4_decode_stage1_cuda(q, k_packed, v_packed, k_dscale, v_dscale,
+                               k_centroids, v_centroids, al, lse,
+                               kv_indptr, kv_indices, num_kv_splits_t, max_kv_splits, sm_scale)
+
+    for fn, name in [(run_triton, "Triton"), (run_cuda, "CUDA")]:
+        for _ in range(warmup):
+            fn()
+        torch.cuda.synchronize()
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(repeat):
+            fn()
+        end.record()
+        torch.cuda.synchronize()
+        print(f"{name:8s}: {start.elapsed_time(end) / repeat:.3f} ms/iter")
+
+
+if __name__ == "__main__":
+    print("Compiling CUDA kernel...")
+    _get_module()
+    print("Compiled. Running correctness test...")
+    test_correctness(batch=4, seq_len=64)
+    test_correctness(batch=32, seq_len=512)
+    print("\nRunning benchmark...")
+    benchmark(batch=32, seq_len=1024)

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -594,6 +594,16 @@ class FlashAttentionBackend(AttentionBackend):
             q = q.to(self.kv_cache_dtype)
             q_rope = q_rope.to(self.kv_cache_dtype) if q_rope is not None else None
             k_rope = k_rope.to(self.kv_cache_dtype) if k_rope is not None else None
+
+        # TurboQuant: rotate Q into WHT domain for extend
+        # K/V are NOT rotated here — set_kv_buffer (above) quantizes original K/V
+        # with internal WHT, and the page cache returns rotspace data via lazy dequant.
+        tq_config = getattr(forward_batch.token_to_kv_pool, "tq_config", None)
+        if tq_config is not None:
+            q = tq_config.rotate_query(
+                q.view(-1, layer.tp_q_head_num, layer.head_dim)
+            ).reshape(q.shape)
+
         causal = True
         if layer.is_cross_attention or layer.attn_type == AttentionType.ENCODER_ONLY:
             causal = False
@@ -654,6 +664,7 @@ class FlashAttentionBackend(AttentionBackend):
         # Use Flash Attention for prefill
         if not self.use_mla:
             # Do multi-head attention
+
             key_cache, value_cache = forward_batch.token_to_kv_pool.get_kv_buffer(
                 layer.layer_id
             )
@@ -898,6 +909,12 @@ class FlashAttentionBackend(AttentionBackend):
                 else:
                     o = result
 
+        # TurboQuant: inverse-rotate output back to original domain
+        if tq_config is not None:
+            o = tq_config.inverse_rotate_output(
+                o.view(-1, layer.tp_q_head_num, layer.v_head_dim)
+            ).reshape(o.shape)
+
         return o.view(-1, layer.tp_q_head_num * layer.v_head_dim)
 
     def forward_decode(
@@ -978,6 +995,14 @@ class FlashAttentionBackend(AttentionBackend):
             q = q.to(self.kv_cache_dtype)
             q_rope = q_rope.to(self.kv_cache_dtype) if q_rope is not None else None
             k_rope = k_rope.to(self.kv_cache_dtype) if k_rope is not None else None
+
+        # TurboQuant: rotate Q into WHT domain
+        tq_config = getattr(forward_batch.token_to_kv_pool, "tq_config", None)
+        if tq_config is not None:
+            q = tq_config.rotate_query(
+                q.view(-1, layer.tp_q_head_num, layer.head_dim)
+            ).reshape(q.shape)
+
         if not self.use_mla:
             # Do multi-head attention
 
@@ -1174,6 +1199,12 @@ class FlashAttentionBackend(AttentionBackend):
                 )
             else:
                 o = result
+
+        # TurboQuant: inverse-rotate output back to original domain
+        if tq_config is not None:
+            o = tq_config.inverse_rotate_output(
+                o.view(-1, layer.tp_q_head_num, layer.v_head_dim)
+            ).reshape(o.shape)
 
         return o.view(-1, layer.tp_q_head_num * layer.v_head_dim)
 

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -775,6 +775,14 @@ class FlashInferAttnBackend(AttentionBackend):
         logits_soft_cap = layer.logit_cap
 
         q = q.contiguous()
+
+        # TurboQuant: rotate Q into WHT domain (K/V rotated after set_kv_buffer below)
+        tq_config = getattr(forward_batch.token_to_kv_pool, "tq_config", None)
+        if tq_config is not None:
+            q = tq_config.rotate_query(
+                q.view(-1, layer.tp_q_head_num, layer.head_dim)
+            ).reshape(q.shape)
+
         if not self.forward_metadata.use_ragged:
             if k is not None:
                 assert v is not None
@@ -866,6 +874,12 @@ class FlashInferAttnBackend(AttentionBackend):
                     layer, cache_loc, k, v, layer.k_scale, layer.v_scale
                 )
 
+        # TurboQuant: inverse-rotate output back to original domain
+        if tq_config is not None:
+            o = tq_config.inverse_rotate_output(
+                o.view(-1, layer.tp_q_head_num, layer.v_head_dim)
+            ).reshape(o.shape)
+
         return o.view(-1, layer.tp_q_head_num * layer.head_dim)
 
     @debug_kernel_api
@@ -895,8 +909,12 @@ class FlashInferAttnBackend(AttentionBackend):
                 )
 
         # Call the wrapped function
+        tq_config = getattr(forward_batch.token_to_kv_pool, "tq_config", None)
+        q_input = q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim)
+        if tq_config is not None:
+            q_input = tq_config.rotate_query(q_input)
         o = decode_wrapper.forward(
-            q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim),
+            q_input,
             forward_batch.token_to_kv_pool.get_kv_buffer(layer.layer_id),
             sm_scale=layer.scaling,
             logits_soft_cap=layer.logit_cap,
@@ -904,6 +922,11 @@ class FlashInferAttnBackend(AttentionBackend):
             k_scale=layer.k_scale_float,
             v_scale=layer.v_scale_float,
         )
+
+        if tq_config is not None:
+            o = tq_config.inverse_rotate_output(
+                o.view(-1, layer.tp_q_head_num, layer.v_head_dim)
+            ).reshape(o.shape)
 
         return o.view(-1, layer.tp_q_head_num * layer.head_dim)
 

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -72,10 +72,18 @@ class TritonAttnBackend(AttentionBackend):
             extend_attention_fwd,
             extend_attention_fwd_unified,
         )
+        from sglang.srt.layers.attention.triton_ops.turboquant_decode_attention import (
+            tq_decode_attention_fwd,
+        )
+        from sglang.srt.layers.attention.triton_ops.turboquant_extend_attention import (
+            tq_extend_attention_fwd,
+        )
 
         super().__init__()
 
         self.decode_attention_fwd = torch.compiler.disable(decode_attention_fwd)
+        self.tq_decode_attention_fwd = torch.compiler.disable(tq_decode_attention_fwd)
+        self.tq_extend_attention_fwd = torch.compiler.disable(tq_extend_attention_fwd)
         self.extend_attention_fwd = torch.compiler.disable(extend_attention_fwd)
         self.extend_attention_fwd_unified = torch.compiler.disable(
             extend_attention_fwd_unified
@@ -117,9 +125,11 @@ class TritonAttnBackend(AttentionBackend):
             self.v_head_dim = model_runner.token_to_kv_pool.get_v_head_dim()
             self.swa_v_head_dim = None
         else:
-            self.v_head_dim = model_runner.token_to_kv_pool.get_value_buffer(0).shape[
-                -1
-            ]
+            pool = model_runner.token_to_kv_pool
+            if hasattr(pool, "get_v_head_dim"):
+                self.v_head_dim = pool.get_v_head_dim()
+            else:
+                self.v_head_dim = pool.get_value_buffer(0).shape[-1]
             self.swa_v_head_dim = None
         self.max_context_len = model_runner.model_config.context_len
         self.device = model_runner.device
@@ -862,7 +872,9 @@ class TritonAttnBackend(AttentionBackend):
         else:
             o = torch.empty_like(q)
 
+        _kv_from_pool = False  # Track if K/V came from dequant buffer (already rotspace)
         if k is None and v is None:
+            _kv_from_pool = True
             pool = forward_batch.token_to_kv_pool
             cache_loc = forward_batch.out_cache_loc
             if isinstance(pool, SWAKVPool) and pool.layers_mapping[layer.layer_id][1]:
@@ -907,11 +919,52 @@ class TritonAttnBackend(AttentionBackend):
         ):
             causal = False
 
+        # TurboQuant: rotate Q into WHT domain; rotate K/V only if fresh (not from pool)
+        tq_config = getattr(forward_batch.token_to_kv_pool, "tq_config", None)
+        if tq_config is not None:
+            if (
+                not _kv_from_pool
+                and k is not None
+                and v is not None
+                and layer.qk_head_dim == layer.v_head_dim
+            ):
+                # Batch Q+K+V rotation into single WHT launch (3→1)
+                q_shape, k_shape, v_shape = q.shape, k.shape, v.shape
+                q_flat = q.reshape(-1, layer.qk_head_dim)
+                k_flat = k.reshape(-1, layer.qk_head_dim)
+                v_flat = v.reshape(-1, layer.v_head_dim)
+                nq, nk = q_flat.shape[0], k_flat.shape[0]
+                qkv_rot = tq_config.rotate_query(
+                    torch.cat([q_flat, k_flat, v_flat], dim=0)
+                )
+                q = qkv_rot[:nq].view(q_shape)
+                k = qkv_rot[nq : nq + nk].view(k_shape)
+                v = qkv_rot[nq + nk :].view(v_shape)
+            else:
+                # Fallback: separate rotations (pool KV or asymmetric head dims)
+                q = tq_config.rotate_query(
+                    q.view(-1, layer.tp_q_head_num, layer.qk_head_dim)
+                ).reshape(q.shape)
+                if not _kv_from_pool:
+                    if k is not None:
+                        k = tq_config.rotate_query(
+                            k.view(-1, layer.tp_k_head_num, layer.qk_head_dim)
+                        ).reshape(k.shape)
+                    if v is not None:
+                        v = tq_config.rotate_query(
+                            v.view(-1, layer.tp_k_head_num, layer.v_head_dim)
+                        ).reshape(v.shape)
+
         # Deterministic mode: use unified 1-stage kernel
         if self.enable_deterministic:
-            return self._forward_extend_unified(
+            o = self._forward_extend_unified(
                 q, o, layer, forward_batch, causal, logits_soft_cap, sinks
             )
+            if tq_config is not None:
+                o = tq_config.inverse_rotate_output(
+                    o.view(-1, layer.tp_q_head_num, layer.v_head_dim)
+                ).reshape(o.shape)
+            return o
 
         # Normal mode: use original 2-stage kernel
         if layer.sliding_window_size is not None and layer.sliding_window_size > -1:
@@ -934,29 +987,81 @@ class TritonAttnBackend(AttentionBackend):
             k_descale = 1.0
             v_descale = 1.0
 
-        self.extend_attention_fwd(
-            q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
-            k.contiguous(),
-            v.contiguous(),
-            o.view(-1, layer.tp_q_head_num, layer.v_head_dim),
-            forward_batch.token_to_kv_pool.get_key_buffer(layer.layer_id),
-            forward_batch.token_to_kv_pool.get_value_buffer(layer.layer_id),
-            self.forward_metadata.qo_indptr,
-            kv_indptr,
-            kv_indices,
-            self.forward_metadata.custom_mask,
-            causal,
-            self.forward_metadata.mask_indptr,
-            self.forward_metadata.max_extend_len,
-            k_descale,
-            v_descale,
-            layer.scaling,
-            logit_cap=logits_soft_cap,
-            sliding_window_size=sliding_window_size,
-            sinks=sinks,
-            window_kv_offsets=window_kv_offsets,
-            xai_temperature_len=layer.xai_temperature_len,
-        )
+        # Get prefix KV buffers
+        pool = forward_batch.token_to_kv_pool
+        if (tq_config is not None
+            and tq_config.k_bit_width in (2, 4)
+            and tq_config.v_bit_width in (2, 4)
+            and not self.enable_deterministic
+            and sliding_window_size == -1
+            and kv_indptr is not None):
+            # Fused TQ extend: read packed uint8 KV directly, skip dequant buffer
+            # Supports symmetric and asymmetric K/V bit widths
+            idx = layer.layer_id - pool.start_layer
+            self.tq_extend_attention_fwd(
+                q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
+                k.contiguous(),
+                v.contiguous(),
+                o.view(-1, layer.tp_q_head_num, layer.v_head_dim),
+                pool.k_buffer[idx],
+                pool.v_buffer[idx],
+                pool.k_dequant_scale_buffer[idx],
+                pool.v_dequant_scale_buffer[idx],
+                tq_config.k_centroids,
+                tq_config.v_centroids,
+                self.forward_metadata.qo_indptr,
+                kv_indptr,
+                kv_indices,
+                self.forward_metadata.custom_mask,
+                causal,
+                self.forward_metadata.mask_indptr,
+                self.forward_metadata.max_extend_len,
+                sm_scale=layer.scaling,
+                k_bit_width=tq_config.k_bit_width,
+                v_bit_width=tq_config.v_bit_width,
+                logit_cap=logits_soft_cap,
+                sinks=sinks,
+                xai_temperature_len=layer.xai_temperature_len,
+            )
+        else:
+            # Fallback: standard extend kernel (non-TQ path)
+            if tq_config is not None:
+                raise RuntimeError(
+                    "TurboQuant extend fallback not supported. "
+                    "Ensure: enable_deterministic=False, no sliding_window."
+                )
+            key_buffer = pool.get_key_buffer(layer.layer_id)
+            value_buffer = pool.get_value_buffer(layer.layer_id)
+
+            self.extend_attention_fwd(
+                q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
+                k.contiguous(),
+                v.contiguous(),
+                o.view(-1, layer.tp_q_head_num, layer.v_head_dim),
+                key_buffer,
+                value_buffer,
+                self.forward_metadata.qo_indptr,
+                kv_indptr,
+                kv_indices,
+                self.forward_metadata.custom_mask,
+                causal,
+                self.forward_metadata.mask_indptr,
+                self.forward_metadata.max_extend_len,
+                k_descale,
+                v_descale,
+                layer.scaling,
+                logit_cap=logits_soft_cap,
+                sliding_window_size=sliding_window_size,
+                sinks=sinks,
+                window_kv_offsets=window_kv_offsets,
+                xai_temperature_len=layer.xai_temperature_len,
+            )
+        # TurboQuant: inverse-rotate output back to original domain
+        # (skipped when rotation is fused into o_proj weights)
+        if tq_config is not None and not getattr(tq_config, 'output_rotation_fused', False):
+            o = tq_config.inverse_rotate_output(
+                o.view(-1, layer.tp_q_head_num, layer.v_head_dim)
+            ).reshape(o.shape)
         return o
 
     def _forward_extend_unified(
@@ -1153,24 +1258,66 @@ class TritonAttnBackend(AttentionBackend):
         ):
             attn_logits = self.forward_metadata.swa_attn_logits
 
-        self.decode_attention_fwd(
-            q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
-            forward_batch.token_to_kv_pool.get_key_buffer(layer.layer_id),
-            forward_batch.token_to_kv_pool.get_value_buffer(layer.layer_id),
-            o.view(-1, layer.tp_q_head_num, layer.v_head_dim),
-            kv_indptr,
-            kv_indices,
-            attn_logits,
-            self.forward_metadata.attn_lse,
-            self.forward_metadata.num_kv_splits,
-            self.max_kv_splits,
-            layer.scaling,
-            k_descale,
-            v_descale,
-            logit_cap=logits_soft_cap,
-            sinks=sinks,
-            xai_temperature_len=layer.xai_temperature_len,
-        )
+        # TurboQuant: rotate Q into WHT domain
+        tq_config = getattr(forward_batch.token_to_kv_pool, "tq_config", None)
+        if tq_config is not None:
+            q = tq_config.rotate_query(
+                q.view(-1, layer.tp_q_head_num, layer.qk_head_dim)
+            ).reshape(q.shape)
+
+        if tq_config is not None and tq_config.k_bit_width in (2, 4) and tq_config.v_bit_width in (2, 4):
+            # Fused TQ decode: read packed uint8 KV directly, skip dequant buffer
+            # Supports symmetric (K=V) and asymmetric (K!=V) bit widths
+            pool = forward_batch.token_to_kv_pool
+            idx = layer.layer_id - pool.start_layer
+            self.tq_decode_attention_fwd(
+                q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
+                pool.k_buffer[idx],
+                pool.v_buffer[idx],
+                pool.k_dequant_scale_buffer[idx],
+                pool.v_dequant_scale_buffer[idx],
+                tq_config.k_centroids,
+                tq_config.v_centroids,
+                o.view(-1, layer.tp_q_head_num, layer.v_head_dim),
+                kv_indptr,
+                kv_indices,
+                attn_logits,
+                self.forward_metadata.attn_lse,
+                self.forward_metadata.num_kv_splits,
+                self.max_kv_splits,
+                layer.scaling,
+                k_bit_width=tq_config.k_bit_width,
+                v_bit_width=tq_config.v_bit_width,
+                logit_cap=logits_soft_cap,
+                sinks=sinks,
+                xai_temperature_len=layer.xai_temperature_len,
+                uniform=getattr(tq_config, 'uniform', False),
+            )
+        else:
+            self.decode_attention_fwd(
+                q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
+                forward_batch.token_to_kv_pool.get_key_buffer(layer.layer_id),
+                forward_batch.token_to_kv_pool.get_value_buffer(layer.layer_id),
+                o.view(-1, layer.tp_q_head_num, layer.v_head_dim),
+                kv_indptr,
+                kv_indices,
+                attn_logits,
+                self.forward_metadata.attn_lse,
+                self.forward_metadata.num_kv_splits,
+                self.max_kv_splits,
+                layer.scaling,
+                k_descale,
+                v_descale,
+                logit_cap=logits_soft_cap,
+                sinks=sinks,
+                xai_temperature_len=layer.xai_temperature_len,
+            )
+
+        # TurboQuant: inverse-rotate output back to original domain
+        if tq_config is not None and not getattr(tq_config, 'output_rotation_fused', False):
+            o = tq_config.inverse_rotate_output(
+                o.view(-1, layer.tp_q_head_num, layer.v_head_dim)
+            ).reshape(o.shape)
         return o
 
 

--- a/python/sglang/srt/layers/attention/triton_ops/turboquant_decode_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/turboquant_decode_attention.py
@@ -1,0 +1,513 @@
+"""Fused TurboQuant decode attention kernel.
+
+Reads packed uint8 KV cache directly during attention computation,
+eliminating the need for a separate dequant buffer.
+
+Supports asymmetric K/V bit widths (e.g., K=4bit V=2bit):
+  K side: Q is split by K_VALS_PER_BYTE, codebook lookup uses K centroids
+  V side: accumulators organized by V_VALS_PER_BYTE, codebook lookup uses V centroids
+
+Uses N-way Split Dot Product (N = values_per_byte):
+  4-bit (N=2): qk = dot(q_even, k_lo) + dot(q_odd, k_hi)
+  2-bit (N=4): qk = dot(q_0, k_0) + dot(q_1, k_1) + dot(q_2, k_2) + dot(q_3, k_3)
+
+Supports GQA (kv_group_num > 1) and MHA (kv_group_num == 1).
+Supports 2-bit (4 values/byte) and 4-bit (2 values/byte).
+"""
+
+import triton
+import triton.language as tl
+
+_MIN_BLOCK_KV = 32
+
+
+@triton.jit
+def tanh(x):
+    return 2 * tl.sigmoid(2 * x) - 1
+
+
+@triton.jit
+def _lookup_2bit(idx, c0, c1, c2, c3):
+    """2-bit codebook lookup via predicated select (no scatter gather)."""
+    return tl.where(idx == 0, c0, tl.where(idx == 1, c1, tl.where(idx == 2, c2, c3)))
+
+
+@triton.jit
+def _lookup_4bit_codebook(idx, c0, c1, c2, c3, c4, c5, c6, c7,
+                          c8, c9, c10, c11, c12, c13, c14, c15):
+    """4-bit codebook lookup via binary select tree (4 levels, 15 tl.where)."""
+    lo = tl.where(
+        (idx & 4) != 0,
+        tl.where((idx & 2) != 0,
+                 tl.where((idx & 1) != 0, c7, c6),
+                 tl.where((idx & 1) != 0, c5, c4)),
+        tl.where((idx & 2) != 0,
+                 tl.where((idx & 1) != 0, c3, c2),
+                 tl.where((idx & 1) != 0, c1, c0)),
+    )
+    hi = tl.where(
+        (idx & 4) != 0,
+        tl.where((idx & 2) != 0,
+                 tl.where((idx & 1) != 0, c15, c14),
+                 tl.where((idx & 1) != 0, c13, c12)),
+        tl.where((idx & 2) != 0,
+                 tl.where((idx & 1) != 0, c11, c10),
+                 tl.where((idx & 1) != 0, c9, c8)),
+    )
+    return tl.where((idx & 8) != 0, hi, lo)
+
+
+@triton.jit
+def _lookup_4bit_uniform(idx, c0, c1, c2, c3, c4, c5, c6, c7,
+                         c8, c9, c10, c11, c12, c13, c14, c15):
+    """4-bit uniform dequant: 1 FMA replaces 15 tl.where selects."""
+    step = (c15 - c0) * 0.06666666666666667  # 1/15
+    return idx.to(tl.float32) * step + c0
+
+
+@triton.jit
+def _lookup_4bit(idx, c0, c1, c2, c3, c4, c5, c6, c7,
+                 c8, c9, c10, c11, c12, c13, c14, c15,
+                 UNIFORM: tl.constexpr = False):
+    """4-bit lookup dispatcher: codebook or uniform based on constexpr flag."""
+    if UNIFORM:
+        return _lookup_4bit_uniform(idx, c0, c1, c2, c3, c4, c5, c6, c7,
+                                    c8, c9, c10, c11, c12, c13, c14, c15)
+    else:
+        return _lookup_4bit_codebook(idx, c0, c1, c2, c3, c4, c5, c6, c7,
+                                     c8, c9, c10, c11, c12, c13, c14, c15)
+
+
+@triton.jit
+def _fwd_tq_grouped_kernel_stage1(
+    Q,
+    K_Packed,
+    V_Packed,
+    K_DScale,
+    V_DScale,
+    K_Centroids,
+    V_Centroids,
+    sm_scale,
+    kv_indptr,
+    kv_indices,
+    Att_Out,
+    Att_Lse,
+    num_kv_splits,
+    stride_qbs,
+    stride_qh,
+    stride_kp_bs,
+    stride_kp_h,
+    stride_vp_bs,
+    stride_vp_h,
+    stride_kds_bs,
+    stride_vds_bs,
+    stride_mid_ob,
+    stride_mid_oh,
+    stride_mid_os,
+    kv_group_num: tl.constexpr,
+    q_head_num: tl.constexpr,
+    K_BLOCK_PACKED_DIM: tl.constexpr,
+    V_BLOCK_PACKED_DIM: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    MIN_BLOCK_KV: tl.constexpr,
+    logit_cap: tl.constexpr,
+    Lk: tl.constexpr,
+    Lv: tl.constexpr,
+    K_Lk_packed: tl.constexpr,
+    V_Lv_packed: tl.constexpr,
+    K_VALS_PER_BYTE: tl.constexpr,  # 2 for K=4-bit, 4 for K=2-bit
+    K_BITS_PER_VAL: tl.constexpr,   # 4 for K=4-bit, 2 for K=2-bit
+    K_BIT_MASK: tl.constexpr,       # 0x0F for K=4-bit, 0x03 for K=2-bit
+    V_VALS_PER_BYTE: tl.constexpr,  # 2 for V=4-bit, 4 for V=2-bit
+    V_BITS_PER_VAL: tl.constexpr,   # 4 for V=4-bit, 2 for V=2-bit
+    V_BIT_MASK: tl.constexpr,       # 0x0F for V=4-bit, 0x03 for V=2-bit
+    xai_temperature_len: tl.constexpr,
+    UNIFORM: tl.constexpr = False,
+):
+    cur_batch = tl.program_id(0)
+    cur_head_id = tl.program_id(1)
+    cur_kv_head = cur_head_id // tl.cdiv(kv_group_num, BLOCK_H)
+    split_kv_id = tl.program_id(2)
+
+    if BLOCK_H < kv_group_num:
+        VALID_BLOCK_H: tl.constexpr = BLOCK_H
+    else:
+        VALID_BLOCK_H: tl.constexpr = kv_group_num
+    cur_head = cur_head_id * VALID_BLOCK_H + tl.arange(0, BLOCK_H)
+    mask_h = cur_head < (cur_head_id + 1) * VALID_BLOCK_H
+    mask_h = mask_h & (cur_head < q_head_num)
+
+    # Separate offset ranges for K and V packed dims
+    offs_kp = tl.arange(0, K_BLOCK_PACKED_DIM)
+    mask_kp = offs_kp < K_Lk_packed
+    offs_vp = tl.arange(0, V_BLOCK_PACKED_DIM)
+    mask_vp = offs_vp < V_Lv_packed
+
+    cur_batch_kv_start_idx = tl.load(kv_indptr + cur_batch)
+    cur_batch_seq_len = tl.load(kv_indptr + cur_batch + 1) - cur_batch_kv_start_idx
+    kv_splits = tl.load(num_kv_splits + cur_batch)
+
+    if xai_temperature_len > 0:
+        offs_qidx = cur_batch_seq_len - 1
+        xai_temperature_scale = 1.0 / tl.log2(float(xai_temperature_len))
+        _qtemp = tl.log2(offs_qidx.to(tl.float32)) * xai_temperature_scale
+        xai_temperature_reg = tl.where(offs_qidx > xai_temperature_len, _qtemp, 1.0)
+
+    kv_len_per_split = (
+        tl.cdiv(tl.cdiv(cur_batch_seq_len, kv_splits), MIN_BLOCK_KV) * MIN_BLOCK_KV
+    )
+    split_kv_start = kv_len_per_split * split_kv_id
+    split_kv_end = tl.minimum(split_kv_start + kv_len_per_split, cur_batch_seq_len)
+
+    e_max = tl.zeros([BLOCK_H], dtype=tl.float32) - float("inf")
+    e_sum = tl.zeros([BLOCK_H], dtype=tl.float32)
+
+    # V-side accumulators (organized by V_VALS_PER_BYTE, compiler eliminates unused)
+    acc_0 = tl.zeros([BLOCK_H, V_BLOCK_PACKED_DIM], dtype=tl.float32)
+    acc_1 = tl.zeros([BLOCK_H, V_BLOCK_PACKED_DIM], dtype=tl.float32)
+    acc_2 = tl.zeros([BLOCK_H, V_BLOCK_PACKED_DIM], dtype=tl.float32)
+    acc_3 = tl.zeros([BLOCK_H, V_BLOCK_PACKED_DIM], dtype=tl.float32)
+
+    if split_kv_end > split_kv_start:
+        # Preload K centroid values
+        if K_VALS_PER_BYTE == 4:
+            # K=2-bit: 4 centroids
+            kc0 = tl.load(K_Centroids)
+            kc1 = tl.load(K_Centroids + 1)
+            kc2 = tl.load(K_Centroids + 2)
+            kc3 = tl.load(K_Centroids + 3)
+        else:
+            # K=4-bit: 16 centroids
+            kc0 = tl.load(K_Centroids)
+            kc1 = tl.load(K_Centroids + 1)
+            kc2 = tl.load(K_Centroids + 2)
+            kc3 = tl.load(K_Centroids + 3)
+            kc4 = tl.load(K_Centroids + 4)
+            kc5 = tl.load(K_Centroids + 5)
+            kc6 = tl.load(K_Centroids + 6)
+            kc7 = tl.load(K_Centroids + 7)
+            kc8 = tl.load(K_Centroids + 8)
+            kc9 = tl.load(K_Centroids + 9)
+            kc10 = tl.load(K_Centroids + 10)
+            kc11 = tl.load(K_Centroids + 11)
+            kc12 = tl.load(K_Centroids + 12)
+            kc13 = tl.load(K_Centroids + 13)
+            kc14 = tl.load(K_Centroids + 14)
+            kc15 = tl.load(K_Centroids + 15)
+
+        # Preload V centroid values
+        if V_VALS_PER_BYTE == 4:
+            # V=2-bit: 4 centroids
+            vc0 = tl.load(V_Centroids)
+            vc1 = tl.load(V_Centroids + 1)
+            vc2 = tl.load(V_Centroids + 2)
+            vc3 = tl.load(V_Centroids + 3)
+        else:
+            # V=4-bit: 16 centroids
+            vc0 = tl.load(V_Centroids)
+            vc1 = tl.load(V_Centroids + 1)
+            vc2 = tl.load(V_Centroids + 2)
+            vc3 = tl.load(V_Centroids + 3)
+            vc4 = tl.load(V_Centroids + 4)
+            vc5 = tl.load(V_Centroids + 5)
+            vc6 = tl.load(V_Centroids + 6)
+            vc7 = tl.load(V_Centroids + 7)
+            vc8 = tl.load(V_Centroids + 8)
+            vc9 = tl.load(V_Centroids + 9)
+            vc10 = tl.load(V_Centroids + 10)
+            vc11 = tl.load(V_Centroids + 11)
+            vc12 = tl.load(V_Centroids + 12)
+            vc13 = tl.load(V_Centroids + 13)
+            vc14 = tl.load(V_Centroids + 14)
+            vc15 = tl.load(V_Centroids + 15)
+
+        # Load Q splits (strided by K_VALS_PER_BYTE, Q only used for QK dot)
+        offs_q_0 = cur_batch * stride_qbs + cur_head[:, None] * stride_qh + (K_VALS_PER_BYTE * offs_kp[None, :])
+        offs_q_1 = cur_batch * stride_qbs + cur_head[:, None] * stride_qh + (K_VALS_PER_BYTE * offs_kp[None, :] + 1)
+        mask_q_0 = (mask_h[:, None]) & ((K_VALS_PER_BYTE * offs_kp[None, :]) < Lk)
+        mask_q_1 = (mask_h[:, None]) & ((K_VALS_PER_BYTE * offs_kp[None, :] + 1) < Lk)
+
+        q_0 = tl.load(Q + offs_q_0, mask=mask_q_0, other=0.0)
+        q_1 = tl.load(Q + offs_q_1, mask=mask_q_1, other=0.0)
+
+        if K_VALS_PER_BYTE == 4:
+            offs_q_2 = cur_batch * stride_qbs + cur_head[:, None] * stride_qh + (4 * offs_kp[None, :] + 2)
+            offs_q_3 = cur_batch * stride_qbs + cur_head[:, None] * stride_qh + (4 * offs_kp[None, :] + 3)
+            mask_q_2 = (mask_h[:, None]) & ((4 * offs_kp[None, :] + 2) < Lk)
+            mask_q_3 = (mask_h[:, None]) & ((4 * offs_kp[None, :] + 3) < Lk)
+            q_2 = tl.load(Q + offs_q_2, mask=mask_q_2, other=0.0)
+            q_3 = tl.load(Q + offs_q_3, mask=mask_q_3, other=0.0)
+
+        for start_n in range(split_kv_start, split_kv_end, BLOCK_N):
+            offs_n = start_n + tl.arange(0, BLOCK_N)
+            kv_loc = tl.load(
+                kv_indices + cur_batch_kv_start_idx + offs_n,
+                mask=offs_n < split_kv_end,
+                other=0,
+            )
+
+            # --- K: load packed, sequential extract+lookup+dot (K params) ---
+            offs_buf_kp = (
+                kv_loc[None, :] * stride_kp_bs
+                + cur_kv_head * stride_kp_h
+                + offs_kp[:, None]
+            )
+            packed_k = tl.load(
+                K_Packed + offs_buf_kp,
+                mask=(offs_n[None, :] < split_kv_end) & (mask_kp[:, None]),
+                other=0,
+            )
+
+            k_idx_0 = (packed_k & K_BIT_MASK).to(tl.int32)
+            if K_VALS_PER_BYTE == 4:
+                k_0 = _lookup_2bit(k_idx_0, kc0, kc1, kc2, kc3)
+            else:
+                k_0 = _lookup_4bit(k_idx_0, kc0, kc1, kc2, kc3, kc4, kc5, kc6, kc7,
+                                   kc8, kc9, kc10, kc11, kc12, kc13, kc14, kc15, UNIFORM=UNIFORM)
+            qk = tl.dot(q_0, k_0.to(q_0.dtype))
+
+            k_idx_1 = ((packed_k >> K_BITS_PER_VAL) & K_BIT_MASK).to(tl.int32)
+            if K_VALS_PER_BYTE == 4:
+                k_1 = _lookup_2bit(k_idx_1, kc0, kc1, kc2, kc3)
+            else:
+                k_1 = _lookup_4bit(k_idx_1, kc0, kc1, kc2, kc3, kc4, kc5, kc6, kc7,
+                                   kc8, kc9, kc10, kc11, kc12, kc13, kc14, kc15, UNIFORM=UNIFORM)
+            qk += tl.dot(q_1, k_1.to(q_1.dtype))
+
+            if K_VALS_PER_BYTE == 4:
+                k_idx_2 = ((packed_k >> (2 * K_BITS_PER_VAL)) & K_BIT_MASK).to(tl.int32)
+                k_2 = _lookup_2bit(k_idx_2, kc0, kc1, kc2, kc3)
+                qk += tl.dot(q_2, k_2.to(q_2.dtype))
+
+                k_idx_3 = ((packed_k >> (3 * K_BITS_PER_VAL)) & K_BIT_MASK).to(tl.int32)
+                k_3 = _lookup_2bit(k_idx_3, kc0, kc1, kc2, kc3)
+                qk += tl.dot(q_3, k_3.to(q_3.dtype))
+
+            # K dequant scale
+            k_dscale = tl.load(
+                K_DScale + kv_loc * stride_kds_bs + cur_kv_head,
+                mask=offs_n < split_kv_end, other=1.0,
+            ).to(tl.float32)
+            qk *= k_dscale[None, :]
+            qk *= sm_scale
+
+            if logit_cap > 0:
+                qk = logit_cap * tanh(qk / logit_cap)
+
+            if xai_temperature_len > 0:
+                qk *= xai_temperature_reg[:, None]
+
+            qk = tl.where(
+                mask_h[:, None] & (offs_n[None, :] < split_kv_end), qk, float("-inf")
+            )
+
+            # --- Online softmax (V not loaded yet → fewer live registers) ---
+            n_e_max = tl.maximum(tl.max(qk, 1), e_max)
+            re_scale = tl.exp(e_max - n_e_max)
+            p = tl.exp(qk - n_e_max[:, None])
+            acc_0 *= re_scale[:, None]
+            acc_1 *= re_scale[:, None]
+            if V_VALS_PER_BYTE == 4:
+                acc_2 *= re_scale[:, None]
+                acc_3 *= re_scale[:, None]
+
+            # V dequant scale
+            v_dscale = tl.load(
+                V_DScale + kv_loc * stride_vds_bs + cur_kv_head,
+                mask=offs_n < split_kv_end, other=1.0,
+            ).to(tl.float32)
+            p_scaled = p * v_dscale[None, :]
+
+            # --- V: load packed AFTER softmax (V params) ---
+            offs_buf_vp = (
+                kv_loc[:, None] * stride_vp_bs
+                + cur_kv_head * stride_vp_h
+                + offs_vp[None, :]
+            )
+            packed_v = tl.load(
+                V_Packed + offs_buf_vp,
+                mask=(offs_n[:, None] < split_kv_end) & (mask_vp[None, :]),
+                other=0,
+            )
+
+            v_idx_0 = (packed_v & V_BIT_MASK).to(tl.int32)
+            if V_VALS_PER_BYTE == 4:
+                v_0 = _lookup_2bit(v_idx_0, vc0, vc1, vc2, vc3)
+            else:
+                v_0 = _lookup_4bit(v_idx_0, vc0, vc1, vc2, vc3, vc4, vc5, vc6, vc7,
+                                   vc8, vc9, vc10, vc11, vc12, vc13, vc14, vc15, UNIFORM=UNIFORM)
+            acc_0 += tl.dot(p_scaled.to(v_0.dtype), v_0)
+
+            v_idx_1 = ((packed_v >> V_BITS_PER_VAL) & V_BIT_MASK).to(tl.int32)
+            if V_VALS_PER_BYTE == 4:
+                v_1 = _lookup_2bit(v_idx_1, vc0, vc1, vc2, vc3)
+            else:
+                v_1 = _lookup_4bit(v_idx_1, vc0, vc1, vc2, vc3, vc4, vc5, vc6, vc7,
+                                   vc8, vc9, vc10, vc11, vc12, vc13, vc14, vc15, UNIFORM=UNIFORM)
+            acc_1 += tl.dot(p_scaled.to(v_1.dtype), v_1)
+
+            if V_VALS_PER_BYTE == 4:
+                v_idx_2 = ((packed_v >> (2 * V_BITS_PER_VAL)) & V_BIT_MASK).to(tl.int32)
+                v_2 = _lookup_2bit(v_idx_2, vc0, vc1, vc2, vc3)
+                acc_2 += tl.dot(p_scaled.to(v_2.dtype), v_2)
+
+                v_idx_3 = ((packed_v >> (3 * V_BITS_PER_VAL)) & V_BIT_MASK).to(tl.int32)
+                v_3 = _lookup_2bit(v_idx_3, vc0, vc1, vc2, vc3)
+                acc_3 += tl.dot(p_scaled.to(v_3.dtype), v_3)
+
+            e_sum = e_sum * re_scale + tl.sum(p, 1)
+            e_max = n_e_max
+
+        # Store: V-side N-way interleaved output
+        base_mid_o = (
+            cur_batch * stride_mid_ob
+            + cur_head[:, None] * stride_mid_oh
+            + split_kv_id * stride_mid_os
+        )
+
+        offs_out_0 = V_VALS_PER_BYTE * tl.arange(0, V_BLOCK_PACKED_DIM)
+        offs_out_1 = V_VALS_PER_BYTE * tl.arange(0, V_BLOCK_PACKED_DIM) + 1
+        mask_out_0 = offs_out_0 < Lv
+        mask_out_1 = offs_out_1 < Lv
+
+        tl.store(Att_Out + base_mid_o + offs_out_0[None, :],
+                 acc_0 / e_sum[:, None], mask=(mask_h[:, None]) & (mask_out_0[None, :]))
+        tl.store(Att_Out + base_mid_o + offs_out_1[None, :],
+                 acc_1 / e_sum[:, None], mask=(mask_h[:, None]) & (mask_out_1[None, :]))
+
+        if V_VALS_PER_BYTE == 4:
+            offs_out_2 = 4 * tl.arange(0, V_BLOCK_PACKED_DIM) + 2
+            offs_out_3 = 4 * tl.arange(0, V_BLOCK_PACKED_DIM) + 3
+            mask_out_2 = offs_out_2 < Lv
+            mask_out_3 = offs_out_3 < Lv
+            tl.store(Att_Out + base_mid_o + offs_out_2[None, :],
+                     acc_2 / e_sum[:, None], mask=(mask_h[:, None]) & (mask_out_2[None, :]))
+            tl.store(Att_Out + base_mid_o + offs_out_3[None, :],
+                     acc_3 / e_sum[:, None], mask=(mask_h[:, None]) & (mask_out_3[None, :]))
+
+        # Store LSE
+        offs_mid_lse = (
+            cur_batch * stride_mid_ob
+            + cur_head * stride_mid_oh
+            + split_kv_id * stride_mid_os
+        ) // Lv
+
+        tl.store(Att_Lse + offs_mid_lse, e_max + tl.log(e_sum), mask=mask_h)
+
+
+def _bit_params(bit_width):
+    """Return (VALS_PER_BYTE, BITS_PER_VAL, BIT_MASK) for a given bit width."""
+    if bit_width == 2:
+        return 4, 2, 0x03
+    elif bit_width == 4:
+        return 2, 4, 0x0F
+    else:
+        raise ValueError(f"Unsupported bit_width: {bit_width}")
+
+
+def _tq_decode_grouped_att_m_fwd(
+    q, k_packed, v_packed, k_dscale, v_dscale,
+    k_centroids, v_centroids, o, att_out, att_lse, kv_indptr, kv_indices,
+    num_kv_splits, max_kv_splits, sm_scale, logit_cap,
+    k_bit_width, v_bit_width,
+    xai_temperature_len=-1,
+    uniform=False,
+):
+    Lk = q.shape[-1]
+    Lv = Lk
+    assert o.shape[-1] == Lk, (
+        f"TurboQuant: v_head_dim ({o.shape[-1]}) != qk_head_dim ({Lk})"
+    )
+    K_Lk_packed = k_packed.shape[-1]
+    V_Lv_packed = v_packed.shape[-1]
+
+    K_VALS_PER_BYTE, K_BITS_PER_VAL, K_BIT_MASK = _bit_params(k_bit_width)
+    V_VALS_PER_BYTE, V_BITS_PER_VAL, V_BIT_MASK = _bit_params(v_bit_width)
+
+    K_BLOCK_PACKED_DIM = triton.next_power_of_2(K_Lk_packed)
+    V_BLOCK_PACKED_DIM = triton.next_power_of_2(V_Lv_packed)
+    BLOCK_N = 16
+    batch, head_num = q.shape[0], q.shape[1]
+    kv_group_num = q.shape[1] // k_packed.shape[1]
+    BLOCK_H = min(16, kv_group_num)
+
+    grid = (
+        batch,
+        triton.cdiv(head_num, min(BLOCK_H, kv_group_num)),
+        max_kv_splits,
+    )
+
+    _fwd_tq_grouped_kernel_stage1[grid](
+        q, k_packed, v_packed, k_dscale, v_dscale,
+        k_centroids, v_centroids,
+        sm_scale, kv_indptr, kv_indices, att_out, att_lse,
+        num_kv_splits,
+        q.stride(0), q.stride(1),
+        k_packed.stride(0), k_packed.stride(1),
+        v_packed.stride(0), v_packed.stride(1),
+        k_dscale.stride(0), v_dscale.stride(0),
+        att_out.stride(0), att_out.stride(1), att_out.stride(2),
+        kv_group_num=kv_group_num,
+        q_head_num=head_num,
+        K_BLOCK_PACKED_DIM=K_BLOCK_PACKED_DIM,
+        V_BLOCK_PACKED_DIM=V_BLOCK_PACKED_DIM,
+        BLOCK_N=BLOCK_N,
+        BLOCK_H=BLOCK_H,
+        MIN_BLOCK_KV=_MIN_BLOCK_KV,
+        logit_cap=logit_cap,
+        num_warps=4,
+        num_stages=2,
+        Lk=Lk,
+        Lv=Lv,
+        K_Lk_packed=K_Lk_packed,
+        V_Lv_packed=V_Lv_packed,
+        K_VALS_PER_BYTE=K_VALS_PER_BYTE,
+        K_BITS_PER_VAL=K_BITS_PER_VAL,
+        K_BIT_MASK=K_BIT_MASK,
+        V_VALS_PER_BYTE=V_VALS_PER_BYTE,
+        V_BITS_PER_VAL=V_BITS_PER_VAL,
+        V_BIT_MASK=V_BIT_MASK,
+        xai_temperature_len=xai_temperature_len,
+        UNIFORM=uniform,
+    )
+
+
+def tq_decode_attention_fwd(
+    q, k_packed, v_packed, k_dscale, v_dscale,
+    k_centroids, v_centroids, o, kv_indptr, kv_indices, attn_logits, attn_lse,
+    num_kv_splits, max_kv_splits, sm_scale,
+    k_bit_width=4, v_bit_width=4,
+    logit_cap=0.0, sinks=None, xai_temperature_len=-1,
+    uniform=False,
+):
+    """Fused TurboQuant decode attention: reads packed uint8 KV directly.
+
+    Supports asymmetric K/V bit widths (e.g., K=4bit V=2bit).
+    Supports 2-bit (4-way split) and 4-bit (2-way split).
+    """
+    from sglang.srt.layers.attention.triton_ops.decode_attention import (
+        _decode_softmax_reducev_fwd,
+    )
+
+    assert max_kv_splits == attn_logits.shape[2]
+    assert k_bit_width in (2, 4), f"Unsupported K bit_width: {k_bit_width}"
+    assert v_bit_width in (2, 4), f"Unsupported V bit_width: {v_bit_width}"
+
+    # Stage 1: fused TQ attention with packed KV
+    _tq_decode_grouped_att_m_fwd(
+        q, k_packed, v_packed, k_dscale, v_dscale,
+        k_centroids, v_centroids, o, attn_logits, attn_lse, kv_indptr, kv_indices,
+        num_kv_splits, max_kv_splits, sm_scale, logit_cap,
+        k_bit_width, v_bit_width,
+        xai_temperature_len=xai_temperature_len,
+        uniform=uniform,
+    )
+
+    # Stage 2: reuse standard softmax reduce
+    _decode_softmax_reducev_fwd(
+        attn_logits, attn_lse, q, o,
+        1.0,  # v_scale = 1.0 (dequant scale applied in stage1)
+        o,    # v_buffer: only .shape[-1] used for Lv
+        kv_indptr, num_kv_splits, max_kv_splits, sinks,
+    )

--- a/python/sglang/srt/layers/attention/triton_ops/turboquant_extend_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/turboquant_extend_attention.py
@@ -1,0 +1,601 @@
+"""Fused TurboQuant extend attention kernel.
+
+Reads packed uint8 KV cache directly during extend (prefill) attention,
+eliminating the expensive eager dequant (`batched_dequantize_rotspace`).
+
+Supports asymmetric K/V bit widths (e.g., K=4bit V=2bit):
+  K side: Q is split by K_VALS_PER_BYTE, K uses K codebook
+  V side: accumulators organized by V_VALS_PER_BYTE, V uses V codebook
+
+Both the prefix stage (packed uint8 from KV pool) and extend stage (fresh bf16)
+use N-way Split Dot Product throughout, with a single interleaved output store.
+"""
+
+import triton
+import triton.language as tl
+
+from sglang.srt.layers.attention.triton_ops.turboquant_decode_attention import (
+    _bit_params,
+    _lookup_2bit,
+    _lookup_4bit,
+    tanh,
+)
+
+
+@triton.jit
+def _fwd_tq_extend_kernel(
+    # Extend tensors (contiguous bf16, already in rotspace)
+    Q_Extend,
+    K_Extend,
+    V_Extend,
+    O_Extend,
+    # Packed KV pool buffers (uint8)
+    K_Packed,
+    V_Packed,
+    # Dequant scales (bf16, per token-head)
+    K_DScale,
+    V_DScale,
+    # Codebook centroids (float32), separate for K and V
+    K_Centroids,
+    V_Centroids,
+    # Standard extend attention indirection
+    qo_indptr,
+    kv_indptr,
+    kv_indices,
+    # Mask
+    mask_ptr,
+    mask_indptr,
+    # Sink
+    sink_ptr,
+    # Scalars
+    sm_scale,
+    kv_group_num,
+    # Q/K/V extend strides
+    stride_qbs,
+    stride_qh,
+    stride_kbs,
+    stride_kh,
+    stride_vbs,
+    stride_vh,
+    stride_obs,
+    stride_oh,
+    # Packed buffer strides
+    stride_kp_bs,
+    stride_kp_h,
+    stride_vp_bs,
+    stride_vp_h,
+    # Dequant scale strides
+    stride_kds_bs,
+    stride_vds_bs,
+    # Constexpr — K side
+    K_BLOCK_PACKED_DIM: tl.constexpr,
+    K_Lk_packed: tl.constexpr,
+    K_VALS_PER_BYTE: tl.constexpr,
+    K_BITS_PER_VAL: tl.constexpr,
+    K_BIT_MASK: tl.constexpr,
+    # Constexpr — V side
+    V_BLOCK_PACKED_DIM: tl.constexpr,
+    V_Lv_packed: tl.constexpr,
+    V_VALS_PER_BYTE: tl.constexpr,
+    V_BITS_PER_VAL: tl.constexpr,
+    V_BIT_MASK: tl.constexpr,
+    # Constexpr — common
+    logit_cap: tl.constexpr,
+    xai_temperature_len: tl.constexpr,
+    Lq: tl.constexpr,
+    Lv: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    USE_CUSTOM_MASK: tl.constexpr,
+    IS_CAUSAL: tl.constexpr,
+    HAS_SINK: tl.constexpr,
+    UNIFORM: tl.constexpr = False,
+):
+    cur_seq = tl.program_id(0)
+    cur_head = tl.program_id(1)
+    cur_block_m = tl.program_id(2)
+    cur_kv_head = cur_head // kv_group_num
+
+    cur_seq_extend_start_idx = tl.load(qo_indptr + cur_seq)
+    cur_seq_len_extend = tl.load(qo_indptr + cur_seq + 1) - cur_seq_extend_start_idx
+    cur_seq_kv_start_idx = tl.load(kv_indptr + cur_seq)
+    cur_seq_len_prefix = tl.load(kv_indptr + cur_seq + 1) - cur_seq_kv_start_idx
+    cur_seq_len = cur_seq_len_prefix + cur_seq_len_extend
+
+    if USE_CUSTOM_MASK:
+        cur_seq_mask_start_idx = tl.load(mask_indptr + cur_seq)
+
+    # Separate offset ranges for K and V packed dims
+    offs_kp = tl.arange(0, K_BLOCK_PACKED_DIM)
+    mask_kp = offs_kp < K_Lk_packed
+    offs_vp = tl.arange(0, V_BLOCK_PACKED_DIM)
+    mask_vp = offs_vp < V_Lv_packed
+    offs_m = tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    mask_m = (cur_block_m * BLOCK_M + offs_m) < cur_seq_len_extend
+
+    if xai_temperature_len > 0:
+        offs_qidx = cur_seq_len_prefix + cur_block_m * BLOCK_M + offs_m
+        xai_temperature_scale = 1.0 / tl.log2(float(xai_temperature_len))
+        xai_temperature_reg = tl.where(
+            offs_qidx > xai_temperature_len,
+            tl.log2(offs_qidx.to(tl.float32)) * xai_temperature_scale,
+            1.0,
+        )
+
+    # --- Preload K centroids ---
+    if K_VALS_PER_BYTE == 4:
+        kc0 = tl.load(K_Centroids)
+        kc1 = tl.load(K_Centroids + 1)
+        kc2 = tl.load(K_Centroids + 2)
+        kc3 = tl.load(K_Centroids + 3)
+    else:
+        kc0 = tl.load(K_Centroids)
+        kc1 = tl.load(K_Centroids + 1)
+        kc2 = tl.load(K_Centroids + 2)
+        kc3 = tl.load(K_Centroids + 3)
+        kc4 = tl.load(K_Centroids + 4)
+        kc5 = tl.load(K_Centroids + 5)
+        kc6 = tl.load(K_Centroids + 6)
+        kc7 = tl.load(K_Centroids + 7)
+        kc8 = tl.load(K_Centroids + 8)
+        kc9 = tl.load(K_Centroids + 9)
+        kc10 = tl.load(K_Centroids + 10)
+        kc11 = tl.load(K_Centroids + 11)
+        kc12 = tl.load(K_Centroids + 12)
+        kc13 = tl.load(K_Centroids + 13)
+        kc14 = tl.load(K_Centroids + 14)
+        kc15 = tl.load(K_Centroids + 15)
+
+    # --- Preload V centroids ---
+    if V_VALS_PER_BYTE == 4:
+        vc0 = tl.load(V_Centroids)
+        vc1 = tl.load(V_Centroids + 1)
+        vc2 = tl.load(V_Centroids + 2)
+        vc3 = tl.load(V_Centroids + 3)
+    else:
+        vc0 = tl.load(V_Centroids)
+        vc1 = tl.load(V_Centroids + 1)
+        vc2 = tl.load(V_Centroids + 2)
+        vc3 = tl.load(V_Centroids + 3)
+        vc4 = tl.load(V_Centroids + 4)
+        vc5 = tl.load(V_Centroids + 5)
+        vc6 = tl.load(V_Centroids + 6)
+        vc7 = tl.load(V_Centroids + 7)
+        vc8 = tl.load(V_Centroids + 8)
+        vc9 = tl.load(V_Centroids + 9)
+        vc10 = tl.load(V_Centroids + 10)
+        vc11 = tl.load(V_Centroids + 11)
+        vc12 = tl.load(V_Centroids + 12)
+        vc13 = tl.load(V_Centroids + 13)
+        vc14 = tl.load(V_Centroids + 14)
+        vc15 = tl.load(V_Centroids + 15)
+
+    # --- Load split Q vectors (strided by K_VALS_PER_BYTE, Q only for QK dot) ---
+    q_base = (
+        (cur_seq_extend_start_idx + cur_block_m * BLOCK_M + offs_m[:, None])
+        * stride_qbs
+        + cur_head * stride_qh
+    )
+    offs_q_0 = q_base + (K_VALS_PER_BYTE * offs_kp[None, :])
+    offs_q_1 = q_base + (K_VALS_PER_BYTE * offs_kp[None, :] + 1)
+    mask_q_0 = mask_m[:, None] & ((K_VALS_PER_BYTE * offs_kp[None, :]) < Lq)
+    mask_q_1 = mask_m[:, None] & ((K_VALS_PER_BYTE * offs_kp[None, :] + 1) < Lq)
+
+    q_0 = tl.load(Q_Extend + offs_q_0, mask=mask_q_0, other=0.0)
+    q_1 = tl.load(Q_Extend + offs_q_1, mask=mask_q_1, other=0.0)
+
+    if K_VALS_PER_BYTE == 4:
+        offs_q_2 = q_base + (4 * offs_kp[None, :] + 2)
+        offs_q_3 = q_base + (4 * offs_kp[None, :] + 3)
+        mask_q_2 = mask_m[:, None] & ((4 * offs_kp[None, :] + 2) < Lq)
+        mask_q_3 = mask_m[:, None] & ((4 * offs_kp[None, :] + 3) < Lq)
+        q_2 = tl.load(Q_Extend + offs_q_2, mask=mask_q_2, other=0.0)
+        q_3 = tl.load(Q_Extend + offs_q_3, mask=mask_q_3, other=0.0)
+
+    # --- Initialize V-side accumulators ---
+    acc_0 = tl.zeros([BLOCK_M, V_BLOCK_PACKED_DIM], dtype=tl.float32)
+    acc_1 = tl.zeros([BLOCK_M, V_BLOCK_PACKED_DIM], dtype=tl.float32)
+    acc_2 = tl.zeros([BLOCK_M, V_BLOCK_PACKED_DIM], dtype=tl.float32)
+    acc_3 = tl.zeros([BLOCK_M, V_BLOCK_PACKED_DIM], dtype=tl.float32)
+    deno = tl.zeros([BLOCK_M], dtype=tl.float32)
+    e_max = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
+
+    # =========================================================
+    # STAGE 1: Prefix loop — packed uint8 from KV pool
+    # =========================================================
+    for start_n in range(0, cur_seq_len_prefix, BLOCK_N):
+        start_n = tl.multiple_of(start_n, BLOCK_N)
+        mask_n = (start_n + offs_n) < cur_seq_len_prefix
+        final_mask = mask_m[:, None] & mask_n[None, :]
+
+        if USE_CUSTOM_MASK:
+            custom_mask = tl.load(
+                mask_ptr
+                + cur_seq_mask_start_idx
+                + (cur_block_m * BLOCK_M + offs_m[:, None])
+                * cur_seq_len
+                + start_n
+                + offs_n[None, :],
+                mask=final_mask,
+                other=0,
+            )
+            final_mask &= custom_mask
+
+        # Load kv_loc via indirection
+        offs_kv_loc = tl.load(
+            kv_indices + cur_seq_kv_start_idx + start_n + offs_n,
+            mask=mask_n,
+            other=0,
+        )
+
+        # --- K: load packed uint8, K codebook lookup (K params) ---
+        offs_buf_kp = (
+            offs_kv_loc[None, :] * stride_kp_bs
+            + cur_kv_head * stride_kp_h
+            + offs_kp[:, None]
+        )
+        packed_k = tl.load(
+            K_Packed + offs_buf_kp,
+            mask=mask_n[None, :] & mask_kp[:, None],
+            other=0,
+        )
+
+        k_idx_0 = (packed_k & K_BIT_MASK).to(tl.int32)
+        k_idx_1 = ((packed_k >> K_BITS_PER_VAL) & K_BIT_MASK).to(tl.int32)
+        if K_VALS_PER_BYTE == 4:
+            k_0 = _lookup_2bit(k_idx_0, kc0, kc1, kc2, kc3)
+            k_1 = _lookup_2bit(k_idx_1, kc0, kc1, kc2, kc3)
+        else:
+            k_0 = _lookup_4bit(k_idx_0, kc0, kc1, kc2, kc3, kc4, kc5, kc6, kc7,
+                               kc8, kc9, kc10, kc11, kc12, kc13, kc14, kc15, UNIFORM=UNIFORM)
+            k_1 = _lookup_4bit(k_idx_1, kc0, kc1, kc2, kc3, kc4, kc5, kc6, kc7,
+                               kc8, kc9, kc10, kc11, kc12, kc13, kc14, kc15, UNIFORM=UNIFORM)
+
+        qk = tl.dot(q_0, k_0.to(q_0.dtype)) + tl.dot(q_1, k_1.to(q_1.dtype))
+
+        if K_VALS_PER_BYTE == 4:
+            k_idx_2 = ((packed_k >> (2 * K_BITS_PER_VAL)) & K_BIT_MASK).to(tl.int32)
+            k_idx_3 = ((packed_k >> (3 * K_BITS_PER_VAL)) & K_BIT_MASK).to(tl.int32)
+            k_2 = _lookup_2bit(k_idx_2, kc0, kc1, kc2, kc3)
+            k_3 = _lookup_2bit(k_idx_3, kc0, kc1, kc2, kc3)
+            qk += tl.dot(q_2, k_2.to(q_2.dtype)) + tl.dot(q_3, k_3.to(q_3.dtype))
+
+        # K dequant scale
+        k_dscale = tl.load(
+            K_DScale + offs_kv_loc * stride_kds_bs + cur_kv_head,
+            mask=mask_n, other=1.0,
+        ).to(tl.float32)
+        qk *= k_dscale[None, :]
+        qk *= sm_scale
+
+        if logit_cap > 0:
+            qk = logit_cap * tanh(qk / logit_cap)
+
+        if xai_temperature_len > 0:
+            qk *= xai_temperature_reg[:, None]
+
+        qk = tl.where(final_mask, qk, float("-inf"))
+
+        # --- V: load packed uint8, V codebook lookup (V params) ---
+        offs_buf_vp = (
+            offs_kv_loc[:, None] * stride_vp_bs
+            + cur_kv_head * stride_vp_h
+            + offs_vp[None, :]
+        )
+        packed_v = tl.load(
+            V_Packed + offs_buf_vp,
+            mask=mask_n[:, None] & mask_vp[None, :],
+            other=0,
+        )
+        v_idx_0 = (packed_v & V_BIT_MASK).to(tl.int32)
+        v_idx_1 = ((packed_v >> V_BITS_PER_VAL) & V_BIT_MASK).to(tl.int32)
+        if V_VALS_PER_BYTE == 4:
+            v_0 = _lookup_2bit(v_idx_0, vc0, vc1, vc2, vc3)
+            v_1 = _lookup_2bit(v_idx_1, vc0, vc1, vc2, vc3)
+        else:
+            v_0 = _lookup_4bit(v_idx_0, vc0, vc1, vc2, vc3, vc4, vc5, vc6, vc7,
+                               vc8, vc9, vc10, vc11, vc12, vc13, vc14, vc15, UNIFORM=UNIFORM)
+            v_1 = _lookup_4bit(v_idx_1, vc0, vc1, vc2, vc3, vc4, vc5, vc6, vc7,
+                               vc8, vc9, vc10, vc11, vc12, vc13, vc14, vc15, UNIFORM=UNIFORM)
+        if V_VALS_PER_BYTE == 4:
+            v_idx_2 = ((packed_v >> (2 * V_BITS_PER_VAL)) & V_BIT_MASK).to(tl.int32)
+            v_idx_3 = ((packed_v >> (3 * V_BITS_PER_VAL)) & V_BIT_MASK).to(tl.int32)
+            v_2 = _lookup_2bit(v_idx_2, vc0, vc1, vc2, vc3)
+            v_3 = _lookup_2bit(v_idx_3, vc0, vc1, vc2, vc3)
+
+        # Online softmax
+        row_max = tl.max(qk, 1)
+        row_max_fixed = tl.where(row_max == float("-inf"), -1e20, row_max)
+        n_e_max = tl.maximum(row_max_fixed, e_max)
+        re_scale = tl.exp(e_max - n_e_max)
+        p = tl.exp(qk - n_e_max[:, None])
+        deno = deno * re_scale + tl.sum(p, 1)
+
+        acc_0 *= re_scale[:, None]
+        acc_1 *= re_scale[:, None]
+        if V_VALS_PER_BYTE == 4:
+            acc_2 *= re_scale[:, None]
+            acc_3 *= re_scale[:, None]
+
+        # V dequant scale + accumulate
+        v_dscale = tl.load(
+            V_DScale + offs_kv_loc * stride_vds_bs + cur_kv_head,
+            mask=mask_n, other=1.0,
+        ).to(tl.float32)
+        p_scaled = p * v_dscale[None, :]
+
+        acc_0 += tl.dot(p_scaled.to(v_0.dtype), v_0)
+        acc_1 += tl.dot(p_scaled.to(v_1.dtype), v_1)
+        if V_VALS_PER_BYTE == 4:
+            acc_2 += tl.dot(p_scaled.to(v_2.dtype), v_2)
+            acc_3 += tl.dot(p_scaled.to(v_3.dtype), v_3)
+
+        e_max = n_e_max
+
+    # =========================================================
+    # STAGE 2: Extend/triangle loop — bf16 with strided loads
+    # K uses K_VALS_PER_BYTE stride, V uses V_VALS_PER_BYTE stride
+    # =========================================================
+    cur_block_m_end = (
+        cur_seq_len_extend
+        if not IS_CAUSAL
+        else tl.minimum(cur_seq_len_extend, (cur_block_m + 1) * BLOCK_M)
+    )
+
+    for start_n in range(0, cur_block_m_end, BLOCK_N):
+        start_n = tl.multiple_of(start_n, BLOCK_N)
+        mask_n = (start_n + offs_n) < cur_block_m_end
+
+        final_mask = mask_m[:, None] & mask_n[None, :]
+        if USE_CUSTOM_MASK:
+            custom_mask = tl.load(
+                mask_ptr
+                + cur_seq_mask_start_idx
+                + (cur_block_m * BLOCK_M + offs_m[:, None])
+                * cur_seq_len
+                + cur_seq_len_prefix
+                + start_n
+                + offs_n[None, :],
+                mask=final_mask,
+                other=0,
+            )
+            custom_mask &= mask_m[:, None] & mask_n[None, :]
+            final_mask &= custom_mask
+        elif IS_CAUSAL:
+            mask_causal = (cur_block_m * BLOCK_M + offs_m[:, None]) >= (
+                start_n + offs_n[None, :]
+            )
+            mask_causal &= mask_m[:, None] & mask_n[None, :]
+            final_mask &= mask_causal
+        else:
+            final_mask &= mask_m[:, None] & mask_n[None, :]
+
+        # Load K_Extend with K stride pattern (transposed: [K_PACKED_DIM, BLOCK_N])
+        k_ext_base = (
+            (cur_seq_extend_start_idx + start_n + offs_n[None, :]) * stride_kbs
+            + cur_kv_head * stride_kh
+        )
+        offs_k_0 = k_ext_base + (K_VALS_PER_BYTE * offs_kp[:, None])
+        offs_k_1 = k_ext_base + (K_VALS_PER_BYTE * offs_kp[:, None] + 1)
+        mask_k = mask_n[None, :] & mask_kp[:, None]
+
+        k_ext_0 = tl.load(K_Extend + offs_k_0, mask=mask_k, other=0.0)
+        k_ext_1 = tl.load(K_Extend + offs_k_1, mask=mask_k, other=0.0)
+
+        qk = tl.dot(q_0, k_ext_0.to(q_0.dtype)) + tl.dot(q_1, k_ext_1.to(q_1.dtype))
+
+        if K_VALS_PER_BYTE == 4:
+            offs_k_2 = k_ext_base + (4 * offs_kp[:, None] + 2)
+            offs_k_3 = k_ext_base + (4 * offs_kp[:, None] + 3)
+            k_ext_2 = tl.load(K_Extend + offs_k_2, mask=mask_k, other=0.0)
+            k_ext_3 = tl.load(K_Extend + offs_k_3, mask=mask_k, other=0.0)
+            qk += tl.dot(q_2, k_ext_2.to(q_2.dtype)) + tl.dot(q_3, k_ext_3.to(q_3.dtype))
+
+        qk *= sm_scale
+
+        if logit_cap > 0:
+            qk = logit_cap * tanh(qk / logit_cap)
+
+        if xai_temperature_len > 0:
+            qk *= xai_temperature_reg[:, None]
+
+        qk = tl.where(final_mask, qk, float("-inf"))
+
+        # Online softmax
+        row_max = tl.max(qk, 1)
+        row_max_fixed = tl.where(row_max == float("-inf"), -1e20, row_max)
+        n_e_max = tl.maximum(row_max_fixed, e_max)
+        re_scale = tl.exp(e_max - n_e_max)
+        p = tl.exp(qk - n_e_max[:, None])
+        deno = deno * re_scale + tl.sum(p, 1)
+
+        acc_0 *= re_scale[:, None]
+        acc_1 *= re_scale[:, None]
+        if V_VALS_PER_BYTE == 4:
+            acc_2 *= re_scale[:, None]
+            acc_3 *= re_scale[:, None]
+
+        # Load V_Extend with V stride pattern [BLOCK_N, V_PACKED_DIM]
+        v_ext_base = (
+            (cur_seq_extend_start_idx + start_n + offs_n[:, None]) * stride_vbs
+            + cur_kv_head * stride_vh
+        )
+        offs_v_0 = v_ext_base + (V_VALS_PER_BYTE * offs_vp[None, :])
+        offs_v_1 = v_ext_base + (V_VALS_PER_BYTE * offs_vp[None, :] + 1)
+        mask_v = mask_n[:, None] & mask_vp[None, :]
+
+        v_ext_0 = tl.load(V_Extend + offs_v_0, mask=mask_v, other=0.0)
+        v_ext_1 = tl.load(V_Extend + offs_v_1, mask=mask_v, other=0.0)
+
+        p_cast = p.to(v_ext_0.dtype)
+        acc_0 += tl.dot(p_cast, v_ext_0)
+        acc_1 += tl.dot(p_cast, v_ext_1)
+
+        if V_VALS_PER_BYTE == 4:
+            offs_v_2 = v_ext_base + (4 * offs_vp[None, :] + 2)
+            offs_v_3 = v_ext_base + (4 * offs_vp[None, :] + 3)
+            v_ext_2 = tl.load(V_Extend + offs_v_2, mask=mask_v, other=0.0)
+            v_ext_3 = tl.load(V_Extend + offs_v_3, mask=mask_v, other=0.0)
+            acc_2 += tl.dot(p_cast, v_ext_2)
+            acc_3 += tl.dot(p_cast, v_ext_3)
+
+        e_max = n_e_max
+
+    # =========================================================
+    # Sink handling
+    # =========================================================
+    if HAS_SINK:
+        cur_sink = tl.load(sink_ptr + cur_head)
+        deno += tl.exp(cur_sink - e_max)
+
+    # =========================================================
+    # Output store — V-side interleaved N-way accumulators
+    # =========================================================
+    o_base = (
+        (cur_seq_extend_start_idx + cur_block_m * BLOCK_M + offs_m[:, None])
+        * stride_obs
+        + cur_head * stride_oh
+    )
+
+    offs_out_0 = V_VALS_PER_BYTE * tl.arange(0, V_BLOCK_PACKED_DIM)
+    offs_out_1 = V_VALS_PER_BYTE * tl.arange(0, V_BLOCK_PACKED_DIM) + 1
+    mask_out_0 = (offs_out_0 < Lv)
+    mask_out_1 = (offs_out_1 < Lv)
+
+    tl.store(
+        O_Extend + o_base + offs_out_0[None, :],
+        acc_0 / deno[:, None],
+        mask=mask_m[:, None] & mask_out_0[None, :],
+    )
+    tl.store(
+        O_Extend + o_base + offs_out_1[None, :],
+        acc_1 / deno[:, None],
+        mask=mask_m[:, None] & mask_out_1[None, :],
+    )
+
+    if V_VALS_PER_BYTE == 4:
+        offs_out_2 = 4 * tl.arange(0, V_BLOCK_PACKED_DIM) + 2
+        offs_out_3 = 4 * tl.arange(0, V_BLOCK_PACKED_DIM) + 3
+        mask_out_2 = (offs_out_2 < Lv)
+        mask_out_3 = (offs_out_3 < Lv)
+        tl.store(
+            O_Extend + o_base + offs_out_2[None, :],
+            acc_2 / deno[:, None],
+            mask=mask_m[:, None] & mask_out_2[None, :],
+        )
+        tl.store(
+            O_Extend + o_base + offs_out_3[None, :],
+            acc_3 / deno[:, None],
+            mask=mask_m[:, None] & mask_out_3[None, :],
+        )
+
+
+def tq_extend_attention_fwd(
+    q_extend,
+    k_extend,
+    v_extend,
+    o_extend,
+    k_packed,
+    v_packed,
+    k_dscale,
+    v_dscale,
+    k_centroids,
+    v_centroids,
+    qo_indptr,
+    kv_indptr,
+    kv_indices,
+    custom_mask,
+    is_causal,
+    mask_indptr,
+    max_len_extend,
+    sm_scale=None,
+    k_bit_width=4,
+    v_bit_width=4,
+    logit_cap=0.0,
+    sinks=None,
+    xai_temperature_len=-1,
+    uniform=False,
+):
+    """Fused TurboQuant extend attention: reads packed uint8 KV directly.
+
+    Supports asymmetric K/V bit widths (e.g., K=4bit V=2bit).
+    Both prefix (packed KV pool) and extend (fresh bf16) stages use
+    N-way split dot products, with interleaved output store.
+    """
+    assert k_bit_width in (2, 4), f"Unsupported K bit_width: {k_bit_width}"
+    assert v_bit_width in (2, 4), f"Unsupported V bit_width: {v_bit_width}"
+
+    Lq = q_extend.shape[-1]
+    Lv = Lq  # TQ constrains Lk == Lv
+    K_Lk_packed = k_packed.shape[-1]
+    V_Lv_packed = v_packed.shape[-1]
+
+    K_VALS_PER_BYTE, K_BITS_PER_VAL, K_BIT_MASK = _bit_params(k_bit_width)
+    V_VALS_PER_BYTE, V_BITS_PER_VAL, V_BIT_MASK = _bit_params(v_bit_width)
+
+    K_BLOCK_PACKED_DIM = triton.next_power_of_2(K_Lk_packed)
+    V_BLOCK_PACKED_DIM = triton.next_power_of_2(V_Lv_packed)
+    # Smaller BLOCK_M than standard extend (128) due to N-way accumulator pressure
+    BLOCK_M = 64
+    BLOCK_N = 64
+
+    sm_scale = sm_scale or 1.0 / (Lq ** 0.5)
+    batch_size = qo_indptr.shape[0] - 1
+    head_num = q_extend.shape[1]
+    kv_group_num = q_extend.shape[1] // k_packed.shape[1]
+
+    USE_CUSTOM_MASK = custom_mask is not None
+    HAS_SINK = sinks is not None
+
+    grid = (batch_size, head_num, triton.cdiv(max_len_extend, BLOCK_M))
+
+    _fwd_tq_extend_kernel[grid](
+        q_extend,
+        k_extend,
+        v_extend,
+        o_extend,
+        k_packed,
+        v_packed,
+        k_dscale,
+        v_dscale,
+        k_centroids,
+        v_centroids,
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        custom_mask,
+        mask_indptr,
+        sinks,
+        sm_scale,
+        kv_group_num,
+        q_extend.stride(0), q_extend.stride(1),
+        k_extend.stride(0), k_extend.stride(1),
+        v_extend.stride(0), v_extend.stride(1),
+        o_extend.stride(0), o_extend.stride(1),
+        k_packed.stride(0), k_packed.stride(1),
+        v_packed.stride(0), v_packed.stride(1),
+        k_dscale.stride(0), v_dscale.stride(0),
+        K_BLOCK_PACKED_DIM=K_BLOCK_PACKED_DIM,
+        K_Lk_packed=K_Lk_packed,
+        K_VALS_PER_BYTE=K_VALS_PER_BYTE,
+        K_BITS_PER_VAL=K_BITS_PER_VAL,
+        K_BIT_MASK=K_BIT_MASK,
+        V_BLOCK_PACKED_DIM=V_BLOCK_PACKED_DIM,
+        V_Lv_packed=V_Lv_packed,
+        V_VALS_PER_BYTE=V_VALS_PER_BYTE,
+        V_BITS_PER_VAL=V_BITS_PER_VAL,
+        V_BIT_MASK=V_BIT_MASK,
+        logit_cap=logit_cap,
+        xai_temperature_len=xai_temperature_len,
+        Lq=Lq,
+        Lv=Lv,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        USE_CUSTOM_MASK=USE_CUSTOM_MASK,
+        IS_CAUSAL=is_causal,
+        HAS_SINK=HAS_SINK,
+        UNIFORM=uniform,
+        num_warps=4,
+        num_stages=2,
+    )

--- a/python/sglang/srt/layers/attention/triton_ops/turboquant_quantize.py
+++ b/python/sglang/srt/layers/attention/triton_ops/turboquant_quantize.py
@@ -1,0 +1,786 @@
+"""Fused TurboQuant quantize: WHT (CUDA) + searchsorted+pack (Triton).
+
+The WHT transform uses SGLang's existing CUDA hadamard kernel (can't fuse).
+The searchsorted + centroid lookup + quant_norm + bit-pack is fused into
+a single Triton kernel for both 4-bit and 2-bit, replacing ~8 separate
+PyTorch ops per call.
+
+Total: 3 kernel launches (batched norm+normalize + WHT rotation + batched pack+store).
+"""
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _fused_pack_4bit_kernel(
+    Y,          # (tokens, heads, dim) float32 — WHT-rotated unit vectors
+    Packed,     # (tokens, heads, packed_dim) uint8 output
+    DScale,     # (tokens, heads) bf16 output — dequant scale = norm / max(qnorm, eps)
+    Norms,      # (tokens, heads) float32 — L2 norms
+    Boundaries, # (N_BOUNDARIES,) float32
+    Centroids,  # (N_CENTROIDS,) float32
+    stride_y_t,
+    stride_y_h,
+    stride_p_t,
+    stride_p_h,
+    stride_ds_t,
+    stride_n_t,
+    N_BOUNDARIES: tl.constexpr,
+    BLOCK_PACKED: tl.constexpr,
+    Lk_half: tl.constexpr,
+):
+    """Fused searchsorted + centroid gather + quant_norm + 4-bit nibble pack.
+
+    One program per (token, head). Processes dim/2 pairs of elements.
+    """
+    pid_t = tl.program_id(0)
+    pid_h = tl.program_id(1)
+
+    offs_pair = tl.arange(0, BLOCK_PACKED)
+    mask_pair = offs_pair < Lk_half
+
+    # Load even/odd elements of the rotated vector
+    y_base = Y + pid_t * stride_y_t + pid_h * stride_y_h
+    y_even = tl.load(y_base + offs_pair * 2, mask=mask_pair, other=0.0)
+    y_odd = tl.load(y_base + offs_pair * 2 + 1, mask=mask_pair, other=0.0)
+
+    # Searchsorted: count boundaries less than y (linear scan, N_BOUNDARIES is small: 7 or 15)
+    idx_even = tl.zeros([BLOCK_PACKED], dtype=tl.int32)
+    idx_odd = tl.zeros([BLOCK_PACKED], dtype=tl.int32)
+    for b in tl.static_range(N_BOUNDARIES):
+        bound = tl.load(Boundaries + b)
+        idx_even += tl.where(y_even > bound, 1, 0).to(tl.int32)
+        idx_odd += tl.where(y_odd > bound, 1, 0).to(tl.int32)
+
+    # Centroid lookup (gather from small table)
+    c_even = tl.load(Centroids + idx_even, mask=mask_pair, other=0.0)
+    c_odd = tl.load(Centroids + idx_odd, mask=mask_pair, other=0.0)
+
+    # Compute quant_norm and dequant scale in one shot
+    qnorm_sq = tl.sum(c_even * c_even, axis=0) + tl.sum(c_odd * c_odd, axis=0)
+    qnorm = tl.sqrt(qnorm_sq)
+    norm = tl.load(Norms + pid_t * stride_n_t + pid_h)
+    safe_qnorm = tl.where(qnorm > 1e-10, qnorm, 1.0)
+    dscale = (norm / safe_qnorm).to(tl.bfloat16)
+    tl.store(DScale + pid_t * stride_ds_t + pid_h, dscale)
+
+    # 4-bit pack: (idx_odd << 4) | idx_even
+    packed = ((idx_odd & 0xF) << 4) | (idx_even & 0xF)
+    p_ptr = Packed + pid_t * stride_p_t + pid_h * stride_p_h + offs_pair
+    tl.store(p_ptr, packed.to(tl.uint8), mask=mask_pair)
+
+
+@triton.jit
+def _fused_pack_2bit_kernel(
+    Y,          # (tokens, heads, dim) float32 — WHT-rotated unit vectors
+    Packed,     # (tokens, heads, packed_dim) uint8 output
+    DScale,     # (tokens, heads) bf16 output — dequant scale
+    Norms,      # (tokens, heads) float32 — L2 norms
+    Boundaries, # (N_BOUNDARIES,) float32
+    Centroids,  # (N_CENTROIDS,) float32
+    stride_y_t,
+    stride_y_h,
+    stride_p_t,
+    stride_p_h,
+    stride_ds_t,
+    stride_n_t,
+    N_BOUNDARIES: tl.constexpr,
+    BLOCK_PACKED: tl.constexpr,
+    Lk_quarter: tl.constexpr,
+):
+    """Fused searchsorted + centroid gather + quant_norm + 2-bit pack.
+
+    One program per (token, head). Processes dim/4 groups of 4 elements.
+    Packing: byte = (idx3 << 6) | (idx2 << 4) | (idx1 << 2) | idx0
+    """
+    pid_t = tl.program_id(0)
+    pid_h = tl.program_id(1)
+
+    offs_group = tl.arange(0, BLOCK_PACKED)
+    mask_group = offs_group < Lk_quarter
+
+    # Load 4 elements per group
+    y_base = Y + pid_t * stride_y_t + pid_h * stride_y_h
+    y_0 = tl.load(y_base + offs_group * 4, mask=mask_group, other=0.0)
+    y_1 = tl.load(y_base + offs_group * 4 + 1, mask=mask_group, other=0.0)
+    y_2 = tl.load(y_base + offs_group * 4 + 2, mask=mask_group, other=0.0)
+    y_3 = tl.load(y_base + offs_group * 4 + 3, mask=mask_group, other=0.0)
+
+    # Searchsorted: count boundaries less than y (N_BOUNDARIES = 3 for 2-bit)
+    idx_0 = tl.zeros([BLOCK_PACKED], dtype=tl.int32)
+    idx_1 = tl.zeros([BLOCK_PACKED], dtype=tl.int32)
+    idx_2 = tl.zeros([BLOCK_PACKED], dtype=tl.int32)
+    idx_3 = tl.zeros([BLOCK_PACKED], dtype=tl.int32)
+    for b in tl.static_range(N_BOUNDARIES):
+        bound = tl.load(Boundaries + b)
+        idx_0 += tl.where(y_0 > bound, 1, 0).to(tl.int32)
+        idx_1 += tl.where(y_1 > bound, 1, 0).to(tl.int32)
+        idx_2 += tl.where(y_2 > bound, 1, 0).to(tl.int32)
+        idx_3 += tl.where(y_3 > bound, 1, 0).to(tl.int32)
+
+    # Centroid lookup
+    c_0 = tl.load(Centroids + idx_0, mask=mask_group, other=0.0)
+    c_1 = tl.load(Centroids + idx_1, mask=mask_group, other=0.0)
+    c_2 = tl.load(Centroids + idx_2, mask=mask_group, other=0.0)
+    c_3 = tl.load(Centroids + idx_3, mask=mask_group, other=0.0)
+
+    # Compute quant_norm and dequant scale in one shot
+    qnorm_sq = (
+        tl.sum(c_0 * c_0, axis=0) + tl.sum(c_1 * c_1, axis=0)
+        + tl.sum(c_2 * c_2, axis=0) + tl.sum(c_3 * c_3, axis=0)
+    )
+    qnorm = tl.sqrt(qnorm_sq)
+    norm = tl.load(Norms + pid_t * stride_n_t + pid_h)
+    safe_qnorm = tl.where(qnorm > 1e-10, qnorm, 1.0)
+    dscale = (norm / safe_qnorm).to(tl.bfloat16)
+    tl.store(DScale + pid_t * stride_ds_t + pid_h, dscale)
+
+    # 2-bit pack: (idx3 << 6) | (idx2 << 4) | (idx1 << 2) | idx0
+    packed = (
+        ((idx_3 & 0x03) << 6)
+        | ((idx_2 & 0x03) << 4)
+        | ((idx_1 & 0x03) << 2)
+        | (idx_0 & 0x03)
+    )
+    p_ptr = Packed + pid_t * stride_p_t + pid_h * stride_p_h + offs_group
+    tl.store(p_ptr, packed.to(tl.uint8), mask=mask_group)
+
+
+@triton.jit
+def _fused_norm_normalize_kernel(
+    X,          # (tokens, heads, dim) bf16/fp16/fp32
+    Out,        # (tokens, heads, dim) float32 — unit vectors
+    Norms,      # (tokens, heads) float32
+    stride_x_t,
+    stride_x_h,
+    stride_o_t,
+    stride_o_h,
+    stride_n_t,
+    BLOCK_DIM: tl.constexpr,
+    Lk: tl.constexpr,
+):
+    """Fused L2 norm + normalize: out = x / max(||x||, eps), norms = ||x||.
+
+    One program per (token, head). Replaces torch.linalg.norm + where + div.
+    """
+    pid_t = tl.program_id(0)
+    pid_h = tl.program_id(1)
+
+    offs_d = tl.arange(0, BLOCK_DIM)
+    mask_d = offs_d < Lk
+
+    # Load x
+    x_ptr = X + pid_t * stride_x_t + pid_h * stride_x_h + offs_d
+    x = tl.load(x_ptr, mask=mask_d, other=0.0).to(tl.float32)
+
+    # L2 norm
+    x_sq = x * x
+    norm_sq = tl.sum(x_sq, axis=0)
+    norm = tl.sqrt(norm_sq)
+
+    # Normalize (safe division)
+    safe_norm = tl.where(norm > 0.0, norm, 1.0)
+    x_unit = x / safe_norm
+
+    # Store
+    out_ptr = Out + pid_t * stride_o_t + pid_h * stride_o_h + offs_d
+    tl.store(out_ptr, x_unit, mask=mask_d)
+    tl.store(Norms + pid_t * stride_n_t + pid_h, norm)
+
+
+@triton.jit
+def _fused_norm_normalize_kv_kernel(
+    X_K,        # (tokens, heads, dim) — K input
+    X_V,        # (tokens, heads, dim) — V input
+    Out,        # (2*tokens, heads, dim) float32 — unit vectors [K; V]
+    Norms,      # (2*tokens, heads) float32 — norms [K; V]
+    stride_k_t,
+    stride_k_h,
+    stride_v_t,
+    stride_v_h,
+    stride_o_t,
+    stride_o_h,
+    stride_n_t,
+    TOKENS: tl.constexpr,
+    BLOCK_DIM: tl.constexpr,
+    Lk: tl.constexpr,
+):
+    """Batched norm+normalize for K and V in a single kernel launch.
+
+    pid_t in [0, 2*TOKENS): first TOKENS programs process K, rest process V.
+    Output is contiguous: [K_unit; V_unit] in Out, [K_norms; V_norms] in Norms.
+    """
+    pid_t = tl.program_id(0)
+    pid_h = tl.program_id(1)
+
+    offs_d = tl.arange(0, BLOCK_DIM)
+    mask_d = offs_d < Lk
+
+    # Select K or V input based on pid_t
+    is_v = pid_t >= TOKENS
+    local_t = pid_t - TOKENS * tl.where(is_v, 1, 0)
+
+    k_base = X_K + local_t * stride_k_t + pid_h * stride_k_h
+    v_base = X_V + local_t * stride_v_t + pid_h * stride_v_h
+    x_ptr = tl.where(is_v, v_base, k_base) + offs_d
+    x = tl.load(x_ptr, mask=mask_d, other=0.0).to(tl.float32)
+
+    # L2 norm
+    norm = tl.sqrt(tl.sum(x * x, axis=0))
+
+    # Normalize (safe division)
+    safe_norm = tl.where(norm > 0.0, norm, 1.0)
+    x_unit = x / safe_norm
+
+    # Store to contiguous output (indexed by pid_t directly)
+    out_ptr = Out + pid_t * stride_o_t + pid_h * stride_o_h + offs_d
+    tl.store(out_ptr, x_unit, mask=mask_d)
+    tl.store(Norms + pid_t * stride_n_t + pid_h, norm)
+
+
+@triton.jit
+def _fused_pack_store_4bit_kernel(
+    Y,              # (tokens, heads, dim) float32 — WHT-rotated unit vectors
+    Norms,          # (tokens, heads) float32 — L2 norms
+    Loc,            # (tokens,) int64 — pool slot indices
+    KBuffer,        # (pool_size, heads, packed_dim) uint8 — destination
+    DScaleBuffer,   # (pool_size, heads) bf16 — destination
+    Boundaries,
+    Centroids,
+    stride_y_t,
+    stride_y_h,
+    stride_kb_s,    # KBuffer stride for pool_size dim
+    stride_kb_h,
+    stride_ds_s,    # DScaleBuffer stride for pool_size dim
+    stride_n_t,
+    N_BOUNDARIES: tl.constexpr,
+    BLOCK_PACKED: tl.constexpr,
+    Lk_half: tl.constexpr,
+):
+    """Fused searchsorted + pack + dscale + scatter store to KV pool."""
+    pid_t = tl.program_id(0)
+    pid_h = tl.program_id(1)
+
+    # Get scatter destination
+    pool_slot = tl.load(Loc + pid_t)
+
+    offs_pair = tl.arange(0, BLOCK_PACKED)
+    mask_pair = offs_pair < Lk_half
+
+    # Load WHT-rotated unit vector
+    y_base = Y + pid_t * stride_y_t + pid_h * stride_y_h
+    y_even = tl.load(y_base + offs_pair * 2, mask=mask_pair, other=0.0)
+    y_odd = tl.load(y_base + offs_pair * 2 + 1, mask=mask_pair, other=0.0)
+
+    # Searchsorted
+    idx_even = tl.zeros([BLOCK_PACKED], dtype=tl.int32)
+    idx_odd = tl.zeros([BLOCK_PACKED], dtype=tl.int32)
+    for b in tl.static_range(N_BOUNDARIES):
+        bound = tl.load(Boundaries + b)
+        idx_even += tl.where(y_even > bound, 1, 0).to(tl.int32)
+        idx_odd += tl.where(y_odd > bound, 1, 0).to(tl.int32)
+
+    # Centroid lookup + quant_norm + dscale
+    c_even = tl.load(Centroids + idx_even, mask=mask_pair, other=0.0)
+    c_odd = tl.load(Centroids + idx_odd, mask=mask_pair, other=0.0)
+    qnorm_sq = tl.sum(c_even * c_even, axis=0) + tl.sum(c_odd * c_odd, axis=0)
+    qnorm = tl.sqrt(qnorm_sq)
+    norm = tl.load(Norms + pid_t * stride_n_t + pid_h)
+    safe_qnorm = tl.where(qnorm > 1e-10, qnorm, 1.0)
+    dscale = (norm / safe_qnorm).to(tl.bfloat16)
+
+    # Pack and scatter store directly to KV pool
+    packed = ((idx_odd & 0xF) << 4) | (idx_even & 0xF)
+    p_ptr = KBuffer + pool_slot * stride_kb_s + pid_h * stride_kb_h + offs_pair
+    tl.store(p_ptr, packed.to(tl.uint8), mask=mask_pair)
+    tl.store(DScaleBuffer + pool_slot * stride_ds_s + pid_h, dscale)
+
+
+@triton.jit
+def _fused_pack_store_2bit_kernel(
+    Y, Norms, Loc,
+    KBuffer, DScaleBuffer,
+    Boundaries, Centroids,
+    stride_y_t, stride_y_h,
+    stride_kb_s, stride_kb_h,
+    stride_ds_s, stride_n_t,
+    N_BOUNDARIES: tl.constexpr,
+    BLOCK_PACKED: tl.constexpr,
+    Lk_quarter: tl.constexpr,
+):
+    """Fused searchsorted + pack + dscale + scatter store (2-bit)."""
+    pid_t = tl.program_id(0)
+    pid_h = tl.program_id(1)
+    pool_slot = tl.load(Loc + pid_t)
+
+    offs_group = tl.arange(0, BLOCK_PACKED)
+    mask_group = offs_group < Lk_quarter
+
+    y_base = Y + pid_t * stride_y_t + pid_h * stride_y_h
+    y_0 = tl.load(y_base + offs_group * 4, mask=mask_group, other=0.0)
+    y_1 = tl.load(y_base + offs_group * 4 + 1, mask=mask_group, other=0.0)
+    y_2 = tl.load(y_base + offs_group * 4 + 2, mask=mask_group, other=0.0)
+    y_3 = tl.load(y_base + offs_group * 4 + 3, mask=mask_group, other=0.0)
+
+    idx_0 = tl.zeros([BLOCK_PACKED], dtype=tl.int32)
+    idx_1 = tl.zeros([BLOCK_PACKED], dtype=tl.int32)
+    idx_2 = tl.zeros([BLOCK_PACKED], dtype=tl.int32)
+    idx_3 = tl.zeros([BLOCK_PACKED], dtype=tl.int32)
+    for b in tl.static_range(N_BOUNDARIES):
+        bound = tl.load(Boundaries + b)
+        idx_0 += tl.where(y_0 > bound, 1, 0).to(tl.int32)
+        idx_1 += tl.where(y_1 > bound, 1, 0).to(tl.int32)
+        idx_2 += tl.where(y_2 > bound, 1, 0).to(tl.int32)
+        idx_3 += tl.where(y_3 > bound, 1, 0).to(tl.int32)
+
+    c_0 = tl.load(Centroids + idx_0, mask=mask_group, other=0.0)
+    c_1 = tl.load(Centroids + idx_1, mask=mask_group, other=0.0)
+    c_2 = tl.load(Centroids + idx_2, mask=mask_group, other=0.0)
+    c_3 = tl.load(Centroids + idx_3, mask=mask_group, other=0.0)
+
+    qnorm_sq = tl.sum(c_0*c_0, 0) + tl.sum(c_1*c_1, 0) + tl.sum(c_2*c_2, 0) + tl.sum(c_3*c_3, 0)
+    qnorm = tl.sqrt(qnorm_sq)
+    norm = tl.load(Norms + pid_t * stride_n_t + pid_h)
+    safe_qnorm = tl.where(qnorm > 1e-10, qnorm, 1.0)
+    dscale = (norm / safe_qnorm).to(tl.bfloat16)
+
+    packed = ((idx_3 & 0x03) << 6) | ((idx_2 & 0x03) << 4) | ((idx_1 & 0x03) << 2) | (idx_0 & 0x03)
+    p_ptr = KBuffer + pool_slot * stride_kb_s + pid_h * stride_kb_h + offs_group
+    tl.store(p_ptr, packed.to(tl.uint8), mask=mask_group)
+    tl.store(DScaleBuffer + pool_slot * stride_ds_s + pid_h, dscale)
+
+
+@triton.jit
+def _fused_pack_store_4bit_kv_kernel(
+    Y,              # (2*tokens, heads, dim) float32 — [K_y; V_y] contiguous
+    Norms,          # (2*tokens, heads) float32 — [K_norms; V_norms]
+    Loc,            # (tokens,) int64 — pool slot indices
+    KBuffer,        # (pool_size, heads, packed_dim) uint8
+    VBuffer,        # (pool_size, heads, packed_dim) uint8
+    KDScale,        # (pool_size, heads) bf16
+    VDScale,        # (pool_size, heads) bf16
+    Boundaries,
+    Centroids,
+    stride_y_t,
+    stride_y_h,
+    stride_kb_s,
+    stride_kb_h,
+    stride_vb_s,
+    stride_vb_h,
+    stride_kds,
+    stride_vds,
+    stride_n_t,
+    TOKENS: tl.constexpr,
+    N_BOUNDARIES: tl.constexpr,
+    BLOCK_PACKED: tl.constexpr,
+    Lk_half: tl.constexpr,
+):
+    """Batched 4-bit pack+store for K and V in a single launch (shared codebook).
+
+    pid_t in [0, 2*TOKENS): first TOKENS programs store to KBuffer, rest to VBuffer.
+    """
+    pid_t = tl.program_id(0)
+    pid_h = tl.program_id(1)
+
+    is_v = pid_t >= TOKENS
+    local_t = pid_t - TOKENS * tl.where(is_v, 1, 0)
+    pool_slot = tl.load(Loc + local_t)
+
+    offs_pair = tl.arange(0, BLOCK_PACKED)
+    mask_pair = offs_pair < Lk_half
+
+    y_base = Y + pid_t * stride_y_t + pid_h * stride_y_h
+    y_even = tl.load(y_base + offs_pair * 2, mask=mask_pair, other=0.0)
+    y_odd = tl.load(y_base + offs_pair * 2 + 1, mask=mask_pair, other=0.0)
+
+    idx_even = tl.zeros([BLOCK_PACKED], dtype=tl.int32)
+    idx_odd = tl.zeros([BLOCK_PACKED], dtype=tl.int32)
+    for b in tl.static_range(N_BOUNDARIES):
+        bound = tl.load(Boundaries + b)
+        idx_even += tl.where(y_even > bound, 1, 0).to(tl.int32)
+        idx_odd += tl.where(y_odd > bound, 1, 0).to(tl.int32)
+
+    c_even = tl.load(Centroids + idx_even, mask=mask_pair, other=0.0)
+    c_odd = tl.load(Centroids + idx_odd, mask=mask_pair, other=0.0)
+    qnorm_sq = tl.sum(c_even * c_even, axis=0) + tl.sum(c_odd * c_odd, axis=0)
+    qnorm = tl.sqrt(qnorm_sq)
+    norm = tl.load(Norms + pid_t * stride_n_t + pid_h)
+    safe_qnorm = tl.where(qnorm > 1e-10, qnorm, 1.0)
+    dscale = (norm / safe_qnorm).to(tl.bfloat16)
+
+    packed = ((idx_odd & 0xF) << 4) | (idx_even & 0xF)
+
+    # Select output buffer: KBuffer or VBuffer
+    k_p_ptr = KBuffer + pool_slot * stride_kb_s + pid_h * stride_kb_h + offs_pair
+    v_p_ptr = VBuffer + pool_slot * stride_vb_s + pid_h * stride_vb_h + offs_pair
+    p_ptr = tl.where(is_v, v_p_ptr, k_p_ptr)
+    tl.store(p_ptr, packed.to(tl.uint8), mask=mask_pair)
+
+    k_ds_ptr = KDScale + pool_slot * stride_kds + pid_h
+    v_ds_ptr = VDScale + pool_slot * stride_vds + pid_h
+    ds_ptr = tl.where(is_v, v_ds_ptr, k_ds_ptr)
+    tl.store(ds_ptr, dscale)
+
+
+@triton.jit
+def _fused_pack_store_2bit_kv_kernel(
+    Y, Norms, Loc,
+    KBuffer, VBuffer,
+    KDScale, VDScale,
+    Boundaries, Centroids,
+    stride_y_t, stride_y_h,
+    stride_kb_s, stride_kb_h,
+    stride_vb_s, stride_vb_h,
+    stride_kds, stride_vds,
+    stride_n_t,
+    TOKENS: tl.constexpr,
+    N_BOUNDARIES: tl.constexpr,
+    BLOCK_PACKED: tl.constexpr,
+    Lk_quarter: tl.constexpr,
+):
+    """Batched 2-bit pack+store for K and V in a single launch (shared codebook)."""
+    pid_t = tl.program_id(0)
+    pid_h = tl.program_id(1)
+
+    is_v = pid_t >= TOKENS
+    local_t = pid_t - TOKENS * tl.where(is_v, 1, 0)
+    pool_slot = tl.load(Loc + local_t)
+
+    offs_group = tl.arange(0, BLOCK_PACKED)
+    mask_group = offs_group < Lk_quarter
+
+    y_base = Y + pid_t * stride_y_t + pid_h * stride_y_h
+    y_0 = tl.load(y_base + offs_group * 4, mask=mask_group, other=0.0)
+    y_1 = tl.load(y_base + offs_group * 4 + 1, mask=mask_group, other=0.0)
+    y_2 = tl.load(y_base + offs_group * 4 + 2, mask=mask_group, other=0.0)
+    y_3 = tl.load(y_base + offs_group * 4 + 3, mask=mask_group, other=0.0)
+
+    idx_0 = tl.zeros([BLOCK_PACKED], dtype=tl.int32)
+    idx_1 = tl.zeros([BLOCK_PACKED], dtype=tl.int32)
+    idx_2 = tl.zeros([BLOCK_PACKED], dtype=tl.int32)
+    idx_3 = tl.zeros([BLOCK_PACKED], dtype=tl.int32)
+    for b in tl.static_range(N_BOUNDARIES):
+        bound = tl.load(Boundaries + b)
+        idx_0 += tl.where(y_0 > bound, 1, 0).to(tl.int32)
+        idx_1 += tl.where(y_1 > bound, 1, 0).to(tl.int32)
+        idx_2 += tl.where(y_2 > bound, 1, 0).to(tl.int32)
+        idx_3 += tl.where(y_3 > bound, 1, 0).to(tl.int32)
+
+    c_0 = tl.load(Centroids + idx_0, mask=mask_group, other=0.0)
+    c_1 = tl.load(Centroids + idx_1, mask=mask_group, other=0.0)
+    c_2 = tl.load(Centroids + idx_2, mask=mask_group, other=0.0)
+    c_3 = tl.load(Centroids + idx_3, mask=mask_group, other=0.0)
+
+    qnorm_sq = tl.sum(c_0*c_0, 0) + tl.sum(c_1*c_1, 0) + tl.sum(c_2*c_2, 0) + tl.sum(c_3*c_3, 0)
+    qnorm = tl.sqrt(qnorm_sq)
+    norm = tl.load(Norms + pid_t * stride_n_t + pid_h)
+    safe_qnorm = tl.where(qnorm > 1e-10, qnorm, 1.0)
+    dscale = (norm / safe_qnorm).to(tl.bfloat16)
+
+    packed = ((idx_3 & 0x03) << 6) | ((idx_2 & 0x03) << 4) | ((idx_1 & 0x03) << 2) | (idx_0 & 0x03)
+
+    k_p_ptr = KBuffer + pool_slot * stride_kb_s + pid_h * stride_kb_h + offs_group
+    v_p_ptr = VBuffer + pool_slot * stride_vb_s + pid_h * stride_vb_h + offs_group
+    p_ptr = tl.where(is_v, v_p_ptr, k_p_ptr)
+    tl.store(p_ptr, packed.to(tl.uint8), mask=mask_group)
+
+    k_ds_ptr = KDScale + pool_slot * stride_kds + pid_h
+    v_ds_ptr = VDScale + pool_slot * stride_vds + pid_h
+    ds_ptr = tl.where(is_v, v_ds_ptr, k_ds_ptr)
+    tl.store(ds_ptr, dscale)
+
+
+def fused_turboquant_quantize_and_store(
+    x, signs1, signs2, centroids, boundaries, bit_width,
+    kv_buffer, dscale_buffer, loc,
+):
+    """Fused quantize + scatter store: norm → normalize → WHT → pack+dscale → scatter to KV pool.
+
+    Eliminates temp tensors and scatter store kernels.
+    """
+    import torch
+    from sglang.jit_kernel.hadamard import hadamard_transform_with_signs
+
+    tokens, heads, dim = x.shape
+
+    # Step 1: Fused norm + normalize (1 Triton kernel)
+    BLOCK_DIM = triton.next_power_of_2(dim)
+    x_unit = torch.empty(tokens, heads, dim, dtype=torch.float32, device=x.device)
+    norms = torch.empty(tokens, heads, dtype=torch.float32, device=x.device)
+    grid_nn = (tokens, heads)
+    _fused_norm_normalize_kernel[grid_nn](
+        x, x_unit, norms,
+        x.stride(0), x.stride(1),
+        x_unit.stride(0), x_unit.stride(1),
+        norms.stride(0),
+        BLOCK_DIM=BLOCK_DIM, Lk=dim, num_warps=4,
+    )
+
+    # Step 2: Fused WHT rotation (1 CUDA kernel)
+    wht_scale = 1.0 / (dim ** 0.5)
+    y = hadamard_transform_with_signs(x_unit, signs1, signs2, scale=wht_scale)
+
+    # Step 3: Fused pack + dscale + scatter store (1 Triton kernel)
+    if bit_width == 4:
+        packed_dim = dim // 2
+        BLOCK_PACKED = triton.next_power_of_2(packed_dim)
+        grid_ps = (tokens, heads)
+        _fused_pack_store_4bit_kernel[grid_ps](
+            y, norms, loc,
+            kv_buffer, dscale_buffer,
+            boundaries, centroids,
+            y.stride(0), y.stride(1),
+            kv_buffer.stride(0), kv_buffer.stride(1),
+            dscale_buffer.stride(0),
+            norms.stride(0),
+            N_BOUNDARIES=boundaries.shape[0],
+            BLOCK_PACKED=BLOCK_PACKED,
+            Lk_half=packed_dim,
+            num_warps=4,
+        )
+    elif bit_width == 2:
+        packed_dim = dim // 4
+        BLOCK_PACKED = triton.next_power_of_2(packed_dim)
+        grid_ps = (tokens, heads)
+        _fused_pack_store_2bit_kernel[grid_ps](
+            y, norms, loc,
+            kv_buffer, dscale_buffer,
+            boundaries, centroids,
+            y.stride(0), y.stride(1),
+            kv_buffer.stride(0), kv_buffer.stride(1),
+            dscale_buffer.stride(0),
+            norms.stride(0),
+            N_BOUNDARIES=boundaries.shape[0],
+            BLOCK_PACKED=BLOCK_PACKED,
+            Lk_quarter=packed_dim,
+            num_warps=4,
+        )
+    else:
+        raise ValueError(f'Unsupported bit_width: {bit_width}')
+
+
+def fused_turboquant_quantize_and_store_kv(
+    cache_k, cache_v,
+    signs1, signs2,
+    k_centroids, k_boundaries, k_bit_width,
+    v_centroids, v_boundaries, v_bit_width,
+    k_buffer, k_dscale_buffer,
+    v_buffer, v_dscale_buffer,
+    loc,
+    pre_kv_unit=None, pre_kv_norms=None,
+):
+    """Batched K+V quantize: shares norm+normalize, WHT, and pack+store launches.
+
+    3 kernel launches total (when K/V share bit_width):
+    1. Batched norm+normalize for [K, V] (1 Triton kernel)
+    2. Batched WHT rotation for [K_unit, V_unit] (1 CUDA kernel)
+    3. Batched pack+store for K and V (1 Triton kernel)
+    """
+    import torch
+    from sglang.jit_kernel.hadamard import hadamard_transform_with_signs
+
+    tokens, heads, dim = cache_k.shape
+    BLOCK_DIM = triton.next_power_of_2(dim)
+    wht_scale = 1.0 / (dim ** 0.5)
+
+    # Use pre-allocated buffers if available (avoids torch.empty inside CUDA graph)
+    if pre_kv_unit is not None and pre_kv_unit.shape[0] >= 2 * tokens:
+        kv_unit = pre_kv_unit[:2 * tokens, :heads, :dim]
+        kv_norms = pre_kv_norms[:2 * tokens, :heads]
+    else:
+        kv_unit = torch.empty(2 * tokens, heads, dim, dtype=torch.float32, device=cache_k.device)
+        kv_norms = torch.empty(2 * tokens, heads, dtype=torch.float32, device=cache_k.device)
+
+    # Step 1: Batched norm+normalize K and V (1 Triton kernel)
+    grid_nn = (2 * tokens, heads)
+    _fused_norm_normalize_kv_kernel[grid_nn](
+        cache_k, cache_v, kv_unit, kv_norms,
+        cache_k.stride(0), cache_k.stride(1),
+        cache_v.stride(0), cache_v.stride(1),
+        kv_unit.stride(0), kv_unit.stride(1),
+        kv_norms.stride(0),
+        TOKENS=tokens,
+        BLOCK_DIM=BLOCK_DIM, Lk=dim, num_warps=4,
+    )
+
+    # Step 2: Batched WHT for K+V together (1 CUDA kernel)
+    kv_y = hadamard_transform_with_signs(kv_unit, signs1, signs2, scale=wht_scale)
+
+    # Step 3: Batched pack+store (1 Triton kernel when K/V share bit_width)
+    if k_bit_width == v_bit_width:
+        if k_bit_width == 4:
+            packed_dim = dim // 2
+            BLOCK_PACKED = triton.next_power_of_2(packed_dim)
+            grid_ps = (2 * tokens, heads)
+            _fused_pack_store_4bit_kv_kernel[grid_ps](
+                kv_y, kv_norms, loc,
+                k_buffer, v_buffer,
+                k_dscale_buffer, v_dscale_buffer,
+                k_boundaries, k_centroids,
+                kv_y.stride(0), kv_y.stride(1),
+                k_buffer.stride(0), k_buffer.stride(1),
+                v_buffer.stride(0), v_buffer.stride(1),
+                k_dscale_buffer.stride(0), v_dscale_buffer.stride(0),
+                kv_norms.stride(0),
+                TOKENS=tokens,
+                N_BOUNDARIES=k_boundaries.shape[0],
+                BLOCK_PACKED=BLOCK_PACKED, Lk_half=packed_dim, num_warps=4,
+            )
+        elif k_bit_width == 2:
+            packed_dim = dim // 4
+            BLOCK_PACKED = triton.next_power_of_2(packed_dim)
+            grid_ps = (2 * tokens, heads)
+            _fused_pack_store_2bit_kv_kernel[grid_ps](
+                kv_y, kv_norms, loc,
+                k_buffer, v_buffer,
+                k_dscale_buffer, v_dscale_buffer,
+                k_boundaries, k_centroids,
+                kv_y.stride(0), kv_y.stride(1),
+                k_buffer.stride(0), k_buffer.stride(1),
+                v_buffer.stride(0), v_buffer.stride(1),
+                k_dscale_buffer.stride(0), v_dscale_buffer.stride(0),
+                kv_norms.stride(0),
+                TOKENS=tokens,
+                N_BOUNDARIES=k_boundaries.shape[0],
+                BLOCK_PACKED=BLOCK_PACKED, Lk_quarter=packed_dim, num_warps=4,
+            )
+    else:
+        # Asymmetric bit widths: fall back to separate K and V pack+store launches
+        k_y = kv_y[:tokens]
+        v_y = kv_y[tokens:]
+        k_norms = kv_norms[:tokens]
+        v_norms = kv_norms[tokens:]
+
+        if k_bit_width == 4:
+            packed_dim = dim // 2
+            BLOCK_PACKED = triton.next_power_of_2(packed_dim)
+            grid_ps = (tokens, heads)
+            _fused_pack_store_4bit_kernel[grid_ps](
+                k_y, k_norms, loc,
+                k_buffer, k_dscale_buffer,
+                k_boundaries, k_centroids,
+                k_y.stride(0), k_y.stride(1),
+                k_buffer.stride(0), k_buffer.stride(1),
+                k_dscale_buffer.stride(0), k_norms.stride(0),
+                N_BOUNDARIES=k_boundaries.shape[0],
+                BLOCK_PACKED=BLOCK_PACKED, Lk_half=packed_dim, num_warps=4,
+            )
+        elif k_bit_width == 2:
+            packed_dim = dim // 4
+            BLOCK_PACKED = triton.next_power_of_2(packed_dim)
+            grid_ps = (tokens, heads)
+            _fused_pack_store_2bit_kernel[grid_ps](
+                k_y, k_norms, loc,
+                k_buffer, k_dscale_buffer,
+                k_boundaries, k_centroids,
+                k_y.stride(0), k_y.stride(1),
+                k_buffer.stride(0), k_buffer.stride(1),
+                k_dscale_buffer.stride(0), k_norms.stride(0),
+                N_BOUNDARIES=k_boundaries.shape[0],
+                BLOCK_PACKED=BLOCK_PACKED, Lk_quarter=packed_dim, num_warps=4,
+            )
+
+        if v_bit_width == 4:
+            packed_dim = dim // 2
+            BLOCK_PACKED = triton.next_power_of_2(packed_dim)
+            grid_ps = (tokens, heads)
+            _fused_pack_store_4bit_kernel[grid_ps](
+                v_y, v_norms, loc,
+                v_buffer, v_dscale_buffer,
+                v_boundaries, v_centroids,
+                v_y.stride(0), v_y.stride(1),
+                v_buffer.stride(0), v_buffer.stride(1),
+                v_dscale_buffer.stride(0), v_norms.stride(0),
+                N_BOUNDARIES=v_boundaries.shape[0],
+                BLOCK_PACKED=BLOCK_PACKED, Lk_half=packed_dim, num_warps=4,
+            )
+        elif v_bit_width == 2:
+            packed_dim = dim // 4
+            BLOCK_PACKED = triton.next_power_of_2(packed_dim)
+            grid_ps = (tokens, heads)
+            _fused_pack_store_2bit_kernel[grid_ps](
+                v_y, v_norms, loc,
+                v_buffer, v_dscale_buffer,
+                v_boundaries, v_centroids,
+                v_y.stride(0), v_y.stride(1),
+                v_buffer.stride(0), v_buffer.stride(1),
+                v_dscale_buffer.stride(0), v_norms.stride(0),
+                N_BOUNDARIES=v_boundaries.shape[0],
+                BLOCK_PACKED=BLOCK_PACKED, Lk_quarter=packed_dim, num_warps=4,
+            )
+
+
+def fused_turboquant_quantize(x, signs1, signs2, centroids, boundaries, bit_width):
+    """Fused TurboQuant quantize: WHT (CUDA) + pack (Triton).
+
+    Returns: (packed, norms, quant_norms) — same interface as batched_quantize.
+    """
+    import torch
+
+    tokens, heads, dim = x.shape
+
+    # --- PyTorch ops (norm + normalize + WHT) ---
+    from sglang.jit_kernel.hadamard import hadamard_transform_with_signs
+
+    # Fused norm + normalize: 1 Triton kernel instead of 3 PyTorch ops
+    BLOCK_DIM = triton.next_power_of_2(dim)
+    x_unit = torch.empty(tokens, heads, dim, dtype=torch.float32, device=x.device)
+    norms = torch.empty(tokens, heads, dtype=torch.float32, device=x.device)
+    grid = (tokens, heads)
+    _fused_norm_normalize_kernel[grid](
+        x, x_unit, norms,
+        x.stride(0), x.stride(1),
+        x_unit.stride(0), x_unit.stride(1),
+        norms.stride(0),
+        BLOCK_DIM=BLOCK_DIM,
+        Lk=dim,
+        num_warps=4,
+    )
+
+    wht_scale = 1.0 / (dim ** 0.5)
+    y = hadamard_transform_with_signs(x_unit, signs1, signs2, scale=wht_scale)
+
+    # --- Fused Triton kernel (searchsorted + gather + qnorm + pack): 1 launch ---
+    if bit_width == 4:
+        packed_dim = dim // 2
+        packed = torch.empty(tokens, heads, packed_dim, dtype=torch.uint8, device=x.device)
+        dscale = torch.empty(tokens, heads, dtype=torch.bfloat16, device=x.device)
+
+        BLOCK_PACKED = triton.next_power_of_2(packed_dim)
+        grid = (tokens, heads)
+        _fused_pack_4bit_kernel[grid](
+            y, packed, dscale, norms,
+            boundaries, centroids,
+            y.stride(0), y.stride(1),
+            packed.stride(0), packed.stride(1),
+            dscale.stride(0),
+            norms.stride(0),
+            N_BOUNDARIES=boundaries.shape[0],
+            BLOCK_PACKED=BLOCK_PACKED,
+            Lk_half=packed_dim,
+            num_warps=4,
+        )
+        return packed, dscale
+    elif bit_width == 2:
+        packed_dim = dim // 4
+        packed = torch.empty(tokens, heads, packed_dim, dtype=torch.uint8, device=x.device)
+        dscale = torch.empty(tokens, heads, dtype=torch.bfloat16, device=x.device)
+
+        BLOCK_PACKED = triton.next_power_of_2(packed_dim)
+        grid = (tokens, heads)
+        _fused_pack_2bit_kernel[grid](
+            y, packed, dscale, norms,
+            boundaries, centroids,
+            y.stride(0), y.stride(1),
+            packed.stride(0), packed.stride(1),
+            dscale.stride(0),
+            norms.stride(0),
+            N_BOUNDARIES=boundaries.shape[0],
+            BLOCK_PACKED=BLOCK_PACKED,
+            Lk_quarter=packed_dim,
+            num_warps=4,
+        )
+        return packed, dscale
+    else:
+        raise ValueError(f"Unsupported bit_width: {bit_width}. Only 2 and 4 are supported.")

--- a/python/sglang/srt/layers/quantization/kv_turboquant.py
+++ b/python/sglang/srt/layers/quantization/kv_turboquant.py
@@ -1,0 +1,403 @@
+"""TurboQuant KV cache quantization utilities.
+
+Implements PolarQuant (Algorithm 1 from arXiv 2504.19874):
+  Walsh-Hadamard rotation → optimal scalar quantization → bit-packing.
+
+Uses deterministic WHT (Walsh-Hadamard Transform) instead of random rotation
+matrix. WHT is O(d log d), deterministic, and maximally decorrelates dimensions
+— 59.7x better PPL than random rotation at 4-bit (llama.cpp findings).
+
+Supports two dequant modes:
+  1. batched_dequantize: Full inverse WHT, returns data in original domain.
+  2. batched_dequantize_rotspace: No inverse WHT, returns data in WHT-rotated
+     domain. Attention backends rotate Q instead (Query Rotation), which is
+     mathematically equivalent but avoids O(d log d) per-token dequant cost.
+"""
+
+import math
+
+import numpy as np
+import torch
+
+
+
+
+# ---------------------------------------------------------------------------
+# Codebook construction (one-time, at init)
+# ---------------------------------------------------------------------------
+
+
+def _lloyds_gaussian(n_centroids: int, sigma: float, n_iter: int = 100):
+    """Lloyd's algorithm for optimal scalar quantization of N(0, sigma^2)."""
+    from scipy import stats
+
+    centroids = np.zeros(n_centroids)
+
+    def _cond_exp(s, a, b):
+        a_s = a / s if np.isfinite(a) else a
+        b_s = b / s if np.isfinite(b) else b
+        if not np.isfinite(a_s):
+            prob = stats.norm.cdf(b_s)
+        elif not np.isfinite(b_s):
+            prob = stats.norm.sf(a_s)
+        else:
+            prob = stats.norm.cdf(b_s) - stats.norm.cdf(a_s)
+        if prob < 1e-15:
+            if np.isfinite(a) and not np.isfinite(b):
+                return a + s
+            elif not np.isfinite(a) and np.isfinite(b):
+                return b - s
+            return (a + b) / 2.0 if np.isfinite(a) else 0.0
+        return s * (stats.norm.pdf(a_s) - stats.norm.pdf(b_s)) / prob
+
+    for _ in range(n_iter):
+        boundaries = (centroids[:-1] + centroids[1:]) / 2.0
+        centroids[0] = _cond_exp(sigma, -np.inf, boundaries[0])
+        for i in range(1, n_centroids - 1):
+            centroids[i] = _cond_exp(sigma, boundaries[i - 1], boundaries[i])
+        centroids[-1] = _cond_exp(sigma, boundaries[-1], np.inf)
+
+    return np.sort(centroids)
+
+
+def build_codebook(bit_width: int, head_dim: int, uniform: bool = False):
+    """Return (centroids, boundaries) as numpy arrays for the given config.
+
+    After WHT rotation, each coordinate ~ N(0, 1/d).
+
+    Args:
+        uniform: If True, use uniformly-spaced centroids (1 FMA dequant)
+                 instead of Lloyd-Max optimal codebook (15 select dequant).
+                 Trades ~0.8 dB SNR for 15x fewer ALU ops in decode kernel.
+    """
+    d = head_dim
+    n = 1 << bit_width
+    if uniform and bit_width >= 3:
+        sigma = 1.0 / math.sqrt(d)
+        r = 2.5 * sigma
+        centroids = np.linspace(-r, r, n)
+    elif bit_width == 1:
+        c = math.sqrt(2.0 / (math.pi * d))
+        centroids = np.array([-c, c])
+    elif bit_width == 2:
+        centroids = np.array([-1.51, -0.453, 0.453, 1.51]) / math.sqrt(d)
+    else:
+        centroids = _lloyds_gaussian(n, sigma=1.0 / math.sqrt(d))
+    boundaries = (centroids[:-1] + centroids[1:]) / 2.0
+    return centroids.astype(np.float32), boundaries.astype(np.float32)
+
+
+# ---------------------------------------------------------------------------
+# GPU quantize / dequantize
+# ---------------------------------------------------------------------------
+
+# Packing helpers:
+#   2-bit: 4 values per byte (uint8), fused decode kernel uses 4-way split dot product
+#   4-bit: 2 values per byte (uint8), fused decode kernel uses 2-way split dot product
+
+
+def batched_quantize(
+    x: torch.Tensor,
+    signs1: torch.Tensor,
+    signs2: torch.Tensor,
+    centroids: torch.Tensor,
+    boundaries: torch.Tensor,
+    bit_width: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Quantize KV tensors to packed uint8 + norms + quant_norms.
+
+    Args:
+        x: (tokens, heads, dim) in bfloat16/float16.
+        signs1: (dim,) float32 — random sign vector for WHT rotation.
+        signs2: (dim,) float32 — random sign vector for WHT rotation.
+        centroids: (2^b,) float32.
+        boundaries: (2^b - 1,) float32.
+        bit_width: 2 or 4.
+
+    Returns:
+        packed: (tokens, heads, packed_dim) uint8.
+        norms: (tokens, heads) bfloat16 — original L2 norms.
+        quant_norms: (tokens, heads) bfloat16 — L2 norm of centroid vector
+            ||centroids[indices]||, used for norm correction in rotspace dequant.
+    """
+
+    from sglang.jit_kernel.hadamard import hadamard_transform
+
+    tokens, heads, dim = x.shape
+
+    # 1. Extract norms
+    norms = torch.linalg.norm(x.float(), dim=-1)  # (tokens, heads)
+
+    # 2. Normalize to unit vectors
+    safe_norms = torch.where(norms > 0, norms, torch.ones_like(norms))
+    x_unit = x.float() / safe_norms.unsqueeze(-1)
+
+    # 3. WHT rotation: D2 @ H_norm @ D1 (normalized Hadamard, scale=1/√d)
+    wht_scale = 1.0 / math.sqrt(dim)
+    y = x_unit * signs1
+    y = hadamard_transform(y.contiguous(), scale=wht_scale)
+    y = y * signs2
+
+    # 4. Quantize: nearest centroid via searchsorted on boundaries
+    indices = torch.searchsorted(boundaries, y.reshape(-1)).reshape(tokens, heads, dim)
+
+    # 5. Compute quant_norms: ||centroids[indices]|| for norm correction
+    centroid_vals = centroids[indices.long()]  # (tokens, heads, dim) float32
+    quant_norms = torch.linalg.norm(centroid_vals, dim=-1)  # (tokens, heads)
+
+    # 6. Pack indices
+    indices_u8 = indices.to(torch.uint8)
+    if bit_width == 2:
+        idx = indices_u8.view(tokens, heads, dim // 4, 4)
+        packed = (
+            (idx[..., 3] << 6)
+            | (idx[..., 2] << 4)
+            | (idx[..., 1] << 2)
+            | idx[..., 0]
+        )
+    elif bit_width == 4:
+        idx = indices_u8.view(tokens, heads, dim // 2, 2)
+        packed = (idx[..., 1] << 4) | idx[..., 0]
+    else:
+        raise ValueError(f"Unsupported bit_width for packing: {bit_width}")
+
+    return packed, norms.to(x.dtype), quant_norms.to(x.dtype)
+
+
+def batched_dequantize(
+    packed: torch.Tensor,
+    norms: torch.Tensor,
+    centroids: torch.Tensor,
+    bit_width: int,
+    signs1: torch.Tensor,
+    signs2: torch.Tensor,
+) -> torch.Tensor:
+    """Dequantize packed uint8 back to bfloat16 tensors.
+
+    Includes inverse WHT rotation — returns data in the original domain.
+    No graph-side rotation needed in the attention backend.
+
+    Args:
+        packed: (tokens, heads, packed_dim) uint8.
+        norms: (tokens, heads) bfloat16.
+        centroids: (2^b,) float32.
+        bit_width: 2 or 4.
+        signs1: (dim,) float32.
+        signs2: (dim,) float32.
+
+    Returns:
+        x_hat: (tokens, heads, dim) bfloat16 — in original domain.
+    """
+    from sglang.jit_kernel.hadamard import hadamard_transform
+
+    tokens, heads, packed_dim = packed.shape
+
+    # 1. Unpack indices
+    if bit_width == 2:
+        dim = packed_dim * 4
+        v0 = packed & 0x03
+        v1 = (packed >> 2) & 0x03
+        v2 = (packed >> 4) & 0x03
+        v3 = (packed >> 6) & 0x03
+        indices = torch.stack([v0, v1, v2, v3], dim=-1).reshape(tokens, heads, dim)
+    elif bit_width == 4:
+        dim = packed_dim * 2
+        low = packed & 0x0F
+        high = (packed >> 4) & 0x0F
+        indices = torch.stack([low, high], dim=-1).reshape(tokens, heads, dim)
+    else:
+        raise ValueError(f"Unsupported bit_width for unpacking: {bit_width}")
+
+    # 2. Centroid lookup
+    y_hat = centroids[indices.long()]  # (tokens, heads, dim) float32
+
+    # 3. Norm correction: normalize y_hat back to unit norm
+    y_hat_norm = torch.linalg.norm(y_hat, dim=-1, keepdim=True)
+    y_hat_norm = torch.where(y_hat_norm > 1e-10, y_hat_norm, torch.ones_like(y_hat_norm))
+    y_hat = y_hat / y_hat_norm
+
+    # 4. Inverse WHT rotation: D1 @ H_norm @ D2 (reverse order, scale=1/√d)
+    wht_scale = 1.0 / math.sqrt(signs1.shape[0])
+    y_hat = y_hat * signs2
+    y_hat = hadamard_transform(y_hat.contiguous(), scale=wht_scale)
+    y_hat = y_hat * signs1
+
+    # 5. Scale by original norm
+    y_hat = y_hat * norms.float().unsqueeze(-1)
+
+    return y_hat.to(norms.dtype)
+
+
+def batched_dequantize_rotspace(
+    packed: torch.Tensor,
+    dequant_scale: torch.Tensor,
+    centroids: torch.Tensor,
+    bit_width: int,
+    head_dim: int = 0,
+) -> torch.Tensor:
+    """Dequantize packed data to WHT-rotated domain (no inverse WHT).
+
+    Args:
+        packed: (tokens, heads, packed_dim) uint8.
+        dequant_scale: (tokens, heads) bfloat16 — precomputed norm / max(quant_norm, eps).
+        centroids: (2^b,) float32.
+        bit_width: 2 or 4.
+        head_dim: original head dimension (for 2-bit padding trim). 0 = auto-infer.
+
+    Returns:
+        x_rotspace: (tokens, heads, head_dim) bfloat16 — in WHT-rotated domain.
+    """
+    tokens, heads, packed_dim = packed.shape
+
+    # 1. Unpack indices
+    if bit_width == 2:
+        dim = packed_dim * 4
+        v0 = packed & 0x03
+        v1 = (packed >> 2) & 0x03
+        v2 = (packed >> 4) & 0x03
+        v3 = (packed >> 6) & 0x03
+        indices = torch.stack([v0, v1, v2, v3], dim=-1).reshape(tokens, heads, dim)
+    elif bit_width == 4:
+        dim = packed_dim * 2
+        low = packed & 0x0F
+        high = (packed >> 4) & 0x0F
+        indices = torch.stack([low, high], dim=-1).reshape(tokens, heads, dim)
+    else:
+        raise ValueError(f"Unsupported bit_width for unpacking: {bit_width}")
+
+    # 2. Centroid lookup
+    y_hat = centroids[indices.long()]  # (tokens, heads, dim) float32
+
+    # 3. Norm-corrected scaling using precomputed dequant_scale
+    y_hat = y_hat * dequant_scale.float().unsqueeze(-1)
+
+    return y_hat.to(dequant_scale.dtype)
+
+
+# ---------------------------------------------------------------------------
+# Init helper — called once at pool creation
+# ---------------------------------------------------------------------------
+
+
+class TurboQuantConfig:
+    """Holds pre-computed constants for TurboQuant on GPU.
+
+    Supports asymmetric K/V bit widths (e.g., K=4bit, V=2bit).
+    """
+
+    def __init__(
+        self,
+        bit_width: int,
+        head_dim: int,
+        device: str,
+        seed: int = 42,
+        k_bit_width: int = 0,
+        v_bit_width: int = 0,
+        uniform: bool = False,
+    ):
+        self.head_dim = head_dim
+        self.k_bit_width = k_bit_width or bit_width
+        self.v_bit_width = v_bit_width or bit_width
+        self.bit_width = bit_width  # backwards compat (= k_bit_width)
+        self.uniform = uniform
+
+        # K codebook
+        k_c_np, k_b_np = build_codebook(self.k_bit_width, head_dim, uniform=uniform)
+        self.k_centroids = torch.tensor(k_c_np, dtype=torch.float32, device=device)
+        self.k_boundaries = torch.tensor(k_b_np, dtype=torch.float32, device=device)
+
+        # V codebook (may differ from K)
+        if self.v_bit_width == self.k_bit_width:
+            self.v_centroids = self.k_centroids
+            self.v_boundaries = self.k_boundaries
+        else:
+            v_c_np, v_b_np = build_codebook(self.v_bit_width, head_dim, uniform=uniform)
+            self.v_centroids = torch.tensor(v_c_np, dtype=torch.float32, device=device)
+            self.v_boundaries = torch.tensor(v_b_np, dtype=torch.float32, device=device)
+
+        # WHT sign vectors (shared for K and V)
+        rng = np.random.default_rng(seed)
+        self.signs1 = torch.tensor(
+            rng.choice([-1.0, 1.0], size=head_dim),
+            dtype=torch.float32,
+            device=device,
+        )
+        self.signs2 = torch.tensor(
+            rng.choice([-1.0, 1.0], size=head_dim),
+            dtype=torch.float32,
+            device=device,
+        )
+
+        # K packed dim/dtype
+        self.k_packed_dim, self.k_packed_dtype = self._packed_params(self.k_bit_width, head_dim)
+        # V packed dim/dtype
+        self.v_packed_dim, self.v_packed_dtype = self._packed_params(self.v_bit_width, head_dim)
+
+    @staticmethod
+    def _packed_params(bits, head_dim):
+        if bits == 2:
+            assert head_dim % 4 == 0, f"2-bit requires head_dim divisible by 4, got {head_dim}"
+            return head_dim // 4, torch.uint8
+        elif bits == 4:
+            assert head_dim % 2 == 0, f"4-bit requires head_dim divisible by 2, got {head_dim}"
+            return head_dim // 2, torch.uint8
+        else:
+            raise ValueError(f"Unsupported bit_width: {bits}. Use 2 or 4.")
+
+    def rotate_query(self, q: torch.Tensor) -> torch.Tensor:
+        """Apply forward WHT rotation to query: Q_rot = D2 @ H @ D1 @ Q.
+
+        Args:
+            q: (..., dim) tensor, any shape with last dim = head_dim.
+
+        Returns:
+            q_rot: same shape and dtype as q, in WHT-rotated domain.
+        """
+        from sglang.jit_kernel.hadamard import hadamard_transform_with_signs
+        wht_scale = 1.0 / math.sqrt(self.head_dim)
+        return hadamard_transform_with_signs(q, self.signs1, self.signs2, scale=wht_scale)
+
+    def inverse_rotate_output(self, o: torch.Tensor) -> torch.Tensor:
+        """Apply inverse WHT rotation to attention output: O = D1 @ H_norm @ D2 @ O_rot.
+
+        Args:
+            o: (..., dim) tensor, in WHT-rotated domain.
+
+        Returns:
+            o_orig: same shape and dtype as o, in original domain.
+        """
+        from sglang.jit_kernel.hadamard import hadamard_transform_with_signs
+        wht_scale = 1.0 / math.sqrt(self.head_dim)
+        return hadamard_transform_with_signs(o, self.signs2, self.signs1, scale=wht_scale)
+
+    def fuse_inverse_rotation_into_o_proj(self, o_proj_weight: torch.Tensor, num_heads: int) -> torch.Tensor:
+        """Absorb inverse WHT rotation into o_proj weight matrix.
+
+        Pre-computes W_O_rot so that: o_rot @ W_O_rot = inv_WHT(o_rot) @ W_O
+        This eliminates inverse_rotate_output at runtime.
+
+        Args:
+            o_proj_weight: (num_heads * head_dim, hidden_dim) weight matrix.
+            num_heads: number of Q heads.
+
+        Returns:
+            Transformed weight with inverse rotation baked in.
+        """
+        from sglang.jit_kernel.hadamard import hadamard_transform_with_signs
+        device = o_proj_weight.device
+        dtype = o_proj_weight.dtype
+        dim = self.head_dim
+        hidden = o_proj_weight.shape[1]
+
+        # inv_WHT per head: W_O[h*d:(h+1)*d, :] = (D1 @ H @ D2) @ W_O[h*d:(h+1)*d, :]
+        # Equivalently: transpose each head block, apply forward WHT with swapped signs, transpose back
+        w = o_proj_weight.float().view(num_heads, dim, hidden)  # (heads, dim, hidden)
+
+        # Apply inverse rotation to each row of each head block
+        # inv_WHT operates on dim dimension: for each column of W, apply D1 @ H @ D2
+        # Reshape to (num_heads * hidden, dim), apply WHT, reshape back
+        w_t = w.permute(0, 2, 1).contiguous().reshape(-1, dim)  # (heads*hidden, dim)
+        wht_scale = 1.0 / math.sqrt(dim)
+        w_rot = hadamard_transform_with_signs(w_t, self.signs1, self.signs2, scale=wht_scale)
+        w_rot = w_rot.reshape(num_heads, hidden, dim).permute(0, 2, 1).contiguous()
+        return w_rot.reshape(num_heads * dim, hidden).to(dtype)

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1224,6 +1224,213 @@ class MHATokenToKVPoolFP4(MHATokenToKVPool):
             self.v_scale_buffer[layer_id - self.start_layer][loc] = cache_v_fp4_sf
 
 
+class MHATokenToKVPoolTurboQuant(MHATokenToKVPool):
+    """TurboQuant KV cache: WHT rotation + optimal scalar quantization.
+
+    Stores KV as packed uint8 indices + bf16 dequant scales.
+    Fused decode/extend kernels read packed KV directly — no dequant buffer needed.
+
+    Memory layout:
+      - Per-layer: k/v_buffer (uint8), k/v_dequant_scale_buffer (bf16)
+      - Shared: _quant_kv_unit, _quant_kv_norms (small pre-alloc for CUDA graph)
+    """
+
+    def __init__(
+        self,
+        size: int,
+        page_size: int,
+        dtype: torch.dtype,
+        head_num: int,
+        head_dim: int,
+        layer_num: int,
+        device: str,
+        enable_memory_saver: bool,
+        turboquant_bits: int = 4,
+        turboquant_k_bits: int = 0,
+        turboquant_v_bits: int = 0,
+        turboquant_uniform: bool = False,
+        v_head_dim: Optional[int] = None,
+        start_layer: Optional[int] = None,
+        end_layer: Optional[int] = None,
+    ):
+        self.turboquant_bits = turboquant_bits
+        from sglang.srt.layers.quantization.kv_turboquant import TurboQuantConfig
+
+        k_bits = turboquant_k_bits or turboquant_bits
+        v_bits = turboquant_v_bits or turboquant_bits
+        self.tq_config = TurboQuantConfig(
+            bit_width=turboquant_bits,
+            head_dim=head_dim,
+            device=device,
+            k_bit_width=k_bits,
+            v_bit_width=v_bits,
+            uniform=turboquant_uniform,
+        )
+        super().__init__(
+            size=size,
+            page_size=page_size,
+            dtype=dtype,
+            head_num=head_num,
+            head_dim=head_dim,
+            layer_num=layer_num,
+            device=device,
+            enable_memory_saver=enable_memory_saver,
+            v_head_dim=v_head_dim,
+            start_layer=start_layer,
+            end_layer=end_layer,
+            enable_alt_stream=False,
+            enable_kv_cache_copy=False,
+        )
+
+    def _create_buffers(self):
+        with self.memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
+            with (
+                torch.cuda.use_mem_pool(self.custom_mem_pool)
+                if self.enable_custom_mem_pool
+                else nullcontext()
+            ):
+                m = self.size + self.page_size
+
+                # Packed quantized indices (K and V may have different dim/dtype)
+                self.k_buffer = [
+                    torch.zeros(
+                        (m, self.head_num, self.tq_config.k_packed_dim),
+                        dtype=self.tq_config.k_packed_dtype,
+                        device=self.device,
+                    )
+                    for _ in range(self.layer_num)
+                ]
+                self.v_buffer = [
+                    torch.zeros(
+                        (m, self.head_num, self.tq_config.v_packed_dim),
+                        dtype=self.tq_config.v_packed_dtype,
+                        device=self.device,
+                    )
+                    for _ in range(self.layer_num)
+                ]
+
+                # Per-vector dequant scale: norm / max(quant_norm, eps)
+                # Precomputed at quantize time to save 2 loads + 1 div in decode kernel
+                self.k_dequant_scale_buffer = [
+                    torch.zeros(
+                        (m, self.head_num),
+                        dtype=torch.bfloat16,
+                        device=self.device,
+                    )
+                    for _ in range(self.layer_num)
+                ]
+                self.v_dequant_scale_buffer = [
+                    torch.zeros(
+                        (m, self.head_num),
+                        dtype=torch.bfloat16,
+                        device=self.device,
+                    )
+                    for _ in range(self.layer_num)
+                ]
+
+                # Pre-allocated buffers for quantize path (avoids torch.empty inside CUDA graph)
+                max_bs = 256  # matches cuda_graph_max_bs default
+                self._quant_kv_unit = torch.empty(
+                    2 * max_bs, self.head_num, self.head_dim, dtype=torch.float32, device=self.device
+                )
+                self._quant_kv_norms = torch.empty(
+                    2 * max_bs, self.head_num, dtype=torch.float32, device=self.device
+                )
+
+        # data_ptrs / data_strides — point to packed buffers (per-layer)
+        self.k_data_ptrs = torch.tensor(
+            [self.k_buffer[i].data_ptr() for i in range(self.layer_num)],
+            dtype=torch.uint64,
+            device=self.device,
+        )
+        self.v_data_ptrs = torch.tensor(
+            [self.v_buffer[i].data_ptr() for i in range(self.layer_num)],
+            dtype=torch.uint64,
+            device=self.device,
+        )
+        self.data_ptrs = torch.cat([self.k_data_ptrs, self.v_data_ptrs], dim=0)
+        k_stride = int(np.prod(self.k_buffer[0].shape[1:])) * self.k_buffer[0].dtype.itemsize
+        v_stride = int(np.prod(self.v_buffer[0].shape[1:])) * self.v_buffer[0].dtype.itemsize
+        self.data_strides = torch.tensor(
+            [k_stride] * self.layer_num + [v_stride] * self.layer_num,
+            device=self.device,
+        )
+
+    def _clear_buffers(self):
+        del self.k_buffer
+        del self.v_buffer
+        del self.k_dequant_scale_buffer
+        del self.v_dequant_scale_buffer
+        del self._quant_kv_unit
+        del self._quant_kv_norms
+
+    def set_kv_buffer(
+        self,
+        layer: RadixAttention,
+        loc: torch.Tensor,
+        cache_k: torch.Tensor,
+        cache_v: torch.Tensor,
+        k_scale: Optional[float] = None,
+        v_scale: Optional[float] = None,
+        layer_id_override: Optional[int] = None,
+        k_pre_rotated: bool = False,
+    ):
+        from sglang.srt.layers.attention.triton_ops.turboquant_quantize import (
+            fused_turboquant_quantize_and_store_kv,
+        )
+
+        if layer_id_override is not None:
+            layer_id = layer_id_override
+        else:
+            layer_id = layer.layer_id
+        idx = layer_id - self.start_layer
+
+        cfg = self.tq_config
+
+        # Quantize K+V with batched norm+WHT, using pre-allocated buffers
+        fused_turboquant_quantize_and_store_kv(
+            cache_k, cache_v,
+            cfg.signs1, cfg.signs2,
+            cfg.k_centroids, cfg.k_boundaries, cfg.k_bit_width,
+            cfg.v_centroids, cfg.v_boundaries, cfg.v_bit_width,
+            self.k_buffer[idx], self.k_dequant_scale_buffer[idx],
+            self.v_buffer[idx], self.v_dequant_scale_buffer[idx],
+            loc,
+            pre_kv_unit=self._quant_kv_unit,
+            pre_kv_norms=self._quant_kv_norms,
+        )
+
+    def _get_key_buffer(self, layer_id: int):
+        raise NotImplementedError(
+            "TurboQuant uses fused decode/extend kernels that read packed KV directly. "
+            "Dequant buffer path not supported."
+        )
+
+    def _get_value_buffer(self, layer_id: int):
+        raise NotImplementedError(
+            "TurboQuant uses fused decode/extend kernels that read packed KV directly. "
+            "Dequant buffer path not supported."
+        )
+
+    def get_v_head_dim(self):
+        return self.head_dim
+
+    def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor):
+        for i in range(self.layer_num):
+            self.k_buffer[i][tgt_loc] = self.k_buffer[i][src_loc]
+            self.v_buffer[i][tgt_loc] = self.v_buffer[i][src_loc]
+            self.k_dequant_scale_buffer[i][tgt_loc] = self.k_dequant_scale_buffer[i][src_loc]
+            self.v_dequant_scale_buffer[i][tgt_loc] = self.v_dequant_scale_buffer[i][src_loc]
+
+    def get_kv_size_bytes(self):
+        """Total GPU memory used by all TurboQuant buffers."""
+        total = 0
+        for i in range(self.layer_num):
+            total += self.k_buffer[i].nbytes + self.v_buffer[i].nbytes
+            total += self.k_dequant_scale_buffer[i].nbytes + self.v_dequant_scale_buffer[i].nbytes
+        return total
+
+
 class HybridLinearKVPool(KVCache):
     """KV cache with separate pools for full and linear attention layers."""
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -623,6 +623,9 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # Init memory pool and attention backends
         self.init_memory_pool(pre_model_load_memory)
 
+        # TurboQuant: fuse inverse WHT rotation into o_proj weights
+        self._maybe_fuse_tq_output_rotation()
+
         # Init ngram embedding token table
         self.maybe_init_ngram_embedding()
 
@@ -1957,6 +1960,54 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                     f"--kv-cache-dtype falls back to 'auto' because this torch version does not support torch.float4_e2m1fn_x2"
                 )
                 self.kv_cache_dtype = self.dtype
+        elif self.server_args.kv_cache_dtype.startswith("turboquant_"):
+            import re
+
+            tq_str = self.server_args.kv_cache_dtype.split("_", 1)[1]
+            # Check for uniform quantization suffix
+            self.turboquant_uniform = tq_str.endswith("_uniform")
+            if self.turboquant_uniform:
+                tq_str = tq_str.rsplit("_uniform", 1)[0]
+            # Asymmetric: "k4v2"
+            asym_match = re.match(r"k(\d)v(\d)", tq_str)
+            if asym_match:
+                self.turboquant_k_bits = int(asym_match.group(1))
+                self.turboquant_v_bits = int(asym_match.group(2))
+                self.turboquant_bits = self.turboquant_k_bits  # for backwards compat
+            else:
+                # Symmetric: "2bit", "4bit"
+                bits = int(tq_str.replace("bit", ""))
+                self.turboquant_k_bits = bits
+                self.turboquant_v_bits = bits
+                self.turboquant_bits = bits
+            self.kv_cache_dtype = torch.bfloat16
+            # TurboQuant fused decode kernel is Triton-only.
+            # Only override DECODE backend to triton; prefill keeps default (fa3/flashinfer)
+            # for maximum prefill throughput. Prefill reads from shared dequant buffer (bf16),
+            # which is compatible with any attention backend.
+            if self.server_args.decode_attention_backend is None or \
+               self.server_args.decode_attention_backend != "triton":
+                prev = self.server_args.decode_attention_backend or "default"
+                self.server_args.decode_attention_backend = "triton"
+                logger.info(
+                    f"TurboQuant: overriding decode-attention-backend={prev} → triton "
+                    f"(fused decode kernel). Prefill backend unchanged for optimal throughput."
+                )
+            # Fused decode kernel supports symmetric and asymmetric 2-bit and 4-bit.
+            has_fused = (
+                self.turboquant_k_bits in (2, 4)
+                and self.turboquant_v_bits in (2, 4)
+            )
+            if not has_fused:
+                if not self.server_args.disable_cuda_graph:
+                    logger.warning(
+                        f"TurboQuant K={self.turboquant_k_bits}bit V={self.turboquant_v_bits}bit: "
+                        f"no fused decode kernel, disabling CUDA graph."
+                    )
+                    self.server_args.disable_cuda_graph = True
+            logger.info(
+                f"TurboQuant K={self.turboquant_k_bits}bit V={self.turboquant_v_bits}bit KV cache enabled"
+            )
         else:
             raise ValueError(
                 f"Unsupported kv_cache_dtype: {self.server_args.kv_cache_dtype}."
@@ -2076,6 +2127,78 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         if self._should_run_flashinfer_autotune():
             self._flashinfer_autotune()
+
+        # Pre-warm TurboQuant JIT kernels so they're compiled before CUDA graph capture
+        if hasattr(self, 'turboquant_bits'):
+            self._warmup_turboquant_kernels()
+
+    def _warmup_turboquant_kernels(self):
+        """Trigger JIT compilation of hadamard + Triton kernels before graph capture."""
+        from sglang.jit_kernel.hadamard import hadamard_transform
+
+        head_dim = self.model_config.head_dim
+        dummy = torch.randn(1, 1, head_dim, dtype=torch.float32, device=self.device)
+        scale = 1.0 / (head_dim ** 0.5)
+        # Warm up JIT hadamard kernel
+        hadamard_transform(dummy, scale=scale)
+
+        # Warm up fused Triton quantize kernel (4-bit only)
+        if self.turboquant_k_bits == 4:
+            from sglang.srt.layers.attention.triton_ops.turboquant_quantize import (
+                fused_turboquant_quantize,
+            )
+            from sglang.srt.layers.quantization.kv_turboquant import TurboQuantConfig
+
+            cfg = TurboQuantConfig(
+                bit_width=4, head_dim=head_dim, device=self.device,
+                k_bit_width=self.turboquant_k_bits, v_bit_width=self.turboquant_v_bits,
+                uniform=getattr(self, 'turboquant_uniform', False),
+            )
+            dummy_kv = torch.randn(1, 1, head_dim, dtype=torch.bfloat16, device=self.device)
+            fused_turboquant_quantize(
+                dummy_kv, cfg.signs1, cfg.signs2,
+                cfg.k_centroids, cfg.k_boundaries, 4,
+            )
+
+    def _maybe_fuse_tq_output_rotation(self):
+        if not hasattr(self, "turboquant_bits") or self.turboquant_bits is None:
+            return
+        if self.token_to_kv_pool_allocator is None:
+            return
+        kvcache = self.token_to_kv_pool_allocator.get_kvcache()
+        tq_cfg = getattr(kvcache, "tq_config", None)
+        if tq_cfg is None:
+            return
+
+        import logging
+        logger = logging.getLogger(__name__)
+        logger.info("TurboQuant: fusing inverse WHT rotation into o_proj weights...")
+        fused = 0
+        skipped_fp8 = False
+        for _, mod in self.model.named_modules():
+            if hasattr(mod, "o_proj") and hasattr(mod.o_proj, "weight"):
+                w = mod.o_proj.weight
+                # FP8 quantized weights have associated scale factors.
+                # Fusing rotation would corrupt the weight-scale relationship.
+                # Skip fusion and use runtime inverse rotation instead.
+                if w.dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+                    skipped_fp8 = True
+                    continue
+                n_heads = w.shape[1] // tq_cfg.head_dim
+                if w.shape[1] % tq_cfg.head_dim == 0 and n_heads > 0:
+                    with torch.no_grad():
+                        wt = w.data.t().contiguous()
+                        wf = tq_cfg.fuse_inverse_rotation_into_o_proj(wt, n_heads)
+                        w.data.copy_(wf.t().contiguous())
+                        fused += 1
+        if skipped_fp8:
+            logger.info(
+                "TurboQuant: skipping rotation fusion (FP8 weights), "
+                "using runtime inverse rotation"
+            )
+        elif fused > 0:
+            tq_cfg.output_rotation_fused = True
+            logger.info("TurboQuant: fused inverse rotation into %d o_proj layers", fused)
 
     def _should_run_flashinfer_autotune(self) -> bool:
         """Check if flashinfer autotune should be run."""

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -130,7 +130,26 @@ class ModelRunnerKVCacheMixin:
                     * kv_size
                 )
 
-            if is_float4_e2m1fn_x2(self.kv_cache_dtype):
+            if hasattr(self, "turboquant_bits"):
+                # TurboQuant: packed indices + bf16 dequant_scale per layer.
+                # No shared dequant buffer (fused kernels read packed directly).
+                n = self.model_config.get_num_kv_heads(get_attention_tp_size())
+                d = self.model_config.head_dim
+                k_bits = getattr(self, "turboquant_k_bits", self.turboquant_bits)
+                v_bits = getattr(self, "turboquant_v_bits", self.turboquant_bits)
+
+                def _packed_bytes(bits, n, d):
+                    if bits == 2:
+                        return n * (d // 4)  # uint8, 4 values/byte
+                    else:  # 4-bit
+                        return n * (d // 2)  # uint8, 2 values/byte
+
+                per_layer_per_token = (
+                    _packed_bytes(k_bits, n, d) + _packed_bytes(v_bits, n, d)
+                    + 2 * n * 2  # k_dequant_scale + v_dequant_scale (bf16)
+                )
+                cell_size = per_layer_per_token * num_layers
+            elif is_float4_e2m1fn_x2(self.kv_cache_dtype):
                 # kv_scale_buffer
                 scale_block_size = 16
 
@@ -678,7 +697,30 @@ class ModelRunnerKVCacheMixin:
                     **extra_args,
                 )
             else:
-                if is_float4_e2m1fn_x2(self.kv_cache_dtype):
+                if hasattr(self, "turboquant_bits"):
+                    from sglang.srt.mem_cache.memory_pool import (
+                        MHATokenToKVPoolTurboQuant,
+                    )
+
+                    self.token_to_kv_pool = MHATokenToKVPoolTurboQuant(
+                        self.max_total_num_tokens,
+                        page_size=self.page_size,
+                        dtype=self.kv_cache_dtype,
+                        head_num=self.model_config.get_num_kv_heads(
+                            get_attention_tp_size()
+                        ),
+                        head_dim=self.model_config.head_dim,
+                        layer_num=self.num_effective_layers,
+                        device=self.device,
+                        enable_memory_saver=self.server_args.enable_memory_saver,
+                        turboquant_bits=self.turboquant_bits,
+                        turboquant_k_bits=getattr(self, "turboquant_k_bits", 0),
+                        turboquant_v_bits=getattr(self, "turboquant_v_bits", 0),
+                        turboquant_uniform=getattr(self, "turboquant_uniform", False),
+                        start_layer=self.start_layer,
+                        end_layer=self.end_layer,
+                    )
+                elif is_float4_e2m1fn_x2(self.kv_cache_dtype):
                     self.token_to_kv_pool = MHATokenToKVPoolFP4(
                         self.max_total_num_tokens,
                         page_size=self.page_size,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3894,8 +3894,8 @@ class ServerArgs:
             "--kv-cache-dtype",
             type=str,
             default=ServerArgs.kv_cache_dtype,
-            choices=["auto", "fp8_e5m2", "fp8_e4m3", "bf16", "bfloat16", "fp4_e2m1"],
-            help='Data type for kv cache storage. "auto" will use model data type. "bf16" or "bfloat16" for BF16 KV cache. "fp8_e5m2" and "fp8_e4m3" are supported for CUDA 11.8+. "fp4_e2m1" (only mxfp4) is supported for CUDA 12.8+ and PyTorch 2.8.0+',
+            choices=["auto", "fp8_e5m2", "fp8_e4m3", "bf16", "bfloat16", "fp4_e2m1", "turboquant_2bit", "turboquant_4bit", "turboquant_4bit_uniform", "turboquant_k4v2"],
+            help='Data type for kv cache storage. "auto" will use model data type. "turboquant_Xbit" for codebook quantization, "turboquant_Xbit_uniform" for uniform quantization (faster decode, slightly lower accuracy).',
         )
         parser.add_argument(
             "--enable-fp32-lm-head",

--- a/test/srt/test_turboquant.py
+++ b/test/srt/test_turboquant.py
@@ -1,0 +1,518 @@
+"""
+Unit tests for TurboQuant KV cache compression.
+
+Tests:
+1. Codebook construction (Lloyd's algorithm, closed-form centroids)
+2. WHT rotation correctness (self-inverse property)
+3. Quantizer roundtrip quality (MSE, cosine similarity) with WHT
+4. Bit packing/unpacking correctness
+5. Zero vector and batch consistency
+
+Usage:
+    python -m pytest test/srt/test_turboquant.py -v -k "not GPU"   # CPU only
+    python -m pytest test/srt/test_turboquant.py -v -k "GPU"       # GPU only
+    python -m pytest test/srt/test_turboquant.py -v                # All
+"""
+
+import math
+import unittest
+
+import numpy as np
+
+
+class TestCodebook(unittest.TestCase):
+
+    def test_1bit_centroids(self):
+        from sglang.srt.layers.quantization.kv_turboquant import build_codebook
+        centroids, boundaries = build_codebook(1, head_dim=128)
+        self.assertEqual(len(centroids), 2)
+        self.assertAlmostEqual(centroids[0], -centroids[1], places=6)
+        expected = math.sqrt(2.0 / (math.pi * 128))
+        self.assertAlmostEqual(abs(centroids[1]), expected, places=5)
+
+    def test_2bit_centroids(self):
+        from sglang.srt.layers.quantization.kv_turboquant import build_codebook
+        centroids, boundaries = build_codebook(2, head_dim=128)
+        self.assertEqual(len(centroids), 4)
+        for i in range(len(centroids) - 1):
+            self.assertLess(centroids[i], centroids[i + 1])
+
+    def test_4bit_lloyds(self):
+        from sglang.srt.layers.quantization.kv_turboquant import build_codebook
+        centroids, boundaries = build_codebook(4, head_dim=128)
+        self.assertEqual(len(centroids), 16)
+
+
+class TestTurboQuantConfig(unittest.TestCase):
+
+    def test_config_creation_cpu(self):
+        from sglang.srt.layers.quantization.kv_turboquant import TurboQuantConfig
+        cfg = TurboQuantConfig(bit_width=4, head_dim=128, device="cpu")
+        self.assertEqual(cfg.bit_width, 4)
+        self.assertEqual(cfg.k_centroids.shape[0], 16)
+        self.assertEqual(cfg.signs1.shape[0], 128)
+        self.assertEqual(cfg.signs2.shape[0], 128)
+        self.assertEqual(cfg.k_packed_dim, 64)
+
+    def test_signs_are_pm1(self):
+        from sglang.srt.layers.quantization.kv_turboquant import TurboQuantConfig
+        cfg = TurboQuantConfig(bit_width=4, head_dim=128, device="cpu")
+        self.assertTrue((cfg.signs1.abs() == 1.0).all())
+        self.assertTrue((cfg.signs2.abs() == 1.0).all())
+
+    def test_packed_dim_2bit(self):
+        from sglang.srt.layers.quantization.kv_turboquant import TurboQuantConfig
+        cfg = TurboQuantConfig(bit_width=2, head_dim=128, device="cpu")
+        self.assertEqual(cfg.k_packed_dim, 32)
+
+    def test_packed_dim_4bit(self):
+        from sglang.srt.layers.quantization.kv_turboquant import TurboQuantConfig
+        cfg = TurboQuantConfig(bit_width=4, head_dim=128, device="cpu")
+        self.assertEqual(cfg.k_packed_dim, 64)
+
+
+try:
+    import torch
+    HAS_CUDA = torch.cuda.is_available()
+except ImportError:
+    HAS_CUDA = False
+
+
+@unittest.skipUnless(HAS_CUDA, "CUDA not available")
+class TestTurboQuantGPU(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        from sglang.srt.layers.quantization.kv_turboquant import TurboQuantConfig
+        cls.device = "cuda"
+        cls.configs = {}
+        for bits in [2, 4]:
+            cls.configs[bits] = TurboQuantConfig(
+                bit_width=bits, head_dim=128, device=cls.device
+            )
+
+    def _roundtrip(self, bits, tokens=64, heads=4):
+        from sglang.srt.layers.quantization.kv_turboquant import (
+            batched_dequantize, batched_quantize,
+        )
+        cfg = self.configs[bits]
+        torch.manual_seed(42)
+        x = torch.randn(tokens, heads, 128, device=self.device, dtype=torch.bfloat16)
+
+        packed, norms, quant_norms = batched_quantize(
+            x, cfg.signs1, cfg.signs2, cfg.k_centroids, cfg.k_boundaries, cfg.bit_width
+        )
+        # dequantize includes inverse WHT — returns in original domain
+        x_hat = batched_dequantize(
+            packed, norms, cfg.k_centroids, cfg.bit_width, cfg.signs1, cfg.signs2
+        )
+
+        mse = ((x.float() - x_hat.float()) ** 2).mean().item()
+        cos = torch.nn.functional.cosine_similarity(
+            x.float().reshape(-1), x_hat.float().reshape(-1), dim=0
+        ).item()
+        return mse, cos
+
+    def test_2bit_roundtrip(self):
+        mse, cos = self._roundtrip(2)
+        self.assertGreater(cos, 0.7, f"2-bit cosine too low: {cos:.4f}")
+
+    def test_4bit_roundtrip(self):
+        mse, cos = self._roundtrip(4)
+        self.assertGreater(cos, 0.95, f"4-bit cosine too low: {cos:.4f}")
+
+    def test_wht_self_inverse(self):
+        """Normalized WHT applied twice should return the original."""
+        from sglang.jit_kernel.hadamard import hadamard_transform
+        import math
+        torch.manual_seed(0)
+        x = torch.randn(8, 4, 128, device=self.device, dtype=torch.float32)
+        scale = 1.0 / math.sqrt(128)
+        y = hadamard_transform(x, scale=scale)
+        x_back = hadamard_transform(y, scale=scale)
+        err = (x - x_back).abs().max().item()
+        self.assertLess(err, 1e-4, f"WHT not self-inverse: max error {err}")
+
+    def test_packing_2bit(self):
+        from sglang.srt.layers.quantization.kv_turboquant import batched_quantize
+        cfg = self.configs[2]
+        x = torch.randn(8, 4, 128, device=self.device, dtype=torch.bfloat16)
+        packed, norms, quant_norms = batched_quantize(
+            x, cfg.signs1, cfg.signs2, cfg.k_centroids, cfg.k_boundaries, 2
+        )
+        self.assertEqual(packed.shape, (8, 4, 32))
+        self.assertEqual(packed.dtype, torch.uint8)
+
+    def test_packing_4bit(self):
+        from sglang.srt.layers.quantization.kv_turboquant import batched_quantize
+        cfg = self.configs[4]
+        x = torch.randn(8, 4, 128, device=self.device, dtype=torch.bfloat16)
+        packed, norms, quant_norms = batched_quantize(
+            x, cfg.signs1, cfg.signs2, cfg.k_centroids, cfg.k_boundaries, 4
+        )
+        self.assertEqual(packed.shape, (8, 4, 64))
+
+    def test_zero_vector(self):
+        from sglang.srt.layers.quantization.kv_turboquant import (
+            batched_dequantize, batched_quantize,
+        )
+        cfg = self.configs[4]
+        x = torch.zeros(1, 1, 128, device=self.device, dtype=torch.bfloat16)
+        packed, norms, quant_norms = batched_quantize(
+            x, cfg.signs1, cfg.signs2, cfg.k_centroids, cfg.k_boundaries, 4
+        )
+        x_hat = batched_dequantize(
+            packed, norms, cfg.k_centroids, 4, cfg.signs1, cfg.signs2
+        )
+        self.assertAlmostEqual(x_hat.abs().max().item(), 0.0, places=3)
+
+    def test_batch_consistency(self):
+        from sglang.srt.layers.quantization.kv_turboquant import (
+            batched_dequantize, batched_quantize,
+        )
+        cfg = self.configs[4]
+        torch.manual_seed(42)
+        x = torch.randn(4, 2, 128, device=self.device, dtype=torch.bfloat16)
+
+        packed_b, norms_b, _ = batched_quantize(
+            x, cfg.signs1, cfg.signs2, cfg.k_centroids, cfg.k_boundaries, 4
+        )
+        hat_b = batched_dequantize(packed_b, norms_b, cfg.k_centroids, 4, cfg.signs1, cfg.signs2)
+
+        for i in range(4):
+            packed_i, norms_i, _ = batched_quantize(
+                x[i:i+1], cfg.signs1, cfg.signs2, cfg.k_centroids, cfg.k_boundaries, 4
+            )
+            hat_i = batched_dequantize(packed_i, norms_i, cfg.k_centroids, 4, cfg.signs1, cfg.signs2)
+            torch.testing.assert_close(hat_b[i:i+1], hat_i, atol=1e-4, rtol=0)
+
+    def test_attention_score_preservation(self):
+        """Verify Q@K^T scores are well-preserved after quantization."""
+        from sglang.srt.layers.quantization.kv_turboquant import (
+            batched_dequantize, batched_quantize,
+        )
+        cfg = self.configs[4]
+        torch.manual_seed(42)
+        Q = torch.randn(1, 4, 128, device=self.device, dtype=torch.bfloat16)
+        K = torch.randn(32, 4, 128, device=self.device, dtype=torch.bfloat16)
+
+        scores_orig = torch.matmul(Q.float(), K.float().transpose(-2, -1))
+
+        k_packed, k_norms, _ = batched_quantize(
+            K, cfg.signs1, cfg.signs2, cfg.k_centroids, cfg.k_boundaries, 4
+        )
+        K_hat = batched_dequantize(k_packed, k_norms, cfg.k_centroids, 4, cfg.signs1, cfg.signs2)
+        scores_quant = torch.matmul(Q.float(), K_hat.float().transpose(-2, -1))
+
+        cos = torch.nn.functional.cosine_similarity(
+            scores_orig.flatten(), scores_quant.flatten(), dim=0
+        ).item()
+        self.assertGreater(cos, 0.9, f"Attention scores diverged: cos={cos:.4f}")
+
+    def test_query_rotation_equivalence(self):
+        """Verify Q_rot @ K_rotspace produces same scores as Q @ K_dequant."""
+        from sglang.srt.layers.quantization.kv_turboquant import (
+            batched_dequantize, batched_dequantize_rotspace, batched_quantize,
+        )
+        for bits in [2, 4]:
+            cfg = self.configs[bits]
+            torch.manual_seed(42)
+            Q = torch.randn(4, 8, 128, device=self.device, dtype=torch.bfloat16)
+            K = torch.randn(32, 8, 128, device=self.device, dtype=torch.bfloat16)
+
+            # Quantize K
+            k_packed, k_norms, k_quant_norms = batched_quantize(
+                K, cfg.signs1, cfg.signs2, cfg.k_centroids, cfg.k_boundaries, bits
+            )
+
+            # Method A: Traditional dequant (with inverse WHT)
+            K_hat = batched_dequantize(
+                k_packed, k_norms, cfg.k_centroids, bits, cfg.signs1, cfg.signs2
+            )
+            scores_a = torch.einsum(
+                "qhd,khd->hqk", Q.float(), K_hat.float()
+            )
+
+            # Method B: Query Rotation + rotspace dequant (no inverse WHT)
+            Q_rot = cfg.rotate_query(Q)
+            safe_k_qnorms = torch.where(k_quant_norms > 1e-10, k_quant_norms, torch.ones_like(k_quant_norms))
+            k_dequant_scale = k_norms / safe_k_qnorms
+            K_rotspace = batched_dequantize_rotspace(
+                k_packed, k_dequant_scale, cfg.k_centroids, bits, head_dim=128
+            )
+            scores_b = torch.einsum(
+                "qhd,khd->hqk", Q_rot.float(), K_rotspace.float()
+            )
+
+            max_diff = (scores_a - scores_b).abs().max().item()
+            cos = torch.nn.functional.cosine_similarity(
+                scores_a.flatten(), scores_b.flatten(), dim=0
+            ).item()
+            self.assertLess(
+                max_diff, 0.2,
+                f"{bits}-bit: Query rotation scores diverge: max_diff={max_diff:.4f}"
+            )
+            self.assertGreater(
+                cos, 0.99,
+                f"{bits}-bit: Query rotation scores diverge: cos={cos:.6f}"
+            )
+
+    def test_output_inverse_rotation(self):
+        """Verify inverse_rotate(rotate(x)) == x (bf16 precision)."""
+        cfg = self.configs[4]
+        torch.manual_seed(42)
+        x = torch.randn(4, 8, 128, device=self.device, dtype=torch.bfloat16)
+        x_rot = cfg.rotate_query(x)
+        x_back = cfg.inverse_rotate_output(x_rot)
+        max_err = (x.float() - x_back.float()).abs().max().item()
+        self.assertLess(max_err, 0.02, f"Rotation roundtrip error: {max_err}")
+
+    def test_rotspace_dequant_v_output_equivalence(self):
+        """Verify attention output equivalence for V side:
+        D1@H@D2 @ sum(attn_i * V_rotspace_i) == sum(attn_i * V_dequant_i)"""
+        from sglang.srt.layers.quantization.kv_turboquant import (
+            batched_dequantize, batched_dequantize_rotspace, batched_quantize,
+        )
+        cfg = self.configs[4]
+        torch.manual_seed(42)
+        V = torch.randn(32, 4, 128, device=self.device, dtype=torch.bfloat16)
+        # attn_weights: (1, 4, 32) — 1 query, 4 heads, 32 KV tokens
+        attn_weights = torch.softmax(
+            torch.randn(1, 4, 32, device=self.device), dim=-1
+        )
+
+        v_packed, v_norms, v_quant_norms = batched_quantize(
+            V, cfg.signs1, cfg.signs2, cfg.v_centroids, cfg.v_boundaries, 4
+        )
+
+        # Method A: traditional dequant
+        V_hat = batched_dequantize(
+            v_packed, v_norms, cfg.v_centroids, 4, cfg.signs1, cfg.signs2
+        )
+        # V_hat: (32, 4, 128) → need (heads, kv_tokens, dim) for einsum
+        o_a = torch.einsum("qhk,khd->qhd", attn_weights, V_hat.float())
+
+        # Method B: rotspace + inverse rotation on output
+        safe_v_qnorms = torch.where(v_quant_norms > 1e-10, v_quant_norms, torch.ones_like(v_quant_norms))
+        v_dequant_scale = v_norms / safe_v_qnorms
+        V_rotspace = batched_dequantize_rotspace(
+            v_packed, v_dequant_scale, cfg.v_centroids, 4, head_dim=128
+        )
+        o_rotspace = torch.einsum("qhk,khd->qhd", attn_weights, V_rotspace.float())
+        o_b = cfg.inverse_rotate_output(o_rotspace.to(torch.bfloat16)).float()
+
+        max_diff = (o_a - o_b).abs().max().item()
+        self.assertLess(
+            max_diff, 0.1,
+            f"V output rotspace equivalence failed: max_diff={max_diff:.4f}"
+        )
+
+    def test_fused_decode_kernel_correctness(self):
+        """Verify fused TQ decode kernel matches PyTorch reference implementation."""
+        from sglang.srt.layers.quantization.kv_turboquant import (
+            batched_dequantize_rotspace, batched_quantize,
+        )
+        from sglang.srt.layers.attention.triton_ops.turboquant_decode_attention import (
+            tq_decode_attention_fwd,
+        )
+        from sglang.srt.layers.attention.triton_ops.decode_attention import (
+            decode_attention_fwd,
+        )
+
+        torch.manual_seed(42)
+        batch = 2
+        q_heads = 32
+        kv_heads = 8
+        head_dim = 128
+        seq_lens = [64, 48]
+        total_kv = sum(seq_lens)
+        max_kv_splits = 4
+
+        for bits in [2, 4]:  # fused kernel supports both 2-bit and 4-bit
+            cfg = self.configs[bits]
+
+            # Generate Q (already rotated) and raw K/V
+            Q = torch.randn(batch, q_heads, head_dim, device=self.device, dtype=torch.bfloat16)
+            K_raw = torch.randn(total_kv, kv_heads, head_dim, device=self.device, dtype=torch.bfloat16)
+            V_raw = torch.randn(total_kv, kv_heads, head_dim, device=self.device, dtype=torch.bfloat16)
+
+            # Quantize K and V
+            k_packed, k_norms, k_qnorms = batched_quantize(
+                K_raw, cfg.signs1, cfg.signs2, cfg.k_centroids, cfg.k_boundaries, bits
+            )
+            v_packed, v_norms, v_qnorms = batched_quantize(
+                V_raw, cfg.signs1, cfg.signs2, cfg.k_centroids, cfg.k_boundaries, bits
+            )
+
+            # Precompute dequant scales
+            safe_k_qn = torch.where(k_qnorms > 1e-10, k_qnorms, torch.ones_like(k_qnorms))
+            safe_v_qn = torch.where(v_qnorms > 1e-10, v_qnorms, torch.ones_like(v_qnorms))
+            k_dscale = (k_norms / safe_k_qn).to(torch.bfloat16)
+            v_dscale = (v_norms / safe_v_qn).to(torch.bfloat16)
+
+            # Build kv_indptr and kv_indices (identity mapping: slot i = position i)
+            kv_indptr = torch.tensor([0, seq_lens[0], total_kv], dtype=torch.int32, device=self.device)
+            kv_indices = torch.arange(total_kv, dtype=torch.int64, device=self.device)
+
+            # num_kv_splits
+            num_kv_splits = torch.full((batch,), max_kv_splits, dtype=torch.int32, device=self.device)
+
+            # --- Method A: Fused kernel ---
+            o_fused = torch.zeros(batch, q_heads, head_dim, device=self.device, dtype=torch.bfloat16)
+            attn_logits_a = torch.zeros(batch, q_heads, max_kv_splits, head_dim, device=self.device, dtype=torch.float32)
+            attn_lse_a = torch.zeros(batch, q_heads, max_kv_splits, device=self.device, dtype=torch.float32)
+
+            tq_decode_attention_fwd(
+                Q, k_packed, v_packed,
+                k_dscale, v_dscale,
+                cfg.k_centroids,
+                o_fused, kv_indptr, kv_indices,
+                attn_logits_a, attn_lse_a,
+                num_kv_splits, max_kv_splits,
+                sm_scale=1.0 / (head_dim ** 0.5),
+                bit_width=bits,
+            )
+
+            # --- Method B: PyTorch reference (rotspace dequant + standard attention) ---
+            K_dequant = batched_dequantize_rotspace(
+                k_packed, k_dscale, cfg.k_centroids, bits, head_dim=128
+            )
+            V_dequant = batched_dequantize_rotspace(
+                v_packed, v_dscale, cfg.k_centroids, bits, head_dim=128
+            )
+            o_ref = torch.zeros(batch, q_heads, head_dim, device=self.device, dtype=torch.bfloat16)
+            attn_logits_b = torch.zeros(batch, q_heads, max_kv_splits, head_dim, device=self.device, dtype=torch.float32)
+            attn_lse_b = torch.zeros(batch, q_heads, max_kv_splits, device=self.device, dtype=torch.float32)
+
+            decode_attention_fwd(
+                Q, K_dequant, V_dequant, o_ref,
+                kv_indptr, kv_indices,
+                attn_logits_b, attn_lse_b,
+                num_kv_splits, max_kv_splits,
+                sm_scale=1.0 / (head_dim ** 0.5),
+                k_scale=1.0, v_scale=1.0,
+            )
+
+            # Compare
+            max_diff = (o_fused.float() - o_ref.float()).abs().max().item()
+            cos = torch.nn.functional.cosine_similarity(
+                o_fused.float().flatten(), o_ref.float().flatten(), dim=0
+            ).item()
+            self.assertLess(
+                max_diff, 0.1,
+                f"{bits}-bit fused kernel output diverged: max_diff={max_diff:.4f}"
+            )
+            self.assertGreater(
+                cos, 0.999,
+                f"{bits}-bit fused kernel output diverged: cos={cos:.6f}"
+            )
+
+    def test_asymmetric_k4v2_roundtrip(self):
+        """Verify K=4bit V=2bit asymmetric quantization roundtrip."""
+        from sglang.srt.layers.quantization.kv_turboquant import (
+            TurboQuantConfig, batched_quantize, batched_dequantize,
+        )
+        cfg = TurboQuantConfig(bit_width=4, head_dim=128, device=self.device,
+                               k_bit_width=4, v_bit_width=2)
+        self.assertEqual(cfg.k_packed_dim, 64)   # 4-bit: dim//2
+        self.assertEqual(cfg.v_packed_dim, 32)    # 2-bit: dim//4
+        self.assertEqual(cfg.k_centroids.shape[0], 16)
+        self.assertEqual(cfg.v_centroids.shape[0], 4)
+
+        torch.manual_seed(42)
+        K = torch.randn(16, 4, 128, device=self.device, dtype=torch.bfloat16)
+        V = torch.randn(16, 4, 128, device=self.device, dtype=torch.bfloat16)
+
+        k_packed, k_norms, k_qnorms = batched_quantize(
+            K, cfg.signs1, cfg.signs2, cfg.k_centroids, cfg.k_boundaries, cfg.k_bit_width)
+        v_packed, v_norms, v_qnorms = batched_quantize(
+            V, cfg.signs1, cfg.signs2, cfg.v_centroids, cfg.v_boundaries, cfg.v_bit_width)
+
+        self.assertEqual(k_packed.shape[-1], 64)
+        self.assertEqual(v_packed.shape[-1], 32)
+
+        # Use full dequant (with inverse WHT) to compare in original domain
+        K_hat = batched_dequantize(
+            k_packed, k_norms, cfg.k_centroids, cfg.k_bit_width, cfg.signs1, cfg.signs2)
+        V_hat = batched_dequantize(
+            v_packed, v_norms, cfg.v_centroids, cfg.v_bit_width, cfg.signs1, cfg.signs2)
+
+        k_cos = torch.nn.functional.cosine_similarity(
+            K.float().reshape(-1), K_hat.float().reshape(-1), dim=0).item()
+        v_cos = torch.nn.functional.cosine_similarity(
+            V.float().reshape(-1), V_hat.float().reshape(-1), dim=0).item()
+        self.assertGreater(k_cos, 0.9, f"K 4-bit roundtrip cos too low: {k_cos:.4f}")
+        self.assertGreater(v_cos, 0.5, f"V 2-bit roundtrip cos too low: {v_cos:.4f}")
+
+    def test_move_kv_cache_dequant_correctness(self):
+        """Verify data is correct after move_kv_cache."""
+        from sglang.srt.layers.quantization.kv_turboquant import (
+            TurboQuantConfig, batched_quantize, batched_dequantize_rotspace,
+        )
+        cfg = self.configs[4]
+        torch.manual_seed(42)
+        x = torch.randn(4, 8, 128, device=self.device, dtype=torch.bfloat16)
+
+        packed, norms, qnorms = batched_quantize(
+            x, cfg.signs1, cfg.signs2, cfg.k_centroids, cfg.k_boundaries, cfg.k_bit_width)
+
+        # Simulate pool: write to positions 0-3, move to 10-13
+        pool_packed = torch.zeros(20, 8, 64, dtype=torch.uint8, device=self.device)
+        safe_qnorms = torch.where(qnorms > 1e-10, qnorms, torch.ones_like(qnorms))
+        dequant_scale = (norms / safe_qnorms).to(torch.bfloat16)
+        pool_dscale = torch.zeros(20, 8, dtype=torch.bfloat16, device=self.device)
+
+        src = torch.arange(4, device=self.device)
+        tgt = torch.arange(10, 14, device=self.device)
+
+        pool_packed[src] = packed
+        pool_dscale[src] = dequant_scale
+
+        # Move
+        pool_packed[tgt] = pool_packed[src]
+        pool_dscale[tgt] = pool_dscale[src]
+
+        # Dequant from moved positions
+        hat_src = batched_dequantize_rotspace(
+            pool_packed[src], pool_dscale[src], cfg.k_centroids, 4, head_dim=128)
+        hat_tgt = batched_dequantize_rotspace(
+            pool_packed[tgt], pool_dscale[tgt], cfg.k_centroids, 4, head_dim=128)
+
+        torch.testing.assert_close(hat_src, hat_tgt, atol=1e-6, rtol=0)
+
+    def test_non_128_head_dim(self):
+        """Verify TurboQuant works with head_dim=64 and head_dim=256."""
+        from sglang.srt.layers.quantization.kv_turboquant import (
+            TurboQuantConfig, batched_quantize, batched_dequantize, batched_dequantize_rotspace,
+        )
+        for dim in [64, 256]:
+            for bits in [2, 4]:
+                cfg = TurboQuantConfig(bit_width=bits, head_dim=dim, device=self.device)
+                torch.manual_seed(42)
+                x = torch.randn(8, 4, dim, device=self.device, dtype=torch.bfloat16)
+
+                packed, norms, qnorms = batched_quantize(
+                    x, cfg.signs1, cfg.signs2, cfg.k_centroids, cfg.k_boundaries, bits)
+
+                # Full dequant roundtrip
+                x_hat = batched_dequantize(
+                    packed, norms, cfg.k_centroids, bits, cfg.signs1, cfg.signs2)
+                self.assertEqual(x_hat.shape, x.shape,
+                    f"dim={dim} bits={bits}: shape mismatch {x_hat.shape} vs {x.shape}")
+
+                cos = torch.nn.functional.cosine_similarity(
+                    x.float().reshape(-1), x_hat.float().reshape(-1), dim=0).item()
+                min_cos = 0.5 if bits == 2 else 0.93
+                self.assertGreater(cos, min_cos,
+                    f"dim={dim} bits={bits}: cos={cos:.4f} < {min_cos}")
+
+                # Rotspace dequant
+                safe_qn = torch.where(qnorms > 1e-10, qnorms, torch.ones_like(qnorms))
+                ds = (norms / safe_qn).to(torch.bfloat16)
+                rs = batched_dequantize_rotspace(
+                    packed, ds, cfg.k_centroids, bits, head_dim=dim)
+                self.assertEqual(rs.shape[-1], dim)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Implement high-performance TurboQuant KV cache compression based on [Zandieh et al., ICLR 2026](https://arxiv.org/abs/2504.19874). This is a v2 rewrite that addresses the performance bottleneck in #21419 — instead of dequant-then-read, v2 uses **fused Triton kernels** that read packed 4-bit KV directly during attention, eliminating the need for dequant buffers entirely.

Related: #21419

## Modifications

**New files (8):**
- `turboquant_decode_attention.py` — Fused decode attention kernel (packed 4-bit read + split dot)
- `turboquant_extend_attention.py` — Fused extend/prefill attention kernel
- `turboquant_quantize.py` — WHT rotation + norm + quantize + pack kernels
- `kv_turboquant.py` — TurboQuantConfig, codebook generation, memory layout
- `tq4_decode_stage1.cu` — Experimental CUDA JIT decode kernel
- `tq_decode_attention.py` — CUDA kernel Python wrapper
- `test_turboquant.py` — 17 unit + E2E tests
- `bench_niah_turboquant.py` — NIAH accuracy benchmark

**Modified files (5):**
- `server_args.py` — Add `turboquant_*` to `--kv-cache-dtype` choices
- `model_runner.py` — TQ dtype parsing, WHT rotation fusion into W_O weights, FP8 compatibility
- `model_runner_kv_cache_mixin.py` — TQ cell size calculation and pool construction
- `memory_pool.py` — `MHATokenToKVPoolTurboQuant` with packed KV storage
- `triton_backend.py` — Route to TQ fused kernels for decode/extend paths

## Accuracy Tests

Near-zero degradation on GSM8K and MMLU (Llama-3.1-8B-Instruct, H200):

| Config | GSM8K (8-shot, 1319q) | MMLU (5-shot, 14042q) |
|--------|-----------------------|-----------------------|
| bf16 | 79.2% | 68.3% |
| tq4_uni | 79.3% | 68.3% |
| fp8m+tq4u | 78.1% | 68.3% |

> Config naming: **bf16** = BF16 model + BF16 KV; **tq4_uni** = BF16 model + TQ4 uniform KV; **fp8m+tq4u** = FP8 model + TQ4 uniform KV; **fp8m+fp8kv** = FP8 model + FP8 KV.
> Test scenarios: **P1(128→1)** = input 128 tokens, output 1 token (pure prefill); **D3(32→1024)** = input 32, output 1024 (pure decode); **ShareGPT** = real conversation distribution.

## Speed Tests and Profiling

**Environment:** NVIDIA H200 (143GB HBM3e), single-GPU, `--disable-radix-cache --cuda-graph-max-bs 1024`, 1000 prompts per test, container restarted between each scenario for isolation.

### Current Status

**Implemented capabilities:**
- WHT (Walsh-Hadamard Transform) rotation + 4-bit KV cache quantization: 3.88x compression per layer
- Codebook quantization (`turboquant_4bit`): Lloyd-Max optimal codebook, 15x tl.where lookups
- Uniform quantization (`turboquant_4bit_uniform`): linearly-spaced centroids, 1 FMA replaces 15 tl.where, +15% decode throughput
- FP8 model compatibility: auto-detects FP8 weight dtype, skips rotation fusion, uses runtime inverse rotation
- Fused Triton decode/extend kernels: read packed 4-bit KV directly, no dequant buffer
- Full CUDA graph support: `--cuda-graph-max-bs 1024` for zero high-concurrency degradation

**Performance summary (Triton backend, same-backend fair comparison):**

| Metric | bf16 | fp8m+fp8kv | fp8m+tq4u | tq4u/bf16 | tq4u/fp8m |
|--------|------|-----------|-----------|-----------|-----------|
| GSM8K (tok/s) | 2,333 | 3,225 | 2,125 | 91% | 66% |
| ShareGPT Output (tok/s) | 7,247 | 9,423 | 6,148 | 85% | 65% |
| D3 Decode (tok/s) | 16,658 | 17,005 | 17,431 | **105%** | **103%** |
| P5 Prefill (tok/s) | 33,982 | 45,816 | 25,496 | 75% | 56% |

**KV cache memory:**

| | bf16 | FP8 | TQ4 |
|---|---|---|---|
| Per-token bytes | 131,072 | 65,536 | 33,792 |
| Compression vs bf16 | 1x | 2x | **3.88x** |

**Current limitations:**
1. Prefill + decode locked to Triton backend — fused kernels read packed 4-bit KV pool directly; fa3/flashinfer extend path attempts to read bf16 KV buffer, resulting in `NotImplementedError`. FA3 is 37% faster for FP8 prefill, but TQ cannot use it.
2. Prefill performance degrades with longer inputs — P1(128→1) tq4_uni/bf16 = 94%, P5(4096→1) drops to 64%, due to WHT rotation + quantize kernel overhead.
3. Only validated on H200 — need testing on smaller GPUs (A30, etc.) to verify memory capacity advantage.

### Triton Backend Full Comparison (same backend, fair comparison)

**Speed summary:** tq4_uni averages **87%** (decode) / **76%** (prefill) / **73%** (ShareGPT) of bf16; fp8m+fp8kv averages **108%** (decode) / **149%** (prefill) / **130%** (ShareGPT) of bf16.

#### Accuracy

| Config | GSM8K Acc | GSM8K tok/s | MMLU Acc | MMLU Latency |
|--------|-----------|-------------|----------|-------------|
| **bf16** | 79.2% | 2,333 | 68.3% | 233s |
| **fp8kv** | 79.8% | 2,318 | 68.4% | 234s |
| **fp8m+fp8kv** | 79.5% | **3,225** | 68.4% | **159s** |
| **tq4** | 78.6% | 1,611 | 68.3% | 291s |
| **tq4_uni** | 79.3% | 1,728 | 68.3% | 294s |
| **fp8m+tq4** | 77.6% | 1,899 | 68.1% | 224s |
| **fp8m+tq4u** | 78.1% | 2,125 | 68.3% | 222s |

#### Prefill Throughput (Input tok/s)

| Config | P1(128→1) | P2(512→1) | P3(1024→1) | P4(2048→1) | P5(4096→1) |
|--------|----------|----------|-----------|-----------|-----------|
| **bf16** | 31,446 | 39,721 | 39,320 | 37,712 | 33,982 |
| **fp8kv** | 31,364 | 39,735 | 39,336 | 37,561 | 33,888 |
| **fp8m+fp8kv** | **39,794** | **58,515** | **57,384** | **53,325** | **45,816** |
| **tq4** | 29,383 | 33,230 | 31,374 | 27,702 | 21,980 |
| **tq4_uni** | 29,468 | 32,625 | 30,967 | 27,441 | 21,710 |
| **fp8m+tq4** | 34,123 | 43,793 | 40,300 | 33,884 | 25,386 |
| **fp8m+tq4u** | 34,840 | 44,215 | 40,768 | 33,350 | 25,496 |

> tq4_uni/bf16: P1=94%, P3=79%, P5=**64%**

#### Decode Throughput (Output tok/s)

| Config | D1(32→256) | D2(32→512) | D3(32→1024) |
|--------|-----------|-----------|------------|
| **bf16** | 19,464 | 18,067 | 16,658 |
| **fp8kv** | 18,714 | 18,164 | 16,882 |
| **fp8m+fp8kv** | **20,772** | **18,797** | **17,005** |
| **tq4** | 18,429 | 16,733 | 12,739 |
| **tq4_uni** | 18,262 | 18,457 | 15,480 |
| **fp8m+tq4** | 16,975 | 18,508 | 14,056 |
| **fp8m+tq4u** | 19,196 | 18,775 | **17,431** |

> tq4_uni/bf16: D1=94%, D2=102%, D3=**93%**

#### ShareGPT Mixed Workload (Output tok/s)

| Config | Input tok/s | Output tok/s | vs bf16 |
|--------|------------|-------------|---------|
| **bf16** | 11,507 | 7,247 | baseline |
| **fp8kv** | 11,637 | 7,329 | 101% |
| **fp8m+fp8kv** | **14,963** | **9,423** | **130%** |
| **tq4** | 7,417 | 4,671 | 64% |
| **tq4_uni** | 8,379 | 5,277 | **73%** |
| **fp8m+tq4** | 8,450 | 5,321 | 73% |
| **fp8m+tq4u** | 9,762 | 6,148 | **85%** |

### FA3 Backend Full Comparison (optimal baseline vs TQ)

> bf16/fp8kv/fp8m use **FA3** (Hopper optimal); TQ configs use **Triton** (only option).

**Speed summary:** tq4_uni averages **95%** (decode) / **72%** (prefill) / **64%** (ShareGPT) of bf16(fa3); fp8m+fp8kv(fa3) averages **99%** (decode) / **152%** (prefill) / **138%** (ShareGPT) of bf16(fa3).

#### Accuracy

| Config | Backend | GSM8K Acc | GSM8K tok/s | MMLU Acc | MMLU Latency |
|--------|---------|-----------|-------------|----------|-------------|
| **bf16** | fa3 | 79.7% | 2,473 | 68.2% | 220s |
| **fp8kv** | fa3 | 78.5% | 2,623 | 68.3% | 218s |
| **fp8m+fp8kv** | fa3 | 78.5% | **3,701** | 67.8% | **143s** |
| **tq4** | triton | 79.3% | 1,594 | 68.3% | 290s |
| **tq4_uni** | triton | 78.9% | 1,726 | 68.3% | 294s |
| **fp8m+tq4** | triton | 78.2% | 1,912 | 68.2% | 224s |
| **fp8m+tq4u** | triton | 77.6% | 2,116 | 68.2% | 222s |

#### Prefill Throughput (Input tok/s)

| Config | Backend | P1(128→1) | P2(512→1) | P3(1024→1) | P4(2048→1) | P5(4096→1) |
|--------|---------|----------|----------|-----------|-----------|-----------|
| **bf16** | fa3 | 33,200 | 40,885 | 41,930 | 41,754 | 40,850 |
| **fp8kv** | fa3 | 32,545 | 41,179 | 42,051 | 42,015 | 41,335 |
| **fp8m+fp8kv** | fa3 | **40,265** | **61,926** | **63,775** | **64,056** | **62,486** |
| **tq4** | triton | 29,542 | 33,200 | 31,401 | 27,736 | 21,926 |
| **tq4_uni** | triton | 28,700 | 32,787 | 30,920 | 27,531 | 21,720 |
| **fp8m+tq4** | triton | 35,372 | 43,992 | 40,434 | 33,991 | 25,442 |
| **fp8m+tq4u** | triton | 35,043 | 44,227 | 40,807 | 34,075 | 25,481 |

> tq4_uni/bf16(fa3): P1=86%, P3=74%, P5=**53%**

#### Decode Throughput (Output tok/s)

| Config | Backend | D1(32→256) | D2(32→512) | D3(32→1024) |
|--------|---------|-----------|-----------|------------|
| **bf16** | fa3 | **20,834** | 19,478 | 16,648 |
| **fp8kv** | fa3 | 18,860 | 18,780 | 16,108 |
| **fp8m+fp8kv** | fa3 | 19,889 | 19,371 | **17,470** |
| **tq4** | triton | 18,354 | 16,645 | 12,734 |
| **tq4_uni** | triton | 19,549 | 18,948 | 15,469 |
| **fp8m+tq4** | triton | 19,919 | 18,583 | 14,029 |
| **fp8m+tq4u** | triton | 19,762 | 18,484 | 16,810 |

> tq4_uni/bf16(fa3): D1=94%, D2=97%, D3=**93%**

#### ShareGPT Mixed Workload (Output tok/s)

| Config | Backend | Input tok/s | Output tok/s | vs bf16(fa3) |
|--------|---------|------------|-------------|-------------|
| **bf16** | fa3 | 13,116 | 8,260 | baseline |
| **fp8kv** | fa3 | 13,282 | 8,364 | 101% |
| **fp8m+fp8kv** | fa3 | **18,143** | **11,426** | **138%** |
| **tq4** | triton | 7,399 | 4,660 | 56% |
| **tq4_uni** | triton | 8,331 | 5,246 | **64%** |
| **fp8m+tq4** | triton | 8,474 | 5,337 | 65% |
| **fp8m+tq4u** | triton | 9,680 | 6,096 | **74%** |

### FlashInfer Backend Full Comparison

> bf16/fp8kv/fp8m use **FlashInfer**; TQ configs use **Triton** (only option).

**Speed summary:** tq4_uni averages **89%** (decode) / **72%** (prefill) / **67%** (ShareGPT) of bf16(fi); fp8m+fp8kv(fi) averages **95%** (decode) / **137%** (prefill) / **118%** (ShareGPT) of bf16(fi).

#### Accuracy

| Config | Backend | GSM8K Acc | GSM8K tok/s | MMLU Acc | MMLU Latency |
|--------|---------|-----------|-------------|----------|-------------|
| **bf16** | flashinfer | 78.7% | 2,475 | 68.3% | 224s |
| **fp8kv** | flashinfer | 78.8% | 2,407 | 68.2% | 232s |
| **fp8m+fp8kv** | flashinfer | 78.8% | **3,300** | 67.8% | **156s** |
| **tq4** | triton | 79.3% | 1,609 | 68.3% | 291s |
| **tq4_uni** | triton | 79.4% | 1,715 | 68.3% | 295s |
| **fp8m+tq4** | triton | 77.5% | 1,923 | 68.1% | 224s |
| **fp8m+tq4u** | triton | 77.9% | 2,134 | 68.1% | 222s |

#### Prefill Throughput (Input tok/s)

| Config | Backend | P1(128→1) | P2(512→1) | P3(1024→1) | P4(2048→1) | P5(4096→1) |
|--------|---------|----------|----------|-----------|-----------|-----------|
| **bf16** | flashinfer | 33,752 | 40,713 | 41,409 | 40,804 | 39,072 |
| **fp8kv** | flashinfer | 25,545 | 40,112 | 40,154 | 39,059 | 36,733 |
| **fp8m+fp8kv** | flashinfer | 32,661 | **59,835** | **60,058** | **56,957** | **51,515** |
| **tq4** | triton | 29,416 | 33,115 | 31,401 | 27,759 | 22,028 |
| **tq4_uni** | triton | 28,831 | 32,738 | 31,053 | 27,485 | 21,766 |
| **fp8m+tq4** | triton | 32,307 | 44,122 | 40,429 | 34,002 | 25,559 |
| **fp8m+tq4u** | triton | **35,432** | 44,305 | 40,649 | 34,179 | 25,399 |

#### Decode Throughput (Output tok/s)

| Config | Backend | D1(32→256) | D2(32→512) | D3(32→1024) |
|--------|---------|-----------|-----------|------------|
| **bf16** | flashinfer | 20,070 | **21,239** | **18,286** |
| **fp8kv** | flashinfer | 19,496 | 18,865 | 17,583 |
| **fp8m+fp8kv** | flashinfer | **20,120** | 18,874 | 17,146 |
| **tq4** | triton | 18,896 | 16,747 | 12,727 |
| **tq4_uni** | triton | 19,537 | 19,012 | 15,460 |
| **fp8m+tq4** | triton | 17,902 | 18,561 | 14,017 |
| **fp8m+tq4u** | triton | 17,449 | 19,080 | 16,805 |

#### ShareGPT Mixed Workload (Output tok/s)

| Config | Backend | Input tok/s | Output tok/s | vs bf16(fi) |
|--------|---------|------------|-------------|-------------|
| **bf16** | flashinfer | 12,586 | 7,926 | baseline |
| **fp8kv** | flashinfer | 11,612 | 7,313 | 92% |
| **fp8m+fp8kv** | flashinfer | **14,869** | **9,364** | **118%** |
| **tq4** | triton | 7,402 | 4,661 | 59% |
| **tq4_uni** | triton | 8,375 | 5,274 | **67%** |
| **fp8m+tq4** | triton | 8,459 | 5,327 | 67% |
| **fp8m+tq4u** | triton | 9,751 | 6,140 | **77%** |

### Deployment Analysis

**Core weaknesses:**
- Prefill performance degrades sharply with input length: P5 tq4_uni/bf16(fa3) = **53%**, root cause is WHT rotation + quantize kernel overhead
- Locked to Triton backend: cannot use FA3 to accelerate prefill, while FA3 is 37% faster for FP8 model prefill

**Strength scenarios:**
- Pure decode (short input + long output): D1-D2 tq4_uni ≈ 94-102% of bf16, near lossless; fp8m+tq4u even exceeds bf16
- 3.88x memory compression: enables longer context or higher concurrency on memory-constrained GPUs
- Accuracy preserved: GSM8K/MMLU accuracy virtually unchanged

**Recommended configs:**

| Scenario | Recommended | Reason |
|----------|------------|--------|
| Maximum speed | fp8m+fp8kv (fa3) | Fastest overall, prefill 62K tok/s |
| Maximum KV capacity | tq4_uni or fp8m+tq4u (triton) | 3.88x compression, ideal for large models on smaller GPUs |
| Short input + long output chat | fp8m+tq4u (triton) | Decode exceeds bf16, 3.88x memory savings |
| Long input, prefill-heavy | fp8m+fp8kv (fa3) | TQ prefill overhead too high |

## Checklist
- [ ] Format your code with pre-commit
- [x] Add unit tests
- [ ] Update documentation
- [x] Provide accuracy and speed benchmark results
- [ ] Follow [SGLang code style guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html)
