### PR TITLE
[OOT] Add Out-of-Tree plugin infrastructure for multi-platform operator dispatch

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -58,6 +58,7 @@ from sglang.srt.utils import (
 )
 from sglang.srt.utils.custom_op import register_custom_op
 from sglang.srt.utils.network import get_local_ip_auto
+from sglang.srt.utils.oot_device import get_oot_device_config
 
 _is_npu = is_npu()
 _is_cpu = is_cpu()
@@ -65,6 +66,9 @@ _is_xpu = is_xpu()
 _is_musa = is_musa()
 
 TensorMetadata = namedtuple("TensorMetadata", ["device", "dtype", "size"])
+
+# OOT communicator factory: plugins register via GroupCoordinator.register_oot_communicator()
+_oot_communicator_factory: Optional[Callable] = None
 
 # use int value instead of ReduceOp.SUM to support torch compile
 REDUCE_OP_SUM = int(torch.distributed.ReduceOp.SUM)
@@ -231,6 +235,20 @@ class GroupCoordinator:
     ca_comm: Optional[Any]  # Custom allreduce communicator
     torch_symm_mem_comm: Optional[Any]  # Torch symm mem communicator
     mq_broadcaster: Optional[Any]  # shared memory broadcaster
+    oot_communicator: Optional[Any]  # OOT plugin communicator
+
+    @classmethod
+    def register_oot_communicator(cls, factory_fn: Callable) -> None:
+        """Register an OOT communicator factory (called by plugins).
+
+        Args:
+            factory_fn: Callable(group, device) -> communicator instance.
+                The communicator must implement all_reduce(tensor),
+                and optionally reduce_scatter/all_gather.
+        """
+        global _oot_communicator_factory
+        _oot_communicator_factory = factory_fn
+        logger.info("Registered OOT communicator factory")
 
     def __init__(
         self,
@@ -260,7 +278,11 @@ class GroupCoordinator:
         self.cpu_group = None
         self.local_size = get_int_env_var("LOCAL_SIZE", 0)
 
-        if is_cuda_alike():
+        # OOT device config takes priority over built-in device selection
+        _oot_dev_cfg = get_oot_device_config()
+        if _oot_dev_cfg is not None:
+            self.device = _oot_dev_cfg.get_device(local_rank)
+        elif is_cuda_alike():
             device_id = (
                 0 if envs.SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS.get() else local_rank
             )
@@ -426,6 +448,17 @@ class GroupCoordinator:
         if use_npu_communicator and self.world_size > 1:
             self.npu_communicator = NpuCommunicator(group=self.device_group)
 
+        # OOT communicator — plugin-registered factory takes priority
+        self.oot_communicator: Optional[Any] = None
+        if _oot_communicator_factory is not None and self.world_size > 1:
+            try:
+                self.oot_communicator = _oot_communicator_factory(
+                    group=self.cpu_group, device=self.device
+                )
+                logger.info("OOT communicator created successfully")
+            except Exception as e:
+                logger.warning(f"Failed to create OOT communicator: {e}")
+
         # Create message queue
         from sglang.srt.distributed.device_communicators.shm_broadcast import (
             MessageQueue,
@@ -566,6 +599,10 @@ class GroupCoordinator:
             else:
                 torch.distributed.all_reduce(input_, group=self.device_group)
             return input_
+
+        # OOT communicator takes priority over built-in hardware communicators
+        if self.oot_communicator is not None and not getattr(self.oot_communicator, "disabled", False):
+            return self.oot_communicator.all_reduce(input_)
 
         if self.hpu_communicator is not None and not self.hpu_communicator.disabled:
             return self.hpu_communicator.all_reduce(input_)
@@ -727,7 +764,9 @@ class GroupCoordinator:
         return output
 
     def reduce_scatter_tensor(self, output: torch.Tensor, input: torch.Tensor):
-        if _is_npu:
+        if self.oot_communicator is not None and hasattr(self.oot_communicator, "reduce_scatter"):
+            self.oot_communicator.reduce_scatter(output, input)
+        elif _is_npu:
             self._reduce_scatter_tensor(output, input)
         else:
             reg_reduce_scatter_tensor(output, input, group_name=self.unique_name)
@@ -787,7 +826,9 @@ class GroupCoordinator:
             )
 
     def all_gather_into_tensor(self, output: torch.Tensor, input: torch.Tensor):
-        if _is_npu or _is_xpu:
+        if self.oot_communicator is not None and hasattr(self.oot_communicator, "all_gather"):
+            self.oot_communicator.all_gather(output, input)
+        elif _is_npu or _is_xpu:
             self._all_gather_into_tensor(output, input)
         else:
             reg_all_gather_into_tensor(output, input, group_name=self.unique_name)
@@ -1574,6 +1615,10 @@ _DEVICE_TO_DISTRIBUTED_BACKEND = {
 
 
 def get_default_distributed_backend(device: str) -> str:
+    # OOT plugin can override the distributed backend (e.g. "flagcx")
+    cfg = get_oot_device_config()
+    if cfg is not None and cfg.dist_backend:
+        return cfg.dist_backend
     return _DEVICE_TO_DISTRIBUTED_BACKEND.get(device, "gloo")
 
 

--- a/python/sglang/srt/layers/utils/multi_platform.py
+++ b/python/sglang/srt/layers/utils/multi_platform.py
@@ -1,4 +1,9 @@
-from typing import Callable
+import logging
+import os
+import types
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, Dict, List, Optional, Set
 
 from torch import nn
 
@@ -13,6 +18,8 @@ from sglang.srt.utils import (
     is_xpu,
 )
 
+logger = logging.getLogger(__name__)
+
 _is_cuda = is_cuda()
 _is_hip = is_hip()
 _is_cpu = is_cpu()
@@ -21,76 +28,338 @@ _is_npu = is_npu()
 _is_xpu = is_xpu()
 _is_musa = is_musa()
 
+# ============================================================
+# Dispatch logging (similar to flag_gems' record mode)
+# SGLANG_OOT_DISPATCH_LOG=/tmp/dispatch.log → write dispatch decisions to file
+# ============================================================
+_dispatch_log_path = os.environ.get("SGLANG_OOT_DISPATCH_LOG", "").strip() or None
+_dispatched_ops: Dict[str, str] = {}  # {op_name: "kind:impl_id"} for inspection
+
+
+def _log_dispatch(op_name: str, source: str, detail: str = ""):
+    """Record a dispatch decision. Only writes to file once per unique op_name."""
+    entry = f"{source}" + (f"({detail})" if detail else "")
+    already_logged = op_name in _dispatched_ops
+    _dispatched_ops[op_name] = entry
+    msg = f"[OOT-DISPATCH] {op_name} → {entry}"
+    logger.info(msg)
+    if _dispatch_log_path and not already_logged:
+        try:
+            with open(_dispatch_log_path, "a") as f:
+                f.write(msg + "\n")
+        except Exception:
+            pass
+
+
+# ============================================================
+# Multi-backend dispatch types
+# ============================================================
+
+class OOTBackendKind(str, Enum):
+    """Backend implementation kind, matching vllm-plugin-FL's design.
+
+    - FLAGOS: FlagOS default implementation (FlagGems Triton kernels), highest priority
+    - VENDOR: Chip vendor's own implementation, medium priority
+    - REFERENCE: PyTorch native fallback, lowest priority
+    """
+    FLAGOS = "flagos"
+    VENDOR = "vendor"
+    REFERENCE = "reference"
+
+
+# Default priority values (higher = preferred)
+_DEFAULT_PRIORITIES = {
+    OOTBackendKind.FLAGOS: 150,
+    OOTBackendKind.VENDOR: 100,
+    OOTBackendKind.REFERENCE: 50,
+}
+
+# Default selection order: flagos > vendor > reference
+_DEFAULT_ORDER = [OOTBackendKind.FLAGOS, OOTBackendKind.VENDOR, OOTBackendKind.REFERENCE]
+
+
+@dataclass(frozen=True)
+class OOTOpImpl:
+    """Operator implementation descriptor.
+
+    Attributes:
+        op_name: Operator class name, e.g. "SiluAndMul"
+        kind: Backend kind (FLAGOS / VENDOR / REFERENCE)
+        fn: The implementation function. Signature: fn(self, *args, **kwargs)
+        priority: Selection priority (higher = preferred). Auto-set from kind if 0.
+        vendor: Vendor name (required if kind is VENDOR)
+        impl_id: Unique identifier, auto-generated if not provided
+    """
+    op_name: str
+    kind: OOTBackendKind
+    fn: Callable
+    priority: int = 0
+    vendor: Optional[str] = None
+    impl_id: str = ""
+
+    def __post_init__(self):
+        # Auto-set priority from kind if not explicitly provided
+        if self.priority == 0:
+            object.__setattr__(self, "priority", _DEFAULT_PRIORITIES.get(self.kind, 50))
+        # Auto-generate impl_id
+        if not self.impl_id:
+            if self.vendor:
+                object.__setattr__(self, "impl_id", f"{self.kind.value}.{self.vendor}")
+            else:
+                object.__setattr__(self, "impl_id", self.kind.value)
+
+
+def _get_selection_order() -> List[OOTBackendKind]:
+    """Get selection order from SGLANG_OOT_PREFER env var.
+
+    Values: "flagos" (default), "vendor", "reference"
+    Controls which backend is tried first. Others follow as fallback.
+    """
+    prefer = os.environ.get("SGLANG_OOT_PREFER", "flagos").strip().lower()
+    if prefer == "vendor":
+        return [OOTBackendKind.VENDOR, OOTBackendKind.FLAGOS, OOTBackendKind.REFERENCE]
+    elif prefer == "reference":
+        return [OOTBackendKind.REFERENCE, OOTBackendKind.FLAGOS, OOTBackendKind.VENDOR]
+    else:
+        return list(_DEFAULT_ORDER)
+
+
+_per_op_prefer: Dict[str, OOTBackendKind] = {}
+
+def _parse_per_op_prefer():
+    """Parse SGLANG_OOT_OP_PREFER env var for per-op backend override.
+
+    Format: "SiluAndMul:flagos,RMSNorm:reference,SiluAndMul:vendor:ascend"
+    The "vendor:{name}" syntax selects a specific vendor backend.
+    """
+    raw = os.environ.get("SGLANG_OOT_OP_PREFER", "").strip()
+    if not raw:
+        return
+    _kind_map = {k.value: k for k in OOTBackendKind}
+    for item in raw.split(","):
+        item = item.strip()
+        if ":" not in item:
+            continue
+        parts = item.split(":")
+        op_name = parts[0].strip()
+        kind_str = parts[1].strip().lower()
+        if kind_str == "vendor" and len(parts) >= 3:
+            # vendor:{name} syntax — store as (kind, vendor_name)
+            vendor_name = parts[2].strip().lower()
+            _per_op_prefer[op_name] = (OOTBackendKind.VENDOR, vendor_name)
+        elif kind_str in _kind_map:
+            _per_op_prefer[op_name] = _kind_map[kind_str]
+        else:
+            logger.warning(f"Unknown backend '{kind_str}' for op '{op_name}' in SGLANG_OOT_OP_PREFER")
+
+_parse_per_op_prefer()
+
+
+# ============================================================
+# Plugin loading
+# ============================================================
+
+def _load_oot_plugins():
+    """Load OOT plugins from SGLANG_OOT_PLUGINS env var.
+
+    Plugins are comma-separated module names. Each module should call
+    MultiPlatformOp.register_oot() or register_oot_impl() when imported.
+    """
+    import importlib
+    plugins = os.environ.get("SGLANG_OOT_PLUGINS", "").strip()
+    if not plugins:
+        return
+    for mod_name in plugins.split(","):
+        mod_name = mod_name.strip()
+        if mod_name:
+            try:
+                importlib.import_module(mod_name)
+                logger.info(f"Loaded OOT plugin: {mod_name}")
+            except Exception as e:
+                logger.warning(f"Failed to load OOT plugin {mod_name}: {e}")
+
+
+# ============================================================
+# MultiPlatformOp
+# ============================================================
 
 class MultiPlatformOp(nn.Module):
+    # Legacy single-impl registry: {op_name: forward_fn}
+    # Kept for backward compatibility with existing plugins.
+    _oot_forward_registry: Dict[str, Callable] = {}
+
+    # Multi-backend registry: {op_name: [OOTOpImpl, ...]}
+    _oot_impl_registry: Dict[str, List[OOTOpImpl]] = {}
+
+    # ---- Legacy API (backward compatible) ----
+
+    @classmethod
+    def register_oot(cls, op_name: str, forward_fn: Callable):
+        """Register an OOT forward implementation for an operator.
+
+        This is the simple API — registers as FLAGOS kind by default.
+        For multi-backend support, use register_oot_impl() instead.
+
+        Args:
+            op_name: Operator class name, e.g. "SiluAndMul", "RMSNorm"
+            forward_fn: Replacement forward function. Signature: fn(self, *args, **kwargs)
+        """
+        cls._oot_forward_registry[op_name] = forward_fn
+        logger.info(f"Registered OOT forward for {op_name}")
+
+    @classmethod
+    def unregister_oot(cls, op_name: str):
+        """Remove an OOT forward registration."""
+        if cls._oot_forward_registry.pop(op_name, None) is not None:
+            logger.info(f"Unregistered OOT forward for {op_name}")
+
+    @classmethod
+    def get_oot_registry(cls) -> Dict[str, Callable]:
+        """Return a copy of the current OOT registry (legacy single-impl)."""
+        return dict(cls._oot_forward_registry)
+
+    # ---- Multi-backend API ----
+
+    @classmethod
+    def register_oot_impl(cls, impl: OOTOpImpl):
+        """Register an OOT operator implementation with backend kind and priority.
+
+        Multiple implementations can be registered for the same op_name.
+        dispatch_forward() selects the best one based on policy and fallback.
+
+        Args:
+            impl: OOTOpImpl descriptor
+        """
+        impls = cls._oot_impl_registry.setdefault(impl.op_name, [])
+        # Prevent duplicate impl_id for same op
+        for existing in impls:
+            if existing.impl_id == impl.impl_id:
+                logger.warning(
+                    f"Replacing OOT impl {impl.impl_id} for {impl.op_name}"
+                )
+                impls.remove(existing)
+                break
+        impls.append(impl)
+        logger.info(
+            f"Registered OOT impl: op={impl.op_name}, kind={impl.kind.value}, "
+            f"priority={impl.priority}, impl_id={impl.impl_id}"
+        )
+
+    @classmethod
+    def get_dispatched_ops(cls) -> Dict[str, str]:
+        """Return dispatch log: {op_name: 'kind(impl_id)'} for all dispatched ops."""
+        return dict(_dispatched_ops)
+
+    @classmethod
+    def unregister_oot_impl(cls, op_name: str, impl_id: str):
+        """Remove a specific OOT implementation."""
+        impls = cls._oot_impl_registry.get(op_name, [])
+        cls._oot_impl_registry[op_name] = [
+            i for i in impls if i.impl_id != impl_id
+        ]
+
+    @classmethod
+    def get_oot_impl_registry(cls) -> Dict[str, List[OOTOpImpl]]:
+        """Return a copy of the multi-backend OOT registry."""
+        return {k: list(v) for k, v in cls._oot_impl_registry.items()}
+
+    @classmethod
+    def _is_impl_available(cls, impl: OOTOpImpl) -> bool:
+        """Check if an impl is available via its _is_available attribute."""
+        avail_fn = getattr(impl.fn, "_is_available", None)
+        if callable(avail_fn):
+            return avail_fn()
+        return True  # no check → assume available
+
+    @classmethod
+    def _resolve_oot_impl(cls, op_name: str) -> Optional[Callable]:
+        """Resolve the best OOT implementation for an operator.
+
+        Selection logic:
+        1. Get selection order from SGLANG_OOT_PREFER (default: flagos > vendor > reference)
+        2. For each kind in order, find matching impls sorted by priority (desc)
+        3. Skip impls whose _is_available() returns False
+        4. Return the first available one
+
+        Returns:
+            The best forward_fn, or None if no multi-backend impl registered.
+        """
+        impls = cls._oot_impl_registry.get(op_name)
+        if not impls:
+            return None
+
+        # Per-op override
+        if op_name in _per_op_prefer:
+            pref = _per_op_prefer[op_name]
+            if isinstance(pref, tuple):
+                # (OOTBackendKind.VENDOR, vendor_name) — match specific vendor
+                preferred_kind, vendor_name = pref
+                candidates = [
+                    i for i in impls
+                    if i.kind == preferred_kind
+                    and i.vendor and i.vendor.lower() == vendor_name
+                ]
+            else:
+                preferred_kind = pref
+                candidates = [i for i in impls if i.kind == preferred_kind]
+            if candidates:
+                candidates.sort(key=lambda x: (x.priority, x.impl_id), reverse=True)
+                for c in candidates:
+                    if cls._is_impl_available(c):
+                        _log_dispatch(op_name, c.kind.value, c.impl_id)
+                        return c.fn
+            # preferred kind not registered or not available → fall through to global order
+
+        order = _get_selection_order()
+
+        for kind in order:
+            candidates = [i for i in impls if i.kind == kind]
+            if not candidates:
+                continue
+            # Sort by priority descending, then impl_id for stability
+            candidates.sort(key=lambda x: (x.priority, x.impl_id), reverse=True)
+            for c in candidates:
+                if cls._is_impl_available(c):
+                    _log_dispatch(op_name, c.kind.value, c.impl_id)
+                    return c.fn
+
+        # Fallback: return highest priority available regardless of kind
+        all_sorted = sorted(impls, key=lambda x: (x.priority, x.impl_id), reverse=True)
+        for c in all_sorted:
+            if cls._is_impl_available(c):
+                _log_dispatch(op_name, "fallback", c.impl_id)
+                return c.fn
+        return None
+
+    # ---- Core ----
+
     def __init__(self):
         super().__init__()
         self._forward_method: Callable = self.dispatch_forward()
 
-        # States for torch.compile
-        self._original_forward_method = None
-        self.is_torch_compile = False
-
-    def enter_torch_compile(self, num_tokens: int):
-        # Skip if Op is already entered compile mode.
-        # NOTE(alcanderian): Some Ops(for example RotaryEmbedding) will be reused
-        # among layers and `enter_torch_compile` will be called many times.
-        # We should prevent `self._original_forward_method` from being overridden when
-        # it is not the first time `enter_torch_compile` called.
-        if self.is_torch_compile:
-            return
-
-        self._original_forward_method = self._forward_method
-        # NOTE: Temporarily workaround MoE
-        # The performance of torch.compile on this layer is not always good when bs > 1,
-        # so we decide to only use torch.compile when bs=1
-        if "FusedMoE" in self.__class__.__name__:
-            if num_tokens == 1:
-                from sglang.srt.layers.moe.fused_moe_native import (
-                    fused_moe_forward_native,
-                )
-
-                self._forward_method = fused_moe_forward_native
-        elif "TopK" in self.__class__.__name__:
-            if num_tokens == 1:
-                self._forward_method = self.forward_native
-        else:
-            self._forward_method = self.forward_native
-        self.is_torch_compile = True
-
-    def leave_torch_compile(self):
-        # Skip if Op is already exited compile mode.
-        if not self.is_torch_compile:
-            return
-
-        self._forward_method = self._original_forward_method
-        self._original_forward_method = None
-        self.is_torch_compile = False
-
-    # Please do not override this method, because `self._forward_method` can change when in torch compile mode
-    @debug_kernel_api
     def forward(self, *args, **kwargs):
         return self._forward_method(*args, **kwargs)
 
+    @debug_kernel_api
     def forward_native(self, *args, **kwargs):
-        raise NotImplementedError
+        raise NotImplementedError(
+            f"{type(self).__name__} does not have a native forward implementation."
+        )
 
+    @debug_kernel_api
     def forward_cuda(self, *args, **kwargs):
-        raise NotImplementedError
-
-    def forward_npu(self, *args, **kwargs):
         return self.forward_native(*args, **kwargs)
 
     def forward_hip(self, *args, **kwargs):
         return self.forward_cuda(*args, **kwargs)
 
+    def forward_npu(self, *args, **kwargs):
+        return self.forward_native(*args, **kwargs)
+
     def forward_xpu(self, *args, **kwargs):
         return self.forward_native(*args, **kwargs)
 
     def forward_musa(self, *args, **kwargs):
-        # XXX (MUSA): MUSA kernels follow the CUDA path by default.
-        # At this stage, sgl-kernel support for MUSA is still under active
-        # development, so we fall back to the PyTorch-native implementation.
         return self.forward_native(*args, **kwargs)
 
     def forward_hpu(self, *args, **kwargs):
@@ -100,17 +369,42 @@ class MultiPlatformOp(nn.Module):
         return self.forward_native(*args, **kwargs)
 
     def dispatch_forward(self):
+        op_name = self.__class__.__name__
+
+        # Priority 1: Multi-backend registry (with kind/priority/fallback)
+        resolved_fn = self._resolve_oot_impl(op_name)
+        if resolved_fn is not None:
+            return types.MethodType(resolved_fn, self)
+
+        # Priority 2: Legacy single-impl registry (backward compatible)
+        if op_name in self._oot_forward_registry:
+            oot_fn = self._oot_forward_registry[op_name]
+            _log_dispatch(op_name, "legacy_oot")
+            return types.MethodType(oot_fn, self)
+
+        # Priority 3: Built-in platform dispatch
         if _is_cuda:
+            _log_dispatch(op_name, "builtin", "cuda")
             return self.forward_cuda
         elif _is_hip:
+            _log_dispatch(op_name, "builtin", "hip")
             return self.forward_hip
         elif _is_cpu and _is_cpu_amx_available:
+            _log_dispatch(op_name, "builtin", "cpu_amx")
             return self.forward_cpu
         elif _is_npu:
+            _log_dispatch(op_name, "builtin", "npu")
             return self.forward_npu
         elif _is_xpu:
+            _log_dispatch(op_name, "builtin", "xpu")
             return self.forward_xpu
         elif _is_musa:
+            _log_dispatch(op_name, "builtin", "musa")
             return self.forward_musa
         else:
+            _log_dispatch(op_name, "builtin", "native")
             return self.forward_native
+
+
+# Auto-load OOT plugins when this module is imported (works in all processes)
+_load_oot_plugins()

--- a/python/sglang/srt/utils/oot_device.py
+++ b/python/sglang/srt/utils/oot_device.py
@@ -1,0 +1,72 @@
+"""OOT (Out-Of-Tree) device configuration registry.
+
+Allows third-party plugins to register custom device configurations
+without modifying SGLang upstream code. This enables non-CUDA devices
+(NPU, XPU, MLU, etc.) to plug in via a single registration call.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Optional
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+_oot_device_config: Optional["OOTDeviceConfig"] = None
+
+
+@dataclass
+class OOTDeviceConfig:
+    """Plugin-registered device configuration.
+
+    Attributes:
+        device_type: Device type string, e.g. "cuda", "npu", "mlu"
+        torch_device_module: The torch device module (e.g. torch.cuda, torch.npu)
+        dist_backend: Distributed backend name, e.g. "nccl", "hccl", "flagcx"
+        empty_cache_fn: Optional function to clear device cache
+        device_count_fn: Optional function to get device count
+    """
+
+    device_type: str
+    dist_backend: str = "nccl"
+    empty_cache_fn: Optional[Callable[[], None]] = None
+    device_count_fn: Optional[Callable[[], int]] = None
+
+    def get_device(self, local_rank: int) -> torch.device:
+        """Return a torch.device for the given local rank."""
+        return torch.device(f"{self.device_type}:{local_rank}")
+
+    def empty_cache(self) -> None:
+        """Clear device memory cache."""
+        if self.empty_cache_fn is not None:
+            self.empty_cache_fn()
+        else:
+            # Fallback: try torch.{device_type}.empty_cache()
+            mod = getattr(torch, self.device_type, None)
+            if mod is not None and hasattr(mod, "empty_cache"):
+                mod.empty_cache()
+
+    def get_device_count(self) -> int:
+        """Return the number of available devices."""
+        if self.device_count_fn is not None:
+            return self.device_count_fn()
+        mod = getattr(torch, self.device_type, None)
+        if mod is not None and hasattr(mod, "device_count"):
+            return mod.device_count()
+        return 0
+
+
+def register_oot_device(config: OOTDeviceConfig) -> None:
+    """Register an OOT device configuration (called by plugins)."""
+    global _oot_device_config
+    _oot_device_config = config
+    logger.info(
+        f"Registered OOT device: type={config.device_type}, "
+        f"dist_backend={config.dist_backend}"
+    )
+
+
+def get_oot_device_config() -> Optional[OOTDeviceConfig]:
+    """Return the registered OOT device config, or None."""
+    return _oot_device_config


### PR DESCRIPTION
  ## Motivation
                                                                                                                                                                                                                          
  Third-party chip vendors (e.g. Ascend NPU, Cambricon MLU, custom accelerators) need to integrate with SGLang without modifying SGLang source code. Currently `MultiPlatformOp.dispatch_forward()` only supports built-in
   platform dispatch (CUDA/HIP/NPU/XPU/MUSA), requiring vendors to fork and patch SGLang.                                                                                                                                 
                                                                                                                                                                                                                          
  This PR adds a lightweight OOT (Out-of-Tree) plugin infrastructure so that chip vendors can replace operators and distributed communicators via a side-installed plugin package, loaded through the `SGLANG_OOT_PLUGINS`
   environment variable.
                                                                                                                                                                                                                          
  ## Changes                                                                     

  ### `python/sglang/srt/layers/utils/multi_platform.py`                                                                                                                                                                  
   
  Extends `MultiPlatformOp` with a multi-backend OOT registry:                                                                                                                                                            
                                                                                 
  - **`OOTBackendKind`**: enum — `FLAGOS` / `VENDOR` / `REFERENCE`                                                                                                                                                        
  - **`OOTOpImpl`**: dataclass describing one backend implementation (op name, kind, function, priority, vendor tag, availability check)
  - **`register_oot_impl()`**: class-level API for plugins to register backend implementations                                                                                                                            
  - **`register_oot()`**: legacy single-impl API (backward compatible)                                                                                                                                                    
  - **`dispatch_forward()`**: extended priority chain:                                                                                                                                                                    
    1. Multi-backend OOT registry (respects `SGLANG_OOT_PREFER` / `SGLANG_OOT_OP_PREFER`)                                                                                                                                 
    2. Legacy OOT registry                                                                                                                                                                                                
    3. Built-in platform dispatch (unchanged)                                                                                                                                                                             
  - Dispatch logging via `SGLANG_OOT_DISPATCH_LOG`                                                                                                                                                                        
                                                                                 
  Default priority: `FLAGOS(150) > VENDOR(100) > REFERENCE(50)`, with per-op override via `SGLANG_OOT_OP_PREFER="OpName:vendor:chip"`.                                                                                    
                                                                                 
  ### `python/sglang/srt/utils/oot_device.py` *(new file)*                                                                                                                                                                
                                                                                 
  `OOTDeviceConfig` registry for plugin-registered device configuration:                                                                                                                                                  
  - `device_type` (e.g. `"npu"`, `"mlu"`)                                        
  - `dist_backend` (e.g. `"hccl"`, `"flagcx"`)                                                                                                                                                                            
  - Optional `empty_cache_fn` / `device_count_fn`                                                                                                                                                                         
  - `register_oot_device()` / `get_oot_device_config()`                                                                                                                                                                   
                                                                                                                                                                                                                          
  ### `python/sglang/srt/distributed/parallel_state.py`                                                                                                                                                                   
                                                                                                                                                                                                                          
  - **`GroupCoordinator.register_oot_communicator(factory_fn)`**: plugins register a communicator factory; called first in `all_reduce` / `reduce_scatter_tensor` / `all_gather_into_tensor`                              
  - **`GroupCoordinator.__init__`**: use `OOTDeviceConfig.get_device()` when an OOT device is registered, falling back to existing CUDA/HPU/etc. logic
  - **`get_default_distributed_backend()`**: check `OOTDeviceConfig.dist_backend` first, fall back to existing `_DEVICE_TO_DISTRIBUTED_BACKEND` dict                                                                      
                                                                                                                                                                                                                          
  ## Design Principles                                                                                                                                                                                                    
                                                                                                                                                                                                                          
  - **Zero impact when unused**: all OOT hooks are guarded by `None` checks; when no plugin is loaded, behavior is identical to before                                                                                    
  - **Environment-variable driven**: no code changes needed to switch backends
  - **Vendor auto-discovery**: plugins can scan their own `ops/vendor/` directories and auto-register via `is_available()` hardware detection                                                                             
                                                                                                                                                                                                                          
  ## Usage Example                                                                                                                                                                                                        
                                                                                                                                                                                                                          
  ```bash                                                                                                                                                                                                                 
  # Install plugin (no SGLang source modification needed)                        
  pip install sglang-plugin-example
                                                                                                                                                                                                                          
  # Launch with plugin
  SGLANG_OOT_PLUGINS=sglang_plugin_example \                                                                                                                                                                              
      python -m sglang.launch_server --model-path Qwen/Qwen2.5-7B-Instruct --port 30000
                                                                                                                                                                                                                          
  # Select specific backend globally                                                                                                                                                                                      
  SGLANG_OOT_PREFER=vendor SGLANG_OOT_PLUGINS=sglang_plugin_example python -m sglang.launch_server ...                                                                                                                    
                                                                                                                                                                                                                          
  # Per-op override                                                                                                                                                                                                       
  SGLANG_OOT_OP_PREFER="SiluAndMul:vendor:ascend,RMSNorm:flagos" \
  SGLANG_OOT_PLUGINS=sglang_plugin_example python -m sglang.launch_server ...                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                          
  Validated scenarios:                                                                                                                                                                                                    
  - flagos backend: dispatch log confirms SiluAndMul → flagos(flagos)            
  - vendor backend (mock NPU): dispatch log + runtime log confirm vendor code path executed during inference                                                                                                              
  - Fallback when vendor unavailable: correctly falls back to flagos
  - Multi-vendor coexistence: CUDA vendor and mock NPU coexist, priority rules apply correctly