### PR TITLE
wait for reap in kill_process_tree

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -772,13 +772,9 @@ class Engine(EngineScoreMixin, EngineBase):
         )
 
     def shutdown(self):
-        """Shutdown the engine.
-
-        Waits for the scheduler subprocess to exit so its GPU context is
-        released before returning. Callers that immediately allocate GPU
-        memory (e.g. loading a reference HF model right after) would
-        otherwise race the kernel's reap of the killed child.
-        """
+        """Shutdown the engine; block until the scheduler subprocess releases
+        its GPU context so the caller can immediately reallocate on the same
+        device."""
         if (
             self.tokenizer_manager is not None
             and self.tokenizer_manager._subprocess_watchdog is not None

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -772,13 +772,19 @@ class Engine(EngineScoreMixin, EngineBase):
         )
 
     def shutdown(self):
-        """Shutdown the engine"""
+        """Shutdown the engine.
+
+        Waits for the scheduler subprocess to exit so its GPU context is
+        released before returning. Callers that immediately allocate GPU
+        memory (e.g. loading a reference HF model right after) would
+        otherwise race the kernel's reap of the killed child.
+        """
         if (
             self.tokenizer_manager is not None
             and self.tokenizer_manager._subprocess_watchdog is not None
         ):
             self.tokenizer_manager._subprocess_watchdog.stop()
-        kill_process_tree(os.getpid(), include_parent=False)
+        kill_process_tree(os.getpid(), include_parent=False, wait_timeout=60)
 
     def __enter__(self):
         return self

--- a/python/sglang/srt/entrypoints/http_server_engine.py
+++ b/python/sglang/srt/entrypoints/http_server_engine.py
@@ -100,7 +100,9 @@ class HttpServerEngineAdapter(EngineBase):
         )
 
     def shutdown(self):
-        kill_process_tree(self.process.pid)
+        # Wait for the server process tree to fully exit so its GPU context
+        # is released before the caller reuses the device.
+        kill_process_tree(self.process.pid, wait_timeout=60)
 
     def generate(
         self,

--- a/python/sglang/srt/entrypoints/http_server_engine.py
+++ b/python/sglang/srt/entrypoints/http_server_engine.py
@@ -100,8 +100,6 @@ class HttpServerEngineAdapter(EngineBase):
         )
 
     def shutdown(self):
