### PR TITLE
Fix MoE no_combine: skip router weight in down projection

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
@@ -618,7 +618,7 @@ def _fused_moe_kernel_sequence(
         sorted_token_ids,
         expert_ids,
         num_tokens_post_padded,
-        not apply_router_weight_on_input,
+        not apply_router_weight_on_input and not no_combine,
         1,
         down_config or config,
         compute_type=compute_type,

--- a/python/sglang/srt/layers/moe/token_dispatcher/base.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/base.py
@@ -262,7 +262,7 @@ class BaseDispatcher(ABC):
     """Base class for dispatchers."""
 
     def __init__(self):
-        self.quant_config: Optional[dict] = None
+        self.quant_config: dict = {}
 
         # Overlap args
         self.overlap_args: Optional[CombineOverlapArgs] = None


### PR DESCRIPTION
## Summary
- When `no_combine` mode is enabled, the down projection kernel should not apply router weights (the combine step handles weighting). Previously only `apply_router_weight_on_input` was checked; now `no_combine` is also checked.
- Change `BaseDispatcher.quant_config` default from `None` to `{}` to avoid AttributeError when accessed before explicit assignment.

## Test plan
- [ ] Run MoE model tests with no_combine mode enabled
- [ ] Verify standard MoE path is unaffected