### PR TITLE
fix(tbo): skip TBO-only work in MLP-sync when TBO is disabled

### DIFF
--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -381,6 +381,14 @@ class TboDPAttentionPreparer:
 
         self.enable_two_batch_overlap = enable_two_batch_overlap
 
+        # Short-circuit when TBO is off: prepare_mlp_sync_batch_raw invokes
+        # this preparer unconditionally for the forward_mode all-gather, but
+        # compute_split_seq_index is TBO-only and undefined for some modes
+        # (e.g. MIXED from enable_mixed_chunk).
+        if not enable_two_batch_overlap:
+            self.local_tbo_split_seq_index = None
+            return False, self._compute_local_forward_mode(local_batch)
+
         if local_batch is not None:
             token_num_per_seq = get_token_num_per_seq(
                 forward_mode=local_batch.forward_mode, spec_info=local_batch.spec_info

--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -379,6 +379,14 @@ class TboDPAttentionPreparer:
 
         self.enable_two_batch_overlap = enable_two_batch_overlap
 
+        # Short-circuit when TBO is off: prepare_mlp_sync_batch_raw invokes
+        # this preparer unconditionally for the forward_mode all-gather, but
+        # compute_split_seq_index is TBO-only and undefined for some modes
+        # (e.g. MIXED from enable_mixed_chunk).
+        if not enable_two_batch_overlap:
+            self.local_tbo_split_seq_index = None
+            return False, self._compute_local_forward_mode(local_batch)
+
         if local_batch is not None:
             token_num_per_seq = get_token_num_per_seq(
                 forward_mode=local_batch.forward_mode, spec_info=local_batch.spec_info


### PR DESCRIPTION
## Motivation

`prepare_mlp_sync_batch_raw` unconditionally calls `TboDPAttentionPreparer.prepare_all_gather` so that ranks can participate in the forward_mode all-gather, even when `is_tbo_enabled()` is False. That path then runs `compute_split_seq_index`, which is TBO-only.

Current `main` already supports `MIXED` in the TBO splitter via #24241. This draft only keeps the remaining TBO-disabled guard for the MLP-sync path.

## Modifications

Short-circuit `TboDPAttentionPreparer.prepare_all_gather` when TBO is disabled: return `(local_can_run_tbo=False, local_forward_mode)` without calling `compute_split_seq_index`.

This is behavior-preserving because `compute_output` already discards `local_tbo_split_seq_index` whenever `self.enable_two_batch_overlap` is False, while the MLP-sync forward_mode all-gather still runs normally via `_compute_local_forward_mode(local_batch)`.

## Accuracy Tests

Not provided for this draft.

## Speed Tests and Profiling

Not provided for this draft.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
