### PR TITLE
fix ngram greedy verify kwarg

### DIFF
--- a/python/sglang/srt/speculative/ngram_info.py
+++ b/python/sglang/srt/speculative/ngram_info.py
@@ -303,9 +303,10 @@ class NgramVerifyInput(SpecInput):
             accept_index=self.accepted_indices,  # mutable
             accept_token_num=self.accept_length,  # mutable
             candidates=candidates,
-            retrieve_index=self.retrieve_index,
-            retrieve_next_token=self.retrieve_next_token,
-            retrieve_next_sibling=self.retrieve_next_sibling,
+            # kwarg LHS retained as `retrive_*` to match sgl_kernel op schema.
+            retrive_index=self.retrieve_index,
+            retrive_next_token=self.retrieve_next_token,
+            retrive_next_sibling=self.retrieve_next_sibling,
             target_predict=target_predict,
         )
 


### PR DESCRIPTION
PR #23503 renamed `retrive_*` -> `retrieve_*` in `_greedy_verify` but `sgl_kernel.verify_tree_greedy` still uses `retrive_*` in its op schema, breaking ngram spec decoding (`TypeError: verify_tree_greedy() got an unexpected keyword argument 'retrieve_index'`). Restore the `retrive_*` kwarg LHS, matching the handling already done in `_sampling_verify`.