### PR TITLE
fix(ci): repair path filters regressed by #21482

### DIFF
--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -147,13 +147,13 @@ jobs:
               - "test/**/!(*.md)"
               - ".github/workflows/pr-test-amd-rocm720.yml"
             sgl_kernel:
-              - "sgl-kernel/**/*.!(md|txt)"
+              - "sgl-kernel/**/!(*.md|THIRDPARTYNOTICES.txt|LICENSE)"
               - ".github/workflows/pr-test-amd-rocm720.yml"
             jit_kernel:
               - "python/sglang/jit_kernel/**"
               - ".github/workflows/pr-test-amd-rocm720.yml"
             multimodal_gen:
-              - "python/sglang/multimodal_gen/**/*.!(md|ipynb)"
+              - "python/sglang/multimodal_gen/**/!(*.md|*.ipynb)"
               - "python/sglang/cli/**"
               - "python/sglang/jit_kernel/diffusion/**"
               - "python/sglang/jit_kernel/tests/diffusion/**"

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -149,13 +149,13 @@ jobs:
               - "test/**/!(*.md)"
               - ".github/workflows/pr-test-amd.yml"
             sgl_kernel:
-              - "sgl-kernel/**/*.!(md|txt)"
+              - "sgl-kernel/**/!(*.md|THIRDPARTYNOTICES.txt|LICENSE)"
               - ".github/workflows/pr-test-amd.yml"
             jit_kernel:
               - "python/sglang/jit_kernel/**"
               - ".github/workflows/pr-test-amd.yml"
             multimodal_gen:
-              - "python/sglang/multimodal_gen/**/*.!(md|ipynb)"
+              - "python/sglang/multimodal_gen/**/!(*.md|*.ipynb)"
               - "python/sglang/cli/**"
               - "python/sglang/jit_kernel/diffusion/**"
               - "python/sglang/jit_kernel/tests/diffusion/**"

--- a/.github/workflows/pr-test-npu.yml
+++ b/.github/workflows/pr-test-npu.yml
@@ -63,7 +63,7 @@ jobs:
               - "test/srt/ascend/**"
               - ".github/workflows/pr-test-npu.yml"
             multimodal_gen:
-              - "python/sglang/multimodal_gen/**/*.!(md|ipynb)"
+              - "python/sglang/multimodal_gen/**/!(*.md|*.ipynb)"
               - "python/sglang/srt/**"
               - "python/pyproject_npu.toml"
               - "scripts/ci/npu/npu_ci_install_dependency.sh"

--- a/.github/workflows/pr-test-xeon.yml
+++ b/.github/workflows/pr-test-xeon.yml
@@ -58,7 +58,7 @@ jobs:
               - "python/sglang/!(multimodal_gen)/**/!(*.md)"
               - "python/pyproject_cpu.toml"
               - "test/**/!(*.md)"
-              - "sgl-kernel/**/*.!(md|txt)"
+              - "sgl-kernel/**/!(*.md|THIRDPARTYNOTICES.txt|LICENSE)"
               - ".github/workflows/pr-test-xeon.yml"
               - "docker/xeon.Dockerfile"
 

--- a/.github/workflows/pr-test-xpu.yml
+++ b/.github/workflows/pr-test-xpu.yml
@@ -57,7 +57,7 @@ jobs:
               - "python/sglang/!(multimodal_gen)/**/!(*.md)"
               - "python/pyproject_xpu.toml"
               - "test/**/!(*.md)"
-              - "sgl-kernel/**/*.!(md|txt)"
+              - "sgl-kernel/**/!(*.md|THIRDPARTYNOTICES.txt|LICENSE)"
               - ".github/workflows/pr-test-xpu.yml"
               - "docker/xpu.Dockerfile"
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -136,7 +136,7 @@ jobs:
               - ".github/workflows/pr-test.yml"
               - ".github/workflows/pr-test-multimodal-gen.yml"
               - "python/pyproject.toml"
-              - "python/sglang/multimodal_gen/**/*.!(md|ipynb)"
+              - "python/sglang/multimodal_gen/**/!(*.md|*.ipynb)"
               - "python/sglang/jit_kernel/diffusion/**"
               - "python/sglang/jit_kernel/tests/diffusion/**"
               - "python/sglang/jit_kernel/benchmark/diffusion/**"
