### PR TITLE
[WIP][EPD][Perf] keep cuda-tensor for receiver

### DIFF
--- a/python/sglang/srt/disaggregation/encode_receiver.py
+++ b/python/sglang/srt/disaggregation/encode_receiver.py
@@ -314,10 +314,7 @@ class MultiModalEmbeddingData(EmbeddingData):
             for i, e in enumerate(self.embedding_list):
                 if e is not None:
                     groups[self.modality_list[i]].append(e.cuda())
-            return {
-                mod: torch.concat(tensors).to("cpu", non_blocking=True)
-                for mod, tensors in groups.items()
-            }
+            return {mod: torch.concat(tensors) for mod, tensors in groups.items()}
         return self.embedding_list
 
     @property

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -447,6 +447,12 @@ def _get_precomputed_embedding(
             raise NotImplementedError(
                 "MM inputs where only some items are precomputed."
             )
+        # Filter out empty chunks to avoid device mismatch: in chunked-prefill,
+        # requests whose mm tokens are fully covered in prior chunks produce
+        # empty tensors that may reside on CPU, while new requests may have non-empty CUDA tensors.
+        precomputed_embeddings = [t for t in precomputed_embeddings if t.numel() > 0]
+        if not precomputed_embeddings:
+            return None
         result = torch.concat(precomputed_embeddings)
         # some models embedding is 3-dim, reshape it to 2-dim (similar to get_embedding_chunk)
         result = result.reshape(-1, result.shape[-1])
@@ -1073,13 +1079,31 @@ def general_mm_embed_routine(
             # if a cache miss occurs in subsequent chunks, while still freeing up
             # critical GPU memory.
             if mm_inputs_list:
-                for mm_input_obj in mm_inputs_list:
+                for idx, mm_input_obj in enumerate(mm_inputs_list):
                     if mm_input_obj and hasattr(mm_input_obj, "mm_items"):
+                        # Check if all mm tokens for this request have been
+                        # fully covered by chunks so far. Only offload to CPU
+                        # when no subsequent chunk will need them, avoiding
+                        # device mismatch with new CUDA requests in later batches.
+                        chunk_end = extend_prefix_lens[idx] + extend_seq_lens[idx]
+                        max_mm_end = max(
+                            (
+                                end
+                                for mm_item in mm_input_obj.mm_items
+                                if mm_item is not None
+                                for _, end in getattr(mm_item, "offsets", [])
+                            ),
+                            default=0,
+                        )
+                        mm_fully_covered = chunk_end > max_mm_end
                         for mm_item in mm_input_obj.mm_items:
                             feature = getattr(mm_item, "feature", None)
                             if isinstance(feature, torch.Tensor) and feature.is_cuda:
                                 mm_item.feature = feature.to("cpu", non_blocking=True)
-                            if get_global_server_args().language_only:
+                            if (
+                                get_global_server_args().language_only
+                                and mm_fully_covered
+                            ):
                                 precomputed_embeddings = getattr(
                                     mm_item, "precomputed_embeddings", None
                                 )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation


In the EPD path, `MultiModalEmbeddingData.get_embedding(is_concat=True)` currently moves the concatenated embedding to CPU via `.to("cpu", non_blocking=True)` before returning it to the caller on the receiver side.
This extra H2D→D2H round trip was introduced alongside https://github.com/sgl-project/sglang/pull/16503, but it is redundant here:
- The downstream consumer in `python/sglang/srt/managers/mm_utils.py` (`general_mm_embed_routine`) already performs its own `mm_item.feature.to("cpu", non_blocking=True)` / `precomputed_embeddings.to("cpu", non_blocking=True)` offload when `language_only` is enabled.
- Forcing the transfer earlier inside the receiver adds a synchronous-ish copy on the hot path and causes measurable performance regression in EPD runs, without providing any additional OOM protection that `mm_utils.py` does not already cover.


## Modifications

- `python/sglang/srt/disaggregation/encode_receiver.py`: drop the `.to("cpu", non_blocking=True)` in `MultiModalEmbeddingData.get_embedding`, returning the concatenated CUDA tensor directly and letting `mm_utils.py` handle offloading.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
