### PR TITLE
[api_server] Plumb runtime multimodal kwargs

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1612,9 +1612,7 @@ async def openai_v1_audio_transcriptions(
             temperature=temperature,
             stream=stream,
             timestamp_granularities=timestamp_granularities,
-            processor_kwargs=_parse_optional_json(
-                "processor_kwargs", processor_kwargs
-            ),
+            processor_kwargs=_parse_optional_json("processor_kwargs", processor_kwargs),
             mm_process_config=_parse_optional_json(
                 "mm_process_config", mm_process_config
             ),

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -19,6 +19,7 @@ This file implements HTTP APIs for the inference engine via fastapi.
 
 import asyncio
 import dataclasses
+import json
 import logging
 import os
 import tempfile
@@ -1569,6 +1570,9 @@ async def openai_v1_audio_transcriptions(
     timestamp_granularities: Optional[List[str]] = Form(
         default=None, alias="timestamp_granularities[]"
     ),
+    processor_kwargs: Optional[str] = Form(default=None),
+    mm_process_config: Optional[str] = Form(default=None),
+    io_kwargs: Optional[str] = Form(default=None),
 ):
     """OpenAI-compatible audio transcription endpoint."""
     if response_format not in ["json", "text", "verbose_json"]:
@@ -1583,6 +1587,22 @@ async def openai_v1_audio_transcriptions(
 
     audio_data = await file.read()
 
+    def _parse_optional_json(field_name: str, raw_value: Optional[str]):
+        if raw_value is None:
+            return None
+        try:
+            value = json.loads(raw_value)
+        except json.JSONDecodeError as e:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{field_name} must be valid JSON: {e.msg}",
+            ) from e
+        if not isinstance(value, dict):
+            raise HTTPException(
+                status_code=400, detail=f"{field_name} must decode to a JSON object."
+            )
+        return value
+
     return (
         await raw_request.app.state.openai_serving_transcription.create_transcription(
             audio_data=audio_data,
@@ -1592,6 +1612,13 @@ async def openai_v1_audio_transcriptions(
             temperature=temperature,
             stream=stream,
             timestamp_granularities=timestamp_granularities,
+            processor_kwargs=_parse_optional_json(
+                "processor_kwargs", processor_kwargs
+            ),
+            mm_process_config=_parse_optional_json(
+                "mm_process_config", mm_process_config
+            ),
+            io_kwargs=_parse_optional_json("io_kwargs", io_kwargs),
             raw_request=raw_request,
         )
     )

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -19,6 +19,7 @@ This file implements HTTP APIs for the inference engine via fastapi.
 
 import asyncio
 import dataclasses
+import json
 import logging
 import os
 import ssl
@@ -1813,6 +1814,9 @@ async def openai_v1_audio_transcriptions(
     timestamp_granularities: Optional[List[str]] = Form(
         default=None, alias="timestamp_granularities[]"
     ),
+    processor_kwargs: Optional[str] = Form(default=None),
+    mm_process_config: Optional[str] = Form(default=None),
+    io_kwargs: Optional[str] = Form(default=None),
 ):
     """OpenAI-compatible audio transcription endpoint."""
     if response_format not in ["json", "text", "verbose_json"]:
@@ -1827,6 +1831,23 @@ async def openai_v1_audio_transcriptions(
 
     audio_data = await file.read()
 
+    def _parse_optional_json(field_name: str, raw_value: Optional[str]):
+        if raw_value is None or not raw_value.strip():
+            return None
+        try:
+            value = json.loads(raw_value)
+        except json.JSONDecodeError as e:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{field_name} must be valid JSON: {e.msg}",
+            ) from e
+        if not isinstance(value, dict):
+            raise HTTPException(
+                status_code=400,
+                detail=f"{field_name} must decode to a JSON object.",
+            )
+        return value
+
     return (
         await raw_request.app.state.openai_serving_transcription.create_transcription(
             audio_data=audio_data,
@@ -1836,6 +1857,11 @@ async def openai_v1_audio_transcriptions(
             temperature=temperature,
             stream=stream,
             timestamp_granularities=timestamp_granularities,
+            processor_kwargs=_parse_optional_json("processor_kwargs", processor_kwargs),
+            mm_process_config=_parse_optional_json(
+                "mm_process_config", mm_process_config
+            ),
+            io_kwargs=_parse_optional_json("io_kwargs", io_kwargs),
             raw_request=raw_request,
         )
     )

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -649,6 +649,9 @@ class ChatCompletionRequest(BaseModel):
     max_dynamic_patch: Optional[int] = None
     min_dynamic_patch: Optional[int] = None
     use_audio_in_video: bool = False
+    processor_kwargs: Optional[Dict[str, Any]] = None
+    mm_process_config: Optional[Dict[str, Any]] = None
+    io_kwargs: Optional[Dict[str, Any]] = None
 
     # Custom logit processor for advanced sampling control
     custom_logit_processor: Optional[Union[List[Optional[str]], str]] = None
@@ -1246,6 +1249,9 @@ class ResponsesRequest(BaseModel):
     top_k: int = -1
     min_p: float = 0.0
     repetition_penalty: float = 1.0
+    processor_kwargs: Optional[Dict[str, Any]] = None
+    mm_process_config: Optional[Dict[str, Any]] = None
+    io_kwargs: Optional[Dict[str, Any]] = None
 
     # Default sampling parameters
     _DEFAULT_SAMPLING_PARAMS = {
@@ -1495,6 +1501,9 @@ class TranscriptionRequest(BaseModel):
     # Internal fields (not from API)
     audio_data: Optional[bytes] = None
     audio_duration_s: float = 0.0
+    processor_kwargs: Optional[Dict[str, Any]] = None
+    mm_process_config: Optional[Dict[str, Any]] = None
+    io_kwargs: Optional[Dict[str, Any]] = None
 
 
 class TranscriptionUsage(BaseModel):

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -913,6 +913,9 @@ class ChatCompletionRequest(BaseModel):
     max_dynamic_patch: Optional[int] = None
     min_dynamic_patch: Optional[int] = None
     use_audio_in_video: bool = False
+    processor_kwargs: Optional[Dict[str, Any]] = None
+    mm_process_config: Optional[Dict[str, Any]] = None
+    io_kwargs: Optional[Dict[str, Any]] = None
 
     images_config: Optional[Dict] = None
     video_config: Optional[Dict] = None
@@ -1637,6 +1640,9 @@ class ResponsesRequest(BaseModel):
     top_k: Optional[int] = None
     min_p: Optional[float] = None
     repetition_penalty: Optional[float] = None
+    processor_kwargs: Optional[Dict[str, Any]] = None
+    mm_process_config: Optional[Dict[str, Any]] = None
+    io_kwargs: Optional[Dict[str, Any]] = None
 
     # Default sampling parameters
     _DEFAULT_SAMPLING_PARAMS = {
@@ -2062,6 +2068,9 @@ class TranscriptionRequest(BaseModel):
     # Internal fields (not from API)
     audio_data: Optional[bytes] = None
     audio_duration_s: float = 0.0
+    processor_kwargs: Optional[Dict[str, Any]] = None
+    mm_process_config: Optional[Dict[str, Any]] = None
+    io_kwargs: Optional[Dict[str, Any]] = None
 
 
 class TranscriptionUsage(BaseModel):

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -420,6 +420,9 @@ class OpenAIServingChat(OpenAIServingBase):
             video_max_dynamic_patch=vid_max_dynamic_patch,
             max_dynamic_patch=getattr(request, "max_dynamic_patch", None),
             use_audio_in_video=getattr(request, "use_audio_in_video", False),
+            processor_kwargs=getattr(request, "processor_kwargs", None),
+            mm_process_config=getattr(request, "mm_process_config", None),
+            io_kwargs=getattr(request, "io_kwargs", None),
         )
 
         return adapted_request, request

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1086,6 +1086,9 @@ class OpenAIServingChat(OpenAIServingBase):
             video_max_dynamic_patch=vid_max_dynamic_patch,
             max_dynamic_patch=getattr(request, "max_dynamic_patch", None),
             use_audio_in_video=getattr(request, "use_audio_in_video", False),
+            processor_kwargs=getattr(request, "processor_kwargs", None),
+            mm_process_config=getattr(request, "mm_process_config", None),
+            io_kwargs=getattr(request, "io_kwargs", None),
             return_prompt_token_ids=request.return_prompt_token_ids
             or request.return_token_ids,
         )

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -283,6 +283,9 @@ class OpenAIServingResponses(OpenAIServingChat):
                         rid=request.request_id,
                         extra_key=self._compute_extra_key(request),
                         background=request.background,
+                        processor_kwargs=request.processor_kwargs,
+                        mm_process_config=request.mm_process_config,
+                        io_kwargs=request.io_kwargs,
                     )
 
                     generator = self._generate_with_builtin_tools(
@@ -384,6 +387,9 @@ class OpenAIServingResponses(OpenAIServingChat):
                 model=request.model,
                 messages=messages,
                 stream=request.stream,
+                processor_kwargs=request.processor_kwargs,
+                mm_process_config=request.mm_process_config,
+                io_kwargs=request.io_kwargs,
             )
 
             # Follow SGLang's _process_messages pattern

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -458,6 +458,9 @@ class OpenAIServingResponses(OpenAIServingChat):
                         cache_salt=request.cache_salt,
                         # background+stream streams on this connection, so don't detach.
                         background=request.background and not request.stream,
+                        processor_kwargs=request.processor_kwargs,
+                        mm_process_config=request.mm_process_config,
+                        io_kwargs=request.io_kwargs,
                         require_reasoning=require_reasoning,
                     )
 
@@ -584,6 +587,9 @@ class OpenAIServingResponses(OpenAIServingChat):
             stop=request.stop,
             reasoning_effort=(request.reasoning.effort if request.reasoning else None),
             chat_template_kwargs=request.chat_template_kwargs,
+            processor_kwargs=request.processor_kwargs,
+            mm_process_config=request.mm_process_config,
+            io_kwargs=request.io_kwargs,
         )
 
         media_error = self._validate_media_content(chat_request)

--- a/python/sglang/srt/entrypoints/openai/serving_transcription.py
+++ b/python/sglang/srt/entrypoints/openai/serving_transcription.py
@@ -91,6 +91,9 @@ class OpenAIServingTranscription(OpenAIServingBase):
             stream=request.stream,
             modalities=["audio"],
             routing_key=self.extract_routing_key(raw_request),
+            processor_kwargs=request.processor_kwargs,
+            mm_process_config=request.mm_process_config,
+            io_kwargs=request.io_kwargs,
         )
 
         return adapted_request, request
