### PR TITLE
Update pr-test-xeon.yml cancel-in-progress config

### DIFF
--- a/.github/workflows/pr-test-xeon.yml
+++ b/.github/workflows/pr-test-xeon.yml
@@ -21,7 +21,7 @@ on:
 
 concurrency:
   group: pr-test-xeon-${{ inputs.ref || github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name != 'workflow_call' }}
 
 jobs:
   # ==================== Check Changes ==================== #


### PR DESCRIPTION

Xeon CI currently uses cancel-in-progress: false, so new PR commits wait behind stale runs of the same PR on the single xeon-gnr runner (often hours).

Align with the existing XPU policy:

PR / push: cancel stale runs on the same ref → faster feedback, runner freed sooner.
workflow_call (release / nightly): unchanged, never cancelled.