### PR TITLE
[PD] Reuse keep-alive HTTP Sessions for bootstrap server queries

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -14,6 +14,7 @@ import numpy.typing as npt
 import requests
 import zmq
 from aiohttp import web
+from requests.adapters import HTTPAdapter
 
 from sglang.srt.disaggregation.base.conn import (
     BaseKVBootstrapServer,
@@ -42,6 +43,43 @@ from sglang.srt.utils.network import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+# Process-wide pool of long-lived requests.Sessions keyed by bootstrap_addr.
+#
+# Decode workers poll the prefill bootstrap server very frequently
+# (`/route` and `/query_dp_ranks`). With one `requests.{get,post}` call per
+# poll the kernel opens a fresh TCP connection every time, which on a busy
+# host quickly exhausts the ephemeral source-port range against a single
+# (dst_ip, dst_port) tuple and surfaces as
+# `[Errno 99] Cannot assign requested address` from `connect(2)`.
+#
+# Using a Session with a sized HTTPAdapter enables HTTP keep-alive and a real
+# connection pool, so all DP ranks on a host share a small number of
+# persistent TCP connections to each bootstrap server instead of burning
+# through (and TIME_WAITing) a new ephemeral port per request.
+_BOOTSTRAP_HTTP_SESSIONS: Dict[str, requests.Session] = {}
+_BOOTSTRAP_HTTP_SESSIONS_LOCK = threading.Lock()
+
+
+def _get_bootstrap_http_session(bootstrap_addr: str) -> requests.Session:
+    """Return a process-wide keep-alive Session for the given bootstrap_addr."""
+    session = _BOOTSTRAP_HTTP_SESSIONS.get(bootstrap_addr)
+    if session is not None:
+        return session
+    with _BOOTSTRAP_HTTP_SESSIONS_LOCK:
+        session = _BOOTSTRAP_HTTP_SESSIONS.get(bootstrap_addr)
+        if session is None:
+            session = requests.Session()
+            adapter = HTTPAdapter(
+                pool_connections=32,
+                pool_maxsize=128,
+                pool_block=False,
+            )
+            session.mount("http://", adapter)
+            session.mount("https://", adapter)
+            _BOOTSTRAP_HTTP_SESSIONS[bootstrap_addr] = session
+    return session
 
 
 @dataclasses.dataclass
@@ -627,7 +665,8 @@ class CommonKVReceiver(BaseKVReceiver):
         """Fetch the bootstrap info from the bootstrap server."""
         try:
             url = f"http://{self.bootstrap_addr}/route?prefill_dp_rank={prefill_dp_rank}&prefill_cp_rank={prefill_cp_rank}&target_tp_rank={target_tp_rank}&target_pp_rank={target_pp_rank}"
-            response = requests.get(url, timeout=5)
+            session = _get_bootstrap_http_session(self.bootstrap_addr)
+            response = session.get(url, timeout=5)
             if response.status_code == 200:
                 bootstrap_info = response.json()
                 return bootstrap_info
@@ -647,7 +686,8 @@ class CommonKVReceiver(BaseKVReceiver):
         """Batch query prefill dp_ranks for given bootstrap_rooms."""
         try:
             url = f"http://{bootstrap_addr}/query_dp_ranks"
-            response = requests.post(
+            session = _get_bootstrap_http_session(bootstrap_addr)
+            response = session.post(
                 url,
                 json={"bootstrap_rooms": bootstrap_rooms},
                 timeout=5,


### PR DESCRIPTION
## Motivation

In a multi-DP decode setup talking to a single bootstrap server, decode workers periodically log:

```
Error querying dp_ranks from bootstrap: HTTPConnectionPool(host='10.0.127.8', port=8998):
Max retries exceeded with url: /query_dp_ranks
(Caused by NewConnectionError(...: Failed to establish a new connection:
[Errno 99] Cannot assign requested address))
```

Errno 99 (`EADDRNOTAVAIL`) here is **client-side ephemeral port exhaustion**, not a server outage:

- `_get_bootstrap_info_from_server` (`GET /route`) and `query_prefill_dp_ranks` (`POST /query_dp_ranks`) in `disaggregation/common/conn.py` use bare `requests.{get,post}(...)` calls.
- Each call opens a brand-new TCP connection. After it closes, the source port sits in `TIME_WAIT` for ~60s.
- All DP ranks on a host poll the **same** `(bootstrap_ip, bootstrap_port)` 4-tuple, so the kernel must pick a unique source port from `net.ipv4.ip_local_port_range` (~28k by default). Under load this drains and `connect(2)` returns `EADDRNOTAVAIL`.

Repro is trivial on a host with many DP ranks (we hit it on a 32-DP-per-node decode setup against a single prefill bootstrap).

## Modifications

Introduce a process-wide pool of long-lived `requests.Session`s keyed by `bootstrap_addr`, mounted with a sized `HTTPAdapter`:

```python
HTTPAdapter(pool_connections=32, pool_maxsize=128, pool_block=False)
```

Switch the two hot-path callsites in `CommonKVReceiver` to use this Session:

- `_get_bootstrap_info_from_server` -> `session.get(...)`
- `query_prefill_dp_ranks` -> `session.post(...)`

HTTP keep-alive lets all DP ranks on a host share a small bounded set of persistent TCP connections to each bootstrap server instead of burning through (and `TIME_WAIT`ing) a new ephemeral port per poll.

Effect on a 32-DP decode host (verified via `ss -tan dport = :8998`):

| | Before | After |
|---|---|---|
| New TCP conns per bootstrap poll | 1 (new src port) | 0 (reuse) |
| Steady-state ESTABLISHED to bootstrap | grows unbounded | ~1 per scheduler process |
| TIME_WAIT to bootstrap | thousands | ~0 |
| Errno 99 occurrences | frequent under load | none |

No public API change. `query_prefill_dp_ranks` keeps the same `@staticmethod` signature; the existing per-`CommonKVManager` `session_pool` used by the heartbeat loops in `nixl/conn.py` and `mooncake/conn.py` is untouched.

## Accuracy Tests

N/A - purely client-side TCP/HTTP plumbing change, no model code touched, request/response payloads unchanged.

## Speed Tests and Profiling

Not directly a perf change, but it eliminates a class of failures that otherwise causes decode workers to silently retry bootstrap queries (driving up TTFT under PD-disagg with high DP). On the affected setup, decode TTFT noise from these warnings disappeared and bootstrap-related failure logs went to zero.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Made with [Cursor](https://cursor.com)