### PR TITLE
Partially revert #21985 and fully revert #23717

### DIFF
--- a/python/sglang/jit_kernel/flash_attention.py
+++ b/python/sglang/jit_kernel/flash_attention.py
@@ -41,7 +41,6 @@ def flash_attn_with_kvcache(
     score_mod=None,
     aux_tensors=None,
     ver=3,
-    out=None,
 ):
     """
     If k and v are not None, k_cache and v_cache will be updated *inplace* with the new values from
@@ -165,7 +164,6 @@ def flash_attn_with_kvcache(
             sm_margin=sm_margin,
             return_softmax_lse=return_softmax_lse,
             sinks=sinks,
-            out=out,
         )
     elif ver == 4:
         from .flash_attention_v4 import (
@@ -234,7 +232,6 @@ def flash_attn_varlen_func(
     score_mod=None,
     aux_tensors=None,
     ver=3,
-    out=None,
 ):
 
     if ver == 3:
@@ -263,7 +260,6 @@ def flash_attn_varlen_func(
             sm_margin=sm_margin,
             return_softmax_lse=return_softmax_lse,
             sinks=sinks,
-            out=out,
         )
     elif ver == 4:
         from .flash_attention_v4 import (

--- a/python/sglang/jit_kernel/flash_attention_v3.py
+++ b/python/sglang/jit_kernel/flash_attention_v3.py
@@ -15,17 +15,6 @@ SGL_FA3_KERNEL_REVISION = "v1"
 DEFAULT_FA3_KERNEL_LOCKFILE = "kernels.lock"
 
 
-def _call_fa3_kernel(kernel, *args, out=None):
-    if out is None:
-        return kernel(*args)
-    try:
-        return kernel(*args, out=out)
-    except TypeError as exc:
-        if "unexpected keyword argument 'out'" not in str(exc):
-            raise
-        return kernel(*args)
-
-
 @cache_once
 def _load_fa3_kernels():
     # By default, we use the implementation from sgl-kernel,
@@ -139,8 +128,7 @@ def flash_attn_with_kvcache(
     assert k_cache.stride(-1) == 1, "k_cache must have contiguous last dimension"
     assert v_cache.stride(-1) == 1, "v_cache must have contiguous last dimension"
 
-    return _call_fa3_kernel(
-        _load_fa3_kernels()["flash_attn_with_kvcache"],
+    return _load_fa3_kernels()["flash_attn_with_kvcache"](
         q,
         k_cache,
         v_cache,
@@ -208,8 +196,7 @@ def flash_attn_varlen_func(
             "flash_attn at sgl-kernel is only supported on sm90 and above"
         )
 
-    return _call_fa3_kernel(
-        _load_fa3_kernels()["flash_attn_varlen_func"],
+    return _load_fa3_kernels()["flash_attn_varlen_func"](
         q,
         k,
         v,

--- a/python/sglang/jit_kernel/flash_attention_v3.py
+++ b/python/sglang/jit_kernel/flash_attention_v3.py
@@ -130,7 +130,6 @@ def flash_attn_with_kvcache(
     sm_margin=0,  # Can be tuned if some SMs are used for communication
     return_softmax_lse=False,
     sinks=None,
-    out=None,
 ):
     if not _is_fa3_supported():
         raise NotImplementedError(
@@ -173,7 +172,6 @@ def flash_attn_with_kvcache(
         sm_margin,
         return_softmax_lse,
         sinks,
-        out=out,
     )
 
 
@@ -203,7 +201,6 @@ def flash_attn_varlen_func(
     sm_margin=0,
     return_softmax_lse=False,
     sinks=None,
-    out=None,
 ):
 
     if not _is_fa3_supported():
@@ -237,5 +234,4 @@ def flash_attn_varlen_func(
         sm_margin,
         return_softmax_lse,
         sinks,
-        out=out,
     )

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -691,12 +691,6 @@ class FlashAttentionBackend(AttentionBackend):
         if sinks is not None:
             kwargs["sinks"] = sinks
 
-        _fa_out = (
-            forward_batch._attn_output.view(-1, layer.tp_q_head_num, layer.v_head_dim)
-            if getattr(forward_batch, "_attn_output", None) is not None
-            else None
-        )
-
         # Get the appropriate page table based on whether we're using local attention
         if use_local_attn:
             local_metadata = metadata.local_attn_metadata
@@ -803,7 +797,6 @@ class FlashAttentionBackend(AttentionBackend):
                     window_size=window_size,
                     softcap=layer.logit_cap,
                     num_splits=self.num_splits,
-                    out=_fa_out,
                     **kwargs,
                 )
             else:
@@ -824,7 +817,6 @@ class FlashAttentionBackend(AttentionBackend):
                     v_descale=v_descale,
                     return_softmax_lse=use_cascade_attn,
                     num_splits=self.num_splits,
-                    out=_fa_out,
                     ver=self.fa_impl_ver,
                     **kwargs,
                 )
@@ -893,7 +885,6 @@ class FlashAttentionBackend(AttentionBackend):
                         softmax_scale=layer.scaling,
                         causal=False,
                         return_softmax_lse=True,
-                        out=_fa_out,
                         ver=self.fa_impl_ver,
                         **kwargs,
                     )
@@ -920,7 +911,6 @@ class FlashAttentionBackend(AttentionBackend):
                         softmax_scale=layer.scaling,
                         causal=True,
                         return_softmax_lse=forward_batch.mha_return_lse,
-                        out=_fa_out,
                         ver=self.fa_impl_ver,
                         **kwargs,
                     )
@@ -1074,12 +1064,6 @@ class FlashAttentionBackend(AttentionBackend):
         if sinks is not None:
             kwargs["sinks"] = sinks
 
-        _fa_out = (
-            forward_batch._attn_output.view(-1, layer.tp_q_head_num, layer.v_head_dim)
-            if getattr(forward_batch, "_attn_output", None) is not None
-            else None
-        )
-
         k_descale, v_descale = None, None
         # only use kv scaling if: 1) fp8 kv is explicitly enabled, 2) RadixAttention
         # has corresponding quantization method so that layer.k_scale is not None,
@@ -1191,7 +1175,6 @@ class FlashAttentionBackend(AttentionBackend):
                     v_descale=v_descale,
                     return_softmax_lse=use_cascade_attn,
                     num_splits=self.num_splits,
-                    out=_fa_out,
                     ver=self.fa_impl_ver,
                     scheduler_metadata=sched_meta,
                     **kwargs,

--- a/python/sglang/srt/layers/radix_attention.py
+++ b/python/sglang/srt/layers/radix_attention.py
@@ -190,11 +190,6 @@ def unified_attention_with_output(
         if hasattr(token_to_kv_pool, "set_swa_loc"):
             token_to_kv_pool.set_swa_loc(forward_batch.out_cache_loc_swa)
 
-    # Store pre-allocated output for FA backend to write directly into.
-    # Must slice to real_num_tokens to match the narrowed query shape —
-    # the FA kernel validates out.size(0) == q.size(0).
-    forward_batch._attn_output = output[:real_num_tokens]
-
     ret = forward_batch.attn_backend.forward(
         query,
         key,
@@ -211,8 +206,7 @@ def unified_attention_with_output(
     ):
         token_to_kv_pool.set_swa_loc(original_swa_loc)
 
-    if ret.data_ptr() != output.data_ptr():
-        output[:real_num_tokens].view(ret.shape).copy_(ret)
+    output[:real_num_tokens].view(ret.shape).copy_(ret)
     return
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Summary

This PR partially reverts #21985 and fully reverts #23717

Hi @Qiaolin-Yu @jasperjiaguo, I think this needs a new `sglang-kernel` release? It's currently breaking fa3

```bash
[2026-04-24 20:04:02] Scheduler hit an exception: Traceback (most recent call last):
  File "/root/sgl-workspace/python/sglang/srt/managers/scheduler.py", line 3802, in run_scheduler_process
    scheduler = Scheduler(
                ^^^^^^^^^^
  File "/root/sgl-workspace/python/sglang/srt/managers/scheduler.py", line 425, in __init__
    self.init_model_worker()
  File "/root/sgl-workspace/python/sglang/srt/managers/scheduler.py", line 681, in init_model_worker
    self.init_tp_model_worker()
  File "/root/sgl-workspace/python/sglang/srt/managers/scheduler.py", line 636, in init_tp_model_worker
    self.tp_worker = TpModelWorker(**worker_kwargs)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-workspace/python/sglang/srt/managers/tp_worker.py", line 260, in __init__
    self._init_model_runner()
  File "/root/sgl-workspace/python/sglang/srt/managers/tp_worker.py", line 343, in _init_model_runner
    self._model_runner = ModelRunner(
                         ^^^^^^^^^^^^
  File "/root/sgl-workspace/python/sglang/srt/model_executor/model_runner.py", line 488, in __init__
    self.initialize(pre_model_load_memory)
  File "/root/sgl-workspace/python/sglang/srt/model_executor/model_runner.py", line 724, in initialize
    self.init_device_graphs()
  File "/root/sgl-workspace/python/sglang/srt/model_executor/model_runner.py", line 2614, in init_device_graphs
    self.graph_runner = graph_runners[self.device](self)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-workspace/python/sglang/srt/model_executor/cuda_graph_runner.py", line 713, in __init__
    self.capture()
  File "/root/sgl-workspace/python/sglang/srt/model_executor/cuda_graph_runner.py", line 895, in capture
    _capture_one_stream()
  File "/root/sgl-workspace/python/sglang/srt/model_executor/cuda_graph_runner.py", line 883, in _capture_one_stream
    ) = self.capture_one_batch_size(bs, forward, stream_idx)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-workspace/python/sglang/srt/model_executor/cuda_graph_runner.py", line 1163, in capture_one_batch_size
    run_once()
  File "/root/sgl-workspace/python/sglang/srt/model_executor/cuda_graph_runner.py", line 1141, in run_once
    logits_output_or_pp_proxy_tensors = forward(
                                        ^^^^^^^^
  File "/root/.venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-workspace/python/sglang/srt/models/qwen3_vl.py", line 1249, in forward
    hidden_states = general_mm_embed_routine(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-workspace/python/sglang/srt/managers/mm_utils.py", line 1106, in general_mm_embed_routine
    hidden_states = language_model(
                    ^^^^^^^^^^^^^^^
  File "/root/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-workspace/python/sglang/srt/models/qwen3_5.py", line 1014, in forward
    hidden_states, residual = layer(
                              ^^^^^^
  File "/root/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-workspace/python/sglang/srt/models/qwen3_5.py", line 854, in forward
    hidden_states = self.self_attention(
                    ^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-workspace/python/sglang/srt/models/qwen3_5.py", line 826, in self_attention
    attn_output = self.attn(q, k, v, forward_batch)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-workspace/python/sglang/srt/layers/radix_attention.py", line 138, in forward
    return forward_batch.attn_backend.forward(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-workspace/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py", line 924, in forward
    return self.forward_extend(
           ^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-workspace/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py", line 871, in forward_extend
    return self.full_attn_backend.forward_extend(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-workspace/python/sglang/srt/layers/attention/flashattention_backend.py", line 810, in forward_extend
    result = flash_attn_with_kvcache(
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-workspace/python/sglang/jit_kernel/flash_attention.py", line 136, in flash_attn_with_kvcache
    return fa3_flash_attn_with_kvcache(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-workspace/python/sglang/jit_kernel/flash_attention_v3.py", line 132, in flash_attn_with_kvcache
    return _load_fa3_kernels()["flash_attn_with_kvcache"](
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: flash_attn_with_kvcache() got an unexpected keyword argument 'out'
```