### PR TITLE
ci: fix cu129 wheel tagging + pipefail-abort in install script (follow-up to #23497)

### DIFF
--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -315,20 +315,14 @@ if [ "${CUSTOM_BUILD_SGL_KERNEL:-}" = "true" ] && [ -d "sgl-kernel/dist" ]; then
         WHEEL_ARCH="x86_64"
     fi
     # Wheel filenames carry a +cuXYZ local version tag (e.g. sglang_kernel-0.4.0+cu130-...).
-    # When the build matrix produces wheels for multiple CUDA versions (e.g. both cu129 and cu130),
-    # pick the one matching the test runner's $CU_VERSION so we don't trigger the PyPI-fallback reinstall
-    # below (which would replace the PR-built wheel with a public main-branch wheel).
-    KERNEL_WHL=$(ls sgl-kernel/dist/sglang_kernel-${SGL_KERNEL_VERSION_FROM_KERNEL}+${CU_VERSION}-cp310-abi3-manylinux2014_${WHEEL_ARCH}.whl 2>/dev/null | head -1)
-    if [ -z "$KERNEL_WHL" ]; then
-        # Fallback for older branches that only build a single CUDA variant and whose wheel matches
-        # the current $CU_VERSION. Restrict to the same arch — we intentionally do NOT match a wheel
-        # whose +cuXYZ tag disagrees with $CU_VERSION here, because the post-install reinstall branch
-        # below would otherwise silently replace it with the public main-branch wheel.
-        SINGLE_CUDA_WHL=$(ls sgl-kernel/dist/sglang_kernel-${SGL_KERNEL_VERSION_FROM_KERNEL}-cp310-abi3-manylinux2014_${WHEEL_ARCH}.whl 2>/dev/null | head -1)
-        if [ -n "$SINGLE_CUDA_WHL" ]; then
-            KERNEL_WHL="$SINGLE_CUDA_WHL"
-        fi
-    fi
+    # Pick the one matching the test runner's $CU_VERSION; any other tag (or an untagged
+    # wheel of unknown CUDA origin) would at best hit the PyPI-reinstall branch below and
+    # silently replace the PR-built wheel with the public main-branch wheel, and at worst
+    # ABI-crash at cuInit. Better to fail loudly — the error message + dist/ listing below
+    # makes the diagnosis obvious.
+    # `|| true` swallows `ls`'s exit-2-on-no-match so `set -o pipefail` doesn't abort the
+    # script before we reach the explicit error check.
+    KERNEL_WHL=$(ls sgl-kernel/dist/sglang_kernel-${SGL_KERNEL_VERSION_FROM_KERNEL}+${CU_VERSION}-cp310-abi3-manylinux2014_${WHEEL_ARCH}.whl 2>/dev/null | head -1 || true)
     if [ -z "$KERNEL_WHL" ]; then
         echo "ERROR: No matching sgl-kernel wheel found in sgl-kernel/dist/ for version ${SGL_KERNEL_VERSION_FROM_KERNEL} arch ${WHEEL_ARCH} cuda ${CU_VERSION}"
         ls -alh sgl-kernel/dist/

--- a/sgl-kernel/rename_wheels.sh
+++ b/sgl-kernel/rename_wheels.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Align CUDA wheel filenames (+cu124/+cu128/+cu130) with internal METADATA Version and
+# Align CUDA wheel filenames (+cu124/+cu128/+cu129/+cu130) with internal METADATA Version and
 # WHEEL tags after build (fixes pip "inconsistent version" when only the .whl name changed).
 # Unpack → patch WHEEL/METADATA → wheel pack (RECORD regenerated; no hand-editing).
 set -ex
@@ -11,6 +11,8 @@ detect_cuda_suffix() {
         echo "+cu124"
     elif ls /usr/local/ 2>/dev/null | grep -q "12.8"; then
         echo "+cu128"
+    elif ls /usr/local/ 2>/dev/null | grep -q "12.9"; then
+        echo "+cu129"
     elif ls /usr/local/ 2>/dev/null | grep -q "13.0"; then
         echo "+cu130"
     else


### PR DESCRIPTION
## Motivation

Two regressions introduced by #23497 surface together on H-series (cu129) test runners. Example failure: [stage-c-test-8-gpu-h20 (0) on PR #21985](https://github.com/sgl-project/sglang/actions/runs/24847310236/job/72768674499) — the `Install dependencies` step exits with code 2 immediately after listing `sgl-kernel/dist/` contents.

### Bug 1: `rename_wheels.sh` doesn't know about CUDA 12.9

`detect_cuda_suffix()` only checked for `12.4 / 12.8 / 13.0`. When #23497 added `cuda-version: "12.9"` back to the `sgl-kernel-build-wheels` matrix, the cu12.9 build fell through to the `else` branch that returns an empty suffix → the wheel was written *without* a `+cu129` tag:

```
sglang_kernel-0.4.1-cp310-abi3-manylinux2014_x86_64.whl        ← untagged (from cu12.9 build!)
sglang_kernel-0.4.1+cu130-cp310-abi3-manylinux2014_x86_64.whl  ← tagged (from cu13.0 build)
```

### Bug 2: install-script pipefail aborts on the first missing `+cuXYZ` wheel

`ci_install_dependency.sh` runs under `set -euxo pipefail`. The line

```bash
KERNEL_WHL=$(ls ...+${CU_VERSION}-...whl 2>/dev/null | head -1)
```

returns exit 2 from `ls` when the glob has no match. `head -1` succeeds, but pipefail propagates the worst exit code from the pipeline, aborting the script before the explicit `[ -z "$KERNEL_WHL" ]` error check below ever runs.

### Net effect

On cu129 runners (today, H20):

1. cu12.9 matrix entry produces an untagged wheel (Bug 1).
2. Install script looks for `+cu129` wheel that doesn't exist.
3. `ls` fails, pipefail propagates, script aborts with exit 2 (Bug 2).
4. The explicit "no wheel found" error message never runs; the test step is skipped and the job is marked failed with only the raw `ls` of dist contents in the log.

## Modifications

1. `sgl-kernel/rename_wheels.sh::detect_cuda_suffix()` — add `12.9 → +cu129` detection alongside the existing `12.4 / 12.8 / 13.0` branches.
2. `scripts/ci/cuda/ci_install_dependency.sh` — add `|| true` after `head -1` on the wheel lookup. Under pipefail, this lets an empty glob yield an empty `KERNEL_WHL` so the explicit error check below fires (with a clear message and dist/ listing) instead of the silent `set -e` abort.
3. `scripts/ci/cuda/ci_install_dependency.sh` — drop the untagged-wheel fallback #23497 added. An untagged wheel in `sgl-kernel/dist/` tells us nothing about its CUDA, so installing it risks either ABI-crash at `cuInit` if the CUDA differs or silent replacement by main's public wheel via the PyPI-reinstall branch below. The original pre-#23497 code didn't have this fallback; local-dev builds can run `sgl-kernel/rename_wheels.sh` themselves to tag wheels (same post-processing CI does) instead.

## Testing Done

This is a CI infra fix. Verifiable by observing that sgl-kernel-touching PRs (e.g. #21985, #22392) produce a properly tagged `+cu129` wheel on the next run and the cu129 test jobs no longer abort in the install step.

- [x] bash syntax check on both files (`bash -n`).
- [ ] Confirmation on a rerun of #21985's stage-c-test-8-gpu-h20.

## Notes for Reviewers

- Strictly a follow-up bug fix for #23497. No behavior change for CUDA versions not on the matrix.
- `|| true` pattern instead of toggling `set +o pipefail` — more portable inside a `$(...)` command-substitution.
- Net of the three changes, the sgl-kernel wheel install block is now **simpler than after #23497** (one lookup + one error check) and **strictly safer** (refuses to install a CUDA-unknown wheel).

## Author Checklist

- [x] Trivial / CI-only change; backwards compatible.
- [x] Documentation not affected.
- [x] Not high-risk.