### PR TITLE
feat: add radix KV events for SWA and Mamba

### DIFF
--- a/python/sglang/srt/mem_cache/kv_cache_events.py
+++ b/python/sglang/srt/mem_cache/kv_cache_events.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+from sglang.srt.disaggregation.kv_events import (
+    AllBlocksCleared,
+    BlockRemoved,
+    BlockStored,
+)
+from sglang.srt.mem_cache.hicache_storage import get_hash_str, hash_str_to_int64
+
+
+def compute_node_hash_values(node: Any, page_size: int) -> List[str]:
+    hash_values = []
+
+    parent_hash = None
+    if node.parent is not None and node.parent.hash_value is not None:
+        if len(node.parent.key) > 0 and len(node.parent.hash_value) > 0:
+            parent_hash = node.parent.hash_value[-1]
+
+    for start in range(0, len(node.key), page_size):
+        page_tokens = node.key.token_ids[start : start + page_size]
+        if not page_tokens:
+            continue
+
+        hash_val = get_hash_str(page_tokens, prior_hash=parent_hash)
+        hash_values.append(hash_val)
+        parent_hash = hash_val
+
+    return hash_values
+
+
+def split_node_hash_value(
+    child_hash_value: Optional[List[str]], split_len: int, page_size: int
+) -> tuple[Optional[List[str]], Optional[List[str]]]:
+    if child_hash_value is None:
+        return None, None
+
+    if page_size == 1:
+        split_pages = split_len
+    else:
+        split_pages = split_len // page_size
+
+    new_node_hash = child_hash_value[:split_pages]
+    child_hash = child_hash_value[split_pages:]
+
+    return new_node_hash, child_hash
+
+
+class KVCacheEventMixin:
+    def _init_kv_cache_events(self, enable_kv_cache_events: bool) -> None:
+        self.enable_kv_cache_events = enable_kv_cache_events
+        self.kv_event_queue = []
+
+    def _ensure_hash_value(self, node: Optional[Any]) -> None:
+        if node is None or node.hash_value is not None:
+            return
+        self._ensure_hash_value(node.parent)
+        node.hash_value = compute_node_hash_values(node, self.page_size)
+
+    def _record_store_event(self, node: Any) -> None:
+        if not self.enable_kv_cache_events:
+            return
+
+        self._ensure_hash_value(node.parent)
+        self._ensure_hash_value(node)
+
+        parent_block_hash = None
+        if node.parent is not None and node.parent != self.root_node:
+            if node.parent.hash_value is not None and len(node.parent.hash_value) > 0:
+                parent_block_hash = hash_str_to_int64(node.parent.hash_value[-1])
+
+        page_index = 0
+        for start in range(0, len(node.key), self.page_size):
+            page_tokens = node.key.token_ids[start : start + self.page_size]
+            if not page_tokens:
+                continue
+
+            block_hash = hash_str_to_int64(node.hash_value[page_index])
+            self.kv_event_queue.append(
+                BlockStored(
+                    block_hashes=[block_hash],
+                    parent_block_hash=parent_block_hash,
+                    token_ids=page_tokens,
+                    block_size=len(page_tokens),
+                    lora_id=None,
+                )
+            )
+
+            parent_block_hash = block_hash
+            page_index += 1
+
+    def _record_remove_event(self, node: Any) -> None:
+        if not self.enable_kv_cache_events:
+            return
+
+        self._ensure_hash_value(node)
+
+        page_index = 0
+        for start in range(0, len(node.key), self.page_size):
+            page_tokens = node.key.token_ids[start : start + self.page_size]
+            if not page_tokens:
+                continue
+
+            block_hash = hash_str_to_int64(node.hash_value[page_index])
+            self.kv_event_queue.append(BlockRemoved(block_hashes=[block_hash]))
+            page_index += 1
+
+    def _record_all_cleared_event(self) -> None:
+        if self.enable_kv_cache_events:
+            self.kv_event_queue.append(AllBlocksCleared())
+
+    def take_events(self):
+        if not self.enable_kv_cache_events:
+            return []
+        events = self.kv_event_queue
+        self.kv_event_queue = []
+        return events

--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -42,6 +42,10 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     MatchPrefixParams,
     MatchResult,
 )
