### PR TITLE
[Disagg] Layer-pipelined KV transfer: overlap RDMA with GPU compute

### DIFF
--- a/docs_new/docs/references/environment_variables.mdx
+++ b/docs_new/docs/references/environment_variables.mdx
@@ -923,6 +923,36 @@ SGLang supports various environment variables that can be used to configure its 
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Force using PyTorch gather/scatter fallback instead of Triton fused kernels for staging operations. Useful for debugging.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>false</code></td>
     </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_ENABLE_PIPELINED_KV_TRANSFER</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Enable layer-pipelined KV transfer. Splits prefill into layer groups and transfers KV cache incrementally after each group, overlapping RDMA transfer with GPU compute. Only effective in PD disaggregation prefill mode. When enabled together with overlap schedule, overlap is automatically disabled (pipelined subsumes its CPU sync savings). When using with <code>--hicache-storage-backend mooncake</code>, set <code>MOONCAKE_DEVICE</code> to a separate IB port (e.g. <code>mlx5_5</code>) to avoid RDMA resource conflicts.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>false</code></td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_PIPELINE_GROUP_SIZE</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>(Optional) Override adaptive formula with a fixed number of layers per pipeline group. When not set, group_size is computed automatically based on prompt length.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Not set (adaptive)</td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_PIPELINE_MIN_TOKENS</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Minimum average input token length to activate pipelined mode. Batches below this threshold use the normal (non-pipelined) path to avoid overhead on short prompts.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>3072</code></td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_PIPELINE_SAT_MULTIPLIER</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Multiplier for MIN_TOKENS that defines the prompt-length saturation point in the adaptive pipeline group-size formula.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>3.0</code></td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_PIPELINE_MAX_ITERS</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Maximum pipeline iterations (used for shortest eligible prompts). The adaptive formula linearly interpolates between MAX_ITERS and MIN_ITERS based on prompt length. Higher values mean smaller groups and more transfer overlap.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>10</code></td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_PIPELINE_MIN_ITERS</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Minimum pipeline iterations (used for longest prompts at saturation point = SAT_MULTIPLIER × MIN_TOKENS). Lower bound ensures large groups don't add excessive per-group overhead.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>4</code></td>
+    </tr>
   </tbody>
 </table>
 

--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -137,6 +137,33 @@ class BaseKVSender(ABC):
         """
         ...
 
+    def send_layer(
+        self,
+        kv_indices: npt.NDArray[np.int32],
+        layer_id: int,
+        cuda_event: object,
+        is_last: bool = False,
+        state_indices: Optional[List[int]] = None,
+    ):
+        """Send a single layer's KV cache for layer-pipelined transfer.
+
+        Backends that support layer-pipelined KV transfer should override
+        this method. The default raises NotImplementedError so that
+        unsupported backends fail loudly if pipelining is misconfigured.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support layer-pipelined KV transfer"
+        )
+
+    def send_final_metadata(
+        self,
+        state_indices: Optional[List[int]] = None,
+    ):
+        """Send final metadata after layer-pipelined KV transfer."""
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support layer-pipelined KV transfer"
+        )
+
     def pop_decode_prefix_len(self) -> int:
         return 0
 

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -1109,6 +1109,46 @@ class CommonKVSender(BaseKVSender):
 
         return kv_indices, index_slice, is_last_chunk, False
 
