### PR TITLE
[gRPC] Native server: Python bridge entrypoint (2/4)

### DIFF
--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -146,9 +146,10 @@ class RuntimeHandle:
         ``payload_coro_factory`` is a zero-arg callable returning a coroutine
         that awaits the operation and returns the success payload (dict/list).
         ``error_payload_fn`` maps a caught exception to the payload sent on
-        the error path; defaults to ``{"message": str(e)}``.
+        the error path; defaults to ``{"error": {"message": str(e)}}``,
+        matching the OpenAI passthrough error shape.
         """
-        error_fn = error_payload_fn or (lambda e: {"message": str(e)})
+        error_fn = error_payload_fn or (lambda e: {"error": {"message": str(e)}})
 
         async def _run() -> None:
             try:
@@ -205,7 +206,14 @@ class RuntimeHandle:
         }
         return self._openai_serving_classes
 
-    def submit_request(self, *, req_type: str, req_dict: dict, chunk_callback):
+    def submit_request(
+        self,
+        *,
+        req_type: str,
+        req_dict: dict,
+        chunk_callback,
+        is_disconnected_fn: Optional[Callable[[], bool]] = None,
+    ):
         """Submit a generate or embed request from a pre-built dict.
 
         The Rust gRPC server builds ``req_dict`` directly from proto fields,
@@ -216,53 +224,82 @@ class RuntimeHandle:
             req_type: "generate" or "embed" (classify uses "embed").
             req_dict: Dict matching the dataclass constructor kwargs.
             chunk_callback: Rust-side PyO3 callback object.
