### PR TITLE
Support --model as alias for --model-path in CLI

### DIFF
--- a/python/sglang/cli/utils.py
+++ b/python/sglang/cli/utils.py
@@ -103,11 +103,11 @@ def get_model_path(extra_argv):
     # Find the model_path argument
     model_path = None
     for i, arg in enumerate(extra_argv):
-        if arg == "--model-path":
+        if arg in ("--model-path", "--model"):
             if i + 1 < len(extra_argv):
                 model_path = extra_argv[i + 1]
                 break
-        elif arg.startswith("--model-path="):
+        elif arg.startswith("--model-path=") or arg.startswith("--model="):
             model_path = arg.split("=", 1)[1]
             break
 


### PR DESCRIPTION
## Summary
- Accept `--model` as an alias for `--model-path` in the CLI argument parser