### PR TITLE
[MUSA][Diffusion] Fix fa3 API on MT MUSA

### DIFF
--- a/python/sglang/jit_kernel/flash_attention_v3.py
+++ b/python/sglang/jit_kernel/flash_attention_v3.py
@@ -7,6 +7,7 @@ import torch
 from sglang.jit_kernel.utils import cache_once
 from sglang.kernel_api_logging import debug_kernel_api
 from sglang.srt.environ import envs
+from sglang.srt.utils import get_device_capability, is_musa
 
 logger = logging.getLogger(__name__)
 
@@ -89,12 +90,12 @@ def _is_fa3_supported(device=None) -> bool:
     #  https://docs.nvidia.com/cuda/cuda-c-programming-guide/#shared-memory-8-x
     #  And for sgl-kernel right now, we can build fa3 on sm80/sm86/sm89/sm90a.
     #  That means if you use A100/A*0/L20/L40/L40s/4090 you can use fa3.
-    if torch.version.cuda is None:
-        return False
-    return (torch.version.cuda >= "12.3") and (
-        torch.cuda.get_device_capability(device)[0] == 9
-        or torch.cuda.get_device_capability(device)[0] == 8
-    )
+    major, minor = get_device_capability()
+    if is_musa():
+        return major >= 3
+    if torch.version.cuda is not None and torch.version.cuda >= "12.3":
+        return major == 9 or major == 8
+    return False
 
 
 @debug_kernel_api
@@ -211,31 +212,30 @@ def flash_attn_varlen_func(
             "flash_attn at sgl-kernel is only supported on sm90 and above"
         )
 
-    return _call_fa3_kernel(
-        _load_fa3_kernels()["flash_attn_varlen_func"],
-        q,
-        k,
-        v,
-        cu_seqlens_q,
-        cu_seqlens_k,
-        max_seqlen_q,
-        max_seqlen_k,
-        seqused_q,
-        seqused_k,
-        page_table,
-        softmax_scale,
-        causal,
-        qv,
-        q_descale,
-        k_descale,
-        v_descale,
-        window_size,
-        attention_chunk,
-        softcap,
-        num_splits,
-        pack_gqa,
-        sm_margin,
-        return_softmax_lse,
-        sinks,
+    return _load_fa3_kernels()["flash_attn_varlen_func"](
+        q=q,
+        k=k,
+        v=v,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        seqused_q=seqused_q,
+        seqused_k=seqused_k,
+        page_table=page_table,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        qv=qv,
+        q_descale=q_descale,
+        k_descale=k_descale,
+        v_descale=v_descale,
+        window_size=window_size,
+        attention_chunk=attention_chunk,
+        softcap=softcap,
+        num_splits=num_splits,
+        pack_gqa=pack_gqa,
+        sm_margin=sm_margin,
+        return_softmax_lse=return_softmax_lse,
+        sinks=sinks,
         out=out,
     )

--- a/python/sglang/jit_kernel/tests/test_flash_attention_3.py
+++ b/python/sglang/jit_kernel/tests/test_flash_attention_3.py
@@ -10,6 +10,7 @@ from einops import rearrange, repeat
 
 apply_rotary_emb = None
 
+from sglang.jit_kernel.flash_attention_v3 import _is_fa3_supported
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=120, suite="stage-b-kernel-unit-1-gpu-large")
@@ -19,21 +20,6 @@ register_cuda_ci(est_time=900, suite="nightly-kernel-1-gpu", nightly=True)
 def is_hopper():
     #  Only Hopper supports different V headdim
     return torch.cuda.get_device_properties(0).major == 9
-
-
-def is_fa3_supported(device=None) -> bool:
-    #  There some fa3 FYI
-    #  FA3 can fail without a enough shared memory for a some shapes, such as higher
-    #  hidden_dim or some special cases.
-    #  Right now, fa3 is supported for sm80/sm87 and sm86/sm89. The main different
-    #  Between sm80/sm87 and sm86/sm89 is the shared memory size. you can follow the link below for more information
-    #  https://docs.nvidia.com/cuda/cuda-c-programming-guide/#shared-memory-8-x
-    #  And for sgl-kernel right now, we can build fa3 on sm80/sm86/sm89/sm90a.
-    #  That means if you use A100/A*0/L20/L40/L40s/4090 you can use fa3.
-    return (torch.version.cuda >= "12.3") and (
-        torch.cuda.get_device_capability(device)[0] == 9
-        or torch.cuda.get_device_capability(device)[0] == 8
-    )
 
 
 DISABLE_BACKWARD = True
