### PR TITLE
[Perf] Optimize alloc_for_decode and stream_output functions

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -895,6 +895,8 @@ class Req(ReqDllmMixin):
         self.return_pooled_hidden_states = return_pooled_hidden_states
         self.pooled_hidden_state = None
 
+        self.eos_token_id = None
+        self.additional_stop_token_ids = None
         # For diffusion LLM
         self.init_diffusion_llm(dllm_config)
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -407,6 +407,7 @@ class Scheduler(
 
         # Init inter-process communication
         self.init_ipc_channels(port_args)
+        self.init_return_logprob_containers()
 
         # Init PD-multiplexing context
         if self.enable_pdmux:
@@ -1888,6 +1889,8 @@ class Scheduler(
                 multi_item_delimiter_indices=recv_req.multi_item_delimiter_indices,
             )
             req.tokenizer = self.tokenizer
+            req.eos_token_id = self.tokenizer.eos_token_id
+            req.additional_stop_token_ids = self.tokenizer.additional_stop_token_ids
 
             if self.disaggregation_mode != DisaggregationMode.NULL:
                 # Invalid request for disaggregated mode
@@ -1944,6 +1947,8 @@ class Scheduler(
                 http_worker_ipc=recv_req.http_worker_ipc,
             )
             req.tokenizer = self.tokenizer
+            req.eos_token_id = self.tokenizer.eos_token_id
+            req.additional_stop_token_ids = self.tokenizer.additional_stop_token_ids
             req.set_finish_with_abort(error_msg)
             self.init_req_max_new_tokens(req)
             self._add_request_to_queue(req)
@@ -2210,6 +2215,8 @@ class Scheduler(
             multi_item_delimiter_indices=recv_req.multi_item_delimiter_indices,
         )
         req.tokenizer = self.tokenizer
+        req.eos_token_id = self.tokenizer.eos_token_id
+        req.additional_stop_token_ids = self.tokenizer.additional_stop_token_ids
 
         # Handle multimodal inputs
         if recv_req.image_inputs is not None:

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -1007,7 +1007,7 @@ class SchedulerOutputProcessorMixin:
 
         time_stats = []
 
-        if self.input_token_logprobs_val != None:
+        if self.input_token_logprobs_val is not None:
             self.clear_list()
 
         if not return_logprob:

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -85,6 +85,41 @@ class SchedulerOutputProcessorMixin:
 
         return None
 
+    def init_return_logprob_containers(self) -> None:
+        """Initialize return_logprob output containers during scheduler init."""
+        self.input_token_logprobs_val = []
+        self.input_token_logprobs_idx = []
+        self.output_token_logprobs_val = []
+        self.output_token_logprobs_idx = []
+        self.input_top_logprobs_val = []
+        self.input_top_logprobs_idx = []
+        self.output_top_logprobs_val = []
+        self.output_top_logprobs_idx = []
+        self.input_token_ids_logprobs_val = []
+        self.input_token_ids_logprobs_idx = []
+        self.output_token_ids_logprobs_val = []
+        self.output_token_ids_logprobs_idx = []
+
+    def clear_list(self):
+        for name in [
+            "input_token_logprobs_val",
+            "input_token_logprobs_idx",
+            "output_token_logprobs_val",
+            "output_token_logprobs_idx",
+            "input_top_logprobs_val",
+            "input_top_logprobs_idx",
+            "output_top_logprobs_val",
+            "output_top_logprobs_idx",
+            "input_token_ids_logprobs_val",
+            "input_token_ids_logprobs_idx",
+            "output_token_ids_logprobs_val",
+            "output_token_ids_logprobs_idx",
+        ]:
+            if hasattr(self, name):
+                getattr(self, name).clear()
+            else:
+                setattr(self, name, [])
+
     def process_batch_result_prebuilt(self: Scheduler, batch: ScheduleBatch):
         assert self.disaggregation_mode == DisaggregationMode.DECODE
         for req in batch.reqs:
@@ -972,29 +1007,22 @@ class SchedulerOutputProcessorMixin:
 
         time_stats = []
 
-        if return_logprob:
-            input_token_logprobs_val = []
-            input_token_logprobs_idx = []
-            output_token_logprobs_val = []
-            output_token_logprobs_idx = []
-            input_top_logprobs_val = []
-            input_top_logprobs_idx = []
-            output_top_logprobs_val = []
-            output_top_logprobs_idx = []
-            input_token_ids_logprobs_val = []
-            input_token_ids_logprobs_idx = []
-            output_token_ids_logprobs_val = []
-            output_token_ids_logprobs_idx = []
-        else:
-            input_token_logprobs_val = input_token_logprobs_idx = (
-                output_token_logprobs_val
-            ) = output_token_logprobs_idx = input_top_logprobs_val = (
-                input_top_logprobs_idx
-            ) = output_top_logprobs_val = output_top_logprobs_idx = (
-                input_token_ids_logprobs_val
-            ) = input_token_ids_logprobs_idx = output_token_ids_logprobs_val = (
-                output_token_ids_logprobs_idx
-            ) = None
+        if self.input_token_logprobs_val != None:
+            self.clear_list()
+
+        if not return_logprob:
+            self.input_token_logprobs_val = None
+            self.input_token_logprobs_idx = None
+            self.output_token_logprobs_val = None
+            self.output_token_logprobs_idx = None
+            self.input_top_logprobs_val = None
+            self.input_top_logprobs_idx = None
+            self.output_top_logprobs_val = None
+            self.output_top_logprobs_idx = None
+            self.input_token_ids_logprobs_val = None
+            self.input_token_ids_logprobs_idx = None
+            self.output_token_ids_logprobs_val = None
+            self.output_token_ids_logprobs_idx = None
 
         for req in reqs:
             if req is skip_req:
@@ -1083,65 +1111,69 @@ class SchedulerOutputProcessorMixin:
                         # Only send when input logprobs have been computed (after prefill)
                         and req.input_token_logprobs_val is not None
                     ):
