### PR TITLE
[CI] release-pypi-nightly: install protoc before building wheel

### DIFF
--- a/.github/workflows/release-pypi-nightly.yml
+++ b/.github/workflows/release-pypi-nightly.yml
@@ -48,6 +48,11 @@ jobs:
         run: |
           pip install build wheel setuptools setuptools-scm
 
+      # Needed by setuptools-rust to build the bundled native gRPC extension
+      # (rust/sglang-grpc) when `python -m build` builds the sglang wheel.
+      - name: Install protoc
+        run: sudo bash scripts/ci/utils/install_protoc.sh
+
       - name: Build wheel
         id: build
         run: |


### PR DESCRIPTION
## Summary

The nightly PyPI wheel build has been failing (e.g. [run 24702019647](https://github.com/sgl-project/sglang/actions/runs/24702019647/job/72247077974#step:5:5319)) with:

```
Error: Custom { kind: NotFound, error: "Could not find `protoc`. ..." }
error: failed to run custom build command for `sglang-grpc v0.1.0`
```

`python -m build --wheel` invokes `setuptools-rust` (configured at `python/pyproject.toml:220-223`) to build the bundled `rust/sglang-grpc` extension, whose build script (`prost-build`) requires `protoc`. The `ubuntu-latest` runner has Rust preinstalled but not `protoc`.

This adds an `Install protoc` step before the build, using the existing `scripts/ci/utils/install_protoc.sh` helper — same pattern already used in `pr-test.yml`.

## Test plan

- [ ] Trigger the workflow on this PR branch via `workflow_dispatch` and confirm the wheel build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)