### PR TITLE
WIP: [Speculative] Add draft-DP mode to eliminate allreduce/all-to-all during draft multi-step decode

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -2077,7 +2077,9 @@ _TP_STATE_PATCHED = False
 
 
 @contextmanager
-def patch_tensor_parallel_group(tp_group: GroupCoordinator):
+def patch_tensor_parallel_group(
+    tp_group: GroupCoordinator, also_patch_attn_tp: bool = False
+):
     """Patch the tp group temporarily until this function ends.
 
     This method is for draft workers of speculative decoding to run draft model
@@ -2085,20 +2087,52 @@ def patch_tensor_parallel_group(tp_group: GroupCoordinator):
 
     Args:
         tp_group (GroupCoordinator): the tp group coordinator
+        also_patch_attn_tp (bool): if True, also patch _ATTN_TP so that
+            attention/KV-cache code sees the same tp_size as the draft model.
     """
-    global _TP_STATE_PATCHED
+    global _TP_STATE_PATCHED, _TP, _ATTN_TP
     assert not _TP_STATE_PATCHED, "Should not call when it's already patched"
 
     _TP_STATE_PATCHED = True
-    old_tp_group = get_tp_group()
-    global _TP
+    old_tp_group = _TP
+    old_attn_tp_group = _ATTN_TP
     _TP = tp_group
+    if also_patch_attn_tp:
+        _ATTN_TP = tp_group
     try:
         yield
     finally:
         # restore the original state
         _TP_STATE_PATCHED = False
         _TP = old_tp_group
+        if also_patch_attn_tp:
+            _ATTN_TP = old_attn_tp_group
+
+
+@contextmanager
+def patch_moe_parallel_group(
+    moe_ep_group: GroupCoordinator,
+    moe_tp_group: GroupCoordinator = None,
+):
+    """Patch MOE EP (and optionally MOE TP) groups temporarily.
+
+    Used by draft-DP mode to make the draft MoE layer see ep_size=1,
+    loading all experts locally on each rank.
+    If moe_tp_group is None, _MOE_TP is not changed (keeps original TP sharding
+    for expert intermediate_size, ensuring computation matches target).
+    """
+    global _MOE_EP, _MOE_TP
+    old_moe_ep = _MOE_EP
+    old_moe_tp = _MOE_TP
+    _MOE_EP = moe_ep_group
+    if moe_tp_group is not None:
+        _MOE_TP = moe_tp_group
+    try:
+        yield
+    finally:
+        _MOE_EP = old_moe_ep
+        if moe_tp_group is not None:
+            _MOE_TP = old_moe_tp
 
 
 def get_world_size():

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -519,6 +519,7 @@ class ServerArgs:
     speculative_draft_model_quantization: Optional[str] = None
     speculative_adaptive: bool = False
     speculative_adaptive_config: Optional[str] = None
+    speculative_draft_dp: bool = False
 
     # Speculative decoding (ngram)
     speculative_ngram_min_bfs_breadth: int = 1
@@ -3439,6 +3440,18 @@ class ServerArgs:
                     "speculative_eagle_topk > 1 with page_size > 1 is unstable and produces incorrect results for paged attention backends. This combination is only supported for the 'flashinfer' backend."
                 )
 