+            is_disconnected_fn: Optional sync callable wrapping the Rust
+                cancellation token; lets TokenizerManager abort the request
+                when the gRPC client drops.
         """
+        mock_request = (
+            MockRequest(is_disconnected_fn=is_disconnected_fn)
+            if is_disconnected_fn is not None
+            else None
+        )
         if req_type == "generate":
             from sglang.srt.managers.io_struct import GenerateReqInput
 
             obj = GenerateReqInput(**req_dict)
             stream = req_dict.get("stream", False)
-            self._submit_on_tm_loop(self._run_generate(obj, chunk_callback, stream))
+            self._submit_on_tm_loop(
+                self._run_generate(obj, chunk_callback, stream, mock_request)
+            )
         elif req_type == "embed":
             from sglang.srt.managers.io_struct import EmbeddingReqInput
 
             obj = EmbeddingReqInput(**req_dict)
-            self._submit_on_tm_loop(self._run_embed(obj, chunk_callback))
+            self._submit_on_tm_loop(self._run_embed(obj, chunk_callback, mock_request))
         else:
             raise ValueError(
                 f"Unknown req_type: {req_type!r} (expected 'generate' or 'embed')"
             )
 
-    async def _run_generate(self, obj, chunk_callback, stream: bool):
+    async def _run_generate(self, obj, chunk_callback, stream: bool, request):
         try:
-            gen = self.tokenizer_manager.generate_request(obj, request=None)
+            gen = self.tokenizer_manager.generate_request(obj, request=request)
             if stream:
                 async for chunk in gen:
                     finished = (
                         chunk.get("meta_info", {}).get("finish_reason") is not None
                     )
-                    chunk_callback(chunk, finished=finished)
+                    self._safe_callback(chunk_callback, chunk, finished=finished)
                     if finished:
                         return
+                # Defensive: generator exited without a finish_reason chunk.
+                # Send a terminal callback so the Rust side closes the stream.
+                self._safe_callback(chunk_callback, {}, finished=True)
             else:
                 result = await gen.__anext__()
-                chunk_callback(result, finished=True)
+                self._safe_callback(chunk_callback, result, finished=True)
         except StopAsyncIteration:
             self._safe_callback(chunk_callback, {}, finished=True)
         except Exception as e:
             logger.error("gRPC generate error for rid=%s: %s", obj.rid, e)
-            self._safe_callback(chunk_callback, {}, finished=True, error=str(e))
+            self._safe_callback(
+                chunk_callback,
+                json.dumps({"error": {"message": str(e)}}).encode("utf-8"),
+                finished=True,
+                error=str(e),
+            )
 
-    async def _run_embed(self, obj, chunk_callback):
+    async def _run_embed(self, obj, chunk_callback, request):
         try:
-            gen = self.tokenizer_manager.generate_request(obj, request=None)
+            gen = self.tokenizer_manager.generate_request(obj, request=request)
             result = await gen.__anext__()
-            chunk_callback(result, finished=True)
+            self._safe_callback(chunk_callback, result, finished=True)
         except StopAsyncIteration:
             self._safe_callback(chunk_callback, {}, finished=True)
         except Exception as e:
             logger.error("gRPC embed error for rid=%s: %s", obj.rid, e)
-            self._safe_callback(chunk_callback, {}, finished=True, error=str(e))
+            self._safe_callback(
+                chunk_callback,
+                json.dumps({"error": {"message": str(e)}}).encode("utf-8"),
+                finished=True,
+                error=str(e),
+            )
+
+    # Bounded so a stuck TM loop can't deadlock the gRPC handler thread that
+    # called abort. abort_request only enqueues a message on the ZMQ socket,
+    # so a few seconds is generous; if we time out, log and drop — the client
+    # will retry or give up.
+    _ABORT_TIMEOUT_S = 5.0
 
     def abort(self, rid: str = "", abort_all: bool = False):
         """Abort a request by request ID or abort all active requests."""
@@ -281,7 +318,17 @@ class RuntimeHandle:
             self._abort_async(rid, abort_all),
             loop,
         )
-        future.result()
+        try:
+            future.result(timeout=self._ABORT_TIMEOUT_S)
+        except TimeoutError:
+            future.cancel()
+            logger.error(
+                "gRPC abort timed out after %ss (rid=%r, abort_all=%s); "
+                "tokenizer_manager loop appears stuck",
+                self._ABORT_TIMEOUT_S,
+                rid,
+                abort_all,
+            )
 
     async def _abort_async(self, rid: str, abort_all: bool) -> None:
         self.tokenizer_manager.abort_request(rid=rid, abort_all=abort_all)
@@ -301,16 +348,10 @@ class RuntimeHandle:
 
     def get_server_info(self) -> str:
         """Return server info as a JSON string."""
-        result: Dict[str, Any] = {}
-        try:
-            sa = self.server_args
-            if hasattr(sa, "model_config"):
-                sa = dataclasses.replace(sa)
-                if hasattr(sa, "model_config"):
-                    delattr(sa, "model_config")
-            result.update(dataclasses.asdict(sa))
-        except Exception:
-            pass
+        # dataclasses.asdict only walks declared fields, so dynamic attrs like
+        # ServerArgs.model_config (set lazily by get_model_config) are
+        # excluded automatically.
+        result: Dict[str, Any] = dict(dataclasses.asdict(self.server_args))
         result.update(self.scheduler_info)
         return json.dumps(result, default=str)
 
@@ -374,12 +415,7 @@ class RuntimeHandle:
             result = await self.tokenizer_manager.get_loads(dp_rank=dp_rank)
             return [dataclasses.asdict(r) for r in result]
 
-        self._submit_json_unary(
-            "get_load",
-            _payload,
-            chunk_callback,
-            error_payload_fn=lambda e: {"error": str(e)},
-        )
+        self._submit_json_unary("get_load", _payload, chunk_callback)
 
     def flush_cache(self, chunk_callback) -> None:
         """Flush the radix cache. Sends result through chunk_callback."""

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -1,0 +1,697 @@
+"""Python-side bridge between the Rust gRPC server and TokenizerManager.
+
+The RuntimeHandle exposes synchronous methods that Rust can call via PyO3
+(with a brief GIL acquisition). Response chunks are pushed into Rust-side
+channels via callback objects while all async work stays on the
+TokenizerManager's event loop.
+"""
+
+import asyncio
+import dataclasses
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class MockRequest:
+    """Lightweight stand-in for fastapi.Request when called from gRPC.
+
+    The OpenAI serving classes expect a fastapi.Request for disconnect
+    detection and routing key extraction. This satisfies that interface
+    without importing FastAPI.
+    """
+
+    def __init__(self, headers: Optional[Dict[str, str]] = None):
+        self.headers = headers or {}
+        self.url = type("URL", (), {"path": "/grpc"})()
+        self.state = type("State", (), {})()
+        self.app = type("App", (), {"state": type("AppState", (), {})()})()
+
+    async def is_disconnected(self) -> bool:
+        return False
+
+
+class RuntimeHandle:
+    """Thin Python handle that the Rust gRPC server calls into.
+
+    Provides synchronous ``submit_*``, ``abort``, and info methods.
+    Each submit method receives a ``chunk_callback`` (a Rust-side PyO3 object)
+    that it invokes with ``(chunk_dict, finished, error)`` for each response
+    chunk produced by TokenizerManager.
+    """
+
+    def __init__(
+        self,
+        tokenizer_manager,
+        template_manager,
+        server_args,
+        scheduler_info: Optional[Dict] = None,
+    ):
+        self.tokenizer_manager = tokenizer_manager
+        self.template_manager = template_manager
+        self.server_args = server_args
+        self.scheduler_info = scheduler_info or {}
+
+        self._openai_serving_classes = None
+
+    @property
+    def _tm_loop(self):
+        """Return the tokenizer_manager's event loop (uvicorn loop).
+
+        Communicator-based async methods (flush_cache, get_load, etc.) use
+        asyncio.Event internally, which only works within a single event
+        loop. These must run on the same loop as handle_loop(), i.e. the
+        tokenizer_manager's event_loop.
+        """
+        loop = getattr(self.tokenizer_manager, "event_loop", None)
+        if loop is None:
+            raise RuntimeError(
+                "TokenizerManager event loop not ready - server still starting"
+            )
+        return loop
+
+    def _safe_callback(self, chunk_callback, payload, *, finished: bool, error=None):
+        try:
+            chunk_callback(payload, finished=finished, error=error)
+        except Exception:
+            pass
+
+    def _submit_on_tm_loop(self, coro_factory, chunk_callback, *, empty_response):
+        try:
+            loop = self._tm_loop
+        except RuntimeError as e:
+            self._safe_callback(
+                chunk_callback, empty_response, finished=True, error=str(e)
+            )
+            return
+        asyncio.run_coroutine_threadsafe(coro_factory(), loop)
+
+    def _get_openai_serving(self):
+        """Lazily initialize OpenAI serving classes."""
+        if self._openai_serving_classes is not None:
+            return self._openai_serving_classes
+
+        from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
+        from sglang.srt.entrypoints.openai.serving_classify import (
+            OpenAIServingClassify,
+        )
+        from sglang.srt.entrypoints.openai.serving_completions import (
+            OpenAIServingCompletion,
+        )
+        from sglang.srt.entrypoints.openai.serving_embedding import (
+            OpenAIServingEmbedding,
+        )
+        from sglang.srt.entrypoints.openai.serving_rerank import OpenAIServingRerank
+        from sglang.srt.entrypoints.openai.serving_score import OpenAIServingScore
+
+        self._openai_serving_classes = {
+            "chat": OpenAIServingChat(self.tokenizer_manager, self.template_manager),
+            "completion": OpenAIServingCompletion(
+                self.tokenizer_manager, self.template_manager
+            ),
+            "embedding": OpenAIServingEmbedding(
+                self.tokenizer_manager, self.template_manager
+            ),
+            "classify": OpenAIServingClassify(
+                self.tokenizer_manager, self.template_manager
+            ),
+            "score": OpenAIServingScore(self.tokenizer_manager),
+            "rerank": OpenAIServingRerank(
+                self.tokenizer_manager, self.template_manager
+            ),
+        }
+        return self._openai_serving_classes
+
+    # ------------------------------------------------------------------
+    # Consolidated request submission (generate / embed / classify)
+    # ------------------------------------------------------------------
+
+    def submit_request(self, *, req_type: str, req_dict: dict, chunk_callback):
+        """Submit a generate or embed request from a pre-built dict.
+
+        The Rust gRPC server builds ``req_dict`` directly from proto fields,
+        mapping them to GenerateReqInput / EmbeddingReqInput field names.
+        Python just does ``**dict`` unpacking - no JSON parsing needed.
+
+        Args:
+            req_type: "generate" or "embed" (classify uses "embed").
+            req_dict: Dict matching the dataclass constructor kwargs.
+            chunk_callback: Rust-side PyO3 callback object.
+        """
+        if req_type == "generate":
+            from sglang.srt.managers.io_struct import GenerateReqInput
+
+            obj = GenerateReqInput(**req_dict)
+            stream = req_dict.get("stream", False)
+            self._submit_on_tm_loop(
+                lambda: self._run_generate(obj, chunk_callback, stream),
+                chunk_callback,
+                empty_response={},
+            )
+        else:
+            from sglang.srt.managers.io_struct import EmbeddingReqInput
+
+            obj = EmbeddingReqInput(**req_dict)
+            self._submit_on_tm_loop(
+                lambda: self._run_embed(obj, chunk_callback),
+                chunk_callback,
+                empty_response={},
+            )
+
+    async def _run_generate(self, obj, chunk_callback, stream: bool):
+        try:
+            gen = self.tokenizer_manager.generate_request(obj, request=None)
+            if stream:
+                async for chunk in gen:
+                    finished = (
+                        chunk.get("meta_info", {}).get("finish_reason") is not None
+                    )
+                    chunk_callback(chunk, finished=finished)
+                    if finished:
+                        return
+            else:
+                result = await gen.__anext__()
+                chunk_callback(result, finished=True)
+        except StopAsyncIteration:
+            self._safe_callback(chunk_callback, {}, finished=True)
+        except Exception as e:
+            logger.error("gRPC generate error for rid=%s: %s", obj.rid, e)
+            self._safe_callback(chunk_callback, {}, finished=True, error=str(e))
+
+    async def _run_embed(self, obj, chunk_callback):
+        try:
+            gen = self.tokenizer_manager.generate_request(obj, request=None)
+            result = await gen.__anext__()
+            chunk_callback(result, finished=True)
+        except StopAsyncIteration:
+            self._safe_callback(chunk_callback, {}, finished=True)
+        except Exception as e:
+            logger.error("gRPC embed error for rid=%s: %s", obj.rid, e)
+            self._safe_callback(chunk_callback, {}, finished=True, error=str(e))
+
+    # ------------------------------------------------------------------
+    # Abort
+    # ------------------------------------------------------------------
+
+    def abort(self, rid: str = "", abort_all: bool = False):
+        """Abort a request by request ID or abort all active requests."""
+        try:
+            loop = self._tm_loop
+        except RuntimeError:
+            self.tokenizer_manager.abort_request(rid=rid, abort_all=abort_all)
+            return
+
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            running_loop = None
+
+        if running_loop is loop:
+            self.tokenizer_manager.abort_request(rid=rid, abort_all=abort_all)
+            return
+
+        future = asyncio.run_coroutine_threadsafe(
+            self._abort_async(rid, abort_all),
+            loop,
+        )
+        future.result()
+
+    async def _abort_async(self, rid: str, abort_all: bool) -> None:
+        self.tokenizer_manager.abort_request(rid=rid, abort_all=abort_all)
+
+    # ------------------------------------------------------------------
+    # Info RPCs (synchronous, small data)
+    # ------------------------------------------------------------------
+
+    def get_model_info(self) -> str:
+        """Return model info as a JSON string."""
+        model_config = self.tokenizer_manager.model_config
+        result = {
+            "model_path": self.tokenizer_manager.model_path,
+            "tokenizer_path": self.server_args.tokenizer_path,
+            "is_generation": self.tokenizer_manager.is_generation,
+            "weight_version": self.server_args.weight_version,
+            "model_type": getattr(model_config.hf_config, "model_type", None),
+            "architectures": getattr(model_config.hf_config, "architectures", None),
+        }
+        return json.dumps(result, default=str)
+
+    def get_server_info(self) -> str:
+        """Return server info as a JSON string."""
+        result: Dict[str, Any] = {}
+        try:
+            sa = self.server_args
+            if hasattr(sa, "model_config"):
+                sa = dataclasses.replace(sa)
+                if hasattr(sa, "model_config"):
+                    delattr(sa, "model_config")
+            result.update(dataclasses.asdict(sa))
+        except Exception:
+            pass
+        result.update(self.scheduler_info)
+        return json.dumps(result, default=str)
+
+    def health_check(self) -> bool:
+        """Return True if the server is healthy."""
+        from sglang.srt.managers.tokenizer_manager import ServerStatus
+
+        if self.tokenizer_manager.gracefully_exit:
+            return False
+        if self.tokenizer_manager.server_status == ServerStatus.Starting:
+            return False
+        return True
+
+    # ------------------------------------------------------------------
+    # Tokenize / Detokenize (local ops, no inference)
+    # ------------------------------------------------------------------
+
+    def tokenize(self, text: str, add_special_tokens: bool = True) -> str:
+        """Tokenize text and return result as JSON string."""
+        tokenizer = self.tokenizer_manager.tokenizer
+        tokens = tokenizer.encode(text, add_special_tokens=add_special_tokens)
+        result = {
+            "tokens": tokens,
+            "count": len(tokens),
+            "max_model_len": self.tokenizer_manager.model_config.context_len,
+            "input_text": text,
+        }
+        return json.dumps(result)
+
+    def detokenize(self, tokens: List[int]) -> str:
+        """Detokenize token IDs and return result as JSON string."""
+        tokenizer = self.tokenizer_manager.tokenizer
+        text = tokenizer.decode(tokens)
+        return json.dumps({"text": text})
+
+    # ------------------------------------------------------------------
+    # List models
+    # ------------------------------------------------------------------
+
+    def list_models(self) -> str:
+        """Return the list of served models as JSON string."""
+        served_model_name = self.tokenizer_manager.served_model_name
+        models = [
+            {
+                "id": served_model_name,
+                "root": served_model_name,
+                "max_model_len": self.tokenizer_manager.model_config.context_len,
+            }
+        ]
+        if self.server_args.enable_lora and hasattr(
+            self.tokenizer_manager, "lora_registry"
+        ):
+            lora_registry = self.tokenizer_manager.lora_registry
+            for _, lora_ref in lora_registry.get_all_adapters().items():
+                models.append(
+                    {
+                        "id": lora_ref.lora_name,
+                        "root": lora_ref.lora_path,
+                        "parent": served_model_name,
+                    }
+                )
+        return json.dumps(models)
+
+    # ------------------------------------------------------------------
+    # Get load
+    # ------------------------------------------------------------------
+
+    def get_load(self, chunk_callback, dp_rank: Optional[int] = None) -> None:
+        """Return load info via chunk_callback."""
+        self._submit_on_tm_loop(
+            lambda: self._get_load_async(chunk_callback, dp_rank),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    async def _get_load_async(
+        self, chunk_callback, dp_rank: Optional[int] = None
+    ) -> None:
+        try:
+            result = await self.tokenizer_manager.get_loads(dp_rank=dp_rank)
+            data = json.dumps([dataclasses.asdict(r) for r in result], default=str)
+            chunk_callback(data.encode("utf-8"), finished=True)
+        except Exception as e:
+            logger.error("gRPC get_load error: %s", e)
+            data = json.dumps({"error": str(e)})
+            chunk_callback(data.encode("utf-8"), finished=True, error=str(e))
+
+    # ------------------------------------------------------------------
+    # Flush cache
+    # ------------------------------------------------------------------
+
+    def flush_cache(self, chunk_callback) -> None:
+        """Flush the radix cache. Sends result through chunk_callback."""
+        self._submit_on_tm_loop(
+            lambda: self._flush_cache_async(chunk_callback),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    async def _flush_cache_async(self, chunk_callback) -> None:
+        try:
+            ret = await self.tokenizer_manager.flush_cache()
+            result = json.dumps({"success": ret.success, "message": "Cache flushed."})
+            chunk_callback(result.encode("utf-8"), finished=True)
+        except Exception as e:
+            logger.error("gRPC flush_cache error: %s", e)
+            result = json.dumps({"success": False, "message": str(e)})
+            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+
+    # ------------------------------------------------------------------
+    # Pause / Continue generation
+    # ------------------------------------------------------------------
+
+    def pause_generation(self, mode: str, chunk_callback) -> None:
+        """Pause generation. Sends result through chunk_callback."""
+        from sglang.srt.managers.io_struct import PauseGenerationReqInput
+
+        obj = PauseGenerationReqInput(mode=mode)
+        self._submit_on_tm_loop(
+            lambda: self._pause_generation_async(obj, chunk_callback),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    async def _pause_generation_async(self, obj, chunk_callback) -> None:
+        try:
+            await self.tokenizer_manager.pause_generation(obj)
+            result = json.dumps({"message": f"Generation paused (mode={obj.mode})."})
+            chunk_callback(result.encode("utf-8"), finished=True)
+        except Exception as e:
+            logger.error("gRPC pause_generation error: %s", e)
+            result = json.dumps({"message": str(e)})
+            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+
+    def continue_generation(self, chunk_callback) -> None:
+        """Continue generation. Sends result through chunk_callback."""
+        from sglang.srt.managers.io_struct import ContinueGenerationReqInput
+
+        obj = ContinueGenerationReqInput()
+        self._submit_on_tm_loop(
+            lambda: self._continue_generation_async(obj, chunk_callback),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    async def _continue_generation_async(self, obj, chunk_callback) -> None:
+        try:
+            await self.tokenizer_manager.continue_generation(obj)
+            result = json.dumps({"message": "Generation continued."})
+            chunk_callback(result.encode("utf-8"), finished=True)
+        except Exception as e:
+            logger.error("gRPC continue_generation error: %s", e)
+            result = json.dumps({"message": str(e)})
+            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+
+    # ------------------------------------------------------------------
+    # Profile (admin)
+    # ------------------------------------------------------------------
+
+    def start_profile(self, output_dir: Optional[str], chunk_callback) -> None:
+        """Start profiling. Sends result through chunk_callback."""
+        self._submit_on_tm_loop(
+            lambda: self._start_profile_async(output_dir, chunk_callback),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    async def _start_profile_async(self, output_dir, chunk_callback) -> None:
+        try:
+            kwargs = {}
+            if output_dir:
+                kwargs["output_dir"] = output_dir
+            await self.tokenizer_manager.start_profile(**kwargs)
+            result = json.dumps({"message": "Profiling started."})
+            chunk_callback(result.encode("utf-8"), finished=True)
+        except Exception as e:
+            logger.error("gRPC start_profile error: %s", e)
+            result = json.dumps({"message": str(e)})
+            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+
+    def stop_profile(self, chunk_callback) -> None:
+        """Stop profiling. Sends result through chunk_callback."""
+        self._submit_on_tm_loop(
+            lambda: self._stop_profile_async(chunk_callback),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    async def _stop_profile_async(self, chunk_callback) -> None:
+        try:
+            await self.tokenizer_manager.stop_profile()
+            result = json.dumps({"message": "Profiling stopped."})
+            chunk_callback(result.encode("utf-8"), finished=True)
+        except Exception as e:
+            logger.error("gRPC stop_profile error: %s", e)
+            result = json.dumps({"message": str(e)})
+            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+
+    # ------------------------------------------------------------------
+    # Update weights from disk (admin)
+    # ------------------------------------------------------------------
+
+    def update_weights_from_disk(
+        self, model_path: str, load_format: Optional[str], chunk_callback
+    ) -> None:
+        """Update weights from disk. Sends result through chunk_callback."""
+        self._submit_on_tm_loop(
+            lambda: self._update_weights_async(model_path, load_format, chunk_callback),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    async def _update_weights_async(
+        self, model_path: str, load_format: Optional[str], chunk_callback
+    ) -> None:
+        try:
+            from sglang.srt.managers.io_struct import UpdateWeightFromDiskReqInput
+
+            obj = UpdateWeightFromDiskReqInput(
+                model_path=model_path,
+                load_format=load_format,
+            )
+            success, message, num_paused = (
+                await self.tokenizer_manager.update_weights_from_disk(obj, request=None)
+            )
+            result = json.dumps(
+                {
+                    "success": success,
+                    "message": message,
+                    "num_paused_requests": num_paused,
+                }
+            )
+            chunk_callback(result.encode("utf-8"), finished=True)
+        except Exception as e:
+            logger.error("gRPC update_weights error: %s", e)
+            result = json.dumps({"success": False, "message": str(e)})
+            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+
+    # ------------------------------------------------------------------
+    # OpenAI-compatible RPCs (JSON pass-through)
+    # ------------------------------------------------------------------
+
+    def submit_openai_chat(
+        self,
+        *,
+        json_body: bytes,
+        chunk_callback,
+        trace_headers: Optional[Dict[str, str]] = None,
+    ):
+        """Submit OpenAI chat completion (JSON pass-through)."""
+        self._submit_on_tm_loop(
+            lambda: self._run_openai_request(
+                "chat",
+                json_body,
+                chunk_callback,
+                streaming=True,
+                trace_headers=trace_headers,
+            ),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    def submit_openai_complete(
+        self,
+        *,
+        json_body: bytes,
+        chunk_callback,
+        trace_headers: Optional[Dict[str, str]] = None,
+    ):
+        """Submit OpenAI completion (JSON pass-through)."""
+        self._submit_on_tm_loop(
+            lambda: self._run_openai_request(
+                "completion",
+                json_body,
+                chunk_callback,
+                streaming=True,
+                trace_headers=trace_headers,
+            ),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    def submit_openai_embed(
+        self,
+        *,
+        json_body: bytes,
+        chunk_callback,
+        trace_headers: Optional[Dict[str, str]] = None,
+    ):
+        """Submit OpenAI embedding (JSON pass-through, unary)."""
+        self._submit_on_tm_loop(
+            lambda: self._run_openai_request(
+                "embedding",
+                json_body,
+                chunk_callback,
+                streaming=False,
+                trace_headers=trace_headers,
+            ),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    def submit_openai_classify(
+        self,
+        *,
+        json_body: bytes,
+        chunk_callback,
+        trace_headers: Optional[Dict[str, str]] = None,
+    ):
+        """Submit OpenAI classify (JSON pass-through, unary)."""
+        self._submit_on_tm_loop(
+            lambda: self._run_openai_request(
+                "classify",
+                json_body,
+                chunk_callback,
+                streaming=False,
+                trace_headers=trace_headers,
+            ),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    def submit_openai_score(
+        self,
+        *,
+        json_body: bytes,
+        chunk_callback,
+        trace_headers: Optional[Dict[str, str]] = None,
+    ):
+        """Submit OpenAI score (JSON pass-through, unary)."""
+        self._submit_on_tm_loop(
+            lambda: self._run_openai_request(
+                "score",
+                json_body,
+                chunk_callback,
+                streaming=False,
+                trace_headers=trace_headers,
+            ),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    def submit_openai_rerank(
+        self,
+        *,
+        json_body: bytes,
+        chunk_callback,
+        trace_headers: Optional[Dict[str, str]] = None,
+    ):
+        """Submit OpenAI rerank (JSON pass-through, unary)."""
+        self._submit_on_tm_loop(
+            lambda: self._run_openai_request(
+                "rerank",
+                json_body,
+                chunk_callback,
+                streaming=False,
+                trace_headers=trace_headers,
+            ),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    def _get_openai_request_class(self, serving_key: str):
+        """Return the Pydantic request class for a given serving key."""
+        from sglang.srt.entrypoints.openai.protocol import (
+            ChatCompletionRequest,
+            ClassifyRequest,
+            CompletionRequest,
+            EmbeddingRequest,
+            ScoringRequest,
+            V1RerankReqInput,
+        )
+
+        return {
+            "chat": ChatCompletionRequest,
+            "completion": CompletionRequest,
+            "embedding": EmbeddingRequest,
+            "classify": ClassifyRequest,
+            "score": ScoringRequest,
+            "rerank": V1RerankReqInput,
+        }[serving_key]
+
+    async def _run_openai_request(
+        self,
+        serving_key: str,
+        json_body: bytes,
+        chunk_callback,
+        streaming: bool,
+        trace_headers: Optional[Dict[str, str]] = None,
+    ):
+        """Generic OpenAI pass-through handler.
+
+        Delegates to the appropriate OpenAIServing* class, sending response
+        data back through the Rust chunk_callback.
+        """
+        try:
+            serving = self._get_openai_serving()[serving_key]
+            request_dict = json.loads(json_body)
+            mock_request = MockRequest(headers=trace_headers)
+
+            request_cls = self._get_openai_request_class(serving_key)
+            request_obj = request_cls(**request_dict)
+
+            result = await serving.handle_request(request_obj, mock_request)
+
+            if hasattr(result, "body_iterator"):
+                async for raw_chunk in result.body_iterator:
+                    if isinstance(raw_chunk, bytes):
+                        raw_chunk = raw_chunk.decode("utf-8", errors="replace")
+                    if (
+                        raw_chunk.startswith("data: ")
+                        and raw_chunk.strip() != "data: [DONE]"
+                    ):
+                        json_chunk = raw_chunk[len("data: ") :].strip()
+                        if json_chunk:
+                            chunk_callback(json_chunk.encode("utf-8"), finished=False)
+                chunk_callback(b"", finished=True)
+            else:
+                if hasattr(result, "model_dump"):
+                    resp_bytes = json.dumps(result.model_dump()).encode("utf-8")
+                elif hasattr(result, "body"):
+                    resp_bytes = result.body
+                elif isinstance(result, (dict, list)):
+                    resp_bytes = json.dumps(result).encode("utf-8")
+                else:
+                    resp_bytes = str(result).encode("utf-8")
+                status_code = int(getattr(result, "status_code", 200))
+                chunk_callback(resp_bytes, finished=True, status_code=status_code)
+
+        except Exception as e:
+            logger.error("gRPC OpenAI %s error: %s", serving_key, e)
+            error_body = json.dumps({"error": {"message": str(e)}}).encode("utf-8")
+            if streaming:
+                self._safe_callback(
+                    chunk_callback, error_body, finished=True, error=str(e)
+                )
+            else:
+                try:
+                    chunk_callback(
+                        error_body,
+                        finished=True,
+                        status_code=int(getattr(e, "status_code", 500)),
+                    )
+                except Exception:
+                    pass

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -10,27 +10,56 @@ import asyncio
 import dataclasses
 import json
 import logging
-from typing import Any, Dict, List, Optional
+from types import SimpleNamespace
+from typing import Any, Callable, Dict, List, Optional
+
+from pydantic import ValidationError
 
 logger = logging.getLogger(__name__)
 
 
-class MockRequest:
-    """Lightweight stand-in for fastapi.Request when called from gRPC.
+class _CaseInsensitiveHeaders:
+    """Minimal read-only header view with case-insensitive lookup.
 
-    The OpenAI serving classes expect a fastapi.Request for disconnect
-    detection and routing key extraction. This satisfies that interface
-    without importing FastAPI.
+    Mirrors the only Starlette ``Headers`` surface the OpenAI serving classes
+    use (``.get(name)``), without importing Starlette or FastAPI.
     """
 
