### PR TITLE
[session] fix mamba pool leak in StreamingSession.release_session + plumb idle leak check

### DIFF
--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -167,6 +167,9 @@ class SchedulerRuntimeCheckerMixin:
     def _session_held_req_count(self: Scheduler) -> int:
         return self.tree_cache.session_held_req_count()
 
+    def _session_held_mamba_slots(self: Scheduler) -> int:
+        return self.tree_cache.session_held_mamba_slots(self._active_pool_idxs())
+
     def get_pool_stats(self: Scheduler) -> PoolStats:
         if self.is_hybrid_swa:
             pool_stats = self._get_swa_token_info()
@@ -336,7 +339,7 @@ class SchedulerRuntimeCheckerMixin:
             ps.mamba_available_size,
             ps.mamba_evictable_size,
             self.tree_cache.mamba_protected_size(),
-            0,
+            self._session_held_mamba_slots(),
             self.req_to_token_pool.mamba_pool.size,
         )
         if leak:

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -280,9 +280,7 @@ class BasePrefixCache(ABC, PrefixCacheTrait):
     def session_held_req_count(self, active_pool_idxs: Optional[set] = None) -> int:
         return 0
 
-    def session_held_mamba_slots(
-        self, active_pool_idxs: Optional[set] = None
-    ) -> int:
+    def session_held_mamba_slots(self, active_pool_idxs: Optional[set] = None) -> int:
         return 0
 
     def is_chunk_cache(self) -> bool:

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -280,6 +280,11 @@ class BasePrefixCache(ABC, PrefixCacheTrait):
     def session_held_req_count(self, active_pool_idxs: Optional[set] = None) -> int:
         return 0
 
+    def session_held_mamba_slots(
+        self, active_pool_idxs: Optional[set] = None
+    ) -> int:
+        return 0
+
     def is_chunk_cache(self) -> bool:
         return False
 

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -812,6 +812,11 @@ class UnifiedRadixCache(BasePrefixCache):
     def session_held_req_count(self, active_pool_idxs: Optional[set] = None) -> int:
         return self.session.session_held_req_count(active_pool_idxs)
 
+    def session_held_mamba_slots(
+        self, active_pool_idxs: Optional[set] = None
+    ) -> int:
+        return self.session.session_held_mamba_slots(active_pool_idxs)
+
     def evictable_size(self) -> int:
         return self.component_evictable_size_.get(BASE_COMPONENT_TYPE, 0)
 

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -812,9 +812,7 @@ class UnifiedRadixCache(BasePrefixCache):
     def session_held_req_count(self, active_pool_idxs: Optional[set] = None) -> int:
         return self.session.session_held_req_count(active_pool_idxs)
 
-    def session_held_mamba_slots(
-        self, active_pool_idxs: Optional[set] = None
-    ) -> int:
+    def session_held_mamba_slots(self, active_pool_idxs: Optional[set] = None) -> int:
         return self.session.session_held_mamba_slots(active_pool_idxs)
 
     def evictable_size(self) -> int:

--- a/python/sglang/srt/session/streaming_session.py
+++ b/python/sglang/srt/session/streaming_session.py
@@ -408,6 +408,15 @@ class StreamingSession(BasePrefixCache):
                 self.token_to_kv_pool_allocator.free(kv_indices)
             self.req_to_token_pool.free_slots.append(slot.req_pool_idx)
 
+        # release_session must also return any mamba pool state the slot
+        # is holding. HybridReqToTokenPool.alloc batch-allocates one
+        # mamba_pool_idx plus, when the extra_buffer feature is enabled,
+        # ping-pong track buffer entries per fresh req; SessionSlot takes
+        # ownership of these in save_from_req, so without this they leak
+        # permanently -- each session close drops `1 + ping_pong_size`
+        # slots until the pool is starved.
+        self._free_slot_mamba(slot)
+
     def session_held_tokens(self, active_pool_idxs: Optional[set] = None) -> int:
         """Total KV tokens held by session slots, not tracked by the tree.
 
@@ -453,6 +462,40 @@ class StreamingSession(BasePrefixCache):
             return s.is_holding_kv and not in_batch
 
         return sum(_owned(s) for s in self.slots.values())
+
+    def session_held_mamba_slots(
+        self, active_pool_idxs: Optional[set] = None
+    ) -> int:
+        """Total mamba_pool entries held by session slots (mamba_pool_idx +
+        mamba_ping_pong_track_buffer). Excludes slots whose owning req is
+        currently in the batch -- those slots are counted via the normal
+        alloc/free paths (same convention as the sibling ``session_held_*``
+        accessors).
+        """
+        total = 0
+        for slot in self.slots.values():
+            in_batch = (
+                active_pool_idxs is not None and slot.req_pool_idx in active_pool_idxs
+            )
+            if in_batch:
+                continue
+            if slot.mamba_pool_idx is not None:
+                total += slot.mamba_pool_idx.numel()
+            if slot.mamba_ping_pong_track_buffer is not None:
+                total += slot.mamba_ping_pong_track_buffer.numel()
+        return total
+
+    def _free_slot_mamba(self, slot: SessionSlot) -> None:
+        """Return a session slot's mamba pool state to the allocator."""
+        mamba_pool = getattr(self.req_to_token_pool, "mamba_pool", None)
+        if mamba_pool is None:
+            return
+        if slot.mamba_pool_idx is not None:
+            mamba_pool.free(slot.mamba_pool_idx.unsqueeze(0))
+            slot.mamba_pool_idx = None
+        if slot.mamba_ping_pong_track_buffer is not None:
+            mamba_pool.free(slot.mamba_ping_pong_track_buffer)
+            slot.mamba_ping_pong_track_buffer = None
 
     # -- Internal helpers (streaming body bits) --
 

