### PR TITLE
[Test] Add unit test gpt oss detector

### DIFF
--- a/python/sglang/srt/function_call/gpt_oss_detector.py
+++ b/python/sglang/srt/function_call/gpt_oss_detector.py
@@ -103,6 +103,7 @@ class GptOssDetector(BaseFormatDetector):
                 # Plain text with no tool markers — emit as normal content
                 out = self._buffer
                 self._buffer = ""
+                self.harmony_parser._buffer = ""
                 return StreamingParseResult(normal_text=out, calls=[])
 
         # Quick check if we might have tool calls

--- a/test/registered/unit/function_call/test_gptoss_detector.py
+++ b/test/registered/unit/function_call/test_gptoss_detector.py
@@ -1,0 +1,158 @@
+"""Unit tests for GptOssDetector — no server, no model loading."""
+
+import json
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.gpt_oss_detector import GptOssDetector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "stage-a-test-cpu")
+
+
+class TestGptOssDetector(CustomTestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_weather",
+                    description="Get weather information",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "city": {"type": "string", "description": "City name"},
+                            "unit": {
+                                "type": "string",
+                                "enum": ["celsius", "fahrenheit"],
+                            },
+                        },
+                        "required": ["city"],
+                    },
+                ),
+            ),
+            Tool(
+                type="function",
+                function=Function(
+                    name="search",
+                    description="Search the web",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "query": {
+                                "type": "string",
+                                "description": "Search query",
+                            },
+                        },
+                        "required": ["query"],
+                    },
+                ),
+            ),
+        ]
+        self.detector = GptOssDetector()
+
+    # ==================== has_tool_call Tests ====================
+
+    def test_has_tool_call_with_python_tag(self):
+        text = '<|start|>assistant<|channel|>commentary to=functions.get_weather<|constrain|>json<|message|>{"city":"Beijing"}<|call|>'
+        self.assertTrue(self.detector.has_tool_call(text))
+
+    def test_has_tool_call_false(self):
+        text = "The weather in Beijing is sunny today."
+        self.assertFalse(self.detector.has_tool_call(text))
+
+    # ==================== detect_and_parse Tests ====================
+
+    def test_single_tool_call(self):
+        text = '<|start|>assistant<|channel|>commentary to=functions.get_weather<|constrain|>json<|message|>{"city":"Beijing"}<|call|>'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        args = json.loads(result.calls[0].parameters)
+        self.assertEqual(args["city"], "Beijing")
+
+    def test_normal_text_before_tool_call(self):
+        text = 'Let me check.<|start|>assistant<|channel|>commentary to=functions.get_weather<|constrain|>json<|message|>{"city":"Beijing"}<|call|>'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(result.normal_text, "Let me check.")
+
+    def test_no_tool_call(self):
+        text = "The weather is nice today."
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 0)
+        self.assertEqual(result.normal_text, "The weather is nice today.")
+
+    def test_multiple_tool_calls(self):
+        text = (
+            '<|start|>assistant<|channel|>commentary to=functions.get_weather<|constrain|>json<|message|>{"city":"Beijing"}<|call|>'
+            '<|start|>assistant<|channel|>commentary to=functions.search<|constrain|>json<|message|>{"query":"restaurants"}<|call|>'
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 2)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        self.assertEqual(result.calls[1].name, "search")
+
+    # ==================== structure_info Tests ====================
+
+    def test_structure_info_not_implemented(self):
+        with self.assertRaises(NotImplementedError):
+            self.detector.structure_info()
+
+    # ==================== Streaming Tests ====================
+
+    def test_streaming_single_tool_call(self):
+        chunks = [
+            "<|start|>",
+            "assistant<|channel|>",
+            "commentary to=functions.get_weather",
+            '<|constrain|>json<|message|>{"city":"Beijing"}<|call|>',
+        ]
+
+        all_calls = []
+        for chunk in chunks:
+            result = self.detector.parse_streaming_increment(chunk, self.tools)
+            all_calls.extend(result.calls)
+
+        func_calls = [c for c in all_calls if c.name]
+        self.assertEqual(len(func_calls), 1)
+        self.assertEqual(func_calls[0].name, "get_weather")
+
+        full_params = "".join(c.parameters for c in all_calls if c.parameters)
+        params = json.loads(full_params)
+        self.assertEqual(params["city"], "Beijing")
+
+    def test_streaming_normal_text_before_tool(self):
+        result = self.detector.parse_streaming_increment(
+            "Let me check the weather. ", self.tools
+        )
+        self.assertEqual(result.normal_text, "Let me check the weather. ")
+        self.assertEqual(len(result.calls), 0)
+
+    def test_streaming_text_then_tool_call(self):
+        chunks = [
+            "I'll look that up. <|start|>",
+            "assistant<|channel|>",
+            "commentary to=functions.get_weather",
+            '<|constrain|>json<|message|>{"city":"Beijing", "unit":"celsius"}<|call|>',
+        ]
+        all_calls = []
+        all_normal_text = ""
+        for chunk in chunks:
+            result = self.detector.parse_streaming_increment(chunk, self.tools)
+            all_calls.extend(result.calls)
+            all_normal_text += result.normal_text
+
+        self.assertEqual(all_normal_text, "I'll look that up. ")
+        func_calls = [c for c in all_calls if c.name]
+        self.assertEqual(len(func_calls), 1)
+        self.assertEqual(func_calls[0].name, "get_weather")
+        full_params = "".join(c.parameters for c in all_calls if c.parameters)
+        params = json.loads(full_params)
+        self.assertEqual(params["city"], "Beijing")
+        self.assertEqual(params["unit"], "celsius")
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/test/registered/unit/function_call/test_gptoss_detector.py
+++ b/test/registered/unit/function_call/test_gptoss_detector.py
@@ -130,7 +130,8 @@ class TestGptOssDetector(CustomTestCase):
 
     def test_streaming_text_then_tool_call(self):
         chunks = [
-            "I'll look that up. <|start|>",
+            "I'll look",
+            " that up. <|start|>",
             "assistant<|channel|>",
             "commentary to=functions.get_weather",
             '<|constrain|>json<|message|>{"city":"Beijing", "unit":"celsius"}<|call|>',

--- a/test/registered/unit/function_call/test_gptoss_detector.py
+++ b/test/registered/unit/function_call/test_gptoss_detector.py
@@ -53,7 +53,7 @@ class TestGptOssDetector(CustomTestCase):
 
     # ==================== has_tool_call Tests ====================
 
-    def test_has_tool_call_with_python_tag(self):
+    def test_has_tool_call_true(self):
         text = '<|start|>assistant<|channel|>commentary to=functions.get_weather<|constrain|>json<|message|>{"city":"Beijing"}<|call|>'
         self.assertTrue(self.detector.has_tool_call(text))
 


### PR DESCRIPTION
Summary
---

- Add 10 unit tests for gpt oss model function call format detectors
- Clean buffer harmony_parser when no events
- Part of #20865 

**New test file**

| File | Tests | Detector Format | Coverage|
| -------- | -------- | -------- |-----|
| `test_gptoss_detector.py`     | 10     | `<\|channel\|>commentary to={namespace.function}<\|constrain\|>json<\|message\|>{args}<\|call\|>` | 86\%|


Problem
---
In `GptOssDetector.parse_streaming_increment`, the detector buffer is cleared when there are no events, but the `harmony_parser` buffer still retains the old text.

```python
if not has_harmony_markers:
    # Plain text with no tool markers — emit as normal content
    out = self._buffer
    self._buffer = ""
    return StreamingParseResult(normal_text=out, calls=[])
```

**Reproduction**

```python
from sglang.srt.function_call.gpt_oss_detector import GptOssDetector
from sglang.srt.entrypoints.openai.protocol import Function, Tool

tools = [
            Tool(
                type="function",
                function=Function(
                    name="get_weather",
                    description="Get weather information",
                    parameters={
                        "type": "object",
                        "properties": {
                            "city": {"type": "string", "description": "City name"},
                            "unit": {
                                "type": "string",
                                "enum": ["celsius", "fahrenheit"],
                            },
                        },
                        "required": ["city"],
                    },
                ),
            )
        ]

chunks = [
    "I'll look",
    " that up. <|start|>",
    "assistant<|channel|>",
    "commentary to=functions.get_weather",
    '<|constrain|>json<|message|>{"city":"Beijing", "unit":"celsius"}<|call|>',
]
all_calls = []
all_normal_text = ""
detector = GptOssDetector()
for chunk in chunks:
    result = detector.parse_streaming_increment(chunk, tools)
    all_calls.extend(result.calls)
    all_normal_text += result.normal_text

print(all_normal_text)
```

Result
```
I'll lookI'll look that up. 
```

After Fix
```
I'll look that up. 
```


Test Plan
---

```
# command
pytest -v test/registered/unit/function_call/test_gptoss_detector.py 
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.11.13, pytest-9.0.3, pluggy-1.6.0 -- /home/os-jeff.wh.lu/my/sglang/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /home/os-jeff.wh.lu/my/sglang/test
configfile: pytest.ini
plugins: cov-7.1.0, anyio-4.13.0
collected 10 items                                                                                                                                                                                           

test/registered/unit/function_call/test_gptoss_detector.py::TestGptOssDetector::test_has_tool_call_false PASSED                                                                                        [ 10%]
test/registered/unit/function_call/test_gptoss_detector.py::TestGptOssDetector::test_has_tool_call_with_python_tag PASSED                                                                              [ 20%]
test/registered/unit/function_call/test_gptoss_detector.py::TestGptOssDetector::test_multiple_tool_calls PASSED                                                                                        [ 30%]
test/registered/unit/function_call/test_gptoss_detector.py::TestGptOssDetector::test_no_tool_call PASSED                                                                                               [ 40%]
test/registered/unit/function_call/test_gptoss_detector.py::TestGptOssDetector::test_normal_text_before_tool_call PASSED                                                                               [ 50%]
test/registered/unit/function_call/test_gptoss_detector.py::TestGptOssDetector::test_single_tool_call PASSED                                                                                           [ 60%]
test/registered/unit/function_call/test_gptoss_detector.py::TestGptOssDetector::test_streaming_normal_text_before_tool PASSED                                                                          [ 70%]
test/registered/unit/function_call/test_gptoss_detector.py::TestGptOssDetector::test_streaming_single_tool_call PASSED                                                                                 [ 80%]
test/registered/unit/function_call/test_gptoss_detector.py::TestGptOssDetector::test_streaming_text_then_tool_call PASSED                                                                              [ 90%]
test/registered/unit/function_call/test_gptoss_detector.py::TestGptOssDetector::test_structure_info_not_implemented PASSED                                                                             [100%]

======================================================================================= 10 passed, 3 warnings in 4.33s =======================================================================================
```

> warnings do not related to this PR.


## Checklist

- [x]  All 10 new tests pass locally
- [x] Existing 302 tests still pass (no regression)
- [x] Follows test/registered/unit/README.md conventions
- [x] Registered for CPU CI via register_cpu_ci
