### PR TITLE
Support dsv4 task / latest_reminder / content parts in OpenAI chat API

### DIFF
--- a/python/sglang/srt/entrypoints/openai/encoding_dsv4.py
+++ b/python/sglang/srt/entrypoints/openai/encoding_dsv4.py
@@ -225,6 +225,16 @@ def find_last_user_index(messages: List[Dict[str, Any]]) -> int:
     return last_user_index
 
 
+def attach_task_to_last_user_message(messages: List[Dict[str, Any]], task: str) -> None:
+    """Set `task` on the most recent user/developer message; raise if none exists."""
+    idx = find_last_user_index(messages)
+    if idx == -1:
+        raise ValueError(
+            "`task` requires at least one message with role='user' or 'developer'."
+        )
+    messages[idx]["task"] = task
+
+
 # ============================================================
 # Message Rendering
 # ============================================================

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -17,7 +17,17 @@ import logging
 import time
 import uuid
 from dataclasses import dataclass
-from typing import Any, Dict, List, NamedTuple, Optional, Tuple, TypeAlias, Union
+from typing import (
+    Any,
+    Dict,
+    List,
+    NamedTuple,
+    Optional,
+    Tuple,
+    TypeAlias,
+    Union,
+    get_args,
+)
 
 from openai.types.responses import (
     ResponseFunctionToolCall,
@@ -425,8 +435,14 @@ class ToolCall(BaseModel):
     function: FunctionResponse
 
 
+_GenericMessageRole = Literal[
+    "system", "assistant", "tool", "function", "developer", "latest_reminder"
+]
+_GENERIC_MESSAGE_ROLES: Tuple[str, ...] = get_args(_GenericMessageRole)
+
+
 class ChatCompletionMessageGenericParam(BaseModel):
-    role: Literal["system", "assistant", "tool", "function", "developer"]
+    role: _GenericMessageRole
     content: Union[str, List[ChatCompletionMessageContentPart], None] = Field(
         default=None
     )
@@ -441,10 +457,9 @@ class ChatCompletionMessageGenericParam(BaseModel):
     def _normalize_role(cls, v):
         if isinstance(v, str):
             v_lower = v.lower()
-            if v_lower not in {"system", "assistant", "tool", "function", "developer"}:
-                raise ValueError(
-                    "'role' must be one of 'system', 'developer', 'assistant', 'tool', or 'function' (case-insensitive)."
-                )
+            if v_lower not in _GENERIC_MESSAGE_ROLES:
+                allowed = ", ".join(repr(r) for r in _GENERIC_MESSAGE_ROLES)
+                raise ValueError(f"'role' must be one of {allowed} (case-insensitive).")
             return v_lower
         raise ValueError("'role' must be a string")
 
@@ -532,6 +547,15 @@ class ChatCompletionRequest(BaseModel):
         "'low' is the least effort, 'high' is the most effort. Reducing reasoning effort can "
         "result in faster responses and fewer tokens used on reasoning in a response. "
         "Currently only supported for OpenAI models in the harmony path, i.e GPT-OSS models.",
+    )
+    task: Optional[
+        Literal["action", "query", "authority", "domain", "title", "read_url"]
+    ] = Field(
+        default=None,
+        description="DeepSeek-V4 quick instruction task. When set, the last "
+        "user/developer message is treated as a single-shot classification prompt "
+        "and the corresponding task special token (e.g. `<｜domain｜>`) is appended "
+        "before generation. Only honored by the dsv4 chat encoder; ignored otherwise.",
     )
 
     # Extra parameters for SRT backend only and will be ignored by OpenAI models.

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -400,6 +400,14 @@ class OpenAIServingChat(OpenAIServingBase):
             thinking_mode = "thinking" if thinking_requested else "chat"
             messages = [msg.model_dump() for msg in request.messages]
 
