### PR TITLE
[CI] Export GB200 nightly logs to S3 

### DIFF
--- a/.github/workflows/nightly-72-gpu-gb200.yml
+++ b/.github/workflows/nightly-72-gpu-gb200.yml
@@ -368,6 +368,26 @@ jobs:
             echo "No log tarball found, skipping analysis"
           fi
 
+      - name: Upload AI analysis to S3
+        if: failure()
+        continue-on-error: true
+        env:
+          ISL: ${{ matrix.config.isl }}
+          OSL: ${{ matrix.config.osl }}
+        run: |
+          ANALYSIS="${{ github.workspace }}/ai_analysis.md"
+          [ -f "$ANALYSIS" ] || { echo "no ai_analysis.md, skipping"; exit 0; }
+          case "${{ github.event_name }}" in
+            schedule)          TRIGGER=cron ;;
+            workflow_dispatch) TRIGGER=manual ;;
+            *)                 TRIGGER="${{ github.event_name }}" ;;
+          esac
+          fmt() { if [ $(( $1 % 1024 )) -eq 0 ]; then echo "$(( $1 / 1024 ))k"; else echo "$1"; fi; }
+          SEQ_LEN="$(fmt "$ISL")$(fmt "$OSL")"
+          KEY="${TRIGGER}/${{ github.run_id }}-${{ github.run_attempt }}/${SEQ_LEN}/${{ matrix.config.name }}/ai_analysis.md"
+          aws --endpoint-url "$S3_ENDPOINT_URL" s3 cp "$ANALYSIS" "s3://${S3_BUCKET}/${KEY}"
+          echo "uploaded to s3://${S3_BUCKET}/${KEY}"
+
       - name: Clean up Slurm jobs on failure/cancel
         if: failure() || cancelled()
         continue-on-error: true

--- a/.github/workflows/nightly-72-gpu-gb200.yml
+++ b/.github/workflows/nightly-72-gpu-gb200.yml
@@ -287,8 +287,15 @@ jobs:
       OSL: ${{ matrix.config.osl }}
       CONFIG_FILE: ${{ matrix.config.config_file }}
       RESULT_FILENAME: gb200-${{ matrix.config.name }}
+      MATRIX_CONFIG_NAME: ${{ matrix.config.name }}
       SQUASH_FILE: ${{ needs.prepare-image.outputs.squash_file }}
       NGINX_SQUASH_FILE: ${{ needs.prepare-image.outputs.nginx_squash_file }}
+      # S3 log-upload credentials — consumed by srt-slurm's postprocess stage
+      # to upload /logs after each Slurm job; prefix derived in launch_gb200.sh.
+      AWS_ACCESS_KEY_ID: ${{ secrets.NV_S3_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.NV_S3_SECRET_ACCESS_KEY }}
+      S3_BUCKET: ${{ secrets.NV_S3_BUCKET }}
+      S3_ENDPOINT_URL: ${{ secrets.NV_S3_ENDPOINT_URL }}
 
     steps:
       - name: Checkout code

--- a/scripts/ci/slurm/launch_gb200.sh
+++ b/scripts/ci/slurm/launch_gb200.sh
@@ -17,6 +17,11 @@
 #   SLURM_ACCOUNT     - Slurm account  (default: sglang)
 #   SRT_SLURM_BRANCH  - branch of srt-slurm repo to check out
 #   GITHUB_WORKSPACE  - set automatically by GitHub Actions
+#   MATRIX_CONFIG_NAME- matrix entry name (e.g. dsr1-fp4-1k1k-mid-curve); used in S3 prefix
+#   S3_BUCKET         - MinIO bucket for benchmark log uploads
+#   S3_ENDPOINT_URL   - MinIO endpoint URL (e.g. https://minio.<host>.nip.io)
+#   AWS_ACCESS_KEY_ID - writer access key for S3_BUCKET (via GH secrets)
+#   AWS_SECRET_ACCESS_KEY - writer secret key for S3_BUCKET (via GH secrets)
 
 set -euo pipefail
 set -x
@@ -90,6 +95,31 @@ fi
 # ---------------------------------------------------------------------------
 SRTCTL_ROOT="$SRT_REPO_DIR"
 
+: "${S3_BUCKET:?S3_BUCKET must be set}"
+: "${S3_ENDPOINT_URL:?S3_ENDPOINT_URL must be set}"
+: "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID must be set}"
+: "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY must be set}"
+: "${MATRIX_CONFIG_NAME:?MATRIX_CONFIG_NAME must be set}"
+: "${GITHUB_RUN_ID:?GITHUB_RUN_ID must be set}"
+: "${GITHUB_RUN_ATTEMPT:?GITHUB_RUN_ATTEMPT must be set}"
+
+# Map the GitHub trigger into a friendlier top-level prefix: cron/manual.
+case "${GITHUB_EVENT_NAME:-}" in
+    schedule)          TRIGGER=cron ;;
+    workflow_dispatch) TRIGGER=manual ;;
+    *)                 TRIGGER="${GITHUB_EVENT_NAME:-unknown}" ;;
+esac
+
+# Format ISL/OSL as "1k1k" / "1k8k" / "8k1k" etc. for the S3 prefix, so logs
+# group naturally by sequence-length bucket under each run.
+fmt_seq_len() {
+    local n=$1
+    if (( n % 1024 == 0 )); then echo "$((n / 1024))k"; else echo "$n"; fi
+}
+SEQ_LEN="$(fmt_seq_len "$ISL")$(fmt_seq_len "$OSL")"
+
+S3_PREFIX="${TRIGGER}/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}/${SEQ_LEN}/${MATRIX_CONFIG_NAME}"
+
 cat > srtslurm.yaml <<EOF
 # SRT SLURM configuration for SGLang GB200 nightly CI
 default_account: "${SLURM_ACCOUNT}"
