### PR TITLE
[bug fix] has_fp8_weights_in_checkpoint: handle HF repo IDs, not just local paths

### DIFF
--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2712,33 +2712,52 @@ def has_fp8_weights_in_checkpoint(model_path: str) -> bool:
     experts without declaring it in quantization_config, while other models
     sharing the same architecture (e.g. Moonlight) are purely BF16.
 
-    Only reads the safetensors header (a few KB of JSON), not the actual weights.
+    Accepts a local directory or a HuggingFace repo ID. For remote repos, only
+    safetensors headers (a few KB) are fetched via byte-range reads; full
+    shards are never downloaded.
     """
     import json
     import struct
 
     try:
-        index_path = os.path.join(model_path, "model.safetensors.index.json")
-        if os.path.exists(index_path):
-            with open(index_path) as f:
-                index = json.load(f)
-            weight_map = index.get("weight_map", {})
-            expert_files = {
-                v for k, v in weight_map.items() if "experts" in k and "weight" in k
-            }
-            shard_file = next(iter(expert_files), None) or next(
-                iter(set(weight_map.values())), None
+        if os.path.isdir(model_path):
+
+            def _open(name):
+                return open(os.path.join(model_path, name), "rb")
+
+            def _exists(name):
+                return os.path.exists(os.path.join(model_path, name))
+
+        else:
+            from huggingface_hub import HfFileSystem
+
+            fs = HfFileSystem()
+
+            def _open(name):
+                return fs.open(f"{model_path}/{name}", "rb")
+
+            def _exists(name):
+                return fs.exists(f"{model_path}/{name}")
+
+        if _exists("model.safetensors.index.json"):
+            with _open("model.safetensors.index.json") as f:
+                weight_map = json.loads(f.read()).get("weight_map", {})
+            expert_files = sorted(
+                {v for k, v in weight_map.items() if "experts" in k and "weight" in k}
+            )
+            shard_file = (
+                expert_files[0]
+                if expert_files
+                else next(iter(sorted(set(weight_map.values()))), None)
             )
             if shard_file is None:
                 return False
-            shard_path = os.path.join(model_path, shard_file)
+        elif _exists("model.safetensors"):
+            shard_file = "model.safetensors"
         else:
-            shard_path = os.path.join(model_path, "model.safetensors")
-
-        if not os.path.exists(shard_path):
             return False
 
-        with open(shard_path, "rb") as f:
+        with _open(shard_file) as f:
             header_len = struct.unpack("<Q", f.read(8))[0]
             header = json.loads(f.read(header_len))
 


### PR DESCRIPTION
## Motivation

Follow-up to #23414. That PR added `has_fp8_weights_in_checkpoint` to auto-detect FP8 MoE experts for `DeepseekV3ForCausalLM` on SM100 (B200). But the helper only checks local directories, so for the most common invocation — passing an HF repo ID — it silently returns `False`.

```
python -m sglang.launch_server --model-path deepseek-ai/DeepSeek-V3
```

Tracing the flow:

1. `ServerArgs.__post_init__` calls `_maybe_download_model_for_runai` (RunAI URIs only) and `_handle_modelscope_paths` (gated by `SGLANG_USE_MODELSCOPE`). Neither resolves HF repo IDs.
2. `_handle_model_specific_adjustments` (server_args.py:820) runs with `self.model_path` still equal to `"deepseek-ai/DeepSeek-V3"`.
3. `get_model_config()` downloads `config.json` via `AutoConfig.from_pretrained`, but `self.model_path` is never rewritten to the snapshot dir. Weight files are not downloaded yet.
4. `has_fp8_weights_in_checkpoint("deepseek-ai/DeepSeek-V3")` does `os.path.exists("deepseek-ai/DeepSeek-V3/model.safetensors.index.json")` → `False` → returns `False`.
5. FP8 auto-default is skipped. DeepSeek-V3/R1 loads as BF16 on B200 — the opposite of #23414's intent.

## Modifications

- Teach the helper to accept an HF repo ID in addition to a local directory.
- For remote repos, use `huggingface_hub.HfFileSystem` so only safetensors header bytes are fetched via HTTP byte-range reads — full shards (tens of GB for DeepSeek-V3) are never downloaded from this helper.
- Sort shard selection (`sorted({...})`) so the choice of representative shard is deterministic across runs. Local-directory behavior is otherwise unchanged.

## Test Plan

- [ ] `--model-path deepseek-ai/DeepSeek-V3` on B200 → log line `"Detected FP8 expert weights in checkpoint, default to fp8 for DeepSeek on sm100"` appears.
- [ ] `--model-path moonshotai/Moonlight-16B-A3B-Instruct` on B200 → log line `"No FP8 expert weights found in checkpoint, keeping bf16..."` appears and the model loads successfully (the original bug #23414 fixed).
- [ ] `--model-path /local/path/to/DeepSeek-V3` still works as before.

## Checklist

- [x] Format your code according to pre-commit.
- [ ] Add unit tests (follow-up — would need to mock HfFileSystem / provide a fixture directory).