### PR TITLE
Fix DeepSeek V4 GB200 serving with max-running-requests=1

### DIFF
--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -311,7 +311,7 @@ class SchedulerRuntimeCheckerMixin:
         if self.disaggregation_mode == DisaggregationMode.DECODE:
             expected_free = req_total_size
         else:
-            expected_free = req_total_size - 1
+            expected_free = req_total_size
         if len(self.req_to_token_pool.free_slots) != expected_free:
             msg = (
                 "req_to_token_pool memory leak detected!"

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -133,11 +133,13 @@ class ReqToTokenPool:
         self.max_context_len = max_context_len
         self.device = device
         with memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
+            # Row 0 is reserved for padded/dummy tokens, so allocate one
+            # additional row to keep `size` equal to usable request capacity.
             self.req_to_token = torch.zeros(
-                (size, max_context_len), dtype=torch.int32, device=device
+                (size + 1, max_context_len), dtype=torch.int32, device=device
             )
 
-        self.free_slots = list(range(1, size))
+        self.free_slots = list(range(1, size + 1))
 
     def write(self, indices, values):
         self.req_to_token[indices] = values
@@ -161,7 +163,7 @@ class ReqToTokenPool:
             self.free_slots.extend(free_index)
 
     def clear(self):
-        self.free_slots = list(range(1, self.size))
+        self.free_slots = list(range(1, self.size + 1))
 
 
 class MambaPool:
@@ -459,12 +461,12 @@ class HybridReqToTokenPool(ReqToTokenPool):
 
         self.device = device
         self.req_index_to_mamba_index_mapping: torch.Tensor = torch.zeros(
-            size, dtype=torch.int32, device=self.device
+            size + 1, dtype=torch.int32, device=self.device
         )
         if enable_mamba_extra_buffer:
             self.req_index_to_mamba_ping_pong_track_buffer_mapping: torch.Tensor = (
                 torch.zeros(
-                    (size, self.mamba_ping_pong_track_buffer_size),
+                    (size + 1, self.mamba_ping_pong_track_buffer_size),
                     dtype=torch.int32,
                     device=self.device,
                 )

--- a/test/srt/test_req_to_token_pool.py
+++ b/test/srt/test_req_to_token_pool.py
@@ -1,0 +1,26 @@
+import pytest
+
+from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
+
+
+@pytest.mark.parametrize("size", [1, 2, 8])
+def test_req_to_token_pool_size_is_usable_capacity(size):
+    pool = ReqToTokenPool(
+        size=size,
+        max_context_len=16,
+        device="cpu",
+        enable_memory_saver=False,
+    )
+
+    assert pool.available_size() == size
+
+    slots = pool.alloc(size)
+    assert slots == list(range(1, size + 1))
+    assert pool.available_size() == 0
+    assert pool.alloc(1) is None
+
+    pool.free(slots)
+    assert pool.available_size() == size
+
+    pool.clear()
+    assert pool.available_size() == size


### PR DESCRIPTION
## Summary

This fixes the DeepSeek V4 serving path on GB200 when the server is launched with `--max-running-requests 1`.

On the GB200 DeepSeek-V4-Flash repro, the model could load and `/model_info` returned 200, but the first `/generate` request never reached model forward. The scheduler accepted the request into the waiting queue, then repeatedly stayed at:

```text
waiting=1, running=0, running_full=True
```

The issue was not attention, MoE, tokenizer, TP communication, or the DSv4 model forward itself. It was an off-by-one capacity bug in the request-to-token pool.

## Root Cause

`ReqToTokenPool` reserves row 0 for padded/dummy tokens, but it previously allocated exactly `size` rows and initialized usable slots as:

```python
self.free_slots = list(range(1, size))
```

That means `ReqToTokenPool(size=1)` exposes zero usable request slots.

For a launch with `--max-running-requests 1`, the scheduler sees no allocatable request slot before the first request can be admitted. It then marks the empty running batch as full, leaving the request stuck in the waiting queue forever.

## Fix

This PR makes the `ReqToTokenPool(size=N)` contract match the public meaning of `max_running_requests`: `N` means `N` usable request slots.

Changes:

- Allocate one extra `ReqToTokenPool` row so row 0 remains reserved while slots `1..N` are usable.
- Reset normal req-pool `free_slots` to `range(1, size + 1)` in initialization and `clear()`.
- Resize `HybridReqToTokenPool` request-index-to-Mamba mapping tensors to `size + 1`, because Hybrid inherits request indices from `ReqToTokenPool`.
- Update the scheduler runtime checker so an idle normal pool expects `total_size` usable free slots.
- Add a focused unit test for the request-pool capacity contract.

## GB200 Validation

Environment:

- Node: one GB200 node
- Model: `/data/models/DeepSeek-V4-Flash`
- Image: `lmsysorg/sglang:deepseek-v4-grace-blackwell`
- Important flags: `--moe-runner-backend flashinfer_mxfp4`, `--disable-cuda-graph`, `--disable-flashinfer-autotune`, `--max-total-tokens 8192`, `--max-running-requests 1`

Validated cases:

1. Before fix, TP=1 two-layer `--max-running-requests 1` queued the request, then spun with `waiting=1`, `running=0`, `running_full=True`; no model forward markers were reached.
2. Workaround check: changing only `--max-running-requests 1` to `2` made the same raw `input_ids` request complete with HTTP 200.
3. Fixed two-layer check: with this patch copied into the DSv4 image, the original TP=1 two-layer `--max-running-requests 1` request completed with HTTP 200.
4. Fixed full-model check: with this patch copied into the DSv4 image, full DeepSeek-V4-Flash TP=4 served a deterministic text prompt successfully:

```text
Question: What is 2 + 2? Answer with just the number.
```

With `max_new_tokens=2`, `/generate` returned HTTP 200 with:

```json
{"text":" 4"}
```

The raw `input_ids` output token was only used as a scheduler-progress probe. The full-model text prompt above is the output sanity check.

## Local Checks

```bash
python3 -m py_compile \
  python/sglang/srt/mem_cache/memory_pool.py \
  python/sglang/srt/managers/scheduler_runtime_checker_mixin.py \
  test/srt/test_req_to_token_pool.py

git diff --check -- \
  python/sglang/srt/mem_cache/memory_pool.py \
  python/sglang/srt/managers/scheduler_runtime_checker_mixin.py \
  test/srt/test_req_to_token_pool.py
```

`pytest test/srt/test_req_to_token_pool.py -q` is blocked in my local Mac environment because `triton` is not installed before importing `memory_pool.py`.

## Reference
https://github.com/sgl-project/sglang/pull/23600
https://github.com/sgl-project/sglang/issues/23602
https://github.com/sgl-project/sglang/pull/23635
https://github.com/sgl-project/sglang/pull/23617
https://github.com/sgl-project/sglang/pull/23622