### PR TITLE
[SPEC][4/N] feat: adaptive spec support ngram

### DIFF
--- a/python/sglang/srt/speculative/adaptive_spec_params.py
+++ b/python/sglang/srt/speculative/adaptive_spec_params.py
@@ -17,12 +17,15 @@ logger = logging.getLogger(__name__)
 
 def adaptive_unsupported_reason(server_args: ServerArgs) -> str | None:
     """Return why adaptive spec cannot run under the given server args, or None if supported."""
-    if server_args.speculative_algorithm not in ("EAGLE", "EAGLE3"):
+    if server_args.speculative_algorithm not in ("EAGLE", "EAGLE3", "NGRAM"):
         return (
             f"speculative_algorithm={server_args.speculative_algorithm} "
-            "(only EAGLE/EAGLE3 are supported)"
+            "(only EAGLE/EAGLE3/NGRAM are supported)"
         )
-    if server_args.speculative_eagle_topk != 1:
+    if (
+        server_args.speculative_algorithm not in ("NGRAM")
+        and server_args.speculative_eagle_topk != 1
+    ):
         return (
             f"speculative_eagle_topk={server_args.speculative_eagle_topk} "
             "(only topk=1 is supported)"

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from typing import List, Optional
 
 import numpy as np
@@ -9,14 +10,20 @@ from sglang.srt.layers.utils.logprob import add_output_logprobs_for_spec_v1
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
+from sglang.srt.model_executor.cuda_graph_runner import CudaGraphRunner
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.observability.req_time_stats import set_time_batch
 from sglang.srt.observability.trace import get_global_tracing_enabled
 from sglang.srt.server_args import ServerArgs
+from sglang.srt.speculative.adaptive_runtime_state import (
+    AdaptiveController,
+    SpecRuntimeState,
+)
 from sglang.srt.speculative.cpp_ngram.ngram_corpus import NgramCorpus
 from sglang.srt.speculative.ngram_info import NgramVerifyInput
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.speculative.spec_utils import generate_token_bitmask
+from sglang.srt.utils import get_available_gpu_memory
 
 logger = logging.getLogger(__name__)
 
@@ -37,15 +44,29 @@ class NGRAMWorker:
         nccl_port: int,
         target_worker: TpModelWorker,
     ):
+        self.server_args = server_args
         self.target_worker = target_worker
         self.model_runner = target_worker.model_runner
         self.tp_rank = tp_rank
+        self.gpu_id = gpu_id
         self.page_size = server_args.page_size
         self.draft_token_num: int = server_args.speculative_num_draft_tokens
         self.max_trie_depth: int = server_args.speculative_ngram_max_trie_depth
 
         self.max_batch_size = target_worker.max_running_requests
         self.device = f"cuda:{gpu_id}" if gpu_id >= 0 else "cuda"
+
+        # Adaptive speculative decoding
+        self.adaptive_controller: Optional[AdaptiveController] = None
+        if server_args.speculative_adaptive:
+            self.adaptive_controller = AdaptiveController(
+                self, config_path=server_args.speculative_adaptive_config
+            )
+            self._max_draft_token_num = max(
+                s + 1 for s in self.adaptive_controller.candidate_steps
+            )
+        else:
+            self._max_draft_token_num = self.draft_token_num
 
         self._init_preallocated_tensors()
 
@@ -55,7 +76,7 @@ class NGRAMWorker:
             match_type=server_args.speculative_ngram_match_type,
             capacity=server_args.speculative_ngram_capacity,
             max_trie_depth=server_args.speculative_ngram_max_trie_depth,
-            draft_token_num=server_args.speculative_num_draft_tokens,
+            draft_token_num=self._max_draft_token_num,
             external_sam_budget=server_args.speculative_ngram_external_sam_budget,
             external_corpus_max_tokens=server_args.speculative_ngram_external_corpus_max_tokens,
         )
@@ -79,6 +100,25 @@ class NGRAMWorker:
                 corpus_path,
                 loaded,
             )
+
+        if self.adaptive_controller is not None:
+            self.adaptive_controller.register(
+                SpecRuntimeState(
+                    speculative_num_steps=self.draft_token_num - 1,
+                    speculative_num_draft_tokens=self.draft_token_num,
+                    draft_attn_backend=None,
+                    cuda_graph_runner=None,
+                    target_attn_backend=self.target_worker.model_runner.attn_backend,
+                    target_graph_runner=self.target_worker.model_runner.graph_runner,
+                    draft_extend_attn_backend=None,
+                    cuda_graph_runner_for_draft_extend=None,
+                )
+            )
+            self.adaptive_controller.init_states()
+
+    @property
+    def speculative_num_steps(self) -> int:
+        return self.draft_token_num - 1
 
     def clear_cache_pool(self):
         self.ngram_corpus.reset()
