### PR TITLE
Fix CUDA 13 cudaMemcpyBatchAsync segfault and restore hicache CI

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -62,7 +62,12 @@ env:
   SGLANG_IS_IN_CI: true
   SGLANG_CUDA_COREDUMP: "1"
   SGLANG_JIT_DEEPGEMM_FAST_WARMUP: true
-  SKIP_STAGE_HEALTH_CHECK: ${{ inputs.skip_stage_health_check == true && 'true' || 'false' }}
+  # PR-local override for #23183: the hicache tests moved back into the
+  # registered suite need to exercise every stage end-to-end on cu13 without
+  # stage-a health check fast-failing on an unrelated shard. REVERT TO
+  # ${{ inputs.skip_stage_health_check == true && 'true' || 'false' }}
+  # BEFORE MERGE.
+  SKIP_STAGE_HEALTH_CHECK: 'true'
   # Schedule / main-branch dispatch / workflow_call from main use refs/heads/main; PR events use refs/pull/*/merge
   SGLANG_PR_TEST_BYPASS_MAINTENANCE_ON_MAIN: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
   USE_VENV: false
@@ -346,7 +351,7 @@ jobs:
       !cancelled() &&
       github.event_name == 'pull_request' &&
       !inputs.target_stage &&
-      inputs.test_parallel_dispatch != true &&
+      false &&  # PR-local override for #23183: skip wait-for-stage so every stage dispatches in parallel (REVERT BEFORE MERGE)
       (needs.check-changes.outputs.main_package == 'true' || needs.check-changes.outputs.sgl_kernel == 'true') &&
       (needs.call-gate.result == 'success' || needs.call-gate.result == 'skipped')
     runs-on: ubuntu-latest
@@ -371,7 +376,7 @@ jobs:
       !cancelled() &&
       github.event_name == 'pull_request' &&
       !inputs.target_stage &&
-      inputs.test_parallel_dispatch != true &&
+      false &&  # PR-local override for #23183: skip wait-for-stage so every stage dispatches in parallel (REVERT BEFORE MERGE)
       (needs.check-changes.outputs.main_package == 'true' || needs.check-changes.outputs.sgl_kernel == 'true') &&
       (needs.wait-for-stage-a.result == 'success' || needs.wait-for-stage-a.result == 'skipped') &&
       (needs.call-gate.result == 'success' || needs.call-gate.result == 'skipped')

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -344,6 +344,8 @@ jobs:
   # For PR runs: wait jobs run and enforce sequential execution via polling.
   # For scheduled runs: wait jobs are skipped, enabling parallel execution for easier retry.
 
+  # PR-local override for #23183: skip wait-for-stage so every stage dispatches
+  # in parallel (REVERT `false &&` BEFORE MERGE).
   wait-for-stage-a:
     needs: [check-changes, call-gate]
     if: |
@@ -351,7 +353,7 @@ jobs:
       !cancelled() &&
       github.event_name == 'pull_request' &&
       !inputs.target_stage &&
-      false &&  # PR-local override for #23183: skip wait-for-stage so every stage dispatches in parallel (REVERT BEFORE MERGE)
+      false &&
       (needs.check-changes.outputs.main_package == 'true' || needs.check-changes.outputs.sgl_kernel == 'true') &&
       (needs.call-gate.result == 'success' || needs.call-gate.result == 'skipped')
     runs-on: ubuntu-latest
@@ -369,6 +371,8 @@ jobs:
           jobs: '["stage-a-test-1-gpu-small", "stage-a-test-cpu"]'
           max-wait-minutes: '240'
 
+  # PR-local override for #23183: skip wait-for-stage so every stage dispatches
+  # in parallel (REVERT `false &&` BEFORE MERGE).
   wait-for-stage-b:
     needs: [check-changes, call-gate, wait-for-stage-a]
     if: |
@@ -376,7 +380,7 @@ jobs:
       !cancelled() &&
       github.event_name == 'pull_request' &&
       !inputs.target_stage &&
-      false &&  # PR-local override for #23183: skip wait-for-stage so every stage dispatches in parallel (REVERT BEFORE MERGE)
+      false &&
       (needs.check-changes.outputs.main_package == 'true' || needs.check-changes.outputs.sgl_kernel == 'true') &&
       (needs.wait-for-stage-a.result == 'success' || needs.wait-for-stage-a.result == 'skipped') &&
       (needs.call-gate.result == 'success' || needs.call-gate.result == 'skipped')

--- a/scripts/ci/cuda/ci_cleanup_venv.sh
+++ b/scripts/ci/cuda/ci_cleanup_venv.sh
@@ -10,14 +10,41 @@
 set +e
 set -u
 
