### PR TITLE
[CP] Fix `prefix_len` calculation for non-DSA context parallelism

### DIFF
--- a/python/sglang/srt/layers/utils/cp_utils.py
+++ b/python/sglang/srt/layers/utils/cp_utils.py
@@ -391,7 +391,7 @@ def prepare_context_parallel_metadata(
     cp_rank,
     cp_size,
     seqs_len,
-    extend_lens=None,
+    extend_lens,
 ):
     from sglang.srt.layers.attention.nsa.utils import (
         is_nsa_prefill_cp_round_robin_split,
@@ -446,32 +446,15 @@ def prepare_context_parallel_metadata(
     bs_per_cp_group = 1
     kv_len_origin = kv_len
 
-    # Derive prefix offset from the full sequence length on CPU.
-    # NOTE: forward_batch.seq_lens_cpu includes cached prefix + extend tokens.
-    # In CP we only split the extend tokens, but cache_seqlens passed to FA must
-    # include the cached prefix.
-    #
-    # `kv_len` is `len(input_ids)`, which `prepare_mlp_sync_batch` pads up to
-    # `ceil_align(tokens, attn_cp_size)`. `seqs_len[0]` (forward_batch.seq_lens_cpu)
-    # stays at the unpadded value, so `seqs_len[0] - kv_len` undercounts
-    # `prefix_len` by the padding amount and shifts the FA causal horizon.
-    # Prefer `extend_lens[0]` (the unpadded extend length) when the caller
-    # threads it through; fall back to the legacy formula otherwise.
-    prefix_len = 0
-    try:
-        if (
-            extend_lens is not None
-            and len(extend_lens) == 1
-            and seqs_len is not None
-            and len(seqs_len) == 1
-        ):
-            prefix_len = int(seqs_len[0]) - int(extend_lens[0])
-        elif seqs_len is not None and len(seqs_len) == 1:
-            prefix_len = int(seqs_len[0]) - int(kv_len_origin.item())
-        if prefix_len < 0:
-            prefix_len = 0
-    except Exception:
-        prefix_len = 0
+    # Derive prefix offset from unpadded CPU tensors. Both `seqs_len` (total
+    # per-request length, prefix + extend) and `extend_lens` (per-request
+    # extend length) are passed through unpadded by the caller; using the
+    # padded `kv_len` here would undercount `prefix_len` by the padding
+    # amount and shift the FA causal horizon.
+    assert (
+        len(seqs_len) == 1 and len(extend_lens) == 1
+    ), "prepare_context_parallel_metadata only supports batch_size == 1"
+    prefix_len = max(0, int(seqs_len[0]) - int(extend_lens[0]))
     # get zigzag index
     cp_segment_num = cp_size * 2
     seq_per_batch = kv_len // cp_segment_num  # seq_len for each batch and segment

--- a/python/sglang/srt/layers/utils/cp_utils.py
+++ b/python/sglang/srt/layers/utils/cp_utils.py
@@ -391,6 +391,7 @@ def prepare_context_parallel_metadata(
     cp_rank,
     cp_size,
     seqs_len,
+    extend_lens=None,
 ):
     from sglang.srt.layers.attention.nsa.utils import (
         is_nsa_prefill_cp_round_robin_split,
@@ -449,12 +450,26 @@ def prepare_context_parallel_metadata(
     # NOTE: forward_batch.seq_lens_cpu includes cached prefix + extend tokens.
     # In CP we only split the extend tokens, but cache_seqlens passed to FA must
     # include the cached prefix.
+    #
+    # `kv_len` is `len(input_ids)`, which `prepare_mlp_sync_batch` pads up to
+    # `ceil_align(tokens, attn_cp_size)`. `seqs_len[0]` (forward_batch.seq_lens_cpu)
+    # stays at the unpadded value, so `seqs_len[0] - kv_len` undercounts
+    # `prefix_len` by the padding amount and shifts the FA causal horizon.
+    # Prefer `extend_lens[0]` (the unpadded extend length) when the caller
+    # threads it through; fall back to the legacy formula otherwise.
     prefix_len = 0
     try:
-        if seqs_len is not None and len(seqs_len) == 1:
+        if (
+            extend_lens is not None
+            and len(extend_lens) == 1
+            and seqs_len is not None
+            and len(seqs_len) == 1
+        ):
+            prefix_len = int(seqs_len[0]) - int(extend_lens[0])
+        elif seqs_len is not None and len(seqs_len) == 1:
             prefix_len = int(seqs_len[0]) - int(kv_len_origin.item())
-            if prefix_len < 0:
-                prefix_len = 0
+        if prefix_len < 0:
+            prefix_len = 0
     except Exception:
         prefix_len = 0
     # get zigzag index

--- a/python/sglang/srt/models/deepseek_nextn.py
+++ b/python/sglang/srt/models/deepseek_nextn.py
@@ -304,6 +304,7 @@ class DeepseekV3ForCausalLMNextN(DeepseekV3ForCausalLM):
                     self.cp_rank,
                     self.cp_size,
                     forward_batch.seq_lens_cpu.tolist(),
+                    extend_lens=forward_batch.extend_seq_lens_cpu,
                 )
         hidden_states = self.model(input_ids, positions, forward_batch)
         return self.logits_processor(

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2298,6 +2298,7 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
                     self.cp_rank,
                     self.cp_size,
                     forward_batch.seq_lens_cpu.tolist(),
+                    extend_lens=forward_batch.extend_seq_lens_cpu,
                 )
 
         with get_attn_tp_context().maybe_input_scattered(forward_batch):

--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -992,6 +992,7 @@ class Qwen3MoeForCausalLM(nn.Module):
                     self.attn_cp_rank,
                     self.attn_cp_size,
                     forward_batch.seq_lens_cpu.tolist(),
+                    extend_lens=forward_batch.extend_seq_lens_cpu,
                 )
 
         hidden_states = self.model(

--- a/test/registered/kernels/test_cp_prefix_len_fa3_parity.py
+++ b/test/registered/kernels/test_cp_prefix_len_fa3_parity.py
@@ -1,0 +1,153 @@
+"""
+FA3 parity test for `prepare_context_parallel_metadata`.
+
+Drives the real function and feeds its `kv_len_prev/next_tensor` into FA3
+via `flash_attn_with_kvcache`. Compares per-rank CP output against a
+full-sequence FA3 reference computed over the unpadded `(prefix + extend)`
+KV. Any discrepancy indicates the metadata function emitted wrong
+`cache_seqlens` for at least one rank.
+"""
+import inspect
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.utils.cp_utils import prepare_context_parallel_metadata
+from sglang.srt.utils.common import ceil_align
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=5, suite="stage-b-test-1-gpu-large")
+
+_NSA_UTILS = "sglang.srt.layers.attention.nsa.utils"
+_DEVICE = "cuda"
+_DTYPE = torch.bfloat16
+_HEAD_NUM = 8
+_HEAD_DIM = 128
+_SCALE = _HEAD_DIM ** -0.5
+
+
+class TestCPPrefixLenFA3Parity(CustomTestCase):
+    """Per-rank FA3 output under CP must match a full-sequence reference."""
+
+    def _run_parity(self, prefix_len: int, extend_len: int, cp_size: int):
+        from sgl_kernel.flash_attn import flash_attn_with_kvcache
+
+        torch.manual_seed(extend_len * 1_000_003 + prefix_len * 101 + cp_size)
+
+        padded_extend = ceil_align(extend_len, cp_size)
+        pad = padded_extend - extend_len
+        self.assertGreaterEqual(
+            padded_extend,
+            2 * cp_size,
+            "runtime `can_cp_split` would skip this case; pick a larger extend",
+        )
+
+        # Reference: one full-sequence FA3 call over the unpadded KV.
+        q_full = torch.randn(
+            extend_len, _HEAD_NUM, _HEAD_DIM, device=_DEVICE, dtype=_DTYPE
+        )
+        k_full = torch.randn(
+            prefix_len + extend_len, _HEAD_NUM, _HEAD_DIM, device=_DEVICE, dtype=_DTYPE
+        )
+        v_full = torch.randn(
+            prefix_len + extend_len, _HEAD_NUM, _HEAD_DIM, device=_DEVICE, dtype=_DTYPE
+        )
+        ref = flash_attn_with_kvcache(
+            q=q_full.unsqueeze(0),
+            k_cache=k_full.unsqueeze(0),
+            v_cache=v_full.unsqueeze(0),
+            cache_seqlens=torch.tensor(
+                [k_full.shape[0]], dtype=torch.int32, device=_DEVICE
+            ),
+            softmax_scale=_SCALE,
+            causal=True,
+        ).squeeze(0)
+
+        # CP path sees tensors padded to `ceil_align(extend, cp_size)`,
+        # matching what `prepare_mlp_sync_batch` does in production.
+        zeros = torch.zeros(
+            pad, _HEAD_NUM, _HEAD_DIM, device=_DEVICE, dtype=_DTYPE
+        )
+        q_padded = torch.cat([q_full, zeros], dim=0)
+        k_padded = torch.cat([k_full, zeros], dim=0)
+        v_padded = torch.cat([v_full, zeros], dim=0)
+
+        seqs_len = [prefix_len + extend_len]
+        extend_lens = [extend_len]
+        accepts_extend_lens = (
+            "extend_lens"
+            in inspect.signature(prepare_context_parallel_metadata).parameters
+        )
+
+        def _call_meta(rank: int):
+            if accepts_extend_lens:
+                return prepare_context_parallel_metadata(
+                    padded_extend, rank, cp_size, seqs_len, extend_lens=extend_lens
+                )
+            return prepare_context_parallel_metadata(
+                padded_extend, rank, cp_size, seqs_len
+            )
+
+        # Exercise the non-NSA branch; the NSA branch uses a separate
+        # `prefix_len` pathway re-added by `_get_topk_ragged_with_cp`.
+        with (
+            patch(f"{_NSA_UTILS}.is_nsa_enable_prefill_cp", return_value=False),
+            patch(
+                f"{_NSA_UTILS}.is_nsa_prefill_cp_round_robin_split",
+                return_value=False,
+            ),
+        ):
+            meta0 = _call_meta(0)
+            cp_segment_num = 2 * cp_size
+            blocks_q = list(torch.split(q_padded, meta0.split_list, dim=0))
+            outs = [None] * cp_segment_num
+
+            for rank in range(cp_size):
+                meta = meta0 if rank == 0 else _call_meta(rank)
+                for idx, cs_tensor in (
+                    (rank, meta.kv_len_prev_tensor),
+                    (cp_size * 2 - rank - 1, meta.kv_len_next_tensor),
+                ):
+                    if meta0.split_list[idx] == 0:
+                        outs[idx] = torch.empty(
+                            0, _HEAD_NUM, _HEAD_DIM, device=_DEVICE, dtype=_DTYPE
+                        )
+                        continue
+                    outs[idx] = flash_attn_with_kvcache(
+                        q=blocks_q[idx].unsqueeze(0),
+                        k_cache=k_padded.unsqueeze(0),
+                        v_cache=v_padded.unsqueeze(0),
+                        cache_seqlens=cs_tensor,
+                        softmax_scale=_SCALE,
+                        causal=True,
+                    ).squeeze(0)
+
+        cp_out = torch.cat(outs, dim=0)
+        err = (cp_out[:extend_len].float() - ref.float()).abs().max().item()
+
+        self.assertLess(
+            err,
+            1e-2,
+            f"CP output diverges from full-sequence FA3 reference by "
+            f"max_err={err:.5f} "
+            f"(prefix_len={prefix_len}, extend_len={extend_len}, "
+            f"cp_size={cp_size}, pad={pad})",
+        )
+
+    def test_cp2_prefix1_extend3(self):
+        """cp_size=2, prefix_len=1, extend_len=3 (pad=1)."""
+        self._run_parity(prefix_len=1, extend_len=3, cp_size=2)
+
+    def test_cp4_prefix1_extend7(self):
+        """cp_size=4, prefix_len=1, extend_len=7 (pad=1)."""
+        self._run_parity(prefix_len=1, extend_len=7, cp_size=4)
+
+    def test_cp8_prefix1_extend17(self):
+        """cp_size=8, prefix_len=1, extend_len=17 (pad=7)."""
+        self._run_parity(prefix_len=1, extend_len=17, cp_size=8)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/kernels/test_cp_prefix_len_fa3_parity.py
+++ b/test/registered/kernels/test_cp_prefix_len_fa3_parity.py
@@ -7,7 +7,6 @@ full-sequence FA3 reference computed over the unpadded `(prefix + extend)`
 KV. Any discrepancy indicates the metadata function emitted wrong
 `cache_seqlens` for at least one rank.
 """
-import inspect
 import unittest
 from unittest.mock import patch
 
@@ -76,18 +75,10 @@ class TestCPPrefixLenFA3Parity(CustomTestCase):
 
         seqs_len = [prefix_len + extend_len]
         extend_lens = [extend_len]
-        accepts_extend_lens = (
-            "extend_lens"
-            in inspect.signature(prepare_context_parallel_metadata).parameters
-        )
 
         def _call_meta(rank: int):
-            if accepts_extend_lens:
-                return prepare_context_parallel_metadata(
-                    padded_extend, rank, cp_size, seqs_len, extend_lens=extend_lens
-                )
             return prepare_context_parallel_metadata(
-                padded_extend, rank, cp_size, seqs_len
+                padded_extend, rank, cp_size, seqs_len, extend_lens=extend_lens
             )
 
         # Exercise the non-NSA branch; the NSA branch uses a separate

--- a/test/registered/kernels/test_cp_prefix_len_fa3_parity.py
+++ b/test/registered/kernels/test_cp_prefix_len_fa3_parity.py
@@ -7,6 +7,7 @@ full-sequence FA3 reference computed over the unpadded `(prefix + extend)`
 KV. Any discrepancy indicates the metadata function emitted wrong
 `cache_seqlens` for at least one rank.
 """
+
 import unittest
 from unittest.mock import patch
 
@@ -24,7 +25,7 @@ _DEVICE = "cuda"
 _DTYPE = torch.bfloat16
 _HEAD_NUM = 8
 _HEAD_DIM = 128
-_SCALE = _HEAD_DIM ** -0.5
+_SCALE = _HEAD_DIM**-0.5
 
 
 class TestCPPrefixLenFA3Parity(CustomTestCase):
@@ -66,9 +67,7 @@ class TestCPPrefixLenFA3Parity(CustomTestCase):
 
         # CP path sees tensors padded to `ceil_align(extend, cp_size)`,
         # matching what `prepare_mlp_sync_batch` does in production.
-        zeros = torch.zeros(
-            pad, _HEAD_NUM, _HEAD_DIM, device=_DEVICE, dtype=_DTYPE
-        )
+        zeros = torch.zeros(pad, _HEAD_NUM, _HEAD_DIM, device=_DEVICE, dtype=_DTYPE)
         q_padded = torch.cat([q_full, zeros], dim=0)
         k_padded = torch.cat([k_full, zeros], dim=0)
         v_padded = torch.cat([v_full, zeros], dim=0)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Part of the context parallel series https://github.com/sgl-project/sglang/issues/21788.

Fix a dormant accuracy bug in the non-NSA prefill CP path (covers MHA CP and the in-flight MLA CP). `prepare_context_parallel_metadata` was miscomputing `prefix_len` whenever the request had a radix-cache hit **and** its extend length was not divisible by `2·cp_size`:

The old formula subtracted `kv_len = len(input_ids)` from `seqs_len[0] = forward_batch.seq_lens_cpu[0]`. `kv_len` is padded by `prepare_mlp_sync_batch` but `seqs_len[0]` stays unpadded. https://github.com/sgl-project/sglang/blob/036edf25339c6b8ab19f7ddadd6b968b3e92ef31/python/sglang/srt/model_executor/forward_batch_info.py#L856-L858


Concrete example, `prefix=1, extend=3670, cp_size=4`:
- padded `kv_len = ceil_align(3670, 4) = 3672` (pad = 2)
- unpadded `seqs_len[0] = 1 + 3670 = 3671`
- old: `prefix_len = 3671 − 3672 = −1` → clamped to `0` WRONG (should be `1`)
- new: `prefix_len = seqs_len[0] − extend_lens[0] = 3671 − 3670 = 1` CORRECT

## Modifications

- **`layers/utils/cp_utils.py`** — add required `extend_lens` parameter to `prepare_context_parallel_metadata`; compute `prefix_len = seqs_len[0] − extend_lens[0]` (both unpadded).
- **`models/deepseek_v2.py`, `models/deepseek_nextn.py`, `models/qwen3_moe.py`** — thread `extend_lens=forward_batch.extend_seq_lens_cpu` through the three callers of the non-NSA branch.
- **`test/registered/kernels/test_cp_prefix_len_fa3_parity.py`** — new FA3 parity test that drives the real `prepare_context_parallel_metadata` and compares per-rank CP output against a full-sequence FA3 reference. Parametrized across `(cp_size, prefix_len, extend_len)` triples that trigger all three conditions; would have caught this class of bug pre-fix.

No kernel / collective / metadata-schema changes. NSA CP path untouched (its downstream indexer re-adds the prefix itself and takes a different branch).

## Accuracy Tests

- **`test/registered/kernels/test_cp_prefix_len_fa3_parity.py`** (`stage-b-test-1-gpu-large`, ~5 s) — 3 cases: `(cp=2, prefix=1, extend=3, pad=1)`, `(cp=4, prefix=1, extend=7, pad=1)`, `(cp=8, prefix=1, extend=17, pad=7)`. Passes post-fix; fails pre-fix on all three with `max_err > 1e-2`.
- **Non-regression gates (no changes, must stay green):**
  - `test/registered/4-gpu-models/test_qwen3_30b.py` — MHA CP (`tp=4, attn-cp=2`), GSM8k ≥ 0.85.
  - `test/registered/cp/test_deepseek_v32_cp_single_node.py` — NSA CP, unaffected by this change.

## Speed Tests and Profiling

N/A. Fix is CPU-side (one integer subtraction in `prepare_context_parallel_metadata`, called once per CP-enabled extend). No kernel, collective, or memory-layout changes.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
