### PR TITLE
[codex] Add Helios ModelOpt FP8 support

### DIFF
--- a/docs/diffusion/quantization.md
+++ b/docs/diffusion/quantization.md
@@ -43,21 +43,21 @@ backend.
 | quant_family      | checkpoint form                                                                            | canonical CLI                                                          | supported models                        | extra dependency                      | platform / notes                                                                                                                       |
 |-------------------|--------------------------------------------------------------------------------------------|------------------------------------------------------------------------|-----------------------------------------|---------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
 | `fp8`             | Quantized transformer component folder, or safetensors with `quantization_config` metadata | `--transformer-path` or `--transformer-weights-path`                   | ALL                                     | None                                  | Component-folder and single-file flows are both supported                                                                              |
-| `modelopt-fp8`    | Converted ModelOpt FP8 transformer directory or repo with `config.json`                    | `--transformer-path`                                                    | FLUX.1, FLUX.2, Wan2.2                  | None                                  | Serialized config stays `quant_method=modelopt` with `quant_algo=FP8`; `dit_layerwise_offload` is supported and `dit_cpu_offload` stays disabled |
+| `modelopt-fp8`    | Converted ModelOpt FP8 transformer directory or repo with `config.json`                    | `--transformer-path`                                                    | FLUX.1, FLUX.2, Wan2.2, Helios          | None                                  | Serialized config stays `quant_method=modelopt` with `quant_algo=FP8`; `dit_layerwise_offload` is supported and `dit_cpu_offload` stays disabled |
 | `modelopt-nvfp4`  | Mixed transformer directory/repo with `config.json`, or raw NVFP4 safetensors export/repo | `--transformer-path` for mixed overrides; `--transformer-weights-path` for raw exports | FLUX.1, FLUX.2, Wan2.2                  | None                                  | Mixed override repos keep the base model separate; raw exports such as `black-forest-labs/FLUX.2-dev-NVFP4` still use the weights-path flow |
 | `nunchaku-svdq`   | Pre-quantized Nunchaku transformer weights, usually named `svdq-{int4\|fp4}_r{rank}-...`   | `--transformer-weights-path`                                           | Model-specific support such as Qwen-Image, FLUX, and Z-Image | `nunchaku`                            | SGLang can infer precision and rank from the filename and supports both `int4` and `nvfp4`                                             |
 | `msmodelslim`     | Pre-quantized msmodelslim transformer weights                                              | `--model-path`                                                         | Wan2.2 family                           | None                                  | Currently only compatible with the Ascend NPU family and supports both `w8a8` and `w4a4`                                               |
 
 ## Validated ModelOpt Checkpoints
 
-This section is the canonical support matrix for the six diffusion ModelOpt
+This section is the canonical support matrix for the seven diffusion ModelOpt
 checkpoints currently wired up in SGLang docs and B200 CI coverage.
 
 Published checkpoints keep the serialized quantization config as
 `quant_method=modelopt`; the FP8 vs NVFP4 split below is a documentation label
 derived from `quant_algo`.
 
-Five of the six repos live under `BBuf/*`. The FLUX.2 NVFP4 entry keeps the
+Six of the seven repos live under `BBuf/*`. The FLUX.2 NVFP4 entry keeps the
 official `black-forest-labs/FLUX.2-dev-NVFP4` repo.
 
 | Quant Algo | Base Model | Preferred CLI | HF Repo | Current Scope | Notes |
@@ -65,11 +65,12 @@ official `black-forest-labs/FLUX.2-dev-NVFP4` repo.
 | `FP8` | `black-forest-labs/FLUX.1-dev` | `--transformer-path` | `BBuf/flux1-dev-modelopt-fp8-sglang-transformer` | single-transformer override, deterministic latent/image comparison, H100 benchmark, torch-profiler trace | SGLang converter keeps a validated BF16 fallback set for modulation and FF projection layers; use `--model-id FLUX.1-dev` for local mirrors |
 | `FP8` | `black-forest-labs/FLUX.2-dev` | `--transformer-path` | `BBuf/flux2-dev-modelopt-fp8-sglang-transformer` | single-transformer override load and generation path | published SGLang-ready transformer override |
 | `FP8` | `Wan-AI/Wan2.2-T2V-A14B-Diffusers` | `--transformer-path` | `BBuf/wan22-t2v-a14b-modelopt-fp8-sglang-transformer` | primary `transformer` quantized, `transformer_2` kept BF16 | primary-transformer-only path; keep `transformer_2` on the base checkpoint, and do not describe this as dual-transformer full-model FP8 unless that path is validated separately |
