### PR TITLE
[Docker] Add opt-in DOCA rdma-core upgrade to fix NCCL alltoall/sendrecv on Mellanox HCAs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -132,6 +132,43 @@ RUN if [ -n "${PIP_DEFAULT_INDEX}" ]; then \
     python3 -m pip config set global.index-url ${PIP_DEFAULT_INDEX}; \
 fi
 
+# ============== DOCA / MLNX_OFED userspace upgrade (opt-in) ==============
+# Ubuntu 24.04's distro rdma-core (50.0-2ubuntu0.2) ships a libmlx5 that
+# does NOT export mlx5dv_reg_dmabuf_mr. NCCL >= 2.27 needs that symbol for
+# the dmabuf MR-registration path used by alltoall / scatter / sendrecv
+# and any CUMEM/VMM-backed buffer sent across NICs. Without it NCCL
+# silently falls back via dlvsym, then later fails with
+# IBV_WC_LOC_PROT_ERR (vendor_err=81) on cross-rack traffic on Mellanox HCAs.
+#
+# DOCA 3.2.2 LTS ships rdma-core 25.10 which exports MLX5_1.25.
+# Disabled by default; enable on Mellanox-HCA hosts (Nebius GB300, DGX,
+# etc.) with:  --build-arg ENABLE_DOCA_RDMA=1
+# To pin a different DOCA release, override DOCA_REPO_URL_BASE.
+ARG ENABLE_DOCA_RDMA=0
+ARG DOCA_REPO_URL_BASE=https://linux.mellanox.com/public/repo/doca/3.2.2/ubuntu24.04
+ARG DOCA_REPO_KEY_URL=https://linux.mellanox.com/public/repo/doca/GPG-KEY-Mellanox.pub
+RUN if [ "${ENABLE_DOCA_RDMA}" = "1" ]; then set -eux; \
+      arch=$(uname -m); \
+      case "$arch" in \
+        aarch64) doca_arch=arm64-sbsa ;; \
+        x86_64)  doca_arch=x86_64 ;; \
+        *) echo "ENABLE_DOCA_RDMA: unsupported arch $arch" && exit 1 ;; \
+      esac; \
+      apt-get update -qq; \
+      apt-get install -y --no-install-recommends curl ca-certificates gnupg; \
+      curl -fsSL "${DOCA_REPO_KEY_URL}" \
+        | gpg --dearmor -o /etc/apt/trusted.gpg.d/mellanox.gpg; \
+      echo "deb [signed-by=/etc/apt/trusted.gpg.d/mellanox.gpg] ${DOCA_REPO_URL_BASE}/${doca_arch} ./" \
+        > /etc/apt/sources.list.d/doca.list; \
+      apt-get update; \
+      apt-get install -y --allow-change-held-packages \
+          rdma-core libibverbs1 libibverbs-dev ibverbs-providers \
+          libibumad3 libibmad5 libibnetdisc5 infiniband-diags; \
+      nm -D "/usr/lib/${arch}-linux-gnu/libmlx5.so.1" | grep -q mlx5dv_reg_dmabuf_mr; \
+      echo "OK: libmlx5 exports mlx5dv_reg_dmabuf_mr @ MLX5_1.25"; \
+      rm -rf /var/lib/apt/lists/*; \
+    fi
+
 # GDRCopy installation
 RUN mkdir -p /tmp/gdrcopy && cd /tmp \
     && curl --retry 3 --retry-delay 2 -fsSL -o v${GDRCOPY_VERSION}.tar.gz \
@@ -726,6 +763,35 @@ RUN --mount=type=cache,target=/var/cache/apt,id=runtime-apt \
     && python3 -m pip config set global.break-system-packages true \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
+
+# ============== DOCA / MLNX_OFED userspace upgrade (opt-in) ==============
+# Mirrors the block in the `base` stage. The `runtime` stage has its own
+# apt install of rdma-core / libibverbs1 / libmlx5 above, so the upgrade
+# must be reapplied here. See `base` stage for the rationale.
+ARG ENABLE_DOCA_RDMA=0
+ARG DOCA_REPO_URL_BASE=https://linux.mellanox.com/public/repo/doca/3.2.2/ubuntu24.04
+ARG DOCA_REPO_KEY_URL=https://linux.mellanox.com/public/repo/doca/GPG-KEY-Mellanox.pub
+RUN if [ "${ENABLE_DOCA_RDMA}" = "1" ]; then set -eux; \
+      arch=$(uname -m); \
+      case "$arch" in \
+        aarch64) doca_arch=arm64-sbsa ;; \
+        x86_64)  doca_arch=x86_64 ;; \
+        *) echo "ENABLE_DOCA_RDMA: unsupported arch $arch" && exit 1 ;; \
+      esac; \
+      apt-get update -qq; \
+      apt-get install -y --no-install-recommends curl ca-certificates gnupg; \
+      curl -fsSL "${DOCA_REPO_KEY_URL}" \
+        | gpg --dearmor -o /etc/apt/trusted.gpg.d/mellanox.gpg; \
+      echo "deb [signed-by=/etc/apt/trusted.gpg.d/mellanox.gpg] ${DOCA_REPO_URL_BASE}/${doca_arch} ./" \
+        > /etc/apt/sources.list.d/doca.list; \
+      apt-get update; \
+      apt-get install -y --allow-change-held-packages \
+          rdma-core libibverbs1 ibverbs-providers \
+          libibumad3 infiniband-diags; \
+      nm -D "/usr/lib/${arch}-linux-gnu/libmlx5.so.1" | grep -q mlx5dv_reg_dmabuf_mr; \
+      echo "OK: libmlx5 exports mlx5dv_reg_dmabuf_mr @ MLX5_1.25"; \
+      rm -rf /var/lib/apt/lists/*; \
+    fi
 
 # Set up locale
 RUN apt-get update && apt-get install -y --no-install-recommends locales \


### PR DESCRIPTION
## Problem

Ubuntu 24.04's distro `rdma-core` (`50.0-2ubuntu0.2`) ships a `libmlx5` that **does not export `mlx5dv_reg_dmabuf_mr`**. NCCL >= 2.27 needs that symbol for the dmabuf MR-registration path used by:

- `alltoall` / `scatter` / `sendrecv` collectives
- any CUMEM/VMM-backed buffer sent across NICs (e.g. PyTorch broadcast on registered buffers, RL frameworks doing weight update across racks)

When the symbol is missing, NCCL's `dlvsym` probe fails silently and falls back to a path that produces invalid MRs. The HCA reports those at completion time as `IBV_WC_LOC_PROT_ERR (vendor_err=81)`. On Mellanox HCAs at scale this manifests as `alltoall` / `scatter` / `sendrecv` hanging or crashing while `all_reduce` / `broadcast` / `gather` continue to work — a confusing partial-failure mode that's hard to attribute back to the image.

Original NCCL log line (from a real run on Nebius GB300):

\`\`\`
NCCL INFO dlvsym failed on mlx5dv_reg_dmabuf_mr -
  /lib/aarch64-linux-gnu/libmlx5.so: undefined symbol: mlx5dv_reg_dmabuf_mr,
  version MLX5_1.25
\`\`\`

Followed later in the same run by:

\`\`\`
NCCL WARN NET/IB: Got completion ... status=IBV_WC_LOC_PROT_ERR(4)
                  opcode=IBV_WC_SEND(0) vendor_err=81 hca mlx5_2
\`\`\`

## Fix

Adds an opt-in build arg \`ENABLE_DOCA_RDMA=1\` that swaps the distro \`rdma-core\` / \`libibverbs1\` / \`libmlx5\` / \`ibverbs-providers\` for the **DOCA 3.2.2 LTS** userspace builds (\`rdma-core 25.10\`, exports \`MLX5_1.25\`, supported through Feb 2029). The block is mirrored in the \`runtime\` stage since it does its own apt install.

- **Default is \`0\`** — behavior is unchanged for everyone else.
- Only userspace packages are installed; no DKMS / kernel modules (those need to come from the host).
- Works on both \64-sbsa\` and \`x86_64\`.
- \`DOCA_REPO_URL_BASE\` is overridable to pin a different DOCA release.
- Build-time \`nm | grep -q mlx5dv_reg_dmabuf_mr\` check fails the build if the symbol isn't present, so a successful build is provably one that fixes the issue.

## Usage

\`\`\`bash
docker buildx build \\
  --file docker/Dockerfile \\
  --target framework \\
  --build-arg ENABLE_DOCA_RDMA=1 \\
  --build-arg CUDA_VERSION=12.9.1 \\
  --build-arg SGL_VERSION=0.5.9 \\
  ...
\`\`\`

## Validation

End-to-end on Nebius GB300 (Grace + Blackwell, arm64-sbsa, 8 GPUs across 2 nodes):

- Verified \`nm -D /usr/lib/aarch64-linux-gnu/libmlx5.so.1 | grep mlx5dv_reg_dmabuf_mr\` returns the symbol at \`MLX5_1.25\` in the resulting image.
- Forced all NCCL traffic onto the IB path (\`NCCL_MNNVL_ENABLE=0\`, \`NCCL_NVLS_ENABLE=0\`, \`NCCL_P2P_DISABLE=1\`, \`NCCL_SHM_DISABLE=1\`, \`NCCL_DMABUF_ENABLE=1\`, \`NCCL_NET_GDR_LEVEL=PIX\`) so every send exercises \`mlx5dv_reg_dmabuf_mr\`.
- All channels routed through \`NET/IB/<n>/GDRDMA(PCI)\`.
- Stress phases (1000-iter broadcast + 200-iter \`all_to_all_single\` + 200-iter \`batch_isend_irecv\`) all completed with no \`LOC_PROT_ERR\` and no \`mlx5dv_reg_dmabuf_mr\` warnings.
- Same workload on the unpatched image reproduces the original \`FAIL(3)\` on \`alltoall\`/\`scatter\`/\`sendrecv\`.

## Notes for reviewers

- I deliberately kept this opt-in rather than changing the default. DOCA's userspace is backward-compatible with older kernel-side \`mlx5\` modules (it's a stable \`/dev/infiniband/uverbs*\` ABI), so flipping the default to \`1\` would also be safe — happy to do that in this PR if maintainers prefer.
- The change is purely additive; no existing layers are modified, so cached builds without the flag are unaffected.