+from sglang.srt.mem_cache.kv_cache_events import (
+    KVCacheEventMixin,
+    split_node_hash_value,
+)
 from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool
 from sglang.srt.mem_cache.radix_cache import (
     RadixKey,
@@ -84,6 +88,8 @@ class TreeNode:
         self.hit_count = 0
         # store the host indices of KV cache
         self.host_value = None
+        # store hash values of each full-KV page
+        self.hash_value: Optional[List[str]] = None
 
         # for lru list, invariant:
         # 1. prev has greater last_access_time
@@ -368,7 +374,7 @@ class LRUList:
                 raise Exception(msg)
 
 
-class MambaRadixCache(BasePrefixCache):
+class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
     def __init__(self, params: CacheInitParams):
         assert isinstance(
             params.token_to_kv_pool_allocator, TokenToKVPoolAllocator
@@ -379,6 +385,7 @@ class MambaRadixCache(BasePrefixCache):
         self.page_size = params.page_size
         self.disable = params.disable
         self.enable_mamba_extra_buffer = params.enable_mamba_extra_buffer
+        self._init_kv_cache_events(params.enable_kv_cache_events)
 
         if not self.enable_mamba_extra_buffer:
             assert (
@@ -412,6 +419,7 @@ class MambaRadixCache(BasePrefixCache):
         self.root_node = TreeNode()
         self.root_node.key = RadixKey([], None)
         self.root_node.value = []
+        self.root_node.hash_value = []
         self.root_node.full_lock_ref = 1
         self.root_node.mamba_lock_ref = 1
         self.full_evictable_size_ = 0
@@ -421,6 +429,7 @@ class MambaRadixCache(BasePrefixCache):
         # LRU lists are used to maintain the order of eviction of the nodes in the tree
         self.full_lru_list = LRUList(mamba=False)
         self.mamba_lru_list = LRUList(mamba=True)
+        self._record_all_cleared_event()
 
     def match_prefix(self, params: MatchPrefixParams) -> MatchResult:
         """Find the matching prefix from the radix tree.
@@ -745,6 +754,7 @@ class MambaRadixCache(BasePrefixCache):
         self.mamba_lru_list.remove_node(x)
 
         # 3. delete the leaf node
+        self._record_remove_event(x)
         self._delete_leaf(x)
 
         # 4. Iteratively delete tombstone leaves to maintain invariant that leaf nodes are not tombstone
@@ -1038,6 +1048,9 @@ class MambaRadixCache(BasePrefixCache):
         child.key = child.key[split_len:]
         child.value = child.value[split_len:].clone()
         new_node.parent.children[self.get_child_key_fn(key)] = new_node
+        new_node.hash_value, child.hash_value = split_node_hash_value(
+            child.hash_value, split_len, self.page_size
+        )
 
         # insert the new node and child into the lru lists, insert
         # parent first so that parent is after child in the lru list
@@ -1098,6 +1111,7 @@ class MambaRadixCache(BasePrefixCache):
             node.children[child_key] = new_node
             self.full_evictable_size_ += len(value)
             self.mamba_evictable_size_ += len(mamba_value)
+            self._record_store_event(new_node)
         elif node.mamba_value is None:  # add for mamba tombstone
             node.mamba_value = mamba_value
             self.full_lru_list.reset_node_mru(node)
@@ -1127,6 +1141,7 @@ class MambaRadixCache(BasePrefixCache):
                 node.parent.mamba_lock_ref == 0
             ), f"tombstone mamba_lock_ref should always be 0, {node.parent.full_lock_ref=}, {node.parent.mamba_lock_ref=}, {node.parent.id=}"
             # delete tombstone node evicts full tokens
+            self._record_remove_event(node.parent)
             self.token_to_kv_pool_allocator.free(node.parent.value)
             full_num_evicted += len(node.parent.value)
             self.full_lru_list.remove_node(node.parent)

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -34,11 +34,6 @@ import torch
 
 logger = logging.getLogger(__name__)
 
-from sglang.srt.disaggregation.kv_events import (
-    AllBlocksCleared,
-    BlockRemoved,
-    BlockStored,
-)
 from sglang.srt.mem_cache.base_prefix_cache import (
     BasePrefixCache,
     EvictParams,
@@ -57,7 +52,11 @@ from sglang.srt.mem_cache.evict_policy import (
     MRUStrategy,
     PriorityStrategy,
 )
-from sglang.srt.mem_cache.hicache_storage import get_hash_str, hash_str_to_int64
+from sglang.srt.mem_cache.kv_cache_events import KVCacheEventMixin
+from sglang.srt.mem_cache.kv_cache_events import (
+    compute_node_hash_values as compute_node_hash_values,
+)
+from sglang.srt.mem_cache.kv_cache_events import split_node_hash_value
 
 if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import Req
@@ -197,78 +196,16 @@ def get_child_key(key: RadixKey, page_size: int = 1):
         return (key.extra_key, plain_key)
 
 
-def compute_node_hash_values(node: "TreeNode", page_size: int) -> List[str]:
-    """Compute SHA256-based hash values for position-aware identification.
-
-    Args:
-        node: The TreeNode to compute hash values for
-        page_size: The page size for chunking tokens
-
-    Returns:
-        List of SHA256 hex strings, one per page
-    """
-    hash_values = []
-
-    # Get parent's last hash value if parent exists
-    parent_hash = None
-    if node.parent is not None and node.parent.hash_value is not None:
-        # Check if parent is root by checking if it has empty key
-        if len(node.parent.key) > 0 and len(node.parent.hash_value) > 0:
-            parent_hash = node.parent.hash_value[-1]
-
-    # Iterate through node's pages
-    for start in range(0, len(node.key), page_size):
-        page_tokens = node.key.token_ids[start : start + page_size]
-        if not page_tokens:
-            continue
-
-        # Use SHA256-based chaining via get_hash_str
-        hash_val = get_hash_str(page_tokens, prior_hash=parent_hash)
-        hash_values.append(hash_val)
-        parent_hash = hash_val
-
-    return hash_values
-
-
-def split_node_hash_value(
-    child_hash_value: Optional[List[str]], split_len: int, page_size: int
-) -> tuple[Optional[List[str]], Optional[List[str]]]:
-    """Split hash_value between parent and child nodes during node splitting.
-
-    Args:
-        child_hash_value: The hash_value list from the child node being split
-        split_len: The length at which to split (in tokens)
-        page_size: The page size for calculating number of pages
-
-    Returns:
-        Tuple of (new_node_hash_value, updated_child_hash_value)
-    """
-    if child_hash_value is None:
-        return None, None
-
-    if page_size == 1:
-        split_pages = split_len
-    else:
-        split_pages = split_len // page_size
-
-    new_node_hash = child_hash_value[:split_pages]
-    child_hash = child_hash_value[split_pages:]
-
-    return new_node_hash, child_hash
-
-
-class RadixCache(BasePrefixCache):
+class RadixCache(KVCacheEventMixin, BasePrefixCache):
     def __init__(self, params: CacheInitParams):
         self.disable = params.disable
         self.req_to_token_pool = params.req_to_token_pool
         self.token_to_kv_pool_allocator = params.token_to_kv_pool_allocator
         self.page_size = params.page_size
-        self.enable_kv_cache_events = params.enable_kv_cache_events
+        self._init_kv_cache_events(params.enable_kv_cache_events)
         self.is_eagle = params.is_eagle
         self.disable_finished_insert = params.disable_finished_insert
         self.eviction_policy = params.eviction_policy.lower()
-
-        self.kv_event_queue = []
 
         if params.enable_metrics:
             self.init_metrics_collector()
@@ -781,78 +718,6 @@ class RadixCache(BasePrefixCache):
                 stack.extend(cur_node.children.values())
 
         return ret_list
-
-    def _record_store_event(self, node: TreeNode):
-        # One BlockStored per ``page_size`` chunk.
-        if self.enable_kv_cache_events:
-            # Compute hash_value lazily if not already set
-            if node.hash_value is None:
-                node.hash_value = compute_node_hash_values(node, self.page_size)
-
-            # Get parent's last hash value for first page
-            parent_block_hash = None
-            if node.parent is not None and node.parent != self.root_node:
-                if (
-                    node.parent.hash_value is not None
-                    and len(node.parent.hash_value) > 0
-                ):
-                    parent_block_hash = hash_str_to_int64(node.parent.hash_value[-1])
-
-            page_index = 0
-            for start in range(0, len(node.key), self.page_size):
-                page_tokens = node.key.token_ids[start : start + self.page_size]
-                if not page_tokens:
-                    continue
-
-                block_hash = hash_str_to_int64(node.hash_value[page_index])
-
-                self.kv_event_queue.append(
-                    BlockStored(
-                        block_hashes=[block_hash],
-                        parent_block_hash=parent_block_hash,
-                        token_ids=page_tokens,
-                        block_size=len(page_tokens),
-                        lora_id=None,
-                    )
-                )
-
-                parent_block_hash = block_hash
-                page_index += 1
-
-    def _record_remove_event(self, node: TreeNode):
-        # One BlockRemoved per chunk.
-        if self.enable_kv_cache_events:
-            # Compute hash_value lazily if not already set (must match what was stored)
-            if node.hash_value is None:
-                node.hash_value = compute_node_hash_values(node, self.page_size)
-
-            page_index = 0
-            for start in range(0, len(node.key), self.page_size):
-                page_tokens = node.key.token_ids[start : start + self.page_size]
-                if not page_tokens:
-                    continue
-
-                block_hash = hash_str_to_int64(node.hash_value[page_index])
-
-                self.kv_event_queue.append(BlockRemoved(block_hashes=[block_hash]))
-
-                page_index += 1
-
-    def _record_all_cleared_event(self):
-        if self.enable_kv_cache_events:
-            self.kv_event_queue.append(AllBlocksCleared())
-
-    def take_events(self):
-        """Atomically takes all events and clears the queue.
-
-        Returns:
-            A list of KV cache events.
-        """
-        if not self.enable_kv_cache_events:
-            return []
-        events = self.kv_event_queue
-        self.kv_event_queue = []
-        return events
 
 
 if __name__ == "__main__":

--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
@@ -28,6 +28,11 @@ from typing import TYPE_CHECKING, List, Optional, Tuple
 import torch
 from numpy import float64
 
+from sglang.srt.disaggregation.kv_events import (
+    AllBlocksCleared,
+    BlockRemoved,
+    BlockStored,
+)
 from sglang.srt.environ import envs
 from sglang.srt.mem_cache.base_prefix_cache import (
     BasePrefixCache,
@@ -39,11 +44,14 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     MatchResult,
 )
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.hicache_storage import hash_str_to_int64
 from sglang.srt.mem_cache.radix_cache import (
     RadixKey,
     _key_match_page_size1,
     _key_match_paged,
+    compute_node_hash_values,
     get_child_key,
+    split_node_hash_value,
 )
 from sglang.srt.mem_cache.swa_memory_pool import SWATokenToKVPoolAllocator
 from sglang.srt.mem_cache.utils import convert_to_bigram_key
@@ -80,6 +88,8 @@ class TreeNode:
         self.hit_count = 0
         # store the host indices of KV cache
         self.host_value = None
+        # store hash values of each page
+        self.hash_value: Optional[List[str]] = None
 
         # for lru list, invariant:
         # 1. prev has greater last_access_time
@@ -345,6 +355,8 @@ class SWARadixCache(BasePrefixCache):
         self.page_size = params.page_size
         self.disable = params.disable
         self.is_eagle = params.is_eagle
+        self.enable_kv_cache_events = params.enable_kv_cache_events
+        self.kv_event_queue = []
 
         if self.token_to_kv_pool_allocator:
             self.device = self.token_to_kv_pool_allocator.device
@@ -381,6 +393,7 @@ class SWARadixCache(BasePrefixCache):
         self.root_node = TreeNode()
         self.root_node.key = []
         self.root_node.value = []
+        self.root_node.hash_value = []
         self.root_node.full_lock_ref = 1
         self.root_node.swa_lock_ref = 1
         self.full_evictable_size_ = 0
@@ -390,6 +403,7 @@ class SWARadixCache(BasePrefixCache):
         # LRU lists are used to maintain the order of eviction of the nodes in the tree
         self.full_lru_list = LRUList(is_swa_list=False)
         self.swa_lru_list = LRUList(is_swa_list=True)
+        self._record_all_cleared_event()
 
     def match_prefix(self, params: MatchPrefixParams) -> MatchResult:
         """Find the matching prefix from the radix tree.
@@ -634,6 +648,7 @@ class SWARadixCache(BasePrefixCache):
                 assert x.full_lock_ref == 0, f"node is in use, {x.id=}"
 
                 # 1. free node kv indices, evict full and swa tokens
+                self._record_remove_event(x)
                 self.token_to_kv_pool_allocator.free(x.value)
                 full_num_evicted += len(x.value)
                 swa_num_evicted += len(x.value)
@@ -683,6 +698,7 @@ class SWARadixCache(BasePrefixCache):
                         x.full_lock_ref == 0
                     ), f"leaf node with full lock must also have swa lock, {x.id=}"
                     # 1. a leaf node, free full and swa tokens
+                    self._record_remove_event(x)
                     self.token_to_kv_pool_allocator.free(x.value)
                     full_num_evicted += len(x.value)
                     swa_num_evicted += len(x.value)
@@ -930,6 +946,11 @@ class SWARadixCache(BasePrefixCache):
             if child.swa_uuid is not None:
                 node.swa_uuid = child.swa_uuid
 
+            if node.hash_value is not None and child.hash_value is not None:
+                node.hash_value = list(node.hash_value) + list(child.hash_value)
+            else:
+                node.hash_value = None
+
             self.full_lru_list.remove_node(child)
             if not child.swa_tombstone:
                 self.swa_lru_list.remove_node(child)
@@ -960,6 +981,10 @@ class SWARadixCache(BasePrefixCache):
         assert len(child.key) > 0, f"child.key should not be empty"
         child.value = child.value[split_len:].clone()
         new_node.parent.children[self.get_child_key_fn(key)] = new_node
+
+        new_node.hash_value, child.hash_value = split_node_hash_value(
+            child.hash_value, split_len, self.page_size
+        )
 
         # insert the new node and child into the lru lists, insert
         # parent first so that parent is after child in the lru list
@@ -1059,7 +1084,6 @@ class SWARadixCache(BasePrefixCache):
                 f"Has Additional Node: len(key)={len(key)}, total_prefix_length={total_prefix_length}, swa_evicted_seqlen={swa_evicted_seqlen}, len(value)={len(value)}"
             )
 
-
             if swa_evicted_seqlen == total_prefix_length + len(key):
                 self.token_to_kv_pool_allocator.free(value)
                 return total_prefix_length
@@ -1100,6 +1124,7 @@ class SWARadixCache(BasePrefixCache):
         if not swa_tombstone:
             self.swa_lru_list.insert_mru(new_node)
             self.swa_evictable_size_ += len(value)
+        self._record_store_event(new_node)
         return new_node
 
     def _iteratively_delete_tombstone_leaf(
@@ -1107,21 +1132,23 @@ class SWARadixCache(BasePrefixCache):
     ) -> Tuple[TreeNode, int]:
         full_num_evicted = 0
         while node.parent.swa_tombstone and len(node.parent.children) == 0:
+            parent = node.parent
             # root node is not evictable
-            if node.parent == self.root_node:
+            if parent == self.root_node:
                 break
             # if locked, means node is in use, skip
-            if node.parent.full_lock_ref > 0:
+            if parent.full_lock_ref > 0:
                 break
             assert (
-                node.parent.swa_lock_ref == 0
-            ), f"tombstone swa_lock_ref should always be 0, {node.parent.full_lock_ref=}, {node.parent.swa_lock_ref=}, {node.parent.id=}"
+                parent.swa_lock_ref == 0
+            ), f"tombstone swa_lock_ref should always be 0, {parent.full_lock_ref=}, {parent.swa_lock_ref=}, {parent.id=}"
             # delete tombstone node evicts full tokens
