### PR TITLE
[AMD] Fix nightly version tag selection

### DIFF
--- a/.github/workflows/release-docker-amd-nightly.yml
+++ b/.github/workflows/release-docker-amd-nightly.yml
@@ -28,6 +28,11 @@ jobs:
         with:
           fetch-depth: 0  # Required for git describe to find tags
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
       - name: "Set Date"
         run: |
           echo "DATE=$(date +%Y%m%d)" >> $GITHUB_ENV
@@ -35,8 +40,8 @@ jobs:
       - name: Get version from latest tag
         id: version
         run: |
-          # Get the latest version tag sorted by version number (e.g., v0.5.7 -> 0.5.7)
-          VERSION=$(git tag -l 'v[0-9]*' --sort=-v:refname | head -1 | sed 's/^v//')
+          # Use the shared helper so stable/post releases sort above rc tags.
+          VERSION=$(python3 python/tools/get_version_tag.py --tag-only | sed 's/^v//')
 
           if [ -z "$VERSION" ]; then
             echo "::error::Could not determine version from git tags"
@@ -181,8 +186,8 @@ jobs:
   #     - name: Get version from latest tag
   #       id: version
   #       run: |
-  #         # Get the latest version tag sorted by version number (e.g., v0.5.7 -> 0.5.7)
-  #         VERSION=$(git tag -l 'v[0-9]*' --sort=-v:refname | head -1 | sed 's/^v//')
+  #         # Use the shared helper so stable/post releases sort above rc tags.
+  #         VERSION=$(python3 python/tools/get_version_tag.py --tag-only | sed 's/^v//')
 
   #         if [ -z "$VERSION" ]; then
   #           echo "::error::Could not determine version from git tags"

--- a/.github/workflows/release-docker-amd-rocm720-nightly.yml
+++ b/.github/workflows/release-docker-amd-rocm720-nightly.yml
@@ -28,6 +28,11 @@ jobs:
         with:
           fetch-depth: 0  # Required for git describe to find tags
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
       - name: "Set Date"
         run: |
           echo "DATE=$(date +%Y%m%d)" >> $GITHUB_ENV
@@ -35,8 +40,8 @@ jobs:
       - name: Get version from latest tag
         id: version
         run: |
-          # Get the latest version tag sorted by version number (e.g., v0.5.7 -> 0.5.7)
-          VERSION=$(git tag -l 'v[0-9]*' --sort=-v:refname | head -1 | sed 's/^v//')
+          # Use the shared helper so stable/post releases sort above rc tags.
+          VERSION=$(python3 python/tools/get_version_tag.py --tag-only | sed 's/^v//')
 
           if [ -z "$VERSION" ]; then
             echo "::error::Could not determine version from git tags"

--- a/scripts/ci/amd/amd_ci_start_container.sh
+++ b/scripts/ci/amd/amd_ci_start_container.sh
@@ -6,14 +6,8 @@ SGLANG_VERSION="v0.5.5"   # Default version, will be overridden if git tags are 
 
 # Fetch tags from origin to ensure we have the latest
 if git fetch --tags origin; then
-  # Prefer the shared helper so stable/post releases sort above rc tags.
-  # Fall back to git's built-in version sort if python3 is unavailable.
-  if command -v python3 >/dev/null 2>&1; then
-    VERSION_FROM_TAG=$(python3 python/tools/get_version_tag.py --tag-only || true)
-  else
-    echo "Warning: python3 not found; falling back to git tag version sort" >&2
-    VERSION_FROM_TAG=$(git tag -l 'v[0-9]*' --sort=-v:refname | head -1)
-  fi
+  # Use the shared helper so stable/post releases sort above rc tags.
+  VERSION_FROM_TAG=$(python3 python/tools/get_version_tag.py --tag-only || true)
   if [ -n "$VERSION_FROM_TAG" ]; then
     SGLANG_VERSION="$VERSION_FROM_TAG"
     echo "Using SGLang version from git tags: $SGLANG_VERSION"

--- a/scripts/ci/amd/amd_ci_start_container.sh
+++ b/scripts/ci/amd/amd_ci_start_container.sh
@@ -6,8 +6,14 @@ SGLANG_VERSION="v0.5.5"   # Default version, will be overridden if git tags are 
 
 # Fetch tags from origin to ensure we have the latest
 if git fetch --tags origin; then
