### PR TITLE
Docs/url redirect

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,8 @@
 .github @merrymercy @Fridge003 @ispobock @Kangyan-Zhou @bingxche
 /docker @Fridge003 @ispobock @HaiShaw @ishandhanani @yctseng0211
 /docker/npu.Dockerfile @ping1jing2 @iforgetmyname
+/docs @wisclmy0611 @zijiexia
+/docs_new @wisclmy0611 @zijiexia
 /python/pyproject.toml @merrymercy @Fridge003 @ispobock
 /python/sglang/jit_kernel @DarkSharpness @BBuf @celve @HydraQYH @yuan-luo
 /python/sglang/jit_kernel/diffusion @yingluosanqian @BBuf @mickqian

--- a/docs_new/docs.json
+++ b/docs_new/docs.json
@@ -11,6 +11,590 @@
     {
       "source": "/docs/references/learn_more",
       "destination": "/"
+    },
+    {
+      "source": "/index.html",
+      "destination": "/"
+    },
+    {
+      "source": "/advanced_features/adaptive_speculative_decoding.html",
+      "destination": "/docs/advanced_features/speculative_decoding"
+    },
+    {
+      "source": "/advanced_features/attention_backend.html",
+      "destination": "/docs/advanced_features/attention_backend"
+    },
+    {
+      "source": "/advanced_features/breakable_cuda_graph.html",
+      "destination": "/docs/advanced_features/breakable_cuda_graph"
+    },
+    {
+      "source": "/advanced_features/checkpoint_engine.html",
+      "destination": "/docs/advanced_features/checkpoint_engine"
+    },
+    {
+      "source": "/advanced_features/cuda_graph_for_multi_modal_encoder.html",
+      "destination": "/docs/advanced_features/cuda_graph_for_multi_modal_encoder"
+    },
+    {
+      "source": "/advanced_features/deterministic_inference.html",
+      "destination": "/docs/advanced_features/deterministic_inference"
+    },
+    {
+      "source": "/advanced_features/dp_dpa_smg_guide.html",
+      "destination": "/docs/advanced_features/dp_dpa_smg_guide"
+    },
+    {
+      "source": "/advanced_features/dp_for_multi_modal_encoder.html",
+      "destination": "/docs/advanced_features/dp_for_multi_modal_encoder"
+    },
+    {
+      "source": "/advanced_features/epd_disaggregation.html",
+      "destination": "/docs/advanced_features/epd_disaggregation"
+    },
+    {
+      "source": "/advanced_features/expert_parallelism.html",
+      "destination": "/docs/advanced_features/expert_parallelism"
+    },
+    {
+      "source": "/advanced_features/forward_hooks.html",
+      "destination": "/docs/advanced_features/forward_hooks"
+    },
+    {
+      "source": "/advanced_features/hicache.html",
+      "destination": "/docs/advanced_features/hicache"
+    },
+    {
+      "source": "/advanced_features/hicache_best_practices.html",
+      "destination": "/docs/advanced_features/hicache_best_practices"
+    },
+    {
+      "source": "/advanced_features/hicache_design.html",
+      "destination": "/docs/advanced_features/hicache_design"
+    },
+    {
+      "source": "/advanced_features/hicache_storage_runtime_attach_detach.html",
+      "destination": "/docs/advanced_features/hicache_storage_runtime_attach_detach"
+    },
+    {
+      "source": "/advanced_features/hisparse_guide.html",
+      "destination": "/docs/advanced_features/overview"
+    },
+    {
+      "source": "/advanced_features/hyperparameter_tuning.html",
+      "destination": "/docs/advanced_features/hyperparameter_tuning"
+    },
+    {
+      "source": "/advanced_features/lora.html",
+      "destination": "/docs/advanced_features/lora"
+    },
+    {
+      "source": "/advanced_features/object_storage.html",
+      "destination": "/docs/advanced_features/object_storage"
+    },
+    {
+      "source": "/advanced_features/observability.html",
+      "destination": "/docs/advanced_features/observability"
+    },
+    {
+      "source": "/advanced_features/pd_disaggregation.html",
+      "destination": "/docs/advanced_features/pd_disaggregation"
+    },
+    {
+      "source": "/advanced_features/piecewise_cuda_graph.html",
+      "destination": "/docs/advanced_features/piecewise_cuda_graph"
+    },
+    {
+      "source": "/advanced_features/pipeline_parallelism.html",
+      "destination": "/docs/advanced_features/pipeline_parallelism"
+    },
+    {
+      "source": "/advanced_features/quantization.html",
+      "destination": "/docs/advanced_features/quantization"
+    },
+    {
+      "source": "/advanced_features/quantized_kv_cache.html",
+      "destination": "/docs/advanced_features/quantized_kv_cache"
+    },
+    {
+      "source": "/advanced_features/rfork.html",
+      "destination": "/docs/advanced_features/rfork"
+    },
+    {
+      "source": "/advanced_features/separate_reasoning.html",
+      "destination": "/docs/advanced_features/separate_reasoning"
+    },
+    {
+      "source": "/advanced_features/server_arguments.html",
+      "destination": "/docs/advanced_features/server_arguments"
+    },
+    {
+      "source": "/advanced_features/sgl_model_gateway.html",
+      "destination": "/docs/advanced_features/sgl_model_gateway"
+    },
+    {
+      "source": "/advanced_features/sglang_for_rl.html",
+      "destination": "/docs/advanced_features/sglang_for_rl"
+    },
+    {
+      "source": "/advanced_features/speculative_decoding.html",
+      "destination": "/docs/advanced_features/speculative_decoding"
+    },
+    {
+      "source": "/advanced_features/structured_outputs.html",
+      "destination": "/docs/advanced_features/structured_outputs"
+    },
+    {
+      "source": "/advanced_features/structured_outputs_for_reasoning_models.html",
+      "destination": "/docs/advanced_features/structured_outputs_for_reasoning_models"
+    },
+    {
+      "source": "/advanced_features/tool_parser.html",
+      "destination": "/docs/advanced_features/tool_parser"
+    },
+    {
+      "source": "/advanced_features/vlm_query.html",
+      "destination": "/docs/advanced_features/vlm_query"
+    },
+    {
+      "source": "/basic_usage/deepseek_ocr.html",
+      "destination": "/docs/basic_usage/overview"
+    },
+    {
+      "source": "/basic_usage/deepseek_v3.html",
+      "destination": "/docs/basic_usage/deepseek_v3"
+    },
+    {
+      "source": "/basic_usage/deepseek_v32.html",
+      "destination": "/docs/basic_usage/deepseek_v32"
+    },
+    {
+      "source": "/basic_usage/glm45.html",
+      "destination": "/docs/basic_usage/glm45"
+    },
+    {
+      "source": "/basic_usage/glmv.html",
+      "destination": "/docs/basic_usage/glmv"
+    },
+    {
+      "source": "/basic_usage/gpt_oss.html",
+      "destination": "/docs/basic_usage/gpt_oss"
+    },
+    {
+      "source": "/basic_usage/llama4.html",
+      "destination": "/docs/basic_usage/llama4"
+    },
+    {
+      "source": "/basic_usage/minimax_m2.html",
+      "destination": "/docs/basic_usage/minimax_m2"
+    },
+    {
+      "source": "/basic_usage/native_api.html",
+      "destination": "/docs/basic_usage/native_api"
+    },
+    {
+      "source": "/basic_usage/offline_engine_api.html",
+      "destination": "/docs/basic_usage/offline_engine_api"
+    },
+    {
+      "source": "/basic_usage/ollama_api.html",
+      "destination": "/docs/basic_usage/ollama_api"
+    },
+    {
+      "source": "/basic_usage/openai_api.html",
+      "destination": "/docs/basic_usage/openai_api"
+    },
+    {
+      "source": "/basic_usage/openai_api_completions.html",
+      "destination": "/docs/basic_usage/openai_api_completions"
+    },
+    {
+      "source": "/basic_usage/openai_api_embeddings.html",
+      "destination": "/docs/basic_usage/openai_api_embeddings"
+    },
+    {
+      "source": "/basic_usage/openai_api_vision.html",
+      "destination": "/docs/basic_usage/openai_api_vision"
+    },
+    {
+      "source": "/basic_usage/popular_model_usage.html",
+      "destination": "/docs/basic_usage/popular_model_usage"
+    },
+    {
+      "source": "/basic_usage/qwen3.html",
+      "destination": "/docs/basic_usage/qwen3"
+    },
+    {
+      "source": "/basic_usage/qwen3_5.html",
+      "destination": "/docs/basic_usage/qwen3"
+    },
+    {
+      "source": "/basic_usage/qwen3_vl.html",
+      "destination": "/docs/basic_usage/qwen3_vl"
+    },
+    {
+      "source": "/basic_usage/sampling_params.html",
+      "destination": "/docs/basic_usage/sampling_params"
+    },
+    {
+      "source": "/basic_usage/send_request.html",
+      "destination": "/docs/basic_usage/send_request"
+    },
+    {
+      "source": "/developer_guide/bench_serving.html",
+      "destination": "/docs/developer_guide/bench_serving"
+    },
+    {
+      "source": "/developer_guide/benchmark_and_profiling.html",
+      "destination": "/docs/developer_guide/benchmark_and_profiling"
+    },
+    {
+      "source": "/developer_guide/contribution_guide.html",
+      "destination": "/docs/developer_guide/contribution_guide"
+    },
+    {
+      "source": "/developer_guide/development_guide_using_docker.html",
+      "destination": "/docs/developer_guide/development_guide_using_docker"
+    },
+    {
+      "source": "/developer_guide/development_jit_kernel_guide.html",
+      "destination": "/docs/developer_guide/JIT_kernels"
+    },
+    {
+      "source": "/developer_guide/evaluating_new_models.html",
+      "destination": "/docs/developer_guide/evaluating_new_models"
+    },
+    {
+      "source": "/developer_guide/release_process.html",
+      "destination": "/docs/developer_guide/release_process"
+    },
+    {
+      "source": "/developer_guide/setup_github_runner.html",
+      "destination": "/docs/developer_guide/setup_github_runner"
+    },
+    {
+      "source": "/diffusion/api/cli.html",
+      "destination": "/docs/sglang-diffusion/api/cli"
+    },
+    {
+      "source": "/diffusion/api/openai_api.html",
+      "destination": "/docs/sglang-diffusion/api/openai-api"
+    },
+    {
+      "source": "/diffusion/api/post_processing.html",
+      "destination": "/docs/sglang-diffusion/index"
+    },
+    {
+      "source": "/diffusion/ci_perf.html",
+      "destination": "/docs/sglang-diffusion/ci-performance"
+    },
+    {
+      "source": "/diffusion/compatibility_matrix.html",
+      "destination": "/docs/sglang-diffusion/index"
+    },
+    {
+      "source": "/diffusion/contributing.html",
+      "destination": "/docs/sglang-diffusion/index"
+    },
+    {
+      "source": "/diffusion/development.html",
+      "destination": "/docs/sglang-diffusion/index"
+    },
+    {
+      "source": "/diffusion/disaggregation.html",
+      "destination": "/docs/sglang-diffusion/index"
+    },
+    {
+      "source": "/diffusion/environment_variables.html",
+      "destination": "/docs/sglang-diffusion/environment-variables"
+    },
+    {
+      "source": "/diffusion/index.html",
+      "destination": "/docs/sglang-diffusion/index"
+    },
+    {
+      "source": "/diffusion/installation.html",
+      "destination": "/docs/sglang-diffusion/installation"
+    },
+    {
+      "source": "/diffusion/performance/attention_backends.html",
+      "destination": "/docs/sglang-diffusion/attention-backends"
+    },
+    {
+      "source": "/diffusion/performance/cache/cache_dit.html",
+      "destination": "/docs/sglang-diffusion/cache-dit"
+    },
+    {
+      "source": "/diffusion/performance/cache/index.html",
+      "destination": "/docs/sglang-diffusion/caching-acceleration"
+    },
+    {
+      "source": "/diffusion/performance/cache/teacache.html",
+      "destination": "/docs/sglang-diffusion/tea-cache"
+    },
+    {
+      "source": "/diffusion/performance/index.html",
+      "destination": "/docs/sglang-diffusion/performance-optimization"
+    },
+    {
+      "source": "/diffusion/performance/profiling.html",
+      "destination": "/docs/sglang-diffusion/profiling"
+    },
+    {
+      "source": "/diffusion/performance/ring_sp_performance.html",
+      "destination": "/docs/sglang-diffusion/performance-optimization"
+    },
+    {
+      "source": "/diffusion/quantization.html",
+      "destination": "/docs/sglang-diffusion/index"
+    },
+    {
+      "source": "/diffusion/reference.html",
+      "destination": "/docs/sglang-diffusion/index"
+    },
+    {
+      "source": "/diffusion/support_new_models.html",
+      "destination": "/docs/sglang-diffusion/index"
+    },
+    {
+      "source": "/diffusion/usage.html",
+      "destination": "/docs/sglang-diffusion/index"
+    },
+    {
+      "source": "/get_started/install.html",
+      "destination": "/docs/get-started/installation"
+    },
+    {
+      "source": "/index.html",
+      "destination": "/"
+    },
+    {
+      "source": "/platforms/amd_gpu.html",
+      "destination": "/docs/hardware-platforms/amd-gpus"
+    },
+    {
+      "source": "/platforms/apple_metal.html",
+      "destination": "/docs/hardware-platforms/overview"
+    },
+    {
+      "source": "/platforms/ascend/ascend_contribution_guide.html",
+      "destination": "/docs/hardware-platforms/overview"
+    },
+    {
+      "source": "/platforms/ascend/ascend_npu.html",
+      "destination": "/docs/hardware-platforms/ascend-npus/SGLang-installation-with-NPUs-support"
+    },
+    {
+      "source": "/platforms/ascend/ascend_npu_best_practice.html",
+      "destination": "/docs/hardware-platforms/ascend-npus/Best-Practice-on-Ascend-NPU"
+    },
+    {
+      "source": "/platforms/ascend/ascend_npu_deepseek_example.html",
+      "destination": "/docs/hardware-platforms/ascend-npus/DeepSeek-Examples"
+    },
+    {
+      "source": "/platforms/ascend/ascend_npu_environment_variables.html",
+      "destination": "/docs/hardware-platforms/overview"
+    },
+    {
+      "source": "/platforms/ascend/ascend_npu_glm5_examples.html",
+      "destination": "/docs/hardware-platforms/ascend-npus/GLM-5"
+    },
+    {
+      "source": "/platforms/ascend/ascend_npu_quantization.html",
+      "destination": "/docs/hardware-platforms/overview"
+    },
+    {
+      "source": "/platforms/ascend/ascend_npu_qwen3_5_examples.html",
+      "destination": "/docs/hardware-platforms/ascend-npus/Qwen3.5"
+    },
+    {
+      "source": "/platforms/ascend/ascend_npu_qwen3_examples.html",
+      "destination": "/docs/hardware-platforms/ascend-npus/Qwen3-Examples"
+    },
+    {
+      "source": "/platforms/ascend/ascend_npu_support.html",
+      "destination": "/docs/hardware-platforms/overview"
+    },
+    {
+      "source": "/platforms/ascend/ascend_npu_support_features.html",
+      "destination": "/docs/hardware-platforms/ascend-npus/Support-Features-on-Ascend-NPU"
+    },
+    {
+      "source": "/platforms/ascend/ascend_npu_support_models.html",
+      "destination": "/docs/hardware-platforms/ascend-npus/Support-Models-on-Ascend-NPU"
+    },
+    {
+      "source": "/platforms/ascend/mindspore_backend.html",
+      "destination": "/docs/hardware-platforms/overview"
+    },
+    {
+      "source": "/platforms/ascend_npu_ring_sp_performance.html",
+      "destination": "/docs/hardware-platforms/overview"
+    },
+    {
+      "source": "/platforms/cpu_server.html",
+      "destination": "/docs/hardware-platforms/cpu-server"
+    },
+    {
+      "source": "/platforms/mthreads_gpu.html",
+      "destination": "/docs/hardware-platforms/overview"
+    },
+    {
+      "source": "/platforms/nvidia_jetson.html",
+      "destination": "/docs/hardware-platforms/overview"
+    },
+    {
+      "source": "/platforms/plugin.html",
+      "destination": "/docs/hardware-platforms/overview"
+    },
+    {
+      "source": "/platforms/tpu.html",
+      "destination": "/docs/hardware-platforms/tpu"
+    },
+    {
+      "source": "/platforms/xpu.html",
+      "destination": "/docs/hardware-platforms/xpu"
+    },
+    {
+      "source": "/references/custom_chat_template.html",
+      "destination": "/docs/references/custom_chat_template"
+    },
+    {
+      "source": "/references/environment_variables.html",
+      "destination": "/docs/references/environment_variables"
+    },
+    {
+      "source": "/references/faq.html",
+      "destination": "/docs/references/faq"
+    },
+    {
+      "source": "/references/frontend/choices_methods.html",
+      "destination": "/docs/references/frontend/choices_methods"
+    },
+    {
+      "source": "/references/frontend/frontend_index.html",
+      "destination": "/docs/references/frontend/frontend_index"
+    },
+    {
+      "source": "/references/frontend/frontend_tutorial.html",
+      "destination": "/docs/references/frontend/frontend_tutorial"
+    },
+    {
+      "source": "/references/learn_more.html",
+      "destination": "/"
+    },
+    {
+      "source": "/references/multi_node_deployment/deploy_on_k8s.html",
+      "destination": "/docs/references/multi_node_deployment/deploy_on_k8s"
+    },
+    {
+      "source": "/references/multi_node_deployment/lws_pd/lws_pd_deploy.html",
+      "destination": "/docs/references/multi_node_deployment/lws_pd/lws_pd_deploy"
+    },
+    {
+      "source": "/references/multi_node_deployment/multi_node.html",
+      "destination": "/docs/references/multi_node_deployment/multi_node"
+    },
+    {
+      "source": "/references/multi_node_deployment/multi_node_index.html",
+      "destination": "/docs/references/multi_node_deployment/multi_node_index"
+    },
+    {
+      "source": "/references/multi_node_deployment/rbg_pd/deepseekv32_pd.html",
+      "destination": "/docs/references/multi_node_deployment/rbg_pd/deepseekv32_pd"
+    },
+    {
+      "source": "/references/post_training_integration.html",
+      "destination": "/docs/references/post_training_integration"
+    },
+    {
+      "source": "/references/production_metrics.html",
+      "destination": "/docs/references/production_metrics"
+    },
+    {
+      "source": "/references/production_request_trace.html",
+      "destination": "/docs/references/production_request_trace"
+    },
+    {
+      "source": "/references/release_lookup.html",
+      "destination": "/docs/references/overview"
+    },
+    {
+      "source": "/references/torch_compile_cache.html",
+      "destination": "/docs/references/torch_compile_cache"
+    },
+    {
+      "source": "/supported_models/extending/index.html",
+      "destination": "/docs/supported-models"
+    },
+    {
+      "source": "/supported_models/extending/mindspore_models.html",
+      "destination": "/docs/supported-models/mindspore-models"
+    },
+    {
+      "source": "/supported_models/extending/modelscope.html",
+      "destination": "/docs/supported-models/modelscope"
+    },
+    {
+      "source": "/supported_models/extending/support_new_models.html",
+      "destination": "/docs/supported-models/new-model-support"
+    },
+    {
+      "source": "/supported_models/extending/transformers_fallback.html",
+      "destination": "/docs/supported-models/transformers-fallback"
+    },
+    {
+      "source": "/supported_models/index.html",
+      "destination": "/docs/supported-models"
+    },
+    {
+      "source": "/supported_models/retrieval_ranking/classify_models.html",
+      "destination": "/docs/supported-models/classification-models"
+    },
+    {
+      "source": "/supported_models/retrieval_ranking/embedding_models.html",
+      "destination": "/docs/supported-models/embedding-models"
+    },
+    {
+      "source": "/supported_models/retrieval_ranking/index.html",
+      "destination": "/docs/supported-models"
+    },
+    {
+      "source": "/supported_models/retrieval_ranking/rerank_models.html",
+      "destination": "/docs/supported-models/rerank-models"
+    },
+    {
+      "source": "/supported_models/specialized/index.html",
+      "destination": "/docs/supported-models"
+    },
+    {
+      "source": "/supported_models/specialized/reward_models.html",
+      "destination": "/docs/supported-models/reward-models"
+    },
+    {
+      "source": "/supported_models/text_generation/diffusion_language_models.html",
+      "destination": "/docs/supported-models/diffusion-language-models"
+    },
+    {
+      "source": "/supported_models/text_generation/generative_models.html",
+      "destination": "/docs/supported-models/large-language-models"
+    },
+    {
+      "source": "/supported_models/text_generation/index.html",
+      "destination": "/docs/supported-models"
+    },
+    {
+      "source": "/supported_models/text_generation/multimodal_language_models.html",
+      "destination": "/docs/supported-models/vision-language-models"
+    },
+    {
+      "source": "/supported_models.html",
+      "destination": "/docs/supported-models"
+    },
+    {
+      "source": "/diffusion.html",
+      "destination": "/docs/sglang-diffusion/index"
     }
   ],
   "colors": {

--- a/docs_new/docs.json
+++ b/docs_new/docs.json
@@ -282,7 +282,7 @@
     },
     {
       "source": "/diffusion/api/post_processing.html",
-      "destination": "/docs/sglang-diffusion/index"
+      "destination": "/docs/sglang-diffusion/installation"
     },
     {
       "source": "/diffusion/ci_perf.html",
@@ -290,19 +290,19 @@
     },
     {
       "source": "/diffusion/compatibility_matrix.html",
-      "destination": "/docs/sglang-diffusion/index"
+      "destination": "/docs/sglang-diffusion/installation"
     },
     {
       "source": "/diffusion/contributing.html",
-      "destination": "/docs/sglang-diffusion/index"
+      "destination": "/docs/sglang-diffusion/installation"
     },
     {
       "source": "/diffusion/development.html",
-      "destination": "/docs/sglang-diffusion/index"
+      "destination": "/docs/sglang-diffusion/installation"
     },
     {
       "source": "/diffusion/disaggregation.html",
-      "destination": "/docs/sglang-diffusion/index"
+      "destination": "/docs/sglang-diffusion/installation"
     },
     {
       "source": "/diffusion/environment_variables.html",
@@ -310,7 +310,7 @@
     },
     {
       "source": "/diffusion/index.html",
-      "destination": "/docs/sglang-diffusion/index"
+      "destination": "/docs/sglang-diffusion/installation"
     },
     {
       "source": "/diffusion/installation.html",
@@ -346,27 +346,23 @@
     },
     {
       "source": "/diffusion/quantization.html",
-      "destination": "/docs/sglang-diffusion/index"
+      "destination": "/docs/sglang-diffusion/installation"
     },
     {
       "source": "/diffusion/reference.html",
-      "destination": "/docs/sglang-diffusion/index"
+      "destination": "/docs/sglang-diffusion/installation"
     },
     {
       "source": "/diffusion/support_new_models.html",
-      "destination": "/docs/sglang-diffusion/index"
+      "destination": "/docs/sglang-diffusion/installation"
     },
     {
       "source": "/diffusion/usage.html",
-      "destination": "/docs/sglang-diffusion/index"
+      "destination": "/docs/sglang-diffusion/installation"
     },
     {
       "source": "/get_started/install.html",
       "destination": "/docs/get-started/installation"
-    },
-    {
-      "source": "/index.html",
-      "destination": "/"
     },
     {
       "source": "/platforms/amd_gpu.html",
@@ -594,7 +590,7 @@
     },
     {
       "source": "/diffusion.html",
-      "destination": "/docs/sglang-diffusion/index"
+      "destination": "/docs/sglang-diffusion/installation"
     }
   ],
   "colors": {

--- a/docs_new/scripts/gen_redirects.py
+++ b/docs_new/scripts/gen_redirects.py
@@ -23,16 +23,13 @@ SECTION_RENAMES = {
 EXPLICIT = {
     # get_started → get-started
     "/get_started/install": "/docs/get-started/installation",
-
     # developer_guide rename
     "/developer_guide/development_jit_kernel_guide": "/docs/developer_guide/JIT_kernels",
-
     # platforms → hardware-platforms (with file renames)
     "/platforms/amd_gpu": "/docs/hardware-platforms/amd-gpus",
     "/platforms/cpu_server": "/docs/hardware-platforms/cpu-server",
     "/platforms/tpu": "/docs/hardware-platforms/tpu",
     "/platforms/xpu": "/docs/hardware-platforms/xpu",
-
     # platforms/ascend → hardware-platforms/ascend-npus (flattened, renamed)
     "/platforms/ascend/ascend_npu": "/docs/hardware-platforms/ascend-npus/SGLang-installation-with-NPUs-support",
     "/platforms/ascend/ascend_npu_best_practice": "/docs/hardware-platforms/ascend-npus/Best-Practice-on-Ascend-NPU",
@@ -53,7 +50,6 @@ EXPLICIT = {
     "/platforms/mthreads_gpu": "/docs/hardware-platforms/overview",
     "/platforms/nvidia_jetson": "/docs/hardware-platforms/overview",
     "/platforms/plugin": "/docs/hardware-platforms/overview",
-
     # supported_models → supported-models (flattened, renamed)
     "/supported_models": "/docs/supported-models",
     "/supported_models/index": "/docs/supported-models",
@@ -72,7 +68,6 @@ EXPLICIT = {
     "/supported_models/text_generation/multimodal_language_models": "/docs/supported-models/vision-language-models",
     "/supported_models/text_generation/diffusion_language_models": "/docs/supported-models/diffusion-language-models",
     "/supported_models/text_generation/index": "/docs/supported-models",
-
     # diffusion → sglang-diffusion (file renames snake_case → kebab-case)
     "/diffusion": "/docs/sglang-diffusion/installation",
     "/diffusion/index": "/docs/sglang-diffusion/installation",
@@ -98,19 +93,15 @@ EXPLICIT = {
     "/diffusion/reference": "/docs/sglang-diffusion/installation",
     "/diffusion/support_new_models": "/docs/sglang-diffusion/installation",
     "/diffusion/usage": "/docs/sglang-diffusion/installation",
-
     # basic_usage dropped pages
     "/basic_usage/deepseek_ocr": "/docs/basic_usage/overview",
     "/basic_usage/qwen3_5": "/docs/basic_usage/qwen3",
-
     # advanced_features dropped pages
     "/advanced_features/adaptive_speculative_decoding": "/docs/advanced_features/speculative_decoding",
     "/advanced_features/hisparse_guide": "/docs/advanced_features/overview",
-
     # references dropped
     "/references/learn_more": "/",
     "/references/release_lookup": "/docs/references/overview",
-
     # Root index
     "/index": "/",
     "/": "/",
@@ -175,7 +166,11 @@ def main():
             continue
         rel = p.relative_to(OLD_DOCS)
         # Skip non-doc dirs
-        if rel.parts and rel.parts[0] in ("_static", "performance_dashboard", "release_lookup"):
+        if rel.parts and rel.parts[0] in (
+            "_static",
+            "performance_dashboard",
+            "release_lookup",
+        ):
             continue
         old_files.append(rel)
 

--- a/docs_new/scripts/gen_redirects.py
+++ b/docs_new/scripts/gen_redirects.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Generate Mintlify docs.json redirects from old Sphinx paths to new Mintlify paths."""
+
 from __future__ import annotations
 
 import json

--- a/docs_new/scripts/gen_redirects.py
+++ b/docs_new/scripts/gen_redirects.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Generate Mintlify docs.json redirects from old Sphinx paths to new Mintlify paths."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent.parent
+OLD_DOCS = REPO / "docs"
+NEW_DOCS = REPO / "docs_new" / "docs"
+
+# Directory-level renames (old → new, under /docs/ prefix)
+SECTION_RENAMES = {
+    "get_started": "get-started",
+    "platforms": "hardware-platforms",
+    "supported_models": "supported-models",
+    "diffusion": "sglang-diffusion",
+}
+
+# Explicit file-level mappings. Keys are old URL paths (no .html, with leading /).
+# Values are new URL paths (with /docs/ prefix, no extension).
+EXPLICIT = {
+    # get_started → get-started
+    "/get_started/install": "/docs/get-started/installation",
+
+    # developer_guide rename
+    "/developer_guide/development_jit_kernel_guide": "/docs/developer_guide/JIT_kernels",
+
+    # platforms → hardware-platforms (with file renames)
+    "/platforms/amd_gpu": "/docs/hardware-platforms/amd-gpus",
+    "/platforms/cpu_server": "/docs/hardware-platforms/cpu-server",
+    "/platforms/tpu": "/docs/hardware-platforms/tpu",
+    "/platforms/xpu": "/docs/hardware-platforms/xpu",
+
+    # platforms/ascend → hardware-platforms/ascend-npus (flattened, renamed)
+    "/platforms/ascend/ascend_npu": "/docs/hardware-platforms/ascend-npus/SGLang-installation-with-NPUs-support",
+    "/platforms/ascend/ascend_npu_best_practice": "/docs/hardware-platforms/ascend-npus/Best-Practice-on-Ascend-NPU",
+    "/platforms/ascend/ascend_npu_deepseek_example": "/docs/hardware-platforms/ascend-npus/DeepSeek-Examples",
+    "/platforms/ascend/ascend_npu_glm5_examples": "/docs/hardware-platforms/ascend-npus/GLM-5",
+    "/platforms/ascend/ascend_npu_qwen3_examples": "/docs/hardware-platforms/ascend-npus/Qwen3-Examples",
+    "/platforms/ascend/ascend_npu_qwen3_5_examples": "/docs/hardware-platforms/ascend-npus/Qwen3.5",
+    "/platforms/ascend/ascend_npu_support_features": "/docs/hardware-platforms/ascend-npus/Support-Features-on-Ascend-NPU",
+    "/platforms/ascend/ascend_npu_support_models": "/docs/hardware-platforms/ascend-npus/Support-Models-on-Ascend-NPU",
+    # Old pages dropped — redirect to section overview
+    "/platforms/ascend/ascend_contribution_guide": "/docs/hardware-platforms/overview",
+    "/platforms/ascend/ascend_npu_environment_variables": "/docs/hardware-platforms/overview",
+    "/platforms/ascend/ascend_npu_quantization": "/docs/hardware-platforms/overview",
+    "/platforms/ascend/ascend_npu_support": "/docs/hardware-platforms/overview",
+    "/platforms/ascend/mindspore_backend": "/docs/hardware-platforms/overview",
+    "/platforms/ascend_npu_ring_sp_performance": "/docs/hardware-platforms/overview",
+    "/platforms/apple_metal": "/docs/hardware-platforms/overview",
+    "/platforms/mthreads_gpu": "/docs/hardware-platforms/overview",
+    "/platforms/nvidia_jetson": "/docs/hardware-platforms/overview",
+    "/platforms/plugin": "/docs/hardware-platforms/overview",
+
+    # supported_models → supported-models (flattened, renamed)
+    "/supported_models": "/docs/supported-models",
+    "/supported_models/index": "/docs/supported-models",
+    "/supported_models/extending/mindspore_models": "/docs/supported-models/mindspore-models",
+    "/supported_models/extending/modelscope": "/docs/supported-models/modelscope",
+    "/supported_models/extending/support_new_models": "/docs/supported-models/new-model-support",
+    "/supported_models/extending/transformers_fallback": "/docs/supported-models/transformers-fallback",
+    "/supported_models/extending/index": "/docs/supported-models",
+    "/supported_models/retrieval_ranking/classify_models": "/docs/supported-models/classification-models",
+    "/supported_models/retrieval_ranking/embedding_models": "/docs/supported-models/embedding-models",
+    "/supported_models/retrieval_ranking/rerank_models": "/docs/supported-models/rerank-models",
+    "/supported_models/retrieval_ranking/index": "/docs/supported-models",
+    "/supported_models/specialized/reward_models": "/docs/supported-models/reward-models",
+    "/supported_models/specialized/index": "/docs/supported-models",
+    "/supported_models/text_generation/generative_models": "/docs/supported-models/large-language-models",
+    "/supported_models/text_generation/multimodal_language_models": "/docs/supported-models/vision-language-models",
+    "/supported_models/text_generation/diffusion_language_models": "/docs/supported-models/diffusion-language-models",
+    "/supported_models/text_generation/index": "/docs/supported-models",
+
+    # diffusion → sglang-diffusion (file renames snake_case → kebab-case)
+    "/diffusion": "/docs/sglang-diffusion/index",
+    "/diffusion/index": "/docs/sglang-diffusion/index",
+    "/diffusion/installation": "/docs/sglang-diffusion/installation",
+    "/diffusion/environment_variables": "/docs/sglang-diffusion/environment-variables",
+    "/diffusion/ci_perf": "/docs/sglang-diffusion/ci-performance",
+    "/diffusion/api/cli": "/docs/sglang-diffusion/api/cli",
+    "/diffusion/api/openai_api": "/docs/sglang-diffusion/api/openai-api",
+    "/diffusion/performance/attention_backends": "/docs/sglang-diffusion/attention-backends",
+    "/diffusion/performance/cache/cache_dit": "/docs/sglang-diffusion/cache-dit",
+    "/diffusion/performance/cache/index": "/docs/sglang-diffusion/caching-acceleration",
+    "/diffusion/performance/cache/teacache": "/docs/sglang-diffusion/tea-cache",
+    "/diffusion/performance/index": "/docs/sglang-diffusion/performance-optimization",
+    "/diffusion/performance/profiling": "/docs/sglang-diffusion/profiling",
+    # Diffusion pages dropped
+    "/diffusion/api/post_processing": "/docs/sglang-diffusion/index",
+    "/diffusion/compatibility_matrix": "/docs/sglang-diffusion/index",
+    "/diffusion/contributing": "/docs/sglang-diffusion/index",
+    "/diffusion/development": "/docs/sglang-diffusion/index",
+    "/diffusion/disaggregation": "/docs/sglang-diffusion/index",
+    "/diffusion/performance/ring_sp_performance": "/docs/sglang-diffusion/performance-optimization",
+    "/diffusion/quantization": "/docs/sglang-diffusion/index",
+    "/diffusion/reference": "/docs/sglang-diffusion/index",
+    "/diffusion/support_new_models": "/docs/sglang-diffusion/index",
+    "/diffusion/usage": "/docs/sglang-diffusion/index",
+
+    # basic_usage dropped pages
+    "/basic_usage/deepseek_ocr": "/docs/basic_usage/overview",
+    "/basic_usage/qwen3_5": "/docs/basic_usage/qwen3",
+
+    # advanced_features dropped pages
+    "/advanced_features/adaptive_speculative_decoding": "/docs/advanced_features/speculative_decoding",
+    "/advanced_features/hisparse_guide": "/docs/advanced_features/overview",
+
+    # references dropped
+    "/references/learn_more": "/",
+    "/references/release_lookup": "/docs/references/overview",
+
+    # Root index
+    "/index": "/",
+    "/": "/",
+}
+
+
+def old_url_from_path(rel: Path) -> str | None:
+    """Convert old docs/<rel> to its Sphinx URL path (no .html, leading /)."""
+    parts = list(rel.parts)
+    stem = rel.stem
+    # Skip README, release_lookup/README, top-level non-doc files
+    if stem == "README":
+        return None
+    # Drop the extension → URL path
+    new_parts = parts[:-1] + [stem]
+    return "/" + "/".join(new_parts)
+
+
+def new_url_for(old_url: str, new_files_set: set[str]) -> str | None:
+    """Compute new URL from old URL using section rename + explicit overrides."""
+    if old_url in EXPLICIT:
+        return EXPLICIT[old_url]
+    # Default rule: `/section/path` → `/docs/section/path`, applying section renames
+    parts = old_url.strip("/").split("/")
+    if not parts or not parts[0]:
+        return None
+    section = parts[0]
+    section = SECTION_RENAMES.get(section, section)
+    new_url = "/docs/" + "/".join([section] + parts[1:])
+    # Verify destination exists in new file tree
+    if new_url in new_files_set:
+        return new_url
+    return None  # unmapped
+
+
+def list_new_urls() -> set[str]:
+    urls = set()
+    for p in NEW_DOCS.rglob("*"):
+        if not p.is_file():
+            continue
+        if p.suffix not in (".mdx", ".ipynb", ".md"):
+            continue
+        rel = p.relative_to(NEW_DOCS)
+        # Mintlify routes .mdx / .ipynb as `/docs/<path-without-ext>`
+        url = "/docs/" + str(rel.with_suffix("")).replace(os.sep, "/")
+        urls.add(url)
+    return urls
+
+
+def main():
+    new_urls = list_new_urls()
+    redirects: list[dict] = []
+    seen_sources: set[str] = set()
+    unmapped: list[str] = []
+
+    # Iterate all old files
+    old_files = []
+    for p in sorted(OLD_DOCS.rglob("*")):
+        if not p.is_file():
+            continue
+        if p.suffix not in (".md", ".rst", ".ipynb"):
+            continue
+        rel = p.relative_to(OLD_DOCS)
+        # Skip non-doc dirs
+        if rel.parts and rel.parts[0] in ("_static", "performance_dashboard", "release_lookup"):
+            continue
+        old_files.append(rel)
+
+    for rel in old_files:
+        old_url = old_url_from_path(rel)
+        if old_url is None:
+            continue
+        # Old Sphinx URLs end in .html
+        source = old_url + ".html"
+        if source in seen_sources:
+            continue
+        new_url = new_url_for(old_url, new_urls)
+        if new_url is None:
+            unmapped.append(source)
+            continue
+        redirects.append({"source": source, "destination": new_url})
+        seen_sources.add(source)
+
+    # Also add explicit entries whose source key wasn't derived from a file (e.g. index variants)
+    for old_key, new_val in EXPLICIT.items():
+        source = old_key + ".html"
+        if source in seen_sources:
+            continue
+        # Only add if old_key corresponds to an actual old page pattern we care about
+        # Skip bare "/" and "/index" (handled by Mintlify default)
+        if old_key in ("/", "/index"):
+            continue
+        redirects.append({"source": source, "destination": new_val})
+        seen_sources.add(source)
+
+    # Output
+    print(f"# Total redirects: {len(redirects)}")
+    print(f"# Unmapped old URLs: {len(unmapped)}")
+    if unmapped:
+        print("# --- UNMAPPED ---")
+        for u in unmapped:
+            print(f"#   {u}")
+    print(json.dumps(redirects, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs_new/scripts/gen_redirects.py
+++ b/docs_new/scripts/gen_redirects.py
@@ -74,8 +74,8 @@ EXPLICIT = {
     "/supported_models/text_generation/index": "/docs/supported-models",
 
     # diffusion → sglang-diffusion (file renames snake_case → kebab-case)
-    "/diffusion": "/docs/sglang-diffusion/index",
-    "/diffusion/index": "/docs/sglang-diffusion/index",
+    "/diffusion": "/docs/sglang-diffusion/installation",
+    "/diffusion/index": "/docs/sglang-diffusion/installation",
     "/diffusion/installation": "/docs/sglang-diffusion/installation",
     "/diffusion/environment_variables": "/docs/sglang-diffusion/environment-variables",
     "/diffusion/ci_perf": "/docs/sglang-diffusion/ci-performance",
@@ -88,16 +88,16 @@ EXPLICIT = {
     "/diffusion/performance/index": "/docs/sglang-diffusion/performance-optimization",
     "/diffusion/performance/profiling": "/docs/sglang-diffusion/profiling",
     # Diffusion pages dropped
-    "/diffusion/api/post_processing": "/docs/sglang-diffusion/index",
-    "/diffusion/compatibility_matrix": "/docs/sglang-diffusion/index",
-    "/diffusion/contributing": "/docs/sglang-diffusion/index",
-    "/diffusion/development": "/docs/sglang-diffusion/index",
-    "/diffusion/disaggregation": "/docs/sglang-diffusion/index",
+    "/diffusion/api/post_processing": "/docs/sglang-diffusion/installation",
+    "/diffusion/compatibility_matrix": "/docs/sglang-diffusion/installation",
+    "/diffusion/contributing": "/docs/sglang-diffusion/installation",
+    "/diffusion/development": "/docs/sglang-diffusion/installation",
+    "/diffusion/disaggregation": "/docs/sglang-diffusion/installation",
     "/diffusion/performance/ring_sp_performance": "/docs/sglang-diffusion/performance-optimization",
-    "/diffusion/quantization": "/docs/sglang-diffusion/index",
-    "/diffusion/reference": "/docs/sglang-diffusion/index",
-    "/diffusion/support_new_models": "/docs/sglang-diffusion/index",
-    "/diffusion/usage": "/docs/sglang-diffusion/index",
+    "/diffusion/quantization": "/docs/sglang-diffusion/installation",
+    "/diffusion/reference": "/docs/sglang-diffusion/installation",
+    "/diffusion/support_new_models": "/docs/sglang-diffusion/installation",
+    "/diffusion/usage": "/docs/sglang-diffusion/installation",
 
     # basic_usage dropped pages
     "/basic_usage/deepseek_ocr": "/docs/basic_usage/overview",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When we switch docs.sglang.io from the legacy Sphinx deployment (on sgl-project.github.io) to the new Mintlify deployment (currently at staging.docs.sglang.io), all previously published URLs in the form /<section>/<page>.html will 404 on the new site, since Mintlify routes are /docs/<section>/<page> with no .html suffix. External docs, blog posts, GitHub issues, and search-engine results all link to the legacy form, so a DNS cutover without redirects would break them en masse.

This PR adds same-domain path redirects in docs.json so that staging.docs.sglang.io / docs.sglang.io serves 301s for every known legacy URL. The cross-domain cookbook.sglang.io redirect is out of scope here — it has to be configured at the Cloudflare edge, since Mintlify can’t issue redirects for a host it doesn’t terminate.

## Modifications

- docs_new/docs.json: expanded redirects from 1 entry to 147, covering every legacy docs URL.
Path-prefix only (/<section>/<page>.html → /docs/<section>/<page>) — majority of entries.
Directory renames: get_started → get-started, platforms → hardware-platforms, supported_models → supported-models, diffusion → sglang-diffusion.
Individual file renames: e.g. amd_gpu → amd-gpus, development_jit_kernel_guide → JIT_kernels, ascend examples renamed to kebab-case, generative_models → large-language-models, etc.
Deleted pages redirected to the closest surviving overview page (e.g. /diffusion/usage.html → /docs/sglang-diffusion/index).

- docs_new/scripts/gen_redirects.py: generator script that walks docs/ (old Sphinx tree) and docs_new/docs/ (new Mintlify tree), computes the mapping from section-rename rules plus explicit overrides, and prints a redirect list. Can be re-run if more pages are renamed or removed.

Self-checks run before committing:

docs.json is valid JSON after the edit.
All 147 destinations resolve to a real .mdx / .ipynb / .md file under docs_new/docs/.
No duplicate source entries.

## Accuracy Tests

N/A — docs-only change.

## Speed Tests and Profiling

N/A — docs-only change.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
