### PR TITLE
[NPU] Add CI tests for --skip-server-warmup and --nccl-port arguments

### DIFF
--- a/test/registered/ascend/basic_function/http/test_npu_nccl_port.py
+++ b/test/registered/ascend/basic_function/http/test_npu_nccl_port.py
@@ -1,0 +1,73 @@
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import LLAMA_2_7B_WEIGHTS_PATH, run_command
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=400, suite="nightly-2-npu-a3", nightly=True)
+
+
+class TestNcclPort(CustomTestCase):
+    """Testcase: Test the basic functions of nccl-port
+                 Test nccl-port configured, the inference request successful.
+
+    [Test Category] Parameter
+    [Test Target] --nccl-port
+    """
+
+    model = LLAMA_2_7B_WEIGHTS_PATH
+
+    @classmethod
+    def setUpClass(cls):
+        other_args = [
+            "--nccl-port",
+            "9111",
+            "--tp-size",
+            "2",
+            "--attention-backend",
+            "ascend",
+            "--disable-cuda-graph",
+        ]
+        cls.process = popen_launch_server(
+            cls.model,
+            DEFAULT_URL_FOR_TEST,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_nccl_port(self):
+        """Test the --nccl-port argument."""
+        response = requests.get(f"{DEFAULT_URL_FOR_TEST}/health_generate")
+        self.assertEqual(response.status_code, 200)
+
+        response = requests.post(
+            f"{DEFAULT_URL_FOR_TEST}/generate",
+            json={
+                "text": "The capital of France is",
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": 32,
+                },
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        result = run_command("netstat -tulnp | grep :9111")
+        self.assertIn(":9111", result)
+        self.assertIn("LISTEN", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/ascend/basic_function/http/test_npu_nccl_port.py
+++ b/test/registered/ascend/basic_function/http/test_npu_nccl_port.py
@@ -64,8 +64,8 @@ class TestNcclPort(CustomTestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        result = run_command("netstat -tulnp | grep :9111")
-        self.assertIn(":9111", result)
+        result = run_command("ss -tuln | grep -w 9111")
+        self.assertIn("9111", result)
         self.assertIn("LISTEN", result)
 
 

--- a/test/registered/ascend/basic_function/http/test_npu_skip_warmup.py
+++ b/test/registered/ascend/basic_function/http/test_npu_skip_warmup.py
@@ -77,7 +77,7 @@ class TestSkipServerWarmup(CustomTestCase):
         self.assertTrue(
             len(content) > 0, "Log file remained empty after server startup"
         )
-        self.assertNotIn("GET /model_info HTTP/1.1", content)
+        self.assertNotIn("Running warmup", content)
 
 
 if __name__ == "__main__":

--- a/test/registered/ascend/basic_function/http/test_npu_skip_warmup.py
+++ b/test/registered/ascend/basic_function/http/test_npu_skip_warmup.py
@@ -70,15 +70,9 @@ class TestSkipServerWarmup(CustomTestCase):
         # Verify that inference is correct when warming up is skipped
         self.assertEqual(response.status_code, 200)
         self.assertIn("Paris", response.text)
-        start_time = time.time()
-        timeout = 30
-        content = ""
-        while time.time() - start_time < timeout:
-            with open(self.out_log_file.name, "r", encoding="utf-8") as f:
-                content = f.read()
-            if content:
-                break
-            time.sleep(0.5)
+        with open(self.out_log_file.name, "r", encoding="utf-8") as f:
+            content = f.read()
+
 
         self.assertTrue(
             len(content) > 0, "Log file remained empty after server startup"

--- a/test/registered/ascend/basic_function/http/test_npu_skip_warmup.py
+++ b/test/registered/ascend/basic_function/http/test_npu_skip_warmup.py
@@ -1,0 +1,90 @@
+import os
+import tempfile
+import time
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=50, suite="nightly-1-npu-a3", nightly=True)
+
+
+class TestSkipServerWarmup(CustomTestCase):
+    """
+    Testcase：Verify that if --skip-server-warmup parameter set, skip warmup.
+
+    [Test Category] Parameter
+    [Test Target] --skip-server-warmup
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model_path = LLAMA_3_2_1B_INSTRUCT_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        other_args = [
+            "--skip-server-warmup",
+            "--attention-backend",
+            "ascend",
+            "--disable-cuda-graph",
+        ]
+
+        cls.out_log_file = tempfile.NamedTemporaryFile(
+            mode="w+", encoding="utf-8", delete=False, suffix=".txt"
+        )
+        cls.err_log_file = tempfile.NamedTemporaryFile(
+            mode="w+", encoding="utf-8", delete=False, suffix=".txt"
+        )
+        cls.process = popen_launch_server(
+            cls.model_path,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+            return_stdout_stderr=(cls.out_log_file, cls.err_log_file),
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+        cls.out_log_file.close()
+        cls.err_log_file.close()
+        os.remove(cls.out_log_file.name)
+        os.remove(cls.err_log_file.name)
+
+    def test_skip_server_warmup(self):
+        response = requests.post(
+            f"{self.base_url}/generate",
+            json={
+                "text": "The capital of France is",
+                "sampling_params": {"temperature": 0, "max_new_tokens": 32},
+            },
+        )
+        # Verify that inference is correct when warming up is skipped
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Paris", response.text)
+        start_time = time.time()
+        timeout = 30
+        content = ""
+        while time.time() - start_time < timeout:
+            with open(self.out_log_file.name, "r", encoding="utf-8") as f:
+                content = f.read()
+            if content:
+                break
+            time.sleep(0.5)
+
+        self.assertTrue(
+            len(content) > 0, "Log file remained empty after server startup"
+        )
+        self.assertNotIn("GET /model_info HTTP/1.1", content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

This PR introduces specific integration tests for NPU (Ascend) environments to verify critical server argument behaviors. The motivation is to ensure:
1.  **NCCL Port Configuration**: The `--nccl-port` argument correctly configures the distributed communication port, which is essential for multi-card NPU setups.
2.  **Server Warmup Control**: The `--skip-server-warmup` argument effectively bypasses the warmup phase, preventing unnecessary initialization overhead or errors on specific hardware backends.

## Modifications

1.  **Added `test_npu_nccl_port.py`**:
    *   Launches the server with `--nccl-port 9111` and `--tp-size 2`.
    *   Verifies that the inference service is healthy (`/health_generate`).
    *   Programmatically checks via `netstat` that the process is listening on the specified NCCL port (9111).

2.  **Added `test_npu_skip_warmup.py`**:
    *   Launches the server with the `--skip-server-warmup` flag.
    *   Captures server startup logs to a temporary file.
    *   Verifies that the inference result is correct (e.g., "Paris" for the capital of France).
    *   Asserts that the startup logs **do not** contain the warmup request signature (`GET /model_info`), confirming the warmup phase was skipped.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
These are infrastructure tests. The accuracy logic is verified by checking standard inference outputs (e.g., ensuring the model generates "Paris" correctly) within the test scripts.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
N/A. These tests verify startup configurations and argument parsing logic.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).