### PR TITLE
[Feature] Support MTP/speculative decoding with hiSparse extra page draft zone

### DIFF
--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -486,6 +486,130 @@ class HiSparseCoordinator:
         self._backup_done_event.wait(device_module.current_stream())
         self._has_pending_backup = False
 
+    def get_draft_device_slots(
+        self,
+        req_pool_indices: torch.Tensor,
+        num_tokens_per_req: int,
+    ) -> torch.Tensor:
+        """Return extra-page device slots for a uniform draft allocation."""
+        start = self.device_buffer_size + 1
+        end = start + num_tokens_per_req
+        if end > self.padded_buffer_size:
+            raise ValueError(
+                f"Requested {num_tokens_per_req} draft slots but extra page only "
+                f"has {self.padded_buffer_size - self.device_buffer_size - 1} "
+                f"available (padded_buffer_size={self.padded_buffer_size}, "
+                f"device_buffer_size={self.device_buffer_size})."
+            )
+        return self.req_to_device_buffer[req_pool_indices, start:end].reshape(-1)
+
+    def get_draft_device_slots_variable(
+        self,
+        req_pool_indices: torch.Tensor,
+        tokens_per_req: torch.Tensor,
+    ) -> torch.Tensor:
+        """Return extra-page device slots when each request needs a different count."""
+        if tokens_per_req.numel() == 0:
+            return torch.empty(0, dtype=torch.int64, device=req_pool_indices.device)
+
+        start = self.device_buffer_size + 1
+        max_tokens = int(tokens_per_req.max().item())
+        if start + max_tokens > self.padded_buffer_size:
+            raise ValueError(
+                f"Max per-request draft slots ({max_tokens}) exceeds extra page "
+                f"capacity ({self.padded_buffer_size - self.device_buffer_size - 1})."
+            )
+
+        slots = []
+        for req_idx, count in zip(req_pool_indices.tolist(), tokens_per_req.tolist()):
+            if count <= 0:
+                continue
+            slots.append(
+                self.req_to_device_buffer[req_idx, start : start + int(count)].reshape(-1)
+            )
+        if not slots:
+            return torch.empty(0, dtype=torch.int64, device=req_pool_indices.device)
+        return torch.cat(slots, dim=0)
+
+    def finalize_accepted_tokens(
+        self,
+        req_pool_indices: torch.Tensor,
+        accepted_cache_locs: torch.Tensor,
+        accept_length: torch.Tensor,
+        seq_lens: torch.Tensor,
+    ) -> None:
+        """Persist accepted speculative tokens and remap the newest token slot."""
+        if accepted_cache_locs.numel() == 0:
+            return
+
+        counts = accept_length.to(torch.int64) + 1
+        total_accepted = int(counts.sum().item())
+        if total_accepted != accepted_cache_locs.numel():
+            raise ValueError(
+                "HiSparse accepted token bookkeeping mismatch: "
+                f"expected {total_accepted} cache locs, got {accepted_cache_locs.numel()}."
+            )
+
+        all_device_locs = self.mem_pool_device._translate_loc_to_hisparse_device(
+            accepted_cache_locs
+        )
+        host_locs = self.mem_pool_host.alloc(total_accepted)
+        if host_locs is None:
+            logger.error(
+                "HiSparse: host alloc failed for %d accepted draft tokens",
+                total_accepted,
+            )
+            raise RuntimeError(
+                f"HiSparse host alloc failed for {total_accepted} accepted draft tokens"
+            )
+        host_locs = host_locs.to(device=self.device)
+
+        with device_module.stream(self.decode_backup_stream):
+            self.mem_pool_host.backup_from_device_all_layer(
+                self.mem_pool_device,
+                host_locs,
+                all_device_locs.contiguous(),
+                io_backend="kernel",
+            )
+        self.decode_backup_stream.synchronize()
+
+        mapping = self.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping
+        seq_lens_cpu = seq_lens.cpu().tolist()
+        req_pool_indices_cpu = req_pool_indices.cpu().tolist()
+        counts_cpu = counts.cpu().tolist()
+
+        move_src = []
+        move_dst = []
+        offset = 0
+        for req_idx, count, seq_len in zip(req_pool_indices_cpu, counts_cpu, seq_lens_cpu):
+            start = seq_len - count
+            end = offset + count
+
+            host_segment = host_locs[offset:end]
+            logical_segment = accepted_cache_locs[offset:end]
+            device_segment = all_device_locs[offset:end]
+
+            self.req_to_host_pool[req_idx, start:seq_len] = host_segment
+
+            if count > 1:
+                mapping[logical_segment[:-1]] = 0
+
+            newest_slot = self.req_to_device_buffer[req_idx, self.device_buffer_size]
+            last_logical = logical_segment[-1:]
+            last_device = device_segment[-1:]
+            if int(last_device.item()) != int(newest_slot.item()):
+                move_src.append(last_device)
+                move_dst.append(newest_slot.reshape(1))
+            mapping[last_logical] = newest_slot
+            self._skip_first_backup[req_idx] = True
+            offset = end
+
+        if move_src:
+            self.mem_pool_device.transfer_values_on_device(
+                dst_indices=torch.cat(move_dst, dim=0),
+                src_indices=torch.cat(move_src, dim=0),
+            )
+
     def get_front_topk_tokens(
         self,
         req_pool_indices: torch.Tensor,
@@ -629,9 +753,10 @@ class HiSparseCoordinator:
         allocated_locs = self.req_to_token_pool.req_to_token[
             req.req_pool_idx, : req.kv_allocated_len
         ]
-        self.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping[
-            allocated_locs
-        ] = 0
+        if current_cap > 0:
+            self.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping[
+                allocated_locs
+            ] = 0
 
         host_indices = self.req_to_host_pool[req.req_pool_idx, : req.kv_allocated_len]
         host_indices = host_indices[host_indices >= 0]

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -882,6 +882,7 @@ class Req(ReqDllmMixin):
 
         # For hisparse
         self.hisparse_staging = False
+        self.hisparse_spec_info = None
 
     @property
     def seqlen(self) -> int:
@@ -1225,6 +1226,7 @@ class Req(ReqDllmMixin):
         self.kv_committed_len = 0
         self.kv_committed_freed = False
         self.kv_overallocated_freed = False
+        self.hisparse_spec_info = None
         self.swa_evicted_seqlen = 0
         self.extend_batch_idx = 0
         self.decode_batch_idx = 0

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2296,7 +2296,40 @@ class Scheduler(
         batch.sampling_info = SamplingBatchInfo.from_schedule_batch(
             batch, self.model_config.vocab_size
         )
-        # todo hisparse, maybe other info to contain for the new batch
+
+        if not batch.spec_algorithm.is_none():
+            missing_spec_info_rids = [
+                req.rid
+                for req in reqs
+                if getattr(req, "hisparse_spec_info", None) is None
+            ]
+            if missing_spec_info_rids:
+                raise RuntimeError(
+                    "HiSparse decode batch is missing speculative draft state for requests: "
+                    + ", ".join(missing_spec_info_rids)
+                )
+
+            batch.spec_info = reqs[0].hisparse_spec_info
+            reqs[0].hisparse_spec_info = None
+            for req in reqs[1:]:
+                batch.spec_info.merge_batch(req.hisparse_spec_info)
+                req.hisparse_spec_info = None
+
+            if batch.is_spec_v2:
+                if batch.spec_info.new_seq_lens is None:
+                    raise RuntimeError(
+                        "HiSparse spec-v2 decode batch is missing new_seq_lens for draft state rebuild."
+                    )
+                future_indices = self.future_map.alloc_future_indices(len(reqs))
+                self.future_map.store_to_map_for_new_batch(
+                    future_indices, batch.spec_info
+                )
+                batch.spec_info.future_indices = future_indices
+                batch.spec_info.verify_done = None
+                batch.seq_lens = batch.spec_info.new_seq_lens
+                batch.seq_lens_cpu = batch.seq_lens.cpu()
+                batch.orig_seq_lens = batch.seq_lens.to(dtype=torch.int32)
+                batch.seq_lens_sum = batch.seq_lens_cpu.sum().item()
         return batch
 
     def get_next_batch_to_run(self) -> Optional[ScheduleBatch]:

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -123,6 +123,17 @@ class SchedulerOutputProcessorMixin:
                     elem = elem.copy()
                 req.customized_info[k].append(elem)
 
+    def _stash_hisparse_spec_info(
+        self: Scheduler, batch: ScheduleBatch, batch_index: int, req: Req
+    ) -> None:
+        if not self.enable_hisparse or batch.spec_info is None:
+            return
+        if not hasattr(batch.spec_info, "slice_single"):
+            raise RuntimeError(
+                f"HiSparse cannot stash speculative state for {type(batch.spec_info).__name__}"
+            )
+        req.hisparse_spec_info = batch.spec_info.slice_single(batch_index)
+
     def process_batch_result_prefill(
         self: Scheduler,
         batch: ScheduleBatch,
@@ -196,6 +207,7 @@ class SchedulerOutputProcessorMixin:
                     elif not batch.decoding_reqs or req not in batch.decoding_reqs:
                         self.tree_cache.cache_unfinished_req(req)
                         if self.enable_hisparse:
+                            self._stash_hisparse_spec_info(batch, i, req)
                             self.hisparse_coordinator.admit_request_into_staging(req)
 
                     self.maybe_collect_customized_info(i, req, logits_output)

--- a/python/sglang/srt/mem_cache/hisparse_memory_pool.py
+++ b/python/sglang/srt/mem_cache/hisparse_memory_pool.py
@@ -264,6 +264,51 @@ class HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         hisparse_last_locs = self._kvcache._translate_loc_to_hisparse_device(last_locs)
         return hisparse_last_locs
 
+    def alloc_extend_with_device_mapping(
+        self,
+        prefix_lens: torch.Tensor,
+        prefix_lens_cpu: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_cpu: torch.Tensor,
+        last_loc: torch.Tensor,
+        extend_num_tokens: int,
+        device_slots: torch.Tensor,
+        backup_state: bool = False,
+    ):
+        """Allocate logical indices and map them to caller-managed HiSparse slots."""
+        avail = self.logical_attn_allocator.available_size()
+        if avail < extend_num_tokens:
+            raise RuntimeError(
+                f"HiSparse logical alloc: need {extend_num_tokens} tokens but only "
+                f"{avail} are available."
+            )
+
+        logical_state = (
+            self.logical_attn_allocator.backup_state() if backup_state else None
+        )
+        out = self.logical_attn_allocator.alloc_extend(
+            prefix_lens,
+            prefix_lens_cpu,
+            seq_lens,
+            seq_lens_cpu,
+            last_loc,
+            extend_num_tokens,
+        )
+        if out is None:
+            raise RuntimeError(
+                f"HiSparse logical alloc failed for {extend_num_tokens} tokens. "
+                f"Logical pool available: {self.logical_attn_allocator.available_size()}"
+            )
+
+        self.full_to_hisparse_device_index_mapping[out] = device_slots
+        if backup_state:
+            return out, (logical_state, out.clone())
+        return out
+
+    def clear_device_mapping(self, logical_indices: torch.Tensor):
+        """Clear mappings for caller-managed slots before freeing logical indices."""
+        self.full_to_hisparse_device_index_mapping[logical_indices] = 0
+
     def alloc_extend(
         self,
         prefix_lens: torch.Tensor,
@@ -390,3 +435,17 @@ class HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             self.hisparse_attn_allocator.available_size()
             <= self.hisparse_attn_allocator.size
         )
+
+    def backup_state(self):
+        return (
+            self.logical_attn_allocator.backup_state(),
+            self.full_to_hisparse_device_index_mapping.clone(),
+        )
+
+    def restore_state(self, state):
+        logical_state, mapping_info = state
+        self.logical_attn_allocator.restore_state(logical_state)
+        if mapping_info.shape[0] < self.full_to_hisparse_device_index_mapping.shape[0]:
+            self.full_to_hisparse_device_index_mapping[mapping_info] = 0
+        else:
+            self.full_to_hisparse_device_index_mapping.copy_(mapping_info)

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -663,6 +663,14 @@ class ModelRunnerKVCacheMixin:
                 self.token_to_kv_pool.full_to_swa_index_mapping = (
                     self.token_to_kv_pool_allocator.full_to_swa_index_mapping
                 )
+            if self.enable_hisparse:
+                assert (
+                    self.token_to_kv_pool_allocator.__class__
+                    == HiSparseTokenToKVPoolAllocator
+                )
+                self.token_to_kv_pool.full_to_hisparse_device_index_mapping = (
+                    self.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping
+                )
 
     def _apply_token_constraints(self: ModelRunner, token_capacity: int) -> int:
         """Apply external constraints to token capacity: user cap, PP sync.

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6603,6 +6603,28 @@ class ServerArgs:
                         f"Please use --nsa-{label}-backend=flashmla_sparse or omit it."
                     )
 
+            if self.speculative_algorithm is not None:
+                from sglang.srt.mem_cache.sparsity import parse_hisparse_config
+
+                hisparse_cfg = parse_hisparse_config(self)
+                hisparse_page_size = getattr(hisparse_cfg, "page_size", 64)
+                max_draft = self.speculative_num_draft_tokens or 0
+                if max_draft >= hisparse_page_size:
+                    raise ValueError(
+                        f"hiSparse extra page capacity ({hisparse_page_size - 1} slots) "
+                        f"is insufficient for speculative_num_draft_tokens={max_draft}. "
+                        f"Reduce draft tokens or increase hiSparse page_size."
+                    )
+                if (
+                    self.speculative_eagle_topk is not None
+                    and self.speculative_eagle_topk > 1
+                    and self.page_size > 1
+                ):
+                    raise ValueError(
+                        "HiSparse + speculative topk > 1 + page_size > 1 is not yet "
+                        "supported. Use speculative_eagle_topk=1 or page_size=1."
+                    )
+
             if self.kv_cache_dtype != "bfloat16":
                 raise ValueError(
                     f"HiSparse requires bfloat16 KV cache, but got --kv-cache-dtype={self.kv_cache_dtype}. "

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -22,6 +22,7 @@ from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.common import (
     alloc_paged_token_slots_extend,
     alloc_token_slots,
+    evict_from_tree_cache,
     get_last_loc,
 )
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
@@ -129,15 +130,35 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 batch.req_pool_indices,
                 prefix_lens,
             )
-            batch.out_cache_loc = alloc_paged_token_slots_extend(
-                batch.tree_cache,
-                prefix_lens,
-                prefix_lens_cpu,
-                end_offset,
-                end_offset_cpu,
-                last_loc,
-                len(batch.input_ids),
-            )
+            if batch.hisparse_coordinator is not None:
+                allocator = batch.tree_cache.token_to_kv_pool_allocator
+                evict_from_tree_cache(
+                    batch.tree_cache,
+                    len(batch.input_ids) + len(prefix_lens_cpu) * allocator.page_size,
+                )
+                device_slots = batch.hisparse_coordinator.get_draft_device_slots(
+                    batch.req_pool_indices,
+                    self.draft_token_num,
+                )
+                batch.out_cache_loc = allocator.alloc_extend_with_device_mapping(
+                    prefix_lens,
+                    prefix_lens_cpu,
+                    end_offset,
+                    end_offset_cpu,
+                    last_loc,
+                    len(batch.input_ids),
+                    device_slots,
+                )
+            else:
+                batch.out_cache_loc = alloc_paged_token_slots_extend(
+                    batch.tree_cache,
+                    prefix_lens,
+                    prefix_lens_cpu,
+                    end_offset,
+                    end_offset_cpu,
+                    last_loc,
+                    len(batch.input_ids),
+                )
             self.last_loc = last_loc
 
         bs = batch.batch_size()
@@ -468,6 +489,16 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
         # try to unify the tensor representation and list representation
         accept_length_list = accept_length_cpu.tolist()
 
+        hisparse_coordinator = getattr(batch, "hisparse_coordinator", None)
+        if hisparse_coordinator is not None:
+            hisparse_coordinator.finalize_accepted_tokens(
+                batch.req_pool_indices,
+                batch.out_cache_loc[accept_index],
+                accept_length,
+                batch.seq_lens + accept_length + 1,
+            )
+            token_to_kv_pool_allocator.clear_device_mapping(batch.out_cache_loc[evict_mask])
+
         if page_size == 1:
             # TODO: boolean array index leads to a device sync. Remove it.
             token_to_kv_pool_allocator.free(batch.out_cache_loc[evict_mask])
@@ -523,6 +554,11 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 token_to_kv_pool_allocator.free(to_free_slots)
 
                 # Copy the kv cache
+                if hisparse_coordinator is not None:
+                    raise NotImplementedError(
+                        "HiSparse + speculative topk > 1 + page_size > 1 needs "
+                        "hisparse-aware move_kv_cache translation."
+                    )
                 batch.token_to_kv_pool_allocator.get_kvcache().move_kv_cache(
                     tgt_cache_loc, src_cache_loc
                 )
@@ -781,6 +817,16 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
     def filter_batch(self, new_indices: torch.Tensor, has_been_filtered: bool = True):
         if self.future_indices is not None:
             self.future_indices.indices = self.future_indices.indices[new_indices]
+            if self.new_seq_lens is not None:
+                self.new_seq_lens = self.new_seq_lens[new_indices]
+            if self.hidden_states is not None:
+                self.hidden_states = self.hidden_states[new_indices]
+            if self.verified_id is not None:
+                self.verified_id = self.verified_id[new_indices]
+            if self.topk_p is not None:
+                self.topk_p = self.topk_p[new_indices]
+            if self.topk_index is not None:
+                self.topk_index = self.topk_index[new_indices]
             return
 
         strict_check = envs.SGLANG_SPEC_ENABLE_STRICT_FILTER_CHECK.get()
@@ -805,6 +851,44 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
             self.hidden_states = self.hidden_states[new_indices]
             self.verified_id = self.verified_id[new_indices]
 
+    def slice_single(self, batch_index: int) -> "EagleDraftInput":
+        sli = slice(batch_index, batch_index + 1)
+        future_indices = None
+        if self.future_indices is not None:
+            future_indices = FutureIndices(indices=self.future_indices.indices[sli])
+        accept_length_cpu = None
+        if self.accept_length_cpu is not None:
+            accept_length_cpu = self.accept_length_cpu[batch_index : batch_index + 1]
+        return EagleDraftInput(
+            topk_p=None if self.topk_p is None else self.topk_p[sli],
+            topk_index=None if self.topk_index is None else self.topk_index[sli],
+            hidden_states=None if self.hidden_states is None else self.hidden_states[sli],
+            capture_hidden_mode=self.capture_hidden_mode,
+            verified_id=None if self.verified_id is None else self.verified_id[sli],
+            accept_length=(
+                None if self.accept_length is None else self.accept_length[sli]
+            ),
+            accept_length_cpu=accept_length_cpu,
+            seq_lens_for_draft_extend=(
+                None
+                if self.seq_lens_for_draft_extend is None
+                else self.seq_lens_for_draft_extend[sli]
+            ),
+            seq_lens_for_draft_extend_cpu=(
+                None
+                if self.seq_lens_for_draft_extend_cpu is None
+                else self.seq_lens_for_draft_extend_cpu[sli]
+            ),
+            req_pool_indices_for_draft_extend=(
+                None
+                if self.req_pool_indices_for_draft_extend is None
+                else self.req_pool_indices_for_draft_extend[sli]
+            ),
+            future_indices=future_indices,
+            new_seq_lens=None if self.new_seq_lens is None else self.new_seq_lens[sli],
+            verify_done=self.verify_done,
+        )
+
     def merge_batch(self, spec_info: "EagleDraftInput"):
         if self.future_indices is not None:
             assert spec_info.future_indices is not None
@@ -813,6 +897,34 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
                     [self.future_indices.indices, spec_info.future_indices.indices]
                 )
             )
+            if self.new_seq_lens is None:
+                self.new_seq_lens = spec_info.new_seq_lens
+            elif spec_info.new_seq_lens is not None:
+                self.new_seq_lens = torch.cat(
+                    [self.new_seq_lens, spec_info.new_seq_lens], axis=0
+                )
+            if self.hidden_states is None:
+                self.hidden_states = spec_info.hidden_states
+            elif spec_info.hidden_states is not None:
+                self.hidden_states = torch.cat(
+                    [self.hidden_states, spec_info.hidden_states], axis=0
+                )
+            if self.verified_id is None:
+                self.verified_id = spec_info.verified_id
+            elif spec_info.verified_id is not None:
+                self.verified_id = torch.cat(
+                    [self.verified_id, spec_info.verified_id], axis=0
+                )
+            if self.topk_p is None:
+                self.topk_p = spec_info.topk_p
+            elif spec_info.topk_p is not None:
+                self.topk_p = torch.cat([self.topk_p, spec_info.topk_p], axis=0)
+            if self.topk_index is None:
+                self.topk_index = spec_info.topk_index
+            elif spec_info.topk_index is not None:
+                self.topk_index = torch.cat(
+                    [self.topk_index, spec_info.topk_index], axis=0
+                )
             return
 
         if self.hidden_states is None:

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -19,6 +19,7 @@ from sglang.srt.managers.utils import get_alloc_len_per_decode
 from sglang.srt.mem_cache.common import (
     alloc_paged_token_slots_extend,
     alloc_token_slots,
+    evict_from_tree_cache,
     get_last_loc,
 )
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
@@ -143,15 +144,40 @@ class EagleDraftInputV2Mixin:
                 batch.req_pool_indices,
                 cur_kv_lens,
             )
-            out_cache_loc = alloc_paged_token_slots_extend(
-                batch.tree_cache,
-                cur_kv_lens,
-                cur_kv_lens_cpu,
-                nxt_kv_lens,
-                nxt_kv_lens_cpu,
-                last_loc,
-                num_needed_tokens,
-            )
+            if batch.hisparse_coordinator is not None:
+                allocator = batch.tree_cache.token_to_kv_pool_allocator
+                evict_from_tree_cache(
+                    batch.tree_cache,
+                    num_needed_tokens + len(cur_kv_lens_cpu) * allocator.page_size,
+                )
+                tokens_per_req = (nxt_kv_lens_cpu - cur_kv_lens_cpu).to(
+                    device=batch.device
+                )
+                device_slots = (
+                    batch.hisparse_coordinator.get_draft_device_slots_variable(
+                        batch.req_pool_indices,
+                        tokens_per_req,
+                    )
+                )
+                out_cache_loc = allocator.alloc_extend_with_device_mapping(
+                    cur_kv_lens,
+                    cur_kv_lens_cpu,
+                    nxt_kv_lens,
+                    nxt_kv_lens_cpu,
+                    last_loc,
+                    num_needed_tokens,
+                    device_slots,
+                )
+            else:
+                out_cache_loc = alloc_paged_token_slots_extend(
+                    batch.tree_cache,
+                    cur_kv_lens,
+                    cur_kv_lens_cpu,
+                    nxt_kv_lens,
+                    nxt_kv_lens_cpu,
+                    last_loc,
+                    num_needed_tokens,
+                )
 
         assign_req_to_token_pool_func(
             batch.req_pool_indices,

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -22,6 +22,7 @@ from sglang.srt.managers.tp_worker import TpModelWorker
 from sglang.srt.mem_cache.common import (
     alloc_paged_token_slots_extend,
     alloc_token_slots,
+    evict_from_tree_cache,
     get_last_loc,
 )
 from sglang.srt.model_executor.forward_batch_info import (
@@ -485,18 +486,46 @@ class EAGLEWorker(TpModelWorker):
                 )
                 extend_num_tokens = torch.sum((seq_lens_cpu - prefix_lens_cpu)).item()
 
-            out_cache_loc, token_to_kv_pool_state_backup = (
-                alloc_paged_token_slots_extend(
+            if batch.hisparse_coordinator is not None:
+                allocator = self.token_to_kv_pool_allocator
+                evict_from_tree_cache(
                     batch.tree_cache,
-                    prefix_lens,
-                    prefix_lens_cpu,
-                    seq_lens,
-                    seq_lens_cpu,
-                    last_loc,
-                    extend_num_tokens,
-                    backup_state=True,
+                    extend_num_tokens + len(prefix_lens_cpu) * allocator.page_size,
                 )
-            )
+                tokens_per_req = (seq_lens_cpu - prefix_lens_cpu).to(
+                    device=batch.device
+                )
+                device_slots = (
+                    batch.hisparse_coordinator.get_draft_device_slots_variable(
+                        batch.req_pool_indices,
+                        tokens_per_req,
+                    )
+                )
+                out_cache_loc, token_to_kv_pool_state_backup = (
+                    allocator.alloc_extend_with_device_mapping(
+                        prefix_lens,
+                        prefix_lens_cpu,
+                        seq_lens,
+                        seq_lens_cpu,
+                        last_loc,
+                        extend_num_tokens,
+                        device_slots,
+                        backup_state=True,
+                    )
+                )
+            else:
+                out_cache_loc, token_to_kv_pool_state_backup = (
+                    alloc_paged_token_slots_extend(
+                        batch.tree_cache,
+                        prefix_lens,
+                        prefix_lens_cpu,
+                        seq_lens,
+                        seq_lens_cpu,
+                        last_loc,
+                        extend_num_tokens,
+                        backup_state=True,
+                    )
+                )
 
         if self.page_size > 1 and self.topk > 1:
             last_page_lens_cumsum = torch.cumsum(last_page_lens, dim=0)


### PR DESCRIPTION
## Summary
- Enable speculative decoding (EAGLE draft/verify) on hiSparse-enabled servers by using the per-request extra page slots as the draft zone
- Add draft slot allocation (`get_draft_device_slots`, `get_draft_device_slots_variable`) and accepted token persistence (`finalize_accepted_tokens`) to `HiSparseCoordinator`
- Add `alloc_extend_with_device_mapping`, `clear_device_mapping`, and `backup_state`/`restore_state` to `HiSparseTokenToKVPoolAllocator`
- Wire EAGLE verify, EAGLE v2 draft, and EAGLE worker allocation paths to use hiSparse device slots when the coordinator is present
- Support scheduler-level batch split/reassemble of speculative state with `slice_single`/`merge_batch` on `EagleDraftInput`
- Add server args validation for draft token count vs hiSparse page size

## Test plan
- [ ] Verify speculative decoding works end-to-end with `--enable-hisparse --speculative-algorithm eagle`
- [ ] Verify draft token acceptance correctly persists to host pool via `finalize_accepted_tokens`
- [ ] Verify rejection fallback frees draft slots without leaking device mappings
- [ ] Verify topk=1 + page_size=1 combination works; confirm topk>1 + page_size>1 raises error