### PR TITLE
Integrate MixedComm from FlashInfer to fuse communication kernels when attention TP and DP are both used

### DIFF
--- a/docs/advanced_features/dp_dpa_smg_guide.md
+++ b/docs/advanced_features/dp_dpa_smg_guide.md
@@ -117,6 +117,31 @@ python -m sglang.launch_server \
 
 Note that MLA models, of course, also support DP. Suppose you want to enable standard DP for MLA models. First, launch each MLA model's replica independently. You may launch these replicas one by one with DPA enabled. After launching each MLA model's replica, launch an SMG and connect all the replicas to the SMG. A detailed explanation of SMG is as follows.
 
+### Fused communication via FlashInfer MixedComm
+
+When DPA is combined with attention tensor parallelism, each layer issues two communication kernels (reducescatter + allgather) both after attention and FFN. SGLang can use MixedComm kernels from [FlashInfer](https://github.com/flashinfer-ai/flashinfer) to fuse two communication kernels into a single kernel.
+
+The communication handler is constructed once per process during initialization (outside CUDA-graph capture). The performance of some predefined communication sizes is also tested during initialization to enable autotuning.
+
+Requirements for MixedComm to be enabled:
+- `--enable-dp-attention` is set and `--dp-size > 1`.
+- GPUs are SM90 (e.g., H200) or SM100 (e.g., B200)**.
+- An NVSwitch / NVLink-Switch fabric is present on each node.
+- Attention TP size and the number of GPUs per node are divisors of one another.
+- The installed version of FlashInfer contains `flashinfer.comm.mixed_comm`.
+
+To enable MixedComm, the environment variable `SGLANG_USE_MIXED_COMM` needs to be set to `1` or `true` before launching the server. It is **off by default**.
+
+```bash
+export SGLANG_USE_MIXED_COMM=1
+python -m sglang.launch_server \
+    --model-path deepseek-ai/DeepSeek-V3 \
+    --tp 8 \
+    --dp-size 2 \
+    --enable-dp-attention \
+    ...
+```
+
 ## Modern Data Parallelism SGLang Model Gateway (SMG)
 
 ### Native DP Mode

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -1212,14 +1212,14 @@ class CommunicateSummableTensorPairFn:
             get_local_dp_buffer(),
             hidden_states,
         )
-        if should_use_dp_reduce_scatterv():
+        if allow_reduce_scatter and forward_batch.dp_padding_mode.is_max_len():
+            dp_reduce_scatter_tensor(hidden_states, global_hidden_states)
+        elif should_use_dp_reduce_scatterv():
             get_tp_group().reduce_scatterv(
                 global_hidden_states,
                 output=hidden_states,
                 sizes=get_dp_global_num_tokens(),
             )
-        elif allow_reduce_scatter and forward_batch.dp_padding_mode.is_max_len():
-            dp_reduce_scatter_tensor(hidden_states, global_hidden_states)
         else:
             dp_scatter(hidden_states, global_hidden_states, forward_batch)
         return hidden_states, residual

--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 import logging
+import os
 from contextlib import contextmanager
 from enum import IntEnum, auto
 from typing import TYPE_CHECKING, List, Optional, Tuple
@@ -48,6 +49,71 @@ _ENABLE_DP_ATTENTION_FLAG: bool = False
 
 _is_hip = is_hip()
 _USE_ROCM700A_WA = _is_hip and get_bool_env_var("SGLANG_USE_ROCM700A")