-# Skip entirely when venv mode is disabled — no /tmp/sglang-ci-* dir exists
-# and there's nothing to sweep. Matches the USE_VENV parsing in
-# ci_install_dependency.sh (accepts 1/true/yes, case-insensitive).
+# Matches the USE_VENV parsing in ci_install_dependency.sh (accepts
+# 1/true/yes, case-insensitive).
 USE_VENV_RAW="${USE_VENV:-true}"
 case "$(printf '%s' "$USE_VENV_RAW" | tr '[:upper:]' '[:lower:]')" in
     1 | true | yes) ;;
     *)
-        echo "USE_VENV=${USE_VENV_RAW}: skipping venv cleanup"
+        # USE_VENV=false path: there is no /tmp/sglang-ci-* venv to drop,
+        # but system site-packages can carry over stale trees between jobs.
+        # Observed: `uv pip uninstall flashinfer-python` leaves flashinfer/data/
+        # behind because flashinfer-cubin owns files beneath it, so the next
+        # job's `uv pip install -e python[...]` fails with
+        # "failed to create directory flashinfer/data/: File exists (os error 17)".
+        # See https://github.com/sgl-project/sglang/actions/runs/24634237642/job/72027123887
+        #
+        # Fully uninstall the flashinfer trio and rm -rf any residual package
+        # dirs so the next setup starts from a clean slate. Cached wheels
+        # under ~/.cache/flashinfer-wheels/ keep the reinstall fast.
+        echo "USE_VENV=${USE_VENV_RAW}: purging flashinfer leftovers from system site-packages"
+        python3 -m pip uninstall -y \
+            flashinfer-python flashinfer-cubin flashinfer-jit-cache \
+            >/dev/null 2>&1 || true
+
+        SITE_PACKAGES="$(python3 -c 'import site; print(site.getsitepackages()[0])' 2>/dev/null)"
+        if [ -n "${SITE_PACKAGES:-}" ] && [ -d "$SITE_PACKAGES" ]; then
+            for pkg in flashinfer flashinfer_cubin flashinfer_jit_cache; do
+                stale="${SITE_PACKAGES}/${pkg}"
+                if [ -e "$stale" ] || [ -L "$stale" ]; then
+                    if rm -rf "$stale"; then
+                        echo "Purged ${stale}"
+                    else
+                        echo "::warning::Failed to remove ${stale}"
+                    fi
+                fi
+            done
+        fi
         exit 0
         ;;
 esac

--- a/scripts/ci/cuda/ci_cleanup_venv.sh
+++ b/scripts/ci/cuda/ci_cleanup_venv.sh
@@ -16,17 +16,10 @@ USE_VENV_RAW="${USE_VENV:-true}"
 case "$(printf '%s' "$USE_VENV_RAW" | tr '[:upper:]' '[:lower:]')" in
     1 | true | yes) ;;
     *)
-        # USE_VENV=false path: there is no /tmp/sglang-ci-* venv to drop,
-        # but system site-packages can carry over stale trees between jobs.
-        # Observed: `uv pip uninstall flashinfer-python` leaves flashinfer/data/
-        # behind because flashinfer-cubin owns files beneath it, so the next
-        # job's `uv pip install -e python[...]` fails with
-        # "failed to create directory flashinfer/data/: File exists (os error 17)".
-        # See https://github.com/sgl-project/sglang/actions/runs/24634237642/job/72027123887
-        #
-        # Fully uninstall the flashinfer trio and rm -rf any residual package
-        # dirs so the next setup starts from a clean slate. Cached wheels
-        # under ~/.cache/flashinfer-wheels/ keep the reinstall fast.
+        # USE_VENV=false: no venv to drop, but uninstall+purge the flashinfer
+        # trio so system site-packages don't carry co-owned dirs (flashinfer/data/)
+        # into the next job. Cached wheels under ~/.cache/flashinfer-wheels/ keep
+        # the reinstall fast.
         echo "USE_VENV=${USE_VENV_RAW}: purging flashinfer leftovers from system site-packages"
         python3 -m pip uninstall -y \
             flashinfer-python flashinfer-cubin flashinfer-jit-cache \
@@ -37,11 +30,8 @@ case "$(printf '%s' "$USE_VENV_RAW" | tr '[:upper:]' '[:lower:]')" in
             for pkg in flashinfer flashinfer_cubin flashinfer_jit_cache; do
                 stale="${SITE_PACKAGES}/${pkg}"
                 if [ -e "$stale" ] || [ -L "$stale" ]; then
