### PR TITLE
fix: wrap static state restore in inference_mode

### DIFF
--- a/python/sglang/srt/managers/scheduler_update_weights_mixin.py
+++ b/python/sglang/srt/managers/scheduler_update_weights_mixin.py
@@ -259,6 +259,7 @@ def _export_static_state(model):
 
 
 def _import_static_state(model, static_params):
-    self_named_buffers = dict(model.named_buffers())
-    for name, tensor in static_params["buffers"]:
-        self_named_buffers[name][...] = tensor
+    with torch.inference_mode():
+        self_named_buffers = dict(model.named_buffers())
+        for name, tensor in static_params["buffers"]:
+            self_named_buffers[name][...] = tensor


### PR DESCRIPTION
## Summary
- Backport sgl-project/sglang#21035 to `sglang-miles`.
- Wrap `_import_static_state` in `torch.inference_mode()` so weight/static-buffer restore works for inference tensors during memory resume.

## Validation
- Command: `scripts/run_qwen3_5_35b_a3b_mtp_cp2_ep8.py --mode debug_minimal --hardware B300 --no-enable-spec --no-enable-eval --extra-args "--sglang-attention-backend flashinfer --sglang-moe-runner-backend flashinfer_cutlass --inprocess-max-iterations 1 --grpo-iterations 1 --save-interval 999999"`.
- Confirmed server args: `attention_backend='flashinfer'`, `moe_runner_backend='flashinfer_cutlass'`.
- `Update weights: 100%|...| 136/136` completed.
- `train/train_rollout_logprob_abs_diff = 0.015068798325955868` at step 0 (`< 0.02`).
- Stopped the run after the first passing train step.
