### PR TITLE
[Cookbook] Add Kimi K2.6 speculative decoding + fix draft attention backend

### DIFF
--- a/docs_new/cookbook/autoregressive/Moonshotai/Kimi-K2.5.mdx
+++ b/docs_new/cookbook/autoregressive/Moonshotai/Kimi-K2.5.mdx
@@ -453,6 +453,7 @@ SGLANG_ENABLE_SPEC_V2=1 sglang serve \
   --speculative-eagle-topk 1 \
   --speculative-num-draft-tokens 4 \
   --speculative-draft-model-path lightseekorg/kimi-k2.5-eagle3 \
+  --speculative-draft-attention-backend trtllm_mha \
   --trust-remote-code \
   --host 0.0.0.0 \
   --port 30000
@@ -472,6 +473,7 @@ SGLANG_ENABLE_SPEC_V2=1 sglang serve \
   --speculative-eagle-topk 1 \
   --speculative-num-draft-tokens 4 \
   --speculative-draft-model-path lightseekorg/kimi-k2.5-eagle3 \
+  --speculative-draft-attention-backend trtllm_mha \
   --trust-remote-code \
   --host 0.0.0.0 \
   --port 30000
@@ -1039,6 +1041,7 @@ SGLANG_ENABLE_SPEC_V2=1 sglang serve \
   --speculative-eagle-topk 1 \
   --speculative-num-draft-tokens 4 \
   --speculative-draft-model-path lightseekorg/kimi-k2.5-eagle3 \
+  --speculative-draft-attention-backend trtllm_mha \
   --trust-remote-code \
   --host 0.0.0.0 \
   --port 30000

--- a/docs_new/cookbook/autoregressive/Moonshotai/Kimi-K2.6.mdx
+++ b/docs_new/cookbook/autoregressive/Moonshotai/Kimi-K2.6.mdx
@@ -16,6 +16,7 @@ tag: NEW
 - **Agent Swarms Elevated**: Scales to 300 parallel sub-agents executing 4,000 coordinated steps per run. One prompt, 100+ files.
 - **Proactive Agents**: Powers OpenClaw, Hermes Agent, and other autonomous frameworks for 5-day continuous operation.
 - **Native Multimodality**: Pre-trained on vision–language tokens with MoonViT (400M parameters) for visual understanding, cross-modal reasoning, and agentic tool use grounded in visual inputs.
+- **Speculative Decoding**: EAGLE-based speculative decoding support for lower latency.
 
 **Benchmarks (Open-Source SOTA):**
 
