### PR TITLE
[Tool Call] Validate function name in DeepSeek streaming detectors

### DIFF
--- a/python/sglang/srt/function_call/deepseekv31_detector.py
+++ b/python/sglang/srt/function_call/deepseekv31_detector.py
@@ -4,6 +4,7 @@ import re
 from typing import List
 
 from sglang.srt.entrypoints.openai.protocol import Tool
+from sglang.srt.environ import envs
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
@@ -122,6 +123,29 @@ class DeepSeekV31Detector(BaseFormatDetector):
                 func_name = partial_match.group(1).strip()
                 func_args_raw = partial_match.group(2).strip()
                 is_tool_end = partial_match.group(3)
+
+                # Validate the function name against the request's tools list.
+                # If the model emitted an undefined function, mirror the base
+                # class's behavior: by default skip the invoke (with a warning),
+                # or forward it as-is when SGLANG_FORWARD_UNKNOWN_TOOLS is set
+                # so the client can surface a recoverable error to the model.
+                if (
+                    not self.current_tool_name_sent
+                    and func_name not in self._tool_indices
+                    and not envs.SGLANG_FORWARD_UNKNOWN_TOOLS.get()
+                ):
+                    logger.warning(
+                        f"Model attempted to call undefined function: {func_name}"
+                    )
+                    if is_tool_end:
+                        # Drop the completed invoke and keep any trailing
+                        # content (potentially the start of a valid invoke).
+                        self._buffer = current_text[partial_match.end(3) :]
+                    else:
+                        # Invoke is still partial; discard the buffer to
+                        # avoid getting stuck re-matching the same name.
+                        self._buffer = ""
+                    return StreamingParseResult(normal_text="", calls=calls)
 
                 # Initialize state if this is the first tool call
                 if self.current_tool_id == -1:

--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -5,6 +5,7 @@ import re
 from partial_json_parser.core.options import Allow
 
 from sglang.srt.entrypoints.openai.protocol import Tool
+from sglang.srt.environ import envs
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
@@ -258,6 +259,31 @@ class DeepSeekV32Detector(BaseFormatDetector):
                 invoke_content = invoke_match.group(2)
                 # group(3) is either "</｜DSML｜invoke>" (complete) or "" (incomplete, matched with $)
                 is_tool_end = bool(invoke_match.group(3))
+
+                # Build tool indices lazily so we can validate function names.
+                if not hasattr(self, "_tool_indices"):
+                    self._tool_indices = self._get_tool_indices(tools)
+
+                # Validate the function name against the request's tools list.
+                # If the model emitted an undefined function, mirror the base
+                # class's behavior: by default skip the invoke (with a warning),
+                # or forward it as-is when SGLANG_FORWARD_UNKNOWN_TOOLS is set
+                # so the client can surface a recoverable error to the model.
+                if func_name not in self._tool_indices:
+                    if not envs.SGLANG_FORWARD_UNKNOWN_TOOLS.get():
+                        logger.warning(
+                            f"Model attempted to call undefined function: {func_name}"
+                        )
+                        if is_tool_end:
+                            # Drop the completed invoke and keep parsing
+                            # whatever comes after it.
+                            self._buffer = current_text[invoke_match.end() :]
+                            current_text = self._buffer
+                            self.current_tool_name_sent = False
+                            continue
+                        # Invoke is still partial; wait for more bytes before
+                        # we can safely advance the buffer past it.
+                        break
 
                 # Initialize state if this is the first tool call
                 if self.current_tool_id == -1:

--- a/python/sglang/srt/function_call/deepseekv3_detector.py
+++ b/python/sglang/srt/function_call/deepseekv3_detector.py
@@ -4,6 +4,7 @@ import re
 from typing import List
 
 from sglang.srt.entrypoints.openai.protocol import Tool
+from sglang.srt.environ import envs
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
@@ -119,6 +120,32 @@ class DeepSeekV3Detector(BaseFormatDetector):
             if partial_match:
                 func_name = partial_match.group(2).strip()
                 func_args_raw = partial_match.group(3).strip()
