### PR TITLE
[CI] Pin uv venv path to /tmp/sglang-ci-venv so deep_gemm JIT cache hits

### DIFF
--- a/scripts/ci/cuda/ci_cleanup_venv.sh
+++ b/scripts/ci/cuda/ci_cleanup_venv.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
-# Remove the per-job uv venv created by ci_install_dependency.sh.
+# Remove the uv venv created by ci_install_dependency.sh.
 #
-# Meant to run in a post-job workflow step with `if: always()` so the venv is
-# destroyed even on job failure/cancel. Runner-level safety net: a cron or
-# startup task should also purge stale /tmp/sglang-ci-* directories to catch
-# cancelled or crashed jobs that never reached this cleanup.
+# The venv lives at a stable path (/tmp/sglang-ci-venv) so cached JIT kernels
+# keyed on include paths (deep_gemm, flashinfer) stay valid across runs.
+# Freshness comes from a wipe-and-recreate at the start of each job's install
+# step, not from this cleanup — so this script is purely for disk hygiene.
+#
+# Meant to run in a post-job workflow step with `if: always()` so the venv
+# doesn't outlive a failed/cancelled job any longer than necessary.
 
 # Best-effort cleanup: never fail the job.
 set +e
@@ -22,37 +25,18 @@ case "$(printf '%s' "$USE_VENV_RAW" | tr '[:upper:]' '[:lower:]')" in
         ;;
 esac
 
-# Prefer the path propagated via GITHUB_ENV. Fallback: glob for any venv from
-# this run+job (covers the case where install crashed before exporting the path).
-if [ -n "${SGLANG_CI_VENV_PATH:-}" ] && [ -d "$SGLANG_CI_VENV_PATH" ]; then
-    if rm -rf "$SGLANG_CI_VENV_PATH"; then
-        echo "Cleaned up venv: $SGLANG_CI_VENV_PATH"
+# Target the stable venv path. Prefer SGLANG_CI_VENV_PATH (set by install),
+# fall back to the hardcoded default so cleanup still works even if GITHUB_ENV
+# propagation dropped the export (e.g., install crashed very early).
+VENV_PATH="${SGLANG_CI_VENV_PATH:-/tmp/sglang-ci-venv}"
+if [ -d "$VENV_PATH" ]; then
+    if rm -rf "$VENV_PATH"; then
+        echo "Cleaned up venv: $VENV_PATH"
     else
-        echo "::warning::Failed to remove $SGLANG_CI_VENV_PATH — runner cron should sweep /tmp/sglang-ci-*"
+        echo "::warning::Failed to remove $VENV_PATH"
     fi
 else
-    matched=0
-    for venv in /tmp/sglang-ci-${GITHUB_RUN_ID:-unknownrun}-${GITHUB_JOB:-unknownjob}-*; do
-        [ -d "$venv" ] || continue
-        matched=1
-        if rm -rf "$venv"; then
-            echo "Cleaned up venv (via glob): $venv"
-        else
-            echo "::warning::Failed to remove $venv — runner cron should sweep /tmp/sglang-ci-*"
-        fi
-    done
-    [ "$matched" -eq 0 ] && echo "No venv to clean for run=${GITHUB_RUN_ID:-?} job=${GITHUB_JOB:-?}"
+    echo "No venv to clean at $VENV_PATH"
 fi
-
-# Sweep stale venvs from cancelled/crashed jobs that never reached cleanup.
-# Any /tmp/sglang-ci-* dir older than 4 hours is considered orphaned.
-stale_count=0
-for venv in /tmp/sglang-ci-*; do
-    [ -d "$venv" ] || continue
-    if find "$venv" -maxdepth 0 -mmin +240 -print -quit | grep -q .; then
-        rm -rf "$venv" && stale_count=$((stale_count + 1))
-    fi
-done
-[ "$stale_count" -gt 0 ] && echo "Swept $stale_count stale venv(s) older than 4h"
 
 exit 0

--- a/scripts/ci/cuda/ci_cleanup_venv.sh
+++ b/scripts/ci/cuda/ci_cleanup_venv.sh
@@ -1,21 +1,13 @@
 #!/bin/bash
