### PR TITLE
[Diffusion][NPU][Bugfix] Ascend_fa crashes when sequence parallelism is used.

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/ascend_fa.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/ascend_fa.py
@@ -77,6 +77,7 @@ class AscendFAImpl(AttentionImpl):
         return_softmax_lse: bool = False,
     ) -> torch.Tensor:
         mask = None
+        num_heads, num_key_value_heads = query.shape[2], key.shape[2]
         if self.causal:
             seq_len = query.shape[1]
             mask = torch.triu(
@@ -90,8 +91,8 @@ class AscendFAImpl(AttentionImpl):
             query,
             key,
             value,
-            num_heads=query.shape[1],
-            num_key_value_heads=key.shape[1],
+            num_heads=num_heads,
+            num_key_value_heads=num_key_value_heads,
             scale=self.softmax_scale,
             input_layout="BNSD",
             softmax_lse_flag=return_softmax_lse,

--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/ascend_fa.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/ascend_fa.py
@@ -67,8 +67,6 @@ class AscendFAImpl(AttentionImpl):
     ) -> None:
         self.causal = causal
         self.softmax_scale = softmax_scale
-        self.num_heads = num_heads
-        self.num_kv_heads = num_kv_heads or num_heads
 
     def forward(
         self,
@@ -92,8 +90,8 @@ class AscendFAImpl(AttentionImpl):
             query,
             key,
             value,
-            num_heads=self.num_heads,
-            num_key_value_heads=self.num_kv_heads,
+            num_heads=query.shape[1],
+            num_key_value_heads=key.shape[1],
             scale=self.softmax_scale,
             input_layout="BNSD",
             softmax_lse_flag=return_softmax_lse,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

```Ascend_fa``` backend crashes when sequence parallelism with ulysses is used.

A command that reproduces the problem:
```
sglang generate --model-path /Wan-AI/Wan2.2-T2V-A14B-Diffusers/ --prompt "Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage" --height 480 --width 640 --tp-size 2 --sp-degree 4 --num-gpus 8 --num-frames 81 --num-inference-steps 40 --port 32000 --dit-cpu-offload False --warmup --output-path --attention-backend "fa"
```
Part of the logs:
```
RuntimeError: npu_fused_infer_attention_score_symint:build/CMakeFiles/torch_npu.dir/compiler_depend.ts:208 NPU function error: call aclnnFusedInferAttentionScoreV3 failed, error code is 561002
[ERROR] 2026-04-23-21:39:27 (PID:243306, Device:4, RankID:4) ERR00100 PTA call acl api failed.
EZ9999: Inner Error!
EZ9999[PID: 243306] 2026-04-23-21:39:27.694.424 (EZ9999):  [CheckQShape] query layout is BNSD, shape [1, 5, 25200, 128] should be equal to [1, 20, 25200, 128].[FUNC:CompareShape][FILE:fia_tiling_shape.cpp][LINE:351]
        TraceBack (most recent call last):
       FusedInferAttentionScore do tiling failed, ret is -1.
       Check NnopbaseExecutorDoTiling(executor) failed
       Check NnopbaseExecutorTilingAndUpdateBinInfo(executor) failed
       Check NnopbaseExecutorMatchCache(executor) failed
       Check NnopbaseRunForWorkspace(*executor, workspaceSize) failed
```


## Modifications

Currently, the ```num_heads``` and ```num_kv_heads``` parameters in the ```AscendFAImpl.__init__()``` function are not valid when sp-degree > 1; in this case need to specify the actual values ​​from the input query and key tensors.

Actual value of the input parameter ```num_heads```  with ```ulysses-degree > 1``` equals ```num_heads / ulysses-degree```.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
