### PR TITLE
[Test] Add unit tests for internlm detector

### DIFF
--- a/test/registered/unit/function_call/test_internlm_detector.py
+++ b/test/registered/unit/function_call/test_internlm_detector.py
@@ -115,14 +115,13 @@ class TestInternlmDetector(CustomTestCase):
         info_func = self.detector.structure_info()
         info = info_func("get_weather")
         self.assertIn("get_weather", info.begin)
-        self.assertIn("|action_start|> <|plugin|>", info.begin)
+        self.assertIn("<|action_start|> <|plugin|>", info.begin)
         self.assertIn("<|action_end|>", info.end)
         self.assertEqual(info.trigger, "<|action_start|> <|plugin|>")
 
     # ==================== Streaming Tests ====================
 
     def test_streaming_single_tool_call(self):
-        detector = InternlmDetector()
         chunks = [
             "<|action_start|> ",
             '<|plugin|>\n{"name": "get_weather",',
@@ -131,7 +130,7 @@ class TestInternlmDetector(CustomTestCase):
         ]
         all_calls = []
         for chunk in chunks:
-            result = detector.parse_streaming_increment(chunk, self.tools)
+            result = self.detector.parse_streaming_increment(chunk, self.tools)
             all_calls.extend(result.calls)
 
         func_calls = [c for c in all_calls if c.name]
@@ -143,15 +142,13 @@ class TestInternlmDetector(CustomTestCase):
         self.assertEqual(params["city"], "Beijing")
 
     def test_streaming_normal_text_before_tool(self):