-# Remove the uv venv created by ci_install_dependency.sh.
-#
-# The venv lives at a stable path (/tmp/sglang-ci-venv) so cached JIT kernels
-# keyed on include paths (deep_gemm, flashinfer) stay valid across runs.
-# Freshness comes from a wipe-and-recreate at the start of each job's install
-# step, not from this cleanup — so this script is purely for disk hygiene.
-#
-# Meant to run in a post-job workflow step with `if: always()` so the venv
-# doesn't outlive a failed/cancelled job any longer than necessary.
+# Disk hygiene for the uv venv created by ci_install_dependency.sh.
+# Freshness is the install side's job (wipe-recreate); this just frees /tmp
+# after each job. Run as a post-job step with `if: always()`.
 
 # Best-effort cleanup: never fail the job.
 set +e
 set -u
 
-# Skip entirely when venv mode is disabled — no /tmp/sglang-ci-* dir exists
-# and there's nothing to sweep. Matches the USE_VENV parsing in
-# ci_install_dependency.sh (accepts 1/true/yes, case-insensitive).
+# Same parse as ci_install_dependency.sh.
 USE_VENV_RAW="${USE_VENV:-true}"
 case "$(printf '%s' "$USE_VENV_RAW" | tr '[:upper:]' '[:lower:]')" in
     1 | true | yes) ;;
@@ -25,9 +17,8 @@ case "$(printf '%s' "$USE_VENV_RAW" | tr '[:upper:]' '[:lower:]')" in
         ;;
 esac
 
-# Target the stable venv path. Prefer SGLANG_CI_VENV_PATH (set by install),
-# fall back to the hardcoded default so cleanup still works even if GITHUB_ENV
-# propagation dropped the export (e.g., install crashed very early).
+# Fall back to the hardcoded default if the install step crashed before
+# exporting SGLANG_CI_VENV_PATH via GITHUB_ENV.
 VENV_PATH="${SGLANG_CI_VENV_PATH:-/tmp/sglang-ci-venv}"
 if [ -d "$VENV_PATH" ]; then
     if rm -rf "$VENV_PATH"; then

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -54,10 +54,26 @@ fi
 SYS_PYTHON_VER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
 
 if [ "$USE_VENV" = "1" ]; then
-    # Per-job unique path. Include $$ (shell PID) so concurrent/back-to-back jobs
-    # on the same runner never target the same directory even if GITHUB_JOB
-    # doesn't differentiate matrix partitions.
-    UV_VENV="/tmp/sglang-ci-${GITHUB_RUN_ID:-norun}-${GITHUB_JOB:-nojob}-$$"
+    # Stable path (no run/job id). Rationale: deep_gemm bakes the site-packages
+    # include path into nvcc flags, which then get MD5'd into the JIT cache key
+    # (DeepGEMM/csrc/jit/compiler.hpp: `-I{library_include_path}` is part of
+    # `flags` in the `{name}$${signature}$${flags}$${code}` signature). A
+    # per-job path would change every run, so the host-mounted cache at
+    # ~/.cache/deep_gemm/cache/ would accumulate unreachable entries. Holding
+    # the path constant lets cached kernels carry across runs.
+    #
+    # Freshness is guaranteed by wiping and recreating the dir at the start of
+    # each job — equivalent isolation to a per-job path, minus the cache churn.
+    # Assumes one job per runner container at a time (current SGLang CI); a
+    # second concurrent job here would have its `rm -rf` pull the venv out
+    # from under the first.
+    UV_VENV="/tmp/sglang-ci-venv"
+    rm -rf "$UV_VENV"
+    # `rm -rf` can exit 0 while leaving contents behind in edge cases (bind
+    # mounts, chattr +i, busy files on distributed fs). If the wipe is
+    # incomplete, `uv venv --seed` would layer onto stale files and the job
+    # would fail obscurely later. Assert cleanliness up front.
+    [ ! -e "$UV_VENV" ] || { echo "FATAL: $UV_VENV still exists after rm -rf"; ls -la "$UV_VENV" || true; exit 1; }
     # --seed installs pip/setuptools into the venv so bare `pip` calls in
     # cache_nvidia_wheels.sh and the human-eval setup resolve to the venv's
     # pip (rather than silently falling back to system Python).
