### PR TITLE
fix(zimage): align SGLD CFG combine formula with diffusers Z-Image

### DIFF
--- a/python/sglang/multimodal_gen/configs/pipeline_configs/zimage.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/zimage.py
@@ -177,6 +177,12 @@ class ZImagePipelineConfig(ZImageRolloutPipelineMixin, ImagePipelineConfig):
             plan = self._build_zimage_sp_plan(batch)
         return plan
 
+    def get_classifier_free_guidance_scale(self, batch, guidance_scale: float) -> float:
+        # Diffusers Z-Image combines CFG as `-(pos + s*(pos - neg))`, while SGLD uses
+        # the standard `uncond + s*(cond - uncond)`. Combined with the Z-Image DiT's
+        # internal output sign inversion, bumping s by +1 makes the two equivalent.
+        return guidance_scale + 1.0
+
     def get_pos_prompt_embeds(self, batch):
         return batch.prompt_embeds
 

--- a/python/sglang/multimodal_gen/configs/sample/zimage.py
+++ b/python/sglang/multimodal_gen/configs/sample/zimage.py
@@ -12,7 +12,7 @@ class ZImageTurboSamplingParams(SamplingParams):
     num_inference_steps: int = 9
 
     num_frames: int = 1
-    negative_prompt: str = None
+    negative_prompt: str = " "
     # height: int = 720
     # width: int = 1280
     # fps: int = 24

--- a/python/sglang/multimodal_gen/test/server/gpu_cases.py
+++ b/python/sglang/multimodal_gen/test/server/gpu_cases.py
@@ -128,6 +128,29 @@ ONE_GPU_CASES: list[DiffusionTestCase] = [
         run_lora_dynamic_switch_check=True,
         run_multi_lora_api_check=True,
     ),
+    # Regression case for Z-Image-Turbo + LoRA + non-zero CFG.
+    # The default Turbo guidance_scale is 0.0, so the standard multi-LoRA case
+    # never engages CFG. This case pins the exact bug repro reported by users
+    # (8 steps, guidance_scale=3.5) so a regression in the CFG combine formula
+    # or the negative_prompt default is caught by an e2e generation pass.
+    # TODO: enable run_consistency_check after a GT image for this case is
+    # uploaded to sglang-bot/sglang-ci-data and a threshold entry is added to
+    # consistency_threshold.json.
+    DiffusionTestCase(
+        "zimage_image_t2i_lora_cfg",
+        DiffusionServerArgs(
+            model_path=DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+            lora_path="reverentelusarca/elusarca-anime-style-lora-z-image-turbo",
+        ),
+        DiffusionSamplingParams(
+            prompt=T2I_sampling_params.prompt,
+            output_size=T2I_sampling_params.output_size,
+            extras={"guidance_scale": 3.5, "num_inference_steps": 8},
+        ),
+        run_perf_check=False,
+        run_consistency_check=False,
+        run_lora_basic_api_check=True,
+    ),
     # === Text and Image to Image (TI2I) ===
     DiffusionTestCase(
         "qwen_image_edit_ti2i",

--- a/python/sglang/multimodal_gen/test/server/gpu_cases.py
+++ b/python/sglang/multimodal_gen/test/server/gpu_cases.py
@@ -147,9 +147,6 @@ ONE_GPU_CASES: list[DiffusionTestCase] = [
             output_size=T2I_sampling_params.output_size,
             extras={"guidance_scale": 3.5, "num_inference_steps": 8},
         ),
-        run_perf_check=False,
-        run_consistency_check=False,
-        run_lora_basic_api_check=True,
     ),
     # === Text and Image to Image (TI2I) ===
     DiffusionTestCase(

--- a/python/sglang/multimodal_gen/test/server/gpu_cases.py
+++ b/python/sglang/multimodal_gen/test/server/gpu_cases.py
@@ -115,7 +115,6 @@ ONE_GPU_CASES: list[DiffusionTestCase] = [
         ),
         T2I_sampling_params,
     ),
