### PR TITLE
guard adaptive speculative against unsupported configs

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3458,18 +3458,55 @@ class ServerArgs:
                 )
 
         if self.speculative_adaptive:
+            unsupported_reason = None
             if self.speculative_algorithm not in ("EAGLE", "EAGLE3"):
-                logger.warning(
-                    "speculative_adaptive is only supported with EAGLE/EAGLE3 and topk=1. "
-                    f"Current algorithm={self.speculative_algorithm}. "
-                    "Falling back to static params."
+                unsupported_reason = (
+                    f"speculative_algorithm={self.speculative_algorithm} "
+                    "(only EAGLE/EAGLE3 are supported)"
                 )
-                self.speculative_adaptive = False
             elif self.speculative_eagle_topk != 1:
+                unsupported_reason = (
+                    f"speculative_eagle_topk={self.speculative_eagle_topk} "
+                    "(only topk=1 is supported)"
+                )
+            elif self.enable_dp_attention:
+                # Per-rank local accept_lengths diverge across DP ranks, producing
+                # different EMA decisions and mismatched CUDA graph shapes.
+                unsupported_reason = (
+                    "enable_dp_attention=True is not supported "
+                    "(adaptive tier decisions are not synchronized across DP ranks)"
+                )
+            elif not self.disable_overlap_schedule:
+                # Worker factory selects EAGLEWorkerV2 when overlap is on, and
+                # AdaptiveController is only wired into EAGLEWorker v1.
+                unsupported_reason = (
+                    "the overlap scheduler (spec v2) is enabled "
+                    "(adaptive is only implemented for EAGLEWorker v1)"
+                )
+            elif self.enable_multi_layer_eagle:
+                unsupported_reason = (
+                    "enable_multi_layer_eagle=True is not supported "
+                    "(MultiLayerEagleWorker does not implement adaptive)"
+                )
+            elif self.enable_two_batch_overlap:
+                # TboAttnBackend wraps the target attn_backend; adaptive state
+                # swap would replace it with a raw backend and break TBO.
+                unsupported_reason = (
+                    "enable_two_batch_overlap=True is not supported "
+                    "(adaptive state swap would discard the TboAttnBackend wrapper)"
+                )
+            elif self.enable_pdmux:
+                # pdmux maintains decode_attn_backend_group alongside attn_backend;
+                # adaptive only swaps attn_backend, leaving the group stale.
+                unsupported_reason = (
+                    "enable_pdmux=True is not supported "
+                    "(adaptive state swap does not update decode_attn_backend_group)"
+                )
+
+            if unsupported_reason is not None:
                 logger.warning(
-                    "speculative_adaptive is only supported with topk=1. "
-                    f"Current topk={self.speculative_eagle_topk}. "
-                    "Falling back to static params."
+                    f"speculative_adaptive disabled: {unsupported_reason}. "
+                    "Falling back to static speculative params."
                 )
                 self.speculative_adaptive = False
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3458,46 +3458,14 @@ class ServerArgs:
                 )
 
         if self.speculative_adaptive:
-            unsupported_reason = None
-            if self.speculative_algorithm not in ("EAGLE", "EAGLE3"):
-                unsupported_reason = (
-                    f"speculative_algorithm={self.speculative_algorithm} "
-                    "(only EAGLE/EAGLE3 are supported)"
-                )
-            elif self.speculative_eagle_topk != 1:
-                unsupported_reason = (
-                    f"speculative_eagle_topk={self.speculative_eagle_topk} "
-                    "(only topk=1 is supported)"
-                )
-            elif self.enable_dp_attention:
-                unsupported_reason = (
-                    "enable_dp_attention=True is not supported "
-                    "(adaptive tier decisions are not synchronized across DP ranks)"
-                )
-            elif not self.disable_overlap_schedule:
-                unsupported_reason = (
-                    "the overlap scheduler (spec v2) is enabled "
-                    "(adaptive is only implemented for EAGLEWorker v1)"
-                )
-            elif self.enable_multi_layer_eagle:
-                unsupported_reason = (
-                    "enable_multi_layer_eagle=True is not supported "
-                    "(MultiLayerEagleWorker does not implement adaptive)"
-                )
-            elif self.enable_two_batch_overlap:
-                unsupported_reason = (
-                    "enable_two_batch_overlap=True is not supported "
-                    "(adaptive state swap would discard the TboAttnBackend wrapper)"
-                )
-            elif self.enable_pdmux:
-                unsupported_reason = (
-                    "enable_pdmux=True is not supported "
-                    "(adaptive state swap does not update decode_attn_backend_group)"
-                )
+            from sglang.srt.speculative.adaptive_spec_params import (
+                adaptive_unsupported_reason,
+            )
 
