### PR TITLE
[Bugfix] fix FP8 quantization error in ERNIE-4.5-VL gate layers

### DIFF
--- a/python/sglang/srt/models/ernie45_moe_vl.py
+++ b/python/sglang/srt/models/ernie45_moe_vl.py
@@ -194,12 +194,13 @@ class Ernie4_5_VLMoeMoE(nn.Module):
             layer_id >= text_moe_layer_start_index
             and layer_id <= text_moe_layer_end_index
         ):
+            # gate uses float32 input, so disable FP8 quantization to avoid error
             self.text_experts_gate = ReplicatedLinear(
                 config.hidden_size,
                 config.moe_num_experts[0],
                 bias=False,
                 params_dtype=torch.float32,
-                quant_config=quant_config,
+                quant_config=None,
                 prefix=add_prefix("text_experts_gate", prefix),
             )
 
@@ -225,13 +226,13 @@ class Ernie4_5_VLMoeMoE(nn.Module):
             layer_id >= vision_moe_layer_start_index
             and layer_id <= vision_moe_layer_end_index
         ):
-
+            # gate uses float32 input, so disable FP8 quantization to avoid error
             self.vision_experts_gate = ReplicatedLinear(
                 config.hidden_size,
                 config.moe_num_experts[1],
                 bias=False,
                 params_dtype=torch.float32,
-                quant_config=quant_config,
+                quant_config=None,
                 prefix=add_prefix("vision_experts_gate", prefix),
             )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
When launching ERNIE-4.5-VL model with FP8 quantization (`--quantization fp8`), the server fails during CUDA graph capture with the error:
RuntimeError: out_dtype must be Half or BFloat16

This occurs because the MoE gate layers (`text_experts_gate` and `vision_experts_gate`) use `float32` input (explicitly cast via `.to(dtype=torch.float32)`), but the FP8 quantized linear layer's `fp8_scaled_mm` kernel only supports `Half` or `BFloat16` output dtype.

## Modifications

<!-- Detail the changes made in this pull request. -->
- Disabled FP8 quantization for `text_experts_gate` and `vision_experts_gate` layers in `ernie45_moe_vl.py` by setting `quant_config=None`.
- These gate layers have minimal parameters (hidden_size → num_experts), so disabling quantization has negligible impact on memory and performance.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
N/A 

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
N/A 

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
