### PR TITLE
[CI] /rerun-stage: fix workflow-run URL lookup for sgl-kernel PRs

### DIFF
--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -406,9 +406,13 @@ def handle_rerun_stage(
         if kernel_changes and not is_amd_stage:
             inputs["include_wheel_build"] = "true"
             # include_wheel_build relies on filter-api detecting kernel changes, which
-            # requires pr_head_sha. Ensure it's set even for non-fork PRs.
+            # requires pr_head_sha. Ensure it's set even for non-fork PRs, and keep
+            # the local pr_head_sha in sync so find_workflow_run_url builds the
+            # expected display_title with the SHA suffix (the workflow's run-name
+            # includes the SHA whenever inputs.pr_head_sha is set).
             if not is_fork:
                 inputs["pr_head_sha"] = pr.head.sha
+                pr_head_sha = pr.head.sha
 
         # Record dispatch time before triggering
         dispatch_time = time.time()


### PR DESCRIPTION
## Motivation

PR #23492 introduced an auto-enabled `include_wheel_build` path for non-fork PRs that touch `sgl-kernel/`. That path adds `pr_head_sha` to the `workflow_dispatch` inputs so the build gate's `filter-api` check sees the kernel changes. However, it forgot to update the **local** `pr_head_sha` variable in `handle_rerun_stage` — the variable that is later passed to `find_workflow_run_url()` for the success-comment URL lookup.

As a result:
- The workflow's `run-name` (`.github/workflows/pr-test.yml:4`) sees `inputs.pr_head_sha` and produces a display_title like `[stage-c-test-deepep-4-gpu-h100] <sha>`.
- But `find_workflow_run_url` builds its expected title from the handler's local `pr_head_sha` (still `None`) and looks for `[stage-c-test-deepep-4-gpu-h100]` (no sha suffix).
- The lookup times out after 30s → the success comment degrades to `⚠️ Could not retrieve workflow run URL.`

Observed on PR #21247 (torch 2.11, touches `sgl-kernel/`) — the dispatch itself worked; only the deep-link in the success comment was lost.

## Changes

In the `kernel_changes and not is_amd_stage` branch, after `inputs["pr_head_sha"] = pr.head.sha` (non-fork case), also set the local `pr_head_sha = pr.head.sha` so `find_workflow_run_url` constructs the correct expected display_title.

## Backward compatibility

- Fork path: local `pr_head_sha` was already set to `pr.head.sha` inside the `if is_fork:` block — unchanged.
- Non-fork + no kernel changes: neither `inputs` nor local `pr_head_sha` gets a SHA — unchanged.
- Non-fork + kernel changes: the local `pr_head_sha` now matches `inputs["pr_head_sha"]` — fixes the regression.

## Test plan

- [x] Offline sanity check (simulating the workflow's `run-name` directive and `find_workflow_run_url`'s `expected_title` formula) confirms the expected and actual display_titles align across all three paths (fork / non-fork+kernel / non-fork+no-kernel).
- [ ] After merge, trigger `/rerun-stage <stage>` on a non-fork PR that touches `sgl-kernel/` (e.g. #21247) and verify the success comment contains `[View workflow run](...)` instead of the `⚠️` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)