### PR TITLE
[diffusion] lora: strip `transformer.` prefix for diffusers PEFT Z-Im…

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/lora_format_adapter.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/lora_format_adapter.py
@@ -105,6 +105,27 @@ def _looks_like_qwen_image(state_dict: Mapping[str, torch.Tensor]) -> bool:
     )
 
 
+def _looks_like_zimage_diffusers(state_dict: Mapping[str, torch.Tensor]) -> bool:
+    """Detect diffusers-PEFT Z-Image LoRA.
+
+    `ZImagePipeline.save_lora_weights(transformer_lora_layers=...)` prefixes every
+    key with `transformer.`, giving patterns like:
+        transformer.layers.{N}.attention.to_q.lora_{A,B}.weight
+        transformer.{noise,context}_refiner.{N}.feed_forward.w{1,2,3}.lora_{A,B}.weight
+    """
+    keys = list(state_dict.keys())
+    if not keys:
+        return False
+    has_prefix = _has_prefix_key(keys, "transformer.")
+    has_lora_ab = _has_substring_key(keys, ".lora_A") or _has_substring_key(
+        keys, ".lora_B"
+    )
+    has_refiner = _has_prefix_key(
+        keys, "transformer.noise_refiner."
+    ) or _has_prefix_key(keys, "transformer.context_refiner.")
+    return has_prefix and has_lora_ab and has_refiner
+
+
 def _looks_like_ai_toolkit_flux_lora(state_dict: Mapping[str, torch.Tensor]) -> bool:
     """Detect ai-toolkit/ComfyUI trained Flux LoRA with double_blocks/single_blocks naming.
 
@@ -185,6 +206,22 @@ def _convert_qwen_image_standard(
 
         out[new_name] = tensor
 
+    return out
+
+
+def _convert_zimage_diffusers_standard(
+    state_dict: Mapping[str, torch.Tensor],
+    log: logging.Logger,
+) -> Dict[str, torch.Tensor]:
+    """Strip leading `transformer.` prefix from Z-Image diffusers PEFT LoRA keys
+    so they match `ZImageTransformer2DModel.named_modules()` (which has no
+    prefix). Mirrors the Qwen-Image case.
+    """
+    out: Dict[str, torch.Tensor] = {}
+    prefix = "transformer."
+    for name, tensor in state_dict.items():
+        new_name = name[len(prefix) :] if name.startswith(prefix) else name
+        out[new_name] = tensor
     return out
 
 
@@ -520,6 +557,9 @@ def convert_lora_state_dict_by_format(
 
         if _looks_like_qwen_image(maybe):
             return _convert_qwen_image_standard(maybe, log)
+
+        if _looks_like_zimage_diffusers(maybe):
+            return _convert_zimage_diffusers_standard(maybe, log)
 
         return maybe
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/lora_format_adapter.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/lora_format_adapter.py
@@ -112,6 +112,18 @@ def _looks_like_zimage_diffusers(state_dict: Mapping[str, torch.Tensor]) -> bool
     key with `transformer.`, giving patterns like:
         transformer.layers.{N}.attention.to_q.lora_{A,B}.weight
         transformer.{noise,context}_refiner.{N}.feed_forward.w{1,2,3}.lora_{A,B}.weight
+
+    We require Z-Image specific fingerprints on top of the prefix + lora_A/B
+    check to avoid false-positives on other diffusers LoRAs that also carry a
+    `transformer.` prefix (Qwen-Image, ErnieImage, etc). Two fingerprints
+    cover the realistic target_modules combinations:
+      - `noise_refiner` or `context_refiner` branch — unique to Z-Image.
+      - `feed_forward.w1/w2/w3` — Z-Image's Gated-MLP naming (Ernie uses `mlp`,
+        Qwen uses `transformer_blocks.*.ff`, etc).
+    Either signal is sufficient. Pure attention-only LoRAs without any FFN or
+    refiner coverage remain undetectable by keys alone — left as an explicit
+    gap rather than widening to `transformer.layers.*` which would misfire on
+    ErnieImage attention-only LoRAs (same key shape after PEFT export).
     """
     keys = list(state_dict.keys())
     if not keys:
@@ -120,10 +132,17 @@ def _looks_like_zimage_diffusers(state_dict: Mapping[str, torch.Tensor]) -> bool
     has_lora_ab = _has_substring_key(keys, ".lora_A") or _has_substring_key(
         keys, ".lora_B"
     )
+    if not (has_prefix and has_lora_ab):
+        return False
     has_refiner = _has_prefix_key(
         keys, "transformer.noise_refiner."
     ) or _has_prefix_key(keys, "transformer.context_refiner.")
-    return has_prefix and has_lora_ab and has_refiner
+    has_gated_ffn = (
+        _has_substring_key(keys, ".feed_forward.w1.")
+        or _has_substring_key(keys, ".feed_forward.w2.")
+        or _has_substring_key(keys, ".feed_forward.w3.")
+    )
+    return has_refiner or has_gated_ffn
 
 
 def _looks_like_ai_toolkit_flux_lora(state_dict: Mapping[str, torch.Tensor]) -> bool:

