### PR TITLE
Fix CUDA 13 cudaMemcpyBatchAsync segfault and restore hicache CI

### DIFF
--- a/scripts/ci/cuda/ci_cleanup_venv.sh
+++ b/scripts/ci/cuda/ci_cleanup_venv.sh
@@ -10,14 +10,41 @@
 set +e
 set -u
 
-# Skip entirely when venv mode is disabled — no /tmp/sglang-ci-* dir exists
-# and there's nothing to sweep. Matches the USE_VENV parsing in
-# ci_install_dependency.sh (accepts 1/true/yes, case-insensitive).
+# Matches the USE_VENV parsing in ci_install_dependency.sh (accepts
+# 1/true/yes, case-insensitive).
 USE_VENV_RAW="${USE_VENV:-true}"
 case "$(printf '%s' "$USE_VENV_RAW" | tr '[:upper:]' '[:lower:]')" in
     1 | true | yes) ;;
     *)
-        echo "USE_VENV=${USE_VENV_RAW}: skipping venv cleanup"
+        # USE_VENV=false path: there is no /tmp/sglang-ci-* venv to drop,
+        # but system site-packages can carry over stale trees between jobs.
+        # Observed: `uv pip uninstall flashinfer-python` leaves flashinfer/data/
+        # behind because flashinfer-cubin owns files beneath it, so the next
+        # job's `uv pip install -e python[...]` fails with
+        # "failed to create directory flashinfer/data/: File exists (os error 17)".
+        # See https://github.com/sgl-project/sglang/actions/runs/24634237642/job/72027123887
+        #
+        # Fully uninstall the flashinfer trio and rm -rf any residual package
+        # dirs so the next setup starts from a clean slate. Cached wheels
+        # under ~/.cache/flashinfer-wheels/ keep the reinstall fast.
+        echo "USE_VENV=${USE_VENV_RAW}: purging flashinfer leftovers from system site-packages"
+        python3 -m pip uninstall -y \
+            flashinfer-python flashinfer-cubin flashinfer-jit-cache \
+            >/dev/null 2>&1 || true
+
+        SITE_PACKAGES="$(python3 -c 'import site; print(site.getsitepackages()[0])' 2>/dev/null)"
+        if [ -n "${SITE_PACKAGES:-}" ] && [ -d "$SITE_PACKAGES" ]; then
+            for pkg in flashinfer flashinfer_cubin flashinfer_jit_cache; do
+                stale="${SITE_PACKAGES}/${pkg}"
+                if [ -e "$stale" ] || [ -L "$stale" ]; then
+                    if rm -rf "$stale"; then
+                        echo "Purged ${stale}"
+                    else
+                        echo "::warning::Failed to remove ${stale}"
+                    fi
+                fi
+            done
+        fi
         exit 0
         ;;
 esac

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -315,6 +315,16 @@ echo "Installing python extras: [${EXTRAS}]"
 # source "${SCRIPT_DIR}/cache_nvidia_wheels.sh"
 $PIP_CMD install -e "python[${EXTRAS}]" $PIP_INSTALL_SUFFIX
 
+# Purge orphaned nvidia-cuda-runtime-cu12 left over from pre-cu13 installs.
+# It ships libcudart.so.12 under nvidia/cuda_runtime/lib/ while the cu13 runtime
+# lives under nvidia/cu13/lib/, so having both on LD_LIBRARY_PATH makes
+# cudnn_frontend_shim.h dlopen both and throw:
+#   RuntimeError: Multiple libcudart libraries found: libcudart.so.12 and libcudart.so.13
+# Observed on CI runners carrying state from the pre-#23119 (cu129) era; nothing
+# currently depends on it (Required-by: empty), and its install dir is disjoint
+# from cu13's so the uninstall doesn't disturb any shared cu13 files.
+$PIP_UNINSTALL_CMD nvidia-cuda-runtime-cu12 $PIP_UNINSTALL_SUFFIX || true
+
 mark_step_done "Install main package"
 
 # ------------------------------------------------------------------------------

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -282,6 +282,25 @@ FLASHINFER_UNINSTALL="flashinfer-python"
 $PIP_UNINSTALL_CMD $FLASHINFER_UNINSTALL $PIP_UNINSTALL_SUFFIX || true
 $PIP_UNINSTALL_CMD opencv-python opencv-python-headless $PIP_UNINSTALL_SUFFIX || true
 
