### PR TITLE
[AMD] Default SGLANG_USE_AITER_AR to false to avoid HIP graph capture invalidation

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce.py
@@ -376,13 +376,24 @@ def dispatch_custom_allreduce():
     if _use_amd_deterministic_impl():
         return CustomAllreduce
 
-    if get_bool_env_var("SGLANG_USE_AITER_AR", default="true"):
+    # NOTE(rocm): AiterCustomAllreduce launches helper kernels on an internal
+    # stream during HIP graph capture, which invalidates the captured graph
+    # (hipErrorStreamCaptureInvalidated) and triggers HSA_STATUS_ERROR_EXCEPTION
+    # 0x1016 on the first decode replay.  This was first observed with the
+    # tencent/Hy3-preview model on MI300X/MI355X (see
+    # https://github.com/sgl-project/sglang/issues/23580).  Until the AITER
+    # kernel is fixed, default to sglang's own CustomAllreduce on HIP and let
+    # the user explicitly opt back into AITER's implementation by setting
+    # SGLANG_USE_AITER_AR=1.
+    if get_bool_env_var("SGLANG_USE_AITER_AR", default="false"):
         try:
             from aiter.dist.device_communicators.custom_all_reduce import (
                 CustomAllreduce as AiterCustomAllreduce,
             )
 
-            logger.info("[AR] Using AiterCustomAllreduce (AMD default)")
+            logger.info(
+                "[AR] Using AiterCustomAllreduce (opted in via SGLANG_USE_AITER_AR=1)"
+            )
             tms_cudagraph = envs.SGLANG_MEMORY_SAVER_CUDA_GRAPH.get()
             return partial(
                 AiterCustomAllreduce,


### PR DESCRIPTION
## Summary

`AiterCustomAllreduce` (the default custom all-reduce on AMD HIP when `SGLANG_USE_AITER_AR=true`, which is the current default) launches helper kernels on an internal stream during HIP graph capture, which invalidates the captured graph (`hipErrorStreamCaptureInvalidated`). The next decode replay then dispatches a broken graph, triggering `HSA_STATUS_ERROR_EXCEPTION: An HSAIL operation resulted in a hardware exception. code: 0x1016` and SIGABRT'ing all TP scheduler subprocesses.

This was first observed with the `tencent/Hy3-preview` model (PR #23533) on MI300X and MI355X at TP=8 with the standard launcher arguments from the model card. **Eager mode (`--disable-cuda-graph`) works fine**, confirming the model code itself is correct on AMD — the crash is specific to CUDA-graph capture/replay.

Filed full diagnosis with reproducer in #23580.

## Fix

Change the default of `SGLANG_USE_AITER_AR` from `"true"` to `"false"`. With this default, `dispatch_custom_allreduce()` picks sglang's own `CustomAllreduce` on HIP, which respects the captured stream and works correctly. AITER's other fast paths (attention, MoE, RMSNorm, fused_qk_norm) remain enabled, so performance is preserved (slightly improved in our benchmarks because we keep AITER attention while using a stream-safe all-reduce).

Users who know their workload doesn't trigger the issue (e.g., NVIDIA, or AMD without large CUDA-graph capture) can opt back in with `SGLANG_USE_AITER_AR=1`.

Once AITER's HIP graph capture path is fixed upstream, this default can be flipped back.

## Validation

Run on `tencent/Hy3-preview` with PR #23533 file overlays applied to `rocm/sgl-dev:v0.5.10.post1-rocm720-mi30x-20260423` and `rocm/sgl-dev:v0.5.10.post1-rocm720-mi35x-20260423`, `transformers==5.6.1`, TP=8, default launcher (no `--disable-cuda-graph`):

| Hardware | Workload | Before (`SGLANG_USE_AITER_AR=true`) | After (this patch) |
|---|---|---|---|
| MI300X TP=8 | Hy3 single long, 512 tok | ❌ HSA exception 0x1016, SIGABRT | ✅ **34.9 tok/s** |
| MI300X TP=8 | Hy3 c=4, 16 reqs | ❌ crash | ✅ 128.8 tok/s |
| MI300X TP=8 | Hy3 c=8, 32 reqs | ❌ crash | ✅ **250.7 tok/s** |
| MI355X TP=8 | Hy3 single long, 512 tok | ❌ crash | ✅ **39.6 tok/s** |
| MI355X TP=8 | Hy3 c=8, 32 reqs | ❌ crash | ✅ **295.7 tok/s** |

For reference, vLLM's piecewise CUDA-graph mode (in vllm-project/vllm#40681) tolerates AITER's all-reduce because it captures graphs per-layer, not monolithically; but SGLang's default monolithic capture cannot. Hence this defaults change is the right scope for SGLang.

## Refs

- #23580 — bug report with full reproducer + crash trace
- #23533 — `tencent/Hy3-preview` model PR (works on AMD with this fix)

## Future work

The proper upstream fix is to make `AiterCustomAllreduce` HIP-graph-safe in AITER itself. This PR is an interim default change so that AMD users of the default `lmsysorg/sglang` and `rocm/sgl-dev` images stop hitting the crash. Once AITER's HIP graph capture is fixed, the default can be flipped back to `true`.
