### PR TITLE
disaggregation: add shm_pinned backend for single-node PCIe transfer

### DIFF
--- a/docs/advanced_features/pd_disaggregation.md
+++ b/docs/advanced_features/pd_disaggregation.md
@@ -15,7 +15,7 @@ PD Disaggregation resolves these by separating the two stages, enabling tailored
 
 For the design details, please refer to [link](https://docs.google.com/document/d/1rQXJwKd5b9b1aOzLh98mnyMhBMhlxXA5ATZTHoQrwvc/edit?tab=t.0).
 
-Currently, we support Mooncake and NIXL as the transfer engine.
+Currently, we support Mooncake, NIXL, and `shm_pinned` as transfer backends.
 
 ## Profiling in PD Disaggregation Mode
 

--- a/docs/advanced_features/server_arguments.md
+++ b/docs/advanced_features/server_arguments.md
@@ -480,9 +480,11 @@ Please consult the documentation below and [server_args.py](https://github.com/s
 | Argument | Description | Defaults | Options |
 | --- | --- | --- | --- |
 | `--disaggregation-mode` | Only used for PD disaggregation. "prefill" for prefill-only server, and "decode" for decode-only server. If not specified, it is not PD disaggregated | `null` | `null`, `prefill`, `decode` |
-| `--disaggregation-transfer-backend` | The backend for disaggregation transfer. Default is mooncake. | `mooncake` | `mooncake`, `nixl`, `ascend`, `fake` |
+| `--disaggregation-transfer-backend` | The backend for disaggregation transfer. Default is mooncake. | `mooncake` | `mooncake`, `nixl`, `ascend`, `fake`, `mori`, `shm_pinned` |
 | `--disaggregation-bootstrap-port` | Bootstrap server port on the prefill server. Default is 8998. | `8998` | Type: int |
 | `--disaggregation-ib-device` | The InfiniBand devices for disaggregation transfer, accepts single device (e.g., --disaggregation-ib-device mlx5_0) or multiple comma-separated devices (e.g., --disaggregation-ib-device mlx5_0,mlx5_1). Default is None, which triggers automatic device detection when mooncake backend is enabled. | `None` | Type: str |
+| `--disaggregation-shm-slot-count` | Number of ring-buffer slots for the `shm_pinned` backend. | `32` | Type: int |
+| `--disaggregation-shm-chunk-tokens` | Token budget per `shm_pinned` transfer chunk. | `512` | Type: int |
 | `--disaggregation-decode-enable-offload-kvcache` | Enable async KV cache offloading on decode server (PD mode). | `False` | bool flag (set to enable) |
 | `--num-reserved-decode-tokens` | Number of decode tokens that will have memory reserved when adding new request to the running batch. | `512` | Type: int |
 | `--disaggregation-decode-polling-interval` | The interval to poll requests in decode server. Can be set to >1 to reduce the overhead of this. | `1` | Type: int |

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
   "packaging",
   "partial_json_parser",
   "pillow",
+  "posix_ipc>=1.1.1",
   "prometheus-client>=0.20.0",
   "psutil",
   "py-spy",

--- a/python/sglang/srt/disaggregation/shm_pinned/__init__.py
+++ b/python/sglang/srt/disaggregation/shm_pinned/__init__.py
@@ -1,0 +1,26 @@
+"""
+Shared-memory pinned disaggregation backend.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+
+__all__ = [
+    "ShmPinnedKVManager",
+    "ShmPinnedKVSender",
+    "ShmPinnedKVReceiver",
+    "ShmPinnedKVBootstrapServer",
+]
+
+
+def __getattr__(name: str):
+    if name not in __all__:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module = import_module("sglang.srt.disaggregation.shm_pinned.conn")
+    return getattr(module, name)
+
+
+def __dir__():
+    return sorted(__all__)

--- a/python/sglang/srt/disaggregation/shm_pinned/conn.py
+++ b/python/sglang/srt/disaggregation/shm_pinned/conn.py
@@ -1,0 +1,962 @@
+"""
+Connection classes for the shm_pinned backend.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import json
+import logging
+import threading
+import time
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+import numpy as np
+import numpy.typing as npt
+import zmq
+
+from sglang.srt.disaggregation.base.conn import KVArgs, KVPoll
+from sglang.srt.disaggregation.common.conn import (
+    CommonKVBootstrapServer,
+    CommonKVManager,
+    CommonKVReceiver,
+    CommonKVSender,
+)
+from sglang.srt.disaggregation.common.utils import group_concurrent_contiguous
+from sglang.srt.disaggregation.shm_pinned.transfer_engine import (
+    ShmPinnedTransferEngine,
+)
+from sglang.srt.disaggregation.shm_pinned.utils import (
+    DEFAULT_CHUNK_TOKENS,
+    DEFAULT_SLOT_COUNT,
+    ShmPinnedInfo,
+)
+from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.server_args import ServerArgs
+from sglang.srt.utils.network import NetworkAddress
+
+logger = logging.getLogger(__name__)
+
+RequestKey = tuple[str, int]
+
+
+def make_request_key(session_id: str, room: int) -> RequestKey:
+    return (session_id, int(room))
+
+
+@dataclass
+class TransferRequest:
+    room: int
+    session_id: str
+    dst_kv_indices: npt.NDArray[np.int32]
+    dst_aux_index: Optional[int] = None
+    engine: Optional[ShmPinnedTransferEngine] = None
+    total_pages: int = 0
+    received_pages: int = 0
+    last_chunk_seen: bool = False
+    received_bitmap: Optional[bytearray] = None
+
+
+class ShmPinnedKVManager(CommonKVManager):
+    def __init__(
+        self,
+        args: KVArgs,
+        disaggregation_mode: DisaggregationMode,
+        server_args: ServerArgs,
+        is_mla_backend: Optional[bool] = False,
+    ):
+        super().__init__(args, disaggregation_mode, server_args, is_mla_backend)
+        self._validate_state_support()
+
+        self.engine: Optional[ShmPinnedTransferEngine] = None
+        self.session_shm_table: Dict[str, ShmPinnedInfo] = {}
+        self.session_engines: Dict[str, ShmPinnedTransferEngine] = {}
+        self.pending_requests: Dict[RequestKey, TransferRequest] = {}
+        self.room_sessions: Dict[int, set[str]] = defaultdict(set)
+        self.pending_lock = threading.Lock()
+        self.decode_connections: Dict[str, tuple[object, threading.Lock]] = {}
+
+        self.slot_count = (
+            server_args.disaggregation_shm_slot_count or DEFAULT_SLOT_COUNT
+        )
+        self.chunk_tokens = (
+            server_args.disaggregation_shm_chunk_tokens or DEFAULT_CHUNK_TOKENS
+        )
+        page_size = max(1, int(getattr(self.kv_args, "page_size", 1)))
+        self.chunk_pages = max(1, (self.chunk_tokens + page_size - 1) // page_size)
+
+        if disaggregation_mode == DisaggregationMode.DECODE:
+            self._init_engine_decode()
+        elif disaggregation_mode == DisaggregationMode.PREFILL:
+            self._start_prefill_thread()
+
+    def _validate_state_support(self) -> None:
+        state_type = getattr(self.kv_args, "state_type", "none") or "none"
+        if state_type != "none":
+            raise ValueError(
+                "shm_pinned PR1 supports KV + aux only; state transfer is not supported."
+            )
+
+    def _init_engine_decode(self) -> None:
+        session_id = f"decode_{self.kv_args.engine_rank}_{int(time.time() * 1000)}"
+        aux_bytes = int(sum(getattr(self.kv_args, "aux_item_lens", []) or []))
+        self.engine = ShmPinnedTransferEngine(
+            session_id=session_id,
+            gpu_id=self.kv_args.gpu_id,
+            slot_count=self.slot_count,
+            chunk_pages=self.chunk_pages,
+            kv_item_lens=self.kv_args.kv_item_lens,
+            extra_slot_bytes=aux_bytes,
+            create=True,
+        )
+        self._decode_thread_running = True
+        self._decode_thread = threading.Thread(
+            target=self._decode_receive_loop,
+            daemon=True,
+        )
+        self._decode_thread.start()
+
+    def _start_prefill_thread(self) -> None:
+        self._prefill_thread_running = True
+        self._prefill_thread = threading.Thread(
+            target=self._prefill_transfer_loop,
+            daemon=True,
+        )
+        self._prefill_thread.start()
+
+    def _add_pending_request(self, req: TransferRequest) -> None:
+        key = make_request_key(req.session_id, req.room)
+        with self.pending_lock:
+            self.pending_requests[key] = req
+            self.room_sessions[req.room].add(req.session_id)
+
+    def _pop_pending_request(self, key: RequestKey) -> Optional[TransferRequest]:
+        with self.pending_lock:
+            req = self.pending_requests.pop(key, None)
+            if req is None:
+                return None
+            sessions = self.room_sessions.get(req.room)
+            if sessions is not None:
+                sessions.discard(req.session_id)
+                if not sessions:
+                    self.room_sessions.pop(req.room, None)
+            return req
+
+    def get_pending_request(
+        self, session_id: str, room: int
+    ) -> Optional[TransferRequest]:
+        with self.pending_lock:
+            return self.pending_requests.get(make_request_key(session_id, room))
+
+    def get_pending_request_for_room(self, room: int) -> Optional[TransferRequest]:
+        with self.pending_lock:
+            sessions = self.room_sessions.get(room)
+            if not sessions or len(sessions) != 1:
+                return None
+            session_id = next(iter(sessions))
+            return self.pending_requests.get(make_request_key(session_id, room))
+
+    def get_status(self, room: int) -> KVPoll:
+        return self.request_status.get(room, KVPoll.Failed)
+
+    def get_failure_message(self, room: int) -> Optional[str]:
+        with self.failure_lock:
+            return self.failure_records.get(room)
+
+    def _connect_to_decode(
+        self, session_id: str
+    ) -> Optional[tuple[object, threading.Lock]]:
+        if session_id in self.decode_connections:
+            return self.decode_connections[session_id]
+
+        shm_info = self.session_shm_table.get(session_id)
+        if shm_info is None or not shm_info.decode_host or not shm_info.decode_port:
+            return None
+
+        na = NetworkAddress(shm_info.decode_host, shm_info.decode_port)
+        sock, lock = CommonKVReceiver._connect(na.to_tcp(), is_ipv6=na.is_ipv6)
+        self.decode_connections[session_id] = (sock, lock)
+        return sock, lock
+
+    def _send_failure_to_decode(self, session_id: str, room: int, reason: str) -> None:
+        connection = self._connect_to_decode(session_id)
+        if connection is None:
+            logger.warning(
+                "No decode control channel for session=%s room=%s", session_id, room
+            )
+            return
+
+        sock, lock = connection
+        logger.info(
+            "shm_pinned sending FAIL to decode: session=%s room=%s reason=%s",
+            session_id,
+            room,
+            reason,
+        )
+        with lock:
+            sock.send_multipart(
+                [
+                    b"FAIL",
+                    str(room).encode("utf-8"),
+                    session_id.encode("utf-8"),
+                    reason.encode("utf-8"),
+                ]
+            )
+
+    def _prefill_transfer_loop(self) -> None:
+        while self._prefill_thread_running:
+            try:
+                msg = self.server_socket.recv_multipart(flags=zmq.NOBLOCK)
+            except zmq.Again:
+                time.sleep(0.05)
+                continue
+            except Exception as e:
+                if self._prefill_thread_running:
+                    logger.error("Prefill transfer loop error: %s", e)
+                    time.sleep(0.1)
+                continue
+
+            try:
+                msg_type = msg[0].decode("utf-8")
+                if msg_type == "SHM_INFO":
+                    session_id = msg[1].decode("utf-8")
+                    shm_info = ShmPinnedInfo.from_dict(
+                        json.loads(msg[2].decode("utf-8"))
+                    )
+                    self._handle_shm_info(session_id, shm_info)
+                elif msg_type == "TRANSFER_REQ":
+                    room = int(msg[1].decode("utf-8"))
+                    session_id = msg[2].decode("utf-8")
+                    dst_kv_indices = np.frombuffer(msg[3], dtype=np.int32).copy()
+                    self._handle_transfer_request(room, session_id, dst_kv_indices)
+                elif msg_type == "ABORT":
+                    room = int(msg[1].decode("utf-8"))
+                    session_id = msg[2].decode("utf-8") if len(msg) > 2 else ""
+                    self._handle_abort(room, session_id)
+            except Exception as e:
+                logger.error("Failed to handle prefill control message: %s", e)
+
+    def _drain_decode_control_messages(self) -> None:
+        while True:
+            try:
+                msg = self.server_socket.recv_multipart(flags=zmq.NOBLOCK)
+            except zmq.Again:
+                return
+            except Exception as e:
+                if self._decode_thread_running:
+                    logger.error("Decode control loop error: %s", e)
+                return
+
+            try:
+                msg_type = msg[0].decode("utf-8")
+                if msg_type not in {"FAIL", "ABORT"}:
+                    continue
+                room = int(msg[1].decode("utf-8"))
+                session_id = msg[2].decode("utf-8")
+                reason = (
+                    msg[3].decode("utf-8") if len(msg) > 3 else "Remote transfer failed"
+                )
+                self.record_failure(room, reason)
+                self.update_status(room, KVPoll.Failed)
+                self._pop_pending_request(make_request_key(session_id, room))
+            except Exception as e:
+                logger.error("Failed to handle decode control message: %s", e)
+
+    def _decode_receive_loop(self) -> None:
+        while self._decode_thread_running:
+            self._drain_decode_control_messages()
+
+            if self.engine is None:
+                time.sleep(0.05)
+                continue
+
+            slot_idx = None
+            slot_released = False
+            try:
+                slot_idx = self.engine.wait_ready(timeout=0.5)
+                meta = self.engine.read_meta(slot_idx)
+                key = make_request_key(self.engine.session_id, meta.room)
+                req = self.get_pending_request(self.engine.session_id, meta.room)
+                logger.debug(
+                    "shm_pinned decode received slot: session=%s room=%s slot=%s "
+                    "index_start=%s index_len=%s is_last=%s seqno=%s",
+                    self.engine.session_id,
+                    meta.room,
+                    slot_idx,
+                    meta.index_start,
+                    meta.index_len,
+                    meta.is_last,
+                    meta.seqno,
+                )
+                if req is None:
+                    logger.warning(
+                        "shm_pinned decode missing pending request: session=%s room=%s",
+                        self.engine.session_id,
+                        meta.room,
+                    )
+                    self.engine.post_free(slot_idx)
+                    slot_released = True
+                    continue
+
+                start_idx = meta.index_start
+                end_idx = meta.index_start + meta.index_len
+                total_pages = req.total_pages or len(req.dst_kv_indices)
+
+                def fail(reason: str) -> None:
+                    nonlocal slot_released
+                    self.record_failure(meta.room, reason)
+                    self.update_status(meta.room, KVPoll.Failed)
+                    self._pop_pending_request(key)
+                    if not slot_released:
+                        self.engine.post_free(slot_idx)
+                        slot_released = True
+
+                if end_idx > total_pages:
+                    fail("Decode received out-of-range dst indices")
+                    continue
+                if meta.is_last and end_idx != total_pages:
+                    fail("Decode received last chunk not aligned to total pages")
+                    continue
+
+                if req.received_bitmap is None:
+                    req.received_bitmap = bytearray(total_pages)
+                if any(req.received_bitmap[i] for i in range(start_idx, end_idx)):
+                    fail("Decode received duplicate pages")
+                    continue
+
+                dst_indices = req.dst_kv_indices[start_idx:end_idx]
+                kv_bytes = self._calculate_chunk_bytes(meta.index_len)
+                self._do_h2d_copy(slot_idx, dst_indices)
+
+                if meta.is_last and self._calculate_aux_bytes() > 0:
+                    self._copy_aux_from_slot(slot_idx, kv_bytes, req.dst_aux_index)
+
+                self.engine.post_free(slot_idx)
+                slot_released = True
+
+                for i in range(start_idx, end_idx):
+                    req.received_bitmap[i] = 1
+                req.received_pages += end_idx - start_idx
+                if meta.is_last:
+                    req.last_chunk_seen = True
+
+                if req.received_pages == total_pages and req.last_chunk_seen:
+                    self._pop_pending_request(key)
+                    self.update_status(meta.room, KVPoll.Success)
+                    logger.debug(
+                        "shm_pinned decode transfer complete: session=%s room=%s total_pages=%s",
+                        self.engine.session_id,
+                        meta.room,
+                        total_pages,
+                    )
+            except Exception as e:
+                if self._decode_thread_running and slot_idx is not None:
+                    logger.error("Decode receive loop error: %s", e)
+            finally:
+                if (
+                    slot_idx is not None
+                    and not slot_released
+                    and self.engine is not None
+                ):
+                    try:
+                        self.engine.post_free(slot_idx)
+                    except Exception:
+                        pass
+
+    def _handle_shm_info(self, session_id: str, shm_info: ShmPinnedInfo) -> None:
+        if session_id in self.session_engines:
+            return
+        logger.info(
+            "shm_pinned prefill opening shared memory: session=%s slot_count=%s slot_bytes=%s",
+            session_id,
+            shm_info.slot_count,
+            shm_info.slot_bytes,
+        )
+        engine = ShmPinnedTransferEngine(
+            session_id=session_id,
+            gpu_id=self.kv_args.gpu_id,
+            create=False,
+        )
+        engine.open_from_info(shm_info)
+        self.session_shm_table[session_id] = shm_info
+        self.session_engines[session_id] = engine
+
+    def _handle_transfer_request(
+        self,
+        room: int,
+        session_id: str,
+        dst_kv_indices: npt.NDArray[np.int32],
+    ) -> None:
+        engine = self.session_engines.get(session_id)
+        if engine is None:
+            reason = f"Missing SHM engine for session {session_id}"
+            self.record_failure(room, reason)
+            self.update_status(room, KVPoll.Failed)
+            self._send_failure_to_decode(session_id, room, reason)
+            return
+
+        logger.debug(
+            "shm_pinned prefill received TRANSFER_REQ: session=%s room=%s total_pages=%s",
+            session_id,
+            room,
+            len(dst_kv_indices),
+        )
+        self._add_pending_request(
+            TransferRequest(
+                room=room,
+                session_id=session_id,
+                dst_kv_indices=dst_kv_indices,
+                engine=engine,
+                total_pages=len(dst_kv_indices),
+            )
+        )
+        self.update_status(room, KVPoll.WaitingForInput)
+
+    def _handle_abort(self, room: int, session_id: str) -> None:
+        logger.info(
+            "shm_pinned received ABORT: session=%s room=%s",
+            session_id,
+            room,
+        )
+        if session_id:
+            self._pop_pending_request(make_request_key(session_id, room))
+        self.update_status(room, KVPoll.Failed)
+
+    def _do_h2d_copy(
+        self,
+        slot_idx: int,
+        dst_indices: npt.NDArray[np.int32],
+    ) -> None:
+        if self.engine is None or dst_indices.size == 0:
+            return
+
+        slot_ptr = self.engine.get_slot_data_ptr(slot_idx)
+        offset = 0
+        contiguous = np.all(np.diff(dst_indices) == 1)
+
+        for buf_ptr, item_len in zip(
+            self.kv_args.kv_data_ptrs,
+            self.kv_args.kv_item_lens,
+        ):
+            item_len = int(item_len)
+            if contiguous:
+                start_page = int(dst_indices[0])
+                total_bytes = item_len * int(dst_indices.size)
+                self.engine.cuda_memcpy(
+                    dst_ptr=buf_ptr + start_page * item_len,
+                    src_ptr=slot_ptr + offset,
+                    num_bytes=total_bytes,
+                )
+                offset += total_bytes
+            else:
+                for j, page_idx in enumerate(dst_indices.tolist()):
+                    self.engine.cuda_memcpy(
+                        dst_ptr=buf_ptr + int(page_idx) * item_len,
+                        src_ptr=slot_ptr + offset + j * item_len,
+                        num_bytes=item_len,
+                    )
+                offset += item_len * int(dst_indices.size)
+
+    def _calculate_chunk_bytes(self, num_indices: int) -> int:
+        return int(num_indices) * int(sum(self.kv_args.kv_item_lens))
+
+    def _calculate_aux_bytes(self) -> int:
+        aux_item_lens = getattr(self.kv_args, "aux_item_lens", None) or []
+        return int(sum(aux_item_lens))
+
+    def _copy_aux_from_slot(
+        self,
+        slot_idx: int,
+        kv_bytes: int,
+        aux_index: Optional[int],
+    ) -> None:
+        if self.engine is None:
+            raise RuntimeError("Transfer engine not initialized")
+        if aux_index is None:
+            raise RuntimeError("Aux index is required for aux copy")
+
+        slot_ptr = self.engine.get_slot_data_ptr(slot_idx)
+        offset = int(kv_bytes)
+        for aux_ptr, item_len in zip(
+            self.kv_args.aux_data_ptrs,
+            self.kv_args.aux_item_lens,
+        ):
+            item_len = int(item_len)
+            ctypes.memmove(
+                aux_ptr + item_len * int(aux_index),
+                slot_ptr + offset,
+                item_len,
+            )
+            offset += item_len
+
+    def close(self) -> None:
+        if hasattr(self, "_prefill_thread_running"):
+            self._prefill_thread_running = False
+        if hasattr(self, "_decode_thread_running"):
+            self._decode_thread_running = False
+        if hasattr(self, "_prefill_thread"):
+            self._prefill_thread.join(timeout=1.0)
+        if hasattr(self, "_decode_thread"):
+            self._decode_thread.join(timeout=1.0)
+        if self.engine is not None:
+            self.engine.close()
+        for engine in self.session_engines.values():
+            if engine is not self.engine:
+                engine.close()
+
+
+class ShmPinnedKVSender(CommonKVSender):
+    def __init__(
+        self,
+        mgr: ShmPinnedKVManager,
+        bootstrap_addr: str,
+        bootstrap_room: int,
+        dest_tp_ranks: List[int],
+        pp_rank: int,
+    ):
+        super().__init__(mgr, bootstrap_addr, bootstrap_room, dest_tp_ranks, pp_rank)
+        self.kv_mgr: ShmPinnedKVManager = mgr
+        self.dest_tp_ranks = dest_tp_ranks
+        self.pp_rank = pp_rank
+        self.session_id: Optional[str] = None
+        self.session_engine: Optional[ShmPinnedTransferEngine] = None
+        self.dst_kv_indices: Optional[npt.NDArray[np.int32]] = None
+        self.sent_chunks = 0
+
+    def init(self, num_kv_indices: int, aux_index: Optional[int] = None) -> None:
+        super().init(num_kv_indices, aux_index)
+
+    def _mark_failed(self, reason: str) -> None:
+        self.kv_mgr.record_failure(self.bootstrap_room, reason)
+        self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
+        if self.session_id is not None:
+            self.kv_mgr._pop_pending_request(
+                make_request_key(self.session_id, self.bootstrap_room)
+            )
+            self.kv_mgr._send_failure_to_decode(
+                self.session_id,
+                self.bootstrap_room,
+                reason,
+            )
+
+    def _ensure_session_ready(self) -> bool:
+        if self.session_engine is not None and self.dst_kv_indices is not None:
+            return True
+
+        req = (
+            self.kv_mgr.get_pending_request(self.session_id, self.bootstrap_room)
+            if self.session_id is not None
+            else self.kv_mgr.get_pending_request_for_room(self.bootstrap_room)
+        )
+        if req is None:
+            return False
+
+        self.session_id = req.session_id
+        if req.engine is None:
+            req.engine = self.kv_mgr.session_engines.get(req.session_id)
+        self.session_engine = req.engine
+        self.dst_kv_indices = req.dst_kv_indices
+        logger.debug(
+            "shm_pinned sender attached session: session=%s room=%s total_pages=%s",
+            self.session_id,
+            self.bootstrap_room,
+            len(self.dst_kv_indices),
+        )
+        return self.session_engine is not None and self.dst_kv_indices is not None
+
+    def send(
+        self,
+        kv_indices: npt.NDArray[np.int32],
+        state_indices: Optional[List[int]] = None,
+    ) -> None:
+        if state_indices is not None:
+            self._mark_failed("shm_pinned PR1 does not support state transfer")
+            return
+        if self.kv_mgr.is_dummy_cp_rank:
+            return
+
+        try:
+            if not self._ensure_session_ready():
+                self._mark_failed("Session engine not initialized")
+                return
+            assert self.dst_kv_indices is not None
+
+            logger.debug(
+                "shm_pinned sender send start: session=%s room=%s curr_idx=%s chunk_pages=%s len(kv_indices)=%s",
+                self.session_id,
+                self.bootstrap_room,
+                self.curr_idx,
+                self.kv_mgr.chunk_pages,
+                len(kv_indices),
+            )
+
+            if self.curr_idx + len(kv_indices) > len(self.dst_kv_indices):
+                self._mark_failed("KV indices exceed destination buffer length")
+                return
+
+            src_groups, dst_groups = group_concurrent_contiguous(
+                kv_indices.astype(np.int32),
+                self.dst_kv_indices[self.curr_idx : self.curr_idx + len(kv_indices)],
+            )
+
+            if self.curr_idx == 0:
+                self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Transferring)
+
+            is_last = (self.curr_idx + len(kv_indices)) >= self.num_kv_indices
+            if is_last and self._calculate_aux_bytes() > 0 and self.aux_index is None:
+                self._mark_failed("Missing aux index for last chunk")
+                return
+
+            chunk_start = self.curr_idx
+            max_pages = self.kv_mgr.chunk_pages
+            for group_idx, (src_chunk, dst_chunk) in enumerate(
+                zip(src_groups, dst_groups)
+            ):
+                group_len = len(src_chunk)
+                for offset in range(0, group_len, max_pages):
+                    sub_src = np.array(
+                        src_chunk[offset : offset + max_pages],
+                        dtype=np.int32,
+                    )
+                    sub_dst = np.array(
+                        dst_chunk[offset : offset + max_pages],
+                        dtype=np.int32,
+                    )
+                    is_last_sub = (
+                        is_last
+                        and group_idx == len(src_groups) - 1
+                        and offset + len(sub_src) == group_len
+                    )
+                    self._send_chunk(
+                        src_indices=sub_src,
+                        dst_indices=sub_dst,
+                        index_start=chunk_start + offset,
+                        is_last=is_last_sub,
+                    )
+                chunk_start += group_len
+
+            self.curr_idx += len(kv_indices)
+            if is_last and self.session_id is not None:
+                self.kv_mgr._pop_pending_request(
+                    make_request_key(self.session_id, self.bootstrap_room)
+                )
+                self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Success)
+                logger.debug(
+                    "shm_pinned sender transfer complete: session=%s room=%s total_pages=%s",
+                    self.session_id,
+                    self.bootstrap_room,
+                    self.curr_idx,
+                )
+        except Exception as e:
+            self._mark_failed(str(e))
+
+    def _send_chunk(
+        self,
+        src_indices: npt.NDArray[np.int32],
+        dst_indices: npt.NDArray[np.int32],
+        index_start: int,
+        is_last: bool,
+    ) -> None:
+        if self.session_engine is None:
+            raise RuntimeError("Session engine not initialized")
+
+        slot_idx = None
+        try:
+            logger.debug(
+                "shm_pinned sender waiting for free slot: session=%s room=%s index_start=%s index_len=%s is_last=%s",
+                self.session_id,
+                self.bootstrap_room,
+                index_start,
+                len(src_indices),
+                is_last,
+            )
+            slot_idx = self.session_engine.wait_free()
+            kv_bytes = self._calculate_chunk_bytes(len(src_indices))
+            aux_bytes = self._calculate_aux_bytes()
+            valid_bytes = kv_bytes + (aux_bytes if is_last else 0)
+            if valid_bytes > self.session_engine.slot_bytes:
+                raise RuntimeError(
+                    f"Chunk bytes {valid_bytes} exceed slot size {self.session_engine.slot_bytes}"
+                )
+
+            self.session_engine.write_meta(
+                slot_idx=slot_idx,
+                room=self.bootstrap_room,
+                index_start=index_start,
+                index_len=len(src_indices),
+                is_last=is_last,
+                valid_bytes=valid_bytes,
+                seqno=self.sent_chunks,
+            )
+            self._do_d2h_copy(slot_idx, src_indices)
+
+            if is_last and aux_bytes > 0:
+                self._copy_aux_to_slot(slot_idx, kv_bytes, self.aux_index)
+
+            self.session_engine.post_ready(slot_idx)
+            self.sent_chunks += 1
+            logger.debug(
+                "shm_pinned sender posted ready slot: session=%s room=%s slot=%s index_start=%s index_len=%s is_last=%s seqno=%s",
+                self.session_id,
+                self.bootstrap_room,
+                slot_idx,
+                index_start,
+                len(src_indices),
+                is_last,
+                self.sent_chunks - 1,
+            )
+        except Exception:
+            if slot_idx is not None:
+                try:
+                    self.session_engine.post_free(slot_idx)
+                except Exception:
+                    pass
+            raise
+
+    def _do_d2h_copy(
+        self,
+        slot_idx: int,
+        src_indices: npt.NDArray[np.int32],
+    ) -> None:
+        if self.session_engine is None or src_indices.size == 0:
+            return
+
+        slot_ptr = self.session_engine.get_slot_data_ptr(slot_idx)
+        offset = 0
+        contiguous = np.all(np.diff(src_indices) == 1)
+
+        for buf_ptr, item_len in zip(
+            self.kv_mgr.kv_args.kv_data_ptrs,
+            self.kv_mgr.kv_args.kv_item_lens,
+        ):
+            item_len = int(item_len)
+            if contiguous:
+                start_page = int(src_indices[0])
+                total_bytes = item_len * int(src_indices.size)
+                self.session_engine.cuda_memcpy(
+                    dst_ptr=slot_ptr + offset,
+                    src_ptr=buf_ptr + start_page * item_len,
+                    num_bytes=total_bytes,
+                )
+                offset += total_bytes
+            else:
+                for j, page_idx in enumerate(src_indices.tolist()):
+                    self.session_engine.cuda_memcpy(
+                        dst_ptr=slot_ptr + offset + j * item_len,
+                        src_ptr=buf_ptr + int(page_idx) * item_len,
+                        num_bytes=item_len,
+                    )
+                offset += item_len * int(src_indices.size)
+
+    def _calculate_chunk_bytes(self, num_indices: int) -> int:
+        return int(num_indices) * int(sum(self.kv_mgr.kv_args.kv_item_lens))
+
+    def _calculate_aux_bytes(self) -> int:
+        return int(sum(getattr(self.kv_mgr.kv_args, "aux_item_lens", []) or []))
+
+    def _copy_aux_to_slot(
+        self,
+        slot_idx: int,
+        kv_bytes: int,
+        aux_index: Optional[int],
+    ) -> None:
+        if self.session_engine is None:
+            raise RuntimeError("Session engine not initialized")
+        if aux_index is None:
+            raise RuntimeError("Aux index is required for aux copy")
+
+        slot_ptr = self.session_engine.get_slot_data_ptr(slot_idx)
+        offset = int(kv_bytes)
+        for aux_ptr, item_len in zip(
+            self.kv_mgr.kv_args.aux_data_ptrs,
+            self.kv_mgr.kv_args.aux_item_lens,
+        ):
+            item_len = int(item_len)
+            ctypes.memmove(
+                slot_ptr + offset,
+                aux_ptr + item_len * int(aux_index),
+                item_len,
+            )
+            offset += item_len
+
+    def poll(self) -> KVPoll:
+        return self.kv_mgr.get_status(self.bootstrap_room)
+
+    def failure_exception(self) -> Exception:
+        message = self.kv_mgr.get_failure_message(self.bootstrap_room)
+        return RuntimeError(f"ShmPinned transfer failed: {message}")
+
+
+class ShmPinnedKVReceiver(CommonKVReceiver):
+    def __init__(
+        self,
+        mgr: ShmPinnedKVManager,
+        bootstrap_addr: str,
+        bootstrap_room: Optional[int] = None,
+    ):
+        super().__init__(mgr, bootstrap_addr, bootstrap_room)
+        self.kv_mgr: ShmPinnedKVManager = mgr
+        self.kv_indices: Optional[npt.NDArray[np.int32]] = None
+        self.aux_index: Optional[int] = None
+        self.session_id: Optional[str] = None
+        self.transfer_timeout = 300.0
+        self.transfer_start_time: Optional[float] = None
+
+    def init(self, prefill_dp_rank: int) -> None:
+        super().init(prefill_dp_rank)
+
+    def send_metadata(
+        self,
+        kv_indices: npt.NDArray[np.int32],
+        aux_index: Optional[int] = None,
+        state_indices: Optional[List[int]] = None,
+    ) -> None:
+        if state_indices is not None:
+            self.kv_mgr.record_failure(
+                self.bootstrap_room,
+                "shm_pinned PR1 does not support state transfer",
+            )
+            self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
+            return
+        if self.kv_mgr.engine is None:
+            self.kv_mgr.record_failure(self.bootstrap_room, "Engine not initialized")
+            self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
+            return
+
+        self.kv_indices = kv_indices
+        self.aux_index = aux_index
+        self.session_id = self.kv_mgr.engine.session_id
+        self.transfer_start_time = time.time()
+        total_pages = int(len(kv_indices))
+        logger.debug(
+            "shm_pinned receiver init: session=%s room=%s total_pages=%s aux_index=%s",
+            self.session_id,
+            self.bootstrap_room,
+            total_pages,
+            aux_index,
+        )
+
+        self.kv_mgr._add_pending_request(
+            TransferRequest(
+                room=self.bootstrap_room,
+                session_id=self.session_id,
+                dst_kv_indices=kv_indices,
+                dst_aux_index=aux_index,
+                total_pages=total_pages,
+                received_bitmap=bytearray(total_pages),
+            )
+        )
+
+        self._send_shm_info_to_prefill()
+        self._send_transfer_req_to_prefill()
+        self.kv_mgr.update_status(self.bootstrap_room, KVPoll.WaitingForInput)
+
+    def _send_shm_info_to_prefill(self) -> None:
+        if self.kv_mgr.engine is None or self.bootstrap_infos is None:
+            return
+
+        shm_info = self.kv_mgr.engine.export_info()
+        shm_info.decode_host = self.kv_mgr.local_ip
+        shm_info.decode_port = self.kv_mgr.rank_port
+        logger.debug(
+            "shm_pinned receiver sending SHM_INFO: session=%s room=%s decode=%s:%s",
+            shm_info.session_id,
+            self.bootstrap_room,
+            shm_info.decode_host,
+            shm_info.decode_port,
+        )
+
+        for bootstrap_info in self.bootstrap_infos:
+            if bootstrap_info.get("is_dummy"):
+                continue
+            sock, lock = self._connect_to_bootstrap_server(bootstrap_info)
+            with lock:
+                sock.send_multipart(
+                    [
+                        b"SHM_INFO",
+                        shm_info.session_id.encode("utf-8"),
+                        json.dumps(shm_info.to_dict()).encode("utf-8"),
+                    ]
+                )
+
+    def _send_transfer_req_to_prefill(self) -> None:
+        if (
+            self.kv_indices is None
+            or self.bootstrap_infos is None
+            or self.session_id is None
+        ):
+            return
+
+        payload = self.kv_indices.astype(np.int32).tobytes()
+        logger.debug(
+            "shm_pinned receiver sending TRANSFER_REQ: session=%s room=%s total_pages=%s",
+            self.session_id,
+            self.bootstrap_room,
+            len(self.kv_indices),
+        )
+        for bootstrap_info in self.bootstrap_infos:
+            if bootstrap_info.get("is_dummy"):
+                continue
+            sock, lock = self._connect_to_bootstrap_server(bootstrap_info)
+            with lock:
+                sock.send_multipart(
+                    [
+                        b"TRANSFER_REQ",
+                        str(self.bootstrap_room).encode("utf-8"),
+                        self.session_id.encode("utf-8"),
+                        payload,
+                    ]
+                )
+
+    def poll(self) -> KVPoll:
+        status = self.kv_mgr.get_status(self.bootstrap_room)
+        if status == KVPoll.Bootstrapping and self.kv_indices is None:
+            return KVPoll.WaitingForInput
+        if status in (KVPoll.WaitingForInput, KVPoll.Transferring):
+            if self.transfer_start_time is not None:
+                elapsed = time.time() - self.transfer_start_time
+                if elapsed > self.transfer_timeout:
+                    reason = f"Transfer timeout after {elapsed:.1f}s"
+                    self.kv_mgr.record_failure(self.bootstrap_room, reason)
+                    self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
+                    self.abort()
+                    return KVPoll.Failed
+        return status
+
+    def failure_exception(self) -> Exception:
+        message = self.kv_mgr.get_failure_message(self.bootstrap_room)
+        return RuntimeError(f"ShmPinned receive failed: {message}")
+
+    def clear(self) -> None:
+        if self.session_id is None:
+            return
+        self.kv_mgr._pop_pending_request(
+            make_request_key(self.session_id, self.bootstrap_room)
+        )
+
+    def abort(self) -> None:
+        self.clear()
+        self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
+        if self.bootstrap_infos is None or self.session_id is None:
+            return
+        for bootstrap_info in self.bootstrap_infos:
+            if bootstrap_info.get("is_dummy"):
+                continue
+            try:
+                sock, lock = self._connect_to_bootstrap_server(bootstrap_info)
+                with lock:
+                    sock.send_multipart(
+                        [
+                            b"ABORT",
+                            str(self.bootstrap_room).encode("utf-8"),
+                            self.session_id.encode("utf-8"),
+                        ]
+                    )
+            except Exception as e:
+                logger.warning("Failed to send abort to prefill: %s", e)
+
+
+class ShmPinnedKVBootstrapServer(CommonKVBootstrapServer):
+    pass

--- a/python/sglang/srt/disaggregation/shm_pinned/transfer_engine.py
+++ b/python/sglang/srt/disaggregation/shm_pinned/transfer_engine.py
@@ -1,0 +1,439 @@
+"""
+Shared-memory transfer engine for the shm_pinned backend.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import logging
+import mmap
+import os
+import time
+from typing import Any, Optional
+
+import numpy as np
+import torch
+
+from sglang.srt.disaggregation.shm_pinned.utils import (
+    DEFAULT_SLOT_COUNT,
+    ShmHeader,
+    ShmPinnedInfo,
+    SlotMeta,
+    SlotState,
+    calculate_meta_shm_size,
+    calculate_slot_bytes,
+    generate_shm_names,
+    get_slot_meta_offset,
+)
+from sglang.srt.distributed.device_communicators.cuda_wrapper import CudaRTLibrary
+
+try:
+    import posix_ipc
+except ImportError:
+    posix_ipc = None
+
+logger = logging.getLogger(__name__)
+
+
+def _require_posix_ipc():
+    if posix_ipc is None:
+        raise ImportError(
+            "shm_pinned requires the optional dependency `posix_ipc` on Linux."
+        )
+    return posix_ipc
+
+
+class ShmPinnedTransferEngine:
+    def __init__(
+        self,
+        session_id: str,
+        gpu_id: int,
+        slot_count: int = DEFAULT_SLOT_COUNT,
+        chunk_pages: Optional[int] = None,
+        kv_item_lens: Optional[list[int]] = None,
+        extra_slot_bytes: int = 0,
+        create: bool = True,
+    ):
+        self._posix_ipc = _require_posix_ipc()
+        self.session_id = session_id
+        self.gpu_id = gpu_id
+        self.slot_count = int(slot_count)
+        self.chunk_pages = 0 if chunk_pages is None else int(chunk_pages)
+        self.kv_item_lens = list(kv_item_lens or [])
+        self.extra_slot_bytes = int(extra_slot_bytes)
+        self.create = create
+        self._closed = False
+
+        if create and chunk_pages is None:
+            raise ValueError("chunk_pages is required when create=True")
+
+        self.data_shm: Any = None
+        self.meta_shm: Any = None
+        self.data_mmap: Optional[mmap.mmap] = None
+        self.meta_mmap: Optional[mmap.mmap] = None
+
+        self.sem_free: Any = None
+        self.sem_ready: Any = None
+        self.sem_slot: Any = None
+
+        self.data_shm_name = ""
+        self.meta_shm_name = ""
+        self.sem_free_name = ""
+        self.sem_ready_name = ""
+        self.sem_slot_name = ""
+
+        self.slot_bytes = 0
+        self.meta_size = 0
+
+        self._cuda_registered = False
+        self._data_ptr = 0
+        self._cudart: Optional[CudaRTLibrary] = None
+
+        if create:
+            self._create_shm()
+
+    def _create_shm(self) -> None:
+        (
+            self.data_shm_name,
+            self.meta_shm_name,
+            self.sem_free_name,
+            self.sem_ready_name,
+            self.sem_slot_name,
+        ) = generate_shm_names(self.session_id)
+        self._calculate_sizes()
+
+        try:
+            self.data_shm = self._posix_ipc.SharedMemory(
+                self.data_shm_name,
+                flags=self._posix_ipc.O_CREX,
+                size=self.slot_count * self.slot_bytes,
+            )
+            self.meta_size = calculate_meta_shm_size(self.slot_count)
+            self.meta_shm = self._posix_ipc.SharedMemory(
+                self.meta_shm_name,
+                flags=self._posix_ipc.O_CREX,
+                size=self.meta_size,
+            )
+
+            self.data_mmap = mmap.mmap(
+                self.data_shm.fd,
+                self.slot_count * self.slot_bytes,
+            )
+            self.data_shm.close_fd()
+
+            self.meta_mmap = mmap.mmap(self.meta_shm.fd, self.meta_size)
+            self.meta_shm.close_fd()
+
+            self.meta_mmap.seek(0)
+            self.meta_mmap.write(
+                ShmHeader(slot_count=self.slot_count, slot_bytes=self.slot_bytes).pack()
+            )
+            for slot_idx in range(self.slot_count):
+                self._write_slot_meta(slot_idx, SlotMeta())
+
+            self.sem_free = self._posix_ipc.Semaphore(
+                self.sem_free_name,
+                flags=self._posix_ipc.O_CREX,
+                initial_value=self.slot_count,
+            )
+            self.sem_ready = self._posix_ipc.Semaphore(
+                self.sem_ready_name,
+                flags=self._posix_ipc.O_CREX,
+                initial_value=0,
+            )
+            self.sem_slot = self._posix_ipc.Semaphore(
+                self.sem_slot_name,
+                flags=self._posix_ipc.O_CREX,
+                initial_value=1,
+            )
+
+            self._register_cuda()
+        except Exception:
+            self._cleanup()
+            raise
+
+    def _calculate_sizes(self) -> None:
+        self.slot_bytes = calculate_slot_bytes(
+            self.chunk_pages,
+            self.kv_item_lens,
+            extra_slot_bytes=self.extra_slot_bytes,
+        )
+
+    def _register_cuda(self) -> None:
+        if self.data_mmap is None or not torch.cuda.is_available():
+            return
+
+        try:
+            data_array = np.frombuffer(self.data_mmap, dtype=np.uint8)
+            self._data_ptr = data_array.ctypes.data_as(ctypes.c_void_p).value
+            torch.cuda.cudart().cudaHostRegister(
+                self._data_ptr,
+                self.slot_count * self.slot_bytes,
+                0,
+            )
+            self._cuda_registered = True
+        except Exception as e:
+            logger.warning("Failed to register CUDA pinned memory: %s", e)
+
+    def _unregister_cuda(self) -> None:
+        if not self._cuda_registered or self._data_ptr == 0:
+            return
+        if not torch.cuda.is_available():
+            return
+        try:
+            torch.cuda.cudart().cudaHostUnregister(self._data_ptr)
+        except Exception as e:
+            logger.warning("Failed to unregister CUDA memory: %s", e)
+        finally:
+            self._cuda_registered = False
+
+    def open_from_info(self, info: ShmPinnedInfo) -> None:
+        self.data_shm_name = info.data_shm_name
+        self.meta_shm_name = info.meta_shm_name
+        self.sem_free_name = info.sem_free_name
+        self.sem_ready_name = info.sem_ready_name
+        self.sem_slot_name = info.sem_slot_name
+        self.slot_count = int(info.slot_count)
+        self.slot_bytes = int(info.slot_bytes)
+        self.kv_item_lens = list(info.kv_item_lens)
+
+        try:
+            self.data_shm = self._posix_ipc.SharedMemory(self.data_shm_name)
+            self.meta_shm = self._posix_ipc.SharedMemory(self.meta_shm_name)
+
+            self.data_mmap = mmap.mmap(
+                self.data_shm.fd,
+                self.slot_count * self.slot_bytes,
+            )
+            self.data_shm.close_fd()
+
+            self.meta_size = calculate_meta_shm_size(self.slot_count)
+            self.meta_mmap = mmap.mmap(self.meta_shm.fd, self.meta_size)
+            self.meta_shm.close_fd()
+
+            if not self._read_header().validate():
+                raise RuntimeError("Invalid shared memory header")
+
+            self.sem_free = self._posix_ipc.Semaphore(self.sem_free_name)
+            self.sem_ready = self._posix_ipc.Semaphore(self.sem_ready_name)
+            self.sem_slot = (
+                self._posix_ipc.Semaphore(self.sem_slot_name)
+                if self.sem_slot_name
+                else None
+            )
+            self._register_cuda()
+        except Exception:
+            self._cleanup()
+            raise
+
+    def export_info(self) -> ShmPinnedInfo:
+        return ShmPinnedInfo(
+            data_shm_name=self.data_shm_name,
+            meta_shm_name=self.meta_shm_name,
+            sem_free_name=self.sem_free_name,
+            sem_ready_name=self.sem_ready_name,
+            sem_slot_name=self.sem_slot_name,
+            slot_count=self.slot_count,
+            slot_bytes=self.slot_bytes,
+            session_id=self.session_id,
+            kv_item_lens=self.kv_item_lens,
+        )
+
+    def _read_header(self) -> ShmHeader:
+        if self.meta_mmap is None:
+            raise RuntimeError("Meta shared memory not mapped")
+        self.meta_mmap.seek(0)
+        return ShmHeader.unpack(self.meta_mmap.read(ShmHeader.size()))
+
+    def _write_slot_meta(self, slot_idx: int, meta: SlotMeta) -> None:
+        if self.meta_mmap is None:
+            raise RuntimeError("Meta shared memory not mapped")
+        self.meta_mmap.seek(get_slot_meta_offset(slot_idx))
+        self.meta_mmap.write(meta.pack())
+
+    def _read_slot_meta(self, slot_idx: int) -> SlotMeta:
+        if self.meta_mmap is None:
+            raise RuntimeError("Meta shared memory not mapped")
+        self.meta_mmap.seek(get_slot_meta_offset(slot_idx))
+        return SlotMeta.unpack(self.meta_mmap.read(SlotMeta.size()))
+
+    def get_slot_data_ptr(self, slot_idx: int) -> int:
+        if self._data_ptr == 0:
+            raise RuntimeError("Data pointer not available")
+        return self._data_ptr + int(slot_idx) * self.slot_bytes
+
+    def _acquire_semaphore(self, sem: Any, timeout: Optional[float]) -> None:
+        if timeout is None:
+            sem.acquire()
+        else:
+            sem.acquire(timeout)
+
+    def _remaining_timeout(self, deadline: Optional[float]) -> Optional[float]:
+        if deadline is None:
+            return None
+        return max(0.0, deadline - time.monotonic())
+
+    def wait_free(self, timeout: Optional[float] = None) -> int:
+        if self.sem_free is None:
+            raise RuntimeError("Semaphore not initialized")
+
+        deadline = None if timeout is None else time.monotonic() + timeout
+        self._acquire_semaphore(self.sem_free, timeout)
+        if self.sem_slot is not None:
+            try:
+                self._acquire_semaphore(
+                    self.sem_slot,
+                    self._remaining_timeout(deadline),
+                )
+            except self._posix_ipc.BusyError:
+                self.sem_free.release()
+                raise
+
+        try:
+            for slot_idx in range(self.slot_count):
+                meta = self._read_slot_meta(slot_idx)
+                if meta.state == SlotState.FREE:
+                    meta.state = SlotState.WRITING
+                    self._write_slot_meta(slot_idx, meta)
+                    return slot_idx
+        finally:
+            if self.sem_slot is not None:
+                self.sem_slot.release()
+
+        self.sem_free.release()
+        raise RuntimeError("No free slot found despite semaphore signaling")
+
+    def post_free(self, slot_idx: int) -> None:
+        if self.sem_free is None:
+            raise RuntimeError("Semaphore not initialized")
+        meta = self._read_slot_meta(slot_idx)
+        meta.state = SlotState.FREE
+        self._write_slot_meta(slot_idx, meta)
+        self.sem_free.release()
+
+    def wait_ready(self, timeout: Optional[float] = None) -> int:
+        if self.sem_ready is None:
+            raise RuntimeError("Semaphore not initialized")
+
+        deadline = None if timeout is None else time.monotonic() + timeout
+        self._acquire_semaphore(self.sem_ready, timeout)
+        if self.sem_slot is not None:
+            try:
+                self._acquire_semaphore(
+                    self.sem_slot,
+                    self._remaining_timeout(deadline),
+                )
+            except self._posix_ipc.BusyError:
+                self.sem_ready.release()
+                raise
+
+        try:
+            for slot_idx in range(self.slot_count):
+                meta = self._read_slot_meta(slot_idx)
+                if meta.state == SlotState.READY:
+                    meta.state = SlotState.READING
+                    self._write_slot_meta(slot_idx, meta)
+                    return slot_idx
+        finally:
+            if self.sem_slot is not None:
+                self.sem_slot.release()
+
+        self.sem_ready.release()
+        raise RuntimeError("No ready slot found despite semaphore signaling")
+
+    def post_ready(self, slot_idx: int) -> None:
+        if self.sem_ready is None:
+            raise RuntimeError("Semaphore not initialized")
+        meta = self._read_slot_meta(slot_idx)
+        meta.state = SlotState.READY
+        self._write_slot_meta(slot_idx, meta)
+        self.sem_ready.release()
+
+    def _get_cudart(self) -> CudaRTLibrary:
+        if self._cudart is None:
+            self._cudart = CudaRTLibrary()
+        return self._cudart
+
+    def cuda_memcpy(self, dst_ptr: int, src_ptr: int, num_bytes: int) -> None:
+        if num_bytes <= 0:
+            return
+        cudart = self._get_cudart()
+        cudart.cudaSetDevice(self.gpu_id)
+        cudart.cudaMemcpy(
+            ctypes.c_void_p(dst_ptr),
+            ctypes.c_void_p(src_ptr),
+            int(num_bytes),
+        )
+
+    def write_meta(
+        self,
+        slot_idx: int,
+        room: int,
+        index_start: int,
+        index_len: int,
+        is_last: bool,
+        valid_bytes: int,
+        seqno: int = 0,
+    ) -> None:
+        self._write_slot_meta(
+            slot_idx,
+            SlotMeta(
+                state=SlotState.WRITING,
+                room=int(room),
+                index_start=int(index_start),
+                index_len=int(index_len),
+                is_last=int(is_last),
+                valid_bytes=int(valid_bytes),
+                seqno=int(seqno),
+                owner_pid=os.getpid(),
+            ),
+        )
+
+    def read_meta(self, slot_idx: int) -> SlotMeta:
+        return self._read_slot_meta(slot_idx)
+
+    def _cleanup(self) -> None:
+        self._unregister_cuda()
+
+        if self.data_mmap is not None:
+            try:
+                self.data_mmap.close()
+            except Exception:
+                pass
+            self.data_mmap = None
+
+        if self.meta_mmap is not None:
+            try:
+                self.meta_mmap.close()
+            except Exception:
+                pass
+            self.meta_mmap = None
+
+        if self.create:
+            for name in (self.data_shm_name, self.meta_shm_name):
+                if not name:
+                    continue
+                try:
+                    self._posix_ipc.unlink_shared_memory(name)
+                except Exception:
+                    pass
+
+            for name in (self.sem_free_name, self.sem_ready_name, self.sem_slot_name):
+                if not name:
+                    continue
+                try:
+                    self._posix_ipc.Semaphore(name).unlink()
+                except Exception:
+                    pass
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._cleanup()
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass

--- a/python/sglang/srt/disaggregation/shm_pinned/utils.py
+++ b/python/sglang/srt/disaggregation/shm_pinned/utils.py
@@ -1,0 +1,215 @@
+"""
+Utility types for the shm_pinned backend.
+"""
+
+from __future__ import annotations
+
+import os
+import struct
+from dataclasses import dataclass, field
+from enum import IntEnum
+
+SHM_MAGIC = b"SHP1"
+SHM_VERSION = 1
+
+DEFAULT_SLOT_COUNT = 32
+DEFAULT_CHUNK_TOKENS = 512
+
+
+class SlotState(IntEnum):
+    FREE = 0
+    WRITING = 1
+    READY = 2
+    READING = 3
+
+
+@dataclass
+class SlotMeta:
+    """
+    64-byte metadata entry for one ring-buffer slot.
+    """
+
+    state: SlotState = SlotState.FREE
+    room: int = 0
+    index_start: int = 0
+    index_len: int = 0
+    is_last: int = 0
+    layer_start: int = 0
+    layer_count: int = 0xFFFFFFFF
+    valid_bytes: int = 0
+    seqno: int = 0
+    owner_pid: int = 0
+
+    _STRUCT_FORMAT = "<IQQIIIIQQI8s"
+    _STRUCT_SIZE = 64
+
+    def pack(self) -> bytes:
+        return struct.pack(
+            self._STRUCT_FORMAT,
+            int(self.state),
+            int(self.room),
+            int(self.index_start),
+            int(self.index_len),
+            int(self.is_last),
+            int(self.layer_start),
+            int(self.layer_count),
+            int(self.valid_bytes),
+            int(self.seqno),
+            int(self.owner_pid),
+            b"\x00" * 8,
+        )
+
+    @classmethod
+    def unpack(cls, data: bytes) -> "SlotMeta":
+        (
+            state,
+            room,
+            index_start,
+            index_len,
+            is_last,
+            layer_start,
+            layer_count,
+            valid_bytes,
+            seqno,
+            owner_pid,
+            _reserved,
+        ) = struct.unpack(cls._STRUCT_FORMAT, data)
+
+        return cls(
+            state=SlotState(state),
+            room=room,
+            index_start=index_start,
+            index_len=index_len,
+            is_last=is_last,
+            layer_start=layer_start,
+            layer_count=layer_count,
+            valid_bytes=valid_bytes,
+            seqno=seqno,
+            owner_pid=owner_pid,
+        )
+
+    @classmethod
+    def size(cls) -> int:
+        return cls._STRUCT_SIZE
+
+
+@dataclass
+class ShmHeader:
+    magic: bytes = SHM_MAGIC
+    version: int = SHM_VERSION
+    slot_count: int = DEFAULT_SLOT_COUNT
+    slot_bytes: int = 0
+    write_idx: int = 0
+    read_idx: int = 0
+
+    _STRUCT_FORMAT = "<4sIIQII36s"
+    _STRUCT_SIZE = 64
+
+    def pack(self) -> bytes:
+        return struct.pack(
+            self._STRUCT_FORMAT,
+            self.magic,
+            self.version,
+            int(self.slot_count),
+            int(self.slot_bytes),
+            int(self.write_idx),
+            int(self.read_idx),
+            b"\x00" * 36,
+        )
+
+    @classmethod
+    def unpack(cls, data: bytes) -> "ShmHeader":
+        magic, version, slot_count, slot_bytes, write_idx, read_idx, _reserved = (
+            struct.unpack(cls._STRUCT_FORMAT, data)
+        )
+        return cls(
+            magic=magic,
+            version=version,
+            slot_count=slot_count,
+            slot_bytes=slot_bytes,
+            write_idx=write_idx,
+            read_idx=read_idx,
+        )
+
+    @classmethod
+    def size(cls) -> int:
+        return cls._STRUCT_SIZE
+
+    def validate(self) -> bool:
+        return self.magic == SHM_MAGIC and self.version == SHM_VERSION
+
+
+@dataclass
+class ShmPinnedInfo:
+    data_shm_name: str = ""
+    meta_shm_name: str = ""
+    sem_free_name: str = ""
+    sem_ready_name: str = ""
+    sem_slot_name: str = ""
+    slot_count: int = DEFAULT_SLOT_COUNT
+    slot_bytes: int = 0
+    session_id: str = ""
+    kv_item_lens: list[int] = field(default_factory=list)
+    decode_host: str = ""
+    decode_port: int = 0
+
+    def to_dict(self) -> dict:
+        return {
+            "data_shm_name": self.data_shm_name,
+            "meta_shm_name": self.meta_shm_name,
+            "sem_free_name": self.sem_free_name,
+            "sem_ready_name": self.sem_ready_name,
+            "sem_slot_name": self.sem_slot_name,
+            "slot_count": self.slot_count,
+            "slot_bytes": self.slot_bytes,
+            "session_id": self.session_id,
+            "kv_item_lens": self.kv_item_lens,
+            "decode_host": self.decode_host,
+            "decode_port": self.decode_port,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "ShmPinnedInfo":
+        return cls(
+            data_shm_name=data["data_shm_name"],
+            meta_shm_name=data["meta_shm_name"],
+            sem_free_name=data["sem_free_name"],
+            sem_ready_name=data["sem_ready_name"],
+            sem_slot_name=data.get("sem_slot_name", ""),
+            slot_count=int(data["slot_count"]),
+            slot_bytes=int(data["slot_bytes"]),
+            session_id=data.get("session_id", ""),
+            kv_item_lens=list(data.get("kv_item_lens", [])),
+            decode_host=data.get("decode_host", ""),
+            decode_port=int(data.get("decode_port", 0)),
+        )
+
+
+def generate_shm_names(session_id: str) -> tuple[str, str, str, str, str]:
+    pid = os.getpid()
+    prefix = f"sglang_shm_{pid}_{session_id}"
+    return (
+        f"/{prefix}_data",
+        f"/{prefix}_meta",
+        f"/{prefix}_free",
+        f"/{prefix}_ready",
+        f"/{prefix}_slot",
+    )
+
+
+def calculate_slot_bytes(
+    chunk_pages: int,
+    kv_item_lens: list[int],
+    extra_slot_bytes: int = 0,
+) -> int:
+    if not kv_item_lens:
+        raise ValueError("kv_item_lens is required for shm_pinned sizing")
+    return int(chunk_pages) * int(sum(kv_item_lens)) + int(extra_slot_bytes)
+
+
+def calculate_meta_shm_size(slot_count: int) -> int:
+    return ShmHeader.size() + int(slot_count) * SlotMeta.size()
+
+
+def get_slot_meta_offset(slot_idx: int) -> int:
+    return ShmHeader.size() + int(slot_idx) * SlotMeta.size()

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -306,6 +306,7 @@ class TransferBackend(Enum):
     MORI = "mori"
     NIXL = "nixl"
     ASCEND = "ascend"
+    SHM_PINNED = "shm_pinned"
     FAKE = "fake"
 
 
@@ -410,6 +411,23 @@ def get_kv_class(
             KVClassType.SENDER: NixlKVSender,
             KVClassType.RECEIVER: (NixlKVReceiver),
             KVClassType.BOOTSTRAP_SERVER: NixlKVBootstrapServer,
+        }
+        return class_mapping.get(class_type)
+    elif transfer_backend == TransferBackend.SHM_PINNED:
+        from sglang.srt.disaggregation.base import KVArgs
+        from sglang.srt.disaggregation.shm_pinned import (
+            ShmPinnedKVBootstrapServer,
+            ShmPinnedKVManager,
+            ShmPinnedKVReceiver,
+            ShmPinnedKVSender,
+        )
+
+        class_mapping = {
+            KVClassType.KVARGS: KVArgs,
+            KVClassType.MANAGER: ShmPinnedKVManager,
+            KVClassType.SENDER: ShmPinnedKVSender,
+            KVClassType.RECEIVER: ShmPinnedKVReceiver,
+            KVClassType.BOOTSTRAP_SERVER: ShmPinnedKVBootstrapServer,
         }
         return class_mapping.get(class_type)
     elif transfer_backend == TransferBackend.FAKE:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -155,7 +155,14 @@ DETERMINISTIC_ATTENTION_BACKEND_CHOICES = ["flashinfer", "fa3", "triton"]
 
 RADIX_SUPPORTED_DETERMINISTIC_ATTENTION_BACKEND = ["fa3", "triton"]
 
-DISAGG_TRANSFER_BACKEND_CHOICES = ["mooncake", "nixl", "ascend", "fake", "mori"]
+DISAGG_TRANSFER_BACKEND_CHOICES = [
+    "mooncake",
+    "nixl",
+    "ascend",
+    "fake",
+    "mori",
+    "shm_pinned",
+]
 
 GRAMMAR_BACKEND_CHOICES = ["xgrammar", "outlines", "llguidance", "none"]
 
@@ -700,6 +707,8 @@ class ServerArgs:
     disaggregation_transfer_backend: str = "mooncake"
     disaggregation_bootstrap_port: int = 8998
     disaggregation_ib_device: Optional[str] = None
+    disaggregation_shm_slot_count: Optional[int] = 32
+    disaggregation_shm_chunk_tokens: Optional[int] = 512
     disaggregation_decode_enable_offload_kvcache: bool = False
     num_reserved_decode_tokens: int = 512  # used for decode kv cache offload in PD
     # FIXME: hack to reduce ITL when decode bs is small
@@ -6201,6 +6210,18 @@ class ServerArgs:
             help="The InfiniBand devices for disaggregation transfer, accepts single device (e.g., --disaggregation-ib-device mlx5_0) "
             "or multiple comma-separated devices (e.g., --disaggregation-ib-device mlx5_0,mlx5_1). "
             "Default is None, which triggers automatic device detection when mooncake backend is enabled.",
+        )
+        parser.add_argument(
+            "--disaggregation-shm-slot-count",
+            type=int,
+            default=ServerArgs.disaggregation_shm_slot_count,
+            help="Number of ring-buffer slots for the shm_pinned backend. Default is 32.",
+        )
+        parser.add_argument(
+            "--disaggregation-shm-chunk-tokens",
+            type=int,
+            default=ServerArgs.disaggregation_shm_chunk_tokens,
+            help="Token budget per shm_pinned transfer chunk. Default is 512.",
         )
         parser.add_argument(
             "--disaggregation-decode-enable-offload-kvcache",

--- a/test/registered/disaggregation/test_shm_pinned_unit.py
+++ b/test/registered/disaggregation/test_shm_pinned_unit.py
@@ -1,0 +1,165 @@
+import ctypes
+
+import pytest
+
+from sglang.srt.disaggregation.shm_pinned.transfer_engine import (
+    ShmPinnedTransferEngine,
+)
+from sglang.srt.disaggregation.shm_pinned.utils import (
+    ShmPinnedInfo,
+    SlotMeta,
+    SlotState,
+    calculate_slot_bytes,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="stage-a-test-cpu")
+
+
+def test_slot_meta_round_trip():
+    meta = SlotMeta(
+        state=SlotState.READY,
+        room=17,
+        index_start=3,
+        index_len=7,
+        is_last=1,
+        valid_bytes=192,
+        seqno=9,
+        owner_pid=1234,
+    )
+
+    assert SlotMeta.unpack(meta.pack()) == meta
+
+
+def test_shm_pinned_info_round_trip():
+    info = ShmPinnedInfo(
+        data_shm_name="/pytest_data",
+        meta_shm_name="/pytest_meta",
+        sem_free_name="/pytest_free",
+        sem_ready_name="/pytest_ready",
+        sem_slot_name="/pytest_slot",
+        slot_count=4,
+        slot_bytes=256,
+        session_id="session-1",
+        kv_item_lens=[64, 64, 64, 64],
+        decode_host="127.0.0.1",
+        decode_port=9001,
+    )
+
+    assert ShmPinnedInfo.from_dict(info.to_dict()) == info
+
+
+def test_calculate_slot_bytes():
+    assert calculate_slot_bytes(4, [8, 12], extra_slot_bytes=16) == 96
+
+    with pytest.raises(ValueError, match="kv_item_lens"):
+        calculate_slot_bytes(1, [])
+
+
+def test_transfer_engine_cpu_smoke(monkeypatch):
+    pytest.importorskip("posix_ipc")
+
+    def cpu_memcpy(self, dst_ptr: int, src_ptr: int, num_bytes: int) -> None:
+        ctypes.memmove(dst_ptr, src_ptr, num_bytes)
+
+    monkeypatch.setattr(ShmPinnedTransferEngine, "cuda_memcpy", cpu_memcpy)
+
+    kv_item_lens = [4, 8]
+    num_pages = 2
+    aux_bytes = b"AUX123"
+    kv_total_bytes = num_pages * sum(kv_item_lens)
+
+    src0 = ctypes.create_string_buffer(b"ABCDWXYZ", 8)
+    src1 = ctypes.create_string_buffer(b"abcdefgh12345678", 16)
+    aux_src = ctypes.create_string_buffer(aux_bytes, len(aux_bytes))
+
+    dst0 = ctypes.create_string_buffer(8)
+    dst1 = ctypes.create_string_buffer(16)
+    aux_dst = ctypes.create_string_buffer(len(aux_bytes))
+
+    decode_engine = ShmPinnedTransferEngine(
+        session_id="pytest-smoke",
+        gpu_id=0,
+        slot_count=2,
+        chunk_pages=num_pages,
+        kv_item_lens=kv_item_lens,
+        extra_slot_bytes=len(aux_bytes),
+        create=True,
+    )
+    prefill_engine = ShmPinnedTransferEngine(
+        session_id="pytest-smoke",
+        gpu_id=0,
+        create=False,
+    )
+
+    try:
+        prefill_engine.open_from_info(decode_engine.export_info())
+        decode_engine._data_ptr = ctypes.addressof(
+            ctypes.c_ubyte.from_buffer(decode_engine.data_mmap)
+        )
+        prefill_engine._data_ptr = ctypes.addressof(
+            ctypes.c_ubyte.from_buffer(prefill_engine.data_mmap)
+        )
+
+        slot_idx = prefill_engine.wait_free(timeout=1.0)
+        slot_ptr = prefill_engine.get_slot_data_ptr(slot_idx)
+
+        prefill_engine.cuda_memcpy(slot_ptr, ctypes.addressof(src0), len(src0.raw))
+        prefill_engine.cuda_memcpy(
+            slot_ptr + len(src0.raw),
+            ctypes.addressof(src1),
+            len(src1.raw),
+        )
+        ctypes.memmove(
+            slot_ptr + kv_total_bytes,
+            ctypes.addressof(aux_src),
+            len(aux_bytes),
+        )
+
+        prefill_engine.write_meta(
+            slot_idx=slot_idx,
+            room=17,
+            index_start=0,
+            index_len=num_pages,
+            is_last=True,
+            valid_bytes=kv_total_bytes + len(aux_bytes),
+            seqno=1,
+        )
+        prefill_engine.post_ready(slot_idx)
+
+        ready_idx = decode_engine.wait_ready(timeout=1.0)
+        meta = decode_engine.read_meta(ready_idx)
+        assert meta.room == 17
+        assert meta.index_len == num_pages
+        assert meta.is_last == 1
+
+        slot_ptr = decode_engine.get_slot_data_ptr(ready_idx)
+        decode_engine.cuda_memcpy(
+            ctypes.addressof(dst0),
+            slot_ptr,
+            len(dst0.raw),
+        )
+        decode_engine.cuda_memcpy(
+            ctypes.addressof(dst1),
+            slot_ptr + len(dst0.raw),
+            len(dst1.raw),
+        )
+        ctypes.memmove(
+            ctypes.addressof(aux_dst),
+            slot_ptr + kv_total_bytes,
+            len(aux_bytes),
+        )
+        decode_engine.post_free(ready_idx)
+
+        assert dst0.raw == src0.raw
+        assert dst1.raw == src1.raw
+        assert aux_dst.raw == aux_bytes
+    finally:
+        prefill_engine.close()
+        decode_engine.close()
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
## Motivation

PD disaggregation currently offers `mooncake`, `nixl`, `ascend`, `mori`, and `fake` as transfer backends. These are a good fit when an RDMA fabric or a broader transport stack is available, but they add a non-trivial dependency and setup surface when the deployment is confined to a **single node over PCIe without NVLink**.

This topology is common in practice: many small and mid-sized teams serve inference on consumer-grade GPUs such as the RTX 4090, where NVLink is unavailable and cross-GPU traffic has to go over PCIe. The existing RDMA-oriented backends do work in this setting, but their setup cost is large relative to what a single-node deployment actually needs.

This PR adds a new backend, `shm_pinned`, that targets exactly that topology:

- prefill and decode run as separate processes on the same host
- GPU-to-GPU P2P is unavailable or not desirable (PCIe, no NVLink)
- the dominant transfer path is D2H / H2D
- operational simplicity (fewer system-level dependencies) is preferred

The backend moves KV pages through a POSIX shared-memory ring buffer registered as pinned host memory, using a simple control protocol between the two workers.

## Scope — what PR1 does and does not do

PR1 is intentionally minimal and is the first of a planned series. It contains **only** the synchronous `KV + aux` transfer path.

In scope:
- new `shm_pinned` backend with sync `KV + aux` transfer
- `(session_id, room)` keyed pending-request tracking (avoids cross-session overwrite when multiple sessions reuse the same room value)
- explicit prefill → decode failure notification (timeout remains only as a safety net)
- lazy `posix_ipc` import (only loaded when `--disaggregation-transfer-backend=shm_pinned`)
- unit tests

Out of scope (explicitly deferred to follow-up PRs):
- async send workers / background queue
- mamba / SWA / NSA state transfer
- `state_item_lens` handshake extensions, `STATE` chunk protocol
- any `chunk_type / buf_start / buf_count` fields that only exist to serve state transfer

No behavior change for existing `mooncake` / `nixl` / `ascend` / `mori` / `fake` users — the new backend is purely additive and is only reached when the user opts in via `--disaggregation-transfer-backend=shm_pinned`.

## Design

1. Decode creates a ring buffer in POSIX shared memory and registers it as pinned host memory.
2. Decode sends `ShmPinnedInfo` (including the decode control endpoint) to prefill.
3. Decode sends a `TRANSFER_REQ` with destination KV page indices.
4. Prefill waits for a free slot, performs D2H copies for the requested KV pages, appends aux metadata on the last chunk, and marks the slot ready.
5. Decode waits for ready slots, performs H2D copies into the destination KV buffers, copies aux metadata on the last chunk, and frees the slot.

The request key is `(session_id, room)` rather than `room` alone. This avoids cross-session collisions when multiple decode sessions happen to reuse the same room value.

## Benchmark results

Two independent measurements on PCIe / no-NVLink hosts. Full logs and reproduction scripts available on request.

### Primary result — 4× RTX 4090 (PCIe, no NVLink), 3 prefill + 1 decode

Qwen3-8B-FP8, `input_len=1000`, `output_len=100`. For each topology we report the highest QPS that clears a joint SLO of **TTFT-P90 < 2 s and TPOT-P90 < 50 ms**.

| Topology | Best QPS | Total tok/s | TTFT P90 | TPOT P90 |
|---|---:|---:|---:|---:|
| `nixl` + P2P driver patch† | 33 | **27,943** | 1222 ms | 32.6 ms |
| **`shm_pinned`** | **30** | **25,193** | 1508 ms | 39.2 ms |
| `agg4` (no PD disaggregation, 4 independent sglang replicas) | 19.9 | 18,539 | 139 ms | 45.7 ms |
| `nixl` on stock RTX 4090 driver | 10 | 10,297 | 1934 ms | 31.1 ms |

† `nixl` with RTX 4090 P2P enabled via the community driver fork [`tinygrad/open-gpu-kernel-modules`](https://github.com/tinygrad/open-gpu-kernel-modules). NVIDIA does not officially support P2P on consumer-class GPUs; this row is included only as an upper-bound reference and is not a realistic deployment option in most environments.

Takeaways for the target scenario (stock RTX 4090 driver, single host, PCIe):

- **`shm_pinned` vs `nixl` on the same stock driver: +144.7% token throughput (2.45×).** This is the apples-to-apples comparison motivating this PR.
- **`shm_pinned` vs a non-disaggregated control (`agg4`): +35.9%.** PD disaggregation itself is worth it on this topology, provided the transfer backend does not become the bottleneck (which is what happens to `nixl` on the stock driver).
- **`shm_pinned` vs `nixl` + P2P patch: −10.9%.** The patched driver sets the realistic ceiling; `shm_pinned` gets within ~10% of it without requiring any kernel-module modification.

### Supplementary result — 2× RTX 4090 (autodl-2, PCIe, no NVLink), 1 prefill + 1 decode

Environment: autodl-2, **2× RTX 4090 on PCIe, no NVLink**, Qwen3-8B-FP8, NVIDIA Dynamo frontend, 1 prefill + 1 decode (`CUDA_VISIBLE_DEVICES=0` / `1`), `--tp 1 --page-size 16`, ShareGPT prompts.

#### Same-SLO token throughput

Under a joint SLO of **TTFT-P90 < 2 s and TPOT-P90 < 50 ms**, 500 prompts, `output_len=100`, `max_concurrency=128`, stack fully restarted between runs, at each backend's highest clean frontier:

| Backend | Frontier QPS | req/s | Total tok/s | TTFT P90 | TPOT P90 |
|---|---|---|---|---|---|
| `shm_pinned` | 12   | 10.94 | **4531** | 279 ms | 48.26 ms |
| `nixl` (UCX loopback) | 8.5 | 7.99 | 3311 | 1994 ms | 15.10 ms |

**Under the same SLO, `shm_pinned` sustains +36.8% (conservative) to +52.9% (aggressive, taking each backend's topmost passing point) more token throughput than `nixl` on this PCIe-only topology.**

#### Longer output (output_len=300, QPS=10)

| Metric | `shm_pinned` | `nixl` | Δ |
|---|---|---|---|
| Benchmark duration | **74.61 s** | 88.95 s | shm −16.1% |
| Request throughput | **6.70 req/s** | 5.62 req/s | shm +19.2% |
| Total tok/s | **4116.08** | 3452.26 | shm +19.2% |
| TTFT P99 | **12806 ms** | 20951 ms | shm −38.9% |
| TPOT P99 | 46.05 ms | **35.11 ms** | nixl wins |

#### Observations

- **Throughput**: `shm_pinned` scales linearly up to QPS=14 (12.58 req/s); `nixl` saturates around 10 req/s on this topology — TTFT-side queueing is the bottleneck.
- **TTFT**: `shm_pinned` TTFT is 11–32× lower and barely grows with load; `nixl`/UCX loopback pays a noticeable handshake cost per request.
- **TPOT / ITL**: `nixl` is slightly smoother under the SLO-bounded regime (decode stays at smaller batches once TTFT limits throughput). `shm_pinned` has larger decode batches at its frontier, so per-token latency is higher — but within SLO.
- 500/500 successful requests on both backends in every run, no fallback, no errors.

## Configuration

Two new server args (default values are conservative and rarely need tuning):

| Flag | Default | Purpose |
|---|---|---|
| `--disaggregation-shm-slot-count` | 32 | ring-buffer slot count |
| `--disaggregation-shm-chunk-tokens` | 512 | token budget per transfer chunk |

Both flags are only read by the `shm_pinned` backend. No flags are added to or changed for any other backend.

## Files

Added:
- `python/sglang/srt/disaggregation/shm_pinned/__init__.py`
- `python/sglang/srt/disaggregation/shm_pinned/conn.py`
- `python/sglang/srt/disaggregation/shm_pinned/transfer_engine.py`
- `python/sglang/srt/disaggregation/shm_pinned/utils.py`
- `test/registered/disaggregation/test_shm_pinned_unit.py`

Modified (integration only):
- `python/sglang/srt/disaggregation/utils.py` — register `SHM_PINNED` in `TransferBackend` and `get_kv_class()`
- `python/sglang/srt/server_args.py` — add backend choice and two new server args
- `python/pyproject.toml` — add `posix_ipc>=1.1.1`
- `docs/advanced_features/pd_disaggregation.md`, `docs/advanced_features/server_arguments.md` — mention the new backend

No changes to `decode.py`, `prefill.py`, `scheduler.py`, `tokenizer_manager.py`, or any other hot path file.

## Testing

Unit tests (`test/registered/disaggregation/test_shm_pinned_unit.py`) cover:
- `SlotMeta.pack() / unpack()` round trip
- `ShmPinnedInfo.to_dict() / from_dict()` round trip
- slot-size math
- one in-process smoke path that does not require a real GPU

Run:

```
pytest -q test/registered/disaggregation/test_shm_pinned_unit.py
```

End-to-end validated on autodl-2 (2× RTX 4090, PCIe, no NVLink) with NVIDIA Dynamo: 500/500 prompts succeeded on every benchmark run; cold restart between every run; `ShareGPT` dataset; no fallback and no errors observed.

## Follow-up PRs

To keep the review surface small, these are explicitly deferred:

- PR2 — async send workers (background `TransferTask` queue, `RoomTransferTracker`, backpressure)
- PR3 — phase-1 `mamba` state transfer (extends the handshake with `state_item_lens`, adds `STATE` chunk protocol)
- PR4 — `SWA` / `NSA` state support (gated on PR3 stabilizing)

Each follow-up PR can be evaluated on its own merits without entangling the sync KV+aux path.

## Checklist

- [x] New backend is purely additive — no behavior change for existing users
- [x] `posix_ipc` is a lazy import; not required for other backends
- [x] Unit tests included
- [x] PCIe / no-NVLink benchmark provided on RTX 4090: 4-GPU (`shm_pinned` vs stock-driver `nixl`, `agg4`, and patched-driver `nixl` upper bound) and 2-GPU (`shm_pinned` vs `nixl` / UCX loopback)
- [x] No changes to hot-path files (`decode.py`, `prefill.py`, `scheduler.py`, `tokenizer_manager.py`)
- [x] Rebased onto the latest `upstream/main` and re-verified (unit tests, smoke, QPS=12 sanity)
