### PR TITLE
[CI] Fix flashinfer/data/ EEXIST on uv reinstall for USE_VENV=false jobs

### DIFF
--- a/scripts/ci/cuda/ci_cleanup_venv.sh
+++ b/scripts/ci/cuda/ci_cleanup_venv.sh
@@ -10,14 +10,41 @@
 set +e
 set -u
 
-# Skip entirely when venv mode is disabled — no /tmp/sglang-ci-* dir exists
-# and there's nothing to sweep. Matches the USE_VENV parsing in
-# ci_install_dependency.sh (accepts 1/true/yes, case-insensitive).
+# Matches the USE_VENV parsing in ci_install_dependency.sh (accepts
+# 1/true/yes, case-insensitive).
 USE_VENV_RAW="${USE_VENV:-true}"
 case "$(printf '%s' "$USE_VENV_RAW" | tr '[:upper:]' '[:lower:]')" in
     1 | true | yes) ;;
     *)
-        echo "USE_VENV=${USE_VENV_RAW}: skipping venv cleanup"
+        # USE_VENV=false path: there is no /tmp/sglang-ci-* venv to drop,
+        # but system site-packages can carry over stale trees between jobs.
+        # Observed: `uv pip uninstall flashinfer-python` leaves flashinfer/data/
+        # behind because flashinfer-cubin owns files beneath it, so the next
+        # job's `uv pip install -e python[...]` fails with
+        # "failed to create directory flashinfer/data/: File exists (os error 17)".
+        # See https://github.com/sgl-project/sglang/actions/runs/24634237642/job/72027123887
+        #
+        # Fully uninstall the flashinfer trio and rm -rf any residual package
+        # dirs so the next setup starts from a clean slate. Cached wheels
+        # under ~/.cache/flashinfer-wheels/ keep the reinstall fast.
+        echo "USE_VENV=${USE_VENV_RAW}: purging flashinfer leftovers from system site-packages"
+        python3 -m pip uninstall -y \
+            flashinfer-python flashinfer-cubin flashinfer-jit-cache \
+            >/dev/null 2>&1 || true
+
+        SITE_PACKAGES="$(python3 -c 'import site; print(site.getsitepackages()[0])' 2>/dev/null)"
+        if [ -n "${SITE_PACKAGES:-}" ] && [ -d "$SITE_PACKAGES" ]; then
+            for pkg in flashinfer flashinfer_cubin flashinfer_jit_cache; do
+                stale="${SITE_PACKAGES}/${pkg}"
+                if [ -e "$stale" ] || [ -L "$stale" ]; then
+                    if rm -rf "$stale"; then
+                        echo "Purged ${stale}"
+                    else
+                        echo "::warning::Failed to remove ${stale}"
+                    fi
+                fi
+            done
+        fi
         exit 0
         ;;
 esac

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -282,6 +282,25 @@ FLASHINFER_UNINSTALL="flashinfer-python"
 $PIP_UNINSTALL_CMD $FLASHINFER_UNINSTALL $PIP_UNINSTALL_SUFFIX || true
 $PIP_UNINSTALL_CMD opencv-python opencv-python-headless $PIP_UNINSTALL_SUFFIX || true
 
+# `uv pip uninstall flashinfer-python` leaves the flashinfer/data/ subdir
+# behind when flashinfer-cubin is kept (cubin files sit under that tree),
+# which breaks the next `uv pip install -e python[...]` with
+# "failed to create directory flashinfer/data/: File exists (os error 17)".
+# See https://github.com/sgl-project/sglang/actions/runs/24634237642/job/72027123887
+#
+# Purge any residual flashinfer/ tree. If we wipe it, cubin's files go with
+# it, so force cubin to reinstall too (150 MB, fetched via the flashinfer
+# artifacts step below).
+SITE_PACKAGES=$(python3 -c 'import site; print(site.getsitepackages()[0])' 2>/dev/null || true)
+if [ -n "$SITE_PACKAGES" ] && [ -d "$SITE_PACKAGES/flashinfer" ]; then
+    rm -rf "$SITE_PACKAGES/flashinfer"
+    echo "Purged residual $SITE_PACKAGES/flashinfer after uninstall"
+    if [ "$UNINSTALL_CUBIN" = false ]; then
+        $PIP_UNINSTALL_CMD flashinfer-cubin $PIP_UNINSTALL_SUFFIX || true
+        UNINSTALL_CUBIN=true
+    fi
+fi
+
 mark_step_done "Uninstall Flashinfer"
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation

On USE_VENV=false runners, `uv pip install -e python[dev,runai,tracing]` is failing during setup with:

```
error: Failed to install: flashinfer_python-0.6.7.post3-py3-none-any.whl
  Caused by: failed to create directory \`/usr/local/lib/python3.10/dist-packages/flashinfer/data\`: File exists (os error 17)
```

Seen on `stage-a-test-1-gpu-small` at https://github.com/sgl-project/sglang/actions/runs/24634237642/job/72027123887 (from PR #23172).

### Root cause

The setup's \"Uninstall Flashinfer\" step keeps \`flashinfer-cubin\` when its version matches (`flashinfer-cubin==0.6.7.post3 already installed, keeping it`) and runs `uv pip uninstall flashinfer-python` standalone. Cubin owns entries beneath `flashinfer/data/`, so uv cannot remove the subdirectory. The subsequent `uv pip install -e python[...]` then tries to create `flashinfer/data/` and trips EEXIST.

This only happens on USE_VENV=false jobs (e.g. `stage-a-test-1-gpu-small`) because the USE_VENV=true path creates a fresh per-job venv — no stale tree to trip over. The post-job cleanup script (`scripts/ci/cuda/ci_cleanup_venv.sh`) historically short-circuits on USE_VENV=false with `skipping venv cleanup`, so nothing ever swept the leftover directory.

## Modifications

Two complementary changes:

1. **`scripts/ci/cuda/ci_install_dependency.sh`** — in-flight safeguard. Right after the flashinfer uninstall step, if `<site-packages>/flashinfer/` still exists, `rm -rf` it and force `flashinfer-cubin` to reinstall. `uv pip install -e python[...]` then repopulates `flashinfer/data/` cleanly. This makes the PR self-healing on its first run without relying on any prior job's post-cleanup having run.

2. **`scripts/ci/cuda/ci_cleanup_venv.sh`** — post-job hygiene. The USE_VENV=false arm now uninstalls `flashinfer-python`, `flashinfer-cubin`, `flashinfer-jit-cache` and `rm -rf`s their residual trees from system site-packages so the next job starts clean even if the in-flight safeguard ever regresses. Cached wheels under `~/.cache/flashinfer-wheels/` keep the reinstall fast.

## Testing

Scheduled for verification on the follow-up CI run. The failure reproduces only on runners that have the leftover state from a prior USE_VENV=false job, so the check here is essentially \"does CI setup complete successfully on the failing runner.\"

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

cc @Fridge003 @zhyncs