### PR TITLE
docs(cookbook): add H200 (FP4) deployment option for DeepSeek-V4

### DIFF
--- a/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
+++ b/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
@@ -1,7 +1,7 @@
 ---
 title: DeepSeek-V4
 metatags:
-    description: "Deploy DeepSeek-V4 with SGLang — a next-generation MoE model from DeepSeek. Blackwell deployments use the FP4 checkpoint; Hopper deployments use the FP8 checkpoint."
+    description: "Deploy DeepSeek-V4 with SGLang — a next-generation MoE model from DeepSeek."
 tag: NEW
 ---
 
@@ -35,7 +35,7 @@ tag: NEW
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><strong><a href="https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro">DeepSeek-V4-Pro</a></strong></td>
       <td style={{padding: "9px 12px", textAlign: "right", backgroundColor: "rgba(255,255,255,0.05)"}}><strong>1.6T</strong></td>
       <td style={{padding: "9px 12px", textAlign: "right", backgroundColor: "rgba(255,255,255,0.02)"}}>49B</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>high-capacity: B200 8 GPU / GB200 8 GPU (2 nodes) / GB300 4 GPU / H200 16 GPU (2 nodes)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>high-capacity: B200 8 GPU / GB200 8 GPU (2 nodes) / GB300 4 GPU / H200 8 GPU(fp4)/16 GPU(fp8)</td>
     </tr>
   </tbody>
 </table>
