### PR TITLE
examples: add MinerU diffusion external plugin scaffold

### DIFF
--- a/examples/runtime/mineru_diffusion_external_plugin/README.md
+++ b/examples/runtime/mineru_diffusion_external_plugin/README.md
@@ -1,0 +1,48 @@
+# MinerU Diffusion External Plugin (Example)
+
+This example shows how to package an external multimodal diffusion model adapter
+for SGLang via `SGLANG_EXTERNAL_*` environment variables.
+
+The plugin targets the architecture name:
+
+- `MinerUDiffusionForConditionalGeneration`
+
+and demonstrates:
+
+- external model class registration via `EntryClass`,
+- external multimodal processor registration,
+- external architecture declaration for multimodal runtime,
+- DLLM launch configuration for diffusion decoding.
+
+## Directory layout
+
+```text
+examples/runtime/mineru_diffusion_external_plugin/
+├── README.md
+├── dllm_config.yaml
+└── mineru_sglang_plugin/
+    ├── __init__.py
+    ├── configuration_mineru_diffusion.py
+    ├── processing_mineru_diffusion.py
+    ├── mm_processor_mineru.py
+    └── modeling_mineru_diffusion.py
+```
+
+## How to use
+
+Install this package in your runtime image/environment, then launch:
+
+```bash
+export SGLANG_EXTERNAL_MODEL_PACKAGE=mineru_sglang_plugin
+export SGLANG_EXTERNAL_MM_MODEL_ARCH=MinerUDiffusionForConditionalGeneration
+export SGLANG_EXTERNAL_MM_PROCESSOR_PACKAGE=mineru_sglang_plugin
+
+python -m sglang.launch_server \
+  --model-path /path/to/model \
+  --enable-multimodal \
+  --dllm-algorithm LowConfidence \
+  --dllm-algorithm-config /path/to/dllm_config.yaml
+```
+
+> Note: this example is provided as an external-plugin reference. It is not
+> wired into SGLang's built-in model registry by default.

--- a/examples/runtime/mineru_diffusion_external_plugin/README.md
+++ b/examples/runtime/mineru_diffusion_external_plugin/README.md
@@ -40,6 +40,7 @@ export SGLANG_EXTERNAL_MM_PROCESSOR_PACKAGE=mineru_sglang_plugin
 python -m sglang.launch_server \
   --model-path /path/to/model \
   --enable-multimodal \
