### PR TITLE
[bug fix] test/glm_51_fp8: cap max_running_requests on TP8+DP8 to fix B200 OOM

### DIFF
--- a/test/registered/8-gpu-models/test_glm_51_fp8.py
+++ b/test/registered/8-gpu-models/test_glm_51_fp8.py
@@ -43,7 +43,10 @@ class TestGlm51Fp8(unittest.TestCase):
             ModelLaunchSettings(
                 GLM_51_FP8_MODEL_PATH,
                 tp_size=8,
-                extra_args=COMMON_ARGS + dp_args,
+                # Cap running requests to bound FlashInfer autotune's dummy
+                # batch, whose logits all-gather across dp=8 otherwise OOMs
+                # on B200 (transient ~6.4 GiB peak during startup).
+                extra_args=COMMON_ARGS + dp_args + ["--max-running-requests=48"],
                 variant="TP8+DP8",
             ),
             ModelLaunchSettings(


### PR DESCRIPTION
## Summary

- `TestGlm51Fp8.TP8+DP8` OOMs at server startup on B200 in the nightly 8-GPU suite; the TP8 and TP8+DP8+MTP variants pass.
- Root cause: FlashInfer autotune (default-on since #14357) runs a dummy forward sized to the full KV budget; with `dp=8 + --enable-dp-attention`, logits are all-gathered across DP ranks, producing a transient ~6.4 GiB tensor that doesn't fit on B200.
- Cap `--max-running-requests=48` on the TP8+DP8 variant so the autotune dummy batch stays small — matching what the MTP variant already gets implicitly (speculative decoding caps running reqs).

## Why this, and not a runtime-side fix

The right structural fix is in the runtime: `_flashinfer_autotune` should bound its dummy batch by `dp_size` when `enable_dp_attention` is on (see `python/sglang/srt/model_executor/model_runner.py:2234-2249`), which would fix every DP-attention test at once. This PR is a minimal, test-side change to un-red the nightly now; I'll open a follow-up for the runtime fix.

## Traceback (for reference)

```
_flashinfer_autotune                              (model_runner.py:2234)
  _dummy_run(batch_size=self.req_to_token_pool.size)   (model_runner.py:2245)
    deepseek_v2.forward
      logits_processor._get_logits              (logits_processor.py:865)
        tensor_model_parallel_all_gather(logits) (parallel_state.py:890)
            torch.OutOfMemoryError: Tried to allocate 6.38 GiB
```

## Why only B200 sees this

The same SHA passes on H200 because the H200 backend mix (`flashmla_sparse` / `fa3`) uses smaller workspaces than B200's `trtllm` / `flashinfer_trtllm`, leaving ~15–20 GiB more headroom for the transient all-gather. The hardware-specific failure is a real bug, not a dismissal.

## Test plan

- [ ] Rerun the `nightly-8-gpu-common` suite on B200 and confirm `TestGlm51Fp8.TP8+DP8` passes server startup and the GSM8K accuracy bar.
- [ ] Rerun on H200 and confirm the variant still passes (should be unaffected — just capping batch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #24915874844](https://github.com/sgl-project/sglang/actions/runs/24915874844)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->