### PR TITLE
[MoE] Unify DeepEPMoE+MoriEPMoE through AITER MoeRunner pre/post-permute

### DIFF
--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -1054,6 +1054,10 @@ class MaybeTboDeepEPDispatcher(BaseDispatcher):
                 NixlEPDispatcher(**kwargs) for _ in range(num_inner_dispatchers)
             ]
 
+    @property
+    def expert_mask_gpu(self):
+        return self._inners[0].expert_mask_gpu
+
     def _execute(self, name, tbo_subbatch_index: Optional[int] = None, **kwargs):
         return getattr(self._inners[tbo_subbatch_index or 0], name)(**kwargs)
 

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -177,19 +177,11 @@ class DeepEPMoE(FusedMoE):
                 topk_output,
             )
 
-        num_tokens = hidden_states.shape[0]
         dispatch_output = self.dispatcher.dispatch(
             hidden_states=hidden_states, topk_output=topk_output
         )
         combine_input = self.run_moe_core(dispatch_output)
-        hidden_states = self.dispatcher.combine(combine_input=combine_input)
-
-        if get_moe_a2a_backend().is_mori():
-            # mori combine returns a buffer-sized tensor; slice back to the
-            # caller's token count.
-            hidden_states = hidden_states[:num_tokens]
-
-        return hidden_states
+        return self.dispatcher.combine(combine_input=combine_input)
 
     def dispatch(
         self,

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -19,14 +19,9 @@ from sglang.srt.layers.moe.fused_moe_triton.layer import (
     FusedMoE,
     moe_forward_piecewise_cuda_graph_impl,
 )
-from sglang.srt.layers.moe.rocm_moe_utils import upscale, upscale_mxfp4
 from sglang.srt.layers.moe.token_dispatcher.deepep import (
     DeepEPLLCombineInput,
     DeepEPNormalCombineInput,
-)
-from sglang.srt.layers.moe.token_dispatcher.moriep import (
-    MoriEPLLCombineInput,
-    MoriEPNormalCombineInput,
 )
 from sglang.srt.layers.moe.topk import TopKOutput, TopKOutputChecker
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
@@ -36,9 +31,8 @@ from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors import
 from sglang.srt.layers.quantization.compressed_tensors.schemes import (
     NPUCompressedTensorsW4A16Int4DynamicMoE,
 )
-from sglang.srt.layers.quantization.fp8 import Fp8Config, Fp8MoEMethod
+from sglang.srt.layers.quantization.fp8 import Fp8Config
 from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
-from sglang.srt.layers.quantization.quark.schemes import QuarkW4A4MXFp4MoE
 from sglang.srt.layers.quantization.w4afp8 import W4AFp8Config, W4AFp8MoEMethod
 from sglang.srt.utils import get_bool_env_var, get_int_env_var, is_hip, is_npu
 
@@ -54,18 +48,11 @@ _is_npu = is_npu()
 _is_fp8_fnuz = is_fp8_fnuz()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
-if _use_aiter:
-    from aiter import ActivationType, QuantType
-    from aiter.fused_moe import fused_moe
-elif _is_npu:
+if _is_npu:
     import torch_npu
 
 
 logger = logging.getLogger(__name__)
-
-
-if _is_npu:
-    import torch_npu
 
 
 class DeepEPMoE(FusedMoE):
@@ -105,11 +92,14 @@ class DeepEPMoE(FusedMoE):
             routed_scaling_factor=routed_scaling_factor,
             **kwargs,
         )
-        if _use_aiter or _is_npu:
+        if _is_npu:
             self.deprecate_flag = False
