### PR TITLE
[perf] cherry-pick #22911: support return_routed_experts with overlap scheduling

### DIFF
--- a/python/sglang/srt/layers/moe/routed_experts_capturer.py
+++ b/python/sglang/srt/layers/moe/routed_experts_capturer.py
@@ -1,3 +1,4 @@
+import dataclasses
 import logging
 from abc import ABC
 from typing import Optional
@@ -29,6 +30,25 @@ _MB = 1024 * 1024
 
 def get_tensor_size_bytes(t: torch.Tensor):
     return np.prod(t.shape) * t.dtype.itemsize
+
+
+@dataclasses.dataclass
+class RoutedExpertsOutput:
+    """Holds GPU tensors captured during forward for overlap scheduling.
+    Call copy_to_cpu() inside forward stream (before copy_done.record()),
+    then finalize() after copy_done.synchronize().
+    """
+
+    out_cache_loc: torch.Tensor
+    routed_experts: torch.Tensor
+    host_cache: "_RoutedExpertsHostCache"
+
+    def copy_to_cpu(self):
+        self.out_cache_loc = self.out_cache_loc.to("cpu", non_blocking=True)
+        self.routed_experts = self.routed_experts.to("cpu", non_blocking=True)
+
+    def finalize(self):
+        self.host_cache.buffer[self.out_cache_loc] = self.routed_experts
 
 
 class _RoutedExpertsDeviceCache:
@@ -147,7 +167,9 @@ class RoutedExpertsCapturer(ABC):
     ):
         raise NotImplementedError
 
-    def on_forward_end(self, forward_batch, can_run_graph, cuda_graph_batch):
+    def on_forward_end(
+        self, forward_batch, can_run_graph, cuda_graph_batch, no_copy_to_cpu=False
+    ) -> Optional[RoutedExpertsOutput]:
         raise NotImplementedError
 
     def get_host_cache(self):
@@ -197,31 +219,47 @@ class _RoutedExpertsCapturerReal(RoutedExpertsCapturer):
                 device=device,
             )
 
+    def _get_local_range(self, forward_batch, can_run_graph, cuda_graph_batch):
+        # When DeepEP is enabled, capture() already does all_gather, so device_cache.buffer
+        # contains data from all DP ranks. We should not slice by DP rank in this case.
+        if is_dp_attention_enabled() and not get_moe_a2a_backend().is_deepep():
+            local_start_pos, local_num_tokens = get_dp_local_info(forward_batch)
+            if can_run_graph:
+                local_start_pos = get_attention_dp_rank() * cuda_graph_batch
+            return local_start_pos, local_start_pos + local_num_tokens
+        else:
+            return 0, forward_batch.out_cache_loc.shape[0]
+
     def _sync_fwd_experts_buffer_DtoH(
         self,
         forward_batch: ForwardBatch,
         can_run_graph: bool,
         cuda_graph_batch: int,
     ):
-        # When DeepEP is enabled, capture() already does all_gather, so device_cache.buffer
-        # contains data from all DP ranks. We should not slice by DP rank in this case.
-        if is_dp_attention_enabled() and not get_moe_a2a_backend().is_deepep():
-            local_start_pos, local_num_tokens = get_dp_local_info(forward_batch)
-            # handle with cuda graph padding
-            if can_run_graph:
-                local_start_pos = get_attention_dp_rank() * cuda_graph_batch
-                local_end_pos = local_start_pos + local_num_tokens
-            else:
-                local_end_pos = local_start_pos + local_num_tokens
-        else:
-            local_start_pos = 0
-            local_end_pos = forward_batch.out_cache_loc.shape[0]
-
-        # FIXME: sync explicitly here, overlap scheduler breaks here.
+        local_start_pos, local_end_pos = self._get_local_range(
+            forward_batch, can_run_graph, cuda_graph_batch
+        )
         out_cache_loc_cpu = forward_batch.out_cache_loc.cpu()
         self.host_cache.buffer[out_cache_loc_cpu] = self.device_cache.buffer[
             local_start_pos:local_end_pos, :, : self.num_experts_per_tok
         ].cpu()
+
+    def _prepare_routed_experts_output(
+        self,
+        forward_batch: ForwardBatch,
+        can_run_graph: bool,
+        cuda_graph_batch: int,
+    ) -> RoutedExpertsOutput:
+        local_start_pos, local_end_pos = self._get_local_range(
+            forward_batch, can_run_graph, cuda_graph_batch
+        )
+        return RoutedExpertsOutput(
+            out_cache_loc=forward_batch.out_cache_loc,
+            routed_experts=self.device_cache.buffer[
+                local_start_pos:local_end_pos, :, : self.num_experts_per_tok
+            ],
+            host_cache=self.host_cache,
+        )
 
     def capture(self, layer_id: int, topk_ids: torch.Tensor):
         if get_moe_a2a_backend().is_deepep():
