### PR TITLE
[DeepSeek V4] Fix meaningless numbers in chat output by adding swiglu_limit clamp to DeepseekV2MLP

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -227,9 +227,11 @@ class DeepseekV2MLP(nn.Module):
         prefix: str = "",
         tp_rank: Optional[int] = None,
         tp_size: Optional[int] = None,
+        swiglu_limit: Optional[float] = None,
     ) -> None:
         super().__init__()
         self.tp_size = tp_size
+        self.swiglu_limit = swiglu_limit
 
         self.gate_up_proj = MergedColumnParallelLinear(
             hidden_size,
@@ -283,6 +285,12 @@ class DeepseekV2MLP(nn.Module):
             x = (x, None, y)
 
         gate_up, _ = self.gate_up_proj(x)
+        if self.swiglu_limit is not None:
+            _g, _u = gate_up.chunk(2, dim=-1)
+            _lim = float(self.swiglu_limit)
+            gate_up = torch.cat(
+                [_g.clamp(max=_lim), _u.clamp(min=-_lim, max=_lim)], dim=-1
+            )
         x = self.act_fn(gate_up)
         x, _ = self.down_proj(
             x,
@@ -533,6 +541,7 @@ class DeepseekV2MoE(nn.Module):
                 hidden_act=config.hidden_act,
                 quant_config=quant_config,
                 reduce_results=False,
+                swiglu_limit=getattr(config, "swiglu_limit", None),
                 prefix=add_prefix("shared_experts", prefix),
                 **(
                     dict(tp_rank=0, tp_size=1)
@@ -2594,6 +2603,7 @@ class DeepseekV2DecoderLayer(nn.Module):
                 prefix=add_prefix("mlp", prefix),
                 tp_rank=mlp_tp_rank,
                 tp_size=mlp_tp_size,
+                swiglu_limit=getattr(config, "swiglu_limit", None),
             )
 
         self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)


### PR DESCRIPTION
Fixes #23752

## Summary

DeepSeek-V4 chat output contains deterministic spurious tokens (e.g. plain `16`, `14:05`, `<｜end▁of▁file｜>` followed by training-data file paths and decode loops) at sentence-boundary positions. Reported in #23752 with this exemplar prompt:

> *"...Thiopentone is a barbiturate with anticonvulsant properties,**16** used sometimes in status epilepticus.  Propofol also has anticonvulsant effects and is**16** used in refractory status epilepticus..."*

The `16` tokens have IDs `[49, 54]` (ASCII `'1' '6'`) — they are plain text picked by argmax at `temperature=0`.

## Root cause

The routed-expert path already reads `config.swiglu_limit` and propagates it through `FusedMoE` → `MoeRunnerConfig.gemm1_clamp_limit` → triton/deepgemm kernels for SiLU clamping (see `deepseek_v2.py:485` → `layers/moe/moe_runner/triton_utils/fused_moe.py:299` `_swiglu_silu_clamp_mul`). However, **the shared-expert path and the dense-MLP path use `DeepseekV2MLP` which never receives `swiglu_limit`**. `DeepseekV2MLP.forward` calls bare `SiluAndMul()` on `gate_up`, leaving SiLU output unbounded.

For DeepSeek-V4 checkpoints trained with `swiglu_limit=10.0` (e.g. V4-Pro / V4-Flash with the `2604B` submode, see `configs/config_backup_large.json`), the missing clamp causes shared-expert SiLU output to grow to **±2000+** during inference. This pollutes the residual stream via `final_hidden_states += shared_output`, propagates through `mhc_post`, and degrades `lm_head` logits at sentence-boundary positions, producing the spurious tokens reported in #23752.

A `mhc_post` debug hook on V4-Pro (multiple layers, contributed by @xu-yfei) shows the magnitude:

```
hc_post #0 return: min=-1368 max=2576 mean=0.369627 nan=0 inf=0
hc_post #9 return: min=-2240 max=2224 mean=0.243731 nan=0 inf=0
hc_post #N return: min/max ±1000 to ±2576, mean ~0.1
```

`mhc_post`'s output formula is `post * x + sum(comb * residual, dim=1)` where `post ∈ [0, 2]` (sigmoid-bounded) and `comb` is Sinkhorn-normalized to a doubly-stochastic matrix with elements in `[0, 1]`. Neither of these can blow up the output by themselves, so the ±2000+ values trace back to the `residual` / `x` inputs being poisoned by unclamped shared-expert SiLU output.

The 2604B-specific comment at `deepseek_v4.py:1432-1433` already flagged the issue:
```python
disable_reason = "2604B checkpoint requires different clamping for shared and routed experts"
```
Disabling shared-expert fusion was implemented but the corresponding clamp on the unfused `DeepseekV2MLP` path was missing. This PR closes that gap.

## Fix

Three minimal edits to `python/sglang/srt/models/deepseek_v2.py`:

1. **`DeepseekV2MLP.__init__`**: add `swiglu_limit: Optional[float] = None` kwarg, store as `self.swiglu_limit`.

2. **`DeepseekV2MLP.forward`**: clamp `gate_up` chunks before `SiluAndMul` if `self.swiglu_limit` is set. Mirrors `_swiglu_silu_clamp_mul` semantics in the routed-expert kernel:
   ```python
   if self.swiglu_limit is not None:
       _g, _u = gate_up.chunk(2, dim=-1)
       _lim = float(self.swiglu_limit)
       gate_up = torch.cat(
           [_g.clamp(max=_lim), _u.clamp(min=-_lim, max=_lim)], dim=-1
       )
   ```

3. **Both call sites** (`shared_experts` at L530, dense-MLP `self.mlp` at L2589) pass `swiglu_limit=getattr(config, "swiglu_limit", None)` — same pattern already used at L485 for routed experts.

No env vars introduced; behavior is gated entirely on `config.swiglu_limit`. Models that don't set this (e.g. plain V2/V3) retain current behavior (no clamp).

## Verification

- Anaesthesia MCQ from #23752 reproduction: spurious `16` tokens **eliminated** at all 3 positions.
- Multi-prompt smoke test (medical / dialog / long-form explanation / code / math): **0 leaks** across all prompts (without patch, multiple `16` interjections and a `the16 the16 ...` decode loop in the long-form case).
- Tested on `97d1a672` of the `deepseek_v4` branch.

## Backwards compatibility

`swiglu_limit=None` is the existing implicit behavior; adding the kwarg with default `None` is non-breaking. Models without `config.swiglu_limit` see no behavioral change.
