### PR TITLE
Test: (function_call) add unit tests for GigaChat3, Pythonic, and Lfm2...

### DIFF
--- a/test/registered/unit/function_call/test_gigachat3_detector.py
+++ b/test/registered/unit/function_call/test_gigachat3_detector.py
@@ -1,0 +1,173 @@
+"""Unit tests for GigaChat3Detector — no server, no model loading."""
+
+import json
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.gigachat3_detector import GigaChat3Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "stage-a-test-cpu")
+
+ROLE_SEP = "<|role_sep|>"
+MSG_SEP = "<|message_sep|>"
+FUNC_CALL_TOKEN = "<|function_call|>"
+
+
+def _role_sep_call(name: str, args: dict) -> str:
+    return f"function call{ROLE_SEP}\n" + json.dumps({"name": name, "arguments": args})
+
+
+def _func_call_token_call(name: str, args: dict) -> str:
+    return FUNC_CALL_TOKEN + json.dumps({"name": name, "arguments": args})
+
+
+class TestGigaChat3Detector(CustomTestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_weather",
+                    description="Get weather",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "city": {"type": "string"},
+                            "unit": {
+                                "type": "string",
+                                "enum": ["celsius", "fahrenheit"],
+                            },
+                        },
+                        "required": ["city"],
+                    },
+                ),
+            ),
+            Tool(
+                type="function",
+                function=Function(
+                    name="search",
+                    description="Search the web",
+                    parameters={
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                        "required": ["query"],
+                    },
+                ),
+            ),
+        ]
+        self.detector = GigaChat3Detector()
+
+    def test_has_tool_call_role_sep(self):
+        self.assertTrue(
+            self.detector.has_tool_call(
+                _role_sep_call("get_weather", {"city": "Tokyo"})
+            )
+        )
+
+    def test_has_tool_call_function_call_token(self):
+        self.assertTrue(
+            self.detector.has_tool_call(
+                _func_call_token_call("get_weather", {"city": "Tokyo"})
+            )
+        )
+
+    def test_has_tool_call_false(self):
+        self.assertFalse(self.detector.has_tool_call("The weather is fine today."))
+
+    def test_single_call_role_sep(self):
+        text = _role_sep_call("get_weather", {"city": "Tokyo"})
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        args = json.loads(result.calls[0].parameters)
+        self.assertEqual(args["city"], "Tokyo")
+
+    def test_single_call_function_call_token(self):
+        text = _func_call_token_call("search", {"query": "python"})
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "search")
+        args = json.loads(result.calls[0].parameters)
+        self.assertEqual(args["query"], "python")
+
+    def test_no_tool_call(self):
+        text = "The weather is fine today."
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 0)
+        self.assertIn("weather", result.normal_text)
+
+    def test_content_before_call(self):
+        content = "Sure, let me check."
+        text = content + MSG_SEP + _role_sep_call("get_weather", {"city": "Paris"})
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.normal_text, content)
+
+    def test_strips_eos_token(self):
+        text = _role_sep_call("get_weather", {"city": "Berlin"}) + "</s>"
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_weather")
+
+    def test_malformed_json_returns_text(self):
+        text = f"function call{ROLE_SEP}\nnot valid json"
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 0)
+        self.assertIn("not valid json", result.normal_text)
+
+    def test_missing_name_field_returns_empty(self):
+        text = f"function call{ROLE_SEP}\n" + json.dumps(
+            {"arguments": {"city": "Tokyo"}}
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 0)
+
+    def test_streaming_plain_text(self):
+        detector = GigaChat3Detector()
+        result = detector.parse_streaming_increment("Hello world. ", self.tools)
+        self.assertEqual(result.normal_text, "Hello world. ")
+        self.assertEqual(len(result.calls), 0)
+
+    def test_streaming_tool_name_sent(self):
+        detector = GigaChat3Detector()
+        payload = json.dumps({"name": "get_weather", "arguments": {"city": "Oslo"}})
+        chunks = [
+            f"function call{ROLE_SEP}\n",
+            payload[:10],
+            payload[10:],
+        ]
+        all_calls = []
+        for chunk in chunks:
+            r = detector.parse_streaming_increment(chunk, self.tools)
+            all_calls.extend(r.calls)
+
+        named = [c for c in all_calls if c.name]
+        self.assertEqual(len(named), 1)
+        self.assertEqual(named[0].name, "get_weather")
+
+    def test_streaming_args_delta(self):
+        detector = GigaChat3Detector()
+        payload = json.dumps({"name": "search", "arguments": {"query": "sglang"}})
+        full_text = f"function call{ROLE_SEP}\n{payload}"
+        all_calls = []
+        for char in full_text:
+            r = detector.parse_streaming_increment(char, self.tools)
+            all_calls.extend(r.calls)
+
+        named = [c for c in all_calls if c.name]
+        self.assertEqual(len(named), 1)
+        self.assertEqual(named[0].name, "search")
+
+    def test_supports_structural_tag_false(self):
+        self.assertFalse(self.detector.supports_structural_tag())
+
+    def test_structure_info_raises(self):
+        with self.assertRaises(NotImplementedError):
+            self.detector.structure_info()
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/test/registered/unit/function_call/test_lfm2_detector.py
+++ b/test/registered/unit/function_call/test_lfm2_detector.py
@@ -1,0 +1,156 @@
+"""Unit tests for Lfm2Detector — no server, no model loading."""
+
+import json
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.lfm2_detector import Lfm2Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "stage-a-test-cpu")
+
+BOT = "<|tool_call_start|>"
+EOT = "<|tool_call_end|>"
+
+
+def _pythonic(content: str) -> str:
+    return BOT + content + EOT
+
+
+def _json_call(name: str, args: dict) -> str:
+    return BOT + json.dumps([{"name": name, "arguments": args}]) + EOT
+
+
+class TestLfm2Detector(CustomTestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_weather",
+                    description="Get weather",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "city": {"type": "string"},
+                            "unit": {
+                                "type": "string",
+                                "enum": ["celsius", "fahrenheit"],
+                            },
+                        },
+                        "required": ["city"],
+                    },
+                ),
+            ),
+            Tool(
+                type="function",
+                function=Function(
+                    name="search",
+                    description="Search the web",
+                    parameters={
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                        "required": ["query"],
+                    },
+                ),
+            ),
+        ]
+        self.detector = Lfm2Detector()
+
+    def test_has_tool_call_true(self):
+        self.assertTrue(
+            self.detector.has_tool_call(BOT + '[get_weather(city="Tokyo")]' + EOT)
+        )
+
+    def test_has_tool_call_false(self):
+        self.assertFalse(self.detector.has_tool_call("The weather is fine today."))
+
+    def test_single_call_pythonic(self):
+        text = _pythonic('[get_weather(city="Tokyo")]')
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        args = json.loads(result.calls[0].parameters)
+        self.assertEqual(args["city"], "Tokyo")
+
+    def test_single_call_json(self):
+        text = _json_call("search", {"query": "sglang"})
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "search")
+        args = json.loads(result.calls[0].parameters)
+        self.assertEqual(args["query"], "sglang")
+
+    def test_multiple_calls_pythonic(self):
+        text = _pythonic('[get_weather(city="Tokyo"), search(query="restaurants")]')
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 2)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        self.assertEqual(result.calls[1].name, "search")
+
+    def test_multiple_args_pythonic(self):
+        text = _pythonic('[get_weather(city="London", unit="celsius")]')
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        args = json.loads(result.calls[0].parameters)
+        self.assertEqual(args["city"], "London")
+        self.assertEqual(args["unit"], "celsius")
+
+    def test_no_tool_call(self):
+        text = "The weather is fine today."
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 0)
+        self.assertIn("weather", result.normal_text)
+
+    def test_normal_text_before_call(self):
+        text = "Sure! " + _pythonic('[get_weather(city="Paris")]')
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertIn("Sure", result.normal_text)
+
+    def test_streaming_plain_text(self):
+        detector = Lfm2Detector()
+        result = detector.parse_streaming_increment("Hello world.", self.tools)
+        self.assertEqual(result.normal_text, "Hello world.")
+        self.assertEqual(len(result.calls), 0)
+
+    def test_streaming_complete_call_pythonic(self):
+        detector = Lfm2Detector()
+        text = _pythonic('[get_weather(city="Tokyo")]')
+        result = detector.parse_streaming_increment(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_weather")
+
+    def test_streaming_split_chunks(self):
+        detector = Lfm2Detector()
+        chunks = [BOT, '[get_weather(city="Oslo")]', EOT]
+        all_calls = []
+        for chunk in chunks:
+            r = detector.parse_streaming_increment(chunk, self.tools)
+            all_calls.extend(r.calls)
+        named = [c for c in all_calls if c.name]
+        self.assertEqual(len(named), 1)
+        self.assertEqual(named[0].name, "get_weather")
+
+    def test_streaming_json_format(self):
+        detector = Lfm2Detector()
+        text = _json_call("search", {"query": "test"})
+        result = detector.parse_streaming_increment(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "search")
+
+    def test_supports_structural_tag_false(self):
+        self.assertFalse(self.detector.supports_structural_tag())
+
+    def test_structure_info_not_none(self):
+        info_fn = self.detector.structure_info()
+        self.assertIsNotNone(info_fn)
+        info = info_fn("get_weather")
+        self.assertIn("get_weather", info.begin)
+        self.assertIn(BOT, info.trigger)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/test/registered/unit/function_call/test_pythonic_detector.py
+++ b/test/registered/unit/function_call/test_pythonic_detector.py
@@ -1,0 +1,139 @@
+"""Unit tests for PythonicDetector — no server, no model loading."""
+
+import json
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.pythonic_detector import PythonicDetector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "stage-a-test-cpu")
+
+PYTHON_START = "<|python_start|>"
+PYTHON_END = "<|python_end|>"
+
+
+class TestPythonicDetector(CustomTestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_weather",
+                    description="Get weather",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "city": {"type": "string"},
+                            "unit": {
+                                "type": "string",
+                                "enum": ["celsius", "fahrenheit"],
+                            },
+                        },
+                        "required": ["city"],
+                    },
+                ),
+            ),
+            Tool(
+                type="function",
+                function=Function(
+                    name="search",
+                    description="Search the web",
+                    parameters={
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                        "required": ["query"],
+                    },
+                ),
+            ),
+        ]
+        self.detector = PythonicDetector()
+
+    def test_has_tool_call_true(self):
+        self.assertTrue(self.detector.has_tool_call('[get_weather(city="Tokyo")]'))
+
+    def test_has_tool_call_false(self):
+        self.assertFalse(self.detector.has_tool_call("The weather is fine today."))
+
+    def test_has_tool_call_with_python_tokens(self):
+        text = PYTHON_START + '[get_weather(city="Tokyo")]' + PYTHON_END
+        self.assertTrue(self.detector.has_tool_call(text))
+
+    def test_single_call(self):
+        text = '[get_weather(city="Tokyo")]'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        args = json.loads(result.calls[0].parameters)
+        self.assertEqual(args["city"], "Tokyo")
+
+    def test_multiple_calls(self):
+        text = '[get_weather(city="Tokyo"), search(query="restaurants")]'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 2)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        self.assertEqual(result.calls[1].name, "search")
+
+    def test_multiple_args(self):
+        text = '[get_weather(city="London", unit="celsius")]'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        args = json.loads(result.calls[0].parameters)
+        self.assertEqual(args["city"], "London")
+        self.assertEqual(args["unit"], "celsius")
+
+    def test_no_tool_call(self):
+        text = "The weather is fine today."
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 0)
+        self.assertIn("weather", result.normal_text)
+
+    def test_strips_python_tokens(self):
+        text = PYTHON_START + '[get_weather(city="Paris")]' + PYTHON_END
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_weather")
+
+    def test_unknown_tool_skipped(self):
+        text = '[undefined_func(arg="val")]'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 0)
+
+    def test_streaming_plain_text(self):
+        detector = PythonicDetector()
+        result = detector.parse_streaming_increment("Hello world.", self.tools)
+        self.assertEqual(result.normal_text, "Hello world.")
+        self.assertEqual(len(result.calls), 0)
+
+    def test_streaming_complete_call_one_chunk(self):
+        detector = PythonicDetector()
+        result = detector.parse_streaming_increment(
+            '[get_weather(city="Tokyo")]', self.tools
+        )
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_weather")
+
+    def test_streaming_split_across_chunks(self):
+        detector = PythonicDetector()
+        all_calls = []
+        for chunk in ['[get_weather(city="', 'Oslo")]']:
+            r = detector.parse_streaming_increment(chunk, self.tools)
+            all_calls.extend(r.calls)
+        named = [c for c in all_calls if c.name]
+        self.assertEqual(len(named), 1)
+        self.assertEqual(named[0].name, "get_weather")
+        args = json.loads(named[0].parameters)
+        self.assertEqual(args["city"], "Oslo")
+
+    def test_supports_structural_tag_false(self):
+        self.assertFalse(self.detector.supports_structural_tag())
+
+    def test_structure_info_raises(self):
+        with self.assertRaises(NotImplementedError):
+            self.detector.structure_info()
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Motivation

  Part of #20865 (`srt/function_call/` portion).

  `GigaChat3Detector`, `PythonicDetector`, and `Lfm2Detector` — three function call format
  parsers — had no unit test coverage. This PR adds 43 tests covering both one-shot and
  streaming parsing paths for all three detectors.

  ## Modifications

  Add three test files under `test/registered/unit/function_call/` (43 tests total,
  CPU-only, no server or model weights):

  - `test_gigachat3_detector.py` (15 tests): `has_tool_call` for both role-sep and
    `<|function_call|>` formats; `detect_and_parse` for single call, no-call, content
    before marker, EOS stripping, malformed JSON, missing `name` field; streaming plain
    text, tool name extraction, and arg delta across character-level chunks
  - `test_pythonic_detector.py` (14 tests): `has_tool_call` with and without
    `<|python_start|>`/`<|python_end|>` tokens; `detect_and_parse` for single call,
    multiple calls, multiple args, unknown tool skipping, token stripping; streaming
    complete call in one chunk and split across two chunks
  - `test_lfm2_detector.py` (14 tests): `has_tool_call`; `detect_and_parse` for Pythonic
    format, JSON format, multiple calls, multiple args, no-call, normal text before
    call; streaming plain text, complete call, split chunks, and JSON format via streaming;
    `structure_info` returns valid `StructureInfo` with correct `begin`/`trigger` fields

  ## Accuracy Tests

  N/A — no model forward code changed.

  ## Speed Tests and Profiling

  N/A — test-only change.

  ## Checklist

  - [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/de
  veloper_guide/contribution_guide.html#format-code-with-pre-commit).
  - [x] Add unit tests according to the [Run and add unit
  tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
  - [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer
  _guide/contribution_guide.html#write-documentations).
  - [ ] Provide accuracy and speed benchmark results according to [Test the
  accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and
   [Benchmark the
  speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
  - [x] Follow the SGLang code style
  [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance)