### PR TITLE
[codex] Allow diffusion GT workflow to sync ci-data files

### DIFF
--- a/.github/workflows/diffusion-ci-gt-gen.yml
+++ b/.github/workflows/diffusion-ci-gt-gen.yml
@@ -23,6 +23,26 @@ on:
         required: false
         default: ''
         type: string
+      ci_data_source_repo:
+        description: 'Optional source repo for syncing non-generated ci-data files, e.g. mickqian/sglang-ci-data-upstream-pr.'
+        required: false
+        default: ''
+        type: string
+      ci_data_source_ref:
+        description: 'Optional source ref for syncing non-generated ci-data files.'
+        required: false
+        default: ''
+        type: string
+      ci_data_sync_preset:
+        description: 'Optional ci-data file sync preset.'
+        required: false
+        default: ''
+        type: string
+      ci_data_sync_only:
+        description: 'Skip GT generation and only sync ci-data files from ci_data_source_repo/ref.'
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: diffusion-ci-gt-gen-${{ github.ref }}
@@ -39,7 +59,7 @@ env:
 
 jobs:
   compute-diffusion-partitions:
-    if: github.repository == 'sgl-project/sglang'
+    if: github.repository == 'sgl-project/sglang' && !inputs.ci_data_sync_only
     runs-on: ubuntu-latest
     outputs:
       matrix-1gpu: ${{ steps.compute.outputs.matrix-1gpu }}
@@ -269,3 +289,64 @@ jobs:
           python scripts/ci/utils/diffusion/publish_diffusion_gt.py \
             --source-dir python/${{ env.OUTPUT_NAME }} \
             ${{ inputs.output_name != '' && format('--target-dir diffusion-ci/{0}', inputs.output_name) || '' }}
+
+  sync-ci-data-files:
+    if: |
+      always() &&
+      github.repository == 'sgl-project/sglang' &&
+      inputs.ci_data_source_repo != '' &&
+      inputs.ci_data_source_ref != '' &&
+      inputs.ci_data_sync_preset == 'ltx23-one-stage-ti2v'
+    needs:
+      - compute-diffusion-partitions
+      - multimodal-diffusion-gen-1gpu
+      - multimodal-diffusion-gen-2gpu
+      - multimodal-diffusion-gen-b200
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Checkout ci-data source files
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.ci_data_source_repo }}
+          ref: ${{ inputs.ci_data_source_ref }}
+          path: ci-data-source
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            diffusion-ci/consistency_gt/ltx_2.3_one_stage_ti2v_2gpu_frame_0.png
+            diffusion-ci/consistency_gt/ltx_2.3_one_stage_ti2v_2gpu_frame_mid.png
+            diffusion-ci/consistency_gt/ltx_2.3_one_stage_ti2v_2gpu_frame_last.png
+            diffusion-ci/consistency_gt/official_generated/ltx_2.3_one_stage_ti2v_2gpu_frame_0.png
+            diffusion-ci/consistency_gt/official_generated/ltx_2.3_one_stage_ti2v_2gpu_frame_mid.png
+            diffusion-ci/consistency_gt/official_generated/ltx_2.3_one_stage_ti2v_2gpu_frame_last.png
+            diffusion-ci/repro_scripts/gen_official_ltx23.py
+            diffusion-ci/repro_scripts/run_official_ltx23.sh
+            diffusion-ci/repro_scripts/official_repro_case_map.json
+
+      - name: Build ci-data path list
+        run: |
+          cat > /tmp/ci-data-paths.txt <<'EOF'
+          diffusion-ci/consistency_gt/ltx_2.3_one_stage_ti2v_2gpu_frame_0.png
+          diffusion-ci/consistency_gt/ltx_2.3_one_stage_ti2v_2gpu_frame_mid.png
+          diffusion-ci/consistency_gt/ltx_2.3_one_stage_ti2v_2gpu_frame_last.png
+          diffusion-ci/consistency_gt/official_generated/ltx_2.3_one_stage_ti2v_2gpu_frame_0.png
+          diffusion-ci/consistency_gt/official_generated/ltx_2.3_one_stage_ti2v_2gpu_frame_mid.png
+          diffusion-ci/consistency_gt/official_generated/ltx_2.3_one_stage_ti2v_2gpu_frame_last.png
+          diffusion-ci/repro_scripts/gen_official_ltx23.py
+          diffusion-ci/repro_scripts/run_official_ltx23.sh
+          diffusion-ci/repro_scripts/official_repro_case_map.json
+          EOF
+
+      - name: Publish ci-data files to sglang-bot/sglang-ci-data
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+          COMMIT_MESSAGE: 'diffusion-ci: refresh LTX2.3 one-stage TI2V GT and repro scripts [automated]'
+        run: |
+          python scripts/ci/utils/diffusion/publish_ci_data_files.py \
+            --source-root ci-data-source \
+            --paths-file /tmp/ci-data-paths.txt \
+            --commit-message "$COMMIT_MESSAGE"