-            self.token_to_kv_pool_allocator.free(node.parent.value)
-            full_num_evicted += len(node.parent.value)
-            self.full_lru_list.remove_node(node.parent)
-            self._delete_tombstone_leaf(node.parent)
-            node = node.parent
+            self._record_remove_event(parent)
+            self.token_to_kv_pool_allocator.free(parent.value)
+            full_num_evicted += len(parent.value)
+            self.full_lru_list.remove_node(parent)
+            self._delete_tombstone_leaf(parent)
+            node = parent
 
         return node, full_num_evicted
 
@@ -1185,6 +1212,71 @@ class SWARadixCache(BasePrefixCache):
             ret_list.append(cur_node)
             stack.extend(cur_node.children.values())
         return ret_list
+
+    def _ensure_hash_value(self, node: Optional[TreeNode]) -> None:
+        if node is None or node.hash_value is not None:
+            return
+        self._ensure_hash_value(node.parent)
+        node.hash_value = compute_node_hash_values(node, self.page_size)
+
+    def _record_store_event(self, node: TreeNode) -> None:
+        if not self.enable_kv_cache_events:
+            return
+
+        self._ensure_hash_value(node.parent)
+        self._ensure_hash_value(node)
+
+        parent_block_hash = None
+        if node.parent is not None and node.parent != self.root_node:
+            if node.parent.hash_value is not None and len(node.parent.hash_value) > 0:
+                parent_block_hash = hash_str_to_int64(node.parent.hash_value[-1])
+
+        page_index = 0
+        for start in range(0, len(node.key), self.page_size):
+            page_tokens = node.key.token_ids[start : start + self.page_size]
+            if not page_tokens:
+                continue
+
+            block_hash = hash_str_to_int64(node.hash_value[page_index])
+            self.kv_event_queue.append(
+                BlockStored(
+                    block_hashes=[block_hash],
+                    parent_block_hash=parent_block_hash,
+                    token_ids=page_tokens,
+                    block_size=len(page_tokens),
+                    lora_id=None,
+                )
+            )
+
+            parent_block_hash = block_hash
+            page_index += 1
+
+    def _record_remove_event(self, node: TreeNode) -> None:
+        if not self.enable_kv_cache_events:
+            return
+
+        self._ensure_hash_value(node)
+
+        page_index = 0
+        for start in range(0, len(node.key), self.page_size):
+            page_tokens = node.key.token_ids[start : start + self.page_size]
+            if not page_tokens:
+                continue
+
+            block_hash = hash_str_to_int64(node.hash_value[page_index])
+            self.kv_event_queue.append(BlockRemoved(block_hashes=[block_hash]))
+            page_index += 1
+
+    def _record_all_cleared_event(self) -> None:
+        if self.enable_kv_cache_events:
+            self.kv_event_queue.append(AllBlocksCleared())
+
+    def take_events(self):
+        if not self.enable_kv_cache_events:
+            return []
+        events = self.kv_event_queue
+        self.kv_event_queue = []
+        return events
 
     def _print_helper(self, node: TreeNode, indent: int) -> None:
         """Prints the radix tree in a human-readable format."""

