### PR TITLE
Add tracing span around model forward(first try)

### DIFF
--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -819,11 +819,13 @@ def embed_mm_inputs(
                     flatten_nested_list([item.offsets for item in mm_items])
                 )
             items_size = torch.cumsum(items_size, dim=0).tolist()
-
-            trace_ctx = getattr(forward_batch, "trace_ctx", None)
-
-            if modality == Modality.IMAGE and trace_ctx is not None:
-                trace_ctx.trace_slice_start("vit_encode", 1)
+            
+            time_stats_list = getattr(forward_batch, "time_stats", None)
+            
+            if modality == Modality.IMAGE and time_stats_list is not None:
+                for time_stats in time_stats_list:
+                    time_stats.set_vit_encode_start_time()
+                    
             try:
                 embedding, mask, input_ids = get_embedding_and_mask(
                     data_embedding_func=embedder,
@@ -836,8 +838,9 @@ def embed_mm_inputs(
                     items_offset_list=items_offsets,
                 )
             finally:
-                if modality == Modality.IMAGE and trace_ctx is not None:
-                    trace_ctx.trace_slice_end("vit_encode", 1)
+                if modality == Modality.IMAGE and time_stats_list is not None:
+                    for time_stats in time_stats_list:
+                        time_stats.set_vit_encode_end_time()
 
             if use_deepstack.get(modality, None) and embedding is not None:
                 embedding, deepstack_embedding = (

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -752,6 +752,7 @@ def embed_mm_inputs(
     input_ids: torch.Tensor,
     input_embedding: nn.Embedding,
     multimodal_model: nn.Module = None,
+    forward_batch: Optional[ForwardBatch] = None,
     data_embedding_func_mapping: Dict[Modality, DataEmbeddingFunc] = None,
     placeholder_tokens: dict[Modality, List[int]] = None,
     use_deepstack: Dict[Modality, bool] = {},
@@ -819,16 +820,24 @@ def embed_mm_inputs(
                 )
             items_size = torch.cumsum(items_size, dim=0).tolist()
 
-            embedding, mask, input_ids = get_embedding_and_mask(
-                data_embedding_func=embedder,
-                embedding_items=items,
-                placeholder_tensor=placeholder_tensor,
-                input_ids=input_ids,
-                items_size=items_size,
-                prefix_length=extend_prefix_lens,
-                extend_length=extend_seq_lens,
-                items_offset_list=items_offsets,
-            )
+            trace_ctx = getattr(forward_batch, "trace_ctx", None)
+
+            if modality == Modality.IMAGE and trace_ctx is not None:
+                trace_ctx.trace_slice_start("vit_encode", 1)
+            try:
+                embedding, mask, input_ids = get_embedding_and_mask(
+                    data_embedding_func=embedder,
+                    embedding_items=items,
+                    placeholder_tensor=placeholder_tensor,
+                    input_ids=input_ids,
+                    items_size=items_size,
+                    prefix_length=extend_prefix_lens,
+                    extend_length=extend_seq_lens,
+                    items_offset_list=items_offsets,
+                )
+            finally:
+                if modality == Modality.IMAGE and trace_ctx is not None:
+                    trace_ctx.trace_slice_end("vit_encode", 1)
 
             if use_deepstack.get(modality, None) and embedding is not None:
                 embedding, deepstack_embedding = (
@@ -910,6 +919,7 @@ def _embed_mm_inputs_with_split(
     embed_kwargs = dict(
         multimodal_model=multimodal_model,
         input_embedding=input_embedding,
+        forward_batch=forward_batch,
         data_embedding_func_mapping=data_embedding_func_mapping,
         placeholder_tokens=placeholder_tokens,
         use_deepstack=use_deepstack,
@@ -1056,6 +1066,7 @@ def general_mm_embed_routine(
                     input_ids=input_ids,
                     input_embedding=embed_tokens,
                     multimodal_model=multimodal_model,
+                    forward_batch=forward_batch,
                     data_embedding_func_mapping=data_embedding_funcs,
                     placeholder_tokens=placeholder_tokens,
                     use_deepstack=use_deepstack,

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import IntEnum, auto
 from functools import total_ordering
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 import torch
 import triton
@@ -73,6 +73,7 @@ if TYPE_CHECKING:
     from sglang.srt.model_executor.model_runner import ModelRunner
     from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
     from sglang.srt.speculative.spec_info import SpecInput, SpeculativeAlgorithm
+    from sglang.srt.observability.req_time_stats import SchedulerReqTimeStats
 
 _is_npu = is_npu()
 
@@ -440,8 +441,8 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     # For dumper: request IDs for cross-step sequence tracking
     rids: Optional[List[str]] = None
 
-    # For request tracing
-    trace_ctx: Optional[Any] = None
+    # For request time stats
+    time_stats: Optional[List[SchedulerReqTimeStats]] = None
 
     @classmethod
     def init_new(
@@ -493,11 +494,11 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             return_hidden_states_before_norm=batch.return_hidden_states_before_norm,
             return_pooled_hidden_states=batch.return_pooled_hidden_states,
             rids=[req.rid for req in batch.reqs],
-            trace_ctx=(
-                batch.reqs[0].time_stats.trace_ctx
-                if batch.reqs is not None and len(batch.reqs) > 0
+            time_stats=(
+                [req.time_stats for req in batch.reqs]
+                if batch.reqs is not None
                 else None
-            ),
+            )
         )
         device = model_runner.device
 

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import IntEnum, auto
 from functools import total_ordering
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import torch
 import triton
@@ -440,6 +440,9 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     # For dumper: request IDs for cross-step sequence tracking
     rids: Optional[List[str]] = None
 
+    # For request tracing
+    trace_ctx: Optional[Any] = None
+
     @classmethod
     def init_new(
         cls,
@@ -490,6 +493,11 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             return_hidden_states_before_norm=batch.return_hidden_states_before_norm,
             return_pooled_hidden_states=batch.return_pooled_hidden_states,
             rids=[req.rid for req in batch.reqs],
+            trace_ctx=(
+                batch.reqs[0].time_stats.trace_ctx
+                if batch.reqs is not None and len(batch.reqs) > 0
+                else None
+            ),
         )
         device = model_runner.device
 

--- a/python/sglang/srt/observability/req_time_stats.py
+++ b/python/sglang/srt/observability/req_time_stats.py
@@ -568,6 +568,10 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
     spec_draft_start_time: float = 0.0
     spec_verify_start_time: float = 0.0
     spec_draft_extend_start_time: float = 0.0
+    
+    # ViT_encode, get time by time.perf_counter()
+    vit_encode_start_time: float = 0.0
+    vit_encode_end_time: float = 0.0
 
     # other
     transfer_speed_gb_s: float = 0.0
@@ -961,6 +965,20 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
 
     def get_queueing_time(self) -> float:
         return self.forward_entry_time - self.wait_queue_entry_time
+    
+    def set_vit_encode_start_time(self, ts=None):
+        ts = ts or time.perf_counter()
+        self.vit_encode_start_time = ts
+        self.trace_ctx.trace_slice_start(
+            "vit_encode", 1, convert_time_to_realtime_ns(ts)
+        )
+        
+    def set_vit_encode_end_time(self, ts=None):
+        ts = ts or time.perf_counter()
+        self.vit_encode_end_time = ts
+        self.trace_ctx.trace_slice_end(
+            "vit_encode", 1, convert_time_to_realtime_ns(ts)
+        )
 
     def convert_to_duration(self) -> str:
         if self.disagg_mode == DisaggregationMode.NULL:


### PR DESCRIPTION
## Motivation

This PR adds an initial tracing span around the scheduler-side model forward call. The goal is to verify whether request-level tracing can capture the model forward stage before adding more fine-grained spans for the vision encode path.

## Modifications

- Extract `trace_ctx` from `batch.reqs[0].time_stats` when available.
- Add `trace_slice_start("model_forward")` before `forward_batch_generation`.
- Add `trace_slice_end("model_forward")` in a `finally` block to ensure the span is closed.
- Keep the tracing logic optional when `trace_ctx` is not available.

## Accuracy Tests

Not run. This PR only adds optional tracing instrumentation and should not change model outputs.

## Speed Tests and Profiling

Not run. This PR is intended for tracing verification. The tracing span is only used when `trace_ctx` is available.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->