### PR TITLE
[CI] Install protoc + Rust toolchain in rerun-test-cpu

### DIFF
--- a/.github/workflows/rerun-test.yml
+++ b/.github/workflows/rerun-test.yml
@@ -138,6 +138,14 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
+      # Needed by setuptools-rust to build the bundled native gRPC extension
+      # (rust/sglang-grpc) when installing the main `sglang` wheel from source.
+      - name: Install protoc
+        run: sudo bash scripts/ci/utils/install_protoc.sh
+
+      - name: Install Rust toolchain
+        run: bash scripts/ci/utils/install_rustup.sh
+
       - name: Install dependencies
         timeout-minutes: 20
         env:


### PR DESCRIPTION
## Summary
- `rerun-test.yml`'s `rerun-test-cpu` job was running `uv pip install -e \"python[dev]\"` without first installing `protoc` or the Rust toolchain, so builds of the bundled `rust/sglang-grpc` extension (added in #22736) failed with `Could not find \`protoc\``.
- Mirror `pr-test.yml:646-652` by invoking the shared `scripts/ci/utils/install_protoc.sh` and `scripts/ci/utils/install_rustup.sh` utilities before the pip install step.

## Context
Example failure: https://github.com/sgl-project/sglang/actions/runs/24679201427/job/72171535463 — the CPU rerun job dies at the `Install dependencies` step with:

```
Error: Could not find \`protoc\`.
```

The CUDA rerun job already goes through `scripts/ci/cuda/ci_install_dependency.sh`, which installs both tools, so only the CPU path was broken.

## Test plan
- [ ] Trigger a `rerun-test-cpu` run and confirm the `Install protoc` + `Install Rust toolchain` steps succeed and the subsequent pip install now builds `rust/sglang-grpc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)