### PR TITLE
[Bugfix] Re-export is_port_available from sglang.srt.utils package init

### DIFF
--- a/python/sglang/srt/utils/__init__.py
+++ b/python/sglang/srt/utils/__init__.py
@@ -1,2 +1,5 @@
 # Temporarily do this to avoid changing all imports in the repo
 from sglang.srt.utils.common import *
+
+# Backward-compat re-export: `is_port_available` was moved to network.py in #20646.
+from sglang.srt.utils.network import is_port_available

--- a/test/registered/utils/test_socket_utils.py
+++ b/test/registered/utils/test_socket_utils.py
@@ -152,6 +152,12 @@ class TestSocketUtilities(CustomTestCase):
         finally:
             sock.close()
 
+    def test_is_port_available_reexported_from_package(self):
+        """`is_port_available` must remain importable from `sglang.srt.utils`."""
+        from sglang.srt.utils import is_port_available as reexported
+
+        self.assertIs(reexported, is_port_available)
+
 
 class TestReservePort(CustomTestCase):
     def test_reserve_port_returns_port_and_socket(self):


### PR DESCRIPTION
## Motivation

`from sglang.srt.utils import is_port_available` raises `ImportError` on
`sglang >= 0.5.10`:

```
ImportError: cannot import name 'is_port_available' from 'sglang.srt.utils'
```

`is_port_available` was moved from `sglang/srt/utils/common.py` to
`sglang/srt/utils/network.py` in #20646, but the package-level re-export was
not preserved (`utils/__init__.py` only does `from .common import *`).

The in-tree `sgl-model-gateway/bindings/python/src/sglang_router/launch_server.py`
already imports from `sglang.srt.utils.network` directly, so this re-export
specifically guards users running `sglang >= 0.5.10` against an older published
`sglang-router 0.3.2` wheel that still imports via the package path.

## Modifications

- `python/sglang/srt/utils/__init__.py`: re-export `is_port_available` from
  `network` so the package path stays valid for downstream wheels.
- `test/registered/utils/test_socket_utils.py`: regression test asserting the
  package-level import resolves to the same function as the direct one.

## How to verify

```bash
python -c "from sglang.srt.utils import is_port_available; print(is_port_available(12345))"
```

Fixes #23535