### PR TITLE
[AMD] Enable dual-stream MoE on ROCm

### DIFF
--- a/docs/references/environment_variables.md
+++ b/docs/references/environment_variables.md
@@ -116,6 +116,7 @@ SGLang supports various environment variables that can be used to configure its 
 | Environment Variable | Description | Default Value |
 | --- | --- | --- |
 | `SGLANG_USE_AITER` | Use AITER optimize implementation | `false` |
+| `SGLANG_ROCM_USE_MULTI_STREAM` | Allocate alt CUDA/HIP stream on ROCm/AITER to overlap shared and routed experts in DeepseekV2 MoE. Requires `GPU_MAX_HW_QUEUES>=5`. Best paired with `--deepep-mode low_latency` so Mori's AsyncLL kernel offloads dispatch/combine to copy engines and frees CUs. | `false` |
 | `SGLANG_MOE_PADDING` | Enable MoE padding (sets padding size to 128 if value is `1`, often set to `1` in Docker builds) | `false` |
 | `SGLANG_CUTLASS_MOE` (deprecated) | Use Cutlass FP8 MoE kernel on Blackwell GPUs (deprecated, use --moe-runner-backend=cutlass) | `false` |
 

--- a/docs/references/environment_variables.md
+++ b/docs/references/environment_variables.md
@@ -116,7 +116,7 @@ SGLang supports various environment variables that can be used to configure its 
 | Environment Variable | Description | Default Value |
 | --- | --- | --- |
 | `SGLANG_USE_AITER` | Use AITER optimize implementation | `false` |
-| `SGLANG_ROCM_USE_MULTI_STREAM` | Allocate alt CUDA/HIP stream on ROCm/AITER to overlap shared and routed experts in DeepseekV2 MoE. Requires `GPU_MAX_HW_QUEUES>=5`. Best paired with `--deepep-mode low_latency` so Mori's AsyncLL kernel offloads dispatch/combine to copy engines and frees CUs. | `false` |
+| `SGLANG_ROCM_USE_MULTI_STREAM` | Allocate alt CUDA/HIP stream on ROCm/AITER to overlap shared and routed experts in DeepseekV2 MoE. Requires the HIP env `GPU_MAX_HW_QUEUES>=5` (default `4`, the cap on HSA/ROCr HW queues HIP creates) so the alt stream gets its own queue instead of serializing with the main stream. Best paired with `--deepep-mode low_latency` so Mori's AsyncLL kernel offloads dispatch/combine to copy engines and frees CUs. | `false` |
 | `SGLANG_MOE_PADDING` | Enable MoE padding (sets padding size to 128 if value is `1`, often set to `1` in Docker builds) | `false` |
 | `SGLANG_CUTLASS_MOE` (deprecated) | Use Cutlass FP8 MoE kernel on Blackwell GPUs (deprecated, use --moe-runner-backend=cutlass) | `false` |
 

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -326,6 +326,9 @@ class Envs:
     SGLANG_ROCM_FUSED_DECODE_MLA = EnvBool(False)
     SGLANG_ROCM_DISABLE_LINEARQUANT = EnvBool(False)
     SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK = EnvInt(4096)
+    # Enable dual-stream MoE (shared experts vs routed experts) on the
+    # ROCm/AITER path. Requires GPU_MAX_HW_QUEUES>=5 to avoid HW-queue serialization.
+    SGLANG_ROCM_USE_MULTI_STREAM = EnvBool(False)
 
     # MPS (Apple Silicon)
     SGLANG_USE_MLX = EnvBool(False)

--- a/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
@@ -916,6 +916,18 @@ class MoriEPDispatcher(BaseDispatcher):
 
         self.deepep_mode = deepep_mode
 
