### PR TITLE
Enable PDL for various kernels in DSV32/GLM5

### DIFF
--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -297,6 +297,12 @@ class Indexer(MultiPlatformOp):
         weights = weights.unsqueeze(-1) * q_scale * self.softmax_scale
         return weights
 
+    @torch.compile(dynamic=True)
+    def _apply_q_scale_and_softmax_scale(
+        self, weights: torch.Tensor, q_scale: torch.Tensor
+    ):
+        return weights.unsqueeze(-1) * q_scale * self.softmax_scale
+
     def _get_q_k_bf16(
         self,
         q_lora: torch.Tensor,
@@ -1135,7 +1141,7 @@ class Indexer(MultiPlatformOp):
                     act_quant=act_quant,
                 )
             current_stream.wait_stream(self.alt_stream)
-            weights = weights.unsqueeze(-1) * q_scale * self.softmax_scale
+            weights = self._apply_q_scale_and_softmax_scale(weights, q_scale)
         else:
             query, key = self._get_q_k_bf16(
                 q_lora, x, positions, enable_dual_stream, forward_batch=forward_batch

--- a/python/sglang/srt/layers/attention/nsa/triton_kernel.py
+++ b/python/sglang/srt/layers/attention/nsa/triton_kernel.py
@@ -3,6 +3,7 @@ from typing import Optional, Tuple
 import torch
 import triton
 import triton.language as tl
+from sgl_kernel.utils import is_arch_support_pdl
 
 
 # Triton implementation
@@ -17,6 +18,7 @@ def _act_quant_kernel(
     round_scale: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
+    USE_GDC: tl.constexpr = False,
 ):
     """
     Triton kernel for activation quantization.
@@ -44,6 +46,9 @@ def _act_quant_kernel(
     row_mask = rows < M
     col_mask = cols < N
     mask = row_mask[:, None] & col_mask[None, :]
+
+    if USE_GDC:
+        tl.extra.cuda.gdc_wait()
 
     # Load input data
     x_ptrs = X_ptr + rows[:, None] * N + cols[None, :]
@@ -81,6 +86,9 @@ def _act_quant_kernel(
     s_ptrs = S_ptr + rows * (N // group_size) + s_cols
     s_mask = row_mask
     tl.store(s_ptrs, scale, mask=s_mask)
+
+    if USE_GDC:
+        tl.extra.cuda.gdc_launch_dependents()
 
 
 def act_quant(
@@ -120,6 +128,8 @@ def act_quant(
     grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, block_size))
     round_scale = scale_fmt is not None
 
+    pdl_kwargs = {"USE_GDC": True, "launch_pdl": True} if is_arch_support_pdl() else {}
+
     _act_quant_kernel[grid](
         x_flat,
         y_flat,
@@ -131,6 +141,7 @@ def act_quant(
         BLOCK_M=BLOCK_M,
         BLOCK_N=BLOCK_N,
         num_stages=0 if round_scale else 2,
+        **pdl_kwargs,
     )
 
     return y, s

--- a/python/sglang/srt/layers/attention/nsa/triton_kernel.py
+++ b/python/sglang/srt/layers/attention/nsa/triton_kernel.py
@@ -3,7 +3,6 @@ from typing import Optional, Tuple
 import torch
 import triton
 import triton.language as tl
-from sgl_kernel.utils import is_arch_support_pdl
 
 
 # Triton implementation
@@ -18,7 +17,6 @@ def _act_quant_kernel(
     round_scale: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
-    USE_GDC: tl.constexpr = False,
 ):
     """
     Triton kernel for activation quantization.
@@ -46,9 +44,6 @@ def _act_quant_kernel(
     row_mask = rows < M
     col_mask = cols < N
     mask = row_mask[:, None] & col_mask[None, :]
-
-    if USE_GDC:
-        tl.extra.cuda.gdc_wait()
 
     # Load input data
     x_ptrs = X_ptr + rows[:, None] * N + cols[None, :]
@@ -86,9 +81,6 @@ def _act_quant_kernel(
     s_ptrs = S_ptr + rows * (N // group_size) + s_cols
     s_mask = row_mask
     tl.store(s_ptrs, scale, mask=s_mask)
-
-    if USE_GDC:
-        tl.extra.cuda.gdc_launch_dependents()
 
 
 def act_quant(
@@ -128,8 +120,6 @@ def act_quant(
     grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, block_size))
     round_scale = scale_fmt is not None
 
-    pdl_kwargs = {"USE_GDC": True, "launch_pdl": True} if is_arch_support_pdl() else {}
-
     _act_quant_kernel[grid](
         x_flat,
         y_flat,
@@ -141,7 +131,6 @@ def act_quant(
         BLOCK_M=BLOCK_M,
         BLOCK_N=BLOCK_N,
         num_stages=0 if round_scale else 2,
-        **pdl_kwargs,
     )
 
     return y, s

--- a/python/sglang/srt/layers/attention/utils.py
+++ b/python/sglang/srt/layers/attention/utils.py
@@ -12,7 +12,7 @@ _is_cuda = is_cuda()
 if _is_cuda:
     from sgl_kernel import concat_mla_absorb_q
 
-from sgl_kernel.utils import is_arch_support_pdl
+from sglang.jit_kernel.utils import is_arch_support_pdl
 
 
 @triton.jit

--- a/python/sglang/srt/layers/attention/utils.py
+++ b/python/sglang/srt/layers/attention/utils.py
@@ -12,6 +12,8 @@ _is_cuda = is_cuda()
 if _is_cuda:
     from sgl_kernel import concat_mla_absorb_q
 
+from sgl_kernel.utils import is_arch_support_pdl
+
 
 @triton.jit
 def create_flashinfer_kv_indices_triton(
@@ -462,6 +464,7 @@ def mla_quantize_and_rope_for_fp8(
         # Quantization scales (set to 1.0 for no additional scaling)
         quant_scale_q=1.0,
         quant_scale_kv=1.0,
+        enable_pdl=is_arch_support_pdl(),
     )
 
     return q_out, k_nope_out, k_rope_out

--- a/python/sglang/srt/mem_cache/utils.py
+++ b/python/sglang/srt/mem_cache/utils.py
@@ -19,6 +19,7 @@ from typing import Any, List, Optional, Tuple
 import torch
 import triton
 import triton.language as tl
+from sgl_kernel.utils import is_arch_support_pdl
 
 from sglang.srt.environ import envs
 
@@ -35,6 +36,7 @@ def set_mla_kv_buffer_kernel(
     nope_dim: tl.constexpr,
     rope_dim: tl.constexpr,
     BLOCK: tl.constexpr,
+    USE_GDC: tl.constexpr = False,
 ):
     pid_loc = tl.program_id(0)
     pid_blk = tl.program_id(1)
@@ -43,6 +45,9 @@ def set_mla_kv_buffer_kernel(
     offs = base + tl.arange(0, BLOCK)
     total_dim = nope_dim + rope_dim
     mask = offs < total_dim
+
+    if USE_GDC:
+        tl.extra.cuda.gdc_wait()
 
     loc = tl.load(loc_ptr + pid_loc).to(tl.int64)
     dst_ptr = kv_buffer_ptr + loc * buffer_stride + offs
@@ -82,6 +87,9 @@ def set_mla_kv_buffer_kernel(
 
     tl.store(dst_ptr, src, mask=mask)
 
+    if USE_GDC:
+        tl.extra.cuda.gdc_launch_dependents()
+
 
 def set_mla_kv_buffer_triton(
     kv_buffer: torch.Tensor,
@@ -96,6 +104,8 @@ def set_mla_kv_buffer_triton(
     n_loc = loc.numel()
     grid = (n_loc, triton.cdiv(total_dim, BLOCK))
 
+    pdl_kwargs = {"USE_GDC": True, "launch_pdl": True} if is_arch_support_pdl() else {}
+
     set_mla_kv_buffer_kernel[grid](
         kv_buffer,
         cache_k_nope,
@@ -107,6 +117,7 @@ def set_mla_kv_buffer_triton(
         nope_dim,
         rope_dim,
         BLOCK=BLOCK,
+        **pdl_kwargs,
     )
 
 
@@ -122,6 +133,7 @@ def set_mla_kv_buffer_fp8_quant_kernel(
     nope_dim: tl.constexpr,
     rope_dim: tl.constexpr,
     BLOCK: tl.constexpr,
+    USE_GDC: tl.constexpr = False,
 ):
     """Fuse BF16/FP16->FP8 cast with paged KV write."""
     pid_loc = tl.program_id(0)
@@ -131,6 +143,9 @@ def set_mla_kv_buffer_fp8_quant_kernel(
     offs = base + tl.arange(0, BLOCK)
     total_dim = nope_dim + rope_dim
     mask = offs < total_dim
+
+    if USE_GDC:
+        tl.extra.cuda.gdc_wait()
 
     loc = tl.load(loc_ptr + pid_loc).to(tl.int64)
     dst_ptr = kv_buffer_fp8_ptr + loc * buffer_stride + offs
@@ -165,6 +180,9 @@ def set_mla_kv_buffer_fp8_quant_kernel(
     # Destination pointer is FP8-typed view; tl.store performs downcast.
     tl.store(dst_ptr, src, mask=mask)
 
+    if USE_GDC:
+        tl.extra.cuda.gdc_launch_dependents()
+
 
 def set_mla_kv_buffer_triton_fp8_quant(
     kv_buffer: torch.Tensor,
@@ -183,6 +201,8 @@ def set_mla_kv_buffer_triton_fp8_quant(
     n_loc = loc.numel()
     grid = (n_loc, triton.cdiv(total_dim, BLOCK))
 
+    pdl_kwargs = {"USE_GDC": True, "launch_pdl": True} if is_arch_support_pdl() else {}
+
     set_mla_kv_buffer_fp8_quant_kernel[grid](
         kv_buffer_fp8,
         cache_k_nope,
@@ -194,6 +214,7 @@ def set_mla_kv_buffer_triton_fp8_quant(
         nope_dim,
         rope_dim,
         BLOCK=BLOCK,
+        **pdl_kwargs,
     )
 
 

--- a/python/sglang/srt/mem_cache/utils.py
+++ b/python/sglang/srt/mem_cache/utils.py
@@ -19,8 +19,8 @@ from typing import Any, List, Optional, Tuple
 import torch
 import triton
 import triton.language as tl
-from sgl_kernel.utils import is_arch_support_pdl
 
+from sglang.jit_kernel.utils import is_arch_support_pdl
 from sglang.srt.environ import envs
 
 

--- a/sgl-kernel/csrc/elementwise/pos_enc.cuh
+++ b/sgl-kernel/csrc/elementwise/pos_enc.cuh
@@ -105,7 +105,7 @@ __global__ void BatchQKApplyRotaryPosIdsCosSinCacheEnhancedHeadParallelismKernel
   const uint32_t bdy = blockDim.y;
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-  asm volatile("griddepcontrol.wait;");
+  cudaGridDependencySynchronize();
 #endif
 
   vec_t<float, vec_size> cos, sin;
@@ -184,7 +184,7 @@ __global__ void BatchQKApplyRotaryPosIdsCosSinCacheEnhancedHeadParallelismKernel
   }
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-  asm volatile("griddepcontrol.launch_dependents;");
+  cudaTriggerProgrammaticLaunchCompletion();
 #endif
 }
 
@@ -229,7 +229,7 @@ __global__ void BatchQKApplyRotaryPosIdsCosSinCacheEnhancedKernel(
   const uint32_t bdy = blockDim.y;
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-  asm volatile("griddepcontrol.wait;");
+  cudaGridDependencySynchronize();
 #endif
 
   vec_t<float, vec_size> cos, sin;
@@ -310,7 +310,7 @@ __global__ void BatchQKApplyRotaryPosIdsCosSinCacheEnhancedKernel(
   }
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-  asm volatile("griddepcontrol.launch_dependents;");
+  cudaTriggerProgrammaticLaunchCompletion();
 #endif
 }
 

--- a/sgl-kernel/csrc/gemm/dsv3_fused_a_gemm.cu
+++ b/sgl-kernel/csrc/gemm/dsv3_fused_a_gemm.cu
@@ -285,7 +285,7 @@ struct GmemLoaderB {
 
   __device__ void issue_mainloop() {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
-    asm volatile("griddepcontrol.wait;");
+    cudaGridDependencySynchronize();
 #pragma unroll 1
     for (int loop_idx = 0; loop_idx < k_iter_cnt; loop_idx++) {
       if (need_wait) {
@@ -571,7 +571,7 @@ __global__ __launch_bounds__(256, 1) void fused_a_gemm_kernel(
     mma_computer.issue_mainloop();
     mma_computer.epi();
   }
-  asm volatile("griddepcontrol.launch_dependents;");
+  cudaTriggerProgrammaticLaunchCompletion();
 #endif
 }
 

--- a/sgl-kernel/csrc/gemm/dsv3_router_gemm_bf16_out.cu
+++ b/sgl-kernel/csrc/gemm/dsv3_router_gemm_bf16_out.cu
@@ -75,7 +75,7 @@ __launch_bounds__(128, 1) void router_gemm_kernel_bf16_output(__nv_bfloat16* out
   }
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-  asm volatile("griddepcontrol.wait;");
+  cudaGridDependencySynchronize();
 #endif
 
   // Process the GEMM in chunks
@@ -159,7 +159,7 @@ __launch_bounds__(128, 1) void router_gemm_kernel_bf16_output(__nv_bfloat16* out
     }
   }
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-  asm volatile("griddepcontrol.launch_dependents;");
+  cudaTriggerProgrammaticLaunchCompletion();
 #endif
 }
 

--- a/sgl-kernel/csrc/gemm/dsv3_router_gemm_float_out.cu
+++ b/sgl-kernel/csrc/gemm/dsv3_router_gemm_float_out.cu
@@ -74,7 +74,7 @@ __global__ __launch_bounds__(128, 1) void router_gemm_kernel_float_output(float*
   }
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-  asm volatile("griddepcontrol.wait;");
+  cudaGridDependencySynchronize();
 #endif
 
   // Process the GEMM in chunks
@@ -158,7 +158,7 @@ __global__ __launch_bounds__(128, 1) void router_gemm_kernel_float_output(float*
     }
   }
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-  asm volatile("griddepcontrol.launch_dependents;");
+  cudaTriggerProgrammaticLaunchCompletion();
 #endif
 }
 

--- a/sgl-kernel/csrc/gemm/per_token_group_quant_8bit_v2.cu
+++ b/sgl-kernel/csrc/gemm/per_token_group_quant_8bit_v2.cu
@@ -271,6 +271,10 @@ __global__ void per_token_group_quant_8bit_kernel(
   using scale_element_t = std::conditional_t<SCALE_UE8M0, uint8_t, float>;
   static_assert(sizeof(scale_packed_t) % sizeof(scale_element_t) == 0);
 
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  cudaGridDependencySynchronize();
+#endif
+
   SCHEDULER::execute<FUSE_SILU_AND_MUL, GROUP_SIZE, THREADS_PER_SUBWARP>(
       subwarps_per_block,
       hidden_dim_num_groups,
@@ -398,6 +402,10 @@ __global__ void per_token_group_quant_8bit_kernel(
             reinterpret_cast<int4*>(output_q + offset_num_groups * GROUP_SIZE + lane_id * INPUT_PRIMARY_VEC_SIZE),
             output_buf);
       });
+
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  cudaTriggerProgrammaticLaunchCompletion();
+#endif
 }
 
 void sgl_per_token_group_quant_8bit_v2(
@@ -445,17 +453,28 @@ void sgl_per_token_group_quant_8bit_v2(
     SCHEDULER::compute_exec_config(                                                                                  \
         THREADS_PER_SUBWARP, num_local_experts, hidden_dim_num_groups, num_groups, subwarps_per_block, grid, block); \
                                                                                                                      \
-    per_token_group_quant_8bit_kernel<SCHEDULER, GROUP_SIZE, THREADS_PER_SUBWARP, T, DST_DTYPE, __VA_ARGS__>         \
-        <<<grid, block, 0, stream>>>(                                                                                \
-            static_cast<T*>(input.data_ptr()),                                                                       \
-            static_cast<DST_DTYPE*>(output_q.data_ptr()),                                                            \
-            static_cast<output_s_dtype*>(output_s.data_ptr()),                                                       \
-            static_cast<int32_t*>(masked_m.has_value() ? masked_m->data_ptr() : 0),                                  \
-            subwarps_per_block,                                                                                      \
-            hidden_dim_num_groups,                                                                                   \
-            scale_expert_stride,                                                                                     \
-            scale_hidden_stride,                                                                                     \
-            num_tokens_per_expert);                                                                                  \
+    cudaLaunchConfig_t config;                                                                                       \
+    config.gridDim = grid;                                                                                           \
+    config.blockDim = block;                                                                                         \
+    config.dynamicSmemBytes = 0;                                                                                     \
+    config.stream = stream;                                                                                          \
+    cudaLaunchAttribute attrs[1];                                                                                    \
+    attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;                                                \
+    attrs[0].val.programmaticStreamSerializationAllowed = getEnvEnablePDL();                                         \
+    config.numAttrs = 1;                                                                                             \
+    config.attrs = attrs;                                                                                            \
+    cudaLaunchKernelEx(                                                                                              \
+        &config,                                                                                                     \
+        per_token_group_quant_8bit_kernel<SCHEDULER, GROUP_SIZE, THREADS_PER_SUBWARP, T, DST_DTYPE, __VA_ARGS__>,    \
+        static_cast<T*>(input.data_ptr()),                                                                           \
+        static_cast<DST_DTYPE*>(output_q.data_ptr()),                                                                \
+        static_cast<output_s_dtype*>(output_s.data_ptr()),                                                           \
+        static_cast<int32_t*>(masked_m.has_value() ? masked_m->data_ptr() : 0),                                      \
+        subwarps_per_block,                                                                                          \
+        hidden_dim_num_groups,                                                                                       \
+        scale_expert_stride,                                                                                         \
+        scale_hidden_stride,                                                                                         \
+        num_tokens_per_expert);                                                                                      \
   } while (0)
 
 #define LAUNCH_KERNEL(GROUP_SIZE, T, DST_DTYPE)                                                                     \


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Improve low latency performance for GLM-5/DSV3.2

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

1. Compile the q_scale and softmax scale
2. Pass in PDL into Flashinfer `mla_rope_quantize_fp8`
3. Enable Triton PDL in `set_mla_kv_buffer_kernel`
5. Enable PDL in per token quant 8bit v2.
4. Remove various potential unsafe usages of `asm volatile("griddepcontrol.launch_dependents;");`, which does not have a memory barrier, as described in https://github.com/flashinfer-ai/flashinfer/issues/2558.

Before
<img width="1276" height="580" alt="Screenshot 2026-04-28 at 5 06 29 PM" src="https://github.com/user-attachments/assets/62aa0c96-1fb1-48b2-a799-fd170c566038" />
<img width="1151" height="525" alt="Screenshot 2026-04-28 at 5 07 08 PM" src="https://github.com/user-attachments/assets/9de3a09f-b48d-4f9b-a5a6-9255a7310aa9" />

After


<img width="913" height="556" alt="Screenshot 2026-04-28 at 5 05 27 PM" src="https://github.com/user-attachments/assets/71c2552e-3519-4395-8030-3e093c03e502" />
<img width="1143" height="558" alt="Screenshot 2026-04-28 at 5 05 50 PM" src="https://github.com/user-attachments/assets/7e098ece-c332-4188-af40-6cdb79844024" />

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

GPQA:

```
Repeat: 8, mean: 0.856
Scores: ['0.889', '0.833', '0.869', '0.823', '0.859', '0.843', '0.874', '0.859']
Mean latency: 10523.918 s
```

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

69.04 -> 71.39 TPS

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->