+    __slots__ = ("_data",)
+
     def __init__(self, headers: Optional[Dict[str, str]] = None):
-        self.headers = headers or {}
-        self.url = type("URL", (), {"path": "/grpc"})()
-        self.state = type("State", (), {})()
-        self.app = type("App", (), {"state": type("AppState", (), {})()})()
+        self._data = {k.lower(): v for k, v in (headers or {}).items()}
+
+    def get(self, name: str, default: Optional[str] = None) -> Optional[str]:
+        return self._data.get(name.lower(), default)
+
+
+class MockRequest:
+    """Stand-in for ``fastapi.Request`` when serving classes are called from gRPC.
+
+    Implements the three surfaces the OpenAI serving classes actually touch:
+      * ``headers.get(name)`` — case-insensitive, matches HTTP semantics
+      * ``state.<attr>`` — attribute namespace for downstream mutations
+      * ``await is_disconnected()`` — client-cancellation probe
+
+    ``is_disconnected_fn`` is an optional sync callable the Rust side can pass
+    that reads its Tonic ``CancellationToken``. When omitted, the request is
+    treated as always-connected (current Rust behaviour).
+    """
+
+    def __init__(
+        self,
+        headers: Optional[Dict[str, str]] = None,
+        is_disconnected_fn: Optional[Callable[[], bool]] = None,
+    ):
+        self.headers = _CaseInsensitiveHeaders(headers)
+        self.state = SimpleNamespace()
+        self._is_disconnected_fn = is_disconnected_fn
 
     async def is_disconnected(self) -> bool:
-        return False
+        if self._is_disconnected_fn is None:
+            return False
+        return bool(self._is_disconnected_fn())
 
 
 class RuntimeHandle:
@@ -56,21 +85,25 @@ class RuntimeHandle:
 
         self._openai_serving_classes = None
 
+        # Ensure the handle_loop task exists before any gRPC RPC is dispatched.
+        # auto_create_handle_loop is idempotent (no-op if the loop is already
+        # running) and uses get_or_create_event_loop on the calling thread, so
+        # constructing RuntimeHandle from the launcher's main thread pins the
+        # loop where handle_loop's signal handlers expect it.
+        self.tokenizer_manager.auto_create_handle_loop()
+        self._event_loop = self.tokenizer_manager.event_loop
+
     @property
     def _tm_loop(self):
-        """Return the tokenizer_manager's event loop (uvicorn loop).
+        """Return the tokenizer_manager's event loop.
 
         Communicator-based async methods (flush_cache, get_load, etc.) use
         asyncio.Event internally, which only works within a single event
         loop. These must run on the same loop as handle_loop(), i.e. the
-        tokenizer_manager's event_loop.
+        tokenizer_manager's event_loop. Cached at construction time so RPCs
+        never race the loop's creation.
         """
-        loop = getattr(self.tokenizer_manager, "event_loop", None)
-        if loop is None:
-            raise RuntimeError(
-                "TokenizerManager event loop not ready - server still starting"
-            )
-        return loop
+        return self._event_loop
 
     def _safe_callback(self, chunk_callback, payload, *, finished: bool, error=None):
         try:
@@ -79,14 +112,7 @@ class RuntimeHandle:
             pass
 
     def _submit_on_tm_loop(self, coro_factory, chunk_callback, *, empty_response):
-        try:
-            loop = self._tm_loop
-        except RuntimeError as e:
-            self._safe_callback(
-                chunk_callback, empty_response, finished=True, error=str(e)
-            )
-            return
-        asyncio.run_coroutine_threadsafe(coro_factory(), loop)
+        asyncio.run_coroutine_threadsafe(coro_factory(), self._tm_loop)
 
     def _get_openai_serving(self):
         """Lazily initialize OpenAI serving classes."""
@@ -197,11 +223,7 @@ class RuntimeHandle:
 
     def abort(self, rid: str = "", abort_all: bool = False):
         """Abort a request by request ID or abort all active requests."""
-        try:
-            loop = self._tm_loop
-        except RuntimeError:
-            self.tokenizer_manager.abort_request(rid=rid, abort_all=abort_all)
-            return
+        loop = self._tm_loop
 
         try:
             running_loop = asyncio.get_running_loop()
@@ -498,6 +520,7 @@ class RuntimeHandle:
         json_body: bytes,
         chunk_callback,
         trace_headers: Optional[Dict[str, str]] = None,
+        is_disconnected_fn: Optional[Callable[[], bool]] = None,
     ):
         """Submit OpenAI chat completion (JSON pass-through)."""
         self._submit_on_tm_loop(
@@ -507,6 +530,7 @@ class RuntimeHandle:
                 chunk_callback,
                 streaming=True,
                 trace_headers=trace_headers,
+                is_disconnected_fn=is_disconnected_fn,
             ),
             chunk_callback,
             empty_response=b"",
@@ -518,6 +542,7 @@ class RuntimeHandle:
         json_body: bytes,
         chunk_callback,
         trace_headers: Optional[Dict[str, str]] = None,
+        is_disconnected_fn: Optional[Callable[[], bool]] = None,
     ):
         """Submit OpenAI completion (JSON pass-through)."""
         self._submit_on_tm_loop(
@@ -527,6 +552,7 @@ class RuntimeHandle:
                 chunk_callback,
                 streaming=True,
                 trace_headers=trace_headers,
+                is_disconnected_fn=is_disconnected_fn,
             ),
             chunk_callback,
             empty_response=b"",
@@ -538,6 +564,7 @@ class RuntimeHandle:
         json_body: bytes,
         chunk_callback,
         trace_headers: Optional[Dict[str, str]] = None,
+        is_disconnected_fn: Optional[Callable[[], bool]] = None,
     ):
         """Submit OpenAI embedding (JSON pass-through, unary)."""
         self._submit_on_tm_loop(
@@ -547,6 +574,7 @@ class RuntimeHandle:
                 chunk_callback,
                 streaming=False,
                 trace_headers=trace_headers,
+                is_disconnected_fn=is_disconnected_fn,
             ),
             chunk_callback,
             empty_response=b"",
@@ -558,6 +586,7 @@ class RuntimeHandle:
         json_body: bytes,
         chunk_callback,
         trace_headers: Optional[Dict[str, str]] = None,
+        is_disconnected_fn: Optional[Callable[[], bool]] = None,
     ):
         """Submit OpenAI classify (JSON pass-through, unary)."""
         self._submit_on_tm_loop(
@@ -567,6 +596,7 @@ class RuntimeHandle:
                 chunk_callback,
                 streaming=False,
                 trace_headers=trace_headers,
+                is_disconnected_fn=is_disconnected_fn,
             ),
             chunk_callback,
             empty_response=b"",
@@ -578,6 +608,7 @@ class RuntimeHandle:
         json_body: bytes,
         chunk_callback,
         trace_headers: Optional[Dict[str, str]] = None,
+        is_disconnected_fn: Optional[Callable[[], bool]] = None,
     ):
         """Submit OpenAI score (JSON pass-through, unary)."""
         self._submit_on_tm_loop(
@@ -587,6 +618,7 @@ class RuntimeHandle:
                 chunk_callback,
                 streaming=False,
                 trace_headers=trace_headers,
+                is_disconnected_fn=is_disconnected_fn,
             ),
             chunk_callback,
             empty_response=b"",
@@ -598,6 +630,7 @@ class RuntimeHandle:
         json_body: bytes,
         chunk_callback,
         trace_headers: Optional[Dict[str, str]] = None,
+        is_disconnected_fn: Optional[Callable[[], bool]] = None,
     ):
         """Submit OpenAI rerank (JSON pass-through, unary)."""
         self._submit_on_tm_loop(
@@ -607,6 +640,7 @@ class RuntimeHandle:
                 chunk_callback,
                 streaming=False,
                 trace_headers=trace_headers,
+                is_disconnected_fn=is_disconnected_fn,
             ),
             chunk_callback,
             empty_response=b"",
@@ -639,6 +673,7 @@ class RuntimeHandle:
         chunk_callback,
         streaming: bool,
         trace_headers: Optional[Dict[str, str]] = None,
+        is_disconnected_fn: Optional[Callable[[], bool]] = None,
     ):
         """Generic OpenAI pass-through handler.
 
