### PR TITLE
Use Torch `torch.mm` for Deepseek V3.2 Indexer GEMM

### DIFF
--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -42,24 +42,6 @@ if _is_cuda:
     except ImportError as e:
         deep_gemm = e
 
-from sglang.srt.utils.custom_op import register_custom_op
-
-
-# torch.mm supports out_dtype=fp32 for bf16 inputs, keeping the fp32
-# accumulator instead of rounding to bf16 then casting up.
-# TODO(b8zhong): drop the custom op wrapper once on torch 2.10+. torch
-# 2.9.1's meta_mm doesn't accept out_dtype, breaking torch.compile.
-@register_custom_op(
-    op_name="weights_proj_bf16_in_fp32_out",
-    fake_impl=lambda x, weight: torch.empty(
-        (x.shape[0], weight.shape[0]), dtype=torch.float32, device=x.device
-    ),
-)
-def weights_proj_bf16_in_fp32_out_op(
-    x: torch.Tensor, weight: torch.Tensor
-) -> torch.Tensor:
-    return torch.mm(x, weight.t(), out_dtype=torch.float32)
-
 
 if _use_aiter:
     from aiter.ops.cache import indexer_k_quant_and_cache
@@ -286,7 +268,7 @@ class Indexer(MultiPlatformOp):
         if _use_aiter and _is_gfx95_supported and isinstance(x, tuple) and len(x) == 3:
             x = x[2]
         if _is_cuda:
-            return weights_proj_bf16_in_fp32_out_op(x, self.weights_proj.weight)
+            return torch.mm(x, self.weights_proj.weight.t(), out_dtype=torch.float32)
 
         weights, _ = self.weights_proj(x)
         if _is_hip:

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -42,7 +42,6 @@ if _is_cuda:
     except ImportError as e:
         deep_gemm = e
 
-
 if _use_aiter:
     from aiter.ops.cache import indexer_k_quant_and_cache
 

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -42,6 +42,25 @@ if _is_cuda:
     except ImportError as e:
         deep_gemm = e
 
+from sglang.srt.utils.custom_op import register_custom_op
+
+
+# torch.mm supports out_dtype=fp32 for bf16 inputs, keeping the fp32
+# accumulator instead of rounding to bf16 then casting up.
+# TODO(b8zhong): drop the custom op wrapper once on torch 2.10+. torch
+# 2.9.1's meta_mm doesn't accept out_dtype, breaking torch.compile.
+@register_custom_op(
+    op_name="weights_proj_bf16_in_fp32_out",
+    fake_impl=lambda x, weight: torch.empty(
+        (x.shape[0], weight.shape[0]), dtype=torch.float32, device=x.device
+    ),
+)
+def weights_proj_bf16_in_fp32_out_op(
+    x: torch.Tensor, weight: torch.Tensor
+) -> torch.Tensor:
+    return torch.mm(x, weight.t(), out_dtype=torch.float32)
+
+
 if _use_aiter:
     from aiter.ops.cache import indexer_k_quant_and_cache
 
@@ -266,15 +285,8 @@ class Indexer(MultiPlatformOp):
         # avoiding an expensive FP8-to-bf16 dequantization.
         if _use_aiter and _is_gfx95_supported and isinstance(x, tuple) and len(x) == 3:
             x = x[2]
-        if deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM:
-            weight = self.weights_proj.weight
-            out = torch.empty(
-                (x.shape[0], weight.shape[0]),
-                dtype=torch.float32,
-                device=x.device,
-            )
-            deep_gemm_wrapper.gemm_nt_bf16bf16f32(x, weight, out)
-            return out
+        if _is_cuda:
+            return weights_proj_bf16_in_fp32_out_op(x, self.weights_proj.weight)
 
         weights, _ = self.weights_proj(x)
         if _is_hip:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Optimize the indexer BF16 GEMM path.

## Modifications

To elaborate, the original problem this code is:

```python
weights, _ = self.weights_proj(x) 
weights = weights.float() 
```

> This is suboptimal: although BF16 tensor-core GEMM accumulates in FP32, the FP32 accumulator is rounded to BF16 in the GEMM epilogue, and only then converted back to FP32 for downstream use. In effect, the path is:
BF16 input → FP32 tensor core accumulation → BF16 epilogue output → FP32 cast
This loses accumulator precision and can increase tie frequency.

