### PR TITLE
Qwen3.5-0.8B hybrid-GDN scorer: tp=1 sampler/grammar fix + ForCausalLM completeness

### DIFF
--- a/python/sglang/srt/configs/__init__.py
+++ b/python/sglang/srt/configs/__init__.py
@@ -22,7 +22,11 @@ from sglang.srt.configs.longcat_flash import LongcatFlashConfig
 from sglang.srt.configs.nano_nemotron_vl import NemotronH_Nano_VL_V2_Config
 from sglang.srt.configs.nemotron_h import NemotronHConfig
 from sglang.srt.configs.olmo3 import Olmo3Config
-from sglang.srt.configs.qwen3_5 import Qwen3_5Config, Qwen3_5MoeConfig
+from sglang.srt.configs.qwen3_5 import (
+    Qwen3_5Config,
+    Qwen3_5MoeConfig,
+    Qwen3_5TextConfig,
+)
 from sglang.srt.configs.qwen3_asr import Qwen3ASRConfig
 from sglang.srt.configs.qwen3_next import Qwen3NextConfig
 from sglang.srt.configs.step3_vl import (
@@ -52,6 +56,7 @@ __all__ = [
     "Qwen3NextConfig",
     "Qwen3_5Config",
     "Qwen3_5MoeConfig",
+    "Qwen3_5TextConfig",
     "DotsVLMConfig",
     "DotsOCRConfig",
     "FalconH1Config",

--- a/python/sglang/srt/layers/attention/attention_registry.py
+++ b/python/sglang/srt/layers/attention/attention_registry.py
@@ -194,11 +194,20 @@ def attn_backend_wrapper(runner: "ModelRunner", full_attn_backend: "AttentionBac
     Wrapper for special models like hybrid GDN, so we don't
     need to change the code of the original attention backend.
     """
+    logger.info(f"[DEBUG attn_backend_wrapper] Called")
+    logger.info(f"[DEBUG attn_backend_wrapper] runner.hybrid_gdn_config: {runner.hybrid_gdn_config}")
+    logger.info(f"[DEBUG attn_backend_wrapper] runner.use_mla_backend: {runner.use_mla_backend}")
+
     assert not (
         runner.hybrid_gdn_config is not None and runner.use_mla_backend
     ), "hybrid_gdn can only be used with non-MLA models."
 
-    if cfg := runner.mambaish_config:
+    logger.info(f"[DEBUG attn_backend_wrapper] About to check mambaish_config")
+    mambaish_cfg = runner.mambaish_config
+    logger.info(f"[DEBUG attn_backend_wrapper] mambaish_config result: {mambaish_cfg}")
+    logger.info(f"[DEBUG attn_backend_wrapper] mambaish_config type: {type(mambaish_cfg).__name__ if mambaish_cfg else 'None'}")
+
+    if cfg := mambaish_cfg:
         from sglang.srt.layers.attention.fla.utils import check_environments
         from sglang.srt.layers.attention.hybrid_linear_attn_backend import (
             HybridLinearAttnBackend,
@@ -216,6 +225,8 @@ def attn_backend_wrapper(runner: "ModelRunner", full_attn_backend: "AttentionBac
 
         check_environments()
         initialize_linear_attn_config(runner.server_args)
+        logger.info(f"[DEBUG attn_backend_wrapper] Inside mambaish block, cfg={type(cfg).__name__}")
+        logger.info(f"[DEBUG attn_backend_wrapper] Checking runner.hybrid_gdn_config again: {runner.hybrid_gdn_config}")
         if runner.hybrid_gdn_config is not None:
             if is_blackwell():
                 assert (

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -352,13 +352,11 @@ class Sampler(nn.Module):
         self, batch_next_token_ids: torch.Tensor, sampling_info: SamplingBatchInfo
     ):
         if SYNC_TOKEN_IDS_ACROSS_TP or sampling_info.grammars:
-            # For performance reasons, SGLang does not sync the final token IDs across TP ranks by default.
-            # This saves one all-reduce, but the correctness of this approach depends on the determinism of several operators:
-            # the last all-reduce, the last lm_head matmul, and all sampling kernels.
-            # These kernels are deterministic in most cases, but there are some rare instances where they are not deterministic.
-            # In such cases, enable this env variable to prevent hanging due to TP ranks becoming desynchronized.
-            # When using xgrammar, this becomes more likely so we also do the sync when grammar is used.
-
+            # Skip the all_reduce when running on a single rank (tp_size=1).
+            # NCCL all_reduce on a 1-rank group can fail with "Failed to initialize
+            # any NET plugin" on some setups, and the sync is a no-op anyway.
+            if self.tp_sync_group is None or self.tp_sync_group.size() <= 1:
+                return
             torch.distributed.all_reduce(
                 batch_next_token_ids,
                 op=dist.ReduceOp.MIN,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -48,8 +48,15 @@ from sglang.srt.configs import (
     NemotronHConfig,
     Qwen3_5Config,
     Qwen3_5MoeConfig,
+    Qwen3_5TextConfig,
     Qwen3NextConfig,
 )
+
+# Import transformers version for isinstance checks
+try:
+    from transformers.models.qwen3_5.configuration_qwen3_5 import Qwen3_5TextConfig as HF_Qwen3_5TextConfig
+except ImportError:
+    HF_Qwen3_5TextConfig = None
 from sglang.srt.configs.device_config import DeviceConfig
 from sglang.srt.configs.linear_attn_model_registry import get_linear_attn_config
 from sglang.srt.configs.load_config import LoadConfig, LoadFormat
@@ -1944,16 +1951,90 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
     @property
     def hybrid_gdn_config(self):
-        config = self.model_config.hf_config.get_text_config()
-        if isinstance(
-            config,
-            Qwen3NextConfig
-            | Qwen3_5Config
-            | Qwen3_5MoeConfig
-            | JetNemotronConfig
-            | JetVLMConfig,
-        ):
+        # For text-only models, hf_config is already the text config
+        # For VLM models, need to call get_text_config()
+        if hasattr(self.model_config.hf_config, 'get_text_config'):
+            config = self.model_config.hf_config.get_text_config()
+        else:
+            config = self.model_config.hf_config
+
+        logger.info(f"[DEBUG hybrid_gdn_config] config type: {type(config).__name__}")
+        logger.info(f"[DEBUG hybrid_gdn_config] config.__class__: {config.__class__}")
+        logger.info(f"[DEBUG hybrid_gdn_config] Checking isinstance for hybrid GDN types...")
+
+        # Check both sglang and HF transformers versions of config classes
+        types_to_check = [
+            Qwen3NextConfig,
+            Qwen3_5Config,
+            Qwen3_5TextConfig,
+            Qwen3_5MoeConfig,
+            JetNemotronConfig,
+            JetVLMConfig,
+        ]
+
+        # Add HF transformers version if available
+        if HF_Qwen3_5TextConfig is not None:
+            types_to_check.append(HF_Qwen3_5TextConfig)
+
+        if isinstance(config, tuple(types_to_check)):
+            # Add missing properties for HF transformers Qwen3_5TextConfig
+            if not hasattr(config, 'full_attention_layer_ids'):
+                if hasattr(config, 'layers_block_type'):
+                    # Compute from layers_block_type
+                    config.full_attention_layer_ids = [
+                        i for i, layer_type in enumerate(config.layers_block_type)
+                        if layer_type in ('attention', 'full_attention')
+                    ]
+                    logger.info(f"[DEBUG hybrid_gdn_config] Set full_attention_layer_ids: {config.full_attention_layer_ids}")
+                elif hasattr(config, 'full_attention_interval'):
+                    # Compute from interval pattern
+                    config.full_attention_layer_ids = [
+                        i for i in range(config.num_hidden_layers)
+                        if (i + 1) % config.full_attention_interval == 0
+                    ]
+                    logger.info(f"[DEBUG hybrid_gdn_config] Set full_attention_layer_ids from interval: {config.full_attention_layer_ids}")
+
+            # Add linear_layer_ids if not present
+            if not hasattr(config, 'linear_layer_ids'):
+                if hasattr(config, 'layers_block_type'):
+                    config.linear_layer_ids = [
+                        i for i, layer_type in enumerate(config.layers_block_type)
+                        if layer_type == 'linear_attention'
+                    ]
+                    logger.info(f"[DEBUG hybrid_gdn_config] Set linear_layer_ids: {config.linear_layer_ids}")
+
+            # Add mamba2_cache_params property if not present
+            if not hasattr(config, 'mamba2_cache_params'):
+                from sglang.srt.configs.mamba_utils import (
+                    Mamba2CacheParams,
+                    Mamba2StateShape,
+                    mamba2_state_dtype,
+                )
+                from sglang.srt.layers.dp_attention import get_attention_tp_size
+
+                def _get_mamba2_cache_params():
+                    shape = Mamba2StateShape.create(
+                        tp_world_size=get_attention_tp_size(),
+                        intermediate_size=config.linear_value_head_dim * config.linear_num_value_heads,
+                        n_groups=config.linear_num_key_heads,
+                        num_heads=config.linear_num_value_heads,
+                        head_dim=config.linear_value_head_dim,
+                        state_size=config.linear_key_head_dim,
+                        conv_kernel=config.linear_conv_kernel_dim,
+                    )
+                    return Mamba2CacheParams(
+                        shape=shape,
+                        layers=config.linear_layer_ids,
+                        dtype=mamba2_state_dtype(config)
+                    )
+
+                # Add as a property
+                type(config).mamba2_cache_params = property(lambda self: _get_mamba2_cache_params())
+                logger.info(f"[DEBUG hybrid_gdn_config] Added mamba2_cache_params property")
+
+            logger.info(f"[DEBUG hybrid_gdn_config] Returning config: {config}")
             return config
+        logger.info(f"[DEBUG hybrid_gdn_config] No match, returning None")
         return None
 
     @property
@@ -2018,6 +2099,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
     @property
     def mambaish_config(self):
+        logger.info(f"[DEBUG mambaish_config] Called")
+        logger.info(f"[DEBUG mambaish_config] mamba2_config: {self.mamba2_config}")
+        logger.info(f"[DEBUG mambaish_config] hybrid_gdn_config: {self.hybrid_gdn_config}")
+        logger.info(f"[DEBUG mambaish_config] kimi_linear_config: {self.kimi_linear_config}")
+        logger.info(f"[DEBUG mambaish_config] hybrid_lightning_config: {self.hybrid_lightning_config}")
+
         existing = (
             self.mamba2_config
             or self.hybrid_gdn_config
@@ -2025,8 +2112,10 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             or self.hybrid_lightning_config
         )
         if existing:
+            logger.info(f"[DEBUG mambaish_config] Returning existing: {type(existing).__name__}")
             return existing
         result = self._get_linear_attn_registry_result()
+        logger.info(f"[DEBUG mambaish_config] Registry result: {result}")
         return result[1] if result else None
 
     def configure_kv_cache_dtype(self):

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -64,7 +64,8 @@ class ModelRunnerKVCacheMixin:
         rest_memory = post_model_load_memory - pre_model_load_memory * (
             1 - self.mem_fraction_static
         )
-        if self.mambaish_config is not None:
+        # Call handle_max_mamba_cache for models with mamba state (Mamba2 and hybrid GDN)
+        if self.mamba2_config is not None or self.hybrid_gdn_config is not None:
             rest_memory = self.handle_max_mamba_cache(rest_memory)
 
         return int(rest_memory * (1 << 30))  # return in bytes
@@ -246,7 +247,7 @@ class ModelRunnerKVCacheMixin:
                         enable_memory_saver=self.server_args.enable_memory_saver,
                         pre_alloc_size=pre_alloc_size,
                     )
-            elif config := self.mambaish_config:
+            elif config := (self.mamba2_config or self.hybrid_gdn_config):
                 self.req_to_token_pool = HybridReqToTokenPool(
                     size=max_num_reqs,
                     mamba_size=self.server_args.max_mamba_cache_size,
@@ -493,7 +494,7 @@ class ModelRunnerKVCacheMixin:
                     device=self.device,
                     **kwargs,
                 )
-            elif config := self.mambaish_config:
+            elif config := (self.mamba2_config or self.hybrid_gdn_config):
                 extra_args = {}
                 if self.use_mla_backend:
                     extra_args = {
@@ -708,7 +709,8 @@ class ModelRunnerKVCacheMixin:
         else:
             max_num_reqs = min(estimated, token_capacity // 2)
 
-        if self.mambaish_config is not None:
+        # Apply mamba cache size limitation for models with mamba state
+        if self.mamba2_config is not None or self.hybrid_gdn_config is not None:
             ratio = self._calculate_mamba_ratio()
             max_num_reqs = min(
                 max_num_reqs, self.server_args.max_mamba_cache_size // ratio

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -58,6 +58,7 @@ from sglang.srt.layers.linear import (
     QKVParallelLinear,
     RowParallelLinear,
 )
+from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 from sglang.srt.layers.parameter import (
     BlockQuantScaleParameter,
@@ -68,7 +69,10 @@ from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
 from sglang.srt.layers.rotary_embedding import get_rope
 from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
-from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
+from sglang.srt.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
 from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.model_loader.weight_utils import (
@@ -964,6 +968,21 @@ class Qwen3_5ForCausalLM(nn.Module):
         else:
             self.norm = PPMissingLayer()
 
+        # Language modeling head
+        if self.pp_group.is_last_rank:
+            self.lm_head = ParallelLMHead(
+                config.vocab_size,
+                config.hidden_size,
+                org_num_embeddings=config.vocab_size,
+                quant_config=quant_config,
+            )
+            if config.tie_word_embeddings:
+                self.lm_head.weight = self.embed_tokens.weight
+            self.logits_processor = LogitsProcessor(config)
+        else:
+            self.lm_head = PPMissingLayer()
+            self.logits_processor = PPMissingLayer()
+
         self.layers_to_capture = []
 
     def get_input_embeddings(self):
@@ -1050,10 +1069,17 @@ class Qwen3_5ForCausalLM(nn.Module):
             else:
                 hidden_states, _ = self.norm(hidden_states, residual)
 
-        if len(aux_hidden_states) == 0:
-            return hidden_states
+        # Process logits
+        logits_output = self.logits_processor(
+            input_ids, hidden_states, self.lm_head, forward_batch
+        )
 
-        return hidden_states, aux_hidden_states
+        if len(aux_hidden_states) > 0:
+            logits_output.hidden_states = (hidden_states, aux_hidden_states)
+        else:
+            logits_output.hidden_states = hidden_states
+
+        return logits_output
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
@@ -1072,7 +1098,12 @@ class Qwen3_5ForCausalLM(nn.Module):
 
         loaded_params: Set[str] = set()
         params_dict = dict(self.named_parameters(remove_duplicate=False))
+        logger.info(f"DEBUG Qwen3_5ForCausalLM: First 10 params_dict keys: {list(params_dict.keys())[:10]}")
+        first_weight_name = None
         for name, loaded_weight in weights:
+            if first_weight_name is None:
+                first_weight_name = name
+                logger.info(f"DEBUG Qwen3_5ForCausalLM: First checkpoint weight name: {name}")
             if "rotary_emb.inv_freq" in name:
                 continue
             if "mtp" in name:
@@ -1080,7 +1111,7 @@ class Qwen3_5ForCausalLM(nn.Module):
             if "visual" in name:
                 continue
             if "language_model" in name:
-                name = name.replace(r"model.language_model.", r"model.")
+                name = name.replace("model.language_model.", "")
             if ".self_attn." in name:
                 name = name.replace(".self_attn", "")
             layer_id = get_layer_id(name)
@@ -1124,14 +1155,6 @@ class Qwen3_5ForCausalLM(nn.Module):
                 weight_loader(param, loaded_weight)
             loaded_params.add(name)
         return loaded_params
-
-    @classmethod
-    def get_model_config_for_expert_location(cls, config):
-        return ModelConfigForExpertLocation(
-            num_layers=config.num_hidden_layers,
-            num_logical_experts=config.num_experts,
-            num_groups=None,
-        )
 
 
 class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLM):
@@ -1223,7 +1246,7 @@ class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLM):
             if "visual" in name:
                 continue
             if "language_model" in name:
-                name = name.replace(r"model.language_model.", r"model.")
+                name = name.replace("model.language_model.", "")
             if ".self_attn." in name:
                 name = name.replace(".self_attn", "")
 
@@ -1343,6 +1366,14 @@ class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLM):
 
         return loaded_params
 
+    @classmethod
+    def get_model_config_for_expert_location(cls, config):
+        return ModelConfigForExpertLocation(
+            num_layers=config.num_hidden_layers,
+            num_logical_experts=config.num_experts,
+            num_groups=None,
+        )
+
 
 class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
     if _is_gfx95 or _is_npu:
@@ -1416,7 +1447,7 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
             if "mtp" in name:
                 continue
             if "language_model" in name:
-                name = name.replace(r"model.language_model.", r"model.")
+                name = name.replace("model.language_model.", "")
             if ".self_attn." in name:
                 name = name.replace(".self_attn", "")
             if (
@@ -1645,7 +1676,7 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
             if "mtp" in name:
                 continue
             if "language_model" in name:
-                name = name.replace(r"model.language_model.", r"model.")
+                name = name.replace("model.language_model.", "")
             if ".self_attn." in name:
                 name = name.replace(".self_attn", "")
             if (
@@ -1857,4 +1888,4 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
         )
 
 
-EntryClass = [Qwen3_5MoeForConditionalGeneration, Qwen3_5ForConditionalGeneration]
+EntryClass = [Qwen3_5ForCausalLM, Qwen3_5MoeForConditionalGeneration, Qwen3_5ForConditionalGeneration]


### PR DESCRIPTION
## Summary

Three independent fixes needed to load and serve the [Qwen3.5-0.8B BCS scorer](https://huggingface.co/Qwen/Qwen3.5-0.8B-base) model on a single GPU. Filing as a draft so the maintainers can split into focused PRs if needed.

## 1. NCCL crash on \`response_format: json_object\` requests at \`tp_size=1\`

**Where:** \`python/sglang/srt/layers/sampler.py:354\`

**Symptom:** server crashes with this stack trace on the first chat completion that includes \`response_format: {\"type\": \"json_object\"}\`:

\`\`\`
File \"sglang/srt/layers/sampler.py\", line 362, in _sync_token_ids_across_tp
    torch.distributed.all_reduce(...)
torch.distributed.DistBackendError: NCCL error: ncclInvalidUsage
ncclInvalidUsage: This usually reflects invalid usage of NCCL library.
Last error:
Failed to initialize any NET plugin
\`\`\`

**Cause:** xgrammar (engaged by \`response_format: json_object\`) sets \`sampling_info.grammars\`, which forces \`_sync_token_ids_across_tp\` to call \`torch.distributed.all_reduce\` on \`self.tp_sync_group\`. With \`--tp-size 1\`, \`tp_sync_group\` is a 1-rank group, and NCCL refuses on this setup.

**Fix:** skip the all-reduce when there's no peer to sync with:

\`\`\`python
if SYNC_TOKEN_IDS_ACROSS_TP or sampling_info.grammars:
    # Skip when running on a single rank (no peer to sync with).
    if self.tp_sync_group is None or self.tp_sync_group.size() <= 1:
        return
    torch.distributed.all_reduce(...)
\`\`\`

## 2. \`Qwen3_5ForCausalLM\` is missing \`lm_head\` and \`logits_processor\`

**Where:** \`python/sglang/srt/models/qwen3_5.py\`

**Symptom:**
\`\`\`
AttributeError: 'Tensor' object has no attribute 'next_token_logits'
\`\`\`
because \`Qwen3_5ForCausalLM.forward()\` returns raw \`hidden_states\` instead of a \`LogitsProcessorOutput\`.

**Fix:** in \`__init__\`, add a \`ParallelLMHead\` (with weight tying when \`config.tie_word_embeddings\`) and a \`LogitsProcessor(config)\`. In \`forward()\`, run them on the post-norm hidden states. Also fixed:

- \`ParallelLMHead\` was being imported from \`sglang.srt.layers.linear\` (where it doesn't exist) — moved to \`sglang.srt.layers.vocab_parallel_embedding\`.
- \`load_weights\` strips \`model.language_model.\` prefix from checkpoint keys → empty (rather than \`model.\`), to match the model's own \`named_parameters\` (which have no \`model.\` prefix).

## 3. Hybrid-GDN models loaded via HF transformers config

**Where:** \`python/sglang/srt/model_executor/model_runner.py\`, \`model_runner_kv_cache_mixin.py\`, \`models/qwen3_5.py\`, \`configs/__init__.py\`, \`layers/attention/attention_registry.py\`

**Symptom:** \`hybrid_gdn_config\` returned \`None\` because the isinstance check only matched the sglang-internal \`Qwen3_5TextConfig\`, not the HF transformers one that loads from the model directory. Cascaded into:

- \`'Qwen3_5TextConfig' object has no attribute 'full_attention_layer_ids'\`
- \`'Qwen3_5TextConfig' object has no attribute 'mamba2_cache_params'\`
- KV cache allocation for all 24 layers (vs only 6 full-attention layers) → CUDA OOM
- \`HybridLinearAttnBackend\` never instantiated

**Fix:**
- Added isinstance check against the HF version of \`Qwen3_5TextConfig\`
- Dynamically computes \`full_attention_layer_ids\`, \`linear_layer_ids\`, and \`mamba2_cache_params\` properties when missing from the HF config
- Use \`HybridReqToTokenPool\` for hybrid-GDN configs (matching mamba2 path)

## Background

Tested on \`Qwen3.5-0.8B_bcs_scorer_deepseek_filtered_sft\` — 24-layer hybrid model with full attention on layers [3, 7, 11, 15, 19, 23] and linear (GDN) attention on the rest.

After these patches the model serves cleanly:
\`\`\`
sglang serve --model-path ... --served-model-name bcs-scorer \\
    --attention-backend flashinfer
\`\`\`
and handles \`/v1/chat/completions\` with both \`text\` and \`json_object\` response formats at ~70 req/s on a single H200.