### PR TITLE
[scheduler] guard _check_mamba_pool against allocators without free_pages

### DIFF
--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -340,9 +340,19 @@ class SchedulerRuntimeCheckerMixin:
             self.req_to_token_pool.mamba_pool.size,
         )
         if leak:
-            # Page-level leak diagnosis for mamba
+            # Page-level leak diagnosis for mamba. Skip the full-page part
+            # when the underlying allocator does not expose ``free_pages``
+            # (e.g. paged allocators used by some hybrid-SSM models) --
+            # without this guard the diagnosis itself crashes the scheduler
+            # with ``AttributeError: 'NoneType' object has no attribute
+            # 'tolist'`` while trying to report the leak.
+            free_pages_attr = getattr(
+                self.token_to_kv_pool_allocator, "free_pages", None
+            )
+            if free_pages_attr is None:
+                return leak, msg
             free_full_pages = set(
-                self.token_to_kv_pool_allocator.free_pages.tolist()
+                free_pages_attr.tolist()
                 + self.token_to_kv_pool_allocator.release_pages.tolist()
             )
             cached_full_pages = set(self.tree_cache.all_values_flatten().tolist())

--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -340,12 +340,7 @@ class SchedulerRuntimeCheckerMixin:
             self.req_to_token_pool.mamba_pool.size,
         )
         if leak:
-            # Page-level leak diagnosis for mamba. Skip the full-page part
-            # when the underlying allocator does not expose ``free_pages``
-            # (e.g. paged allocators used by some hybrid-SSM models) --
-            # without this guard the diagnosis itself crashes the scheduler
-            # with ``AttributeError: 'NoneType' object has no attribute
-            # 'tolist'`` while trying to report the leak.
+            # Skip page-level diagnosis when allocator has no `free_pages`.
             free_pages_attr = getattr(
                 self.token_to_kv_pool_allocator, "free_pages", None
             )


### PR DESCRIPTION
## Motivation

Some hybrid-SSM backends use paged allocators that do not expose a `free_pages` attribute (i.e. `token_to_kv_pool_allocator.free_pages is None`). When `_check_mamba_pool` detects a leak, the page-level diagnosis path hits `free_pages.tolist()` unconditionally, so the diagnosis itself crashes the scheduler with:

```
AttributeError: 'NoneType' object has no attribute 'tolist'
```

— hiding the actual leak report under a noisy traceback.

## Modifications

Guard the `free_pages` access with `getattr(..., None)` and bail out of the page-level portion if it's missing. The leak is still surfaced via the `(leak, msg)` returned up to `_check_all_pools`; only the per-page diagnostics are skipped.

```python
free_pages_attr = getattr(self.token_to_kv_pool_allocator, "free_pages", None)
if free_pages_attr is None:
    return leak, msg
```

No behavior change for allocators that do expose `free_pages`.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit)
- [x] Add unit tests as outlined in the [Running Unit Tests & Adding to CI](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci) — N/A, defensive fallback; only triggers on already-leaking state.
- [x] Update documentation / docstrings — added an explanatory comment in the guard.