### PR TITLE
ci: reduce scheduled PR test from 4x to 3x daily

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -5,7 +5,7 @@ run-name: ${{ inputs.target_stage && (inputs.pr_head_sha && format('[{0}] {1}', 
 
 on:
   schedule:
-    - cron: '0 1,9,17 * * *'  # Run 3x daily: 6pm / 2am / 10am Pacific
+    - cron: '0 1,9,17 * * *'  # Run 3x daily: 2am / 10am / 6pm Pacific (PDT)
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -5,7 +5,7 @@ run-name: ${{ inputs.target_stage && (inputs.pr_head_sha && format('[{0}] {1}', 
 
 on:
   schedule:
-    - cron: '0 */6 * * *'  # Run every 6 hours (UTC)
+    - cron: '0 1,9,17 * * *'  # Run 3x daily: 6pm / 2am / 10am Pacific
   pull_request:
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Reduce scheduled PR test frequency from every 6 hours (4x/day) to 3x/day
- New schedule: 2am / 10am / 6pm Pacific (9:00 / 17:00 / 1:00 UTC)

## Test plan
- [ ] Verify cron triggers at expected times