### PR TITLE
Fix DSv4 metadata chunking for mixed long prefill

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -504,6 +504,9 @@ class Envs:
     SGLANG_OPT_DG_PAGED_MQA_LOGITS_CHUNK_SIZE = EnvInt(-1)
     SGLANG_DSV4_FIX_ATTN_PADDING = EnvBool(True)  # verified in journal 2026-04-21-017
     SGLANG_DSV4_FIX_TP_ATTN_A2A_SCATTER = EnvBool(True)
+    # Opt-in workaround for FlashMLA metadata kernels whose dynamic shared
+    # memory scales with flattened DSv4 prefill query rows.
+    SGLANG_DSV4_FLASHMLA_PREFILL_CHUNK_SIZE = EnvInt(0)
     SGLANG_DEBUG_SANITY_CHECK_CONFIG = EnvBool(False)
     SGLANG_DEBUG_HACK_CP_ASSERT_PURE_EXTEND = EnvBool(False)
     SGLANG_DEBUG_HACK_CP_CHECK_RANK_CONSISTENCY = EnvBool(False)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -504,9 +504,10 @@ class Envs:
     SGLANG_OPT_DG_PAGED_MQA_LOGITS_CHUNK_SIZE = EnvInt(-1)
     SGLANG_DSV4_FIX_ATTN_PADDING = EnvBool(True)  # verified in journal 2026-04-21-017
     SGLANG_DSV4_FIX_TP_ATTN_A2A_SCATTER = EnvBool(True)
-    # Opt-in workaround for FlashMLA metadata kernels whose dynamic shared
-    # memory scales with flattened DSv4 prefill query rows.
-    SGLANG_DSV4_FLASHMLA_PREFILL_CHUNK_SIZE = EnvInt(0)
+    # DSv4 FlashMLA and DeepGEMM metadata kernels use shared memory that scales
+    # with flattened prefill query rows. Keep internal prefill work units under
+    # the validated GB200 metadata-kernel limit.
+    SGLANG_DSV4_PREFILL_METADATA_CHUNK_SIZE = EnvInt(4096)
     SGLANG_DEBUG_SANITY_CHECK_CONFIG = EnvBool(False)
     SGLANG_DEBUG_HACK_CP_ASSERT_PURE_EXTEND = EnvBool(False)
     SGLANG_DEBUG_HACK_CP_CHECK_RANK_CONSISTENCY = EnvBool(False)

--- a/python/sglang/srt/layers/attention/compressed/indexer.py
+++ b/python/sglang/srt/layers/attention/compressed/indexer.py
@@ -379,7 +379,10 @@ class C4IndexerBackend:
         elif envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.get():
             fn = fp8_paged_mqa_logits_torch
         else:
-            if envs.SGLANG_OPT_DG_PAGED_MQA_LOGITS_CHUNK_SIZE.get() != -1:
+            if (
+                envs.SGLANG_OPT_DG_PAGED_MQA_LOGITS_CHUNK_SIZE.get() != -1
+                or not isinstance(indexer_metadata.deep_gemm_metadata, torch.Tensor)
+            ):
                 from sglang.srt.layers.deep_gemm_wrapper.paged_mqa_logits import (
                     fp8_paged_mqa_logits_chunked as fn,
                 )

--- a/python/sglang/srt/layers/attention/compressed/metadata.py
+++ b/python/sglang/srt/layers/attention/compressed/metadata.py
@@ -131,6 +131,14 @@ class PagedIndexerMetadata(IndexerMetadata):
                 from sglang.srt.layers.deep_gemm_wrapper.paged_mqa_logits import (
                     get_paged_mqa_logits_metadata_chunked as get_paged_mqa_logits_metadata,
                 )
+            elif (
+                envs.SGLANG_DSV4_PREFILL_METADATA_CHUNK_SIZE.get() > 0
+                and self.c4_seq_lens.shape[0]
+                > envs.SGLANG_DSV4_PREFILL_METADATA_CHUNK_SIZE.get()
+            ):
+                from sglang.srt.layers.deep_gemm_wrapper.paged_mqa_logits import (
+                    get_paged_mqa_logits_metadata_chunked as get_paged_mqa_logits_metadata,
+                )
             elif envs.SGLANG_OPT_USE_JIT_INDEXER_METADATA.get():
                 from sglang.jit_kernel.deepseek_v4 import get_paged_mqa_logits_metadata
             else:
@@ -145,7 +153,7 @@ class PagedIndexerMetadata(IndexerMetadata):
                 deep_gemm.get_num_sms(),
             )
 
-            if envs.SGLANG_OPT_DG_PAGED_MQA_LOGITS_CHUNK_SIZE.get() != -1:
+            if not isinstance(self.deep_gemm_metadata, torch.Tensor):
                 pass
             else:
                 assert isinstance(self.deep_gemm_metadata, torch.Tensor)

--- a/python/sglang/srt/layers/attention/compressed/metadata.py
+++ b/python/sglang/srt/layers/attention/compressed/metadata.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field, fields
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple
 
 import torch
 