+            # dsv4/dsv32 are text-only and consume string content; flatten
+            # OpenAI parts-list content here so the encoder sees a plain string.
+            for i, msg in enumerate(messages):
+                if isinstance(msg.get("content"), list):
+                    messages[i] = process_content_for_template_format(
+                        msg, "string", [], [], [], []
+                    )
+
             # Handle continue_final_message: separate final assistant message
             messages, assistant_prefix = self._handle_last_assistant_message(
                 messages, request
@@ -423,6 +431,10 @@ class OpenAIServingChat(OpenAIServingBase):
                 v4_reasoning_effort = (
                     effort_source if effort_source in ("max", "high") else None
                 )
+                if request.task is not None:
+                    encoding_dsv4.attach_task_to_last_user_message(
+                        messages, request.task
+                    )
                 real_input = encoding_dsv4.encode_messages(
                     messages,
                     thinking_mode=thinking_mode,

--- a/test/registered/openai_server/basic/test_serving_chat.py
+++ b/test/registered/openai_server/basic/test_serving_chat.py
@@ -638,6 +638,178 @@ class ServingChatTestCase(unittest.TestCase):
             serving_chat = OpenAIServingChat(tokenizer_manager, TemplateManager())
             self.assertEqual(serving_chat.chat_encoding_spec, "dsv4")
 
+    # ------------- dsv4 task + latest_reminder -------------
+    def test_dsv4_task_field_schema(self):
+        """Top-level `task` accepts the 6 DS task tokens and rejects others."""
+        for valid in ("action", "query", "authority", "domain", "title", "read_url"):
+            req = ChatCompletionRequest(
+                model="x",
+                messages=[{"role": "user", "content": "hi"}],
+                task=valid,
+            )
+            self.assertEqual(req.task, valid)
+
+        # None / unset is fine
+        self.assertIsNone(self.basic_req.task)
+
+        # Bogus value rejected at validation time
+        from pydantic import ValidationError
+
+        with self.assertRaises(ValidationError):
+            ChatCompletionRequest(
+                model="x",
+                messages=[{"role": "user", "content": "hi"}],
+                task="bogus",
+            )
+
+    def test_latest_reminder_role_accepted(self):
+        """`latest_reminder` is a first-class message role on generic param."""
+        from sglang.srt.entrypoints.openai.protocol import (
+            ChatCompletionMessageGenericParam,
+        )
+
+        msg = ChatCompletionMessageGenericParam(
+            role="latest_reminder", content="Be terse."
+        )
+        self.assertEqual(msg.role, "latest_reminder")
+
+        # Full request with reminder before user parses cleanly.
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[
+                {"role": "latest_reminder", "content": "Be terse."},
+                {"role": "user", "content": "Hi"},
+            ],
+        )
+        self.assertEqual(req.messages[0].role, "latest_reminder")
+        self.assertEqual(req.messages[1].role, "user")
+
+    def test_attach_task_to_last_user_message(self):
+        """Helper attaches task to the nearest user/developer message."""
+        from sglang.srt.entrypoints.openai import encoding_dsv4
+
+        messages = [{"role": "user", "content": "Hi"}]
+        encoding_dsv4.attach_task_to_last_user_message(messages, "domain")
+        self.assertEqual(messages[0]["task"], "domain")
+
+        # Prefers the LAST user message across a multi-turn conversation.
+        messages = [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "ok"},
+            {"role": "user", "content": "second"},
+        ]
+        encoding_dsv4.attach_task_to_last_user_message(messages, "query")
+        self.assertNotIn("task", messages[0])
+        self.assertEqual(messages[2]["task"], "query")
+
+        # `developer` role is treated like `user` (matches encoder semantics).
+        messages = [{"role": "developer", "content": "dev"}]
+        encoding_dsv4.attach_task_to_last_user_message(messages, "authority")
+        self.assertEqual(messages[0]["task"], "authority")
+
+        # No user/developer present -> raises.
+        with self.assertRaises(ValueError):
+            encoding_dsv4.attach_task_to_last_user_message(
+                [{"role": "system", "content": "s"}], "domain"
+            )
+
+    def test_dsv4_content_parts_list_normalized(self):
+        """OpenAI list-of-parts content flattens to text before reaching the encoder."""
+        from sglang.srt.entrypoints.openai import encoding_dsv4
+        from sglang.srt.parser.jinja_template_utils import (
+            process_content_for_template_format,
+        )
+
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "say hi"}],
+                }
+            ],
+        )
+        messages = [m.model_dump() for m in req.messages]
+        # Mirror the boundary normalization _process_messages does for any
+        # non-None chat_encoding_spec.
+        for i, msg in enumerate(messages):
+            if isinstance(msg.get("content"), list):
+                messages[i] = process_content_for_template_format(
+                    msg, "string", [], [], [], []
+                )
+        out = encoding_dsv4.encode_messages(messages, thinking_mode="chat")
+        self.assertIn("<｜User｜>say hi", out)
+
+        # Multiple text parts concat with single space; non-text parts dropped.
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe"},
+                    {"type": "image_url", "image_url": {"url": "x"}},
+                ],
+            }
+        ]
+        for i, msg in enumerate(messages):
+            if isinstance(msg.get("content"), list):
+                messages[i] = process_content_for_template_format(
+                    msg, "string", [], [], [], []
+                )
+        out = encoding_dsv4.encode_messages(messages, thinking_mode="chat")
+        self.assertIn("<｜User｜>describe", out)
+        self.assertNotIn("image_url", out)
+
+    def test_dsv4_task_and_reminder_encode_end_to_end(self):
+        """Task + latest_reminder plumb through to the dsv4 encoder correctly."""
+        from sglang.srt.entrypoints.openai import encoding_dsv4
+
+        # 1) task='domain' in chat mode -> `<｜domain｜>` appended, no Assistant
+        #    prefix (this is a single-shot classification, not a chat turn).
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "What is SGLang?"}],
+            task="domain",
+        )
+        messages = [m.model_dump() for m in req.messages]
+        encoding_dsv4.attach_task_to_last_user_message(messages, req.task)
+        out = encoding_dsv4.encode_messages(messages, thinking_mode="chat")
+        self.assertIn("<｜domain｜>", out)
+        self.assertTrue(out.rstrip().endswith("<｜domain｜>"))
+        self.assertNotIn("<｜Assistant｜>", out)
+
+        # 2) task='action' in thinking mode -> Assistant + <think> + <｜action｜>
+        #    (action is the one task that still runs a reasoning pass).
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi"}],
+            task="action",
+        )
+        messages = [m.model_dump() for m in req.messages]
+        encoding_dsv4.attach_task_to_last_user_message(messages, req.task)
+        out = encoding_dsv4.encode_messages(messages, thinking_mode="thinking")
+        self.assertIn("<｜Assistant｜>", out)
+        self.assertIn("<think>", out)
+        self.assertTrue(out.rstrip().endswith("<｜action｜>"))
+
+        # 3) latest_reminder preceding user -> reminder renders before user,
+        #    Assistant prefix still comes after user.
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[
+                {"role": "latest_reminder", "content": "Be terse."},
+                {"role": "user", "content": "Hello"},
+            ],
+        )
+        messages = [m.model_dump() for m in req.messages]
+        out = encoding_dsv4.encode_messages(messages, thinking_mode="chat")
+        self.assertIn("<｜latest_reminder｜>Be terse.", out)
+        self.assertIn("<｜User｜>Hello", out)
+        self.assertLess(
+            out.index("<｜latest_reminder｜>"),
+            out.index("<｜User｜>"),
+        )
+        self.assertIn("<｜Assistant｜>", out)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Plumbs three DeepSeek-V4 chat surface gaps through the OpenAI-compatible `/v1/chat/completions` endpoint:

