### PR TITLE
docs: add external MLLM DLLM adapter integration checklist

### DIFF
--- a/docs/supported_models/extending/support_new_models.md
+++ b/docs/supported_models/extending/support_new_models.md
@@ -512,7 +512,7 @@ python -m sglang.launch_server \
 
 ### Integration checklist for MLLM + DLLM external adapters
 
-When adapting multimodal diffusion models through `SGLANG_EXTERNAL_*` plugins, keep the
+When adapting multimodal and diffusion models through `SGLANG_EXTERNAL_*` plugins, keep the
 adapter `forward()` logic minimal and aligned with built-in multimodal models:
 
 - Avoid preprocessing `input_ids` in adapter `forward()` unless required by the model

--- a/docs/supported_models/extending/support_new_models.md
+++ b/docs/supported_models/extending/support_new_models.md
@@ -510,6 +510,21 @@ python -m sglang.launch_server \
     --enable-multimodal
 ```
 
+### Integration checklist for MLLM + DLLM external adapters
+
+When adapting multimodal diffusion models through `SGLANG_EXTERNAL_*` plugins, keep the
+adapter `forward()` logic minimal and aligned with built-in multimodal models:
+
+- Avoid preprocessing `input_ids` in adapter `forward()` unless required by the model
+  architecture and validated end-to-end.
+- Do not manually override `forward_batch.mm_inputs`; let SGLang's multimodal embed
+  routine manage multimodal state ownership and lifecycle.
+- Validate CUDA graph compatibility for your model path. If needed during bring-up,
+  use `--disable-cuda-graph` first, then re-enable after correctness validation.
+
+This helps preserve expected multimodal alignment and scheduler behavior across
+prefill/chunked prefill/DLLM iterations.
+
 ## Documentation
 
 Add to table of supported models in [generative_models.md](../text_generation/generative_models.md) or [multimodal_language_models.md](../text_generation/multimodal_language_models.md)

--- a/docs_new/docs/supported-models/support_new_models.mdx
+++ b/docs_new/docs/supported-models/support_new_models.mdx
@@ -514,7 +514,7 @@ python -m sglang.launch_server \
 
 ### Integration checklist for MLLM + DLLM external adapters
 
-When adapting multimodal diffusion models through `SGLANG_EXTERNAL_*` plugins, keep the
+When adapting multimodal and diffusion models through `SGLANG_EXTERNAL_*` plugins, keep the
 adapter `forward()` logic minimal and aligned with built-in multimodal models:
 
 - Avoid preprocessing `input_ids` in adapter `forward()` unless required by the model

--- a/docs_new/docs/supported-models/support_new_models.mdx
+++ b/docs_new/docs/supported-models/support_new_models.mdx
@@ -512,6 +512,21 @@ python -m sglang.launch_server \
     --enable-multimodal
 ```
 
+### Integration checklist for MLLM + DLLM external adapters
+
+When adapting multimodal diffusion models through `SGLANG_EXTERNAL_*` plugins, keep the
+adapter `forward()` logic minimal and aligned with built-in multimodal models:
+
+- Avoid preprocessing `input_ids` in adapter `forward()` unless required by the model
+  architecture and validated end-to-end.
+- Do not manually override `forward_batch.mm_inputs`; let SGLang's multimodal embed
+  routine manage multimodal state ownership and lifecycle.
+- Validate CUDA graph compatibility for your model path. If needed during bring-up,
+  use `--disable-cuda-graph` first, then re-enable after correctness validation.
+
+This helps preserve expected multimodal alignment and scheduler behavior across
+prefill/chunked prefill/DLLM iterations.
+
 ## Documentation
 
 Add to table of supported models in [generative_models.md](./generative_models) or [multimodal_language_models.md](./multimodal_language_models)


### PR DESCRIPTION
Summary
This PR updates the external model extension guide for multimodal diffusion adapters (MLLM + DLLM) with an integration checklist.

It adds practical guidance to keep adapter behavior aligned with SGLang built-in multimodal paths, including:
1.minimizing custom preprocessing in adapter forward(),
2.leaving multimodal runtime state ownership (forward_batch.mm_inputs) to framework routines
3.validating CUDA graph compatibility in a staged way during bring-up.
Both legacy docs and docs_new are updated to keep the guidance consistent.

Motivation
External multimodal diffusion adapters are increasingly integrated via SGLANG_EXTERNAL_* plugin paths.
A concise checklist helps reduce integration drift and improves first-pass correctness when adapting new models.

Changes
1.Updated docs/supported_models/extending/support_new_models.md
2.Updated docs_new/docs/supported-models/support_new_models.mdx
3.Added an “Integration checklist for MLLM + DLLM external adapters” section in both files.

Test Plan
Docs-only change.
Verified content parity between docs and docs_new sections.
No runtime code path changes.

Scope
Documentation only (no functional/runtime behavior change).