-                        input_token_logprobs_val.append(req.input_token_logprobs_val)
-                        input_token_logprobs_idx.append(req.input_token_logprobs_idx)
-                        input_top_logprobs_val.append(req.input_top_logprobs_val)
-                        input_top_logprobs_idx.append(req.input_top_logprobs_idx)
-                        input_token_ids_logprobs_val.append(
+                        self.input_token_logprobs_val.append(
+                            req.input_token_logprobs_val
+                        )
+                        self.input_token_logprobs_idx.append(
+                            req.input_token_logprobs_idx
+                        )
+                        self.input_top_logprobs_val.append(req.input_top_logprobs_val)
+                        self.input_top_logprobs_idx.append(req.input_top_logprobs_idx)
+                        self.input_token_ids_logprobs_val.append(
                             req.input_token_ids_logprobs_val
                         )
-                        input_token_ids_logprobs_idx.append(
+                        self.input_token_ids_logprobs_idx.append(
                             req.input_token_ids_logprobs_idx
                         )
                         req.input_logprob_sent = True
                     else:
-                        input_token_logprobs_val.append([])
-                        input_token_logprobs_idx.append([])
-                        input_top_logprobs_val.append([])
-                        input_top_logprobs_idx.append([])
-                        input_token_ids_logprobs_val.append([])
-                        input_token_ids_logprobs_idx.append([])
+                        self.input_token_logprobs_val.append([])
+                        self.input_token_logprobs_idx.append([])
+                        self.input_top_logprobs_val.append([])
+                        self.input_top_logprobs_idx.append([])
+                        self.input_token_ids_logprobs_val.append([])
+                        self.input_token_ids_logprobs_idx.append([])
 
                     if req.return_logprob:
                         logprob_end = max(len(output_ids_), 1)
-                        output_token_logprobs_val.append(
+                        self.output_token_logprobs_val.append(
                             req.output_token_logprobs_val[
                                 send_output_token_logprobs_offset:logprob_end
                             ]
                         )
-                        output_token_logprobs_idx.append(
+                        self.output_token_logprobs_idx.append(
                             req.output_token_logprobs_idx[
                                 send_output_token_logprobs_offset:logprob_end
                             ]
                         )
-                        output_top_logprobs_val.append(
+                        self.output_top_logprobs_val.append(
                             req.output_top_logprobs_val[
                                 send_output_token_logprobs_offset:logprob_end
                             ]
                         )
-                        output_top_logprobs_idx.append(
+                        self.output_top_logprobs_idx.append(
                             req.output_top_logprobs_idx[
                                 send_output_token_logprobs_offset:logprob_end
                             ]
                         )
-                        output_token_ids_logprobs_val.append(
+                        self.output_token_ids_logprobs_val.append(
                             req.output_token_ids_logprobs_val[
                                 send_output_token_logprobs_offset:logprob_end
                             ]
                         )
-                        output_token_ids_logprobs_idx.append(
+                        self.output_token_ids_logprobs_idx.append(
                             req.output_token_ids_logprobs_idx[
                                 send_output_token_logprobs_offset:logprob_end
                             ]
                         )
                         req.send_output_token_logprobs_offset = logprob_end
                     else:
-                        output_token_logprobs_val.append([])
-                        output_token_logprobs_idx.append([])
-                        output_top_logprobs_val.append([])
-                        output_top_logprobs_idx.append([])
-                        output_token_ids_logprobs_val.append([])
-                        output_token_ids_logprobs_idx.append([])
+                        self.output_token_logprobs_val.append([])
+                        self.output_token_logprobs_idx.append([])
+                        self.output_top_logprobs_val.append([])
+                        self.output_top_logprobs_idx.append([])
+                        self.output_token_ids_logprobs_val.append([])
+                        self.output_token_ids_logprobs_idx.append([])
 
                 if req.return_hidden_states:
                     if output_hidden_states is None:
@@ -1192,18 +1224,18 @@ class SchedulerOutputProcessorMixin:
                     completion_tokens=completion_tokens,
                     cached_tokens=cached_tokens,
                     cached_tokens_details=cached_tokens_details,
-                    input_token_logprobs_val=input_token_logprobs_val,
-                    input_token_logprobs_idx=input_token_logprobs_idx,
-                    output_token_logprobs_val=output_token_logprobs_val,
-                    output_token_logprobs_idx=output_token_logprobs_idx,
-                    input_top_logprobs_val=input_top_logprobs_val,
-                    input_top_logprobs_idx=input_top_logprobs_idx,
-                    output_top_logprobs_val=output_top_logprobs_val,
-                    output_top_logprobs_idx=output_top_logprobs_idx,
-                    input_token_ids_logprobs_val=input_token_ids_logprobs_val,
-                    input_token_ids_logprobs_idx=input_token_ids_logprobs_idx,
-                    output_token_ids_logprobs_val=output_token_ids_logprobs_val,
-                    output_token_ids_logprobs_idx=output_token_ids_logprobs_idx,
+                    input_token_logprobs_val=self.input_token_logprobs_val,
+                    input_token_logprobs_idx=self.input_token_logprobs_idx,
+                    output_token_logprobs_val=self.output_token_logprobs_val,
+                    output_token_logprobs_idx=self.output_token_logprobs_idx,
+                    input_top_logprobs_val=self.input_top_logprobs_val,
+                    input_top_logprobs_idx=self.input_top_logprobs_idx,
+                    output_top_logprobs_val=self.output_top_logprobs_val,
+                    output_top_logprobs_idx=self.output_top_logprobs_idx,
+                    input_token_ids_logprobs_val=self.input_token_ids_logprobs_val,
+                    input_token_ids_logprobs_idx=self.input_token_ids_logprobs_idx,
+                    output_token_ids_logprobs_val=self.output_token_ids_logprobs_val,
+                    output_token_ids_logprobs_idx=self.output_token_ids_logprobs_idx,
                     output_token_entropy_val=None,
                     output_hidden_states=output_hidden_states,
                     routed_experts=routed_experts,

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -497,6 +497,24 @@ def alloc_paged_token_slots_decode(
     return out_cache_loc
 
 
+@triton.jit
+def _write_decode_req_to_token_kernel(
+    req_to_token_ptr,  # [max_batch, max_context_len], int32
+    req_pool_indices_ptr,  # [bs], int64
+    seq_lens_ptr,  # [bs], int32/int64 (used as column index)
+    out_cache_loc_ptr,  # [bs], int64
+    stride: tl.constexpr,  # max_context_len
+):
+    pid = tl.program_id(0)
+    req_idx = tl.load(req_pool_indices_ptr + pid)
+    col_idx = tl.load(seq_lens_ptr + pid)
+    value = tl.load(out_cache_loc_ptr + pid)
+    tl.store(
+        req_to_token_ptr + req_idx * stride + col_idx,
+        value.to(tl.int32),
+    )
+
+
 def alloc_for_decode(batch: ScheduleBatch, token_per_req: int) -> torch.Tensor:
     """
     Allocate KV cache for decode batch and write to req_to_token_pool.
@@ -532,8 +550,12 @@ def alloc_for_decode(batch: ScheduleBatch, token_per_req: int) -> torch.Tensor:
     else:
         locs = batch.seq_lens.clone()
 
-    batch.req_to_token_pool.write(
-        (batch.req_pool_indices, locs), out_cache_loc.to(torch.int32)
+    _write_decode_req_to_token_kernel[(bs,)](
+        batch.req_to_token_pool.req_to_token,
+        batch.req_pool_indices,
+        locs,
+        out_cache_loc,
+        batch.req_to_token_pool.req_to_token.shape[1],
     )
 
     return out_cache_loc

--- a/test/registered/unit/managers/test_scheduler_output_processor.py
+++ b/test/registered/unit/managers/test_scheduler_output_processor.py
@@ -58,9 +58,7 @@ class TestInitReturnLogprobContainers(unittest.TestCase):
         ]
 
         for attr in expected_attrs:
-            self.assertTrue(
-                hasattr(mixin, attr), f"Missing attribute: {attr}"
-            )
+            self.assertTrue(hasattr(mixin, attr), f"Missing attribute: {attr}")
             self.assertEqual(
                 getattr(mixin, attr), [], f"Attribute {attr} should be an empty list"
             )
@@ -107,7 +105,9 @@ class TestClearList(unittest.TestCase):
         ]
         for name in container_names:
             getattr(mixin, name).append("some_data")
-            self.assertEqual(len(getattr(mixin, name)), 1, f"{name} should have 1 item before clear")
+            self.assertEqual(
+                len(getattr(mixin, name)), 1, f"{name} should have 1 item before clear"
+            )
 
         mixin.clear_list()
 
@@ -137,14 +137,20 @@ class TestClearList(unittest.TestCase):
 
         # Verify attributes don't exist before clear_list
         for name in container_names:
-            self.assertFalse(hasattr(mixin, name), f"{name} should not exist before clear_list")
+            self.assertFalse(
+                hasattr(mixin, name), f"{name} should not exist before clear_list"
+            )
 
         mixin.clear_list()
 
         # Verify attributes are created as empty lists
         for name in container_names:
-            self.assertTrue(hasattr(mixin, name), f"{name} should exist after clear_list")
-            self.assertEqual(getattr(mixin, name), [], f"{name} should be an empty list")
+            self.assertTrue(
+                hasattr(mixin, name), f"{name} should exist after clear_list"
+            )
+            self.assertEqual(
+                getattr(mixin, name), [], f"{name} should be an empty list"
+            )
 
     def test_clear_list_after_partial_set_to_none(self):
         """Test clear_list behavior when containers are properly initialized.

--- a/test/registered/unit/managers/test_scheduler_output_processor.py
+++ b/test/registered/unit/managers/test_scheduler_output_processor.py
@@ -1,0 +1,268 @@
+"""
+Unit tests for the scheduler output processor mixin and Req tokenizer attributes.
+
+This module tests:
+- init_return_logprob_containers: initialization of logprob containers on the scheduler
+- clear_list: clearing logprob container lists
+- Req.eos_token_id and Req.additional_stop_token_ids: tokenizer attribute caching
+
+Usage:
+    python test_scheduler_output_processor.py
+    python -m pytest test_scheduler_output_processor.py -v
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.managers.scheduler_output_processor_mixin import (
+    SchedulerOutputProcessorMixin,
+)
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+
+
+class TestInitReturnLogprobContainers(unittest.TestCase):
+    """Test cases for init_return_logprob_containers method."""
+
+    def _create_mixin_instance(self):
+        """Create a minimal instance of SchedulerOutputProcessorMixin."""
+        mixin = SchedulerOutputProcessorMixin.__new__(SchedulerOutputProcessorMixin)
+        return mixin
+
+    def test_creates_all_container_lists(self):
+        """Test that init_return_logprob_containers creates all 12 container lists."""
+        mixin = self._create_mixin_instance()
+        mixin.init_return_logprob_containers()
+
+        expected_attrs = [
+            "input_token_logprobs_val",
+            "input_token_logprobs_idx",
+            "output_token_logprobs_val",
+            "output_token_logprobs_idx",
+            "input_top_logprobs_val",
+            "input_top_logprobs_idx",
+            "output_top_logprobs_val",
+            "output_top_logprobs_idx",
+            "input_token_ids_logprobs_val",
+            "input_token_ids_logprobs_idx",
+            "output_token_ids_logprobs_val",
+            "output_token_ids_logprobs_idx",
+        ]
+
+        for attr in expected_attrs:
+            self.assertTrue(
+                hasattr(mixin, attr), f"Missing attribute: {attr}"
+            )
+            self.assertEqual(
+                getattr(mixin, attr), [], f"Attribute {attr} should be an empty list"
+            )
+
+    def test_containers_are_independent_lists(self):
+        """Test that each container is an independent list, not shared references."""
+        mixin = self._create_mixin_instance()
+        mixin.init_return_logprob_containers()
+
+        # Append to one list and verify others are not affected
+        mixin.input_token_logprobs_val.append("test")
+        self.assertEqual(len(mixin.input_token_logprobs_val), 1)
+        self.assertEqual(len(mixin.input_token_logprobs_idx), 0)
+        self.assertEqual(len(mixin.output_token_logprobs_val), 0)
+
+
+class TestClearList(unittest.TestCase):
+    """Test cases for clear_list method."""
+
+    def _create_mixin_instance(self):
+        """Create a minimal instance with initialized containers."""
+        mixin = SchedulerOutputProcessorMixin.__new__(SchedulerOutputProcessorMixin)
+        mixin.init_return_logprob_containers()
+        return mixin
+
+    def test_clear_list_clears_all_containers(self):
+        """Test that clear_list clears all container lists."""
+        mixin = self._create_mixin_instance()
+
+        # Add data to all containers
+        container_names = [
+            "input_token_logprobs_val",
+            "input_token_logprobs_idx",
+            "output_token_logprobs_val",
+            "output_token_logprobs_idx",
+            "input_top_logprobs_val",
+            "input_top_logprobs_idx",
+            "output_top_logprobs_val",
+            "output_top_logprobs_idx",
+            "input_token_ids_logprobs_val",
+            "input_token_ids_logprobs_idx",
+            "output_token_ids_logprobs_val",
+            "output_token_ids_logprobs_idx",
+        ]
+        for name in container_names:
+            getattr(mixin, name).append("some_data")
+            self.assertEqual(len(getattr(mixin, name)), 1, f"{name} should have 1 item before clear")
+
+        mixin.clear_list()
+
+        for name in container_names:
+            self.assertEqual(
+                len(getattr(mixin, name)), 0, f"{name} should be empty after clear_list"
+            )
+
+    def test_clear_list_creates_missing_attributes(self):
+        """Test that clear_list creates lists for attributes that don't exist yet."""
+        mixin = SchedulerOutputProcessorMixin.__new__(SchedulerOutputProcessorMixin)
+
+        container_names = [
+            "input_token_logprobs_val",
+            "input_token_logprobs_idx",
+            "output_token_logprobs_val",
+            "output_token_logprobs_idx",
+            "input_top_logprobs_val",
+            "input_top_logprobs_idx",
+            "output_top_logprobs_val",
+            "output_top_logprobs_idx",
+            "input_token_ids_logprobs_val",
+            "input_token_ids_logprobs_idx",
+            "output_token_ids_logprobs_val",
+            "output_token_ids_logprobs_idx",
+        ]
+
+        # Verify attributes don't exist before clear_list
+        for name in container_names:
+            self.assertFalse(hasattr(mixin, name), f"{name} should not exist before clear_list")
+
+        mixin.clear_list()
+
+        # Verify attributes are created as empty lists
+        for name in container_names:
+            self.assertTrue(hasattr(mixin, name), f"{name} should exist after clear_list")
+            self.assertEqual(getattr(mixin, name), [], f"{name} should be an empty list")
+
+    def test_clear_list_after_partial_set_to_none(self):
+        """Test clear_list behavior when containers are properly initialized.
+
+        Note: In actual code, clear_list() is only called when input_token_logprobs_val
+        is not None (see stream_output at line 1010), so this test verifies the normal
+        behavior when containers are properly initialized as lists.
+        """
+        mixin = self._create_mixin_instance()
+
+        # All containers should be initialized as empty lists
+        self.assertIsInstance(mixin.input_token_logprobs_val, list)
+        self.assertIsInstance(mixin.input_top_logprobs_val, list)
+
+        # Add some data
+        mixin.input_top_logprobs_val.append("data")
+        mixin.output_top_logprobs_val.append("data")
+
+        # clear_list should clear all containers
+        mixin.clear_list()
+
+        # All containers should be empty lists
+        self.assertEqual(mixin.input_token_logprobs_val, [])
+        self.assertEqual(mixin.input_token_logprobs_idx, [])
+        self.assertEqual(mixin.output_token_logprobs_val, [])
+        self.assertEqual(mixin.output_token_logprobs_idx, [])
+        self.assertEqual(mixin.input_top_logprobs_val, [])
+        self.assertEqual(mixin.output_top_logprobs_val, [])
+
+    def test_init_then_clear_then_reinit_cycle(self):
+        """Test the full lifecycle: init -> populate -> clear -> reinit."""
+        mixin = self._create_mixin_instance()
+
+        # Populate
+        mixin.input_token_logprobs_val.append([0.1, 0.2])
+        mixin.output_token_logprobs_val.append([0.3])
+
+        # Clear
+        mixin.clear_list()
+        self.assertEqual(mixin.input_token_logprobs_val, [])
+        self.assertEqual(mixin.output_token_logprobs_val, [])
+
+        # Re-populate
+        mixin.input_token_logprobs_val.append([0.5])
+        self.assertEqual(len(mixin.input_token_logprobs_val), 1)
+
+
+class TestReqTokenizerAttributes(unittest.TestCase):
+    """Test cases for Req.eos_token_id and Req.additional_stop_token_ids attributes."""
+
+    def setUp(self):
+        set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
+
+    def _create_req(self, rid="test-req", input_ids=None):
+        """Create a Req instance with minimal required arguments."""
+        if input_ids is None:
+            input_ids = [1, 2, 3]
+        return Req(
+            rid=rid,
+            origin_input_text="test text",
+            origin_input_ids=input_ids,
+            sampling_params=SamplingParams(),
+        )
+
+    def test_req_has_eos_token_id_attribute(self):
+        """Test that Req instances have eos_token_id attribute initialized to None."""
+        req = self._create_req(rid="test-1")
+        self.assertIsNone(req.eos_token_id)
+
+    def test_req_has_additional_stop_token_ids_attribute(self):
+        """Test that Req instances have additional_stop_token_ids attribute initialized to None."""
+        req = self._create_req(rid="test-2")
+        self.assertIsNone(req.additional_stop_token_ids)
+
+    def test_req_eos_token_id_can_be_set(self):
+        """Test that eos_token_id can be set on a Req instance."""
+        req = self._create_req(rid="test-3")
+        req.eos_token_id = 2
+        self.assertEqual(req.eos_token_id, 2)
+
+    def test_req_additional_stop_token_ids_can_be_set(self):
+        """Test that additional_stop_token_ids can be set on a Req instance."""
+        req = self._create_req(rid="test-4")
+        req.additional_stop_token_ids = [32000, 32001]
+        self.assertEqual(req.additional_stop_token_ids, [32000, 32001])
+
+    def test_req_tokenizer_attributes_set_from_mock_tokenizer(self):
+        """Test setting eos_token_id and additional_stop_token_ids from a mock tokenizer."""
+        req = self._create_req(rid="test-5")
+
+        # Simulate what the scheduler does
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.eos_token_id = 2
+        mock_tokenizer.additional_stop_token_ids = [32000, 32001]
+
+        req.tokenizer = mock_tokenizer
+        req.eos_token_id = mock_tokenizer.eos_token_id
+        req.additional_stop_token_ids = mock_tokenizer.additional_stop_token_ids
+
+        self.assertEqual(req.eos_token_id, 2)
+        self.assertEqual(req.additional_stop_token_ids, [32000, 32001])
+
+    def test_multiple_reqs_independent_tokenizer_attrs(self):
+        """Test that different Req instances can have different tokenizer attributes."""
+        req1 = self._create_req(rid="test-6a")
+        req2 = self._create_req(rid="test-6b")
+
+        req1.eos_token_id = 2
+        req1.additional_stop_token_ids = [100]
+
+        req2.eos_token_id = 50256
+        req2.additional_stop_token_ids = [200, 300]
+
+        self.assertEqual(req1.eos_token_id, 2)
+        self.assertEqual(req1.additional_stop_token_ids, [100])
+        self.assertEqual(req2.eos_token_id, 50256)
+        self.assertEqual(req2.additional_stop_token_ids, [200, 300])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_write_decode_req_to_token_kernel.py
+++ b/test/registered/unit/mem_cache/test_write_decode_req_to_token_kernel.py
@@ -66,13 +66,9 @@ class TestWriteDecodeReqToTokenKernel(unittest.TestCase):
         req_to_token = torch.zeros(
             (max_batch, max_context_len), dtype=torch.int32, device="cuda"
         )
-        req_pool_indices = torch.tensor(
-            [0, 2, 5, 7], dtype=torch.int64, device="cuda"
-        )
+        req_pool_indices = torch.tensor([0, 2, 5, 7], dtype=torch.int64, device="cuda")
         seq_lens = torch.tensor([3, 10, 1, 20], dtype=torch.int64, device="cuda")
-        out_cache_loc = torch.tensor(
-            [50, 60, 70, 80], dtype=torch.int64, device="cuda"
-        )
+        out_cache_loc = torch.tensor([50, 60, 70, 80], dtype=torch.int64, device="cuda")
 
         _write_decode_req_to_token_kernel[(bs,)](
             req_to_token,
@@ -176,9 +172,7 @@ class TestWriteDecodeReqToTokenKernel(unittest.TestCase):
         seq_lens = torch.randint(
             0, max_context_len, (bs,), dtype=torch.int64, device="cuda"
         )
-        out_cache_loc = torch.randint(
-            0, 10000, (bs,), dtype=torch.int64, device="cuda"
-        )
+        out_cache_loc = torch.randint(0, 10000, (bs,), dtype=torch.int64, device="cuda")
 
         # Triton kernel result
         req_to_token_triton = torch.zeros(

--- a/test/registered/unit/mem_cache/test_write_decode_req_to_token_kernel.py
+++ b/test/registered/unit/mem_cache/test_write_decode_req_to_token_kernel.py
@@ -1,0 +1,212 @@
+"""
+Unit tests for the _write_decode_req_to_token_kernel Triton kernel.
+
+This module tests the Triton kernel that replaces the previous
+req_to_token_pool.write() call in alloc_for_decode, ensuring correctness
+of writing decode cache locations to the req_to_token pool.
+
+Test Coverage:
+- Basic correctness: single request write
+- Multiple requests: batch write
+- Edge cases: different stride values, boundary positions
+
+Usage:
+    python test_write_decode_req_to_token_kernel.py
+    python -m pytest test_write_decode_req_to_token_kernel.py -v
+"""
+
+import unittest
+
+import torch
+
+from sglang.srt.mem_cache.common import _write_decode_req_to_token_kernel
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, suite="stage-b-test-1-gpu-small")
+
+
+class TestWriteDecodeReqToTokenKernel(unittest.TestCase):
+    """Test cases for _write_decode_req_to_token_kernel."""
+
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA not available")
+
+    def test_single_request_write(self):
+        """Test writing a single decode entry to req_to_token pool."""
+        max_batch = 4
+        max_context_len = 16
+        req_to_token = torch.zeros(
+            (max_batch, max_context_len), dtype=torch.int32, device="cuda"
+        )
+        req_pool_indices = torch.tensor([2], dtype=torch.int64, device="cuda")
+        seq_lens = torch.tensor([5], dtype=torch.int64, device="cuda")
+        out_cache_loc = torch.tensor([100], dtype=torch.int64, device="cuda")
+
+        _write_decode_req_to_token_kernel[(1,)](
+            req_to_token,
+            req_pool_indices,
+            seq_lens,
+            out_cache_loc,
+            max_context_len,
+        )
+
+        # Verify the value was written at the correct position
+        self.assertEqual(req_to_token[2, 5].item(), 100)
+        # Verify no other positions were modified
+        req_to_token[2, 5] = 0
+        self.assertTrue(torch.all(req_to_token == 0).item())
+
+    def test_batch_write(self):
+        """Test writing multiple decode entries in a batch."""
+        bs = 4
+        max_batch = 8
+        max_context_len = 32
+        req_to_token = torch.zeros(
+            (max_batch, max_context_len), dtype=torch.int32, device="cuda"
+        )
+        req_pool_indices = torch.tensor(
+            [0, 2, 5, 7], dtype=torch.int64, device="cuda"
+        )
+        seq_lens = torch.tensor([3, 10, 1, 20], dtype=torch.int64, device="cuda")
+        out_cache_loc = torch.tensor(
+            [50, 60, 70, 80], dtype=torch.int64, device="cuda"
+        )
+
+        _write_decode_req_to_token_kernel[(bs,)](
+            req_to_token,
+            req_pool_indices,
+            seq_lens,
+            out_cache_loc,
+            max_context_len,
+        )
+
+        # Verify each request wrote to the correct position
+        self.assertEqual(req_to_token[0, 3].item(), 50)
+        self.assertEqual(req_to_token[2, 10].item(), 60)
+        self.assertEqual(req_to_token[5, 1].item(), 70)
+        self.assertEqual(req_to_token[7, 20].item(), 80)
+
+        # Verify no other positions were modified
+        expected_positions = {(0, 3), (2, 10), (5, 1), (7, 20)}
+        for i in range(max_batch):
+            for j in range(max_context_len):
+                if (i, j) in expected_positions:
+                    self.assertNotEqual(req_to_token[i, j].item(), 0)
+                else:
+                    self.assertEqual(req_to_token[i, j].item(), 0)
+
+    def test_overwrite_existing_value(self):
+        """Test that the kernel correctly overwrites existing values."""
+        max_batch = 2
+        max_context_len = 8
+        req_to_token = torch.full(
+            (max_batch, max_context_len), 999, dtype=torch.int32, device="cuda"
+        )
+        req_pool_indices = torch.tensor([1], dtype=torch.int64, device="cuda")
+        seq_lens = torch.tensor([4], dtype=torch.int64, device="cuda")
+        out_cache_loc = torch.tensor([42], dtype=torch.int64, device="cuda")
+
+        _write_decode_req_to_token_kernel[(1,)](
+            req_to_token,
+            req_pool_indices,
+            seq_lens,
+            out_cache_loc,
+            max_context_len,
+        )
+
+        # Verify the value was overwritten
+        self.assertEqual(req_to_token[1, 4].item(), 42)
+        # Other positions should still have the old value
+        self.assertEqual(req_to_token[1, 3].item(), 999)
+        self.assertEqual(req_to_token[0, 4].item(), 999)
+
+    def test_large_stride(self):
+        """Test with a large stride (max_context_len) value."""
+        max_batch = 2
+        max_context_len = 1024
+        req_to_token = torch.zeros(
+            (max_batch, max_context_len), dtype=torch.int32, device="cuda"
+        )
+        req_pool_indices = torch.tensor([1], dtype=torch.int64, device="cuda")
+        seq_lens = torch.tensor([512], dtype=torch.int64, device="cuda")
+        out_cache_loc = torch.tensor([12345], dtype=torch.int64, device="cuda")
+
+        _write_decode_req_to_token_kernel[(1,)](
+            req_to_token,
+            req_pool_indices,
+            seq_lens,
+            out_cache_loc,
+            max_context_len,
+        )
+
+        self.assertEqual(req_to_token[1, 512].item(), 12345)
+
+    def test_write_at_position_zero(self):
+        """Test writing at seq_len=0 (first position)."""
+        max_batch = 2
+        max_context_len = 8
+        req_to_token = torch.zeros(
+            (max_batch, max_context_len), dtype=torch.int32, device="cuda"
+        )
+        req_pool_indices = torch.tensor([0], dtype=torch.int64, device="cuda")
+        seq_lens = torch.tensor([0], dtype=torch.int64, device="cuda")
+        out_cache_loc = torch.tensor([7], dtype=torch.int64, device="cuda")
+
+        _write_decode_req_to_token_kernel[(1,)](
+            req_to_token,
+            req_pool_indices,
+            seq_lens,
+            out_cache_loc,
+            max_context_len,
+        )
+
+        self.assertEqual(req_to_token[0, 0].item(), 7)
+
+    def test_matches_python_reference(self):
+        """Test that the Triton kernel produces the same result as a Python reference."""
+        bs = 8
+        max_batch = 16
+        max_context_len = 64
+
+        req_pool_indices = torch.randint(
+            0, max_batch, (bs,), dtype=torch.int64, device="cuda"
+        )
+        seq_lens = torch.randint(
+            0, max_context_len, (bs,), dtype=torch.int64, device="cuda"
+        )
+        out_cache_loc = torch.randint(
+            0, 10000, (bs,), dtype=torch.int64, device="cuda"
+        )
+
+        # Triton kernel result
+        req_to_token_triton = torch.zeros(
+            (max_batch, max_context_len), dtype=torch.int32, device="cuda"
+        )
+        _write_decode_req_to_token_kernel[(bs,)](
+            req_to_token_triton,
+            req_pool_indices,
+            seq_lens,
+            out_cache_loc,
+            max_context_len,
+        )
+
+        # Python reference result
+        req_to_token_ref = torch.zeros(
+            (max_batch, max_context_len), dtype=torch.int32, device="cuda"
+        )
+        for i in range(bs):
+            req_idx = req_pool_indices[i].item()
+            col_idx = seq_lens[i].item()
+            value = out_cache_loc[i].item()
+            req_to_token_ref[req_idx, col_idx] = value
+
+        self.assertTrue(
+            torch.equal(req_to_token_triton, req_to_token_ref),
+            "Triton kernel result does not match Python reference",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR contains two performance optimization commits:

1. **Triton Kernel Optimization**: Added a Triton kernel for the `alloc_for_decode` function to improve KV cache allocation performance in the decode phase.

2. **Tokenizer Optimization and Initialization Refactoring**: Moved the creation of logprob containers from runtime to initialization phase to reduce runtime overhead and optimize tokenizer-related attribute access.

## Modifications

### Commit 1: add triton kernal for alloc_for_decode functions for better performance
- Goal: The write function can be optimized using Triton and removes an implicit synchronization operation.
- Added `_write_decode_req_to_token_kernel` Triton kernel in `python/sglang/srt/mem_cache/common.py`
- Replaced the original `batch.req_to_token_pool.write()` call with Triton kernel call
- Modified file: `python/sglang/srt/mem_cache/common.py`

### Commit 2: optmize tokenizer and move the behavior of creating list from runtime to init
- Goal: The original code had several lists that need to be created at runtime, moved this logic to the `__init__` phase
- Implementation:
    - Added `eos_token_id` and `additional_stop_token_ids` attributes to the `Req` class
    - Added `init_return_logprob_containers()` method to the `Scheduler` class to create logprob containers during initialization
    - When creating requests, obtain `eos_token_id` and `additional_stop_token_ids` from tokenizer and store them in the request object
    - Added `clear_list()` method to clear the lists


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
