### PR TITLE
[Intel GPU] Enable pipeline parallelism on XPU

### DIFF
--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -31,7 +31,7 @@ from sglang.srt.managers.utils import (
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.srt.utils import DynamicGradMode, broadcast_pyobj, point_to_point_pyobj
-from sglang.srt.utils.common import is_xpu
+from sglang.srt.utils.common import get_device_module, is_xpu
 
 logger = logging.getLogger(__name__)
 
@@ -628,8 +628,9 @@ class SchedulerPPMixin:
                 pp_proxy = PPProxyTensors(proxy_tensors)
 
                 # Measure latency with device synchronization for accurate timing
+                device_module = get_device_module()
                 # Synchronize before starting timing to ensure clean measurement
-                self.device_module.synchronize()
+                device_module.synchronize()
 
                 start = time.perf_counter()
                 batch.prepare_for_extend()
@@ -643,7 +644,7 @@ class SchedulerPPMixin:
                 )
 
                 # Synchronize after forward to ensure GPU operations complete
-                self.device_module.synchronize()
+                device_module.synchronize()
 
                 latency_seconds = time.perf_counter() - start
                 latency_ms = latency_seconds * 1e3  # Convert to milliseconds

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -860,7 +860,11 @@ class SchedulerPPMixin:
         self: Scheduler,
         next_first_rank_mb_id: int,
         next_mb_id: int,
-    ) -> Tuple[PPProxyTensors, GenerationBatchResult, torch.Event]:
+    ) -> Tuple[
+        Optional[PPProxyTensors],
+        Optional[GenerationBatchResult],
+        Optional[torch.Event],
+    ]:
         self._pp_commit_comm_work(work=self.send_output_work)
         (
             next_pp_outputs,
@@ -1091,7 +1095,12 @@ class SchedulerPPMixin:
         mb_metadata: List[PPBatchMetadata],
         last_rank_comm_queue: deque[Tuple[torch.Event, PPProxyTensors]],
         pp_outputs: PPProxyTensors | None,
-    ) -> Tuple[PPProxyTensors, List[P2PWork], torch.Event]:
+    ) -> Tuple[
+        Optional[PPProxyTensors],
+        Optional[GenerationBatchResult],
+        Optional[torch.Event],
+        List[P2PWork],
+    ]:
         next_pp_outputs = None
         d2h_event = None
         batch_result = None

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -129,7 +129,9 @@ class SchedulerPPMixin:
                     self.last_mbs[next_mb_id] = self.mbs[next_mb_id]
                 if not self.pp_group.is_last_rank:
                     if self.cur_batch:
-                        torch.cuda.current_stream().wait_event(self.launch_event)
+                        self.device_module.current_stream().wait_event(
+                            self.launch_event
+                        )
                         with torch.profiler.record_function(
                             "send_proxy_dict_to_next_stage"
                         ):
@@ -304,7 +306,9 @@ class SchedulerPPMixin:
                         transferred_rids, async_send=True
                     )
                     if self.cur_batch:
-                        torch.cuda.current_stream().wait_event(self.launch_event)
+                        self.device_module.current_stream().wait_event(
+                            self.launch_event
+                        )
                         self.send_proxy_work = self._pp_send_dict_to_next_stage(
                             result.pp_hidden_states_proxy_tensors.tensors,
                             async_send=True,
@@ -485,7 +489,9 @@ class SchedulerPPMixin:
                         transferred_rids, async_send=True
                     )
                     if self.cur_batch and not self.cur_batch.forward_mode.is_prebuilt():
-                        torch.cuda.current_stream().wait_event(self.launch_event)
+                        self.device_module.current_stream().wait_event(
+                            self.launch_event
+                        )
                         self.send_proxy_work = self._pp_send_dict_to_next_stage(
                             result.pp_hidden_states_proxy_tensors.tensors,
                             async_send=True,
@@ -525,9 +531,7 @@ class SchedulerPPMixin:
         ]
         self.mb_metadata: List[Optional[PPBatchMetadata]] = [None] * self.pp_loop_size
         self.pp_outputs: Optional[PPProxyTensors] = None
