### PR TITLE
[NemotronH] auto-coerce Nemotron-Nano-V3-Omni arch to V2 config

### DIFF
--- a/python/sglang/srt/configs/nano_nemotron_vl.py
+++ b/python/sglang/srt/configs/nano_nemotron_vl.py
@@ -30,6 +30,11 @@ def float_triplet(seq: Any):
     return a, b, c
 
 
+NEMOTRON_ARCH_ALIASES = {
+    "NemotronH_Nano_Omni_Reasoning_V3": "NemotronH_Nano_VL_V2",
+}
+
+
 class NemotronH_Nano_VL_V2_Config(PretrainedConfig):
     model_type = "NemotronH_Nano_VL_V2"
     is_composition = True

--- a/python/sglang/srt/utils/hf_transformers/config.py
+++ b/python/sglang/srt/utils/hf_transformers/config.py
@@ -19,6 +19,10 @@ from typing import Optional
 from transformers import PretrainedConfig
 from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
 
+from sglang.srt.configs.nano_nemotron_vl import (
+    NEMOTRON_ARCH_ALIASES,
+    NemotronH_Nano_VL_V2_Config,
+)
 from sglang.srt.connector import create_remote_connector
 from sglang.srt.utils import is_remote_url, logger, lru_cache_frozenset
 from sglang.srt.utils.runai_utils import ObjectStorageModel, is_runai_obj_uri
@@ -108,6 +112,18 @@ def get_config(
                     config._name_or_path = model
                 else:
                     raise
+
+    archs = getattr(config, "architectures", None) or []
+    if archs and NEMOTRON_ARCH_ALIASES.get(archs[0]) == "NemotronH_Nano_VL_V2":
+        original_arch = archs[0]
+        raw = config.to_dict()
+        raw["architectures"] = ["NemotronH_Nano_VL_V2"]
+        raw["model_type"] = "NemotronH_Nano_VL_V2"
+        raw.pop("auto_map", None)
+        config = NemotronH_Nano_VL_V2_Config.from_dict(raw)
+        logger.info(
+            "Coerced renamed-arch %s -> NemotronH_Nano_VL_V2", original_arch
+        )
 
     if (
         config.architectures is not None


### PR DESCRIPTION
## Summary
Add a small alias mechanism so `nvidia/Nemotron-Nano-V3-Omni-*` checkpoints — whose `config.json` declares `architectures: ["NemotronH_Nano_Omni_Reasoning_V3"]` and ships a remote-code config class that lacks sglang-expected methods like `create_radio_config` — load via the sglang-native `NemotronH_Nano_VL_V2_Config` path without users having to hand-edit `config.json` on disk.

## Motivation
Without this, V3-Omni checkpoints fail in two ways:

- With `--trust-remote-code`: HF loads the remote V3 config class via `auto_map`. It's a valid `PretrainedConfig` subclass but lacks `create_radio_config` / `raw_vision_config`. sglang's `NemotronH_Nano_VL_V2.__init__` calls `config.create_radio_config()` and crashes with `AttributeError`.
- Without `--trust-remote-code`: HF can't resolve `model_type=NemotronH_Nano_Omni_Reasoning_V3` and raises before sglang sees the config at all.

## Change
1. `configs/nano_nemotron_vl.py` — `NEMOTRON_ARCH_ALIASES` dict mapping renamed-arch names to their sglang-native target. One entry today (`NemotronH_Nano_Omni_Reasoning_V3 → NemotronH_Nano_VL_V2`).
2. `utils/hf_transformers/config.py` — after `AutoConfig.from_pretrained` succeeds in `get_config`, if `config.architectures[0]` matches an alias, rebuild via `NemotronH_Nano_VL_V2_Config.from_dict(config.to_dict())` with arch / model_type rewritten and `auto_map` stripped. The rest of `get_config` (registry reload via `from_pretrained`, `text_config` backfill, `_name_or_path` set) then runs the standard V2 path unchanged.

## Why post-AutoConfig coercion
- Works uniformly for HF hub IDs, `s3://`, `runai://`, and local-dir paths — we operate on the already-loaded `PretrainedConfig`, not on disk bytes.
- Coerced configs flow through the existing registry-reload path, so they pick up `generation_config.json`, `_name_or_path`, and the standard `text_config` backfill — no new code paths.
- Works regardless of `--trust-remote-code`.
- Coerced object is a real `NemotronH_Nano_VL_V2_Config` — `isinstance` checks in downstream sglang code keep working.

## Related
- #23544 — companion PR adding `getattr` fallbacks at the field level (`mamba_n_groups` / `n_groups`, `image_size` / `force_image_size`, `mamba2_cache_params` from `hybrid_override_pattern`). Orthogonal — this PR does not depend on it. Together they make NemotronH tolerant of both arch-name and field-name drift.