### PR TITLE
[CI] Broaden stage-b-test-4-gpu-b200 runner pool to low-disk label

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -905,7 +905,10 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    runs-on: ${{ needs.check-changes.outputs.b200_runner }}
+    # The `*-low-disk` label (resolved by `set-runner` to `4-gpu-b200-low-disk` or
+    # `4-gpu-b200-kernel-low-disk`) is advertised by both the existing large-disk B200
+    # runners and the new low-disk runner, so this job can land on either pool.
+    runs-on: ${{ needs.check-changes.outputs.b200_low_disk_runner }}
     timeout-minutes: 240
     strategy:
       fail-fast: false

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -905,10 +905,8 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    # The `*-low-disk` label (resolved by `set-runner` to `4-gpu-b200-low-disk` or
-    # `4-gpu-b200-kernel-low-disk`) is advertised by both the existing large-disk B200
-    # runners and the new low-disk runner, so this job can land on either pool.
-    runs-on: ${{ needs.check-changes.outputs.b200_low_disk_runner }}
+    # TEMP: hardcoded to 4-gpu-b200-low-disk-test for testing the new runner pool.
+    runs-on: 4-gpu-b200-low-disk-test
     timeout-minutes: 240
     strategy:
       fail-fast: false

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -905,8 +905,10 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    # TEMP: hardcoded to 4-gpu-b200-low-disk-test for testing the new runner pool.
-    runs-on: 4-gpu-b200-low-disk-test
+    # The `*-low-disk` label (resolved by `set-runner` to `4-gpu-b200-low-disk` or
+    # `4-gpu-b200-kernel-low-disk`) is advertised by both the existing large-disk B200
+    # runners and the new low-disk runner, so this job can land on either pool.
+    runs-on: ${{ needs.check-changes.outputs.b200_low_disk_runner }}
     timeout-minutes: 240
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- Switch `stage-b-test-4-gpu-b200` from `b200_runner` (`4-gpu-b200` / `4-gpu-b200-kernel`) to `b200_low_disk_runner` (`4-gpu-b200-low-disk` / `4-gpu-b200-kernel-low-disk`).
- The `*-low-disk` label is advertised by both the existing large-disk B200 runners and the new low-disk runners, so this job can now land on either pool — matching the pattern already used by the partitioned B200 job further down in the same workflow.

## Test plan
- [ ] `/rerun-stage stage-b-test-4-gpu-b200` lands on a runner from either pool and succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)