@@ -117,6 +120,9 @@ class OpenAIServingTranscription(OpenAIServingBase):
         stream: bool,
         raw_request: Request,
         timestamp_granularities: Optional[List[str]] = None,
+        processor_kwargs: Optional[dict] = None,
+        mm_process_config: Optional[dict] = None,
+        io_kwargs: Optional[dict] = None,
     ) -> Union[
         TranscriptionResponse,
         TranscriptionVerboseResponse,
@@ -154,6 +160,9 @@ class OpenAIServingTranscription(OpenAIServingBase):
             timestamp_granularities=timestamp_granularities,
             stream=stream,
             audio_duration_s=audio_duration_s,
+            processor_kwargs=processor_kwargs,
+            mm_process_config=mm_process_config,
+            io_kwargs=io_kwargs,
         )
         if use_fused:
             request._fused_autodetect = True

--- a/python/sglang/srt/entrypoints/openai/serving_transcription.py
+++ b/python/sglang/srt/entrypoints/openai/serving_transcription.py
@@ -102,6 +102,9 @@ class OpenAIServingTranscription(OpenAIServingBase):
             stream=request.stream,
             modalities=["audio"],
             routing_key=self.extract_routing_key(raw_request),
+            processor_kwargs=request.processor_kwargs,
+            mm_process_config=request.mm_process_config,
+            io_kwargs=request.io_kwargs,
         )
 
         return adapted_request, request
@@ -136,6 +139,9 @@ class OpenAIServingTranscription(OpenAIServingBase):
         stream: bool,
         raw_request: Request,
         timestamp_granularities: Optional[List[str]] = None,
+        processor_kwargs: Optional[dict] = None,
+        mm_process_config: Optional[dict] = None,
+        io_kwargs: Optional[dict] = None,
     ) -> Union[
         TranscriptionResponse,
         TranscriptionVerboseResponse,
@@ -228,6 +234,9 @@ class OpenAIServingTranscription(OpenAIServingBase):
             timestamp_granularities=timestamp_granularities,
             stream=stream,
             audio_duration_s=audio_duration_s,
+            processor_kwargs=processor_kwargs,
+            mm_process_config=mm_process_config,
+            io_kwargs=io_kwargs,
         )
         if use_fused:
             request._fused_autodetect = True

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -155,6 +155,12 @@ class GenerateReqInput(BaseReq):
     audio_data: Optional[MultimodalDataInputFormat] = None
     # Whether to extract and process audio from video inputs.
     use_audio_in_video: bool = False
+    # Runtime multimodal processor kwargs forwarded through the API server.
+    processor_kwargs: Optional[Dict[str, Any]] = None
+    # Runtime multimodal processing config overrides merged with server_args.mm_process_config.
+    mm_process_config: Optional[Dict[str, Any]] = None
+    # Runtime multimodal IO config overrides, keyed by modality (image/video/audio).
+    io_kwargs: Optional[Dict[str, Any]] = None
     # The sampling_params. See descriptions below.
     sampling_params: Optional[Union[List[Dict], Dict]] = None
     # Whether to return logprobs.
@@ -637,6 +643,9 @@ class GenerateReqInput(BaseReq):
             image_data=self.image_data[i],
             video_data=self.video_data[i],
             audio_data=self.audio_data[i],
+            processor_kwargs=copy.deepcopy(self.processor_kwargs),
+            mm_process_config=copy.deepcopy(self.mm_process_config),
+            io_kwargs=copy.deepcopy(self.io_kwargs),
             sampling_params=self.sampling_params[i],
             rid=self.rid[i],
             return_logprob=self.return_logprob[i],

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -212,6 +212,12 @@ class GenerateReqInput:
     ] = None
     # Whether to extract and process audio from video inputs.
     use_audio_in_video: bool = False
+    # Runtime multimodal processor kwargs forwarded through the API server.
+    processor_kwargs: Optional[Dict[str, Any]] = None
+    # Runtime multimodal process config overrides merged with server defaults.
+    mm_process_config: Optional[Dict[str, Any]] = None
+    # Runtime multimodal IO config overrides keyed by modality.
+    io_kwargs: Optional[Dict[str, Any]] = None
     # Optional request-scoped video processor configuration.
     video_config: Optional[Dict[str, Any]] = None
     # The sampling_params. See descriptions below.
@@ -884,6 +890,9 @@ class GenerateReqInput:
             image_data=self.image_data[i],
             video_data=self.video_data[i],
             audio_data=self.audio_data[i],
+            processor_kwargs=copy.deepcopy(self.processor_kwargs),
+            mm_process_config=copy.deepcopy(self.mm_process_config),
+            io_kwargs=copy.deepcopy(self.io_kwargs),
             mm_hashes=self.mm_hashes[i] if self.mm_hashes is not None else None,
             mm_content_hashes=(
                 self.mm_content_hashes[i]

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -763,13 +763,14 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                         need_wait_for_mm_inputs=obj.need_wait_for_mm_inputs,
                     )
                 if mm_inputs is None:
-                    mm_inputs = await self.mm_processor.process_mm_data_async(
-                        image_data=obj.image_data,
-                        audio_data=obj.audio_data,
-                        input_text=(input_text or input_ids),
-                        request_obj=obj,
-                        max_req_input_len=self.max_req_input_len,
-                    )
+                    with self.mm_processor.request_context(obj):
+                        mm_inputs = await self.mm_processor.process_mm_data_async(
+                            image_data=obj.image_data,
+                            audio_data=obj.audio_data,
+                            input_text=(input_text or input_ids),
+                            request_obj=obj,
+                            max_req_input_len=self.max_req_input_len,
+                        )
             elif (
                 self.server_args.language_only
                 and self.server_args.encoder_transfer_backend == "zmq_to_scheduler"
@@ -777,13 +778,14 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             ):
                 # In language_only mode with zmq_to_scheduler, if we didn't dispatch
                 # to encoder (e.g., only one image), process locally like non-language_only mode
-                mm_inputs = await self.mm_processor.process_mm_data_async(
-                    image_data=obj.image_data,
-                    audio_data=obj.audio_data,
-                    input_text=(input_text or input_ids),
-                    request_obj=obj,
-                    max_req_input_len=self.max_req_input_len,
-                )
+                with self.mm_processor.request_context(obj):
+                    mm_inputs = await self.mm_processor.process_mm_data_async(
+                        image_data=obj.image_data,
+                        audio_data=obj.audio_data,
+                        input_text=(input_text or input_ids),
+                        request_obj=obj,
+                        max_req_input_len=self.max_req_input_len,
+                    )
 
             if mm_inputs and mm_inputs.input_ids is not None:
                 input_ids = mm_inputs.input_ids

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1052,13 +1052,14 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                             "Encoder embedding not available, "
                             "falling back to local mm processing"
                         )
-                    mm_inputs = await self.mm_processor.process_mm_data_async(
-                        image_data=obj.image_data,
-                        audio_data=obj.audio_data,
-                        input_text=mm_processor_input,
-                        request_obj=obj,
-                        max_req_input_len=self.max_req_input_len,
-                    )
+                    with self.mm_processor.request_context(obj):
+                        mm_inputs = await self.mm_processor.process_mm_data_async(
+                            image_data=obj.image_data,
+                            audio_data=obj.audio_data,
+                            input_text=mm_processor_input,
+                            request_obj=obj,
+                            max_req_input_len=self.max_req_input_len,
+                        )
             elif (
                 get_disagg().language_only
                 and get_disagg().encoder_transfer_backend
@@ -1067,13 +1068,14 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             ):
                 # In language_only mode with zmq_to_scheduler/mooncake, if we didn't dispatch
                 # to encoder (e.g., only one image), process locally like non-language_only mode
-                mm_inputs = await self.mm_processor.process_mm_data_async(
-                    image_data=obj.image_data,
-                    audio_data=obj.audio_data,
-                    input_text=mm_processor_input,
-                    request_obj=obj,
-                    max_req_input_len=self.max_req_input_len,
-                )
+                with self.mm_processor.request_context(obj):
+                    mm_inputs = await self.mm_processor.process_mm_data_async(
+                        image_data=obj.image_data,
+                        audio_data=obj.audio_data,
+                        input_text=mm_processor_input,
+                        request_obj=obj,
+                        max_req_input_len=self.max_req_input_len,
+                    )
 
             if mm_inputs and mm_inputs.input_ids is not None:
                 input_ids = mm_inputs.input_ids

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -1,10 +1,13 @@
 import concurrent
 import concurrent.futures
+import copy
 import dataclasses
 import multiprocessing as mp
 import os
 import re
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from contextvars import ContextVar
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import numpy as np
@@ -42,6 +45,9 @@ _is_xpu = is_xpu()
 
 SGL_USE_CUDA_IPC = envs.SGLANG_USE_CUDA_IPC_TRANSPORT.get()
 _IPC_POOL_HANDLE_CACHE = envs.SGLANG_USE_IPC_POOL_HANDLE_CACHE.get()
+_RUNTIME_MM_REQUEST: ContextVar[Optional[object]] = ContextVar(
+    "sglang_runtime_mm_request", default=None
+)
 
 
 @dataclasses.dataclass
