### PR TITLE
feat(observability): add OpenTelemetry tracing for all speculative decoding workers

### DIFF
--- a/python/sglang/srt/speculative/dflash_worker.py
+++ b/python/sglang/srt/speculative/dflash_worker.py
@@ -20,6 +20,8 @@ from sglang.srt.server_args import (
     get_global_server_args,
     set_global_server_args_for_scheduler,
 )
+from sglang.srt.observability.req_time_stats import set_time_batch
+from sglang.srt.observability.trace import get_global_tracing_enabled
 from sglang.srt.speculative.dflash_info import DFlashDraftInput, DFlashVerifyInput
 from sglang.srt.speculative.dflash_utils import (
     can_dflash_use_fused_qkv_proj,
@@ -1179,7 +1181,12 @@ class DFlashWorker:
                 "This usually means the request did not complete the prefill stage."
             )
 
+        set_time_batch(batch.reqs, "set_spec_draft_start_time", trace_only=True)
+
         self._prepare_for_speculative_decoding(batch, draft_input)
+
+        set_time_batch(batch.reqs, "set_spec_draft_end_time", trace_only=True)
+        set_time_batch(batch.reqs, "set_spec_verify_start_time", trace_only=True)
 
         model_worker_batch = batch.get_model_worker_batch()
         assert model_worker_batch.forward_mode.is_target_verify()
@@ -1227,6 +1234,11 @@ class DFlashWorker:
         self._append_target_hidden_to_draft_kv(batch, draft_input)
         batch.spec_info = draft_input
         batch.forward_mode = ForwardMode.DECODE
+
+        if get_global_tracing_enabled():
+            for idx, req in enumerate(batch.reqs):
+                accepted = accept_length_per_req_cpu[idx]
+                req.time_stats.set_spec_verify_end_time(accepted_tokens=accepted)
 
         num_accepted_tokens = sum(accept_length_per_req_cpu)
         if not self._logged_first_verify and self.tp_rank == 0:

--- a/python/sglang/srt/speculative/dflash_worker.py
+++ b/python/sglang/srt/speculative/dflash_worker.py
@@ -15,6 +15,8 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardBatch,
     ForwardMode,
 )
+from sglang.srt.observability.req_time_stats import set_time_batch
+from sglang.srt.observability.trace import get_global_tracing_enabled
 from sglang.srt.server_args import (
     ServerArgs,
     get_global_server_args,
@@ -1190,7 +1192,12 @@ class DFlashWorker:
                 "This usually means the request did not complete the prefill stage."
             )
 
+        set_time_batch(batch.reqs, "set_spec_draft_start_time", trace_only=True)
+
         self._prepare_for_speculative_decoding(batch, draft_input)
+
+        set_time_batch(batch.reqs, "set_spec_draft_end_time", trace_only=True)
+        set_time_batch(batch.reqs, "set_spec_verify_start_time", trace_only=True)
 
         model_worker_batch = batch.get_model_worker_batch()
         assert model_worker_batch.forward_mode.is_target_verify()
@@ -1238,6 +1245,11 @@ class DFlashWorker:
         self._append_target_hidden_to_draft_kv(batch, draft_input)
         batch.spec_info = draft_input
         batch.forward_mode = ForwardMode.DECODE
