### PR TITLE
[PD] Gate disagg event loops on _engine_paused; reject pause(retract) in PD

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1158,6 +1158,8 @@ class SchedulerDisaggregationDecodeMixin:
             # Receive requests
             recv_reqs = self.recv_requests()
             self.process_input_requests(recv_reqs)
+            if self._engine_paused:
+                continue
             # polling and allocating kv cache
             self.process_decode_queue()
 
@@ -1185,6 +1187,8 @@ class SchedulerDisaggregationDecodeMixin:
             # Receive requests
             recv_reqs = self.recv_requests()
             self.process_input_requests(recv_reqs)
+            if self._engine_paused:
+                continue
             # polling and allocating kv cache
             self.process_decode_queue()
 

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -398,6 +398,8 @@ class SchedulerDisaggregationPrefillMixin:
             # Receive requests
             recv_reqs = self.recv_requests()
             self.process_input_requests(recv_reqs)
+            if self._engine_paused:
+                continue
             self.waiting_queue.extend(
                 self.disagg_prefill_bootstrap_queue.pop_bootstrapped()
             )
@@ -429,6 +431,8 @@ class SchedulerDisaggregationPrefillMixin:
             # Receive requests
             recv_reqs = self.recv_requests()
             self.process_input_requests(recv_reqs)
+            if self._engine_paused:
+                continue
             self.waiting_queue.extend(
                 self.disagg_prefill_bootstrap_queue.pop_bootstrapped()
             )

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3315,6 +3315,20 @@ class Scheduler(
         raise NotImplementedError()
 
     def pause_generation(self, recv_req: PauseGenerationReqInput):
+        # PD disaggregation: `retract` has no decode-to-prefill rebootstrap path,
+        # so retracted decode-side requests cannot be re-prefilled under new
+        # weights. Fail fast before mutating any scheduler state to avoid
+        # leaving the engine in a half-paused / inconsistent state that later
+        # crashes inside radix-cache cleanup on flush_cache.
+        assert not (
+            recv_req.mode == "retract"
+            and self.disaggregation_mode != DisaggregationMode.NULL
+        ), (
+            "pause_generation(mode='retract') is not supported in PD "
+            "disaggregation mode yet. Decode-side retracted requests need "
+            "a rebootstrap path back to prefill."
+        )
+
         self._engine_paused = True
 
         if recv_req.mode == "in_place":

--- a/test/registered/unit/managers/test_scheduler_pause_generation.py
+++ b/test/registered/unit/managers/test_scheduler_pause_generation.py
@@ -7,6 +7,7 @@ from sglang.test.test_utils import maybe_stub_sgl_kernel
 
 maybe_stub_sgl_kernel()
 
+from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.managers.io_struct import PauseGenerationReqInput
 from sglang.srt.managers.scheduler import Scheduler
 
@@ -21,6 +22,7 @@ class TestSchedulerPauseGeneration(unittest.TestCase):
         scheduler.last_batch = None
         scheduler.cur_batch = None
         scheduler.chunked_req = None
+        scheduler.disaggregation_mode = DisaggregationMode.NULL
         scheduler.running_batch = MagicMock()
         scheduler.running_batch.reqs = []
         scheduler.running_batch.is_empty.return_value = True


### PR DESCRIPTION
## Why?

In PD-disaggregated mode, `pause_generation` does not actually quiesce the engine and can leave the scheduler in an inconsistent state:

1. The disagg event loops (`event_loop_normal_disagg_prefill`, `event_loop_overlap_disagg_prefill`, `event_loop_normal_disagg_decode`, `event_loop_overlap_disagg_decode`) never check `self._engine_paused`. They keep popping bootstrap queues, draining KV transfer queues, building batches, and running forwards while the engine is supposedly paused. As a result, `mode="in_place"` is effectively a no-op in PD and cannot serve as a weight-sync barrier.

2. `mode="retract"` partially retracts decode-side requests into `disagg_decode_prealloc_queue`, but there is no mechanism to send them back to the prefill node for re-prefill. A subsequent `flush_cache` then crashes inside `RadixCache.dec_lock_ref` because requests still in `disagg_prefill_inflight_queue` hold tree locks across the radix-tree reset:

```
File "sglang/srt/mem_cache/common.py", line 479, in release_kv_cache
    tree_cache.cache_finished_req(req, is_insert=is_insert)
File "sglang/srt/mem_cache/radix_cache.py", line 508, in cache_finished_req
    self.dec_lock_ref(req.last_node)
File "sglang/srt/mem_cache/radix_cache.py", line 642, in dec_lock_ref
    assert node is self.root_node, \
        "This request holds the node from another tree"
```

## How?

- Add `if self._engine_paused: continue` immediately after `process_input_requests` in both PD prefill and PD decode event loops, mirroring the unified-mode pattern. Control RPCs continue to be processed while paused, but no scheduler-visible state transitions occur until `continue_generation`.
- Assert early in `Scheduler.pause_generation` that `mode="retract"` is unsupported when `disaggregation_mode != NULL`, before mutating any scheduler state. A proper fix requires a decode-to-prefill rebootstrap protocol that does not exist yet; until then, failing fast is preferable to partial state changes followed by a delayed crash inside radix-cache cleanup.
- Update the `pause_generation` unit-test fixture to set `disaggregation_mode = NULL` so the existing retract-mode tests keep exercising the unified-mode path.

Made with [Cursor](https://cursor.com)