-                    if rm -rf "$stale"; then
-                        echo "Purged ${stale}"
-                    else
-                        echo "::warning::Failed to remove ${stale}"
-                    fi
+                    rm -rf "$stale" && echo "Purged ${stale}" \
+                        || echo "::warning::Failed to remove ${stale}"
                 fi
             done
         fi

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -315,6 +315,16 @@ echo "Installing python extras: [${EXTRAS}]"
 # source "${SCRIPT_DIR}/cache_nvidia_wheels.sh"
 $PIP_CMD install -e "python[${EXTRAS}]" $PIP_INSTALL_SUFFIX
 
+# Purge orphaned nvidia-cuda-runtime-cu12 left over from pre-cu13 installs.
+# It ships libcudart.so.12 under nvidia/cuda_runtime/lib/ while the cu13 runtime
+# lives under nvidia/cu13/lib/, so having both on LD_LIBRARY_PATH makes
+# cudnn_frontend_shim.h dlopen both and throw:
+#   RuntimeError: Multiple libcudart libraries found: libcudart.so.12 and libcudart.so.13
+# Observed on CI runners carrying state from the pre-#23119 (cu129) era; nothing
+# currently depends on it (Required-by: empty), and its install dir is disjoint
+# from cu13's so the uninstall doesn't disturb any shared cu13 files.
+$PIP_UNINSTALL_CMD nvidia-cuda-runtime-cu12 $PIP_UNINSTALL_SUFFIX || true
+
 mark_step_done "Install main package"
 
 # ------------------------------------------------------------------------------

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -282,6 +282,25 @@ FLASHINFER_UNINSTALL="flashinfer-python"
 $PIP_UNINSTALL_CMD $FLASHINFER_UNINSTALL $PIP_UNINSTALL_SUFFIX || true
 $PIP_UNINSTALL_CMD opencv-python opencv-python-headless $PIP_UNINSTALL_SUFFIX || true
 
+# `uv pip uninstall flashinfer-python` leaves the flashinfer/data/ subdir
+# behind when flashinfer-cubin is kept (cubin files sit under that tree),
+# which breaks the next `uv pip install -e python[...]` with
+# "failed to create directory flashinfer/data/: File exists (os error 17)".
+# See https://github.com/sgl-project/sglang/actions/runs/24634237642/job/72027123887
+#
+# Purge any residual flashinfer/ tree. If we wipe it, cubin's files go with
+# it, so force cubin to reinstall too (150 MB, fetched via the flashinfer
+# artifacts step below).
+SITE_PACKAGES=$(python3 -c 'import site; print(site.getsitepackages()[0])' 2>/dev/null || true)
+if [ -n "$SITE_PACKAGES" ] && [ -d "$SITE_PACKAGES/flashinfer" ]; then
+    rm -rf "$SITE_PACKAGES/flashinfer"
+    echo "Purged residual $SITE_PACKAGES/flashinfer after uninstall"
+    if [ "$UNINSTALL_CUBIN" = false ]; then
+        $PIP_UNINSTALL_CMD flashinfer-cubin $PIP_UNINSTALL_SUFFIX || true
+        UNINSTALL_CUBIN=true
+    fi
+fi
+
 mark_step_done "Uninstall Flashinfer"
 
 # ------------------------------------------------------------------------------

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -282,19 +282,13 @@ FLASHINFER_UNINSTALL="flashinfer-python"
 $PIP_UNINSTALL_CMD $FLASHINFER_UNINSTALL $PIP_UNINSTALL_SUFFIX || true
 $PIP_UNINSTALL_CMD opencv-python opencv-python-headless $PIP_UNINSTALL_SUFFIX || true
 
-# `uv pip uninstall flashinfer-python` leaves the flashinfer/data/ subdir
-# behind when flashinfer-cubin is kept (cubin files sit under that tree),
-# which breaks the next `uv pip install -e python[...]` with
-# "failed to create directory flashinfer/data/: File exists (os error 17)".
-# See https://github.com/sgl-project/sglang/actions/runs/24634237642/job/72027123887
-#
-# Purge any residual flashinfer/ tree. If we wipe it, cubin's files go with
-# it, so force cubin to reinstall too (150 MB, fetched via the flashinfer
-# artifacts step below).
+# Runner-state robustness: flashinfer-python and flashinfer-cubin co-own files
+# under flashinfer/data/. Uninstalling only python leaves the dir; the next
+# `uv pip install` then fails with `mkdir flashinfer/data/: File exists`. Wipe
+# the tree and force cubin to reinstall so both packages land atomically.
 SITE_PACKAGES=$(python3 -c 'import site; print(site.getsitepackages()[0])' 2>/dev/null || true)
 if [ -n "$SITE_PACKAGES" ] && [ -d "$SITE_PACKAGES/flashinfer" ]; then
     rm -rf "$SITE_PACKAGES/flashinfer"
