### PR TITLE
fix granite hybrid model bug on npu

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -240,6 +240,13 @@ class AscendAttnBackend(AttentionBackend):
                 in model_runner.model_config.hf_config.architectures
             ):
                 self.use_native_sdpa = True
+            elif (
+                "GraniteMoeHybridForCausalLM"
+                in model_runner.model_config.hf_config.architectures
+            ):
+                self.use_native_sdpa = True
+                self.use_npu_paged_attention = False
+
         self.native_attn = AscendTorchNativeAttnBackend()
         self.graph_metadata = {}
         self.max_context_len = model_runner.model_config.context_len
@@ -1868,9 +1875,13 @@ class AscendAttnBackend(AttentionBackend):
                     actual_seq_lengths_kv=actual_seq_len_kv,
                     scale=layer.scaling,
                 )
-            # there are some accuracy issues in cross attention scene to use torch_npu._npu_flash_attention_qlens
-            # forward_batch.encoder_lens is not None in cross attention scend, we add native attn to solve accuracy issues
-            elif forward_batch.encoder_lens is None and layer.logit_cap == 0:
+            # there are some accuracy issues in cross attention scene to use torch_npu._npu_paged_attention
+            # forward_batch.encoder_lens is not None in cross attention scene, we add native attn to solve accuracy issues
+            elif (
+                forward_batch.encoder_lens is None
+                and layer.logit_cap == 0
+                and getattr(self, "use_npu_paged_attention", False)
+            ):
                 query = q.reshape(-1, layer.tp_q_head_num, layer.qk_head_dim)
                 num_tokens = query.shape[0]
                 if not self.use_alibi:

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -1880,7 +1880,7 @@ class AscendAttnBackend(AttentionBackend):
             elif (
                 forward_batch.encoder_lens is None
                 and layer.logit_cap == 0
-                and getattr(self, "use_npu_paged_attention", False)
+                and getattr(self, "use_npu_paged_attention", True)
             ):
                 query = q.reshape(-1, layer.tp_q_head_num, layer.qk_head_dim)
                 num_tokens = query.shape[0]

