### PR TITLE
[AMD] Pin peft<0.19 in pyproject_other.toml to fix ROCm CI ImportError

### DIFF
--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -99,7 +99,7 @@ srt_hip = [
 
 diffusion_hip = [
   "sglang[diffusion_common]",
-  "peft>=0.18.0",
+  "peft>=0.18.0,<0.19.0",
   "st_attn==0.0.7",
   "vsa==0.0.4",
   "runai_model_streamer>=0.15.5",
@@ -161,7 +161,7 @@ test = [
   "jsonlines",
   "matplotlib",
   "pandas",
-  "peft>=0.18.0",
+  "peft>=0.18.0,<0.19.0",
   "pytest",
   "sentence_transformers",
   "tabulate",

--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -99,7 +99,7 @@ srt_hip = [
 
 diffusion_hip = [
   "sglang[diffusion_common]",
-  "peft>=0.18.0,<0.19.0",
+  "peft>=0.18.0,<0.19.0", # Pin to <0.19.0 due to torchao incompatibility
   "st_attn==0.0.7",
   "vsa==0.0.4",
   "runai_model_streamer>=0.15.5",
@@ -161,7 +161,7 @@ test = [
   "jsonlines",
   "matplotlib",
   "pandas",
-  "peft>=0.18.0,<0.19.0",
+  "peft>=0.18.0,<0.19.0", # Pin to <0.19.0 due to torchao incompatibility
   "pytest",
   "sentence_transformers",
   "tabulate",


### PR DESCRIPTION
## Summary

Pin `peft>=0.18.0,<0.19.0` in both the `diffusion_hip` and `test` extras of `python/pyproject_other.toml` to unblock AMD ROCm CI.

## Motivation

[`peft 0.19.0`](https://github.com/huggingface/peft/releases) (released Apr 14, 2026) bumped its required `torchao` floor from `>=0.4.0` to `>=0.16.0` inside `peft.import_utils.is_torchao_available` ([huggingface/peft#3101](https://github.com/huggingface/peft/commit/2d488820ab039f31e1289e5b4f66e4fee176593b)). The ROCm Docker image used by AMD CI (`rocm/sgl-dev:v0.5.x-rocm700-mi30x-*`) ships `torchao==0.9.0`, so any test path that imports `peft.tuners.lora.torchao.dispatch_torchao` now hits:

```
ImportError: Found an incompatible version of torchao.
Found version 0.9.0, but only versions above 0.16.0 are supported
```

This kills HFRunner subprocesses with `exit code 1 before producing output`, breaking two LoRA reference-comparison tests:

- `test/registered/lora/test_multi_lora_backend.py::TestMultiLoRABackend::test_ci_lora_models_multi_batch`
- `test/registered/lora/test_lora_hf_sgl_logprob_diff.py::test_lora_logprob_comparison_basic`

Fingerprint in baseline AMD nightly [run 24527146590](https://github.com/sgl-project/sglang/actions/runs/24527146590) (partitions 11 & 12 of `stage-b-test-1-gpu-small-amd`):https://github.com/sgl-project/sglang/actions/runs/24527146590/job/71700328208#step:6:1348

```
File ".../peft/tuners/lora/torchao.py", line 142, in dispatch_torchao
File ".../peft/import_utils.py", line 143, in is_torchao_available
ImportError: Found an incompatible version of torchao. Found version 0.9.0, but only versions above 0.16.0 are supported
```

## Why `python/pyproject_other.toml`

`scripts/ci/amd/amd_ci_install_dependency.sh:123` renames `pyproject_other.toml` to `pyproject.toml` inside the container before `pip install -e`:

```bash
docker exec ci_sglang bash -c \
  'rm -rf python/pyproject.toml && mv python/pyproject_other.toml python/pyproject.toml'
```

So `pyproject_other.toml` is the file AMD CI actually resolves dependencies from. #23072 covers the AMD wheel pyproject (`3rdparty/amd/wheel/sglang/pyproject.toml`); this PR covers the CI install path.

## Verification

[Run 24563832425](https://github.com/sgl-project/sglang/actions/runs/24563832425) on `bingxche/fix-peft-torchao-amd` (workflow_dispatch, `stage-b-test-1-gpu-small-amd` only):

| Test | Partition | Baseline | After pin |
|---|---|---|---|
| `test_multi_lora_backend.py` | 11 | `Ran 3 tests in 144s → FAILED (errors=1)` | **PASS, 30.0 min** |
| `test_lora_hf_sgl_logprob_diff.py` | 12 | `subprocess died with exit code 1` | **PASS, 196s** (overall logprob 2/2 + 5/5 + 5/5) |

Tier 3 re-verification on [run 24599716745](https://github.com/sgl-project/sglang/actions/runs/24599716745): both tests continue to PASS in partitions 11 / 12, no regression in any other partition.

## Modifications

`python/pyproject_other.toml`:

- `diffusion_hip` extras: `peft>=0.18.0` → `peft>=0.18.0,<0.19.0`
- `test` extras: `peft>=0.18.0` → `peft>=0.18.0,<0.19.0`

Diff stat: `1 file changed, 2 insertions(+), 2 deletions(-)`.

## Note on long-term fix

Bumping `torchao` in the ROCm image to `>=0.16.0` would also fix this and let us stay on the latest peft. Pinning here is the immediate unblock; image bump can be a follow-up PR.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] CI verified green on this pin (run 24563832425 + 24599716745).