### PR TITLE
Support for C4 and C128 state storage bits BF16 on HBM space-constrained gpu(H20)

### DIFF
--- a/python/sglang/jit_kernel/csrc/deepseek_v4/c128.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/c128.cuh
@@ -87,38 +87,48 @@ struct Compress128SharedBuffer {
   }
 };
 
-template <typename T>
+template <typename BufferFloat, typename InputFloat>
 SGL_DEVICE void c128_write(
-    T* kv_score_buf,  //
-    const T* kv_score_src,
+    BufferFloat* kv_score_buf,  //
+    const InputFloat* kv_score_src,
     const int64_t head_dim,
     const int32_t write_pos,
     const uint32_t lane_id) {
   using namespace device;
 
-  using Storage = AlignedVector<T, kTileElements>;
+  using StorageBuffer = AlignedVector<BufferFloat, kTileElements>;
+  using StorageInput = AlignedVector<InputFloat, kTileElements>;
   const auto element_size = head_dim * 2;
-  const auto gmem = tile::Memory<Storage>{lane_id, kWarpThreads};
+  const auto gmem_buffer = tile::Memory<StorageBuffer>{lane_id, kWarpThreads};
+  const auto gmem_input = tile::Memory<StorageInput>{lane_id, kWarpThreads};
   kv_score_buf += write_pos * element_size;
 
   /// NOTE: Layout | [0] = kv | [1] = score |
-  Storage kv_score[2];
+  StorageInput kv_score[2];
+  StorageBuffer kv_score_cast[2];
 #pragma unroll
   for (int32_t i = 0; i < 2; ++i) {
-    kv_score[i] = gmem.load(kv_score_src + head_dim * i);
+    kv_score[i] = gmem_input.load(kv_score_src + head_dim * i);
   }
 #pragma unroll
   for (int32_t i = 0; i < 2; ++i) {
-    gmem.store(kv_score_buf + head_dim * i, kv_score[i]);
+#pragma unroll
+    for (int32_t j = 0; j < kTileElements; ++j) {
+      kv_score_cast[i][j] = cast<BufferFloat>(kv_score[i][j]);
+    }
+  }
+#pragma unroll
+  for (int32_t i = 0; i < 2; ++i) {
+    gmem_buffer.store(kv_score_buf + head_dim * i, kv_score_cast[i]);
   }
 }
 
