### PR TITLE
[Bugfix] Guard .weight access in DeepseekV2AttentionMLA for AWQ / compressed-tensors

### DIFF
--- a/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
+++ b/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
@@ -29,7 +29,10 @@ def _dispatch_mla_subtype(attn, forward_batch):
         else:
             return AttnForwardMethod.MLA
     else:
-        if hasattr(attn, "fused_qkv_a_proj_with_mqa") and use_intel_amx_backend(attn):
+        fused_weight = getattr(
+            getattr(attn, "fused_qkv_a_proj_with_mqa", None), "weight", None
+        )
+        if fused_weight is not None and use_intel_amx_backend(attn):
             return AttnForwardMethod.MLA_FUSED_ROPE_CPU
         else:
             return AttnForwardMethod.MLA

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla_fused_rope_cpu.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla_fused_rope_cpu.py
@@ -29,15 +29,16 @@ class DeepseekMLACpuForwardMixin:
                 weight_names=["w_kc", "w_vc"], transpose_dims=[[1, 2], [1, 2]]
             )
 
+        fused_weight = self._get_fused_qkv_a_proj_weight()
         self.qkv_proj_with_rope_is_int8 = (
-            self.has_fused_proj
+            fused_weight is not None
             and not self.is_packed_weight
-            and self.fused_qkv_a_proj_with_mqa.weight.dtype == torch.int8
+            and fused_weight.dtype == torch.int8
         )
         self.qkv_proj_with_rope_is_fp8 = (
-            self.has_fused_proj
+            fused_weight is not None
             and not self.is_packed_weight
-            and self.fused_qkv_a_proj_with_mqa.weight.dtype == torch.float8_e4m3fn
+            and fused_weight.dtype == torch.float8_e4m3fn
         )
 
         self.weight_block_size = None

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1135,6 +1135,23 @@ class DeepseekV2AttentionMLA(
     DeepseekMLACpuForwardMixin,
 ):
 