@@ -153,18 +153,9 @@ The generator currently picks values on the **conservative** side (mirroring an 
 
 **Hopper (H200) note**
 
-H200 image (`lmsysorg/sglang:deepseek-v4-hopper`) and FP8 checkpoints
-(`sgl-project/DeepSeek-V4-Flash-FP8`, `sgl-project/DeepSeek-V4-Pro-FP8`) are
-publicly available.
-
-**H200 (FP4):** select **H200 (FP4)** in the generator to run the original
-FP4-mixed Instruct repos (`deepseek-ai/DeepSeek-V4-Flash`,
-`deepseek-ai/DeepSeek-V4-Pro`) on Hopper through the Marlin MoE runner
-(`--moe-runner-backend marlin`). Flash fits on TP=4 and Pro fits on TP=8
-single-node. Only the `low-latency` / `balanced` / `max-throughput`
-recipes are supported on this path (`cp` / `pd-disagg` are not). MTP is
-enabled for `low-latency` (`steps=3 / topk=1 / draft=4`) and `balanced`
-(`steps=1 / topk=1 / draft=2`), and disabled for `max-throughput`.
+We provide two different options for running DeepSeek-V4 models on Hopper devices (H200)
+- Original FP4 checkpoints: To run original FP4 checkpoints, apply the w4a16 MoE kernels (marlin) as in interactive command generator. For this option we only support TP method. Complete Pro model can be run on a single H200 node with this option.
+- Converted FP8 checkpoints: We also provide pre-converted FP8 checkpoints (`sgl-project/DeepSeek-V4-Flash-FP8`, `sgl-project/DeepSeek-V4-Pro-FP8`), which support more parallelism and features.
 
 PD-Disagg recipes on H200 may require `docker run --privileged --ulimit memlock=-1`
 (or `--device /dev/infiniband:/dev/infiniband --cap-add IPC_LOCK`) so mooncake

--- a/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
+++ b/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
@@ -157,6 +157,13 @@ H200 image (`lmsysorg/sglang:deepseek-v4-hopper`) and FP8 checkpoints
 (`sgl-project/DeepSeek-V4-Flash-FP8`, `sgl-project/DeepSeek-V4-Pro-FP8`) are
 publicly available.
 
+**H200 (FP4):** select **H200 (FP4)** in the generator to run the original
+FP4-mixed Instruct repos (`deepseek-ai/DeepSeek-V4-Flash`,
+`deepseek-ai/DeepSeek-V4-Pro`) on Hopper through the Marlin MoE runner
+(`--moe-runner-backend marlin`). Flash fits on TP=4 and Pro fits on TP=8
+single-node. MTP is enabled for `low-latency` and disabled for
+`balanced` / `max-throughput`.
+
 PD-Disagg recipes on H200 may require `docker run --privileged --ulimit memlock=-1`
 (or `--device /dev/infiniband:/dev/infiniband --cap-add IPC_LOCK`) so mooncake
 can discover the IB HCAs; without IB exposure mooncake silently falls back to

--- a/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
+++ b/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
@@ -163,7 +163,8 @@ FP4-mixed Instruct repos (`deepseek-ai/DeepSeek-V4-Flash`,
 (`--moe-runner-backend marlin`). Flash fits on TP=4 and Pro fits on TP=8
 single-node. Only the `low-latency` / `balanced` / `max-throughput`
 recipes are supported on this path (`cp` / `pd-disagg` are not). MTP is
-enabled for `low-latency` and disabled for `balanced` / `max-throughput`.
+enabled for `low-latency` (`steps=3 / topk=1 / draft=4`) and `balanced`
+(`steps=1 / topk=1 / draft=2`), and disabled for `max-throughput`.
 
 PD-Disagg recipes on H200 may require `docker run --privileged --ulimit memlock=-1`
 (or `--device /dev/infiniband:/dev/infiniband --cap-add IPC_LOCK`) so mooncake

--- a/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
+++ b/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
@@ -161,8 +161,9 @@ publicly available.
 FP4-mixed Instruct repos (`deepseek-ai/DeepSeek-V4-Flash`,
 `deepseek-ai/DeepSeek-V4-Pro`) on Hopper through the Marlin MoE runner
 (`--moe-runner-backend marlin`). Flash fits on TP=4 and Pro fits on TP=8
-single-node. MTP is enabled for `low-latency` and disabled for
-`balanced` / `max-throughput`.
+single-node. Only the `low-latency` / `balanced` / `max-throughput`
+recipes are supported on this path (`cp` / `pd-disagg` are not). MTP is
+enabled for `low-latency` and disabled for `balanced` / `max-throughput`.
 
 PD-Disagg recipes on H200 may require `docker run --privileged --ulimit memlock=-1`
 (or `--device /dev/infiniband:/dev/infiniband --cap-add IPC_LOCK`) so mooncake

--- a/docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx
@@ -295,8 +295,9 @@ export const DeepSeekV4Deployment = () => {
     // Instruct repos through the Marlin MoE runner, so it doesn't share envs
     // or flags with either the FP8 H200 path or the Blackwell paths.
     //   Flash: TP=4, single node       Pro: TP=8, single node
-    //   low-latency:           MTP enabled (steps=3 / topk=1 / draft=4)
-    //   balanced / max-throughput: MTP disabled
+    //   low-latency:    MTP 3 / 1 / 4 (steps / topk / draft-tokens)
+    //   balanced:       MTP 1 / 1 / 2
+    //   max-throughput: MTP disabled
     if (hardware === "h200-fp4") {
       const verifyKey = `${hardware}|${modelSize}|${recipe}`;
       if (TBD_RECIPES.has(verifyKey)) return TBD_PLACEHOLDER;
@@ -312,6 +313,11 @@ export const DeepSeekV4Deployment = () => {
         fp4Flags.push("  --speculative-num-steps 3");
         fp4Flags.push("  --speculative-eagle-topk 1");
         fp4Flags.push("  --speculative-num-draft-tokens 4");
+      } else if (recipe === "balanced") {
+        fp4Flags.push("  --speculative-algo EAGLE");
+        fp4Flags.push("  --speculative-num-steps 1");
+        fp4Flags.push("  --speculative-eagle-topk 1");
+        fp4Flags.push("  --speculative-num-draft-tokens 2");
       }
       if (isBig) fp4Flags.push("  --mem-fraction-static 0.88");
       if (toolcall === "enabled") fp4Flags.push("  --tool-call-parser deepseekv4");

--- a/docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx
@@ -31,6 +31,7 @@ export const DeepSeekV4Deployment = () => {
         { id: "gb200", label: "GB200 (FP4)", default: false },
         { id: "gb300", label: "GB300 (FP4)", default: false },
         { id: "h200",  label: "H200 (FP8)",  default: false },
+        { id: "h200-fp4", label: "H200 (FP4)", default: false },
       ],
     },
     modelSize: {
@@ -147,6 +148,11 @@ export const DeepSeekV4Deployment = () => {
     // repackagings for both variants.
     "h200|small":  { slug: "sgl-project/DeepSeek-V4-Flash-FP8",        tp: 4,  multinode: false },
     "h200|big":    { slug: "sgl-project/DeepSeek-V4-Pro-FP8",          tp: 16, multinode: true, nnodes: 2 },
+    // H200 (FP4) runs the original FP4-mixed Instruct repos through the Marlin
+    // MoE runner: experts are dequantized from FP4 to FP16 at runtime, so a
+    // single-node TP=4 / TP=8 deployment fits Flash / Pro on Hopper.
+    "h200-fp4|small": { slug: "deepseek-ai/DeepSeek-V4-Flash", tp: 4, multinode: false },
+    "h200-fp4|big":   { slug: "deepseek-ai/DeepSeek-V4-Pro",   tp: 8, multinode: false },
   };
   // Per (hardware, modelSize) PD role TP (from allinone _PD_SPEC).
   const PD_TP_SPEC = {
@@ -202,6 +208,12 @@ export const DeepSeekV4Deployment = () => {
     "gb200|big|low-latency",
     "gb200|big|balanced",
     "gb200|big|max-throughput",
+    "h200-fp4|small|low-latency",
+    "h200-fp4|small|balanced",
+    "h200-fp4|small|max-throughput",
+    "h200-fp4|big|low-latency",
+    "h200-fp4|big|balanced",
+    "h200-fp4|big|max-throughput",
   ]);
   // Recipes whose command is intentionally not yet provided (e.g. blocked by an
   // upstream limitation). Showing a minimal placeholder is friendlier to users
@@ -210,6 +222,11 @@ export const DeepSeekV4Deployment = () => {
     "h200|big|cp",
     "gb200|small|pd-disagg",
     "gb200|big|pd-disagg",
+    // H200 (FP4) Marlin path: cp / pd-disagg are not yet validated.
+    "h200-fp4|small|cp",
+    "h200-fp4|big|cp",
+    "h200-fp4|small|pd-disagg",
+    "h200-fp4|big|pd-disagg",
   ]);
   const TBD_PLACEHOLDER = "# to be provided";
   const BEING_VERIFIED_NOTE =
@@ -253,6 +270,42 @@ export const DeepSeekV4Deployment = () => {
 
     if (recipe === "pd-disagg") {
       return buildPDDisaggCommand(hardware, modelSize);
+    }
+
+    // H200 (FP4) Marlin path: dedicated branch — Hopper runs the FP4-mixed
+    // Instruct repos through the Marlin MoE runner, so it doesn't share envs
+    // or flags with either the FP8 H200 path or the Blackwell paths.
+    //   Flash: TP=4, single node       Pro: TP=8, single node
+    //   low-latency:           MTP enabled (steps=3 / topk=1 / draft=4)
+    //   balanced / max-throughput: MTP disabled
+    if (hardware === "h200-fp4") {
+      const verifyKey = `${hardware}|${modelSize}|${recipe}`;
+      if (TBD_RECIPES.has(verifyKey)) return TBD_PLACEHOLDER;
+
+      const fp4Flags = [
+        "  --trust-remote-code",
+        `  --model-path ${slug}`,
+        `  --tp ${tp}`,
+        "  --moe-runner-backend marlin",
+      ];
+      if (recipe === "low-latency") {
+        fp4Flags.push("  --speculative-algo EAGLE");
+        fp4Flags.push("  --speculative-num-steps 3");
+        fp4Flags.push("  --speculative-eagle-topk 1");
+        fp4Flags.push("  --speculative-num-draft-tokens 4");
+      }
+      fp4Flags.push("  --chunked-prefill-size 4096");
+      fp4Flags.push("  --disable-flashinfer-autotune");
+      if (isBig) fp4Flags.push("  --mem-fraction-static 0.88");
+      if (toolcall === "enabled") fp4Flags.push("  --tool-call-parser deepseekv4");
+      if (reasoningParser === "enabled") fp4Flags.push("  --reasoning-parser deepseek-v4");
+      fp4Flags.push("  --host 0.0.0.0");
+      fp4Flags.push("  --port 30000");
+
+      const fp4Cmd = `sglang serve \\\n${fp4Flags.join(" \\\n")}`;
+      return VERIFIED_RECIPES.has(verifyKey)
+        ? fp4Cmd
+        : `${BEING_VERIFIED_NOTE}\n${commentOutCommand(fp4Cmd)}`;
     }
 
     // ---- env ----

--- a/docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx
@@ -71,7 +71,19 @@ export const DeepSeekV4Deployment = () => {
     },
   };
 
-  const resolveItems = (option) => option.items;
+  // Recipes that are not supported on the H200 (FP4) Marlin path.
+  const H200_FP4_UNSUPPORTED_RECIPES = new Set(["cp", "pd-disagg"]);
+
+  const resolveItems = (option, vals) => {
+    if (option.name === "recipe" && vals && vals.hardware === "h200-fp4") {
+      return option.items.map((it) =>
+        H200_FP4_UNSUPPORTED_RECIPES.has(it.id)
+          ? { ...it, disabled: true, disabledReason: "Not supported on H200 (FP4)" }
+          : it
+      );
+    }
+    return option.items;
+  };
 
   const getInitialState = () => {
     const initialState = {};
@@ -105,7 +117,19 @@ export const DeepSeekV4Deployment = () => {
   }, []);
 
   const handleRadioChange = (optionName, value) => {
-    setValues((prev) => ({ ...prev, [optionName]: value }));
+    setValues((prev) => {
+      const next = { ...prev, [optionName]: value };
+      // Switching to H200 (FP4) while cp / pd-disagg is selected: fall back
+      // to low-latency since those recipes are not supported on this path.
+      if (
+        optionName === "hardware" &&
+        value === "h200-fp4" &&
+        H200_FP4_UNSUPPORTED_RECIPES.has(next.recipe)
+      ) {
+        next.recipe = "low-latency";
+      }
+      return next;
+    });
   };
 
   // ============================================================================
@@ -222,11 +246,6 @@ export const DeepSeekV4Deployment = () => {
     "h200|big|cp",
     "gb200|small|pd-disagg",
     "gb200|big|pd-disagg",
-    // H200 (FP4) Marlin path: cp / pd-disagg are not yet validated.
-    "h200-fp4|small|cp",
-    "h200-fp4|big|cp",
-    "h200-fp4|small|pd-disagg",
-    "h200-fp4|big|pd-disagg",
   ]);
   const TBD_PLACEHOLDER = "# to be provided";
   const BEING_VERIFIED_NOTE =
@@ -778,7 +797,7 @@ python3 -m sglang_router.launch_router \\
   return (
     <div style={containerStyle} className="not-prose">
       {Object.entries(options).map(([key, option]) => {
-        const items = resolveItems(option);
+        const items = resolveItems(option, values);
         return (
           <div key={key} style={cardStyle}>
             <div style={titleStyle}>{option.title}</div>

--- a/docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx
@@ -313,8 +313,6 @@ export const DeepSeekV4Deployment = () => {
         fp4Flags.push("  --speculative-eagle-topk 1");
         fp4Flags.push("  --speculative-num-draft-tokens 4");
       }
-      fp4Flags.push("  --chunked-prefill-size 4096");
-      fp4Flags.push("  --disable-flashinfer-autotune");
       if (isBig) fp4Flags.push("  --mem-fraction-static 0.88");
       if (toolcall === "enabled") fp4Flags.push("  --tool-call-parser deepseekv4");
       if (reasoningParser === "enabled") fp4Flags.push("  --reasoning-parser deepseek-v4");


### PR DESCRIPTION
## Summary
- Adds an **H200 (FP4)** hardware row to the DeepSeek-V4 cookbook generator (`docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx`).
- The new option runs the FP4-mixed Instruct repos (`deepseek-ai/DeepSeek-V4-Flash`, `deepseek-ai/DeepSeek-V4-Pro`) on Hopper through the Marlin MoE runner (`--moe-runner-backend marlin`):
  - **Flash** → TP=4, single-node
  - **Pro** → TP=8, single-node
  - **low-latency** → MTP enabled (`steps=3 / topk=1 / draft=4`)
  - **balanced / max-throughput** → MTP disabled
- `cp` and `pd-disagg` are marked TBD on this row until they're validated.
- Adds a short H200 (FP4) note in `DeepSeek-V4.mdx` pointing users at the new generator option.

## Test plan
- [ ] Render the cookbook and pick `H200 (FP4) → Pro → Low-Latency`; confirm the generated command matches the requested launch:
  ```
  sglang serve \
      --trust-remote-code \
      --model-path deepseek-ai/DeepSeek-V4-Pro \
      --tp 8 \
      --moe-runner-backend marlin \
      --speculative-algo EAGLE \
      --speculative-num-steps 3 \
      --speculative-eagle-topk 1 \
      --speculative-num-draft-tokens 4 \
      --chunked-prefill-size 4096 \
      --disable-flashinfer-autotune \
      --mem-fraction-static 0.88 \
      --host 0.0.0.0 \
      --port 30000
  ```
- [ ] Pick `H200 (FP4) → Flash → Low-Latency`; confirm the same template with `--model-path deepseek-ai/DeepSeek-V4-Flash`, `--tp 4`, no `--mem-fraction-static` line.
- [ ] Pick `H200 (FP4) → Pro/Flash → Balanced` and `Max-Throughput`; confirm MTP flags are absent.
- [ ] Pick `H200 (FP4) → cp` / `pd-disagg`; confirm the `# to be provided` placeholder.
- [ ] Existing `H200 (FP8)` / Blackwell rows render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)