### PR TITLE
[Bug fix]redact video_data in request logs at --log-requests-level 0 and 1

### DIFF
--- a/python/sglang/srt/utils/request_logger.py
+++ b/python/sglang/srt/utils/request_logger.py
@@ -206,6 +206,7 @@ class RequestLogger:
                     "input_ids",
                     "input_embeds",
                     "image_data",
+                    "video_data",
                     "audio_data",
                     "lora_path",
                     "sampling_params",
@@ -218,6 +219,7 @@ class RequestLogger:
                     "input_ids",
                     "input_embeds",
                     "image_data",
+                    "video_data",
                     "audio_data",
                     "lora_path",
                 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
RequestLogger._compute_metadata already omitted image_data and audio_data from logged request/finish payloads when --log-requests-level is 0 or 1, but video_data was missing from the same skip_names set. That meant video inputs could still appear in logs at those levels, inconsistent with image/audio and with the intent to log mostly metadata (and, at level 1, sampling parameters) without large multimodal blobs.
## Modifications

<!-- Detail the changes made in this pull request. -->
Add "video_data" to skip_names for both log_requests_level == 0 and log_requests_level == 1 in python/sglang/srt/utils/request_logger.py.


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