--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
@@ -28,11 +28,6 @@ from typing import TYPE_CHECKING, List, Optional, Tuple
 import torch
 from numpy import float64
 
-from sglang.srt.disaggregation.kv_events import (
-    AllBlocksCleared,
-    BlockRemoved,
-    BlockStored,
-)
 from sglang.srt.environ import envs
 from sglang.srt.mem_cache.base_prefix_cache import (
     BasePrefixCache,
@@ -44,14 +39,15 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     MatchResult,
 )
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
-from sglang.srt.mem_cache.hicache_storage import hash_str_to_int64
+from sglang.srt.mem_cache.kv_cache_events import (
+    KVCacheEventMixin,
+    split_node_hash_value,
+)
 from sglang.srt.mem_cache.radix_cache import (
     RadixKey,
     _key_match_page_size1,
     _key_match_paged,
-    compute_node_hash_values,
     get_child_key,
-    split_node_hash_value,
 )
 from sglang.srt.mem_cache.swa_memory_pool import SWATokenToKVPoolAllocator
 from sglang.srt.mem_cache.utils import convert_to_bigram_key
@@ -347,7 +343,7 @@ class LRUList:
             raise Exception(msg)
 
 
-class SWARadixCache(BasePrefixCache):
+class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
     def __init__(self, params: CacheInitParams):
         assert isinstance(params.token_to_kv_pool_allocator, SWATokenToKVPoolAllocator)
         self.req_to_token_pool = params.req_to_token_pool
