### PR TITLE
[diffusion] Add transformer fp8-cast compatibility mode

### DIFF
--- a/docs/diffusion/quantization.md
+++ b/docs/diffusion/quantization.md
@@ -34,6 +34,17 @@ directory directly as `--model-path`, but that is a compatibility path. If a
 repo contains multiple candidate checkpoints, pass
 `--transformer-weights-path` explicitly.
 
+## Transformer FP8-Cast
+
+`--transformer-fp8-cast` is a reference-compatibility mode for transformer
+components whose native implementation declares fp8-cast rules. It rounds the
+selected weights through `torch.float8_e4m3fn` at load time and restores the
+original dtype for inference.
+
+This is not FP8 GEMM and does not load an FP8 checkpoint. It is disabled by
+default because it changes model outputs and is intended only when a model's
+reference pipeline uses this fp8-cast policy.
+
 ## Quant Families
 
 Here, `quant_family` means a checkpoint and loading family with shared CLI

--- a/python/sglang/multimodal_gen/runtime/loader/transformer_load_utils.py
+++ b/python/sglang/multimodal_gen/runtime/loader/transformer_load_utils.py
@@ -259,6 +259,68 @@ class _ModelOptFp8OffloadAdapter(_TransformerQuantAdapter):
         )
 
 
+class _TransformerFp8CastAdapter(_TransformerQuantAdapter):
+    """Adapter for model-declared fp8-cast reference weight rounding."""
+
+    def __init__(
+        self,
+        *,
+        cls_name: str,
+        model_cls: type[nn.Module],
+        server_args: ServerArgs,
+    ) -> None:
+        self.cls_name = cls_name
+        self.model_cls = model_cls
+        self.server_args = server_args
+
+    def get_post_load_hooks(self) -> list[PostLoadHook]:
+        if not self.server_args.transformer_fp8_cast:
+            return []
+
+        should_round_module = getattr(
+            self.model_cls, "should_apply_fp8_cast_to_module", None
+        )
+        if should_round_module is None:
+            logger.warning(
+                "Skipping --transformer-fp8-cast for %s because it does not "
+                "define fp8-cast module rules.",
+                self.cls_name,
+            )
+            return []
+
+        return [
+            partial(
+                self._round_matching_modules_to_fp8,
+                cls_name=self.cls_name,
+                should_round_module=should_round_module,
+            )
+        ]
+
+    @staticmethod
+    def _round_matching_modules_to_fp8(
+        model: nn.Module,
+        *,
+        cls_name: str,
+        should_round_module: Callable[[str, nn.Module], bool],
+    ) -> None:
+        rounded_tensors = 0
+        for name, module in model.named_modules():
+            if not should_round_module(name, module):
+                continue
+            for attr in ("weight", "bias"):
+                param = getattr(module, attr, None)
+                if param is None:
+                    continue
+                dtype = param.data.dtype
+                param.data = param.data.to(torch.float8_e4m3fn).to(dtype)
+                rounded_tensors += 1
+        logger.info(
+            "Applied transformer fp8-cast weight rounding to %d tensors for %s.",
+            rounded_tensors,
+            cls_name,
+        )
+
+
 def resolve_transformer_safetensors_to_load(
     server_args: ServerArgs, component_model_path: str
 ) -> list[str]:
@@ -420,6 +482,11 @@ def _build_transformer_quant_adapters(
         _ModelOptFp8OffloadAdapter(
             server_args=server_args,
             quant_config=quant_config,
+        ),
+        _TransformerFp8CastAdapter(
+            cls_name=cls_name,
+            model_cls=model_cls,
+            server_args=server_args,
         ),
     ]
     if nunchaku_config is not None:

--- a/python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py
@@ -1212,6 +1212,22 @@ class LTX2VideoTransformer3DModel(CachableDiT, OffloadableDiTMixin):
     param_names_mapping = LTX2ArchConfig().param_names_mapping
     reverse_param_names_mapping = LTX2ArchConfig().reverse_param_names_mapping
     lora_param_names_mapping = LTX2ArchConfig().lora_param_names_mapping