--- a/scripts/ci/utils/diffusion/publish_ci_data_files.py
+++ b/scripts/ci/utils/diffusion/publish_ci_data_files.py
@@ -1,0 +1,172 @@
+"""Publish selected files to sglang-bot/sglang-ci-data via the GitHub API."""
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+from urllib.error import HTTPError
+
+if __package__:
+    from ..publish_traces import (
+        create_blob,
+        create_commit,
+        create_tree,
+        get_branch_sha,
+        get_tree_sha,
+        is_permission_error,
+        is_rate_limit_error,
+        update_branch_ref,
+        verify_token_permissions,
+    )
+else:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from publish_traces import (
+        create_blob,
+        create_commit,
+        create_tree,
+        get_branch_sha,
+        get_tree_sha,
+        is_permission_error,
+        is_rate_limit_error,
+        update_branch_ref,
+        verify_token_permissions,
+    )
+
+REPO_OWNER = "sglang-bot"
+REPO_NAME = "sglang-ci-data"
+BRANCH = "main"
+
+
+def read_paths(paths_file: str) -> list[str]:
+    paths = []
+    for raw in Path(paths_file).read_text().splitlines():
+        path = raw.strip()
+        if path and not path.startswith("#"):
+            paths.append(path)
+    return paths
+
+
+def validate_repo_path(path: str) -> None:
+    candidate = Path(path)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        raise ValueError(f"Refusing unsafe repo path: {path}")
+
+
+def collect_files(source_root: str, paths: list[str]) -> list[dict[str, object]]:
+    root = Path(source_root)
+    files = []
+    for repo_path in paths:
+        validate_repo_path(repo_path)
+        source = root / repo_path
+        if not source.is_file():
+            raise FileNotFoundError(f"Missing source file: {source}")
+        files.append(
+            {
+                "path": repo_path,
+                "content": source.read_bytes(),
+                "mode": "100755" if os.access(source, os.X_OK) else "100644",
+            }
+        )
+    return files
+
+
+def create_tree_items(
+    files: list[dict[str, object]], token: str
+) -> list[dict[str, str]]:
+    tree_items = []
+    for index, file_info in enumerate(files, start=1):
+        blob_sha = create_blob(
+            REPO_OWNER, REPO_NAME, file_info["content"], token  # type: ignore[arg-type]
+        )
+        tree_items.append(
+            {
+                "path": file_info["path"],
+                "mode": file_info["mode"],
+                "type": "blob",
+                "sha": blob_sha,
+            }
+        )
+        print(f"Created blob {index}/{len(files)}: {file_info['path']}")
+    return tree_items
+
+
+def publish(files: list[dict[str, object]], commit_message: str) -> None:
+    token = os.getenv("GITHUB_TOKEN")
+    if not token:
+        print("Error: GITHUB_TOKEN environment variable not set")
+        sys.exit(1)
+
+    perm = verify_token_permissions(REPO_OWNER, REPO_NAME, token)
+    if perm == "rate_limited":
+        print("GitHub API rate-limited, skipping upload.")
+        return
+    if not perm:
+        print("Token permission verification failed.")
+        sys.exit(1)
+
+    try:
+        tree_items = create_tree_items(files, token)
+    except Exception as exc:
+        if is_rate_limit_error(exc):
+            print("Rate-limited during blob creation, skipping.")
+            return
+        if is_permission_error(exc):
+            print(f"ERROR: permission denied to {REPO_OWNER}/{REPO_NAME}")
+            sys.exit(1)
+        raise
+
+    for attempt in range(5):
+        try:
+            branch_sha = get_branch_sha(REPO_OWNER, REPO_NAME, BRANCH, token)
+            tree_sha = get_tree_sha(REPO_OWNER, REPO_NAME, branch_sha, token)
+            new_tree_sha = create_tree(REPO_OWNER, REPO_NAME, tree_sha, tree_items, token)
+            commit_sha = create_commit(
+                REPO_OWNER, REPO_NAME, new_tree_sha, branch_sha, commit_message, token
+            )
+            update_branch_ref(REPO_OWNER, REPO_NAME, BRANCH, commit_sha, token)
+            print(f"Successfully published {len(files)} file(s): {commit_sha}")
+            return
+        except Exception as exc:
+            if is_rate_limit_error(exc):
+                print("Rate-limited, skipping.")
+                return
+            if is_permission_error(exc):
+                print(f"ERROR: permission denied to {REPO_OWNER}/{REPO_NAME}")
+                sys.exit(1)
+
+            retryable = isinstance(exc, HTTPError) and exc.code in {
+                422,
+                500,
+                502,
+                503,
+                504,
+            }
+            if hasattr(exc, "error_body"):
+                retryable = retryable or "Update is not a fast forward" in exc.error_body
+                retryable = retryable or "Object does not exist" in exc.error_body
+            if retryable and attempt < 4:
+                wait = 2**attempt
+                print(f"Attempt {attempt + 1}/5 failed, retrying in {wait}s...")
+                time.sleep(wait)
+                continue
+            raise
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-root", required=True)
+    parser.add_argument("--paths-file", required=True)
+    parser.add_argument("--commit-message", required=True)
+    args = parser.parse_args()
+
+    paths = read_paths(args.paths_file)
+    if not paths:
+        raise ValueError("No paths to publish")
+    files = collect_files(args.source_root, paths)
+    print(f"Publishing {len(files)} file(s) to {REPO_OWNER}/{REPO_NAME}:{BRANCH}")
+    publish(files, args.commit_message)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Extend the existing `diffusion-ci-gt-gen.yml` workflow so it can sync a small preset of `sglang-ci-data` files through the same `GH_PAT_FOR_NIGHTLY_CI_DATA` publishing path.

