### PR TITLE
[diffusion] model: Fix FLUX.1/2 graph breaks

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/linear.py
+++ b/python/sglang/multimodal_gen/runtime/layers/linear.py
@@ -41,6 +41,7 @@ from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
 logger = init_logger(__name__)
 
+IS_AMP_SUPPORTED = current_platform.is_amp_supported()
 WEIGHT_LOADER_V2_SUPPORTED = [
     "CompressedTensorsLinearMethod",
     "AWQMarlinLinearMethod",
@@ -156,7 +157,7 @@ class UnquantizedLinearMethod(LinearMethodBase):
     ) -> torch.Tensor:
         output = (
             F.linear(x, layer.weight, bias)
-            if current_platform.is_amp_supported() or bias is None
+            if IS_AMP_SUPPORTED or bias is None
             else F.linear(x, layer.weight, bias.to(x.dtype))
         )  # NOTE: explicit dtype cast for bias is needed on platforms where amp isn't supported
         return output

--- a/python/sglang/multimodal_gen/runtime/layers/rotary_embedding/utils.py
+++ b/python/sglang/multimodal_gen/runtime/layers/rotary_embedding/utils.py
@@ -1,6 +1,5 @@
 """Primitive RoPE ops: rotate helpers and apply_rotary_emb utilities."""
 
-import logging
 from typing import Optional, Tuple
 
 import torch

--- a/python/sglang/multimodal_gen/runtime/layers/rotary_embedding/utils.py
+++ b/python/sglang/multimodal_gen/runtime/layers/rotary_embedding/utils.py
@@ -8,9 +8,10 @@ import torch
 from sglang.jit_kernel.diffusion.triton.rotary import apply_rotary_embedding
 from sglang.kernel_api_logging import debug_kernel_api
 from sglang.multimodal_gen.runtime.platforms import current_platform
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.srt.utils.custom_op import register_custom_op_from_extern
 
-logger = logging.getLogger(__name__)
+logger = init_logger(__name__)
 
 _is_cuda = current_platform.is_cuda()
 if _is_cuda:
