### PR TITLE
Fix image input bug when n > 1

### DIFF
--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -1529,6 +1529,9 @@ class ShmPointerMMData:
     This acts as a "pointer" to the tensor data across process boundaries.
     """
 
+    # Class-level dictionary to track reference counts for shared memory objects
+    _shm_ref_counts = {}
+
     def __init__(self, tensor: torch.Tensor):
         if not tensor.is_cpu:
             tensor = tensor.cpu()
@@ -1548,8 +1551,13 @@ class ShmPointerMMData:
         self.shm_name = shm.name
         shm.close()
         self._shm_handle = None
+        ShmPointerMMData._shm_ref_counts[self.shm_name] = 1
 
     def __getstate__(self):
+        # Increment reference count when pickling (new instance will be created)
+        # Only increment if the shm_name is still tracked (not already released)
+        if self.shm_name in ShmPointerMMData._shm_ref_counts:
+            ShmPointerMMData._shm_ref_counts[self.shm_name] += 1
         return {
             "shm_name": self.shm_name,
             "shape": self.shape,
@@ -1572,10 +1580,15 @@ class ShmPointerMMData:
         tensor = self.tensor.clone()
         if self._shm_handle is not None:
             self._shm_handle.close()
-            try:
-                self._shm_handle.unlink()
-            except FileNotFoundError:
-                pass  # Another rank already unlinked
+            # Decrement reference count and unlink only if this is the last reference
+            if self.shm_name in ShmPointerMMData._shm_ref_counts:
+                ShmPointerMMData._shm_ref_counts[self.shm_name] -= 1
+                if ShmPointerMMData._shm_ref_counts[self.shm_name] <= 0:
+                    try:
+                        shared_memory.SharedMemory(name=self.shm_name).unlink()
+                        del ShmPointerMMData._shm_ref_counts[self.shm_name]
+                    except FileNotFoundError:
+                        pass  # Already unlinked
             self._shm_handle = None
         return tensor
 


### PR DESCRIPTION
## Motivation

For multimodal models, curling a request with an image input and n > 1 will trigger an error

## Modifications

For multimodal models, curling a request with an image input and n > 1 will trigger an error. This PR is to fix this issue.
We introduced a counter in ShmPointerMMData to track references. Each replica increments the reference count, and the shared memory is deallocated only when all replicas are processed and the count reaches zero.

when n = 3:
before:
<img width="845" height="80" alt="image" src="https://github.com/user-attachments/assets/67fcc7fb-2c59-4019-96ec-1dae54043e5d" />

after:
`{"id":"ef730055e6f841af99af4fccd194d3c4","object":"chat.completion","created":1777085740,"model":"Qwen3.6-35B-A3B","choices":[{"index":0,"message":{"role":"assistant","content":"用户希望我描述这张图片的内容。\n\n1.  **主体识别**：图片的主角是一只大熊猫（Giant Panda）。\n\n2.  **动作与姿态**：\n    *   它正坐着，身体微微前倾。\n    *   左前爪（或右前爪)拿着一根竹子在吃。\n\n3.  **环境背景：\n    *   背景是茂密的绿色竹林，竹子高大挺拔，叶片翠绿。\n    *   前景有竹叶和竹枝，右侧有粗壮的竹竿。\n\n4.  **细节特征**：\n   ","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"length","matched_stop":null},{"index":1,"message":{"role":"assistant","content":"用户希望我描述这张图片的内容。\n\n1.  **主体识别**：图片的主角是一只大熊猫（Giant Panda）。\n2.  **动作与姿态**：\n    *   它正坐着，身体微微前倾。\n    *   它的左爪（画面右侧）似乎扶着竹子或者放在身侧。\n    *   它的右爪（画面左侧）抓着一束绿色的竹叶/竹枝，正送到嘴边吃。\n    *   它的表情看起来很专注，眼睛睁得大大的，看着镜头方向。\n3.  **外貌特征**：\n    *  ","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"length","matched_stop":null},{"index":2,"message":{"role":"assistant","content":"用户希望我描述这张图片的内容。\n\n1.  **主体识别**：图片的主角是一只大熊猫（Giant Panda）。\n2.  **动作与姿态**：\n    *   它正坐着，身体微微前倾。\n    *   它的左爪（画面右侧）似乎扶着竹子，右爪（画面左侧）拿着一束竹叶或竹枝放在嘴边，正在进食。\n    *   它的表情看起来很专注，眼神清澈，直视前方（镜头）。\n3.  **外貌特征**：\n    *   典型的黑白毛色：耳朵、眼圈、四肢是","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"length","matched_stop":null}],"usage":{"prompt_tokens":1040,"total_tokens":1424,"completion_tokens":384,"prompt_tokens_details":null,"reasoning_tokens":0},"metadata":{"weight_version":"default"}}`

## Accuracy Tests

None


## Speed Tests and Profiling

None

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
