### PR TITLE
Fix cross-package import in LoRA test utils; add lint guard

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,6 +75,13 @@ repos:
         files: ^python/sglang/multimodal_gen/.*
         exclude: ^(python/sglang/multimodal_gen/configs/sample|python/sglang/multimodal_gen/apps/ComfyUI_SGLDiffusion/workflows|python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages)(/|$)
         types_or: [python, markdown, json, text]
+      - id: check-no-multimodal-gen-imports-in-srt
+        name: prohibit sglang.multimodal_gen imports in srt/test
+        entry: >-
+          python3 -c 'import sys, re; p=re.compile(r"^\s*(?:from\s+sglang\.multimodal_gen(?![\w])|import\s+sglang\.multimodal_gen(?![\w]))"); ec=0; [ ([(print(f"{f}:{i+1}: {l.rstrip()}") or (ec:=1)) for i,l in enumerate(open(f, "r", encoding="utf-8", errors="replace")) if p.search(l)]) for f in sys.argv[1:] ]; sys.exit(ec)'
+        language: system
+        files: ^python/sglang/(srt|test)/.*\.py$
+        types: [python]
       - id: sort-ci-permissions
         name: sort CI_PERMISSIONS.json
         entry: python3 .github/update_ci_permission.py --sort-only

--- a/python/sglang/test/lora_utils.py
+++ b/python/sglang/test/lora_utils.py
@@ -670,8 +670,7 @@ def create_multiple_batch_test_samples(
     prompts: List[str], lora_adapter_paths: List[str]
 ):
     random.seed(42)
-    from sglang.multimodal_gen.runtime.utils.common import get_bool_env_var
-    from sglang.srt.utils.common import is_hip
+    from sglang.srt.utils.common import get_bool_env_var, is_hip
 
     _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and is_hip()
 


### PR DESCRIPTION
## Summary

- `python/sglang/test/lora_utils.py` was importing `get_bool_env_var` from `sglang.multimodal_gen.runtime.utils.common`, causing srt-side LoRA tests to crash in environments that don't ship `multimodal_gen`. The symbol also lives in `sglang.srt.utils.common` — where `is_hip` is already imported on the next line — so consolidate both into a single import.
- Add a local pre-commit hook `check-no-multimodal-gen-imports-in-srt` that fails if any file under `python/sglang/{srt,test}/` imports from `sglang.multimodal_gen`. This encodes the layering invariant: `srt` and `test` must not depend on `multimodal_gen`; the reverse is fine and expected, since `multimodal_gen` builds on `srt`. Modeled on the existing `check-chinese-characters` local hook.

Pre-fix boundary audit:
- `sglang.srt` → `sglang.multimodal_gen`: 0 imports
- `sglang.test` → `sglang.multimodal_gen`: 1 import (the bug)
- `sglang.multimodal_gen` → `sglang.srt`: 39 imports across 23 files (expected)

`sglang.cli` is intentionally outside the hook's scope since it legitimately dispatches to both.

## Test plan

- [x] `pre-commit run --all-files` passes on the repo.
- [x] Hook empirically catches seeded violations (`from sglang.multimodal_gen.X`, `import sglang.multimodal_gen.X`) with `file:line: <offending line>` output and exit 1.
- [x] Hook correctly **ignores** hypothetical sibling packages like `sglang.multimodal_gen_v2` (regex uses `(?![\w])` boundary).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)