### PR TITLE
[MUSA] Resolve output garbage in Context Parallel on MusaFlashAttentionBackend

### DIFF
--- a/3rdparty/amd/wheel/sglang/pyproject.toml
+++ b/3rdparty/amd/wheel/sglang/pyproject.toml
@@ -123,8 +123,11 @@ srt_musa = [
   "sglang[runtime_common]",
   "torch",
   "torch_musa",
-  "torchada>=0.1.45",
+  "torchada>=0.1.50",
   "mthreads-ml-py",
+  "mate>=0.2.0",
+  "deep-gemm>=0.1.3",
+  "flash_attn_3>=0.1.4",
   "numpy<2.0",
 ]
 

--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -112,15 +112,15 @@ srt_hpu = ["sglang[runtime_common]"]
 
 # https://docs.sglang.io/platforms/mthreads_gpu.md
 srt_musa = [
-    "sglang[runtime_common]",
-    "torch",
-    "torch_musa",
-    "torchada>=0.1.48",
-    "mthreads-ml-py",
-    "mate",
-    "mate-deep_gemm",
-    "mate-flash-attention",
-    "numpy<2.0",
+  "sglang[runtime_common]",
+  "torch",
+  "torch_musa",
+  "torchada>=0.1.50",
+  "mthreads-ml-py",
+  "mate>=0.2.0",
+  "deep-gemm>=0.1.3",
+  "flash_attn_3>=0.1.4",
+  "numpy<2.0",
 ]
 
 diffusion_musa = [

--- a/python/sglang/srt/hardware_backend/musa/attention/flashattention_backend.py
+++ b/python/sglang/srt/hardware_backend/musa/attention/flashattention_backend.py
@@ -4,12 +4,15 @@ import threading
 from typing import TYPE_CHECKING, Optional, Tuple, Union
 
 import torch
-from flash_attn import flash_attn_varlen_func
-from flash_attn import flash_attn_with_kvcache as mate_flash_attn_with_kvcache
-from flash_attn import get_scheduler_metadata
+from flash_attn_interface import flash_attn_varlen_func
+from flash_attn_interface import flash_attn_with_kvcache as mate_flash_attn_with_kvcache
+from flash_attn_interface import get_scheduler_metadata
 
 from sglang.srt.distributed import get_pp_group, get_pp_indices
 from sglang.srt.environ import envs
+from sglang.srt.hardware_backend.musa.layers.utils.cp_utils import (
+    musa_cp_attn_forward_extend as cp_attn_forward_extend,
+)
 from sglang.srt.layers.attention.flashattention_backend import (
     FlashAttentionBackend,
     merge_state_v2_wrapper,
@@ -17,7 +20,6 @@ from sglang.srt.layers.attention.flashattention_backend import (
 from sglang.srt.layers.radix_attention import AttentionType
 from sglang.srt.layers.utils.cp_utils import (
     cp_allgather_and_save_kv_cache,
-    cp_attn_forward_extend,
 )
 from sglang.srt.server_args import get_global_server_args
 
@@ -143,10 +145,15 @@ def flash_attn_with_kvcache(
     pack_gqa=None,
     sm_margin: int = 0,
     return_softmax_lse: bool = False,
-    ver: int = 3,
-    **kwargs,
+    sinks=None,
+    score_mod=None,
+    aux_tensors=None,
+    ver=3,
 ):
     """MUSA flash_attn_with_kvcache wrapper that auto-injects scheduler_metadata."""
+    if ver != 3:
+        raise ValueError("Only ver=3 is supported for MUSA FA3.")
+
     if scheduler_metadata is None and _CURRENT_BACKEND is not None:
         backend = _CURRENT_BACKEND
         # Ensure backend has been properly set up for this call
@@ -195,6 +202,7 @@ def flash_attn_with_kvcache(
         pack_gqa=pack_gqa,
         sm_margin=sm_margin,
         return_softmax_lse=return_softmax_lse,
+        sinks=sinks,
     )
 
 
@@ -210,6 +218,9 @@ class MusaFlashAttentionBackend(FlashAttentionBackend):
         self._current_prefix: str = ""
         self._current_max_seqlen_k: int = 0
         self._current_can_run_tbo: bool = False
+
+        # Disable default scheduler metadata for fa3
+        self._get_scheduler_metadata = None
 
         # Register this backend as the global current instance for the wrapper
         global _CURRENT_BACKEND
@@ -402,6 +413,7 @@ class MusaFlashAttentionBackend(FlashAttentionBackend):
                     )
 
                 result = cp_attn_forward_extend(
+                    self,
                     forward_batch,
                     q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim),
                     self.device,
@@ -431,50 +443,6 @@ class MusaFlashAttentionBackend(FlashAttentionBackend):
                     num_splits=self.num_splits,
                     **kwargs,
                 )
-
-                if use_cascade_attn:
-                    # Update state for the second call
-                    self._current_prefix = "forward_extend_use_cascade_attn"
-                    self._current_max_seqlen_k = (
-                        self.forward_metadata_spec_decode_expand.max_seq_len_k
-                    )
-
-                    o, softmax_lse, *rest = result
-                    o_expand, softmax_lse_expand, *rest_expand = (
-                        flash_attn_with_kvcache(
-                            q=q.contiguous().view(
-                                -1, layer.tp_q_head_num, layer.head_dim
-                            ),
-                            k_cache=key_cache.view(
-                                -1, 1, layer.tp_k_head_num, layer.head_dim
-                            ),
-                            v_cache=value_cache.view(
-                                -1, 1, layer.tp_v_head_num, layer.head_dim
-                            ),
-                            page_table=self.forward_metadata_spec_decode_expand.page_table,
-                            cache_seqlens=self.forward_metadata_spec_decode_expand.cache_seqlens_int32,
-                            cu_seqlens_q=self.forward_metadata_spec_decode_expand.cu_seqlens_q,
-                            cu_seqlens_k_new=self.forward_metadata_spec_decode_expand.cu_seqlens_k,
-                            max_seqlen_q=self.forward_metadata_spec_decode_expand.max_seq_len_q,
-                            softmax_scale=layer.scaling,
-                            causal=False,
-                            window_size=window_size,
-                            softcap=layer.logit_cap,
-                            k_descale=k_descale,
-                            v_descale=v_descale,
-                            return_softmax_lse=True,
-                            num_splits=self.num_splits,
-                            **kwargs,
-                        )
-                    )
-                    o, _ = merge_state_v2_wrapper(
-                        o,
-                        softmax_lse.T.contiguous(),
-                        o_expand,
-                        softmax_lse_expand.T.contiguous(),
-                    )
-                else:
-                    o = result
             else:
                 output = flash_attn_varlen_func(
                     q=q.view(-1, layer.tp_q_head_num, layer.head_dim),
@@ -487,6 +455,7 @@ class MusaFlashAttentionBackend(FlashAttentionBackend):
                     softmax_scale=layer.scaling,
                     causal=True,
                     return_softmax_lse=forward_batch.mha_return_lse,
+                    **kwargs,
                 )
                 if forward_batch.mha_return_lse:
                     output, lse, *rest = output
@@ -496,6 +465,44 @@ class MusaFlashAttentionBackend(FlashAttentionBackend):
                         lse,
                     )
                 return output.view(-1, layer.tp_q_head_num * layer.v_head_dim)