-        elif deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM and isinstance(
-            quant_config, Fp8Config
+        elif _use_aiter or (
+            deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
+            and isinstance(quant_config, Fp8Config)
         ):
+            # AITER routes through the unified MoeRunner (("deepep","aiter") /
+            # ("mori","aiter") fused funcs); DeepGemm uses self.quant_method.apply.
             self.deprecate_flag = True
         elif (
             deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
@@ -236,11 +226,7 @@ class DeepEPMoE(FusedMoE):
 
         from sglang.srt.layers.moe.token_dispatcher import DispatchOutputChecker
 
-        if _use_aiter:
-            assert DispatchOutputChecker.format_is_deepep(dispatch_output)
-            # in forward_aiter, we skip token permutation and unpermutation, which have been fused inside aiter kernel
-            output = self.forward_aiter(dispatch_output)
-        elif _is_npu:
+        if _is_npu:
             assert DispatchOutputChecker.format_is_deepep(dispatch_output)
             output = self.forward_npu(dispatch_output)
         elif DispatchOutputChecker.format_is_deepep_normal(dispatch_output):
@@ -292,72 +278,7 @@ class DeepEPMoE(FusedMoE):
             overlap_args=overlap_args,
         )
 
-    def forward_aiter(
-        self,
-        dispatch_output: Union[DeepEPNormalDispatchOutput, DeepEPLLDispatchOutput],
-    ):
-        hidden_states, topk_ids, topk_weights = (
-            dispatch_output.hidden_states,
-            dispatch_output.topk_ids,
-            dispatch_output.topk_weights,
-        )
 
-        if hidden_states.shape[0] == 0:
-            return hidden_states
-
-        # in original deepep, idx == -1 meaning invalid and will not be processed.
-        # aiter does not accept -1, we use a expert mask to make these idx invalid
-        # (idx == num_local_experts) meaning not used in aiter fused_moe
-        topk_ids_copy = topk_ids.to(torch.int32)
-        topk_ids_copy[topk_ids_copy == -1] = self.num_local_experts
-
-        return fused_moe(
-            hidden_states,
-            self.w13_weight,
-            self.w2_weight,
-            topk_weights,
-            topk_ids_copy,
-            w1_scale=self.w13_weight_scale_inv,
-            w2_scale=self.w2_weight_scale_inv,
-            quant_type=QuantType.per_128x128,
-            activation=(
-                ActivationType.Silu
-                if self.moe_runner_config.activation == "silu"
-                else ActivationType.Gelu
-            ),
-            expert_mask=self.expert_mask,
-        )
-
-    def forward_unquantized_deepep_ll(
-        self,
-        dispatch_output: DeepEPLLDispatchOutput,
-    ):
-        hidden_states, hidden_states_scale, _, _, masked_m, _ = dispatch_output
-        assert hidden_states_scale is None
-        assert self.moe_runner_config.activation == "silu"
-        assert self.moe_runner_config.is_gated
-        assert hidden_states.dim() == 3
-
-        num_experts, max_tokens, _ = hidden_states.shape
-        token_offsets = torch.arange(max_tokens, device=hidden_states.device)
-        valid_mask = (
-            token_offsets.unsqueeze(0) < masked_m[:num_experts].unsqueeze(1)
-        ).unsqueeze(-1)
-        hidden_states = hidden_states.masked_fill(~valid_mask, 0)
-
-        gate_up = torch.bmm(hidden_states, self.w13_weight.transpose(1, 2))
-        w13_bias = getattr(self, "w13_weight_bias", None)
-        if w13_bias is not None:
-            gate_up = gate_up + w13_bias.unsqueeze(1)
-
-        gate, up = gate_up.chunk(2, dim=-1)
-        hidden_states = F.silu(gate) * up
-
-        output = torch.bmm(hidden_states, self.w2_weight.transpose(1, 2))
-        w2_bias = getattr(self, "w2_weight_bias", None)
-        if w2_bias is not None:
-            output = output + w2_bias.unsqueeze(1)
-        return output.masked_fill(~valid_mask, 0)
 
     def forward_flashinfer_cutedsl(
         self,
@@ -704,146 +625,6 @@ class MoriEPMoE(DeepEPMoE):
         )
 
         return hidden_states[:num_token]
-
-    def run_moe_core(
-        self,
-        dispatch_output: DispatchOutput,
-    ):
-        scale = None
-        is_fp8_quant = isinstance(self.quant_method, Fp8MoEMethod)
-        is_quark_w4a4 = hasattr(self, "scheme") and isinstance(
-            self.scheme, QuarkW4A4MXFp4MoE
-        )
-
-        (
-            dispatch_a1,
-            dispatch_scale,
-            dispatch_ids,
-            dispatch_weights,
-            dispatch_recv_token_num,
-            origin_topk_ids,
-            origin_topk_weights,
-            output_dtype,
-        ) = (
-            dispatch_output.hidden_states,
-            dispatch_output.hidden_states_scale,
-            dispatch_output.topk_ids,
-            dispatch_output.topk_weights,
-            dispatch_output.num_recv_tokens_per_expert,
-            dispatch_output.origin_topk_ids,
-            dispatch_output.origin_topk_weights,
-            dispatch_output.out_dtype,
-        )
-
-        # Truncate dispatch tensors to reduce MoE computation on padding rows.
-        # dispatch_a1 has shape (M, hidden_size) where M is the full buffer size,
-        # but only the first dispatch_recv_token_num rows are valid.
-        # mori combine only reads [0, totalRecvTokenNum), so the truncated
-        # output can be passed directly without padding back.
-        if self.mori_moe_max_input_tokens > 0:
-            limit = self.mori_moe_max_input_tokens
-            dispatch_a1 = dispatch_a1[:limit]
-            if dispatch_scale is not None:
-                dispatch_scale = dispatch_scale[:limit]
-            dispatch_ids = dispatch_ids[:limit]
-            dispatch_weights = dispatch_weights[:limit]
-
-        w13_weight = self.w13_weight
-        w2_weight = self.w2_weight
-
-        w13_scale = None
-        w2_scale = None
-
-        quant_type = QuantType.No
-
-        if (
-            not is_fp8_quant
-            and dispatch_scale is not None
-            and dispatch_a1.dtype != torch.float4_e2m1fn_x2
-        ):
-            if is_quark_w4a4:
-                # W4A4 model with FP8 dispatch: must dequant FP8->BF16 first,
-                # because the FP4 per_1x32 quantization path needs BF16 input
-                dispatch_a1 = upscale(
-                    dispatch_a1, dispatch_scale, dispatch_recv_token_num, output_dtype
-                )
-                dispatch_scale = None
-            else:
-                # Non-W4A4 model with FP8 dispatch: pass FP8 hidden_states + scale
-                # directly to fused_moe, avoiding unnecessary dequant->requant round-trip
-                quant_type = QuantType.per_128x128
-
-        if dispatch_a1.dtype == torch.float4_e2m1fn_x2 and dispatch_scale is not None:
-            if is_fp8_quant:
-                # FP8 weights + FP4 dispatch is not supported by fused_moe kernels
-                # (no kernel for q_dtype_a=fp4x2, q_dtype_w=fp8).
-                # Must dequant FP4->BF16 first; fused_moe will re-quant to FP8 internally.
-                dispatch_a1 = upscale_mxfp4(
-                    dispatch_a1, dispatch_scale, dispatch_recv_token_num, output_dtype
-                )
-                dispatch_scale = None
-            elif quant_type == QuantType.No:
-                # Skip upscale_mxfp4: pass FP4 hidden_states + scale directly to fused_moe
-                # fused_moe with QuantType.per_1x32 can accept pre-quantized fp4x2 input
-                quant_type = QuantType.per_1x32
-
-        if is_quark_w4a4:
-            if hasattr(torch, "float4_e2m1fn_x2"):
-                w13_weight = self.w13_weight.view(torch.float4_e2m1fn_x2)
-                w2_weight = self.w2_weight.view(torch.float4_e2m1fn_x2)
-
-            w13_scale = self.w13_weight_scale
-            w2_scale = self.w2_weight_scale
-            quant_type = QuantType.per_1x32
-
-            if hasattr(self.w13_weight, "is_shuffled"):
-                w13_weight.is_shuffled = True
-                w2_weight.is_shuffled = True
-        elif is_fp8_quant:
-            if hasattr(self, "w13_weight_scale_inv"):
-                w13_scale = self.w13_weight_scale_inv
-            if hasattr(self, "w2_weight_scale_inv"):
-                w2_scale = self.w2_weight_scale_inv
-
-            # Only set per_128x128 if quant_type was not already set by
-            # a prior dispatch path (e.g. FP4 dispatch sets per_1x32)
-            if quant_type == QuantType.No:
-                quant_type = QuantType.per_128x128
-
-        # [KK TODO] should to call the apply of quant method to handle fused moe
-        hidden_states = fused_moe(
-            hidden_states=dispatch_a1,
-            w1=w13_weight,
-            w2=w2_weight,
-            w1_scale=w13_scale,
-            w2_scale=w2_scale,
-            a1_scale=dispatch_scale,
-            topk_weight=dispatch_weights,
-            topk_ids=dispatch_ids,
-            quant_type=quant_type,
-            activation=(
-                ActivationType.Silu
-                if self.moe_runner_config.activation == "silu"
-                else ActivationType.Gelu
-            ),
-            expert_mask=self.expert_mask,
-            num_local_tokens=dispatch_recv_token_num,
-            dtype=output_dtype,
-        )
-
-        from sglang.srt.layers.moe.token_dispatcher import DispatchOutputChecker
-
-        combine_input_wrapper = (
-            MoriEPNormalCombineInput
-            if DispatchOutputChecker.format_is_deepep_normal(dispatch_output)
-            else MoriEPLLCombineInput
-        )
-
-        return combine_input_wrapper(
-            hidden_states=hidden_states,
-            topk_ids=dispatch_output.origin_topk_ids,
-            topk_weights=dispatch_output.origin_topk_weights,
-        )
 
 
 def get_moe_impl_class(quant_config: Optional[QuantizationConfig]):

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -34,7 +34,7 @@ from sglang.srt.layers.quantization.compressed_tensors.schemes import (
 from sglang.srt.layers.quantization.fp8 import Fp8Config
 from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
 from sglang.srt.layers.quantization.w4afp8 import W4AFp8Config, W4AFp8MoEMethod
-from sglang.srt.utils import get_bool_env_var, get_int_env_var, is_hip, is_npu
+from sglang.srt.utils import get_bool_env_var, is_hip, is_npu
 
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher import (
@@ -145,35 +145,6 @@ class DeepEPMoE(FusedMoE):
             assert (
                 deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
             ), f"DeepEP {self.deepep_mode} mode requires deep_gemm"
-
-        if _use_aiter:
-            self._init_aiter_expert_mask()
-
-    def _init_aiter_expert_mask(self) -> None:
-        if get_moe_a2a_backend().is_mori():
-            # mori dispatch produces global topk_ids in [0, num_experts);
-            # mask out experts that are not local to this rank.
-            expert_mask = torch.zeros(
-                self.num_experts,
-                device=torch.cuda.current_device(),
-                dtype=torch.int32,
-            )
-            start = self.moe_ep_rank * self.num_local_experts
-            expert_mask[start : start + self.num_local_experts] = 1
-            self.mori_moe_max_input_tokens = get_int_env_var(
-                "SGLANG_MORI_MOE_MAX_INPUT_TOKENS", 0
-            )
-        else:
-            # DeepEP/Mooncake/Nixl mark invalid topk slots with -1; the AITER
-            # pre_permute reroutes them to the sink slot at index
-            # num_local_experts, which is masked off here.
-            expert_mask = torch.zeros(
-                self.num_local_experts + 1,
-                device=torch.cuda.current_device(),
-                dtype=torch.int,
-            )
-            expert_mask[:-1] = 1
-        self.dispatcher.expert_mask_gpu = expert_mask
 
     def forward(
         self,

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -94,8 +94,6 @@ class DeepEPMoE(FusedMoE):
         )
         if _use_aiter:
             self.deprecate_flag = True
-            if quant_config is None and hasattr(self.dispatcher, "set_quant_config"):
-                self.dispatcher.set_quant_config({"bf16_dispatch": True})
         elif _is_npu:
             self.deprecate_flag = False
         elif deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM and isinstance(

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -92,7 +92,9 @@ class DeepEPMoE(FusedMoE):
             routed_scaling_factor=routed_scaling_factor,
             **kwargs,
         )
-        if _use_aiter or _is_npu:
+        if _use_aiter:
+            self.deprecate_flag = True
+        elif _is_npu:
             self.deprecate_flag = False
         elif deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM and isinstance(
             quant_config, Fp8Config
@@ -198,9 +200,7 @@ class DeepEPMoE(FusedMoE):
         dispatch_output: DispatchOutput,
     ):
 
-        if self.deprecate_flag or _use_aiter:
-            # AITER routes through quant_method.apply -> self.runner.run, which
-            # picks the right ("<dispatch>", "aiter") pre/post permute pair.
+        if self.deprecate_flag:
             return super().run_moe_core(dispatch_output)
 
         from sglang.srt.layers.moe.token_dispatcher import DispatchOutputChecker

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -293,7 +293,36 @@ class DeepEPMoE(FusedMoE):
             overlap_args=overlap_args,
         )
 
+    def forward_unquantized_deepep_ll(
+        self,
+        dispatch_output: DeepEPLLDispatchOutput,
+    ):
+        hidden_states, hidden_states_scale, _, _, masked_m, _ = dispatch_output
+        assert hidden_states_scale is None
+        assert self.moe_runner_config.activation == "silu"
+        assert self.moe_runner_config.is_gated
+        assert hidden_states.dim() == 3
 
+        num_experts, max_tokens, _ = hidden_states.shape
+        token_offsets = torch.arange(max_tokens, device=hidden_states.device)
+        valid_mask = (
+            token_offsets.unsqueeze(0) < masked_m[:num_experts].unsqueeze(1)
+        ).unsqueeze(-1)
+        hidden_states = hidden_states.masked_fill(~valid_mask, 0)
+
+        gate_up = torch.bmm(hidden_states, self.w13_weight.transpose(1, 2))
+        w13_bias = getattr(self, "w13_weight_bias", None)
+        if w13_bias is not None:
+            gate_up = gate_up + w13_bias.unsqueeze(1)
+
+        gate, up = gate_up.chunk(2, dim=-1)
+        hidden_states = F.silu(gate) * up
+
+        output = torch.bmm(hidden_states, self.w2_weight.transpose(1, 2))
+        w2_bias = getattr(self, "w2_weight_bias", None)
+        if w2_bias is not None:
+            output = output + w2_bias.unsqueeze(1)
+        return output.masked_fill(~valid_mask, 0)
 
     def forward_flashinfer_cutedsl(
         self,

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -153,13 +153,13 @@ class DeepEPMoE(FusedMoE):
         if get_moe_a2a_backend().is_mori():
             # mori dispatch produces global topk_ids in [0, num_experts);
             # mask out experts that are not local to this rank.
-            self.expert_mask = torch.zeros(
+            expert_mask = torch.zeros(
                 self.num_experts,
                 device=torch.cuda.current_device(),
                 dtype=torch.int32,
             )
             start = self.moe_ep_rank * self.num_local_experts
-            self.expert_mask[start : start + self.num_local_experts] = 1
+            expert_mask[start : start + self.num_local_experts] = 1
             self.mori_moe_max_input_tokens = get_int_env_var(
                 "SGLANG_MORI_MOE_MAX_INPUT_TOKENS", 0
             )
@@ -167,12 +167,13 @@ class DeepEPMoE(FusedMoE):
             # DeepEP/Mooncake/Nixl mark invalid topk slots with -1; the AITER
             # pre_permute reroutes them to the sink slot at index
             # num_local_experts, which is masked off here.
-            self.expert_mask = torch.zeros(
+            expert_mask = torch.zeros(
                 self.num_local_experts + 1,
                 device=torch.cuda.current_device(),
                 dtype=torch.int,
             )
-            self.expert_mask[:-1] = 1
+            expert_mask[:-1] = 1
+        self.dispatcher.expert_mask_gpu = expert_mask
 
     def forward(
         self,

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -92,14 +92,11 @@ class DeepEPMoE(FusedMoE):
             routed_scaling_factor=routed_scaling_factor,
             **kwargs,
         )
-        if _is_npu:
+        if _use_aiter or _is_npu:
             self.deprecate_flag = False
-        elif _use_aiter or (
-            deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
-            and isinstance(quant_config, Fp8Config)
+        elif deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM and isinstance(
+            quant_config, Fp8Config
         ):
-            # AITER routes through the unified MoeRunner (("deepep","aiter") /
-            # ("mori","aiter") fused funcs); DeepGemm uses self.quant_method.apply.
             self.deprecate_flag = True
         elif (
             deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
@@ -148,18 +145,33 @@ class DeepEPMoE(FusedMoE):
             assert (
                 deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
             ), f"DeepEP {self.deepep_mode} mode requires deep_gemm"
+
         if _use_aiter:
-            # expert_mask is of size (self.num_local_experts + 1),
-            # the extra 1 is for invalid rank_id (in original deepep, the invalid rank_id is -1, but aiter does not allow -1, we use a mask to make those ids invalid)
-            # for instance, if we have 4 experts on this rank, we would have a expert_mask like:
-            #     self.expert_mask = [1, 1, 1, 1, 0]
-            # idx from 0-3 is valid and will be processed, while idx == 4 will be masked out
+            self._init_aiter_expert_mask()
+
+    def _init_aiter_expert_mask(self) -> None:
+        if get_moe_a2a_backend().is_mori():
+            # mori dispatch produces global topk_ids in [0, num_experts);
+            # mask out experts that are not local to this rank.
             self.expert_mask = torch.zeros(
-                (self.num_local_experts + 1),
+                self.num_experts,
+                device=torch.cuda.current_device(),
+                dtype=torch.int32,
+            )
+            start = self.moe_ep_rank * self.num_local_experts
+            self.expert_mask[start : start + self.num_local_experts] = 1
+            self.mori_moe_max_input_tokens = get_int_env_var(
+                "SGLANG_MORI_MOE_MAX_INPUT_TOKENS", 0
+            )
+        else:
+            # DeepEP/Mooncake/Nixl mark invalid topk slots with -1; the AITER
+            # pre_permute reroutes them to the sink slot at index
+            # num_local_experts, which is masked off here.
+            self.expert_mask = torch.zeros(
+                self.num_local_experts + 1,
                 device=torch.cuda.current_device(),
                 dtype=torch.int,
             )
-            # the last one is invalid rank_id
             self.expert_mask[:-1] = 1
 
     def forward(
@@ -193,14 +205,17 @@ class DeepEPMoE(FusedMoE):
                 topk_output,
             )
 
-        # TODO: can we call super().forward here?
+        num_tokens = hidden_states.shape[0]
         dispatch_output = self.dispatcher.dispatch(
             hidden_states=hidden_states, topk_output=topk_output
         )
         combine_input = self.run_moe_core(dispatch_output)
-        hidden_states = self.dispatcher.combine(
-            combine_input=combine_input,
-        )
+        hidden_states = self.dispatcher.combine(combine_input=combine_input)
+
+        if get_moe_a2a_backend().is_mori():
+            # mori combine returns a buffer-sized tensor; slice back to the
+            # caller's token count.
+            hidden_states = hidden_states[:num_tokens]
 
         return hidden_states
 
@@ -219,10 +234,10 @@ class DeepEPMoE(FusedMoE):
         dispatch_output: DispatchOutput,
     ):
 
-        if self.deprecate_flag:
-            return super().run_moe_core(
-                dispatch_output,
-            )
+        if self.deprecate_flag or _use_aiter:
+            # AITER routes through quant_method.apply -> self.runner.run, which
+            # picks the right ("<dispatch>", "aiter") pre/post permute pair.
+            return super().run_moe_core(dispatch_output)
 
         from sglang.srt.layers.moe.token_dispatcher import DispatchOutputChecker
 
@@ -565,74 +580,11 @@ class NpuFuseEPMoE(DeepEPMoE):
             )
 
 
-class MoriEPMoE(DeepEPMoE):
-    def __init__(
-        self,
-        num_experts: int,
-        top_k: int,
-        hidden_size: int,
-        intermediate_size: int,
-        layer_id: int,
-        num_fused_shared_experts: int = 0,
-        params_dtype: Optional[torch.dtype] = None,
-        quant_config: Optional[QuantizationConfig] = None,
-        prefix: str = "",
-        activation: str = "silu",
-        routed_scaling_factor: Optional[float] = None,
-        **kwargs,
-    ):
-        super().__init__(
-            num_experts=num_experts,
-            top_k=top_k,
-            hidden_size=hidden_size,
-            intermediate_size=intermediate_size,
-            layer_id=layer_id,
-            num_fused_shared_experts=num_fused_shared_experts,
-            params_dtype=params_dtype,
-            quant_config=quant_config,
-            prefix=prefix,
-            activation=activation,
-            routed_scaling_factor=routed_scaling_factor,
-            **kwargs,
-        )
-
-        assert _use_aiter, "Mori need to be used together with aiter as of now"
-        self.expert_mask = torch.zeros(
-            (self.num_experts),
-            device=torch.cuda.current_device(),
-            dtype=torch.int32,
-        )
-        expert_start_idx = self.moe_ep_rank * self.num_local_experts
-        expert_end_idx = expert_start_idx + self.num_local_experts
-        self.expert_mask[expert_start_idx:expert_end_idx] = 1
-
-        self.mori_moe_max_input_tokens = get_int_env_var(
-            "SGLANG_MORI_MOE_MAX_INPUT_TOKENS", 0
-        )
-
-    def forward(
-        self,
-        hidden_states: torch.Tensor,
-        topk_output: TopKOutput,
-    ):
-        num_token = hidden_states.shape[0]
-        dispatch_output = self.dispatcher.dispatch(
-            hidden_states=hidden_states, topk_output=topk_output
-        )
-        combine_input = self.run_moe_core(dispatch_output)
-        hidden_states = self.dispatcher.combine(
-            combine_input=combine_input,
-        )
-
-        return hidden_states[:num_token]
-
-
 def get_moe_impl_class(quant_config: Optional[QuantizationConfig]):
     # [TODO] kk, temporary solution
-    if get_moe_a2a_backend().is_mori():
-        return MoriEPMoE
     if (
-        get_moe_a2a_backend().is_deepep()
+        get_moe_a2a_backend().is_mori()
+        or get_moe_a2a_backend().is_deepep()
         or get_moe_a2a_backend().is_mooncake()
         or get_moe_a2a_backend().is_nixl()
     ):

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -94,6 +94,8 @@ class DeepEPMoE(FusedMoE):
         )
         if _use_aiter:
             self.deprecate_flag = True
+            if quant_config is None and hasattr(self.dispatcher, "set_quant_config"):
+                self.dispatcher.set_quant_config({"bf16_dispatch": True})
         elif _is_npu:
             self.deprecate_flag = False
         elif deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM and isinstance(

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -234,10 +234,10 @@ def _resolve_mori_quant_type(
 
 def _pre_permute_deepep_to_aiter(
     dispatch_output: Union[
-        "DeepEPNormalDispatchOutput",
-        "DeepEPLLDispatchOutput",
-        "MoriEPNormalDispatchOutput",
-        "MoriEPLLDispatchOutput",
+        DeepEPNormalDispatchOutput,
+        DeepEPLLDispatchOutput,
+        MoriEPNormalDispatchOutput,
+        MoriEPLLDispatchOutput,
     ],
     quant_info: AiterMoeQuantInfo,
     runner_config: MoeRunnerConfig,
@@ -357,7 +357,7 @@ def _post_permute_aiter_to_deepep(
     runner_config: MoeRunnerConfig,
     running_state: dict,
     is_normal: bool,
-) -> "CombineInput":
+) -> CombineInput:
     if running_state.get("aiter_combine_is_mori"):
         from sglang.srt.layers.moe.token_dispatcher.moriep import (
             MoriEPLLCombineInput,
@@ -386,7 +386,7 @@ def post_permute_aiter_to_deepep_normal(
     quant_info: AiterMoeQuantInfo,
     runner_config: MoeRunnerConfig,
     running_state: dict,
-) -> "CombineInput":
+) -> CombineInput:
     return _post_permute_aiter_to_deepep(
         runner_output, quant_info, runner_config, running_state, is_normal=True
     )
@@ -398,7 +398,7 @@ def post_permute_aiter_to_deepep_ll(
     quant_info: AiterMoeQuantInfo,
     runner_config: MoeRunnerConfig,
     running_state: dict,
-) -> "CombineInput":
+) -> CombineInput:
     return _post_permute_aiter_to_deepep(
         runner_output, quant_info, runner_config, running_state, is_normal=False
     )

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -2,22 +2,24 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import torch
 
 from sglang.srt.layers.moe.moe_runner.base import (
     MoeQuantInfo,
     MoeRunnerConfig,
-    register_fused_func,
+    MoeRunnerCore,
+    RunnerInput,
+    RunnerOutput,
+    register_post_permute,
+    register_pre_permute,
 )
+from sglang.srt.layers.moe.utils import MoeRunnerBackend
 from sglang.srt.utils import get_int_env_var
 
 if TYPE_CHECKING:
-    from sglang.srt.layers.moe.token_dispatcher.base import (
-        CombineInput,
-        DispatchOutput,
-    )
+    from sglang.srt.layers.moe.token_dispatcher.base import CombineInput
     from sglang.srt.layers.moe.token_dispatcher.deepep import (
         DeepEPLLDispatchOutput,
         DeepEPNormalDispatchOutput,
@@ -56,15 +58,36 @@ class AiterMoeQuantInfo(MoeQuantInfo):
     intermediate_pad: int = 0
 
 
+@dataclass
+class AiterRunnerInput(RunnerInput):
+    hidden_states: torch.Tensor
+    topk_ids: torch.Tensor  # int32
+    topk_weights: torch.Tensor  # float32
+    # Effective activation quant_type (may differ from quant_info.quant_type
+    # after the dispatch-aware decision in mori pre_permute).
+    quant_type: AiterQuantType
+    # Per-token activation scale produced by an EP dispatcher (mori). Falls
+    # back to quant_info.a13_scale when None.
+    a1_scale: Optional[torch.Tensor] = None
+    # Mori-only fused_moe kwargs.
+    num_local_tokens: Optional[torch.Tensor] = None
+    output_dtype: Optional[torch.dtype] = None
+
+    @property
+    def runner_backend(self) -> MoeRunnerBackend:
+        return MoeRunnerBackend.AITER
+
+
+@dataclass
+class AiterRunnerOutput(RunnerOutput):
+    hidden_states: torch.Tensor
+
+    @property
+    def runner_backend(self) -> MoeRunnerBackend:
+        return MoeRunnerBackend.AITER
+
+
 _AITER_ACTIVATIONS = {"silu": "Silu", "swiglu": "Swiglu"}
-
-
-def get_aiter_expert_mask(layer) -> Optional[torch.Tensor]:
-    # DeepEPMoE / MoriEPMoE set self.expert_mask in __init__; standard FusedMoE
-    # exposes it via the dispatcher.
-    if getattr(layer, "expert_mask", None) is not None:
-        return layer.expert_mask
-    return getattr(layer.dispatcher, "expert_mask_gpu", None)
 
 
 def _aiter_activation(activation: str):
@@ -79,18 +102,80 @@ def _aiter_quant_type(quant_type: AiterQuantType):
     return getattr(QuantType, quant_type.value)
 
 
-@register_fused_func("none", "aiter")
-def fused_experts_none_to_aiter(
+def get_aiter_expert_mask(layer) -> Optional[torch.Tensor]:
+    # DeepEPMoE sets self.expert_mask in __init__; standard FusedMoE exposes
+    # it via the dispatcher.
+    if getattr(layer, "expert_mask", None) is not None:
+        return layer.expert_mask
+    return getattr(layer.dispatcher, "expert_mask_gpu", None)
+
+
+class AiterRunnerCore(MoeRunnerCore):
+    def run(
+        self,
+        runner_input: AiterRunnerInput,
+        quant_info: AiterMoeQuantInfo,
+        running_state: dict,
+        hooks: Optional[Any] = None,
+    ) -> AiterRunnerOutput:
+        assert not self.config.no_combine, "no_combine=True is not supported by AITER"
+
+        if runner_input.hidden_states.shape[0] == 0:
+            return AiterRunnerOutput(hidden_states=runner_input.hidden_states)
+
+        from aiter.fused_moe import fused_moe
+
+        a1_scale = (
+            runner_input.a1_scale
+            if runner_input.a1_scale is not None
+            else quant_info.a13_scale
+        )
+
+        extra: dict = {}
+        if runner_input.num_local_tokens is not None:
+            extra["num_local_tokens"] = runner_input.num_local_tokens
+        if runner_input.output_dtype is not None:
+            extra["dtype"] = runner_input.output_dtype
+
+        output = fused_moe(
+            hidden_states=runner_input.hidden_states,
+            w1=quant_info.w13_weight,
+            w2=quant_info.w2_weight,
+            topk_weight=runner_input.topk_weights,
+            topk_ids=runner_input.topk_ids,
+            quant_type=_aiter_quant_type(runner_input.quant_type),
+            activation=_aiter_activation(self.config.activation),
+            w1_scale=quant_info.w13_scale,
+            w2_scale=quant_info.w2_scale,
+            a1_scale=a1_scale,
+            a2_scale=quant_info.a2_scale,
+            bias1=quant_info.b13,
+            bias2=quant_info.b2,
+            expert_mask=quant_info.expert_mask,
+            doweight_stage1=quant_info.doweight_stage1,
+            hidden_pad=quant_info.hidden_pad,
+            intermediate_pad=quant_info.intermediate_pad,
+            **extra,
+        )
+        return AiterRunnerOutput(hidden_states=output)
+
+    @property
+    def runner_backend(self) -> MoeRunnerBackend:
+        return MoeRunnerBackend.AITER
+
+
+# ---------------------------------------------------------------------------
+# Pre-permute: dispatch_output -> AiterRunnerInput
+# ---------------------------------------------------------------------------
+
+
+@register_pre_permute("standard", "aiter")
+def pre_permute_standard_to_aiter(
     dispatch_output: StandardDispatchOutput,
     quant_info: AiterMoeQuantInfo,
     runner_config: MoeRunnerConfig,
-) -> StandardCombineInput:
-    from aiter.fused_moe import fused_moe
-
-    from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
-
-    assert not runner_config.no_combine, "no_combine=True is not supported by AITER"
-
+    running_state: dict,
+) -> AiterRunnerInput:
     hidden_states = dispatch_output.hidden_states
     topk_weights, topk_ids, _ = dispatch_output.topk_output
     topk_weights = topk_weights.to(torch.float32)
@@ -103,208 +188,217 @@ def fused_experts_none_to_aiter(
         hidden_states = hidden_states * topk_weights.to(hidden_states.dtype)
         topk_weights = torch.ones_like(topk_weights)
 
-    output = fused_moe(
+    return AiterRunnerInput(
         hidden_states=hidden_states,
-        w1=quant_info.w13_weight,
-        w2=quant_info.w2_weight,
-        topk_weight=topk_weights,
         topk_ids=topk_ids.to(torch.int32),
-        quant_type=_aiter_quant_type(quant_info.quant_type),
-        activation=_aiter_activation(runner_config.activation),
-        w1_scale=quant_info.w13_scale,
-        w2_scale=quant_info.w2_scale,
-        a1_scale=quant_info.a13_scale,
-        a2_scale=quant_info.a2_scale,
-        bias1=quant_info.b13,
-        bias2=quant_info.b2,
-        expert_mask=quant_info.expert_mask,
-        doweight_stage1=quant_info.doweight_stage1,
-        hidden_pad=quant_info.hidden_pad,
-        intermediate_pad=quant_info.intermediate_pad,
-    )
-    return StandardCombineInput(hidden_states=output)
-
-
-def _run_aiter_for_deepep(
-    dispatch_output: "DeepEPNormalDispatchOutput | DeepEPLLDispatchOutput",
-    quant_info: AiterMoeQuantInfo,
-    runner_config: MoeRunnerConfig,
-) -> torch.Tensor:
-    from aiter.fused_moe import fused_moe
-
-    hidden_states = dispatch_output.hidden_states
-    topk_ids = dispatch_output.topk_ids
-    topk_weights = dispatch_output.topk_weights
-
-    if hidden_states.shape[0] == 0:
-        return hidden_states
-
-    # DeepEP marks invalid slots with idx == -1; AITER cannot accept negative ids,
-    # so we reroute them to the sink slot at index num_local_experts (masked off
-    # by quant_info.expert_mask, which has shape (num_local_experts + 1,)).
-    topk_ids = topk_ids.to(torch.int32)
-    topk_ids = torch.where(
-        topk_ids == -1,
-        torch.full_like(topk_ids, runner_config.num_local_experts),
-        topk_ids,
-    )
-
-    return fused_moe(
-        hidden_states=hidden_states,
-        w1=quant_info.w13_weight,
-        w2=quant_info.w2_weight,
-        topk_weight=topk_weights.to(torch.float32),
-        topk_ids=topk_ids,
-        quant_type=_aiter_quant_type(quant_info.quant_type),
-        activation=_aiter_activation(runner_config.activation),
-        w1_scale=quant_info.w13_scale,
-        w2_scale=quant_info.w2_scale,
-        a1_scale=quant_info.a13_scale,
-        a2_scale=quant_info.a2_scale,
-        bias1=quant_info.b13,
-        bias2=quant_info.b2,
-        expert_mask=quant_info.expert_mask,
-        doweight_stage1=quant_info.doweight_stage1,
-        hidden_pad=quant_info.hidden_pad,
-        intermediate_pad=quant_info.intermediate_pad,
+        topk_weights=topk_weights,
+        quant_type=quant_info.quant_type,
     )
 
 
-def _build_deepep_combine_input(
-    dispatch_output: "DispatchOutput",
-    output: torch.Tensor,
-) -> "CombineInput":
-    from sglang.srt.layers.moe.token_dispatcher import DispatchOutputChecker
-    from sglang.srt.layers.moe.token_dispatcher.deepep import (
-        DeepEPLLCombineInput,
-        DeepEPNormalCombineInput,
-    )
-
-    cls = (
-        DeepEPNormalCombineInput
-        if DispatchOutputChecker.format_is_deepep_normal(dispatch_output)
-        else DeepEPLLCombineInput
-    )
-    return cls(
-        hidden_states=output,
-        topk_ids=dispatch_output.topk_ids,
-        topk_weights=dispatch_output.topk_weights,
-    )
+def _is_mori_dispatch_output(dispatch_output: Any) -> bool:
+    # MoriEP{Normal,LL}DispatchOutput carry the post-mori-permute origin_topk_*
+    # tensors that the standard DeepEP outputs lack.
+    return hasattr(dispatch_output, "origin_topk_ids")
 
 
-@register_fused_func("deepep", "aiter")
-@register_fused_func("mooncake", "aiter")
-@register_fused_func("nixl", "aiter")
-def fused_experts_deepep_to_aiter(
-    dispatch_output: "DeepEPNormalDispatchOutput | DeepEPLLDispatchOutput",
-    quant_info: AiterMoeQuantInfo,
-    runner_config: MoeRunnerConfig,
-) -> "CombineInput":
-    output = _run_aiter_for_deepep(dispatch_output, quant_info, runner_config)
-    return _build_deepep_combine_input(dispatch_output, output)
-
-
-@register_fused_func("mori", "aiter")
-def fused_experts_mori_to_aiter(
-    dispatch_output: "MoriEPNormalDispatchOutput | MoriEPLLDispatchOutput",
-    quant_info: AiterMoeQuantInfo,
-    runner_config: MoeRunnerConfig,
-) -> "CombineInput":
-    from aiter.fused_moe import fused_moe
-
-    from sglang.srt.layers.moe.rocm_moe_utils import upscale, upscale_mxfp4
-    from sglang.srt.layers.moe.token_dispatcher import DispatchOutputChecker
-    from sglang.srt.layers.moe.token_dispatcher.moriep import (
-        MoriEPLLCombineInput,
-        MoriEPNormalCombineInput,
-    )
-
-    dispatch_a1 = dispatch_output.hidden_states
-    dispatch_scale = dispatch_output.hidden_states_scale
-    dispatch_ids = dispatch_output.topk_ids
-    dispatch_weights = dispatch_output.topk_weights
-    dispatch_recv_token_num = dispatch_output.num_recv_tokens_per_expert
-    output_dtype = dispatch_output.out_dtype
-
-    # Truncate dispatch tensors to reduce MoE computation on padding rows.
-    # mori combine only reads [0, totalRecvTokenNum), so the truncated output
-    # can be passed directly without padding back.
-    mori_max = get_int_env_var("SGLANG_MORI_MOE_MAX_INPUT_TOKENS", 0)
-    if mori_max > 0:
-        dispatch_a1 = dispatch_a1[:mori_max]
-        if dispatch_scale is not None:
-            dispatch_scale = dispatch_scale[:mori_max]
-        dispatch_ids = dispatch_ids[:mori_max]
-        dispatch_weights = dispatch_weights[:mori_max]
-
-    # Infer weight quant family from the quant method's choice.
-    weight_quant = quant_info.quant_type
+def _resolve_mori_quant_type(
+    dispatch_a1_dtype: torch.dtype,
+    dispatch_scale: Optional[torch.Tensor],
+    weight_quant: AiterQuantType,
+) -> AiterQuantType:
+    """Pick the activation quant_type for AITER when the dispatch path may have
+    pre-quantized hidden_states. Mirrors the original MoriEPMoE.run_moe_core
+    decision tree."""
     is_fp8_quant = weight_quant in (
         AiterQuantType.PER_128X128,
         AiterQuantType.PER_TOKEN,
     )
     is_w4a4 = weight_quant == AiterQuantType.PER_1X32
-
-    # Decide the effective activation quant_type based on dispatch dtype/scale,
-    # upscaling the dispatched tensor when there is a kernel-unsupported
-    # weight/activation dtype mismatch.
-    quant_type = AiterQuantType.NONE
-    if (
-        not is_fp8_quant
-        and dispatch_scale is not None
-        and dispatch_a1.dtype != torch.float4_e2m1fn_x2
-    ):
-        if is_w4a4:
-            # W4A4 weights with FP8 dispatch: dequant FP8->BF16 first; the FP4
-            # per_1x32 path needs BF16 input.
-            dispatch_a1 = upscale(
-                dispatch_a1, dispatch_scale, dispatch_recv_token_num, output_dtype
-            )
-            dispatch_scale = None
-        else:
-            # BF16 weights with FP8 dispatch: pass FP8 through, no requantize.
-            quant_type = AiterQuantType.PER_128X128
-
-    if dispatch_a1.dtype == torch.float4_e2m1fn_x2 and dispatch_scale is not None:
-        if is_fp8_quant:
-            # FP8 weights + FP4 dispatch: no kernel for fp4x2/fp8 pair, dequant
-            # FP4->BF16 first; fused_moe will re-quantize to FP8 internally.
-            dispatch_a1 = upscale_mxfp4(
-                dispatch_a1, dispatch_scale, dispatch_recv_token_num, output_dtype
-            )
-            dispatch_scale = None
-        elif quant_type == AiterQuantType.NONE:
-            # BF16 / W4A4 weights with FP4 dispatch: pass FP4 through.
-            quant_type = AiterQuantType.PER_1X32
+    is_fp4_dispatch = dispatch_a1_dtype == torch.float4_e2m1fn_x2
+    has_dispatch_scale = dispatch_scale is not None
 
     if is_w4a4:
-        quant_type = AiterQuantType.PER_1X32
-    elif is_fp8_quant and quant_type == AiterQuantType.NONE:
-        quant_type = weight_quant
+        # W4A4 weights always run as per_1x32; FP8 dispatch is upscaled to BF16
+        # before this point so dispatch_scale won't conflict.
+        return AiterQuantType.PER_1X32
+    if is_fp8_quant:
+        return weight_quant
+    # BF16 weights: lift to the dispatch-side quant type when scales are provided.
+    if has_dispatch_scale and is_fp4_dispatch:
+        return AiterQuantType.PER_1X32
+    if has_dispatch_scale and not is_fp4_dispatch:
+        return AiterQuantType.PER_128X128
+    return AiterQuantType.NONE
 
-    output = fused_moe(
-        hidden_states=dispatch_a1,
-        w1=quant_info.w13_weight,
-        w2=quant_info.w2_weight,
-        w1_scale=quant_info.w13_scale,
-        w2_scale=quant_info.w2_scale,
-        a1_scale=dispatch_scale,
-        topk_weight=dispatch_weights.to(torch.float32),
-        topk_ids=dispatch_ids.to(torch.int32),
-        quant_type=_aiter_quant_type(quant_type),
-        activation=_aiter_activation(runner_config.activation),
-        expert_mask=quant_info.expert_mask,
-        num_local_tokens=dispatch_recv_token_num,
-        dtype=output_dtype,
+
+def _pre_permute_deepep_to_aiter(
+    dispatch_output: Union[
+        "DeepEPNormalDispatchOutput",
+        "DeepEPLLDispatchOutput",
+        "MoriEPNormalDispatchOutput",
+        "MoriEPLLDispatchOutput",
+    ],
+    quant_info: AiterMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+    running_state: dict,
+) -> AiterRunnerInput:
+    is_mori = _is_mori_dispatch_output(dispatch_output)
+
+    hidden_states = dispatch_output.hidden_states
+    topk_ids = dispatch_output.topk_ids.to(torch.int32)
+    topk_weights = dispatch_output.topk_weights.to(torch.float32)
+    a1_scale: Optional[torch.Tensor] = None
+    num_local_tokens: Optional[torch.Tensor] = None
+    output_dtype: Optional[torch.dtype] = None
+    quant_type = quant_info.quant_type
+
+    if is_mori:
+        from sglang.srt.layers.moe.rocm_moe_utils import upscale, upscale_mxfp4
+
+        a1_scale = dispatch_output.hidden_states_scale
+        num_local_tokens = dispatch_output.num_recv_tokens_per_expert
+        output_dtype = dispatch_output.out_dtype
+
+        # Truncate dispatch tensors to the configured cap; mori combine only
+        # reads [0, totalRecvTokenNum), so the truncated result needs no
+        # padding back.
+        mori_max = get_int_env_var("SGLANG_MORI_MOE_MAX_INPUT_TOKENS", 0)
+        if mori_max > 0:
+            hidden_states = hidden_states[:mori_max]
+            if a1_scale is not None:
+                a1_scale = a1_scale[:mori_max]
+            topk_ids = topk_ids[:mori_max]
+            topk_weights = topk_weights[:mori_max]
+
+        # Upscale dispatched activations when there is no AITER kernel for the
+        # weight/activation dtype pair.
+        weight_quant = quant_info.quant_type
+        is_fp8_quant = weight_quant in (
+            AiterQuantType.PER_128X128,
+            AiterQuantType.PER_TOKEN,
+        )
+        is_w4a4 = weight_quant == AiterQuantType.PER_1X32
+        is_fp4_dispatch = hidden_states.dtype == torch.float4_e2m1fn_x2
+
+        if is_w4a4 and a1_scale is not None and not is_fp4_dispatch:
+            # W4A4 weights with FP8 dispatch: dequant FP8->BF16 first; the
+            # FP4 per_1x32 path needs BF16 input.
+            hidden_states = upscale(
+                hidden_states, a1_scale, num_local_tokens, output_dtype
+            )
+            a1_scale = None
+        elif is_fp8_quant and is_fp4_dispatch and a1_scale is not None:
+            # FP8 weights + FP4 dispatch: no kernel for the fp4x2/fp8 pair;
+            # dequant FP4->BF16 and let fused_moe re-quantize to FP8.
+            hidden_states = upscale_mxfp4(
+                hidden_states, a1_scale, num_local_tokens, output_dtype
+            )
+            a1_scale = None
+
+        quant_type = _resolve_mori_quant_type(
+            hidden_states.dtype, a1_scale, weight_quant
+        )
+
+        running_state["aiter_combine_topk_ids"] = dispatch_output.origin_topk_ids
+        running_state["aiter_combine_topk_weights"] = (
+            dispatch_output.origin_topk_weights
+        )
+    else:
+        # DeepEP marks invalid topk slots with idx == -1; AITER cannot accept
+        # negative ids, so reroute them to the sink slot at index
+        # num_local_experts (masked off by quant_info.expert_mask which has
+        # shape (num_local_experts + 1,)).
+        topk_ids = torch.where(
+            topk_ids == -1,
+            torch.full_like(topk_ids, runner_config.num_local_experts),
+            topk_ids,
+        )
+        running_state["aiter_combine_topk_ids"] = dispatch_output.topk_ids
+        running_state["aiter_combine_topk_weights"] = dispatch_output.topk_weights
+
+    running_state["aiter_combine_is_mori"] = is_mori
+
+    return AiterRunnerInput(
+        hidden_states=hidden_states,
+        topk_ids=topk_ids,
+        topk_weights=topk_weights,
+        quant_type=quant_type,
+        a1_scale=a1_scale,
+        num_local_tokens=num_local_tokens,
+        output_dtype=output_dtype,
     )
 
-    cls = (
-        MoriEPNormalCombineInput
-        if DispatchOutputChecker.format_is_deepep_normal(dispatch_output)
-        else MoriEPLLCombineInput
-    )
+
+register_pre_permute("deepep_normal", "aiter")(_pre_permute_deepep_to_aiter)
+register_pre_permute("deepep_ll", "aiter")(_pre_permute_deepep_to_aiter)
+
+
+# ---------------------------------------------------------------------------
+# Post-permute: AiterRunnerOutput -> CombineInput
+# ---------------------------------------------------------------------------
+
+
+@register_post_permute("aiter", "standard")
+def post_permute_aiter_to_standard(
+    runner_output: AiterRunnerOutput,
+    quant_info: AiterMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+    running_state: dict,
+) -> StandardCombineInput:
+    from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
+
+    return StandardCombineInput(hidden_states=runner_output.hidden_states)
+
+
+def _post_permute_aiter_to_deepep(
+    runner_output: AiterRunnerOutput,
+    quant_info: AiterMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+    running_state: dict,
+    is_normal: bool,
+) -> "CombineInput":
+    if running_state.get("aiter_combine_is_mori"):
+        from sglang.srt.layers.moe.token_dispatcher.moriep import (
+            MoriEPLLCombineInput,
+            MoriEPNormalCombineInput,
+        )
+
+        cls = MoriEPNormalCombineInput if is_normal else MoriEPLLCombineInput
+    else:
+        from sglang.srt.layers.moe.token_dispatcher.deepep import (
+            DeepEPLLCombineInput,
+            DeepEPNormalCombineInput,
+        )
+
+        cls = DeepEPNormalCombineInput if is_normal else DeepEPLLCombineInput
+
     return cls(
-        hidden_states=output,
-        topk_ids=dispatch_output.origin_topk_ids,
-        topk_weights=dispatch_output.origin_topk_weights,
+        hidden_states=runner_output.hidden_states,
+        topk_ids=running_state["aiter_combine_topk_ids"],
+        topk_weights=running_state["aiter_combine_topk_weights"],
+    )
+
+
+@register_post_permute("aiter", "deepep_normal")
+def post_permute_aiter_to_deepep_normal(
+    runner_output: AiterRunnerOutput,
+    quant_info: AiterMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+    running_state: dict,
+) -> "CombineInput":
+    return _post_permute_aiter_to_deepep(
+        runner_output, quant_info, runner_config, running_state, is_normal=True
+    )
+
+
+@register_post_permute("aiter", "deepep_ll")
+def post_permute_aiter_to_deepep_ll(
+    runner_output: AiterRunnerOutput,
+    quant_info: AiterMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+    running_state: dict,
+) -> "CombineInput":
+    return _post_permute_aiter_to_deepep(
+        runner_output, quant_info, runner_config, running_state, is_normal=False
     )

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -11,8 +11,21 @@ from sglang.srt.layers.moe.moe_runner.base import (
     MoeRunnerConfig,
     register_fused_func,
 )
+from sglang.srt.utils import get_int_env_var
 
 if TYPE_CHECKING:
+    from sglang.srt.layers.moe.token_dispatcher.base import (
+        CombineInput,
+        DispatchOutput,
+    )
+    from sglang.srt.layers.moe.token_dispatcher.deepep import (
+        DeepEPLLDispatchOutput,
+        DeepEPNormalDispatchOutput,
+    )
+    from sglang.srt.layers.moe.token_dispatcher.moriep import (
+        MoriEPLLDispatchOutput,
+        MoriEPNormalDispatchOutput,
+    )
     from sglang.srt.layers.moe.token_dispatcher.standard import (
         StandardCombineInput,
         StandardDispatchOutput,
@@ -46,13 +59,32 @@ class AiterMoeQuantInfo(MoeQuantInfo):
 _AITER_ACTIVATIONS = {"silu": "Silu", "swiglu": "Swiglu"}
 
 
+def get_aiter_expert_mask(layer) -> Optional[torch.Tensor]:
+    # DeepEPMoE / MoriEPMoE set self.expert_mask in __init__; standard FusedMoE
+    # exposes it via the dispatcher.
+    if getattr(layer, "expert_mask", None) is not None:
+        return layer.expert_mask
+    return getattr(layer.dispatcher, "expert_mask_gpu", None)
+
+
+def _aiter_activation(activation: str):
+    from aiter import ActivationType
+
+    return getattr(ActivationType, _AITER_ACTIVATIONS.get(activation, "Gelu"))
+
+
+def _aiter_quant_type(quant_type: AiterQuantType):
+    from aiter import QuantType
+
+    return getattr(QuantType, quant_type.value)
+
+
 @register_fused_func("none", "aiter")
 def fused_experts_none_to_aiter(
     dispatch_output: StandardDispatchOutput,
     quant_info: AiterMoeQuantInfo,
     runner_config: MoeRunnerConfig,
 ) -> StandardCombineInput:
-    from aiter import ActivationType, QuantType
     from aiter.fused_moe import fused_moe
 
     from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
@@ -71,15 +103,14 @@ def fused_experts_none_to_aiter(
         hidden_states = hidden_states * topk_weights.to(hidden_states.dtype)
         topk_weights = torch.ones_like(topk_weights)
 
-    activation = runner_config.activation
     output = fused_moe(
         hidden_states=hidden_states,
         w1=quant_info.w13_weight,
         w2=quant_info.w2_weight,
         topk_weight=topk_weights,
         topk_ids=topk_ids.to(torch.int32),
-        quant_type=getattr(QuantType, quant_info.quant_type.value),
-        activation=getattr(ActivationType, _AITER_ACTIVATIONS.get(activation, "Gelu")),
+        quant_type=_aiter_quant_type(quant_info.quant_type),
+        activation=_aiter_activation(runner_config.activation),
         w1_scale=quant_info.w13_scale,
         w2_scale=quant_info.w2_scale,
         a1_scale=quant_info.a13_scale,
@@ -92,3 +123,188 @@ def fused_experts_none_to_aiter(
         intermediate_pad=quant_info.intermediate_pad,
     )
     return StandardCombineInput(hidden_states=output)
+
+
+def _run_aiter_for_deepep(
+    dispatch_output: "DeepEPNormalDispatchOutput | DeepEPLLDispatchOutput",
+    quant_info: AiterMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+) -> torch.Tensor:
+    from aiter.fused_moe import fused_moe
+
+    hidden_states = dispatch_output.hidden_states
+    topk_ids = dispatch_output.topk_ids
+    topk_weights = dispatch_output.topk_weights
+
+    if hidden_states.shape[0] == 0:
+        return hidden_states
+
+    # DeepEP marks invalid slots with idx == -1; AITER cannot accept negative ids,
+    # so we reroute them to the sink slot at index num_local_experts (masked off
+    # by quant_info.expert_mask, which has shape (num_local_experts + 1,)).
+    topk_ids = topk_ids.to(torch.int32)
+    topk_ids = torch.where(
+        topk_ids == -1,
+        torch.full_like(topk_ids, runner_config.num_local_experts),
+        topk_ids,
+    )
+
+    return fused_moe(
+        hidden_states=hidden_states,
+        w1=quant_info.w13_weight,
+        w2=quant_info.w2_weight,
+        topk_weight=topk_weights.to(torch.float32),
+        topk_ids=topk_ids,
+        quant_type=_aiter_quant_type(quant_info.quant_type),
+        activation=_aiter_activation(runner_config.activation),
+        w1_scale=quant_info.w13_scale,
+        w2_scale=quant_info.w2_scale,
+        a1_scale=quant_info.a13_scale,
+        a2_scale=quant_info.a2_scale,
+        bias1=quant_info.b13,
+        bias2=quant_info.b2,
+        expert_mask=quant_info.expert_mask,
+        doweight_stage1=quant_info.doweight_stage1,
+        hidden_pad=quant_info.hidden_pad,
+        intermediate_pad=quant_info.intermediate_pad,
+    )
+
+
+def _build_deepep_combine_input(
+    dispatch_output: "DispatchOutput",
+    output: torch.Tensor,
+) -> "CombineInput":
+    from sglang.srt.layers.moe.token_dispatcher import DispatchOutputChecker
+    from sglang.srt.layers.moe.token_dispatcher.deepep import (
+        DeepEPLLCombineInput,
+        DeepEPNormalCombineInput,
+    )
+
+    cls = (
+        DeepEPNormalCombineInput
+        if DispatchOutputChecker.format_is_deepep_normal(dispatch_output)
+        else DeepEPLLCombineInput
+    )
+    return cls(
+        hidden_states=output,
+        topk_ids=dispatch_output.topk_ids,
+        topk_weights=dispatch_output.topk_weights,
+    )
+
+
+@register_fused_func("deepep", "aiter")
+@register_fused_func("mooncake", "aiter")
+@register_fused_func("nixl", "aiter")
+def fused_experts_deepep_to_aiter(
+    dispatch_output: "DeepEPNormalDispatchOutput | DeepEPLLDispatchOutput",
+    quant_info: AiterMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+) -> "CombineInput":
+    output = _run_aiter_for_deepep(dispatch_output, quant_info, runner_config)
+    return _build_deepep_combine_input(dispatch_output, output)
+
+
+@register_fused_func("mori", "aiter")
+def fused_experts_mori_to_aiter(
+    dispatch_output: "MoriEPNormalDispatchOutput | MoriEPLLDispatchOutput",
+    quant_info: AiterMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+) -> "CombineInput":
+    from aiter.fused_moe import fused_moe
+
+    from sglang.srt.layers.moe.rocm_moe_utils import upscale, upscale_mxfp4
+    from sglang.srt.layers.moe.token_dispatcher import DispatchOutputChecker
+    from sglang.srt.layers.moe.token_dispatcher.moriep import (
+        MoriEPLLCombineInput,
+        MoriEPNormalCombineInput,
+    )
+
+    dispatch_a1 = dispatch_output.hidden_states
+    dispatch_scale = dispatch_output.hidden_states_scale
+    dispatch_ids = dispatch_output.topk_ids
+    dispatch_weights = dispatch_output.topk_weights
+    dispatch_recv_token_num = dispatch_output.num_recv_tokens_per_expert
+    output_dtype = dispatch_output.out_dtype
+
+    # Truncate dispatch tensors to reduce MoE computation on padding rows.
+    # mori combine only reads [0, totalRecvTokenNum), so the truncated output
+    # can be passed directly without padding back.
+    mori_max = get_int_env_var("SGLANG_MORI_MOE_MAX_INPUT_TOKENS", 0)
+    if mori_max > 0:
+        dispatch_a1 = dispatch_a1[:mori_max]
+        if dispatch_scale is not None:
+            dispatch_scale = dispatch_scale[:mori_max]
+        dispatch_ids = dispatch_ids[:mori_max]
+        dispatch_weights = dispatch_weights[:mori_max]
+
+    # Infer weight quant family from the quant method's choice.
+    weight_quant = quant_info.quant_type
+    is_fp8_quant = weight_quant in (
+        AiterQuantType.PER_128X128,
+        AiterQuantType.PER_TOKEN,
+    )
+    is_w4a4 = weight_quant == AiterQuantType.PER_1X32
+
+    # Decide the effective activation quant_type based on dispatch dtype/scale,
+    # upscaling the dispatched tensor when there is a kernel-unsupported
+    # weight/activation dtype mismatch.
+    quant_type = AiterQuantType.NONE
+    if (
+        not is_fp8_quant
+        and dispatch_scale is not None
+        and dispatch_a1.dtype != torch.float4_e2m1fn_x2
+    ):
+        if is_w4a4:
+            # W4A4 weights with FP8 dispatch: dequant FP8->BF16 first; the FP4
+            # per_1x32 path needs BF16 input.
+            dispatch_a1 = upscale(
+                dispatch_a1, dispatch_scale, dispatch_recv_token_num, output_dtype
+            )
+            dispatch_scale = None
+        else:
+            # BF16 weights with FP8 dispatch: pass FP8 through, no requantize.
+            quant_type = AiterQuantType.PER_128X128
+
+    if dispatch_a1.dtype == torch.float4_e2m1fn_x2 and dispatch_scale is not None:
+        if is_fp8_quant:
+            # FP8 weights + FP4 dispatch: no kernel for fp4x2/fp8 pair, dequant
+            # FP4->BF16 first; fused_moe will re-quantize to FP8 internally.
+            dispatch_a1 = upscale_mxfp4(
+                dispatch_a1, dispatch_scale, dispatch_recv_token_num, output_dtype
+            )
+            dispatch_scale = None
+        elif quant_type == AiterQuantType.NONE:
+            # BF16 / W4A4 weights with FP4 dispatch: pass FP4 through.
+            quant_type = AiterQuantType.PER_1X32
+
+    if is_w4a4:
+        quant_type = AiterQuantType.PER_1X32
+    elif is_fp8_quant and quant_type == AiterQuantType.NONE:
+        quant_type = weight_quant
+
+    output = fused_moe(
+        hidden_states=dispatch_a1,
+        w1=quant_info.w13_weight,
+        w2=quant_info.w2_weight,
+        w1_scale=quant_info.w13_scale,
+        w2_scale=quant_info.w2_scale,
+        a1_scale=dispatch_scale,
+        topk_weight=dispatch_weights.to(torch.float32),
+        topk_ids=dispatch_ids.to(torch.int32),
+        quant_type=_aiter_quant_type(quant_type),
+        activation=_aiter_activation(runner_config.activation),
+        expert_mask=quant_info.expert_mask,
+        num_local_tokens=dispatch_recv_token_num,
+        dtype=output_dtype,
+    )
+
+    cls = (
+        MoriEPNormalCombineInput
+        if DispatchOutputChecker.format_is_deepep_normal(dispatch_output)
+        else MoriEPLLCombineInput
+    )
+    return cls(
+        hidden_states=output,
+        topk_ids=dispatch_output.origin_topk_ids,
+        topk_weights=dispatch_output.origin_topk_weights,
+    )

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -41,11 +41,6 @@ class AiterMoeQuantInfo(MoeQuantInfo):
     doweight_stage1: bool = False
     hidden_pad: int = 0
     intermediate_pad: int = 0
-    # Override MoeRunnerConfig.activation (used by MXFP4's hard-coded Swiglu).
-    activation_override: Optional[str] = None
-    # Pre-scale hidden_states by topk_weights when apply_router_weight_on_input
-    # is True; only enabled by unquant.py and compressed-tensors FP8.
-    apply_router_weight_on_input_pre_scale: bool = False
 
 
 _AITER_ACTIVATIONS = {"silu": "Silu", "swiglu": "Swiglu"}
@@ -67,23 +62,22 @@ def fused_experts_none_to_aiter(
     hidden_states = dispatch_output.hidden_states
     topk_weights, topk_ids, _ = dispatch_output.topk_output
     topk_weights = topk_weights.to(torch.float32)
-    topk_ids = topk_ids.to(torch.int32)
 
-    if (
-        runner_config.apply_router_weight_on_input
-        and quant_info.apply_router_weight_on_input_pre_scale
-    ):
-        assert topk_weights.dim() == 2 and topk_weights.shape[-1] == 1
+    if runner_config.apply_router_weight_on_input and not quant_info.doweight_stage1:
+        # Pre-scale at the Python level for kernels that don't honor doweight_stage1.
+        assert (
+            topk_weights.dim() == 2 and topk_weights.shape[-1] == 1
+        ), "apply_router_weight_on_input requires topk=1"
         hidden_states = hidden_states * topk_weights.to(hidden_states.dtype)
-        topk_weights = torch.ones_like(topk_weights, dtype=torch.float32)
+        topk_weights = torch.ones_like(topk_weights)
 
-    activation = quant_info.activation_override or runner_config.activation
+    activation = runner_config.activation
     output = fused_moe(
         hidden_states=hidden_states,
         w1=quant_info.w13_weight,
         w2=quant_info.w2_weight,
         topk_weight=topk_weights,
-        topk_ids=topk_ids,
+        topk_ids=topk_ids.to(torch.int32),
         quant_type=getattr(QuantType, quant_info.quant_type.value),
         activation=getattr(ActivationType, _AITER_ACTIVATIONS.get(activation, "Gelu")),
         w1_scale=quant_info.w13_scale,

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -189,8 +189,12 @@ def pre_permute_standard_to_aiter(
 
 
 def _is_mori_dispatch_output(dispatch_output: Any) -> bool:
-    # MoriEP{Normal,LL}DispatchOutput carry the post-mori-permute origin_topk_*
-    # tensors that the standard DeepEP outputs lack.
+    # MoriEP{Normal,LL}DispatchOutput reuse DispatchOutputFormat.DEEPEP_NORMAL/LL
+    # so format-based dispatch cannot distinguish them from DeepEP outputs.
+    # The structural presence of origin_topk_ids (the post-mori-permute ids
+    # that the combine step needs) is the only available signal.
+    # If a future DeepEP output ever gains this field this check must be revised
+    # (e.g. by introducing MORI_NORMAL / MORI_LL format enum values).
     return hasattr(dispatch_output, "origin_topk_ids")
 
 

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -102,10 +102,6 @@ def _aiter_quant_type(quant_type: AiterQuantType):
     return getattr(QuantType, quant_type.value)
 
 
-def get_aiter_expert_mask(layer) -> Optional[torch.Tensor]:
-    return getattr(layer.dispatcher, "expert_mask_gpu", None)
-
-
 class AiterRunnerCore(MoeRunnerCore):
     def run(
         self,

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -369,6 +369,10 @@ def _post_permute_aiter_to_deepep(
 
         cls = DeepEPNormalCombineInput if is_normal else DeepEPLLCombineInput
 
+    assert (
+        "aiter_combine_topk_ids" in running_state
+        and "aiter_combine_topk_weights" in running_state
+    ), "post_permute called without a prior pre_permute; running_state keys missing"
     return cls(
         hidden_states=runner_output.hidden_states,
         topk_ids=running_state["aiter_combine_topk_ids"],

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -306,6 +306,10 @@ def _pre_permute_deepep_to_aiter(
         # negative ids, so reroute them to the sink slot at index
         # num_local_experts (masked off by quant_info.expert_mask which has
         # shape (num_local_experts + 1,)).
+        assert quant_info.expert_mask is not None, (
+            "expert_mask must be set for DeepEP/Mooncake/Nixl AITER dispatch; "
+            "DeepEPDispatcher.__init__ sets it when _use_aiter is True"
+        )
         topk_ids = torch.where(
             topk_ids == -1,
             torch.full_like(topk_ids, runner_config.num_local_experts),

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -18,6 +18,8 @@ from sglang.srt.layers.moe.moe_runner.base import (
 from sglang.srt.layers.moe.utils import MoeRunnerBackend
 from sglang.srt.utils import get_int_env_var
 
+_MORI_MOE_MAX_INPUT_TOKENS = get_int_env_var("SGLANG_MORI_MOE_MAX_INPUT_TOKENS", 0)
+
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher.base import CombineInput
     from sglang.srt.layers.moe.token_dispatcher.deepep import (
@@ -259,13 +261,12 @@ def _pre_permute_deepep_to_aiter(
         # Truncate dispatch tensors to the configured cap; mori combine only
         # reads [0, totalRecvTokenNum), so the truncated result needs no
         # padding back.
-        mori_max = get_int_env_var("SGLANG_MORI_MOE_MAX_INPUT_TOKENS", 0)
-        if mori_max > 0:
-            hidden_states = hidden_states[:mori_max]
+        if _MORI_MOE_MAX_INPUT_TOKENS > 0:
+            hidden_states = hidden_states[:_MORI_MOE_MAX_INPUT_TOKENS]
             if a1_scale is not None:
-                a1_scale = a1_scale[:mori_max]
-            topk_ids = topk_ids[:mori_max]
-            topk_weights = topk_weights[:mori_max]
+                a1_scale = a1_scale[:_MORI_MOE_MAX_INPUT_TOKENS]
+            topk_ids = topk_ids[:_MORI_MOE_MAX_INPUT_TOKENS]
+            topk_weights = topk_weights[:_MORI_MOE_MAX_INPUT_TOKENS]
 
         # Upscale dispatched activations when there is no AITER kernel for the
         # weight/activation dtype pair.

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -41,6 +41,11 @@ class AiterMoeQuantInfo(MoeQuantInfo):
     doweight_stage1: bool = False
     hidden_pad: int = 0
     intermediate_pad: int = 0
+    # Override MoeRunnerConfig.activation (used by MXFP4's hard-coded Swiglu).
+    activation_override: Optional[str] = None
+    # Pre-scale hidden_states by topk_weights when apply_router_weight_on_input
+    # is True; only enabled by unquant.py and compressed-tensors FP8.
+    apply_router_weight_on_input_pre_scale: bool = False
 
 
 _AITER_ACTIVATIONS = {"silu": "Silu", "swiglu": "Swiglu"}
@@ -62,22 +67,23 @@ def fused_experts_none_to_aiter(
     hidden_states = dispatch_output.hidden_states
     topk_weights, topk_ids, _ = dispatch_output.topk_output
     topk_weights = topk_weights.to(torch.float32)
+    topk_ids = topk_ids.to(torch.int32)
 
-    if runner_config.apply_router_weight_on_input and not quant_info.doweight_stage1:
-        # Pre-scale at the Python level for kernels that don't honor doweight_stage1.
-        assert (
-            topk_weights.dim() == 2 and topk_weights.shape[-1] == 1
-        ), "apply_router_weight_on_input requires topk=1"
+    if (
+        runner_config.apply_router_weight_on_input
+        and quant_info.apply_router_weight_on_input_pre_scale
+    ):
+        assert topk_weights.dim() == 2 and topk_weights.shape[-1] == 1
         hidden_states = hidden_states * topk_weights.to(hidden_states.dtype)
-        topk_weights = torch.ones_like(topk_weights)
+        topk_weights = torch.ones_like(topk_weights, dtype=torch.float32)
 
-    activation = runner_config.activation
+    activation = quant_info.activation_override or runner_config.activation
     output = fused_moe(
         hidden_states=hidden_states,
         w1=quant_info.w13_weight,
         w2=quant_info.w2_weight,
         topk_weight=topk_weights,
-        topk_ids=topk_ids.to(torch.int32),
+        topk_ids=topk_ids,
         quant_type=getattr(QuantType, quant_info.quant_type.value),
         activation=getattr(ActivationType, _AITER_ACTIVATIONS.get(activation, "Gelu")),
         w1_scale=quant_info.w13_scale,

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -18,8 +18,6 @@ from sglang.srt.layers.moe.moe_runner.base import (
 from sglang.srt.layers.moe.utils import MoeRunnerBackend
 from sglang.srt.utils import get_int_env_var
 
-_MORI_MOE_MAX_INPUT_TOKENS = get_int_env_var("SGLANG_MORI_MOE_MAX_INPUT_TOKENS", 0)
-
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher.base import CombineInput
     from sglang.srt.layers.moe.token_dispatcher.deepep import (
@@ -191,12 +189,8 @@ def pre_permute_standard_to_aiter(
 
 
 def _is_mori_dispatch_output(dispatch_output: Any) -> bool:
-    # MoriEP{Normal,LL}DispatchOutput reuse DispatchOutputFormat.DEEPEP_NORMAL/LL
-    # so format-based dispatch cannot distinguish them from DeepEP outputs.
-    # The structural presence of origin_topk_ids (the post-mori-permute ids
-    # that the combine step needs) is the only available signal.
-    # If a future DeepEP output ever gains this field this check must be revised
-    # (e.g. by introducing MORI_NORMAL / MORI_LL format enum values).
+    # MoriEP{Normal,LL}DispatchOutput carry the post-mori-permute origin_topk_*
+    # tensors that the standard DeepEP outputs lack.
     return hasattr(dispatch_output, "origin_topk_ids")
 
 
@@ -261,12 +255,13 @@ def _pre_permute_deepep_to_aiter(
         # Truncate dispatch tensors to the configured cap; mori combine only
         # reads [0, totalRecvTokenNum), so the truncated result needs no
         # padding back.
-        if _MORI_MOE_MAX_INPUT_TOKENS > 0:
-            hidden_states = hidden_states[:_MORI_MOE_MAX_INPUT_TOKENS]
+        mori_max = get_int_env_var("SGLANG_MORI_MOE_MAX_INPUT_TOKENS", 0)
+        if mori_max > 0:
+            hidden_states = hidden_states[:mori_max]
             if a1_scale is not None:
-                a1_scale = a1_scale[:_MORI_MOE_MAX_INPUT_TOKENS]
-            topk_ids = topk_ids[:_MORI_MOE_MAX_INPUT_TOKENS]
-            topk_weights = topk_weights[:_MORI_MOE_MAX_INPUT_TOKENS]
+                a1_scale = a1_scale[:mori_max]
+            topk_ids = topk_ids[:mori_max]
+            topk_weights = topk_weights[:mori_max]
 
         # Upscale dispatched activations when there is no AITER kernel for the
         # weight/activation dtype pair.
@@ -306,10 +301,6 @@ def _pre_permute_deepep_to_aiter(
         # negative ids, so reroute them to the sink slot at index
         # num_local_experts (masked off by quant_info.expert_mask which has
         # shape (num_local_experts + 1,)).
-        assert quant_info.expert_mask is not None, (
-            "expert_mask must be set for DeepEP/Mooncake/Nixl AITER dispatch; "
-            "DeepEPDispatcher.__init__ sets it when _use_aiter is True"
-        )
         topk_ids = torch.where(
             topk_ids == -1,
             torch.full_like(topk_ids, runner_config.num_local_experts),
@@ -374,10 +365,6 @@ def _post_permute_aiter_to_deepep(
 
         cls = DeepEPNormalCombineInput if is_normal else DeepEPLLCombineInput
 
-    assert (
-        "aiter_combine_topk_ids" in running_state
-        and "aiter_combine_topk_weights" in running_state
-    ), "post_permute called without a prior pre_permute; running_state keys missing"
     return cls(
         hidden_states=runner_output.hidden_states,
         topk_ids=running_state["aiter_combine_topk_ids"],

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -103,10 +103,6 @@ def _aiter_quant_type(quant_type: AiterQuantType):
 
 
 def get_aiter_expert_mask(layer) -> Optional[torch.Tensor]:
-    # DeepEPMoE sets self.expert_mask in __init__; standard FusedMoE exposes
-    # it via the dispatcher.
-    if getattr(layer, "expert_mask", None) is not None:
-        return layer.expert_mask
     return getattr(layer.dispatcher, "expert_mask_gpu", None)
 
 

--- a/python/sglang/srt/layers/moe/moe_runner/runner.py
+++ b/python/sglang/srt/layers/moe/moe_runner/runner.py
@@ -44,10 +44,9 @@ class MoeRunner:
         elif runner_backend.is_deep_gemm():
             self.runner_core = DeepGemmRunnerCore(config)
         elif runner_backend.is_aiter():
-            # Side-effect import: registers the ("none", "aiter") fused func.
-            from sglang.srt.layers.moe.moe_runner import aiter  # noqa: F401
+            from sglang.srt.layers.moe.moe_runner.aiter import AiterRunnerCore
 
-            self.runner_core = None  # AITER only supports fused path
+            self.runner_core = AiterRunnerCore(config)
         elif runner_backend.is_marlin():
             if lora_enabled:
                 from sglang.srt.lora.lora_moe_runner_marlin import MarlinLoraRunnerCore

--- a/python/sglang/srt/layers/moe/moe_runner/runner.py
+++ b/python/sglang/srt/layers/moe/moe_runner/runner.py
@@ -130,7 +130,7 @@ class MoeRunner:
 
         dispatch_format = dispatch_output.format.value
         runner_format = self.runner_core.runner_backend.value
-        pre_permute_func = PermuteMethodPool.get_pre_permute(
+        self.pre_permute_func = PermuteMethodPool.get_pre_permute(
             dispatch_format, runner_format
         )
 
@@ -140,7 +140,7 @@ class MoeRunner:
         if self.meta_overlap_args is not None:
             running_state["meta_overlap_args"] = self.meta_overlap_args
 
-        runner_input = pre_permute_func(
+        runner_input = self.pre_permute_func(
             dispatch_output, quant_info, self.config, running_state
         )
 
@@ -149,11 +149,12 @@ class MoeRunner:
         runner_output = self.runner_core.run(
             runner_input, quant_info, running_state, hooks=hooks
         )
+        runner_format = self.runner_core.runner_backend.value
         combine_format = dispatch_output.format.value
-        post_permute_func = PermuteMethodPool.get_post_permute(
+        self.post_permute_func = PermuteMethodPool.get_post_permute(
             runner_format, combine_format
         )
-        combine_input = post_permute_func(
+        combine_input = self.post_permute_func(
             runner_output, quant_info, self.config, running_state
         )
 

--- a/python/sglang/srt/layers/moe/moe_runner/runner.py
+++ b/python/sglang/srt/layers/moe/moe_runner/runner.py
@@ -130,7 +130,7 @@ class MoeRunner:
 
         dispatch_format = dispatch_output.format.value
         runner_format = self.runner_core.runner_backend.value
-        self.pre_permute_func = PermuteMethodPool.get_pre_permute(
+        pre_permute_func = PermuteMethodPool.get_pre_permute(
             dispatch_format, runner_format
         )
 
@@ -140,7 +140,7 @@ class MoeRunner:
         if self.meta_overlap_args is not None:
             running_state["meta_overlap_args"] = self.meta_overlap_args
 
-        runner_input = self.pre_permute_func(
+        runner_input = pre_permute_func(
             dispatch_output, quant_info, self.config, running_state
         )
 
@@ -149,12 +149,11 @@ class MoeRunner:
         runner_output = self.runner_core.run(
             runner_input, quant_info, running_state, hooks=hooks
         )
-        runner_format = self.runner_core.runner_backend.value
         combine_format = dispatch_output.format.value
-        self.post_permute_func = PermuteMethodPool.get_post_permute(
+        post_permute_func = PermuteMethodPool.get_post_permute(
             runner_format, combine_format
         )
-        combine_input = self.post_permute_func(
+        combine_input = post_permute_func(
             runner_output, quant_info, self.config, running_state
         )
 

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -816,6 +816,21 @@ class DeepEPDispatcher(BaseDispatcher):
         self._stage = _Stage.INITIAL
         self._deepep_dispatch_hooks = DeepEPPDispatchHooks()
 
+        # DeepEP/Mooncake/Nixl mark invalid topk slots with -1; the AITER
+        # pre_permute reroutes them to a sink slot at index num_local_experts,
+        # which is masked off here.
+        self.expert_mask_gpu = None
+        if _use_aiter and num_local_experts is not None:
+            import torch
+
+            expert_mask = torch.zeros(
+                num_local_experts + 1,
+                device=torch.cuda.current_device(),
+                dtype=torch.int,
+            )
+            expert_mask[:-1] = 1
+            self.expert_mask_gpu = expert_mask
+
     def dispatch(
         self,
         hidden_states: torch.Tensor,

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -821,8 +821,6 @@ class DeepEPDispatcher(BaseDispatcher):
         # which is masked off here.
         self.expert_mask_gpu = None
         if _use_aiter and num_local_experts is not None:
-            import torch
-
             expert_mask = torch.zeros(
                 num_local_experts + 1,
                 device=torch.cuda.current_device(),

--- a/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
@@ -1010,6 +1010,7 @@ class MoriEPDispatcher(BaseDispatcher):
 
         self._stage = _Stage.INITIAL
         self._deepep_dispatch_hooks = MoriEPPDispatchHooks()
+        self._num_tokens: Optional[int] = None
 
         # Mori dispatch produces global topk_ids in [0, num_experts); mask out
         # experts that are not local to this rank.
@@ -1030,7 +1031,6 @@ class MoriEPDispatcher(BaseDispatcher):
         hidden_states: torch.Tensor,
         topk_output: TopKOutput,
     ) -> DispatchOutput:
-        self._num_tokens = hidden_states.shape[0]
         self.dispatch_a(hidden_states, topk_output)
         if self._deepep_dispatch_hooks is not None:
             self._deepep_dispatch_hooks(self)
@@ -1043,6 +1043,7 @@ class MoriEPDispatcher(BaseDispatcher):
         topk_output: TopKOutput,
     ):
         self._update_stage(_Stage.INITIAL, _Stage.AFTER_DISPATCH_A)
+        self._num_tokens = hidden_states.shape[0]
         inner_state = self._get_impl().dispatch_a(
             hidden_states=hidden_states,
             topk_output=topk_output,
@@ -1059,6 +1060,9 @@ class MoriEPDispatcher(BaseDispatcher):
         self,
         combine_input: CombineInput,
     ) -> Tuple:
+        assert self._num_tokens is not None, (
+            "combine() called without a prior dispatch_a(); _num_tokens not set"
+        )
         self.combine_a(combine_input)
         hidden_states = self.combine_b()
         return hidden_states[: self._num_tokens]

--- a/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
@@ -1030,6 +1030,7 @@ class MoriEPDispatcher(BaseDispatcher):
         hidden_states: torch.Tensor,
         topk_output: TopKOutput,
     ) -> DispatchOutput:
+        self._num_tokens = hidden_states.shape[0]
         self.dispatch_a(hidden_states, topk_output)
         if self._deepep_dispatch_hooks is not None:
             self._deepep_dispatch_hooks(self)
@@ -1042,7 +1043,6 @@ class MoriEPDispatcher(BaseDispatcher):
         topk_output: TopKOutput,
     ):
         self._update_stage(_Stage.INITIAL, _Stage.AFTER_DISPATCH_A)
-        self._num_tokens = hidden_states.shape[0]
         inner_state = self._get_impl().dispatch_a(
             hidden_states=hidden_states,
             topk_output=topk_output,

--- a/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
@@ -1010,7 +1010,6 @@ class MoriEPDispatcher(BaseDispatcher):
 
         self._stage = _Stage.INITIAL
         self._deepep_dispatch_hooks = MoriEPPDispatchHooks()
-        self._num_tokens: Optional[int] = None
 
         # Mori dispatch produces global topk_ids in [0, num_experts); mask out
         # experts that are not local to this rank.
@@ -1031,6 +1030,7 @@ class MoriEPDispatcher(BaseDispatcher):
         hidden_states: torch.Tensor,
         topk_output: TopKOutput,
     ) -> DispatchOutput:
+        self._num_tokens = hidden_states.shape[0]
         self.dispatch_a(hidden_states, topk_output)
         if self._deepep_dispatch_hooks is not None:
             self._deepep_dispatch_hooks(self)
@@ -1043,7 +1043,6 @@ class MoriEPDispatcher(BaseDispatcher):
         topk_output: TopKOutput,
     ):
         self._update_stage(_Stage.INITIAL, _Stage.AFTER_DISPATCH_A)
-        self._num_tokens = hidden_states.shape[0]
         inner_state = self._get_impl().dispatch_a(
             hidden_states=hidden_states,
             topk_output=topk_output,
@@ -1060,9 +1059,6 @@ class MoriEPDispatcher(BaseDispatcher):
         self,
         combine_input: CombineInput,
     ) -> Tuple:
-        assert self._num_tokens is not None, (
-            "combine() called without a prior dispatch_a(); _num_tokens not set"
-        )
         self.combine_a(combine_input)
         hidden_states = self.combine_b()
         return hidden_states[: self._num_tokens]

--- a/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
@@ -1011,6 +1011,20 @@ class MoriEPDispatcher(BaseDispatcher):
         self._stage = _Stage.INITIAL
         self._deepep_dispatch_hooks = MoriEPPDispatchHooks()
 
+        # Mori dispatch produces global topk_ids in [0, num_experts); mask out
+        # experts that are not local to this rank.
+        self.expert_mask_gpu = None
+        if _use_aiter and num_experts is not None and num_local_experts is not None:
+            ep_rank = get_moe_expert_parallel_rank()
+            expert_mask = torch.zeros(
+                num_experts,
+                device=torch.cuda.current_device(),
+                dtype=torch.int32,
+            )
+            start = ep_rank * num_local_experts
+            expert_mask[start : start + num_local_experts] = 1
+            self.expert_mask_gpu = expert_mask
+
     def dispatch(
         self,
         hidden_states: torch.Tensor,

--- a/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
@@ -1042,6 +1042,7 @@ class MoriEPDispatcher(BaseDispatcher):
         topk_output: TopKOutput,
     ):
         self._update_stage(_Stage.INITIAL, _Stage.AFTER_DISPATCH_A)
+        self._num_tokens = hidden_states.shape[0]
         inner_state = self._get_impl().dispatch_a(
             hidden_states=hidden_states,
             topk_output=topk_output,
@@ -1059,8 +1060,8 @@ class MoriEPDispatcher(BaseDispatcher):
         combine_input: CombineInput,
     ) -> Tuple:
         self.combine_a(combine_input)
-        ret = self.combine_b()
-        return ret
+        hidden_states = self.combine_b()
+        return hidden_states[: self._num_tokens]
 
     def combine_a(
         self,

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -64,6 +64,17 @@ class MoeA2ABackend(Enum):
     def is_customized(self):
         return self == MoeA2ABackend.CUSTOMIZED
 
+    def supports_aiter(self) -> bool:
+        # a2a backends that have an ("<a2a>", "aiter") fused func registered in
+        # sglang.srt.layers.moe.moe_runner.aiter.
+        return self in (
+            MoeA2ABackend.NONE,
+            MoeA2ABackend.DEEPEP,
+            MoeA2ABackend.MOONCAKE,
+            MoeA2ABackend.NIXL,
+            MoeA2ABackend.MORI,
+        )
+
 
 class MoeRunnerBackend(Enum):
 

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -65,10 +65,6 @@ class MoeA2ABackend(Enum):
         return self == MoeA2ABackend.CUSTOMIZED
 
     def supports_aiter(self) -> bool:
-        # a2a backends for which register_pre_permute("<dispatch_format>", "aiter")
-        # and register_post_permute("aiter", "<dispatch_format>") are registered in
-        # sglang.srt.layers.moe.moe_runner.aiter. "none" maps to "standard" format;
-        # deepep/mooncake/nixl/mori map to the "deepep_normal"/"deepep_ll" formats.
         return self in (
             MoeA2ABackend.NONE,
             MoeA2ABackend.DEEPEP,

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -65,8 +65,10 @@ class MoeA2ABackend(Enum):
         return self == MoeA2ABackend.CUSTOMIZED
 
     def supports_aiter(self) -> bool:
-        # a2a backends that have an ("<a2a>", "aiter") fused func registered in
-        # sglang.srt.layers.moe.moe_runner.aiter.
+        # a2a backends for which register_pre_permute("<dispatch_format>", "aiter")
+        # and register_post_permute("aiter", "<dispatch_format>") are registered in
+        # sglang.srt.layers.moe.moe_runner.aiter. "none" maps to "standard" format;
+        # deepep/mooncake/nixl/mori map to the "deepep_normal"/"deepep_ll" formats.
         return self in (
             MoeA2ABackend.NONE,
             MoeA2ABackend.DEEPEP,

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8_moe.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8_moe.py
@@ -346,12 +346,10 @@ class CompressedTensorsW8A8Fp8MoE(CompressedTensorsMoEScheme):
         self.moe_runner_config = moe_runner_config
         moe_runner_backend = get_moe_runner_backend()
         if moe_runner_backend.is_auto():
-            if _use_aiter and get_moe_a2a_backend().is_mori():
-                # mori bypasses self.runner via MoriEPMoE.run_moe_core.
-                pass
-            elif (
+            if (
                 _use_aiter
                 and self.weight_quant.strategy == QuantizationStrategy.CHANNEL
+                and get_moe_a2a_backend().is_none()
             ):
                 moe_runner_backend = MoeRunnerBackend.AITER
             else:
@@ -394,7 +392,6 @@ class CompressedTensorsW8A8Fp8MoE(CompressedTensorsMoEScheme):
                 w2_scale=layer.w2_weight_scale,
                 a13_scale=layer.w13_input_scale,
                 a2_scale=layer.w2_input_scale,
-                apply_router_weight_on_input_pre_scale=True,
             )
             return self.runner.run(dispatch_output, quant_info)
         elif self.weight_quant.strategy == QuantizationStrategy.BLOCK:

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8_moe.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8_moe.py
@@ -349,7 +349,7 @@ class CompressedTensorsW8A8Fp8MoE(CompressedTensorsMoEScheme):
             if (
                 _use_aiter
                 and self.weight_quant.strategy == QuantizationStrategy.CHANNEL
-                and get_moe_a2a_backend().is_none()
+                and get_moe_a2a_backend().supports_aiter()
             ):
                 moe_runner_backend = MoeRunnerBackend.AITER
             else:

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8_moe.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8_moe.py
@@ -346,25 +346,11 @@ class CompressedTensorsW8A8Fp8MoE(CompressedTensorsMoEScheme):
         self.moe_runner_config = moe_runner_config
         moe_runner_backend = get_moe_runner_backend()
         if moe_runner_backend.is_auto():
-            if (
-                _use_aiter
-                and self.weight_quant.strategy == QuantizationStrategy.CHANNEL
-                and get_moe_a2a_backend().is_none()
-            ):
-                moe_runner_backend = MoeRunnerBackend.AITER
-            else:
-                moe_runner_backend = MoeRunnerBackend.TRITON
-
-        if (
-            moe_runner_backend.is_aiter()
-            or moe_runner_backend.is_triton()
-            or moe_runner_backend.is_flashinfer_trtllm()
-            or moe_runner_backend.is_flashinfer_trtllm_routed()
-        ):
-            self.runner = MoeRunner(moe_runner_backend, moe_runner_config)
-        else:
-            # TODO(cwan): refactor other backends
-            pass
+            moe_runner_backend = MoeRunnerBackend.TRITON
+        # Pre-refactor aiter fast-path: _use_aiter + channel-quant.
+        if _use_aiter and self.weight_quant.strategy == QuantizationStrategy.CHANNEL:
+            moe_runner_backend = MoeRunnerBackend.AITER
+        self.runner = MoeRunner(moe_runner_backend, moe_runner_config)
 
     def apply_weights(
         self,
@@ -392,6 +378,7 @@ class CompressedTensorsW8A8Fp8MoE(CompressedTensorsMoEScheme):
                 w2_scale=layer.w2_weight_scale,
                 a13_scale=layer.w13_input_scale,
                 a2_scale=layer.w2_input_scale,
+                apply_router_weight_on_input_pre_scale=True,
             )
             return self.runner.run(dispatch_output, quant_info)
         elif self.weight_quant.strategy == QuantizationStrategy.BLOCK:

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8_moe.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8_moe.py
@@ -346,11 +346,27 @@ class CompressedTensorsW8A8Fp8MoE(CompressedTensorsMoEScheme):
         self.moe_runner_config = moe_runner_config
         moe_runner_backend = get_moe_runner_backend()
         if moe_runner_backend.is_auto():
-            moe_runner_backend = MoeRunnerBackend.TRITON
-        # Pre-refactor aiter fast-path: _use_aiter + channel-quant.
-        if _use_aiter and self.weight_quant.strategy == QuantizationStrategy.CHANNEL:
-            moe_runner_backend = MoeRunnerBackend.AITER
-        self.runner = MoeRunner(moe_runner_backend, moe_runner_config)
+            if _use_aiter and get_moe_a2a_backend().is_mori():
+                # mori bypasses self.runner via MoriEPMoE.run_moe_core.
+                pass
+            elif (
+                _use_aiter
+                and self.weight_quant.strategy == QuantizationStrategy.CHANNEL
+            ):
+                moe_runner_backend = MoeRunnerBackend.AITER
+            else:
+                moe_runner_backend = MoeRunnerBackend.TRITON
+
+        if (
+            moe_runner_backend.is_aiter()
+            or moe_runner_backend.is_triton()
+            or moe_runner_backend.is_flashinfer_trtllm()
+            or moe_runner_backend.is_flashinfer_trtllm_routed()
+        ):
+            self.runner = MoeRunner(moe_runner_backend, moe_runner_config)
+        else:
+            # TODO(cwan): refactor other backends
+            pass
 
     def apply_weights(
         self,

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1637,22 +1637,12 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         if moe_runner_backend.is_auto():
             if self.is_deepgemm_moe_runner_backend_enabled():
                 moe_runner_backend = MoeRunnerBackend.DEEP_GEMM
-            elif (
-                _is_hip
-                and (_use_aiter or _use_hip_int4)
-                and get_moe_a2a_backend().is_none()
-            ):
-                # *EPMoE backends bypass self.runner via run_moe_core, and the
-                # AITER fused func is only registered for ("none", "aiter").
-                moe_runner_backend = MoeRunnerBackend.AITER
+            elif _is_hip and (_use_aiter or _use_hip_int4):
+                # mori bypasses self.runner via MoriEPMoE.run_moe_core.
+                if not get_moe_a2a_backend().is_mori():
+                    moe_runner_backend = MoeRunnerBackend.AITER
             else:
                 moe_runner_backend = MoeRunnerBackend.TRITON
-
-
-        # On HIP with SGLANG_USE_AITER / SGLANG_INT4_WEIGHT, the aiter fused
-        # kernel was the unconditional fast-path before this refactor.
-        if _is_hip and (_use_aiter or _use_hip_int4):
-            moe_runner_backend = MoeRunnerBackend.AITER
 
 
         if (

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1640,10 +1640,8 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             elif (
                 _is_hip
                 and (_use_aiter or _use_hip_int4)
-                and get_moe_a2a_backend().is_none()
+                and get_moe_a2a_backend().supports_aiter()
             ):
-                # *EPMoE backends bypass self.runner via run_moe_core, and the
-                # AITER fused func is only registered for ("none", "aiter").
                 moe_runner_backend = MoeRunnerBackend.AITER
             else:
                 moe_runner_backend = MoeRunnerBackend.TRITON
@@ -1931,6 +1929,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         from sglang.srt.layers.moe.moe_runner.aiter import (
             AiterMoeQuantInfo,
             AiterQuantType,
+            get_aiter_expert_mask,
         )
 
         if _use_aiter and self.block_quant:
@@ -1947,7 +1946,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             quant_type=quant_type,
             w13_scale=w13_scale,
             w2_scale=w2_scale,
-            expert_mask=layer.dispatcher.expert_mask_gpu if _use_aiter else None,
+            expert_mask=get_aiter_expert_mask(layer) if _use_aiter else None,
         )
 
 

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1646,7 +1646,6 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             else:
                 moe_runner_backend = MoeRunnerBackend.TRITON
 
-
         if (
             moe_runner_backend.is_deep_gemm()
             or moe_runner_backend.is_triton()

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1637,10 +1637,14 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         if moe_runner_backend.is_auto():
             if self.is_deepgemm_moe_runner_backend_enabled():
                 moe_runner_backend = MoeRunnerBackend.DEEP_GEMM
-            elif _is_hip and (_use_aiter or _use_hip_int4):
-                # mori bypasses self.runner via MoriEPMoE.run_moe_core.
-                if not get_moe_a2a_backend().is_mori():
-                    moe_runner_backend = MoeRunnerBackend.AITER
+            elif (
+                _is_hip
+                and (_use_aiter or _use_hip_int4)
+                and get_moe_a2a_backend().is_none()
+            ):
+                # *EPMoE backends bypass self.runner via run_moe_core, and the
+                # AITER fused func is only registered for ("none", "aiter").
+                moe_runner_backend = MoeRunnerBackend.AITER
             else:
                 moe_runner_backend = MoeRunnerBackend.TRITON
 

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1648,6 +1648,13 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             else:
                 moe_runner_backend = MoeRunnerBackend.TRITON
 
+
+        # On HIP with SGLANG_USE_AITER / SGLANG_INT4_WEIGHT, the aiter fused
+        # kernel was the unconditional fast-path before this refactor.
+        if _is_hip and (_use_aiter or _use_hip_int4):
+            moe_runner_backend = MoeRunnerBackend.AITER
+
+
         if (
             moe_runner_backend.is_deep_gemm()
             or moe_runner_backend.is_triton()

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1929,7 +1929,6 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         from sglang.srt.layers.moe.moe_runner.aiter import (
             AiterMoeQuantInfo,
             AiterQuantType,
-            get_aiter_expert_mask,
         )
 
         if _use_aiter and self.block_quant:
@@ -1946,7 +1945,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             quant_type=quant_type,
             w13_scale=w13_scale,
             w2_scale=w2_scale,
-            expert_mask=get_aiter_expert_mask(layer) if _use_aiter else None,
+            expert_mask=layer.dispatcher.expert_mask_gpu if _use_aiter else None,
         )
 
 

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -1018,7 +1018,11 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             self.runner = MoeRunner(
                 moe_runner_backend, replace(moe_runner_config, activation="swiglu")
             )
-        elif moe_runner_backend.is_triton_kernels() or moe_runner_backend.is_triton():
+        elif (
+            moe_runner_backend.is_triton_kernels()
+            or moe_runner_backend.is_triton()
+            or moe_runner_backend.is_marlin()
+        ):
             self.runner = MoeRunner(moe_runner_backend, moe_runner_config)
         else:
             # TODO(cwan): refactor other backends

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -1006,21 +1006,19 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         moe_runner_backend = get_moe_runner_backend()
         if moe_runner_backend.is_auto():
             # Must match apply() priority: _use_aiter before use_triton_kernels.
-            if _use_aiter and get_moe_a2a_backend().is_mori():
-                # mori bypasses self.runner via MoriEPMoE.run_moe_core.
-                pass
-            elif _use_aiter:
+            if _use_aiter and get_moe_a2a_backend().is_none():
                 moe_runner_backend = MoeRunnerBackend.AITER
             elif self.use_triton_kernels:
                 moe_runner_backend = MoeRunnerBackend.TRITON_KERNELS
             else:
                 moe_runner_backend = MoeRunnerBackend.TRITON
 
-        if (
-            moe_runner_backend.is_aiter()
-            or moe_runner_backend.is_triton_kernels()
-            or moe_runner_backend.is_triton()
-        ):
+        if moe_runner_backend.is_aiter():
+            # MXFP4 hard-codes Swiglu in the AITER kernel path.
+            self.runner = MoeRunner(
+                moe_runner_backend, replace(moe_runner_config, activation="swiglu")
+            )
+        elif moe_runner_backend.is_triton_kernels() or moe_runner_backend.is_triton():
             self.runner = MoeRunner(moe_runner_backend, moe_runner_config)
         else:
             # TODO(cwan): refactor other backends
@@ -1219,7 +1217,6 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 doweight_stage1=self.moe_runner_config.apply_router_weight_on_input,
                 hidden_pad=self.hidden_pad,
                 intermediate_pad=self.intermediate_pad,
-                activation_override="swiglu",
             )
             return self.runner.run(
                 dispatch_output._replace(hidden_states=x_padded), quant_info
@@ -1359,8 +1356,7 @@ class Mxfp4DynamicQuantMoEMethod(FusedMoEMethodBase):
     ):
         self.moe_runner_config = moe_runner_config
         moe_runner_backend = get_moe_runner_backend()
-        if moe_runner_backend.is_auto() and not get_moe_a2a_backend().is_mori():
-            # mori bypasses self.runner via MoriEPMoE.run_moe_core.
+        if moe_runner_backend.is_auto() and get_moe_a2a_backend().is_none():
             moe_runner_backend = MoeRunnerBackend.AITER
 
         if moe_runner_backend.is_aiter():

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -1197,7 +1197,6 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             from sglang.srt.layers.moe.moe_runner.aiter import (
                 AiterMoeQuantInfo,
                 AiterQuantType,
-                get_aiter_expert_mask,
             )
 
             if hasattr(torch, "float4_e2m1fn_x2"):
@@ -1218,7 +1217,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 w2_scale=layer.w2_weight_scale,
                 b13=layer.w13_weight_bias,
                 b2=layer.w2_weight_bias,
-                expert_mask=get_aiter_expert_mask(layer),
+                expert_mask=layer.dispatcher.expert_mask_gpu,
                 doweight_stage1=self.moe_runner_config.apply_router_weight_on_input,
                 hidden_pad=self.hidden_pad,
                 intermediate_pad=self.intermediate_pad,
@@ -1378,7 +1377,6 @@ class Mxfp4DynamicQuantMoEMethod(FusedMoEMethodBase):
         from sglang.srt.layers.moe.moe_runner.aiter import (
             AiterMoeQuantInfo,
             AiterQuantType,
-            get_aiter_expert_mask,
         )
 
         if hasattr(torch, "float4_e2m1fn_x2"):
@@ -1398,6 +1396,6 @@ class Mxfp4DynamicQuantMoEMethod(FusedMoEMethodBase):
             quant_type=AiterQuantType.PER_1X32,
             w13_scale=layer.w13_weight_scale,
             w2_scale=layer.w2_weight_scale,
-            expert_mask=get_aiter_expert_mask(layer),
+            expert_mask=layer.dispatcher.expert_mask_gpu,
         )
         return self.runner.run(dispatch_output, quant_info)

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -1003,30 +1003,14 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
     ):
         self.moe_runner_config = moe_runner_config
-        moe_runner_backend = get_moe_runner_backend()
-        if moe_runner_backend.is_auto():
-            # Must match apply() priority: _use_aiter before use_triton_kernels.
-            if _use_aiter and get_moe_a2a_backend().is_none():
-                moe_runner_backend = MoeRunnerBackend.AITER
-            elif self.use_triton_kernels:
-                moe_runner_backend = MoeRunnerBackend.TRITON_KERNELS
-            else:
-                moe_runner_backend = MoeRunnerBackend.TRITON
-
-        if moe_runner_backend.is_aiter():
-            # MXFP4 hard-codes Swiglu in the AITER kernel path.
-            self.runner = MoeRunner(
-                moe_runner_backend, replace(moe_runner_config, activation="swiglu")
-            )
-        elif (
-            moe_runner_backend.is_triton_kernels()
-            or moe_runner_backend.is_triton()
-            or moe_runner_backend.is_marlin()
-        ):
-            self.runner = MoeRunner(moe_runner_backend, moe_runner_config)
+        # Must match apply() priority: _use_aiter before use_triton_kernels.
+        if _use_aiter:
+            backend = MoeRunnerBackend.AITER
+        elif self.use_triton_kernels:
+            backend = MoeRunnerBackend.TRITON_KERNELS
         else:
-            # TODO(cwan): refactor other backends
-            pass
+            backend = MoeRunnerBackend.TRITON
+        self.runner = MoeRunner(backend, moe_runner_config)
 
     def _apply_sm90_cutlass(self, layer, x, topk_output):
         """SM90 (Hopper) MXFP4 x BF16 MoE via FlashInfer's cutlass mixed-input
@@ -1221,6 +1205,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 doweight_stage1=self.moe_runner_config.apply_router_weight_on_input,
                 hidden_pad=self.hidden_pad,
                 intermediate_pad=self.intermediate_pad,
+                activation_override="swiglu",
             )
             return self.runner.run(
                 dispatch_output._replace(hidden_states=x_padded), quant_info
@@ -1359,15 +1344,7 @@ class Mxfp4DynamicQuantMoEMethod(FusedMoEMethodBase):
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
     ):
         self.moe_runner_config = moe_runner_config
-        moe_runner_backend = get_moe_runner_backend()
-        if moe_runner_backend.is_auto() and get_moe_a2a_backend().is_none():
-            moe_runner_backend = MoeRunnerBackend.AITER
-
-        if moe_runner_backend.is_aiter():
-            self.runner = MoeRunner(moe_runner_backend, moe_runner_config)
-        else:
-            # TODO(cwan): refactor other backends
-            pass
+        self.runner = MoeRunner(MoeRunnerBackend.AITER, moe_runner_config)
 
     def apply(
         self,

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -1003,14 +1003,28 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
     ):
         self.moe_runner_config = moe_runner_config
-        # Must match apply() priority: _use_aiter before use_triton_kernels.
-        if _use_aiter:
-            backend = MoeRunnerBackend.AITER
-        elif self.use_triton_kernels:
-            backend = MoeRunnerBackend.TRITON_KERNELS
+        moe_runner_backend = get_moe_runner_backend()
+        if moe_runner_backend.is_auto():
+            # Must match apply() priority: _use_aiter before use_triton_kernels.
+            if _use_aiter and get_moe_a2a_backend().is_mori():
+                # mori bypasses self.runner via MoriEPMoE.run_moe_core.
+                pass
+            elif _use_aiter:
+                moe_runner_backend = MoeRunnerBackend.AITER
+            elif self.use_triton_kernels:
+                moe_runner_backend = MoeRunnerBackend.TRITON_KERNELS
+            else:
+                moe_runner_backend = MoeRunnerBackend.TRITON
+
+        if (
+            moe_runner_backend.is_aiter()
+            or moe_runner_backend.is_triton_kernels()
+            or moe_runner_backend.is_triton()
+        ):
+            self.runner = MoeRunner(moe_runner_backend, moe_runner_config)
         else:
-            backend = MoeRunnerBackend.TRITON
-        self.runner = MoeRunner(backend, moe_runner_config)
+            # TODO(cwan): refactor other backends
+            pass
 
     def _apply_sm90_cutlass(self, layer, x, topk_output):
         """SM90 (Hopper) MXFP4 x BF16 MoE via FlashInfer's cutlass mixed-input
@@ -1344,7 +1358,16 @@ class Mxfp4DynamicQuantMoEMethod(FusedMoEMethodBase):
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
     ):
         self.moe_runner_config = moe_runner_config
-        self.runner = MoeRunner(MoeRunnerBackend.AITER, moe_runner_config)
+        moe_runner_backend = get_moe_runner_backend()
+        if moe_runner_backend.is_auto() and not get_moe_a2a_backend().is_mori():
+            # mori bypasses self.runner via MoriEPMoE.run_moe_core.
+            moe_runner_backend = MoeRunnerBackend.AITER
+
+        if moe_runner_backend.is_aiter():
+            self.runner = MoeRunner(moe_runner_backend, moe_runner_config)
+        else:
+            # TODO(cwan): refactor other backends
+            pass
 
     def apply(
         self,

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -1006,7 +1006,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         moe_runner_backend = get_moe_runner_backend()
         if moe_runner_backend.is_auto():
             # Must match apply() priority: _use_aiter before use_triton_kernels.
-            if _use_aiter and get_moe_a2a_backend().is_none():
+            if _use_aiter and get_moe_a2a_backend().supports_aiter():
                 moe_runner_backend = MoeRunnerBackend.AITER
             elif self.use_triton_kernels:
                 moe_runner_backend = MoeRunnerBackend.TRITON_KERNELS
@@ -1193,6 +1193,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             from sglang.srt.layers.moe.moe_runner.aiter import (
                 AiterMoeQuantInfo,
                 AiterQuantType,
+                get_aiter_expert_mask,
             )
 
             if hasattr(torch, "float4_e2m1fn_x2"):
@@ -1213,7 +1214,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 w2_scale=layer.w2_weight_scale,
                 b13=layer.w13_weight_bias,
                 b2=layer.w2_weight_bias,
-                expert_mask=layer.dispatcher.expert_mask_gpu,
+                expert_mask=get_aiter_expert_mask(layer),
                 doweight_stage1=self.moe_runner_config.apply_router_weight_on_input,
                 hidden_pad=self.hidden_pad,
                 intermediate_pad=self.intermediate_pad,
@@ -1356,7 +1357,7 @@ class Mxfp4DynamicQuantMoEMethod(FusedMoEMethodBase):
     ):
         self.moe_runner_config = moe_runner_config
         moe_runner_backend = get_moe_runner_backend()
-        if moe_runner_backend.is_auto() and get_moe_a2a_backend().is_none():
+        if moe_runner_backend.is_auto() and get_moe_a2a_backend().supports_aiter():
             moe_runner_backend = MoeRunnerBackend.AITER
 
         if moe_runner_backend.is_aiter():
@@ -1373,6 +1374,7 @@ class Mxfp4DynamicQuantMoEMethod(FusedMoEMethodBase):
         from sglang.srt.layers.moe.moe_runner.aiter import (
             AiterMoeQuantInfo,
             AiterQuantType,
+            get_aiter_expert_mask,
         )
 
         if hasattr(torch, "float4_e2m1fn_x2"):
@@ -1392,6 +1394,6 @@ class Mxfp4DynamicQuantMoEMethod(FusedMoEMethodBase):
             quant_type=AiterQuantType.PER_1X32,
             w13_scale=layer.w13_weight_scale,
             w2_scale=layer.w2_weight_scale,
-            expert_mask=layer.dispatcher.expert_mask_gpu,
+            expert_mask=get_aiter_expert_mask(layer),
         )
         return self.runner.run(dispatch_output, quant_info)

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
@@ -187,7 +187,7 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
 
         self.moe_runner_config = moe_runner_config
         moe_runner_backend = get_moe_runner_backend()
-        if moe_runner_backend.is_auto() and get_moe_a2a_backend().is_none():
+        if moe_runner_backend.is_auto() and get_moe_a2a_backend().supports_aiter():
             moe_runner_backend = MoeRunnerBackend.AITER
 
         if moe_runner_backend.is_aiter():
@@ -204,6 +204,7 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
         from sglang.srt.layers.moe.moe_runner.aiter import (
             AiterMoeQuantInfo,
             AiterQuantType,
+            get_aiter_expert_mask,
         )
 
         if hasattr(torch, "float4_e2m1fn_x2"):
@@ -223,6 +224,6 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
             quant_type=AiterQuantType.PER_1X32,
             w13_scale=layer.w13_weight_scale,
             w2_scale=layer.w2_weight_scale,
-            expert_mask=layer.dispatcher.expert_mask_gpu,
+            expert_mask=get_aiter_expert_mask(layer),
         )
         return self.runner.run(dispatch_output, quant_info)

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
@@ -187,8 +187,7 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
 
         self.moe_runner_config = moe_runner_config
         moe_runner_backend = get_moe_runner_backend()
-        if moe_runner_backend.is_auto() and not get_moe_a2a_backend().is_mori():
-            # mori bypasses self.runner via MoriEPMoE.run_moe_core.
+        if moe_runner_backend.is_auto() and get_moe_a2a_backend().is_none():
             moe_runner_backend = MoeRunnerBackend.AITER
 
         if moe_runner_backend.is_aiter():

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
@@ -186,15 +186,7 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
         )
 
         self.moe_runner_config = moe_runner_config
-        moe_runner_backend = get_moe_runner_backend()
-        if moe_runner_backend.is_auto() and get_moe_a2a_backend().is_none():
-            moe_runner_backend = MoeRunnerBackend.AITER
-
-        if moe_runner_backend.is_aiter():
-            self.runner = MoeRunner(moe_runner_backend, moe_runner_config)
-        else:
-            # TODO(cwan): refactor other backends
-            pass
+        self.runner = MoeRunner(MoeRunnerBackend.AITER, moe_runner_config)
 
     def apply_weights(
         self,

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
@@ -204,7 +204,6 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
         from sglang.srt.layers.moe.moe_runner.aiter import (
             AiterMoeQuantInfo,
             AiterQuantType,
-            get_aiter_expert_mask,
         )
 
         if hasattr(torch, "float4_e2m1fn_x2"):
@@ -224,6 +223,6 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
             quant_type=AiterQuantType.PER_1X32,
             w13_scale=layer.w13_weight_scale,
             w2_scale=layer.w2_weight_scale,
-            expert_mask=get_aiter_expert_mask(layer),
+            expert_mask=layer.dispatcher.expert_mask_gpu,
         )
         return self.runner.run(dispatch_output, quant_info)

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
@@ -186,7 +186,16 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
         )
 
         self.moe_runner_config = moe_runner_config
-        self.runner = MoeRunner(MoeRunnerBackend.AITER, moe_runner_config)
+        moe_runner_backend = get_moe_runner_backend()
+        if moe_runner_backend.is_auto() and not get_moe_a2a_backend().is_mori():
+            # mori bypasses self.runner via MoriEPMoE.run_moe_core.
+            moe_runner_backend = MoeRunnerBackend.AITER
+
+        if moe_runner_backend.is_aiter():
+            self.runner = MoeRunner(moe_runner_backend, moe_runner_config)
+        else:
+            # TODO(cwan): refactor other backends
+            pass
 
     def apply_weights(
         self,

--- a/python/sglang/srt/layers/quantization/quark_int4fp8_moe.py
+++ b/python/sglang/srt/layers/quantization/quark_int4fp8_moe.py
@@ -410,7 +410,7 @@ class QuarkInt4Fp8MoEMethod(FusedMoEMethodBase):
 
         self.moe_runner_config = moe_runner_config
         moe_runner_backend = get_moe_runner_backend()
-        if moe_runner_backend.is_auto() and get_moe_a2a_backend().is_none():
+        if moe_runner_backend.is_auto() and get_moe_a2a_backend().supports_aiter():
             moe_runner_backend = MoeRunnerBackend.AITER
 
         if moe_runner_backend.is_aiter():

--- a/python/sglang/srt/layers/quantization/quark_int4fp8_moe.py
+++ b/python/sglang/srt/layers/quantization/quark_int4fp8_moe.py
@@ -410,8 +410,7 @@ class QuarkInt4Fp8MoEMethod(FusedMoEMethodBase):
 
         self.moe_runner_config = moe_runner_config
         moe_runner_backend = get_moe_runner_backend()
-        if moe_runner_backend.is_auto() and not get_moe_a2a_backend().is_mori():
-            # mori bypasses self.runner via MoriEPMoE.run_moe_core.
+        if moe_runner_backend.is_auto() and get_moe_a2a_backend().is_none():
             moe_runner_backend = MoeRunnerBackend.AITER
 
         if moe_runner_backend.is_aiter():

--- a/python/sglang/srt/layers/quantization/quark_int4fp8_moe.py
+++ b/python/sglang/srt/layers/quantization/quark_int4fp8_moe.py
@@ -409,15 +409,7 @@ class QuarkInt4Fp8MoEMethod(FusedMoEMethodBase):
         )
 
         self.moe_runner_config = moe_runner_config
-        moe_runner_backend = get_moe_runner_backend()
-        if moe_runner_backend.is_auto() and get_moe_a2a_backend().is_none():
-            moe_runner_backend = MoeRunnerBackend.AITER
-
-        if moe_runner_backend.is_aiter():
-            self.runner = MoeRunner(moe_runner_backend, moe_runner_config)
-        else:
-            # TODO(cwan): refactor other backends
-            pass
+        self.runner = MoeRunner(MoeRunnerBackend.AITER, moe_runner_config)
 
     def apply(
         self,

--- a/python/sglang/srt/layers/quantization/quark_int4fp8_moe.py
+++ b/python/sglang/srt/layers/quantization/quark_int4fp8_moe.py
@@ -409,7 +409,16 @@ class QuarkInt4Fp8MoEMethod(FusedMoEMethodBase):
         )
 
         self.moe_runner_config = moe_runner_config
-        self.runner = MoeRunner(MoeRunnerBackend.AITER, moe_runner_config)
+        moe_runner_backend = get_moe_runner_backend()
+        if moe_runner_backend.is_auto() and not get_moe_a2a_backend().is_mori():
+            # mori bypasses self.runner via MoriEPMoE.run_moe_core.
+            moe_runner_backend = MoeRunnerBackend.AITER
+
+        if moe_runner_backend.is_aiter():
+            self.runner = MoeRunner(moe_runner_backend, moe_runner_config)
+        else:
+            # TODO(cwan): refactor other backends
+            pass
 
     def apply(
         self,

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -390,7 +390,14 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
 
         # Separate runner so CK-shape errors fall back to self.runner on every call.
         self._aiter_runner: Optional[MoeRunner] = None
-        if _use_aiter and get_moe_runner_backend().is_auto():
+        if (
+            _use_aiter
+            and (
+                get_moe_runner_backend().is_auto()
+                or get_moe_runner_backend().is_aiter()
+            )
+            and get_moe_a2a_backend().is_none()
+        ):
             self._aiter_runner = MoeRunner(MoeRunnerBackend.AITER, moe_runner_config)
 
     @property
@@ -489,7 +496,6 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
                         w13_weight=layer.w13_weight,
                         w2_weight=layer.w2_weight,
                         expert_mask=layer.dispatcher.expert_mask_gpu,
-                        apply_router_weight_on_input_pre_scale=True,
                     )
                     return self._aiter_runner.run(dispatch_output, quant_info)
                 except RuntimeError as e:

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -491,14 +491,13 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
             if self._aiter_runner is not None:
                 from sglang.srt.layers.moe.moe_runner.aiter import (
                     AiterMoeQuantInfo,
-                    get_aiter_expert_mask,
                 )
 
                 try:
                     quant_info = AiterMoeQuantInfo(
                         w13_weight=layer.w13_weight,
                         w2_weight=layer.w2_weight,
-                        expert_mask=get_aiter_expert_mask(layer),
+                        expert_mask=layer.dispatcher.expert_mask_gpu,
                     )
                     return self._aiter_runner.run(dispatch_output, quant_info)
                 except RuntimeError as e:

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -390,14 +390,7 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
 
         # Separate runner so CK-shape errors fall back to self.runner on every call.
         self._aiter_runner: Optional[MoeRunner] = None
-        if (
-            _use_aiter
-            and (
-                get_moe_runner_backend().is_auto()
-                or get_moe_runner_backend().is_aiter()
-            )
-            and get_moe_a2a_backend().is_none()
-        ):
+        if _use_aiter and get_moe_runner_backend().is_auto():
             self._aiter_runner = MoeRunner(MoeRunnerBackend.AITER, moe_runner_config)
 
     @property
@@ -496,6 +489,7 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
                         w13_weight=layer.w13_weight,
                         w2_weight=layer.w2_weight,
                         expert_mask=layer.dispatcher.expert_mask_gpu,
+                        apply_router_weight_on_input_pre_scale=True,
                     )
                     return self._aiter_runner.run(dispatch_output, quant_info)
                 except RuntimeError as e:

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -396,7 +396,7 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
                 get_moe_runner_backend().is_auto()
                 or get_moe_runner_backend().is_aiter()
             )
-            and get_moe_a2a_backend().is_none()
+            and get_moe_a2a_backend().supports_aiter()
         ):
             self._aiter_runner = MoeRunner(MoeRunnerBackend.AITER, moe_runner_config)
 
@@ -489,13 +489,16 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
             return self.runner.run(dispatch_output, quant_info)
         else:
             if self._aiter_runner is not None:
-                from sglang.srt.layers.moe.moe_runner.aiter import AiterMoeQuantInfo
+                from sglang.srt.layers.moe.moe_runner.aiter import (
+                    AiterMoeQuantInfo,
+                    get_aiter_expert_mask,
+                )
 
                 try:
                     quant_info = AiterMoeQuantInfo(
                         w13_weight=layer.w13_weight,
                         w2_weight=layer.w2_weight,
-                        expert_mask=layer.dispatcher.expert_mask_gpu,
+                        expert_mask=get_aiter_expert_mask(layer),
                     )
                     return self._aiter_runner.run(dispatch_output, quant_info)
                 except RuntimeError as e:


### PR DESCRIPTION
<!-- Stacked on top of #23597 (cheng/refactor/aiter-moe-runner). Merge that PR first. -->

## Motivation

Follow-up to the AITER MoE runner refactor in #23597. After that PR, every quant method (FP8, MXFP4, Quark W4A4 / INT4-FP8, Compressed-Tensors W8A8 FP8, Unquant) routes ``aiter.fused_moe`` through ``MoeRunner`` for the standard ``none`` a2a backend. The two remaining direct ``aiter.fused_moe`` call sites in ``ep_moe/layer.py`` — ``DeepEPMoE.forward_aiter`` and ``MoriEPMoE.run_moe_core`` — were carved out as separate roadmap items. This PR finishes the unification:

- Both EP layers now go through ``self.quant_method.apply -> self.runner.run`` with the AITER backend.
- ``MoriEPMoE`` is fully deprecated; mori is just another a2a backend that ``DeepEPMoE`` handles.
- The AITER backend uses the standard ``MoeRunner`` ``pre_permute -> runner_core -> post_permute`` pipeline (matches deep_gemm / triton_kernels / triton), instead of the per-(a2a, runner) fused-func registry that #23597 introduced.

The result: one ``AiterRunnerCore`` driving every ``aiter.fused_moe`` call in the codebase, regardless of a2a backend.

## Modifications

### ``moe_runner/aiter.py``: pre/post-permute pipeline

- ``AiterRunnerCore`` (a real ``MoeRunnerCore`` subclass) drives ``aiter.fused_moe``. ``MoeRunner.__init__`` now constructs it instead of leaving ``runner_core=None`` and relying on a fused func.
- ``AiterRunnerInput`` / ``AiterRunnerOutput`` dataclasses carry the runner IO between permute steps, including the mori-only ``num_local_tokens`` / ``output_dtype`` / per-token ``a1_scale`` plus an effective ``quant_type`` resolved by pre_permute.
- ``register_pre_permute(\"standard\", \"aiter\")`` — for the standard FusedMoE path. Handles the ``apply_router_weight_on_input`` Python pre-scale.
- ``register_pre_permute(\"deepep_normal\", \"aiter\")`` and ``register_pre_permute(\"deepep_ll\", \"aiter\")`` share one body that:
  - Detects mori dispatch outputs by attribute (``hasattr(dispatch_output, \"origin_topk_ids\")``) — mori reuses the DEEPEP_NORMAL/DEEPEP_LL formats so a single permute key serves both.
  - Mori-only: truncates by ``SGLANG_MORI_MOE_MAX_INPUT_TOKENS``, runs ``upscale`` / ``upscale_mxfp4`` for the W4A4↔FP8 / FP8↔FP4 dispatch combos AITER doesn't natively kernel, and resolves the effective ``quant_type``.
  - DeepEP/Mooncake/Nixl: rewrites the invalid ``-1`` topk_ids to the sink slot at ``num_local_experts``.
  - Stashes the topk_ids/topk_weights that combine needs (``origin_topk_*`` for mori, raw for deepep) plus an ``aiter_combine_is_mori`` flag in ``running_state``.
- ``register_post_permute(\"aiter\", \"standard\"/\"deepep_normal\"/\"deepep_ll\")`` wraps the runner output in the right ``CombineInput`` class, picking ``MoriEP*CombineInput`` vs ``DeepEP*CombineInput`` from the running_state flag.
- The ``("none","aiter")``, ``("deepep","aiter")``, ``("mooncake","aiter")``, ``("nixl","aiter")``, ``("mori","aiter")`` fused-func registrations from #23597 are removed.

### ``ep_moe/layer.py``: drop ``MoriEPMoE`` and ``forward_aiter``

- ``MoriEPMoE`` deleted. ``get_moe_impl_class`` returns ``DeepEPMoE`` for the mori a2a too.
- ``DeepEPMoE._init_aiter_expert_mask`` consolidates the two AITER expert_mask shapes:
  - mori: ``(num_experts,)`` global mask + the ``SGLANG_MORI_MOE_MAX_INPUT_TOKENS`` env hook.
  - deepep / mooncake / nixl: ``(num_local_experts + 1,)`` with the last slot reserved as the sink for invalid ``-1`` topk_ids that the AITER pre_permute reroutes.
- ``DeepEPMoE.forward_impl`` adds a ``hidden_states[:num_tokens]`` slice when a2a is mori, replacing the slice that ``MoriEPMoE.forward`` used to do.
- ``DeepEPMoE.run_moe_core`` short-circuits to ``super().run_moe_core(...)`` (i.e., ``self.quant_method.apply``) when ``_use_aiter``, dropping the ``forward_aiter`` branch.
- ``forward_aiter`` is removed.

### ``moe_runner/runner.py``: construct ``AiterRunnerCore``

- ``MoeRunner.__init__`` now does ``self.runner_core = AiterRunnerCore(config)`` for ``runner_backend.is_aiter()``, which lets the standard pre/post-permute dispatch path take over.

## Accuracy Tests

Needs validation on AMD Instinct hardware (MI300X / MI325X / MI350X). Suggested coverage:

- ``SGLANG_USE_AITER=1`` FP8 block-quant DeepSeek V3 with DeepEP normal + LL.
- Mori a2a with FP8 block-quant DeepSeek V3 (covers the FP8 dispatch upscale / per_128x128 path).
- Quark W4A4 MXFP4 with mori (covers W4A4 + FP8 dispatch upscale).
- MXFP4 GPT-OSS with standard a2a (covers the ``replace(config, activation=\"swiglu\")`` runner override).
- Mooncake EP + FP8 block-quant.
- Unquant Gemma4 with HIP+aiter standard a2a (CK fallback path).

No non-HIP paths are touched.

## Speed Tests and Profiling

No perf changes expected — the runner pipeline still funnels into the same ``aiter.fused_moe`` call with the same arguments. The extra Python work per MoE call is one ``AiterRunnerInput`` dataclass plus the pre/post-permute lookup (already paid by the deep_gemm and triton_kernels backends), all outside the kernel. Want a before/after MI300X bench_serving pass on FP8 DeepSeek V3 (DeepEP) and a Quark W4A4 model (mori) before merge.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include ``/tag-and-rerun-ci``, ``/tag-run-ci-label``, ``/rerun-failed-ci``
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->[Run #25955053141](https://github.com/sgl-project/sglang/actions/runs/25955053141)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** — add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->