### PR TITLE
[Bugfix] Fix heterogeneous TP disaggregation precision for GQA head mapping and Mamba conv state

### DIFF
--- a/python/sglang/srt/configs/mamba_utils.py
+++ b/python/sglang/srt/configs/mamba_utils.py
@@ -137,6 +137,9 @@ class Mamba2StateShape:
     head_dim: int
     state_size: int
     conv_kernel: int
+    # Unsharded group sizes for conv state, matching mamba_v2_sharded_weight_loader ordering.
+    # e.g. Mamba2: [x_size, B_size, C_size], GatedDeltaNet: [K_dim, K_dim, V_dim]
+    conv_shard_groups: list[int] = field(default_factory=list)
 
     @staticmethod
     def create(
@@ -148,6 +151,7 @@ class Mamba2StateShape:
         head_dim: int,
         state_size: int,
         conv_kernel: int,
+        conv_shard_groups: Optional[list[int]] = None,
     ) -> "Mamba2StateShape":
         # if n_groups is not divisible by world_size, need to extend the shards
         # to ensure all groups needed by a head is sharded along with it
@@ -164,6 +168,15 @@ class Mamba2StateShape:
         # - they are typically small
         #   e.g., QWen3-Next: (32, 128, 128)
         temporal_state_shape = (divide(num_heads, tp_world_size), head_dim, state_size)
+        if conv_shard_groups is None:
+            bc_size = n_groups * state_size
+            conv_shard_groups = [intermediate_size, bc_size, bc_size]
+        if sum(conv_shard_groups) != conv_dim:
+            raise ValueError(
+                f"conv_shard_groups {conv_shard_groups} sum={sum(conv_shard_groups)} "
+                f"!= conv_dim={conv_dim}"
+            )
+
         return Mamba2StateShape(
             conv=[conv_state_shape],
             temporal=temporal_state_shape,
@@ -174,6 +187,7 @@ class Mamba2StateShape:
             head_dim=head_dim,
             state_size=state_size,
             conv_kernel=conv_kernel,
+            conv_shard_groups=conv_shard_groups,
         )
 
 

--- a/python/sglang/srt/configs/qwen3_next.py
+++ b/python/sglang/srt/configs/qwen3_next.py
@@ -287,14 +287,17 @@ class Qwen3NextConfig(PretrainedConfig):
             world_size = get_attention_tp_size()
             adjust_tp_num_heads_if_necessary(self, world_size, False)
 