- **`task` field** — `ChatCompletionRequest` now accepts a top-level `task` (one of `action`, `query`, `authority`, `domain`, `title`, `read_url`). The serving layer attaches it to the last user/developer message; the dsv4 encoder then appends the corresponding special token (`<｜domain｜>`, etc.) to drive V4's quick-instruction classification path.
- **`latest_reminder` role** — added to `ChatCompletionMessageGenericParam`'s role enum so callers can submit `{"role": "latest_reminder", "content": "..."}` messages. The dsv4 encoder already renders these into `<｜latest_reminder｜>...` natively; we were just blocking the input.
- **Content parts list flatten** — fixes `TypeError: sequence item 0: expected str instance, list found` when clients (SWE-bench, etc.) send `content: [{"type":"text","text":"..."}]` against text-only dsv4/dsv32 models. Boundary-normalize via the existing `process_content_for_template_format(..., "string", ...)` helper so the encoder always receives a plain string.

## Notes

- `task` is honored only by the dsv4 chat encoder; other models ignore it (consistent with how `reasoning_effort` works for non-harmony paths).
- Non-text parts (`image_url`, `video_url`, `audio_url`) are silently dropped during flatten — matches the existing string-format jinja path's behavior.
- `latest_reminder` precedes the user turn in the prompt; encoder ordering / transition tokens were already correct.

