### PR TITLE
[fix] Qwen3.5 (VL) inference device mismatch in get_rope_index multimodal position id construction

### DIFF
--- a/python/sglang/srt/layers/rotary_embedding/mrope_rope_index.py
+++ b/python/sglang/srt/layers/rotary_embedding/mrope_rope_index.py
@@ -146,7 +146,10 @@ def get_rope_index(
                     llm_pos_ids_list[-1].max() + 1 if len(llm_pos_ids_list) > 0 else 0
                 )
                 llm_pos_ids_list.append(
-                    torch.arange(text_len).view(1, -1).expand(3, -1) + st_idx
+                    torch.arange(text_len, device=position_ids.device)
+                    .view(1, -1)
+                    .expand(3, -1)
+                    + st_idx
                 )
                 if model_type in ("qwen2_5_vl", "paddleocr_vl"):
                     range_tensor = torch.arange(llm_grid_t).view(-1, 1)
@@ -190,7 +193,10 @@ def get_rope_index(
                 )
                 text_len = len(input_tokens) - st
                 llm_pos_ids_list.append(
-                    torch.arange(text_len).view(1, -1).expand(3, -1) + st_idx
+                    torch.arange(text_len, device=position_ids.device)
+                    .view(1, -1)
+                    .expand(3, -1)
+                    + st_idx
                 )
             llm_positions = torch.cat(llm_pos_ids_list, dim=1).reshape(3, -1)
             position_ids[..., i, :] = llm_positions.to(position_ids.device)
@@ -293,7 +299,10 @@ def get_rope_index_qwen3_omni(
                 text_len = min_ed - st
                 if text_len != 0:
                     llm_pos_ids_list.append(
-                        torch.arange(text_len).view(1, -1).expand(3, -1) + st_idx
+                        torch.arange(text_len, device=position_ids.device)
+                        .view(1, -1)
+                        .expand(3, -1)
+                        + st_idx
                     )
                     st_idx += text_len
                 if min_ed == ed_vision_start and ed_vision_start + 1 == ed_audio_start:
@@ -453,7 +462,10 @@ def get_rope_index_qwen3_omni(
                 )
                 text_len = len(input_tokens) - st
                 llm_pos_ids_list.append(
-                    torch.arange(text_len).view(1, -1).expand(3, -1) + st_idx
+                    torch.arange(text_len, device=position_ids.device)
+                    .view(1, -1)
+                    .expand(3, -1)
+                    + st_idx
                 )
             llm_positions = torch.cat(
                 [item.float() for item in llm_pos_ids_list], dim=1
@@ -802,7 +814,10 @@ def get_rope_index_ernie45(
                 else:
                     text_len = end_idx - start_idx
                     llm_pos_ids_list.append(
-                        torch.arange(text_len).view(1, -1).expand(3, -1) + st_idx
+                        torch.arange(text_len, device=position_ids.device)
+                        .view(1, -1)
+                        .expand(3, -1)
+                        + st_idx
                     )
                     video_frame_num = 1
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

In `python/sglang/srt/layers/rotary_embedding/mrope_rope_index.py`, the multimodal `get_rope_index` builds the position ids by concatenating the vision position ids (`h,w,t_index`) with the text position ids, `torch.arange(text_len)`, and some offset. However, a device mismatch occurs because `h,w,t_index` is put on the same device of the position_ids by specification but `torch.arange(text_len)` implicitly places it on `cpu`, which manifests when we are training on cuda or any non-cpu device as:

`RuntimeError: Expected all tensors to be on the same device,
  but found at least two devices, cuda:0 and cpu!`

This occurs especially when employing sglang for inference on VLMs.

## Modifications

Added bug-fix for device mismatch in mrope applications used in VLM inference. Specified the text position ids to have device matching position_ids just like the vision position ids: `torch.arange(text_ids, device=position_ids.device)`

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
n/a

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
n/a

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
