### PR TITLE
[moe] Capture routing softmax weights alongside routed experts and DP buffer-shape fix

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/moe/topk.py
+++ b/python/sglang/srt/hardware_backend/npu/moe/topk.py
@@ -96,5 +96,9 @@ def fused_topk_npu(
         layer_id=layer_id,
         topk_ids=topk_ids,
     )
+    get_global_experts_capturer().capture_weights(
+        layer_id=layer_id,
+        topk_weights=topk_weights,
+    )
 
     return StandardTopKOutput(topk_weights, topk_ids, router_logits)

--- a/python/sglang/srt/layers/moe/routed_experts_capturer.py
+++ b/python/sglang/srt/layers/moe/routed_experts_capturer.py
@@ -37,13 +37,25 @@ class RoutedExpertsOutput:
     out_cache_loc: torch.Tensor
     routed_experts: torch.Tensor
     host_cache: "_RoutedExpertsHostCache"
+    routed_expert_weights: Optional[torch.Tensor] = None
 
     def copy_to_cpu(self):
         self.out_cache_loc = self.out_cache_loc.to("cpu", non_blocking=True)
         self.routed_experts = self.routed_experts.to("cpu", non_blocking=True)
+        if self.routed_expert_weights is not None:
+            self.routed_expert_weights = self.routed_expert_weights.to(
+                "cpu", non_blocking=True
+            )
 
     def finalize(self):
         self.host_cache.buffer[self.out_cache_loc] = self.routed_experts
+        if (
+            self.routed_expert_weights is not None
+            and self.host_cache.weights_buffer is not None
+        ):
+            self.host_cache.weights_buffer[self.out_cache_loc] = (
+                self.routed_expert_weights
+            )
 
 
 class _RoutedExpertsDeviceCache:
@@ -54,30 +66,68 @@ class _RoutedExpertsDeviceCache:
         num_experts_per_tok: int,
         num_fused_shared_experts: int,
         device: str,
+        enable_weights: bool = False,
     ) -> None:
+        # Multiply by ``dp_size`` so that the buffer can hold the full
+        # concatenated batch across DP attention ranks. ``_get_local_range``
+        # indexes into ``[attention_dp_rank * cuda_graph_batch, ...)`` so the
+        # highest touched index scales with ``dp_size``.
+        dp_size = get_global_server_args().dp_size
+        buffer_first_dim = max(
+            get_global_server_args().chunked_prefill_size * dp_size,
+            max_running_requests * dp_size,
+        )
         self.buffer = torch.zeros(
             (
-                max(
-                    get_global_server_args().chunked_prefill_size
-                    * get_global_server_args().dp_size,
-                    max_running_requests,
-                ),
+                buffer_first_dim,
                 num_hidden_layers,
                 num_experts_per_tok + num_fused_shared_experts,
             ),
             dtype=torch.int32,
             device=device,
         )
+        # Optional parallel float32 buffer for routing softmax weights.
+        # Shape mirrors ``self.buffer`` so the same indexing logic applies.
+        self.weights_buffer: Optional[torch.Tensor] = None
+        if enable_weights:
+            self.weights_buffer = torch.zeros(
+                (
+                    buffer_first_dim,
+                    num_hidden_layers,
+                    num_experts_per_tok + num_fused_shared_experts,
+                ),
+                dtype=torch.float32,
+                device=device,
+            )
         self._finalize_allocation_log()
 
     def get_buffer_size_bytes(self):
         assert hasattr(self, "buffer")
-        return get_tensor_size_bytes(self.buffer)
+        size = get_tensor_size_bytes(self.buffer)
+        if self.weights_buffer is not None:
+            size += get_tensor_size_bytes(self.weights_buffer)
+        return size
 
     def capture_fwd_routed_experts(self, layer_id: int, topk_ids: torch.Tensor):
         assert layer_id is not None, "capturing routing experts but get layer_id None"
         batch, _ = topk_ids.shape
         self.buffer[:batch, layer_id, :] = topk_ids
+
+    def capture_fwd_routed_expert_weights(
+        self, layer_id: int, topk_weights: torch.Tensor
+    ):
+        """Store routing weights (softmax probabilities) for the given layer.
+
+        No-op when the optional ``weights_buffer`` was not allocated.
+        """
+        if self.weights_buffer is None:
+            return
+        assert layer_id is not None, (
+            "capturing routing expert weights but get layer_id None"
+        )
+        batch, k = topk_weights.shape
+        cols = min(k, self.weights_buffer.shape[2])
+        self.weights_buffer[:batch, layer_id, :cols] = topk_weights[:, :cols]
 
     def _finalize_allocation_log(self):
         """Common logging and memory usage computation for captured experts buffers."""
