### PR TITLE
chore(codeowners): add @kpham-sgl as owner for gemma4 files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -78,10 +78,7 @@
 /test/srt/test_modelopt* @Edwardf0t1
 /python/sglang/srt/layers/gemma4_fused_ops.py @merrymercy @Ying1123 @Fridge003 @ispobock @HaiShaw @ch-wan @BBuf @Edwardf0t1 @kpham-sgl
 /python/sglang/srt/function_call/gemma4_detector.py @CatherineSue @JustinTong0323 @kpham-sgl
-/python/sglang/srt/models/gemma4_audio.py @kpham-sgl
-/python/sglang/srt/models/gemma4_causal.py @kpham-sgl
-/python/sglang/srt/models/gemma4_mm.py @kpham-sgl
-/python/sglang/srt/models/gemma4_vision.py @kpham-sgl
+/python/sglang/srt/models/gemma4_*.py @kpham-sgl
 /python/sglang/srt/multimodal/processors/gemma4.py @mickqian @JustinTong0323 @yhyang201 @yuan-luo @kpham-sgl
 /docs_new/cookbook/autoregressive/Google/Gemma4.mdx @wisclmy0611 @zijiexia @Richardczl98 @kpham-sgl
 /docs_new/src/snippets/autoregressive/gemma4-deployment.jsx @wisclmy0611 @zijiexia @Richardczl98 @kpham-sgl

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -76,3 +76,12 @@
 /benchmark/prefill_only/bench_score.py @sundar24295s @chanh @fortunecookiee
 /test/srt/ascend @ping1jing2 @iforgetmyname
 /test/srt/test_modelopt* @Edwardf0t1
+/python/sglang/srt/layers/gemma4_fused_ops.py @merrymercy @Ying1123 @Fridge003 @ispobock @HaiShaw @ch-wan @BBuf @Edwardf0t1 @kpham-sgl
+/python/sglang/srt/function_call/gemma4_detector.py @CatherineSue @JustinTong0323 @kpham-sgl
+/python/sglang/srt/models/gemma4_audio.py @kpham-sgl
+/python/sglang/srt/models/gemma4_causal.py @kpham-sgl
+/python/sglang/srt/models/gemma4_mm.py @kpham-sgl
+/python/sglang/srt/models/gemma4_vision.py @kpham-sgl
+/python/sglang/srt/multimodal/processors/gemma4.py @mickqian @JustinTong0323 @yhyang201 @yuan-luo @kpham-sgl
+/docs_new/cookbook/autoregressive/Google/Gemma4.mdx @wisclmy0611 @zijiexia @Richardczl98 @kpham-sgl
+/docs_new/src/snippets/autoregressive/gemma4-deployment.jsx @wisclmy0611 @zijiexia @Richardczl98 @kpham-sgl


### PR DESCRIPTION
## Summary
- Add `@kpham-sgl` as a CODEOWNER for all gemma4 files (model variants, fused ops, function-call detector, multimodal processor, and Gemma4 docs).
- Existing directory-level owners are preserved on every overlapping path.

## Files now covered
- `python/sglang/srt/layers/gemma4_fused_ops.py`
- `python/sglang/srt/function_call/gemma4_detector.py`
- `python/sglang/srt/models/gemma4_{audio,causal,mm,vision}.py`
- `python/sglang/srt/multimodal/processors/gemma4.py`
- `docs_new/cookbook/autoregressive/Google/Gemma4.mdx`
- `docs_new/src/snippets/autoregressive/gemma4-deployment.jsx`

## Test plan
- [ ] CI lint of `.github/CODEOWNERS` passes
- [ ] GitHub recognizes the new ownership rules on a follow-up PR touching a gemma4 file

🤖 Generated with [Claude Code](https://claude.com/claude-code)