+| `FP8` | `BestWishYsh/Helios-Base` | `--transformer-path` | `BBuf/helios-base-modelopt-fp8-sglang-transformer` | single-transformer override, 640x384 33-frame video comparison, H100 benchmark, torch-profiler trace | SGLang converter keeps patch embeddings, conditioning/output projections, and the first/last three transformer blocks in BF16 for quality stability; use `--model-id Helios-Base` for local mirrors |
 | `NVFP4` | `black-forest-labs/FLUX.1-dev` | `--transformer-path` | `BBuf/flux1-dev-modelopt-nvfp4-sglang-transformer` | mixed BF16+NVFP4 transformer override, correctness validation, 4x RTX 5090 benchmark, torch-profiler trace | use `build_modelopt_nvfp4_transformer.py`; validated builder keeps selected FLUX.1 modules in BF16 and sets `swap_weight_nibbles=false` |
 | `NVFP4` | `black-forest-labs/FLUX.2-dev` | `--transformer-weights-path` | `black-forest-labs/FLUX.2-dev-NVFP4` | packed-QKV load path | official raw export repo; validated packed export detection and runtime layout handling |
 | `NVFP4` | `Wan-AI/Wan2.2-T2V-A14B-Diffusers` | `--transformer-path` | `BBuf/wan22-t2v-a14b-modelopt-nvfp4-sglang-transformer` | primary `transformer` quantized with ModelOpt NVFP4, `transformer_2` kept BF16 | primary-transformer-only path; keep `transformer_2` on the base checkpoint, and current B200/Blackwell bring-up uses `SGLANG_DIFFUSION_FLASHINFER_FP4_GEMM_BACKEND=cudnn` |
 
-These six checkpoints are also the intended case set for the B200 diffusion CI
+These seven checkpoints are also the intended case set for the B200 diffusion CI
 job (`multimodal-gen-test-1-b200`).
 
 ## ModelOpt FP8
@@ -93,6 +94,18 @@ sglang generate \
   --model-path Wan-AI/Wan2.2-T2V-A14B-Diffusers \
   --transformer-path BBuf/wan22-t2v-a14b-modelopt-fp8-sglang-transformer \
   --prompt "a fox walking through neon rain" \
