### PR TITLE
fix: use uint8 dtype for FP4 packed expert weights to match DeepGEMM kPackedFP4

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -929,8 +929,8 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             will_use_deepgemm = self.is_deepgemm_moe_runner_backend_enabled()
 
             if self.is_fp4_expert:
-                layer.w13_weight.data = layer.w13_weight.data.view(torch.int8)
-                layer.w2_weight.data = layer.w2_weight.data.view(torch.int8)
+                layer.w13_weight.data = layer.w13_weight.data.view(torch.uint8)
+                layer.w2_weight.data = layer.w2_weight.data.view(torch.uint8)
 
                 if envs.SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE.get():
                     from sglang.srt.models.deepseek_v4 import (


### PR DESCRIPTION
## Summary

Fix incorrect dtype when viewing FP4 packed expert weights after loading. DeepGEMM defines `kPackedFP4 = torch::kUInt8`, meaning FP4 packed weights must be `uint8`. However, the code was using `.view(torch.int8)`, which causes an assertion failure in DeepGEMM's `check_grouped_ab_fp8_fp4()` at MoE inference time:

```
assertion failed: ab.scalar_type() == kPackedFP4
```

Changed `.view(torch.int8)` to `.view(torch.uint8)` for FP4 expert weights (`w13_weight` and `w2_weight`).

This is a zero-copy type reinterpretation — the underlying data is unchanged, only the dtype label changes from `int8` to `uint8` to match what DeepGEMM's FP4 GEMM kernels expect.

**Note**: The weights are created with `dtype=torch.int8` because safetensors stores FP4 weights as int8. The `.view(torch.uint8)` call reinterprets them to the type expected by DeepGEMM.

## Impact

Without this fix, the first MoE inference request crashes with an assertion error. This is triggered whenever `SGLANG_DSV4_MODE=2604` + `--moe-runner-backend deep_gemm` is used (FP4 expert mode).

## Test Plan

- [x] Start server with `SGLANG_DSV4_MODE=2604 --moe-runner-backend deep_gemm` - no longer crashes at MoE inference
- [x] Successfully run inference with DeepSeek-V4-Flash model at 128K/256K/512K/1M context lengths

🤖 Generated with [Claude Code](https://claude.com/claude-code)