### PR TITLE
feat(docker/b200): rebuild mooncake from source for MC_PKEY_INDEX sup…

### DIFF
--- a/docker/deepseek_v4_b200.Dockerfile
+++ b/docker/deepseek_v4_b200.Dockerfile
@@ -32,3 +32,25 @@ RUN pip uninstall -y deep-gemm deep_gemm 2>/dev/null; \
 # DeepGEMM install.sh bumps apache-tvm-ffi to 0.1.10, which breaks tilelang
 # 0.1.8 ABI. Re-pin to 0.1.9 (--no-deps so pip does not touch deep-gemm).
 RUN pip install --no-deps apache-tvm-ffi==0.1.9
+
+# Mooncake MC_PKEY_INDEX support (upstream PR #1985):
+#   The pip-released mooncake-transfer-engine wheels (<= v0.3.10.post2) hardcode
+#   attr.pkey_index = 0 when transitioning RDMA QPs into INIT state. On clusters
+#   where the routed InfiniBand partition lives at pkey index != 0 (e.g. some
+#   Verda B200 clusters expose 0xf282 only at pkey index 1), cross-node KV
+#   transfer silently fails with "transport retry counter exceeded" / "Context
+#   is not active: <hca>". Mooncake commit ae292ee adds MC_PKEY_INDEX env var
+#   to override this. Pin to that commit until a release tag containing it is
+#   available, then this whole RUN block can be removed (base image will ship
+#   the fixed wheel).
+RUN pip uninstall -y mooncake-transfer-engine 2>/dev/null; \
+    cd /tmp && rm -rf Mooncake && \
+    git clone https://github.com/kvcache-ai/Mooncake.git && \
+    cd Mooncake && \
+    git checkout ae292ee837e344839eecba943363a8cd84ba49b3 && \
+    git submodule update --init --recursive && \
+    bash dependencies.sh -y && \
+    mkdir -p build && cd build && cmake .. && make -j"$(nproc)" && cd .. && \
+    bash scripts/build_wheel.sh "$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')" && \
+    pip install mooncake-wheel/dist/*.whl && \
+    cd /tmp && rm -rf Mooncake


### PR DESCRIPTION
…port

The base image's pip-released mooncake-transfer-engine (<= v0.3.10.post2) hardcodes attr.pkey_index = 0 when transitioning RDMA QPs into INIT state. On clusters where the routed InfiniBand partition lives at a non-zero pkey index (e.g. some Verda B200 clusters expose 0xf282 only at pkey index 1), mooncake's cross-node KV transfer silently fails with "transport retry counter exceeded" / "Context is not active: <hca>".

Pin mooncake to commit ae292ee (kvcache-ai/Mooncake#1985), which adds an MC_PKEY_INDEX env var to override the default. Set MC_PKEY_INDEX=N in the serving container's env when the routed partition is at index N != 0.

This RUN block can be removed once a mooncake-transfer-engine release containing #1985 lands and the base sglang image picks it up.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
