### PR TITLE
ci: build sgl-kernel wheels for both cu129 and cu130

### DIFF
--- a/.github/workflows/pr-test-multimodal-gen.yml
+++ b/.github/workflows/pr-test-multimodal-gen.yml
@@ -117,7 +117,7 @@ jobs:
         with:
           path: sgl-kernel/dist/
           merge-multiple: true
-          pattern: wheel-python3.10-cuda13.0
+          pattern: wheel-python3.10-cuda*
 
       - name: Install dependencies
         timeout-minutes: 20
@@ -186,7 +186,7 @@ jobs:
         with:
           path: sgl-kernel/dist/
           merge-multiple: true
-          pattern: wheel-python3.10-cuda13.0
+          pattern: wheel-python3.10-cuda*
 
       - name: Install dependencies
         timeout-minutes: 20
@@ -251,7 +251,7 @@ jobs:
         with:
           path: sgl-kernel/dist/
           merge-multiple: true
-          pattern: wheel-python3.10-cuda13.0
+          pattern: wheel-python3.10-cuda*
 
       - name: Install dependencies
         timeout-minutes: 20
@@ -300,7 +300,7 @@ jobs:
         with:
           path: sgl-kernel/dist/
           merge-multiple: true
-          pattern: wheel-python3.10-cuda13.0
+          pattern: wheel-python3.10-cuda*
 
       - name: Install dependencies
         timeout-minutes: 20
@@ -356,7 +356,7 @@ jobs:
         with:
           path: sgl-kernel/dist/
           merge-multiple: true
-          pattern: wheel-python3.10-cuda13.0
+          pattern: wheel-python3.10-cuda*
 
       - name: Install dependencies
         timeout-minutes: 20

--- a/.github/workflows/pr-test-sgl-kernel.yml
+++ b/.github/workflows/pr-test-sgl-kernel.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           path: sgl-kernel/dist/
           merge-multiple: true
-          pattern: wheel-python3.10-cuda13.0
+          pattern: wheel-python3.10-cuda*
 
       - name: Install dependencies
         timeout-minutes: 20
@@ -88,7 +88,7 @@ jobs:
         with:
           path: sgl-kernel/dist/
           merge-multiple: true
-          pattern: wheel-python3.10-cuda13.0
+          pattern: wheel-python3.10-cuda*
 
       - name: Install dependencies
         timeout-minutes: 20
@@ -123,7 +123,7 @@ jobs:
         with:
           path: sgl-kernel/dist/
           merge-multiple: true
-          pattern: wheel-python3.10-cuda13.0
+          pattern: wheel-python3.10-cuda*
 
       - name: Install dependencies
         timeout-minutes: 20
@@ -170,7 +170,7 @@ jobs:
         with:
           path: sgl-kernel/dist/
           merge-multiple: true
-          pattern: wheel-python3.10-cuda13.0
+          pattern: wheel-python3.10-cuda*
 
       - name: Install dependencies
         timeout-minutes: 20
@@ -201,7 +201,7 @@ jobs:
   #       with:
   #         path: sgl-kernel/dist/
   #         merge-multiple: true
-  #         pattern: wheel-python3.10-cuda13.0
+  #         pattern: wheel-python3.10-cuda*
 
   #     - name: Install dependencies
   #       run: |

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -459,6 +459,8 @@ jobs:
         include:
           - python-version: "3.10"
             cuda-version: "13.0"
+          - python-version: "3.10"
+            cuda-version: "12.9"
     name: Build Wheel
     steps:
       - name: Cleanup
@@ -519,6 +521,8 @@ jobs:
         include:
           - python-version: "3.10"
             cuda-version: "13.0"
+          - python-version: "3.10"
+            cuda-version: "12.9"
     name: Build Wheel Arm
     steps:
       - name: Cleanup
@@ -625,7 +629,7 @@ jobs:
         with:
           path: sgl-kernel/dist/
           merge-multiple: true
-          pattern: wheel-python3.10-cuda13.0
+          pattern: wheel-python3.10-cuda*
 
       - name: Install dependencies
         timeout-minutes: 20
@@ -748,7 +752,7 @@ jobs:
         with:
           path: sgl-kernel/dist/
           merge-multiple: true
-          pattern: wheel-python3.10-cuda13.0
+          pattern: wheel-python3.10-cuda*
 
       - name: Install dependencies
         timeout-minutes: 20
@@ -810,7 +814,7 @@ jobs:
         with:
           path: sgl-kernel/dist/
           merge-multiple: true
-          pattern: wheel-python3.10-cuda13.0
+          pattern: wheel-python3.10-cuda*
 
       - name: Install dependencies
         timeout-minutes: 20
@@ -869,7 +873,7 @@ jobs:
         with:
           path: sgl-kernel/dist/
           merge-multiple: true
