### PR TITLE
Revert "perf: optimize PCG inductor path for FP8 models (#21734)"

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
 from sglang.srt.layers.quantization.fp8_kernel import (
     fp8_dtype,
     fp8_max,
-    fp8_min,
     is_fp8_fnuz,
     mxfp8_block_scaled_matmul_triton,
     per_token_group_quant_fp8,
@@ -29,7 +28,6 @@ from sglang.srt.layers.quantization.fp8_kernel import (
     w8a8_block_fp8_matmul_deepgemm,
     w8a8_block_fp8_matmul_triton,
 )
-from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import (
     ceil_align,
     ceil_div,
@@ -1457,32 +1455,12 @@ def apply_fp8_linear(
         num_token_padding = output_padding
         if cutlass_fp8_supported and weight_scale.numel() == weight.shape[1]:
             num_token_padding = None
-        # For static per-tensor activation scales when using inductor compiler,
-        # use pure PyTorch ops instead of the opaque sgl_kernel quant kernel.
-        # Inductor fuses these with surrounding ops (RMSNorm, residual add),
-        # eliminating a separate kernel launch per linear layer.
-        # weight_scale shape does not matter here -- it is only used in the
-        # GEMM epilogue, not in the activation quant fusion. Only activates when
-        # piecewise_cuda_graph_compiler=inductor; eager PCG and decode both
-        # use the faster custom kernel.
-        if (
-            input_scale is not None
-            and input_scale.numel() == 1
-            and get_global_server_args().piecewise_cuda_graph_compiler == "inductor"
-        ):
-            qinput = (
-                (input_2d * input_scale.reciprocal())
-                .clamp(min=fp8_min, max=fp8_max)
-                .to(fp8_dtype)
-            )
-            x_scale = input_scale
-        else:
-            qinput, x_scale = scaled_fp8_quant(
-                input_2d,
-                input_scale,
-                num_token_padding=num_token_padding,
-                use_per_token_if_dynamic=use_per_token_if_dynamic,
-            )
+        qinput, x_scale = scaled_fp8_quant(
+            input_2d,
+            input_scale,
+            num_token_padding=num_token_padding,
+            use_per_token_if_dynamic=use_per_token_if_dynamic,
+        )
     else:
         # cutlass w8a8 fp8 sgl-kernel only supports per-token scale
         if input_scale is not None:

--- a/python/sglang/srt/models/utils.py
+++ b/python/sglang/srt/models/utils.py
@@ -30,7 +30,6 @@ from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
-from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import get_current_device_stream_fast, is_cuda, is_hip
 from sglang.srt.utils.custom_op import register_custom_op
 
@@ -423,8 +422,6 @@ def apply_qk_norm(
         and allow_inplace  # TODO(dark): this can be relaxed if needed
         and (q_eps == k_eps)  # TODO(dark): this can also be relaxed
         and not envs.SGLANG_ENABLE_DETERMINISTIC_INFERENCE.get()
-        and get_global_server_args().piecewise_cuda_graph_compiler
-        != "inductor"  # let inductor fuse QK norm
         and can_use_fused_inplace_qknorm(head_dim, q.dtype)
     ):
         fused_inplace_qknorm(
@@ -440,16 +437,16 @@ def apply_qk_norm(
     if alt_stream is not None and get_is_capture_mode():
         current_stream = get_current_device_stream_fast()
         alt_stream.wait_stream(current_stream)
-        q_by_head = q.view(*q.shape[:-1], -1, head_dim)
+        q_by_head = q.reshape(-1, head_dim)
         q_by_head = q_norm(q_by_head)
         with torch.cuda.stream(alt_stream):
-            k_by_head = k.view(*k.shape[:-1], -1, head_dim)
+            k_by_head = k.reshape(-1, head_dim)
             k_by_head = k_norm(k_by_head)
         current_stream.wait_stream(alt_stream)
     else:
-        q_by_head = q.view(*q.shape[:-1], -1, head_dim)
+        q_by_head = q.reshape(-1, head_dim)
         q_by_head = q_norm(q_by_head)
-        k_by_head = k.view(*k.shape[:-1], -1, head_dim)
+        k_by_head = k.reshape(-1, head_dim)
         k_by_head = k_norm(k_by_head)
     q = q_by_head.view(q.shape)
     k = k_by_head.view(k.shape)


### PR DESCRIPTION
## Summary

Reverts #21734 (`perf: optimize PCG inductor path for FP8 models`, commit 6da3aba6a5d62f9b9b976553c46b5d45b88b3b13).

Re-submission of the previously closed #23039, this time with full Tier 2 + Tier 3 AMD CI verification evidence.

cc @jasperjiaguo , @HaiShaw

## Motivation

#21734 introduces a non-recoverable `Memory access fault by GPU` on AMD CI that takes down 7+ tests across 14 model files. The faulty change is in `python/sglang/srt/models/utils.py::apply_qk_norm`, where four `q.reshape(-1, head_dim)` / `k.reshape(-1, head_dim)` calls are replaced with `q.view(*q.shape[:-1], -1, head_dim)` / `k.view(*k.shape[:-1], -1, head_dim)`:

- Under PCG capture mode `q` / `k` are frequently non-contiguous (stride-trick views from the QKV split), so `.view()` yields a tensor whose stride disagrees with what the downstream `q_norm` / `k_norm` kernels expect.
- The kernel then writes into an unmapped page, producing the fingerprint `Memory access fault by GPU node-2 (Agent handle: 0x...) on address 0x7f...` immediately followed by `scheduler died with exit code -6` / `SIGKILL -9` / 30-min action timeout.
- `apply_qk_norm` is called from **14 model files** (`qwen3.py`, `qwen3_5.py`, `qwen3_next.py`, `qwen3_moe.py`, `llada2.py`, `glm4_moe.py`, `olmo2.py`, `commandr.py`, `dflash.py`, `sdar.py`, `sdar_moe.py`, `bailing_moe.py`, `bailing_moe_linear.py`, `afmoe.py`), so the regression is **not limited to FP8 models** as the PR title suggests; bf16 models hit it too.

## Evidence

**Bisect:**

- The PR's own check ([run 24262716047 partition 4](https://github.com/sgl-project/sglang/actions/runs/24262716047/job/70897227241), Apr 11) was already failing with `Memory access fault ... addr 0x7f28244bf000`. This is **before** the aiter 0.1.12.post1 bump (Apr 13), so the regression cannot be attributed to aiter.
- Baseline AMD schedule PR test ([run 24527146590](https://github.com/sgl-project/sglang/actions/runs/24527146590)) hits the same fingerprint on partitions 2 / 4 / 8 / 10 / 12 / 13 of `stage-b-test-1-gpu-small-amd`.

**Affected tests (all share the same fault fingerprint):**

- `test_lora_load_from_tensor.py`
- `test_priority_metrics.py`
- `test_metrics.py`
- `test_llada2_mini.py`
- `test_llada2_mini_amd.py`
- `test_reasoning.py`
- `test_deterministic.py`
- (likely) `test_eagle_dp_attention.py`

**Manual revert verification:**

- One-shot revert run [24450852614](https://github.com/sgl-project/sglang/actions/runs/24450852614): `test_priority_metrics.py` 70s PASS / `test_metrics.py` 73s PASS / `test_deterministic.py` 155s PASS / `test_llada2_mini.py` 293s PASS, all `Memory access fault` occurrences gone.

**Tier 2 + Tier 3 verification (this revert):**

- Tier 2 [run 24596337420](https://github.com/sgl-project/sglang/actions/runs/24596337420) (Apr 18 03:55 UTC, 1h 11m): `stage-b-test-1-gpu-small-amd` + `stage-b-test-1-gpu-small-amd-nondeterministic` + `stage-c-test-4-gpu-amd` (16 jobs) all green, all 7 affected tests PASS.
- Tier 3 [run 24599716745](https://github.com/sgl-project/sglang/actions/runs/24599716745) (Apr 18 07:21 UTC, full stage matrix ~35 jobs): `Memory access fault` fingerprint **never re-appeared**.

## Modifications

- Revert `python/sglang/srt/layers/quantization/fp8_utils.py` and `python/sglang/srt/models/utils.py` to their state before 6da3aba6a.
- Diff stat: `2 files changed, 10 insertions(+), 35 deletions(-)`.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] CI verified green on this revert (Tier 2 run 24596337420 + Tier 3 run 24599716745).