-    echo "Purged residual $SITE_PACKAGES/flashinfer after uninstall"
     if [ "$UNINSTALL_CUBIN" = false ]; then
         $PIP_UNINSTALL_CMD flashinfer-cubin $PIP_UNINSTALL_SUFFIX || true
         UNINSTALL_CUBIN=true
@@ -315,14 +309,10 @@ echo "Installing python extras: [${EXTRAS}]"
 # source "${SCRIPT_DIR}/cache_nvidia_wheels.sh"
 $PIP_CMD install -e "python[${EXTRAS}]" $PIP_INSTALL_SUFFIX
 
-# Purge orphaned nvidia-cuda-runtime-cu12 left over from pre-cu13 installs.
-# It ships libcudart.so.12 under nvidia/cuda_runtime/lib/ while the cu13 runtime
-# lives under nvidia/cu13/lib/, so having both on LD_LIBRARY_PATH makes
-# cudnn_frontend_shim.h dlopen both and throw:
-#   RuntimeError: Multiple libcudart libraries found: libcudart.so.12 and libcudart.so.13
-# Observed on CI runners carrying state from the pre-#23119 (cu129) era; nothing
-# currently depends on it (Required-by: empty), and its install dir is disjoint
-# from cu13's so the uninstall doesn't disturb any shared cu13 files.
+# Runner-state robustness: orphan cu12 runtime drags libcudart.so.12 onto
+# LD_LIBRARY_PATH next to cu13's libcudart.so.13, which trips cudnn_frontend's
+# dlopen probe (`Multiple libcudart libraries found`). Its install dir is
+# disjoint from cu13's so dropping it doesn't touch any shared files.
 $PIP_UNINSTALL_CMD nvidia-cuda-runtime-cu12 $PIP_UNINSTALL_SUFFIX || true
 
 mark_step_done "Install main package"
@@ -419,38 +409,34 @@ mark_step_done "Download flashinfer artifacts"
 # ------------------------------------------------------------------------------
 # Stabilize FlashInfer JIT cache paths
 # ------------------------------------------------------------------------------
-# FlashInfer JIT writes build.ninja with hardcoded -isystem paths pointing to the
-# venv's flashinfer/data/ and tvm_ffi/include/. With per-job venvs each job gets
-# a unique /tmp/sglang-ci-<run>-<job>-<pid>/ path, but the JIT cache is shared
-# on the host mount. When the next job's venv has a different path and the old one
-# is cleaned up, ninja fails because source files no longer exist at the cached path.
-#
-# Fix (two parts):
-# 1. Clear only STALE cached_ops (build.ninja referencing non-existent venv paths).
-#    Do NOT clear all cached_ops — they contain compiled .so files that take 10-20 min
-#    to recompile. Only remove entries where the source paths no longer exist.
-# 2. Copy source files to a stable host-mounted path and symlink each venv's
-#    copy there. build.ninja then references the stable path across all jobs.
-#
-# Part 1: Clear stale cached_ops (keep valid compiled kernels)
+# FlashInfer JIT writes build.ninja with absolute source paths. Two things make
+# them go stale on a long-lived runner: per-job venv dirs (/tmp/sglang-ci-*)
+# rotate under USE_VENV=1, and _stable_src/ (written by Part 2 below) only
+# exists while USE_VENV=1. Stale ninjas surface as
+#   "ninja: error: '<path>', needed by '<obj>', missing and no known rule".
+# Part 1: drop any cached_ops whose build.ninja references a missing source;
+# keeps already-compiled .so files intact (rebuilds are 10-20 min).
+# Part 2: under USE_VENV=1, materialize a stable source dir so build.ninja
+# paths survive venv rotation.
+if [ -d "${HOME}/.cache/flashinfer" ]; then
+    STALE_COUNT=0
+    while IFS= read -r ninja_file; do
+        missing=0
+        for p in $(grep -oE '/[^[:space:]:|]+\.(cu|cc|cpp|h|hpp)' "$ninja_file" 2>/dev/null | sort -u); do
+            [ -e "$p" ] || { missing=1; break; }
+        done
+        if [ "$missing" = 1 ]; then
+            rm -rf "$(dirname "$ninja_file")"
+            STALE_COUNT=$((STALE_COUNT + 1))
+        fi
+    done < <(find "${HOME}/.cache/flashinfer" -name "build.ninja" -type f 2>/dev/null)
+    echo "Cleaned $STALE_COUNT stale FlashInfer cached_ops (kept valid ones)"
+fi
+
+# Part 2: stable_src exists solely to anchor build.ninja paths across rotating
+# per-job venvs, so it's only populated under USE_VENV=1.
 if [ "$USE_VENV" = "1" ]; then
     STABLE_FI_DIR="${HOME}/.cache/flashinfer/_stable_src"
