### PR TITLE
fix(openai): map reasoning.enabled to thinking AND enable_thinking

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -720,7 +720,11 @@ class ChatCompletionRequest(BaseModel):
                 ctk = values.get("chat_template_kwargs")
                 if not isinstance(ctk, dict):
                     ctk = {}
+                # different models check different keys:
+                # - "thinking" for deepseek-v3, kimi_k2
+                # - "enable_thinking" for qwen3, glm45, nemotron_3, interns1, mimo
                 ctk.setdefault("thinking", True)
+                ctk.setdefault("enable_thinking", True)
                 values["chat_template_kwargs"] = ctk
 
         if values.get("reasoning_effort") == "none":

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -191,7 +191,10 @@ class TestChatCompletionRequest(unittest.TestCase):
             },
         )
         self.assertEqual(request.reasoning_effort, "high")
-        self.assertEqual(request.chat_template_kwargs, {"thinking": True})
+        self.assertEqual(
+            request.chat_template_kwargs,
+            {"thinking": True, "enable_thinking": True},
+        )
 
     def test_chat_completion_reasoning_effort_none(self):
         """Test reasoning_effort='none' disables thinking"""


### PR DESCRIPTION
## Summary

When a request sets `reasoning.enabled=true` (or its OpenAI equivalent), the chat completion handler used to forward only `chat_template_kwargs={"thinking": True}` — which works for `deepseek-v3` / `kimi_k2` but is silently ignored by `qwen3` / `glm45` / `nemotron_3` / `interns1` / `mimo` (those check `enable_thinking` instead).

Set both keys via `setdefault` so a single request flag covers all model families uniformly. Existing behavior is preserved when callers pass `chat_template_kwargs` explicitly.

Split out of #22254 — 9-line standalone bugfix, no dependency on the rest.

## Test plan

- [x] `python3 test/registered/unit/entrypoints/openai/test_protocol.py` (assertion updated to verify both keys are set)
- [ ] Manual: send a request with `reasoning.enabled=true` to a Qwen3 server, confirm the model produces `<think>` content