-        self.last_rank_comm_queue: deque[Tuple[torch.cuda.Event, PPProxyTensors]] = (
-            deque()
-        )
+        self.last_rank_comm_queue: deque[Tuple[torch.Event, PPProxyTensors]] = deque()
 
         self.send_req_work = []
         self.send_proxy_work = []
@@ -611,21 +615,20 @@ class SchedulerPPMixin:
                     "hidden_states": torch.zeros(
                         (current_seq_len, model_config.hidden_size),
                         dtype=model_config.dtype,
-                        device="cuda",
+                        device=self.device,
                     ),
                     "residual": torch.zeros(
                         (current_seq_len, model_config.hidden_size),
                         dtype=model_config.dtype,
-                        device="cuda",
+                        device=self.device,
                     ),
                 }
 
                 pp_proxy = PPProxyTensors(proxy_tensors)
 
-                # Measure latency with CUDA synchronization for accurate timing
+                # Measure latency with device synchronization for accurate timing
                 # Synchronize before starting timing to ensure clean measurement
-                if torch.cuda.is_available():
-                    torch.cuda.synchronize()
+                self.device_module.synchronize()
 
                 start = time.perf_counter()
                 batch.prepare_for_extend()
@@ -639,8 +642,7 @@ class SchedulerPPMixin:
                 )
 
                 # Synchronize after forward to ensure GPU operations complete
-                if torch.cuda.is_available():
-                    torch.cuda.synchronize()
+                self.device_module.synchronize()
 
                 latency_seconds = time.perf_counter() - start
                 latency_ms = latency_seconds * 1e3  # Convert to milliseconds
@@ -858,7 +860,7 @@ class SchedulerPPMixin:
         self: Scheduler,
         next_first_rank_mb_id: int,
         next_mb_id: int,
-    ) -> Tuple[PPProxyTensors, GenerationBatchResult, torch.cuda.Event]:
+    ) -> Tuple[PPProxyTensors, GenerationBatchResult, torch.Event]:
         self._pp_commit_comm_work(work=self.send_output_work)
         (
             next_pp_outputs,
@@ -1054,7 +1056,7 @@ class SchedulerPPMixin:
         self: Scheduler,
         next_first_rank_mb_id: int,
         mbs: List[ScheduleBatch],
-        last_rank_comm_queue: deque[Tuple[torch.cuda.Event, PPProxyTensors]],
+        last_rank_comm_queue: deque,
         pp_outputs: PPProxyTensors | None,
     ) -> List[P2PWork]:
         send_output_work = []
@@ -1063,7 +1065,7 @@ class SchedulerPPMixin:
             if mbs[next_first_rank_mb_id] is not None:
                 q_event, pp_outputs_to_send = last_rank_comm_queue.popleft()
                 if not mbs[next_first_rank_mb_id].forward_mode.is_prebuilt():
-                    torch.cuda.current_stream().wait_event(q_event)
+                    self.device_module.current_stream().wait_event(q_event)
                     with torch.profiler.record_function("send_res_dict_to_next_stage"):
                         send_output_work = self._pp_send_dict_to_next_stage(
                             pp_outputs_to_send.tensors,
@@ -1087,34 +1089,49 @@ class SchedulerPPMixin:
         next_mb_id: int,
         mbs: List[ScheduleBatch],
         mb_metadata: List[PPBatchMetadata],
-        last_rank_comm_queue: deque[Tuple[torch.cuda.Event, PPProxyTensors]],
+        last_rank_comm_queue: deque[Tuple[torch.Event, PPProxyTensors]],
         pp_outputs: PPProxyTensors | None,
-    ) -> Tuple[PPProxyTensors, List[P2PWork], torch.cuda.Event]:
+    ) -> Tuple[PPProxyTensors, List[P2PWork], torch.Event]:
         next_pp_outputs = None
         d2h_event = None
         batch_result = None
-        send_output_work = self._pp_send_output_to_next_stage(
-            next_first_rank_mb_id,
-            mbs,
-            last_rank_comm_queue,
-            pp_outputs,
-        )
+        send_output_work = []
 