@@ -391,15 +407,17 @@ mark_step_done "Download flashinfer artifacts"
 # Stabilize FlashInfer JIT cache paths
 # ------------------------------------------------------------------------------
 # FlashInfer JIT writes build.ninja with hardcoded -isystem paths pointing to the
-# venv's flashinfer/data/ and tvm_ffi/include/. With per-job venvs each job gets
-# a unique /tmp/sglang-ci-<run>-<job>-<pid>/ path, but the JIT cache is shared
-# on the host mount. When the next job's venv has a different path and the old one
-# is cleaned up, ninja fails because source files no longer exist at the cached path.
+# venv's flashinfer/data/ and tvm_ffi/include/. The venv itself is stable across
+# runs (/tmp/sglang-ci-venv), but two cases can still invalidate ninja paths:
+# - Legacy build.ninja files left over from the old per-job path scheme
+#   (/tmp/sglang-ci-<run>-<job>-<pid>) before this code ran on the runner.
+# - FlashInfer version bumps that rebuild $STABLE_FI_DIR (see Part 2 below),
+#   leaving ninja entries pointing into the previous stable tree.
 #
-# Fix (two parts):
-# 1. Clear only STALE cached_ops (build.ninja referencing non-existent venv paths).
-#    Do NOT clear all cached_ops — they contain compiled .so files that take 10-20 min
-#    to recompile. Only remove entries where the source paths no longer exist.
+# Two parts:
+# 1. Clear only STALE cached_ops (build.ninja referencing non-existent paths).
+#    Do NOT clear all cached_ops — they contain compiled .so files that take
+#    10-20 min to recompile. Only remove entries where source paths are gone.
 # 2. Copy source files to a stable host-mounted path and symlink each venv's
 #    copy there. build.ninja then references the stable path across all jobs.
 #

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -44,6 +44,37 @@ OPTIONAL_DEPS="${1:-}"
 USE_VENV="${USE_VENV:-0}"
 echo "USE_VENV=${USE_VENV}"
 
+# ------------------------------------------------------------------------------
+# Self-heal dangling flashinfer/tvm_ffi symlinks in system site-packages
+# ------------------------------------------------------------------------------
+# An earlier revision of the "Stabilize FlashInfer JIT cache paths" block below
+# symlinked `<site-packages>/{tvm_ffi/include,flashinfer/data}` into
+# `~/.cache/flashinfer/_stable_src/` without asserting the resolved path was
+# inside the venv. Under USE_VENV=false (and on a buggy branch where the guard
+# was missing), `python3 -c "import tvm_ffi"` returned the system path, so the
+# symlink replaced the real headers in /usr/local/lib/python3.*/dist-packages/.
+# A later job's `rm -rf "$STABLE_FI_DIR"` (on a flashinfer version bump) then
+# left the symlink dangling, and every subsequent job failed with
+#   tvm_ffi.libinfo.find_include_path() -> RuntimeError: Cannot find include path.
+# until the runner was hand-patched. The guard added to the stabilize block
+# below prevents re-planting, but runners still carrying old damage need repair.
+SYSTEM_SITE=$(/usr/bin/python3 -c 'import site; print(site.getsitepackages()[0])' 2>/dev/null || true)
+if [ -n "$SYSTEM_SITE" ]; then
+    for pair in "tvm_ffi/include apache-tvm-ffi" "flashinfer/data flashinfer-python"; do
+        # shellcheck disable=SC2086
+        set -- $pair
+        link="${SYSTEM_SITE}/$1"
+        pkg="$2"
+        if [ -L "$link" ] && [ ! -e "$link" ]; then
+            echo "::warning::Self-heal: dangling symlink ${link} -> $(readlink "$link"). Removing and force-reinstalling ${pkg}."
+            rm -f "$link"
+            # Use system pip explicitly — the venv (if any) doesn't exist yet,
+            # and we want the reinstall to target SYSTEM_SITE regardless.
+            /usr/bin/python3 -m pip install --force-reinstall --no-deps "$pkg" --root-user-action=ignore >/dev/null 2>&1 || true
+        fi
+    done
+fi
+
 # uv must be available on system Python (to create the venv, or to run
 # `uv pip install --system` when venv mode is disabled). Install if missing.
 python3 -m pip install --upgrade pip
