### PR TITLE
fix: replace bare except with specific exception types in model_runner.py

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -491,7 +491,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                     self.eagle_aux_hidden_state_layer_ids = eagle_config[
                         "eagle_aux_hidden_state_layer_ids"
                     ]
-                except:
+                except (AttributeError, KeyError, TypeError):
                     # if there is no aux layer, set to None
                     self.eagle_aux_hidden_state_layer_ids = None
 
@@ -1175,7 +1175,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                     from mooncake import ep as mooncake_ep
 
                     mooncake_ep.set_device_filter(mooncake_ib_device)
-                except:
+                except (ImportError, RuntimeError):
                     pass  # A warning will be raised in `init_distributed_environment`
 
         before_avail_memory = get_available_gpu_memory(self.device, self.gpu_id)


### PR DESCRIPTION
## Motivation

Bare `except:` clauses catch all exceptions including `SystemExit` and `KeyboardInterrupt`, which can mask critical errors and prevent clean process shutdown. This follows the same pattern as #22947.

## Modifications

Replace two bare `except:` clauses in `model_runner.py` with specific exception types:

1. **EAGLE config access** (line 389): `except:` → `except (AttributeError, KeyError, TypeError):`
   - Handles missing `eagle_config` attribute, missing dict keys, and `None.get()` calls

2. **mooncake import** (line 1008): `except:` → `except (ImportError, RuntimeError):`
   - Handles missing mooncake package and device filter setup failures

## Checklist
- [x] Format: `pre-commit run --all-files` passes
- [x] No new tests needed (exception handling refinement only)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27469901539](https://github.com/sgl-project/sglang/actions/runs/27469901539)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27469901474](https://github.com/sgl-project/sglang/actions/runs/27469901474)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->