### PR TITLE
[CI] Clean up stale cu12 packages before cu13 installs

### DIFF
--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -282,6 +282,19 @@ FLASHINFER_UNINSTALL="flashinfer-python"
 $PIP_UNINSTALL_CMD $FLASHINFER_UNINSTALL $PIP_UNINSTALL_SUFFIX || true
 $PIP_UNINSTALL_CMD opencv-python opencv-python-headless $PIP_UNINSTALL_SUFFIX || true
 
+# Runner-state robustness: flashinfer-python and flashinfer-cubin co-own files
+# under flashinfer/data/. Uninstalling only python leaves the dir; the next
+# `uv pip install` then fails with `mkdir flashinfer/data/: File exists`. Wipe
+# the tree and force cubin to reinstall so both packages land atomically.
+SITE_PACKAGES=$(python3 -c 'import site; print(site.getsitepackages()[0])' 2>/dev/null || true)
+if [ -n "$SITE_PACKAGES" ] && [ -d "$SITE_PACKAGES/flashinfer" ]; then
+    rm -rf "$SITE_PACKAGES/flashinfer"
+    if [ "$UNINSTALL_CUBIN" = false ]; then
+        $PIP_UNINSTALL_CMD flashinfer-cubin $PIP_UNINSTALL_SUFFIX || true
+        UNINSTALL_CUBIN=true
+    fi
+fi
+
 mark_step_done "Uninstall Flashinfer"
 
 # ------------------------------------------------------------------------------
@@ -295,6 +308,12 @@ fi
 echo "Installing python extras: [${EXTRAS}]"
 # source "${SCRIPT_DIR}/cache_nvidia_wheels.sh"
 $PIP_CMD install -e "python[${EXTRAS}]" $PIP_INSTALL_SUFFIX
+
+# Runner-state robustness: orphan cu12 runtime drags libcudart.so.12 onto
+# LD_LIBRARY_PATH next to cu13's libcudart.so.13, which trips cudnn_frontend's
+# dlopen probe (`Multiple libcudart libraries found`). Its install dir is
+# disjoint from cu13's so dropping it doesn't touch any shared files.
+$PIP_UNINSTALL_CMD nvidia-cuda-runtime-cu12 $PIP_UNINSTALL_SUFFIX || true
 
 mark_step_done "Install main package"
 
@@ -390,38 +409,32 @@ mark_step_done "Download flashinfer artifacts"
 # ------------------------------------------------------------------------------
 # Stabilize FlashInfer JIT cache paths
 # ------------------------------------------------------------------------------
-# FlashInfer JIT writes build.ninja with hardcoded -isystem paths pointing to the
-# venv's flashinfer/data/ and tvm_ffi/include/. With per-job venvs each job gets
-# a unique /tmp/sglang-ci-<run>-<job>-<pid>/ path, but the JIT cache is shared
-# on the host mount. When the next job's venv has a different path and the old one
-# is cleaned up, ninja fails because source files no longer exist at the cached path.
-#
-# Fix (two parts):
-# 1. Clear only STALE cached_ops (build.ninja referencing non-existent venv paths).
-#    Do NOT clear all cached_ops — they contain compiled .so files that take 10-20 min
-#    to recompile. Only remove entries where the source paths no longer exist.
-# 2. Copy source files to a stable host-mounted path and symlink each venv's
-#    copy there. build.ninja then references the stable path across all jobs.
-#
-# Part 1: Clear stale cached_ops (keep valid compiled kernels)
+# FlashInfer JIT writes build.ninja with absolute source paths. Two things make
+# them go stale on a long-lived runner: per-job venv dirs (/tmp/sglang-ci-*)
+# rotate under USE_VENV=1, and _stable_src/ (written by Part 2 below) only
+# exists while USE_VENV=1. Stale ninjas surface as
+#   "ninja: error: '<path>', needed by '<obj>', missing and no known rule".
+# Part 1: drop any cached_ops whose build.ninja references a missing source;
+# keeps already-compiled .so files intact (rebuilds are 10-20 min).
+# Part 2: under USE_VENV=1, materialize a stable source dir so build.ninja
+# paths survive venv rotation.
+if [ -d "${HOME}/.cache/flashinfer" ]; then
+    STALE_COUNT=0
+    while IFS= read -r ninja_file; do
+        missing=0
+        for p in $(grep -oE '/[^[:space:]:|]+\.(cu|cuh|cc|cpp|cxx|c|h|hpp)' "$ninja_file" 2>/dev/null | sort -u); do
+            [ -e "$p" ] || { missing=1; break; }
+        done
+        if [ "$missing" = 1 ]; then
+            rm -rf "$(dirname "$ninja_file")"
+            STALE_COUNT=$((STALE_COUNT + 1))
+        fi
+    done < <(find "${HOME}/.cache/flashinfer" -name "build.ninja" -type f 2>/dev/null)
+    echo "Cleaned $STALE_COUNT stale FlashInfer cached_ops (kept valid ones)"
+fi
+
 if [ "$USE_VENV" = "1" ]; then
     STABLE_FI_DIR="${HOME}/.cache/flashinfer/_stable_src"