@@ -647,11 +682,30 @@ class RuntimeHandle:
         """
         try:
             serving = self._get_openai_serving()[serving_key]
-            request_dict = json.loads(json_body)
-            mock_request = MockRequest(headers=trace_headers)
 
-            request_cls = self._get_openai_request_class(serving_key)
-            request_obj = request_cls(**request_dict)
+            # JSON parse + Pydantic validation are client errors. Surface
+            # them with status_code=400 so the Rust side maps them to
+            # INVALID_ARGUMENT instead of INTERNAL. They always happen
+            # before any stream chunks are emitted, so it is safe to send a
+            # single status-bearing chunk even on streaming endpoints.
+            try:
+                request_dict = json.loads(json_body)
+                request_cls = self._get_openai_request_class(serving_key)
+                request_obj = request_cls(**request_dict)
+            except (json.JSONDecodeError, ValidationError) as e:
+                error_body = json.dumps(
+                    {"error": {"message": str(e), "type": "BadRequest"}}
+                ).encode("utf-8")
+                try:
+                    chunk_callback(error_body, finished=True, status_code=400)
+                except Exception:
+                    pass
+                return
+
+            mock_request = MockRequest(
+                headers=trace_headers,
+                is_disconnected_fn=is_disconnected_fn,
+            )
 
             result = await serving.handle_request(request_obj, mock_request)
 

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -11,7 +11,7 @@ import dataclasses
 import json
 import logging
 from types import SimpleNamespace
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from pydantic import ValidationError
 
@@ -105,14 +105,50 @@ class RuntimeHandle:
         """
         return self._event_loop
 
-    def _safe_callback(self, chunk_callback, payload, *, finished: bool, error=None):
+    def _safe_callback(self, chunk_callback, payload, **kwargs) -> None:
         try:
-            chunk_callback(payload, finished=finished, error=error)
+            chunk_callback(payload, **kwargs)
         except Exception:
             pass
 
-    def _submit_on_tm_loop(self, coro_factory, chunk_callback, *, empty_response):
-        asyncio.run_coroutine_threadsafe(coro_factory(), self._tm_loop)
+    def _submit_on_tm_loop(self, coro: Awaitable) -> None:
+        asyncio.run_coroutine_threadsafe(coro, self._tm_loop)
+
+    def _submit_json_unary(
+        self,
+        op_name: str,
+        payload_coro_factory: Callable[[], Awaitable[Any]],
+        chunk_callback,
+        *,
+        error_payload_fn: Optional[Callable[[Exception], Any]] = None,
+    ) -> None:
+        """Schedule a unary op whose result is JSON-encoded and sent via chunk_callback.
+
+        ``payload_coro_factory`` is a zero-arg callable returning a coroutine
+        that awaits the operation and returns the success payload (dict/list).
+        ``error_payload_fn`` maps a caught exception to the payload sent on
+        the error path; defaults to ``{"message": str(e)}``.
+        """
+        error_fn = error_payload_fn or (lambda e: {"message": str(e)})
+
+        async def _run() -> None:
+            try:
+                payload = await payload_coro_factory()
+                self._safe_callback(
+                    chunk_callback,
+                    json.dumps(payload, default=str).encode("utf-8"),
+                    finished=True,
+                )
+            except Exception as e:
+                logger.error("gRPC %s error: %s", op_name, e)
+                self._safe_callback(
+                    chunk_callback,
+                    json.dumps(error_fn(e), default=str).encode("utf-8"),
+                    finished=True,
+                    error=str(e),
+                )
+
+        self._submit_on_tm_loop(_run())
 
     def _get_openai_serving(self):
         """Lazily initialize OpenAI serving classes."""
@@ -150,10 +186,6 @@ class RuntimeHandle:
         }
         return self._openai_serving_classes
 