@@ -118,6 +118,7 @@ class PagedIndexerMetadata(IndexerMetadata):
     page_size: int
     page_table: torch.Tensor
     c4_seq_lens: torch.Tensor
+    chunk_ranges: Optional[List[Tuple[int, int]]] = None
     deep_gemm_metadata: Any = field(init=False, repr=False)
     topk_metadata: torch.Tensor = field(init=False, repr=False)
 
@@ -127,10 +128,13 @@ class PagedIndexerMetadata(IndexerMetadata):
         else:
             import deep_gemm
 
+            use_chunked_metadata = False
             if envs.SGLANG_OPT_DG_PAGED_MQA_LOGITS_CHUNK_SIZE.get() != -1:
                 from sglang.srt.layers.deep_gemm_wrapper.paged_mqa_logits import (
                     get_paged_mqa_logits_metadata_chunked as get_paged_mqa_logits_metadata,
                 )
+
+                use_chunked_metadata = True
             elif (
                 envs.SGLANG_DSV4_PREFILL_METADATA_CHUNK_SIZE.get() > 0
                 and self.c4_seq_lens.shape[0]
@@ -139,6 +143,8 @@ class PagedIndexerMetadata(IndexerMetadata):
                 from sglang.srt.layers.deep_gemm_wrapper.paged_mqa_logits import (
                     get_paged_mqa_logits_metadata_chunked as get_paged_mqa_logits_metadata,
                 )
+
+                use_chunked_metadata = True
             elif envs.SGLANG_OPT_USE_JIT_INDEXER_METADATA.get():
                 from sglang.jit_kernel.deepseek_v4 import get_paged_mqa_logits_metadata
             else:
@@ -147,11 +153,19 @@ class PagedIndexerMetadata(IndexerMetadata):
             _c4 = self.c4_seq_lens.to(torch.int32)
             if _c4.dim() == 1:
                 _c4 = _c4.unsqueeze(-1)
-            self.deep_gemm_metadata = get_paged_mqa_logits_metadata(
-                _c4,
-                self.c4_page_size,
-                deep_gemm.get_num_sms(),
-            )
+            if use_chunked_metadata:
+                self.deep_gemm_metadata = get_paged_mqa_logits_metadata(
+                    _c4,
+                    self.c4_page_size,
+                    deep_gemm.get_num_sms(),
+                    self.chunk_ranges,
+                )
+            else:
+                self.deep_gemm_metadata = get_paged_mqa_logits_metadata(
+                    _c4,
+                    self.c4_page_size,
+                    deep_gemm.get_num_sms(),
+                )
 
             if not isinstance(self.deep_gemm_metadata, torch.Tensor):
                 pass
@@ -188,7 +202,7 @@ class PagedIndexerMetadata(IndexerMetadata):
         copy_metadata(
             src=other,
             dst=self,
-            check_eq_fields=["page_size"],
+            check_eq_fields=["page_size", "chunk_ranges"],
             copy_fields=copy_fields,
         )
 

--- a/python/sglang/srt/layers/attention/compressed/metadata.py
+++ b/python/sglang/srt/layers/attention/compressed/metadata.py
@@ -167,11 +167,6 @@ class PagedIndexerMetadata(IndexerMetadata):
                     deep_gemm.get_num_sms(),
                 )
 
-            if not isinstance(self.deep_gemm_metadata, torch.Tensor):
-                pass
-            else:
-                assert isinstance(self.deep_gemm_metadata, torch.Tensor)
-
         from sglang.jit_kernel.deepseek_v4 import plan_topk_v2
 
         if envs.SGLANG_OPT_USE_TOPK_V2.get():

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_radix.py
@@ -150,7 +150,7 @@ def _flash_mla_with_optional_prefill_chunking(
     runner: Callable = flash_mla_with_kvcache_entrypoint,
 ) -> torch.Tensor:
     q = input_dict["q"]
