### PR TITLE
[HiSparse][ROCm] Use TileLang NSA backend policy on HIP

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -233,6 +233,9 @@ NSA_CHOICES = [
     "trtllm",
 ]
 
+HISPARSE_CUDA_NSA_BACKENDS = ("flashmla_sparse",)
+HISPARSE_ROCM_NSA_BACKENDS = ("tilelang",)
+
 MAMBA_SCHEDULER_STRATEGY_CHOICES = ["auto", "no_buffer", "extra_buffer"]
 
 MAMBA_BACKEND_CHOICES = ["triton", "flashinfer"]
@@ -1581,14 +1584,14 @@ class ServerArgs:
         user_set_prefill = self.nsa_prefill_backend is not None
         user_set_decode = self.nsa_decode_backend is not None
 
-        # HiSparse requires flashmla_sparse for both prefill and decode
         if self.enable_hisparse:
+            backend = self._get_default_hisparse_nsa_backend()
             if not user_set_prefill:
-                self.nsa_prefill_backend = "flashmla_sparse"
+                self.nsa_prefill_backend = backend
             if not user_set_decode:
-                self.nsa_decode_backend = "flashmla_sparse"
+                self.nsa_decode_backend = backend
             logger.warning(
-                f"HiSparse enabled: using flashmla_sparse NSA backends "
+                f"HiSparse enabled: using {backend} NSA backends "
                 f"(prefill={self.nsa_prefill_backend}, decode={self.nsa_decode_backend})."
             )
             return
@@ -1625,6 +1628,27 @@ class ServerArgs:
         logger.warning(
             f"Set NSA backends for {self.kv_cache_dtype} KV Cache: prefill={self.nsa_prefill_backend}, decode={self.nsa_decode_backend}."
         )
+
+    def _get_default_hisparse_nsa_backend(self) -> str:
+        if is_hip():
+            return "tilelang"
+        return "flashmla_sparse"
+
+    def _get_supported_hisparse_nsa_backends(self) -> tuple[str, ...]:
+        if is_hip():
+            return HISPARSE_ROCM_NSA_BACKENDS
+        return HISPARSE_CUDA_NSA_BACKENDS
+
+    def _validate_hisparse_nsa_backend(self, attr: str, label: str):
+        backend = getattr(self, attr)
+        supported_backends = self._get_supported_hisparse_nsa_backends()
+        if backend is not None and backend not in supported_backends:
+            supported = ", ".join(supported_backends)
+            raise ValueError(
+                f"HiSparse supports NSA {label} backend(s) [{supported}] on this platform, "
+                f"but got --nsa-{label}-backend={backend}. "
+                f"Please use --nsa-{label}-backend={self._get_default_hisparse_nsa_backend()} or omit it."
+            )
 
     def _handle_model_specific_adjustments(self):
         from sglang.srt.configs.model_config import is_deepseek_nsa
@@ -6740,13 +6764,7 @@ class ServerArgs:
                 ("nsa_prefill_backend", "prefill"),
                 ("nsa_decode_backend", "decode"),
             ]:
-                backend = getattr(self, attr)
-                if backend is not None and backend != "flashmla_sparse":
-                    raise ValueError(
-                        f"HiSparse requires flashmla_sparse NSA {label} backend, "
-                        f"but got --nsa-{label}-backend={backend}. "
-                        f"Please use --nsa-{label}-backend=flashmla_sparse or omit it."
-                    )
+                self._validate_hisparse_nsa_backend(attr, label)
 
             if self.kv_cache_dtype != "bfloat16":
                 raise ValueError(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -235,6 +235,7 @@ NSA_CHOICES = [
 
 HISPARSE_CUDA_NSA_BACKENDS = ("flashmla_sparse",)
 HISPARSE_ROCM_NSA_BACKENDS = ("tilelang",)
+HISPARSE_KV_CACHE_DTYPES = ("bfloat16", "fp8_e4m3")
 
 MAMBA_SCHEDULER_STRATEGY_CHOICES = ["auto", "no_buffer", "extra_buffer"]
 
@@ -1649,6 +1650,18 @@ class ServerArgs:
                 f"but got --nsa-{label}-backend={backend}. "
                 f"Please use --nsa-{label}-backend={self._get_default_hisparse_nsa_backend()} or omit it."
             )
+
+    def _validate_hisparse_kv_cache_dtype(self):
+        if self.kv_cache_dtype in HISPARSE_KV_CACHE_DTYPES:
+            return
+
+        choices = " or ".join(
+            f"--kv-cache-dtype={dtype}" for dtype in HISPARSE_KV_CACHE_DTYPES
+        )
+        raise ValueError(
+            f"HiSparse requires one of {HISPARSE_KV_CACHE_DTYPES} KV cache dtypes, "
+            f"but got --kv-cache-dtype={self.kv_cache_dtype}. Please use {choices}."
+        )
 
     def _handle_model_specific_adjustments(self):
         from sglang.srt.configs.model_config import is_deepseek_nsa
@@ -6766,11 +6779,7 @@ class ServerArgs:
             ]:
                 self._validate_hisparse_nsa_backend(attr, label)
 