+
+                # Validate the function name against the request's tools list.
+                # If the model emitted an undefined function, mirror the base
+                # class's behavior: by default skip the invoke (with a warning),
+                # or forward it as-is when SGLANG_FORWARD_UNKNOWN_TOOLS is set
+                # so the client can surface a recoverable error to the model.
+                if (
+                    not self.current_tool_name_sent
+                    and func_name not in self._tool_indices
+                    and not envs.SGLANG_FORWARD_UNKNOWN_TOOLS.get()
+                ):
+                    logger.warning(
+                        f"Model attempted to call undefined function: {func_name}"
+                    )
+                    # Drop the buffered invoke; if the closing token is
+                    # already present, advance past it so any trailing
+                    # valid invoke has a chance to parse on the next chunk.
+                    tool_call_end_pattern = (
+                        r"<｜tool▁call▁begin｜>.*?<｜tool▁call▁end｜>"
+                    )
+                    match = re.search(tool_call_end_pattern, current_text, re.DOTALL)
+                    if match:
+                        self._buffer = current_text[match.end() :]
+                    else:
+                        self._buffer = ""
+                    return StreamingParseResult(normal_text="", calls=calls)
 
                 # Initialize state if this is the first tool call
                 if self.current_tool_id == -1:

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -2,6 +2,7 @@ import json
 import unittest
 
 from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.environ import envs
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
 from sglang.srt.function_call.core_types import StreamingParseResult
 from sglang.srt.function_call.deepseekv3_detector import DeepSeekV3Detector
@@ -1254,6 +1255,74 @@ class TestDeepSeekV3Detector(unittest.TestCase):
         self.assertEqual(params1["city"], "Shanghai")
         self.assertEqual(params2["city"], "Beijing")
 
+    def test_parse_streaming_unknown_function_skipped_by_default(self):
+        """Streaming: undefined function name is skipped by default and does not leak as a tool call."""
+        chunks = [
+            "<｜tool▁calls▁begin｜>",
+            "<｜tool▁call▁begin｜>function",
+            "<｜tool▁sep｜>undefined_func\n",
+            "```json\n",
+            '{"city": "Shanghai"}\n```',
+            "<｜tool▁call▁end｜><｜tool▁calls▁end｜>",
+        ]
+
+        all_calls = []
+        for chunk in chunks:
+            r = self.detector.parse_streaming_increment(chunk, self.tools)
+            all_calls.extend(r.calls)
+
+        self.assertEqual(all_calls, [], "Unknown function should be skipped by default")
+
+    def test_parse_streaming_unknown_function_forwarded_with_env(self):
+        """Streaming: SGLANG_FORWARD_UNKNOWN_TOOLS=1 forwards undefined functions to the client."""
+        chunks = [
+            "<｜tool▁calls▁begin｜>",
+            "<｜tool▁call▁begin｜>function",
+            "<｜tool▁sep｜>undefined_func\n",
+            "```json\n",
+            '{"city": "Shanghai"}\n```',
+            "<｜tool▁call▁end｜><｜tool▁calls▁end｜>",
+        ]
+
+        with envs.SGLANG_FORWARD_UNKNOWN_TOOLS.override(True):
+            self.detector = DeepSeekV3Detector()
+            all_calls = []
+            for chunk in chunks:
+                r = self.detector.parse_streaming_increment(chunk, self.tools)
+                all_calls.extend(r.calls)
+
+        names = [c.name for c in all_calls if c.name]
+        self.assertEqual(
+            names, ["undefined_func"], "Unknown function should be forwarded as-is"
+        )
+
+    def test_parse_streaming_unknown_then_known(self):
+        """Streaming: an unknown invoke is dropped, a following known invoke still parses."""
+        chunks = [
+            "<｜tool▁calls▁begin｜>",
+            "<｜tool▁call▁begin｜>function",
+            "<｜tool▁sep｜>undefined_func\n",
+            "```json\n",
+            '{"x": 1}\n```',
+            "<｜tool▁call▁end｜>",
+            "\n<｜tool▁call▁begin｜>function<｜tool▁sep｜>",
+            "get_weather\n```json\n",
+            '{"city": "Beijing"}\n',
+            "```<｜tool▁call▁end｜><｜tool▁calls▁end｜>",
+        ]
+
+        all_calls = []
+        for chunk in chunks:
+            r = self.detector.parse_streaming_increment(chunk, self.tools)
+            all_calls.extend(r.calls)
+
+        names = [c.name for c in all_calls if c.name]
+        self.assertEqual(
+            names,
+            ["get_weather"],
+            "Unknown invoke should be dropped while the following known invoke still parses",
+        )
+
 
 class TestDeepSeekV32Detector(unittest.TestCase):
     def setUp(self):
