### PR TITLE
fix(nixl): avoid UnboundLocalError in create_backend error handler

### DIFF
--- a/python/sglang/srt/mem_cache/storage/nixl/nixl_utils.py
+++ b/python/sglang/srt/mem_cache/storage/nixl/nixl_utils.py
@@ -157,7 +157,7 @@ class NixlBackendSelection:
 
         except Exception as e:
             logger.error(
-                f"Failed to create NIXL backend: {e}, backend_name {self.backend_name}, supported plugins {plugin_list} initparams {initparams}"
+                f"Failed to create NIXL backend: {e}, backend_name {self.backend_name}, supported plugins {locals().get('plugin_list', 'N/A')} initparams {locals().get('initparams', 'N/A')}"
             )
             return False
 


### PR DESCRIPTION
## Motivation

In `NixlBackendSelection.create_backend()`, if `agent.get_plugin_list()` (line 101) raises an exception, the `except` block at line 158-161 references `plugin_list` and `initparams` — variables that were never assigned. This turns the original exception into an `UnboundLocalError`, hiding the real failure.

## Modifications

Use `locals().get()` to safely reference these variables in the error log message.

## Checklist

- [x] `format.sh` and `lint.sh` passed locally