### PR TITLE
[RL] Add tensor bucket builders and use spec-based

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1922,15 +1922,9 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self, names, dtypes, shapes, group_name
     ):
         try:
-            named_tensors = []
-            for name, dtype, shape in zip(names, dtypes, shapes):
-                target_dtype = (
-                    dtype if isinstance(dtype, torch.dtype) else getattr(torch, dtype)
-                )
-                named_tensors.append(
-                    (name, torch.empty(shape, dtype=target_dtype, device=self.device))
-                )
-            bucket = FlattenedTensorBucket(named_tensors=named_tensors)
+            bucket = FlattenedTensorBucket.from_specs(
+                names=names, dtypes=dtypes, shapes=shapes, device=self.device
+            )
             flattened_tensor = bucket.get_flattened_tensor()
             torch.distributed.broadcast(
                 flattened_tensor,

--- a/python/sglang/srt/weight_sync/tensor_bucket.py
+++ b/python/sglang/srt/weight_sync/tensor_bucket.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
-from typing import List, Tuple
+from typing import List, Tuple, Union
 
+import numpy as np
 import torch
 
 
@@ -27,57 +28,20 @@ class FlattenedTensorBucket:
 
     def __init__(
         self,
-        named_tensors: List[Tuple[str, torch.Tensor]] = None,
-        flattened_tensor: torch.Tensor = None,
-        metadata: List[FlattenedTensorMetadata] = None,
+        flattened_tensor: torch.Tensor,
+        metadata: List[FlattenedTensorMetadata],
     ):
         """
-        Initialize a tensor bucket from a list of named tensors OR from pre-flattened data.
+        Initialize a tensor bucket from pre-flattened data.
         Args:
-            named_tensors: List of (name, tensor) tuples (for creating new bucket)
             flattened_tensor: Pre-flattened tensor (for reconstruction)
             metadata: Pre-computed metadata (for reconstruction)
         """
-        if named_tensors is not None:
-            # Create bucket from named tensors
-            self.metadata: List[FlattenedTensorMetadata] = [None] * len(named_tensors)
-            self.flattened_tensor: torch.Tensor = None
-
-            if not named_tensors:
-                raise ValueError("Cannot create empty tensor bucket")
-
-            # Collect metadata and flatten tensors
-            current_idx = 0
-            flattened_tensors: List[torch.Tensor] = [None] * len(named_tensors)
-
-            for i, (name, tensor) in enumerate(named_tensors):
-                flattened = tensor.flatten().view(torch.uint8)
-                flattened_tensors[i] = flattened
-
-                # Store metadata
-
-                numel = flattened.numel()
-                metadata_obj = FlattenedTensorMetadata(
-                    name=name,
-                    shape=tensor.shape,
-                    dtype=tensor.dtype,
-                    start_idx=current_idx,
-                    end_idx=current_idx + numel,
-                    numel=numel,
-                )
-                self.metadata[i] = metadata_obj
-                current_idx += numel
-
-            # Concatenate all flattened tensors
-            self.flattened_tensor = torch.cat(flattened_tensors, dim=0)
-        else:
-            # Initialize from pre-flattened data
-            if flattened_tensor is None or metadata is None:
-                raise ValueError(
-                    "Must provide either named_tensors or both flattened_tensor and metadata"
-                )
-            self.flattened_tensor = flattened_tensor
-            self.metadata = metadata
+        # Initialize from pre-flattened data
+        if flattened_tensor is None or metadata is None:
+            raise ValueError("Must provide both flattened_tensor and metadata")
+        self.flattened_tensor = flattened_tensor
+        self.metadata = metadata
 
     def get_flattened_tensor(self) -> torch.Tensor:
         """Get the flattened tensor containing all bucket tensors"""
@@ -105,3 +69,67 @@ class FlattenedTensorBucket:
             reconstructed[i] = (meta.name, tensor)
 
         return reconstructed
+
+    @classmethod
+    def from_tensors(cls, named_tensors: List[Tuple[str, torch.Tensor]]):
+        # Create bucket from named tensors
+        if not named_tensors:
+            raise ValueError("Cannot create empty tensor bucket")
+
+        current_idx = 0
+        metadata: List[FlattenedTensorMetadata] = [None] * len(named_tensors)
+        # Collect metadata and flatten tensors
+        flattened_tensors: List[torch.Tensor] = [None] * len(named_tensors)
+
+        for i, (name, tensor) in enumerate(named_tensors):
+            flattened = tensor.flatten().view(torch.uint8)
+            flattened_tensors[i] = flattened
+
+            # Store metadata
+            numel = flattened.numel()
+            metadata_obj = FlattenedTensorMetadata(
+                name=name,
+                shape=tensor.shape,
+                dtype=tensor.dtype,
+                start_idx=current_idx,
+                end_idx=current_idx + numel,
+                numel=numel,
+            )
+            metadata[i] = metadata_obj
+            current_idx += numel
+
+        # Concatenate all flattened tensors
+        flattened_tensor = torch.cat(flattened_tensors, dim=0)
+        return cls(flattened_tensor=flattened_tensor, metadata=metadata)
+
+    @classmethod
+    def from_specs(
+        cls,
+        names: List[str],
+        dtypes: List[Union[str, torch.dtype]],
+        shapes: List[torch.Size],
+        device: Union[torch.device, str],
+    ):
+        if not names or not (len(names) == len(dtypes) == len(shapes)):
+            raise ValueError("Cannot create empty specs")
+        current_idx = 0
+        metadata: List[FlattenedTensorMetadata] = [None] * len(names)
+        for i, (name, dtype, shape) in enumerate(zip(names, dtypes, shapes)):
+            target_dtype = (
+                dtype if isinstance(dtype, torch.dtype) else getattr(torch, dtype)
+            )
+            numel = np.prod(shape) * target_dtype.itemsize
+            metadata_obj = FlattenedTensorMetadata(
+                name=name,
+                shape=shape,
+                dtype=target_dtype,
+                start_idx=current_idx,
+                end_idx=current_idx + numel,
+                numel=numel,
+            )
+            metadata[i] = metadata_obj
+            current_idx += numel
+        flattened_tensor = torch.empty(
+            metadata[-1].end_idx, dtype=torch.uint8, device=device
+        )
+        return cls(flattened_tensor=flattened_tensor, metadata=metadata)

--- a/python/sglang/srt/weight_sync/tensor_bucket.py
+++ b/python/sglang/srt/weight_sync/tensor_bucket.py
@@ -1,7 +1,7 @@
+import math
 from dataclasses import dataclass
 from typing import List, Tuple, Union
 
-import numpy as np
 import torch
 
 
@@ -118,7 +118,7 @@ class FlattenedTensorBucket:
             target_dtype = (
                 dtype if isinstance(dtype, torch.dtype) else getattr(torch, dtype)
             )
-            numel = np.prod(shape) * target_dtype.itemsize
+            numel = math.prod(shape) * target_dtype.itemsize
             metadata_obj = FlattenedTensorMetadata(
                 name=name,
                 shape=shape,

--- a/test/registered/rl/test_lora_load_from_tensor.py
+++ b/test/registered/rl/test_lora_load_from_tensor.py
@@ -335,7 +335,9 @@ class TestLoRALoadFromTensor(CustomTestCase):
         from sglang.srt.weight_sync.tensor_bucket import FlattenedTensorBucket
 
         named_tensors = list(self.lora_tensors.items())
-        bucket = FlattenedTensorBucket(named_tensors=[(n, t) for n, t in named_tensors])
+        bucket = FlattenedTensorBucket.from_tensors(
+            named_tensors=[(n, t) for n, t in named_tensors]
+        )
         bucket_dict = {
             "flattened_tensor": bucket.get_flattened_tensor(),
             "metadata": bucket.get_metadata(),

--- a/test/registered/rl/test_update_weights_from_distributed.py
+++ b/test/registered/rl/test_update_weights_from_distributed.py
@@ -81,7 +81,7 @@ def _warmup_broadcast(
         named_tensors = [
             (name, hf_base_model.get_parameter(name)) for name in broadcast_parameters
         ]
-        bucket = FlattenedTensorBucket(named_tensors=named_tensors)
+        bucket = FlattenedTensorBucket.from_tensors(named_tensors=named_tensors)
         flattened_tensor = bucket.get_flattened_tensor()
         torch.distributed.broadcast(flattened_tensor, src=0, group=group)
     else:
@@ -261,7 +261,7 @@ def init_process_hf(
             (parameter_name, hf_base_model.get_parameter(parameter_name))
             for parameter_name in broadcast_parameters
         ]
-        bucket = FlattenedTensorBucket(named_tensors=named_tensors)
+        bucket = FlattenedTensorBucket.from_tensors(named_tensors=named_tensors)
         flattened_tensor = bucket.get_flattened_tensor()
         torch.distributed.broadcast(flattened_tensor, src=0, group=group)
     else:

--- a/test/registered/rl/test_update_weights_from_tensor.py
+++ b/test/registered/rl/test_update_weights_from_tensor.py
@@ -148,7 +148,7 @@ class TestUpdateWeightsFromTensor(CustomTestCase):
             new_tensors.append((name, new_tensor))
 
         # Create a flattened bucket
-        flattened_bucket = FlattenedTensorBucket(named_tensors=new_tensors)
+        flattened_bucket = FlattenedTensorBucket.from_tensors(named_tensors=new_tensors)
 
         # Extract the flattened tensor and metadata in the format expected by model_runner
         flattened_tensor = flattened_bucket.get_flattened_tensor()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

In the flattened_bucket path of `update_weights_from_distributed`, the current flow allocates a separate `torch.empty(shape, dtype)` tensor for each parameter in the bucket, then passes them through `FlattenedTensorBucket(named_tensors=...)` which flattens, views as uint8 and concatenates via torch.cat into a contiguous buffer. When the bucket contains a large number of parameters, the GPU memory allocation and gc of these intermediate tensors becomes a significant overhead. 

## Modifications

- Add `FlattenedTensorBucket.from_specs` classesmethod that pre-computes byte offsets from tensor specs and allocates the flattened buffer, eliminating per-tensor allocation, flatten, and concatenation.
- Update `update_weights_from_distributed` to use `FlattenedTensorBucket.from_specs`

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

Test setup:
- Model: Qwen3-30B-A3B
- Bucket size: ~8G
- Update iterations: 5 consecutive calls
- Hardware: H200 with TP=4 EP=4

First run (cold):
| Phase | Before | After | Speedup |
| --- | --- | --- | --- |
| Bucket creation | 160.7ms | 8.7ms | 18.5x |
| Broadcast | 812.4ms | 640.7ms | 1.3x |
| Load weights | 26.7ms | 26.5ms | ~1.0x |
| Total | 999.7ms | 675.9ms | 1.5x |

Steady state (avg of runs 3-5):
| Phase | Before | After | Speedup |
| --- | --- | --- | --- |
| Bucket creation | 194.5ms | 7.1ms | 27.4xx |
| Broadcast | 4.4ms | 4.2ms | ~1.0x |
| Load weights | 23.5ms | 23.0ms | ~1.0x |
| Total | 222.4ms | 34.3ms | 6.5x |

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
