### PR TITLE
[CI] Fix CI error: multimodal-gen-test-1-gpu-amd timeout by increasing partitions

### DIFF
--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -595,7 +595,7 @@ jobs:
       fail-fast: false
       max-parallel: 1  # Run one at a time to avoid eviction from resource exhaustion during AITER kernel JIT
       matrix:
-        part: [0, 1, 2, 3]
+        part: [0, 1, 2, 3, 4, 5, 6]
     runs-on: ${{ format('linux-{0}-1gpu-sglang', inputs.runner_arch || (github.event_name == 'pull_request' && 'mi300' || 'mi325')) }}
     steps:
       - name: Checkout code
@@ -701,7 +701,7 @@ jobs:
             ci_sglang python3 sglang/multimodal_gen/test/run_suite.py \
               --suite 1-gpu \
               --partition-id ${{ matrix.part }} \
-              --total-partitions 4 \
+              --total-partitions 7 \
               -k "not flux_2" \
               ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 


### PR DESCRIPTION
  ## Motivation                                         
                                                                                                                                                                                         
  The `multimodal-gen-test-1-gpu-amd` CI job (shard 0) times out at 90 minutes. The root cause is a partitioning imbalance: with `total_partitions=4` and 3 standalone test files        
  (`test_generate_t2i_perf.py`, `test_update_weights_from_disk.py`, `test_tracing.py`), only **1 partition** remains for all 21 parametrized test cases. The LPT load-balancing algorithm
   is effectively a no-op when distributing across a single partition.                                                                                                                   
                                                        
  The H100-based time estimates for those 21 cases sum to ~50 min, but actual AMD MI300 runtimes are ~2-2.5x longer due to:                                                              
  - aiter kernel JIT compilation (~120s on first model load)
  - Slower HF model downloads on the runner                                                                                                                                              
  - Longer warmup for large models (e.g., `wan2_2_ti2v_5b`: 437s actual vs 142s estimated)
  - ROCm GPU memory cleanup between tests (15s each)                                                                                                                                     
                                                                                                                                                                                         
  ## Modifications                                                                                                                                                                       
                                                                                                                                                                                         
  Increase `total_partitions` from 4 to 7 in the AMD 1-GPU diffusion test job (`pr-test-amd.yml`):                                                                                       
   
  - **Before**: 4 partitions = 1 parametrized + 3 standalone → shard 0 gets all 21 cases (~90+ min on AMD)                                                                               
  - **After**: 7 partitions = 4 parametrized + 3 standalone → LPT distributes cases to ~30 min each on AMD
                                                                                                                                                                                         
  Two lines changed:                                    
  1. `matrix.part: [0, 1, 2, 3]` → `[0, 1, 2, 3, 4, 5, 6]`                                                                                                                               
  2. `--total-partitions 4` → `--total-partitions 7`                                                                                                                                     
   
  No changes to test logic, baselines, or the partitioning algorithm. `max-parallel: 1` is preserved (required for aiter JIT resource management).                                       
                                                        
  ## Accuracy Tests                                                                                                                                                                      
                                                        
  N/A — CI-only change; no model or test logic modifications.                                                                                                                            
                                                        
  ## Speed Tests and Profiling

  N/A — no runtime code changes. Expected per-partition execution time after fix: ~30 min each (vs ~90+ min before for the single overloaded partition).                                 
   
  ## Checklist                                                                                                                                                                           
                                                        
  - [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).                     
  - [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
  - [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).                                   
  - [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark   
  the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).                                                                                        
  - [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).                                                     
                                                                                                                                                                                         
  ## Review and Merge Process                           
                                                                                                                                                                                         
  1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).              
  2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
  3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.                      
     - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`                                                                                              
  4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.                                                                           
