### PR TITLE
[PD] Fix clip logic when state indices lens are mismatch

### DIFF
--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1003,12 +1003,19 @@ class MooncakeKVManager(CommonKVManager):
                 raise RuntimeError(
                     f"PD Disaggregation does NOT support PD different TP sizes for non-MLA {state_type.upper()} hybrid models yet."
                 )
-            if len(prefill_state_indices) < len(req.dst_state_indices):
+            if len(prefill_state_indices) > len(req.dst_state_indices):
                 logger.warning(
                     f"len(prefill_state_indices) = {len(prefill_state_indices)}, len(dst_state_indices) = {len(req.dst_state_indices)}"
                 )
                 prefill_state_indices = prefill_state_indices[
                     : len(req.dst_state_indices)
+                ]
+            elif len(prefill_state_indices) < len(req.dst_state_indices):
+                logger.warning(
+                    f"len(prefill_state_indices) = {len(prefill_state_indices)}, len(dst_state_indices) = {len(req.dst_state_indices)}"
+                )
+                req.dst_state_indices = req.dst_state_indices[
+                    : len(prefill_state_indices)
                 ]
             # Reuse _send_kvcache_generic interface to send extra pool data
             prefill_state_indices = np.array(prefill_state_indices, dtype=np.int32)

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1008,16 +1008,12 @@ class MooncakeKVManager(CommonKVManager):
                 logger.warning(
                     f"len(prefill_state_indices) = {len(prefill_state_indices)}, len(dst_state_indices) = {len(dst_state_indices)}"
                 )
-                prefill_state_indices = prefill_state_indices[
-                    : len(dst_state_indices)
-                ]
+                prefill_state_indices = prefill_state_indices[: len(dst_state_indices)]
             elif len(prefill_state_indices) < len(dst_state_indices):
                 logger.warning(
                     f"len(prefill_state_indices) = {len(prefill_state_indices)}, len(dst_state_indices) = {len(dst_state_indices)}"
                 )
-                dst_state_indices = dst_state_indices[
-                    : len(prefill_state_indices)
-                ]
+                dst_state_indices = dst_state_indices[: len(prefill_state_indices)]
             # Reuse _send_kvcache_generic interface to send extra pool data
             prefill_state_indices = np.array(prefill_state_indices, dtype=np.int32)
             dst_state_indices = np.array(dst_state_indices, dtype=np.int32)

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1003,23 +1003,24 @@ class MooncakeKVManager(CommonKVManager):
                 raise RuntimeError(
                     f"PD Disaggregation does NOT support PD different TP sizes for non-MLA {state_type.upper()} hybrid models yet."
                 )
+            dst_state_indices = req.dst_state_indices
             if len(prefill_state_indices) > len(req.dst_state_indices):
                 logger.warning(
-                    f"len(prefill_state_indices) = {len(prefill_state_indices)}, len(dst_state_indices) = {len(req.dst_state_indices)}"
+                    f"len(prefill_state_indices) = {len(prefill_state_indices)}, len(dst_state_indices) = {len(dst_state_indices)}"
                 )
                 prefill_state_indices = prefill_state_indices[
-                    : len(req.dst_state_indices)
+                    : len(dst_state_indices)
                 ]
             elif len(prefill_state_indices) < len(req.dst_state_indices):
                 logger.warning(
-                    f"len(prefill_state_indices) = {len(prefill_state_indices)}, len(dst_state_indices) = {len(req.dst_state_indices)}"
+                    f"len(prefill_state_indices) = {len(prefill_state_indices)}, len(dst_state_indices) = {len(dst_state_indices)}"
                 )
-                req.dst_state_indices = req.dst_state_indices[
+                dst_state_indices = dst_state_indices[
                     : len(prefill_state_indices)
                 ]
             # Reuse _send_kvcache_generic interface to send extra pool data
             prefill_state_indices = np.array(prefill_state_indices, dtype=np.int32)
-            dst_state_indices = np.array(req.dst_state_indices, dtype=np.int32)
+            dst_state_indices = np.array(dst_state_indices, dtype=np.int32)
             return self._send_kvcache_generic(
                 mooncake_session_id=req.mooncake_session_id,
                 src_data_ptrs=self.kv_args.state_data_ptrs,

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1004,14 +1004,14 @@ class MooncakeKVManager(CommonKVManager):
                     f"PD Disaggregation does NOT support PD different TP sizes for non-MLA {state_type.upper()} hybrid models yet."
                 )
             dst_state_indices = req.dst_state_indices
-            if len(prefill_state_indices) > len(req.dst_state_indices):
+            if len(prefill_state_indices) > len(dst_state_indices):
                 logger.warning(
                     f"len(prefill_state_indices) = {len(prefill_state_indices)}, len(dst_state_indices) = {len(dst_state_indices)}"
                 )
                 prefill_state_indices = prefill_state_indices[
                     : len(dst_state_indices)
                 ]
-            elif len(prefill_state_indices) < len(req.dst_state_indices):
+            elif len(prefill_state_indices) < len(dst_state_indices):
                 logger.warning(
                     f"len(prefill_state_indices) = {len(prefill_state_indices)}, len(dst_state_indices) = {len(dst_state_indices)}"
                 )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Fix #18727.
In `MooncakeKVManager.maybe_send_extra`, the clip logic for SWA/NSA hybrid models only handled one direction of length mismatch between `prefill_state_indices` and `req.dst_state_indices`, and even that branch was effectively a no-op:
```python
if len(prefill_state_indices) < len(req.dst_state_indices):
    logger.warning(...)
    prefill_state_indices = prefill_state_indices[: len(req.dst_state_indices)]
```
Two issues:
1. When `prefill < dst`, slicing `prefill_state_indices` with an upper bound **larger than its own length** is a Python no-op: the list is returned unchanged, so the two sides remain mismatched.
2. The opposite case (`prefill > dst`) is not handled at all.
Whenever the two index arrays have different lengths, the downstream `_send_kvcache_generic` path calls `group_concurrent_contiguous`, which evaluates:
```python
brk = np.where((np.diff(src_indices) != 1) | (np.diff(dst_indices) != 1))[0] + 1
```
The bitwise-OR between two arrays of different shapes raises and causes the transfer to fail for SWA/NSA hybrid models under PD disaggregation.
## Modifications
`python/sglang/srt/disaggregation/mooncake/conn.py`:
- Handle both directions of length mismatch so the two index arrays always line up before being passed to `_send_kvcache_generic`:
  - `len(prefill) > len(dst)` → clip `prefill_state_indices` down to `len(dst)`.
  - `len(prefill) < len(dst)` → clip `dst_state_indices` down to `len(prefill)`.
- Introduce a local `dst_state_indices` variable instead of mutating `req.dst_state_indices` in place, so `TransferInfo` is not modified as a side effect of the clip.
- No behavioral change for the Mamba / MLA branches; only the SWA/NSA hybrid path is touched.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