-    if [ -d "${HOME}/.cache/flashinfer" ]; then
-        STALE_COUNT=0
-        while IFS= read -r ninja_file; do
-            # Check for stale venv paths (/tmp/sglang-ci-*) or old stable path (flashinfer-src)
-            STALE_PATH=$(grep -o '/tmp/sglang-ci-[^ ]*\|flashinfer-src' "$ninja_file" 2>/dev/null | head -1 || true)
-            if [ -n "$STALE_PATH" ]; then
-                if echo "$STALE_PATH" | grep -q "flashinfer-src" || [ ! -d "$STALE_PATH" ]; then
-                    rm -rf "$(dirname "$ninja_file")"
-                    STALE_COUNT=$((STALE_COUNT + 1))
-                fi
-            fi
-        done < <(find "${HOME}/.cache/flashinfer" -name "build.ninja" -type f 2>/dev/null)
-        echo "Cleaned $STALE_COUNT stale FlashInfer cached_ops (kept valid ones)"
-    fi
-
-    # Part 2: Stabilize paths (STABLE_FI_DIR set above in Part 1)
     FI_DATA=$(python3 -c "import flashinfer, os; print(os.path.join(os.path.dirname(flashinfer.__file__), 'data'))")
     TVM_INC=$(python3 -c "import tvm_ffi, os; print(os.path.join(os.path.dirname(tvm_ffi.__file__), 'include'))")
 

--- a/sgl-kernel/csrc/kvcacheio/transfer.cu
+++ b/sgl-kernel/csrc/kvcacheio/transfer.cu
@@ -812,9 +812,19 @@ inline void transfer_kv_page_first_direct_impl(
     return;
   }
 
-  // CUDA 13.0 removed the failIdx parameter from cudaMemcpyBatchAsync.
-  // Use runtime version to select the correct signature for binary portability.
-  const bool use_v13_signature = driver_version >= 13000;
+  // CUDA 13.0 removed the failIdx parameter from cudaMemcpyBatchAsync. The ABI
+  // of the dlsym'd symbol is determined by the libcudart loaded in this process,
+  // not the host driver — a cu12 runtime on a cu13 driver host (common in
+  // containers) still exposes the 9-param v12 signature. Dispatching on the
+  // driver version here would segfault in that case (verified empirically).
+  // Use cudaRuntimeGetVersion so the signature follows the runtime.
+  int runtime_version = 0;
+  cudaError_t runtime_version_err = cudaRuntimeGetVersion(&runtime_version);
+  if (runtime_version_err != cudaSuccess) {
+    fallback_to_page_copy();
+    return;
+  }
+  const bool use_v13_signature = runtime_version >= 13000;
 
   size_t num_copies = 0;
   std::vector<void*> batch_srcs;