-    # ------------------------------------------------------------------
-    # Consolidated request submission (generate / embed / classify)
-    # ------------------------------------------------------------------
-
     def submit_request(self, *, req_type: str, req_dict: dict, chunk_callback):
         """Submit a generate or embed request from a pre-built dict.
 
@@ -171,20 +203,12 @@ class RuntimeHandle:
 
             obj = GenerateReqInput(**req_dict)
             stream = req_dict.get("stream", False)
-            self._submit_on_tm_loop(
-                lambda: self._run_generate(obj, chunk_callback, stream),
-                chunk_callback,
-                empty_response={},
-            )
+            self._submit_on_tm_loop(self._run_generate(obj, chunk_callback, stream))
         else:
             from sglang.srt.managers.io_struct import EmbeddingReqInput
 
             obj = EmbeddingReqInput(**req_dict)
-            self._submit_on_tm_loop(
-                lambda: self._run_embed(obj, chunk_callback),
-                chunk_callback,
-                empty_response={},
-            )
+            self._submit_on_tm_loop(self._run_embed(obj, chunk_callback))
 
     async def _run_generate(self, obj, chunk_callback, stream: bool):
         try:
@@ -217,10 +241,6 @@ class RuntimeHandle:
             logger.error("gRPC embed error for rid=%s: %s", obj.rid, e)
             self._safe_callback(chunk_callback, {}, finished=True, error=str(e))
 
-    # ------------------------------------------------------------------
-    # Abort
-    # ------------------------------------------------------------------
-
     def abort(self, rid: str = "", abort_all: bool = False):
         """Abort a request by request ID or abort all active requests."""
         loop = self._tm_loop
@@ -242,10 +262,6 @@ class RuntimeHandle:
 
     async def _abort_async(self, rid: str, abort_all: bool) -> None:
         self.tokenizer_manager.abort_request(rid=rid, abort_all=abort_all)
-
-    # ------------------------------------------------------------------
-    # Info RPCs (synchronous, small data)
-    # ------------------------------------------------------------------
 
     def get_model_info(self) -> str:
         """Return model info as a JSON string."""
@@ -285,10 +301,6 @@ class RuntimeHandle:
             return False
         return True
 
-    # ------------------------------------------------------------------
-    # Tokenize / Detokenize (local ops, no inference)
-    # ------------------------------------------------------------------
-
     def tokenize(self, text: str, add_special_tokens: bool = True) -> str:
         """Tokenize text and return result as JSON string."""
         tokenizer = self.tokenizer_manager.tokenizer
@@ -306,10 +318,6 @@ class RuntimeHandle:
         tokenizer = self.tokenizer_manager.tokenizer
         text = tokenizer.decode(tokens)
         return json.dumps({"text": text})
-
-    # ------------------------------------------------------------------
-    # List models
-    # ------------------------------------------------------------------
 
     def list_models(self) -> str:
         """Return the list of served models as JSON string."""
@@ -335,184 +343,126 @@ class RuntimeHandle:
                 )
         return json.dumps(models)
 
-    # ------------------------------------------------------------------
-    # Get load
-    # ------------------------------------------------------------------
-
     def get_load(self, chunk_callback, dp_rank: Optional[int] = None) -> None:
         """Return load info via chunk_callback."""
-        self._submit_on_tm_loop(
-            lambda: self._get_load_async(chunk_callback, dp_rank),
-            chunk_callback,
-            empty_response=b"",
-        )
 
-    async def _get_load_async(
-        self, chunk_callback, dp_rank: Optional[int] = None
-    ) -> None:
-        try:
+        async def _payload():
             result = await self.tokenizer_manager.get_loads(dp_rank=dp_rank)
-            data = json.dumps([dataclasses.asdict(r) for r in result], default=str)
-            chunk_callback(data.encode("utf-8"), finished=True)
-        except Exception as e:
-            logger.error("gRPC get_load error: %s", e)
-            data = json.dumps({"error": str(e)})
-            chunk_callback(data.encode("utf-8"), finished=True, error=str(e))
+            return [dataclasses.asdict(r) for r in result]
 
-    # ------------------------------------------------------------------
-    # Flush cache
-    # ------------------------------------------------------------------
+        self._submit_json_unary(
+            "get_load",
+            _payload,
+            chunk_callback,
+            error_payload_fn=lambda e: {"error": str(e)},
+        )
 
     def flush_cache(self, chunk_callback) -> None:
         """Flush the radix cache. Sends result through chunk_callback."""
-        self._submit_on_tm_loop(
-            lambda: self._flush_cache_async(chunk_callback),
-            chunk_callback,
-            empty_response=b"",
-        )
 
-    async def _flush_cache_async(self, chunk_callback) -> None:
-        try:
+        async def _payload():
             ret = await self.tokenizer_manager.flush_cache()
-            result = json.dumps({"success": ret.success, "message": "Cache flushed."})
-            chunk_callback(result.encode("utf-8"), finished=True)
-        except Exception as e:
-            logger.error("gRPC flush_cache error: %s", e)
-            result = json.dumps({"success": False, "message": str(e)})
-            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+            return {"success": ret.success, "message": "Cache flushed."}
 
-    # ------------------------------------------------------------------
-    # Pause / Continue generation
-    # ------------------------------------------------------------------
+        self._submit_json_unary(
+            "flush_cache",
+            _payload,
+            chunk_callback,
+            error_payload_fn=lambda e: {"success": False, "message": str(e)},
+        )
 
     def pause_generation(self, mode: str, chunk_callback) -> None:
         """Pause generation. Sends result through chunk_callback."""
-        from sglang.srt.managers.io_struct import PauseGenerationReqInput
 
-        obj = PauseGenerationReqInput(mode=mode)
-        self._submit_on_tm_loop(
-            lambda: self._pause_generation_async(obj, chunk_callback),
-            chunk_callback,
-            empty_response=b"",
-        )
+        async def _payload():
+            from sglang.srt.managers.io_struct import PauseGenerationReqInput
 
-    async def _pause_generation_async(self, obj, chunk_callback) -> None:
-        try:
-            await self.tokenizer_manager.pause_generation(obj)
-            result = json.dumps({"message": f"Generation paused (mode={obj.mode})."})
-            chunk_callback(result.encode("utf-8"), finished=True)
-        except Exception as e:
-            logger.error("gRPC pause_generation error: %s", e)
-            result = json.dumps({"message": str(e)})
-            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+            await self.tokenizer_manager.pause_generation(
+                PauseGenerationReqInput(mode=mode)
+            )
+            return {"message": f"Generation paused (mode={mode})."}
+
+        self._submit_json_unary("pause_generation", _payload, chunk_callback)
 
     def continue_generation(self, chunk_callback) -> None:
         """Continue generation. Sends result through chunk_callback."""
-        from sglang.srt.managers.io_struct import ContinueGenerationReqInput
 
-        obj = ContinueGenerationReqInput()
-        self._submit_on_tm_loop(
-            lambda: self._continue_generation_async(obj, chunk_callback),
-            chunk_callback,
-            empty_response=b"",
-        )
+        async def _payload():
+            from sglang.srt.managers.io_struct import ContinueGenerationReqInput
 
-    async def _continue_generation_async(self, obj, chunk_callback) -> None:
-        try:
-            await self.tokenizer_manager.continue_generation(obj)
-            result = json.dumps({"message": "Generation continued."})
-            chunk_callback(result.encode("utf-8"), finished=True)
-        except Exception as e:
-            logger.error("gRPC continue_generation error: %s", e)
-            result = json.dumps({"message": str(e)})
-            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+            await self.tokenizer_manager.continue_generation(
+                ContinueGenerationReqInput()
+            )
+            return {"message": "Generation continued."}
 
-    # ------------------------------------------------------------------
-    # Profile (admin)
-    # ------------------------------------------------------------------
+        self._submit_json_unary("continue_generation", _payload, chunk_callback)
 
     def start_profile(self, output_dir: Optional[str], chunk_callback) -> None:
         """Start profiling. Sends result through chunk_callback."""
-        self._submit_on_tm_loop(
-            lambda: self._start_profile_async(output_dir, chunk_callback),
-            chunk_callback,
-            empty_response=b"",
-        )
 
-    async def _start_profile_async(self, output_dir, chunk_callback) -> None:
-        try:
-            kwargs = {}
-            if output_dir:
-                kwargs["output_dir"] = output_dir
+        async def _payload():
+            kwargs = {"output_dir": output_dir} if output_dir else {}
             await self.tokenizer_manager.start_profile(**kwargs)
-            result = json.dumps({"message": "Profiling started."})
-            chunk_callback(result.encode("utf-8"), finished=True)
-        except Exception as e:
-            logger.error("gRPC start_profile error: %s", e)
-            result = json.dumps({"message": str(e)})
-            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+            return {"message": "Profiling started."}
+
+        self._submit_json_unary("start_profile", _payload, chunk_callback)
 
     def stop_profile(self, chunk_callback) -> None:
         """Stop profiling. Sends result through chunk_callback."""
-        self._submit_on_tm_loop(
-            lambda: self._stop_profile_async(chunk_callback),
-            chunk_callback,
-            empty_response=b"",
-        )
 
-    async def _stop_profile_async(self, chunk_callback) -> None:
-        try:
+        async def _payload():
             await self.tokenizer_manager.stop_profile()
-            result = json.dumps({"message": "Profiling stopped."})
-            chunk_callback(result.encode("utf-8"), finished=True)
-        except Exception as e:
-            logger.error("gRPC stop_profile error: %s", e)
-            result = json.dumps({"message": str(e)})
-            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+            return {"message": "Profiling stopped."}
 
-    # ------------------------------------------------------------------
-    # Update weights from disk (admin)
-    # ------------------------------------------------------------------
+        self._submit_json_unary("stop_profile", _payload, chunk_callback)
 
     def update_weights_from_disk(
         self, model_path: str, load_format: Optional[str], chunk_callback
     ) -> None:
         """Update weights from disk. Sends result through chunk_callback."""
-        self._submit_on_tm_loop(
-            lambda: self._update_weights_async(model_path, load_format, chunk_callback),
-            chunk_callback,
-            empty_response=b"",
-        )
 
-    async def _update_weights_async(
-        self, model_path: str, load_format: Optional[str], chunk_callback
-    ) -> None:
-        try:
+        async def _payload():
             from sglang.srt.managers.io_struct import UpdateWeightFromDiskReqInput
 
             obj = UpdateWeightFromDiskReqInput(
-                model_path=model_path,
-                load_format=load_format,
+                model_path=model_path, load_format=load_format
             )
             success, message, num_paused = (
                 await self.tokenizer_manager.update_weights_from_disk(obj, request=None)
             )
-            result = json.dumps(
-                {
-                    "success": success,
-                    "message": message,
-                    "num_paused_requests": num_paused,
-                }
-            )
-            chunk_callback(result.encode("utf-8"), finished=True)
-        except Exception as e:
-            logger.error("gRPC update_weights error: %s", e)
-            result = json.dumps({"success": False, "message": str(e)})
-            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+            return {
+                "success": success,
+                "message": message,
+                "num_paused_requests": num_paused,
+            }
 
-    # ------------------------------------------------------------------
-    # OpenAI-compatible RPCs (JSON pass-through)
-    # ------------------------------------------------------------------
+        self._submit_json_unary(
+            "update_weights",
+            _payload,
+            chunk_callback,
+            error_payload_fn=lambda e: {"success": False, "message": str(e)},
+        )
+
+    def _submit_openai(
+        self,
+        serving_key: str,
+        streaming: bool,
+        json_body: bytes,
+        chunk_callback,
+        trace_headers: Optional[Dict[str, str]],
+        is_disconnected_fn: Optional[Callable[[], bool]],
+    ) -> None:
+        """Schedule an OpenAI pass-through request on the tokenizer_manager loop."""
+        self._submit_on_tm_loop(
+            self._run_openai_request(
+                serving_key,
+                json_body,
+                chunk_callback,
+                streaming=streaming,
+                trace_headers=trace_headers,
+                is_disconnected_fn=is_disconnected_fn,
+            )
+        )
 
     def submit_openai_chat(
         self,
@@ -521,19 +471,10 @@ class RuntimeHandle:
         chunk_callback,
         trace_headers: Optional[Dict[str, str]] = None,
         is_disconnected_fn: Optional[Callable[[], bool]] = None,
-    ):
-        """Submit OpenAI chat completion (JSON pass-through)."""
-        self._submit_on_tm_loop(
-            lambda: self._run_openai_request(
-                "chat",
-                json_body,
-                chunk_callback,
-                streaming=True,
-                trace_headers=trace_headers,
-                is_disconnected_fn=is_disconnected_fn,
-            ),
-            chunk_callback,
-            empty_response=b"",
+    ) -> None:
+        """Submit OpenAI chat completion (JSON pass-through, streaming)."""
+        self._submit_openai(
+            "chat", True, json_body, chunk_callback, trace_headers, is_disconnected_fn
         )
 
     def submit_openai_complete(
@@ -543,19 +484,15 @@ class RuntimeHandle:
         chunk_callback,
         trace_headers: Optional[Dict[str, str]] = None,
         is_disconnected_fn: Optional[Callable[[], bool]] = None,
-    ):
-        """Submit OpenAI completion (JSON pass-through)."""
-        self._submit_on_tm_loop(
-            lambda: self._run_openai_request(
-                "completion",
-                json_body,
-                chunk_callback,
-                streaming=True,
-                trace_headers=trace_headers,
-                is_disconnected_fn=is_disconnected_fn,
-            ),
+    ) -> None:
+        """Submit OpenAI completion (JSON pass-through, streaming)."""
+        self._submit_openai(
+            "completion",
+            True,
+            json_body,
             chunk_callback,
-            empty_response=b"",
+            trace_headers,
+            is_disconnected_fn,
         )
 
     def submit_openai_embed(
@@ -565,19 +502,15 @@ class RuntimeHandle:
         chunk_callback,
         trace_headers: Optional[Dict[str, str]] = None,
         is_disconnected_fn: Optional[Callable[[], bool]] = None,
-    ):
+    ) -> None:
         """Submit OpenAI embedding (JSON pass-through, unary)."""
-        self._submit_on_tm_loop(
-            lambda: self._run_openai_request(
-                "embedding",
-                json_body,
-                chunk_callback,
-                streaming=False,
-                trace_headers=trace_headers,
-                is_disconnected_fn=is_disconnected_fn,
-            ),
+        self._submit_openai(
+            "embedding",
+            False,
+            json_body,
             chunk_callback,
-            empty_response=b"",
+            trace_headers,
+            is_disconnected_fn,
         )
 
     def submit_openai_classify(
@@ -587,19 +520,15 @@ class RuntimeHandle:
         chunk_callback,
         trace_headers: Optional[Dict[str, str]] = None,
         is_disconnected_fn: Optional[Callable[[], bool]] = None,
-    ):
+    ) -> None:
         """Submit OpenAI classify (JSON pass-through, unary)."""
-        self._submit_on_tm_loop(
-            lambda: self._run_openai_request(
-                "classify",
-                json_body,
-                chunk_callback,
-                streaming=False,
-                trace_headers=trace_headers,
-                is_disconnected_fn=is_disconnected_fn,
-            ),
+        self._submit_openai(
+            "classify",
+            False,
+            json_body,
             chunk_callback,
-            empty_response=b"",
+            trace_headers,
+            is_disconnected_fn,
         )
 
     def submit_openai_score(
@@ -609,19 +538,10 @@ class RuntimeHandle:
         chunk_callback,
         trace_headers: Optional[Dict[str, str]] = None,
         is_disconnected_fn: Optional[Callable[[], bool]] = None,
-    ):
+    ) -> None:
         """Submit OpenAI score (JSON pass-through, unary)."""
-        self._submit_on_tm_loop(
-            lambda: self._run_openai_request(
-                "score",
-                json_body,
-                chunk_callback,
-                streaming=False,
-                trace_headers=trace_headers,
-                is_disconnected_fn=is_disconnected_fn,
-            ),
-            chunk_callback,
-            empty_response=b"",
+        self._submit_openai(
+            "score", False, json_body, chunk_callback, trace_headers, is_disconnected_fn
         )
 
     def submit_openai_rerank(
@@ -631,19 +551,15 @@ class RuntimeHandle:
         chunk_callback,
         trace_headers: Optional[Dict[str, str]] = None,
         is_disconnected_fn: Optional[Callable[[], bool]] = None,
-    ):
+    ) -> None:
         """Submit OpenAI rerank (JSON pass-through, unary)."""
-        self._submit_on_tm_loop(
-            lambda: self._run_openai_request(
-                "rerank",
-                json_body,
-                chunk_callback,
-                streaming=False,
-                trace_headers=trace_headers,
-                is_disconnected_fn=is_disconnected_fn,
-            ),
+        self._submit_openai(
+            "rerank",
+            False,
+            json_body,
             chunk_callback,
-            empty_response=b"",
+            trace_headers,
+            is_disconnected_fn,
         )
 
     def _get_openai_request_class(self, serving_key: str):
@@ -696,10 +612,9 @@ class RuntimeHandle:
                 error_body = json.dumps(
                     {"error": {"message": str(e), "type": "BadRequest"}}
                 ).encode("utf-8")
-                try:
-                    chunk_callback(error_body, finished=True, status_code=400)
-                except Exception:
-                    pass
+                self._safe_callback(
+                    chunk_callback, error_body, finished=True, status_code=400
+                )
                 return
 
             mock_request = MockRequest(
@@ -741,11 +656,9 @@ class RuntimeHandle:
                     chunk_callback, error_body, finished=True, error=str(e)
                 )
             else:
-                try:
-                    chunk_callback(
-                        error_body,
-                        finished=True,
-                        status_code=int(getattr(e, "status_code", 500)),
-                    )
-                except Exception:
-                    pass
+                self._safe_callback(
+                    chunk_callback,
+                    error_body,
+                    finished=True,
+                    status_code=int(getattr(e, "status_code", 500)),
+                )

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -108,11 +108,30 @@ class RuntimeHandle:
     def _safe_callback(self, chunk_callback, payload, **kwargs) -> None:
         try:
             chunk_callback(payload, **kwargs)
-        except Exception:
-            pass
+        except Exception as e:
+            # Most often: Rust receiver dropped (client disconnect, channel
+            # closed). Log at warning so it's visible without spamming on
+            # every normal cancellation.
+            logger.warning("gRPC chunk_callback failed: %s", e)
 
     def _submit_on_tm_loop(self, coro: Awaitable) -> None:
-        asyncio.run_coroutine_threadsafe(coro, self._tm_loop)
+        future = asyncio.run_coroutine_threadsafe(coro, self._tm_loop)
+        future.add_done_callback(self._log_unhandled_future_exception)
+
+    @staticmethod
+    def _log_unhandled_future_exception(future) -> None:
+        # All RuntimeHandle coroutines wrap their bodies in try/except and
+        # route errors through chunk_callback, so this is a defence in depth:
+        # if anything ever escapes (or a new caller forgets the wrap), we
+        # surface it instead of silently hanging the gRPC stream.
+        try:
+            future.result()
+        except Exception as e:
+            logger.error(
+                "gRPC scheduled coroutine raised unhandled exception: %s",
+                e,
+                exc_info=True,
+            )
 
     def _submit_json_unary(
         self,
@@ -204,11 +223,15 @@ class RuntimeHandle:
             obj = GenerateReqInput(**req_dict)
             stream = req_dict.get("stream", False)
             self._submit_on_tm_loop(self._run_generate(obj, chunk_callback, stream))
-        else:
+        elif req_type == "embed":
             from sglang.srt.managers.io_struct import EmbeddingReqInput
 
             obj = EmbeddingReqInput(**req_dict)
             self._submit_on_tm_loop(self._run_embed(obj, chunk_callback))
+        else:
+            raise ValueError(
+                f"Unknown req_type: {req_type!r} (expected 'generate' or 'embed')"
+            )
 
     async def _run_generate(self, obj, chunk_callback, stream: bool):
         try:
@@ -297,9 +320,10 @@ class RuntimeHandle:
 
         if self.tokenizer_manager.gracefully_exit:
             return False
-        if self.tokenizer_manager.server_status == ServerStatus.Starting:
-            return False
-        return True
+        return self.tokenizer_manager.server_status not in (
+            ServerStatus.Starting,
+            ServerStatus.UnHealthy,
+        )
 
     def tokenize(self, text: str, add_special_tokens: bool = True) -> str:
         """Tokenize text and return result as JSON string."""
@@ -625,16 +649,43 @@ class RuntimeHandle:
             result = await serving.handle_request(request_obj, mock_request)
 
             if hasattr(result, "body_iterator"):
+                # Parse SSE events per WHATWG spec (data:/event:/id: fields,
+                # `:` comments, blank-line event boundaries). OpenAIServing*
+                # currently emits one `data: <json>\n\n` per yield, but a
+                # naive `startswith("data: ")` filter silently drops anything
+                # else — multi-line data, comments, future event/id usage.
+                # See follow-up: replace SSE round-trip with a (dict,
+                # finished) hook on OpenAIServing*.
+                data_buf: List[str] = []
+
+                def _flush_event() -> None:
+                    if not data_buf:
+                        return
+                    body = "\n".join(data_buf)
+                    data_buf.clear()
+                    if body == "[DONE]" or not body:
+                        return
+                    chunk_callback(body.encode("utf-8"), finished=False)
+
                 async for raw_chunk in result.body_iterator:
                     if isinstance(raw_chunk, bytes):
                         raw_chunk = raw_chunk.decode("utf-8", errors="replace")
-                    if (
-                        raw_chunk.startswith("data: ")
-                        and raw_chunk.strip() != "data: [DONE]"
-                    ):
-                        json_chunk = raw_chunk[len("data: ") :].strip()
-                        if json_chunk:
-                            chunk_callback(json_chunk.encode("utf-8"), finished=False)
+                    for line in raw_chunk.split("\n"):
+                        line = line.rstrip("\r")
+                        if not line:
+                            _flush_event()
+                        elif line.startswith(":"):
+                            continue  # SSE comment / heartbeat
+                        elif line.startswith("data:"):
+                            value = line[5:]
+                            if value.startswith(" "):
+                                value = value[1:]
+                            data_buf.append(value)
+                        # event:, id:, retry:, unknown fields: ignored
+
+                # Defensive: emit a trailing event if the stream ended
+                # without a final blank line.
+                _flush_event()
                 chunk_callback(b"", finished=True)
             else:
                 if hasattr(result, "model_dump"):
@@ -645,7 +696,14 @@ class RuntimeHandle:
                     resp_bytes = json.dumps(result).encode("utf-8")
                 else:
                     resp_bytes = str(result).encode("utf-8")
-                status_code = int(getattr(result, "status_code", 200))
+                # ErrorResponse uses ``code``; Starlette/FastAPI Response
+                # uses ``status_code``. Honour whichever is present so error
+                # responses don't ship as HTTP 200 with an error body.
+                status_code = int(
+                    getattr(result, "status_code", None)
+                    or getattr(result, "code", None)
+                    or 200
+                )
                 chunk_callback(resp_bytes, finished=True, status_code=status_code)
 
         except Exception as e:

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -673,9 +673,14 @@ class RuntimeHandle:
                 error_body = json.dumps(
                     {"error": {"message": str(e), "type": "BadRequest"}}
                 ).encode("utf-8")
-                self._safe_callback(
-                    chunk_callback, error_body, finished=True, status_code=400
-                )
+                if streaming:
+                    self._safe_callback(
+                        chunk_callback, error_body, finished=True, error=str(e)
+                    )
+                else:
+                    self._safe_callback(
+                        chunk_callback, error_body, finished=True, status_code=400
+                    )
                 return
 
             mock_request = _GrpcRequest(

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -18,13 +18,11 @@ from pydantic import ValidationError
 logger = logging.getLogger(__name__)
 
 
+class _BadOpenAIRequest(ValueError):
+    pass
+
+
 class _CaseInsensitiveHeaders:
-    """Minimal read-only header view with case-insensitive lookup.
-
-    Mirrors the only Starlette ``Headers`` surface the OpenAI serving classes
-    use (``.get(name)``), without importing Starlette or FastAPI.
-    """
-
     __slots__ = ("_data",)
 
     def __init__(self, headers: Optional[Dict[str, str]] = None):
@@ -34,18 +32,8 @@ class _CaseInsensitiveHeaders:
         return self._data.get(name.lower(), default)
 
 
-class MockRequest:
-    """Stand-in for ``fastapi.Request`` when serving classes are called from gRPC.
-
-    Implements the three surfaces the OpenAI serving classes actually touch:
-      * ``headers.get(name)`` — case-insensitive, matches HTTP semantics
-      * ``state.<attr>`` — attribute namespace for downstream mutations
-      * ``await is_disconnected()`` — client-cancellation probe
-
-    ``is_disconnected_fn`` is an optional sync callable the Rust side can pass
-    that reads its Tonic ``CancellationToken``. When omitted, the request is
-    treated as always-connected (current Rust behaviour).
-    """
+class _GrpcRequest:
+    """Small FastAPI Request shim used by OpenAIServing* and TokenizerManager."""
 
     def __init__(
         self,
@@ -85,98 +73,84 @@ class RuntimeHandle:
 
         self._openai_serving_classes = None
 
-        # Ensure the handle_loop task exists before any gRPC RPC is dispatched.
-        # auto_create_handle_loop is idempotent (no-op if the loop is already
-        # running) and uses get_or_create_event_loop on the calling thread, so
-        # constructing RuntimeHandle from the launcher's main thread pins the
-        # loop where handle_loop's signal handlers expect it.
         self.tokenizer_manager.auto_create_handle_loop()
         self._event_loop = self.tokenizer_manager.event_loop
 
     @property
     def _tm_loop(self):
-        """Return the tokenizer_manager's event loop.
-
-        Communicator-based async methods (flush_cache, get_load, etc.) use
-        asyncio.Event internally, which only works within a single event
-        loop. These must run on the same loop as handle_loop(), i.e. the
-        tokenizer_manager's event_loop. Cached at construction time so RPCs
-        never race the loop's creation.
-        """
+        """Return the TokenizerManager loop used by communicator RPCs."""
         return self._event_loop
 
     def _safe_callback(self, chunk_callback, payload, **kwargs):
-        """Invoke chunk_callback swallowing exceptions; returns the status it returned, or None on failure.
-
-        The Rust callbacks return ``ChunkSendStatus`` (Ready/Pending/Closed);
-        callers that care about backpressure should use
-        ``_send_with_backpressure`` instead, which awaits on Pending.
-        """
+        """Invoke a Rust callback and return its ChunkSendStatus, if any."""
         try:
             return chunk_callback(payload, **kwargs)
         except Exception as e:
-            # Most often: Rust receiver dropped (client disconnect, channel
-            # closed). Log at warning so it's visible without spamming on
-            # every normal cancellation.
             logger.warning("gRPC chunk_callback failed: %s", e)
             return None
 
-    # Generous ceiling so a Rust-side close that fails to fire on_ready
-    # (only possible when the channel closes during a parked send) doesn't
-    # deadlock the stream coroutine forever. Legitimate slow clients can
-    # easily take seconds per chunk, so this is a stuck-stream backstop, not
-    # a normal pacing knob.
+    def _send_native_error(self, chunk_callback, message: str):
+        # ChunkCallback extracts the PyDict arg before reading error=.
+        return self._safe_callback(chunk_callback, {}, finished=True, error=message)
+
     _BACKPRESSURE_TIMEOUT_S = 300.0
 
     @staticmethod
     def _is_pending_status(status) -> bool:
-        # ChunkSendStatus is a Rust pyclass enum with eq_int, so name-based
-        # comparison via the variant on the value's type works regardless of
-        # discriminant values.
         return status is not None and status == type(status).Pending
 
     @staticmethod
     def _is_closed_status(status) -> bool:
         return status is not None and status == type(status).Closed
 
+    def _abort_request_id(self, rid) -> None:
+        if isinstance(rid, list):
+            for single_rid in rid:
+                self.tokenizer_manager.abort_request(rid=single_rid)
+        else:
+            self.tokenizer_manager.abort_request(rid=rid)
+
     async def _send_with_backpressure(
         self,
         chunk_callback,
         ready_event: Optional[asyncio.Event],
         payload,
+        *,
+        timeout_abort_rid=None,
         **kwargs,
     ) -> bool:
-        """Send one chunk and honor ChunkSendStatus backpressure.
-
-        Returns True if the caller should keep producing, False if the Rust
-        side reported the channel closed (or the call itself failed).
-        ``ready_event`` may be None if the callback doesn't support
-        set_on_ready (test stubs); in that case Pending is treated as
-        Ready — best-effort, not crash.
-        """
         status = self._safe_callback(chunk_callback, payload, **kwargs)
         if status is None or self._is_closed_status(status):
             return False
-        if self._is_pending_status(status) and ready_event is not None:
-            try:
-                await asyncio.wait_for(
-                    ready_event.wait(), timeout=self._BACKPRESSURE_TIMEOUT_S
-                )
-            except asyncio.TimeoutError:
+        if not self._is_pending_status(status):
+            return True
+
+        if kwargs.get("finished"):
+            return True
+        if ready_event is None:
+            return True
+
+        try:
+            await asyncio.wait_for(
+                ready_event.wait(), timeout=self._BACKPRESSURE_TIMEOUT_S
+            )
+        except asyncio.TimeoutError:
+            if timeout_abort_rid is not None:
+                self._abort_request_id(timeout_abort_rid)
                 logger.warning(
-                    "gRPC chunk backpressure wait timed out after %ss; aborting stream",
+                    "gRPC chunk backpressure wait timed out after %ss; aborted request",
                     self._BACKPRESSURE_TIMEOUT_S,
                 )
-                return False
-            ready_event.clear()
+            else:
+                logger.warning(
+                    "gRPC chunk backpressure wait timed out after %ss; closing stream",
+                    self._BACKPRESSURE_TIMEOUT_S,
+                )
+            return False
+        ready_event.clear()
         return True
 
     def _install_on_ready(self, chunk_callback) -> Optional[asyncio.Event]:
-        """Register an on_ready hook on ``chunk_callback`` that wakes a TM-loop Event.
-
-        Returns the event, or None if the callback doesn't expose
-        set_on_ready (e.g. unit-test stub) so callers can no-op gracefully.
-        """
         set_on_ready = getattr(chunk_callback, "set_on_ready", None)
         if set_on_ready is None:
             return None
@@ -184,15 +158,13 @@ class RuntimeHandle:
         loop = self._tm_loop
 
         def _on_ready() -> None:
-            # Fired from a Tokio thread under the GIL; bounce onto the TM
-            # loop so the awaiting coroutine wakes safely.
             loop.call_soon_threadsafe(ready_event.set)
 
         try:
             set_on_ready(_on_ready)
         except Exception as e:
             logger.warning("gRPC set_on_ready failed: %s", e)
-            return None
+            raise
         return ready_event
 
     @staticmethod
@@ -211,10 +183,6 @@ class RuntimeHandle:
 
     @staticmethod
     def _log_unhandled_future_exception(future) -> None:
-        # All RuntimeHandle coroutines wrap their bodies in try/except and
-        # route errors through chunk_callback, so this is a defence in depth:
-        # if anything ever escapes (or a new caller forgets the wrap), we
-        # surface it instead of silently hanging the gRPC stream.
         try:
             future.result()
         except Exception as e:
@@ -232,14 +200,6 @@ class RuntimeHandle:
         *,
         error_payload_fn: Optional[Callable[[Exception], Any]] = None,
     ) -> None:
-        """Schedule a unary op whose result is JSON-encoded and sent via chunk_callback.
-
-        ``payload_coro_factory`` is a zero-arg callable returning a coroutine
-        that awaits the operation and returns the success payload (dict/list).
-        ``error_payload_fn`` maps a caught exception to the payload sent on
-        the error path; defaults to ``{"error": {"message": str(e)}}``,
-        matching the OpenAI passthrough error shape.
-        """
         error_fn = error_payload_fn or (lambda e: {"error": {"message": str(e)}})
 
         async def _run() -> None:
@@ -305,22 +265,8 @@ class RuntimeHandle:
         chunk_callback,
         is_disconnected_fn: Optional[Callable[[], bool]] = None,
     ):
-        """Submit a generate or embed request from a pre-built dict.
-
-        The Rust gRPC server builds ``req_dict`` directly from proto fields,
-        mapping them to GenerateReqInput / EmbeddingReqInput field names.
-        Python just does ``**dict`` unpacking - no JSON parsing needed.
-
-        Args:
-            req_type: "generate" or "embed" (classify uses "embed").
-            req_dict: Dict matching the dataclass constructor kwargs.
-            chunk_callback: Rust-side PyO3 callback object.
-            is_disconnected_fn: Optional sync callable wrapping the Rust
-                cancellation token; lets TokenizerManager abort the request
-                when the gRPC client drops.
-        """
         mock_request = (
-            MockRequest(is_disconnected_fn=is_disconnected_fn)
+            _GrpcRequest(is_disconnected_fn=is_disconnected_fn)
             if is_disconnected_fn is not None
             else None
         )
@@ -343,11 +289,9 @@ class RuntimeHandle:
             )
 
     async def _run_generate(self, obj, chunk_callback, stream: bool, request):
-        # ChunkCallback expects a PyDict positional arg; even error chunks
-        # send {} (the body is ignored when error= is set, but pyo3 still
-        # extracts the dict before dispatching).
-        ready_event = self._install_on_ready(chunk_callback) if stream else None
+        ready_event = None
         try:
+            ready_event = self._install_on_ready(chunk_callback) if stream else None
             gen = self.tokenizer_manager.generate_request(obj, request=request)
             if stream:
                 async for chunk in gen:
@@ -355,7 +299,11 @@ class RuntimeHandle:
                         chunk.get("meta_info", {}).get("finish_reason") is not None
                     )
                     keep_going = await self._send_with_backpressure(
-                        chunk_callback, ready_event, chunk, finished=finished
+                        chunk_callback,
+                        ready_event,
+                        chunk,
+                        finished=finished,
+                        timeout_abort_rid=obj.rid,
                     )
                     if finished or not keep_going:
                         return
@@ -368,7 +316,7 @@ class RuntimeHandle:
             self._safe_callback(chunk_callback, {}, finished=True)
         except Exception as e:
             logger.error("gRPC generate error for rid=%s: %s", obj.rid, e)
-            self._safe_callback(chunk_callback, {}, finished=True, error=str(e))
+            self._send_native_error(chunk_callback, str(e))
         finally:
             if stream:
                 self._uninstall_on_ready(chunk_callback)
@@ -382,7 +330,7 @@ class RuntimeHandle:
             self._safe_callback(chunk_callback, {}, finished=True)
         except Exception as e:
             logger.error("gRPC embed error for rid=%s: %s", obj.rid, e)
-            self._safe_callback(chunk_callback, {}, finished=True, error=str(e))
+            self._send_native_error(chunk_callback, str(e))
 
     # Bounded so a stuck TM loop can't deadlock the gRPC handler thread that
     # called abort. abort_request only enqueues a message on the ZMQ socket,
@@ -423,7 +371,6 @@ class RuntimeHandle:
         self.tokenizer_manager.abort_request(rid=rid, abort_all=abort_all)
 
     def get_model_info(self) -> str:
-        """Return model info as a JSON string."""
         model_config = self.tokenizer_manager.model_config
         result = {
             "model_path": self.tokenizer_manager.model_path,
@@ -436,16 +383,11 @@ class RuntimeHandle:
         return json.dumps(result, default=str)
 
     def get_server_info(self) -> str:
-        """Return server info as a JSON string."""
-        # dataclasses.asdict only walks declared fields, so dynamic attrs like
-        # ServerArgs.model_config (set lazily by get_model_config) are
-        # excluded automatically.
         result: Dict[str, Any] = dict(dataclasses.asdict(self.server_args))
         result.update(self.scheduler_info)
         return json.dumps(result, default=str)
 
     def health_check(self) -> bool:
-        """Return True if the server is healthy."""
         from sglang.srt.managers.tokenizer_manager import ServerStatus
 
         if self.tokenizer_manager.gracefully_exit:
@@ -456,7 +398,6 @@ class RuntimeHandle:
         )
 
     def tokenize(self, text: str, add_special_tokens: bool = True) -> str:
-        """Tokenize text and return result as JSON string."""
         tokenizer = self.tokenizer_manager.tokenizer
         tokens = tokenizer.encode(text, add_special_tokens=add_special_tokens)
         result = {
@@ -468,13 +409,11 @@ class RuntimeHandle:
         return json.dumps(result)
 
     def detokenize(self, tokens: List[int]) -> str:
-        """Detokenize token IDs and return result as JSON string."""
         tokenizer = self.tokenizer_manager.tokenizer
         text = tokenizer.decode(tokens)
         return json.dumps({"text": text})
 
     def list_models(self) -> str:
-        """Return the list of served models as JSON string."""
         served_model_name = self.tokenizer_manager.served_model_name
         models = [
             {
@@ -498,17 +437,13 @@ class RuntimeHandle:
         return json.dumps(models)
 
     def get_load(self, chunk_callback, dp_rank: Optional[int] = None) -> None:
-        """Return load info via chunk_callback."""
-
         async def _payload():
             result = await self.tokenizer_manager.get_loads(dp_rank=dp_rank)
-            return [dataclasses.asdict(r) for r in result]
+            return [r.to_dict() for r in result]
 
         self._submit_json_unary("get_load", _payload, chunk_callback)
 
     def flush_cache(self, chunk_callback) -> None:
-        """Flush the radix cache. Sends result through chunk_callback."""
-
         async def _payload():
             ret = await self.tokenizer_manager.flush_cache()
             return {"success": ret.success, "message": "Cache flushed."}
@@ -521,8 +456,6 @@ class RuntimeHandle:
         )
 
     def pause_generation(self, mode: str, chunk_callback) -> None:
-        """Pause generation. Sends result through chunk_callback."""
-
         async def _payload():
             from sglang.srt.managers.io_struct import PauseGenerationReqInput
 
@@ -534,8 +467,6 @@ class RuntimeHandle:
         self._submit_json_unary("pause_generation", _payload, chunk_callback)
 
     def continue_generation(self, chunk_callback) -> None:
-        """Continue generation. Sends result through chunk_callback."""
-
         async def _payload():
             from sglang.srt.managers.io_struct import ContinueGenerationReqInput
 
@@ -547,8 +478,6 @@ class RuntimeHandle:
         self._submit_json_unary("continue_generation", _payload, chunk_callback)
 
     def start_profile(self, output_dir: Optional[str], chunk_callback) -> None:
-        """Start profiling. Sends result through chunk_callback."""
-
         async def _payload():
             kwargs = {"output_dir": output_dir} if output_dir else {}
             await self.tokenizer_manager.start_profile(**kwargs)
@@ -557,8 +486,6 @@ class RuntimeHandle:
         self._submit_json_unary("start_profile", _payload, chunk_callback)
 
     def stop_profile(self, chunk_callback) -> None:
-        """Stop profiling. Sends result through chunk_callback."""
-
         async def _payload():
             await self.tokenizer_manager.stop_profile()
             return {"message": "Profiling stopped."}
@@ -568,8 +495,6 @@ class RuntimeHandle:
     def update_weights_from_disk(
         self, model_path: str, load_format: Optional[str], chunk_callback
     ) -> None:
-        """Update weights from disk. Sends result through chunk_callback."""
-
         async def _payload():
             from sglang.srt.managers.io_struct import UpdateWeightFromDiskReqInput
 
@@ -601,7 +526,6 @@ class RuntimeHandle:
         trace_headers: Optional[Dict[str, str]],
         is_disconnected_fn: Optional[Callable[[], bool]],
     ) -> None:
-        """Schedule an OpenAI pass-through request on the tokenizer_manager loop."""
         self._submit_on_tm_loop(
             self._run_openai_request(
                 serving_key,
@@ -621,7 +545,6 @@ class RuntimeHandle:
         trace_headers: Optional[Dict[str, str]] = None,
         is_disconnected_fn: Optional[Callable[[], bool]] = None,
     ) -> None:
-        """Submit OpenAI chat completion (JSON pass-through, streaming)."""
         self._submit_openai(
             "chat", True, json_body, chunk_callback, trace_headers, is_disconnected_fn
         )
@@ -634,7 +557,6 @@ class RuntimeHandle:
         trace_headers: Optional[Dict[str, str]] = None,
         is_disconnected_fn: Optional[Callable[[], bool]] = None,
     ) -> None:
-        """Submit OpenAI completion (JSON pass-through, streaming)."""
         self._submit_openai(
             "completion",
             True,
@@ -652,7 +574,6 @@ class RuntimeHandle:
         trace_headers: Optional[Dict[str, str]] = None,
         is_disconnected_fn: Optional[Callable[[], bool]] = None,
     ) -> None:
-        """Submit OpenAI embedding (JSON pass-through, unary)."""
         self._submit_openai(
             "embedding",
             False,
@@ -670,7 +591,6 @@ class RuntimeHandle:
         trace_headers: Optional[Dict[str, str]] = None,
         is_disconnected_fn: Optional[Callable[[], bool]] = None,
     ) -> None:
-        """Submit OpenAI classify (JSON pass-through, unary)."""
         self._submit_openai(
             "classify",
             False,
@@ -688,7 +608,6 @@ class RuntimeHandle:
         trace_headers: Optional[Dict[str, str]] = None,
         is_disconnected_fn: Optional[Callable[[], bool]] = None,
     ) -> None:
-        """Submit OpenAI score (JSON pass-through, unary)."""
         self._submit_openai(
             "score", False, json_body, chunk_callback, trace_headers, is_disconnected_fn
         )
@@ -701,7 +620,6 @@ class RuntimeHandle:
         trace_headers: Optional[Dict[str, str]] = None,
         is_disconnected_fn: Optional[Callable[[], bool]] = None,
     ) -> None:
-        """Submit OpenAI rerank (JSON pass-through, unary)."""
         self._submit_openai(
             "rerank",
             False,
@@ -740,32 +658,18 @@ class RuntimeHandle:
         trace_headers: Optional[Dict[str, str]] = None,
         is_disconnected_fn: Optional[Callable[[], bool]] = None,
     ):
-        """Generic OpenAI pass-through handler.
-
-        Delegates to the appropriate OpenAIServing* class, sending response
-        data back through the Rust chunk_callback.
-        """
         try:
             serving = self._get_openai_serving()[serving_key]
 
-            # JSON parse + Pydantic validation are client errors. Surface
-            # them with status_code=400 so the Rust side maps them to
-            # INVALID_ARGUMENT instead of INTERNAL. They always happen
-            # before any stream chunks are emitted, so it is safe to send a
-            # single status-bearing chunk even on streaming endpoints.
             try:
                 request_dict = json.loads(json_body)
-                # `[]`, `null`, `"…"`, numbers etc. parse as JSON but can't be
-                # **-unpacked into the request model; that raises TypeError
-                # outside our handler and ends up as an internal 500. Reject
-                # non-object bodies up front as a client error.
                 if not isinstance(request_dict, dict):
-                    raise TypeError(
+                    raise _BadOpenAIRequest(
                         f"Request body must be a JSON object, got {type(request_dict).__name__}"
                     )
                 request_cls = self._get_openai_request_class(serving_key)
                 request_obj = request_cls(**request_dict)
-            except (json.JSONDecodeError, ValidationError, TypeError) as e:
+            except (json.JSONDecodeError, ValidationError, _BadOpenAIRequest) as e:
                 error_body = json.dumps(
                     {"error": {"message": str(e), "type": "BadRequest"}}
                 ).encode("utf-8")
@@ -774,7 +678,7 @@ class RuntimeHandle:
                 )
                 return
 
-            mock_request = MockRequest(
+            mock_request = _GrpcRequest(
                 headers=trace_headers,
                 is_disconnected_fn=is_disconnected_fn,
             )
@@ -782,13 +686,6 @@ class RuntimeHandle:
             result = await serving.handle_request(request_obj, mock_request)
 
             if hasattr(result, "body_iterator"):
-                # Parse SSE events per WHATWG spec (data:/event:/id: fields,
-                # `:` comments, blank-line event boundaries). OpenAIServing*
-                # currently emits one `data: <json>\n\n` per yield, but a
-                # naive `startswith("data: ")` filter silently drops anything
-                # else — multi-line data, comments, future event/id usage.
-                # See follow-up: replace SSE round-trip with a (dict,
-                # finished) hook on OpenAIServing*.
                 ready_event = self._install_on_ready(chunk_callback)
                 data_buf: List[str] = []
                 stream_closed = False
@@ -830,8 +727,6 @@ class RuntimeHandle:
                             break
 
                     if not stream_closed:
-                        # Defensive: emit a trailing event if the stream ended
-                        # without a final blank line.
                         await _flush_event()
                         self._safe_callback(chunk_callback, b"", finished=True)
                 finally:
@@ -845,15 +740,17 @@ class RuntimeHandle:
                     resp_bytes = json.dumps(result).encode("utf-8")
                 else:
                     resp_bytes = str(result).encode("utf-8")
-                # ErrorResponse uses ``code``; Starlette/FastAPI Response
-                # uses ``status_code``. Honour whichever is present so error
-                # responses don't ship as HTTP 200 with an error body.
                 status_code = int(
                     getattr(result, "status_code", None)
                     or getattr(result, "code", None)
                     or 200
                 )
-                chunk_callback(resp_bytes, finished=True, status_code=status_code)
+                self._safe_callback(
+                    chunk_callback,
+                    resp_bytes,
+                    finished=True,
+                    status_code=status_code,
+                )
 
         except Exception as e:
             logger.error("gRPC OpenAI %s error: %s", serving_key, e)

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -105,14 +105,105 @@ class RuntimeHandle:
         """
         return self._event_loop
 