@@ -282,6 +288,115 @@ class BaseMultimodalProcessor(ABC):
         """
         return None, None
 
+    @contextmanager
+    def request_context(self, request_obj):
+        token = _RUNTIME_MM_REQUEST.set(request_obj)
+        try:
+            yield
+        finally:
+            _RUNTIME_MM_REQUEST.reset(token)
+
+    @staticmethod
+    def _deep_merge_dicts(
+        base: Optional[Dict[str, Any]], override: Optional[Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        merged = copy.deepcopy(base or {})
+        for key, value in (override or {}).items():
+            if isinstance(value, dict) and isinstance(merged.get(key), dict):
+                merged[key] = BaseMultimodalProcessor._deep_merge_dicts(
+                    merged[key], value
+                )
+            elif isinstance(value, dict):
+                merged[key] = BaseMultimodalProcessor._deep_merge_dicts({}, value)
+            else:
+                merged[key] = copy.deepcopy(value)
+        return merged
+
+    def _get_runtime_request(self):
+        return _RUNTIME_MM_REQUEST.get()
+
+    def _get_runtime_request_dict(
+        self,
+        field_name: str,
+        *,
+        validate_modalities: bool = False,
+    ) -> Dict[str, Any]:
+        request_obj = self._get_runtime_request()
+        value = (
+            getattr(request_obj, field_name, None)
+            if request_obj is not None
+            else None
+        )
+        if value is None:
+            return {}
+        if not isinstance(value, dict):
+            raise ValueError(f"{field_name} must be a dict when provided.")
+        if validate_modalities:
+            for modality in ("image", "video", "audio"):
+                if modality in value and not isinstance(value[modality], dict):
+                    raise ValueError(
+                        f"{field_name}['{modality}'] must be a dict when provided."
+                    )
+        return value
+
+    def _get_effective_modality_process_config(
+        self, modality: str
+    ) -> Dict[str, Any]:
+        base_config = getattr(self, f"{modality}_config", {}) or {}
+        runtime_config = self._get_runtime_request_dict(
+            "mm_process_config", validate_modalities=True
+        ).get(modality, {})
+        return self._deep_merge_dicts(base_config, runtime_config)
+
+    def _get_runtime_processor_kwargs(self) -> Dict[str, Any]:
+        return self._get_runtime_request_dict("processor_kwargs")
+
+    def _get_runtime_io_kwargs(self) -> Dict[str, Any]:
+        return self._get_runtime_request_dict("io_kwargs", validate_modalities=True)
+
+    def _merge_runtime_processor_kwargs(
+        self, kwargs: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        runtime_kwargs = self._get_runtime_processor_kwargs()
+        if not runtime_kwargs:
+            return kwargs
+
+        reserved = {
+            "text",
+            "padding",
+            "return_tensors",
+            "images",
+            "videos",
+            "audio",
+            "audios",
+        }
+        collisions = reserved.intersection(runtime_kwargs.keys())
+        if collisions:
+            raise ValueError(
+                "processor_kwargs cannot override reserved processor inputs: "
+                + ", ".join(sorted(collisions))
+            )
+
+        return self._deep_merge_dicts(kwargs, runtime_kwargs)
+
+    def _get_effective_io_settings(
+        self,
+        *,
+        discard_alpha_channel: bool = True,
+        audio_sample_rate: Optional[int] = None,
+        video_frame_count_limit: Optional[int] = None,
+    ) -> tuple[bool, Optional[int], Optional[int]]:
+        io_kwargs = self._get_runtime_io_kwargs()
+        image_io = io_kwargs.get("image", {})
+        audio_io = io_kwargs.get("audio", {})
+        video_io = io_kwargs.get("video", {})
+
+        return (
+            image_io.get("discard_alpha_channel", discard_alpha_channel),
+            audio_io.get("audio_sample_rate", audio_sample_rate),
+            video_io.get("frame_count_limit", video_frame_count_limit),
+        )
+
     @property
     def spatial_merge_size(self):
         return self.hf_config.vision_config.spatial_merge_size
@@ -399,14 +514,18 @@ class BaseMultimodalProcessor(ABC):
         """
         process multimodal data with transformers AutoProcessor
         """
+        image_config = self._get_effective_modality_process_config("image")
+        video_config = self._get_effective_modality_process_config("video")
+        audio_config = self._get_effective_modality_process_config("audio")
+
         if images:
             kwargs["images"] = images
-            if self.image_config:
-                kwargs.setdefault("images_kwargs", {}).update(self.image_config)
+            if image_config:
+                kwargs.setdefault("images_kwargs", {}).update(image_config)
         if videos:
             kwargs["videos"] = videos
-            if self.video_config:
-                kwargs.setdefault("videos_kwargs", {}).update(self.video_config)
+            if video_config:
+                kwargs.setdefault("videos_kwargs", {}).update(video_config)
         if audios:
             if self._processor.__class__.__name__ in {
                 "Gemma3nProcessor",
@@ -422,8 +541,10 @@ class BaseMultimodalProcessor(ABC):
                 kwargs["audio_kwargs"].setdefault("truncation", False)
             else:
                 kwargs["audios"] = audios
-            if self.audio_config:
-                kwargs.setdefault("audio_kwargs", {}).update(self.audio_config)
+            if audio_config:
+                kwargs.setdefault("audio_kwargs", {}).update(audio_config)
+
+        kwargs = self._merge_runtime_processor_kwargs(kwargs)
 
         processor = self._processor
         if (
@@ -548,6 +669,7 @@ class BaseMultimodalProcessor(ABC):
         self,
         data_list: Optional[list],
         modality: Modality,
+        frame_count_limit: Optional[int],
         audio_sample_rate: Optional[int],
         discard_alpha_channel: bool,
     ) -> List[Tuple[Modality, int, concurrent.futures.Future]]:
@@ -577,7 +699,7 @@ class BaseMultimodalProcessor(ABC):
                 self.__class__._load_single_item,
                 data,
                 modality,
-                None,  # frame_count_limit: no consider for fast path
+                frame_count_limit,
                 audio_sample_rate,
                 discard_alpha_channel,
             )
@@ -595,6 +717,7 @@ class BaseMultimodalProcessor(ABC):
         image_scaling_factor: float = 1.0,
         max_image_frames: int = 30,
         audio_sample_rate: Optional[int] = None,
+        video_frame_count_limit: Optional[int] = None,
     ) -> Tuple[List, List]:
         """
         load multimodal data parallelly using iterators.
@@ -631,6 +754,8 @@ class BaseMultimodalProcessor(ABC):
                         raise ValueError(
                             "Mismatch between image tokens and estimated frame counts."
                         )
+                elif modality == Modality.VIDEO:
+                    frame_count_limit = video_frame_count_limit
 
                 futures.append(
                     self.io_executor.submit(
@@ -738,7 +863,18 @@ class BaseMultimodalProcessor(ABC):
         return_text: Optional[bool] = True,
         discard_alpha_channel: bool = True,
         audio_sample_rate: Optional[int] = None,
+        video_frame_count_limit: Optional[int] = None,
     ) -> BaseMultiModalProcessorOutput:
+
+        (
+            discard_alpha_channel,
+            audio_sample_rate,
+            video_frame_count_limit,
+        ) = self._get_effective_io_settings(
+            discard_alpha_channel=discard_alpha_channel,
+            audio_sample_rate=audio_sample_rate,
+            video_frame_count_limit=video_frame_count_limit,
+        )
 
         BaseMultimodalProcessor.validate_mm_data(image_data, video_data, audio_data)
 
@@ -780,6 +916,7 @@ class BaseMultimodalProcessor(ABC):
                 return_text=return_text,
                 discard_alpha_channel=discard_alpha_channel,
                 audio_sample_rate=audio_sample_rate,
+                video_frame_count_limit=video_frame_count_limit,
             )
         # For models other than MiniCPMO and MiniCPMV,
         # totally align multimodal_tokens, fast path
@@ -792,6 +929,7 @@ class BaseMultimodalProcessor(ABC):
             return_text=return_text,
             discard_alpha_channel=discard_alpha_channel,
             audio_sample_rate=audio_sample_rate,
+            video_frame_count_limit=video_frame_count_limit,
         )
 
     def fast_load_mm_data(
@@ -804,6 +942,7 @@ class BaseMultimodalProcessor(ABC):
         return_text: Optional[bool] = True,
         discard_alpha_channel: bool = True,
         audio_sample_rate: Optional[int] = None,
+        video_frame_count_limit: Optional[int] = None,
     ) -> BaseMultiModalProcessorOutput:
         """
         A fast version of `load_mm_data` that loads multimodal data directly.
@@ -834,7 +973,11 @@ class BaseMultimodalProcessor(ABC):
         for data_list, modality in modalities_data:
             futures.extend(
                 self._submit_mm_data_loading_tasks_simple(
-                    data_list, modality, audio_sample_rate, discard_alpha_channel
+                    data_list,
+                    modality,
+                    video_frame_count_limit if modality == Modality.VIDEO else None,
+                    audio_sample_rate,
+                    discard_alpha_channel,
                 )
             )
 
@@ -888,6 +1031,7 @@ class BaseMultimodalProcessor(ABC):
         return_text: Optional[bool] = True,
         discard_alpha_channel: bool = True,
         audio_sample_rate: Optional[int] = None,
+        video_frame_count_limit: Optional[int] = None,
     ) -> BaseMultiModalProcessorOutput:
         """
         Each frame of video/image will be replaced by a single image token
@@ -926,6 +1070,7 @@ class BaseMultimodalProcessor(ABC):
             data_iterators=data_iterators,
             discard_alpha_channel=discard_alpha_channel,
             audio_sample_rate=audio_sample_rate,
+            video_frame_count_limit=video_frame_count_limit,
         )
         task_info_iter = iter(task_info)
         futures_iter = iter(futures)

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -323,9 +323,7 @@ class BaseMultimodalProcessor(ABC):
     ) -> Dict[str, Any]:
         request_obj = self._get_runtime_request()
         value = (
-            getattr(request_obj, field_name, None)
-            if request_obj is not None
-            else None
+            getattr(request_obj, field_name, None) if request_obj is not None else None
         )
         if value is None:
             return {}
@@ -339,9 +337,7 @@ class BaseMultimodalProcessor(ABC):
                     )
         return value
 