+# `uv pip uninstall flashinfer-python` leaves the flashinfer/data/ subdir
+# behind when flashinfer-cubin is kept (cubin files sit under that tree),
+# which breaks the next `uv pip install -e python[...]` with
+# "failed to create directory flashinfer/data/: File exists (os error 17)".
+# See https://github.com/sgl-project/sglang/actions/runs/24634237642/job/72027123887
+#
+# Purge any residual flashinfer/ tree. If we wipe it, cubin's files go with
+# it, so force cubin to reinstall too (150 MB, fetched via the flashinfer
+# artifacts step below).
+SITE_PACKAGES=$(python3 -c 'import site; print(site.getsitepackages()[0])' 2>/dev/null || true)
+if [ -n "$SITE_PACKAGES" ] && [ -d "$SITE_PACKAGES/flashinfer" ]; then
+    rm -rf "$SITE_PACKAGES/flashinfer"
+    echo "Purged residual $SITE_PACKAGES/flashinfer after uninstall"
+    if [ "$UNINSTALL_CUBIN" = false ]; then
+        $PIP_UNINSTALL_CMD flashinfer-cubin $PIP_UNINSTALL_SUFFIX || true
+        UNINSTALL_CUBIN=true
+    fi
+fi
+
 mark_step_done "Uninstall Flashinfer"
 
 # ------------------------------------------------------------------------------

--- a/sgl-kernel/csrc/kvcacheio/transfer.cu
+++ b/sgl-kernel/csrc/kvcacheio/transfer.cu
@@ -812,9 +812,19 @@ inline void transfer_kv_page_first_direct_impl(
     return;
   }
 
-  // CUDA 13.0 removed the failIdx parameter from cudaMemcpyBatchAsync.
-  // Use runtime version to select the correct signature for binary portability.
-  const bool use_v13_signature = driver_version >= 13000;
+  // CUDA 13.0 removed the failIdx parameter from cudaMemcpyBatchAsync. The ABI
+  // of the dlsym'd symbol is determined by the libcudart loaded in this process,
+  // not the host driver — a cu12 runtime on a cu13 driver host (common in
+  // containers) still exposes the 9-param v12 signature. Dispatching on the
+  // driver version here would segfault in that case (verified empirically).
+  // Use cudaRuntimeGetVersion so the signature follows the runtime.
+  int runtime_version = 0;
+  cudaError_t runtime_version_err = cudaRuntimeGetVersion(&runtime_version);
+  if (runtime_version_err != cudaSuccess) {
+    fallback_to_page_copy();
+    return;
+  }
+  const bool use_v13_signature = runtime_version >= 13000;
 
   size_t num_copies = 0;
   std::vector<void*> batch_srcs;

--- a/sgl-kernel/csrc/kvcacheio/transfer.cu
+++ b/sgl-kernel/csrc/kvcacheio/transfer.cu
@@ -806,16 +806,15 @@ inline void transfer_kv_page_first_direct_impl(
   }
 
   // Symbol gate: runtime may not expose cudaMemcpyBatchAsync in some environments.
