### PR TITLE
Fix running-req piling up when return_logprob is True

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2675,6 +2675,7 @@ class Scheduler(
                 reqs=[], batch_is_full=self.running_batch.batch_is_full
             )
         else:
+            self.running_batch.filter_batch(v1_spec_info_filtered=True)
             new_batch.decoding_reqs = None
 
         return new_batch


### PR DESCRIPTION
## Summary

Fixes #23177

When `return_logprob=True`, the mixed-chunk prefill code path in `get_new_batch_prefill()` takes the `else` branch (line 2677), which skips `self.running_batch.filter_batch()`. This means finished requests are never removed from `running_batch`, causing `#running-req` to grow monotonically without bound while `token usage` stays near 0.

The `if` branch (when `return_logprob=False`) correctly calls `filter_batch()` to clean up finished requests before resetting `running_batch`. The `else` branch was missing this call.

**The fix**: Add `self.running_batch.filter_batch(v1_spec_info_filtered=True)` to the `else` branch so finished requests are cleaned up regardless of `return_logprob`.

## Reproduction

Reproduced on 8×B200 with GLM-5.1-FP8 (TP=8), using the driver script from the issue (`concurrency=256, n_requests=14000, prompt_tokens=2500, max_new_tokens=1, return_logprob=True`).

- **Before fix**: `#running-req` grew from 0 to 991+ (monotonically increasing, never decreasing)
- **After fix**: `#running-req` stable at 12, all 14000 requests completed with 0 failures

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34827601286](https://github.com/sgl-project/sglang/actions/runs/34827601286)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34827601044](https://github.com/sgl-project/sglang/actions/runs/34827601044)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34827601215](https://github.com/sgl-project/sglang/actions/runs/34827601215)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->