-    def _get_effective_modality_process_config(
-        self, modality: str
-    ) -> Dict[str, Any]:
+    def _get_effective_modality_process_config(self, modality: str) -> Dict[str, Any]:
         base_config = getattr(self, f"{modality}_config", {}) or {}
         runtime_config = self._get_runtime_request_dict(
             "mm_process_config", validate_modalities=True
@@ -354,9 +350,7 @@ class BaseMultimodalProcessor(ABC):
     def _get_runtime_io_kwargs(self) -> Dict[str, Any]:
         return self._get_runtime_request_dict("io_kwargs", validate_modalities=True)
 
-    def _merge_runtime_processor_kwargs(
-        self, kwargs: Dict[str, Any]
-    ) -> Dict[str, Any]:
+    def _merge_runtime_processor_kwargs(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
         runtime_kwargs = self._get_runtime_processor_kwargs()
         if not runtime_kwargs:
             return kwargs

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -1,6 +1,7 @@
 import asyncio
 import concurrent
 import concurrent.futures
+import copy
 import dataclasses
 import multiprocessing as mp
 import os
@@ -8,6 +9,7 @@ import re
 import threading
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
+from contextvars import ContextVar
 from typing import (
     Any,
     Dict,
@@ -61,6 +63,9 @@ from sglang.srt.utils import (
 _is_cpu = is_cpu()
 _is_npu = is_npu()
 _is_xpu = is_xpu()
+_RUNTIME_MM_REQUEST: ContextVar[Optional[object]] = ContextVar(
+    "sglang_runtime_mm_request", default=None
+)
 
 
 @dataclasses.dataclass
@@ -532,6 +537,110 @@ class BaseMultimodalProcessor(ABC):
         """
         return None, None
 
+    @contextmanager
+    def request_context(self, request_obj):
+        token = _RUNTIME_MM_REQUEST.set(request_obj)
+        try:
+            yield
+        finally:
+            _RUNTIME_MM_REQUEST.reset(token)
+
+    @staticmethod
+    def _deep_merge_dicts(
+        base: Optional[Dict[str, Any]],
+        override: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        merged = copy.deepcopy(base or {})
+        for key, value in (override or {}).items():
+            if isinstance(value, dict) and isinstance(merged.get(key), dict):
+                merged[key] = BaseMultimodalProcessor._deep_merge_dicts(
+                    merged[key], value
+                )
+            elif isinstance(value, dict):
+                merged[key] = BaseMultimodalProcessor._deep_merge_dicts({}, value)
+            else:
+                merged[key] = copy.deepcopy(value)
+        return merged
+
+    def _get_runtime_request(self):
+        return _RUNTIME_MM_REQUEST.get()
+
+    def _get_runtime_request_dict(
+        self,
+        field_name: str,
+        *,
+        validate_modalities: bool = False,
+    ) -> Dict[str, Any]:
+        request_obj = self._get_runtime_request()
+        value = (
+            getattr(request_obj, field_name, None) if request_obj is not None else None
+        )
+        if value is None:
+            return {}
+        if not isinstance(value, dict):
+            raise ValueError(f"{field_name} must be a dict when provided.")
+        if validate_modalities:
+            for modality in ("image", "video", "audio"):
+                if modality in value and not isinstance(value[modality], dict):
+                    raise ValueError(
+                        f"{field_name}['{modality}'] must be a dict when provided."
+                    )
+        return value
+
+    def _get_effective_modality_process_config(self, modality: str) -> Dict[str, Any]:
+        base_config = getattr(self, f"{modality}_config", {}) or {}
+        runtime_config = self._get_runtime_request_dict(
+            "mm_process_config", validate_modalities=True
+        ).get(modality, {})
+        return self._deep_merge_dicts(base_config, runtime_config)
+
+    def _get_runtime_processor_kwargs(self) -> Dict[str, Any]:
+        return self._get_runtime_request_dict("processor_kwargs")
+
+    def _get_runtime_io_kwargs(self) -> Dict[str, Any]:
+        return self._get_runtime_request_dict("io_kwargs", validate_modalities=True)
+
+    def _merge_runtime_processor_kwargs(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        runtime_kwargs = self._get_runtime_processor_kwargs()
+        if not runtime_kwargs:
+            return kwargs
+
+        reserved = {
+            "text",
+            "padding",
+            "return_tensors",
+            "images",
+            "videos",
+            "audio",
+            "audios",
+        }
+        collisions = reserved.intersection(runtime_kwargs.keys())
+        if collisions:
+            raise ValueError(
+                "processor_kwargs cannot override reserved processor inputs: "
+                + ", ".join(sorted(collisions))
+            )
+
+        return self._deep_merge_dicts(kwargs, runtime_kwargs)
+
+    def _get_effective_io_settings(
+        self,
+        *,
+        discard_alpha_channel: bool = True,
+        audio_sample_rate: Optional[int] = None,
+        video_frame_count_limit: Optional[int] = None,
+    ) -> Tuple[bool, Optional[int], Optional[int]]:
+        io_kwargs = self._get_runtime_io_kwargs()
+        image_io = io_kwargs.get("image", {})
+        audio_io = io_kwargs.get("audio", {})
+        video_io = io_kwargs.get("video", {})
+
+        return (
+            image_io.get("discard_alpha_channel", discard_alpha_channel),
+            audio_io.get("audio_sample_rate", audio_sample_rate),
+            video_io.get("frame_count_limit", video_frame_count_limit),
+        )
+
     @property
     def spatial_merge_size(self):
         return self.hf_config.vision_config.spatial_merge_size
@@ -766,18 +875,20 @@ class BaseMultimodalProcessor(ABC):
         process multimodal data with transformers AutoProcessor
         """
         processor, tokenizer = self._resolve_processor(processor)
+        image_config = self._get_effective_modality_process_config("image")
+        video_config = (
+            self._get_effective_modality_process_config("video")
+            if processor_video_config is None
+            else processor_video_config
+        )
+        audio_config = self._get_effective_modality_process_config("audio")
 
         if images:
             kwargs["images"] = images
-            if self.image_config:
-                kwargs.setdefault("images_kwargs", {}).update(self.image_config)
+            if image_config:
+                kwargs.setdefault("images_kwargs", {}).update(image_config)
         if videos:
             kwargs["videos"] = videos
-            video_config = (
-                self.video_config
-                if processor_video_config is None
-                else processor_video_config
-            )
             if video_config:
                 kwargs.setdefault("videos_kwargs", {}).update(video_config)
         if audios:
@@ -797,8 +908,10 @@ class BaseMultimodalProcessor(ABC):
                 kwargs["audio_kwargs"].setdefault("truncation", False)
             else:
                 kwargs["audios"] = audios
-            if self.audio_config:
-                kwargs.setdefault("audio_kwargs", {}).update(self.audio_config)
+            if audio_config:
+                kwargs.setdefault("audio_kwargs", {}).update(audio_config)
+
+        kwargs = self._merge_runtime_processor_kwargs(kwargs)
 
         processor_device = None
         if (
@@ -960,6 +1073,7 @@ class BaseMultimodalProcessor(ABC):
         self,
         data_list: Optional[list],
         modality: Modality,
+        frame_count_limit: Optional[int],
         audio_sample_rate: Optional[int],
         discard_alpha_channel: bool,
     ) -> List[Tuple[Modality, int, concurrent.futures.Future]]:
@@ -989,7 +1103,7 @@ class BaseMultimodalProcessor(ABC):
                 self.__class__._load_single_item,
                 data,
                 modality,
-                None,  # frame_count_limit: no consider for fast path
+                frame_count_limit,
                 audio_sample_rate,
                 discard_alpha_channel,
             )
@@ -1007,6 +1121,7 @@ class BaseMultimodalProcessor(ABC):
         image_scaling_factor: float = 1.0,
         max_image_frames: int = 30,
         audio_sample_rate: Optional[int] = None,
+        video_frame_count_limit: Optional[int] = None,
     ) -> Tuple[List, List]:
         """
         load multimodal data parallelly using iterators.
@@ -1043,6 +1158,8 @@ class BaseMultimodalProcessor(ABC):
                         raise ValueError(
                             "Mismatch between image tokens and estimated frame counts."
                         )
+                elif modality == Modality.VIDEO:
+                    frame_count_limit = video_frame_count_limit
 
                 futures.append(
                     self.io_executor.submit(
@@ -1143,7 +1260,18 @@ class BaseMultimodalProcessor(ABC):
         return_text: Optional[bool] = True,
         discard_alpha_channel: bool = True,
         audio_sample_rate: Optional[int] = None,
+        video_frame_count_limit: Optional[int] = None,
     ) -> BaseMultiModalProcessorOutput:
+        (
+            discard_alpha_channel,
+            audio_sample_rate,
+            video_frame_count_limit,
+        ) = self._get_effective_io_settings(
+            discard_alpha_channel=discard_alpha_channel,
+            audio_sample_rate=audio_sample_rate,
+            video_frame_count_limit=video_frame_count_limit,
+        )
+
         BaseMultimodalProcessor.validate_mm_data(image_data, video_data, audio_data)
 
         input_ids = prompt if isinstance(prompt, list) else None
@@ -1197,6 +1325,7 @@ class BaseMultimodalProcessor(ABC):
                 return_text=return_text,
                 discard_alpha_channel=discard_alpha_channel,
                 audio_sample_rate=audio_sample_rate,
+                video_frame_count_limit=video_frame_count_limit,
                 input_ids=input_ids,
             )
         # For models other than MiniCPMO and MiniCPMV,
@@ -1210,6 +1339,7 @@ class BaseMultimodalProcessor(ABC):
             return_text=return_text,
             discard_alpha_channel=discard_alpha_channel,
             audio_sample_rate=audio_sample_rate,
+            video_frame_count_limit=video_frame_count_limit,
             input_ids=input_ids,
         )
 
@@ -1223,6 +1353,7 @@ class BaseMultimodalProcessor(ABC):
         return_text: Optional[bool] = True,
         discard_alpha_channel: bool = True,
         audio_sample_rate: Optional[int] = None,
+        video_frame_count_limit: Optional[int] = None,
         input_ids: Optional[Union[List[int], torch.Tensor]] = None,
     ) -> BaseMultiModalProcessorOutput:
         """
@@ -1254,7 +1385,11 @@ class BaseMultimodalProcessor(ABC):
         for data_list, modality in modalities_data:
             futures.extend(
                 self._submit_mm_data_loading_tasks_simple(
-                    data_list, modality, audio_sample_rate, discard_alpha_channel
+                    data_list,
+                    modality,
+                    video_frame_count_limit if modality == Modality.VIDEO else None,
+                    audio_sample_rate,
+                    discard_alpha_channel,
                 )
             )
 
@@ -1320,6 +1455,7 @@ class BaseMultimodalProcessor(ABC):
         return_text: Optional[bool] = True,
         discard_alpha_channel: bool = True,
         audio_sample_rate: Optional[int] = None,
+        video_frame_count_limit: Optional[int] = None,
         input_ids: Optional[Union[List[int], torch.Tensor]] = None,
     ) -> BaseMultiModalProcessorOutput:
         """
@@ -1359,6 +1495,7 @@ class BaseMultimodalProcessor(ABC):
             data_iterators=data_iterators,
             discard_alpha_channel=discard_alpha_channel,
             audio_sample_rate=audio_sample_rate,
+            video_frame_count_limit=video_frame_count_limit,
         )
         task_info_iter = iter(task_info)
         futures_iter = iter(futures)

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -551,15 +551,16 @@ class BaseMultimodalProcessor(ABC):
         override: Optional[Dict[str, Any]],
     ) -> Dict[str, Any]:
         merged = copy.deepcopy(base or {})
-        for key, value in (override or {}).items():
-            if isinstance(value, dict) and isinstance(merged.get(key), dict):
-                merged[key] = BaseMultimodalProcessor._deep_merge_dicts(
-                    merged[key], value
-                )
-            elif isinstance(value, dict):
-                merged[key] = BaseMultimodalProcessor._deep_merge_dicts({}, value)
-            else:
-                merged[key] = copy.deepcopy(value)
+
+        def merge_into(target: Dict[str, Any], source: Dict[str, Any]) -> None:
+            for key, value in source.items():
+                if isinstance(value, dict) and isinstance(target.get(key), dict):
+                    merge_into(target[key], value)
+                else:
+                    target[key] = copy.deepcopy(value)
+
+        if override:
+            merge_into(merged, override)
         return merged
 
     def _get_runtime_request(self):

--- a/python/sglang/srt/multimodal/processors/ernie45_vl.py
+++ b/python/sglang/srt/multimodal/processors/ernie45_vl.py
@@ -290,14 +290,18 @@ class Ernie4_5_VLImageProcessor(SGLangBaseProcessor):
         """
         process multimodal data with transformers AutoProcessor
         """
+        image_config = self._get_effective_modality_process_config("image")
+        video_config = self._get_effective_modality_process_config("video")
         if images:
             kwargs["images"] = images
-            if self.image_config:
-                kwargs.setdefault("images_kwargs", {}).update(self.image_config)
+            if image_config:
+                kwargs.setdefault("images_kwargs", {}).update(image_config)
         if videos:
             kwargs["videos"] = videos
-            if self.video_config:
-                kwargs.setdefault("videos_kwargs", {}).update(self.video_config)
+            if video_config:
+                kwargs.setdefault("videos_kwargs", {}).update(video_config)
+
+        kwargs = self._merge_runtime_processor_kwargs(kwargs)
 
         processor = self._processor
         if (

--- a/python/sglang/srt/multimodal/processors/ernie45_vl.py
+++ b/python/sglang/srt/multimodal/processors/ernie45_vl.py
@@ -16,9 +16,7 @@ from sglang.srt.models.ernie45_vl import Ernie4_5_VLMoeForConditionalGeneration
 from sglang.srt.multimodal.processors.base_processor import (
     BaseMultimodalProcessor as SGLangBaseProcessor,
 )
-from sglang.srt.multimodal.processors.base_processor import (
-    MultimodalSpecialTokens,
-)
+from sglang.srt.multimodal.processors.base_processor import MultimodalSpecialTokens
 from sglang.srt.utils import is_npu, logger
 
 _is_npu = is_npu()
@@ -293,14 +291,18 @@ class Ernie4_5_VLImageProcessor(SGLangBaseProcessor):
         """
         process multimodal data with transformers AutoProcessor
         """
+        image_config = self._get_effective_modality_process_config("image")
+        video_config = self._get_effective_modality_process_config("video")
         if images:
             kwargs["images"] = images
-            if self.image_config:
-                kwargs.setdefault("images_kwargs", {}).update(self.image_config)
+            if image_config:
+                kwargs.setdefault("images_kwargs", {}).update(image_config)
         if videos:
             kwargs["videos"] = videos
-            if self.video_config:
-                kwargs.setdefault("videos_kwargs", {}).update(self.video_config)
+            if video_config:
+                kwargs.setdefault("videos_kwargs", {}).update(video_config)
+
+        kwargs = self._merge_runtime_processor_kwargs(kwargs)
 
         # Take the worker pool's per-thread clone when it hands one over; falling
         # back to self._processor would put every worker on one shared object.

--- a/python/sglang/srt/multimodal/processors/ernie45_vl.py
+++ b/python/sglang/srt/multimodal/processors/ernie45_vl.py
@@ -16,7 +16,9 @@ from sglang.srt.models.ernie45_vl import Ernie4_5_VLMoeForConditionalGeneration
 from sglang.srt.multimodal.processors.base_processor import (
     BaseMultimodalProcessor as SGLangBaseProcessor,
 )
-from sglang.srt.multimodal.processors.base_processor import MultimodalSpecialTokens
+from sglang.srt.multimodal.processors.base_processor import (
+    MultimodalSpecialTokens,
+)
 from sglang.srt.utils import is_npu, logger
 
 _is_npu = is_npu()

--- a/python/sglang/srt/multimodal/processors/midashenglm.py
+++ b/python/sglang/srt/multimodal/processors/midashenglm.py
@@ -51,6 +51,7 @@ class MiDashengLMMultimodalProcessor(BaseMultimodalProcessor):
         self, input_text, images=None, videos=None, audios=None, **kwargs
     ):
         """Override to use correct audio parameter name for MiDashengLM processor."""
+        audio_config = self._get_effective_modality_process_config("audio")
         if images:
             kwargs["images"] = images
         if videos:
@@ -59,8 +60,10 @@ class MiDashengLMMultimodalProcessor(BaseMultimodalProcessor):
             kwargs["audio"] = audios
             kwargs.setdefault("audio_kwargs", {})
             kwargs["audio_kwargs"].setdefault("truncation", False)
-            if self.audio_config:
-                kwargs["audio_kwargs"].update(self.audio_config)
+            if audio_config:
+                kwargs["audio_kwargs"].update(audio_config)
+
+        kwargs = self._merge_runtime_processor_kwargs(kwargs)
 
         processor = self._processor
         result = processor.__call__(

--- a/python/sglang/srt/multimodal/processors/midashenglm.py
+++ b/python/sglang/srt/multimodal/processors/midashenglm.py
@@ -57,6 +57,7 @@ class MiDashengLMMultimodalProcessor(BaseMultimodalProcessor):
         **kwargs,
     ):
         """Override to use correct audio parameter name for MiDashengLM processor."""
+        audio_config = self._get_effective_modality_process_config("audio")
         if images:
             kwargs["images"] = images
         if videos:
@@ -65,8 +66,10 @@ class MiDashengLMMultimodalProcessor(BaseMultimodalProcessor):
             kwargs["audio"] = audios
             kwargs.setdefault("audio_kwargs", {})
             kwargs["audio_kwargs"].setdefault("truncation", False)
-            if self.audio_config:
-                kwargs["audio_kwargs"].update(self.audio_config)
+            if audio_config:
+                kwargs["audio_kwargs"].update(audio_config)
+
+        kwargs = self._merge_runtime_processor_kwargs(kwargs)
 
         # Take the worker pool's per-thread clone when it hands one over; falling
         # back to self._processor would put every worker on one shared object.

--- a/python/sglang/srt/multimodal/processors/transformers_auto.py
+++ b/python/sglang/srt/multimodal/processors/transformers_auto.py
@@ -99,10 +99,12 @@ class TransformersAutoMultimodalProcessor(BaseMultimodalProcessor):
         """Download / decode images from URLs, file paths, or base64."""
         if not image_data:
             return []
+        image_io = self._get_runtime_io_kwargs().get("image", {})
+        discard_alpha_channel = image_io.get("discard_alpha_channel", True)
         images = []
         for data in image_data:
             img, _ = load_image(data)
-            if img.mode != "RGB":
+            if discard_alpha_channel and img.mode != "RGB":
                 img = img.convert("RGB")
             images.append(img)
         return images
@@ -116,10 +118,17 @@ class TransformersAutoMultimodalProcessor(BaseMultimodalProcessor):
         insertion, and tokenization in one shot.
         """
         kwargs = {}
+        image_config = self._get_effective_modality_process_config("image")
+        video_config = self._get_effective_modality_process_config("video")
         if images:
             kwargs["images"] = images
+            if image_config:
+                kwargs.setdefault("images_kwargs", {}).update(image_config)
         if videos:
             kwargs["videos"] = videos
+            if video_config:
+                kwargs.setdefault("videos_kwargs", {}).update(video_config)
+        kwargs = self._merge_runtime_processor_kwargs(kwargs)
         return self._processor(text=text, return_tensors="pt", **kwargs)
 
     def _build_mm_items(

--- a/test/registered/core/test_mm_process_config.py
+++ b/test/registered/core/test_mm_process_config.py
@@ -201,6 +201,89 @@ class TestProcessMmDataKwargs(unittest.TestCase):
         self.assertFalse(audio_kw.get("truncation", True))
         self.assertEqual(audio_kw.get("sample_rate"), 16000)
 
+    def test_runtime_mm_process_config_merges_with_server_defaults(self):
+        config = {"image": {"max_pixels": 5000000, "do_resize": True}}
+        proc, mock_proc, _ = self._make_base_processor(config)
+        request = MagicMock(
+            processor_kwargs=None,
+            mm_process_config={"image": {"max_pixels": 1024}},
+            io_kwargs=None,
+        )
+
+        with proc.request_context(request):
+            proc.process_mm_data("test", images=["img1"])
+
+        call_kwargs = mock_proc.__call__.call_args
+        self.assertEqual(
+            call_kwargs.kwargs.get("images_kwargs"),
+            {"max_pixels": 1024, "do_resize": True},
+        )
+
+    def test_runtime_processor_kwargs_merge_after_mm_config(self):
+        config = {"image": {"max_pixels": 5000000}}
+        proc, mock_proc, _ = self._make_base_processor(config)
+        request = MagicMock(
+            processor_kwargs={
+                "images_kwargs": {"size": {"height": 512}},
+                "custom_flag": True,
+            },
+            mm_process_config={"image": {"max_pixels": 1024}},
+            io_kwargs=None,
+        )
+
+        with proc.request_context(request):
+            proc.process_mm_data("test", images=["img1"])
+
+        call_kwargs = mock_proc.__call__.call_args
+        self.assertEqual(
+            call_kwargs.kwargs.get("images_kwargs"),
+            {"max_pixels": 1024, "size": {"height": 512}},
+        )
+        self.assertTrue(call_kwargs.kwargs.get("custom_flag"))
+
+    def test_runtime_processor_kwargs_reject_reserved_keys(self):
+        proc, _, _ = self._make_base_processor({})
+        request = MagicMock(
+            processor_kwargs={"text": ["bad"]},
+            mm_process_config=None,
+            io_kwargs=None,
+        )
+
+        with proc.request_context(request):
+            with self.assertRaisesRegex(
+                ValueError, "processor_kwargs cannot override reserved processor inputs"
+            ):
+                proc.process_mm_data("test", images=["img1"])
+
+    def test_runtime_io_kwargs_apply_to_fast_load(self):
+        proc, _, _ = self._make_base_processor({})
+        proc._submit_mm_data_loading_tasks_simple = MagicMock(return_value=[])
+        request = MagicMock(
+            processor_kwargs=None,
+            mm_process_config=None,
+            io_kwargs={
+                "image": {"discard_alpha_channel": False},
+                "audio": {"audio_sample_rate": 22050},
+                "video": {"frame_count_limit": 8},
+            },
+        )
+
+        with proc.request_context(request):
+            proc.fast_load_mm_data(
+                prompt="test",
+                multimodal_tokens=MagicMock(),
+                image_data=["img1"],
+                video_data=["vid1"],
+                audio_data=["aud1"],
+            )
+
+        calls = proc._submit_mm_data_loading_tasks_simple.call_args_list
+        self.assertEqual(calls[0].args[2], None)
+        self.assertEqual(calls[0].args[3], 22050)
+        self.assertFalse(calls[0].args[4])
+        self.assertEqual(calls[1].args[2], 8)
+        self.assertEqual(calls[2].args[3], 22050)
+
 
 class TestOverrideProcessorsConfigInjection(unittest.TestCase):
     """Regression tests for processors that override process_mm_data."""
@@ -284,6 +367,66 @@ class TestOverrideProcessorsConfigInjection(unittest.TestCase):
         audio_kw = call_kwargs.kwargs.get("audio_kwargs", {})
         # User config can override truncation if they explicitly set it
         self.assertTrue(audio_kw.get("truncation"))
+
+    def test_midashenglm_runtime_kwargs_merged(self):
+        from sglang.srt.multimodal.processors.midashenglm import (
+            MiDashengLMMultimodalProcessor,
+        )
+
+        proc, mock_proc = self._make_override_processor(
+            MiDashengLMMultimodalProcessor, {"audio": {"sample_rate": 16000}}
+        )
+        request = MagicMock(
+            processor_kwargs={"audio_kwargs": {"padding": "longest"}},
+            mm_process_config={"audio": {"sample_rate": 22050}},
+            io_kwargs=None,
+        )
+
+        with proc.request_context(request):
+            proc.process_mm_data("test", audios=["aud1"])
+
+        call_kwargs = mock_proc.__call__.call_args
+        self.assertEqual(
+            call_kwargs.kwargs.get("audio_kwargs"),
+            {
+                "truncation": False,
+                "sample_rate": 22050,
+                "padding": "longest",
+            },
+        )
+
+
+class TestTransformersAutoRuntimeKwargs(unittest.TestCase):
+    def test_runtime_processor_kwargs_merged_for_transformers_auto(self):
+        from sglang.srt.multimodal.processors.transformers_auto import (
+            TransformersAutoMultimodalProcessor,
+        )
+
+        with patch.object(
+            TransformersAutoMultimodalProcessor, "__init__", lambda self: None
+        ):
+            proc = TransformersAutoMultimodalProcessor()
+
+        proc._processor = MagicMock()
+        proc._processor.return_value = {"input_ids": MagicMock(flatten=MagicMock())}
+        proc.image_config = {"max_pixels": 5000000}
+        proc.video_config = {}
+        proc.audio_config = {}
+
+        request = MagicMock(
+            processor_kwargs={"images_kwargs": {"size": {"height": 512}}},
+            mm_process_config={"image": {"max_pixels": 1024}},
+            io_kwargs=None,
+        )
+
+        with proc.request_context(request):
+            proc._apply_hf_processor("hello", images=["img1"])
+
+        call_kwargs = proc._processor.call_args.kwargs
+        self.assertEqual(
+            call_kwargs.get("images_kwargs"),
+            {"max_pixels": 1024, "size": {"height": 512}},
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -187,9 +187,7 @@ class TestChatCompletionRequest(unittest.TestCase):
             request.processor_kwargs, {"images_kwargs": {"max_pixels": 1024}}
         )
         self.assertEqual(request.mm_process_config, {"image": {"max_pixels": 2048}})
-        self.assertEqual(
-            request.io_kwargs, {"image": {"discard_alpha_channel": False}}
-        )
+        self.assertEqual(request.io_kwargs, {"image": {"discard_alpha_channel": False}})
 
     def test_chat_completion_reasoning_effort(self):
         """Test chat completion with reasoning effort"""

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -27,7 +27,9 @@ from sglang.srt.entrypoints.openai.protocol import (
     Function,
     ModelCard,
     ModelList,
+    ResponsesRequest,
     Tool,
+    TranscriptionRequest,
     UsageInfo,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -172,12 +174,22 @@ class TestChatCompletionRequest(unittest.TestCase):
             separate_reasoning=False,
             stream_reasoning=False,
             chat_template_kwargs={"custom_param": "value"},
+            processor_kwargs={"images_kwargs": {"max_pixels": 1024}},
+            mm_process_config={"image": {"max_pixels": 2048}},
+            io_kwargs={"image": {"discard_alpha_channel": False}},
         )
         self.assertEqual(request.top_k, 40)
         self.assertEqual(request.min_p, 0.05)
         self.assertFalse(request.separate_reasoning)
         self.assertFalse(request.stream_reasoning)
         self.assertEqual(request.chat_template_kwargs, {"custom_param": "value"})
+        self.assertEqual(
+            request.processor_kwargs, {"images_kwargs": {"max_pixels": 1024}}
+        )
+        self.assertEqual(request.mm_process_config, {"image": {"max_pixels": 2048}})
+        self.assertEqual(
+            request.io_kwargs, {"image": {"discard_alpha_channel": False}}
+        )
 
     def test_chat_completion_reasoning_effort(self):
         """Test chat completion with reasoning effort"""
@@ -336,6 +348,35 @@ class TestModelSerialization(unittest.TestCase):
         data = response.model_dump(exclude_none=True)
         self.assertIn("hidden_states", data["choices"][0])
         self.assertEqual(data["choices"][0]["hidden_states"], [0.1, 0.2, 0.3])
+
+
+class TestResponsesAndTranscriptionRequests(unittest.TestCase):
+    def test_responses_request_runtime_mm_kwargs(self):
+        request = ResponsesRequest(
+            model="test-model",
+            input="hello",
+            processor_kwargs={"images_kwargs": {"max_pixels": 1024}},
+            mm_process_config={"image": {"max_pixels": 2048}},
+            io_kwargs={"video": {"frame_count_limit": 8}},
+        )
+        self.assertEqual(
+            request.processor_kwargs, {"images_kwargs": {"max_pixels": 1024}}
+        )
+        self.assertEqual(request.mm_process_config, {"image": {"max_pixels": 2048}})
+        self.assertEqual(request.io_kwargs, {"video": {"frame_count_limit": 8}})
+
+    def test_transcription_request_runtime_mm_kwargs(self):
+        request = TranscriptionRequest(
+            model="whisper",
+            processor_kwargs={"audio_kwargs": {"padding": "longest"}},
+            mm_process_config={"audio": {"sample_rate": 16000}},
+            io_kwargs={"audio": {"audio_sample_rate": 22050}},
+        )
+        self.assertEqual(
+            request.processor_kwargs, {"audio_kwargs": {"padding": "longest"}}
+        )
+        self.assertEqual(request.mm_process_config, {"audio": {"sample_rate": 16000}})
+        self.assertEqual(request.io_kwargs, {"audio": {"audio_sample_rate": 22050}})
 
 
 class TestFunctionDeferLoading(unittest.TestCase):

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -30,7 +30,9 @@ from sglang.srt.entrypoints.openai.protocol import (
     Function,
     ModelCard,
     ModelList,
+    ResponsesRequest,
     Tool,
+    TranscriptionRequest,
     UsageInfo,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -223,12 +225,20 @@ class TestChatCompletionRequest(unittest.TestCase):
             separate_reasoning=False,
             stream_reasoning=False,
             chat_template_kwargs={"custom_param": "value"},
+            processor_kwargs={"images_kwargs": {"max_pixels": 1024}},
+            mm_process_config={"image": {"max_pixels": 2048}},
+            io_kwargs={"image": {"discard_alpha_channel": False}},
         )
         self.assertEqual(request.top_k, 40)
         self.assertEqual(request.min_p, 0.05)
         self.assertFalse(request.separate_reasoning)
         self.assertFalse(request.stream_reasoning)
         self.assertEqual(request.chat_template_kwargs, {"custom_param": "value"})
+        self.assertEqual(
+            request.processor_kwargs, {"images_kwargs": {"max_pixels": 1024}}
+        )
+        self.assertEqual(request.mm_process_config, {"image": {"max_pixels": 2048}})
+        self.assertEqual(request.io_kwargs, {"image": {"discard_alpha_channel": False}})
 
     def test_chat_completion_tito_extensions(self):
         """Test chat completion with pre-tokenized prompt extensions."""
@@ -690,6 +700,35 @@ class TestModelSerialization(unittest.TestCase):
         self.assertNotIn("token_ids", data)
         self.assertEqual(data["response_token_ids"], [4, 5])
         self.assertEqual(data["meta_info"], {"prompt_tokens": 3})
+
+
+class TestResponsesAndTranscriptionRequests(unittest.TestCase):
+    def test_responses_request_runtime_mm_kwargs(self):
+        request = ResponsesRequest(
+            model="test-model",
+            input="hello",
+            processor_kwargs={"images_kwargs": {"max_pixels": 1024}},
+            mm_process_config={"image": {"max_pixels": 2048}},
+            io_kwargs={"video": {"frame_count_limit": 8}},
+        )
+        self.assertEqual(
+            request.processor_kwargs, {"images_kwargs": {"max_pixels": 1024}}
+        )
+        self.assertEqual(request.mm_process_config, {"image": {"max_pixels": 2048}})
+        self.assertEqual(request.io_kwargs, {"video": {"frame_count_limit": 8}})
+
+    def test_transcription_request_runtime_mm_kwargs(self):
+        request = TranscriptionRequest(
+            model="whisper",
+            processor_kwargs={"audio_kwargs": {"padding": "longest"}},
+            mm_process_config={"audio": {"sample_rate": 16000}},
+            io_kwargs={"audio": {"audio_sample_rate": 22050}},
+        )
+        self.assertEqual(
+            request.processor_kwargs, {"audio_kwargs": {"padding": "longest"}}
+        )
+        self.assertEqual(request.mm_process_config, {"audio": {"sample_rate": 16000}})
+        self.assertEqual(request.io_kwargs, {"audio": {"audio_sample_rate": 22050}})
 
 
 class TestFunctionDeferLoading(unittest.TestCase):

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -141,6 +141,32 @@ class ServingChatTestCase(unittest.TestCase):
             self.assertFalse(adapted.stream)
             self.assertEqual(processed, self.basic_req)
 
+    def test_convert_to_internal_request_preserves_runtime_mm_kwargs(self):
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi?"}],
+            processor_kwargs={"images_kwargs": {"max_pixels": 1024}},
+            mm_process_config={"image": {"max_pixels": 2048}},
+            io_kwargs={"video": {"frame_count_limit": 8}},
+        )
+        with patch.object(self.chat, "_process_messages") as proc_mock:
+            proc_mock.return_value = MessageProcessingResult(
+                "Test prompt",
+                [1, 2, 3],
+                None,
+                None,
+                [],
+                ["</s>"],
+                None,
+            )
+            adapted, _ = self.chat._convert_to_internal_request(req)
+
+        self.assertEqual(
+            adapted.processor_kwargs, {"images_kwargs": {"max_pixels": 1024}}
+        )
+        self.assertEqual(adapted.mm_process_config, {"image": {"max_pixels": 2048}})
+        self.assertEqual(adapted.io_kwargs, {"video": {"frame_count_limit": 8}})
+
     def test_jinja_uses_openai_tool_schema_first(self):
         """Ensure Jinja chat templates receive OpenAI-shaped tools by default."""
         self.template_manager.chat_template_name = None

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -752,6 +752,32 @@ class ServingChatTestCase(unittest.TestCase):
         kwargs = self.tm.tokenizer.apply_chat_template.call_args.kwargs
         self.assertEqual(kwargs["tools"], expected_tools)
 
+    def test_convert_to_internal_request_preserves_runtime_mm_kwargs(self):
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi?"}],
+            processor_kwargs={"images_kwargs": {"max_pixels": 1024}},
+            mm_process_config={"image": {"max_pixels": 2048}},
+            io_kwargs={"video": {"frame_count_limit": 8}},
+        )
+        with patch.object(self.chat, "_process_messages") as proc_mock:
+            proc_mock.return_value = MessageProcessingResult(
+                prompt="Test prompt",
+                prompt_ids=[1, 2, 3],
+                image_data=None,
+                audio_data=None,
+                video_data=None,
+                modalities=[],
+                stop=["</s>"],
+            )
+            adapted, _ = self.chat._convert_to_internal_request(req)
+
+        self.assertEqual(
+            adapted.processor_kwargs, {"images_kwargs": {"max_pixels": 1024}}
+        )
+        self.assertEqual(adapted.mm_process_config, {"image": {"max_pixels": 2048}})
+        self.assertEqual(adapted.io_kwargs, {"video": {"frame_count_limit": 8}})
+
     def test_jinja_tool_schema_fallback_to_flat_function(self):
         """Fallback to function-only schema when template rejects OpenAI wrapper."""
         self.template_manager.chat_template_name = None

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -199,6 +199,44 @@ class ChatToolForwardingTestCase(CustomTestCase):
         self.assertFalse(seen["parallel_tool_calls"])
         self.assertEqual(processed.tool_call_constraint[0], "json_schema")
 
