### PR TITLE
[Bug Fix]fix(devcontainer): fall back when dotfiles live under /opt/sglang/

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,11 +20,11 @@ RUN apt-get update && apt-get install -y sudo && \
 RUN cp -r /root/.oh-my-zsh /home/devuser/.oh-my-zsh && \
     cp /root/.zshrc /home/devuser/.zshrc && \
     for src in /opt/sglang/.vimrc /root/.vimrc; do \
-        [ -f "$src" ] && cp "$src" /home/devuser/.vimrc && break; \
-    done; \
+        if [ -f "$src" ]; then cp "$src" /home/devuser/.vimrc; break; fi; \
+    done && \
     for src in /opt/sglang/.tmux.conf /root/.tmux.conf; do \
-        [ -f "$src" ] && cp "$src" /home/devuser/.tmux.conf && break; \
-    done; \
+        if [ -f "$src" ]; then cp "$src" /home/devuser/.tmux.conf; break; fi; \
+    done && \
     sed -i 's|/root/.oh-my-zsh|/home/devuser/.oh-my-zsh|g' /home/devuser/.zshrc && \
     chown -R devuser:devuser /home/devuser/
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,11 +13,18 @@ RUN apt-get update && apt-get install -y sudo && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 
-# Set up oh-my-zsh for devuser
+# Set up oh-my-zsh / editor configs for devuser.
+# .zshrc and .oh-my-zsh live under /root/ in lmsysorg/sglang:dev.
+# .vimrc / .tmux.conf were moved to /opt/sglang/ in upstream PR #16365 and
+# are optional — copy them only if the base image still ships them.
 RUN cp -r /root/.oh-my-zsh /home/devuser/.oh-my-zsh && \
     cp /root/.zshrc /home/devuser/.zshrc && \
-    cp /root/.vimrc /home/devuser/.vimrc && \
-    cp /root/.tmux.conf /home/devuser/.tmux.conf && \
+    for src in /opt/sglang/.vimrc /root/.vimrc; do \
+        [ -f "$src" ] && cp "$src" /home/devuser/.vimrc && break; \
+    done; \
+    for src in /opt/sglang/.tmux.conf /root/.tmux.conf; do \
+        [ -f "$src" ] && cp "$src" /home/devuser/.tmux.conf && break; \
+    done; \
     sed -i 's|/root/.oh-my-zsh|/home/devuser/.oh-my-zsh|g' /home/devuser/.zshrc && \
     chown -R devuser:devuser /home/devuser/
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

In PR #16365 , the maintainers have moved the destination of the tmux/git/vim configs from `/root` to `/opt/sglang` in the Dockerfile.  And the SGLang team also recommends that for users who want to begin development, they could follow [this guide](https://docs.sglang.io/developer_guide/development_guide_using_docker.html#setup-docker-container) which lets user spawn their own dev containers via the vscode related plugin.

However, there is gap between the two settings. Although the Dockerfile in `docker/Dockerfile` have changed those settings, the Dockerfile in `.devcontainer` are not. Therefore, this PR would like to bridge this gap by revising the destinations of the related source files.

Here is a reproduction log of this problem:

```
➜  sglang git:(main) docker build -f .devcontainer/Dockerfile .devcontainer/ 
[+] Building 14.2s (7/11)                                                                                                                docker:default
 => [internal] load build definition from Dockerfile                                                                                               0.4s
 => => transferring dockerfile: 1.35kB                                                                                                             0.0s
 => [internal] load metadata for docker.io/lmsysorg/sglang:dev                                                                                     2.0s
 => [internal] load .dockerignore                                                                                                                  0.3s
 => => transferring context: 2B                                                                                                                    0.0s
 => [1/8] FROM docker.io/lmsysorg/sglang:dev@sha256:67921c763dfe719d5e91440eadf065ab1d7ae284e973553b64eaed902bdccd1e                               0.0s
 => CACHED [2/8] RUN groupadd -g 1003 devuser &&     useradd -m -u 1003 -g 1003 -s /bin/zsh devuser                                                0.0s
 => CACHED [3/8] RUN apt-get update && apt-get install -y sudo &&     echo "devuser ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/devuser &&     rm -r  0.0s
 => ERROR [4/8] RUN cp -r /root/.oh-my-zsh /home/devuser/.oh-my-zsh &&     cp /root/.zshrc /home/devuser/.zshrc &&     cp /root/.vimrc /home/dev  10.6s
------                                                                                                                                                  
 > [4/8] RUN cp -r /root/.oh-my-zsh /home/devuser/.oh-my-zsh &&     cp /root/.zshrc /home/devuser/.zshrc &&     cp /root/.vimrc /home/devuser/.vimrc &&     cp /root/.tmux.conf /home/devuser/.tmux.conf &&     sed -i 's|/root/.oh-my-zsh|/home/devuser/.oh-my-zsh|g' /home/devuser/.zshrc &&     chown -R devuser:devuser /home/devuser/:
2.186 cp: cannot stat '/root/.vimrc': No such file or directory
------
Dockerfile:17
--------------------
  16 |     # Set up oh-my-zsh for devuser
  17 | >>> RUN cp -r /root/.oh-my-zsh /home/devuser/.oh-my-zsh && \
  18 | >>>     cp /root/.zshrc /home/devuser/.zshrc && \
  19 | >>>     cp /root/.vimrc /home/devuser/.vimrc && \
  20 | >>>     cp /root/.tmux.conf /home/devuser/.tmux.conf && \
  21 | >>>     sed -i 's|/root/.oh-my-zsh|/home/devuser/.oh-my-zsh|g' /home/devuser/.zshrc && \
  22 | >>>     chown -R devuser:devuser /home/devuser/
  23 |     
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c cp -r /root/.oh-my-zsh /home/devuser/.oh-my-zsh &&     cp /root/.zshrc /home/devuser/.zshrc &&     cp /root/.vimrc /home/devuser/.vimrc &&     cp /root/.tmux.conf /home/devuser/.tmux.conf &&     sed -i 's|/root/.oh-my-zsh|/home/devuser/.oh-my-zsh|g' /home/devuser/.zshrc &&     chown -R devuser:devuser /home/devuser/" did not complete successfully: exit code: 1
```
## Modifications

In this modification, I revised the logic of the placement of the related config files: first the script would detect whether the related files exist in `/root` or `/opt/sglang` folders, copy them if they do exist and skip if neither of the files present in those two folders.

## Accuracy Tests

N/A(as this PR only revises the `.devcontainer/Docker`)

## Speed Tests and Profiling

N/A(the same reason as above)

## Checklist

- [X] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [X] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [X] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
   N/A, as only there is only modification of `.devcontainer/Docker` for building development containers. 
- [X] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [X] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.