### PR TITLE
Add cookbook-add-model skill for Mintlify cookbook

### DIFF
--- a/.claude/skills/cookbook-add-model/SKILL.md
+++ b/.claude/skills/cookbook-add-model/SKILL.md
@@ -196,7 +196,7 @@ Stamp from [templates/config-generator.jsx.tmpl](templates/config-generator.jsx.
 
 Template behavior:
 
-- Row 1: all 11 GPUs grouped by NVIDIA / AMD. Green dot means verified. Unverified combos have no dot and no warning banner.
+- Row 1: all 11 GPUs grouped by NVIDIA / AMD. Each hardware option should show its VRAM subtitle from the hardware reference table (for example `80GB`, `141GB`, `275GB`). Green dot means verified. Unverified combos have no dot and no warning banner.
 - Row 2: model variant buttons only. Do not mix quantization into the variant label unless the model itself is quantization-specific.
 - Row 3: quantization buttons for the selected model variant. Quantization choices come from the HuggingFace model card / linked repos. BF16 is the default when available.
 - Row 4: strategy checkboxes. TP is required. EP shows only for applicable MoE configs. MTP shows only when confirmed by the selected variant/quantization. Optimized appears here, not in features, and is enabled only when the selected strategy profile has a matching verbatim optimized command. PP is intentionally hidden for now.
@@ -300,6 +300,7 @@ Can be triggered with `/cookbook-add-model review`.
 - [ ] No bare module imports.
 - [ ] All CONFIG, helpers, styles, and render code are closure-scoped inside the component.
 - [ ] All 11 GPUs are present and grouped NVIDIA / AMD.
+- [ ] Hardware options display the correct VRAM subtitle from the hardware reference.
 - [ ] Every variant has a parsed `reference` command.
 - [ ] `verified` covers only tested combos.
 - [ ] Optional env prefixes are preserved only where confirmed.

--- a/.claude/skills/cookbook-add-model/SKILL.md
+++ b/.claude/skills/cookbook-add-model/SKILL.md
@@ -1,0 +1,326 @@
+---
+name: cookbook-add-model
+description: Add a new model to the SGLang Mintlify cookbook — MDX page, reference-derived autoregressive config-generator JSX snippet, docs.json registration, NEW tag handling, and category-intro card update.
+disable-model-invocation: true
+---
+
+# Add New Model to SGLang Cookbook (Mintlify)
+
+Interactive, multi-step workflow. Collect inputs incrementally; do not ask for everything upfront.
+
+The cookbook lives in `docs_new/` and uses Mintlify (`.mdx`, `docs.json`, `mint`). There is no YAML model corpus and no shared Docusaurus `ConfigGenerator` component. New autoregressive deployment snippets are self-contained `.jsx` files stamped from [templates/config-generator.jsx.tmpl](templates/config-generator.jsx.tmpl). Diffusion and omni pages keep their category-specific structures unless the user explicitly asks to unify them.
+
+## Phase 1: Collect Inputs
+
+Ask for and record:
+
+1. **Model card** — HuggingFace model name or URL. Fetch it to confirm description, capabilities, parameter count, architecture, context length, variants, and license. If the model is private/unreleased, ask the user for those facts.
+2. **Cookbook category** — `autoregressive`, `diffusion`, or `omni`. Use the unified generator template for new autoregressive pages first; for diffusion/omni, follow the closest existing category page and snippet.
+3. **Model variants and quantizations** — keep model variant and quantization separate:
+   - model variants are size/architecture/mode choices such as `397B-A17B`, `35B-A3B`, `Instruct`, or `Thinking`;
+   - quantization choices come from the HuggingFace model card or linked model repos, such as `BF16`, `FP8`, `NVFP4`, `MXFP4`, or `AWQ`;
+   - default to `BF16` for each model variant when a BF16/full-precision repo exists;
+   - each model variant may expose a different set of quantizations.
+4. **Reference deployment command per variant + quantization** — each `(model variant, quantization)` pair needs at least one user-provided `sglang serve --model-path ...` command. If the source uses `python -m sglang.launch_server`, rewrite it to `sglang serve` form and confirm the rewritten command. Parse and preserve:
+   - baseline hardware, quantization, `tp`, `ep`, `dp`, `--mem-fraction-static`, optional env prefixes, required flags, parsers, chat template, MTP/EAGLE, Mamba, KV/cache, and other feature flags;
+   - default `strategies` and `features` for that variant + quantization;
+   - which flags are required for correctness vs optional optimizations.
+5. **Feature/strategy applicability** — infer only from the reference command, model card, SGLang docs, or user confirmation. If it is unclear whether MTP, Mamba cache, KV FP8, parser, chat template, DP attention, EP, or an env prefix applies to a model/hardware/variant, ask before adding it.
+6. **Verified matrix** — for each tested `(variant x quantization x hardware)` combo, record `{ env, tp, ep, mem, flags, strategies, features }`. Untested combos can be auto-estimated from that quantization's reference command, but only for single-node commands.
+7. **Optimized commands** — if the user supplies hand-tuned launches, store them under the verified combo as verbatim `optimizedCommands`. Optimized is a deployment strategy option, not a feature option. Support at least:
+   - `default`: optimized command without MTP;
+   - `mtp`: optimized command with MTP/EAGLE.
+   Never rewrite an optimized command. If only an optimized command is provided, use it as capability evidence and as `optimizedCommands`, then derive the best non-optimized baseline from its parsed fields.
+8. **SGLang version** — used in benchmark metadata and Docker image tags.
+9. **Tested hardware platforms** — show the full list below and let the user pick. Only mark a combo verified when it was actually tested.
+
+Hardware reference:
+
+| Platform | Vendor | Memory | Docker Image |
+|----------|--------|--------|--------------|
+| A100     | NVIDIA | 80GB   | `lmsysorg/sglang:<ver>` |
+| H100     | NVIDIA | 80GB   | `lmsysorg/sglang:<ver>` |
+| H200     | NVIDIA | 141GB  | `lmsysorg/sglang:<ver>` |
+| B200     | NVIDIA | 180GB  | `lmsysorg/sglang:<ver>` |
+| B300     | NVIDIA | 275GB  | `lmsysorg/sglang:<ver>` or `-cu130` when required |
+| GB200    | NVIDIA | 192GB  | `lmsysorg/sglang:<ver>-cu130` |
+| GB300    | NVIDIA | 275GB  | `lmsysorg/sglang:<ver>-cu130` |
+| MI300X   | AMD    | 192GB  | `lmsysorg/sglang:<ver>-rocm720-mi30x` |
+| MI325X   | AMD    | 256GB  | `lmsysorg/sglang:<ver>-rocm720-mi30x` |
+| MI350X   | AMD    | 288GB  | `lmsysorg/sglang:<ver>-rocm720-mi35x` |
+| MI355X   | AMD    | 288GB  | `lmsysorg/sglang:<ver>-rocm720-mi35x` |
+
+TP calculation for auto-generation:
+
+- `model_weight_GB / gpu_mem_GB`, round up to nearest power of 2. Leave 20-30% headroom.
+- BF16 ≈ params * 2 GB, FP8 ≈ params * 1 GB, FP4 ≈ params * 0.5 GB
+- FP4 is Blackwell-only (B200/B300)
+- MoE models: use total weight size (all experts), not active params
+
+Platform notes:
+
+- Blackwell/Grace-Blackwell may need `--attention-backend trtllm_mha`; GB200/GB300 need `-cu130` Docker tag (CUDA 13) and typically max out at 4 GPUs per node.
+- AMD typically needs `--attention-backend triton`; model-specific AMD env vars include `SGLANG_USE_AITER=1` and `SGLANG_ROCM_FUSED_DECODE_MLA=0`.
+- AMD MoE/MLA: check AITER kernel constraints on TP (e.g., `heads_per_gpu % 16 == 0`)
+- Multi-node commands are never auto-generated. If a model does not fit within one node, the generator should output not available and ask for a verified multi-node command.
+
+Expert Parallelism (EP) for MoE models — common patterns observed:
+
+- 8-GPU NVIDIA: `--tp 8 --ep 8`
+- AMD (all TP sizes): `EP = TP` (e.g., `--tp 4 --ep 4`)
+- Smaller NVIDIA configs (TP≤4): omit `--ep` unless explicitly benchmarked — don't blindly scale EP
+
+Before starting files, check duplicate work:
+
+```bash
+gh pr list --search "<model name>"
+```
+
+## Phase 2: Create Files
+
+Read the relevant current files before writing:
+
+- **Template**: [templates/config-generator.jsx.tmpl](templates/config-generator.jsx.tmpl) — source of truth for new autoregressive snippets.
+- **Similar MDX**: pick a recent page under `docs_new/cookbook/<category>/`.
+- **Category intro**: `docs_new/cookbook/autoregressive/intro.mdx`, `docs_new/cookbook/diffusion/intro.mdx`, or `docs_new/cookbook/omni/intro.mdx`.
+- **Navigation**: `docs_new/docs.json`.
+
+### Step 1: Create the MDX page
+
+Path: `docs_new/cookbook/<category>/<Vendor>/<ModelName>.mdx`.
+
+Required frontmatter:
+
+See [references/frontmatter-example.mdx](references/frontmatter-example.mdx).
+
+For **autoregressive** pages, use five top-level sections:
+
+1. **Model Introduction** — concise intro, Key Features, Available Models when there are multiple entries, benchmark/feature tables as JSX tables, Recommended Generation Parameters, License, HF/blog links. If there is only one model entry, inline the HF link in the intro.
+2. **SGLang Installation** — link to `../../../docs/get-started/install`; include a Docker Images by Hardware Platform JSX table for tested platforms. Example: [references/installation-table-example.jsx](references/installation-table-example.jsx).
+3. **Model Deployment** — `### 3.1 Basic Configuration` embeds the snippet:
+   see [references/deployment-snippet-embed-example.mdx](references/deployment-snippet-embed-example.mdx).
+   Put imports in the MDX body, not frontmatter. Use absolute `/src/snippets/...` imports, never `@site/...`. Add `### 3.2 Configuration Tips`.
+4. **Model Invocation** — include a canonical deployment command at top, then `### 4.1 Basic Usage` linking to `../../../docs/basic_usage/send_request`, and `### 4.2 Advanced Usage` with reasoning, tool calling, multimodal/tool-call subsections only when applicable. Each followed by an `**Output Example:**` + ```text block. Use `Pending update...` placeholders if the model isn't yet deployed.
+5. **Benchmark** — order is strict: `### 5.1 Accuracy Benchmark`, then `### 5.2 Speed Benchmark`. `Pending update...` placeholders are acceptable for unfinished runs. Benchmark test-environment metadata (Hardware, Model quantization, TP, SGLang version, Docker image) must match a quantization actually listed in Section 1 — `(BF16)` on a model that only released INT4 is a factual bug.
+
+Benchmark commands — each benchmark has two pieces. The **deploy** (server launch at the top of the section) uses `sglang serve`. The **bench workload** uses `python3 -m sglang.bench_serving` (never bare `python -m`).
+
+Accuracy benchmark commands:
+
+**SGLang built-in benchmarks** (lightweight, no extra deps):
+- GSM8K: `python3 benchmark/gsm8k/bench_sglang.py --port <port>`
+- MMLU: `python3 benchmark/mmlu/bench_sglang.py --port <port>`
+- MMMU: `python3 benchmark/mmmu/bench_sglang.py --port <port>` — uses a universal answer regex that works across models. Don't use model-specific parsing (e.g., `<|begin_of_box|>`) as it breaks with standard answer formats. Note: this is plain MMMU, not MMMU-Pro or MMMU-Pro-Vision — those are separate benchmarks.
+- Latency: `python3 -m sglang.bench_serving --backend sglang --num-prompts 10 --max-concurrency 1 ...`
+- Throughput: `python3 -m sglang.bench_serving --backend sglang --num-prompts 1000 --max-concurrency 100 ...`
+
+**Heavier reasoning/MCQ suites** via [NVIDIA NeMo-Skills](https://github.com/NVIDIA-NeMo/Skills) (GPQA Diamond, AIME, MMLU-Pro, etc.):
+- `ns prepare_data <dataset>` then `ns eval --server_type=openai --server_address=http://localhost:30000/v1 --model=<hf-path> --benchmarks=<name>:<epochs> ...`
+- For reasoning-mode models, pass `++parse_reasoning=True` so the grader sees the answer, not the `<think>` content.
+- MMLU-Pro is 10-choice — use `++prompt_config=eval/aai/mcq-10choices` (not the 4-choice config).
+- Give extended-thinking models enough budget: `++inference.tokens_to_generate=120000` is typical. A 32K cap often produces a spiky "No Answer" rate; call this out in the results if it happens.
+- Report results as a table with `pass@1 (avg-of-N)`, `majority@N`, `pass@N`, plus a `No Answer` column if non-zero. Example: [references/benchmark-results-table-example.jsx](references/benchmark-results-table-example.jsx).
+
+Don't add multiple scenarios or concurrency levels unless asked.
+
+For **diffusion** and **omni** pages, do not force the autoregressive five-section/generator structure. Follow the closest existing category page, but still obey Mintlify formatting, NEW tag, `docs.json`, category card, and validation rules.
+
+**JSX table pattern**: use JSX tables for every table. Markdown pipe tables are forbidden for new pages. Base pattern: [references/jsx-table-pattern.jsx](references/jsx-table-pattern.jsx).
+
+For 3-col or 5-col tables, adjust `<colgroup>` and alternate column background colors.
+
+Mintlify rules:
+
+- Allowed docs components: `<Card>`, `<CardGroup>`, `<Note>`, `<Tip>`, `<Warning>`, `<Info>`, `<Accordion>`, `<AccordionGroup>`, `<Steps>`, `<Step>`, `<Tabs>`, `<Tab>`, `<CodeGroup>`, `<Frame>`, `<Icon>`.
+- `<CardGroup>`/`<Card>` are for intro pages only, not individual model pages.
+- Forbidden syntax: Docusaurus admonitions (`:::note` etc.), `@site/...`, `@theme/...`, GitHub alert blocks (`> [!NOTE]`), markdown pipe tables, inline `<details>/<summary>`, and unknown components.
+- Use labeled fences: ` ```python Example`, ` ```shell Command`, ` ```bash Command`, ` ```text Output`.
+- When nesting code fences inside another code fence, use four backticks for the outer fence.
+
+Content rules carried over from the old cookbook:
+
+- Deploy commands use `sglang serve --model-path ...`. Benchmark workload commands use `python3 -m sglang.bench_serving ...`; built-in accuracy scripts use `python3 benchmark/...`.
+- Keep one canonical deployment command when possible; avoid duplicating launch commands across invocation and benchmark sections. Refer back to the canonical command or state the exact generator selection.
+- Launch port must match client, curl, and benchmark port on the same page; default to `30000`.
+- Every runnable invocation code block needs `**Output Example:**` followed by a ` ```text Output` block. Real output is preferred; `Pending update...` is acceptable only with user acknowledgement.
+- Do not hardcode sampling params (`temperature`, `top_p`) in sample code; SGLang uses `generation_config.json` defaults. Listing recommended params in Section 1 is fine.
+- Benchmark metadata quantization must match a variant listed in Section 1.
+- License must match the actual HF license; never copy from another model.
+- No Google Drive images and no shell no-ops like `export VAR=${VAR}`.
+- Reasoning parser examples must match the parser output shape:
+  - separate field parsers (`kimi_k2`, most qwen/glm): print `reasoning_content` and `content`;
+  - inline tag parsers (`minimax-append-think`): parse `<think>...</think>` from `content`.
+- Thinking-mode tool-call follow-up may put final text in `reasoning_content`; print both `reasoning_content` and `content`.
+- Format raw API objects into readable Reasoning / Content / Tool Calls blocks.
+
+Notes:
+- Nested code blocks: use four backticks ```````` for the outer block
+- Don't hardcode sampling params (`temperature`, `top_p`) in sample code — SGLang uses `generation_config.json` defaults. (It's fine to list "Recommended Generation Parameters" informationally in Section 1.)
+- Hybrid reasoning models: show both thinking-on (default) and thinking-off (`enable_thinking: False`) examples
+- Separate Instruct/Thinking variants (e.g., Qwen3-Next): model name changes, handled by ConfigGenerator
+- Format raw API response objects (e.g., `ChatCompletionMessage(...)`) into readable structured output
+- Tool-call follow-up on thinking-mode models: the final assistant response may put text in `reasoning_content` instead of (or in addition to) `content`. When writing the example, print both so the output isn't misleadingly `None`.
+- Invocation section output format: immediately after each code block, add `**Output Example:**` followed by a ```text fenced block with the real run output. Keep the text verbatim from the server — don't paraphrase.
+
+### Step 2: Update `docs.json`, NEW tags, and category intro card
+
+`docs_new/docs.json`:
+
+- Add the new page under the Cookbook tab, in the correct category and vendor group.
+- Put the new page at the top of that vendor's `pages` list.
+- If the vendor group is new, insert it in the category list in the local ordering style used by that section.
+
+NEW tags:
+
+- The new page must have `tag: NEW`.
+- Scan the same `docs_new/cookbook/<category>/<Vendor>/` directory for existing `tag: NEW` and remove it from siblings.
+- Do not assume the current first `docs.json` page is the one holding NEW; scan the files.
+- Verify: `grep -rn 'tag: NEW' docs_new/cookbook/<category>/<Vendor>/` returns at most one result.
+
+Category intro card:
+
+- Autoregressive: `docs_new/cookbook/autoregressive/intro.mdx`
+- Diffusion: `docs_new/cookbook/diffusion/intro.mdx`
+- Omni: `docs_new/cookbook/omni/intro.mdx`
+
+If the org already has a `<Card>`, update only `href` to the new page and keep the existing `img`. If the org is new, add a card:
+see [references/category-intro-card-example.jsx](references/category-intro-card-example.jsx).
+
+Tell the user to provide `docs_new/cards/logos/<org-slug>.png`; do not invent or copy a logo.
+
+### Step 3: Create the autoregressive config generator
+
+Path: `docs_new/src/snippets/autoregressive/<name>-deployment.jsx`.
+
+Stamp from [templates/config-generator.jsx.tmpl](templates/config-generator.jsx.tmpl). Fill in `CONFIG` and the exported component name. Keep helpers/render logic unchanged unless the model truly needs a template-level behavior change.
+
+Template behavior:
+
+- Row 1: all 11 GPUs grouped by NVIDIA / AMD. Green dot means verified. Unverified combos have no dot and no warning banner.
+- Row 2: model variant buttons only. Do not mix quantization into the variant label unless the model itself is quantization-specific.
+- Row 3: quantization buttons for the selected model variant. Quantization choices come from the HuggingFace model card / linked repos. BF16 is the default when available.
+- Row 4: strategy checkboxes. TP is required. EP shows only for applicable MoE configs. MTP shows only when confirmed by the selected variant/quantization. Optimized appears here, not in features, and is enabled only when the selected strategy profile has a matching verbatim optimized command. PP is intentionally hidden for now.
+- Row 5: feature buttons. Parsers are parameterized from `CONFIG.model.toolCallParser` and `CONFIG.model.reasoningParser`; no `<parser>` placeholders. Parser buttons default enabled when configured. Mamba/KV FP8/chat template appear only when confirmed and default from the selected quantization reference or explicit CONFIG.
+- Layout: keep the generator inside the normal Mintlify content column. Do not use negative margins or viewport-width breakout styles that can overlap the left nav or right TOC/sidebar. Hardware rows may wrap within the content column.
+- `modelVariants[].quantizations[].reference` is mandatory. It stores parsed fields from the user-provided reference command and is the basis for unverified auto-generation.
+- `reference.env`, `estimates[hardwareId].env`, and `verified[variantId][quantizationId][hardwareId].env` are optional arrays of `KEY=VALUE` strings. Most combos omit them; include them only when the author-provided command actually needs them.
+- `verified[variantId][quantizationId][hardwareId]` overrides reference-derived estimates for tested combos.
+- `optimizedCommands.default` and `optimizedCommands.mtp` are optional verbatim commands on verified combos.
+
+Command generation rules:
+
+- Verified combo: use verified data.
+- Unverified combo: derive from the selected variant + quantization reference, adjusting only single-node TP, mem, and platform-required flags.
+- Single-node maxTP defaults to 8; GB200/GB300 maxTP is 4.
+- Non-optimized env prefixes come from resolved data in this order: `verified.env`, else `estimate.env`, else `reference.env`.
+- For non-optimized MTP commands, prepend `SGLANG_ENABLE_SPEC_V2=1` unless it is already present.
+- Do not invent non-MTP env prefixes. Preserve them only when explicitly provided or confirmed.
+- If estimated TP exceeds maxTP, show:
+  ```text
+  # Not available: estimated deployment requires multiple nodes.
+  # Please provide a verified multi-node deployment command.
+  ```
+- Do not auto-generate multi-node commands.
+- Single-node DP emits `--dp <tp> --enable-dp-attention`.
+- Optimized strategy:
+  - with MTP selected, emit `optimizedCommands.mtp` if present;
+  - without MTP, emit `optimizedCommands.default` if present;
+  - if the selected profile has no optimized command, keep the toggle disabled or show an explicit not-available message;
+  - never append, remove, or rewrite flags inside optimized commands.
+
+Doc-generator parity:
+
+- Every launch command shown in the MDX must match the generator output for the same variant/hardware/strategy/features.
+- If a flag appears in generated AMD/B200/GB commands, the corresponding documented command must include it too.
+
+## Phase 3: Validate
+
+Run from `docs_new/`:
+
+```bash
+mint validate
+mint broken-links
+mint dev
+```
+
+Visual checks:
+
+- NEW badge renders on the new page and is gone from same-org siblings.
+- Category intro card points to the new model.
+- Generator shows all 11 GPUs grouped by vendor.
+- Verified combos show green dots; unverified combos show no warning banner.
+- Too-large single-node estimates show the not-available command.
+- Parser/features hide, show, enable, and default according to CONFIG/reference.
+- Optimized default and optimized MTP emit the correct verbatim commands.
+
+## Phase 4: Interactive Testing
+
+User deploys the model, runs scripts, and pastes results. Replace `Pending update...` placeholders with actual outputs:
+
+1. Invocation results: basic generation, streaming/reasoning, tool calling, multimodal/tool-call if applicable.
+2. Accuracy benchmarks: GSM8K, MMLU, MMMU, GPQA/AIME/MMLU-Pro if applicable.
+3. Speed benchmarks: latency and throughput.
+
+## Phase 5: Configuration Tips
+
+Ask for recommended settings, known issues, DP attention tradeoffs, hardware-specific `--mem-fraction-static`, parser/template nuances, and any unsupported hardware/feature combinations. Add them to `### 3.2 Configuration Tips`.
+
+## Phase 6: Review Checklist
+
+Can be triggered with `/cookbook-add-model review`.
+
+**MDX**
+
+- [ ] Frontmatter has `title`, `metatags.description`, `tag: NEW`.
+- [ ] Same category/vendor directory has at most one `tag: NEW`.
+- [ ] Category intro `<Card href>` points to the new model.
+- [ ] New org card has a real planned logo path and the user was told to provide the asset.
+- [ ] Imports use absolute `/src/snippets/...` paths in the MDX body.
+- [ ] No markdown pipe tables, Docusaurus syntax, GitHub alert blocks, `<details>`, `@site`, or unknown components.
+- [ ] Code fences are labeled; nested fences use four backticks outside.
+- [ ] Runnable invocation blocks have `**Output Example:**` plus ` ```text Output`.
+- [ ] Deploy commands use `sglang serve --model-path`; bench workload commands use `python3 -m sglang.bench_serving`.
+- [ ] One canonical deployment command is reused or referenced; no unnecessary duplicate launch blocks.
+- [ ] Ports match across launch, client/curl, and benchmarks.
+- [ ] Benchmark order is accuracy first, speed second.
+- [ ] Benchmark metadata quantization matches a listed variant.
+- [ ] Reasoning/tool-call examples match actual parser output shape.
+- [ ] License matches the HF card.
+- [ ] No hardcoded sampling params, Google Drive images, or `export VAR=${VAR}` no-ops.
+
+**docs.json**
+
+- [ ] New model is at the top of its vendor `pages` array.
+- [ ] New vendor group is inserted in the section's local ordering style.
+
+**Config generator**
+
+- [ ] Stamped from `templates/config-generator.jsx.tmpl`; only CONFIG/export name changed unless justified.
+- [ ] Exactly one top-level `export const <Name>Deployment = () => { ... }`.
+- [ ] No bare module imports.
+- [ ] All CONFIG, helpers, styles, and render code are closure-scoped inside the component.
+- [ ] All 11 GPUs are present and grouped NVIDIA / AMD.
+- [ ] Every variant has a parsed `reference` command.
+- [ ] `verified` covers only tested combos.
+- [ ] Optional env prefixes are preserved only where confirmed.
+- [ ] Unverified combos have no green dot and no warning banner.
+- [ ] Over-maxTP single-node estimates show the not-available command.
+- [ ] Parser and feature flags are parameterized; no `<parser>` placeholders.
+- [ ] MTP/Mamba/KV FP8/chat template are shown only when confirmed.
+- [ ] Optimized default and optimized MTP commands are verbatim and selected by strategy profile.
+- [ ] No dead code or unreachable feature/strategy branches.
+- [ ] Doc-generator parity is checked.
+
+**Validation**
+
+- [ ] `mint validate` passes.
+- [ ] `mint broken-links` passes.
+- [ ] `mint dev` visual inspection passes.
+
+## Git Workflow
+
+Always create a branch; never commit directly to main.
+
+Example sequence: [references/git-workflow-example.sh](references/git-workflow-example.sh).
+
+Do not commit generated YAML or compiled files; the new cookbook has none.

--- a/.claude/skills/cookbook-add-model/references/benchmark-results-table-example.jsx
+++ b/.claude/skills/cookbook-add-model/references/benchmark-results-table-example.jsx
@@ -1,0 +1,55 @@
+<table style={{ width: "100%", borderCollapse: "collapse", tableLayout: "fixed" }}>
+  <colgroup>
+    <col style={{ width: "46%" }} />
+    <col style={{ width: "27%" }} />
+    <col style={{ width: "27%" }} />
+  </colgroup>
+  <thead>
+    <tr style={{ borderBottom: "2px solid #d55816" }}>
+      <th style={{ textAlign: "left", padding: "10px 12px", fontWeight: 700, backgroundColor: "rgba(255,255,255,0.02)" }}>
+        Evaluation Mode
+      </th>
+      <th style={{ textAlign: "left", padding: "10px 12px", fontWeight: 700, backgroundColor: "rgba(255,255,255,0.05)" }}>
+        Accuracy
+      </th>
+      <th style={{ textAlign: "left", padding: "10px 12px", fontWeight: 700, backgroundColor: "rgba(255,255,255,0.02)" }}>
+        No Answer
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style={{ padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)" }}>
+        pass@1 (avg-of-8)
+      </td>
+      <td style={{ padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)" }}>
+        84.91%
+      </td>
+      <td style={{ padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)" }}>
+        3.54%
+      </td>
+    </tr>
+    <tr>
+      <td style={{ padding: "9px 12px", fontWeight: 700, backgroundColor: "rgba(255,255,255,0.02)" }}>
+        majority@8
+      </td>
+      <td style={{ padding: "9px 12px", fontWeight: 700, backgroundColor: "rgba(255,255,255,0.05)" }}>
+        88.89%
+      </td>
+      <td style={{ padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)" }}>
+        0.00%
+      </td>
+    </tr>
+    <tr>
+      <td style={{ padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)" }}>
+        pass@8
+      </td>
+      <td style={{ padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)" }}>
+        96.46%
+      </td>
+      <td style={{ padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)" }}>
+        0.00%
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/.claude/skills/cookbook-add-model/references/category-intro-card-example.jsx
+++ b/.claude/skills/cookbook-add-model/references/category-intro-card-example.jsx
@@ -1,0 +1,6 @@
+<Card
+  title="<Org Name>"
+  mode="card"
+  href="/cookbook/<category>/<Org>/<Model>"
+  img="/cards/logos/<org-slug>.png"
+/>

--- a/.claude/skills/cookbook-add-model/references/deployment-snippet-embed-example.mdx
+++ b/.claude/skills/cookbook-add-model/references/deployment-snippet-embed-example.mdx
@@ -1,0 +1,3 @@
+import { <Name>Deployment } from "/src/snippets/autoregressive/<name>-deployment.jsx";
+
+<<Name>Deployment />

--- a/.claude/skills/cookbook-add-model/references/frontmatter-example.mdx
+++ b/.claude/skills/cookbook-add-model/references/frontmatter-example.mdx
@@ -1,0 +1,6 @@
+---
+title: <Model Name>
+metatags:
+    description: "<SEO line — deploy X with SGLang, key capabilities>"
+tag: NEW
+---

--- a/.claude/skills/cookbook-add-model/references/git-workflow-example.sh
+++ b/.claude/skills/cookbook-add-model/references/git-workflow-example.sh
@@ -1,0 +1,9 @@
+git checkout -b add-<model-slug>
+git add docs_new/cookbook/<category>/<Vendor>/<Model>.mdx
+git add docs_new/src/snippets/autoregressive/<name>-deployment.jsx
+git add docs_new/cookbook/<category>/intro.mdx
+git add docs_new/cookbook/<category>/<Vendor>/<PreviousNew>.mdx
+git add docs_new/docs.json
+git commit -m "Add <Model Name> cookbook"
+git push -u origin add-<model-slug>
+gh pr create --title "Add <Model Name> cookbook" --body "..."

--- a/.claude/skills/cookbook-add-model/references/installation-table-example.jsx
+++ b/.claude/skills/cookbook-add-model/references/installation-table-example.jsx
@@ -1,0 +1,50 @@
+<table style={{ width: "100%", borderCollapse: "collapse", tableLayout: "fixed" }}>
+  <colgroup>
+    <col style={{ width: "55%" }} />
+    <col style={{ width: "45%" }} />
+  </colgroup>
+  <thead>
+    <tr style={{ borderBottom: "2px solid #d55816" }}>
+      <th style={{ textAlign: "left", padding: "10px 12px", fontWeight: 700, backgroundColor: "rgba(255,255,255,0.02)" }}>
+        Hardware Platform
+      </th>
+      <th style={{ textAlign: "left", padding: "10px 12px", fontWeight: 700, backgroundColor: "rgba(255,255,255,0.05)" }}>
+        Docker Image
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style={{ padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)" }}>
+        NVIDIA A100 / H100 / H200 / B200
+      </td>
+      <td style={{ padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)" }}>
+        <code>lmsysorg/sglang:&lt;ver&gt;</code>
+      </td>
+    </tr>
+    <tr>
+      <td style={{ padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)" }}>
+        NVIDIA B300 / GB300
+      </td>
+      <td style={{ padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)" }}>
+        <code>lmsysorg/sglang:&lt;ver&gt;-cu130</code>
+      </td>
+    </tr>
+    <tr>
+      <td style={{ padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)" }}>
+        AMD MI300X / MI325X
+      </td>
+      <td style={{ padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)" }}>
+        <code>lmsysorg/sglang:&lt;ver&gt;-rocm720-mi30x</code>
+      </td>
+    </tr>
+    <tr>
+      <td style={{ padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)" }}>
+        AMD MI350X / MI355X
+      </td>
+      <td style={{ padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)" }}>
+        <code>lmsysorg/sglang:&lt;ver&gt;-rocm720-mi35x</code>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/.claude/skills/cookbook-add-model/references/jsx-table-pattern.jsx
+++ b/.claude/skills/cookbook-add-model/references/jsx-table-pattern.jsx
@@ -1,0 +1,24 @@
+<table style={{width: "100%", borderCollapse: "collapse", tableLayout: "fixed"}}>
+  <colgroup>
+    <col style={{width: "25%"}} />
+    <col style={{width: "25%"}} />
+    <col style={{width: "25%"}} />
+    <col style={{width: "25%"}} />
+  </colgroup>
+  <thead>
+    <tr style={{borderBottom: "2px solid #d55816"}}>
+      <th style={{textAlign: "left", padding: "10px 12px", fontWeight: 700, whiteSpace: "nowrap", backgroundColor: "rgba(255,255,255,0.02)"}}>Col 1</th>
+      <th style={{textAlign: "left", padding: "10px 12px", fontWeight: 700, whiteSpace: "nowrap", backgroundColor: "rgba(255,255,255,0.05)"}}>Col 2</th>
+      <th style={{textAlign: "left", padding: "10px 12px", fontWeight: 700, whiteSpace: "nowrap", backgroundColor: "rgba(255,255,255,0.02)"}}>Col 3</th>
+      <th style={{textAlign: "left", padding: "10px 12px", fontWeight: 700, whiteSpace: "nowrap", backgroundColor: "rgba(255,255,255,0.05)"}}>Col 4</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>cell</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>cell</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>cell</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>cell</td>
+    </tr>
+  </tbody>
+</table>

--- a/.claude/skills/cookbook-add-model/templates/config-generator.jsx.tmpl
+++ b/.claude/skills/cookbook-add-model/templates/config-generator.jsx.tmpl
@@ -615,7 +615,7 @@ export const __COMPONENT_NAME__ = () => {
                     locked && hwId !== h.id,
                     () => setHwId(h.id),
                     isVerified ? `${h.label} - verified by contributor` : h.label,
-                    undefined,
+                    h.vramGB ? `${h.vramGB}GB` : undefined,
                     isVerified,
                   );
                 })}

--- a/.claude/skills/cookbook-add-model/templates/config-generator.jsx.tmpl
+++ b/.claude/skills/cookbook-add-model/templates/config-generator.jsx.tmpl
@@ -1,0 +1,677 @@
+// Template: unified SGLang autoregressive cookbook config generator for
+// Mintlify /src/snippets/.
+//
+// Usage: copy this file to
+//   docs_new/src/snippets/autoregressive/<name>-deployment.jsx
+// and edit only the CONFIG block + `export const` name unless every cookbook
+// generator needs the behavior change.
+//
+// HARD RULES for Mintlify /src/snippets/ jsx:
+//   1. No bare React or package imports. Mintlify only
+//      permits local imports; `useState` and `useEffect` are globals.
+//   2. Exactly one top-level export:
+//        `export const __COMPONENT_NAME__ = () => { ... }`
+//      CONFIG, helpers, styles, and render code must stay inside the component.
+//   3. JSX only. Avoid TypeScript and avoid optional chaining inside JSX.
+//
+// Placeholders:
+//   __COMPONENT_NAME__   e.g. "GLM46Deployment"
+//   __MODEL_DISPLAY__    e.g. "GLM-4.6"
+
+export const __COMPONENT_NAME__ = () => {
+  // -------------------------------------------------------------------------
+  // CONFIG - edit per model.
+  // -------------------------------------------------------------------------
+  const CONFIG = {
+    model: {
+      displayName: "__MODEL_DISPLAY__",
+      isMoE: false,          // true -> paramsB is TOTAL params across experts
+      supportsSpec: false,   // true only when MTP/EAGLE is confirmed
+      supportsKVFP8: false,  // true only when KV FP8 is confirmed
+      hasMamba: false,       // true only when Mamba cache flags are relevant
+      toolCallParser: "",    // e.g. "qwen3_coder"; empty -> button hidden
+      reasoningParser: "",   // e.g. "qwen3"; empty -> button hidden
+      chatTemplatePath: "",  // empty -> button hidden
+      specFlags:
+        "--speculative-algorithm EAGLE \\\n" +
+        "  --speculative-num-steps 3 \\\n" +
+        "  --speculative-eagle-topk 1 \\\n" +
+        "  --speculative-num-draft-tokens 4",
+    },
+
+    // Row 1 - Hardware. All 11 GPUs are rendered. maxTP is single-node only;
+    // GB systems default to 4 GPUs per node.
+    hardware: {
+      title: "Hardware Platform",
+      groups: [
+        {
+          vendor: "NVIDIA",
+          items: [
+            { id: "a100",  label: "A100",  vramGB: 80,  maxTP: 8 },
+            { id: "h100",  label: "H100",  vramGB: 80,  maxTP: 8 },
+            { id: "h200",  label: "H200",  vramGB: 141, maxTP: 8 },
+            { id: "b200",  label: "B200",  vramGB: 180, maxTP: 8 },
+            { id: "b300",  label: "B300",  vramGB: 275, maxTP: 8 },
+            { id: "gb200", label: "GB200", vramGB: 192, maxTP: 4 },
+            { id: "gb300", label: "GB300", vramGB: 275, maxTP: 4 },
+          ],
+        },
+        {
+          vendor: "AMD",
+          items: [
+            { id: "mi300x", label: "MI300X", vramGB: 192, maxTP: 8 },
+            { id: "mi325x", label: "MI325X", vramGB: 256, maxTP: 8 },
+            { id: "mi350x", label: "MI350X", vramGB: 288, maxTP: 8 },
+            { id: "mi355x", label: "MI355X", vramGB: 288, maxTP: 8 },
+          ],
+        },
+      ],
+    },
+
+    // Row 2 + 3 - Model Variant and Quantization are separate.
+    // Quantization choices come from the HuggingFace model card / linked repos.
+    // Each quantization must include a parsed reference command. The builder
+    // derives unverified single-node commands from that reference and only
+    // adjusts hardware-sensitive values such as TP, mem, and platform flags.
+    modelVariants: [
+      // {
+      //   id: "<variant-slug>",
+      //   label: "<Model Variant>",
+      //   paramsB: 0,
+      //   isMoE: false,
+      //   supportsSpec: false,
+      //   hasMamba: false,
+      //   quantizations: [
+      //     {
+      //       id: "bf16",
+      //       label: "BF16",
+      //       default: true,
+      //       hfPath: "<org>/<repo>",
+      //       bytesPerParam: 2, // BF16/FP16=2, FP8=1, FP4/NVFP4=0.5
+      //       reference: {
+      //         hardware: "h200",
+      //         env: ["SGLANG_USE_AITER=1"],
+      //         tp: 8,
+      //         ep: 0,
+      //         mem: 0.9,
+      //         flags: [],
+      //         strategies: ["tp"],
+      //         features: ["reasoning", "toolCall"],
+      //         command: "sglang serve \\\n  --model-path <org>/<repo> \\\n  --tp 8",
+      //       },
+      //     },
+      //   ],
+      // },
+    ],
+
+    // Verified matrix. Missing combo -> reference-derived single-node estimate.
+    // optimizedCommands is author-provided verbatim and is never rewritten.
+    verified: {
+      // "<variantId>": {
+      //   "<quantizationId>": {
+      //     h200: {
+      //       env: ["SGLANG_USE_AITER=1"],
+      //       tp: 8,
+      //       ep: 8,
+      //       mem: 0.85,
+      //       flags: [],
+      //       strategies: ["tp", "ep"],
+      //       features: ["reasoning", "toolCall"],
+      //       optimizedCommands: {
+      //         default: "sglang serve \\\n  --model-path <hf> \\\n  ...",
+      //         mtp: "SGLANG_ENABLE_SPEC_V2=1 sglang serve \\\n  --model-path <hf> \\\n  ...",
+      //       },
+      //     },
+      //   },
+      // },
+    },
+
+    strategy: {
+      title: "Deployment Strategy",
+      items: [
+        { id: "tp",  label: "TP",  subtitle: "Tensor Parallel",              default: true, required: true },
+        { id: "ep",  label: "EP",  subtitle: "Expert Parallel",              defaultFromReference: true,
+          showWhen: (ctx) => capability(ctx, "isMoE") },
+        { id: "dp",  label: "DP",  subtitle: "Data Parallel + DP-Attention", defaultFromReference: true },
+        { id: "mtp", label: "MTP / EAGLE", subtitle: "Speculative decoding", defaultFromReference: true,
+          showWhen: (ctx) => capability(ctx, "supportsSpec") },
+        { id: "optimized", label: "Optimized", subtitle: "Author-provided", kind: "optimized" },
+      ],
+    },
+
+    features: {
+      title: "Features",
+      items: [
+        { id: "toolCall",   label: "Tool Call Parser", default: true,
+          showWhen: (ctx) => Boolean(ctx.model.toolCallParser),
+          emit: (ctx) => `--tool-call-parser ${ctx.model.toolCallParser}` },
+        { id: "reasoning",  label: "Reasoning Parser", default: true,
+          showWhen: (ctx) => Boolean(ctx.model.reasoningParser),
+          emit: (ctx) => `--reasoning-parser ${ctx.model.reasoningParser}` },
+        { id: "mambaCache", label: "Mamba Radix Cache V2", defaultFromReference: true,
+          showWhen: (ctx) => capability(ctx, "hasMamba"),
+          emit: () => "--mamba-scheduler-strategy extra_buffer \\\n  --page-size 64" },
+        { id: "kvCacheFP8", label: "FP8 KV Cache", defaultFromReference: true,
+          showWhen: (ctx) => capability(ctx, "supportsKVFP8"),
+          emit: () => "--kv-cache-dtype fp8_e4m3" },
+        { id: "chatTemplate", label: "Chat Template", defaultFromReference: true,
+          showWhen: (ctx) => Boolean(ctx.model.chatTemplatePath),
+          emit: (ctx) => `--chat-template ${ctx.model.chatTemplatePath}` },
+      ],
+    },
+  };
+
+  // -------------------------------------------------------------------------
+  // Helpers (closure-scoped - keep inside the component).
+  // -------------------------------------------------------------------------
+  const nextPow2 = (n) => {
+    let p = 1;
+    while (p < n) p *= 2;
+    return p;
+  };
+
+  const arrayHas = (arr, id) => Array.isArray(arr) && arr.indexOf(id) >= 0;
+  const cloneEnv = (env) => (Array.isArray(env) ? [...env] : []);
+  const sameArray = (a, b) => {
+    if (!Array.isArray(a) || !Array.isArray(b)) return false;
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i += 1) {
+      if (a[i] !== b[i]) return false;
+    }
+    return true;
+  };
+
+  const capability = (ctx, key) => {
+    if (ctx.quantization && typeof ctx.quantization[key] === "boolean") return ctx.quantization[key];
+    if (ctx.variant && typeof ctx.variant[key] === "boolean") return ctx.variant[key];
+    return Boolean(ctx.model[key]);
+  };
+
+  const findVariant = (id) => CONFIG.modelVariants.find((v) => v.id === id);
+
+  const defaultQuantizationId = (variantId) => {
+    const variant = findVariant(variantId);
+    if (!variant || !Array.isArray(variant.quantizations) || variant.quantizations.length === 0) return "";
+    const bf16 = variant.quantizations.find((q) => q.id === "bf16");
+    const defaultQuant = variant.quantizations.find((q) => q.default);
+    return (bf16 || defaultQuant || variant.quantizations[0]).id;
+  };
+
+  const findQuantization = (variantId, quantizationId) => {
+    const variant = findVariant(variantId);
+    if (!variant || !Array.isArray(variant.quantizations)) return null;
+    return variant.quantizations.find((q) => q.id === quantizationId) || null;
+  };
+
+  const findHardware = (id) => {
+    for (const g of CONFIG.hardware.groups) {
+      const h = g.items.find((x) => x.id === id);
+      if (h) return { ...h, vendor: g.vendor };
+    }
+    return null;
+  };
+
+  const verifiedEntry = (variantId, quantizationId, hwId) => {
+    const variantRow = CONFIG.verified[variantId];
+    const quantRow = variantRow && variantRow[quantizationId] ? variantRow[quantizationId] : null;
+    return quantRow && quantRow[hwId] ? quantRow[hwId] : null;
+  };
+
+  const contextFor = (variantId, quantizationId, hwId) => {
+    const variant = findVariant(variantId);
+    const quantization = findQuantization(variantId, quantizationId);
+    const hw = findHardware(hwId);
+    const verified = variant && quantization && hw ? verifiedEntry(variantId, quantizationId, hwId) : null;
+    const reference = quantization && quantization.reference ? quantization.reference : {};
+    return { model: CONFIG.model, variant, quantization, hardware: hw, verified, reference };
+  };
+
+  const sourceForContext = (ctx) => {
+    if (!ctx || !ctx.quantization) return {};
+    const estimates = ctx.quantization.estimates || {};
+    return ctx.verified || estimates[ctx.hardware.id] || ctx.reference || {};
+  };
+
+  const isVisible = (item, ctx) => {
+    if (typeof item.showWhen === "function") return item.showWhen(ctx);
+    return true;
+  };
+
+  const isEnabled = (item, ctx) => {
+    if (typeof item.enableWhen === "function") return item.enableWhen(ctx);
+    return true;
+  };
+
+  const visibleStrategyItems = (ctx) => CONFIG.strategy.items.filter((item) => isVisible(item, ctx));
+
+  const visibleFeatureItems = (ctx) => CONFIG.features.items.filter((item) => isVisible(item, ctx));
+
+  const defaultStrategyIds = (variantId, quantizationId, hwId) => {
+    const ctx = contextFor(variantId, quantizationId, hwId);
+    const source = sourceForContext(ctx);
+    return visibleStrategyItems(ctx)
+      .filter((item) => item.kind !== "optimized")
+      .filter((item) => item.default || (item.defaultFromReference && arrayHas(source.strategies, item.id)))
+      .map((item) => item.id);
+  };
+
+  const defaultFeatureIds = (variantId, quantizationId, hwId) => {
+    const ctx = contextFor(variantId, quantizationId, hwId);
+    const source = sourceForContext(ctx);
+    return visibleFeatureItems(ctx)
+      .filter((item) => item.default || (item.defaultFromReference && arrayHas(source.features, item.id)))
+      .map((item) => item.id);
+  };
+
+  const notAvailable = () => ({
+    cmd:
+      "# Not available: estimated deployment requires multiple nodes.\n" +
+      "# Please provide a verified multi-node deployment command.",
+    unavailable: true,
+    optimized: false,
+  });
+
+  const unsupported = () => ({
+    cmd:
+      "# Not available: this variant or quantization is not supported on the selected hardware.\n" +
+      "# Please provide a verified deployment command for this combination.",
+    unavailable: true,
+    optimized: false,
+  });
+
+  const autoEstimate = (variant, quantization, hw) => {
+    if (
+      Array.isArray(quantization.availableHardware) &&
+      quantization.availableHardware.indexOf(hw.id) < 0
+    ) {
+      return { unsupported: true };
+    }
+
+    if (quantization.estimates && quantization.estimates[hw.id]) {
+      const estimate = quantization.estimates[hw.id];
+      if (estimate.tp && estimate.tp > hw.maxTP) return { unavailable: true };
+      return {
+        env: cloneEnv(estimate.env),
+        tp: estimate.tp,
+        ep: estimate.ep || 0,
+        mem: estimate.mem || 0.9,
+        flags: Array.isArray(estimate.flags) ? [...estimate.flags] : [],
+        strategies: Array.isArray(estimate.strategies) ? [...estimate.strategies] : ["tp"],
+        features: Array.isArray(estimate.features) ? [...estimate.features] : ["reasoning", "toolCall"],
+        unavailable: false,
+      };
+    }
+
+    const reference = quantization.reference ? quantization.reference : {};
+    const paramsB = quantization.paramsB || variant.paramsB || 0;
+    const bytesPerParam = quantization.bytesPerParam || 2;
+    const vramMin = Math.ceil(paramsB * bytesPerParam * 1.2);
+    const gpusNeeded = Math.max(1, Math.ceil(vramMin / hw.vramGB));
+    const neededTP = Math.max(1, nextPow2(gpusNeeded));
+    const cap = hw.maxTP ? hw.maxTP : 8;
+    if (neededTP > cap) return { unavailable: true, vramMin, neededTP, maxTP: cap };
+
+    const isAMD = hw.vendor === "AMD";
+    const referenceTP = reference.tp ? reference.tp : 1;
+    const tp = Math.min(cap, Math.max(neededTP, Math.min(referenceTP, cap)));
+    const referenceEP = reference.ep ? reference.ep : 0;
+    let ep = referenceEP;
+    if (capability({ model: CONFIG.model, variant, quantization }, "isMoE") && isAMD && referenceEP === referenceTP) ep = tp;
+
+    const mem = reference.mem ? reference.mem : isAMD && bytesPerParam >= 2 ? 0.85 : 0.9;
+    const flags = Array.isArray(reference.flags) ? [...reference.flags] : [];
+    if (isAMD && flags.indexOf("--attention-backend triton") < 0) flags.push("--attention-backend triton");
+
+    return {
+      env: cloneEnv(reference.env),
+      tp,
+      ep,
+      mem,
+      flags,
+      strategies: Array.isArray(reference.strategies) ? [...reference.strategies] : ["tp"],
+      features: Array.isArray(reference.features) ? [...reference.features] : [],
+      vramMin,
+      unavailable: false,
+    };
+  };
+
+  const optimizedCommandsFor = (entry) => {
+    if (!entry || !entry.optimizedCommands) return {};
+    return entry.optimizedCommands;
+  };
+
+  const optimizedProfile = (strategy) => (strategy.indexOf("mtp") >= 0 ? "mtp" : "default");
+
+  const hasOptimized = (variantId, quantizationId, hwId, strategy) => {
+    const entry = verifiedEntry(variantId, quantizationId, hwId);
+    const cmds = optimizedCommandsFor(entry);
+    const profile = optimizedProfile(strategy);
+    return Boolean(cmds[profile]);
+  };
+
+  const appendFeatureFlags = (cmd, ctx, selectedFeatures) => {
+    for (const feat of visibleFeatureItems(ctx)) {
+      if (selectedFeatures.indexOf(feat.id) < 0) continue;
+      if (!isEnabled(feat, ctx)) continue;
+      if (typeof feat.emit === "function") {
+        const emitted = feat.emit(ctx);
+        if (emitted) cmd += ` \\\n  ${emitted}`;
+      }
+    }
+    return cmd;
+  };
+
+  const buildCommand = (variantId, quantizationId, hwId, selectedStrategy, selectedFeatures) => {
+    const ctx = contextFor(variantId, quantizationId, hwId);
+    const variant = ctx.variant;
+    const quantization = ctx.quantization;
+    const hw = ctx.hardware;
+    if (!variant || !quantization || !hw) return { cmd: "", optimized: false };
+
+    const verified = ctx.verified;
+    const optimizedSelected = selectedStrategy.indexOf("optimized") >= 0;
+    if (optimizedSelected) {
+      const cmds = optimizedCommandsFor(verified);
+      const profile = optimizedProfile(selectedStrategy);
+      if (cmds[profile]) return { cmd: cmds[profile], optimized: true };
+      return {
+        cmd: "# Not available: no optimized command supplied for this strategy profile.",
+        optimized: true,
+        unavailable: true,
+      };
+    }
+
+    const resolved = verified ? verified : autoEstimate(variant, quantization, hw);
+    if (resolved.unsupported) return unsupported();
+    if (resolved.unavailable) return notAvailable();
+
+    const tp = resolved.tp ? resolved.tp : 1;
+    const ep = resolved.ep ? resolved.ep : 0;
+    const mem = resolved.mem;
+    const env = cloneEnv(resolved.env);
+    const flags = Array.isArray(resolved.flags) ? resolved.flags : [];
+
+    let cmd = "sglang serve \\\n";
+    cmd += `  --model-path ${quantization.hfPath}`;
+    if (selectedStrategy.indexOf("tp") >= 0 && tp > 1) cmd += ` \\\n  --tp ${tp}`;
+    if (selectedStrategy.indexOf("ep") >= 0 && ep > 0) cmd += ` \\\n  --ep ${ep}`;
+    if (selectedStrategy.indexOf("dp") >= 0) cmd += ` \\\n  --dp ${tp} \\\n  --enable-dp-attention`;
+    if (mem) cmd += ` \\\n  --mem-fraction-static ${mem}`;
+    for (const f of flags) cmd += ` \\\n  ${f}`;
+    cmd = appendFeatureFlags(cmd, ctx, selectedFeatures);
+
+    if (selectedStrategy.indexOf("mtp") >= 0) {
+      if (env.indexOf("SGLANG_ENABLE_SPEC_V2=1") < 0) env.unshift("SGLANG_ENABLE_SPEC_V2=1");
+      if (CONFIG.model.specFlags) cmd += ` \\\n  ${CONFIG.model.specFlags}`;
+    }
+    if (env.length > 0) cmd = `${env.join(" ")} ${cmd}`;
+    return { cmd, optimized: false };
+  };
+
+  // -------------------------------------------------------------------------
+  // State
+  // -------------------------------------------------------------------------
+  const initialVariant = CONFIG.modelVariants[0] ? CONFIG.modelVariants[0].id : "";
+  const initialQuantization = defaultQuantizationId(initialVariant);
+  const initialHardware = "h200";
+  const [variantId, setVariantId] = useState(initialVariant);
+  const [quantizationId, setQuantizationId] = useState(initialQuantization);
+  const [hwId, setHwId] = useState(initialHardware);
+  const [strategy, setStrategy] = useState(() => defaultStrategyIds(initialVariant, initialQuantization, initialHardware));
+  const [features, setFeatures] = useState(() => defaultFeatureIds(initialVariant, initialQuantization, initialHardware));
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const check = () => {
+      const html = document.documentElement;
+      const dark =
+        html.classList.contains("dark") ||
+        html.getAttribute("data-theme") === "dark" ||
+        html.style.colorScheme === "dark";
+      setIsDark(dark);
+    };
+    check();
+    const obs = new MutationObserver(check);
+    obs.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class", "data-theme", "style"],
+    });
+    return () => obs.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const variant = findVariant(variantId);
+    const quantization = findQuantization(variantId, quantizationId);
+    if (variant && !quantization) {
+      setQuantizationId(defaultQuantizationId(variantId));
+    }
+  }, [variantId, quantizationId]);
+
+  useEffect(() => {
+    const ctx = contextFor(variantId, quantizationId, hwId);
+    const visibleStrategy = visibleStrategyItems(ctx).map((item) => item.id);
+    const visibleFeatures = visibleFeatureItems(ctx).map((item) => item.id);
+    setStrategy((prev) => {
+      const defaults = defaultStrategyIds(variantId, quantizationId, hwId);
+      let kept = prev.filter((id) => visibleStrategy.indexOf(id) >= 0);
+      for (const id of defaults) {
+        if (kept.indexOf(id) < 0) kept.push(id);
+      }
+      if (kept.indexOf("tp") < 0) kept.unshift("tp");
+      if (kept.indexOf("optimized") >= 0 && !hasOptimized(variantId, quantizationId, hwId, kept)) {
+        kept = kept.filter((id) => id !== "optimized");
+      }
+      return sameArray(prev, kept) ? prev : kept;
+    });
+    setFeatures((prev) => {
+      const defaults = defaultFeatureIds(variantId, quantizationId, hwId);
+      const kept = prev.filter((id) => visibleFeatures.indexOf(id) >= 0);
+      for (const id of defaults) {
+        if (kept.indexOf(id) < 0) kept.push(id);
+      }
+      return sameArray(prev, kept) ? prev : kept;
+    });
+  }, [variantId, quantizationId, hwId, strategy]);
+
+  const toggleStrategy = (id) => {
+    const ctx = contextFor(variantId, quantizationId, hwId);
+    const item = CONFIG.strategy.items.find((x) => x.id === id);
+    if (item && item.required) return;
+    if (item && !isEnabled(item, ctx)) return;
+    if (item && item.kind === "optimized" && !hasOptimized(variantId, quantizationId, hwId, strategy)) return;
+    setStrategy((prev) => (prev.indexOf(id) >= 0 ? prev.filter((x) => x !== id) : [...prev, id]));
+  };
+
+  const toggleFeature = (id) => {
+    setFeatures((prev) => (prev.indexOf(id) >= 0 ? prev.filter((x) => x !== id) : [...prev, id]));
+  };
+
+  const { cmd, optimized } = buildCommand(variantId, quantizationId, hwId, strategy, features);
+  const locked = optimized;
+  const currentCtx = contextFor(variantId, quantizationId, hwId);
+  const selectedVariant = findVariant(variantId);
+  const currentQuantizations = selectedVariant && Array.isArray(selectedVariant.quantizations) ? selectedVariant.quantizations : [];
+
+  // -------------------------------------------------------------------------
+  // Styles
+  // -------------------------------------------------------------------------
+  const containerStyle = { maxWidth: "1160px", margin: "0 auto", display: "flex", flexDirection: "column", gap: "4px" };
+  const cardStyle = {
+    padding: "8px 12px",
+    border: `1px solid ${isDark ? "#374151" : "#e5e7eb"}`,
+    borderLeft: `3px solid ${isDark ? "#E85D4D" : "#D45D44"}`,
+    borderRadius: "4px",
+    display: "flex",
+    alignItems: "center",
+    gap: "12px",
+    background: isDark ? "#1f2937" : "#fff",
+  };
+  const titleStyle = { fontSize: "13px", fontWeight: "600", minWidth: "140px", flexShrink: 0, color: isDark ? "#e5e7eb" : "inherit" };
+  const itemsStyle = { display: "flex", rowGap: "2px", columnGap: "6px", flexWrap: "wrap", alignItems: "center", flex: 1 };
+  const labelBase = {
+    padding: "4px 10px",
+    border: `1px solid ${isDark ? "#9ca3af" : "#d1d5db"}`,
+    borderRadius: "3px",
+    cursor: "pointer",
+    display: "inline-flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    fontWeight: "500",
+    fontSize: "13px",
+    userSelect: "none",
+    minWidth: "54px",
+    textAlign: "center",
+    background: isDark ? "#374151" : "#fff",
+    color: isDark ? "#e5e7eb" : "inherit",
+  };
+  const checkedStyle = { background: "#D45D44", color: "white", borderColor: "#D45D44" };
+  const disabledStyle = { cursor: "not-allowed", opacity: 0.5 };
+  const subtitleStyle = { display: "block", fontSize: "9px", marginTop: "1px", lineHeight: "1.1", opacity: 0.7 };
+  const vendorLabelStyle = {
+    fontSize: "10px",
+    color: isDark ? "#9ca3af" : "#6b7280",
+    marginRight: "4px",
+    alignSelf: "center",
+    textTransform: "uppercase",
+    letterSpacing: "0.04em",
+  };
+  const commandDisplayStyle = {
+    flex: 1,
+    padding: "12px 16px",
+    background: isDark ? "#111827" : "#f5f5f5",
+    borderRadius: "6px",
+    fontFamily: "'Menlo', 'Monaco', 'Courier New', monospace",
+    fontSize: "12px",
+    lineHeight: "1.5",
+    color: isDark ? "#e5e7eb" : "#374151",
+    whiteSpace: "pre-wrap",
+    overflowX: "auto",
+    margin: 0,
+    border: `1px solid ${isDark ? "#374151" : "#e5e7eb"}`,
+  };
+  const verifiedDotStyle = {
+    width: "7px",
+    height: "7px",
+    borderRadius: "50%",
+    background: "#22c55e",
+    boxShadow: "0 0 4px rgba(34,197,94,0.6)",
+    position: "absolute",
+    top: "3px",
+    right: "3px",
+  };
+
+  const pill = (label, active, disabled, onClick, title, subtitle, showDot) => (
+    <label
+      key={label + (subtitle || "")}
+      title={title || ""}
+      onClick={() => !disabled && onClick && onClick()}
+      style={{
+        ...labelBase,
+        ...(active ? checkedStyle : {}),
+        ...(disabled ? disabledStyle : {}),
+        position: "relative",
+      }}
+    >
+      {showDot && <span style={verifiedDotStyle} />}
+      {label}
+      {subtitle && (
+        <small style={{ ...subtitleStyle, color: active ? "rgba(255,255,255,0.85)" : "inherit" }}>
+          {subtitle}
+        </small>
+      )}
+    </label>
+  );
+
+  return (
+    <div style={containerStyle} className="not-prose">
+      <div style={{ ...cardStyle, alignItems: "flex-start" }}>
+        <div style={{ ...titleStyle, paddingTop: "4px", display: "flex", flexDirection: "column", gap: "2px" }}>
+          <span>{CONFIG.hardware.title}</span>
+          <span
+            style={{
+              fontSize: "10px",
+              fontWeight: 400,
+              color: isDark ? "#9ca3af" : "#6b7280",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "4px",
+            }}
+          >
+            <span style={{ width: "6px", height: "6px", borderRadius: "50%", background: "#22c55e", display: "inline-block" }} />
+            verified
+          </span>
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: "4px", flex: 1 }}>
+          {CONFIG.hardware.groups.map((g) => (
+            <div key={g.vendor} style={{ display: "flex", alignItems: "center", gap: "6px", width: "100%" }}>
+              <span style={{ ...vendorLabelStyle, width: "44px", flexShrink: 0 }}>{g.vendor}</span>
+              <div style={{ display: "flex", flexWrap: "wrap", gap: "4px", flex: 1 }}>
+                {g.items.map((h) => {
+                  const isVerified = Boolean(verifiedEntry(variantId, quantizationId, h.id));
+                  return pill(
+                    h.label,
+                    hwId === h.id,
+                    locked && hwId !== h.id,
+                    () => setHwId(h.id),
+                    isVerified ? `${h.label} - verified by contributor` : h.label,
+                    undefined,
+                    isVerified,
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div style={cardStyle}>
+        <div style={titleStyle}>Model Variant</div>
+        <div style={itemsStyle}>
+          {CONFIG.modelVariants.map((v) =>
+            pill(v.label, variantId === v.id, locked && variantId !== v.id, () => setVariantId(v.id), v.label),
+          )}
+        </div>
+      </div>
+
+      <div style={cardStyle}>
+        <div style={titleStyle}>Quantization</div>
+        <div style={itemsStyle}>
+          {currentQuantizations.map((q) =>
+            pill(q.label, quantizationId === q.id, locked && quantizationId !== q.id, () => setQuantizationId(q.id), q.hfPath),
+          )}
+        </div>
+      </div>
+
+      <div style={cardStyle}>
+        <div style={titleStyle}>{CONFIG.strategy.title}</div>
+        <div style={itemsStyle}>
+          {visibleStrategyItems(currentCtx).map((item) => {
+            const active = strategy.indexOf(item.id) >= 0;
+            const isOpt = item.kind === "optimized";
+            const available = isOpt ? hasOptimized(variantId, quantizationId, hwId, strategy) : isEnabled(item, currentCtx);
+            const disabled = Boolean(item.required) || !available || (locked && !isOpt);
+            const title = isOpt && !available ? "No optimized command supplied for this strategy profile" : item.subtitle;
+            return pill(item.label, active, disabled, () => toggleStrategy(item.id), title, item.subtitle);
+          })}
+        </div>
+      </div>
+
+      <div style={cardStyle}>
+        <div style={titleStyle}>{CONFIG.features.title}</div>
+        <div style={itemsStyle}>
+          {visibleFeatureItems(currentCtx).map((f) => {
+            const active = features.indexOf(f.id) >= 0;
+            const disabled = locked || !isEnabled(f, currentCtx);
+            return pill(f.label, active, disabled, () => toggleFeature(f.id), f.label);
+          })}
+        </div>
+      </div>
+
+      <div style={cardStyle}>
+        <div style={titleStyle}>Run this Command:</div>
+        <pre style={commandDisplayStyle}>{cmd}</pre>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- Migrates the `add-model` Claude Code skill from the old Docusaurus cookbook to the new Mintlify-based cookbook (`docs_new/`) as `cookbook-add-model`.
- Ships `SKILL.md`, a unified `config-generator.jsx.tmpl` template, and reference examples (frontmatter, JSX tables, category intro cards, deployment embed, git workflow).
- Codifies Mintlify-specific rules (no bare `react` imports, single closure-scoped `export const`, `tag: NEW` workflow, `docs.json` navigation, `sglang serve` launch convention, auto-estimated TP for unverified hardware combos, subtle green-dot verified indicator).

## Test plan
- [ ] Dry-run the skill on a sample model (e.g., GLM-4.6) and confirm every step produces files matching existing `docs_new/` conventions.
- [ ] Hand-stamp `config-generator.jsx.tmpl` for one existing model and verify it covers the full feature set.
- [ ] Run `mint validate` and `mint broken-links` in `docs_new/`.