@@ -243,12 +281,22 @@ class _RoutedExpertsCapturerReal(RoutedExpertsCapturer):
         )
         return self.get_host_cache().buffer[cache_pool_idx]
 
-    def on_forward_end(self, forward_batch, can_run_graph, cuda_graph_batch):
-        self._sync_fwd_experts_buffer_DtoH(
-            forward_batch=forward_batch,
-            can_run_graph=can_run_graph,
-            cuda_graph_batch=cuda_graph_batch,
-        )
+    def on_forward_end(
+        self, forward_batch, can_run_graph, cuda_graph_batch, no_copy_to_cpu=False
+    ) -> Optional[RoutedExpertsOutput]:
+        if no_copy_to_cpu:
+            return self._prepare_routed_experts_output(
+                forward_batch=forward_batch,
+                can_run_graph=can_run_graph,
+                cuda_graph_batch=cuda_graph_batch,
+            )
+        else:
+            self._sync_fwd_experts_buffer_DtoH(
+                forward_batch=forward_batch,
+                can_run_graph=can_run_graph,
+                cuda_graph_batch=cuda_graph_batch,
+            )
+            return None
 
     def get_host_cache(self):
         return self.host_cache
@@ -280,8 +328,10 @@ class _RoutedExpertsCapturerNoop(RoutedExpertsCapturer):
     ):
         pass
 
-    def on_forward_end(self, forward_batch, can_run_graph, cuda_graph_batch):
-        pass
+    def on_forward_end(
+        self, forward_batch, can_run_graph, cuda_graph_batch, no_copy_to_cpu=False
+    ) -> Optional[RoutedExpertsOutput]:
+        return None
 
     def get_host_cache(self):
         pass

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -132,6 +132,9 @@ class SchedulerOutputProcessorMixin:
         if self.is_generation:
             if result.copy_done is not None:
                 result.copy_done.synchronize()
+            if result.routed_experts_output is not None:
+                result.routed_experts_output.finalize()
+                result.routed_experts_output = None
 
             (
                 logits_output,
@@ -380,6 +383,9 @@ class SchedulerOutputProcessorMixin:
     ):
         if result.copy_done is not None:
             result.copy_done.synchronize()
+        if result.routed_experts_output is not None:
+            result.routed_experts_output.finalize()
+            result.routed_experts_output = None
 
         logits_output, next_token_ids, can_run_cuda_graph = (
             result.logits_output,

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -482,6 +482,7 @@ class TpModelWorker(BaseTpWorker):
                 logits_output=logits_output,
                 can_run_cuda_graph=can_run_cuda_graph,
                 expert_distribution_metrics=out.expert_distribution_metrics,
+                routed_experts_output=out.routed_experts_output,
             )
 
             if is_verify:

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -8,6 +8,7 @@ import torch
 
 from sglang.srt.eplb.expert_distribution import ExpertDistributionMetrics
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.layers.moe.routed_experts_capturer import RoutedExpertsOutput
 from sglang.srt.managers.overlap_utils import FutureIndices
 from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.model_executor.forward_batch_info import PPProxyTensors
@@ -45,6 +46,9 @@ class GenerationBatchResult:
 
     # relay path: forward stream -> next step forward
     next_draft_input: Optional[EagleDraftInput] = None
+
+    # Routed experts: pending async D2H for overlap scheduling
+    routed_experts_output: Optional[RoutedExpertsOutput] = None
 
     # metrics
     expert_distribution_metrics: Optional[ExpertDistributionMetrics] = None
@@ -86,6 +90,9 @@ class GenerationBatchResult:
 
         if self.accept_lens is not None:
             self.accept_lens = self.accept_lens.to("cpu", non_blocking=True)
+
+        if self.routed_experts_output is not None:
+            self.routed_experts_output.copy_to_cpu()
 
         if (x := self.expert_distribution_metrics) is not None:
             x.copy_to_cpu()

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -112,6 +112,7 @@ from sglang.srt.layers.dp_attention import (
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.layers.moe.routed_experts_capturer import (
     RoutedExpertsCapturer,
+    RoutedExpertsOutput,
     get_global_experts_capturer,
     set_global_experts_capturer,
 )
@@ -284,6 +285,7 @@ class ModelRunnerOutput:
     logits_output: Union[LogitsProcessorOutput, PPProxyTensors]
     can_run_graph: bool
     expert_distribution_metrics: Optional[ExpertDistributionMetrics] = None
+    routed_experts_output: Optional[RoutedExpertsOutput] = None
 
 
 class ModelRunner(ModelRunnerKVCacheMixin):
@@ -2868,7 +2870,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 )
         output.expert_distribution_metrics = recorder_outputs.get("metrics")
 
