### PR TITLE
fix: guard get_compile_mode/set_compile_mode for DeepGEMM < 2.4.2

### DIFF
--- a/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
@@ -196,12 +196,19 @@ def _compile_deep_gemm_one_type_all(
             kernel_type, max_m=max_m, n=n, k=k, num_groups=num_groups
         )
 
-        old_compile_mode = deep_gemm.get_compile_mode()
-        deep_gemm.set_compile_mode(1)
+        # get_compile_mode / set_compile_mode were added after DeepGEMM 2.4.2;
+        # guard so older images (e.g. lmsysorg/sglang:deepseek-v4-hopper) don't crash.
+        _has_compile_mode = hasattr(deep_gemm, "get_compile_mode") and hasattr(
+            deep_gemm, "set_compile_mode"
+        )
+        if _has_compile_mode:
+            old_compile_mode = deep_gemm.get_compile_mode()
+            deep_gemm.set_compile_mode(1)
         # TODO can use multi thread
         for m in tqdm(m_list, desc=f"DeepGEMM warmup"):
             executor.execute(m=m)
-        deep_gemm.set_compile_mode(old_compile_mode)
+        if _has_compile_mode:
+            deep_gemm.set_compile_mode(old_compile_mode)
 
         # clean up input buffers
         torch.cuda.current_stream().synchronize()


### PR DESCRIPTION
Fixes #23843

## Problem

`python3 -m sglang.compile_deep_gemm` crashes with `AttributeError: module 'deep_gemm' has no attribute 'get_compile_mode'` when using **DeepGEMM 2.4.2** (the version shipped in `lmsysorg/sglang:deepseek-v4-hopper`).

The APIs `get_compile_mode()` and `set_compile_mode()` were added to DeepGEMM after version 2.4.2, so environments pinned to that image cannot run the precompile step at all.

## Solution

Wrap the two calls with `hasattr` guards in `compile_utils.py`:

```python
_has_compile_mode = hasattr(deep_gemm, "get_compile_mode") and hasattr(
    deep_gemm, "set_compile_mode"
)
if _has_compile_mode:
    old_compile_mode = deep_gemm.get_compile_mode()
    deep_gemm.set_compile_mode(1)
for m in tqdm(m_list, desc=f"DeepGEMM warmup"):
    executor.execute(m=m)
if _has_compile_mode:
    deep_gemm.set_compile_mode(old_compile_mode)
```

When the APIs are absent the warmup loop runs normally; it just skips the compile-mode optimisation that was introduced in newer DeepGEMM releases. This keeps the precompile command functional across both old and new DeepGEMM versions.

## Testing

- Verified the change is backward-compatible: the `hasattr` path is taken when `get_compile_mode` / `set_compile_mode` are present (newer DeepGEMM), and skipped cleanly when they are absent (DeepGEMM 2.4.2).
- The logic of the warmup loop itself is unchanged.