### PR TITLE
[moe] Preserve routed experts across retraction

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -885,6 +885,15 @@ class Req(ReqDllmMixin):
         self.indexer_topk: Optional[torch.Tensor] = (
             None  # cpu tensor: shape (seqlen, num_indexer_layers, index_topk)
         )
+        # Snapshot of routed experts already generated before the most recent
+        # retract(s). Stitched in front of the post-re-prefill suffix in
+        # ``Scheduler.maybe_collect_routed_experts`` so the final response
+        # exposes the full per-token routing trajectory across retraction
+        # boundaries. ``_retract_snapshot_seqlen`` records the seqlen at the
+        # time of the last snapshot so the next snapshot only captures new
+        # tokens generated since then.
+        self._retract_routed_experts_prefix: Optional[torch.Tensor] = None
+        self._retract_snapshot_seqlen: int = 0
         # Customized info
         self.customized_info: Optional[Dict[str, List[Any]]] = None
 
@@ -2379,6 +2388,13 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             req.offload_kv_cache(
                 self.req_to_token_pool, self.token_to_kv_pool_allocator
             )
+        # Snapshot routed experts BEFORE we release the KV cache. After
+        # ``release_kv_cache`` the per-token mapping in ``req_to_token_pool``
+        # is no longer guaranteed to point at this request's expert ids in
+        # the host cache, so the snapshot must happen here.
+        if req.return_routed_experts:
+            self._snapshot_routed_experts_for_retract(req)
+
         # TODO (csy): for preempted requests, we may want to insert into the tree
         release_kv_cache(req, self.tree_cache, is_insert=False)
         # NOTE(lsyin): we should use the newly evictable memory instantly.
@@ -2386,6 +2402,53 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         evict_from_tree_cache(self.tree_cache, num_tokens)
 
         req.reset_for_retract()
+
+    def _snapshot_routed_experts_for_retract(self, req: Req) -> None:
+        """Capture routed expert ids generated since the last snapshot.
+
+        Without this snapshot, retracted (preempted) requests lose all
+        routing information from their pre-retract decode steps because
+        ``release_kv_cache`` frees the host-cache slots backing them.
+        After re-prefill, ``maybe_collect_routed_experts`` stitches this
+        prefix in front of the post-re-prefill suffix so the final
+        response exposes the complete per-token routing trajectory.
+        """
+        try:
+            from sglang.srt.state_capturer.routed_experts import (
+                get_global_experts_capturer,
+            )
+
+            capturer = get_global_experts_capturer()
+            if capturer is None:
+                return
+
+            # ``seqlen - 1`` mirrors ``get_topk`` upper bound (the last token
+            # has no completed routing decision yet).
+            end_index = req.seqlen - 1
+            start_index = max(0, req._retract_snapshot_seqlen - 1)
+            if start_index >= end_index:
+                return
+
+            new_snap = capturer.get_topk(
+                req_pool_idx=req.req_pool_idx,
+                seqlen=req.seqlen,
+                req_to_token_pool=self.req_to_token_pool,
+                start_len=start_index,
+            )
+
+            if req._retract_routed_experts_prefix is None:
+                req._retract_routed_experts_prefix = new_snap
+            else:
+                req._retract_routed_experts_prefix = torch.cat(
+                    [req._retract_routed_experts_prefix, new_snap], dim=0
+                )
+            req._retract_snapshot_seqlen = int(req.seqlen)
+        except Exception as exc:
+            logger.warning(
+                "Failed to snapshot routed experts for rid=%s: %r",
+                getattr(req, "rid", "N/A"),
+                exc,
+            )
 
     def prepare_encoder_info_decode(self):
         # Reset the encoder cached status

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2391,8 +2391,10 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         # Snapshot routed experts BEFORE we release the KV cache. After
         # ``release_kv_cache`` the per-token mapping in ``req_to_token_pool``
         # is no longer guaranteed to point at this request's expert ids in
-        # the host cache, so the snapshot must happen here.
-        if req.return_routed_experts:
+        # the host cache, so the snapshot must happen here. Skip when
+        # ``input_embeds`` is set: retract discards decoded output_ids in
+        # that case, so the associated experts should be discarded too.
+        if req.return_routed_experts and req.input_embeds is None:
             self._snapshot_routed_experts_for_retract(req)
 
         # TODO (csy): for preempted requests, we may want to insert into the tree

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -108,6 +108,14 @@ class SchedulerBatchResultProcessor:
         `[start_len, seqlen - 1)`. The default start_len is 0, which returns
         the full sequence.
 
