### PR TITLE
[bugfix] Fix staging ring-buffer leak when prefix cache skips chunked prefill

### DIFF
--- a/python/sglang/srt/disaggregation/common/staging_handler.py
+++ b/python/sglang/srt/disaggregation/common/staging_handler.py
@@ -166,7 +166,8 @@ class DecodeStagingHandler:
         ok = self._scatter_region(staging_offset, page_start, num_pages, decode_req)
         if ok:
             self._record_chunk_scatter_event(decode_req, alloc_id)
-            chunk_infos[chunk_idx] = (-1, -1, 0, -1, 0)
+            # Keep num_pages (index 4) so page_start accumulation stays correct.
+            chunk_infos[chunk_idx] = (-1, -1, 0, -1, num_pages)
         else:
             logger.warning(
                 "submit_chunk_scatter failed room=%s chunk_idx=%s tp_rank=%s",
@@ -349,35 +350,30 @@ class DecodeStagingHandler:
             return  # Only one chunk (or none); nothing extra to scatter.
 
         # Process all chunks except the last one (which is handled by
-        # _submit_last_scatter).
+        # _submit_last_scatter).  Use a running sum for page_start so the
+        # cost is O(N) instead of O(N^2), and we are immune to any
+        # earlier chunk having been marked as processed.
+        page_start = 0
         for chunk_idx in range(len(chunk_infos) - 1):
             alloc_id, staging_offset, _, _, chunk_num_pages = chunk_infos[chunk_idx]
-            if staging_offset < 0 or alloc_id < 0:
-                # Already scattered (via CHUNK_READY) or invalid.
-                continue
-
-            # Compute the page_start for this chunk.  Chunks are laid out
-            # sequentially: chunk 0 starts at page 0, chunk 1 at
-            # chunk_0_pages, etc.  We reconstruct page_start from the
-            # cumulative sum of preceding chunk sizes.
-            page_start = sum(
-                chunk_infos[i][4] for i in range(chunk_idx)  # [4] = num_pages
-            )
-
-            ok = self._scatter_region(
-                staging_offset, page_start, chunk_num_pages, decode_req
-            )
-            if ok:
-                self._record_chunk_scatter_event(decode_req, alloc_id)
-                chunk_infos[chunk_idx] = (-1, -1, 0, -1, 0)
-            else:
-                logger.warning(
-                    "[STAGING] _scatter_pending_intermediate_chunks failed "
-                    "room=%s chunk_idx=%s tp_rank=%s",
-                    decode_req.req.bootstrap_room,
-                    chunk_idx,
-                    self.tp_rank,
+            if staging_offset >= 0 and alloc_id >= 0:
+                # This chunk has not been scattered yet.
+                ok = self._scatter_region(
+                    staging_offset, page_start, chunk_num_pages, decode_req
                 )
+                if ok:
+                    self._record_chunk_scatter_event(decode_req, alloc_id)
+                    # Keep num_pages so page_start accumulation stays correct.
+                    chunk_infos[chunk_idx] = (-1, -1, 0, -1, chunk_num_pages)
+                else:
+                    logger.warning(
+                        "[STAGING] _scatter_pending_intermediate_chunks failed "
+                        "room=%s chunk_idx=%s tp_rank=%s",
+                        decode_req.req.bootstrap_room,
+                        chunk_idx,
+                        self.tp_rank,
+                    )
+            page_start += chunk_num_pages
 
     def _submit_last_scatter(self, decode_req: "DecodeRequest") -> int:
         """Submit scatter for the last chunk. Returns alloc_id >= 0, or -1."""

--- a/python/sglang/srt/disaggregation/common/staging_handler.py
+++ b/python/sglang/srt/disaggregation/common/staging_handler.py
@@ -165,11 +165,7 @@ class DecodeStagingHandler:
 
         ok = self._scatter_region(staging_offset, page_start, num_pages, decode_req)
         if ok:
-            event = torch.cuda.Event()
-            event.record(self.staging_allocator._scatter_stream)
-            if not hasattr(decode_req, "_chunk_events"):
-                decode_req._chunk_events = []
-            decode_req._chunk_events.append((event, alloc_id))
+            self._record_chunk_scatter_event(decode_req, alloc_id)
             chunk_infos[chunk_idx] = (-1, -1, 0, -1, 0)
         else:
             logger.warning(
@@ -190,6 +186,10 @@ class DecodeStagingHandler:
         Called from decode_thread.  Sets ``_scatter_event`` **before**
         ``_staging_last_scatter_submitted`` so the main thread sees the
         event when it checks the flag (CPython GIL guarantees ordering).
+
+        Also handles intermediate chunks that were never sent a CHUNK_READY
+        (e.g., when prefix cache causes the prefill to take the non-chunked
+        path while staging allocated multiple chunks).
         """
         decode_req = self._room_to_decode_req.get(room)
         if decode_req is None:
@@ -200,6 +200,13 @@ class DecodeStagingHandler:
                 room,
             )
             return False
+
+        # Scatter any intermediate chunks that were never submitted via
+        # CHUNK_READY.  This happens when prefix cache makes the prefill
+        # take the non-chunked path (extend_input_len <= chunked_prefill_size)
+        # while the staging side allocated >1 chunks based on total seq_len.
+        self._scatter_pending_intermediate_chunks(decode_req)
+
         alloc_id = self._submit_last_scatter(decode_req)
         if alloc_id >= 0:
             event = torch.cuda.Event()
@@ -310,6 +317,67 @@ class DecodeStagingHandler:
             )
 
         return True
+
+    def _record_chunk_scatter_event(
+        self, decode_req: "DecodeRequest", alloc_id: int
+    ) -> None:
+        """Record a CUDA event after scatter and attach it to *decode_req*.
+
+        The main thread later polls these events to know when the scatter
+        stream has finished so it can safely free the staging allocation.
+        """
+        event = torch.cuda.Event()
+        event.record(self.staging_allocator._scatter_stream)
+        if not hasattr(decode_req, "_chunk_events"):
+            decode_req._chunk_events = []
+        decode_req._chunk_events.append((event, alloc_id))
+
+    def _scatter_pending_intermediate_chunks(self, decode_req: "DecodeRequest") -> None:
+        """Scatter and record events for intermediate chunks that were never
+        submitted via CHUNK_READY.
+
+        This handles the case where the prefill took the non-chunked path
+        (e.g., due to prefix cache reducing extend_input_len below
+        chunked_prefill_size) while the decode-side staging allocated
+        multiple chunks based on the full sequence length.  Without this,
+        intermediate chunk allocations are never scattered or freed,
+        causing the staging ring buffer watermark to stall permanently.
+        """
+        receiver = decode_req.kv_receiver
+        chunk_infos = getattr(receiver, "chunk_staging_infos", [])
+        if len(chunk_infos) <= 1:
+            return  # Only one chunk (or none); nothing extra to scatter.
+
+        # Process all chunks except the last one (which is handled by
+        # _submit_last_scatter).
+        for chunk_idx in range(len(chunk_infos) - 1):
+            alloc_id, staging_offset, _, _, chunk_num_pages = chunk_infos[chunk_idx]
+            if staging_offset < 0 or alloc_id < 0:
+                # Already scattered (via CHUNK_READY) or invalid.
+                continue
+
+            # Compute the page_start for this chunk.  Chunks are laid out
+            # sequentially: chunk 0 starts at page 0, chunk 1 at
+            # chunk_0_pages, etc.  We reconstruct page_start from the
+            # cumulative sum of preceding chunk sizes.
+            page_start = sum(
+                chunk_infos[i][4] for i in range(chunk_idx)  # [4] = num_pages
+            )
+
+            ok = self._scatter_region(
+                staging_offset, page_start, chunk_num_pages, decode_req
+            )
+            if ok:
+                self._record_chunk_scatter_event(decode_req, alloc_id)
+                chunk_infos[chunk_idx] = (-1, -1, 0, -1, 0)
+            else:
+                logger.warning(
+                    "[STAGING] _scatter_pending_intermediate_chunks failed "
+                    "room=%s chunk_idx=%s tp_rank=%s",
+                    decode_req.req.bootstrap_room,
+                    chunk_idx,
+                    self.tp_rank,
+                )
 
     def _submit_last_scatter(self, decode_req: "DecodeRequest") -> int:
         """Submit scatter for the last chunk. Returns alloc_id >= 0, or -1."""

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -825,4 +825,30 @@ class SchedulerDisaggregationPrefillMixin:
                 f"Skip sending kv chunk for request {req.rid=} {req.bootstrap_room=} because page_indices is empty"
             )
             return
+
+        # When staging is enabled and a non-chunked prefill produces more
+        # pages than one staging chunk covers, split the transfer into
+        # staging-chunk-aligned sub-transfers.  Without this, the single
+        # bulk RDMA writes past the staging chunk boundary and intermediate
+        # chunks are never scattered on the decode side, causing a
+        # permanent staging allocator leak and eventual watermark stall.
+        # Use the same chunked_prefill_size as prefetch_staging_reqs to
+        # ensure staging chunk alignment.  The fallback to 8192 matches
+        # the ``cps = chunked_prefill_size or 8192`` in prefetch_staging_reqs.
+        cps = getattr(self, "chunked_prefill_size", None) or 8192
+        if last_chunk and getattr(self, "enable_staging", False) and cps > 0:
+            staging_chunk_pages = max(1, cps // page_size)
+            if staging_chunk_pages > 0 and len(page_indices) > staging_chunk_pages:
+                offset = 0
+                while offset < len(page_indices):
+                    end = min(offset + staging_chunk_pages, len(page_indices))
+                    sub_indices = page_indices[offset:end]
+                    is_final = end == len(page_indices)
+                    req.disagg_kv_sender.send(
+                        sub_indices,
+                        state_indices if is_final else None,
+                    )
+                    offset = end
+                return
+
         req.disagg_kv_sender.send(page_indices, state_indices)


### PR DESCRIPTION

## Motivation

When prefix cache reduces extend_input_len below chunked_prefill_size, the prefill forward pass runs in a single round (no chunked prefill splitting). However, the decode-side staging allocator still splits the allocation into multiple chunks based on the full seq_len. The single send_kv_chunk(last_chunk=True) call writes past the first staging chunk boundary via RDMA, and intermediate chunks never receive CHUNK_READY, so they are never scattered or freed.
<img width="3008" height="930" alt="image" src="https://github.com/user-attachments/assets/522b34e4-ede4-440a-920a-11b7be8d31fa" />

This permanently leaks staging ring-buffer space and eventually stalls the watermark → hangs all subsequent P→D transfers. We observe that transfer-req increases and after few time decode and prefill nodes hang. 

## Modifications

Two-layer defense:

prefill.py – send_kv_chunk: When staging is enabled and the page count exceeds one staging chunk, split the transfer into staging-chunk-aligned sub-transfers so each RDMA stays within its allocated chunk. (Root fix)

staging_handler.py – _scatter_pending_intermediate_chunks: Safety net that scatters and frees any un-processed intermediate chunks when the last chunk's Success arrives. Guards against edge cases where the P-side split alone is not sufficient.

staging_handler.py – _record_chunk_scatter_event: Extracted shared event-recording logic to avoid code duplication between submit_chunk_scatter and the new method.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
