### PR TITLE
[MUSA][20/N] Support qwen series models

### DIFF
--- a/3rdparty/amd/wheel/sglang/pyproject.toml
+++ b/3rdparty/amd/wheel/sglang/pyproject.toml
@@ -123,7 +123,7 @@ srt_musa = [
   "sglang[runtime_common]",
   "torch",
   "torch_musa",
-  "torchada>=0.1.50",
+  "torchada>=0.1.53",
   "mthreads-ml-py",
   "mate>=0.2.0",
   "deep-gemm>=0.1.3",

--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -115,7 +115,7 @@ srt_musa = [
   "sglang[runtime_common]",
   "torch",
   "torch_musa",
-  "torchada>=0.1.50",
+  "torchada>=0.1.53",
   "mthreads-ml-py",
   "mate>=0.2.0",
   "deep-gemm>=0.1.3",

--- a/python/sglang/srt/hardware_backend/musa/attention/flashattention_backend.py
+++ b/python/sglang/srt/hardware_backend/musa/attention/flashattention_backend.py
@@ -15,6 +15,7 @@ from sglang.srt.hardware_backend.musa.layers.utils.cp_utils import (
 )
 from sglang.srt.layers.attention.flashattention_backend import (
     FlashAttentionBackend,
+    FlashAttentionMultiStepBackend,
     merge_state_v2_wrapper,
 )
 from sglang.srt.layers.radix_attention import AttentionType
@@ -235,17 +236,6 @@ class MusaFlashAttentionBackend(FlashAttentionBackend):
         self._current_max_seqlen_k = max_seqlen_k
         self._current_can_run_tbo = can_run_tbo
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
-        super().init_forward_metadata(forward_batch)
-        metadata = self.forward_metadata
-        if not hasattr(metadata, "extend_with_prefix"):
-            metadata.extend_with_prefix = False
-
-        if forward_batch.forward_mode.is_extend_or_draft_extend_or_mixed(
-            include_draft_extend_v2=True
-        ):
-            metadata.extend_with_prefix = any(forward_batch.extend_prefix_lens_cpu)
-
     def forward_extend(
         self,
         q: torch.Tensor,
@@ -420,7 +410,10 @@ class MusaFlashAttentionBackend(FlashAttentionBackend):
                     _fa_cp_attn,
                 )
             elif (
-                metadata.extend_with_prefix
+                (
+                    forward_batch.extend_prefix_lens_cpu is not None
+                    and any(forward_batch.extend_prefix_lens_cpu)
+                )
                 or forward_batch.forward_mode.is_target_verify()
                 or forward_batch.forward_mode.is_draft_extend()
             ):
@@ -918,3 +911,28 @@ class MusaFlashAttentionBackend(FlashAttentionBackend):
                 o = result
 
         return o.view(-1, layer.tp_q_head_num * layer.v_head_dim)
+
+
+class MusaFlashAttentionMultiStepBackend(FlashAttentionMultiStepBackend):
+
+    def __init__(
+        self,
+        model_runner: ModelRunner,
+        topk: int,
+        speculative_num_steps: int,
+        fa_impl_ver: int = 3,
+    ):
+        self.model_runner = model_runner
+        self.topk = topk
+        self.speculative_num_steps = speculative_num_steps
+        self.attn_backends = []
+        for i in range(self.speculative_num_steps - 1):
+            self.attn_backends.append(
+                MusaFlashAttentionBackend(
+                    model_runner,
+                    speculative_step_id=i,
+                    topk=self.topk,
+                    speculative_num_steps=self.speculative_num_steps,
+                    fa_impl_ver=fa_impl_ver,
+                )
+            )

--- a/python/sglang/srt/hardware_backend/musa/kernels/topk.py
+++ b/python/sglang/srt/hardware_backend/musa/kernels/topk.py
@@ -1,0 +1,300 @@
+from typing import (
+    Optional,
+)
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def tanh(x):
+    # Tanh is just a scaled sigmoid
+    return 2 * tl.sigmoid(2 * x) - 1
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=1, num_stages=1),
+        triton.Config({}, num_warps=1, num_stages=2),
+        triton.Config({}, num_warps=2, num_stages=1),
+        triton.Config({}, num_warps=2, num_stages=2),
+        triton.Config({}, num_warps=4, num_stages=1),
+        triton.Config({}, num_warps=4, num_stages=2),
+        triton.Config({}, num_warps=4, num_stages=3),
+        triton.Config({}, num_warps=8, num_stages=1),
+        triton.Config({}, num_warps=8, num_stages=2),
+        triton.Config({}, num_warps=8, num_stages=3),
+        triton.Config({}, num_warps=16, num_stages=1),
+        triton.Config({}, num_warps=16, num_stages=2),
+        triton.Config({}, num_warps=16, num_stages=3),
+        triton.Config({}, num_warps=32, num_stages=1),
+        triton.Config({}, num_warps=32, num_stages=2),
+    ],
+    key=["num_tokens", "num_experts", "has_correction_bias"],
+)
+@triton.jit
+def topk_softmax_triton_kernel(
+    gating_output_ptr,
+    selected_expert_ptr,
+    moe_weights_ptr,
+    renormalize_flag,
+    num_experts,
+    num_tokens,  # for autotune key
+    moe_softcapping,
+    correction_bias_ptr,
+    has_correction_bias: tl.constexpr,
+    K: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    BLOCK_WIDTH_SIZE_UP: tl.constexpr,
+):
+    curr_row_idx = tl.program_id(0)
+
+    FLOAT_MINIMUM = -10000.0
+    LOG2E = 1.4426950408889634
+
+    weights_local_final = tl.zeros((BLOCK_K,), dtype=tl.float32)
+    selected_local_final = tl.zeros((BLOCK_K,), dtype=tl.int32)
+
+    offset = tl.arange(0, BLOCK_WIDTH_SIZE_UP)
+    k_offset = tl.arange(0, BLOCK_K)
+    mask_expert = offset < num_experts
+    mask_topk = k_offset < K
+
+    row_offset = curr_row_idx * num_experts
+
+    logits = tl.load(
+        gating_output_ptr + row_offset + offset, mask=mask_expert, other=FLOAT_MINIMUM
+    )
+    logits = tl.cast(logits, tl.float32)
+
+    if has_correction_bias:
+        bias = tl.load(correction_bias_ptr + offset, mask=mask_expert, other=0.0)
+        logits = logits + bias
+
+    if moe_softcapping > 0.0:
+        logits = moe_softcapping * tanh(logits / moe_softcapping)
+
+    row_max = tl.max(logits, axis=0)
+    probs = tl.exp2((logits - row_max) * LOG2E)
+    row_sum = tl.sum(probs, axis=0)
+    inv_row_sum = 1.0 / row_sum
+    probs = probs * inv_row_sum
+    probs = tl.where(mask_expert, probs, FLOAT_MINIMUM)
+
+    weights_selected_sum = 0.0
+    for k_idx in range(K):
+        top_k_index = tl.argmax(probs, axis=0)
+        mask = offset == top_k_index
+        top_k_value = tl.sum(tl.where(mask, probs, 0.0))
+
+        weights_local_final = tl.where(
+            k_offset == k_idx, top_k_value, weights_local_final
+        )
+        selected_local_final = tl.where(
+            k_offset == k_idx, top_k_index, selected_local_final
+        )
+        weights_selected_sum += top_k_value
+
+        probs = tl.where(offset == top_k_index, FLOAT_MINIMUM, probs)
+
+    if renormalize_flag:
+        weights_local_final = weights_local_final / weights_selected_sum
+
+    tl.store(
+        moe_weights_ptr + curr_row_idx * K + k_offset,
+        weights_local_final,
+        mask=mask_topk,
+    )
+    tl.store(
+        selected_expert_ptr + curr_row_idx * K + k_offset,
+        selected_local_final,
+        mask=mask_topk,
+    )
+
+
+def topk_softmax(
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    gating_output: torch.Tensor,
+    renormalize: bool = False,
+    moe_softcapping: float = 0.0,
+    correction_bias: Optional[torch.Tensor] = None,
+) -> None:
+    """
+    Compute top-k softmax for MoE routing.
+
+    Args:
+        topk_weights: Output tensor for top-k weights [num_tokens, topk]
+        topk_ids: Output tensor for top-k expert indices [num_tokens, topk]
+        gating_output: Gating logits [num_tokens, num_experts]
+        renormalize: Whether to renormalize the top-k weights
+        moe_softcapping: Tanh softcapping value (0.0 to disable)
+        correction_bias: Per-expert bias correction [num_experts], must be float32 if provided
+    """
+
+    num_tokens, num_experts = gating_output.shape
+    topk = topk_weights.shape[-1]
+    has_correction_bias = correction_bias is not None
+
+    block_width_up = triton.next_power_of_2(num_experts)
+    grid = (num_tokens,)
+
+    topk_softmax_triton_kernel[grid](
+        gating_output,
+        topk_ids,
+        topk_weights,
+        renormalize,
+        num_experts,
+        num_tokens,
+        moe_softcapping,
+        correction_bias,
+        has_correction_bias,
+        K=topk,
+        BLOCK_K=triton.next_power_of_2(topk),
+        BLOCK_WIDTH_SIZE_UP=block_width_up,
+    )
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=1, num_stages=1),
+        triton.Config({}, num_warps=1, num_stages=2),
+        triton.Config({}, num_warps=2, num_stages=1),
+        triton.Config({}, num_warps=2, num_stages=2),
+        triton.Config({}, num_warps=4, num_stages=1),
+        triton.Config({}, num_warps=4, num_stages=2),
+        triton.Config({}, num_warps=4, num_stages=3),
+        triton.Config({}, num_warps=8, num_stages=1),
+        triton.Config({}, num_warps=8, num_stages=2),
+        triton.Config({}, num_warps=8, num_stages=3),
+        triton.Config({}, num_warps=16, num_stages=1),
+        triton.Config({}, num_warps=16, num_stages=2),
+        triton.Config({}, num_warps=16, num_stages=3),
+        triton.Config({}, num_warps=32, num_stages=1),
+        triton.Config({}, num_warps=32, num_stages=2),
+    ],
+    key=["num_tokens", "num_experts"],
+)
+@triton.jit
+def topk_sigmoid_triton_kernel(
+    gating_output_ptr,
+    selected_expert_ptr,
+    moe_weights_ptr,
+    renormalize_flag,
+    correction_bias_ptr,
+    has_correction_bias: tl.constexpr,
+    num_experts,
+    num_tokens,  # for autotune key
+    K: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    BLOCK_WIDTH_SIZE_UP: tl.constexpr,
+):
+    curr_row_idx = tl.program_id(0)
+
+    FLOAT_MINIMUM = -10000.0
+    LOG2E = 1.4426950408889634
+
+    weights_local_final = tl.zeros((BLOCK_K,), dtype=tl.float32)
+    selected_local_final = tl.zeros((BLOCK_K,), dtype=tl.int32)
+
+    offset = tl.arange(0, BLOCK_WIDTH_SIZE_UP)
+    k_offset = tl.arange(0, BLOCK_K)
+    mask_expert = offset < num_experts
+    mask_topk = k_offset < K
+
+    row_offset = curr_row_idx * num_experts
+
+    x = tl.load(
+        gating_output_ptr + row_offset + offset, mask=mask_expert, other=FLOAT_MINIMUM
+    )
+    x = tl.cast(x, tl.float32)
+
+    # Compute sigmoid(x)
+    is_positive = x >= 0
+    neg_x = tl.where(is_positive, -x, x)
+    exp_neg_x = tl.exp2(neg_x * LOG2E)
+    probs = tl.where(
+        is_positive,
+        1.0 / (1.0 + exp_neg_x),
+        exp_neg_x / (1.0 + exp_neg_x),
+    )
+
+    if has_correction_bias:
+        bias = tl.load(correction_bias_ptr + offset, mask=mask_expert, other=0.0)
+        probs_for_choice = probs + bias
+    else:
+        probs_for_choice = probs
+
+    probs_for_choice = tl.where(mask_expert, probs_for_choice, FLOAT_MINIMUM)
+
+    weights_selected_sum = 0.0
+    for k_idx in range(K):
+        top_k_index = tl.argmax(probs_for_choice, axis=0)
+        mask = offset == top_k_index
+        top_k_value = tl.sum(tl.where(mask, probs, 0.0))
+
+        weights_local_final = tl.where(
+            k_offset == k_idx, top_k_value, weights_local_final
+        )
+        selected_local_final = tl.where(
+            k_offset == k_idx, top_k_index, selected_local_final
+        )
+        weights_selected_sum += top_k_value
+
+        probs_for_choice = tl.where(
+            offset == top_k_index, FLOAT_MINIMUM, probs_for_choice
+        )
+
+    if renormalize_flag:
+        weights_local_final = weights_local_final / weights_selected_sum
+
+    tl.store(
+        moe_weights_ptr + curr_row_idx * K + k_offset,
+        weights_local_final,
+        mask=mask_topk,
+    )
+    tl.store(
+        selected_expert_ptr + curr_row_idx * K + k_offset,
+        selected_local_final,
+        mask=mask_topk,
+    )
+
+
+def topk_sigmoid(
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    gating_output: torch.Tensor,
+    renormalize: bool = False,
+    correction_bias: Optional[torch.Tensor] = None,
+) -> None:
+    """
+    Compute top-k sigmoid for MoE routing.
+
+    Args:
+        topk_weights: Output tensor for top-k weights [num_tokens, topk]
+        topk_ids: Output tensor for top-k expert indices [num_tokens, topk]
+        gating_output: Gating logits [num_tokens, num_experts]
+        renormalize: Whether to renormalize the top-k weights
+        correction_bias: Per-expert bias correction [num_experts], must be float32 if provided
+    """
+    num_tokens, num_experts = gating_output.shape
+    topk = topk_weights.shape[-1]
+    has_correction_bias = correction_bias is not None
+
+    block_width_up = triton.next_power_of_2(num_experts)
+    grid = (num_tokens,)
+
+    topk_sigmoid_triton_kernel[grid](
+        gating_output,
+        topk_ids,
+        topk_weights,
+        renormalize,
+        correction_bias,
+        has_correction_bias,
+        num_experts,
+        num_tokens,
+        K=topk,
+        BLOCK_K=triton.next_power_of_2(topk),
+        BLOCK_WIDTH_SIZE_UP=block_width_up,
+    )