-template <typename InFloat, typename OutFloat>
+template <typename BufferFloat, typename InputFloat, typename OutFloat>
 SGL_DEVICE void c128_forward(
-    const InFloat* kv_score_buf,
-    const InFloat* kv_score_src,
+    const BufferFloat* kv_score_buf,
+    const InputFloat* kv_score_src,
     OutFloat* kv_out,
-    const InFloat* score_bias,
+    const InputFloat* score_bias,
     const int64_t head_dim,
     const int32_t window_len,
     const uint32_t warp_id,
@@ -129,33 +139,38 @@ SGL_DEVICE void c128_forward(
   const auto score_offset = head_dim;
 
   /// NOTE: part 1: load kv + score
-  using StorageIn = AlignedVector<InFloat, kTileElements>;
-  const auto gmem_in = tile::Memory<StorageIn>{lane_id, kWarpThreads};
-  StorageIn kv[kElementsPerWarp];
-  StorageIn score[kElementsPerWarp];
-  StorageIn bias[kElementsPerWarp];
+  using StorageBuffer = AlignedVector<BufferFloat, kTileElements>;
+  using StorageInput = AlignedVector<InputFloat, kTileElements>;
+  const auto gmem_buffer = tile::Memory<StorageBuffer>{lane_id, kWarpThreads};
+  const auto gmem_input = tile::Memory<StorageInput>{lane_id, kWarpThreads};
+  StorageBuffer kv_hist[kElementsPerWarp];
+  StorageBuffer score_hist[kElementsPerWarp];
+  StorageInput kv_live[kElementsPerWarp];
+  StorageInput score_live[kElementsPerWarp];
+  StorageInput bias[kElementsPerWarp];
   const int32_t warp_offset = warp_id * kElementsPerWarp;
 
 #pragma unroll
   for (int32_t i = 0; i < 8; ++i) {
     const int32_t j = i + warp_offset;
-    bias[i] = gmem_in.load(score_bias + j * head_dim);
+    bias[i] = gmem_input.load(score_bias + j * head_dim);
   }
 
 #pragma unroll
   for (int32_t i = 0; i < kElementsPerWarp; ++i) {
     const int32_t j = i + warp_offset;
-    const InFloat* src;
     __builtin_assume(j < 128);
     if (j < window_len) {
-      src = kv_score_buf + j * element_size;
+      const auto src = kv_score_buf + j * element_size;
+      kv_hist[i] = gmem_buffer.load(src);
+      score_hist[i] = gmem_buffer.load(src + score_offset);
     } else {
       /// NOTE: k in [-127, 0]. We'll load from the ragged `kv_score_src`
       const int32_t k = j - 127;
-      src = kv_score_src + k * element_size;
+      const auto src = kv_score_src + k * element_size;
+      kv_live[i] = gmem_input.load(src);
+      score_live[i] = gmem_input.load(src + score_offset);
     }
-    kv[i] = gmem_in.load(src);
-    score[i] = gmem_in.load(src + score_offset);
   }
 
   /// NOTE: part 2: safe online softmax + weighted sum
@@ -174,7 +189,9 @@ SGL_DEVICE void c128_forward(
 
 #pragma unroll
     for (int32_t j = 0; j < kElementsPerWarp; ++j) {
-      score_fp32[j] = cast<float>(score[j][i]) + cast<float>(bias[j][i]);
+      const float score_value =
+          j + warp_offset < window_len ? cast<float>(score_hist[j][i]) : cast<float>(score_live[j][i]);
+      score_fp32[j] = score_value + cast<float>(bias[j][i]);
     }
 
     float max_value = score_fp32[0];
@@ -191,7 +208,9 @@ SGL_DEVICE void c128_forward(
     for (int32_t j = 0; j < 8; ++j) {
       const auto fp32_score = score_fp32[j];
       const auto exp_score = expf(fp32_score - max_value);
-      sum_product += cast<float>(kv[j][i]) * exp_score;
+      const float kv_value =
+          j + warp_offset < window_len ? cast<float>(kv_hist[j][i]) : cast<float>(kv_live[j][i]);
+      sum_product += kv_value * exp_score;
       sum_exp_value += exp_score;
     }
 
@@ -241,7 +260,7 @@ SGL_DEVICE void c128_forward(
   }
 }
 
-template <int64_t kHeadDim, typename InFloat, typename OutFloat, bool kUsePDL>
+template <int64_t kHeadDim, typename BufferFloat, typename InputFloat, typename OutFloat, bool kUsePDL>
 C128_KERNEL void flash_c128_decode(const __grid_constant__ Compress128DecodeParams params) {
   using namespace device;
 
@@ -266,11 +285,11 @@ C128_KERNEL void flash_c128_decode(const __grid_constant__ Compress128DecodePara
   const int64_t split_offset = global_sid * kTileDim;
 
   // kv score
-  const auto kv_score_buffer = static_cast<InFloat*>(_kv_score_buffer);
+  const auto kv_score_buffer = static_cast<BufferFloat*>(_kv_score_buffer);
   const auto kv_buf = kv_score_buffer + index * (kElementSize * 128) + split_offset;
 
   // kv input
-  const auto kv_score_input = static_cast<const InFloat*>(_kv_score_input);
+  const auto kv_score_input = static_cast<const InputFloat*>(_kv_score_input);
   const auto kv_src = kv_score_input + global_bid * kElementSize + split_offset;
 
   // kv output
@@ -278,7 +297,7 @@ C128_KERNEL void flash_c128_decode(const __grid_constant__ Compress128DecodePara
   const auto kv_out = kv_compressed_output + global_bid * kHeadDim + split_offset;
 
   // score bias (ape)
-  const auto score_bias = static_cast<const InFloat*>(_score_bias) + split_offset;
+  const auto score_bias = static_cast<const InputFloat*>(_score_bias) + split_offset;
 
   PDLWaitPrimary<kUsePDL>();
 
@@ -296,7 +315,7 @@ C128_KERNEL void flash_c128_decode(const __grid_constant__ Compress128DecodePara
 }
 
 // compress kernel
-template <int64_t kHeadDim, typename InFloat, typename OutFloat, bool kWrite, bool kUsePDL>
+template <int64_t kHeadDim, typename BufferFloat, typename InputFloat, typename OutFloat, bool kWrite, bool kUsePDL>
 C128_KERNEL void flash_c128_prefill(const __grid_constant__ Compress128PrefillParams params) {
   using namespace device;
 
@@ -334,7 +353,7 @@ C128_KERNEL void flash_c128_prefill(const __grid_constant__ Compress128PrefillPa
   const int64_t split_offset = global_sid * kTileDim;
 
   // kv input
-  const auto kv_score_input = static_cast<const InFloat*>(_kv_score_input);
+  const auto kv_score_input = static_cast<const InputFloat*>(_kv_score_input);
   const auto kv_src = kv_score_input + ragged_id * kElementSize + split_offset;
 
   // kv output
@@ -342,14 +361,14 @@ C128_KERNEL void flash_c128_prefill(const __grid_constant__ Compress128PrefillPa
   const auto kv_out = kv_compressed_output + ragged_id * kHeadDim + split_offset;
 
   // score bias (ape)
-  const auto score_bias = static_cast<const InFloat*>(_score_bias) + split_offset;
+  const auto score_bias = static_cast<const InputFloat*>(_score_bias) + split_offset;
 
   if (ragged_id == 0xFFFFFFFF) [[unlikely]]
     return;
 
   const int32_t index = indices_ptr[global_bid];
   // kv score
-  const auto kv_score_buffer = static_cast<InFloat*>(_kv_score_buffer);
+  const auto kv_score_buffer = static_cast<BufferFloat*>(_kv_score_buffer);
   const auto kv_buf = kv_score_buffer + index * (kElementSize * 128) + split_offset;
 
   PDLWaitPrimary<kUsePDL>();
@@ -364,11 +383,13 @@ C128_KERNEL void flash_c128_prefill(const __grid_constant__ Compress128PrefillPa
   PDLTriggerSecondary<kUsePDL>();
 }
 
-template <int64_t kHeadDim, typename InFloat, typename OutFloat, bool kUsePDL>
+template <int64_t kHeadDim, typename BufferFloat, typename InputFloat, typename OutFloat, bool kUsePDL>
 struct FlashCompress128Kernel {
-  static constexpr auto decode_kernel = flash_c128_decode<kHeadDim, InFloat, OutFloat, kUsePDL>;
+  static constexpr auto decode_kernel =
+      flash_c128_decode<kHeadDim, BufferFloat, InputFloat, OutFloat, kUsePDL>;
   template <bool kWrite>
-  static constexpr auto prefill_kernel = flash_c128_prefill<kHeadDim, InFloat, OutFloat, kWrite, kUsePDL>;
+  static constexpr auto prefill_kernel =
+      flash_c128_prefill<kHeadDim, BufferFloat, InputFloat, OutFloat, kWrite, kUsePDL>;
   static constexpr auto prefill_c_kernel = prefill_kernel</*kWrite=*/false>;
   static constexpr auto prefill_w_kernel = prefill_kernel</*kWrite=*/true>;
   static constexpr int64_t kTileDim = kTileElements * device::kWarpThreads;  // 64
@@ -392,11 +413,11 @@ struct FlashCompress128Kernel {
     device.set_options<kDLCUDA>();
 
     TensorMatcher({-1, 128, kHeadDim * 2})  // kv score
-        .with_dtype<InFloat>()
+        .with_dtype<BufferFloat>()
         .with_device(device)
         .verify(kv_score_buffer);
     TensorMatcher({B, kHeadDim * 2})  // kv score input
-        .with_dtype<InFloat>()
+        .with_dtype<InputFloat>()
         .with_device(device)
         .verify(kv_score_input);
     TensorMatcher({B, kHeadDim})  // kv compressed output
@@ -404,7 +425,7 @@ struct FlashCompress128Kernel {
         .with_device(device)
         .verify(kv_compressed_output);
     TensorMatcher({128, kHeadDim})  // ape
-        .with_dtype<InFloat>()
+        .with_dtype<InputFloat>()
         .with_device(device)
         .verify(ape);
     TensorMatcher({B})  // indices
@@ -451,11 +472,11 @@ struct FlashCompress128Kernel {
     device_.set_options<kDLCUDA>();
 
     TensorMatcher({-1, 128, kHeadDim * 2})  // kv score
-        .with_dtype<InFloat>()
+        .with_dtype<BufferFloat>()
         .with_device(device_)
         .verify(kv_score_buffer);
     TensorMatcher({N, kHeadDim * 2})  // kv score input
-        .with_dtype<InFloat>()
+        .with_dtype<InputFloat>()
         .with_device(device_)
         .verify(kv_score_input);
     TensorMatcher({N, kHeadDim})  // kv compressed output
@@ -463,7 +484,7 @@ struct FlashCompress128Kernel {
         .with_device(device_)
         .verify(kv_compressed_output);
     TensorMatcher({128, kHeadDim})  // ape
-        .with_dtype<InFloat>()
+        .with_dtype<InputFloat>()
         .with_device(device_)
         .verify(ape);
     TensorMatcher({B})  // indices

--- a/python/sglang/jit_kernel/csrc/deepseek_v4/c4.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/c4.cuh
@@ -86,41 +86,51 @@ struct Compress4PrefillParams {
   uint32_t num_write;
 };
 
-template <typename T>
+template <typename BufferFloat, typename InputFloat>
 SGL_DEVICE void c4_write(
-    T* kv_score_buf,  //
-    const T* kv_score_src,
+    BufferFloat* kv_score_buf,  //
+    const InputFloat* kv_score_src,
     const int64_t head_dim,
     const int32_t write_pos) {
   using namespace device;
 
-  using Storage = AlignedVector<T, kTileElements>;
+  using StorageBuffer = AlignedVector<BufferFloat, kTileElements>;
+  using StorageInput = AlignedVector<InputFloat, kTileElements>;
   const auto element_size = head_dim * 4;
-  const auto gmem = tile::Memory<Storage>::warp();
+  const auto gmem_buffer = tile::Memory<StorageBuffer>::warp();
+  const auto gmem_input = tile::Memory<StorageInput>::warp();
   kv_score_buf += write_pos * element_size;
 
   /// NOTE: Layout | [0] = kv overlap | [1] = kv | [2] = score overlap | [3] = score |
-  Storage kv_score[4];
+  StorageInput kv_score[4];
+  StorageBuffer kv_score_cast[4];
 #pragma unroll
   for (int32_t i = 0; i < 4; ++i) {
-    kv_score[i] = gmem.load(kv_score_src + head_dim * i);
+    kv_score[i] = gmem_input.load(kv_score_src + head_dim * i);
   }
 #pragma unroll
   for (int32_t i = 0; i < 4; ++i) {
-    gmem.store(kv_score_buf + head_dim * i, kv_score[i]);
+#pragma unroll
+    for (int32_t j = 0; j < kTileElements; ++j) {
+      kv_score_cast[i][j] = cast<BufferFloat>(kv_score[i][j]);
+    }
+  }
+#pragma unroll
+  for (int32_t i = 0; i < 4; ++i) {
+    gmem_buffer.store(kv_score_buf + head_dim * i, kv_score_cast[i]);
   }
 }
 
-template <bool kPaged, typename InFloat, typename OutFloat>
+template <bool kPaged, typename BufferFloat, typename InputFloat, typename OutFloat>
 SGL_DEVICE void c4_forward(
-    const InFloat* kv_score_buf,
-    const InFloat* kv_score_src,
+    const BufferFloat* kv_score_buf,
+    const InputFloat* kv_score_src,
     OutFloat* kv_out,
-    const InFloat* score_bias,
+    const InputFloat* score_bias,
     const int64_t head_dim,
     const int32_t seq_len,
     const int32_t window_len,
-    [[maybe_unused]] const InFloat* kv_score_overlap_buf = nullptr) {
+    [[maybe_unused]] const BufferFloat* kv_score_overlap_buf = nullptr) {
   using namespace device;
 
   const auto element_size = head_dim * 4;
@@ -128,39 +138,45 @@ SGL_DEVICE void c4_forward(
   const auto overlap_stride = head_dim;
 
   /// NOTE: part 1: load kv + score
-  using StorageIn = AlignedVector<InFloat, kTileElements>;
-  const auto gmem_in = tile::Memory<StorageIn>::warp();
-  StorageIn kv[8];
-  StorageIn score[8];
-  StorageIn bias[8];
+  using StorageBuffer = AlignedVector<BufferFloat, kTileElements>;
+  using StorageInput = AlignedVector<InputFloat, kTileElements>;
+  const auto gmem_buffer = tile::Memory<StorageBuffer>::warp();
+  const auto gmem_input = tile::Memory<StorageInput>::warp();
+  StorageBuffer kv_hist[8];
+  StorageBuffer score_hist[8];
+  StorageInput kv_live[8];
+  StorageInput score_live[8];
+  StorageInput bias[8];
 
 #pragma unroll
   for (int32_t i = 0; i < 8; ++i) {
-    bias[i] = gmem_in.load(score_bias + i * head_dim);
+    bias[i] = gmem_input.load(score_bias + i * head_dim);
   }
 
 #pragma unroll
   for (int32_t i = 0; i < 8; ++i) {
     const bool is_overlap = i < 4;
-    const InFloat* src;
     if (i < window_len) {
       /// NOTE: `seq_len` must be a multiple of 4 here
       if constexpr (kPaged) {
         const auto kv_score_ptr = is_overlap ? kv_score_overlap_buf : kv_score_buf;
         const int32_t k = i % 4;
-        src = kv_score_ptr + k * element_size;
+        const auto src = kv_score_ptr + k * element_size + (is_overlap ? 0 : overlap_stride);
+        kv_hist[i] = gmem_buffer.load(src);
+        score_hist[i] = gmem_buffer.load(src + score_offset);
       } else {
         const int32_t k = (seq_len + i) % 8;
-        src = kv_score_buf + k * element_size;
+        const auto src = kv_score_buf + k * element_size + (is_overlap ? 0 : overlap_stride);
+        kv_hist[i] = gmem_buffer.load(src);
+        score_hist[i] = gmem_buffer.load(src + score_offset);
       }
     } else {
       /// NOTE: k in [-7, 0]. We'll load from the ragged `kv_score_src`
       const int32_t k = i - 7;
-      src = kv_score_src + k * element_size;
+      const auto src = kv_score_src + k * element_size + (is_overlap ? 0 : overlap_stride);
+      kv_live[i] = gmem_input.load(src);
+      score_live[i] = gmem_input.load(src + score_offset);
     }
-    src += (is_overlap ? 0 : overlap_stride);
-    kv[i] = gmem_in.load(src);
-    score[i] = gmem_in.load(src + score_offset);
   }
 
   if (seq_len == 4) {
@@ -168,8 +184,8 @@ SGL_DEVICE void c4_forward(
     constexpr float kFloatNegInf = -1e9f;
 #pragma unroll
     for (int32_t i = 0; i < 4; ++i) {
-      kv[i].fill(cast<InFloat>(0.0f));
-      score[i].fill(cast<InFloat>(kFloatNegInf));
+      kv_hist[i].fill(cast<BufferFloat>(0.0f));
+      score_hist[i].fill(cast<BufferFloat>(kFloatNegInf));
     }
   }
 
@@ -184,7 +200,9 @@ SGL_DEVICE void c4_forward(
 
 #pragma unroll
     for (int32_t j = 0; j < 8; ++j) {
-      score_fp32[j] = cast<float>(score[j][i]) + cast<float>(bias[j][i]);
+      const float score_value =
+          j < window_len ? cast<float>(score_hist[j][i]) : cast<float>(score_live[j][i]);
+      score_fp32[j] = score_value + cast<float>(bias[j][i]);
     }
 
     float max_value = score_fp32[0];
@@ -201,7 +219,9 @@ SGL_DEVICE void c4_forward(
     for (int32_t j = 0; j < 8; ++j) {
       const auto fp32_score = score_fp32[j];
       const auto exp_score = expf(fp32_score - max_value);
-      sum_product += cast<float>(kv[j][i]) * exp_score;
+      const float kv_value =
+          j < window_len ? cast<float>(kv_hist[j][i]) : cast<float>(kv_live[j][i]);
+      sum_product += kv_value * exp_score;
       sum_exp_value += exp_score;
     }
 
@@ -211,7 +231,7 @@ SGL_DEVICE void c4_forward(
   gmem_out.store(kv_out, result);
 }
 
-template <int64_t kHeadDim, typename InFloat, typename OutFloat, PageMode kMode, bool kUsePDL>
+template <int64_t kHeadDim, typename BufferFloat, typename InputFloat, typename OutFloat, PageMode kMode, bool kUsePDL>
 C4_KERNEL void flash_c4_decode(const __grid_constant__ Compress4DecodeParams params) {
   using namespace device;
 
@@ -236,10 +256,10 @@ C4_KERNEL void flash_c4_decode(const __grid_constant__ Compress4DecodeParams par
   const int64_t split_offset = global_sid * kTileDim;
 
   // kv score
-  const auto kv_score_buffer = static_cast<InFloat*>(_kv_score_buffer);
+  const auto kv_score_buffer = static_cast<BufferFloat*>(_kv_score_buffer);
 
   // kv input
-  const auto kv_score_input = static_cast<const InFloat*>(_kv_score_input);
+  const auto kv_score_input = static_cast<const InputFloat*>(_kv_score_input);
   const auto kv_src = kv_score_input + global_bid * kElementSize + split_offset;
 
   // kv output
@@ -247,7 +267,7 @@ C4_KERNEL void flash_c4_decode(const __grid_constant__ Compress4DecodeParams par
   const auto kv_out = kv_compressed_output + global_bid * kHeadDim + split_offset;
 
   // score bias (ape)
-  const auto score_bias = static_cast<const InFloat*>(_score_bias) + split_offset;
+  const auto score_bias = static_cast<const InputFloat*>(_score_bias) + split_offset;
 
   PDLWaitPrimary<kUsePDL>();
 
@@ -272,7 +292,7 @@ C4_KERNEL void flash_c4_decode(const __grid_constant__ Compress4DecodeParams par
   PDLTriggerSecondary<kUsePDL>();
 }
 
-template <int64_t kHeadDim, typename InFloat, typename OutFloat, PageMode kMode, bool kWrite, bool kUsePDL>
+template <int64_t kHeadDim, typename BufferFloat, typename InputFloat, typename OutFloat, PageMode kMode, bool kWrite, bool kUsePDL>
 C4_KERNEL void flash_c4_prefill(const __grid_constant__ Compress4PrefillParams params) {
   using namespace device;
 
@@ -300,10 +320,10 @@ C4_KERNEL void flash_c4_prefill(const __grid_constant__ Compress4PrefillParams p
   const int64_t split_offset = global_sid * kTileDim;
 
   // kv score
-  const auto kv_score_buffer = static_cast<InFloat*>(_kv_score_buffer);
+  const auto kv_score_buffer = static_cast<BufferFloat*>(_kv_score_buffer);
 
   // kv input
-  const auto kv_score_input = static_cast<const InFloat*>(_kv_score_input);
+  const auto kv_score_input = static_cast<const InputFloat*>(_kv_score_input);
   const auto kv_src = kv_score_input + ragged_id * kElementSize + split_offset;
 
   // kv output
@@ -314,7 +334,7 @@ C4_KERNEL void flash_c4_prefill(const __grid_constant__ Compress4PrefillParams p
     return;
 
   // score bias (ape)
-  const auto score_bias = static_cast<const InFloat*>(_score_bias) + split_offset;
+  const auto score_bias = static_cast<const InputFloat*>(_score_bias) + split_offset;
   const auto seq_len = position + 1;
   const int32_t index = indices[global_bid];
 
@@ -358,12 +378,14 @@ C4_KERNEL void flash_c4_prefill(const __grid_constant__ Compress4PrefillParams p
   PDLTriggerSecondary<kUsePDL>();
 }
 
-template <int64_t kHeadDim, typename InFloat, typename OutFloat, bool kUsePDL>
+template <int64_t kHeadDim, typename BufferFloat, typename InputFloat, typename OutFloat, bool kUsePDL>
 struct FlashCompress4Kernel {
   template <PageMode kMode>
-  static constexpr auto decode_kernel = flash_c4_decode<kHeadDim, InFloat, OutFloat, kMode, kUsePDL>;
+  static constexpr auto decode_kernel =
+      flash_c4_decode<kHeadDim, BufferFloat, InputFloat, OutFloat, kMode, kUsePDL>;
   template <PageMode kMode, bool kWrite>
-  static constexpr auto prefill_kernel = flash_c4_prefill<kHeadDim, InFloat, OutFloat, kMode, kWrite, kUsePDL>;
+  static constexpr auto prefill_kernel =
+      flash_c4_prefill<kHeadDim, BufferFloat, InputFloat, OutFloat, kMode, kWrite, kUsePDL>;
   template <PageMode kMode>
   static constexpr auto prefill_c_kernel = prefill_kernel<kMode, /*kWrite=*/false>;
   template <PageMode kMode>
@@ -393,11 +415,11 @@ struct FlashCompress4Kernel {
     const auto page_size = extra_ptr != nullptr ? 4 : 8;
 
     TensorMatcher({-1, page_size, kHeadDim * 4})  // kv score
-        .with_dtype<InFloat>()
+        .with_dtype<BufferFloat>()
         .with_device(device_)
         .verify(kv_score_buffer);
     TensorMatcher({B, kHeadDim * 4})  // kv score input
-        .with_dtype<InFloat>()
+        .with_dtype<InputFloat>()
         .with_device(device_)
         .verify(kv_score_input);
     TensorMatcher({B, kHeadDim})  // kv compressed output
@@ -405,7 +427,7 @@ struct FlashCompress4Kernel {
         .with_device(device_)
         .verify(kv_compressed_output);
     TensorMatcher({8, kHeadDim})  // ape
-        .with_dtype<InFloat>()
+        .with_dtype<InputFloat>()
         .with_device(device_)
         .verify(ape);
     TensorMatcher({B})  // indices
@@ -457,11 +479,11 @@ struct FlashCompress4Kernel {
     const auto page_size = extra_ptr != nullptr ? 4 : 8;
 
     TensorMatcher({-1, page_size, kHeadDim * 4})  // kv score
-        .with_dtype<InFloat>()
+        .with_dtype<BufferFloat>()
         .with_device(device_)
         .verify(kv_score_buffer);
     TensorMatcher({N, kHeadDim * 4})  // kv score input
-        .with_dtype<InFloat>()
+        .with_dtype<InputFloat>()
         .with_device(device_)
         .verify(kv_score_input);
     TensorMatcher({N, kHeadDim})  // kv compressed output
@@ -469,7 +491,7 @@ struct FlashCompress4Kernel {
         .with_device(device_)
         .verify(kv_compressed_output);
     TensorMatcher({8, kHeadDim})  // ape
-        .with_dtype<InFloat>()
+        .with_dtype<InputFloat>()
         .with_device(device_)
         .verify(ape);
     TensorMatcher({B})  // indices

--- a/python/sglang/jit_kernel/deepseek_v4.py
+++ b/python/sglang/jit_kernel/deepseek_v4.py
@@ -139,6 +139,50 @@ def _jit_compress_module(
         extra_cuda_cflags=["-use_fast_math"],
     )
 
+@cache_once
+def _jit_compress4_module(
+    head_dim: int,
+    dtype_buffer: torch.dtype,
+    dtype_input: torch.dtype,
+    dtype_out: torch.dtype,
+) -> Module:
+    args = make_cpp_args(
+        head_dim, dtype_buffer, dtype_input, dtype_out, is_arch_support_pdl()
+    )
+    kernel_class = f"FlashCompress4Kernel<{args}>"
+    return load_jit(
+        make_name("compress_4_mixed"),
+        *args,
+        cuda_files=["deepseek_v4/c4.cuh"],
+        cuda_wrappers=[
+            ("decode", f"{kernel_class}::run_decode"),
+            ("prefill", f"{kernel_class}::run_prefill"),
+        ],
+        extra_cuda_cflags=["-use_fast_math"],
+    )
+
+
+@cache_once
+def _jit_compress128_module(
+    head_dim: int,
+    dtype_buffer: torch.dtype,
+    dtype_input: torch.dtype,
+    dtype_out: torch.dtype,
+) -> Module:
+    args = make_cpp_args(
+        head_dim, dtype_buffer, dtype_input, dtype_out, is_arch_support_pdl()
+    )
+    kernel_class = f"FlashCompress128Kernel<{args}>"
+    return load_jit(
+        make_name("compress_128_mixed"),
+        *args,
+        cuda_files=["deepseek_v4/c128.cuh"],
+        cuda_wrappers=[
+            ("decode", f"{kernel_class}::run_decode"),
+            ("prefill", f"{kernel_class}::run_prefill"),
+        ],
+        extra_cuda_cflags=["-use_fast_math"],
+    )
 
 @cache_once
 def _jit_compress_module_v2_defensive(
@@ -596,12 +640,27 @@ def compress_forward(
         F = online_module.decode if plan.is_decode else online_module.prefill
         F(kv_score_buffer, kv_score_input, out, ape, indices, *plan[1:], extra_data)
         return out
-    module = _jit_compress_module(
-        head_dim,
-        kv_score_input.dtype,
-        out.dtype,
-        compress_ratio,
-    )
+    if compress_ratio == 4:
+        module = _jit_compress4_module(
+            head_dim,
+            kv_score_buffer.dtype,
+            kv_score_input.dtype,
+            out.dtype,
+        )
+    elif compress_ratio == 128:
+        module = _jit_compress128_module(
+            head_dim,
+            kv_score_buffer.dtype,
+            kv_score_input.dtype,
+            out.dtype,
+        )
+    else:
+        module = _jit_compress_module(
+            head_dim,
+            kv_score_input.dtype,
+            out.dtype,
+            compress_ratio,
+        )
     if plan.is_decode:
         F = module.decode
     elif compress_ratio == 128 and _should_use_c128_prefill_defensive():

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -530,6 +530,7 @@ class Envs:
     SGLANG_HANDLE_C128_PREFILL_KERNEL = EnvBool(False)
     SGLANG_HACK_DEBUG_DUMP_CREATE_PAGED_COMPRESS_DATA = EnvStr("")
     SGLANG_OPT_USE_ONLINE_COMPRESS = EnvBool(False)
+    SGLANG_DSV4_COMPRESS_STATE_DTYPE = EnvStr("float32")
 
     # Dangerous untested flagas
     SGLANG_OPT_USE_FAST_MASK_EP = EnvBool(False)

--- a/python/sglang/srt/mem_cache/deepseekv4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseekv4_memory_pool.py
@@ -374,7 +374,8 @@ class DeepSeekV4TokenToKVPool(KVCache):
         page_size: int,
         swa_page_size: int,
         dtype: torch.dtype,
-        state_dtype: torch.dtype,
+        c4_state_dtype: torch.dtype,
+        c128_state_dtype: torch.dtype,
         qk_nope_head_dim: int,
         qk_rope_head_dim: int,
         indexer_head_dim: int,
@@ -411,7 +412,8 @@ class DeepSeekV4TokenToKVPool(KVCache):
         self.c128_size = c128_size
         self.c4_state_pool_size = c4_state_pool_size
         self.c128_state_pool_size = c128_state_pool_size
-        self.state_dtype = state_dtype
+        self.c4_state_dtype = c4_state_dtype
+        self.c128_state_dtype = c128_state_dtype
         self.compression_ratios = compression_ratios
 
         assert page_size % swa_page_size == 0
@@ -629,7 +631,7 @@ class DeepSeekV4TokenToKVPool(KVCache):
                     ring_size=ring_size,
                     overlap=overlap,
                     head_dim=self.qk_nope_head_dim + self.qk_rope_head_dim,
-                    dtype=self.state_dtype,
+                    dtype=self.c4_state_dtype if ratio == 4 else self.c128_state_dtype,
                     device=self.device,
                     enable_memory_saver=enable_memory_saver,
                     ratio=ratio,
@@ -644,7 +646,7 @@ class DeepSeekV4TokenToKVPool(KVCache):
                     overlap=overlap,
                     head_dim=self.indexer_head_dim,
                     device=self.device,
-                    dtype=self.state_dtype,
+                    dtype=self.c4_state_dtype,
                     enable_memory_saver=enable_memory_saver,
                     ratio=ratio,
                 )

--- a/python/sglang/srt/model_executor/memory_profiler.py
+++ b/python/sglang/srt/model_executor/memory_profiler.py
@@ -15,6 +15,21 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+def _get_dsv4_compress_state_dtype_sizes() -> tuple[int, int]:
+    dtype_name = envs.SGLANG_DSV4_COMPRESS_STATE_DTYPE.get().strip().lower()
+    if dtype_name in ("float32", "fp32"):
+        return 4, 4
+    if dtype_name in ("bfloat16", "bf16"):
+        if envs.SGLANG_OPT_USE_ONLINE_COMPRESS.get():
+            raise ValueError(
+                "SGLANG_DSV4_COMPRESS_STATE_DTYPE=bf16 is not supported when "
+                "SGLANG_OPT_USE_ONLINE_COMPRESS=1; online c128 state must stay float32."
+            )
+        return 2, 2
+    raise ValueError(
+        "Unsupported SGLANG_DSV4_COMPRESS_STATE_DTYPE="
+        f"{dtype_name!r}. Expected one of: float32, fp32, bfloat16, bf16."
+    )
 
 @dataclass
 class DSv4PoolSizes:
@@ -66,14 +81,18 @@ class DSv4MemoryCalculator:
         )
 
         attn_head_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
-        state_dtype_size = 4
-        c4_state_bytes = 2 * 2 * attn_head_dim * state_dtype_size
+        c4_state_dtype_size, c128_state_dtype_size = (
+            _get_dsv4_compress_state_dtype_sizes()
+        )
+        c4_state_bytes = 2 * 2 * attn_head_dim * c4_state_dtype_size
         # Online c128 stores (max, sum, kv) per slot (3*head_dim) instead of
         # raw (kv, score) (2*head_dim). Combined with ring_size=1 this still
         # nets a large reduction (~3/256x) but the per-slot bytes go up.
         c128_online = envs.SGLANG_OPT_USE_ONLINE_COMPRESS.get()
-        c128_state_bytes = (3 if c128_online else 2 * 1) * attn_head_dim * state_dtype_size
-        c4_indexer_state_bytes = 2 * 2 * self.indexer_head_dim * state_dtype_size
+        c128_state_bytes = (
+            (3 if c128_online else 2 * 1) * attn_head_dim * c128_state_dtype_size
+        )
+        c4_indexer_state_bytes = 2 * 2 * self.indexer_head_dim * c4_state_dtype_size
 
         c4_state_ratio = self.c4_ring_size / self.swa_page_size
         c128_state_ratio = self.c128_ring_size / self.swa_page_size

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -50,6 +50,22 @@ MAMBA_CACHE_V2_ADDITIONAL_RATIO_NO_OVERLAP = 1
 
 logger = logging.getLogger(__name__)
 
+def _get_dsv4_compress_state_dtypes() -> tuple[torch.dtype, torch.dtype]:
+    dtype_name = envs.SGLANG_DSV4_COMPRESS_STATE_DTYPE.get().strip().lower()
+    if dtype_name in ("float32", "fp32"):
+        return torch.float32, torch.float32
+    if dtype_name in ("bfloat16", "bf16"):
+        if envs.SGLANG_OPT_USE_ONLINE_COMPRESS.get():
+            raise ValueError(
+                "SGLANG_DSV4_COMPRESS_STATE_DTYPE=bf16 is not supported when "
+                "SGLANG_OPT_USE_ONLINE_COMPRESS=1; online c128 state must stay float32."
+            )
+        return torch.bfloat16, torch.bfloat16
+    raise ValueError(
+        "Unsupported SGLANG_DSV4_COMPRESS_STATE_DTYPE="
+        f"{dtype_name!r}. Expected one of: float32, fp32, bfloat16, bf16."
+    )
+    
 _is_npu = is_npu()
 
 
@@ -282,9 +298,13 @@ class ModelRunnerKVCacheMixin:
     def set_num_tokens_hybrid_swa_compress(self: ModelRunner):
         from sglang.srt.model_executor.memory_profiler import DSv4MemoryCalculator
 
-        self.state_dtype = torch.float32
+        self.c4_state_dtype, self.c128_state_dtype = _get_dsv4_compress_state_dtypes()
         logger.info(f"DSv4 compressed attention: kv_cache_dtype={self.kv_cache_dtype}")
-        logger.info(f"DSv4 compressed attention: state_dtype={self.state_dtype}")
+        logger.info(
+            "DSv4 compressed attention: "
+            f"c4_state_dtype={self.c4_state_dtype}, "
+            f"c128_state_dtype={self.c128_state_dtype}"
+        )
 
         page_size = self.server_args.page_size
         assert (
@@ -547,7 +567,8 @@ class ModelRunnerKVCacheMixin:
                 page_size=self.page_size,
                 swa_page_size=swa_page_size,
                 dtype=self.kv_cache_dtype,
-                state_dtype=self.state_dtype,
+                c4_state_dtype=self.c4_state_dtype,
+                c128_state_dtype=self.c128_state_dtype,
                 qk_nope_head_dim=self.model_config.qk_nope_head_dim,
                 qk_rope_head_dim=self.model_config.qk_rope_head_dim,
                 indexer_head_dim=self.model_config.index_head_dim,

--- a/test/registered/kernels/test_deepseek_v4_c128_compress.py
+++ b/test/registered/kernels/test_deepseek_v4_c128_compress.py
@@ -1,0 +1,102 @@
+import unittest
+
+import torch
+
+from sglang.jit_kernel.deepseek_v4 import compress_forward
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=2, suite="stage-b-test-small-1-gpu")
+
+
+def _cpu_c128_decode_reference(
+    kv_score_buffer: torch.Tensor,
+    ape: torch.Tensor,
+    seq_len: int,
+    head_dim: int,
+) -> torch.Tensor:
+    scores = []
+    kvs = []
+    for i in range(128):
+        j = (seq_len + i) % 128
+        src = kv_score_buffer[0, j]
+        kv = src[:head_dim]
+        score = src[head_dim:]
+        kvs.append(kv.float())
+        scores.append(score.float())
+
+    kv_tensor = torch.stack(kvs, dim=0)
+    score_tensor = torch.stack(scores, dim=0) + ape.float()
+    weights = torch.softmax(score_tensor, dim=0)
+    return (kv_tensor * weights).sum(dim=0)
+
+
+class TestDeepseekV4C128Compress(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA is not available")
+
+    def _run_decode_case(self, buffer_dtype: torch.dtype):
+        device = "cuda"
+        head_dim = 128
+        torch.manual_seed(1)
+
+        kv_score_buffer = torch.zeros(
+            (1, 128, head_dim * 2), dtype=buffer_dtype, device=device
+        )
+        ape = torch.randn((128, head_dim), dtype=torch.float32, device=device)
+        indices = torch.zeros((1,), dtype=torch.int32, device=device)
+
+        ref_buffer = torch.zeros((1, 128, head_dim * 2), dtype=buffer_dtype)
+
+        for seq_len in range(1, 257):
+            kv_score_input = torch.randn(
+                (1, head_dim * 2), dtype=torch.float32, device=device
+            )
+            write_pos = (seq_len + 127) % 128
+            ref_buffer[0, write_pos] = kv_score_input[0].cpu().to(buffer_dtype)
+
+            out = compress_forward(
+                kv_score_buffer=kv_score_buffer,
+                kv_score_input=kv_score_input,
+                ape=ape,
+                indices=indices,
+                head_dim=head_dim,
+                compress_ratio=128,
+                seq_lens=torch.tensor([seq_len], dtype=torch.int32, device=device),
+            )
+
+            self.assertTrue(
+                torch.equal(kv_score_buffer.cpu(), ref_buffer),
+                msg=f"buffer mismatch for seq_len={seq_len}, dtype={buffer_dtype}",
+            )
+
+            if seq_len % 128 != 0:
+                continue
+
+            ref_out = _cpu_c128_decode_reference(
+                ref_buffer,
+                ape.cpu(),
+                seq_len=seq_len,
+                head_dim=head_dim,
+            )
+            atol = 2e-4 if buffer_dtype == torch.float32 else 2e-2
+            rtol = 2e-4 if buffer_dtype == torch.float32 else 2e-2
+            self.assertTrue(
+                torch.allclose(out[0].cpu().float(), ref_out, atol=atol, rtol=rtol),
+                msg=(
+                    f"output mismatch for seq_len={seq_len}, "
+                    f"dtype={buffer_dtype}, "
+                    f"max_diff={(out[0].cpu().float() - ref_out).abs().max().item():.6f}"
+                ),
+            )
+
+    def test_c128_decode_fp32_buffer_fp32_input(self):
+        self._run_decode_case(torch.float32)
+
+    def test_c128_decode_bf16_buffer_fp32_input(self):
+        self._run_decode_case(torch.bfloat16)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/kernels/test_deepseek_v4_c4_compress.py
+++ b/test/registered/kernels/test_deepseek_v4_c4_compress.py
@@ -1,0 +1,151 @@
+import argparse
+from dataclasses import dataclass
+
+import torch
+
+from sglang.jit_kernel.deepseek_v4 import compress_forward
+
+
+@dataclass(frozen=True)
+class BenchCase:
+    name: str
+    buffer_dtype: torch.dtype
+    input_dtype: torch.dtype
+
+
+CASES = [
+    BenchCase("fp32_buffer_fp32_input", torch.float32, torch.float32),
+    BenchCase("bf16_buffer_fp32_input", torch.bfloat16, torch.float32),
+    BenchCase("bf16_buffer_bf16_input", torch.bfloat16, torch.bfloat16),
+]
+
+
+def _make_inputs(
+    case: BenchCase,
+    batch_size: int,
+    head_dim: int,
+    seq_len: int,
+    device: str,
+):
+    torch.manual_seed(42)
+    kv_score_buffer = torch.randn(
+        (batch_size, 8, head_dim * 4),
+        dtype=case.buffer_dtype,
+        device=device,
+    )
+    kv_score_input = torch.randn(
+        (batch_size, head_dim * 4),
+        dtype=case.input_dtype,
+        device=device,
+    )
+    ape = torch.randn(
+        (8, head_dim),
+        dtype=case.input_dtype,
+        device=device,
+    )
+    indices = torch.arange(batch_size, dtype=torch.int32, device=device)
+    seq_lens = torch.full((batch_size,), seq_len, dtype=torch.int32, device=device)
+    return kv_score_buffer, kv_score_input, ape, indices, seq_lens
+
+
+def _run_once(
+    case: BenchCase,
+    batch_size: int,
+    head_dim: int,
+    seq_len: int,
+    device: str,
+):
+    kv_score_buffer, kv_score_input, ape, indices, seq_lens = _make_inputs(
+        case, batch_size, head_dim, seq_len, device
+    )
+    return compress_forward(
+        kv_score_buffer=kv_score_buffer,
+        kv_score_input=kv_score_input,
+        ape=ape,
+        indices=indices,
+        head_dim=head_dim,
+        compress_ratio=4,
+        seq_lens=seq_lens,
+    )
+
+
+def _benchmark_case(
+    case: BenchCase,
+    batch_size: int,
+    head_dim: int,
+    seq_len: int,
+    warmup: int,
+    iters: int,
+    device: str,
+) -> float:
+    for _ in range(warmup):
+        _run_once(case, batch_size, head_dim, seq_len, device)
+    torch.cuda.synchronize()
+
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+    start_event.record()
+    for _ in range(iters):
+        _run_once(case, batch_size, head_dim, seq_len, device)
+    end_event.record()
+    torch.cuda.synchronize()
+    return start_event.elapsed_time(end_event) / iters
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Benchmark DeepSeek V4 C4 compress decode kernel."
+    )
+    parser.add_argument("--batch-size", type=int, default=1024)
+    parser.add_argument("--head-dim", type=int, default=128)
+    parser.add_argument(
+        "--seq-len",
+        type=int,
+        default=8,
+        help="Must be a multiple of 4 to trigger C4 compress compute.",
+    )
+    parser.add_argument("--warmup", type=int, default=50)
+    parser.add_argument("--iters", type=int, default=200)
+    parser.add_argument("--device", type=str, default="cuda")
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required for this benchmark.")
+    if args.head_dim % 128 != 0:
+        raise ValueError("--head-dim must be a multiple of 128.")
+    if args.seq_len % 4 != 0:
+        raise ValueError("--seq-len must be a multiple of 4.")
+
+    print(
+        f"Benchmark config: batch_size={args.batch_size}, "
+        f"head_dim={args.head_dim}, seq_len={args.seq_len}, "
+        f"warmup={args.warmup}, iters={args.iters}"
+    )
+    print("Note: bf16_input cases also use bf16 APE, because the current C4 kernel matches input and APE dtypes.")
+
+    results = {}
+    for case in CASES:
+        mean_ms = _benchmark_case(
+            case,
+            batch_size=args.batch_size,
+            head_dim=args.head_dim,
+            seq_len=args.seq_len,
+            warmup=args.warmup,
+            iters=args.iters,
+            device=args.device,
+        )
+        results[case.name] = mean_ms
+
+    baseline_ms = results["fp32_buffer_fp32_input"]
+    print("\nResults:")
+    for case in CASES:
+        mean_ms = results[case.name]
+        speedup = baseline_ms / mean_ms
+        print(
+            f"{case.name:24s}  {mean_ms:8.4f} ms/iter  "
+            f"speedup_vs_fp32={speedup:6.3f}x"
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Space for HBM on the H20 96G is extremely limited. We are considering changing the C4 and C128 states from FP32 to BF16 to save space, as the impact on precision is negligible.

```
SGLANG_DSV4_COMPRESS_STATE_DTYPE=bf16 SGLANG_ENABLE_THINKING=1 SGLANG_DSV4_FP4_EXPERTS=1 SGLANG_JIT_DEEPGEMM_PRECOMPILE=0 GLOO_SOCKET_IFNAME=eth0 NCCL_MIN_NCHANNELS=24 NCCL_IB_QPS_PER_CONNECTION=8 sglang serve --trust-remote-code --model-path /data00/models/DeepSeek-V4-Pro --tp 16 --dp-size 2  --enable-dp-attention --cuda-graph-max-bs 8 --max-running-requests 16 --enable-metrics --host 0.0.0.0 --port 8080 --mem-fraction-static 0.9 --moe-runner-backend marlin --dist-init-addr 192.168.3.198:30300 --nnodes 2 --node-rank 0 --tool-call-parser deepseekv4 --reasoning-parser deepseek-v4 --speculative-algo EAGLE --speculative-num-steps 1 --speculative-eagle-topk 1 --speculative-num-draft-tokens 2 --chunked-prefill-size 4096

SGLANG_DSV4_COMPRESS_STATE_DTYPE=bf16 SGLANG_ENABLE_THINKING=1 SGLANG_DSV4_FP4_EXPERTS=1 SGLANG_JIT_DEEPGEMM_PRECOMPILE=0 GLOO_SOCKET_IFNAME=eth0 NCCL_MIN_NCHANNELS=24 NCCL_IB_QPS_PER_CONNECTION=8 sglang serve --trust-remote-code --model-path /data00/models/DeepSeek-V4-Pro --tp 16 --dp-size 2 --enable-dp-attention --cuda-graph-max-bs 8 --max-running-requests 16 --enable-metrics --host 0.0.0.0 --port 8080 --mem-fraction-static 0.9 --moe-runner-backend marlin --dist-init-addr 192.168.3.198:30300 --nnodes 2 --node-rank 1 --tool-call-parser deepseekv4 --reasoning-parser deepseek-v4 --speculative-algo EAGLE --speculative-num-steps 1 --speculative-eagle-topk 1 --speculative-num-draft-tokens 2 --chunked-prefill-size 4096
```

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
GSM8K
```
python3 bench_sglang.py --host http://localhost  --port 8080 --data-path /data00 --num-questions 5000 --parallel 100
Accuracy: 0.948
Invalid: 0.000
Latency: 405.306 s
Output throughput: 299.113 token/s
```
MMLU
```
python3 bench_sglang.py --parallel 128 --backend srt --host http://127.0.0.1 --port 8080 --data_dir /data00/mmlu
subject: abstract_algebra, #q:100, acc: 0.860
subject: anatomy, #q:135, acc: 0.911
subject: astronomy, #q:152, acc: 0.947
subject: business_ethics, #q:100, acc: 0.850
subject: clinical_knowledge, #q:265, acc: 0.928
subject: college_biology, #q:144, acc: 0.972
subject: college_chemistry, #q:100, acc: 0.690
subject: college_computer_science, #q:100, acc: 0.920
subject: college_mathematics, #q:100, acc: 0.810
subject: college_medicine, #q:173, acc: 0.890
subject: college_physics, #q:102, acc: 0.971
subject: computer_security, #q:100, acc: 0.860
subject: conceptual_physics, #q:235, acc: 0.953
subject: econometrics, #q:114, acc: 0.842
subject: electrical_engineering, #q:145, acc: 0.910
subject: elementary_mathematics, #q:378, acc: 0.960
subject: formal_logic, #q:126, acc: 0.778
subject: global_facts, #q:100, acc: 0.780
subject: high_school_biology, #q:310, acc: 0.968
subject: high_school_chemistry, #q:203, acc: 0.892
subject: high_school_computer_science, #q:100, acc: 0.960
subject: high_school_european_history, #q:165, acc: 0.909
subject: high_school_geography, #q:198, acc: 0.955
subject: high_school_government_and_politics, #q:193, acc: 0.990
subject: high_school_macroeconomics, #q:390, acc: 0.944
subject: high_school_mathematics, #q:270, acc: 0.848
subject: high_school_microeconomics, #q:238, acc: 0.975
subject: high_school_physics, #q:151, acc: 0.914
subject: high_school_psychology, #q:545, acc: 0.967
subject: high_school_statistics, #q:216, acc: 0.917
subject: high_school_us_history, #q:204, acc: 0.946
subject: high_school_world_history, #q:237, acc: 0.962
subject: human_aging, #q:223, acc: 0.865
subject: human_sexuality, #q:131, acc: 0.901
subject: international_law, #q:121, acc: 0.967
subject: jurisprudence, #q:108, acc: 0.898
subject: logical_fallacies, #q:163, acc: 0.914
subject: machine_learning, #q:112, acc: 0.893
subject: management, #q:103, acc: 0.981
subject: marketing, #q:234, acc: 0.966
subject: medical_genetics, #q:100, acc: 0.960
subject: miscellaneous, #q:783, acc: 0.964
subject: moral_disputes, #q:346, acc: 0.876
subject: moral_scenarios, #q:895, acc: 0.844
subject: nutrition, #q:306, acc: 0.928
subject: philosophy, #q:311, acc: 0.932
subject: prehistory, #q:324, acc: 0.954
subject: professional_accounting, #q:282, acc: 0.904
subject: professional_law, #q:1534, acc: 0.746
subject: professional_medicine, #q:272, acc: 0.949
subject: professional_psychology, #q:612, acc: 0.926
subject: public_relations, #q:110, acc: 0.800
subject: security_studies, #q:245, acc: 0.886
subject: sociology, #q:201, acc: 0.950
subject: us_foreign_policy, #q:100, acc: 0.940
subject: virology, #q:166, acc: 0.590
subject: world_religions, #q:171, acc: 0.930
Total latency: 936.149
Average accuracy: 0.896
```
gpqa
```
python -m sglang.test.run_eval --port 8080 --eval-name gpqa --num-examples 32 --max-tokens 128000 --repeat 8 --top-p 0.95 --temperature 1.0 --thinking-mode deepseek-v3

```
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