@@ -1631,6 +1700,86 @@ class TestDeepSeekV32Detector(unittest.TestCase):
         self.assertEqual(tool_calls_by_index[0]["name"], "get_date")
         params = json.loads(tool_calls_by_index[0]["parameters"])
         self.assertEqual(params, {})
+
+    def test_parse_streaming_unknown_function_skipped_by_default(self):
+        """Streaming: undefined function name is skipped by default and does not leak as a tool call."""
+        text = (
+            "<｜DSML｜function_calls>\n"
+            '<｜DSML｜invoke name="undefined_func">\n'
+            '<｜DSML｜parameter name="city" string="true">Shanghai</｜DSML｜parameter>\n'
+            "</｜DSML｜invoke>\n"
+            "</｜DSML｜function_calls>"
+        )
+
+        # Feed in 1-char chunks to exercise the streaming path.
+        all_calls = []
+        for ch in text:
+            r = self.detector.parse_streaming_increment(ch, self.tools)
+            all_calls.extend(r.calls)
+
+        self.assertEqual(all_calls, [], "Unknown function should be skipped by default")
+
+    def test_parse_streaming_unknown_function_forwarded_with_env(self):
+        """Streaming: SGLANG_FORWARD_UNKNOWN_TOOLS=1 forwards undefined functions to the client."""
+        text = (
+            "<｜DSML｜function_calls>\n"
+            '<｜DSML｜invoke name="undefined_func">\n'
+            '<｜DSML｜parameter name="city" string="true">Shanghai</｜DSML｜parameter>\n'
+            "</｜DSML｜invoke>\n"
+            "</｜DSML｜function_calls>"
+        )
+
+        with envs.SGLANG_FORWARD_UNKNOWN_TOOLS.override(True):
+            self.detector = DeepSeekV32Detector()
+            all_calls = []
+            for ch in text:
+                r = self.detector.parse_streaming_increment(ch, self.tools)
+                all_calls.extend(r.calls)
+
+        names = [c.name for c in all_calls if c.name]
+        self.assertEqual(
+            names, ["undefined_func"], "Unknown function should be forwarded as-is"
+        )
+
+    def test_parse_streaming_unknown_then_known(self):
+        """Streaming: an unknown invoke is dropped, a following known invoke still parses."""
+        text = (
+            "<｜DSML｜function_calls>\n"
+            '<｜DSML｜invoke name="undefined_func">\n'
+            '<｜DSML｜parameter name="city" string="true">Shanghai</｜DSML｜parameter>\n'
+            "</｜DSML｜invoke>\n"
+            '<｜DSML｜invoke name="search">\n'
+            '<｜DSML｜parameter name="query" string="true">food</｜DSML｜parameter>\n'
+            "</｜DSML｜invoke>\n"
+            "</｜DSML｜function_calls>"
+        )
+
+        all_calls = []
+        for ch in text:
+            r = self.detector.parse_streaming_increment(ch, self.tools)
+            all_calls.extend(r.calls)
+
+        names = [c.name for c in all_calls if c.name]
+        self.assertEqual(
+            names,
+            ["search"],
+            "Unknown invoke should be dropped while the following known invoke still parses",
+        )
+        # Reassemble streamed args for the surviving call to ensure correctness.
+        params_by_index = {}
+        for c in all_calls:
+            if c.tool_index is None:
+                continue
+            params_by_index.setdefault(c.tool_index, "")
+            if c.parameters:
+                params_by_index[c.tool_index] += c.parameters
+        # Exactly one tool slot was used and its arguments are valid JSON.
+        self.assertEqual(len(params_by_index), 1)
+        only_index = next(iter(params_by_index))
+        self.assertEqual(
+            json.loads(params_by_index[only_index]),
+            {"query": "food"},
+        )
 
 
 class TestQwen3CoderDetector(unittest.TestCase):