-        # Wait for the server process tree to fully exit so its GPU context
-        # is released before the caller reuses the device.
         kill_process_tree(self.process.pid, wait_timeout=60)
 
     def generate(

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -1048,14 +1048,11 @@ def check_pkg_version_at_least(pkg: str, min_version: str) -> bool:
 
 
 def _wait_for_reap_or_raise(procs, wait_timeout: float) -> None:
-    """Block until `procs` exit, warning midway and raising on hard timeout.
+    """Wait for `procs` to exit; warn at ~10s, raise on `wait_timeout`.
 
-    SIGKILL is asynchronous: a killed process keeps holding resources (GPU
-    contexts, pinned memory, file descriptors) until the kernel reaps it.
-    Callers that reuse those resources right after kill must wait for reap.
-    This helper warns at ~10s if anything is still alive, then raises at
-    `wait_timeout` so a stuck process surfaces loudly instead of leaving a
-    latent race in place.
+    SIGKILL is asynchronous -- children hold GPU context, pinned memory and
+    fds until the kernel reaps them. Raise on timeout so a stuck process
+    surfaces instead of leaving a latent race.
     """
     warn_at = min(10.0, wait_timeout / 2)
     gone, alive = psutil.wait_procs(procs, timeout=warn_at)
@@ -1087,13 +1084,10 @@ def kill_process_tree(
 ):
     """Kill the process and all its child processes.
 
-    If `wait_timeout` is set, block until every killed process is reaped by
-    the kernel (so its GPU context, pinned memory and fds are actually
-    released). Exceeding `wait_timeout` raises `RuntimeError`. Leave it as
-    `None` for fire-and-forget kills where no resource is reused after.
-    The `parent_pid == os.getpid()` branch calls `sys.exit(0)` and cannot
-    wait for itself; pass `include_parent=False` in that case if you need
-    child reap to complete first.
+    `wait_timeout` (seconds) blocks until every killed process is reaped and
+    raises `RuntimeError` on timeout; `None` is fire-and-forget. The
+    `parent_pid == os.getpid()` branch calls `sys.exit(0)` and cannot wait
+    for itself -- use `include_parent=False` if child reap must finish first.
     """
     if parent_pid is None:
         parent_pid = os.getpid()

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -1047,8 +1047,54 @@ def check_pkg_version_at_least(pkg: str, min_version: str) -> bool:
         return False
 
 
-def kill_process_tree(parent_pid, include_parent: bool = True, skip_pid: int = None):
-    """Kill the process and all its child processes."""
+def _wait_for_reap_or_raise(procs, wait_timeout: float) -> None:
+    """Block until `procs` exit, warning midway and raising on hard timeout.
+
+    SIGKILL is asynchronous: a killed process keeps holding resources (GPU
+    contexts, pinned memory, file descriptors) until the kernel reaps it.
+    Callers that reuse those resources right after kill must wait for reap.
+    This helper warns at ~10s if anything is still alive, then raises at
+    `wait_timeout` so a stuck process surfaces loudly instead of leaving a
+    latent race in place.
+    """
+    warn_at = min(10.0, wait_timeout / 2)
+    gone, alive = psutil.wait_procs(procs, timeout=warn_at)
+    if not alive:
+        return
+    logger.warning(
+        "kill_process_tree: %d process(es) still alive after %.1fs SIGKILL; "
+        "continuing to wait up to %.1fs total. pids=%s",
+        len(alive),
+        warn_at,
+        wait_timeout,
+        [p.pid for p in alive],
+    )
+    remaining = wait_timeout - warn_at
+    if remaining > 0:
+        _, alive = psutil.wait_procs(alive, timeout=remaining)
+    if alive:
+        raise RuntimeError(
+            f"kill_process_tree: {len(alive)} process(es) not reaped within "
+            f"{wait_timeout}s after SIGKILL; pids={[p.pid for p in alive]}"
+        )
+
+
+def kill_process_tree(
+    parent_pid,
+    include_parent: bool = True,
+    skip_pid: int = None,
+    wait_timeout: Optional[float] = None,
+):
+    """Kill the process and all its child processes.
+
+    If `wait_timeout` is set, block until every killed process is reaped by
+    the kernel (so its GPU context, pinned memory and fds are actually
+    released). Exceeding `wait_timeout` raises `RuntimeError`. Leave it as
+    `None` for fire-and-forget kills where no resource is reused after.
+    The `parent_pid == os.getpid()` branch calls `sys.exit(0)` and cannot
+    wait for itself; pass `include_parent=False` in that case if you need
+    child reap to complete first.
+    """
     if parent_pid is None:
         parent_pid = os.getpid()
         include_parent = False
@@ -1059,11 +1105,13 @@ def kill_process_tree(parent_pid, include_parent: bool = True, skip_pid: int = N
         return
 
     children = itself.children(recursive=True)
+    killed = []
     for child in children:
         if child.pid == skip_pid:
             continue
         try:
             child.kill()
+            killed.append(child)
         except psutil.NoSuchProcess:
             pass
 
@@ -1078,8 +1126,12 @@ def kill_process_tree(parent_pid, include_parent: bool = True, skip_pid: int = N
             # Sometime processes cannot be killed with SIGKILL (e.g, PID=1 launched by kubernetes),
             # so we send an additional signal to kill them.
             itself.send_signal(signal.SIGQUIT)
+            killed.append(itself)
         except psutil.NoSuchProcess:
             pass
+
+    if wait_timeout is not None and killed:
+        _wait_for_reap_or_raise(killed, wait_timeout)
 
 
 def monkey_patch_p2p_access_check():

--- a/python/sglang/test/server_fixtures/default_fixture.py
+++ b/python/sglang/test/server_fixtures/default_fixture.py
@@ -65,8 +65,6 @@ class DefaultServerBase(CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        # wait_timeout lets the killed server release its GPU context
-        # before the next test class sets up a new server on the same GPU.
         kill_process_tree(cls.process.pid, wait_timeout=60)
         time.sleep(2)
 

--- a/python/sglang/test/server_fixtures/default_fixture.py
+++ b/python/sglang/test/server_fixtures/default_fixture.py
@@ -65,7 +65,9 @@ class DefaultServerBase(CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
+        # wait_timeout lets the killed server release its GPU context
+        # before the next test class sets up a new server on the same GPU.
+        kill_process_tree(cls.process.pid, wait_timeout=60)
         time.sleep(2)
 
     @classmethod

--- a/python/sglang/test/server_fixtures/disaggregation_fixture.py
+++ b/python/sglang/test/server_fixtures/disaggregation_fixture.py
@@ -140,10 +140,12 @@ class PDDisaggregationServerBase(CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
+        # wait_timeout ensures each killed server releases its GPU context
+        # and RDMA resources before the next test class sets up new servers.
         for process in [cls.process_lb, cls.process_decode, cls.process_prefill]:
             if process:
                 try:
-                    kill_process_tree(process.pid)
+                    kill_process_tree(process.pid, wait_timeout=60)
                 except Exception as e:
                     print(f"Error killing process {process.pid}: {e}")
 

--- a/python/sglang/test/server_fixtures/disaggregation_fixture.py
+++ b/python/sglang/test/server_fixtures/disaggregation_fixture.py
@@ -140,8 +140,6 @@ class PDDisaggregationServerBase(CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        # wait_timeout ensures each killed server releases its GPU context
-        # and RDMA resources before the next test class sets up new servers.
         for process in [cls.process_lb, cls.process_decode, cls.process_prefill]:
             if process:
                 try:

--- a/python/sglang/test/server_fixtures/eagle_fixture.py
+++ b/python/sglang/test/server_fixtures/eagle_fixture.py
@@ -57,7 +57,9 @@ class EagleServerBase(CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
+        # Wait for the killed server to release its GPU context before the
+        # next test class starts a new one on the same device.
+        kill_process_tree(cls.process.pid, wait_timeout=60)
 
     def send_request(self):
         time.sleep(random.uniform(0, 2))

--- a/python/sglang/test/server_fixtures/eagle_fixture.py
+++ b/python/sglang/test/server_fixtures/eagle_fixture.py
@@ -57,8 +57,6 @@ class EagleServerBase(CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        # Wait for the killed server to release its GPU context before the
-        # next test class starts a new one on the same device.
         kill_process_tree(cls.process.pid, wait_timeout=60)
 
     def send_request(self):

--- a/python/sglang/test/server_fixtures/mmmu_fixture.py
+++ b/python/sglang/test/server_fixtures/mmmu_fixture.py
@@ -60,9 +60,11 @@ class MMMUServerBase(CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
+        # Wait for the killed server to release its GPU context so the next
+        # test class can allocate cleanly on the same device.
         if cls.process is not None and cls.process.poll() is None:
             try:
-                kill_process_tree(cls.process.pid)
+                kill_process_tree(cls.process.pid, wait_timeout=60)
             except Exception as e:
                 logger.error(f"Error killing process: {e}")
         time.sleep(2)

--- a/python/sglang/test/server_fixtures/mmmu_fixture.py
+++ b/python/sglang/test/server_fixtures/mmmu_fixture.py
@@ -60,8 +60,6 @@ class MMMUServerBase(CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        # Wait for the killed server to release its GPU context so the next
-        # test class can allocate cleanly on the same device.
         if cls.process is not None and cls.process.poll() is None:
             try:
                 kill_process_tree(cls.process.pid, wait_timeout=60)


### PR DESCRIPTION
Fix race between `Engine.shutdown()` / fixture teardown and the next GPU allocation: after SIGKILL, children still hold GPU context until the kernel reaps them. Add optional `wait_timeout` to `kill_process_tree` (warn after ~10s, raise on hard timeout), default `None` keeps existing behavior. Apply `wait_timeout=60` in engine and server fixture shutdown paths.