### PR TITLE
Add adaptive speculative decoding observability

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1926,6 +1926,45 @@ class SpeculativeMetrics:
     accept_rate: float = field(
         metadata={"metric": ("gauge", "Speculative acceptance rate")}
     )
+    adaptive_enabled: int = field(
+        default=0,
+        metadata={
+            "metric": ("gauge", "Whether adaptive speculative decoding is active")
+        },
+    )
+    adaptive_current_steps: int = field(
+        default=0,
+        metadata={"metric": ("gauge", "Current adaptive speculative decoding tier")},
+    )
+    adaptive_previous_steps: int = field(
+        default=0,
+        metadata={"metric": ("gauge", "Previous adaptive speculative decoding tier")},
+    )
+    adaptive_num_tier_switches: int = field(
+        default=0,
+        metadata={"metric": ("gauge", "Adaptive speculative decoding tier switches")},
+    )
+    adaptive_ema_accept_length: float = field(
+        default=0.0,
+        metadata={
+            "metric": ("gauge", "Adaptive speculative decoding EMA accept length")
+        },
+    )
+    adaptive_last_batch_accept_length: float = field(
+        default=0.0,
+        metadata={
+            "metric": (
+                "gauge",
+                "Adaptive speculative decoding last batch accept length",
+            )
+        },
+    )
+    adaptive_wasted_draft_ratio: float = field(
+        default=0.0,
+        metadata={
+            "metric": ("gauge", "Adaptive speculative decoding wasted draft ratio")
+        },
+    )
 
 
 @dataclass

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3328,6 +3328,22 @@ class Scheduler(
                 self.spec_total_num_accepted_tokens / self.spec_total_num_forward_ct
             )
 
+        adaptive_metrics = self._get_adaptive_spec_metrics()
+        if adaptive_metrics["enabled"]:
+            ret["adaptive_spec_enabled"] = adaptive_metrics["enabled"]
+            ret["adaptive_spec_current_steps"] = adaptive_metrics["current_steps"]
+            ret["adaptive_spec_previous_steps"] = adaptive_metrics["previous_steps"]
+            ret["adaptive_spec_num_tier_switches"] = adaptive_metrics[
+                "num_tier_switches"
+            ]
+            ret["adaptive_spec_ema_accept_length"] = adaptive_metrics["ema_accept_len"]
+            ret["adaptive_spec_last_batch_accept_length"] = adaptive_metrics[
+                "last_batch_accept_len"
+            ]
+            ret["adaptive_spec_wasted_draft_ratio"] = adaptive_metrics[
+                "wasted_draft_ratio"
+            ]
+
         if RECORD_STEP_TIME:
             ret["step_time_dict"] = self.step_time_dict
 

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -101,6 +101,13 @@ class SchedulerStats:
     # Speculative decoding
     spec_accept_length: float = 0.0
     spec_accept_rate: float = 0.0
+    adaptive_spec_enabled: int = 0
+    adaptive_spec_current_steps: int = 0
+    adaptive_spec_previous_steps: int = 0
+    adaptive_spec_num_tier_switches: int = 0
+    adaptive_spec_ema_accept_length: float = 0.0
+    adaptive_spec_last_batch_accept_length: float = 0.0
+    adaptive_spec_wasted_draft_ratio: float = 0.0
 
     # Retract
     num_retracted_reqs: int = 0
@@ -177,7 +184,6 @@ class DPCooperationInfo:
 
 
 class SchedulerMetricsCollector:
-
     def __init__(
         self,
         labels: Dict[str, str],
@@ -311,6 +317,48 @@ class SchedulerMetricsCollector:
         self.spec_accept_rate = Gauge(
             name="sglang:spec_accept_rate",
             documentation="Speculative acceptance rate (`accepted drafts / proposed drafts` in batch).",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+        self.adaptive_spec_enabled = Gauge(
+            name="sglang:adaptive_spec_enabled",
+            documentation="Whether adaptive speculative decoding is active for this scheduler.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+        self.adaptive_spec_current_steps = Gauge(
+            name="sglang:adaptive_spec_current_steps",
+            documentation="The active speculative_num_steps tier selected by adaptive speculative decoding.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+        self.adaptive_spec_previous_steps = Gauge(
+            name="sglang:adaptive_spec_previous_steps",
+            documentation="The previous speculative_num_steps tier before the last adaptive switch.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+        self.adaptive_spec_num_tier_switches = Gauge(
+            name="sglang:adaptive_spec_num_tier_switches",
+            documentation="The number of adaptive speculative decoding tier switches since startup.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+        self.adaptive_spec_ema_accept_length = Gauge(
+            name="sglang:adaptive_spec_ema_accept_length",
+            documentation="The EMA accept length used by the adaptive speculative decoding policy.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+        self.adaptive_spec_last_batch_accept_length = Gauge(
+            name="sglang:adaptive_spec_last_batch_accept_length",
+            documentation="The last observed batch average accept length for adaptive speculative decoding.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+        self.adaptive_spec_wasted_draft_ratio = Gauge(
+            name="sglang:adaptive_spec_wasted_draft_ratio",
+            documentation="The last observed ratio of proposed draft tokens not accepted by adaptive speculative decoding.",
             labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
         )
@@ -1043,6 +1091,29 @@ class SchedulerMetricsCollector:
         # Speculative decoding
         self._log_gauge(self.spec_accept_length, stats.spec_accept_length)
         self._log_gauge(self.spec_accept_rate, stats.spec_accept_rate)
+        self._log_gauge(self.adaptive_spec_enabled, stats.adaptive_spec_enabled)
+        self._log_gauge(
+            self.adaptive_spec_current_steps, stats.adaptive_spec_current_steps
+        )
+        self._log_gauge(
+            self.adaptive_spec_previous_steps, stats.adaptive_spec_previous_steps
+        )
+        self._log_gauge(
+            self.adaptive_spec_num_tier_switches,
+            stats.adaptive_spec_num_tier_switches,
+        )
+        self._log_gauge(
+            self.adaptive_spec_ema_accept_length,
+            stats.adaptive_spec_ema_accept_length,
+        )
+        self._log_gauge(
+            self.adaptive_spec_last_batch_accept_length,
+            stats.adaptive_spec_last_batch_accept_length,
+        )
+        self._log_gauge(
+            self.adaptive_spec_wasted_draft_ratio,
+            stats.adaptive_spec_wasted_draft_ratio,
+        )
 
         # PD disaggregation
         self._log_gauge_queue_count(

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -183,6 +183,38 @@ class SchedulerMetricsMixin:
         # Bonus tokens updated elsewhere
         self.num_generated_tokens += num_accepted_drafts
 
+    def _get_adaptive_spec_metrics(self: Scheduler) -> dict[str, float | int]:
+        draft_worker = getattr(self, "draft_worker", None)
+        controller = getattr(draft_worker, "adaptive_controller", None)
+        if controller is None and draft_worker is not None:
+            nested_draft_worker = getattr(draft_worker, "draft_worker", None)
+            controller = getattr(nested_draft_worker, "adaptive_controller", None)
+        if controller is None:
+            return {
+                "enabled": 0,
+                "current_steps": 0,
+                "previous_steps": 0,
+                "num_tier_switches": 0,
+                "ema_accept_len": 0.0,
+                "last_batch_accept_len": 0.0,
+                "wasted_draft_ratio": 0.0,
+            }
+        return controller.get_metrics()
+
+    def _update_adaptive_spec_stats(self: Scheduler) -> None:
+        metrics = self._get_adaptive_spec_metrics()
+        self.stats.adaptive_spec_enabled = int(metrics["enabled"])
+        self.stats.adaptive_spec_current_steps = int(metrics["current_steps"])
+        self.stats.adaptive_spec_previous_steps = int(metrics["previous_steps"])
+        self.stats.adaptive_spec_num_tier_switches = int(metrics["num_tier_switches"])
+        self.stats.adaptive_spec_ema_accept_length = float(metrics["ema_accept_len"])
+        self.stats.adaptive_spec_last_batch_accept_length = float(
+            metrics["last_batch_accept_len"]
+        )
+        self.stats.adaptive_spec_wasted_draft_ratio = float(
+            metrics["wasted_draft_ratio"]
+        )
+
     def _init_estimated_perf_constants(self: Scheduler) -> None:
         model_config = self.model_config
         hf_text_config = model_config.hf_text_config
@@ -611,6 +643,7 @@ class SchedulerMetricsMixin:
             # Speculative decoding
             self.stats.spec_accept_rate = spec_accept_rate
             self.stats.spec_accept_length = spec_accept_length
+            self._update_adaptive_spec_stats()
 
             # Retract
             self.stats.num_retracted_reqs = self.num_retracted_reqs
@@ -839,13 +872,36 @@ class SchedulerMetricsMixin:
 
         speculative = None
         if include_all or "spec" in include:
-            if not self.spec_algorithm.is_none() and self.spec_total_num_forward_ct > 0:
+            adaptive_metrics = self._get_adaptive_spec_metrics()
+            has_spec_totals = (
+                not self.spec_algorithm.is_none() and self.spec_total_num_forward_ct > 0
+            )
+            if not self.spec_algorithm.is_none() and (
+                has_spec_totals or adaptive_metrics["enabled"]
+            ):
                 speculative = SpeculativeMetrics(
                     accept_length=(
                         self.spec_total_num_accepted_tokens
                         / self.spec_total_num_forward_ct
+                        if self.spec_total_num_forward_ct > 0
+                        else 0.0
                     ),
                     accept_rate=self.stats.spec_accept_rate,
+                    adaptive_enabled=int(adaptive_metrics["enabled"]),
+                    adaptive_current_steps=int(adaptive_metrics["current_steps"]),
+                    adaptive_previous_steps=int(adaptive_metrics["previous_steps"]),
+                    adaptive_num_tier_switches=int(
+                        adaptive_metrics["num_tier_switches"]
+                    ),
+                    adaptive_ema_accept_length=float(
+                        adaptive_metrics["ema_accept_len"]
+                    ),
+                    adaptive_last_batch_accept_length=float(
+                        adaptive_metrics["last_batch_accept_len"]
+                    ),
+                    adaptive_wasted_draft_ratio=float(
+                        adaptive_metrics["wasted_draft_ratio"]
+                    ),
                 )
 
         lora = None

--- a/python/sglang/srt/speculative/adaptive_runtime_state.py
+++ b/python/sglang/srt/speculative/adaptive_runtime_state.py
@@ -82,10 +82,25 @@ class AdaptiveController:
             config=cfg,
         )
         self._states: dict[int, SpecRuntimeState] = {}
+        self._active_steps: int | None = None
+        self.previous_steps: int | None = None
+        self.num_tier_switches = 0
 
     @property
     def candidate_steps(self) -> list[int]:
         return self.params.candidate_steps
+
+    def get_metrics(self) -> dict[str, float | int]:
+        """Return low-cardinality observability state for adaptive spec."""
+        return {
+            "enabled": 1,
+            "current_steps": self.params.current_steps,
+            "previous_steps": self.previous_steps or 0,
+            "num_tier_switches": self.num_tier_switches,
+            "ema_accept_len": self.params.ema_accept_len,
+            "last_batch_accept_len": self.params.last_batch_accept_len,
+            "wasted_draft_ratio": self.params.last_batch_wasted_draft_ratio,
+        }
 
     def register(self, state: SpecRuntimeState, steps: int | None = None) -> None:
         """Register a pre-built runtime state.
@@ -109,7 +124,14 @@ class AdaptiveController:
 
     def on_verify_complete(self, num_accepted_drafts_per_req: list[int]) -> None:
         """Feed verify results; switch runtime state if EMA warrants it."""
-        if self.params.update(num_accepted_drafts_per_req):
+        active_steps = (
+            self._active_steps
+            if self._active_steps is not None
+            else self.params.current_steps
+        )
+        if self.params.update(
+            num_accepted_drafts_per_req, draft_capacity_per_req=active_steps
+        ):
             self._activate(self.params.current_steps)
 
     def _activate(self, speculative_num_steps: int) -> None:
@@ -118,4 +140,11 @@ class AdaptiveController:
             raise ValueError(
                 f"Missing adaptive runtime state for steps={speculative_num_steps}"
             )
+        if (
+            self._active_steps is not None
+            and self._active_steps != speculative_num_steps
+        ):
+            self.previous_steps = self._active_steps
+            self.num_tier_switches += 1
+        self._active_steps = speculative_num_steps
         self.worker.apply_runtime_state(state)

--- a/python/sglang/srt/speculative/adaptive_spec_params.py
+++ b/python/sglang/srt/speculative/adaptive_spec_params.py
@@ -115,6 +115,8 @@ class AdaptiveSpeculativeParams:
 
         # Initialize EMA at current steps - 1 (neutral starting point)
         self.ema_accept_len = float(self.current_steps - 1)
+        self.last_batch_accept_len = 0.0
+        self.last_batch_wasted_draft_ratio = 0.0
         self._batch_count = 0
 
         logger.info(
@@ -122,16 +124,26 @@ class AdaptiveSpeculativeParams:
             f"steps={self.current_steps}, candidate_steps={self.candidate_steps}"
         )
 
-    def update(self, num_accepted_drafts_per_req: list[int]) -> bool:
+    def update(
+        self,
+        num_accepted_drafts_per_req: list[int],
+        draft_capacity_per_req: int | None = None,
+    ) -> bool:
         """Update EMA with observed accept lengths. Returns True if params changed.
 
         Args:
             num_accepted_drafts_per_req: Per-request accepted draft token counts from last verify.
+            draft_capacity_per_req: Maximum accepted draft length per request for the
+                active tier before any update-triggered switch.
         """
         if not num_accepted_drafts_per_req:
             return False
 
         batch_avg = sum(num_accepted_drafts_per_req) / len(num_accepted_drafts_per_req)
+        self.last_batch_accept_len = batch_avg
+        self.last_batch_wasted_draft_ratio = self._compute_wasted_draft_ratio(
+            num_accepted_drafts_per_req, draft_capacity_per_req
+        )
         self.ema_accept_len = (
             1 - self.ema_alpha
         ) * self.ema_accept_len + self.ema_alpha * batch_avg
@@ -144,6 +156,26 @@ class AdaptiveSpeculativeParams:
             return False
 
         return self._recompute_params()
+
+    def _compute_wasted_draft_ratio(
+        self,
+        num_accepted_drafts_per_req: list[int],
+        draft_capacity_per_req: int | None,
+    ) -> float:
+        draft_capacity_per_req = (
+            self.current_steps
+            if draft_capacity_per_req is None
+            else max(0, draft_capacity_per_req)
+        )
+        total_draft_tokens = len(num_accepted_drafts_per_req) * draft_capacity_per_req
+        if total_draft_tokens == 0:
+            return 0.0
+
+        accepted_draft_tokens = sum(
+            min(max(num_accepted_drafts, 0), draft_capacity_per_req)
+            for num_accepted_drafts in num_accepted_drafts_per_req
+        )
+        return (total_draft_tokens - accepted_draft_tokens) / total_draft_tokens
 
     def _recompute_params(self) -> bool:
         """Recompute steps from EMA. Returns True if params changed."""

--- a/test/registered/unit/observability/test_adaptive_spec_metrics.py
+++ b/test/registered/unit/observability/test_adaptive_spec_metrics.py
@@ -1,0 +1,170 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.managers.io_struct import GetLoadsReqInput
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.observability.metrics_collector import (
+    SchedulerMetricsCollector,
+    SchedulerStats,
+)
+from sglang.srt.observability.scheduler_metrics_mixin import SchedulerMetricsMixin
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+
+
+class _FakeMetric:
+    def __init__(self, *args, **kwargs):
+        self.name = kwargs.get("name")
+        self.value = None
+        self.observations = []
+        self.increments = []
+
+    def labels(self, **kwargs):
+        return self
+
+    def set(self, value):
+        self.value = value
+
+    def observe(self, value):
+        self.observations.append(value)
+
+    def inc(self, value=1):
+        self.increments.append(value)
+
+
+def _scheduler_labels():
+    return {
+        "model_name": "test",
+        "engine_type": "unified",
+        "tp_rank": 0,
+        "pp_rank": 0,
+        "moe_ep_rank": 0,
+    }
+
+
+def _server_args():
+    return SimpleNamespace(
+        prefill_delayer_max_delay_passes=8,
+        prefill_delayer_forward_passes_buckets=None,
+        prefill_delayer_wait_seconds_buckets=None,
+    )
+
+
+def _make_collector():
+    return SchedulerMetricsCollector(
+        labels=_scheduler_labels(),
+        server_args=_server_args(),
+    )
+
+
+def _adaptive_metrics():
+    return {
+        "enabled": 1,
+        "current_steps": 3,
+        "previous_steps": 1,
+        "num_tier_switches": 2,
+        "ema_accept_len": 2.25,
+        "last_batch_accept_len": 2.5,
+        "wasted_draft_ratio": 0.5,
+    }
+
+
+def _make_scheduler_stub():
+    return SimpleNamespace(
+        running_batch=SimpleNamespace(reqs=[]),
+        waiting_queue=[],
+        disaggregation_mode=DisaggregationMode.NULL,
+        get_pool_stats=lambda: SimpleNamespace(get_kv_token_stats=lambda: (8, 0.125)),
+        _get_adaptive_spec_metrics=_adaptive_metrics,
+        spec_algorithm=SimpleNamespace(is_none=lambda: False),
+        spec_total_num_forward_ct=0,
+        spec_total_num_accepted_tokens=0,
+        stats=SchedulerStats(spec_accept_rate=0.75),
+        dp_rank=0,
+        max_total_num_tokens=1024,
+        max_running_requests=16,
+        last_gen_throughput=0.0,
+        tp_worker=SimpleNamespace(
+            model_runner=SimpleNamespace(
+                weight_load_mem_usage=0.0,
+                graph_mem_usage=0.0,
+            )
+        ),
+        token_to_kv_pool_allocator=SimpleNamespace(
+            get_kvcache=lambda: SimpleNamespace(mem_usage=0.0)
+        ),
+    )
+
+
+@patch("prometheus_client.Summary", _FakeMetric)
+@patch("prometheus_client.Histogram", _FakeMetric)
+@patch("prometheus_client.Counter", _FakeMetric)
+@patch("prometheus_client.Gauge", _FakeMetric)
+class TestAdaptiveSpecMetricsCollector(CustomTestCase):
+    def test_log_stats_emits_adaptive_spec_gauges(self):
+        collector = _make_collector()
+        stats = SchedulerStats(
+            adaptive_spec_enabled=1,
+            adaptive_spec_current_steps=3,
+            adaptive_spec_previous_steps=1,
+            adaptive_spec_num_tier_switches=2,
+            adaptive_spec_ema_accept_length=2.25,
+            adaptive_spec_last_batch_accept_length=2.5,
+            adaptive_spec_wasted_draft_ratio=0.5,
+        )
+
+        collector.log_stats(stats)
+
+        self.assertEqual(collector.adaptive_spec_enabled.value, 1)
+        self.assertEqual(collector.adaptive_spec_current_steps.value, 3)
+        self.assertEqual(collector.adaptive_spec_previous_steps.value, 1)
+        self.assertEqual(collector.adaptive_spec_num_tier_switches.value, 2)
+        self.assertEqual(collector.adaptive_spec_ema_accept_length.value, 2.25)
+        self.assertEqual(
+            collector.adaptive_spec_last_batch_accept_length.value,
+            2.5,
+        )
+        self.assertEqual(collector.adaptive_spec_wasted_draft_ratio.value, 0.5)
+
+    def test_log_stats_marks_adaptive_spec_disabled_by_default(self):
+        collector = _make_collector()
+
+        collector.log_stats(SchedulerStats())
+
+        self.assertEqual(collector.adaptive_spec_enabled.value, 0)
+        self.assertEqual(collector.adaptive_spec_current_steps.value, 0)
+        self.assertEqual(collector.adaptive_spec_wasted_draft_ratio.value, 0.0)
+
+    def test_get_loads_includes_adaptive_spec_wasted_draft_ratio(self):
+        scheduler = _make_scheduler_stub()
+
+        loads = SchedulerMetricsMixin.get_loads(
+            scheduler, GetLoadsReqInput(include=["spec"])
+        )
+
+        self.assertIsNotNone(loads.speculative)
+        self.assertEqual(loads.speculative.adaptive_enabled, 1)
+        self.assertEqual(loads.speculative.adaptive_wasted_draft_ratio, 0.5)
+
+    @patch("sglang.srt.managers.scheduler.get_global_server_args")
+    def test_internal_state_includes_adaptive_spec_wasted_draft_ratio(
+        self, get_global_server_args
+    ):
+        scheduler = _make_scheduler_stub()
+        get_global_server_args.return_value = SimpleNamespace(model_config=object())
+
+        output = Scheduler.get_internal_state(scheduler, recv_req=None)
+
+        self.assertEqual(output.internal_state["adaptive_spec_enabled"], 1)
+        self.assertEqual(output.internal_state["adaptive_spec_wasted_draft_ratio"], 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_adaptive_spec_params.py
+++ b/test/registered/unit/spec/test_adaptive_spec_params.py
@@ -1,12 +1,17 @@
 import unittest
 
+from sglang.srt.speculative.adaptive_runtime_state import (
+    AdaptiveController,
+    SpecRuntimeState,
+)
 from sglang.srt.speculative.adaptive_spec_params import AdaptiveSpeculativeParams
 from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=6, suite="stage-a-test-cpu")
 
 
-class TestAdaptiveSpeculativeParams(unittest.TestCase):
+class TestAdaptiveSpeculativeParams(CustomTestCase):
     def test_initial_steps_snap_to_nearest_candidate_preferring_larger_step(self):
         params = AdaptiveSpeculativeParams(
             initial_steps=2,
@@ -15,6 +20,8 @@ class TestAdaptiveSpeculativeParams(unittest.TestCase):
 
         self.assertEqual(params.current_steps, 3)
         self.assertEqual(params.ema_accept_len, 2.0)
+        self.assertEqual(params.last_batch_accept_len, 0.0)
+        self.assertEqual(params.last_batch_wasted_draft_ratio, 0.0)
 
     def test_update_respects_warmup_and_interval(self):
         params = AdaptiveSpeculativeParams(
@@ -29,6 +36,7 @@ class TestAdaptiveSpeculativeParams(unittest.TestCase):
 
         self.assertFalse(params.update([0, 0]))
         self.assertEqual(params.current_steps, 3)
+        self.assertEqual(params.last_batch_wasted_draft_ratio, 1.0)
 
         self.assertFalse(params.update([0, 0]))
         self.assertEqual(params.current_steps, 3)
@@ -50,9 +58,13 @@ class TestAdaptiveSpeculativeParams(unittest.TestCase):
         self.assertFalse(params.update([]))
         self.assertEqual(params.current_steps, 3)
         self.assertEqual(params.ema_accept_len, 2.0)
+        self.assertEqual(params.last_batch_accept_len, 0.0)
+        self.assertEqual(params.last_batch_wasted_draft_ratio, 0.0)
 
         self.assertFalse(params.update([0, 0]))
         self.assertEqual(params.current_steps, 3)
+        self.assertEqual(params.last_batch_accept_len, 0.0)
+        self.assertEqual(params.last_batch_wasted_draft_ratio, 1.0)
 
         self.assertTrue(params.update([0, 0]))
         self.assertEqual(params.current_steps, 1)
@@ -189,6 +201,119 @@ class TestAdaptiveSpeculativeParams(unittest.TestCase):
         self.assertTrue(params.update([0, 0]))
         self.assertEqual(params.current_steps, 1)
         self.assertEqual(params.ema_accept_len, 0.375)
+        self.assertEqual(params.last_batch_accept_len, 0.0)
+        self.assertEqual(params.last_batch_wasted_draft_ratio, 1.0)
+
+    def test_wasted_draft_ratio_uses_active_tier_capacity(self):
+        params = AdaptiveSpeculativeParams(
+            initial_steps=3,
+            config={
+                "candidate_steps": [1, 3, 7],
+                "ema_alpha": 1.0,
+                "warmup_batches": 1,
+                "update_interval": 1,
+            },
+        )
+
+        self.assertFalse(params.update([1, 3], draft_capacity_per_req=3))
+        self.assertAlmostEqual(params.last_batch_wasted_draft_ratio, 1 / 3)
+
+    def test_wasted_draft_ratio_handles_zero_capacity(self):
+        params = AdaptiveSpeculativeParams(
+            initial_steps=1,
+            config={"candidate_steps": [1, 3, 7]},
+        )
+
+        self.assertFalse(params.update([0, 0], draft_capacity_per_req=0))
+        self.assertEqual(params.last_batch_wasted_draft_ratio, 0.0)
+
+
+class _FakeAdaptiveWorker:
+    def __init__(self, initial_steps: int = 1):
+        self.speculative_num_steps = initial_steps
+        self.applied_steps = []
+        self.built_steps = []
+
+    def build_adaptive_runtime_state(
+        self, speculative_num_steps: int, speculative_num_draft_tokens: int
+    ) -> SpecRuntimeState:
+        self.built_steps.append(speculative_num_steps)
+        return _make_runtime_state(
+            speculative_num_steps=speculative_num_steps,
+            speculative_num_draft_tokens=speculative_num_draft_tokens,
+        )
+
+    def apply_runtime_state(self, state: SpecRuntimeState) -> None:
+        self.speculative_num_steps = state.speculative_num_steps
+        self.applied_steps.append(state.speculative_num_steps)
+
+
+def _make_runtime_state(
+    speculative_num_steps: int,
+    speculative_num_draft_tokens: int | None = None,
+) -> SpecRuntimeState:
+    if speculative_num_draft_tokens is None:
+        speculative_num_draft_tokens = speculative_num_steps + 1
+    return SpecRuntimeState(
+        speculative_num_steps=speculative_num_steps,
+        speculative_num_draft_tokens=speculative_num_draft_tokens,
+        draft_attn_backend=None,
+        cuda_graph_runner=None,
+        target_attn_backend=object(),
+        target_graph_runner=None,
+        draft_extend_attn_backend=None,
+        cuda_graph_runner_for_draft_extend=None,
+    )
+
+
+class TestAdaptiveControllerMetrics(CustomTestCase):
+    def test_metrics_snapshot_tracks_acceptance_and_switches(self):
+        worker = _FakeAdaptiveWorker(initial_steps=1)
+        controller = AdaptiveController(worker)
+        controller.params.ema_alpha = 1.0
+        controller.params.warmup_batches = 0
+        controller.params.update_interval = 1
+        controller.params.up_hysteresis = 0.0
+        controller.register(_make_runtime_state(1))
+        controller.init_states()
+
+        self.assertEqual(worker.built_steps, [3, 7])
+        self.assertEqual(worker.applied_steps, [1])
+        self.assertEqual(
+            controller.get_metrics(),
+            {
+                "enabled": 1,
+                "current_steps": 1,
+                "previous_steps": 0,
+                "num_tier_switches": 0,
+                "ema_accept_len": 0.0,
+                "last_batch_accept_len": 0.0,
+                "wasted_draft_ratio": 0.0,
+            },
+        )
+
+        controller.on_verify_complete([1, 1])
+        metrics = controller.get_metrics()
+
+        self.assertEqual(worker.applied_steps, [1, 3])
+        self.assertEqual(metrics["current_steps"], 3)
+        self.assertEqual(metrics["previous_steps"], 1)
+        self.assertEqual(metrics["num_tier_switches"], 1)
+        self.assertEqual(metrics["ema_accept_len"], 1.0)
+        self.assertEqual(metrics["last_batch_accept_len"], 1.0)
+        self.assertEqual(metrics["wasted_draft_ratio"], 0.0)
+
+    def test_initial_activation_is_not_counted_as_tier_switch(self):
+        worker = _FakeAdaptiveWorker(initial_steps=3)
+        controller = AdaptiveController(worker)
+        controller.register(_make_runtime_state(3))
+        controller.init_states()
+
+        metrics = controller.get_metrics()
+        self.assertEqual(metrics["enabled"], 1)
+        self.assertEqual(metrics["current_steps"], 3)
+        self.assertEqual(metrics["previous_steps"], 0)
+        self.assertEqual(metrics["num_tier_switches"], 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Adaptive speculative decoding roadmap issue #23705 includes a reliability/observability item for adaptive spec metrics: active tier and wasted draft ratio. This is part of the broader speculative decoding roadmap #23005.

This PR implements that observability sub-item for the currently merged adaptive EAGLE/EAGLE3 controller path. It does not change the adaptive policy, scheduling behavior, or speculative decoding correctness. The goal is to give operators and maintainers low-cardinality signals for understanding whether adaptive spec is using the intended tier and how much draft work is being discarded under changing workloads.

## Modifications

- Add adaptive controller/runtime metrics:
  - enabled state
  - current adaptive tier / `speculative_num_steps`
  - previous tier
  - tier switch count
  - EMA accept length
  - last batch average accept length
  - wasted draft ratio
- Define wasted draft ratio from the just-verified batch as:
  - `(proposed draft tokens - accepted draft tokens) / proposed draft tokens`
  - For the current EAGLE/EAGLE3 topk=1 path, the denominator is `batch_size * active speculative_num_steps`, using the active tier before any EMA-triggered switch.
  - Handles zero draft-token capacity defensively for future step=0 support.
- Surface the metrics through:
  - Prometheus gauges in `SchedulerMetricsCollector`
  - `/v1/loads?include=spec` via `SpeculativeMetrics`
  - `/server_info` internal adaptive state
- Add unit coverage for:
  - adaptive state accounting and tier switch metrics
  - wasted draft ratio calculation
  - Prometheus collector logging
  - `/v1/loads` and `/server_info` public fields

## Accuracy Tests

Not applicable. This PR only adds observability state and does not change model forward outputs or acceptance decisions.

## Speed Tests and Profiling

Not a throughput optimization PR. The new work is scalar accounting on the adaptive controller path and low-cardinality metric export. No model-forward or GPU-kernel paths are changed.

An A100 smoke test was run to verify the metric surfaces on an adaptive EAGLE server:

- GPU: A100-80GB
- Server: `meta-llama/Llama-2-7b-chat-hf` target with `lmsys/sglang-EAGLE-llama2-chat-7B` draft model
- Flags included `--speculative-adaptive`, `--enable-metrics`, `--decode-log-interval 1`
- Verified:
  - server starts with adaptive EAGLE
  - `/metrics` contains all adaptive spec gauges, including `sglang:adaptive_spec_wasted_draft_ratio`
  - `/v1/loads?include=spec` includes adaptive fields, including `adaptive_wasted_draft_ratio`
  - `/server_info` includes adaptive internal state, including `adaptive_spec_wasted_draft_ratio`
  - observed final adaptive state: `current_steps=1`, `previous_steps=3`, `num_tier_switches=8`, `wasted_draft_ratio=1.0`

## Validation

Local static:

```bash
python3 -m py_compile python/sglang/srt/speculative/adaptive_spec_params.py python/sglang/srt/speculative/adaptive_runtime_state.py python/sglang/srt/observability/metrics_collector.py python/sglang/srt/observability/scheduler_metrics_mixin.py python/sglang/srt/managers/io_struct.py python/sglang/srt/managers/scheduler.py test/registered/unit/spec/test_adaptive_spec_params.py test/registered/unit/observability/test_adaptive_spec_metrics.py
pre-commit run black-jupyter --files python/sglang/srt/speculative/adaptive_spec_params.py python/sglang/srt/speculative/adaptive_runtime_state.py python/sglang/srt/observability/metrics_collector.py python/sglang/srt/observability/scheduler_metrics_mixin.py python/sglang/srt/managers/io_struct.py python/sglang/srt/managers/scheduler.py test/registered/unit/spec/test_adaptive_spec_params.py test/registered/unit/observability/test_adaptive_spec_metrics.py
ruff check --extend-ignore E402,E731 python/sglang/srt/speculative/adaptive_spec_params.py python/sglang/srt/speculative/adaptive_runtime_state.py python/sglang/srt/observability/metrics_collector.py python/sglang/srt/observability/scheduler_metrics_mixin.py python/sglang/srt/managers/io_struct.py python/sglang/srt/managers/scheduler.py test/registered/unit/spec/test_adaptive_spec_params.py test/registered/unit/observability/test_adaptive_spec_metrics.py
git diff --check
```

CPU validation:

```bash
pytest -q test/registered/unit/spec/test_adaptive_spec_params.py test/registered/unit/observability/test_adaptive_spec_metrics.py
black --check <touched files>
ruff check --extend-ignore E402,E731 <touched files>
```

- `18 passed, 6 warnings in 54.65s`
- `black --check`: passed
- `ruff check`: passed

A100 validation:

- A100-80GB adaptive EAGLE smoke passed.
- Verified Prometheus, `/v1/loads`, and `/server_info` adaptive metrics.

## CI note

A previous draft of this branch had CI blocked by PR gate because the PR was draft, and lint reported one black formatting issue in `adaptive_spec_params.py`. This revision is opened ready for review and includes the black-compatible formatting fix.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Not applicable; this is an internal observability metric surface.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable for accuracy/speed; GPU smoke provided for runtime validation.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).


