### PR TITLE
[AMD] Enable MTP for GLM-5-mxfp4 model

### DIFF
--- a/python/sglang/srt/models/deepseek_nextn.py
+++ b/python/sglang/srt/models/deepseek_nextn.py
@@ -42,6 +42,7 @@ from sglang.srt.layers.dp_attention import (
     is_dp_attention_enabled,
 )
 from sglang.srt.layers.layernorm import RMSNorm
+from sglang.srt.layers.linear import ReplicatedLinear
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.quantization import Fp8Config
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
@@ -99,7 +100,18 @@ class DeepseekModelNextN(nn.Module):
         self.enorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hnorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
-        self.eh_proj = nn.Linear(2 * config.hidden_size, config.hidden_size, bias=False)
+        if quant_config is not None and quant_config.get_name() == "quark":
+            self.eh_proj = ReplicatedLinear(
+                2 * config.hidden_size,
+                config.hidden_size,
+                bias=False,
+                quant_config=quant_config,
+                prefix=add_prefix("eh_proj", prefix),
+            )
+        else:
+            self.eh_proj = nn.Linear(
+                2 * config.hidden_size, config.hidden_size, bias=False
+            )
 
         self.rot_weight = None
         if _is_npu:
@@ -164,21 +176,23 @@ class DeepseekModelNextN(nn.Module):
             hidden_states = input_embeds
 
         if hidden_states.shape[0] > 0:
-            hidden_states = self.eh_proj(
-                torch.cat(
-                    (
-                        self.enorm(hidden_states),
-                        self.hnorm(
-                            forward_batch.spec_info.hidden_states
-                            if self.rot_weight is None
-                            else torch.matmul(
-                                forward_batch.spec_info.hidden_states, self.rot_weight
-                            )
-                        ),
+            eh_input = torch.cat(
+                (
+                    self.enorm(hidden_states),
+                    self.hnorm(
+                        forward_batch.spec_info.hidden_states
+                        if self.rot_weight is None
+                        else torch.matmul(
+                            forward_batch.spec_info.hidden_states, self.rot_weight
+                        )
                     ),
-                    dim=-1,
-                )
+                ),
+                dim=-1,
             )
+            if isinstance(self.eh_proj, ReplicatedLinear):
+                hidden_states, _ = self.eh_proj(eh_input)
+            else:
+                hidden_states = self.eh_proj(eh_input)
 
         if nsa_use_prefill_cp(forward_batch, self.nsa_enable_prefill_cp):
             hidden_states = cp_split_and_rebuild_data(forward_batch, hidden_states)
@@ -247,8 +261,19 @@ class DeepseekV3ForCausalLMNextN(DeepseekV3ForCausalLM):
             self.cp_rank = None
             self.cp_size = None
 
+        nextn_quant_config = quant_config
+        if nextn_quant_config is not None and nextn_quant_config.get_name() == "quark":
+            from sglang.srt.layers.quantization.quark.utils import (
+                should_ignore_layer,
+            )
+
+            ckpt_prefix = f"model.layers.{config.num_hidden_layers}"
+            mapped_prefix = self.hf_to_sglang_mapper._map_name(ckpt_prefix)
+            if should_ignore_layer(mapped_prefix, nextn_quant_config.exclude_layers):
+                nextn_quant_config = None
+
         self.model = DeepseekModelNextN(
-            config, quant_config, prefix=add_prefix("model", prefix)
+            config, nextn_quant_config, prefix=add_prefix("model", prefix)
         )
         self.lm_head = ParallelLMHead(
             config.vocab_size,

--- a/python/sglang/srt/models/deepseek_nextn.py
+++ b/python/sglang/srt/models/deepseek_nextn.py
@@ -262,6 +262,7 @@ class DeepseekV3ForCausalLMNextN(DeepseekV3ForCausalLM):
             self.cp_size = None
 
         nextn_quant_config = quant_config
+        # For quark, if the MTP layer is listed in exclude_layers, set quant_config to None.
         if nextn_quant_config is not None and nextn_quant_config.get_name() == "quark":
             from sglang.srt.layers.quantization.quark.utils import (
                 should_ignore_layer,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Fix https://github.com/sgl-project/sglang/issues/23142.

Quark-quantized GLM-5-MXFP4 checkpoints store MTP (NextN) weights — including `eh_proj` — in FP4-packed format. The existing code always creates `eh_proj` as `nn.Linear`, causing a shape mismatch ([6144, 6144] vs [6144, 12288]) during weight loading.

## Modifications

<!-- Detail the changes made in this pull request. -->

- In `DeepseekV3ForCausalLMNextN.__init__`, check whether the MTP layer is listed in quark's exclude_layers. If so, set `quant_config` to None so the NextN model falls back to bf16 parameters.
- In `DeepseekModelNextN.__init__`, use `ReplicatedLinear` instead of `nn.Linear` for `eh_proj` when the quant config is quark, so that `QuarkLinearMethod` creates parameters matching the `FP4-packed` checkpoint format.
- Update `forward()` to handle the (output, output_bias) tuple returned by `ReplicatedLinear`.
- The existing `modelopt_fp4` (NVFP4) code path is unchanged.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

<details>
<summary>GLM-5.1-mxfp4 launch cmd</summary>

```bash
python3 -m sglang.launch_server \
    --model-path /data/models/GLM-5-mxfp4/ \
    --port 9000 --trust-remote-code --tp 8 --chunked-prefill-size 131072 \
    --disable-radix-cache \
    --mem-fraction-static 0.85 \
    --model-loader-extra-config '{"enable_multithread_load": true}' \
    --watchdog-timeout 1200 \
    --reasoning-parser glm45 \
    --tool-call-parser glm47 \
    --speculative-algorithm EAGLE \
    --speculative-num-steps 3 \
    --speculative-eagle-topk 1 \
    --speculative-num-draft-tokens 4
```
</details>

| Model | Accept Len | GSM8k acc | 
|---|---|---|
| glm-5.1-mxfp4 (mtp) | 2.813, 2.926, 2.960 | 0.941 | 
| glm-5-fp8 (mtp) | 3.180, 3.122 , 3.084 | 0.954 |
| dpsk-r1-0528-mxfp4 (mtp) | 2.738, 2.860 , 2.813 | 0.942 | 

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
