### PR TITLE
Fix dsv4 self-closing invoke tags + accept reasoning_effort=max

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -541,12 +541,14 @@ class ChatCompletionRequest(BaseModel):
     )  # noqa
     return_hidden_states: bool = False
     return_routed_experts: bool = False
-    reasoning_effort: Optional[Literal["low", "medium", "high"]] = Field(
+    reasoning_effort: Optional[Literal["low", "medium", "high", "max"]] = Field(
         default="medium",
         description="Constrains effort on reasoning for reasoning models. "
-        "'low' is the least effort, 'high' is the most effort. Reducing reasoning effort can "
-        "result in faster responses and fewer tokens used on reasoning in a response. "
-        "Currently only supported for OpenAI models in the harmony path, i.e GPT-OSS models.",
+        "'low' is the least effort, 'high' is the most effort. Reducing reasoning "
+        "effort can result in faster responses and fewer tokens used on reasoning "
+        "in a response. 'max' is an sglang extension to the OpenAI schema for "
+        "models that expose a maximum-effort tier above 'high'; models that don't "
+        "support it treat it the same as 'high'.",
     )
     task: Optional[
         Literal["action", "query", "authority", "domain", "title", "read_url"]

--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -81,8 +81,13 @@ class DeepSeekV32Detector(BaseFormatDetector):
         self.function_calls_regex = (
             r"<｜DSML｜function_calls>(.*?)</｜DSML｜function_calls>"
         )
+        # Long-form `<｜DSML｜invoke name="x">...</｜DSML｜invoke>` and the
+        # self-closing `<｜DSML｜invoke name="x"/>` shape V4 emits for zero-arg
+        # tools. The `end` group is empty when the closer hasn't streamed in.
         self.invoke_regex = (
-            r'<｜DSML｜invoke\s+name="([^"]+)"\s*>(.*?)(</｜DSML｜invoke>|$)'
+            r'<｜DSML｜invoke\s+name="(?P<name>[^"]+)"\s*'
+            r"(?:(?P<self_close>/>)"
+            r"|>(?P<body>.*?)(?P<end>(?:</｜DSML｜invoke>|$)))"
         )
         self.prefix_parameter_end_call = ["</", "｜DSML｜", "parameter"]
         self.current_tool_id = -1
@@ -90,6 +95,20 @@ class DeepSeekV32Detector(BaseFormatDetector):
     def has_tool_call(self, text: str) -> bool:
         """Check if the text contains a deepseek v32 format tool call."""
         return self.bot_token in text or "<｜DSML｜invoke" in text
+
+    @staticmethod
+    def _unpack_invoke_match(m: "re.Match[str]") -> tuple[str, str, bool]:
+        """Returns (name, body, is_complete) for an invoke_regex match.
+
+        Self-closing invokes have empty body and are always complete.
+        Long-form bodies are always strings (possibly empty); they're
+        incomplete when matched against `$` because the closing tag
+        hasn't streamed in yet.
+        """
+        name = m.group("name").strip()
+        if m.group("self_close"):
+            return name, "", True
+        return name, m.group("body"), bool(m.group("end"))
 
     def _parse_parameters_from_xml(
         self, invoke_content: str, allow_partial: bool = False
@@ -191,14 +210,11 @@ class DeepSeekV32Detector(BaseFormatDetector):
             function_calls_content = function_calls_match.group(1)
 
             # Find all invoke blocks
-            invoke_matches = re.findall(
+            for invoke_match in re.finditer(
                 self.invoke_regex, function_calls_content, re.DOTALL
-            )
-
-            for func_name, invoke_content, _ in invoke_matches:
-                # Parse parameters from XML format
+            ):
+                func_name, invoke_content, _ = self._unpack_invoke_match(invoke_match)
                 func_args = self._parse_parameters_from_xml(invoke_content)
-                # construct match_result for parse_base_json
                 match_result = {"name": func_name, "parameters": func_args}
                 calls.extend(self.parse_base_json(match_result, tools))
 
@@ -253,10 +269,9 @@ class DeepSeekV32Detector(BaseFormatDetector):
                 if not invoke_match:
                     break
 
-                func_name = invoke_match.group(1).strip()
-                invoke_content = invoke_match.group(2)
-                # group(3) is either "</｜DSML｜invoke>" (complete) or "" (incomplete, matched with $)
-                is_tool_end = bool(invoke_match.group(3))
+                func_name, invoke_content, is_tool_end = self._unpack_invoke_match(
+                    invoke_match
+                )
 
                 # Initialize state if this is the first tool call
                 if self.current_tool_id == -1:

--- a/test/registered/function_call/test_function_call_parser.py
+++ b/test/registered/function_call/test_function_call_parser.py
@@ -1613,6 +1613,26 @@ class TestDeepSeekV32Detector(unittest.TestCase):
         params = json.loads(tool_calls_by_index[0]["parameters"])
         self.assertEqual(params, {})
 
+    def test_self_closing_zero_arg_invoke(self):
+        """V32 inherits the same regex; verify self-closing parses to empty
+        params here too (V32 model rarely emits this shape, but the parser
+        must agree with V4 since V4 inherits from V32)."""
+        submit_tool = Tool(
+            type="function",
+            function=Function(
+                name="submit",
+                parameters={"type": "object", "properties": {}},
+            ),
+        )
+        text = (
+            '<｜DSML｜function_calls>\n<｜DSML｜invoke name="submit"/>\n'
+            "</｜DSML｜function_calls>"
+        )
+        result = self.detector.detect_and_parse(text, [submit_tool])
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "submit")
+        self.assertEqual(json.loads(result.calls[0].parameters), {})
+
 
 class TestDeepSeekV4Detector(unittest.TestCase):
     """DeepSeek V4 DSML tool-call tests.
@@ -1889,6 +1909,96 @@ class TestDeepSeekV4Detector(unittest.TestCase):
         self.assertEqual(tool_calls_by_index[0]["name"], "get_date")
         params = json.loads(tool_calls_by_index[0]["parameters"])
         self.assertEqual(params, {})
+
+    def test_self_closing_zero_arg_invoke(self):
+        """V4 emits `<｜DSML｜invoke name="x"/>` for zero-arg tools; the
+        detector must parse it as a complete tool call with empty params
+        instead of leaking the raw markup back into normal_text."""
+        submit_tool = Tool(
+            type="function",
+            function=Function(
+                name="submit",
+                description="Submit the final answer.",
+                parameters={"type": "object", "properties": {}},
+            ),
+        )
+
+        text = (
+            "Final answer.\n"
+            '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="submit"/>\n'
+            "</｜DSML｜tool_calls>"
+        )
+        result = self.detector.detect_and_parse(text, [submit_tool])
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "submit")
+        self.assertEqual(json.loads(result.calls[0].parameters), {})
+        self.assertNotIn("DSML", result.normal_text)
+
+    def test_self_closing_mixed_with_long_form(self):
+        """Mix of long-form (with params) and self-closing tags in one block."""
+        submit_tool = Tool(
+            type="function",
+            function=Function(
+                name="submit",
+                parameters={"type": "object", "properties": {}},
+            ),
+        )
+        text = (
+            "<｜DSML｜tool_calls>\n"
+            '<｜DSML｜invoke name="get_favorite_tourist_spot">\n'
+            '<｜DSML｜parameter name="city" string="true">SF</｜DSML｜parameter>\n'
+            "</｜DSML｜invoke>\n"
+            '<｜DSML｜invoke name="submit"/>\n'
+            "</｜DSML｜tool_calls>"
+        )
+        result = self.detector.detect_and_parse(text, self.tools + [submit_tool])
+        self.assertEqual(len(result.calls), 2)
+        self.assertEqual(result.calls[0].name, "get_favorite_tourist_spot")
+        self.assertEqual(json.loads(result.calls[0].parameters), {"city": "SF"})
+        self.assertEqual(result.calls[1].name, "submit")
+        self.assertEqual(json.loads(result.calls[1].parameters), {})
+
+    def test_streaming_self_closing_invoke(self):
+        """Self-closing invoke must terminate cleanly even when `/>` arrives
+        after the `name=` attribute crosses chunk boundaries."""
+        submit_tool = Tool(
+            type="function",
+            function=Function(
+                name="submit",
+                parameters={"type": "object", "properties": {}},
+            ),
+        )
+        # Build the prompt and feed it through the tokenizer to exercise the
+        # same chunk shapes the runtime sees.
+        text = (
+            "<｜DSML｜tool_calls>\n"
+            '<｜DSML｜invoke name="submit"/>\n'
+            "</｜DSML｜tool_calls>"
+        )
+        self.detector = DeepSeekV4Detector()
+        input_ids = self.tokenizer.encode(text, add_special_tokens=False)
+        chunks = [
+            self.tokenizer.decode(input_ids[i : i + self.interval])
+            for i in range(0, len(input_ids), self.interval)
+        ]
+
+        tool_calls_by_index = {}
+        for chunk in chunks:
+            result = self.detector.parse_streaming_increment(chunk, [submit_tool])
+            for call in result.calls:
+                if call.tool_index is None:
+                    continue
+                slot = tool_calls_by_index.setdefault(
+                    call.tool_index, {"name": "", "parameters": ""}
+                )
+                if call.name:
+                    slot["name"] = call.name
+                if call.parameters:
+                    slot["parameters"] += call.parameters
+
+        self.assertEqual(len(tool_calls_by_index), 1)
+        self.assertEqual(tool_calls_by_index[0]["name"], "submit")
+        self.assertEqual(json.loads(tool_calls_by_index[0]["parameters"]), {})
 
 
 class TestQwen3CoderDetector(unittest.TestCase):

--- a/test/registered/openai_server/basic/test_protocol.py
+++ b/test/registered/openai_server/basic/test_protocol.py
@@ -192,6 +192,37 @@ class TestChatCompletionRequest(unittest.TestCase):
         self.assertEqual(request.reasoning_effort, "high")
         self.assertEqual(request.chat_template_kwargs, {"thinking": True})
 
+    def test_chat_completion_reasoning_effort_max(self):
+        """`max` is an sglang extension on chat completion's top-level
+        `reasoning_effort` only; the Responses-API-style nested
+        `reasoning.effort` path stays aligned with OpenAI's three levels."""
+        from pydantic import ValidationError
+
+        messages = [{"role": "user", "content": "Hello"}]
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=messages,
+            reasoning_effort="max",
+        )
+        self.assertEqual(request.reasoning_effort, "max")
+
+        # Unknown values still rejected.
+        with self.assertRaises(ValidationError):
+            ChatCompletionRequest(
+                model="test-model",
+                messages=messages,
+                reasoning_effort="ultra",
+            )
+
+        # Nested reasoning.effort=max is NOT promoted by normalize_reasoning_inputs:
+        # the Responses API path keeps the OpenAI low/medium/high contract.
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=messages,
+            reasoning={"effort": "max"},
+        )
+        self.assertNotEqual(request.reasoning_effort, "max")
+
     def test_chat_completion_json_format(self):
         """Test chat completion json format"""
         transcript = "Good morning! It's 7:00 AM, and I'm just waking up. Today is going to be a busy day, "


