### PR TITLE
Multi detokenizer support for dsv4.

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -650,6 +650,10 @@ class ModelConfig:
             and envs.SGLANG_DSV4_MODE.get() == "2604"
             else self.hidden_size
         )
+        # Effective hidden size after mHC flattening: hc_mult * hidden_size.
+        # For non-mHC models this equals hidden_size.
+        # Same value as spec_hidden_size; TODO: unify into one field.
+        self.hc_hidden_size = self.spec_hidden_size
         self.num_hidden_layers = self.hf_text_config.num_hidden_layers
         self.num_attention_layers = self.num_hidden_layers
         if "LongcatFlashForCausalLM" in self.hf_config.architectures:

--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -33,12 +33,22 @@ class KVArgs:
     decode_tp_size: int
     kv_head_num: int
     page_size: int
+    # for system dp
+    system_dp_rank: int
     # for pp prefill
     prefill_pp_size: int
     pp_rank: int
     prefill_start_layer: int
-    # for system dp
-    system_dp_rank: int
+    # Absolute end layer (exclusive) for this prefill PP stage. Needed to
+    # reconstruct PP sub-ranges when kv_data_ptrs does not use a flat
+    # layer-indexed layout (e.g. DeepSeek V4's buffer-type-organized flat
+    # list).
+    prefill_end_layer: int
+    # For DeepSeek V4 (and other compressed-MLA) memory pools only.
+    # Full-model compression ratio per layer (entries are 0/4/128). Used by
+    # the connection layer to slice the buffer-type-organized flat list in a
+    # PP-aware manner.
+    mla_compression_ratios: Optional[List[int]]
 
 
 class KVPoll:

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -188,15 +188,120 @@ class CommonKVManager(BaseKVManager):
     def get_mla_kv_ptrs_with_pp(
         self, src_kv_ptrs: List[int], dst_kv_ptrs: List[int]
     ) -> Tuple[List[int], List[int], int]:
+        # Fast path: both sides use exactly the same PP layout
+        if len(src_kv_ptrs) == len(dst_kv_ptrs):
+            return src_kv_ptrs, dst_kv_ptrs, len(src_kv_ptrs)
+
+        mla_ratios = getattr(self.kv_args, "mla_compression_ratios", None)
+        if mla_ratios:
+            # Compressed-MLA (e.g. DeepSeek V4): the flat list is organized
+            # by buffer type (compression-ratio bucket) rather than by
+            # layer, so we locate the sub-range for this PP stage inside each
+            # section of the dst flat list.
+            sliced_src_kv_ptrs, sliced_dst_kv_ptrs = self._mla_slice_ptrs_for_pp(
+                src_kv_ptrs, dst_kv_ptrs, mla_ratios
+            )
+            return (
+                sliced_src_kv_ptrs,
+                sliced_dst_kv_ptrs,
+                len(sliced_src_kv_ptrs),
+            )
+
+        # Regular MLA PP slicing
         start_layer = self.kv_args.prefill_start_layer
         end_layer = start_layer + len(src_kv_ptrs)
-        if len(src_kv_ptrs) == len(dst_kv_ptrs):
-            sliced_dst_kv_ptrs = dst_kv_ptrs
+        # Decode pp size should be equal to prefill pp size or 1
+        sliced_dst_kv_ptrs = dst_kv_ptrs[start_layer:end_layer]
+        return src_kv_ptrs, sliced_dst_kv_ptrs, len(src_kv_ptrs)
+
+    def _mla_slice_ptrs_for_pp(
+        self,
+        src_kv_ptrs: List[int],
+        dst_kv_ptrs: List[int],
+        mla_ratios: List[int],
+    ) -> Tuple[List[int], List[int]]:
+        """Produce aligned (src, dst) pointer lists for compressed-MLA
+        pools (e.g. DeepSeek V4) under PP.
+
+        The pool produces two possible flat-list layouts (selected via dst
+        length):
+
+        - kv_data layout, length = 2 * c4_L + c128_L:
+            [c4_layer_{0..c4_L-1},
+             c4_indexer_layer_{0..c4_L-1},
+             c128_layer_{0..c128_L-1}]
+          Each section is indexed by compressed-layer id within that
+          compression bucket.
+
+        - state_data layout, length = total_L + 2 * c4_L + c128_L:
+            [swa_layer_{0..total_L-1},
+             compress_state_{non-None, c4_L + c128_L},
+             indexer_compress_state_{non-None, c4_L}]
+          SWA is indexed by absolute layer id; the other two sections
+          iterate the full ratios list and skip None (ratio == 0).
+
+        src is already PP-filtered on the prefill side. dst is the
+        decode-side full-model list (when decode is PP=1). We slice dst to
+        match src's PP stage. If src itself is also full-model, it is
+        returned unchanged.
+        """
+        start_layer = self.kv_args.prefill_start_layer
+        end_layer = getattr(self.kv_args, "prefill_end_layer", None)
+        assert end_layer is not None, (
+            "KVArgs.prefill_end_layer must be set when using "
+            "compressed-MLA PD with PP"
+        )
+
+        c4_full = sum(1 for r in mla_ratios if r == 4)
+        c128_full = sum(1 for r in mla_ratios if r == 128)
+        total_full = len(mla_ratios)
+        kv_layout_len = 2 * c4_full + c128_full
+        state_layout_len = total_full + 2 * c4_full + c128_full
+
+        c4_off_s = sum(1 for r in mla_ratios[:start_layer] if r == 4)
+        c4_off_e = sum(1 for r in mla_ratios[:end_layer] if r == 4)
+        c128_off_s = sum(1 for r in mla_ratios[:start_layer] if r == 128)
+        c128_off_e = sum(1 for r in mla_ratios[:end_layer] if r == 128)
+
+        if len(dst_kv_ptrs) == kv_layout_len:
+            sliced_dst = (
+                list(dst_kv_ptrs[c4_off_s:c4_off_e])
+                + list(dst_kv_ptrs[c4_full + c4_off_s : c4_full + c4_off_e])
+                + list(dst_kv_ptrs[2 * c4_full + c128_off_s : 2 * c4_full + c128_off_e])
+            )
+        elif len(dst_kv_ptrs) == state_layout_len:
+            # compress_state non-None count up to L = count(r != 0).
+            c_non_zero_s = sum(1 for r in mla_ratios[:start_layer] if r != 0)
+            c_non_zero_e = sum(1 for r in mla_ratios[:end_layer] if r != 0)
+            compress_section_start = total_full
+            indexer_section_start = total_full + (c4_full + c128_full)
+            sliced_dst = (
+                list(dst_kv_ptrs[start_layer:end_layer])
+                + list(
+                    dst_kv_ptrs[
+                        compress_section_start
+                        + c_non_zero_s : compress_section_start
+                        + c_non_zero_e
+                    ]
+                )
+                + list(
+                    dst_kv_ptrs[
+                        indexer_section_start
+                        + c4_off_s : indexer_section_start
+                        + c4_off_e
+                    ]
+                )
+            )
         else:
-            # Decode pp size should be equal to prefill pp size or 1
-            sliced_dst_kv_ptrs = dst_kv_ptrs[start_layer:end_layer]
-        layers_current_pp_stage = len(src_kv_ptrs)
-        return src_kv_ptrs, sliced_dst_kv_ptrs, layers_current_pp_stage
+            raise ValueError(
+                f"Unexpected compressed-MLA dst_kv_ptrs length "
+                f"{len(dst_kv_ptrs)}; expected either {kv_layout_len} "
+                f"(kv_data) or {state_layout_len} (state_data) given "
+                f"compression_ratios (c4={c4_full}, c128={c128_full}, "
+                f"total={total_full})."
+            )
+
+        return src_kv_ptrs, sliced_dst
 
 
 class CommonKVSender(BaseKVSender):

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -233,12 +233,15 @@ class CommonKVManager(BaseKVManager):
           Each section is indexed by compressed-layer id within that
           compression bucket.
 
