### PR TITLE
Fix: auto-detect Qwen3.5/3.6 MTP draft model path for speculative decoding

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3414,6 +3414,8 @@ class ServerArgs:
                 "MistralLarge3ForCausalLM",
                 "PixtralForConditionalGeneration",
                 "HYV3ForCausalLM",
+                "Qwen3_5ForConditionalGeneration",
+                "Qwen3_5MoeForConditionalGeneration",
             ]:
                 if self.speculative_draft_model_path is None:
                     self.speculative_draft_model_path = self.model_path


### PR DESCRIPTION
## Problem

`Qwen3_5ForConditionalGeneration` and `Qwen3_5MoeForConditionalGeneration` are missing from the auto-detect MTP draft model path list in `server_args.py`. 

When using `--speculative-algorithm NEXTN` with Qwen3.5/3.6 models, users must manually set `--speculative-draft-model-path` or spec decode fails silently.

## Impact

Without `--speculative-draft-model-path`, speculative decoding cannot find the draft model for Qwen3.5/3.6 architectures. This causes spec decode to fail silently, reducing throughput from 300+ TPS to ~8-18 TPS on Qwen3.6-35B-A3B (3-40x performance loss).

## Fix

Add `Qwen3_5ForConditionalGeneration` and `Qwen3_5MoeForConditionalGeneration` to the auto-detect list, so `speculative_draft_model_path` defaults to `model_path` (same as DeepseekV3, BailingMoe, etc.).

## Testing

Tested on Qwen3.6-35B-A3B-FP8, H100 80GB, SGLang 0.5.10.post1:
- Before fix: must set `--speculative-draft-model-path` manually
- After fix: NEXTN auto-detects draft model, spec decode works without manual flag