### PR TITLE
Move expert_mask_gpu from FusedMoE layer to StandardDispatcher

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -213,8 +213,6 @@ class FusedMoE(torch.nn.Module):
         self.num_local_experts = self._num_local_routed + num_fused_shared_experts
         self._has_fused_shared = num_fused_shared_experts > 0
 
-        self.expert_mask_gpu = None
-
         assert intermediate_size % self.moe_tp_size == 0
         self.intermediate_size_per_partition = intermediate_size // self.moe_tp_size
         self.reduce_results = reduce_results
@@ -1009,16 +1007,6 @@ class FusedMoE(torch.nn.Module):
         dispatch_output = self.dispatcher.dispatch(
             hidden_states=hidden_states, topk_output=topk_output
         )
-
-        if _use_aiter and self.dispatcher.local_expert_mapping is not None:
-            self.expert_mask_gpu = (
-                (
-                    (self.dispatcher.local_expert_mapping >= 0)
-                    & (self.dispatcher.local_expert_mapping < self.num_local_experts)
-                )
-                .to(torch.int32)
-                .to(device="cuda")
-            )
 
         combine_input = self.run_moe_core(
             dispatch_output=dispatch_output,

--- a/python/sglang/srt/layers/moe/token_dispatcher/standard.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/standard.py
@@ -99,12 +99,14 @@ class StandardDispatcher(BaseDispatcher):
             get_moe_runner_backend().is_flashinfer_trtllm_routed()
         )
         self.num_experts = moe_runner_config.num_experts
+        self.num_local_experts = moe_runner_config.num_local_experts
         self.num_local_shared_experts = moe_runner_config.num_fused_shared_experts
         self.num_local_routed_experts = (
-            moe_runner_config.num_local_experts - self.num_local_shared_experts
+            self.num_local_experts - self.num_local_shared_experts
         )
         self.moe_ep_rank = get_moe_expert_parallel_rank()
         self.local_expert_mapping = None
+        self.expert_mask_gpu = None
 
     def dispatch(
         self, hidden_states: torch.Tensor, topk_output: TopKOutput
@@ -187,13 +189,23 @@ class StandardDispatcher(BaseDispatcher):
                         )
                     )
 
-        if self.local_expert_mapping is not None and not _use_aiter:
-            if TopKOutputChecker.format_is_standard(topk_output):
-                topk_output = topk_output._replace(
-                    topk_ids=self.local_expert_mapping[topk_output.topk_ids]
+        if self.local_expert_mapping is not None:
+            if _use_aiter:
+                self.expert_mask_gpu = (
+                    (
+                        (self.local_expert_mapping >= 0)
+                        & (self.local_expert_mapping < self.num_local_experts)
+                    )
+                    .to(torch.int32)
+                    .to(device="cuda")
                 )
-            elif TopKOutputChecker.format_is_triton_kernels(topk_output):
-                raise NotImplementedError()
+            else:
+                if TopKOutputChecker.format_is_standard(topk_output):
+                    topk_output = topk_output._replace(
+                        topk_ids=self.local_expert_mapping[topk_output.topk_ids]
+                    )
+                elif TopKOutputChecker.format_is_triton_kernels(topk_output):
+                    raise NotImplementedError()
 
         return StandardDispatchOutput(
             hidden_states=hidden_states,

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1821,7 +1821,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                         if activation == "silu"
                         else ActivationType.Gelu
                     ),
-                    expert_mask=layer.expert_mask_gpu,
+                    expert_mask=layer.dispatcher.expert_mask_gpu,
                 )
             else:
                 return fused_moe(
@@ -1838,7 +1838,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                         if activation == "silu"
                         else ActivationType.Gelu
                     ),
-                    expert_mask=layer.expert_mask_gpu,
+                    expert_mask=layer.dispatcher.expert_mask_gpu,
                 )
         return None
 

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -856,7 +856,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 w2_weight,
                 topk_weights,
                 topk_ids,
-                expert_mask=layer.expert_mask_gpu,
+                expert_mask=layer.dispatcher.expert_mask_gpu,
                 activation=ActivationType.Swiglu,
                 quant_type=QuantType.per_1x32,
                 w1_scale=layer.w13_weight_scale,
@@ -1045,6 +1045,6 @@ class Mxfp4DynamicQuantMoEMethod(FusedMoEMethodBase):
                 else ActivationType.Gelu
             ),
             doweight_stage1=False,
-            expert_mask=layer.expert_mask_gpu,
+            expert_mask=layer.dispatcher.expert_mask_gpu,
         )
         return StandardCombineInput(hidden_states=output)

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
@@ -227,6 +227,6 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
                 else ActivationType.Gelu
             ),
             doweight_stage1=False,
-            expert_mask=layer.expert_mask_gpu,
+            expert_mask=layer.dispatcher.expert_mask_gpu,
         )
         return StandardCombineInput(hidden_states=output)

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -484,7 +484,7 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
                             if moe_runner_config.activation == "silu"
                             else ActivationType.Gelu
                         ),
-                        expert_mask=layer.expert_mask_gpu,
+                        expert_mask=layer.dispatcher.expert_mask_gpu,
                     )
                     return StandardCombineInput(hidden_states=output)
                 except RuntimeError as e:


### PR DESCRIPTION
## Motivation

The aiter `expert_mask_gpu` tensor is a pure function of the dispatcher's `local_expert_mapping` and `num_local_experts`, but today it lives on `FusedMoE` and is computed in `FusedMoE.forward_impl`. Having the layer reach into `self.dispatcher.local_expert_mapping` to build state that it then exposes back to quant kernels is a leaky abstraction. This PR moves ownership to `StandardDispatcher`, where the inputs already live.

## Modifications

- `python/sglang/srt/layers/moe/token_dispatcher/standard.py`: `StandardDispatcher` now owns `expert_mask_gpu` (initialized to `None` in `__init__`) and computes it inside `dispatch()` alongside the existing `local_expert_mapping` setup — aiter path builds the mask, non-aiter path keeps the existing topk_ids remap. Also exposes `self.num_local_experts` on the dispatcher for this computation.
- `python/sglang/srt/layers/moe/fused_moe_triton/layer.py`: remove the `self.expert_mask_gpu = None` init and the aiter mask-build block from `forward_impl`.
- `python/sglang/srt/layers/quantization/{unquant,mxfp4,fp8}.py` and `.../quark/schemes/quark_w4a4_mxfp4_moe.py`: update five call sites from `layer.expert_mask_gpu` to `layer.dispatcher.expert_mask_gpu`.

Behavior is unchanged: the mask is still rebuilt every forward under `_use_aiter`, same `(mapping >= 0) & (mapping < num_local_experts)` predicate, same int32 dtype, same `.to(device="cuda")` target.

## Accuracy Tests

No model-output changes — pure refactor, computation and dtype preserved.

## Speed Tests and Profiling

N/A — no hot-path changes.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).