### PR TITLE
[AMD] Fix CI error: Increase disagg test timeout from 120s to 300s

### DIFF
--- a/python/sglang/multimodal_gen/test/server/test_disagg_server.py
+++ b/python/sglang/multimodal_gen/test/server/test_disagg_server.py
@@ -226,7 +226,7 @@ class DisaggCluster:
             "--host",
             HOST,
             "--disagg-timeout",
-            "120",
+            "300",
             "--log-level",
             "info",
             *self.extra_role_args.get("server", []),


### PR DESCRIPTION
## Motivation

  On MI300 with cold AITER JIT and MIOpen caches, the first disaggregated diffusion inference can exceed the 120s `--disagg-timeout`, producing:                                         
  
  RuntimeError: Model generation returned no output. Error from scheduler:                                                                                                               
  DiffusionServer timeout: request ... not completed within 120.0s

  This triggers up to 6 retries in `run_suite.py` (each with full cluster restart + another 120s wait), accumulating past the 90-minute CI timeout. The issue was revealed by #23940
  which added the `tracing` dependency — `TestDisaggZImageTracing` now actually runs the full disagg pipeline instead of failing fast on missing opentelemetry.  This PR is used to solve [multimodal-gen-test-2-gpu-amd (mi300, 2)](https://github.com/sgl-project/sglang/actions/runs/25059368582/job/73408828905) timeout issue.
  
  
  ## Modifications                                                                                                                                                                       
                                                        
  - Increased `--disagg-timeout` from `120` to `300` in `DisaggCluster._launch_server_head()` (`test_disagg_server.py:229`)                                                              
  - 300s gives each of the 3 disagg roles (encoder → denoiser → decoder) ~100s for JIT compilation + inference on first use, while still catching genuine hangs

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