--- a/python/sglang/srt/layers/attention/vision.py
+++ b/python/sglang/srt/layers/attention/vision.py
@@ -21,6 +21,7 @@ from sglang.srt.utils import (
     is_blackwell_supported,
     is_cuda,
     is_hip,
+    is_musa,
     is_npu,
     is_xpu,
     print_info_once,
@@ -31,6 +32,7 @@ from sglang.srt.utils.multi_stream_utils import (
 )
 
 _is_cuda = is_cuda()
+_is_musa = is_musa()
 _is_npu = is_npu()
 _is_hip = is_hip()
 _is_xpu = is_xpu()
@@ -41,6 +43,9 @@ if _is_cuda:
     from sglang.jit_kernel.flash_attention import (
         flash_attn_varlen_func,
     )
+
+if _is_musa:
+    from flash_attn_interface import flash_attn_varlen_func
 
 if _is_npu:
     import torch_npu
@@ -381,8 +386,8 @@ class VisionFlash3Attention(nn.Module):
         self,
         **kwargs,
     ):
-        if not _is_cuda:
-            raise Exception("VisionFlash3Attention is only available for cuda")
+        if not (_is_cuda or _is_musa):
+            raise Exception("VisionFlash3Attention is only available for cuda or musa")
         super().__init__()
         use_data_parallel = (
             kwargs["use_data_parallel"] if "use_data_parallel" in kwargs else False
@@ -917,6 +922,11 @@ class VisionAttention(nn.Module):
                 backend = "fa3"
             elif major == 10:
                 backend = "fa4"
+            else:
+                backend = "triton_attn"
+        elif _is_musa:
+            if get_device_capability() >= (3, 1):
+                backend = "fa3"
             else:
                 backend = "triton_attn"
         elif _is_hip:

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -83,7 +83,7 @@ _is_xpu = is_xpu()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 _is_musa = is_musa()
 
-if _is_cuda or _is_musa:
+if _is_cuda:
     from sgl_kernel import moe_fused_gate
 
     try:
@@ -126,7 +126,7 @@ if _is_cuda or _is_musa:
     except ImportError as e:
         pass
 
-if _is_cuda or _is_hip or _is_xpu or _is_musa:
+if _is_cuda or _is_hip or _is_xpu:
     from sgl_kernel import topk_softmax
 
     try:
@@ -139,6 +139,13 @@ if _use_aiter:
         from aiter.fused_moe import fused_topk as aiter_fused_topk
     except ImportError:
         raise ImportError("aiter is required when SGLANG_USE_AITER is set to True")
+if _is_musa:
+    try:
+        from mate import moe_fused_gate
+    except ImportError as e:
+        raise ImportError("mate is required for the biased grouped topk.")
+
+    from sglang.srt.hardware_backend.musa.kernels.topk import topk_sigmoid, topk_softmax
 
 # -------------------------------- TopKConfig ---------------------------------------
 
@@ -864,7 +871,7 @@ def biased_grouped_topk_gpu(
         return topk_weights, topk_ids
 
     elif (
-        (_is_cuda or _is_musa)
+        _is_cuda
         # moe_fused_gate kernel ensures that num_experts/num_expert_group does not exceed MAX_VPT=32 now. And when kernel can handle MAX_VPT > 32, we can remove this assertion.
         and experts_per_group <= 32
         and is_power_of_two(num_experts)
@@ -902,6 +909,21 @@ def biased_grouped_topk_gpu(
             routed_scaling_factor if routed_scaling_factor is not None else 1.0,
         )
         return topk_weights, topk_ids
+    elif _is_musa and (
+        gating_output.shape[1] // num_expert_group <= 32
+        or (num_expert_group == 1 and gating_output.shape[1] in {160, 256, 384})
+    ):
+        topk_weights, topk_ids = moe_fused_gate(
+            gating_output.to(dtype=torch.float32),
+            correction_bias,
+            num_expert_group,
+            topk_group,
+            topk,
+            num_fused_shared_experts,
+            routed_scaling_factor if routed_scaling_factor is not None else 1.0,
+            True,
+            apply_routed_scaling_factor_on_output,
+        )
     else:
         # Use optimized path for Kimi K2 (384 experts with num_expert_group=1)
         num_experts = gating_output.shape[1]

--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -1113,11 +1113,6 @@ def w8a8_block_fp8_matmul_deepgemm(
     # Deepgemm only supports output tensor type as bfloat16
     assert C.dtype == torch.bfloat16 and deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
 
-    if _is_musa:
-        # XXX (MUSA): `deep_gemm_fp8_fp8_bf16_nt` on MUSA requires contiguous tensors
-        As = As.contiguous()
-        Bs = Bs.contiguous()
-
     deep_gemm_fp8_fp8_bf16_nt(A, As, B, Bs, C)
 
     return C

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -675,13 +675,19 @@ def deepgemm_w8a8_block_fp8_linear_with_fallback(
     input_2d = input.view(-1, input.shape[-1])
     output_shape = [*input.shape[:-1], weight.shape[0]]
 
-    q_input, x_scale = sglang_per_token_group_quant_fp8(
-        input_2d,
-        block_size[1],
-        column_major_scales=True,
-        scale_tma_aligned=True,
-        scale_ue8m0=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
-    )
+    if not _is_musa:
+        q_input, x_scale = sglang_per_token_group_quant_fp8(
+            input_2d,
+            block_size[1],
+            column_major_scales=True,
+            scale_tma_aligned=True,
+            scale_ue8m0=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
+        )
+    else:
+        q_input, x_scale = sglang_per_token_group_quant_fp8(
+            input_2d,
+            block_size[1],
+        )
 
     output = w8a8_block_fp8_matmul_deepgemm(
         q_input, weight, x_scale, weight_scale, block_size, output_dtype=output_dtype

--- a/python/sglang/srt/layers/rotary_embedding/base.py
+++ b/python/sglang/srt/layers/rotary_embedding/base.py
@@ -99,7 +99,8 @@ class RotaryEmbedding(MultiPlatformOp):
 
         self._apply_rotary_emb_wrapped = apply_rotary_emb
 
-        if get_global_server_args().rl_on_policy_target is not None:
+        # XXX (MUSA): Implement sgl_kernel.rotary_embedding support for MUSA backend
+        if get_global_server_args().rl_on_policy_target is not None or _is_musa:
             self._forward_method = self.forward_native
             self._apply_rotary_emb_wrapped = torch.compile(dynamic=True)(
                 apply_rotary_emb

--- a/python/sglang/srt/layers/utils/multi_platform.py
+++ b/python/sglang/srt/layers/utils/multi_platform.py
@@ -98,10 +98,7 @@ class MultiPlatformOp(nn.Module):
         return self.forward_native(*args, **kwargs)
 
     def forward_musa(self, *args, **kwargs):
-        # XXX (MUSA): MUSA kernels follow the CUDA path by default.
-        # At this stage, sgl-kernel support for MUSA is still under active
-        # development, so we fall back to the PyTorch-native implementation.
-        return self.forward_native(*args, **kwargs)
+        return self.forward_cuda(*args, **kwargs)
 
     def forward_hpu(self, *args, **kwargs):
         return self.forward_native(*args, **kwargs)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2364,8 +2364,8 @@ class ServerArgs:
                 )
 
             assert (
-                is_cuda()
-            ), "Mamba extra_buffer is only supported on CUDA devices with FLA backend"
+                is_cuda() or is_musa()
+            ), "Mamba extra_buffer is only supported on CUDA and MUSA devices with FLA backend"
             if self.speculative_num_draft_tokens is not None:
                 assert (
                     self.mamba_track_interval >= self.speculative_num_draft_tokens

--- a/python/sglang/srt/speculative/dflash_utils.py
+++ b/python/sglang/srt/speculative/dflash_utils.py
@@ -8,7 +8,7 @@ import torch
 import torch.nn.functional as F
 
 from sglang.srt.layers.quantization.unquant import UnquantizedLinearMethod
-from sglang.srt.utils import is_cuda
+from sglang.srt.utils import is_cuda, is_musa
 
 DEFAULT_DFLASH_MASK_TOKEN = "<|MASK|>"
 
@@ -25,7 +25,7 @@ _DFLASH_VERIFY_SKIP_CUSTOM_MASK_BACKENDS = frozenset(
 )
 
 
-if is_cuda():
+if is_cuda() or is_musa():
     try:
         from sgl_kernel import (
             top_k_renorm_prob,

--- a/python/sglang/srt/speculative/draft_utils.py
+++ b/python/sglang/srt/speculative/draft_utils.py
@@ -1,7 +1,7 @@
 import logging
 
 from sglang.srt.server_args import ServerArgs, get_global_server_args
-from sglang.srt.utils.common import is_blackwell
+from sglang.srt.utils.common import is_blackwell, is_musa
 
 logger = logging.getLogger(__name__)
 
@@ -142,9 +142,14 @@ class DraftBackendFactory:
         )
 
     def _create_fa_decode_backend(self, fa_impl_ver: int = 3):
-        from sglang.srt.layers.attention.flashattention_backend import (
-            FlashAttentionMultiStepBackend,
-        )
+        if not is_musa():
+            from sglang.srt.layers.attention.flashattention_backend import (
+                FlashAttentionMultiStepBackend,
+            )
+        else:
+            from sglang.srt.hardware_backend.musa.attention.flashattention_backend import (
+                MusaFlashAttentionMultiStepBackend as FlashAttentionMultiStepBackend,
+            )
 
         return FlashAttentionMultiStepBackend(
             self.draft_model_runner,
@@ -225,10 +230,14 @@ class DraftBackendFactory:
         return AiterAttnBackend(self.draft_model_runner, skip_prefill=False)
 
     def _create_fa_prefill_backend(self, fa_impl_ver: int = 3):
-        from sglang.srt.layers.attention.flashattention_backend import (
-            FlashAttentionBackend,
-        )
-
+        if not is_musa():
+            from sglang.srt.layers.attention.flashattention_backend import (
+                FlashAttentionBackend,
+            )
+        else:
+            from sglang.srt.hardware_backend.musa.attention.flashattention_backend import (
+                MusaFlashAttentionBackend as FlashAttentionBackend,
+            )
         return FlashAttentionBackend(
             self.draft_model_runner, skip_prefill=False, fa_impl_ver=fa_impl_ver
         )

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -44,9 +44,9 @@ from sglang.srt.speculative.spec_utils import (
     get_src_tgt_cache_loc,
     get_target_cache_loc,
 )
-from sglang.srt.utils import is_cuda, next_power_of_2
+from sglang.srt.utils import is_cuda, is_musa, next_power_of_2
 
-if is_cuda():
+if is_cuda() or is_musa():
     from sgl_kernel import (
         top_k_renorm_prob,
         top_p_renorm_prob,

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -35,11 +35,12 @@ from sglang.srt.speculative.spec_utils import (
     SIMULATE_ACC_LEN,
     generate_simulated_accept_index,
 )
-from sglang.srt.utils.common import is_cuda, is_hip, is_npu, next_power_of_2
+from sglang.srt.utils.common import is_cuda, is_hip, is_musa, is_npu, next_power_of_2
 
 _is_cuda = is_cuda()
 _is_hip = is_hip()
 _is_npu = is_npu()
+_is_musa = is_musa()
 
 if TYPE_CHECKING:
     from sglang.srt.managers.tp_worker import TpModelWorker
@@ -48,7 +49,7 @@ if TYPE_CHECKING:
     )
     from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
 
-if is_cuda():
+if is_cuda() or is_musa():
     from sgl_kernel import (
         top_k_renorm_prob,
         top_p_renorm_prob,
@@ -539,7 +540,7 @@ def assign_extend_cache_locs_func(
     draft_token_num: int,
     device,
 ) -> torch.Tensor:
-    if _is_cuda or _is_hip:
+    if _is_cuda or _is_hip or _is_musa:
         out_cache_loc = torch.empty(
             (batch_size * draft_token_num,),
             dtype=torch.int64,

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -272,6 +272,7 @@ class EAGLEWorker(TpModelWorker):
         Device2DraftCudaGraphRunner = {
             "npu": EAGLEDraftNpuGraphRunner,
             "cuda": EAGLEDraftCudaGraphRunner,
+            "musa": EAGLEDraftCudaGraphRunner,
         }
         # Capture draft
         if self.speculative_num_steps > 1:

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -63,6 +63,7 @@ from sglang.srt.utils.common import (
     get_available_gpu_memory,
     is_cuda,
     is_hip,
+    is_musa,
     is_npu,
     next_power_of_2,
 )
@@ -70,6 +71,7 @@ from sglang.srt.utils.patch_torch import monkey_patch_torch_reductions
 
 _is_npu = is_npu()
 _is_cuda = is_cuda()
+_is_musa = is_musa()
 _is_hip = is_hip()
 
 logger = logging.getLogger(__name__)
@@ -265,6 +267,7 @@ class EagleDraftWorker(BaseDraftWorker):
         Device2DraftCudaGraphRunner = {
             "npu": EAGLEDraftNpuGraphRunner,
             "cuda": EAGLEDraftCudaGraphRunner,
+            "musa": EAGLEDraftCudaGraphRunner,
         }
         # Capture draft
         if self.speculative_num_steps > 1:
@@ -284,6 +287,7 @@ class EagleDraftWorker(BaseDraftWorker):
         Device2ExtendCudaGraphRunner = {
             "npu": EAGLEDraftExtendNpuGraphRunner,
             "cuda": EAGLEDraftExtendCudaGraphRunner,
+            "musa": EAGLEDraftCudaGraphRunner,
         }
         supports_hip_aiter_draft_extend_graph = False
         if _is_hip:
@@ -296,7 +300,7 @@ class EagleDraftWorker(BaseDraftWorker):
                 self.draft_attn_backend, AiterMultiStepDraftBackend
             )
 
-        supports_cuda_draft_extend_graph = _is_cuda and (
+        supports_cuda_draft_extend_graph = (_is_cuda or _is_musa) and (
             isinstance(self.draft_extend_attn_backend, TritonAttnBackend)
             or isinstance(self.draft_extend_attn_backend, TRTLLMMLABackend)
         )

--- a/python/sglang/srt/speculative/ngram_info.py
+++ b/python/sglang/srt/speculative/ngram_info.py
@@ -34,9 +34,9 @@ from sglang.srt.speculative.spec_utils import (
     get_src_tgt_cache_loc,
     get_target_cache_loc,
 )
-from sglang.srt.utils import is_cuda, is_hip, next_power_of_2
+from sglang.srt.utils import is_cuda, is_hip, is_musa, next_power_of_2
 
-if is_cuda():
+if is_cuda() or is_musa():
     from sgl_kernel import (
         top_k_renorm_prob,
         top_p_renorm_prob,

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -20,11 +20,12 @@ from sglang.srt.environ import envs
 from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.mem_cache.common import get_last_loc
 from sglang.srt.server_args import ServerArgs, get_global_server_args
-from sglang.srt.utils import is_cuda, is_hip, is_npu, next_power_of_2
+from sglang.srt.utils import is_cuda, is_hip, is_musa, is_npu, next_power_of_2
 
 _is_cuda = is_cuda()
 _is_hip = is_hip()
 _is_npu = is_npu()
+_is_musa = is_musa()
 
 if TYPE_CHECKING:
     from sglang.srt.speculative.eagle_info import EagleVerifyInput
@@ -46,7 +47,9 @@ SIMULATE_ACC_LEN = envs.SGLANG_SIMULATE_ACC_LEN.get()  # turn off if < 0
 SIMULATE_ACC_METHOD = envs.SGLANG_SIMULATE_ACC_METHOD.get()
 
 TREE_TRAVERSE_TIME_THRESHOLD = 1  # TODO: set this properly
-TREE_SPEC_KERNEL_AVAILABLE = _is_cuda  # This kernel is only available for CUDA now
+TREE_SPEC_KERNEL_AVAILABLE = (
+    _is_cuda or _is_musa
+)  # This kernel is only available for CUDA and MUSA now
 
 
 def spec_need_hidden_states(server_args: Optional[ServerArgs] = None) -> bool:

--- a/sgl-kernel/pyproject_musa.toml
+++ b/sgl-kernel/pyproject_musa.toml
@@ -3,7 +3,7 @@ requires = [
   "setuptools>=75.0",
   "scikit-build-core>=0.10",
   "torch",
-  "torchada>=0.1.50",
+  "torchada>=0.1.53",
   "wheel",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR is part of the MUSA (Moore Threads GPU) backend support series (19/N). The goal is to enable Qwen series models on the MUSA platform by:
1. Adding MUSA-specific MoE fused gate and top-k kernels.
2. Fixing compatibility issues in vision attention, FP8 quantization, and multi-platform dispatch for MUSA.

## Modifications

### 1. MUSA Top-K Kernels (New File)
- **`python/sglang/srt/hardware_backend/musa/kernels/topk.py`** (new)
  - Implemented `topk_softmax` and `topk_sigmoid` Triton kernels for MUSA
  - Support `correction_bias`, `renormalize`, and `moe_softcapping` parameters
  - Added Triton autotune configs for various token/expert shapes
### 2. MoE TopK Integration
- **`python/sglang/srt/layers/moe/topk.py`**
  - Removed MUSA from CUDA `moe_fused_gate` import guard; MUSA now uses `mate.moe_fused_gate`
  - Added MUSA-specific `topk_sigmoid` and `topk_softmax` imports from new backend kernel
  - Updated `biased_grouped_topk_gpu` to dispatch to MUSA fused gate path when on MUSA hardware
### 3. Vision Attention MUSA Support
- **`python/sglang/srt/layers/attention/vision.py`**
  - Added MUSA support for vision flash attention backend
### 4. FP8 Quantization Fixes
- **`python/sglang/srt/layers/quantization/fp8_kernel.py`**
- **`python/sglang/srt/layers/quantization/fp8_utils.py`**
  - Removed MUSA-specific workaround and skip unsupported options on MUSA
### 5. Multi-Platform Dispatch Fix
- **`python/sglang/srt/layers/utils/multi_platform.py`**
  - Changed `forward_musa` to forward through `forward_cuda` instead of falling back to `forward_native`
### 6. Speculative Decoding Updates
- Updated multiple speculative decoding files to support MUSA hardware


## Accuracy Tests

```
SGLANG_ENABLE_SPEC_V2=1 python3 -m sglang.launch_server \
    --model-path /mnt/seed17/001688/models/Qwen3.5-27B-FP8 \
    --trust-remote-code \
    --attention-backend fa3 \
    --mamba-scheduler-strategy extra_buffer \
    --speculative-algo NEXTN \
    --max-running-requests 128 \
    --speculative-num-steps 1 \
    --speculative-eagle-topk 1 \
    --speculative-num-draft-tokens 2 \
    --disable-piecewise-cuda-graph

WARNING:py.warnings:/mnt/seed17/001688/qzg/qwen3/260124/github/qwen-test/sglang/python/sglang/launch_server.py:54: UserWarning: 'python -m sglang.launch_server' is still supported, but 'sglang serve' is the recommended entrypoint.
  Example: sglang serve --model-path <model> [options]
  warnings.warn(

2026-04-28 13:44:02 | warnings | 140415835060032 | WARNING : /mnt/seed17/001688/qzg/qwen3/260124/github/qwen-test/sglang/python/sglang/launch_server.py:54: UserWarning: 'python -m sglang.launch_server' is still supported, but 'sglang serve' is the recommended entrypoint.
  Example: sglang serve --model-path <model> [options]
  warnings.warn(

[2026-04-28 13:44:03] No platform detected. Using base SRTPlatform with defaults.
INFO 04-28 13:44:03 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 04-28 13:44:03 [__init__.py:38] - musa -> vllm_musa:register
INFO 04-28 13:44:03 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 04-28 13:44:03 [__init__.py:232] Platform plugin musa is activated
[2026-04-28 13:44:03] /mnt/seed17/001688/qzg/qwen3/260124/github/qwen-test/sglang/python/sglang/srt/layers/quantization/awq.py:87: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

`torch_dtype` is deprecated! Use `dtype` instead!
[2026-04-28 13:44:03] Max running requests is reset to 48 for speculative decoding. You can override this by explicitly setting --max-running-requests.
[2026-04-28 13:44:03] Spec v2 is enabled for eagle/eagle3 speculative decoding and overlap schedule is turned on.
[2026-04-28 13:44:04] server_args=ServerArgs(model_path='/mnt/seed17/001688/models/Qwen3.5-27B-FP8', tokenizer_path='/mnt/seed17/001688/models/Qwen3.5-27B-FP8', tokenizer_mode='auto', tokenizer_worker_num=1, skip_tokenizer_init=False, load_format='auto', model_loader_extra_config='{}', trust_remote_code=True, context_length=None, is_embedding=False, enable_multimodal=None, revision=None, model_impl='auto', host='127.0.0.1', port=30000, fastapi_root_path='', grpc_mode=False, skip_server_warmup=False, warmups=None, nccl_port=None, checkpoint_engine_wait_weights_before_ready=False, ssl_keyfile=None, ssl_certfile=None, ssl_ca_certs=None, ssl_keyfile_password=None, enable_ssl_refresh=False, enable_http2=False, dtype='auto', quantization=None, quantization_param_path=None, kv_cache_dtype='auto', enable_fp32_lm_head=False, modelopt_quant=None, modelopt_checkpoint_restore_path=None, modelopt_checkpoint_save_path=None, modelopt_export_path=None, quantize_and_serve=False, rl_quant_profile=None, mem_fraction_static=0.72686578125, max_running_requests=48, max_queued_requests=None, max_total_tokens=None, chunked_prefill_size=8192, enable_dynamic_chunking=False, max_prefill_tokens=16384, prefill_max_requests=None, schedule_policy='fcfs', enable_priority_scheduling=False, disable_priority_preemption=False, default_priority_value=None, abort_on_priority_when_disabled=False, schedule_low_priority_values_first=False, priority_scheduling_preemption_threshold=10, schedule_conservativeness=1.0, page_size=64, swa_full_tokens_ratio=0.8, disable_hybrid_swa_memory=False, radix_eviction_policy='lru', enable_prefill_delayer=False, prefill_delayer_max_delay_passes=30, prefill_delayer_token_usage_low_watermark=None, prefill_delayer_forward_passes_buckets=None, prefill_delayer_wait_seconds_buckets=None, device='musa', tp_size=1, pp_size=1, pp_max_micro_batch_size=None, pp_async_batch_depth=0, stream_interval=1, batch_notify_size=16, stream_response_default_include_usage=False, incremental_streaming_output=False, enable_streaming_session=False, random_seed=56410566, constrained_json_whitespace_pattern=None, constrained_json_disable_any_whitespace=False, watchdog_timeout=300, soft_watchdog_timeout=None, dist_timeout=None, download_dir=None, model_checksum=None, base_gpu_id=0, gpu_id_step=1, sleep_on_idle=False, use_ray=False, custom_sigquit_handler=None, log_level='info', log_level_http=None, log_requests=False, log_requests_level=2, log_requests_format='text', log_requests_target=None, uvicorn_access_log_exclude_prefixes=[], crash_dump_folder=None, show_time_cost=False, enable_metrics=False, grpc_http_sidecar_port=None, enable_mfu_metrics=False, enable_metrics_for_all_schedulers=False, tokenizer_metrics_custom_labels_header='x-custom-labels', tokenizer_metrics_allowed_custom_labels=None, extra_metric_labels=None, bucket_time_to_first_token=None, bucket_inter_token_latency=None, bucket_e2e_request_latency=None, collect_tokens_histogram=False, prompt_tokens_buckets=None, generation_tokens_buckets=None, gc_warning_threshold_secs=0.0, decode_log_interval=40, enable_request_time_stats_logging=False, kv_events_config=None, enable_trace=False, otlp_traces_endpoint='localhost:4317', export_metrics_to_file=False, export_metrics_to_file_dir=None, api_key=None, admin_api_key=None, served_model_name='/mnt/seed17/001688/models/Qwen3.5-27B-FP8', weight_version='default', chat_template=None, hf_chat_template_name=None, completion_template=None, file_storage_path='sglang_storage', enable_cache_report=False, reasoning_parser=None, strip_thinking_cache=False, tool_call_parser=None, tool_server=None, sampling_defaults='model', dp_size=1, load_balance_method='round_robin', attn_cp_size=1, moe_dp_size=1, dist_init_addr=None, nnodes=1, node_rank=0, json_model_override_args='{}', preferred_sampling_params=None, enable_lora=None, enable_lora_overlap_loading=None, max_lora_rank=None, lora_target_modules=None, lora_paths=None, max_loaded_loras=None, max_loras_per_batch=8, lora_eviction_policy='lru', lora_backend='csgmv', max_lora_chunk_size=16, experts_shared_outer_loras=None, lora_use_virtual_experts=False, lora_strict_loading=False, attention_backend='fa3', decode_attention_backend=None, prefill_attention_backend=None, sampling_backend='pytorch', grammar_backend='xgrammar', mm_attention_backend=None, fp8_gemm_runner_backend='auto', fp4_gemm_runner_backend='auto', nsa_prefill_backend=None, nsa_decode_backend=None, disable_flashinfer_autotune=False, mamba_backend='triton', speculative_algorithm='EAGLE', speculative_draft_model_path=None, speculative_draft_model_revision=None, speculative_draft_load_format=None, speculative_num_steps=1, speculative_eagle_topk=1, speculative_num_draft_tokens=2, speculative_dflash_block_size=None, speculative_dflash_draft_window_size=None, speculative_accept_threshold_single=1.0, speculative_accept_threshold_acc=1.0, speculative_token_map=None, speculative_attention_mode='prefill', speculative_draft_attention_backend=None, speculative_moe_runner_backend='auto', speculative_moe_a2a_backend=None, speculative_draft_model_quantization=None, speculative_adaptive=False, speculative_adaptive_config=None, speculative_ngram_min_bfs_breadth=1, speculative_ngram_max_bfs_breadth=10, speculative_ngram_match_type='BFS', speculative_ngram_max_trie_depth=18, speculative_ngram_capacity=10000000, speculative_ngram_external_corpus_path=None, speculative_ngram_external_sam_budget=0, speculative_ngram_external_corpus_max_tokens=10000000, enable_multi_layer_eagle=False, ep_size=1, moe_a2a_backend='none', moe_runner_backend='auto', record_nolora_graph=True, flashinfer_mxfp4_moe_precision='default', enable_flashinfer_allreduce_fusion=False, enforce_disable_flashinfer_allreduce_fusion=False, enable_aiter_allreduce_fusion=False, deepep_mode='auto', ep_num_redundant_experts=0, ep_dispatch_algorithm=None, init_expert_location='trivial', enable_eplb=False, eplb_algorithm='auto', eplb_rebalance_num_iterations=1000, eplb_rebalance_layers_per_chunk=None, eplb_min_rebalancing_utilization_threshold=1.0, expert_distribution_recorder_mode=None, expert_distribution_recorder_buffer_size=1000, enable_expert_distribution_metrics=False, deepep_config=None, moe_dense_tp_size=None, elastic_ep_backend=None, enable_elastic_expert_backup=False, mooncake_ib_device=None, max_mamba_cache_size=None, mamba_ssm_dtype=None, mamba_full_memory_ratio=0.9, mamba_scheduler_strategy='extra_buffer', mamba_track_interval=256, linear_attn_backend='triton', linear_attn_decode_backend=None, linear_attn_prefill_backend=None, enable_hierarchical_cache=False, hicache_ratio=2.0, hicache_size=0, hicache_write_policy='write_through', hicache_io_backend='kernel', hicache_mem_layout='layer_first', hicache_storage_backend=None, hicache_storage_prefetch_policy='best_effort', hicache_storage_backend_extra_config=None, enable_hisparse=False, hisparse_config=None, enable_lmcache=False, kt_weight_path=None, kt_method='AMXINT4', kt_cpuinfer=None, kt_threadpool_count=2, kt_num_gpu_experts=None, kt_max_deferred_experts_per_token=None, dllm_algorithm=None, dllm_algorithm_config=None, cpu_offload_gb=0, offload_group_size=-1, offload_num_in_group=1, offload_prefetch_step=1, offload_mode='cpu', enable_mis=False, disable_radix_cache=False, cuda_graph_max_bs=256, cuda_graph_bs=[1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 40, 44, 48, 52, 56, 60, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256], disable_cuda_graph=False, disable_cuda_graph_padding=False, enable_breakable_cuda_graph=False, enable_profile_cuda_graph=False, enable_cudagraph_gc=False, debug_cuda_graph=False, enable_layerwise_nvtx_marker=False, enable_nccl_nvls=False, enable_symm_mem=False, disable_flashinfer_cutlass_moe_fp4_allgather=False, enable_tokenizer_batch_encode=False, disable_tokenizer_batch_decode=False, disable_outlines_disk_cache=False, disable_custom_all_reduce=False, enable_mscclpp=False, enable_torch_symm_mem=False, pre_warm_nccl=False, disable_overlap_schedule=False, enable_mixed_chunk=False, enable_dp_attention=False, enable_dp_attention_local_control_broadcast=False, enable_dp_lm_head=False, enable_two_batch_overlap=False, enable_single_batch_overlap=False, tbo_token_distribution_threshold=0.48, enable_torch_compile=False, disable_piecewise_cuda_graph=True, enforce_piecewise_cuda_graph=False, enable_torch_compile_debug_mode=False, torch_compile_max_bs=32, piecewise_cuda_graph_max_tokens=8192, piecewise_cuda_graph_tokens=[4, 8, 12, 16, 20, 24, 28, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256, 288, 320, 352, 384, 416, 448, 480, 512, 576, 640, 704, 768, 832, 896, 960, 1024, 1280, 1536, 1792, 2048, 2304, 2560, 2816, 3072, 3328, 3584, 3840, 4096, 4608, 5120, 5632, 6144, 6656, 7168, 7680, 8192], piecewise_cuda_graph_compiler='eager', torchao_config='', enable_nan_detection=False, enable_p2p_check=False, triton_attention_reduce_in_fp32=False, triton_attention_num_kv_splits=8, triton_attention_split_tile_size=None, num_continuous_decode_steps=1, delete_ckpt_after_loading=False, enable_memory_saver=False, enable_weights_cpu_backup=False, enable_draft_weights_cpu_backup=False, allow_auto_truncate=False, enable_custom_logit_processor=False, flashinfer_mla_disable_ragged=False, disable_shared_experts_fusion=False, enforce_shared_experts_fusion=False, disable_chunked_prefix_cache=False, disable_fast_image_processor=False, keep_mm_feature_on_device=False, enable_return_hidden_states=False, enable_return_routed_experts=False, scheduler_recv_interval=1, numa_node=None, enable_deterministic_inference=False, rl_on_policy_target=None, enable_attn_tp_input_scattered=False, gc_threshold=None, enable_nsa_prefill_context_parallel=False, nsa_prefill_cp_mode='round-robin-split', enable_fused_qk_norm_rope=False, enable_precise_embedding_interpolation=False, enable_fused_moe_sum_all_reduce=False, enable_prefill_context_parallel=False, prefill_cp_mode='in-seq-split', enable_dynamic_batch_tokenizer=False, dynamic_batch_tokenizer_batch_size=32, dynamic_batch_tokenizer_batch_timeout=0.002, debug_tensor_dump_output_folder=None, debug_tensor_dump_layers=None, debug_tensor_dump_input_file=None, debug_tensor_dump_inject=False, disaggregation_mode='null', disaggregation_transfer_backend='mooncake', disaggregation_bootstrap_port=8998, disaggregation_ib_device=None, disaggregation_decode_enable_offload_kvcache=False, num_reserved_decode_tokens=512, disaggregation_decode_polling_interval=1, encoder_only=False, language_only=False, encoder_transfer_backend='zmq_to_scheduler', encoder_urls=[], enable_adaptive_dispatch_to_encoder=False, custom_weight_loader=[], weight_loader_disable_mmap=False, weight_loader_prefetch_checkpoints=False, weight_loader_prefetch_num_threads=4, remote_instance_weight_loader_seed_instance_ip=None, remote_instance_weight_loader_seed_instance_service_port=None, remote_instance_weight_loader_send_weights_group_ports=None, remote_instance_weight_loader_backend='nccl', remote_instance_weight_loader_start_seed_via_transfer_engine=False, engine_info_bootstrap_port=6789, modelexpress_config=None, enable_pdmux=False, pdmux_config_path=None, sm_group_num=8, enable_broadcast_mm_inputs_process=False, enable_prefix_mm_cache=False, mm_enable_dp_encoder=False, mm_process_config={}, limit_mm_data_per_request=None, enable_mm_global_cache=False, decrypted_config_file=None, decrypted_draft_config_file=None, forward_hooks=None)
[2026-04-28 13:44:05] Ignore import error when loading sglang.srt.multimodal.processors.gemma4: cannot import name 'Gemma4AudioConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-28 13:44:05] Ignore import error when loading sglang.srt.multimodal.processors.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-28 13:44:05] Ignore import error when loading sglang.srt.multimodal.processors.midashenglm: No module named 'torchaudio'
[2026-04-28 13:44:07] Ignore import error when loading sglang.srt.models.gemma4_audio: cannot import name 'Gemma4AudioConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-28 13:44:07] Ignore import error when loading sglang.srt.models.gemma4_causal: cannot import name 'Gemma4TextConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-28 13:44:07] Ignore import error when loading sglang.srt.models.gemma4_mm: cannot import name 'Gemma4AudioConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-28 13:44:07] Ignore import error when loading sglang.srt.models.gemma4_vision: cannot import name 'Gemma4VisionConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-28 13:44:07] Ignore import error when loading sglang.srt.models.glm_ocr: No module named 'transformers.models.glm_ocr'
[2026-04-28 13:44:07] Ignore import error when loading sglang.srt.models.glm_ocr_nextn: No module named 'transformers.models.glm_ocr'
[2026-04-28 13:44:07] Ignore import error when loading sglang.srt.models.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-28 13:44:07] Ignore import error when loading sglang.srt.models.midashenglm: No module named 'torchaudio'
[2026-04-28 13:44:07] Using default HuggingFace chat template with detected content format: openai
WARNING:sglang.srt.platforms:No platform detected. Using base SRTPlatform with defaults.
2026-04-28 13:44:11 | __init__ | 139744385541952 | WARNING : No platform detected. Using base SRTPlatform with defaults.
WARNING:sglang.srt.platforms:No platform detected. Using base SRTPlatform with defaults.
2026-04-28 13:44:11 | __init__ | 139957017069376 | WARNING : No platform detected. Using base SRTPlatform with defaults.
INFO 04-28 13:44:11 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 04-28 13:44:11 [__init__.py:38] - musa -> vllm_musa:register
INFO 04-28 13:44:11 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 04-28 13:44:11 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 04-28 13:44:11 [__init__.py:38] - musa -> vllm_musa:register
INFO 04-28 13:44:11 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 04-28 13:44:11 [__init__.py:232] Platform plugin musa is activated
INFO 04-28 13:44:11 [__init__.py:232] Platform plugin musa is activated
WARNING:py.warnings:/mnt/seed17/001688/qzg/qwen3/260124/github/qwen-test/sglang/python/sglang/srt/layers/quantization/awq.py:87: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-04-28 13:44:11 | warnings | 139957017069376 | WARNING : /mnt/seed17/001688/qzg/qwen3/260124/github/qwen-test/sglang/python/sglang/srt/layers/quantization/awq.py:87: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

WARNING:py.warnings:/mnt/seed17/001688/qzg/qwen3/260124/github/qwen-test/sglang/python/sglang/srt/layers/quantization/awq.py:87: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-04-28 13:44:11 | warnings | 139744385541952 | WARNING : /mnt/seed17/001688/qzg/qwen3/260124/github/qwen-test/sglang/python/sglang/srt/layers/quantization/awq.py:87: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

`torch_dtype` is deprecated! Use `dtype` instead!
[2026-04-28 13:44:14] Ignore import error when loading sglang.srt.multimodal.processors.gemma4: cannot import name 'Gemma4AudioConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-28 13:44:14] Ignore import error when loading sglang.srt.multimodal.processors.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-28 13:44:14] Ignore import error when loading sglang.srt.multimodal.processors.midashenglm: No module named 'torchaudio'
[2026-04-28 13:44:14] Init torch distributed begin.
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[2026-04-28 13:44:16] Init torch distributed ends. elapsed=1.60 s, mem usage=0.10 GB
[2026-04-28 13:44:16] Ignore import error when loading sglang.srt.models.gemma4_audio: cannot import name 'Gemma4AudioConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-28 13:44:16] Ignore import error when loading sglang.srt.models.gemma4_causal: cannot import name 'Gemma4TextConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-28 13:44:16] Ignore import error when loading sglang.srt.models.gemma4_mm: cannot import name 'Gemma4AudioConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-28 13:44:16] Ignore import error when loading sglang.srt.models.gemma4_vision: cannot import name 'Gemma4VisionConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-28 13:44:16] Ignore import error when loading sglang.srt.models.glm_ocr: No module named 'transformers.models.glm_ocr'
[2026-04-28 13:44:16] Ignore import error when loading sglang.srt.models.glm_ocr_nextn: No module named 'transformers.models.glm_ocr'
[2026-04-28 13:44:16] Ignore import error when loading sglang.srt.models.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/transformers/__init__.py)
[2026-04-28 13:44:16] Ignore import error when loading sglang.srt.models.midashenglm: No module named 'torchaudio'
[2026-04-28 13:44:16] Load weight begin. avail mem=79.11 GB
[2026-04-28 13:44:16] Detected fp8 checkpoint.
[2026-04-28 13:44:20] Multimodal attention backend not set. Use fa3.
[2026-04-28 13:44:20] Using fa3 as multimodal attention backend.
[2026-04-28 13:44:20] using attn output gate!

Multi-thread loading shards:   0% Completed | 0/11 [00:00<?, ?it/s]
Multi-thread loading shards:   9% Completed | 1/11 [00:04<00:49,  4.92s/it]
Multi-thread loading shards:  18% Completed | 2/11 [00:07<00:32,  3.56s/it]
Multi-thread loading shards:  27% Completed | 3/11 [00:10<00:25,  3.17s/it]
Multi-thread loading shards:  36% Completed | 4/11 [00:12<00:20,  3.00s/it]
Multi-thread loading shards:  45% Completed | 5/11 [00:15<00:17,  2.89s/it]
Multi-thread loading shards:  55% Completed | 6/11 [00:18<00:14,  2.81s/it]
Multi-thread loading shards:  64% Completed | 7/11 [00:20<00:11,  2.76s/it]
Multi-thread loading shards:  73% Completed | 8/11 [00:23<00:08,  2.69s/it]
Multi-thread loading shards:  82% Completed | 9/11 [00:26<00:05,  2.68s/it]
Multi-thread loading shards:  91% Completed | 10/11 [00:28<00:02,  2.67s/it]
Multi-thread loading shards: 100% Completed | 11/11 [00:30<00:00,  2.36s/it]
Multi-thread loading shards: 100% Completed | 11/11 [00:30<00:00,  2.77s/it]
[2026-04-28 13:44:51] Load weight end. elapsed=34.53 s, type=Qwen3_5ForConditionalGeneration, quant=fp8, avail mem=50.39 GB, mem usage=28.73 GB.
[2026-04-28 13:44:51] Using KV cache dtype: torch.bfloat16
[2026-04-28 13:44:51] Mamba Cache is allocated. max_mamba_cache_size: 49, conv_state size: 0.14GB, ssm_state size: 7.03GB intermediate_ssm_state_cache size: 2.81GB intermediate_conv_window_cache size: 0.05GB 
[2026-04-28 13:44:51] KV Cache is allocated. #tokens: 130048, K size: 3.97 GB, V size: 3.97 GB
[2026-04-28 13:44:51] Memory pool end. avail mem=32.28 GB
[2026-04-28 13:44:51] Current Python version 3.10 is below the recommended 3.11 version. It is recommended to upgrade to Python 3.11 or higher for the best experience.
[2026-04-28 13:44:51] Linear attention kernel backend: decode=triton, prefill=triton
[2026-04-28 13:44:51] Using hybrid linear attention backend for hybrid GDN models.
[2026-04-28 13:44:51] GDN kernel dispatcher: decode=TritonGDNKernel, extend=TritonGDNKernel, verify=TritonGDNKernel packed_decode=True
[2026-04-28 13:44:51] Capture cuda graph begin. This can take up to several minutes. avail mem=32.27 GB
[2026-04-28 13:44:51] 111111111 capture_bs=[1, 2, 3, 4, 5, 6, 7, 8, 9] num_max_requests=9 num_tokens_per_bs=2
[2026-04-28 13:44:51] Capture cuda graph bs [1, 2, 3, 4, 5, 6, 7, 8, 9]

  0%|          | 0/9 [00:00<?, ?it/s]
Capturing batches (bs=9 avail_mem=32.25 GB):   0%|          | 0/9 [00:00<?, ?it/s]
Capturing batches (bs=9 avail_mem=32.25 GB):  11%|█         | 1/9 [00:10<01:24, 10.61s/it]
Capturing batches (bs=8 avail_mem=31.46 GB):  11%|█         | 1/9 [00:10<01:24, 10.61s/it]
Capturing batches (bs=8 avail_mem=31.46 GB):  22%|██▏       | 2/9 [00:13<00:42,  6.13s/it]
Capturing batches (bs=7 avail_mem=31.46 GB):  22%|██▏       | 2/9 [00:13<00:42,  6.13s/it]
Capturing batches (bs=7 avail_mem=31.46 GB):  33%|███▎      | 3/9 [00:16<00:28,  4.71s/it]
Capturing batches (bs=6 avail_mem=31.45 GB):  33%|███▎      | 3/9 [00:16<00:28,  4.71s/it]
Capturing batches (bs=6 avail_mem=31.45 GB):  44%|████▍     | 4/9 [00:19<00:20,  4.03s/it]
Capturing batches (bs=5 avail_mem=31.45 GB):  44%|████▍     | 4/9 [00:19<00:20,  4.03s/it]
Capturing batches (bs=5 avail_mem=31.45 GB):  56%|█████▌    | 5/9 [00:22<00:14,  3.66s/it]
Capturing batches (bs=4 avail_mem=31.44 GB):  56%|█████▌    | 5/9 [00:22<00:14,  3.66s/it]
Capturing batches (bs=4 avail_mem=31.44 GB):  67%|██████▋   | 6/9 [00:25<00:10,  3.43s/it]
Capturing batches (bs=3 avail_mem=31.44 GB):  67%|██████▋   | 6/9 [00:25<00:10,  3.43s/it]
Capturing batches (bs=3 avail_mem=31.44 GB):  78%|███████▊  | 7/9 [00:28<00:06,  3.29s/it]
Capturing batches (bs=2 avail_mem=31.43 GB):  78%|███████▊  | 7/9 [00:28<00:06,  3.29s/it]
Capturing batches (bs=2 avail_mem=31.43 GB):  89%|████████▉ | 8/9 [00:31<00:03,  3.26s/it]
Capturing batches (bs=1 avail_mem=31.43 GB):  89%|████████▉ | 8/9 [00:31<00:03,  3.26s/it]
Capturing batches (bs=1 avail_mem=31.43 GB): 100%|██████████| 9/9 [00:35<00:00,  3.25s/it]
Capturing batches (bs=1 avail_mem=31.43 GB): 100%|██████████| 9/9 [00:35<00:00,  3.89s/it]
[2026-04-28 13:45:26] Capture cuda graph end. Time elapsed: 35.69 s. mem usage=0.85 GB. avail mem=31.42 GB.
[2026-04-28 13:45:26] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
[2026-04-28 13:45:28] Init torch distributed begin.
[2026-04-28 13:45:28] Init torch distributed ends. elapsed=0.00 s, mem usage=0.00 GB
[2026-04-28 13:45:28] Load weight begin. avail mem=31.42 GB
[2026-04-28 13:45:28] Detected fp8 checkpoint.

Multi-thread loading shards:   0% Completed | 0/11 [00:00<?, ?it/s]
Multi-thread loading shards:  18% Completed | 2/11 [00:00<00:01,  7.03it/s]
Multi-thread loading shards:  73% Completed | 8/11 [00:00<00:00, 19.47it/s]
Multi-thread loading shards: 100% Completed | 11/11 [00:00<00:00, 21.31it/s]
[2026-04-28 13:45:28] Load weight end. elapsed=0.55 s, type=Qwen3_5ForCausalLMMTP, quant=fp8, avail mem=26.23 GB, mem usage=5.19 GB.
[2026-04-28 13:45:28] Using KV cache dtype: torch.bfloat16
[2026-04-28 13:45:28] KV Cache is allocated. #tokens: 130048, K size: 0.25 GB, V size: 0.25 GB
[2026-04-28 13:45:28] Memory pool end. avail mem=25.73 GB
[2026-04-28 13:45:28] Linear attention kernel backend: decode=triton, prefill=triton
[2026-04-28 13:45:28] Using hybrid linear attention backend for hybrid GDN models.
[2026-04-28 13:45:28] GDN kernel dispatcher: decode=TritonGDNKernel, extend=TritonGDNKernel, verify=TritonGDNKernel packed_decode=True
[2026-04-28 13:45:28] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
[2026-04-28 13:45:30] max_total_num_tokens=130048, chunked_prefill_size=8192, max_prefill_tokens=16384, max_running_requests=9, context_len=262144, available_gpu_mem=30.48 GB
[2026-04-28 13:45:31] INFO:     Started server process [679269]
[2026-04-28 13:45:31] INFO:     Waiting for application startup.
[2026-04-28 13:45:31] Using default chat sampling params from model generation config: {'repetition_penalty': 1.0, 'temperature': 0.6, 'top_k': 20, 'top_p': 0.95}
[2026-04-28 13:45:31] INFO:     Application startup complete.
[2026-04-28 13:45:31] INFO:     Uvicorn running on http://127.0.0.1:30000 (Press CTRL+C to quit)
[2026-04-28 13:45:32] INFO:     127.0.0.1:59244 - "GET /model_info HTTP/1.1" 200 OK
[2026-04-28 13:45:42] Prefill batch, #new-seq: 1, #new-token: 128, #cached-token: 0, full token usage: 0.00, mamba usage: 0.08, #running-req: 0, #queue-req: 0, #pending-token: 0, musa graph: False, input throughput (token/s): 1.43
[2026-04-28 13:45:42] INFO:     127.0.0.1:59258 - "POST /v1/chat/completions HTTP/1.1" 200 OK
[2026-04-28 13:45:42] The server is fired up and ready to roll!
[2026-04-28 13:59:30] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 0, full token usage: 0.00, mamba usage: 0.06, #running-req: 0, #queue-req: 0, #pending-token: 0, musa graph: False, input throughput (token/s): 0.08
[2026-04-28 13:59:31] Decode batch, #running-req: 1, #full token: 128, full token usage: 0.00, mamba num: 3, mamba usage: 0.06, accept len: 1.75, accept rate: 0.88, musa graph: True, gen throughput (token/s): 0.08, #queue-req: 0
[2026-04-28 13:59:33] Decode batch, #running-req: 1, #full token: 192, full token usage: 0.00, mamba num: 3, mamba usage: 0.06, accept len: 1.88, accept rate: 0.94, musa graph: True, gen throughput (token/s): 47.48, #queue-req: 0
[2026-04-28 13:59:35] Decode batch, #running-req: 1, #full token: 256, full token usage: 0.00, mamba num: 3, mamba usage: 0.06, accept len: 1.90, accept rate: 0.95, musa graph: True, gen throughput (token/s): 48.01, #queue-req: 0
[2026-04-28 13:59:36] Decode batch, #running-req: 1, #full token: 320, full token usage: 0.00, mamba num: 3, mamba usage: 0.06, accept len: 1.88, accept rate: 0.94, musa graph: True, gen throughput (token/s): 47.36, #queue-req: 0
[2026-04-28 13:59:36] INFO:     127.0.0.1:33028 - "POST /generate HTTP/1.1" 200 OK


python sglang/python/sglang/test/few_shot_gsm8k.py 
100%|████████████████████████████████████████████████████████████| 200/200 [03:28<00:00,  1.04s/it]
Accuracy: 0.725
Invalid: 0.000
Latency: 208.778 s
Output throughput: 215.564 token/s

```


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