+
+        if get_global_tracing_enabled():
+            for idx, req in enumerate(batch.reqs):
+                accepted = num_accepted_drafts_per_req_cpu[idx]
+                req.time_stats.set_spec_verify_end_time(accepted_tokens=accepted)
 
         num_accepted_drafts = sum(num_accepted_drafts_per_req_cpu)
         if not self._logged_first_verify and self.tp_rank == 0:

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -36,6 +36,8 @@ from sglang.srt.speculative.eagle_draft_cuda_graph_runner import (
 from sglang.srt.speculative.eagle_draft_extend_cuda_graph_runner import (
     EAGLEDraftExtendCudaGraphRunner,
 )
+from sglang.srt.observability.req_time_stats import set_time_batch
+from sglang.srt.observability.trace import get_global_tracing_enabled
 from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
 from sglang.srt.speculative.eagle_info_v2 import (
     assign_extend_cache_locs,
@@ -721,21 +723,38 @@ class EAGLEWorkerV2(BaseSpecWorker):
                     topk=self.topk,
                     capture_hidden_mode=CaptureHiddenMode.LAST,
                 )
+            set_time_batch(model_worker_batch.reqs, "set_spec_draft_start_time", trace_only=True)
+
             with self.draft_worker.draft_tp_context(
                 self.draft_worker.draft_runner.tp_group
             ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
                 verify_input: EagleVerifyInput = self.draft_worker.draft(
                     model_worker_batch
                 )
+
+            set_time_batch(model_worker_batch.reqs, "set_spec_draft_end_time", trace_only=True)
+            set_time_batch(model_worker_batch.reqs, "set_spec_verify_start_time", trace_only=True)
+
             assert verify_input.is_verify_input()
             model_worker_batch.spec_info = verify_input
             batch_output = self.verify(model_worker_batch)
+
+            if get_global_tracing_enabled() and model_worker_batch.reqs:
+                for idx, req in enumerate(model_worker_batch.reqs):
+                    accepted = batch_output.accept_lens[idx].item()
+                    req.time_stats.set_spec_verify_end_time(accepted_tokens=accepted)
+
+            set_time_batch(model_worker_batch.reqs, "set_spec_draft_extend_start_time", trace_only=True)
+
             with self.draft_worker.draft_tp_context(
                 self.draft_worker.draft_runner.tp_group
             ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
                 self.draft_worker._draft_extend_for_decode(
                     model_worker_batch, batch_output
                 )
+
+            set_time_batch(model_worker_batch.reqs, "set_spec_draft_extend_end_time", trace_only=True)
+
             return batch_output
 
     def verify(self, batch: ModelWorkerBatch):

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -32,6 +32,8 @@ from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
 from sglang.srt.model_executor.cuda_graph_runner import CudaGraphRunner
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardBatch
+from sglang.srt.observability.req_time_stats import set_time_batch
+from sglang.srt.observability.trace import get_global_tracing_enabled
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.adaptive_runtime_state import (
     AdaptiveController,
@@ -768,12 +770,24 @@ class EAGLEWorkerV2(BaseSpecWorker):
                     topk=self.topk,
                     capture_hidden_mode=CaptureHiddenMode.LAST,
                 )
+            set_time_batch(
+                model_worker_batch.reqs, "set_spec_draft_start_time", trace_only=True
+            )
+
             with self.draft_worker.draft_tp_context(
                 self.draft_worker.draft_runner.tp_group
             ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
                 verify_input: EagleVerifyInput = self.draft_worker.draft(
                     model_worker_batch
                 )
+
+            set_time_batch(
+                model_worker_batch.reqs, "set_spec_draft_end_time", trace_only=True
+            )
+            set_time_batch(
+                model_worker_batch.reqs, "set_spec_verify_start_time", trace_only=True
+            )
+
             assert verify_input.is_verify_input()
             # Record a CUDA event after draft() GPU work is dispatched.
             # This event will be waited on by plan_stream in verify()
@@ -784,12 +798,30 @@ class EAGLEWorkerV2(BaseSpecWorker):
                 self._draft_done_event.record()
             model_worker_batch.spec_info = verify_input
             batch_output = self.verify(model_worker_batch)
+
+            if get_global_tracing_enabled() and model_worker_batch.reqs:
+                for idx, req in enumerate(model_worker_batch.reqs):
+                    accepted = batch_output.accept_lens[idx].item()
+                    req.time_stats.set_spec_verify_end_time(accepted_tokens=accepted)
+
+            set_time_batch(
+                model_worker_batch.reqs,
+                "set_spec_draft_extend_start_time",
+                trace_only=True,
+            )
+
             with self.draft_worker.draft_tp_context(
                 self.draft_worker.draft_runner.tp_group
             ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
                 self.draft_worker._draft_extend_for_decode(
                     model_worker_batch, batch_output
                 )
+
+            set_time_batch(
+                model_worker_batch.reqs,
+                "set_spec_draft_extend_end_time",
+                trace_only=True,
+            )
 
             return batch_output
 

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -31,6 +31,8 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardBatch,
     ForwardMode,
 )
+from sglang.srt.observability.req_time_stats import set_time_batch
+from sglang.srt.observability.trace import get_global_tracing_enabled
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.draft_utils import DraftBackendFactory
 from sglang.srt.speculative.eagle_info import (
@@ -268,12 +270,27 @@ class MultiLayerEagleWorker(TpModelWorker):
                 can_run_cuda_graph=can_run_cuda_graph,
             )
         else:
+            set_time_batch(batch.reqs, "set_spec_draft_start_time", trace_only=True)
+
             with self.draft_tp_context(
                 self.mtp_model_runner(0).tp_group
             ), speculative_moe_backend_context():
                 spec_info = self.draft(batch)
+
+            set_time_batch(batch.reqs, "set_spec_draft_end_time", trace_only=True)
+            set_time_batch(batch.reqs, "set_spec_verify_start_time", trace_only=True)
+
             logits_output, verify_output, model_worker_batch, can_run_cuda_graph = (
                 self.verify(batch, spec_info)
+            )
+
+            if get_global_tracing_enabled():
+                for idx, req in enumerate(batch.reqs):
+                    accepted = verify_output.accept_length_per_req_cpu[idx]
+                    req.time_stats.set_spec_verify_end_time(accepted_tokens=accepted)
+
+            set_time_batch(
+                batch.reqs, "set_spec_draft_extend_start_time", trace_only=True
             )
 
             with self.draft_tp_context(
@@ -287,6 +304,10 @@ class MultiLayerEagleWorker(TpModelWorker):
                 ):
                     # decode is not finished
                     self.forward_draft_extend_after_decode(batch)
+
+            set_time_batch(
+                batch.reqs, "set_spec_draft_extend_end_time", trace_only=True
+            )
 
             return GenerationBatchResult(
                 logits_output=logits_output,

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -31,6 +31,8 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardBatch,
     ForwardMode,
 )
+from sglang.srt.observability.req_time_stats import set_time_batch
+from sglang.srt.observability.trace import get_global_tracing_enabled
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.draft_utils import DraftBackendFactory
 from sglang.srt.speculative.eagle_info import (
@@ -268,12 +270,27 @@ class MultiLayerEagleWorker(TpModelWorker):
                 can_run_cuda_graph=can_run_cuda_graph,
             )
         else:
+            set_time_batch(batch.reqs, "set_spec_draft_start_time", trace_only=True)
+
             with self.draft_tp_context(
                 self.mtp_model_runner(0).tp_group
             ), speculative_moe_backend_context():
                 spec_info = self.draft(batch)
+
+            set_time_batch(batch.reqs, "set_spec_draft_end_time", trace_only=True)
+            set_time_batch(batch.reqs, "set_spec_verify_start_time", trace_only=True)
+
             logits_output, verify_output, model_worker_batch, can_run_cuda_graph = (
                 self.verify(batch, spec_info)
+            )
+
+            if get_global_tracing_enabled():
+                for idx, req in enumerate(batch.reqs):
+                    accepted = verify_output.accept_length_per_req_cpu[idx]
+                    req.time_stats.set_spec_verify_end_time(accepted_tokens=accepted)
+
+            set_time_batch(
+                batch.reqs, "set_spec_draft_extend_start_time", trace_only=True
             )
 
             with self.draft_tp_context(
@@ -287,6 +304,10 @@ class MultiLayerEagleWorker(TpModelWorker):
                 ):
                     # decode is not finished
                     self.forward_draft_extend_after_decode(batch, verify_output)
+
+            set_time_batch(
+                batch.reqs, "set_spec_draft_extend_end_time", trace_only=True
+            )
 
             return GenerationBatchResult(
                 logits_output=logits_output,

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -26,6 +26,8 @@ from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardBatch
 from sglang.srt.server_args import ServerArgs
+from sglang.srt.observability.req_time_stats import set_time_batch
+from sglang.srt.observability.trace import get_global_tracing_enabled
 from sglang.srt.speculative.base_spec_worker import BaseDraftWorker, BaseSpecWorker
 from sglang.srt.speculative.draft_utils import DraftBackendFactory
 from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
@@ -664,11 +666,29 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
                     capture_hidden_mode=CaptureHiddenMode.LAST,
                 )
             draft_input: EagleDraftInput = model_worker_batch.spec_info
+
+            set_time_batch(model_worker_batch.reqs, "set_spec_draft_start_time", trace_only=True)
+
             verify_input: EagleVerifyInput = self.draft_worker.draft(model_worker_batch)
+
+            set_time_batch(model_worker_batch.reqs, "set_spec_draft_end_time", trace_only=True)
+            set_time_batch(model_worker_batch.reqs, "set_spec_verify_start_time", trace_only=True)
+
             assert verify_input.is_verify_input()
             model_worker_batch.spec_info = verify_input
             batch_output = self.verify(model_worker_batch)
+
+            if get_global_tracing_enabled() and model_worker_batch.reqs:
+                for idx, req in enumerate(model_worker_batch.reqs):
+                    accepted = batch_output.accept_lens[idx].item()
+                    req.time_stats.set_spec_verify_end_time(accepted_tokens=accepted)
+
+            set_time_batch(model_worker_batch.reqs, "set_spec_draft_extend_start_time", trace_only=True)
+
             self.draft_worker._draft_extend_for_decode(model_worker_batch, batch_output)
+
+            set_time_batch(model_worker_batch.reqs, "set_spec_draft_extend_end_time", trace_only=True)
+
             return batch_output
 
     def verify(

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -29,6 +29,8 @@ from sglang.srt.managers.schedule_batch import ModelWorkerBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardBatch
+from sglang.srt.observability.req_time_stats import set_time_batch
+from sglang.srt.observability.trace import get_global_tracing_enabled
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.base_spec_worker import BaseDraftWorker, BaseSpecWorker
 from sglang.srt.speculative.draft_utils import DraftBackendFactory
@@ -683,7 +685,20 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
                     capture_hidden_mode=CaptureHiddenMode.LAST,
                 )
             draft_input: EagleDraftInput = model_worker_batch.spec_info
+
+            set_time_batch(
+                model_worker_batch.reqs, "set_spec_draft_start_time", trace_only=True
+            )
+
             verify_input: EagleVerifyInput = self.draft_worker.draft(model_worker_batch)
+
+            set_time_batch(
+                model_worker_batch.reqs, "set_spec_draft_end_time", trace_only=True
+            )
+            set_time_batch(
+                model_worker_batch.reqs, "set_spec_verify_start_time", trace_only=True
+            )
+
             assert verify_input.is_verify_input()
             # Record a CUDA event after draft() GPU work is dispatched.
             if self.plan_stream:
@@ -691,7 +706,26 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
                 self._draft_done_event.record()
             model_worker_batch.spec_info = verify_input
             batch_output = self.verify(model_worker_batch)
+
+            if get_global_tracing_enabled() and model_worker_batch.reqs:
+                for idx, req in enumerate(model_worker_batch.reqs):
+                    accepted = batch_output.accept_lens[idx].item()
+                    req.time_stats.set_spec_verify_end_time(accepted_tokens=accepted)
+
+            set_time_batch(
+                model_worker_batch.reqs,
+                "set_spec_draft_extend_start_time",
+                trace_only=True,
+            )
+
             self.draft_worker._draft_extend_for_decode(model_worker_batch, batch_output)
+
+            set_time_batch(
+                model_worker_batch.reqs,
+                "set_spec_draft_extend_end_time",
+                trace_only=True,
+            )
+
             return batch_output
 
     def verify(


### PR DESCRIPTION
## Motivation

PR #19545 added OpenTelemetry tracing for speculative decoding, but **only covered `EAGLEWorker` (v1) and `NgramWorker`**. However, the default EAGLE path uses `EAGLEWorkerV2` (overlap mode), meaning most users cannot see spec decode traces.

### Root Cause

```python
# spec_info.py - worker routing logic
enable_overlap = not server_args.disable_overlap_schedule  # default: True

if self.is_eagle():
    if enable_overlap:       # <-- default path
        return EAGLEWorkerV2  # ❌ no tracing code
    return EAGLEWorker        # ✅ has tracing (PR #19545)
```

This is why the maintainer reported that Qwen3.5 + EAGLE shows no trace — it's not a Mamba issue, but a **worker routing issue**.

## Modifications

Added `set_time_batch` and `get_global_tracing_enabled` tracing instrumentation to all 4 uncovered speculative decoding workers, following the exact same pattern as `eagle_worker.py` (v1):

| Worker | Trigger Condition | Changes |
|--------|------------------|---------|
| `eagle_worker_v2.py` | EAGLE + overlap (**default path**) | +19 lines |
| `multi_layer_eagle_worker.py` | EAGLE + multi_layer + non-overlap | +21 lines |
| `multi_layer_eagle_worker_v2.py` | EAGLE + multi_layer + overlap | +20 lines |
| `dflash_worker.py` | DFlash speculative decoding | +12 lines |

**Total: 4 files changed, +72 insertions, 0 deletions**

### Tracing Pattern

For v2 workers (overlap mode), uses `model_worker_batch.reqs` instead of `batch.reqs`:

```python
from sglang.srt.observability.req_time_stats import set_time_batch
from sglang.srt.observability.trace import get_global_tracing_enabled

# In forward_batch_generation:
set_time_batch(model_worker_batch.reqs, "set_spec_draft_start_time", trace_only=True)
# ... draft phase ...
set_time_batch(model_worker_batch.reqs, "set_spec_draft_end_time", trace_only=True)
set_time_batch(model_worker_batch.reqs, "set_spec_verify_start_time", trace_only=True)
# ... verify phase ...
if get_global_tracing_enabled() and model_worker_batch.reqs:
    for idx, req in enumerate(model_worker_batch.reqs):
        accepted = batch_output.accept_lens[idx].item()
        req.time_stats.set_spec_verify_end_time(accepted_tokens=accepted)
```

For DFlash worker, the draft phase happens inside `_prepare_for_speculative_decoding`, so tracing is placed accordingly.

## Checklist
- [x] Format code with pre-commit
- [x] Follow the SGLang code style guidance
- [x] Zero overhead when tracing is disabled (`trace_only=True` + `get_global_tracing_enabled()` guard)