@@ -93,6 +143,7 @@ class _RoutedExpertsHostCache:
         num_tokens: int,
         num_hidden_layers: int,
         num_experts_per_tok: int,
+        enable_weights: bool = False,
     ) -> None:
         self.num_tokens = num_tokens
         self.buffer = torch.zeros(
@@ -105,11 +156,26 @@ class _RoutedExpertsHostCache:
             device="cpu",
             pin_memory=True,
         )
+        self.weights_buffer: Optional[torch.Tensor] = None
+        if enable_weights:
+            self.weights_buffer = torch.zeros(
+                (
+                    num_tokens,
+                    num_hidden_layers,
+                    num_experts_per_tok,
+                ),
+                dtype=torch.float32,
+                device="cpu",
+                pin_memory=True,
+            )
         self._finalize_allocation_log()
 
     def get_buffer_size_bytes(self):
         assert hasattr(self, "buffer")
-        return get_tensor_size_bytes(self.buffer)
+        size = get_tensor_size_bytes(self.buffer)
+        if self.weights_buffer is not None:
+            size += get_tensor_size_bytes(self.weights_buffer)
+        return size
 
     def set_experts_buffer(self, layer_id: int, loc: torch.Tensor, top_k: torch.Tensor):
         self.buffer[layer_id, loc, :] = top_k.to(device="cpu", non_blocking=True)
@@ -131,6 +197,7 @@ class RoutedExpertsCapturer(ABC):
         num_tokens: int,
         max_running_requests: int,
         device: str,
+        enable_weights: bool = False,
     ):
         if enable:
             return _RoutedExpertsCapturerReal(
@@ -139,6 +206,7 @@ class RoutedExpertsCapturer(ABC):
                 max_running_requests=max_running_requests,
                 num_fused_shared_experts=num_fused_shared_experts,
                 device=device,
+                enable_weights=enable_weights,
             )
         else:
             return _RoutedExpertsCapturerNoop()
@@ -154,12 +222,28 @@ class RoutedExpertsCapturer(ABC):
     def capture(self, layer_id: int, topk_ids: torch.Tensor):
         raise NotImplementedError
 
+    def capture_weights(self, layer_id: int, topk_weights: torch.Tensor):
+        """Capture routing weights for the current layer.
+
+        No-op unless the capturer was created with ``enable_weights=True``.
+        """
+        raise NotImplementedError
+
     def get_routed_experts(
         self,
         req_pool_idx: int,
         seqlen: int,
         req_to_token_pool: ReqToTokenPool,
     ):
+        raise NotImplementedError
+
+    def get_routed_expert_weights(
+        self,
+        req_pool_idx: int,
+        seqlen: int,
+        req_to_token_pool: ReqToTokenPool,
+    ):
+        """Return host-cached routing weights for a request, or ``None``."""
         raise NotImplementedError
 
     def on_forward_end(
@@ -184,15 +268,18 @@ class _RoutedExpertsCapturerReal(RoutedExpertsCapturer):
         max_running_requests: int,
         num_fused_shared_experts: int,
         device: str,
+        enable_weights: bool = False,
     ):
         self.num_fused_shared_experts = num_fused_shared_experts
         self.num_hidden_layers = model_config.hf_text_config.num_hidden_layers
         self.num_experts_per_tok = model_config.hf_text_config.num_experts_per_tok
+        self.enable_weights = enable_weights
 
         self.host_cache = _RoutedExpertsHostCache(
             num_tokens=num_tokens,
             num_hidden_layers=self.num_hidden_layers,
             num_experts_per_tok=self.num_experts_per_tok,
+            enable_weights=enable_weights,
         )
 
         self.device_cache = _RoutedExpertsDeviceCache(
@@ -201,6 +288,7 @@ class _RoutedExpertsCapturerReal(RoutedExpertsCapturer):
             num_experts_per_tok=self.num_experts_per_tok,
             num_fused_shared_experts=self.num_fused_shared_experts,
             device=device,
+            enable_weights=enable_weights,
         )
 
     def _get_local_range(self, forward_batch, can_run_graph, cuda_graph_batch):
