### PR TITLE
[CI] release-docker-deepseek-v4: select which flavors to push

### DIFF
--- a/.github/workflows/release-docker-deepseek-v4.yml
+++ b/.github/workflows/release-docker-deepseek-v4.yml
@@ -12,35 +12,73 @@ on:
         description: "Docker Hub destination repository. Default: lmsysorg/sglang-staging (set to lmsysorg/sglang for production release)."
         required: false
         default: "lmsysorg/sglang-staging"
+      build_hopper:
+        description: "Build and push the Hopper (H200) image."
+        required: false
+        type: boolean
+        default: true
+      build_blackwell:
+        description: "Build and push the Blackwell (B200) image."
+        required: false
+        type: boolean
+        default: true
+      build_b300:
+        description: "Build and push the B300 image."
+        required: false
+        type: boolean
+        default: true
+      build_grace_blackwell:
+        description: "Build and push the Grace Blackwell (ARM) image."
+        required: false
+        type: boolean
+        default: true
 
 concurrency:
   group: release-docker-deepseek-v4-${{ inputs.repository }}
   cancel-in-progress: true
 
 jobs:
-  build-deepseek-v4:
+  build-matrix:
     if: ${{ github.repository == 'sgl-project/sglang' }}
+    runs-on: ubuntu-latest
+    outputs:
+      include: ${{ steps.set.outputs.include }}
+    steps:
+      - id: set
+        env:
+          BUILD_HOPPER: ${{ inputs.build_hopper }}
+          BUILD_BLACKWELL: ${{ inputs.build_blackwell }}
+          BUILD_B300: ${{ inputs.build_b300 }}
+          BUILD_GRACE_BLACKWELL: ${{ inputs.build_grace_blackwell }}
+        run: |
+          entries=()
+          if [ "$BUILD_HOPPER" = "true" ]; then
+            entries+=('{"runner":"x64-docker-build-node","platform":"linux/amd64","dockerfile":"docker/deepseek_v4_h200.Dockerfile","tag":"deepseek-v4-hopper"}')
+          fi
+          if [ "$BUILD_BLACKWELL" = "true" ]; then
+            entries+=('{"runner":"x64-docker-build-node","platform":"linux/amd64","dockerfile":"docker/deepseek_v4_b200.Dockerfile","tag":"deepseek-v4-blackwell"}')
+          fi
+          if [ "$BUILD_B300" = "true" ]; then
+            entries+=('{"runner":"x64-docker-build-node","platform":"linux/amd64","dockerfile":"docker/deepseek_v4_b300.Dockerfile","tag":"deepseek-v4-b300"}')
+          fi
+          if [ "$BUILD_GRACE_BLACKWELL" = "true" ]; then
+            entries+=('{"runner":"arm-docker-build-node","platform":"linux/arm64","dockerfile":"docker/deepseek_v4_grace_blackwell.Dockerfile","tag":"deepseek-v4-grace-blackwell"}')
+          fi
+          if [ ${#entries[@]} -eq 0 ]; then
+            echo "::error::At least one build_* input must be true."
+            exit 1
+          fi
+          joined=$(IFS=,; echo "${entries[*]}")
+          echo "include=[${joined}]" >> "$GITHUB_OUTPUT"
+          echo "Selected matrix: [${joined}]"
+
+  build-deepseek-v4:
+    needs: build-matrix
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - runner: x64-docker-build-node
-            platform: linux/amd64
-            dockerfile: docker/deepseek_v4_h200.Dockerfile
-            tag: deepseek-v4-hopper
-          - runner: x64-docker-build-node
-            platform: linux/amd64
-            dockerfile: docker/deepseek_v4_b200.Dockerfile
-            tag: deepseek-v4-blackwell
-          - runner: x64-docker-build-node
-            platform: linux/amd64
-            dockerfile: docker/deepseek_v4_b300.Dockerfile
-            tag: deepseek-v4-b300
-          - runner: arm-docker-build-node
-            platform: linux/arm64
-            dockerfile: docker/deepseek_v4_grace_blackwell.Dockerfile
-            tag: deepseek-v4-grace-blackwell
+        include: ${{ fromJson(needs.build-matrix.outputs.include) }}
     steps:
       - name: Delete huge unnecessary tools folder
         run: rm -rf /opt/hostedtoolcache


### PR DESCRIPTION
## Summary

- Add four boolean `workflow_dispatch` inputs to `release-docker-deepseek-v4.yml` — `build_hopper`, `build_blackwell`, `build_b300`, `build_grace_blackwell` — all defaulted to `true`, so the existing "build all four" behavior is preserved when nothing is changed in the dispatch UI.
- Introduce a small `build-matrix` setup job that emits the matrix `include` array based on the selected toggles. The `build-deepseek-v4` job consumes it via `matrix: ${{ fromJson(needs.build-matrix.outputs.include) }}`, so unselected flavors don't allocate a docker-build runner at all.
- The setup job fails fast with a clear error if all four toggles are off.

## Why a setup job rather than `if:` on the matrix job

`matrix` is not in the context-availability list for `jobs.<job_id>.if`, so the obvious `if: matrix.flavor == 'hopper' && inputs.build_hopper` pattern would skip every matrix entry. Generating the matrix dynamically in a setup job is the standard workaround and has the bonus that excluded flavors never claim a self-hosted runner.

## Test plan

- [ ] Trigger the workflow on `lmsysorg/sglang-staging` with all four toggles defaulted (true) — should build all four flavors as before.
- [ ] Trigger with only `build_hopper=true` — only the hopper job should appear in the matrix.
- [ ] Trigger with only `build_b300=true` and `build_grace_blackwell=true` — only those two jobs should appear.
- [ ] Trigger with all four toggles set to false — `build-matrix` should fail with the "At least one build_* input must be true." error and `build-deepseek-v4` should not run.