@@ -355,8 +351,7 @@ class SWARadixCache(BasePrefixCache):
         self.page_size = params.page_size
         self.disable = params.disable
         self.is_eagle = params.is_eagle
-        self.enable_kv_cache_events = params.enable_kv_cache_events
-        self.kv_event_queue = []
+        self._init_kv_cache_events(params.enable_kv_cache_events)
 
         if self.token_to_kv_pool_allocator:
             self.device = self.token_to_kv_pool_allocator.device
@@ -1212,71 +1207,6 @@ class SWARadixCache(BasePrefixCache):
             ret_list.append(cur_node)
             stack.extend(cur_node.children.values())
         return ret_list
-
-    def _ensure_hash_value(self, node: Optional[TreeNode]) -> None:
-        if node is None or node.hash_value is not None:
-            return
-        self._ensure_hash_value(node.parent)
-        node.hash_value = compute_node_hash_values(node, self.page_size)
-
-    def _record_store_event(self, node: TreeNode) -> None:
-        if not self.enable_kv_cache_events:
-            return
-
-        self._ensure_hash_value(node.parent)
-        self._ensure_hash_value(node)
-
-        parent_block_hash = None
-        if node.parent is not None and node.parent != self.root_node:
-            if node.parent.hash_value is not None and len(node.parent.hash_value) > 0:
-                parent_block_hash = hash_str_to_int64(node.parent.hash_value[-1])
-
-        page_index = 0
-        for start in range(0, len(node.key), self.page_size):
-            page_tokens = node.key.token_ids[start : start + self.page_size]
-            if not page_tokens:
-                continue
-
-            block_hash = hash_str_to_int64(node.hash_value[page_index])
-            self.kv_event_queue.append(
-                BlockStored(
-                    block_hashes=[block_hash],
-                    parent_block_hash=parent_block_hash,
-                    token_ids=page_tokens,
-                    block_size=len(page_tokens),
-                    lora_id=None,
-                )
-            )
-
-            parent_block_hash = block_hash
-            page_index += 1
-
-    def _record_remove_event(self, node: TreeNode) -> None:
-        if not self.enable_kv_cache_events:
-            return
-
-        self._ensure_hash_value(node)
-
-        page_index = 0
-        for start in range(0, len(node.key), self.page_size):
-            page_tokens = node.key.token_ids[start : start + self.page_size]
-            if not page_tokens:
-                continue
-
-            block_hash = hash_str_to_int64(node.hash_value[page_index])
-            self.kv_event_queue.append(BlockRemoved(block_hashes=[block_hash]))
-            page_index += 1
-
-    def _record_all_cleared_event(self) -> None:
-        if self.enable_kv_cache_events:
-            self.kv_event_queue.append(AllBlocksCleared())
-
-    def take_events(self):
-        if not self.enable_kv_cache_events:
-            return []
-        events = self.kv_event_queue
-        self.kv_event_queue = []
-        return events
 
     def _print_helper(self, node: TreeNode, indent: int) -> None:
         """Prints the radix tree in a human-readable format."""

--- a/test/registered/radix_cache/test_mamba_unittest.py
+++ b/test/registered/radix_cache/test_mamba_unittest.py
@@ -3,6 +3,7 @@ import unittest
 import torch
 
 from sglang.srt.configs.mamba_utils import Mamba2CacheParams, Mamba2StateShape
+from sglang.srt.disaggregation.kv_events import BlockRemoved, BlockStored
 from sglang.srt.environ import envs
 from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.mem_cache.allocator import TokenToKVPoolAllocator