+        if self.speculative_draft_dp:
+            if self.tp_size <= 1 and self.ep_size <= 1:
+                logger.warning(
+                    "--speculative-draft-dp has no effect with tp_size=1 and ep_size=1. Ignoring."
+                )
+                self.speculative_draft_dp = False
+            elif self.speculative_moe_a2a_backend is None:
+                self.speculative_moe_a2a_backend = "none"
+                logger.info(
+                    "--speculative-draft-dp: auto-setting --speculative-moe-a2a-backend=none"
+                )
+
         if self.speculative_algorithm == "NGRAM":
             if not self.device.startswith("cuda"):
                 raise ValueError(
@@ -5304,6 +5317,13 @@ class ServerArgs:
             choices=SPECULATIVE_DRAFT_MODEL_QUANTIZATION_CHOICES,
             default=ServerArgs.speculative_draft_model_quantization,
             help="The quantization method for speculative model.",
+        )
+        parser.add_argument(
+            "--speculative-draft-dp",
+            action="store_true",
+            default=ServerArgs.speculative_draft_dp,
+            help="Run the draft model with data parallelism (tp_size=1, ep_size=1 per rank) "
+            "to eliminate allreduce/all-to-all communication during draft multi-step decode.",
         )
 
         # Speculative decoding (ngram)

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -57,6 +57,8 @@ from sglang.srt.speculative.eagle_utils import (
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.speculative.spec_utils import (
     assign_draft_cache_locs,
+    create_draft_dp_group,
+    draft_dp_full_context,
     draft_tp_context,
     fast_topk,
     generate_token_bitmask,
@@ -147,20 +149,54 @@ class EAGLEWorker(TpModelWorker):
             self.hot_token_id = None
 
         # Init draft worker
-        if server_args.enable_dp_attention and self.speculative_algorithm.is_eagle3():
+        # Draft-DP requires enable_dp_attention so each rank has complete KV cache.
+        # Use DP attention's draft_tp_context (patches _TP to attn_tp group, keeps _ATTN_TP intact)
+        # and additionally patch _MOE_EP/_MOE_TP for MoE-only DP.
+        from sglang.srt.distributed.parallel_state import patch_moe_parallel_group
+
+        if server_args.speculative_draft_dp and server_args.enable_dp_attention:
+            # Draft-DP + DP attention:
+            # - Attention: use attn_tp group (size=1, per-rank KV cache)
+            # - MoE: patch _MOE_EP/_MOE_TP to size=1 (all experts local, no EP all-to-all)
+            # Since _TP is patched to attn_tp (size=1), MoE layer's self.tp_size=1, skipping allreduce
+            self.draft_dp_group = create_draft_dp_group()
+            attn_tp_group = get_attention_tp_group()
+            from contextlib import ExitStack
+
+            self._init_stack = ExitStack()
+            ctx = self._init_stack
+            ctx.enter_context(draft_tp_context(attn_tp_group))
+            ctx.enter_context(
+                patch_moe_parallel_group(
+                    self.draft_dp_group, self.draft_dp_group
+                )
+            )
+        elif server_args.speculative_draft_dp:
+            # Draft DP without DP attention — patch everything (may have KV cache issues)
+            self.draft_dp_group = create_draft_dp_group()
+            ctx = draft_dp_full_context(
+                self.draft_dp_group, self.draft_dp_group, self.draft_dp_group
+            )
+        elif server_args.enable_dp_attention and self.speculative_algorithm.is_eagle3():
             ctx = draft_tp_context(get_attention_tp_group())
         else:
             ctx = empty_context()
+        # Don't change tp_rank when using DP attention (each rank keeps its own rank)
+        draft_tp_rank = tp_rank if server_args.enable_dp_attention else (
+            0 if server_args.speculative_draft_dp else tp_rank
+        )
+        # Draft-DP patches MOE_EP to size=1, so ep_rank must be 0 (all experts local)
+        draft_ep_rank = 0 if server_args.speculative_draft_dp else moe_ep_rank
         with (
             ctx
         ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
             super().__init__(
                 server_args=server_args,
                 gpu_id=gpu_id,
-                tp_rank=tp_rank,
+                tp_rank=draft_tp_rank,
                 pp_rank=0,  # FIXME
                 dp_rank=dp_rank,
-                moe_ep_rank=moe_ep_rank,
+                moe_ep_rank=draft_ep_rank,
                 attn_cp_rank=attn_cp_rank,
                 moe_dp_rank=moe_dp_rank,
                 nccl_port=nccl_port,
@@ -169,10 +205,48 @@ class EAGLEWorker(TpModelWorker):
                 token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
                 memory_pool_config=target_worker.model_runner.memory_pool_config,
             )
+        if hasattr(self, "_init_stack"):
+            self._init_stack.close()
 
         embed, head = self.target_worker.model_runner.model.get_embed_and_head()
 
-        if self.speculative_algorithm.is_eagle3():
+        if server_args.speculative_draft_dp and server_args.enable_dp_attention:
+            # Draft-DP + DPA: draft is at tp=1, target at tp=8.
+            # MTP weight loader skips embed/head — they must come from target via set_embed_and_head.
+            # With DPA, target's embed is full (use_attn_tp_group=True), so no allgather needed.
+            # Target's lm_head is sharded by TP (use_attn_tp_group=False), so allgather it.
+            target_tp_group = self.target_worker.model_runner.tp_group
+            full_embed = embed  # Already full with DPA
+            full_head = self._allgather_tensor(head, target_tp_group)
+            if self.speculative_algorithm.is_eagle3():
+                self.draft_model_runner.model.set_embed(full_embed)
+                if (
+                    hasattr(self.draft_model_runner.model, "load_lm_head_from_target")
+                    and self.draft_model_runner.model.load_lm_head_from_target
+                ):
+                    self.draft_model_runner.model.lm_head.weight.data.copy_(full_head)
+            else:
+                self.draft_model_runner.model.set_embed_and_head(
+                    full_embed, full_head
+                )
+        elif server_args.speculative_draft_dp and not server_args.enable_dp_attention:
+            # Draft-DP without DP attention: allgather target's sharded embed/head
+            target_tp_group = self.target_worker.model_runner.tp_group
+            full_embed = self._allgather_tensor(embed, target_tp_group)
+            if self.speculative_algorithm.is_eagle3():
+                self.draft_model_runner.model.set_embed(full_embed)
+                if (
+                    hasattr(self.draft_model_runner.model, "load_lm_head_from_target")
+                    and self.draft_model_runner.model.load_lm_head_from_target
+                ):
+                    full_head = self._allgather_tensor(head, target_tp_group)
+                    self.draft_model_runner.model.lm_head.weight.data.copy_(full_head)
+            else:
+                full_head = self._allgather_tensor(head, target_tp_group)
+                self.draft_model_runner.model.set_embed_and_head(
+                    full_embed, full_head
+                )
+        elif self.speculative_algorithm.is_eagle3():
             # most cases EAGLE3 models don't share lm_head
             # but some models (e.g. nvidia/gpt-oss-120b-Eagle3) shares
             if (
@@ -188,7 +262,6 @@ class EAGLEWorker(TpModelWorker):
                 self.hot_token_id = self.draft_model_runner.model.hot_token_id.to(
                     embed.device
                 )
-
         else:
             if self.hot_token_id is not None:
                 head = head.clone()
@@ -202,9 +275,32 @@ class EAGLEWorker(TpModelWorker):
         self.draft_model_runner.server_args.disable_cuda_graph = (
             backup_disable_cuda_graph
         )
-        self.draft_tp_context = (
-            draft_tp_context if server_args.enable_dp_attention else empty_context
-        )
+        if server_args.speculative_draft_dp and server_args.enable_dp_attention:
+            # Draft-DP + DP attention: patch TP (via attn_tp) + MOE (via draft_dp_group)
+            @contextmanager
+            def _dpa_dp_ctx(_tp_group=None):
+                tp_grp = _tp_group or self.draft_model_runner.tp_group
+                with draft_tp_context(tp_grp), patch_moe_parallel_group(
+                    self.draft_dp_group, self.draft_dp_group
+                ):
+                    yield
+
+            self._draft_ctx_fn = _dpa_dp_ctx
+            self.draft_tp_context = _dpa_dp_ctx
+        elif server_args.speculative_draft_dp:
+            # Draft-DP without DP attention
+            self._draft_ctx_fn = lambda: draft_dp_full_context(
+                self.draft_dp_group, self.draft_dp_group, self.draft_dp_group
+            )
+            self.draft_tp_context = lambda _tp_group=None: self._draft_ctx_fn()
+        elif server_args.enable_dp_attention and self.speculative_algorithm.is_eagle3():
+            self._draft_ctx_fn = lambda: draft_tp_context(
+                self.draft_model_runner.tp_group
+            )
+            self.draft_tp_context = draft_tp_context
+        else:
+            self._draft_ctx_fn = empty_context
+            self.draft_tp_context = empty_context
         self.eagle_use_aux_hidden_state = False
         if self.speculative_algorithm.is_eagle3():
             self.eagle_use_aux_hidden_state = True
@@ -214,9 +310,7 @@ class EAGLEWorker(TpModelWorker):
             self.eagle_use_aux_hidden_state = eagle_config.get(
                 "use_aux_hidden_state", True
             )
-        with self.draft_tp_context(
-            self.draft_model_runner.tp_group
-        ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
+        with self._draft_ctx_fn(), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
             self.init_attention_backend()
             self.init_cuda_graphs()
             if self.adaptive_controller is not None:
@@ -239,6 +333,23 @@ class EAGLEWorker(TpModelWorker):
             (), dtype=torch.int64, device=self.device
         )
         self.extend_lens = torch.empty((), dtype=torch.int64, device=self.device)
+
+    @staticmethod
+    def _allgather_tensor(tensor, tp_group):
+        if tp_group.world_size <= 1:
+            return tensor
+        gathered = [torch.empty_like(tensor) for _ in range(tp_group.world_size)]
+        torch.distributed.all_gather(gathered, tensor, group=tp_group.device_group)
+        return torch.cat(gathered, dim=0)
+
+    @contextmanager
+    def _draft_forward_context(self):
+        """In draft-DP mode, patches MoE A2A backend (TP already patched by draft_tp_context)."""
+        if self.server_args.speculative_draft_dp:
+            with speculative_moe_a2a_backend_context():
+                yield
+        else:
+            yield
 
     def init_attention_backend(self):
         # Create multi-step attn backends and cuda graph runners
@@ -825,49 +936,50 @@ class EAGLEWorker(TpModelWorker):
 
         # Forward multiple steps
         scores = None
-        for i in range(self.speculative_num_steps):
-            input_ids, hidden_states, scores, tree_info = select_top_k_tokens(
-                i, topk_p, topk_index, hidden_states, scores, self.topk
-            )
-            score_list.append(tree_info[0])
-            token_list.append(tree_info[1])
-            parents_list.append(tree_info[2])
+        with self._draft_forward_context():
+            for i in range(self.speculative_num_steps):
+                input_ids, hidden_states, scores, tree_info = select_top_k_tokens(
+                    i, topk_p, topk_index, hidden_states, scores, self.topk
+                )
+                score_list.append(tree_info[0])
+                token_list.append(tree_info[1])
+                parents_list.append(tree_info[2])
 
-            # We don't need to run the last forward. we get 1 token from draft prefill and (#spec steps - 1) tokens here
-            if i == self.speculative_num_steps - 1:
-                break
+                # We don't need to run the last forward. we get 1 token from draft prefill and (#spec steps - 1) tokens here
+                if i == self.speculative_num_steps - 1:
+                    break
 
-            # Set inputs
-            forward_batch.input_ids = input_ids
-            # This is a temporary fix for the case that the user is using standalone
-            # speculative decoding and the draft model architecture is gpt-oss. gpt-oss
-            # rope kernel needs cache_loc to be contiguous.
-            if (
-                self.server_args.speculative_algorithm == "STANDALONE"
-                and self.model_config.hf_config.architectures[0] == "GptOssForCausalLM"
-            ):
-                out_cache_loc = out_cache_loc.contiguous()
-            forward_batch.out_cache_loc = out_cache_loc[i]
-            forward_batch.positions.add_(1)
-            forward_batch.attn_backend = self.draft_attn_backend.attn_backends[i]
-            spec_info.hidden_states = hidden_states
+                # Set inputs
+                forward_batch.input_ids = input_ids
+                # This is a temporary fix for the case that the user is using standalone
+                # speculative decoding and the draft model architecture is gpt-oss. gpt-oss
+                # rope kernel needs cache_loc to be contiguous.
+                if (
+                    self.server_args.speculative_algorithm == "STANDALONE"
+                    and self.model_config.hf_config.architectures[0] == "GptOssForCausalLM"
+                ):
+                    out_cache_loc = out_cache_loc.contiguous()
+                forward_batch.out_cache_loc = out_cache_loc[i]
+                forward_batch.positions.add_(1)
+                forward_batch.attn_backend = self.draft_attn_backend.attn_backends[i]
+                spec_info.hidden_states = hidden_states
 
-            # Run forward
-            logits_output = self.draft_model_runner.forward(
-                forward_batch, skip_attn_backend_init=True
-            ).logits_output
-            maybe_detect_nan(logits_output.next_token_logits, f"draft_forward step {i}")
-            probs = torch.softmax(logits_output.next_token_logits, dim=-1)
-            topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)
-            maybe_detect_oob(
-                topk_index,
-                0,
-                logits_output.next_token_logits.shape[-1],
-                f"draft_forward step {i}: topk_index OOB vs vocab_size={logits_output.next_token_logits.shape[-1]}",
-            )
-            if self.hot_token_id is not None:
-                topk_index = self.hot_token_id[topk_index]
-            hidden_states = logits_output.hidden_states
+                # Run forward
+                logits_output = self.draft_model_runner.forward(
+                    forward_batch, skip_attn_backend_init=True
+                ).logits_output
+                maybe_detect_nan(logits_output.next_token_logits, f"draft_forward step {i}")
+                probs = torch.softmax(logits_output.next_token_logits, dim=-1)
+                topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)
+                maybe_detect_oob(
+                    topk_index,
+                    0,
+                    logits_output.next_token_logits.shape[-1],
+                    f"draft_forward step {i}: topk_index OOB vs vocab_size={logits_output.next_token_logits.shape[-1]}",
+                )
+                if self.hot_token_id is not None:
+                    topk_index = self.hot_token_id[topk_index]
+                hidden_states = logits_output.hidden_states
 
         parent_list, top_scores_index, draft_tokens = organize_draft_results(
             score_list, token_list, parents_list, self.speculative_num_draft_tokens
@@ -1087,7 +1199,8 @@ class EAGLEWorker(TpModelWorker):
         forward_batch.return_logprob = False
         if mm_input_embeds is not None:
             forward_batch.mm_input_embeds = mm_input_embeds
-        logits_output = self.draft_model_runner.forward(forward_batch).logits_output
+        with self._draft_forward_context():
+            logits_output = self.draft_model_runner.forward(forward_batch).logits_output
         maybe_detect_nan(logits_output.next_token_logits, "draft_extend_for_prefill")
         assert isinstance(forward_batch.spec_info, EagleDraftInput)
         assert forward_batch.spec_info is batch.spec_info
@@ -1167,9 +1280,10 @@ class EAGLEWorker(TpModelWorker):
                 )
                 attn_backend.init_forward_metadata(forward_batch)
                 forward_batch.attn_backend = attn_backend
-            logits_output = self.draft_model_runner.forward(
-                forward_batch, skip_attn_backend_init=True
-            ).logits_output
+            with self._draft_forward_context():
+                logits_output = self.draft_model_runner.forward(
+                    forward_batch, skip_attn_backend_init=True
+                ).logits_output
             self.capture_for_decode(logits_output, forward_batch.spec_info)
 
         maybe_detect_nan(

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -14,6 +14,7 @@ from huggingface_hub import snapshot_download
 from sglang.srt.constrained.base_grammar_backend import BaseGrammarObject
 from sglang.srt.distributed.parallel_state import (
     GroupCoordinator,
+    patch_moe_parallel_group,
     patch_tensor_parallel_group,
 )
 from sglang.srt.environ import envs
@@ -722,6 +723,50 @@ def draft_tp_context(tp_group: GroupCoordinator):
     # We disable mscclpp now because it doesn't support 2 comm groups.
     with patch_tensor_parallel_group(tp_group):
         yield
+
+
+@contextmanager
+def draft_dp_full_context(
+    tp_group: GroupCoordinator,
+    moe_ep_group: GroupCoordinator,
+    moe_tp_group: GroupCoordinator,
+):
+    """Patch TP, ATTN_TP, MOE_EP, and MOE_TP for draft-DP mode with MoE."""
+    with patch_tensor_parallel_group(
+        tp_group, also_patch_attn_tp=True
+    ), patch_moe_parallel_group(moe_ep_group, moe_tp_group):
+        yield
+
+
+def create_draft_dp_group() -> GroupCoordinator:
+    """Create a single-rank GroupCoordinator for draft-DP mode.
+
+    Each rank gets its own group of size 1. All ranks must call this
+    simultaneously (it uses torch.distributed.new_group which is collective).
+    """
+    import torch.distributed as dist
+
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    group_ranks = [[r] for r in range(world_size)]
+    local_rank = rank
+    if os.environ.get("SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS"):
+        local_rank = 0
+
+    return GroupCoordinator(
+        group_ranks=group_ranks,
+        local_rank=local_rank,
+        torch_distributed_backend="nccl",
+        use_pynccl=False,
+        use_pymscclpp=False,
+        use_custom_allreduce=False,
+        use_torch_symm_mem_all_reduce=False,
+        use_hpu_communicator=False,
+        use_xpu_communicator=False,
+        use_npu_communicator=False,
+        use_message_queue_broadcaster=False,
+        group_name="draft_dp",
+    )
 
 
 def maybe_detect_nan(tensor: torch.Tensor, msg: str = ""):


### PR DESCRIPTION
## Motivation

In speculative decoding with MoE models (e.g., DeepSeek-R1 with MTP), the draft model's multi-step decode phase incurs significant collective communication overhead (allreduce, all-to-all) across TP/EP ranks. Since the draft model is much smaller than the target model, running it with full TP/EP parallelism is wasteful — the communication cost dominates the compute savings.

This PR introduces `--speculative-draft-dp`, which runs the draft model with data parallelism (tp_size=1, ep_size=1 per rank), so each rank loads all draft experts locally and skips all collective communication during draft decode steps.

## Modifications

- **`server_args.py`**: Add `--speculative-draft-dp` flag with validation logic (auto-sets `--speculative-moe-a2a-backend=none`, warns if tp/ep=1).
- **`parallel_state.py`**:
  - Extend `patch_tensor_parallel_group` with `also_patch_attn_tp` parameter for full TP+ATTN_TP patching.
  - Add `patch_moe_parallel_group` context manager to temporarily override `_MOE_EP` / `_MOE_TP`.
- **`spec_utils.py`**: Add `draft_dp_full_context` (patches TP+ATTN_TP+MOE_EP+MOE_TP) and `create_draft_dp_group` (creates a single-rank GroupCoordinator per rank).
- **`eagle_worker.py`**:
  - Draft init: patch parallel groups so draft model weights are loaded with tp=1, ep=1; allgather target's embed/lm_head for the draft model.
  - Draft forward: wrap multi-step decode, draft extend, and draft extend-after-decode with `_draft_forward_context` to patch MoE A2A backend.
  - Support both draft-DP + DPA (recommended) and draft-DP standalone paths.

## Benchmark Results

**Setup:** 8×B200, DeepSeek-R1 MTP, FP8, same prompt and parameters.

### Throughput & Latency

| Metric | DPA Baseline | Draft DP | Change |
|--------|-------------|----------|--------|
| Avg throughput | 97.1 tok/s | 101.7 tok/s | **+4.7%** |
| Avg latency | 2.65s | 2.53s | **-4.5%** |
| Avg accept_len | 2.64 | 2.65 | ≈0 (correctness verified) |

### Profile (same workload)

| Metric | Baseline | Draft DP | Change |
|--------|----------|----------|--------|
| Total communication | 5838ms (38.1%) | 4672ms (31.2%) | **-20%** |
| Total GPU time | 15343ms | 14980ms | **-2.4%** |
| NCCL AllGather | 2827ms | 2137ms | **-24%** |
| custom allreduce 2stage | 1708 calls | 1152 calls | **-32.5%** |
| FP8 GEMM (bmm) | 1877ms | 2139ms | +14% (draft computes more experts) |
| fused_moe | 154ms | 253ms | +64% (8 vs 1 expert/rank) |

**Key takeaway:** Draft-DP trades a small increase in per-rank compute (each rank runs all draft experts) for a large reduction in communication overhead, resulting in a net **4.7% throughput improvement** and **4.5% latency reduction**. Accept length remains unchanged, confirming correctness.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