@@ -149,6 +150,6 @@ def _warn_about_missing_flashinfer():
     Function to warn about the missing FlashInfer.
     Exists to not cause a graph break during the compilation.
     """
-    logger.info_once(
+    logger.warning_once(
         "FlashInfer not available, using Triton fallback for RoPE",
     )

--- a/python/sglang/multimodal_gen/runtime/layers/rotary_embedding/utils.py
+++ b/python/sglang/multimodal_gen/runtime/layers/rotary_embedding/utils.py
@@ -97,7 +97,7 @@ def apply_flashinfer_rope_qk_inplace(
     if flashinfer_apply_rope_inplace is None:
         # Triton fallback for AMD/ROCm where FlashInfer is not available
 
-        _maybe_warn_about_missing_flashinfer()
+        _warn_about_missing_flashinfer()
 
         half_size = cos_sin_cache.shape[-1] // 2
         if positions is None:
@@ -144,7 +144,11 @@ def apply_flashinfer_rope_qk_inplace(
 
 
 @torch.compiler.assume_constant_result
-def _maybe_warn_about_missing_flashinfer():
+def _warn_about_missing_flashinfer():
+    """
+    Function to warn about the missing FlashInfer.
+    Exists to not cause a graph break during the compilation.
+    """
     logger.info_once(
         "FlashInfer not available, using Triton fallback for RoPE",
     )

--- a/python/sglang/multimodal_gen/runtime/layers/rotary_embedding/utils.py
+++ b/python/sglang/multimodal_gen/runtime/layers/rotary_embedding/utils.py
@@ -3,11 +3,14 @@
 from typing import Optional, Tuple
 
 import torch
+import logging
 
 from sglang.jit_kernel.diffusion.triton.rotary import apply_rotary_embedding
 from sglang.kernel_api_logging import debug_kernel_api
 from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.srt.utils.custom_op import register_custom_op_from_extern
+
+logger = logging.getLogger(__name__)
 
 _is_cuda = current_platform.is_cuda()
 if _is_cuda:
@@ -142,10 +145,7 @@ def apply_flashinfer_rope_qk_inplace(
 
 @torch.compiler.assume_constant_result
 def _maybe_warn_about_missing_flashinfer():
-    import warnings
-
-    warnings.warn(
+    logger.info_once(
         "FlashInfer not available, using Triton fallback for RoPE",
-        stacklevel=2,
     )
-    return None
+

--- a/python/sglang/multimodal_gen/runtime/layers/rotary_embedding/utils.py
+++ b/python/sglang/multimodal_gen/runtime/layers/rotary_embedding/utils.py
@@ -93,12 +93,9 @@ def apply_flashinfer_rope_qk_inplace(
 
     if flashinfer_apply_rope_inplace is None:
         # Triton fallback for AMD/ROCm where FlashInfer is not available
-        import warnings
 
-        warnings.warn(
-            "FlashInfer not available, using Triton fallback for RoPE",
-            stacklevel=2,
-        )
+        _maybe_warn_about_missing_flashinfer()
+
         half_size = cos_sin_cache.shape[-1] // 2
         if positions is None:
             cos = cos_sin_cache[:seqlen, :half_size].to(q.dtype)
@@ -141,3 +138,14 @@ def apply_flashinfer_rope_qk_inplace(
         is_neox=is_neox,
     )
     return q_flat.view(bsz, seqlen, nheads, d), k_flat.view(bsz, seqlen, nheads, d)
+
+
+@torch.compiler.assume_constant_result
+def _maybe_warn_about_missing_flashinfer():
+    import warnings
+
+    warnings.warn(
+        "FlashInfer not available, using Triton fallback for RoPE",
+        stacklevel=2,
+    )
+    return None

--- a/python/sglang/multimodal_gen/runtime/layers/rotary_embedding/utils.py
+++ b/python/sglang/multimodal_gen/runtime/layers/rotary_embedding/utils.py
@@ -1,9 +1,9 @@
 """Primitive RoPE ops: rotate helpers and apply_rotary_emb utilities."""
 
+import logging
 from typing import Optional, Tuple
 
 import torch
-import logging
 
 from sglang.jit_kernel.diffusion.triton.rotary import apply_rotary_embedding
 from sglang.kernel_api_logging import debug_kernel_api
@@ -152,4 +152,3 @@ def _warn_about_missing_flashinfer():
     logger.info_once(
         "FlashInfer not available, using Triton fallback for RoPE",
     )
-


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Currently two graph breaks significantly reduce the performance of at least FLUX.1 and also somewhat FLUX.2. Other models might be affected as well, but are not tested. This PR fixes the the two graph breaks without changing the model behavior.

## Modifications

<!-- Detail the changes made in this pull request. -->
1. In case where FlashInfer is not installed (Non-NV HW at least), a warning caused a critical graph break. This log is separated to a torch.compile compatible function.
2. `current_platform.is_amp_supported()` check itself causes a graph break due to the `lru_cache`. Rather than checking this during compile, it's now checked at startup.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

### FLUX.1-dev:

**Baseline vs AMP support change:**
| Metric | Baseline | New | Diff | Status |
| :--- | :--- | :--- | :--- | :--- |
| **E2E Latency** | 1445.12 ms | 1332.11 ms | **-113.01 ms (-7.8%)** | ✅ |
| **Throughput** | 0.69 req/s | 0.75 req/s | - | - |

| Stage Name | Baseline (ms) | New (ms) | Diff (ms) | Diff (%) | Status |
| :--- | :--- | :--- | :--- | :--- | :--- |
| InputValidationStage | 0.02 | 0.03 | +0.01 | +30.2% | ⚪️ |
| TextEncodingStage | 16.74 | 18.96 | +2.22 | +13.3% | ⚪️ |
| TimestepPreparationStage | 0.30 | 0.34 | +0.05 | +15.2% | ⚪️ |
| LatentPreparationStage | 0.09 | 0.11 | +0.03 | +30.8% | ⚪️ |
| DenoisingStage | 1420.71 | 1304.79 | -115.92 | -8.2% | ⚪️ |
| DecodingStage | 4.90 | 6.06 | +1.16 | +23.6% | ⚪️ |

**Baseline vs AMP support change + FlashInfer logging fix**:



| Metric | Baseline | New | Diff | Status |
| :--- | :--- | :--- | :--- | :--- |
| **E2E Latency** | 1445.12 ms | 829.41 ms | **-615.71 ms (-42.6%)** | ✅ |
| **Throughput** | 0.69 req/s | 1.21 req/s | - | - |


| Stage Name | Baseline (ms) | New (ms) | Diff (ms) | Diff (%) | Status |
| :--- | :--- | :--- | :--- | :--- | :--- |
| InputValidationStage | 0.02 | 0.05 | +0.02 | +87.0% | ⚪️ |
| TextEncodingStage | 16.74 | 16.70 | -0.04 | -0.3% | ⚪️ |
| TimestepPreparationStage | 0.30 | 0.31 | +0.01 | +3.4% | ⚪️ |
| LatentPreparationStage | 0.09 | 0.09 | +0.00 | +1.4% | ⚪️ |
| DenoisingStage | 1420.71 | 803.94 | -616.77 | -43.4% | 🟢 |
| DecodingStage | 4.90 | 4.95 | +0.05 | +0.9% | ⚪️ |


**Baseline output:**
<img width="1024" height="1024" alt="A_small_cat_20260424-103926_a8303df9_0" src="https://github.com/user-attachments/assets/66673d47-a092-4167-9f4f-54a566190a7a" />


**Output after fixes:**
<img width="1024" height="1024" alt="A_small_cat_20260424-104035_9f6e19dc_1" src="https://github.com/user-attachments/assets/7ceab0fa-b975-4a23-9494-ce92121e22f5" />

**Run command:**
```
SGLANG_USE_ROCM_VAE=1 sglang generate --model-path black-forest-labs/FLUX.1-dev --height 1024 --width 1024 --ulysses-degree 8 --ring-degree 1 --num-gpus 8 --num-inference-steps 25 --guidance-scale 0.0 --prompt "A small cat" --dit-cpu-offload False --dit-layerwise-offload False --text-encoder-cpu-offload False --image-encoder-cpu-offload False --vae-cpu-offload False --warmup True --warmup-steps 2 --vae-precision bf16  --seed 42 --enable-torch-compile
```


### FLUX.2-dev

**Baseline vs AMP support change:**
| Metric | Baseline | New | Diff | Status |
| :--- | :--- | :--- | :--- | :--- |
| **E2E Latency** | 5293.63 ms | 5307.02 ms | **+13.39 ms (+0.3%)** | ⚪️ |
| **Throughput** | 0.19 req/s | 0.19 req/s | - | - |

| Stage Name | Baseline (ms) | New (ms) | Diff (ms) | Diff (%) | Status |
| :--- | :--- | :--- | :--- | :--- | :--- |
| InputValidationStage | 15.06 | 15.10 | +0.04 | +0.3% | ⚪️ |
| TextEncodingStage | 17.61 | 17.59 | -0.02 | -0.1% | ⚪️ |
| ImageVAEEncodingStage | 105.57 | 91.63 | -13.95 | -13.2% | ⚪️ |
| LatentPreparationStage | 0.18 | 0.20 | +0.02 | +10.4% | ⚪️ |
| TimestepPreparationStage | 0.26 | 0.33 | +0.07 | +27.2% | ⚪️ |
| DenoisingStage | 5128.56 | 5133.03 | +4.47 | +0.1% | ⚪️ |
| DecodingStage | 5.41 | 5.23 | -0.18 | -3.3% | ⚪️ |


**Baseline vs AMP support change + FlashInfer logging fix:**
| Metric | Baseline | New | Diff | Status |
| :--- | :--- | :--- | :--- | :--- |
| **E2E Latency** | 5293.63 ms | 5127.07 ms | **-166.55 ms (-3.1%)** | ✅ |
| **Throughput** | 0.19 req/s | 0.20 req/s | - | - |

| Stage Name | Baseline (ms) | New (ms) | Diff (ms) | Diff (%) | Status |
| :--- | :--- | :--- | :--- | :--- | :--- |
| InputValidationStage | 15.06 | 15.02 | -0.04 | -0.3% | ⚪️ |
| TextEncodingStage | 17.61 | 18.93 | +1.32 | +7.5% | ⚪️ |
| ImageVAEEncodingStage | 105.57 | 26.06 | -79.51 | -75.3% | ⚪️ |
| LatentPreparationStage | 0.18 | 0.23 | +0.05 | +29.4% | ⚪️ |
| TimestepPreparationStage | 0.26 | 0.30 | +0.03 | +13.1% | ⚪️ |
| DenoisingStage | 5128.56 | 5042.30 | -86.26 | -1.7% | ⚪️ |
| DecodingStage | 5.41 | 4.77 | -0.64 | -11.8% | ⚪️ |

**Baseline output:**
<img width="1024" height="1024" alt="Add_a_cool_hat_to_the_cat_20260424-102535_6658450c_0" src="https://github.com/user-attachments/assets/6adea9b7-d87d-421c-93e9-3f8a02a37c02" />

**Output after fixes:**
<img width="1024" height="1024" alt="Add_a_cool_hat_to_the_cat_20260424-103140_efeb46e2_2" src="https://github.com/user-attachments/assets/72bde810-509b-4136-afa9-128402636f02" />

**Run command:**
```
SGLANG_USE_ROCM_VAE=1 sglang generate --model-path black-forest-labs/FLUX.2-dev --height 1024 --width 1024 --ulysses-degree 8 --ring-degree 1 --num-gpus 8 --num-inference-steps 50 --guidance-scale 4.0 --prompt "Add a cool hat to the cat" --dit-cpu-offload False --dit-layerwise-offload False --text-encoder-cpu-offload False --image-encoder-cpu-offload False --vae-cpu-offload False --warmup True --warmup-steps 2 --vae-precision bf16 --seed 42 --image-path /app/data/flux_cat.png --enable-torch-compile
```


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
3. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
4. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
5. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