## Why

`ltx_2.3_one_stage_ti2v` loads GT from `diffusion-ci/consistency_gt/official_generated` before the top-level `consistency_gt` directory, and its official repro scripts live under `diffusion-ci/repro_scripts`. The existing GT generation workflow only publishes generated image files to top-level `consistency_gt`, so it cannot update this case's effective GT plus repro scripts by itself.

## Changes

- Add optional `ci_data_source_repo`, `ci_data_source_ref`, `ci_data_sync_preset`, and `ci_data_sync_only` workflow inputs.
- Add a `sync-ci-data-files` job to the existing GT workflow.
- Add `scripts/ci/utils/diffusion/publish_ci_data_files.py` to publish selected files via GitHub API while preserving executable mode for scripts.
- Current preset: `ltx23-one-stage-ti2v`.

## How to run after merge

```bash
gh workflow run diffusion-ci-gt-gen.yml \
  --repo sgl-project/sglang \
  --ref main \
  -f ci_data_sync_only=true \
  -f ci_data_source_repo=mickqian/sglang-ci-data-upstream-pr \
  -f ci_data_source_ref=codex/ltx23-one-stage-ti2v-gt \
  -f ci_data_sync_preset=ltx23-one-stage-ti2v
```

This syncs the regenerated `ltx_2.3_one_stage_ti2v` GT images and `gen_official_ltx23.py`/wrapper metadata into `sglang-bot/sglang-ci-data:main` without requiring the caller to have write access to `sglang-ci-data`.

## Validation

- `python3 -m py_compile scripts/ci/utils/diffusion/publish_ci_data_files.py`
- YAML parses locally via Ruby `YAML.load_file`.
- `git diff --check`
- Local collection check finds the 9 expected files from `mickqian/sglang-ci-data-upstream-pr:codex/ltx23-one-stage-ti2v-gt` and preserves `run_official_ltx23.sh` as `100755`.
