### PR TITLE
Fix pre-stream bad-request status for OpenAI streaming endpoints

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_base.py
+++ b/python/sglang/srt/entrypoints/openai/serving_base.py
@@ -4,6 +4,7 @@ import json
 import logging
 import uuid
 from abc import ABC, abstractmethod
+from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
 
 import orjson
@@ -239,6 +240,46 @@ class OpenAIServingBase(ABC):
             code=status_code,
         )
         return json.dumps({"error": error.model_dump()})
+
+    def maybe_convert_pre_stream_bad_request(
+        self, first_chunk: Any
+    ) -> Optional[ORJSONResponse]:
+        """Convert a pre-stream SSE bad-request chunk into an HTTP 400 response.
+
+        Streaming OpenAI handlers kick-start their generators before returning a
+        StreamingResponse so deterministic validation failures can still surface
+        as request-level HTTP errors. Some validation paths in stream mode yield
+        an SSE error chunk as the first item instead of raising ValueError.
+        Detect that first-chunk bad-request case and convert it back into the
+        same flat HTTP 400 error payload used by non-streaming requests.
+        """
+        if isinstance(first_chunk, bytes):
+            first_chunk = first_chunk.decode()
+        if not isinstance(first_chunk, str) or not first_chunk.startswith("data: "):
+            return None
+
+        payload = first_chunk[len("data: ") :].strip()
+        if payload == "[DONE]":
+            return None
+
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError:
+            return None
+
+        error = data.get("error")
+        if not isinstance(error, dict):
+            return None
+
+        if error.get("code") != HTTPStatus.BAD_REQUEST.value:
+            return None
+
+        return self.create_error_response(
+            message=error.get("message", "Bad request"),
+            err_type="BadRequest",
+            status_code=HTTPStatus.BAD_REQUEST.value,
+            param=error.get("param"),
+        )
 
     def extract_custom_labels(self, raw_request):
         if (

--- a/python/sglang/srt/entrypoints/openai/serving_base.py
+++ b/python/sglang/srt/entrypoints/openai/serving_base.py
@@ -295,10 +295,13 @@ class OpenAIServingBase(ABC):
         param = error.get("param")
         if not isinstance(param, str):
             param = None
+        err_type = error.get("type")
+        if not isinstance(err_type, str) or not err_type:
+            err_type = "BadRequest"
 
         return self.create_error_response(
             message=message,
-            err_type="BadRequest",
+            err_type=err_type,
             status_code=status_code,
             param=param,
         )

--- a/python/sglang/srt/entrypoints/openai/serving_base.py
+++ b/python/sglang/srt/entrypoints/openai/serving_base.py
@@ -254,11 +254,18 @@ class OpenAIServingBase(ABC):
         same flat HTTP 400 error payload used by non-streaming requests.
         """
         if isinstance(first_chunk, bytes):
-            first_chunk = first_chunk.decode()
-        if not isinstance(first_chunk, str) or not first_chunk.startswith("data: "):
+            try:
+                first_chunk = first_chunk.decode()
+            except UnicodeDecodeError:
+                return None
+        if not isinstance(first_chunk, str):
             return None
 
-        payload = first_chunk[len("data: ") :].strip()
+        first_chunk = first_chunk.strip()
+        if not first_chunk.startswith("data:"):
+            return None
+
+        payload = first_chunk[len("data:") :].strip()
         if payload == "[DONE]":
             return None
 
@@ -267,18 +274,33 @@ class OpenAIServingBase(ABC):
         except json.JSONDecodeError:
             return None
 
+        if not isinstance(data, dict):
+            return None
+
         error = data.get("error")
         if not isinstance(error, dict):
             return None
 
-        if error.get("code") != HTTPStatus.BAD_REQUEST.value:
+        try:
+            status_code = int(error.get("code"))
+        except (TypeError, ValueError):
             return None
 
+        if status_code != HTTPStatus.BAD_REQUEST.value:
+            return None
+
+        message = error.get("message")
+        if not isinstance(message, str) or not message:
+            message = "Bad request"
+        param = error.get("param")
+        if not isinstance(param, str):
+            param = None
+
         return self.create_error_response(
-            message=error.get("message", "Bad request"),
+            message=message,
             err_type="BadRequest",
-            status_code=HTTPStatus.BAD_REQUEST.value,
-            param=error.get("param"),
+            status_code=status_code,
+            param=param,
         )
 
     def extract_custom_labels(self, raw_request):

--- a/python/sglang/srt/entrypoints/openai/serving_base.py
+++ b/python/sglang/srt/entrypoints/openai/serving_base.py
@@ -4,6 +4,7 @@ import json
 import logging
 import uuid
 from abc import ABC, abstractmethod
+from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
 
 import orjson
@@ -226,6 +227,71 @@ class OpenAIServingBase(ABC):
             code=status_code,
         )
         return json.dumps({"error": error.model_dump()})
+
+    def maybe_convert_pre_stream_bad_request(
+        self, first_chunk: Any
+    ) -> Optional[ORJSONResponse]:
+        """Convert a pre-stream SSE bad-request chunk into an HTTP 400 response.
+
+        Streaming OpenAI handlers kick-start their generators before returning a
+        StreamingResponse so deterministic validation failures can still surface
+        as request-level HTTP errors. Some validation paths in stream mode yield
+        an SSE error chunk as the first item instead of raising ValueError.
+        Detect that first-chunk bad-request case and convert it back into the
+        same flat HTTP 400 error payload used by non-streaming requests.
+        """
+        if isinstance(first_chunk, bytes):
+            try:
+                first_chunk = first_chunk.decode()
+            except UnicodeDecodeError:
+                return None
+        if not isinstance(first_chunk, str):
+            return None
+
+        first_chunk = first_chunk.strip()
+        if not first_chunk.startswith("data:"):
+            return None
+
+        payload = first_chunk[len("data:") :].strip()
+        if payload == "[DONE]":
+            return None
+
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError:
+            return None
+
+        if not isinstance(data, dict):
+            return None
+
+        error = data.get("error")
+        if not isinstance(error, dict):
+            return None
+
+        try:
+            status_code = int(error.get("code"))
+        except (TypeError, ValueError):
+            return None
+
+        if status_code != HTTPStatus.BAD_REQUEST.value:
+            return None
+
+        message = error.get("message")
+        if not isinstance(message, str) or not message:
+            message = "Bad request"
+        param = error.get("param")
+        if not isinstance(param, str):
+            param = None
+        err_type = error.get("type")
+        if not isinstance(err_type, str) or not err_type:
+            err_type = "BadRequest"
+
+        return self.create_error_response(
+            message=message,
+            err_type=err_type,
+            status_code=status_code,
+            param=param,
+        )
 
     def extract_custom_labels(self, raw_request):
         if (

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -721,6 +721,8 @@ class OpenAIServingChat(OpenAIServingBase):
             first_chunk = await generator.__anext__()
         except ValueError as e:
             return self.create_error_response(str(e))
+        if error_response := self.maybe_convert_pre_stream_bad_request(first_chunk):
+            return error_response
 
         async def prepend_first_chunk():
             yield first_chunk

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -710,7 +710,7 @@ class OpenAIServingChat(OpenAIServingBase):
         adapted_request: GenerateReqInput,
         request: ChatCompletionRequest,
         raw_request: Request,
-    ) -> Union[StreamingResponse, ErrorResponse]:
+    ) -> Union[StreamingResponse, ErrorResponse, ORJSONResponse]:
         """Handle streaming chat completion request"""
         generator = self._generate_chat_stream(adapted_request, request, raw_request)
 
@@ -722,6 +722,7 @@ class OpenAIServingChat(OpenAIServingBase):
         except ValueError as e:
             return self.create_error_response(str(e))
         if error_response := self.maybe_convert_pre_stream_bad_request(first_chunk):
+            await generator.aclose()
             return error_response
 
         async def prepend_first_chunk():

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1517,7 +1517,7 @@ class OpenAIServingChat(OpenAIServingBase):
         adapted_request: GenerateReqInput,
         request: ChatCompletionRequest,
         raw_request: Request,
-    ) -> Union[StreamingResponse, ErrorResponse]:
+    ) -> Union[StreamingResponse, ErrorResponse, ORJSONResponse]:
         """Handle streaming chat completion request"""
         generator = self._generate_chat_stream(adapted_request, request, raw_request)
 
@@ -1528,6 +1528,9 @@ class OpenAIServingChat(OpenAIServingBase):
             first_chunk = await generator.__anext__()
         except ValueError as e:
             return self.create_error_response(str(e))
+        if error_response := self.maybe_convert_pre_stream_bad_request(first_chunk):
+            await generator.aclose()
+            return error_response
 
         async def prepend_first_chunk():
             yield first_chunk

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -181,7 +181,7 @@ class OpenAIServingCompletion(OpenAIServingBase):
         adapted_request: GenerateReqInput,
         request: CompletionRequest,
         raw_request: Request,
-    ) -> Union[StreamingResponse, ErrorResponse]:
+    ) -> Union[StreamingResponse, ErrorResponse, ORJSONResponse]:
         """Handle streaming completion request"""
         generator = self._generate_completion_stream(
             adapted_request, request, raw_request
@@ -193,6 +193,7 @@ class OpenAIServingCompletion(OpenAIServingBase):
         except ValueError as e:
             return self.create_error_response(str(e))
         if error_response := self.maybe_convert_pre_stream_bad_request(first_chunk):
+            await generator.aclose()
             return error_response
 
         async def prepend_first_chunk():

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -192,6 +192,8 @@ class OpenAIServingCompletion(OpenAIServingBase):
             first_chunk = await generator.__anext__()
         except ValueError as e:
             return self.create_error_response(str(e))
+        if error_response := self.maybe_convert_pre_stream_bad_request(first_chunk):
+            return error_response
 
         async def prepend_first_chunk():
             yield first_chunk

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -195,7 +195,7 @@ class OpenAIServingCompletion(OpenAIServingBase):
         adapted_request: GenerateReqInput,
         request: CompletionRequest,
         raw_request: Request,
-    ) -> Union[StreamingResponse, ErrorResponse]:
+    ) -> Union[StreamingResponse, ErrorResponse, ORJSONResponse]:
         """Handle streaming completion request"""
         generator = self._generate_completion_stream(
             adapted_request, request, raw_request
@@ -206,6 +206,9 @@ class OpenAIServingCompletion(OpenAIServingBase):
             first_chunk = await generator.__anext__()
         except ValueError as e:
             return self.create_error_response(str(e))
+        if error_response := self.maybe_convert_pre_stream_bad_request(first_chunk):
+            await generator.aclose()
+            return error_response
 
         async def prepend_first_chunk():
             yield first_chunk

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -809,7 +809,7 @@ class ServingChatTestCase(unittest.TestCase):
         body = json.loads(response.body)
         self.assertEqual(body["message"], err_msg)
         self.assertEqual(body["code"], HTTPStatus.BAD_REQUEST.value)
-        self.assertEqual(body["type"], "BadRequest")
+        self.assertEqual(body["type"], HTTPStatus.BAD_REQUEST.name)
         self.tm.create_abort_task.assert_not_called()
         self.assertTrue(generator_closed)
 
@@ -836,6 +836,7 @@ class ServingChatTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST.value)
         body = json.loads(response.body)
         self.assertEqual(body["message"], err_msg)
+        self.assertEqual(body["type"], "BadRequestError")
         self.assertEqual(body["param"], "max_tokens")
         self.assertIsNone(
             self.chat.maybe_convert_pre_stream_bad_request("data: []\n\n")

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -778,15 +778,20 @@ class ServingChatTestCase(unittest.TestCase):
 
     def test_handle_streaming_request_returns_http_400_for_pre_stream_bad_request(self):
         err_msg = "Requested token count exceeds the model's maximum context length."
+        generator_closed = False
 
         async def _mock_pre_stream_bad_request(*args, **kwargs):
-            error = self.chat.create_streaming_error_response(
-                err_msg,
-                HTTPStatus.BAD_REQUEST.name,
-                HTTPStatus.BAD_REQUEST.value,
-            )
-            yield f"data: {error}\n\n"
-            yield "data: [DONE]\n\n"
+            nonlocal generator_closed
+            try:
+                error = self.chat.create_streaming_error_response(
+                    err_msg,
+                    HTTPStatus.BAD_REQUEST.name,
+                    HTTPStatus.BAD_REQUEST.value,
+                )
+                yield f"data: {error}\n\n"
+                yield "data: [DONE]\n\n"
+            finally:
+                generator_closed = True
 
         self.chat._generate_chat_stream = Mock(
             return_value=_mock_pre_stream_bad_request()
@@ -806,6 +811,35 @@ class ServingChatTestCase(unittest.TestCase):
         self.assertEqual(body["code"], HTTPStatus.BAD_REQUEST.value)
         self.assertEqual(body["type"], "BadRequest")
         self.tm.create_abort_task.assert_not_called()
+        self.assertTrue(generator_closed)
+
+    def test_maybe_convert_pre_stream_bad_request_accepts_string_code(self):
+        err_msg = "String status code should still be recognized."
+        chunk = (
+            "data: "
+            + json.dumps(
+                {
+                    "error": {
+                        "message": err_msg,
+                        "type": "BadRequestError",
+                        "param": "max_tokens",
+                        "code": str(HTTPStatus.BAD_REQUEST.value),
+                    }
+                }
+            )
+            + "\n\n"
+        )
+
+        response = self.chat.maybe_convert_pre_stream_bad_request(chunk)
+
+        self.assertIsInstance(response, ORJSONResponse)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST.value)
+        body = json.loads(response.body)
+        self.assertEqual(body["message"], err_msg)
+        self.assertEqual(body["param"], "max_tokens")
+        self.assertIsNone(
+            self.chat.maybe_convert_pre_stream_bad_request("data: []\n\n")
+        )
 
     def test_handle_streaming_request_keeps_sse_for_post_start_abort(self):
         err_msg = "Backend failed after streaming started"

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -18,6 +18,7 @@ from typing import Optional
 from unittest.mock import Mock, patch
 
 from fastapi import Request
+from fastapi.responses import ORJSONResponse, StreamingResponse
 
 from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionRequest,
@@ -774,6 +775,85 @@ class ServingChatTestCase(unittest.TestCase):
         # Check that there is an error chunk and a DONE chunk
         self.assertEqual(len(chunks), 2)
         self.assertIn("error", chunks[0])
+
+    def test_handle_streaming_request_returns_http_400_for_pre_stream_bad_request(self):
+        err_msg = "Requested token count exceeds the model's maximum context length."
+
+        async def _mock_pre_stream_bad_request(*args, **kwargs):
+            error = self.chat.create_streaming_error_response(
+                err_msg,
+                HTTPStatus.BAD_REQUEST.name,
+                HTTPStatus.BAD_REQUEST.value,
+            )
+            yield f"data: {error}\n\n"
+            yield "data: [DONE]\n\n"
+
+        self.chat._generate_chat_stream = Mock(
+            return_value=_mock_pre_stream_bad_request()
+        )
+
+        loop = get_or_create_event_loop()
+        response = loop.run_until_complete(
+            self.chat._handle_streaming_request(
+                Mock(spec=GenerateReqInput), self.stream_req, self.fastapi_request
+            )
+        )
+
+        self.assertIsInstance(response, ORJSONResponse)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST.value)
+        body = json.loads(response.body)
+        self.assertEqual(body["message"], err_msg)
+        self.assertEqual(body["code"], HTTPStatus.BAD_REQUEST.value)
+        self.assertEqual(body["type"], "BadRequest")
+        self.tm.create_abort_task.assert_not_called()
+
+    def test_handle_streaming_request_keeps_sse_for_post_start_abort(self):
+        err_msg = "Backend failed after streaming started"
+
+        async def _mock_post_start_abort(*args, **kwargs):
+            yield (
+                'data: {"choices":[{"index":0,"delta":{"role":"assistant","content":""}}]}\n\n'
+            )
+            error = self.chat.create_streaming_error_response(
+                err_msg,
+                HTTPStatus.INTERNAL_SERVER_ERROR.name,
+                HTTPStatus.INTERNAL_SERVER_ERROR.value,
+            )
+            yield f"data: {error}\n\n"
+            yield "data: [DONE]\n\n"
+
+        self.chat._generate_chat_stream = Mock(return_value=_mock_post_start_abort())
+        adapted_request = Mock(spec=GenerateReqInput)
+
+        loop = get_or_create_event_loop()
+        response = loop.run_until_complete(
+            self.chat._handle_streaming_request(
+                adapted_request, self.stream_req, self.fastapi_request
+            )
+        )
+
+        self.assertIsInstance(response, StreamingResponse)
+        self.assertEqual(response.status_code, HTTPStatus.OK.value)
+        self.tm.create_abort_task.assert_called_once_with(adapted_request)
+
+        async def collect_chunks():
+            chunks = []
+            async for chunk in response.body_iterator:
+                chunks.append(chunk)
+            return chunks
+
+        chunks = loop.run_until_complete(collect_chunks())
+        self.assertEqual(
+            chunks[1],
+            "data: "
+            + self.chat.create_streaming_error_response(
+                err_msg,
+                HTTPStatus.INTERNAL_SERVER_ERROR.name,
+                HTTPStatus.INTERNAL_SERVER_ERROR.value,
+            )
+            + "\n\n",
+        )
+        self.assertEqual(chunks[-1], "data: [DONE]\n\n")
 
     # ------------- incremental streaming output tests -------------
     def test_incremental_streaming_output_delta(self):

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -21,6 +21,7 @@ from typing import Optional
 from unittest.mock import Mock, patch
 
 from fastapi import Request
+from fastapi.responses import ORJSONResponse, StreamingResponse
 
 from sglang.srt.entrypoints.openai import chat_encoding
 from sglang.srt.entrypoints.openai.chat_encoding import (
@@ -2312,6 +2313,76 @@ class ServingChatTestCase(unittest.TestCase):
         # Check that there is an error chunk and a DONE chunk
         self.assertEqual(len(chunks), 2)
         self.assertIn("error", chunks[0])
+
+    def test_pre_stream_bad_request_returns_http_400_and_closes_generator(self):
+        closed = False
+
+        async def _mock_pre_stream_bad_request(*args, **kwargs):
+            nonlocal closed
+            try:
+                yield (
+                    'data: {"error":{"message":"context length exceeded",'
+                    '"type":"BadRequestError","param":"prompt","code":"400"}}\n\n'
+                )
+                yield "data: [DONE]\n\n"
+            finally:
+                closed = True
+
+        self.chat._generate_chat_stream = Mock(
+            return_value=_mock_pre_stream_bad_request()
+        )
+        adapted_request = Mock(spec=GenerateReqInput)
+
+        response = get_or_create_event_loop().run_until_complete(
+            self.chat._handle_streaming_request(
+                adapted_request, self.stream_req, self.fastapi_request
+            )
+        )
+
+        self.assertIsInstance(response, ORJSONResponse)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST.value)
+        self.assertEqual(
+            json.loads(response.body),
+            {
+                "object": "error",
+                "message": "context length exceeded",
+                "type": "BadRequestError",
+                "param": "prompt",
+                "code": HTTPStatus.BAD_REQUEST.value,
+            },
+        )
+        self.assertTrue(closed)
+        self.tm.create_abort_task.assert_not_called()
+
+    def test_post_start_bad_request_remains_an_sse_chunk(self):
+        async def _mock_post_start_bad_request(*args, **kwargs):
+            yield 'data: {"choices":[{"delta":{"content":"hello"}}]}\n\n'
+            yield (
+                'data: {"error":{"message":"late failure",'
+                '"type":"BadRequestError","code":400}}\n\n'
+            )
+            yield "data: [DONE]\n\n"
+
+        self.chat._generate_chat_stream = Mock(
+            return_value=_mock_post_start_bad_request()
+        )
+        adapted_request = Mock(spec=GenerateReqInput)
+
+        response = get_or_create_event_loop().run_until_complete(
+            self.chat._handle_streaming_request(
+                adapted_request, self.stream_req, self.fastapi_request
+            )
+        )
+
+        self.assertIsInstance(response, StreamingResponse)
+
+        async def collect_chunks():
+            return [chunk async for chunk in response.body_iterator]
+
+        chunks = get_or_create_event_loop().run_until_complete(collect_chunks())
+        self.assertIn("late failure", chunks[1])
+        self.assertEqual(chunks[-1], "data: [DONE]\n\n")
+        self.tm.create_abort_task.assert_called_once_with(adapted_request)
 
     def _run_chat_stream(self, adapted_request, req):
         async def run_stream():

--- a/test/registered/unit/entrypoints/openai/test_serving_completions.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_completions.py
@@ -282,9 +282,7 @@ class ServingCompletionTestCase(unittest.TestCase):
 
         loop = get_or_create_event_loop()
         response = loop.run_until_complete(
-            self.sc._handle_streaming_request(
-                Mock(), req, self.fastapi_request
-            )
+            self.sc._handle_streaming_request(Mock(), req, self.fastapi_request)
         )
 
         self.assertIsInstance(response, ORJSONResponse)

--- a/test/registered/unit/entrypoints/openai/test_serving_completions.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_completions.py
@@ -15,6 +15,7 @@ from typing import Optional
 from unittest.mock import AsyncMock, Mock
 
 from fastapi import Request
+from fastapi.responses import ORJSONResponse
 
 from sglang.srt.entrypoints.openai.protocol import CompletionRequest
 from sglang.srt.entrypoints.openai.serving_completions import OpenAIServingCompletion
@@ -255,6 +256,44 @@ class ServingCompletionTestCase(unittest.TestCase):
         # Check that there is an error chunk and a DONE chunk, and possibly a role chunk
         self.assertGreaterEqual(len(chunks), 2)
         self.assertIn("error", chunks[0])
+
+    def test_handle_streaming_request_returns_http_400_for_pre_stream_bad_request(self):
+        err_msg = "Requested token count exceeds the model's maximum context length."
+
+        async def _mock_pre_stream_bad_request(*args, **kwargs):
+            error = self.sc.create_streaming_error_response(
+                err_msg,
+                HTTPStatus.BAD_REQUEST.name,
+                HTTPStatus.BAD_REQUEST.value,
+            )
+            yield f"data: {error}\n\n"
+            yield "data: [DONE]\n\n"
+
+        self.sc._generate_completion_stream = Mock(
+            return_value=_mock_pre_stream_bad_request()
+        )
+
+        req = CompletionRequest(
+            model="x",
+            prompt="Hello world",
+            max_tokens=100,
+            stream=True,
+        )
+
+        loop = get_or_create_event_loop()
+        response = loop.run_until_complete(
+            self.sc._handle_streaming_request(
+                Mock(), req, self.fastapi_request
+            )
+        )
+
+        self.assertIsInstance(response, ORJSONResponse)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST.value)
+        body = json.loads(response.body)
+        self.assertEqual(body["message"], err_msg)
+        self.assertEqual(body["code"], HTTPStatus.BAD_REQUEST.value)
+        self.assertEqual(body["type"], "BadRequest")
+        self.sc.tokenizer_manager.create_abort_task.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/entrypoints/openai/test_serving_completions.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_completions.py
@@ -259,15 +259,20 @@ class ServingCompletionTestCase(unittest.TestCase):
 
     def test_handle_streaming_request_returns_http_400_for_pre_stream_bad_request(self):
         err_msg = "Requested token count exceeds the model's maximum context length."
+        generator_closed = False
 
         async def _mock_pre_stream_bad_request(*args, **kwargs):
-            error = self.sc.create_streaming_error_response(
-                err_msg,
-                HTTPStatus.BAD_REQUEST.name,
-                HTTPStatus.BAD_REQUEST.value,
-            )
-            yield f"data: {error}\n\n"
-            yield "data: [DONE]\n\n"
+            nonlocal generator_closed
+            try:
+                error = self.sc.create_streaming_error_response(
+                    err_msg,
+                    HTTPStatus.BAD_REQUEST.name,
+                    HTTPStatus.BAD_REQUEST.value,
+                )
+                yield f"data: {error}\n\n"
+                yield "data: [DONE]\n\n"
+            finally:
+                generator_closed = True
 
         self.sc._generate_completion_stream = Mock(
             return_value=_mock_pre_stream_bad_request()
@@ -292,6 +297,7 @@ class ServingCompletionTestCase(unittest.TestCase):
         self.assertEqual(body["code"], HTTPStatus.BAD_REQUEST.value)
         self.assertEqual(body["type"], "BadRequest")
         self.sc.tokenizer_manager.create_abort_task.assert_not_called()
+        self.assertTrue(generator_closed)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/entrypoints/openai/test_serving_completions.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_completions.py
@@ -295,7 +295,7 @@ class ServingCompletionTestCase(unittest.TestCase):
         body = json.loads(response.body)
         self.assertEqual(body["message"], err_msg)
         self.assertEqual(body["code"], HTTPStatus.BAD_REQUEST.value)
-        self.assertEqual(body["type"], "BadRequest")
+        self.assertEqual(body["type"], HTTPStatus.BAD_REQUEST.name)
         self.sc.tokenizer_manager.create_abort_task.assert_not_called()
         self.assertTrue(generator_closed)
 

--- a/test/registered/unit/entrypoints/openai/test_serving_completions.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_completions.py
@@ -15,6 +15,7 @@ from typing import Optional
 from unittest.mock import AsyncMock, Mock
 
 from fastapi import Request
+from fastapi.responses import ORJSONResponse
 
 from sglang.srt.entrypoints.openai.protocol import CompletionRequest
 from sglang.srt.entrypoints.openai.serving_completions import OpenAIServingCompletion
@@ -311,6 +312,40 @@ class ServingCompletionTestCase(unittest.TestCase):
         # Check that there is an error chunk and a DONE chunk, and possibly a role chunk
         self.assertGreaterEqual(len(chunks), 2)
         self.assertIn("error", chunks[0])
+
+    def test_pre_stream_bad_request_returns_http_400_and_closes_generator(self):
+        closed = False
+
+        async def _mock_pre_stream_bad_request(*args, **kwargs):
+            nonlocal closed
+            try:
+                yield (
+                    'data:{"error":{"message":"too many tokens",'
+                    '"type":"BadRequestError","code":"400"}}\n\n'
+                )
+                yield "data: [DONE]\n\n"
+            finally:
+                closed = True
+
+        self.sc._generate_completion_stream = Mock(
+            return_value=_mock_pre_stream_bad_request()
+        )
+        request = CompletionRequest(
+            model="x", prompt="Hello world", max_tokens=100, stream=True
+        )
+
+        response = get_or_create_event_loop().run_until_complete(
+            self.sc._handle_streaming_request(Mock(), request, self.fastapi_request)
+        )
+
+        self.assertIsInstance(response, ORJSONResponse)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST.value)
+        self.assertEqual(json.loads(response.body)["type"], "BadRequestError")
+        self.assertTrue(closed)
+        self.sc.tokenizer_manager.create_abort_task.assert_not_called()
+
+    def test_pre_stream_converter_ignores_non_object_json(self):
+        self.assertIsNone(self.sc.maybe_convert_pre_stream_bad_request("data: []\n\n"))
 
     def test_streaming_token_ids_deltas_cover_output_exactly(self):
         req = CompletionRequest(


### PR DESCRIPTION
## Summary
- convert a first SSE bad-request chunk back into an HTTP 400 before the stream starts
- apply that handling to both `/v1/chat/completions` and `/v1/completions` streaming paths
- add handler-level unit coverage for pre-stream 400 conversion and preserving SSE errors after streaming begins

## Testing
- `python3 -m py_compile python/sglang/srt/entrypoints/openai/serving_base.py python/sglang/srt/entrypoints/openai/serving_chat.py python/sglang/srt/entrypoints/openai/serving_completions.py test/registered/unit/entrypoints/openai/test_serving_chat.py test/registered/unit/entrypoints/openai/test_serving_completions.py`
- focused import-stubbed handler verification for the new pre-stream/post-start streaming status behavior

Closes #22785

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33300320700](https://github.com/sgl-project/sglang/actions/runs/33300320700)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33300320634](https://github.com/sgl-project/sglang/actions/runs/33300320634)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33300320671](https://github.com/sgl-project/sglang/actions/runs/33300320671)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->