### PR TITLE
[DLLM] Add forward count metric for dLLM observability

### DIFF
--- a/python/sglang/srt/dllm/algorithm/base.py
+++ b/python/sglang/srt/dllm/algorithm/base.py
@@ -1,5 +1,6 @@
 from sglang.srt.dllm.algorithm import get_algorithm
 from sglang.srt.dllm.config import DllmConfig
+from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.server_args import ServerArgs
 
 
@@ -16,3 +17,12 @@ class DllmAlgorithm:
     def from_server_args(server_args: ServerArgs):
         config = DllmConfig.from_server_args(server_args)
         return get_algorithm(config)
+
+    @staticmethod
+    def _attach_forward_counts_per_request(
+        logits_output: LogitsProcessorOutput, counts: list[int]
+    ):
+        assert isinstance(logits_output, LogitsProcessorOutput)
+        if logits_output.customized_info is None:
+            logits_output.customized_info = {}
+        logits_output.customized_info["dllm_forward_counts"] = counts

--- a/python/sglang/srt/dllm/algorithm/joint_threshold.py
+++ b/python/sglang/srt/dllm/algorithm/joint_threshold.py
@@ -34,7 +34,10 @@ class JointThreshold(DllmAlgorithm):
         mask_index = forward_batch.input_ids == self.mask_id
         if not mask_index.any():
             out = model_runner.forward(forward_batch, pp_proxy_tensors=None)
+            self._attach_forward_counts_per_request(out.logits_output, [1] * batch_size)
             return out.logits_output, [], out.can_run_graph
+
+        forward_counts_per_request = [0] * batch_size
 
         start_list = []
         prompt_masks = []
@@ -60,6 +63,9 @@ class JointThreshold(DllmAlgorithm):
             if finished.all():
                 break
 
+            forward_counts_per_request = [
+                count + 1 for count in forward_counts_per_request
+            ]
             out = model_runner.forward(forward_batch, pp_proxy_tensors=None)
             logits_output, can_run_cuda_graph = out.logits_output, out.can_run_graph
 
@@ -125,6 +131,9 @@ class JointThreshold(DllmAlgorithm):
                 any_changed_in_last_step = True
 
         if any_changed_in_last_step:
+            forward_counts_per_request = [
+                count + 1 for count in forward_counts_per_request
+            ]
             out = model_runner.forward(forward_batch, pp_proxy_tensors=None)
             logits_output, can_run_cuda_graph = out.logits_output, out.can_run_graph
 
@@ -132,6 +141,9 @@ class JointThreshold(DllmAlgorithm):
         next_token_ids_list = [
             next_token_ids[i, start_list[i] :] for i in range(batch_size)
         ]
+        self._attach_forward_counts_per_request(
+            logits_output, forward_counts_per_request
+        )
 
         return logits_output, next_token_ids_list, can_run_cuda_graph
 

--- a/python/sglang/srt/dllm/algorithm/low_confidence.py
+++ b/python/sglang/srt/dllm/algorithm/low_confidence.py
@@ -37,7 +37,10 @@ class LowConfidence(DllmAlgorithm):
             logits_output, can_run_cuda_graph = out.logits_output, out.can_run_graph
 
             next_token_ids = []
+            self._attach_forward_counts_per_request(logits_output, [1] * batch_size)
             return logits_output, next_token_ids, can_run_cuda_graph
+
+        forward_counts_per_request = [0] * batch_size
 
         # Calculate start positions for each block
         for block_id in range(batch_size):
@@ -53,6 +56,11 @@ class LowConfidence(DllmAlgorithm):
             if torch.sum(mask_index).item() == 0:
                 break
 
+            # The current scheduler makes all requests in a batch wait for the slowest request,
+            # so every request has the same forward count.
+            forward_counts_per_request = [
+                count + 1 for count in forward_counts_per_request
+            ]
             out = model_runner.forward(forward_batch, pp_proxy_tensors=None)
             logits_output, can_run_cuda_graph = out.logits_output, out.can_run_graph
             assert batch_size == forward_batch.input_ids.shape[0] // self.block_size
