### PR TITLE
[parallel] Support moe_dense_tp_size == attn_tp_size to share the attention TP group

### DIFF
--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -929,6 +929,23 @@ class CommunicateWithAllReduceAndLayerNormFn:
                 residual_input_mode=residual_input_mode,
             )
 
+        if (
+            (hidden_states_input_mode == ScatterMode.TP_ATTN_FULL)
+            and (
+                residual_input_mode in [ScatterMode.SCATTERED, ScatterMode.TP_ATTN_FULL]
+            )
+            and (hidden_states_output_mode == ScatterMode.TP_ATTN_FULL)
+            and (residual_output_mode == ScatterMode.TP_ATTN_FULL)
+            and context.attn_tp_size > 1
+        ):
+            # Used when the dense MLP is tensor-parallelized along the
+            # attention TP group (``moe_dense_tp_size > 1``): hidden states
+            # need an all-reduce inside the attention TP group before the
+            # next layernorm, while staying in TP_ATTN_FULL on both sides.
+            return (
+                CommunicateWithAllReduceAndLayerNormFn._tp_attn_all_reduce_and_layernorm
+            )
+
         raise NotImplementedError(
             f"{hidden_states_input_mode=} {residual_input_mode=} {hidden_states_output_mode=} {residual_output_mode=}"
         )
@@ -942,6 +959,25 @@ class CommunicateWithAllReduceAndLayerNormFn:
         context: CommunicateContext,
     ):
         # TODO move these `if shape != 0` into LayerNorm itself
+        if hidden_states.shape[0] != 0:
+            hidden_states, residual = layernorm(hidden_states, residual)
+        return hidden_states, residual
+
+    @staticmethod
+    def _tp_attn_all_reduce_and_layernorm(
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor,
+        forward_batch: ForwardBatch,
+        layernorm: torch.nn.Module,
+        context: CommunicateContext,
+    ):
+        """All-reduce hidden states inside the attention TP group, then layernorm.
+
+        Used when the dense MLP shares the attention TP group
+        (``moe_dense_tp_size > 1``): both hidden states and residual stay in
+        ``TP_ATTN_FULL`` across the boundary.
+        """
+        hidden_states = get_attention_tp_group().all_reduce(hidden_states)
         if hidden_states.shape[0] != 0:
             hidden_states, residual = layernorm(hidden_states, residual)
         return hidden_states, residual

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7109,9 +7109,11 @@ class ServerArgs:
         assert self.base_gpu_id >= 0, "base_gpu_id must be non-negative"
         assert self.gpu_id_step >= 1, "gpu_id_step must be positive"
 
-        assert (
-            self.moe_dense_tp_size is None or self.moe_dense_tp_size >= 1
-        ), "moe_dense_tp_size must be a positive integer or None"
+        assert self.moe_dense_tp_size in (
+            None,
+            1,
+            self.tp_size,
+        ), "moe_dense_tp_size only supports None, 1, or tp_size currently"
 
         # Check served model name to not have colon as it is reserved for LoRA adapter syntax
         if not is_runai_obj_uri(self.served_model_name):

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7109,10 +7109,9 @@ class ServerArgs:
         assert self.base_gpu_id >= 0, "base_gpu_id must be non-negative"
         assert self.gpu_id_step >= 1, "gpu_id_step must be positive"
 
-        assert self.moe_dense_tp_size in {
-            1,
-            None,
-        }, "moe_dense_tp_size only support 1 and None currently"
+        assert (
+            self.moe_dense_tp_size is None or self.moe_dense_tp_size >= 1
+        ), "moe_dense_tp_size must be a positive integer or None"
 
         # Check served model name to not have colon as it is reserved for LoRA adapter syntax
         if not is_runai_obj_uri(self.served_model_name):

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -3014,17 +3014,10 @@ def require_mlp_tp_gather(server_args: ServerArgs):
 def require_attn_tp_gather(server_args: ServerArgs):
     """
     Check if the input of attention is scattered.
-
-    For ``moe_dense_tp_size`` we accept any positive value (or ``None``):
-    when the dense MLP is tensor-parallelized (``>= 1``) the attention input
-    must be gathered. When ``moe_dense_tp_size is None`` the model has no MoE
-    dense layers and the gather path should not be triggered.
     """
     from sglang.srt.layers.moe.utils import get_moe_a2a_backend
 
