### PR TITLE
[kernel] Fix cudaErrorInvalidConfiguration when num_tokens=0 in activation kernels

### DIFF
--- a/sgl-kernel/csrc/elementwise/activation.cu
+++ b/sgl-kernel/csrc/elementwise/activation.cu
@@ -85,6 +85,7 @@ __device__ __forceinline__ T gelu_tanh(const T& x) {
 void silu_and_mul(at::Tensor& out, at::Tensor& input) {
   int d = input.size(-1) / 2;
   int64_t num_tokens = input.numel() / input.size(-1);
+  if (num_tokens == 0) return;
   dim3 grid(num_tokens);
 
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
@@ -107,6 +108,7 @@ void silu_and_mul(at::Tensor& out, at::Tensor& input) {
 void gelu_tanh_and_mul(at::Tensor& out, at::Tensor& input) {
   int d = input.size(-1) / 2;
   int64_t num_tokens = input.numel() / input.size(-1);
+  if (num_tokens == 0) return;
   dim3 grid(num_tokens);
 
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
@@ -129,6 +131,7 @@ void gelu_tanh_and_mul(at::Tensor& out, at::Tensor& input) {
 void gelu_and_mul(at::Tensor& out, at::Tensor& input) {
   int d = input.size(-1) / 2;
   int64_t num_tokens = input.numel() / input.size(-1);
+  if (num_tokens == 0) return;
   dim3 grid(num_tokens);
 
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
@@ -153,6 +156,7 @@ void gelu_and_mul(at::Tensor& out, at::Tensor& input) {
 void gelu_quick(at::Tensor& out, const at::Tensor& input) {
   int d = input.size(-1);
   int64_t num_tokens = input.numel() / input.size(-1);
+  if (num_tokens == 0) return;
   dim3 grid(num_tokens);
 
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();


### PR DESCRIPTION
## Summary

- Fix crash with `cudaErrorInvalidConfiguration` (error 9) when activation kernels (`silu_and_mul`, `gelu_tanh_and_mul`, `gelu_and_mul`, `gelu_quick`) are called with zero-row input tensors (`num_tokens=0`)
- Add early return guard for `num_tokens==0` to avoid launching CUDA kernels with invalid `dim3(0)` grid dimension

## Problem

In DeepEP expert-parallel deployments (e.g., DeepSeek V3, EP=8), when the batch size is small, some ranks may receive 0 tokens for all local experts. The MoE contiguous GEMM path then calls these activation functions with `(0, N*2)` shaped tensors, triggering the crash.

The error is sticky - it corrupts CUDA runtime state and causes subsequent unrelated CUDA operations to fail.

## Fix

```cpp
if (num_tokens == 0) return;
```

Added to the four affected functions in `sgl-kernel/csrc/elementwise/activation.cu`.

## Test plan

- [x] Verified with minimal reproduction script (num_tokens=32 works, num_tokens=0 no longer crashes)
- [ ] Real DeepEP deployment test (EP=8, small batch prefill)

Fixes #23609

🤖 Generated with [Claude Code](https://claude.com/claude-code)