### PR TITLE
Add ChatCompletionRequest-style support to /v1/tokenize

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -333,7 +333,7 @@ async def lifespan(fast_api_app: FastAPI):
         _global_state.tokenizer_manager, _global_state.template_manager
     )
     fast_api_app.state.openai_serving_tokenize = OpenAIServingTokenize(
-        _global_state.tokenizer_manager
+        _global_state.tokenizer_manager, _global_state.template_manager
     )
     fast_api_app.state.openai_serving_detokenize = OpenAIServingDetokenize(
         _global_state.tokenizer_manager

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -31,6 +31,7 @@ from openai.types.responses.response import ToolChoice
 from openai.types.responses.tool import Tool
 from pydantic import (
     BaseModel,
+    ConfigDict,
     Field,
     field_validator,
     model_serializer,
@@ -1118,12 +1119,31 @@ class RerankResponse(BaseModel):
 class TokenizeRequest(BaseModel):
     """Request schema for the /tokenize endpoint."""
 
+    model_config = ConfigDict(extra="allow")
+
     model: str = DEFAULT_MODEL_NAME
-    prompt: Union[str, List[str]]
+    prompt: Optional[Union[str, List[str]]] = None
+    messages: Optional[List[ChatCompletionMessageParam]] = None
     add_special_tokens: bool = Field(
         default=True,
         description="whether to add model-specific special tokens (e.g. BOS/EOS) during encoding.",
     )
+
+    @model_validator(mode="after")
+    def validate_tokenize_input(self) -> "TokenizeRequest":
+        if (self.prompt is None) == (self.messages is None):
+            raise ValueError("Exactly one of 'prompt' or 'messages' must be provided.")
+        return self
+
+    def to_chat_completion_request(self) -> ChatCompletionRequest:
+        data = self.model_dump(
+            exclude={"prompt", "add_special_tokens"},
+            exclude_none=True,
+        )
+        extra = getattr(self, "__pydantic_extra__", None)
+        if extra:
+            data.update(extra)
+        return ChatCompletionRequest.model_validate(data)
 
 
 class TokenizeResponse(BaseModel):

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -1124,6 +1124,13 @@ class TokenizeRequest(BaseModel):
     model: str = DEFAULT_MODEL_NAME
     prompt: Optional[Union[str, List[str]]] = None
     messages: Optional[List[ChatCompletionMessageParam]] = None
+    tools: Optional[List[Tool]] = Field(default=None, examples=[None])
+    tool_choice: Optional[Union[ToolChoice, Literal["auto", "required", "none"]]] = (
+        Field(default=None, examples=["auto"])
+    )
+    reasoning_effort: Optional[Literal["none", "low", "medium", "high"]] = None
+    continue_final_message: bool = False
+    chat_template_kwargs: Optional[Dict] = None
     add_special_tokens: bool = Field(
         default=True,
         description="whether to add model-specific special tokens (e.g. BOS/EOS) during encoding.",

--- a/python/sglang/srt/entrypoints/openai/serving_tokenize.py
+++ b/python/sglang/srt/entrypoints/openai/serving_tokenize.py
@@ -1,6 +1,6 @@
 import logging
 from http import HTTPStatus
-from typing import List, Union
+from typing import List, Optional, Union
 
 from fastapi import Request
 
@@ -12,12 +12,21 @@ from sglang.srt.entrypoints.openai.protocol import (
     TokenizeResponse,
 )
 from sglang.srt.entrypoints.openai.serving_base import OpenAIServingBase
+from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
 
 logger = logging.getLogger(__name__)
 
 
 class OpenAIServingTokenize(OpenAIServingBase):
     """Handler for /v1/tokenize requests"""
+
+    def __init__(self, tokenizer_manager, template_manager=None):
+        super().__init__(tokenizer_manager)
+        self.chat_serving: Optional[OpenAIServingChat] = (
+            OpenAIServingChat(tokenizer_manager, template_manager)
+            if template_manager is not None
+            else None
+        )
 
     def _request_id_prefix(self) -> str:
         return "tok-"
@@ -37,7 +46,11 @@ class OpenAIServingTokenize(OpenAIServingBase):
             tokenizer = self.tokenizer_manager.tokenizer
             max_model_len = getattr(tokenizer, "model_max_length", -1)
 
-            if isinstance(request.prompt, str):
+            if request.messages is not None:
+                token_ids = self._tokenize_chat_request(request)
+                tokens = token_ids
+                count = len(token_ids)
+            elif isinstance(request.prompt, str):
                 token_ids = tokenizer.encode(
                     request.prompt,
                     add_special_tokens=request.add_special_tokens,
@@ -61,6 +74,8 @@ class OpenAIServingTokenize(OpenAIServingBase):
             return TokenizeResponse(
                 tokens=tokens, count=count, max_model_len=max_model_len
             )
+        except ValueError as e:
+            return self.create_error_response(str(e))
         except Exception as e:
             logger.error("Error during tokenization", exc_info=True)
             return self.create_error_response(
@@ -68,6 +83,34 @@ class OpenAIServingTokenize(OpenAIServingBase):
                 err_type="InternalServerError",
                 status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
             )
+
+    def _tokenize_chat_request(self, request: TokenizeRequest) -> List[int]:
+        if self.chat_serving is None:
+            raise ValueError("Chat template tokenization requires a template manager.")
+
+        chat_request = request.to_chat_completion_request()
+        validation_error = self.chat_serving._validate_request(chat_request)
+        if validation_error:
+            raise ValueError(validation_error)
+
+        is_multimodal = self.tokenizer_manager.model_config.is_multimodal
+        processed_messages = self.chat_serving._process_messages(
+            chat_request, is_multimodal
+        )
+
+        prompt_ids = processed_messages.prompt_ids
+        if isinstance(prompt_ids, list) and (prompt_ids or not processed_messages.prompt):
+            return prompt_ids
+        if isinstance(prompt_ids, str):
+            return self.tokenizer_manager.tokenizer.encode(
+                prompt_ids, add_special_tokens=False
+            )
+        if processed_messages.prompt:
+            return self.tokenizer_manager.tokenizer.encode(
+                processed_messages.prompt, add_special_tokens=False
+            )
+
+        raise ValueError("Failed to render chat messages into token ids.")
 
 
 class OpenAIServingDetokenize(OpenAIServingBase):

--- a/python/sglang/srt/entrypoints/openai/serving_tokenize.py
+++ b/python/sglang/srt/entrypoints/openai/serving_tokenize.py
@@ -99,7 +99,9 @@ class OpenAIServingTokenize(OpenAIServingBase):
         )
 
         prompt_ids = processed_messages.prompt_ids
-        if isinstance(prompt_ids, list) and (prompt_ids or not processed_messages.prompt):
+        if isinstance(prompt_ids, list) and (
+            prompt_ids or not processed_messages.prompt
+        ):
             return prompt_ids
         if isinstance(prompt_ids, str):
             return self.tokenizer_manager.tokenizer.encode(

--- a/test/registered/core/test_srt_endpoint.py
+++ b/test/registered/core/test_srt_endpoint.py
@@ -17,6 +17,7 @@ import requests
 
 from sglang.srt.sampling.custom_logit_processor import CustomLogitProcessor
 from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils.hf_transformers_utils import get_tokenizer
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
@@ -642,7 +643,7 @@ class TestSRTEndpoint(CustomTestCase):
 
 
 # -------------------------------------------------------------------------
-#    /tokenize & /detokenize Test Class: TestTokenizeDetokenize
+#    /tokenize, /v1/tokenize & /detokenize Test Class: TestTokenizeDetokenize
 # -------------------------------------------------------------------------
 
 
@@ -652,6 +653,7 @@ class TestTokenizeDetokenize(CustomTestCase):
         cls.model = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
         cls.base_url = DEFAULT_URL_FOR_TEST
         cls.tokenize_url = f"{cls.base_url}/tokenize"
+        cls.openai_tokenize_url = f"{cls.base_url}/v1/tokenize"
         cls.detokenize_url = f"{cls.base_url}/detokenize"
         cls.session = requests.Session()
         cls.process = popen_launch_server(
@@ -659,6 +661,7 @@ class TestTokenizeDetokenize(CustomTestCase):
             cls.base_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
         )
+        cls.tokenizer = get_tokenizer(cls.model)
 
     @classmethod
     def tearDownClass(cls):
@@ -704,6 +707,58 @@ class TestTokenizeDetokenize(CustomTestCase):
             self.tokenize_url, json={"model": self.model, "prompt": 12345}
         )
         self.assertEqual(r.status_code, 400)
+
+    def test_openai_tokenize_chat_messages(self):
+        messages = [{"role": "user", "content": "What is the weather in Paris?"}]
+        resp = self._post_json(
+            self.openai_tokenize_url,
+            {"model": self.model, "messages": messages},
+        )
+        expected_tokens = self.tokenizer.apply_chat_template(
+            messages,
+            tokenize=True,
+            add_generation_prompt=True,
+        )
+        if not isinstance(expected_tokens, list):
+            expected_tokens = expected_tokens["input_ids"]
+        if hasattr(expected_tokens, "tolist"):
+            expected_tokens = expected_tokens.tolist()
+        self.assertEqual(resp["tokens"], expected_tokens)
+        self.assertEqual(resp["count"], len(expected_tokens))
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get weather for a city.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                },
+            }
+        ]
+        tools_resp = self._post_json(
+            self.openai_tokenize_url,
+            {"model": self.model, "messages": messages, "tools": tools},
+        )
+        self.assertIsInstance(tools_resp["tokens"], list)
+        self.assertEqual(tools_resp["count"], len(tools_resp["tokens"]))
+        self.assertNotEqual(tools_resp["tokens"], resp["tokens"])
+
+        no_tools_resp = self._post_json(
+            self.openai_tokenize_url,
+            {
+                "model": self.model,
+                "messages": messages,
+                "tools": tools,
+                "tool_choice": "none",
+            },
+        )
+        self.assertEqual(no_tools_resp["tokens"], resp["tokens"])
+        self.assertEqual(no_tools_resp["count"], resp["count"])
 
     def test_detokenize_roundtrip(self):
         text = "Verify detokenization round trip. यह डिटोकेनाइजेशन है"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