-    if [ -d "${HOME}/.cache/flashinfer" ]; then
-        STALE_COUNT=0
-        while IFS= read -r ninja_file; do
-            # Check for stale venv paths (/tmp/sglang-ci-*) or old stable path (flashinfer-src)
-            STALE_PATH=$(grep -o '/tmp/sglang-ci-[^ ]*\|flashinfer-src' "$ninja_file" 2>/dev/null | head -1 || true)
-            if [ -n "$STALE_PATH" ]; then
-                if echo "$STALE_PATH" | grep -q "flashinfer-src" || [ ! -d "$STALE_PATH" ]; then
-                    rm -rf "$(dirname "$ninja_file")"
-                    STALE_COUNT=$((STALE_COUNT + 1))
-                fi
-            fi
-        done < <(find "${HOME}/.cache/flashinfer" -name "build.ninja" -type f 2>/dev/null)
-        echo "Cleaned $STALE_COUNT stale FlashInfer cached_ops (kept valid ones)"
-    fi
-
-    # Part 2: Stabilize paths (STABLE_FI_DIR set above in Part 1)
     FI_DATA=$(python3 -c "import flashinfer, os; print(os.path.join(os.path.dirname(flashinfer.__file__), 'data'))")
     TVM_INC=$(python3 -c "import tvm_ffi, os; print(os.path.join(os.path.dirname(tvm_ffi.__file__), 'include'))")
 
@@ -459,6 +472,14 @@ fi
 if [ "$CU_MAJOR" = "13" ]; then
     MOONCAKE_PKG="mooncake-transfer-engine-cuda13==0.3.10.post1"
     EXTRA_NVIDIA_SPECS="nvidia-cuda-nvrtc"
+    # Remove cu12 variants left over from prior runs. Two distinct failure modes:
+    #   - mooncake-transfer-engine shares the `mooncake_engine` Python module
+    #     name with the cu13 package; the stale one gets imported instead.
+    #   - nvidia-cuda-nvrtc-cu12 drops libnvrtc.so.12 next to cu13's libnvrtc,
+    #     same LD_LIBRARY_PATH dual-so problem as the cu12 runtime at line 312.
+    # Kept on separate lines so a missing one doesn't short-circuit the other.
+    $PIP_UNINSTALL_CMD mooncake-transfer-engine $PIP_UNINSTALL_SUFFIX || true
+    $PIP_UNINSTALL_CMD nvidia-cuda-nvrtc-cu12 $PIP_UNINSTALL_SUFFIX || true
 else
     MOONCAKE_PKG="mooncake-transfer-engine==0.3.10.post1"
     EXTRA_NVIDIA_SPECS="nvidia-cuda-nvrtc-cu12"


### PR DESCRIPTION
## Motivation

On long-lived CI runners that share Python environments across jobs, leftover cu12 packages collide with their cu13 replacements. We hit three distinct failure modes on cu13 runners:

1. **Mooncake PD disaggregation misbehaves on GB300** — `mooncake-transfer-engine` (cu12 wheel) shares the `mooncake_engine` module name with `mooncake-transfer-engine-cuda13`, so after a prior cu12 run the stale module wins the import race and the cu13 install never actually takes effect.
2. **`mkdir flashinfer/data/: File exists`** on fresh `uv pip install flashinfer-python` — when `flashinfer-cubin` is kept across jobs but `flashinfer-python` is uninstalled, `flashinfer/data/` is left behind (both packages co-own it) and the next install aborts.
3. **`Multiple libcudart libraries found: libcudart.so.12 and libcudart.so.13`** from `cudnn_frontend_shim.h` on SM120 runners — an orphan `nvidia-cuda-runtime-cu12` wheel ships `libcudart.so.12` that lands on `LD_LIBRARY_PATH` next to cu13's `libcudart.so.13`.

Items 2 and 3 (and the FlashInfer JIT cache rework) port the `ci_install_dependency.sh` logic from #23183.

## Modifications

All changes are in `scripts/ci/cuda/ci_install_dependency.sh`:

- **CU_MAJOR=13 branch** — uninstall `mooncake-transfer-engine` and `nvidia-cuda-nvrtc-cu12` as two separate `|| true` lines so a missing package doesn't short-circuit the other.
- **After flashinfer uninstall block** — purge `$SITE_PACKAGES/flashinfer` and force `flashinfer-cubin` to reinstall, so the co-owned `flashinfer/data/` tree lands atomically.
- **After main install** — `$PIP_UNINSTALL_CMD nvidia-cuda-runtime-cu12 || true` to drop the orphan cu12 runtime before sgl-kernel's cudnn_frontend dlopen probe fires.
- **FlashInfer JIT stale-cache** — Part 1 moved out of the `USE_VENV=1` guard and rewritten to scan each `build.ninja` for missing source paths (matches `cu|cuh|cc|cpp|cxx|c|h|hpp`, replacing the old `/tmp/sglang-ci-*` string pattern that only worked for `USE_VENV=1`). Part 2 (stable_src symlinks) stays inside `USE_VENV=1`.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (N/A — CI install script changes; validated via CI.)
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy). (N/A — no runtime code paths touched.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).