+  --save-output
+```
+
+```bash
+sglang generate \
+  --model-path BestWishYsh/Helios-Base \
+  --model-id Helios-Base \
+  --transformer-path BBuf/helios-base-modelopt-fp8-sglang-transformer \
+  --prompt "A curious raccoon" \
+  --width 640 \
+  --height 384 \
+  --num-frames 33 \
   --save-output
 ```
 

--- a/python/sglang/multimodal_gen/.claude/skills/sglang-diffusion-modelopt-quant/SKILL.md
+++ b/python/sglang/multimodal_gen/.claude/skills/sglang-diffusion-modelopt-quant/SKILL.md
@@ -61,9 +61,9 @@ This repo now contains:
 - trajectory similarity validation:
   [`python/sglang/multimodal_gen/tools/compare_diffusion_trajectory_similarity.py`](../../../tools/compare_diffusion_trajectory_similarity.py)
 
-Validated documentation and CI coverage currently center on six ModelOpt diffusion transformer override families:
+Validated documentation and CI coverage currently center on seven ModelOpt diffusion transformer override families:
 
-- FP8: FLUX.1-dev, FLUX.2-dev, Wan2.2
+- FP8: FLUX.1-dev, FLUX.2-dev, Wan2.2, Helios-Base
 - NVFP4: FLUX.1-dev, FLUX.2-dev, Wan2.2
 
 Treat a new family, a new precision, or a new checkpoint layout as unsupported until it has a documented matrix row and a matching validation story.
@@ -172,6 +172,16 @@ For `FLUX.1-dev`, the validated fallback set currently keeps these modules in BF
 - `single_transformer_blocks.*.proj_mlp`
 
 Use `--model-type flux1` to force that profile, or rely on `--model-type auto` when the export config identifies `FluxTransformer2DModel`.
+
+For `Helios-Base`, the validated fallback set currently keeps these modules in BF16:
+
+- `patch_embedding`
+- `patch_short`, `patch_mid`, and `patch_long`
+- `condition_embedder.*`
+- `proj_out`
+- first and last three `blocks.*` attention projections and FFN projections
+
+Use `--model-type helios` to force that profile, or rely on `--model-type auto` when the export config identifies `HeliosTransformer3DModel`. Helios runtime linear layers must carry diffusers-compatible prefixes so ModelOpt ignore patterns map to the SGLang quantized layers.
 
 For FLUX.1-dev NVFP4 model families that need a mixed BF16+NVFP4 checkpoint, build the merged transformer explicitly:
 

--- a/python/sglang/multimodal_gen/runtime/models/dits/helios.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/helios.py
@@ -49,6 +49,7 @@ from sglang.multimodal_gen.runtime.managers.forward_context import get_forward_c
 from sglang.multimodal_gen.runtime.models.dits.base import CachableDiT
 from sglang.multimodal_gen.runtime.utils.layerwise_offload import OffloadableDiTMixin
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.srt.utils import add_prefix
 
 logger = init_logger(__name__)
 
@@ -239,6 +240,7 @@ class HeliosSelfAttention(nn.Module):
         is_amplify_history: bool = False,
         history_scale_mode: str = "per_head",
         quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
     ):
         super().__init__()
         self.dim = dim
@@ -248,16 +250,36 @@ class HeliosSelfAttention(nn.Module):
         self.local_num_heads = divide(num_heads, tp_size)
 
         self.to_q = ColumnParallelLinear(
-            dim, dim, bias=True, gather_output=False, quant_config=quant_config
+            dim,
+            dim,
+            bias=True,
+            gather_output=False,
+            quant_config=quant_config,
+            prefix=add_prefix("to_q", prefix),
         )
         self.to_k = ColumnParallelLinear(
-            dim, dim, bias=True, gather_output=False, quant_config=quant_config
+            dim,
+            dim,
+            bias=True,
+            gather_output=False,
+            quant_config=quant_config,
+            prefix=add_prefix("to_k", prefix),
         )
         self.to_v = ColumnParallelLinear(
-            dim, dim, bias=True, gather_output=False, quant_config=quant_config
+            dim,
+            dim,
+            bias=True,
+            gather_output=False,
+            quant_config=quant_config,
+            prefix=add_prefix("to_v", prefix),
         )
         self.to_out = RowParallelLinear(
-            dim, dim, bias=True, reduce_results=True, quant_config=quant_config
+            dim,
+            dim,
+            bias=True,
+            reduce_results=True,
+            quant_config=quant_config,
+            prefix=add_prefix("to_out.0", prefix),
         )
         self.norm_q = RMSNorm(dim, eps=eps)
         self.norm_k = RMSNorm(dim, eps=eps)
@@ -339,6 +361,7 @@ class HeliosCrossAttention(nn.Module):
         num_heads: int,
         eps: float = 1e-6,
         quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
     ):
         super().__init__()
         self.dim = dim
@@ -348,16 +371,36 @@ class HeliosCrossAttention(nn.Module):
         self.local_num_heads = divide(num_heads, tp_size)
 
         self.to_q = ColumnParallelLinear(
-            dim, dim, bias=True, gather_output=False, quant_config=quant_config
+            dim,
+            dim,
+            bias=True,
+            gather_output=False,
+            quant_config=quant_config,
+            prefix=add_prefix("to_q", prefix),
         )
         self.to_k = ColumnParallelLinear(
-            dim, dim, bias=True, gather_output=False, quant_config=quant_config
+            dim,
+            dim,
+            bias=True,
+            gather_output=False,
+            quant_config=quant_config,
+            prefix=add_prefix("to_k", prefix),
         )
         self.to_v = ColumnParallelLinear(
-            dim, dim, bias=True, gather_output=False, quant_config=quant_config
+            dim,
+            dim,
+            bias=True,
+            gather_output=False,
+            quant_config=quant_config,
+            prefix=add_prefix("to_v", prefix),
         )
         self.to_out = RowParallelLinear(
-            dim, dim, bias=True, reduce_results=True, quant_config=quant_config
+            dim,
+            dim,
+            bias=True,
+            reduce_results=True,
+            quant_config=quant_config,
+            prefix=add_prefix("to_out.0", prefix),
         )
         self.norm_q = RMSNorm(dim, eps=eps)
         self.norm_k = RMSNorm(dim, eps=eps)
@@ -414,6 +457,7 @@ class HeliosTransformerBlock(nn.Module):
         is_amplify_history: bool = False,
         history_scale_mode: str = "per_head",
         quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
     ):
         super().__init__()
 
@@ -426,6 +470,7 @@ class HeliosTransformerBlock(nn.Module):
             is_amplify_history=is_amplify_history,
             history_scale_mode=history_scale_mode,
             quant_config=quant_config,
+            prefix=add_prefix("attn1", prefix),
         )
 
         # 2. Cross-attention
@@ -434,6 +479,7 @@ class HeliosTransformerBlock(nn.Module):
             num_heads=num_heads,
             eps=eps,
             quant_config=quant_config,
+            prefix=add_prefix("attn2", prefix),
         )
         self.self_attn_residual_norm = (
             FP32LayerNorm(dim, eps, elementwise_affine=True)
@@ -443,7 +489,11 @@ class HeliosTransformerBlock(nn.Module):
 
         # 3. Feed-forward
         self.ffn = MLP(
-            dim, ffn_dim, act_type="gelu_pytorch_tanh", quant_config=quant_config
+            dim,
+            ffn_dim,
+            act_type="gelu_pytorch_tanh",
+            quant_config=quant_config,
+            prefix=add_prefix("ffn.net", prefix),
         )
         self.norm3 = FP32LayerNorm(dim, eps, elementwise_affine=False)
 
@@ -617,8 +667,9 @@ class HeliosTransformer3DModel(CachableDiT, OffloadableDiTMixin):
                     is_amplify_history=config.is_amplify_history,
                     history_scale_mode=config.history_scale_mode,
                     quant_config=quant_config,
+                    prefix=f"blocks.{i}",
                 )
-                for _ in range(config.num_layers)
+                for i in range(config.num_layers)
             ]
         )
 
@@ -630,6 +681,7 @@ class HeliosTransformer3DModel(CachableDiT, OffloadableDiTMixin):
             bias=True,
             gather_output=True,
             quant_config=quant_config,
+            prefix="proj_out",
         )
 
         self.cnt = 0
@@ -652,7 +704,6 @@ class HeliosTransformer3DModel(CachableDiT, OffloadableDiTMixin):
         latents_history_long=None,
         **kwargs,
     ) -> torch.Tensor:
-        orig_dtype = hidden_states.dtype
         if not isinstance(encoder_hidden_states, torch.Tensor):
             encoder_hidden_states = encoder_hidden_states[0]
 

--- a/python/sglang/multimodal_gen/tools/build_modelopt_fp8_transformer.py
+++ b/python/sglang/multimodal_gen/tools/build_modelopt_fp8_transformer.py
@@ -76,6 +76,16 @@ DEFAULT_LTX2_KEEP_BF16_PATTERNS = [
     r"^transformer_blocks\.(0|43|44|45|46|47)\.(attn1|attn2|audio_attn1|audio_attn2|audio_to_video_attn|video_to_audio_attn)\.to_out\.0$",
     r"^transformer_blocks\.(0|43|44|45|46|47)\.(ff|audio_ff)\.proj_(in|out)$",
 ]
+DEFAULT_HELIOS_KEEP_BF16_PATTERNS = [
+    r"^patch_embedding$",
+    r"^patch_(short|mid|long)$",
+    r"^condition_embedder\.(text_embedder\.linear_[12]|time_embedder\.linear_[12]|time_proj)$",
+    r"^proj_out$",
+    r"^blocks\.(0|1|2|37|38|39)\.(attn1|attn2)\.to_(q|k|v)$",
+    r"^blocks\.(0|1|2|37|38|39)\.(attn1|attn2)\.to_out\.0$",
+    r"^blocks\.(0|1|2|37|38|39)\.ffn\.net\.0\.proj$",
+    r"^blocks\.(0|1|2|37|38|39)\.ffn\.net\.2$",
+]
 
 
 def _resolve_transformer_dir(path: str) -> str:
@@ -259,12 +269,16 @@ def get_default_keep_bf16_patterns(
         return list(DEFAULT_FLUX1_KEEP_BF16_PATTERNS)
     if model_type == "flux2":
         return list(DEFAULT_FLUX2_KEEP_BF16_PATTERNS)
+    if model_type == "helios":
+        return list(DEFAULT_HELIOS_KEEP_BF16_PATTERNS)
     if model_type == "none":
         return []
     if class_name == "FluxTransformer2DModel":
         return list(DEFAULT_FLUX1_KEEP_BF16_PATTERNS)
     if class_name == "Flux2Transformer2DModel":
         return list(DEFAULT_FLUX2_KEEP_BF16_PATTERNS)
+    if class_name == "HeliosTransformer3DModel":
+        return list(DEFAULT_HELIOS_KEEP_BF16_PATTERNS)
     return []
 
 
@@ -552,13 +566,14 @@ def build_modelopt_fp8_transformer(
             if name in fallback_scale_names:
                 del shard_tensors[name]
                 continue
+            if name in fallback_tensors:
+                shard_tensors[name] = fallback_tensors[name]
+                continue
             if name.endswith(".weight") and is_ignored_by_modelopt(
                 name, ignore_patterns
             ):
                 preserved_ignored_weight_count += 1
                 continue
-            if name in fallback_tensors:
-                shard_tensors[name] = fallback_tensors[name]
             scale_key = _resolve_scale_key(name, fp8_scale_map)
             if (
                 name.endswith(".weight")
@@ -645,11 +660,11 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--model-type",
-        choices=["auto", "flux1", "flux2", "ltx2", "none"],
+        choices=["auto", "flux1", "flux2", "ltx2", "helios", "none"],
         default="auto",
         help=(
             "Optional model-family BF16 fallback profile. 'none' uses the generic "
-            "conversion path. 'auto' enables the validated FLUX.1 / FLUX.2 / LTX-2 "
+            "conversion path. 'auto' enables the validated FLUX.1 / FLUX.2 / LTX-2 / Helios "
             "fallback set when the export config matches those transformer classes."
         ),
     )


### PR DESCRIPTION
## Summary

This PR adds Helios-Base support to the SGLang ModelOpt FP8 flow.

- Adds diffusers-compatible prefixes to Helios runtime linear layers so ModelOpt ignore/fallback patterns map to SGLang quantized layers.
- Adds a Helios fallback profile to `build_modelopt_fp8_transformer.py` that keeps patch embeddings, conditioning/output projections, and the first/last three transformer blocks in BF16.
- Documents the published SGLang-ready FP8 transformer repo and updates the ModelOpt diffusion quant skill.

HF repo: https://huggingface.co/BBuf/helios-base-modelopt-fp8-sglang-transformer

## Validation Setup

All GPU runs used one H100 with only rank 0 visible (`CUDA_VISIBLE_DEVICES=0`). The base model was `BestWishYsh/Helios-Base`, loaded from the local HF snapshot with `--model-id Helios-Base`.

BF16 command:

```bash
CUDA_VISIBLE_DEVICES=0 HF_HUB_OFFLINE=1 FLASHINFER_DISABLE_VERSION_CHECK=1 PYTHONPATH=python \
sglang generate \
  --model-path=$SNAP --model-id=Helios-Base \
  --prompt="A curious raccoon" \
  --backend=sglang --log-level=info --seed=42 \
  --width=640 --height=384 --num-frames=33 \
  --dit-layerwise-offload false --dit-cpu-offload false \
  --text-encoder-cpu-offload false --vae-cpu-offload false \
  --save-output --warmup --enable-torch-compile \
  --perf-dump-path /data/bbuf/helios_fp8_20260420/perf/helios_bf16_skill_640x384_33f_50s_compile.json \
  --output-file-path /data/bbuf/helios_fp8_20260420/outputs/helios_bf16_skill_640x384_33f_50s_compile.mp4