@@ -89,6 +97,7 @@ class LowConfidence(DllmAlgorithm):
 
                 block_input_ids[transfer_index] = x[transfer_index]
 
+        forward_counts_per_request = [count + 1 for count in forward_counts_per_request]
         out = model_runner.forward(forward_batch, pp_proxy_tensors=None)
         logits_output, can_run_cuda_graph = out.logits_output, out.can_run_graph
         # Here next token ids is tricky to implement the dynamic lengths,
@@ -97,6 +106,9 @@ class LowConfidence(DllmAlgorithm):
         next_token_ids_list = [
             next_token_ids[i, start_list[i] :] for i in range(batch_size)
         ]
+        self._attach_forward_counts_per_request(
+            logits_output, forward_counts_per_request
+        )
 
         return logits_output, next_token_ids_list, can_run_cuda_graph
 

--- a/python/sglang/srt/dllm/mixin/scheduler.py
+++ b/python/sglang/srt/dllm/mixin/scheduler.py
@@ -89,6 +89,8 @@ class SchedulerDllmMixin:
                     release_kv_cache(req, self.tree_cache)
                     req.time_stats.set_completion_time()
 
+                self.maybe_collect_customized_info(idx, req, result.logits_output)
+
             self.stream_output(batch.reqs, batch.return_logprob)
             self.token_to_kv_pool_allocator.free_group_end()
 

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -1156,9 +1156,13 @@ class SchedulerOutputProcessorMixin:
                     for k, v in req.customized_info.items():
                         if k not in customized_info:
                             customized_info[k] = []