@@ -153,6 +193,80 @@ class NGRAMWorker:
                 self.tree_mask[: bs * self.draft_token_num * self.draft_token_num]
             )
 
+    # -- Adaptive speculative decoding --
+
+    def build_adaptive_runtime_state(
+        self, speculative_num_steps: int, speculative_num_draft_tokens: int
+    ) -> SpecRuntimeState:
+        """Build a NGRAM runtime state for the given draft-token count."""
+        tic = time.perf_counter()
+        before_mem = get_available_gpu_memory(self.server_args.device, self.gpu_id)
+
+        target_model_runner = self.target_worker.model_runner
+        sa = self.server_args
+        backup = (sa.speculative_num_steps, sa.speculative_num_draft_tokens)
+        try:
+            sa.speculative_num_steps = speculative_num_steps
+            sa.speculative_num_draft_tokens = speculative_num_draft_tokens
+
+            backup_init = target_model_runner.init_new_workspace
+            try:
+                target_attn_backend = target_model_runner._get_attention_backend(
+                    init_new_workspace=True
+                )
+            finally:
+                target_model_runner.init_new_workspace = backup_init
+
+            target_graph_runner = None
+            if not sa.disable_cuda_graph:
+                target_graph_runner = CudaGraphRunner(
+                    target_model_runner,
+                    attn_backend=target_attn_backend,
+                    speculative_num_steps=speculative_num_steps,
+                    speculative_num_draft_tokens=speculative_num_draft_tokens,
+                )
+        finally:
+            sa.speculative_num_steps, sa.speculative_num_draft_tokens = backup
+
+        after_mem = get_available_gpu_memory(self.server_args.device, self.gpu_id)
+        logger.info(
+            "Built NGRAM adaptive state draft_tokens=%s: elapsed=%.2fs, mem=%.2fGB",
+            speculative_num_draft_tokens,
+            time.perf_counter() - tic,
+            before_mem - after_mem,
+        )
+        return SpecRuntimeState(
+            speculative_num_steps=speculative_num_steps,
+            speculative_num_draft_tokens=speculative_num_draft_tokens,
+            draft_attn_backend=None,
+            cuda_graph_runner=None,
+            target_attn_backend=target_attn_backend,
+            target_graph_runner=target_graph_runner,
+            draft_extend_attn_backend=None,
+            cuda_graph_runner_for_draft_extend=None,
+        )
+
+    def apply_runtime_state(self, state: SpecRuntimeState):
+        """Apply a pre-built runtime state to this worker."""
+        if self.draft_token_num == state.speculative_num_draft_tokens:
+            return
+
+        logger.info(
+            "Switch NGRAM adaptive state: draft_tokens %d -> %d",
+            self.draft_token_num,
+            state.speculative_num_draft_tokens,
+        )
+        self.draft_token_num = state.speculative_num_draft_tokens
+        self._init_preallocated_tensors()
+        self.target_worker.model_runner.attn_backend = state.target_attn_backend
+        self.target_worker.model_runner.graph_runner = state.target_graph_runner
+        self.server_args.speculative_num_steps = state.speculative_num_steps
+        self.server_args.speculative_num_draft_tokens = (
+            state.speculative_num_draft_tokens
+        )
+
+    # -- Draft / verify pipeline --
+
     def _prepare_draft_tokens(
         self, batch: ScheduleBatch
     ) -> tuple[np.ndarray, np.ndarray]:
@@ -172,6 +286,13 @@ class NGRAMWorker:
         req_drafts, mask = self.ngram_corpus.batch_get(
             req_ids, batch_tokens, total_lens
         )
+
+        # Truncate if corpus produces more tokens than current config
+        if self._max_draft_token_num > self.draft_token_num:
+            n, k = self._max_draft_token_num, self.draft_token_num
+            req_drafts = req_drafts.reshape(bs, n)[:, :k].flatten()
+            mask = mask.reshape(bs, n, n)[:, :k, :k].flatten()
+
         total_draft_token_num = len(req_drafts)
 
         # Check if speculative decoding is needed; here we always enforce it
@@ -332,6 +453,10 @@ class NGRAMWorker:
                     finished_req_ids.append(req.rid)
             if finished_req_ids:
                 self.ngram_corpus.erase_match_state(finished_req_ids)
+
+            if self.adaptive_controller is not None:
+                self.adaptive_controller.on_verify_complete(accept_length_per_req_cpu)
+
             batch.forward_mode = ForwardMode.DECODE
 
         else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
adaptive spec support ngram

Model and hardware:
- Target model: `/models/LLM-Research/Meta-Llama-3.1-8B-Instruct`
- Hardware: `1x H20` (`CUDA_VISIBLE_DEVICES=0`)