-    def _safe_callback(self, chunk_callback, payload, **kwargs) -> None:
+    def _safe_callback(self, chunk_callback, payload, **kwargs):
+        """Invoke chunk_callback swallowing exceptions; returns the status it returned, or None on failure.
+
+        The Rust callbacks return ``ChunkSendStatus`` (Ready/Pending/Closed);
+        callers that care about backpressure should use
+        ``_send_with_backpressure`` instead, which awaits on Pending.
+        """
         try:
-            chunk_callback(payload, **kwargs)
+            return chunk_callback(payload, **kwargs)
         except Exception as e:
             # Most often: Rust receiver dropped (client disconnect, channel
             # closed). Log at warning so it's visible without spamming on
             # every normal cancellation.
             logger.warning("gRPC chunk_callback failed: %s", e)
+            return None
+
+    # Generous ceiling so a Rust-side close that fails to fire on_ready
+    # (only possible when the channel closes during a parked send) doesn't
+    # deadlock the stream coroutine forever. Legitimate slow clients can
+    # easily take seconds per chunk, so this is a stuck-stream backstop, not
+    # a normal pacing knob.
+    _BACKPRESSURE_TIMEOUT_S = 300.0
+
+    @staticmethod
+    def _is_pending_status(status) -> bool:
+        # ChunkSendStatus is a Rust pyclass enum with eq_int, so name-based
+        # comparison via the variant on the value's type works regardless of
+        # discriminant values.
+        return status is not None and status == type(status).Pending
+
+    @staticmethod
+    def _is_closed_status(status) -> bool:
+        return status is not None and status == type(status).Closed
+
+    async def _send_with_backpressure(
+        self,
+        chunk_callback,
+        ready_event: Optional[asyncio.Event],
+        payload,
+        **kwargs,
+    ) -> bool:
+        """Send one chunk and honor ChunkSendStatus backpressure.
+
+        Returns True if the caller should keep producing, False if the Rust
+        side reported the channel closed (or the call itself failed).
+        ``ready_event`` may be None if the callback doesn't support
+        set_on_ready (test stubs); in that case Pending is treated as
+        Ready — best-effort, not crash.
+        """
+        status = self._safe_callback(chunk_callback, payload, **kwargs)
+        if status is None or self._is_closed_status(status):
+            return False
+        if self._is_pending_status(status) and ready_event is not None:
+            try:
+                await asyncio.wait_for(
+                    ready_event.wait(), timeout=self._BACKPRESSURE_TIMEOUT_S
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "gRPC chunk backpressure wait timed out after %ss; aborting stream",
+                    self._BACKPRESSURE_TIMEOUT_S,
+                )
+                return False
+            ready_event.clear()
+        return True
+
+    def _install_on_ready(self, chunk_callback) -> Optional[asyncio.Event]:
+        """Register an on_ready hook on ``chunk_callback`` that wakes a TM-loop Event.
+
+        Returns the event, or None if the callback doesn't expose
+        set_on_ready (e.g. unit-test stub) so callers can no-op gracefully.
+        """
+        set_on_ready = getattr(chunk_callback, "set_on_ready", None)
+        if set_on_ready is None:
+            return None
+        ready_event = asyncio.Event()
+        loop = self._tm_loop
+
+        def _on_ready() -> None:
+            # Fired from a Tokio thread under the GIL; bounce onto the TM
+            # loop so the awaiting coroutine wakes safely.
+            loop.call_soon_threadsafe(ready_event.set)
+
+        try:
+            set_on_ready(_on_ready)
+        except Exception as e:
+            logger.warning("gRPC set_on_ready failed: %s", e)
+            return None
+        return ready_event
+
+    @staticmethod
+    def _uninstall_on_ready(chunk_callback) -> None:
+        clear = getattr(chunk_callback, "clear_on_ready", None)
+        if clear is None:
+            return
+        try:
+            clear()
+        except Exception as e:
+            logger.warning("gRPC clear_on_ready failed: %s", e)
 
     def _submit_on_tm_loop(self, coro: Awaitable) -> None:
         future = asyncio.run_coroutine_threadsafe(coro, self._tm_loop)
