### PR TITLE
[gRPC] Native server: integration tests (4/4)

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -102,8 +102,11 @@ torch = { index = "torch-cu130" }
 torchvision = { index = "torch-cu130" }
 torchaudio = { index = "torch-cu130" }
 sglang-kernel = { index = "sglang-kernel-cu130" }
+# sglang-grpc is built from rust/sglang-grpc (maturin); not published on PyPI.
+sglang-grpc = { path = "../rust/sglang-grpc", editable = true }
 
 [project.optional-dependencies]
+grpc = ["sglang-grpc>=0.1.0"]
 checkpoint-engine = ["checkpoint-engine==0.1.2"]
 runai = ["runai-model-streamer[s3,gcs,azure]>=0.15.7"]
 diffusion = [

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -102,11 +102,8 @@ torch = { index = "torch-cu130" }
 torchvision = { index = "torch-cu130" }
 torchaudio = { index = "torch-cu130" }
 sglang-kernel = { index = "sglang-kernel-cu130" }
-# sglang-grpc is built from rust/sglang-grpc (maturin); not published on PyPI.
-sglang-grpc = { path = "../rust/sglang-grpc", editable = true }
 
 [project.optional-dependencies]
-grpc = ["sglang-grpc>=0.1.0"]
 checkpoint-engine = ["checkpoint-engine==0.1.2"]
 runai = ["runai-model-streamer[s3,gcs,azure]>=0.15.7"]
 diffusion = [

--- a/python/sglang/launch_server.py
+++ b/python/sglang/launch_server.py
@@ -13,10 +13,10 @@ suppress_noisy_warnings()
 
 
 def run_server(server_args):
-    """Run the server based on server_args.grpc_mode and server_args.encoder_only."""
+    """Run the server based on server_args configuration."""
     if server_args.encoder_only:
         # For encoder disaggregation
-        if server_args.grpc_mode:
+        if server_args.smg_grpc or server_args.grpc_mode:
             from sglang.srt.disaggregation.encode_grpc_server import (
                 serve_grpc_encoder,
             )
@@ -26,10 +26,7 @@ def run_server(server_args):
             from sglang.srt.disaggregation.encode_server import launch_server
 
             launch_server(server_args)
-    elif server_args.grpc_mode:
-        # TODO: Once the native Rust gRPC server starts alongside HTTP in the
-        # default path below (controlled by SGLANG_ENABLE_GRPC / SGLANG_GRPC_PORT),
-        # remove this legacy SMG path and the grpc_mode flag.
+    elif server_args.smg_grpc:
         from sglang.srt.entrypoints.grpc_server import serve_grpc
 
         asyncio.run(serve_grpc(server_args))

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -1,0 +1,695 @@
+"""Python-side bridge between the Rust gRPC server and TokenizerManager.
+
+The RuntimeHandle exposes synchronous methods that Rust can call via PyO3
+(with a brief GIL acquisition). Response chunks are pushed into Rust-side
+channels via callback objects while all async work stays on the
+TokenizerManager's event loop.
+"""
+
+import asyncio
+import dataclasses
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class MockRequest:
+    """Lightweight stand-in for fastapi.Request when called from gRPC.
+
+    The OpenAI serving classes expect a fastapi.Request for disconnect
+    detection and routing key extraction. This satisfies that interface
+    without importing FastAPI.
+    """
+
+    def __init__(self, headers: Optional[Dict[str, str]] = None):
+        self.headers = headers or {}
+        self.url = type("URL", (), {"path": "/grpc"})()
+        self.state = type("State", (), {})()
+        self.app = type("App", (), {"state": type("AppState", (), {})()})()
+
+    async def is_disconnected(self) -> bool:
+        return False
+
+
+class RuntimeHandle:
+    """Thin Python handle that the Rust gRPC server calls into.
+
+    Provides synchronous ``submit_*``, ``abort``, and info methods.
+    Each submit method receives a ``chunk_callback`` (a Rust-side PyO3 object)
+    that it invokes with ``(chunk_dict, finished, error)`` for each response
+    chunk produced by TokenizerManager.
+    """
+
+    def __init__(
+        self,
+        tokenizer_manager,
+        template_manager,
+        server_args,
+        scheduler_info: Optional[Dict] = None,
+    ):
+        self.tokenizer_manager = tokenizer_manager
+        self.template_manager = template_manager
+        self.server_args = server_args
+        self.scheduler_info = scheduler_info or {}
+
+        self._openai_serving_classes = None
+
+    @property
+    def _tm_loop(self):
+        """Return the tokenizer_manager's event loop (uvicorn loop).
+
+        Communicator-based async methods (flush_cache, get_load, etc.) use
+        asyncio.Event internally, which only works within a single event
+        loop. These must run on the same loop as handle_loop(), i.e. the
+        tokenizer_manager's event_loop.
+        """
+        loop = getattr(self.tokenizer_manager, "event_loop", None)
+        if loop is None:
+            raise RuntimeError(
+                "TokenizerManager event loop not ready - server still starting"
+            )
+        return loop
+
+    def _safe_callback(self, chunk_callback, payload, *, finished: bool, error=None):
+        try:
+            chunk_callback(payload, finished=finished, error=error)
+        except Exception:
+            pass
+
+    def _submit_on_tm_loop(self, coro_factory, chunk_callback, *, empty_response):
+        try:
+            loop = self._tm_loop
+        except RuntimeError as e:
+            self._safe_callback(
+                chunk_callback, empty_response, finished=True, error=str(e)
+            )
+            return
+        asyncio.run_coroutine_threadsafe(coro_factory(), loop)
+
+    def _get_openai_serving(self):
+        """Lazily initialize OpenAI serving classes."""
+        if self._openai_serving_classes is not None:
+            return self._openai_serving_classes
+
+        from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
+        from sglang.srt.entrypoints.openai.serving_classify import (
+            OpenAIServingClassify,
+        )
+        from sglang.srt.entrypoints.openai.serving_completions import (
+            OpenAIServingCompletion,
+        )
+        from sglang.srt.entrypoints.openai.serving_embedding import (
+            OpenAIServingEmbedding,
+        )
+        from sglang.srt.entrypoints.openai.serving_rerank import OpenAIServingRerank
+        from sglang.srt.entrypoints.openai.serving_score import OpenAIServingScore
+
+        self._openai_serving_classes = {
+            "chat": OpenAIServingChat(self.tokenizer_manager, self.template_manager),
+            "completion": OpenAIServingCompletion(
+                self.tokenizer_manager, self.template_manager
+            ),
+            "embedding": OpenAIServingEmbedding(
+                self.tokenizer_manager, self.template_manager
+            ),
+            "classify": OpenAIServingClassify(
+                self.tokenizer_manager, self.template_manager
+            ),
+            "score": OpenAIServingScore(self.tokenizer_manager),
+            "rerank": OpenAIServingRerank(
+                self.tokenizer_manager, self.template_manager
+            ),
+        }
+        return self._openai_serving_classes
+
+    # ------------------------------------------------------------------
+    # Consolidated request submission (generate / embed / classify)
+    # ------------------------------------------------------------------
+
+    def submit_request(self, *, req_type: str, req_dict: dict, chunk_callback):
+        """Submit a generate or embed request from a pre-built dict.
+
+        The Rust gRPC server builds ``req_dict`` directly from proto fields,
+        mapping them to GenerateReqInput / EmbeddingReqInput field names.
+        Python just does ``**dict`` unpacking - no JSON parsing needed.
+
+        Args:
+            req_type: "generate" or "embed" (classify uses "embed").
+            req_dict: Dict matching the dataclass constructor kwargs.
+            chunk_callback: Rust-side PyO3 callback object.
+        """
+        if req_type == "generate":
+            from sglang.srt.managers.io_struct import GenerateReqInput
+
+            obj = GenerateReqInput(**req_dict)
+            stream = req_dict.get("stream", False)
+            self._submit_on_tm_loop(
+                lambda: self._run_generate(obj, chunk_callback, stream),
+                chunk_callback,
+                empty_response={},
+            )
+        else:
+            from sglang.srt.managers.io_struct import EmbeddingReqInput
+
+            obj = EmbeddingReqInput(**req_dict)
+            self._submit_on_tm_loop(
+                lambda: self._run_embed(obj, chunk_callback),
+                chunk_callback,
+                empty_response={},
+            )
+
+    async def _run_generate(self, obj, chunk_callback, stream: bool):
+        try:
+            gen = self.tokenizer_manager.generate_request(obj, request=None)
+            if stream:
+                async for chunk in gen:
+                    finished = (
+                        chunk.get("meta_info", {}).get("finish_reason") is not None
+                    )
+                    chunk_callback(chunk, finished=finished)
+                    if finished:
+                        return
+            else:
+                result = await gen.__anext__()
+                chunk_callback(result, finished=True)
+        except StopAsyncIteration:
+            self._safe_callback(chunk_callback, {}, finished=True)
+        except Exception as e:
+            logger.error("gRPC generate error for rid=%s: %s", obj.rid, e)
+            self._safe_callback(chunk_callback, {}, finished=True, error=str(e))
+
+    async def _run_embed(self, obj, chunk_callback):
+        try:
+            gen = self.tokenizer_manager.generate_request(obj, request=None)
+            result = await gen.__anext__()
+            chunk_callback(result, finished=True)
+        except StopAsyncIteration:
+            self._safe_callback(chunk_callback, {}, finished=True)
+        except Exception as e:
+            logger.error("gRPC embed error for rid=%s: %s", obj.rid, e)
+            self._safe_callback(chunk_callback, {}, finished=True, error=str(e))
+
+    # ------------------------------------------------------------------
+    # Abort
+    # ------------------------------------------------------------------
+
+    def abort(self, rid: str = "", abort_all: bool = False):
+        """Abort a request by request ID or abort all active requests."""
+        try:
+            loop = self._tm_loop
+        except RuntimeError:
+            self.tokenizer_manager.abort_request(rid=rid, abort_all=abort_all)
+            return
+
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            running_loop = None
+
+        if running_loop is loop:
+            self.tokenizer_manager.abort_request(rid=rid, abort_all=abort_all)
+            return
+
+        future = asyncio.run_coroutine_threadsafe(
+            self._abort_async(rid, abort_all),
+            loop,
+        )
+        future.result()
+
+    async def _abort_async(self, rid: str, abort_all: bool) -> None:
+        self.tokenizer_manager.abort_request(rid=rid, abort_all=abort_all)
+
+    # ------------------------------------------------------------------
+    # Info RPCs (synchronous, small data)
+    # ------------------------------------------------------------------
+
+    def get_model_info(self) -> str:
+        """Return model info as a JSON string."""
+        model_config = self.tokenizer_manager.model_config
+        result = {
+            "model_path": self.tokenizer_manager.model_path,
+            "tokenizer_path": self.server_args.tokenizer_path,
+            "is_generation": self.tokenizer_manager.is_generation,
+            "weight_version": self.server_args.weight_version,
+            "model_type": getattr(model_config.hf_config, "model_type", None),
+            "architectures": getattr(model_config.hf_config, "architectures", None),
+        }
+        return json.dumps(result, default=str)
+
+    def get_server_info(self) -> str:
+        """Return server info as a JSON string."""
+        result: Dict[str, Any] = {}
+        try:
+            sa = self.server_args
+            if hasattr(sa, "model_config"):
+                sa = dataclasses.replace(sa)
+                if hasattr(sa, "model_config"):
+                    delattr(sa, "model_config")
+            result.update(dataclasses.asdict(sa))
+        except Exception:
+            pass
+        result.update(self.scheduler_info)
+        return json.dumps(result, default=str)
+
+    def health_check(self) -> bool:
+        """Return True if the server is healthy."""
+        from sglang.srt.managers.tokenizer_manager import ServerStatus
+
+        if self.tokenizer_manager.gracefully_exit:
+            return False
+        if self.tokenizer_manager.server_status == ServerStatus.Starting:
+            return False
+        return True
+
+    # ------------------------------------------------------------------
+    # Tokenize / Detokenize (local ops, no inference)
+    # ------------------------------------------------------------------
+
+    def tokenize(self, text: str, add_special_tokens: bool = True) -> str:
+        """Tokenize text and return result as JSON string."""
+        tokenizer = self.tokenizer_manager.tokenizer
+        tokens = tokenizer.encode(text, add_special_tokens=add_special_tokens)
+        result = {
+            "tokens": tokens,
+            "count": len(tokens),
+            "max_model_len": self.tokenizer_manager.model_config.context_len,
+            "input_text": text,
+        }
+        return json.dumps(result)
+
+    def detokenize(self, tokens: List[int]) -> str:
+        """Detokenize token IDs and return result as JSON string."""
+        tokenizer = self.tokenizer_manager.tokenizer
+        text = tokenizer.decode(tokens)
+        return json.dumps({"text": text})
+
+    # ------------------------------------------------------------------
+    # List models
+    # ------------------------------------------------------------------
+
+    def list_models(self) -> str:
+        """Return the list of served models as JSON string."""
+        served_model_name = self.tokenizer_manager.served_model_name
+        models = [
+            {
+                "id": served_model_name,
+                "root": served_model_name,
+                "max_model_len": self.tokenizer_manager.model_config.context_len,
+            }
+        ]
+        if self.server_args.enable_lora and hasattr(
+            self.tokenizer_manager, "lora_registry"
+        ):
+            lora_registry = self.tokenizer_manager.lora_registry
+            for _, lora_ref in lora_registry.get_all_adapters().items():
+                models.append(
+                    {
+                        "id": lora_ref.lora_name,
+                        "root": lora_ref.lora_path,
+                        "parent": served_model_name,
+                    }
+                )
+        return json.dumps(models)
+
+    # ------------------------------------------------------------------
+    # Get load
+    # ------------------------------------------------------------------
+
+    def get_load(self, chunk_callback, dp_rank: Optional[int] = None) -> None:
+        """Return load info via chunk_callback."""
+        self._submit_on_tm_loop(
+            lambda: self._get_load_async(chunk_callback, dp_rank),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    async def _get_load_async(
+        self, chunk_callback, dp_rank: Optional[int] = None
+    ) -> None:
+        try:
+            result = await self.tokenizer_manager.get_loads(dp_rank=dp_rank)
+            data = json.dumps([dataclasses.asdict(r) for r in result], default=str)
+            chunk_callback(data.encode("utf-8"), finished=True)
+        except Exception as e:
+            logger.error("gRPC get_load error: %s", e)
+            data = json.dumps({"error": str(e)})
+            chunk_callback(data.encode("utf-8"), finished=True, error=str(e))
+
+    # ------------------------------------------------------------------
+    # Flush cache
+    # ------------------------------------------------------------------
+
+    def flush_cache(self, chunk_callback) -> None:
+        """Flush the radix cache. Sends result through chunk_callback."""
+        self._submit_on_tm_loop(
+            lambda: self._flush_cache_async(chunk_callback),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    async def _flush_cache_async(self, chunk_callback) -> None:
+        try:
+            ret = await self.tokenizer_manager.flush_cache()
+            result = json.dumps({"success": ret.success, "message": "Cache flushed."})
+            chunk_callback(result.encode("utf-8"), finished=True)
+        except Exception as e:
+            logger.error("gRPC flush_cache error: %s", e)
+            result = json.dumps({"success": False, "message": str(e)})
+            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+
+    # ------------------------------------------------------------------
+    # Pause / Continue generation
+    # ------------------------------------------------------------------
+
+    def pause_generation(self, mode: str, chunk_callback) -> None:
+        """Pause generation. Sends result through chunk_callback."""
+        from sglang.srt.managers.io_struct import PauseGenerationReqInput
+
+        obj = PauseGenerationReqInput(mode=mode)
+        self._submit_on_tm_loop(
+            lambda: self._pause_generation_async(obj, chunk_callback),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    async def _pause_generation_async(self, obj, chunk_callback) -> None:
+        try:
+            await self.tokenizer_manager.pause_generation(obj)
+            result = json.dumps({"message": f"Generation paused (mode={obj.mode})."})
+            chunk_callback(result.encode("utf-8"), finished=True)
+        except Exception as e:
+            logger.error("gRPC pause_generation error: %s", e)
+            result = json.dumps({"message": str(e)})
+            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+
+    def continue_generation(self, chunk_callback) -> None:
+        """Continue generation. Sends result through chunk_callback."""
+        from sglang.srt.managers.io_struct import ContinueGenerationReqInput
+
+        obj = ContinueGenerationReqInput()
+        self._submit_on_tm_loop(
+            lambda: self._continue_generation_async(obj, chunk_callback),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    async def _continue_generation_async(self, obj, chunk_callback) -> None:
+        try:
+            await self.tokenizer_manager.continue_generation(obj)
+            result = json.dumps({"message": "Generation continued."})
+            chunk_callback(result.encode("utf-8"), finished=True)
+        except Exception as e:
+            logger.error("gRPC continue_generation error: %s", e)
+            result = json.dumps({"message": str(e)})
+            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+
+    # ------------------------------------------------------------------
+    # Profile (admin)
+    # ------------------------------------------------------------------
+
+    def start_profile(self, output_dir: Optional[str], chunk_callback) -> None:
+        """Start profiling. Sends result through chunk_callback."""
+        self._submit_on_tm_loop(
+            lambda: self._start_profile_async(output_dir, chunk_callback),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    async def _start_profile_async(self, output_dir, chunk_callback) -> None:
+        try:
+            kwargs = {}
+            if output_dir:
+                kwargs["output_dir"] = output_dir
+            await self.tokenizer_manager.start_profile(**kwargs)
+            result = json.dumps({"message": "Profiling started."})
+            chunk_callback(result.encode("utf-8"), finished=True)
+        except Exception as e:
+            logger.error("gRPC start_profile error: %s", e)
+            result = json.dumps({"message": str(e)})
+            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+
+    def stop_profile(self, chunk_callback) -> None:
+        """Stop profiling. Sends result through chunk_callback."""
+        self._submit_on_tm_loop(
+            lambda: self._stop_profile_async(chunk_callback),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    async def _stop_profile_async(self, chunk_callback) -> None:
+        try:
+            await self.tokenizer_manager.stop_profile()
+            result = json.dumps({"message": "Profiling stopped."})
+            chunk_callback(result.encode("utf-8"), finished=True)
+        except Exception as e:
+            logger.error("gRPC stop_profile error: %s", e)
+            result = json.dumps({"message": str(e)})
+            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+
+    # ------------------------------------------------------------------
+    # Update weights from disk (admin)
+    # ------------------------------------------------------------------
+
+    def update_weights_from_disk(
+        self, model_path: str, load_format: Optional[str], chunk_callback
+    ) -> None:
+        """Update weights from disk. Sends result through chunk_callback."""
+        self._submit_on_tm_loop(
+            lambda: self._update_weights_async(model_path, load_format, chunk_callback),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    async def _update_weights_async(
+        self, model_path: str, load_format: Optional[str], chunk_callback
+    ) -> None:
+        try:
+            from sglang.srt.managers.io_struct import UpdateWeightFromDiskReqInput
+
+            obj = UpdateWeightFromDiskReqInput(
+                model_path=model_path,
+                load_format=load_format,
+            )
+            success, message, num_paused = (
+                await self.tokenizer_manager.update_weights_from_disk(obj, request=None)
+            )
+            result = json.dumps(
+                {
+                    "success": success,
+                    "message": message,
+                    "num_paused_requests": num_paused,
+                }
+            )
+            chunk_callback(result.encode("utf-8"), finished=True)
+        except Exception as e:
+            logger.error("gRPC update_weights error: %s", e)
+            result = json.dumps({"success": False, "message": str(e)})
+            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+
+    # ------------------------------------------------------------------
+    # OpenAI-compatible RPCs (JSON pass-through)
+    # ------------------------------------------------------------------
+
+    def submit_openai_chat(
+        self,
+        *,
+        json_body: bytes,
+        chunk_callback,
+        trace_headers: Optional[Dict[str, str]] = None,
+    ):
+        """Submit OpenAI chat completion (JSON pass-through)."""
+        self._submit_on_tm_loop(
+            lambda: self._run_openai_request(
+                "chat",
+                json_body,
+                chunk_callback,
+                streaming=True,
+                trace_headers=trace_headers,
+            ),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    def submit_openai_complete(
+        self,
+        *,
+        json_body: bytes,
+        chunk_callback,
+        trace_headers: Optional[Dict[str, str]] = None,
+    ):
+        """Submit OpenAI completion (JSON pass-through)."""
+        self._submit_on_tm_loop(
+            lambda: self._run_openai_request(
+                "completion",
+                json_body,
+                chunk_callback,
+                streaming=True,
+                trace_headers=trace_headers,
+            ),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    def submit_openai_embed(
+        self,
+        *,
+        json_body: bytes,
+        chunk_callback,
+        trace_headers: Optional[Dict[str, str]] = None,
+    ):
+        """Submit OpenAI embedding (JSON pass-through, unary)."""
+        self._submit_on_tm_loop(
+            lambda: self._run_openai_request(
+                "embedding",
+                json_body,
+                chunk_callback,
+                streaming=False,
+                trace_headers=trace_headers,
+            ),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    def submit_openai_classify(
+        self,
+        *,
+        json_body: bytes,
+        chunk_callback,
+        trace_headers: Optional[Dict[str, str]] = None,
+    ):
+        """Submit OpenAI classify (JSON pass-through, unary)."""
+        self._submit_on_tm_loop(
+            lambda: self._run_openai_request(
+                "classify",
+                json_body,
+                chunk_callback,
+                streaming=False,
+                trace_headers=trace_headers,
+            ),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    def submit_openai_score(
+        self,
+        *,
+        json_body: bytes,
+        chunk_callback,
+        trace_headers: Optional[Dict[str, str]] = None,
+    ):
+        """Submit OpenAI score (JSON pass-through, unary)."""
+        self._submit_on_tm_loop(
+            lambda: self._run_openai_request(
+                "score",
+                json_body,
+                chunk_callback,
+                streaming=False,
+                trace_headers=trace_headers,
+            ),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    def submit_openai_rerank(
+        self,
+        *,
+        json_body: bytes,
+        chunk_callback,
+        trace_headers: Optional[Dict[str, str]] = None,
+    ):
+        """Submit OpenAI rerank (JSON pass-through, unary)."""
+        self._submit_on_tm_loop(
+            lambda: self._run_openai_request(
+                "rerank",
+                json_body,
+                chunk_callback,
+                streaming=False,
+                trace_headers=trace_headers,
+            ),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    def _get_openai_request_class(self, serving_key: str):
+        """Return the Pydantic request class for a given serving key."""
+        from sglang.srt.entrypoints.openai.protocol import (
+            ChatCompletionRequest,
+            ClassifyRequest,
+            CompletionRequest,
+            EmbeddingRequest,
+            ScoringRequest,
+            V1RerankReqInput,
+        )
+
+        return {
+            "chat": ChatCompletionRequest,
+            "completion": CompletionRequest,
+            "embedding": EmbeddingRequest,
+            "classify": ClassifyRequest,
+            "score": ScoringRequest,
+            "rerank": V1RerankReqInput,
+        }[serving_key]
+
+    async def _run_openai_request(
+        self,
+        serving_key: str,
+        json_body: bytes,
+        chunk_callback,
+        streaming: bool,
+        trace_headers: Optional[Dict[str, str]] = None,
+    ):
+        """Generic OpenAI pass-through handler.
+
+        Delegates to the appropriate OpenAIServing* class, sending response
+        data back through the Rust chunk_callback.
+        """
+        try:
+            serving = self._get_openai_serving()[serving_key]
+            request_dict = json.loads(json_body)
+            mock_request = MockRequest(headers=trace_headers)
+
+            request_cls = self._get_openai_request_class(serving_key)
+            request_obj = request_cls(**request_dict)
+
+            result = await serving.handle_request(request_obj, mock_request)
+
+            if hasattr(result, "body_iterator"):
+                async for raw_chunk in result.body_iterator:
+                    if isinstance(raw_chunk, bytes):
+                        raw_chunk = raw_chunk.decode("utf-8", errors="replace")
+                    if (
+                        raw_chunk.startswith("data: ")
+                        and raw_chunk.strip() != "data: [DONE]"
+                    ):
+                        json_chunk = raw_chunk[len("data: ") :].strip()
+                        if json_chunk:
+                            chunk_callback(json_chunk.encode("utf-8"), finished=False)
+                chunk_callback(b"", finished=True)
+            else:
+                if hasattr(result, "model_dump"):
+                    resp_bytes = json.dumps(result.model_dump()).encode("utf-8")
+                elif hasattr(result, "body"):
+                    resp_bytes = result.body
+                elif isinstance(result, (dict, list)):
+                    resp_bytes = json.dumps(result).encode("utf-8")
+                else:
+                    resp_bytes = str(result).encode("utf-8")
+                status_code = int(getattr(result, "status_code", 200))
+                chunk_callback(resp_bytes, finished=True, status_code=status_code)
+
+        except Exception as e:
+            logger.error("gRPC OpenAI %s error: %s", serving_key, e)
+            error_body = json.dumps({"error": {"message": str(e)}}).encode("utf-8")
+            if streaming:
+                self._safe_callback(chunk_callback, error_body, finished=True, error=str(e))
+            else:
+                try:
+                    chunk_callback(
+                        error_body,
+                        finished=True,
+                        status_code=int(getattr(e, "status_code", 500)),
+                    )
+                except Exception:
+                    pass

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -190,7 +190,7 @@ WAIT_WEIGHTS_READY_TIMEOUT = int(os.getenv("SGLANG_WAIT_WEIGHTS_READY_TIMEOUT", 
 @dataclasses.dataclass
 class _GlobalState:
     tokenizer_manager: Union[TokenizerManager, MultiTokenizerRouter, TokenizerWorker]
-    template_manager: TemplateManager
+    template_manager: Optional[TemplateManager]
     scheduler_info: Dict
 
 
@@ -285,6 +285,7 @@ async def init_multi_tokenizer() -> ServerArgs:
 
 @asynccontextmanager
 async def lifespan(fast_api_app: FastAPI):
+    grpc_handle = None
     if getattr(fast_api_app, "is_single_tokenizer_mode", False):
         server_args = fast_api_app.server_args
         warmup_thread_kwargs = fast_api_app.warmup_thread_kwargs
@@ -377,6 +378,17 @@ async def lifespan(fast_api_app: FastAPI):
         traceback = get_exception_traceback()
         logger.warning(f"Can not initialize OpenAIServingResponses, error: {traceback}")
 
+    if (
+        envs.SGLANG_GRANIAN_PARENT_PID.get() is not None
+        and server_args.enable_grpc
+    ):
+        grpc_handle = _start_native_grpc_server_for_runtime(
+            server_args=server_args,
+            tokenizer_manager=_global_state.tokenizer_manager,
+            template_manager=_global_state.template_manager,
+            scheduler_info=_global_state.scheduler_info,
+        )
+
     # Execute custom warmups
     if server_args.warmups is not None:
         await execute_warmups(
@@ -397,6 +409,7 @@ async def lifespan(fast_api_app: FastAPI):
     try:
         yield
     finally:
+        _shutdown_native_grpc_server(grpc_handle)
         warmup_thread.join()
 
 
@@ -2310,6 +2323,59 @@ def _setup_and_run_http_server(
                 _global_state.tokenizer_manager.socket_mapping.clear_all_sockets()
 
 
+def _start_native_grpc_server_for_runtime(
+    server_args,
+    tokenizer_manager,
+    template_manager,
+    scheduler_info,
+):
+    """Attempt to start the native Rust gRPC server for a live runtime.
+
+    Returns a GrpcServerHandle on success, or None if sglang-grpc is not installed.
+    """
+    try:
+        import sglang_grpc
+
+        from sglang.srt.entrypoints.grpc_bridge import RuntimeHandle
+
+        runtime_handle = RuntimeHandle(
+            tokenizer_manager=tokenizer_manager,
+            template_manager=template_manager,
+            server_args=server_args,
+            scheduler_info=scheduler_info or {},
+        )
+
+        grpc_handle = sglang_grpc.start_server(
+            host=server_args.host,
+            port=server_args.grpc_port,
+            runtime_handle=runtime_handle,
+            worker_threads=server_args.grpc_worker_threads,
+            max_prefill_tokens=server_args.grpc_max_prefill_tokens,
+        )
+        logger.info(
+            f"Native gRPC server started on {server_args.host}:{server_args.grpc_port}"
+        )
+        return grpc_handle
+    except ImportError:
+        logger.info(
+            "sglang-grpc package not installed; native gRPC server disabled. "
+            "Install with: pip install sglang-grpc"
+        )
+        return None
+    except Exception as e:
+        logger.warning(f"Failed to start native gRPC server: {e}")
+        return None
+
+
+def _shutdown_native_grpc_server(grpc_handle) -> None:
+    if grpc_handle is None:
+        return
+    try:
+        grpc_handle.shutdown()
+    except Exception as e:
+        logger.warning(f"Failed to shut down native gRPC server: {e}")
+
+
 def launch_server(
     server_args: ServerArgs,
     init_tokenizer_manager_func: Callable = init_tokenizer_manager,
@@ -2347,13 +2413,32 @@ def launch_server(
         run_detokenizer_process_func=run_detokenizer_process_func,
     )
 
-    _setup_and_run_http_server(
-        server_args,
-        tokenizer_manager,
-        template_manager,
-        port_args,
-        scheduler_init_result.scheduler_infos,
-        subprocess_watchdog,
-        execute_warmup_func=execute_warmup_func,
-        launch_callback=launch_callback,
-    )
+    # Start native gRPC in the same process that owns the live TokenizerManager.
+    # Granian workers get their own TokenizerManager instances, so they start
+    # native gRPC from the worker lifespan instead of the parent process.
+    grpc_handle = None
+    if server_args.enable_grpc and not server_args.enable_http2:
+        grpc_handle = _start_native_grpc_server_for_runtime(
+            server_args,
+            tokenizer_manager,
+            template_manager,
+            (
+                scheduler_init_result.scheduler_infos[0]
+                if scheduler_init_result.scheduler_infos
+                else {}
+            ),
+        )
+
+    try:
+        _setup_and_run_http_server(
+            server_args,
+            tokenizer_manager,
+            template_manager,
+            port_args,
+            scheduler_init_result.scheduler_infos,
+            subprocess_watchdog,
+            execute_warmup_func=execute_warmup_func,
+            launch_callback=launch_callback,
+        )
+    finally:
+        _shutdown_native_grpc_server(grpc_handle)

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -378,10 +378,7 @@ async def lifespan(fast_api_app: FastAPI):
         traceback = get_exception_traceback()
         logger.warning(f"Can not initialize OpenAIServingResponses, error: {traceback}")
 
-    if (
-        envs.SGLANG_GRANIAN_PARENT_PID.get() is not None
-        and server_args.enable_grpc
-    ):
+    if envs.SGLANG_GRANIAN_PARENT_PID.get() is not None and server_args.enable_grpc:
         grpc_handle = _start_native_grpc_server_for_runtime(
             server_args=server_args,
             tokenizer_manager=_global_state.tokenizer_manager,
@@ -2331,12 +2328,12 @@ def _start_native_grpc_server_for_runtime(
 ):
     """Attempt to start the native Rust gRPC server for a live runtime.
 
-    Returns a GrpcServerHandle on success, or None if sglang-grpc is not installed.
+    Returns a GrpcServerHandle on success, or None if the native gRPC
+    extension is not present in this wheel.
     """
     try:
-        import sglang_grpc
-
         from sglang.srt.entrypoints.grpc_bridge import RuntimeHandle
+        from sglang.srt.grpc import _core as grpc_native
 
         runtime_handle = RuntimeHandle(
             tokenizer_manager=tokenizer_manager,
@@ -2345,7 +2342,7 @@ def _start_native_grpc_server_for_runtime(
             scheduler_info=scheduler_info or {},
         )
 
-        grpc_handle = sglang_grpc.start_server(
+        grpc_handle = grpc_native.start_server(
             host=server_args.host,
             port=server_args.grpc_port,
             runtime_handle=runtime_handle,
@@ -2358,8 +2355,9 @@ def _start_native_grpc_server_for_runtime(
         return grpc_handle
     except ImportError:
         logger.info(
-            "sglang-grpc package not installed; native gRPC server disabled. "
-            "Install with: pip install sglang-grpc"
+            "Native gRPC extension (sglang.srt.grpc._core) not found in this wheel; "
+            "native gRPC server disabled. The extension is built from rust/sglang-grpc/ "
+            "via setuptools-rust during wheel build."
         )
         return None
     except Exception as e:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -319,6 +319,11 @@ class ServerArgs:
     port: int = 30000
     fastapi_root_path: str = ""
     grpc_mode: bool = False
+    grpc_port: Optional[int] = None
+    grpc_worker_threads: int = 4
+    grpc_max_prefill_tokens: Optional[int] = None  # None = auto-detect from KV cache
+    enable_grpc: bool = False
+    smg_grpc: bool = False
     skip_server_warmup: bool = False
     warmups: Optional[str] = None
     nccl_port: Optional[int] = None
@@ -979,6 +984,20 @@ class ServerArgs:
                     "Multi-worker HTTP/2 support will be added in a future release."
                 )
 
+        legacy_grpc_requested = self.smg_grpc or self.grpc_mode
+        native_grpc_requested = (
+            self.enable_grpc
+            and not legacy_grpc_requested
+            and not self.use_ray
+            and not self.encoder_only
+            and importlib.util.find_spec("sglang_grpc") is not None
+        )
+        if native_grpc_requested and self.tokenizer_worker_num > 1:
+            raise ValueError(
+                "Native gRPC does not yet support --tokenizer-worker-num > 1. "
+                "Unset --enable-grpc or set --tokenizer-worker-num 1."
+            )
+
     def _handle_multimodal(self):
         """Validate mm_process_config structure before model loading."""
         if self.mm_process_config is not None:
@@ -1013,20 +1032,33 @@ class ServerArgs:
             envs.SGLANG_SPEC_NAN_DETECTION.set(True)
             envs.SGLANG_SPEC_OOB_DETECTION.set(True)
 
-        # Native gRPC flags — env-only for now, not exposed as CLI args.
-        # Set as instance attributes (not dataclass fields) to avoid
-        # argparse namespace lookup in from_cli_args.
-        self.enable_grpc = envs.SGLANG_ENABLE_GRPC.get()
+        if self.grpc_mode and not self.smg_grpc:
+            import warnings
 
+            warnings.warn(
+                "--grpc-mode is deprecated and will be removed in a future version. "
+                "Use --smg-grpc for the legacy SMG gRPC server. "
+                "The native gRPC server now starts automatically alongside HTTP.",
+                DeprecationWarning,
+                stacklevel=4,
+            )
+            self.smg_grpc = True
+
+        # Env var fallbacks for gRPC flags (backwards compat with env-only phase).
+        if not self.enable_grpc and envs.SGLANG_ENABLE_GRPC.get():
+            self.enable_grpc = True
         grpc_port_env = envs.SGLANG_GRPC_PORT.get()
-        self.grpc_port = (
-            grpc_port_env if grpc_port_env is not None else self.port + 10000
-        )
+        if self.grpc_port is None and grpc_port_env is not None:
+            self.grpc_port = grpc_port_env
 
+        if self.grpc_port is None:
+            self.grpc_port = self.port + 10000
         if not (1 <= self.grpc_port <= 65535):
             raise ValueError(
-                f"SGLANG_GRPC_PORT ({self.grpc_port}) must be between 1 and 65535"
+                f"--grpc-port / SGLANG_GRPC_PORT ({self.grpc_port}) must be between 1 and 65535"
             )
+        if self.grpc_worker_threads < 1:
+            raise ValueError("--grpc-worker-threads must be >= 1")
 
     def _handle_prefill_delayer_env_compat(self):
         if envs.SGLANG_SCHEDULER_DECREASE_PREFILL_IDLE.get():
@@ -4163,7 +4195,43 @@ class ServerArgs:
         parser.add_argument(
             "--grpc-mode",
             action="store_true",
-            help="If set, use gRPC server instead of HTTP server.",
+            help="(Deprecated, use --smg-grpc) If set, use legacy SMG gRPC server instead of HTTP server.",
+        )
+        parser.add_argument(
+            "--grpc-port",
+            type=int,
+            default=None,
+            help="Port for the native gRPC server. Defaults to --port + 10000 (e.g., 30000 → 40000).",
+        )
+        parser.add_argument(
+            "--grpc-worker-threads",
+            type=int,
+            default=4,
+            help="Number of Tokio worker threads for the native gRPC server.",
+        )
+        parser.add_argument(
+            "--grpc-max-prefill-tokens",
+            type=int,
+            default=None,
+            help=(
+                "Coarse token budget for concurrent prefill admission in the "
+                "native gRPC server. Each request currently acquires "
+                "max_new_tokens permits before prefill and releases them on the "
+                "first response token, so this bounds weighted prefill admission "
+                "rather than true KV occupancy. Default (None) auto-detects "
+                "from the scheduler's max_total_num_tokens. Set to 0 to disable "
+                "admission control."
+            ),
+        )
+        parser.add_argument(
+            "--enable-grpc",
+            action="store_true",
+            help="If set, start the native gRPC server alongside HTTP. Off by default.",
+        )
+        parser.add_argument(
+            "--smg-grpc",
+            action="store_true",
+            help="If set, use the legacy SMG gRPC server (smg-grpc-servicer) instead of HTTP server.",
         )
         parser.add_argument(
             "--skip-server-warmup",
@@ -6735,12 +6803,13 @@ class ServerArgs:
             and self.grpc_port == self.port
         ):
             raise ValueError(
-                f"SGLANG_GRPC_PORT ({self.grpc_port}) must differ from --port ({self.port})"
+                f"--grpc-port ({self.grpc_port}) must differ from --port ({self.port})"
             )
 
         # TODO: Also validate grpc_port != metrics_http_port and grpc_port != nccl_port
         # to avoid opaque bind errors at runtime. Deferred because metrics_http_port
         # and nccl_port have dynamic defaults that may not be resolved yet here.
+
 
         if self.gc_threshold:
             if not (1 <= len(self.gc_threshold) <= 3):

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -990,7 +990,7 @@ class ServerArgs:
             and not legacy_grpc_requested
             and not self.use_ray
             and not self.encoder_only
-            and importlib.util.find_spec("sglang_grpc") is not None
+            and importlib.util.find_spec("sglang.srt.grpc._core") is not None
         )
         if native_grpc_requested and self.tokenizer_worker_num > 1:
             raise ValueError(
@@ -6809,7 +6809,6 @@ class ServerArgs:
         # TODO: Also validate grpc_port != metrics_http_port and grpc_port != nccl_port
         # to avoid opaque bind errors at runtime. Deferred because metrics_http_port
         # and nccl_port have dynamic defaults that may not be resolved yet here.
-
 
         if self.gc_threshold:
             if not (1 <= len(self.gc_threshold) <= 3):

--- a/rust/sglang-grpc/Cargo.toml
+++ b/rust/sglang-grpc/Cargo.toml
@@ -14,7 +14,6 @@ pyo3 = { version = "0.23", features = ["extension-module"] }
 tokio = { version = "1", features = ["full"] }
 tonic = { version = "0.12", features = ["gzip", "transport"] }
 prost = "0.13"
-crossbeam-channel = "0.5"
 uuid = { version = "1", features = ["v4"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/rust/sglang-grpc/pyproject.toml
+++ b/rust/sglang-grpc/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "sglang-grpc"
+version = "0.1.0"
+description = "In-process Rust gRPC server for SGLang inference engine"
+requires-python = ">=3.10"
+license = { text = "Apache-2.0" }
+classifiers = [
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "grpcio>=1.60.0",
+    "grpcio-tools>=1.60.0",
+]
+
+[tool.maturin]
+python-source = "src"
+module-name = "sglang_grpc._core"

--- a/rust/sglang-grpc/src/bridge.rs
+++ b/rust/sglang-grpc/src/bridge.rs
@@ -1,0 +1,867 @@
+use pyo3::prelude::*;
+use pyo3::types::{PyBytes, PyDict, PyList};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc::error::TrySendError;
+use tokio::sync::mpsc::{self, Receiver, Sender};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio::time::Duration;
+
+use crate::tokenizer::RustTokenizer;
+
+#[derive(Debug, Clone)]
+pub enum ResponseChunk {
+    Data(ResponseData),
+    Finished(ResponseData),
+    Error(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct ResponseData {
+    pub text: Option<String>,
+    pub output_ids: Option<Vec<i32>>,
+    pub embedding: Option<Vec<f32>>,
+    pub json_bytes: Option<Vec<u8>>,
+    pub meta_info: HashMap<String, String>,
+}
+
+/// Holds a reference to the Python RuntimeHandle and manages per-request channels.
+pub struct PyBridge {
+    runtime_handle: PyObject,
+    channels: Arc<Mutex<HashMap<String, Sender<ResponseChunk>>>>,
+    terminal_errors: Arc<Mutex<HashMap<String, String>>>,
+    rust_tokenizer: Option<RustTokenizer>,
+    context_len: i32,
+    /// Coarse prefill-admission semaphore: each inference RPC acquires a weighted
+    /// cost before submission and may release it on the first response token.
+    /// This is not a true KV-occupancy limiter because decode can continue after
+    /// the permit is dropped.
+    semaphore: Option<Arc<Semaphore>>,
+    semaphore_capacity: Option<u32>,
+}
+
+impl PyBridge {
+    pub fn new(
+        runtime_handle: PyObject,
+        rust_tokenizer: Option<RustTokenizer>,
+        context_len: i32,
+        semaphore: Option<Arc<Semaphore>>,
+        semaphore_capacity: Option<u32>,
+    ) -> Self {
+        Self {
+            runtime_handle,
+            channels: Arc::new(Mutex::new(HashMap::new())),
+            terminal_errors: Arc::new(Mutex::new(HashMap::new())),
+            rust_tokenizer,
+            context_len,
+            semaphore,
+            semaphore_capacity,
+        }
+    }
+
+    /// Access the Rust tokenizer (if available).
+    pub fn rust_tokenizer(&self) -> Option<&RustTokenizer> {
+        self.rust_tokenizer.as_ref()
+    }
+
+    /// Return the model's context length.
+    pub fn context_len(&self) -> i32 {
+        self.context_len
+    }
+
+    /// Attempt to acquire an inference concurrency slot before submitting to Python.
+    ///
+    /// - `Ok(None)`         — no limit configured; caller proceeds unconditionally.
+    /// - `Ok(Some(permit))` — limit configured and slot acquired; caller must hold
+    ///                        the permit until its chosen release point.
+    /// - `Err(())`          — limit configured but `deadline` elapsed before a slot
+    ///                        was free; caller should return `RESOURCE_EXHAUSTED`.
+    /// Acquire `n_tokens` permits from the prefill-budget semaphore.
+    ///
+    /// `n_tokens` is a caller-defined weight. The semaphore capacity is derived from
+    /// the configured budget, and oversized requests are clamped to that total
+    /// capacity so they can still make forward progress.
+    pub async fn acquire_slot(
+        &self,
+        n_tokens: u32,
+        deadline: Duration,
+    ) -> Result<Option<OwnedSemaphorePermit>, ()> {
+        match &self.semaphore {
+            None => Ok(None),
+            Some(sem) => {
+                // Clamp to semaphore capacity so a single over-sized request
+                // can always make progress (rather than deadlocking).
+                let n = n_tokens
+                    .min(self.semaphore_capacity.unwrap_or(u32::MAX))
+                    .max(1);
+                tokio::time::timeout(deadline, Arc::clone(sem).acquire_many_owned(n))
+                    .await
+                    .map(|r| Some(r.expect("inference semaphore was unexpectedly closed")))
+                    .map_err(|_| ())
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Channel + callback helpers
+    // ------------------------------------------------------------------
+
+    fn create_channel(&self, rid: &str) -> Receiver<ResponseChunk> {
+        let (sender, receiver) = mpsc::channel(64);
+        {
+            let mut channels = self.channels.lock().unwrap();
+            channels.insert(rid.to_string(), sender);
+        }
+        {
+            let mut terminal_errors = self.terminal_errors.lock().unwrap();
+            terminal_errors.remove(rid);
+        }
+        receiver
+    }
+
+    fn make_chunk_callback(
+        &self,
+        py: Python<'_>,
+        rid: String,
+        channels: Arc<Mutex<HashMap<String, Sender<ResponseChunk>>>>,
+        terminal_errors: Arc<Mutex<HashMap<String, String>>>,
+        runtime_handle: PyObject,
+    ) -> PyResult<PyObject> {
+        let callback = ChunkCallback {
+            rid,
+            channels,
+            terminal_errors,
+            runtime_handle,
+        };
+        let py_callback = Py::new(py, callback)?;
+        Ok(py_callback.into_any().into())
+    }
+
+    fn make_json_callback(
+        &self,
+        py: Python<'_>,
+        rid: String,
+        channels: Arc<Mutex<HashMap<String, Sender<ResponseChunk>>>>,
+        terminal_errors: Arc<Mutex<HashMap<String, String>>>,
+        runtime_handle: PyObject,
+    ) -> PyResult<PyObject> {
+        let callback = JsonChunkCallback {
+            rid,
+            channels,
+            terminal_errors,
+            runtime_handle,
+        };
+        let py_callback = Py::new(py, callback)?;
+        Ok(py_callback.into_any().into())
+    }
+
+    // ------------------------------------------------------------------
+    // Consolidated request submission (generate / embed / classify)
+    // ------------------------------------------------------------------
+
+    /// Submit a generate or embed request by passing a pre-built dict to Python.
+    ///
+    /// `req_type` is "generate", "embed", or "classify".
+    /// `req_dict` contains fields matching GenerateReqInput or EmbeddingReqInput.
+    pub fn submit_request(
+        &self,
+        rid: &str,
+        req_type: &str,
+        req_dict: HashMap<String, serde_json::Value>,
+    ) -> PyResult<Receiver<ResponseChunk>> {
+        let receiver = self.create_channel(rid);
+        let channels_ref = self.channels.clone();
+        let terminal_errors_ref = self.terminal_errors.clone();
+        let rid_owned = rid.to_string();
+
+        let result = Python::with_gil(|py| -> PyResult<()> {
+            let py_req_dict = json_map_to_pydict(py, &req_dict)?;
+            let callback = self.make_chunk_callback(
+                py,
+                rid_owned,
+                channels_ref,
+                terminal_errors_ref,
+                self.runtime_handle.clone_ref(py),
+            )?;
+
+            let kwargs = PyDict::new(py);
+            kwargs.set_item("req_type", req_type)?;
+            kwargs.set_item("req_dict", py_req_dict)?;
+            kwargs.set_item("chunk_callback", callback)?;
+
+            self.runtime_handle
+                .call_method(py, "submit_request", (), Some(&kwargs))?;
+            Ok(())
+        });
+
+        match result {
+            Ok(()) => Ok(receiver),
+            Err(err) => {
+                self.remove_channel(rid);
+                Err(err)
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Abort
+    // ------------------------------------------------------------------
+
+    pub fn abort(&self, rid: &str, abort_all: bool) -> PyResult<()> {
+        if abort_all {
+            let rids = {
+                let channels = self.channels.lock().unwrap();
+                channels.keys().cloned().collect::<Vec<_>>()
+            };
+            {
+                let mut channels = self.channels.lock().unwrap();
+                channels.clear();
+            }
+            let mut terminal_errors = self.terminal_errors.lock().unwrap();
+            for channel_rid in rids {
+                terminal_errors.insert(channel_rid, "Request aborted".to_string());
+            }
+        } else {
+            {
+                let mut channels = self.channels.lock().unwrap();
+                channels.remove(rid);
+            }
+            let mut terminal_errors = self.terminal_errors.lock().unwrap();
+            terminal_errors.insert(rid.to_string(), "Request aborted".to_string());
+        }
+        Python::with_gil(|py| {
+            self.runtime_handle
+                .call_method1(py, "abort", (rid, abort_all))?;
+            Ok(())
+        })
+    }
+
+    // ------------------------------------------------------------------
+    // Info / control RPCs (synchronous, small data)
+    // ------------------------------------------------------------------
+
+    pub fn get_model_info(&self) -> PyResult<String> {
+        Python::with_gil(|py| {
+            let result = self.runtime_handle.call_method0(py, "get_model_info")?;
+            result.extract::<String>(py)
+        })
+    }
+
+    pub fn get_server_info(&self) -> PyResult<String> {
+        Python::with_gil(|py| {
+            let result = self.runtime_handle.call_method0(py, "get_server_info")?;
+            result.extract::<String>(py)
+        })
+    }
+
+    pub fn health_check(&self) -> PyResult<bool> {
+        Python::with_gil(|py| {
+            let result = self.runtime_handle.call_method0(py, "health_check")?;
+            result.extract::<bool>(py)
+        })
+    }
+
+    /// Tokenize via Python (fallback when Rust tokenizer unavailable).
+    pub fn tokenize_py(&self, text: &str, add_special_tokens: bool) -> PyResult<String> {
+        Python::with_gil(|py| {
+            let result =
+                self.runtime_handle
+                    .call_method1(py, "tokenize", (text, add_special_tokens))?;
+            result.extract::<String>(py)
+        })
+    }
+
+    /// Detokenize via Python (fallback when Rust tokenizer unavailable).
+    pub fn detokenize_py(&self, tokens: Vec<i32>) -> PyResult<String> {
+        Python::with_gil(|py| {
+            let result = self
+                .runtime_handle
+                .call_method1(py, "detokenize", (tokens,))?;
+            result.extract::<String>(py)
+        })
+    }
+
+    pub fn list_models(&self) -> PyResult<String> {
+        Python::with_gil(|py| {
+            let result = self.runtime_handle.call_method0(py, "list_models")?;
+            result.extract::<String>(py)
+        })
+    }
+
+    pub fn submit_get_load(
+        &self,
+        rid: &str,
+        dp_rank: Option<i32>,
+    ) -> PyResult<Receiver<ResponseChunk>> {
+        let receiver = self.create_channel(rid);
+        let channels_ref = self.channels.clone();
+        let terminal_errors_ref = self.terminal_errors.clone();
+        let rid_owned = rid.to_string();
+
+        let result = Python::with_gil(|py| -> PyResult<()> {
+            let callback = self.make_json_callback(
+                py,
+                rid_owned,
+                channels_ref,
+                terminal_errors_ref,
+                self.runtime_handle.clone_ref(py),
+            )?;
+            self.runtime_handle
+                .call_method1(py, "get_load", (callback, dp_rank))?;
+            Ok(())
+        });
+
+        match result {
+            Ok(()) => Ok(receiver),
+            Err(err) => {
+                self.remove_channel(rid);
+                Err(err)
+            }
+        }
+    }
+
+    pub fn submit_flush_cache(&self, rid: &str) -> PyResult<Receiver<ResponseChunk>> {
+        let receiver = self.create_channel(rid);
+        let channels_ref = self.channels.clone();
+        let terminal_errors_ref = self.terminal_errors.clone();
+        let rid_owned = rid.to_string();
+
+        let result = Python::with_gil(|py| -> PyResult<()> {
+            let callback = self.make_json_callback(
+                py,
+                rid_owned,
+                channels_ref,
+                terminal_errors_ref,
+                self.runtime_handle.clone_ref(py),
+            )?;
+            self.runtime_handle
+                .call_method1(py, "flush_cache", (callback,))?;
+            Ok(())
+        });
+
+        match result {
+            Ok(()) => Ok(receiver),
+            Err(err) => {
+                self.remove_channel(rid);
+                Err(err)
+            }
+        }
+    }
+
+    pub fn submit_pause_generation(
+        &self,
+        rid: &str,
+        mode: &str,
+    ) -> PyResult<Receiver<ResponseChunk>> {
+        let receiver = self.create_channel(rid);
+        let channels_ref = self.channels.clone();
+        let terminal_errors_ref = self.terminal_errors.clone();
+        let rid_owned = rid.to_string();
+
+        let result = Python::with_gil(|py| -> PyResult<()> {
+            let callback = self.make_json_callback(
+                py,
+                rid_owned,
+                channels_ref,
+                terminal_errors_ref,
+                self.runtime_handle.clone_ref(py),
+            )?;
+            self.runtime_handle
+                .call_method1(py, "pause_generation", (mode, callback))?;
+            Ok(())
+        });
+
+        match result {
+            Ok(()) => Ok(receiver),
+            Err(err) => {
+                self.remove_channel(rid);
+                Err(err)
+            }
+        }
+    }
+
+    pub fn submit_continue_generation(&self, rid: &str) -> PyResult<Receiver<ResponseChunk>> {
+        let receiver = self.create_channel(rid);
+        let channels_ref = self.channels.clone();
+        let terminal_errors_ref = self.terminal_errors.clone();
+        let rid_owned = rid.to_string();
+
+        let result = Python::with_gil(|py| -> PyResult<()> {
+            let callback = self.make_json_callback(
+                py,
+                rid_owned,
+                channels_ref,
+                terminal_errors_ref,
+                self.runtime_handle.clone_ref(py),
+            )?;
+            self.runtime_handle
+                .call_method1(py, "continue_generation", (callback,))?;
+            Ok(())
+        });
+
+        match result {
+            Ok(()) => Ok(receiver),
+            Err(err) => {
+                self.remove_channel(rid);
+                Err(err)
+            }
+        }
+    }
+
+    pub fn submit_start_profile(
+        &self,
+        rid: &str,
+        output_dir: Option<&str>,
+    ) -> PyResult<Receiver<ResponseChunk>> {
+        let receiver = self.create_channel(rid);
+        let channels_ref = self.channels.clone();
+        let terminal_errors_ref = self.terminal_errors.clone();
+        let rid_owned = rid.to_string();
+
+        let result = Python::with_gil(|py| -> PyResult<()> {
+            let callback = self.make_json_callback(
+                py,
+                rid_owned,
+                channels_ref,
+                terminal_errors_ref,
+                self.runtime_handle.clone_ref(py),
+            )?;
+            self.runtime_handle
+                .call_method1(py, "start_profile", (output_dir, callback))?;
+            Ok(())
+        });
+
+        match result {
+            Ok(()) => Ok(receiver),
+            Err(err) => {
+                self.remove_channel(rid);
+                Err(err)
+            }
+        }
+    }
+
+    pub fn submit_stop_profile(&self, rid: &str) -> PyResult<Receiver<ResponseChunk>> {
+        let receiver = self.create_channel(rid);
+        let channels_ref = self.channels.clone();
+        let terminal_errors_ref = self.terminal_errors.clone();
+        let rid_owned = rid.to_string();
+
+        let result = Python::with_gil(|py| -> PyResult<()> {
+            let callback = self.make_json_callback(
+                py,
+                rid_owned,
+                channels_ref,
+                terminal_errors_ref,
+                self.runtime_handle.clone_ref(py),
+            )?;
+            self.runtime_handle
+                .call_method1(py, "stop_profile", (callback,))?;
+            Ok(())
+        });
+
+        match result {
+            Ok(()) => Ok(receiver),
+            Err(err) => {
+                self.remove_channel(rid);
+                Err(err)
+            }
+        }
+    }
+
+    pub fn submit_update_weights(
+        &self,
+        rid: &str,
+        model_path: &str,
+        load_format: Option<&str>,
+    ) -> PyResult<Receiver<ResponseChunk>> {
+        let receiver = self.create_channel(rid);
+        let channels_ref = self.channels.clone();
+        let terminal_errors_ref = self.terminal_errors.clone();
+        let rid_owned = rid.to_string();
+
+        let result = Python::with_gil(|py| -> PyResult<()> {
+            let callback = self.make_json_callback(
+                py,
+                rid_owned,
+                channels_ref,
+                terminal_errors_ref,
+                self.runtime_handle.clone_ref(py),
+            )?;
+            self.runtime_handle.call_method1(
+                py,
+                "update_weights_from_disk",
+                (model_path, load_format, callback),
+            )?;
+            Ok(())
+        });
+
+        match result {
+            Ok(()) => Ok(receiver),
+            Err(err) => {
+                self.remove_channel(rid);
+                Err(err)
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // OpenAI pass-through RPCs
+    // ------------------------------------------------------------------
+
+    pub fn submit_openai(
+        &self,
+        rid: &str,
+        method_name: &str,
+        json_body: &[u8],
+        trace_headers: &HashMap<String, String>,
+    ) -> PyResult<Receiver<ResponseChunk>> {
+        let receiver = self.create_channel(rid);
+        let channels_ref = self.channels.clone();
+        let terminal_errors_ref = self.terminal_errors.clone();
+        let rid_owned = rid.to_string();
+
+        let result = Python::with_gil(|py| -> PyResult<()> {
+            let kwargs = PyDict::new(py);
+            let py_bytes = PyBytes::new(py, json_body);
+            kwargs.set_item("json_body", py_bytes)?;
+            if !trace_headers.is_empty() {
+                let py_trace_headers = PyDict::new(py);
+                for (key, value) in trace_headers {
+                    py_trace_headers.set_item(key, value)?;
+                }
+                kwargs.set_item("trace_headers", py_trace_headers)?;
+            }
+
+            let callback = self.make_json_callback(
+                py,
+                rid_owned,
+                channels_ref,
+                terminal_errors_ref,
+                self.runtime_handle.clone_ref(py),
+            )?;
+            kwargs.set_item("chunk_callback", callback)?;
+
+            self.runtime_handle
+                .call_method(py, method_name, (), Some(&kwargs))?;
+            Ok(())
+        });
+
+        match result {
+            Ok(()) => Ok(receiver),
+            Err(err) => {
+                self.remove_channel(rid);
+                Err(err)
+            }
+        }
+    }
+
+    pub fn remove_channel(&self, rid: &str) {
+        let mut channels = self.channels.lock().unwrap();
+        channels.remove(rid);
+        let mut terminal_errors = self.terminal_errors.lock().unwrap();
+        terminal_errors.remove(rid);
+    }
+
+    pub fn take_terminal_error(&self, rid: &str) -> Option<String> {
+        let mut terminal_errors = self.terminal_errors.lock().unwrap();
+        terminal_errors.remove(rid)
+    }
+}
+
+// ======================================================================
+// Convert serde_json::Value map to PyDict
+// ======================================================================
+
+fn json_value_to_py<'py>(py: Python<'py>, v: &serde_json::Value) -> PyResult<PyObject> {
+    match v {
+        serde_json::Value::Null => Ok(py.None()),
+        serde_json::Value::Bool(b) => Ok(b.into_pyobject(py)?.to_owned().into_any().unbind()),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Ok(i.into_pyobject(py)?.into_any().unbind())
+            } else if let Some(f) = n.as_f64() {
+                Ok(f.into_pyobject(py)?.into_any().unbind())
+            } else {
+                Ok(py.None())
+            }
+        }
+        serde_json::Value::String(s) => Ok(s.into_pyobject(py)?.into_any().unbind()),
+        serde_json::Value::Array(arr) => {
+            let items: Vec<PyObject> = arr
+                .iter()
+                .map(|item| json_value_to_py(py, item))
+                .collect::<PyResult<_>>()?;
+            let py_list = PyList::new(py, &items)?;
+            Ok(py_list.into_any().unbind())
+        }
+        serde_json::Value::Object(map) => {
+            let py_dict = PyDict::new(py);
+            for (k, val) in map {
+                py_dict.set_item(k, json_value_to_py(py, val)?)?;
+            }
+            Ok(py_dict.into_any().unbind())
+        }
+    }
+}
+
+fn json_map_to_pydict<'py>(
+    py: Python<'py>,
+    map: &HashMap<String, serde_json::Value>,
+) -> PyResult<Bound<'py, PyDict>> {
+    let py_dict = PyDict::new(py);
+    for (k, v) in map {
+        py_dict.set_item(k, json_value_to_py(py, v)?)?;
+    }
+    Ok(py_dict)
+}
+
+fn close_channel_with_error(
+    py: Python<'_>,
+    rid: &str,
+    channels: &Arc<Mutex<HashMap<String, Sender<ResponseChunk>>>>,
+    terminal_errors: &Arc<Mutex<HashMap<String, String>>>,
+    runtime_handle: &PyObject,
+    error: &str,
+) {
+    {
+        let mut terminal_errors = terminal_errors.lock().unwrap();
+        terminal_errors.insert(rid.to_string(), error.to_string());
+    }
+    {
+        let mut channels = channels.lock().unwrap();
+        channels.remove(rid);
+    }
+    let _ = runtime_handle.call_method1(py, "abort", (rid, false));
+}
+
+fn try_send_chunk(
+    py: Python<'_>,
+    rid: &str,
+    channels: &Arc<Mutex<HashMap<String, Sender<ResponseChunk>>>>,
+    terminal_errors: &Arc<Mutex<HashMap<String, String>>>,
+    runtime_handle: &PyObject,
+    sender: &Sender<ResponseChunk>,
+    msg: ResponseChunk,
+) -> PyResult<()> {
+    match sender.try_send(msg) {
+        Ok(()) => Ok(()),
+        Err(TrySendError::Full(_)) => {
+            close_channel_with_error(
+                py,
+                rid,
+                channels,
+                terminal_errors,
+                runtime_handle,
+                "gRPC response channel full: client not consuming",
+            );
+            Ok(())
+        }
+        Err(TrySendError::Closed(_)) => {
+            close_channel_with_error(
+                py,
+                rid,
+                channels,
+                terminal_errors,
+                runtime_handle,
+                "gRPC client disconnected",
+            );
+            Ok(())
+        }
+    }
+}
+
+// ======================================================================
+// Typed chunk callback (for SGLang-native RPCs: dict-based chunks)
+// ======================================================================
+
+#[pyclass]
+struct ChunkCallback {
+    rid: String,
+    channels: Arc<Mutex<HashMap<String, Sender<ResponseChunk>>>>,
+    terminal_errors: Arc<Mutex<HashMap<String, String>>>,
+    runtime_handle: PyObject,
+}
+
+#[pymethods]
+impl ChunkCallback {
+    #[pyo3(signature = (chunk, finished=false, error=None))]
+    fn __call__(
+        &self,
+        chunk: &Bound<'_, PyDict>,
+        finished: bool,
+        error: Option<String>,
+    ) -> PyResult<()> {
+        let py = chunk.py();
+        let channels = self.channels.lock().unwrap();
+        let sender = match channels.get(&self.rid) {
+            Some(s) => s.clone(),
+            None => return Ok(()),
+        };
+        drop(channels);
+
+        if let Some(err_msg) = error {
+            try_send_chunk(
+                py,
+                &self.rid,
+                &self.channels,
+                &self.terminal_errors,
+                &self.runtime_handle,
+                &sender,
+                ResponseChunk::Error(err_msg),
+            )?;
+            let mut channels = self.channels.lock().unwrap();
+            channels.remove(&self.rid);
+            return Ok(());
+        }
+
+        let text: Option<String> = chunk
+            .get_item("text")?
+            .and_then(|v| v.extract::<String>().ok());
+
+        let output_ids: Option<Vec<i32>> = chunk
+            .get_item("output_ids")?
+            .and_then(|v| v.extract::<Vec<i32>>().ok());
+
+        let embedding: Option<Vec<f32>> = chunk
+            .get_item("embedding")?
+            .and_then(|v| v.extract::<Vec<f32>>().ok());
+
+        let meta_info = extract_meta_info(chunk);
+
+        let data = ResponseData {
+            text,
+            output_ids,
+            embedding,
+            json_bytes: None,
+            meta_info,
+        };
+
+        let msg = if finished {
+            ResponseChunk::Finished(data)
+        } else {
+            ResponseChunk::Data(data)
+        };
+
+        try_send_chunk(
+            py,
+            &self.rid,
+            &self.channels,
+            &self.terminal_errors,
+            &self.runtime_handle,
+            &sender,
+            msg,
+        )?;
+
+        if finished {
+            let mut channels = self.channels.lock().unwrap();
+            channels.remove(&self.rid);
+        }
+
+        Ok(())
+    }
+}
+
+// ======================================================================
+// JSON chunk callback (for OpenAI pass-through RPCs: raw bytes)
+// ======================================================================
+
+#[pyclass]
+struct JsonChunkCallback {
+    rid: String,
+    channels: Arc<Mutex<HashMap<String, Sender<ResponseChunk>>>>,
+    terminal_errors: Arc<Mutex<HashMap<String, String>>>,
+    runtime_handle: PyObject,
+}
+
+#[pymethods]
+impl JsonChunkCallback {
+    #[pyo3(signature = (chunk_bytes, finished=false, error=None, status_code=None))]
+    fn __call__(
+        &self,
+        chunk_bytes: &Bound<'_, pyo3::PyAny>,
+        finished: bool,
+        error: Option<String>,
+        status_code: Option<i32>,
+    ) -> PyResult<()> {
+        let py = chunk_bytes.py();
+        let channels = self.channels.lock().unwrap();
+        let sender = match channels.get(&self.rid) {
+            Some(s) => s.clone(),
+            None => return Ok(()),
+        };
+        drop(channels);
+
+        if let Some(err_msg) = error {
+            try_send_chunk(
+                py,
+                &self.rid,
+                &self.channels,
+                &self.terminal_errors,
+                &self.runtime_handle,
+                &sender,
+                ResponseChunk::Error(err_msg),
+            )?;
+            let mut channels = self.channels.lock().unwrap();
+            channels.remove(&self.rid);
+            return Ok(());
+        }
+
+        let bytes_data: Vec<u8> = if let Ok(b) = chunk_bytes.extract::<Vec<u8>>() {
+            b
+        } else if let Ok(s) = chunk_bytes.extract::<String>() {
+            s.into_bytes()
+        } else {
+            vec![]
+        };
+
+        let mut meta_info = HashMap::new();
+        if let Some(code) = status_code {
+            meta_info.insert("status_code".to_string(), code.to_string());
+        }
+
+        let data = ResponseData {
+            text: None,
+            output_ids: None,
+            embedding: None,
+            json_bytes: Some(bytes_data),
+            meta_info,
+        };
+
+        let msg = if finished {
+            ResponseChunk::Finished(data)
+        } else {
+            ResponseChunk::Data(data)
+        };
+
+        try_send_chunk(
+            py,
+            &self.rid,
+            &self.channels,
+            &self.terminal_errors,
+            &self.runtime_handle,
+            &sender,
+            msg,
+        )?;
+
+        if finished {
+            let mut channels = self.channels.lock().unwrap();
+            channels.remove(&self.rid);
+        }
+
+        Ok(())
+    }
+}
+
+fn extract_meta_info(chunk: &Bound<'_, PyDict>) -> HashMap<String, String> {
+    let mut meta = HashMap::new();
+    if let Ok(Some(meta_obj)) = chunk.get_item("meta_info") {
+        if let Ok(meta_dict) = meta_obj.downcast::<PyDict>() {
+            for (k, v) in meta_dict.iter() {
+                if let (Ok(key), Ok(val)) = (k.extract::<String>(), v.str()) {
+                    meta.insert(key, val.to_string());
+                }
+            }
+        }
+    }
+    meta
+}

--- a/rust/sglang-grpc/src/lib.rs
+++ b/rust/sglang-grpc/src/lib.rs
@@ -1,21 +1,29 @@
-use pyo3::prelude::*;
-use std::sync::Arc;
-use tokio::sync::Notify;
+pub mod bridge;
+pub mod server;
+pub mod tokenizer;
 
 pub mod proto {
     tonic::include_proto!("sglang.runtime.v1");
 }
 
-/// Handle returned by `start_server` — used to shut down the gRPC server.
+use pyo3::prelude::*;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::sync::{Notify, Semaphore};
+
+use bridge::PyBridge;
+use tokenizer::RustTokenizer;
+
+/// Handle returned to Python that controls the running gRPC server.
 #[pyclass]
-pub struct GrpcServerHandle {
+struct GrpcServerHandle {
     shutdown: Arc<Notify>,
     join_handle: Option<std::thread::JoinHandle<()>>,
 }
 
 #[pymethods]
 impl GrpcServerHandle {
-    /// Signal the server to stop and wait for the background thread to exit.
+    /// Gracefully shut down the gRPC server.
     fn shutdown(&mut self) {
         self.shutdown.notify_one();
         if let Some(handle) = self.join_handle.take() {
@@ -23,7 +31,7 @@ impl GrpcServerHandle {
         }
     }
 
-    /// Returns `true` while the server thread is still running.
+    /// Check if the server thread is still running.
     fn is_alive(&self) -> bool {
         self.join_handle
             .as_ref()
@@ -31,43 +39,152 @@ impl GrpcServerHandle {
     }
 }
 
-/// Start the gRPC server in a background thread.
+/// Extract tokenizer path and context_len from the Python RuntimeHandle (one-time GIL).
+fn extract_tokenizer_info(runtime_handle: &PyObject) -> (Option<String>, i32) {
+    Python::with_gil(|py| {
+        let tm = match runtime_handle.getattr(py, "tokenizer_manager") {
+            Ok(tm) => tm,
+            Err(_) => return (None, 0),
+        };
+
+        let model_path: Option<String> = tm
+            .getattr(py, "model_path")
+            .ok()
+            .and_then(|v| v.extract(py).ok());
+
+        let context_len: i32 = tm
+            .getattr(py, "model_config")
+            .ok()
+            .and_then(|mc| mc.getattr(py, "context_len").ok())
+            .and_then(|v| v.extract(py).ok())
+            .unwrap_or(0);
+
+        (model_path, context_len)
+    })
+}
+
+/// Read `max_total_num_tokens` from the scheduler via the Python bridge's
+/// `get_server_info()` method.  Returns `None` if the field is absent or the
+/// call fails (caller should fall back to a safe static default).
+fn read_max_total_num_tokens(runtime_handle: &PyObject) -> Option<usize> {
+    let json_str: String = Python::with_gil(|py| {
+        runtime_handle
+            .call_method0(py, "get_server_info")
+            .ok()
+            .and_then(|v| v.extract::<String>(py).ok())
+    })?;
+
+    let v: serde_json::Value = serde_json::from_str(&json_str).ok()?;
+    // scheduler_info is merged flat into the JSON by grpc_bridge.py
+    v.get("max_total_num_tokens")
+        .and_then(|x| x.as_u64())
+        .map(|x| x as usize)
+}
+
+/// Start the gRPC server in a background thread with its own Tokio runtime.
 ///
-/// * `host` – bind address (e.g. "0.0.0.0")
-/// * `port` – listen port
-/// * `runtime_handle` – Python `RuntimeHandle` object (from `grpc_bridge.py`)
+/// Args:
+///     host: Bind address (e.g., "0.0.0.0")
+///     port: Port number (e.g., 40000)
+///     runtime_handle: Python RuntimeHandle object with submit_generate, submit_embed, abort, etc.
 ///
-/// Returns a `GrpcServerHandle` that can be used to shut the server down.
+/// Returns:
+///     GrpcServerHandle that can be used to shut down the server.
+/// Start the native gRPC server in a background thread.
+///
+/// `max_prefill_tokens`:
+///   - `None`  → auto-detect budget from scheduler's `max_total_num_tokens`
+///   - `0`     → disable admission control entirely
+///   - `N > 0` → use exactly N tokens as the prefill semaphore budget
 #[pyfunction]
-fn start_server(host: String, port: u16, runtime_handle: PyObject) -> PyResult<GrpcServerHandle> {
-    let _ = &runtime_handle; // Will be used in Phase 1 PR 2
+#[pyo3(signature = (host, port, runtime_handle, worker_threads=4, max_prefill_tokens=None))]
+fn start_server(
+    host: String,
+    port: u16,
+    runtime_handle: PyObject,
+    worker_threads: usize,
+    max_prefill_tokens: Option<usize>,
+) -> PyResult<GrpcServerHandle> {
+    let addr: SocketAddr = format!("{}:{}", host, port).parse().map_err(|e| {
+        PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid address: {}", e))
+    })?;
+
+    // Extract tokenizer info from Python (one-time GIL acquisition)
+    let (model_path, context_len) = extract_tokenizer_info(&runtime_handle);
+
+    // Attempt to load the Rust tokenizer
+    let rust_tokenizer = model_path
+        .as_deref()
+        .and_then(|p| RustTokenizer::from_model_path(p, context_len));
+
+    // Resolve the prefill token budget:
+    //   0        → disabled
+    //   Some(n)  → explicit override
+    //   None     → auto-detect from scheduler's KV cache capacity
+    //
+    // Known limitation — this semaphore is a *concurrency* limiter, not a
+    // *rate* limiter. It provides a coarse weighted bound on prefill admission,
+    // but because permits may be released on the first output token it is not a
+    // true KV-occupancy limiter. Under heavy overload (arriving rate >> serving
+    // rate) the queue can still build inside the Python scheduler, inflating
+    // TTFT regardless of the budget size.
+    //
+    // The legacy sgl-model-gateway can achieve lower overload TTFT because it
+    // has a paced ingress queue. Reaching parity likely requires a proper
+    // token-bucket rate limiter in front of the scheduler submission path
+    // (e.g. the `governor` crate). That is left as a follow-up; this semaphore
+    // remains a coarse guard against admitting too many large-prefill requests
+    // at once.
+    let budget: Option<usize> = match max_prefill_tokens {
+        Some(0) => None,
+        Some(n) => Some(n),
+        None => {
+            let detected = read_max_total_num_tokens(&runtime_handle);
+            match detected {
+                Some(b) => eprintln!(
+                    "[sglang-grpc] prefill token budget auto-detected: {} tokens",
+                    b
+                ),
+                None => eprintln!(
+                    "[sglang-grpc] could not read max_total_num_tokens; \
+                     prefill admission control disabled"
+                ),
+            }
+            detected
+        }
+    };
+
+    let semaphore = budget.map(|n| Arc::new(Semaphore::new(n)));
+    let semaphore_capacity = budget.map(|n| u32::try_from(n).unwrap_or(u32::MAX));
+    let bridge = Arc::new(PyBridge::new(
+        runtime_handle,
+        rust_tokenizer,
+        context_len,
+        semaphore,
+        semaphore_capacity,
+    ));
     let shutdown = Arc::new(Notify::new());
     let shutdown_clone = shutdown.clone();
 
-    let addr_str = format!("{}:{}", host, port);
-    let addr: std::net::SocketAddr = addr_str
-        .parse()
-        .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("Bad address: {e}")))?;
-
     let join_handle = std::thread::Builder::new()
-        .name("grpc-server".into())
+        .name("sglang-grpc".to_string())
         .spawn(move || {
             let rt = tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(4)
+                .worker_threads(worker_threads)
                 .enable_all()
+                .thread_name("sglang-grpc-tokio")
                 .build()
-                .expect("Failed to build Tokio runtime");
+                .expect("Failed to build Tokio runtime for gRPC server");
 
-            rt.block_on(async move {
-                tracing::info!("gRPC server listening on {}", addr);
-                // Server implementation will be added in PR 2.
-                // For now, just wait for shutdown signal.
-                shutdown_clone.notified().await;
-                tracing::info!("gRPC server shutting down");
-            });
+            if let Err(e) = rt.block_on(server::run_grpc_server(addr, bridge, shutdown_clone)) {
+                eprintln!("gRPC server error: {}", e);
+            }
         })
         .map_err(|e| {
-            pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to spawn thread: {e}"))
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+                "Failed to spawn gRPC thread: {}",
+                e
+            ))
         })?;
 
     Ok(GrpcServerHandle {
@@ -76,7 +193,6 @@ fn start_server(host: String, port: u16, runtime_handle: PyObject) -> PyResult<G
     })
 }
 
-/// Python module exported by the Rust extension.
 #[pymodule]
 fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(start_server, m)?)?;

--- a/rust/sglang-grpc/src/server.rs
+++ b/rust/sglang-grpc/src/server.rs
@@ -1,0 +1,1116 @@
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use tokio::sync::{mpsc::Receiver, Notify, OwnedSemaphorePermit};
+use tokio::time::{timeout, Duration};
+use tokio_stream::Stream;
+use tonic::{Request, Response, Status};
+
+use crate::bridge::{PyBridge, ResponseChunk};
+use crate::proto;
+
+pub struct SglangServiceImpl {
+    pub bridge: Arc<PyBridge>,
+    pub shutdown: Arc<Notify>,
+}
+
+/// Convert proto SamplingParams to a serde_json map (used as Python dict via PyO3).
+fn sampling_params_to_map(params: &Option<proto::SamplingParams>) -> serde_json::Value {
+    match params {
+        Some(p) => {
+            let mut map = serde_json::Map::new();
+            if let Some(v) = p.temperature {
+                map.insert("temperature".into(), serde_json::json!(v));
+            }
+            if let Some(v) = p.top_p {
+                map.insert("top_p".into(), serde_json::json!(v));
+            }
+            if let Some(v) = p.top_k {
+                map.insert("top_k".into(), serde_json::json!(v));
+            }
+            if let Some(v) = p.min_p {
+                map.insert("min_p".into(), serde_json::json!(v));
+            }
+            if let Some(v) = p.frequency_penalty {
+                map.insert("frequency_penalty".into(), serde_json::json!(v));
+            }
+            if let Some(v) = p.presence_penalty {
+                map.insert("presence_penalty".into(), serde_json::json!(v));
+            }
+            if let Some(v) = p.repetition_penalty {
+                map.insert("repetition_penalty".into(), serde_json::json!(v));
+            }
+            if let Some(v) = p.max_new_tokens {
+                map.insert("max_new_tokens".into(), serde_json::json!(v));
+            }
+            if let Some(v) = p.min_new_tokens {
+                map.insert("min_new_tokens".into(), serde_json::json!(v));
+            }
+            if !p.stop.is_empty() {
+                map.insert("stop".into(), serde_json::json!(p.stop));
+            }
+            if !p.stop_token_ids.is_empty() {
+                map.insert("stop_token_ids".into(), serde_json::json!(p.stop_token_ids));
+            }
+            if let Some(v) = p.ignore_eos {
+                map.insert("ignore_eos".into(), serde_json::json!(v));
+            }
+            if let Some(v) = p.n {
+                map.insert("n".into(), serde_json::json!(v));
+            }
+            if let Some(ref v) = p.json_schema {
+                map.insert("json_schema".into(), serde_json::json!(v));
+            }
+            if let Some(ref v) = p.regex {
+                map.insert("regex".into(), serde_json::json!(v));
+            }
+            serde_json::Value::Object(map)
+        }
+        None => serde_json::Value::Object(serde_json::Map::new()),
+    }
+}
+
+fn trace_headers_to_json(headers: &HashMap<String, String>) -> Option<serde_json::Value> {
+    if headers.is_empty() {
+        None
+    } else {
+        Some(serde_json::json!(headers))
+    }
+}
+
+type StreamResult<T> = Pin<Box<dyn Stream<Item = Result<T, Status>> + Send + 'static>>;
+const RESPONSE_TIMEOUT: Duration = Duration::from_secs(300);
+/// How long an inference RPC will wait for a concurrency slot before returning
+/// RESOURCE_EXHAUSTED. 30 s is generous enough to absorb short saturation spikes
+/// while still giving clients a timely signal under sustained overload.
+const ADMIT_TIMEOUT: Duration = Duration::from_secs(30);
+
+async fn recv_chunk_with_timeout(
+    receiver: &mut Receiver<ResponseChunk>,
+    timeout_message: &'static str,
+) -> Result<Option<ResponseChunk>, Status> {
+    timeout(RESPONSE_TIMEOUT, receiver.recv())
+        .await
+        .map_err(|_| Status::deadline_exceeded(timeout_message))
+}
+
+/// Acquire `n_tokens` permits from the prefill token-budget semaphore.
+///
+/// `n_tokens` is currently derived from the request's `max_new_tokens`. The
+/// semaphore capacity is derived from `max_total_num_tokens`, but because
+/// permits are released on the first response token this is only a coarse
+/// weighted prefill-admission guard, not a true KV-occupancy limit.
+///
+/// Returns `Err(Status::resource_exhausted(...))` when `ADMIT_TIMEOUT` elapses
+/// before enough permits are available; the client should retry with backoff.
+async fn acquire_inference_slot(
+    bridge: &Arc<PyBridge>,
+    n_tokens: u32,
+) -> Result<Option<OwnedSemaphorePermit>, Status> {
+    bridge
+        .acquire_slot(n_tokens, ADMIT_TIMEOUT)
+        .await
+        .map_err(|_| {
+            Status::resource_exhausted(
+                "prefill admission budget exhausted; server is overloaded — retry after backoff",
+            )
+        })
+}
+
+async fn recv_required_chunk(
+    receiver: &mut Receiver<ResponseChunk>,
+) -> Result<ResponseChunk, Status> {
+    recv_chunk_with_timeout(receiver, "Request timed out after 300s")
+        .await?
+        .ok_or_else(|| Status::internal("Channel closed before response"))
+}
+
+fn closed_stream_status(bridge: &Arc<PyBridge>, rid: &str) -> Status {
+    if let Some(message) = bridge.take_terminal_error(rid) {
+        if message == "gRPC response channel full: client not consuming" {
+            Status::resource_exhausted(message)
+        } else if message == "gRPC client disconnected" || message == "Request aborted" {
+            Status::cancelled(message)
+        } else {
+            Status::internal(message)
+        }
+    } else {
+        Status::internal("gRPC response stream closed before a terminal response")
+    }
+}
+
+fn openai_status_code(meta_info: &HashMap<String, String>, default: i32) -> i32 {
+    meta_info
+        .get("status_code")
+        .and_then(|value| value.parse::<i32>().ok())
+        .unwrap_or(default)
+}
+
+fn extract_model_path(json_info: &str) -> String {
+    serde_json::from_str::<serde_json::Value>(json_info)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("model_path")
+                .and_then(|v| v.as_str())
+                .map(str::to_owned)
+        })
+        .unwrap_or_default()
+}
+
+/// Build a request dict for GenerateReqInput from proto TextGenerateRequest fields.
+fn build_text_generate_dict(
+    rid: &str,
+    req: &proto::TextGenerateRequest,
+) -> HashMap<String, serde_json::Value> {
+    let mut d = HashMap::new();
+    d.insert("rid".into(), serde_json::json!(rid));
+    d.insert("text".into(), serde_json::json!(req.text));
+    d.insert(
+        "sampling_params".into(),
+        sampling_params_to_map(&req.sampling_params),
+    );
+    d.insert(
+        "stream".into(),
+        serde_json::json!(req.stream.unwrap_or(false)),
+    );
+    d.insert(
+        "return_logprob".into(),
+        serde_json::json!(req.return_logprob.unwrap_or(false)),
+    );
+    d.insert(
+        "top_logprobs_num".into(),
+        serde_json::json!(req.top_logprobs_num.unwrap_or(0)),
+    );
+    d.insert(
+        "logprob_start_len".into(),
+        serde_json::json!(req.logprob_start_len.unwrap_or(-1)),
+    );
+    d.insert(
+        "return_text_in_logprobs".into(),
+        serde_json::json!(req.return_text_in_logprobs.unwrap_or(false)),
+    );
+    if let Some(ref lp) = req.lora_path {
+        d.insert("lora_path".into(), serde_json::json!(lp));
+    }
+    if let Some(ref rk) = req.routing_key {
+        d.insert("routing_key".into(), serde_json::json!(rk));
+    }
+    if let Some(rank) = req.routed_dp_rank {
+        d.insert("routed_dp_rank".into(), serde_json::json!(rank));
+    }
+    if let Some(trace) = trace_headers_to_json(&req.trace_headers) {
+        d.insert("external_trace_header".into(), trace);
+    }
+    d.insert("received_time".into(), serde_json::json!(now_timestamp()));
+    d
+}
+
+/// Build a request dict for GenerateReqInput from proto GenerateRequest (tokenized).
+fn build_generate_dict(
+    rid: &str,
+    req: &proto::GenerateRequest,
+) -> HashMap<String, serde_json::Value> {
+    let mut d = HashMap::new();
+    d.insert("rid".into(), serde_json::json!(rid));
+    d.insert("input_ids".into(), serde_json::json!(req.input_ids));
+    d.insert(
+        "sampling_params".into(),
+        sampling_params_to_map(&req.sampling_params),
+    );
+    d.insert(
+        "stream".into(),
+        serde_json::json!(req.stream.unwrap_or(false)),
+    );
+    d.insert(
+        "return_logprob".into(),
+        serde_json::json!(req.return_logprob.unwrap_or(false)),
+    );
+    d.insert(
+        "top_logprobs_num".into(),
+        serde_json::json!(req.top_logprobs_num.unwrap_or(0)),
+    );
+    d.insert(
+        "logprob_start_len".into(),
+        serde_json::json!(req.logprob_start_len.unwrap_or(-1)),
+    );
+    if let Some(ref lp) = req.lora_path {
+        d.insert("lora_path".into(), serde_json::json!(lp));
+    }
+    if let Some(ref rk) = req.routing_key {
+        d.insert("routing_key".into(), serde_json::json!(rk));
+    }
+    if let Some(rank) = req.routed_dp_rank {
+        d.insert("routed_dp_rank".into(), serde_json::json!(rank));
+    }
+    if let Some(trace) = trace_headers_to_json(&req.trace_headers) {
+        d.insert("external_trace_header".into(), trace);
+    }
+    d.insert("received_time".into(), serde_json::json!(now_timestamp()));
+    d
+}
+
+/// Build a request dict for EmbeddingReqInput from proto TextEmbedRequest.
+fn build_text_embed_dict(
+    rid: &str,
+    req: &proto::TextEmbedRequest,
+) -> HashMap<String, serde_json::Value> {
+    let mut d = HashMap::new();
+    d.insert("rid".into(), serde_json::json!(rid));
+    d.insert("text".into(), serde_json::json!(req.text));
+    if let Some(ref rk) = req.routing_key {
+        d.insert("routing_key".into(), serde_json::json!(rk));
+    }
+    if let Some(trace) = trace_headers_to_json(&req.trace_headers) {
+        d.insert("external_trace_header".into(), trace);
+    }
+    d.insert("received_time".into(), serde_json::json!(now_timestamp()));
+    d
+}
+
+/// Build a request dict for EmbeddingReqInput from proto EmbedRequest (tokenized).
+fn build_embed_dict(rid: &str, req: &proto::EmbedRequest) -> HashMap<String, serde_json::Value> {
+    let mut d = HashMap::new();
+    d.insert("rid".into(), serde_json::json!(rid));
+    d.insert("input_ids".into(), serde_json::json!(req.input_ids));
+    if let Some(ref rk) = req.routing_key {
+        d.insert("routing_key".into(), serde_json::json!(rk));
+    }
+    if let Some(trace) = trace_headers_to_json(&req.trace_headers) {
+        d.insert("external_trace_header".into(), trace);
+    }
+    d.insert("received_time".into(), serde_json::json!(now_timestamp()));
+    d
+}
+
+/// Build a request dict for EmbeddingReqInput from proto ClassifyRequest.
+fn build_classify_dict(
+    rid: &str,
+    req: &proto::ClassifyRequest,
+) -> HashMap<String, serde_json::Value> {
+    let mut d = HashMap::new();
+    d.insert("rid".into(), serde_json::json!(rid));
+    if !req.text.is_empty() {
+        d.insert("text".into(), serde_json::json!(req.text));
+    }
+    if !req.input_ids.is_empty() {
+        d.insert("input_ids".into(), serde_json::json!(req.input_ids));
+    }
+    if let Some(ref rk) = req.routing_key {
+        d.insert("routing_key".into(), serde_json::json!(rk));
+    }
+    if let Some(trace) = trace_headers_to_json(&req.trace_headers) {
+        d.insert("external_trace_header".into(), trace);
+    }
+    d.insert("received_time".into(), serde_json::json!(now_timestamp()));
+    d
+}
+
+fn now_timestamp() -> f64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs_f64()
+}
+
+#[tonic::async_trait]
+impl proto::sglang_service_server::SglangService for SglangServiceImpl {
+    // ==================================================================
+    // SGLang-native RPCs: TextGenerate / Generate
+    // ==================================================================
+
+    type TextGenerateStream = StreamResult<proto::TextGenerateResponse>;
+
+    async fn text_generate(
+        &self,
+        request: Request<proto::TextGenerateRequest>,
+    ) -> Result<Response<Self::TextGenerateStream>, Status> {
+        let req = request.into_inner();
+        let n_tokens = req
+            .sampling_params
+            .as_ref()
+            .and_then(|p| p.max_new_tokens)
+            .unwrap_or(512)
+            .max(1) as u32;
+        let permit = acquire_inference_slot(&self.bridge, n_tokens).await?;
+        let rid = req
+            .rid
+            .clone()
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+        let req_dict = build_text_generate_dict(&rid, &req);
+
+        let mut receiver = self
+            .bridge
+            .submit_request(&rid, "generate", req_dict)
+            .map_err(|e| Status::internal(format!("Failed to submit request: {}", e)))?;
+
+        let bridge = self.bridge.clone();
+        let rid_clone = rid.clone();
+
+        let stream = async_stream::stream! {
+            // Release the permit after the first chunk (prefill done, now in decode).
+            // This lets the next queued request enter prefill while this one decodes,
+            // so the semaphore bounds prefill-queue depth rather than total concurrency.
+            let mut permit = Some(permit);
+            loop {
+                match recv_chunk_with_timeout(&mut receiver, "Stream chunk timed out").await {
+                    Ok(Some(ResponseChunk::Data(data))) => {
+                        permit.take(); // drop on first token — prefill complete
+                        yield Ok(proto::TextGenerateResponse {
+                            text: data.text.unwrap_or_default(),
+                            meta_info: data.meta_info,
+                            finished: false,
+                        });
+                    }
+                    Ok(Some(ResponseChunk::Finished(data))) => {
+                        permit.take(); // also covers single-chunk (non-streaming) responses
+                        yield Ok(proto::TextGenerateResponse {
+                            text: data.text.unwrap_or_default(),
+                            meta_info: data.meta_info,
+                            finished: true,
+                        });
+                        break;
+                    }
+                    Ok(Some(ResponseChunk::Error(msg))) => {
+                        permit.take();
+                        yield Err(Status::internal(msg));
+                        break;
+                    }
+                    Ok(None) => {
+                        permit.take();
+                        yield Err(closed_stream_status(&bridge, &rid_clone));
+                        break;
+                    }
+                    Err(status) => {
+                        permit.take();
+                        let _ = bridge.abort(&rid_clone, false);
+                        yield Err(status);
+                        break;
+                    }
+                }
+            }
+        };
+
+        Ok(Response::new(Box::pin(stream)))
+    }
+
+    type GenerateStream = StreamResult<proto::GenerateResponse>;
+
+    async fn generate(
+        &self,
+        request: Request<proto::GenerateRequest>,
+    ) -> Result<Response<Self::GenerateStream>, Status> {
+        let req = request.into_inner();
+        let n_tokens = req
+            .sampling_params
+            .as_ref()
+            .and_then(|p| p.max_new_tokens)
+            .unwrap_or(512)
+            .max(1) as u32;
+        let permit = acquire_inference_slot(&self.bridge, n_tokens).await?;
+        let rid = req
+            .rid
+            .clone()
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+        let req_dict = build_generate_dict(&rid, &req);
+
+        let mut receiver = self
+            .bridge
+            .submit_request(&rid, "generate", req_dict)
+            .map_err(|e| Status::internal(format!("Failed to submit request: {}", e)))?;
+
+        let bridge = self.bridge.clone();
+        let rid_clone = rid.clone();
+
+        let stream = async_stream::stream! {
+            let mut permit = Some(permit); // released on first token (prefill done)
+            loop {
+                match recv_chunk_with_timeout(&mut receiver, "Stream chunk timed out").await {
+                    Ok(Some(ResponseChunk::Data(data))) => {
+                        permit.take();
+                        yield Ok(proto::GenerateResponse {
+                            output_ids: data.output_ids.unwrap_or_default(),
+                            meta_info: data.meta_info,
+                            finished: false,
+                        });
+                    }
+                    Ok(Some(ResponseChunk::Finished(data))) => {
+                        permit.take();
+                        yield Ok(proto::GenerateResponse {
+                            output_ids: data.output_ids.unwrap_or_default(),
+                            meta_info: data.meta_info,
+                            finished: true,
+                        });
+                        break;
+                    }
+                    Ok(Some(ResponseChunk::Error(msg))) => {
+                        permit.take();
+                        yield Err(Status::internal(msg));
+                        break;
+                    }
+                    Ok(None) => {
+                        permit.take();
+                        yield Err(closed_stream_status(&bridge, &rid_clone));
+                        break;
+                    }
+                    Err(status) => {
+                        permit.take();
+                        let _ = bridge.abort(&rid_clone, false);
+                        yield Err(status);
+                        break;
+                    }
+                }
+            }
+        };
+
+        Ok(Response::new(Box::pin(stream)))
+    }
+
+    // ==================================================================
+    // SGLang-native RPCs: Embed (text / tokenized)
+    // ==================================================================
+
+    async fn text_embed(
+        &self,
+        request: Request<proto::TextEmbedRequest>,
+    ) -> Result<Response<proto::TextEmbedResponse>, Status> {
+        let _permit = acquire_inference_slot(&self.bridge, 1).await?;
+
+        let req = request.into_inner();
+        let rid = req
+            .rid
+            .clone()
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+        let req_dict = build_text_embed_dict(&rid, &req);
+
+        let mut receiver = self
+            .bridge
+            .submit_request(&rid, "embed", req_dict)
+            .map_err(|e| Status::internal(format!("Failed to submit request: {}", e)))?;
+
+        let chunk = recv_required_chunk(&mut receiver).await?;
+
+        match chunk {
+            ResponseChunk::Data(data) | ResponseChunk::Finished(data) => {
+                Ok(Response::new(proto::TextEmbedResponse {
+                    embedding: data.embedding.unwrap_or_default(),
+                    meta_info: data.meta_info,
+                }))
+            }
+            ResponseChunk::Error(msg) => Err(Status::internal(msg)),
+        }
+    }
+
+    async fn embed(
+        &self,
+        request: Request<proto::EmbedRequest>,
+    ) -> Result<Response<proto::EmbedResponse>, Status> {
+        let _permit = acquire_inference_slot(&self.bridge, 1).await?;
+
+        let req = request.into_inner();
+        let rid = req
+            .rid
+            .clone()
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+        let req_dict = build_embed_dict(&rid, &req);
+
+        let mut receiver = self
+            .bridge
+            .submit_request(&rid, "embed", req_dict)
+            .map_err(|e| Status::internal(format!("Failed to submit request: {}", e)))?;
+
+        let chunk = recv_required_chunk(&mut receiver).await?;
+
+        match chunk {
+            ResponseChunk::Data(data) | ResponseChunk::Finished(data) => {
+                Ok(Response::new(proto::EmbedResponse {
+                    embedding: data.embedding.unwrap_or_default(),
+                    meta_info: data.meta_info,
+                }))
+            }
+            ResponseChunk::Error(msg) => Err(Status::internal(msg)),
+        }
+    }
+
+    // ==================================================================
+    // SGLang-native RPCs: Classify
+    // ==================================================================
+
+    async fn classify(
+        &self,
+        request: Request<proto::ClassifyRequest>,
+    ) -> Result<Response<proto::ClassifyResponse>, Status> {
+        let _permit = acquire_inference_slot(&self.bridge, 1).await?;
+
+        let req = request.into_inner();
+        let rid = req
+            .rid
+            .clone()
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+        let req_dict = build_classify_dict(&rid, &req);
+
+        let mut receiver = self
+            .bridge
+            .submit_request(&rid, "embed", req_dict)
+            .map_err(|e| Status::internal(format!("Failed to submit request: {}", e)))?;
+
+        let chunk = recv_required_chunk(&mut receiver).await?;
+
+        match chunk {
+            ResponseChunk::Data(data) | ResponseChunk::Finished(data) => {
+                Ok(Response::new(proto::ClassifyResponse {
+                    embedding: data.embedding.unwrap_or_default(),
+                    meta_info: data.meta_info,
+                }))
+            }
+            ResponseChunk::Error(msg) => Err(Status::internal(msg)),
+        }
+    }
+
+    // ==================================================================
+    // SGLang-native RPCs: Tokenize / Detokenize (Rust-native with fallback)
+    // ==================================================================
+
+    async fn tokenize(
+        &self,
+        request: Request<proto::TokenizeRequest>,
+    ) -> Result<Response<proto::TokenizeResponse>, Status> {
+        let req = request.into_inner();
+        let add_special = req.add_special_tokens.unwrap_or(true);
+
+        // Try Rust-native tokenizer first (no GIL)
+        if let Some(tok) = self.bridge.rust_tokenizer() {
+            let tokens = tok
+                .encode(&req.text, add_special)
+                .map_err(|e| Status::internal(e))?;
+            let count = tokens.len() as i32;
+            return Ok(Response::new(proto::TokenizeResponse {
+                tokens: tokens.iter().map(|&t| t as i32).collect(),
+                count,
+                max_model_len: self.bridge.context_len(),
+                input_text: req.text,
+            }));
+        }
+
+        // Fallback to Python
+        let json_str = tokio::task::spawn_blocking({
+            let bridge = self.bridge.clone();
+            let text = req.text.clone();
+            move || bridge.tokenize_py(&text, add_special)
+        })
+        .await
+        .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
+        .map_err(|e| Status::internal(format!("Tokenize failed: {}", e)))?;
+
+        let v: serde_json::Value = serde_json::from_str(&json_str)
+            .map_err(|e| Status::internal(format!("Failed to parse JSON response: {}", e)))?;
+        Ok(Response::new(proto::TokenizeResponse {
+            tokens: v["tokens"]
+                .as_array()
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|x| x.as_i64().map(|n| n as i32))
+                        .collect()
+                })
+                .unwrap_or_default(),
+            count: v["count"].as_i64().unwrap_or(0) as i32,
+            max_model_len: v["max_model_len"].as_i64().unwrap_or(0) as i32,
+            input_text: v["input_text"].as_str().unwrap_or("").to_string(),
+        }))
+    }
+
+    async fn detokenize(
+        &self,
+        request: Request<proto::DetokenizeRequest>,
+    ) -> Result<Response<proto::DetokenizeResponse>, Status> {
+        let req = request.into_inner();
+        if req.tokens.iter().any(|&token| token < 0) {
+            return Err(Status::invalid_argument(
+                "Detokenize tokens must be non-negative",
+            ));
+        }
+
+        // Try Rust-native tokenizer first (no GIL)
+        if let Some(tok) = self.bridge.rust_tokenizer() {
+            let ids: Vec<u32> = req.tokens.iter().map(|&t| t as u32).collect();
+            let text = tok.decode(&ids, true).map_err(|e| Status::internal(e))?;
+            return Ok(Response::new(proto::DetokenizeResponse { text }));
+        }
+
+        // Fallback to Python
+        let json_str = tokio::task::spawn_blocking({
+            let bridge = self.bridge.clone();
+            let tokens = req.tokens;
+            move || bridge.detokenize_py(tokens)
+        })
+        .await
+        .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
+        .map_err(|e| Status::internal(format!("Detokenize failed: {}", e)))?;
+
+        let v: serde_json::Value = serde_json::from_str(&json_str)
+            .map_err(|e| Status::internal(format!("Failed to parse JSON response: {}", e)))?;
+        Ok(Response::new(proto::DetokenizeResponse {
+            text: v["text"].as_str().unwrap_or("").to_string(),
+        }))
+    }
+
+    // ==================================================================
+    // SGLang-native RPCs: Info / control
+    // ==================================================================
+
+    async fn health_check(
+        &self,
+        _request: Request<proto::HealthCheckRequest>,
+    ) -> Result<Response<proto::HealthCheckResponse>, Status> {
+        let healthy = self
+            .bridge
+            .health_check()
+            .map_err(|e| Status::internal(format!("Health check failed: {}", e)))?;
+
+        Ok(Response::new(proto::HealthCheckResponse { healthy }))
+    }
+
+    async fn get_model_info(
+        &self,
+        _request: Request<proto::GetModelInfoRequest>,
+    ) -> Result<Response<proto::GetModelInfoResponse>, Status> {
+        let json_info = self
+            .bridge
+            .get_model_info()
+            .map_err(|e| Status::internal(format!("Failed to get model info: {}", e)))?;
+
+        Ok(Response::new(proto::GetModelInfoResponse {
+            model_path: extract_model_path(&json_info),
+            json_info,
+        }))
+    }
+
+    async fn get_server_info(
+        &self,
+        _request: Request<proto::GetServerInfoRequest>,
+    ) -> Result<Response<proto::GetServerInfoResponse>, Status> {
+        let json_info = self
+            .bridge
+            .get_server_info()
+            .map_err(|e| Status::internal(format!("Failed to get server info: {}", e)))?;
+
+        Ok(Response::new(proto::GetServerInfoResponse { json_info }))
+    }
+
+    async fn list_models(
+        &self,
+        _request: Request<proto::ListModelsRequest>,
+    ) -> Result<Response<proto::ListModelsResponse>, Status> {
+        let json_str = tokio::task::spawn_blocking({
+            let bridge = self.bridge.clone();
+            move || bridge.list_models()
+        })
+        .await
+        .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
+        .map_err(|e| Status::internal(format!("Failed to list models: {}", e)))?;
+
+        let models_arr: Vec<serde_json::Value> = serde_json::from_str(&json_str)
+            .map_err(|e| Status::internal(format!("Failed to parse models JSON: {}", e)))?;
+
+        let models = models_arr
+            .iter()
+            .map(|m| proto::ModelCard {
+                id: m["id"].as_str().unwrap_or("").to_string(),
+                root: m["root"].as_str().unwrap_or("").to_string(),
+                parent: m.get("parent").and_then(|v| v.as_str()).map(String::from),
+                max_model_len: m
+                    .get("max_model_len")
+                    .and_then(|v| v.as_i64())
+                    .map(|n| n as i32),
+            })
+            .collect();
+
+        Ok(Response::new(proto::ListModelsResponse { models }))
+    }
+
+    async fn get_load(
+        &self,
+        request: Request<proto::GetLoadRequest>,
+    ) -> Result<Response<proto::GetLoadResponse>, Status> {
+        let req = request.into_inner();
+        let rid = uuid::Uuid::new_v4().to_string();
+        let receiver = self
+            .bridge
+            .submit_get_load(&rid, req.dp_rank)
+            .map_err(|e| Status::internal(format!("Failed to get load: {}", e)))?;
+
+        let json_info = recv_json_response(receiver).await?;
+        Ok(Response::new(proto::GetLoadResponse { json_info }))
+    }
+
+    async fn abort(
+        &self,
+        request: Request<proto::AbortRequest>,
+    ) -> Result<Response<proto::AbortResponse>, Status> {
+        let req = request.into_inner();
+        self.bridge
+            .abort(&req.rid, req.abort_all)
+            .map_err(|e| Status::internal(format!("Failed to abort: {}", e)))?;
+
+        Ok(Response::new(proto::AbortResponse { success: true }))
+    }
+
+    async fn flush_cache(
+        &self,
+        _request: Request<proto::FlushCacheRequest>,
+    ) -> Result<Response<proto::FlushCacheResponse>, Status> {
+        let rid = uuid::Uuid::new_v4().to_string();
+        let receiver = self
+            .bridge
+            .submit_flush_cache(&rid)
+            .map_err(|e| Status::internal(format!("Failed to flush cache: {}", e)))?;
+
+        let json_str = recv_json_response(receiver).await?;
+        let v: serde_json::Value = serde_json::from_str(&json_str)
+            .map_err(|e| Status::internal(format!("Failed to parse JSON response: {}", e)))?;
+        Ok(Response::new(proto::FlushCacheResponse {
+            success: v["success"].as_bool().unwrap_or(false),
+            message: v["message"].as_str().unwrap_or("").to_string(),
+        }))
+    }
+
+    async fn pause_generation(
+        &self,
+        request: Request<proto::PauseGenerationRequest>,
+    ) -> Result<Response<proto::PauseGenerationResponse>, Status> {
+        let req = request.into_inner();
+        let rid = uuid::Uuid::new_v4().to_string();
+        let receiver = self
+            .bridge
+            .submit_pause_generation(&rid, &req.mode)
+            .map_err(|e| Status::internal(format!("Failed to pause generation: {}", e)))?;
+
+        let json_str = recv_json_response(receiver).await?;
+        let v: serde_json::Value = serde_json::from_str(&json_str)
+            .map_err(|e| Status::internal(format!("Failed to parse JSON response: {}", e)))?;
+        Ok(Response::new(proto::PauseGenerationResponse {
+            message: v["message"].as_str().unwrap_or("").to_string(),
+        }))
+    }
+
+    async fn continue_generation(
+        &self,
+        _request: Request<proto::ContinueGenerationRequest>,
+    ) -> Result<Response<proto::ContinueGenerationResponse>, Status> {
+        let rid = uuid::Uuid::new_v4().to_string();
+        let receiver = self
+            .bridge
+            .submit_continue_generation(&rid)
+            .map_err(|e| Status::internal(format!("Failed to continue generation: {}", e)))?;
+
+        let json_str = recv_json_response(receiver).await?;
+        let v: serde_json::Value = serde_json::from_str(&json_str)
+            .map_err(|e| Status::internal(format!("Failed to parse JSON response: {}", e)))?;
+        Ok(Response::new(proto::ContinueGenerationResponse {
+            message: v["message"].as_str().unwrap_or("").to_string(),
+        }))
+    }
+
+    // ==================================================================
+    // OpenAI-compatible RPCs (JSON pass-through)
+    // ==================================================================
+
+    type ChatCompleteStream = StreamResult<proto::OpenAiStreamChunk>;
+
+    async fn chat_complete(
+        &self,
+        request: Request<proto::OpenAiRequest>,
+    ) -> Result<Response<Self::ChatCompleteStream>, Status> {
+        self.openai_streaming_rpc(request, "submit_openai_chat")
+            .await
+    }
+
+    type CompleteStream = StreamResult<proto::OpenAiStreamChunk>;
+
+    async fn complete(
+        &self,
+        request: Request<proto::OpenAiRequest>,
+    ) -> Result<Response<Self::CompleteStream>, Status> {
+        self.openai_streaming_rpc(request, "submit_openai_complete")
+            .await
+    }
+
+    async fn open_ai_embed(
+        &self,
+        request: Request<proto::OpenAiRequest>,
+    ) -> Result<Response<proto::OpenAiResponse>, Status> {
+        self.openai_unary_rpc(request, "submit_openai_embed").await
+    }
+
+    async fn open_ai_classify(
+        &self,
+        request: Request<proto::OpenAiRequest>,
+    ) -> Result<Response<proto::OpenAiResponse>, Status> {
+        self.openai_unary_rpc(request, "submit_openai_classify")
+            .await
+    }
+
+    async fn score(
+        &self,
+        request: Request<proto::OpenAiRequest>,
+    ) -> Result<Response<proto::OpenAiResponse>, Status> {
+        self.openai_unary_rpc(request, "submit_openai_score").await
+    }
+
+    async fn rerank(
+        &self,
+        request: Request<proto::OpenAiRequest>,
+    ) -> Result<Response<proto::OpenAiResponse>, Status> {
+        self.openai_unary_rpc(request, "submit_openai_rerank").await
+    }
+
+    // ==================================================================
+    // Admin RPCs
+    // ==================================================================
+
+    async fn start_profile(
+        &self,
+        request: Request<proto::StartProfileRequest>,
+    ) -> Result<Response<proto::StartProfileResponse>, Status> {
+        let req = request.into_inner();
+        let rid = uuid::Uuid::new_v4().to_string();
+        let receiver = self
+            .bridge
+            .submit_start_profile(&rid, req.output_dir.as_deref())
+            .map_err(|e| Status::internal(format!("Failed to start profile: {}", e)))?;
+
+        let json_str = recv_json_response(receiver).await?;
+        let v: serde_json::Value = serde_json::from_str(&json_str)
+            .map_err(|e| Status::internal(format!("Failed to parse JSON response: {}", e)))?;
+        Ok(Response::new(proto::StartProfileResponse {
+            message: v["message"].as_str().unwrap_or("").to_string(),
+        }))
+    }
+
+    async fn stop_profile(
+        &self,
+        _request: Request<proto::StopProfileRequest>,
+    ) -> Result<Response<proto::StopProfileResponse>, Status> {
+        let rid = uuid::Uuid::new_v4().to_string();
+        let receiver = self
+            .bridge
+            .submit_stop_profile(&rid)
+            .map_err(|e| Status::internal(format!("Failed to stop profile: {}", e)))?;
+
+        let json_str = recv_json_response(receiver).await?;
+        let v: serde_json::Value = serde_json::from_str(&json_str)
+            .map_err(|e| Status::internal(format!("Failed to parse JSON response: {}", e)))?;
+        Ok(Response::new(proto::StopProfileResponse {
+            message: v["message"].as_str().unwrap_or("").to_string(),
+        }))
+    }
+
+    async fn update_weights_from_disk(
+        &self,
+        request: Request<proto::UpdateWeightsRequest>,
+    ) -> Result<Response<proto::UpdateWeightsResponse>, Status> {
+        let req = request.into_inner();
+        let rid = uuid::Uuid::new_v4().to_string();
+        let receiver = self
+            .bridge
+            .submit_update_weights(&rid, &req.model_path, req.load_format.as_deref())
+            .map_err(|e| Status::internal(format!("Failed to update weights: {}", e)))?;
+
+        let json_str = recv_json_response(receiver).await?;
+        let v: serde_json::Value = serde_json::from_str(&json_str)
+            .map_err(|e| Status::internal(format!("Failed to parse JSON response: {}", e)))?;
+        Ok(Response::new(proto::UpdateWeightsResponse {
+            success: v["success"].as_bool().unwrap_or(false),
+            message: v["message"].as_str().unwrap_or("").to_string(),
+        }))
+    }
+}
+
+// ======================================================================
+// Helper methods for OpenAI pass-through RPCs
+// ======================================================================
+
+impl SglangServiceImpl {
+    async fn openai_streaming_rpc(
+        &self,
+        request: Request<proto::OpenAiRequest>,
+        method_name: &str,
+    ) -> Result<Response<StreamResult<proto::OpenAiStreamChunk>>, Status> {
+        let req = request.into_inner();
+        // Best-effort parse of max_tokens from OpenAI JSON body; fall back to 512.
+        let n_tokens: u32 = serde_json::from_slice::<serde_json::Value>(&req.json_body)
+            .ok()
+            .and_then(|v| v.get("max_tokens").and_then(|t| t.as_u64()))
+            .unwrap_or(512)
+            .max(1) as u32;
+        let permit = acquire_inference_slot(&self.bridge, n_tokens).await?;
+        let rid = uuid::Uuid::new_v4().to_string();
+
+        let mut receiver = self
+            .bridge
+            .submit_openai(&rid, method_name, &req.json_body, &req.trace_headers)
+            .map_err(|e| Status::internal(format!("Failed to submit request: {}", e)))?;
+
+        let bridge = self.bridge.clone();
+        let rid_clone = rid.clone();
+
+        let stream = async_stream::stream! {
+            let mut permit = Some(permit); // released on first token (prefill done)
+            loop {
+                match recv_chunk_with_timeout(&mut receiver, "Stream chunk timed out").await {
+                    Ok(Some(ResponseChunk::Data(data))) => {
+                        permit.take();
+                        yield Ok(proto::OpenAiStreamChunk {
+                            json_chunk: data.json_bytes.unwrap_or_default(),
+                            finished: false,
+                        });
+                    }
+                    Ok(Some(ResponseChunk::Finished(data))) => {
+                        permit.take();
+                        let bytes = data.json_bytes.unwrap_or_default();
+                        yield Ok(proto::OpenAiStreamChunk {
+                            json_chunk: bytes,
+                            finished: true,
+                        });
+                        break;
+                    }
+                    Ok(Some(ResponseChunk::Error(msg))) => {
+                        permit.take();
+                        yield Err(Status::internal(msg));
+                        break;
+                    }
+                    Ok(None) => {
+                        permit.take();
+                        yield Err(closed_stream_status(&bridge, &rid_clone));
+                        break;
+                    }
+                    Err(status) => {
+                        permit.take();
+                        let _ = bridge.abort(&rid_clone, false);
+                        yield Err(status);
+                        break;
+                    }
+                }
+            }
+        };
+
+        Ok(Response::new(Box::pin(stream)))
+    }
+
+    async fn openai_unary_rpc(
+        &self,
+        request: Request<proto::OpenAiRequest>,
+        method_name: &str,
+    ) -> Result<Response<proto::OpenAiResponse>, Status> {
+        let _permit = acquire_inference_slot(&self.bridge, 1).await?;
+
+        let req = request.into_inner();
+        let rid = uuid::Uuid::new_v4().to_string();
+
+        let mut receiver = self
+            .bridge
+            .submit_openai(&rid, method_name, &req.json_body, &req.trace_headers)
+            .map_err(|e| Status::internal(format!("Failed to submit request: {}", e)))?;
+
+        let chunk = recv_required_chunk(&mut receiver).await?;
+
+        match chunk {
+            ResponseChunk::Data(data) | ResponseChunk::Finished(data) => {
+                Ok(Response::new(proto::OpenAiResponse {
+                    json_body: data.json_bytes.unwrap_or_default(),
+                    status_code: openai_status_code(&data.meta_info, 200),
+                }))
+            }
+            ResponseChunk::Error(msg) => {
+                let error_json = serde_json::json!({"error": {"message": msg}});
+                Ok(Response::new(proto::OpenAiResponse {
+                    json_body: error_json.to_string().into_bytes(),
+                    status_code: 500,
+                }))
+            }
+        }
+    }
+}
+
+/// Receive a single JSON response from the bridge channel.
+async fn recv_json_response(mut receiver: Receiver<ResponseChunk>) -> Result<String, Status> {
+    let chunk = recv_required_chunk(&mut receiver).await?;
+
+    match chunk {
+        ResponseChunk::Data(data) | ResponseChunk::Finished(data) => {
+            let bytes = data.json_bytes.unwrap_or_default();
+            String::from_utf8(bytes)
+                .map_err(|e| Status::internal(format!("Invalid UTF-8 in response: {}", e)))
+        }
+        ResponseChunk::Error(msg) => Err(Status::internal(msg)),
+    }
+}
+
+/// Start the Tonic gRPC server on the given address.
+///
+/// # Why not `tower::limit::ConcurrencyLimitLayer`?
+///
+/// Tonic is built on Tower, so one might reach for
+/// `Server::builder().layer(ConcurrencyLimitLayer::new(n))` as a two-line solution.
+/// It is intentionally NOT used here for two reasons:
+///
+/// 1. **Scope**: a Tower layer applied at the server level gates *all* RPCs, including
+///    lightweight ones like `HealthCheck`, `Tokenize`, `GetModelInfo`, and `Abort`.
+///    Those must remain unconditionally available even under full saturation (health
+///    probes from Kubernetes, abort requests from clients, etc.). The semaphore in
+///    [`PyBridge`] is applied only inside the inference RPC handlers
+///    (`text_generate`, `generate`, `*embed`, `classify`, and the OpenAI pass-throughs),
+///    leaving control-plane RPCs completely unaffected.
+///
+/// 2. **Granularity**: `ConcurrencyLimitLayer` counts concurrent *connections* or
+///    *requests at the transport level*, not concurrent requests that are actually
+///    in-flight to the Python scheduler. The semaphore tracks exactly one permit per
+///    live scheduler request, so the cap maps directly onto GPU concurrency rather
+///    than an approximation of it.
+pub async fn run_grpc_server(
+    addr: std::net::SocketAddr,
+    bridge: Arc<PyBridge>,
+    shutdown: Arc<Notify>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let service = SglangServiceImpl {
+        bridge,
+        shutdown: shutdown.clone(),
+    };
+
+    let svc = proto::sglang_service_server::SglangServiceServer::new(service);
+
+    tracing::info!("gRPC server listening on {}", addr);
+
+    tonic::transport::Server::builder()
+        .add_service(svc)
+        .serve_with_shutdown(addr, async move {
+            shutdown.notified().await;
+            tracing::info!("gRPC server shutting down");
+        })
+        .await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::openai_status_code;
+    use std::collections::HashMap;
+
+    #[test]
+    fn openai_status_code_uses_forwarded_status_when_present() {
+        let meta_info =
+            HashMap::from([(String::from("status_code"), String::from("429"))]);
+        assert_eq!(openai_status_code(&meta_info, 200), 429);
+    }
+
+    #[test]
+    fn openai_status_code_falls_back_when_missing_or_invalid() {
+        assert_eq!(openai_status_code(&HashMap::new(), 200), 200);
+
+        let meta_info =
+            HashMap::from([(String::from("status_code"), String::from("not-an-int"))]);
+        assert_eq!(openai_status_code(&meta_info, 200), 200);
+    }
+}

--- a/rust/sglang-grpc/src/sglang_grpc/__init__.py
+++ b/rust/sglang-grpc/src/sglang_grpc/__init__.py
@@ -1,0 +1,5 @@
+"""SGLang gRPC server — Rust/Tonic implementation via PyO3."""
+
+from sglang_grpc._core import GrpcServerHandle, start_server
+
+__all__ = ["start_server", "GrpcServerHandle"]

--- a/rust/sglang-grpc/src/tokenizer.rs
+++ b/rust/sglang-grpc/src/tokenizer.rs
@@ -1,0 +1,66 @@
+use std::path::Path;
+use tokenizers::Tokenizer;
+
+/// Rust-native tokenizer wrapping HuggingFace's `tokenizers` crate.
+///
+/// This is the same Rust library that Python's `tokenizers` package wraps,
+/// so it produces identical output for the same tokenizer.json file.
+pub struct RustTokenizer {
+    inner: Tokenizer,
+    context_len: i32,
+}
+
+impl RustTokenizer {
+    /// Load a tokenizer from a model directory (looks for `tokenizer.json`).
+    /// Returns `None` if the file doesn't exist or can't be loaded.
+    pub fn from_model_path(model_path: &str, context_len: i32) -> Option<Self> {
+        let tokenizer_json = Path::new(model_path).join("tokenizer.json");
+        if !tokenizer_json.exists() {
+            tracing::info!(
+                "No tokenizer.json found at {:?}, Rust tokenizer disabled",
+                tokenizer_json
+            );
+            return None;
+        }
+
+        match Tokenizer::from_file(&tokenizer_json) {
+            Ok(inner) => {
+                tracing::info!(
+                    "Rust tokenizer loaded from {:?} (context_len={})",
+                    tokenizer_json,
+                    context_len
+                );
+                Some(Self { inner, context_len })
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to load Rust tokenizer from {:?}: {}. Falling back to Python.",
+                    tokenizer_json,
+                    e
+                );
+                None
+            }
+        }
+    }
+
+    /// Tokenize text, returning token IDs.
+    pub fn encode(&self, text: &str, add_special_tokens: bool) -> Result<Vec<u32>, String> {
+        let encoding = self
+            .inner
+            .encode(text, add_special_tokens)
+            .map_err(|e| format!("Tokenization failed: {}", e))?;
+        Ok(encoding.get_ids().to_vec())
+    }
+
+    /// Decode token IDs back to text.
+    pub fn decode(&self, ids: &[u32], skip_special_tokens: bool) -> Result<String, String> {
+        self.inner
+            .decode(ids, skip_special_tokens)
+            .map_err(|e| format!("Detokenization failed: {}", e))
+    }
+
+    /// Return the model's context length.
+    pub fn context_len(&self) -> i32 {
+        self.context_len
+    }
+}

--- a/test/registered/core/test_grpc_server.py
+++ b/test/registered/core/test_grpc_server.py
@@ -1,0 +1,970 @@
+"""
+Integration tests for the native Rust gRPC server.
+
+These tests verify that the gRPC server starts alongside HTTP and correctly
+handles all implemented RPCs: text generate, tokenized generate, streaming,
+embed, classify, tokenize, detokenize, list models, get load, flush cache,
+pause/continue, abort, health, model info, server info, and OpenAI-compat RPCs.
+
+Usage:
+    python3 -m pytest test_grpc_server.py -v
+"""
+
+import asyncio
+import importlib.util
+import json
+import socket
+import struct
+import unittest
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import (
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    find_available_port,
+    popen_launch_server,
+)
+
+try:
+    import grpc
+
+    _HAS_GRPCIO = True
+except ImportError:
+    grpc = None
+    _HAS_GRPCIO = False
+
+try:
+    import granian  # noqa: F401
+
+    _HAS_GRANIAN = True
+except ImportError:
+    _HAS_GRANIAN = False
+
+_HAS_SGLANG_GRPC = importlib.util.find_spec("sglang_grpc") is not None
+
+register_cuda_ci(est_time=300, suite="stage-b-test-small-1-gpu")
+
+
+def _grpc_port_from_http_url(http_url: str) -> int:
+    """Derive the gRPC port from the HTTP base URL (port + 10000)."""
+    from urllib.parse import urlparse
+
+    parsed = urlparse(http_url)
+    return parsed.port + 10000
+
+
+def _grpc_host_from_http_url(http_url: str) -> str:
+    from urllib.parse import urlparse
+
+    parsed = urlparse(http_url)
+    return parsed.hostname
+
+
+def _make_test_base_url() -> str:
+    from urllib.parse import urlparse
+
+    parsed = urlparse(DEFAULT_URL_FOR_TEST)
+    while True:
+        port = find_available_port(parsed.port)
+        grpc_port = port + 10000
+        try:
+            with socket.create_server((parsed.hostname, grpc_port)):
+                return f"http://{parsed.hostname}:{port}"
+        except OSError:
+            continue
+
+
+def _create_grpc_channel(host: str, port: int):
+    if not _HAS_GRPCIO:
+        raise unittest.SkipTest("grpcio not installed")
+    target = f"{host}:{port}"
+    channel = grpc.insecure_channel(target)
+    try:
+        grpc.channel_ready_future(channel).result(timeout=30)
+    except grpc.FutureTimeoutError as exc:
+        channel.close()
+        raise RuntimeError(
+            f"gRPC channel to {target} did not become ready within 30s"
+        ) from exc
+    return channel
+
+
+def _make_unary_call(
+    channel, method: str, request_bytes: bytes, timeout: float = 30
+) -> bytes:
+    return channel.unary_unary(
+        f"/sglang.runtime.v1.SglangService/{method}",
+        request_serializer=lambda x: x,
+        response_deserializer=lambda x: x,
+    )(request_bytes, timeout=timeout)
+
+
+def _make_server_stream_call(
+    channel, method: str, request_bytes: bytes, timeout: float = 30
+):
+    return channel.unary_stream(
+        f"/sglang.runtime.v1.SglangService/{method}",
+        request_serializer=lambda x: x,
+        response_deserializer=lambda x: x,
+    )(request_bytes, timeout=timeout)
+
+
+# ======================================================================
+# Protobuf encoding/decoding helpers (minimal, no grpc-tools needed)
+# ======================================================================
+
+
+def _encode_varint(value: int) -> bytes:
+    bits = value & 0x7F
+    value >>= 7
+    result = b""
+    while value:
+        result += bytes([0x80 | bits])
+        bits = value & 0x7F
+        value >>= 7
+    result += bytes([bits])
+    return result
+
+
+def _encode_string_field(field_number: int, value: str) -> bytes:
+    tag = (field_number << 3) | 2
+    encoded = value.encode("utf-8")
+    return _encode_varint(tag) + _encode_varint(len(encoded)) + encoded
+
+
+def _encode_bytes_field(field_number: int, value: bytes) -> bytes:
+    tag = (field_number << 3) | 2
+    return _encode_varint(tag) + _encode_varint(len(value)) + value
+
+
+def _encode_bool_field(field_number: int, value: bool) -> bytes:
+    tag = (field_number << 3) | 0
+    return _encode_varint(tag) + bytes([1 if value else 0])
+
+
+def _encode_float_field(field_number: int, value: float) -> bytes:
+    tag = (field_number << 3) | 5
+    return _encode_varint(tag) + struct.pack("<f", value)
+
+
+def _encode_int32_field(field_number: int, value: int) -> bytes:
+    tag = (field_number << 3) | 0
+    if value < 0:
+        value = (1 << 64) + value
+    return _encode_varint(tag) + _encode_varint(value)
+
+
+def _encode_submessage_field(field_number: int, data: bytes) -> bytes:
+    tag = (field_number << 3) | 2
+    return _encode_varint(tag) + _encode_varint(len(data)) + data
+
+
+def _decode_varint(data: bytes, offset: int):
+    result = 0
+    shift = 0
+    while offset < len(data):
+        b = data[offset]
+        result |= (b & 0x7F) << shift
+        offset += 1
+        if not (b & 0x80):
+            return result, offset
+        shift += 7
+    return None, None
+
+
+def _decode_string_field(data: bytes, field_number: int) -> Optional[str]:
+    expected_tag = (field_number << 3) | 2
+    i = 0
+    while i < len(data):
+        tag, new_i = _decode_varint(data, i)
+        if new_i is None:
+            break
+        i = new_i
+        wire_type = tag & 0x7
+
+        if wire_type == 0:
+            _, i = _decode_varint(data, i)
+            if i is None:
+                break
+        elif wire_type == 2:
+            length, i = _decode_varint(data, i)
+            if i is None:
+                break
+            if tag == expected_tag:
+                try:
+                    return data[i : i + length].decode("utf-8")
+                except UnicodeDecodeError:
+                    return None
+            i += length
+        elif wire_type == 5:
+            i += 4
+        elif wire_type == 1:
+            i += 8
+        else:
+            break
+    return None
+
+
+def _decode_bytes_field(data: bytes, field_number: int) -> Optional[bytes]:
+    expected_tag = (field_number << 3) | 2
+    i = 0
+    while i < len(data):
+        tag, new_i = _decode_varint(data, i)
+        if new_i is None:
+            break
+        i = new_i
+        wire_type = tag & 0x7
+
+        if wire_type == 0:
+            _, i = _decode_varint(data, i)
+            if i is None:
+                break
+        elif wire_type == 2:
+            length, i = _decode_varint(data, i)
+            if i is None:
+                break
+            if tag == expected_tag:
+                return data[i : i + length]
+            i += length
+        elif wire_type == 5:
+            i += 4
+        elif wire_type == 1:
+            i += 8
+        else:
+            break
+    return None
+
+
+def _decode_bool_field(data: bytes, field_number: int) -> Optional[bool]:
+    expected_tag = (field_number << 3) | 0
+    i = 0
+    while i < len(data):
+        tag, new_i = _decode_varint(data, i)
+        if new_i is None:
+            break
+        i = new_i
+        wire_type = tag & 0x7
+
+        if wire_type == 0:
+            val, i = _decode_varint(data, i)
+            if i is None:
+                break
+            if tag == expected_tag:
+                return bool(val)
+        elif wire_type == 2:
+            length, i = _decode_varint(data, i)
+            if i is None:
+                break
+            i += length
+        elif wire_type == 5:
+            i += 4
+        elif wire_type == 1:
+            i += 8
+        else:
+            break
+    return None
+
+
+def _decode_int32_field(data: bytes, field_number: int) -> Optional[int]:
+    expected_tag = (field_number << 3) | 0
+    i = 0
+    while i < len(data):
+        tag, new_i = _decode_varint(data, i)
+        if new_i is None:
+            break
+        i = new_i
+        wire_type = tag & 0x7
+
+        if wire_type == 0:
+            val, i = _decode_varint(data, i)
+            if i is None:
+                break
+            if tag == expected_tag:
+                return val
+        elif wire_type == 2:
+            length, i = _decode_varint(data, i)
+            if i is None:
+                break
+            i += length
+        elif wire_type == 5:
+            i += 4
+        elif wire_type == 1:
+            i += 8
+        else:
+            break
+    return None
+
+
+def _build_text_generate_request(
+    text: str,
+    max_new_tokens: int = 16,
+    temperature: float = 0.0,
+    stream: bool = False,
+) -> bytes:
+    result = _encode_string_field(1, text)
+    sampling = b""
+    sampling += _encode_float_field(1, temperature)
+    sampling += _encode_int32_field(8, max_new_tokens)
+    result += _encode_submessage_field(2, sampling)
+    result += _encode_bool_field(3, stream)
+    return result
+
+
+# ======================================================================
+# Tests
+# ======================================================================
+
+
+@unittest.skipUnless(_HAS_GRPCIO, "grpcio not installed")
+@unittest.skipUnless(_HAS_SGLANG_GRPC, "sglang_grpc package not installed")
+class GrpcEnabledServerBase(CustomTestCase):
+    grpc_channel = None
+    other_args = ("--mem-fraction-static", "0.7", "--enable-grpc")
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN
+        cls.base_url = _make_test_base_url()
+        cls.grpc_port = _grpc_port_from_http_url(cls.base_url)
+        cls.grpc_host = _grpc_host_from_http_url(cls.base_url)
+
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=cls.other_args,
+        )
+
+        cls.grpc_channel = _create_grpc_channel(cls.grpc_host, cls.grpc_port)
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "grpc_channel") and cls.grpc_channel is not None:
+            cls.grpc_channel.close()
+        if hasattr(cls, "process") and cls.process:
+            kill_process_tree(cls.process.pid)
+
+    def _make_unary_call(self, method: str, request_bytes: bytes) -> bytes:
+        return _make_unary_call(self.grpc_channel, method, request_bytes)
+
+    def _make_server_stream_call(self, method: str, request_bytes: bytes):
+        return _make_server_stream_call(self.grpc_channel, method, request_bytes)
+
+
+class TestGrpcServer(GrpcEnabledServerBase):
+    """Test the native gRPC server running alongside HTTP."""
+
+    # ------------------------------------------------------------------
+    # Existing Phase 1 RPCs
+    # ------------------------------------------------------------------
+
+    def test_http_still_works(self):
+        """Regression: HTTP /generate still works when gRPC is enabled."""
+        response = requests.post(
+            self.base_url + "/generate",
+            json={
+                "text": "The capital of France is",
+                "sampling_params": {"temperature": 0, "max_new_tokens": 8},
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertIn("text", result)
+        self.assertGreater(len(result["text"]), 0)
+
+    def test_http_health(self):
+        response = requests.get(self.base_url + "/health")
+        self.assertEqual(response.status_code, 200)
+
+    def test_http_model_info(self):
+        response = requests.get(self.base_url + "/model_info")
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertIn("model_path", result)
+
+    def test_http_server_info(self):
+        response = requests.get(self.base_url + "/server_info")
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertIn("internal_states", result)
+        self.assertIn("version", result)
+        self.assertNotIn("model_config", result)
+
+    def test_grpc_health_check(self):
+        response_bytes = self._make_unary_call("HealthCheck", b"")
+        self.assertIn(b"\x08\x01", response_bytes)
+
+    def test_grpc_get_model_info(self):
+        response_bytes = self._make_unary_call("GetModelInfo", b"")
+        self.assertGreater(len(response_bytes), 0)
+        model_path = _decode_string_field(response_bytes, field_number=1)
+        self.assertIsNotNone(model_path)
+        self.assertGreater(len(model_path), 0)
+        decoded = _decode_string_field(response_bytes, field_number=2)
+        if decoded:
+            info = json.loads(decoded)
+            self.assertIn("model_path", info)
+
+    def test_grpc_get_server_info(self):
+        response_bytes = self._make_unary_call("GetServerInfo", b"")
+        self.assertGreater(len(response_bytes), 0)
+        decoded = _decode_string_field(response_bytes, field_number=1)
+        if decoded:
+            info = json.loads(decoded)
+            self.assertIsInstance(info, dict)
+
+    def test_grpc_text_generate(self):
+        request = _build_text_generate_request(
+            text="The capital of France is",
+            max_new_tokens=8,
+            temperature=0.0,
+            stream=False,
+        )
+        responses = list(self._make_server_stream_call("TextGenerate", request))
+        self.assertGreater(len(responses), 0)
+        last = responses[-1]
+        self.assertIn(b"\x18\x01", last)
+        text = _decode_string_field(last, field_number=1)
+        self.assertIsNotNone(text)
+        self.assertGreater(len(text), 0)
+
+    def test_grpc_text_generate_streaming(self):
+        request = _build_text_generate_request(
+            text="Write a short poem about the ocean",
+            max_new_tokens=32,
+            temperature=0.5,
+            stream=True,
+        )
+        responses = list(self._make_server_stream_call("TextGenerate", request))
+        self.assertGreater(len(responses), 0)
+        last = responses[-1]
+        self.assertIn(b"\x18\x01", last)
+
+    def test_grpc_abort(self):
+        rid = "test-abort-rid-12345"
+        request = _encode_string_field(1, rid)
+        response_bytes = self._make_unary_call("Abort", request)
+        self.assertIn(b"\x08\x01", response_bytes)
+
+    def test_grpc_abort_all_interrupts_stream(self):
+        request = _encode_string_field(1, "Count forever, one number at a time.")
+        sampling = b""
+        sampling += _encode_float_field(1, 0.0)
+        sampling += _encode_int32_field(8, 1024)
+        sampling += _encode_bool_field(12, True)
+        request += _encode_submessage_field(2, sampling)
+        request += _encode_bool_field(3, True)
+        responses = self._make_server_stream_call("TextGenerate", request)
+        first = next(responses)
+        self.assertIsNotNone(first)
+
+        abort_all_request = _encode_bool_field(2, True)
+        response_bytes = self._make_unary_call("Abort", abort_all_request)
+        self.assertIn(b"\x08\x01", response_bytes)
+
+        with self.assertRaises(grpc.RpcError):
+            list(responses)
+
+    # ------------------------------------------------------------------
+    # New Part 1 RPCs: Tokenize / Detokenize
+    # ------------------------------------------------------------------
+
+    def test_grpc_tokenize(self):
+        """gRPC Tokenize returns tokens for a text string."""
+        request = _encode_string_field(1, "Hello, world!")
+        response_bytes = self._make_unary_call("Tokenize", request)
+        self.assertGreater(len(response_bytes), 0)
+
+        count = _decode_int32_field(response_bytes, field_number=2)
+        self.assertIsNotNone(count)
+        self.assertGreater(count, 0)
+
+        max_model_len = _decode_int32_field(response_bytes, field_number=3)
+        self.assertIsNotNone(max_model_len)
+        self.assertGreater(max_model_len, 0)
+
+        input_text = _decode_string_field(response_bytes, field_number=4)
+        self.assertEqual(input_text, "Hello, world!")
+
+    def test_grpc_detokenize(self):
+        """gRPC Detokenize returns text from token IDs."""
+        tok_request = _encode_string_field(1, "Hello")
+        tok_response = self._make_unary_call("Tokenize", tok_request)
+
+        http_result = requests.post(
+            self.base_url + "/generate",
+            json={
+                "text": "Hello",
+                "sampling_params": {"temperature": 0, "max_new_tokens": 1},
+            },
+        )
+        self.assertEqual(http_result.status_code, 200)
+
+        detok_request = b""
+        for token_id in [9707]:
+            detok_request += _encode_int32_field(1, token_id)
+        response_bytes = self._make_unary_call("Detokenize", detok_request)
+        text = _decode_string_field(response_bytes, field_number=1)
+        self.assertIsNotNone(text)
+        self.assertGreater(len(text), 0)
+
+    def test_grpc_detokenize_rejects_negative_token_ids(self):
+        """Detokenize rejects invalid negative token IDs."""
+        request = _encode_int32_field(1, -1)
+        with self.assertRaises(grpc.RpcError) as ctx:
+            self._make_unary_call("Detokenize", request)
+
+        self.assertEqual(ctx.exception.code(), grpc.StatusCode.INVALID_ARGUMENT)
+        self.assertIn("non-negative", ctx.exception.details())
+
+    # ------------------------------------------------------------------
+    # New Part 1 RPCs: ListModels
+    # ------------------------------------------------------------------
+
+    def test_grpc_list_models(self):
+        """gRPC ListModels returns at least one model."""
+        response_bytes = self._make_unary_call("ListModels", b"")
+        self.assertGreater(len(response_bytes), 0)
+
+        models_bytes = _decode_bytes_field(response_bytes, field_number=1)
+        self.assertIsNotNone(models_bytes)
+        model_id = _decode_string_field(models_bytes, field_number=1)
+        self.assertIsNotNone(model_id)
+        self.assertGreater(len(model_id), 0)
+
+    # ------------------------------------------------------------------
+    # New Part 1 RPCs: GetLoad
+    # ------------------------------------------------------------------
+
+    def test_grpc_get_load(self):
+        """gRPC GetLoad returns valid load info JSON."""
+        response_bytes = self._make_unary_call("GetLoad", b"")
+        json_info = _decode_string_field(response_bytes, field_number=1)
+        self.assertIsNotNone(json_info)
+        data = json.loads(json_info)
+        self.assertIsInstance(data, list)
+
+    def test_grpc_get_load_respects_dp_rank(self):
+        """GetLoad filters results when dp_rank is specified."""
+        request = _encode_int32_field(1, 999)
+        response_bytes = self._make_unary_call("GetLoad", request)
+        json_info = _decode_string_field(response_bytes, field_number=1)
+        self.assertIsNotNone(json_info)
+        self.assertEqual(json.loads(json_info), [])
+
+    # ------------------------------------------------------------------
+    # New Part 1 RPCs: FlushCache
+    # ------------------------------------------------------------------
+
+    def test_grpc_flush_cache(self):
+        """gRPC FlushCache returns success."""
+        response_bytes = self._make_unary_call("FlushCache", b"")
+        success = _decode_bool_field(response_bytes, field_number=1)
+        self.assertTrue(success)
+
+    # ------------------------------------------------------------------
+    # New Part 2: OpenAI ChatComplete (JSON pass-through)
+    # ------------------------------------------------------------------
+
+    def test_grpc_chat_complete(self):
+        """gRPC ChatComplete (non-streaming) returns valid OpenAI response JSON."""
+        request_json = json.dumps(
+            {
+                "model": self.model,
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "What is 2+2? Answer with just the number.",
+                    },
+                ],
+                "max_tokens": 8,
+                "temperature": 0,
+                "stream": False,
+            }
+        ).encode("utf-8")
+
+        request = _encode_bytes_field(1, request_json)
+        responses = list(self._make_server_stream_call("ChatComplete", request))
+        self.assertGreater(len(responses), 0)
+
+        last = responses[-1]
+        json_chunk = _decode_bytes_field(last, field_number=1)
+        self.assertIsNotNone(json_chunk)
+        if json_chunk:
+            data = json.loads(json_chunk)
+            self.assertIn("choices", data)
+            self.assertGreater(len(data["choices"]), 0)
+
+    def test_grpc_chat_complete_streaming(self):
+        """gRPC ChatComplete (streaming) returns multiple SSE chunks."""
+        request_json = json.dumps(
+            {
+                "model": self.model,
+                "messages": [
+                    {"role": "user", "content": "Count from 1 to 5."},
+                ],
+                "max_tokens": 32,
+                "temperature": 0,
+                "stream": True,
+            }
+        ).encode("utf-8")
+
+        request = _encode_bytes_field(1, request_json)
+        responses = list(self._make_server_stream_call("ChatComplete", request))
+        self.assertGreater(
+            len(responses), 1, "Streaming should produce multiple chunks"
+        )
+        self.assertTrue(_decode_bool_field(responses[-1], field_number=2))
+
+    # ------------------------------------------------------------------
+    # New Part 2: OpenAI Complete (JSON pass-through)
+    # ------------------------------------------------------------------
+
+    def test_grpc_complete(self):
+        """gRPC Complete (non-streaming) returns valid OpenAI completion."""
+        request_json = json.dumps(
+            {
+                "model": self.model,
+                "prompt": "The capital of France is",
+                "max_tokens": 8,
+                "temperature": 0,
+                "stream": False,
+            }
+        ).encode("utf-8")
+
+        request = _encode_bytes_field(1, request_json)
+        responses = list(self._make_server_stream_call("Complete", request))
+        self.assertGreater(len(responses), 0)
+
+        last = responses[-1]
+        json_chunk = _decode_bytes_field(last, field_number=1)
+        self.assertIsNotNone(json_chunk)
+        if json_chunk:
+            data = json.loads(json_chunk)
+            self.assertIn("choices", data)
+
+    # ------------------------------------------------------------------
+    # Tokenizer equivalence: gRPC (Rust) vs HTTP (Python)
+    # ------------------------------------------------------------------
+
+    def test_grpc_tokenize_matches_http(self):
+        """Rust tokenizer output matches Python tokenizer output."""
+        test_texts = [
+            "Hello, world!",
+            "The capital of France is Paris.",
+            "",  # empty string
+            "🎉 emoji test 🚀",
+            "def foo():\n    return 42",
+            "a " * 100,  # longer text
+        ]
+        for text in test_texts:
+            # gRPC tokenize
+            request = _encode_string_field(1, text)
+            grpc_response = self._make_unary_call("Tokenize", request)
+            grpc_count = _decode_int32_field(grpc_response, field_number=2) or 0
+
+            # HTTP tokenize
+            http_response = requests.post(
+                self.base_url + "/tokenize",
+                json={"prompt": text},
+            )
+            self.assertEqual(
+                http_response.status_code, 200, f"HTTP tokenize failed for: {text!r}"
+            )
+            http_data = http_response.json()
+            http_count = http_data.get("count", len(http_data.get("tokens", [])))
+
+            self.assertEqual(
+                grpc_count,
+                http_count,
+                f"Token count mismatch for {text!r}: gRPC={grpc_count}, HTTP={http_count}",
+            )
+
+    def test_grpc_tokenize_no_special_tokens(self):
+        """Tokenize with add_special_tokens=False."""
+        text = "Hello"
+        # With special tokens
+        req_with = _encode_string_field(1, text)
+        resp_with = self._make_unary_call("Tokenize", req_with)
+        count_with = _decode_int32_field(resp_with, field_number=2)
+
+        # Without special tokens
+        req_without = _encode_string_field(1, text) + _encode_bool_field(2, False)
+        resp_without = self._make_unary_call("Tokenize", req_without)
+        count_without = _decode_int32_field(resp_without, field_number=2)
+
+        # Both should return valid counts; with special tokens >= without
+        self.assertIsNotNone(count_with)
+        self.assertIsNotNone(count_without)
+        self.assertGreaterEqual(count_with, count_without)
+
+    def test_grpc_detokenize_roundtrip(self):
+        """Tokenize then detokenize should approximately recover original text."""
+        text = "The quick brown fox jumps over the lazy dog"
+
+        # Tokenize via HTTP to get reliable token IDs
+        http_response = requests.post(
+            self.base_url + "/tokenize",
+            json={"prompt": text},
+        )
+        self.assertEqual(http_response.status_code, 200)
+        token_ids = http_response.json()["tokens"]
+
+        # Detokenize via gRPC
+        detok_request = b""
+        for tid in token_ids:
+            detok_request += _encode_int32_field(1, tid)
+        response_bytes = self._make_unary_call("Detokenize", detok_request)
+        decoded_text = _decode_string_field(response_bytes, field_number=1)
+
+        self.assertIsNotNone(decoded_text)
+        # Detokenized text should contain the original words
+        self.assertIn("quick", decoded_text)
+        self.assertIn("fox", decoded_text)
+        self.assertIn("dog", decoded_text)
+
+    # ------------------------------------------------------------------
+    # Sampling params dict path
+    # ------------------------------------------------------------------
+
+    def test_grpc_text_generate_with_sampling_params(self):
+        """TextGenerate with various sampling params via proto SamplingParams."""
+        # Build request with explicit sampling params
+        result = _encode_string_field(1, "Count: 1, 2, 3,")
+        sampling = b""
+        sampling += _encode_float_field(1, 0.0)  # temperature
+        sampling += _encode_int32_field(8, 4)  # max_new_tokens
+        sampling += _encode_float_field(2, 0.95)  # top_p
+        result += _encode_submessage_field(2, sampling)
+        result += _encode_bool_field(3, False)  # stream
+
+        responses = list(self._make_server_stream_call("TextGenerate", result))
+        self.assertGreater(len(responses), 0)
+        last = responses[-1]
+        text = _decode_string_field(last, field_number=1)
+        self.assertIsNotNone(text)
+        self.assertGreater(len(text), 0)
+
+
+@unittest.skipUnless(_HAS_GRANIAN, "granian not installed (pip install sglang[http2])")
+class TestGrpcHttp2Server(GrpcEnabledServerBase):
+    other_args = ("--mem-fraction-static", "0.7", "--enable-http2")
+
+    def test_http2_health_with_grpc_enabled(self):
+        response = requests.get(self.base_url + "/health")
+        self.assertEqual(response.status_code, 200)
+
+        response_bytes = self._make_unary_call("HealthCheck", b"")
+        self.assertIn(b"\x08\x01", response_bytes)
+
+    def test_http2_grpc_text_generate(self):
+        request = _build_text_generate_request(
+            text="Explain why HTTP/2 matters in one sentence.",
+            max_new_tokens=16,
+            temperature=0.0,
+            stream=False,
+        )
+        responses = list(self._make_server_stream_call("TextGenerate", request))
+        self.assertGreater(len(responses), 0)
+        self.assertTrue(_decode_bool_field(responses[-1], field_number=3))
+
+
+class TestGrpcDisabledServer(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN
+        cls.base_url = _make_test_base_url()
+        cls.grpc_port = _grpc_port_from_http_url(cls.base_url)
+        cls.grpc_host = _grpc_host_from_http_url(cls.base_url)
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=("--mem-fraction-static", "0.7"),
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process") and cls.process:
+            kill_process_tree(cls.process.pid)
+
+    def test_http_works_when_native_grpc_disabled(self):
+        response = requests.post(
+            self.base_url + "/generate",
+            json={
+                "text": "Answer with the word hello.",
+                "sampling_params": {"temperature": 0, "max_new_tokens": 8},
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("text", response.json())
+
+    def test_grpc_port_does_not_bind_when_disabled(self):
+        with self.assertRaises(OSError):
+            socket.create_connection((self.grpc_host, self.grpc_port), timeout=5)
+
+
+@unittest.skipUnless(_HAS_SGLANG_GRPC, "sglang_grpc package not installed")
+class TestGrpcServerArgs(CustomTestCase):
+    def test_multi_tokenizer_requires_disabling_native_grpc(self):
+        from sglang.srt.server_args import prepare_server_args
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Native gRPC does not yet support --tokenizer-worker-num > 1",
+        ):
+            prepare_server_args(
+                [
+                    "--model-path",
+                    DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN,
+                    "--tokenizer-worker-num",
+                    "2",
+                    "--enable-grpc",
+                ]
+            )
+
+    def test_multi_tokenizer_is_allowed_when_native_grpc_disabled(self):
+        from sglang.srt.server_args import prepare_server_args
+
+        server_args = prepare_server_args(
+            [
+                "--model-path",
+                DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN,
+                "--tokenizer-worker-num",
+                "2",
+            ]
+        )
+        self.assertFalse(server_args.enable_grpc)
+        self.assertEqual(server_args.tokenizer_worker_num, 2)
+
+    def test_deprecated_grpc_mode_skips_native_multi_tokenizer_validation(self):
+        from sglang.srt.server_args import prepare_server_args
+
+        with patch("importlib.util.find_spec", return_value=object()):
+            server_args = prepare_server_args(
+                [
+                    "--model-path",
+                    DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN,
+                    "--grpc-mode",
+                    "--tokenizer-worker-num",
+                    "2",
+                ]
+            )
+
+        self.assertTrue(server_args.grpc_mode)
+        self.assertTrue(server_args.smg_grpc)
+        self.assertEqual(server_args.tokenizer_worker_num, 2)
+
+
+class DummyOpenAIRequest:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class DummyOpenAIResponse:
+    def __init__(self, body: bytes, status_code: int):
+        self.body = body
+        self.status_code = status_code
+
+
+class TestGrpcBridgeHelpers(CustomTestCase):
+    def test_runtime_handle_abort_forwards_abort_all(self):
+        from sglang.srt.entrypoints.grpc_bridge import RuntimeHandle
+
+        tokenizer_manager = MagicMock()
+        tokenizer_manager.event_loop = None
+        handle = RuntimeHandle(
+            tokenizer_manager=tokenizer_manager,
+            template_manager=MagicMock(),
+            server_args=MagicMock(),
+        )
+
+        handle.abort(abort_all=True)
+
+        tokenizer_manager.abort_request.assert_called_once_with(rid="", abort_all=True)
+
+    def test_runtime_handle_openai_trace_headers_reach_mock_request(self):
+        from sglang.srt.entrypoints.grpc_bridge import RuntimeHandle
+
+        tokenizer_manager = MagicMock()
+        tokenizer_manager.event_loop = None
+        serving = MagicMock()
+        serving.handle_request = AsyncMock(return_value={"ok": True})
+        handle = RuntimeHandle(
+            tokenizer_manager=tokenizer_manager,
+            template_manager=MagicMock(),
+            server_args=MagicMock(),
+        )
+        handle._openai_serving_classes = {"chat": serving}
+
+        with patch.object(
+            handle,
+            "_get_openai_request_class",
+            return_value=DummyOpenAIRequest,
+        ):
+            callback = MagicMock()
+            trace_headers = {"traceparent": "00-abc-123-01"}
+            asyncio.run(
+                handle._run_openai_request(
+                    "chat",
+                    json.dumps({"model": "dummy", "messages": []}).encode("utf-8"),
+                    callback,
+                    streaming=False,
+                    trace_headers=trace_headers,
+                )
+            )
+
+        raw_request = serving.handle_request.await_args.args[1]
+        self.assertEqual(raw_request.headers, trace_headers)
+        callback.assert_called_once()
+
+    def test_runtime_handle_openai_unary_forwards_status_code(self):
+        from sglang.srt.entrypoints.grpc_bridge import RuntimeHandle
+
+        tokenizer_manager = MagicMock()
+        tokenizer_manager.event_loop = None
+        serving = MagicMock()
+        serving.handle_request = AsyncMock(
+            return_value=DummyOpenAIResponse(
+                body=b'{"error":{"message":"rate limited"}}',
+                status_code=429,
+            )
+        )
+        handle = RuntimeHandle(
+            tokenizer_manager=tokenizer_manager,
+            template_manager=MagicMock(),
+            server_args=MagicMock(),
+        )
+        handle._openai_serving_classes = {"embedding": serving}
+
+        with patch.object(
+            handle,
+            "_get_openai_request_class",
+            return_value=DummyOpenAIRequest,
+        ):
+            callback = MagicMock()
+            asyncio.run(
+                handle._run_openai_request(
+                    "embedding",
+                    json.dumps({"model": "dummy", "input": "hello"}).encode("utf-8"),
+                    callback,
+                    streaming=False,
+                )
+            )
+
+        callback.assert_called_once_with(
+            b'{"error":{"message":"rate limited"}}',
+            finished=True,
+            status_code=429,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/core/test_grpc_server.py
+++ b/test/registered/core/test_grpc_server.py
@@ -47,7 +47,7 @@ try:
 except ImportError:
     _HAS_GRANIAN = False
 
-_HAS_SGLANG_GRPC = importlib.util.find_spec("sglang_grpc") is not None
+_HAS_NATIVE_GRPC = importlib.util.find_spec("sglang.srt.grpc._core") is not None
 
 register_cuda_ci(est_time=300, suite="stage-b-test-small-1-gpu")
 
@@ -323,7 +323,9 @@ def _build_text_generate_request(
 
 
 @unittest.skipUnless(_HAS_GRPCIO, "grpcio not installed")
-@unittest.skipUnless(_HAS_SGLANG_GRPC, "sglang_grpc package not installed")
+@unittest.skipUnless(
+    _HAS_NATIVE_GRPC, "Native gRPC extension (sglang.srt.grpc._core) not built"
+)
 class GrpcEnabledServerBase(CustomTestCase):
     grpc_channel = None
     other_args = ("--mem-fraction-static", "0.7", "--enable-grpc")
@@ -811,7 +813,9 @@ class TestGrpcDisabledServer(CustomTestCase):
             socket.create_connection((self.grpc_host, self.grpc_port), timeout=5)
 
 
-@unittest.skipUnless(_HAS_SGLANG_GRPC, "sglang_grpc package not installed")
+@unittest.skipUnless(
+    _HAS_NATIVE_GRPC, "Native gRPC extension (sglang.srt.grpc._core) not built"
+)
 class TestGrpcServerArgs(CustomTestCase):
     def test_multi_tokenizer_requires_disabling_native_grpc(self):
         from sglang.srt.server_args import prepare_server_args


### PR DESCRIPTION
## Summary
Adds `test/registered/core/test_grpc_server.py` — integration tests for the native gRPC server. Covers:

- \`--enable-grpc\` opt-in semantics
- Request lifecycle through the Rust ↔ Python bridge
- Coexistence checks with legacy flags

## Stack
Part of the phase-1 split of the original PR #22907. Review order:
1. #23506 — Rust crate
2. #23507 — Python bridge entrypoint
3. #23508 — launcher / HTTP / server args wiring
4. **(this)** `tests`

Base: #23508

## Test plan
- [ ] \`pytest test/registered/core/test_grpc_server.py\`