### PR TITLE
[Feature] Xiaomi MiMo-V2.5-Pro day0 support

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -338,7 +338,8 @@ class ModelConfig:
         if is_draft_model and self.hf_config.architectures[0] == "MiMoForCausalLM":
             self.hf_config.architectures[0] = "MiMoMTP"
         if is_draft_model and self.hf_config.architectures[0] in (
-            "MiMoV2FlashForCausalLM", "MiMoV2ProForCausalLM",
+            "MiMoV2FlashForCausalLM",
+            "MiMoV2ProForCausalLM",
         ):
             self.hf_config.architectures[0] = "MiMoV2MTP"
         if is_draft_model and self.hf_config.architectures[0] == "Step3p5ForCausalLM":
@@ -1550,7 +1551,10 @@ def get_hybrid_layer_ids(
         full_attention_layer_ids = [
             i for i, x in enumerate(layer_types) if x == "full_attention"
         ]
-    elif any(x in model_architectures for x in ("MiMoV2FlashForCausalLM", "MiMoV2ProForCausalLM")):
+    elif any(
+        x in model_architectures
+        for x in ("MiMoV2FlashForCausalLM", "MiMoV2ProForCausalLM")
+    ):
         hybrid_layer_pattern = getattr(hf_text_config, "hybrid_layer_pattern", None)
         swa_attention_layer_ids = [
             i for i in range(num_hidden_layers) if hybrid_layer_pattern[i] == 1

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -338,8 +338,8 @@ class ModelConfig:
         if is_draft_model and self.hf_config.architectures[0] == "MiMoForCausalLM":
             self.hf_config.architectures[0] = "MiMoMTP"
         if is_draft_model and self.hf_config.architectures[0] in (
+            "MiMoV2ForCausalLM",
             "MiMoV2FlashForCausalLM",
-            "MiMoV2ProForCausalLM",
         ):
             self.hf_config.architectures[0] = "MiMoV2MTP"
         if is_draft_model and self.hf_config.architectures[0] == "Step3p5ForCausalLM":
@@ -397,8 +397,8 @@ class ModelConfig:
         self.has_attention_sinks = self._detect_attention_sinks()
 
         self.is_hybrid_swa_compress = self.hf_config.architectures[0] in [
+            "MiMoV2ForCausalLM",
             "MiMoV2FlashForCausalLM",
-            "MiMoV2ProForCausalLM",
             "MiMoV2MTP",
             "Gemma4ForCausalLM",
             "Gemma4ForConditionalGeneration",
@@ -421,7 +421,7 @@ class ModelConfig:
             a in archs
             for a in (
                 "MiMoV2FlashForCausalLM",
-                "MiMoV2ProForCausalLM",
+                "MiMoV2ForCausalLM",
                 "MiMoV2MTP",
             )
         ):
@@ -1520,9 +1520,9 @@ def is_hybrid_swa_model(model_architectures: List[str]):
     hybrid_swa_archs = {
         "Llama4ForConditionalGeneration",
         "GptOssForCausalLM",
+        "MiMoV2ForCausalLM",
         "MiMoV2FlashForCausalLM",
         "MiMoV2MTP",
-        "MiMoV2ProForCausalLM",
         "Step3p5ForCausalLM",
         "Step3p5MTP",
         "Gemma4ForCausalLM",
@@ -1553,7 +1553,10 @@ def get_hybrid_layer_ids(
         ]
     elif any(
         x in model_architectures
-        for x in ("MiMoV2FlashForCausalLM", "MiMoV2ProForCausalLM")
+        for x in (
+            "MiMoV2ForCausalLM",
+            "MiMoV2FlashForCausalLM",
+        )
     ):
         hybrid_layer_pattern = getattr(hf_text_config, "hybrid_layer_pattern", None)
         swa_attention_layer_ids = [

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -337,9 +337,8 @@ class ModelConfig:
 
         if is_draft_model and self.hf_config.architectures[0] == "MiMoForCausalLM":
             self.hf_config.architectures[0] = "MiMoMTP"
-        if (
-            is_draft_model
-            and self.hf_config.architectures[0] == "MiMoV2FlashForCausalLM"
+        if is_draft_model and self.hf_config.architectures[0] in (
+            "MiMoV2FlashForCausalLM", "MiMoV2ProForCausalLM",
         ):
             self.hf_config.architectures[0] = "MiMoV2MTP"
         if is_draft_model and self.hf_config.architectures[0] == "Step3p5ForCausalLM":
@@ -398,6 +397,7 @@ class ModelConfig:
 
         self.is_hybrid_swa_compress = self.hf_config.architectures[0] in [
             "MiMoV2FlashForCausalLM",
+            "MiMoV2ProForCausalLM",
             "MiMoV2MTP",
             "Gemma4ForCausalLM",
             "Gemma4ForConditionalGeneration",
@@ -416,7 +416,14 @@ class ModelConfig:
             return True
 
         # MiMoV2 creates sinks only when the config flags are set.
-        if any(a in archs for a in ("MiMoV2FlashForCausalLM", "MiMoV2MTP")):
+        if any(
+            a in archs
+            for a in (
+                "MiMoV2FlashForCausalLM",
+                "MiMoV2ProForCausalLM",
+                "MiMoV2MTP",
+            )
+        ):
             return getattr(
                 self.hf_text_config, "add_swa_attention_sink_bias", False
             ) or getattr(self.hf_text_config, "add_full_attention_sink_bias", False)
@@ -1514,6 +1521,7 @@ def is_hybrid_swa_model(model_architectures: List[str]):
         "GptOssForCausalLM",
         "MiMoV2FlashForCausalLM",
         "MiMoV2MTP",
+        "MiMoV2ProForCausalLM",
         "Step3p5ForCausalLM",
         "Step3p5MTP",
         "Gemma4ForCausalLM",
@@ -1542,7 +1550,7 @@ def get_hybrid_layer_ids(
         full_attention_layer_ids = [
             i for i, x in enumerate(layer_types) if x == "full_attention"
         ]
-    elif "MiMoV2FlashForCausalLM" in model_architectures:
+    elif any(x in model_architectures for x in ("MiMoV2FlashForCausalLM", "MiMoV2ProForCausalLM")):
         hybrid_layer_pattern = getattr(hf_text_config, "hybrid_layer_pattern", None)
         swa_attention_layer_ids = [
             i for i in range(num_hidden_layers) if hybrid_layer_pattern[i] == 1

--- a/python/sglang/srt/models/mimo_v2.py
+++ b/python/sglang/srt/models/mimo_v2.py
@@ -76,7 +76,7 @@ from sglang.srt.utils import (
     make_layers,
 )
 
-MiMoV2FlashConfig = None
+MiMoV2Config = None
 
 logger = logging.getLogger(__name__)
 
@@ -178,7 +178,7 @@ class MiMoV2MoE(nn.Module):
 
     def __init__(
         self,
-        config: MiMoV2FlashConfig,
+        config: MiMoV2Config,
         layer_id: int,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
@@ -562,7 +562,7 @@ class MiMoV2Attention(nn.Module):
 class MiMoV2DecoderLayer(nn.Module):
     def __init__(
         self,
-        config: MiMoV2FlashConfig,
+        config: MiMoV2Config,
         layer_id: int = 0,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
@@ -582,7 +582,11 @@ class MiMoV2DecoderLayer(nn.Module):
             and rope_scaling.get("rope_type") == "default"
         ):
             rope_scaling = None
-        max_position_embeddings = getattr(config, "max_position_embeddings", 32768)
+        max_position_embeddings = getattr(
+            config,
+            "context_len",
+            getattr(config, "max_position_embeddings", 32768),
+        )
 
         if self.is_swa_layer():
             self.self_attn = MiMoV2Attention(
@@ -792,7 +796,7 @@ class MiMoV2DecoderLayer(nn.Module):
 class MiMoV2Model(nn.Module):
     def __init__(
         self,
-        config: MiMoV2FlashConfig,
+        config: MiMoV2Config,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
         decoder_layer_type: type[nn.Module] = MiMoV2DecoderLayer,
@@ -965,7 +969,7 @@ class MiMoV2FlashForCausalLM(nn.Module):
 
     def __init__(
         self,
-        config: MiMoV2FlashConfig,
+        config: MiMoV2Config,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
     ) -> None:
@@ -1099,6 +1103,16 @@ class MiMoV2FlashForCausalLM(nn.Module):
             if "mtp" in name:
                 continue
 
+            # Support fused qkv_proj checkpoint (Pro format)
+            if "qkv_proj" in name:
+                if name in params_dict:
+                    tp_size = get_attention_tp_size()
+                    tp_rank = get_attention_tp_rank()
+                    param = params_dict[name]
+                    loaded_weight = loaded_weight.chunk(tp_size, dim=0)[tp_rank]
+                    default_weight_loader(param, loaded_weight)
+                continue
+
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if weight_name not in name:
                     continue
@@ -1173,4 +1187,9 @@ class MiMoV2FlashForCausalLM(nn.Module):
         )
 
 
-EntryClass = MiMoV2FlashForCausalLM
+# Pro uses the same architecture; subclass so registry sees a distinct __name__
+class MiMoV2ProForCausalLM(MiMoV2FlashForCausalLM):
+    pass
+
+
+EntryClass = [MiMoV2FlashForCausalLM, MiMoV2ProForCausalLM]

--- a/python/sglang/srt/models/mimo_v2.py
+++ b/python/sglang/srt/models/mimo_v2.py
@@ -947,7 +947,7 @@ class MiMoV2Model(nn.Module):
                 )
 
 
-class MiMoV2FlashForCausalLM(nn.Module):
+class MiMoV2ForCausalLM(nn.Module):
     # BitandBytes specific attributes
     default_bitsandbytes_target_modules = [
         ".gate_proj.",
@@ -1187,9 +1187,9 @@ class MiMoV2FlashForCausalLM(nn.Module):
         )
 
 
-# Pro uses the same architecture; subclass so registry sees a distinct __name__
-class MiMoV2ProForCausalLM(MiMoV2FlashForCausalLM):
+# Keep the old Flash architecture name loadable while new configs use MiMoV2ForCausalLM.
+class MiMoV2FlashForCausalLM(MiMoV2ForCausalLM):
     pass
 
 
-EntryClass = [MiMoV2FlashForCausalLM, MiMoV2ProForCausalLM]
+EntryClass = [MiMoV2ForCausalLM, MiMoV2FlashForCausalLM]

--- a/python/sglang/srt/models/mimo_v2_nextn.py
+++ b/python/sglang/srt/models/mimo_v2_nextn.py
@@ -42,7 +42,7 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.mimo_v2 import (
     MiMoV2Attention,
-    MiMoV2FlashForCausalLM,
+    MiMoV2ForCausalLM,
     MiMoV2MLP,
 )
 from sglang.srt.server_args import get_global_server_args
@@ -233,7 +233,7 @@ class MiMoV2ModelNextN(nn.Module):
         return hidden_states, hidden_states_before_norm
 
 
-class MiMoV2MTP(MiMoV2FlashForCausalLM):
+class MiMoV2MTP(MiMoV2ForCausalLM):
 
     def __init__(
         self,

--- a/python/sglang/srt/models/mimo_v2_nextn.py
+++ b/python/sglang/srt/models/mimo_v2_nextn.py
@@ -28,6 +28,7 @@ from sglang.srt.layers.communicator import (
 )
 from sglang.srt.layers.dp_attention import (
     get_attention_tp_rank,
+    get_attention_tp_size,
     is_dp_attention_enabled,
 )
 from sglang.srt.layers.layernorm import RMSNorm
@@ -39,7 +40,7 @@ from sglang.srt.layers.vocab_parallel_embedding import (
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
-from sglang.srt.models.mimo_v2_flash import (
+from sglang.srt.models.mimo_v2 import (
     MiMoV2Attention,
     MiMoV2FlashForCausalLM,
     MiMoV2MLP,
@@ -47,7 +48,7 @@ from sglang.srt.models.mimo_v2_flash import (
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import add_prefix
 
-MiMoV2FlashConfig = None
+MiMoV2Config = None
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +56,7 @@ logger = logging.getLogger(__name__)
 class MiMoV2MTPLayer(nn.Module):
     def __init__(
         self,
-        config: MiMoV2FlashConfig,
+        config: MiMoV2Config,
         layer_id: int = 0,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
@@ -71,7 +72,11 @@ class MiMoV2MTPLayer(nn.Module):
             and rope_scaling.get("rope_type") == "default"
         ):
             rope_scaling = None
-        max_position_embeddings = getattr(config, "max_position_embeddings", 32768)
+        max_position_embeddings = getattr(
+            config,
+            "context_len",
+            getattr(config, "max_position_embeddings", 32768),
+        )
 
         self.self_attn = MiMoV2Attention(
             hidden_size=self.hidden_size,
@@ -295,6 +300,16 @@ class MiMoV2MTP(MiMoV2FlashForCausalLM):
             if name.startswith("model.vision_tower") and name not in params_dict:
                 continue
             name = self.map_model_name_to_mtp_param_name(name)
+
+            # Support fused qkv_proj checkpoint (Pro format)
+            if "qkv_proj" in name:
+                if name in params_dict:
+                    tp_size = get_attention_tp_size()
+                    tp_rank = get_attention_tp_rank()
+                    param = params_dict[name]
+                    loaded_weight = loaded_weight.chunk(tp_size, dim=0)[tp_rank]
+                    default_weight_loader(param, loaded_weight)
+                continue
 
             for param_name, weight_name, shard_id in stacked_params_mapping:
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1949,7 +1949,11 @@ class ServerArgs:
                 ), "Triton kernel MoE is only supported when ep_size == 1"
 
         elif any(
-            x in model_arch for x in ("MiMoV2FlashForCausalLM", "MiMoV2ProForCausalLM")
+            x in model_arch
+            for x in (
+                "MiMoV2ForCausalLM",
+                "MiMoV2FlashForCausalLM",
+            )
         ):
             if self.speculative_algorithm == "EAGLE":
                 self.enable_multi_layer_eagle = True
@@ -7320,8 +7324,8 @@ def auto_choose_speculative_params(self: ServerArgs):
         "BailingMoeV2_5ForCausalLM",
         "MistralLarge3ForCausalLM",
         "PixtralForConditionalGeneration",
+        "MiMoV2ForCausalLM",
         "MiMoV2FlashForCausalLM",
-        "MiMoV2ProForCausalLM",
     ]:
         return (3, 1, 4)
     elif arch in ["Grok1ForCausalLM", "Grok1VForCausalLM"]:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1948,11 +1948,11 @@ class ServerArgs:
                     self.ep_size == 1
                 ), "Triton kernel MoE is only supported when ep_size == 1"
 
-        elif "MiMoV2FlashForCausalLM" in model_arch:
+        elif any(x in model_arch for x in ("MiMoV2FlashForCausalLM", "MiMoV2ProForCausalLM")):
             if self.speculative_algorithm == "EAGLE":
                 self.enable_multi_layer_eagle = True
                 logger.info(
-                    "Enable multi-layer EAGLE speculative decoding for MiMoV2FlashForCausalLM model."
+                    "Enable multi-layer EAGLE speculative decoding for MiMoV2 model."
                 )
                 if not envs.SGLANG_ENABLE_SPEC_V2.get():
                     envs.SGLANG_ENABLE_SPEC_V2.set(True)
@@ -1963,11 +1963,11 @@ class ServerArgs:
             if self.enable_hierarchical_cache:
                 self.swa_full_tokens_ratio = 1.0
                 logger.warning(
-                    "Reset swa_full_tokens_ratio to 1.0 for MiMoV2FlashForCausalLM model with hierarchical cache"
+                    "Reset swa_full_tokens_ratio to 1.0 for MiMoV2 model with hierarchical cache"
                 )
                 self.disable_hybrid_swa_memory = True
                 logger.warning(
-                    "Disable hybrid SWA memory for MiMoV2FlashForCausalLM model with hierarchical cache"
+                    "Disable hybrid SWA memory for MiMoV2 model with hierarchical cache"
                 )
         elif "Step3p5ForCausalLM" in model_arch:
             if self.speculative_algorithm == "EAGLE":
@@ -7319,6 +7319,7 @@ def auto_choose_speculative_params(self: ServerArgs):
         "MistralLarge3ForCausalLM",
         "PixtralForConditionalGeneration",
         "MiMoV2FlashForCausalLM",
+        "MiMoV2ProForCausalLM",
     ]:
         return (3, 1, 4)
     elif arch in ["Grok1ForCausalLM", "Grok1VForCausalLM"]:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1948,7 +1948,9 @@ class ServerArgs:
                     self.ep_size == 1
                 ), "Triton kernel MoE is only supported when ep_size == 1"
 
-        elif any(x in model_arch for x in ("MiMoV2FlashForCausalLM", "MiMoV2ProForCausalLM")):
+        elif any(
+            x in model_arch for x in ("MiMoV2FlashForCausalLM", "MiMoV2ProForCausalLM")
+        ):
             if self.speculative_algorithm == "EAGLE":
                 self.enable_multi_layer_eagle = True
                 logger.info(

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2839,6 +2839,7 @@ def is_fa3_default_architecture(hf_config):
         "Step3VLForConditionalGeneration",
         "StepVLForConditionalGeneration",
         "MiMoV2FlashForCausalLM",
+        "MiMoV2ProForCausalLM",
     }
     return architectures[0] in default_archs
 

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2838,8 +2838,8 @@ def is_fa3_default_architecture(hf_config):
         "GlmOcrForConditionalGeneration",
         "Step3VLForConditionalGeneration",
         "StepVLForConditionalGeneration",
+        "MiMoV2ForCausalLM",
         "MiMoV2FlashForCausalLM",
-        "MiMoV2ProForCausalLM",
     }
     return architectures[0] in default_archs
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

MiMo-V2.5-Pro is a Mixture-of-Experts (MoE) language model with 1.02T total parameters and 42B active parameters. It utilizes hybrid attention architecture and 3-layers Multi-Token Prediction (MTP) described in MiMo-V2-Flash. The context length is up to 1M tokens.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

### Benchmark command

```
python3 -m sglang.bench_serving \
  --backend sglang \
  --model XiaomiMiMo/MiMo-V2.5-Pro \
  --host 0.0.0.0 \
  --port 9001 \
  --dataset-name random \
  --random-input-len 8192 \
  --random-output-len 1 \
  --random-range-ratio 1.0 \
  --flush-cache \
  --seed 12345 \
  --num-prompts 10000 
```

### Prefill performance

Test setting: `EP16`, `chunk_size=32K`, output length = 1 token, cache flushed.

| Input length | Output length | Single-node prefill throughput, cache miss |
| ------------ | ------------- | ------------------------------------------ |
| 4K           | 1             | 30.8K tok/s                                |
| 8K           | 1             | 30.65K tok/s                               |
| 16K          | 1             | 29.85K tok/s                               |
| 32K          | 1             | 28.6K tok/s                                |
| 64K          | 1             | 26.65K tok/s                               |
| 128K         | 1             | 23.0K tok/s                                |
| 256K         | 1             | 17.9K tok/s                                |
| 512K         | 1             | 11.3K tok/s                                |
| 768K         | 1             | 9.4K tok/s                                 |
| 1M           | 1             | 7.3K tok/s                                 |

For input lengths up to 256K, we tested with the benchmark commands above and checked the final output / logs to confirm that the requests were processed correctly.

For input lengths >= 512K, we sent two requests and ensured that they were routed to two different DP ranks. We then checked the `bench_serving` output and recorded the single-node prefill throughput.

### Decode performance

Test setting: fixed 16K input and 1K output. We compared single-node decode throughput with and without 3-layer MTP.

| BS per DP rank | MTP      | MTP accept length | TPS  | Single-node decode throughput |
| -------------- | -------- | ----------------- | ---- | ----------------------------- |
| 64             | disabled | -                 | 29.3 | 1875 tok/s                    |
| 64             | 3-layer  | 3                 | 60.5 | 3873 tok/s                    |
| 64             | 3-layer  | 4                 | 79.7 | 5103 tok/s                    |
| 96             | disabled | -                 | 26.7 | 2564 tok/s                    |
| 96             | 3-layer  | 3                 | 50.4 | 4840 tok/s                    |
| 96             | 3-layer  | 4                 | 64.8 | 6225 tok/s                    |

With 3-layer MTP enabled, decode throughput improves significantly:

| BS per DP rank | Without MTP | 3-layer MTP, accept length = 3 | 3-layer MTP, accept length = 4 |
| -------------- | ----------- | ------------------------------ | ------------------------------ |
| 64             | 1875 tok/s  | 3873 tok/s                     | 5103 tok/s                     |
| 96             | 2564 tok/s  | 4840 tok/s                     | 6225 tok/s                     |

These results show that the model can run correctly with long-context prefill up to 1M tokens, and 3-layer MTP provides a clear decode-side throughput improvement under the tested 16K-input / 1K-output setting.



## Launch Command example


```shell
SGLANG_ENABLE_SPEC_V2=1
SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256
python3 -m sglang.launch_server \
              --model-path XiaomiMiMo/MiMo-V2.5-Pro \
              --trust-remote-code \
              --pp-size 1 \
              --dp-size 2 \
              --ep-size 16 \
              --tp-size 16 \
              --moe-dense-tp-size 1 \
              --enable-dp-attention \
              --moe-a2a-backend deepep \
              --dist-init-addr ${LWS_LEADER_IP}:20000 \
              --node-rank ${LWS_WORKER_INDEX} \
              --nnodes ${LWS_GROUP_SIZE} \
              --page-size 64 \
              --attention-backend fa3 \
              --quantization fp8 \
              --mem-fraction-static 0.7 \
              --max-running-requests 128 \
              --cuda-graph-max-bs 64 \
              --chunked-prefill-size 32768 \
              --context-length 1048576 \
              --tokenizer-worker-num 64 \
              --speculative-algorithm EAGLE \
              --speculative-num-steps 3 \
              --speculative-eagle-topk 1 \
              --speculative-num-draft-tokens 4 \
              --enable-multi-layer-eagle \
              --host 0.0.0.0 \
              --port 9001 \
              --reasoning-parser mimo \
              --tool-call-parser mimo \
              --watchdog-timeout 3600 \
              --model-loader-extra-config '{"enable_multithread_load": "true","num_threads": 64}' 
```


MiMo-V2.5-Pro FP8 checkpoint uses a fused QKV projection layout exported with attention TP=8.

The FP8 quantization is performed independently on each attention TP shard before the shards are concatenated into the HF checkpoint. Therefore, the fused qkv_proj checkpoint is TP-rank-interleaved rather than a flat [Q_all | K_all | V_all] layout.

For MiMo-V2.5-Pro:
- hidden_size = 6144
- num_attention_heads = 128
- head_dim = 192
- num_key_value_heads = 8
- v_head_dim = 128

With attention TP=8, each attention TP shard has:
- Q: 128 / 8 * 192 = 3072 rows
- K: 1 * 192 = 192 rows
- V: 1 * 128 = 128 rows
- Total QKV output per shard = 3392 rows

Since FP8 block-wise quantization uses 128x128 blocks, each TP shard's row dimension is padded independently for scale generation:

ceil(3392 / 128) = 27

So each shard has:
- qkv_proj.weight shard shape: [3392, 6144]
- qkv_proj.weight_scale_inv shard shape: [27, 48]

After concatenating 8 shards along the row dimension, the HF checkpoint stores:
- qkv_proj.weight: [27136, 6144]
- qkv_proj.weight_scale_inv: [216, 48]

Note that the scale rows are 8 * ceil(3392 / 128) = 216, not ceil((3392 * 8) / 128) = 212, because quantization is done independently per TP shard.

Therefore, this checkpoint requires runtime attention TP=8 for the fused QKV loading path. With DP attention enabled, this means the derived attention TP size should be 8, e.g. --tp-size 16 --dp-size 2 gives attention TP=8.





## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