@@ -252,6 +343,10 @@ class RuntimeHandle:
             )
 
     async def _run_generate(self, obj, chunk_callback, stream: bool, request):
+        # ChunkCallback expects a PyDict positional arg; even error chunks
+        # send {} (the body is ignored when error= is set, but pyo3 still
+        # extracts the dict before dispatching).
+        ready_event = self._install_on_ready(chunk_callback) if stream else None
         try:
             gen = self.tokenizer_manager.generate_request(obj, request=request)
             if stream:
@@ -259,11 +354,12 @@ class RuntimeHandle:
                     finished = (
                         chunk.get("meta_info", {}).get("finish_reason") is not None
                     )
-                    self._safe_callback(chunk_callback, chunk, finished=finished)
-                    if finished:
+                    keep_going = await self._send_with_backpressure(
+                        chunk_callback, ready_event, chunk, finished=finished
+                    )
+                    if finished or not keep_going:
                         return
                 # Defensive: generator exited without a finish_reason chunk.
-                # Send a terminal callback so the Rust side closes the stream.
                 self._safe_callback(chunk_callback, {}, finished=True)
             else:
                 result = await gen.__anext__()
@@ -272,12 +368,10 @@ class RuntimeHandle:
             self._safe_callback(chunk_callback, {}, finished=True)
         except Exception as e:
             logger.error("gRPC generate error for rid=%s: %s", obj.rid, e)
