### PR TITLE
Add test cases for data type, data parallelism and kernel backend.

### DIFF
--- a/python/sglang/test/ascend/output_capturer.py
+++ b/python/sglang/test/ascend/output_capturer.py
@@ -1,0 +1,117 @@
+import os
+import select
+import threading
+
+
+class OutputCapturer:
+    """Capture all console print information
+
+    Class Description:
+        Capture console output using low-level file descriptor redirection.
+        Used to obtain print information from child processes, NPU processes,
+        and underlying C/C++ modules that are not logged in sglang logs for test assertion.
+        All captured output will be displayed normally in the console in real-time.
+    """
+
+    def __init__(self):
+        """Initialize all member variables of the capturer"""
+        self.old_stdout = None
+        self.old_stderr = None
+        self.pipe_out = None
+        self.pipe_in = None
+        self.pipe_err_out = None
+        self.pipe_err_in = None
+        self.captured_stdout = []
+        self.captured_stderr = []
+        self.stop_thread = False
+        self.thread = None
+
+    def start(self):
+        """Start console output capture"""
+        # Duplicate and save original stdout/stderr file descriptors
+        self.old_stdout = os.dup(1)
+        self.old_stderr = os.dup(2)
+
+        # Create anonymous pipes for output redirection
+        self.pipe_out, self.pipe_in = os.pipe()
+        self.pipe_err_out, self.pipe_err_in = os.pipe()
+
+        # Redirect system stdout/stderr to the write end of pipes
+        os.dup2(self.pipe_in, 1)
+        os.dup2(self.pipe_err_in, 2)
+
+        # Close unused pipe write ends
+        os.close(self.pipe_in)
+        os.close(self.pipe_err_in)
+
+        # Start daemon thread to read output in real time
+        self.stop_thread = False
+        self.thread = threading.Thread(target=self._read_loop, daemon=True)
+        self.thread.start()
+
+    def _read_loop(self):
+        """The background process reads and prints pipeline data records in a loop."""
+        read_fds = [self.pipe_out, self.pipe_err_out]
+        while not self.stop_thread:
+            try:
+                # select listens to multiple file descriptors simultaneously, waiting for data in a non-blocking manner
+                readable, _, exceptional = select.select(read_fds, [], read_fds, 0.01)
+
+                # Processing file descriptors containing data
+                for fd in readable:
+                    if fd == self.pipe_out:
+                        data = os.read(fd, 4096)
+                        if data:
+                            self.captured_stdout.append(data)
+                            os.write(self.old_stdout, data)
+                    elif fd == self.pipe_err_out:
+                        err_data = os.read(fd, 4096)
+                        if err_data:
+                            self.captured_stderr.append(err_data)
+                            os.write(self.old_stderr, err_data)
+
+                for fd in exceptional:
+                    if fd in read_fds:
+                        self.stop()
+
+            except OSError:
+                self.stop()
+                break
+
+    def get_all(self):
+        """Get all captured stdout and stderr as UTF-8 string
+
+        Return: Decoded stdout and stderr string (ignore decoding errors)
+        """
+        return self.get_output() + self.get_error()
+
+    def get_output(self):
+        """Get all captured stdout as UTF-8 string
+
+        Return: Decoded stdout string (ignore decoding errors)
+        """
+        return b"".join(self.captured_stdout).decode("utf-8", errors="ignore")
+
+    def get_error(self):
+        """Get all captured stderr as UTF-8 string
+
+        Return: Decoded stderr string (ignore decoding errors)
+        """
+        return b"".join(self.captured_stderr).decode("utf-8", errors="ignore")
+
+    def stop(self):
+        """Stop capture and restore system environment"""
+        self.stop_thread = True
+        if self.thread:
+            self.thread.join(timeout=0.5)
+
+        # Restore original output
+        os.dup2(self.old_stdout, 1)
+        os.dup2(self.old_stderr, 2)
+
+        # Close all file descriptors
+        for fd in [self.pipe_out, self.pipe_err_out, self.old_stdout, self.old_stderr]:
+            try:
+                os.close(fd)
+            except (OSError, IOError):
+                pass

