### PR TITLE
docs(DeepSeek-V4): add GB200 platform to cookbook recipe

### DIFF
--- a/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
+++ b/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
@@ -29,13 +29,13 @@ tag: NEW
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><strong><a href="https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash">DeepSeek-V4-Flash</a></strong></td>
       <td style={{padding: "9px 12px", textAlign: "right", backgroundColor: "rgba(255,255,255,0.05)"}}><strong>284B</strong></td>
       <td style={{padding: "9px 12px", textAlign: "right", backgroundColor: "rgba(255,255,255,0.02)"}}>13B</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>single-node serving: B200 / GB300 / H200 on 4 GPUs</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>single-node serving: B200 / GB200 / GB300 / H200 on 4 GPUs</td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><strong><a href="https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro">DeepSeek-V4-Pro</a></strong></td>
       <td style={{padding: "9px 12px", textAlign: "right", backgroundColor: "rgba(255,255,255,0.05)"}}><strong>1.6T</strong></td>
       <td style={{padding: "9px 12px", textAlign: "right", backgroundColor: "rgba(255,255,255,0.02)"}}>49B</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>high-capacity: B200 8 GPU / GB300 4 GPU / H200 16 GPU (2 nodes)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>high-capacity: B200 8 GPU / GB200 8 GPU (2 nodes) / GB300 4 GPU / H200 16 GPU (2 nodes)</td>
     </tr>
   </tbody>
 </table>