-                        customized_info[k].append(
-                            v[send_token_offset : len(output_ids_)]
-                        )
+                        if self.dllm_config is not None:
+                            # for dLLM only slice at the tokenizer manager level
+                            customized_info[k].append(v)
+                        else:
+                            customized_info[k].append(
+                                v[send_token_offset : len(output_ids_)]
+                            )
 
             if (
                 req.finished()

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -128,6 +128,7 @@ _INCREMENTAL_STREAMING_META_INFO_KEYS = (
     "output_top_logprobs",
     "output_token_ids_logprobs",
 )
+_INCREMENTAL_STREAMING_DLLM_META_INFO_KEYS = ("dllm_forward_counts",)
 
 
 @dataclasses.dataclass
@@ -146,6 +147,9 @@ class ReqState:
 
     # For streaming output
     last_output_offset: int = 0
+
+    # For dLLM block-aligned streaming metadata
+    last_dllm_meta_info_offset: int = 0
 
     # Accumulate text lazily so incremental streaming can emit the incoming
     # delta directly without rebuilding the full output prefix.
@@ -202,6 +206,18 @@ def _slice_streaming_output_meta_info(
     """Align output-side metadata with the current incremental streaming chunk."""
     for key in meta_info.keys() & set(_INCREMENTAL_STREAMING_META_INFO_KEYS):
         meta_info[key] = meta_info[key][last_output_offset:]
+
+
+def _slice_streaming_dllm_output_meta_info(
+    meta_info: Dict[Any, Any],
+    last_output_offset: int,
+) -> int:
+    """Align block-aligned dLLM metadata with the current streaming chunk."""
+    next_offset = last_output_offset
+    for key in meta_info.keys() & set(_INCREMENTAL_STREAMING_DLLM_META_INFO_KEYS):
+        next_offset = len(meta_info[key])
+        meta_info[key] = meta_info[key][last_output_offset:]
+    return next_offset
 
 
 class InputFormat(Enum):
@@ -1211,7 +1227,11 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         if "meta_info" in out:
             meta_info_list = [chunk["meta_info"] for chunk in out_list]
             meta_info = dict(meta_info_list[-1])
-            for key in _INCREMENTAL_STREAMING_META_INFO_KEYS:
+            incremental_keys = (
+                *_INCREMENTAL_STREAMING_META_INFO_KEYS,
+                *_INCREMENTAL_STREAMING_DLLM_META_INFO_KEYS,
+            )
+            for key in incremental_keys:
                 if any(key in m for m in meta_info_list):
                     meta_info[key] = [
                         item for m in meta_info_list for item in m.get(key, [])
@@ -1727,6 +1747,13 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                         output_token_ids = delta_output_ids
                         _slice_streaming_output_meta_info(meta_info, output_offset)
                         state.last_output_offset = len(state.output_ids)
+                        # dLLM incremental metadata is block-aligned rather than token-aligned.
+                        state.last_dllm_meta_info_offset = (
+                            _slice_streaming_dllm_output_meta_info(
+                                meta_info,
+                                state.last_dllm_meta_info_offset,
+                            )
+                        )
                         out_dict = {
                             "text": delta_text,
                             "output_ids": output_token_ids,
@@ -1769,6 +1796,13 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                         output_token_ids = delta_output_ids
                         _slice_streaming_output_meta_info(meta_info, output_offset)
                         state.last_output_offset = len(state.output_ids)
+                        # dLLM incremental metadata is block-aligned rather than token-aligned.
+                        state.last_dllm_meta_info_offset = (
+                            _slice_streaming_dllm_output_meta_info(
+                                meta_info,
+                                state.last_dllm_meta_info_offset,
+                            )
+                        )
                         out_dict = {
                             "output_ids": output_token_ids,
                             "meta_info": meta_info,

--- a/python/sglang/test/test_dllm_observability.py
+++ b/python/sglang/test/test_dllm_observability.py
@@ -1,0 +1,173 @@
+import json
+from typing import Any
+
+import requests
+
+OBSERVABILITY_MAX_NEW_TOKENS = 100
+OBSERVABILITY_SEED = 42
+FORWARD_COUNTS_KEY = "dllm_forward_counts"
+PROMPT_1 = (
+    "Human: What is the capital of France and how is that city like. "
+    "Give me 3 trivial information about that city. "
+    "Write in a format of json.\nAssistant:"
+)
+PROMPT_2 = (
+    "Human: What is the capital of Germany and how is that city like. "
+    "Give me 3 trivial information about that city. "
+    "Write in a format of json.\nAssistant:"
+)
+
+
+def build_single_prompt() -> list[str]:
+    return [PROMPT_1]
+
+
+def build_two_prompts() -> list[str]:
+    return [PROMPT_1, PROMPT_2]
+
+
+def _build_generate_payload(
+    prompts: list[str],
+    stream: bool,
+    stream_interval: int | None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "text": prompts[0] if len(prompts) == 1 else prompts,
+        "sampling_params": {
+            "sampling_seed": OBSERVABILITY_SEED,
+            "temperature": 0.0,
+            "max_new_tokens": OBSERVABILITY_MAX_NEW_TOKENS,
+            "ignore_eos": True,
+        },
+        "stream": stream,
+    }
+    if stream_interval is not None:
+        payload["sampling_params"]["stream_interval"] = stream_interval
+    return payload
+
+
+def _extract_forward_counts(output: dict[str, Any]) -> list[int]:
+    meta_info = output.get("meta_info")
+    if not isinstance(meta_info, dict):
+        raise AssertionError(f"Missing meta_info: {output}")
+
+    counts = meta_info.get(FORWARD_COUNTS_KEY)
+    if not isinstance(counts, list):
+        raise AssertionError(
+            f"Expected {FORWARD_COUNTS_KEY} to be a list, got: {type(counts)}"
+        )
+
+    for count in counts:
+        if not isinstance(count, int):
+            raise AssertionError(
+                f"Every {FORWARD_COUNTS_KEY} entry should be an int, got: {count!r}"
+            )
+        if count < 1:
+            raise AssertionError(
+                f"Every {FORWARD_COUNTS_KEY} entry should be >= 1, got: {count}"
+            )
+    return counts
+
+
+def get_forward_counts_from_generate_non_stream(
+    base_url: str,
+    prompts: list[str],
+) -> dict[int, list[int]]:
+    response = requests.post(
+        f"{base_url}/generate",
+        json=_build_generate_payload(
+            prompts,
+            stream=False,
+            stream_interval=None,
+        ),
+    )
+    outputs = response.json()
+    if not isinstance(outputs, list):
+        outputs = [outputs]
+    return {
+        output.get("index", index): _extract_forward_counts(output)
+        for index, output in enumerate(outputs)
+    }
+
+
+def get_forward_counts_from_generate_stream(
+    base_url: str,
+    prompts: list[str],
+    stream_interval: int | None = None,
+    incremental_streaming_output: bool = False,
+) -> dict[int, list[int]]:
+    response = requests.post(
+        f"{base_url}/generate",
+        json=_build_generate_payload(
+            prompts,
+            stream=True,
+            stream_interval=stream_interval,
+        ),
+        stream=True,
+    )
+
+    chunks_by_index: dict[int, list[dict[str, Any]]] = {}
+    incremental_counts_by_index: dict[int, list[int]] = {}
+    for line in response.iter_lines(decode_unicode=True):
+        if not line or not line.startswith("data:"):
+            continue
+        if line == "data: [DONE]":
+            break
+
+        chunk = json.loads(line[len("data:") :].strip())
+        index = chunk.get("index", 0)
+        if incremental_streaming_output:
+            incremental_counts_by_index.setdefault(index, []).extend(
+                _extract_forward_counts(chunk)
+            )
+        else:
+            chunks_by_index.setdefault(index, []).append(chunk)
+
+    if incremental_streaming_output:
+        return incremental_counts_by_index
+
+    return {
+        index: _extract_forward_counts(chunks[-1])
+        for index, chunks in chunks_by_index.items()
+        if chunks
+    }
+
+
+class DllmObservabilityMixin:
+    def assert_generate_stream_cumulative_matches_non_stream(
+        self,
+        base_url: str,
+        prompts: list[str],
+        stream_interval: int | None = None,
+        incremental_streaming_output: bool = False,
+    ) -> None:
+        stream_label = "default" if stream_interval is None else str(stream_interval)
+        non_stream_forward_counts_by_index = (
+            get_forward_counts_from_generate_non_stream(base_url, prompts)
+        )
+        stream_forward_counts_by_index = get_forward_counts_from_generate_stream(
+            base_url,
+            prompts,
+            stream_interval,
+            incremental_streaming_output=incremental_streaming_output,
+        )
+
+        self.assertEqual(
+            len(non_stream_forward_counts_by_index.items()),
+            len(stream_forward_counts_by_index.items()),
+            "Number of non-stream and stream outputs should match.",
+        )
+        self.assertEqual(
+            set(non_stream_forward_counts_by_index),
+            set(stream_forward_counts_by_index),
+            "Non-stream and stream request indexes should match.",
+        )
+
+        for index in sorted(non_stream_forward_counts_by_index):
+            self.assertEqual(
+                non_stream_forward_counts_by_index[index],
+                stream_forward_counts_by_index[index],
+                f"Streamed {FORWARD_COUNTS_KEY} should match non-stream output for "
+                f"request {index} (stream_interval={stream_label}, "
+                f"incremental_streaming_output={incremental_streaming_output}).",
+            )

--- a/test/registered/dllm/test_observability.py
+++ b/test/registered/dllm/test_observability.py
@@ -1,0 +1,139 @@
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=500, suite="stage-b-test-1-gpu-large")
+
+import unittest
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.test_dllm_observability import (
+    DllmObservabilityMixin,
+    build_single_prompt,
+    build_two_prompts,
+)
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+BASE_SERVER_ARGS = [
+    "--trust-remote-code",
+    "--tp-size",
+    "1",
+    "--mem-fraction-static",
+    "0.9",
+    "--max-running-requests",
+    "2",
+    "--attention-backend",
+    "flashinfer",
+    "--cuda-graph-bs",
+    "1",
+    "2",
+    "--disable-radix-cache",
+]
+INCREMENTAL_OBSERVABILITY_SERVER_ARGS = BASE_SERVER_ARGS + [
+    "--incremental-streaming-output",
+]
+STREAM_INTERVALS = (None, 2, 3)
+
+
+class ObservabilityServerBase(DllmObservabilityMixin, CustomTestCase):
+    dllm_algorithm: str | None = None
+    dllm_algorithm_config_path: str | None = None
+    incremental_streaming_output = False
+    server_args = BASE_SERVER_ARGS
+
+    @classmethod
+    def setUpClass(cls):
+        if cls.dllm_algorithm is None:
+            raise unittest.SkipTest("Skip the base observability test class")
+
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=cls._build_server_args(),
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    @classmethod
+    def _build_server_args(cls) -> list[str]:
+        args = list(cls.server_args)
+        args.extend(["--dllm-algorithm", cls.dllm_algorithm])
+        if cls.dllm_algorithm_config_path is not None:
+            args.extend(["--dllm-algorithm-config", cls.dllm_algorithm_config_path])
+        return args
+
+    def _assert_forward_counts(self, prompts: list[str]):
+        for stream_interval in STREAM_INTERVALS:
+            label = "default" if stream_interval is None else str(stream_interval)
+            with self.subTest(stream_interval=label):
+                self.assert_generate_stream_cumulative_matches_non_stream(
+                    base_url=self.base_url,
+                    prompts=prompts,
+                    stream_interval=stream_interval,
+                    incremental_streaming_output=self.incremental_streaming_output,
+                )
+
+    def test_single_request_forward_counts(self):
+        self._assert_forward_counts(build_single_prompt())
+
+    def test_two_request_forward_counts(self):
+        self._assert_forward_counts(build_two_prompts())
+
+
+class TestSDARLowConfidenceObservability(ObservabilityServerBase):
+    dllm_algorithm = "LowConfidence"
+    model = "JetLM/SDAR-8B-Chat"
+
+
+class TestSDARJointThresholdObservability(ObservabilityServerBase):
+    dllm_algorithm = "JointThreshold"
+    model = "JetLM/SDAR-8B-Chat"
+
+
+class TestSDARLowConfidenceIncrementalObservability(ObservabilityServerBase):
+    dllm_algorithm = "LowConfidence"
+    incremental_streaming_output = True
+    model = "JetLM/SDAR-8B-Chat"
+    server_args = INCREMENTAL_OBSERVABILITY_SERVER_ARGS
+
+
+class TestSDARJointThresholdIncrementalObservability(ObservabilityServerBase):
+    dllm_algorithm = "JointThreshold"
+    incremental_streaming_output = True
+    model = "JetLM/SDAR-8B-Chat"
+    server_args = INCREMENTAL_OBSERVABILITY_SERVER_ARGS
+
+
+class TestLLaDALowConfidenceObservability(ObservabilityServerBase):
+    dllm_algorithm = "LowConfidence"
+    model = "inclusionAI/LLaDA2.0-mini"
+
+
+class TestLLaDAJointThresholdObservability(ObservabilityServerBase):
+    dllm_algorithm = "JointThreshold"
+    model = "inclusionAI/LLaDA2.0-mini"
+
+
+class TestLLaDALowConfidenceIncrementalObservability(ObservabilityServerBase):
+    dllm_algorithm = "LowConfidence"
+    incremental_streaming_output = True
+    model = "inclusionAI/LLaDA2.0-mini"
+    server_args = INCREMENTAL_OBSERVABILITY_SERVER_ARGS
+
+
+class TestLLaDAJointThresholdIncrementalObservability(ObservabilityServerBase):
+    dllm_algorithm = "JointThreshold"
+    incremental_streaming_output = True
+    model = "inclusionAI/LLaDA2.0-mini"
+    server_args = INCREMENTAL_OBSERVABILITY_SERVER_ARGS
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

As mentioned in #21926, the forward count for dLLM is an essential metric for performance and algorithm behavior. With the forward count information for each block, users can perform more detailed analysis and calculate metrics like Tokens Per Forward (TPF) for scenarios such as performance tuning.

Since the `/generate` API currently supports both non-streaming mode and streaming mode with and without the `incremental_streaming_output` flag, there are three scenarios that should be covered:

1. Non-streaming mode: only one response is returned when the request is finished. In that response body's `meta_info`, it should contain the request-corresponding `dllm_forward_counts`, which is a list of ints representing all processed block forward counts. The prefill block takes 1 forward, and decode blocks might take 1 to N forward counts depending on the `dllm_algorithm` design.
2. Streaming mode without incremental flag: for each streaming chunk, the chunk body's `meta_info` should contain the latest cumulative `dllm_forward_counts`.
3. Streaming mode with incremental flag: for each streaming chunk, the chunk body's `meta_info` should only contain the newly emitted block `dllm_forward_counts`.

and since the current dLLM support includes two algorithms, LowConfidence and JointThreshold, and two model types, LLaDA and SDAR, so the goal of this PR is to add `dllm_forward_counts` information for each request across all configurations of model type, algorithm, and supported flags.

## Modifications

<img width="8690" height="2632" alt="image" src="https://github.com/user-attachments/assets/59736301-f80b-4d6e-aa76-d534ebfe2499" />

The above figure demonstrates the key modifications for this feature. I tried my best to reuse the existing helper functions and make minimal changes to the codebase, but there are still dLLM-specific limitations that required me to add new dLLM-specific helpers.

1. The first is for `SchedulerOutputProcessorMixin`. To record the cumulative results, I decided to skip the `customized_info` slicing and always assign the latest state when copying to `BatchTokenIDOutput`. With this change, non-streaming mode and normal streaming mode without the incremental flag can reuse the existing path to attach the latest cumulative `dllm_forward_counts` information into `meta_info` every time the HTTP server responds to the user.

2. The second is a special scenario for `TokenizerManager` when the user chooses streaming mode with the incremental flag enabled. In this path, block-level slicing is required. Because token-based and block-based slicing have fundamentally misaligned slice logic, I cannot reuse the existing `_slice_streaming_output_meta_info`; instead, it is necessary to introduce a block-based `_slice_streaming_dllm_output_meta_info`.

There is also a minor design choice, which is that `maybe_collect_customized_info` only runs under if result.next_token_ids:, aligning with the `stream_output` timing, so the current forward count info is for the actual generated new token block. A pure prefill block that does not generate new token is not shown to the user.

## Tests

To correctly cover the possible scenarios, the following dimensions need to be covered:

1. Non-streaming, streaming without incremental, and streaming with incremental
2. LowConfidence algorithm and JointThreshold algorithm
3. LLaDA and SDAR
5. Multiple batch sizes
6. Different `stream_interval` values

To efficiently cover the above combinations without creating too many cases, I designed the single unit of evaluation as: “non-streaming `forward_counts` should be identical to streaming `forward_counts` if the seed and prompts are identical.” Then, I extended a single unittest class to contain batch size = 1 and 2 to cover multiple batch scenarios (Batch size 2 sends two different prompts), and each batch size tests `stream_interval` from the default value (1), to 2 and 3 as subtests.

Since different server flags, different models, or different algorithms require launching the server again, I will create 8 classes: 2 algorithms x 2 model types x 2 comparison modes (non-streaming compared to streaming without incremental, and non-streaming compared to streaming with incremental).

The total test case count is 8 x 2, and the total subtest-level count is 8 x 2 x 3 (different stream intervals).

The following is the test case result run on H100 80GB, which took ~550 on my machine.

```bash
........
[2026-04-25 16:49:54] Prefill batch, #new-seq: 2, #new-token: 8, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, cuda graph: True, input throughput (token/s): 194.23
[2026-04-25 16:49:54] Prefill batch, #new-seq: 2, #new-token: 8, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, cuda graph: True, input throughput (token/s): 194.63
[2026-04-25 16:49:54] Prefill batch, #new-seq: 2, #new-token: 8, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, cuda graph: True, input throughput (token/s): 189.64
.
----------------------------------------------------------------------
Ran 16 tests in 552.367s

OK (skipped=1)
```

If this should not take too much time, since CI resources are expensive and the current time overhead mainly comes from multiple server relaunches, it would be acceptable to reduce the test scope of the LLaDA model. Since the cheaper SDAR model has already covered the algorithm level and flag level combinations, we can keep only the test class below for LLaDA:
```python
class TestLLaDALowConfidenceObservability(ObservabilityServerBase):
    dllm_algorithm = "LowConfidence"
    model = "inclusionAI/LLaDA2.0-mini"
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
7. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
8. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
9. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
