### PR TITLE
[diffusion] remove heterogeneous ltx23 guider batching

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/ltx_2_denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/ltx_2_denoising.py
@@ -976,7 +976,7 @@ class LTX2DenoisingStage(DenoisingStage):
                     encoder_attention_mask=negative_encoder_attention_mask,
                 ),
             ]
-            if need_perturbed:
+            if not use_cfg_pair_batch and need_perturbed:
                 pass_specs.append(
                     LTX2GuidancePassSpec(
                         name="perturbed",
@@ -991,7 +991,7 @@ class LTX2DenoisingStage(DenoisingStage):
                         ),
                     )
                 )
-            if need_modality:
+            if not use_cfg_pair_batch and need_modality:
                 pass_specs.append(
                     LTX2GuidancePassSpec(
                         name="modality",
@@ -1032,7 +1032,7 @@ class LTX2DenoisingStage(DenoisingStage):
                     [pass_spec.encoder_attention_mask for pass_spec in pass_specs]
                 ),
             )
-            if use_split_two_stage_ti2v_guider or not use_cfg_pair_batch:
+            if use_split_two_stage_ti2v_guider:
                 split_sizes = [1] * expanded_batch_size
                 batched_video_chunks = []
                 batched_audio_chunks = []
@@ -1084,6 +1084,53 @@ class LTX2DenoisingStage(DenoisingStage):
             v_neg, a_v_neg = pass_outputs["neg"]
             v_ptb, a_v_ptb = pass_outputs.get("perturbed", (None, None))
             v_mod, a_v_mod = pass_outputs.get("modality", (None, None))
+
+            if use_cfg_pair_batch:
+                v_ptb = None
+                a_v_ptb = None
+                if need_perturbed:
+                    with set_forward_context(
+                        current_timestep=step.step_index,
+                        attn_metadata=step.attn_metadata,
+                    ):
+                        v_ptb, a_v_ptb = step.current_model(
+                            **self._build_ltx2_model_kwargs(
+                                ctx,
+                                base_model_kwargs,
+                                encoder_hidden_states=encoder_hidden_states,
+                                audio_encoder_hidden_states=audio_encoder_hidden_states,
+                                encoder_attention_mask=encoder_attention_mask,
+                                skip_video_self_attn_blocks=tuple(
+                                    stage1_guider_params["video_stg_blocks"]
+                                ),
+                                skip_audio_self_attn_blocks=tuple(
+                                    stage1_guider_params["audio_stg_blocks"]
+                                ),
+                            )
+                        )
+                    v_ptb = v_ptb.float()
+                    a_v_ptb = a_v_ptb.float()
+
+                v_mod = None
+                a_v_mod = None
+                if need_modality:
+                    with set_forward_context(
+                        current_timestep=step.step_index,
+                        attn_metadata=step.attn_metadata,
+                    ):
+                        v_mod, a_v_mod = step.current_model(
+                            **self._build_ltx2_model_kwargs(
+                                ctx,
+                                base_model_kwargs,
+                                encoder_hidden_states=encoder_hidden_states,
+                                audio_encoder_hidden_states=audio_encoder_hidden_states,
+                                encoder_attention_mask=encoder_attention_mask,
+                                disable_a2v_cross_attn=True,
+                                disable_v2a_cross_attn=True,
+                            )
+                        )
+                    v_mod = v_mod.float()
+                    a_v_mod = a_v_mod.float()
 
         sigma_val = float(sigma.item())
         video_sigma_for_x0: float | torch.Tensor = sigma_val

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/ltx_2_denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/ltx_2_denoising.py
@@ -288,6 +288,31 @@ class LTX2DenoisingStage(DenoisingStage):
             return False
         return not is_ltx2_two_stage_pipeline_name(server_args.pipeline_class_name)
 
+    @staticmethod
+    def _should_use_ltx23_two_stage_cfg_pair_batch(
+        batch: Req,
+        ctx: LTX2DenoisingContext,
+        server_args: ServerArgs,
+    ) -> bool:
+        """Only batch stage-1 guider passes whose execution graph is identical.
+
+        For native LTX-2.3 two-stage guider passes, `cond` and `neg` differ only in
+        text conditioning, so they can share one CFG pair batch. `perturbed` changes
+        the executed graph by skipping selected video/audio self-attention blocks, and
+        `modality` changes it by disabling A2V/V2A cross-attention. Those two passes
+        must remain separate forwards rather than being mixed into the same batch as
+        `cond`/`neg`, otherwise the stage-1 guider drifts from the sequential
+        reference.
+        """
+        if not is_ltx2_two_stage_pipeline_name(server_args.pipeline_class_name):
+            return False
+        if not ctx.is_ltx23_variant or ctx.use_ltx23_legacy_one_stage:
+            return False
+        if int(getattr(batch, "ltx2_num_image_tokens", 0)) > 0:
+            return False
+        if get_sp_world_size() != 1:
+            return False
+        return True
     @classmethod
     def _ltx2_calculate_guided_x0(
         cls,
@@ -931,6 +956,11 @@ class LTX2DenoisingStage(DenoisingStage):
                 is_ltx2_two_stage_pipeline_name(server_args.pipeline_class_name)
                 and int(getattr(batch, "ltx2_num_image_tokens", 0)) > 0
             )
+            use_cfg_pair_batch = self._should_use_ltx23_two_stage_cfg_pair_batch(
+                batch=batch,
+                ctx=ctx,
+                server_args=server_args,
+            )
 
             pass_specs: list[LTX2GuidancePassSpec] = [
                 LTX2GuidancePassSpec(
@@ -1002,7 +1032,7 @@ class LTX2DenoisingStage(DenoisingStage):
                     [pass_spec.encoder_attention_mask for pass_spec in pass_specs]
                 ),
             )
-            if use_split_two_stage_ti2v_guider:
+            if use_split_two_stage_ti2v_guider or not use_cfg_pair_batch:
                 split_sizes = [1] * expanded_batch_size
                 batched_video_chunks = []
                 batched_audio_chunks = []


### PR DESCRIPTION
## Motivation

For native LTX-2.3 two-stage guider passes, only passes with the same execution graph should share a batched forward.

`cond` and `neg` differ only in text conditioning, so they can be kept as one CFG-pair batch. But `perturbed` and `modality` change the executed graph:

- `perturbed` skips selected self-attention blocks
- `modality` disables A2V/V2A cross attention

Mixing those passes into the same batched forward changes stage-1 guider numerics enough to drift from the sequential reference.

## Changes

- add `_should_use_ltx23_two_stage_cfg_pair_batch()`
- only keep CFG-pair batching for native LTX-2.3 two-stage non-TI2V requests
- force heterogeneous guider passes to run as separate forwards
- document the execution-graph rule in the helper docstring


## Validation

Behavioral extraction only in this split PR. No new test run in this branch.