### PR TITLE
[AMD] fused qk gemma norm kernels to reduce four kernels 

### DIFF
--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -79,6 +79,7 @@ from sglang.srt.models.qwen2_moe import Qwen2MoeMLP, Qwen2MoeSparseMoeBlock
 
 # Models
 from sglang.srt.models.qwen3_vl import Qwen3VLForConditionalGeneration
+from sglang.srt.models.utils import fused_qk_gemma_rmsnorm
 from sglang.srt.server_args import get_global_server_args
 
 # Utils
@@ -105,7 +106,6 @@ _is_gfx95 = is_gfx95_supported()
 _is_hip = is_hip()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 _is_amx_available = cpu_has_amx_support()
-
 
 cached_get_processor = lru_cache(get_processor)
 
@@ -791,6 +791,15 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
                 k_by_head = k.reshape(-1, self.head_dim)
                 k_by_head = self.k_norm(k_by_head)
             current_stream.wait_stream(self.alt_stream)
+        elif _is_hip:
+            q_by_head, k_by_head = fused_qk_gemma_rmsnorm(
+                q,
+                k,
+                self.q_norm.weight.data,
+                self.k_norm.weight.data,
+                self.q_norm.variance_epsilon,
+                self.head_dim,
+            )
         else:
             q_by_head = q.reshape(-1, self.head_dim)
             q_by_head = self.q_norm(q_by_head)

--- a/python/sglang/srt/models/utils.py
+++ b/python/sglang/srt/models/utils.py
@@ -21,6 +21,8 @@ from typing import TYPE_CHECKING, Any, Optional, Tuple
 
 import numpy as np
 import torch
+import triton
+import triton.language as tl
 
 from sglang.jit_kernel.norm import can_use_fused_inplace_qknorm, fused_inplace_qknorm
 from sglang.srt.environ import envs
@@ -451,6 +453,99 @@ def apply_qk_norm(
     q = q_by_head.view(q.shape)
     k = k_by_head.view(k.shape)
     return q, k
+
+
+# ---------------------------------------------------------------------------
+# Fused QK GemmaRMSNorm Triton kernel
+# grid = q_rows (the larger dimension in GQA).  Every block computes Q norm
+# for its row; the first k_rows blocks also compute K norm.  No torch.cat,
+# no tl.where for weight selection, no output slice.
+# ---------------------------------------------------------------------------
+@triton.jit
+def _fused_qk_gemma_rmsnorm_kernel(
+    Q_ptr,
+    K_ptr,
+    Q_out_ptr,
+    K_out_ptr,
+    QW_ptr,
+    KW_ptr,
+    q_stride,
+    k_stride,
+    k_rows,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_HD: tl.constexpr,
+    EPS: tl.constexpr,
+    FP16: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    cols = tl.arange(0, BLOCK_HD)
+    mask = cols < HEAD_DIM
+    out_dtype = tl.float16 if FP16 else tl.bfloat16
+
+    # Q norm (every block) — use q_stride to handle non-contiguous input
+    q_off = pid * q_stride + cols
+    q = tl.load(Q_ptr + q_off, mask=mask, other=0.0).to(tl.float32)
+    w_q = tl.load(QW_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+    q_var = tl.sum(q * q, axis=0) / HEAD_DIM
+    q_normed = (q * tl.rsqrt(q_var + EPS) * (w_q + 1.0)).to(out_dtype)
+    # output is always contiguous
+    q_out_off = pid * HEAD_DIM + cols
+    tl.store(Q_out_ptr + q_out_off, q_normed, mask=mask)
+
+    # K norm (first k_rows blocks only) — use k_stride for input
+    if pid < k_rows:
+        k_off = pid * k_stride + cols
+        k = tl.load(K_ptr + k_off, mask=mask, other=0.0).to(tl.float32)
+        w_k = tl.load(KW_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        k_var = tl.sum(k * k, axis=0) / HEAD_DIM
+        k_normed = (k * tl.rsqrt(k_var + EPS) * (w_k + 1.0)).to(out_dtype)
+        k_out_off = pid * HEAD_DIM + cols
+        tl.store(K_out_ptr + k_out_off, k_normed, mask=mask)
+
+
+def fused_qk_gemma_rmsnorm(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    eps: float,
+    head_dim: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Fused QK GemmaRMSNorm — single Triton kernel for both q_norm and k_norm.
+
+    grid = q_rows; every block processes its Q row, and the first k_rows
+    blocks also process K.  No torch.cat, no slice, no tl.where.
+    Passes input strides to the kernel so non-contiguous tensors (e.g. from
+    qkv.split()) are read correctly without an extra .contiguous() copy.
+    """
+    q_flat = q.reshape(-1, head_dim)
+    k_flat = k.reshape(-1, head_dim)
+
+    q_rows = q_flat.shape[0]
+    k_rows = k_flat.shape[0]
+
+    q_out = torch.empty(q_rows, head_dim, dtype=q.dtype, device=q.device)
+    k_out = torch.empty(k_rows, head_dim, dtype=k.dtype, device=k.device)
+
+    BLOCK_HD = triton.next_power_of_2(head_dim)
+
+    _fused_qk_gemma_rmsnorm_kernel[(q_rows,)](
+        q_flat,
+        k_flat,
+        q_out,
+        k_out,
+        q_weight,
+        k_weight,
+        q_flat.stride(0),
+        k_flat.stride(0),
+        k_rows,
+        HEAD_DIM=head_dim,
+        BLOCK_HD=BLOCK_HD,
+        EPS=eps,
+        FP16=(q.dtype == torch.float16),
+    )
+
+    return q_out, k_out
 
 
 # Register the inplace op


### PR DESCRIPTION
Co-author: @hubertlu-tw 

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

From the profiling data, apply_qk_norm function will bring 4 kernels launch on ROCm platform compared two kernels overlapped on CUDA platform. In order to reduce the e2e time cost, fused 4 kernels into one triton kernel

<img width="1740" height="315" alt="image" src="https://github.com/user-attachments/assets/72e104d9-d8e4-48f5-89eb-e656e9480493" />


## Modifications

**models/utils.py**
Add triton kernel implementation for fused kernel
**models/qwen3_5.py**
Check the path of hip to apply the fused triton kernel

## Accuracy Tests
<details><summary>Server launch command</summary>
<p>

```
SGLANG_USE_AITER_UNIFIED_ATTN=1 SGLANG_USE_AITER=1 \
python3 -m sglang.launch_server \
  --model-path /dockerx/data/models/Qwen3.5-397B-A17B-FP8/ --tp 8 \
  --attention-backend aiter --trust-remote-code \
  --chunked-prefill-size 32768 \
  --model-loader-extra-config '{"enable_multithread_load": true}' \
  --watchdog-timeout 1200 --mem-fraction-static 0.9 \
  --host 0.0.0.0 --port 8000 --disable-radix-cache \
  --enable-aiter-allreduce-fusion --max-running-requests 128 \
  --page-size 16
```
</p>
</details> 

## Speed Tests and Profiling
| Concurrency| total token throughput before | total token throughput after| Ratio |
|--------|--------|--------|--------|
| 4| 864.11| 883.77| +2.2%|
| 8 | 1582.05 | 1624.43| +2.6% | 
| 16 | 2888.91 | 2945.39| +1.9% |
| 32 | 5005.01 | 5021.38| +0.3% |
| 64 | 7609.9 | 7634.51| +0.3% |


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
