### PR TITLE
[gRPC] Pass --experimental_allow_proto3_optional to protoc in build.rs

### DIFF
--- a/rust/sglang-grpc/build.rs
+++ b/rust/sglang-grpc/build.rs
@@ -4,6 +4,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .build_server(true)
         .build_client(false)
+        .protoc_arg("--experimental_allow_proto3_optional")
         .file_descriptor_set_path(
             std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap())
                 .join("sglang_descriptor.bin"),


### PR DESCRIPTION
## Summary

Follow-up to #22736. Some CI runners (e.g. `stage-c-test-8-gpu-h20`) ship `libprotoc 3.12.4`, which treats proto3 `optional` as experimental and refuses to compile without `--experimental_allow_proto3_optional`. `proto/sglang/runtime/v1/sglang.proto` uses `optional` throughout (sampling params, etc.), so tonic_build's protoc invocation fails on those runners:

```
error: "protoc failed:
sglang/runtime/v1/sglang.proto: This file contains proto3 optional
fields, but --experimental_allow_proto3_optional was not set."
```

`scripts/ci/utils/install_protoc.sh` short-circuits when `protoc` is already on PATH, so it never upgrades the old 3.12.4 installs. Rather than forcing a protoc upgrade across every runner image, pass the flag through `tonic_build` so the build works on any protoc ≥ 3.12.

Example failure: https://github.com/sgl-project/sglang/actions/runs/24652543548 (jobs `stage-c-test-8-gpu-h20 (0)` and `(1)`).

## Test plan

- [x] `cargo check` in `rust/sglang-grpc/` still compiles locally
- [x] Verify `stage-c-test-8-gpu-h20` dependency install passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)