--- a/test/registered/ascend/basic_function/kernel_backends/test_npu_hybrid_attention_backend.py
+++ b/test/registered/ascend/basic_function/kernel_backends/test_npu_hybrid_attention_backend.py
@@ -1,0 +1,110 @@
+import os
+import unittest
+from types import SimpleNamespace
+from urllib.parse import urlparse
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=400, suite="nightly-1-npu-a3", nightly=True)
+
+GSM_DATASET_PATH = None
+
+# Default server arguments shared across all tests
+DEFAULT_SERVER_ARGS = [
+    "--trust-remote-code",
+    "--cuda-graph-max-bs",
+    "8",
+    "--prefill-attention-backend",
+    "ascend",
+    "--decode-attention-backend",
+    "ascend",
+    "--disable-cuda-graph",
+    "--mem-fraction-static",
+    0.9,
+    "--tp-size",
+    2,
+]
+
+
+class TestHybridAttnBackendBase(CustomTestCase):
+    """Testcase：Verify set --prefill-attention-backend, --decode-attention-backend, the inference request is successfully processed.
+
+    [Test Category] Parameter
+    [Test Target] --prefill-attention-backend, --decode-attention-backend
+    """
+
+    model = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+    base_url = DEFAULT_URL_FOR_TEST
+    accuracy_threshold = 0.36  # derived tests need to override this
+
+    @classmethod
+    def get_server_args(cls):
+        """Return the arguments for the server launch. Override in subclasses."""
+        return DEFAULT_SERVER_ARGS
+
+    @classmethod
+    def setUpClass(cls):
+        # disable deep gemm precompile to make launch server faster
+        # please don't do this if you want to make your inference workload faster
+        os.environ["SGL_JIT_DEEPGEMM_PRECOMPILE"] = "false"
+        os.environ["SGL_ENABLE_JIT_DEEPGEMM"] = "false"
+        model = cls.model
+        cls.process = popen_launch_server(
+            model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=cls.get_server_args(),
+        )
+        cls.host = urlparse(cls.base_url).hostname
+        cls.port = urlparse(cls.base_url).port
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        requests.get(self.base_url + "/flush_cache")
+
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="gsm8k",
+            api="completion",
+            max_tokens=512,
+            num_examples=200,
+            num_threads=64,
+            num_shots=8,
+        )
+        metrics = run_eval(args)
+
+        self.assertGreater(metrics["score"], self.accuracy_threshold)
+
+        response = requests.get(f"{self.base_url}/get_server_info")
+        self.assertEqual(
+            response.status_code, 200, "The request status code is not 200."
+        )
+        self.assertEqual(
+            response.json()["internal_states"][0]["prefill_attention_backend"],
+            "ascend",
+            "--prefill-attention-backend is not taking effect.",
+        )
+        self.assertEqual(
+            response.json()["internal_states"][0]["decode_attention_backend"],
+            "ascend",
+            "--decode-attention-backend is not taking effect.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/kernel_backends/test_npu_json_mode.py
+++ b/test/registered/ascend/basic_function/kernel_backends/test_npu_json_mode.py
@@ -1,0 +1,146 @@
+import json
+import logging
+import unittest
+
+import openai
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler()],
+)
+logger = logging.getLogger(__name__)
+
+register_npu_ci(est_time=400, suite="nightly-1-npu-a3", nightly=True)
+
+
+class TestJSONModeMixin:
+    """Mixin class containing JSON mode test methods"""
+
+    def test_json_mode_response(self):
+        """Test that response_format json_object (also known as "json mode") produces valid JSON, even without a system prompt that mentions JSON."""
+        response = self.client.chat.completions.create(
+            model=self.model,
+            messages=[
+                # We are deliberately omitting "That produces JSON" or similar phrases from the assistant prompt so that we don't have misleading test results
+                {
+                    "role": "system",
+                    "content": "You are a helpful AI assistant that gives a short answer.",
+                },
+                {"role": "user", "content": "What is the capital of Bulgaria?"},
+            ],
+            temperature=0,
+            max_tokens=128,
+            response_format={"type": "json_object"},
+        )
+        text = response.choices[0].message.content
+
+        logger.info("JSON mode response (%d characters): %s", len(text), text)
+
+        # Verify the response is valid JSON
+        try:
+            js_obj = json.loads(text)
+        except json.JSONDecodeError as e:
+            self.fail(f"Response is not valid JSON. Error: {e}. Response: {text}")
+
+        # Verify it's actually an object (dict)
+        self.assertIsInstance(js_obj, dict, f"Response is not a JSON object: {text}")
+
+    def test_json_mode_with_streaming(self):
+        """Test that streaming with json_object response (also known as "json mode") format works correctly, even without a system prompt that mentions JSON."""
+        stream = self.client.chat.completions.create(
+            model=self.model,
+            messages=[
+                # We are deliberately omitting "That produces JSON" or similar phrases from the assistant prompt so that we don't have misleading test results
+                {
+                    "role": "system",
+                    "content": "You are a helpful AI assistant that gives a short answer.",
+                },
+                {"role": "user", "content": "What is the capital of Bulgaria?"},
+            ],
+            temperature=0,
+            max_tokens=128,
+            response_format={"type": "json_object"},
+            stream=True,
+        )
+
+        # Collect all chunks
+        chunks = []
+        for chunk in stream:
+            if chunk.choices[0].delta.content is not None:
+                chunks.append(chunk.choices[0].delta.content)
+        full_response = "".join(chunks)
+
+        logger.info(
+            "Concatenated streamed JSON response (%d characters): %s",
+            len(full_response),
+            full_response,
+        )
+
+        # Verify the combined response is valid JSON
+        try:
+            js_obj = json.loads(full_response)
+        except json.JSONDecodeError as e:
+            self.fail(
+                f"Streamed response is not valid JSON. Error: {e}. Response: {full_response}"
+            )
+
+        self.assertIsInstance(js_obj, dict)
+
+
+class ServerWithGrammarBackend(CustomTestCase):
+    """Testcase: Base class for tests requiring a grammar backend server.
+
+    [Test Category] Parameter
+    [Test Target] --grammar-backend
+    """
+
+    backend = "xgrammar"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+
+        other_args = [
+            "--max-running-requests",
+            "10",
+            "--grammar-backend",
+            cls.backend,
+        ]
+
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+        )
+        cls.client = openai.Client(api_key="EMPTY", base_url=f"{cls.base_url}/v1")
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+
+class TestJSONModeXGrammar(ServerWithGrammarBackend, TestJSONModeMixin):
+    """Testcase: Verify JSON mode functionality with xgrammar grammar backend (non-streaming and streaming).
+
+    [Test Category] Parameter
+    [Test Target] --grammar-backend
+    """
+
+    backend = "xgrammar"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/kernel_backends/test_npu_mm_attention_backend.py
+++ b/test/registered/ascend/basic_function/kernel_backends/test_npu_mm_attention_backend.py
@@ -1,0 +1,59 @@
+import unittest
+
+from sglang.test.ascend.output_capturer import OutputCapturer
+from sglang.test.ascend.test_ascend_utils import GEMMA_3_4B_IT_WEIGHTS_PATH
+from sglang.test.ascend.vlm_utils import TestVLMModels
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(est_time=400, suite="nightly-4-npu-a3", nightly=True)
+
+
+class TestAscendMMAttentionBackend(TestVLMModels):
+    """Testcase: Verify MMMU dataset accuracy ≥0.2 for google/gemma-3-4b-it with --mm-attention-backend ascend_attn.
+
+    [Test Category] Parameter
+    [Test Target] --mm-attention-backend
+    """
+
+    mm_attention_backend = "ascend_attn"
+    model = GEMMA_3_4B_IT_WEIGHTS_PATH
+    mmmu_accuracy = 0.2
+    other_args = [
+        "--trust-remote-code",
+        "--cuda-graph-max-bs",
+        "32",
+        "--enable-multimodal",
+        "--mem-fraction-static",
+        0.35,
+        "--log-level",
+        "info",
+        "--attention-backend",
+        "ascend",
+        "--disable-cuda-graph",
+        "--tp-size",
+        4,
+        "--mm-attention-backend",
+        mm_attention_backend,
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.output = OutputCapturer()
+        cls.output.start()
+
+    def test_mmmu(self):
+        self._run_vlm_mmmu_test()
+        self.assertIn(
+            f"Using {self.mm_attention_backend} as multimodal attention backend.",
+            self.output.get_all(),
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        cls.output.stop()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/kernel_backends/test_npu_sampling_backend.py
+++ b/test/registered/ascend/basic_function/kernel_backends/test_npu_sampling_backend.py
@@ -1,0 +1,115 @@
+import unittest
+from types import SimpleNamespace
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=800, suite="nightly-1-npu-a3", nightly=True)
+
+
+class TestAscendSamplingBackend(CustomTestCase):
+    """Testcase：When --sampling-backend=pytorch or ascend, verify the MMLU dataset accuracy (>0.65) and greedy sampling consistency of the Llama-3.1-8B-Instruct mode
+
+    [Test Category] Parameter
+    [Test Target] --sampling-backend;
+    """
+
+    sampling_backend = "ascend"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = LLAMA_3_1_8B_INSTRUCT_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+                "--sampling-backend",
+                cls.sampling_backend,
+                "--disable-radix-cache",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_mmlu(self):
+        """Verify MMLU dataset evaluation accuracy meets the minimum requirement (score ≥ 0.65)"""
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="mmlu",
+            num_examples=64,
+            num_threads=32,
+            temperature=0.1,
+        )
+
+        metrics = run_eval(args)
+        self.assertGreaterEqual(metrics["score"], 0.65)
+
+    def test_greedy(self):
+        """Verify greedy sampling consistency (identical results for single/batch requests with temperature=0)"""
+
+        first_text = None
+
+        # 1. Verify consistency of results for 5 consecutive single requests
+        for _ in range(5):
+            response_single = requests.post(
+                self.base_url + "/generate",
+                json={
+                    "text": "The capital of Germany is",
+                    "sampling_params": {
+                        "temperature": 0,
+                        "max_new_tokens": 32,
+                    },
+                },
+            ).json()
+            text = response_single["text"]
+            if first_text is None:
+                first_text = text
+
+            self.assertEqual(text, first_text)
+
+        first_text = None
+
+        # 2. Send a batch request with 10 identical prompts
+        response_batch = requests.post(
+            self.base_url + "/generate",
+            json={
+                "text": ["The capital of Germany is"] * 10,
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": 32,
+                },
+            },
+        ).json()
+
+        # 3. Verify consistency of results within the batch response
+        for i in range(10):
+            text = response_batch[i]["text"]
+            if first_text is None:
+                first_text = text
+            self.assertEqual(text, first_text)
+
+
+class TestPyTorchSamplingBackend(TestAscendSamplingBackend):
+    sampling_backend = "pytorch"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/parallel_strategy/data_parallelism/test_npu_load_balance_method.py
+++ b/test/registered/ascend/basic_function/parallel_strategy/data_parallelism/test_npu_load_balance_method.py
@@ -1,0 +1,120 @@
+import random
+import unittest
+from types import SimpleNamespace
+from urllib.parse import urlparse
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import DEEPSEEK_R1_0528_W8A8_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    is_in_ci,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=700, suite="nightly-16-npu-a3", nightly=True)
+
+
+class TestDPAttentionRoundBinLoadBalance(CustomTestCase):
+    """Testcase：Verify that the model accuracy did not decrease when --load-balance-method is set to round_robin, auto,
+    total_requests or total_tokens in PD mixed scenario
+
+    [Test Category] Parameter
+    [Test Target] --load-balance-method
+    """
+
+    mode = "round_robin"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model_path = DEEPSEEK_R1_0528_W8A8_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.url = urlparse(cls.base_url)
+        other_args = [
+            "--trust-remote-code",
+            "--tp",
+            "16",
+            "--enable-dp-attention",
+            "--dp",
+            "2",
+            "--enable-torch-compile",
+            "--torch-compile-max-bs",
+            "2",
+            "--load-balance-method",
+            cls.mode,
+            "--attention-backend",
+            "ascend",
+            "--disable-cuda-graph",
+            "--quantization",
+            "modelslim",
+            "--mem-fraction-static",
+            "0.75",
+        ]
+
+        cls.process = popen_launch_server(
+            cls.model_path,
+            cls.base_url,
+            timeout=3 * DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            num_shots=5,
+            data_path=None,
+            num_questions=200,
+            max_new_tokens=512,
+            parallel=128,
+            host=f"http://{self.url.hostname}",
+            port=int(self.url.port),
+        )
+
+        metrics = run_eval_few_shot_gsm8k(args)
+        self.assertGreaterEqual(
+            metrics["accuracy"],
+            0.95,
+        )
+
+    def test_server_info(self):
+        response = requests.get(f"{self.base_url}/get_server_info")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(self.mode, response.text)
+
+
+class _TestDPAttentionAutoLoadBalance(TestDPAttentionRoundBinLoadBalance):
+    mode = "auto"
+
+
+class _TestDPAttentionTotalRequestsLoadBalance(TestDPAttentionRoundBinLoadBalance):
+    mode = "total_requests"
+
+
+class _TestDPAttentionTotalTokensLoadBalance(TestDPAttentionRoundBinLoadBalance):
+    mode = "total_tokens"
+
+
+if __name__ == "__main__":
+    # To reduce the CI execution time.
+    if is_in_ci():
+        loader = unittest.TestLoader()
+        suite = unittest.TestSuite()
+        RUN_FLAG = [
+            TestDPAttentionRoundBinLoadBalance,
+            _TestDPAttentionAutoLoadBalance,
+            _TestDPAttentionTotalRequestsLoadBalance,
+            _TestDPAttentionTotalTokensLoadBalance,
+        ]
+        suite.addTests(loader.loadTestsFromTestCase(random.choice(RUN_FLAG)))
+        runner = unittest.TextTestRunner()
+        runner.run(suite)
+    else:
+        unittest.main()