+  --disable-fast-image-processor \
   --dllm-algorithm LowConfidence \
   --dllm-algorithm-config /path/to/dllm_config.yaml
 ```

--- a/examples/runtime/mineru_diffusion_external_plugin/dllm_config.yaml
+++ b/examples/runtime/mineru_diffusion_external_plugin/dllm_config.yaml
@@ -1,0 +1,3 @@
+# DLLM config for MinerU diffusion decoding.
+threshold: 0.95
+block_size: 32

--- a/examples/runtime/mineru_diffusion_external_plugin/mineru_sglang_plugin/__init__.py
+++ b/examples/runtime/mineru_diffusion_external_plugin/mineru_sglang_plugin/__init__.py
@@ -1,0 +1,24 @@
+"""MinerU-Diffusion plugin for SGLang external model loading."""
+
+from .configuration_mineru_diffusion import MinerUDiffusionConfig, SDARConfig
+
+try:
+    from transformers import AutoConfig
+
+    AutoConfig.register("mineru_diffusion", MinerUDiffusionConfig, exist_ok=True)
+    AutoConfig.register("sdar", SDARConfig, exist_ok=True)
+except Exception:
+    pass
+
+
+def _lazy_entry_class():
+    from .modeling_mineru_diffusion import MinerUDiffusionForConditionalGeneration
+
+    return MinerUDiffusionForConditionalGeneration
+
+
+__all__ = [
+    "MinerUDiffusionConfig",
+    "SDARConfig",
+    "_lazy_entry_class",
+]

--- a/examples/runtime/mineru_diffusion_external_plugin/mineru_sglang_plugin/__init__.py
+++ b/examples/runtime/mineru_diffusion_external_plugin/mineru_sglang_plugin/__init__.py
@@ -1,14 +1,20 @@
 """MinerU-Diffusion plugin for SGLang external model loading."""
 
+import logging
+
 from .configuration_mineru_diffusion import MinerUDiffusionConfig, SDARConfig
+
+logger = logging.getLogger(__name__)
 
 try:
     from transformers import AutoConfig
 
     AutoConfig.register("mineru_diffusion", MinerUDiffusionConfig, exist_ok=True)
     AutoConfig.register("sdar", SDARConfig, exist_ok=True)
-except Exception:
-    pass
+except ImportError:
+    logger.warning("transformers is not available; AutoConfig registration is skipped.")
+except Exception as exc:
+    logger.warning("AutoConfig registration failed: %s", exc)
 
 
 def _lazy_entry_class():

--- a/examples/runtime/mineru_diffusion_external_plugin/mineru_sglang_plugin/configuration_mineru_diffusion.py
+++ b/examples/runtime/mineru_diffusion_external_plugin/mineru_sglang_plugin/configuration_mineru_diffusion.py
@@ -1,0 +1,168 @@
+"""Config classes for MinerU-Diffusion external adapter."""
+
+from transformers import PretrainedConfig
+from transformers.modeling_rope_utils import rope_config_validation
+from transformers.models.qwen2_vl.configuration_qwen2_vl import Qwen2VLVisionConfig
+
+
+class SDARConfig(PretrainedConfig):
+    model_type = "sdar"
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    def __init__(
+        self,
+        vocab_size=151936,
+        hidden_size=2048,
+        intermediate_size=6144,
+        num_hidden_layers=28,
+        num_attention_heads=16,
+        num_key_value_heads=8,
+        head_dim=128,
+        hidden_act="silu",
+        max_position_embeddings=32768,
+        initializer_range=0.02,
+        rms_norm_eps=1e-6,
+        use_cache=True,
+        tie_word_embeddings=False,
+        rope_theta=1000000.0,
+        rope_scaling=None,
+        attention_bias=False,
+        use_sliding_window=False,
+        sliding_window=None,
+        max_window_layers=28,
+        attention_dropout=0.0,
+        **kwargs,
+    ):
+        self.vocab_size = vocab_size
+        self.max_position_embeddings = max_position_embeddings
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.use_sliding_window = use_sliding_window
+        self.sliding_window = sliding_window
+        self.max_window_layers = max_window_layers
+        self.num_key_value_heads = (
+            num_attention_heads if num_key_value_heads is None else num_key_value_heads
+        )
+        self.head_dim = head_dim
+        self.hidden_act = hidden_act
+        self.initializer_range = initializer_range
+        self.rms_norm_eps = rms_norm_eps
+        self.use_cache = use_cache
+        self.rope_theta = rope_theta
+        self.rope_scaling = rope_scaling
+        self.attention_bias = attention_bias
+        self.attention_dropout = attention_dropout
+        if self.rope_scaling is not None and "type" in self.rope_scaling:
+            self.rope_scaling["rope_type"] = self.rope_scaling["type"]
+        rope_config_validation(self)
+        super().__init__(tie_word_embeddings=tie_word_embeddings, **kwargs)
+
+
+class MinerUDiffusionConfig(PretrainedConfig):
+    model_type = "mineru_diffusion"
+    sub_configs = {"vision_config": Qwen2VLVisionConfig, "text_config": SDARConfig}
+    keys_to_ignore_at_inference = ["past_key_values"]
+    architectures = ["MinerUDiffusionForConditionalGeneration"]
+
+    def __init__(
+        self,
+        text_config=None,
+        vision_config=None,
+        language_model_config=None,
+        vision_model_config=None,
+        image_token_id=151655,
+        video_token_id=151656,
+        vision_start_token_id=151652,
+        vision_end_token_id=151653,
+        mask_token_id=151669,
+        image_size=512,
+        patch_size=16,
+        downsample_ratio=0.5,
+        vision_projector_type="patch_merger2x",
+        vision_select_layer=-2,
+        tie_word_embeddings=False,
+        **kwargs,
+    ):
+        kwargs.pop("rm_vit_merger", None)
+        top_level_torch_dtype = kwargs.pop("torch_dtype", None)
+        if text_config is None:
+            text_config = language_model_config
+        if vision_config is None:
+            vision_config = vision_model_config
+
+        if isinstance(text_config, dict):
+            self.text_config = SDARConfig(**text_config)
+        elif text_config is None:
+            self.text_config = SDARConfig()
+        else:
+            self.text_config = text_config
+
+        if isinstance(vision_config, dict):
+            vision_model_type = vision_config.get("model_type", "")
+            if vision_model_type != "qwen2_vl":
+                raise ValueError(f"Unsupported vision config type: {vision_model_type}")
+            self.vision_config = Qwen2VLVisionConfig(**vision_config)
+        elif vision_config is None:
+            self.vision_config = Qwen2VLVisionConfig()
+        else:
+            self.vision_config = vision_config
+
+        self.image_token_id = image_token_id
+        self.video_token_id = video_token_id
+        self.vision_start_token_id = vision_start_token_id
+        self.vision_end_token_id = vision_end_token_id
+        self.mask_token_id = mask_token_id
+        self.image_size = image_size
+        self.patch_size = patch_size
+        self.downsample_ratio = downsample_ratio
+        self.vision_projector_type = vision_projector_type
+        self.vision_select_layer = vision_select_layer
+        self.tie_word_embeddings = tie_word_embeddings
+
+        super().__init__(
+            tie_word_embeddings=tie_word_embeddings,
+            bos_token_id=getattr(self.text_config, "bos_token_id", None),
+            eos_token_id=getattr(self.text_config, "eos_token_id", None),
+            pad_token_id=getattr(self.text_config, "pad_token_id", None),
+            **kwargs,
+        )
+        self.torch_dtype = getattr(self.text_config, "torch_dtype", top_level_torch_dtype)
+
+        for attr in (
+            "hidden_size",
+            "intermediate_size",
+            "num_hidden_layers",
+            "num_attention_heads",
+            "num_key_value_heads",
+            "head_dim",
+            "hidden_act",
+            "max_position_embeddings",
+            "rms_norm_eps",
+            "rope_theta",
+            "rope_scaling",
+            "attention_bias",
+            "attention_dropout",
+            "vocab_size",
+            "use_sliding_window",
+            "sliding_window",
+            "max_window_layers",
+        ):
+            if not hasattr(self, attr):
+                setattr(self, attr, getattr(self.text_config, attr, None))
+
+    @property
+    def language_model_config(self):
+        return self.text_config
+
+    @property
+    def vision_model_config(self):
+        return self.vision_config
+
+    @property
+    def vision_model_type(self):
+        return getattr(self.vision_config, "model_type", None)
+
+
+__all__ = ["MinerUDiffusionConfig", "SDARConfig"]

--- a/examples/runtime/mineru_diffusion_external_plugin/mineru_sglang_plugin/mm_processor_mineru.py
+++ b/examples/runtime/mineru_diffusion_external_plugin/mineru_sglang_plugin/mm_processor_mineru.py
@@ -1,0 +1,34 @@
+"""Multimodal processor registration for MinerU external architecture."""
+
+import logging
+
+from sglang.srt.multimodal.processors.qwen_vl import QwenVLImageProcessor
+
+logger = logging.getLogger(__name__)
+
+
+class MinerUDiffusionForConditionalGeneration:
+    """Name-only placeholder used for processor registration."""
+
+
+class MinerUDiffusionProcessor(QwenVLImageProcessor):
+    """Reuse Qwen-VL image processor for MinerU's Qwen2-VL-based visual inputs."""
+
+    models = [MinerUDiffusionForConditionalGeneration]
+
+    def __init__(self, hf_config, server_args, _processor, *args, **kwargs):
+        super().__init__(hf_config, server_args, _processor, *args, **kwargs)
+        if not self.server_args.disable_fast_image_processor:
+            logger.warning(
+                "Disable fast image processor for MinerU to avoid tokenizer "
+                "kwargs incompatibility (`device` argument)."
+            )
+        self.server_args.disable_fast_image_processor = True
+
+        if self.model_type == "mineru_diffusion":
+            logger.info(
+                "Map MinerU processor model_type from `%s` to `qwen2_vl` for "
+                "mRoPE index compatibility.",
+                self.model_type,
+            )
+            self.model_type = "qwen2_vl"

--- a/examples/runtime/mineru_diffusion_external_plugin/mineru_sglang_plugin/mm_processor_mineru.py
+++ b/examples/runtime/mineru_diffusion_external_plugin/mineru_sglang_plugin/mm_processor_mineru.py
@@ -18,12 +18,11 @@ class MinerUDiffusionProcessor(QwenVLImageProcessor):
 
     def __init__(self, hf_config, server_args, _processor, *args, **kwargs):
         super().__init__(hf_config, server_args, _processor, *args, **kwargs)
-        if not self.server_args.disable_fast_image_processor:
-            logger.warning(
-                "Disable fast image processor for MinerU to avoid tokenizer "
-                "kwargs incompatibility (`device` argument)."
+        if not server_args.disable_fast_image_processor:
+            raise ValueError(
+                "MinerU external processor requires --disable-fast-image-processor. "
+                "Please set it in launch args to avoid tokenizer kwargs incompatibility."
             )
-        self.server_args.disable_fast_image_processor = True
 
         if self.model_type == "mineru_diffusion":
             logger.info(

--- a/examples/runtime/mineru_diffusion_external_plugin/mineru_sglang_plugin/modeling_mineru_diffusion.py
+++ b/examples/runtime/mineru_diffusion_external_plugin/mineru_sglang_plugin/modeling_mineru_diffusion.py
@@ -1,0 +1,45 @@
+"""Skeleton external model entry for MinerU diffusion architecture.
+
+This file demonstrates wiring for an external multimodal architecture name via
+`EntryClass`. Replace this skeleton with a full model port for production use.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.models.qwen2_vl import Qwen2VLForConditionalGeneration
+
+
+class MinerUDiffusionForConditionalGeneration(Qwen2VLForConditionalGeneration):
+    """Minimal external-entry skeleton.
+
+    Notes:
+    - Keeps forward path aligned with built-in multimodal model behavior.
+    - Intended as an example container for external registration and processor
+      wiring.
+    """
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: Optional[torch.Tensor] = None,
+        get_embedding: bool = False,
+    ):
+        return super().forward(
+            input_ids=input_ids,
+            positions=positions,
+            forward_batch=forward_batch,
+            input_embeds=input_embeds,
+            get_embedding=get_embedding,
+        )
+
+
+EntryClass = MinerUDiffusionForConditionalGeneration
+
+__all__ = ["MinerUDiffusionForConditionalGeneration", "EntryClass"]

--- a/examples/runtime/mineru_diffusion_external_plugin/mineru_sglang_plugin/processing_mineru_diffusion.py
+++ b/examples/runtime/mineru_diffusion_external_plugin/mineru_sglang_plugin/processing_mineru_diffusion.py
@@ -8,7 +8,7 @@ from transformers.image_utils import load_image
 from transformers.processing_utils import ProcessorMixin
 
 
-class MinerUDiffusionProcessor(ProcessorMixin):
+class MinerUDiffusionHFProcessor(ProcessorMixin):
     attributes = ["image_processor", "tokenizer"]
     valid_kwargs = ["chat_template"]
     optional_attributes = ["chat_template"]
@@ -56,26 +56,25 @@ class MinerUDiffusionProcessor(ProcessorMixin):
         }
 
     def _expand_image_tokens(self, text, image_grid_thw):
-        expanded_text = list(text)
         image_token_lengths = (image_grid_thw.prod(dim=1) // (self.downsample_size**2)).tolist()
         image_index = 0
-        for index in range(len(expanded_text)):
-            while self.image_token in expanded_text[index]:
+        new_text = []
+        for t in text:
+            parts = t.split(self.image_token)
+            expanded_t = parts[0]
+            for i in range(1, len(parts)):
                 if image_index >= len(image_token_lengths):
                     raise ValueError("Wrong image token count, more image tokens than processed images.")
-                expanded_text[index] = expanded_text[index].replace(
-                    self.image_token,
-                    "<|placeholder|>" * image_token_lengths[image_index],
-                    1,
-                )
+                expanded_t += self.image_token * image_token_lengths[image_index]
+                expanded_t += parts[i]
                 image_index += 1
-            expanded_text[index] = expanded_text[index].replace("<|placeholder|>", self.image_token)
+            new_text.append(expanded_t)
         if image_index != len(image_token_lengths):
             raise ValueError(
                 "Wrong image token count, "
                 f"image_token_count({image_index}) != image_count({len(image_token_lengths)})"
             )
-        return expanded_text
+        return new_text
 
     @staticmethod
     def _count_image_embeds(image_grid_thw, downsample_size):
@@ -133,3 +132,7 @@ class MinerUDiffusionProcessor(ProcessorMixin):
         tokenizer_input_names = self.tokenizer.model_input_names
         image_processor_input_names = self.image_processor.model_input_names
         return list(dict.fromkeys(tokenizer_input_names + image_processor_input_names))
+
+
+# Backward-compatible alias for external imports using previous class name.
+MinerUDiffusionProcessor = MinerUDiffusionHFProcessor

--- a/examples/runtime/mineru_diffusion_external_plugin/mineru_sglang_plugin/processing_mineru_diffusion.py
+++ b/examples/runtime/mineru_diffusion_external_plugin/mineru_sglang_plugin/processing_mineru_diffusion.py
@@ -1,0 +1,135 @@
+"""Processor class for MinerU-Diffusion."""
+
+from typing import Union
+
+import torch
+from transformers.feature_extraction_utils import BatchFeature
+from transformers.image_utils import load_image
+from transformers.processing_utils import ProcessorMixin
+
+
+class MinerUDiffusionProcessor(ProcessorMixin):
+    attributes = ["image_processor", "tokenizer"]
+    valid_kwargs = ["chat_template"]
+    optional_attributes = ["chat_template"]
+    image_processor_class = "AutoImageProcessor"
+    tokenizer_class = ("Qwen2Tokenizer", "Qwen2TokenizerFast")
+
+    special_tokens = ["<|image_pad|>", "<|vision_start|>", "<|vision_end|>"]
+
+    def __init__(self, image_processor=None, tokenizer=None, chat_template=None, **kwargs):
+        if chat_template == "auto":
+            chat_template = tokenizer.chat_template
+        super().__init__(image_processor, tokenizer, chat_template=chat_template)
+        self.downsample_size = kwargs.pop("downsample_size", 2)
+        self.image_token = kwargs.pop(
+            "image_token",
+            getattr(tokenizer, "image_token", "<|image_pad|>"),
+        )
+        self.special_tokens = kwargs.pop(
+            "special_tokens",
+            ["<|image_pad|>", "<|vision_start|>", "<|vision_end|>"],
+        )
+
+        try:
+            self.tokenizer.add_special_tokens(
+                {"additional_special_tokens": self.special_tokens},
+                replace_additional_special_tokens=False,
+            )
+        except TypeError:
+            self.tokenizer.add_special_tokens({"additional_special_tokens": self.special_tokens})
+        self.image_token_id = (
+            tokenizer.image_token_id
+            if getattr(tokenizer, "image_token_id", None) is not None
+            else tokenizer.convert_tokens_to_ids(self.image_token)
+        )
+
+    def _process_images(self, images) -> dict:
+        loaded_images = [load_image(image) for image in images]
+        if loaded_images:
+            return self.image_processor(images=loaded_images, return_tensors="pt")
+
+        patch_size = getattr(self.image_processor, "patch_size", 14)
+        return {
+            "pixel_values": torch.zeros((0, 3 * 2 * (patch_size**2)), dtype=torch.float32),
+            "image_grid_thw": torch.zeros((0, 3), dtype=torch.int64),
+        }
+
+    def _expand_image_tokens(self, text, image_grid_thw):
+        expanded_text = list(text)
+        image_token_lengths = (image_grid_thw.prod(dim=1) // (self.downsample_size**2)).tolist()
+        image_index = 0
+        for index in range(len(expanded_text)):
+            while self.image_token in expanded_text[index]:
+                if image_index >= len(image_token_lengths):
+                    raise ValueError("Wrong image token count, more image tokens than processed images.")
+                expanded_text[index] = expanded_text[index].replace(
+                    self.image_token,
+                    "<|placeholder|>" * image_token_lengths[image_index],
+                    1,
+                )
+                image_index += 1
+            expanded_text[index] = expanded_text[index].replace("<|placeholder|>", self.image_token)
+        if image_index != len(image_token_lengths):
+            raise ValueError(
+                "Wrong image token count, "
+                f"image_token_count({image_index}) != image_count({len(image_token_lengths)})"
+            )
+        return expanded_text
+
+    @staticmethod
+    def _count_image_embeds(image_grid_thw, downsample_size):
+        return int((image_grid_thw.prod(dim=1) // (downsample_size**2)).sum().item())
+
+    def _validate_image_inputs(self, input_ids, image_grid_thw):
+        if isinstance(input_ids, torch.Tensor):
+            image_token_count = torch.count_nonzero(input_ids == self.image_token_id).item()
+        else:
+            image_token_count = sum(row.count(self.image_token_id) for row in input_ids)
+        image_embed_count = self._count_image_embeds(image_grid_thw, self.downsample_size)
+        if image_token_count != image_embed_count:
+            raise ValueError(
+                "Wrong image embed token count, "
+                f"image_embed_token_count({image_token_count}) != image_embed_count({image_embed_count})"
+            )
+
+    def __call__(self, images=None, text=None, **kwargs) -> BatchFeature:
+        if images is None:
+            images = []
+        return_tensors = kwargs.pop("return_tensors", None)
+        image_inputs = self._process_images(images)
+        if text is None:
+            return BatchFeature(data=image_inputs, tensor_type=return_tensors)
+
+        if not isinstance(text, list):
+            text = [text]
+        text = self._expand_image_tokens(list(text), image_inputs["image_grid_thw"])
+        text_inputs = self.tokenizer(text, return_tensors=return_tensors, **kwargs)
+        self._validate_image_inputs(text_inputs["input_ids"], image_inputs["image_grid_thw"])
+        return BatchFeature(data={**text_inputs, **image_inputs}, tensor_type=return_tensors)
+
+    def batch_decode(self, *args, **kwargs):
+        return self.tokenizer.batch_decode(*args, **kwargs)
+
+    def decode(self, *args, **kwargs):
+        return self.tokenizer.decode(*args, **kwargs)
+
+    def post_process_image_text_to_text(
+        self,
+        generated_outputs: Union[list, torch.Tensor],
+        skip_special_tokens: bool = True,
+        clean_up_tokenization_spaces: bool = False,
+        **kwargs,
+    ):
+        return self.tokenizer.batch_decode(
+            generated_outputs,
+            skip_special_tokens=skip_special_tokens,
+            clean_up_tokenization_spaces=clean_up_tokenization_spaces,
+            **kwargs,
+        )
+
+    @property
+    def model_input_names(self):
+        tokenizer_input_names = self.tokenizer.model_input_names
+        image_processor_input_names = self.image_processor.model_input_names
+        return list(dict.fromkeys(tokenizer_input_names + image_processor_input_names))

--- a/examples/runtime/mineru_diffusion_external_plugin/setup.py
+++ b/examples/runtime/mineru_diffusion_external_plugin/setup.py
@@ -1,0 +1,7 @@
+from setuptools import find_packages, setup
+
+setup(
+    name="sglang-mineru-diffusion-external-plugin-example",
+    version="0.0.1",
+    packages=find_packages(),
+)


### PR DESCRIPTION
## Summary

This PR adds a runnable external-plugin scaffold for a MinerU-style multimodal diffusion architecture under `examples/runtime`.

The goal is to provide a concrete reference for users integrating external MLLM + DLLM models through `SGLANG_EXTERNAL_*` entry points, without modifying SGLang core runtime/model registry.

## What is added

New example directory:

- `examples/runtime/mineru_diffusion_external_plugin/`

Contents:

- `setup.py` for packaging
- `README.md` with launch flow and env setup
- `dllm_config.yaml` for diffusion decoding config
- `mineru_sglang_plugin/__init__.py` for config registration and lazy entry wiring
- `mineru_sglang_plugin/configuration_mineru_diffusion.py` (config classes)
- `mineru_sglang_plugin/processing_mineru_diffusion.py` (processor implementation)
- `mineru_sglang_plugin/mm_processor_mineru.py` (MM processor registration)
- `mineru_sglang_plugin/modeling_mineru_diffusion.py` (external entry skeleton)

## Design intent

- Keep this as an **external plugin example** (not a built-in model integration).
- Demonstrate the end-to-end wiring pattern:
  - architecture naming,
  - multimodal processor registration,
  - external model package discovery,
  - DLLM launch configuration.

## Scope / non-goals

- No changes to SGLang core runtime behavior.
- No built-in model registry updates.
- This PR focuses on example scaffolding and integration wiring only.

## Test plan

- Python syntax check on all new example files (`py_compile`).
- Manual verification of package layout and environment-variable-based launch flow in README.
- Docs/examples-only addition; no existing tests modified.

## Why this is useful

Users adapting external multimodal diffusion models currently need to assemble several moving pieces (EntryClass, MM processor mapping, DLLM config, env wiring).  
This scaffold provides a concrete, versionable template to reduce integration friction and onboarding time.