### PR TITLE
[Scheduler] Fix head-of-line blocking on NO_TOKEN that regresses small-req TTFT

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2580,6 +2580,9 @@ class Scheduler(
                         req.mamba_pool_idx.unsqueeze(-1)
                     )
                     req.mamba_pool_idx = None
+                if res == AddReqResult.NO_TOKEN and int(adder.rem_total_tokens) > 0:
+                    self.running_batch.batch_is_full = False
+                    continue
                 break
 
         # Update waiting queue

--- a/test/registered/unit/managers/test_scheduler_admission_hol.py
+++ b/test/registered/unit/managers/test_scheduler_admission_hol.py
@@ -1,0 +1,197 @@
+"""Regression tests for #22831: head-of-line blocking in the prefill
+admission loop of Scheduler._get_new_batch_prefill_raw.
+
+Fix invariant: when add_one_req returns NO_TOKEN for the head-of-queue
+req but the adder still has KV slack (rem_total_tokens > 0), the
+scheduler must clear batch_is_full and continue walking the waiting
+queue instead of breaking. Under true saturation (rem_total_tokens == 0)
+the original break path is preserved.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.managers.schedule_policy import AddReqResult
+from sglang.srt.managers.scheduler import Scheduler
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+
+
+class TestSchedulerAdmissionHOL(CustomTestCase):
+    def _new_scheduler(self) -> Scheduler:
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.enable_hierarchical_cache = False
+        scheduler.enable_priority_preemption = False
+        scheduler.enable_lora = False
+        scheduler.enable_hicache_storage = False
+        scheduler.enable_dynamic_chunking = False
+        scheduler.enable_overlap = False
+        scheduler.enable_priority_scheduling = False
+        scheduler.is_mixed_chunk = False
+        scheduler.disaggregation_mode = DisaggregationMode.NULL
+        scheduler.chunked_req = None
+        scheduler.truncation_align_size = 0
+        scheduler.chunked_prefill_size = 4096
+        scheduler.page_size = 1
+        scheduler.new_token_ratio = 1.0
+        scheduler.max_prefill_tokens = 16384
+        scheduler.max_prefill_bs = 128
+        scheduler.max_running_requests = 128
+        scheduler.priority_scheduling_preemption_threshold = 0
+        scheduler.dllm_config = None
+        scheduler.prefill_delayer = None
+        scheduler.spec_algorithm = MagicMock()
+        scheduler.model_config = MagicMock()
+
+        scheduler.grammar_manager = MagicMock()
+        scheduler.grammar_manager.has_waiting_grammars.return_value = False
+
+        scheduler.running_batch = MagicMock()
+        scheduler.running_batch.reqs = []
+        scheduler.running_batch.is_empty.return_value = True
+        scheduler.running_batch.batch_is_full = False
+        scheduler.running_batch.return_logprob = False
+
+        scheduler.tree_cache = MagicMock()
+        scheduler.token_to_kv_pool_allocator = MagicMock()
+        scheduler.req_to_token_pool = MagicMock()
+        scheduler.policy = MagicMock()
+        scheduler.server_args = MagicMock()
+        scheduler.server_args.prefill_max_requests = 128
+
+        scheduler.get_num_allocatable_reqs = MagicMock(return_value=128)
+        scheduler._get_num_pending_tokens = MagicMock(return_value=0)
+        scheduler._add_request_to_queue = MagicMock()
+
+        return scheduler
+
+    def _make_req(self, rid: str, input_len: int):
+        req = MagicMock()
+        req.rid = rid
+        req.origin_input_ids = [0] * input_len
+        req.lora_id = None
+        req.mamba_pool_idx = None
+        return req
+
+    def _make_adder(self, rem_total_tokens, failing_req, failing_result):
+        """Build a fake PrefillAdder where `failing_req` returns
+        `failing_result` and every other req is admitted."""
+        fake_adder = MagicMock()
+        fake_adder.can_run_list = []
+        fake_adder.preempt_list = []
+        fake_adder.new_chunked_req = None
+        fake_adder.rem_total_tokens = rem_total_tokens
+
+        def add_one_req(req, **_):
+            if req is failing_req:
+                return failing_result
+            fake_adder.can_run_list.append(req)
+            return AddReqResult.CONTINUE
+
+        fake_adder.add_one_req.side_effect = add_one_req
+        return fake_adder
+
+    def _run_admission(self, scheduler, fake_adder):
+        """Call _get_new_batch_prefill_raw with the batch-construction
+        tail patched out, so only the admission loop is exercised."""
+        with patch(
+            "sglang.srt.managers.scheduler.PrefillAdder", return_value=fake_adder
+        ), patch(
+            "sglang.srt.managers.scheduler.ScheduleBatch"
+        ) as mock_batch_cls, patch(
+            "sglang.srt.managers.scheduler.PrefillStats"
+        ), patch(
+            "sglang.srt.managers.scheduler.set_time_batch"
+        ):
+            mock_batch_cls.init_new.return_value = MagicMock()
+            Scheduler._get_new_batch_prefill_raw(
+                scheduler, prefill_delayer_single_pass=None
+            )
+
+    def test_continue_on_no_token_when_slack_remains(self):
+        """NO_TOKEN on an oversized head req + remaining KV slack should
+        clear batch_is_full and continue to the next req, not break."""
+        scheduler = self._new_scheduler()
+        large = self._make_req("large", 11000)
+        small = self._make_req("small", 50)
+        scheduler.waiting_queue = [large, small]
+
+        fake_adder = self._make_adder(
+            rem_total_tokens=8000,
+            failing_req=large,
+            failing_result=AddReqResult.NO_TOKEN,
+        )
+
+        self._run_admission(scheduler, fake_adder)
+
+        self.assertIn(
+            small,
+            fake_adder.can_run_list,
+            "small req behind an oversized NO_TOKEN head must still be admitted "
+            "when adder reports KV slack remains",
+        )
+        self.assertFalse(
+            scheduler.running_batch.batch_is_full,
+            "batch_is_full must not be sticky-set when the skip guard fires",
+        )
+
+    def test_break_preserved_under_true_saturation(self):
+        """NO_TOKEN with rem_total_tokens == 0 must still break
+        (original path), so the admission loop doesn't churn under
+        true KV saturation."""
+        scheduler = self._new_scheduler()
+        large = self._make_req("large", 11000)
+        small = self._make_req("small", 50)
+        scheduler.waiting_queue = [large, small]
+
+        fake_adder = self._make_adder(
+            rem_total_tokens=0,
+            failing_req=large,
+            failing_result=AddReqResult.NO_TOKEN,
+        )
+
+        self._run_admission(scheduler, fake_adder)
+
+        self.assertNotIn(
+            small,
+            fake_adder.can_run_list,
+            "under true saturation (rem_total_tokens == 0) the original break "
+            "path must fire; small reqs should not be admitted",
+        )
+        self.assertTrue(
+            scheduler.running_batch.batch_is_full,
+            "batch_is_full must be set under true saturation",
+        )
+
+    def test_other_result_breaks_without_guard(self):
+        """The NO_TOKEN-specific guard must not leak to other non-CONTINUE
+        results (e.g. AddReqResult.OTHER from max-concurrency limits)."""
+        scheduler = self._new_scheduler()
+        head = self._make_req("head", 100)
+        tail = self._make_req("tail", 50)
+        scheduler.waiting_queue = [head, tail]
+
+        fake_adder = self._make_adder(
+            rem_total_tokens=8000,
+            failing_req=head,
+            failing_result=AddReqResult.OTHER,
+        )
+
+        self._run_admission(scheduler, fake_adder)
+
+        self.assertNotIn(
+            tail,
+            fake_adder.can_run_list,
+            "AddReqResult.OTHER must still break the admission loop; the "
+            "HOL guard is NO_TOKEN-specific",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #22831. When the waiting queue mixes large and small prompts, a small request stuck behind an oversized one sees up to 9.5× p99 TTFT regression on the issue's repro. Root cause is head-of-line (HOL) blocking in the prefill admission loop: when `adder.add_one_req()` returns `AddReqResult.NO_TOKEN` for the head req, the scheduler sets `batch_is_full=True` and breaks out of the waiting-queue walk — even when there's still KV room that a smaller req behind it would fit into. The flag stays set until `update_running_batch` shrinks the batch, so admissions are frozen for the whole window (~65 scheduler iters per trigger in our repro).

## Modifications

Single-file, 3-line change in `python/sglang/srt/managers/scheduler.py`, inside `_get_new_batch_prefill_raw`'s waiting-queue loop. When `NO_TOKEN` fires but `adder.rem_total_tokens > 0`, clear `batch_is_full` and `continue` to the next req instead of breaking. When KV is truly saturated (`rem_total_tokens == 0`) the original `break` still fires, so behavior under real saturation is unchanged.

## Accuracy Tests

Not applicable — the change only affects admission ordering within an iteration, not kernel output. Existing scheduler tests pass locally.

## Speed Tests and Profiling

Reproducer and raw data for the saturation sweep below live on a pinned fork snapshot (not part of this PR): [`sandyhu533/sglang@51c7786:ttft_ablation/`](https://github.com/sandyhu533/sglang/tree/51c77862d3b329d9b9604480d48bb1b2bf721228/ttft_ablation). Relevant files:

- `run_throughput.sh` — ShareGPT saturation sweep harness (configs A/E3)
- `parse_throughput.py` — aggregation + paired-seed stats
- `results/throughput/sweep/` — raw per-seed JSONs for every cell cited below

Root-cause analysis and the fixed-workload ablation that led to E3 are discussed in issue #22831.

### Setup

- **Model**: `Qwen/Qwen3-0.6B`
- **Workload**: ShareGPT, 1000 prompts, `max_concurrency ∈ {32, 64, 128}`, `chunk_size=2048` (default), `warmup_requests=1`
- **Seeds**: `s ∈ {0..9}` per cell (n=10, paired across A and E3)
- **Configs**:
  - `A`: baseline, no env flag
  - `E3`: `SGLANG_TTFT_HOL_SMART=1` (this PR)
- **Run script / parser**: see the pinned `ttft_ablation/` snapshot referenced above

### Workload choice & expected impact

HOL only triggers when a single head-of-queue prompt is bigger than the current `rem_total_tokens` budget, with smaller requests queued behind it. Two workloads bracket the impact:

**Issue repro** (#22831 ablation): synthetic bimodal workload. 40 large requests (~11 k input tokens each, from `--large-words 3500` under Qwen3 tokenization) co-fire at t=0 with a stream of 120 small requests (~50 input tokens each, from `--small-words 40`). Every large request individually consumes 2–10× typical `rem_total_tokens` headroom during a running batch, so HOL events trigger frequently. **Upper bound on E3's impact.**

**ShareGPT** (this PR): industry-standard serving benchmark, 1000 conversations, Qwen3-0.6B tokenizer. Right-tailed distribution (median 142 / p99 2821 input tokens) — the tail exists but sits well below typical KV headroom, so HOL events are rare but reproducible. **Lower bound / safety check on homogeneous production workloads.**

| workload     | % prompts > 2 k tok | p99 / median length | small p99 TTFT (A → E3) |
| ------------ | ------------------: | ------------------: | --- |
| Issue repro  | **25 %**            | **220 ×**           | **10.9 – 27.2 s → 2.85 – 3.17 s (3.4× – 9.5×)** |
| ShareGPT     | 1.9 %               | 21 ×                | 200 ms → 160 ms healthy-path (−3.4 %); 2/10 baseline seeds see HOL events → 0/10 with E3 |

Both workloads are heavy-tailed but trigger HOL at very different rates (deterministic in the repro vs 2/10 in ShareGPT). The differentiator is absolute tail length vs `rem_total_tokens` (what the guard checks). Production traffic falls between these two brackets — chat-only closer to ShareGPT, mixed RAG + chat closer to the repro. Full issue-repro data: [EXPERIMENT_LOG.md](https://github.com/sandyhu533/sglang/blob/51c77862d3b329d9b9604480d48bb1b2bf721228/ttft_ablation/EXPERIMENT_LOG.md).

### Results summary (paired seed, n=10)

The **HOL event rate** is the direct measurement of the bug. The TTFT/ITL/throughput tables below are regression checks on the rest of the distribution.

#### HOL events (full n=10)

An HOL event = a baseline seed whose TTFT distribution is visibly shifted up vs other seeds at the same concurrency (per-seed detail in Finding 1).

| concurrency | baseline | with E3 | Wilson 95% CI on baseline |
| ---: | :--- | :--- | --- |
| 32  | **2/10** | **0/10** | [6%, 51%] |
| 64  | 0/10 | 0/10 | — |
| 128 | 0/10 | 0/10 | — |

The Wilson lower bound of 6% rules out "purely incidental" — this bug reproduces at a non-trivial rate even on the conservative end. The issue-repro workload (deterministic HOL trigger) confirms the mechanism with a 3.4×–9.5× small-req p99 TTFT gain.

#### Full distribution (n=10)

c=32 is bimodal (2 HOL seeds + 8 healthy), so we report descriptive Δ instead of t-test there. c=64/128 never trigger HOL — paired t-test applies normally.

| metric         | c=32 (n=10)         | c=64 (n=10)    | c=128 (n=10)   |
| -------------- | ------------------- | -------------- | -------------- |
| output tok/s Δ | +7.9% (bimodal)     | −0.2% (p=0.84) | −0.9% (p=0.52) |
| **p99 TTFT Δ** | **−32% (bimodal)**  | −4.1% (p=0.32) | −0.8% (p=0.91) |
| median TTFT Δ  | unchanged           | −0.8%          | −0.8%          |
| p99 ITL Δ      | (bimodal)           | +2.1% (p=0.22) | +2.5% (p=0.20) |

The c=32 numbers come entirely from E3 pulling the 2 HOL seeds (s2, s4) back into the healthy cluster; the other 8 seeds barely move. That's the expected shape for a targeted bug fix (Finding 2).

#### Healthy seeds only (safety check)

Excluding the 2 HOL seeds at c=32 (paired n=8) shows what E3 does on seeds where the bug never fires:

| metric         | c=32 healthy (n=8) | c=64 (n=10)    | c=128 (n=10)   |
| -------------- | ------------------ | -------------- | -------------- |
| output tok/s Δ | +0.8% (p=0.22)     | −0.2% (p=0.84) | −0.9% (p=0.52) |
| median TTFT Δ  | −0.5%              | −0.8%          | −0.8%          |
| mean TTFT Δ    | −1.0% (p=0.26)     | −2.5% (p=0.32) | −0.3% (p=0.95) |
| p99 TTFT Δ     | −3.4% (p=0.34)     | −4.1% (p=0.32) | −0.8% (p=0.91) |
| p99 ITL Δ      | −0.6% (p=0.52)     | +2.1% (p=0.22) | +2.5% (p=0.20) |

All Δ within [−4%, +3%], nothing significant at n=10. The fix is a no-op on healthy seeds — the guard only fires on `NO_TOKEN AND rem_total_tokens > 0`, which is exactly the pathological path.

### Key findings

**1. E3 eliminates the HOL events seen in baseline.**
At c=32, baseline triggers HOL in **2/10 seeds** (Wilson 95% CI [6%, 51%]):

- `A_c32_s2` (severe): p99 TTFT 678 ms vs ~186 ms healthy; mean 118 ms vs ~40 ms; ITL p99 185 ms vs ~37 ms; duration 242 s vs 98 s — the whole distribution shifts up, consistent with a sustained admission-loop freeze.
- `A_c32_s4` (mild): p99 TTFT 367 ms vs ~180 ms (+100%), ITL p99 73 ms vs ~37 ms (+97%); median and duration unchanged — a localized HOL window.

Under E3, both s2 and s4 land inside the healthy cluster → 0/10. c=64 and c=128 never trigger HOL on ShareGPT (concurrency-saturated, `token_usage ≤ 0.43`) — the precondition `NO_TOKEN + rem_total_tokens > 0` rarely holds.

**2. The fix only acts when the bug fires — bimodal aggregate is the expected shape.**
Healthy seeds: no-op. Pathological seeds: distribution snaps back to healthy. The −32% aggregate p99 TTFT at c=32 is a weighted average of those two regimes, not a uniform speedup.

**3. Healthy-path scheduling is not perturbed.**
On healthy seeds (n=8 at c=32, full n=10 at c=64/128), all paired Δ in TTFT and throughput fall within [−4%, +3%] and none reach significance. Median TTFT stays within ±1% at every concurrency.

**4. Throughput is neutral.**
Paired Δ between −0.9% and +0.8% on the healthy subsets, all p ≥ 0.22. The earlier n=3 reading of −3.8% at c=128 converged to −0.9% (p=0.52) at n=10.

**5. Small ITL p99 elevation at saturation — non-significant.**
+2.1% at c=64, +2.5% at c=128 (p ≥ 0.20, 4/10 seeds improving each). Likely E3 occasionally admits a small that briefly co-runs with decodes, inflating tail ITL. Not profiled. If reproducible in production, `max_skips_per_outer_iter` is a bounded follow-up.

## Checklist

[x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
[x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
[x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
[x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
[x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
  - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