-            if unsupported_reason is not None:
+            reason = adaptive_unsupported_reason(self)
+            if reason is not None:
                 logger.warning(
-                    f"speculative_adaptive disabled: {unsupported_reason}. "
+                    f"speculative_adaptive disabled: {reason}. "
                     "Falling back to static speculative params."
                 )
                 self.speculative_adaptive = False

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3470,15 +3470,11 @@ class ServerArgs:
                     "(only topk=1 is supported)"
                 )
             elif self.enable_dp_attention:
-                # Per-rank local accept_lengths diverge across DP ranks, producing
-                # different EMA decisions and mismatched CUDA graph shapes.
                 unsupported_reason = (
                     "enable_dp_attention=True is not supported "
                     "(adaptive tier decisions are not synchronized across DP ranks)"
                 )
             elif not self.disable_overlap_schedule:
-                # Worker factory selects EAGLEWorkerV2 when overlap is on, and
-                # AdaptiveController is only wired into EAGLEWorker v1.
                 unsupported_reason = (
                     "the overlap scheduler (spec v2) is enabled "
                     "(adaptive is only implemented for EAGLEWorker v1)"
@@ -3489,15 +3485,11 @@ class ServerArgs:
                     "(MultiLayerEagleWorker does not implement adaptive)"
                 )
             elif self.enable_two_batch_overlap:
-                # TboAttnBackend wraps the target attn_backend; adaptive state
-                # swap would replace it with a raw backend and break TBO.
                 unsupported_reason = (
                     "enable_two_batch_overlap=True is not supported "
                     "(adaptive state swap would discard the TboAttnBackend wrapper)"
                 )
             elif self.enable_pdmux:
-                # pdmux maintains decode_attn_backend_group alongside attn_backend;
-                # adaptive only swaps attn_backend, leaving the group stale.
                 unsupported_reason = (
                     "enable_pdmux=True is not supported "
                     "(adaptive state swap does not update decode_attn_backend_group)"

--- a/python/sglang/srt/speculative/adaptive_spec_params.py
+++ b/python/sglang/srt/speculative/adaptive_spec_params.py
@@ -5,8 +5,52 @@ Adjusts speculative_num_steps at runtime based on observed acceptance lengths.
 
 import json
 import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sglang.srt.server_args import ServerArgs
 
 logger = logging.getLogger(__name__)
+
+
+def adaptive_unsupported_reason(server_args: "ServerArgs") -> str | None:
+    """Return why adaptive spec cannot run under the given server args, or None if supported."""
+    if server_args.speculative_algorithm not in ("EAGLE", "EAGLE3"):
+        return (
+            f"speculative_algorithm={server_args.speculative_algorithm} "
+            "(only EAGLE/EAGLE3 are supported)"
+        )
+    if server_args.speculative_eagle_topk != 1:
+        return (
+            f"speculative_eagle_topk={server_args.speculative_eagle_topk} "
+            "(only topk=1 is supported)"
+        )
+    if server_args.enable_dp_attention:
+        return (
+            "enable_dp_attention=True is not supported "
+            "(adaptive tier decisions are not synchronized across DP ranks)"
+        )
+    if not server_args.disable_overlap_schedule:
+        return (
+            "the overlap scheduler (spec v2) is enabled "
+            "(adaptive is only implemented for EAGLEWorker v1)"
+        )
+    if server_args.enable_multi_layer_eagle:
+        return (
+            "enable_multi_layer_eagle=True is not supported "
+            "(MultiLayerEagleWorker does not implement adaptive)"
+        )
+    if server_args.enable_two_batch_overlap:
+        return (
+            "enable_two_batch_overlap=True is not supported "
+            "(adaptive state swap would discard the TboAttnBackend wrapper)"
+        )
+    if server_args.enable_pdmux:
+        return (
+            "enable_pdmux=True is not supported "
+            "(adaptive state swap does not update decode_attn_backend_group)"
+        )
+    return None
 
 
 def load_adaptive_config(path: str | None) -> dict[str, object]:

--- a/python/sglang/srt/speculative/adaptive_spec_params.py
+++ b/python/sglang/srt/speculative/adaptive_spec_params.py
@@ -3,6 +3,8 @@
 Adjusts speculative_num_steps at runtime based on observed acceptance lengths.
 """
 
+from __future__ import annotations
+
 import json
 import logging
 from typing import TYPE_CHECKING
@@ -13,7 +15,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def adaptive_unsupported_reason(server_args: "ServerArgs") -> str | None:
+def adaptive_unsupported_reason(server_args: ServerArgs) -> str | None:
     """Return why adaptive spec cannot run under the given server args, or None if supported."""
     if server_args.speculative_algorithm not in ("EAGLE", "EAGLE3"):
         return (


### PR DESCRIPTION
Falls back to static speculative params when `--speculative-adaptive` is combined with a config that the adaptive path does not implement: `enable_dp_attention`, overlap scheduler / spec v2, `enable_multi_layer_eagle`, `enable_two_batch_overlap`, `enable_pdmux`. Follow-up to #21599.