### PR TITLE
fix UnboundLocalError on model_config in init_disaggregation

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -871,6 +871,10 @@ class Scheduler(
             self.server_args.disaggregation_transfer_backend
         )
 
+        # Default to the target model_config so the MetadataBuffers branches
+        # below can always access it; overridden by the draft model_config
+        # when this node runs a spec module.
+        model_config = self.model_config
         if self.draft_worker is None or self.spec_algorithm.is_ngram():
             draft_token_to_kv_pool = None
         elif self.spec_algorithm.supports_spec_v2() and self.enable_overlap:


### PR DESCRIPTION
Hotfix for #23958: when this node runs no draft worker (asymmetric P/D prefill, ngram, etc.) the local model_config variable was never assigned, so the always-on MetadataBuffers allocation hit UnboundLocalError. Default model_config to self.model_config (the target's config) before the draft-worker dispatch so all paths have a valid config; the draft branches still override with the draft runner's config when present.