### PR TITLE
Add engine_type label to tokenizer manager metrics

### DIFF
--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -35,6 +35,14 @@ class DisaggregationMode(Enum):
     PREFILL = "prefill"
     DECODE = "decode"
 
+    @staticmethod
+    def to_engine_type(mode: str) -> str:
+        if mode == DisaggregationMode.PREFILL.value:
+            return "prefill"
+        elif mode == DisaggregationMode.DECODE.value:
+            return "decode"
+        return "unified"
+
 
 #########################
 # Synchronization

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -453,9 +453,13 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
     def init_metric_collector_watchdog(self):
         # Metrics
         if self.enable_metrics:
+            engine_type = DisaggregationMode.to_engine_type(
+                self.server_args.disaggregation_mode
+            )
+
             labels = {
                 "model_name": self.server_args.served_model_name,
-                # TODO: Add lora name/path in the future,
+                "engine_type": engine_type,
             }
             if self.enable_priority_scheduling:
                 labels["priority"] = ""

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -120,14 +120,9 @@ class SchedulerMetricsMixin:
             self.attn_tp_rank == 0 or self.server_args.enable_metrics_for_all_schedulers
         )
         if self.enable_metrics:
-            if self.server_args.disaggregation_mode == DisaggregationMode.PREFILL.value:
-                engine_type = "prefill"
-            elif (
-                self.server_args.disaggregation_mode == DisaggregationMode.DECODE.value
-            ):
-                engine_type = "decode"
-            else:
-                engine_type = "unified"
+            engine_type = DisaggregationMode.to_engine_type(
+                self.server_args.disaggregation_mode
+            )
 
             labels = {
                 "model_name": self.server_args.served_model_name,


### PR DESCRIPTION
## Summary
- Tokenizer manager metrics (prompt_tokens_total, generation_tokens_total, time_to_first_token_seconds, etc.) were missing the `engine_type` label, making it impossible to filter by prefill/decode/unified role in dashboards.
- Added `engine_type` label to tokenizer metrics, matching the existing scheduler pattern.
- Extracted the duplicated if/else `disaggregation_mode`-to-`engine_type` logic into `DisaggregationMode.to_engine_type()` static method, used by both scheduler and tokenizer.

## Test plan
- [ ] Verify tokenizer metrics now include engine_type label when server starts
- [ ] Confirm dashboard queries with engine_type filter return data for tokenizer metrics
- [ ] Verify scheduler metrics are unchanged