+    def _get_fused_qkv_a_proj_weight(self):
+        if not getattr(self, "has_fused_proj", False):
+            return None
+        return getattr(self.fused_qkv_a_proj_with_mqa, "weight", None)
+
+    def _can_use_min_latency_fused_a_gemm(self) -> bool:
+        fused_weight = self._get_fused_qkv_a_proj_weight()
+        return (
+            fused_weight is not None
+            and not self.is_packed_weight
+            and fused_weight.dtype == torch.bfloat16
+            and fused_weight.shape[0] == 2112
+            and fused_weight.shape[1] == 7168
+            and _is_cuda
+            and 90 <= _device_sm < 120
+        )
+
     def __init__(
         self,
         config: PretrainedConfig,
@@ -1351,15 +1368,7 @@ class DeepseekV2AttentionMLA(
             and self.fused_qkv_a_proj_with_mqa.quant_method.quant_config.get_name()
             in {"awq", "awq_marlin", "moe_wna16"}
         )
-        self.use_min_latency_fused_a_gemm = (
-            self.has_fused_proj
-            and not self.is_packed_weight
-            and self.fused_qkv_a_proj_with_mqa.weight.dtype == torch.bfloat16
-            and self.fused_qkv_a_proj_with_mqa.weight.shape[0] == 2112
-            and self.fused_qkv_a_proj_with_mqa.weight.shape[1] == 7168
-            and _is_cuda
-            and 90 <= _device_sm < 120
-        )
+        self.use_min_latency_fused_a_gemm = self._can_use_min_latency_fused_a_gemm()
 
         self.init_mha_forward()
         self.init_mla_forward()

--- a/test/registered/unit/models/test_deepseek_v2_attention_mla.py
+++ b/test/registered/unit/models/test_deepseek_v2_attention_mla.py
@@ -1,0 +1,111 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+import torch.nn as nn
+
+from sglang.srt.models.deepseek_common.attention_backend_handler import (
+    _dispatch_mla_subtype,
+)
+from sglang.srt.models.deepseek_common.attention_forward_methods.forward_methods import (
+    AttnForwardMethod,
+)
+from sglang.srt.models.deepseek_v2 import DeepseekV2AttentionMLA
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=6, suite="stage-a-test-cpu")
+
+
+class TestDeepseekV2AttentionMLA(unittest.TestCase):
+    def _make_attn(self, fused_proj=None):
+        attn = object.__new__(DeepseekV2AttentionMLA)
+        nn.Module.__init__(attn)
+        attn.has_fused_proj = fused_proj is not None
+        attn.is_packed_weight = False
+        if fused_proj is not None:
+            attn.fused_qkv_a_proj_with_mqa = fused_proj
+        return attn
+
+    def test_get_fused_qkv_a_proj_weight_returns_none_when_missing(self):
+        attn = self._make_attn(SimpleNamespace())
+
+        self.assertIsNone(attn._get_fused_qkv_a_proj_weight())
+
+    @patch("sglang.srt.models.deepseek_v2._device_sm", 90)
+    @patch("sglang.srt.models.deepseek_v2._is_cuda", True)
+    def test_can_use_min_latency_fused_a_gemm_preserves_bf16_path(self):
+        fused_proj = SimpleNamespace(
+            weight=torch.empty((2112, 7168), dtype=torch.bfloat16)
+        )
+        attn = self._make_attn(fused_proj)
+
+        self.assertTrue(attn._can_use_min_latency_fused_a_gemm())
+
+    @patch("sglang.srt.models.deepseek_v2._device_sm", 90)
+    @patch("sglang.srt.models.deepseek_v2._is_cuda", True)
+    def test_can_use_min_latency_fused_a_gemm_disables_when_weight_missing(self):
+        attn = self._make_attn(SimpleNamespace())
+
+        self.assertFalse(attn._can_use_min_latency_fused_a_gemm())
+
+    @patch(
+        "sglang.srt.models.deepseek_common.attention_forward_methods.forward_mla_fused_rope_cpu._is_cpu_amx_available",
+        False,
+    )
+    @patch(
+        "sglang.srt.models.deepseek_common.attention_forward_methods.forward_mla_fused_rope_cpu._is_cpu",
+        False,
+    )
+    def test_init_mla_fused_rope_cpu_forward_tolerates_missing_weight(self):
+        attn = self._make_attn(SimpleNamespace())
+
+        attn.init_mla_fused_rope_cpu_forward()
+
+        self.assertFalse(attn.qkv_proj_with_rope_is_int8)
+        self.assertFalse(attn.qkv_proj_with_rope_is_fp8)
+        self.assertIsNone(attn.weight_block_size)
+
+    @patch(
+        "sglang.srt.models.deepseek_common.attention_forward_methods.forward_mla_fused_rope_cpu._is_cpu_amx_available",
+        False,
+    )
+    @patch(
+        "sglang.srt.models.deepseek_common.attention_forward_methods.forward_mla_fused_rope_cpu._is_cpu",
+        False,
+    )
+    def test_init_mla_fused_rope_cpu_forward_preserves_int8_detection(self):
+        fused_proj = SimpleNamespace(weight=torch.empty((8, 8), dtype=torch.int8))
+        attn = self._make_attn(fused_proj)
+
+        attn.init_mla_fused_rope_cpu_forward()
+
+        self.assertTrue(attn.qkv_proj_with_rope_is_int8)
+        self.assertFalse(attn.qkv_proj_with_rope_is_fp8)
+
+    @patch(
+        "sglang.srt.models.deepseek_common.attention_backend_handler.use_intel_amx_backend",
+        return_value=True,
+    )
+    @patch("sglang.srt.models.deepseek_common.attention_backend_handler._is_hip", False)
+    def test_dispatch_mla_subtype_falls_back_without_weight(self, *_):
+        attn = SimpleNamespace(fused_qkv_a_proj_with_mqa=SimpleNamespace())
+
+        self.assertEqual(_dispatch_mla_subtype(attn, None), AttnForwardMethod.MLA)
+
+    @patch(
+        "sglang.srt.models.deepseek_common.attention_backend_handler.use_intel_amx_backend",
+        return_value=True,
+    )
+    @patch("sglang.srt.models.deepseek_common.attention_backend_handler._is_hip", False)
+    def test_dispatch_mla_subtype_keeps_cpu_fused_rope_with_weight(self, *_):
+        attn = SimpleNamespace(fused_qkv_a_proj_with_mqa=SimpleNamespace(weight=object()))
+
+        self.assertEqual(
+            _dispatch_mla_subtype(attn, None),
+            AttnForwardMethod.MLA_FUSED_ROPE_CPU,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hey all, this is my first PR, thought I'd try my hand a a recent bug.

----

## Motivation

Fixes #22855.

When a DeepseekV2-architecture checkpoint is loaded with a `compressed_tensors`-wrapped AWQ quant method (as with GLM-5.1-AWQ-4bit), the quant method registers `.qweight`, `.qzeros`, and `.scales` but NOT `.weight` on the fused `ReplicatedLinear`. Three call sites accessed `.weight.dtype` directly during init without guarding, raising:

```
AttributeError: 'ReplicatedLinear' object has no attribute 'weight'
```

The existing `is_packed_weight` short-circuit only covers quant names `{"awq", "awq_marlin", "moe_wna16"}`. `compressed_tensors` is not in that set (`get_name()` returns `"compressed_tensors"`), so checkpoints in that format fall through to the unguarded `.weight` access. Verified in `compressed_tensors.py` and `compressed_tensors_wNa16.py`: the wNa16 scheme registers `weight_packed`, not `.weight`.

## Modifications

Adds a `_get_fused_qkv_a_proj_weight()` helper that mirrors the defensive `getattr(..., "weight", None)` pattern already used in `_detect_gfx95_quant_format` (line 1721 of the same file), and applies it to all three affected sites:

- `DeepseekV2AttentionMLA.__init__` — `use_min_latency_fused_a_gemm` check
- `DeepseekMLACpuForwardMixin.init_mla_fused_rope_cpu_forward` — int8/fp8 dtype detection
- `_dispatch_mla_subtype` in `attention_backend_handler.py` — `MLA_FUSED_ROPE_CPU` gating

When the helper returns `None`, optimization paths disable cleanly and requests route through `self.fused_qkv_a_proj_with_mqa(hidden_states)`, which handles quantized weights via the module's own quant_method.

## Accuracy Tests

N/A. This fix is purely defensive init code. It disables an optimization flag (`use_min_latency_fused_a_gemm`) for compressed-tensors AWQ models that were previously crashing before reaching any forward pass. No change to outputs for any model that was previously loading successfully.

## Speed Tests and Profiling

N/A. The optimization path guarded by `use_min_latency_fused_a_gemm` is a special-case fast GEMM for bf16 fused weights with specific shapes (2112x7168). AWQ-quantized models use a different forward path regardless; this change has no performance impact for any model that was previously running.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (N/A — no user-facing behavior change)
- [ ] Provide accuracy and speed benchmark results (see above).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.