### PR DESCRIPTION
Two small dsv4 OpenAI-compat fixes that the V4 deployment hit recently. Bundled because they're both schema/parser gaps surfaced by the same model.

## 1. Self-closing invoke tag is parsed as a complete tool call

DeepSeek-V4 occasionally emits a self-closing invoke tag for zero-arg tools:

```xml
<｜DSML｜tool_calls>
<｜DSML｜invoke name="submit"/>
</｜DSML｜tool_calls>
```

`DeepSeekV32Detector.invoke_regex` (which `DeepSeekV4Detector` inherits unchanged) only matches the long form `<｜DSML｜invoke name="x">...</｜DSML｜invoke>`, so the self-closing shape falls through both `detect_and_parse` and `parse_streaming_increment`. Result: raw DSML markup leaks into assistant `content` with `tool_calls: null`.

Reported on SWE-bench Verified at ~5% of trials (50 / 466), 100% on the parameterless `submit` tool. Patched image dropped leak rate to 0/500.

### Changes

- `invoke_regex` rewritten with named groups so the alternation is self-documenting:
  ```python
  r'<｜DSML｜invoke\s+name="(?P<name>[^"]+)"\s*'
  r'(?:(?P<self_close>/>)'
  r'|>(?P<body>.*?)(?P<end>(?:</｜DSML｜invoke>|$)))'
  ```