## Test plan

- [x] `test/registered/openai_server/basic/test_serving_chat.py` — 15/15 pass (4 new tests covering schema, role, helper, end-to-end encoding, and content-parts normalization)
- [x] `test/registered/openai_server/basic/test_protocol.py` — 17/17 pass (no regression on schema)
- [x] `pre-commit run` clean on isort / black / ruff / codespell
- [x] Manually verified against live `pg-deepseek-v4-flash` H200 deployment for the original bug shape and `task=domain` request semantics


## Live deployment verification

Deployed PR HEAD onto a live H200 sglang instance serving DeepSeek-V4-Flash-FP8 and ran 7 chat-completion workloads covering each surface change in this PR (content-parts list flatten, `task` field, `latest_reminder` role) plus a plain-string regression baseline. All 7 returned HTTP 200 with coherent content; pre-PR baselines for W1 and W3 would have failed (W1 with a `TypeError`, W3 with a 400).

### Environment

| Item | Value |
|---|---|
| sglang install | editable install at `/workspace/sglang/python` (`pip install -e .`) |
| Hardware | 8× NVIDIA H200, `tp=8 dp=8` |
| Container image | `lmsysorg/sglang:deepseek-v4-hopper` |
| Model | `sgl-project/DeepSeek-V4-Flash-FP8` |
| Endpoint | `http://localhost:47733/v1/chat/completions` |
| Reasoning / tool parser | `--reasoning-parser deepseek-v4 --tool-call-parser deepseekv4` |
| Speculative decoding | `EAGLE`, `num-steps=1`, `topk=1`, `draft-tokens=2` |
| MoE | `--moe-a2a-backend deepep` |
| Patch application | `cd /workspace/sglang && patch -p1 < pr_23692.diff` → 4 files patched cleanly, 0 rejects, 0 fuzz |
| Time-to-healthy after restart | ~85 s (NFS-cached weights; cold start would be longer) |

All workloads use `temperature: 0` for determinism. Server log showed no tracebacks or post-startup errors during the verification window.

---

### W0 — Plain string content (regression baseline)

Verifies the existing OpenAI-compatible path still works for the simplest message shape after the patch (no behavior change expected).

```bash
curl -s -H 'Content-Type: application/json' -X POST \
  http://localhost:47733/v1/chat/completions \
  -d '{
    "model": "sgl-project/DeepSeek-V4-Flash-FP8",
    "messages": [{"role": "user", "content": "What is 2+3? Just the number."}],
    "max_tokens": 50,
    "temperature": 0
  }'
```

```json
{
  "id": "c644135fe55c4122a2b1284ab9324512",
  "object": "chat.completion",
  "model": "sgl-project/DeepSeek-V4-Flash-FP8",
  "choices": [{
    "index": 0,
    "message": {"role": "assistant", "content": "5", "reasoning_content": null, "tool_calls": null},
    "finish_reason": "stop",
    "matched_stop": 1
  }],
  "usage": {"prompt_tokens": 15, "total_tokens": 17, "completion_tokens": 2, "reasoning_tokens": 0}
}
```

**Verdict: PASS ✅** — baseline regression intact.

---

### W1 — Content-parts list (the bug fix)

