### PR TITLE
[Fix][NPU] Fix FIA_NZ radix-prefix accuracy regression in MLA extend path

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -43,6 +43,19 @@ def _reshape_kv_for_fia_nz(
     return tensor.view(-1, 1, num_heads * head_dim // 16, page_size, 16)
 
 
+def _restore_kv_from_fia_nz(
+    tensor: torch.Tensor, head_dim: int, page_size: int
+) -> torch.Tensor:
+    """Restore NZ-laid MLA cache to token-major [num_page, page, 1, head_dim]."""
+    num_pages = tensor.shape[0]
+    return (
+        tensor.view(num_pages, head_dim // 16, page_size, 16)
+        .permute(0, 2, 1, 3)
+        .contiguous()
+        .view(num_pages, page_size, 1, head_dim)
+    )
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -1062,6 +1075,13 @@ class AscendAttnBackend(AttentionBackend):
                 v_buffer = forward_batch.token_to_kv_pool.get_value_buffer(
                     layer.layer_id
                 )
+                if is_fia_nz():
+                    k_buffer = _restore_kv_from_fia_nz(
+                        k_buffer, self.kv_lora_rank, self.page_size
+                    )
+                    v_buffer = _restore_kv_from_fia_nz(
+                        v_buffer, self.qk_rope_head_dim, self.page_size
+                    )
                 kv_cached = torch.index_select(
                     k_buffer, 0, self.forward_metadata.flatten_prefix_block_tables
                 )
@@ -1174,6 +1194,13 @@ class AscendAttnBackend(AttentionBackend):
                 v_buffer = forward_batch.token_to_kv_pool.get_value_buffer(
                     layer.layer_id
                 )
+                if is_fia_nz():
+                    k_buffer = _restore_kv_from_fia_nz(
+                        k_buffer, self.kv_lora_rank, self.page_size
+                    )
+                    v_buffer = _restore_kv_from_fia_nz(
+                        v_buffer, self.qk_rope_head_dim, self.page_size
+                    )
                 kv_cached = torch.index_select(
                     k_buffer, 0, self.forward_metadata.flatten_prefix_block_tables
                 )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When SGLANG_USE_FIA_NZ=1 and radix cache is enabled, GSM8K accuracy drops for cache-hit requests, while non-cache-hit requests remain normal.
The issue does not reproduce when either:

SGLANG_USE_FIA_NZ=0, or
radix cache is disabled.
This strongly indicates a layout mismatch specific to the radix-prefix history path under FIA_NZ.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

This PR adds an explicit NZ-to-token-major restoration step before consuming historical prefix KV blocks in the MLA extend prefix-cache branches.

- Introduce a helper to restore FIA_NZ cache layout into the token-major layout expected by prefix-history reconstruction logic.
- Apply this restoration only in the two MLA + prefix-hit branches that manually read historical KV via `get_key_buffer/get_value_buffer` + `index_select`.
- Keep all other decode/MTP/non-prefix paths unchanged, since they already use FIA_NZ-aware handling or do not consume radix-prefix history in this way.
As a result, the radix-prefix path reads historical KV in a layout consistent with downstream `kv_b_proj` and attention composition, eliminating the observed cache-hit accuracy regression.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

```bash
# System Settings
echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
sysctl -w vm.swappiness=10
sysctl -w kernel.numa_balancing=0

export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
export SGLANG_SET_CPU_AFFINITY=1
export STREAMS_PER_DEVICE=32

# deepep communication settings
export DEEP_NORMAL_MODE_USE_INT8_QUANT=1
export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=64
export HCCL_BUFFSIZE=1200

# spec overlap
export SGLANG_ENABLE_SPEC_V2=1
export SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1

export SGLANG_NPU_USE_MLAPO=1
export SGLANG_USE_FIA_NZ=1

python -m sglang.launch_server \
    --model-path /path/to/Kimi-K2.5-w4a8 --quantization modelslim --dtype bfloat16 \
    --model-loader-extra-config '{"enable_multithread_load": true}' \
    --host 0.0.0.0 --port 8100 \
    --trust-remote-code --device npu --attention-backend ascend \
    --tp-size 16 --mem-fraction-static 0.72 --max-running-requests 192 \
    --chunked-prefill-size -1 --context-length 8192\
    --enable-multimodal --mm-attention-backend ascend_attn --sampling-backend ascend \
    --moe-a2a-backend deepep --deepep-mode auto \
    --disable-cuda-graph \
    --speculative-algorithm EAGLE3 \
    --speculative-draft-model-path /path/to/kimi-k2.5-eagle3 \
    --speculative-num-steps 4 \
    --speculative-eagle-topk 1 \
    --speculative-num-draft-tokens 5 \
    --speculative-draft-model-quantization unquant \
    --skip-server-warmup 

#--disable-radix-cache
```

### before this pr, when use fia_nz and radix_cache

<img width="832" height="242" alt="image" src="https://github.com/user-attachments/assets/8e1dfd90-0ac9-4dd9-908d-59ff45805264" />

### with this pr, when use fia_nz and radix_cache

<img width="835" height="481" alt="image" src="https://github.com/user-attachments/assets/4f05ff50-694c-4882-ace2-b016b086f5bb" />

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
