### PR TITLE
[Misc] Remove misleading echo+logprobs warning

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -67,12 +67,6 @@ class OpenAIServingCompletion(OpenAIServingBase):
         raw_request: Request = None,
     ) -> tuple[GenerateReqInput, CompletionRequest]:
         """Convert OpenAI completion request to internal format"""
-        # NOTE: with openai API, the prompt's logprobs are always not computed
-        if request.echo and request.logprobs:
-            logger.warning(
-                "Echo is not compatible with logprobs. "
-                "To compute logprobs of input prompt, please use the native /generate API."
-            )
         # Process prompt
         prompt = request.prompt
         if self.template_manager.completion_template_name is not None:


### PR DESCRIPTION
## Summary

While running evals, I kept getting spammed by this warning. The code right below it already handles this

https://github.com/sgl-project/sglang/blob/929e00eeab0e0f2d5537a9019984941a4f8f7071/python/sglang/srt/entrypoints/openai/serving_completions.py#L81-L83

so the warning was just noise