-  # Get the latest version tag sorted by version number (e.g., v0.5.7)
-  VERSION_FROM_TAG=$(git tag -l 'v[0-9]*' --sort=-v:refname | head -1)
+  # Prefer the shared helper so stable/post releases sort above rc tags.
+  # Fall back to git's built-in version sort if python3 is unavailable.
+  if command -v python3 >/dev/null 2>&1; then
+    VERSION_FROM_TAG=$(python3 python/tools/get_version_tag.py --tag-only || true)
+  else
+    echo "Warning: python3 not found; falling back to git tag version sort" >&2
+    VERSION_FROM_TAG=$(git tag -l 'v[0-9]*' --sort=-v:refname | head -1)
+  fi
   if [ -n "$VERSION_FROM_TAG" ]; then
     SGLANG_VERSION="$VERSION_FROM_TAG"
     echo "Using SGLang version from git tags: $SGLANG_VERSION"

--- a/scripts/ci/amd/amd_ci_start_container_disagg.sh
+++ b/scripts/ci/amd/amd_ci_start_container_disagg.sh
@@ -6,14 +6,8 @@ SGLANG_VERSION="v0.5.5"   # Default version, will be overridden if git tags are 
 
 # Fetch tags from origin to ensure we have the latest
 if git fetch --tags origin; then
-  # Prefer the shared helper so stable/post releases sort above rc tags.
-  # Fall back to git's built-in version sort if python3 is unavailable.
-  if command -v python3 >/dev/null 2>&1; then
-    VERSION_FROM_TAG=$(python3 python/tools/get_version_tag.py --tag-only || true)
-  else
-    echo "Warning: python3 not found; falling back to git tag version sort" >&2
-    VERSION_FROM_TAG=$(git tag -l 'v[0-9]*' --sort=-v:refname | head -1)
-  fi
+  # Use the shared helper so stable/post releases sort above rc tags.
+  VERSION_FROM_TAG=$(python3 python/tools/get_version_tag.py --tag-only || true)
   if [ -n "$VERSION_FROM_TAG" ]; then
     SGLANG_VERSION="$VERSION_FROM_TAG"
     echo "Using SGLang version from git tags: $SGLANG_VERSION"

--- a/scripts/ci/amd/amd_ci_start_container_disagg.sh
+++ b/scripts/ci/amd/amd_ci_start_container_disagg.sh
@@ -6,8 +6,14 @@ SGLANG_VERSION="v0.5.5"   # Default version, will be overridden if git tags are 
 
 # Fetch tags from origin to ensure we have the latest
 if git fetch --tags origin; then
-  # Get the latest version tag sorted by version number (e.g., v0.5.7)
-  VERSION_FROM_TAG=$(git tag -l 'v[0-9]*' --sort=-v:refname | head -1)
+  # Prefer the shared helper so stable/post releases sort above rc tags.
+  # Fall back to git's built-in version sort if python3 is unavailable.
+  if command -v python3 >/dev/null 2>&1; then
+    VERSION_FROM_TAG=$(python3 python/tools/get_version_tag.py --tag-only || true)
+  else
+    echo "Warning: python3 not found; falling back to git tag version sort" >&2
+    VERSION_FROM_TAG=$(git tag -l 'v[0-9]*' --sort=-v:refname | head -1)
+  fi
   if [ -n "$VERSION_FROM_TAG" ]; then
     SGLANG_VERSION="$VERSION_FROM_TAG"
     echo "Using SGLang version from git tags: $SGLANG_VERSION"


### PR DESCRIPTION
## Summary
- switch AMD nightly docker workflows to the shared PEP 440-aware version helper so `post` and stable tags no longer sort below `rc` tags
- add explicit Python setup in the AMD nightly workflows before calling the helper on `amd-docker-scale`
- update the host-side AMD CI container bootstrap scripts to prefer the helper and fall back to git's built-in sort if `python3` is unavailable

## Test plan
- [x] `python3 test/registered/unit/tools/test_get_version_tag.py`
- [x] `bash -n scripts/ci/amd/amd_ci_start_container.sh`
- [x] `bash -n scripts/ci/amd/amd_ci_start_container_disagg.sh`
- [x] pre-commit hooks during `git commit`

Made with [Cursor](https://cursor.com)