### PR TITLE
[AMD] Fused qk rmsnorm bf16 for amd/Kimi-K2.5-MXFP4

### DIFF
--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -60,6 +60,9 @@ if _is_cuda:
 
 
 if _use_aiter:
+    from aiter.ops.fused_qk_norm_rope_cache_quant import (
+        fused_qk_rmsnorm as fused_qk_rmsnorm_bf16,
+    )
     from aiter.ops.triton.batched_gemm_a8w8_a_per_token_group_prequant_w_per_batched_tensor_quant import (
         batched_gemm_a8w8_a_per_token_group_prequant_w_per_batched_tensor_quant,
     )
@@ -160,6 +163,15 @@ class DeepseekMLAForwardMixin:
                                 output_unquantized_inp1=False,
                             )
 
+                    elif _use_aiter:
+                        q, k_nope = fused_qk_rmsnorm_bf16(
+                            q,
+                            self.q_a_layernorm.weight,
+                            self.q_a_layernorm.variance_epsilon,
+                            k_nope,
+                            self.kv_a_layernorm.weight,
+                            self.kv_a_layernorm.variance_epsilon,
+                        )
                     else:
                         q = self.q_a_layernorm(q)
                         k_nope = self.kv_a_layernorm(k_nope)


### PR DESCRIPTION
## Motivation

  On ROCm targets with a BF16 DeepSeek model, the MLA QK layernorm path falls through to the PyTorch sequential
  fallback instead of using aiter's fused kernel. The BF16 fused branch in forward_mla.py was gated by _use_aiter and
  not _use_aiter_gfx95, which correctly excludes gfx950 from the FP8/MXFP4 quantized paths but incorrectly also
  excludes it from the BF16 fused path. This PR fixes the condition so the fused BF16 kernel is used on all
  AITER-enabled ROCm targets (gfx942, gfx950).

## Technical Details

  The condition in forward_mla.py is changed from _use_aiter and not _use_aiter_gfx95 to elif _use_aiter:, making the
  fused layernorm branch fire on all AITER-enabled targets when model weights are not in a quantized format
  (FP8/MXFP4). alt_stream is always None on ROCm/HIP, so the fused path is always reachable on those targets.

  The fused op is fused_qk_rmsnorm from aiter.ops.fused_qk_norm_rope_cache_quant, backed by
  csrc/kernels/fused_qk_norm.cu. This kernel already supports both fp16 and bf16 natively via a clean 2D-grid design
  (Q and K blocks run in parallel on separate CUs) — no new aiter kernel is required.

## Accuracy Tests

Before the change: GSM8K 0.928
After the change: GSM8K 0.935

## Speed Tests and Profiling

In terms of `Decode batch ... gen throughput (token/s)`: Before the change 90.12; after the change 90.84, for a large configuration ISL/OSL=128000/64000.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