```

FP8 command was identical except for:

```bash
--transformer-path /data/bbuf/helios_fp8_20260420/modelopt/helios_fp8_sglang_transformer \
--perf-dump-path /data/bbuf/helios_fp8_20260420/perf/helios_fp8_skill_640x384_33f_50s_compile.json \
--output-file-path /data/bbuf/helios_fp8_20260420/outputs/helios_fp8_skill_640x384_33f_50s_compile.mp4
```

## Output Comparison

BF16 contact sheet:

![Helios BF16 contact sheet](https://huggingface.co/BBuf/helios-base-modelopt-fp8-sglang-transformer/resolve/main/validation/frames/helios_bf16_contact.png)

FP8 contact sheet:

![Helios FP8 contact sheet](https://huggingface.co/BBuf/helios-base-modelopt-fp8-sglang-transformer/resolve/main/validation/frames/helios_fp8_contact.png)

Videos:

- BF16: https://huggingface.co/BBuf/helios-base-modelopt-fp8-sglang-transformer/resolve/main/validation/outputs/helios_bf16_skill_640x384_33f_50s_compile.mp4
- FP8: https://huggingface.co/BBuf/helios-base-modelopt-fp8-sglang-transformer/resolve/main/validation/outputs/helios_fp8_skill_640x384_33f_50s_compile.mp4

The FP8 output is visually coherent at the validated setting. It is not pixel- or composition-identical to BF16, but it does not show the corrupted-output failure mode seen during earlier bring-up experiments.

## Benchmark

| Run | Denoise | E2E | Peak reserved | Speedup |
| --- | ---: | ---: | ---: | ---: |
| BF16 | 95.80 s | 96.85 s | 59.31 GiB | 1.00x |
| ModelOpt FP8 | 83.72 s | 84.77 s | 47.36 GiB | 1.14x denoise / 1.14x E2E |

Peak reserved memory drops by 11.94 GiB, about 20.1%.

## Profiler

Full-stage torch profiler traces were collected with 5 inference steps at the same 640x384, 33-frame shape. Kernel summary and raw traces are in the HF repo under `validation/`.

- Summary: https://huggingface.co/BBuf/helios-base-modelopt-fp8-sglang-transformer/blob/main/validation/analysis/profiler_kernel_summary.md
- BF16 trace: https://huggingface.co/BBuf/helios-base-modelopt-fp8-sglang-transformer/resolve/main/validation/profiles/helios_bf16_5step_full.trace.json.gz
- FP8 trace: https://huggingface.co/BBuf/helios-base-modelopt-fp8-sglang-transformer/resolve/main/validation/profiles/helios_fp8_5step_full.trace.json.gz

| Run | CUDA kernel time | GEMM/Linear | Attention | Elementwise/Cast/Reduce | Norm | Activation | Conv/VAE | FP8 quantize overhead |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| BF16 | 9996.4 ms | 34.97% | 14.14% | 41.44% | 3.46% | 1.04% | 4.81% | 0.00% |
| FP8 | 8980.3 ms | 26.62% | 15.35% | 45.61% | 3.84% | 1.15% | 5.35% | 1.95% |

## Converter Output

```json
{
  "added_scale_tensors": 680,
  "bf16_fallback_weights": 70,
  "output_shards": 3,
  "preserved_ignored_weights": 200,
  "quantized_weights": 340
}
```

## Checks

- `python3 -m ruff format python/sglang/multimodal_gen/runtime/models/dits/helios.py python/sglang/multimodal_gen/tools/build_modelopt_fp8_transformer.py`
- `python3 -m ruff check python/sglang/multimodal_gen/runtime/models/dits/helios.py python/sglang/multimodal_gen/tools/build_modelopt_fp8_transformer.py`
- `python3 -m py_compile python/sglang/multimodal_gen/runtime/models/dits/helios.py python/sglang/multimodal_gen/tools/build_modelopt_fp8_transformer.py`
- `git diff --check`
- H100 BF16/FP8 50-step generation and benchmark with the commands above
- H100 BF16/FP8 5-step full-stage torch profiler traces
