### PR TITLE
[AMD] Fix Kimi-K2.6 Quark MXFP4 loading prefix and packed module mapping

### DIFF
--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -199,7 +199,12 @@ def _get_quantization_config(
     remap_prefix = getattr(model_class, "remap_prefix", None)
     # TODO: we should remove this code and switch to the packed_modules_mapping declared inside the modeling files
     if model_config.quantization == "quark":
-        packed_modules_mapping.update({"gate_up_proj": ["gate_proj", "up_proj"]})
+        packed_modules_mapping.update(
+            {
+                "gate_up_proj": ["gate_proj", "up_proj"],
+                "fused_qkv_a_proj_with_mqa": ["q_a_proj", "kv_a_proj_with_mqa"],
+            }
+        )
 
     if _is_npu:
         packed_modules_mapping.update(

--- a/python/sglang/srt/models/kimi_k25.py
+++ b/python/sglang/srt/models/kimi_k25.py
@@ -28,6 +28,7 @@ except ImportError:
 from sglang.srt.layers.attention.vision import VisionAttention
 from sglang.srt.layers.linear import ReplicatedLinear
 from sglang.srt.layers.quantization.modelslim.modelslim import ModelSlimConfig
+from sglang.srt.layers.quantization.quark.quark import QuarkConfig
 from sglang.srt.managers.schedule_batch import (
     Modality,
     MultimodalDataItem,
@@ -661,7 +662,7 @@ class KimiK25ForConditionalGeneration(nn.Module):
                 quant_config,
                 prefix=(
                     "language_model"
-                    if isinstance(quant_config, ModelSlimConfig)
+                    if isinstance(quant_config, (ModelSlimConfig, QuarkConfig))
                     else ""
                 ),
             )


### PR DESCRIPTION
## Motivation

Fix Kimi-K2.6 Quark MXFP4 checkpoint loading. 
Two issues:
1. DeepseekV3ForCausalLM in `KimiK25ForConditionalGeneration` was only given the "language_model" prefix when the quant config was "ModelSlimConfig". For Quark MXFP4 checkpoints, the `exclude_layers` list contains entries prefixed with language_model. (e.g., language_model.model.layers.0.self_attn.q_a_proj). Without passing `prefix="language_model"`, layer prefixes during model construction fail to match the exclude list, causing layers that should be kept unquantized to be incorrectly quantized.
  2. The Quark quantization path was missing the packed module mapping for fused QKV-A projections used in DeepseekV3-based models, which is needed for correct weight loading of f`used q_a_proj` + `kv_a_proj_with_mqa` layers.

## Modifications

- Add QuarkConfig to the `isinstance` check so DeepseekV3ForCausalLM receives `prefix="language_model"` for both ModelSlimConfig and QuarkConfig.
- Add `fused_qkv_a_proj_with_mqa` to the Quark `packed_modules_mapping`.

## Server Command and Accuracy Verification

Serving Command:
```
sglang serve --model-path [Kimi-K2.6-MXFP4] --host 0.0.0.0 --tp 4 --trust-remote-code
```
Accuracy Verification via [lm_eval](https://github.com/EleutherAI/lm-evaluation-harness):
```
lm_eval --model sglang --model_args pretrained=[Kimi-K2.6-MXFP4],tp_size=4 --tasks gsm8k --batch_size auto

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9348|±  |0.0068|
|     |       |strict-match    |     5|exact_match|↑  |0.9356|±  |0.0068|
```

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