-            self._safe_callback(
-                chunk_callback,
-                json.dumps({"error": {"message": str(e)}}).encode("utf-8"),
-                finished=True,
-                error=str(e),
-            )
+            self._safe_callback(chunk_callback, {}, finished=True, error=str(e))
+        finally:
+            if stream:
+                self._uninstall_on_ready(chunk_callback)
 
     async def _run_embed(self, obj, chunk_callback, request):
         try:
@@ -288,12 +382,7 @@ class RuntimeHandle:
             self._safe_callback(chunk_callback, {}, finished=True)
         except Exception as e:
             logger.error("gRPC embed error for rid=%s: %s", obj.rid, e)
-            self._safe_callback(
-                chunk_callback,
-                json.dumps({"error": {"message": str(e)}}).encode("utf-8"),
-                finished=True,
-                error=str(e),
-            )
+            self._safe_callback(chunk_callback, {}, finished=True, error=str(e))
 
     # Bounded so a stuck TM loop can't deadlock the gRPC handler thread that
     # called abort. abort_request only enqueues a message on the ZMQ socket,
@@ -666,9 +755,17 @@ class RuntimeHandle:
             # single status-bearing chunk even on streaming endpoints.
             try:
                 request_dict = json.loads(json_body)
+                # `[]`, `null`, `"…"`, numbers etc. parse as JSON but can't be
+                # **-unpacked into the request model; that raises TypeError
+                # outside our handler and ends up as an internal 500. Reject
+                # non-object bodies up front as a client error.
+                if not isinstance(request_dict, dict):
+                    raise TypeError(
+                        f"Request body must be a JSON object, got {type(request_dict).__name__}"
+                    )
                 request_cls = self._get_openai_request_class(serving_key)
                 request_obj = request_cls(**request_dict)
-            except (json.JSONDecodeError, ValidationError) as e:
+            except (json.JSONDecodeError, ValidationError, TypeError) as e:
                 error_body = json.dumps(
                     {"error": {"message": str(e), "type": "BadRequest"}}
                 ).encode("utf-8")
@@ -692,37 +789,53 @@ class RuntimeHandle:
                 # else — multi-line data, comments, future event/id usage.
                 # See follow-up: replace SSE round-trip with a (dict,
                 # finished) hook on OpenAIServing*.
+                ready_event = self._install_on_ready(chunk_callback)
                 data_buf: List[str] = []
+                stream_closed = False
 
-                def _flush_event() -> None:
+                async def _flush_event() -> bool:
+                    """Flush buffered SSE data lines as one chunk. Returns False if Rust closed."""
                     if not data_buf:
-                        return
+                        return True
                     body = "\n".join(data_buf)
                     data_buf.clear()
                     if body == "[DONE]" or not body:
-                        return
-                    chunk_callback(body.encode("utf-8"), finished=False)
+                        return True
+                    return await self._send_with_backpressure(
+                        chunk_callback,
+                        ready_event,
+                        body.encode("utf-8"),
+                        finished=False,
+                    )
 
-                async for raw_chunk in result.body_iterator:
-                    if isinstance(raw_chunk, bytes):
-                        raw_chunk = raw_chunk.decode("utf-8", errors="replace")
-                    for line in raw_chunk.split("\n"):
-                        line = line.rstrip("\r")
-                        if not line:
-                            _flush_event()
-                        elif line.startswith(":"):
-                            continue  # SSE comment / heartbeat
-                        elif line.startswith("data:"):
-                            value = line[5:]
-                            if value.startswith(" "):
-                                value = value[1:]
-                            data_buf.append(value)
-                        # event:, id:, retry:, unknown fields: ignored
+                try:
+                    async for raw_chunk in result.body_iterator:
+                        if isinstance(raw_chunk, bytes):
+                            raw_chunk = raw_chunk.decode("utf-8", errors="replace")
+                        for line in raw_chunk.split("\n"):
+                            line = line.rstrip("\r")
+                            if not line:
+                                if not await _flush_event():
+                                    stream_closed = True
+                                    break
+                            elif line.startswith(":"):
+                                continue  # SSE comment / heartbeat
+                            elif line.startswith("data:"):
+                                value = line[5:]
+                                if value.startswith(" "):
+                                    value = value[1:]
+                                data_buf.append(value)
+                            # event:, id:, retry:, unknown fields: ignored
+                        if stream_closed:
+                            break
 
-                # Defensive: emit a trailing event if the stream ended
-                # without a final blank line.
-                _flush_event()
-                chunk_callback(b"", finished=True)
+                    if not stream_closed:
+                        # Defensive: emit a trailing event if the stream ended
+                        # without a final blank line.
+                        await _flush_event()
+                        self._safe_callback(chunk_callback, b"", finished=True)
+                finally:
+                    self._uninstall_on_ready(chunk_callback)
             else:
                 if hasattr(result, "model_dump"):
                     resp_bytes = json.dumps(result.model_dump()).encode("utf-8")


### PR DESCRIPTION
## Summary
Introduces `python/sglang/srt/entrypoints/grpc_bridge.py`, providing `RuntimeHandle` — the Python-side handle the Rust gRPC server calls into via PyO3. `RuntimeHandle` exposes synchronous `submit_*`, `abort`, and info methods that delegate to `TokenizerManager`; streaming responses are pushed back into Rust via per-request callbacks while async work stays on the `TokenizerManager` event loop.

## Stack
Part of the phase-1 split of the original PR #22907. Review order:
1. ~~#23506 — Rust crate~~ (merged)
2. **(this)** `python-bridge`
3. `server-integration` — launcher / HTTP server / server args wiring
4. `tests` — integration tests

## Test plan
- [ ] `python -c "from sglang.srt.entrypoints import grpc_bridge"`
- [ ] Smoke-test that the Rust extension (`sglang.srt.grpc._core`) can construct a `RuntimeHandle` and invoke `get_model_info`/`health_check` end-to-end

























































































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #27961972677](https://github.com/sgl-project/sglang/actions/runs/27961972677)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27961971692](https://github.com/sgl-project/sglang/actions/runs/27961971692)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->