### PR TITLE
[DeepSeek V4] Fix BF16 checkpoint downcasting error by dropping backup FP8 quantiza…

### DIFF
--- a/python/sglang/srt/utils/hf_transformers_utils.py
+++ b/python/sglang/srt/utils/hf_transformers_utils.py
@@ -224,6 +224,24 @@ def _load_deepseek_temp_model(
     config_json["architectures"] = [architecture]
     config_json["model_type"] = "deepseek_v3"
 
+    # The packaged backup config is built for FP8 and always carries a
+    # quantization_config. When the real checkpoint is BF16, drop it so the loader
+    # doesn't try to dequantize BF16 weights as FP8.
+    if backup_mode != "none" and "quantization_config" in config_json:
+        original_config_path = os.path.join(local_path, "config.json")
+        checkpoint_has_quant_config = False
+        if os.path.exists(original_config_path):
+            with open(original_config_path, "r") as f:
+                checkpoint_has_quant_config = "quantization_config" in json.load(f)
+        else:
+            logger.warning(
+                f"Checkpoint config.json not found at {original_config_path}; "
+                f"dropping quantization_config from backup config."
+            )
+            
+        if not checkpoint_has_quant_config:
+            del config_json["quantization_config"]
+
     tmp_path = os.path.join(tempfile.gettempdir(), "_tmp_config_folder")
     os.makedirs(tmp_path, exist_ok=True)
 


### PR DESCRIPTION
## Motivation

When `SGLANG_APPLY_CONFIG_BACKUP` is enabled (`small` / `large` / `auto`),
the model config is loaded from a packaged backup
`config_backup_{small,large}.json` instead of the checkpoint's own
`config.json`. These backup configs are built for FP8 weights and always
carry a `quantization_config` field.

This breaks BF16 checkpoints of the same architecture: the loader sees the
FP8 `quantization_config` and tries to dequantize BF16 weights as FP8,
producing dtype mismatches at load time.

## Modifications

In `_load_deepseek_temp_model` (`python/sglang/srt/hf_transformers_utils.py`),
after merging the backup config into `config_json`, reconcile
`quantization_config` against the real checkpoint:

- If the real checkpoint's `config.json` does **not** contain
  `quantization_config` (i.e. BF16), drop `quantization_config` from
  `config_json` so the loader treats the weights as plain BF16.
- If the real checkpoint's `config.json` already contains
  `quantization_config` (i.e. FP8), keep it as-is.
- If the real `config.json` is missing, log a warning and drop
  `quantization_config` from the backup config (BF16 is the safer default
  on this code path).
- The reconciliation only runs when `backup_mode != "none"` **and** the
  backup config actually carries a `quantization_config`, so
  `backup_mode == "none"` is unaffected.

## Accuracy Tests

Verified that BF16 DeepSeek-V4 loads successfully under
`SGLANG_APPLY_CONFIG_BACKUP` (previously failed with FP8 dtype mismatch):

Server launch:

```bash
TVM_FFI_CUDA_ARCH_LIST=9.0 \
SGLANG_DSV4_FP4_EXPERTS=0 \
SGLANG_JIT_DEEPGEMM_PRECOMPILE=0 \
python -m sglang.launch_server \
    --trust-remote-code \
    --mem-fraction-static 0.8 \
    --model-path ./DeepSeek-V4-Flash-BF16-official \
    --tp-size 8 \
    --ep-size 8 \
    --host 0.0.0.0 \
    --port 30019
```

Client request:
```bash
curl -X POST http://127.0.0.1:30019/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{
        "model": "DeepSeek-V4-Flash-BF16",
        "messages": [
            {"role": "user", "content": "感冒了怎么办?"}
        ],
        "max_tokens": 4096,
        "top_k": 1
    }'
```
<img width="2972" height="540" alt="image" src="https://github.com/user-attachments/assets/c3f384b7-0a36-4006-9806-9b4ede73228d" />
