### PR TITLE
fix: defer session reaper for non-streaming decodes; forward session_params in /v1/completions

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -128,6 +128,7 @@ class OpenAIServingCompletion(OpenAIServingBase):
             routing_key=self.extract_routing_key(raw_request),
             custom_labels=custom_labels,
             custom_logit_processor=request.custom_logit_processor,
+            session_params=request.session_params,
         )
 
         return adapted_request, request

--- a/python/sglang/srt/session/session_controller.py
+++ b/python/sglang/srt/session/session_controller.py
@@ -311,14 +311,25 @@ class SessionController:
         session = self.sessions[session_id]
         req = None
         has_unfinished_request = False
-        if session.streaming and session._inflight:
-            has_unfinished_request = True
-        elif session.streaming and session.req_nodes:
-            assert len(session.req_nodes) == 1
-            [last_node] = session.req_nodes.values()
-            req = last_node.req
-            if not req.finished():
+        if session.streaming:
+            if session._inflight:
                 has_unfinished_request = True
+            elif session.req_nodes:
+                assert len(session.req_nodes) == 1
+                [last_node] = session.req_nodes.values()
+                req = last_node.req
+                if not req.finished():
+                    has_unfinished_request = True
+        else:
+            # Non-streaming sessions also park their active request in
+            # session.req_nodes; if any of them is still decoding, the reaper
+            # must defer close, otherwise it wipes the session's KV state mid
+            # generate and subsequent calls fail with "session id does not
+            # exist" while the in-flight request keeps running on freed slots.
+            for node in session.req_nodes.values():
+                if not node.req.finished():
+                    has_unfinished_request = True
+                    break
 
         if has_unfinished_request:
             # An in-flight request is still decoding on this session's KV


### PR DESCRIPTION
Fixes #23579.

Two bugs, fixed together because they combine on the same failure path (non-streaming session + `/v1/completions`).

## 1. Session reaper mid-decode race

`SessionController._close` only inspected `session.streaming` branches when deciding whether any active request was still in flight:

```python
if session.streaming and session._inflight:
    has_unfinished_request = True
elif session.streaming and session.req_nodes:
    ...
```

For **non-streaming** sessions, `create_req` still parks the active request on `session.req_nodes`, but the check above never runs, so a `timeout=2.0` session whose `/generate` call is still decoding at t=3.8s gets freed mid-flight. The follow-up request then fails with `session id ... does not exist`, and the scheduler reads/writes from the in-flight request land on freed KV slots (visible as corruption/OOB when `--enable-streaming-session` is on).

Fix: walk `session.req_nodes` for non-streaming sessions too, and defer close via the existing `close_on_finish` path when any parked request is still running.

## 2. `/v1/completions` silently drops `session_params`

`CompletionRequest` declares `session_params: Optional[Dict] = None`, but `OpenAIServingCompletion._convert_to_internal_request` never forwarded it when building `GenerateReqInput` — so a session-aware OpenAI-compatible call was indistinguishable from a sessionless one, and users were forced onto the native `/generate` path.

Fix: pass `session_params=request.session_params` through in the existing kwargs block (one-line plumbing fix).

## Test plan

Reporter's repro from #23579 against the new code path:

```
Session repro_mid_decode_... opened (timeout=2.0s)
Sending slow request (800 tokens) via /generate...
Request finished in 3.8s
SUCCESS: Generated tokens
Sending quick follow-up to check if session survived...
RESULT: Session SURVIVED
```

On the `/v1/completions` side, any request passing `session_params={"id": "..."}` now actually reaches `GenerateReqInput.session_params` instead of being silently dropped.

No test added yet — happy to add one if reviewers can point me at the existing session-controller test scaffolding; both fixes are mechanical enough that I'd rather not invent fresh harnesses.