### PR TITLE
fix: increase CLIP_MAX_NEW_TOKENS default from 4096 to 16384

### DIFF
--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
 # Note that this only clips the estimation in the scheduler but does not change the stop
 # condition. The request can still generate tokens until it hits the unclipped max_new_tokens.
 CLIP_MAX_NEW_TOKENS = int(
-    os.environ.get("SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION", "4096")
+    os.environ.get("SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION", "16384")
 )
 
 # Threshold for in-batch prefix cache.


### PR DESCRIPTION
Fixes #23365

## Problem

The default value of `SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION` was 4096, which is too conservative for modern long-context LLMs. When a model generates more than 4096 tokens (common with thinking/reasoning models like DeepSeek-R1), the scheduler only reserved 4096 token memory slots. In PD disaggregation with a single decoding sequence near memory limits, this causes OOM once the sequence exceeds the 4096-token reservation.

## Solution

Increase the default from 4096 to 16384, which better accommodates current long-context LLMs with 128k+ context windows. The `SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION` environment variable remains fully configurable for users who need a different value.

## Testing

This is a configuration default change. The existing scheduler logic is unchanged; only the clipping threshold for memory estimation is increased.