### PR TITLE
[disagg] Add RDMA transfer speed/latency metrics for Mooncake.

### DIFF
--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -9,7 +9,7 @@ import struct
 import threading
 import time
 from collections import defaultdict
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import numpy.typing as npt
@@ -227,6 +227,7 @@ class MooncakeKVManager(CommonKVManager):
             self.enable_custom_mem_pool, self.custom_mem_pool_type = (
                 check_mooncake_custom_mem_pool_enabled()
             )
+            self.room_transfer_elapsed: Dict[int, float] = {}
             self._staging_ctx = PrefillStagingContext() if self.enable_staging else None
             if self.enable_staging:
                 self._init_staging_buffers(len(self.transfer_queues))
@@ -1181,6 +1182,7 @@ class MooncakeKVManager(CommonKVManager):
                 # When staging transfer is not yet ready (watermark/allocation pending),
                 # the chunk is re-enqueued and we break out of the req loop to retry later.
                 staging_deferred = False
+                t_chunk_start = time.monotonic()
                 for req in reqs_to_be_processed:
                     if not req.is_dummy:
                         # Early exit if the request has failed
@@ -1315,6 +1317,11 @@ class MooncakeKVManager(CommonKVManager):
 
                             # Only sync status when all the dst ranks have received the kvcache
                             if len(polls) == req.required_dst_info_num:
+                                chunk_elapsed = time.monotonic() - t_chunk_start
+                                self.room_transfer_elapsed[kv_chunk.room] = (
+                                    self.room_transfer_elapsed.get(kv_chunk.room, 0.0)
+                                    + chunk_elapsed
+                                )
                                 status = KVPoll.Success if all(polls) else KVPoll.Failed
                                 self.update_status(req.room, status)
                                 for endpoint, dst_port, room in dst_ranks_infos:
@@ -1330,6 +1337,13 @@ class MooncakeKVManager(CommonKVManager):
                         # Dummy request does not need to sync status to decode endpoint
                         if kv_chunk.is_last_chunk and req.room in self.request_status:
                             self.update_status(req.room, KVPoll.Success)
+
+                if not kv_chunk.is_last_chunk:
+                    chunk_elapsed = time.monotonic() - t_chunk_start
+                    self.room_transfer_elapsed[kv_chunk.room] = (
+                        self.room_transfer_elapsed.get(kv_chunk.room, 0.0)
+                        + chunk_elapsed
+                    )
 
                 if staging_deferred:
                     continue
@@ -1649,6 +1663,7 @@ class MooncakeKVSender(CommonKVSender):
         super().__init__(mgr, bootstrap_addr, bootstrap_room, dest_tp_ranks, pp_rank)
         self.conclude_state = None
         self.init_time = time.time()
