### PR TITLE
jit_kernel/deepseek_v4: replace BF16->FP32 cuBLAS JIT with torch.mm

### DIFF
--- a/python/sglang/jit_kernel/deepseek_v4.py
+++ b/python/sglang/jit_kernel/deepseek_v4.py
@@ -1168,65 +1168,6 @@ def rmsnorm_self(q: torch.Tensor, eps: float) -> torch.Tensor:
     return out
 
 
-@cache_once
-def _jit_torch_cublas_bf16_fp32() -> Any:
-    import torch.utils.cpp_extension
-
-    source = """
-#include <torch/extension.h>
-#include <ATen/cuda/CUDAContext.h>
-#include <cublas_v2.h>
-
-torch::Tensor linear_bf16_fp32(
-    torch::Tensor X,
-    torch::Tensor W)
-{
-    int batch = X.size(0);
-    int in_features = X.size(1);
-    int out_features = W.size(0);
-
-    auto Y = torch::empty(
-        {batch, out_features},
-        torch::dtype(torch::kFloat32).device(X.device()));
-
-    cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
-
-    float alpha = 1.0f;
-    float beta = 0.0f;
-
-    cublasGemmEx(
-        handle,
-        CUBLAS_OP_T,
-        CUBLAS_OP_N,
-        out_features,
-        batch,
-        in_features,
-        &alpha,
-        W.data_ptr(), CUDA_R_16BF, in_features,
-        X.data_ptr(), CUDA_R_16BF, in_features,
-        &beta,
-        Y.data_ptr(), CUDA_R_32F, out_features,
-        CUBLAS_COMPUTE_32F,
-        CUBLAS_GEMM_DEFAULT_TENSOR_OP
-    );
-
-    return Y;
-}
-
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-  m.def("linear_bf16_fp32", &linear_bf16_fp32, "BF16xBF16 -> FP32 linear (no bias)");
-}
-"""
-    module = torch.utils.cpp_extension.load_inline(
-        name="linear_bf16_fp32",
-        cpp_sources="",
-        cuda_sources=source,
-        extra_cflags=["-O3"],
-        extra_cuda_cflags=["-O3"],
-        verbose=False,
-    )
-    return module
-
 
 def linear_bf16_fp32(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     from sglang.srt.environ import envs
@@ -1245,8 +1186,9 @@ def _dispatch_bf16_fp32_backend(
     x: torch.Tensor, y: torch.Tensor, *, algo: str
 ) -> torch.Tensor:
     if algo == "cublas":
-        module = _jit_torch_cublas_bf16_fp32()
-        return module.linear_bf16_fp32(x, y)
+        # cuBLAS BF16xBF16 -> FP32 GEMM via PyTorch native API (torch >= 2.9).
+        # Bit-exact and matches the previous JIT cublasGemmEx kernel.
+        return torch.mm(x, y.t(), out_dtype=torch.float32)
     elif algo == "deep_gemm":
         import deep_gemm
 
@@ -1267,7 +1209,6 @@ def _compile_one(*input_tuple) -> None:
 def compile_aot():
     c_dtype = torch.float32
     jobs = [
-        ("cublas", _jit_torch_cublas_bf16_fp32),
         ("common", _jit_common_module),
         ("mask_topk", _jit_mask_topk_module),
         ("topk", _jit_topk_module),


### PR DESCRIPTION
## Motivation

Use the PyTorch-native `torch.mm(input, mat2, out_dtype=torch.float32)` API for the BF16-input / FP32-output GEMM, instead of the hand-written JIT `cublasGemmEx` kernel.

The JIT kernel was the right thing to ship before this `out_dtype` overload landed. PyTorch 2.9 (which `python/pyproject.toml` already pins via `"torch==2.9.1"`) lowers `torch.mm(bf16, bf16, out_dtype=torch.float32)` directly to the same cuBLAS `gemmEx` path, so the JIT no longer adds anything — it just costs ~74 s of `nvcc` compile on cold start, an inline-CUDA blob, and a `compile_aot()` entry.

## Change

`python/sglang/jit_kernel/deepseek_v4.py`:

- Replace the `algo == "cublas"` branch in `_dispatch_bf16_fp32_backend` with `torch.mm(x, y.t(), out_dtype=torch.float32)`.
- Delete `_jit_torch_cublas_bf16_fp32()` (the `@cache_once` `load_inline` block).
- Remove the corresponding `("cublas", _jit_torch_cublas_bf16_fp32)` entry from `compile_aot()`.

`deep_gemm` and the python-fallback branches are kept untouched. Net diff: **+4 / -62**.

## Verification

Built the same JIT kernel inline (verbatim source from this branch's parent commit) and compared head-to-head against `torch.mm(out_dtype=torch.float32)`. Tested on **B200** (`lmsysorg/sglang:deepseek-v4-blackwell` image, GCP a4 partition) and **H100** (`lmsysorg/sglang:deepseek-v4-hopper` image, single GPU). Both: `torch==2.9.1+cu129`, CUDA 12.9.

### 1. Accuracy — bit-exact on every shape, both GPUs

`torch.equal(jit_out, mm_out) == True`, max abs diff = `0.0` for all M ∈ {1,2,4,8,16,32,64,128,256,512,1024,2048,4096,8192,16384} (with N=1024 K=4096), and for the additional shapes (256/1024/4096/8192, 4096, 4096), (256/1024/4096, 8192, 4096). Both implementations also produce the same residual against an FP32 reference.

| (M, N, K)            | max abs diff (pair) | bit-exact (B200) | bit-exact (H100) |
| -------------------- | ------------------- | :--------------: | :--------------: |
| (1, 1024, 4096)      | 0.000e+00           |        ✓         |        ✓         |
| (256, 1024, 4096)    | 0.000e+00           |        ✓         |        ✓         |
| (4096, 1024, 4096)   | 0.000e+00           |        ✓         |        ✓         |
| (16384, 1024, 4096)  | 0.000e+00           |        ✓         |        ✓         |
| (4096, 4096, 4096)   | 0.000e+00           |        ✓         |        ✓         |
| (4096, 8192, 4096)   | 0.000e+00           |        ✓         |        ✓         |

This confirms `torch.mm(out_dtype=fp32)` dispatches into the **same** cuBLAS routine with the same algo selection as `cublasGemmEx(... CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT_TENSOR_OP)`.

### 2. Performance — focus on **CUDA Graph** numbers (kernel-only, no Python overhead)

CUDA Graph capture replays 8 ops per graph × 2000 graphs = **16 000 timed kernel invocations per cell**, eliminating eager-mode Python dispatcher / driver-launch overhead so we measure the kernel itself.

**B200 — reference shape `[M, 4096] × [1024, 4096]ᵀ` → `[M, 1024]`**

|     M | JIT graph (µs) | mm graph (µs) | Δ (mm − JIT) |
| ----: | -------------: | ------------: | -----------: |
|     1 |       **7.42** |      **7.42** |    **+0.00** |
|    32 |       **7.42** |      **7.42** |    **+0.00** |
|    64 |       **7.43** |      **7.43** |    **+0.00** |
|   128 |       **7.69** |      **7.69** |    **+0.00** |
|   256 |           7.69 |          7.68 |        −0.01 |
|  1024 |          10.40 |         10.57 |        +0.17 |
|  4096 |          28.75 |         28.90 |        +0.15 |
|  8192 |          59.16 |         58.73 |        −0.43 |
| 16384 |         112.30 |        112.32 |        +0.02 |

**H100 — same shape**

|     M | JIT graph (µs) | mm graph (µs) | Δ (mm − JIT) |
| ----: | -------------: | ------------: | -----------: |
|     1 |       **6.05** |      **5.94** |    **−0.11** |
|     2 |       **5.95** |      **5.95** |    **+0.00** |
|     8 |       **6.01** |      **5.99** |    **−0.02** |
|    32 |       **6.20** |      **6.25** |    **+0.05** |
|   128 |       **7.77** |      **7.77** |    **+0.00** |
|   256 |           8.35 |          8.38 |        +0.03 |
|  1024 |          19.72 |         16.88 |        −2.84 |
|  4096 |          62.36 |         62.31 |        −0.05 |
|  8192 |         123.25 |        123.25 |    **+0.00** |
| 16384 |         247.74 |        248.39 |        +0.65 |

**Reading these.** Inside CUDA Graph, the two routes are statistically indistinguishable on both architectures — `|Δ|` ≤ ~0.7 µs everywhere, with many rows reading exactly equal to the µs. The single H100 outlier at M=1024 has `mm` *faster* than the JIT, suggesting the variance is from cuBLAS heuristic selection per graph capture rather than any systematic kernel difference.

Launch-bound floors (M ≤ 128): B200 ~7.4 µs, H100 ~6.0 µs — the cuBLAS minimum-tile + graph-launch cost. Neither implementation can go below that.

### 3. Eager-mode footnote

In eager mode at very small M (≤ 128), `torch.mm` is ~1 µs (8–10 %) slower than the JIT — but that gap is **purely Python dispatcher overhead** (extra ~1 µs from torch's dispatcher / autograd-key check vs the JIT's leaner pybind11 stub). It vanishes under any CUDA Graph capture, including `torch.compile(mode="reduce-overhead")`. Decoding loops in sglang already capture graphs, so this is invisible in practice.

For compute-bound shapes (M ≥ 256) eager-mode times also match within ±5 % run-to-run noise on both GPUs.

### Test commands

Build the JIT kernel inline (verbatim source from `_jit_torch_cublas_bf16_fp32`) and run:

```bash
# inside lmsysorg/sglang:deepseek-v4-{blackwell,hopper}
python bench_bf16_fp32_gemm.py \
    --warmup 30 --iters 300 \
    --batch-sizes 1,2,4,8,16,32,64,128,256,512,1024,2048,4096,8192,16384

python bench_overhead.py \
    --batch-sizes 1,2,4,8,16,32,64,128,256,512,1024,2048,4096,8192,16384
```

Bench scripts available on request.

### Summary

| Aspect           | Result                                                                                                         |
| ---------------- | -------------------------------------------------------------------------------------------------------------- |
| Accuracy         | **Bit-exact** on every shape, both B200 and H100 (`torch.equal == True`)                                       |
| Perf, M ≥ 256    | Same TFLOPS within ±5 % noise (both GPUs)                                                                      |
| Perf, M ≤ 128    | **Identical under CUDA Graph** (\|Δ\| ≤ 0.2 µs over 16 000 timed calls/cell)                                   |
| Eager-mode small-M | ~1 µs Python-dispatcher overhead in `torch.mm`; closed by any graph capture                                  |
| Cold-start cost  | -1 × `nvcc` JIT compile (~60–74 s) and -1 `compile_aot` entry                                                  |

Net: drops 62 lines of inline-CUDA + JIT machinery, with no perf or accuracy regression.