-        if mbs[next_mb_id] is not None:
+        # Order send/recv by pp_rank parity so each adjacent pair has one
+        # sender and one receiver posted at the same time. If every rank
+        # sends first, backends where point-to-point isend busy-polls for a
+        # matching recv rendezvous (e.g. xccl on XPU) livelock: all ranks
+        # spin in isend and none posts recv.
+        send_first = (self.pp_rank % 2) == 0
+
+        def _do_send():
+            return self._pp_send_output_to_next_stage(
+                next_first_rank_mb_id,
+                mbs,
+                last_rank_comm_queue,
+                pp_outputs,
+            )
+
+        def _do_recv():
+            nonlocal next_pp_outputs, batch_result, d2h_event
+            if mbs[next_mb_id] is None or mbs[next_mb_id].forward_mode.is_prebuilt():
+                return
             with torch.profiler.record_function("recv_res_dict_from_prev_stage"):
-                next_pp_outputs = None
-                if not mbs[next_mb_id].forward_mode.is_prebuilt():
-                    next_pp_outputs = PPProxyTensors(
-                        self._pp_recv_dict_from_prev_stage()
-                    )
-            if not mbs[next_mb_id].forward_mode.is_prebuilt():
-                with self.copy_stream_ctx:
-                    self.copy_stream.wait_stream(self.schedule_stream)
-                    batch_result = self._pp_prep_batch_result(
-                        mbs[next_mb_id], mb_metadata[next_mb_id], next_pp_outputs
-                    )
-                    d2h_event = torch.cuda.Event()
-                    d2h_event.record(torch.cuda.current_stream())
+                next_pp_outputs = PPProxyTensors(self._pp_recv_dict_from_prev_stage())
+            with self.copy_stream_ctx:
+                self.copy_stream.wait_stream(self.schedule_stream)
+                batch_result = self._pp_prep_batch_result(
+                    mbs[next_mb_id], mb_metadata[next_mb_id], next_pp_outputs
+                )
+                d2h_event = self.device_module.Event()
+                d2h_event.record(self.device_module.current_stream())
+
+        if send_first:
+            send_output_work = _do_send()
+            _do_recv()
+        else:
+            _do_recv()
+            send_output_work = _do_send()
 
         return next_pp_outputs, batch_result, d2h_event, send_output_work
 
@@ -1123,7 +1140,7 @@ class SchedulerPPMixin:
         mb_id: int,
         pp_proxy_tensors: PPProxyTensors,
         mb_metadata: List[Optional[PPBatchMetadata]],
-        last_rank_comm_queue: deque[Tuple[torch.cuda.Event, PPProxyTensors]],
+        last_rank_comm_queue: deque,
     ):
         with torch.profiler.record_function("run_batch"):
             with self.forward_stream_ctx:
@@ -1132,8 +1149,8 @@ class SchedulerPPMixin:
                 mb_metadata[mb_id] = PPBatchMetadata(
                     can_run_cuda_graph=result.can_run_cuda_graph,
                 )
