### PR TITLE
Fix avg_request_queue_latency metric not being collected (#6357)

### DIFF
--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -92,6 +92,7 @@ class SchedulerStats:
     num_grammar_queue_reqs: int = 0
     num_running_reqs_offline_batch: int = 0
     cache_hit_rate: float = 0.0
+    avg_request_queue_latency: float = 0.0
 
     max_total_num_tokens: int = 0
     kv_available_tokens: int = 0
@@ -271,6 +272,12 @@ class SchedulerMetricsCollector:
         self.cache_hit_rate = Gauge(
             name="sglang:cache_hit_rate",
             documentation="The prefix cache hit rate.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+        self.avg_request_queue_latency = Gauge(
+            name="sglang:avg_request_queue_latency",
+            documentation="The average time (in seconds) that requests currently in the waiting queue have been waiting.",
             labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
         )
@@ -1034,6 +1041,9 @@ class SchedulerMetricsCollector:
             self.num_running_reqs_offline_batch, stats.num_running_reqs_offline_batch
         )
         self._log_gauge(self.cache_hit_rate, stats.cache_hit_rate)
+        self._log_gauge(
+            self.avg_request_queue_latency, stats.avg_request_queue_latency
+        )
 
         self._log_gauge(self.max_total_num_tokens, stats.max_total_num_tokens)
         self._log_gauge(self.kv_available_tokens, stats.kv_available_tokens)

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -1041,9 +1041,7 @@ class SchedulerMetricsCollector:
             self.num_running_reqs_offline_batch, stats.num_running_reqs_offline_batch
         )
         self._log_gauge(self.cache_hit_rate, stats.cache_hit_rate)
-        self._log_gauge(
-            self.avg_request_queue_latency, stats.avg_request_queue_latency
-        )
+        self._log_gauge(self.avg_request_queue_latency, stats.avg_request_queue_latency)
 
         self._log_gauge(self.max_total_num_tokens, stats.max_total_num_tokens)
         self._log_gauge(self.kv_available_tokens, stats.kv_available_tokens)

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -326,6 +326,17 @@ class SchedulerMetricsMixin:
         self.spec_total_num_accepted_tokens = 0
         self.spec_total_num_forward_ct = 0
 
+    def _compute_avg_queue_latency(self: Scheduler) -> float:
+        if not self.waiting_queue:
+            return 0.0
+        now = time.perf_counter()
+        waits = [
+            now - req.time_stats.wait_queue_entry_time
+            for req in self.waiting_queue
+            if req.time_stats.wait_queue_entry_time > 0.0
+        ]
+        return sum(waits) / len(waits) if waits else 0.0
+
     def report_prefill_stats(
         self: Scheduler,
         prefill_stats: PrefillStats,
@@ -426,6 +437,7 @@ class SchedulerMetricsMixin:
             )
             self.stats.num_grammar_queue_reqs = len(self.grammar_manager)
             self.stats.cache_hit_rate = cache_hit_rate
+            self.stats.avg_request_queue_latency = self._compute_avg_queue_latency()
 
             self.stats.max_total_num_tokens = self.max_total_num_tokens
 
@@ -604,6 +616,7 @@ class SchedulerMetricsMixin:
             )
             self.stats.num_grammar_queue_reqs = len(self.grammar_manager)
             self.stats.cache_hit_rate = cache_hit_rate
+            self.stats.avg_request_queue_latency = self._compute_avg_queue_latency()
 
             self.stats.max_total_num_tokens = self.max_total_num_tokens
             self.stats.num_streaming_sessions = self._streaming_session_count()

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -330,12 +330,14 @@ class SchedulerMetricsMixin:
         if not self.waiting_queue:
             return 0.0
         now = time.perf_counter()
-        waits = [
-            now - req.time_stats.wait_queue_entry_time
-            for req in self.waiting_queue
-            if req.time_stats.wait_queue_entry_time > 0.0
-        ]
-        return sum(waits) / len(waits) if waits else 0.0
+        total = 0.0
+        count = 0
+        for req in self.waiting_queue:
+            entry_time = req.time_stats.wait_queue_entry_time
+            if entry_time > 0.0:
+                total += now - entry_time
+                count += 1
+        return total / count if count else 0.0
 
     def report_prefill_stats(
         self: Scheduler,


### PR DESCRIPTION
## Summary
Adds `sglang:avg_request_queue_latency` Prometheus Gauge that reports average wait time of requests currently in the waiting queue. Updated every stats interval in both prefill and decode reporting paths.

Reopens #20159 (rebased onto current main).

Closes #6357.