-    chunk_size = envs.SGLANG_DSV4_FLASHMLA_PREFILL_CHUNK_SIZE.get()
+    chunk_size = envs.SGLANG_DSV4_PREFILL_METADATA_CHUNK_SIZE.get()
     if (
         chunk_size <= 0
         or not forward_mode.is_extend()
@@ -167,6 +167,7 @@ def _flash_mla_with_optional_prefill_chunking(
             end=min(start + chunk_size, total_rows),
             total_rows=total_rows,
         )
+        chunk["tile_scheduler_metadata"] = _create_flashmla_metadata()
         outputs.append(runner(**chunk, backend=backend)[0])
     return torch.cat(outputs, dim=0)
 

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_radix.py
@@ -32,6 +32,9 @@ from sglang.srt.layers.attention.compressed.metadata import (
     PagedIndexerMetadata,
     maybe_copy_inplace,
 )
+from sglang.srt.layers.deep_gemm_wrapper.paged_mqa_logits import (
+    chunk_ranges_from_seq_lens,
+)
 from sglang.srt.layers.attention.debug_flash_mla_adapter import (
     flash_mla_with_kvcache_entrypoint,
 )
@@ -136,11 +139,38 @@ _FLASHMLA_ROW_ARGS = (
 
 def _slice_flashmla_rows(input_dict: Dict, start: int, end: int, total_rows: int):
     chunk = dict(input_dict)
+    chunk.pop("_chunk_ranges", None)
     for key in _FLASHMLA_ROW_ARGS:
         value = chunk.get(key)
         if isinstance(value, torch.Tensor) and value.shape[0] == total_rows:
             chunk[key] = value[start:end]
     return chunk
+
+
+def _sequence_chunk_ranges(
+    seq_lens: Optional[torch.Tensor], total_rows: int, chunk_size: int
+) -> List[Tuple[int, int]]:
+    if seq_lens is None or seq_lens.shape[0] != total_rows:
+        return [(0, total_rows)]
+
+    lens = seq_lens.detach().flatten().to("cpu")
+    starts = [0]
+    for idx in range(1, total_rows):
+        if int(lens[idx].item()) < int(lens[idx - 1].item()):
+            starts.append(idx)
+    starts.append(total_rows)
+
+    ranges: List[Tuple[int, int]] = []
+    current_start = starts[0]
+    current_end = starts[1]
+    for seq_start, seq_end in zip(starts[1:-1], starts[2:]):
+        if current_end - current_start + seq_end - seq_start <= chunk_size:
+            current_end = seq_end
+        else:
+            ranges.append((current_start, current_end))
+            current_start, current_end = seq_start, seq_end
+    ranges.append((current_start, current_end))
+    return ranges
 
 
 def _flash_mla_with_optional_prefill_chunking(
@@ -156,15 +186,25 @@ def _flash_mla_with_optional_prefill_chunking(
         or not forward_mode.is_extend()
         or q.shape[0] <= chunk_size
     ):
+        input_dict = dict(input_dict)
+        input_dict.pop("_chunk_ranges", None)
         return runner(**input_dict, backend=backend)[0]
 
     outputs = []
     total_rows = q.shape[0]
-    for start in range(0, total_rows, chunk_size):
+    chunk_ranges = input_dict.get("_chunk_ranges") or _sequence_chunk_ranges(
+        input_dict.get("topk_length"), total_rows, chunk_size
+    )
+    if chunk_ranges == [(0, total_rows)]:
+        input_dict = dict(input_dict)
+        input_dict.pop("_chunk_ranges", None)
+        return runner(**input_dict, backend=backend)[0]
+
+    for start, end in chunk_ranges:
         chunk = _slice_flashmla_rows(
             input_dict=input_dict,
             start=start,
-            end=min(start + chunk_size, total_rows),
+            end=end,
             total_rows=total_rows,
         )
         chunk["tile_scheduler_metadata"] = _create_flashmla_metadata()
@@ -197,6 +237,7 @@ class DSV4AttnMetadataRadix:
     c128_positions: Optional[torch.Tensor] = None
     c128_page_indices: Optional[torch.Tensor] = None
     c128_topk_lengths_clamp1: Optional[torch.Tensor] = None
+    chunk_ranges: Optional[List[Tuple[int, int]]] = None
 
     c1_flashmla_metadata: FlashMLASchedMeta = field(init=False, repr=False)
     c4_flashmla_metadata: FlashMLASchedMeta = field(init=False, repr=False)
@@ -247,6 +288,7 @@ class DSV4AttnMetadataRadix:
                 "c1_flashmla_metadata",
                 "c4_flashmla_metadata",
                 "c128_flashmla_metadata",
+                "chunk_ranges",
             ],
         )
 
@@ -453,11 +495,16 @@ class DeepseekV4BackendRadix(AttentionBackend, C4IndexerBackend, CompressorBacke
         pin_tensor = torch.tensor(x, dtype=torch.int32, pin_memory=True)
         return pin_tensor.to(self.device, non_blocking=True)
 
-    def init_forward_metadata_indexer(self, core_attn_metadata: DSV4AttnMetadataRadix):
+    def init_forward_metadata_indexer(
+        self,
+        core_attn_metadata: DSV4AttnMetadataRadix,
+        chunk_ranges: Optional[List[Tuple[int, int]]] = None,
+    ):
         return PagedIndexerMetadata(
             page_size=self.page_size,
             page_table=core_attn_metadata.page_table,
             c4_seq_lens=core_attn_metadata.c4_topk_lengths_raw,
+            chunk_ranges=chunk_ranges,
         )
 
     def init_forward_metadata_decode(
@@ -534,8 +581,12 @@ class DeepseekV4BackendRadix(AttentionBackend, C4IndexerBackend, CompressorBacke
             need_compress=need_compress,
             is_prefill=True,
         )
+        chunk_ranges = chunk_ranges_from_seq_lens(
+            extend_seq_lens_cpu, envs.SGLANG_DSV4_PREFILL_METADATA_CHUNK_SIZE.get()
+        )
+        core_attn_metadata.chunk_ranges = chunk_ranges
         indexer_metadata = (
-            self.init_forward_metadata_indexer(core_attn_metadata)
+            self.init_forward_metadata_indexer(core_attn_metadata, chunk_ranges)
             if need_compress
             else None
         )
@@ -1148,6 +1199,7 @@ class DeepseekV4BackendRadix(AttentionBackend, C4IndexerBackend, CompressorBacke
                 extra_k_cache=extra_k_cache,
                 extra_indices_in_kvcache=extra_indices,
                 extra_topk_length=extra_topk_lengths,
+                _chunk_ranges=core_attn_metadata.chunk_ranges,
             )
 
             backend = envs.SGLANG_HACK_FLASHMLA_BACKEND.get()

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_radix.py
@@ -154,11 +154,8 @@ def _sequence_chunk_ranges(
         return [(0, total_rows)]
 
     lens = seq_lens.detach().flatten().to("cpu")
-    starts = [0]
-    for idx in range(1, total_rows):
-        if int(lens[idx].item()) < int(lens[idx - 1].item()):
-            starts.append(idx)
-    starts.append(total_rows)
+    boundary_indices = torch.nonzero(lens[1:] < lens[:-1], as_tuple=False).flatten()
+    starts = [0, *boundary_indices.add(1).tolist(), total_rows]
 
     ranges: List[Tuple[int, int]] = []
     current_start = starts[0]

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_radix.py
@@ -125,6 +125,52 @@ def _create_dummy_paged_compress_data(compress_ratio: int):
     return None
 
 
+_FLASHMLA_ROW_ARGS = (
+    "q",
+    "indices",
+    "topk_length",
+    "extra_indices_in_kvcache",
+    "extra_topk_length",
+)
+
+
+def _slice_flashmla_rows(input_dict: Dict, start: int, end: int, total_rows: int):
+    chunk = dict(input_dict)
+    for key in _FLASHMLA_ROW_ARGS:
+        value = chunk.get(key)
+        if isinstance(value, torch.Tensor) and value.shape[0] == total_rows:
+            chunk[key] = value[start:end]
+    return chunk
+
+
+def _flash_mla_with_optional_prefill_chunking(
+    input_dict: Dict,
+    backend: str,
+    forward_mode: ForwardMode,
+    runner: Callable = flash_mla_with_kvcache_entrypoint,
+) -> torch.Tensor:
+    q = input_dict["q"]
+    chunk_size = envs.SGLANG_DSV4_FLASHMLA_PREFILL_CHUNK_SIZE.get()
+    if (
+        chunk_size <= 0
+        or not forward_mode.is_extend()
+        or q.shape[0] <= chunk_size
+    ):
+        return runner(**input_dict, backend=backend)[0]
+
+    outputs = []
+    total_rows = q.shape[0]
+    for start in range(0, total_rows, chunk_size):
+        chunk = _slice_flashmla_rows(
+            input_dict=input_dict,
+            start=start,
+            end=min(start + chunk_size, total_rows),
+            total_rows=total_rows,
+        )
+        outputs.append(runner(**chunk, backend=backend)[0])
+    return torch.cat(outputs, dim=0)
+
+
 @dataclass
 class DSV4AttnMetadataRadix:
     page_size: int
@@ -1104,7 +1150,11 @@ class DeepseekV4BackendRadix(AttentionBackend, C4IndexerBackend, CompressorBacke
             )
 
             backend = envs.SGLANG_HACK_FLASHMLA_BACKEND.get()
-            o = flash_mla_with_kvcache_entrypoint(**input_dict, backend=backend)[0]
+            o = _flash_mla_with_optional_prefill_chunking(
+                input_dict=input_dict,
+                backend=backend,
+                forward_mode=forward_batch.forward_mode,
+            )
 
             o = o.squeeze(1)
             return o

--- a/python/sglang/srt/layers/deep_gemm_wrapper/paged_mqa_logits.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/paged_mqa_logits.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Union
+from typing import List, Optional, Tuple, Union
 
 import deep_gemm
 import torch
@@ -22,10 +22,56 @@ class _PagedMqaLogitsMetadata:
         raise Exception("Not expect to be copied")
 
 
+def _sequence_chunk_ranges(
+    seq_lens: torch.Tensor,
+    batch_size: int,
+    chunk_size: int,
+) -> List[Tuple[int, int]]:
+    lens = seq_lens.detach().flatten().to("cpu")
+    starts = [0]
+    for idx in range(1, batch_size):
+        if int(lens[idx].item()) < int(lens[idx - 1].item()):
+            starts.append(idx)
+    starts.append(batch_size)
+
+    ranges: List[Tuple[int, int]] = []
+    current_start = starts[0]
+    current_end = starts[1]
+    for seq_start, seq_end in zip(starts[1:-1], starts[2:]):
+        if current_end - current_start + seq_end - seq_start <= chunk_size:
+            current_end = seq_end
+        else:
+            ranges.append((current_start, current_end))
+            current_start, current_end = seq_start, seq_end
+    ranges.append((current_start, current_end))
+    return ranges
+
+
+def chunk_ranges_from_seq_lens(
+    seq_lens: Optional[List[int]],
+    chunk_size: int,
+) -> Optional[List[Tuple[int, int]]]:
+    if seq_lens is None:
+        return None
+    ranges: List[Tuple[int, int]] = []
+    current_start = 0
+    current_end = 0
+    for seq_len in seq_lens:
+        seq_start, seq_end = current_end, current_end + int(seq_len)
+        if current_end > current_start and seq_end - current_start > chunk_size:
+            ranges.append((current_start, current_end))
+            current_start = seq_start
+        current_end = seq_end
+    if current_end > current_start:
+        ranges.append((current_start, current_end))
+    return ranges
+
+
 def get_paged_mqa_logits_metadata_chunked(
     context_lens: torch.Tensor,
     block_kv: int,
     num_sms: int,
+    chunk_ranges: Optional[List[Tuple[int, int]]] = None,
 ) -> Union[_PagedMqaLogitsMetadata, torch.Tensor]:
     chunk_size = envs.SGLANG_OPT_DG_PAGED_MQA_LOGITS_CHUNK_SIZE.get()
     if chunk_size == -1:
@@ -39,9 +85,18 @@ def get_paged_mqa_logits_metadata_chunked(
             num_sms,
         )
 
+    chunk_ranges = chunk_ranges or _sequence_chunk_ranges(
+        context_lens, batch_size, chunk_size
+    )
+    if chunk_ranges == [(0, batch_size)]:
+        return deep_gemm.get_paged_mqa_logits_metadata(
+            context_lens.unsqueeze(-1) if context_lens.dim() == 1 else context_lens,
+            block_kv,
+            num_sms,
+        )
+
     chunks: List[_PagedMqaLogitsMetadataChunk] = []
-    for start in range(0, batch_size, chunk_size):
-        end = min(start + chunk_size, batch_size)
+    for start, end in chunk_ranges:
         schedule_meta = deep_gemm.get_paged_mqa_logits_metadata(
             (
                 (context_lens[start:end]).unsqueeze(-1)

--- a/python/sglang/srt/layers/deep_gemm_wrapper/paged_mqa_logits.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/paged_mqa_logits.py
@@ -28,11 +28,8 @@ def _sequence_chunk_ranges(
     chunk_size: int,
 ) -> List[Tuple[int, int]]:
     lens = seq_lens.detach().flatten().to("cpu")
-    starts = [0]
-    for idx in range(1, batch_size):
-        if int(lens[idx].item()) < int(lens[idx - 1].item()):
-            starts.append(idx)
-    starts.append(batch_size)
+    boundary_indices = torch.nonzero(lens[1:] < lens[:-1], as_tuple=False).flatten()
+    starts = [0, *boundary_indices.add(1).tolist(), batch_size]
 
     ranges: List[Tuple[int, int]] = []
     current_start = starts[0]

--- a/python/sglang/srt/layers/deep_gemm_wrapper/paged_mqa_logits.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/paged_mqa_logits.py
@@ -28,9 +28,11 @@ def get_paged_mqa_logits_metadata_chunked(
     num_sms: int,
 ) -> Union[_PagedMqaLogitsMetadata, torch.Tensor]:
     chunk_size = envs.SGLANG_OPT_DG_PAGED_MQA_LOGITS_CHUNK_SIZE.get()
+    if chunk_size == -1:
+        chunk_size = envs.SGLANG_DSV4_PREFILL_METADATA_CHUNK_SIZE.get()
     batch_size = context_lens.shape[0]
 
-    if batch_size <= chunk_size:
+    if chunk_size <= 0 or batch_size <= chunk_size:
         return deep_gemm.get_paged_mqa_logits_metadata(
             context_lens.unsqueeze(-1) if context_lens.dim() == 1 else context_lens,
             block_kv,

--- a/test/srt/test_deepseek_v4_flashmla_chunking.py
+++ b/test/srt/test_deepseek_v4_flashmla_chunking.py
@@ -1,6 +1,7 @@
 import torch
 
 import sglang.srt.layers.attention.deepseek_v4_backend_radix as dsv4_radix
+import sglang.srt.layers.deep_gemm_wrapper.paged_mqa_logits as paged_mqa
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 
 
@@ -83,3 +84,85 @@ def test_dsv4_flashmla_chunking_is_prefill_only(monkeypatch):
     )
 
     assert calls == [10]
+
+
+def test_dsv4_paged_mqa_metadata_and_logits_chunking(monkeypatch):
+    monkeypatch.setenv("SGLANG_DSV4_PREFILL_METADATA_CHUNK_SIZE", "4")
+    metadata_calls = []
+    logits_calls = []
+
+    class FakeDeepGemm:
+        @staticmethod
+        def get_paged_mqa_logits_metadata(context_lens, block_kv, num_sms):
+            metadata_calls.append((context_lens.clone(), block_kv, num_sms))
+            return {"rows": context_lens.shape[0]}
+
+        @staticmethod
+        def fp8_paged_mqa_logits(
+            q,
+            kv_cache,
+            weights,
+            context_lens,
+            block_table,
+            schedule_meta,
+            max_context_len,
+            clean_logits,
+        ):
+            logits_calls.append(
+                {
+                    "q": q.clone(),
+                    "weights": weights.clone(),
+                    "context_lens": context_lens.clone(),
+                    "block_table": block_table.clone(),
+                    "schedule_meta": schedule_meta,
+                    "max_context_len": max_context_len,
+                    "clean_logits": clean_logits,
+                }
+            )
+            return q[:, 0, 0, :1].to(torch.float32)
+
+    monkeypatch.setattr(paged_mqa, "deep_gemm", FakeDeepGemm)
+
+    context_lens = torch.arange(10, dtype=torch.int32)
+    schedule_meta = paged_mqa.get_paged_mqa_logits_metadata_chunked(
+        context_lens=context_lens,
+        block_kv=64,
+        num_sms=132,
+    )
+
+    assert [call[0].flatten().tolist() for call in metadata_calls] == [
+        [0, 1, 2, 3],
+        [4, 5, 6, 7],
+        [8, 9],
+    ]
+    assert [chunk.schedule_meta["rows"] for chunk in schedule_meta.chunks] == [4, 4, 2]
+
+    q = torch.arange(10 * 1 * 1 * 2, dtype=torch.float32).view(10, 1, 1, 2)
+    kv_cache = torch.zeros(3, 64, 1, 132)
+    weights = torch.arange(10, dtype=torch.float32).view(10, 1)
+    block_table = torch.arange(10 * 3, dtype=torch.int32).view(10, 3)
+
+    logits = paged_mqa.fp8_paged_mqa_logits_chunked(
+        q=q,
+        kv_cache=kv_cache,
+        weights=weights,
+        context_lens=context_lens,
+        block_table=block_table,
+        schedule_meta=schedule_meta,
+        max_context_len=192,
+        clean_logits=False,
+    )
+
+    assert logits.shape == (10, 1)
+    assert torch.equal(logits.flatten(), q[:, 0, 0, 0])
+    assert [call["q"].shape[0] for call in logits_calls] == [4, 4, 2]
+    assert [call["weights"].flatten().tolist() for call in logits_calls] == [
+        [0.0, 1.0, 2.0, 3.0],
+        [4.0, 5.0, 6.0, 7.0],
+        [8.0, 9.0],
+    ]
+    assert [call["block_table"][:, 0].tolist() for call in logits_calls] == [
+        [0, 3, 6, 9],
+        [12, 15, 18, 21],
+        [24, 27],
+    ]

--- a/test/srt/test_deepseek_v4_flashmla_chunking.py
+++ b/test/srt/test_deepseek_v4_flashmla_chunking.py
@@ -35,7 +35,7 @@ def test_dsv4_flashmla_prefill_chunking_slices_row_tensors(monkeypatch):
         "q": torch.arange(10, dtype=torch.float32).view(10, 1, 1, 1),
         "k_cache": torch.zeros(3, 128, 1, 1),
         "indices": torch.arange(10 * 64, dtype=torch.int32).view(10, 1, 64),
-        "topk_length": torch.arange(10, dtype=torch.int32),
+        "topk_length": torch.tensor([1, 2, 3, 4, 1, 2, 3, 4, 1, 2], dtype=torch.int32),
         "extra_indices_in_kvcache": None,
         "extra_topk_length": None,
     }
@@ -123,7 +123,7 @@ def test_dsv4_paged_mqa_metadata_and_logits_chunking(monkeypatch):
 
     monkeypatch.setattr(paged_mqa, "deep_gemm", FakeDeepGemm)
 
-    context_lens = torch.arange(10, dtype=torch.int32)
+    context_lens = torch.tensor([1, 2, 3, 4, 1, 2, 3, 4, 1, 2], dtype=torch.int32)
     schedule_meta = paged_mqa.get_paged_mqa_logits_metadata_chunked(
         context_lens=context_lens,
         block_kv=64,
@@ -131,9 +131,9 @@ def test_dsv4_paged_mqa_metadata_and_logits_chunking(monkeypatch):
     )
 
     assert [call[0].flatten().tolist() for call in metadata_calls] == [
-        [0, 1, 2, 3],
-        [4, 5, 6, 7],
-        [8, 9],
+        [1, 2, 3, 4],
+        [1, 2, 3, 4],
+        [1, 2],
     ]
     assert [chunk.schedule_meta["rows"] for chunk in schedule_meta.chunks] == [4, 4, 2]
 

--- a/test/srt/test_deepseek_v4_flashmla_chunking.py
+++ b/test/srt/test_deepseek_v4_flashmla_chunking.py
@@ -1,0 +1,76 @@
+import torch
+
+from sglang.srt.layers.attention.deepseek_v4_backend_radix import (
+    _flash_mla_with_optional_prefill_chunking,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+
+
+def test_dsv4_flashmla_prefill_chunking_slices_row_tensors(monkeypatch):
+    monkeypatch.setenv("SGLANG_DSV4_FLASHMLA_PREFILL_CHUNK_SIZE", "4")
+
+    calls = []
+
+    def fake_runner(**kwargs):
+        calls.append(
+            {
+                "q": kwargs["q"].clone(),
+                "indices": kwargs["indices"].clone(),
+                "topk_length": kwargs["topk_length"].clone(),
+                "k_cache_shape": kwargs["k_cache"].shape,
+                "backend": kwargs["backend"],
+            }
+        )
+        return (kwargs["q"] + 1,)
+
+    input_dict = {
+        "q": torch.arange(10, dtype=torch.float32).view(10, 1, 1, 1),
+        "k_cache": torch.zeros(3, 128, 1, 1),
+        "indices": torch.arange(10 * 64, dtype=torch.int32).view(10, 1, 64),
+        "topk_length": torch.arange(10, dtype=torch.int32),
+        "extra_indices_in_kvcache": None,
+        "extra_topk_length": None,
+    }
+
+    out = _flash_mla_with_optional_prefill_chunking(
+        input_dict=input_dict,
+        backend="kernel",
+        forward_mode=ForwardMode.EXTEND,
+        runner=fake_runner,
+    )
+
+    assert out.shape == input_dict["q"].shape
+    assert torch.equal(out, input_dict["q"] + 1)
+    assert [call["q"].shape[0] for call in calls] == [4, 4, 2]
+    assert [call["indices"].shape[0] for call in calls] == [4, 4, 2]
+    assert [call["topk_length"].shape[0] for call in calls] == [4, 4, 2]
+    assert all(call["k_cache_shape"] == input_dict["k_cache"].shape for call in calls)
+    assert all(call["backend"] == "kernel" for call in calls)
+
+
+def test_dsv4_flashmla_chunking_is_prefill_only(monkeypatch):
+    monkeypatch.setenv("SGLANG_DSV4_FLASHMLA_PREFILL_CHUNK_SIZE", "4")
+
+    calls = []
+
+    def fake_runner(**kwargs):
+        calls.append(kwargs["q"].shape[0])
+        return (kwargs["q"],)
+
+    input_dict = {
+        "q": torch.zeros(10, 1, 1, 1),
+        "k_cache": torch.zeros(3, 128, 1, 1),
+        "indices": torch.zeros(10, 1, 64, dtype=torch.int32),
+        "topk_length": torch.ones(10, dtype=torch.int32),
+        "extra_indices_in_kvcache": None,
+        "extra_topk_length": None,
+    }
+
+    _flash_mla_with_optional_prefill_chunking(
+        input_dict=input_dict,
+        backend="kernel",
+        forward_mode=ForwardMode.DECODE,
+        runner=fake_runner,
+    )
+
+    assert calls == [10]

--- a/test/srt/test_deepseek_v4_flashmla_chunking.py
+++ b/test/srt/test_deepseek_v4_flashmla_chunking.py
@@ -1,13 +1,19 @@
 import torch
 
-from sglang.srt.layers.attention.deepseek_v4_backend_radix import (
-    _flash_mla_with_optional_prefill_chunking,
-)
+import sglang.srt.layers.attention.deepseek_v4_backend_radix as dsv4_radix
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 
 
 def test_dsv4_flashmla_prefill_chunking_slices_row_tensors(monkeypatch):
-    monkeypatch.setenv("SGLANG_DSV4_FLASHMLA_PREFILL_CHUNK_SIZE", "4")
+    monkeypatch.setenv("SGLANG_DSV4_PREFILL_METADATA_CHUNK_SIZE", "4")
+    created_metadata = []
+
+    def fake_metadata():
+        metadata = object()
+        created_metadata.append(metadata)
+        return metadata
+
+    monkeypatch.setattr(dsv4_radix, "_create_flashmla_metadata", fake_metadata)
 
     calls = []
 
@@ -19,6 +25,7 @@ def test_dsv4_flashmla_prefill_chunking_slices_row_tensors(monkeypatch):
                 "topk_length": kwargs["topk_length"].clone(),
                 "k_cache_shape": kwargs["k_cache"].shape,
                 "backend": kwargs["backend"],
+                "tile_scheduler_metadata": kwargs["tile_scheduler_metadata"],
             }
         )
         return (kwargs["q"] + 1,)
@@ -32,7 +39,7 @@ def test_dsv4_flashmla_prefill_chunking_slices_row_tensors(monkeypatch):
         "extra_topk_length": None,
     }
 
-    out = _flash_mla_with_optional_prefill_chunking(
+    out = dsv4_radix._flash_mla_with_optional_prefill_chunking(
         input_dict=input_dict,
         backend="kernel",
         forward_mode=ForwardMode.EXTEND,
@@ -46,10 +53,12 @@ def test_dsv4_flashmla_prefill_chunking_slices_row_tensors(monkeypatch):
     assert [call["topk_length"].shape[0] for call in calls] == [4, 4, 2]
     assert all(call["k_cache_shape"] == input_dict["k_cache"].shape for call in calls)
     assert all(call["backend"] == "kernel" for call in calls)
+    assert [call["tile_scheduler_metadata"] for call in calls] == created_metadata
+    assert len(set(map(id, created_metadata))) == 3
 
 
 def test_dsv4_flashmla_chunking_is_prefill_only(monkeypatch):
-    monkeypatch.setenv("SGLANG_DSV4_FLASHMLA_PREFILL_CHUNK_SIZE", "4")
+    monkeypatch.setenv("SGLANG_DSV4_PREFILL_METADATA_CHUNK_SIZE", "4")
 
     calls = []
 
@@ -66,7 +75,7 @@ def test_dsv4_flashmla_chunking_is_prefill_only(monkeypatch):
         "extra_topk_length": None,
     }
 
-    _flash_mla_with_optional_prefill_chunking(
+    dsv4_radix._flash_mla_with_optional_prefill_chunking(
         input_dict=input_dict,
         backend="kernel",
         forward_mode=ForwardMode.DECODE,


### PR DESCRIPTION
## Summary

This PR fixes the DSv4 GB200 mixed prefill/decode metadata failure by chunking compressed-attention metadata work at real request/prefill segment boundaries.

The earlier operational workaround was to launch with `--max-prefill-tokens 8192`, which prevented the scheduler from admitting multiple 4k prefills in the same step. This PR does not throttle scheduling. Instead, it lets the scheduler produce the mixed shapes and splits the FlashMLA / DeepGEMM paged-MQA metadata work into legal request-boundary chunks derived from `extend_seq_lens_cpu`.

Key behavior:
- builds DSv4 metadata chunk ranges from scheduler request segments, not arbitrary row counts
- keeps the single full-range fast path native
- creates fresh FlashMLA scheduler metadata per chunk
- applies the same request-boundary chunk plan to DeepGEMM/C4 paged-MQA metadata/logits work
- strips the private `_chunk_ranges` key before native FlashMLA calls, including decode/no-chunk paths

## Why

On GB200, DeepSeek-V4-Flash TP=4 could load and return `/model_info`, but long generation could fail when a running decode request was mixed with several new long-prefill requests. One observed failing shape was:

```text
#new-seq: 3
#new-token: 12288
#running-req: 1
```

The old workaround avoided this scheduler shape. The root-fix path should handle it without changing scheduler admission.

During validation, arbitrary flattened-row chunking was rejected: a forced 1024-row chunk test made `4096+16` generated token IDs diverge. The safe unit here is the request/prefill segment boundary from the scheduler.

## Validation

Validated on one GB200 node with `lmsysorg/sglang:deepseek-v4-grace-blackwell`, model `/data/models/DeepSeek-V4-Flash`, TP=4.

Server shape:

```bash
python3 -m sglang.launch_server \
  --model-path /data/models/DeepSeek-V4-Flash \
  --tp 4 \
  --moe-runner-backend flashinfer_mxfp4 \
  --disable-cuda-graph \
  --disable-flashinfer-autotune \
  --skip-server-warmup \
  --max-total-tokens 262144 \
  --max-running-requests 32 \
  --context-length 8192
```

Important: validation did **not** use `--max-prefill-tokens 8192`, did **not** use the scheduler guard workaround, and did **not** set `SGLANG_OPT_DG_PAGED_MQA_LOGITS_CHUNK_SIZE`.

Env used for stress validation:

```bash
SGLANG_DSV4_PREFILL_METADATA_CHUNK_SIZE=1024
SGLANG_JIT_DEEPGEMM_PRECOMPILE=0
SGLANG_OPT_USE_TILELANG_MHC_PRE=0
SGLANG_OPT_USE_TILELANG_MHC_POST=0
```

Tests:
- `PYTHONPATH=python pytest -q test/srt/test_deepseek_v4_flashmla_chunking.py`: `3 passed`
- full-model raw-ID requests, `input_len=4096`, `output_len=1500`:
  - `bs=4`: `ok_count=4/4`, elapsed `415.496s`, target output throughput `14.44 token/s`
  - `bs=8`: `ok_count=8/8`, elapsed `549.593s`, target output throughput `21.83 token/s`
  - `bs=16`: `ok_count=16/16`, elapsed `1031.461s`, target output throughput `23.27 token/s`

The server logs crossed the original failure family repeatedly, including:

```text
#new-seq: 3, #new-token: 12288, #running-req: 1
#new-seq: 3, #new-token: 12288, #running-req: 3
#new-seq: 3, #new-token: 12800, #running-req: 3
```

No `get_decoding_sched_meta`, `invalid argument`, `paged_mqa_logits_metadata`, `uses too much shared`, scheduler exception, traceback, or runtime error appeared in the validation grep.