-        - state_data layout, length = total_L + 2 * c4_L + c128_L:
-            [swa_layer_{0..total_L-1},
+        - state_data layout, length = swa_L + 2 * c4_L + c128_L:
+            [swa_layer_{0..swa_L-1},
              compress_state_{non-None, c4_L + c128_L},
              indexer_compress_state_{non-None, c4_L}]
-          SWA is indexed by absolute layer id; the other two sections
-          iterate the full ratios list and skip None (ratio == 0).
+          ``swa_L`` is the SWA pool's actual buffer count
+          (``num_effective_layers``), which can be smaller than
+          ``len(mla_ratios)`` when the HF config's ``compress_ratios``
+          list contains entries for layers not materialized into the SWA
+          pool (e.g. an MTP/nextn slot at the tail).
 
         src is already PP-filtered on the prefill side. dst is the
         decode-side full-model list (when decode is PP=1). We slice dst to
@@ -254,9 +257,7 @@ class CommonKVManager(BaseKVManager):
 
         c4_full = sum(1 for r in mla_ratios if r == 4)
         c128_full = sum(1 for r in mla_ratios if r == 128)
-        total_full = len(mla_ratios)
         kv_layout_len = 2 * c4_full + c128_full
-        state_layout_len = total_full + 2 * c4_full + c128_full
 
         c4_off_s = sum(1 for r in mla_ratios[:start_layer] if r == 4)
         c4_off_e = sum(1 for r in mla_ratios[:end_layer] if r == 4)
@@ -269,37 +270,49 @@ class CommonKVManager(BaseKVManager):
                 + list(dst_kv_ptrs[c4_full + c4_off_s : c4_full + c4_off_e])
                 + list(dst_kv_ptrs[2 * c4_full + c128_off_s : 2 * c4_full + c128_off_e])
             )
-        elif len(dst_kv_ptrs) == state_layout_len:
-            # compress_state non-None count up to L = count(r != 0).
-            c_non_zero_s = sum(1 for r in mla_ratios[:start_layer] if r != 0)
-            c_non_zero_e = sum(1 for r in mla_ratios[:end_layer] if r != 0)
-            compress_section_start = total_full
-            indexer_section_start = total_full + (c4_full + c128_full)
-            sliced_dst = (
-                list(dst_kv_ptrs[start_layer:end_layer])
-                + list(
-                    dst_kv_ptrs[
-                        compress_section_start
-                        + c_non_zero_s : compress_section_start
-                        + c_non_zero_e
-                    ]
-                )
-                + list(
-                    dst_kv_ptrs[
-                        indexer_section_start
-                        + c4_off_s : indexer_section_start
-                        + c4_off_e
-                    ]
-                )
-            )
-        else:
+            return src_kv_ptrs, sliced_dst
+
+        # State-data layout. ``swa_L`` is derived from the actual dst
+        # length so we tolerate cases where the SWA pool has fewer
+        # buffers than ``len(mla_ratios)`` (e.g. nextn padding).
+        swa_L = len(dst_kv_ptrs) - 2 * c4_full - c128_full
+        if swa_L < 0 or swa_L > len(mla_ratios):
             raise ValueError(
                 f"Unexpected compressed-MLA dst_kv_ptrs length "
                 f"{len(dst_kv_ptrs)}; expected either {kv_layout_len} "
-                f"(kv_data) or {state_layout_len} (state_data) given "
-                f"compression_ratios (c4={c4_full}, c128={c128_full}, "
-                f"total={total_full})."
+                f"(kv_data) or swa_L + {2 * c4_full + c128_full} "
+                f"(state_data) given compression_ratios "
+                f"(c4={c4_full}, c128={c128_full}, "
+                f"total={len(mla_ratios)})."
             )
+        # Guard against asking the prefill side to read past the SWA
+        # pool boundary.
+        assert end_layer <= swa_L, (
+            f"prefill_end_layer ({end_layer}) exceeds dst SWA pool "
+            f"buffer count ({swa_L}); compression_ratios may include "
+            f"layers (e.g. nextn) that the SWA pool does not cover."
+        )
+
+        # compress_state non-None count up to L = count(r != 0).
+        c_non_zero_s = sum(1 for r in mla_ratios[:start_layer] if r != 0)
+        c_non_zero_e = sum(1 for r in mla_ratios[:end_layer] if r != 0)
+        compress_section_start = swa_L
+        indexer_section_start = swa_L + (c4_full + c128_full)
+        sliced_dst = (
+            list(dst_kv_ptrs[start_layer:end_layer])
+            + list(
+                dst_kv_ptrs[
+                    compress_section_start
+                    + c_non_zero_s : compress_section_start
+                    + c_non_zero_e
+                ]
+            )
+            + list(
+                dst_kv_ptrs[
+                    indexer_section_start + c4_off_s : indexer_section_start + c4_off_e
+                ]
+            )
+        )
 
         return src_kv_ptrs, sliced_dst
 

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -281,12 +281,6 @@ class DecodePreallocQueue:
             self.metadata_buffers.get_buf_infos()
         )
 
