### PR TITLE
[NPU] Fix warmup error with --disable-cuda-graph and mtp

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -1846,10 +1846,13 @@ class AscendAttnBackend(AttentionBackend):
                     actual_seq_len_kv = (
                         self.forward_metadata.seq_lens_cpu_int.cpu().int().tolist()
                     )
+                num_token_padding = q.shape[0]
+                actual_bs = self.forward_metadata.block_tables.shape[0]
+                q = q[:actual_bs]
                 attn_output, _ = torch.ops.npu.npu_fused_infer_attention_score(
                     q.view(
-                        forward_batch.batch_size,
                         -1,
+                        1,
                         layer.tp_q_head_num,
                         layer.qk_head_dim,
                     ),
@@ -1868,6 +1871,17 @@ class AscendAttnBackend(AttentionBackend):
                     actual_seq_lengths_kv=actual_seq_len_kv,
                     scale=layer.scaling,
                 )
+                if actual_bs != num_token_padding:
+                    attn_output = torch.cat(
+                        [
+                            attn_output,
+                            attn_output.new_zeros(
+                                num_token_padding - actual_bs,
+                                *attn_output.shape[1:],
+                            ),
+                        ],
+                        dim=0,
+                    )
             # there are some accuracy issues in cross attention scene to use torch_npu._npu_flash_attention_qlens
             # forward_batch.encoder_lens is not None in cross attention scend, we add native attn to solve accuracy issues
             elif forward_batch.encoder_lens is None and layer.logit_cap == 0:


### PR DESCRIPTION
## Motivation
The server warmup encounters an error in forward_decode when --disable-cuda-graph is enabled. The root cause is the redundant padding tokens in the input tensor, which leads to a dimension mismatch for the NPU fused attention operator.
```
File "/xxx/sglang/srt/hardware_backend/npu/attention/ascend_backend.py", line 1846, in forward_decode
attn_output, _ = torch.ops.npu.npu_fused_infer_attention_score(
```

## Modification

Fix the padding logic in forward_decode for the NPU attention backend:

- Crop the query tensor to remove redundant padding tokens before calling the NPU fused attention operator
- Run the fused attention operator with the valid tensor
- Pad zeros back to restore the original tensor shape after the operator computation

## Accuracy Tests

```
export DEEP_NORMAL_MODE_USE_INT8_QUANT=0
export SGLANG_DEEPEP_BF16_DISPATCH=1

MODEL_PATH=/home/weights/Qwen3.6-35B-A3B
python3 -m sglang.launch_server \
        --model-path ${MODEL_PATH} \
        --attention-backend ascend \
        --device npu \
        --tp-size 4 --nnodes 1 --node-rank 0 \
        --chunked-prefill-size -1 --max-prefill-tokens 16384 \
        --trust-remote-code \
        --host 127.0.0.1 --max-running-requests 128 \
        --mem-fraction-static 0.8 \
        --port 9903 \
        --mm-attention-backend ascend_attn --max-total-tokens 800000 \
        --dtype bfloat16 --mamba-ssm-dtype bfloat16 \
        --base-gpu-id 4 \
        --enable-multimodal \
        --disable-radix-cache \
        --dp-size 2 --enable-dp-attention --enable-dp-lm-head \
        --speculative-algorithm NEXTN --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 \
        --speculative-draft-model-quantization unquant \
        --moe-a2a-backend deepep --deepep-mode auto \
        --disable-cuda-graph \
```

```
+-----------------+-----------+----------+------------------------------------------+-------+---------+----------------+
| Qwen3.6-35B-A3B | ceval     | mean_acc | OVERALL                                  |  1346 |  0.9005 | -              |
+-----------------+-----------+----------+------------------------------------------+-------+---------+----------------+

```

## Speed Tests and Profiling

No impact.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