-          pattern: wheel-python3.10-cuda13.0
+          pattern: wheel-python3.10-cuda*
 
       - name: Install dependencies
         timeout-minutes: 20
@@ -926,7 +930,7 @@ jobs:
         with:
           path: sgl-kernel/dist/
           merge-multiple: true
-          pattern: wheel-python3.10-cuda13.0
+          pattern: wheel-python3.10-cuda*
 
       - name: Install dependencies
         timeout-minutes: 20
@@ -1020,7 +1024,7 @@ jobs:
         with:
           path: sgl-kernel/dist/
           merge-multiple: true
-          pattern: wheel-python3.10-cuda13.0
+          pattern: wheel-python3.10-cuda*
 
       - name: Install dependencies
         timeout-minutes: 20
@@ -1078,7 +1082,7 @@ jobs:
         with:
           path: sgl-kernel/dist/
           merge-multiple: true
-          pattern: wheel-python3.10-cuda13.0
+          pattern: wheel-python3.10-cuda*
 
       - name: Install dependencies
         timeout-minutes: 20
@@ -1158,7 +1162,7 @@ jobs:
         with:
           path: sgl-kernel/dist/
           merge-multiple: true
-          pattern: wheel-python3.10-cuda13.0
+          pattern: wheel-python3.10-cuda*
 
       - name: Install dependencies
         timeout-minutes: 20
@@ -1212,7 +1216,7 @@ jobs:
         with:
           path: sgl-kernel/dist/
           merge-multiple: true
-          pattern: wheel-python3.10-cuda13.0
+          pattern: wheel-python3.10-cuda*
 
       - name: Install dependencies
         timeout-minutes: 20
@@ -1281,7 +1285,7 @@ jobs:
         with:
           path: sgl-kernel/dist/
           merge-multiple: true
-          pattern: wheel-python3.10-cuda13.0
+          pattern: wheel-python3.10-cuda*
 
       - name: Install dependencies
         timeout-minutes: 20
@@ -1356,7 +1360,7 @@ jobs:
         with:
           path: sgl-kernel/dist/
           merge-multiple: true
-          pattern: wheel-python3.10-cuda13.0
+          pattern: wheel-python3.10-cuda*
 
       - name: Install dependencies
         timeout-minutes: 20
@@ -1418,7 +1422,7 @@ jobs:
         with:
           path: sgl-kernel/dist/
           merge-multiple: true
-          pattern: wheel-python3.10-cuda13.0
+          pattern: wheel-python3.10-cuda*
 
       - name: Install dependencies
         timeout-minutes: 20

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -314,10 +314,23 @@ if [ "${CUSTOM_BUILD_SGL_KERNEL:-}" = "true" ] && [ -d "sgl-kernel/dist" ]; then
     else
         WHEEL_ARCH="x86_64"
     fi
-    # Wheel may have +cuXYZ suffix (e.g. sglang_kernel-0.4.0+cu130-...) depending on CUDA version
-    KERNEL_WHL=$(ls sgl-kernel/dist/sglang_kernel-${SGL_KERNEL_VERSION_FROM_KERNEL}*-cp310-abi3-manylinux2014_${WHEEL_ARCH}.whl 2>/dev/null | head -1)
+    # Wheel filenames carry a +cuXYZ local version tag (e.g. sglang_kernel-0.4.0+cu130-...).
+    # When the build matrix produces wheels for multiple CUDA versions (e.g. both cu129 and cu130),
+    # pick the one matching the test runner's $CU_VERSION so we don't trigger the PyPI-fallback reinstall
+    # below (which would replace the PR-built wheel with a public main-branch wheel).
+    KERNEL_WHL=$(ls sgl-kernel/dist/sglang_kernel-${SGL_KERNEL_VERSION_FROM_KERNEL}+${CU_VERSION}-cp310-abi3-manylinux2014_${WHEEL_ARCH}.whl 2>/dev/null | head -1)
     if [ -z "$KERNEL_WHL" ]; then
-        echo "ERROR: No matching sgl-kernel wheel found in sgl-kernel/dist/ for version ${SGL_KERNEL_VERSION_FROM_KERNEL} arch ${WHEEL_ARCH}"
+        # Fallback for older branches that only build a single CUDA variant and whose wheel matches
+        # the current $CU_VERSION. Restrict to the same arch — we intentionally do NOT match a wheel
+        # whose +cuXYZ tag disagrees with $CU_VERSION here, because the post-install reinstall branch
+        # below would otherwise silently replace it with the public main-branch wheel.
+        SINGLE_CUDA_WHL=$(ls sgl-kernel/dist/sglang_kernel-${SGL_KERNEL_VERSION_FROM_KERNEL}-cp310-abi3-manylinux2014_${WHEEL_ARCH}.whl 2>/dev/null | head -1)
+        if [ -n "$SINGLE_CUDA_WHL" ]; then
+            KERNEL_WHL="$SINGLE_CUDA_WHL"
+        fi
+    fi
+    if [ -z "$KERNEL_WHL" ]; then
+        echo "ERROR: No matching sgl-kernel wheel found in sgl-kernel/dist/ for version ${SGL_KERNEL_VERSION_FROM_KERNEL} arch ${WHEEL_ARCH} cuda ${CU_VERSION}"
         ls -alh sgl-kernel/dist/
         exit 1
     fi

