### PR TITLE
scheduler: preserve output ids when merging batches

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2395,7 +2395,14 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.orig_seq_lens = torch.cat([self.orig_seq_lens, other.orig_seq_lens])
         self.out_cache_loc = None
         self.seq_lens_sum += other.seq_lens_sum
-        if self.output_ids is not None:
+        # Batches can be merged across prefill/decode boundaries. A prepared
+        # decode batch has already moved its pending token ids into
+        # ``input_ids`` and cleared ``output_ids``, while prebuilt decode
+        # batches still populate ``output_ids``. Preserve whichever side still
+        # has pending token ids and concatenate only when both do.
+        if self.output_ids is None:
+            self.output_ids = other.output_ids
+        elif other.output_ids is not None:
             self.output_ids = torch.cat([self.output_ids, other.output_ids])
         self.mamba_track_indices = None
         self.mamba_track_mask = None

--- a/test/registered/unit/managers/test_schedule_batch_merge.py
+++ b/test/registered/unit/managers/test_schedule_batch_merge.py
@@ -1,12 +1,45 @@
 import unittest
+import sys
+import importlib.abc
+import importlib.machinery
 from types import SimpleNamespace
 
 import torch
 
 from sglang.test.ci.ci_register import register_cpu_ci
-from sglang.test.test_utils import maybe_stub_sgl_kernel
 
-maybe_stub_sgl_kernel()
+
+def _maybe_stub_sgl_kernel():
+    try:
+        import sgl_kernel  # noqa: F401
+
+        return
+    except (ImportError, OSError):
+        pass
+
+    class _SglKernelLoader(importlib.abc.Loader):
+        def create_module(self, spec):
+            return None
+
+        def exec_module(self, module):
+            from unittest.mock import MagicMock
+
+            module.__getattr__ = lambda name: MagicMock()
+
+    class _SglKernelFinder(importlib.abc.MetaPathFinder):
+        def find_spec(self, fullname, path, target=None):
+            if fullname == "sgl_kernel" or fullname.startswith("sgl_kernel."):
+                return importlib.machinery.ModuleSpec(
+                    fullname,
+                    _SglKernelLoader(),
+                    is_package=True,
+                )
+            return None
+
+    sys.meta_path.insert(0, _SglKernelFinder())
+
+
+_maybe_stub_sgl_kernel()
 
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 

--- a/test/registered/unit/managers/test_schedule_batch_merge.py
+++ b/test/registered/unit/managers/test_schedule_batch_merge.py
@@ -1,0 +1,85 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.schedule_batch import ScheduleBatch
+
+register_cpu_ci(est_time=6, suite="stage-a-test-cpu")
+
+
+class _DummySamplingInfo:
+    def merge_batch(self, other):
+        del other
+
+
+class _DummyModelConfig:
+    is_encoder_decoder = False
+
+
+def _make_batch(output_ids: torch.Tensor | None) -> SimpleNamespace:
+    return SimpleNamespace(
+        maybe_wait_verify_done=lambda: None,
+        sampling_info=_DummySamplingInfo(),
+        model_config=_DummyModelConfig(),
+        req_pool_indices=torch.tensor([0], dtype=torch.int64),
+        seq_lens=torch.tensor([1], dtype=torch.int64),
+        seq_lens_cpu=torch.tensor([1], dtype=torch.int64),
+        orig_seq_lens=torch.tensor([1], dtype=torch.int64),
+        out_cache_loc=None,
+        seq_lens_sum=1,
+        output_ids=output_ids,
+        mamba_track_indices=None,
+        mamba_track_mask=None,
+        mamba_track_seqlens=None,
+        return_logprob=False,
+        top_logprobs_nums=None,
+        token_ids_logprobs=None,
+        reqs=[object()],
+        multimodal_inputs=None,
+        has_stream=False,
+        has_grammar=False,
+        return_hidden_states=False,
+        is_prefill_only=True,
+        spec_info=None,
+    )
+
+
+class TestScheduleBatchMerge(unittest.TestCase):
+    def test_merge_keeps_existing_output_ids_when_other_side_is_missing(self):
+        extend_batch = _make_batch(torch.tensor([5], dtype=torch.int64))
+        decode_batch = _make_batch(None)
+
+        ScheduleBatch.merge_batch(extend_batch, decode_batch)
+
+        self.assertTrue(torch.equal(extend_batch.output_ids, torch.tensor([5])))
+        self.assertEqual(len(extend_batch.reqs), 2)
+        self.assertEqual(extend_batch.seq_lens.shape[0], 2)
+
+    def test_merge_adopts_other_output_ids_when_self_side_is_missing(self):
+        decode_batch = _make_batch(None)
+        prebuilt_batch = _make_batch(torch.tensor([7], dtype=torch.int64))
+
+        ScheduleBatch.merge_batch(decode_batch, prebuilt_batch)
+
+        self.assertTrue(torch.equal(decode_batch.output_ids, torch.tensor([7])))
+        self.assertEqual(len(decode_batch.reqs), 2)
+        self.assertEqual(decode_batch.seq_lens.shape[0], 2)
+
+    def test_merge_keeps_existing_output_id_concat_behavior(self):
+        first = _make_batch(torch.tensor([5], dtype=torch.int64))
+        second = _make_batch(torch.tensor([7], dtype=torch.int64))
+
+        ScheduleBatch.merge_batch(first, second)
+
+        self.assertTrue(torch.equal(first.output_ids, torch.tensor([5, 7])))
+        self.assertEqual(len(first.reqs), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- preserve pending output ids when merging batches across prefill/decode boundaries where one side has already moved token ids into `input_ids`
- add focused unit coverage for the `output_ids is None` merge cases
- inline the `sgl_kernel` stub in the new unit test so it can run without pulling in heavy `test_utils` dependencies

## Testing
- `PYTHONPATH=/home/wuyingjun/llm/sglang-git/python:/home/wuyingjun/llm/sglang-git:/tmp/sglang-testdeps python -m pytest /home/wuyingjun/llm/sglang-git/test/registered/unit/managers/test_schedule_batch_merge.py /home/wuyingjun/llm/sglang-git/test/registered/rl/test_pause_generation_tensor_consistency.py`