### PR TITLE
Fix mixed LoRA/no-LoRA CUDA graph replay for marlin

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -22,6 +22,7 @@ from sglang.srt.layers.attention.flashinfer_backend import (
     create_flashinfer_kv_indices_triton,
 )
 from sglang.srt.layers.dp_attention import get_attention_tp_size
+from sglang.srt.model_executor.cuda_graph_runner import get_capture_lora_variant
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.speculative.spec_info import SpecInput
@@ -285,6 +286,11 @@ class FlashInferMLAAttnBackend(AttentionBackend):
         self.decode_cuda_graph_metadata = {}
         self.prefill_cuda_graph_metadata = {}  # For verify
 
+    @staticmethod
+    def _cuda_graph_metadata_key(bs: int):
+        variant = get_capture_lora_variant()
+        return (bs, variant) if variant is not None else bs
+
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         if forward_batch.forward_mode.is_decode_or_idle():
             self.indices_updater_decode.update(
@@ -400,7 +406,9 @@ class FlashInferMLAAttnBackend(AttentionBackend):
                 init_metadata_replay=False,
                 spec_info=spec_info,
             )
-            self.decode_cuda_graph_metadata[bs] = decode_wrapper
+            self.decode_cuda_graph_metadata[self._cuda_graph_metadata_key(bs)] = (
+                decode_wrapper
+            )
             self.forward_metadata = DecodeMetadata(decode_wrapper)
             decode_wrapper.plan = partial(fast_mla_decode_plan, decode_wrapper)
         elif forward_mode.is_target_verify():
@@ -423,7 +431,9 @@ class FlashInferMLAAttnBackend(AttentionBackend):
                 use_ragged=False,
                 spec_info=spec_info,
             )
-            self.prefill_cuda_graph_metadata[bs] = verify_wrapper
+            self.prefill_cuda_graph_metadata[self._cuda_graph_metadata_key(bs)] = (
+                verify_wrapper
+            )
             self.forward_metadata = PrefillMetadata(verify_wrapper, False)
         elif forward_mode.is_draft_extend():
             draft_extend_wrapper = BatchMLAPagedAttentionWrapper(
@@ -445,7 +455,9 @@ class FlashInferMLAAttnBackend(AttentionBackend):
                 use_ragged=False,
                 spec_info=spec_info,
             )
-            self.prefill_cuda_graph_metadata[bs] = draft_extend_wrapper
+            self.prefill_cuda_graph_metadata[self._cuda_graph_metadata_key(bs)] = (
+                draft_extend_wrapper
+            )
             self.forward_metadata = PrefillMetadata(draft_extend_wrapper, False)
         else:
             raise ValueError(f"Invalid mode: {forward_mode=}")
@@ -479,7 +491,9 @@ class FlashInferMLAAttnBackend(AttentionBackend):
                 req_pool_indices[:bs],
                 seq_lens[:bs],
                 seq_lens_sum,
-                decode_wrapper=self.decode_cuda_graph_metadata[bs],
+                decode_wrapper=self.decode_cuda_graph_metadata[
+                    self._cuda_graph_metadata_key(bs)
+                ],
                 init_metadata_replay=True,
                 spec_info=spec_info,
                 **self.fast_decode_kwargs,
@@ -490,7 +504,9 @@ class FlashInferMLAAttnBackend(AttentionBackend):
                 seq_lens[:bs],
                 seq_lens_sum,
                 prefix_lens=None,
-                prefill_wrapper_paged=self.prefill_cuda_graph_metadata[bs],
+                prefill_wrapper_paged=self.prefill_cuda_graph_metadata[
+                    self._cuda_graph_metadata_key(bs)
+                ],
                 use_ragged=False,
                 spec_info=spec_info,
             )
@@ -500,7 +516,9 @@ class FlashInferMLAAttnBackend(AttentionBackend):
                 seq_lens[:bs],
                 seq_lens_sum,
                 prefix_lens=None,
-                prefill_wrapper_paged=self.prefill_cuda_graph_metadata[bs],
+                prefill_wrapper_paged=self.prefill_cuda_graph_metadata[
+                    self._cuda_graph_metadata_key(bs)
+                ],
                 use_ragged=False,
                 spec_info=spec_info,
             )

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -174,24 +174,26 @@ def initialize_moe_config(server_args: ServerArgs):
 
     MOE_A2A_BACKEND = MoeA2ABackend(server_args.moe_a2a_backend)
     MOE_RUNNER_BACKEND = MoeRunnerBackend(server_args.moe_runner_backend)
