### PR TITLE
[Flashinfer] Integrate flashinfer router gemm for sm103

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -329,7 +329,7 @@ class MoEGate(nn.Module):
                 and (self.weight.shape[0] == 256 or self.weight.shape[0] == 384)
                 and _device_sm >= 90
             ):
-                if _device_sm == 100 and self.weight.shape[0] == 256:
+                if _device_sm in [100, 103] and self.weight.shape[0] == 256:
                     # router gemm output float32
                     logits = torch.empty(
                         hidden_states.shape[0],

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -334,7 +334,7 @@ class MoEGate(nn.Module):
                 and (self.weight.shape[0] == 256 or self.weight.shape[0] == 384)
                 and _device_sm >= 90
             ):
-                if _device_sm == 100 and self.weight.shape[0] == 256:
+                if _device_sm in [100, 103] and self.weight.shape[0] == 256:
                     # router gemm output float32
                     logits = torch.empty(
                         hidden_states.shape[0],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Depends on flashinfer version >= 0.6.8
Supporting PR in flashinfer: https://github.com/flashinfer-ai/flashinfer/pull/2991
Test result on sm103 needs to be posted later

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

```
python3 -m sglang.launch_server \
  --model-path nvidia/DeepSeek-V3.2-NVFP4 \
  --tp 4 \
  --ep 4 \
  --quantization modelopt_fp4 \
  --tool-call-parser deepseekv32 \
  --reasoning-parser deepseek-v3 \
  --port 30020
```

```
python3 -m sglang.test.run_eval \
  --port 30020 \
  --eval-name gpqa \
  --num-examples 198 \
  --max-tokens 128000 \
  --repeat 8 \
  --top-p 0.95 \
  --temperature 1.0 \
  --thinking-mode deepseek-v3
```

Result:
<img width="1468" height="243" alt="Screenshot 2026-04-25 at 1 41 03 AM" src="https://github.com/user-attachments/assets/965659b0-b767-4735-bfcf-f7a64ca6a720" />


Looks good.

```
root@sgl-b300-inference:/sgl-workspace/sglang# python /sgl-workspace/sglang/benchmark/kernels/deepseek/benchmark_deepgemm_dsv3_router_gemm_blackwell.py --tp-sizes 1 2 4
Running correctness tests...
Shape m=1, n=256, k=7168:
Using PDL=False
Flashinfer output: tensor([-17.9624,  43.4657, -15.9304, -63.4333, -69.3980], device='cuda:0')
SGLang output: tensor([-17.9624,  43.4657, -15.9304, -63.4333, -69.3980], device='cuda:0')
Correctness check:
  - Flashinfer vs SGLang: ✅
Shape m=2, n=256, k=7168:
Using PDL=False
Flashinfer output: tensor([ -58.0966,    2.5838,  120.5637,  -73.2267, -111.2808],
       device='cuda:0')
SGLang output: tensor([ -58.0966,    2.5838,  120.5637,  -73.2267, -111.2808],
       device='cuda:0')
Correctness check:
  - Flashinfer vs SGLang: ✅
Shape m=3, n=256, k=7168:
Using PDL=False
Flashinfer output: tensor([-64.0988,  28.5874, -88.4202, -38.3858,   5.1933], device='cuda:0')
SGLang output: tensor([-64.0988,  28.5874, -88.4202, -38.3858,   5.1933], device='cuda:0')
Correctness check:
  - Flashinfer vs SGLang: ✅
Shape m=4, n=256, k=7168:
```

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
