### PR TITLE
[tokenizer] Guard communicator handle_recv against stale messages

### DIFF
--- a/python/sglang/srt/managers/communicator.py
+++ b/python/sglang/srt/managers/communicator.py
@@ -81,9 +81,14 @@ class FanOutCommunicator(Generic[T]):
             return await self.watching_call(obj)
 
     def handle_recv(self, recv_obj: T):
-        self._result_values.append(recv_obj)
-        if len(self._result_values) == self._fan_out:
-            self._result_event.set()
+        # Guard against stale late-arriving messages after the active call has
+        # already completed and cleared shared state. Without this, a delayed
+        # response from a previous round would AttributeError on append() and
+        # kill the TokenizerManager event loop.
+        if self._result_values is not None and self._result_event is not None:
+            self._result_values.append(recv_obj)
+            if len(self._result_values) == self._fan_out:
+                self._result_event.set()
 
     @staticmethod
     def merge_results(results):

--- a/test/registered/tokenizer/test_tokenizer_communicator.py
+++ b/test/registered/tokenizer/test_tokenizer_communicator.py
@@ -1,0 +1,51 @@
+import asyncio
+import unittest
+
+try:
+    from sglang.test.ci.ci_register import register_cpu_ci
+except ModuleNotFoundError:
+    # Allows running this unit test in minimal local environments.
+    def register_cpu_ci(*args, **kwargs):
+        return
+
+
+register_cpu_ci(est_time=10, suite="default", nightly=True)
+
+
+from sglang.srt.managers.communicator import FanOutCommunicator
+
+
+class _DummySender:
+    def __init__(self):
+        self.sent = []
+
+    def send_pyobj(self, obj):
+        self.sent.append(obj)
+
+
+class TestTokenizerCommunicator(unittest.IsolatedAsyncioTestCase):
+    async def test_handle_recv_ignores_stale_message_after_watch_completes(self):
+        sender = _DummySender()
+        communicator = FanOutCommunicator(sender=sender, fan_out=1, mode="watching")
+
+        watch_task = asyncio.create_task(communicator.watching_call(obj={"op": "x"}))
+        await asyncio.sleep(0)
+
+        # Simulate normal response completing the active watch.
+        communicator.handle_recv({"result": 1})
+        result = await watch_task
+
+        self.assertEqual(result, [{"result": 1}])
+        self.assertIsNone(communicator._result_values)
+        self.assertIsNone(communicator._result_event)
+
+        # Simulate a stale late-arriving message after cleanup.
+        communicator.handle_recv({"stale": True})
+
+        # No crash and no state reactivation.
+        self.assertIsNone(communicator._result_values)
+        self.assertIsNone(communicator._result_event)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)


### PR DESCRIPTION
This PR fixes a race in tokenizer communicator receive handling. Late messages can arrive after watching-call cleanup; previously that path could append into cleared state and throw. I added a guard in handle_recv so it only processes messages when active watch state exists, plus a regression test that reproduces the late-message case and verifies no crash. Local test run: /usr/bin/python3 -m unittest discover -s test/registered/tokenizer -p test_tokenizer_communicator.py -v (pass).

## Motivation

Fix a race in tokenizer communicator receive handling. Late messages can arrive after a watch call has already cleaned up internal state. Previously, that path could try to append into cleared state and throw.

## Modifications

1. Added a guard in handle_recv so it only appends/signals when active watch state exists.
2. Added a regression test that completes a watch call, sends a late stale message, and verifies no crash.

## Accuracy Tests

Ran:

`/usr/bin/python3 -m unittest discover -s test/registered/tokenizer -p test_tokenizer_communicator.py -v`

Pass:

test_handle_recv_ignores_stale_message_after_watch_completes

## Speed Tests and Profiling

Not applicable. This is a control-flow safety fix only.