### PR TITLE
Skip mamba_pool_idx revert for session requests in _get_new_batch_prefill_raw

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2575,9 +2575,16 @@ class Scheduler(
                         ) > 0 or (not self.running_batch.is_empty())
                     else:
                         self.running_batch.batch_is_full = True
-                # revert matched mamba idx to avoid memory leak, if req is not added
+                # revert matched mamba idx to avoid memory leak, if req is not added.
+                # Only free if the slot was freshly allocated in this batch (not
+                # pre-existing from a session). Session-held slots have their own
+                # lifecycle and freeing them here causes double-free.
                 added = len(adder.can_run_list) > 0 and req is adder.can_run_list[-1]
-                if not added and req.mamba_pool_idx is not None:
+                if (
+                    not added
+                    and req.mamba_pool_idx is not None
+                    and not getattr(req, "session", None)
+                ):
                     self.tree_cache.req_to_token_pool.mamba_pool.free(
                         req.mamba_pool_idx.unsqueeze(-1)
                     )


### PR DESCRIPTION
## Summary

The revert path added in #21404 frees session-held mamba slots when a request can't be added to a batch, causing double-free when the session later closes (we observed `mamba_leaked=-9` on our workload).

A streaming session request has its `mamba_pool_idx` restored from a `SessionSlot` via `slot.restore_to_req`; the slot intentionally retains the same index across turns (see the `NOTE` in `SessionSlot.restore_to_req` in `python/sglang/srt/session/streaming_session.py`). Unconditionally freeing `req.mamba_pool_idx` in the scheduler revert path leaves the slot's reference dangling.

Fix: skip the revert when the request belongs to a session. Session-held slots manage their own mamba lifecycle; non-session requests still take the original revert path.

## Test plan

- [ ] Existing CI
- [ ] Manual: streaming-session workload that previously reproduced `mamba_leaked=-9`