--- a/python/sglang/multimodal_gen/test/unit/test_lora_format_adapter.py
+++ b/python/sglang/multimodal_gen/test/unit/test_lora_format_adapter.py
@@ -370,6 +370,39 @@ class TestLoRAFormatAdapter:
             assert k_old in state_dict
             assert v_new.shape == state_dict[k_old].shape
 
+    def test_zimage_diffusers_ffn_only_lora_still_detected(self):
+        """Regression for gemini-code-assist review feedback.
+
+        A target_modules=['w1','w2','w3'] LoRA has no `noise_refiner` or
+        `context_refiner` keys, but still needs `transformer.` prefix stripping.
+        The Gated-MLP fingerprint in `_looks_like_zimage_diffusers` catches it.
+        """
+        state_dict = {}
+        for layer_idx in range(2):
+            for w in ("w1", "w2", "w3"):
+                base = f"transformer.layers.{layer_idx}.feed_forward.{w}"
+                state_dict[f"{base}.lora_A.weight"] = torch.randn(4, 2560)
+                state_dict[f"{base}.lora_B.weight"] = torch.randn(2560, 4)
+
+        # No refiner keys present — would have slipped past the old detector.
+        assert not any("refiner" in k for k in state_dict)
+
+        fmt = detect_lora_format_from_state_dict(state_dict)
+        assert fmt == LoRAFormat.STANDARD
+
+        normalized = normalize_lora_state_dict(state_dict, logger=logger)
+
+        assert not any(k.startswith("transformer.") for k in normalized), (
+            "`transformer.` prefix must be stripped for FFN-only Z-Image LoRA; "
+            + "found keys: "
+            + str([k for k in normalized if k.startswith("transformer.")][:3])
+        )
+        assert len(normalized) == len(state_dict)
+        for k_new, v_new in normalized.items():
+            k_old = "transformer." + k_new
+            assert k_old in state_dict
+            assert v_new.shape == state_dict[k_old].shape
+
 
 if __name__ == "__main__":
     main()

--- a/python/sglang/multimodal_gen/test/unit/test_lora_format_adapter.py
+++ b/python/sglang/multimodal_gen/test/unit/test_lora_format_adapter.py
@@ -331,6 +331,45 @@ class TestLoRAFormatAdapter:
             r["pass"] for r in results
         ), "At least one LoRA format adapter case failed"
 