- New `_unpack_invoke_match(m) -> (name, body, is_complete)` static helper used by both `detect_and_parse` and `parse_streaming_increment`.
- `detect_and_parse` switched `findall` -> `finditer` (Match objects + named groups).

V32 inherits the same regex; the parser change applies there too. V32 models rarely emit this shape in practice (this is why the bug was V4-specific in the wild), but keeping the parsers in lockstep avoids surprises and matches V4's inheritance contract.

## 2. `reasoning_effort="max"` accepted on chat completions

`encoding_dsv4.encode_messages` already honors `reasoning_effort="max"` for thinking-mode prompts, but `ChatCompletionRequest.reasoning_effort` was `Literal["low", "medium", "high"]`, so callers had to smuggle the value through `chat_template_kwargs.reasoning_effort` to bypass Pydantic. Extending the literal lets V4 users hit the top-level field directly.

### Changes

- `ChatCompletionRequest.reasoning_effort` literal now includes `"max"`.
- Description updated to reflect that `"max"` is an sglang extension to the OpenAI schema for models with a maximum-effort tier above `"high"`; models that don't support it treat it the same as `"high"`.

### Intentionally NOT changed

- `ResponseReasoningParam.effort` (the `/v1/responses` endpoint) stays at `Literal["low", "medium", "high"]`. `"max"` is a chat-completion-only extension.
- The nested `reasoning.effort` normalizer in `ChatCompletionRequest.normalize_reasoning_inputs` still only promotes `low`/`medium`/`high` -- callers that want `"max"` use the top-level `reasoning_effort` field.

## Out of scope (separate follow-up)

`encoding_dsv4.parse_tool_calls` / `encoding_dsv32.parse_tool_calls` (used by the offline `parse_message_from_completion_text`) hardcode `>\n` after the invoke open tag and would also fail on self-closing. They aren't on the serving hot path, so I left them for a follow-up.

## Test plan

- [x] `test_self_closing_zero_arg_invoke` (V4 + V32) - non-streaming parse with self-closing tag
- [x] `test_self_closing_mixed_with_long_form` (V4) - long-form-with-params + self-closing in one tool_calls block
- [x] `test_streaming_self_closing_invoke` (V4) - char-by-char streaming via the V3.2 tokenizer
- [x] `test_chat_completion_reasoning_effort_max` - top-level field accepts `"max"`; nested `reasoning.effort="max"` does NOT promote (asymmetry locked in)
- [x] All existing V32 / V4 detector tests still pass (12 prior + 4 new = 16/16)
- [x] All existing protocol tests still pass (17 prior + 1 new = 18/18)
- [x] `pre-commit run` clean
