### PR TITLE
Add opt-in canonical ordering for DSv4 legacy C4 TopK producer

### DIFF
--- a/python/sglang/jit_kernel/csrc/deepseek_v4/topk.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/topk.cuh
@@ -24,6 +24,7 @@ struct TopK512Params {
   const int64_t score_stride;
   const int64_t page_table_stride;
   uint32_t page_bits;
+  bool canonical_order;
 };
 
 SGL_DEVICE uint8_t convert_to_uint8(float x) {
@@ -223,11 +224,49 @@ SGL_DEVICE void radix_topk(const float* __restrict__ input, int32_t* __restrict_
   }
 }
 
+SGL_DEVICE void bitonic_sort_512_int32_pair(
+    int32_t* __restrict__ values,
+    int32_t* __restrict__ carried_values) {
+  static_assert(kTopK == 512);
+  static_assert(kTopKBlockSize == 512);
+  const uint32_t tx = threadIdx.x;
+  constexpr int32_t kInvalidIndexSortKey = 0x7fffffff;
+
+  // One thread owns one selected value. Sort ascending in shared memory so the
+  // native top-k producer emits a canonical order rather than atomic arrival
+  // order. When carried_values is present, carry raw indices with translated
+  // page indices so optional raw-index consumers keep pair correspondence.
+  for (uint32_t k = 2; k <= kTopK; k <<= 1) {
+    for (uint32_t j = k >> 1; j > 0; j >>= 1) {
+      const uint32_t ixj = tx ^ j;
+      if (ixj > tx) {
+        const int32_t a = values[tx];
+        const int32_t b = values[ixj];
+        const int32_t a_key = a >= 0 ? a : kInvalidIndexSortKey;
+        const int32_t b_key = b >= 0 ? b : kInvalidIndexSortKey;
+        const int32_t carried_a = carried_values != nullptr ? carried_values[tx] : 0;
+        const int32_t carried_b = carried_values != nullptr ? carried_values[ixj] : 0;
+        const bool ascending = (tx & k) == 0;
+        const bool should_swap = (a_key > b_key || (a_key == b_key && carried_a > carried_b)) == ascending;
+        if (should_swap) {
+          values[tx] = b;
+          values[ixj] = a;
+          if (carried_values != nullptr) {
+            carried_values[tx] = carried_b;
+            carried_values[ixj] = carried_a;
+          }
+        }
+      }
+      __syncthreads();
+    }
+  }
+}
+
 template <bool kUsePDL>
 __global__ void topk_512_transform(const __grid_constant__ TopK512Params params) {
   const auto &[
     scores, seq_lens, page_table, page_indices, raw_indices, // pointers
-    score_stride, page_table_stride, page_bits // sizes
+    score_stride, page_table_stride, page_bits, canonical_order // sizes
   ] = params;
   const uint32_t work_id = blockIdx.x;
 
@@ -240,18 +279,42 @@ __global__ void topk_512_transform(const __grid_constant__ TopK512Params params)
 
   device::PDLWaitPrimary<kUsePDL>();
 
+  __shared__ int32_t s_page_indices[kTopK];
+  __shared__ int32_t s_raw_indices[kTopK];
+  const auto tx = threadIdx.x;
   if (seq_len <= kTopK) {
-    naive_transform(score_ptr, page_ptr, indices_ptr, raw_indices_ptr, seq_len, page_bits);
+    if (kTopK == kTopKBlockSize || tx < kTopK) {
+      if (tx < seq_len) {
+        s_page_indices[tx] = page_to_indices(page_ptr, tx, page_bits);
+        if (raw_indices_ptr != nullptr) {
+          s_raw_indices[tx] = tx;
+        }
+      } else {
+        s_page_indices[tx] = -1;
+        if (raw_indices_ptr != nullptr) {
+          s_raw_indices[tx] = -1;
+        }
+      }
+    }
   } else {
     __shared__ int32_t s_topk_indices[kTopK];
     radix_topk(score_ptr, s_topk_indices, seq_len);
     static_assert(kTopK <= kTopKBlockSize);
-    const auto tx = threadIdx.x;
     if (kTopK == kTopKBlockSize || tx < kTopK) {
-      indices_ptr[tx] = page_to_indices(page_ptr, s_topk_indices[tx], page_bits);
+      s_page_indices[tx] = page_to_indices(page_ptr, s_topk_indices[tx], page_bits);
       if (raw_indices_ptr != nullptr) {
-        raw_indices_ptr[tx] = s_topk_indices[tx];
+        s_raw_indices[tx] = s_topk_indices[tx];
       }
+    }
+  }
+  __syncthreads();
+  if (canonical_order) {
+    bitonic_sort_512_int32_pair(s_page_indices, raw_indices_ptr != nullptr ? s_raw_indices : nullptr);
+  }
+  if (kTopK == kTopKBlockSize || tx < kTopK) {
+    indices_ptr[tx] = s_page_indices[tx];
+    if (raw_indices_ptr != nullptr) {
+      raw_indices_ptr[tx] = s_raw_indices[tx];
     }
   }
 
@@ -278,7 +341,8 @@ struct TopK512Kernel {
       const tvm::ffi::TensorView page_table,
       const tvm::ffi::TensorView page_indices,
       const uint32_t page_size,
-      const tvm::ffi::Optional<tvm::ffi::TensorView> raw_indices) {
+      const tvm::ffi::Optional<tvm::ffi::TensorView> raw_indices,
+      const bool canonical_order) {
     using namespace host;
     auto B = SymbolicSize{"batch_size"};
     auto S = SymbolicSize{"score_stride"};
@@ -326,6 +390,7 @@ struct TopK512Kernel {
         .score_stride = S.unwrap(),
         .page_table_stride = P.unwrap(),
         .page_bits = page_bits,
+        .canonical_order = canonical_order,
     };
     constexpr auto kSMEM_ = kSMEM + sizeof(int32_t);  // align up a little
     setup_kernel_smem_once<kernel, kSMEM_>();

--- a/python/sglang/jit_kernel/deepseek_v4.py
+++ b/python/sglang/jit_kernel/deepseek_v4.py
@@ -302,6 +302,16 @@ def topk_transform_512(
 ) -> None:
     if out_page_indices.shape[1] == 512:
         module = _jit_topk_module()
+        module.topk_transform(
+            scores,
+            seq_lens,
+            page_tables,
+            out_page_indices,
+            page_size,
+            out_raw_indices,
+            envs.SGLANG_DSV4_CANONICAL_TOPK_IN_KERNEL.get(),
+        )
+        return
     else:
         module = _jit_topk1024_module()
     module.topk_transform(

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -591,6 +591,7 @@ class Envs:
     SGLANG_OPT_USE_FUSED_HASH_TOPK = EnvBool(True)
     SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK = EnvBool(True)
     SGLANG_OPT_USE_TOPK_V2 = EnvBool(False)
+    SGLANG_DSV4_CANONICAL_TOPK_IN_KERNEL = EnvBool(False)
 
     # GEMM / kernel fusion
     SGLANG_OPT_FP8_WO_A_GEMM = EnvBool(False)

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -485,10 +485,18 @@ class C4IndexerBackendMixin:
                     )
                 )
 
-        _sort_c4_sparse_indices_by_row(
-            core_metadata.c4_sparse_page_indices,
-            core_metadata.c4_sparse_topk_lengths,
+        in_kernel_canonical = (
+            envs.SGLANG_DSV4_CANONICAL_TOPK_IN_KERNEL.get()
+            and not envs.SGLANG_OPT_USE_TOPK_V2.get()
+            and not envs.SGLANG_TOPK_TRANSFORM_512_TORCH.get()
+            and hisparse_coordinator is None
+            and core_metadata.c4_sparse_page_indices.shape[1] == 512
         )
+        if not in_kernel_canonical:
+            _sort_c4_sparse_indices_by_row(
+                core_metadata.c4_sparse_page_indices,
+                core_metadata.c4_sparse_topk_lengths,
+            )
 
         if capture_enabled:
             compress_layer_id = token_to_kv_pool.layer_mapping[

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -186,6 +186,24 @@ def topk_transform_512_pytorch_vectorized(
         out_raw_indices.copy_(raw_indices)
 
 
+def _sort_c4_sparse_indices_by_row(
+    page_indices: torch.Tensor,
+    topk_lengths: torch.Tensor,
+) -> None:
+    if page_indices.numel() == 0:
+        return
+    if topk_lengths.dim() != 1:
+        topk_lengths = topk_lengths.view(-1)
+
+    cols = page_indices.shape[-1]
+    positions = torch.arange(cols, device=page_indices.device).unsqueeze(0)
+    valid = positions < topk_lengths.unsqueeze(1)
+    sentinel = torch.iinfo(page_indices.dtype).max
+    sortable = torch.where(valid, page_indices, sentinel)
+    sorted_indices = torch.sort(sortable, dim=-1).values
+    page_indices.copy_(torch.where(valid, sorted_indices, -1))
+
+
 @triton.jit
 def _fused_scale_kernel(
     weight_ptr,
@@ -466,6 +484,11 @@ class C4IndexerBackendMixin:
                         core_metadata.c4_sparse_page_indices
                     )
                 )
+
+        _sort_c4_sparse_indices_by_row(
+            core_metadata.c4_sparse_page_indices,
+            core_metadata.c4_sparse_topk_lengths,
+        )
 
         if capture_enabled:
             compress_layer_id = token_to_kv_pool.layer_mapping[

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -532,7 +532,7 @@ class MQALayer(nn.Module):
 
         tp_slice, q_padded, q_out = slice(None), None, None
         if self.tp_size > 1:
-            q_padded = x.new_empty(x.shape[0], self.n_heads, self.head_dim)
+            q_padded = x.new_zeros(x.shape[0], self.n_heads, self.head_dim)
             rank = self.tp_rank
             tp_slice = slice(rank * self.n_local_heads, (rank + 1) * self.n_local_heads)
             q_out = q_padded[:, tp_slice, :]


### PR DESCRIPTION
## Summary

This PR adds an opt-in DeepSeek V4 compressed-attention path that makes the legacy 512-way C4 TopK producer emit canonical page-index order directly from the CUDA kernel.

It is a follow-up to #23926:

- #23926 hardens the FlashMLA input contract by sorting C4 sparse indices before consumption.
- This PR keeps that fallback as the default, and only skips it when the legacy 512 TopK producer is explicitly configured to emit canonical order itself.

This also follows the DSv4 work tracked in #23602 and the performance checklist in #23666.

## Motivation

The DSv4 compressed-attention path consumes C4 sparse page indices downstream in FlashMLA. The legacy native TopK path selects the right set of indices, but row order can follow native producer order rather than a canonical page-index order.

The hardening path in #23926 sorts after TopK and before FlashMLA. That is simple and safe, but it adds a separate post-sort step. This PR moves canonicalization into the legacy 512 TopK producer behind an opt-in env flag.

## Implementation

- Add `SGLANG_DSV4_CANONICAL_TOPK_IN_KERNEL`.
- Pass the flag into the legacy `topk_transform_512` JIT wrapper.
- Add an optional shared-memory bitonic sort over translated page indices in `topk_512_transform`.
- Carry raw indices together with their translated page-index pair when raw output is requested.
- Treat invalid `-1` entries as tail elements while sorting so short rows keep a canonical valid prefix.
- Skip the Python post-sort only when all of these are true:
  - `SGLANG_DSV4_CANONICAL_TOPK_IN_KERNEL=1`
  - `SGLANG_OPT_USE_TOPK_V2=0`
  - `SGLANG_TOPK_TRANSFORM_512_TORCH=0`
  - no HiSparse coordinator path is active
  - C4 sparse width is `512`

All other paths keep the existing post-sort fallback from #23926.

## Validation

Static checks:

```bash
git diff --check dsv4-flashmla-determinism-community..HEAD
python3 -m compileall -q \
  python/sglang/jit_kernel/deepseek_v4.py \
  python/sglang/srt/environ.py \
  python/sglang/srt/layers/attention/compressed/indexer.py
```

Both passed.

Focused GB200 checks:

- Frozen TopK replay, legacy 512 path, `seq_len=4096`: deterministic ordered output for random and boundary-tie inputs.
- Short-row replay, legacy 512 path, `seq_len=256`: deterministic ordered output for random and boundary-tie inputs.
- Raw-index pair contract: page output is sorted with and without raw output requested; raw output is stable and carried with the sorted page-output pair.
- Full DSv4 TP4 serving smoke:
  - `DeepSeek-V4-Flash`
  - `SGLANG_DSV4_CANONICAL_TOPK_IN_KERNEL=1`
  - `SGLANG_OPT_USE_TOPK_V2=0`
  - prompt length `4096`
  - `max_new_tokens=2`
  - HTTP 200, output ids `[2701, 95]`

Serving benchmark on one GB200 node, TP4, `input_len=4096`, `output_len=1500`, `temperature=0`, `ignore_eos=true`:

| batch size | post-sort tok/s | in-kernel canonical tok/s | gain |
|---:|---:|---:|---:|
| 1 | `3.959` | `4.093` | `+3.39%` |
| 2 | `11.276` | `11.793` | `+4.59%` |
| 4 | `22.155` | `23.058` | `+4.08%` |

All benchmark requests completed successfully with `1500` generated tokens.

## Risk and scope

This is intentionally scoped to the legacy 512 TopK path. It does not canonicalize the v2 TopK producer, and it does not remove the post-sort fallback.

The performance claim is narrow: this avoids measurable post-sort overhead on one DSv4 GB200 serving shape. It should not be read as a broad DSv4 serving performance fix.

## Related

- Depends on / follows #23926
- Roadmap: #23602
- Performance tracker: #23666
