### PR TITLE
docs: split MI300X and MI325X options in GLM-5.1 generator

### DIFF
--- a/docs_new/cookbook/autoregressive/intro.mdx
+++ b/docs_new/cookbook/autoregressive/intro.mdx
@@ -28,7 +28,7 @@ metatags:
   <Card
     title="GLM"
     mode="card"
-    href="/cookbook/autoregressive/GLM/GLM-4.5"
+    href="/cookbook/autoregressive/GLM/GLM-5.1"
     img="/cards/logos/glm.png"
   />
   <Card

--- a/docs_new/docs.json
+++ b/docs_new/docs.json
@@ -960,16 +960,16 @@
                   {
                     "group": "GLM",
                     "pages": [
-                      "cookbook/autoregressive/GLM/GLM-4.5",
-                      "cookbook/autoregressive/GLM/GLM-4.6",
+                      "cookbook/autoregressive/GLM/GLM-5.1",
+                      "cookbook/autoregressive/GLM/GLM-5",
+                      "cookbook/autoregressive/GLM/GLM-OCR",
+                      "cookbook/autoregressive/GLM/GLM-Glyph",
                       "cookbook/autoregressive/GLM/GLM-4.7",
                       "cookbook/autoregressive/GLM/GLM-4.7-Flash",
-                      "cookbook/autoregressive/GLM/GLM-5",
-                      "cookbook/autoregressive/GLM/GLM-5.1",
-                      "cookbook/autoregressive/GLM/GLM-Glyph",
-                      "cookbook/autoregressive/GLM/GLM-OCR",
-                      "cookbook/autoregressive/GLM/GLM-4.5V",
-                      "cookbook/autoregressive/GLM/GLM-4.6V"
+                      "cookbook/autoregressive/GLM/GLM-4.6",
+                      "cookbook/autoregressive/GLM/GLM-4.6V",
+                      "cookbook/autoregressive/GLM/GLM-4.5",
+                      "cookbook/autoregressive/GLM/GLM-4.5V"
                     ]
                   },
                   {

--- a/docs_new/src/snippets/autoregressive/glm-51-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/glm-51-deployment.jsx
@@ -14,7 +14,8 @@ export const GLM51Deployment = () => {
         { id: 'b200',   label: 'B200',          default: false },
         { id: 'gb300',  label: 'GB300',         default: false },
         { id: 'h100',   label: 'H100',          default: false },
-        { id: 'mi300x', label: 'MI300X/MI325X', default: false },
+        { id: 'mi300x', label: 'MI300X',        default: false },
+        { id: 'mi325x', label: 'MI325X',        default: false },
         { id: 'mi355x', label: 'MI355X',        default: false }
       ]
     },
