### PR TITLE
Fix Qwen3 MoE double-reduce when DP attention + EP + reduce_scatterv (#23729)

### DIFF
--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -50,6 +50,7 @@ from sglang.srt.layers.linear import (
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.moe import (
     get_moe_a2a_backend,
+    should_use_dp_reduce_scatterv,
     should_use_flashinfer_cutlass_moe_fp4_allgather,
 )
 from sglang.srt.layers.moe.ep_moe.layer import get_moe_impl_class
@@ -331,7 +332,11 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
         topk_output = self.topk(hidden_states, router_logits)
         final_hidden_states = self.experts(hidden_states, topk_output)
 
-        if self.ep_size > 1 and not should_allreduce_fusion:
+        if (
+            self.ep_size > 1
+            and not should_allreduce_fusion
+            and not should_use_dp_reduce_scatterv()
+        ):
             final_hidden_states = moe_expert_parallel_all_reduce(final_hidden_states)
 
         if (
@@ -339,6 +344,7 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
             and not should_allreduce_fusion
             and not use_reduce_scatter
             and not should_use_flashinfer_cutlass_moe_fp4_allgather()
+            and not should_use_dp_reduce_scatterv()
         ):
             final_hidden_states = moe_tensor_model_parallel_all_reduce(
                 final_hidden_states


### PR DESCRIPTION
## Motivation

PR #22642 introduced `should_use_dp_reduce_scatterv()` which fuses the post-MoE all-reduce with the dp_scatter into a single `reduce_scatterv` inside `LayerCommunicator`. The `qwen2_moe.py` forward path was patched to skip the explicit `tensor_model_parallel_all_reduce` when the fast path is active — but `qwen3_moe.py` was missed.

As a result, Qwen3 MoE models running with DP attention + EP (e.g. `--tp 2 --dp 2 --ep 2 --enable-dp-attention`, no `--moe-a2a-backend`) double-reduce the MoE output: once explicitly via `moe_expert_parallel_all_reduce` (and `moe_tensor_model_parallel_all_reduce`) in `forward_normal`, then again inside `reduce_scatterv` from the communicator. The output is silently corrupted; the model still produces fluent text but logprobs differ from a tp-only baseline by 0.5–2 nats.

Reported as #23729.

## Reproduction (no DP attention vs DP+EP, same model, same prompt, temperature 0)

```bash
# Server A: tp-only baseline
python -m sglang.launch_server --model-path Qwen/Qwen3-30B-A3B-Instruct-2507 \
  --tp-size 2 --trust-remote-code --mem-fraction-static 0.8 --port 30000

# Server D: tp + dp + ep + dp_attention (the broken combination)
python -m sglang.launch_server --model-path Qwen/Qwen3-30B-A3B-Instruct-2507 \
  --tp-size 2 --dp-size 2 --ep-size 2 --enable-dp-attention \
  --trust-remote-code --mem-fraction-static 0.8 \
  --chunked-prefill-size 16384 --cuda-graph-max-bs 128 --port 30000
```

```bash
curl -sS -X POST http://127.0.0.1:30000/generate \
  -H 'Content-Type: application/json' \
  -d '{"text":"Write a science fiction for me please.","sampling_params":{"temperature":0,"max_new_tokens":100,"top_p":1.0},"return_logprob":true,"logprob_start_len":0}'
```

| variant | common-prefix vs A | mean &#124;Δlp&#124; | max &#124;Δlp&#124; | A and D text |
|---|---|---|---|---|
| **before fix** | **2 / 100** | **1.291** | **2.032** | diverge |
| **after fix** | **100 / 100** | **0.027** | **0.279** | identical |

v0.5.9 is also clean (76/100 prefix, max &#124;Δlp&#124;=0.147 — pure float drift), confirming the regression was introduced after that release.

A and D agreement is now within normal float drift, matching the level of agreement between any of the (TP-only, DP-attn-only, EP-only) configurations on this model.

## Modifications

In `Qwen3MoeSparseMoeBlock.forward_normal`, mirror the `qwen2_moe.py` guard onto both the EP and TP all-reduce branches: skip them when `should_use_dp_reduce_scatterv()` returns True (the communicator now performs the reduce inside `reduce_scatterv`).

```diff
-        if self.ep_size > 1 and not should_allreduce_fusion:
+        if (
+            self.ep_size > 1
+            and not should_allreduce_fusion
+            and not should_use_dp_reduce_scatterv()
+        ):
             final_hidden_states = moe_expert_parallel_all_reduce(final_hidden_states)

         if (
             self.tp_size > 1
             and not should_allreduce_fusion
             and not use_reduce_scatter
             and not should_use_flashinfer_cutlass_moe_fp4_allgather()
+            and not should_use_dp_reduce_scatterv()
         ):
             final_hidden_states = moe_tensor_model_parallel_all_reduce(...)
```

## Accuracy

The fix only deletes redundant collectives along the affected branch; numerics on every other path are identical. Validated above on Qwen3-30B-A3B-Instruct-2507 in the broken configuration; configurations that didn't trigger `should_use_dp_reduce_scatterv()` (TP-only, DP-attn alone, EP alone) are unaffected.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

cc @YAMY1234 (PR #22642 author)

Fixes #23729
