### PR TITLE
[Bug Fix] Reject incompatible combination of --disable-cuda-graph-padding and --enable-torch-compile

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6626,6 +6626,14 @@ class ServerArgs:
             f"Got: {self.pp_max_micro_batch_size}"
         )
 
+        assert not (self.disable_cuda_graph_padding and self.enable_torch_compile), (
+            "--disable-cuda-graph-padding is incompatible with --enable-torch-compile. "
+            "With padding disabled, every distinct batch size gets its own torch.compile + "
+            "Triton autotune cycle (O(max_batch_size) compilations) instead of the small fixed "
+            "set of padded bucket sizes, causing engine initialisation to stall for many minutes. "
+            "Remove --disable-cuda-graph-padding or --enable-torch-compile."
+        )
+
         if self.pp_size > 1:
             assert (
                 self.disable_overlap_schedule and self.speculative_algorithm is None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fixes #23865.

When a user passes both `--disable-cuda-graph-padding` and `--enable-torch-compile` together, the engine never finishes initializing. It silently hangs for many minutes (or indefinitely on larger models) with no indication that anything is wrong.

The root cause is a batch size explosion in the CUDA/CPU graph capture step. With padding enabled, the capture list is a small fixed set of bucket sizes like `[1, 2, 4, 8, 12, 16, 24]`. With padding disabled, `_generate_cuda_graph_batch_sizes` and `_generate_cpu_graph_batch_sizes` both expand this to every integer from 1 up to `cuda_graph_max_bs` (for example, 1 through 24 or up to 160 on small GPUs). Because `CPUGraphRunner` runs a full `torch.compile` and Triton AUTOTUNE cycle for each batch size, the number of kernel benchmarks grows from roughly 28 (7 buckets x 4 matmul shapes) to hundreds or thousands. In the reproduction on an RTX 4090, the process was killed after 3 minutes while still at batch size 11 out of 24.

The two flags are also semantically incompatible at runtime. `--disable-cuda-graph-padding` means the server will route exact incoming batch sizes without rounding up. If those exact sizes were not pre-compiled, `torch.compile` would trigger a new compilation on the fly during request serving, causing latency spikes for real traffic.

## Modifications

- Added a validation check in `ServerArgs.check_server_args()` in `python/sglang/srt/server_args.py` that raises an `AssertionError` immediately at engine startup when both `--disable-cuda-graph-padding` and `--enable-torch-compile` are passed together.
- The error message explains the cause (O(max_batch_size) autotune explosion) and tells the user which flag to remove, so there is no silent hang and no confusion about what went wrong.
- No behavior change for any other flag combination.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