`/v1/tokenize` previously only accepted raw string prompts, which made it difficult to inspect the actual token sequence used by `/v1/chat/completions`. 

When we aim to build a cache-aware system using KV events, we need to obtain the actual token sequence resulting from rendering the model's chat template. 

This change allows `/v1/tokenize` to accept ChatCompletion-style messages input and return token IDs consistent with the chat completion path.

#### Qwen3.5-9B
Without tools
```
curl -sS http://127.0.0.1:31080/v1/tokenize \
  -H "Content-Type: application/json" \
  -d '{"model":"qwen-tokenize-test","messages":[{"role":"system","content":"You are concise."},{"role":"user","content":"Hello world"}],"max_tokens":1}'

{"tokens":[248045,8678,198,2523,513,61446,13,248046,198,248045,846,198,9419,1814,248046,198,248045,74455,198,248068,198],"count":21,"max_model_len":262144}

```
With tools
```
curl -sS http://127.0.0.1:31080/v1/tokenize \
  -H "Content-Type: application/json" \
  -d '{"model":"Qwen3___5-9B","messages":[{"role":"user","content":"What is the weather in Paris?"}],"tools":[{"type":"function","function":{"name":"get_weather","description":"Get weather for a city.","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}]}'

{"tokens":[248045,8678,198,2,13455,271,2523,599,2528,310,279,2614,5568,25,271,27,15449,29,198,4754,1267,763,328,1628,487,328,1628,763,5046,4532,763,328,1882,8831,364,264,3177,10152,328,591,763,328,447,67017,487,328,13390,763,5046,1267,763,328,1640,487,328,12811,763,5046,8656,763,5046,1267,763,328,889,8934,2069,328,6081,763,4241,8656,1293,2069,328,6418,763,867,2069,328,60003,55791,763,819,92,198,510,15449,29,271,2592,488,4992,310,1562,264,709,25835,9559,303,279,2614,3443,440,5486,19900,25,271,248058,198,27,1628,28,8422,8901,1224,29,198,27,15704,28,8422,24109,62,16,29,198,927,62,16,198,510,15704,29,198,27,15704,28,8422,24109,62,17,29,198,1919,369,279,869,364,279,2018,5555,198,8761,628,9111,198,34493,4965,198,510,15704,29,198,510,1628,29,198,248059,271,27,95328,29,198,92065,25,198,12,5534,6526,26834,1732,279,5024,3443,25,449,8906,361,1628,28,1076,1419,1628,29,2424,1902,381,23283,2785,220,248058,248059,11535,9212,198,12,12296,4868,26834,381,5024,198,12,1394,1189,3300,9801,31626,364,678,709,1562,303,5629,3992,54588,279,709,1562,11,694,4045,1238,198,12,1368,1017,369,874,709,1562,2420,11,4087,279,3296,1040,4472,440,678,1428,6337,321,635,524,3184,279,1156,883,709,6526,198,510,95328,29,248046,198,248045,846,198,3710,369,279,8831,303,11751,30,248046,198,248045,74455,198,248068,198],"count":285,"max_model_len":262144}
```

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