@@ -31,6 +32,219 @@ class TestMamba(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         pass
+
+    def _create_mamba_radix_cache(self, enable_kv_cache_events=False):
+        set_global_server_args_for_scheduler(
+            ServerArgs(model_path="dummy", page_size=1)
+        )
+
+        size = 128
+        dtype = torch.bfloat16
+        head_num = 2
+        head_dim = 64
+        num_layers = 8
+        global_interval = 4
+        max_num_reqs = 10
+        mamba_cache_size = 20
+        max_context_len = 128
+        device = "cuda"
+        full_attention_layer_ids = [
+            i for i in range(global_interval - 1, num_layers, global_interval)
+        ]
+        mamba_layers = [
+            i for i in range(num_layers) if i not in full_attention_layer_ids
+        ]
+        with envs.SGLANG_MAMBA_SSM_DTYPE.override("bfloat16"):
+            shape = Mamba2StateShape.create(
+                tp_world_size=1,
+                intermediate_size=128,
+                n_groups=2,
+                num_heads=2,
+                head_dim=64,
+                state_size=16,
+                conv_kernel=4,
+            )
+            mamba2_cache_params = Mamba2CacheParams(shape=shape, layers=mamba_layers)
+
+        req_to_token_pool = HybridReqToTokenPool(
+            size=max_num_reqs,
+            mamba_size=mamba_cache_size,
+            mamba_spec_state_size=max_num_reqs,
+            max_context_len=max_context_len,
+            device=device,
+            enable_memory_saver=False,
+            cache_params=mamba2_cache_params,
+            enable_mamba_extra_buffer=False,
+            speculative_num_draft_tokens=3,
+        )
+        pool = HybridLinearKVPool(
+            size=size,
+            dtype=dtype,
+            page_size=1,
+            head_num=head_num,
+            head_dim=head_dim,
+            full_attention_layer_ids=full_attention_layer_ids,
+            enable_kvcache_transpose=False,
+            device=device,
+            enable_memory_saver=False,
+            mamba_pool=req_to_token_pool.mamba_pool,
+        )
+        allocator = TokenToKVPoolAllocator(
+            size=size,
+            dtype=dtype,
+            device=device,
+            kvcache=pool,
+            need_sort=False,
+        )
+        tree = MambaRadixCache(
+            params=CacheInitParams(
+                req_to_token_pool=req_to_token_pool,
+                token_to_kv_pool_allocator=allocator,
+                page_size=1,
+                disable=False,
+                enable_kv_cache_events=enable_kv_cache_events,
+            )
+        )
+        return tree, allocator, req_to_token_pool
+
+    def _insert_mamba(self, tree, allocator, req_to_token_pool, token_ids):
+        kv_indices = allocator.alloc(len(token_ids))
+        self.assertIsNotNone(kv_indices)
+        mamba_value = req_to_token_pool.mamba_pool.alloc(1)
+        self.assertIsNotNone(mamba_value)
+        tree.insert(
+            InsertParams(
+                key=RadixKey(token_ids),
+                value=kv_indices,
+                mamba_value=mamba_value,
+            )
+        )
+
+    def test_mamba_kv_cache_events_store_full_blocks(self):
+        tree, allocator, req_to_token_pool = self._create_mamba_radix_cache(
+            enable_kv_cache_events=True
+        )
+        tree.take_events()
+
+        self._insert_mamba(tree, allocator, req_to_token_pool, [1, 2, 3])
+
+        events = tree.take_events()
+        stored_events = [e for e in events if isinstance(e, BlockStored)]
+        self.assertEqual(len(stored_events), 3)
+        self.assertEqual([e.token_ids for e in stored_events], [[1], [2], [3]])
+        self.assertIsNone(stored_events[0].parent_block_hash)
+        self.assertEqual(
+            stored_events[1].parent_block_hash,
+            stored_events[0].block_hashes[0],
+        )
+        self.assertEqual(
+            stored_events[2].parent_block_hash,
+            stored_events[1].block_hashes[0],
+        )
+
+    def test_mamba_kv_cache_events_ignore_mamba_tombstone(self):
+        tree, allocator, req_to_token_pool = self._create_mamba_radix_cache(
+            enable_kv_cache_events=True
+        )
+        tree.take_events()
+
+        self._insert_mamba(tree, allocator, req_to_token_pool, [1, 2, 3])
+        self._insert_mamba(tree, allocator, req_to_token_pool, [1, 2, 3, 4])
+        tree.take_events()
+
+        result = tree.evict(EvictParams(num_tokens=0, mamba_num=1))
+
+        self.assertGreaterEqual(result.mamba_num_evicted, 1)
+        events = tree.take_events()
+        self.assertEqual([e for e in events if isinstance(e, BlockRemoved)], [])
+
+    def test_mamba_kv_cache_events_full_eviction_removes(self):
+        tree, allocator, req_to_token_pool = self._create_mamba_radix_cache(
+            enable_kv_cache_events=True
+        )
+        tree.take_events()
+
+        self._insert_mamba(tree, allocator, req_to_token_pool, [10, 11, 12])
+        stored_hashes = [
+            e.block_hashes[0] for e in tree.take_events() if isinstance(e, BlockStored)
+        ]
+
+        result = tree.evict(EvictParams(num_tokens=1))
+
+        self.assertGreaterEqual(result.num_tokens_evicted, 1)
+        removed_hashes = [
+            e.block_hashes[0] for e in tree.take_events() if isinstance(e, BlockRemoved)
+        ]
+        self.assertEqual(removed_hashes, stored_hashes)
+
+    def test_mamba_kv_cache_events_split_preserves_remove_hashes(self):
+        tree, allocator, req_to_token_pool = self._create_mamba_radix_cache(
+            enable_kv_cache_events=True
+        )
+        tree.take_events()
+
+        self._insert_mamba(tree, allocator, req_to_token_pool, [1, 2, 3, 4])
+        first_stored_events = [
+            e for e in tree.take_events() if isinstance(e, BlockStored)
+        ]
+        first_hashes = [e.block_hashes[0] for e in first_stored_events]
+        original_node = tree.root_node.children[1]
+        original_hash_value = list(original_node.hash_value)
+
+        self._insert_mamba(tree, allocator, req_to_token_pool, [1, 2, 9, 10])
+        second_stored_events = [
+            e for e in tree.take_events() if isinstance(e, BlockStored)
+        ]
+        second_hashes = [e.block_hashes[0] for e in second_stored_events]
+
+        shared_node = tree.root_node.children[1]
+        self.assertEqual(shared_node.key.token_ids, [1, 2])
+        self.assertEqual(shared_node.hash_value, original_hash_value[:2])
+        self.assertIn(3, shared_node.children)
+        self.assertIn(9, shared_node.children)
+
+        old_child = shared_node.children[3]
+        new_child = shared_node.children[9]
+        self.assertEqual(old_child.key.token_ids, [3, 4])
+        self.assertEqual(old_child.hash_value, original_hash_value[2:])
+        self.assertEqual(new_child.key.token_ids, [9, 10])
+        self.assertEqual(second_stored_events[0].parent_block_hash, first_hashes[1])
+
+        tree.evict(EvictParams(num_tokens=100))
+
+        removed_hashes = [
+            e.block_hashes[0] for e in tree.take_events() if isinstance(e, BlockRemoved)
+        ]
+        self.assertEqual(len(removed_hashes), len(first_hashes) + len(second_hashes))
+        for block_hash in first_hashes + second_hashes:
+            self.assertIn(block_hash, removed_hashes)
+
+    def test_mamba_kv_cache_events_tombstone_cleanup_removes(self):
+        tree, allocator, req_to_token_pool = self._create_mamba_radix_cache(
+            enable_kv_cache_events=True
+        )
+        tree.take_events()
+
+        self._insert_mamba(tree, allocator, req_to_token_pool, [1, 2, 3])
+        self._insert_mamba(tree, allocator, req_to_token_pool, [1, 2, 3, 4])
+        stored_by_tokens = {
+            tuple(e.token_ids): e.block_hashes[0]
+            for e in tree.take_events()
+            if isinstance(e, BlockStored)
+        }
+
+        tree.evict(EvictParams(num_tokens=0, mamba_num=1))
+        events = tree.take_events()
+        self.assertEqual([e for e in events if isinstance(e, BlockRemoved)], [])
+
+        tree.evict(EvictParams(num_tokens=1))
+
+        removed_hashes = [
+            e.block_hashes[0] for e in tree.take_events() if isinstance(e, BlockRemoved)
+        ]
+        self.assertIn(stored_by_tokens[(4,)], removed_hashes)
+        for token_id in [1, 2, 3]:
+            self.assertIn(stored_by_tokens[(token_id,)], removed_hashes)
 
     def test_hybrid_linear_kv_pool(self):
         size = 16

--- a/test/registered/radix_cache/test_swa_unittest.py
+++ b/test/registered/radix_cache/test_swa_unittest.py
@@ -151,6 +151,47 @@ class TestSWA(unittest.TestCase):
         ]
         self.assertEqual(removed_hashes, stored_hashes)
 