+    def test_make_request_preserves_runtime_mm_kwargs(self):
+        serving = make_serving()
+        seen = {}
+
+        def fake_process(chat_request, is_multimodal):
+            seen["processor_kwargs"] = chat_request.processor_kwargs
+            seen["mm_process_config"] = chat_request.mm_process_config
+            seen["io_kwargs"] = chat_request.io_kwargs
+            return MessageProcessingResult(
+                prompt="prompt",
+                prompt_ids=[1, 2, 3],
+                image_data=None,
+                audio_data=None,
+                video_data=None,
+                modalities=[],
+                stop=["</s>"],
+            )
+
+        serving._process_messages = Mock(side_effect=fake_process)
+        request = ResponsesRequest(
+            model="x",
+            input="hello",
+            processor_kwargs={"images_kwargs": {"max_pixels": 1024}},
+            mm_process_config={"image": {"max_pixels": 2048}},
+            io_kwargs={"video": {"frame_count_limit": 8}},
+            store=False,
+        )
+
+        asyncio.run(
+            serving._make_request(request, None, serving.tokenizer_manager.tokenizer)
+        )
+
+        self.assertEqual(
+            seen["processor_kwargs"], {"images_kwargs": {"max_pixels": 1024}}
+        )
+        self.assertEqual(seen["mm_process_config"], {"image": {"max_pixels": 2048}})
+        self.assertEqual(seen["io_kwargs"], {"video": {"frame_count_limit": 8}})
+
     def test_required_tool_choice_without_function_tool_returns_400(self):
         serving = make_serving()
         request = ResponsesRequest(

--- a/test/registered/unit/entrypoints/openai/test_serving_transcription.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_transcription.py
@@ -238,6 +238,27 @@ class TestStreamingFusedAutodetect(CustomTestCase):
         self.assertFalse(any("<|" in d for d in deltas))
 
 
+class TestTranscriptionRequestConversion(CustomTestCase):
+    def test_convert_to_internal_request_preserves_runtime_mm_kwargs(self):
+        tm = _MockTokenizerManager([])
+        serving = OpenAIServingTranscription(tm)
+        request = TranscriptionRequest(
+            model="whisper",
+            processor_kwargs={"audio_kwargs": {"padding": "longest"}},
+            mm_process_config={"audio": {"sample_rate": 16000}},
+            io_kwargs={"audio": {"audio_sample_rate": 22050}},
+        )
+        request.audio_data = b"audio"
+
+        adapted, _ = serving._convert_to_internal_request(request)
+
+        self.assertEqual(
+            adapted.processor_kwargs, {"audio_kwargs": {"padding": "longest"}}
+        )
+        self.assertEqual(adapted.mm_process_config, {"audio": {"sample_rate": 16000}})
+        self.assertEqual(adapted.io_kwargs, {"audio": {"audio_sample_rate": 22050}})
+
+
 class TestStreamingIncrementalOutputMode(CustomTestCase):
     """Server runs with ``incremental_streaming_output=True``.
 

--- a/test/registered/unit/entrypoints/openai/test_serving_transcription.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_transcription.py
@@ -249,6 +249,27 @@ class TestStreamingFusedAutodetect(CustomTestCase):
         self.assertFalse(any("<|" in d for d in deltas))
 
 
+class TestTranscriptionRequestConversion(CustomTestCase):
+    def test_convert_to_internal_request_preserves_runtime_mm_kwargs(self):
+        tm = _MockTokenizerManager([])
+        serving = OpenAIServingTranscription(tm)
+        request = TranscriptionRequest(
+            model="whisper",
+            processor_kwargs={"audio_kwargs": {"padding": "longest"}},
+            mm_process_config={"audio": {"sample_rate": 16000}},
+            io_kwargs={"audio": {"audio_sample_rate": 22050}},
+        )
+        request.audio_data = b"audio"
+
+        adapted, _ = serving._convert_to_internal_request(request)
+
+        self.assertEqual(
+            adapted.processor_kwargs, {"audio_kwargs": {"padding": "longest"}}
+        )
+        self.assertEqual(adapted.mm_process_config, {"audio": {"sample_rate": 16000}})
+        self.assertEqual(adapted.io_kwargs, {"audio": {"audio_sample_rate": 22050}})
+
+
 class _MockChunkTokenizerManager:
     """Mock TM scripting one result list per dispatched request, in order."""
 

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -501,6 +501,9 @@ class TestGenerateReqInputNormalization(CustomTestCase):
             text=["Hello", "World"],
             image_data=[["img1.jpg"], ["img2.jpg"]],
             audio_data=["audio1.mp3", "audio2.mp3"],
+            processor_kwargs={"images_kwargs": {"max_pixels": 1024}},
+            mm_process_config={"image": {"max_pixels": 2048}},
+            io_kwargs={"video": {"frame_count_limit": 8}},
             sampling_params=[{"temp": 0.7}, {"temp": 0.8}],
             rid=["id1", "id2"],
             return_logprob=[True, False],
@@ -533,6 +536,11 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         self.assertEqual(item0.lora_path, "path1")
         self.assertEqual(item0.custom_logit_processor, "processor1")
         self.assertEqual(item0.return_hidden_states, True)
+        self.assertEqual(
+            item0.processor_kwargs, {"images_kwargs": {"max_pixels": 1024}}
+        )
+        self.assertEqual(item0.mm_process_config, {"image": {"max_pixels": 2048}})
+        self.assertEqual(item0.io_kwargs, {"video": {"frame_count_limit": 8}})
 
     def test_regenerate_rid(self):
         """Test the regenerate_rid method."""

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -1015,6 +1015,9 @@ class TestGenerateReqInputNormalization(CustomTestCase):
             text=["Hello", "World"],
             image_data=[["img1.jpg"], ["img2.jpg"]],
             audio_data=["audio1.mp3", "audio2.mp3"],
+            processor_kwargs={"images_kwargs": {"max_pixels": 1024}},
+            mm_process_config={"image": {"max_pixels": 2048}},
+            io_kwargs={"video": {"frame_count_limit": 8}},
             sampling_params=[{"temp": 0.7}, {"temp": 0.8}],
             rid=["id1", "id2"],
             return_logprob=[True, False],
@@ -1047,6 +1050,11 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         self.assertEqual(item0.lora_path, "path1")
         self.assertEqual(item0.custom_logit_processor, "processor1")
         self.assertEqual(item0.return_hidden_states, True)
+        self.assertEqual(
+            item0.processor_kwargs, {"images_kwargs": {"max_pixels": 1024}}
+        )
+        self.assertEqual(item0.mm_process_config, {"image": {"max_pixels": 2048}})
+        self.assertEqual(item0.io_kwargs, {"video": {"frame_count_limit": 8}})
         self.assertEqual(req[1].return_hidden_states, "last")
 
     def test_getitem_preserves_return_prompt_token_ids(self):

--- a/test/registered/unit/managers/test_mm_process_config.py
+++ b/test/registered/unit/managers/test_mm_process_config.py
@@ -822,6 +822,35 @@ class TestProcessMmDataKwargs(CustomTestCase):
         )
         self.assertTrue(call_kwargs.kwargs.get("custom_flag"))
 
+    def test_runtime_processor_kwargs_deep_merge_nested_dicts(self):
+        config = {
+            "image": {
+                "size": {"longest_edge": 2048, "shortest_edge": 1024},
+                "max_pixels": 5000000,
+            }
+        }
+        proc, mock_proc, _ = self._make_base_processor(config)
+        request = MagicMock(
+            processor_kwargs={"images_kwargs": {"size": {"height": 512}}},
+            mm_process_config={"image": {"size": {"shortest_edge": 768}}},
+            io_kwargs=None,
+        )
+
+        with proc.request_context(request):
+            proc.process_mm_data("test", images=["img1"])
+
+        self.assertEqual(
+            mock_proc.__call__.call_args.kwargs.get("images_kwargs"),
+            {
+                "size": {
+                    "longest_edge": 2048,
+                    "shortest_edge": 768,
+                    "height": 512,
+                },
+                "max_pixels": 5000000,
+            },
+        )
+
     def test_runtime_processor_kwargs_reject_reserved_keys(self):
         proc, _, _ = self._make_base_processor({})
         request = MagicMock(

--- a/test/registered/unit/managers/test_mm_process_config.py
+++ b/test/registered/unit/managers/test_mm_process_config.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import threading
 import unittest
@@ -781,6 +782,91 @@ class TestProcessMmDataKwargs(CustomTestCase):
         self.assertFalse(audio_kw.get("truncation", True))
         self.assertEqual(audio_kw.get("sample_rate"), 16000)
 
+    def test_runtime_mm_process_config_merges_with_server_defaults(self):
+        config = {"image": {"max_pixels": 5000000, "do_resize": True}}
+        proc, mock_proc, _ = self._make_base_processor(config)
+        request = MagicMock(
+            processor_kwargs=None,
+            mm_process_config={"image": {"max_pixels": 1024}},
+            io_kwargs=None,
+        )
+
+        with proc.request_context(request):
+            proc.process_mm_data("test", images=["img1"])
+
+        call_kwargs = mock_proc.__call__.call_args
+        self.assertEqual(
+            call_kwargs.kwargs.get("images_kwargs"),
+            {"max_pixels": 1024, "do_resize": True},
+        )
+
+    def test_runtime_processor_kwargs_merge_after_mm_config(self):
+        config = {"image": {"max_pixels": 5000000}}
+        proc, mock_proc, _ = self._make_base_processor(config)
+        request = MagicMock(
+            processor_kwargs={
+                "images_kwargs": {"size": {"height": 512}},
+                "custom_flag": True,
+            },
+            mm_process_config={"image": {"max_pixels": 1024}},
+            io_kwargs=None,
+        )
+
+        with proc.request_context(request):
+            proc.process_mm_data("test", images=["img1"])
+
+        call_kwargs = mock_proc.__call__.call_args
+        self.assertEqual(
+            call_kwargs.kwargs.get("images_kwargs"),
+            {"max_pixels": 1024, "size": {"height": 512}},
+        )
+        self.assertTrue(call_kwargs.kwargs.get("custom_flag"))
+
+    def test_runtime_processor_kwargs_reject_reserved_keys(self):
+        proc, _, _ = self._make_base_processor({})
+        request = MagicMock(
+            processor_kwargs={"text": ["bad"]},
+            mm_process_config=None,
+            io_kwargs=None,
+        )
+
+        with proc.request_context(request):
+            with self.assertRaisesRegex(
+                ValueError, "processor_kwargs cannot override reserved processor inputs"
+            ):
+                proc.process_mm_data("test", images=["img1"])
+
+    def test_runtime_io_kwargs_apply_to_fast_load(self):
+        proc, _, _ = self._make_base_processor({})
+        proc._submit_mm_data_loading_tasks_simple = MagicMock(return_value=[])
+        request = MagicMock(
+            processor_kwargs=None,
+            mm_process_config=None,
+            io_kwargs={
+                "image": {"discard_alpha_channel": False},
+                "audio": {"audio_sample_rate": 22050},
+                "video": {"frame_count_limit": 8},
+            },
+        )
+
+        with proc.request_context(request):
+            asyncio.run(
+                proc.fast_load_mm_data(
+                    prompt="test",
+                    multimodal_tokens=MagicMock(),
+                    image_data=["img1"],
+                    video_data=["vid1"],
+                    audio_data=["aud1"],
+                )
+            )
+
+        calls = proc._submit_mm_data_loading_tasks_simple.call_args_list
+        self.assertEqual(calls[0].args[2], None)
+        self.assertEqual(calls[0].args[3], 22050)
+        self.assertFalse(calls[0].args[4])
+        self.assertEqual(calls[1].args[2], 8)
+        self.assertEqual(calls[2].args[3], 22050)
+
 
 class TestOverrideProcessorsConfigInjection(CustomTestCase):
     """Regression tests for processors that override process_mm_data."""
@@ -870,6 +956,66 @@ class TestOverrideProcessorsConfigInjection(CustomTestCase):
         audio_kw = call_kwargs.kwargs.get("audio_kwargs", {})
         # User config can override truncation if they explicitly set it
         self.assertTrue(audio_kw.get("truncation"))
+
+    def test_midashenglm_runtime_kwargs_merged(self):
+        from sglang.srt.multimodal.processors.midashenglm import (
+            MiDashengLMMultimodalProcessor,
+        )
+
+        proc, mock_proc = self._make_override_processor(
+            MiDashengLMMultimodalProcessor, {"audio": {"sample_rate": 16000}}
+        )
+        request = MagicMock(
+            processor_kwargs={"audio_kwargs": {"padding": "longest"}},
+            mm_process_config={"audio": {"sample_rate": 22050}},
+            io_kwargs=None,
+        )
+
+        with proc.request_context(request):
+            proc.process_mm_data("test", audios=["aud1"])
+
+        call_kwargs = mock_proc.__call__.call_args
+        self.assertEqual(
+            call_kwargs.kwargs.get("audio_kwargs"),
+            {
+                "truncation": False,
+                "sample_rate": 22050,
+                "padding": "longest",
+            },
+        )
+
+
+class TestTransformersAutoRuntimeKwargs(CustomTestCase):
+    def test_runtime_processor_kwargs_merged_for_transformers_auto(self):
+        from sglang.srt.multimodal.processors.transformers_auto import (
+            TransformersAutoMultimodalProcessor,
+        )
+
+        with patch.object(
+            TransformersAutoMultimodalProcessor, "__init__", lambda self: None
+        ):
+            proc = TransformersAutoMultimodalProcessor()
+
+        proc._processor = MagicMock()
+        proc._processor.return_value = {"input_ids": MagicMock(flatten=MagicMock())}
+        proc.image_config = {"max_pixels": 5000000}
+        proc.video_config = {}
+        proc.audio_config = {}
+
+        request = MagicMock(
+            processor_kwargs={"images_kwargs": {"size": {"height": 512}}},
+            mm_process_config={"image": {"max_pixels": 1024}},
+            io_kwargs=None,
+        )
+
+        with proc.request_context(request):
+            proc._apply_hf_processor("hello", images=["img1"])
+
+        call_kwargs = proc._processor.call_args.kwargs
+        self.assertEqual(
+            call_kwargs.get("images_kwargs"),
+            {"max_pixels": 1024, "size": {"height": 512}},
+        )
 
 
 class TestQwenVideoConfigRouting(CustomTestCase):


### PR DESCRIPTION
## Summary
- plumb `processor_kwargs`, `mm_process_config`, and `io_kwargs` through the OpenAI chat, responses, and transcription adapters plus `GenerateReqInput`
- merge request-scoped multimodal config and processor overrides at runtime inside the multimodal processor path, including loader-level `io_kwargs`
- add focused regression coverage for request models, request adaptation, responses passthrough, and runtime multimodal kwargs merging

## Testing
- `python3 -m py_compile python/sglang/srt/managers/io_struct.py python/sglang/srt/managers/tokenizer_manager.py python/sglang/srt/entrypoints/openai/protocol.py python/sglang/srt/entrypoints/openai/serving_chat.py python/sglang/srt/entrypoints/openai/serving_responses.py python/sglang/srt/entrypoints/openai/serving_transcription.py python/sglang/srt/entrypoints/http_server.py python/sglang/srt/multimodal/processors/base_processor.py python/sglang/srt/multimodal/processors/ernie45_vl.py python/sglang/srt/multimodal/processors/midashenglm.py python/sglang/srt/multimodal/processors/transformers_auto.py test/registered/unit/entrypoints/openai/test_protocol.py test/registered/unit/entrypoints/openai/test_serving_chat.py test/registered/unit/entrypoints/openai/test_serving_responses.py test/registered/unit/entrypoints/openai/test_serving_transcription.py test/registered/unit/managers/test_io_struct.py test/registered/unit/managers/test_mm_process_config.py`
- `uvx --from ruff ruff check --select F401,F821,UP037 python/sglang/srt/managers/io_struct.py python/sglang/srt/managers/tokenizer_manager.py python/sglang/srt/entrypoints/openai/protocol.py python/sglang/srt/entrypoints/openai/serving_chat.py python/sglang/srt/entrypoints/openai/serving_responses.py python/sglang/srt/entrypoints/openai/serving_transcription.py python/sglang/srt/entrypoints/http_server.py python/sglang/srt/multimodal/processors/base_processor.py python/sglang/srt/multimodal/processors/ernie45_vl.py python/sglang/srt/multimodal/processors/midashenglm.py python/sglang/srt/multimodal/processors/transformers_auto.py test/registered/unit/entrypoints/openai/test_protocol.py test/registered/unit/entrypoints/openai/test_serving_chat.py test/registered/unit/entrypoints/openai/test_serving_responses.py test/registered/unit/entrypoints/openai/test_serving_transcription.py test/registered/unit/managers/test_io_struct.py test/registered/unit/managers/test_mm_process_config.py`
- `uvx isort --check-only python/sglang/srt/managers/io_struct.py python/sglang/srt/managers/tokenizer_manager.py python/sglang/srt/entrypoints/openai/protocol.py python/sglang/srt/entrypoints/openai/serving_chat.py python/sglang/srt/entrypoints/openai/serving_responses.py python/sglang/srt/entrypoints/openai/serving_transcription.py python/sglang/srt/entrypoints/http_server.py python/sglang/srt/multimodal/processors/base_processor.py python/sglang/srt/multimodal/processors/ernie45_vl.py python/sglang/srt/multimodal/processors/midashenglm.py python/sglang/srt/multimodal/processors/transformers_auto.py test/registered/unit/entrypoints/openai/test_protocol.py test/registered/unit/entrypoints/openai/test_serving_chat.py test/registered/unit/entrypoints/openai/test_serving_responses.py test/registered/unit/entrypoints/openai/test_serving_transcription.py test/registered/unit/managers/test_io_struct.py test/registered/unit/managers/test_mm_process_config.py`
- `uvx black --check python/sglang/srt/managers/io_struct.py python/sglang/srt/managers/tokenizer_manager.py python/sglang/srt/entrypoints/openai/protocol.py python/sglang/srt/entrypoints/openai/serving_chat.py python/sglang/srt/entrypoints/openai/serving_responses.py python/sglang/srt/entrypoints/openai/serving_transcription.py python/sglang/srt/entrypoints/http_server.py python/sglang/srt/multimodal/processors/base_processor.py python/sglang/srt/multimodal/processors/ernie45_vl.py python/sglang/srt/multimodal/processors/midashenglm.py python/sglang/srt/multimodal/processors/transformers_auto.py test/registered/unit/entrypoints/openai/test_protocol.py test/registered/unit/entrypoints/openai/test_serving_chat.py test/registered/unit/entrypoints/openai/test_serving_responses.py test/registered/unit/entrypoints/openai/test_serving_transcription.py test/registered/unit/managers/test_io_struct.py test/registered/unit/managers/test_mm_process_config.py`
- `python3 scripts/lint/check_registered_tests.py`
- `git diff --check`

## Notes
- On August 30, 2026, I attempted to run the targeted runtime/unit suite locally, but the available macOS environment lacked required Python deps (`orjson`, `msgspec`, `torch`, and `pytest`) and the checked-in `python/.venv` was effectively empty, so only the static validation above was runnable locally.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33333806859](https://github.com/sgl-project/sglang/actions/runs/33333806859)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33333806689](https://github.com/sgl-project/sglang/actions/runs/33333806689)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33333806942](https://github.com/sgl-project/sglang/actions/runs/33333806942)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->