+
+# When enabled, route DP attention gather/reduce-scatter through flashinfer's
+# fused mixed_comm kernels (virtual-memory intra-node + nvshmem inter-node).
+_USE_MIXED_COMM = get_bool_env_var("SGLANG_USE_MIXED_COMM")
+
+if _USE_MIXED_COMM:
+    from flashinfer.comm.mixed_comm import (
+        MixedCommHandler,
+        MixedCommOp,
+        run_mixed_comm,
+    )
+
+_MIXED_COMM_HANDLER = None
+
+
+def _init_mixed_comm_handler(dtype: torch.dtype, device: torch.device):
+    """Construct the process-wide MixedCommHandler.
+
+    Must be called once per process, at a point outside any CUDA graph capture,
+    because the constructor performs collective init (new_group, broadcast,
+    barrier), nvshmem setup, and autotune. Topology maps flashinfer TP/DP to
+    sglang attention_tp/attention_dp.
+    """
+    global _MIXED_COMM_HANDLER
+    assert _USE_MIXED_COMM
+    assert _MIXED_COMM_HANDLER is None, "MixedCommHandler already initialized."
+
+    world_rank = torch.distributed.get_rank()
+    world_size = torch.distributed.get_world_size()
+    local_size = int(os.environ.get("LOCAL_WORLD_SIZE", str(torch.cuda.device_count())))
+    assert world_size % local_size == 0, (
+        f"SGLANG_USE_MIXED_COMM: world_size={world_size} is not a multiple of "
+        f"LOCAL_WORLD_SIZE={local_size}."
+    )
+    local_rank = world_rank % local_size
+    inter_size = world_size // local_size
+    inter_rank = world_rank // local_size
+
+    if device.type == "cuda" and device.index is None:
+        device = torch.device("cuda", torch.cuda.current_device())
+
+    attn_tp_size = get_attention_tp_size()
+    assert attn_tp_size % local_size == 0 or local_size % attn_tp_size == 0, (
+        f"SGLANG_USE_MIXED_COMM: the larger one of attn_tp_size={attn_tp_size} "
+        f"and LOCAL_WORLD_SIZE={local_size} must be a multiple of the smaller one."
+    )
+    local_tp_size = min(attn_tp_size, local_size)
+    local_dp_size = local_size // local_tp_size
+    inter_tp_size = attn_tp_size // local_tp_size
+    inter_dp_size = inter_size // inter_tp_size
+
+    _MIXED_COMM_HANDLER = MixedCommHandler(
+        world_rank=world_rank,
+        world_size=world_size,
+        local_rank=local_rank,
+        local_size=local_size,
+        inter_rank=inter_rank,
+        inter_size=inter_size,
+        local_tp_size=local_tp_size,
+        local_dp_size=local_dp_size,
+        inter_tp_size=inter_tp_size,
+        inter_dp_size=inter_dp_size,
+        dtype=dtype,
+        device=device,
+    )
 
 
 class DpPaddingMode(IntEnum):
@@ -310,6 +376,11 @@ def initialize_dp_attention(
         device=torch.device(server_args.device),
     )
 
+    # Construct the MixedCommHandler eagerly so its collective/nvshmem init and
+    # autotune run outside any CUDA graph capture that happens later.
+    if _USE_MIXED_COMM:
+        _init_mixed_comm_handler(model_config.dtype, torch.device(server_args.device))
+
 
 def is_dp_attention_enabled() -> bool:
     return _ENABLE_DP_ATTENTION_FLAG
@@ -484,6 +555,25 @@ def _dp_gather_via_all_gather(
     forward_batch: ForwardBatch,
     is_partial: bool,
 ):
+    if _USE_MIXED_COMM:
+        if get_attention_tp_size() == 1:
+            run_mixed_comm(
+                MixedCommOp.ALLGATHER,
+                _MIXED_COMM_HANDLER,
+                local_tokens,
+                global_tokens,
+            )
+        else:
+            if not is_partial and get_attention_tp_rank() != 0:
+                local_tokens.fill_(0)
+            run_mixed_comm(
+                MixedCommOp.ALLREDUCE_ALLGATHER,
+                _MIXED_COMM_HANDLER,
+                local_tokens,
+                global_tokens,
+            )
+        return
+
     if get_attention_tp_size() == 1:
         get_tp_group().all_gather_into_tensor(global_tokens, local_tokens)
         return