@@ -108,10 +138,20 @@ containers:
   dynamo-sglang: ${SQUASH_FILE}
   nginx: ${NGINX_SQUASH_FILE}
   nginx-sqsh: ${NGINX_SQUASH_FILE}
+
+# srt-slurm postprocess uploads /logs to this bucket after each Slurm job.
+# Credentials are read from AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY env vars,
+# not written to disk. srt-slurm appends /<date>/<slurm-job-id>/ after prefix.
+reporting:
+  s3:
+    bucket: "${S3_BUCKET}"
+    prefix: "${S3_PREFIX}"
+    endpoint_url: "${S3_ENDPOINT_URL}"
 EOF
 
 echo "--- srtslurm.yaml ---"
 cat srtslurm.yaml
+echo "--- S3 log upload: s3://${S3_BUCKET}/${S3_PREFIX}/ ---"
 
 make setup ARCH=aarch64
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Today the only way to see srtslurm logs from a GB200 nightly run is to access them directly from the cluster which causes friction when a dev needs to dig into a failure past the AI summary that's already in the step output. This PR pipes the full /logs directory (prefill / decode / frontend worker .out files, benchmark-rollup.json, postprocess.log, sweep_*.log, etc.) to an S3-compatible backend after every run, keyed by trigger / run id / seq-len / config / date — so devs can mc cp --recursive s3://... or browse via the MinIO web console. Backend (MinIO on a Brev instance) is stood up separately; this PR wires the sglang pipeline to use it.

## Modifications

<!-- Detail the changes made in this pull request. -->

scripts/ci/slurm/launch_gb200.sh
  - Appends a reporting.s3 block to the generated srtslurm.yaml
  - Computes the S3 prefix from the trigger (cron or manual), GitHub run_id-attempt, seq-len bucket (1k1k / 8k1k / etc.), and matrix config name
  - S3 credentials flow through the env (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY) — not written to disk
  - Validates that S3_BUCKET, S3_ENDPOINT_URL, and the AWS creds are present before generating the config; fails early with a clear error otherwise

  .github/workflows/nightly-72-gpu-gb200.yml
  - Adds four new env vars to nightly-gb200-benchmark (sourced from existing repo secrets):
    - AWS_ACCESS_KEY_ID ← secrets.NV_S3_ACCESS_KEY_ID
    - AWS_SECRET_ACCESS_KEY ← secrets.NV_S3_SECRET_ACCESS_KEY
    - S3_BUCKET ← secrets.NV_S3_BUCKET
    - S3_ENDPOINT_URL ← secrets.NV_S3_ENDPOINT_URL
  - Adds MATRIX_CONFIG_NAME: ${{ matrix.config.name }} so the launch script can include it in the S3 path without re-deriving it from config metadata

 S3 path layout:
```
  s3://<bucket>/<trigger>/<run_id>-<attempt>/<seq_len>/<config>/<date>/<slurm_job>/<bench_subdir>/<files>
  ```

  Example:
  ```
  s3://sglang-ci-logs/cron/24591826053-1/1k1k/dsr1-fp8-1k1k-max-tpt/2026-04-18/4665/sa-bench_isl_1024_osl_1024/results_concurrency_1024_gpus_48_ctx_16_gen_32.json
  ```

  The `s3://` URI is the canonical CLI form — bucket + key, host-agnostic. Clients (`aws`, `mc`, `boto3`) resolve the actual endpoint from `--endpoint-url` / `AWS_ENDPOINT_URL` (supplied via the `S3_ENDPOINT_URL` secret in CI).

  Equivalent URLs by use case:

  | Audience | URL |
  |---|---|
  | CLI (`aws s3 cp`, `mc cp`) | `s3://sglang-ci-logs/<path>` (with `--endpoint-url $S3_ENDPOINT_URL`) |
  | Browse via MinIO console | `https://sgl-ci-logs-khjfeoysf.brevlab.com/browser/sglang-ci-logs/<url-encoded-path>` |
  | Raw HTTP (signed request) | `$S3_ENDPOINT_URL/sglang-ci-logs/<path>` |

  Team-facing fetch snippet:

  ```bash
  # reader-only credentials
  mc alias set sglang-ci "$SGLANG_CI_S3_ENDPOINT" "$SGLANG_CI_READER_KEY" "$SGLANG_CI_READER_SECRET"
  mc cp --recursive sglang-ci/sglang-ci-logs/cron/<run-id>-<attempt>/<seq-len>/<config>/ ./logs/
  ```

https://github.com/sgl-project/sglang/actions/runs/24803056480

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