-        if isinstance(self.token_to_kv_pool, DeepSeekV4TokenToKVPool):
-            assert self.prefill_pp_size == 1, (
-                "V4 PD disaggregation requires PP=1 "
-                "(get_mla_kv_ptrs_with_pp cannot slice V4's buffer-type-organized flat list)"
-            )
-
         if hasattr(self.token_to_kv_pool, "get_state_buf_infos"):
             state_data_ptrs, state_data_lens, state_item_lens = (
                 self.token_to_kv_pool.get_state_buf_infos()

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -123,6 +123,8 @@ class PrefillBootstrapQueue:
         kv_args.decode_tp_size = self.decode_tp_size // self.decode_dp_size
         kv_args.prefill_pp_size = self.pp_size
         kv_args.prefill_start_layer = self.token_to_kv_pool.start_layer
+        kv_args.prefill_end_layer = self.token_to_kv_pool.end_layer
+        kv_args.mla_compression_ratios = None
         kv_data_ptrs, kv_data_lens, kv_item_lens = (
             self.token_to_kv_pool.get_contiguous_buf_infos()
         )
@@ -151,9 +153,10 @@ class PrefillBootstrapQueue:
         kv_args.gpu_id = self.scheduler.gpu_id
 
         if isinstance(self.token_to_kv_pool, DeepSeekV4TokenToKVPool):
-            assert self.pp_size == 1, (
-                "V4 PD disaggregation requires PP=1 "
-                "(get_mla_kv_ptrs_with_pp cannot slice V4's buffer-type-organized flat list)"
+            # V4's KVCache is organized by compression-ratio
+            # buckets rather than by layer.
+            kv_args.mla_compression_ratios = list(
+                self.token_to_kv_pool.compression_ratios
             )
             assert (
                 self.decode_tp_size == self.scheduler.tp_size

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -25,6 +25,7 @@ import multiprocessing as mp
 import os
 import random
 import signal
+import tempfile
 import threading
 import time
 from typing import AsyncIterator, Callable, Dict, Iterator, List, Optional, Tuple, Union
@@ -60,7 +61,10 @@ from sglang.srt.managers.io_struct import (
     UpdateWeightsFromIPCReqInput,
     UpdateWeightsFromTensorReqInput,
 )
-from sglang.srt.managers.multi_tokenizer_mixin import MultiTokenizerRouter
+from sglang.srt.managers.multi_tokenizer_mixin import (
+    MultiTokenizerRouter,
+    run_multi_detokenizer_router_process,
+)
 from sglang.srt.managers.scheduler import run_scheduler_process
 from sglang.srt.managers.template_manager import TemplateManager
 from sglang.srt.managers.tokenizer_manager import TokenizerManager
@@ -941,6 +945,48 @@ def _launch_scheduler_processes(
     return scheduler_procs, scheduler_pipe_readers
 
 
+def _launch_detokenizer_subprocesses(
+    server_args: ServerArgs,
+    port_args: PortArgs,
+    run_detokenizer_process_func: Callable,
+) -> None:
+    """Launch detokenizer worker(s).
+
+    - When ``detokenizer_worker_num == 1``: a single detokenizer process listens on
+      ``port_args.detokenizer_ipc_name`` (the original behavior).
+    - When ``detokenizer_worker_num > 1``: each detokenizer worker gets its own
+      private IPC socket, and a ``MultiDetokenizerRouter`` process owns the
+      original ``port_args.detokenizer_ipc_name`` and fans out to them.
+    """
+    if server_args.detokenizer_worker_num <= 1:
+        mp.Process(
+            target=run_detokenizer_process_func,
+            args=(server_args, port_args),
+        ).start()
+        return
+
+    router_ipc_name = port_args.detokenizer_ipc_name
+    worker_ipc_names: List[str] = []
+    try:
+        for _ in range(server_args.detokenizer_worker_num):
+            worker_ipc = f"ipc://{tempfile.NamedTemporaryFile(delete=False).name}"
+            port_args.detokenizer_ipc_name = worker_ipc
+            mp.Process(
+                target=run_detokenizer_process_func,
+                args=(server_args, port_args),
+            ).start()
+            worker_ipc_names.append(worker_ipc)
+    finally:
+        # Restore the public IPC name so downstream code (and the router) keeps
+        # using it.
+        port_args.detokenizer_ipc_name = router_ipc_name
+
+    mp.Process(
+        target=run_multi_detokenizer_router_process,
+        args=(worker_ipc_names, server_args, port_args),
+    ).start()
+
+
 def _launch_subprocesses(
     server_args: ServerArgs,
     init_tokenizer_manager_func: Callable,
@@ -991,15 +1037,13 @@ def _launch_subprocesses(
             )
         return None, None, scheduler_infos, port_args
 
-    # Launch detokenizer process
-    detoken_proc = mp.Process(
-        target=run_detokenizer_process_func,
-        args=(
-            server_args,
-            port_args,
-        ),
+    # Launch detokenizer process(es) — optionally fronted by a router when
+    # detokenizer_worker_num > 1.
+    _launch_detokenizer_subprocesses(
+        server_args=server_args,
+        port_args=port_args,
+        run_detokenizer_process_func=run_detokenizer_process_func,
     )
-    detoken_proc.start()
 
     # Init tokenizer manager first, as the bootstrap server is initialized here
     if server_args.tokenizer_worker_num == 1:

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -463,6 +463,11 @@ class Envs:
     # Tokenizer
     SGLANG_PATCH_TOKENIZER = EnvBool(False)  # TODO enable by default
 
+    # Defaults for --tokenizer-worker-num / --detokenizer-worker-num.
+    # Used only when the CLI flag is not explicitly set (CLI wins).
+    SGLANG_TOKENIZER_WORKER_NUM = EnvInt(None)
+    SGLANG_DETOKENIZER_WORKER_NUM = EnvInt(None)
+
     # TokenizerManager
     SGLANG_REQUEST_STATE_WAIT_TIMEOUT = EnvInt(4)
 

--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -80,7 +80,7 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
         port_args: PortArgs,
     ):
         # Init inter-process communication
-        self.init_ipc_channels(port_args)
+        self.init_ipc_channels(port_args, server_args)
 
         # Init tokenizer
         self.init_tokenizer(server_args)
@@ -98,14 +98,18 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
     def is_health_check_request(rid: Optional[str]) -> bool:
         return isinstance(rid, str) and rid.startswith("HEALTH_CHECK")
 
-    def init_ipc_channels(self, port_args: PortArgs):
+    def init_ipc_channels(self, port_args: PortArgs, server_args: ServerArgs):
         context = zmq.Context(2)
         self.recv_from_scheduler = get_zmq_socket(
             context, zmq.PULL, port_args.detokenizer_ipc_name, True
         )
-        self.send_to_tokenizer = get_zmq_socket(
-            context, zmq.PUSH, port_args.tokenizer_ipc_name, False
-        )
+        # In multi-tokenizer mode, results are pushed back to each TokenizerWorker
+        # directly via SocketMapping inside multi_http_worker_event_loop, so the
+        # single send_to_tokenizer socket is unused.
+        if server_args.tokenizer_worker_num == 1:
+            self.send_to_tokenizer = get_zmq_socket(
+                context, zmq.PUSH, port_args.tokenizer_ipc_name, False
+            )
 
     def init_tokenizer(self, server_args: ServerArgs):
         if server_args.skip_tokenizer_init:

--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -24,12 +24,15 @@ import logging
 import multiprocessing as multiprocessing
 import os
 import pickle
+import signal
 import sys
 import threading
+import zlib
 from functools import partialmethod
 from multiprocessing import shared_memory
-from typing import TYPE_CHECKING, Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Union
 
+import psutil
 import setproctitle
 import zmq
 import zmq.asyncio
@@ -43,11 +46,17 @@ from sglang.srt.managers.io_struct import (
     BatchMultimodalOutput,
     BatchStrOutput,
     BatchTokenIDOutput,
+    FreezeGCReq,
 )
 from sglang.srt.managers.tokenizer_communicator_mixin import _Communicator
 from sglang.srt.managers.tokenizer_manager import TokenizerManager
 from sglang.srt.server_args import PortArgs, ServerArgs
-from sglang.srt.utils import get_zmq_socket, kill_process_tree
+from sglang.srt.utils import (
+    configure_logger,
+    get_zmq_socket,
+    kill_itself_when_parent_died,
+    kill_process_tree,
+)
 from sglang.utils import get_exception_traceback
 
 if TYPE_CHECKING:
@@ -75,14 +84,14 @@ class SocketMapping:
         socket = get_zmq_socket(self._zmq_context, zmq.PUSH, ipc_name, False)
         self._mapping[ipc_name] = socket
 
-    def send_output(self, ipc_name: str, output: Any):
+    def send_output(self, ipc_name: str, output: Any, is_tokenizer: bool = False):
         if ipc_name is None:
             # Some unhandled cases
             logger.warning(f"IPC name is None, output type={type(output)}, skipping...")
             return
 
         if ipc_name not in self._mapping:
-            self._register_ipc_mapping(ipc_name, is_tokenizer=False)
+            self._register_ipc_mapping(ipc_name, is_tokenizer=is_tokenizer)
         self._mapping[ipc_name].send_pyobj(output)
 
 
@@ -107,9 +116,7 @@ def _extract_field_by_index(
     if isinstance(field, dict):
         new_field = {}
         for k, v in field.items():
-            if len(v) <= index:
-                new_field[k] = None
-            new_field[k] = v[index]
+            new_field[k] = v[index] if len(v) > index else None
         return new_field
 
     if check_length:
@@ -196,6 +203,13 @@ def _handle_output_by_index(output, i):
             output_hidden_states=_extract_field_by_index(
                 output, "output_hidden_states", i, check_length=False
             ),
+            routed_experts=_extract_field_by_index(
+                output, "routed_experts", i, check_length=False
+            ),
+            indexer_topk=_extract_field_by_index(
+                output, "indexer_topk", i, check_length=False
+            ),
+            retraction_counts=_extract_field_by_index(output, "retraction_counts", i),
             placeholder_tokens_idx=None,
             placeholder_tokens_val=None,
             token_steps=_extract_field_by_index(
@@ -326,14 +340,23 @@ class MultiHttpWorkerDetokenizerMixin:
             if output is None:
                 continue
 
-            assert isinstance(
-                recv_obj, BaseBatchReq
-            ), "for multi-http-worker, recv_obj must be BaseBatchReq"
-
-            # Send data using the corresponding socket
-            for i, ipc_name in enumerate(recv_obj.http_worker_ipcs):
-                new_output = _handle_output_by_index(output, i)
-                self.socket_mapping.send_output(ipc_name, new_output)
+            # Fan out the output back to the originating tokenizer worker(s).
+            # In multi-detokenizer mode the upstream MultiDetokenizerRouter may
+            # forward either batched or single requests, so handle both shapes.
+            if isinstance(recv_obj, BaseBatchReq):
+                for i, ipc_name in enumerate(recv_obj.http_worker_ipcs):
+                    new_output = _handle_output_by_index(output, i)
+                    self.socket_mapping.send_output(
+                        ipc_name, new_output, is_tokenizer=True
+                    )
+            elif isinstance(recv_obj, BaseReq):
+                self.socket_mapping.send_output(
+                    recv_obj.http_worker_ipc, output, is_tokenizer=True
+                )
+            else:
+                raise ValueError(
+                    f"multi_http_worker_event_loop got unexpected req type {type(recv_obj)}"
+                )
 
 
 class MultiTokenizerRouter:
@@ -394,6 +417,100 @@ class MultiTokenizerRouter:
         for i, ipc_name in enumerate(ipc_names):
             new_recv_obj = _handle_output_by_index(recv_obj, i)
             self.socket_mapping.send_output(ipc_name, new_recv_obj)
+
+
+class MultiDetokenizerRouter:
+    """Route scheduler outputs to one of N DetokenizerManager workers.
+
+    Each request is pinned to a worker by hashing its ``http_worker_ipc`` with
+    ``zlib.crc32`` (deterministic across runs), so all outputs of the same rid
+    always land on the same detokenizer and ``decode_status`` stays consistent.
+    """
+
+    def __init__(self, ipc_name_list: List[str], port_args: PortArgs):
+        self.ipc_name_list = ipc_name_list
+        self.num_workers = len(ipc_name_list)
+        self.socket_mapping = SocketMapping()
+        context = zmq.Context(2)
+        self.recv_from_scheduler = get_zmq_socket(
+            context, zmq.PULL, port_args.detokenizer_ipc_name, True
+        )
+
+    def _pick(self, key: str) -> str:
+        return self.ipc_name_list[zlib.crc32(key.encode()) % self.num_workers]
+
+    def _send(self, ipc_name: str, obj: Any) -> None:
+        self.socket_mapping.send_output(ipc_name, obj, is_tokenizer=False)
+
+    def event_loop(self):
+        while True:
+            recv_obj = self.recv_from_scheduler.recv_pyobj()
+
+            # FreezeGCReq must freeze every detokenizer process.
+            if isinstance(recv_obj, FreezeGCReq):
+                for ipc in self.ipc_name_list:
+                    self._send(ipc, recv_obj)
+                continue
+
+            # Single request: route by its own http_worker_ipc.
+            if isinstance(recv_obj, BaseReq):
+                assert (
+                    recv_obj.http_worker_ipc is not None
+                ), f"Single req {recv_obj.rid=} missing http_worker_ipc"
+                self._send(self._pick(recv_obj.http_worker_ipc), recv_obj)
+                continue
+
+            # Batch request.
+            if isinstance(recv_obj, BaseBatchReq):
+                # Idle/no-op batch (rids=[]): keep whole, send to one detokenizer
+                # so single-tokenizer load updates still work.
+                if not recv_obj.rids:
+                    self._send(self.ipc_name_list[0], recv_obj)
+                    continue
+
+                ipcs = recv_obj.http_worker_ipcs
+                assert (
+                    ipcs is not None
+                    and len(ipcs) == len(recv_obj.rids)
+                    and all(x is not None for x in ipcs)
+                ), f"Batch req {recv_obj.rids=} has invalid http_worker_ipcs"
+
+                # A scheduler batch can mix requests from different HTTP workers,
+                # so split per-item and route each by its own ipc.
+                for i, ipc_key in enumerate(ipcs):
+                    one = _handle_output_by_index(recv_obj, i)
+                    if one is recv_obj:
+                        raise TypeError(f"Cannot split {type(recv_obj)}")
+                    one.http_worker_ipcs = [ipc_key]
+                    self._send(self._pick(ipc_key), one)
+                continue
+
+            raise ValueError(
+                f"MultiDetokenizerRouter got unsupported type {type(recv_obj)}"
+            )
+
+
+def run_multi_detokenizer_router_process(
+    ipc_name_list: List[str],
+    server_args: ServerArgs,
+    port_args: PortArgs,
+):
+    kill_itself_when_parent_died()
+    setproctitle.setproctitle("sglang::detokenizer_router")
+    configure_logger(server_args)
+    parent_process = psutil.Process().parent()
+
+    router = None
+    try:
+        router = MultiDetokenizerRouter(ipc_name_list, port_args)
+        router.event_loop()
+    except Exception:
+        logger.error(
+            f"MultiDetokenizerRouter hit an exception: {get_exception_traceback()}"
+        )
+        if router is not None:
+            router.socket_mapping.clear_all_sockets()
+        parent_process.send_signal(signal.SIGQUIT)
 
 
 class TokenizerWorker(TokenizerManager):

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2019,7 +2019,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 )
 
         # Update fields
-        self.input_ids = self.output_ids
+        self.input_ids = self.output_ids.to(torch.int64)
         self.output_ids = None
 
         if self.model_config.is_encoder_decoder:

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -600,9 +600,12 @@ class SchedulerPPMixin:
                     batch.global_num_tokens = global_num_tokens
                     batch.global_num_tokens_for_logprob = global_num_tokens
 
+                hs = getattr(
+                    model_config, "hc_hidden_size", model_config.hidden_size
+                )
                 proxy_tensors = {
                     "hidden_states": torch.zeros(
-                        (current_seq_len, model_config.hidden_size),
+                        (current_seq_len, hs),
                         dtype=model_config.dtype,
                         device="cuda",
                     ),

--- a/python/sglang/srt/mem_cache/deepseekv4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseekv4_memory_pool.py
@@ -414,6 +414,19 @@ class DeepSeekV4TokenToKVPool(KVCache):
         self.state_dtype = state_dtype
         self.compression_ratios = compression_ratios
 
+        # Determine this PP stage's absolute layer range
+        if (
+            start_layer is not None
+            and end_layer is not None
+            and len(compression_ratios) >= end_layer
+        ):
+            self._stage_start = start_layer
+            self._stage_end = end_layer
+        else:
+            self._stage_start = 0
+            self._stage_end = len(compression_ratios)
+        stage_ratios = compression_ratios[self._stage_start : self._stage_end]
+
         assert page_size % swa_page_size == 0
 
         self.swa_size = swa_size
@@ -425,8 +438,8 @@ class DeepSeekV4TokenToKVPool(KVCache):
         self.qk_rope_head_dim = qk_rope_head_dim
         self.indexer_head_dim = indexer_head_dim
 
-        c4_layer_num = sum(1 for r in compression_ratios if r == 4)
-        c128_layer_num = sum(1 for r in compression_ratios if r == 128)
+        c4_layer_num = sum(1 for r in stage_ratios if r == 4)
+        c128_layer_num = sum(1 for r in stage_ratios if r == 128)
         c4_page_size = page_size // 4
         c128_page_size = page_size // 128
         self.swa_kv_pool = DeepSeekV4SingleKVPool(
@@ -481,6 +494,7 @@ class DeepSeekV4TokenToKVPool(KVCache):
         self._init_paged_compress_states(enable_memory_saver)
 
         self._should_cache_swa = envs.SGLANG_OPT_CACHE_SWA_TRANSLATION.get()
+        self.cached_loc = None
 
         self._dbg_dump_pool_sizes()
 
@@ -614,30 +628,33 @@ class DeepSeekV4TokenToKVPool(KVCache):
     def _init_paged_compress_states(self, enable_memory_saver: bool):
         c4_state_pool_size = self.c4_state_pool_size
         c128_state_pool_size = self.c128_state_pool_size
-        self.compress_state_pools: List[CompressStatePool] = []
-        self.indexer_compress_state_pools: List[CompressStatePool] = []
+        total_L = len(self.compression_ratios)
+        self.compress_state_pools: List[Optional[CompressStatePool]] = [None] * total_L
+        self.indexer_compress_state_pools: List[Optional[CompressStatePool]] = [None] * total_L
 
-        for ratio in self.compression_ratios:
+        for idx in range(self._stage_start, self._stage_end):
+            ratio = self.compression_ratios[idx]
+            if ratio == 0:
+                continue
             overlap = ratio == 4
-            compress_state_pool = indexer_compress_state_pool = None
             size = c4_state_pool_size if ratio == 4 else c128_state_pool_size
-            ring_size = self.get_ring_size(ratio) if ratio != 0 else 0
-            if ratio != 0:
-                compress_state_pool = CompressStatePool(
-                    size=size,
-                    swa_page_size=self.swa_page_size,
-                    ring_size=ring_size,
-                    overlap=overlap,
-                    head_dim=self.qk_nope_head_dim + self.qk_rope_head_dim,
-                    dtype=self.state_dtype,
-                    device=self.device,
-                    enable_memory_saver=enable_memory_saver,
-                    ratio=ratio,
-                    online=(ratio == 128 and ONLINE_C128),
-                )
+            ring_size = self.get_ring_size(ratio)
+
+            self.compress_state_pools[idx] = CompressStatePool(
+                size=size,
+                swa_page_size=self.swa_page_size,
+                ring_size=ring_size,
+                overlap=overlap,
+                head_dim=self.qk_nope_head_dim + self.qk_rope_head_dim,
+                dtype=self.state_dtype,
+                device=self.device,
+                enable_memory_saver=enable_memory_saver,
+                ratio=ratio,
+                online=(ratio == 128 and ONLINE_C128),
+            )
 
             if ratio == 4:
-                indexer_compress_state_pool = CompressStatePool(
+                self.indexer_compress_state_pools[idx] = CompressStatePool(
                     size=size,
                     swa_page_size=self.swa_page_size,
                     ring_size=ring_size,
@@ -649,38 +666,31 @@ class DeepSeekV4TokenToKVPool(KVCache):
                     ratio=ratio,
                 )
 
-            self.compress_state_pools.append(compress_state_pool)
-            self.indexer_compress_state_pools.append(indexer_compress_state_pool)
-
     def _init_compressed_layer_mapping(self):
-        c1_cnt, c4_cnt, c128_cnt = 0, 0, 0
-        self.layer_mapping: List[DeepSeekV4LayerItem] = []
+        c1_cnt = c4_cnt = c128_cnt = 0
+        total_L = len(self.compression_ratios)
+        self.layer_mapping: List[Optional[DeepSeekV4LayerItem]] = [None] * total_L
 
-        for ratio in self.compression_ratios:
+        for idx in range(self._stage_start, self._stage_end):
+            ratio = self.compression_ratios[idx]
             if ratio == 0:
-                self.layer_mapping.append(
-                    DeepSeekV4LayerItem(
-                        compress_ratio=0,
-                        compress_layer_id=c1_cnt,
-                    )
+                self.layer_mapping[idx] = DeepSeekV4LayerItem(
+                    compress_ratio=0,
+                    compress_layer_id=c1_cnt,
                 )
                 c1_cnt += 1
             elif ratio == 4:
-                self.layer_mapping.append(
-                    DeepSeekV4LayerItem(
-                        compress_ratio=4,
-                        compress_layer_id=c4_cnt,
-                        compress_kv_pool=self.c4_kv_pool,
-                    )
+                self.layer_mapping[idx] = DeepSeekV4LayerItem(
+                    compress_ratio=4,
+                    compress_layer_id=c4_cnt,
+                    compress_kv_pool=self.c4_kv_pool,
                 )
                 c4_cnt += 1
             elif ratio == 128:
-                self.layer_mapping.append(
-                    DeepSeekV4LayerItem(
-                        compress_ratio=128,
-                        compress_layer_id=c128_cnt,
-                        compress_kv_pool=self.c128_kv_pool,
-                    )
+                self.layer_mapping[idx] = DeepSeekV4LayerItem(
+                    compress_ratio=128,
+                    compress_layer_id=c128_cnt,
+                    compress_kv_pool=self.c128_kv_pool,
                 )
                 c128_cnt += 1
             else:
@@ -700,9 +710,12 @@ class DeepSeekV4TokenToKVPool(KVCache):
         ), "Only c4 layers have indexer states."
         return indexer_compress_state_pool
 
-    def get_swa_key_buffer(self, layer_id: int) -> torch.Tensor:
-        return self.swa_kv_pool.get_key_buffer(layer_id)
+    def _swa_layer_id(self, layer_id: int) -> int:
+        """Convert absolute layer_id to SWA-pool-local index."""
+        return layer_id - self._stage_start
 
+    def get_swa_key_buffer(self, layer_id: int) -> torch.Tensor:
+        return self.swa_kv_pool.get_key_buffer(self._swa_layer_id(layer_id))
 
     def set_swa_key_buffer(
         self,
@@ -710,7 +723,7 @@ class DeepSeekV4TokenToKVPool(KVCache):
         loc: torch.Tensor,
         cache_nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack,
     ) -> None:
-        self.swa_kv_pool.set_key_buffer(layer_id, loc, cache_nope_fp8_rope_bf16_pack)
+        self.swa_kv_pool.set_key_buffer(self._swa_layer_id(layer_id), loc, cache_nope_fp8_rope_bf16_pack)
 
     def get_extra_key_buffer(self, layer_id: int) -> torch.Tensor | None:
         _, compress_layer_id, compress_kv_pool = self.layer_mapping[layer_id]
@@ -779,11 +792,11 @@ class DeepSeekV4TokenToKVPool(KVCache):
     ) -> None:
         swa_loc = self.translate_loc_from_full_to_swa(raw_loc)
         self.swa_kv_pool.set_key_buffer(
-            layer_id, swa_loc, cache_nope_fp8_rope_bf16_pack
+            self._swa_layer_id(layer_id), swa_loc, cache_nope_fp8_rope_bf16_pack
         )
 
     def get_swa_key_buffer_radix(self, layer_id: int) -> torch.Tensor:
-        return self.swa_kv_pool.get_key_buffer(layer_id)
+        return self.swa_kv_pool.get_key_buffer(self._swa_layer_id(layer_id))
 
     def set_swa_key_buffer_radix_fused(
         self,
@@ -792,12 +805,12 @@ class DeepSeekV4TokenToKVPool(KVCache):
         cache_k: torch.Tensor,
     ) -> None:
         if self._should_cache_swa:
-            if layer_id == 0:
+            if layer_id == self.start_layer or self.cached_loc is None:
                 self.cached_loc = self.translate_loc_from_full_to_swa(raw_loc)
             swa_loc = self.cached_loc
         else:
             swa_loc = self.translate_loc_from_full_to_swa(raw_loc)
-        return self.swa_kv_pool.set_key_buffer_fused(layer_id, swa_loc, cache_k)
+        return self.swa_kv_pool.set_key_buffer_fused(self._swa_layer_id(layer_id), swa_loc, cache_k)
 
     def set_extra_key_buffer_fused(
         self,

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -349,6 +349,7 @@ class CudaGraphRunner:
             num_tokens_per_bs=self.num_tokens_per_bs,
             cache_loc_dtype=self._cache_loc_dtype(),
             enable_mamba_track=enable_mamba_track,
+            hc_hidden_size=getattr(self.model_runner.model_config, "hc_hidden_size", None),
         )
 
         self.tbo_plugin = TboCudaGraphRunnerPlugin()

--- a/python/sglang/srt/model_executor/input_buffers.py
+++ b/python/sglang/srt/model_executor/input_buffers.py
@@ -51,6 +51,7 @@ class GraphInputBuffers:
         num_tokens_per_bs: int,
         cache_loc_dtype: torch.dtype,
         enable_mamba_track: bool,
+        hc_hidden_size: Optional[int] = None,
     ) -> "GraphInputBuffers":
         with torch.device(device):
             input_ids = torch.zeros((max_num_token,), dtype=torch.int64)
@@ -79,8 +80,11 @@ class GraphInputBuffers:
             )
 
             if pp_size > 1:
+                # For mHC models (e.g. DeepSeek-V4), hc_hidden_size =
+                # hc_mult * hidden_size, as hidden_states are flattened for PP.
+                hs = hc_hidden_size or hidden_size
                 pp_proxy_tensors = {
-                    "hidden_states": torch.zeros((max_bs, hidden_size), dtype=dtype),
+                    "hidden_states": torch.zeros((max_bs, hs), dtype=dtype),
                     "residual": torch.zeros((max_bs, hidden_size), dtype=dtype),
                 }
             else:

--- a/python/sglang/srt/model_executor/input_buffers.py
+++ b/python/sglang/srt/model_executor/input_buffers.py
@@ -84,11 +84,12 @@ class GraphInputBuffers:
                 # hc_mult * hidden_size, as hidden_states are flattened for PP.
                 # mHC fuses residual into the 3D hidden_states, so no separate
                 # residual buffer is needed.
-                hs = hc_hidden_size or hidden_size
+                is_mhc = hc_hidden_size is not None
+                hs = hc_hidden_size if is_mhc else hidden_size
                 pp_proxy_tensors = {
                     "hidden_states": torch.zeros((max_bs, hs), dtype=dtype),
                 }
-                if hc_hidden_size is None:
+                if not is_mhc:
                     pp_proxy_tensors["residual"] = torch.zeros(
                         (max_bs, hidden_size), dtype=dtype
                     )

--- a/python/sglang/srt/model_executor/input_buffers.py
+++ b/python/sglang/srt/model_executor/input_buffers.py
@@ -82,11 +82,16 @@ class GraphInputBuffers:
             if pp_size > 1:
                 # For mHC models (e.g. DeepSeek-V4), hc_hidden_size =
                 # hc_mult * hidden_size, as hidden_states are flattened for PP.
+                # mHC fuses residual into the 3D hidden_states, so no separate
+                # residual buffer is needed.
                 hs = hc_hidden_size or hidden_size
                 pp_proxy_tensors = {
                     "hidden_states": torch.zeros((max_bs, hs), dtype=dtype),
-                    "residual": torch.zeros((max_bs, hidden_size), dtype=dtype),
                 }
+                if hc_hidden_size is None:
+                    pp_proxy_tensors["residual"] = torch.zeros(
+                        (max_bs, hidden_size), dtype=dtype
+                    )
             else:
                 pp_proxy_tensors = None
 

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -4,7 +4,17 @@ import concurrent.futures
 import logging
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterable, List, Literal, Optional, Set, Tuple
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Iterable,
+    List,
+    Literal,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
 import torch
 import torch.nn as nn
@@ -54,12 +64,13 @@ from sglang.srt.layers.moe import get_moe_a2a_backend
 from sglang.srt.layers.moe.fused_moe_triton import FusedMoE
 from sglang.srt.layers.quantization.fp8_kernel import sglang_per_token_group_quant_fp8
 from sglang.srt.layers.rotary_embedding import get_rope_wrapper
-from sglang.srt.layers.utils import get_layer_id
+from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
 from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from sglang.srt.mem_cache.compress_state import CompressStatePool
 from sglang.srt.mem_cache.deepseekv4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.mem_cache.memory_pool import RadixAttention
 from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
+from sglang.srt.model_executor.forward_batch_info import PPProxyTensors
 from sglang.srt.model_loader.utils import maybe_executor_submit, should_async_load
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.dbrx import ReplicatedLinear
@@ -90,10 +101,7 @@ if TYPE_CHECKING:
     )
     from sglang.srt.layers.quantization import QuantizationConfig
     from sglang.srt.layers.rotary_embedding import RotaryEmbedding
-    from sglang.srt.model_executor.forward_batch_info import (
-        ForwardBatch,
-        PPProxyTensors,
-    )
+    from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
 
 class DeepseekRefRMSNorm(nn.Module):
@@ -1186,11 +1194,14 @@ class DeepseekV4Model(nn.Module):
         self.vocab_size = config.vocab_size
         self.pp_group = get_pp_group()
         self.first_k_dense_replace = config.first_k_dense_replace
-        self.embed_tokens = VocabParallelEmbedding(
-            config.vocab_size,
-            config.hidden_size,
-            enable_tp=not is_dp_attention_enabled(),
-        )
+        if self.pp_group.is_first_rank:
+            self.embed_tokens = VocabParallelEmbedding(
+                config.vocab_size,
+                config.hidden_size,
+                enable_tp=not is_dp_attention_enabled(),
+            )
+        else:
+            self.embed_tokens = PPMissingLayer()
         self.rms_norm_eps = config.rms_norm_eps
         self.alt_streams = (
             [torch.cuda.Stream() for _ in range(5)] if (_is_cuda or _is_hip) else None
@@ -1208,7 +1219,10 @@ class DeepseekV4Model(nn.Module):
             pp_size=self.pp_group.world_size,
             prefix=add_prefix("layers", prefix),
         )
-        self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        if self.pp_group.is_last_rank:
+            self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        else:
+            self.norm = PPMissingLayer()
         self.gemm_output_zero_allocator_size = 0
         self.layers_to_capture = []
         if get_moe_a2a_backend().is_deepep() or get_moe_a2a_backend().is_mooncake():
@@ -1219,12 +1233,13 @@ class DeepseekV4Model(nn.Module):
         self.hc_eps = config.hc_eps
         self.hc_mult = hc_mult = config.hc_mult
         self.norm_eps = config.rms_norm_eps
-        hc_dim = hc_mult * config.hidden_size
-        self.hc_head_fn = nn.Parameter(
-            torch.empty(hc_mult, hc_dim, dtype=torch.float32)
-        )
-        self.hc_head_base = nn.Parameter(torch.empty(hc_mult, dtype=torch.float32))
-        self.hc_head_scale = nn.Parameter(torch.empty(1, dtype=torch.float32))
+        if self.pp_group.is_last_rank:
+            hc_dim = hc_mult * config.hidden_size
+            self.hc_head_fn = nn.Parameter(
+                torch.empty(hc_mult, hc_dim, dtype=torch.float32)
+            )
+            self.hc_head_base = nn.Parameter(torch.empty(hc_mult, dtype=torch.float32))
+            self.hc_head_scale = nn.Parameter(torch.empty(1, dtype=torch.float32))
 
         self.nsa_enable_prefill_cp = is_nsa_enable_prefill_cp()
         if self.nsa_enable_prefill_cp:
@@ -1252,7 +1267,7 @@ class DeepseekV4Model(nn.Module):
         forward_batch: ForwardBatch,
         input_embeds: Optional[torch.Tensor],
         pp_proxy_tensors: Optional[PPProxyTensors],
-    ) -> torch.Tensor:
+    ) -> Union[torch.Tensor, PPProxyTensors]:
         total_num_layers = self.end_layer - self.start_layer
         device = input_embeds.device if input_embeds is not None else input_ids.device
         zero_allocator = BumpAllocator(
@@ -1273,8 +1288,18 @@ class DeepseekV4Model(nn.Module):
             and self.gemm_output_zero_allocator_size > 0
             else None
         )
-        hidden_states = self.embed_tokens(input_ids)
-        hidden_states = hidden_states.unsqueeze(1).repeat(1, self.hc_mult, 1)
+        if self.pp_group.is_first_rank:
+            hidden_states = self.embed_tokens(input_ids)
+            hidden_states = hidden_states.unsqueeze(1).repeat(1, self.hc_mult, 1)
+        else:
+            assert pp_proxy_tensors is not None
+            hidden_states = pp_proxy_tensors["hidden_states"]
+            # PP sends flattened 2D (seq_len, hc_mult*hidden_size).
+            # Unflatten back to 3D (seq_len, hc_mult, hidden_size) for mHC.
+            if hidden_states.ndim == 2:
+                hidden_states = hidden_states.view(
+                    hidden_states.shape[0], self.hc_mult, -1
+                )
 
         if get_attention_dp_size() > 1 and get_moe_a2a_backend().is_none():
             input_ids_global = torch.empty(
@@ -1288,15 +1313,16 @@ class DeepseekV4Model(nn.Module):
             input_ids_global = input_ids
 
         if nsa_use_prefill_cp(forward_batch):
-            _check_rank_consistency = (
-                envs.SGLANG_DEBUG_HACK_CP_CHECK_RANK_CONSISTENCY.get()
-            )
-            if _check_rank_consistency:
-                _pre_split_hidden_states = hidden_states.clone()
-                _pre_split_positions = positions.clone()
-            hidden_states = cp_split_and_rebuild_data(forward_batch, hidden_states)
+            if self.pp_group.is_first_rank:
+                _check_rank_consistency = (
+                    envs.SGLANG_DEBUG_HACK_CP_CHECK_RANK_CONSISTENCY.get()
+                )
+                if _check_rank_consistency:
+                    _pre_split_hidden_states = hidden_states.clone()
+                    _pre_split_positions = positions.clone()
+                hidden_states = cp_split_and_rebuild_data(forward_batch, hidden_states)
             positions = cp_split_and_rebuild_position(forward_batch, positions)
-            if _check_rank_consistency:
+            if self.pp_group.is_first_rank and _check_rank_consistency:
                 _gathered_hidden = cp_all_gather_rerange_output(
                     hidden_states,
                     self.cp_size,
@@ -1337,6 +1363,11 @@ class DeepseekV4Model(nn.Module):
                 torch.cuda.current_stream(),
             )
 
+        if not self.pp_group.is_last_rank:
+            # Flatten 3D (seq_len, hc_mult, hidden_size) → 2D (seq_len, hc_mult*hidden_size)
+            # so PP communication uses standard 2D tensor shape.
+            return PPProxyTensors({"hidden_states": hidden_states.flatten(1)})
+
         pre_hc_head = (
             hidden_states.flatten(1)
             if envs.SGLANG_FIX_MTP_HC_HIDDEN.get()
@@ -1370,27 +1401,34 @@ class DeepseekV4ForCausalLM(nn.Module):
             config, quant_config, prefix=add_prefix("model", prefix)
         )
         self.pp_group = get_pp_group()
-        if config.tie_word_embeddings:
-            self.lm_head = self.model.embed_tokens
+        if self.pp_group.is_last_rank:
+            if self.pp_group.world_size == 1 and config.tie_word_embeddings:
+                self.lm_head = self.model.embed_tokens
+            else:
+                self.lm_head = ParallelLMHead(
+                    config.vocab_size,
+                    config.hidden_size,
+                    quant_config=quant_config,
+                    prefix=add_prefix("lm_head", prefix),
+                    use_attn_tp_group=get_global_server_args().enable_dp_lm_head,
+                )
         else:
-            self.lm_head = ParallelLMHead(
-                config.vocab_size,
-                config.hidden_size,
-                quant_config=quant_config,
-                prefix=add_prefix("lm_head", prefix),
-                use_attn_tp_group=get_global_server_args().enable_dp_lm_head,
-            )
+            self.lm_head = PPMissingLayer()
         self.logits_processor = LogitsProcessor(config)
         self.capture_aux_hidden_states = False
         get_attn_tp_context().init_context(config.q_lora_rank, is_nsa=True)
 
         self._routed_experts_weights_of_layer = LazyValue(
             lambda: {
-                layer_id: layer.mlp.get_moe_weights()
-                for layer_id, layer in enumerate(self.model.layers)
-                if isinstance(layer.mlp, deepseek_v2.DeepseekV2MoE)
+                layer_id: self.model.layers[layer_id].mlp.get_moe_weights()
+                for layer_id in range(self.model.start_layer, self.model.end_layer)
+                if isinstance(self.model.layers[layer_id].mlp, deepseek_v2.DeepseekV2MoE)
             }
         )
+
+        # Expose start_layer/end_layer for model_runner PP support
+        self.start_layer = self.model.start_layer
+        self.end_layer = self.model.end_layer
 
         self.nsa_enable_prefill_cp = is_nsa_enable_prefill_cp()
         if self.nsa_enable_prefill_cp:
@@ -1465,6 +1503,9 @@ class DeepseekV4ForCausalLM(nn.Module):
             hidden_states = self.model.forward(
                 input_ids, positions, forward_batch, input_embeds, pp_proxy_tensors
             )
+        if not self.pp_group.is_last_rank:
+            return hidden_states
+
         aux_hidden_states = None
         pre_hc_head = None
         if self.capture_aux_hidden_states:
@@ -1486,8 +1527,8 @@ class DeepseekV4ForCausalLM(nn.Module):
     def _setup_fp8_wo_a_scales(self, is_nextn: bool) -> None:
         from deep_gemm import transform_sf_into_required_layout
 
-        layers = self.model.layers
-        for layer in layers:
+        for layer_id in range(self.model.start_layer, self.model.end_layer):
+            layer = self.model.layers[layer_id]
             attn = layer.self_attn
             G = attn.n_local_groups
             R = attn.o_lora_rank
@@ -1509,7 +1550,8 @@ class DeepseekV4ForCausalLM(nn.Module):
 
         if is_nextn:
             return
-        for layer in self.model.layers:
+        for layer_id in range(self.model.start_layer, self.model.end_layer):
+            layer = self.model.layers[layer_id]
             self_attn = layer.self_attn
             if self_attn.compress_ratio != 0 and not self_attn.compressor.ape_converted:
                 self_attn.compressor.apply_ape_hotfix()
@@ -1815,7 +1857,12 @@ class DeepseekV4ForCausalLM(nn.Module):
                                 and not self.pp_group.is_first_rank
                             ):
                                 continue
-                            if ".norm." in name and not self.pp_group.is_last_rank:
+                            if name == "model.norm.weight" and not self.pp_group.is_last_rank:
+                                continue
+                            if (
+                                name.startswith("model.hc_head_")
+                                or name == "lm_head.weight"
+                            ) and not self.pp_group.is_last_rank:
                                 continue
                             elif COMPRESSOR_PART in name:
                                 is_kv = name.endswith(".wkv.weight")
@@ -1919,6 +1966,11 @@ class DeepseekV4ForCausalLM(nn.Module):
         unloaded_params = params_dict.keys() - loaded_params
 
         skipped_checking_patterns = ["attn_mqa.k_scale", "attn_mqa.v_scale"]
+        if not self.pp_group.is_first_rank:
+            skipped_checking_patterns.append("embed_tokens")
+        if not self.pp_group.is_last_rank:
+            skipped_checking_patterns.append("model.norm.")
+            skipped_checking_patterns.extend(["lm_head", "hc_head_"])
         if is_nextn:
             skipped_checking_patterns.extend(["lm_head", "embed_tokens"])
         unloaded_params = {

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -276,6 +276,7 @@ class ServerArgs:
     tokenizer_path: Optional[str] = None
     tokenizer_mode: str = "auto"
     tokenizer_worker_num: int = 1
+    detokenizer_worker_num: int = 1
     skip_tokenizer_init: bool = False
     load_format: str = "auto"
     model_loader_extra_config: str = "{}"
@@ -2496,6 +2497,31 @@ class ServerArgs:
                 "Please choose one tokenizer batching approach."
             )
 
+        # Env-based default: only applied when CLI is not explicitly set
+        # (i.e. value still equals the dataclass default). CLI always wins.
+        if (
+            self.tokenizer_worker_num == ServerArgs.tokenizer_worker_num
+            and envs.SGLANG_TOKENIZER_WORKER_NUM.is_set()
+        ):
+            env_val = envs.SGLANG_TOKENIZER_WORKER_NUM.get()
+            if env_val is not None and env_val != self.tokenizer_worker_num:
+                logger.info(
+                    f"tokenizer_worker_num={env_val} from env "
+                    f"SGLANG_TOKENIZER_WORKER_NUM (CLI not set)."
+                )
+                self.tokenizer_worker_num = env_val
+        if (
+            self.detokenizer_worker_num == ServerArgs.detokenizer_worker_num
+            and envs.SGLANG_DETOKENIZER_WORKER_NUM.is_set()
+        ):
+            env_val = envs.SGLANG_DETOKENIZER_WORKER_NUM.get()
+            if env_val is not None and env_val != self.detokenizer_worker_num:
+                logger.info(
+                    f"detokenizer_worker_num={env_val} from env "
+                    f"SGLANG_DETOKENIZER_WORKER_NUM (CLI not set)."
+                )
+                self.detokenizer_worker_num = env_val
+
         if self.skip_tokenizer_init:
             if self.tokenizer_worker_num != 1:
                 logger.warning(
@@ -2503,6 +2529,12 @@ class ServerArgs:
                     f"(requested {self.tokenizer_worker_num})."
                 )
                 self.tokenizer_worker_num = 1
+            if self.detokenizer_worker_num != 1:
+                logger.warning(
+                    "skip_tokenizer_init=True disables detokenizer workers; forcing detokenizer_worker_num=1 "
+                    f"(requested {self.detokenizer_worker_num})."
+                )
+                self.detokenizer_worker_num = 1
 
             if self.enable_tokenizer_batch_encode:
                 logger.warning(
@@ -2749,6 +2781,13 @@ class ServerArgs:
             type=int,
             default=ServerArgs.tokenizer_worker_num,
             help="The worker num of the tokenizer manager.",
+        )
+        parser.add_argument(
+            "--detokenizer-worker-num",
+            type=int,
+            default=ServerArgs.detokenizer_worker_num,
+            help="The worker num of the detokenizer manager. "
+            "tokenizer_worker_num must be a multiple of detokenizer_worker_num.",
         )
         parser.add_argument(
             "--skip-tokenizer-init",
@@ -5025,6 +5064,11 @@ class ServerArgs:
                 )
 
         assert self.tokenizer_worker_num > 0, "Tokenizer worker num must >= 1"
+        assert self.detokenizer_worker_num > 0, "Detokenizer worker num must >= 1"
+        assert self.tokenizer_worker_num % self.detokenizer_worker_num == 0, (
+            f"tokenizer_worker_num ({self.tokenizer_worker_num}) must be a multiple of "
+            f"detokenizer_worker_num ({self.detokenizer_worker_num})."
+        )
         self.validate_buckets_rule(
             "--prompt-tokens-buckets", self.prompt_tokens_buckets
         )

--- a/test/registered/tokenizer/test_multi_tokenizer.py
+++ b/test/registered/tokenizer/test_multi_tokenizer.py
@@ -34,6 +34,8 @@ class TestMultiTokenizer(CustomTestCase):
             other_args=[
                 "--tokenizer-worker-num",
                 8,
+                "--detokenizer-worker-num",
+                4,
                 "--mem-fraction-static",
                 0.7,
             ],


### PR DESCRIPTION

# Priority Resolution

| Source | Priority |
|---|---|
| **CLI flag** (`--tokenizer-worker-num N`) | **Highest** |
| **Environment variable** (`SGLANG_TOKENIZER_WORKER_NUM`) | Fallback / default |
| **Dataclass default** (`= 1`) | Lowest |

## Implementation

In `server_args.py:2500-2523`, the env value is applied **only when** `self.tokenizer_worker_num == ServerArgs.tokenizer_worker_num` — i.e. the field still equals the dataclass default, which is equivalent to "CLI flag not set". Once the CLI flag is explicitly provided (even with value `1`), the env variable is ignored.

## Behavior Matrix

| Scenario | Effective value |
|---|---|
| No CLI flag, env not set | `1` (default) |
| No CLI flag, `SGLANG_TOKENIZER_WORKER_NUM=8` | `8` (env applied, info log emitted) |
| `--tokenizer-worker-num 4`, env not set | `4` (CLI) |
| `--tokenizer-worker-num 4`, `SGLANG_TOKENIZER_WORKER_NUM=8` | `4` (CLI wins, env ignored) |

The same rules apply to `--detokenizer-worker-num` / `SGLANG_DETOKENIZER_WORKER_NUM`.
test cmd
```
 SGLANG_DSV4_FP4_EXPERTS=0 \
 SGLANG_JIT_DEEPGEMM_PRECOMPILE=0 \
nohup  python -m sglang.launch_server \
   --trust-remote-code \
   --mem-fraction-static 0.8 \
   --model-path /work/models \
   --tp-size 8 \
   --pp-size 2\
   --dp-size 1 \
   --enable-dp-attention \
   --tokenizer-worker-num 8 \
   --detokenizer-worker-num 8 \
   --host 0.0.0.0 \
   --port 30000 \
   --nnodes 2 \
   --node-rank 0 \
   --dist-init-addr 26.5.35.131:20000 \
   --max-running-requests 256  &
   
   
 SGLANG_DSV4_FP4_EXPERTS=0 \
 SGLANG_JIT_DEEPGEMM_PRECOMPILE=0 \
 nohup python -m sglang.launch_server \
   --trust-remote-code \
   --mem-fraction-static 0.8 \
   --model-path /work/models \
   --tp-size 8 \
   --pp-size 2\
   --dp-size 1 \
   --enable-dp-attention \
   --tokenizer-worker-num 8 \
   --detokenizer-worker-num 8 \
   --nnodes 2 \
   --node-rank 1 \
   --dist-init-addr 26.5.35.131:20000 \
   --max-running-requests 256  &
```
gsm8k：
<img width="1370" height="243" alt="image" src="https://github.com/user-attachments/assets/243f884a-b9fe-47dd-b1c2-7825cec0c271" />

CC @ShangmingCai @Fridge003 @fzyzcjy @ch-wan 