### PR TITLE
support granite hybrid model on npu

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -240,6 +240,13 @@ class AscendAttnBackend(AttentionBackend):
                 in model_runner.model_config.hf_config.architectures
             ):
                 self.use_native_sdpa = True
+            elif (
+                "GraniteMoeHybridForCausalLM"
+                in model_runner.model_config.hf_config.architectures
+            ):
+                self.use_native_sdpa = True
+                self.use_npu_paged_attention = False
+
         self.native_attn = AscendTorchNativeAttnBackend()
         self.graph_metadata = {}
         self.max_context_len = model_runner.model_config.context_len
@@ -1868,9 +1875,13 @@ class AscendAttnBackend(AttentionBackend):
                     actual_seq_lengths_kv=actual_seq_len_kv,
                     scale=layer.scaling,
                 )
-            # there are some accuracy issues in cross attention scene to use torch_npu._npu_flash_attention_qlens
-            # forward_batch.encoder_lens is not None in cross attention scend, we add native attn to solve accuracy issues
-            elif forward_batch.encoder_lens is None and layer.logit_cap == 0:
+            # there are some accuracy issues in cross attention scene to use torch_npu._npu_paged_attention
+            # forward_batch.encoder_lens is not None in cross attention scene, we add native attn to solve accuracy issues
+            elif (
+                forward_batch.encoder_lens is None
+                and layer.logit_cap == 0
+                and getattr(self, "use_npu_paged_attention", True)
+            ):
                 query = q.reshape(-1, layer.tp_q_head_num, layer.qk_head_dim)
                 num_tokens = query.shape[0]
                 if not self.use_alibi:

--- a/python/sglang/srt/layers/attention/mamba/mamba.py
+++ b/python/sglang/srt/layers/attention/mamba/mamba.py
@@ -503,7 +503,7 @@ class MambaMixer2(torch.nn.Module):
             )  # this is the form that causal-conv see
             ccfn = (
                 causal_conv1d_fn
-                if not use_triton_causal_conv
+                if is_npu() or not use_triton_causal_conv
                 else causal_conv1d_fn_triton
             )
             hidden_states_B_C_p = ccfn(
@@ -602,7 +602,7 @@ class MambaMixer2(torch.nn.Module):
             else:
                 ccu = (
                     causal_conv1d_update
-                    if not use_triton_causal_conv
+                    if is_npu() or not use_triton_causal_conv
                     else causal_conv1d_update_triton
                 )
                 hidden_states_B_C_d = ccu(

--- a/python/sglang/srt/layers/attention/mamba/ops/ssd_combined.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/ssd_combined.py
@@ -33,7 +33,6 @@ elif is_npu():
         _chunk_state_fwd,
         chunk_state_varlen
     )
-    print("enter npu")
 
 from .ssd_state_passing import _state_passing_fwd
 

--- a/python/sglang/srt/layers/attention/mamba/ops/ssd_combined.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/ssd_combined.py
@@ -12,10 +12,29 @@ import torch
 import triton
 from einops import rearrange
 from packaging import version
+from sglang.srt.utils import is_cuda, is_npu
 
 from .ssd_bmm import _bmm_chunk_fwd
-from .ssd_chunk_scan import _chunk_scan_fwd
-from .ssd_chunk_state import _chunk_cumsum_fwd, _chunk_state_fwd, chunk_state_varlen
+
+if is_cuda:
+    from .ssd_chunk_scan import _chunk_scan_fwd
+elif is_npu:
+     from sgl_kernel_npu.mamba.ssd_chunk_scan import _chunk_scan_fwd
+
+if is_cuda():
+    from .ssd_chunk_state import (
+        _chunk_cumsum_fwd,
+        _chunk_state_fwd,
+        chunk_state_varlen
+    )
+elif is_npu():
+    from sgl_kernel_npu.mamba.ssd_chunk_state import (
+        _chunk_cumsum_fwd,
+        _chunk_state_fwd,
+        chunk_state_varlen
+    )
+    print("enter npu")
+
 from .ssd_state_passing import _state_passing_fwd
 
 TRITON_22 = version.parse(triton.__version__) >= version.parse("2.2.0")

--- a/python/sglang/srt/layers/attention/mamba/ops/ssd_combined.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/ssd_combined.py
@@ -12,6 +12,7 @@ import torch
 import triton
 from einops import rearrange
 from packaging import version
+
 from sglang.srt.utils import is_cuda, is_npu
 
 from .ssd_bmm import _bmm_chunk_fwd
@@ -19,19 +20,15 @@ from .ssd_bmm import _bmm_chunk_fwd
 if is_cuda():
     from .ssd_chunk_scan import _chunk_scan_fwd
 elif is_npu():
-     from sgl_kernel_npu.mamba.ssd_chunk_scan import _chunk_scan_fwd
+    from sgl_kernel_npu.mamba.ssd_chunk_scan import _chunk_scan_fwd
 
 if is_cuda():
-    from .ssd_chunk_state import (
-        _chunk_cumsum_fwd,
-        _chunk_state_fwd,
-        chunk_state_varlen
-    )
+    from .ssd_chunk_state import _chunk_cumsum_fwd, _chunk_state_fwd, chunk_state_varlen
 elif is_npu():
     from sgl_kernel_npu.mamba.ssd_chunk_state import (
         _chunk_cumsum_fwd,
         _chunk_state_fwd,
-        chunk_state_varlen
+        chunk_state_varlen,
     )
 
 from .ssd_state_passing import _state_passing_fwd

--- a/python/sglang/srt/layers/attention/mamba/ops/ssd_combined.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/ssd_combined.py
@@ -16,9 +16,9 @@ from sglang.srt.utils import is_cuda, is_npu
 
 from .ssd_bmm import _bmm_chunk_fwd
 
-if is_cuda:
+if is_cuda():
     from .ssd_chunk_scan import _chunk_scan_fwd
-elif is_npu:
+elif is_npu():
      from sgl_kernel_npu.mamba.ssd_chunk_scan import _chunk_scan_fwd
 
 if is_cuda():

--- a/python/sglang/srt/models/granitemoehybrid.py
+++ b/python/sglang/srt/models/granitemoehybrid.py
@@ -452,7 +452,7 @@ class GraniteMoeHybridModel(nn.Module):
                 }
             )
         else:
-            hidden_states, _ = self.norm(hidden_states, residual)
+            hidden_states = self.norm(hidden_states)
 
         if len(aux_hidden_states) == 0:
             return hidden_states


### PR DESCRIPTION
## Motivation
Enable GraniteMoeHybridForCausalLM (IBM Granite 4.0 MoE Hybrid) to run correctly on Ascend NPU backend by fixing accuracy issues in the attention layer.
  
## Key Fix
Problem: **torch_npu._npu_flash_attention_qlens** and **torch_npu._npu_paged_attention** has accuracy issues in cross-attention scenarios and with Granite Hybrid models.
Solution: 
1. Set **use_native_sdpa = True** for GraniteMoeHybridForCausalLM
2. Introduced **use_npu_paged_attention** flag (default True, set False for Granite Hybrid) to dynamically route to native SDPA when needed.

### Usage

```bash
python -m sglang.launch_server \
--model-path  /home/weights/granite-4.0-h-micro \
--port 8010 \
--tp-size 1 \
--mem-fraction-static 0.7 \
--base-gpu-id 0  \
--max-total-tokens 4096 \
--attention-backend ascend \
--device npu \
```