### PR TITLE
Fix DeepGEMM JIT warmup crash by passing m_indices positionally

### DIFF
--- a/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
@@ -67,7 +67,9 @@ def update_deep_gemm_config(gpu_id: int, server_args: ServerArgs):
             else 16 * 1024
         )
         while next_m < max_prefill_bs:
-            _BUILTIN_M_LIST += list(range(next_m, min(2 * next_m, max_prefill_bs), sample_step))
+            _BUILTIN_M_LIST += list(
+                range(next_m, min(2 * next_m, max_prefill_bs), sample_step)
+            )
             next_m = next_m * 2
             sample_step = sample_step * 2
         _BUILTIN_M_LIST.append(max_prefill_bs)
@@ -297,7 +299,7 @@ class _GroupedContWarmupExecutor(_BaseWarmupExecutor):
             (self.lhs_q[:m], self.lhs_s[:m]),
             (self.rhs_q, self.rhs_s),
             self.out[:m],
-            m_indices=self.m_indices[:m],
+            self.m_indices[:m],
         )
 
 


### PR DESCRIPTION
## Summary
- DeepGEMM 2.4.2 renamed the keyword arg `m_indices` to `grouped_layout` on `m_grouped_fp8_gemm_nt_contiguous` (now an alias of `m_grouped_fp8_fp4_gemm_nt_contiguous`).
- The runtime call site in `entrypoint.py:118` already passes the indices positionally, so inference works, but the JIT-warmup executor in `compile_utils.py:303` still uses `m_indices=...`, which throws a pybind `TypeError: incompatible function arguments` and crashes the scheduler during DeepGEMM precompile.
- Fix: pass it positionally to match the runtime call site. Compatible with both the old and new DeepGEMM signatures.

## Repro
```
SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256 sglang serve \
  --trust-remote-code --model-path deepseek-ai/DeepSeek-V4-Pro \
  --tp 8 --dp 8 --enable-dp-attention --moe-a2a-backend deepep \
  --mem-fraction-static 0.82 --cuda-graph-max-bs 64 --max-running-requests 256 \
  --deepep-config '{"normal_dispatch":{"num_sms":96},"normal_combine":{"num_sms":96}}' \
  --tool-call-parser deepseekv4 --reasoning-parser deepseek-v4 \
  --host 0.0.0.0 --port 30000
```
Crashes at `Try DeepGEMM JIT Compiling for <GROUPED_GEMM_NT_F8F8BF16_CONTIG> ...` with:
```
TypeError: m_grouped_fp8_fp4_gemm_nt_contiguous(): incompatible function arguments.
```
Setting `SGLANG_JIT_DEEPGEMM_PRECOMPILE=0` bypasses the warmup path and avoids the crash.

## Test plan
- [x] Repro on B200 with DSV4-Pro, TP=8, DP=8, dp-attention + DeepEP — server reaches `The server is fired up and ready to roll!`
- [x] Sanity-check `/v1/chat/completions` returns a valid response post-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)