### PR TITLE
[Bugfix] Fix Kimi-K2.5 checkpoint-engine update and /dev/shm multi-rank loading

### DIFF
--- a/python/sglang/srt/checkpoint_engine/update.py
+++ b/python/sglang/srt/checkpoint_engine/update.py
@@ -313,9 +313,13 @@ def main():
     else:
         if args.checkpoint_path:
             ps.init_process_group()
-        if args.checkpoint_path and os.path.exists(
-            os.path.join(args.checkpoint_path, "model.safetensors.index.json")
-        ) and not args.checkpoint_path.startswith("/dev/shm/"):  # noqa: S108
+        if (
+            args.checkpoint_path
+            and os.path.exists(
+                os.path.join(args.checkpoint_path, "model.safetensors.index.json")
+            )
+            and not args.checkpoint_path.startswith("/dev/shm/")
+        ):
             named_tensors = split_tensors(args.checkpoint_path, rank, world_size)
             checkpoint_files = []
         else:

--- a/python/sglang/srt/checkpoint_engine/update.py
+++ b/python/sglang/srt/checkpoint_engine/update.py
@@ -318,7 +318,7 @@ def main():
             and os.path.exists(
                 os.path.join(args.checkpoint_path, "model.safetensors.index.json")
             )
-            and not args.checkpoint_path.startswith("/dev/shm/")
+            and not args.checkpoint_path.startswith("/dev/shm")
         ):
             named_tensors = split_tensors(args.checkpoint_path, rank, world_size)
             checkpoint_files = []

