### PR TITLE
docs: verify GB300 Pro DeepSeek V4 recipes

### DIFF
--- a/docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx
@@ -182,7 +182,9 @@ export const DeepSeekV4Deployment = () => {
     "gb300|small|low-latency",
     "gb300|big|low-latency",
     "gb300|small|balanced",
+    "gb300|big|balanced",
     "gb300|small|max-throughput",
+    "gb300|big|max-throughput",
     "h200|small|cp",
     "h200|small|pd-disagg",
     "h200|big|low-latency",
@@ -365,6 +367,8 @@ export const DeepSeekV4Deployment = () => {
       flags.push("  --speculative-num-draft-tokens 2");
       if (hardware === "h200" && isBig) {
         flags.push("  --mem-fraction-static 0.88");
+      } else if (isBig && hardware === "gb300") {
+        flags.push("  --mem-fraction-static 0.9");
       } else if (isBig && hardware === "gb200") {
         flags.push("  --mem-fraction-static 0.78");
       } else if (isBig) {
@@ -401,6 +405,8 @@ export const DeepSeekV4Deployment = () => {
       flags.push("  --moe-a2a-backend deepep");
       if (hardware === "h200" && isBig) {
         flags.push("  --mem-fraction-static 0.88");
+      } else if (isBig && hardware === "gb300") {
+        flags.push("  --mem-fraction-static 0.9");
       } else if (isBig && hardware === "gb200") {
         flags.push("  --mem-fraction-static 0.78");
       } else if (isBig) {


### PR DESCRIPTION
Summary:
- mark GB300 Pro balanced and max-throughput recipes verified
- set GB300 Pro balanced/max-throughput mem-fraction-static to 0.9
