### PR TITLE
[codex] docs: note H200 DeepSeek-V4 checkpoint

### DIFF
--- a/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
+++ b/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
@@ -99,6 +99,10 @@ Please refer to the [official SGLang installation guide](../../../docs/get-start
 
 SGLang supports three main serving recipes for DeepSeek-V4 with different latency/throughput trade-offs (`low-latency`, `balanced`, `max-throughput`), plus specialized recipes for long-context (`cp`, prefill context-parallel) and prefill/decode disaggregation (`pd-disagg`). The interactive generator below emits the exact launch command for any `(hardware, variant, recipe)` combination.
 
+<Note>
+For H200 GPU deployments, use the SGLang checkpoint under `sgl-project`, not the default DeepSeek checkpoint.
+</Note>
+
 ### 3.1 Basic Configuration
 
 **Interactive Command Generator**: Use the selector below to generate the deployment command for your hardware + recipe combination.


### PR DESCRIPTION
## Summary

- Add a highlighted note in the DeepSeek-V4 deployment section for H200 GPU users.
- Clarify that H200 deployments should use the SGLang checkpoint under `sgl-project` instead of the default DeepSeek checkpoint.

## Validation

- Ran `git diff --check -- docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx`.
- Commit hooks passed during `git commit`.