### PR TITLE
[diffusion] ci: allow using prebuilt sgl-kernel wheel for GT regeneration

### DIFF
--- a/.github/workflows/diffusion-ci-gt-gen.yml
+++ b/.github/workflows/diffusion-ci-gt-gen.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: ''
         type: string
+      kernel_artifact_run_id:
+        description: "Optional sgl-kernel wheel source: GitHub Actions run ID of a pr-test.yml run on the SAME commit as 'ref' that uploaded wheel-python3.10-cuda13.0. Use only when this branch's torch/ABI change makes the PyPI sglang-kernel wheel incompatible. Find it under Actions > pr-test; artifacts expire after 90 days."
+        required: false
+        default: ''
+        type: string
 
 concurrency:
   group: diffusion-ci-gt-gen-${{ github.ref }}
@@ -46,8 +51,26 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
+      - name: Prepare sgl-kernel/dist for prebuilt wheel
+        if: inputs.kernel_artifact_run_id != ''
+        run: |
+          ls -alh sgl-kernel/dist || true
+          rm -rf sgl-kernel/dist/* || true
+
+      - name: Download prebuilt sgl-kernel wheel
+        if: inputs.kernel_artifact_run_id != ''
+        uses: actions/download-artifact@v4
+        with:
+          path: sgl-kernel/dist/
+          merge-multiple: true
+          name: wheel-python3.10-cuda13.0
+          run-id: ${{ inputs.kernel_artifact_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install dependencies
-        run: bash scripts/ci/cuda/ci_install_dependency.sh diffusion
+        run: |
+          CUSTOM_BUILD_SGL_KERNEL="${{ inputs.kernel_artifact_run_id != '' && 'true' || 'false' }}" \
+            bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 
       - name: Generate outputs
         env:
@@ -89,8 +112,26 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
+      - name: Prepare sgl-kernel/dist for prebuilt wheel
+        if: inputs.kernel_artifact_run_id != ''
+        run: |
+          ls -alh sgl-kernel/dist || true
+          rm -rf sgl-kernel/dist/* || true
+
+      - name: Download prebuilt sgl-kernel wheel
+        if: inputs.kernel_artifact_run_id != ''
+        uses: actions/download-artifact@v4
+        with:
+          path: sgl-kernel/dist/
+          merge-multiple: true
+          name: wheel-python3.10-cuda13.0
+          run-id: ${{ inputs.kernel_artifact_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install dependencies
-        run: bash scripts/ci/cuda/ci_install_dependency.sh diffusion
+        run: |
+          CUSTOM_BUILD_SGL_KERNEL="${{ inputs.kernel_artifact_run_id != '' && 'true' || 'false' }}" \
+            bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 
       - name: Generate outputs
         env:
@@ -129,8 +170,26 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
+      - name: Prepare sgl-kernel/dist for prebuilt wheel
+        if: inputs.kernel_artifact_run_id != ''
+        run: |
+          ls -alh sgl-kernel/dist || true
+          rm -rf sgl-kernel/dist/* || true
+
+      - name: Download prebuilt sgl-kernel wheel
+        if: inputs.kernel_artifact_run_id != ''
+        uses: actions/download-artifact@v4
+        with:
+          path: sgl-kernel/dist/
+          merge-multiple: true
+          name: wheel-python3.10-cuda13.0
+          run-id: ${{ inputs.kernel_artifact_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install dependencies
-        run: bash scripts/ci/cuda/ci_install_dependency.sh diffusion
+        run: |
+          CUSTOM_BUILD_SGL_KERNEL="${{ inputs.kernel_artifact_run_id != '' && 'true' || 'false' }}" \
+            bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 
       - name: Generate outputs
         env:


### PR DESCRIPTION
## Summary

- Add an optional \`kernel_artifact_run_id\` input to \`diffusion-ci-gt-gen.yml\`.
- When set, each of the three jobs (1-gpu-h100, 2-gpu-h100, 4-gpu-b200) downloads the \`wheel-python3.10-cuda13.0\` artifact from that prior workflow run and installs it via the existing \`CUSTOM_BUILD_SGL_KERNEL=true\` path in \`scripts/ci/cuda/ci_install_dependency.sh\`.
- Unblocks ground-truth regeneration on branches that upgrade torch (PyPI \`sglang-kernel\` wheel is ABI-incompatible on such branches).

## Motivation

See failure on a torch-upgrade branch: https://github.com/sgl-project/sglang/actions/runs/24759099673

\`\`\`
ImportError: /usr/local/lib/python3.10/dist-packages/sgl_kernel/sm90/common_ops.abi3.so: undefined symbol: _ZN3c104cuda29c10_cuda_check_implementationEiPKcS2_ib
\`\`\`

The branch bumps torch, which makes the published \`sglang-kernel\` wheel fail to load against the new torch ABI. Until the next kernel release catches up, we had no way to regenerate diffusion baselines from such a branch.

## Changes

- New optional \`workflow_dispatch\` input \`kernel_artifact_run_id\`.
- In each of the three jobs, added two gated steps before \`Install dependencies\`:
  - \`Prepare sgl-kernel/dist for prebuilt wheel\` — clears \`sgl-kernel/dist/\`.
  - \`Download prebuilt sgl-kernel wheel\` — \`actions/download-artifact@v4\` with \`run-id\` + \`github-token: \${{ secrets.GITHUB_TOKEN }}\` (the existing \`permissions: actions: read\` grants the cross-run scope).
- \`Install dependencies\` now forwards \`CUSTOM_BUILD_SGL_KERNEL=true\` only when the input is set. The existing block at \`scripts/ci/cuda/ci_install_dependency.sh:309-335\` handles the force-reinstall from \`sgl-kernel/dist/\`.

The pattern mirrors what \`.github/workflows/pr-test-sgl-kernel.yml\` already does, extended with \`run-id\` for cross-run downloads.

## Usage

1. Run \`pr-test.yml\` on the branch; let \`sgl-kernel-build-wheels\` finish and upload \`wheel-python3.10-cuda13.0\`.
2. Dispatch \`Diffusion CI Ground Truth Generation\` with:
   - \`ref\` = branch name
   - \`kernel_artifact_run_id\` = the \`pr-test.yml\` run ID (must be on the same commit as \`ref\`)

Default behavior (empty input) is unchanged — the workflow installs \`sglang-kernel\` from PyPI as before.

## Test Plan

- [ ] Dispatch the workflow with the input empty on \`main\` — verify no behavioral change.
- [ ] Dispatch on a torch-upgrade branch with \`kernel_artifact_run_id\` set — verify the downloaded wheel is installed and GT generation succeeds.