### PR TITLE
[CI] Partition stage-a-test-cpu into 4 matrix shards

### DIFF
--- a/.claude/skills/ci-workflow-guide/SKILL.md
+++ b/.claude/skills/ci-workflow-guide/SKILL.md
@@ -270,7 +270,7 @@ Large suites are split across matrix jobs using the **LPT (Longest Processing Ti
 | Suite | Partitions | Runner | max_parallel |
 |-------|-----------|--------|-------------|
 | `stage-a-test-1-gpu-small` | 1 (no matrix) | `1-gpu-5090` | — |
-| `stage-a-test-cpu` | 1 (no matrix) | `ubuntu-latest` | — |
+| `stage-a-test-cpu` | 4 | `ubuntu-latest` | — |
 | `stage-b-test-1-gpu-small` | 8 | `1-gpu-5090` | 8 |
 | `stage-b-test-1-gpu-large` | 14 | `1-gpu-h100` | dynamic (3 or 14) |
 | `stage-b-test-2-gpu-large` | 4 | `2-gpu-h100` | — |

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -361,7 +361,7 @@ jobs:
         id: wait
         with:
           stage-name: stage-a
-          jobs: '["stage-a-test-1-gpu-small", "stage-a-test-cpu"]'
+          jobs: '["stage-a-test-1-gpu-small", {"prefix": "stage-a-test-cpu", "expected_count": 4}]'
           max-wait-minutes: '240'
 
   wait-for-stage-b:
@@ -616,6 +616,10 @@ jobs:
       )
     runs-on: ubuntu-latest
     timeout-minutes: 240
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: [0, 1, 2, 3]
     steps:
       - name: Free disk space
         run: |
@@ -661,7 +665,7 @@ jobs:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
         run: |
           cd test/
-          python3 run_suite.py --hw cpu --suite stage-a-test-cpu $CONTINUE_ON_ERROR_FLAG
+          python3 run_suite.py --hw cpu --suite stage-a-test-cpu --auto-partition-id ${{ matrix.partition }} --auto-partition-size 4 $CONTINUE_ON_ERROR_FLAG
 
   # Runs on 5090 (32GB, SM120)
   stage-b-test-1-gpu-small:


### PR DESCRIPTION
## Summary

- Split `stage-a-test-cpu` into 4 matrix partitions to address tight wall time.
- The suite has grown to ~1219s of estimated test time across 115 registered tests; the single-job run was close to the 10-min step timeout.
- Uses the same LPT auto-partition mechanism already in place for `stage-b-test-*` matrix jobs (`run_suite.py --auto-partition-id --auto-partition-size`), so no new infrastructure is introduced.

## Changes

- `.github/workflows/pr-test.yml`
  - `stage-a-test-cpu`: add `strategy.matrix.partition: [0, 1, 2, 3]` and pass `--auto-partition-id ${{ matrix.partition }} --auto-partition-size 4` to `run_suite.py`.
  - `wait-for-stage-a.jobs`: change the `stage-a-test-cpu` entry from a bare string to `{"prefix": "stage-a-test-cpu", "expected_count": 4}` so the stage-a wait polls for all 4 shards.
- `pr-test-finish.needs` is unchanged — GitHub Actions aggregates matrix shards under the base job name.

## Test Plan

Regular CI: https://github.com/sgl-project/sglang/actions/runs/24649230919/job/72068228156
/rerun-stage: https://github.com/sgl-project/sglang/actions/runs/24649434855/job/72068792310