### PR TITLE
Fix segfault in cudaMemcpyBatchAsync on CUDA 13.0

### DIFF
--- a/sgl-kernel/csrc/kvcacheio/transfer.cu
+++ b/sgl-kernel/csrc/kvcacheio/transfer.cu
@@ -812,9 +812,19 @@ inline void transfer_kv_page_first_direct_impl(
     return;
   }
 
-  // CUDA 13.0 removed the failIdx parameter from cudaMemcpyBatchAsync.
-  // Use runtime version to select the correct signature for binary portability.
-  const bool use_v13_signature = driver_version >= 13000;
+  // CUDA 13.0 removed the failIdx parameter from cudaMemcpyBatchAsync. The ABI
+  // of the dlsym'd symbol is determined by the libcudart loaded in this process,
+  // not the host driver — a cu12 runtime on a cu13 driver host (common in
+  // containers) still exposes the 9-param v12 signature. Dispatching on the
+  // driver version here would segfault in that case (verified empirically).
+  // Use cudaRuntimeGetVersion so the signature follows the runtime.
+  int runtime_version = 0;
+  cudaError_t runtime_version_err = cudaRuntimeGetVersion(&runtime_version);
+  if (runtime_version_err != cudaSuccess) {
+    fallback_to_page_copy();
+    return;
+  }
+  const bool use_v13_signature = runtime_version >= 13000;
 
   size_t num_copies = 0;
   std::vector<void*> batch_srcs;

--- a/sgl-kernel/csrc/kvcacheio/transfer.cu
+++ b/sgl-kernel/csrc/kvcacheio/transfer.cu
@@ -806,8 +806,14 @@ inline void transfer_kv_page_first_direct_impl(
   }
 
   // Symbol gate: runtime may not expose cudaMemcpyBatchAsync in some environments.
+  // CUDA 13.0 removed the failIdx parameter from cudaMemcpyBatchAsync.
+#if CUDA_VERSION >= 13000
+  using CudaMemcpyBatchAsyncFn =
+      cudaError_t (*)(void *const *, const void *const *, const size_t *, size_t, cudaMemcpyAttributes*, size_t*, size_t, cudaStream_t);
+#else
   using CudaMemcpyBatchAsyncFn =
       cudaError_t (*)(void**, void**, size_t*, size_t, cudaMemcpyAttributes*, size_t*, size_t, size_t*, cudaStream_t);
