### PR TITLE
[PD+DP] Allow PrefillDelayer in disaggregated-prefill mode

### DIFF
--- a/python/sglang/srt/managers/prefill_delayer.py
+++ b/python/sglang/srt/managers/prefill_delayer.py
@@ -71,9 +71,6 @@ class PrefillDelayer:
         self.skip_first_delayer = True
 
         assert (
-            server_args.disaggregation_mode == "null"
-        ), "To use PrefillDelayer, disaggregation_mode must be null."
-        assert (
             not server_args.disable_overlap_schedule
         ), "To use PrefillDelayer, disable_overlap_schedule must be False."
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -982,22 +982,28 @@ class Scheduler(
         self.prefill_delayer: Optional[PrefillDelayer] = None
         self.max_prefill_bs: int = 0
         if self.server_args.enable_prefill_delayer:
-            self.prefill_delayer = PrefillDelayer(
-                dp_size=self.dp_size,
-                attn_tp_size=self.attn_tp_size,
-                cpu_group=self.tp_cpu_group,
-                server_args=self.server_args,
-                metrics_collector=(
-                    self.metrics_collector if self.enable_metrics else None
-                ),
-                max_delay_passes=self.server_args.prefill_delayer_max_delay_passes,
-                token_usage_low_watermark=self.server_args.prefill_delayer_token_usage_low_watermark,
-                device=(
-                    self.tp_group.device
-                    if self.server_args.disable_overlap_schedule
-                    else "cpu"
-                ),
-            )
+            if self.server_args.disaggregation_mode == "decode":
+                logger.info(
+                    "Ignoring --enable-prefill-delayer on decode engine "
+                    "(no prefill scheduling path; delayer would be a no-op)."
+                )
+            else:
+                self.prefill_delayer = PrefillDelayer(
+                    dp_size=self.dp_size,
+                    attn_tp_size=self.attn_tp_size,
+                    cpu_group=self.tp_cpu_group,
+                    server_args=self.server_args,
+                    metrics_collector=(
+                        self.metrics_collector if self.enable_metrics else None
+                    ),
+                    max_delay_passes=self.server_args.prefill_delayer_max_delay_passes,
+                    token_usage_low_watermark=self.server_args.prefill_delayer_token_usage_low_watermark,
+                    device=(
+                        self.tp_group.device
+                        if self.server_args.disable_overlap_schedule
+                        else "cpu"
+                    ),
+                )
 
         # NOTE: preemption is enabled by default for priority scheduling.
         self.enable_priority_preemption = (


### PR DESCRIPTION
## Motivation

`PrefillDelayer` is currently gated by `assert disaggregation_mode == "null"` in its constructor, so launching a disaggregated **prefill** engine with `--enable-prefill-delayer` aborts at scheduler init. However, the delayer's negotiation logic — per-iteration `all_gather` over DP ranks of an `all/none/mixed` prefillable status, with bounded `max_delay_passes` waiting — is exactly the mechanism a disaggregated-prefill + `--enable-dp-attention` deployment needs to fuse near-simultaneous prefills into a single forward pass instead of paying for repeated "1 real + N idle" passes through the EP all-to-all.

In a `--tp 4 --dp 4 --ep 4 --enable-dp-attention --disaggregation-mode prefill` setup, four concurrent client requests routed round-robin to four DP ranks currently end up as two scheduler iterations:

1. Iteration 1: DP0 prefills its req, DP1/2/3 run idle batches (still paying the EP collective)
2. Iteration 2: DP1/2/3 prefill their reqs

With this change, `--enable-prefill-delayer` can be used on the prefill engine to delay iteration 1 by a few passes so all four reqs land in the same forward, halving the number of EP all-to-alls and improving prefill throughput at small/medium prompt lengths where the per-pass collective overhead is non-trivial relative to the actual MoE compute.

## Modifications

- `python/sglang/srt/managers/prefill_delayer.py`: drop the `disaggregation_mode == "null"` assertion. The delayer's logic only depends on the per-iteration prefill scheduling path, which exists in both `null` and `prefill` modes.
- `python/sglang/srt/managers/scheduler.py`: when constructing the delayer, skip it (and log) on a `decode` engine. A decode engine has no prefill scheduling path, so `--enable-prefill-delayer` would be silently unused; this makes that explicit and avoids allocating the gather buffer / cpu_group state on decode workers.

No behavior change for non-disaggregated deployments. Existing `--prefill-delayer-max-delay-passes` / `--prefill-delayer-token-usage-low-watermark` flags work unchanged on the prefill engine of a disaggregated PD setup.

## Accuracy Tests

N/A — this is a scheduler-side gating change. No model forward / kernel code is touched. Generation outputs are unaffected.

## Speed Tests and Profiling

Tested locally on 1×H200 node, `Qwen/Qwen3-30B-A3B`, prefill engine launched as:

```
python3 -m sglang.launch_server --model-path Qwen/Qwen3-30B-A3B \
  --tp 4 --dp 4 --ep 4 --enable-dp-attention \
  --disaggregation-mode prefill --disable-radix-cache \
  --load-balance-method round_robin --chunked-prefill-size 32768 \
  [--enable-prefill-delayer]
```

(Without this PR the `--enable-prefill-delayer` variant aborts at `PrefillDelayer.__init__` with the assertion.)

Client: 4 concurrent requests, 8192-token prompt, 1 output token, round-robin over the 4 DP ranks, no client-side stagger.

### Without `--enable-prefill-delayer`: requests split into two batches

```
python3 client.py --batch-size 4 --input-len 8192 --output-len 1 \
  --tokenizer Qwen/Qwen3-30B-A3B --dp-size 4 --flush-cache --stagger-ms 0
sent 4 reqs in 3.023s, ok=4/4
```

Per-DP `Prefill batch` log on the prefill engine — DP0 fires alone first, DPs 1/2/3 fuse in the next iteration:

```
DP0 ... Prefill batch, #new-seq: 1, #new-token: 8192   <- iter 1
DP1 ... Prefill batch, #new-seq: 1, #new-token: 8192   <- iter 2
DP2 ... Prefill batch, #new-seq: 1, #new-token: 8192   <- iter 2
DP3 ... Prefill batch, #new-seq: 1, #new-token: 8192   <- iter 2
```

### With `--enable-prefill-delayer`: requests fused into one batch

```
python3 client.py --batch-size 4 --input-len 8192 --output-len 1 \
  --tokenizer Qwen/Qwen3-30B-A3B --dp-size 4 --flush-cache --stagger-ms 0
sent 4 reqs in 1.957s, ok=4/4
```

All four DPs prefill in the same iteration:

```
DP0 ... Prefill batch, #new-seq: 1, #new-token: 8192   <- iter 1
DP1 ... Prefill batch, #new-seq: 1, #new-token: 8192   <- iter 1
DP2 ... Prefill batch, #new-seq: 1, #new-token: 8192   <- iter 1
DP3 ... Prefill batch, #new-seq: 1, #new-token: 8192   <- iter 1
```

End-to-end wall clock for 4 concurrent reqs drops from **3.023 s → 1.957 s** (~35% faster) because the EP all-to-all is amortized over one forward pass instead of two.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).