### PR TITLE
[CI] Fix nightly docker builds failing on root-owned workspace leftovers

### DIFF
--- a/.github/workflows/patch-docker-dev.yml
+++ b/.github/workflows/patch-docker-dev.yml
@@ -20,6 +20,9 @@ jobs:
     if: github.repository == 'sgl-project/sglang'
     runs-on: x64-docker-build-node
     steps:
+      - name: Cleanup workspace (remove root-owned files from prior runs)
+        run: sudo rm -rf "$GITHUB_WORKSPACE"/* || true
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-docker-dev.yml
+++ b/.github/workflows/release-docker-dev.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Delete huge unnecessary tools folder
         run: rm -rf /opt/hostedtoolcache
 
+      - name: Cleanup workspace (remove root-owned files from prior runs)
+        run: sudo rm -rf "$GITHUB_WORKSPACE"/* || true
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-docker-runtime.yml
+++ b/.github/workflows/release-docker-runtime.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Delete huge unnecessary tools folder
         run: rm -rf /opt/hostedtoolcache
 
+      - name: Cleanup workspace (remove root-owned files from prior runs)
+        run: sudo rm -rf "$GITHUB_WORKSPACE"/* || true
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -139,6 +142,9 @@ jobs:
     steps:
       - name: Delete huge unnecessary tools folder
         run: rm -rf /opt/hostedtoolcache
+
+      - name: Cleanup workspace (remove root-owned files from prior runs)
+        run: sudo rm -rf "$GITHUB_WORKSPACE"/* || true
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Delete huge unnecessary tools folder
         run: rm -rf /opt/hostedtoolcache
 
+      - name: Cleanup workspace (remove root-owned files from prior runs)
+        run: sudo rm -rf "$GITHUB_WORKSPACE"/* || true
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -139,6 +142,9 @@ jobs:
     steps:
       - name: Delete huge unnecessary tools folder
         run: rm -rf /opt/hostedtoolcache
+
+      - name: Cleanup workspace (remove root-owned files from prior runs)
+        run: sudo rm -rf "$GITHUB_WORKSPACE"/* || true
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/trivy-scan-dev.yml
+++ b/.github/workflows/trivy-scan-dev.yml
@@ -24,6 +24,9 @@ jobs:
       matrix:
         tag: ${{ inputs.tag && fromJSON(format('["{0}"]', inputs.tag)) || fromJSON('["dev", "dev-cu13"]') }}
     steps:
+      - name: Cleanup workspace (remove root-owned files from prior runs)
+        run: sudo rm -rf "$GITHUB_WORKSPACE"/* || true
+
       - name: Checkout repository
         uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

- Fixes the nightly `Build and Push Development Docker Images` workflow (and siblings) failing at `actions/checkout@v4` with `EACCES: permission denied, rmdir '.../sgl-kernel/build/.cmake'` — see [run 24592533407](https://github.com/sgl-project/sglang/actions/runs/24592533407).
- Adds a `sudo rm -rf "$GITHUB_WORKSPACE"/*` cleanup step before checkout in every workflow that targets `x64-docker-build-node` / `arm-docker-build-node`.

## Root cause

The self-hosted runner `labubu` carries **both** `arm-docker-build-node` and `arm-kernel-build-node` labels (and `moirai-a10-runner-0` carries both x64 equivalents), so those workflows share a single `_work` directory.

`sgl-kernel/build.sh` runs the wheel build inside a container with a bind-mount of the workspace:

```bash
docker run --rm -v "$(pwd):/sgl-kernel" ... bash -c '... uv build --wheel -Cbuild-dir=build ...'
```

The container runs as root, so `sgl-kernel/build/` shows up on the host owned by root. When a subsequent `release-docker-*` run lands on the same runner, `actions/checkout@v4` can't `rmdir` those root-owned files and the strategy dies.

`pr-test.yml` already handles this for the kernel-build jobs ([line 431](https://github.com/sgl-project/sglang/blob/main/.github/workflows/pr-test.yml#L431), [line 479](https://github.com/sgl-project/sglang/blob/main/.github/workflows/pr-test.yml#L479)) — this PR mirrors the same `sudo rm -rf` step into every docker-build-node workflow so they stop tripping on each other's leftovers.

## Files changed

- `release-docker-dev.yml` (nightly — was failing)
- `release-docker.yml` (tagged releases)
- `release-docker-runtime.yml` (runtime image releases)
- `trivy-scan-dev.yml` (daily vuln scan of dev tags)
- `patch-docker-dev.yml` (manual patch workflow)

`create-manifests` jobs run on `ubuntu-22.04` (GitHub-hosted), so they don't need the step.

## Test plan

- [ ] Trigger `Build and Push Development Docker Images` via `workflow_dispatch` on this branch and confirm `build-dev` matrix completes past checkout on both `x86` and `arm64` nodes.
- [ ] Confirm the manifest job still publishes `dev` / `dev-cu13` tags end to end.
- [ ] Let the nightly cron run once on `main` after merge and verify it stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)