### PR TITLE
Docs/add sglang omni redirect

### DIFF
--- a/docs_new/docs.json
+++ b/docs_new/docs.json
@@ -27,6 +27,16 @@
       "permanent": false
     },
     {
+      "source": "/sglang-omni",
+      "destination": "https://sgl-project.github.io/sglang-omni/",
+      "permanent": false
+    },
+    {
+      "source": "/sglang-omni/:path*",
+      "destination": "https://sgl-project.github.io/sglang-omni/:path*",
+      "permanent": false
+    },
+    {
       "source": "/SpecForge",
       "destination": "https://sgl-project.github.io/SpecForge/",
       "permanent": false


### PR DESCRIPTION
Fix sglang-omni doc redirection problem.

Validation:
- `jq empty docs_new/docs.json`
- `mint validate`