+        self.transfer_elapsed_s: float = 0.0
 
     def send(
         self,
@@ -1694,6 +1709,11 @@ class MooncakeKVSender(CommonKVSender):
         if self.conclude_state is None:
             status = self.kv_mgr.check_status(self.bootstrap_room)
             if status in (KVPoll.Success, KVPoll.Failed):
+                popped = self.kv_mgr.room_transfer_elapsed.pop(
+                    self.bootstrap_room, 0.0
+                )
+                if status == KVPoll.Success:
+                    self.transfer_elapsed_s = popped
                 self.conclude_state = status
             elif status == KVPoll.Bootstrapping:
                 if self.init_time is not None:
@@ -1719,6 +1739,7 @@ class MooncakeKVSender(CommonKVSender):
     def clear(self) -> None:
         if self.bootstrap_room in self.kv_mgr.request_status:
             self.kv_mgr.request_status.pop(self.bootstrap_room)
+        self.kv_mgr.room_transfer_elapsed.pop(self.bootstrap_room, None)
 
     def failure_exception(self):
         # Explicitly set the status to failure since this request has failed in another rank

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -634,6 +634,10 @@ class SchedulerDisaggregationPrefillMixin:
             elif poll == KVPoll.Success:  # transfer done
                 release_kv_cache(req, self.tree_cache)  # unlock the tree
                 req.finished_reason = FINISH_LENGTH(length=0)
+                if hasattr(req.disagg_kv_sender, "transfer_elapsed_s"):
+                    req.time_stats.transfer_elapsed_s = (
+                        req.disagg_kv_sender.transfer_elapsed_s
+                    )
                 # FIXME: clean up req's data in transfer engine
                 if hasattr(req.disagg_kv_sender, "clear"):
                     req.disagg_kv_sender.clear()
@@ -684,6 +688,10 @@ class SchedulerDisaggregationPrefillMixin:
                     self.kv_transfer_latency_ms = metrics["latency_ms"]
                 if "speed_gb_s" in metrics:
                     self.kv_transfer_speed_gb_s = metrics["speed_gb_s"]
+                if "rdma_latency_ms" in metrics:
+                    self.kv_transfer_rdma_latency_ms = metrics["rdma_latency_ms"]
+                if "rdma_speed_gb_s" in metrics:
+                    self.kv_transfer_rdma_speed_gb_s = metrics["rdma_speed_gb_s"]
 
         # Stream requests which have finished transfer
         self.stream_output(

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1965,6 +1965,14 @@ class DisaggregationMetrics:
     kv_transfer_latency_ms: float = field(
         default=0.0, metadata={"metric": ("gauge", "KV transfer latency in ms")}
     )
+    kv_transfer_rdma_speed_gb_s: float = field(
+        default=0.0,
+        metadata={"metric": ("gauge", "RDMA transfer speed of KV cache in GB/s")},
+    )
+    kv_transfer_rdma_latency_ms: float = field(
+        default=0.0,
+        metadata={"metric": ("gauge", "RDMA transfer latency of KV cache in ms")},
+    )
 
 
 @dataclass

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -113,6 +113,8 @@ class SchedulerStats:
     num_decode_transfer_queue_reqs: QueueCount = field(default_factory=QueueCount)
     kv_transfer_speed_gb_s: float = 0.0
     kv_transfer_latency_ms: float = 0.0
+    kv_transfer_rdma_speed_gb_s: float = 0.0
+    kv_transfer_rdma_latency_ms: float = 0.0
 
     # Utilization
     utilization: float = 0.0
@@ -413,6 +415,18 @@ class SchedulerMetricsCollector:
             documentation="Histogram of KV cache transfer size in MB.",
             labelnames=labels.keys(),
             buckets=(1, 5, 10, 50, 100, 500, 1000, 5000, 10000),
+        )
+        self.kv_transfer_rdma_speed_gb_s = Gauge(
+            name="sglang:kv_transfer_rdma_speed_gb_s",
+            documentation="The RDMA transfer speed of the KV cache in GB/s.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+        self.kv_transfer_rdma_latency_ms = Gauge(
+            name="sglang:kv_transfer_rdma_latency_ms",
+            documentation="The RDMA transfer latency of the KV cache in ms.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
         )
 
         # Utilization
@@ -1056,6 +1070,12 @@ class SchedulerMetricsCollector:
         )
         self._log_gauge_queue_count(
             self.num_decode_transfer_queue_reqs, stats.num_decode_transfer_queue_reqs
+        )
+        self._log_gauge(
+            self.kv_transfer_rdma_speed_gb_s, stats.kv_transfer_rdma_speed_gb_s
+        )
+        self._log_gauge(
+            self.kv_transfer_rdma_latency_ms, stats.kv_transfer_rdma_latency_ms
         )
         # Retract
         self._log_gauge(self.num_retracted_reqs, stats.num_retracted_reqs)

--- a/python/sglang/srt/observability/req_time_stats.py
+++ b/python/sglang/srt/observability/req_time_stats.py
@@ -580,6 +580,7 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
     spec_draft_extend_start_time: float = 0.0
 
     # other
