### PR TITLE
Fix FlashInfer GDN SM90 mamba state scatter corrupting pool on dummy requests

### DIFF
--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
@@ -153,7 +153,16 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         else:
             # TODO: Once FlashInfer PR#2521 is merged for SM90, gather/scatter
             # will no longer be needed here.
-            state_batch = ssm_states[cache_indices]
+            # Remap -1 (dummy padding during CUDA graph) to last pool slot.
+            # Gather: reading garbage from sentinel slot is harmless.
+            # Scatter: writes garbage to sentinel slot — acceptable until
+            # FlashInfer supports initial_state_indices on SM90.
+            safe_indices = torch.where(
+                cache_indices >= 0,
+                cache_indices,
+                ssm_states.shape[0] - 1,
+            )
+            state_batch = ssm_states[safe_indices]
             output_fi, new_state = self._decode_fn(
                 q=query_fi,
                 k=key_fi,
@@ -167,7 +176,7 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
                 output=None,
                 use_qk_l2norm=True,
             )
-            ssm_states[cache_indices] = new_state
+            ssm_states[safe_indices] = new_state
 
         return output_fi.view(1, batch_size, num_v_heads, head_v_dim)
 
@@ -232,12 +241,17 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
             use_qk_l2norm_in_kernel=False,
         )
 
-        # Write back state to pool
-        ssm_states.index_copy_(
-            0,
-            ssm_cache_indices,
-            output_state_fi.to(ssm_states.dtype),
-        )
+        # Write back state to pool — only for valid (non-dummy) sequences.
+        # During CUDA graph capture, dummy requests have cache_indices=-1
+        # (remapped to pool_size-1 above for gather). We must NOT scatter
+        # their garbage results back, as that would corrupt the last pool slot.
+        valid_mask = cache_indices >= 0
+        if valid_mask.any():
+            ssm_states.index_copy_(
+                0,
+                ssm_cache_indices[valid_mask],
+                output_state_fi[valid_mask].to(ssm_states.dtype),
+            )
 
         # Output: [seq, HV, V] -> [1, seq, HV, V]
         core_attn_out = output_fi.view(1, total_seq_len, num_v_heads, head_v_dim)

--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
@@ -155,8 +155,6 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
             # will no longer be needed here.
             # Remap -1 (dummy padding during CUDA graph) to last pool slot.
             # Gather: reading garbage from sentinel slot is harmless.
-            # Scatter: writes garbage to sentinel slot — acceptable until
-            # FlashInfer supports initial_state_indices on SM90.
             safe_indices = torch.where(
                 cache_indices >= 0,
                 cache_indices,
@@ -176,7 +174,10 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
                 output=None,
                 use_qk_l2norm=True,
             )
-            ssm_states[safe_indices] = new_state
+            # For dummy requests (cache_indices=-1), write back the original
+            # state_batch instead of garbage new_state.  CUDA-graph safe.
+            valid = (cache_indices >= 0).view(-1, 1, 1, 1)
+            ssm_states[safe_indices] = torch.where(valid, new_state, state_batch)
 
         return output_fi.view(1, batch_size, num_v_heads, head_v_dim)
 


### PR DESCRIPTION
## Summary

Fix a bug in the SM90 FlashInfer GDN backend where dummy padding requests (from CUDA graph capture) corrupt the SSM state pool during scatter-back.

**Root cause**: During CUDA graph mode, batch is padded to a fixed size with dummy requests whose `cache_indices=-1`. The SM90 path uses manual gather/scatter (since FlashInfer lacks `initial_state_indices` on SM90), but was writing garbage output states back for these dummy sequences:

- **decode**: `ssm_states[cache_indices]` with -1 used Python negative indexing, silently overwriting `pool[-1]` with garbage
- **extend (prefill)**: `index_copy_` wrote all output states including dummies remapped to `pool_size-1`

When the pool is near capacity, the corrupted slot may belong to a valid request, causing **silent accuracy degradation** that is extremely hard to diagnose.

**Fix**:
- **decode**: Explicitly remap -1 → `pool_size-1` via `torch.where` (CUDA-graph safe). Acceptable until FlashInfer PR#2521 adds `initial_state_indices` for SM90.
- **extend**: Filter scatter with `valid_mask = cache_indices >= 0` so only real sequences write back. Safe because prefill is not CUDA-graph captured on SM90.

## Changes

**File**: `python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py`

### decode path (L153-176)

Before:
```python
state_batch = ssm_states[cache_indices]
...
ssm_states[cache_indices] = new_state
```

After:
```python
safe_indices = torch.where(
    cache_indices >= 0,
    cache_indices,
    ssm_states.shape[0] - 1,
)
state_batch = ssm_states[safe_indices]
...
ssm_states[safe_indices] = new_state
```

### extend path (L239-250)

Before:
```python
ssm_states.index_copy_(
    0,
    ssm_cache_indices,
    output_state_fi.to(ssm_states.dtype),
)
```

After:
```python
valid_mask = cache_indices >= 0
if valid_mask.any():
    ssm_states.index_copy_(
        0,
        ssm_cache_indices[valid_mask],
        output_state_fi[valid_mask].to(ssm_states.dtype),
    )
```

## Test plan

### Reproduce

Launch server (SM90 GPU, e.g. H200/H20):
```bash
python -m sglang.launch_server \
    --model /path/to/Qwen3.5-35B-A3B-FP8 \
    --tp 1 \
    --linear-attn-decode-backend flashinfer \
    --port 30000 \
    --host 0.0.0.0
```

Run GSM8K accuracy eval (1319 examples, 8-shot):
```bash
python3 -m sglang.test.run_eval \
    --port 30000 \
    --eval-name gsm8k \
    --num-examples 1319 \
    --max-tokens 10240 \
    --repeat 1 \
    --num-threads 1319 \
    --num-shots 8 \
    --temperature 0.6 \
    --top-p 0.95 \
    --top-k 20
```

### Results

GPU: H200 (SM90), tp=1, Qwen3.5-35B-A3B-FP8, `--linear-attn-decode-backend flashinfer`

| Version | GSM8K Score | Latency | Throughput |
|---------|------------|---------|------------|
| Before fix (main) | **96.87%** | 1019s | 3645 tok/s |
| After fix | **96.87%** | 960s | 3896 tok/s |

- [x] No accuracy regression
- [x] CUDA graph enabled (decode path exercised with batch padding)
- [ ] CI tests
