### PR TITLE
Enable `flashinfer::trtllm_allreduce_fusion` with PDL

### DIFF
--- a/python/sglang/srt/layers/flashinfer_comm_fusion.py
+++ b/python/sglang/srt/layers/flashinfer_comm_fusion.py
@@ -490,7 +490,7 @@ def flashinfer_allreduce_residual_rmsnorm(
         workspace=workspace_manager.workspace,
         pattern=_flashinfer_comm.AllReduceFusionPattern.kARResidualRMSNorm,
         launch_with_pdl=True,
-        trigger_completion_at_end=False,
+        trigger_completion_at_end=trigger_completion_at_end,
         residual_out=residual_out,
         norm_out=norm_out,
         residual_in=residual,

--- a/python/sglang/srt/layers/flashinfer_comm_fusion.py
+++ b/python/sglang/srt/layers/flashinfer_comm_fusion.py
@@ -490,6 +490,7 @@ def flashinfer_allreduce_residual_rmsnorm(
         workspace=workspace_manager.workspace,
         pattern=_flashinfer_comm.AllReduceFusionPattern.kARResidualRMSNorm,
         launch_with_pdl=True,
+        trigger_completion_at_end=False,
         residual_out=residual_out,
         norm_out=norm_out,
         residual_in=residual,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

For BS = 1:
<img width="1458" height="486" alt="Screenshot 2026-04-26 at 9 15 32 AM" src="https://github.com/user-attachments/assets/e1e31ec1-c409-4ff1-839f-8a92b3020e8d" />

With PDL:
<img width="1460" height="505" alt="Screenshot 2026-04-26 at 9 16 46 AM" src="https://github.com/user-attachments/assets/24349f73-e9d5-4b1e-a00b-e662003b881e" />

Thus, the latency of AR can be (nearly) fully hidden here.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

With regards to read after write hazards in the dependent kernel, it will only happen when:

PDL is issued without `griddepcontrol.wait`, which never is in the case in: `fp4_quantize` in all backends in Flashinfer, and `fused_a_gemm`. If there is no PDL signal (like in per token quant 8bit v2), then it will fully serialize like before (for ex, see the cvt_fp16_to_fp4 in the `sgl-kernel` one, which does not issue either PDL or GDC await. However, when we switch to https://github.com/sgl-project/sglang/pull/23745#issuecomment-4321195903 for quantize, it will work properly.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

```
python3 -m sglang.launch_server \
  --model-path nvidia/DeepSeek-V3.2-NVFP4 \
  --tp 4 \
  --ep 4 \
  --quantization modelopt_fp4 \
  --tool-call-parser deepseekv32 \
  --reasoning-parser deepseek-v3 \
  --port 30020 \
  --cuda-graph-bs 1 2 4 8 16 32 64 128 160 192 224 256 288 320 352 384 416 448 480 512 \
  --max-running-requests 512
```

```
python3 -m sglang.test.run_eval --port 30020 --eval-name gpqa --num-examples 198 --max-tokens 128000 --repeat 8 --top-p 0.95 --temperature 1.0 --thinking-mode deepseek-v3
```

```
Repeat: 8, mean: 0.834██████████████████████████████████████████████████████████████████████████████████████████████████████████████▌       | 187/198 [25:35<00:50,  4.55s/it]
Scores: ['0.813', '0.859', '0.869', '0.813', '0.869', '0.798', '0.843', '0.808']
```

## Speed Tests and Profiling

109 -> 111.20 tps