-                event = torch.cuda.Event()
-                event.record(torch.cuda.current_stream())
+                event = self.device_module.Event()
+                event.record(self.device_module.current_stream())
                 if self.pp_group.is_last_rank:
                     # (last rank) buffer the outputs for async batch depth
                     last_rank_comm_queue.append(

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -31,6 +31,7 @@ from sglang.srt.managers.utils import (
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.srt.utils import DynamicGradMode, broadcast_pyobj, point_to_point_pyobj
+from sglang.srt.utils.common import is_xpu
 
 logger = logging.getLogger(__name__)
 
@@ -1106,12 +1107,18 @@ class SchedulerPPMixin:
         batch_result = None
         send_output_work = []
 
-        # Order send/recv by pp_rank parity so each adjacent pair has one
-        # sender and one receiver posted at the same time. If every rank
-        # sends first, backends where point-to-point isend busy-polls for a
-        # matching recv rendezvous (e.g. xccl on XPU) livelock: all ranks
-        # spin in isend and none posts recv.
-        send_first = (self.pp_rank % 2) == 0
+        # On CUDA, isend is async: it enqueues to the stream and returns,
+        # so every rank can send first safely. On some backends isend is
+        # effectively blocking and does not return until the peer posts a
+        # matching recv; if every PP rank sends first, all ranks block
+        # waiting for a receiver and the ring deadlocks. Order send/recv
+        # by pp_rank parity (even: send->recv, odd: recv->send) so each
+        # adjacent pair has one sender and one receiver posted at the
+        # same time.
+
+        # CUDA: send first
+        # XPU: even ranks send first, odd ranks recv first.
+        send_first = (not is_xpu()) or ((self.pp_rank % 2) == 0)
 
         def _do_send():
             return self._pp_send_output_to_next_stage(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Pipeline parallelism (PP) only ran on CUDA. On Intel XPU, launching any `--pp-size > 1` server crashed at startup with `RuntimeError: Tried to instantiate dummy base class Event` because `SchedulerPPMixin` hard-codes `torch.cuda.{Event, current_stream, synchronize}`. Even after fixing the hard-coded CUDA calls, `PP >= 2` livelocked during the first multi-rank communication: with XCCL on XPU, `torch.distributed.isend` busy-polls waiting for a matching `recv` rendezvous, so when every PP rank sent before receiving, all ranks spun at 100% CPU inside `torch.distributed` and none ever reached its `recv`.

This PR makes PP work on XPU (and generalizes to any non-CUDA backend `torch.get_device_module()` supports) without changing CUDA behavior.

## Modifications

<!-- Detail the changes made in this pull request. -->

1. **Device-agnostic event/stream/sync calls** in `python/sglang/srt/managers/scheduler_pp_mixin.py`:
   - Replaced `torch.cuda.Event()` → `get_device_module().Event()`
   - Replaced `torch.cuda.current_stream()` → `get_device_module().current_stream()`
   - Replaced `torch.cuda.synchronize()` → `get_device_module().synchronize()`
   - Replaced `deque[Tuple[torch.cuda.Event, ...]]` type hints with backend-agnostic forms
   - Added `get_device_module` to the existing `from sglang.srt.utils import ...` block

2. **Parity-based send/recv ordering** in `_pp_send_recv_and_preprocess_output_tensors`:
   - Even `pp_rank` ranks: send → recv
   - Odd `pp_rank` ranks: recv → send
   - Guarantees every adjacent PP pair has one sender and one receiver posted simultaneously, so `isend` always finds a matching `recv` already waiting and the rendezvous completes instead of busy-spinning.
   - Helper closures `_do_send()` / `_do_recv()` keep the two branches symmetric and avoid duplicating the profiler/copy-stream/d2h-event logic.

No CUDA codepath changes behavior: on CUDA, `get_device_module()` returns `torch.cuda`, and parity ordering is a pure reordering of already-independent send and recv operations.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

Verified on 4× Intel XPU with `meta-llama/Llama-3.1-8B-Instruct`:

| Config | Status |
|---|---|
| TP=1 PP=2 | ✅ |
| TP=1 PP=3 | ✅ |
| TP=1 PP=4 | ✅ |
| TP=2 PP=2 | ✅ |
| `TestPPAccuracy.test_logprob` (TP=2 PP=2) | ✅ pass |

CUDA behavior unchanged (no codepath difference for `torch.cuda` backend).

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

`bench_one_batch_server` full warmup + bench cycle at PP=4 on Intel XPU, Llama-3.1-8B, `batch_size=8`, `input_len=1024`, `output_len=128`:

======== Warmup Begin ========
Warmup with batch_size=[8]
#Input tokens: 8192
#Output tokens: 128
batch size: 8
input_len: 1024
output_len: 16
latency: 4.04 s
input throughput: 6569.72 tok/s
output throughput: 45.89 tok/s
======== Warmup End   ========

#Input tokens: 8192
#Output tokens: 1024
batch size: 8
input_len: 1024
output_len: 128
latency: 25.09 s
input throughput: 13051.32 tok/s
output throughput: 41.85 tok/s
last_ttft: 0.63 s
last generation throughput: 40.53 tok/s



Before this fix the same command hung indefinitely at the first large warmup batch (all 4 ranks at 100% CPU in `torch.distributed`).

## Checklist

- [x] Format your code according to [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). *(Existing `test_pp_single_node` tests cover this path; no new tests added since it's a backend-portability fix.)*
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). *(No user-facing API change.)*
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

cc@ShangmingCai