-  using CudaMemcpyBatchAsyncFn =
-      cudaError_t (*)(void**, void**, size_t*, size_t, cudaMemcpyAttributes*, size_t*, size_t, size_t*, cudaStream_t);
-  static CudaMemcpyBatchAsyncFn cuda_memcpy_batch_async = []() {
-    void* symbol = dlsym(RTLD_DEFAULT, "cudaMemcpyBatchAsync");
-    return reinterpret_cast<CudaMemcpyBatchAsyncFn>(symbol);
-  }();
-  if (cuda_memcpy_batch_async == nullptr) {
+  static void* cuda_memcpy_batch_async_sym = dlsym(RTLD_DEFAULT, "cudaMemcpyBatchAsync");
+  if (cuda_memcpy_batch_async_sym == nullptr) {
     fallback_to_page_copy();
     return;
   }
+
+  // CUDA 13.0 removed the failIdx parameter from cudaMemcpyBatchAsync.
+  // Use runtime version to select the correct signature for binary portability.
+  const bool use_v13_signature = driver_version >= 13000;
 
   size_t num_copies = 0;
   std::vector<void*> batch_srcs;
@@ -916,17 +915,36 @@ inline void transfer_kv_page_first_direct_impl(
 
   TORCH_CHECK(batch_srcs.size() == num_copies, "Batch memcpy count mismatch");
   if (num_copies > 0) {
+    cudaError_t err;
     size_t fail_idx = std::numeric_limits<size_t>::max();
-    cudaError_t err = cuda_memcpy_batch_async(
-        batch_dsts.data(),
-        batch_srcs.data(),
-        batch_sizes.data(),
-        num_copies,
-        &attrs,
-        attrs_idxs.data(),
-        1,
-        &fail_idx,
-        stream);
+    if (use_v13_signature) {
+      using FnV13 = cudaError_t (*)(
+          void* const*,
+          const void* const*,
+          const size_t*,
+          size_t,
+          cudaMemcpyAttributes*,
+          size_t*,
+          size_t,
+          cudaStream_t);
+      auto fn = reinterpret_cast<FnV13>(cuda_memcpy_batch_async_sym);
+      err = fn(
+          batch_dsts.data(), batch_srcs.data(), batch_sizes.data(), num_copies, &attrs, attrs_idxs.data(), 1, stream);
+    } else {
+      using FnV12 = cudaError_t (*)(
+          void**, void**, size_t*, size_t, cudaMemcpyAttributes*, size_t*, size_t, size_t*, cudaStream_t);
+      auto fn = reinterpret_cast<FnV12>(cuda_memcpy_batch_async_sym);
+      err =
+          fn(batch_dsts.data(),
+             batch_srcs.data(),
+             batch_sizes.data(),
+             num_copies,
+             &attrs,
+             attrs_idxs.data(),
+             1,
+             &fail_idx,
+             stream);
+    }
     if (err == cudaErrorNotSupported || err == cudaErrorCallRequiresNewerDriver) {
       fallback_to_page_copy();
       return;

--- a/test/registered/4-gpu-models/test_qwen35_hicache.py
+++ b/test/registered/4-gpu-models/test_qwen35_hicache.py
@@ -1,8 +1,3 @@
-"""
-# TODO: Fails on cu13 venv migration. Ref: https://github.com/sgl-project/sglang/actions/runs/24616960626/job/71980705674?pr=23119
-# Should move back to registered test after it's fixed
-"""
-
 import shutil
 import tempfile
 import unittest

--- a/test/registered/hicache/test_hicache_storage.py
+++ b/test/registered/hicache/test_hicache_storage.py
@@ -3,11 +3,6 @@ from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 register_cuda_ci(est_time=99, suite="stage-b-test-1-gpu-small")
 register_amd_ci(est_time=300, suite="stage-b-test-1-gpu-small-amd")
 
-"""
-# TODO: Segmentation fault occurs when upgraded to Cu13. Ref: https://github.com/sgl-project/sglang/actions/runs/24603159715/job/71945537414?pr=23119")
-# Should move back to registered test after it's fixed
-"""
-
 import time
 import unittest
 

--- a/test/registered/hicache/test_hicache_storage_3fs_backend.py
+++ b/test/registered/hicache/test_hicache_storage_3fs_backend.py
@@ -2,8 +2,6 @@
 Benchmark tests for HiCache Storage with 3FS backend.
 Usage:
     python3 -m pytest test/registered/hicache/test_hicache_storage_3fs_backend.py -v
-# TODO: Segmentation fault occurs when upgraded to Cu13. Ref: https://github.com/sgl-project/sglang/actions/runs/24603159715/job/71945537414?pr=23119")
-# Should move back to registered test after it's fixed
 """
 
 import json

--- a/test/registered/hicache/test_hicache_storage_file_backend.py
+++ b/test/registered/hicache/test_hicache_storage_file_backend.py
@@ -2,8 +2,6 @@
 E2E tests for HiCache Storage functionality.
 Usage:
     python3 -m pytest test/registered/hicache/test_hicache_storage_file_backend.py -v
-# TODO: Segmentation fault occurs when upgraded to Cu13. Ref: https://github.com/sgl-project/sglang/actions/runs/24603159715/job/71945537414?pr=23119")
-# Should move back to registered test after it's fixed
 """
 
 import json

--- a/test/registered/hicache/test_hicache_storage_mooncake_backend.py
+++ b/test/registered/hicache/test_hicache_storage_mooncake_backend.py
@@ -4,9 +4,6 @@ Usage:
     python3.10 -m pytest test/registered/hicache/test_hicache_storage_mooncake_backend.py -v
 """
 
-# TODO: Segmentation fault occurs when upgraded to Cu13. Ref: https://github.com/sgl-project/sglang/actions/runs/24601791606/job/71942123195?pr=23119")
-# Should move back to registered test after it's fixed
-
 import os
 import subprocess
 import time
@@ -15,12 +12,15 @@ import unittest
 import requests
 from test_hicache_storage_file_backend import HiCacheStorageBaseMixin
 
+from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import (
     DEFAULT_MLA_MODEL_NAME_FOR_TEST,
     CustomTestCase,
     find_available_port,
     is_in_ci,
 )
+
+register_cuda_ci(est_time=236, suite="stage-b-test-2-gpu-large")
 
 
 class HiCacheStorageMooncakeBackendBaseMixin(HiCacheStorageBaseMixin):

--- a/test/registered/hicache/test_hicache_storage_runtime_attach_detach.py
+++ b/test/registered/hicache/test_hicache_storage_runtime_attach_detach.py
@@ -7,8 +7,6 @@ HTTP endpoints.
 
 Usage:
     python3 -m pytest test/registered/hicache/test_hicache_storage_runtime_attach_detach.py -v
-# TODO: Segmentation fault occurs when upgraded to Cu13. Ref: https://github.com/sgl-project/sglang/actions/runs/24603159715/job/71945537414?pr=23119")
-# Should move back to registered test after it's fixed
 """
 
 import json

--- a/test/registered/hicache/test_hicache_variants.py
+++ b/test/registered/hicache/test_hicache_variants.py
@@ -5,8 +5,6 @@ register_amd_ci(est_time=524, suite="stage-b-test-1-gpu-small-amd")
 """
 Consolidated HiCache variant tests.
 Tests HiCache with different configurations: standard, MLA, EAGLE, and page size variants.
-# TODO: Segmentation fault occurs when upgraded to Cu13. Ref: https://github.com/sgl-project/sglang/actions/runs/24603159715/job/71945537414?pr=23119")
-# Should move back to registered test after it's fixed
 """
 
 import unittest


### PR DESCRIPTION
## Motivation

Ports @yhyang201's fix from #23136 and follows up by re-enabling the hicache tests that were parked under `test/manual/` while the CUDA 13 segfault was unresolved.

CUDA 13.0 removed the `failIdx` parameter from `cudaMemcpyBatchAsync` (9 params → 8). The dlsym path in `sgl-kernel/csrc/kvcacheio/transfer.cu` was hard-coded to the CUDA 12.8 signature, so the CUDA stream argument landed in the wrong slot and the runtime segfaulted inside `cuMemcpyBatchAsync_v2`. The fix uses `driver_version` at runtime to dispatch to either the CUDA 12 or CUDA 13 signature, preserving binary portability.

With the segfault fixed, the hicache tests that were temporarily moved to `test/manual/` in #23119 and the follow-on cu13 flake sweeps can run in CI again.

## Modifications

- `sgl-kernel/csrc/kvcacheio/transfer.cu`: runtime-version dispatch between the v12 and v13 `cudaMemcpyBatchAsync` signatures (ported from #23136).
- Move 7 hicache tests from `test/manual/` back to `test/registered/`:
  - `hicache/test_hicache_storage.py`
  - `hicache/test_hicache_storage_3fs_backend.py`
  - `hicache/test_hicache_storage_file_backend.py`
  - `hicache/test_hicache_storage_mooncake_backend.py` (also restores the `register_cuda_ci(est_time=236, suite="stage-b-test-2-gpu-large")` call that was dropped on the way to manual)
  - `hicache/test_hicache_storage_runtime_attach_detach.py`
  - `hicache/test_hicache_variants.py`
  - `4-gpu-models/test_qwen35_hicache.py`
- Strips the "TODO: move back after fixed" docstrings added when the files were parked.

## Accuracy Tests

Credit to @yhyang201 for the original H200 CU13 run (from #23136): all 192 tests in `sgl-kernel/tests/test_kvcacheio.py` pass; previously the suite segfaulted at `test_transfer_kv_pf_direct` (~37%).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

cc @yhyang201 @Fridge003 @alisonshao