@@ -469,6 +470,28 @@ Let me search for this product and similar items for you.
   Arguments: {"query":"Auntie Anne's Cinnamon Sugar Pretzel"}
 ```
 
+#### 4.2.5 Speculative Decoding
+
+**Nvidia**
+
+Deploy Kimi-K2.6 with the following command (H200/B200, all features enabled):
+
+```shell Command
+SGLANG_ENABLE_SPEC_V2=1 sglang serve \
+  --model-path moonshotai/Kimi-K2.6 \
+  --tp 8 \
+  --reasoning-parser kimi_k2 \
+  --tool-call-parser kimi_k2 \
+  --speculative-algorithm=EAGLE3 \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  --speculative-draft-model-path lightseekorg/kimi-k2.6-eagle3 \
+  --speculative-draft-attention-backend trtllm_mha \
+  --trust-remote-code \
+  --host 0.0.0.0 \
+  --port 30000
+```
 
 ## 5. Benchmark
 

--- a/docs_new/src/snippets/autoregressive/kimi-k25-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/kimi-k25-deployment.jsx
@@ -195,7 +195,7 @@ export const KimiK25Deployment = () => {
 
     // Speculative decoding (EAGLE3)
     if (speculative === 'enabled') {
-      cmd += ' \\\n  --speculative-algorithm EAGLE3 \\\n  --speculative-num-steps 3 \\\n  --speculative-eagle-topk 1 \\\n  --speculative-num-draft-tokens 4 \\\n  --speculative-draft-model-path lightseekorg/kimi-k2.5-eagle3';
+      cmd += ' \\\n  --speculative-algorithm EAGLE3 \\\n  --speculative-num-steps 3 \\\n  --speculative-eagle-topk 1 \\\n  --speculative-num-draft-tokens 4 \\\n  --speculative-draft-model-path lightseekorg/kimi-k2.5-eagle3 \\\n  --speculative-draft-attention-backend trtllm_mha';
     }
 
     // AMD: FP8 KV cache for memory efficiency

--- a/docs_new/src/snippets/autoregressive/kimi-k26-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/kimi-k26-deployment.jsx
@@ -1,5 +1,6 @@
 export const KimiK26Deployment = () => {
   // Config mirrors sgl-cookbook src/components/autoregressive/KimiK26ConfigGenerator/index.js.
+  // Speculative decoding is only supported on H200 and B300.
   const options = {
     hardware: {
       name: 'hardware',
@@ -35,6 +36,15 @@ export const KimiK26Deployment = () => {
       items: [
         { id: 'disabled', label: 'Disabled', subtitle: 'Low Latency', default: true },
         { id: 'enabled', label: 'Enabled', subtitle: 'High Throughput', default: false },
+      ],
+    },
+    speculative: {
+      name: 'speculative',
+      title: 'Speculative Decoding',
+      condition: (values) => values.hardware === 'h200' || values.hardware === 'b300',
+      items: [
+        { id: 'disabled', label: 'Disabled', default: true },
+        { id: 'enabled', label: 'Enabled', default: false },
       ],
     },
   };
@@ -88,15 +98,31 @@ export const KimiK26Deployment = () => {
   };
 
   const generateCommand = () => {
-    const { hardware, reasoning, toolcall, dpattention } = values;
+    const { hardware, reasoning, toolcall, dpattention, speculative } = values;
     const isAMD = hardware === 'mi300x' || hardware === 'mi325x' || hardware === 'mi350x' || hardware === 'mi355x';
     const hwConfig = modelConfigs[hardware];
     const tpValue = hwConfig.tp;
 
+    // Speculative decoding only supported on H200 and B300
+    if (speculative === 'enabled' && hardware !== 'h200' && hardware !== 'b300') {
+      return '# Speculative Decoding for Kimi-K2.6 is only supported on H200 and B300';
+    }
+
     let cmd = '';
 
+    // AMD ROCm environment variables
     if (isAMD) {
-      cmd += 'SGLANG_USE_AITER=1 SGLANG_ROCM_FUSED_DECODE_MLA=0 \\\n';
+      cmd += 'SGLANG_USE_AITER=1 SGLANG_ROCM_FUSED_DECODE_MLA=0 ';
+    }
+
+    // Speculative decoding env var
+    if (speculative === 'enabled') {
+      cmd += 'SGLANG_ENABLE_SPEC_V2=1 ';
+    }
+
+    // If we added any env vars above, break to a new line for readability
+    if (isAMD || speculative === 'enabled') {
+      cmd += '\\\n';
     }
 
     cmd += 'sglang serve \\\n';
@@ -117,6 +143,11 @@ export const KimiK26Deployment = () => {
 
     if (toolcall === 'enabled') {
       cmd += ' \\\n  --tool-call-parser kimi_k2';
+    }
+
+    // Speculative decoding (EAGLE3)
+    if (speculative === 'enabled') {
+      cmd += ' \\\n  --speculative-algorithm EAGLE3 \\\n  --speculative-num-steps 3 \\\n  --speculative-eagle-topk 1 \\\n  --speculative-num-draft-tokens 4 \\\n  --speculative-draft-model-path lightseekorg/kimi-k2.6-eagle3 \\\n  --speculative-draft-attention-backend trtllm_mha';
     }
 
     if (isAMD) {


### PR DESCRIPTION
## Summary

- Add EAGLE3 speculative decoding support for Kimi K2.6 (matching K2.5 setup).
- Add explicit `--speculative-draft-attention-backend trtllm_mha` flag to both K2.5 and K2.6 to prevent draft model from incorrectly inheriting target model's `trtllm_mla` backend. See #23490.