### PR TITLE
fix(lora): don't assert on non-LoRA lm_head adapter weights

### DIFF
--- a/python/sglang/srt/lora/mem_pool.py
+++ b/python/sglang/srt/lora/mem_pool.py
@@ -905,7 +905,20 @@ class LoRAMemoryPool:
                         :lora_rank,
                     ]
                     load_lora_weight_tensor(buffer_view, lora_b_weights)
-                elif target_module == "lm_head" and "lm_head" in name:
+                elif (
+                    target_module == "lm_head"
+                    and "lm_head" in name
+                    and (
+                        "lora_embedding_A" in name
+                        or "lora_A" in name
+                        or "lora_embedding_B" in name
+                        or "lora_B" in name
+                    )
+                ):
+                    # Only assert for genuine LoRA A/B deltas. Non-LoRA adapter
+                    # entries (e.g. `base_layer.weight` emitted by PEFT for
+                    # tied-embedding lm_head) fall through and are handled by
+                    # the base weight loader, mirroring embed_tokens behavior.
                     # Non-last PP stages do not own lm_head, so adapters can
                     # legitimately contain lm_head LoRA weights with no local
                     # module to load them into, otherwise we should have been able to load this weight.


### PR DESCRIPTION
## Summary

- Tightens the lm_head assertion added in #21864 to only match genuine LoRA A/B delta weights, so PEFT's non-LoRA `base_layer.weight` entry for tied-embedding adapters falls through silently instead of crashing the scheduler.
- Fixes the `test/registered/lora/test_lora_tied_lm_head.py` nightly regression that has been failing since #21864 landed on 2026-04-17 (e.g. runs [24698143162](https://github.com/sgl-project/sglang/actions/runs/24698143162), [24754179764](https://github.com/sgl-project/sglang/actions/runs/24754179764)).

## Root cause

PEFT's saved adapter for `target_modules=[\"lm_head\"]` on a model with `tie_word_embeddings=True` (e.g. Qwen2.5-0.5B) writes **three** keys:

```
base_model.model.lm_head.base_layer.weight
base_model.model.lm_head.lora_A.weight
base_model.model.lm_head.lora_B.weight
```

The A/B deltas match the existing lm_head branches at `python/sglang/srt/lora/mem_pool.py:875-907` and load correctly. The `base_layer.weight` entry (PEFT's copy of the original tied weight, not a LoRA delta) matches `target_module == \"lm_head\"` + `\"lm_head\" in name`, then falls into the new assertion branch added in #21864, which trips on any TP=PP=1 run because `get_pp_group().is_last_rank` is True:

```
AssertionError: Failed to load lm_head LoRA weight: base_model.model.lm_head.base_layer.weight,
this is only expected to happen on non-last PP stages.
```

## Fix

Require the assertion branch to match only genuine LoRA A/B delta names (`lora_A` / `lora_B` / `lora_embedding_A` / `lora_embedding_B`), mirroring the key-suffix guard already used by the `embed_tokens` branches at lines 850-873. Non-LoRA entries fall through without any buffer load — the base lm_head weight is already placed by the model loader (tied to `embed_tokens`), so the forward output is `base_layer(x) + B(A(x)) * scale`, same as HF+PEFT.

The PP safety check for genuinely unplaced LoRA deltas is preserved.

## Test plan

- [x] Repro baseline on H200 (sglang at f41f1a74a, torch 2.9.1+cu130) — `AssertionError` reproduces on `test_lora_tied_lm_head.py`.
- [x] With fix: `Ran 1 test in 48.836s` / `OK`. Logprob max diffs SGLang vs HF+PEFT:
      - Prompt 0 prefill: 2.65e-02
      - Prompt 1 prefill: 2.02e-02
      - Prompt 0 decode: 2.46e-02
      - Prompt 1 decode: 2.02e-02

      All ~10× below the 2e-1 threshold, confirming the LoRA is actually applied (not silently dropped).
- [x] `pre-commit run --files python/sglang/srt/lora/mem_pool.py` — passes.
- [ ] Wait for CI to confirm the rest of the LoRA suite still passes.

cc @kurt-stolle — since #21864 added the assertion, please sanity-check that the tightened condition still covers the PP case you intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)