Sends the OpenAI multimodal-style `content: [{"type": "text", "text": "..."}]` shape. Pre-PR this crashed with `TypeError: sequence item 0: expected str instance, list found` because the list was passed straight into a `str.join`. Post-PR the patch flattens content-parts into a string before template formatting.

```bash
curl -s -H 'Content-Type: application/json' -X POST \
  http://localhost:47733/v1/chat/completions \
  -d '{
    "model": "sgl-project/DeepSeek-V4-Flash-FP8",
    "messages": [{
      "role": "user",
      "content": [{"type": "text", "text": "What is 2+3? Just the number."}]
    }],
    "max_tokens": 50,
    "temperature": 0
  }'
```

```json
{
  "id": "1807d9b85e8548f6be1acf9c18ad22d5",
  "object": "chat.completion",
  "model": "sgl-project/DeepSeek-V4-Flash-FP8",
  "choices": [{
    "index": 0,
    "message": {"role": "assistant", "content": "5", "reasoning_content": null, "tool_calls": null},
    "finish_reason": "stop",
    "matched_stop": 1
  }],
  "usage": {"prompt_tokens": 15, "total_tokens": 17, "completion_tokens": 2, "reasoning_tokens": 0}
}
```

**Verdict: PASS ✅** — content-parts list accepted, no `TypeError`, identical answer to W0.

---

### W2a — `task: "domain"`

Drives the DSV4 quick-instruction domain-classification path via the new top-level `task` field.

```bash
curl -s -H 'Content-Type: application/json' -X POST \
  http://localhost:47733/v1/chat/completions \
  -d '{
    "model": "sgl-project/DeepSeek-V4-Flash-FP8",
    "task": "domain",
    "messages": [{"role": "user", "content": "List 3 popular Python web frameworks."}],
    "max_tokens": 80,
    "temperature": 0
  }'
```

```json
{
  "id": "ba3b8895902a44b2a80f467bdf0e5ac4",
  "object": "chat.completion",
  "model": "sgl-project/DeepSeek-V4-Flash-FP8",
  "choices": [{
    "index": 0,
    "message": {"role": "assistant", "content": "科技", "reasoning_content": null, "tool_calls": null},
    "finish_reason": "stop",
    "matched_stop": 1
  }],
  "usage": {"prompt_tokens": 11, "total_tokens": 13, "completion_tokens": 2, "reasoning_tokens": 0}
}
```

**Verdict: PASS ✅** — request accepted, model returned a domain label (`科技` / "Technology"), consistent with the classifier instruction template.

---

### W2b — `task: "query"`

Same `task` field, different value — drives the query-rewrite/expansion path.

```bash
curl -s -H 'Content-Type: application/json' -X POST \
  http://localhost:47733/v1/chat/completions \
  -d '{
    "model": "sgl-project/DeepSeek-V4-Flash-FP8",
    "task": "query",
    "messages": [{"role": "user", "content": "List 3 popular Python web frameworks."}],
    "max_tokens": 80,
    "temperature": 0
  }'
```

```json
{
  "id": "4b008e6cb45a4c30ae4128e15c402c9e",
  "object": "chat.completion",
  "model": "sgl-project/DeepSeek-V4-Flash-FP8",
  "choices": [{
    "index": 0,
    "message": {"role": "assistant", "content": "Flask||Django||FastAPI", "reasoning_content": null, "tool_calls": null},
    "finish_reason": "stop",
    "matched_stop": 1
  }],
  "usage": {"prompt_tokens": 11, "total_tokens": 20, "completion_tokens": 9, "reasoning_tokens": 0}
}
```

**Verdict: PASS ✅** — `||`-delimited entity list matches the query-task output shape.

---

### W2c — `task: "title"`

Title-extraction value of the `task` field.

```bash
curl -s -H 'Content-Type: application/json' -X POST \
  http://localhost:47733/v1/chat/completions \
  -d '{
    "model": "sgl-project/DeepSeek-V4-Flash-FP8",
    "task": "title",
    "messages": [{"role": "user", "content": "List 3 popular Python web frameworks."}],
    "max_tokens": 80,
    "temperature": 0
  }'
```

