### PR TITLE
[AMD] skip deterministic inference for MLA FP8 test

### DIFF
--- a/test/registered/mla/test_mla_fp8.py
+++ b/test/registered/mla/test_mla_fp8.py
@@ -1,6 +1,6 @@
 import unittest
 
-from sglang.srt.utils import is_hip, kill_process_tree
+from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.kits.eval_accuracy_kit import MGSMEnMixin
 from sglang.test.test_utils import (

--- a/test/registered/mla/test_mla_fp8.py
+++ b/test/registered/mla/test_mla_fp8.py
@@ -1,6 +1,6 @@
 import unittest
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import is_hip, kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.kits.eval_accuracy_kit import MGSMEnMixin
 from sglang.test.test_utils import (
@@ -23,23 +23,26 @@ class TestMLA(CustomTestCase, MGSMEnMixin):
     def setUpClass(cls):
         cls.model = DEFAULT_MLA_FP8_MODEL_NAME_FOR_TEST
         cls.base_url = DEFAULT_URL_FOR_TEST
+        other_args = [
+            "--trust-remote-code",
+            "--kv-cache-dtype",
+            "fp8_e5m2",
+            # Pin MoE expert dispatch and kernel reduction order so MGSM
+            # scores don't drift across runs. The eval already uses greedy
+            # decoding, but FP8 dequant + non-deterministic MoE top-k
+            # tie-breaks produce ~1–3 point swings without this flag and
+            # straddle the 0.8 threshold. With deterministic inference,
+            # the score becomes a fixed function of (model, weights, CUDA
+            # stack), so threshold-edge flakes stop being random noise.
+        ]
+        if not is_hip():
+            # On AMD, the default attention backend (aiter) is not in the deterministic-inference allowlist, so the server fails to start, disable it.
+            other_args.append("--enable-deterministic-inference")
         cls.process = popen_launch_server(
             cls.model,
             cls.base_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=[
-                "--trust-remote-code",
-                "--kv-cache-dtype",
-                "fp8_e5m2",
-                # Pin MoE expert dispatch and kernel reduction order so MGSM
-                # scores don't drift across runs. The eval already uses greedy
-                # decoding, but FP8 dequant + non-deterministic MoE top-k
-                # tie-breaks produce ~1–3 point swings without this flag and
-                # straddle the 0.8 threshold. With deterministic inference,
-                # the score becomes a fixed function of (model, weights, CUDA
-                # stack), so threshold-edge flakes stop being random noise.
-                "--enable-deterministic-inference",
-            ],
+            other_args=other_args,
         )
 
     @classmethod

--- a/test/registered/mla/test_mla_fp8.py
+++ b/test/registered/mla/test_mla_fp8.py
@@ -35,7 +35,7 @@ class TestMLA(CustomTestCase, MGSMEnMixin):
             # the score becomes a fixed function of (model, weights, CUDA
             # stack), so threshold-edge flakes stop being random noise.
         ]
-        if not is_hip():
+        if not is_in_amd_ci():
             # On AMD, the default attention backend (aiter) is not in the deterministic-inference allowlist, so the server fails to start, disable it.
             other_args.append("--enable-deterministic-inference")
         cls.process = popen_launch_server(

--- a/test/registered/mla/test_mla_fp8.py
+++ b/test/registered/mla/test_mla_fp8.py
@@ -8,6 +8,7 @@ from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
+    is_in_amd_ci,
     popen_launch_server,
 )
 


### PR DESCRIPTION
## Motivation

PR #23303 added `--enable-deterministic-inference` to `test/registered/mla/test_mla_fp8.py` to stabilize MGSM scores around the 0.8 threshold. The flag works on NVIDIA but breaks the AMD CI partition that runs the same test (`stage-b-test-1-gpu-small-amd`, partition 5). Failing run:

- https://github.com/sgl-project/sglang/actions/runs/24713176882/job/72282791399

Server fails to start with:

```
ValueError: Currently only ['flashinfer', 'fa3', 'triton'] attention
backends are supported for deterministic inference, but you explicitly
specified 'aiter'.
```

That's the surface symptom. Three stacked sglang ROCm bugs prevent us from cleanly turning the flag on under DeepSeek MLA + FP8:

1. `_handle_attention_backend_compatibility` runs before `_handle_deterministic_inference` and auto-defaults `attention_backend` to `aiter`, which is not in `DETERMINISTIC_ATTENTION_BACKEND_CHOICES`, so the server refuses to start.
2. Working around (1) with `--attention-backend triton` hits `FUSED_ROPE_ROCM` (gated by `SGLANG_ROCM_FUSED_DECODE_MLA=1` in the CI image), whose `forward_metadata` unpacking is aiter-specific.
3. Working around (2) by also setting `SGLANG_ROCM_FUSED_DECODE_MLA=0` then hits a GPU memory access fault during CUDA graph capture (`bs=512`) under triton MLA — a kernel-level bug.

For comparison, NVIDIA's auto-default lands on `fa3` (Hopper) or `flashinfer` (Blackwell), both of which are in `DETERMINISTIC_ATTENTION_BACKEND_CHOICES`, so deterministic inference accepts them and the path is clean.

## Modifications

`test/registered/mla/test_mla_fp8.py`: only append `--enable-deterministic-inference` to `other_args` when `is_hip()` is `False`. NVIDIA path is untouched and keeps the measured-good `fa3` default behind PR #23303's existing 0.8 threshold. AMD reverts to the pre-#23303 (non-deterministic) baseline until the upstream ROCm issues above are addressed.

No production code changed — test-only.


## Accuracy Tests
[
<img width="1739" height="1577" alt="image" src="https://github.com/user-attachments/assets/867f6cc2-ebc1-4941-b0cc-ffd13837b8ae" />](https://github-production-user-asset-6210df.s3.amazonaws.com/195740905/581717194-867f6cc2-ebc1-4941-b0cc-ffd13837b8ae.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20260422%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20260422T083609Z&X-Amz-Expires=300&X-Amz-Signature=33e3072bc4c4c2a64d5444217fc208d2df2bf328ea09aa1f55eddafb0d029906&X-Amz-SignedHeaders=host&response-content-type=image%2Fpng)

AMD test passed: https://github.com/sgl-project/sglang/actions/runs/24754995344/job/72427956953?pr=23382#step:6:3086


## Speed Tests and Profiling

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (pre-commit: isort / ruff / black / codespell all pass)
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (modifies an existing registered test)
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (no doc impact)
- [ ] Provide accuracy and speed benchmark results. (CI reports the deterministic MGSM-EN score on NVIDIA; AMD reverts to non-deterministic baseline at 0.856 vs 0.8 threshold)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