+    _fp8_cast_module_suffixes = (
+        ".to_q",
+        ".to_k",
+        ".to_v",
+        ".to_out.0",
+        "ff.proj_in",
+        "ff.proj_out",
+    )
+
+    @classmethod
+    def should_apply_fp8_cast_to_module(
+        cls, name: str, module: nn.Module
+    ) -> bool:
+        return name.startswith("transformer_blocks.") and name.endswith(
+            cls._fp8_cast_module_suffixes
+        )
 
     @staticmethod
     def _collapse_prompt_timestep(timestep: torch.Tensor) -> torch.Tensor:

--- a/python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py
@@ -1222,9 +1222,7 @@ class LTX2VideoTransformer3DModel(CachableDiT, OffloadableDiTMixin):
     )
 
     @classmethod
-    def should_apply_fp8_cast_to_module(
-        cls, name: str, module: nn.Module
-    ) -> bool:
+    def should_apply_fp8_cast_to_module(cls, name: str, module: nn.Module) -> bool:
         return name.startswith("transformer_blocks.") and name.endswith(
             cls._fp8_cast_module_suffixes
         )

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -194,6 +194,7 @@ class ServerArgs(DisaggArgsMixin):
     use_fsdp_inference: bool = False
     pin_cpu_memory: bool = True
     ltx2_two_stage_device_mode: str | None = None
+    transformer_fp8_cast: bool = False
 
     # ComfyUI integration
     comfyui_mode: bool = False
@@ -996,6 +997,16 @@ class ServerArgs(DisaggArgsMixin):
                 "'snapshot' keeps premerged stage2 with snapshot-based release, "
                 "'resident' keeps both transformers resident on GPU. "
                 "Default is auto: resident on H200/high-memory CUDA GPUs, otherwise snapshot."
+            ),
+        )
+        parser.add_argument(
+            "--transformer-fp8-cast",
+            action=StoreBoolean,
+            default=ServerArgs.transformer_fp8_cast,
+            help=(
+                "Round supported transformer weights through float8_e4m3fn at "
+                "load time, then restore the original dtype. This is a "
+                "reference-compatibility mode, not FP8 GEMM. Default is disabled."
             ),
         )
         parser.add_argument(

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -46,6 +46,26 @@ class TestServerArgsPathExpansion(unittest.TestCase):
         )
 
 
+class TestServerArgsCli(unittest.TestCase):
+    def test_transformer_fp8_cast_cli_arg_is_disabled_by_default(self):
+        parser = FlexibleArgumentParser()
+        ServerArgs.add_cli_args(parser)
+
+        args, _ = parser.parse_known_args(["--model-path", "/fake"])
+
+        self.assertFalse(args.transformer_fp8_cast)
+
+    def test_transformer_fp8_cast_cli_arg_can_be_enabled(self):
+        parser = FlexibleArgumentParser()
+        ServerArgs.add_cli_args(parser)
+
+        args, _ = parser.parse_known_args(
+            ["--model-path", "/fake", "--transformer-fp8-cast"]
+        )
+
+        self.assertTrue(args.transformer_fp8_cast)
+
+
 class TestModelIdResolution(unittest.TestCase):
     def setUp(self):
         _get_config_info.cache_clear()
@@ -209,6 +229,23 @@ class TestPipelineResolutionCliOverride(unittest.TestCase):
             server_args = ServerArgs.from_cli_args(args, unknown_args)
 
         self.assertEqual(server_args.pipeline_config.resolution, 768)
+
+    def test_disable_autocast_is_preserved_after_pipeline_config_resolution(self):
+        parser = FlexibleArgumentParser()
+        ServerArgs.add_cli_args(parser)
+        argv = [
+            "--model-path",
+            "Qwen/Qwen-Image-Layered",
+            "--disable-autocast",
+            "true",
+        ]
+
+        with patch.object(sys, "argv", ["sglang"] + argv):
+            args, unknown_args = parser.parse_known_args(argv)
+            server_args = ServerArgs.from_cli_args(args, unknown_args)
+
+        self.assertTrue(server_args.pipeline_config.disable_autocast)
+        self.assertTrue(server_args.disable_autocast)
 
 
 if __name__ == "__main__":