-        detector = InternlmDetector()
-        result = detector.parse_streaming_increment(
+        result = self.detector.parse_streaming_increment(
             "Let me check the weather. ", self.tools
         )
         self.assertEqual(result.normal_text, "Let me check the weather. ")
         self.assertEqual(len(result.calls), 0)
 
     def test_streaming_text_then_tool_call(self):
-        detector = InternlmDetector()
         chunks = [
             "I'll look that up. ",
             "<|action_start|> ",
@@ -162,7 +159,7 @@ class TestInternlmDetector(CustomTestCase):
         all_calls = []
         all_normal_text = ""
         for chunk in chunks:
-            result = detector.parse_streaming_increment(chunk, self.tools)
+            result = self.detector.parse_streaming_increment(chunk, self.tools)
             all_calls.extend(result.calls)
             all_normal_text += result.normal_text
 

--- a/test/registered/unit/function_call/test_internlm_detector.py
+++ b/test/registered/unit/function_call/test_internlm_detector.py
@@ -1,0 +1,182 @@
+"""Unit tests for InternlmDetector — no server, no model loading."""
+
+import json
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.internlm_detector import InternlmDetector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "stage-a-test-cpu")
+
+
+class TestInternlmDetector(CustomTestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_weather",
+                    description="Get weather information",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "city": {"type": "string", "description": "City name"},
+                            "unit": {
+                                "type": "string",
+                                "enum": ["celsius", "fahrenheit"],
+                            },
+                        },
+                        "required": ["city"],
+                    },
+                ),
+            ),
+            Tool(
+                type="function",
+                function=Function(
+                    name="search",
+                    description="Search the web",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "query": {
+                                "type": "string",
+                                "description": "Search query",
+                            },
+                        },
+                        "required": ["query"],
+                    },
+                ),
+            ),
+        ]
+        self.detector = InternlmDetector()
+
+    # ==================== has_tool_call Tests ====================
+
+    def test_has_tool_call_true(self):
+        text = (
+            "<|action_start|> <|plugin|>"
+            '{"name": "get_weather", "parameters": {"city": "Tokyo"}}<|action_end|>'
+        )
+        self.assertTrue(self.detector.has_tool_call(text))
+
+    def test_has_tool_call_false(self):
+        text = "What's the weather like?"
+        self.assertFalse(self.detector.has_tool_call(text))
+
+    # ==================== detect_and_parse Tests ====================
+
+    def test_single_tool_call(self):
+        text = (
+            "<|action_start|> <|plugin|>"
+            '{"name": "get_weather", "parameters": {"city": "Tokyo"}}<|action_end|>'
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        call = result.calls[0]
+        self.assertEqual(call.name, "get_weather")
+        args = json.loads(result.calls[0].parameters)
+        self.assertEqual(args["city"], "Tokyo")
+
+    def test_normal_text_before_tool_call(self):
+        text = (
+            "Let me check."
+            "<|action_start|> <|plugin|>"
+            '{"name": "get_weather", "parameters": {"city": "Tokyo"}}<|action_end|>'
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        args = json.loads(result.calls[0].parameters)
+        self.assertEqual(args["city"], "Tokyo")
+        self.assertEqual(result.normal_text, "Let me check.")
+
+    def test_no_tool_call(self):
+        text = "The weather is nice today."
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 0)
+        self.assertEqual(result.normal_text, "The weather is nice today.")
+
+    def test_tool_call_with_multiple_arguments(self):
+        text = (
+            "<|action_start|> <|plugin|>"
+            '{"name": "get_weather", "parameters": {"city": "London", "unit": "celsius"}}<|action_end|>'
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        args = json.loads(result.calls[0].parameters)
+        self.assertEqual(args["city"], "London")
+        self.assertEqual(args["unit"], "celsius")
+
+    # ==================== structure_info Tests ====================
+
+    def test_structure_info(self):
+        info_func = self.detector.structure_info()
+        info = info_func("get_weather")
+        self.assertIn("get_weather", info.begin)
+        self.assertIn("|action_start|> <|plugin|>", info.begin)
+        self.assertIn("<|action_end|>", info.end)
+        self.assertEqual(info.trigger, "<|action_start|> <|plugin|>")
+
+    # ==================== Streaming Tests ====================
+
+    def test_streaming_single_tool_call(self):
+        detector = InternlmDetector()
+        chunks = [
+            "<|action_start|> ",
+            '<|plugin|>\n{"name": "get_weather",',
+            ' "arguments": {"city": "Beijing"',
+            "}}<|action_end|>",
+        ]
+        all_calls = []
+        for chunk in chunks:
+            result = detector.parse_streaming_increment(chunk, self.tools)
+            all_calls.extend(result.calls)
+
+        func_calls = [c for c in all_calls if c.name]
+        self.assertEqual(len(func_calls), 1)
+        self.assertEqual(func_calls[0].name, "get_weather")
+
+        full_params = "".join(c.parameters for c in all_calls if c.parameters)
+        params = json.loads(full_params)
+        self.assertEqual(params["city"], "Beijing")
+
+    def test_streaming_normal_text_before_tool(self):
+        detector = InternlmDetector()
+        result = detector.parse_streaming_increment(
+            "Let me check the weather. ", self.tools
+        )
+        self.assertEqual(result.normal_text, "Let me check the weather. ")
+        self.assertEqual(len(result.calls), 0)
+
+    def test_streaming_text_then_tool_call(self):
+        detector = InternlmDetector()
+        chunks = [
+            "I'll look that up. ",
+            "<|action_start|> ",
+            '<|plugin|>\n{"name": "get_weather",',
+            ' "arguments": {"city": "Tokyo", "unit": "celsius"',
+            "}}<|action_end|>",
+        ]
+        all_calls = []
+        all_normal_text = ""
+        for chunk in chunks:
+            result = detector.parse_streaming_increment(chunk, self.tools)
+            all_calls.extend(result.calls)
+            all_normal_text += result.normal_text
+
+        self.assertEqual(all_normal_text, "I'll look that up. ")
+        func_calls = [c for c in all_calls if c.name]
+        self.assertEqual(len(func_calls), 1)
+        self.assertEqual(func_calls[0].name, "get_weather")
+        full_params = "".join(c.parameters for c in all_calls if c.parameters)
+        params = json.loads(full_params)
+        self.assertEqual(params["city"], "Tokyo")
+        self.assertEqual(params["unit"], "celsius")
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Summary

- Add 10 unit tests for InternLM2/Intern-S1 model function call format detectors
- Part of #20865 


**New test file**

| File | Tests | Detector Format |
| -------- | -------- | -------- |
| `test_internlm_detector.py`     | 10     | `<\|action_start\|> <\|plugin\|>\n{"name":...}<\|action_end\|>` |



## Test Plan

```
# command
pytest test/registered/unit/function_call/test_internlm_detector.py -v

========================================================================= test session starts =========================================================================
platform linux -- Python 3.12.11, pytest-9.0.3, pluggy-1.6.0 -- /home/jeff/sglang/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /home/jeff/sglang/test
configfile: pytest.ini
plugins: cov-7.1.0, anyio-4.13.0
collected 10 items                                                                                                                                                    

test/registered/unit/function_call/test_internlm_detector.py::TestInternlmDetector::test_has_tool_call_false PASSED                                             [ 10%]
test/registered/unit/function_call/test_internlm_detector.py::TestInternlmDetector::test_has_tool_call_true PASSED                                              [ 20%]
test/registered/unit/function_call/test_internlm_detector.py::TestInternlmDetector::test_no_tool_call PASSED                                                    [ 30%]
test/registered/unit/function_call/test_internlm_detector.py::TestInternlmDetector::test_normal_text_before_tool_call PASSED                                    [ 40%]
test/registered/unit/function_call/test_internlm_detector.py::TestInternlmDetector::test_single_tool_call PASSED                                                [ 50%]
test/registered/unit/function_call/test_internlm_detector.py::TestInternlmDetector::test_streaming_normal_text_before_tool PASSED                               [ 60%]
test/registered/unit/function_call/test_internlm_detector.py::TestInternlmDetector::test_streaming_single_tool_call PASSED                                      [ 70%]
test/registered/unit/function_call/test_internlm_detector.py::TestInternlmDetector::test_streaming_text_then_tool_call PASSED                                   [ 80%]
test/registered/unit/function_call/test_internlm_detector.py::TestInternlmDetector::test_structure_info PASSED                                                  [ 90%]
test/registered/unit/function_call/test_internlm_detector.py::TestInternlmDetector::test_tool_call_with_multiple_arguments PASSED                               [100%]

=================================================================== 10 passed, 4 warnings in 8.92s ====================================================================
```
> warnings do not related to this PR.

## Checklist

- [x]  All 10 new tests pass locally
- [x] Existing 302 tests still pass (no regression)
- [x] Follows test/registered/unit/README.md conventions
- [x] Registered for CPU CI via register_cpu_ci



