### PR TITLE
Fix HiSparse prefill admission capacity for DeepSeek V4

### DIFF
--- a/python/sglang/srt/mem_cache/hisparse_memory_pool.py
+++ b/python/sglang/srt/mem_cache/hisparse_memory_pool.py
@@ -518,13 +518,14 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
 
         self.dtype = self.hisparse_kvcache.dtype
         self.device = self.hisparse_kvcache.device
-        self.page_size = self.hisparse_kvcache.page_size
+        self.page_size = logical_attn_allocator.page_size
+        self.hisparse_page_size = self.hisparse_kvcache.page_size
 
         self.logical_attn_allocator = logical_attn_allocator
         self._kvcache = logical_attn_allocator._kvcache
         self.hisparse_attn_allocator = PagedTokenToKVPoolAllocator(
             self._size_hisparse,
-            self.page_size,
+            self.hisparse_page_size,
             self.dtype,
             self.device,
             self.hisparse_kvcache,
@@ -534,7 +535,7 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         self.full_to_hisparse_device_index_mapping = torch.cat(
             [
                 torch.zeros(
-                    self._kvcache.c4_logical_size + self.page_size,
+                    self._kvcache.c4_logical_size + self.hisparse_page_size,
                     dtype=torch.int64,
                     device=self.device,
                 ),
@@ -608,11 +609,11 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         )
 
     def alloc_device_buffer(self, allocated_indices, need_size: int):
-        assert need_size % self.page_size == 0
+        assert need_size % self.hisparse_page_size == 0
         hisparse_indices = self.full_to_hisparse_device_index_mapping[allocated_indices]
         self.full_to_hisparse_device_index_mapping[allocated_indices] = 0
 
-        device_buffer_size = need_size - self.page_size
+        device_buffer_size = need_size - self.hisparse_page_size
         P = len(hisparse_indices)
         if P > device_buffer_size + 1:
             newest_src = hisparse_indices[P - 1].clone()
@@ -624,14 +625,16 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             buffer_indices = hisparse_indices[:need_size]
             surplus = hisparse_indices[need_size:]
             if surplus.numel() > 0:
-                buffer_pages = torch.unique(buffer_indices // self.page_size)
-                surplus_pages = torch.unique(surplus // self.page_size)
+                buffer_pages = torch.unique(buffer_indices // self.hisparse_page_size)
+                surplus_pages = torch.unique(surplus // self.hisparse_page_size)
                 pure_surplus = surplus_pages[~torch.isin(surplus_pages, buffer_pages)]
                 if pure_surplus.numel() > 0:
                     self.hisparse_attn_allocator.is_not_in_free_group = True
-                    self.hisparse_attn_allocator.free(pure_surplus * self.page_size)
+                    self.hisparse_attn_allocator.free(
+                        pure_surplus * self.hisparse_page_size
+                    )
         else:
-            page_residual_length = len(hisparse_indices) % self.page_size
+            page_residual_length = len(hisparse_indices) % self.hisparse_page_size
             if page_residual_length != 0:
                 hisparse_indices = torch.cat(
                     [
@@ -639,7 +642,7 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
                         torch.arange(
                             hisparse_indices[-1] + 1,
                             hisparse_indices[-1]
-                            + self.page_size
+                            + self.hisparse_page_size
                             - page_residual_length
                             + 1,
                             device=self.device,
@@ -683,7 +686,7 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         )
         num_new_pages_hisparse = get_num_new_pages(
             seq_lens=seq_lens_cpu // self.compress_ratio,
-            page_size=self.page_size,
+            page_size=self.hisparse_page_size,
             prefix_lens=prefix_lens_cpu // self.compress_ratio,
         )
         if (
@@ -693,7 +696,7 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             return None
         if (
             num_new_pages_hisparse
-            > self.hisparse_attn_allocator.available_size() // self.page_size
+            > self.hisparse_attn_allocator.available_size() // self.hisparse_page_size
         ):
             return None
 


### PR DESCRIPTION
# Fix HiSparse prefill admission capacity

## Summary

This PR fixes HiSparse allocator page-size accounting for DeepSeek V4.

`HiSparseTokenToKVPoolAllocator` wraps the logical KV allocator, but the wrapper exposed the C4/HiSparse KV pool page size through `self.page_size`. In DeepSeek V4, the wrapped logical allocator can use a larger logical/SWA page size while the C4 HiSparse pool uses a smaller compressed page size. Reusing the C4 page size as the wrapper page size can under-estimate logical allocation demand and allow prefill batches that later fail allocation.

The fix keeps the public wrapper page size aligned with the logical allocator and tracks the C4 pool page size separately:

- `self.page_size` now follows `logical_attn_allocator.page_size`.
- `self.hisparse_page_size` stores `self.hisparse_kvcache.page_size`.
- C4/HiSparse allocator, mapping, device-buffer, and compressed-page accounting use `hisparse_page_size`.

## Why

The scheduler and common KV allocation path use `token_to_kv_pool_allocator.page_size` as the logical allocation unit. For HiSparse, exposing the compressed C4 page size through this field makes admission checks too optimistic when the wrapped logical allocator has a larger page size.

This can lead to a runtime allocation failure in `alloc_extend`, for example when a prefill batch is accepted based on the smaller C4 page size but the underlying logical/SWA allocator cannot satisfy the larger logical-page allocation.

## Scope

This PR intentionally only changes allocator page-size accounting in:

- `python/sglang/srt/mem_cache/hisparse_memory_pool.py`

## Validation

Local validation:

```bash
git diff --check origin/deepseek_v4..HEAD
python -m py_compile \
  python/sglang/srt/mem_cache/hisparse_memory_pool.py \
  python/sglang/srt/managers/scheduler.py
```

Both commands pass.

Runtime validation was also done with DeepSeek V4 SGLang serving on GB200. After separating logical and C4 page-size accounting, the previously failing HiSparse pressure row served successfully instead of hitting the logical allocation assertion.