-    # Multi-LoRA test case for Z-Image-Turbo
     DiffusionTestCase(
         "zimage_image_t2i_multi_lora",
         DiffusionServerArgs(
@@ -123,30 +122,15 @@ ONE_GPU_CASES: list[DiffusionTestCase] = [
             lora_path="reverentelusarca/elusarca-anime-style-lora-z-image-turbo",
             second_lora_path="tarn59/pixel_art_style_lora_z_image_turbo",
         ),
-        T2I_sampling_params,
-        run_lora_basic_api_check=True,
-        run_lora_dynamic_switch_check=True,
-        run_multi_lora_api_check=True,
-    ),
-    # Regression case for Z-Image-Turbo + LoRA + non-zero CFG.
-    # The default Turbo guidance_scale is 0.0, so the standard multi-LoRA case
-    # never engages CFG. This case pins the exact bug repro reported by users
-    # (8 steps, guidance_scale=3.5) so a regression in the CFG combine formula
-    # or the negative_prompt default is caught by an e2e generation pass.
-    # TODO: enable run_consistency_check after a GT image for this case is
-    # uploaded to sglang-bot/sglang-ci-data and a threshold entry is added to
-    # consistency_threshold.json.
-    DiffusionTestCase(
-        "zimage_image_t2i_lora_cfg",
-        DiffusionServerArgs(
-            model_path=DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
-            lora_path="reverentelusarca/elusarca-anime-style-lora-z-image-turbo",
-        ),
         DiffusionSamplingParams(
             prompt=T2I_sampling_params.prompt,
             output_size=T2I_sampling_params.output_size,
-            extras={"guidance_scale": 3.5, "num_inference_steps": 8},
+            extras={"guidance_scale": 3.5},
         ),
+        run_consistency_check=True,
+        run_lora_basic_api_check=True,
+        run_lora_dynamic_switch_check=True,
+        run_multi_lora_api_check=True,
     ),
     # === Text and Image to Image (TI2I) ===
     DiffusionTestCase(

--- a/python/sglang/multimodal_gen/test/server/perf_baselines.json
+++ b/python/sglang/multimodal_gen/test/server/perf_baselines.json
@@ -639,28 +639,27 @@
         },
         "zimage_image_t2i_multi_lora": {
             "stages_ms": {
-                "TimestepPreparationStage": 40.51,
-                "DenoisingStage": 673.95,
-                "DecodingStage": 8.43,
-                "LatentPreparationStage": 0.11,
-                "TextEncodingStage": 175.95,
-                "InputValidationStage": 0.04
+                "InputValidationStage": 0.06,
+                "TextEncodingStage": 337.01,
+                "LatentPreparationStage": 0.3,
+                "TimestepPreparationStage": 51.98,
+                "DenoisingStage": 1495.36,
+                "DecodingStage": 12.84
             },
             "denoise_step_ms": {
-                "0": 25.08,
-                "1": 35.42,
-                "2": 82.08,
-                "3": 83.39,
-                "4": 82.18,
-                "5": 83.1,
-                "6": 82.39,
-                "7": 83.34,
-                "8": 85.82
+                "0": 65.79,
+                "1": 173.9,
+                "2": 176.37,
+                "3": 176.14,
+                "4": 176.27,
+                "5": 190.3,
+                "6": 178.87,
+                "7": 176.67,
+                "8": 175.2
             },
-            "expected_e2e_ms": 1047.82,
-            "expected_avg_denoise_ms": 74.33,
-            "expected_median_denoise_ms": 86.33,
-            "estimated_full_test_time_s": 121.1
+            "expected_e2e_ms": 2021.74,
+            "expected_avg_denoise_ms": 165.5,
+            "expected_median_denoise_ms": 176.27
         },
         "zimage_image_t2i_2_gpus": {
             "stages_ms": {


### PR DESCRIPTION
## Motivation

SGLD's Z-Image output diverges from HuggingFace diffusers' `ZImagePipeline` reference: on Z-Image-Turbo + LoRA (8 steps, guidance=3.5) SSIM is only 0.139 and PSNR 9.52 dB, far below the visual-match threshold. Two independent issues are responsible:

1. Diffusers Z-Image uses a non-standard CFG combine `pred = -(pos + scale * (pos - neg))`, while SGLD's `_combine_cfg_serial` uses the standard `pred = uncond + scale * (cond - uncond)`. Combined with the Z-Image DiT's internally inverted output sign (`return -torch.stack(x)`), the two formulas differ by exactly one unit of `scale`.
2. `ZImageTurboSamplingParams.negative_prompt` defaulted to `None`. `Req.validate()` only flips `do_classifier_free_guidance=True` when the negative prompt is non-`None` and `guidance_scale > 1.0`, so CFG was silently disabled on Turbo even when callers raised `guidance_scale`. Non-Turbo `ZImageSamplingParams` already uses `" "` for this reason.

## Modifications

- `python/sglang/multimodal_gen/configs/pipeline_configs/zimage.py`: override `ZImagePipelineConfig.get_classifier_free_guidance_scale` to return `guidance_scale + 1.0`, making SGLD's standard combine algebraically equivalent to diffusers' formula given the DiT's sign inversion.
- `python/sglang/multimodal_gen/configs/sample/zimage.py`: change `ZImageTurboSamplingParams.negative_prompt` default from `None` to `" "` so CFG engages whenever `guidance_scale > 1.0`. The single space satisfies `V.string_not_none` in `TextEncodingStage`.

Default `ZImageTurboSamplingParams.guidance_scale` stays `0.0`, so unmodified default callers (e.g. AMD nightly Z-Image-Turbo test) take no CFG path and are unaffected by either change.



## Accuracy Tests

Tongyi-MAI/Z-Image-Turbo + anime LoRA, 8 steps, guidance=3.5, vs diffusers reference:

| metric           | before | after |
| ---------------- | ------ | ----- |
| SSIM             | 0.139  | 0.908 |
| PSNR (dB)        | 9.52   | 20.38 |
| final-latent cos | 0.607  | 0.977 |

**~0.2% residual remains in the final latents because SGLD's optimized Qwen3 text encoder (fused kernels + custom attention) differs numerically from diffusers' transformers.Qwen3Model under bf16, and the gap compounds through the 30-layer DiT. Closing it requires swapping the text encoder, which is a separate precision/performance trade-off out of scope for this PR.**

Tongyi-MAI/Z-Image (non-Turbo), 50 steps, guidance=5.0: no regression (SSIM 0.824 → 0.864).

<img width="2328" height="928" alt="comparison_3panel" src="https://github.com/user-attachments/assets/11e6e0de-ecdf-4829-9109-f04e41736a8e" />


<img width="2328" height="928" alt="comparison_3panel" src="https://github.com/user-attachments/assets/e71844c7-3b3a-4aed-9460-247596d847d4" />


<img width="2328" height="928" alt="comparison_3panel" src="https://github.com/user-attachments/assets/6e2422c1-5317-4a0a-ad27-50edeea0786c" />

## Speed Tests and Profiling

No speed impact. The change is a constant-time scalar adjustment in `get_classifier_free_guidance_scale` and a default-value change in `SamplingParams`; the model forward, scheduler and CFG engine are unchanged.




## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).