-            if self.kv_cache_dtype != "bfloat16":
-                raise ValueError(
-                    f"HiSparse requires bfloat16 KV cache, but got --kv-cache-dtype={self.kv_cache_dtype}. "
-                    f"Please use --kv-cache-dtype=bfloat16."
-                )
+            self._validate_hisparse_kv_cache_dtype()
 
         assert (
             self.schedule_conservativeness >= 0

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -104,6 +104,34 @@ class TestHiSparseNsaBackendPolicy(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, r"backend\(s\) \[flashmla_sparse\]"):
             server_args._validate_hisparse_nsa_backend("nsa_decode_backend", "decode")
 
+    def test_hisparse_accepts_bfloat16_kv_cache_dtype(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            enable_hisparse=True,
+            kv_cache_dtype="bfloat16",
+        )
+
+        server_args._validate_hisparse_kv_cache_dtype()
+
+    def test_hisparse_accepts_fp8_e4m3_kv_cache_dtype(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            enable_hisparse=True,
+            kv_cache_dtype="fp8_e4m3",
+        )
+
+        server_args._validate_hisparse_kv_cache_dtype()
+
+    def test_hisparse_rejects_unsupported_kv_cache_dtype(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            enable_hisparse=True,
+            kv_cache_dtype="float16",
+        )
+
+        with self.assertRaisesRegex(ValueError, r"fp8_e4m3"):
+            server_args._validate_hisparse_kv_cache_dtype()
+
 
 class TestPortArgs(unittest.TestCase):
     @patch("sglang.srt.server_args.get_free_port")

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -48,6 +48,67 @@ class TestLoadBalanceMethod(unittest.TestCase):
         self.assertEqual(server_args.load_balance_method, "round_robin")
 
 
+class TestHiSparseNsaBackendPolicy(unittest.TestCase):
+    @patch("sglang.srt.server_args.is_hip", return_value=False)
+    def test_hisparse_defaults_to_flashmla_sparse_on_cuda(self, _mock_is_hip):
+        server_args = ServerArgs(model_path="dummy", enable_hisparse=True)
+
+        server_args._set_default_nsa_backends(kv_cache_dtype="bfloat16", major=9)
+
+        self.assertEqual(server_args.nsa_prefill_backend, "flashmla_sparse")
+        self.assertEqual(server_args.nsa_decode_backend, "flashmla_sparse")
+
+    @patch("sglang.srt.server_args.is_hip", return_value=True)
+    def test_hisparse_defaults_to_tilelang_on_rocm(self, _mock_is_hip):
+        server_args = ServerArgs(model_path="dummy", enable_hisparse=True)
+
+        server_args._set_default_nsa_backends(kv_cache_dtype="bfloat16", major=9)
+
+        self.assertEqual(server_args.nsa_prefill_backend, "tilelang")
+        self.assertEqual(server_args.nsa_decode_backend, "tilelang")
+
+    @patch("sglang.srt.server_args.is_hip", return_value=True)
+    def test_hisparse_preserves_rocm_user_backend_and_defaults_missing_side(
+        self, _mock_is_hip
+    ):
+        server_args = ServerArgs(
+            model_path="dummy",
+            enable_hisparse=True,
+            nsa_prefill_backend="tilelang",
+        )
+
+        server_args._set_default_nsa_backends(kv_cache_dtype="bfloat16", major=9)
+
+        self.assertEqual(server_args.nsa_prefill_backend, "tilelang")
+        self.assertEqual(server_args.nsa_decode_backend, "tilelang")
+
+    @patch("sglang.srt.server_args.is_hip", return_value=True)
+    def test_hisparse_rejects_cuda_backend_on_rocm(self, _mock_is_hip):
+        server_args = ServerArgs(
+            model_path="dummy",
+            enable_hisparse=True,
+            nsa_prefill_backend="flashmla_sparse",
+        )
+
+        with self.assertRaisesRegex(ValueError, r"backend\(s\) \[tilelang\]"):
+            server_args._validate_hisparse_nsa_backend(
+                "nsa_prefill_backend", "prefill"
+            )
+
+    @patch("sglang.srt.server_args.is_hip", return_value=False)
+    def test_hisparse_rejects_rocm_backend_on_cuda(self, _mock_is_hip):
+        server_args = ServerArgs(
+            model_path="dummy",
+            enable_hisparse=True,
+            nsa_decode_backend="tilelang",
+        )
+
+        with self.assertRaisesRegex(ValueError, r"backend\(s\) \[flashmla_sparse\]"):
+            server_args._validate_hisparse_nsa_backend(
+                "nsa_decode_backend", "decode"
+            )
+
+
 class TestPortArgs(unittest.TestCase):
     @patch("sglang.srt.server_args.get_free_port")
     @patch("sglang.srt.server_args.tempfile.NamedTemporaryFile")

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -91,9 +91,7 @@ class TestHiSparseNsaBackendPolicy(unittest.TestCase):
         )
 
         with self.assertRaisesRegex(ValueError, r"backend\(s\) \[tilelang\]"):
