### PR TITLE
Harden DeepSeek V4 compressed-attention inputs for deterministic FlashMLA serving

### DIFF
--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -186,6 +186,24 @@ def topk_transform_512_pytorch_vectorized(
         out_raw_indices.copy_(raw_indices)
 
 
+def _sort_c4_sparse_indices_by_row(
+    page_indices: torch.Tensor,
+    topk_lengths: torch.Tensor,
+) -> None:
+    if page_indices.numel() == 0:
+        return
+    if topk_lengths.dim() != 1:
+        topk_lengths = topk_lengths.view(-1)
+
+    cols = page_indices.shape[-1]
+    positions = torch.arange(cols, device=page_indices.device).unsqueeze(0)
+    valid = positions < topk_lengths.unsqueeze(1)
+    sentinel = torch.iinfo(page_indices.dtype).max
+    sortable = torch.where(valid, page_indices, sentinel)
+    sorted_indices = torch.sort(sortable, dim=-1).values
+    page_indices.copy_(torch.where(valid, sorted_indices, -1))
+
+
 @triton.jit
 def _fused_scale_kernel(
     weight_ptr,
@@ -466,6 +484,11 @@ class C4IndexerBackendMixin:
                         core_metadata.c4_sparse_page_indices
                     )
                 )
+
+        _sort_c4_sparse_indices_by_row(
+            core_metadata.c4_sparse_page_indices,
+            core_metadata.c4_sparse_topk_lengths,
+        )
 
         if capture_enabled:
             compress_layer_id = token_to_kv_pool.layer_mapping[

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -532,7 +532,7 @@ class MQALayer(nn.Module):
 
         tp_slice, q_padded, q_out = slice(None), None, None
         if self.tp_size > 1:
-            q_padded = x.new_empty(x.shape[0], self.n_heads, self.head_dim)
+            q_padded = x.new_zeros(x.shape[0], self.n_heads, self.head_dim)
             rank = self.tp_rank
             tp_slice = slice(rank * self.n_local_heads, (rank + 1) * self.n_local_heads)
             q_out = q_padded[:, tp_slice, :]


### PR DESCRIPTION
# Harden DeepSeek V4 compressed-attention inputs for deterministic FlashMLA serving

## Summary

This PR hardens the DeepSeek V4 FlashMLA input path to make compressed-attention metadata deterministic during serving.

It makes two small changes:

- zero-fill TP padded q before passing the full q tensor to FlashMLA;
- canonicalize C4 sparse page-index order before FlashMLA consumes the compressed-attention metadata.

The change fixes a DeepSeek V4 Flash TP4 first-request nondeterminism repro where two fresh baseline SGLang servers could return different output tokens for the same raw-input request.

## Problem

For DeepSeek V4 Flash serving, the attention path builds a full q tensor for FlashMLA even under tensor parallelism. Before this PR, the padded q tensor was allocated with `new_empty`, while only the local TP head slice was filled. That leaves non-local head slices undefined in the tensor passed to FlashMLA.

The compressed-attention C4 sparse index path also relied on the native top-k transform output order. In the repro, q/kv inputs, SWA metadata, and C4 top-k lengths matched across runs, but the C4 sparse page-index metadata differed before the FlashMLA output drifted.

This made a baseline-vs-baseline DSv4 run nondeterministic. The issue was not TileKernels-specific.

## Fix

### Zero-fill TP padded q

Use a zero-initialized tensor for TP padded q so all heads in the full tensor passed to FlashMLA are well-defined.

### Canonicalize C4 sparse page indices

After C4 sparse top-k page indices are produced, sort the valid indices in each row and keep invalid slots as `-1`. This gives FlashMLA a deterministic sparse metadata order.

## Validation

Static check:

```bash
python3 -m py_compile \
  python/sglang/srt/models/deepseek_v4.py \
  python/sglang/srt/layers/attention/compressed/indexer.py
```

Runtime validation was done on DeepSeek V4 Flash with TP4 using a raw 4096-token request and `max_new_tokens=2`.

Clean patch result, with no debug boundary dumps enabled:

```text
baseline_a output_ids: [2701, 95]
baseline_b output_ids: [2701, 95]
baseline_a elapsed: 150.326s
baseline_b elapsed: 148.184s
mean elapsed: 149.255s
```

A control run with q-padding only measured:

```text
mean elapsed: 148.437s
```

A run with q-padding plus C4 sparse index sorting measured:

```text
mean elapsed: 150.815s
delta: +2.378s, +1.60%
```

Given request-level noise and full prefill cost, this is best described as roughly 1-2% overhead for this single 4096+2 validation shape.

## Notes

This PR addresses the DSv4 first-request determinism/input-contract issue in the FlashMLA compressed-attention path. It is separate from scheduler-side mitigations for mixed decode plus multi-prefill FlashMLA metadata shapes.