```json
{
  "id": "890d51415a9a4511b57f99ee73e6ebe7",
  "object": "chat.completion",
  "model": "sgl-project/DeepSeek-V4-Flash-FP8",
  "choices": [{
    "index": 0,
    "message": {"role": "assistant", "content": "flask||django||fastapi", "reasoning_content": null, "tool_calls": null},
    "finish_reason": "stop",
    "matched_stop": 1
  }],
  "usage": {"prompt_tokens": 11, "total_tokens": 20, "completion_tokens": 9, "reasoning_tokens": 0}
}
```

**Verdict: PASS ✅** — title path produces the lowercased entity list expected for this task value.

---

### W3 — `latest_reminder` role

Pre-PR, a message with `role: "latest_reminder"` was rejected at the schema layer with HTTP 400 (`Input should be 'system','user','assistant','tool','function','developer'`). Post-PR the role is in the enum.

```bash
curl -s -H 'Content-Type: application/json' -X POST \
  http://localhost:47733/v1/chat/completions \
  -d '{
    "model": "sgl-project/DeepSeek-V4-Flash-FP8",
    "messages": [
      {"role": "latest_reminder", "content": "Be concise."},
      {"role": "user", "content": "What is 2+3?"}
    ],
    "max_tokens": 50,
    "temperature": 0
  }'
```

```json
{
  "id": "b38ced0f4f41468f91942ba33ace51f2",
  "object": "chat.completion",
  "model": "sgl-project/DeepSeek-V4-Flash-FP8",
  "choices": [{
    "index": 0,
    "message": {"role": "assistant", "content": "2 + 3 = 5.", "reasoning_content": null, "tool_calls": null},
    "finish_reason": "stop",
    "matched_stop": 1
  }],
  "usage": {"prompt_tokens": 15, "total_tokens": 24, "completion_tokens": 9, "reasoning_tokens": 0}
}
```

**Verdict: PASS ✅** — role accepted, request reaches the model, coherent answer returned.

---

### W4 — Combined (all three features at once)

`task: "query"` + `latest_reminder` role + content-parts list in the same request — sanity check that the three features compose without interaction bugs.

```bash
curl -s -H 'Content-Type: application/json' -X POST \
  http://localhost:47733/v1/chat/completions \
  -d '{
    "model": "sgl-project/DeepSeek-V4-Flash-FP8",
    "task": "query",
    "messages": [
      {"role": "latest_reminder", "content": "Be concise."},
      {"role": "user", "content": [{"type": "text", "text": "What is 2+3?"}]}
    ],
    "max_tokens": 50,
    "temperature": 0
  }'
```

```json
{
  "id": "40d7e2cdb75c4d3592a41b346dc9654a",
  "object": "chat.completion",
  "model": "sgl-project/DeepSeek-V4-Flash-FP8",
  "choices": [{
    "index": 0,
    "message": {"role": "assistant", "content": "2+3", "reasoning_content": null, "tool_calls": null},
    "finish_reason": "stop",
    "matched_stop": 1
  }],
  "usage": {"prompt_tokens": 14, "total_tokens": 18, "completion_tokens": 4, "reasoning_tokens": 0}
}
```

**Verdict: PASS ✅** — all three features compose. The output (`"2+3"`) is a query-rewrite of the user content, which is the expected shape for `task: "query"` (compare to W2b's `||`-delimited rewrite); no schema rejection, no crash.

---

### Summary

| WL | Description | HTTP | Verdict |
|---|---|---|---|
| W0 | Plain string content (regression baseline) | 200 | PASS ✅ |
| W1 | Content-parts list (`content: [{type, text}]`) — pre-PR `TypeError` | 200 | PASS ✅ |
| W2a | `task: "domain"` quick-instruction path | 200 | PASS ✅ |
| W2b | `task: "query"` quick-instruction path | 200 | PASS ✅ |
| W2c | `task: "title"` quick-instruction path | 200 | PASS ✅ |
| W3 | `latest_reminder` role — pre-PR HTTP 400 | 200 | PASS ✅ |
| W4 | Combined (`task` + `latest_reminder` + content-parts list) | 200 | PASS ✅ |