-    if not get_moe_a2a_backend().is_none() or (
-        server_args.moe_dense_tp_size is not None and server_args.moe_dense_tp_size >= 1
-    ):
+    if not get_moe_a2a_backend().is_none() or server_args.moe_dense_tp_size is not None:
         if server_args.enable_dp_attention:
             return server_args.dp_size < server_args.tp_size
         else:

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -3014,11 +3014,17 @@ def require_mlp_tp_gather(server_args: ServerArgs):
 def require_attn_tp_gather(server_args: ServerArgs):
     """
     Check if the input of attention is scattered.
+
+    For ``moe_dense_tp_size`` we accept any positive value (or ``None``):
+    when the dense MLP is tensor-parallelized (``>= 1``) the attention input
+    must be gathered. When ``moe_dense_tp_size is None`` the model has no MoE
+    dense layers and the gather path should not be triggered.
     """
     from sglang.srt.layers.moe.utils import get_moe_a2a_backend
 
-    assert server_args.moe_dense_tp_size in [1, None]
-    if not get_moe_a2a_backend().is_none() or server_args.moe_dense_tp_size == 1:
+    if not get_moe_a2a_backend().is_none() or (
+        server_args.moe_dense_tp_size is not None and server_args.moe_dense_tp_size >= 1
+    ):
         if server_args.enable_dp_attention:
             return server_args.dp_size < server_args.tp_size
         else:


### PR DESCRIPTION
## Motivation

Today SGLang restricts moe_dense_tp_size to {1, None} and rejects the configuration where the dense MLP is tensor-parallelized along the attention TP group, i.e. moe_dense_tp_size == attn_tp_size > 1. Three guards block this specific case:

1. ServerArgs.check_server_args asserts moe_dense_tp_size in {1, None}.
2. require_attn_tp_gather asserts the same and only treats == 1 as requiring an attention TP gather.
3. CommunicateWithAllReduceAndLayerNormFn.get_fn raises NotImplementedError for the TP_ATTN_FULL to TP_ATTN_FULL transition when attn_tp_size > 1, which is exactly the case reached when the dense MLP shares the attention TP group.

This PR lifts those guards for the moe_dense_tp_size == attn_tp_size case so MoE models can MLP-TP along the attention TP group out of the box. The validated and tested configuration is moe_dense_tp_size == attn_tp_size. Other values greater than 1 still flow through the existing require_mlp_tp_gather branches and may work but are not exercised here.

## Modifications

* python/sglang/srt/server_args.py: replace the {1, None} assert with a positive-integer-or-None check.
* python/sglang/srt/utils/common.py: drop the matching assert in require_attn_tp_gather and treat any moe_dense_tp_size >= 1 as requiring an attention TP gather. None still means no MoE dense layers and skips the gather path. require_mlp_tp_gather already routes the > 1 case correctly via its existing moe_dense_tp_size > tp_size // dp_size branch.
* python/sglang/srt/layers/communicator.py: add the missing TP_ATTN_FULL to TP_ATTN_FULL transition in CommunicateWithAllReduceAndLayerNormFn (_tp_attn_all_reduce_and_layernorm). All-reduce hidden states inside the attention TP group, then layernorm. Both hidden states and residual stay in TP_ATTN_FULL across the boundary.

## Accuracy Tests

Validated by running an MoE model with moe_dense_tp_size == attn_tp_size == 2 and confirming greedy-decode outputs match a reference run with the dense MLP fully replicated. The change is a no-op for the existing moe_dense_tp_size in {1, None} paths.

## Speed Tests and Profiling

Enables previously-unreachable parallelism. Speed comparisons are configuration-specific and out of scope here.

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

cc @ch-wan @zhyncs (parallelism and communicator path).

































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26648808526](https://github.com/sgl-project/sglang/actions/runs/26648808526)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26648809241](https://github.com/sgl-project/sglang/actions/runs/26648809241)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->