--- a/sgl-kernel/csrc/kvcacheio/transfer.cu
+++ b/sgl-kernel/csrc/kvcacheio/transfer.cu
@@ -817,14 +817,17 @@ inline void transfer_kv_page_first_direct_impl(
   // not the host driver — a cu12 runtime on a cu13 driver host (common in
   // containers) still exposes the 9-param v12 signature. Dispatching on the
   // driver version here would segfault in that case (verified empirically).
-  // Use cudaRuntimeGetVersion so the signature follows the runtime.
-  int runtime_version = 0;
-  cudaError_t runtime_version_err = cudaRuntimeGetVersion(&runtime_version);
+  // Use cudaRuntimeGetVersion so the signature follows the runtime. The
+  // runtime version is process-constant, so cache the query (static init is
+  // thread-safe in C++11+) to keep the KV-transfer hot path free of a redundant
+  // runtime API call per invocation.
+  static int runtime_version = 0;
+  static cudaError_t runtime_version_err = cudaRuntimeGetVersion(&runtime_version);
   if (runtime_version_err != cudaSuccess) {
     fallback_to_page_copy();
     return;
   }
-  const bool use_v13_signature = runtime_version >= 13000;
+  static const bool use_v13_signature = runtime_version >= 13000;
 
   size_t num_copies = 0;
   std::vector<void*> batch_srcs;

--- a/sgl-kernel/csrc/kvcacheio/transfer.cu
+++ b/sgl-kernel/csrc/kvcacheio/transfer.cu
@@ -806,16 +806,15 @@ inline void transfer_kv_page_first_direct_impl(
   }
 
   // Symbol gate: runtime may not expose cudaMemcpyBatchAsync in some environments.
-  using CudaMemcpyBatchAsyncFn =
-      cudaError_t (*)(void**, void**, size_t*, size_t, cudaMemcpyAttributes*, size_t*, size_t, size_t*, cudaStream_t);
-  static CudaMemcpyBatchAsyncFn cuda_memcpy_batch_async = []() {
-    void* symbol = dlsym(RTLD_DEFAULT, "cudaMemcpyBatchAsync");
-    return reinterpret_cast<CudaMemcpyBatchAsyncFn>(symbol);
-  }();
-  if (cuda_memcpy_batch_async == nullptr) {
+  static void* cuda_memcpy_batch_async_sym = dlsym(RTLD_DEFAULT, "cudaMemcpyBatchAsync");
+  if (cuda_memcpy_batch_async_sym == nullptr) {
     fallback_to_page_copy();
     return;
   }
+
+  // CUDA 13.0 removed the failIdx parameter from cudaMemcpyBatchAsync.
+  // Use runtime version to select the correct signature for binary portability.
+  const bool use_v13_signature = driver_version >= 13000;
 
   size_t num_copies = 0;
   std::vector<void*> batch_srcs;
@@ -916,17 +915,36 @@ inline void transfer_kv_page_first_direct_impl(
 
   TORCH_CHECK(batch_srcs.size() == num_copies, "Batch memcpy count mismatch");
   if (num_copies > 0) {
+    cudaError_t err;
     size_t fail_idx = std::numeric_limits<size_t>::max();
-    cudaError_t err = cuda_memcpy_batch_async(
-        batch_dsts.data(),
-        batch_srcs.data(),
-        batch_sizes.data(),
-        num_copies,
-        &attrs,
-        attrs_idxs.data(),
-        1,
-        &fail_idx,
-        stream);
+    if (use_v13_signature) {
+      using FnV13 = cudaError_t (*)(
+          void* const*,
+          const void* const*,
+          const size_t*,
+          size_t,
+          cudaMemcpyAttributes*,
+          size_t*,
+          size_t,
+          cudaStream_t);
+      auto fn = reinterpret_cast<FnV13>(cuda_memcpy_batch_async_sym);
+      err = fn(
+          batch_dsts.data(), batch_srcs.data(), batch_sizes.data(), num_copies, &attrs, attrs_idxs.data(), 1, stream);
+    } else {
+      using FnV12 = cudaError_t (*)(
+          void**, void**, size_t*, size_t, cudaMemcpyAttributes*, size_t*, size_t, size_t*, cudaStream_t);
+      auto fn = reinterpret_cast<FnV12>(cuda_memcpy_batch_async_sym);
+      err =
+          fn(batch_dsts.data(),
+             batch_srcs.data(),
+             batch_sizes.data(),
+             num_copies,
+             &attrs,
+             attrs_idxs.data(),
+             1,
+             &fail_idx,
+             stream);
+    }
     if (err == cudaErrorNotSupported || err == cudaErrorCallRequiresNewerDriver) {
       fallback_to_page_copy();
       return;

--- a/test/registered/4-gpu-models/test_qwen35_hicache.py
+++ b/test/registered/4-gpu-models/test_qwen35_hicache.py
@@ -1,8 +1,3 @@
-"""
-# TODO: Fails on cu13 venv migration. Ref: https://github.com/sgl-project/sglang/actions/runs/24616960626/job/71980705674?pr=23119
-# Should move back to registered test after it's fixed
-"""
-
 import shutil
 import tempfile
 import unittest

--- a/test/registered/hicache/test_hicache_storage.py
+++ b/test/registered/hicache/test_hicache_storage.py
@@ -3,11 +3,6 @@ from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 register_cuda_ci(est_time=99, suite="stage-b-test-1-gpu-small")
 register_amd_ci(est_time=300, suite="stage-b-test-1-gpu-small-amd")
 
-"""
-# TODO: Segmentation fault occurs when upgraded to Cu13. Ref: https://github.com/sgl-project/sglang/actions/runs/24603159715/job/71945537414?pr=23119")
-# Should move back to registered test after it's fixed
-"""
-
 import time
 import unittest
 

--- a/test/registered/hicache/test_hicache_storage_3fs_backend.py
+++ b/test/registered/hicache/test_hicache_storage_3fs_backend.py
@@ -2,8 +2,6 @@
 Benchmark tests for HiCache Storage with 3FS backend.
 Usage:
     python3 -m pytest test/registered/hicache/test_hicache_storage_3fs_backend.py -v
-# TODO: Segmentation fault occurs when upgraded to Cu13. Ref: https://github.com/sgl-project/sglang/actions/runs/24603159715/job/71945537414?pr=23119")
-# Should move back to registered test after it's fixed
 """
 
 import json

--- a/test/registered/hicache/test_hicache_storage_file_backend.py
+++ b/test/registered/hicache/test_hicache_storage_file_backend.py
@@ -2,8 +2,6 @@
 E2E tests for HiCache Storage functionality.
 Usage:
     python3 -m pytest test/registered/hicache/test_hicache_storage_file_backend.py -v
-# TODO: Segmentation fault occurs when upgraded to Cu13. Ref: https://github.com/sgl-project/sglang/actions/runs/24603159715/job/71945537414?pr=23119")
-# Should move back to registered test after it's fixed
 """
 
 import json

--- a/test/registered/hicache/test_hicache_storage_mooncake_backend.py
+++ b/test/registered/hicache/test_hicache_storage_mooncake_backend.py
@@ -4,9 +4,6 @@ Usage:
     python3.10 -m pytest test/registered/hicache/test_hicache_storage_mooncake_backend.py -v
 """
 
-# TODO: Segmentation fault occurs when upgraded to Cu13. Ref: https://github.com/sgl-project/sglang/actions/runs/24601791606/job/71942123195?pr=23119")
-# Should move back to registered test after it's fixed
-
 import os
 import subprocess
 import time
@@ -15,12 +12,15 @@ import unittest
 import requests
 from test_hicache_storage_file_backend import HiCacheStorageBaseMixin
 
+from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import (
     DEFAULT_MLA_MODEL_NAME_FOR_TEST,
     CustomTestCase,
     find_available_port,
     is_in_ci,
 )
+
+register_cuda_ci(est_time=236, suite="stage-b-test-2-gpu-large")
 
 
 class HiCacheStorageMooncakeBackendBaseMixin(HiCacheStorageBaseMixin):

--- a/test/registered/hicache/test_hicache_storage_runtime_attach_detach.py
+++ b/test/registered/hicache/test_hicache_storage_runtime_attach_detach.py
@@ -7,8 +7,6 @@ HTTP endpoints.
 
 Usage:
     python3 -m pytest test/registered/hicache/test_hicache_storage_runtime_attach_detach.py -v
-# TODO: Segmentation fault occurs when upgraded to Cu13. Ref: https://github.com/sgl-project/sglang/actions/runs/24603159715/job/71945537414?pr=23119")
-# Should move back to registered test after it's fixed
 """
 
 import json

--- a/test/registered/hicache/test_hicache_variants.py
+++ b/test/registered/hicache/test_hicache_variants.py
@@ -5,8 +5,6 @@ register_amd_ci(est_time=524, suite="stage-b-test-1-gpu-small-amd")
 """
 Consolidated HiCache variant tests.
 Tests HiCache with different configurations: standard, MLA, EAGLE, and page size variants.
-# TODO: Segmentation fault occurs when upgraded to Cu13. Ref: https://github.com/sgl-project/sglang/actions/runs/24603159715/job/71945537414?pr=23119")
-# Should move back to registered test after it's fixed
 """
 
 import unittest


### PR DESCRIPTION
Supersedes #23172 (closed) — pushed to the upstream repo instead of a fork so that `test_parallel_dispatch=true` and `skip_stage_health_check=true` can be set on the pr-test run.

## Motivation

Three related CI gaps are holding back the cu12 → cu13 migration landed in #23119. This PR fixes all three so the affected tests can run in CI on CUDA 13 without regressions.

### 1. `cudaMemcpyBatchAsync` segfault on CUDA 13 (ports #23136 from @yhyang201)

CUDA 13.0 removed the `failIdx` parameter from `cudaMemcpyBatchAsync` (9 params → 8). The dlsym path in `sgl-kernel/csrc/kvcacheio/transfer.cu` was hard-coded to the CUDA 12.8 signature, so on cu13 the stream argument landed in the wrong slot and the runtime segfaulted inside `cuMemcpyBatchAsync_v2`. Fix: dispatch between the v12 and v13 signatures at runtime.

Importantly, the signature selection must follow the *runtime* (`cudaRuntimeGetVersion`), not the driver (`cudaDriverGetVersion`). The ABI of the symbol is owned by the `libcudart` actually loaded into the process — a cu12 runtime on a cu13-capable host driver (common in containers) still exposes the 9-param v12 variant, and dispatching on the driver would segfault in that case. Reproduced on `lmsysorg/sglang:dev` (cu12.9) on a cu13 host driver:

```
cudaDriverGetVersion()  = 13000
cudaRuntimeGetVersion() = 12090
v12 dispatch of dlsym'd symbol: cudaSuccess, exit 0
v13 dispatch of dlsym'd symbol: Segmentation fault (core dumped)
```

### 2. Restore hicache tests to the CI-registered suite

PR #23119 moved seven hicache tests from `test/registered/` to `test/manual/` because they segfaulted on cu13. With (1) fixed, they move back:

- `hicache/test_hicache_storage.py`
- `hicache/test_hicache_storage_3fs_backend.py`
- `hicache/test_hicache_storage_file_backend.py`
- `hicache/test_hicache_storage_mooncake_backend.py` (also restores the `register_cuda_ci(est_time=236, suite="stage-b-test-2-gpu-large")` call that was dropped on the way to manual)
- `hicache/test_hicache_storage_runtime_attach_detach.py`
- `hicache/test_hicache_variants.py`
- `4-gpu-models/test_qwen35_hicache.py`

All tests pass end-to-end on cu13 H200 with the fixed wheel (see validation section).

### 3. CI install/cleanup hygiene

Two install-path failures uncovered while rebuilding the PR's own CI:

- **`flashinfer/data/` EEXIST on `uv pip install`** for `USE_VENV=false` jobs (`stage-a-test-1-gpu-small`): `uv pip uninstall flashinfer-python` leaves `flashinfer/data/` behind when `flashinfer-cubin` is kept, and the next reinstall hits `File exists (os error 17)`. Fix in `ci_install_dependency.sh` purges the residual tree right after the uninstall and forces cubin to reinstall; `ci_cleanup_venv.sh` adds a post-job sweep as a belt-and-braces safety net so the next job's runner also starts clean.

- **`Multiple libcudart libraries found: libcudart.so.12 and libcudart.so.13`** from `cudnn_frontend_shim.h` on the SM120 (RTX 5090) runners. An orphan `nvidia-cuda-runtime-cu12` wheel leftover from the pre-#23119 cu129 era is still shipping `libcudart.so.12` under `nvidia/cuda_runtime/lib/` next to cu13's `nvidia/cu13/lib/libcudart.so.13`; both end up on `LD_LIBRARY_PATH` and cudnn_frontend's dlopen probe throws. This is a pre-existing failure on main (same error on run `24635819338` commit `32b7777f`), but carrying the fix here lets CI on this PR go green. Fix: `pip uninstall -y nvidia-cuda-runtime-cu12` after the main install. A blunter sweep of all `nvidia-*-cu12` would break torch (several cu12/cu13 wheel pairs share `nvidia/<name>/lib/` dirs and uninstalling one wipes files the other's RECORD still references); the cu12 cuda_runtime wheel's install dir is disjoint from cu13's so this is safe.

## Modifications

- `sgl-kernel/csrc/kvcacheio/transfer.cu`: v12 vs v13 `cudaMemcpyBatchAsync` signature dispatch using `cudaRuntimeGetVersion`.
- `test/registered/hicache/*` and `test/registered/4-gpu-models/test_qwen35_hicache.py`: restored from `test/manual/`.
- `scripts/ci/cuda/ci_install_dependency.sh`: residual `flashinfer/` tree purge + orphan `nvidia-cuda-runtime-cu12` uninstall.
- `scripts/ci/cuda/ci_cleanup_venv.sh`: post-job flashinfer cleanup for `USE_VENV=false` jobs.

## Validation on cu13 H200 (ion-user-9, `lmsysorg/sglang:dev-cu13` with this PR's wheels)

| Test | Status | Time |
|---|---|---|
| `test_hicache_storage.py` | ✅ | 150s (MMLU 0.734) |
| `test_hicache_storage_runtime_attach_detach.py` | ✅ | 158s |
| `test_hicache_storage_file_backend.TestHiCache` | ✅ | — |
| `test_hicache_storage_file_backend.TestHiCacheStoragePageFirstLayout` | ✅ | — |
| **`test_hicache_storage_file_backend.TestHiCacheStoragePageFirstDirectIO`** | **✅** | **116s** — direct validation of the `cudaMemcpyBatchAsync` path |
| `test_hicache_storage_file_backend.TestHiCacheStorageAccuracy` | ✅ | — (acc diff 0.0000) |
| `test_hicache_storage_file_backend.TestHiCacheStorageMLA` | ✅ | 97s (standalone) |
| `test_hicache_variants.TestHiCacheStandard` | ✅ | MMLU 0.703 |
| `test_hicache_variants.TestHiCacheMLA` | ✅ | MMLU 0.578 |
| `test_hicache_variants.TestHiCachePage` | ✅ | MMLU 0.75 |
| `test_hicache_variants.TestHiCacheEagle` | ✅ | 111s (needs `SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN=1`) |
| `4-gpu-models/test_qwen35_hicache.py` | ✅ | (TP=4 on H200, storage on `/data`) |

Cross-shout to @yhyang201 — the original fix in #23136 is the foundation of this PR.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (Hicache tests restored from `test/manual/` to `test/registered/`.)
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) — MMLU + GSM8K validated on the restored tests.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

cc @Fridge003 @alisonshao