### PR TITLE
[AMD] Fix CI test_diffusion_generation[flux_2_image_t2i_2_gpus]

### DIFF
--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -751,7 +751,7 @@ jobs:
           docker exec ci_sglang rocm-smi --showmeminfo vram 2>/dev/null || echo "rocm-smi not available"
 
       - name: Run diffusion server tests (2-GPU)
-        timeout-minutes: 80
+        timeout-minutes: 150
         run: |
           # AMD CI: All 2-GPU tests including LoRA
           # Tests: T2V, T2I, I2V, LoRA

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -807,7 +807,7 @@ jobs:
           docker exec ci_sglang rocm-smi --showmeminfo vram 2>/dev/null || echo "rocm-smi not available"
 
       - name: Run diffusion server tests (2-GPU)
-        timeout-minutes: 90
+        timeout-minutes: 150
         run: |
           # AMD CI: All 2-GPU tests including LoRA
           # Tests: T2V, T2I, I2V, LoRA


### PR DESCRIPTION
## Motivation

The `multimodal-gen-test-2-gpu-amd` CI job times out when HuggingFace Hub downloads are slow. The FLUX.1-dev model requires downloading ~39 files, and under degraded network conditions (~4 min/file), the 90-minute step timeout is exceeded before tests can even begin.

For reference, the NVIDIA equivalent workflow (`pr-test-multimodal-gen.yml`) uses a 240-minute timeout for the same tests. The AMD workflows had less than half that budget despite downloading the same models.

**Example failure:** https://github.com/sgl-project/sglang/actions/runs/25038683025 — `multimodal-gen-test-2-gpu-amd` timed out at 90 minutes during model download.

## Modifications

Increased the `timeout-minutes` for the "Run diffusion server tests (2-GPU)" step in two AMD CI workflow files:

| Workflow | Before | After |
|---|---|---|
| `.github/workflows/pr-test-amd.yml` | 90 min | 150 min |
| `.github/workflows/pr-test-amd-rocm720.yml` | 80 min | 150 min |

150 minutes provides sufficient headroom for slow downloads while staying well below the NVIDIA 240-minute timeout.

## Accuracy Tests

N/A — CI-only change, no model or kernel code modified.

## Speed Tests and Profiling

N/A — no inference code changes.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
