### PR TITLE
Deprecate --collect-tokens-histogram, auto-collect with --enable-metrics

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -470,7 +470,6 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 bucket_time_to_first_token=self.server_args.bucket_time_to_first_token,
                 bucket_e2e_request_latency=self.server_args.bucket_e2e_request_latency,
                 bucket_inter_token_latency=self.server_args.bucket_inter_token_latency,
-                collect_tokens_histogram=self.server_args.collect_tokens_histogram,
             )
 
             start_cpu_monitor_thread("tokenizer")

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -1151,13 +1151,11 @@ class TokenizerMetricsCollector:
         bucket_time_to_first_token: Optional[List[float]] = None,
         bucket_inter_token_latency: Optional[List[float]] = None,
         bucket_e2e_request_latency: Optional[List[float]] = None,
-        collect_tokens_histogram: bool = False,
     ) -> None:
         # We need to import prometheus_client after setting the env variable `PROMETHEUS_MULTIPROC_DIR`
         from prometheus_client import Counter, Histogram
 
         self.labels = labels or {}
-        self.collect_tokens_histogram = collect_tokens_histogram
 
         self.prompt_tokens_total = Counter(
             name="sglang:prompt_tokens_total",
@@ -1171,56 +1169,55 @@ class TokenizerMetricsCollector:
             labelnames=labels.keys(),
         )
 
-        if collect_tokens_histogram:
-            default_bucket_prompt_tokens = [
-                100,
-                300,
-                500,
-                700,
-                1000,
-                1500,
-                2000,
-                3000,
-                4000,
-                5000,
-                6000,
-                7000,
-                8000,
-                9000,
-                10000,
-                12000,
-                15000,
-                20000,
-                22000,
-                25000,
-                30000,
-                35000,
-                40000,
-                66000,
-                99000,
-                132000,
-                300000,
-                600000,
-                900000,
-                1100000,
-            ]
-            self.prompt_tokens_histogram = Histogram(
-                name="sglang:prompt_tokens_histogram",
-                documentation="Histogram of prompt token length.",
-                labelnames=labels.keys(),
-                buckets=generate_buckets(
-                    server_args.prompt_tokens_buckets, default_bucket_prompt_tokens
-                ),
-            )
-            self.generation_tokens_histogram = Histogram(
-                name="sglang:generation_tokens_histogram",
-                documentation="Histogram of generation token length.",
-                labelnames=labels.keys(),
-                buckets=generate_buckets(
-                    server_args.generation_tokens_buckets,
-                    default_bucket_prompt_tokens,
-                ),
-            )
+        default_bucket_prompt_tokens = [
+            100,
+            300,
+            500,
+            700,
+            1000,
+            1500,
+            2000,
+            3000,
+            4000,
+            5000,
+            6000,
+            7000,
+            8000,
+            9000,
+            10000,
+            12000,
+            15000,
+            20000,
+            22000,
+            25000,
+            30000,
+            35000,
+            40000,
+            66000,
+            99000,
+            132000,
+            300000,
+            600000,
+            900000,
+            1100000,
+        ]
+        self.prompt_tokens_histogram = Histogram(
+            name="sglang:prompt_tokens_histogram",
+            documentation="Histogram of prompt token length.",
+            labelnames=labels.keys(),
+            buckets=generate_buckets(
+                server_args.prompt_tokens_buckets, default_bucket_prompt_tokens
+            ),
+        )
+        self.generation_tokens_histogram = Histogram(
+            name="sglang:generation_tokens_histogram",
+            documentation="Histogram of generation token length.",
+            labelnames=labels.keys(),
+            buckets=generate_buckets(
+                server_args.generation_tokens_buckets,
+                default_bucket_prompt_tokens,
+            ),
+        )
 
         self.cached_tokens_total = Counter(
             name="sglang:cached_tokens_total",
@@ -1413,11 +1410,10 @@ class TokenizerMetricsCollector:
         if has_grammar:
             self.num_so_requests_total.labels(**labels).inc(1)
         self.histogram_e2e_request_latency.labels(**labels).observe(float(e2e_latency))
-        if self.collect_tokens_histogram:
-            self.prompt_tokens_histogram.labels(**labels).observe(float(prompt_tokens))
-            self.generation_tokens_histogram.labels(**labels).observe(
-                float(generation_tokens)
-            )
+        self.prompt_tokens_histogram.labels(**labels).observe(float(prompt_tokens))
+        self.generation_tokens_histogram.labels(**labels).observe(
+            float(generation_tokens)
+        )
         self.num_retractions.labels(**labels).observe(retraction_count)
 
     def observe_time_to_first_token(self, labels: Dict[str, str], value: float):

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -420,7 +420,6 @@ class ServerArgs:
     bucket_time_to_first_token: Optional[List[float]] = None
     bucket_inter_token_latency: Optional[List[float]] = None
     bucket_e2e_request_latency: Optional[List[float]] = None
-    collect_tokens_histogram: bool = False
     prompt_tokens_buckets: Optional[List[str]] = None
     generation_tokens_buckets: Optional[List[str]] = None
     gc_warning_threshold_secs: float = 0.0
@@ -4791,9 +4790,8 @@ class ServerArgs:
         )
         parser.add_argument(
             "--collect-tokens-histogram",
-            action="store_true",
-            default=ServerArgs.collect_tokens_histogram,
-            help="Collect prompt/generation tokens histogram.",
+            action=DeprecatedAction,
+            help="Deprecated. Token histograms are now automatically collected when --enable-metrics is set.",
         )
         bucket_rule = (
             "Supports 3 rule types: 'default' uses predefined buckets; 'tse <middle> <base> <count>' "


### PR DESCRIPTION
## Summary
- Remove the separate `--collect-tokens-histogram` flag; token histograms (prompt/generation length) are now always collected when `--enable-metrics` is set.
- The `TokenizerMetricsCollector` is only instantiated inside an `if enable_metrics` guard, so the extra flag was redundant.
- The CLI arg is preserved with `DeprecatedAction` for backward compatibility.

## Test plan
- [ ] Verify `--enable-metrics` emits `sglang:prompt_tokens_histogram` and `sglang:generation_tokens_histogram` without needing `--collect-tokens-histogram`
- [ ] Verify passing `--collect-tokens-histogram` prints a deprecation warning but does not error