### PR TITLE
[Fix] FP8 Qwen3-Next quant error by removing fallback fused shards

### DIFF
--- a/python/sglang/srt/layers/quantization/utils.py
+++ b/python/sglang/srt/layers/quantization/utils.py
@@ -60,8 +60,6 @@ def _module_path_match(ignored: str, prefix: str) -> bool:
 _FALLBACK_FUSED_SHARDS: Mapping[str, List[str]] = {
     "qkv_proj": ["q_proj", "k_proj", "v_proj"],
     "gate_up_proj": ["gate_proj", "up_proj"],
-    "in_proj_ba": ["in_proj_b", "in_proj_a"],
-    "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
 }
 
 

--- a/test/registered/quant/test_is_layer_skipped.py
+++ b/test/registered/quant/test_is_layer_skipped.py
@@ -1,0 +1,52 @@
+import unittest
+
+from sglang.srt.layers.quantization.utils import is_layer_skipped
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+
+
+# Qwen3-Next FP8 actually publishes the equivalent of this in
+# packed_modules_mapping (qwen3_next.py:908-911). in_proj_ba / in_proj_qkvz
+# are deliberately omitted because they are real, unified tensors.
+QWEN3_NEXT_FUSED_MAPPING = {
+    "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+    "gate_up_proj": ["gate_proj", "up_proj"],
+}
+
+
+def _qwen3_next_ignored_layers(layer_idx: int, name: str) -> list:
+    # Mirrors the normalization in Fp8Config.from_config: each entry is kept in
+    # both "model.<...>" and bare "<...>" forms.
+    base = f"layers.{layer_idx}.linear_attn.{name}"
+    return [base, f"model.{base}"]
+
+
+class TestIsLayerSkipped(CustomTestCase):
+    def test_qwen3_next_in_proj_ba_is_skipped(self):
+        # Regression for #23467: in_proj_ba is a unified tensor in the FP8
+        # checkpoint. modules_to_not_convert lists it explicitly, so it must
+        # bypass FP8 quantization (otherwise validate_block_quant_shapes raises
+        # on output_partition_size=8 vs block_n=128 at tp=4).
+        prefix = "model.layers.0.linear_attn.in_proj_ba"
+        ignored = _qwen3_next_ignored_layers(0, "in_proj_ba")
+        self.assertTrue(is_layer_skipped(prefix, ignored, QWEN3_NEXT_FUSED_MAPPING))
+
+    def test_qwen3_next_in_proj_qkvz_is_skipped(self):
+        prefix = "model.layers.5.linear_attn.in_proj_qkvz"
+        ignored = _qwen3_next_ignored_layers(5, "in_proj_qkvz")
+        self.assertTrue(is_layer_skipped(prefix, ignored, QWEN3_NEXT_FUSED_MAPPING))
+
+    def test_mlp_gate_does_not_match_gate_up_proj(self):
+        # The motivation for #23467: an entry "mlp.gate" in
+        # modules_to_not_convert must NOT skip a sibling "mlp.gate_up_proj".
+        ignored = ["mlp.gate"]
+        self.assertFalse(
+            is_layer_skipped("model.layers.0.mlp.gate_up_proj", ignored, {})
+        )
+        self.assertTrue(is_layer_skipped("model.layers.0.mlp.gate", ignored, {}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
- Fixes a regression introduced by #23467 that broke Qwen3-Next FP8 on B200 4-GPU at server initialization with: 
```ValueError: Weight output_partition_size = 8 is not divisible by weight quantization block_n = 128.```
- Root cause. #23467 added `in_proj_ba` and `in_proj_qkvz` to `_FALLBACK_FUSED_SHARDS` in `python/sglang/srt/layers/quantization/utils.py`, treating them as virtual fused names. However, they are real, unified tensors in the Qwen3-Next FP8 checkpoint, listed explicitly in modules_to_not_convert. The fallback unfused them into non-existent shard names (`in_proj_b/_a`, `in_proj_qkv/_z`), which never appear in `modules_to_not_convert`, so `is_layer_skipped` returned `False` for layers that should have been skipped. `Fp8LinearMethod.validate_block_quant_shapes` then ran on those layers and failed the `block_n = 128` divisibility check.
- The original motivation of #23467, preventing `mlp.gate` from substring-matching `mlp.gate_up_proj`, is preserved by `_module_path_match`, which is unchanged. Models that genuinely fuse these projections (Qwen3.5 on gfx95/NPU) declare them in their own packed_modules_mapping, which is_layer_skipped already prefers over the global fallback.

## Modifications
-  `python/sglang/srt/layers/quantization/utils.py`: removed the spurious `in_proj_ba` and `in_proj_qkvz` entries from `_FALLBACK_FUSED_SHARDS`
- `test/registered/quant/test_is_layer_skipped.py`: new CPU regression test (≈5s, stage-a-test-cpu) covering:
  -` in_proj_ba` and `in_proj_qkvz` are correctly skipped when listed in modules_to_not_convert (the bug)
  - `mlp.gate` does not match a sibling `mlp.gate_up_proj` (the preserved motivation of #23467)
 
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
No model forward, kernel, or quantization-math changes. The fix only affects which layers are skipped during FP8 quantization config resolution at startup — restoring the pre-#23467 behavior for in_proj_ba/in_proj_qkvz. Verified that Qwen3-Next-80B FP8 now loads on B200 4-GPU without the divisibility error.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