To solve this, we use DeepGEMM based BF16 input with FP32 output and accumulate, but it is relatively slow. In https://github.com/deepseek-ai/DeepGEMM/pull/304, SwapAB will be supported for SM90 and SM100, but not sure when the branch will get updated (it should be somewhat closer to torch.mm performance, but will investigate when the release branch is updated). In fact, the accuracy of DeepGEMM is actually worse than the proposed cuBLAS based FP32 output GEMM below.

Here is the output of DeepGEMM:

<img width="1457" height="801" alt="Screenshot 2026-04-27 at 12 30 28 PM" src="https://github.com/user-attachments/assets/76a5198a-1673-4994-b278-26f49205e5c8" />

And here is the output of:
```python
 weights, _ = self.weights_proj(x) 
 weights = weights.float() 
 ```
 
<img width="1456" height="805" alt="Screenshot 2026-04-27 at 12 32 01 PM" src="https://github.com/user-attachments/assets/c2434cad-2a7a-4916-ba1f-92c99d023036" />

We can see that it uses TST, where the T stands for bfloat16 and S stands for float32. Specifically, TST indicates bfloat16 inputs, float32 accumulation, and bfloat16 output. Because the output is in bfloat16, the SplitK reduction is forced into bfloat16, evidenced by the reduction kernel signature: `void cublasLt::splitKreduce_kernel<32, 16, int, float, __nv_bfloat16, float, __nv_bfloat16, false, float, __nv_bfloat16, __nv_bfloat16, true, false, false, false>(...)`. The next part of _get_logits_head_gate (which is torch.compile) requires an additional copy kernel: triton_poi_fused__to_copy_mul_0. This to_copy indicates a redundant memory load/store to perform the cast because the GEMM did not finish in the required precision.

Finally, here is the code using torch.mm.

<img width="1454" height="799" alt="Screenshot 2026-04-27 at 12 34 00 PM" src="https://github.com/user-attachments/assets/cb982cc3-975b-45d0-8830-53fab7f9cbac" />

We can see that it uses TSS (bfloat16 inputs, float32 accumulation, and float32 output). Consequently, the SplitK reduction is handled in float32, evidenced by the signature: `void cublasLt::splitKreduce_kernel<32, 16, int, float, float, float, float, false, float, float, float, true, false, false, false>(...)`. Because the accumulation and final output are kept in float32, the next part of _get_logits_head_gate does not have the copy. The Triton kernel is simplified to triton_poi_fused_mul_0 because the data is already in the correct float32 format, matching the optimized DeepGEMM path.

## Accuracy Tests