@@ -553,6 +643,20 @@ def dp_scatter(
 
 
 def dp_reduce_scatter_tensor(output: torch.Tensor, input: torch.Tensor):
+    if _USE_MIXED_COMM:
+        if get_tensor_model_parallel_world_size() == get_attention_dp_size():
+            run_mixed_comm(
+                MixedCommOp.REDUCESCATTER, _MIXED_COMM_HANDLER, input, output
+            )
+        else:
+            run_mixed_comm(
+                MixedCommOp.REDUCESCATTER_ALLREDUCE,
+                _MIXED_COMM_HANDLER,
+                input,
+                output,
+            )
+        return
+
     if get_tensor_model_parallel_world_size() == get_attention_dp_size():
         get_tp_group().reduce_scatter_tensor(output, input)
     else:

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -11,6 +11,7 @@ import torch
 from sglang.srt.distributed.parallel_state import get_moe_expert_parallel_world_size
 from sglang.srt.layers.dp_attention import (
     get_attention_dp_size,
+    get_attention_tp_size,
     is_dp_attention_enabled,
 )
 
@@ -346,6 +347,7 @@ def should_use_dp_reduce_scatterv():
         and get_moe_a2a_backend().is_none()
         and is_dp_attention_enabled()
         and get_attention_dp_size() > 1
+        and get_attention_tp_size() == 1
         and get_moe_expert_parallel_world_size() == get_attention_dp_size()
     )
 