@@ -148,7 +148,7 @@ jobs:
               - "python/sglang/jit_kernel/**"
             sgl_kernel:
               - ".github/workflows/pr-test-sgl-kernel.yml"
-              - "sgl-kernel/**/*.!(md|txt)"
+              - "sgl-kernel/**/!(*.md|THIRDPARTYNOTICES.txt|LICENSE)"
 
       # For /rerun-stage (workflow_dispatch with target_stage), dorny/paths-filter doesn't work
       # correctly because it falls back to "last commit" detection which breaks for merge commits.


### PR DESCRIPTION
## Summary

PR #21482 ("Skip ci for .md files", merged 2026-03-28) introduced two different negation styles in the same change. It used the correct basename-level form for `main_package` and `test`:

```
"python/sglang/!(multimodal_gen)/**/!(*.md)"
"test/**/!(*.md)"
```

but used a broken extension-level form for `sgl_kernel` and `multimodal_gen`:

```
"sgl-kernel/**/*.!(md|txt)"
"python/sglang/multimodal_gen/**/*.!(md|ipynb)"
```

The extension-level form has two silent false-negative bugs:

1. **Extensionless files don't match.** The negation sits inside the extension (`.!(md|txt)`), so the filename must contain a literal `.`. Files like `sgl-kernel/Dockerfile`, `sgl-kernel/Makefile`, `sgl-kernel/LICENSE`, and (in `multimodal_gen`) any `Dockerfile`/`Makefile`/`LICENSE` never trip the filter. This caused #21247 (torch 2.11 bump) to skip `sgl-kernel-build-wheels` and hit an ABI mismatch against the pre-built PyPI sglang-kernel wheel (`undefined symbol: _ZN3c104cuda29c10_cuda_check_implementationEiPKcS2_ib`).
2. **Blanket `*.txt` exclusion swallows `CMakeLists.txt`.** `sgl-kernel/CMakeLists.txt` and `sgl-kernel/csrc/cpu/CMakeLists.txt` control the build (Triton tag, include paths, compile flags) and should absolutely trigger a rebuild. The exclusion was almost certainly intended only for `THIRDPARTYNOTICES.txt`.

Fix: rewrite the two broken filters at the basename level, matching the style already used for `main_package` / `test`:

```yaml
sgl_kernel:
  - "sgl-kernel/**/!(*.md|THIRDPARTYNOTICES.txt|LICENSE)"
multimodal_gen:
  - "python/sglang/multimodal_gen/**/!(*.md|*.ipynb)"
```

