### PR TITLE
Fix double-reduce in DeepseekV2MoE with flashinfer_cutedsl + EP + DP-attention

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutedsl.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutedsl.py
@@ -249,6 +249,8 @@ def ensure_cutedsl_wrapper(layer: torch.nn.Module) -> None:
         getattr(server_args, "cuda_graph_max_bs", None) or 512,
         getattr(server_args, "chunked_prefill_size", None) or 8192,
     )
+    if server_args.enable_dp_attention:
+        max_num_tokens *= server_args.dp_size
     top_k = layer.top_k if layer.top_k is not None else layer.moe_runner_config.top_k
     # inference_mode(False) ensures the wrapper's pre-allocated CUDA-graph
     # buffers are normal tensors.  This call typically happens inside

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -89,6 +89,7 @@ from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.moe import (
     get_moe_a2a_backend,
     get_moe_runner_backend,
+    should_use_dp_reduce_scatterv,
     should_use_flashinfer_cutlass_moe_fp4_allgather,
 )
 from sglang.srt.layers.moe.ep_moe.layer import get_moe_impl_class
@@ -648,6 +649,7 @@ class DeepseekV2MoE(nn.Module):
             and not should_allreduce_fusion
             and not use_reduce_scatter
             and not should_use_flashinfer_cutlass_moe_fp4_allgather()
+            and not should_use_dp_reduce_scatterv()
         ):
             final_hidden_states = tensor_model_parallel_all_reduce(final_hidden_states)
         return final_hidden_states
@@ -736,6 +738,7 @@ class DeepseekV2MoE(nn.Module):
             and not should_allreduce_fusion
             and not use_reduce_scatter
             and not should_use_flashinfer_cutlass_moe_fp4_allgather()
+            and not should_use_dp_reduce_scatterv()
         ):
             final_hidden_states = tensor_model_parallel_all_reduce(final_hidden_states)
         return final_hidden_states


### PR DESCRIPTION
## Motivation

Running `nvidia/DeepSeek-V3-0324-NVFP4` with `--moe-runner-backend flashinfer_cutedsl --enable-dp-attention --ep-size N --dp-size N` (N>1) hit two separate bugs.

**Bug 1 — double-reduce on MoE output.** Pure TP and EP without DP-attention both worked; only `cutedsl × EP × DP-attention` produced gibberish. Root cause: the MoE output was reduced **twice**.

1. `DeepseekV2MoE.forward_normal` / `forward_normal_dual_stream` unconditionally ran `tensor_model_parallel_all_reduce` on the MoE output.
2. When `should_use_dp_reduce_scatterv()` was True (cutedsl + DP-attention + `EP == DP`), `LayerCommunicator._scatter_hidden_states` additionally performed `reduce_scatterv`, which also summed across TP ranks.

The result was scaled by the TP world size, corrupting every token. The cutlass fp4-allgather path already had a symmetric guard (`not should_use_flashinfer_cutlass_moe_fp4_allgather()`); the cutedsl reduce-scatterv path was simply missing the same guard.

**Bug 2 — `max_num_tokens` under-sized in CuteDSL wrapper under DP-attention.** With CUDA graph enabled, `ensure_cutedsl_wrapper` sized the wrapper with `max(cuda_graph_max_bs, chunked_prefill_size)`. But when `--enable-dp-attention` is set, `chunked_prefill_size` has already been divided by `dp_size` in `server_args`, while the MoE layer receives hidden states gathered across all DP ranks (i.e. per-rank tokens × `dp_size`). The mismatch crashed the worker with `ValueError: num_tokens (N) exceeds max_num_tokens (N/dp_size)` during prefill/warmup.

## Modifications

- `python/sglang/srt/models/deepseek_v2.py`: in both `forward_normal` and `forward_normal_dual_stream`, add `and not should_use_dp_reduce_scatterv()` to the all-reduce guard so the reduction is only performed by `reduce_scatterv` in the communicator. The two guards are mutually exclusive by construction (`should_use_dp_reduce_scatterv()` already requires `not should_use_flashinfer_cutlass_moe_fp4_allgather()`), so no other config is affected.
- `python/sglang/srt/layers/moe/moe_runner/flashinfer_cutedsl.py`: when `enable_dp_attention` is on, scale `max_num_tokens` back up by `dp_size` so the wrapper covers the gathered MoE input.

Verified on 4×B200 with `nvidia/DeepSeek-V3-0324-NVFP4` + `trtllm_mla` (`tp=ep=dp=4 + DP-attention + cutedsl`, CUDA graph enabled): gsm8k = **0.957** (512 examples).