--- a/python/sglang/srt/checkpoint_engine/update.py
+++ b/python/sglang/srt/checkpoint_engine/update.py
@@ -74,14 +74,37 @@ def check_sglang_ready(
 def split_checkpoint_files(
     checkpoint_path: str, rank: int, world_size: int
 ) -> list[str]:
-    checkpoint_files = [
+    checkpoint_files = sorted(
         os.path.join(checkpoint_path, f)
-        for f in filter(
-            lambda x: x.endswith(".safetensors"), os.listdir(checkpoint_path)
-        )
-    ]
+        for f in os.listdir(checkpoint_path)
+        if f.endswith(".safetensors")
+    )
     files_per_rank = (len(checkpoint_files) + world_size - 1) // world_size
     return checkpoint_files[rank * files_per_rank : (rank + 1) * files_per_rank]
+
+
+def split_checkpoint_files_from_list(
+    checkpoint_files: list[str], rank: int, world_size: int
+) -> list[str]:
+    files_per_rank = (len(checkpoint_files) + world_size - 1) // world_size
+    return checkpoint_files[rank * files_per_rank : (rank + 1) * files_per_rank]
+
+
+def collect_checkpoint_files(
+    checkpoint_path: str, rank: int, world_size: int
+) -> list[str]:
+    checkpoint_files = (
+        sorted(
+            os.path.join(checkpoint_path, f)
+            for f in os.listdir(checkpoint_path)
+            if f.endswith(".safetensors")
+        )
+        if rank == 0
+        else []
+    )
+    object_list = [checkpoint_files]
+    dist.broadcast_object_list(object_list, src=0)
+    return split_checkpoint_files_from_list(object_list[0], rank, world_size)
 
 
 def split_tensors(
@@ -149,7 +172,8 @@ def update_weights(
     ps.register_checkpoint(
         checkpoint_name, files=checkpoint_files, named_tensors=named_tensors
     )
-    ps.init_process_group()
+    if not dist.is_initialized():
+        ps.init_process_group()
     check_sglang_ready(endpoint, inference_parallel_size, uds)
     dist.barrier()
     with timer("Gather metas"):
@@ -184,7 +208,8 @@ def join(
     assert load_metas_file, "load_metas_file is required"
     with open(load_metas_file, "rb") as f:
         metas = pickle.load(f)
-    ps.init_process_group()
+    if not dist.is_initialized():
+        ps.init_process_group()
     check_sglang_ready(endpoint, inference_parallel_size, uds)
     dist.barrier()
     with timer("Gather metas before join"):
@@ -286,14 +311,16 @@ def main():
             args.uds,
         )
     else:
+        if args.checkpoint_path:
+            ps.init_process_group()
         if args.checkpoint_path and os.path.exists(
             os.path.join(args.checkpoint_path, "model.safetensors.index.json")
-        ):
+        ) and not args.checkpoint_path.startswith("/dev/shm/"):  # noqa: S108
             named_tensors = split_tensors(args.checkpoint_path, rank, world_size)
             checkpoint_files = []
         else:
             checkpoint_files = (
-                split_checkpoint_files(args.checkpoint_path, rank, world_size)
+                collect_checkpoint_files(args.checkpoint_path, rank, world_size)
                 if args.checkpoint_path
                 else []
             )

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -692,10 +692,13 @@ class FusedMoE(torch.nn.Module):
         if method.__class__.__name__ == "KTEPWrapperMethod":
             method = method.gpu_method
 
-        # For flashinfer TRT-LLM BF16 path, process_weights_after_loading reshapes
-        # expert weights into block layout. During weight update, we must restore
-        # canonical load-time shapes before copying checkpoint tensors.
-        if isinstance(method, UnquantizedFusedMoEMethod):
+        # Some MoE backends reshape or repack expert weights after loading.
+        # During hot updates, restore canonical load-time shapes before copy.
+        if hasattr(method, "restore_weights_before_loading"):
+            method.restore_weights_before_loading(self)
+        elif isinstance(method, UnquantizedFusedMoEMethod):
+            # For flashinfer TRT-LLM BF16 path, process_weights_after_loading
+            # reshapes expert weights into block layout.
             method.maybe_restore_flashinfer_trtllm_bf16_weight_shape_for_load(
                 layer=self,
                 param=param,

--- a/python/sglang/srt/models/kimi_k25.py
+++ b/python/sglang/srt/models/kimi_k25.py
@@ -779,6 +779,13 @@ class KimiK25ForConditionalGeneration(nn.Module):
         if not self.config.encoder_only and language_weights:
             self.language_model.load_weights(language_weights)
 
+    def post_load_weights(self):
+        # Dummy loading initializes parameter tensors directly on the wrapper
+        # model and then only calls the wrapper's post_load_weights(). The
+        # MLA runtime path depends on the inner language model packing kv_b_proj
+        # into per-layer tensors like w_kc/w_vc before CUDA graph capture.
+        self.language_model.post_load_weights()
+
     @classmethod
     def get_model_config_for_expert_location(cls, config: KimiK25Config):
         text_config = config.text_config


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->


Add checkpoint-engine compatibility for Kimi K2.5 and make checkpoint-engine updates more robust when loading checkpoints staged in `/dev/shm`.

Kimi K2.5 requires a post-load processing when `--load-format dummy`. Without this, the wrapper model’s`post_load_weights()` path does not forward to the inner language model, so MLA-related packed tensors such as `w_kc`/`w_vc` may not be prepared before CUDA graph capture.

For `/dev/shm` staged checkpoints, checkpoint-engine can use in-place pinned memory for `.safetensors` files. The SGLang update script previously bypassed that path when `model.safetensors.index.json` existed, and multi-rank loading could race with checkpoint-engine’s in-place file removal.

## Modifications

- Add `post_load_weights()` to `KimiK25ForConditionalGeneration` and forward it to the inner language model so Kimi K2.5 runs the required post-load preparation after checkpoint-engine weight updates.
- Generalize MoE hot-update restoration by calling `restore_weights_before_loading()` when the active MoE method provides it, while preserving the existing unquantized FlashInfer TRT-LLM BF16 restore path.
- Update checkpoint-engine `update.py` to avoid the indexed `split_tensors()` path for `/dev/shm` checkpoints, allowing `.safetensors` files staged in `/dev/shm` to use checkpoint-engine’s in-place pin-memory path.
- Make checkpoint file assignment deterministic by sorting `.safetensors` file lists before rank slicing.
- Add rank-0 checkpoint file collection and broadcast so all ranks use the same file list before `/dev/shm` in-place pinning starts. This avoids races where faster ranks remove files before slower ranks finish listing/opening them.
- Guard process-group initialization to avoid duplicate initialization after the earlier synchronization step.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

This pr would not affect model output accuracy. The changes affect checkpoint loading/update orchestration and post-load preparation for KimiK2.5.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

This pr would not impact inference.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). No need
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No need
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). No need
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
