### PR TITLE
[CI] release-whl-kernel: clean root-owned build artifacts before checkout

### DIFF
--- a/.github/workflows/release-whl-kernel.yml
+++ b/.github/workflows/release-whl-kernel.yml
@@ -50,6 +50,15 @@ jobs:
             runner: arm-kernel-build-node
     runs-on: ${{ matrix.runner }}
     steps:
+      # Self-hosted build nodes retain the workspace across jobs. Prior builds
+      # leave root-owned artifacts under sgl-kernel/build/ that actions/checkout
+      # cannot remove, causing EACCES on rmdir. Wipe them via a throwaway root
+      # container before checkout recreates the workspace.
+      - name: Clean workspace (remove root-owned files from prior runs)
+        run: |
+          docker run --rm -v "${{ github.workspace }}:/workspace" alpine:3 \
+            sh -c 'rm -rf /workspace/..?* /workspace/.[!.]* /workspace/*' || true
+
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
@@ -149,6 +158,15 @@ jobs:
             runner: arm-kernel-build-node
     runs-on: ${{ matrix.runner }}
     steps:
+      # Self-hosted build nodes retain the workspace across jobs. Prior builds
+      # leave root-owned artifacts under sgl-kernel/build/ that actions/checkout
+      # cannot remove, causing EACCES on rmdir. Wipe them via a throwaway root
+      # container before checkout recreates the workspace.
+      - name: Clean workspace (remove root-owned files from prior runs)
+        run: |
+          docker run --rm -v "${{ github.workspace }}:/workspace" alpine:3 \
+            sh -c 'rm -rf /workspace/..?* /workspace/.[!.]* /workspace/*' || true
+
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
@@ -235,6 +253,15 @@ jobs:
         python-version: ["3.10"]
         rocm-version: ["700", "720"]
     steps:
+      # Self-hosted build nodes retain the workspace across jobs. Prior builds
+      # leave root-owned artifacts under sgl-kernel/build/ that actions/checkout
+      # cannot remove, causing EACCES on rmdir. Wipe them via a throwaway root
+      # container before checkout recreates the workspace.
+      - name: Clean workspace (remove root-owned files from prior runs)
+        run: |
+          docker run --rm -v "${{ github.workspace }}:/workspace" alpine:3 \
+            sh -c 'rm -rf /workspace/..?* /workspace/.[!.]* /workspace/*' || true
+
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
@@ -370,6 +397,15 @@ jobs:
         python-version: ["3.10"]
         musa-version: ["43"]
     steps:
+      # Self-hosted build nodes retain the workspace across jobs. Prior builds
+      # leave root-owned artifacts under sgl-kernel/build/ that actions/checkout
+      # cannot remove, causing EACCES on rmdir. Wipe them via a throwaway root
+      # container before checkout recreates the workspace.
+      - name: Clean workspace (remove root-owned files from prior runs)
+        run: |
+          docker run --rm -v "${{ github.workspace }}:/workspace" alpine:3 \
+            sh -c 'rm -rf /workspace/..?* /workspace/.[!.]* /workspace/*' || true
+
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"


### PR DESCRIPTION
## Summary

- The four sgl-kernel build jobs in `release-whl-kernel.yml` (`build-cu129-matrix`, `build-cu130-matrix`, `build-rocm-matrix`, `build-musa43`) run on self-hosted nodes that retain the workspace across jobs. Their in-container compile runs as root and leaves root-owned files under `sgl-kernel/build/`, which causes the next run's `actions/checkout@v4` to fail with `EACCES: permission denied, rmdir 'sgl-kernel/build/.cmake'`.
- Add a pre-checkout cleanup step that wipes the workspace via a throwaway `alpine:3` root container — same pattern already in use in `nightly-72-gpu-gb200.yml:132-140` for the same reason.
- `pr-test.yml`'s kernel-build jobs already have a working `sudo rm -rf $GITHUB_WORKSPACE/*` cleanup, so they are intentionally left unchanged. `release-whl-kernel.yml` was the only kernel-building workflow with no cleanup at all.

## Test plan

- [ ] Trigger `release-whl-kernel.yml` (workflow_dispatch) on a PR build and confirm the new "Clean workspace" step runs and the subsequent `actions/checkout@v4` succeeds with no `EACCES` errors.
- [ ] Confirm the four build jobs still produce wheel artifacts (`wheel-python3.10-cuda12.9*`, `wheel-python3.10-cuda13.0*`, `wheel-python3.10-rocm{700,720}`, `wheel-python3.10-musa43`) as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)