@@ -442,6 +473,20 @@ if [ "$USE_VENV" = "1" ]; then
     # Part 2: Stabilize paths (STABLE_FI_DIR set above in Part 1)
     FI_DATA=$(python3 -c "import flashinfer, os; print(os.path.join(os.path.dirname(flashinfer.__file__), 'data'))")
     TVM_INC=$(python3 -c "import tvm_ffi, os; print(os.path.join(os.path.dirname(tvm_ffi.__file__), 'include'))")
+
+    # Refuse to clobber paths outside the venv. If python3 here ever resolves
+    # to system site-packages (misconfigured PATH, --system-site-packages,
+    # explicit /usr/bin/python3, or venv activation silently failing), the
+    # `rm -rf` + `ln -s` below would wipe system-installed headers and leave
+    # a dangling symlink once $STABLE_FI_DIR gets rebuilt on a version bump.
+    # That exact bug corrupted every persistent CI runner on 2026-04-19 and
+    # required hand-repair via the self-heal block at the top of this script.
+    for p in "$FI_DATA" "$TVM_INC"; do
+        case "$p" in
+            "$UV_VENV"/*) ;;
+            *) echo "FATAL: refusing to symlink '$p' outside venv '$UV_VENV'"; exit 1 ;;
+        esac
+    done
 
     FI_VERSION="${FLASHINFER_PYTHON_REQUIRED}"
     if [ ! -d "$STABLE_FI_DIR/flashinfer-data" ] || [ "$(cat "$STABLE_FI_DIR/.version" 2>/dev/null)" != "$FI_VERSION" ]; then

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -43,6 +43,37 @@ configure_environment() {
     USE_VENV="${USE_VENV:-0}"
     echo "USE_VENV=${USE_VENV}"
 
+    # ------------------------------------------------------------------------------
+    # Self-heal dangling flashinfer/tvm_ffi symlinks in system site-packages
+    # ------------------------------------------------------------------------------
+    # An earlier revision of the "Stabilize FlashInfer JIT cache paths" block below
+    # symlinked `<site-packages>/{tvm_ffi/include,flashinfer/data}` into
+    # `~/.cache/flashinfer/_stable_src/` without asserting the resolved path was
+    # inside the venv. Under USE_VENV=false (and on a buggy branch where the guard
+    # was missing), `python3 -c "import tvm_ffi"` returned the system path, so the
+    # symlink replaced the real headers in /usr/local/lib/python3.*/dist-packages/.
+    # A later job's `rm -rf "$STABLE_FI_DIR"` (on a flashinfer version bump) then
+    # left the symlink dangling, and every subsequent job failed with
+    #   tvm_ffi.libinfo.find_include_path() -> RuntimeError: Cannot find include path.
+    # until the runner was hand-patched. The guard added to the stabilize block
+    # below prevents re-planting, but runners still carrying old damage need repair.
+    SYSTEM_SITE=$(/usr/bin/python3 -c 'import site; print(site.getsitepackages()[0])' 2>/dev/null || true)
+    if [ -n "$SYSTEM_SITE" ]; then
+        for pair in "tvm_ffi/include apache-tvm-ffi" "flashinfer/data flashinfer-python"; do
+            # shellcheck disable=SC2086
+            set -- $pair
+            link="${SYSTEM_SITE}/$1"
+            pkg="$2"
+            if [ -L "$link" ] && [ ! -e "$link" ]; then
+                echo "::warning::Self-heal: dangling symlink ${link} -> $(readlink "$link"). Removing and force-reinstalling ${pkg}."
+                rm -f "$link"
+                # Use system pip explicitly — the venv (if any) doesn't exist yet,
+                # and we want the reinstall to target SYSTEM_SITE regardless.
+                /usr/bin/python3 -m pip install --force-reinstall --no-deps "$pkg" --root-user-action=ignore >/dev/null 2>&1 || true
+            fi
+        done
+    fi
+
     python3 -m pip install --upgrade pip
     if ! command -v uv >/dev/null 2>&1; then
         pip install uv
