### PR TITLE
[HiCache] fix: normalize pool transfer indices in hybrid move_indices

### DIFF
--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -723,28 +723,32 @@ class HiCacheController:
         )
         return device_indices
 
-    def move_indices(self, op: CacheOperation):
-        host_indices, device_indices = op.host_indices, op.device_indices
-        # move indices to GPU if using kernels, to host if using direct indexing
+    def _normalize_indices(self, host_indices, device_indices, layout=None):
+        """Normalize index tensors for the configured io_backend / layout."""
+        if layout is None:
+            layout = self.mem_pool_host.layout
         if self.io_backend == "kernel":
             if not host_indices.is_cuda:
                 host_indices = host_indices.to(self.device, non_blocking=True)
             return host_indices, device_indices
         elif self.io_backend == "direct":
-            if self.mem_pool_host.layout == "layer_first":
+            if layout == "layer_first":
                 device_indices = device_indices.cpu()
                 host_indices, idx = host_indices.sort()
                 return host_indices, device_indices.index_select(0, idx)
-            elif self.mem_pool_host.layout == "page_first_direct":
+            elif layout == "page_first_direct":
                 return host_indices, device_indices.cpu()
             else:
                 raise ValueError(
-                    f"Unsupported layout {self.mem_pool_host.layout!r} for io backend 'direct'"
+                    f"Unsupported layout {layout!r} for io backend 'direct'"
                 )
         elif self.io_backend == "kernel_ascend":
             return host_indices, device_indices.cpu()
         else:
             raise ValueError(f"Unsupported io backend")
+
+    def move_indices(self, op: CacheOperation):
+        return self._normalize_indices(op.host_indices, op.device_indices)
 
     def start_loading(self) -> int:
         if len(self.load_queue) == 0:

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -257,6 +257,15 @@ class HybridCacheController(BaseHiCacheController):
         self.start_writing()
         return host_indices
 
+    @staticmethod
+    def _record_stream_transfers(pool_transfers, stream):
+        """Ensure transfer index tensors stay alive until *stream* finishes."""
+        for transfer in pool_transfers or []:
+            if transfer.host_indices is not None and transfer.host_indices.is_cuda:
+                transfer.host_indices.record_stream(stream)
+            if transfer.device_indices is not None and transfer.device_indices.is_cuda:
+                transfer.device_indices.record_stream(stream)
+
     def move_indices(self, op):
         host_indices, device_indices = super().move_indices(op)
         for transfer in op.pool_transfers or []:
@@ -300,6 +309,7 @@ class HybridCacheController(BaseHiCacheController):
                 host_indices.record_stream(self.write_stream)
             if device_indices.is_cuda:
                 device_indices.record_stream(self.write_stream)
+            self._record_stream_transfers(op.pool_transfers, self.write_stream)
         self.ack_write_queue.append(HiCacheAck(start_event, finish_event, op.node_ids))
 
     def load(
@@ -364,6 +374,7 @@ class HybridCacheController(BaseHiCacheController):
                 host_indices.record_stream(self.load_stream)
             if device_indices.is_cuda:
                 device_indices.record_stream(self.load_stream)
+            self._record_stream_transfers(op.pool_transfers, self.load_stream)
         self.ack_load_queue.append(
             HiCacheAck(
                 producer_event.start_event,

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -257,6 +257,26 @@ class HybridCacheController(BaseHiCacheController):
         self.start_writing()
         return host_indices
 
+    def move_indices(self, op):
+        host_indices, device_indices = super().move_indices(op)
+        for transfer in op.pool_transfers or []:
+            entry = self.mem_pool_host.entry_map.get(transfer.name)
+            if entry is not None and entry.share_indices_with_anchor:
+                transfer.host_indices = host_indices
+                transfer.device_indices = device_indices
+            elif (
+                transfer.host_indices is not None
+                and transfer.device_indices is not None
+            ):
+                transfer.host_indices, transfer.device_indices = (
+                    self._normalize_indices(
+                        transfer.host_indices,
+                        transfer.device_indices,
+                        layout=entry.host_pool.layout if entry else None,
+                    )
+                )
+        return host_indices, device_indices
+
     def start_writing(self) -> None:
         if not self.write_queue:
             return


### PR DESCRIPTION
## Summary
- The base `HiCacheController.move_indices` only normalizes anchor KV indices but ignores `PoolTransfer` indices for sidecar pools (e.g., NSA INDEXER), causing device/host mismatch or unsorted indices during hybrid cache I/O.
- Extract `_normalize_indices` from `move_indices` and override `move_indices` in `HybridCacheController` to also normalize each `PoolTransfer`'s indices (shared-anchor reuse or per-pool normalization).
- Add unit tests verifying both the contract difference (base vs hybrid) and an end-to-end data-integrity roundtrip through `HostPoolGroup`.

## Motivation
When `HybridCacheController` performs cache load/write with multiple pools (e.g., MLA KV + NSA Indexer), the sidecar pool's `PoolTransfer` indices were left un-normalized — wrong device placement or unsorted order — leading to silent data corruption or CUDA errors during `backup_from_device_all_layer` / `load_to_device_per_layer`.

## Test plan
- [ ] `python -m pytest test/registered/unit/mem_cache/test_hybrid_move_indices.py` — unit tests for kernel and direct backends
- [ ] Existing HiCache CI tests remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)