+#endif
   static CudaMemcpyBatchAsyncFn cuda_memcpy_batch_async = []() {
     void* symbol = dlsym(RTLD_DEFAULT, "cudaMemcpyBatchAsync");
     return reinterpret_cast<CudaMemcpyBatchAsyncFn>(symbol);
@@ -916,6 +922,24 @@ inline void transfer_kv_page_first_direct_impl(
 
   TORCH_CHECK(batch_srcs.size() == num_copies, "Batch memcpy count mismatch");
   if (num_copies > 0) {
+#if CUDA_VERSION >= 13000
+    cudaError_t err = cuda_memcpy_batch_async(
+        batch_dsts.data(),
+        batch_srcs.data(),
+        batch_sizes.data(),
+        num_copies,
+        &attrs,
+        attrs_idxs.data(),
+        1,
+        stream);
+    if (err == cudaErrorNotSupported || err == cudaErrorCallRequiresNewerDriver) {
+      fallback_to_page_copy();
+      return;
+    }
+    if (err != cudaSuccess) {
+      TORCH_CHECK(false, "cudaMemcpyBatchAsync failed. error=", cudaGetErrorString(err));
+    }
+#else
     size_t fail_idx = std::numeric_limits<size_t>::max();
     cudaError_t err = cuda_memcpy_batch_async(
         batch_dsts.data(),
@@ -934,6 +958,7 @@ inline void transfer_kv_page_first_direct_impl(
     if (err != cudaSuccess) {
       TORCH_CHECK(false, "cudaMemcpyBatchAsync failed. failIdx=", fail_idx, " error=", cudaGetErrorString(err));
     }
+#endif
   }
 #endif
 }

--- a/sgl-kernel/csrc/kvcacheio/transfer.cu
+++ b/sgl-kernel/csrc/kvcacheio/transfer.cu
@@ -916,6 +916,7 @@ inline void transfer_kv_page_first_direct_impl(
   TORCH_CHECK(batch_srcs.size() == num_copies, "Batch memcpy count mismatch");
   if (num_copies > 0) {
     cudaError_t err;
+    size_t fail_idx = std::numeric_limits<size_t>::max();
     if (use_v13_signature) {
       using FnV13 = cudaError_t (*)(void *const *, const void *const *, const size_t *, size_t,
                                     cudaMemcpyAttributes*, size_t*, size_t, cudaStream_t);
@@ -933,7 +934,6 @@ inline void transfer_kv_page_first_direct_impl(
       using FnV12 = cudaError_t (*)(void**, void**, size_t*, size_t,
                                     cudaMemcpyAttributes*, size_t*, size_t, size_t*, cudaStream_t);
       auto fn = reinterpret_cast<FnV12>(cuda_memcpy_batch_async_sym);
-      size_t fail_idx = std::numeric_limits<size_t>::max();
       err = fn(
           batch_dsts.data(),
           batch_srcs.data(),
@@ -950,7 +950,7 @@ inline void transfer_kv_page_first_direct_impl(
       return;
     }
     if (err != cudaSuccess) {
-      TORCH_CHECK(false, "cudaMemcpyBatchAsync failed. error=", cudaGetErrorString(err));
+      TORCH_CHECK(false, "cudaMemcpyBatchAsync failed. failIdx=", fail_idx, " error=", cudaGetErrorString(err));
     }
   }
 #endif

--- a/sgl-kernel/csrc/kvcacheio/transfer.cu
+++ b/sgl-kernel/csrc/kvcacheio/transfer.cu
@@ -806,22 +806,15 @@ inline void transfer_kv_page_first_direct_impl(
   }
 
   // Symbol gate: runtime may not expose cudaMemcpyBatchAsync in some environments.
-  // CUDA 13.0 removed the failIdx parameter from cudaMemcpyBatchAsync.
-#if CUDA_VERSION >= 13000
-  using CudaMemcpyBatchAsyncFn =
-      cudaError_t (*)(void *const *, const void *const *, const size_t *, size_t, cudaMemcpyAttributes*, size_t*, size_t, cudaStream_t);
-#else
-  using CudaMemcpyBatchAsyncFn =
-      cudaError_t (*)(void**, void**, size_t*, size_t, cudaMemcpyAttributes*, size_t*, size_t, size_t*, cudaStream_t);
-#endif
-  static CudaMemcpyBatchAsyncFn cuda_memcpy_batch_async = []() {
-    void* symbol = dlsym(RTLD_DEFAULT, "cudaMemcpyBatchAsync");
-    return reinterpret_cast<CudaMemcpyBatchAsyncFn>(symbol);
-  }();
-  if (cuda_memcpy_batch_async == nullptr) {
+  static void* cuda_memcpy_batch_async_sym = dlsym(RTLD_DEFAULT, "cudaMemcpyBatchAsync");
+  if (cuda_memcpy_batch_async_sym == nullptr) {
     fallback_to_page_copy();
     return;
   }
+
+  // CUDA 13.0 removed the failIdx parameter from cudaMemcpyBatchAsync.
+  // Use runtime version to select the correct signature for binary portability.
+  const bool use_v13_signature = driver_version >= 13000;
 
   size_t num_copies = 0;
   std::vector<void*> batch_srcs;
@@ -922,16 +915,36 @@ inline void transfer_kv_page_first_direct_impl(
 
   TORCH_CHECK(batch_srcs.size() == num_copies, "Batch memcpy count mismatch");
   if (num_copies > 0) {
-#if CUDA_VERSION >= 13000
-    cudaError_t err = cuda_memcpy_batch_async(
-        batch_dsts.data(),
-        batch_srcs.data(),
-        batch_sizes.data(),
-        num_copies,
-        &attrs,
-        attrs_idxs.data(),
-        1,
-        stream);
+    cudaError_t err;
+    if (use_v13_signature) {
+      using FnV13 = cudaError_t (*)(void *const *, const void *const *, const size_t *, size_t,
+                                    cudaMemcpyAttributes*, size_t*, size_t, cudaStream_t);
+      auto fn = reinterpret_cast<FnV13>(cuda_memcpy_batch_async_sym);
+      err = fn(
+          batch_dsts.data(),
+          batch_srcs.data(),
+          batch_sizes.data(),
+          num_copies,
+          &attrs,
+          attrs_idxs.data(),
+          1,
+          stream);
+    } else {
+      using FnV12 = cudaError_t (*)(void**, void**, size_t*, size_t,
+                                    cudaMemcpyAttributes*, size_t*, size_t, size_t*, cudaStream_t);
+      auto fn = reinterpret_cast<FnV12>(cuda_memcpy_batch_async_sym);
+      size_t fail_idx = std::numeric_limits<size_t>::max();
+      err = fn(
+          batch_dsts.data(),
+          batch_srcs.data(),
+          batch_sizes.data(),
+          num_copies,
+          &attrs,
+          attrs_idxs.data(),
+          1,
+          &fail_idx,
+          stream);
+    }
     if (err == cudaErrorNotSupported || err == cudaErrorCallRequiresNewerDriver) {
       fallback_to_page_copy();
       return;
@@ -939,26 +952,6 @@ inline void transfer_kv_page_first_direct_impl(
     if (err != cudaSuccess) {
       TORCH_CHECK(false, "cudaMemcpyBatchAsync failed. error=", cudaGetErrorString(err));
     }
-#else
-    size_t fail_idx = std::numeric_limits<size_t>::max();
-    cudaError_t err = cuda_memcpy_batch_async(
-        batch_dsts.data(),
-        batch_srcs.data(),
-        batch_sizes.data(),
-        num_copies,
-        &attrs,
-        attrs_idxs.data(),
-        1,
-        &fail_idx,
-        stream);
-    if (err == cudaErrorNotSupported || err == cudaErrorCallRequiresNewerDriver) {
-      fallback_to_page_copy();
-      return;
-    }
-    if (err != cudaSuccess) {
-      TORCH_CHECK(false, "cudaMemcpyBatchAsync failed. failIdx=", fail_idx, " error=", cudaGetErrorString(err));
-    }
-#endif
   }
 #endif
 }

--- a/sgl-kernel/csrc/kvcacheio/transfer.cu
+++ b/sgl-kernel/csrc/kvcacheio/transfer.cu
@@ -817,14 +817,17 @@ inline void transfer_kv_page_first_direct_impl(
   // not the host driver — a cu12 runtime on a cu13 driver host (common in
   // containers) still exposes the 9-param v12 signature. Dispatching on the
   // driver version here would segfault in that case (verified empirically).
-  // Use cudaRuntimeGetVersion so the signature follows the runtime.
-  int runtime_version = 0;
-  cudaError_t runtime_version_err = cudaRuntimeGetVersion(&runtime_version);
+  // Use cudaRuntimeGetVersion so the signature follows the runtime. The
+  // runtime version is process-constant, so cache the query (static init is
+  // thread-safe in C++11+) to keep the KV-transfer hot path free of a redundant
+  // runtime API call per invocation.
+  static int runtime_version = 0;
+  static cudaError_t runtime_version_err = cudaRuntimeGetVersion(&runtime_version);
   if (runtime_version_err != cudaSuccess) {
     fallback_to_page_copy();
     return;
   }
-  const bool use_v13_signature = runtime_version >= 13000;
+  static const bool use_v13_signature = runtime_version >= 13000;
 
   size_t num_copies = 0;
   std::vector<void*> batch_srcs;
@@ -928,32 +931,32 @@ inline void transfer_kv_page_first_direct_impl(
     cudaError_t err;
     size_t fail_idx = std::numeric_limits<size_t>::max();
     if (use_v13_signature) {
-      using FnV13 = cudaError_t (*)(void *const *, const void *const *, const size_t *, size_t,
-                                    cudaMemcpyAttributes*, size_t*, size_t, cudaStream_t);
+      using FnV13 = cudaError_t (*)(
+          void* const*,
+          const void* const*,
+          const size_t*,
+          size_t,
+          cudaMemcpyAttributes*,
+          size_t*,
+          size_t,
+          cudaStream_t);
       auto fn = reinterpret_cast<FnV13>(cuda_memcpy_batch_async_sym);
       err = fn(
-          batch_dsts.data(),
-          batch_srcs.data(),
-          batch_sizes.data(),
-          num_copies,
-          &attrs,
-          attrs_idxs.data(),
-          1,
-          stream);
+          batch_dsts.data(), batch_srcs.data(), batch_sizes.data(), num_copies, &attrs, attrs_idxs.data(), 1, stream);
     } else {
-      using FnV12 = cudaError_t (*)(void**, void**, size_t*, size_t,
-                                    cudaMemcpyAttributes*, size_t*, size_t, size_t*, cudaStream_t);
+      using FnV12 = cudaError_t (*)(
+          void**, void**, size_t*, size_t, cudaMemcpyAttributes*, size_t*, size_t, size_t*, cudaStream_t);
       auto fn = reinterpret_cast<FnV12>(cuda_memcpy_batch_async_sym);
-      err = fn(
-          batch_dsts.data(),
-          batch_srcs.data(),
-          batch_sizes.data(),
-          num_copies,
-          &attrs,
-          attrs_idxs.data(),
-          1,
-          &fail_idx,
-          stream);
+      err =
+          fn(batch_dsts.data(),
+             batch_srcs.data(),
+             batch_sizes.data(),
+             num_copies,
+             &attrs,
+             attrs_idxs.data(),
+             1,
+             &fail_idx,
+             stream);
     }
     if (err == cudaErrorNotSupported || err == cudaErrorCallRequiresNewerDriver) {
       fallback_to_page_copy();


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

CUDA 13.0 removed the `failIdx` parameter from `cudaMemcpyBatchAsync` (8 params), but the code was using the CUDA 12.8 signature (9 params) via `dlsym`. This caused the `stream` argument to be misaligned — the runtime received a stack pointer as the CUDA stream handle, resulting in a segfault inside `cuMemcpyBatchAsync_v2`.

Fixed by using runtime `driver_version` detection to select the correct function signature, ensuring binary portability across CUDA 12.8 and 13.0 environments.

This may not be the optimal approach — the main intent of this PR is to identify the root cause of the segfault and provide a working fix.                                      

cc @alisonshao @Fridge003

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

### Environment

| Item | Value |
|------|-------|
| GPU | NVIDIA H200 x8 |
| Driver | 580.126.09 |
| CUDA | 13.0 |
| PyTorch | 2.9.1+cu130 |
| nvcc | 13.0, V13.0.88 |

### Result

All 192 tests in `sgl-kernel/tests/test_kvcacheio.py` pass. Previously crashed at `test_transfer_kv_pf_direct` (~37%).

Before (segfault at the first `test_transfer_kv_pf_direct` case, ~37%):
```
sgl-kernel/tests/test_kvcacheio.py::test_transfer_kv_pf_direct[False-False-20480-256-16-128-dtype0]
!!!!!!! Segfault encountered !!!!!!!
  File "<unknown>", line 0, in cuMemcpyBatchAsync_v2
  File "<unknown>", line 0, in cudaMemcpyBatchAsync
  File "<unknown>", line 0, in void transfer_kv_page_first_direct_impl<false>(...)
```

After (192/192 passed):
```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0

sgl-kernel/tests/test_kvcacheio.py::test_transfer_kv[False-False-10240-256-1-1-dtype0] PASSED [  0%]
...
sgl-kernel/tests/test_kvcacheio.py::test_transfer_kv_pf_direct[False-False-20480-256-16-128-dtype0] PASSED [ 38%]  <-- previously segfaulted here
...
sgl-kernel/tests/test_kvcacheio.py::test_transfer_kv_page_head[True-4096-16-1024-128-1024-dtype1] PASSED [100%]

======================= 192 passed in 239.86s (0:03:59) ========================
```


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
