### PR TITLE
[Bug Fix] Reject pp_max_micro_batch_size=0 to prevent silent deadlock on generate()

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -702,7 +702,7 @@ class Scheduler(
             _,
             _,
         ) = self.tp_worker.get_worker_info()
-        if get_global_server_args().pp_max_micro_batch_size is None:
+        if not get_global_server_args().pp_max_micro_batch_size:
             get_global_server_args().pp_max_micro_batch_size = max(
                 self.max_running_requests // self.pp_size, 1
             )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6619,6 +6619,13 @@ class ServerArgs:
             self.tp_size * self.pp_size
         ) % self.nnodes == 0, "tp_size must be divisible by number of nodes"
 
+        assert (
+            self.pp_max_micro_batch_size is None or self.pp_max_micro_batch_size >= 1
+        ), (
+            "pp_max_micro_batch_size must be a positive integer or None (for auto-compute). "
+            f"Got: {self.pp_max_micro_batch_size}"
+        )
+
         if self.pp_size > 1:
             assert (
                 self.disable_overlap_schedule and self.speculative_algorithm is None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation


`pp_max_micro_batch_size` is an `Optional[int]` CLI argument that defaults to `None`. When `None`, `Scheduler.__init__` auto-computes a safe value via `max(self.max_running_requests // self.pp_size, 1)` — always ≥ 1.

Passing an explicit `0` bypassed the `is None` guard in `scheduler.py`, leaving `pp_max_micro_batch_size = 0` throughout execution. `Scheduler.get_num_allocatable_reqs` then returns `0 - running_bs ≤ 0` on every scheduler tick, so no request ever transitions from waiting → running. The first `engine.generate()` call hangs indefinitely — with no assertion, no exception, no watchdog fire, and no stderr output past the CUDA-graph capture phase.

Found and fixed. Same family as the `prefill_max_requests=0` silent deadlock.

Closes #23789

## Modifications

- **`python/sglang/srt/server_args.py`** — Added an assertion in `check_server_args`
  that rejects `pp_max_micro_batch_size <= 0` at startup with a clear error message: AssertionError: pp_max_micro_batch_size     must be a positive integer or None (for auto-compute). Got: 0 This fails fast before any model loading or CUDA graph capture occurs.

- **`python/sglang/srt/managers/scheduler.py`** — Broadened the auto-compute guard from `is None` to `not pp_max_micro_batch_size`, so `0` also falls through to the safe auto-compute path as defense-in-depth (e.g. when `Engine()` is called programmatically, bypassing CLI validation).

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