+        async_mode = self.deepep_mode.enable_low_latency()
+        if get_bool_env_var("SGLANG_ROCM_USE_MULTI_STREAM") and not async_mode:
+            logger.warning_once(
+                "SGLANG_ROCM_USE_MULTI_STREAM=1 is set but Mori AsyncLL is "
+                "not enabled (--deepep-mode=%s). The alt-stream overlap only "
+                "frees up CUs when dispatch/combine runs on the AsyncLL "
+                "copy-engine kernel; otherwise it stays on CUs and competes "
+                "with the alt-stream work. Pass --deepep-mode low_latency "
+                "(or auto) to enable the AsyncLL kernel.",
+                self.deepep_mode.value,
+            )
+
         common_kwargs = dict(
             group=group,
             router_topk=router_topk,

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1915,7 +1915,12 @@ class DeepseekV2Model(nn.Module):
 
         self.alt_stream = (
             torch.cuda.Stream()
-            if _is_cuda or _is_musa or envs.SGLANG_NPU_USE_MULTI_STREAM.get()
+            if (
+                _is_cuda
+                or _is_musa
+                or envs.SGLANG_NPU_USE_MULTI_STREAM.get()
+                or envs.SGLANG_ROCM_USE_MULTI_STREAM.get()
+            )
             else None
         )
 


### PR DESCRIPTION

Add an opt-in env var that lets Deepseek Model allocate its alt CUDA/HIP stream on the ROCmpath. This is the same alt_stream consumed by DeepseekV2MoE.{forward_normal_dual_stream, forward_deepep, _fuse_shared_experts_inside_sbo} to overlap shared experts vs routed experts. Without this gate the AMD path runs single-stream regardless of the existing dual-stream code.
Recommend pairing the alt-stream overlap with Mori's CU-free AsyncLL ep kernel (`--deepep-mode low_latency`) for better overlap performance.
Note: AsyncLL also requires Mori's `MORI_ENABLE_SDMA=1` for intra-node deployments — without it, intra-node transfers fall back to RDMA loopback and the AsyncLL benefit is lost. This Mori-side knob will be defaulted on soon.



suggest to use (cu-free ep kernel) asyncLL,
before:
<img width="259" height="68" alt="image" src="https://github.com/user-attachments/assets/28282118-dcdf-45ca-ac42-3a7ff7ea3dcd" />
after
<img width="224" height="100" alt="image" src="https://github.com/user-attachments/assets/c455d31c-7c47-4732-bd50-c10fd6a849e7" />



<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->



```bash
export GPU_MAX_HW_QUEUES=5
export MORI_ENABLE_SDMA=1     # (Mori-side knob, will be defaulted on in Mori soon)
export SGLANG_ROCM_USE_MULTI_STREAM=1

python3 -m sglang.launch_server \
    --model-path /apps/data/models/DeepSeek-R1-0528-MXFP4-th \
    --host 0.0.0.0 --port 8888 \
    --tp-size 8 --ep-size 8 --dp-size 8 \
    --kv-cache-dtype fp8_e4m3 \
    --attention-backend aiter \
    --moe-a2a-backend mori \
    --enable-dp-attention \
    --moe-dense-tp-size 1 \
    --enable-dp-lm-head \
    --mem-fraction-static 0.65 \
    --max-running-requests 4096 \
    --cuda-graph-bs 1 8 32 64 128 192 224 256 \
    --trust-remote-code \
    --deepep-mode  low_latency
    
   
   python3 -m sglang.bench_serving \
    --backend sglang --port 8888 \
    --model /apps/data/models/DeepSeek-R1-0528-MXFP4-th \
    --dataset-name random \
    --random-input-len 1 --random-output-len 64 --random-range-ratio 1.0 \
    --num-prompts 8192 --max-concurrency 2048 \
    --request-rate inf --warmup-requests 256
  ```
    
Config	       Mean TPOT (ms)            	Total tok/s
A: AsyncLL + alt-stream overlap	83.32	23,234
B: Baseline (IntraNode, no overlap)	97.35	20,094


cc @billishyahao  @Duyi-Wang 
## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