+    def test_zimage_diffusers_peft_prefix_stripped(self):
+        """Regression: diffusers PEFT Z-Image LoRA must have `transformer.` prefix stripped.
+
+        Without stripping, every key misses `ZImageTransformer2DModel.named_modules()`
+        naming and LoRA silently becomes a no-op.
+        """
+        rank = 4
+        hidden = 2560
+        state_dict = {}
+        for layer_idx in range(2):
+            for branch in ("layers", "noise_refiner", "context_refiner"):
+                for proj in ("to_q", "to_k", "to_v"):
+                    base = f"transformer.{branch}.{layer_idx}.attention.{proj}"
+                    state_dict[f"{base}.lora_A.weight"] = torch.randn(rank, hidden)
+                    state_dict[f"{base}.lora_B.weight"] = torch.randn(hidden, rank)
+                for w in ("w1", "w2", "w3"):
+                    base = f"transformer.{branch}.{layer_idx}.feed_forward.{w}"
+                    state_dict[f"{base}.lora_A.weight"] = torch.randn(rank, hidden)
+                    state_dict[f"{base}.lora_B.weight"] = torch.randn(hidden, rank)
+
+        assert all(k.startswith("transformer.") for k in state_dict)
+
+        fmt = detect_lora_format_from_state_dict(state_dict)
+        assert fmt == LoRAFormat.STANDARD, f"unexpected detected format: {fmt}"
+
+        normalized = normalize_lora_state_dict(state_dict, logger=logger)
+
+        assert not any(
+            k.startswith("transformer.") for k in normalized
+        ), "`transformer.` prefix must be stripped; found keys: " + str(
+            [k for k in normalized if k.startswith("transformer.")][:3]
+        )
+
+        assert len(normalized) == len(state_dict)
+        for k_new, v_new in normalized.items():
+            k_old = "transformer." + k_new
+            assert k_old in state_dict
+            assert v_new.shape == state_dict[k_old].shape
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
<head></head><h2 style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">Motivation</h2><p style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">Z-Image LoRAs saved through diffusers'<span class="Apple-converted-space"> </span><code>ZImagePipeline.save_lora_weights()</code><span class="Apple-converted-space"> </span>don't work in SGLang — every call to<span class="Apple-converted-space"> </span><code>set_lora</code><span class="Apple-converted-space"> </span>+<span class="Apple-converted-space"> </span><code>merge_lora_weights</code><span class="Apple-converted-space"> </span>succeeds, but the output is byte-identical to baseline. The<span class="Apple-converted-space"> </span><code>strength</code><span class="Apple-converted-space"> </span>parameter has no visible effect either (0.85 and 1.0 produce the same image).</p><p style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">Root cause: diffusers'<span class="Apple-converted-space"> </span><code>_pack_dict_with_prefix</code><span class="Apple-converted-space"> </span>(lora_base.py#L316) prepends<span class="Apple-converted-space"> </span><code>transformer.</code><span class="Apple-converted-space"> </span>to every key on save.<span class="Apple-converted-space"> </span><code>ZImageTransformer2DModel.named_modules()</code><span class="Apple-converted-space"> </span>here has no such prefix, so the key-matching loop in<span class="Apple-converted-space"> </span><code>_apply_lora_to_layers</code><span class="Apple-converted-space"> </span>(lora_pipeline.py#L436-L438) skips every single entry. No error, no warning surfaced to the user — just a silent no-op.</p><p style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">Qwen-Image has the same situation and it's already handled in this file via<span class="Apple-converted-space"> </span><code>_convert_qwen_image_standard</code>. This PR adds the equivalent path for Z-Image.</p><h3 style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">Repro before the PR</h3><pre style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><code class="language-python"># train any Z-Image LoRA with diffusers + PEFT
ZImagePipeline.save_lora_weights(
    save_dir,
    transformer_lora_layers=get_peft_model_state_dict(transformer, adapter_name="char"),
)
# serve that file via SGLang, POST /v1/set_lora + /v1/merge_lora_weights
# → output identical to no-LoRA baseline
</code></pre><h2 style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">Modifications</h2><p style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><code>python/sglang/multimodal_gen/runtime/pipelines_core/lora_format_adapter.py</code></p><ul style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><li><code>_looks_like_zimage_diffusers</code><span class="Apple-converted-space"> </span>— detects the format. Requires<span class="Apple-converted-space"> </span><code>transformer.</code><span class="Apple-converted-space"> </span>prefix,<span class="Apple-converted-space"> </span><code>.lora_A/B</code><span class="Apple-converted-space"> </span>substring,<span class="Apple-converted-space"> </span><strong>and</strong><span class="Apple-converted-space"> </span>a Z-Image specific branch (<code>noise_refiner</code><span class="Apple-converted-space"> </span>or<span class="Apple-converted-space"> </span><code>context_refiner</code>). The last condition keeps this from firing on Qwen-Image or any other diffusers LoRA that happens to have the<span class="Apple-converted-space"> </span><code>transformer.</code><span class="Apple-converted-space"> </span>prefix.</li><li><code>_convert_zimage_diffusers_standard</code><span class="Apple-converted-space"> </span>— drops the<span class="Apple-converted-space"> </span><code>transformer.</code><span class="Apple-converted-space"> </span>prefix. That's it.</li><li>Dispatched from<span class="Apple-converted-space"> </span><code>convert_lora_state_dict_by_format</code><span class="Apple-converted-space"> </span>in the STANDARD branch, right after the Qwen-Image check.</li></ul><p style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><code>python/sglang/multimodal_gen/test/unit/test_lora_format_adapter.py</code></p><ul style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><li><code>test_zimage_diffusers_peft_prefix_stripped</code><span class="Apple-converted-space"> </span>— builds a minimal state dict matching diffusers PEFT output (72 keys, covers<span class="Apple-converted-space"> </span><code>layers</code><span class="Apple-converted-space"> </span>/<span class="Apple-converted-space"> </span><code>noise_refiner</code><span class="Apple-converted-space"> </span>/<span class="Apple-converted-space"> </span><code>context_refiner</code><span class="Apple-converted-space"> </span>× attention + feed_forward), runs<span class="Apple-converted-space"> </span><code>normalize_lora_state_dict</code>, asserts the prefix is gone and tensor shapes are preserved. No HF download needed.</li></ul><h2 style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">Accuracy Tests</h2><p style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">Verified end-to-end on a rank-32 Z-Image-Turbo character LoRA, seed 42, 9 steps, CFG 0.0:</p>
  | baseline md5 | with LoRA md5
-- | -- | --
before PR, strength=0.85 | 3d1065a4 | 3d1065a4 (no effect)
before PR, strength=1.0 | 3d1065a4 | 3d1065a4 (no effect)
after PR, strength=0.5 | 3d1065a4 | e2d2f74a
after PR, strength=0.85 | 3d1065a4 | 74fc4fac
after PR, strength=1.0 | 3d1065a4 | 1a286cb0

<p style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">Before: baseline and LoRA outputs are the same file. After: each strength produces a distinct image and the expected character identity shows up.</p><h2 style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">Speed Tests and Profiling</h2><p style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">Not applicable. One extra prefix check at LoRA load time, runs once per file, not per request.</p><h2 style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">Checklist</h2><ul style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><li>[x] pre-commit hooks pass</li><li>[x] unit test added</li><li>[ ] docs — not needed, fix is transparent to users</li><li>[x] accuracy numbers above</li><li>[x] matches the existing<span class="Apple-converted-space"> </span><code>_convert_qwen_image_standard</code><span class="Apple-converted-space"> </span>structure</li></ul>