-            server_args._validate_hisparse_nsa_backend(
-                "nsa_prefill_backend", "prefill"
-            )
+            server_args._validate_hisparse_nsa_backend("nsa_prefill_backend", "prefill")
 
     @patch("sglang.srt.server_args.is_hip", return_value=False)
     def test_hisparse_rejects_rocm_backend_on_cuda(self, _mock_is_hip):
@@ -104,9 +102,7 @@ class TestHiSparseNsaBackendPolicy(unittest.TestCase):
         )
 
         with self.assertRaisesRegex(ValueError, r"backend\(s\) \[flashmla_sparse\]"):
-            server_args._validate_hisparse_nsa_backend(
-                "nsa_decode_backend", "decode"
-            )
+            server_args._validate_hisparse_nsa_backend("nsa_decode_backend", "decode")
 
 
 class TestPortArgs(unittest.TestCase):


### PR DESCRIPTION
## Summary

This PR updates HiSparse NSA backend defaulting and validation so HIP/ROCm platforms use the ROCm NSA backend policy instead of the CUDA-only `flashmla_sparse` policy.

- Keep CUDA HiSparse behavior unchanged: default and validate `flashmla_sparse`.
- Default HiSparse on HIP/ROCm to `tilelang` for both NSA prefill and decode.
- Add platform-specific HiSparse NSA backend validation helpers.
- Allow HiSparse KV cache dtype `fp8_e4m3` in addition to `bfloat16`.
- Add unit coverage for CUDA/ROCm backend defaulting, backend validation, and HiSparse KV dtype validation.

## Scope

This remains the policy/validation groundwork PR. It does not include the HIP-compatible HiSparse JIT/kernel implementation or the MI300X resource-default tuning needed for full long-prompt serving.

Validated follow-up scope from the stacked PRs:

- GLM-5.1-FP8 on 8x MI300X, TP8, ROCm TileLang NSA, HiSparse, `--kv-cache-dtype fp8_e4m3`.
- Long-prompt serving passed up to 25,513 prompt tokens.
- 16-way concurrent completion batch passed.
- GSM8K 5-shot, 200-question accuracy passed: `0.955` vs GLM-5.1 threshold `0.93`.

Caveat: SGLang logs that FP8 KV scaling factors are not provided and defaults them to `1.0`; the accuracy signal passed despite that, so the FP8 KV claim should stay scoped to the validated GLM-5.1-FP8 ROCm/TileLang path for now.

Planned follow-ups:

1. HIP-compatible HiSparse JIT/kernel path.
2. ROCm HiSparse kernel/unit validation.
3. ROCm DSA end-to-end validation with HiSparse on GLM-5/GLM-5.1.
4. MI300X resource-default tuning for long-prompt serving.

## Testing

Tested in a nightly SGLang ROCm container on an 8x AMD Instinct MI350X server (`gfx950`, HIP 7.0):

```bash
python3 -m py_compile python/sglang/srt/server_args.py test/registered/unit/server_args/test_server_args.py
python3 -m pytest test/registered/unit/server_args/test_server_args.py -q
```

Result:

```text
42 passed, 5 warnings in 9.90s
```

Also verified the unmocked ROCm defaulting path on the same host:

```text
HiSparse enabled: using tilelang NSA backends (prefill=tilelang, decode=tilelang).
is_hip True
prefill tilelang
decode tilelang
```

And confirmed all 8 MI350X devices are visible to PyTorch/HIP.

Additional MI300X validation after adding FP8 KV dtype support:

```bash
PYTHONPATH=$PWD/python python3 -m py_compile python/sglang/srt/server_args.py test/registered/unit/server_args/test_server_args.py
PYTHONPATH=$PWD/python python3 -m pytest test/registered/unit/server_args/test_server_args.py -q
```

Result:

```text
45 passed, 5 warnings
```

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #25139934333](https://github.com/sgl-project/sglang/actions/runs/25139934333)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->