+    def test_swa_kv_cache_events_split_preserves_remove_hashes(self):
+        tree, allocator = self._create_swa_radix_cache(enable_kv_cache_events=True)
+        tree.take_events()
+
+        self._insert_allocated(tree, allocator, [1, 2, 3, 4])
+        first_stored_events = [
+            e for e in tree.take_events() if isinstance(e, BlockStored)
+        ]
+        first_hashes = [e.block_hashes[0] for e in first_stored_events]
+        self.assertIn(1, tree.root_node.children)
+        original_node = tree.root_node.children[1]
+        original_hash_value = list(original_node.hash_value)
+
+        self._insert_allocated(tree, allocator, [1, 2, 9, 10])
+        second_stored_events = [
+            e for e in tree.take_events() if isinstance(e, BlockStored)
+        ]
+        second_hashes = [e.block_hashes[0] for e in second_stored_events]
+
+        shared_node = tree.root_node.children[1]
+        self.assertEqual(shared_node.key.token_ids, [1, 2])
+        self.assertEqual(shared_node.hash_value, original_hash_value[:2])
+        self.assertIn(3, shared_node.children)
+        self.assertIn(9, shared_node.children)
+
+        old_child = shared_node.children[3]
+        new_child = shared_node.children[9]
+        self.assertEqual(old_child.key.token_ids, [3, 4])
+        self.assertEqual(old_child.hash_value, original_hash_value[2:])
+        self.assertEqual(new_child.key.token_ids, [9, 10])
+        self.assertEqual(second_stored_events[0].parent_block_hash, first_hashes[1])
+
+        tree.evict(EvictParams(num_tokens=100, swa_num_tokens=0))
+
+        removed_hashes = [
+            e.block_hashes[0] for e in tree.take_events() if isinstance(e, BlockRemoved)
+        ]
+        self.assertEqual(len(removed_hashes), len(first_hashes) + len(second_hashes))
+        for block_hash in first_hashes + second_hashes:
+            self.assertIn(block_hash, removed_hashes)
+
     def test_swa_kv_cache_events_tombstone_cleanup_removes(self):
         tree, allocator = self._create_swa_radix_cache(enable_kv_cache_events=True)
         tree.take_events()

--- a/test/registered/radix_cache/test_swa_unittest.py
+++ b/test/registered/radix_cache/test_swa_unittest.py
@@ -2,6 +2,7 @@ import unittest
 
 import torch
 