-    # Dual CUDA graphs only validated for triton MoE backends.
-    _triton_ok = MOE_RUNNER_BACKEND in (
+    # Dual CUDA graphs are validated for backends whose LoRA path can capture a
+    # no-op/no-LoRA variant without changing the base MoE dispatch contract.
+    _dual_graph_ok = MOE_RUNNER_BACKEND in (
         MoeRunnerBackend.TRITON,
         MoeRunnerBackend.TRITON_KERNELS,
+        MoeRunnerBackend.MARLIN,
     )
     if (
         bool(server_args.record_nolora_graph)
         and bool(server_args.enable_lora)
-        and not _triton_ok
+        and not _dual_graph_ok
     ):
         logger.warning(
-            f"record_nolora_graph only validated for triton MoE backend, "
+            f"record_nolora_graph only validated for triton/marlin MoE backends, "
             f"but moe_runner_backend={server_args.moe_runner_backend}. Disabling."
         )
     RECORD_NOLORA_GRAPH = (
         bool(server_args.record_nolora_graph)
         and bool(server_args.enable_lora)
-        and _triton_ok
+        and _dual_graph_ok
     )
     SPECULATIVE_MOE_RUNNER_BACKEND = (
         MoeRunnerBackend(server_args.speculative_moe_runner_backend)

--- a/python/sglang/srt/lora/lora_moe_runners.py
+++ b/python/sglang/srt/lora/lora_moe_runners.py
@@ -322,7 +322,13 @@ def _compute_token_lora_mapping(
         token_positions,
         right=True,
     )
-    return lora_info.req_to_lora.to(torch.int32)[req_indices]
+    token_lora_mapping = lora_info.req_to_lora.to(torch.int32)[req_indices]
+    token_lora_ranks = lora_info.lora_ranks[token_lora_mapping.long()]
+    return torch.where(
+        token_lora_ranks > 0,
+        token_lora_mapping,
+        torch.full_like(token_lora_mapping, -1),
+    )
 
 
 def _compute_lora_alignment(

--- a/python/sglang/srt/lora/triton_ops/virtual_experts.py
+++ b/python/sglang/srt/lora/triton_ops/virtual_experts.py
@@ -17,6 +17,7 @@ def _fused_virtual_topk_ids_kernel(
     virtual_topk_ids_ptr,
     token_lora_mask_ptr,
     num_experts_for_weight: tl.constexpr,
+    num_virtual_experts: tl.constexpr,
     M,
     top_k: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
@@ -28,10 +29,14 @@ def _fused_virtual_topk_ids_kernel(
         lora_id = token_lora_mapping[m]
         mask[m] = (lora_id >= 0)
         safe_lora = max(lora_id, 0)
-        if shared_outer:  (handled by num_experts_for_weight == 0 sentinel)
+        if shared_outer:
             virtual_topk_ids[m, k] = safe_lora * 1  (= safe_lora)
         else:
             virtual_topk_ids[m, k] = topk_ids[m, k] + safe_lora * num_experts_for_weight
+
+    For no-LoRA tokens, route to the extra sentinel bucket
+    (num_virtual_experts). The align helper maps that bucket to expert_id=-1,
+    so LoRA kernels skip those rows instead of running them through adapter 0.
     """
     pid = tl.program_id(0)
     offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
@@ -46,7 +51,11 @@ def _fused_virtual_topk_ids_kernel(
     safe_lora = tl.maximum(lora_id, 0)
 
     base = tl.load(topk_ids_ptr + offs, mask=valid, other=0)
-    result = base + safe_lora * num_experts_for_weight
+    result = tl.where(
+        mask_val,
+        base + safe_lora * num_experts_for_weight,
+        num_virtual_experts,
+    )
     tl.store(virtual_topk_ids_ptr + offs, result, mask=valid)
 
     # Write mask once per row (at first k position)
@@ -76,6 +85,7 @@ def _fused_virtual_topk_ids(
     else:
         num_experts_for_weight = num_experts
         input_topk = topk_ids
+    virtual_num_experts = num_experts_for_weight * max_loras
 
     virtual_topk_ids = torch.empty_like(topk_ids)
     token_lora_mask = torch.empty(M, dtype=torch.bool, device=device)
@@ -89,12 +99,12 @@ def _fused_virtual_topk_ids(
         virtual_topk_ids,
         token_lora_mask,
         num_experts_for_weight,
+        virtual_num_experts,
         M,
         top_k,
         BLOCK_SIZE,
     )
 
-    virtual_num_experts = num_experts_for_weight * max_loras
     return virtual_topk_ids, token_lora_mask, virtual_num_experts
 
 
@@ -140,6 +150,34 @@ def fused_sanitize_expert_ids(
     return output
 
 
+def _trim_num_tokens_post_padded_to_active_experts(
+    expert_ids: torch.Tensor,
+    num_tokens_post_padded: torch.Tensor,
+    block_size: int,
+) -> torch.Tensor:
+    """Exclude sentinel/tail blocks from the runtime LoRA GEMM extent.
+
+    No-LoRA tokens are routed to a sentinel bucket and then sanitized to
+    expert_id=-1. The fused MoE kernels can skip -1 blocks, but keeping those
+    blocks inside num_tokens_post_padded still makes CUDA graph replay execute
+    over no-op sentinel work. For Marlin mixed replay this can surface as an
+    illegal memory access, so bound the runtime extent to non-negative expert
+    blocks only.
+    """
+    block_indices = torch.arange(
+        expert_ids.numel(), device=expert_ids.device, dtype=torch.int32
+    )
+    active_num_blocks = torch.max(
+        torch.where(
+            expert_ids >= 0,
+            block_indices + 1,
+            torch.zeros_like(block_indices),
+        )
+    )
+    active_num_tokens = (active_num_blocks * block_size).reshape(1)
+    return torch.minimum(num_tokens_post_padded, active_num_tokens)
+
+
 @triton.jit
 def _moe_lora_shrink_splitk_kernel(
     # Pointers
@@ -181,6 +219,8 @@ def _moe_lora_shrink_splitk_kernel(
     num_pid_in_group = GROUP_SIZE_M * num_pid_n
     group_id = pid_mn // num_pid_in_group
     first_pid_m = group_id * GROUP_SIZE_M
+    if first_pid_m >= num_pid_m:
+        return
     group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
     pid_m = first_pid_m + ((pid_mn % num_pid_in_group) % group_size_m)
     pid_n = (pid_mn % num_pid_in_group) // group_size_m
@@ -303,8 +343,16 @@ def _align_block_size_torch(
     device = topk_ids.device
     flat_topk_ids = topk_ids.reshape(-1).to(torch.int64)
     num_valid_tokens = flat_topk_ids.numel()
+    # Reserve one extra bucket for no-LoRA tokens so their padded blocks can be
+    # sanitized to expert_id=-1 instead of being routed through adapter 0.
+    num_expert_buckets = num_experts + 1
     max_total_padded_tokens = (
-        (num_valid_tokens + num_experts * (block_size - 1) + block_size - 1)
+        (
+            num_valid_tokens
+            + num_expert_buckets * (block_size - 1)
+            + block_size
+            - 1
+        )
         // block_size
     ) * block_size
     max_num_blocks = max_total_padded_tokens // block_size
@@ -328,7 +376,7 @@ def _align_block_size_torch(
 
     sorted_order = torch.argsort(flat_topk_ids)
     sorted_expert_ids = flat_topk_ids[sorted_order]
-    expert_range = torch.arange(num_experts, device=device, dtype=torch.int64)
+    expert_range = torch.arange(num_expert_buckets, device=device, dtype=torch.int64)
     counts_offsets = torch.searchsorted(sorted_expert_ids, expert_range, right=False)
     counts_end = torch.searchsorted(sorted_expert_ids, expert_range, right=True)
     counts = counts_end - counts_offsets
@@ -493,7 +541,7 @@ def _merged_experts_fused_moe_lora_add_impl(
         # _align_block_size uses a worst-case padded allocation. Trim the routing buffers
         # to a tighter upper bound so we keep the real routed work but drop unused padding
         num_tokens = topk_ids.numel()
-        max_nonempty = min(num_tokens, virtual_num_experts)
+        max_nonempty = min(num_tokens, virtual_num_experts + 1)
         tight_padded = (
             triton.cdiv(num_tokens + max_nonempty * (block_size - 1), block_size)
             * block_size
@@ -501,6 +549,11 @@ def _merged_experts_fused_moe_lora_add_impl(
         sorted_token_ids = sorted_token_ids[:tight_padded]
         expert_ids = expert_ids[: tight_padded // block_size]
         expert_ids = fused_sanitize_expert_ids(expert_ids, virtual_num_experts)
+        num_tokens_post_padded = _trim_num_tokens_post_padded_to_active_experts(
+            expert_ids,
+            num_tokens_post_padded,
+            block_size,
+        )
         result = (
             sorted_token_ids,
             expert_ids,

--- a/python/sglang/srt/lora/triton_ops/virtual_experts.py
+++ b/python/sglang/srt/lora/triton_ops/virtual_experts.py
@@ -347,12 +347,7 @@ def _align_block_size_torch(
     # sanitized to expert_id=-1 instead of being routed through adapter 0.
     num_expert_buckets = num_experts + 1
     max_total_padded_tokens = (
-        (
-            num_valid_tokens
-            + num_expert_buckets * (block_size - 1)
-            + block_size
-            - 1
-        )
+        (num_valid_tokens + num_expert_buckets * (block_size - 1) + block_size - 1)
         // block_size
     ) * block_size
     max_num_blocks = max_total_padded_tokens // block_size


### PR DESCRIPTION
## Summary

Fix mixed LoRA/no-LoRA CUDA graph replay when `record_nolora_graph` is used with Marlin MoE and FlashInfer MLA.

The bug came from treating no-LoRA rows like adapter-0 rows in virtual-expert routing and from sharing FlashInfer MLA CUDA graph metadata between LoRA and no-LoRA captures for the same batch size.

## Changes

- Allow dual no-LoRA graph capture for the Marlin MoE backend.
- Map rank-0 adapters to inactive/no-LoRA token rows instead of adapter 0.
- Route no-LoRA virtual-expert rows through a sentinel bucket, sanitize sentinel blocks to `expert_id=-1`, and trim the runtime LoRA GEMM extent to active expert blocks.
- Key FlashInfer MLA CUDA graph metadata by `(batch_size, lora_variant)` during LoRA/no-LoRA graph capture.
- Guard the split-K shrink kernel against empty M-tile groups after sentinel trimming.

## Validation


Downstream validation in TML with Kimi K2.5 showed mixed LoRA/no-LoRA KL passing and no-LoRA graph throughput remaining faster than LoRA at bs512.
