### PR TITLE
[CI] release-whl-kernel: strip +cu129 local version before PyPI upload

### DIFF
--- a/.github/workflows/release-whl-kernel.yml
+++ b/.github/workflows/release-whl-kernel.yml
@@ -78,11 +78,42 @@ jobs:
           BUILD_JOBS: 64
           NVCC_THREADS: 8
 
+      # rename_wheels.sh tags the cu129 wheel's METADATA Version with +cu129
+      # (needed elsewhere — e.g. local install discrimination — see PR #23587),
+      # but PyPI rejects PEP 440 local version labels with HTTP 400. Repack a
+      # PyPI-clean copy with the +cu129 segment stripped into dist-pypi/, and
+      # upload that copy. dist/ is left untouched so the +cu129 wheel still
+      # flows through the upload-artifact -> sgl-project/whl index path below.
+      - name: Strip +cu129 local version for PyPI upload
+        working-directory: sgl-kernel
+        run: |
+          set -eux
+          pip install wheel
+          mkdir -p dist-pypi
+          for w in dist/*.whl; do
+            tmp=$(mktemp -d)
+            python3 -m wheel unpack "$w" --dest "$tmp"
+            unpacked=$(find "$tmp" -mindepth 1 -maxdepth 1 -type d | head -1)
+            info=$(find "$unpacked" -maxdepth 1 -type d -name "*.dist-info" | head -1)
+            meta="$info/METADATA"
+            orig=$(grep '^Version:' "$meta" | head -1 | sed 's/^Version:[[:space:]]*//')
+            new=$(echo "$orig" | sed 's/+cu[0-9]\+$//')
+            if [ "$orig" != "$new" ]; then
+              sed -i "s/^Version:.*/Version: ${new}/" "$meta"
+              old_base=$(basename "$info")
+              new_base="${old_base/${orig}/${new}}"
+              mv "$info" "$(dirname "$info")/${new_base}"
+            fi
+            python3 -m wheel pack "$unpacked" --dest-dir dist-pypi
+            rm -rf "$tmp"
+          done
+          ls -lh dist-pypi/
+
       - name: Upload to PyPI
         working-directory: sgl-kernel
         run: |
           pip install twine
-          python3 -m twine upload --skip-existing dist/* -u __token__ -p ${{ secrets.PYPI_TOKEN_SGLANG_KERNEL }}
+          python3 -m twine upload --skip-existing dist-pypi/* -u __token__ -p ${{ secrets.PYPI_TOKEN_SGLANG_KERNEL }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- PR #23587 added a `+cu129` PEP 440 local version label to the cu129 wheel's `METADATA` Version (needed elsewhere — e.g. local install discrimination — see `sgl-kernel/rename_wheels.sh`). PyPI rejects all uploads with local version labels with HTTP 400, so the release pipeline started failing on `twine upload` (e.g. https://github.com/sgl-project/sglang/actions/runs/24943991382/job/73053271617).
- Repack a PyPI-clean copy with the `+cu129` segment stripped from the wheel filename, `METADATA Version`, and `.dist-info` dirname into `sgl-kernel/dist-pypi/`, and point `twine upload` at `dist-pypi/*` instead of `dist/*`.
- `dist/` is left untouched, so the `+cu129` wheel still flows through `Upload artifacts` → `release-cu129` → `update_kernel_whl_index.py --cuda 129`. The default-cuda index lookup at `scripts/update_kernel_whl_index.py:check_wheel_cuda_version` accepts both suffixed and unsuffixed filenames, so that path keeps working.
- Scoped to `build-cu129-matrix` only. `build-cu130-matrix` is intentionally untouched (no PyPI upload, per the existing comment "for now we do not release CUDA 13.0 wheels to pypi").

## Test plan

- [x] Verified end-to-end inside a `python:3.10-slim` container against a synthetic `sglang_kernel-0.4.1.post1+cu129-cp310-abi3-manylinux2014_aarch64.whl`. Output: clean filename `sglang_kernel-0.4.1.post1-...whl`, `METADATA Version: 0.4.1.post1`, preserved `WHEEL Tag: cp310-abi3-manylinux2014_aarch64`, regenerated `RECORD` referencing the renamed dist-info.
- [ ] Once merged, trigger `release-whl-kernel.yml` (workflow_dispatch with target=cu129) and confirm the PyPI upload succeeds.
- [ ] Confirm `release-cu129` job's whl index update still picks up the `+cu129`-tagged wheel from `dist/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)