+    def _prepare_layer_send_indices(
+        self,
+        kv_indices: npt.NDArray[np.int32],
+    ) -> Tuple[npt.NDArray[np.int32], slice, bool]:
+        """Common pre-processing for per-layer sends.
+
+        Layer-pipelined transfer sends the same page slice once per layer, so it
+        must not advance curr_idx for every layer. It still needs the same CP
+        rank filtering as send(). Final status is sent separately after metadata
+        is written.
+        """
+        num_indices = len(kv_indices)
+        index_slice = slice(self.curr_idx, self.curr_idx + num_indices)
+
+        if self.kv_mgr.enable_all_cp_ranks_for_transfer:
+            cache_key = (self.curr_idx, num_indices)
+            cached_key = getattr(self, "_layer_send_cache_key", None)
+            if cached_key == cache_key:
+                kv_indices, index_slice = self._layer_send_cache
+            else:
+                kv_indices, index_slice = filter_kv_indices_for_cp_rank(
+                    self.kv_mgr,
+                    kv_indices,
+                    index_slice,
+                )
+                self._layer_send_cache_key = cache_key
+                self._layer_send_cache = (kv_indices, index_slice)
+        elif self.kv_mgr.is_dummy_cp_rank:
+            return kv_indices, index_slice, True
+
+        return kv_indices, index_slice, len(kv_indices) == 0
+
+    def _prepare_final_metadata_send(self) -> Tuple[slice, bool]:
+        index_slice = slice(self.curr_idx, self.curr_idx)
+        self.curr_idx = self.num_kv_indices
+        if self.kv_mgr.is_dummy_cp_rank:
+            self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Success)
+            return index_slice, True
+        return index_slice, False
+
     def send(
         self,
         kv_indices: npt.NDArray[np.int32],

--- a/python/sglang/srt/disaggregation/common/utils.py
+++ b/python/sglang/srt/disaggregation/common/utils.py
@@ -25,6 +25,8 @@ class TransferKVChunk:
     prefill_aux_index: Optional[int]
     state_indices: Optional[List]
     chunk_id: Optional[int] = None
+    layer_id: Optional[int] = None
+    cuda_event: Optional[object] = None
     trace_ctx: Union[TraceReqContext, TraceNullContext] = dataclasses.field(
         default_factory=TraceNullContext
     )

--- a/python/sglang/srt/disaggregation/fake/conn.py
+++ b/python/sglang/srt/disaggregation/fake/conn.py
@@ -64,6 +64,9 @@ class FakeKVSender(BaseKVSender):
     def get_transfer_metric(self) -> KVTransferMetric:
         return KVTransferMetric()
 
+    def should_send_kv_chunk(self, num_pages: int, last_chunk: bool) -> bool:
+        return num_pages > 0 or last_chunk
+
     def init(
         self,
         kv_indices: list[int],
@@ -82,6 +85,23 @@ class FakeKVSender(BaseKVSender):
         self.has_sent = True
         logger.debug(
             f"FakeKVSender send with kv_indices: {kv_indices}, state_indices: {state_indices}"
+        )
+
+    def send_layer(
+        self,
+        kv_indices: npt.NDArray[np.int32],
+        layer_id: int = 0,
+        cuda_event=None,
+        is_last: bool = False,
+        state_indices=None,
+    ):
+        """Per-layer KV send stub for warmup."""
+        logger.debug(f"FakeKVSender send_layer layer_id={layer_id} is_last={is_last}")
+
+    def send_final_metadata(self, state_indices=None):
+        self.has_sent = True
+        logger.debug(
+            f"FakeKVSender send_final_metadata with state_indices: {state_indices}"
         )
 
     def failure_exception(self):

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -712,6 +712,193 @@ class MooncakeKVManager(CommonKVManager):
             executor=executor,
         )
 
+    def send_kvcache_layer(
+        self,
+        mooncake_session_id: str,
+        layer_id: int,
+        prefill_kv_indices: npt.NDArray[np.int32],
+        dst_kv_ptrs: list[int],
+        dst_kv_indices: npt.NDArray[np.int32],
+        dst_tp_rank: Optional[int] = None,
+        dst_attn_tp_size: Optional[int] = None,
+        dst_kv_item_len: Optional[int] = None,
+    ) -> int:
+        """Send KV cache for a single transformer layer via RDMA.
+
+        For MHA models, kv_data_ptrs layout is [K0..K_{N-1}, V0..V_{N-1}].
+        For MLA models, kv_data_ptrs layout is [KV0..KV_{N-1}].
+
+        When dst_attn_tp_size is provided and differs from prefill TP,
+        head slicing is applied for MHA models (MLA is TP-invariant).
+
+        Note: PP (pipeline parallelism) is not supported — layer_id indexes
+        kv_data_ptrs directly assuming all layers are on the current rank.
+        The caller (_get_pipeline_group_size) guards against pp_size > 1.
+        """
+        prefill_kv_blocks, dst_kv_blocks = group_concurrent_contiguous(
+            prefill_kv_indices, dst_kv_indices
+        )
+
+        if self.is_mla_backend:
+            src_kv_ptrs, dst_kv_ptrs_pp, layers_current_pp_stage = (
+                self.get_mla_kv_ptrs_with_pp(self.kv_args.kv_data_ptrs, dst_kv_ptrs)
+            )
+            # MLA: single combined KV per layer (TP-invariant, no head slicing)
+            src_ptr = src_kv_ptrs[layer_id]
+            dst_ptr = dst_kv_ptrs_pp[layer_id]
+            item_len = self.kv_args.kv_item_lens[layer_id]
+            transfer_blocks = []
+            for prefill_index, decode_index in zip(prefill_kv_blocks, dst_kv_blocks):
+                src_addr = src_ptr + int(prefill_index[0]) * item_len
+                dst_addr = dst_ptr + int(decode_index[0]) * item_len
+                length = item_len * len(prefill_index)
+                transfer_blocks.append((src_addr, dst_addr, length))
+            return self._transfer_data(mooncake_session_id, transfer_blocks)
+        else:
+            src_k_ptrs, src_v_ptrs, dst_k_ptrs, dst_v_ptrs, layers_current_pp_stage = (
+                self.get_mha_kv_ptrs_with_pp(self.kv_args.kv_data_ptrs, dst_kv_ptrs)
+            )
+            need_head_slice = (
+                dst_attn_tp_size is not None and self.attn_tp_size != dst_attn_tp_size
+            )
+
+            if not need_head_slice:
+                # Same-TP fast path: transfer full K and V pages
+                k_item_len = self.kv_args.kv_item_lens[layer_id]
+                v_item_len = self.kv_args.kv_item_lens[
+                    layers_current_pp_stage + layer_id
+                ]
+                transfer_blocks = []
+                for src_ptr, dst_ptr, item_len in [
+                    (src_k_ptrs[layer_id], dst_k_ptrs[layer_id], k_item_len),
+                    (src_v_ptrs[layer_id], dst_v_ptrs[layer_id], v_item_len),
+                ]:
+                    for prefill_index, decode_index in zip(
+                        prefill_kv_blocks, dst_kv_blocks
+                    ):
+                        src_addr = src_ptr + int(prefill_index[0]) * item_len
+                        dst_addr = dst_ptr + int(decode_index[0]) * item_len
+                        length = item_len * len(prefill_index)
+                        transfer_blocks.append((src_addr, dst_addr, length))
+                return self._transfer_data(mooncake_session_id, transfer_blocks)
+            else:
+                # Different-TP path: per-token head slicing for a single layer
+                return self._send_kvcache_layer_head_slice(
+                    mooncake_session_id,
+                    layer_id,
+                    prefill_kv_indices,
+                    dst_kv_indices,
+                    src_k_ptrs,
+                    src_v_ptrs,
+                    dst_k_ptrs,
+                    dst_v_ptrs,
+                    layers_current_pp_stage,
+                    dst_tp_rank,
+                    dst_attn_tp_size,
+                    dst_kv_item_len,
+                )
+
+    def _send_kvcache_layer_head_slice(
+        self,
+        mooncake_session_id: str,
+        layer_id: int,
+        prefill_kv_indices: npt.NDArray[np.int32],
+        dst_kv_indices: npt.NDArray[np.int32],
+        src_k_ptrs: list[int],
+        src_v_ptrs: list[int],
+        dst_k_ptrs: list[int],
+        dst_v_ptrs: list[int],
+        layers_current_pp_stage: int,
+        dst_tp_rank: int,
+        dst_attn_tp_size: int,
+        dst_kv_item_len: int,
+    ) -> int:
+        """Per-layer head-sliced KV transfer for MHA with different TP sizes.
+
+        Mirrors the head-offset math from send_kvcache_slice but applies it
+        to a single layer, using vectorized numpy addressing.
+        """
+        local_tp_rank_in_group = self.kv_args.engine_rank % self.attn_tp_size
+        src_kv_item_len = self.kv_args.kv_item_lens[0]
+        dst_tp_rank_in_group = dst_tp_rank % dst_attn_tp_size
+        page_size = self.kv_args.page_size
+
+        total_kv_heads = getattr(self.kv_args, "total_kv_head_num", 0)
+        if total_kv_heads <= 0:
+            total_kv_heads = self.kv_args.kv_head_num * self.attn_tp_size
+
+        src_heads_per_rank = max(1, total_kv_heads // self.attn_tp_size)
+        dst_heads_per_rank = max(1, total_kv_heads // dst_attn_tp_size)
+        bytes_per_head_slice = dst_kv_item_len // page_size // dst_heads_per_rank
+        src_replication = max(1, self.attn_tp_size // total_kv_heads)
+
+        if self.attn_tp_size > dst_attn_tp_size:
+            src_head_start_offset = 0
+            num_heads_to_send = src_heads_per_rank
+            unique_head_idx = local_tp_rank_in_group // src_replication
+            dst_head_start_offset = (
+                unique_head_idx * src_heads_per_rank
+            ) % dst_heads_per_rank
+        else:
+            src_head_start_offset = (
+                dst_tp_rank_in_group * dst_heads_per_rank
+            ) % src_heads_per_rank
+            num_heads_to_send = dst_heads_per_rank
+            dst_head_start_offset = 0
+
+        src_head_slice_offset = src_head_start_offset * bytes_per_head_slice
+        dst_head_slice_offset = dst_head_start_offset * bytes_per_head_slice
+        heads_bytes_per_token = num_heads_to_send * bytes_per_head_slice
+
+        bytes_per_token_src = src_kv_item_len // page_size
+        bytes_per_token_dst = dst_kv_item_len // page_size
+
+        # Sanity check: slice must fit in destination token slot
+        if heads_bytes_per_token > bytes_per_token_dst:
+            logger.error(
+                f"[{mooncake_session_id}] layer {layer_id}: slice size "
+                f"({heads_bytes_per_token}) exceeds target token slot size "
+                f"({bytes_per_token_dst})"
+            )
+            return -1
+
+        # Vectorized address computation (same pattern as send_kvcache_slice)
+        prefill_page_indices = prefill_kv_indices.reshape(-1, 1).astype(np.int64)
+        decode_page_indices = dst_kv_indices.reshape(-1, 1).astype(np.int64)
+        tokens_per_page = np.arange(page_size, dtype=np.int64).reshape(1, -1)
+        src_token_slot_offsets = (
+            tokens_per_page * bytes_per_token_src + src_head_slice_offset
+        )
+        dst_token_slot_offsets = (
+            tokens_per_page * bytes_per_token_dst + dst_head_slice_offset
+        )
+
+        for src_layer_ptr, dst_layer_ptr in [
+            (src_k_ptrs[layer_id], dst_k_ptrs[layer_id]),
+            (src_v_ptrs[layer_id], dst_v_ptrs[layer_id]),
+        ]:
+            src_addrs = (
+                src_layer_ptr
+                + prefill_page_indices * src_kv_item_len
+                + src_token_slot_offsets
+            ).reshape(-1)
+            dst_addrs = (
+                dst_layer_ptr
+                + decode_page_indices * dst_kv_item_len
+                + dst_token_slot_offsets
+            ).reshape(-1)
+            src_list = src_addrs.tolist()
+            if not src_list:
+                continue
+            dst_list = dst_addrs.tolist()
+            length_list = [heads_bytes_per_token] * len(src_list)
+            ret = self.engine.batch_transfer_sync(
+                mooncake_session_id, src_list, dst_list, length_list
+            )
+            if ret != 0:
+                return ret
+        return 0
+
     def send_kvcache_slice(
         self,
         mooncake_session_id: str,
@@ -1278,6 +1465,9 @@ class MooncakeKVManager(CommonKVManager):
         while True:
             try:
                 kv_chunk: TransferKVChunk = queue.get()
+                # Early-abort: skip if room already failed (prior layer/chunk failed)
+                if self.request_status.get(kv_chunk.room) == KVPoll.Failed:
+                    continue
                 if self.enable_trace:
                     kv_chunk.trace_ctx.rebuild_thread_context()
                     kv_chunk.trace_ctx.trace_slice_start(
@@ -1364,6 +1554,36 @@ class MooncakeKVManager(CommonKVManager):
                         )
                         if len(kv_chunk.prefill_kv_indices) == 0 or skip_kv:
                             ret = 0
+                        elif kv_chunk.layer_id is not None:
+                            # Layer-pipelined mode: sync CUDA event, send single layer.
+                            # All layers in the same group share one event; repeated
+                            # synchronize() on an already-completed event is a no-op.
+                            if kv_chunk.cuda_event is not None:
+                                kv_chunk.cuda_event.synchronize()
+                            # Detect TP mismatch for MHA head slicing
+                            if (
+                                not self.is_mla_backend
+                                and self.attn_tp_size
+                                != target_rank_registration_info.dst_attn_tp_size
+                            ):
+                                ret = self.send_kvcache_layer(
+                                    req.mooncake_session_id,
+                                    kv_chunk.layer_id,
+                                    kv_chunk.prefill_kv_indices,
+                                    target_rank_registration_info.dst_kv_ptrs,
+                                    chunked_dst_kv_indice,
+                                    dst_tp_rank=target_rank_registration_info.dst_tp_rank,
+                                    dst_attn_tp_size=target_rank_registration_info.dst_attn_tp_size,
+                                    dst_kv_item_len=target_rank_registration_info.dst_kv_item_len,
+                                )
+                            else:
+                                ret = self.send_kvcache_layer(
+                                    req.mooncake_session_id,
+                                    kv_chunk.layer_id,
+                                    kv_chunk.prefill_kv_indices,
+                                    target_rank_registration_info.dst_kv_ptrs,
+                                    chunked_dst_kv_indice,
+                                )
                         elif (
                             self.is_mla_backend
                             or self.is_hybrid_mla_backend
@@ -1432,8 +1652,9 @@ class MooncakeKVManager(CommonKVManager):
                             break
 
                         if kv_chunk.is_last_chunk:
+                            extra_ret = 0
                             if kv_chunk.state_indices and not skip_state:
-                                self.maybe_send_extra(
+                                extra_ret = self.maybe_send_extra(
                                     req,
                                     kv_chunk.state_indices,
                                     executor,
@@ -1446,7 +1667,7 @@ class MooncakeKVManager(CommonKVManager):
                                 kv_chunk.prefill_aux_index,
                                 target_rank_registration_info.dst_aux_ptrs,
                             )
-                            polls.append(True if ret == 0 else False)
+                            polls.append(extra_ret == 0 and ret == 0)
                             dst_ranks_infos.append(
                                 (req.endpoint, req.dst_port, req.room)
                             )
@@ -1679,6 +1900,8 @@ class MooncakeKVManager(CommonKVManager):
         is_last_chunk: bool,
         aux_index: Optional[int] = None,
         state_indices: Optional[List] = None,
+        layer_id: Optional[int] = None,
+        cuda_event: object = None,
         trace_ctx: Optional[Union[TraceReqContext, TraceNullContext]] = None,
     ):
         assert self.disaggregation_mode == DisaggregationMode.PREFILL
@@ -1717,6 +1940,8 @@ class MooncakeKVManager(CommonKVManager):
                 is_last_chunk=is_last_chunk,
                 prefill_aux_index=aux_index,
                 state_indices=state_indices,
+                layer_id=layer_id,
+                cuda_event=cuda_event,
                 trace_ctx=trace_ctx,
             )
         )
@@ -1823,6 +2048,53 @@ class MooncakeKVSender(CommonKVSender):
                 trace_ctx=self.trace_ctx.copy_for_thread(),
             )
         self._record_transfer_indices(kv_indices, state_indices)
+
+    def send_layer(
+        self,
+        kv_indices: npt.NDArray[np.int32],
+        layer_id: int,
+        cuda_event: object,
+        is_last: bool = False,
+        state_indices: Optional[List[int]] = None,
+    ):
+        """Enqueue a single layer's KV transfer for layer-pipelined mode."""
+        kv_indices, index_slice, should_skip = self._prepare_layer_send_indices(
+            kv_indices,
+        )
+        if should_skip:
+            return
+
+        self.kv_mgr.add_transfer_request(
+            self.bootstrap_room,
+            kv_indices,
+            index_slice,
+            is_last_chunk=False,
+            layer_id=layer_id,
+            cuda_event=cuda_event,
+            trace_ctx=self.trace_ctx.copy_for_thread(),
+        )
+        if is_last:
+            self._record_transfer_indices(kv_indices, None)
+
+    def send_final_metadata(
+        self,
+        state_indices: Optional[List[int]] = None,
+    ):
+        index_slice, should_skip = self._prepare_final_metadata_send()
+        if should_skip:
+            return
+
+        empty_kv_indices = np.array([], dtype=np.int32)
+        self.kv_mgr.add_transfer_request(
+            self.bootstrap_room,
+            empty_kv_indices,
+            index_slice,
+            is_last_chunk=True,
+            aux_index=self.aux_index,
+            state_indices=state_indices,
+            trace_ctx=self.trace_ctx.copy_for_thread(),
+        )
+        self._record_transfer_indices(empty_kv_indices, state_indices)
 
     def poll(self) -> KVPoll:
         if self.conclude_state is None:

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -435,6 +435,34 @@ class SchedulerDisaggregationPrefillMixin:
             if room is not None and room in kv_mgr.transfer_infos:
                 prefetch(room)
 
+    def _batch_needs_staging_for_heterogeneous_tp(
+        self: Scheduler, batch: ScheduleBatch
+    ) -> bool:
+        if not getattr(self, "enable_staging", False):
+            return False
+
+        kv_mgr = self.disagg_prefill_bootstrap_queue.kv_manager
+        transfer_infos = getattr(kv_mgr, "transfer_infos", {})
+        decode_kv_args_table = getattr(kv_mgr, "decode_kv_args_table", {})
+        attn_tp_size = getattr(kv_mgr, "attn_tp_size", self.ps.attn_tp_size)
+
+        for req in batch.reqs:
+            room = getattr(req, "bootstrap_room", None)
+            if room is None:
+                continue
+            for transfer_info in transfer_infos.get(room, {}).values():
+                if transfer_info.is_dummy:
+                    continue
+                register_info = decode_kv_args_table.get(
+                    transfer_info.mooncake_session_id
+                )
+                if (
+                    register_info is not None
+                    and register_info.dst_attn_tp_size != attn_tp_size
+                ):
+                    return True
+        return False
+
     def resolve_waiting_queue_bootstrap(self: Scheduler) -> None:
         """Resolve bootstrap status for waiting prefill requests before admission.
 
@@ -502,6 +530,176 @@ class SchedulerDisaggregationPrefillMixin:
 
         return NextBatchPlan(batch_to_run=batch, running_batch=running_batch)
 
+    def _prepare_pipelined_state_indices(self: Scheduler, batch) -> None:
+        """Pre-compute state indices for hybrid models and attach to each req.
+
+        Mirrors the state_indices computation in send_kv_chunk, but stores
+        the result on req.pipelined_state_indices so the final metadata send
+        can pass it through after KV data is enqueued.
+        """
+        page_size = self.token_to_kv_pool_allocator.page_size
+        state_types = self.disagg_prefill_bootstrap_queue.kv_manager.kv_args.state_types
+
+        for req in batch.reqs:
+            state_indices = None
+            if state_types:
+                seq_len = min(req.fill_len, len(req.origin_input_ids))
+
+                def _mamba_payload():
+                    return [
+                        self.req_to_token_pool.req_index_to_mamba_index_mapping[
+                            req.req_pool_idx
+                        ]
+                        .cpu()
+                        .numpy()
+                    ]
+
+                def _swa_payload():
+                    window_size = self.sliding_window_size
+                    window_start = max(0, seq_len - window_size)
+                    window_start = (window_start // page_size) * page_size
+                    window_kv_indices_full = self.req_to_token_pool.req_to_token[
+                        req.req_pool_idx, window_start:seq_len
+                    ]
+                    window_kv_indices_swa = (
+                        self.token_to_kv_pool_allocator.translate_loc_from_full_to_swa(
+                            window_kv_indices_full
+                        )
+                    )
+                    return kv_to_page_indices(
+                        window_kv_indices_swa.cpu().numpy(), page_size
+                    )
+
+                def _dsa_payload():
+                    kv_indices_full = self.req_to_token_pool.req_to_token[
+                        req.req_pool_idx, :seq_len
+                    ]
+                    return kv_to_page_indices(kv_indices_full.cpu().numpy(), page_size)
+
+                state_indices = []
+                for st in state_types:
+                    if st == StateType.MAMBA:
+                        state_indices.append(_mamba_payload())
+                    elif st == StateType.SWA:
+                        state_indices.append(_swa_payload())
+                    elif st == StateType.DSA:
+                        state_indices.append(_dsa_payload())
+                    else:
+                        state_indices.append(None)
+
+            req.pipelined_state_indices = state_indices
+
+    def _get_pipeline_group_size(self: Scheduler, batch) -> int:
+        """Return adaptive group_size, or 0 if pipelining should not be used."""
+        # group_size == 0 is the sentinel for "fall back to non-pipelined path".
+        if not envs.SGLANG_ENABLE_PIPELINED_KV_TRANSFER.get():
+            return 0
+
+        # Layer-pipelined transfer currently requires the mooncake backend.
+        if self.transfer_backend not in (
+            TransferBackend.MOONCAKE,
+            TransferBackend.FAKE,
+        ):
+            return 0
+
+        # PP (pipeline parallelism) is not yet supported — send_kvcache_layer
+        # indexes kv_data_ptrs with global layer_id which is incompatible with
+        # PP's per-stage pointer slicing.
+        if self.ps.pp_size > 1:
+            return 0
+
+        # Models without split-prefill support safely fall back to the normal path.
+        model_runner = self.tp_worker.model_runner
+        model = model_runner.model
+        if not hasattr(model, "forward_split_prefill"):
+            return 0
+
+        # Layer-pipelined transfer sends KV during forward, so optimistic requests
+        # must wait until bootstrap finalizes sender metadata and prefix offsets.
+        if any(req.pending_bootstrap for req in batch.reqs):
+            return 0
+
+        # Multimodal split-prefill support is not covered by this path yet.
+        if any(req.multimodal_inputs is not None for req in batch.reqs):
+            return 0
+
+        kv_args = self.disagg_prefill_bootstrap_queue.kv_manager.kv_args
+        # Compressed MLA uses a bucketed KV pointer layout rather than a simple
+        # per-layer layout; keep it on the normal transfer path for now.
+        if getattr(kv_args, "mla_compression_ratios", None):
+            return 0
+
+        # DP attention requires prepare_mlp_sync_batch() which forward_split_prefill
+        # bypasses — DP buffers would be uninitialized, causing incorrect results.
+        if self.server_args.enable_dp_attention:
+            return 0
+
+        # EPLB (Expert Parallelism Load Balancing) requires the forward pass to be
+        # wrapped with expert_distribution_recorder.with_forward_pass() context and
+        # experts_capturer.on_forward_end() call, which forward_split_prefill bypasses.
+        # Without this, EPLB loses routing statistics and makes suboptimal decisions.
+        if self.server_args.enable_eplb:
+            return 0
+
+        # Speculative decoding (EAGLE) appends draft-model KV layers beyond
+        # num_hidden_layers. Pipelined mode only iterates target layers, so
+        # draft KV would never be transferred to the decode side.
+        if self.draft_worker is not None:
+            return 0
+
+        # input_embeds (custom embeddings via API) are not forwarded through
+        # forward_split_prefill — it always calls embed_tokens(input_ids).
+        # Fall back to normal path to avoid silently ignoring user embeddings.
+        if any(req.input_embeds is not None for req in batch.reqs):
+            return 0
+
+        # The layer path bypasses staging gather/scatter. When staging is needed
+        # for heterogeneous TP, use the normal chunk path.
+        if self._batch_needs_staging_for_heterogeneous_tp(batch):
+            return 0
+
+        # If user explicitly set group_size, it takes priority over all heuristics.
+        if envs.SGLANG_PIPELINE_GROUP_SIZE.is_set():
+            return envs.SGLANG_PIPELINE_GROUP_SIZE.get()
+
+        num_layers = self.model_config.num_hidden_layers
+
+        # Models with very few layers gain nothing from pipelining — the per-group
+        # overhead (event sync, queue enqueue, RDMA doorbell) outweighs any overlap.
+        if num_layers <= 4:
+            return 0
+
+        min_tokens = max(1, envs.SGLANG_PIPELINE_MIN_TOKENS.get())  # guard div-by-zero
+        if len(batch.reqs) == 0:
+            return 0  # Empty batch — fallback to non-pipelined
+        avg_tokens = sum(req.extend_range.length for req in batch.reqs) // len(
+            batch.reqs
+        )
+        if avg_tokens < min_tokens:
+            return 0
+
+        # Adaptive group_size via continuous formula:
+        #   target_iters = clamp(MAX - t*(MAX-MIN), MIN, MAX)
+        #   where t = (avg_tokens - min_tokens) / (sat_tokens - min_tokens)
+        #
+        # Pipeline total time:
+        #   Good bandwidth (T<C): total = C + T/N  (last group's xfer exposed)
+        #   Poor bandwidth (T>C): total = C/N + T  (first group's compute exposed)
+        #
+        # Short prompts: T/C ratio is high (attention is O(n²), xfer is O(n)),
+        #   need more groups to reduce exposed time (T/N or C/N).
+        # Long prompts: compute dominates (T<<C), even few groups hide most
+        #   transfer; extra groups only add per-group overhead for little gain.
+        max_iters = envs.SGLANG_PIPELINE_MAX_ITERS.get()
+        min_iters = envs.SGLANG_PIPELINE_MIN_ITERS.get()
+        if min_iters > max_iters:
+            min_iters, max_iters = max_iters, min_iters
+        sat_tokens = min_tokens * max(1.01, envs.SGLANG_PIPELINE_SAT_MULTIPLIER.get())
+        t = min(1.0, max(0.0, (avg_tokens - min_tokens) / (sat_tokens - min_tokens)))
+        target_iters = max(min_iters, round(max_iters - t * (max_iters - min_iters)))
+
+        return max(1, num_layers // target_iters)
+
     @torch.no_grad()
     def event_loop_normal_disagg_prefill(self: Scheduler) -> None:
         """A normal scheduler loop for prefill worker in disaggregation mode."""
@@ -528,10 +726,15 @@ class SchedulerDisaggregationPrefillMixin:
 
             # Launch the current batch
             if batch:
-                if self.enable_staging:
-                    self.maybe_prefetch_staging_for_batch(batch)
-                result = self.run_batch(batch)
-                self.process_batch_result(batch, result)
+                group_size = self._get_pipeline_group_size(batch)
+                if group_size > 0:
+                    result = self.run_batch_pipelined(batch, group_size=group_size)
+                    self.process_batch_result(batch, result)
+                else:
+                    if self.enable_staging:
+                        self.maybe_prefetch_staging_for_batch(batch)
+                    result = self.run_batch(batch)
+                    self.process_batch_result(batch, result)
             else:
                 self.on_idle()
 
@@ -598,8 +801,12 @@ class SchedulerDisaggregationPrefillMixin:
         result: GenerationBatchResult,
     ) -> None:
         """
-        Transfer kv for prefill completed requests and add it into disagg_prefill_inflight_queue
-        Adapted from process_batch_result_prefill
+        Transfer kv for prefill completed requests and add it into disagg_prefill_inflight_queue.
+        Adapted from process_batch_result_prefill.
+
+        Requests with req.pipelined_kv_sent set by run_batch_pipelined already
+        sent KV data per-layer, so this writes metadata before sending the final
+        metadata/status transfer.
         """
         (
             logits_output,
@@ -691,7 +898,15 @@ class SchedulerDisaggregationPrefillMixin:
                     self.batch_result_processor.add_sampling_mask_return_values(
                         i, req, logits_output
                     )
-                if not req.pending_bootstrap:
+                if getattr(req, "pipelined_kv_sent", False):
+                    # KV data was already sent per-layer. Write metadata first,
+                    # then enqueue the final metadata/status transfer so the
+                    # worker cannot race ahead and send stale aux buffers.
+                    self.disagg_metadata_buffers.set_buf(req)
+                    req.disagg_kv_sender.send_final_metadata(
+                        getattr(req, "pipelined_state_indices", None)
+                    )
+                elif not req.pending_bootstrap:
                     self.send_kv_chunk(req, last_chunk=True)
                 req.time_stats.set_prefill_transfer_queue_entry_time()
 

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -543,7 +543,7 @@ class SchedulerDisaggregationPrefillMixin:
         for req in batch.reqs:
             state_indices = None
             if state_types:
-                seq_len = min(req.fill_len, len(req.origin_input_ids))
+                seq_len = min(req.extend_range.end, len(req.origin_input_ids))
 
                 def _mamba_payload():
                     return [

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -566,15 +566,13 @@ class SchedulerDisaggregationPrefillMixin:
                             window_kv_indices_full
                         )
                     )
-                    return kv_to_page_indices(
-                        window_kv_indices_swa.cpu().numpy(), page_size
-                    )
+                    return kv_to_page_indices(window_kv_indices_swa, page_size)
 
                 def _dsa_payload():
                     kv_indices_full = self.req_to_token_pool.req_to_token[
                         req.req_pool_idx, :seq_len
                     ]
-                    return kv_to_page_indices(kv_indices_full.cpu().numpy(), page_size)
+                    return kv_to_page_indices(kv_indices_full, page_size)
 
                 state_indices = []
                 for st in state_types:

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -382,6 +382,26 @@ class Envs:
     SGLANG_DISAGGREGATION_ALL_CP_RANKS_TRANSFER = EnvBool(False)
     SGLANG_DISAGGREGATION_FORCE_QUERY_PREFILL_DP_RANK = EnvBool(False)
     SGLANG_DISAGGREGATION_SAMPLING_MASK_MAX_TOKENS = EnvInt(0)
+    # Layer-pipelined KV transfer: overlap RDMA transfer with GPU compute
+    # by splitting prefill into layer groups and transferring each group
+    # incrementally. Only effective in PD disaggregation prefill mode.
+    SGLANG_ENABLE_PIPELINED_KV_TRANSFER = EnvBool(False)
+    # Optional fixed group_size override. When not set, the adaptive formula
+    # below computes group_size automatically based on prompt length.
+    SGLANG_PIPELINE_GROUP_SIZE = EnvInt(0)
+    SGLANG_PIPELINE_MIN_TOKENS = EnvInt(3072)
+    # Adaptive iteration bounds for the pipeline formula:
+    # target_iters = clamp(MAX - t*(MAX-MIN), MIN, MAX) where
+    # t = (avg_tokens - MIN_TOKENS) / (SAT_TOKENS - MIN_TOKENS),
+    # SAT_TOKENS = MIN_TOKENS * SAT_MULTIPLIER (saturation point).
+    # SAT_MULTIPLIER: controls how quickly target_iters decreases as prompt
+    # length grows. Higher = stay at more iterations longer. Tune down for
+    # fast networks (800G IB), up for slower networks (200G-400G IB).
+    # MAX_ITERS: more groups for short prompts (reduces exposed T/N or C/N).
+    # MIN_ITERS: fewer groups for long prompts (compute already hides transfer).
+    SGLANG_PIPELINE_SAT_MULTIPLIER = EnvFloat(3.0)
+    SGLANG_PIPELINE_MAX_ITERS = EnvInt(10)
+    SGLANG_PIPELINE_MIN_ITERS = EnvInt(4)
 
     # Scheduler: others:
     # in seconds. Set if you observe high memory accumulation over a long serving period.

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -228,7 +228,11 @@ from sglang.srt.managers.utils import (
     validate_input_length,
 )
 from sglang.srt.mem_cache import kv_cache_builder
-from sglang.srt.mem_cache.common import maybe_cache_unfinished_req, release_kv_cache
+from sglang.srt.mem_cache.common import (
+    kv_to_page_indices,
+    maybe_cache_unfinished_req,
+    release_kv_cache,
+)
 from sglang.srt.model_executor.forward_batch_info import PPProxyTensors
 from sglang.srt.model_loader.utils import get_resolved_model_impl
 from sglang.srt.multiplex.multiplexing_mixin import SchedulerMultiplexMixin
@@ -3580,6 +3584,122 @@ class Scheduler(
         if batch_result.logits_output is not None:
             batch_result.logits_output.next_token_logits = None
 
+    def run_batch_pipelined(
+        self, batch: ScheduleBatch, group_size: int
+    ) -> GenerationBatchResult:
+        """Run a batch with layer-pipelined KV transfer.
+
+        Instead of computing all layers then transferring all KV at once,
+        this runs layers in groups and enqueues KV transfer after each group.
+        Transfer of group N overlaps with GPU compute of group N+1.
+
+        group_size is computed adaptively by _get_pipeline_group_size().
+        """
+        self.forward_ct += 1
+        batch.forward_iter = self.forward_ct
+        self.profiler_manager._profile_batch_predicate(batch)
+
+        # Match run_batch(): ForwardBatch.init_new borrows batch.input_ids, so
+        # materialize deferred prefill inputs before initializing split prefill.
+        resolve_forward_inputs(batch, self.future_map)
+
+        num_layers = self.model_config.num_hidden_layers
+        page_size = self.token_to_kv_pool_allocator.page_size
+
+        # Prepare KV page indices for requests that can be sent per-layer.
+        req_page_indices_list = []
+        for req in batch.reqs:
+            req.pipelined_kv_sent = False
+            start_idx = req.start_send_idx
+            end_idx = min(req.fill_len, len(req.origin_input_ids))
+            kv_indices = (
+                self.req_to_token_pool.req_to_token[req.req_pool_idx, start_idx:end_idx]
+                .cpu()
+                .numpy()
+            )
+            page_indices = kv_to_page_indices(kv_indices, page_size)
+            req_page_indices_list.append(page_indices)
+
+        # Pre-compute state indices for hybrid models (Mamba/SWA/DSA).
+        # Attached to req so the final metadata send can pass them through.
+        self._prepare_pipelined_state_indices(batch)
+
+        # Initialize split prefill
+        forward_batch = self.tp_worker.forward_batch_generation_split_init(batch)
+
+        logits_output = None
+        # Grouped layer forward + per-group KV transfer
+        for group_start in range(0, num_layers, group_size):
+            group_end = min(group_start + group_size, num_layers)
+            forward_count = group_end - group_start
+
+            ret, cuda_event = self.tp_worker.forward_batch_generation_split_layer(
+                forward_batch, forward_count=forward_count
+            )
+            if ret is not None:
+                logits_output = ret
+
+            # Enqueue KV transfer for all layers in this group. Requests with
+            # no pages, or with unfinished chunked-prefill chunks, fall back to
+            # send_kv_chunk in process_batch_result so their final metadata is
+            # still sent.
+            is_last_group = group_end == num_layers
+            for req, page_indices in zip(batch.reqs, req_page_indices_list):
+                if len(page_indices) == 0 or req.inflight_middle_chunks > 0:
+                    continue
+                for layer_id in range(group_start, group_end):
+                    is_last = is_last_group and layer_id == num_layers - 1
+                    req.disagg_kv_sender.send_layer(
+                        page_indices,
+                        layer_id=layer_id,
+                        cuda_event=cuda_event,
+                        is_last=is_last,
+                    )
+                if is_last_group:
+                    req.pipelined_kv_sent = True
+                    req.start_send_idx = min(req.fill_len, len(req.origin_input_ids))
+
+        # Sample next tokens unless this is a logprob-only/prefill-only batch.
+        assert (
+            logits_output is not None
+        ), "forward_split_prefill should return logits after the last layer"
+        if not forward_batch.is_prefill_only:
+            next_token_ids = self.tp_worker.forward_batch_generation_split_sample(
+                logits_output, forward_batch
+            )
+        else:
+            next_token_ids = torch.zeros(
+                len(forward_batch.seq_lens),
+                dtype=torch.long,
+                device=forward_batch.input_ids.device,
+            )
+            if (
+                forward_batch.return_logprob
+                and logits_output.next_token_logits is not None
+            ):
+                self.tp_worker.model_runner.compute_logprobs_only(
+                    logits_output, forward_batch
+                )
+
+        batch.output_ids = next_token_ids
+
+        if batch.return_logprob:
+            extend_input_len_per_req = [req.extend_input_len for req in batch.reqs]
+            extend_logprob_start_len_per_req = [
+                req.extend_logprob_start_len for req in batch.reqs
+            ]
+        else:
+            extend_input_len_per_req = None
+            extend_logprob_start_len_per_req = None
+
+        return GenerationBatchResult(
+            logits_output=logits_output,
+            next_token_ids=next_token_ids,
+            extend_input_len_per_req=extend_input_len_per_req,
+            extend_logprob_start_len_per_req=extend_logprob_start_len_per_req,
+            can_run_cuda_graph=False,
+        )
+
     @scheduler_nvtx_method("scheduler.process_batch_result")
     def process_batch_result(
         self,
@@ -4515,6 +4635,20 @@ def dispatch_event_loop(scheduler: Scheduler):
         else:
             scheduler.event_loop_normal()
     elif disaggregation_mode == DisaggregationMode.PREFILL:
+        if envs.SGLANG_ENABLE_PIPELINED_KV_TRANSFER.get():
+            logger.info(
+                "Layer-pipelined KV transfer enabled "
+                "(dispatched per-batch in normal event loop)"
+            )
+            # Pipelining uses its own compute/transfer overlap mechanism via
+            # per-layer-group CUDA events, which is incompatible with the
+            # overlap scheduler's batch-level overlap. Force the normal loop.
+            if scheduler.enable_overlap:
+                logger.info(
+                    "Disabling overlap schedule (incompatible with "
+                    "layer-pipelined transfer)"
+                )
+                scheduler.enable_overlap = False
         if server_args.pp_size > 1:
             scheduler.event_loop_pp_disagg_prefill()
         elif scheduler.enable_overlap:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3611,7 +3611,7 @@ class Scheduler(
         for req in batch.reqs:
             req.pipelined_kv_sent = False
             start_idx = req.start_send_idx
-            end_idx = min(req.fill_len, len(req.origin_input_ids))
+            end_idx = min(req.extend_range.end, len(req.origin_input_ids))
             kv_indices = (
                 self.req_to_token_pool.req_to_token[req.req_pool_idx, start_idx:end_idx]
                 .cpu()
@@ -3657,7 +3657,9 @@ class Scheduler(
                     )
                 if is_last_group:
                     req.pipelined_kv_sent = True
-                    req.start_send_idx = min(req.fill_len, len(req.origin_input_ids))
+                    req.start_send_idx = min(
+                        req.extend_range.end, len(req.origin_input_ids)
+                    )
 
         # Sample next tokens unless this is a logprob-only/prefill-only batch.
         assert (
@@ -3684,7 +3686,7 @@ class Scheduler(
         batch.output_ids = next_token_ids
 
         if batch.return_logprob:
-            extend_input_len_per_req = [req.extend_input_len for req in batch.reqs]
+            extend_input_len_per_req = [req.extend_range.length for req in batch.reqs]
             extend_logprob_start_len_per_req = [
                 req.extend_logprob_start_len for req in batch.reqs
             ]

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3612,11 +3612,9 @@ class Scheduler(
             req.pipelined_kv_sent = False
             start_idx = req.start_send_idx
             end_idx = min(req.extend_range.end, len(req.origin_input_ids))
-            kv_indices = (
-                self.req_to_token_pool.req_to_token[req.req_pool_idx, start_idx:end_idx]
-                .cpu()
-                .numpy()
-            )
+            kv_indices = self.req_to_token_pool.req_to_token[
+                req.req_pool_idx, start_idx:end_idx
+            ]
             page_indices = kv_to_page_indices(kv_indices, page_size)
             req_page_indices_list.append(page_indices)
 

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -44,6 +44,7 @@ from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
 from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
     ForwardBatch,
+    ForwardMode,
     PPProxyTensors,
 )
 from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig
@@ -627,6 +628,47 @@ class TpModelWorker(BaseTpWorker):
                 can_run_cuda_graph=can_run_cuda_graph,
                 expert_distribution_metrics=out.expert_distribution_metrics,
             )
+
+    def forward_batch_generation_split_init(
+        self,
+        batch: ScheduleBatch,
+    ) -> ForwardBatch:
+        """Initialize a ForwardBatch for layer-pipelined split prefill."""
+        forward_batch = ForwardBatch.init_new(batch, self.model_runner)
+        forward_batch.forward_mode = ForwardMode.SPLIT_PREFILL
+        forward_batch.split_index = 0
+        return forward_batch
+
+    def forward_batch_generation_split_layer(
+        self,
+        forward_batch: ForwardBatch,
+        forward_count: int = 1,
+    ) -> tuple:
+        """Run forward_count layers of split prefill and return (logits_or_none, event).
+
+        The CUDA event is recorded right after the layer forward completes.
+        Returns (None, event) for intermediate groups.
+        Returns (LogitsProcessorOutput, event) for the final group
+        (when split_index reaches num_hidden_layers).
+        """
+        # Route through ModelRunner.forward to preserve the common forward
+        # bookkeeping before it dispatches to forward_split_prefill.
+        out = self.model_runner.forward(
+            forward_batch,
+            reinit_attn_backend=(forward_batch.split_index == 0),
+            split_forward_count=forward_count,
+        )
+        event = torch.cuda.Event()
+        event.record()
+        return out.logits_output, event
+
+    def forward_batch_generation_split_sample(
+        self,
+        logits_output,
+        forward_batch: ForwardBatch,
+    ):
+        """Sample next tokens from logits after split prefill completes."""
+        return self.model_runner.sample(logits_output, forward_batch)
 
     def forward_batch_split_prefill(self, batch: ScheduleBatch):
         if batch.split_index == 0:

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -634,7 +634,11 @@ class TpModelWorker(BaseTpWorker):
         batch: ScheduleBatch,
     ) -> ForwardBatch:
         """Initialize a ForwardBatch for layer-pipelined split prefill."""
-        forward_batch = ForwardBatch.init_new(batch, self.model_runner)
+        forward_batch = ForwardBatch.init_new(
+            batch,
+            self.model_runner,
+            return_hidden_states_before_norm=False,
+        )
         forward_batch.forward_mode = ForwardMode.SPLIT_PREFILL
         forward_batch.split_index = 0
         return forward_batch

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1299,12 +1299,18 @@ class ModelRunner:
             forward_batch.split_index + forward_count,
             self.model_config.num_hidden_layers,
         )
-        ctx = (
+        timer_ctx = (
             self.device_timer.wrap(metadata={"category": "split_prefill"})
             if self.device_timer
             else contextlib.nullcontext()
         )
-        with ctx:
+        # Publish forward context so attention layers can access attn_backend
+        # via get_forward_context(). Honor outer context if already set.
+        if has_forward_context():
+            fwd_ctx = contextlib.nullcontext()
+        else:
+            fwd_ctx = forward_context(ForwardContext(attn_backend=self.attn_backend))
+        with fwd_ctx, timer_ctx:
             ret = self.model.forward_split_prefill(
                 forward_batch.input_ids,
                 forward_batch.positions,

--- a/python/sglang/srt/models/falcon_h1.py
+++ b/python/sglang/srt/models/falcon_h1.py
@@ -22,7 +22,7 @@ from sglang.srt.layers.linear import (
     QKVParallelLinear,
     RowParallelLinear,
 )
-from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.logits_processor import LogitsProcessor, LogitsProcessorOutput
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.layers.rotary_embedding import get_rope
@@ -499,6 +499,55 @@ class FalconH1ForCausalLM(nn.Module):
         return self.logits_processor(
             input_ids, hidden_states, self.lm_head, forward_batch
         )
+
+    @torch.no_grad()
+    def forward_split_prefill(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        split_interval: Tuple[int, int],
+        input_embeds: torch.Tensor = None,
+    ) -> Optional["LogitsProcessorOutput"]:
+        start, end = split_interval
+        # embed
+        if start == 0:
+            if input_embeds is None:
+                forward_batch.hidden_states = (
+                    self.model.embed_tokens(input_ids) * self.model.embedding_multiplier
+                )
+            else:
+                forward_batch.hidden_states = (
+                    input_embeds * self.model.embedding_multiplier
+                )
+        # decoder layers
+        for i in range(start, end):
+            layer = self.model.layers[i]
+            forward_batch.hidden_states, forward_batch.residual = layer(
+                layer_id=i,
+                positions=positions,
+                hidden_states=forward_batch.hidden_states,
+                residual=forward_batch.residual,
+                forward_batch=forward_batch,
+            )
+
+        if end == self.config.num_hidden_layers:
+            # norm
+            if forward_batch.residual is None:
+                hidden_states = self.model.final_layernorm(forward_batch.hidden_states)
+            else:
+                hidden_states, _ = self.model.final_layernorm(
+                    forward_batch.hidden_states, forward_batch.residual
+                )
+            forward_batch.hidden_states = hidden_states
+            # logits
+            result = self.logits_processor(
+                input_ids, forward_batch.hidden_states, self.lm_head, forward_batch
+            )
+        else:
+            result = None
+
+        return result
 
     def get_embed_and_head(self):
         return self.model.embed_tokens.weight, self.lm_head.weight

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -1553,6 +1553,49 @@ class Qwen3_5ForCausalLM(nn.Module):
             num_groups=None,
         )
 
+    @torch.no_grad()
+    def forward_split_prefill(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        split_interval: Tuple[int, int],
+        input_embeds: torch.Tensor = None,
+    ):
+        start, end = split_interval
+        # Embed
+        if start == 0:
+            if input_embeds is None:
+                forward_batch.hidden_states = self.embed_tokens(input_ids)
+            else:
+                forward_batch.hidden_states = input_embeds
+            forward_batch.residual = None
+
+        # Decoder layers
+        for i in range(start, end):
+            with get_global_expert_distribution_recorder().with_current_layer(i):
+                layer = self.layers[i]
+                forward_batch.hidden_states, forward_batch.residual = layer(
+                    positions=positions,
+                    hidden_states=forward_batch.hidden_states,
+                    residual=forward_batch.residual,
+                    forward_batch=forward_batch,
+                )
+
+        if end == self.config.num_hidden_layers:
+            # Norm
+            if forward_batch.residual is None:
+                hidden_states = self.norm(forward_batch.hidden_states)
+            else:
+                hidden_states, _ = self.norm(
+                    forward_batch.hidden_states, forward_batch.residual
+                )
+            forward_batch.hidden_states = hidden_states
+
+        # Returns None: this is the inner language model; the outer
+        # ConditionalGeneration wrapper handles logits_processor.
+        return None
+
 
 class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLM):
     def __init__(
@@ -1823,6 +1866,34 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
         else:
             torch.cuda.empty_cache()
             torch.cuda.synchronize()
+
+    @torch.no_grad()
+    def forward_split_prefill(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        split_interval: Tuple[int, int],
+        input_embeds: torch.Tensor = None,
+    ):
+        if forward_batch.contains_mm_inputs():
+            raise NotImplementedError(
+                "Qwen3.5 multimodal split-prefill is not supported"
+            )
+
+        _, end = split_interval
+        if self.is_mrope_enabled:
+            positions = forward_batch.mrope_positions
+
+        self.model.forward_split_prefill(
+            input_ids, positions, forward_batch, split_interval, input_embeds
+        )
+
+        if end == self.end_layer:
+            return self.logits_processor(
+                input_ids, forward_batch.hidden_states, self.lm_head, forward_batch
+            )
+        return None
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
@@ -2308,6 +2379,34 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
             num_logical_experts=text_config.num_experts,
             num_groups=None,
         )
+
+    @torch.no_grad()
+    def forward_split_prefill(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        split_interval: Tuple[int, int],
+        input_embeds: torch.Tensor = None,
+    ):
+        if forward_batch.contains_mm_inputs():
+            raise NotImplementedError(
+                "Qwen3.5 multimodal split-prefill is not supported"
+            )
+
+        _, end = split_interval
+        if self.is_mrope_enabled:
+            positions = forward_batch.mrope_positions
+
+        self.model.forward_split_prefill(
+            input_ids, positions, forward_batch, split_interval, input_embeds
+        )
+
+        if end == self.end_layer:
+            return self.logits_processor(
+                input_ids, forward_batch.hidden_states, self.lm_head, forward_batch
+            )
+        return None
 
 
 EntryClass = [Qwen3_5MoeForConditionalGeneration, Qwen3_5ForConditionalGeneration]

--- a/test/registered/disaggregation/test_disaggregation_pipelined.py
+++ b/test/registered/disaggregation/test_disaggregation_pipelined.py
@@ -1,0 +1,189 @@
+"""Tests for layer-pipelined KV transfer in disaggregated prefill-decode mode.
+
+Validates that enabling SGLANG_ENABLE_PIPELINED_KV_TRANSFER produces correct outputs
+across different prompt lengths and verifies the adaptive group_size logic
+correctly falls back to the normal path for short prompts.
+"""
+
+import unittest
+from contextlib import ExitStack
+from types import SimpleNamespace
+
+import requests
+
+from sglang.srt.environ import envs
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.run_eval import run_eval
+from sglang.test.server_fixtures.disaggregation_fixture import (
+    PDDisaggregationServerBase,
+)
+from sglang.test.test_utils import DEFAULT_MODEL_NAME_FOR_TEST
+
+register_cuda_ci(est_time=480, stage="base-b", runner_config="2-gpu-large")
+
+
+class TestDisaggregationPipelined(PDDisaggregationServerBase):
+    """Test layer-pipelined KV transfer correctness."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.model = DEFAULT_MODEL_NAME_FOR_TEST
+        cls._env_stack = ExitStack()
+        cls._env_stack.enter_context(
+            envs.SGLANG_ENABLE_PIPELINED_KV_TRANSFER.override(True)
+        )
+        cls._env_stack.enter_context(envs.SGLANG_PIPELINE_MIN_TOKENS.override(64))
+        try:
+            cls.launch_all()
+        except Exception:
+            cls._env_stack.close()
+            raise
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            super().tearDownClass()
+        finally:
+            env_stack = getattr(cls, "_env_stack", None)
+            if env_stack is not None:
+                env_stack.close()
+
+    def test_gsm8k(self):
+        """Validate end-to-end correctness with pipelined transfer on GSM8K."""
+        args = SimpleNamespace(
+            base_url=f"http://{self.base_host}:{self.lb_port}",
+            eval_name="gsm8k",
+            api="completion",
+            max_tokens=512,
+            num_examples=200,
+            num_threads=128,
+        )
+        metrics = run_eval(args)
+        print(f"Pipelined evaluation metrics: {metrics}")
+        self.assertGreater(metrics["score"], 0.62)
+
+    def test_basic_generation(self):
+        """Smoke test: single request produces valid output."""
+        response = requests.post(
+            self.lb_url + "/generate",
+            json={
+                "text": "The capital of France is",
+                "sampling_params": {"temperature": 0, "max_new_tokens": 16},
+            },
+            timeout=30,
+        )
+        self.assertEqual(response.status_code, 200)
+        output = response.json()
+        self.assertIn("text", output)
+        self.assertGreater(len(output["text"].strip()), 0)
+        print(f"Basic generation output: {output['text']}")
+
+    def test_long_prompt(self):
+        """Verify correctness with a long prompt that triggers more pipeline groups."""
+        # ~2000 tokens prompt to exercise deeper pipeline overlap
+        long_prompt = "Summarize the following text:\n" + (
+            "The quick brown fox jumps over the lazy dog. " * 200
+        )
+        response = requests.post(
+            self.lb_url + "/generate",
+            json={
+                "text": long_prompt,
+                "sampling_params": {"temperature": 0, "max_new_tokens": 64},
+            },
+            timeout=60,
+        )
+        self.assertEqual(response.status_code, 200)
+        output = response.json()
+        self.assertIn("text", output)
+        self.assertGreater(len(output["text"].strip()), 0)
+        print(f"Long prompt generation output: {output['text'][:100]}")
+
+    def test_concurrent_requests(self):
+        """Verify pipelined transfer handles concurrent prefills correctly."""
+        import concurrent.futures
+
+        # Each prompt must exceed SGLANG_PIPELINE_MIN_TOKENS (64) to actually
+        # exercise the pipelined path under concurrency.
+        base_prompts = [
+            "What is 2 + 2?",
+            "Explain gravity in one sentence.",
+            "Write a haiku about coding.",
+            "What is the speed of light?",
+            "Name three primary colors.",
+            "What year did World War II end?",
+            "Define photosynthesis briefly.",
+            "What is the capital of Japan?",
+        ]
+        # Pad each prompt to ~100 tokens so they exceed the min_tokens threshold
+        padding = " ".join(["word"] * 80)
+        prompts = [f"{padding}\n{p}" for p in base_prompts]
+
+        def send_request(prompt):
+            resp = requests.post(
+                self.lb_url + "/generate",
+                json={
+                    "text": prompt,
+                    "sampling_params": {"temperature": 0, "max_new_tokens": 32},
+                },
+                timeout=30,
+            )
+            return resp.status_code, resp.json()
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+            futures = [executor.submit(send_request, p) for p in prompts]
+            results = [f.result() for f in concurrent.futures.as_completed(futures)]
+
+        for status_code, output in results:
+            self.assertEqual(status_code, 200)
+            self.assertIn("text", output)
+            self.assertGreater(len(output["text"].strip()), 0)
+
+        print(f"All {len(results)} concurrent requests completed successfully")
+
+
+class TestDisaggregationPipelinedGroupSize(PDDisaggregationServerBase):
+    """Test layer-pipelined transfer with explicit group_size."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.model = DEFAULT_MODEL_NAME_FOR_TEST
+        cls._env_stack = ExitStack()
+        cls._env_stack.enter_context(
+            envs.SGLANG_ENABLE_PIPELINED_KV_TRANSFER.override(True)
+        )
+        cls._env_stack.enter_context(envs.SGLANG_PIPELINE_MIN_TOKENS.override(64))
+        cls._env_stack.enter_context(envs.SGLANG_PIPELINE_GROUP_SIZE.override(5))
+        try:
+            cls.launch_all()
+        except Exception:
+            cls._env_stack.close()
+            raise
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            super().tearDownClass()
+        finally:
+            env_stack = getattr(cls, "_env_stack", None)
+            if env_stack is not None:
+                env_stack.close()
+
+    def test_gsm8k(self):
+        """Validate correctness with fixed group_size=5."""
+        args = SimpleNamespace(
+            base_url=f"http://{self.base_host}:{self.lb_port}",
+            eval_name="gsm8k",
+            api="completion",
+            max_tokens=512,
+            num_examples=200,
+            num_threads=128,
+        )
+        metrics = run_eval(args)
+        print(f"Fixed group_size=5 metrics: {metrics}")
+        self.assertGreater(metrics["score"], 0.62)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

In PD disaggregation mode, KV cache transfer happens **after** full prefill computation completes. For long prompts (≥1K tokens), this creates a significant TTFT bottleneck — the decode side must wait for all layers to be computed and then transferred sequentially.

This PR implements **layer-pipelined KV transfer**: instead of computing all layers then transferring all KV at once, we split layers into groups and transfer each group incrementally. Transfer of group N overlaps with GPU compute of group N+1, significantly reducing TTFT.

Related: #19931 (same direction, different approach)

## Key Results

> **Benchmark environment**: SGLang v0.4.10.post2, torch 2.7.1+cu126, Qwen2.5-72B-Instruct, 2×8 H20 GPUs (TP=4 each), 4×400G IB (RDMA), PD + Mooncake backend.
> The pipelined KV transfer logic is algorithmically identical between v0.4.10.post2 and this PR — differences are limited to upstream API adaptation (environ.py registration, PP-aware pointers, EAGLE/staging guards). See \"Code equivalence\" section below.

### TTFT (ms) — Prompt Length Sweep (C=32, output=256)

| Prompt | Baseline | Pipelined | Δ% |
|--------|----------|-----------|-----|
| 256 | 229 | 269 | +18% (normal path, below threshold) |
| 1024 | 696 | 274 | **-61%** |
| 4096 | 1192 | 378 | **-68%** |
| 8192 | 1234 | 637 | **-48%** |
| 16384 | 1070 | 922 | **-14%** |

### TTFT p95 (ms)

| Prompt | Baseline | Pipelined | Δ% |
|--------|----------|-----------|-----|
| 1024 | 3378 | 589 | **-83%** |
| 4096 | 5553 | 859 | **-85%** |
| 8192 | 5344 | 1832 | **-66%** |
| 16384 | 6164 | 3029 | **-51%** |

### Throughput (output tok/s)

| Prompt | Baseline | Pipelined | Δ% |
|--------|----------|-----------|-----|
| 1024 | 888 | 923 | **+4%** |
| 4096 | 723 | 858 | **+19%** |
| 16384 | 136 | 636 | **+367%** |

### Multi-turn Dialogue (16 sessions × 10 turns)

| Metric | Baseline | Pipelined | Δ |
|--------|----------|-----------|---|
| Completed | 160 | 160 | same |
| Throughput | 485 t/s | 481 t/s | -1% |
| TTFT avg | 311 ms | 314 ms | +1% |

### Extreme Stress (C=64, prompt=4096, output=1024)

| Metric | Baseline | Pipelined | Δ |
|--------|----------|-----------|---|
| Completed reqs | 128 | 128 | same |
| TPOT avg | 46.1 ms | 46.0 ms | **0%** |
| Throughput | 1352 t/s | 1347 t/s | **0%** |

## Design

The feature is controlled by environment variables (registered in \`environ.py\`), **disabled by default**:

- \`SGLANG_ENABLE_PIPELINED_KV_TRANSFER=true\` — enable the feature
- \`SGLANG_PIPELINE_MIN_TOKENS=3072\` — threshold; short prompts use normal path
- \`SGLANG_PIPELINE_MAX_ITERS=10\` — max pipeline stages (for short prompts, more overlap)
- \`SGLANG_PIPELINE_MIN_ITERS=4\` — min pipeline stages (for long prompts, less overhead)
- \`SGLANG_PIPELINE_SAT_MULTIPLIER=3.0\` — saturation point multiplier in adaptive formula (clamped ≥ 1.01)
- \`SGLANG_PIPELINE_GROUP_SIZE\` (default unset) — (optional) override adaptive formula with a fixed number of layers per group

### How it works

1. **\`_get_pipeline_group_size(batch)\`** — per-batch decision: returns adaptive group_size (>0) or 0 to skip pipeline. A universal guard ensures models without \`forward_split_prefill\` safely fallback to the normal path. Short prompts also fall back with zero overhead.

2. **\`run_batch_pipelined(batch, group_size)\`** in \`Scheduler\` — splits forward into layer groups using \`model_runner.forward_split_prefill()\`, enqueues per-layer KV transfer via \`send_layer()\` after each group. CUDA events synchronize GPU→transfer ordering. Pre-computes state indices for hybrid models via \`_prepare_pipelined_state_indices()\`.

3. **\`process_batch_result_pipelined_prefill()\`** — result handler that dispatches to \`run_batch_pipelined\` instead of \`run_batch\`, then follows the same downstream logic (including EAGLE spec_info propagation, staging sync, A2A MoE finalization).

4. **\`MooncakeKVManager.send_kvcache_layer()\`** — single-layer RDMA transfer supporting both MHA and MLA architectures via \`get_mha_kv_ptrs_with_pp\` / \`get_mla_kv_ptrs_with_pp\`.

5. **\`TpModelWorker.forward_batch_generation_split_{init,layer,sample}()\`** — three-phase split forward: init attention backend → run N layers per call → sample after last group.

### Call chain

\`\`\`
event_loop_normal_disagg_prefill
→ _get_pipeline_group_size(batch)
→ >0:  run_batch_pipelined → split_init → [split_layer + send_layer] × N → split_sample
→  0:  run_batch (unchanged)
\`\`\`

### Event loop compatibility

Pipelined mode integrates with `event_loop_normal_disagg_prefill` only. Combining with overlap mode (`event_loop_overlap_disagg_prefill`) provides no additional benefit — pipelined already eliminates the `.cpu()` index sync that overlap mode defers (pipelined pre-computes indices before the forward loop and `process_batch_result` with `pipelined=True` skips `send_kv_chunk` entirely), and the per-group indices must be available during the forward pass so they cannot be deferred to the next iteration.

### Adaptive group_size (E1)

Instead of a fixed `SGLANG_PIPELINE_GROUP_SIZE`, group_size is automatically computed via a continuous formula that adapts to both **prompt length** and **model depth**:

```
sat_tokens = MIN_TOKENS × 3
t = clamp((avg_tokens - MIN_TOKENS) / (sat_tokens - MIN_TOKENS), 0, 1)
target_iters = clamp(MAX_ITERS - t × (MAX_ITERS - MIN_ITERS), MIN_ITERS, MAX_ITERS)
group_size = max(1, num_layers // target_iters)
```

**Why prompt length matters** — Pipeline total time depends on which is the bottleneck:
- Good bandwidth (T<C): `total = C + T/N` — last group's transfer is exposed
- Poor bandwidth (T>C): `total = C/N + T` — first group's compute is exposed

Short prompts have higher T/C ratio (attention is O(n²) but transfer is O(n)), so more groups (larger N) are needed to reduce the exposed `T/N` or `C/N`. Long prompts have compute dominating (T≪C), even few groups hide most transfer.

**Why model depth is handled automatically** — `target_iters` (number of pipeline stages) determines the overlap fraction `(N-1)/N`, which depends on T/C ratio, not on total layer count. The `num_layers // target_iters` division naturally produces appropriate group sizes for any depth (e.g., 80-layer → 8 layers/group, 32-layer → 3 layers/group at target_iters=10).

**Configurable env vars** (two new, both optional):
| Env Var | Default | Effect |
|---------|---------|--------|
| `SGLANG_PIPELINE_MAX_ITERS` | 10 | Iterations for shortest eligible prompts (more groups = less exposed time) |
| `SGLANG_PIPELINE_MIN_ITERS` | 4 | Floor for longest prompts (fewer groups = less per-group overhead) |

**Tuning guide**: Poor bandwidth → increase `MAX_ITERS` (e.g., 12) so network starts sooner; excellent bandwidth → decrease `MIN_ITERS` (e.g., 3) to reduce dispatch overhead.

User can still override with a fixed value via `SGLANG_PIPELINE_GROUP_SIZE` env var (backward compatible).

### Different TP support (E2)

\`send_kvcache_layer()\` supports MHA head slicing when prefill TP ≠ decode TP, using vectorized numpy addressing (same math as \`send_kvcache_slice\`). MLA is TP-invariant and needs no slicing.

### Mamba/SWA/NSA state support (E4)

Hybrid models (Jamba, FalconH1, DeepSeek-R1 with SWA) are fully supported. \`_prepare_pipelined_state_indices()\` pre-computes state indices before the layer loop, then passes them through \`send_layer(state_indices=...)\` on the last layer to trigger \`maybe_send_extra()\`. This covers:
- **HybridLinearKVPool** (Mamba SSM): \`req_index_to_mamba_index_mapping\`
- **SWAKVPool** (Sliding Window): windowed page indices via \`translate_loc_from_full_to_swa\`
- **NSATokenToKVPool** (Native Sparse Attention): full sequence page indices

No decode-side changes needed — decode already waits for all data (KV + state) before starting.

### Universal guard + FalconH1 support (E7)

A universal \`hasattr(model, \"forward_split_prefill\")\` guard replaces the previous multimodal-only guard. This ensures:
- Models without \`forward_split_prefill\` (e.g. DeepSeek-V2/V3) safely fallback — no crash
- Models with \`forward_split_prefill\` (LLaMA, Qwen, Gemma, FalconH1, etc.) use pipelined path

**FalconH1** (Mamba hybrid) now has \`forward_split_prefill\`, enabling layer-pipelined transfer. Each layer's attention produces KV cache (transferred per-layer via pipeline), while SSM state is sent once at the end via \`maybe_send_extra()\` (SSM state is fixed-size, independent of sequence length — no benefit from per-layer pipelining).

### MTP/EAGLE compatibility (E8)

Reviewed and confirmed that \`process_batch_result_pipelined_prefill\` correctly propagates EAGLE \`spec_info\` (\`topk_p\`, \`topk_index\`, \`hidden_states\`) to requests — identical to the normal path. MTP decode-side rollback is purely a decode-phase operation with no interaction with prefill-time pipelined transfer. Also aligned \`copy_done.synchronize()\`, \`routed_experts_output.finalize()\`, and \`maybe_cache_unfinished_req\` with the normal result handler.

### Zero regression guarantee

When \`SGLANG_ENABLE_PIPELINED_KV_TRANSFER=false\` (default):
- \`_get_pipeline_group_size()\` returns \`0\` on the first line
- \`run_batch_pipelined\`, \`process_batch_result_pipelined_prefill\`, and all \`split_*\` methods are never called
- \`TransferKVChunk.layer_id\` defaults to \`None\`, so \`transfer_worker\` always takes the existing path
- \`add_transfer_request\` new parameters have default values — existing callers unaffected

### Code equivalence (v0.4.10.post2 → this PR)

Benchmarks were collected on v0.4.10.post2. This PR ports the same logic to upstream main with these adaptations:
- \`os.environ.get()\` → \`envs.XXX.get()\` (central environ.py registry)
- \`send_kvcache_layer\` uses PP-aware \`get_mha_kv_ptrs_with_pp\` / \`get_mla_kv_ptrs_with_pp\` (upstream helpers, equivalent at PP=1)
- \`process_batch_result_pipelined_prefill\` adapted for upstream's EAGLE spec info, staging buffer, and \`report_prefill_stats\` APIs
- Core algorithm (grouped layer forward loop, CUDA event sync, per-layer RDMA enqueue) is identical

## Checklist

| # | Item | Status |
|---|------|--------|
| 1 | GQA, same TP, no MTP | ✅ Done (LLaMA, Qwen, Gemma verified) |
| 2 | Mamba hybrid (FalconH1), same TP | ✅ Done — \`forward_split_prefill\` implemented, SSM state via \`maybe_send_extra()\` |
| 3 | GQA + Mamba, different TP | ✅ Done (E2 head slicing + E4 state transfer) |
| 4 | MLA (DeepSeek-V2/V3) | ⚠️ Transport layer ready (`send_kvcache_layer` MLA path), but DeepSeek models lack `forward_split_prefill` due to complex TBO/A2A/CP interactions — safely fallback via universal guard. Note: MLA compresses KV ~4.6x (1152 B vs 4096 B/token/layer for GQA), so pipelined benefit is inherently smaller (~15-30% TTFT reduction vs 48-68% for GQA models); prioritizing GQA/MHA models is intentional. |
| 5 | MTP/EAGLE compatibility | ✅ Done — \`spec_info\` propagation verified, result handler aligned with normal path |
| 6 | PP support | ❌ Not started |
| 7 | EPLB (Expert Load Balancing) | ⚠️ Pipelined path bypasses \`expert_distribution_recorder.with_forward_pass()\` context and \`experts_capturer.on_forward_end()\` — automatically disabled when \`enable_eplb=True\` to ensure complete routing statistics. Full EPLB+pipelined support (wrapping split forward with capture logic) deferred to follow-up PR. |
| 8 | DP Attention | ⚠️ \`forward_split_prefill\` bypasses \`prepare_mlp_sync_batch()\` — automatically disabled when \`enable_dp_attention=True\`. |
| 9 | input_embeds (custom embeddings via API) | ⚠️ \`forward_split_prefill\` always calls \`embed_tokens(input_ids)\` — automatically disabled when any request has \`input_embeds\`. |

## Modified Files

| File | Changes |
|------|---------|
| \`sglang/srt/disaggregation/prefill.py\` | \`_get_pipeline_group_size\` (universal guard + adaptive formula), \`_prepare_pipelined_state_indices\`, pipelined event loop branch, \`process_batch_result_pipelined_prefill\` (with EAGLE/staging/A2A alignment) |
| \`sglang/srt/managers/scheduler.py\` | \`run_batch_pipelined\` (with state_indices pass-through), overlap auto-disable logic, info log in \`dispatch_event_loop\` |
| \`sglang/srt/disaggregation/mooncake/conn.py\` | \`send_kvcache_layer\` (MHA+MLA+head slicing), \`_send_kvcache_layer_head_slice\`, \`TransferKVChunk\` extension, \`transfer_worker\` dispatch, \`MooncakeKVSender.send_layer\` (with state_indices) |
| \`sglang/srt/disaggregation/base/conn.py\` | \`BaseKVSender.send_layer\` default (raises NotImplementedError) |
| \`sglang/srt/disaggregation/common/utils.py\` | \`TransferKVChunk\`: add \`layer_id\`, \`cuda_event\` fields |
| \`sglang/srt/disaggregation/fake/conn.py\` | \`FakeKVSender.send_layer\` stub (with state_indices) |
| \`sglang/srt/managers/tp_worker.py\` | \`forward_batch_generation_split_{init,layer,sample}\` |
| \`sglang/srt/model_executor/model_runner.py\` | \`ModelRunner.forward_split_prefill\` (with forward_context + attn_backend init) |
| \`sglang/srt/models/falcon_h1.py\` | \`FalconH1ForCausalLM.forward_split_prefill\` |
| \`sglang/srt/models/qwen3_5.py\` | \`forward_split_prefill\` for Qwen3.5 + VL (contributed by @UNIDY2002) |
| \`sglang/srt/environ.py\` | Register 6 env vars (\`SGLANG_ENABLE_PIPELINED_KV_TRANSFER\`, \`SGLANG_PIPELINE_GROUP_SIZE\`, \`SGLANG_PIPELINE_MIN_TOKENS\`, \`SGLANG_PIPELINE_SAT_MULTIPLIER\`, \`SGLANG_PIPELINE_MAX_ITERS\`, \`SGLANG_PIPELINE_MIN_ITERS\`) with adaptive formula comments |
| \`docs_new/docs/references/environment_variables.mdx\` | Document the 6 env vars |
| \`test/registered/disaggregation/test_disaggregation_pipelined.py\` | CI tests for pipelined transfer |

## Future Work

- **MLA \`forward_split_prefill\`** — DeepSeek-V2/V3 has complex interactions with TBO, NSA context parallel, and A2A MoE. Deferred as separate PR by someone familiar with DeepSeek internals.
- **NIXL backend support** — NIXL already has async queue architecture (PR #23967); adding `send_layer()` is ~160 LOC. Planned as follow-up PR after this merges.
- **PP support** — Cross-PP-stage pipeline coordination (long-term)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30077189926](https://github.com/sgl-project/sglang/actions/runs/30077189926)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #30077189782](https://github.com/sgl-project/sglang/actions/runs/30077189782)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->


