### PR TITLE
[NPU] Fix DeepEP LL dispatch BF16 flag and skip triton kernel on NPU for Qwen3.5

### DIFF
--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -620,9 +620,8 @@ class _DeepEPDispatcherImplLowLatency(_DeepEPDispatcherImplBase):
         input_global_scale = self.quant_config.get("input_global_scale", None)
         if input_global_scale is not None:
             use_nvfp4 = True
-        elif (
-            not get_moe_runner_backend().is_flashinfer_cutedsl()
-            and (not _is_npu or not envs.SGLANG_DEEPEP_BF16_DISPATCH.get())
+        elif not get_moe_runner_backend().is_flashinfer_cutedsl() and (
+            not _is_npu or not envs.SGLANG_DEEPEP_BF16_DISPATCH.get()
         ):
             # flashinfer_cutedsl expects BF16 dispatch when NVFP4 dispatch is
             # off; its kernel quantizes to NVFP4 internally.

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -622,7 +622,7 @@ class _DeepEPDispatcherImplLowLatency(_DeepEPDispatcherImplBase):
             use_nvfp4 = True
         elif (
             not get_moe_runner_backend().is_flashinfer_cutedsl()
-            and not envs.SGLANG_DEEPEP_BF16_DISPATCH.get()
+            and (not _is_npu or not envs.SGLANG_DEEPEP_BF16_DISPATCH.get())
         ):
             # flashinfer_cutedsl expects BF16 dispatch when NVFP4 dispatch is
             # off; its kernel quantizes to NVFP4 internally.

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -620,9 +620,14 @@ class _DeepEPDispatcherImplLowLatency(_DeepEPDispatcherImplBase):
         input_global_scale = self.quant_config.get("input_global_scale", None)
         if input_global_scale is not None:
             use_nvfp4 = True
-        elif not get_moe_runner_backend().is_flashinfer_cutedsl():
+        elif (
+            not get_moe_runner_backend().is_flashinfer_cutedsl()
+            and not envs.SGLANG_DEEPEP_BF16_DISPATCH.get()
+        ):
             # flashinfer_cutedsl expects BF16 dispatch when NVFP4 dispatch is
             # off; its kernel quantizes to NVFP4 internally.
+            # SGLANG_DEEPEP_BF16_DISPATCH forces BF16 dispatch for NPU
+            # where INT8 input + BF16 weight GMM is not supported.
             use_fp8 = True
 
         # round_scale / use_ue8m0 are FP8-DeepGEMM specific; they cause DeepEP

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -464,7 +464,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             hidden_states
         )
 
-        if self.num_v_heads // self.num_k_heads in [1, 2, 4] and not _is_cpu:
+        if self.num_v_heads // self.num_k_heads in [1, 2, 4] and not _is_cpu and not _is_npu:
             mixed_qkv, z, b, a = fused_qkvzba_split_reshape_cat_contiguous(
                 projected_states_qkvz,
                 projected_states_ba,
@@ -488,6 +488,8 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             query, key, value, z, b, a = self.fix_query_key_value_ordering(
                 projected_states_qkvz, projected_states_ba
             )
+            b = b.contiguous()
+            a = a.contiguous()
 
             query, key, value = map(
                 lambda x: x.reshape(x.shape[0], -1), (query, key, value)

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -464,7 +464,11 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             hidden_states
         )
 
-        if self.num_v_heads // self.num_k_heads in [1, 2, 4] and not _is_cpu and not _is_npu:
+        if (
+            self.num_v_heads // self.num_k_heads in [1, 2, 4]
+            and not _is_cpu
+            and not _is_npu
+        ):
             mixed_qkv, z, b, a = fused_qkvzba_split_reshape_cat_contiguous(
                 projected_states_qkvz,
                 projected_states_ba,


### PR DESCRIPTION
## Motivation
Fix two bugs that block NPU inference for Qwen3.5 MoE models with DeepEP backend.

## Modifications

### 1. DeepEP low-latency dispatch ignores `SGLANG_DEEPEP_BF16_DISPATCH` (`deepep.py`)
The normal dispatch path respects `SGLANG_DEEPEP_BF16_DISPATCH` to skip FP8 quantization, but the low-latency dispatch path (`_dispatch_core`) did not check this flag. It always quantized hidden states to INT8/FP8 during all-to-all communication, causing a dtype mismatch on NPU where `npu_grouped_matmul` does not support INT8 input with BF16 weights.

Fix : Added `and not envs.SGLANG_DEEPEP_BF16_DISPATCH.get()` to the `use_fp8` condition in `_dispatch_core` , consistent with the normal dispatch path.

### 2. Skip triton kernel on NPU in Qwen3.5 GDN forward (`qwen3_5.py`)
The `fused_qkvzba_split_reshape_cat_contiguous` triton kernel uses a 2D grid that crashes when token count exceeds 65536. This kernel is GPU-only and unnecessary on NPU.

Fix : Added `and not _is_npu` to the condition so NPU uses the PyTorch-native `fix_query_key_value_ordering` path instead.

## Accuracy Tests

```
export DEEP_NORMAL_MODE_USE_INT8_QUANT=0
export SGLANG_DEEPEP_BF16_DISPATCH=1

MODEL_PATH=/home/weights/Qwen3.6-35B-A3B
python3 -m sglang.launch_server \
        --model-path ${MODEL_PATH} \
        --attention-backend ascend \
        --device npu \
        --tp-size 4 --nnodes 1 --node-rank 0 \
        --chunked-prefill-size -1 --max-prefill-tokens 16384 \
        --trust-remote-code \
        --host 127.0.0.1 --max-running-requests 128 \
        --mem-fraction-static 0.8 \
        --port 9903 \
        --mm-attention-backend ascend_attn --max-total-tokens 800000 \
        --dtype bfloat16 --mamba-ssm-dtype bfloat16 \
        --base-gpu-id 4 \
        --enable-multimodal \
        --disable-radix-cache \
        --dp-size 2 --enable-dp-attention --enable-dp-lm-head \
        --cuda-graph-bs 8 12 16 20 24 32 40 48 56 64 \
        --speculative-algorithm NEXTN --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 \
        --speculative-draft-model-quantization unquant \
        --moe-a2a-backend deepep --deepep-mode auto \
```

```
+-----------------+-----------+----------+------------------------------------------+-------+---------+----------------+
| Qwen3.6-35B-A3B | ceval     | mean_acc | OVERALL                                  |  1346 |  0.893  | -              |
+-----------------+-----------+----------+------------------------------------------+-------+---------+----------------+
```

## Speed Tests and Profiling

No speed impact. The `fix_query_key_value_ordering` path on NPU uses basic PyTorch ops and has similar cost to the triton kernel.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
4. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
5. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
6. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
