### PR TITLE
[BugFix][EPD] fix embedding req_id transfer error

### DIFF
--- a/python/sglang/srt/disaggregation/encode_receiver.py
+++ b/python/sglang/srt/disaggregation/encode_receiver.py
@@ -343,7 +343,12 @@ class MultiModalEmbeddingData(EmbeddingData):
         return kwargs
 
     def add(self, embedding_data: EmbeddingData):
-        assert self.req_id == embedding_data.req_id
+        if self.req_id != embedding_data.req_id:
+            logger.warning(
+                f"Dropping embedding data with mismatched req_id: "
+                f"expected {self.req_id}, got {embedding_data.req_id}"
+            )
+            return False
         assert not self.ready_list[embedding_data.part_idx]
         pid = embedding_data.part_idx
         self.ready_list[pid] = True
@@ -520,6 +525,13 @@ class WaitingImageRequest:
                 self.status = WaitingImageRequestStatus.FAIL
                 self.recv_socket.close()
                 return
+
+            if recv_obj.req_id != self.recv_req.rid:
+                logger.warning(
+                    f"Dropping stale embedding data: expected rid={self.recv_req.rid}, "
+                    f"got rid={recv_obj.req_id} (likely from ZMQ port reuse)"
+                )
+                continue
 
             buffer = parts[1].buffer if hasattr(parts[1], "buffer") else parts[1]
             recv_obj.embedding = (

--- a/python/sglang/srt/disaggregation/encode_receiver.py
+++ b/python/sglang/srt/disaggregation/encode_receiver.py
@@ -526,12 +526,16 @@ class WaitingImageRequest:
                 self.recv_socket.close()
                 return
 
-            if recv_obj.req_id != self.recv_req.rid:
+            # Extract original req_id from part_req_id and drop stale payloads
+            # that may arrive on a reused ZMQ port after a prior request aborted.
+            original_req_id = extract_original_req_id(recv_obj.req_id)
+            if original_req_id != self.recv_req.rid:
                 logger.warning(
                     f"Dropping stale embedding data: expected rid={self.recv_req.rid}, "
                     f"got rid={recv_obj.req_id} (likely from ZMQ port reuse)"
                 )
                 continue
+            recv_obj.req_id = original_req_id
 
             buffer = parts[1].buffer if hasattr(parts[1], "buffer") else parts[1]
             recv_obj.embedding = (
@@ -539,12 +543,6 @@ class WaitingImageRequest:
                 .reshape(recv_obj.shape)
                 .clone()
             )
-
-            # Extract original req_id from part_req_id
-            part_req_id = recv_obj.req_id
-            original_req_id = extract_original_req_id(part_req_id)
-            # Update recv_obj.req_id to original for aggregation
-            recv_obj.req_id = original_req_id
 
             if self.recv_embedding_data is None:
                 self.recv_embedding_data = MultiModalEmbeddingData.from_embedding_data(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

In the EPD path, each incoming request on the language side allocates a dedicated ZMQ `PULL` socket on a dynamically assigned port (`get_zmq_socket_on_host`) and sends that port to the encoder, so the encoder can push the embedding back over it.
When a request is aborted (e.g. client disconnect / timeout / upstream error), `WaitingImageRequest` calls `self.recv_socket.close()` and the port is released back to the OS **immediately**, while the encoder side may still be in the middle of computing / sending that request's embedding. The race then plays out as:
1. Request A allocates port P and tells the encoder to push to P.
2. Request A is aborted → `recv_socket.close()` releases P.
3. Request B arrives and `get_zmq_socket_on_host` picks the same port P.
4. The encoder (which did not know about the abort) finishes A's forward and pushes A's embedding bytes to port P, where B's socket is now listening.
5. B reads A's payload, sees `req_id_A != rid_B`, and either trips `assert self.req_id == embedding_data.req_id` in `MultiModalEmbeddingData.add` (crashing the scheduler) or mixes A's embedding into B's aggregation buffer.
This PR makes the receiver tolerant of this port-reuse race by detecting and discarding stale payloads instead of asserting / corrupting data.

## Modifications


`python/sglang/srt/disaggregation/encode_receiver.py`:
- `WaitingImageRequest._try_recv_mm_data`: after `pickle.loads`, call `extract_original_req_id(recv_obj.req_id)` first, then
  - if it does not match `self.recv_req.rid`, log a warning and `continue` (skip buffer decode as well, so stale messages cost nothing);
- `MultiModalEmbeddingData.add`: relax the hard `assert` on `req_id` to a warning + early `return False`, as a defense-in-depth fallback for any stale part that slips past the outer check.


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