@@ -225,6 +313,15 @@ class _RoutedExpertsCapturerReal(RoutedExpertsCapturer):
         self.host_cache.buffer[out_cache_loc_cpu] = self.device_cache.buffer[
             local_start_pos:local_end_pos, :, : self.num_experts_per_tok
         ].cpu()
+        if (
+            self.device_cache.weights_buffer is not None
+            and self.host_cache.weights_buffer is not None
+        ):
+            self.host_cache.weights_buffer[out_cache_loc_cpu] = (
+                self.device_cache.weights_buffer[
+                    local_start_pos:local_end_pos, :, : self.num_experts_per_tok
+                ].cpu()
+            )
 
     def _prepare_routed_experts_output(
         self,
@@ -235,16 +332,25 @@ class _RoutedExpertsCapturerReal(RoutedExpertsCapturer):
         local_start_pos, local_end_pos = self._get_local_range(
             forward_batch, can_run_graph, cuda_graph_batch
         )
+        weights = None
+        if self.device_cache.weights_buffer is not None:
+            weights = self.device_cache.weights_buffer[
+                local_start_pos:local_end_pos, :, : self.num_experts_per_tok
+            ]
         return RoutedExpertsOutput(
             out_cache_loc=forward_batch.out_cache_loc,
             routed_experts=self.device_cache.buffer[
                 local_start_pos:local_end_pos, :, : self.num_experts_per_tok
             ],
             host_cache=self.host_cache,
+            routed_expert_weights=weights,
         )
 
     def capture(self, layer_id: int, topk_ids: torch.Tensor):
         self.device_cache.capture_fwd_routed_experts(layer_id, topk_ids)
+
+    def capture_weights(self, layer_id: int, topk_weights: torch.Tensor):
+        self.device_cache.capture_fwd_routed_expert_weights(layer_id, topk_weights)
 
     def get_routed_experts(
         self,
@@ -256,6 +362,20 @@ class _RoutedExpertsCapturerReal(RoutedExpertsCapturer):
             req_to_token_pool.req_to_token[req_pool_idx][: seqlen - 1].cpu().clone()
         )
         return self.get_host_cache().buffer[cache_pool_idx]
+
+    def get_routed_expert_weights(
+        self,
+        req_pool_idx: int,
+        seqlen: int,
+        req_to_token_pool: ReqToTokenPool,
+    ):
+        host = self.get_host_cache()
+        if host.weights_buffer is None:
+            return None
+        cache_pool_idx = (
+            req_to_token_pool.req_to_token[req_pool_idx][: seqlen - 1].cpu().clone()
+        )
+        return host.weights_buffer[cache_pool_idx]
 
     def on_forward_end(
         self, forward_batch, can_run_graph, cuda_graph_batch, no_copy_to_cpu=False
@@ -296,6 +416,9 @@ class _RoutedExpertsCapturerNoop(RoutedExpertsCapturer):
     def capture(self, layer_id: int, topk_ids: torch.Tensor):
         pass
 
+    def capture_weights(self, layer_id: int, topk_weights: torch.Tensor):
+        pass
+
     def get_routed_experts(
         self,
         req_pool_idx: int,
@@ -303,6 +426,14 @@ class _RoutedExpertsCapturerNoop(RoutedExpertsCapturer):
         req_to_token_pool: ReqToTokenPool,
     ):
         pass
+
+    def get_routed_expert_weights(
+        self,
+        req_pool_idx: int,
+        seqlen: int,
+        req_to_token_pool: ReqToTokenPool,
+    ):
+        return None
 
     def on_forward_end(
         self, forward_batch, can_run_graph, cuda_graph_batch, no_copy_to_cpu=False

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -1053,6 +1053,10 @@ def _post_process_topk_ids(
         layer_id=layer_id,
         topk_ids=topk_ids,
     )
+    get_global_experts_capturer().capture_weights(
+        layer_id=layer_id,
+        topk_weights=topk_weights,
+    )
     if _is_cuda:
         # When shared experts are fused (appended as extra columns in topk_ids),
         # EPLB dispatch must only remap the routed expert columns.

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -799,6 +799,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 num_tokens=self.max_total_num_tokens + self.page_size,
                 max_running_requests=self.max_running_requests,
                 device=self.device,
+                enable_weights=get_global_server_args().enable_return_routed_expert_weights,
             )
         )
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -679,6 +679,7 @@ class ServerArgs:
     keep_mm_feature_on_device: bool = False
     enable_return_hidden_states: bool = False
     enable_return_routed_experts: bool = False
+    enable_return_routed_expert_weights: bool = False
     scheduler_recv_interval: int = 1
     numa_node: Optional[List[int]] = None
     enable_deterministic_inference: bool = False
@@ -6191,6 +6192,15 @@ class ServerArgs:
             "--enable-return-routed-experts",
             action="store_true",
             help="Enable returning routed experts of each layer with responses.",
+        )
+        parser.add_argument(
+            "--enable-return-routed-expert-weights",
+            action="store_true",
+            help=(
+                "Enable returning routing softmax weights of each layer alongside "
+                "the routed experts. Requires --enable-return-routed-experts. "
+                "Adds a parallel float32 buffer to the routed experts capturer."
+            ),
         )
         parser.add_argument(
             "--scheduler-recv-interval",


### PR DESCRIPTION
## Motivation

Today the routed experts capturer (`sglang.srt.layers.moe.routed_experts_capturer`) records only expert *indices* (int32) for downstream consumers (e.g. `meta_info.routed_experts`). For RL / on-policy correction, distillation, and routing-weight analysis, the matching softmax *weights* (float32) are equally useful but currently unrecoverable from the response.

Two related issues to fix together:

1. **Missing weights capture.** No mechanism today to surface the per-token, per-layer routing weights that are already computed inside `select_experts`.
2. **DP buffer-shape bug.** `_RoutedExpertsDeviceCache` allocates its first dim as `max(chunked_prefill_size * dp_size, max_running_requests)`. The `max_running_requests` term is missing the `* dp_size` factor: under DP attention, `_get_local_range` indexes `[attention_dp_rank * cuda_graph_batch, ...]`, so on DP rank > 0 the touched indices can exceed the buffer when `max_running_requests > chunked_prefill_size`.

## Modifications

User-facing:
- New CLI flag `--enable-return-routed-expert-weights` (default off). Requires `--enable-return-routed-experts`. Adds a parallel float32 weights buffer; default install/runtime behaviour is unchanged when off.
- New `ServerArgs.enable_return_routed_expert_weights: bool`.
- New capturer method `get_routed_expert_weights(req_pool_idx, seqlen, req_to_token_pool)` returning per-token, per-layer float32 weights or `None`.

Internal:
- `_RoutedExpertsDeviceCache` / `_RoutedExpertsHostCache` gain an optional `weights_buffer` (float32) with the same shape as the existing int32 buffer.
- `_RoutedExpertsDeviceCache` buffer first dim now multiplies `max_running_requests` by `dp_size` (DP buffer-shape fix). Comment added explaining the indexing.
- `_sync_fwd_experts_buffer_DtoH` and `_prepare_routed_experts_output` copy/expose weights when the optional buffers exist. `RoutedExpertsOutput` carries the optional weights tensor and `finalize()` commits them under the same `out_cache_loc`-indexed write.
- `select_experts` (CUDA path in `layers/moe/topk.py`, NPU path in `hardware_backend/npu/moe/topk.py`) calls a new `capture_weights(layer_id, topk_weights)` alongside the existing `capture()` so weights flow into the device buffer at the same call site as indices.
- The Noop capturer implements the new methods as no-ops.

Touched files:
- `python/sglang/srt/server_args.py`
- `python/sglang/srt/layers/moe/routed_experts_capturer.py`
- `python/sglang/srt/layers/moe/topk.py`
- `python/sglang/srt/hardware_backend/npu/moe/topk.py`
- `python/sglang/srt/model_executor/model_runner.py`

## Accuracy Tests

I/O-only feature on the model side; `select_experts` returns the same `(topk_weights, topk_ids)` tensors as before — `capture_weights` only writes into the optional buffer. Greedy decode outputs are bit-identical with the new flag both off and on (validated locally on a small MoE model).

## Speed Tests and Profiling

When `--enable-return-routed-expert-weights` is off (default), there are no extra allocations and no extra copies — the `capture_weights` call hits the noop or skips when `weights_buffer is None`. When on, the additional cost is one float32 device write per `select_experts` call and one D→H copy per forward, mirroring the existing indices path.

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

cc @ch-wan @zhyncs (MoE / router-capture path).