Benchmark script:
```bash
PYTHONPATH=python python3 benchmark/bench_adaptive_speculative.py \
  --host 127.0.0.1 \
  --port 7011 \
  --workload transition \
  --requests 16 \
  --concurrency 8 \
  --warmup 8 \
  --max-tokens 256
```

Mode definitions:

| Mode | Extra flags |
|---|---|
| static1 | `--speculative-num-steps 1 --speculative-num-draft-tokens 2` |
| static3 | `--speculative-num-steps 3 --speculative-num-draft-tokens 4` |
| static7 | `--speculative-num-steps 7 --speculative-num-draft-tokens 8` |
| static15 | `--speculative-num-steps 15 --speculative-num-draft-tokens 16` |
| adaptive | static7 flags plus `--speculative-adaptive --speculative-adaptive-config <cfg>` |

Shared NGRAM flags:
- `--speculative-algorithm NGRAM`
- `--speculative-ngram-max-bfs-breadth 1`
- `--attention-backend triton`
- `--skip-server-warmup`
- `--mem-fraction-static 0.7`

Adaptive config in this rerun:

```json
{"candidate_steps": [1, 3, 7, 15]}
```

Note: the config is explicit because the current workspace default remains
`[1, 3, 7]`.

## Server Launch Commands

### Static15

```bash
CUDA_VISIBLE_DEVICES=0 \
PYTHONPATH=python \
python3 -m sglang.launch_server \
  --model /models/LLM-Research/Meta-Llama-3.1-8B-Instruct \
  --speculative-algorithm NGRAM \
  --speculative-num-steps 15 \
  --speculative-num-draft-tokens 16 \
  --speculative-ngram-max-bfs-breadth 1 \
  --attention-backend triton \
  --skip-server-warmup \
  --mem-fraction-static 0.7 \
  --host 0.0.0.0 \
  --port 7011 \
  --log-level info
```

### Adaptive

```bash
CUDA_VISIBLE_DEVICES=0 \
PYTHONPATH=python \
python3 -m sglang.launch_server \
  --model /models/LLM-Research/Meta-Llama-3.1-8B-Instruct \
  --speculative-algorithm NGRAM \
  --speculative-num-steps 7 \
  --speculative-num-draft-tokens 8 \
  --speculative-ngram-max-bfs-breadth 1 \
  --speculative-adaptive \
  --speculative-adaptive-config /tmp/ngram_adaptive_bench_update_20260424_064555/adaptive_1_3_7_15.json \
  --attention-backend triton \
  --skip-server-warmup \
  --mem-fraction-static 0.7 \
  --host 0.0.0.0 \
  --port 7011 \
  --log-level info
```

## Result Summary

| Scenario | Date | Best mode | Best throughput | Key point |
|---|---|---|---:|---|
| NGRAM + Meta-Llama-3.1-8B-Instruct (1x H20) | 2026-04-24 | static7 | 1660.0 tok/s | adaptive with `[1,3,7,15]` did not beat the best static tier |

## Overall

| Mode | Throughput | Avg Latency | Avg Accept Len | Switches | Errors | Ready Time |
|---|---:|---:|---:|---:|---:|---:|
| static1 | 1093.0 tok/s | 1.613 s | 1.73 | 0 | 0 | 62 s |
| static3 | 1640.0 tok/s | 1.100 s | 2.88 | 0 | 0 | 62 s |
| static7 | 1660.0 tok/s | 0.998 s | 4.46 | 0 | 0 | 62 s |
| static15 | 1301.3 tok/s | 1.334 s | 6.36 | 0 | 0 | 65 s |
| adaptive | 1606.3 tok/s | 1.133 s | 3.64 | 13 | 0 | 70 s |

## Comparison

| Pair | Static | Adaptive | Delta | Verdict |
|---|---:|---:|---:|---|
| adaptive vs static1 | 1093.0 | 1606.3 | +513.3 tok/s (+46.96%) | improvement |
| adaptive vs static3 | 1640.0 | 1606.3 | -33.7 tok/s (-2.05%) | regression |
| adaptive vs static7 | 1660.0 | 1606.3 | -53.7 tok/s (-3.23%) | regression |
| adaptive vs static15 | 1301.3 | 1606.3 | +305.0 tok/s (+23.44%) | improvement |

## Per-Phase Throughput

| Phase | static1 | static3 | static7 | static15 | adaptive |
|---|---:|---:|---:|---:|---:|
| low_1 | 931.3 | 1306.0 | 1113.9 | 906.9 | 1142.7 |
| high_1 | 1076.1 | 1276.1 | 1240.2 | 865.7 | 1377.1 |
| low_2 | 1034.3 | 1913.6 | 2090.0 | 1578.8 | 1771.4 |
| high_2 | 1454.2 | 2728.9 | 4413.2 | 5458.2 | 3058.6 |
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