@@ -87,6 +87,10 @@ Please refer to the [official SGLang installation guide](../../../docs/get-start
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>NVIDIA B200</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>lmsysorg/sglang:deepseek-v4-blackwell</code></td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>NVIDIA GB200</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>lmsysorg/sglang:deepseek-v4-grace-blackwell</code></td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>NVIDIA GB300</td>

--- a/docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx
@@ -4,6 +4,7 @@ export const DeepSeekV4Deployment = () => {
   //
   //   Hardware (quantization determined by GPU generation):
   //     B200  → FP4 weights, Flash TP=4 / Pro TP=8 single-node
+  //     GB200 → FP4 weights, Flash TP=4 / Pro TP=8 2-node
   //     GB300 → FP4 weights, Flash TP=4 / Pro TP=4 single-node
   //     H200  → FP8 weights, Flash TP=4 / Pro TP=16 2-node
   //   Model variant → HF slug:
@@ -27,6 +28,7 @@ export const DeepSeekV4Deployment = () => {
       items: [
         { id: "b200",  label: "B200 (FP4)",  default: true  },
         { id: "b300",  label: "B300 (FP4)",  default: false  },
+        { id: "gb200", label: "GB200 (FP4)", default: false },
         { id: "gb300", label: "GB300 (FP4)", default: false },
         { id: "h200",  label: "H200 (FP8)",  default: false },
       ],
@@ -138,6 +140,8 @@ export const DeepSeekV4Deployment = () => {
     "b200|big":    { slug: "deepseek-ai/DeepSeek-V4-Pro",   tp: 8,  multinode: false },
     "gb300|small": { slug: "deepseek-ai/DeepSeek-V4-Flash", tp: 4,  multinode: false },
     "gb300|big":   { slug: "deepseek-ai/DeepSeek-V4-Pro",   tp: 4,  multinode: false },
+    "gb200|small": { slug: "deepseek-ai/DeepSeek-V4-Flash", tp: 4,  multinode: false },
+    "gb200|big":   { slug: "deepseek-ai/DeepSeek-V4-Pro",   tp: 8,  multinode: true, nnodes: 2 },
     // H200 needs an FP8-only Instruct ckpt (deepseek-ai's Flash/Pro repos ship
     // FP4-mixed weights that Hopper can't run). sgl-project publishes FP8
     // repackagings for both variants.
@@ -150,6 +154,8 @@ export const DeepSeekV4Deployment = () => {
     "b200|big":    { tp: 8,  multinode: false },
     "gb300|small": { tp: 4,  multinode: false },
     "gb300|big":   { tp: 4,  multinode: false },
+    "gb200|small": { tp: 4,  multinode: false },
+    "gb200|big":   { tp: 8,  multinode: true, nnodes: 2 },
     "h200|small":  { tp: 4,  multinode: false },
     "h200|big":    { tp: 16, multinode: true, nnodes: 2 },
   };
@@ -184,12 +190,21 @@ export const DeepSeekV4Deployment = () => {
     "gb300|big|cp",
     "gb300|small|pd-disagg",
     "gb300|big|pd-disagg",
+    "gb200|small|low-latency",
+    "gb200|small|balanced",
+    "gb200|small|max-throughput",
+    "gb200|small|cp",
+    "gb200|big|low-latency",
+    "gb200|big|balanced",
+    "gb200|big|max-throughput",
   ]);
   // Recipes whose command is intentionally not yet provided (e.g. blocked by an
   // upstream limitation). Showing a minimal placeholder is friendlier to users
   // than emitting a commented-out invalid command.
   const TBD_RECIPES = new Set([
     "h200|big|cp",
+    "gb200|small|pd-disagg",
+    "gb200|big|pd-disagg",
   ]);
   const TBD_PLACEHOLDER = "# to be provided";
   const BEING_VERIFIED_NOTE =
@@ -243,14 +258,18 @@ export const DeepSeekV4Deployment = () => {
       h200:  ["SGLANG_DSV4_FP4_EXPERTS=0"],   // allinone _ENV_H200
       b200:  [],                              // _ENV_B200 minus NVSHMEM
       gb300: [],                              // _ENV_GB300
+      // GB200 multinode needs NCCL MNNVL for cross-node NVLink communication.
+      gb200: multinode ? ["NCCL_MNNVL_ENABLE=1", "NCCL_CUMEM_ENABLE=1"] : [],
     }[hardware];
 
     // Recipe-specific env (matches allinone exactly, taking size into account).
     const recipeEnv = [];
     if (recipe === "low-latency") {
-      // H200 big low-latency has extra dispatch-token cap (allinone line 233).
+      // Big low-latency dispatch-token cap.
       if (hardware === "h200" && isBig) {
         recipeEnv.push("SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=128");
+      } else if (hardware === "gb200" && isBig) {
+        recipeEnv.push("SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256");
       }
     } else if (recipe === "balanced") {
       if (hardware === "h200") {
@@ -294,6 +313,7 @@ export const DeepSeekV4Deployment = () => {
       // allinone:
       //   H200 small: pure TP + MTP_314
       //   H200 big:   DP-attn + DeepEP + MTP_314 + cg=32 max-run=64 + multi-node + mem-frac 0.82
+      //   GB200 big:  pure TP + multinode + flashinfer_mxfp4 + MTP_314 + mem-frac 0.82 (no DP-attn/DeepEP)
       //   Blackwell:  TP + flashinfer_mxfp4 + MTP_314 + chunked-prefill-size 4096 + autotune-fix
       //               Big Blackwell additionally: mem-frac 0.82
       flags.push(`  --tp ${tp}`);
@@ -336,7 +356,11 @@ export const DeepSeekV4Deployment = () => {
       flags.push("  --speculative-num-steps 1");
       flags.push("  --speculative-eagle-topk 1");
       flags.push("  --speculative-num-draft-tokens 2");
-      if (isBig) flags.push("  --mem-fraction-static 0.82");
+      if (isBig && hardware === "gb200") {
+        flags.push("  --mem-fraction-static 0.78");
+      } else if (isBig) {
+        flags.push("  --mem-fraction-static 0.82");
+      }
       if (hardware === "h200") {
         flags.push("  --cuda-graph-max-bs 128");
         flags.push("  --max-running-requests 128");
@@ -346,6 +370,9 @@ export const DeepSeekV4Deployment = () => {
       } else if (isBig && hardware === "gb300") {
         flags.push("  --cuda-graph-max-bs 128");
         flags.push("  --max-running-requests 256");
+      } else if (isBig && hardware === "gb200") {
+        flags.push("  --cuda-graph-max-bs 64");
+        flags.push("  --max-running-requests 128");
       }
       // allinone H200 gates DEEPEP_LARGE_SMS_FLAG on !multinode — only H200 big
       // is multi-node; all Blackwell cells get the flag unconditionally.
@@ -360,7 +387,11 @@ export const DeepSeekV4Deployment = () => {
       flags.push("  --enable-dp-attention");
       if (multinode) flags.push(...multiNodeFlags(nnodes));
       flags.push("  --moe-a2a-backend deepep");
-      if (isBig) flags.push("  --mem-fraction-static 0.82");
+      if (isBig && hardware === "gb200") {
+        flags.push("  --mem-fraction-static 0.78");
+      } else if (isBig) {
+        flags.push("  --mem-fraction-static 0.82");
+      }
       if (hardware === "h200") {
         flags.push("  --cuda-graph-max-bs 128");
         flags.push("  --max-running-requests 256");
@@ -369,6 +400,9 @@ export const DeepSeekV4Deployment = () => {
         flags.push("  --max-running-requests 256");
       } else if (isBig && hardware === "gb300") {
         flags.push("  --cuda-graph-max-bs 128");
+        flags.push("  --max-running-requests 256");
+      } else if (isBig && hardware === "gb200") {
+        flags.push("  --cuda-graph-max-bs 64");
         flags.push("  --max-running-requests 256");
       }
       if (!multinode) flags.push(DEEPEP_LARGE_SMS_FLAG);
@@ -417,7 +451,18 @@ export const DeepSeekV4Deployment = () => {
     const envAll = [...HW_ENV, ...recipeEnv, ...COMMON_ENV];
     const envBlock = envAll.length ? envAll.join(" \\\n") + " \\\n" : "";
     const base = `${envBlock}sglang serve \\\n${flags.join(" \\\n")}`;
-    const withMultinode = multinode ? prependMultiNodeNote(base, nnodes) : base;
+    // GB200 multinode may need machine-specific NVSHMEM / Gloo env vars;
+    // emit them as commented hints above the env block so users know to check.
+    let cmd = base;
+    if (hardware === "gb200" && multinode) {
+      cmd =
+        `# The following env vars may be needed depending on your cluster:\n` +
+        `#   GLOO_SOCKET_IFNAME=<your-nic>\n` +
+        `#   NVSHMEM_ENABLE_NIC_PE_MAPPING=1\n` +
+        `#   NVSHMEM_HCA_LIST=<your-hca-list>\n` +
+        cmd;
+    }
+    const withMultinode = multinode ? prependMultiNodeNote(cmd, nnodes) : cmd;
     const verifyKey = `${hardware}|${modelSize}|${recipe}`;
     if (TBD_RECIPES.has(verifyKey)) return TBD_PLACEHOLDER;
     return VERIFIED_RECIPES.has(verifyKey)
@@ -448,14 +493,15 @@ export const DeepSeekV4Deployment = () => {
     const specKey = `${hardware}|${modelSize}`;
     const { tp: pdTp, multinode, nnodes } = PD_TP_SPEC[specKey];
     const slug = HW_SIZE_SPEC[specKey].slug;
-    const ibDevice = { h200: "mlx5_0", b200: "mlx5_7", gb300: "" }[hardware];
+    const ibDevice = { h200: "mlx5_0", b200: "mlx5_7", gb300: "", gb200: "" }[hardware];
     const isGB300 = hardware === "gb300";
-    const isBlackwell = hardware === "b200" || isGB300;
+    const isBlackwell = hardware === "b200" || hardware === "gb200" || isGB300;
 
     const HW_ENV = {
       h200:  ["SGLANG_DSV4_FP4_EXPERTS=0"],
       b200:  [],
       gb300: [],
+      gb200: [],
     }[hardware];
     // Whitelist #5: only SGLANG_MOONCAKE_CUSTOM_MEM_POOL kept; MC_FORCE_MNNVL /
     // NCCL_MNNVL_ENABLE / NCCL_CUMEM_ENABLE may also be needed depending on the


### PR DESCRIPTION
## Summary
- Add NVIDIA GB200 (FP4, Grace Blackwell, 4 GPU/node NVL4) as a new hardware platform in the DeepSeek-V4 cookbook
- Flash (285B): TP=4, single-node — all 4 recipes verified
- Pro (1.6T): TP=8, 2-node multinode — low-latency, balanced, max-throughput verified; cp unverified; pd-disagg TBD
- Pro low-latency uses pure TP (no DP-attn/DeepEP), unlike H200 big
- Pro balanced/max-throughput: `mem-fraction-static=0.78`, `cuda-graph-max-bs=64`
- Multinode recipes include `NCCL_MNNVL_ENABLE=1` + `NCCL_CUMEM_ENABLE=1` for cross-node NVLink
- Docker image: reuses `lmsysorg/sglang:deepseek-v4-grace-blackwell`

## Test plan
- [x] All GB200 Flash recipes (low-latency, balanced, max-throughput, cp) verified
- [x] GB200 Pro low-latency verified on 2-node cluster
- [x] GB200 Pro balanced verified on 2-node cluster
- [x] GB200 Pro max-throughput verified on 2-node cluster
- [ ] GB200 Pro cp — unverified (command commented out)
- [ ] GB200 pd-disagg — TBD (placeholder shown)
- [x] Existing B200/B300/GB300/H200 recipes unaffected (no logic changes for those paths)
- [x] Local Mintlify preview renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)