--- a/python/sglang/multimodal_gen/test/unit/test_transformer_quant.py
+++ b/python/sglang/multimodal_gen/test/unit/test_transformer_quant.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import torch
+from torch import nn
 
 partial_json_parser = types.ModuleType("partial_json_parser")
 partial_json_parser_core = types.ModuleType("partial_json_parser.core")
@@ -54,6 +55,7 @@ from sglang.multimodal_gen.runtime.layers.quantization.modelopt_quant import (
 from sglang.multimodal_gen.runtime.loader.transformer_load_utils import (
     _filter_duplicate_precision_variant_safetensors,
     _Flux2Nvfp4FallbackAdapter,
+    _TransformerFp8CastAdapter,
     resolve_transformer_quant_load_spec,
     resolve_transformer_safetensors_to_load,
 )
@@ -73,6 +75,16 @@ class _FakeQuantConfig:
         return "modelopt_fp4"
 
 
+class _FakeFp8CastTransformer(nn.Module):
+    @staticmethod
+    def should_apply_fp8_cast_to_module(name: str, module: nn.Module) -> bool:
+        return name == "blocks.0.match"
+
+
+class _FakeNoFp8CastRuleTransformer(nn.Module):
+    pass
+
+
 class TestTransformerQuantHelpers(unittest.TestCase):
     def _make_server_args(self, **overrides):
         defaults = dict(
@@ -87,6 +99,7 @@ class TestTransformerQuantHelpers(unittest.TestCase):
             tp_size=1,
             dit_cpu_offload=False,
             text_encoder_cpu_offload=False,
+            transformer_fp8_cast=False,
         )
         defaults.update(overrides)
         return SimpleNamespace(**defaults)
@@ -146,6 +159,44 @@ class TestTransformerQuantHelpers(unittest.TestCase):
         resolved = _filter_duplicate_precision_variant_safetensors(files)
 
         self.assertEqual(resolved, files)
+
+    def test_transformer_fp8_cast_hook_rounds_only_model_declared_modules(self):
+        model = nn.Module()
+        model.blocks = nn.ModuleList([nn.Module()])
+        model.blocks[0].match = nn.Linear(2, 2)
+        model.blocks[0].keep = nn.Linear(2, 2)
+
+        match_weight = model.blocks[0].match.weight.detach().clone()
+        keep_weight = model.blocks[0].keep.weight.detach().clone()
+        hook = _TransformerFp8CastAdapter(
+            cls_name=_FakeFp8CastTransformer.__name__,
+            model_cls=_FakeFp8CastTransformer,
+            server_args=self._make_server_args(transformer_fp8_cast=True),
+        ).get_post_load_hooks()[0]
+
+        hook(model)
+
+        torch.testing.assert_close(
+            model.blocks[0].match.weight,
+            match_weight.to(torch.float8_e4m3fn).to(match_weight.dtype),
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(
+            model.blocks[0].keep.weight,
+            keep_weight,
+            rtol=0,
+            atol=0,
+        )
+
+    def test_transformer_fp8_cast_noops_without_model_rule(self):
+        hooks = _TransformerFp8CastAdapter(
+            cls_name=_FakeNoFp8CastRuleTransformer.__name__,
+            model_cls=_FakeNoFp8CastRuleTransformer,
+            server_args=self._make_server_args(transformer_fp8_cast=True),
+        ).get_post_load_hooks()
+
+        self.assertEqual(hooks, [])
 
     @patch(
         "sglang.multimodal_gen.runtime.loader.transformer_load_utils.build_nvfp4_config_from_safetensors_list",


### PR DESCRIPTION
## Summary

Add a default-off transformer fp8-cast compatibility mode for diffusion transformer loaders.

## Changes

- Add `--transformer-fp8-cast` server arg.
- Add a post-load adapter that rounds model-declared transformer weights through `torch.float8_e4m3fn` and restores the original dtype.
- Add LTX2 module selection rules for official fp8-cast compatibility.
- Add unit tests for CLI parsing and adapter behavior.
- Document that this is reference weight rounding, not FP8 GEMM or FP8 checkpoint loading.