--- a/test/registered/distributed/test_dp_attention.py
+++ b/test/registered/distributed/test_dp_attention.py
@@ -100,6 +100,52 @@ class TestDPAttentionMixedChunk(
         kill_process_tree(cls.process.pid)
 
 
+class TestDPAttentionDP2TP2MixedComm(
+    CustomTestCase,
+    GSM8KMixin,
+    JSONConstrainedMixin,
+    EBNFConstrainedMixin,
+    RegexConstrainedMixin,
+):
+    gsm8k_accuracy_thres = 0.6
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import flashinfer.comm.mixed_comm  # noqa: F401
+        except ImportError as e:
+            raise unittest.SkipTest(f"flashinfer.comm.mixed_comm unavailable: {e}")
+
+        cls.model = DEFAULT_MODEL_NAME_FOR_TEST_MLA
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls._env_override = envs.SGLANG_DISABLE_CONSECUTIVE_PREFILL_OVERLAP.override(
+            True
+        )
+        cls._env_override.__enter__()
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--tp",
+                "2",
+                "--enable-dp-attention",
+                "--dp",
+                "2",
+                "--enable-torch-compile",
+                "--torch-compile-max-bs",
+                "2",
+            ],
+            env={"SGLANG_USE_MIXED_COMM": "1"},
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+        cls._env_override.__exit__(None, None, None)
+
+
 class TestDPRetract(
     CustomTestCase,
     JSONConstrainedMixin,

--- a/test/registered/distributed/test_dp_attention_large.py
+++ b/test/registered/distributed/test_dp_attention_large.py
@@ -72,6 +72,56 @@ class TestDPAttentionDP2TP4(
 
 @unittest.skipIf(
     is_in_amd_ci(),
+    "MixedComm path is CUDA-only (flashinfer.comm.mixed_comm)",
+)
+class TestDPAttentionDP2TP4MixedComm(
+    CustomTestCase,
+    JSONConstrainedMixin,
+    EBNFConstrainedMixin,
+    RegexConstrainedMixin,
+):
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import flashinfer.comm.mixed_comm  # noqa: F401
+        except ImportError as e:
+            raise unittest.SkipTest(f"flashinfer.comm.mixed_comm unavailable: {e}")
+
+        cls.model = DEFAULT_MLA_MODEL_NAME_FOR_TEST
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--tp=4",
+                "--enable-dp-attention",
+                "--dp=2",
+            ],
+            env={"SGLANG_USE_MIXED_COMM": "1"},
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="gsm8k",
+            num_examples=None,
+            num_threads=1024,
+        )
+
+        metrics = run_eval(args)
+        print(f"{metrics=}")
+        self.assertGreater(metrics["score"], 0.8)
+
+
+@unittest.skipIf(
+    is_in_amd_ci(),
     "DeepSeek MTP forward_mla NameError on AMD + needs 8 GPUs",
 )
 class TestDPAttentionDP2TP2DeepseekV3MTP(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

When attention TP and DP are both used, two kernels are used for allreduce + allgather / reducescatter + allreduce currently (implemented via a reducescatter kernel + an allgather kernel). Using fused kernels for these two communication patterns can improve the performance in the low-latency scenarios.

A small bug is found when testing the following case (a single reducescatter is not sufficient for this case). Therefore, this PR also fixes this bug.
- attention_dp_size = moe_ep_size > 1
- attention_tp_size = moe_tp_size > 1

## Modifications

<!-- Detail the changes made in this pull request. -->

`python/sglang/srt/layers/dp_attention.py` is modified to use [MixedComm](https://github.com/flashinfer-ai/flashinfer/pull/2563) from FlashInfer when the environment variable `SGLANG_USE_MIXED_COMM` is set to `1` or `true`.

`python/sglang/srt/layers/communicator.py` is modified to prefer reduce_scatter over reduce_scatterv when the numbers of tokens are identical on all ranks.

`python/sglang/srt/layers/moe/utils.py` is modified to fix the abovementioned bug.

`docs/advanced_features/dp_dpa_smg_guide.md` is modified to update documentation.

`test/registered/distributed/test_dp_attention.py` and `test/registered/distributed/test_dp_attention_large.py` are modified to add unit tests.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

The accuracy has been verified by testing GSM8K and GPQA scores of Qwen3.5 on H200. The tested cases are:
- Number of GPUs: 8
- MoE EP size: 4
- Attention DP size: 2, 4, and 8

Scores:
- Attention DP size = 2
  - GSM8K: 0.980
  - GPQA: 0.865
- Attention DP size = 4
  - GSM8K: 0.980
  - GPQA: 0.873
- Attention DP size = 8
  - GSM8K: 0.990
  - GPQA: 0.869
 
Scripts to reproduce the results:
```bash
#!/bin/bash

export SGLANG_USE_MIXED_COMM=1

host=0.0.0.0
port=8000

model_path=../Qwen3.5-397B-A17B-FP8
quantization=fp8
kv_cache_dtype=fp8_e4m3

mem_fraction_static=0.83
max_running_requests=128
prefill_max_requests=1
max_prefill_tokens=$(( 128 * 1024 ))
chunked_prefill_size=$(( 64 * 1024 ))
cuda_graph_bs=(1 2 4 8 12 16 24 32 48 64 96 128)

prefill_attention_backend=fa3
decode_attention_backend=trtllm_mha
linear_attn_prefill_backend=triton
linear_attn_decode_backend=triton
fp8_gemm_backend=deep_gemm
moe_runner_backend=triton

function run_eval() {
    pkill -9 -f "sglang.launch_server" 2>/dev/null || true
    pkill -9 -f "sglang.srt.managers" 2>/dev/null || true
    sleep 10

    setsid python3 -m sglang.launch_server "${command_args[@]}" \
        > >(tee server_gpqa_${mode}.log) 2>&1 &
    server_pid=$!

    while ! curl -s http://${host}:${port}/health > /dev/null 2>&1; do
        sleep 10
    done

    python3 -m sglang.test.run_eval \
        --port 8000 \
        --eval-name gsm8k \
        --num-examples 100 \
        --max-tokens 10240 \
        --repeat 1 \
        --num-threads 100 \
        --num-shots 8 \
        --temperature 0.6 \
        --top-p 0.95 \
        --top-k 20 \
    2>&1 | tee out_gsm8k_${mode}.log

    python3 -m sglang.test.run_eval \
        --port 8000 \
        --eval-name gpqa \
        --num-examples 198 \
        --max-tokens 81920 \
        --repeat 8 \
        --temperature 0.6 \
        --top-p 0.95 \
        --top-k 20 \
    2>&1 | tee out_gpqa_${mode}.log

    if kill -0 ${server_pid} 2>/dev/null; then
        kill -9 -- -${server_pid} 2>/dev/null || kill -9 ${server_pid} 2>/dev/null
    fi
    wait ${server_pid} 2>/dev/null
    sleep 10
    echo "Evaluation completed for ${mode}"
}

num_gpus=8
ep_size=4
for dp_size in 2 4 8; do
    if (( dp_size == 1)); then
        dp_args="--dp-size ${dp_size}"
    else
        dp_args="--dp-size ${dp_size} --enable-dp-attention"
    fi
    a2a_args="--moe-a2a-backend none"

    command_args=(
        --host ${host}
        --port ${port}
        --model-path ${model_path}
        --quantization ${quantization}
        --kv-cache-dtype ${kv_cache_dtype}
        --mem-fraction-static ${mem_fraction_static}
        --max-running-requests ${max_running_requests}
        --prefill-max-requests ${prefill_max_requests}
        --max-prefill-tokens ${max_prefill_tokens}
        --chunked-prefill-size ${chunked_prefill_size}
        --cuda-graph-bs ${cuda_graph_bs[@]}
        --tp-size ${num_gpus}
        --ep-size ${ep_size}
        ${dp_args}
        ${a2a_args}
        --prefill-attention-backend ${prefill_attention_backend}
        --decode-attention-backend ${decode_attention_backend}
        --linear-attn-prefill-backend ${linear_attn_prefill_backend}
        --linear-attn-decode-backend ${linear_attn_decode_backend}
        --fp8-gemm-backend ${fp8_gemm_backend}
        --moe-runner-backend ${moe_runner_backend}
        --mamba-ssm-dtype bfloat16
        --random-seed 0
        --watchdog-timeout 3600
        --skip-server-warmup
        --model-loader-extra-config '{"enable_multithread_load": true}'
        --enable-multimodal
        --disable-radix-cache
        --incremental-streaming-output
        --enable-layerwise-nvtx-marker
    )
    mode=dp${dp_size}
    run_eval
done
```

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

The performance of Qwen3.5 is tested on H200 using the following cases:
- Number of GPUs: 8
- MoE EP size: 4
- Attention DP size: 2, 4, and 8
- Input length: 8192
- Output length: 24
- Concurrency: 16

Results of median ITL are obtained from the outputs of `sglang.bench_serving`. Results of kernel execution time are obtained by analyzing nsys timelines.

---
| Attn DP Size = 2 | NCCL Baseline | NCCL Symmetric | MixedComm | Perf Gain w.r.t NCCL Symmetric |
|---|---|---|---|---|
| Median ITL (ms) | 14.889  | 14.386  | 12.002 | 1.20x |
| Comm Kern Time w/ load imbalance (ms) | 3.817 | 3.631 | 2.145 | 1.69x |
| Comm Kern Time w/o load imbalance (ms)  | 1.582 | 1.323 | 0.399 | 3.32x |
---

---
| Attn DP Size = 4 | NCCL Baseline | NCCL Symmetric | MixedComm | Perf Gain w.r.t NCCL Symmetric |
|---|---|---|---|---|
| Median ITL (ms) | 15.155  | 14.824  | 12.924 | 1.15x |
| Comm Kern Time w/ load imbalance (ms) | 3.595 | 3.261 | 2.286 | 1.43x |
| Comm Kern Time w/o load imbalance (ms)  | 1.274 | 1.267 | 0.405 | 3.13x |
---

---
| Attn DP Size = 8 | NCCL Baseline | NCCL Symmetric | MixedComm | Perf Gain w.r.t NCCL Symmetric |
|---|---|---|---|---|
| Median ITL (ms) | 15.043  | 14.262  | 13.560 | 1.05x |
| Comm Kern Time w/ load imbalance (ms) | 2.492 | 1.776 | 1.435 | 1.24x |
| Comm Kern Time w/o load imbalance (ms)  | 1.168 | 0.673 | 0.340 | 1.98x |
---

The performance is tested using the following commands:
```bash
#!/bin/bash

# Comment the following line to disable MixedComm
export SGLANG_USE_MIXED_COMM=1

host=0.0.0.0
port=8000

model_path=../Qwen3.5-397B-A17B-FP8
quantization=fp8
kv_cache_dtype=fp8_e4m3

mem_fraction_static=0.84
max_running_requests=128
prefill_max_requests=1
max_prefill_tokens=$(( 128 * 1024 ))
chunked_prefill_size=$(( 64 * 1024 ))
cuda_graph_bs=(1 2 4 8 12 16 24 32 48 64 96 128)

prefill_attention_backend=fa3
decode_attention_backend=trtllm_mha
linear_attn_prefill_backend=triton
linear_attn_decode_backend=triton
fp8_gemm_backend=deep_gemm
moe_runner_backend=triton

folder_out=timelines
if [[ ! -d ${folder_out} ]]; then mkdir ${folder_out}; fi

num_gpus=8
ep_size=4
for dp_size in 2 4 8; do
    if (( dp_size == 1)); then
        dp_args="--dp-size ${dp_size}"
    else
        dp_args="--dp-size ${dp_size} --enable-dp-attention"
    fi
    a2a_args="--moe-a2a-backend none"
    # Add --enable-symm-mem and --enable-nccl-nvls to use NCCL symmetric kernels
    command_args=(
        --host ${host}
        --port ${port}
        --model-path ${model_path}
        --quantization ${quantization}
        --kv-cache-dtype ${kv_cache_dtype}
        --mem-fraction-static ${mem_fraction_static}
        --max-running-requests ${max_running_requests}
        --prefill-max-requests ${prefill_max_requests}
        --max-prefill-tokens ${max_prefill_tokens}
        --chunked-prefill-size ${chunked_prefill_size}
        --cuda-graph-bs ${cuda_graph_bs[@]}
        --tp-size ${num_gpus}
        --ep-size ${ep_size}
        ${dp_args}
        ${a2a_args}
        --prefill-attention-backend ${prefill_attention_backend}
        --decode-attention-backend ${decode_attention_backend}
        --linear-attn-prefill-backend ${linear_attn_prefill_backend}
        --linear-attn-decode-backend ${linear_attn_decode_backend}
        --fp8-gemm-backend ${fp8_gemm_backend}
        --moe-runner-backend ${moe_runner_backend}
        --mamba-ssm-dtype bfloat16
        --random-seed 0
        --watchdog-timeout 3600
        --skip-server-warmup
        --model-loader-extra-config '{"enable_multithread_load": true}'
        --enable-multimodal
        --disable-radix-cache
        --incremental-streaming-output
        --enable-layerwise-nvtx-marker
    )

    pkill -9 -f "sglang.launch_server" 2>/dev/null || true
    pkill -9 -f "sglang.srt.managers" 2>/dev/null || true
    sleep 10

    setsid nsys launch \
        --session-new profile_session \
        --trace-fork-before-exec=true \
        --cuda-graph-trace=node \
        --trace cuda,nvtx,mpi \
        python3 -m sglang.launch_server "${command_args[@]}" \
        > >(tee server_dp${dp_size}_ep${ep_size}.log) 2>&1 &
    server_pid=$!

    while ! curl -s http://${host}:${port}/health > /dev/null 2>&1; do
        sleep 10
    done

    for input_len_base in 8; do
        input_len=$(( input_len_base * 1024 ))
        for concurrency in 16; do
            output_len=$(( concurrency + 8 ))
            name=${folder_out}/qwen_isl${input_len}_bs${concurrency}_dp${dp_size}_ep${ep_size}
            command_args=(
                --backend sglang
                --dataset-name random
                --host ${host}
                --port ${port}
                --model ${model_path}
                --tokenizer ${model_path}
                --num-prompts ${concurrency}
                --random-input ${input_len}
                --random-output ${output_len}
                --max-concurrency ${concurrency}
                --output-file ${name}.jsonl
                --random-range-ratio 1.0
                --warmup-requests 1
                --seed 0
            )
            nsys start \
                --session profile_session \
                --backtrace none \
                --sample none \
                --cpuctxsw none \
                --force-overwrite true \
                --output ${name} || echo "ERROR: nsys start failed for ${name}"
            python3 -m sglang.bench_serving "${command_args[@]}"
            nsys stop --session profile_session || echo "ERROR: nsys stop failed for ${name}"
        done
    done

    nsys shutdown --session profile_session || true
    # If nsys shutdown failed to terminate the server, kill it explicitly
    if kill -0 ${server_pid} 2>/dev/null; then
        kill -9 -- -${server_pid} 2>/dev/null || kill -9 ${server_pid} 2>/dev/null || true
    fi
    wait ${server_pid} 2>/dev/null || true
    sleep 10
done
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.