### PR TITLE
ci: clean up stale-CUDA mooncake variant in install_extra_deps

### DIFF
--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -377,9 +377,15 @@ install_extra_deps() {
         MOONCAKE_STALE_PKG="mooncake-transfer-engine-cuda13"
         EXTRA_NVIDIA_SPECS="nvidia-cuda-nvrtc-cu12"
     fi
-    # Both variants own the same mooncake/ package dir; remove any stale
-    # opposite-CUDA variant that an older PR run may have left on the runner.
-    $PIP_UNINSTALL_CMD ${MOONCAKE_STALE_PKG} $PIP_UNINSTALL_SUFFIX || true
+    # Both variants own the same mooncake/ package files and bin/ scripts
+    # (mooncake_master, etc.). Uninstalling the stale variant deletes shared
+    # files that the live variant's RECORD still references, so we force a
+    # reinstall to restore them — pip would otherwise see "already satisfied"
+    # and skip.
+    if pip show ${MOONCAKE_STALE_PKG} >/dev/null 2>&1; then
+        $PIP_UNINSTALL_CMD ${MOONCAKE_STALE_PKG} $PIP_UNINSTALL_SUFFIX || true
+        $PIP_CMD install ${MOONCAKE_PKG} --force-reinstall --no-deps $PIP_INSTALL_SUFFIX
+    fi
     $PIP_CMD install ${MOONCAKE_PKG} ${EXTRA_NVIDIA_SPECS} py-spy scipy huggingface_hub[hf_xet] pytest $PIP_INSTALL_SUFFIX
 
     if [ "$IS_BLACKWELL" != "1" ]; then

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -370,11 +370,16 @@ stabilize_flashinfer_jit_paths() {
 install_extra_deps() {
     if [ "$CU_MAJOR" = "13" ]; then
         MOONCAKE_PKG="mooncake-transfer-engine-cuda13==0.3.10.post2"
+        MOONCAKE_STALE_PKG="mooncake-transfer-engine"
         EXTRA_NVIDIA_SPECS="nvidia-cuda-nvrtc"
     else
         MOONCAKE_PKG="mooncake-transfer-engine==0.3.10.post2"
+        MOONCAKE_STALE_PKG="mooncake-transfer-engine-cuda13"
         EXTRA_NVIDIA_SPECS="nvidia-cuda-nvrtc-cu12"
     fi
+    # Both variants own the same mooncake/ package dir; remove any stale
+    # opposite-CUDA variant that an older PR run may have left on the runner.
+    $PIP_UNINSTALL_CMD ${MOONCAKE_STALE_PKG} $PIP_UNINSTALL_SUFFIX || true
     $PIP_CMD install ${MOONCAKE_PKG} ${EXTRA_NVIDIA_SPECS} py-spy scipy huggingface_hub[hf_xet] pytest $PIP_INSTALL_SUFFIX
 
     if [ "$IS_BLACKWELL" != "1" ]; then


### PR DESCRIPTION
## Summary

- Defensively uninstall the opposite-CUDA `mooncake-transfer-engine` variant before installing the right one in `install_extra_deps`, so CI runners self-heal from prior stale-base PR infections.

## Background

PR #23119 (`6ecd6f84d`, merged 2026-04-19 12:32 UTC) added the CU 13 conditional that picks `mooncake-transfer-engine-cuda13` instead of `mooncake-transfer-engine` for CUDA 13 builds.

PRs whose base commit predates that merge still run the **old** `ci_install_dependency.sh` from their own checkout, which unconditionally installs `mooncake-transfer-engine`. Both packages own the same `mooncake/` Python package directory, so the wrong variant lingers on the runner alongside the right one (and can take precedence depending on install order).

A fleet-wide audit on 2026-04-28 found the non-cuda13 variant on **~60 containers** across all CI hosts. 17 of those were "post-cutoff" infections traced to **11 distinct stale PRs** (#19582, #20177, #21388, #21543, #21674, #22289, #22921, #22972, #23013, #23053, #23139), each based on a commit older than the cutoff.

## Fix

`install_extra_deps` already picks `MOONCAKE_PKG` based on `CU_MAJOR`. Pick `MOONCAKE_STALE_PKG` symmetrically and `pip uninstall` it (best-effort) right before the install step. This is symmetric, so it also handles a hypothetical CUDA 13 → 12 rollback.

## Test plan

- [ ] Per-commit CI runs and installs cleanly with no mooncake variant lingering on the runner afterwards
- [ ] Subsequent re-runs of stale-base PRs still keep the runner in a clean state once they cycle through any fresh-base PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)