### PR TITLE
Avoid DSv4 compressed mixed multi-prefill FlashMLA crash

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -330,6 +330,10 @@ class Scheduler(
         # Init model configs
         self.init_model_config()
         self._dsv4_compressed_prefill_guard_warned = False
+        self._is_dsv4_compressed_with_compressed_backend = (
+            is_deepseek_compressed(self.model_config.hf_config)
+            and self.server_args.get_attention_backends() == ("compressed", "compressed")
+        )
 
         # Init metrics stats
         self.init_metrics(tp_rank, pp_rank, dp_rank)
@@ -1955,8 +1959,7 @@ class Scheduler(
         prefill_max_requests = self.server_args.prefill_max_requests
         if (
             running_bs > 0
-            and is_deepseek_compressed(self.model_config.hf_config)
-            and self.server_args.get_attention_backends() == ("compressed", "compressed")
+            and self._is_dsv4_compressed_with_compressed_backend
             and (prefill_max_requests is None or prefill_max_requests > 1)
         ):
             if not self._dsv4_compressed_prefill_guard_warned:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -33,7 +33,7 @@ from torch.cuda import Stream as CudaStream
 from torch.cuda import StreamContext as CudaStreamContext
 from torch.distributed import barrier
 
-from sglang.srt.configs.model_config import ModelConfig
+from sglang.srt.configs.model_config import ModelConfig, is_deepseek_compressed
 from sglang.srt.constrained.grammar_manager import GrammarManager
 from sglang.srt.disaggregation.decode import (
     DecodePreallocQueue,
@@ -329,6 +329,7 @@ class Scheduler(
 
         # Init model configs
         self.init_model_config()
+        self._dsv4_compressed_prefill_guard_warned = False
 
         # Init metrics stats
         self.init_metrics(tp_rank, pp_rank, dp_rank)
@@ -1950,6 +1951,24 @@ class Scheduler(
         res = min(res, self.req_to_token_pool.available_size())
         return res
 
+    def _get_effective_prefill_max_requests(self, running_bs: int) -> Optional[int]:
+        prefill_max_requests = self.server_args.prefill_max_requests
+        if (
+            running_bs > 0
+            and is_deepseek_compressed(self.model_config.hf_config)
+            and self.server_args.get_attention_backends() == ("compressed", "compressed")
+            and (prefill_max_requests is None or prefill_max_requests > 1)
+        ):
+            if not self._dsv4_compressed_prefill_guard_warned:
+                logger.warning(
+                    "DSv4 compressed prefill guard active: running_bs=%s, "
+                    "effective_prefill_max_requests=1",
+                    running_bs,
+                )
+                self._dsv4_compressed_prefill_guard_warned = True
+            return 1
+        return prefill_max_requests
+
     def get_new_batch_prefill(self) -> Optional[ScheduleBatch]:
         prefill_delayer_single_pass = None
         if self.prefill_delayer:
@@ -2019,6 +2038,8 @@ class Scheduler(
             if dynamic_size is not None:
                 chunked_prefill_size = dynamic_size
 
+        prefill_max_requests = self._get_effective_prefill_max_requests(running_bs)
+
         # Prefill policy
         adder = PrefillAdder(
             self.page_size,
@@ -2030,7 +2051,7 @@ class Scheduler(
             chunked_prefill_size,
             running_bs if self.is_mixed_chunk else 0,
             self.priority_scheduling_preemption_threshold,
-            prefill_max_requests=self.server_args.prefill_max_requests,
+            prefill_max_requests=prefill_max_requests,
             prefill_delayer_single_pass=prefill_delayer_single_pass,
             dllm_config=self.dllm_config,
         )


### PR DESCRIPTION
## Summary

This PR adds a narrow scheduler guard for DeepSeek V4 compressed attention.

When DSv4 compressed attention already has running decode requests, the scheduler now caps the effective prefill request count to 1. This avoids a mixed decode plus multi-new-prefill shape that currently produces invalid FlashMLA decode metadata on GB200.

The problematic live shape was:

```text
Prefill batch, #new-seq: 1, #new-token: 4096, #running-req: 0
Prefill batch, #new-seq: 3, #new-token: 12288, #running-req: 1
CUDA error (.../get_decoding_sched_meta.cu:111): invalid argument
```

With this guard, the trailing prefills are admitted as separate prefill steps while decode is running:

```text
DSv4 compressed prefill guard active: running_bs=1, effective_prefill_max_requests=1
Prefill batch, #new-seq: 1, #new-token: 4096, #running-req: 1
Prefill batch, #new-seq: 1, #new-token: 4096, #running-req: 2
Prefill batch, #new-seq: 1, #new-token: 4096, #running-req: 3
```

This is intentionally scoped to:

- DSv4 compressed attention
- compressed/compressed attention backend
- only while `running_bs > 0`
- only when the user did not already set `prefill_max_requests <= 1`

## Validation

Validated on one GB200 node with full DeepSeek-V4-Flash TP=4, `moe_runner_backend=flashinfer_mxfp4`, `disable_cuda_graph`, `disable_flashinfer_autotune`, and `SGLANG_JIT_DEEPGEMM_PRECOMPILE=0`.

First, a single raw `4096+2` request completed and boundary instrumentation showed all layers `0..42` reached `backend_post_flashmla`, clearing the first FP8/DeepGEMM and first FlashMLA prefill paths as the blocker.

Then the original staggered failure shape was rerun:

- request 0: `4096+1500`
- wait `5s`
- requests 1-3: `4096+2`

Result:

```text
ok_count=4
error_count=0
elapsed_sec=251.926597
```

No `#new-seq: 3` mixed-prefill batch occurred, and no `get_decoding_sched_meta.cu:111` error occurred.

## Notes

This PR does not claim to fix FlashMLA's internal handling of the mixed metadata shape. It prevents SGLang from constructing that currently unsupported DSv4 compressed-attention scheduling state. A follow-up investigation should compare the legal guarded metadata with the failing `#running-req: 1 + #new-seq: 3` metadata to decide whether the deeper fix belongs in metadata construction or FlashMLA.
