### PR TITLE
DSV4 Hopper: support load fp4 models

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -395,8 +395,7 @@ class ModelConfig:
         (mxfp4); only flip it automatically when we can positively identify the
         converted-FP8 layout. Explicit env settings always win.
         """
-        if envs.SGLANG_DSV4_FP4_EXPERTS.is_set():
-            return
+        explicitly_set = envs.SGLANG_DSV4_FP4_EXPERTS.is_set()
         if not is_deepseek_compressed(self.hf_config):
             return
         if envs.SGLANG_DSV4_MODE.get() != "2604":
@@ -416,8 +415,16 @@ class ModelConfig:
         # Packed mxfp4 expert weights are stored as int8/uint8 (or native F4);
         # the FP4-to-FP8 conversion path writes F8_E4M3. Anything else is
         # unexpected for 2604 mode, so leave the env alone and log it.
+        is_fp4_experts = envs.SGLANG_DSV4_FP4_EXPERTS.get()
+        is_fp4_checkpoint = False
         if dtype in ("U8", "I8", "F4"):
-            is_fp4_experts = True
+            from sglang.srt.utils import is_blackwell_supported, is_sm90_supported
+
+            if is_sm90_supported() and not is_blackwell_supported():
+                is_fp4_experts = False
+                is_fp4_checkpoint = True
+            else:
+                is_fp4_experts = True
         elif dtype == "F8_E4M3":
             is_fp4_experts = False
         else:
@@ -427,12 +434,15 @@ class ModelConfig:
                 dtype,
             )
             return
-        envs.SGLANG_DSV4_FP4_EXPERTS.set(is_fp4_experts)
+        if not explicitly_set:
+            envs.SGLANG_DSV4_FP4_EXPERTS.set(is_fp4_experts)
+        envs.SGLANG_DSV4_FP4_CHECKPOINT.set(is_fp4_checkpoint)
         logger.info(
             "Auto-detected routed-expert safetensors dtype=%s; "
-            "SGLANG_DSV4_FP4_EXPERTS=%s",
+            "SGLANG_DSV4_FP4_EXPERTS=%s, SGLANG_DSV4_FP4_CHECKPOINT=%s",
             dtype,
-            is_fp4_experts,
+            envs.SGLANG_DSV4_FP4_EXPERTS.get(),
+            envs.SGLANG_DSV4_FP4_CHECKPOINT.get(),
         )
 
     def _derive_hybrid_model(self):

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -469,6 +469,7 @@ class Envs:
     SGLANG_DSV4_MODE = EnvStr("2604")
     SGLANG_DSV4_2604_SUBMODE = EnvStr("2604B")
     SGLANG_DSV4_FP4_EXPERTS = EnvBool(True)  # Set False when using FP4-to-FP8 converted checkpoint with 2604 config
+    SGLANG_DSV4_FP4_CHECKPOINT = EnvBool(False)  # True when checkpoint is FP4 but runtime converts to FP8 (Hopper)
     SGLANG_OPT_HISPARSE_C4_SHRINK = EnvInt(1)
     SGLANG_OPT_DEEPGEMM_HC_PRENORM = EnvBool(True)
     SGLANG_OPT_USE_TILELANG_MHC_PRE = EnvBool(True)

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -153,7 +153,7 @@ def convert_fp4_experts_to_fp8(
     s = s.float().view(E, bOut, fp8_blk_n, bIn, -1).transpose(2, 3).flatten(3)
 
     # Compute per-block scale and apply offset
-    scale_max = s.amax(dim=-1, keepdim=True) / (2**MAX_OFFSET_BITS)
+    scale_max = s.amax(dim=-1, keepdim=True).clamp(min=1e-12) / (2**MAX_OFFSET_BITS)
     offset = (
         (s / scale_max)
         .unflatten(-1, (fp8_blk_n, -1))

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -92,6 +92,80 @@ _is_fp8_fnuz = is_fp8_fnuz()
 _use_hip_int4 = get_bool_env_var("SGLANG_INT4_WEIGHT") and _is_hip
 _use_aiter = envs.SGLANG_USE_AITER.get() and _is_hip
 
+_FP4_TABLE = torch.tensor(
+    [
+        0.0,
+        0.5,
+        1.0,
+        1.5,
+        2.0,
+        3.0,
+        4.0,
+        6.0,
+        0.0,
+        -0.5,
+        -1.0,
+        -1.5,
+        -2.0,
+        -3.0,
+        -4.0,
+        -6.0,
+    ],
+    dtype=torch.float32,
+)
+
+
+def convert_fp4_experts_to_fp8(
+    weight_param: torch.nn.Parameter,
+    scale_param: torch.nn.Parameter,
+    weight_block_size: List[int],
+) -> None:
+    """Convert FP4 (E2M1) expert weights to FP8 (E4M3) in-place.
+
+    Called after EP/TP sharding so only local experts are converted.
+    Batched across all local experts with no Python loop.
+
+    Args:
+        weight_param: [E, out_dim, in_dim//2] int8 (two E2M1 nibbles per byte)
+        scale_param:  [E, out_dim, in_dim//fp4_block_size] float32 per-block scales
+        weight_block_size: [block_n, block_k] from quant_config
+    """
+    fp8_blk_n, fp8_blk_k = weight_block_size
+    MAX_OFFSET_BITS = 6
+
+    w = weight_param.data
+    s = scale_param.data
+    E, out_dim, half_in = w.shape
+    in_dim = half_in * 2
+    fp4_blk = in_dim // s.shape[-1]
+
+    # Unpack two FP4 nibbles per byte via lookup table
+    w = w.view(torch.uint8)
+    table = _FP4_TABLE.to(w.device)
+    w = torch.stack([table[(w & 0x0F).long()], table[(w >> 4).long()]], dim=-1).flatten(
+        3
+    )
+
+    # Reshape into (fp8_blk_n x fp8_blk_k) blocks
+    bOut = out_dim // fp8_blk_n
+    bIn = in_dim // fp8_blk_k
+    w = w.view(E, bOut, fp8_blk_n, bIn, fp8_blk_k).transpose(2, 3)
+    s = s.float().view(E, bOut, fp8_blk_n, bIn, -1).transpose(2, 3).flatten(3)
+
+    # Compute per-block scale and apply offset
+    scale_max = s.amax(dim=-1, keepdim=True) / (2**MAX_OFFSET_BITS)
+    offset = (
+        (s / scale_max)
+        .unflatten(-1, (fp8_blk_n, -1))
+        .repeat_interleave(fp4_blk, dim=-1)
+    )
+    w = (w * offset).transpose(2, 3).reshape(E, out_dim, in_dim)
+
+    weight_param.data = w.to(torch.float8_e4m3fn)
+    scale_param.data = scale_max.squeeze(-1).to(torch.float32)
+    del w, s
+
+
 if _use_aiter or _use_hip_int4:
     from aiter import ActivationType, QuantType
     from aiter.fused_moe import fused_moe
@@ -618,6 +692,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         self.is_fp4_expert = (
             envs.SGLANG_DSV4_MODE.get() == "2604" and envs.SGLANG_DSV4_FP4_EXPERTS.get()
         )
+        self.convert_fp4_to_fp8 = envs.SGLANG_DSV4_FP4_CHECKPOINT.get()
         if get_moe_runner_backend().is_cutlass():
             assert (
                 cutlass_fp8_supported()
@@ -677,7 +752,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                     )
 
         # WEIGHTS
-        if self.is_fp4_expert:
+        if self.is_fp4_expert or self.convert_fp4_to_fp8:
             w13_weight = torch.nn.Parameter(
                 torch.empty(
                     num_experts,
@@ -743,8 +818,11 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         set_weight_attrs(w2_weight, extra_weight_attrs)
 
         # WEIGHT_SCALES
-        if self.is_fp4_expert:
-            if envs.SGLANG_DEBUG_SANITY_CHECK_CONFIG.get() and not is_large_dummy_model():
+        if self.is_fp4_expert or self.convert_fp4_to_fp8:
+            if (
+                envs.SGLANG_DEBUG_SANITY_CHECK_CONFIG.get()
+                and not is_large_dummy_model()
+            ):
                 assert hidden_size == 4096
                 assert intermediate_size_per_partition == 2048
             fp4_block_k = 32
@@ -927,6 +1005,20 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
             # Check if MoE will actually use DeepGEMM runner
             will_use_deepgemm = self.is_deepgemm_moe_runner_backend_enabled()
+
+            if self.convert_fp4_to_fp8:
+                weight_block_size = self.quant_config.weight_block_size
+                convert_fp4_experts_to_fp8(
+                    layer.w13_weight,
+                    layer.w13_weight_scale_inv,
+                    weight_block_size,
+                )
+                convert_fp4_experts_to_fp8(
+                    layer.w2_weight,
+                    layer.w2_weight_scale_inv,
+                    weight_block_size,
+                )
+                return
 
             if self.is_fp4_expert:
                 layer.w13_weight.data = layer.w13_weight.data.view(torch.int8)

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -1625,21 +1625,7 @@ class DeepseekV4ForCausalLM(nn.Module):
             envs.SGLANG_DSV4_MODE.get() == "2604"
             and not envs.SGLANG_OPT_FP8_WO_A_GEMM.get()
         ):
-            if envs.SGLANG_FIX_DSV4_BASE_MODEL_LOAD.get():
-                weights = list(weights)
-                exists_wo_a_scale = any(n.endswith(".wo_a.scale") for n, t in weights)
-                if exists_wo_a_scale:
-                    logger.info("Execute dequant fp8 wo_a")
-                    weights = _dequant_fp8_wo_a(weights)
-                else:
-                    logger.info("Skip dequant fp8 wo_a")
-            else:
-                # ----------------------------- legacy code ------------------------------
-                if envs.SGLANG_DSV4_FP4_EXPERTS.get():
-                    weights = _dequant_fp8_wo_a(weights)
-                else:
-                    weights = ((n, t) for n, t in weights if not n.endswith(".wo_a.scale"))
-                # ------------------------------------------------------------------------
+            weights = _dequant_fp8_wo_a(weights)
 
         stacked_params_mapping = [
             ("gate_up_proj", "gate_proj", 0),
@@ -2054,20 +2040,30 @@ def build_mega_moe_experts_weights(experts) -> None:
 def _dequant_fp8_wo_a(
     weights: Iterable[Tuple[str, torch.Tensor]],
 ) -> Iterable[Tuple[str, torch.Tensor]]:
-    weights_dict = dict(weights)
+    wo_a_weights: dict[str, torch.Tensor] = {}
+    wo_a_scales: dict[str, torch.Tensor] = {}
 
-    for name in list(weights_dict.keys()):
-        if name not in weights_dict:
+    for name, tensor in weights:
+        if (
+            name.endswith(".wo_a.weight")
+            and tensor.dtype.is_floating_point
+            and tensor.element_size() <= 1
+        ):
+            wo_a_weights[name] = tensor
             continue
-        if not name.endswith(".wo_a.weight"):
+        if name.endswith(".wo_a.scale"):
+            wo_a_scales[name] = tensor
             continue
+        yield name, tensor
+
+    for name, weight in wo_a_weights.items():
         scale_name = name.replace(".wo_a.weight", ".wo_a.scale")
-        assert scale_name in weights_dict
-        weight = weights_dict.pop(name)
-        scale = weights_dict.pop(scale_name)
+        if scale_name not in wo_a_scales:
+            raise ValueError(
+                f"Missing scale {scale_name} for non-bfloat16 weight {name}"
+            )
+        scale = wo_a_scales.pop(scale_name)
         yield name, _dequant_fp8(weight, scale)
-
-    yield from weights_dict.items()
 
 
 def _debug_assert_model_path_configs() -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

DeepSeek-V4-Flash ships with FP4 (E2M1) expert weights, natively supported on Blackwell (SM100) but not on Hopper (SM90, e.g. H20). Previously, loading FP4 checkpoints on Hopper would crash or produce incorrect results. This PR enables Hopper to load FP4 checkpoints by converting expert weights to FP8 at model loading time, with automatic platform-aware detection — **no manual env var overrides needed**.

## Modifications

### 1. Auto-detection with platform awareness (`model_config.py`)

When checkpoint expert dtype is `U8`/`I8`/`F4` (FP4 format):
- **Blackwell**: `FP4_EXPERTS=True, FP4_CHECKPOINT=False` — native FP4 execution
- **Hopper**: `FP4_EXPERTS=False, FP4_CHECKPOINT=True` — convert to FP8 at runtime

Both `SGLANG_DSV4_FP4_EXPERTS` and `SGLANG_DSV4_FP4_CHECKPOINT` are auto-detected and set — users **no longer need to manually set `SGLANG_DSV4_FP4_EXPERTS=0` on Hopper**.

### 2. New env var (`environ.py`)

`SGLANG_DSV4_FP4_CHECKPOINT = EnvBool(False)` — auto-set to `True` on Hopper when checkpoint expert dtype is FP4. Marks that the checkpoint is FP4 but will be converted to FP8 at runtime.

### 3. FP4→FP8 conversion (`fp8.py`)

`convert_fp4_experts_to_fp8()` — batched in-place conversion after EP/TP sharding:
- Unpack two FP4 nibbles per byte via 16-entry lookup table
- Reshape into FP8 block structure, compute per-block scale+offset
- Quantize to `float8_e4m3fn`

Weight loading: `is_fp4_expert or convert_fp4_to_fp8` shares FP4 loading logic (same on-disk format). In `process_weights_after_loading`, conversion runs on w13/w2 then returns early.

### 4. Simplified `_dequant_fp8_wo_a()` (`deepseek_v4.py`)

Removed `SGLANG_FIX_DSV4_BASE_MODEL_LOAD` and legacy code paths. Now always dequantizes FP8 `wo_a` weights with streaming yield. Added `ValueError` for missing scales.

## Accuracy Tests

**Environment**: 8× H20-3e (SM90), SGLang 0.5.10rc0, GSM8K 8-shot

### Startup Command

CP8 deepep:

```bash
export SGLANG_JIT_DEEPGEMM_PRECOMPILE=0

nohup python3 -m sglang.launch_server --model-path $model_path \
  --host 0.0.0.0 --port 8188 --trust-remote-code \
  --enable-cache-report --log-level info --max-running-requests 128 \
  --tp-size 8 --cuda-graph-max-bs 128 \
  --mem-fraction-static 0.80 \
  --enable-nsa-prefill-context-parallel --nsa-prefill-cp-mode round-robin-split \
  --tool-call-parser deepseekv4 \
  --reasoning-parser deepseek-v4 \
  --speculative-algo EAGLE \
  --speculative-num-steps 3 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4 \
  --moe-a2a-backend deepep \
  > /home/admin/logs/sglang.log 2>&1 &
```

Model paths: `/home/models/DeepSeek-V4-Flash` (FP4), `/home/models/DeepSeek-V4-Flash-FP8` (FP8).

### GSM8K Evaluation

```bash
python -m sglang.test.run_eval --eval-name gsm8k --host localhost --port 8188 --num-shots 8
```

### Auto-detection

| Model | Detected dtype | FP4_EXPERTS | FP4_CHECKPOINT |
|-------|---------------|-------------|----------------|
| Base | F8_E4M3 | False | False |
| FP4 | I8 | False | True |
| FP8 | F8_E4M3 | False | False |

### Results

| Model | SGLANG_DSV4_FP4_EXPERTS | GSM8K 8-shot |
|-------|------------------------|-------------|
| FP4 (auto-detect, no env var) | not set | **97.2%** |
| FP4 (with env var) | =0 | **96.9%** |
| FP8 | not set | **97.0%** |
| FP8 | =0 | **96.9%** |

FP4→FP8 conversion matches native FP8 accuracy (within noise). Auto-detection works correctly — no manual env var needed.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
