### PR TITLE
[bug fix] flashinfer fusion: preflight workspace allocation to avoid NCCL hang

### DIFF
--- a/python/sglang/srt/layers/flashinfer_comm_fusion.py
+++ b/python/sglang/srt/layers/flashinfer_comm_fusion.py
@@ -275,9 +275,9 @@ def _preflight_check_workspace_memory(
     )
     if flag.item() == 0:
         logger.warning(
-            "FlashInfer workspace preflight: fabric probe failed on at "
-            "least one rank. Skipping allreduce fusion to avoid "
-            "cross-rank desync inside the flashinfer collective."
+            "FlashInfer workspace preflight: cuMemCreate probe failed on at "
+            "least one rank. Skipping allreduce fusion to avoid cross-rank "
+            "desync inside the flashinfer collective."
         )
         return False
     return True

--- a/python/sglang/srt/layers/flashinfer_comm_fusion.py
+++ b/python/sglang/srt/layers/flashinfer_comm_fusion.py
@@ -167,44 +167,26 @@ def _preflight_check_workspace_memory(
     """Collectively decide whether to enter create_allreduce_fusion_workspace.
 
     If one rank OOMs in flashinfer's per-rank cuMemCreate and escapes via
-    the caller's try/except while another rank enters the internal
-    cross-rank handle exchange, the surviving rank blocks until the NCCL
-    watchdog aborts the process ~10 minutes later. This preflight has
-    every rank probe a matching cuMemCreate locally and vote on a CPU
-    group so all ranks either proceed or skip atomically.
+    the caller's try/except while peers are blocked in the cross-rank
+    handle exchange, the surviving rank stalls until the NCCL watchdog
+    aborts ~10 minutes later. Every rank probes a matching cuMemCreate
+    and votes on a CPU group so all ranks proceed or skip atomically.
 
-    torch.cuda.mem_get_info() is not a reliable signal on FABRIC-handle
-    systems (the fabric pool can be smaller than the driver's generic
-    free counter), so we probe with the same handle type flashinfer
-    will use -- FABRIC on devices where is_mnnvl_fabric_supported is
-    True (typically GB200), POSIX_FILE_DESCRIPTOR otherwise (H200/B200).
-
-    Lifecycle note: the probe momentarily allocates a buffer the size of
-    flashinfer's largest single allocation (the lamport buffer, capped at
-    3 * MAX_COMM_SIZE ~= 6 GiB) and releases it immediately. Intended to
-    run once at startup before the model occupies device memory.
-
-    Caveat: on POSIX_FD systems the probe doesn't model FD-table
-    exhaustion, which is a separate failure mode flashinfer can hit
-    across its three handle allocations.
+    Probes with the handle type flashinfer will use (FABRIC where
+    is_mnnvl_fabric_supported, POSIX_FD otherwise) since
+    torch.cuda.mem_get_info() doesn't reflect the fabric pool.
+    The probe transiently allocates the lamport buffer
+    (<= 3 * MAX_COMM_SIZE ~= 6 GiB) and releases it; runs once at
+    startup before the model occupies device memory. POSIX_FD FD-table
+    exhaustion is not modeled.
     """
-    # Setup: import + prop construction + granularity query. Any failure
-    # here means the preflight can't run on this platform; fall through to
-    # the existing try/except around create_allreduce_fusion_workspace,
-    # which still handles OOM at a per-rank granularity (the same behavior
-    # we had before this preflight existed).
     try:
         import torch.distributed as dist
         from cuda import cuda as _cu
         from flashinfer.comm.mnnvl import is_mnnvl_fabric_supported
 
-        # Match flashinfer's SymmDeviceMemory exchanger selection
-        # (mnnvl.py:949-957): FABRIC on systems with multi-node NVLink
-        # fabric initialized (e.g. GB200), POSIX_FD elsewhere (H200/B200).
-        # The hang surface is identical -- any per-rank cuMemCreate OOM
-        # that escapes via the caller's try/except while peers are blocked
-        # in the cross-rank handle exchange triggers the NCCL watchdog --
-        # so we must probe with whichever handle flashinfer will use.
+        # Match flashinfer SymmDeviceMemory's exchanger selection
+        # (mnnvl.py:949-957) so the probe sees the same allocator.
         if is_mnnvl_fabric_supported(torch.cuda.current_device()):
             handle_type = _cu.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_FABRIC
         else:
@@ -213,9 +195,8 @@ def _preflight_check_workspace_memory(
             )
 
         dtype_bytes = torch.empty((), dtype=dtype).element_size()
-        # Mirror flashinfer's lamport sizing in trtllm_ar.py: cap the
-        # per-comm size at MAX_COMM_SIZE (INT32_MAX rounded down to 2 MiB)
-        # then triple it for the lamport buffer.
+        # Mirror flashinfer's lamport sizing (trtllm_ar.py): per-comm size
+        # capped at MAX_COMM_SIZE, then x3 for the lamport buffer.
         _MAX_COMM_SIZE = 2147483647 & ~((1 << 21) - 1)
         lamport_comm_size = min(
             world_size * max_token_num * hidden_dim * dtype_bytes,
@@ -236,9 +217,8 @@ def _preflight_check_workspace_memory(
             _cu.CUmemAllocationGranularity_flags.CU_MEM_ALLOC_GRANULARITY_RECOMMENDED,
         )
         if err != _cu.CUresult.CUDA_SUCCESS:
-            # Fail closed: if the driver can't even tell us the granularity
-            # for the chosen handle type, flashinfer's real allocation won't
-            # work either -- skip fusion rather than risk the 10-minute hang.
+            # Fail closed: granularity failure implies the real allocation
+            # would fail too.
             logger.warning(
                 "FlashInfer workspace preflight: cuMemGetAllocationGranularity "
                 "failed (%s). Skipping allreduce fusion.",
@@ -247,6 +227,8 @@ def _preflight_check_workspace_memory(
             return False
         aligned_probe = ((probe_size + gran - 1) // gran) * gran
     except Exception as e:
+        # Setup couldn't run on this platform; fall through to the legacy
+        # per-rank try/except around create_allreduce_fusion_workspace.
         logger.warning(
             "FlashInfer workspace preflight bypassed (setup error: %s); "
             "proceeding without the collective guard.",
@@ -254,7 +236,6 @@ def _preflight_check_workspace_memory(
         )
         return True
 
-    # Probe: the cuMemRelease must run regardless of what happens next.
     local_ok = 0
     handle = None
     try:
@@ -264,9 +245,8 @@ def _preflight_check_workspace_memory(
         if local_ok:
             _cu.cuMemRelease(handle)
 
-    # Vote: failures here (e.g. gloo transport error) cannot fall through
-    # to True -- if some ranks enter the flashinfer call and others don't,
-    # we reintroduce the original hang. Skip fusion on any vote failure.
+    # Vote: any failure here must fail closed -- falling through to True
+    # would let some ranks enter flashinfer while others skip and hang.
     try:
         group = cpu_group
         if group is None:

--- a/python/sglang/srt/layers/flashinfer_comm_fusion.py
+++ b/python/sglang/srt/layers/flashinfer_comm_fusion.py
@@ -157,6 +157,121 @@ def is_flashinfer_allreduce_unavailable() -> bool:
     return _flashinfer_allreduce_unavailable
 
 
+def _preflight_check_workspace_memory(
+    world_size: int,
+    max_token_num: int,
+    hidden_dim: int,
+    dtype: torch.dtype,
+    cpu_group: Optional["torch.distributed.ProcessGroup"] = None,
+) -> bool:
+    """Collectively decide whether to enter create_allreduce_fusion_workspace.
+
+    If one rank OOMs in flashinfer's per-rank fabric allocation and escapes
+    via the caller's try/except while another rank enters the internal
+    cross-rank collective, the surviving rank blocks until the NCCL
+    watchdog aborts the process ~10 minutes later. This preflight has
+    every rank probe a matching cuMemCreate locally and vote on a CPU
+    group so all ranks either proceed or skip atomically.
+
+    torch.cuda.mem_get_info() is not a reliable signal: the fabric
+    pool can be smaller than the driver's generic free counter, so we
+    probe with the same handle type flashinfer uses.
+    """
+    # Setup: import + prop construction + granularity query. Any failure
+    # here means the preflight can't run on this platform; fall through to
+    # the existing try/except around create_allreduce_fusion_workspace,
+    # which still handles OOM at a per-rank granularity (the same behavior
+    # we had before this preflight existed).
+    try:
+        import torch.distributed as dist
+        from cuda import cuda as _cu
+
+        dtype_bytes = torch.empty((), dtype=dtype).element_size()
+        # lamport buffer (3x the base) is the largest flashinfer allocation.
+        probe_size = 3 * world_size * max_token_num * hidden_dim * dtype_bytes
+
+        prop = _cu.CUmemAllocationProp()
+        prop.requestedHandleTypes = (
+            _cu.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_FABRIC
+        )
+        prop.type = _cu.CUmemAllocationType.CU_MEM_ALLOCATION_TYPE_PINNED
+        prop.location = _cu.CUmemLocation()
+        prop.location.type = _cu.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
+        prop.location.id = torch.cuda.current_device()
+        prop.allocFlags.gpuDirectRDMACapable = 1
+
+        err, gran = _cu.cuMemGetAllocationGranularity(
+            prop,
+            _cu.CUmemAllocationGranularity_flags.CU_MEM_ALLOC_GRANULARITY_RECOMMENDED,
+        )
+        if err != _cu.CUresult.CUDA_SUCCESS:
+            # Fail closed: if the driver can't even tell us the granularity
+            # for a fabric handle, flashinfer's real allocation won't work
+            # either -- skip fusion rather than risk the 10-minute hang.
+            logger.warning(
+                "FlashInfer workspace preflight: cuMemGetAllocationGranularity "
+                "failed (%s). Skipping allreduce fusion.",
+                err,
+            )
+            return False
+        aligned_probe = ((probe_size + gran - 1) // gran) * gran
+    except Exception as e:
+        logger.warning(
+            "FlashInfer workspace preflight bypassed (setup error: %s); "
+            "proceeding without the collective guard.",
+            e,
+        )
+        return True
+
+    # Probe: the cuMemRelease must run regardless of what happens next.
+    local_ok = 0
+    handle = None
+    try:
+        err, handle = _cu.cuMemCreate(aligned_probe, prop, 0)
+        local_ok = 1 if err == _cu.CUresult.CUDA_SUCCESS else 0
+    finally:
+        if local_ok and handle is not None:
+            _cu.cuMemRelease(handle)
+
+    # Vote: failures here (e.g. gloo transport error) cannot fall through
+    # to True -- if some ranks enter the flashinfer call and others don't,
+    # we reintroduce the original hang. Skip fusion on any vote failure.
+    try:
+        group = cpu_group
+        if group is None:
+            tp_group = get_tp_group()
+            if tp_group.world_size <= 1:
+                return local_ok == 1
+            group = tp_group.cpu_group
+
+        flag = torch.tensor([local_ok], dtype=torch.int32)
+        dist.all_reduce(flag, op=dist.ReduceOp.MIN, group=group)
+    except Exception as e:
+        logger.warning(
+            "FlashInfer workspace preflight vote failed (%s). "
+            "Skipping allreduce fusion.",
+            e,
+        )
+        return False
+
+    logger.debug(
+        "FlashInfer workspace preflight [rank %s]: probe=%.2f GB, "
+        "local_probe=%s, vote=%s",
+        dist.get_rank(group=group),
+        aligned_probe / 1e9,
+        "OK" if local_ok else "FAIL",
+        "PROCEED" if flag.item() == 1 else "SKIP",
+    )
+    if flag.item() == 0:
+        logger.warning(
+            "FlashInfer workspace preflight: fabric probe failed on at "
+            "least one rank. Skipping allreduce fusion to avoid "
+            "cross-rank desync inside the flashinfer collective."
+        )
+        return False
+    return True
+
+
 class FlashInferWorkspaceManager:
     def __init__(self):
         self.workspace = None
@@ -187,6 +302,20 @@ class FlashInferWorkspaceManager:
             return
 
         self.cleanup()
+
+        global _flashinfer_allreduce_unavailable
+        if not _preflight_check_workspace_memory(
+            world_size=world_size,
+            max_token_num=max_token_num,
+            hidden_dim=hidden_dim,
+            dtype=dtype,
+            cpu_group=cpu_group,
+        ):
+            _flashinfer_allreduce_unavailable = True
+            self.workspace = None
+            self.initialized = False
+            return
+
         try:
             kwargs = dict(
                 backend="trtllm",
@@ -210,7 +339,6 @@ class FlashInferWorkspaceManager:
                     **kwargs
                 )
         except Exception as e:
-            global _flashinfer_allreduce_unavailable
             _flashinfer_allreduce_unavailable = True
             logger.warning(
                 f"Failed to initialize FlashInfer workspace: {e}. "

--- a/python/sglang/srt/layers/flashinfer_comm_fusion.py
+++ b/python/sglang/srt/layers/flashinfer_comm_fusion.py
@@ -166,21 +166,27 @@ def _preflight_check_workspace_memory(
 ) -> bool:
     """Collectively decide whether to enter create_allreduce_fusion_workspace.
 
-    If one rank OOMs in flashinfer's per-rank fabric allocation and escapes
-    via the caller's try/except while another rank enters the internal
-    cross-rank collective, the surviving rank blocks until the NCCL
+    If one rank OOMs in flashinfer's per-rank cuMemCreate and escapes via
+    the caller's try/except while another rank enters the internal
+    cross-rank handle exchange, the surviving rank blocks until the NCCL
     watchdog aborts the process ~10 minutes later. This preflight has
     every rank probe a matching cuMemCreate locally and vote on a CPU
     group so all ranks either proceed or skip atomically.
 
-    torch.cuda.mem_get_info() is not a reliable signal: the fabric
-    pool can be smaller than the driver's generic free counter, so we
-    probe with the same handle type flashinfer uses.
+    torch.cuda.mem_get_info() is not a reliable signal on FABRIC-handle
+    systems (the fabric pool can be smaller than the driver's generic
+    free counter), so we probe with the same handle type flashinfer
+    will use -- FABRIC on devices where is_mnnvl_fabric_supported is
+    True (typically GB200), POSIX_FILE_DESCRIPTOR otherwise (H200/B200).
 
     Lifecycle note: the probe momentarily allocates a buffer the size of
     flashinfer's largest single allocation (the lamport buffer, capped at
     3 * MAX_COMM_SIZE ~= 6 GiB) and releases it immediately. Intended to
     run once at startup before the model occupies device memory.
+
+    Caveat: on POSIX_FD systems the probe doesn't model FD-table
+    exhaustion, which is a separate failure mode flashinfer can hit
+    across its three handle allocations.
     """
     # Setup: import + prop construction + granularity query. Any failure
     # here means the preflight can't run on this platform; fall through to
@@ -190,6 +196,21 @@ def _preflight_check_workspace_memory(
     try:
         import torch.distributed as dist
         from cuda import cuda as _cu
+        from flashinfer.comm.mnnvl import is_mnnvl_fabric_supported
+
+        # Match flashinfer's SymmDeviceMemory exchanger selection
+        # (mnnvl.py:949-957): FABRIC on systems with multi-node NVLink
+        # fabric initialized (e.g. GB200), POSIX_FD elsewhere (H200/B200).
+        # The hang surface is identical -- any per-rank cuMemCreate OOM
+        # that escapes via the caller's try/except while peers are blocked
+        # in the cross-rank handle exchange triggers the NCCL watchdog --
+        # so we must probe with whichever handle flashinfer will use.
+        if is_mnnvl_fabric_supported(torch.cuda.current_device()):
+            handle_type = _cu.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_FABRIC
+        else:
+            handle_type = (
+                _cu.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+            )
 
         dtype_bytes = torch.empty((), dtype=dtype).element_size()
         # Mirror flashinfer's lamport sizing in trtllm_ar.py: cap the
@@ -203,9 +224,7 @@ def _preflight_check_workspace_memory(
         probe_size = 3 * lamport_comm_size
 
         prop = _cu.CUmemAllocationProp()
-        prop.requestedHandleTypes = (
-            _cu.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_FABRIC
-        )
+        prop.requestedHandleTypes = handle_type
         prop.type = _cu.CUmemAllocationType.CU_MEM_ALLOCATION_TYPE_PINNED
         prop.location = _cu.CUmemLocation()
         prop.location.type = _cu.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
@@ -218,8 +237,8 @@ def _preflight_check_workspace_memory(
         )
         if err != _cu.CUresult.CUDA_SUCCESS:
             # Fail closed: if the driver can't even tell us the granularity
-            # for a fabric handle, flashinfer's real allocation won't work
-            # either -- skip fusion rather than risk the 10-minute hang.
+            # for the chosen handle type, flashinfer's real allocation won't
+            # work either -- skip fusion rather than risk the 10-minute hang.
             logger.warning(
                 "FlashInfer workspace preflight: cuMemGetAllocationGranularity "
                 "failed (%s). Skipping allreduce fusion.",

--- a/python/sglang/srt/layers/flashinfer_comm_fusion.py
+++ b/python/sglang/srt/layers/flashinfer_comm_fusion.py
@@ -176,6 +176,11 @@ def _preflight_check_workspace_memory(
     torch.cuda.mem_get_info() is not a reliable signal: the fabric
     pool can be smaller than the driver's generic free counter, so we
     probe with the same handle type flashinfer uses.
+
+    Lifecycle note: the probe momentarily allocates a buffer the size of
+    flashinfer's largest single allocation (the lamport buffer, capped at
+    3 * MAX_COMM_SIZE ~= 6 GiB) and releases it immediately. Intended to
+    run once at startup before the model occupies device memory.
     """
     # Setup: import + prop construction + granularity query. Any failure
     # here means the preflight can't run on this platform; fall through to
@@ -187,8 +192,15 @@ def _preflight_check_workspace_memory(
         from cuda import cuda as _cu
 
         dtype_bytes = torch.empty((), dtype=dtype).element_size()
-        # lamport buffer (3x the base) is the largest flashinfer allocation.
-        probe_size = 3 * world_size * max_token_num * hidden_dim * dtype_bytes
+        # Mirror flashinfer's lamport sizing in trtllm_ar.py: cap the
+        # per-comm size at MAX_COMM_SIZE (INT32_MAX rounded down to 2 MiB)
+        # then triple it for the lamport buffer.
+        _MAX_COMM_SIZE = 2147483647 & ~((1 << 21) - 1)
+        lamport_comm_size = min(
+            world_size * max_token_num * hidden_dim * dtype_bytes,
+            _MAX_COMM_SIZE,
+        )
+        probe_size = 3 * lamport_comm_size
 
         prop = _cu.CUmemAllocationProp()
         prop.requestedHandleTypes = (
@@ -230,7 +242,7 @@ def _preflight_check_workspace_memory(
         err, handle = _cu.cuMemCreate(aligned_probe, prop, 0)
         local_ok = 1 if err == _cu.CUresult.CUDA_SUCCESS else 0
     finally:
-        if local_ok and handle is not None:
+        if local_ok:
             _cu.cuMemRelease(handle)
 
     # Vote: failures here (e.g. gloo transport error) cannot fall through

--- a/test/registered/distributed/test_flashinfer_fusion_preflight.py
+++ b/test/registered/distributed/test_flashinfer_fusion_preflight.py
@@ -1,0 +1,168 @@
+"""Real-distributed integration tests for FlashInfer fusion workspace preflight.
+
+Spawns multiple processes on real CUDA devices (no mocks) and exercises
+`_preflight_check_workspace_memory` from
+`sglang.srt.layers.flashinfer_comm_fusion`:
+
+- happy path: every rank's probe succeeds, vote returns PROCEED
+- skewed path: rank 0 pre-pins enough memory that its probe must fail,
+  every rank's vote returns SKIP (i.e. failure is *broadcast*)
+"""
+
+import multiprocessing as mp
+import os
+import unittest
+
+import torch
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=30, suite="stage-b-test-2-gpu-large")
+
+WORLD_SIZE = 2
+
+
+def _run_rank(rank, world_size, scenario, result_q):
+    """Worker entrypoint. Each rank runs end-to-end in its own process."""
+    try:
+        os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+        os.environ.setdefault("MASTER_PORT", "29512")
+        os.environ["RANK"] = str(rank)
+        os.environ["WORLD_SIZE"] = str(world_size)
+        os.environ["LOCAL_RANK"] = str(rank)
+
+        torch.cuda.set_device(rank)
+
+        import torch.distributed as dist
+
+        dist.init_process_group(
+            backend="gloo",
+            rank=rank,
+            world_size=world_size,
+        )
+        cpu_group = dist.group.WORLD
+
+        from sglang.srt.layers.flashinfer_comm_fusion import (
+            _preflight_check_workspace_memory,
+        )
+
+        # Mirror an 8-way TP lamport probe (~6 GiB after the MAX_COMM_SIZE cap
+        # x3): big enough that the starvation scenario reliably exhausts the
+        # rank-0 device pool, small enough not to OOM a healthy rank.
+        probe_kwargs = dict(
+            world_size=8,
+            max_token_num=2048,
+            hidden_dim=12288,
+            dtype=torch.bfloat16,
+            cpu_group=cpu_group,
+        )
+
+        held = None
+        if scenario == "rank0_starved" and rank == 0:
+            # Pin almost all of GPU 0's memory so the probe's cuMemCreate
+            # has nowhere to land. Use cuMemCreate (matches the probe path)
+            # rather than torch.empty so we starve the same allocator pool.
+            from cuda import cuda as _cu
+
+            free, _total = torch.cuda.mem_get_info(rank)
+            # Leave only ~1 GiB so the ~6 GiB lamport probe must fail.
+            target = max(free - (1 << 30), 0)
+
+            prop = _cu.CUmemAllocationProp()
+            prop.requestedHandleTypes = (
+                _cu.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+            )
+            prop.type = _cu.CUmemAllocationType.CU_MEM_ALLOCATION_TYPE_PINNED
+            prop.location = _cu.CUmemLocation()
+            prop.location.type = _cu.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
+            prop.location.id = rank
+            prop.allocFlags.gpuDirectRDMACapable = 1
+
+            err, gran = _cu.cuMemGetAllocationGranularity(
+                prop,
+                _cu.CUmemAllocationGranularity_flags.CU_MEM_ALLOC_GRANULARITY_RECOMMENDED,
+            )
+            assert err == _cu.CUresult.CUDA_SUCCESS, err
+            aligned = (target // gran) * gran
+            err, held = _cu.cuMemCreate(aligned, prop, 0)
+            assert err == _cu.CUresult.CUDA_SUCCESS, (err, aligned)
+
+        try:
+            decision = _preflight_check_workspace_memory(**probe_kwargs)
+        finally:
+            if held is not None:
+                from cuda import cuda as _cu
+
+                _cu.cuMemRelease(held)
+
+        # The vote must be unanimous. Make every rank report so the parent
+        # can assert all of them, not just rank 0.
+        result_q.put((rank, "ok", bool(decision)))
+    except Exception as e:  # pragma: no cover - debug path
+        result_q.put((rank, "err", repr(e)))
+    finally:
+        try:
+            import torch.distributed as dist
+
+            if dist.is_initialized():
+                dist.destroy_process_group()
+        except Exception:
+            pass
+
+
+def _spawn_and_collect(scenario, world_size=WORLD_SIZE, port=29512):
+    ctx = mp.get_context("spawn")
+    q = ctx.Queue()
+    procs = []
+    for r in range(world_size):
+        p = ctx.Process(
+            target=_run_rank,
+            args=(r, world_size, scenario, q),
+        )
+        p.start()
+        procs.append(p)
+
+    results = {}
+    for _ in range(world_size):
+        rank, status, payload = q.get(timeout=300)
+        results[rank] = (status, payload)
+    for p in procs:
+        p.join(timeout=60)
+        assert p.exitcode == 0, f"rank exited with {p.exitcode}"
+    return results
+
+
+class TestFlashInferPreflightDistributed(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available() or torch.cuda.device_count() < WORLD_SIZE:
+            raise unittest.SkipTest(
+                f"Need {WORLD_SIZE} CUDA devices, got {torch.cuda.device_count()}"
+            )
+        try:
+            from cuda import cuda  # noqa: F401
+        except Exception as e:
+            raise unittest.SkipTest(f"cuda-python not importable: {e}")
+
+    def test_happy_path_votes_proceed(self):
+        """Normal probe: every rank's local probe succeeds -> PROCEED."""
+        results = _spawn_and_collect("normal")
+        for rank, (status, payload) in results.items():
+            self.assertEqual(status, "ok", f"rank {rank}: {payload}")
+            self.assertTrue(payload, f"rank {rank} voted SKIP unexpectedly")
+
+    def test_starved_rank_broadcasts_skip(self):
+        """One starved rank fails its probe; all ranks must agree to SKIP."""
+        results = _spawn_and_collect("rank0_starved")
+        for rank, (status, payload) in results.items():
+            self.assertEqual(status, "ok", f"rank {rank}: {payload}")
+            self.assertFalse(
+                payload,
+                f"rank {rank} voted PROCEED but rank 0 was starved -- "
+                "vote did not propagate, this is the original hang bug",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- Adds a collective preflight in `FlashInferWorkspaceManager.initialize_workspace` so all ranks atomically agree on whether to enter `create_allreduce_fusion_workspace` or fall back to the non-fused path.
- Fixes a ~10 minute NCCL watchdog hang that occurred when one rank OOMed in flashinfer's per-rank fabric allocation and escaped via the caller's try/except, while peer ranks blocked inside the internal cross-rank collective.

## Background

`flashinfer` allocates a per-rank fabric workspace and then performs a cross-rank handshake to share IPC handles. If rank A fails the per-rank `cuMemCreate` (e.g. fabric pool exhausted) and the caller catches the exception, rank B is already blocked inside the collective and cannot make progress. NCCL then aborts ~10 minutes later — much too late, and surfaced as an opaque watchdog timeout rather than the underlying OOM.

`torch.cuda.mem_get_info()` is not a sufficient signal here: the fabric pool can be smaller than the driver's generic free counter, so a rank can have plenty of \"free\" memory and still fail the fabric `cuMemCreate`.

## Approach

`_preflight_check_workspace_memory` runs before `create_allreduce_fusion_workspace`:

1. **Setup** — import + build a `CUmemAllocationProp` matching flashinfer's fabric handle type, query the recommended granularity, align the lamport-buffer-sized probe (`3 * world_size * max_token_num * hidden_dim * dtype_bytes`).
2. **Probe** — every rank attempts a matching `cuMemCreate` for the aligned probe size, releasing immediately on success.
3. **Vote** — `all_reduce(MIN)` over the int32 success flag on the TP CPU group. All ranks proceed only if every rank's local probe succeeded.

Failure modes:
- **Setup failure** (e.g. cuda-python missing): fall through with `True`. The existing per-rank `try/except` around `create_allreduce_fusion_workspace` still handles OOM at the prior granularity — same behavior we had before this preflight existed.
- **Granularity query failure**: fail closed (`False`). If the driver can't describe a fabric handle, the real allocation won't work either.
- **Vote failure** (e.g. gloo transport error): fail closed (`False`). Falling through to `True` here would reintroduce the original hang if some ranks entered the collective and others didn't.

On any \"skip\" decision, `_flashinfer_allreduce_unavailable` is set so subsequent calls bypass fusion without re-probing.

## Test plan

- [ ] Reproduce the original 10-minute hang on the deployment that triggered this (high `max_token_num` + tight fabric pool) and confirm it now exits cleanly to the non-fused path.
- [ ] Verify normal-case startup with sufficient memory: preflight passes on all ranks, fusion engages.
- [ ] Force a single-rank probe failure (e.g. by inflating `max_token_num` on one rank) and confirm all ranks vote SKIP and continue without a hang.
- [ ] Run a TP=1 path to confirm the `tp_group.world_size <= 1` short-circuit works.
- [ ] Spot-check that bypass behavior is logged at WARNING and not silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)