--- a/sgl-kernel/csrc/common_extension.cc
+++ b/sgl-kernel/csrc/common_extension.cc
@@ -496,3 +496,4 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
 }
 
 REGISTER_EXTENSION(common_ops)
+// dummy: trigger sgl-kernel rebuild for cu129/cu130 matrix CI test


### PR DESCRIPTION
## Motivation

Since #23119 flipped the `sgl-kernel-build-wheels` matrix to `cuda-version: "13.0"` only (preparing for the CI torch upgrade), any PR touching `sgl-kernel/` is silently reverted on H-series (SM90) runners. The H-series CI boxes still ship **NVIDIA driver 535.x** (we confirmed driver `535.161.08` on the `stage-c-test-8-gpu-h20` runner), which supports CUDA ≤ 12.x — it **cannot load cu130-built wheels at all**. The test-job env correctly sets `CU_VERSION=cu129` on those runners, and `ci_install_dependency.sh`'s public-index fallback is therefore load-bearing for them.

The failure mode this creates is invisible on the surface:

1. PR's `sgl-kernel-build-wheels` produces a cu130 wheel only (artifact `wheel-python3.10-cuda13.0`).
2. H-series test jobs download that wheel into `sgl-kernel/dist/` and `ci_install_dependency.sh` installs it.
3. The script's "`sgl-kernel +cuXYZ` ≠ `CU_VERSION`" guard (correct in intent — a cu130 wheel is driver-incompat on R535) then reinstalls `sglang-kernel==<ver>` from the public Artifactory index, replacing the PR's wheel with the main-branch wheel the runner is compatible with.
4. Any sgl-kernel change in the PR (new kernel signatures, schema tweaks, etc.) is silently dropped. Python-side editable code keeps the PR's expectations → `TypeError: unexpected keyword argument` at first call.

**Concrete example:** #21985 adds `out=` to `flash_attn_with_kvcache`. The Python wrapper (editable) passes `out=`, but the reinstalled main-wheel's C++ op doesn't accept it → `TypeError` on `stage-c-test-8-gpu-h20`. Full traceback and analysis: https://github.com/sgl-project/sglang/actions/runs/24757463942/job/72560110848?pr=21985

## Modifications

1. Restore `cuda-version: "12.9"` as a second matrix entry in both the x86_64 and aarch64 `sgl-kernel-build-wheels` jobs, so every PR produces BOTH cu129 and cu130 wheels (artifacts `wheel-python3.10-cuda12.9` and `wheel-python3.10-cuda13.0`).
2. Change all test-job `download-artifact` patterns from `wheel-python3.10-cuda13.0` to `wheel-python3.10-cuda*` so both wheels land in `sgl-kernel/dist/` (`merge-multiple: true` already set).
3. In `ci_install_dependency.sh`, select the wheel matching `\$CU_VERSION` by filename (`sglang_kernel-\${VER}+\${CU_VERSION}-...`), with a fallback to the previous glob for branches that haven't picked up this change.

After this patch:
- B200 (R560+ driver, cu130) tests install the cu130 wheel, no reinstall.
- H-series (R535 driver, cu129) tests install the cu129 wheel, no reinstall.
- The public-index fallback only fires when the PR didn't build its own wheel (e.g. `/rerun-stage` without kernel rebuild), matching its original purpose.

This is the right long-term fix as long as the H-series runners stay on R535 — a cu130-only matrix will keep corrupting sgl-kernel tests on them until those hosts are upgraded to R560+.

## Accuracy Tests

N/A — CI infra change, no runtime/model behavior impact. The test suites that were formerly running main's sgl-kernel will now correctly run the PR's sgl-kernel, which is the intended behavior.

## Speed Tests and Profiling

N/A — CI infra change.

Cost: one extra matrix job per PR that touches sgl-kernel (~10 min on x86_64, ~10 min on aarch64). Net per-PR CI runtime change is positive for sgl-kernel PRs (no more silently-passing tests that were really running main's wheel) and zero for other PRs (matrix doesn't run when there's nothing to build).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). *(workflow YAML + shell; no Python code changes)*
- [x] Add unit tests. *(N/A — CI infra; verifiable by landing a follow-up or rerun of an sgl-kernel PR and observing that the correct wheel is installed on cu129 runners)*
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results. *(N/A — no model impact)*
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Reopened from #23497 (pushed from upstream branch to get sgl-project/sglang CI coverage).