+        key_dim = self.linear_num_key_heads * self.linear_key_head_dim
+        value_dim = self.linear_value_head_dim * self.linear_num_value_heads
         shape = Mamba2StateShape.create(
             tp_world_size=get_attention_tp_size(),
-            intermediate_size=self.linear_value_head_dim * self.linear_num_value_heads,
+            intermediate_size=value_dim,
             n_groups=self.linear_num_key_heads,
             num_heads=self.linear_num_value_heads,
             head_dim=self.linear_value_head_dim,
             state_size=self.linear_key_head_dim,
             conv_kernel=self.linear_conv_kernel_dim,
+            conv_shard_groups=[key_dim, key_dim, value_dim],
         )
 
         return Mamba2CacheParams(

--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -34,6 +34,9 @@ class KVArgs:
     state_type: str  # "none", "mamba", "swa", "nsa", "dsv4"
     # for mamba state different tp slice transfer
     state_dim_per_tensor: List[int]  # dimension to slice for each state tensor
+    # Conv state shard groups for heterogeneous TP slice transfer (unsharded group sizes)
+    state_conv_shard_groups: List[int]
+    state_conv_tensor_count: int  # number of conv entries in state_dim_per_tensor
     ib_device: str
     ib_traffic_class: str
     gpu_id: int

--- a/python/sglang/srt/disaggregation/common/staging_buffer.py
+++ b/python/sglang/srt/disaggregation/common/staging_buffer.py
@@ -708,9 +708,12 @@ def compute_head_slice_params(
         unique_head_idx = local_tp_rank // src_replication
         dst_head_start = (unique_head_idx * src_heads_per_rank) % dst_heads_per_rank
     else:
-        src_head_start = (
-            dst_tp_rank_in_group * dst_heads_per_rank
-        ) % src_heads_per_rank
+        # When dst_attn_tp_size > total_kv_heads, multiple decode ranks share
+        # the same KV head (GQA replication on dst side). Map
+        # dst_tp_rank_in_group to its actual KV head index first.
+        dst_replication = max(1, dst_attn_tp_size // total_kv_heads)
+        unique_dst_idx = dst_tp_rank_in_group // dst_replication
+        src_head_start = (unique_dst_idx * dst_heads_per_rank) % src_heads_per_rank
         num_heads_to_send = dst_heads_per_rank
         dst_head_start = 0
 

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -797,9 +797,14 @@ class MooncakeKVManager(CommonKVManager):
                 unique_head_idx * src_heads_per_rank
             ) % dst_heads_per_rank
         else:
-            # Send KVCache from 1 prefill instance to multiple decode instances
+            # Send KVCache from 1 prefill instance to multiple decode instances.
+            # When dst_attn_tp_size > total_kv_heads, multiple decode ranks share
+            # the same KV head (GQA replication on dst side). Map
+            # dst_tp_rank_in_group to its actual KV head index first.
+            dst_replication = max(1, dst_attn_tp_size // total_kv_heads)
+            unique_dst_idx = dst_tp_rank_in_group // dst_replication
             src_head_start_offset = (
-                dst_tp_rank_in_group * dst_heads_per_rank
+                unique_dst_idx * dst_heads_per_rank
             ) % src_heads_per_rank
             num_heads_to_send = dst_heads_per_rank
             dst_head_start_offset = 0
@@ -1070,6 +1075,11 @@ class MooncakeKVManager(CommonKVManager):
 
         The 3rd dimension is sliced by TP. When prefill and decode have different
         attn_tp_size, we need to slice the state accordingly.
+
+        For conv_state, the sliceable dimension is composed of multiple groups
+        (e.g. [K, K, V] for GatedDeltaNet) that are each independently sharded
+        by mamba_v2_sharded_weight_loader. Simple contiguous slicing would
+        corrupt the data; we must slice each group independently.
         """
         logger.warning_once(
             "Using Mamba state slice transfer for different TP sizes between prefill and decode. "
@@ -1090,51 +1100,90 @@ class MooncakeKVManager(CommonKVManager):
         local_tp_rank_in_group = self.kv_args.engine_rank % self.attn_tp_size
         dst_tp_rank_in_group = dst_tp_rank % dst_attn_tp_size
 
+        # Conv shard groups for group-aware slicing. Tensors are laid out with
+        # all conv-state tensors first (indices [0, conv_tensor_count)) followed
+        # by temporal-state tensors. Per-group slicing only kicks in when the
+        # conv dim is composed of multiple independently TP-sharded groups
+        # (e.g. [K, K, V] for GatedDeltaNet); standard single-group conv state
+        # and all temporal tensors fall through to plain contiguous slicing.
+        conv_shard_groups = getattr(self.kv_args, "state_conv_shard_groups", [])
+        conv_tensor_count = getattr(self.kv_args, "state_conv_tensor_count", 0)
+        has_grouped_conv_layout = len(conv_shard_groups) > 1
+
         for i, dst_state_ptr in enumerate(dst_state_data_ptrs):
             src_item_len = prefill_state_item_lens[i]
             dst_item_len = dst_state_item_lens[i]
             src_dim = src_state_dim_per_tensor[i]
             dst_dim = dst_state_dim_per_tensor[i]
 
-            # Calculate bytes per dimension slice
-            # item_len = dim * trailing_dims_size, so trailing_dims_size = item_len / dim
             src_bytes_per_dim = src_item_len // src_dim
-            dst_bytes_per_dim = dst_item_len // dst_dim
 
-            # Determine slicing parameters based on TP configuration
-            if self.attn_tp_size > dst_attn_tp_size:
-                # Multiple prefill ranks send to 1 decode rank
-                # Each prefill sends all its dims to the appropriate offset in decode
-                src_dim_start = 0
-                num_dims_to_send = src_dim
-                writers_per_decode = self.attn_tp_size // dst_attn_tp_size
-                local_writer_idx = local_tp_rank_in_group % writers_per_decode
-                dst_dim_start = local_writer_idx * src_dim
+            src_base = prefill_state_data_ptrs[i] + src_item_len * int(
+                prefill_mamba_index[0]
+            )
+            dst_base = dst_state_ptr + dst_item_len * int(req.dst_state_indices[0])
+
+            is_conv_tensor = i < conv_tensor_count
+            needs_per_group_slicing = is_conv_tensor and has_grouped_conv_layout
+
+            if needs_per_group_slicing:
+                # Per-group slicing for conv state tensors.
+                # The conv dim is composed of groups (e.g. [K, K, V]) that are
+                # each independently TP-sharded by mamba_v2_sharded_weight_loader.
+                src_group_dim_offset = 0
+                dst_group_dim_offset = 0
+
+                for group_size in conv_shard_groups:
+                    src_group_dims = group_size // self.attn_tp_size
+                    dst_group_dims = group_size // dst_attn_tp_size
+
+                    if self.attn_tp_size > dst_attn_tp_size:
+                        writers_per_dst = self.attn_tp_size // dst_attn_tp_size
+                        local_writer_idx = local_tp_rank_in_group % writers_per_dst
+                        src_start = src_group_dim_offset
+                        dst_start = (
+                            dst_group_dim_offset + local_writer_idx * src_group_dims
+                        )
+                        dims_to_send = src_group_dims
+                    else:
+                        readers_per_src = dst_attn_tp_size // self.attn_tp_size
+                        dst_local_idx = dst_tp_rank_in_group % readers_per_src
+                        src_start = (
+                            src_group_dim_offset + dst_local_idx * dst_group_dims
+                        )
+                        dst_start = dst_group_dim_offset
+                        dims_to_send = dst_group_dims
+
+                    transfer_blocks.append(
+                        (
+                            src_base + src_start * src_bytes_per_dim,
+                            dst_base + dst_start * src_bytes_per_dim,
+                            dims_to_send * src_bytes_per_dim,
+                        )
+                    )
+
+                    src_group_dim_offset += src_group_dims
+                    dst_group_dim_offset += dst_group_dims
             else:
-                # 1 prefill rank sends to multiple decode ranks
-                # Prefill sends a slice of its dims to each decode rank
-                src_dim_start = (dst_tp_rank_in_group * dst_dim) % src_dim
-                num_dims_to_send = dst_dim
-                dst_dim_start = 0
+                # Contiguous slicing for temporal state (or conv without groups)
+                if self.attn_tp_size > dst_attn_tp_size:
+                    writers_per_decode = self.attn_tp_size // dst_attn_tp_size
+                    local_writer_idx = local_tp_rank_in_group % writers_per_decode
+                    src_dim_start = 0
+                    num_dims_to_send = src_dim
+                    dst_dim_start = local_writer_idx * src_dim
+                else:
+                    src_dim_start = (dst_tp_rank_in_group * dst_dim) % src_dim
+                    num_dims_to_send = dst_dim
+                    dst_dim_start = 0
 
-            # Calculate byte offsets
-            src_dim_offset = src_dim_start * src_bytes_per_dim
-            dst_dim_offset = dst_dim_start * dst_bytes_per_dim
-            bytes_to_send = num_dims_to_send * src_bytes_per_dim
-
-            # Calculate addresses for this state tensor
-            src_addr = (
-                prefill_state_data_ptrs[i]
-                + src_item_len * int(prefill_mamba_index[0])
-                + src_dim_offset
-            )
-            dst_addr = (
-                dst_state_ptr
-                + dst_item_len * int(req.dst_state_indices[0])
-                + dst_dim_offset
-            )
-
-            transfer_blocks.append((src_addr, dst_addr, bytes_to_send))
+                transfer_blocks.append(
+                    (
+                        src_base + src_dim_start * src_bytes_per_dim,
+                        dst_base + dst_dim_start * src_bytes_per_dim,
+                        num_dims_to_send * src_bytes_per_dim,
+                    )
+                )
 
         return self._transfer_data(req.mooncake_session_id, transfer_blocks)
 

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -736,9 +736,14 @@ class NixlKVManager(CommonKVManager):
                 unique_head_idx * src_heads_per_rank
             ) % dst_heads_per_rank
         else:
-            # Send KVCache from 1 prefill instance to multiple decode instances
+            # Send KVCache from 1 prefill instance to multiple decode instances.
+            # When decode_tp_size > total_kv_heads, multiple decode ranks share
+            # the same KV head (GQA replication on dst side). Map
+            # dst_tp_rank_in_group to its actual KV head index first.
+            dst_replication = max(1, decode_tp_size // total_kv_heads)
+            unique_dst_idx = dst_tp_rank_in_group // dst_replication
             src_head_start_offset = (
-                dst_tp_rank_in_group * dst_heads_per_rank
+                unique_dst_idx * dst_heads_per_rank
             ) % src_heads_per_rank
             num_heads_to_send = dst_heads_per_rank
             dst_head_start_offset = 0
@@ -953,6 +958,16 @@ class NixlKVManager(CommonKVManager):
         local_tp_rank_in_group = self.kv_args.engine_rank % self.attn_tp_size
         dst_tp_rank_in_group = decode_tp_rank % decode_tp_size
 
+        # Conv shard groups for group-aware slicing. Tensors are laid out with
+        # all conv-state tensors first (indices [0, conv_tensor_count)) followed
+        # by temporal-state tensors. Per-group slicing only kicks in when the
+        # conv dim is composed of multiple independently TP-sharded groups
+        # (e.g. [K, K, V] for GatedDeltaNet); standard single-group conv state
+        # and all temporal tensors fall through to plain contiguous slicing.
+        conv_shard_groups = getattr(self.kv_args, "state_conv_shard_groups", [])
+        conv_tensor_count = getattr(self.kv_args, "state_conv_tensor_count", 0)
+        has_grouped_conv_layout = len(conv_shard_groups) > 1
+
         src_addrs = []
         dst_addrs = []
 
@@ -963,35 +978,85 @@ class NixlKVManager(CommonKVManager):
             dst_dim = dst_state_dim_per_tensor[i]
 
             src_bytes_per_dim = src_item_len // src_dim
-            dst_bytes_per_dim = dst_item_len // dst_dim
 
-            if self.attn_tp_size > decode_tp_size:
-                src_dim_start = 0
-                num_dims_to_send = src_dim
-                writers_per_decode = self.attn_tp_size // decode_tp_size
-                local_writer_idx = local_tp_rank_in_group % writers_per_decode
-                dst_dim_start = local_writer_idx * src_dim
+            src_base = prefill_state_data_ptrs[i] + src_item_len * int(
+                prefill_state_indices[0]
+            )
+            dst_base = dst_state_ptr + dst_item_len * int(dst_state_indices[0])
+
+            is_conv_tensor = i < conv_tensor_count
+            needs_per_group_slicing = is_conv_tensor and has_grouped_conv_layout
+
+            if needs_per_group_slicing:
+                src_group_dim_offset = 0
+                dst_group_dim_offset = 0
+
+                for group_size in conv_shard_groups:
+                    src_group_dims = group_size // self.attn_tp_size
+                    dst_group_dims = group_size // decode_tp_size
+
+                    if self.attn_tp_size > decode_tp_size:
+                        writers_per_dst = self.attn_tp_size // decode_tp_size
+                        local_writer_idx = local_tp_rank_in_group % writers_per_dst
+                        src_start = src_group_dim_offset
+                        dst_start = (
+                            dst_group_dim_offset + local_writer_idx * src_group_dims
+                        )
+                        dims_to_send = src_group_dims
+                    else:
+                        readers_per_src = decode_tp_size // self.attn_tp_size
+                        dst_local_idx = dst_tp_rank_in_group % readers_per_src
+                        src_start = (
+                            src_group_dim_offset + dst_local_idx * dst_group_dims
+                        )
+                        dst_start = dst_group_dim_offset
+                        dims_to_send = dst_group_dims
+
+                    bytes_to_send = dims_to_send * src_bytes_per_dim
+                    src_addrs.append(
+                        (
+                            src_base + src_start * src_bytes_per_dim,
+                            bytes_to_send,
+                            self.kv_args.gpu_id,
+                        )
+                    )
+                    dst_addrs.append(
+                        (
+                            dst_base + dst_start * src_bytes_per_dim,
+                            bytes_to_send,
+                            dst_gpu_id,
+                        )
+                    )
+
+                    src_group_dim_offset += src_group_dims
+                    dst_group_dim_offset += dst_group_dims
             else:
-                src_dim_start = (dst_tp_rank_in_group * dst_dim) % src_dim
-                num_dims_to_send = dst_dim
-                dst_dim_start = 0
+                if self.attn_tp_size > decode_tp_size:
+                    src_dim_start = 0
+                    num_dims_to_send = src_dim
+                    writers_per_decode = self.attn_tp_size // decode_tp_size
+                    local_writer_idx = local_tp_rank_in_group % writers_per_decode
+                    dst_dim_start = local_writer_idx * src_dim
+                else:
+                    src_dim_start = (dst_tp_rank_in_group * dst_dim) % src_dim
+                    num_dims_to_send = dst_dim
+                    dst_dim_start = 0
 
-            src_dim_offset = src_dim_start * src_bytes_per_dim
-            dst_dim_offset = dst_dim_start * dst_bytes_per_dim
-            bytes_to_send = num_dims_to_send * src_bytes_per_dim
-
-            src_addr = (
-                prefill_state_data_ptrs[i]
-                + src_item_len * int(prefill_state_indices[0])
-                + src_dim_offset
-            )
-            dst_addr = (
-                dst_state_ptr
-                + dst_item_len * int(dst_state_indices[0])
-                + dst_dim_offset
-            )
-            src_addrs.append((src_addr, bytes_to_send, self.kv_args.gpu_id))
-            dst_addrs.append((dst_addr, bytes_to_send, dst_gpu_id))
+                bytes_to_send = num_dims_to_send * src_bytes_per_dim
+                src_addrs.append(
+                    (
+                        src_base + src_dim_start * src_bytes_per_dim,
+                        bytes_to_send,
+                        self.kv_args.gpu_id,
+                    )
+                )
+                dst_addrs.append(
+                    (
+                        dst_base + dst_dim_start * src_bytes_per_dim,
+                        bytes_to_send,
+                        dst_gpu_id,
+                    )
+                )
 
         src_descs = self.agent.get_xfer_descs(src_addrs, "VRAM")
         dst_descs = self.agent.get_xfer_descs(dst_addrs, "VRAM")

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -572,6 +572,10 @@ def setup_state_kv_args(
         # Get state dimension info for cross-TP slice transfer
         if hasattr(token_to_kv_pool, "get_state_dim_per_tensor"):
             kv_args.state_dim_per_tensor = token_to_kv_pool.get_state_dim_per_tensor()
+        if hasattr(token_to_kv_pool, "get_state_conv_shard_info"):
+            groups, count = token_to_kv_pool.get_state_conv_shard_info()
+            kv_args.state_conv_shard_groups = groups
+            kv_args.state_conv_tensor_count = count
     elif isinstance(token_to_kv_pool, NSATokenToKVPool):
         kv_args.state_type = "nsa"
         if draft_token_to_kv_pool is not None and isinstance(

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -244,6 +244,14 @@ class MambaPool:
         self.size = size
         self.device = device
 
+        # Store conv shard groups for disagg heterogeneous TP transfer
+        shape = cache_params.shape
+        if hasattr(shape, "conv_shard_groups") and shape.conv_shard_groups:
+            self._conv_shard_groups = shape.conv_shard_groups
+        else:
+            self._conv_shard_groups = []
+        self._num_conv_types = len(cache_params.shape.conv)
+
         # for disagg with nvlink
         self.enable_custom_mem_pool, self.custom_mem_pool, _ = (
             maybe_init_custom_mem_pool(device=self.device)
@@ -478,6 +486,16 @@ class MambaPool:
             # Repeat for each layer since we have per-layer data_ptrs
             dim_per_tensor += [sliceable_dim] * self.num_mamba_layers
         return dim_per_tensor
+
+    def get_state_conv_shard_info(self):
+        """Get conv shard group info for heterogeneous TP disagg transfer.
+
+        Returns (conv_shard_groups, conv_tensor_count):
+        - conv_shard_groups: unsharded group sizes for conv state (e.g. [2048, 2048, 2048])
+        - conv_tensor_count: number of entries in state_dim_per_tensor that are conv type
+        """
+        conv_tensor_count = self._num_conv_types * self.num_mamba_layers
+        return self._conv_shard_groups, conv_tensor_count
 
 
 class HybridReqToTokenPool(ReqToTokenPool):
@@ -1370,6 +1388,10 @@ class HybridLinearKVPool(KVCache):
     def get_state_dim_per_tensor(self):
         """Get the sliceable dimension size for each mamba state tensor."""
         return self.mamba_pool.get_state_dim_per_tensor()
+
+    def get_state_conv_shard_info(self):
+        """Get conv shard group info for heterogeneous TP disagg transfer."""
+        return self.mamba_pool.get_state_conv_shard_info()
 
     def maybe_get_custom_mem_pool(self):
         return self.full_kv_pool.maybe_get_custom_mem_pool()

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -66,6 +66,8 @@ DEFAULT_MODEL_NAME_FOR_TEST_MLA_NEXTN = "lmsys/sglang-ci-dsv3-test-NextN"
 
 # Hybrid Mamba models
 DEFAULT_HYBRID_MAMBA_MODEL_NAME_FOR_TEST = "Qwen/Qwen3-Next-80B-A3B-Instruct"
+DEFAULT_SMALL_HYBRID_MAMBA_MODEL_NAME_FOR_TEST = "Qwen/Qwen3.5-0.8B"
+
 # VL test models
 DEFAULT_MODEL_NAME_FOR_TEST_VL_PP = "Qwen/Qwen3-VL-2B-Thinking"
 DEFAULT_MODEL_NAME_FOR_TEST_GLM_41V_PP = "zai-org/GLM-4.1V-9B-Thinking"

--- a/test/registered/distributed/test_disaggregation_different_tp.py
+++ b/test/registered/distributed/test_disaggregation_different_tp.py
@@ -11,6 +11,7 @@ from sglang.test.server_fixtures.disaggregation_fixture import (
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
     DEFAULT_MODEL_NAME_FOR_TEST_MLA,
+    DEFAULT_SMALL_HYBRID_MAMBA_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     popen_launch_pd_server,
     try_cached_model,
@@ -502,6 +503,86 @@ class TestDisaggregationStagingDecodeLargerTP(PDDisaggregationServerBase):
         metrics = run_eval(args)
         print(f"[Staging DecodeLargerTP] Evaluation metrics: {metrics}")
         self.assertGreater(metrics["score"], 0.60)
+
+
+class TestDisaggregationMambaHeteroTP(PDDisaggregationServerBase):
+    """Hybrid Mamba-attention model with prefill TP=1 -> decode TP=4.
+
+    This is the configuration originally surfaced by issue #23746: when
+    decode TP exceeds num_kv_heads (=2 for Qwen3.5), the GQA head-mapping
+    bug triggers, and the Mamba per-group conv slicing bug also triggers
+    because the state is expanded across more shards than the source.
+    Without both fixes, accuracy collapses from ~0.3+ to ~0.01.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        envs.SGLANG_ENABLE_JIT_DEEPGEMM.set(False)
+
+        cls.model = try_cached_model(DEFAULT_SMALL_HYBRID_MAMBA_MODEL_NAME_FOR_TEST)
+
+        cls.start_prefill()
+        cls.start_decode()
+
+        cls.wait_server_ready(cls.prefill_url + "/health", process=cls.process_prefill)
+        cls.wait_server_ready(cls.decode_url + "/health", process=cls.process_decode)
+
+        cls.launch_lb()
+
+    @classmethod
+    def start_prefill(cls):
+        prefill_args = [
+            "--trust-remote-code",
+            "--disaggregation-mode",
+            "prefill",
+            "--disaggregation-bootstrap-port",
+            cls.bootstrap_port,
+            "--tp",
+            "1",
+        ]
+        prefill_args += cls.transfer_backend + cls.rdma_devices
+        cls.process_prefill = popen_launch_pd_server(
+            cls.model,
+            cls.prefill_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=prefill_args,
+        )
+
+    @classmethod
+    def start_decode(cls):
+        decode_args = [
+            "--trust-remote-code",
+            "--disaggregation-mode",
+            "decode",
+            "--disaggregation-bootstrap-port",
+            cls.bootstrap_port,
+            "--tp",
+            "4",
+            "--base-gpu-id",
+            "4",
+        ]
+        decode_args += cls.transfer_backend + cls.rdma_devices
+        cls.process_decode = popen_launch_pd_server(
+            cls.model,
+            cls.decode_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=decode_args,
+        )
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="gsm8k",
+            api="completion",
+            max_tokens=512,
+            num_examples=200,
+            num_threads=128,
+        )
+        metrics = run_eval(args)
+        print(f"[Mamba DecodeLargerTP] Evaluation metrics: {metrics}")
+        self.assertGreater(metrics["score"], 0.30)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
2025.7.16 update: 
This issue has been fixed and merged in https://github.com/sgl-project/sglang/pull/30997 , Thanks to @YAMY1234 and the reviewers for carrying it forward and getting it merged.



## Motivation

Fixes #23746

Two independent bugs in heterogeneous TP PD disaggregation (prefill TP < decode TP) cause accuracy degradation. Both bugs corrupt KV cache or Mamba state during heterogeneous TP transfer when decode TP exceeds the number of KV heads.

**Affected models**: Any hybrid Mamba-attention model where `num_kv_heads < decode_tp_size`, such as all Qwen3.5 models (which have `num_key_value_heads=2`) running with TP>=4 decode.

## Bug 1: GQA Head Mapping

**Problem**: When `dst_attn_tp_size > total_kv_heads`, multiple decode ranks should share the same KV head (GQA replication). `dst_heads_per_rank` is clamped to 1. The old modulo formula then cycles decode ranks across source offsets (e.g. `0,1,0,1`) instead of grouping replicated decode ranks that should share the same KV head (e.g. `0,0,1,1`).

**Fix**: Compute a `dst_replication` factor (`dst_attn_tp_size // total_kv_heads`) and map each decode rank to its correct KV head: `actual_kv_head = dst_tp_rank_in_group // dst_replication`. Applied in `mooncake/conn.py`, `nixl/conn.py`, and `staging_buffer.py`.

## Bug 2: Mamba Conv State Slicing

**Problem**: The conv_state dimension is composed of multiple independently TP-sharded groups. For example, GatedDeltaNet (used in Qwen3.5) has groups `[K, K, V]` where K=key_dim and V=value_dim, each sharded separately by `mamba_v2_sharded_weight_loader`. The previous `_send_mamba_state_slice` did a simple contiguous slice across the entire dimension, which corrupts data at group boundaries when source and destination TP sizes differ.

**Fix**: Add `conv_shard_groups` metadata to `Mamba2StateShape` (defaulting to `[conv_dimension]` for standard Mamba2, with explicit `[key_dim, key_dim, value_dim]` override for GatedDeltaNet/Qwen3Next). Use per-group slicing in `_send_mamba_state_slice` for both mooncake and nixl backends.

## Modifications

- `configs/mamba_utils.py`: Add `conv_shard_groups` field to `Mamba2StateShape`
- `configs/qwen3_next.py`: Override `conv_shard_groups` for GatedDeltaNet `[K, K, V]`
- `disaggregation/base/conn.py`: Propagate conv metadata in `kv_args`
- `disaggregation/common/staging_buffer.py`: GQA `dst_replication` fix in `compute_head_slice_params`
- `disaggregation/mooncake/conn.py`: GQA head mapping + per-group conv slicing
- `disaggregation/nixl/conn.py`: Same fixes ported to nixl backend
- `disaggregation/prefill.py`: Pass conv shard metadata from model to transfer args
- `mem_cache/memory_pool.py`: Expose `conv_shard_groups` from `MambaStateBuffer`

## Test Results

### Qwen3.5-0.8B (GSM8K)

| Config | Accuracy | Invalid Rate |
|--------|----------|--------------|
| Standalone TP1 baseline | 0.343 | 0.010 |
| **TP1->TP4 mooncake no-fix** | **0.012** | **0.371** |
| TP1->TP4 mooncake GQA-only fix | 0.152 | 0.011 |
| TP1->TP4 mooncake Mamba-only fix | 0.024 | 0.035 |
| **TP1->TP4 mooncake both fixes** | **0.336** | **0.005** |
| TP1->TP4 nixl no-fix | 0.011 | 0.379 |
| **TP1->TP4 nixl both fixes** | **0.334** | **0.005** |

### Qwen3.5-35B-A3B-FP8 (GSM8K)

| Config | Accuracy | Invalid Rate |
|--------|----------|--------------|
| Standalone TP1 baseline (10-run avg) | 0.780 | 0.000 |
| **TP1->TP4 mooncake no-fix** | **0.669** | **0.052** |
| **TP1->TP4 mooncake with fix (10-run avg)** | **0.778** | **0.001** |

## How to Reproduce

```bash
# Prefill server (TP1)
python -m sglang.launch_server \
  --model-path Qwen/Qwen3.5-0.8B \
  --tp 1 --port 9999 --host 0.0.0.0 \
  --disaggregation-mode prefill \
  --disaggregation-transfer-backend mooncake \
  --disaggregation-bootstrap-port 8998 \
  --disaggregation-ib-device <your_ib_devices> \
  --disable-radix-cache --page-size 1 \
  --attention-backend flashinfer

# Decode server (TP4, on a different node)
python -m sglang.launch_server \
  --model-path Qwen/Qwen3.5-0.8B \
  --tp 4 --port 9999 --host 0.0.0.0 \
  --disaggregation-mode decode \
  --disaggregation-transfer-backend mooncake \
  --disaggregation-bootstrap-port 8998 \
  --disaggregation-ib-device <your_ib_devices> \
  --disable-radix-cache --page-size 1 \
  --attention-backend flashinfer

# Router
python -m sglang_router.launch_router \
  --port 8081 --pd-disaggregation \
  --prefill http://<prefill_ip>:9999 8998 \
  --decode http://<decode_ip>:9999

# Evaluate (expect ~0.34 accuracy with fix, ~0.01 without)
python benchmark/gsm8k/bench_sglang.py \
  --host <prefill_ip> --port 8081 \
  --num-questions 1319 --parallel 16
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).