+    transfer_elapsed_s: float = 0.0
     transfer_speed_gb_s: float = 0.0
     transfer_total_mb: float = 0.0
     # Number of prefill retries for this request
@@ -874,6 +875,12 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
             result["latency_ms"] = latency_ms
             result["total_mb"] = total_mb
             result["speed_gb_s"] = speed_gb_s
+
+            if self.transfer_elapsed_s > 0:
+                result["rdma_latency_ms"] = self.transfer_elapsed_s * 1000
+                result["rdma_speed_gb_s"] = (
+                    self.transfer_total_mb / 1024
+                ) / self.transfer_elapsed_s
 
             if self.enable_metrics:
                 self.metrics_collector.observe_kv_transfer_metrics(

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -110,6 +110,8 @@ class SchedulerMetricsMixin:
         # For PD disaggregation
         self.kv_transfer_speed_gb_s: float = 0.0
         self.kv_transfer_latency_ms: float = 0.0
+        self.kv_transfer_rdma_speed_gb_s: float = 0.0
+        self.kv_transfer_rdma_latency_ms: float = 0.0
 
         self.stats = SchedulerStats()
 
@@ -442,6 +444,12 @@ class SchedulerMetricsMixin:
                 )
                 self.stats.kv_transfer_speed_gb_s = self.kv_transfer_speed_gb_s
                 self.stats.kv_transfer_latency_ms = self.kv_transfer_latency_ms
+                self.stats.kv_transfer_rdma_speed_gb_s = (
+                    self.kv_transfer_rdma_speed_gb_s
+                )
+                self.stats.kv_transfer_rdma_latency_ms = (
+                    self.kv_transfer_rdma_latency_ms
+                )
             elif self.disaggregation_mode == DisaggregationMode.DECODE:
                 self.stats.num_decode_prealloc_queue_reqs = QueueCount.from_reqs(
                     self.disagg_decode_prealloc_queue.queue, priority_enabled
@@ -887,6 +895,8 @@ class SchedulerMetricsMixin:
                 decode_retracted_queue_reqs=decode_retracted,
                 kv_transfer_speed_gb_s=self.stats.kv_transfer_speed_gb_s,
                 kv_transfer_latency_ms=self.stats.kv_transfer_latency_ms,
+                kv_transfer_rdma_speed_gb_s=self.stats.kv_transfer_rdma_speed_gb_s,
+                kv_transfer_rdma_latency_ms=self.stats.kv_transfer_rdma_latency_ms,
             )
 
         queues = None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Closes #23937
When chunked prefill is enabled in disaggregated inference, the existing
`kv_transfer_speed_gb_s` metric measures the time window from
`prefill_transfer_queue_entry_time` to `completion_time`, which includes
scheduling overhead and is not a direct reflection of RDMA transfer
performance. This makes it difficult to diagnose whether a transfer
bottleneck comes from the network or from scheduling delays.

## Modifications

- Track per-chunk RDMA wall-clock elapsed time in `MooncakeKVManager.room_transfer_elapsed`
  and accumulate it across all chunks for each room.
- Expose `transfer_elapsed_s` on `MooncakeKVSender` and propagate it through
  `req.time_stats` to the metrics pipeline.
- Add two new Prometheus gauges:
  - `sglang:kv_transfer_rdma_speed_gb_s` — total KV bytes / RDMA elapsed time
  - `sglang:kv_transfer_rdma_latency_ms` — accumulated RDMA elapsed time in ms
- Plumb the new metrics through `DisaggregationMetrics`, `SchedulerStats`,
  `SchedulerMetricsMixin`, and `SchedulerMetricsCollector`.
- No changes to the existing `speed_gb_s` / `latency_ms` metrics.

## Accuracy Tests

No model output changes. This PR only adds observability metrics.

## Speed Tests and Profiling

No performance impact expected. The only overhead is two `time.monotonic()` calls
per chunk in the transfer thread.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