+from sglang.srt.disaggregation.kv_events import BlockRemoved, BlockStored
 from sglang.srt.mem_cache.base_prefix_cache import (
     EvictParams,
     EvictResult,
@@ -27,6 +28,154 @@ class TestSWA(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         pass
+
+    def _create_swa_radix_cache(
+        self,
+        page_size=1,
+        sliding_window_size=4,
+        enable_kv_cache_events=False,
+    ):
+        req_size = 10
+        max_context_len = 128
+        kv_size = 128
+        kv_size_swa = 64
+        head_num = 8
+        head_dim = 128
+        num_layers = 48
+        global_interval = 4
+        dtype = torch.bfloat16
+        device = "cuda"
+        full_attention_layer_ids = [i for i in range(0, num_layers, global_interval)]
+        full_attention_layer_ids_set = set(full_attention_layer_ids)
+        swa_attention_layer_ids = [
+            i for i in range(num_layers) if i not in full_attention_layer_ids_set
+        ]
+        req_to_token_pool = ReqToTokenPool(
+            size=req_size,
+            max_context_len=max_context_len,
+            device=device,
+            enable_memory_saver=False,
+        )
+        kv_pool = SWAKVPool(
+            size=kv_size,
+            size_swa=kv_size_swa,
+            page_size=page_size,
+            dtype=dtype,
+            head_num=head_num,
+            head_dim=head_dim,
+            swa_attention_layer_ids=swa_attention_layer_ids,
+            full_attention_layer_ids=full_attention_layer_ids,
+            enable_kvcache_transpose=False,
+            device=device,
+        )
+        allocator = SWATokenToKVPoolAllocator(
+            size=kv_size,
+            size_swa=kv_size_swa,
+            page_size=page_size,
+            dtype=dtype,
+            device=device,
+            kvcache=kv_pool,
+            need_sort=False,
+        )
+        tree = SWARadixCache(
+            params=CacheInitParams(
+                req_to_token_pool=req_to_token_pool,
+                token_to_kv_pool_allocator=allocator,
+                disable=False,
+                page_size=page_size,
+                sliding_window_size=sliding_window_size,
+                enable_kv_cache_events=enable_kv_cache_events,
+            ),
+        )
+        return tree, allocator
+
+    def _insert_allocated(self, tree, allocator, token_ids):
+        kv_indices = allocator.alloc(len(token_ids))
+        self.assertIsNotNone(kv_indices)
+        tree.insert(InsertParams(key=RadixKey(token_ids), value=kv_indices))
+
+    def test_swa_kv_cache_events_store(self):
+        tree, _ = self._create_swa_radix_cache(
+            page_size=2,
+            enable_kv_cache_events=True,
+        )
+        tree.take_events()
+
+        tree.insert(
+            InsertParams(
+                key=RadixKey([1, 2, 3, 4]),
+                value=torch.tensor([10, 11, 12, 13], dtype=torch.int64, device="cuda"),
+            )
+        )
+
+        events = tree.take_events()
+        stored_events = [e for e in events if isinstance(e, BlockStored)]
+        self.assertEqual(len(stored_events), 2)
+        self.assertEqual(stored_events[0].token_ids, [1, 2])
+        self.assertEqual(stored_events[1].token_ids, [3, 4])
+        self.assertIsNone(stored_events[0].parent_block_hash)
+        self.assertEqual(
+            stored_events[1].parent_block_hash,
+            stored_events[0].block_hashes[0],
+        )
+
+    def test_swa_kv_cache_events_ignore_swa_tombstone(self):
+        tree, allocator = self._create_swa_radix_cache(enable_kv_cache_events=True)
+        tree.take_events()
+
+        self._insert_allocated(tree, allocator, [1, 2, 3, 4])
+        self._insert_allocated(tree, allocator, [1, 2, 3, 4, 5, 6])
+        tree.take_events()
+
+        result = tree.evict(EvictParams(num_tokens=0, swa_num_tokens=1))
+
+        self.assertEqual(result.num_tokens_evicted, 0)
+        self.assertGreaterEqual(result.swa_num_tokens_evicted, 1)
+        events = tree.take_events()
+        self.assertEqual([e for e in events if isinstance(e, BlockRemoved)], [])
+
+    def test_swa_kv_cache_events_full_eviction_removes(self):
+        tree, allocator = self._create_swa_radix_cache(enable_kv_cache_events=True)
+        tree.take_events()
+
+        self._insert_allocated(tree, allocator, [10, 11, 12, 13])
+        stored_hashes = [
+            e.block_hashes[0] for e in tree.take_events() if isinstance(e, BlockStored)
+        ]
+
+        result = tree.evict(EvictParams(num_tokens=1, swa_num_tokens=0))
+
+        self.assertGreaterEqual(result.num_tokens_evicted, 1)
+        removed_hashes = [
+            e.block_hashes[0] for e in tree.take_events() if isinstance(e, BlockRemoved)
+        ]
+        self.assertEqual(removed_hashes, stored_hashes)
+
+    def test_swa_kv_cache_events_tombstone_cleanup_removes(self):
+        tree, allocator = self._create_swa_radix_cache(enable_kv_cache_events=True)
+        tree.take_events()
+
+        self._insert_allocated(tree, allocator, [1, 2, 3, 4])
+        self._insert_allocated(tree, allocator, [1, 2, 3, 4, 5, 6])
+        stored_by_tokens = {
+            tuple(e.token_ids): e.block_hashes[0]
+            for e in tree.take_events()
+            if isinstance(e, BlockStored)
+        }
+
+        tree.evict(EvictParams(num_tokens=0, swa_num_tokens=1))
+        events = tree.take_events()
+        self.assertEqual([e for e in events if isinstance(e, BlockRemoved)], [])
+
+        tree.evict(EvictParams(num_tokens=1, swa_num_tokens=0))
+
+        removed_hashes = [
+            e.block_hashes[0] for e in tree.take_events() if isinstance(e, BlockRemoved)
+        ]
+        self.assertIn(stored_by_tokens[(5,)], removed_hashes)
+        self.assertIn(stored_by_tokens[(6,)], removed_hashes)
+        for token_id in [1, 2, 3, 4]:
+            self.assertIn(stored_by_tokens[(token_id,)], removed_hashes)
 
     def test_swa_memory_pool(self):
         size = 16


### PR DESCRIPTION
Adds opt-in KV event emission to SWARadixCache using the existing event schema and full/main logical prefix lifecycle. SWA-only tombstoning stays silent while full/main eviction and tombstone cleanup emit removes.