Unit test (code here): https://gist.github.com/b8zhong/29a07e917bfaee4d117bbee8077e2f14
```
python benchmark/kernels/deepseek/benchmark_nsa_indexer_weights_proj_accuracy.py
 m  n    k F.linear+float (max) F.linear+float (mean) torch.mm fp32 (max) torch.mm fp32 (mean) deep_gemm (max) deep_gemm (mean)
 1 64 7168            4.152e-01             8.063e-02           2.289e-04            6.402e-05       1.572e-03        4.677e-04
 2 64 7168            4.368e-01             7.583e-02           2.594e-04            6.802e-05       1.953e-03        4.925e-04
 3 64 7168            8.889e-01             8.673e-02           3.052e-04            6.725e-05       2.350e-03        4.956e-04
 4 64 7168            4.971e-01             9.133e-02           1.984e-04            6.316e-05       1.869e-03        5.336e-04
 5 64 7168            4.996e-01             9.103e-02           2.594e-04            6.387e-05       2.167e-03        5.078e-04
 6 64 7168            7.921e-01             9.367e-02           2.518e-04            6.465e-05       2.502e-03        5.110e-04
 7 64 7168            4.976e-01             9.370e-02           2.747e-04            6.910e-05       2.350e-03        5.319e-04
 8 64 7168            4.979e-01             9.356e-02           3.662e-04            6.778e-05       2.213e-03        5.163e-04
 1 32 6144            2.763e-01             6.717e-02           1.450e-04            4.922e-05       1.190e-03        3.503e-04
 2 32 6144            4.733e-01             1.050e-01           1.907e-04            6.847e-05       1.724e-03        4.470e-04
 3 32 6144            4.940e-01             7.391e-02           2.136e-04            5.559e-05       1.160e-03        3.454e-04
 4 32 6144            4.880e-01             9.436e-02           2.899e-04            6.496e-05       1.526e-03        4.046e-04
 5 32 6144            4.978e-01             1.019e-01           2.594e-04            7.047e-05       1.480e-03        4.370e-04
 6 32 6144            4.762e-01             9.823e-02           2.441e-04            6.422e-05       1.740e-03        4.291e-04
 7 32 6144            4.550e-01             8.145e-02           2.899e-04            5.447e-05       1.404e-03        3.981e-04
 8 32 6144            4.229e-01             9.100e-02           2.289e-04            6.556e-05       1.785e-03        4.242e-04
 ```
 
 Speed with CUPTI:
 ```
    m  n    k torch (F.linear + .float) torch.mm (out_dtype=fp32) deep_gemm                    Winner
   1 64 7168                    12.384                     5.344    16.096 torch.mm (out_dtype=fp32)
   2 64 7168                    12.320                     5.216    16.033 torch.mm (out_dtype=fp32)
   4 64 7168                    12.641                     5.536    16.096 torch.mm (out_dtype=fp32)
   8 64 7168                    13.248                     5.408    16.096 torch.mm (out_dtype=fp32)
  16 64 7168                    13.216                     5.472    16.064 torch.mm (out_dtype=fp32)
  32 64 7168                    13.312                     6.048    16.113 torch.mm (out_dtype=fp32)
  64 64 7168                    13.664                     6.272    16.160 torch.mm (out_dtype=fp32)
 128 64 7168                    13.888                     6.720    16.288 torch.mm (out_dtype=fp32)
 256 64 7168                    13.536                     6.912    16.224 torch.mm (out_dtype=fp32)
 512 64 7168                    13.984                     7.488    15.584 torch.mm (out_dtype=fp32)
1024 64 7168                    14.592                     9.537    16.000 torch.mm (out_dtype=fp32)
   1 32 6144                    11.872                     4.864    14.336 torch.mm (out_dtype=fp32)
   2 32 6144                    11.937                     4.832    14.240 torch.mm (out_dtype=fp32)
   4 32 6144                    11.904                     4.896    14.272 torch.mm (out_dtype=fp32)
   8 32 6144                    12.352                     4.992    14.208 torch.mm (out_dtype=fp32)
  16 32 6144                    13.088                     5.248    14.240 torch.mm (out_dtype=fp32)
  32 32 6144                    13.024                     5.376    14.272 torch.mm (out_dtype=fp32)
  64 32 6144                    13.312                     5.824    14.272 torch.mm (out_dtype=fp32)
 128 32 6144                    13.216                     6.368    14.560 torch.mm (out_dtype=fp32)
 256 32 6144                    13.377                     6.400    14.496 torch.mm (out_dtype=fp32)
 512 32 6144                    13.153                     7.552    13.920 torch.mm (out_dtype=fp32)
1024 32 6144                    14.336                     8.608    14.465 torch.mm (out_dtype=fp32)
```

`69.04` -> `73.22` BS = 1 (and large BS performance above).

```
python3 -m sglang.launch_server --model-path nvidia/GLM-5-NVFP4 \
  --tp 8 \
  --ep 8 \
  --trust-remote-code \
  --reasoning-parser glm45 \
  --tool-call-parser glm47 --max-running-requests 256
```

Before:
<img width="2568" height="1442" alt="image" src="https://github.com/user-attachments/assets/341856fb-7e93-486e-bccf-9f57f305ced7" />

After:
<img width="1275" height="604" alt="Screenshot 2026-04-27 at 1 25 54 PM" src="https://github.com/user-attachments/assets/b30aff01-15fc-4438-a364-672bb34b1568" />

For GLM-5 NVFP4, `0.854` -> `0.86`.

For GLM-5 FP8:

```
nohup python3 -u -m sglang.launch_server --model-path zai-org/GLM-5-FP8 --trust-remote-code --tp-size 8 --ep 8 --tool-call-parser glm47 --reasoning-parser glm45 --port 30020 --max-running-requests 256 --mem-fraction-static 0.93 > sglang_server.log 2>&1 &
```

```
nohup python3 -m sglang.test.run_eval --port 30020 --eval-name gpqa --num-examples 198 --max-tokens 128000 --repeat 8 --top-p 0.95 --temperature 1.0 --thinking-mode glm-45 > eval.log 2>&1 &
```

Before (some of it can be attributed to output variance, but also I think some from the improvement in error from DeepGEMM vs cuBLAS):
```
Repeat: 8, mean: 0.851
Scores: ['0.854', '0.874', '0.854', '0.838', '0.848', '0.838', '0.833', '0.869']
Mean latency: 12627.124 s
```

After:
```
Repeat: 8, mean: 0.860
Scores: ['0.828', '0.859', '0.879', '0.854', '0.869', '0.869', '0.854', '0.869']
Mean latency: 11864.799 s
```