### PR TITLE
[AMD] Enable EAGLE speculative decoding for Qwen3.5 FP8 and MXFP4 models with aiter's unified attention

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -151,9 +151,12 @@ def _scatter_req_to_token_to_page_table_kernel(
     page_table_ptr,
     req_to_token_stride,
     page_table_stride,
+    sw_page_table_ptr,
+    swa_slot_mapping_ptr,
     DRAFT_NUM: tl.constexpr,
     PAGE_SIZE: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
+    HAS_SWA: tl.constexpr,
 ):
     """Build the 2D block-level page_table for target_verify directly from
     req_to_token by sampling at PAGE_SIZE stride for rows [0, num_blocks).
@@ -184,6 +187,15 @@ def _scatter_req_to_token_to_page_table_kernel(
         block_vals,
         mask=mask,
     )
+
+    if HAS_SWA:
+        sw_vals = tl.load(swa_slot_mapping_ptr + vals)
+        block_vals = sw_vals // PAGE_SIZE
+        tl.store(
+            sw_page_table_ptr + pid.to(tl.int64) * page_table_stride + offsets,
+            block_vals,
+            mask=mask,
+        )
 
 
 _AITER_PARTITION_SIZE_ROCM = 256
@@ -628,6 +640,7 @@ class AiterAttnBackend(AttentionBackend):
         req_pool_indices: torch.Tensor,
         draft_num: int,
         page_table_dest: Optional[torch.Tensor] = None,
+        swa_page_table_dest: Optional[torch.Tensor] = None,
     ):
         """Build the 2D block page_table + qo_indptr for EAGLE target_verify
         through unified_attention. Assumes the new draft K/V have already been
@@ -648,10 +661,23 @@ class AiterAttnBackend(AttentionBackend):
         page_size = self.page_size
         max_blocks = (self.max_context_len + page_size - 1) // page_size
 
+        swa_slot_mapping = None
+        swa_page_table = None
+
         if page_table_dest is not None:
             page_table = page_table_dest
         else:
             page_table = torch.zeros(bs, max_blocks, dtype=torch.int32, device=device)
+
+        if self.use_sliding_window_kv_pool:
+            swa_slot_mapping = self.token_to_kv_pool.full_to_swa_index_mapping.long()
+
+            if swa_page_table_dest is not None:
+                swa_page_table = swa_page_table_dest
+            else:
+                swa_page_table = torch.zeros(
+                    bs, max_blocks, dtype=torch.int32, device=device
+                )
 
         BLOCK_SIZE = 1024
         grid = (bs, triton.cdiv(max(max_blocks, 1), BLOCK_SIZE))
@@ -662,12 +688,15 @@ class AiterAttnBackend(AttentionBackend):
             page_table,
             self.req_to_token.stride(0),
             page_table.stride(0),
+            swa_page_table,
+            swa_slot_mapping,
             DRAFT_NUM=draft_num,
             PAGE_SIZE=page_size,
             BLOCK_SIZE=BLOCK_SIZE,
+            HAS_SWA=(swa_slot_mapping is not None),
         )
 
