### PR TITLE
Fix dynamic chunk sizing for TP8 and merge small dynamic chunk tails

### DIFF
--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -58,6 +58,14 @@ CLIP_MAX_NEW_TOKENS = int(
     os.environ.get("SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION", "4096")
 )
 
+# When using chunked prefill (including dynamic chunking), very small remaining
+# tails can result in many tiny prefill batches and extra communication.
+# This threshold controls when to merge the remaining tail into the current
+# chunk instead of starting another tiny chunk.
+DYNAMIC_CHUNK_TAIL_MERGE_TOKENS = int(
+    os.environ.get("SGLANG_DYNAMIC_CHUNK_TAIL_MERGE_TOKENS", "256")
+)
+
 # Threshold for in-batch prefix cache.
 # If a request has a matched prefix length (against existing cache) less than this value,
 # the scheduler runs the in-batch prefix caching check for this request.
@@ -441,6 +449,10 @@ class PrefillAdder:
         self.prefill_delayer_single_pass = prefill_delayer_single_pass
         self.max_prefill_bs = max_prefill_bs
 
+        # Small-tail merge threshold for chunked prefill.
+        # A value of 0 disables this behavior.
+        self.tail_merge_threshold = DYNAMIC_CHUNK_TAIL_MERGE_TOKENS
+
     def _init_dllm_meta(self, dllm_config: DllmConfig):
         self.dllm_block_size = dllm_config.block_size
         max_running_reqs = dllm_config.max_running_requests
@@ -630,6 +642,8 @@ class PrefillAdder:
         if self.dllm_config is not None:
             _rem_tokens = self._get_dllm_remain_tokens()
         else:
+            remain = req.extend_input_len
+
             _rem_tokens = min(self.rem_chunk_tokens, int(self.rem_total_tokens))
             if self.is_hybrid_swa:
                 # alloc_extend needs extend_num_tokens + page_size per request,
@@ -643,6 +657,23 @@ class PrefillAdder:
                 if self.is_hybrid_swa:
                     return req
                 _rem_tokens = self.rem_chunk_tokens
+
+            # Try to merge a very small remaining tail into this chunk instead of
+            # creating another tiny prefill chunk in the next round.
+            if (
+                self.tail_merge_threshold > 0
+                and self.rem_chunk_tokens is not None
+                and remain > _rem_tokens
+                and (remain - _rem_tokens) <= self.tail_merge_threshold
+                and len(self.can_run_list) == 0
+                and (
+                    self.running_batch is None or self.running_batch.is_empty()
+                )
+            ):
+                # Ensure we still respect the overall token budget.
+                paged_len = self.ceil_paged_tokens(remain)
+                if paged_len <= min(self.cur_rem_tokens, self.rem_total_tokens):
+                    _rem_tokens = remain
 
         truncated = req.extend_input_len > _rem_tokens
         req.set_extend_input_len(min(req.extend_input_len, _rem_tokens))

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -21,6 +21,7 @@ from sglang.srt.layers.dp_attention import (
     get_attention_dp_size,
     is_dp_attention_enabled,
     set_is_extend_in_batch,
+    set_dp_buffer_len,
 )
 from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
 from sglang.srt.managers.utils import (
@@ -556,10 +557,10 @@ class SchedulerPPMixin:
             model_runner = self.tp_worker.model_runner
             model_config = model_runner.model_config
             input_ids_list = []
-            for i in range(128):
+            for i in range(160):
                 chunk_size = int(
                     self.chunked_prefill_size * 1.25
-                    - i * (self.chunked_prefill_size * 1.25 // 128)
+                    - i * (self.chunked_prefill_size * 1.25 // 160)
                 )
                 if chunk_size <= 0:
                     break
@@ -611,6 +612,17 @@ class SchedulerPPMixin:
                     global_num_tokens[dp_rank] = current_seq_len
                     batch.global_num_tokens = global_num_tokens
                     batch.global_num_tokens_for_logprob = global_num_tokens
+                else:
+                    # DP disabled: set_dp_buffer_len is never called in normal forward path,
+                    # but communicator still uses get_local_dp_buffer() for TP all_gather.
+                    # With context parallel / scatter, each rank has input (current_seq_len // attn_tp_size, H),
+                    # so all_gather output is (current_seq_len, H); use current_seq_len for buffer.
+                    set_dp_buffer_len(
+                        current_seq_len,
+                        current_seq_len,
+                        dp_max_padding=False,
+                        global_num_tokens=[current_seq_len],
+                    )
 
                 proxy_tensors = {
                     "hidden_states": torch.zeros(


### PR DESCRIPTION
## Motivation

While testing dynamic chunking for DeepSeek V3.2 in a local 2P1D setup, I ran into two issues.

First, the dynamic chunk profiling logic samples 128 prefill sizes and uses the following step size:

`chunked_prefill_size * 1.25 // 128`

With TP8 enabled, this step size needs to be divisible by 8. This works for `--chunked-prefill-size 4096`, but fails for `3072` because:

`3072 * 1.25 // 128 = 30`

and `30` is not divisible by 8. In this case, dynamic chunk size derivation can fail and the service may not start correctly.
However, when tuning dynamic chunking for specific input lengths, we often need to set `--chunked-prefill-size`to `3072` or other values to achieve optimal tuning results. The current logic severely limits this tuning flexibility.

Second, dynamic chunking can leave a very small tail at the end. For example, with:

- `input = 16k`
- `--chunked-prefill-size 4096`
- `dynamic chunking smooth factor = 0.65`

the final split may leave only `192` tokens. Running an additional tiny prefill round for such a short tail adds another communication round and hurts TTFT. In practice, this can offset part of the benefit from dynamic chunking.
<img width="684" height="296" alt="image" src="https://github.com/user-attachments/assets/b5697b90-d05d-4593-ae22-71512cf85208" />


## Modifications

This PR makes two changes.

1. Increase the number of profiling sample points from `128` to `160` in dynamic chunk sizing.  
   This changes the step size to:

   `chunked_prefill_size * 1.25 // 160`

   For `chunked_prefill_size = 3072`, this becomes `24`, which is divisible by 8 and works correctly under TP8.

2. Add a small-tail merge optimization in `PrefillAdder.add_chunked_req()`.  
   If the remaining tail after the current chunk is below a threshold, the scheduler merges that tail into the current prefill instead of launching another tiny prefill round.

The small-tail threshold is exposed through a new environment variable:

`SGLANG_DYNAMIC_CHUNK_TAIL_MERGE_TOKENS`

with a default value of `256`, so the merge behavior can be tuned explicitly at launch time when needed.

## Accuracy Tests

This PR does not change model math, kernel computation, or model forward semantics. It only adjusts dynamic chunk sizing and chunk scheduling behavior.

No accuracy difference is expected.

## Speed Tests and Profiling

Test setup:

- local 2P1D
- DeepSeek V3.2
- `input = 16k`
- `--chunked-prefill-size 4096`
- `dynamic chunking smooth factor = 0.65`

Observed TTFT:

- before: `1458.04`
- after: `1360.22`

This is about a `100 ms` improvement in this setup.

The improvement mainly comes from avoiding an extra tiny final prefill round in short-tail cases. This change is intended as a safeguard for dynamic chunking so that otherwise good chunk splits are less likely to be penalized by a very small final tail.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