--- a/test/registered/ascend/basic_function/parallel_strategy/data_parallelism/test_npu_load_balance_method_pd_disaggregation.py
+++ b/test/registered/ascend/basic_function/parallel_strategy/data_parallelism/test_npu_load_balance_method_pd_disaggregation.py
@@ -1,0 +1,208 @@
+import itertools
+import json
+import os
+import random
+import unittest
+from time import sleep
+from types import SimpleNamespace
+from typing import List, Type
+from urllib.parse import urlparse
+
+import requests
+
+from sglang.test.ascend.disaggregation_utils import TestDisaggregationBase
+from sglang.test.ascend.test_ascend_utils import (
+    QWEN3_30B_A3B_INSTRUCT_2507_WEIGHTS_PATH,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    is_in_ci,
+    popen_launch_pd_server,
+)
+
+register_npu_ci(est_time=3600, suite="nightly-4-npu-a3", nightly=True)
+
+load_balance_method_options = [
+    "auto",
+    "round_robin",
+    "total_requests",
+    "total_tokens",
+    "follow_bootstrap_room",
+]
+all_params = list(itertools.product(load_balance_method_options, repeat=2))
+
+
+class BaseTestNPULoadBalanceMethodDPDisaggregation(TestDisaggregationBase):
+    """Testcase：Verify that the model accuracy did not decrease when --load-balance-method is set to round_robin, auto,
+    total_requests, total_tokens or follow_bootstrap_room in PD disaggregation scenario
+
+    [Test Category] Parameter
+    [Test Target] --load-balance-method
+    """
+
+    params = ("auto", "auto")
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.prefill_load_balance_method, cls.decode_load_balance_method = cls.params
+        cls.model = QWEN3_30B_A3B_INSTRUCT_2507_WEIGHTS_PATH
+        os.environ["ASCEND_MF_STORE_URL"] = "tcp://127.0.0.1:24666"
+
+        # Non blocking start servers
+        cls.start_prefill()
+        cls.start_decode()
+
+        # Block until both
+        cls.wait_server_ready(cls.prefill_url + "/health")
+        cls.wait_server_ready(cls.decode_url + "/health")
+
+        cls.launch_lb()
+        cls.url = urlparse(cls.lb_url)
+
+    @classmethod
+    def start_prefill(cls):
+        prefill_args = [
+            "--disaggregation-mode",
+            "prefill",
+            "--tp-size",
+            "2",
+            "--enable-dp-attention",
+            "--dp",
+            "2",
+            "--load-balance-method",
+            cls.prefill_load_balance_method,
+            "--disaggregation-transfer-backend",
+            "ascend",
+            "--disable-cuda-graph",
+            "--attention-backend",
+            "ascend",
+            "--mem-fraction-static",
+            0.8,
+            "--dist-init-addr",
+            "127.0.0.1:10100",
+            "--base-gpu-id",
+            4,
+        ]
+
+        cls.process_prefill = popen_launch_pd_server(
+            cls.model,
+            cls.prefill_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=prefill_args,
+        )
+
+    @classmethod
+    def start_decode(cls):
+        decode_args = [
+            "--disaggregation-mode",
+            "decode",
+            "--base-gpu-id",
+            2,
+            "--tp-size",
+            "2",
+            "--enable-dp-attention",
+            "--dp",
+            "2",
+            "--load-balance-method",
+            cls.decode_load_balance_method,
+            "--disaggregation-transfer-backend",
+            "ascend",
+            "--disable-cuda-graph",
+            "--attention-backend",
+            "ascend",
+            "--mem-fraction-static",
+            0.8,
+            "--dist-init-addr",
+            "127.0.0.1:10000",
+        ]
+
+        cls.process_decode = popen_launch_pd_server(
+            cls.model,
+            cls.decode_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=decode_args,
+        )
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            num_shots=5,
+            data_path=None,
+            num_questions=200,
+            max_new_tokens=512,
+            parallel=128,
+            host=f"http://{self.url.hostname}",
+            port=int(self.url.port),
+        )
+
+        metrics = run_eval_few_shot_gsm8k(args)
+        self.assertGreaterEqual(
+            metrics["accuracy"],
+            # 0.95 with 0.02 tolerable fluctuation
+            0.93,
+        )
+
+    def test_server_info(self):
+        response = requests.get(f"{self.lb_url}/get_server_info")
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.text)
+        self.assertEqual(
+            (
+                "follow_bootstrap_room"
+                if self.prefill_load_balance_method == "auto"
+                else self.prefill_load_balance_method
+            ),
+            data.get("prefill")[0].get("load_balance_method"),
+        )
+        self.assertEqual(
+            (
+                "round_robin"
+                if self.decode_load_balance_method == "auto"
+                else self.decode_load_balance_method
+            ),
+            data.get("decode")[0].get("load_balance_method"),
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        os.environ.pop("ASCEND_MF_STORE_URL")
+        super().tearDownClass()
+        # wait for server release source
+        sleep(10)
+
+
+TestClassType = Type[BaseTestNPULoadBalanceMethodDPDisaggregation]
+all_test_classes: List[TestClassType] = [BaseTestNPULoadBalanceMethodDPDisaggregation]
+for index, param_tuple in enumerate(all_params):
+    if param_tuple == BaseTestNPULoadBalanceMethodDPDisaggregation.params:
+        continue
+
+    prefill_load_balance_method, decode_load_balance_method = param_tuple
+    class_name = f"Test_{index:02d}_prefill_{prefill_load_balance_method}_decode_{decode_load_balance_method}"
+    new_class = type(
+        class_name,
+        (BaseTestNPULoadBalanceMethodDPDisaggregation,),
+        {"params": param_tuple},
+    )
+
+    all_test_classes.append(new_class)
+
+if __name__ == "__main__":
+    if is_in_ci():
+        RUN_COUNT = 3
+        loader = unittest.TestLoader()
+        suite = unittest.TestSuite()
+
+        selected_classes = random.sample(
+            all_test_classes, min(RUN_COUNT, len(all_test_classes))
+        )
+
+        for cls in selected_classes:
+            suite.addTests(loader.loadTestsFromTestCase(cls))
+
+        runner = unittest.TextTestRunner(verbosity=2)
+        runner.run(suite)
+    else:
+        unittest.main()

--- a/test/registered/ascend/basic_function/quantization_and_data_type/test_npu_dtype.py
+++ b/test/registered/ascend/basic_function/quantization_and_data_type/test_npu_dtype.py
@@ -1,0 +1,58 @@
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=400, suite="nightly-1-npu-a3", nightly=True)
+
+
+class TestNPUDtype(CustomTestCase):
+    """Testcase：Verify set --dtype is half or float16 or bfloat16, request inference successful.
+
+    [Test Category] Parameter
+    [Test Target] --dtype
+    """
+
+    model = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+
+    def test_dtype_options(self):
+        for i in ["half", "float16", "bfloat16"]:
+            other_args = [
+                "--dtype",
+                i,
+                "--attention-backend",
+                "ascend",
+                "--disable-cuda-graph",
+            ]
+            process = popen_launch_server(
+                self.model,
+                DEFAULT_URL_FOR_TEST,
+                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                other_args=other_args,
+            )
+            response = requests.post(
+                f"{DEFAULT_URL_FOR_TEST}/generate",
+                json={
+                    "text": "The capital of France is",
+                    "sampling_params": {
+                        "temperature": 0,
+                        "max_new_tokens": 32,
+                    },
+                },
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertIn("Paris", response.text)
+            kill_process_tree(process.pid)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/quantization_and_data_type/test_npu_enable_fp32_lm_head.py
+++ b/test/registered/ascend/basic_function/quantization_and_data_type/test_npu_enable_fp32_lm_head.py
@@ -1,0 +1,38 @@
+import unittest
+
+from sglang.test.ascend.gsm8k_ascend_mixin import GSM8KAscendMixin
+from sglang.test.ascend.test_ascend_utils import QWEN3_32B_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_npu_ci(
+    est_time=300,
+    suite="nightly-4-npu-a3",
+    nightly=True,
+)
+
+
+class TestNPUEnableFp32LmHead(GSM8KAscendMixin, CustomTestCase):
+    """Testcase: Verify that the inference accuracy on the GSM8K dataset does not decrease after --enable-fp32-lm-head is set.
+
+    [Test Category] Parameter
+    [Test Target] --enable-fp32-lm-head
+    """
+
+    model = QWEN3_32B_WEIGHTS_PATH
+    accuracy = 0.86
+    other_args = [
+        "--enable-fp32-lm-head",
+        "--trust-remote-code",
+        "--mem-fraction-static",
+        "0.8",
+        "--attention-backend",
+        "ascend",
+        "--disable-cuda-graph",
+        "--tp-size",
+        "4",
+    ]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/quantization_and_data_type/test_npu_kv_cache_dtype.py
+++ b/test/registered/ascend/basic_function/quantization_and_data_type/test_npu_kv_cache_dtype.py
@@ -1,0 +1,93 @@
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.output_capturer import OutputCapturer
+from sglang.test.ascend.test_ascend_utils import LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=150, suite="nightly-1-npu-a3", nightly=True)
+
+
+class TestNPUKVCacheDtype(CustomTestCase):
+    """Testcase: Verify set --kv_cache_dtype is auto, bf16 or bfloat16, request inference successful.
+
+    [Test Category] Parameter
+    [Test Target] --kv_cache_dtype
+    """
+
+    model = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+    kv_cache_dtype = "auto"
+    using_kv_cache_dtype = "torch.bfloat16"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.capturer = OutputCapturer()
+        cls.capturer.start()
+
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        other_args = [
+            "--dtype",
+            "auto",
+            "--attention-backend",
+            "ascend",
+            "--disable-cuda-graph",
+            "--kv-cache-dtype",
+            cls.kv_cache_dtype,
+        ]
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.process:
+            kill_process_tree(cls.process.pid)
+        cls.capturer.stop()
+
+    def test_dtype_options(self):
+        response = requests.post(
+            f"{self.base_url}/generate",
+            json={
+                "text": "The capital of France is",
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": 32,
+                },
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Paris", response.text)
+
+        response = requests.get(
+            f"{self.base_url}/server_info",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(f'"kv_cache_dtype":"{self.kv_cache_dtype}"', response.text)
+
+        output = (
+            self.__class__.capturer.get_output() + self.__class__.capturer.get_error()
+        )
+        self.assertIn(f"Using KV cache dtype: {self.using_kv_cache_dtype}", output)
+
+
+class TestNPUKVCacheDtypeBf16(TestNPUKVCacheDtype):
+    kv_cache_dtype = "bf16"
+
+
+class TestNPUKVCacheDtypeBfloat16(TestNPUKVCacheDtype):
+    kv_cache_dtype = "bfloat16"
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR aims to improve the test coverage of parameters under data parallelism kernel backends, quantization and data type features on the Ascend NPU platform.

## Modifications

1、Add output_capturer.py: Capture console output using low-level file descriptor redirection to obtain print information from child processes, NPU processes.
2、Add test_npu_dtype.py: Verify set --dtype is half or float16 or bfloat16, request inference successful.
3、Add test_npu_enable_fp32_lm_head.py: Verify that the inference accuracy on the GSM8K dataset does not decrease after --enable-fp32-lm-head is set.
4、Add test_npu_hybrid_attention_backend.py: Verify set --prefill-attention-backend, --decode-attention-backend, the inference request is successfully processed.
5、Add test_npu_json_mode.py: Verify JSON mode functionality with xgrammar grammar backend (non-streaming and streaming).
6、Add test_npu_kv_cache_dtype.py: Verify set --kv_cache_dtype is auto, bf16 or bfloat16, request inference successful.
7、Add test_npu_load_balance_method.py: Verify that the model accuracy did not decrease when --load-balance-method is set to round_robin, auto,
8、Add test_npu_load_balance_method_pd_disaggregation.py: Verify that the model accuracy did not decrease when --load-balance-method is set to round_robin, auto,
9、Add test_npu_mm_attention_backend.py: Verify MMMU dataset accuracy ≥0.2 for google/gemma-3-4b-it with --mm-attention-backend ascend_attn.
10、Add test_npu_sampling_backend.py: When --sampling-backend=pytorch or ascend, verify the MMLU dataset accuracy (>0.65) and greedy sampling consistency of the Llama-3.1-8B-Instruct mode

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