-        return page_table, qo_indptr, draft_num
+        return page_table, qo_indptr, draft_num, swa_page_table
 
     def _resolve_v2_num_draft_tokens(
         self,
@@ -1230,7 +1259,7 @@ class AiterAttnBackend(AttentionBackend):
                 draft_num = spec_info.draft_token_num
 
                 if self._use_unified_verify:
-                    page_table, qo_indptr, max_q_len = (
+                    page_table, qo_indptr, max_q_len, swa_page_table = (
                         self._build_verify_unified_metadata(
                             bs,
                             forward_batch.seq_lens,
@@ -1247,6 +1276,7 @@ class AiterAttnBackend(AttentionBackend):
                         max_q_len,
                         max_kv_len,
                         max_extend_len=max_q_len,
+                        swa_page_table=swa_page_table,
                     )
                 else:
                     qo_indptr = torch.arange(
@@ -1704,13 +1734,22 @@ class AiterAttnBackend(AttentionBackend):
                     page_table = self.cuda_graph_kv_indices.view(
                         -1, max_num_blocks_per_seq
                     )[:bs]
-                    _page_table, _qo_indptr, _max_q_len = (
+
+                    swa_page_table = None
+
+                    if self.use_sliding_window_kv_pool:
+                        swa_page_table = self.cuda_graph_swa_page_table.view(
+                            -1, max_num_blocks_per_seq
+                        )[:bs]
+
+                    _page_table, _qo_indptr, _max_q_len, _swa_page_table = (
                         self._build_verify_unified_metadata(
                             bs,
                             seq_lens,
                             req_pool_indices,
                             self.num_draft_tokens,
                             page_table_dest=page_table,
+                            swa_page_table_dest=swa_page_table,
                         )
                     )
                     max_kv_len = max_num_blocks_per_seq * self.page_size
@@ -1722,6 +1761,7 @@ class AiterAttnBackend(AttentionBackend):
                         _max_q_len,
                         max_kv_len,
                         max_extend_len=_max_q_len,
+                        swa_page_table=_swa_page_table,
                     )
                 else:
                     custom_mask = self.cuda_graph_custom_mask
@@ -2124,15 +2164,25 @@ class AiterAttnBackend(AttentionBackend):
                     page_table = self.cuda_graph_kv_indices.view(
                         -1, max_num_blocks_per_seq
                     )[:bs]
-                    _page_table, _qo_indptr, _max_q_len = (
+
+                    swa_page_table = None
+
+                    if self.use_sliding_window_kv_pool:
+                        swa_page_table = self.cuda_graph_swa_page_table.view(
+                            -1, max_num_blocks_per_seq
+                        )[:bs]
+
+                    _page_table, _qo_indptr, _max_q_len, _swa_page_table = (
                         self._build_verify_unified_metadata(
                             bs,
                             seq_lens,
                             req_pool_indices,
                             self.num_draft_tokens,
                             page_table_dest=page_table,
+                            swa_page_table_dest=swa_page_table,
                         )
                     )
+
                     max_kv_len_unified = max_num_blocks_per_seq * self.page_size
                     self.forward_metadata = ForwardMetadata(
                         None,
@@ -2142,6 +2192,7 @@ class AiterAttnBackend(AttentionBackend):
                         _max_q_len,
                         max_kv_len_unified,
                         max_extend_len=_max_q_len,
+                        swa_page_table=_swa_page_table,
                     )
                 else:
                     custom_mask = self.cuda_graph_custom_mask
@@ -2648,6 +2699,17 @@ class AiterAttnBackend(AttentionBackend):
                     )
                     page_table = self.forward_metadata.kv_indices
                     max_kv_len = page_table.shape[1] * self.page_size
+
+                    window_size = (-1, -1)
+
+                    if (
+                        layer.sliding_window_size is not None
+                        and layer.sliding_window_size > -1
+                    ):
+                        window_size = (layer.sliding_window_size - 1, 0)
+                        if self.forward_metadata.swa_page_table is not None:
+                            page_table = self.forward_metadata.swa_page_table
+
                     # The seq_lens + draft_num add has to run INSIDE the graph
                     # region; a host-side pre-add would allocate a new tensor
                     # each replay and break the captured pointer.
@@ -2666,7 +2728,7 @@ class AiterAttnBackend(AttentionBackend):
                         max_seqlen_k=max_kv_len,
                         softmax_scale=layer.scaling,
                         causal=True,
-                        window_size=(-1, -1),
+                        window_size=window_size,
                         block_table=page_table,
                         softcap=layer.logit_cap,
                         q_descale=None,

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import triton
+import triton.language as tl
 
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.utils import (
@@ -106,6 +107,85 @@ class ForwardMetadata:
 
 global_workspace_buffer = None
 
+
+@triton.jit
+def _scatter_ragged_to_page_table_kernel(
+    kv_flat_ptr,
+    kv_indptr_ptr,
+    dest_ptr,
+    dest_stride,
+    PAGE_SIZE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Scatter ragged token-level kv_indices into a 2D block-level page table.
+    Output columns store block indices (token_id // PAGE_SIZE); per-request
+    row length is ceil(kv_len / PAGE_SIZE). Only writes rows [0, num_blocks);
+    `unified_attention` bounds reads by seqused_k, so the tail is never read.
+    """
+    pid = tl.program_id(0)
+    block_id = tl.program_id(1)
+
+    start = tl.load(kv_indptr_ptr + pid).to(tl.int64)
+    kv_len = tl.load(kv_indptr_ptr + pid + 1).to(tl.int64) - start
+    num_blocks = (kv_len + PAGE_SIZE - 1) // PAGE_SIZE
+
+    offsets = block_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    if block_id * BLOCK_SIZE >= num_blocks:
+        return
+    mask = offsets < num_blocks
+    token_idx = offsets.to(tl.int64) * PAGE_SIZE
+    vals = tl.load(kv_flat_ptr + start + token_idx, mask=mask, other=0)
+    block_vals = vals // PAGE_SIZE
+    tl.store(
+        dest_ptr + pid.to(tl.int64) * dest_stride + offsets,
+        block_vals,
+        mask=mask,
+    )
+
+
+@triton.jit
+def _scatter_req_to_token_to_page_table_kernel(
+    req_to_token_ptr,
+    req_pool_indices_ptr,
+    seq_lens_ptr,
+    page_table_ptr,
+    req_to_token_stride,
+    page_table_stride,
+    DRAFT_NUM: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Build the 2D block-level page_table for target_verify directly from
+    req_to_token by sampling at PAGE_SIZE stride for rows [0, num_blocks).
+    Avoids a (bs * max_context_len) int32 intermediate scratch buffer.
+    """
+    pid = tl.program_id(0)
+    block_id = tl.program_id(1)
+
+    seq_len = tl.load(seq_lens_ptr + pid).to(tl.int64)
+    kv_len = seq_len + DRAFT_NUM
+    num_blocks = (kv_len + PAGE_SIZE - 1) // PAGE_SIZE
+
+    offsets = block_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    if block_id * BLOCK_SIZE >= num_blocks:
+        return
+    mask = offsets < num_blocks
+
+    rp = tl.load(req_pool_indices_ptr + pid).to(tl.int64)
+    token_idx = offsets.to(tl.int64) * PAGE_SIZE
+    vals = tl.load(
+        req_to_token_ptr + rp * req_to_token_stride + token_idx,
+        mask=mask,
+        other=0,
+    )
+    block_vals = vals // PAGE_SIZE
+    tl.store(
+        page_table_ptr + pid.to(tl.int64) * page_table_stride + offsets,
+        block_vals,
+        mask=mask,
+    )
+
+
 _AITER_PARTITION_SIZE_ROCM = 256
 
 
@@ -179,6 +259,11 @@ class AiterAttnBackend(AttentionBackend):
         self.qo_indptr = torch.zeros(
             (max_bs + 1,), dtype=torch.int32, device=model_runner.device
         )
+        # qo_indptr for the unified-attn decode path (q_len == 1 per request)
+        # is always arange(0, bs+1); precompute once to avoid a per-step cumsum.
+        self.qo_indptr_unified_decode = torch.arange(
+            0, max_bs + 1, dtype=torch.int32, device=model_runner.device
+        )
         self.mask_indptr = torch.zeros(
             (max_bs + 1,), dtype=torch.int64, device=model_runner.device
         )
@@ -207,6 +292,17 @@ class AiterAttnBackend(AttentionBackend):
             self.use_triton_unified_attention = get_bool_env_var(
                 "SGLANG_USE_AITER_UNIFIED_ATTN"
             )
+
+        # When topk == 1 the EAGLE draft chain is linear, so target_verify's
+        # mask reduces to pure causal and can go through unified_attention
+        # instead of the legacy triton extend_attention_fwd. Gated on non-MLA
+        # (MLA has its own verify path) and env var for opt-out.
+        self._use_unified_verify = (
+            self.use_triton_unified_attention
+            and not self.use_mla
+            and self.topk == 1
+            and get_bool_env_var("SGLANG_AITER_UNIFIED_VERIFY", "1")
+        )
 
         # aiter kernel related initialization
         self.max_num_partitions = (
@@ -485,6 +581,94 @@ class AiterAttnBackend(AttentionBackend):
         )
         return page_table[:, strided_indices] // page_size
 
+    def _build_unified_page_table_from_spec(
+        self,
+        spec_info,
+        bs: int,
+        dest_buf: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Convert ragged (token-level) kv_indices from spec_info into a 2D
+        block-level page_table of shape (bs, max_num_blocks_per_seq).
+        unified_attention expects max_seqlen_k = page_table.shape[1] *
+        page_size to be a captured constant, so rows are sized to the
+        backend-level max_num_blocks_per_seq regardless of seqused_k.
+        """
+        kv_indptr = spec_info.kv_indptr
+        kv_flat = spec_info.kv_indices
+        page_size = self.page_size
+        max_blocks = (self.max_context_len + page_size - 1) // page_size
+
+        if dest_buf is not None:
+            # The scatter kernel fills [0, num_blocks) and loads past that use
+            # other=0, so the tail is 0-filled. Under graph replay rows > bs
+            # are stale but unified_attention only walks rows [0, bs).
+            page_table = dest_buf
+        else:
+            page_table = torch.zeros(
+                bs, max_blocks, dtype=torch.int32, device=self.device
+            )
+
+        BLOCK_SIZE = 1024
+        grid = (bs, triton.cdiv(max(max_blocks, 1), BLOCK_SIZE))
+        _scatter_ragged_to_page_table_kernel[grid](
+            kv_flat,
+            kv_indptr,
+            page_table,
+            page_table.stride(0),
+            PAGE_SIZE=page_size,
+            BLOCK_SIZE=BLOCK_SIZE,
+        )
+
+        return page_table
+
+    def _build_verify_unified_metadata(
+        self,
+        bs: int,
+        seq_lens: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+        draft_num: int,
+        page_table_dest: Optional[torch.Tensor] = None,
+    ):
+        """Build the 2D block page_table + qo_indptr for EAGLE target_verify
+        through unified_attention. Assumes the new draft K/V have already been
+        written by set_kv_buffer, so req_to_token[rp, :seq_lens[i]+draft_num]
+        covers both the prefix and the freshly committed draft tokens. Returns
+        (page_table, qo_indptr, max_q_len=draft_num).
+        """
+        device = seq_lens.device
+        qo_indptr = self.qo_indptr[: bs + 1]
+        qo_indptr[: bs + 1] = torch.arange(
+            0,
+            (1 + bs) * draft_num,
+            step=draft_num,
+            dtype=torch.int32,
+            device=device,
+        )
+
+        page_size = self.page_size
+        max_blocks = (self.max_context_len + page_size - 1) // page_size
+
+        if page_table_dest is not None:
+            page_table = page_table_dest
+        else:
+            page_table = torch.zeros(bs, max_blocks, dtype=torch.int32, device=device)
+
+        BLOCK_SIZE = 1024
+        grid = (bs, triton.cdiv(max(max_blocks, 1), BLOCK_SIZE))
+        _scatter_req_to_token_to_page_table_kernel[grid](
+            self.req_to_token,
+            req_pool_indices,
+            seq_lens,
+            page_table,
+            self.req_to_token.stride(0),
+            page_table.stride(0),
+            DRAFT_NUM=draft_num,
+            PAGE_SIZE=page_size,
+            BLOCK_SIZE=BLOCK_SIZE,
+        )
+
+        return page_table, qo_indptr, draft_num
+
     def _resolve_v2_num_draft_tokens(
         self,
         extend_seq_lens: Optional[torch.Tensor] = None,
@@ -729,14 +913,18 @@ class AiterAttnBackend(AttentionBackend):
                     elif self.page_size > 1:
                         kv_indices = self._transform_table_1_to_real(kv_indices)
 
-                    qo_indptr = self.qo_indptr[: bs + 1]
-                    qo_indptr[1 : bs + 1] = torch.cumsum(
-                        self.kv_last_page_len[:bs], dim=0
-                    )
+                    qo_indptr = self.qo_indptr_unified_decode[: bs + 1]
 
             else:
-                kv_indptr, kv_indices = spec_info.kv_indptr, spec_info.kv_indices
-                bs = kv_indptr.shape[0] - 1
+                if self.use_triton_unified_attention and not self.use_mla:
+                    bs = spec_info.kv_indptr.shape[0] - 1
+                    kv_indices = self._build_unified_page_table_from_spec(spec_info, bs)
+                    max_q_len = 1
+                    qo_indptr = self.qo_indptr_unified_decode[: bs + 1]
+                    kv_indptr = None
+                else:
+                    kv_indptr, kv_indices = spec_info.kv_indptr, spec_info.kv_indices
+                    bs = kv_indptr.shape[0] - 1
 
             if self.use_mla:
                 qo_indptr = self.qo_indptr_[: bs + 1]
@@ -1038,51 +1226,70 @@ class AiterAttnBackend(AttentionBackend):
                     run_graph=False,
                 )
             else:
-                # Non-MLA target_verify: use triton extend kernel with custom mask
                 bs = len(forward_batch.req_pool_indices)
                 draft_num = spec_info.draft_token_num
 
-                qo_indptr = torch.arange(
-                    0,
-                    (1 + bs) * draft_num,
-                    step=draft_num,
-                    dtype=torch.int32,
-                    device=self.device,
-                )
+                if self._use_unified_verify:
+                    page_table, qo_indptr, max_q_len = (
+                        self._build_verify_unified_metadata(
+                            bs,
+                            forward_batch.seq_lens,
+                            forward_batch.req_pool_indices,
+                            draft_num,
+                        )
+                    )
+                    max_kv_len = page_table.shape[1] * self.page_size
+                    self.forward_metadata = ForwardMetadata(
+                        None,  # kv_indptr unused in unified-verify path
+                        page_table,  # 2D block page_table stored in kv_indices
+                        qo_indptr,
+                        None,
+                        max_q_len,
+                        max_kv_len,
+                        max_extend_len=max_q_len,
+                    )
+                else:
+                    qo_indptr = torch.arange(
+                        0,
+                        (1 + bs) * draft_num,
+                        step=draft_num,
+                        dtype=torch.int32,
+                        device=self.device,
+                    )
 
-                kv_indptr[1 : bs + 1] = torch.cumsum(forward_batch.seq_lens, dim=0)
-                kv_indptr = kv_indptr[: bs + 1]
+                    kv_indptr[1 : bs + 1] = torch.cumsum(forward_batch.seq_lens, dim=0)
+                    kv_indptr = kv_indptr[: bs + 1]
 
-                kv_indices = torch.empty(
-                    kv_indptr[-1], dtype=torch.int64, device=self.device
-                )
-                create_flashinfer_kv_indices_triton[(bs,)](
-                    self.req_to_token,
-                    forward_batch.req_pool_indices,
-                    forward_batch.seq_lens,
-                    kv_indptr,
-                    None,
-                    kv_indices,
-                    self.req_to_token.stride(0),
-                )
+                    kv_indices = torch.empty(
+                        kv_indptr[-1], dtype=torch.int64, device=self.device
+                    )
+                    create_flashinfer_kv_indices_triton[(bs,)](
+                        self.req_to_token,
+                        forward_batch.req_pool_indices,
+                        forward_batch.seq_lens,
+                        kv_indptr,
+                        None,
+                        kv_indices,
+                        self.req_to_token.stride(0),
+                    )
 
-                custom_mask = spec_info.custom_mask
-                seq_mask_len = draft_num * (forward_batch.seq_lens + draft_num)
-                mask_indptr = self.mask_indptr
-                mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len[:bs], dim=0)
-                mask_indptr = mask_indptr[: bs + 1]
+                    custom_mask = spec_info.custom_mask
+                    seq_mask_len = draft_num * (forward_batch.seq_lens + draft_num)
+                    mask_indptr = self.mask_indptr
+                    mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len[:bs], dim=0)
+                    mask_indptr = mask_indptr[: bs + 1]
 
-                self.forward_metadata = ForwardMetadata(
-                    kv_indptr,
-                    kv_indices,
-                    qo_indptr,
-                    None,
-                    draft_num,
-                    None,
-                    custom_mask=custom_mask,
-                    mask_indptr=mask_indptr,
-                    max_extend_len=draft_num,
-                )
+                    self.forward_metadata = ForwardMetadata(
+                        kv_indptr,
+                        kv_indices,
+                        qo_indptr,
+                        None,
+                        draft_num,
+                        None,
+                        custom_mask=custom_mask,
+                        mask_indptr=mask_indptr,
+                        max_extend_len=draft_num,
+                    )
         else:
             prefix_lens = forward_batch.extend_prefix_lens
 
@@ -1281,7 +1488,12 @@ class AiterAttnBackend(AttentionBackend):
             kv_last_page_len = None
             max_q_len = None
 
-            if spec_info is None:
+            if spec_info is None or (
+                self.use_triton_unified_attention and not self.use_mla
+            ):
+                max_num_blocks_per_seq = (
+                    self.max_context_len + self.page_size - 1
+                ) // self.page_size
 
                 if not self.use_triton_unified_attention:
                     kv_indptr = self.kv_indptr
@@ -1299,43 +1511,44 @@ class AiterAttnBackend(AttentionBackend):
                     )
                 else:
                     max_q_len = 1
-                    max_num_blocks_per_seq = (
-                        self.max_context_len + self.page_size - 1
-                    ) // self.page_size
                     kv_indices = self.cuda_graph_kv_indices.view(
                         -1, max_num_blocks_per_seq
                     )
 
-                    page_indices = self.req_to_token[req_pool_indices[:bs], :max_kv_len]
+                    if spec_info is not None:
+                        self._build_unified_page_table_from_spec(
+                            spec_info, bs, dest_buf=kv_indices
+                        )
+                    else:
+                        page_indices = self.req_to_token[
+                            req_pool_indices[:bs], :max_kv_len
+                        ]
 
-                    if self.use_sliding_window_kv_pool:
-                        swa_page_indices = (
-                            self.token_to_kv_pool.translate_loc_from_full_to_swa(
-                                page_indices
+                        if self.use_sliding_window_kv_pool:
+                            swa_page_indices = (
+                                self.token_to_kv_pool.translate_loc_from_full_to_swa(
+                                    page_indices
+                                )
                             )
-                        )
 
-                        page_indices = self._transform_table_1_to_real(page_indices)
-                        swa_page_indices = self._transform_table_1_to_real(
-                            swa_page_indices
-                        )
+                            page_indices = self._transform_table_1_to_real(page_indices)
+                            swa_page_indices = self._transform_table_1_to_real(
+                                swa_page_indices
+                            )
 
-                        new_rows = swa_page_indices.shape[0]
-                        new_cols = swa_page_indices.shape[1]
+                            new_rows = swa_page_indices.shape[0]
+                            new_cols = swa_page_indices.shape[1]
 
-                        kv_indices[:new_rows, :new_cols].copy_(page_indices)
-                        swa_page_table = self.cuda_graph_swa_page_table
-                        swa_page_table[:new_rows, :new_cols].copy_(swa_page_indices)
-                    elif self.page_size > 1:
-                        page_indices = self._transform_table_1_to_real(page_indices)
-                        new_rows = page_indices.shape[0]
-                        new_cols = page_indices.shape[1]
-                        kv_indices[:new_rows, :new_cols].copy_(page_indices)
+                            kv_indices[:new_rows, :new_cols].copy_(page_indices)
+                            swa_page_table = self.cuda_graph_swa_page_table
+                            swa_page_table[:new_rows, :new_cols].copy_(swa_page_indices)
+                        elif self.page_size > 1:
+                            page_indices = self._transform_table_1_to_real(page_indices)
+                            new_rows = page_indices.shape[0]
+                            new_cols = page_indices.shape[1]
+                            kv_indices[:new_rows, :new_cols].copy_(page_indices)
 
-                    qo_indptr = self.qo_indptr[: bs + 1]
-                    qo_indptr[1 : bs + 1] = torch.cumsum(
-                        self.cuda_graph_kv_last_page_len[:bs], dim=0
-                    )
+                    qo_indptr = self.qo_indptr_unified_decode[: bs + 1]
 
                     kv_indptr = None
             else:
@@ -1466,24 +1679,53 @@ class AiterAttnBackend(AttentionBackend):
                     num_kv_splits=num_kv_splits,
                 )
             else:
-                custom_mask = self.cuda_graph_custom_mask
-                custom_mask[: spec_info.custom_mask.shape[0]] = spec_info.custom_mask
-                seq_mask_len = max_q_len * (seq_lens + max_q_len)
-                mask_indptr = self.mask_indptr
-                mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len[:bs], dim=0)
-                mask_indptr = mask_indptr[: bs + 1]
+                if self._use_unified_verify:
+                    max_num_blocks_per_seq = (
+                        self.max_context_len + self.page_size - 1
+                    ) // self.page_size
+                    page_table = self.cuda_graph_kv_indices.view(
+                        -1, max_num_blocks_per_seq
+                    )[:bs]
+                    _page_table, _qo_indptr, _max_q_len = (
+                        self._build_verify_unified_metadata(
+                            bs,
+                            seq_lens,
+                            req_pool_indices,
+                            self.num_draft_tokens,
+                            page_table_dest=page_table,
+                        )
+                    )
+                    max_kv_len = max_num_blocks_per_seq * self.page_size
+                    self.forward_metadata = ForwardMetadata(
+                        None,
+                        _page_table,
+                        _qo_indptr,
+                        kv_last_page_len,
+                        _max_q_len,
+                        max_kv_len,
+                        max_extend_len=_max_q_len,
+                    )
+                else:
+                    custom_mask = self.cuda_graph_custom_mask
+                    custom_mask[: spec_info.custom_mask.shape[0]] = (
+                        spec_info.custom_mask
+                    )
+                    seq_mask_len = max_q_len * (seq_lens + max_q_len)
+                    mask_indptr = self.mask_indptr
+                    mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len[:bs], dim=0)
+                    mask_indptr = mask_indptr[: bs + 1]
 
-                self.forward_metadata = ForwardMetadata(
-                    kv_indptr,
-                    kv_indices,
-                    qo_indptr,
-                    kv_last_page_len,
-                    max_q_len,
-                    max_kv_len,
-                    custom_mask=custom_mask,
-                    mask_indptr=mask_indptr,
-                    max_extend_len=max_q_len,
-                )
+                    self.forward_metadata = ForwardMetadata(
+                        kv_indptr,
+                        kv_indices,
+                        qo_indptr,
+                        kv_last_page_len,
+                        max_q_len,
+                        max_kv_len,
+                        custom_mask=custom_mask,
+                        mask_indptr=mask_indptr,
+                        max_extend_len=max_q_len,
+                    )
         elif forward_mode.is_draft_extend_v2():
             # EAGLE V2: Uses fixed num_draft_tokens per batch
             self._ensure_spec_v2_topk_supported()
@@ -1664,7 +1906,13 @@ class AiterAttnBackend(AttentionBackend):
             kv_last_page_len = None
             max_q_len = None
 
-            if spec_info is None:
+            if spec_info is None or (
+                self.use_triton_unified_attention and not self.use_mla
+            ):
+                max_num_blocks_per_seq = (
+                    self.max_context_len + self.page_size - 1
+                ) // self.page_size
+
                 if not self.use_triton_unified_attention:
                     kv_indptr = self.kv_indptr
                     kv_indptr[1 : bs + 1] = torch.cumsum(seq_lens, dim=0)
@@ -1681,43 +1929,44 @@ class AiterAttnBackend(AttentionBackend):
                     )
                 else:
                     max_q_len = 1
-                    max_num_blocks_per_seq = (
-                        self.max_context_len + self.page_size - 1
-                    ) // self.page_size
                     kv_indices = self.cuda_graph_kv_indices.view(
                         -1, max_num_blocks_per_seq
                     )
 
-                    page_indices = self.req_to_token[req_pool_indices[:bs], :max_kv_len]
+                    if spec_info is not None:
+                        self._build_unified_page_table_from_spec(
+                            spec_info, bs, dest_buf=kv_indices
+                        )
+                    else:
+                        page_indices = self.req_to_token[
+                            req_pool_indices[:bs], :max_kv_len
+                        ]
 
-                    if self.use_sliding_window_kv_pool:
-                        swa_page_indices = (
-                            self.token_to_kv_pool.translate_loc_from_full_to_swa(
-                                page_indices
+                        if self.use_sliding_window_kv_pool:
+                            swa_page_indices = (
+                                self.token_to_kv_pool.translate_loc_from_full_to_swa(
+                                    page_indices
+                                )
                             )
-                        )
 
-                        page_indices = self._transform_table_1_to_real(page_indices)
-                        swa_page_indices = self._transform_table_1_to_real(
-                            swa_page_indices
-                        )
+                            page_indices = self._transform_table_1_to_real(page_indices)
+                            swa_page_indices = self._transform_table_1_to_real(
+                                swa_page_indices
+                            )
 
-                        new_rows = swa_page_indices.shape[0]
-                        new_cols = swa_page_indices.shape[1]
+                            new_rows = swa_page_indices.shape[0]
+                            new_cols = swa_page_indices.shape[1]
 
-                        kv_indices[:new_rows, :new_cols].copy_(page_indices)
-                        swa_page_table = self.cuda_graph_swa_page_table
-                        swa_page_table[:new_rows, :new_cols].copy_(swa_page_indices)
-                    elif self.page_size > 1:
-                        page_indices = self._transform_table_1_to_real(page_indices)
-                        new_rows = page_indices.shape[0]
-                        new_cols = page_indices.shape[1]
-                        kv_indices[:new_rows, :new_cols].copy_(page_indices)
+                            kv_indices[:new_rows, :new_cols].copy_(page_indices)
+                            swa_page_table = self.cuda_graph_swa_page_table
+                            swa_page_table[:new_rows, :new_cols].copy_(swa_page_indices)
+                        elif self.page_size > 1:
+                            page_indices = self._transform_table_1_to_real(page_indices)
+                            new_rows = page_indices.shape[0]
+                            new_cols = page_indices.shape[1]
+                            kv_indices[:new_rows, :new_cols].copy_(page_indices)
 
-                    qo_indptr = self.qo_indptr[: bs + 1]
-                    qo_indptr[1 : bs + 1] = torch.cumsum(
-                        self.cuda_graph_kv_last_page_len[:bs], dim=0
-                    )
+                    qo_indptr = self.qo_indptr_unified_decode[: bs + 1]
 
                     kv_indptr = None
             else:
@@ -1850,23 +2099,52 @@ class AiterAttnBackend(AttentionBackend):
                     num_kv_splits=num_kv_splits,
                 )
             else:
-                custom_mask = self.cuda_graph_custom_mask
-                custom_mask[: spec_info.custom_mask.shape[0]] = spec_info.custom_mask
-                seq_mask_len = max_q_len * (seq_lens + max_q_len)
-                mask_indptr = self.mask_indptr[: bs + 1]
-                mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len, dim=0)
+                if self._use_unified_verify:
+                    max_num_blocks_per_seq = (
+                        self.max_context_len + self.page_size - 1
+                    ) // self.page_size
+                    page_table = self.cuda_graph_kv_indices.view(
+                        -1, max_num_blocks_per_seq
+                    )[:bs]
+                    _page_table, _qo_indptr, _max_q_len = (
+                        self._build_verify_unified_metadata(
+                            bs,
+                            seq_lens,
+                            req_pool_indices,
+                            self.num_draft_tokens,
+                            page_table_dest=page_table,
+                        )
+                    )
+                    max_kv_len_unified = max_num_blocks_per_seq * self.page_size
+                    self.forward_metadata = ForwardMetadata(
+                        None,
+                        _page_table,
+                        _qo_indptr,
+                        kv_last_page_len,
+                        _max_q_len,
+                        max_kv_len_unified,
+                        max_extend_len=_max_q_len,
+                    )
+                else:
+                    custom_mask = self.cuda_graph_custom_mask
+                    custom_mask[: spec_info.custom_mask.shape[0]] = (
+                        spec_info.custom_mask
+                    )
+                    seq_mask_len = max_q_len * (seq_lens + max_q_len)
+                    mask_indptr = self.mask_indptr[: bs + 1]
+                    mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len, dim=0)
 
-                self.forward_metadata = ForwardMetadata(
-                    kv_indptr,
-                    kv_indices,
-                    qo_indptr,
-                    kv_last_page_len,
-                    max_q_len,
-                    max_kv_len,
-                    custom_mask=custom_mask,
-                    mask_indptr=mask_indptr,
-                    max_extend_len=max_q_len,
-                )
+                    self.forward_metadata = ForwardMetadata(
+                        kv_indptr,
+                        kv_indices,
+                        qo_indptr,
+                        kv_last_page_len,
+                        max_q_len,
+                        max_kv_len,
+                        custom_mask=custom_mask,
+                        mask_indptr=mask_indptr,
+                        max_extend_len=max_q_len,
+                    )
         elif forward_mode.is_draft_extend_v2():
             # EAGLE V2: Fixed num_draft_tokens per batch
             self._ensure_spec_v2_topk_supported()
@@ -2333,13 +2611,52 @@ class AiterAttnBackend(AttentionBackend):
                 forward_batch.forward_mode.is_target_verify()
                 or forward_batch.forward_mode.is_draft_extend()
             ):
-                # Use triton extend kernel which supports custom masks and causal masking
                 if layer.qk_head_dim != layer.v_head_dim:
                     o = q.new_empty(
                         (q.shape[0], layer.tp_q_head_num * layer.v_head_dim)
                     )
                 else:
                     o = torch.empty_like(q)
+
+                # target_verify goes through unified_attention when topk == 1
+                # (the linear draft chain gives a pure causal mask). MLA and
+                # draft_extend still use the legacy extend_attention_fwd path.
+                if (
+                    self._use_unified_verify
+                    and forward_batch.forward_mode.is_target_verify()
+                ):
+                    k_cache, v_cache = forward_batch.token_to_kv_pool.get_kv_buffer(
+                        layer.layer_id
+                    )
+                    page_table = self.forward_metadata.kv_indices
+                    max_kv_len = page_table.shape[1] * self.page_size
+                    # The seq_lens + draft_num add has to run INSIDE the graph
+                    # region; a host-side pre-add would allocate a new tensor
+                    # each replay and break the captured pointer.
+                    unified_attention(
+                        q=q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
+                        k=k_cache.view(
+                            -1, self.page_size, layer.tp_k_head_num, layer.qk_head_dim
+                        ),
+                        v=v_cache.view(
+                            -1, self.page_size, layer.tp_v_head_num, layer.v_head_dim
+                        ),
+                        out=o.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
+                        cu_seqlens_q=self.forward_metadata.qo_indptr,
+                        seqused_k=forward_batch.seq_lens + self.num_draft_tokens,
+                        max_seqlen_q=self.forward_metadata.max_q_len,
+                        max_seqlen_k=max_kv_len,
+                        softmax_scale=layer.scaling,
+                        causal=True,
+                        window_size=(-1, -1),
+                        block_table=page_table,
+                        softcap=layer.logit_cap,
+                        q_descale=None,
+                        k_descale=k_descale,
+                        v_descale=v_descale,
+                        sinks=sinks,
+                    )
+                    return o.view(-1, layer.tp_q_head_num * layer.v_head_dim)
 
                 self.extend_attention_fwd(
                     q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -114,8 +114,11 @@ def _scatter_ragged_to_page_table_kernel(
     kv_indptr_ptr,
     dest_ptr,
     dest_stride,
+    sw_page_table_ptr,
+    swa_slot_mapping_ptr,
     PAGE_SIZE: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
+    HAS_SWA: tl.constexpr,
 ):
     """Scatter ragged token-level kv_indices into a 2D block-level page table.
     Output columns store block indices (token_id // PAGE_SIZE); per-request
@@ -141,6 +144,15 @@ def _scatter_ragged_to_page_table_kernel(
         block_vals,
         mask=mask,
     )
+
+    if HAS_SWA:
+        sw_vals = tl.load(swa_slot_mapping_ptr + vals)
+        block_vals = sw_vals // PAGE_SIZE
+        tl.store(
+            sw_page_table_ptr + pid.to(tl.int64) * dest_stride + offsets,
+            block_vals,
+            mask=mask,
+        )
 
 
 @triton.jit
@@ -598,6 +610,7 @@ class AiterAttnBackend(AttentionBackend):
         spec_info,
         bs: int,
         dest_buf: Optional[torch.Tensor] = None,
+        swa_dest_buf: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Convert ragged (token-level) kv_indices from spec_info into a 2D
         block-level page_table of shape (bs, max_num_blocks_per_seq).
@@ -610,6 +623,9 @@ class AiterAttnBackend(AttentionBackend):
         page_size = self.page_size
         max_blocks = (self.max_context_len + page_size - 1) // page_size
 
+        swa_slot_mapping = None
+        swa_page_table = None
+
         if dest_buf is not None:
             # The scatter kernel fills [0, num_blocks) and loads past that use
             # other=0, so the tail is 0-filled. Under graph replay rows > bs
@@ -620,6 +636,16 @@ class AiterAttnBackend(AttentionBackend):
                 bs, max_blocks, dtype=torch.int32, device=self.device
             )
 
+        if self.use_sliding_window_kv_pool:
+            swa_slot_mapping = self.token_to_kv_pool.full_to_swa_index_mapping.long()
+
+            if swa_dest_buf is not None:
+                swa_page_table = swa_dest_buf
+            else:
+                swa_page_table = torch.zeros(
+                    bs, max_blocks, dtype=torch.int32, device=self.device
+                )
+
         BLOCK_SIZE = 1024
         grid = (bs, triton.cdiv(max(max_blocks, 1), BLOCK_SIZE))
         _scatter_ragged_to_page_table_kernel[grid](
@@ -627,11 +653,14 @@ class AiterAttnBackend(AttentionBackend):
             kv_indptr,
             page_table,
             page_table.stride(0),
+            swa_page_table,
+            swa_slot_mapping,
             PAGE_SIZE=page_size,
             BLOCK_SIZE=BLOCK_SIZE,
+            HAS_SWA=(swa_slot_mapping is not None),
         )
 
-        return page_table
+        return page_table, swa_page_table
 
     def _build_verify_unified_metadata(
         self,
@@ -947,13 +976,27 @@ class AiterAttnBackend(AttentionBackend):
             else:
                 if self.use_triton_unified_attention and not self.use_mla:
                     bs = spec_info.kv_indptr.shape[0] - 1
-                    kv_indices = self._build_unified_page_table_from_spec(spec_info, bs)
+                    kv_indices, swa_page_table = (
+                        self._build_unified_page_table_from_spec(spec_info, bs)
+                    )
                     max_q_len = 1
                     qo_indptr = self.qo_indptr_unified_decode[: bs + 1]
                     kv_indptr = None
                 else:
                     kv_indptr, kv_indices = spec_info.kv_indptr, spec_info.kv_indices
                     bs = kv_indptr.shape[0] - 1
+
+                    if self.use_sliding_window_kv_pool:
+                        swa_page_table = (
+                            self.token_to_kv_pool.translate_loc_from_full_to_swa(
+                                kv_indices
+                            )
+                        )
+
+                        kv_indices = self._transform_table_1_to_real(kv_indices)
+                        swa_page_table = self._transform_table_1_to_real(swa_page_table)
+                    else:
+                        kv_indices = self._transform_table_1_to_real(kv_indices)
 
             if self.use_mla:
                 qo_indptr = self.qo_indptr_[: bs + 1]
@@ -1563,9 +1606,15 @@ class AiterAttnBackend(AttentionBackend):
                         -1, max_num_blocks_per_seq
                     )
 
+                    if self.use_sliding_window_kv_pool:
+                        swa_page_table = self.cuda_graph_swa_page_table
+
                     if spec_info is not None:
                         self._build_unified_page_table_from_spec(
-                            spec_info, bs, dest_buf=kv_indices
+                            spec_info,
+                            bs,
+                            dest_buf=kv_indices,
+                            swa_dest_buf=swa_page_table,
                         )
                     else:
                         page_indices = self.req_to_token[
@@ -1991,9 +2040,15 @@ class AiterAttnBackend(AttentionBackend):
                         -1, max_num_blocks_per_seq
                     )
 
+                    if self.use_sliding_window_kv_pool:
+                        swa_page_table = self.cuda_graph_swa_page_table
+
                     if spec_info is not None:
                         self._build_unified_page_table_from_spec(
-                            spec_info, bs, dest_buf=kv_indices
+                            spec_info,
+                            bs,
+                            dest_buf=kv_indices,
+                            swa_dest_buf=swa_page_table,
                         )
                     else:
                         page_indices = self.req_to_token[

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -151,9 +151,12 @@ def _scatter_req_to_token_to_page_table_kernel(
     page_table_ptr,
     req_to_token_stride,
     page_table_stride,
+    sw_page_table_ptr,
+    swa_slot_mapping_ptr,
     DRAFT_NUM: tl.constexpr,
     PAGE_SIZE: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
+    HAS_SWA: tl.constexpr,
 ):
     """Build the 2D block-level page_table for target_verify directly from
     req_to_token by sampling at PAGE_SIZE stride for rows [0, num_blocks).
@@ -184,6 +187,15 @@ def _scatter_req_to_token_to_page_table_kernel(
         block_vals,
         mask=mask,
     )
+
+    if HAS_SWA:
+        sw_vals = tl.load(swa_slot_mapping_ptr + vals)
+        block_vals = sw_vals // PAGE_SIZE
+        tl.store(
+            sw_page_table_ptr + pid.to(tl.int64) * page_table_stride + offsets,
+            block_vals,
+            mask=mask,
+        )
 
 
 _AITER_PARTITION_SIZE_ROCM = 256
@@ -628,6 +640,7 @@ class AiterAttnBackend(AttentionBackend):
         req_pool_indices: torch.Tensor,
         draft_num: int,
         page_table_dest: Optional[torch.Tensor] = None,
+        swa_page_table_dest: Optional[torch.Tensor] = None,
     ):
         """Build the 2D block page_table + qo_indptr for EAGLE target_verify
         through unified_attention. Assumes the new draft K/V have already been
@@ -648,10 +661,23 @@ class AiterAttnBackend(AttentionBackend):
         page_size = self.page_size
         max_blocks = (self.max_context_len + page_size - 1) // page_size
 
+        swa_slot_mapping = None
+        swa_page_table = None
+
         if page_table_dest is not None:
             page_table = page_table_dest
         else:
             page_table = torch.zeros(bs, max_blocks, dtype=torch.int32, device=device)
+
+        if self.use_sliding_window_kv_pool:
+            swa_slot_mapping = self.token_to_kv_pool.full_to_swa_index_mapping.long()
+
+            if swa_page_table_dest is not None:
+                swa_page_table = swa_page_table_dest
+            else:
+                swa_page_table = torch.zeros(
+                    bs, max_blocks, dtype=torch.int32, device=device
+                )
 
         BLOCK_SIZE = 1024
         grid = (bs, triton.cdiv(max(max_blocks, 1), BLOCK_SIZE))
@@ -662,12 +688,15 @@ class AiterAttnBackend(AttentionBackend):
             page_table,
             self.req_to_token.stride(0),
             page_table.stride(0),
+            swa_page_table,
+            swa_slot_mapping,
             DRAFT_NUM=draft_num,
             PAGE_SIZE=page_size,
             BLOCK_SIZE=BLOCK_SIZE,
+            HAS_SWA=(swa_slot_mapping is not None),
         )
 
-        return page_table, qo_indptr, draft_num
+        return page_table, qo_indptr, draft_num, swa_page_table
 
     def _resolve_v2_num_draft_tokens(
         self,
@@ -1230,7 +1259,7 @@ class AiterAttnBackend(AttentionBackend):
                 draft_num = spec_info.draft_token_num
 
                 if self._use_unified_verify:
-                    page_table, qo_indptr, max_q_len = (
+                    page_table, qo_indptr, max_q_len, swa_page_table = (
                         self._build_verify_unified_metadata(
                             bs,
                             forward_batch.seq_lens,
@@ -1247,6 +1276,7 @@ class AiterAttnBackend(AttentionBackend):
                         max_q_len,
                         max_kv_len,
                         max_extend_len=max_q_len,
+                        swa_page_table=swa_page_table,
                     )
                 else:
                     qo_indptr = torch.arange(
@@ -1686,13 +1716,22 @@ class AiterAttnBackend(AttentionBackend):
                     page_table = self.cuda_graph_kv_indices.view(
                         -1, max_num_blocks_per_seq
                     )[:bs]
-                    _page_table, _qo_indptr, _max_q_len = (
+
+                    swa_page_table = None
+
+                    if self.use_sliding_window_kv_pool:
+                        swa_page_table = self.cuda_graph_swa_page_table.view(
+                            -1, max_num_blocks_per_seq
+                        )[:bs]
+
+                    _page_table, _qo_indptr, _max_q_len, _swa_page_table = (
                         self._build_verify_unified_metadata(
                             bs,
                             seq_lens,
                             req_pool_indices,
                             self.num_draft_tokens,
                             page_table_dest=page_table,
+                            swa_page_table_dest=swa_page_table,
                         )
                     )
                     max_kv_len = max_num_blocks_per_seq * self.page_size
@@ -1704,6 +1743,7 @@ class AiterAttnBackend(AttentionBackend):
                         _max_q_len,
                         max_kv_len,
                         max_extend_len=_max_q_len,
+                        swa_page_table=_swa_page_table,
                     )
                 else:
                     custom_mask = self.cuda_graph_custom_mask
@@ -2106,15 +2146,25 @@ class AiterAttnBackend(AttentionBackend):
                     page_table = self.cuda_graph_kv_indices.view(
                         -1, max_num_blocks_per_seq
                     )[:bs]
-                    _page_table, _qo_indptr, _max_q_len = (
+
+                    swa_page_table = None
+
+                    if self.use_sliding_window_kv_pool:
+                        swa_page_table = self.cuda_graph_swa_page_table.view(
+                            -1, max_num_blocks_per_seq
+                        )[:bs]
+
+                    _page_table, _qo_indptr, _max_q_len, _swa_page_table = (
                         self._build_verify_unified_metadata(
                             bs,
                             seq_lens,
                             req_pool_indices,
                             self.num_draft_tokens,
                             page_table_dest=page_table,
+                            swa_page_table_dest=swa_page_table,
                         )
                     )
+
                     max_kv_len_unified = max_num_blocks_per_seq * self.page_size
                     self.forward_metadata = ForwardMetadata(
                         None,
@@ -2124,6 +2174,7 @@ class AiterAttnBackend(AttentionBackend):
                         _max_q_len,
                         max_kv_len_unified,
                         max_extend_len=_max_q_len,
+                        swa_page_table=_swa_page_table,
                     )
                 else:
                     custom_mask = self.cuda_graph_custom_mask
@@ -2630,6 +2681,17 @@ class AiterAttnBackend(AttentionBackend):
                     )
                     page_table = self.forward_metadata.kv_indices
                     max_kv_len = page_table.shape[1] * self.page_size
+
+                    window_size = (-1, -1)
+
+                    if (
+                        layer.sliding_window_size is not None
+                        and layer.sliding_window_size > -1
+                    ):
+                        window_size = (layer.sliding_window_size - 1, 0)
+                        if self.forward_metadata.swa_page_table is not None:
+                            page_table = self.forward_metadata.swa_page_table
+
                     # The seq_lens + draft_num add has to run INSIDE the graph
                     # region; a host-side pre-add would allocate a new tensor
                     # each replay and break the captured pointer.
@@ -2648,7 +2710,7 @@ class AiterAttnBackend(AttentionBackend):
                         max_seqlen_k=max_kv_len,
                         softmax_scale=layer.scaling,
                         causal=True,
-                        window_size=(-1, -1),
+                        window_size=window_size,
                         block_table=page_table,
                         softcap=layer.logit_cap,
                         q_descale=None,

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import triton
+import triton.language as tl
 
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.utils import (
@@ -106,6 +107,85 @@ class ForwardMetadata:
 
 global_workspace_buffer = None
 
+
+@triton.jit
+def _scatter_ragged_to_page_table_kernel(
+    kv_flat_ptr,
+    kv_indptr_ptr,
+    dest_ptr,
+    dest_stride,
+    PAGE_SIZE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Scatter ragged token-level kv_indices into a 2D block-level page table.
+    Output columns store block indices (token_id // PAGE_SIZE); per-request
+    row length is ceil(kv_len / PAGE_SIZE). Only writes rows [0, num_blocks);
+    `unified_attention` bounds reads by seqused_k, so the tail is never read.
+    """
+    pid = tl.program_id(0)
+    block_id = tl.program_id(1)
+
+    start = tl.load(kv_indptr_ptr + pid).to(tl.int64)
+    kv_len = tl.load(kv_indptr_ptr + pid + 1).to(tl.int64) - start
+    num_blocks = (kv_len + PAGE_SIZE - 1) // PAGE_SIZE
+
+    offsets = block_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    if block_id * BLOCK_SIZE >= num_blocks:
+        return
+    mask = offsets < num_blocks
+    token_idx = offsets.to(tl.int64) * PAGE_SIZE
+    vals = tl.load(kv_flat_ptr + start + token_idx, mask=mask, other=0)
+    block_vals = vals // PAGE_SIZE
+    tl.store(
+        dest_ptr + pid.to(tl.int64) * dest_stride + offsets,
+        block_vals,
+        mask=mask,
+    )
+
+
+@triton.jit
+def _scatter_req_to_token_to_page_table_kernel(
+    req_to_token_ptr,
+    req_pool_indices_ptr,
+    seq_lens_ptr,
+    page_table_ptr,
+    req_to_token_stride,
+    page_table_stride,
+    DRAFT_NUM: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Build the 2D block-level page_table for target_verify directly from
+    req_to_token by sampling at PAGE_SIZE stride for rows [0, num_blocks).
+    Avoids a (bs * max_context_len) int32 intermediate scratch buffer.
+    """
+    pid = tl.program_id(0)
+    block_id = tl.program_id(1)
+
+    seq_len = tl.load(seq_lens_ptr + pid).to(tl.int64)
+    kv_len = seq_len + DRAFT_NUM
+    num_blocks = (kv_len + PAGE_SIZE - 1) // PAGE_SIZE
+
+    offsets = block_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    if block_id * BLOCK_SIZE >= num_blocks:
+        return
+    mask = offsets < num_blocks
+
+    rp = tl.load(req_pool_indices_ptr + pid).to(tl.int64)
+    token_idx = offsets.to(tl.int64) * PAGE_SIZE
+    vals = tl.load(
+        req_to_token_ptr + rp * req_to_token_stride + token_idx,
+        mask=mask,
+        other=0,
+    )
+    block_vals = vals // PAGE_SIZE
+    tl.store(
+        page_table_ptr + pid.to(tl.int64) * page_table_stride + offsets,
+        block_vals,
+        mask=mask,
+    )
+
+
 _AITER_PARTITION_SIZE_ROCM = 256
 
 
@@ -179,6 +259,11 @@ class AiterAttnBackend(AttentionBackend):
         self.qo_indptr = torch.zeros(
             (max_bs + 1,), dtype=torch.int32, device=model_runner.device
         )
+        # qo_indptr for the unified-attn decode path (q_len == 1 per request)
+        # is always arange(0, bs+1); precompute once to avoid a per-step cumsum.
+        self.qo_indptr_unified_decode = torch.arange(
+            0, max_bs + 1, dtype=torch.int32, device=model_runner.device
+        )
         self.mask_indptr = torch.zeros(
             (max_bs + 1,), dtype=torch.int64, device=model_runner.device
         )
@@ -207,6 +292,17 @@ class AiterAttnBackend(AttentionBackend):
             self.use_triton_unified_attention = get_bool_env_var(
                 "SGLANG_USE_AITER_UNIFIED_ATTN"
             )
+
+        # When topk == 1 the EAGLE draft chain is linear, so target_verify's
+        # mask reduces to pure causal and can go through unified_attention
+        # instead of the legacy triton extend_attention_fwd. Gated on non-MLA
+        # (MLA has its own verify path) and env var for opt-out.
+        self._use_unified_verify = (
+            self.use_triton_unified_attention
+            and not self.use_mla
+            and self.topk == 1
+            and get_bool_env_var("SGLANG_AITER_UNIFIED_VERIFY", "1")
+        )
 
         # aiter kernel related initialization
         self.max_num_partitions = (
@@ -485,6 +581,94 @@ class AiterAttnBackend(AttentionBackend):
         )
         return page_table[:, strided_indices] // page_size
 
+    def _build_unified_page_table_from_spec(
+        self,
+        spec_info,
+        bs: int,
+        dest_buf: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Convert ragged (token-level) kv_indices from spec_info into a 2D
+        block-level page_table of shape (bs, max_num_blocks_per_seq).
+        unified_attention expects max_seqlen_k = page_table.shape[1] *
+        page_size to be a captured constant, so rows are sized to the
+        backend-level max_num_blocks_per_seq regardless of seqused_k.
+        """
+        kv_indptr = spec_info.kv_indptr
+        kv_flat = spec_info.kv_indices
+        page_size = self.page_size
+        max_blocks = (self.max_context_len + page_size - 1) // page_size
+
+        if dest_buf is not None:
+            # The scatter kernel fills [0, num_blocks) and loads past that use
+            # other=0, so the tail is 0-filled. Under graph replay rows > bs
+            # are stale but unified_attention only walks rows [0, bs).
+            page_table = dest_buf
+        else:
+            page_table = torch.zeros(
+                bs, max_blocks, dtype=torch.int32, device=self.device
+            )
+
+        BLOCK_SIZE = 1024
+        grid = (bs, triton.cdiv(max(max_blocks, 1), BLOCK_SIZE))
+        _scatter_ragged_to_page_table_kernel[grid](
+            kv_flat,
+            kv_indptr,
+            page_table,
+            page_table.stride(0),
+            PAGE_SIZE=page_size,
+            BLOCK_SIZE=BLOCK_SIZE,
+        )
+
+        return page_table
+
+    def _build_verify_unified_metadata(
+        self,
+        bs: int,
+        seq_lens: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+        draft_num: int,
+        page_table_dest: Optional[torch.Tensor] = None,
+    ):
+        """Build the 2D block page_table + qo_indptr for EAGLE target_verify
+        through unified_attention. Assumes the new draft K/V have already been
+        written by set_kv_buffer, so req_to_token[rp, :seq_lens[i]+draft_num]
+        covers both the prefix and the freshly committed draft tokens. Returns
+        (page_table, qo_indptr, max_q_len=draft_num).
+        """
+        device = seq_lens.device
+        qo_indptr = self.qo_indptr[: bs + 1]
+        qo_indptr[: bs + 1] = torch.arange(
+            0,
+            (1 + bs) * draft_num,
+            step=draft_num,
+            dtype=torch.int32,
+            device=device,
+        )
+
+        page_size = self.page_size
+        max_blocks = (self.max_context_len + page_size - 1) // page_size
+
+        if page_table_dest is not None:
+            page_table = page_table_dest
+        else:
+            page_table = torch.zeros(bs, max_blocks, dtype=torch.int32, device=device)
+
+        BLOCK_SIZE = 1024
+        grid = (bs, triton.cdiv(max(max_blocks, 1), BLOCK_SIZE))
+        _scatter_req_to_token_to_page_table_kernel[grid](
+            self.req_to_token,
+            req_pool_indices,
+            seq_lens,
+            page_table,
+            self.req_to_token.stride(0),
+            page_table.stride(0),
+            DRAFT_NUM=draft_num,
+            PAGE_SIZE=page_size,
+            BLOCK_SIZE=BLOCK_SIZE,
+        )
+
+        return page_table, qo_indptr, draft_num
+
     def _resolve_v2_num_draft_tokens(
         self,
         extend_seq_lens: Optional[torch.Tensor] = None,
@@ -729,14 +913,18 @@ class AiterAttnBackend(AttentionBackend):
                     elif self.page_size > 1:
                         kv_indices = self._transform_table_1_to_real(kv_indices)
 
-                    qo_indptr = self.qo_indptr[: bs + 1]
-                    qo_indptr[1 : bs + 1] = torch.cumsum(
-                        self.kv_last_page_len[:bs], dim=0
-                    )
+                    qo_indptr = self.qo_indptr_unified_decode[: bs + 1]
 
             else:
-                kv_indptr, kv_indices = spec_info.kv_indptr, spec_info.kv_indices
-                bs = kv_indptr.shape[0] - 1
+                if self.use_triton_unified_attention and not self.use_mla:
+                    bs = spec_info.kv_indptr.shape[0] - 1
+                    kv_indices = self._build_unified_page_table_from_spec(spec_info, bs)
+                    max_q_len = 1
+                    qo_indptr = self.qo_indptr_unified_decode[: bs + 1]
+                    kv_indptr = None
+                else:
+                    kv_indptr, kv_indices = spec_info.kv_indptr, spec_info.kv_indices
+                    bs = kv_indptr.shape[0] - 1
 
             if self.use_mla:
                 qo_indptr = self.qo_indptr_[: bs + 1]
@@ -1038,51 +1226,70 @@ class AiterAttnBackend(AttentionBackend):
                     run_graph=False,
                 )
             else:
-                # Non-MLA target_verify: use triton extend kernel with custom mask
                 bs = len(forward_batch.req_pool_indices)
                 draft_num = spec_info.draft_token_num
 
-                qo_indptr = torch.arange(
-                    0,
-                    (1 + bs) * draft_num,
-                    step=draft_num,
-                    dtype=torch.int32,
-                    device=self.device,
-                )
+                if self._use_unified_verify:
+                    page_table, qo_indptr, max_q_len = (
+                        self._build_verify_unified_metadata(
+                            bs,
+                            forward_batch.seq_lens,
+                            forward_batch.req_pool_indices,
+                            draft_num,
+                        )
+                    )
+                    max_kv_len = page_table.shape[1] * self.page_size
+                    self.forward_metadata = ForwardMetadata(
+                        None,  # kv_indptr unused in unified-verify path
+                        page_table,  # 2D block page_table stored in kv_indices
+                        qo_indptr,
+                        None,
+                        max_q_len,
+                        max_kv_len,
+                        max_extend_len=max_q_len,
+                    )
+                else:
+                    qo_indptr = torch.arange(
+                        0,
+                        (1 + bs) * draft_num,
+                        step=draft_num,
+                        dtype=torch.int32,
+                        device=self.device,
+                    )
 
-                kv_indptr[1 : bs + 1] = torch.cumsum(forward_batch.seq_lens, dim=0)
-                kv_indptr = kv_indptr[: bs + 1]
+                    kv_indptr[1 : bs + 1] = torch.cumsum(forward_batch.seq_lens, dim=0)
+                    kv_indptr = kv_indptr[: bs + 1]
 
-                kv_indices = torch.empty(
-                    kv_indptr[-1], dtype=torch.int64, device=self.device
-                )
-                create_flashinfer_kv_indices_triton[(bs,)](
-                    self.req_to_token,
-                    forward_batch.req_pool_indices,
-                    forward_batch.seq_lens,
-                    kv_indptr,
-                    None,
-                    kv_indices,
-                    self.req_to_token.stride(0),
-                )
+                    kv_indices = torch.empty(
+                        kv_indptr[-1], dtype=torch.int64, device=self.device
+                    )
+                    create_flashinfer_kv_indices_triton[(bs,)](
+                        self.req_to_token,
+                        forward_batch.req_pool_indices,
+                        forward_batch.seq_lens,
+                        kv_indptr,
+                        None,
+                        kv_indices,
+                        self.req_to_token.stride(0),
+                    )
 
-                custom_mask = spec_info.custom_mask
-                seq_mask_len = draft_num * (forward_batch.seq_lens + draft_num)
-                mask_indptr = self.mask_indptr
-                mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len[:bs], dim=0)
-                mask_indptr = mask_indptr[: bs + 1]
+                    custom_mask = spec_info.custom_mask
+                    seq_mask_len = draft_num * (forward_batch.seq_lens + draft_num)
+                    mask_indptr = self.mask_indptr
+                    mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len[:bs], dim=0)
+                    mask_indptr = mask_indptr[: bs + 1]
 
-                self.forward_metadata = ForwardMetadata(
-                    kv_indptr,
-                    kv_indices,
-                    qo_indptr,
-                    None,
-                    draft_num,
-                    None,
-                    custom_mask=custom_mask,
-                    mask_indptr=mask_indptr,
-                    max_extend_len=draft_num,
-                )
+                    self.forward_metadata = ForwardMetadata(
+                        kv_indptr,
+                        kv_indices,
+                        qo_indptr,
+                        None,
+                        draft_num,
+                        None,
+                        custom_mask=custom_mask,
+                        mask_indptr=mask_indptr,
+                        max_extend_len=draft_num,
+                    )
         else:
             prefix_lens = forward_batch.extend_prefix_lens
 
@@ -1299,7 +1506,12 @@ class AiterAttnBackend(AttentionBackend):
             kv_last_page_len = None
             max_q_len = None
 
-            if spec_info is None:
+            if spec_info is None or (
+                self.use_triton_unified_attention and not self.use_mla
+            ):
+                max_num_blocks_per_seq = (
+                    self.max_context_len + self.page_size - 1
+                ) // self.page_size
 
                 if not self.use_triton_unified_attention:
                     kv_indptr = self.kv_indptr
@@ -1317,43 +1529,44 @@ class AiterAttnBackend(AttentionBackend):
                     )
                 else:
                     max_q_len = 1
-                    max_num_blocks_per_seq = (
-                        self.max_context_len + self.page_size - 1
-                    ) // self.page_size
                     kv_indices = self.cuda_graph_kv_indices.view(
                         -1, max_num_blocks_per_seq
                     )
 
-                    page_indices = self.req_to_token[req_pool_indices[:bs], :max_kv_len]
+                    if spec_info is not None:
+                        self._build_unified_page_table_from_spec(
+                            spec_info, bs, dest_buf=kv_indices
+                        )
+                    else:
+                        page_indices = self.req_to_token[
+                            req_pool_indices[:bs], :max_kv_len
+                        ]
 
-                    if self.use_sliding_window_kv_pool:
-                        swa_page_indices = (
-                            self.token_to_kv_pool.translate_loc_from_full_to_swa(
-                                page_indices
+                        if self.use_sliding_window_kv_pool:
+                            swa_page_indices = (
+                                self.token_to_kv_pool.translate_loc_from_full_to_swa(
+                                    page_indices
+                                )
                             )
-                        )
 
-                        page_indices = self._transform_table_1_to_real(page_indices)
-                        swa_page_indices = self._transform_table_1_to_real(
-                            swa_page_indices
-                        )
+                            page_indices = self._transform_table_1_to_real(page_indices)
+                            swa_page_indices = self._transform_table_1_to_real(
+                                swa_page_indices
+                            )
 
-                        new_rows = swa_page_indices.shape[0]
-                        new_cols = swa_page_indices.shape[1]
+                            new_rows = swa_page_indices.shape[0]
+                            new_cols = swa_page_indices.shape[1]
 
-                        kv_indices[:new_rows, :new_cols].copy_(page_indices)
-                        swa_page_table = self.cuda_graph_swa_page_table
-                        swa_page_table[:new_rows, :new_cols].copy_(swa_page_indices)
-                    elif self.page_size > 1:
-                        page_indices = self._transform_table_1_to_real(page_indices)
-                        new_rows = page_indices.shape[0]
-                        new_cols = page_indices.shape[1]
-                        kv_indices[:new_rows, :new_cols].copy_(page_indices)
+                            kv_indices[:new_rows, :new_cols].copy_(page_indices)
+                            swa_page_table = self.cuda_graph_swa_page_table
+                            swa_page_table[:new_rows, :new_cols].copy_(swa_page_indices)
+                        elif self.page_size > 1:
+                            page_indices = self._transform_table_1_to_real(page_indices)
+                            new_rows = page_indices.shape[0]
+                            new_cols = page_indices.shape[1]
+                            kv_indices[:new_rows, :new_cols].copy_(page_indices)
 
-                    qo_indptr = self.qo_indptr[: bs + 1]
-                    qo_indptr[1 : bs + 1] = torch.cumsum(
-                        self.cuda_graph_kv_last_page_len[:bs], dim=0
-                    )
+                    qo_indptr = self.qo_indptr_unified_decode[: bs + 1]
 
                     kv_indptr = None
             else:
@@ -1484,24 +1697,53 @@ class AiterAttnBackend(AttentionBackend):
                     num_kv_splits=num_kv_splits,
                 )
             else:
-                custom_mask = self.cuda_graph_custom_mask
-                custom_mask[: spec_info.custom_mask.shape[0]] = spec_info.custom_mask
-                seq_mask_len = max_q_len * (seq_lens + max_q_len)
-                mask_indptr = self.mask_indptr
-                mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len[:bs], dim=0)
-                mask_indptr = mask_indptr[: bs + 1]
+                if self._use_unified_verify:
+                    max_num_blocks_per_seq = (
+                        self.max_context_len + self.page_size - 1
+                    ) // self.page_size
+                    page_table = self.cuda_graph_kv_indices.view(
+                        -1, max_num_blocks_per_seq
+                    )[:bs]
+                    _page_table, _qo_indptr, _max_q_len = (
+                        self._build_verify_unified_metadata(
+                            bs,
+                            seq_lens,
+                            req_pool_indices,
+                            self.num_draft_tokens,
+                            page_table_dest=page_table,
+                        )
+                    )
+                    max_kv_len = max_num_blocks_per_seq * self.page_size
+                    self.forward_metadata = ForwardMetadata(
+                        None,
+                        _page_table,
+                        _qo_indptr,
+                        kv_last_page_len,
+                        _max_q_len,
+                        max_kv_len,
+                        max_extend_len=_max_q_len,
+                    )
+                else:
+                    custom_mask = self.cuda_graph_custom_mask
+                    custom_mask[: spec_info.custom_mask.shape[0]] = (
+                        spec_info.custom_mask
+                    )
+                    seq_mask_len = max_q_len * (seq_lens + max_q_len)
+                    mask_indptr = self.mask_indptr
+                    mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len[:bs], dim=0)
+                    mask_indptr = mask_indptr[: bs + 1]
 
-                self.forward_metadata = ForwardMetadata(
-                    kv_indptr,
-                    kv_indices,
-                    qo_indptr,
-                    kv_last_page_len,
-                    max_q_len,
-                    max_kv_len,
-                    custom_mask=custom_mask,
-                    mask_indptr=mask_indptr,
-                    max_extend_len=max_q_len,
-                )
+                    self.forward_metadata = ForwardMetadata(
+                        kv_indptr,
+                        kv_indices,
+                        qo_indptr,
+                        kv_last_page_len,
+                        max_q_len,
+                        max_kv_len,
+                        custom_mask=custom_mask,
+                        mask_indptr=mask_indptr,
+                        max_extend_len=max_q_len,
+                    )
         elif forward_mode.is_draft_extend_v2():
             # EAGLE V2: Uses fixed num_draft_tokens per batch
             self._ensure_spec_v2_topk_supported()
@@ -1682,7 +1924,13 @@ class AiterAttnBackend(AttentionBackend):
             kv_last_page_len = None
             max_q_len = None
 
-            if spec_info is None:
+            if spec_info is None or (
+                self.use_triton_unified_attention and not self.use_mla
+            ):
+                max_num_blocks_per_seq = (
+                    self.max_context_len + self.page_size - 1
+                ) // self.page_size
+
                 if not self.use_triton_unified_attention:
                     kv_indptr = self.kv_indptr
                     kv_indptr[1 : bs + 1] = torch.cumsum(seq_lens, dim=0)
@@ -1699,43 +1947,44 @@ class AiterAttnBackend(AttentionBackend):
                     )
                 else:
                     max_q_len = 1
-                    max_num_blocks_per_seq = (
-                        self.max_context_len + self.page_size - 1
-                    ) // self.page_size
                     kv_indices = self.cuda_graph_kv_indices.view(
                         -1, max_num_blocks_per_seq
                     )
 
-                    page_indices = self.req_to_token[req_pool_indices[:bs], :max_kv_len]
+                    if spec_info is not None:
+                        self._build_unified_page_table_from_spec(
+                            spec_info, bs, dest_buf=kv_indices
+                        )
+                    else:
+                        page_indices = self.req_to_token[
+                            req_pool_indices[:bs], :max_kv_len
+                        ]
 
-                    if self.use_sliding_window_kv_pool:
-                        swa_page_indices = (
-                            self.token_to_kv_pool.translate_loc_from_full_to_swa(
-                                page_indices
+                        if self.use_sliding_window_kv_pool:
+                            swa_page_indices = (
+                                self.token_to_kv_pool.translate_loc_from_full_to_swa(
+                                    page_indices
+                                )
                             )
-                        )
 
-                        page_indices = self._transform_table_1_to_real(page_indices)
-                        swa_page_indices = self._transform_table_1_to_real(
-                            swa_page_indices
-                        )
+                            page_indices = self._transform_table_1_to_real(page_indices)
+                            swa_page_indices = self._transform_table_1_to_real(
+                                swa_page_indices
+                            )
 
-                        new_rows = swa_page_indices.shape[0]
-                        new_cols = swa_page_indices.shape[1]
+                            new_rows = swa_page_indices.shape[0]
+                            new_cols = swa_page_indices.shape[1]
 
-                        kv_indices[:new_rows, :new_cols].copy_(page_indices)
-                        swa_page_table = self.cuda_graph_swa_page_table
-                        swa_page_table[:new_rows, :new_cols].copy_(swa_page_indices)
-                    elif self.page_size > 1:
-                        page_indices = self._transform_table_1_to_real(page_indices)
-                        new_rows = page_indices.shape[0]
-                        new_cols = page_indices.shape[1]
-                        kv_indices[:new_rows, :new_cols].copy_(page_indices)
+                            kv_indices[:new_rows, :new_cols].copy_(page_indices)
+                            swa_page_table = self.cuda_graph_swa_page_table
+                            swa_page_table[:new_rows, :new_cols].copy_(swa_page_indices)
+                        elif self.page_size > 1:
+                            page_indices = self._transform_table_1_to_real(page_indices)
+                            new_rows = page_indices.shape[0]
+                            new_cols = page_indices.shape[1]
+                            kv_indices[:new_rows, :new_cols].copy_(page_indices)
 
-                    qo_indptr = self.qo_indptr[: bs + 1]
-                    qo_indptr[1 : bs + 1] = torch.cumsum(
-                        self.cuda_graph_kv_last_page_len[:bs], dim=0
-                    )
+                    qo_indptr = self.qo_indptr_unified_decode[: bs + 1]
 
                     kv_indptr = None
             else:
@@ -1868,23 +2117,52 @@ class AiterAttnBackend(AttentionBackend):
                     num_kv_splits=num_kv_splits,
                 )
             else:
-                custom_mask = self.cuda_graph_custom_mask
-                custom_mask[: spec_info.custom_mask.shape[0]] = spec_info.custom_mask
-                seq_mask_len = max_q_len * (seq_lens + max_q_len)
-                mask_indptr = self.mask_indptr[: bs + 1]
-                mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len, dim=0)
+                if self._use_unified_verify:
+                    max_num_blocks_per_seq = (
+                        self.max_context_len + self.page_size - 1
+                    ) // self.page_size
+                    page_table = self.cuda_graph_kv_indices.view(
+                        -1, max_num_blocks_per_seq
+                    )[:bs]
+                    _page_table, _qo_indptr, _max_q_len = (
+                        self._build_verify_unified_metadata(
+                            bs,
+                            seq_lens,
+                            req_pool_indices,
+                            self.num_draft_tokens,
+                            page_table_dest=page_table,
+                        )
+                    )
+                    max_kv_len_unified = max_num_blocks_per_seq * self.page_size
+                    self.forward_metadata = ForwardMetadata(
+                        None,
+                        _page_table,
+                        _qo_indptr,
+                        kv_last_page_len,
+                        _max_q_len,
+                        max_kv_len_unified,
+                        max_extend_len=_max_q_len,
+                    )
+                else:
+                    custom_mask = self.cuda_graph_custom_mask
+                    custom_mask[: spec_info.custom_mask.shape[0]] = (
+                        spec_info.custom_mask
+                    )
+                    seq_mask_len = max_q_len * (seq_lens + max_q_len)
+                    mask_indptr = self.mask_indptr[: bs + 1]
+                    mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len, dim=0)
 
-                self.forward_metadata = ForwardMetadata(
-                    kv_indptr,
-                    kv_indices,
-                    qo_indptr,
-                    kv_last_page_len,
-                    max_q_len,
-                    max_kv_len,
-                    custom_mask=custom_mask,
-                    mask_indptr=mask_indptr,
-                    max_extend_len=max_q_len,
-                )
+                    self.forward_metadata = ForwardMetadata(
+                        kv_indptr,
+                        kv_indices,
+                        qo_indptr,
+                        kv_last_page_len,
+                        max_q_len,
+                        max_kv_len,
+                        custom_mask=custom_mask,
+                        mask_indptr=mask_indptr,
+                        max_extend_len=max_q_len,
+                    )
         elif forward_mode.is_draft_extend_v2():
             # EAGLE V2: Fixed num_draft_tokens per batch
             self._ensure_spec_v2_topk_supported()
@@ -2351,13 +2629,52 @@ class AiterAttnBackend(AttentionBackend):
                 forward_batch.forward_mode.is_target_verify()
                 or forward_batch.forward_mode.is_draft_extend()
             ):
-                # Use triton extend kernel which supports custom masks and causal masking
                 if layer.qk_head_dim != layer.v_head_dim:
                     o = q.new_empty(
                         (q.shape[0], layer.tp_q_head_num * layer.v_head_dim)
                     )
                 else:
                     o = torch.empty_like(q)
+
+                # target_verify goes through unified_attention when topk == 1
+                # (the linear draft chain gives a pure causal mask). MLA and
+                # draft_extend still use the legacy extend_attention_fwd path.
+                if (
+                    self._use_unified_verify
+                    and forward_batch.forward_mode.is_target_verify()
+                ):
+                    k_cache, v_cache = forward_batch.token_to_kv_pool.get_kv_buffer(
+                        layer.layer_id
+                    )
+                    page_table = self.forward_metadata.kv_indices
+                    max_kv_len = page_table.shape[1] * self.page_size
+                    # The seq_lens + draft_num add has to run INSIDE the graph
+                    # region; a host-side pre-add would allocate a new tensor
+                    # each replay and break the captured pointer.
+                    unified_attention(
+                        q=q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
+                        k=k_cache.view(
+                            -1, self.page_size, layer.tp_k_head_num, layer.qk_head_dim
+                        ),
+                        v=v_cache.view(
+                            -1, self.page_size, layer.tp_v_head_num, layer.v_head_dim
+                        ),
+                        out=o.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
+                        cu_seqlens_q=self.forward_metadata.qo_indptr,
+                        seqused_k=forward_batch.seq_lens + self.num_draft_tokens,
+                        max_seqlen_q=self.forward_metadata.max_q_len,
+                        max_seqlen_k=max_kv_len,
+                        softmax_scale=layer.scaling,
+                        causal=True,
+                        window_size=(-1, -1),
+                        block_table=page_table,
+                        softcap=layer.logit_cap,
+                        q_descale=None,
+                        k_descale=k_descale,
+                        v_descale=v_descale,
+                        sinks=sinks,
+                    )
+                    return o.view(-1, layer.tp_q_head_num * layer.v_head_dim)
 
                 self.extend_attention_fwd(
                     q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -114,8 +114,11 @@ def _scatter_ragged_to_page_table_kernel(
     kv_indptr_ptr,
     dest_ptr,
     dest_stride,
+    sw_page_table_ptr,
+    swa_slot_mapping_ptr,
     PAGE_SIZE: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
+    HAS_SWA: tl.constexpr,
 ):
     """Scatter ragged token-level kv_indices into a 2D block-level page table.
     Output columns store block indices (token_id // PAGE_SIZE); per-request
@@ -141,6 +144,15 @@ def _scatter_ragged_to_page_table_kernel(
         block_vals,
         mask=mask,
     )
+
+    if HAS_SWA:
+        sw_vals = tl.load(swa_slot_mapping_ptr + vals)
+        block_vals = sw_vals // PAGE_SIZE
+        tl.store(
+            sw_page_table_ptr + pid.to(tl.int64) * dest_stride + offsets,
+            block_vals,
+            mask=mask,
+        )
 
 
 @triton.jit
@@ -598,6 +610,7 @@ class AiterAttnBackend(AttentionBackend):
         spec_info,
         bs: int,
         dest_buf: Optional[torch.Tensor] = None,
+        swa_dest_buf: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Convert ragged (token-level) kv_indices from spec_info into a 2D
         block-level page_table of shape (bs, max_num_blocks_per_seq).
@@ -610,6 +623,9 @@ class AiterAttnBackend(AttentionBackend):
         page_size = self.page_size
         max_blocks = (self.max_context_len + page_size - 1) // page_size
 
+        swa_slot_mapping = None
+        swa_page_table = None
+
         if dest_buf is not None:
             # The scatter kernel fills [0, num_blocks) and loads past that use
             # other=0, so the tail is 0-filled. Under graph replay rows > bs
@@ -620,6 +636,16 @@ class AiterAttnBackend(AttentionBackend):
                 bs, max_blocks, dtype=torch.int32, device=self.device
             )
 
+        if self.use_sliding_window_kv_pool:
+            swa_slot_mapping = self.token_to_kv_pool.full_to_swa_index_mapping.long()
+
+            if swa_dest_buf is not None:
+                swa_page_table = swa_dest_buf
+            else:
+                swa_page_table = torch.zeros(
+                    bs, max_blocks, dtype=torch.int32, device=self.device
+                )
+
         BLOCK_SIZE = 1024
         grid = (bs, triton.cdiv(max(max_blocks, 1), BLOCK_SIZE))
         _scatter_ragged_to_page_table_kernel[grid](
@@ -627,11 +653,14 @@ class AiterAttnBackend(AttentionBackend):
             kv_indptr,
             page_table,
             page_table.stride(0),
+            swa_page_table,
+            swa_slot_mapping,
             PAGE_SIZE=page_size,
             BLOCK_SIZE=BLOCK_SIZE,
+            HAS_SWA=(swa_slot_mapping is not None),
         )
 
-        return page_table
+        return page_table, swa_page_table
 
     def _build_verify_unified_metadata(
         self,
@@ -947,13 +976,27 @@ class AiterAttnBackend(AttentionBackend):
             else:
                 if self.use_triton_unified_attention and not self.use_mla:
                     bs = spec_info.kv_indptr.shape[0] - 1
-                    kv_indices = self._build_unified_page_table_from_spec(spec_info, bs)
+                    kv_indices, swa_page_table = (
+                        self._build_unified_page_table_from_spec(spec_info, bs)
+                    )
                     max_q_len = 1
                     qo_indptr = self.qo_indptr_unified_decode[: bs + 1]
                     kv_indptr = None
                 else:
                     kv_indptr, kv_indices = spec_info.kv_indptr, spec_info.kv_indices
                     bs = kv_indptr.shape[0] - 1
+
+                    if self.use_sliding_window_kv_pool:
+                        swa_page_table = (
+                            self.token_to_kv_pool.translate_loc_from_full_to_swa(
+                                kv_indices
+                            )
+                        )
+
+                        kv_indices = self._transform_table_1_to_real(kv_indices)
+                        swa_page_table = self._transform_table_1_to_real(swa_page_table)
+                    else:
+                        kv_indices = self._transform_table_1_to_real(kv_indices)
 
             if self.use_mla:
                 qo_indptr = self.qo_indptr_[: bs + 1]
@@ -1545,9 +1588,15 @@ class AiterAttnBackend(AttentionBackend):
                         -1, max_num_blocks_per_seq
                     )
 
+                    if self.use_sliding_window_kv_pool:
+                        swa_page_table = self.cuda_graph_swa_page_table
+
                     if spec_info is not None:
                         self._build_unified_page_table_from_spec(
-                            spec_info, bs, dest_buf=kv_indices
+                            spec_info,
+                            bs,
+                            dest_buf=kv_indices,
+                            swa_dest_buf=swa_page_table,
                         )
                     else:
                         page_indices = self.req_to_token[
@@ -1973,9 +2022,15 @@ class AiterAttnBackend(AttentionBackend):
                         -1, max_num_blocks_per_seq
                     )
 
+                    if self.use_sliding_window_kv_pool:
+                        swa_page_table = self.cuda_graph_swa_page_table
+
                     if spec_info is not None:
                         self._build_unified_page_table_from_spec(
-                            spec_info, bs, dest_buf=kv_indices
+                            spec_info,
+                            bs,
+                            dest_buf=kv_indices,
+                            swa_dest_buf=swa_page_table,
                         )
                     else:
                         page_indices = self.req_to_token[

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -11,9 +11,12 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 import triton
-import triton.language as tl
 
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+from sglang.srt.layers.attention.triton_ops.aiter_unified_attention import (
+    scatter_ragged_to_page_table_kernel,
+    scatter_req_to_token_to_page_table_kernel,
+)
 from sglang.srt.layers.attention.utils import (
     create_flashinfer_kv_indices_triton,
     create_flashmla_kv_indices_triton,
@@ -106,108 +109,6 @@ class ForwardMetadata:
 
 
 global_workspace_buffer = None
-
-
-@triton.jit
-def _scatter_ragged_to_page_table_kernel(
-    kv_flat_ptr,
-    kv_indptr_ptr,
-    dest_ptr,
-    dest_stride,
-    sw_page_table_ptr,
-    swa_slot_mapping_ptr,
-    PAGE_SIZE: tl.constexpr,
-    BLOCK_SIZE: tl.constexpr,
-    HAS_SWA: tl.constexpr,
-):
-    """Scatter ragged token-level kv_indices into a 2D block-level page table.
-    Output columns store block indices (token_id // PAGE_SIZE); per-request
-    row length is ceil(kv_len / PAGE_SIZE). Only writes rows [0, num_blocks);
-    `unified_attention` bounds reads by seqused_k, so the tail is never read.
-    """
-    pid = tl.program_id(0)
-    block_id = tl.program_id(1)
-
-    start = tl.load(kv_indptr_ptr + pid).to(tl.int64)
-    kv_len = tl.load(kv_indptr_ptr + pid + 1).to(tl.int64) - start
-    num_blocks = (kv_len + PAGE_SIZE - 1) // PAGE_SIZE
-
-    offsets = block_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    if block_id * BLOCK_SIZE >= num_blocks:
-        return
-    mask = offsets < num_blocks
-    token_idx = offsets.to(tl.int64) * PAGE_SIZE
-    vals = tl.load(kv_flat_ptr + start + token_idx, mask=mask, other=0)
-    block_vals = vals // PAGE_SIZE
-    tl.store(
-        dest_ptr + pid.to(tl.int64) * dest_stride + offsets,
-        block_vals,
-        mask=mask,
-    )
-
-    if HAS_SWA:
-        sw_vals = tl.load(swa_slot_mapping_ptr + vals)
-        block_vals = sw_vals // PAGE_SIZE
-        tl.store(
-            sw_page_table_ptr + pid.to(tl.int64) * dest_stride + offsets,
-            block_vals,
-            mask=mask,
-        )
-
-
-@triton.jit
-def _scatter_req_to_token_to_page_table_kernel(
-    req_to_token_ptr,
-    req_pool_indices_ptr,
-    seq_lens_ptr,
-    page_table_ptr,
-    req_to_token_stride,
-    page_table_stride,
-    sw_page_table_ptr,
-    swa_slot_mapping_ptr,
-    DRAFT_NUM: tl.constexpr,
-    PAGE_SIZE: tl.constexpr,
-    BLOCK_SIZE: tl.constexpr,
-    HAS_SWA: tl.constexpr,
-):
-    """Build the 2D block-level page_table for target_verify directly from
-    req_to_token by sampling at PAGE_SIZE stride for rows [0, num_blocks).
-    Avoids a (bs * max_context_len) int32 intermediate scratch buffer.
-    """
-    pid = tl.program_id(0)
-    block_id = tl.program_id(1)
-
-    seq_len = tl.load(seq_lens_ptr + pid).to(tl.int64)
-    kv_len = seq_len + DRAFT_NUM
-    num_blocks = (kv_len + PAGE_SIZE - 1) // PAGE_SIZE
-
-    offsets = block_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    if block_id * BLOCK_SIZE >= num_blocks:
-        return
-    mask = offsets < num_blocks
-
-    rp = tl.load(req_pool_indices_ptr + pid).to(tl.int64)
-    token_idx = offsets.to(tl.int64) * PAGE_SIZE
-    vals = tl.load(
-        req_to_token_ptr + rp * req_to_token_stride + token_idx,
-        mask=mask,
-        other=0,
-    )
-    block_vals = vals // PAGE_SIZE
-    tl.store(
-        page_table_ptr + pid.to(tl.int64) * page_table_stride + offsets,
-        block_vals,
-        mask=mask,
-    )
-
-    if HAS_SWA:
-        sw_vals = tl.load(swa_slot_mapping_ptr + vals)
-        block_vals = sw_vals // PAGE_SIZE
-        tl.store(
-            sw_page_table_ptr + pid.to(tl.int64) * page_table_stride + offsets,
-            block_vals,
-            mask=mask,
-        )
 
 
 _AITER_PARTITION_SIZE_ROCM = 256
@@ -648,7 +549,7 @@ class AiterAttnBackend(AttentionBackend):
 
         BLOCK_SIZE = 1024
         grid = (bs, triton.cdiv(max(max_blocks, 1), BLOCK_SIZE))
-        _scatter_ragged_to_page_table_kernel[grid](
+        scatter_ragged_to_page_table_kernel[grid](
             kv_flat,
             kv_indptr,
             page_table,
@@ -710,7 +611,7 @@ class AiterAttnBackend(AttentionBackend):
 
         BLOCK_SIZE = 1024
         grid = (bs, triton.cdiv(max(max_blocks, 1), BLOCK_SIZE))
-        _scatter_req_to_token_to_page_table_kernel[grid](
+        scatter_req_to_token_to_page_table_kernel[grid](
             self.req_to_token,
             req_pool_indices,
             seq_lens,
@@ -985,18 +886,6 @@ class AiterAttnBackend(AttentionBackend):
                 else:
                     kv_indptr, kv_indices = spec_info.kv_indptr, spec_info.kv_indices
                     bs = kv_indptr.shape[0] - 1
-
-                    if self.use_sliding_window_kv_pool:
-                        swa_page_table = (
-                            self.token_to_kv_pool.translate_loc_from_full_to_swa(
-                                kv_indices
-                            )
-                        )
-
-                        kv_indices = self._transform_table_1_to_real(kv_indices)
-                        swa_page_table = self._transform_table_1_to_real(swa_page_table)
-                    else:
-                        kv_indices = self._transform_table_1_to_real(kv_indices)
 
             if self.use_mla:
                 qo_indptr = self.qo_indptr_[: bs + 1]
@@ -1733,7 +1622,6 @@ class AiterAttnBackend(AttentionBackend):
 
             if self.use_mla:
                 if _use_mla_ps_kernel:
-
                     num_kv_splits = self.max_split_per_batch
 
                     self.make_mla_meta_data(
@@ -1924,7 +1812,6 @@ class AiterAttnBackend(AttentionBackend):
                 max_q_len = num_tokens_per_bs
 
                 if _use_mla_ps_kernel:
-
                     num_kv_splits = self.max_split_per_batch
 
                     self.make_mla_meta_data(
@@ -2169,7 +2056,6 @@ class AiterAttnBackend(AttentionBackend):
 
             if self.use_mla:
                 if _use_mla_ps_kernel:
-
                     num_kv_splits = self.max_split_per_batch
 
                     self.make_mla_meta_data(
@@ -2297,7 +2183,6 @@ class AiterAttnBackend(AttentionBackend):
             max_q_len = num_tokens_per_bs
 
             if self.use_mla and _use_mla_ps_kernel:
-
                 num_kv_splits = self.max_split_per_batch
 
                 self.make_mla_meta_data(
@@ -2363,7 +2248,6 @@ class AiterAttnBackend(AttentionBackend):
             max_q_len = num_tokens_per_bs
 
             if self.use_mla and _use_mla_ps_kernel:
-
                 num_kv_splits = self.max_split_per_batch
 
                 self.make_mla_meta_data(
@@ -2456,7 +2340,6 @@ class AiterAttnBackend(AttentionBackend):
                     self.use_triton_unified_attention
                     and self.use_sliding_window_kv_pool
                 ):
-
                     token_to_kv_pool = forward_batch.token_to_kv_pool
                     k_cache, v_cache = forward_batch.token_to_kv_pool.get_kv_buffer(
                         layer.layer_id
@@ -2659,7 +2542,6 @@ class AiterAttnBackend(AttentionBackend):
                 forward_batch.forward_mode.is_draft_extend()
                 or forward_batch.forward_mode.is_draft_extend_v2()
             ):
-
                 work_metadata = self.forward_metadata.work_metadata
                 work_indptr = self.forward_metadata.work_indptr
                 work_info_set = self.forward_metadata.work_info_set
@@ -2776,7 +2658,7 @@ class AiterAttnBackend(AttentionBackend):
                         v=v_cache.view(
                             -1, self.page_size, layer.tp_v_head_num, layer.v_head_dim
                         ),
-                        out=o.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
+                        out=o.view(-1, layer.tp_q_head_num, layer.v_head_dim),
                         cu_seqlens_q=self.forward_metadata.qo_indptr,
                         seqused_k=forward_batch.seq_lens + self.num_draft_tokens,
                         max_seqlen_q=self.forward_metadata.max_q_len,
@@ -2891,7 +2773,6 @@ class AiterAttnBackend(AttentionBackend):
             # use standard set_kv_buffer, as they lack SWA-specific attributes
             # like full_to_swa_index_mapping.
             if self.use_triton_unified_attention and self.use_sliding_window_kv_pool:
-
                 token_to_kv_pool = forward_batch.token_to_kv_pool
                 k_cache, v_cache = forward_batch.token_to_kv_pool.get_kv_buffer(
                     layer.layer_id
@@ -2979,7 +2860,6 @@ class AiterAttnBackend(AttentionBackend):
             o = torch.empty_like(q, dtype=self.input_dtype)
 
             if self.use_triton_unified_attention:
-
                 bs = forward_batch.batch_size
                 window_size = (-1, -1)
                 page_table = self.forward_metadata.kv_indices

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -2647,9 +2647,7 @@ class AiterAttnBackend(AttentionBackend):
                         if self.forward_metadata.swa_page_table is not None:
                             page_table = self.forward_metadata.swa_page_table
 
-                    q_unified = q.view(
-                        -1, layer.tp_q_head_num, layer.qk_head_dim
-                    )
+                    q_unified = q.view(-1, layer.tp_q_head_num, layer.qk_head_dim)
                     k_unified = k_cache.view(
                         -1, self.page_size, layer.tp_k_head_num, layer.qk_head_dim
                     )
@@ -2660,12 +2658,8 @@ class AiterAttnBackend(AttentionBackend):
                         # Qwen3.5 can replicate one KV head across multiple TP ranks.
                         # Present the local KV head as per-Q-head stride-0 views so
                         # target_verify uses the same local head mapping as the model.
-                        k_unified = k_unified.expand(
-                            -1, -1, layer.tp_q_head_num, -1
-                        )
-                        v_unified = v_unified.expand(
-                            -1, -1, layer.tp_q_head_num, -1
-                        )
+                        k_unified = k_unified.expand(-1, -1, layer.tp_q_head_num, -1)
+                        v_unified = v_unified.expand(-1, -1, layer.tp_q_head_num, -1)
 
                     # The seq_lens + draft_num add has to run INSIDE the graph
                     # region; a host-side pre-add would allocate a new tensor

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -2647,17 +2647,33 @@ class AiterAttnBackend(AttentionBackend):
                         if self.forward_metadata.swa_page_table is not None:
                             page_table = self.forward_metadata.swa_page_table
 
+                    q_unified = q.view(
+                        -1, layer.tp_q_head_num, layer.qk_head_dim
+                    )
+                    k_unified = k_cache.view(
+                        -1, self.page_size, layer.tp_k_head_num, layer.qk_head_dim
+                    )
+                    v_unified = v_cache.view(
+                        -1, self.page_size, layer.tp_v_head_num, layer.v_head_dim
+                    )
+                    if layer.tp_k_head_num == 1 and layer.tp_q_head_num > 1:
+                        # Qwen3.5 can replicate one KV head across multiple TP ranks.
+                        # Present the local KV head as per-Q-head stride-0 views so
+                        # target_verify uses the same local head mapping as the model.
+                        k_unified = k_unified.expand(
+                            -1, -1, layer.tp_q_head_num, -1
+                        )
+                        v_unified = v_unified.expand(
+                            -1, -1, layer.tp_q_head_num, -1
+                        )
+
                     # The seq_lens + draft_num add has to run INSIDE the graph
                     # region; a host-side pre-add would allocate a new tensor
                     # each replay and break the captured pointer.
                     unified_attention(
-                        q=q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
-                        k=k_cache.view(
-                            -1, self.page_size, layer.tp_k_head_num, layer.qk_head_dim
-                        ),
-                        v=v_cache.view(
-                            -1, self.page_size, layer.tp_v_head_num, layer.v_head_dim
-                        ),
+                        q=q_unified,
+                        k=k_unified,
+                        v=v_unified,
                         out=o.view(-1, layer.tp_q_head_num, layer.v_head_dim),
                         cu_seqlens_q=self.forward_metadata.qo_indptr,
                         seqused_k=forward_batch.seq_lens + self.num_draft_tokens,
@@ -2857,7 +2873,13 @@ class AiterAttnBackend(AttentionBackend):
                 layer.layer_id
             )
 
-            o = torch.empty_like(q, dtype=self.input_dtype)
+            if layer.qk_head_dim != layer.v_head_dim:
+                o = q.new_empty(
+                    (q.shape[0], layer.tp_q_head_num * layer.v_head_dim),
+                    dtype=self.input_dtype,
+                )
+            else:
+                o = torch.empty_like(q, dtype=self.input_dtype)
 
             if self.use_triton_unified_attention:
                 bs = forward_batch.batch_size
@@ -2882,7 +2904,7 @@ class AiterAttnBackend(AttentionBackend):
                     v=v_cache.view(
                         -1, self.page_size, layer.tp_v_head_num, layer.v_head_dim
                     ),
-                    out=o.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
+                    out=o.view(-1, layer.tp_q_head_num, layer.v_head_dim),
                     cu_seqlens_q=self.forward_metadata.qo_indptr,
                     seqused_k=forward_batch.seq_lens,
                     max_seqlen_q=self.forward_metadata.max_q_len,
@@ -2903,7 +2925,7 @@ class AiterAttnBackend(AttentionBackend):
                     v_cache = v_cache.to(self.input_dtype)
 
                 paged_attention_ragged(
-                    o.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
+                    o.view(-1, layer.tp_q_head_num, layer.v_head_dim),
                     self.workspace_buffer,
                     q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
                     k_cache.view(-1, 1, layer.tp_k_head_num, layer.qk_head_dim),

--- a/python/sglang/srt/layers/attention/triton_ops/aiter_unified_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/aiter_unified_attention.py
@@ -1,0 +1,97 @@
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def scatter_ragged_to_page_table_kernel(
+    kv_flat_ptr,
+    kv_indptr_ptr,
+    dest_ptr,
+    dest_stride,
+    sw_page_table_ptr,
+    swa_slot_mapping_ptr,
+    PAGE_SIZE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    HAS_SWA: tl.constexpr,
+):
+    """Scatter ragged token-level kv_indices into a 2D block-level page table."""
+    pid = tl.program_id(0)
+    block_id = tl.program_id(1)
+
+    start = tl.load(kv_indptr_ptr + pid).to(tl.int64)
+    kv_len = tl.load(kv_indptr_ptr + pid + 1).to(tl.int64) - start
+    num_blocks = (kv_len + PAGE_SIZE - 1) // PAGE_SIZE
+
+    offsets = block_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    if block_id * BLOCK_SIZE >= num_blocks:
+        return
+    mask = offsets < num_blocks
+    token_idx = offsets.to(tl.int64) * PAGE_SIZE
+    vals = tl.load(kv_flat_ptr + start + token_idx, mask=mask, other=0)
+    block_vals = vals // PAGE_SIZE
+    tl.store(
+        dest_ptr + pid.to(tl.int64) * dest_stride + offsets,
+        block_vals,
+        mask=mask,
+    )
+
+    if HAS_SWA:
+        sw_vals = tl.load(swa_slot_mapping_ptr + vals)
+        block_vals = sw_vals // PAGE_SIZE
+        tl.store(
+            sw_page_table_ptr + pid.to(tl.int64) * dest_stride + offsets,
+            block_vals,
+            mask=mask,
+        )
+
+
+@triton.jit
+def scatter_req_to_token_to_page_table_kernel(
+    req_to_token_ptr,
+    req_pool_indices_ptr,
+    seq_lens_ptr,
+    page_table_ptr,
+    req_to_token_stride,
+    page_table_stride,
+    sw_page_table_ptr,
+    swa_slot_mapping_ptr,
+    DRAFT_NUM: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    HAS_SWA: tl.constexpr,
+):
+    """Build the 2D block-level page_table for target_verify from req_to_token."""
+    pid = tl.program_id(0)
+    block_id = tl.program_id(1)
+
+    seq_len = tl.load(seq_lens_ptr + pid).to(tl.int64)
+    kv_len = seq_len + DRAFT_NUM
+    num_blocks = (kv_len + PAGE_SIZE - 1) // PAGE_SIZE
+
+    offsets = block_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    if block_id * BLOCK_SIZE >= num_blocks:
+        return
+    mask = offsets < num_blocks
+
+    rp = tl.load(req_pool_indices_ptr + pid).to(tl.int64)
+    token_idx = offsets.to(tl.int64) * PAGE_SIZE
+    vals = tl.load(
+        req_to_token_ptr + rp * req_to_token_stride + token_idx,
+        mask=mask,
+        other=0,
+    )
+    block_vals = vals // PAGE_SIZE
+    tl.store(
+        page_table_ptr + pid.to(tl.int64) * page_table_stride + offsets,
+        block_vals,
+        mask=mask,
+    )
+
+    if HAS_SWA:
+        sw_vals = tl.load(swa_slot_mapping_ptr + vals)
+        block_vals = sw_vals // PAGE_SIZE
+        tl.store(
+            sw_page_table_ptr + pid.to(tl.int64) * page_table_stride + offsets,
+            block_vals,
+            mask=mask,
+        )

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -11,8 +11,10 @@ from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache, EvictParams
 from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool, ReqToTokenPool
 from sglang.srt.mem_cache.swa_memory_pool import SWATokenToKVPoolAllocator
 from sglang.srt.server_args import get_global_server_args
-from sglang.srt.utils import support_triton
+from sglang.srt.utils import is_hip, support_triton
 from sglang.srt.utils.common import ceil_align
+
+_is_hip = is_hip()
 
 if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
@@ -129,6 +131,17 @@ def get_last_loc(
     req_pool_indices_tensor: torch.Tensor,
     prefix_lens_tensor: torch.Tensor,
 ) -> torch.Tensor:
+    if _is_hip and get_global_server_args().attention_backend == "aiter":
+        # HIP-only: the legacy get_last_loc_triton kernel emits a
+        # mixed-width int32->int64 store that Triton mis-compiles on HIP,
+        # producing out-of-range last_loc values under EAGLE +
+        # page_size>1 + aiter unified attention. Route this combination
+        # through the int32-safe variant; other hardware and other
+        # attention backends keep the original dispatcher below.
+        return get_last_loc_triton_safe(
+            req_to_token, req_pool_indices_tensor, prefix_lens_tensor
+        )
+
     if (
         get_global_server_args().attention_backend != "ascend"
         and get_global_server_args().attention_backend != "torch_native"
@@ -150,6 +163,67 @@ def get_last_loc_torch(
         req_to_token[req_pool_indices_tensor, prefix_lens_tensor - 1],
         torch.full_like(prefix_lens_tensor, -1),
     )
+
+
+@triton.jit
+def _get_last_loc_safe_kernel(
+    req_to_token,
+    req_pool_indices_tensor,
+    prefix_lens_tensor,
+    result_i32,
+    num_tokens,
+    req_to_token_stride,
+    BLOCK_SIZE: tl.constexpr,
+    PREFIX_DTYPE_IS_I64: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offset = tl.arange(0, BLOCK_SIZE) + pid * BLOCK_SIZE
+    mask = offset < num_tokens
+
+    if PREFIX_DTYPE_IS_I64:
+        prefix_lens = tl.load(prefix_lens_tensor + offset, mask=mask, other=0)
+        req_pool_indices = tl.load(req_pool_indices_tensor + offset, mask=mask, other=0)
+        token_index = req_pool_indices * req_to_token_stride + (prefix_lens - 1)
+    else:
+        prefix_lens = tl.load(prefix_lens_tensor + offset, mask=mask, other=0)
+        req_pool_indices = tl.load(req_pool_indices_tensor + offset, mask=mask, other=0)
+        token_index = req_pool_indices.to(tl.int64) * req_to_token_stride + (
+            prefix_lens.to(tl.int64) - 1
+        )
+
+    token_mask = mask & (prefix_lens > 0)
+    tokens = tl.load(req_to_token + token_index, mask=token_mask, other=-1)
+    # Result stays int32 (req_to_token dtype); caller promotes after return.
+    tl.store(result_i32 + offset, tokens, mask=mask)
+
+
+def get_last_loc_triton_safe(
+    req_to_token: torch.Tensor,
+    req_pool_indices_tensor: torch.Tensor,
+    prefix_lens_tensor: torch.Tensor,
+) -> torch.Tensor:
+    """Fused `last_loc` Triton kernel whose in-kernel result buffer is int32
+    (the dtype of req_to_token). The consumer-dtype promotion happens in
+    torch after the kernel returns, so Triton never issues a mixed-width
+    store — avoiding the HIP int32->int64 store bug hit by the legacy kernel.
+    """
+    num_tokens = prefix_lens_tensor.shape[0]
+    BLOCK_SIZE = 256
+    result_i32 = torch.empty(
+        num_tokens, dtype=torch.int32, device=prefix_lens_tensor.device
+    )
+    grid = (triton.cdiv(num_tokens, BLOCK_SIZE),)
+    _get_last_loc_safe_kernel[grid](
+        req_to_token,
+        req_pool_indices_tensor,
+        prefix_lens_tensor,
+        result_i32,
+        num_tokens,
+        req_to_token.stride(0),
+        BLOCK_SIZE=BLOCK_SIZE,
+        PREFIX_DTYPE_IS_I64=(prefix_lens_tensor.dtype == torch.int64),
+    )
+    return result_i32.to(prefix_lens_tensor.dtype)
 
 
 @triton.jit

--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -62,6 +62,18 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
         ):
             quant_config = None
 
+        # Quark-quantized Qwen3.5 MXFP4 checkpoints ship the MTP module in
+        # bf16; every `mtp.*` layer appears under the quantization exclude
+        # list. Detect that and skip quantization here so linear/MoE weight
+        # loaders allocate bf16 shapes (see sgl-project/sglang#23113).
+        if quant_config and quant_config.get_name() == "quark":
+            exclude_layers = getattr(quant_config, "exclude_layers", [])
+            if any(
+                isinstance(layer, str) and layer.startswith("mtp.")
+                for layer in exclude_layers
+            ):
+                quant_config = None
+
         self.config = config
         self.tp_size = get_tensor_model_parallel_world_size()
         self.quant_config = quant_config

--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -54,6 +54,18 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
         if quant_config and quant_config.get_name() == "modelopt_fp4":
             quant_config = None
 
+        # Quark-quantized Qwen3.5 MXFP4 checkpoints ship the MTP module in
+        # bf16; every `mtp.*` layer appears under the quantization exclude
+        # list. Detect that and skip quantization here so linear/MoE weight
+        # loaders allocate bf16 shapes (see sgl-project/sglang#23113).
+        if quant_config and quant_config.get_name() == "quark":
+            exclude_layers = getattr(quant_config, "exclude_layers", [])
+            if any(
+                isinstance(layer, str) and layer.startswith("mtp.")
+                for layer in exclude_layers
+            ):
+                quant_config = None
+
         self.config = config
         self.tp_size = get_tensor_model_parallel_world_size()
         self.quant_config = quant_config

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -121,6 +121,7 @@ QUANTIZATION_CHOICES = [
     "auto-round",
     "compressed-tensors",  # for Ktransformers
     "modelslim",  # for NPU
+    "quark",  # AMD Quark quantizer (FP8 / MXFP4 / Int4FP8 etc.)
     "quark_int4fp8_moe",
     "unquant",
 ]

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -122,6 +122,7 @@ QUANTIZATION_CHOICES = [
     "auto-round",
     "compressed-tensors",  # for Ktransformers
     "modelslim",  # for NPU
+    "quark",  # AMD Quark quantizer (FP8 / MXFP4 / Int4FP8 etc.)
     "quark_int4fp8_moe",
     "unquant",
 ]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

Co-author: @kkHuang-amd, @sogalin

## Motivation

Enable EAGLE speculative decoding on top of the aiter unified-attention decode path for Qwen3.5-397B-A17B FP8 and MXFP4 on AMD (gfx950 / MI355X), and fix loading for the Quark-MXFP4 EAGLE/MTP variant.

Before this change:
- `SGLANG_USE_AITER_UNIFIED_ATTN=1` plus `--speculative-algorithm EAGLE` does not have a unified-attention target-verify path for the non-MLA, `topk == 1` EAGLE case.
- The `spec_info` decode path can provide token-level ragged indices, while `unified_attention` expects a 2-D block-level page table.
- `Qwen3.5-397B-A17B-MXFP4` fails to load with EAGLE because the Quark-exported MTP module is bf16 but the loader tries to allocate MXFP4-packed shapes (sgl-project/sglang#23113).
- `--quantization quark` is rejected by the CLI even though `QuarkConfig` is registered.

This PR keeps the draft-decode `seqused_k` fix and radix-cache behavior out of scope. The draft-decode fix is handled separately in #23461, and radix-cache enablement remains in the separate radix-cache/MTP conflict path. Validation here uses `--disable-radix-cache`.

## Modifications

- `python/sglang/srt/layers/attention/aiter_backend.py`
  - When `SGLANG_USE_AITER_UNIFIED_ATTN=1`, the model is non-MLA, and `speculative_eagle_topk == 1`, route EAGLE target_verify through `unified_attention`. The linear draft chain's verify mask reduces to pure causal, so the previous `extend_attention_fwd` + custom-mask path is not required for this case. This is gated by `SGLANG_AITER_UNIFIED_VERIFY` (default on for this combination).
  - Build the 2-D block-level page table required by `unified_attention` for decode-with-spec and target_verify paths without allocating an intermediate `bs x max_context_len` int32 scratch.
  - Use `layer.v_head_dim` for the target-verify `unified_attention` output view so it matches the value cache shape and the legacy extend path.
  - For Qwen3.5 tensor-parallel layouts where one local KV head is replicated across multiple local query heads (for example MXFP4 TP=4), pass stride-0 expanded KV views to `unified_attention` in target_verify so the unified path preserves the model's local replicated-KV mapping instead of corrupting speculative verification.
  - Keep the unified-attention page-table transform behind `self.use_triton_unified_attention and not self.use_mla`. MLA and non-unified-attention paths continue using the original token-level `spec_info` indices.
  - Respect sliding-window attention in target_verify by deriving `window_size` from `layer.sliding_window_size` and using the SWA page table when available.
- `python/sglang/srt/layers/attention/triton_ops/aiter_unified_attention.py`
  - Add the Triton scatter kernels used by the aiter unified-attention page-table builders.
- `python/sglang/srt/models/qwen3_5_mtp.py`
  - Quark-quantized Qwen3.5 MXFP4 checkpoints ship the MTP module in bf16; every `mtp.*` layer is listed under `quantization_config.exclude`. Detect that and skip quantization for the MTP module so linear/MoE weight loaders allocate bf16 shapes. Tracks sgl-project/sglang#23113.
- `python/sglang/srt/server_args.py`
  - Add `"quark"` to `QUANTIZATION_CHOICES` so `--quantization quark` is accepted (`QuarkConfig` is already registered in `QUANTIZATION_METHODS`).

Environment variable:
- `SGLANG_AITER_UNIFIED_VERIFY` (default `1` for non-MLA + `topk == 1`; set to `0` to disable target_verify unified attention).

## Accuracy Tests

Latest FP8 validation after review-comment fixes:

| Model | Run | Accuracy | Invalid | Latency (s) | Output throughput (token/s) | Gate |
| --- | --- | --- | --- | --- | --- | --- |
| Qwen3.5-397B-A17B-FP8 + EAGLE | 1 | 0.949 | 0.011 | 62.754 | 3436.185 | Pass |
| Qwen3.5-397B-A17B-FP8 + EAGLE | 2 | 0.951 | 0.008 | 84.644 | 2553.427 | Pass |
| Qwen3.5-397B-A17B-FP8 + EAGLE | 3 | 0.951 | 0.009 | 59.399 | 3653.503 | Pass |
| Qwen3.5-397B-A17B-FP8 + EAGLE | 4 | 0.945 | 0.008 | 58.442 | 3686.672 | Pass |

Latest TP=4 validation after fixing replicated-KV target_verify handling:

| Model | TP | Run | Accuracy | Invalid | Latency (s) | Output throughput (token/s) | Gate |
| --- | --- | --- | --- | --- | --- | --- | --- |
| Qwen3.5-397B-A17B-MXFP4 + EAGLE | 4 | Before fix | 0.472 / 0.024 | 0.236 / 0.581 | 100.916 / 93.650 | 4447.324 / 7124.179 | Fail |
| Qwen3.5-397B-A17B-MXFP4 + EAGLE | 4 | Legacy-verify A/B | 0.925 | 0.006 | 78.280 | 2861.588 | Pass |
| Qwen3.5-397B-A17B-MXFP4 + EAGLE | 4 | Unified-verify fixed run 1 | 0.920 | 0.008 | 78.024 | 2902.959 | Pass |
| Qwen3.5-397B-A17B-MXFP4 + EAGLE | 4 | Unified-verify fixed run 2 | 0.923 | 0.011 | 81.640 | 2700.822 | Pass |
| Qwen3.5-397B-A17B-MXFP4 + EAGLE | 4 | Unified-verify fixed run 3 | 0.933 | 0.006 | 76.664 | 2901.184 | Pass |
| Qwen3.5-397B-A17B-MXFP4 + EAGLE | 4 | Unified-verify fixed run 4 | 0.933 | 0.009 | 75.362 | 2942.084 | Pass |
| Qwen3.5-397B-A17B-MXFP4 + EAGLE | 4 | Unified-verify fixed run 5 | 0.927 | 0.007 | 74.698 | 2981.545 | Pass |
| Qwen3.5-397B-A17B-FP8 + EAGLE | 4 | Unified-verify fixed run 1 | 0.947 | 0.012 | 74.310 | 2887.723 | Pass |
| Qwen3.5-397B-A17B-FP8 + EAGLE | 4 | Unified-verify fixed run 2 | 0.948 | 0.011 | 73.890 | 2922.611 | Pass |
| Qwen3.5-397B-A17B-FP8 + EAGLE | 4 | Unified-verify fixed run 3 | 0.951 | 0.008 | 74.399 | 2916.144 | Pass |

Earlier full GSM8K validation for the original FP8/MXFP4 enablement:

| Model | Run 1 | Run 2 | Run 3 | Avg | Gate |
| --- | --- | --- | --- | --- | --- |
| Qwen3.5-397B-A17B-FP8 + EAGLE | 0.946 | 0.955 | 0.947 | 0.949 | Pass |
| Qwen3.5-397B-A17B-MXFP4 + EAGLE | 0.929 | 0.938 | 0.933 | 0.933 | Pass |

<details>
<summary>Server launch: FP8 + EAGLE</summary>

```bash
SGLANG_USE_AITER_UNIFIED_ATTN=1 SGLANG_USE_AITER=1 \
SGLANG_AITER_UNIFIED_VERIFY=1 \
python3 -m sglang.launch_server \
  --model-path /data2/Qwen/Qwen3.5-397B-A17B-FP8 --tp 8 \
  --attention-backend aiter --trust-remote-code \
  --model-loader-extra-config '{"enable_multithread_load": true}' \
  --watchdog-timeout 1200 --mem-fraction-static 0.9 \
  --host 0.0.0.0 --port 9000 --disable-radix-cache \
  --enable-aiter-allreduce-fusion --max-running-requests 128 \
  --page-size 16 \
  --speculative-algorithm EAGLE --speculative-num-steps 3 \
  --speculative-eagle-topk 1 --speculative-num-draft-tokens 4
```

</details>

<details>
<summary>Server launch: MXFP4 + EAGLE</summary>

```bash
SGLANG_USE_AITER_UNIFIED_ATTN=1 SGLANG_USE_AITER=1 \
SGLANG_AITER_UNIFIED_VERIFY=1 \
python3 -m sglang.launch_server \
  --model-path /data/Qwen3.5-397B-A17B-MXFP4 --tp 8 \
  --quantization quark \
  --attention-backend aiter --trust-remote-code \
  --model-loader-extra-config '{"enable_multithread_load": true}' \
  --watchdog-timeout 1200 --mem-fraction-static 0.85 \
  --host 0.0.0.0 --port 9000 --disable-radix-cache \
  --enable-aiter-allreduce-fusion --max-running-requests 128 \
  --page-size 16 \
  --speculative-algorithm EAGLE --speculative-num-steps 3 \
  --speculative-eagle-topk 1 --speculative-num-draft-tokens 4
```

</details>

<details>
<summary>Server launch: FP8 TP=4 + EAGLE</summary>

```bash
SGLANG_USE_AITER_UNIFIED_ATTN=1 SGLANG_USE_AITER=1 \
SGLANG_AITER_UNIFIED_VERIFY=1 \
python3 -m sglang.launch_server \
  --model-path /data2/Qwen/Qwen3.5-397B-A17B-FP8 --tp 4 \
  --attention-backend aiter --trust-remote-code \
  --model-loader-extra-config '{"enable_multithread_load": true}' \
  --watchdog-timeout 1200 --mem-fraction-static 0.9 \
  --host 0.0.0.0 --port 9000 --disable-radix-cache \
  --enable-aiter-allreduce-fusion --max-running-requests 128 \
  --page-size 16 \
  --speculative-algorithm EAGLE --speculative-num-steps 3 \
  --speculative-eagle-topk 1 --speculative-num-draft-tokens 4
```

</details>

<details>
<summary>Server launch: MXFP4 TP=4 + EAGLE</summary>

```bash
SGLANG_USE_AITER_UNIFIED_ATTN=1 SGLANG_USE_AITER=1 \
SGLANG_AITER_UNIFIED_VERIFY=1 \
python3 -m sglang.launch_server \
  --model-path /data2/amd/Qwen3.5-397B-A17B-MXFP4/ --tp 4 \
  --quantization quark \
  --attention-backend aiter --trust-remote-code \
  --model-loader-extra-config '{"enable_multithread_load": true}' \
  --watchdog-timeout 1200 --mem-fraction-static 0.85 \
  --host 0.0.0.0 --port 9000 --disable-radix-cache \
  --enable-aiter-allreduce-fusion --max-running-requests 128 \
  --page-size 16 \
  --speculative-algorithm EAGLE --speculative-num-steps 3 \
  --speculative-eagle-topk 1 --speculative-num-draft-tokens 4
```

</details>

<details>
<summary>GSM8K command used for latest FP8 validation</summary>

```bash
for i in 1 2 3 4; do
  python3 benchmark/gsm8k/bench_sglang.py \
    --num-questions 1319 --parallel 1319 --num-shots 5 --port 9000
done
```

</details>

## Benchmarking and Profiling

`sa_benchmark.sh` with `input_tokens=8192 output_tokens=8192 concurrency=16 num_prompts=64`, identical serving flags except for the speculative-decoding flags. Improvement columns use:
- Lower-is-better: `(baseline - candidate) / baseline * 100`
- Higher-is-better: `(candidate - baseline) / baseline * 100`

### Qwen3.5-397B-A17B-FP8: EAGLE on/off

| Metric | No EAGLE baseline | EAGLE | Improvement |
| --- | --- | --- | --- |
| Benchmark duration (s) | 367.03 | 236.24 | -35.6% |
| Output throughput (tok/s) | 1428.44 | 2219.30 | +55.4% |
| Total token throughput (tok/s) | 2856.88 | 4438.60 | +55.4% |
| Median TPOT (ms) | 11.04 | 5.87 | -46.8% |
| Median TTFT (ms) | 1318.99 | 201.54 | -84.7% |
| Median E2E latency (ms) | 91842.25 | 48291.89 | -47.4% |

<details>
<summary>Serving benchmark command</summary>

```bash
python3 benchmark_serving.py \
  --model /data/Qwen3.5-397B-A17B-FP8 \
  --base-url http://0.0.0.0:9000 --backend sglang \
  --dataset-name random \
  --random-input-len 8192 --random-output-len 8192 --random-range-ratio 1.0 \
  --num-prompts 64 --max-concurrency 16 --request-rate inf --ignore-eos \
  --num-warmups 32 --percentile-metrics ttft,tpot,itl,e2el
```

</details>

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`.
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