A single extglob also sidesteps the [dorny/paths-filter multi-`!` ordering bug](https://github.com/dorny/paths-filter/issues/113) that would otherwise force `predicate-quantifier: 'every'` and break OR-semantics with the other include patterns ([issue #260](https://github.com/dorny/paths-filter/issues/260)). Keeping the negation intra-pattern also avoids any cross-filter side-effects in the same step.

Applied across all workflows that used the broken pattern:
- **`sgl_kernel`** filter: `pr-test.yml`, `pr-test-amd.yml`, `pr-test-amd-rocm720.yml`, `pr-test-xeon.yml`, `pr-test-xpu.yml` (5 files).
- **`multimodal_gen`** filter: `pr-test.yml`, `pr-test-npu.yml`, `pr-test-amd.yml`, `pr-test-amd-rocm720.yml` (4 files; `pr-test.yml` and `pr-test-amd*.yml` intersect the `sgl_kernel` set).

## Test plan

Verified locally with `picomatch@2.3.1` (the version `dorny/paths-filter` pins) invoked with `{dot: true}` (matching `dorny/paths-filter/src/filter.ts:16`). The test script reads the patterns straight from the committed workflow files, confirms all 5 `sgl_kernel:` and 4 `multimodal_gen:` blocks collapsed to the same two unique strings, and runs 19 + 13 = 32 cases — all pass.

### `sgl_kernel` filter

| File | Old pattern | New pattern | Notes |
|---|:-:|:-:|---|
| `sgl-kernel/Dockerfile` | skip ❌ | **match ✓** | fixes #21247 |
| `sgl-kernel/Makefile` | skip ❌ | **match ✓** | |
| `sgl-kernel/CMakeLists.txt` | skip ❌ | **match ✓** | fixes latent build bug |
| `sgl-kernel/csrc/cpu/CMakeLists.txt` | skip ❌ | **match ✓** | nested CMakeLists.txt |
| `sgl-kernel/LICENSE` | match ❌ | **skip ✓** | legal; no rebuild needed |
| `sgl-kernel/3rdparty/fmt/LICENSE` | — | skip | nested LICENSE (hypothetical vendored code) |
| `sgl-kernel/README.md`, `docs/guide.md` | skip | skip | preserved (incl. nested) |
| `sgl-kernel/THIRDPARTYNOTICES.txt` | skip | skip | preserved |
| `sgl-kernel/.gitignore`, `csrc/.clang-format` | match | match | dotfiles still match |
| `sgl-kernel/build.sh`, `pyproject.toml`, `*.cu`, `*.py`, `*.cmake` | match | match | preserved |

### `multimodal_gen` filter

| File | Old pattern | New pattern |
|---|:-:|:-:|
| `python/sglang/multimodal_gen/Dockerfile` | skip ❌ | **match ✓** |
| `python/sglang/multimodal_gen/Makefile` | skip ❌ | **match ✓** |
| `python/sglang/multimodal_gen/LICENSE` | skip ❌ | **match ✓** |
| `python/sglang/multimodal_gen/README.md` | skip | skip |
| `python/sglang/multimodal_gen/apps/webui/README.md` | skip | skip |
| `python/sglang/multimodal_gen/.claude/CLAUDE.md` | skip | skip | (actual file in repo) |
| `python/sglang/multimodal_gen/notebook.ipynb` | skip | skip |
| `python/sglang/multimodal_gen/nested/dir/tutorial.ipynb` | skip | skip | (nested) |
| `python/sglang/multimodal_gen/foo.py`, `pyproject.toml`, `apps/webui/foo.tsx` | match | match |

Reproducer:

```bash
mkdir -p /tmp/dorny-test && cd /tmp/dorny-test
npm init -y && npm install picomatch@^2.3.1
node -e "console.log(require('picomatch')('sgl-kernel/**/!(*.md|THIRDPARTYNOTICES.txt|LICENSE)', {dot:true})('sgl-kernel/CMakeLists.txt'))"
# → true  (false with the old pattern)
```

## Notes

- **Exclusion scope.** The basename-level excludes (`LICENSE`, `THIRDPARTYNOTICES.txt`, `*.md`, `*.ipynb`) apply at any depth under `sgl-kernel/` or `python/sglang/multimodal_gen/`, not just top-level. Today the repo only has top-level occurrences, so this is observationally identical. If vendored code were ever added under e.g. `sgl-kernel/3rdparty/<lib>/LICENSE`, that would also be excluded — which is arguably the right behavior (vendored license metadata shouldn't trigger kernel rebuilds).
- **Out of scope.** This PR deliberately keeps the denylist style inherited from #21482. A follow-up could switch `sgl_kernel` to an explicit allowlist of build-relevant extensions (`.py`, `.cu`, `.cuh`, `.cpp`, `.h`, `.hpp`, `.sh`, `.toml`, `.cmake`, `.yml`) plus explicit files (`CMakeLists.txt`, `Dockerfile`, `Makefile`). Trade-off is different (new build-relevant extensions would need explicit adds), so saving that for a separate discussion.

## Checks

- [x] `pre-commit run` clean on the six touched files
- [x] Local picomatch tests read patterns directly from the six committed workflow files; 32 cases (19 sgl_kernel + 13 multimodal_gen) all pass, including nested files, dotfiles, hypothetical vendored `LICENSE`, and in-repo `.claude/CLAUDE.md`
- [x] Grepped entire `.github/` tree for remaining extension-level negation patterns — none left
- [ ] CI on this PR triggers `sgl-kernel-build-wheels` because the change touches workflow files (confirms filter is re-exercised end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