### PR DESCRIPTION
### Summary

The DeepSeek V3 / V3.1 / V3.2 streaming detectors override `parse_streaming_increment` and accidentally drop the function-name validation gate that the base class uses in both `parse_base_json` (non-streaming) and the JSON streaming path.

When a model emits a tool-call block whose name is not in the request's `tools` list, the streaming path:

- emits an OpenAI tool_call delta with the unknown name and a locally-scoped `tool_index`;
- signals `finish_reason=tool_calls` to the client.

Downstream Anthropic-style clients (e.g. Claude Code) then receive a `stop_reason=tool_use` response without a corresponding `tool_use` content block (their adapter drops the OpenAI tool_call delta because the name is not in the client's tool list), or worse, an OpenAI client receives a tool call it cannot dispatch.

This diverges from every other detector in the codebase (`pythonic`, `gpt_oss`, `mimo`, `internlm`, `glm4_moe`, `lfm2`, …) which honor the `SGLANG_FORWARD_UNKNOWN_TOOLS` env var contract:

- **default** — log a warning and skip the unknown invoke;
- `SGLANG_FORWARD_UNKNOWN_TOOLS=1` — forward as-is so the client can surface a recoverable error to the model. This matches Anthropic's official pattern: e.g. Claude Code's `runToolUse` injects a `tool_result` with `is_error=true` and the message `No such tool available: <name>` back into the conversation, which the model then self-corrects on.

### Changes

This PR adds the missing validation gate to all three detectors, matching the base class contract:

- **V3 / V3.1**: drop the buffered invoke; if the closing token is already in the buffer, advance past it so any trailing valid invoke can still parse.
- **V3.2**: skip the matched invoke and `continue` the outer loop so a following valid invoke in the same `<｜DSML｜function_calls>` block still parses normally.

The `_tool_indices` cache is built lazily in V3.2 (it was already lazy in V3 and V3.1), and the warning log message matches the existing base-class wording.

### Tests

Added 6 unit tests across `TestDeepSeekV3Detector` and `TestDeepSeekV32Detector`:

- `test_parse_streaming_unknown_function_skipped_by_default` — default behavior, unknown invoke produces zero tool calls.
- `test_parse_streaming_unknown_function_forwarded_with_env` — with `SGLANG_FORWARD_UNKNOWN_TOOLS=1`, unknown invoke is forwarded with name + arguments intact.
- `test_parse_streaming_unknown_then_known` — mixed-block case, the unknown invoke is dropped while a following valid invoke still parses cleanly with reassembled JSON arguments.

The mixed test exercises the buffer-advance logic (so a following valid invoke isn't blocked behind the dropped one) and tool-index reuse for the surviving call.

### Compatibility

- Default behavior change: previously, V3/V3.1/V3.2 streaming would forward unknown tool names; now they're skipped by default, which matches every other detector and the V3 detect_and_parse path.
- Users who want the old "forward" behavior can opt in with `SGLANG_FORWARD_UNKNOWN_TOOLS=1`.
- The non-streaming detect_and_parse path was already validating names via `parse_base_json` in the base class — only streaming was inconsistent.

### Repro context

End-to-end repro is straightforward: any Anthropic-style client whose registered tool set is a strict subset of what the model was trained to call (e.g. a stripped-down Claude Code build vs. the full Droid tool set) will trigger the symptom on a tool-eager prompt. The model emits a tool_call markup for a tool the client doesn't know about, the client's Anthropic adapter discards the unknown name, and the response shape becomes `stop_reason=tool_use` with no `tool_use` block — at which point the client either hangs or surfaces a "Stop reason: tool_use" error to the user.

