### PR TITLE
ci: add docker release workflow for deepseek_v4 branch

### DIFF
--- a/.github/workflows/release-docker-deepseek-v4.yml
+++ b/.github/workflows/release-docker-deepseek-v4.yml
@@ -1,0 +1,93 @@
+name: Build and Push DeepSeek-V4 Docker Images
+
+# Builds the 4 Dockerfiles added in #23600 from the deepseek_v4 branch and
+# pushes them to Docker Hub. Each Dockerfile is single-arch and does its own
+# `git clone -b deepseek_v4` inside, so no build context source is required
+# beyond the Dockerfiles themselves and `--no-cache` is mandatory.
+
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: "Docker Hub destination repository. Default: lmsysorg/sglang-staging (set to lmsysorg/sglang for production release)."
+        required: false
+        default: "lmsysorg/sglang-staging"
+
+concurrency:
+  group: release-docker-deepseek-v4-${{ inputs.repository }}
+  cancel-in-progress: true
+
+jobs:
+  build-deepseek-v4:
+    if: ${{ github.repository == 'sgl-project/sglang' }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: x64-docker-build-node
+            platform: linux/amd64
+            dockerfile: docker/deepseek_v4_h200.Dockerfile
+            tag: deepseek-v4-hopper
+          - runner: x64-docker-build-node
+            platform: linux/amd64
+            dockerfile: docker/deepseek_v4_b200.Dockerfile
+            tag: deepseek-v4-blackwell
+          - runner: x64-docker-build-node
+            platform: linux/amd64
+            dockerfile: docker/deepseek_v4_b300.Dockerfile
+            tag: deepseek-v4-b300
+          - runner: arm-docker-build-node
+            platform: linux/arm64
+            dockerfile: docker/deepseek_v4_grace_blackwell.Dockerfile
+            tag: deepseek-v4-grace-blackwell
+    steps:
+      - name: Delete huge unnecessary tools folder
+        run: rm -rf /opt/hostedtoolcache
+
+      - name: Cleanup workspace (remove root-owned files from prior runs)
+        run: sudo rm -rf "$GITHUB_WORKSPACE"/* || true
+
+      - name: Checkout deepseek_v4 sources
+        uses: actions/checkout@v4
+        with:
+          ref: deepseek_v4
+
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          docker-images: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+
+      - name: Prune Docker to reclaim disk space
+        run: |
+          docker buildx prune --filter "until=72h" -f
+          docker system prune -af --filter "until=72h"
+          docker volume prune -af
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and Push DeepSeek-V4 image
+        run: |
+          IMAGE="${{ inputs.repository }}:${{ matrix.tag }}"
+          echo "Will push: ${IMAGE}"
+          docker buildx build \
+            --platform ${{ matrix.platform }} \
+            -f ${{ matrix.dockerfile }} \
+            -t "${IMAGE}" \
+            --push \
+            --no-cache \
+            .
+          echo "Published ${IMAGE}"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release-docker-deepseek-v4.yml`, a `workflow_dispatch` workflow that builds the four DeepSeek-V4 Dockerfiles introduced in #23600 from the `deepseek_v4` branch and pushes them to Docker Hub.
- Single input: `repository`, defaulting to `lmsysorg/sglang-staging`. Override to `lmsysorg/sglang` when cutting the actual release; the staging default keeps test runs from clobbering the production tags.

## Images built

| Dockerfile | Platform | CUDA | Tag |
| --- | --- | --- | --- |
| `docker/deepseek_v4_h200.Dockerfile` | linux/amd64 | 12.9 | `<repo>:deepseek-v4-hopper` |
| `docker/deepseek_v4_b200.Dockerfile` | linux/amd64 | 12.9 | `<repo>:deepseek-v4-blackwell` |
| `docker/deepseek_v4_b300.Dockerfile` | linux/amd64 | 13.0 | `<repo>:deepseek-v4-b300` |
| `docker/deepseek_v4_grace_blackwell.Dockerfile` | linux/arm64 | 13.0 | `<repo>:deepseek-v4-grace-blackwell` |

## Notes

- Each Dockerfile does its own `git clone -b deepseek_v4` internally, so no source build context is required — the workflow just needs the Dockerfile, hence `actions/checkout` of `deepseek_v4` and `--no-cache` on the buildx invocation (otherwise stale clone layers would be reused).
- The four Dockerfiles target different architectures, so this is a single matrix of single-arch builds — no multi-arch manifest needed.
- Concurrency keyed on the destination repo so staging and prod runs don't cancel each other.

## Test Plan

- [ ] Trigger the workflow with the default `lmsysorg/sglang-staging` and confirm all four tags are pushed.
- [ ] `docker pull lmsysorg/sglang-staging:deepseek-v4-hopper` (and the other three) and smoke-test on the relevant hardware.
- [ ] Re-run with `repository=lmsysorg/sglang` to publish the production tags listed in the #23600 PR description.