### PR TITLE
[Log] improve log error message related to mem_fraction_static

### DIFF
--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -214,12 +214,9 @@ def alloc_token_slots(
 
     if out_cache_loc is None:
         error_msg = (
-            f"Out of memory when allocating KV cache tokens.\n"
-            f"Tried to allocate {num_tokens} tokens.\n"
-            f"{available_and_evictable_str(tree_cache)}\n"
-            f"Possible fixes:\n"
-            f"  - Reduce --max-running-requests or request batch size\n"
-            f"  - Increase --mem-fraction-static to give more memory to KV cache"
+            f"Out of memory. Try to lower your batch size.\n"
+            f"Try to allocate {num_tokens} tokens.\n"
+            f"{available_and_evictable_str(tree_cache)}"
         )
         logger.error(error_msg)
         if tree_cache is not None:
@@ -285,12 +282,9 @@ def alloc_paged_token_slots_extend(
 
     if out_cache_loc is None:
         error_msg = (
-            f"Prefill out of memory.\n"
-            f"Tried to allocate {extend_num_tokens} tokens.\n"
-            f"{available_and_evictable_str(tree_cache)}\n"
-            f"Possible fixes:\n"
-            f"  - Reduce --chunked-prefill-size or --max-running-requests\n"
-            f"  - Increase --mem-fraction-static to give more memory to KV cache"
+            f"Prefill out of memory. Try to lower your batch size.\n"
+            f"Try to allocate {extend_num_tokens} tokens.\n"
+            f"{available_and_evictable_str(tree_cache)}"
         )
         logger.error(error_msg)
         if tree_cache is not None:
@@ -414,12 +408,9 @@ def alloc_paged_token_slots_decode(
 
     if out_cache_loc is None:
         error_msg = (
-            f"Decode out of memory.\n"
-            f"Tried to allocate {len(seq_lens) * token_per_req} tokens.\n"
-            f"{available_and_evictable_str(tree_cache)}\n"
-            f"Possible fixes:\n"
-            f"  - Reduce --max-running-requests to limit concurrent decodes\n"
-            f"  - Increase --mem-fraction-static to give more memory to KV cache"
+            f"Decode out of memory. Try to lower your batch size.\n"
+            f"Try to allocate {len(seq_lens) * token_per_req} tokens.\n"
+            f"{available_and_evictable_str(tree_cache)}"
         )
         logger.error(error_msg)
         if tree_cache is not None:

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -214,9 +214,12 @@ def alloc_token_slots(
 
     if out_cache_loc is None:
         error_msg = (
-            f"Out of memory. Try to lower your batch size.\n"
-            f"Try to allocate {num_tokens} tokens.\n"
-            f"{available_and_evictable_str(tree_cache)}"
+            f"Out of memory when allocating KV cache tokens.\n"
+            f"Tried to allocate {num_tokens} tokens.\n"
+            f"{available_and_evictable_str(tree_cache)}\n"
+            f"Possible fixes:\n"
+            f"  - Reduce --max-running-requests or request batch size\n"
+            f"  - Increase --mem-fraction-static to give more memory to KV cache"
         )
         logger.error(error_msg)
         if tree_cache is not None:
@@ -282,9 +285,12 @@ def alloc_paged_token_slots_extend(
 
     if out_cache_loc is None:
         error_msg = (
-            f"Prefill out of memory. Try to lower your batch size.\n"
-            f"Try to allocate {extend_num_tokens} tokens.\n"
-            f"{available_and_evictable_str(tree_cache)}"
+            f"Prefill out of memory.\n"
+            f"Tried to allocate {extend_num_tokens} tokens.\n"
+            f"{available_and_evictable_str(tree_cache)}\n"
+            f"Possible fixes:\n"
+            f"  - Reduce --chunked-prefill-size or --max-running-requests\n"
+            f"  - Increase --mem-fraction-static to give more memory to KV cache"
         )
         logger.error(error_msg)
         if tree_cache is not None:
@@ -408,9 +414,12 @@ def alloc_paged_token_slots_decode(
 
     if out_cache_loc is None:
         error_msg = (
-            f"Decode out of memory. Try to lower your batch size.\n"
-            f"Try to allocate {len(seq_lens) * token_per_req} tokens.\n"
-            f"{available_and_evictable_str(tree_cache)}"
+            f"Decode out of memory.\n"
+            f"Tried to allocate {len(seq_lens) * token_per_req} tokens.\n"
+            f"{available_and_evictable_str(tree_cache)}\n"
+            f"Possible fixes:\n"
+            f"  - Reduce --max-running-requests to limit concurrent decodes\n"
+            f"  - Increase --mem-fraction-static to give more memory to KV cache"
         )
         logger.error(error_msg)
         if tree_cache is not None:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2833,6 +2833,20 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         forward_batch.split_index = next_split_index
         return ret
 
+    def _annotate_forward_oom(self, e: torch.cuda.OutOfMemoryError):
+        msg_lines = [
+            "CUDA out of memory during forward pass.",
+            "This usually means activation memory is insufficient.",
+            "Possible fixes:",
+            "  - Decrease --mem-fraction-static to reserve more memory for activations",
+            "  - Reduce --max-running-requests or --chunked-prefill-size",
+        ]
+        if self.mem_fraction_static is not None:
+            msg_lines.append(
+                f"Current --mem-fraction-static={self.mem_fraction_static}"
+            )
+        e.add_note("\n".join(msg_lines))
+
     def forward(
         self,
         forward_batch: ForwardBatch,
@@ -2843,11 +2857,11 @@ class ModelRunner(ModelRunnerKVCacheMixin):
     ) -> ModelRunnerOutput:
         self.forward_pass_id += 1
 
-        try:
-            with get_global_expert_distribution_recorder().with_forward_pass(
-                self.forward_pass_id,
-                forward_batch,
-            ) as recorder_outputs:
+        with get_global_expert_distribution_recorder().with_forward_pass(
+            self.forward_pass_id,
+            forward_batch,
+        ) as recorder_outputs:
+            try:
                 output = self._forward_raw(
                     forward_batch,
                     skip_attn_backend_init,
@@ -2855,20 +2869,24 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                     reinit_attn_backend,
                     split_forward_count,
                 )
-                elastic_ep_state = ElasticEPStateManager.instance()
-                if (
-                    elastic_ep_state is not None
-                    and not elastic_ep_state.is_active_equal_last()
-                ):
-                    elastic_ep_state.snapshot_active_to_last()
-                    elastic_ep_state.sync_active_to_cpu()
-                    logging.info("EPLB due to rank faults")
-                    gen = self.eplb_manager.rebalance()
-                    while True:
-                        try:
-                            next(gen)
-                        except StopIteration:
-                            break
+            except torch.cuda.OutOfMemoryError as e:
+                self._annotate_forward_oom(e)
+                raise
+            elastic_ep_state = ElasticEPStateManager.instance()
+            if (
+                elastic_ep_state is not None
+                and not elastic_ep_state.is_active_equal_last()
+            ):
+                elastic_ep_state.snapshot_active_to_last()
+                elastic_ep_state.sync_active_to_cpu()
+                logger.info("EPLB due to rank faults")
+                gen = self.eplb_manager.rebalance()
+                while True:
+                    try:
+                        next(gen)
+                    except StopIteration:
+                        break
+                try:
                     output = self._forward_raw(
                         forward_batch,
                         skip_attn_backend_init,
@@ -2876,33 +2894,25 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                         reinit_attn_backend,
                         split_forward_count,
                     )
-            output.expert_distribution_metrics = recorder_outputs.get("metrics")
+                except torch.cuda.OutOfMemoryError as e:
+                    self._annotate_forward_oom(e)
+                    raise
+        output.expert_distribution_metrics = recorder_outputs.get("metrics")
 
-            # Copy cached routing experts' buffers back to CPU cache
-            get_global_experts_capturer().on_forward_end(
-                forward_batch=forward_batch,
-                can_run_graph=output.can_run_graph,
-                cuda_graph_batch=getattr(self.graph_runner, "bs", None),
-            )
+        # Copy cached routing experts' buffers back to CPU cache
+        get_global_experts_capturer().on_forward_end(
+            forward_batch=forward_batch,
+            can_run_graph=output.can_run_graph,
+            cuda_graph_batch=getattr(self.graph_runner, "bs", None),
+        )
 
-            if self.eplb_manager is not None:
-                self.eplb_manager.on_forward_pass_end()
+        if self.eplb_manager is not None:
+            self.eplb_manager.on_forward_pass_end()
 
-            if dumper.may_enable:
-                dumper.step()
+        if dumper.may_enable:
+            dumper.step()
 
-            return output
-        except torch.cuda.OutOfMemoryError as e:
-            msg = (
-                f"CUDA out of memory during forward pass.\n"
-                f"This usually means activation memory is insufficient.\n"
-                f"Possible fixes:\n"
-                f"  - Decrease --mem-fraction-static to reserve more memory for activations\n"
-                f"  - Reduce --max-running-requests or --chunked-prefill-size"
-            )
-            if self.mem_fraction_static is not None:
-                msg += f"\nCurrent --mem-fraction-static={self.mem_fraction_static}"
-            raise RuntimeError(msg) from e
+        return output
 
     def _forward_raw(
         self,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2843,31 +2843,11 @@ class ModelRunner(ModelRunnerKVCacheMixin):
     ) -> ModelRunnerOutput:
         self.forward_pass_id += 1
 
-        with get_global_expert_distribution_recorder().with_forward_pass(
-            self.forward_pass_id,
-            forward_batch,
-        ) as recorder_outputs:
-            output = self._forward_raw(
+        try:
+            with get_global_expert_distribution_recorder().with_forward_pass(
+                self.forward_pass_id,
                 forward_batch,
-                skip_attn_backend_init,
-                pp_proxy_tensors,
-                reinit_attn_backend,
-                split_forward_count,
-            )
-            elastic_ep_state = ElasticEPStateManager.instance()
-            if (
-                elastic_ep_state is not None
-                and not elastic_ep_state.is_active_equal_last()
-            ):
-                elastic_ep_state.snapshot_active_to_last()
-                elastic_ep_state.sync_active_to_cpu()
-                logging.info("EPLB due to rank faults")
-                gen = self.eplb_manager.rebalance()
-                while True:
-                    try:
-                        next(gen)
-                    except StopIteration:
-                        break
+            ) as recorder_outputs:
                 output = self._forward_raw(
                     forward_batch,
                     skip_attn_backend_init,
@@ -2875,22 +2855,54 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                     reinit_attn_backend,
                     split_forward_count,
                 )
-        output.expert_distribution_metrics = recorder_outputs.get("metrics")
+                elastic_ep_state = ElasticEPStateManager.instance()
+                if (
+                    elastic_ep_state is not None
+                    and not elastic_ep_state.is_active_equal_last()
+                ):
+                    elastic_ep_state.snapshot_active_to_last()
+                    elastic_ep_state.sync_active_to_cpu()
+                    logging.info("EPLB due to rank faults")
+                    gen = self.eplb_manager.rebalance()
+                    while True:
+                        try:
+                            next(gen)
+                        except StopIteration:
+                            break
+                    output = self._forward_raw(
+                        forward_batch,
+                        skip_attn_backend_init,
+                        pp_proxy_tensors,
+                        reinit_attn_backend,
+                        split_forward_count,
+                    )
+            output.expert_distribution_metrics = recorder_outputs.get("metrics")
 
-        # Copy cached routing experts' buffers back to CPU cache
-        get_global_experts_capturer().on_forward_end(
-            forward_batch=forward_batch,
-            can_run_graph=output.can_run_graph,
-            cuda_graph_batch=getattr(self.graph_runner, "bs", None),
-        )
+            # Copy cached routing experts' buffers back to CPU cache
+            get_global_experts_capturer().on_forward_end(
+                forward_batch=forward_batch,
+                can_run_graph=output.can_run_graph,
+                cuda_graph_batch=getattr(self.graph_runner, "bs", None),
+            )
 
-        if self.eplb_manager is not None:
-            self.eplb_manager.on_forward_pass_end()
+            if self.eplb_manager is not None:
+                self.eplb_manager.on_forward_pass_end()
 
-        if dumper.may_enable:
-            dumper.step()
+            if dumper.may_enable:
+                dumper.step()
 
-        return output
+            return output
+        except torch.cuda.OutOfMemoryError as e:
+            msg = (
+                f"CUDA out of memory during forward pass.\n"
+                f"This usually means activation memory is insufficient.\n"
+                f"Possible fixes:\n"
+                f"  - Decrease --mem-fraction-static to reserve more memory for activations\n"
+                f"  - Reduce --max-running-requests or --chunked-prefill-size"
+            )
+            if self.mem_fraction_static is not None:
+                msg += f"\nCurrent --mem-fraction-static={self.mem_fraction_static}"
+            raise RuntimeError(msg) from e
 
     def _forward_raw(
         self,

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -40,8 +40,7 @@ class MemoryPoolConfig:
         if self.max_total_num_tokens <= 0:
             msg = (
                 "Not enough memory to allocate KV cache.\n"
-                "Possible fixes: increase --mem-fraction-static, "
-                "reduce --chunked-prefill-size, or reduce --max-running-requests."
+                "Please try to increase --mem-fraction-static."
             )
             if self.mem_fraction_static is not None:
                 msg += f"\nCurrent --mem-fraction-static={self.mem_fraction_static}"

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -38,9 +38,13 @@ class MemoryPoolConfig:
 
     def __post_init__(self):
         if self.max_total_num_tokens <= 0:
-            msg = "Not enough memory. Please try to increase --mem-fraction-static."
+            msg = (
+                "Not enough memory to allocate KV cache.\n"
+                "Possible fixes: increase --mem-fraction-static, "
+                "reduce --chunked-prefill-size, or reduce --max-running-requests."
+            )
             if self.mem_fraction_static is not None:
-                msg += f" Current value: mem_fraction_static={self.mem_fraction_static}"
+                msg += f"\nCurrent --mem-fraction-static={self.mem_fraction_static}"
             raise RuntimeError(msg)
 
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4228,7 +4228,12 @@ class ServerArgs:
             "--mem-fraction-static",
             type=float,
             default=ServerArgs.mem_fraction_static,
-            help="The fraction of the memory used for static allocation (model weights and KV cache memory pool). Use a smaller value if you see out-of-memory errors.",
+            help=(
+                "Fraction of GPU memory for model weights + KV cache pool. "
+                "The remainder (1 - value) is reserved for activations and CUDA graphs. "
+                "Decrease if OOM during forward pass or CUDA graph capture; "
+                "increase if KV cache is too small at startup."
+            ),
         )
         parser.add_argument(
             "--max-running-requests",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4231,8 +4231,9 @@ class ServerArgs:
             help=(
                 "Fraction of GPU memory for model weights + KV cache pool. "
                 "The remainder (1 - value) is reserved for activations and CUDA graphs. "
-                "Decrease if OOM during forward pass or CUDA graph capture; "
-                "increase if KV cache is too small at startup."
+                "Increase when SGLang has the GPU to itself and KV cache is too small at startup. "
+                "Decrease when a co-tenant process shares the GPU and causes activation OOM "
+                "(e.g., sibling process memory grew after SGLang booted)."
             ),
         )
         parser.add_argument(


### PR DESCRIPTION
## Motivation

Current OOM error messages in SGLang give one-sided or generic advice (e.g., "lower your batch size"), which can mislead users — especially when the fix is actually to **increase** `--mem-fraction-static`. Additionally, `torch.cuda.OutOfMemoryError` during forward passes provides no SGLang-specific guidance at all.

This PR improves error messages so users can distinguish between two OOM directions:
- **KV cache insufficient** → increase `--mem-fraction-static`
- **Activation memory insufficient** → decrease `--mem-fraction-static`

Ref: sgl-project/sglang-omni#293
Related doc Improvement: https://github.com/zhaochenyang20/Awesome-ML-SYS-Tutorial/pull/259

## Modifications

- **`model_executor/pool_configurator.py`**: Clarify startup error as KV cache allocation failure; list actionable flags (`--mem-fraction-static`, `--chunked-prefill-size`, `--max-running-requests`).
- **`mem_cache/common.py`** (3 places): Improve alloc/prefill/decode OOM messages with context-specific fixes and `--mem-fraction-static` guidance.
- **`server_args.py`**: Rewrite `--mem-fraction-static` help text to explain both directions (decrease for activation OOM, increase for KV cache OOM).
- **`model_executor/model_runner.py`**: Catch `torch.cuda.OutOfMemoryError` in `ModelRunner.forward()` and re-raise with actionable message suggesting to decrease `--mem-fraction-static`. Covers all 15 call sites across tp_worker, eagle_worker, dflash_worker, dllm, etc.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