--- a/python/sglang/srt/layers/attention/mamba/mamba.py
+++ b/python/sglang/srt/layers/attention/mamba/mamba.py
@@ -503,7 +503,7 @@ class MambaMixer2(torch.nn.Module):
             )  # this is the form that causal-conv see
             ccfn = (
                 causal_conv1d_fn
-                if not use_triton_causal_conv
+                if is_npu() or not use_triton_causal_conv
                 else causal_conv1d_fn_triton
             )
             hidden_states_B_C_p = ccfn(
@@ -602,7 +602,7 @@ class MambaMixer2(torch.nn.Module):
             else:
                 ccu = (
                     causal_conv1d_update
-                    if not use_triton_causal_conv
+                    if is_npu() or not use_triton_causal_conv
                     else causal_conv1d_update_triton
                 )
                 hidden_states_B_C_d = ccu(

--- a/python/sglang/srt/layers/attention/mamba/ops/ssd_chunk_scan.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/ssd_chunk_scan.py
@@ -92,6 +92,7 @@ def _chunk_scan_fwd_kernel(
     BLOCK_SIZE_DSTATE: tl.constexpr,
     IS_TRITON_22: tl.constexpr,
     HAS_INITSTATES: tl.constexpr,
+    IS_NPU: tl.constexpr = False,
     BLOCK_SIZE_M: tl.constexpr = 16,
     BLOCK_SIZE_N: tl.constexpr = 16,
     BLOCK_SIZE_K: tl.constexpr = 16,
@@ -135,14 +136,26 @@ def _chunk_scan_fwd_kernel(
     # M-block offsets and prev states
     #  - logic in next block may override these if there is an active offset
     offs_m = pid_m * BLOCK_SIZE_M + c_off + tl.arange(0, BLOCK_SIZE_M)
-    prev_states_ptr = (
+    
+    # NPU-compatible: compute both pointers outside conditionals
+    chunk_states_ptr_base = (
         states_ptr
         + pid_b * stride_states_batch
         + c_idx * stride_states_chunk
         + pid_h * stride_states_head
     )
-    prev_states_hdim = stride_states_hdim
-    prev_states_dstate = stride_states_dstate
+    
+    if IS_NPU:
+        use_chunk_states = True
+        if HAS_INITSTATES:
+            init_states_ptr_base = (
+                initstates_ptr
+                + pid_h * stride_init_states_head
+            )
+    else:
+        prev_states_ptr = chunk_states_ptr_base
+        prev_states_hdim = stride_states_hdim
+        prev_states_dstate = stride_states_dstate
 
     chunk_size_limit = min(chunk_size, seqlen - c_idx * chunk_size)
     if HAS_SEQ_IDX:
@@ -169,7 +182,18 @@ def _chunk_scan_fwd_kernel(
                 # - recall that in ssd_state_passing, for the case c_off == 0
                 # i.e., the very first sequence, we made states_ptr hold its initial state
                 # so this edge case is taken care of
-                if (
+                if IS_NPU:
+                    # NPU-compatible: track condition, use later with tl.where
+                    use_chunk_states = not (
+                        (c_off == 0 and seq_idx_prev != seq_idx_m)
+                        or (c_off > 0)
+                    )
+                    init_states_ptr_base = (
+                        initstates_ptr
+                        + seq_idx_m * stride_init_states_batch
+                        + pid_h * stride_init_states_head
+                    )
+                elif (
                     (c_off == 0)
                     and (
                         seq_idx_prev != seq_idx_m
@@ -260,10 +284,22 @@ def _chunk_scan_fwd_kernel(
             offs_m[:, None] * stride_C_seqlen + offs_k_dstate[None, :] * stride_C_dstate
         )
 
-        prev_states_ptrs = prev_states_ptr + (
-            offs_n[None, :] * prev_states_hdim
-            + offs_k_dstate[:, None] * prev_states_dstate
-        )
+        if IS_NPU:
+            # NPU-compatible: compute both pointers, use tl.where to select data
+            chunk_states_ptrs = chunk_states_ptr_base + (
+                offs_n[None, :] * stride_states_hdim
+                + offs_k_dstate[:, None] * stride_states_dstate
+            )
+            if HAS_INITSTATES:
+                init_states_ptrs = init_states_ptr_base + (
+                    offs_n[None, :] * stride_init_states_hdim
+                    + offs_k_dstate[:, None] * stride_init_states_dstate
+                )
+        else:
+            prev_states_ptrs = prev_states_ptr + (
+                offs_n[None, :] * prev_states_hdim
+                + offs_k_dstate[:, None] * prev_states_dstate
+            )
         if HAS_SEQ_IDX:
 
             if not HAS_INITSTATES:
@@ -283,11 +319,28 @@ def _chunk_scan_fwd_kernel(
                 other=0.0,
             )
 
-            prev_states = tl.load(
-                prev_states_ptrs,
-                mask=(offs_k_dstate[:, None] < dstate) & (offs_n[None, :] < hdim),
-                other=0.0,
-            )
+            if IS_NPU:
+                # NPU-compatible: load both and use tl.where
+                prev_states_chunk = tl.load(
+                    chunk_states_ptrs,
+                    mask=(offs_k_dstate[:, None] < dstate) & (offs_n[None, :] < hdim),
+                    other=0.0,
+                )
+                if HAS_INITSTATES:
+                    prev_states_init = tl.load(
+                        init_states_ptrs,
+                        mask=(offs_k_dstate[:, None] < dstate) & (offs_n[None, :] < hdim),
+                        other=0.0,
+                    )
+                    prev_states = tl.where(use_chunk_states, prev_states_chunk, prev_states_init)
+                else:
+                    prev_states = prev_states_chunk
+            else:
+                prev_states = tl.load(
+                    prev_states_ptrs,
+                    mask=(offs_k_dstate[:, None] < dstate) & (offs_n[None, :] < hdim),
+                    other=0.0,
+                )
             prev_states = prev_states.to(C_ptr.dtype.element_ty)
             acc = tl.dot(C, prev_states) * scale_m[:, None]
         else:
@@ -299,16 +352,40 @@ def _chunk_scan_fwd_kernel(
                     other=0.0,
                 )
                 # C = (C * scale_m[:, None]).to(C_ptr.dtype.element_ty)
-                prev_states = tl.load(
-                    prev_states_ptrs,
-                    mask=(offs_k_dstate[:, None] < dstate - k)
-                    & (offs_n[None, :] < hdim),
-                    other=0.0,
-                )
+                if IS_NPU:
+                    # NPU-compatible: load both and use tl.where
+                    prev_states_chunk = tl.load(
+                        chunk_states_ptrs,
+                        mask=(offs_k_dstate[:, None] < dstate - k)
+                        & (offs_n[None, :] < hdim),
+                        other=0.0,
+                    )
+                    if HAS_INITSTATES:
+                        prev_states_init = tl.load(
+                            init_states_ptrs,
+                            mask=(offs_k_dstate[:, None] < dstate - k)
+                            & (offs_n[None, :] < hdim),
+                            other=0.0,
+                        )
+                        prev_states = tl.where(use_chunk_states, prev_states_chunk, prev_states_init)
+                    else:
+                        prev_states = prev_states_chunk
+                else:
+                    prev_states = tl.load(
+                        prev_states_ptrs,
+                        mask=(offs_k_dstate[:, None] < dstate - k)
+                        & (offs_n[None, :] < hdim),
+                        other=0.0,
+                    )
                 prev_states = prev_states.to(C_ptr.dtype.element_ty)
                 acc += tl.dot(C, prev_states)
                 C_ptrs += BLOCK_SIZE_K
-                prev_states_ptrs += BLOCK_SIZE_K
+                if IS_NPU:
+                    chunk_states_ptrs += BLOCK_SIZE_K
+                    if HAS_INITSTATES:
+                        init_states_ptrs += BLOCK_SIZE_K
+                else:
+                    prev_states_ptrs += BLOCK_SIZE_K
             acc *= scale_m[:, None]
 
     offs_k = tl.arange(0, BLOCK_SIZE_K) + c_off
@@ -434,6 +511,7 @@ def _chunk_scan_fwd(
     initial_states=None,
     out=None,
 ):
+    is_npu_device = x.device.type == 'npu' or str(x.device).startswith('npu')
     batch, seqlen, nheads, headdim = x.shape
     _, _, nchunks, chunk_size = dt.shape
     _, _, ngroups, dstate = C.shape
@@ -558,5 +636,6 @@ def _chunk_scan_fwd(
         HAS_SEQ_IDX=seq_idx is not None,
         IS_TRITON_22=TRITON_22,
         HAS_INITSTATES=initial_states is not None,
+        IS_NPU=is_npu_device,
     )
     return out_x

--- a/python/sglang/srt/layers/attention/mamba/ops/ssd_chunk_scan.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/ssd_chunk_scan.py
@@ -136,7 +136,7 @@ def _chunk_scan_fwd_kernel(
     # M-block offsets and prev states
     #  - logic in next block may override these if there is an active offset
     offs_m = pid_m * BLOCK_SIZE_M + c_off + tl.arange(0, BLOCK_SIZE_M)
-    
+
     # NPU-compatible: compute both pointers outside conditionals
     chunk_states_ptr_base = (
         states_ptr
@@ -144,14 +144,11 @@ def _chunk_scan_fwd_kernel(
         + c_idx * stride_states_chunk
         + pid_h * stride_states_head
     )
-    
+
     if IS_NPU:
         use_chunk_states = True
         if HAS_INITSTATES:
-            init_states_ptr_base = (
-                initstates_ptr
-                + pid_h * stride_init_states_head
-            )
+            init_states_ptr_base = initstates_ptr + pid_h * stride_init_states_head
     else:
         prev_states_ptr = chunk_states_ptr_base
         prev_states_hdim = stride_states_hdim
@@ -185,8 +182,7 @@ def _chunk_scan_fwd_kernel(
                 if IS_NPU:
                     # NPU-compatible: track condition, use later with tl.where
                     use_chunk_states = not (
-                        (c_off == 0 and seq_idx_prev != seq_idx_m)
-                        or (c_off > 0)
+                        (c_off == 0 and seq_idx_prev != seq_idx_m) or (c_off > 0)
                     )
                     init_states_ptr_base = (
                         initstates_ptr
@@ -329,10 +325,13 @@ def _chunk_scan_fwd_kernel(
                 if HAS_INITSTATES:
                     prev_states_init = tl.load(
                         init_states_ptrs,
-                        mask=(offs_k_dstate[:, None] < dstate) & (offs_n[None, :] < hdim),
+                        mask=(offs_k_dstate[:, None] < dstate)
+                        & (offs_n[None, :] < hdim),
                         other=0.0,
                     )
-                    prev_states = tl.where(use_chunk_states, prev_states_chunk, prev_states_init)
+                    prev_states = tl.where(
+                        use_chunk_states, prev_states_chunk, prev_states_init
+                    )
                 else:
                     prev_states = prev_states_chunk
             else:
@@ -367,7 +366,9 @@ def _chunk_scan_fwd_kernel(
                             & (offs_n[None, :] < hdim),
                             other=0.0,
                         )
-                        prev_states = tl.where(use_chunk_states, prev_states_chunk, prev_states_init)
+                        prev_states = tl.where(
+                            use_chunk_states, prev_states_chunk, prev_states_init
+                        )
                     else:
                         prev_states = prev_states_chunk
                 else:
@@ -511,7 +512,7 @@ def _chunk_scan_fwd(
     initial_states=None,
     out=None,
 ):
-    is_npu_device = x.device.type == 'npu' or str(x.device).startswith('npu')
+    is_npu_device = x.device.type == "npu" or str(x.device).startswith("npu")
     batch, seqlen, nheads, headdim = x.shape
     _, _, nchunks, chunk_size = dt.shape
     _, _, ngroups, dstate = C.shape

--- a/python/sglang/srt/layers/attention/mamba/ops/ssd_chunk_state.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/ssd_chunk_state.py
@@ -15,6 +15,7 @@ import triton
 import triton.language as tl
 
 from sglang.srt.utils import is_npu
+
 from .mamba_ssm import softplus
 
 SSD_BLOCK_SIZE_H = 2 if is_npu() else 16
@@ -397,23 +398,23 @@ def _chunk_state_varlen_kernel(
     if IS_NPU:
         # NPU-compatible logic: NO runtime conditionals with pointer operations
         # All pointers computed outside, all runtime selections via tl.where
-        
+
         use_chunk_states = start_idx < pid_c * chunk_size
         need_boundary = start_idx > pid_c * chunk_size
-        
+
         # Always compute chunk_states_ptrs
         chunk_states_ptrs = chunk_states_ptr + (
             offs_m[:, None] * stride_chunk_states_hdim
             + offs_n[None, :] * stride_chunk_states_dstate
         )
-        
+
         # Load chunk states unconditionally
         past_states_chunk = tl.load(
             chunk_states_ptrs,
             mask=(offs_m[:, None] < hdim) & (offs_n[None, :] < dstate),
             other=0.0,
         ).to(tl.float32)
-        
+
         if HAS_INITSTATES:
             # Compute init_states_ptrs (this is compile-time branch)
             init_states_ptrs = initstates_ptr + (
@@ -421,17 +422,19 @@ def _chunk_state_varlen_kernel(
                 + offs_m[:, None] * stride_init_states_hdim
                 + offs_n[None, :] * stride_init_states_dstate
             )
-            
+
             # Load init states unconditionally
             past_states_init = tl.load(
                 init_states_ptrs,
                 mask=(offs_m[:, None] < hdim) & (offs_n[None, :] < dstate),
                 other=0.0,
             ).to(tl.float32)
-            
+
             # Select data via tl.where (runtime selection without control flow)
-            past_states = tl.where(use_chunk_states, past_states_chunk, past_states_init)
-            
+            past_states = tl.where(
+                use_chunk_states, past_states_chunk, past_states_init
+            )
+
             # Load dA_cs_boundary conditionally via tl.where
             # Compute pointer for boundary load
             dA_cs_boundary_idx = start_idx - pid_c * chunk_size - 1
@@ -441,14 +444,14 @@ def _chunk_state_varlen_kernel(
                 other=0.0,
             ).to(tl.float32)
             dA_cs_boundary = tl.where(need_boundary, dA_cs_boundary_val, 0.0)
-            
+
             scale = tl.exp(dA_cs_last - dA_cs_boundary)
             acc += past_states * scale
         else:
             # No HAS_INITSTATES: use tl.where for runtime selection
             # When use_chunk_states=False, scale=0, so contribution is zero
             scale = tl.where(use_chunk_states, tl.exp(dA_cs_last), 0.0)
-            acc += past_states_chunk * scale[:, None]
+            acc += past_states_chunk * scale
     else:
         # Original GPU logic
         if (start_idx < pid_c * chunk_size) or (HAS_INITSTATES):
@@ -629,7 +632,7 @@ def _chunk_state_fwd(
 def chunk_state_varlen(
     B, x, dt, dA_cumsum, cu_seqlens, chunk_states, initial_states=None
 ):
-    is_npu_device = x.device.type == 'npu' or str(x.device).startswith('npu')
+    is_npu_device = x.device.type == "npu" or str(x.device).startswith("npu")
     total_seqlen, nheads, headdim = x.shape
     _, nchunks, chunk_size = dt.shape
     _, ngroups, dstate = B.shape

--- a/python/sglang/srt/layers/attention/mamba/ops/ssd_chunk_state.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/ssd_chunk_state.py
@@ -14,7 +14,10 @@ import torch
 import triton
 import triton.language as tl
 
+from sglang.srt.utils import is_npu
 from .mamba_ssm import softplus
+
+SSD_BLOCK_SIZE_H = 2 if is_npu() else 16
 
 
 @triton.jit
@@ -303,6 +306,7 @@ def _chunk_state_varlen_kernel(
     stride_init_states_dstate,
     # Meta-parameters
     HAS_INITSTATES: tl.constexpr,
+    IS_NPU: tl.constexpr = False,
     BLOCK_SIZE_M: tl.constexpr = 16,
     BLOCK_SIZE_N: tl.constexpr = 16,
     BLOCK_SIZE_K: tl.constexpr = 16,
@@ -389,45 +393,101 @@ def _chunk_state_varlen_kernel(
     # If HAS_INITSTATES==True need to consider two possibilities
     # - if start_idx < pid_c * chunk_size, then we need to take the past_states_ptrs
     # - if state_idx >= pid * chunk_size, then we need to insert initstates
-    if (start_idx < pid_c * chunk_size) or (HAS_INITSTATES):  # first chunk
 
-        dA_cs_boundary = 0.0  # default
-
-        if not HAS_INITSTATES:
-            past_states_ptrs = chunk_states_ptr + (
-                offs_m[:, None] * stride_chunk_states_hdim
-                + offs_n[None, :] * stride_chunk_states_dstate
+    if IS_NPU:
+        # NPU-compatible logic: NO runtime conditionals with pointer operations
+        # All pointers computed outside, all runtime selections via tl.where
+        
+        use_chunk_states = start_idx < pid_c * chunk_size
+        need_boundary = start_idx > pid_c * chunk_size
+        
+        # Always compute chunk_states_ptrs
+        chunk_states_ptrs = chunk_states_ptr + (
+            offs_m[:, None] * stride_chunk_states_hdim
+            + offs_n[None, :] * stride_chunk_states_dstate
+        )
+        
+        # Load chunk states unconditionally
+        past_states_chunk = tl.load(
+            chunk_states_ptrs,
+            mask=(offs_m[:, None] < hdim) & (offs_n[None, :] < dstate),
+            other=0.0,
+        ).to(tl.float32)
+        
+        if HAS_INITSTATES:
+            # Compute init_states_ptrs (this is compile-time branch)
+            init_states_ptrs = initstates_ptr + (
+                pid_b * stride_init_states_batch
+                + offs_m[:, None] * stride_init_states_hdim
+                + offs_n[None, :] * stride_init_states_dstate
             )
+            
+            # Load init states unconditionally
+            past_states_init = tl.load(
+                init_states_ptrs,
+                mask=(offs_m[:, None] < hdim) & (offs_n[None, :] < dstate),
+                other=0.0,
+            ).to(tl.float32)
+            
+            # Select data via tl.where (runtime selection without control flow)
+            past_states = tl.where(use_chunk_states, past_states_chunk, past_states_init)
+            
+            # Load dA_cs_boundary conditionally via tl.where
+            # Compute pointer for boundary load
+            dA_cs_boundary_idx = start_idx - pid_c * chunk_size - 1
+            dA_cs_boundary_val = tl.load(
+                dA_cumsum_ptr + dA_cs_boundary_idx * stride_dA_cs_csize,
+                mask=need_boundary,
+                other=0.0,
+            ).to(tl.float32)
+            dA_cs_boundary = tl.where(need_boundary, dA_cs_boundary_val, 0.0)
+            
+            scale = tl.exp(dA_cs_last - dA_cs_boundary)
+            acc += past_states * scale
         else:
+            # No HAS_INITSTATES: use tl.where for runtime selection
+            # When use_chunk_states=False, scale=0, so contribution is zero
+            scale = tl.where(use_chunk_states, tl.exp(dA_cs_last), 0.0)
+            acc += past_states_chunk * scale[:, None]
+    else:
+        # Original GPU logic
+        if (start_idx < pid_c * chunk_size) or (HAS_INITSTATES):
 
-            # - this seems repetitive, buts its to help the compiler
-            if start_idx < pid_c * chunk_size:
+            dA_cs_boundary = 0.0
+
+            if not HAS_INITSTATES:
                 past_states_ptrs = chunk_states_ptr + (
                     offs_m[:, None] * stride_chunk_states_hdim
                     + offs_n[None, :] * stride_chunk_states_dstate
                 )
             else:
-                past_states_ptrs = initstates_ptr + (
-                    pid_b * stride_init_states_batch
-                    + offs_m[:, None] * stride_init_states_hdim
-                    + offs_n[None, :] * stride_init_states_dstate
-                )
 
-                # need to adjust the boundary
-                if start_idx > pid_c * chunk_size:
-                    dA_cs_boundary = tl.load(
-                        dA_cumsum_ptr
-                        + (start_idx - pid_c * chunk_size - 1) * stride_dA_cs_csize
-                    ).to(tl.float32)
+                if start_idx < pid_c * chunk_size:
+                    past_states_ptrs = chunk_states_ptr + (
+                        offs_m[:, None] * stride_chunk_states_hdim
+                        + offs_n[None, :] * stride_chunk_states_dstate
+                    )
+                else:
+                    past_states_ptrs = initstates_ptr + (
+                        pid_b * stride_init_states_batch
+                        + offs_m[:, None] * stride_init_states_hdim
+                        + offs_n[None, :] * stride_init_states_dstate
+                    )
 
-        past_states = tl.load(
-            past_states_ptrs,
-            mask=(offs_m[:, None] < hdim) & (offs_n[None, :] < dstate),
-            other=0.0,
-        ).to(tl.float32)
+                    if start_idx > pid_c * chunk_size:
+                        dA_cs_boundary = tl.load(
+                            dA_cumsum_ptr
+                            + (start_idx - pid_c * chunk_size - 1) * stride_dA_cs_csize
+                        ).to(tl.float32)
 
-        scale = tl.exp(dA_cs_last - dA_cs_boundary)
-        acc += past_states * scale
+            past_states = tl.load(
+                past_states_ptrs,
+                mask=(offs_m[:, None] < hdim) & (offs_n[None, :] < dstate),
+                other=0.0,
+            ).to(tl.float32)
+
+            scale = tl.exp(dA_cs_last - dA_cs_boundary)
+            acc += past_states * scale
 
     states = acc.to(states_ptr.dtype.element_ty)
 
@@ -489,6 +549,7 @@ def _chunk_cumsum_fwd(
             dt_softplus,
             HAS_DT_BIAS=dt_bias is not None,
             BLOCK_SIZE_CHUNK=triton.next_power_of_2(chunk_size),
+            BLOCK_SIZE_H=SSD_BLOCK_SIZE_H,
         )
     return dA_cumsum, dt_out
 
@@ -568,6 +629,7 @@ def _chunk_state_fwd(
 def chunk_state_varlen(
     B, x, dt, dA_cumsum, cu_seqlens, chunk_states, initial_states=None
 ):
+    is_npu_device = x.device.type == 'npu' or str(x.device).startswith('npu')
     total_seqlen, nheads, headdim = x.shape
     _, nchunks, chunk_size = dt.shape
     _, ngroups, dstate = B.shape
@@ -642,5 +704,6 @@ def chunk_state_varlen(
                 else (0, 0, 0, 0)
             ),
             HAS_INITSTATES=initial_states is not None,
+            IS_NPU=is_npu_device,
         )
     return states

--- a/python/sglang/srt/models/granitemoehybrid.py
+++ b/python/sglang/srt/models/granitemoehybrid.py
@@ -452,7 +452,7 @@ class GraniteMoeHybridModel(nn.Module):
                 }
             )
         else:
-            hidden_states, _ = self.norm(hidden_states, residual)
+            hidden_states = self.norm(hidden_states)
 
         if len(aux_hidden_states) == 0:
             return hidden_states


### PR DESCRIPTION
## Summary of Changes

- **Problem Fixed**: Resolved runtime errors for the **Granite hybrid model** when running on **NPU (Ascend backend)**.
- **Main Modifications** (according to the Gemini code review bot):
  - Refactored **Triton kernels** to replace runtime control flow with `tl.where` for pointer operations and data selection (necessary for NPU compatibility).
  - Optimized **Mamba** and **GraniteMoE** models for the Ascend NPU backend.
  - Configured `GraniteMoeHybridForCausalLM` to use **native SDPA** on NPUs.
  

### Usage

```bash
python -m sglang.launch_server \
--model-path  /home/weights/granite-4.0-h-micro \
--port 8010 \
--tp-size 1 \
--mem-fraction-static 0.7 \
--base-gpu-id 0  \
--max-total-tokens 4096 \
--attention-backend ascend \
--device npu \
--disable-radix-cache \
--page-size 128 \
```