+
+            if use_cascade_attn:
+                # Update state for the second call
+                self._current_prefix = "forward_extend_use_cascade_attn"
+                self._current_max_seqlen_k = (
+                    self.forward_metadata_spec_decode_expand.max_seq_len_k
+                )
+
+                o, softmax_lse, *rest = result
+                o_expand, softmax_lse_expand, *rest_expand = flash_attn_with_kvcache(
+                    q=q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim),
+                    k_cache=key_cache.view(-1, 1, layer.tp_k_head_num, layer.head_dim),
+                    v_cache=value_cache.view(
+                        -1, 1, layer.tp_v_head_num, layer.head_dim
+                    ),
+                    page_table=self.forward_metadata_spec_decode_expand.page_table,
+                    cache_seqlens=self.forward_metadata_spec_decode_expand.cache_seqlens_int32,
+                    cu_seqlens_q=self.forward_metadata_spec_decode_expand.cu_seqlens_q,
+                    cu_seqlens_k_new=self.forward_metadata_spec_decode_expand.cu_seqlens_k,
+                    max_seqlen_q=self.forward_metadata_spec_decode_expand.max_seq_len_q,
+                    softmax_scale=layer.scaling,
+                    causal=False,
+                    window_size=window_size,
+                    softcap=layer.logit_cap,
+                    k_descale=k_descale,
+                    v_descale=v_descale,
+                    return_softmax_lse=True,
+                    num_splits=self.num_splits,
+                    **kwargs,
+                )
+                o, _ = merge_state_v2_wrapper(
+                    o,
+                    softmax_lse.T.contiguous(),
+                    o_expand,
+                    softmax_lse_expand.T.contiguous(),
+                )
+            else:
+                o = result
         else:
             if (
                 forward_batch.attn_attend_prefix_cache is not None

--- a/python/sglang/srt/hardware_backend/musa/layers/utils/cp_utils.py
+++ b/python/sglang/srt/hardware_backend/musa/layers/utils/cp_utils.py
@@ -1,0 +1,57 @@
+from typing import TYPE_CHECKING, Callable
+
+import torch
+
+if TYPE_CHECKING:
+    from sglang.srt.hardware_backend.musa.attention.flashattention_backend import (
+        MusaFlashAttentionBackend,
+    )
+    from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+
+
+def musa_cp_attn_forward_extend(
+    musa_fa_backend: "MusaFlashAttentionBackend",
+    forward_batch: "ForwardBatch",
+    q: torch.Tensor,
+    device: torch.device,
+    attn_fn: Callable[[torch.Tensor, torch.Tensor, torch.Tensor, int], torch.Tensor],
+) -> torch.Tensor:
+    """
+    Split q into prev/next zigzag halves based on CP metadata, call the
+    backend-specific attention function twice with appropriate per-half
+    metadata, and concatenate the results.
+
+    attn_fn signature:
+        attn_fn(q, cu_seqlens_q, cache_seqlens, max_seqlen_q) -> result
+    where only these four CP-varying parameters differ between halves.
+    All other backend-specific args should be captured in the closure.
+    """
+    cp_meta = forward_batch.attn_cp_metadata
+
+    q_prev, q_next = torch.chunk(q, 2, dim=0)
+
+    cu_seqlens_q_prev = torch.tensor(
+        [0, cp_meta.actual_seq_q_prev], device=device, dtype=torch.int32
+    )
+    if hasattr(musa_fa_backend, "_current_prefix"):
+        musa_fa_backend._current_prefix = "forward_extend_cp_prev"
+    result_prev = attn_fn(
+        q_prev,
+        cu_seqlens_q_prev,
+        cp_meta.kv_len_prev_tensor,
+        cp_meta.actual_seq_q_prev,
+    )
+
+    cu_seqlens_q_next = torch.tensor(
+        [0, cp_meta.actual_seq_q_next], device=device, dtype=torch.int32
+    )
+    if hasattr(musa_fa_backend, "_current_prefix"):
+        musa_fa_backend._current_prefix = "forward_extend_cp_next"
+    result_next = attn_fn(
+        q_next,
+        cu_seqlens_q_next,
+        cp_meta.kv_len_next_tensor,
+        cp_meta.actual_seq_q_next,
+    )
+
+    return torch.concat([result_prev, result_next], dim=0)

--- a/sgl-kernel/pyproject_musa.toml
+++ b/sgl-kernel/pyproject_musa.toml
@@ -3,7 +3,7 @@ requires = [
   "setuptools>=75.0",
   "scikit-build-core>=0.10",
   "torch",
-  "torchada>=0.1.45",
+  "torchada>=0.1.50",
   "wheel",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fix Context Parallel (CP) attention forward extension for the MUSA backend. The original `cp_attn_forward_extend` function from `cp_utils.py` was incompatible with the MUSA FA Attention backend, causing CP workloads to fail on MUSA devices.

## Modifications
- **Fix context parallel**:  Modify the original cp_attn_forward_extend function to be able to switch the backend's _current_prefix in order to obtain the correct schedule metadata.
- **Fix cascade attention logic**: Moved the cascade attention handling block to the correct location after the initial attention call.
- **Add `**kwargs` propagation**: Ensures all keyword arguments are passed to `flash_attn_varlen_func`.
- **Disable default scheduler metadata**: Set `self._get_scheduler_metadata = None` for FA3 compatibility.
- **Switched the MUSA FlashAttention backend** to import FlashAttention APIs from flash_attn_interface instead of flash_attn, so the MUSA implementation matches the updated MATE integration.

  - Upgraded the minimum torchada version from older releases to >=0.1.50 in both the main MUSA package definition and the MUSA kernel build configuration.

  - Updated MUSA runtime dependencies in python/pyproject_other.toml:
      - mate -> mate>=0.2.0
      - mate-deep_gemm -> deep-gemm>=0.1.3
      - mate-flash-attention -> flash_attn_3>=0.1.4
  - Updated the AMD wheel packaging entry for MUSA dependencies in 3rdparty/amd/wheel/sglang/pyproject.toml to keep package definitions consistent across build targets.


## Accuracy Tests

```
python3 -m sglang.launch_server \
    --model-path /mnt/seed17/001688/models/Qwen3-30B-A3B/ \
    --disable-cuda-graph \
    --trust-remote-code \
    --attention-backend fa3 \
    --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 64}' \
    --tp 4 \
    --disable-piecewise-cuda-graph \
    --cuda-graph-max-bs 32 \
    --attn-cp-size 2 \
    --moe-dp-size 2 \
    --enable-prefill-context-parallel \
    --max-running-requests 32
2026-04-20 21:33:52 | warnings | 140189055194944 | WARNING : /mnt/seed17/001688/qzg/qwen3/260124/github/sglang/python/sglang/launch_server.py:51: UserWarning: 'python -m sglang.launch_server' is still supported, but 'sglang serve' is the recommended entrypoint.
  Example: sglang serve --model-path <model> [options]
  warnings.warn(

INFO 04-20 21:33:53 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 04-20 21:33:53 [__init__.py:38] - musa -> vllm_musa:register
INFO 04-20 21:33:53 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 04-20 21:33:53 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 04-20 21:33:53 [__init__.py:38] - musa -> vllm_musa:register
INFO 04-20 21:33:53 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 04-20 21:33:53 [__init__.py:232] Platform plugin musa is activated
INFO 04-20 21:33:53 [__init__.py:245] No platform detected, vLLM is running on UnspecifiedPlatform
[2026-04-20 21:33:53] /mnt/seed17/001688/qzg/qwen3/260124/github/sglang/python/sglang/srt/layers/quantization/awq.py:87: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

`torch_dtype` is deprecated! Use `dtype` instead!
[2026-04-20 21:33:54] server_args=ServerArgs(model_path='/mnt/seed17/001688/models/Qwen3-30B-A3B/', tokenizer_path='/mnt/seed17/001688/models/Qwen3-30B-A3B/', tokenizer_mode='auto', tokenizer_worker_num=1, skip_tokenizer_init=False, load_format='auto', model_loader_extra_config='{"enable_multithread_load": true, "num_threads": 64}', trust_remote_code=True, context_length=None, is_embedding=False, enable_multimodal=None, revision=None, model_impl='auto', host='127.0.0.1', port=30000, fastapi_root_path='', grpc_mode=False, skip_server_warmup=False, warmups=None, nccl_port=None, checkpoint_engine_wait_weights_before_ready=False, ssl_keyfile=None, ssl_certfile=None, ssl_ca_certs=None, ssl_keyfile_password=None, enable_ssl_refresh=False, enable_http2=False, dtype='auto', quantization=None, quantization_param_path=None, kv_cache_dtype='auto', enable_fp32_lm_head=False, modelopt_quant=None, modelopt_checkpoint_restore_path=None, modelopt_checkpoint_save_path=None, modelopt_export_path=None, quantize_and_serve=False, rl_quant_profile=None, mem_fraction_static=0.837, max_running_requests=32, max_queued_requests=None, max_total_tokens=None, chunked_prefill_size=8192, enable_dynamic_chunking=False, max_prefill_tokens=16384, prefill_max_requests=None, schedule_policy='fcfs', enable_priority_scheduling=False, disable_priority_preemption=False, default_priority_value=None, abort_on_priority_when_disabled=False, schedule_low_priority_values_first=False, priority_scheduling_preemption_threshold=10, schedule_conservativeness=1.0, page_size=64, swa_full_tokens_ratio=0.8, disable_hybrid_swa_memory=False, radix_eviction_policy='lru', enable_prefill_delayer=False, prefill_delayer_max_delay_passes=30, prefill_delayer_token_usage_low_watermark=None, prefill_delayer_forward_passes_buckets=None, prefill_delayer_wait_seconds_buckets=None, device='musa', tp_size=4, pp_size=1, pp_max_micro_batch_size=None, pp_async_batch_depth=0, stream_interval=1, stream_response_default_include_usage=False, incremental_streaming_output=False, enable_streaming_session=False, random_seed=901125475, constrained_json_whitespace_pattern=None, constrained_json_disable_any_whitespace=False, watchdog_timeout=300, soft_watchdog_timeout=None, dist_timeout=None, download_dir=None, model_checksum=None, base_gpu_id=0, gpu_id_step=1, sleep_on_idle=False, use_ray=False, custom_sigquit_handler=None, log_level='info', log_level_http=None, log_requests=False, log_requests_level=2, log_requests_format='text', log_requests_target=None, uvicorn_access_log_exclude_prefixes=[], crash_dump_folder=None, show_time_cost=False, enable_metrics=False, metrics_http_port=None, enable_mfu_metrics=False, enable_metrics_for_all_schedulers=False, tokenizer_metrics_custom_labels_header='x-custom-labels', tokenizer_metrics_allowed_custom_labels=None, extra_metric_labels=None, bucket_time_to_first_token=None, bucket_inter_token_latency=None, bucket_e2e_request_latency=None, collect_tokens_histogram=False, prompt_tokens_buckets=None, generation_tokens_buckets=None, gc_warning_threshold_secs=0.0, decode_log_interval=40, enable_request_time_stats_logging=False, kv_events_config=None, enable_trace=False, otlp_traces_endpoint='localhost:4317', export_metrics_to_file=False, export_metrics_to_file_dir=None, api_key=None, admin_api_key=None, served_model_name='/mnt/seed17/001688/models/Qwen3-30B-A3B/', weight_version='default', chat_template=None, hf_chat_template_name=None, completion_template=None, file_storage_path='sglang_storage', enable_cache_report=False, reasoning_parser=None, tool_call_parser=None, tool_server=None, sampling_defaults='model', dp_size=1, load_balance_method='round_robin', attn_cp_size=2, moe_dp_size=2, dist_init_addr=None, nnodes=1, node_rank=0, json_model_override_args='{}', preferred_sampling_params=None, enable_lora=None, enable_lora_overlap_loading=None, max_lora_rank=None, lora_target_modules=None, lora_paths=None, max_loaded_loras=None, max_loras_per_batch=8, lora_eviction_policy='lru', lora_backend='csgmv', max_lora_chunk_size=16, experts_shared_outer_loras=None, lora_use_virtual_experts=False, lora_strict_loading=False, attention_backend='fa3', decode_attention_backend=None, prefill_attention_backend=None, sampling_backend='pytorch', grammar_backend='xgrammar', mm_attention_backend=None, fp8_gemm_runner_backend='auto', fp4_gemm_runner_backend='auto', nsa_prefill_backend=None, nsa_decode_backend=None, disable_flashinfer_autotune=False, mamba_backend='triton', speculative_algorithm=None, speculative_draft_model_path=None, speculative_draft_model_revision=None, speculative_draft_load_format=None, speculative_num_steps=None, speculative_eagle_topk=None, speculative_num_draft_tokens=None, speculative_dflash_block_size=None, speculative_dflash_draft_window_size=None, speculative_accept_threshold_single=1.0, speculative_accept_threshold_acc=1.0, speculative_token_map=None, speculative_attention_mode='prefill', speculative_draft_attention_backend=None, speculative_moe_runner_backend='auto', speculative_moe_a2a_backend=None, speculative_draft_model_quantization=None, speculative_ngram_min_bfs_breadth=1, speculative_ngram_max_bfs_breadth=10, speculative_ngram_match_type='BFS', speculative_ngram_max_trie_depth=18, speculative_ngram_capacity=10000000, speculative_ngram_external_corpus_path=None, speculative_ngram_external_sam_budget=0, speculative_ngram_external_corpus_max_tokens=10000000, enable_multi_layer_eagle=False, ep_size=1, moe_a2a_backend='none', moe_runner_backend='auto', flashinfer_mxfp4_moe_precision='default', enable_flashinfer_allreduce_fusion=False, enforce_disable_flashinfer_allreduce_fusion=False, enable_aiter_allreduce_fusion=False, deepep_mode='auto', ep_num_redundant_experts=0, ep_dispatch_algorithm=None, init_expert_location='trivial', enable_eplb=False, eplb_algorithm='auto', eplb_rebalance_num_iterations=1000, eplb_rebalance_layers_per_chunk=None, eplb_min_rebalancing_utilization_threshold=1.0, expert_distribution_recorder_mode=None, expert_distribution_recorder_buffer_size=1000, enable_expert_distribution_metrics=False, deepep_config=None, moe_dense_tp_size=None, elastic_ep_backend=None, enable_elastic_expert_backup=False, mooncake_ib_device=None, max_mamba_cache_size=None, mamba_ssm_dtype=None, mamba_full_memory_ratio=0.9, mamba_scheduler_strategy='no_buffer', mamba_track_interval=256, linear_attn_backend='triton', linear_attn_decode_backend=None, linear_attn_prefill_backend=None, enable_hierarchical_cache=False, hicache_ratio=2.0, hicache_size=0, hicache_write_policy='write_through', hicache_io_backend='kernel', hicache_mem_layout='layer_first', hicache_storage_backend=None, hicache_storage_prefetch_policy='best_effort', hicache_storage_backend_extra_config=None, enable_hisparse=False, hisparse_config=None, enable_lmcache=False, kt_weight_path=None, kt_method='AMXINT4', kt_cpuinfer=None, kt_threadpool_count=2, kt_num_gpu_experts=None, kt_max_deferred_experts_per_token=None, dllm_algorithm=None, dllm_algorithm_config=None, enable_double_sparsity=False, ds_channel_config_path=None, ds_heavy_channel_num=32, ds_heavy_token_num=256, ds_heavy_channel_type='qk', ds_sparse_decode_threshold=4096, cpu_offload_gb=0, offload_group_size=-1, offload_num_in_group=1, offload_prefetch_step=1, offload_mode='cpu', multi_item_scoring_delimiter=None, disable_radix_cache=False, cuda_graph_max_bs=32, cuda_graph_bs=[1, 2, 4, 8, 12, 16, 24, 32], disable_cuda_graph=True, disable_cuda_graph_padding=False, enable_profile_cuda_graph=False, enable_cudagraph_gc=False, debug_cuda_graph=False, enable_layerwise_nvtx_marker=False, enable_nccl_nvls=False, enable_symm_mem=False, disable_flashinfer_cutlass_moe_fp4_allgather=False, enable_tokenizer_batch_encode=False, disable_tokenizer_batch_decode=False, disable_outlines_disk_cache=False, disable_custom_all_reduce=False, enable_mscclpp=False, enable_torch_symm_mem=False, pre_warm_nccl=False, disable_overlap_schedule=False, enable_mixed_chunk=False, enable_dp_attention=False, enable_dp_attention_local_control_broadcast=False, enable_dp_lm_head=False, enable_two_batch_overlap=False, enable_single_batch_overlap=False, tbo_token_distribution_threshold=0.48, enable_torch_compile=False, disable_piecewise_cuda_graph=True, enforce_piecewise_cuda_graph=False, enable_torch_compile_debug_mode=False, torch_compile_max_bs=32, piecewise_cuda_graph_max_tokens=8192, piecewise_cuda_graph_tokens=[4, 8, 12, 16, 20, 24, 28, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256, 288, 320, 352, 384, 416, 448, 480, 512, 576, 640, 704, 768, 832, 896, 960, 1024, 1280, 1536, 1792, 2048, 2304, 2560, 2816, 3072, 3328, 3584, 3840, 4096, 4608, 5120, 5632, 6144, 6656, 7168, 7680, 8192], piecewise_cuda_graph_compiler='eager', torchao_config='', enable_nan_detection=False, enable_p2p_check=False, triton_attention_reduce_in_fp32=False, triton_attention_num_kv_splits=8, triton_attention_split_tile_size=None, num_continuous_decode_steps=1, delete_ckpt_after_loading=False, enable_memory_saver=False, enable_weights_cpu_backup=False, enable_draft_weights_cpu_backup=False, allow_auto_truncate=False, enable_custom_logit_processor=False, flashinfer_mla_disable_ragged=False, disable_shared_experts_fusion=False, enforce_shared_experts_fusion=False, disable_chunked_prefix_cache=False, disable_fast_image_processor=False, keep_mm_feature_on_device=False, enable_return_hidden_states=False, enable_return_routed_experts=False, scheduler_recv_interval=1, numa_node=None, enable_deterministic_inference=False, rl_on_policy_target=None, enable_attn_tp_input_scattered=False, gc_threshold=None, enable_nsa_prefill_context_parallel=False, nsa_prefill_cp_mode='round-robin-split', enable_fused_qk_norm_rope=False, enable_precise_embedding_interpolation=False, enable_fused_moe_sum_all_reduce=False, enable_prefill_context_parallel=True, prefill_cp_mode='in-seq-split', enable_dynamic_batch_tokenizer=False, dynamic_batch_tokenizer_batch_size=32, dynamic_batch_tokenizer_batch_timeout=0.002, debug_tensor_dump_output_folder=None, debug_tensor_dump_layers=None, debug_tensor_dump_input_file=None, debug_tensor_dump_inject=False, disaggregation_mode='null', disaggregation_transfer_backend='mooncake', disaggregation_bootstrap_port=8998, disaggregation_ib_device=None, disaggregation_decode_enable_offload_kvcache=False, num_reserved_decode_tokens=512, disaggregation_decode_polling_interval=1, encoder_only=False, language_only=False, encoder_transfer_backend='zmq_to_scheduler', encoder_urls=[], enable_adaptive_dispatch_to_encoder=False, custom_weight_loader=[], weight_loader_disable_mmap=False, weight_loader_prefetch_checkpoints=False, weight_loader_prefetch_num_threads=4, remote_instance_weight_loader_seed_instance_ip=None, remote_instance_weight_loader_seed_instance_service_port=None, remote_instance_weight_loader_send_weights_group_ports=None, remote_instance_weight_loader_backend='nccl', remote_instance_weight_loader_start_seed_via_transfer_engine=False, engine_info_bootstrap_port=6789, modelexpress_config=None, enable_pdmux=False, pdmux_config_path=None, sm_group_num=8, enable_broadcast_mm_inputs_process=False, enable_prefix_mm_cache=False, mm_enable_dp_encoder=False, mm_process_config={}, limit_mm_data_per_request=None, enable_mm_global_cache=False, decrypted_config_file=None, decrypted_draft_config_file=None, forward_hooks=None)
[2026-04-20 21:33:55] Using default HuggingFace chat template with detected content format: string
INFO 04-20 21:34:01 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 04-20 21:34:01 [__init__.py:38] - musa -> vllm_musa:register
INFO 04-20 21:34:01 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 04-20 21:34:01 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 04-20 21:34:01 [__init__.py:38] - musa -> vllm_musa:register
INFO 04-20 21:34:01 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 04-20 21:34:01 [__init__.py:232] Platform plugin musa is activated
INFO 04-20 21:34:01 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 04-20 21:34:01 [__init__.py:38] - musa -> vllm_musa:register
INFO 04-20 21:34:01 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 04-20 21:34:02 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 04-20 21:34:02 [__init__.py:38] - musa -> vllm_musa:register
INFO 04-20 21:34:02 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 04-20 21:34:02 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 04-20 21:34:02 [__init__.py:38] - musa -> vllm_musa:register
INFO 04-20 21:34:02 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 04-20 21:34:02 [__init__.py:232] Platform plugin musa is activated
INFO 04-20 21:34:02 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 04-20 21:34:02 [__init__.py:38] - musa -> vllm_musa:register
INFO 04-20 21:34:02 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 04-20 21:34:02 [__init__.py:232] Platform plugin musa is activated
INFO 04-20 21:34:02 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 04-20 21:34:02 [__init__.py:38] - musa -> vllm_musa:register
INFO 04-20 21:34:02 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 04-20 21:34:02 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 04-20 21:34:02 [__init__.py:38] - musa -> vllm_musa:register
INFO 04-20 21:34:02 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 04-20 21:34:02 [__init__.py:232] Platform plugin musa is activated
INFO 04-20 21:34:02 [__init__.py:245] No platform detected, vLLM is running on UnspecifiedPlatform
2026-04-20 21:34:02 | warnings | 140666710714176 | WARNING : /mnt/seed17/001688/qzg/qwen3/260124/github/sglang/python/sglang/srt/layers/quantization/awq.py:87: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

INFO 04-20 21:34:02 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 04-20 21:34:02 [__init__.py:38] - musa -> vllm_musa:register
INFO 04-20 21:34:02 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 04-20 21:34:02 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 04-20 21:34:02 [__init__.py:38] - musa -> vllm_musa:register
INFO 04-20 21:34:02 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 04-20 21:34:02 [__init__.py:232] Platform plugin musa is activated
INFO 04-20 21:34:02 [__init__.py:245] No platform detected, vLLM is running on UnspecifiedPlatform
INFO 04-20 21:34:02 [__init__.py:245] No platform detected, vLLM is running on UnspecifiedPlatform
2026-04-20 21:34:02 | warnings | 140671758464832 | WARNING : /mnt/seed17/001688/qzg/qwen3/260124/github/sglang/python/sglang/srt/layers/quantization/awq.py:87: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-04-20 21:34:02 | warnings | 139625772468032 | WARNING : /mnt/seed17/001688/qzg/qwen3/260124/github/sglang/python/sglang/srt/layers/quantization/awq.py:87: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

INFO 04-20 21:34:02 [__init__.py:245] No platform detected, vLLM is running on UnspecifiedPlatform
2026-04-20 21:34:02 | warnings | 139958655321920 | WARNING : /mnt/seed17/001688/qzg/qwen3/260124/github/sglang/python/sglang/srt/layers/quantization/awq.py:87: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

INFO 04-20 21:34:02 [__init__.py:245] No platform detected, vLLM is running on UnspecifiedPlatform
2026-04-20 21:34:02 | warnings | 140401904592704 | WARNING : /mnt/seed17/001688/qzg/qwen3/260124/github/sglang/python/sglang/srt/layers/quantization/awq.py:87: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

[2026-04-20 21:34:02 ATTN_CP0 MOE_DP0 TP0] Process 3621419 gpu_id 0 is running on CPUs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79]
`torch_dtype` is deprecated! Use `dtype` instead!
[2026-04-20 21:34:03 ATTN_CP1 MOE_DP1 TP3] Process 3621429 gpu_id 3 is running on CPUs: [48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127]
[2026-04-20 21:34:03 ATTN_CP0 MOE_DP0 TP1] Process 3621426 gpu_id 1 is running on CPUs: [16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95]
`torch_dtype` is deprecated! Use `dtype` instead!
`torch_dtype` is deprecated! Use `dtype` instead!
[2026-04-20 21:34:03 ATTN_CP1 MOE_DP1 TP2] Process 3621427 gpu_id 2 is running on CPUs: [32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111]
`torch_dtype` is deprecated! Use `dtype` instead!
[2026-04-20 21:34:03 ATTN_CP0 MOE_DP0 TP0] Init torch distributed begin.
[2026-04-20 21:34:03 ATTN_CP1 MOE_DP1 TP3] Init torch distributed begin.
[2026-04-20 21:34:03 ATTN_CP0 MOE_DP0 TP1] Init torch distributed begin.
[2026-04-20 21:34:04 ATTN_CP1 MOE_DP1 TP2] Init torch distributed begin.
[Gloo] Rank 0 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 1 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 2 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 3 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 0 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 2 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 1 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 3 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[2026-04-20 21:34:06 ATTN_CP0 MOE_DP0 TP0] sglang is using nccl==2.11.4
[Gloo] Rank 0 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 1 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 1 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 0 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[2026-04-20 21:34:07 ATTN_CP0 MOE_DP0 TP0] sglang is using nccl==2.11.4
[2026-04-20 21:34:07 ATTN_CP0 MOE_DP0 TP1] sglang is using nccl==2.11.4
[Gloo] Rank 0 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 1 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 1 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 0 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 1 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 0 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 0 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 1 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[2026-04-20 21:34:07 ATTN_CP0 MOE_DP0 TP1] sglang is using nccl==2.11.4
[2026-04-20 21:34:07 ATTN_CP0 MOE_DP0 TP0] sglang is using nccl==2.11.4
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 1 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 0 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 1 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[2026-04-20 21:34:07 ATTN_CP1 MOE_DP1 TP2] Init torch distributed ends. elapsed=3.71 s, mem usage=2.11 GB
[2026-04-20 21:34:07 ATTN_CP1 MOE_DP1 TP3] Init torch distributed ends. elapsed=3.88 s, mem usage=2.11 GB
[2026-04-20 21:34:07 ATTN_CP0 MOE_DP0 TP0] Init torch distributed ends. elapsed=3.96 s, mem usage=2.00 GB
[2026-04-20 21:34:07 ATTN_CP0 MOE_DP0 TP1] Init torch distributed ends. elapsed=3.82 s, mem usage=2.11 GB
[2026-04-20 21:34:08 ATTN_CP1 MOE_DP1 TP3] Ignore import error when loading sglang.srt.models.gemma4_audio: cannot import name 'Gemma4AudioConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-20 21:34:08 ATTN_CP1 MOE_DP1 TP2] Ignore import error when loading sglang.srt.models.gemma4_audio: cannot import name 'Gemma4AudioConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-20 21:34:08 ATTN_CP1 MOE_DP1 TP3] Ignore import error when loading sglang.srt.models.gemma4_causal: cannot import name 'Gemma4TextConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-20 21:34:08 ATTN_CP1 MOE_DP1 TP2] Ignore import error when loading sglang.srt.models.gemma4_causal: cannot import name 'Gemma4TextConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-20 21:34:08 ATTN_CP1 MOE_DP1 TP3] Ignore import error when loading sglang.srt.models.gemma4_mm: cannot import name 'Gemma4AudioConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-20 21:34:08 ATTN_CP1 MOE_DP1 TP2] Ignore import error when loading sglang.srt.models.gemma4_mm: cannot import name 'Gemma4AudioConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-20 21:34:08 ATTN_CP1 MOE_DP1 TP3] Ignore import error when loading sglang.srt.models.gemma4_vision: cannot import name 'Gemma4VisionConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-20 21:34:08 ATTN_CP1 MOE_DP1 TP2] Ignore import error when loading sglang.srt.models.gemma4_vision: cannot import name 'Gemma4VisionConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-20 21:34:08 ATTN_CP1 MOE_DP1 TP3] Ignore import error when loading sglang.srt.models.glm_ocr: No module named 'transformers.models.glm_ocr'
[2026-04-20 21:34:08 ATTN_CP1 MOE_DP1 TP2] Ignore import error when loading sglang.srt.models.glm_ocr: No module named 'transformers.models.glm_ocr'
[2026-04-20 21:34:08 ATTN_CP1 MOE_DP1 TP2] Ignore import error when loading sglang.srt.models.glm_ocr_nextn: No module named 'transformers.models.glm_ocr'
[2026-04-20 21:34:08 ATTN_CP1 MOE_DP1 TP3] Ignore import error when loading sglang.srt.models.glm_ocr_nextn: No module named 'transformers.models.glm_ocr'
[2026-04-20 21:34:08 ATTN_CP1 MOE_DP1 TP2] Ignore import error when loading sglang.srt.models.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-20 21:34:08 ATTN_CP1 MOE_DP1 TP3] Ignore import error when loading sglang.srt.models.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-20 21:34:08 ATTN_CP0 MOE_DP0 TP0] Ignore import error when loading sglang.srt.models.gemma4_audio: cannot import name 'Gemma4AudioConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-20 21:34:08 ATTN_CP0 MOE_DP0 TP1] Ignore import error when loading sglang.srt.models.gemma4_audio: cannot import name 'Gemma4AudioConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-20 21:34:08 ATTN_CP0 MOE_DP0 TP0] Ignore import error when loading sglang.srt.models.gemma4_causal: cannot import name 'Gemma4TextConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-20 21:34:08 ATTN_CP0 MOE_DP0 TP1] Ignore import error when loading sglang.srt.models.gemma4_causal: cannot import name 'Gemma4TextConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-20 21:34:08 ATTN_CP0 MOE_DP0 TP0] Ignore import error when loading sglang.srt.models.gemma4_mm: cannot import name 'Gemma4AudioConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-20 21:34:08 ATTN_CP0 MOE_DP0 TP1] Ignore import error when loading sglang.srt.models.gemma4_mm: cannot import name 'Gemma4AudioConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-20 21:34:08 ATTN_CP0 MOE_DP0 TP0] Ignore import error when loading sglang.srt.models.gemma4_vision: cannot import name 'Gemma4VisionConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-20 21:34:08 ATTN_CP0 MOE_DP0 TP1] Ignore import error when loading sglang.srt.models.gemma4_vision: cannot import name 'Gemma4VisionConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-20 21:34:08 ATTN_CP0 MOE_DP0 TP0] Ignore import error when loading sglang.srt.models.glm_ocr: No module named 'transformers.models.glm_ocr'
[2026-04-20 21:34:08 ATTN_CP0 MOE_DP0 TP1] Ignore import error when loading sglang.srt.models.glm_ocr: No module named 'transformers.models.glm_ocr'
[2026-04-20 21:34:08 ATTN_CP0 MOE_DP0 TP0] Ignore import error when loading sglang.srt.models.glm_ocr_nextn: No module named 'transformers.models.glm_ocr'
[2026-04-20 21:34:08 ATTN_CP0 MOE_DP0 TP1] Ignore import error when loading sglang.srt.models.glm_ocr_nextn: No module named 'transformers.models.glm_ocr'
[2026-04-20 21:34:08 ATTN_CP0 MOE_DP0 TP0] Ignore import error when loading sglang.srt.models.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-20 21:34:08 ATTN_CP0 MOE_DP0 TP1] Ignore import error when loading sglang.srt.models.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-20 21:34:08 ATTN_CP1 MOE_DP1 TP3] Ignore import error when loading sglang.srt.models.midashenglm: No module named 'torchaudio'
[2026-04-20 21:34:08 ATTN_CP1 MOE_DP1 TP2] Ignore import error when loading sglang.srt.models.midashenglm: No module named 'torchaudio'
[2026-04-20 21:34:08 ATTN_CP0 MOE_DP0 TP1] Ignore import error when loading sglang.srt.models.midashenglm: No module named 'torchaudio'
[2026-04-20 21:34:08 ATTN_CP0 MOE_DP0 TP0] Ignore import error when loading sglang.srt.models.midashenglm: No module named 'torchaudio'
[2026-04-20 21:34:09 ATTN_CP1 MOE_DP1 TP3] Load weight begin. avail mem=77.10 GB
[2026-04-20 21:34:09 ATTN_CP1 MOE_DP1 TP2] Load weight begin. avail mem=77.10 GB
[2026-04-20 21:34:09 ATTN_CP0 MOE_DP0 TP1] Load weight begin. avail mem=77.10 GB
[2026-04-20 21:34:10 ATTN_CP0 MOE_DP0 TP0] Load weight begin. avail mem=77.02 GB
Multi-thread loading shards:  88% Completed | 14/16 [00:40<00:05,  2.69s/it][2026-04-20 21:34:53 ATTN_CP1 MOE_DP1 TP2] Load weight end. elapsed=43.23 s, type=Qwen3MoeForCausalLM, avail mem=48.66 GB, mem usage=28.43 GB.
[2026-04-20 21:34:54 ATTN_CP1 MOE_DP1 TP3] Load weight end. elapsed=44.50 s, type=Qwen3MoeForCausalLM, avail mem=48.66 GB, mem usage=28.43 GB.
Multi-thread loading shards: 100% Completed | 16/16 [00:43<00:00,  2.70s/it]
[2026-04-20 21:34:55 ATTN_CP0 MOE_DP0 TP0] Load weight end. elapsed=45.67 s, type=Qwen3MoeForCausalLM, avail mem=48.59 GB, mem usage=28.43 GB.
[2026-04-20 21:34:55 ATTN_CP0 MOE_DP0 TP1] Load weight end. elapsed=45.74 s, type=Qwen3MoeForCausalLM, avail mem=48.66 GB, mem usage=28.43 GB.
[2026-04-20 21:34:55 ATTN_CP0 MOE_DP0 TP0] Using KV cache dtype: torch.bfloat16
[2026-04-20 21:34:55 ATTN_CP1 MOE_DP1 TP2] KV Cache is allocated. #tokens: 786880, K size: 18.01 GB, V size: 18.01 GB
[2026-04-20 21:34:55 ATTN_CP1 MOE_DP1 TP3] KV Cache is allocated. #tokens: 786880, K size: 18.01 GB, V size: 18.01 GB
[2026-04-20 21:34:55 ATTN_CP0 MOE_DP0 TP0] KV Cache is allocated. #tokens: 786880, K size: 18.01 GB, V size: 18.01 GB
[2026-04-20 21:34:55 ATTN_CP0 MOE_DP0 TP1] KV Cache is allocated. #tokens: 786880, K size: 18.01 GB, V size: 18.01 GB
[2026-04-20 21:34:55 ATTN_CP1 MOE_DP1 TP2] Memory pool end. avail mem=12.40 GB
[2026-04-20 21:34:55 ATTN_CP1 MOE_DP1 TP3] Memory pool end. avail mem=12.40 GB
[2026-04-20 21:34:55 ATTN_CP0 MOE_DP0 TP0] Memory pool end. avail mem=12.32 GB
[2026-04-20 21:34:55 ATTN_CP0 MOE_DP0 TP1] Memory pool end. avail mem=12.40 GB
[2026-04-20 21:34:56 ATTN_CP1 MOE_DP1 TP2] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
[2026-04-20 21:34:56 ATTN_CP1 MOE_DP1 TP3] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
[2026-04-20 21:34:56 ATTN_CP0 MOE_DP0 TP1] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
[2026-04-20 21:34:56 ATTN_CP0 MOE_DP0 TP0] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
[2026-04-20 21:34:57 ATTN_CP0 MOE_DP0 TP0] max_total_num_tokens=786880, chunked_prefill_size=8192, max_prefill_tokens=16384, max_running_requests=32, context_len=40960, available_gpu_mem=12.27 GB
[2026-04-20 21:34:58] INFO:     Started server process [3619866]
[2026-04-20 21:34:58] INFO:     Waiting for application startup.
[2026-04-20 21:34:58] Using default chat sampling params from model generation config: {'repetition_penalty': 1.0, 'temperature': 0.6, 'top_k': 20, 'top_p': 0.95}
[2026-04-20 21:34:58] INFO:     Application startup complete.
[2026-04-20 21:34:58] INFO:     Uvicorn running on http://127.0.0.1:30000 (Press CTRL+C to quit)
[2026-04-20 21:34:59] INFO:     127.0.0.1:37586 - "GET /model_info HTTP/1.1" 200 OK
[2026-04-20 21:35:08 ATTN_CP1 MOE_DP1 TP2] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, cuda graph: False, input throughput (token/s): 0.99
[2026-04-20 21:35:08 ATTN_CP0 MOE_DP0 TP0] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, cuda graph: False, input throughput (token/s): 0.98
[2026-04-20 21:35:09] INFO:     127.0.0.1:37598 - "POST /generate HTTP/1.1" 200 OK
[2026-04-20 21:35:09] The server is fired up and ready to roll!
[2026-04-20 21:38:17 ATTN_CP1 MOE_DP1 TP2] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, cuda graph: False, input throughput (token/s): 0.34
[2026-04-20 21:38:17 ATTN_CP0 MOE_DP0 TP0] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, cuda graph: False, input throughput (token/s): 0.34
[2026-04-20 21:38:22 ATTN_CP1 MOE_DP1 TP2] Decode batch, #running-req: 1, #token: 64, token usage: 0.00, cuda graph: False, gen throughput (token/s): 0.15, #queue-req: 0
[2026-04-20 21:38:22 ATTN_CP0 MOE_DP0 TP0] Decode batch, #running-req: 1, #token: 64, token usage: 0.00, cuda graph: False, gen throughput (token/s): 0.15, #queue-req: 0
[2026-04-20 21:38:28 ATTN_CP1 MOE_DP1 TP2] Decode batch, #running-req: 1, #token: 128, token usage: 0.00, cuda graph: False, gen throughput (token/s): 6.71, #queue-req: 0
[2026-04-20 21:38:28 ATTN_CP0 MOE_DP0 TP0] Decode batch, #running-req: 1, #token: 128, token usage: 0.00, cuda graph: False, gen throughput (token/s): 6.71, #queue-req: 0
[2026-04-20 21:38:33 ATTN_CP1 MOE_DP1 TP2] Decode batch, #running-req: 1, #token: 128, token usage: 0.00, cuda graph: False, gen throughput (token/s): 6.91, #queue-req: 0
[2026-04-20 21:38:33 ATTN_CP0 MOE_DP0 TP0] Decode batch, #running-req: 1, #token: 128, token usage: 0.00, cuda graph: False, gen throughput (token/s): 6.91, #queue-req: 0
[2026-04-20 21:38:39 ATTN_CP1 MOE_DP1 TP2] Decode batch, #running-req: 1, #token: 192, token usage: 0.00, cuda graph: False, gen throughput (token/s): 6.92, #queue-req: 0
[2026-04-20 21:38:39 ATTN_CP0 MOE_DP0 TP0] Decode batch, #running-req: 1, #token: 192, token usage: 0.00, cuda graph: False, gen throughput (token/s): 6.92, #queue-req: 0
[2026-04-20 21:38:45 ATTN_CP1 MOE_DP1 TP2] Decode batch, #running-req: 1, #token: 256, token usage: 0.00, cuda graph: False, gen throughput (token/s): 6.85, #queue-req: 0
[2026-04-20 21:38:45 ATTN_CP0 MOE_DP0 TP0] Decode batch, #running-req: 1, #token: 256, token usage: 0.00, cuda graph: False, gen throughput (token/s): 6.85, #queue-req: 0
[2026-04-20 21:38:51 ATTN_CP1 MOE_DP1 TP2] Decode batch, #running-req: 1, #token: 256, token usage: 0.00, cuda graph: False, gen throughput (token/s): 6.93, #queue-req: 0
[2026-04-20 21:38:51 ATTN_CP0 MOE_DP0 TP0] Decode batch, #running-req: 1, #token: 256, token usage: 0.00, cuda graph: False, gen throughput (token/s): 6.93, #queue-req: 0
[2026-04-20 21:38:57 ATTN_CP1 MOE_DP1 TP2] Decode batch, #running-req: 1, #token: 320, token usage: 0.00, cuda graph: False, gen throughput (token/s): 6.92, #queue-req: 0
[2026-04-20 21:38:57 ATTN_CP0 MOE_DP0 TP0] Decode batch, #running-req: 1, #token: 320, token usage: 0.00, cuda graph: False, gen throughput (token/s): 6.92, #queue-req: 0
[2026-04-20 21:39:01] INFO:     127.0.0.1:48726 - "POST /generate HTTP/1.1" 200 OK

python3 python/sglang/test/few_shot_gsm8k.py
100%|█████████████████████| 200/200 [06:41<00:00,  2.01s/it]
Accuracy: 0.950
Invalid: 0.000
Latency: 402.374 s
Output throughput: 56.843 token/s
```

## Speed Tests and Profiling

No measurable performance regression. CP workloads now run successfully on MUSA backend.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.