### PR TITLE
test: move test_epd_disaggregation to nightly-4-gpu

### DIFF
--- a/test/registered/distributed/test_epd_disaggregation.py
+++ b/test/registered/distributed/test_epd_disaggregation.py
@@ -36,7 +36,7 @@ DEFAULT_OMNI_MODEL = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
 QWEN35_27B_MODEL = "Qwen/Qwen3.5-27B"
 
 
-register_cuda_ci(est_time=97, suite="stage-c-test-4-gpu-h100")
+register_cuda_ci(est_time=97, suite="nightly-4-gpu", nightly=True)
 
 
 @unittest.skipIf(


### PR DESCRIPTION
## Summary

Moves `test/registered/distributed/test_epd_disaggregation.py` from the per-commit suite `stage-c-test-4-gpu-h100` to the nightly suite `nightly-4-gpu`. Same 4-GPU H100 hardware, just no longer gating PR merges.

`test_mmmu` in `TestEPDDisaggregationMultiEncoders` is flaky at the accuracy boundary — it asserts `mmmu_accuracy > 0.40` and observed exactly `0.40` in production CI, causing `AssertionError: 0.4 not greater than 0.4` on main. Keeping it in nightly preserves daily signal on the flakiness while unblocking per-commit CI.

Failure example: https://github.com/sgl-project/sglang/actions/runs/24485670240/job/71559926349

## Diff

```diff
-register_cuda_ci(est_time=97, suite="stage-c-test-4-gpu-h100")
+register_cuda_ci(est_time=97, suite="nightly-4-gpu", nightly=True)
```

Pattern matches existing nightly-4-gpu tests (`test/registered/core/test_qwen3_next_deterministic.py:15`, `test/registered/debug_utils/test_engine_dumper_comparator_e2e.py:38`).

## Test plan

- [ ] Verify CI registry parses cleanly (done locally — `suite='nightly-4-gpu', nightly=True, est_time=97.0, has_main_entry=True`)
- [ ] Confirm test no longer appears in per-commit `stage-c-test-4-gpu-h100` after merge
- [ ] Confirm test runs in the next nightly run via `nightly-test-nvidia.yml`
- [ ] Separately investigate and fix the 0.40-boundary flakiness in `test_mmmu` (follow-up)