### PR TITLE
Revert "[Docs] Add single-node H200 DeepSeek-V4-Pro low-latency recipe"

### DIFF
--- a/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
+++ b/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
@@ -121,7 +121,7 @@ docker run --gpus all \
 SGLang supports three main serving recipes for DeepSeek-V4 with different latency/throughput trade-offs (`low-latency`, `balanced`, `max-throughput`), plus specialized recipes for long-context (`cp`, prefill context-parallel) and prefill/decode disaggregation (`pd-disagg`). The interactive generator below emits the exact launch command for any `(hardware, variant, recipe)` combination.
 
 <Note>
-For H200 GPU deployments, use the SGLang checkpoint under `sgl-project`, not the default DeepSeek checkpoint.
+For FP8 H200 deployment and multi-node H200 deployment, use the SGLang checkpoint under `sgl-project`, not the default DeepSeek checkpoint.
 </Note>
 
 ### 3.1 Basic Configuration

--- a/docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx
@@ -558,38 +558,6 @@ export const DeepSeekV4Deployment = () => {
         cmd;
     }
     const withMultinode = multinode ? prependMultiNodeNote(cmd, nnodes) : cmd;
-
-    // H200 Pro low-latency: show BOTH a single-node (TP=8 marlin) variant
-    // and the existing multi-node (TP=16 DP-attn + DeepEP) variant.
-    if (hardware === "h200" && isBig && recipe === "low-latency") {
-      const singleFlags = [
-        "  --trust-remote-code",
-        "  --model-path deepseek-ai/DeepSeek-V4-Pro",
-        "  --tp 8",
-        "  --moe-runner-backend marlin",
-        "  --speculative-algo EAGLE",
-        "  --speculative-num-steps 3",
-        "  --speculative-eagle-topk 1",
-        "  --speculative-num-draft-tokens 4",
-        "  --chunked-prefill-size 4096",
-        "  --disable-flashinfer-autotune",
-        "  --mem-fraction-static 0.88",
-      ];
-      if (toolcall === "enabled") singleFlags.push("  --tool-call-parser deepseekv4");
-      if (reasoningParser === "enabled") singleFlags.push("  --reasoning-parser deepseek-v4");
-      singleFlags.push("  --host 0.0.0.0");
-      singleFlags.push("  --port 30000");
-      const singleNodeCmd = `sglang serve \\\n${singleFlags.join(" \\\n")}`;
-      const combined =
-        `# --- Single-Node (TP=8, Marlin) ---\n${singleNodeCmd}\n\n` +
-        `# --- Multi-Node (2 nodes, TP=16, DP-Attn + DeepEP) ---\n${withMultinode}`;
-      const verifyKey = `${hardware}|${modelSize}|${recipe}`;
-      if (TBD_RECIPES.has(verifyKey)) return TBD_PLACEHOLDER;
-      return VERIFIED_RECIPES.has(verifyKey)
-        ? combined
-        : `${BEING_VERIFIED_NOTE}\n${commentOutCommand(combined)}`;
-    }
-
     const verifyKey = `${hardware}|${modelSize}|${recipe}`;
     if (TBD_RECIPES.has(verifyKey)) return TBD_PLACEHOLDER;
     return VERIFIED_RECIPES.has(verifyKey)


### PR DESCRIPTION
Reverts sgl-project/sglang#23943
A new major category H200 (FP4) has been created, instead of using H200 FP8.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #25089573468](https://github.com/sgl-project/sglang/actions/runs/25089573468)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->