+        If the request was retracted at least once during decode, the host
+        cache slots that backed its pre-retract tokens have been freed and
+        reused. ``ScheduleBatch.release_req`` snapshots the routed experts
+        for those tokens into ``req._retract_routed_experts_prefix`` before
+        each retract; when ``start_len == 0`` we stitch that prefix in front
+        of the post-re-prefill suffix so the final response exposes the
+        complete per-token routing trajectory.
+
         Logs a soft warning if the resulting tensor's row count differs from
         the expected `seqlen - 1 - start_len`, to catch silent regressions.
         """
@@ -118,12 +126,26 @@ class SchedulerBatchResultProcessor:
             return
         start_len = req.routed_experts_start_len
         seqlen = len(req.origin_input_ids) + len(req.output_ids_through_stop)
-        req.routed_experts = capturer.get_topk(
+        suffix = capturer.get_topk(
             req_pool_idx=req.req_pool_idx,
             seqlen=seqlen,
             req_to_token_pool=self.req_to_token_pool,
             start_len=start_len,
         )
+
+        prefix = getattr(req, "_retract_routed_experts_prefix", None)
+        if prefix is None or start_len != 0:
+            req.routed_experts = suffix
+        elif suffix is None:
+            req.routed_experts = prefix
+        else:
+            # ``prefix`` covers tokens [0, snap_seqlen - 1); ``suffix`` covers
+            # the full [0, seqlen - 1) when start_len == 0. Slice the suffix
+            # so we do not double-count tokens that were also captured during
+            # re-prefill after retraction.
+            snap = max(0, getattr(req, "_retract_snapshot_seqlen", 0) - 1)
+            tail = suffix[snap:] if snap < suffix.shape[0] else suffix[0:0]
+            req.routed_experts = torch.cat([prefix, tail], dim=0)
 
         expected_rows = max(0, seqlen - 1 - start_len)
         if (

--- a/test/registered/unit/managers/test_routed_experts_retract_snapshot.py
+++ b/test/registered/unit/managers/test_routed_experts_retract_snapshot.py
@@ -1,0 +1,110 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.scheduler_components.batch_result_processor import (
+    SchedulerBatchResultProcessor,
+)
+
+register_cpu_ci(est_time=10, suite="stage-a-test-cpu")
+
+
+def _make_req(
+    prefix=None,
+    snap_seqlen=0,
+    seqlen=None,
+    req_pool_idx=0,
+    start_len=0,
+):
+    req = MagicMock()
+    req._retract_routed_experts_prefix = prefix
+    req._retract_snapshot_seqlen = snap_seqlen
+    req.req_pool_idx = req_pool_idx
+    req.return_routed_experts = True
+    req.routed_experts_start_len = start_len
+    req.rid = "test-rid"
+    req.seqlen = seqlen if seqlen is not None else snap_seqlen
+    # batch_result_processor computes seqlen as
+    # len(origin_input_ids) + len(output_ids_through_stop)
+    req.origin_input_ids = [0] * (seqlen if seqlen is not None else snap_seqlen)
+    req.output_ids_through_stop = []
+    return req
+
+
+class TestMaybeCollectRoutedExpertsWithRetract(unittest.TestCase):
+    def _call(self, req, suffix):
+        processor = MagicMock(spec=SchedulerBatchResultProcessor)
+        processor.req_to_token_pool = MagicMock()
+        capturer = MagicMock()
+        capturer.get_topk.return_value = suffix
+        with patch(
+            "sglang.srt.managers.scheduler_components.batch_result_processor."
+            "get_global_experts_capturer",
+            return_value=capturer,
+        ):
+            SchedulerBatchResultProcessor._maybe_collect_routed_experts(processor, req)
+        return req.routed_experts
+
+    def test_no_prefix_returns_suffix(self):
+        suffix = torch.arange(12).reshape(4, 3)
+        req = _make_req(prefix=None, snap_seqlen=0, seqlen=5)
+        result = self._call(req, suffix)
+        self.assertTrue(torch.equal(result, suffix))
+
+    def test_prefix_only_when_suffix_none(self):
+        prefix = torch.arange(6).reshape(2, 3)
+        req = _make_req(prefix=prefix, snap_seqlen=3, seqlen=3)
+        result = self._call(req, None)
+        self.assertTrue(torch.equal(result, prefix))
+
+    def test_stitches_prefix_and_sliced_suffix(self):
+        prefix = torch.tensor([[0, 0, 0], [1, 1, 1]])
+        suffix = torch.tensor(
+            [
+                [0, 0, 0],
+                [1, 1, 1],
+                [2, 2, 2],
+                [3, 3, 3],
+                [4, 4, 4],
+            ]
+        )
+        # snapshot was taken at seqlen=3, so snap = 3 - 1 = 2 and tail = suffix[2:]
+        req = _make_req(prefix=prefix, snap_seqlen=3, seqlen=6)
+        result = self._call(req, suffix)
+        expected = torch.tensor(
+            [
+                [0, 0, 0],
+                [1, 1, 1],
+                [2, 2, 2],
+                [3, 3, 3],
+                [4, 4, 4],
+            ]
+        )
+        self.assertTrue(torch.equal(result, expected))
+
+    def test_snap_beyond_suffix_drops_tail(self):
+        prefix = torch.tensor([[7, 7, 7], [8, 8, 8]])
+        suffix = torch.tensor([[1, 1, 1]])
+        # snap_seqlen - 1 = 4 >= suffix.shape[0], so tail must be empty
+        req = _make_req(prefix=prefix, snap_seqlen=5, seqlen=6)
+        result = self._call(req, suffix)
+        self.assertTrue(torch.equal(result, prefix))
+
+    def test_snap_zero_keeps_full_suffix(self):
+        prefix = torch.tensor([[9, 9, 9]])
+        suffix = torch.tensor([[1, 1, 1], [2, 2, 2]])
+        # snap = max(0, 0 - 1) = 0, so tail = suffix[0:] which is the full suffix
+        req = _make_req(prefix=prefix, snap_seqlen=0, seqlen=3)
+        result = self._call(req, suffix)
+        expected = torch.cat([prefix, suffix], dim=0)
+        self.assertTrue(torch.equal(result, expected))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

When a request that has `return_routed_experts=True` is retracted (preempted) one or more times during decode, the per-token routing trajectory in its final response is incomplete or stale. The reason is that `ScheduleBatch.release_req` calls `release_kv_cache(...)` which frees the host-cache slots backing the request's pre-retract tokens, and those slots get reused by other requests immediately after. By the time `Scheduler.maybe_collect_routed_experts` runs, indexing `host_cache.buffer` via `req_to_token_pool.req_to_token[req_pool_idx, : seqlen - 1]` either points at slots that have been overwritten by unrelated requests or, after re-prefill, only reflects the routing decisions made during re-prefill — which can race with normal decode capture and produce inconsistent results in practice.

This is the production bug hit while running a request-parking style preemption mode where retraction is the primary admission-control hammer for long-context MoE workloads. Without this fix, downstream tooling that consumes per-token expert ids (routing analysis, expert load auditing, replay) sees gaps and discontinuities at every retract boundary.

## Modifications

- **`Req.__init__`** (`python/sglang/srt/managers/schedule_batch.py`): introduce two private fields, `_retract_routed_experts_prefix` and `_retract_snapshot_seqlen`, that persist across `reset_for_retract` (which only clears the post-retract decode state).
- **`ScheduleBatch.release_req`** (`python/sglang/srt/managers/schedule_batch.py`): just before `release_kv_cache(...)`, call a new helper `_snapshot_routed_experts_for_retract(req)` when `req.return_routed_experts` is set. The helper reads the still-valid `req_to_token` indices for `[max(0, snap_seqlen - 1), seqlen - 1)`, gathers the corresponding rows out of `host_cache.buffer` into a CPU tensor, appends them to `req._retract_routed_experts_prefix`, and updates `req._retract_snapshot_seqlen`. The capturer is imported lazily to avoid a circular import. All errors are caught and logged so a snapshot failure can never block retraction itself.
- **`SchedulerOutputProcessorMixin.maybe_collect_routed_experts`** (`python/sglang/srt/managers/scheduler_output_processor_mixin.py`): if a snapshot prefix exists, slice the post-re-prefill suffix from `snap_seqlen - 1` onward and `torch.cat` it after the prefix. This guarantees the final `req.routed_experts` is the complete `[0, seqlen - 1)` trajectory and avoids double-counting tokens that were also captured during re-prefill.

The change is a pure no-op when `return_routed_experts=False` (the default), and when no retract ever happens for a request the new code path collapses to the existing single-slice behavior.

## Accuracy Tests

Verified against a long-context MoE workload that exercises retraction during decode. With this patch, the per-token expert-id sequence returned in `meta_info.routed_experts` exactly matches the routing decisions actually made by the model across an arbitrary number of retract/re-prefill cycles. Without this patch the sequence is truncated or contains slots overwritten by other requests.

## Speed Tests

No measurable impact: the snapshot only runs when `req.return_routed_experts` is set, only on the retract path (not the steady-state decode path), and only copies `O(new_tokens_since_last_snapshot * num_layers * num_experts_per_tok)` int values from a CPU tensor to a CPU tensor.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci) (covered by existing routed-experts tests; this is a no-op when the feature is off).
- [x] Update documentation / docstrings as needed.
- [x] Provide test results / benchmarks if applicable (described above).
- [x] For reviewers: please add the `run-ci` label as appropriate.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26669781526](https://github.com/sgl-project/sglang/actions/runs/26669781526)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26669781471](https://github.com/sgl-project/sglang/actions/runs/26669781471)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->