### PR TITLE
fix: use recipe_ab instead of recipe for 2-tuple in transform_sf_into_required_layout

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -958,7 +958,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                             scale_param.data,
                             mn=n,
                             k=k,
-                            recipe=(1, 32),
+                            recipe_ab=(1, 32),
                             num_groups=num_experts,
                             disable_ue8m0_cast=False,
                         )

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -2010,7 +2010,7 @@ def build_mega_moe_experts_weights(experts) -> None:
         w13_sf_fp32,
         mn=n1,
         k=k1,
-        recipe=(1, 32),
+        recipe_ab=(1, 32),
         num_groups=num_groups,
         disable_ue8m0_cast=False,
     )
@@ -2018,7 +2018,7 @@ def build_mega_moe_experts_weights(experts) -> None:
         w2_sf_fp32,
         mn=n2,
         k=k2,
-        recipe=(1, 32),
+        recipe_ab=(1, 32),
         num_groups=num_groups,
         disable_ue8m0_cast=False,
     )


### PR DESCRIPTION
## Summary

Fix incorrect parameter name when calling  for FP4 expert scale conversion.

The function  has two distinct parameters:
- : expects a 3-tuple  or 
- : expects a 2-tuple 

The caller was passing  (a 2-tuple) to the  parameter, which causes a  at server startup when loading FP4 expert weights with DeepGEMM (), since the function expects either a 3-tuple or  for .

The 2-tuple  should be passed to  instead.

## Impact

Without this fix, the server fails to start with:


This is triggered whenever  +  is used (FP4 expert mode).

## Test Plan

- [x] Start server with  - no longer crashes at weight loading
- [x] Successfully run inference with DeepSeek-V4-Flash model

🤖 Generated with [Claude Code](https://claude.com/claude-code)