-        # Copy cached routing experts' buffers back to CPU cache
         if not self.is_draft_worker:
             # In speculative decoding, num_tokens_per_bs > 1, so we need to pass
             # the actual number of tokens per dp rank in cuda graph, not batch size.
@@ -2877,10 +2878,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 cuda_graph_num_tokens = (
                     self.graph_runner.bs * self.graph_runner.num_tokens_per_bs
                 )
-            get_global_experts_capturer().on_forward_end(
+            no_copy_to_cpu = not self.server_args.disable_overlap_schedule
+            output.routed_experts_output = get_global_experts_capturer().on_forward_end(
                 forward_batch=forward_batch,
                 can_run_graph=output.can_run_graph,
                 cuda_graph_batch=cuda_graph_num_tokens,
+                no_copy_to_cpu=no_copy_to_cpu,
             )
 
         if self.eplb_manager is not None:

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -866,6 +866,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
             can_run_cuda_graph=can_run_cuda_graph,
             next_draft_input=next_draft_input,
             accept_lens=accept_length,
+            routed_experts_output=forward_batch_output.routed_experts_output,
         )
 
     def _compute_spec_v2_logprobs(

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -749,4 +749,5 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
             can_run_cuda_graph=can_run_cuda_graph,
             next_draft_input=next_draft_input,
             accept_lens=accept_length,
+            routed_experts_output=forward_batch_output.routed_experts_output,
         )


### PR DESCRIPTION
## Motivation

Cherry-pick of upstream PR #22911 ([perf] support return_routed_experts with overlap scheduling, commit `c5603268`) onto the `sglang-miles` branch.

Previously, the routed-experts capture path issued a synchronous device-to-host copy inside the forward step (`out_cache_loc.cpu()` + `device_cache.buffer[...].cpu()`), which forced the GPU to drain and broke the overlap scheduler. This made `--return-routed-experts` unusable in overlap mode.

## Modifications

- Add `RoutedExpertsOutput` dataclass that holds GPU tensors plus a reference to the host cache, with `copy_to_cpu()` (called inside the forward stream before `copy_done.record()`) and `finalize()` (called after `copy_done.synchronize()`).
- Refactor `_RoutedExpertsCapturerReal` to extract `_get_local_range` and add `_prepare_routed_experts_output`; `on_forward_end` now takes `no_copy_to_cpu=False` and returns an `Optional[RoutedExpertsOutput]`.
- In `model_runner.py`, set `no_copy_to_cpu = not server_args.disable_overlap_schedule` so the deferred path is used whenever overlap is enabled, and surface the result on `ModelRunnerOutput.routed_experts_output`.
- Plumb `routed_experts_output` through `GenerationBatchResult`, `TpModelWorker`, and both `EAGLEWorkerV2` / `MultiLayerEagleWorkerV2`.
- In `SchedulerOutputProcessorMixin`, after `copy_done.synchronize()`, call `routed_experts_output.finalize()` and clear the field.

### Conflict resolution

Resolved conflicts in `routed_experts_capturer.py` and `model_runner.py` to keep the following miles-side changes on top of upstream's `_get_local_range` / `no_copy_to_cpu` refactor:
- Draft-worker guard around `on_forward_end` (`if not self.is_draft_worker:`).
- `bs * num_tokens_per_bs` cuda_graph token-count fix for spec decoding.
- DeepEP all-gather path: skip DP-rank slicing when DeepEP is enabled (the `is_dp_attention_enabled() and not get_moe_a2a_backend().is_deepep()` guard).

## Accuracy Tests

Router replay accuracy test (`test_return_routed_experts`) passes 3/3 with **0 mismatches across ~26.7M expert IDs**.

## Speed Tests and Profiling

H200 TP=4, Qwen3-30B-A3B, batch=64, in=1024, out=512:

| Mode | Output throughput |
|---|---|
| Before (sync DtoH inside forward) | 7453.48 tok/s |
| After (deferred copy via `RoutedExpertsOutput`) | **8609.21 tok/s** |

→ **+15.5%** end-to-end output throughput with `--return-routed-experts` enabled in overlap mode.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).