### PR TITLE
Fix test_modelopt_export using stale ModelConfig kwargs

### DIFF
--- a/test/registered/unit/model_loader/test_modelopt_export.py
+++ b/test/registered/unit/model_loader/test_modelopt_export.py
@@ -321,11 +321,10 @@ class TestModelOptExportIntegration(unittest.TestCase):
 
         model_config = ModelConfig(
             model_path="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
-            modelopt_quant="fp8",
-            modelopt_export_path=self.export_dir,
+            quantization="modelopt_fp8",
         )
 
-        load_config = LoadConfig()
+        load_config = LoadConfig(modelopt_export_path=self.export_dir)
         device_config = DeviceConfig()
 
         # Mock the quantization and export process


### PR DESCRIPTION
## Summary
- `modelopt_quant` and `modelopt_export_path` were removed from `ModelConfig.__init__` in #10154 (replaced by the unified `quantization` flag and `LoadConfig.modelopt_export_path`), but `test_full_workflow_with_export` was never updated.
- The bug stayed latent because `TestModelOptExportIntegration` is skipped when `nvidia-modelopt` isn't installed. PR #23119 added the dep to the CI image yesterday, which exposed the failure (e.g. https://github.com/sgl-project/sglang/actions/runs/24649475047/job/72069610508).

## Test plan
- [x] Reproduced failure on remote dev container without fix: `TypeError: ModelConfig.__init__() got an unexpected keyword argument 'modelopt_quant'`
- [x] With fix, `python3 test/srt/test_modelopt_export.py` → `Ran 7 tests in 2.6s OK`