### PR TITLE
[MUSA][19/N] Support HiCache with pin_memory allocator

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -147,6 +147,7 @@ ALLOC_MEMORY_FUNCS = defaultdict(
     lambda: alloc_with_host_register,
     {
         "npu": alloc_with_pin_memory,
+        "musa": alloc_with_pin_memory,
     },
 )
 


### PR DESCRIPTION
## Motivation

(tracked in https://github.com/sgl-project/sglang/issues/16565)

HiCache currently falls back to the default host allocation path on MUSA, which uses `cudaHostRegister` when `pin_memory=True`. That path is CUDA-specific and is not appropriate for MUSA.

This change aligns MUSA with the existing NPU behavior by using PyTorch's built-in `pin_memory` allocation path for host buffers.

Error log:

```
[2026-04-20 08:09:39] Allocating 138.97 GB host memory for hierarchical KV cache.
[2026-04-20 08:09:39] Scheduler hit an exception: Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/sglang/srt/managers/scheduler.py", line 2685, in run_scheduler_process
    scheduler = Scheduler(
  File "/usr/local/lib/python3.10/dist-packages/sglang/srt/managers/scheduler.py", line 434, in __init__
    self.init_cache_with_memory_pool()
  File "/usr/local/lib/python3.10/dist-packages/sglang/srt/managers/scheduler.py", line 762, in init_cache_with_memory_pool
    self.tree_cache = HiRadixCache(params=params, server_args=server_args)
  File "/usr/local/lib/python3.10/dist-packages/sglang/srt/mem_cache/hiradix_cache.py", line 49, in __init__
    self.token_to_kv_pool_host = MHATokenToKVPoolHost(
  File "/usr/local/lib/python3.10/dist-packages/sglang/srt/mem_cache/memory_pool_host.py", line 243, in __init__
    super().__init__(
  File "/usr/local/lib/python3.10/dist-packages/sglang/srt/mem_cache/memory_pool_host.py", line 146, in __init__
    self.kv_buffer = self.init_kv_buffer()
  File "/usr/local/lib/python3.10/dist-packages/sglang/srt/mem_cache/memory_pool_host.py", line 309, in init_kv_buffer
    buffer = alloc_func(
  File "/usr/local/lib/python3.10/dist-packages/sglang/srt/mem_cache/memory_pool_host.py", line 67, in alloc_with_host_register
    torch.cuda.cudart().cudaHostRegister(
AttributeError: 'NoneType' object has no attribute 'cudaHostRegister'

```

## Modifications

- Add `musa` to `ALLOC_MEMORY_FUNCS`
- Route MUSA host buffer allocation to `alloc_with_pin_memory`


## Testing Done

Tested in a clean torch_musa container:

<details>
<summary><===Click to expand log details===></summary>

```sh
python -m sglang.launch_server \
    --model-path /home/dist/models/Qwen3-0.6B/ \
    --served-model-name base-model \
    --trust-remote-code \
    --base-gpu-id 0 \
    --port 31000 \
    --enable-cache-report \
    --enable-hierarchical-cache \
    --hicache-ratio 2 \
    --hicache-size 0 \
    --page-size 64 \
    --cuda-graph-max-bs 10 \

[2026-04-21 09:59:42] INFO __init__.py:36: Available plugins for group vllm.platform_plugins:
[2026-04-21 09:59:42] INFO __init__.py:38: - musa -> vllm_musa:register
[2026-04-21 09:59:42] INFO __init__.py:41: All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
[2026-04-21 09:59:42] INFO __init__.py:36: Available plugins for group vllm.platform_plugins:
[2026-04-21 09:59:42] INFO __init__.py:38: - musa -> vllm_musa:register
[2026-04-21 09:59:42] INFO __init__.py:41: All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
[2026-04-21 09:59:42] INFO __init__.py:232: Platform plugin musa is activated
[2026-04-21 09:59:42] INFO __init__.py:245: No platform detected, vLLM is running on UnspecifiedPlatform
[2026-04-21 09:59:42] WARNING _custom_ops.py:20: Failed to import from vllm._C with ModuleNotFoundError("No module named 'vllm._C'")
/home/dist/yafeng/code/sglang/python/sglang/srt/layers/quantization/awq.py:82: UserWarning: MUSA does not support fused_marlin_moe currently.
  warnings.warn(f"MUSA does not support fused_marlin_moe currently.")
[2026-04-21 09:59:42] WARNING server_args.py:1415: Attention backend not explicitly specified. Use triton backend by default.
[2026-04-21 09:59:47] INFO __init__.py:36: Available plugins for group vllm.platform_plugins:
[2026-04-21 09:59:47] INFO __init__.py:38: - musa -> vllm_musa:register
[2026-04-21 09:59:47] INFO __init__.py:41: All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
[2026-04-21 09:59:47] INFO __init__.py:36: Available plugins for group vllm.platform_plugins:
[2026-04-21 09:59:47] INFO __init__.py:38: - musa -> vllm_musa:register
[2026-04-21 09:59:47] INFO __init__.py:41: All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
[2026-04-21 09:59:47] INFO __init__.py:36: Available plugins for group vllm.platform_plugins:
[2026-04-21 09:59:47] INFO __init__.py:38: - musa -> vllm_musa:register
[2026-04-21 09:59:47] INFO __init__.py:41: All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
[2026-04-21 09:59:47] INFO __init__.py:232: Platform plugin musa is activated
[2026-04-21 09:59:47] INFO __init__.py:36: Available plugins for group vllm.platform_plugins:
[2026-04-21 09:59:47] INFO __init__.py:38: - musa -> vllm_musa:register
[2026-04-21 09:59:47] INFO __init__.py:41: All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
[2026-04-21 09:59:47] INFO __init__.py:232: Platform plugin musa is activated
[2026-04-21 09:59:48] INFO __init__.py:245: No platform detected, vLLM is running on UnspecifiedPlatform
[2026-04-21 09:59:48] WARNING _custom_ops.py:20: Failed to import from vllm._C with ModuleNotFoundError("No module named 'vllm._C'")
[2026-04-21 09:59:48] INFO __init__.py:245: No platform detected, vLLM is running on UnspecifiedPlatform
[2026-04-21 09:59:48] WARNING _custom_ops.py:20: Failed to import from vllm._C with ModuleNotFoundError("No module named 'vllm._C'")
/home/dist/yafeng/code/sglang/python/sglang/srt/layers/quantization/awq.py:82: UserWarning: MUSA does not support fused_marlin_moe currently.
  warnings.warn(f"MUSA does not support fused_marlin_moe currently.")
/home/dist/yafeng/code/sglang/python/sglang/srt/layers/quantization/awq.py:82: UserWarning: MUSA does not support fused_marlin_moe currently.
  warnings.warn(f"MUSA does not support fused_marlin_moe currently.")
[2026-04-21 09:59:48] Process 2126297 gpu_id 0 is running on CPUs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255]
[2026-04-21 09:59:48] Init torch distributed begin.
[2026-04-21 09:59:48] Init torch distributed ends. mem usage=0.00 GB
[2026-04-21 09:59:48] MOE_RUNNER_BACKEND is not initialized, the backend will be automatically selected
[2026-04-21 09:59:49] Ignore import error when loading sglang.srt.models.mindspore: name 'ms' is not defined
[2026-04-21 09:59:49] Load weight begin. avail mem=79.27 GB
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  2.66it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  2.66it/s]

[2026-04-21 09:59:53] Load weight end. type=Qwen3ForCausalLM, dtype=torch.bfloat16, avail mem=77.71 GB, mem usage=1.56 GB.
[2026-04-21 09:59:53] Using KV cache dtype: torch.bfloat16
[2026-04-21 09:59:53] KV Cache is allocated. #tokens: 610240, K size: 32.59 GB, V size: 32.59 GB
[2026-04-21 09:59:53] Memory pool end. avail mem=11.77 GB
[2026-04-21 09:59:54] Capture cuda graph begin. This can take up to several minutes. avail mem=11.71 GB
[2026-04-21 09:59:54] Capture cuda graph bs [1, 2, 4, 8]
Capturing batches (bs=1 avail_mem=10.86 GB): 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:12<00:00,  3.15s/it]
[2026-04-21 10:00:07] Capture cuda graph end. Time elapsed: 13.15 s. mem usage=0.87 GB. avail mem=10.85 GB.
[2026-04-21 10:00:07] max_total_num_tokens=610240, chunked_prefill_size=8192, max_prefill_tokens=16384, max_running_requests=4096, context_len=40960, available_gpu_mem=10.85 GB
[2026-04-21 10:00:07] Allocating 139.98 GB host memory for hierarchical KV cache.
[2026-04-21 10:02:04] INFO:     Started server process [2126034]
[2026-04-21 10:02:04] INFO:     Waiting for application startup.
[2026-04-21 10:02:04] Using default chat sampling params from model generation config: {'repetition_penalty': 1.0, 'temperature': 0.6, 'top_k': 20, 'top_p': 0.95}
[2026-04-21 10:02:04] Using default chat sampling params from model generation config: {'repetition_penalty': 1.0, 'temperature': 0.6, 'top_k': 20, 'top_p': 0.95}
[2026-04-21 10:02:04] INFO:     Application startup complete.
[2026-04-21 10:02:04] INFO:     Uvicorn running on http://127.0.0.1:31000 (Press CTRL+C to quit)
[2026-04-21 10:02:05] Endpoint '/get_model_info' is deprecated and will be removed in a future version. Please use '/model_info' instead.
[2026-04-21 10:02:05] INFO:     127.0.0.1:54220 - "GET /get_model_info HTTP/1.1" 200 OK
[2026-04-21 10:02:05] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2026-04-21 10:02:08] INFO:     127.0.0.1:54224 - "POST /generate HTTP/1.1" 200 OK
[2026-04-21 10:02:08] The server is fired up and ready to roll!
[2026-04-21 10:02:12] INFO:     127.0.0.1:54234 - "GET /v1/models HTTP/1.1" 200 OK
```
</details>


Hicache multiturn benchmark:

<details>
<summary><===Click to expand log details===></summary>

```sh
python3 benchmark/hicache/bench_multiturn.py \
    --dataset-path /home/dist/yafeng/datasets/ShareGPT_V3_unfiltered_cleaned_split.json \
    --model-path /home/dist/models/Qwen3-0.6B/ \
    --host 127.0.0.1 \
    --port 31000 \
    --disable-random-sample \
    --output-length 10 \
    --request-length 2048 \
    --num-clients 1 \
    --num-rounds 10 \
    --max-parallel 2 \
    --request-rate 2 \
    --ready-queue-policy random \
    --disable-auto-run \
    --seed 42
    

Running with specified request rate...
#Input tokens: 2048
#Output tokens: 10
#Input tokens: 18432
#Output tokens: 90
100%|██████████████████████████████████████████████████████████████████████████| 10/10 [02:38<00:00, 15.86s/it]
All requests completed
Performance metrics summary:
  Total requests: 10 at 2.0 requests per second
  Average Prompt Length: 8854.30 tokens
  Average Output Length: 8.20 tokens
  Average TTFT: 9.61
  P90 TTFT: 24.58
  Median TTFT: 11.59
  Average latency: 14.44
  P90 latency: 26.84
  Median latency: 15.50
  Input token throughput: 595.68 tokens per second
  Output token throughput: 0.55 tokens per second
  Request Throughput: 0.07 requests per second
  Cache Hit Rate: 0.805213

```
</details>



## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