@@ -467,8 +453,8 @@ def generate_qkv(
 
 
 @pytest.mark.skipif(
-    not is_fa3_supported(),
-    reason="flash_attn at sgl-kernel is only supported on sm90 or sm80",
+    not _is_fa3_supported(),
+    reason="flash_attn at sgl-kernel is only supported on CUDA sm90, sm80 or MUSA >= mp31",
 )
 # @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float8_e4m3fn])
 @pytest.mark.parametrize(
@@ -1039,8 +1025,8 @@ def _generate_block_kvcache(
 
 
 @pytest.mark.skipif(
-    not is_fa3_supported(),
-    reason="flash_attn at sgl-kernel is only supported on sm90 or sm80",
+    not _is_fa3_supported(),
+    reason="flash_attn at sgl-kernel is only supported on CUDA sm90, sm80 or MUSA >= mp31",
 )
 # @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float8_e4m3fn])
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fix bugs on MT MUSA device

## Modifications

Fix `_is_fa3_supported` to support both CUDA and MUSA
Fix `flash_attn_varlen_func` parameters  using explicit keyword arguments

## Testing Done

Tested on Both Nvidia H200 and MUSA S5000

```
root@worker32219:/data/qingfu.wen/bak/sglang/python# python3 test.py 
2026-04-24 17:51:15 | __init__ | 139970559284352 | WARNING : No platform detected. Using base SRTPlatform with defaults.
2026-04-24 17:51:16 | warnings | 139970559284352 | WARNING : /data/qingfu.wen/bak/sglang/python/sglang/srt/layers/quantization/awq.py:87: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-04-24 17:51:18 | hf_diffusers_utils | 139970559284352 | INFO : Diffusers version: 0.33.0.dev0
[04-24 17:51:18] Automatically enable dit_layerwise_offload for WanT2V480PConfig for low memory and performance balance
[04-24 17:51:18] dit_layerwise_offload is enabled: lower GPU memory usage, but may reduce throughput or increase latency. If you are using multi-GPU deployment and already have enough memory headroom, prefer keeping dit_layerwise_offload disabled. Please tune this based on your memory headroom and performance target.
[04-24 17:51:18] server_args: {"model_path": "/data/qingfu.wen/models/Wan2.1-T2V-1.3B-Diffusers/", "model_id": null, "backend": "auto", "attention_backend": null, "attention_backend_config": {}, "cache_dit_config": null, "nccl_port": null, "trust_remote_code": false, "revision": null, "num_gpus": 1, "tp_size": 1, "sp_degree": 1, "ulysses_degree": 1, "ring_degree": 1, "dp_size": 1, "dp_degree": 1, "enable_cfg_parallel": false, "hsdp_replicate_dim": 1, "hsdp_shard_dim": 1, "dist_timeout": 3600, "pipeline_class_name": null, "lora_path": null, "lora_nickname": "default", "lora_scale": 1.0, "lora_weight_name": null, "component_paths": {}, "transformer_weights_path": null, "lora_target_modules": null, "dit_cpu_offload": true, "dit_layerwise_offload": true, "dit_offload_prefetch_size": 0.0, "text_encoder_cpu_offload": true, "image_encoder_cpu_offload": true, "vae_cpu_offload": true, "use_fsdp_inference": false, "pin_cpu_memory": true, "ltx2_two_stage_device_mode": null, "comfyui_mode": false, "enable_torch_compile": false, "warmup": false, "warmup_resolutions": null, "warmup_steps": 1, "disable_autocast": false, "master_port": 30005, "host": "127.0.0.1", "port": 30000, "webui": false, "webui_port": 12312, "scheduler_port": 5604, "strict_ports": false, "output_path": "outputs/", "input_save_path": "inputs/uploads", "prompt_file_path": null, "model_paths": {}, "model_loaded": {"transformer": true, "vae": true, "video_vae": true, "audio_vae": true, "video_dit": true, "audio_dit": true, "dual_tower_bridge": true}, "boundary_ratio": null, "base_gpu_id": 0, "disagg_role": "monolithic", "disagg_timeout": 600, "disagg_dispatch_policy": "round_robin", "disagg_mode": false, "disagg_server_addr": null, "encoder_urls": null, "denoiser_urls": null, "decoder_urls": null, "encoder_tp": null, "denoiser_tp": null, "denoiser_sp": null, "denoiser_ulysses": null, "denoiser_ring": null, "decoder_tp": null, "disagg_transfer_pool_size": 268435456, "disagg_p2p_hostname": "127.0.0.1", "disagg_ib_device": null, "pool_work_endpoint": null, "pool_result_endpoint": null, "log_level": "info", "uvicorn_access_log_exclude_prefixes": [], "enable_trace": false, "otlp_traces_endpoint": "localhost:4317"}
[04-24 17:51:18] Local mode: True
[04-24 17:51:18] Starting server...
2026-04-24 17:51:25 | __init__ | 139827764388992 | WARNING : No platform detected. Using base SRTPlatform with defaults.
2026-04-24 17:51:26 | warnings | 139827764388992 | WARNING : /data/qingfu.wen/bak/sglang/python/sglang/srt/layers/quantization/awq.py:87: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

[04-24 17:51:28] Scheduler bind at endpoint: tcp://127.0.0.1:5604
[04-24 17:51:28] Initializing distributed environment with world_size=1, device=musa:0, timeout=3600
[04-24 17:51:28] Setting distributed timeout to 3600 seconds
[04-24 17:51:28] No pipeline_class_name specified, using model_index.json
[04-24 17:51:28] Diffusers version: 0.33.0.dev0
[04-24 17:51:28] Using pipeline from model_index.json: WanPipeline
[04-24 17:51:28] Loading pipeline modules...
[04-24 17:51:28] Model already exists locally and is complete
[04-24 17:51:28] Model path: /data/qingfu.wen/models/Wan2.1-T2V-1.3B-Diffusers/
[04-24 17:51:28] Diffusers version: 0.33.0.dev0
[04-24 17:51:28] Loading pipeline modules from config: {'_class_name': 'WanPipeline', '_diffusers_version': '0.33.0.dev0', 'scheduler': ['diffusers', 'UniPCMultistepScheduler'], 'text_encoder': ['transformers', 'UMT5EncoderModel'], 'tokenizer': ['transformers', 'T5TokenizerFast'], 'transformer': ['diffusers', 'WanTransformer3DModel'], 'vae': ['diffusers', 'AutoencoderKLWan']}
[04-24 17:51:28] Loading required components: ['text_encoder', 'tokenizer', 'vae', 'transformer', 'scheduler']
Loading required modules:   0%|                                                                                                                                                                                    | 0/5 [00:00<?, ?it/s][04-24 17:51:28] Loading text_encoder from /data/qingfu.wen/models/Wan2.1-T2V-1.3B-Diffusers/text_encoder. avail mem: 79.26 GB
[04-24 17:51:32] [RunAI Streamer] Overall time to stream 21.2 GiB of all files to cpu: 4.16s, 5.1 GiB/s
[04-24 17:51:32] ce_comm is available, using intra-node all-gather/reduce-scatter overlapped implementation by default
[04-24 17:51:57] Loaded text_encoder: FSDPUMT5EncoderModel (sgl-diffusion version). model size: 21.16 GB, consumed GPU mem: 0.28 GB, avail GPU mem: 78.98 GB
Loading required modules:  20%|██████████████████████████████████▍                                                                                                                                         | 1/5 [00:28<01:55, 28.78s/it][04-24 17:51:57] Loading tokenizer from /data/qingfu.wen/models/Wan2.1-T2V-1.3B-Diffusers/tokenizer. avail mem: 78.98 GB
[04-24 17:51:58] Loaded tokenizer: T5Tokenizer (sgl-diffusion version). model size: NA GB, consumed GPU mem: 0.00 GB, avail GPU mem: 78.98 GB
Loading required modules:  40%|████████████████████████████████████████████████████████████████████▊                                                                                                       | 2/5 [00:30<00:38, 12.85s/it][04-24 17:51:58] Loading vae from /data/qingfu.wen/models/Wan2.1-T2V-1.3B-Diffusers/vae. avail mem: 78.98 GB
[04-24 17:51:58] VAE unexpected keys: ['encoder.conv_in.bias', 'encoder.conv_in.weight', 'encoder.conv_out.bias', 'encoder.conv_out.weight', 'encoder.down_blocks.0.conv1.bias', 'encoder.down_blocks.0.conv1.weight', 'encoder.down_blocks.0.conv2.bias', 'encoder.down_blocks.0.conv2.weight', 'encoder.down_blocks.0.norm1.gamma', 'encoder.down_blocks.0.norm2.gamma', 'encoder.down_blocks.1.conv1.bias', 'encoder.down_blocks.1.conv1.weight', 'encoder.down_blocks.1.conv2.bias', 'encoder.down_blocks.1.conv2.weight', 'encoder.down_blocks.1.norm1.gamma', 'encoder.down_blocks.1.norm2.gamma', 'encoder.down_blocks.10.conv1.bias', 'encoder.down_blocks.10.conv1.weight', 'encoder.down_blocks.10.conv2.bias', 'encoder.down_blocks.10.conv2.weight', 'encoder.down_blocks.10.norm1.gamma', 'encoder.down_blocks.10.norm2.gamma', 'encoder.down_blocks.2.resample.1.bias', 'encoder.down_blocks.2.resample.1.weight', 'encoder.down_blocks.3.conv1.bias', 'encoder.down_blocks.3.conv1.weight', 'encoder.down_blocks.3.conv2.bias', 'encoder.down_blocks.3.conv2.weight', 'encoder.down_blocks.3.conv_shortcut.bias', 'encoder.down_blocks.3.conv_shortcut.weight', 'encoder.down_blocks.3.norm1.gamma', 'encoder.down_blocks.3.norm2.gamma', 'encoder.down_blocks.4.conv1.bias', 'encoder.down_blocks.4.conv1.weight', 'encoder.down_blocks.4.conv2.bias', 'encoder.down_blocks.4.conv2.weight', 'encoder.down_blocks.4.norm1.gamma', 'encoder.down_blocks.4.norm2.gamma', 'encoder.down_blocks.5.resample.1.bias', 'encoder.down_blocks.5.resample.1.weight', 'encoder.down_blocks.5.time_conv.bias', 'encoder.down_blocks.5.time_conv.weight', 'encoder.down_blocks.6.conv1.bias', 'encoder.down_blocks.6.conv1.weight', 'encoder.down_blocks.6.conv2.bias', 'encoder.down_blocks.6.conv2.weight', 'encoder.down_blocks.6.conv_shortcut.bias', 'encoder.down_blocks.6.conv_shortcut.weight', 'encoder.down_blocks.6.norm1.gamma', 'encoder.down_blocks.6.norm2.gamma', 'encoder.down_blocks.7.conv1.bias', 'encoder.down_blocks.7.conv1.weight', 'encoder.down_blocks.7.conv2.bias', 'encoder.down_blocks.7.conv2.weight', 'encoder.down_blocks.7.norm1.gamma', 'encoder.down_blocks.7.norm2.gamma', 'encoder.down_blocks.8.resample.1.bias', 'encoder.down_blocks.8.resample.1.weight', 'encoder.down_blocks.8.time_conv.bias', 'encoder.down_blocks.8.time_conv.weight', 'encoder.down_blocks.9.conv1.bias', 'encoder.down_blocks.9.conv1.weight', 'encoder.down_blocks.9.conv2.bias', 'encoder.down_blocks.9.conv2.weight', 'encoder.down_blocks.9.norm1.gamma', 'encoder.down_blocks.9.norm2.gamma', 'encoder.mid_block.attentions.0.norm.gamma', 'encoder.mid_block.attentions.0.proj.bias', 'encoder.mid_block.attentions.0.proj.weight', 'encoder.mid_block.attentions.0.to_qkv.bias', 'encoder.mid_block.attentions.0.to_qkv.weight', 'encoder.mid_block.resnets.0.conv1.bias', 'encoder.mid_block.resnets.0.conv1.weight', 'encoder.mid_block.resnets.0.conv2.bias', 'encoder.mid_block.resnets.0.conv2.weight', 'encoder.mid_block.resnets.0.norm1.gamma', 'encoder.mid_block.resnets.0.norm2.gamma', 'encoder.mid_block.resnets.1.conv1.bias', 'encoder.mid_block.resnets.1.conv1.weight', 'encoder.mid_block.resnets.1.conv2.bias', 'encoder.mid_block.resnets.1.conv2.weight', 'encoder.mid_block.resnets.1.norm1.gamma', 'encoder.mid_block.resnets.1.norm2.gamma', 'encoder.norm_out.gamma']
[04-24 17:51:58] Loaded vae: AutoencoderKLWan (sgl-diffusion version). model size: 0.27 GB, consumed GPU mem: 0.00 GB, avail GPU mem: 78.98 GB
[04-24 17:51:58] Loading transformer from /data/qingfu.wen/models/Wan2.1-T2V-1.3B-Diffusers/transformer. avail mem: 78.98 GB
[04-24 17:51:58] Loading WanTransformer3DModel from 2 safetensors file(s) , param_dtype: torch.bfloat16
[04-24 17:51:58] Using FlashAttention (FA3) backend on MUSA
[04-24 17:51:58] Using FlashAttention (FA3) backend on MUSA
[04-24 17:51:59] [RunAI Streamer] Overall time to stream 5.3 GiB of all files to cpu: 0.48s, 11.0 GiB/s
[04-24 17:52:00] Loaded model with 1.42B parameters
[04-24 17:52:00] Loaded transformer: WanTransformer3DModel (sgl-diffusion version). model size: 2.64 GB, consumed GPU mem: 0.00 GB, avail GPU mem: 78.98 GB
Loading required modules:  80%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▌                                  | 4/5 [00:32<00:05,  5.44s/it][04-24 17:52:00] Loading scheduler from /data/qingfu.wen/models/Wan2.1-T2V-1.3B-Diffusers/scheduler. avail mem: 78.98 GB
[04-24 17:52:00] Loaded scheduler: UniPCMultistepScheduler (sgl-diffusion version). model size: NA GB, consumed GPU mem: 0.00 GB, avail GPU mem: 78.98 GB
Loading required modules: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:32<00:00,  6.51s/it]
[04-24 17:52:00] Creating pipeline stages...
[04-24 17:52:00] Using FlashAttention (FA3) backend on MUSA
[04-24 17:52:00] Pipeline instantiated
[04-24 17:52:02] LayerwiseOffloadManager initialized with num prefetched layer: 1, total num layers: 30
[04-24 17:52:02] Enabled layerwise offload for WanTransformer3DModel on modules: ['blocks']
[04-24 17:52:02] Worker 0: Initialized device, model, and distributed environment.
[04-24 17:52:02] Worker 0: Scheduler loop started.
[04-24 17:52:02] Diffusers version: 0.33.0.dev0
[04-24 17:52:02] Sequence dimension shard is enabled, disabling frame adjustment for better performance
[04-24 17:52:02] Adjusting number of frames from 81 to 81 based on model
[04-24 17:52:02] Processing prompt 1/1: <redacted, len=536>
[04-24 17:52:02] Sampling params:
                       width: 832
                      height: 480
                  num_frames: 81
                         fps: 16
                      prompt: <redacted, len=536>
                  neg_prompt: <redacted, len=392>
                        seed: 42
                 infer_steps: 2
      num_outputs_per_prompt: 1
              guidance_scale: 3.0
     embedded_guidance_scale: 6.0
                    n_tokens: None
                  flow_shift: 3.0
                  image_path: None
                 save_output: True
            output_file_path: outputs/Drone_view_of_waves_crashing_against_the_rugged_cliffs_along_Big_Sur_s_garay_point_beach.The_crashin_20260424-175202_95131e8c.mp4
        
[04-24 17:52:02] Running pipeline stages: ['InputValidationStage', 'TextEncodingStage', 'LatentPreparationStage', 'TimestepPreparationStage', 'DenoisingStage', 'DecodingStage']
[04-24 17:52:02] Profiling request: None for 5 steps...
[04-24 17:52:02] Starting Profiler...
[04-24 17:52:02] [InputValidationStage] started...
[04-24 17:52:02] [InputValidationStage] finished in 0.0001 seconds
[04-24 17:52:02] [TextEncodingStage] started...
[04-24 17:52:13] [TextEncodingStage] finished in 10.6047 seconds
[04-24 17:52:13] [LatentPreparationStage] started...
[04-24 17:52:13] [LatentPreparationStage] finished in 0.0044 seconds
[04-24 17:52:13] [TimestepPreparationStage] started...
[04-24 17:52:13] [TimestepPreparationStage] finished in 0.0004 seconds
[04-24 17:52:13] [DenoisingStage] started...
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:05<00:00,  2.66s/it]
[04-24 17:52:18] [DenoisingStage] average time per step: 2.6652 seconds
[04-24 17:52:18] [DenoisingStage] finished in 5.3347 seconds
[04-24 17:52:18] [DecodingStage] started...
[04-24 17:52:19] /home/pytorch/torch/amp/autocast_mode.py:332: UserWarning: In musa autocast, but the target dtype torch.float32 is not supported. Disabling autocast.
 musa Autocast only supports dtypes of torch.float16, torch.bfloat16 currently.
  warnings.warn(error_message)

[04-24 17:52:25] [DecodingStage] finished in 7.0761 seconds
[04-24 17:52:25] Stopping Profiler...
[04-24 17:52:39] Saved profiler traces to: /data/qingfu.wen/bak/sglang/python/logs/profile_trace-5_steps-global-rank0.trace.json.gz
[04-24 17:52:40] Output saved to outputs/Drone_view_of_waves_crashing_against_the_rugged_cliffs_along_Big_Sur_s_garay_point_beach.The_crashin_20260424-175202_95131e8c.mp4
[04-24 17:52:40] Pixel data generated successfully in 38.05 seconds
[04-24 17:52:40] Completed batch processing. Generated 1 outputs in 38.05 seconds
[04-24 17:52:40] Generator was garbage collected without being shut down. Attempting to shut down the local server and client.
[04-24 17:52:41] Worker 0: Shutdown complete.
```
## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
