### PR TITLE
[HiSparse][ROCm] Add HIP JIT kernel fallback

### DIFF
--- a/python/sglang/jit_kernel/csrc/hisparse.cuh
+++ b/python/sglang/jit_kernel/csrc/hisparse.cuh
@@ -22,8 +22,8 @@ __device__ __forceinline__ int hash_slot(int32_t key, int hash_size) {
 }
 
 #ifdef USE_ROCM
-__device__ __forceinline__ void transfer_item_serial(
-    const void* __restrict__ src_addr, void* __restrict__ dst_addr, int64_t item_size_bytes) {
+__device__ __forceinline__ void
+transfer_item_serial(const void* __restrict__ src_addr, void* __restrict__ dst_addr, int64_t item_size_bytes) {
   const auto src = static_cast<const char*>(src_addr);
   auto dst = static_cast<char*>(dst_addr);
   for (int64_t i = 0; i < item_size_bytes; ++i) {

--- a/python/sglang/jit_kernel/csrc/hisparse.cuh
+++ b/python/sglang/jit_kernel/csrc/hisparse.cuh
@@ -6,7 +6,6 @@
 #include <dlpack/dlpack.h>
 #include <tvm/ffi/container/tensor.h>
 
-#include <cuda_runtime.h>
 #include <stdexcept>
 #include <stdint.h>
 #include <string>
@@ -22,6 +21,16 @@ __device__ __forceinline__ int hash_slot(int32_t key, int hash_size) {
   return ((uint32_t)key * 2654435761u) % (uint32_t)hash_size;
 }
 
+#ifdef USE_ROCM
+__device__ __forceinline__ void transfer_item_serial(
+    const void* __restrict__ src_addr, void* __restrict__ dst_addr, int64_t item_size_bytes) {
+  const auto src = static_cast<const char*>(src_addr);
+  auto dst = static_cast<char*>(dst_addr);
+  for (int64_t i = 0; i < item_size_bytes; ++i) {
+    dst[i] = src[i];
+  }
+}
+#else
 __device__ __forceinline__ void
 transfer_item_warp(int32_t lane_id, const void* src_addr, void* dst_addr, int64_t item_size_bytes) {
   // 128-bit bulk transfer via paired 64-bit loads (avoids alignment issues with uint4)
@@ -66,6 +75,7 @@ __device__ __forceinline__ int warp_inclusive_scan(int* s_data, int lane_id, int
   accumulator = __shfl_sync(0xffffffff, val, 31);
   return accumulator;
 }
+#endif
 
 // Shared memory size calculation for dynamic allocation.
 // Layout: int32_t region (4-byte aligned) followed by int16_t region (2-byte aligned).
@@ -145,6 +155,94 @@ __global__ void load_cache_to_device_buffer_kernel(
     return;
   }
 
+  const int newest_slot = HOT_BUFFER_SIZE;
+  const int32_t newest_token = seq_len - 1;
+
+#ifdef USE_ROCM
+  if (tid == 0) {
+    int16_t lru_slots_out[HOT_BUFFER_SIZE];
+    int total_hits = 0;
+    int total_evictable = 0;
+
+    for (int i = 0; i < HOT_BUFFER_SIZE; ++i) {
+      lru_slots_out[i] = -1;
+    }
+
+    // Mark hits, preserve hit order, and compact evictable slots from MRU to LRU.
+    for (int slot_idx = 0; slot_idx < HOT_BUFFER_SIZE; ++slot_idx) {
+      const int16_t buf_slot = req_lru_slots[slot_idx];
+      const int32_t buffer_token = (buf_slot >= 0) ? req_device_buffer_tokens[buf_slot] : -1;
+      bool is_hit = false;
+
+      if (buffer_token >= 0) {
+        for (int topk_idx = 0; topk_idx < NUM_TOP_K; ++topk_idx) {
+          if (req_top_k_tokens[topk_idx] == buffer_token) {
+            req_top_k_device_locs[topk_idx] = req_device_buffer_locs[buf_slot];
+            is_hit = true;
+            lru_slots_out[total_hits++] = buf_slot;
+          }
+        }
+      }
+
+      if (!is_hit && buf_slot >= 0) {
+        lru_slots_out[HOT_BUFFER_SIZE - 1 - total_evictable] = buf_slot;
+        ++total_evictable;
+      }
+    }
+
+    int total_misses = 0;
+    for (int topk_idx = 0; topk_idx < NUM_TOP_K; ++topk_idx) {
+      const int32_t token = req_top_k_tokens[topk_idx];
+      if (token == newest_token) {
+        req_top_k_device_locs[topk_idx] = req_device_buffer_locs[newest_slot];
+        continue;
+      }
+
+      bool is_hit = false;
+      for (int hit_idx = 0; hit_idx < total_hits; ++hit_idx) {
+        const int16_t hit_slot = lru_slots_out[hit_idx];
+        if (hit_slot >= 0 && req_device_buffer_tokens[hit_slot] == token) {
+          is_hit = true;
+          break;
+        }
+      }
+      if (is_hit) {
+        continue;
+      }
+
+      const int16_t evict_slot = lru_slots_out[HOT_BUFFER_SIZE - 1 - total_misses];
+      const int64_t src_loc = req_host_cache_locs[token];
+      const int64_t dst_loc = static_cast<int64_t>(req_device_buffer_locs[evict_slot]);
+
+      req_top_k_device_locs[topk_idx] = req_device_buffer_locs[evict_slot];
+      req_device_buffer_tokens[evict_slot] = token;
+
+      const auto src_k = static_cast<const char*>(host_cache_k) + src_loc * item_size_bytes;
+      auto dst_k = static_cast<char*>(device_buffer_k) + dst_loc * item_size_bytes;
+      transfer_item_serial(src_k, dst_k, item_size_bytes);
+
+      if constexpr (!IsMLA) {
+        const auto src_v = static_cast<const char*>(host_cache_v) + src_loc * item_size_bytes;
+        auto dst_v = static_cast<char*>(device_buffer_v) + dst_loc * item_size_bytes;
+        transfer_item_serial(src_v, dst_v, item_size_bytes);
+      }
+      ++total_misses;
+    }
+
+    total_evictable = HOT_BUFFER_SIZE - total_hits;
+    for (int i = 0; i < HOT_BUFFER_SIZE; ++i) {
+      if (i < total_misses) {
+        req_lru_slots[total_evictable - total_misses + i] = lru_slots_out[HOT_BUFFER_SIZE - 1 - i];
+      } else if (i < total_evictable) {
+        req_lru_slots[i - total_misses] = lru_slots_out[HOT_BUFFER_SIZE - 1 - i];
+      } else {
+        req_lru_slots[i] = lru_slots_out[i - total_evictable];
+      }
+    }
+  }
+  return;
+#else
+
   // Dynamic shared memory layout: int32_t arrays first, then int16_t arrays.
   extern __shared__ char smem_raw[];
   using Layout = SmemLayout<NUM_TOP_K, HOT_BUFFER_SIZE>;
@@ -182,9 +280,6 @@ __global__ void load_cache_to_device_buffer_kernel(
     s_evict_chunk_offset[i] = 0;
   }
   __syncthreads();
-
-  const int newest_slot = HOT_BUFFER_SIZE;
-  const int32_t newest_token = seq_len - 1;
 
   // Insert top-k tokens into shared-memory hash table.
   for (int i = tid; i < NUM_TOP_K; i += BLOCK_SIZE) {
@@ -372,6 +467,7 @@ __global__ void load_cache_to_device_buffer_kernel(
       transfer_item_warp(lane_id, src_v, dst_v, item_size_bytes);
     }
   }
+#endif
 }
 
 template <int BLOCK_SIZE, int NUM_TOP_K, int HOT_BUFFER_SIZE, bool IsMLA>
@@ -405,9 +501,11 @@ void load_cache_to_device_buffer(
   // the correct one is selected at runtime based on seq_lens dtype.
   auto launch = [&](auto kernel_fn, const auto* seq_lens_ptr) {
     constexpr size_t smem_bytes = SmemLayout<NUM_TOP_K, HOT_BUFFER_SIZE>::BYTES;
+#ifndef USE_ROCM
     if constexpr (smem_bytes > 48u * 1024u) {
       cudaFuncSetAttribute(kernel_fn, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_bytes);
     }
+#endif
     LaunchKernel(bs, BLOCK_SIZE, device, smem_bytes)(
         kernel_fn,
         static_cast<const int32_t*>(top_k_tokens.data_ptr()),

--- a/python/sglang/jit_kernel/tests/test_hisparse.py
+++ b/python/sglang/jit_kernel/tests/test_hisparse.py
@@ -5,8 +5,9 @@ import torch
 
 from sglang.jit_kernel.hisparse import load_cache_to_device_buffer_mla
 from sglang.srt.utils import is_cuda, is_hip, is_npu, is_xpu
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
+register_amd_ci(est_time=30, suite="stage-b-test-1-gpu-small-amd")
 register_cuda_ci(est_time=10, suite="stage-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -233,6 +233,9 @@ NSA_CHOICES = [
     "trtllm",
 ]
 
+HISPARSE_CUDA_NSA_BACKENDS = ("flashmla_sparse",)
+HISPARSE_ROCM_NSA_BACKENDS = ("tilelang",)
+
 MAMBA_SCHEDULER_STRATEGY_CHOICES = ["auto", "no_buffer", "extra_buffer"]
 
 MAMBA_BACKEND_CHOICES = ["triton", "flashinfer"]
@@ -1581,14 +1584,14 @@ class ServerArgs:
         user_set_prefill = self.nsa_prefill_backend is not None
         user_set_decode = self.nsa_decode_backend is not None
 
-        # HiSparse requires flashmla_sparse for both prefill and decode
         if self.enable_hisparse:
+            backend = self._get_default_hisparse_nsa_backend()
             if not user_set_prefill:
-                self.nsa_prefill_backend = "flashmla_sparse"
+                self.nsa_prefill_backend = backend
             if not user_set_decode:
-                self.nsa_decode_backend = "flashmla_sparse"
+                self.nsa_decode_backend = backend
             logger.warning(
-                f"HiSparse enabled: using flashmla_sparse NSA backends "
+                f"HiSparse enabled: using {backend} NSA backends "
                 f"(prefill={self.nsa_prefill_backend}, decode={self.nsa_decode_backend})."
             )
             return
@@ -1625,6 +1628,27 @@ class ServerArgs:
         logger.warning(
             f"Set NSA backends for {self.kv_cache_dtype} KV Cache: prefill={self.nsa_prefill_backend}, decode={self.nsa_decode_backend}."
         )
+
+    def _get_default_hisparse_nsa_backend(self) -> str:
+        if is_hip():
+            return "tilelang"
+        return "flashmla_sparse"
+
+    def _get_supported_hisparse_nsa_backends(self) -> tuple[str, ...]:
+        if is_hip():
+            return HISPARSE_ROCM_NSA_BACKENDS
+        return HISPARSE_CUDA_NSA_BACKENDS
+
+    def _validate_hisparse_nsa_backend(self, attr: str, label: str):
+        backend = getattr(self, attr)
+        supported_backends = self._get_supported_hisparse_nsa_backends()
+        if backend is not None and backend not in supported_backends:
+            supported = ", ".join(supported_backends)
+            raise ValueError(
+                f"HiSparse supports NSA {label} backend(s) [{supported}] on this platform, "
+                f"but got --nsa-{label}-backend={backend}. "
+                f"Please use --nsa-{label}-backend={self._get_default_hisparse_nsa_backend()} or omit it."
+            )
 
     def _handle_model_specific_adjustments(self):
         from sglang.srt.configs.model_config import is_deepseek_nsa
@@ -6740,13 +6764,7 @@ class ServerArgs:
                 ("nsa_prefill_backend", "prefill"),
                 ("nsa_decode_backend", "decode"),
             ]:
-                backend = getattr(self, attr)
-                if backend is not None and backend != "flashmla_sparse":
-                    raise ValueError(
-                        f"HiSparse requires flashmla_sparse NSA {label} backend, "
-                        f"but got --nsa-{label}-backend={backend}. "
-                        f"Please use --nsa-{label}-backend=flashmla_sparse or omit it."
-                    )
+                self._validate_hisparse_nsa_backend(attr, label)
 
             if self.kv_cache_dtype != "bfloat16":
                 raise ValueError(

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -48,6 +48,67 @@ class TestLoadBalanceMethod(unittest.TestCase):
         self.assertEqual(server_args.load_balance_method, "round_robin")
 
 
+class TestHiSparseNsaBackendPolicy(unittest.TestCase):
+    @patch("sglang.srt.server_args.is_hip", return_value=False)
+    def test_hisparse_defaults_to_flashmla_sparse_on_cuda(self, _mock_is_hip):
+        server_args = ServerArgs(model_path="dummy", enable_hisparse=True)
+
+        server_args._set_default_nsa_backends(kv_cache_dtype="bfloat16", major=9)
+
+        self.assertEqual(server_args.nsa_prefill_backend, "flashmla_sparse")
+        self.assertEqual(server_args.nsa_decode_backend, "flashmla_sparse")
+
+    @patch("sglang.srt.server_args.is_hip", return_value=True)
+    def test_hisparse_defaults_to_tilelang_on_rocm(self, _mock_is_hip):
+        server_args = ServerArgs(model_path="dummy", enable_hisparse=True)
+
+        server_args._set_default_nsa_backends(kv_cache_dtype="bfloat16", major=9)
+
+        self.assertEqual(server_args.nsa_prefill_backend, "tilelang")
+        self.assertEqual(server_args.nsa_decode_backend, "tilelang")
+
+    @patch("sglang.srt.server_args.is_hip", return_value=True)
+    def test_hisparse_preserves_rocm_user_backend_and_defaults_missing_side(
+        self, _mock_is_hip
+    ):
+        server_args = ServerArgs(
+            model_path="dummy",
+            enable_hisparse=True,
+            nsa_prefill_backend="tilelang",
+        )
+
+        server_args._set_default_nsa_backends(kv_cache_dtype="bfloat16", major=9)
+
+        self.assertEqual(server_args.nsa_prefill_backend, "tilelang")
+        self.assertEqual(server_args.nsa_decode_backend, "tilelang")
+
+    @patch("sglang.srt.server_args.is_hip", return_value=True)
+    def test_hisparse_rejects_cuda_backend_on_rocm(self, _mock_is_hip):
+        server_args = ServerArgs(
+            model_path="dummy",
+            enable_hisparse=True,
+            nsa_prefill_backend="flashmla_sparse",
+        )
+
+        with self.assertRaisesRegex(ValueError, r"backend\(s\) \[tilelang\]"):
+            server_args._validate_hisparse_nsa_backend(
+                "nsa_prefill_backend", "prefill"
+            )
+
+    @patch("sglang.srt.server_args.is_hip", return_value=False)
+    def test_hisparse_rejects_rocm_backend_on_cuda(self, _mock_is_hip):
+        server_args = ServerArgs(
+            model_path="dummy",
+            enable_hisparse=True,
+            nsa_decode_backend="tilelang",
+        )
+
+        with self.assertRaisesRegex(ValueError, r"backend\(s\) \[flashmla_sparse\]"):
+            server_args._validate_hisparse_nsa_backend(
+                "nsa_decode_backend", "decode"
+            )
+
+
 class TestPortArgs(unittest.TestCase):
     @patch("sglang.srt.server_args.get_free_port")
     @patch("sglang.srt.server_args.tempfile.NamedTemporaryFile")

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -91,9 +91,7 @@ class TestHiSparseNsaBackendPolicy(unittest.TestCase):
         )
 
         with self.assertRaisesRegex(ValueError, r"backend\(s\) \[tilelang\]"):
-            server_args._validate_hisparse_nsa_backend(
-                "nsa_prefill_backend", "prefill"
-            )
+            server_args._validate_hisparse_nsa_backend("nsa_prefill_backend", "prefill")
 
     @patch("sglang.srt.server_args.is_hip", return_value=False)
     def test_hisparse_rejects_rocm_backend_on_cuda(self, _mock_is_hip):
@@ -104,9 +102,7 @@ class TestHiSparseNsaBackendPolicy(unittest.TestCase):
         )
 
         with self.assertRaisesRegex(ValueError, r"backend\(s\) \[flashmla_sparse\]"):
-            server_args._validate_hisparse_nsa_backend(
-                "nsa_decode_backend", "decode"
-            )
+            server_args._validate_hisparse_nsa_backend("nsa_decode_backend", "decode")
 
 
 class TestPortArgs(unittest.TestCase):


### PR DESCRIPTION
## Summary

This PR adds a correctness-first HIP/ROCm path for the HiSparse JIT cache-loading kernel.

- Remove the direct `cuda_runtime.h` include and rely on the existing JIT `utils.cuh` CUDA/HIP abstraction.
- Keep the existing optimized CUDA warp/inline-PTX implementation under the non-ROCm path.
- Add a simple serial per-request HIP path for correctness on ROCm, avoiding wave32/wave64 assumptions and CUDA inline PTX while the optimized HIP implementation is developed.
- Skip `cudaFuncSetAttribute` on ROCm.
- Register the HiSparse JIT unit test in AMD CI.

## Scope

This is stacked on top of #23877, which updates HiSparse NSA backend policy so HIP selects `tilelang` instead of CUDA-only `flashmla_sparse`.

This PR is intentionally correctness-first. The HIP path is not yet optimized; performance tuning should follow after end-to-end ROCm HiSparse validation.

## Testing

Tested in a nightly SGLang ROCm container on an 8x AMD Instinct MI350X server (`gfx950`, HIP 7.0):

```bash
python3 -m pytest python/sglang/jit_kernel/tests/test_hisparse.py -q
python3 -m pytest test/registered/unit/server_args/test_server_args.py -q
python3 -m py_compile python/sglang/jit_kernel/hisparse.py python/sglang/jit_kernel/tests/test_hisparse.py
python3 - <<'PY'
from sglang.test.ci.ci_register import ut_parse_one_file
regs, has_main = ut_parse_one_file('python/sglang/jit_kernel/tests/test_hisparse.py')
assert any(r.backend.name == 'AMD' for r in regs)
assert has_main
PY
```

Results:

```text
python/sglang/jit_kernel/tests/test_hisparse.py: 5 passed
 test/registered/unit/server_args/test_server_args.py: 42 passed, 5 warnings
```

Ruff is not installed in this nightly container, so I could not run `ruff check` locally.

## Additional MI300X / FP8 KV Validation

The stacked HiSparse ROCm path was also validated on an 8x MI300X server with GLM-5.1-FP8, TP8, ROCm TileLang NSA, `--enable-hisparse`, and `--kv-cache-dtype fp8_e4m3`.

Relevant to this PR, the HiSparse JIT validation passed on MI300X:

```bash
PYTHONPATH=$PWD/python python3 -m pytest python/sglang/jit_kernel/tests/test_hisparse.py -q -s
```

Result:

```text
7 passed
```

The final stacked validation in #23970 passed long-prompt serving up to 25,513 prompt tokens, 16-way concurrent completion, and GSM8K 5-shot 200-question accuracy at `0.955` vs the GLM-5.1 threshold `0.93` while the runtime selected `torch.float8_e4m3fnuz` for FP8 KV cache.

Caveat: SGLang logs that FP8 KV scaling factors are not provided and defaults them to `1.0`; the accuracy signal passed despite that, so the FP8 KV support claim should stay scoped to the validated GLM-5.1-FP8 MI300X ROCm/TileLang path for now.

Local MI300X artifacts are saved under `/models/sglang_hisparse_mi300x_results_20260428T235702Z/`. 