@@ -23,7 +24,7 @@ export const GLM51Deployment = () => {
       title: 'Quantization',
       getDynamicItems: (values) => {
         const hw = values.hardware;
-        const isAMD = hw === 'mi300x' || hw === 'mi355x';
+        const isAMD = hw === 'mi300x' || hw === 'mi325x' || hw === 'mi355x';
         const isGB300 = hw === 'gb300';
         return [
           { id: 'bf16', label: 'BF16', subtitle: 'Full Weights',    default: isAMD,  disabled: isGB300, disabledReason: isGB300 ? 'BF16 is not recommended on GB300 for GLM-5.1' : '' },
@@ -58,7 +59,7 @@ export const GLM51Deployment = () => {
     speculative: {
       name: 'speculative',
       title: 'Speculative Decoding',
-      condition: (values) => values.hardware !== 'mi300x' && values.hardware !== 'mi355x',
+      condition: (values) => values.hardware !== 'mi300x' && values.hardware !== 'mi325x' && values.hardware !== 'mi355x',
       items: [
         { id: 'disabled', label: 'Disabled', default: false },
         { id: 'enabled',  label: 'Enabled',  default: true  }
@@ -72,6 +73,7 @@ export const GLM51Deployment = () => {
     b200:   { fp8: { tp: 8,  mem: 0.9  }, bf16: { tp: 16, mem: 0.9  } },
     gb300:  { fp8: { tp: 4,  mem: 0.9  } },
     mi300x: { bf16: { tp: 8, mem: 0.80 } },
+    mi325x: { bf16: { tp: 8, mem: 0.80 } },
     mi355x: { bf16: { tp: 8, mem: 0.80 } }
   };
 
@@ -129,7 +131,7 @@ export const GLM51Deployment = () => {
 
   const generateCommand = () => {
     const { hardware, quantization } = values;
-    const isAMD = hardware === 'mi300x' || hardware === 'mi355x';
+    const isAMD = hardware === 'mi300x' || hardware === 'mi325x' || hardware === 'mi355x';
     const isGB300 = hardware === 'gb300';
     const effectiveQuant = isAMD ? 'bf16' : (isGB300 && quantization === 'bf16' ? 'fp8' : quantization);
     const suffix = effectiveQuant === 'fp8' ? '-FP8' : '';

--- a/docs_new/src/snippets/autoregressive/glm-51-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/glm-51-deployment.jsx
@@ -24,7 +24,7 @@ export const GLM51Deployment = () => {
       title: 'Quantization',
       getDynamicItems: (values) => {
         const hw = values.hardware;
-        const isAMD = hw === 'mi300x' || hw === 'mi325x' || hw === 'mi355x';
+        const isAMD = ['mi300x', 'mi325x', 'mi355x'].includes(hw);
         const isGB300 = hw === 'gb300';
         return [
           { id: 'bf16', label: 'BF16', subtitle: 'Full Weights',    default: isAMD,  disabled: isGB300, disabledReason: isGB300 ? 'BF16 is not recommended on GB300 for GLM-5.1' : '' },
@@ -59,7 +59,7 @@ export const GLM51Deployment = () => {
     speculative: {
       name: 'speculative',
       title: 'Speculative Decoding',
-      condition: (values) => values.hardware !== 'mi300x' && values.hardware !== 'mi325x' && values.hardware !== 'mi355x',
+      condition: (values) => !['mi300x', 'mi325x', 'mi355x'].includes(values.hardware),
       items: [
         { id: 'disabled', label: 'Disabled', default: false },
         { id: 'enabled',  label: 'Enabled',  default: true  }
@@ -131,7 +131,7 @@ export const GLM51Deployment = () => {
 
   const generateCommand = () => {
     const { hardware, quantization } = values;
-    const isAMD = hardware === 'mi300x' || hardware === 'mi325x' || hardware === 'mi355x';
+    const isAMD = ['mi300x', 'mi325x', 'mi355x'].includes(hardware);
     const isGB300 = hardware === 'gb300';
     const effectiveQuant = isAMD ? 'bf16' : (isGB300 && quantization === 'bf16' ? 'fp8' : quantization);
     const suffix = effectiveQuant === 'fp8' ? '-FP8' : '';


### PR DESCRIPTION
## Summary
- split the GLM-5.1 hardware selector button `MI300X/MI325X` into separate `MI300X` and `MI325X` options
- map `MI325X` to the same AMD config path and generated command that the combined `MI300X/MI325X` option previously used
- update the GLM card on the autoregressive cookbook navigation page to point to `GLM-5.1`
- reorder the GLM cookbook entries to match the intended GLM model ordering, with the `4.x` entries listed as `4.7 -> 4.6 -> 4.5`
- preserve the existing GLM-5.1 generator behavior on `main`; this change does not introduce any new speculative decoding or other command logic changes

## Validation
- compared the current branch against `main` for GLM-5.1 AMD behavior
- ran `mint validate` under `docs_new/`
- verified that the GLM navigation changes are limited to the cookbook card target and GLM ordering in `docs.json`