--- a/python/sglang/srt/session/streaming_session.py
+++ b/python/sglang/srt/session/streaming_session.py
@@ -456,9 +456,7 @@ class StreamingSession(BasePrefixCache):
 
         return sum(_owned(s) for s in self.slots.values())
 
-    def session_held_mamba_slots(
-        self, active_pool_idxs: Optional[set] = None
-    ) -> int:
+    def session_held_mamba_slots(self, active_pool_idxs: Optional[set] = None) -> int:
         """Total mamba_pool entries held by session slots (mamba_pool_idx +
         mamba_ping_pong_track_buffer). Excludes slots whose owning req is
         currently in the batch -- those slots are counted via the normal

--- a/python/sglang/srt/session/streaming_session.py
+++ b/python/sglang/srt/session/streaming_session.py
@@ -408,13 +408,6 @@ class StreamingSession(BasePrefixCache):
                 self.token_to_kv_pool_allocator.free(kv_indices)
             self.req_to_token_pool.free_slots.append(slot.req_pool_idx)
 
-        # release_session must also return any mamba pool state the slot
-        # is holding. HybridReqToTokenPool.alloc batch-allocates one
-        # mamba_pool_idx plus, when the extra_buffer feature is enabled,
-        # ping-pong track buffer entries per fresh req; SessionSlot takes
-        # ownership of these in save_from_req, so without this they leak
-        # permanently -- each session close drops `1 + ping_pong_size`
-        # slots until the pool is starved.
         self._free_slot_mamba(slot)
 
     def session_held_tokens(self, active_pool_idxs: Optional[set] = None) -> int:


### PR DESCRIPTION
## Motivation

`StreamingSession.release_session` frees KV tokens and the req-pool slot but **does not release the mamba pool state** the slot is holding (`mamba_pool_idx` + `mamba_ping_pong_track_buffer`).

`HybridReqToTokenPool.alloc` batch-allocates one `mamba_pool_idx` plus, when the extra-buffer feature is enabled, several ping-pong track buffer entries per fresh req. `SessionSlot.save_from_req` takes ownership of all of these, so every session close leaks `1 + ping_pong_size` mamba slots permanently. For hybrid-SSM models that rely on short-lived sessions (e.g. full-duplex/streaming inference over mamba backbones), the pool is slowly starved until max concurrency collapses.

Related: on the sibling pool check, `_check_mamba_pool` passes a hard-coded `0` for session-held slots, so once any session is open with held mamba state the idle invariant check fires a false-positive leak warning every tick.

This PR restores on the current file layout the fix that originally shipped as an internal patch against the (now renamed) `session_aware_cache.py`; the rename to `sglang/srt/session/streaming_session.py` dropped the mamba-freeing call.

## Modifications

- **`streaming_session.py`**
  - Add `_free_slot_mamba(slot)` helper that returns both `mamba_pool_idx` (via `mamba_pool.free(idx.unsqueeze(0))`) and `mamba_ping_pong_track_buffer` to the allocator, no-op if the underlying `req_to_token_pool` has no `mamba_pool`.
  - Call it at the end of `release_session`.
  - Add `session_held_mamba_slots(active_pool_idxs)` matching the sibling `session_held_*` accessors (excludes slots whose owning req is currently in the batch — those are accounted for via the normal alloc/free paths).

- **`mem_cache/base_prefix_cache.py`** — default `session_held_mamba_slots` stub returning 0.
- **`mem_cache/unified_radix_cache.py`** — passthrough to `self.session.session_held_mamba_slots`.
- **`managers/scheduler_runtime_checker_mixin.py`**
  - Add `_session_held_mamba_slots()` mirror of the existing `_session_held_tokens` / `_session_held_swa_tokens` helpers.
  - Pass it into `_check_pool_invariant` for the mamba pool instead of the hard-coded `0`.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit)
- [x] Add unit tests as outlined in the [Running Unit Tests & Adding to CI](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci) — verified internally via a mock-full-duplex regression test that opens/closes many streaming sessions and asserts no mamba-pool drift; happy to port the test to OSS CI if reviewers want it.
- [x] Update documentation / docstrings — docstrings added to the new methods.