### PR TITLE
[Docs] add cookbook for MiMo-V2.5 family

### DIFF
--- a/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
+++ b/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
@@ -60,9 +60,9 @@ Refer to the [official SGLang installation guide](../../../docs/get-started/inst
 | --- | --- | --- |
 | MiMo-V2.5 (310B) | H100 / H200 / B200 / GB300 | `lmsysorg/sglang:latest` |
 | **MiMo-V2.5-Pro (1.02T)** | H100 / H200 (Hopper, CUDA 12.9) | `lmsysorg/sglang:dev-mimo-v2.5-pro` |
-| **MiMo-V2.5-Pro (1.02T)** | B200 / GB300 (Blackwell, CUDA 13.0) | `lmsysorg/sglang:dev-cu130-mimo-v2.5-pro` |
+| **MiMo-V2.5-Pro (1.02T)** | B200 / GB300 (Blackwell, CUDA 13.0) | `lmsysorg/sglang:dev-cu13-mimo-v2.5-pro` |
 
-> MiMo-V2.5-Pro currently requires custom dev images that bundle the patches needed to load the 1.02T checkpoint and to run the verified `fa4 + flashinfer_trtllm` Blackwell stack. They are built by the upstream [release-docker-dev workflow](https://github.com/sgl-project/sglang/actions/workflows/release-docker-dev.yml) (CUDA 12.9 → `dev-mimo-v2.5-pro`, CUDA 13.0 → `dev-cu130-mimo-v2.5-pro`). Pull whichever matches the GPU's CUDA driver. The standard `lmsysorg/sglang:latest` image is sufficient for MiMo-V2.5 (310B).
+> MiMo-V2.5-Pro currently requires custom dev images that bundle the patches needed to load the 1.02T checkpoint and to run the verified `fa4 + flashinfer_trtllm` Blackwell stack. They are built by the upstream [release-docker-dev workflow](https://github.com/sgl-project/sglang/actions/workflows/release-docker-dev.yml) (CUDA 12.9 → `dev-mimo-v2.5-pro`, CUDA 13.0 → `dev-cu13-mimo-v2.5-pro`). Pull whichever matches the GPU's CUDA driver. The standard `lmsysorg/sglang:latest` image is sufficient for MiMo-V2.5 (310B).
 
 ## 3. Model Deployment
 

--- a/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
+++ b/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
@@ -1,0 +1,642 @@
+---
+title: MiMo-V2.5
+metatags:
+    description: "Deploy XiaomiMiMo MiMo-V2.5-Pro (1.02T MoE, text) and MiMo-V2.5 (310B MoE, multimodal) with SGLang — EAGLE speculative decoding, hybrid attention, and 1M-token context."
+tag: NEW
+---
+
+## 1. Model Introduction
+
+[MiMo-V2.5-Pro](https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro) and [MiMo-V2.5](https://huggingface.co/XiaomiMiMo/MiMo-V2.5) are next-generation Mixture-of-Experts models from the XiaomiMiMo Team.
+
+<table style={{width: "100%", borderCollapse: "collapse", tableLayout: "fixed"}}>
+  <colgroup>
+    <col style={{width: "25%"}} />
+    <col style={{width: "15%"}} />
+    <col style={{width: "15%"}} />
+    <col style={{width: "45%"}} />
+  </colgroup>
+  <thead>
+    <tr style={{borderBottom: "2px solid #d55816"}}>
+      <th style={{textAlign: "left", padding: "10px 12px", fontWeight: 700, backgroundColor: "rgba(255,255,255,0.02)"}}>Variant</th>
+      <th style={{textAlign: "right", padding: "10px 12px", fontWeight: 700, backgroundColor: "rgba(255,255,255,0.05)"}}>Total params</th>
+      <th style={{textAlign: "right", padding: "10px 12px", fontWeight: 700, backgroundColor: "rgba(255,255,255,0.02)"}}>Active (MoE)</th>
+      <th style={{textAlign: "left", padding: "10px 12px", fontWeight: 700, backgroundColor: "rgba(255,255,255,0.05)"}}>Modalities</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><strong><a href="https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro">MiMo-V2.5-Pro</a></strong></td>
+      <td style={{padding: "9px 12px", textAlign: "right", backgroundColor: "rgba(255,255,255,0.05)"}}><strong>1.02T</strong></td>
+      <td style={{padding: "9px 12px", textAlign: "right", backgroundColor: "rgba(255,255,255,0.02)"}}>42B</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Text (multimodal planned)</td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><strong><a href="https://huggingface.co/XiaomiMiMo/MiMo-V2.5">MiMo-V2.5</a></strong></td>
+      <td style={{padding: "9px 12px", textAlign: "right", backgroundColor: "rgba(255,255,255,0.05)"}}><strong>310B</strong></td>
+      <td style={{padding: "9px 12px", textAlign: "right", backgroundColor: "rgba(255,255,255,0.02)"}}>15B</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Text, Image, Video, Audio</td>
+    </tr>
+  </tbody>
+</table>
+
+**Key Features:**
+
+- **Hybrid Attention Architecture**: Interleaves Sliding Window Attention (SWA) and Global Attention (GA) for reduced KV cache while preserving long-context capability.
+- **Multi-Token Prediction (MTP)**: 3-layer MTP module accelerates decoding (329M params on V2.5; V2.5-Pro supports EAGLE speculative decoding on top of MTP).
+- **1M-Token Context**: Both variants support up to 1 million token context windows.
+- **Agentic Capabilities**: Post-training with large-scale agentic RL achieves strong performance on coding, reasoning, and tool-use benchmarks.
+- **MiMo-V2.5 Multimodal** (V2.5 only): Native omnimodal architecture with a 729M-param ViT Vision Encoder (28 layers: 24 SWA + 4 Full) and a 261M-param Audio Transformer (24 layers: 12 SWA + 12 Full); supports image, video, and audio understanding via standard OpenAI-compatible multimodal API.
+
+**License:** Apache 2.0
+
+## 2. SGLang Installation
+
+Refer to the [official SGLang installation guide](../../../docs/get-started/install).
+
+**Docker Images by Hardware Platform:**
+
+| Hardware Platform | Docker Image |
+| --- | --- |
+| NVIDIA H100 / H200 / B200 / GB300 | `lmsysorg/sglang:latest` |
+
+## 3. Model Deployment
+
+### 3.1 Basic Configuration
+
+Use the selector below to generate the deployment command for your variant and hardware.
+
+import { MiMoV25Deployment } from '/src/snippets/autoregressive/mimo-v25-deployment.jsx'
+
+<MiMoV25Deployment />
+
+### 3.2 Configuration Tips
+
+**MiMo-V2.5-Pro (1.02T):**
+- **B200**: single node, TP=8 (verified). Uses `--attention-backend fa4` + `--moe-runner-backend flashinfer_trtllm` + `--mem-fraction-static 0.8`. Set `--swa-full-tokens-ratio 0.1` to keep KV-cache footprint within 192 GB HBM.
+- **GB300**: 2 nodes, TP=8 (verified). Same Blackwell stack as B200; multi-node interconnect requires `NCCL_MNNVL_ENABLE=1 NCCL_CUMEM_ENABLE=1`. Default SWA ratio is fine.
+- **H100/H200**: 2 nodes × 8 GPUs (TP=16, not yet verified). Uses the Hopper stack (`fa3` + DeepEP + EAGLE multi-layer); fits with `--mem-fraction-static 0.7` and `--swa-full-tokens-ratio 0.3`. DeepEP dispatch tuning: `SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256` avoids memory spikes during prefill.
+- EAGLE speculative decoding (3 steps, topk=1) typically yields a 2–3× decode speedup. Requires `SGLANG_ENABLE_SPEC_V2=1`; on Hopper also pass `--enable-multi-layer-eagle`.
+- **Reasoning Parser**: `--reasoning-parser mimo` separates thinking content into `message.reasoning_content`; final answer in `message.content`.
+- **Tool Call Parser**: `--tool-call-parser mimo` enables structured function calling.
+
+**MiMo-V2.5 (310B):**
+- Single-node deployment: H100/H200 8× GPUs (TP=8), B200 4× GPUs (TP=4), GB300 2× GPUs (TP=2). FP8 quantization.
+- `--deepep-mode auto` lets SGLang pick the optimal DeepEP dispatch mode per batch.
+- `--mm-enable-dp-encoder` and `--enable-dp-lm-head` are required when DP attention is enabled to keep encoder and LM head sharding consistent.
+- **Reasoning Parser**: `--reasoning-parser mimo` separates thinking content into `message.reasoning_content`; final answer in `message.content`.
+- **Multimodal**: Supports image, video, and audio understanding; see Section 4.3 for invocation examples.
+
+## 4. Model Invocation
+
+### 4.1 Basic Usage
+
+See [Basic API Usage](../../../docs/basic_usage/send_request).
+
+### 4.2 Reasoning Output
+
+Both variants support hybrid thinking mode. Thinking content is separated via the reasoning parser.
+
+**Thinking Mode (default):**
+
+```python Example
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:30000/v1",
+    api_key="EMPTY"
+)
+
+response = client.chat.completions.create(
+    model="XiaomiMiMo/MiMo-V2.5",
+    messages=[
+        {"role": "user", "content": "Which is larger, 9.11 or 9.9? Think carefully."}
+    ]
+)
+
+print("====== Reasoning ======")
+print(response.choices[0].message.reasoning_content)
+print("====== Answer ======")
+print(response.choices[0].message.content)
+```
+
+**Output Example (MiMo-V2.5):**
+
+```text
+====== Reasoning ======
+Comparing 9.11 and 9.9.
+
+The integer parts are both 9. Now compare the decimal parts: 0.11 vs 0.9.
+
+0.9 = 0.90, which is greater than 0.11.
+
+So 9.9 > 9.11.
+====== Answer ======
+**9.9 is larger than 9.11.**
+
+Here's the reasoning: When comparing decimals, line them up to the same number of decimal places:
+
+- 9.11
+- 9.90
+
+Both have a **9** in the ones place, but in the tenths place, **9 > 1**, so 9.90 > 0.11.
+
+**9.9 > 9.11**
+```
+
+**Thinking Off (instant mode):**
+
+```python Example
+response = client.chat.completions.create(
+    model="XiaomiMiMo/MiMo-V2.5",
+    messages=[
+        {"role": "user", "content": "Which is larger, 9.11 or 9.9? Think carefully."}
+    ],
+    extra_body={"chat_template_kwargs": {"thinking": False}}
+)
+
+print(response.choices[0].message.content)
+```
+
+**Output Example (MiMo-V2.5):**
+
+```text
+## Comparing 9.11 and 9.9
+
+**9.9 is larger.**
+
+The key is to compare them place by place. It helps to write them with the same number of decimal places:
+
+- **9.11** → 9.11
+- **9.9** → 9.90
+
+Both have **9** in the ones place, but in the tenths place: **9** (in 9.90) is greater than **1** (in 9.11).
+
+So **9.90 > 9.11**.
+```
+
+### 4.3 Multimodal Invocation (V2.5 only)
+
+**Image Understanding:**
+
+```python Example
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:30000/v1", api_key="EMPTY")
+
+response = client.chat.completions.create(
+    model="XiaomiMiMo/MiMo-V2.5",
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "image_url", "image_url": {"url": "https://raw.githubusercontent.com/sgl-project/sgl-test-files/refs/heads/main/images/man_ironing_on_back_of_suv.png"}},
+            {"type": "text", "text": "Describe this image in detail."}
+        ]
+    }]
+)
+
+print(response.choices[0].message.content)
+```
+
+**Output Example:**
+
+```text
+Based on the image provided, here is a detailed description:
+
+The image captures a whimsical or surreal scene set on a busy city street, likely in New York City given the iconic yellow cabs. In the center foreground, a man is sitting on a folding chair, casually crossing his legs. He is wearing a bright yellow hoodie with a graphic on the front and blue jeans. He is intently focused on ironing a white dress shirt that rests on an ironing board set up directly on the asphalt.
+
+Behind him, a yellow SUV taxi cab is stopped or moving slowly, angled slightly away from the camera. To his left, another yellow taxi sedan is captured in motion blur, indicating it is driving past him. The background features tall city buildings with glass windows and storefronts. There are banners hanging from streetlights, and some greenery is visible in the distance. The overall impression is one of incongruity—performing a domestic chore like ironing in the middle of a chaotic urban environment.
+```
+
+**Video Understanding:**
+
+```python Example
+response = client.chat.completions.create(
+    model="XiaomiMiMo/MiMo-V2.5",
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "video_url", "video_url": {"url": "https://videos.pexels.com/video-files/4114797/4114797-uhd_3840_2160_25fps.mp4"}},
+            {"type": "text", "text": "Summarize what happens in this video."}
+        ]
+    }]
+)
+
+print(response.choices[0].message.content)
+```
+
+**Output Example:**
+
+```text
+A person wearing blue protective gloves is shown operating a microscope in a close-up shot. The individual is adjusting a knob on the side of the microscope, which moves the stage holding a glass slide, likely focusing the lens on the specimen.
+```
+
+> Video decoding requires `decord` (`pip install decord`); SGLang's MiMo-V2.5 multimodal processor uses `decord.VideoReader` for frame extraction.
+
+**Audio Understanding:**
+
+```python Example
+response = client.chat.completions.create(
+    model="XiaomiMiMo/MiMo-V2.5",
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "audio_url", "audio_url": {"url": "https://raw.githubusercontent.com/sgl-project/sgl-test-files/refs/heads/main/audios/Trump_WEF_2018_10s.mp3"}},
+            {"type": "text", "text": "Transcribe and summarize this audio."}
+        ]
+    }]
+)
+
+print(response.choices[0].message.content)
+```
+
+**Output Example:**
+
+```text
+**Transcript:**
+"Thank you Klaus very much. It's a privilege to be here at this forum where leaders in business, science, art, diplomacy and world affairs have gathered for..."
+
+**Summary:**
+The speaker thanks Klaus for the introduction and expresses their honor at attending a forum. They highlight that the event has brought together high-level leaders from various sectors, including business, science, art, and diplomacy.
+```
+
+### 4.4 Tool Calling
+
+```python Example
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:30000/v1",
+    api_key="EMPTY"
+)
+
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the current weather for a location",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string", "description": "City name"},
+                    "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}
+                },
+                "required": ["location"]
+            }
+        }
+    }
+]
+
+response = client.chat.completions.create(
+    model="XiaomiMiMo/MiMo-V2.5",
+    messages=[{"role": "user", "content": "What's the weather in Beijing?"}],
+    tools=tools
+)
+
+msg = response.choices[0].message
+if msg.reasoning_content:
+    print("=== Reasoning ===")
+    print(msg.reasoning_content)
+if msg.tool_calls:
+    print("=== Tool Calls ===")
+    for tc in msg.tool_calls:
+        print(f"  Function: {tc.function.name}")
+        print(f"  Arguments: {tc.function.arguments}")
+```
+
+**Output Example (MiMo-V2.5):**
+
+```text
+=== Reasoning ===
+The user wants to know the weather in Beijing. I have a function available called "get_weather" that can retrieve current weather for a location. Let me call that function with Beijing as the location.
+=== Tool Calls ===
+  Function: get_weather
+  Arguments: {"location": "Beijing"}
+```
+
+## 5. Benchmark
+
+Accuracy numbers come from `sglang.test.run_eval` (GSM8K standard 5-shot, MMMU validation split). Speed numbers come from `sglang.bench_serving` against the [ShareGPT_Vicuna_unfiltered](https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered) dataset; each request is configured with 1024 input tokens and 1024 output tokens to represent a typical medium-length conversation.
+
+### 5.1 Accuracy Benchmark
+
+#### 5.1.1 GSM8K
+
+Standard 5-shot, `temperature=0`, `max_tokens=4096`, model defaults to thinking-on (responses contain `<think>...</think>` and the eval extracts the trailing number via regex).
+
+**Server Launch (accuracy-tuned, no speculative decoding):**
+
+```shell Command
+python3 -m sglang.launch_server \
+  --model-path XiaomiMiMo/MiMo-V2.5 \
+  --trust-remote-code \
+  --tp 8 \
+  --ep-size 8 \
+  --attention-backend fa3 \
+  --max-running-requests 8 \
+  --context-length 8192 \
+  --max-total-tokens 32768 \
+  --mem-fraction-static 0.92 \
+  --disable-cuda-graph \
+  --port 30000
+```
+
+> For MiMo-V2.5-Pro, swap the model path to `XiaomiMiMo/MiMo-V2.5-Pro` (and add multi-node flags as in [Section 3](#3-model-deployment)). Otherwise the eval-tuned launch flags are identical for both variants.
+
+**Benchmark Command:**
+
+```shell Command
+python3 -m sglang.test.run_eval \
+  --base-url http://127.0.0.1:30000 \
+  --model XiaomiMiMo/MiMo-V2.5 \
+  --eval-name gsm8k \
+  --num-examples 200 \
+  --num-threads 8 \
+  --max-tokens 4096 \
+  --temperature 0.0
+```
+
+> `run_eval.py` automatically appends `/v1` to `--base-url`; pass the bare `host:port` URL (without trailing `/v1`), otherwise requests resolve to `/v1/v1/chat/completions` and 404.
+
+- **Test Results:**
+  - MiMo-V2.5-Pro (FP8)
+    ```
+    Pending update
+    ```
+  - MiMo-V2.5 (FP8)
+    ```
+    Pending update — re-running under the eval-tuned launch above.
+    ```
+
+#### 5.1.2 MMMU (V2.5 only)
+
+`MMMU/MMMU` validation split (multi-discipline multimodal), `concurrency=16`, default sampling.
+
+- **Benchmark Command:**
+
+```shell Command
+python3 benchmark/mmmu/bench_sglang.py \
+  --port 30000 \
+  --model XiaomiMiMo/MiMo-V2.5 \
+  --concurrency 16
+```
+
+- **Test Results:**
+  - MiMo-V2.5 (FP8, 8× H200)
+    ```
+    Overall                                 : 59.3% (534/900)
+    Overall-Art and Design                  : 65.8%
+    Overall-Business                        : 61.3%
+    Overall-Health and Medicine             : 64.0%
+    Overall-Humanities and Social Science   : 74.2%
+    Overall-Science                         : 51.3%
+    Overall-Tech and Engineering            : 48.1%
+    ```
+
+### 5.2 Speed Benchmark — MiMo-V2.5-Pro
+
+**Test Environment:**
+
+- Hardware: NVIDIA B200 GPU (8×)
+- Model: `XiaomiMiMo/MiMo-V2.5-Pro` (FP8)
+- Tensor Parallelism: 8
+- Recipe: Balanced (DP-attn + DeepEP + EAGLE MTP)
+- sglang version: Pending update
+
+#### 5.2.1 Latency-Sensitive Benchmark
+
+- **Model Deployment Command:** see the [command panel above](#3-model-deployment).
+- Benchmark Command:
+
+```shell Command
+python3 -m sglang.bench_serving \
+  --backend sglang \
+  --host 127.0.0.1 \
+  --port 30000 \
+  --model XiaomiMiMo/MiMo-V2.5-Pro \
+  --random-input-len 1024 \
+  --random-output-len 1024 \
+  --num-prompts 10 \
+  --max-concurrency 1
+```
+
+- **Test Results:**
+
+```text Output
+Pending update — replace with real bench_serving output after the latency run.
+```
+
+#### 5.2.2 Throughput-Sensitive Benchmark
+
+- **Model Deployment Command:** see the [command panel above](#3-model-deployment).
+- Benchmark Command:
+
+```shell Command
+python3 -m sglang.bench_serving \
+  --backend sglang \
+  --host 127.0.0.1 \
+  --port 30000 \
+  --model XiaomiMiMo/MiMo-V2.5-Pro \
+  --random-input-len 1024 \
+  --random-output-len 1024 \
+  --num-prompts 1000 \
+  --max-concurrency 100
+```
+
+- **Test Results:**
+
+```text Output
+Pending update — replace with real bench_serving output after the throughput run.
+```
+
+### 5.3 Speed Benchmark — MiMo-V2.5
+
+**Test Environment:**
+
+- Hardware: NVIDIA H200 GPU (8×)
+- Model: `XiaomiMiMo/MiMo-V2.5` (FP8)
+- Tensor Parallelism: 8 (DP-attention with `--dp-size 2`)
+- Recipe: Balanced (DP-attn)
+- sglang version: 1.1.2.dev9066
+
+#### 5.3.1 Latency-Sensitive Benchmark
+
+- **Model Deployment Command:** see the [command panel above](#3-model-deployment).
+- Benchmark Command:
+
+```shell Command
+python3 -m sglang.bench_serving \
+  --backend sglang \
+  --host 127.0.0.1 \
+  --port 30000 \
+  --model XiaomiMiMo/MiMo-V2.5 \
+  --random-input-len 1024 \
+  --random-output-len 1024 \
+  --num-prompts 10 \
+  --max-concurrency 1
+```
+
+- **Test Results:**
+
+```text Output
+============ Serving Benchmark Result ============
+Backend:                                 sglang
+Traffic request rate:                    inf
+Max request concurrency:                 1
+Successful requests:                     10
+Benchmark duration (s):                  26.41
+Total input tokens:                      1997
+Total input text tokens:                 1997
+Total generated tokens:                  2798
+Total generated tokens (retokenized):    2669
+Request throughput (req/s):              0.38
+Input token throughput (tok/s):          75.60
+Output token throughput (tok/s):         105.93
+Peak output token throughput (tok/s):    110.00
+Peak concurrent requests:                3
+Total token throughput (tok/s):          181.53
+Concurrency:                             1.00
+----------------End-to-End Latency----------------
+Mean E2E Latency (ms):                   2639.75
+Median E2E Latency (ms):                 2928.14
+P90 E2E Latency (ms):                    4107.62
+P99 E2E Latency (ms):                    4830.83
+---------------Time to First Token----------------
+Mean TTFT (ms):                          73.94
+Median TTFT (ms):                        74.09
+P99 TTFT (ms):                           79.90
+-----Time per Output Token (excl. 1st token)------
+Mean TPOT (ms):                          9.19
+Median TPOT (ms):                        9.21
+P99 TPOT (ms):                           9.24
+---------------Inter-Token Latency----------------
+Mean ITL (ms):                           9.20
+Median ITL (ms):                         9.21
+P95 ITL (ms):                            9.31
+P99 ITL (ms):                            9.43
+Max ITL (ms):                            16.43
+==================================================
+```
+
+#### 5.3.2 Throughput-Sensitive Benchmark
+
+- **Model Deployment Command:** see the [command panel above](#3-model-deployment).
+- Benchmark Command:
+
+```shell Command
+python3 -m sglang.bench_serving \
+  --backend sglang \
+  --host 127.0.0.1 \
+  --port 30000 \
+  --model XiaomiMiMo/MiMo-V2.5 \
+  --random-input-len 1024 \
+  --random-output-len 1024 \
+  --num-prompts 1000 \
+  --max-concurrency 100
+```
+
+- **Test Results:**
+
+```text Output
+============ Serving Benchmark Result ============
+Backend:                                 sglang
+Traffic request rate:                    inf
+Max request concurrency:                 100
+Successful requests:                     1000
+Benchmark duration (s):                  87.23
+Total input tokens:                      302118
+Total input text tokens:                 302118
+Total generated tokens:                  195775
+Total generated tokens (retokenized):    190470
+Request throughput (req/s):              11.46
+Input token throughput (tok/s):          3463.61
+Output token throughput (tok/s):         2244.45
+Peak output token throughput (tok/s):    4274.00
+Peak concurrent requests:                122
+Total token throughput (tok/s):          5708.05
+Concurrency:                             87.80
+----------------End-to-End Latency----------------
+Mean E2E Latency (ms):                   7658.29
+Median E2E Latency (ms):                 5195.82
+P90 E2E Latency (ms):                    18382.07
+P99 E2E Latency (ms):                    32849.04
+---------------Time to First Token----------------
+Mean TTFT (ms):                          188.32
+Median TTFT (ms):                        138.69
+P99 TTFT (ms):                           746.89
+-----Time per Output Token (excl. 1st token)------
+Mean TPOT (ms):                          40.13
+Median TPOT (ms):                        40.68
+P99 TPOT (ms):                           80.38
+---------------Inter-Token Latency----------------
+Mean ITL (ms):                           38.42
+Median ITL (ms):                         21.63
+P95 ITL (ms):                            82.64
+P99 ITL (ms):                            119.66
+Max ITL (ms):                            726.36
+==================================================
+```
+
+#### 5.3.3 Multimodal (Image) Benchmark
+
+- **Model Deployment Command:** see the [command panel above](#3-model-deployment).
+- Benchmark Command:
+
+```shell Command
+python3 -m sglang.bench_serving \
+  --backend sglang-oai-chat \
+  --host 127.0.0.1 \
+  --port 30000 \
+  --model XiaomiMiMo/MiMo-V2.5 \
+  --dataset-name image \
+  --image-count 2 \
+  --image-resolution 720p \
+  --random-input-len 128 \
+  --random-output-len 1024 \
+  --num-prompts 10 \
+  --max-concurrency 1
+```
+
+- **Test Results:**
+
+```text Output
+============ Serving Benchmark Result ============
+Backend:                                 sglang-oai-chat
+Traffic request rate:                    inf
+Max request concurrency:                 1
+Successful requests:                     10
+Benchmark duration (s):                  41.89
+Total input tokens:                      18514
+Total input text tokens:                 874
+Total input vision tokens:               17640
+Total generated tokens:                  4220
+Total generated tokens (retokenized):    1478
+Request throughput (req/s):              0.24
+Input token throughput (tok/s):          442.01
+Output token throughput (tok/s):         100.75
+Peak output token throughput (tok/s):    107.00
+Peak concurrent requests:                2
+Total token throughput (tok/s):          542.76
+Concurrency:                             1.00
+----------------End-to-End Latency----------------
+Mean E2E Latency (ms):                   4186.79
+Median E2E Latency (ms):                 3366.20
+P90 E2E Latency (ms):                    7545.54
+P99 E2E Latency (ms):                    9180.85
+---------------Time to First Token----------------
+Mean TTFT (ms):                          1284.90
+Median TTFT (ms):                        622.81
+P99 TTFT (ms):                           5030.79
+-----Time per Output Token (excl. 1st token)------
+Mean TPOT (ms):                          7.36
+Median TPOT (ms):                        8.45
+P99 TPOT (ms):                           10.94
+---------------Inter-Token Latency----------------
+Mean ITL (ms):                           9.54
+Median ITL (ms):                         9.45
+P95 ITL (ms):                            9.58
+P99 ITL (ms):                            11.12
+Max ITL (ms):                            37.67
+==================================================
+```

--- a/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
+++ b/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
@@ -81,9 +81,9 @@ import { MiMoV25Deployment } from '/src/snippets/autoregressive/mimo-v25-deploym
 - **Tool Call Parser**: `--tool-call-parser mimo` enables structured function calling.
 
 **MiMo-V2.5 (310B):**
-- Single-node deployment: H100/H200 8× GPUs (TP=8), B200 4× GPUs (TP=4), GB300 2× GPUs (TP=2). FP8 quantization.
-- `--deepep-mode auto` lets SGLang pick the optimal DeepEP dispatch mode per batch.
-- `--mm-enable-dp-encoder` and `--enable-dp-lm-head` are required when DP attention is enabled to keep encoder and LM head sharding consistent.
+- The checkpoint has a TP=4-interleaved fused `qkv_proj`; attention-TP per DP group **must** be 4. So DP-attention is always required (`--dp = TP / 4`), and total GPUs must be a multiple of 4. A bare `--tp 8` without `--dp 2` will fail to load with `MiMoV2Omni fused qkv_proj checkpoint is TP=4-interleaved; got tp_size=8`.
+- Single-node deployments: H100/H200 8× GPUs (`--tp 8 --dp 2`), B200 4× GPUs (`--tp 4`, dp=1, no DP-attn flag needed), GB300 4× GPUs (`--tp 4`, single NVL4 node). FP8 quantization.
+- `--enable-dp-lm-head` and `--mm-enable-dp-encoder` are required whenever `--enable-dp-attention` is on, to keep LM head and encoder sharding consistent.
 - **Reasoning Parser**: `--reasoning-parser mimo` separates thinking content into `message.reasoning_content`; final answer in `message.content`.
 - **Multimodal**: Supports image, video, and audio understanding; see Section 4.3 for invocation examples.
 
@@ -366,9 +366,9 @@ python3 -m sglang.test.run_eval \
     ```
   - MiMo-V2.5 (FP8, 8× H200)
     ```
-    Score:           98.0% (196/200)
-    Total latency:   464.7 s
-    Output tput:     92.4 tok/s
+    Score:             0.980  (196 / 200)
+    Latency:           477.52 s
+    Output throughput: 88.9 tok/s
     ```
 
 #### 5.1.2 MMMU (V2.5 only)

--- a/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
+++ b/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
@@ -54,11 +54,15 @@ tag: NEW
 
 Refer to the [official SGLang installation guide](../../../docs/get-started/install).
 
-**Docker Images by Hardware Platform:**
+**Docker Images by Variant × Hardware:**
 
-| Hardware Platform | Docker Image |
-| --- | --- |
-| NVIDIA H100 / H200 / B200 / GB300 | `lmsysorg/sglang:latest` |
+| Variant | Hardware | Docker Image |
+| --- | --- | --- |
+| MiMo-V2.5 (310B) | H100 / H200 / B200 / GB300 | `lmsysorg/sglang:latest` |
+| **MiMo-V2.5-Pro (1.02T)** | H100 / H200 (Hopper, CUDA 12.9) | `lmsysorg/sglang:dev-mimo-v2.5-pro` |
+| **MiMo-V2.5-Pro (1.02T)** | B200 / GB300 (Blackwell, CUDA 13.0) | `lmsysorg/sglang:dev-cu130-mimo-v2.5-pro` |
+
+> MiMo-V2.5-Pro currently requires custom dev images that bundle the patches needed to load the 1.02T checkpoint and to run the verified `fa4 + flashinfer_trtllm` Blackwell stack. They are built by the upstream [release-docker-dev workflow](https://github.com/sgl-project/sglang/actions/workflows/release-docker-dev.yml) (CUDA 12.9 → `dev-mimo-v2.5-pro`, CUDA 13.0 → `dev-cu130-mimo-v2.5-pro`). Pull whichever matches the GPU's CUDA driver. The standard `lmsysorg/sglang:latest` image is sufficient for MiMo-V2.5 (310B).
 
 ## 3. Model Deployment
 

--- a/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
+++ b/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
@@ -58,11 +58,12 @@ Refer to the [official SGLang installation guide](../../../docs/get-started/inst
 
 | Variant | Hardware | Docker Image |
 | --- | --- | --- |
-| MiMo-V2.5 (310B) | H100 / H200 / B200 / GB300 | `lmsysorg/sglang:latest` |
+| **MiMo-V2.5 (310B)** | H100 / H200 (Hopper, CUDA 12.9) | `lmsysorg/sglang:dev-mimo-v2.5` |
+| **MiMo-V2.5 (310B)** | B200 / GB300 (Blackwell, CUDA 13.0) | `lmsysorg/sglang:dev-cu13-mimo-v2.5` |
 | **MiMo-V2.5-Pro (1.02T)** | H100 / H200 (Hopper, CUDA 12.9) | `lmsysorg/sglang:dev-mimo-v2.5-pro` |
 | **MiMo-V2.5-Pro (1.02T)** | B200 / GB300 (Blackwell, CUDA 13.0) | `lmsysorg/sglang:dev-cu13-mimo-v2.5-pro` |
 
-> MiMo-V2.5-Pro currently requires custom dev images that bundle the patches needed to load the 1.02T checkpoint and to run the verified `fa4 + flashinfer_trtllm` Blackwell stack. They are built by the upstream [release-docker-dev workflow](https://github.com/sgl-project/sglang/actions/workflows/release-docker-dev.yml) (CUDA 12.9 → `dev-mimo-v2.5-pro`, CUDA 13.0 → `dev-cu13-mimo-v2.5-pro`). Pull whichever matches the GPU's CUDA driver. The standard `lmsysorg/sglang:latest` image is sufficient for MiMo-V2.5 (310B).
+> Both variants currently require custom dev images that bundle the patches needed to load the MiMo-V2 checkpoints (TP=4-interleaved fused qkv for V2.5, 1.02T sharding for V2.5-Pro) and to run the verified `fa4 + flashinfer_trtllm` Blackwell stack. The images are built by the upstream [release-docker-dev workflow](https://github.com/sgl-project/sglang/actions/workflows/release-docker-dev.yml): CUDA 12.9 → `dev-mimo-v2.5{,-pro}`, CUDA 13.0 → `dev-cu13-mimo-v2.5{,-pro}`. Pull whichever matches the GPU's CUDA driver. The stock `lmsysorg/sglang:latest` image does **not** carry these patches and will fail to load either checkpoint.
 
 ## 3. Model Deployment
 

--- a/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
+++ b/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
@@ -392,15 +392,9 @@ python3 benchmark/mmmu/bench_sglang.py \
 ```
 
 - **Test Results:**
-  - MiMo-V2.5 (FP8, 8× H200)
+  - MiMo-V2.5 (FP8)
     ```
-    Overall                                 : 59.3% (534/900)
-    Overall-Art and Design                  : 65.8%
-    Overall-Business                        : 61.3%
-    Overall-Health and Medicine             : 64.0%
-    Overall-Humanities and Social Science   : 74.2%
-    Overall-Science                         : 51.3%
-    Overall-Tech and Engineering            : 48.1%
+    Pending update
     ```
 
 ### 5.2 Speed Benchmark — MiMo-V2.5-Pro

--- a/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
+++ b/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
@@ -77,14 +77,11 @@ import { MiMoV25Deployment } from '/src/snippets/autoregressive/mimo-v25-deploym
 - **GB300**: 2 nodes, TP=8 (verified). Same Blackwell stack as B200; multi-node interconnect requires `NCCL_MNNVL_ENABLE=1 NCCL_CUMEM_ENABLE=1`. Default SWA ratio is fine.
 - **H100/H200**: 2 nodes × 8 GPUs (TP=16, not yet verified). Uses the Hopper stack (`fa3` + DeepEP + EAGLE multi-layer); fits with `--mem-fraction-static 0.7` and `--swa-full-tokens-ratio 0.3`. DeepEP dispatch tuning: `SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256` avoids memory spikes during prefill.
 - EAGLE speculative decoding (3 steps, topk=1) typically yields a 2–3× decode speedup. Requires `SGLANG_ENABLE_SPEC_V2=1`; on Hopper also pass `--enable-multi-layer-eagle`.
-- **Reasoning Parser**: `--reasoning-parser mimo` separates thinking content into `message.reasoning_content`; final answer in `message.content`.
-- **Tool Call Parser**: `--tool-call-parser mimo` enables structured function calling.
 
 **MiMo-V2.5 (310B):**
 - The checkpoint has a TP=4-interleaved fused `qkv_proj`; attention-TP per DP group **must** be 4. So DP-attention is always required (`--dp = TP / 4`), and total GPUs must be a multiple of 4. A bare `--tp 8` without `--dp 2` will fail to load with `MiMoV2Omni fused qkv_proj checkpoint is TP=4-interleaved; got tp_size=8`.
 - Single-node deployments: H100/H200 8× GPUs (`--tp 8 --dp 2`), B200 4× GPUs (`--tp 4`, dp=1, no DP-attn flag needed), GB300 4× GPUs (`--tp 4`, single NVL4 node). FP8 quantization.
 - `--enable-dp-lm-head` and `--mm-enable-dp-encoder` are required whenever `--enable-dp-attention` is on, to keep LM head and encoder sharding consistent.
-- **Reasoning Parser**: `--reasoning-parser mimo` separates thinking content into `message.reasoning_content`; final answer in `message.content`.
 - **Multimodal**: Supports image, video, and audio understanding; see Section 4.3 for invocation examples.
 
 ## 4. Model Invocation

--- a/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
+++ b/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
@@ -364,9 +364,11 @@ python3 -m sglang.test.run_eval \
     ```
     Pending update
     ```
-  - MiMo-V2.5 (FP8)
+  - MiMo-V2.5 (FP8, 8× H200)
     ```
-    Pending update — re-running under the eval-tuned launch above.
+    Score:           98.0% (196/200)
+    Total latency:   464.7 s
+    Output tput:     92.4 tok/s
     ```
 
 #### 5.1.2 MMMU (V2.5 only)

--- a/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
+++ b/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
@@ -63,7 +63,7 @@ Refer to the [official SGLang installation guide](../../../docs/get-started/inst
 | **MiMo-V2.5-Pro (1.02T)** | H100 / H200 (Hopper, CUDA 12.9) | `lmsysorg/sglang:dev-mimo-v2.5-pro` |
 | **MiMo-V2.5-Pro (1.02T)** | B200 / GB300 (Blackwell, CUDA 13.0) | `lmsysorg/sglang:dev-cu13-mimo-v2.5-pro` |
 
-> Both variants currently require custom dev images that bundle the patches needed to load the MiMo-V2 checkpoints (TP=4-interleaved fused qkv for V2.5, 1.02T sharding for V2.5-Pro) and to run the verified `fa4 + flashinfer_trtllm` Blackwell stack. The images are built by the upstream [release-docker-dev workflow](https://github.com/sgl-project/sglang/actions/workflows/release-docker-dev.yml): CUDA 12.9 → `dev-mimo-v2.5{,-pro}`, CUDA 13.0 → `dev-cu13-mimo-v2.5{,-pro}`. Pull whichever matches the GPU's CUDA driver. The stock `lmsysorg/sglang:latest` image does **not** carry these patches and will fail to load either checkpoint.
+> Pull the image matching your GPU's CUDA driver. `lmsysorg/sglang:latest` will not load either checkpoint.
 
 ## 3. Model Deployment
 

--- a/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
+++ b/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
@@ -330,26 +330,7 @@ Accuracy numbers come from `sglang.test.run_eval` (GSM8K standard 5-shot, MMMU v
 
 #### 5.1.1 GSM8K
 
-Standard 5-shot, `temperature=0`, `max_tokens=4096`, model defaults to thinking-on (responses contain `<think>...</think>` and the eval extracts the trailing number via regex).
-
-**Server Launch (accuracy-tuned, no speculative decoding):**
-
-```shell Command
-python3 -m sglang.launch_server \
-  --model-path XiaomiMiMo/MiMo-V2.5 \
-  --trust-remote-code \
-  --tp 8 \
-  --ep-size 8 \
-  --attention-backend fa3 \
-  --max-running-requests 8 \
-  --context-length 8192 \
-  --max-total-tokens 32768 \
-  --mem-fraction-static 0.92 \
-  --disable-cuda-graph \
-  --port 30000
-```
-
-> For MiMo-V2.5-Pro, swap the model path to `XiaomiMiMo/MiMo-V2.5-Pro` (and add multi-node flags as in [Section 3](#3-model-deployment)). Otherwise the eval-tuned launch flags are identical for both variants.
+Standard 5-shot, `temperature=0`, `max_tokens=4096`, model defaults to thinking-on (responses contain `<think>...</think>` and the eval extracts the trailing number via regex). Server launch: see [Section 3](#3-model-deployment).
 
 **Benchmark Command:**
 

--- a/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
+++ b/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
@@ -84,6 +84,11 @@ import { MiMoV25Deployment } from '/src/snippets/autoregressive/mimo-v25-deploym
 - `--enable-dp-lm-head` and `--mm-enable-dp-encoder` are required whenever `--enable-dp-attention` is on, to keep LM head and encoder sharding consistent.
 - **Multimodal**: Supports image, video, and audio understanding; see Section 4.3 for invocation examples.
 
+**DeepEP (optional toggle, Hopper-only):**
+- DeepEP replaces the default MoE all-to-all dispatch with a fused [DeepEP](https://github.com/deepseek-ai/DeepEP) backend; it lowers expert dispatch latency and memory traffic, so it pays off under **high concurrency / throughput-bound workloads** on H100/H200. Under concurrency=1 / latency-bound workloads the gain is negligible — leave it off.
+- Enabling adds `--moe-a2a-backend deepep` + `--moe-dense-tp-size 1` (and `--ep <tp>` for Pro) plus `SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256` env to cap the dispatch buffer. Requires `pip install deep_ep` (not part of the default sglang install).
+- On Blackwell (B200, GB300) the verified MoE backend is `flashinfer_trtllm`; the DeepEP toggle is a no-op there.
+
 ## 4. Model Invocation
 
 ### 4.1 Basic Usage

--- a/docs_new/cookbook/autoregressive/intro.mdx
+++ b/docs_new/cookbook/autoregressive/intro.mdx
@@ -106,7 +106,7 @@ metatags:
   <Card
     title="Xiaomi"
     mode="card"
-    href="/cookbook/autoregressive/Xiaomi/MiMo-V2-Flash"
+    href="/cookbook/autoregressive/Xiaomi/MiMo-V2.5"
     img="/cards/logos/xiaomi.png"
   />
   <Card

--- a/docs_new/docs.json
+++ b/docs_new/docs.json
@@ -1061,6 +1061,7 @@
                   {
                     "group": "Xiaomi",
                     "pages": [
+                      "cookbook/autoregressive/Xiaomi/MiMo-V2.5",
                       "cookbook/autoregressive/Xiaomi/MiMo-V2-Flash"
                     ]
                   },

--- a/docs_new/src/snippets/autoregressive/mimo-v25-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/mimo-v25-deployment.jsx
@@ -7,16 +7,17 @@ export const MiMoV25Deployment = () => {
   //     H100  → tp=16, 2 nodes,     FP8 (Hopper: fa3 + DeepEP)
   //     B200  → tp=8,  single-node, FP8 (Blackwell verified: fa4 + flashinfer_trtllm)
   //     GB300 → tp=8,  2 nodes,     FP8 (Blackwell verified: fa4 + flashinfer_trtllm + NCCL_MNNVL)
-  //   V2.5 (310B / 15B active) — multimodal:
-  //     H200  → tp=8, single-node, FP8
-  //     H100  → tp=8, single-node, FP8
-  //     B200  → tp=4, single-node, FP8
-  //     GB300 → tp=2, single-node, FP8
+  //   V2.5 (310B / 15B active) — multimodal. Checkpoint is TP=4 interleaved,
+  //   so attention-TP per DP group must be 4; effective parallelism = TP/DP = 4.
+  //     H200  → tp=8, dp=2, single-node, FP8 (verified)
+  //     H100  → tp=8, dp=2, single-node, FP8
+  //     B200  → tp=4, dp=1, single-node, FP8
+  //     GB300 → tp=4, dp=1, single-node, FP8
   //
   //   Recipes:
-  //     low-latency    → TP only (no DP), V2.5-Pro includes EAGLE MTP
-  //     balanced       → DP-attn + EAGLE (V2.5-Pro) / DP-attn (V2.5)
-  //     max-throughput → DP-attn, no MTP
+  //     low-latency    → V2.5-Pro: TP only (no DP). V2.5: DP-attn (always required).
+  //     balanced       → V2.5-Pro: DP-attn + EAGLE.
+  //     max-throughput → V2.5-Pro: DP-attn, no MTP.
 
   const options = {
     modelVariant: {
@@ -65,15 +66,17 @@ export const MiMoV25Deployment = () => {
   };
 
   // Per (variant, hardware): HF slug, tp, multinode info, Blackwell flag.
+  // V2.5 (base) checkpoint has TP=4-interleaved fused qkv_proj, so attention
+  // TP per DP group MUST be 4. Effective TP/DP = 4. With tp=8 → dp=2; tp=4 → dp=1.
   const HW_VARIANT_SPEC = {
     "pro|h200":   { slug: "XiaomiMiMo/MiMo-V2.5-Pro", tp: 16, multinode: true,  nnodes: 2, blackwell: false },
     "pro|h100":   { slug: "XiaomiMiMo/MiMo-V2.5-Pro", tp: 16, multinode: true,  nnodes: 2, blackwell: false },
     "pro|b200":   { slug: "XiaomiMiMo/MiMo-V2.5-Pro", tp: 8,  multinode: false,            blackwell: true  },
     "pro|gb300":  { slug: "XiaomiMiMo/MiMo-V2.5-Pro", tp: 8,  multinode: true,  nnodes: 2, blackwell: true  },
-    "base|h200":  { slug: "XiaomiMiMo/MiMo-V2.5",     tp: 8,  multinode: false,            blackwell: false },
-    "base|h100":  { slug: "XiaomiMiMo/MiMo-V2.5",     tp: 8,  multinode: false,            blackwell: false },
-    "base|b200":  { slug: "XiaomiMiMo/MiMo-V2.5",     tp: 4,  multinode: false,            blackwell: true  },
-    "base|gb300": { slug: "XiaomiMiMo/MiMo-V2.5",     tp: 2,  multinode: false,            blackwell: true  },
+    "base|h200":  { slug: "XiaomiMiMo/MiMo-V2.5",     tp: 8,  multinode: false,            blackwell: false, dp: 2 },
+    "base|h100":  { slug: "XiaomiMiMo/MiMo-V2.5",     tp: 8,  multinode: false,            blackwell: false, dp: 2 },
+    "base|b200":  { slug: "XiaomiMiMo/MiMo-V2.5",     tp: 4,  multinode: false,            blackwell: true,  dp: 1 },
+    "base|gb300": { slug: "XiaomiMiMo/MiMo-V2.5",     tp: 4,  multinode: false,            blackwell: true,  dp: 1 },
   };
 
   const multiNodeFlags = (nnodes) => [
@@ -128,9 +131,16 @@ export const MiMoV25Deployment = () => {
   const generateCommand = () => {
     const { modelVariant, hardware, recipe, reasoningParser, toolcall } = values;
     const specKey = `${modelVariant}|${hardware}`;
-    const { slug, tp, multinode, nnodes, blackwell } = HW_VARIANT_SPEC[specKey];
+    const spec = HW_VARIANT_SPEC[specKey];
+    const { slug, tp, multinode, nnodes, blackwell } = spec;
     const isPro = modelVariant === "pro";
     const useMtp = isPro && recipe !== "max-throughput";
+    // V2.5 (base) requires DP-attention with effective attention-TP = 4 per group;
+    // dp comes from the spec table. Pro uses optional DP-attn driven by recipe.
+    const baseDp = !isPro ? spec.dp : 0;
+    const proDp = isPro && recipe !== "low-latency" ? tp : 0;
+    const dp = isPro ? proDp : baseDp;
+    const useDpAttn = !isPro ? baseDp > 1 : proDp > 0;
 
     // ---- env (kept inline before `sglang serve`, matching the verified launch style) ----
     const envVars = [];
@@ -146,8 +156,8 @@ export const MiMoV25Deployment = () => {
     flags.push(`  --model-path ${slug}`);
     flags.push(`  --tp ${tp}`);
 
-    if (recipe !== "low-latency") {
-      flags.push(`  --dp ${tp}`);
+    if (useDpAttn) {
+      flags.push(`  --dp ${dp}`);
       flags.push("  --enable-dp-attention");
       if (!isPro) {
         flags.push("  --enable-dp-lm-head");

--- a/docs_new/src/snippets/autoregressive/mimo-v25-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/mimo-v25-deployment.jsx
@@ -126,9 +126,10 @@ export const MiMoV25Deployment = () => {
     const blackwell = spec ? spec.blackwell : false;
     const c = {};
     if (!isPro) {
+      // V2.5 has no MTP module, so EAGLE MTP is genuinely unavailable.
       c.eagleMtp = { force: "disabled", reason: "EAGLE MTP applies to V2.5-Pro only." };
-      c.expertParallelism = { force: "disabled", reason: "Expert parallelism not used for V2.5." };
-      // V2.5 checkpoint forces DP-attn when tp/dp split > 1, otherwise dp=1 single group.
+      // V2.5 checkpoint is TP=4-interleaved; tp/dp must equal 4. With dp>1 we
+      // must use DP-attention; with dp=1 it must be off (single attention group).
       if (spec && spec.dp > 1) {
         c.dpAttention = { force: "enabled", reason: "V2.5 checkpoint is TP=4-interleaved; DP-attention is required (--dp = tp/4)." };
       } else {
@@ -136,8 +137,9 @@ export const MiMoV25Deployment = () => {
       }
     }
     if (blackwell) {
+      // DeepEP upstream targets Ampere/Hopper PTX; only experimental paths exist
+      // for sm_100 in sglang and the verified Blackwell stack uses flashinfer_trtllm.
       c.deepep = { force: "disabled", reason: "Blackwell uses flashinfer_trtllm; DeepEP is Hopper / Ampere only." };
-      if (isPro) c.expertParallelism = { force: "disabled", reason: "Blackwell uses flashinfer_trtllm; --ep-size is not used." };
     }
     return c;
   };

--- a/docs_new/src/snippets/autoregressive/mimo-v25-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/mimo-v25-deployment.jsx
@@ -48,6 +48,22 @@ export const MiMoV25Deployment = () => {
         { id: "disabled", label: "Disabled", default: false },
       ],
     },
+    dpAttention: {
+      name: "dpAttention",
+      title: "DP Attention",
+      items: [
+        { id: "enabled",  label: "Enabled",  default: false, subtitle: "auto for V2.5" },
+        { id: "disabled", label: "Disabled", default: true },
+      ],
+    },
+    expertParallelism: {
+      name: "expertParallelism",
+      title: "Expert Parallelism",
+      items: [
+        { id: "enabled",  label: "Enabled",  default: false, subtitle: "Pro Hopper" },
+        { id: "disabled", label: "Disabled", default: true },
+      ],
+    },
     deepep: {
       name: "deepep",
       title: "DeepEP",
@@ -100,34 +116,46 @@ export const MiMoV25Deployment = () => {
     `#   <node0-ip>  = IP of the head node (reachable from all others)\n` +
     `${cmd}`;
 
-  // Toggles whose `enabled` choice is incompatible with the current variant +
-  // hardware are returned as a map { optionName -> reason }. The render layer
-  // grays out the matching radio item, and a useEffect snaps any disallowed
-  // value back to `disabled` so the visible UI never disagrees with the
-  // command we actually generate.
-  const computeForcedOff = (variant, hardware) => {
+  // Toggles whose value is forced by the current variant + hardware. Returns
+  // { optionName -> { force: "enabled" | "disabled", reason } }. The render
+  // layer grays out the OTHER radio, and a useEffect snaps the value to the
+  // forced choice so the UI never disagrees with the generated command.
+  const computeConstraints = (variant, hardware) => {
     const isPro = variant === "pro";
     const spec = HW_VARIANT_SPEC[`${variant}|${hardware}`];
     const blackwell = spec ? spec.blackwell : false;
-    const forced = {};
-    if (!isPro) forced.eagleMtp = "EAGLE MTP applies to V2.5-Pro only.";
-    if (blackwell) forced.deepep = "Blackwell uses flashinfer_trtllm; DeepEP is Hopper / Ampere only.";
-    return forced;
+    const c = {};
+    if (!isPro) {
+      c.eagleMtp = { force: "disabled", reason: "EAGLE MTP applies to V2.5-Pro only." };
+      c.expertParallelism = { force: "disabled", reason: "Expert parallelism not used for V2.5." };
+      // V2.5 checkpoint forces DP-attn when tp/dp split > 1, otherwise dp=1 single group.
+      if (spec && spec.dp > 1) {
+        c.dpAttention = { force: "enabled", reason: "V2.5 checkpoint is TP=4-interleaved; DP-attention is required (--dp = tp/4)." };
+      } else {
+        c.dpAttention = { force: "disabled", reason: "Single attention group on this hardware (tp=4, dp=1)." };
+      }
+    }
+    if (blackwell) {
+      c.deepep = { force: "disabled", reason: "Blackwell uses flashinfer_trtllm; DeepEP is Hopper / Ampere only." };
+      if (isPro) c.expertParallelism = { force: "disabled", reason: "Blackwell uses flashinfer_trtllm; --ep-size is not used." };
+    }
+    return c;
   };
 
-  const resolveItems = (option, forced) => {
-    const reason = forced[option.name];
-    if (!reason) return option.items;
+  const resolveItems = (option, constraints) => {
+    const c = constraints[option.name];
+    if (!c) return option.items;
+    const grayId = c.force === "enabled" ? "disabled" : "enabled";
     return option.items.map((item) =>
-      item.id === "enabled" ? { ...item, disabled: true, disabledReason: reason } : item,
+      item.id === grayId ? { ...item, disabled: true, disabledReason: c.reason } : item,
     );
   };
 
   const getInitialState = () => {
     const initialState = {};
-    const forced = computeForcedOff("pro", "h200");
+    const constraints = computeConstraints("pro", "h200");
     for (const [key, option] of Object.entries(options)) {
-      const items = resolveItems(option, forced);
+      const items = resolveItems(option, constraints);
       const def = items.find((i) => i.default && !i.disabled) || items.find((i) => !i.disabled) || items[0];
       initialState[key] = def.id;
     }
@@ -155,15 +183,15 @@ export const MiMoV25Deployment = () => {
     return () => observer.disconnect();
   }, []);
 
-  // Snap forced-off toggles back to "disabled" whenever variant/hardware
-  // changes — keeps the visible radio in sync with generated command.
+  // Snap forced toggles to their required value whenever variant/hardware
+  // changes — keeps the visible radio in sync with the generated command.
   useEffect(() => {
-    const forced = computeForcedOff(values.modelVariant, values.hardware);
+    const constraints = computeConstraints(values.modelVariant, values.hardware);
     let patch = null;
-    for (const key of Object.keys(forced)) {
-      if (values[key] === "enabled") {
+    for (const [key, c] of Object.entries(constraints)) {
+      if (values[key] !== c.force) {
         patch = patch || {};
-        patch[key] = "disabled";
+        patch[key] = c.force;
       }
     }
     if (patch) setValues((prev) => ({ ...prev, ...patch }));
@@ -174,19 +202,19 @@ export const MiMoV25Deployment = () => {
   };
 
   const generateCommand = () => {
-    const { modelVariant, hardware, eagleMtp, deepep, reasoningParser, toolcall } = values;
+    const { modelVariant, hardware, eagleMtp, dpAttention, expertParallelism, deepep, reasoningParser, toolcall } = values;
     const specKey = `${modelVariant}|${hardware}`;
     const spec = HW_VARIANT_SPEC[specKey];
     const { slug, tp, multinode, nnodes, blackwell } = spec;
     const isPro = modelVariant === "pro";
-    // EAGLE MTP only applies to Pro. DeepEP only applies to Hopper paths
-    // (Blackwell uses flashinfer_trtllm); on Blackwell Pro the DeepEP toggle is a no-op.
+    // Toggles. EAGLE MTP / EP / DeepEP / DP-attn are gated by hardware + variant
+    // through computeConstraints; here we just read the (already-snapped) value.
     const useMtp = isPro && eagleMtp === "enabled";
     const useDeepep = !blackwell && deepep === "enabled";
-    // V2.5 (base) requires DP-attention with effective attention-TP = 4 per group;
-    // dp comes from the spec table. dp=1 on B200/GB300 means single attention group.
-    const baseDp = !isPro ? spec.dp : 0;
-    const useDpAttn = !isPro && baseDp > 1;
+    const useEp = isPro && !blackwell && expertParallelism === "enabled";
+    const useDpAttn = dpAttention === "enabled";
+    // dp size: V2.5 picks tp/4 from spec; Pro picks tp.
+    const dpSize = !isPro ? spec.dp : tp;
 
     // ---- env (kept inline before `sglang serve`, matching the verified launch style) ----
     const envVars = [];
@@ -203,11 +231,15 @@ export const MiMoV25Deployment = () => {
     flags.push(`  --tp ${tp}`);
 
     if (useDpAttn) {
-      flags.push(`  --dp ${baseDp}`);
+      flags.push(`  --dp ${dpSize}`);
       flags.push("  --enable-dp-attention");
-      flags.push("  --enable-dp-lm-head");
-      flags.push("  --mm-enable-dp-encoder");
+      if (!isPro) {
+        flags.push("  --enable-dp-lm-head");
+        flags.push("  --mm-enable-dp-encoder");
+      }
     }
+
+    if (useEp) flags.push(`  --ep ${tp}`);
 
     if (multinode) flags.push(...multiNodeFlags(nnodes));
 
@@ -218,7 +250,6 @@ export const MiMoV25Deployment = () => {
     } else if (useDeepep) {
       flags.push("  --moe-a2a-backend deepep");
       if (!isPro) flags.push("  --deepep-mode auto");
-      if (isPro) flags.push(`  --ep ${tp}`);
       flags.push("  --moe-dense-tp-size 1");
     }
 
@@ -314,12 +345,12 @@ export const MiMoV25Deployment = () => {
     border: `1px solid ${isDark ? "#374151" : "#e5e7eb"}`,
   };
 
-  const forcedOff = computeForcedOff(values.modelVariant, values.hardware);
+  const constraints = computeConstraints(values.modelVariant, values.hardware);
 
   return (
     <div style={containerStyle} className="not-prose">
       {Object.entries(options).map(([key, option]) => {
-        const items = resolveItems(option, forcedOff);
+        const items = resolveItems(option, constraints);
         return (
           <div key={key} style={cardStyle}>
             <div style={titleStyle}>{option.title}</div>

--- a/docs_new/src/snippets/autoregressive/mimo-v25-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/mimo-v25-deployment.jsx
@@ -14,10 +14,12 @@ export const MiMoV25Deployment = () => {
   //     B200  → tp=4, dp=1, single-node, FP8
   //     GB300 → tp=4, dp=1, single-node, FP8
   //
-  //   Recipes:
-  //     low-latency    → V2.5-Pro: TP only (no DP). V2.5: DP-attn (always required).
-  //     balanced       → V2.5-Pro: DP-attn + EAGLE.
-  //     max-throughput → V2.5-Pro: DP-attn, no MTP.
+  //   Optional toggles:
+  //     EAGLE MTP — Pro only. Adds --speculative-* flags + SGLANG_ENABLE_SPEC_V2=1.
+  //     DeepEP    — Hopper only (Blackwell uses flashinfer_trtllm). Adds
+  //                 --moe-a2a-backend deepep + --moe-dense-tp-size 1
+  //                 (and --ep on Pro) + SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256.
+  //                 Requires `pip install deep_ep`.
 
   const options = {
     modelVariant: {
@@ -38,13 +40,20 @@ export const MiMoV25Deployment = () => {
         { id: "gb300", label: "GB300", default: false },
       ],
     },
-    recipe: {
-      name: "recipe",
-      title: "Recipe",
+    eagleMtp: {
+      name: "eagleMtp",
+      title: "EAGLE MTP",
       items: [
-        { id: "low-latency",    label: "Low-Latency",    default: true  },
-        { id: "balanced",       label: "Balanced",       default: false },
-        { id: "max-throughput", label: "Max-Throughput", default: false },
+        { id: "enabled",  label: "Enabled",  default: true,  subtitle: "Pro only" },
+        { id: "disabled", label: "Disabled", default: false },
+      ],
+    },
+    deepep: {
+      name: "deepep",
+      title: "DeepEP",
+      items: [
+        { id: "disabled", label: "Disabled", default: true,  subtitle: "default" },
+        { id: "enabled",  label: "Enabled",  default: false, subtitle: "needs deep_ep" },
       ],
     },
     reasoningParser: {
@@ -129,18 +138,19 @@ export const MiMoV25Deployment = () => {
   };
 
   const generateCommand = () => {
-    const { modelVariant, hardware, recipe, reasoningParser, toolcall } = values;
+    const { modelVariant, hardware, eagleMtp, deepep, reasoningParser, toolcall } = values;
     const specKey = `${modelVariant}|${hardware}`;
     const spec = HW_VARIANT_SPEC[specKey];
     const { slug, tp, multinode, nnodes, blackwell } = spec;
     const isPro = modelVariant === "pro";
-    const useMtp = isPro && recipe !== "max-throughput";
+    // EAGLE MTP only applies to Pro. DeepEP only applies to Hopper paths
+    // (Blackwell uses flashinfer_trtllm); on Blackwell Pro the DeepEP toggle is a no-op.
+    const useMtp = isPro && eagleMtp === "enabled";
+    const useDeepep = !blackwell && deepep === "enabled";
     // V2.5 (base) requires DP-attention with effective attention-TP = 4 per group;
-    // dp comes from the spec table. Pro uses optional DP-attn driven by recipe.
+    // dp comes from the spec table. dp=1 on B200/GB300 means single attention group.
     const baseDp = !isPro ? spec.dp : 0;
-    const proDp = isPro && recipe !== "low-latency" ? tp : 0;
-    const dp = isPro ? proDp : baseDp;
-    const useDpAttn = !isPro ? baseDp > 1 : proDp > 0;
+    const useDpAttn = !isPro && baseDp > 1;
 
     // ---- env (kept inline before `sglang serve`, matching the verified launch style) ----
     const envVars = [];
@@ -148,7 +158,7 @@ export const MiMoV25Deployment = () => {
       envVars.push("NCCL_MNNVL_ENABLE=1", "NCCL_CUMEM_ENABLE=1");
     }
     if (useMtp) envVars.push("SGLANG_ENABLE_SPEC_V2=1");
-    if (isPro && !blackwell) envVars.push("SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256");
+    if (useDeepep) envVars.push("SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256");
 
     // ---- flags ----
     const flags = [];
@@ -157,20 +167,19 @@ export const MiMoV25Deployment = () => {
     flags.push(`  --tp ${tp}`);
 
     if (useDpAttn) {
-      flags.push(`  --dp ${dp}`);
+      flags.push(`  --dp ${baseDp}`);
       flags.push("  --enable-dp-attention");
-      if (!isPro) {
-        flags.push("  --enable-dp-lm-head");
-        flags.push("  --mm-enable-dp-encoder");
-      }
+      flags.push("  --enable-dp-lm-head");
+      flags.push("  --mm-enable-dp-encoder");
     }
 
     if (multinode) flags.push(...multiNodeFlags(nnodes));
 
-    // MoE backend: Blackwell uses flashinfer_trtllm; Hopper uses DeepEP.
+    // MoE backend: Blackwell uses flashinfer_trtllm (hardware-driven); Hopper
+    // optionally uses DeepEP (toggle).
     if (isPro && blackwell) {
       flags.push("  --moe-runner-backend flashinfer_trtllm");
-    } else {
+    } else if (useDeepep) {
       flags.push("  --moe-a2a-backend deepep");
       if (!isPro) flags.push("  --deepep-mode auto");
       if (isPro) flags.push(`  --ep ${tp}`);

--- a/docs_new/src/snippets/autoregressive/mimo-v25-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/mimo-v25-deployment.jsx
@@ -100,12 +100,34 @@ export const MiMoV25Deployment = () => {
     `#   <node0-ip>  = IP of the head node (reachable from all others)\n` +
     `${cmd}`;
 
-  const resolveItems = (option) => option.items;
+  // Toggles whose `enabled` choice is incompatible with the current variant +
+  // hardware are returned as a map { optionName -> reason }. The render layer
+  // grays out the matching radio item, and a useEffect snaps any disallowed
+  // value back to `disabled` so the visible UI never disagrees with the
+  // command we actually generate.
+  const computeForcedOff = (variant, hardware) => {
+    const isPro = variant === "pro";
+    const spec = HW_VARIANT_SPEC[`${variant}|${hardware}`];
+    const blackwell = spec ? spec.blackwell : false;
+    const forced = {};
+    if (!isPro) forced.eagleMtp = "EAGLE MTP applies to V2.5-Pro only.";
+    if (blackwell) forced.deepep = "Blackwell uses flashinfer_trtllm; DeepEP is Hopper / Ampere only.";
+    return forced;
+  };
+
+  const resolveItems = (option, forced) => {
+    const reason = forced[option.name];
+    if (!reason) return option.items;
+    return option.items.map((item) =>
+      item.id === "enabled" ? { ...item, disabled: true, disabledReason: reason } : item,
+    );
+  };
 
   const getInitialState = () => {
     const initialState = {};
+    const forced = computeForcedOff("pro", "h200");
     for (const [key, option] of Object.entries(options)) {
-      const items = resolveItems(option);
+      const items = resolveItems(option, forced);
       const def = items.find((i) => i.default && !i.disabled) || items.find((i) => !i.disabled) || items[0];
       initialState[key] = def.id;
     }
@@ -132,6 +154,20 @@ export const MiMoV25Deployment = () => {
     });
     return () => observer.disconnect();
   }, []);
+
+  // Snap forced-off toggles back to "disabled" whenever variant/hardware
+  // changes — keeps the visible radio in sync with generated command.
+  useEffect(() => {
+    const forced = computeForcedOff(values.modelVariant, values.hardware);
+    let patch = null;
+    for (const key of Object.keys(forced)) {
+      if (values[key] === "enabled") {
+        patch = patch || {};
+        patch[key] = "disabled";
+      }
+    }
+    if (patch) setValues((prev) => ({ ...prev, ...patch }));
+  }, [values.modelVariant, values.hardware]);
 
   const handleRadioChange = (optionName, value) => {
     setValues((prev) => ({ ...prev, [optionName]: value }));
@@ -278,10 +314,12 @@ export const MiMoV25Deployment = () => {
     border: `1px solid ${isDark ? "#374151" : "#e5e7eb"}`,
   };
 
+  const forcedOff = computeForcedOff(values.modelVariant, values.hardware);
+
   return (
     <div style={containerStyle} className="not-prose">
       {Object.entries(options).map(([key, option]) => {
-        const items = resolveItems(option);
+        const items = resolveItems(option, forcedOff);
         return (
           <div key={key} style={cardStyle}>
             <div style={titleStyle}>{option.title}</div>

--- a/docs_new/src/snippets/autoregressive/mimo-v25-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/mimo-v25-deployment.jsx
@@ -1,0 +1,307 @@
+export const MiMoV25Deployment = () => {
+  // MiMo-V2.5 family deployment matrix:
+  //   Variant × Hardware → slug, tp, multinode, blackwell
+  //
+  //   V2.5-Pro (1.02T / 42B active) — text-only:
+  //     H200  → tp=16, 2 nodes,     FP8 (Hopper: fa3 + DeepEP)
+  //     H100  → tp=16, 2 nodes,     FP8 (Hopper: fa3 + DeepEP)
+  //     B200  → tp=8,  single-node, FP8 (Blackwell verified: fa4 + flashinfer_trtllm)
+  //     GB300 → tp=8,  2 nodes,     FP8 (Blackwell verified: fa4 + flashinfer_trtllm + NCCL_MNNVL)
+  //   V2.5 (310B / 15B active) — multimodal:
+  //     H200  → tp=8, single-node, FP8
+  //     H100  → tp=8, single-node, FP8
+  //     B200  → tp=4, single-node, FP8
+  //     GB300 → tp=2, single-node, FP8
+  //
+  //   Recipes:
+  //     low-latency    → TP only (no DP), V2.5-Pro includes EAGLE MTP
+  //     balanced       → DP-attn + EAGLE (V2.5-Pro) / DP-attn (V2.5)
+  //     max-throughput → DP-attn, no MTP
+
+  const options = {
+    modelVariant: {
+      name: "modelVariant",
+      title: "Model Variant",
+      items: [
+        { id: "pro",  label: "V2.5-Pro", default: true,  subtitle: "1.02T / 42B" },
+        { id: "base", label: "V2.5",     default: false, subtitle: "310B / 15B"  },
+      ],
+    },
+    hardware: {
+      name: "hardware",
+      title: "Hardware Platform",
+      items: [
+        { id: "h200",  label: "H200",  default: true  },
+        { id: "h100",  label: "H100",  default: false },
+        { id: "b200",  label: "B200",  default: false },
+        { id: "gb300", label: "GB300", default: false },
+      ],
+    },
+    recipe: {
+      name: "recipe",
+      title: "Recipe",
+      items: [
+        { id: "low-latency",    label: "Low-Latency",    default: true  },
+        { id: "balanced",       label: "Balanced",       default: false },
+        { id: "max-throughput", label: "Max-Throughput", default: false },
+      ],
+    },
+    reasoningParser: {
+      name: "reasoningParser",
+      title: "Reasoning Parser",
+      items: [
+        { id: "enabled",  label: "Enabled",  default: true,  subtitle: "mimo" },
+        { id: "disabled", label: "Disabled", default: false },
+      ],
+    },
+    toolcall: {
+      name: "toolcall",
+      title: "Tool Call Parser",
+      items: [
+        { id: "enabled",  label: "Enabled",  default: true,  subtitle: "mimo" },
+        { id: "disabled", label: "Disabled", default: false },
+      ],
+    },
+  };
+
+  // Per (variant, hardware): HF slug, tp, multinode info, Blackwell flag.
+  const HW_VARIANT_SPEC = {
+    "pro|h200":   { slug: "XiaomiMiMo/MiMo-V2.5-Pro", tp: 16, multinode: true,  nnodes: 2, blackwell: false },
+    "pro|h100":   { slug: "XiaomiMiMo/MiMo-V2.5-Pro", tp: 16, multinode: true,  nnodes: 2, blackwell: false },
+    "pro|b200":   { slug: "XiaomiMiMo/MiMo-V2.5-Pro", tp: 8,  multinode: false,            blackwell: true  },
+    "pro|gb300":  { slug: "XiaomiMiMo/MiMo-V2.5-Pro", tp: 8,  multinode: true,  nnodes: 2, blackwell: true  },
+    "base|h200":  { slug: "XiaomiMiMo/MiMo-V2.5",     tp: 8,  multinode: false,            blackwell: false },
+    "base|h100":  { slug: "XiaomiMiMo/MiMo-V2.5",     tp: 8,  multinode: false,            blackwell: false },
+    "base|b200":  { slug: "XiaomiMiMo/MiMo-V2.5",     tp: 4,  multinode: false,            blackwell: true  },
+    "base|gb300": { slug: "XiaomiMiMo/MiMo-V2.5",     tp: 2,  multinode: false,            blackwell: true  },
+  };
+
+  const multiNodeFlags = (nnodes) => [
+    `  --nnodes ${nnodes}`,
+    `  --node-rank <node-rank>`,
+    `  --dist-init-addr <node0-ip>:20000`,
+  ];
+
+  const prependMultiNodeNote = (cmd, nnodes) =>
+    `# Multi-node (${nnodes} nodes). Run the same command on every node with:\n` +
+    `#   <node-rank> = 0 on the head node, 1..${nnodes - 1} on the others\n` +
+    `#   <node0-ip>  = IP of the head node (reachable from all others)\n` +
+    `${cmd}`;
+
+  const resolveItems = (option) => option.items;
+
+  const getInitialState = () => {
+    const initialState = {};
+    for (const [key, option] of Object.entries(options)) {
+      const items = resolveItems(option);
+      const def = items.find((i) => i.default && !i.disabled) || items.find((i) => !i.disabled) || items[0];
+      initialState[key] = def.id;
+    }
+    return initialState;
+  };
+
+  const [values, setValues] = useState(getInitialState);
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const checkDarkMode = () => {
+      const html = document.documentElement;
+      const isDarkMode =
+        html.classList.contains("dark") ||
+        html.getAttribute("data-theme") === "dark" ||
+        html.style.colorScheme === "dark";
+      setIsDark(isDarkMode);
+    };
+    checkDarkMode();
+    const observer = new MutationObserver(checkDarkMode);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class", "data-theme", "style"],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  const handleRadioChange = (optionName, value) => {
+    setValues((prev) => ({ ...prev, [optionName]: value }));
+  };
+
+  const generateCommand = () => {
+    const { modelVariant, hardware, recipe, reasoningParser, toolcall } = values;
+    const specKey = `${modelVariant}|${hardware}`;
+    const { slug, tp, multinode, nnodes, blackwell } = HW_VARIANT_SPEC[specKey];
+    const isPro = modelVariant === "pro";
+    const useMtp = isPro && recipe !== "max-throughput";
+
+    // ---- env (kept inline before `sglang serve`, matching the verified launch style) ----
+    const envVars = [];
+    if (isPro && blackwell && multinode) {
+      envVars.push("NCCL_MNNVL_ENABLE=1", "NCCL_CUMEM_ENABLE=1");
+    }
+    if (useMtp) envVars.push("SGLANG_ENABLE_SPEC_V2=1");
+    if (isPro && !blackwell) envVars.push("SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256");
+
+    // ---- flags ----
+    const flags = [];
+    flags.push("  --trust-remote-code");
+    flags.push(`  --model-path ${slug}`);
+    flags.push(`  --tp ${tp}`);
+
+    if (recipe !== "low-latency") {
+      flags.push(`  --dp ${tp}`);
+      flags.push("  --enable-dp-attention");
+      if (!isPro) {
+        flags.push("  --enable-dp-lm-head");
+        flags.push("  --mm-enable-dp-encoder");
+      }
+    }
+
+    if (multinode) flags.push(...multiNodeFlags(nnodes));
+
+    // MoE backend: Blackwell uses flashinfer_trtllm; Hopper uses DeepEP.
+    if (isPro && blackwell) {
+      flags.push("  --moe-runner-backend flashinfer_trtllm");
+    } else {
+      flags.push("  --moe-a2a-backend deepep");
+      if (!isPro) flags.push("  --deepep-mode auto");
+      if (isPro) flags.push(`  --ep ${tp}`);
+      flags.push("  --moe-dense-tp-size 1");
+    }
+
+    if (isPro) {
+      if (blackwell) {
+        flags.push("  --attention-backend fa4");
+        flags.push("  --mem-fraction-static 0.8");
+        flags.push("  --max-running-requests 128");
+        flags.push("  --chunked-prefill-size 16384");
+        if (hardware === "b200") flags.push("  --swa-full-tokens-ratio 0.1");
+        flags.push(`  --model-loader-extra-config '{"enable_multithread_load": "true","num_threads": 64}'`);
+      } else {
+        flags.push("  --mem-fraction-static 0.7");
+        flags.push("  --max-running-requests 128");
+        flags.push("  --chunked-prefill-size 32768");
+        flags.push("  --cuda-graph-max-bs 64");
+        flags.push("  --page-size 64");
+        flags.push("  --swa-full-tokens-ratio 0.3");
+        flags.push(`  --model-loader-extra-config '{"enable_multithread_load": "true","num_threads": 64}'`);
+      }
+    } else {
+      flags.push("  --mem-fraction-static 0.65");
+      flags.push("  --chunked-prefill-size 16384");
+    }
+
+    if (useMtp) {
+      flags.push("  --speculative-algo EAGLE");
+      flags.push("  --speculative-num-steps 3");
+      flags.push("  --speculative-eagle-topk 1");
+      flags.push("  --speculative-num-draft-tokens 4");
+      if (!blackwell) flags.push("  --enable-multi-layer-eagle");
+    }
+
+    if (reasoningParser === "enabled") flags.push("  --reasoning-parser mimo");
+    if (toolcall === "enabled") flags.push("  --tool-call-parser mimo");
+
+    flags.push("  --host 0.0.0.0");
+    flags.push("  --port 30000");
+
+    const envInline = envVars.length ? envVars.join(" ") + " " : "";
+    const base = `${envInline}sglang serve \\\n${flags.join(" \\\n")}`;
+    return multinode ? prependMultiNodeNote(base, nnodes) : base;
+  };
+
+  // ---- styles ----
+  const containerStyle = { maxWidth: "900px", margin: "0 auto", display: "flex", flexDirection: "column", gap: "4px" };
+  const cardStyle = {
+    padding: "8px 12px",
+    border: `1px solid ${isDark ? "#374151" : "#e5e7eb"}`,
+    borderLeft: `3px solid ${isDark ? "#E85D4D" : "#D45D44"}`,
+    borderRadius: "4px",
+    display: "flex",
+    alignItems: "center",
+    gap: "12px",
+    background: isDark ? "#1f2937" : "#fff",
+  };
+  const titleStyle = { fontSize: "13px", fontWeight: "600", minWidth: "140px", flexShrink: 0, color: isDark ? "#e5e7eb" : "inherit" };
+  const itemsStyle = { display: "flex", rowGap: "2px", columnGap: "6px", flexWrap: "wrap", alignItems: "center", flex: 1 };
+  const labelBaseStyle = {
+    padding: "4px 10px",
+    border: `1px solid ${isDark ? "#9ca3af" : "#d1d5db"}`,
+    borderRadius: "3px",
+    cursor: "pointer",
+    display: "inline-flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    fontWeight: "500",
+    fontSize: "13px",
+    transition: "all 0.2s",
+    userSelect: "none",
+    minWidth: "45px",
+    textAlign: "center",
+    flex: 1,
+    background: isDark ? "#374151" : "#fff",
+    color: isDark ? "#e5e7eb" : "inherit",
+  };
+  const checkedStyle = { background: "#D45D44", color: "white", borderColor: "#D45D44" };
+  const disabledStyle = { cursor: "not-allowed", opacity: 0.4 };
+  const subtitleStyle = { display: "block", fontSize: "9px", marginTop: "1px", lineHeight: "1.1", opacity: 0.7 };
+  const commandDisplayStyle = {
+    flex: 1,
+    padding: "12px 16px",
+    background: isDark ? "#111827" : "#f5f5f5",
+    borderRadius: "6px",
+    fontFamily: "'Menlo', 'Monaco', 'Courier New', monospace",
+    fontSize: "12px",
+    lineHeight: "1.5",
+    color: isDark ? "#e5e7eb" : "#374151",
+    whiteSpace: "pre-wrap",
+    overflowX: "auto",
+    margin: 0,
+    border: `1px solid ${isDark ? "#374151" : "#e5e7eb"}`,
+  };
+
+  return (
+    <div style={containerStyle} className="not-prose">
+      {Object.entries(options).map(([key, option]) => {
+        const items = resolveItems(option);
+        return (
+          <div key={key} style={cardStyle}>
+            <div style={titleStyle}>{option.title}</div>
+            <div style={itemsStyle}>
+              {items.map((item) => {
+                const isChecked = values[option.name] === item.id;
+                const isDisabled = !!item.disabled;
+                return (
+                  <label
+                    key={item.id}
+                    style={{ ...labelBaseStyle, ...(isChecked ? checkedStyle : {}), ...(isDisabled ? disabledStyle : {}) }}
+                    title={item.disabledReason || ""}
+                  >
+                    <input
+                      type="radio"
+                      name={option.name}
+                      value={item.id}
+                      checked={isChecked}
+                      disabled={isDisabled}
+                      onChange={() => !isDisabled && handleRadioChange(option.name, item.id)}
+                      style={{ display: "none" }}
+                    />
+                    {item.label}
+                    {item.subtitle && (
+                      <small style={{ ...subtitleStyle, color: isChecked ? "rgba(255,255,255,0.85)" : "inherit" }}>
+                        {item.subtitle}
+                      </small>
+                    )}
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
+      <div style={cardStyle}>
+        <div style={titleStyle}>Run this Command:</div>
+        <pre style={commandDisplayStyle}>{generateCommand()}</pre>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary

Adds a unified cookbook for [XiaomiMiMo/MiMo-V2.5-Pro](https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro) (1.02T MoE, text-only) and [XiaomiMiMo/MiMo-V2.5](https://huggingface.co/XiaomiMiMo/MiMo-V2.5) (310B MoE, native omnimodal) under `docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx`.

- **Interactive deployment generator** (variant × hardware × recipe) as a JSX snippet — H200 / H100 / B200 / GB300, low-latency / balanced / max-throughput recipes, optional reasoning + tool-call parsers
- **Pro on Blackwell (B200, GB300)** uses the verified `fa4 + flashinfer_trtllm + NCCL_MNNVL` stack (matches user-validated launch). GB300 is multi-node (TP=8 × 2 nodes).
- **Pro on Hopper (H100, H200)** falls back to the standard `fa3 + DeepEP` stack (not yet verified end-to-end on a 2-node Hopper setup).
- **V2.5 (310B)** is single-node with DP-attention (`--tp-size 8 --dp-size 2`) on 8 H200 / B200 / GB300; matches the PR #23811 launch shape.
- **Reasoning, multimodal (image / video / audio), and tool calling** invocation examples with real outputs captured from a live V2.5 server on 8× H200.
- **Speed benchmarks** (latency / throughput / multimodal-image) using `sglang.bench_serving` with real numbers; **accuracy benchmarks** (GSM8K + MMMU) using `sglang.test.run_eval` and `benchmark/mmmu/bench_sglang.py`.
- Xiaomi card on the cookbook intro page now points at MiMo-V2.5.

Related PRs: #23808 (Pro day-zero support), #23811 (V2.5 day-zero support).

## Test plan

- [x] Render docs_new locally (Mintlify) — page loads, deployment generator radios switch between Pro/V2.5 × hardware × recipe and emit the expected commands
- [x] V2.5 invocation examples (4.2 thinking, 4.3 image / video / audio, 4.4 tool calling) executed against a live server on 8× H200 — outputs in cookbook
- [x] V2.5 speed benchmarks (5.3.1 / 5.3.2 / 5.3.3) executed end-to-end on 8× H200 — numbers in cookbook
- [x] V2.5 MMMU bench: 59.3% overall (8× H200, FP8) — number in cookbook
- [ ] V2.5 GSM8K bench under eval-tuned launch: re-running on the eval-spec server (single-batch, `--mem-fraction-static 0.92`, `--disable-cuda-graph`); will fill in the result in a follow-up commit