@@ -361,6 +392,20 @@ stabilize_flashinfer_jit_paths() {
     # Copy source files to stable path and symlink venv copies there
     FI_DATA=$(python3 -c "import flashinfer, os; print(os.path.join(os.path.dirname(flashinfer.__file__), 'data'))")
     TVM_INC=$(python3 -c "import tvm_ffi, os; print(os.path.join(os.path.dirname(tvm_ffi.__file__), 'include'))")
+
+    # Refuse to clobber paths outside the venv. If python3 here ever resolves
+    # to system site-packages (misconfigured PATH, --system-site-packages,
+    # explicit /usr/bin/python3, or venv activation silently failing), the
+    # `rm -rf` + `ln -s` below would wipe system-installed headers and leave
+    # a dangling symlink once $STABLE_FI_DIR gets rebuilt on a version bump.
+    # That exact bug corrupted every persistent CI runner on 2026-04-19 and
+    # required hand-repair via the self-heal block at the top of this script.
+    for p in "$FI_DATA" "$TVM_INC"; do
+        case "$p" in
+            "$UV_VENV"/*) ;;
+            *) echo "FATAL: refusing to symlink '$p' outside venv '$UV_VENV'"; exit 1 ;;
+        esac
+    done
 
     FI_VERSION="${FLASHINFER_PYTHON_REQUIRED}"
     if [ ! -d "$STABLE_FI_DIR/flashinfer-data" ] || [ "$(cat "$STABLE_FI_DIR/.version" 2>/dev/null)" != "$FI_VERSION" ]; then

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -48,20 +48,9 @@ configure_environment() {
     esac
     echo "USE_VENV=${USE_VENV} (input: ${USE_VENV_RAW})"
 
-    # ------------------------------------------------------------------------------
-    # Self-heal dangling flashinfer/tvm_ffi symlinks in system site-packages
-    # ------------------------------------------------------------------------------
-    # An earlier revision of the "Stabilize FlashInfer JIT cache paths" block below
-    # symlinked `<site-packages>/{tvm_ffi/include,flashinfer/data}` into
-    # `~/.cache/flashinfer/_stable_src/` without asserting the resolved path was
-    # inside the venv. Under USE_VENV=false (and on a buggy branch where the guard
-    # was missing), `python3 -c "import tvm_ffi"` returned the system path, so the
-    # symlink replaced the real headers in /usr/local/lib/python3.*/dist-packages/.
-    # A later job's `rm -rf "$STABLE_FI_DIR"` (on a flashinfer version bump) then
-    # left the symlink dangling, and every subsequent job failed with
-    #   tvm_ffi.libinfo.find_include_path() -> RuntimeError: Cannot find include path.
-    # until the runner was hand-patched. The guard added to the stabilize block
-    # below prevents re-planting, but runners still carrying old damage need repair.
+    # Repair dangling tvm_ffi/flashinfer symlinks in system site-packages
+    # (left by stabilize_flashinfer_jit_paths runs that escaped the venv).
+    # No-op when clean.
     SYSTEM_SITE=$(/usr/bin/python3 -c 'import site; print(site.getsitepackages()[0])' 2>/dev/null || true)
     if [ -n "$SYSTEM_SITE" ]; then
         for pair in "tvm_ffi/include apache-tvm-ffi" "flashinfer/data flashinfer-python"; do
@@ -72,8 +61,6 @@ configure_environment() {
             if [ -L "$link" ] && [ ! -e "$link" ]; then
                 echo "::warning::Self-heal: dangling symlink ${link} -> $(readlink "$link"). Removing and force-reinstalling ${pkg}."
                 rm -f "$link"
-                # Use system pip explicitly — the venv (if any) doesn't exist yet,
-                # and we want the reinstall to target SYSTEM_SITE regardless.
                 /usr/bin/python3 -m pip install --force-reinstall --no-deps "$pkg" --root-user-action=ignore >/dev/null 2>&1 || true
             fi
         done
@@ -87,26 +74,14 @@ configure_environment() {
     SYS_PYTHON_VER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
 
     if [ "$USE_VENV" = "1" ]; then
-        # Stable path (no run/job id). Rationale: deep_gemm bakes the
-        # site-packages include path into nvcc flags, which then get MD5'd into
-        # the JIT cache key (DeepGEMM/csrc/jit/compiler.hpp:
-        # `-I{library_include_path}` is part of `flags` in the
-        # `{name}$${signature}$${flags}$${code}` signature). A per-job path
-        # would change every run, so the host-mounted cache at
-        # ~/.cache/deep_gemm/cache/ would accumulate unreachable entries.
-        # Holding the path constant lets cached kernels carry across runs.
-        #
-        # Freshness is guaranteed by wiping and recreating the dir at the start
-        # of each job — equivalent isolation to a per-job path, minus the cache
-        # churn. Assumes one job per runner container at a time (current SGLang
-        # CI); a second concurrent job here would have its `rm -rf` pull the
-        # venv out from under the first.
+        # Stable path: deep_gemm MD5s `-I<site-packages>/deep_gemm/include`
+        # into its JIT cache key, so a per-job path rotates the key every run
+        # and ~/.cache/deep_gemm fills with unreachable entries. Assumes one
+        # job per runner container; concurrent jobs would race the rm -rf.
         UV_VENV="/tmp/sglang-ci-venv"
         rm -rf "$UV_VENV"
-        # `rm -rf` can exit 0 while leaving contents behind in edge cases (bind
-        # mounts, chattr +i, busy files on distributed fs). If the wipe is
-        # incomplete, `uv venv --seed` would layer onto stale files and the job
-        # would fail obscurely later. Assert cleanliness up front.
+        # rm -rf can exit 0 with content still present (chattr +i, bind
+        # mounts); uv venv --seed would silently layer onto stale state.
         [ ! -e "$UV_VENV" ] || { echo "FATAL: $UV_VENV still exists after rm -rf"; ls -la "$UV_VENV" || true; exit 1; }
         uv venv "$UV_VENV" --python "python${SYS_PYTHON_VER}" --seed
         # shellcheck disable=SC1091
@@ -398,13 +373,9 @@ stabilize_flashinfer_jit_paths() {
     FI_DATA=$(python3 -c "import flashinfer, os; print(os.path.join(os.path.dirname(flashinfer.__file__), 'data'))")
     TVM_INC=$(python3 -c "import tvm_ffi, os; print(os.path.join(os.path.dirname(tvm_ffi.__file__), 'include'))")
 
-    # Refuse to clobber paths outside the venv. If python3 here ever resolves
-    # to system site-packages (misconfigured PATH, --system-site-packages,
-    # explicit /usr/bin/python3, or venv activation silently failing), the
-    # `rm -rf` + `ln -s` below would wipe system-installed headers and leave
-    # a dangling symlink once $STABLE_FI_DIR gets rebuilt on a version bump.
-    # That exact bug corrupted every persistent CI runner on 2026-04-19 and
-    # required hand-repair via the self-heal block at the top of this script.
+    # Guard against python3 resolving outside the venv (broken activation,
+    # --system-site-packages): rm -rf + ln -s below would clobber system
+    # headers and dangle on the next $STABLE_FI_DIR rebuild.
     for p in "$FI_DATA" "$TVM_INC"; do
         case "$p" in
             "$UV_VENV"/*) ;;

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -51,7 +51,27 @@ configure_environment() {
     SYS_PYTHON_VER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
 
     if [ "$USE_VENV" = "1" ]; then
-        UV_VENV="/tmp/sglang-ci-${GITHUB_RUN_ID:-norun}-${GITHUB_JOB:-nojob}-$$"
+        # Stable path (no run/job id). Rationale: deep_gemm bakes the
+        # site-packages include path into nvcc flags, which then get MD5'd into
+        # the JIT cache key (DeepGEMM/csrc/jit/compiler.hpp:
+        # `-I{library_include_path}` is part of `flags` in the
+        # `{name}$${signature}$${flags}$${code}` signature). A per-job path
+        # would change every run, so the host-mounted cache at
+        # ~/.cache/deep_gemm/cache/ would accumulate unreachable entries.
+        # Holding the path constant lets cached kernels carry across runs.
+        #
+        # Freshness is guaranteed by wiping and recreating the dir at the start
+        # of each job — equivalent isolation to a per-job path, minus the cache
+        # churn. Assumes one job per runner container at a time (current SGLang
+        # CI); a second concurrent job here would have its `rm -rf` pull the
+        # venv out from under the first.
+        UV_VENV="/tmp/sglang-ci-venv"
+        rm -rf "$UV_VENV"
+        # `rm -rf` can exit 0 while leaving contents behind in edge cases (bind
+        # mounts, chattr +i, busy files on distributed fs). If the wipe is
+        # incomplete, `uv venv --seed` would layer onto stale files and the job
+        # would fail obscurely later. Assert cleanliness up front.
+        [ ! -e "$UV_VENV" ] || { echo "FATAL: $UV_VENV still exists after rm -rf"; ls -la "$UV_VENV" || true; exit 1; }
         uv venv "$UV_VENV" --python "python${SYS_PYTHON_VER}" --seed
         # shellcheck disable=SC1091
         source "$UV_VENV/bin/activate"

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -39,9 +39,14 @@ configure_environment() {
     NVIDIA_NVSHMEM_VERSION="3.4.5"
     OPTIONAL_DEPS="${1:-}"
 
-    # Whether to create a uv venv (set USE_VENV=1). Default: 0.
-    USE_VENV="${USE_VENV:-0}"
-    echo "USE_VENV=${USE_VENV}"
+    # Match ci_cleanup_venv.sh parsing — install and cleanup must agree on
+    # what USE_VENV=true means, or one runs while the other skips.
+    USE_VENV_RAW="${USE_VENV:-0}"
+    case "$(printf '%s' "$USE_VENV_RAW" | tr '[:upper:]' '[:lower:]')" in
+        1 | true | yes) USE_VENV=1 ;;
+        *)              USE_VENV=0 ;;
+    esac
+    echo "USE_VENV=${USE_VENV} (input: ${USE_VENV_RAW})"
 
     # ------------------------------------------------------------------------------
     # Self-heal dangling flashinfer/tvm_ffi symlinks in system site-packages
@@ -119,7 +124,7 @@ configure_environment() {
             echo "$UV_VENV/bin" >> "$GITHUB_PATH"
         fi
     else
-        echo "USE_VENV=0: skipping uv venv creation, installing into system Python"
+        echo "USE_VENV=${USE_VENV} (input: ${USE_VENV_RAW}): skipping uv venv creation, installing into system Python"
         UV_VENV=""
     fi
 


### PR DESCRIPTION
## Summary

- Move the per-job uv venv from `/tmp/sglang-ci-${GITHUB_RUN_ID}-${GITHUB_JOB}-$$` to a stable `/tmp/sglang-ci-venv`, wiped and recreated at the start of each install.
- Add an existence assertion after the wipe since `rm -rf` can exit 0 while leaving content behind (chattr +i, bind mounts, busy files on distributed fs).
- Simplify `ci_cleanup_venv.sh` to target the stable path.

## Why

DeepGEMM's JIT compiler MD5s the full `-I<site-packages>/deep_gemm/include` path into its kernel cache key (`DeepGEMM/csrc/jit/compiler.hpp` → `{name}$$signature$$flags$$code`). A per-job venv path rotates every run, so the host-mounted `~/.cache/deep_gemm/cache/` accumulated unreachable entries while every run paid full JIT recompile cost.

## Correctness

The original reason the path was per-job was to isolate stale state between jobs. That invariant still holds — a stable path with `rm -rf` + recreate at job start gives the same "fresh dependency set per job" guarantee, minus the cache churn.

Assumes one job per runner container at a time (current SGLang CI setup), called out in a code comment. If two concurrent jobs ever land in the same container, the second's `rm -rf` would pull the venv out from under the first.

## Test plan

- [ ] Run the CI workflow on this branch and confirm installs succeed across stage-a (`1-gpu-5090`), stage-b 1-gpu (`1-gpu-h100`), and stage-b 2-gpu.
- [ ] Verify deep_gemm JIT cache hit rate: inspect `~/.cache/deep_gemm/cache/` between two consecutive runs on the same runner and confirm the same `kernel.*.{hash}` entries are reused rather than duplicated.
- [ ] Confirm `/tmp/sglang-ci-venv` is cleaned up by the post-job step.

## Non-goals

The flashinfer `_stable_src` race across the 4 containers sharing `/root/.cache` on the same host is a separate, pre-existing issue (see job failure on PR #23172). Not addressed here.