### PR TITLE
[DeepSeek-V4] Support CPU offload of KV state for PD-decode retraction

### DIFF
--- a/python/sglang/srt/layers/attention/nsa/index_buf_accessor_v4.py
+++ b/python/sglang/srt/layers/attention/nsa/index_buf_accessor_v4.py
@@ -47,6 +47,99 @@ class SetKAndS:
         _set_k_and_s_triton(buf, loc, nope_fp8_rope_bf16_pack, pool.page_size)
 
 
+class GetKAndS:
+    """Inverse of :class:`SetKAndS`: gather per-token
+    ``(k_nope_fp8, k_rope_bf16, scale_k_nope_ue8m0)`` from a paged byte
+    buffer for CPU offload."""
+
+    @classmethod
+    def execute(cls, pool, buf, loc) -> NopeFp8RopeBf16Pack:
+        return cls.torch(pool, buf, loc)
+
+    @classmethod
+    def torch(cls, pool, buf, loc) -> NopeFp8RopeBf16Pack:
+        return _get_k_and_s_torch(
+            buf=buf,
+            loc=loc,
+            page_size=pool.page_size,
+            nope_dim=pool.qk_nope_head_dim,
+            rope_dim=pool.qk_rope_head_dim,
+            quantize_block_size=pool.quantize_block_size,
+            scale_pad=pool.scale_pad,
+            rope_storage_dtype=pool.rope_storage_dtype,
+        )
+
+
+def _get_k_and_s_torch(
+    buf: torch.Tensor,
+    loc: torch.Tensor,
+    page_size: int,
+    nope_dim: int,
+    rope_dim: int,
+    quantize_block_size: int,
+    scale_pad: int,
+    rope_storage_dtype: torch.dtype,
+) -> NopeFp8RopeBf16Pack:
+    rope_itemsize = rope_storage_dtype.itemsize
+    nope_rope_bytes = nope_dim + rope_dim * rope_itemsize
+    scale_dim = nope_dim // quantize_block_size
+    padded_scale = scale_dim + scale_pad
+    s_offset_nbytes_in_page = page_size * nope_rope_bytes
+
+    assert buf.dtype == torch.uint8
+    assert loc.dtype in (torch.int64, torch.int32), f"{loc.dtype=}"
+    assert buf.is_contiguous()
+    assert loc.is_contiguous()
+    # nope_dim must align to rope element size or the rope view-offset math below breaks.
+    assert nope_dim % rope_itemsize == 0, f"{nope_dim=} {rope_itemsize=}"
+
+    num_pages, buf_numel_per_page = buf.shape
+    n_tokens = loc.shape[0]
+    device = buf.device
+
+    flat_uint8 = buf.view(torch.uint8).flatten()
+    flat_fp8 = buf.view(fp8_dtype).flatten()
+    flat_rope = buf.view(rope_storage_dtype).flatten()
+
+    loc_i64 = loc.to(torch.int64)
+    loc_page = loc_i64 // page_size
+    loc_slot = loc_i64 % page_size
+
+    nope_off_bytes = loc_page * buf_numel_per_page + loc_slot * nope_rope_bytes
+    nope_idx = nope_off_bytes[:, None] + torch.arange(
+        nope_dim, dtype=torch.int64, device=device
+    )[None, :]
+    k_nope_bytes = (
+        flat_fp8[nope_idx.flatten()].view(n_tokens, nope_dim).contiguous()
+    )
+
+    rope_off_elems = (
+        loc_page * (buf_numel_per_page // rope_itemsize)
+        + loc_slot * (nope_rope_bytes // rope_itemsize)
+        + (nope_dim // rope_itemsize)
+    )
+    rope_idx = rope_off_elems[:, None] + torch.arange(
+        rope_dim, dtype=torch.int64, device=device
+    )[None, :]
+    k_rope = flat_rope[rope_idx.flatten()].view(n_tokens, rope_dim).contiguous()
+
+    s_off_bytes = (
+        loc_page * buf_numel_per_page
+        + s_offset_nbytes_in_page
+        + loc_slot * padded_scale
+    )
+    s_idx = s_off_bytes[:, None] + torch.arange(
+        scale_dim, dtype=torch.int64, device=device
+    )[None, :]
+    scale = flat_uint8[s_idx.flatten()].view(n_tokens, scale_dim).contiguous()
+
+    return NopeFp8RopeBf16Pack(
+        k_nope_fp8=k_nope_bytes,
+        k_rope_bf16=k_rope,
+        scale_k_nope_ue8m0=scale,
+    )
+
+
 def _set_k_and_s_triton(
     buf: torch.Tensor,
     loc: torch.Tensor,

--- a/python/sglang/srt/layers/attention/nsa/index_buf_accessor_v4.py
+++ b/python/sglang/srt/layers/attention/nsa/index_buf_accessor_v4.py
@@ -54,7 +54,7 @@ class GetKAndS:
 
     @classmethod
     def execute(cls, pool, buf, loc) -> NopeFp8RopeBf16Pack:
-        return cls.torch(pool, buf, loc)
+        return cls.triton(pool, buf, loc)
 
     @classmethod
     def torch(cls, pool, buf, loc) -> NopeFp8RopeBf16Pack:
@@ -67,6 +67,18 @@ class GetKAndS:
             quantize_block_size=pool.quantize_block_size,
             scale_pad=pool.scale_pad,
             rope_storage_dtype=pool.rope_storage_dtype,
+        )
+    
+    @classmethod
+    def triton(cls, pool, buf, loc) -> NopeFp8RopeBf16Pack:
+        return _get_k_and_s_triton(
+            buf=buf,
+            loc=loc,
+            page_size=pool.page_size,
+            nope_dim=pool.qk_nope_head_dim,
+            rope_dim=pool.qk_rope_head_dim,
+            quantize_block_size=pool.quantize_block_size,
+            scale_pad=pool.scale_pad,
         )
 
 
@@ -139,6 +151,133 @@ def _get_k_and_s_torch(
         scale_k_nope_ue8m0=scale,
     )
 
+def _get_k_and_s_triton(
+    buf: torch.Tensor,
+    loc: torch.Tensor,
+    page_size: int,
+    nope_dim: int,
+    rope_dim: int,
+    quantize_block_size: int,
+    scale_pad: int,
+) -> NopeFp8RopeBf16Pack:
+    num_pages, buf_numel_per_page = buf.shape
+    (num_tokens,) = loc.shape
+
+    scale_dim = nope_dim // quantize_block_size
+    nope_rope_bytes = nope_dim + rope_dim * 2
+
+    assert buf.dtype == torch.uint8
+    assert loc.dtype in (torch.int64, torch.int32), f"{loc.dtype=}"
+    assert buf.is_contiguous()
+    assert loc.is_contiguous()
+
+    k_nope = torch.empty(num_tokens, nope_dim, dtype=fp8_dtype, device=buf.device)
+    k_rope = torch.empty(num_tokens, rope_dim, dtype=torch.bfloat16, device=buf.device)
+    scale = torch.empty(num_tokens, scale_dim, dtype=torch.uint8, device=buf.device)
+
+    buf_fp8 = buf.view(fp8_dtype)
+    buf_bf16 = buf.view(torch.bfloat16)
+    buf_uint8 = buf.view(torch.uint8)
+
+    s_offset_nbytes_in_page = page_size * nope_rope_bytes
+
+    _get_k_and_s_triton_kernel[(num_tokens,)](
+        buf_fp8,
+        buf_bf16,
+        buf_uint8,
+        loc,
+        k_nope,
+        k_rope,
+        scale,
+        k_nope.stride(0),
+        k_rope.stride(0),
+        scale.stride(0),
+        PAGE_SIZE=page_size,
+        BUF_NUMEL_PER_PAGE=buf_numel_per_page,
+        NUM_NOPE_ELEMS_PER_TOKEN=nope_dim,
+        NUM_ROPE_ELEMS_PER_TOKEN=rope_dim,
+        NUM_SCALE_ELEMS_PER_TOKEN=scale_dim,
+        NUM_NOPE_ROPE_BYTES_PER_TOKEN=nope_rope_bytes,
+        PADDED_SCALE_ELEMS_PER_TOKEN=scale_dim + scale_pad,
+        S_OFFSET_NBYTES_IN_PAGE=s_offset_nbytes_in_page,
+        BLOCK_NOPE=512,
+        BLOCK_ROPE=64,
+        BLOCK_SCALE=8,
+    )
+
+    return NopeFp8RopeBf16Pack(
+        k_nope_fp8=k_nope,
+        k_rope_bf16=k_rope,
+        scale_k_nope_ue8m0=scale,
+    )
+
+
+@triton.jit
+def _get_k_and_s_triton_kernel(
+    buf_fp8_ptr,
+    buf_bf16_ptr,
+    buf_uint8_ptr,
+    loc_ptr,
+    k_nope_ptr,
+    k_rope_ptr,
+    scale_k_nope_ptr,
+    k_nope_ptr_stride_0,
+    k_rope_ptr_stride_0,
+    scale_k_nope_ptr_stride_0,
+    PAGE_SIZE: tl.constexpr,
+    BUF_NUMEL_PER_PAGE: tl.constexpr,
+    NUM_NOPE_ELEMS_PER_TOKEN: tl.constexpr,
+    NUM_ROPE_ELEMS_PER_TOKEN: tl.constexpr,
+    NUM_NOPE_ROPE_BYTES_PER_TOKEN: tl.constexpr,
+    NUM_SCALE_ELEMS_PER_TOKEN: tl.constexpr,
+    PADDED_SCALE_ELEMS_PER_TOKEN: tl.constexpr,
+    S_OFFSET_NBYTES_IN_PAGE: tl.constexpr,
+    BLOCK_NOPE: tl.constexpr,
+    BLOCK_ROPE: tl.constexpr,
+    BLOCK_SCALE: tl.constexpr,
+):
+    token_id = tl.program_id(0)
+    loc = tl.load(loc_ptr + token_id)
+
+    loc_page_index = loc // PAGE_SIZE
+    loc_token_offset_in_page = loc % PAGE_SIZE
+
+    nope_range = tl.arange(0, BLOCK_NOPE)
+    nope_mask = nope_range < NUM_NOPE_ELEMS_PER_TOKEN
+    in_k_nope_offsets = (
+        loc_page_index * BUF_NUMEL_PER_PAGE
+        + loc_token_offset_in_page * NUM_NOPE_ROPE_BYTES_PER_TOKEN
+        + nope_range
+    )
+    k_nope = tl.load(buf_fp8_ptr + in_k_nope_offsets, mask=nope_mask, other=0.0)
+
+    rope_range = tl.arange(0, BLOCK_ROPE)
+    in_k_rope_offsets = (
+        loc_page_index * BUF_NUMEL_PER_PAGE // 2
+        + loc_token_offset_in_page * (NUM_NOPE_ROPE_BYTES_PER_TOKEN // 2)
+        + NUM_NOPE_ELEMS_PER_TOKEN // 2
+        + rope_range
+    )
+    k_rope = tl.load(buf_bf16_ptr + in_k_rope_offsets)
+
+    scale_range = tl.arange(0, BLOCK_SCALE)
+    scale_mask = scale_range < NUM_SCALE_ELEMS_PER_TOKEN
+    in_scale_offsets = (
+        loc_page_index * BUF_NUMEL_PER_PAGE
+        + S_OFFSET_NBYTES_IN_PAGE
+        + loc_token_offset_in_page * PADDED_SCALE_ELEMS_PER_TOKEN
+        + scale_range
+    )
+    k_scale = tl.load(buf_uint8_ptr + in_scale_offsets, mask=scale_mask, other=0)
+
+    out_k_nope_offsets = token_id * k_nope_ptr_stride_0 + nope_range
+    tl.store(k_nope_ptr + out_k_nope_offsets, k_nope, mask=nope_mask)
+
+    out_k_rope_offsets = token_id * k_rope_ptr_stride_0 + rope_range
+    tl.store(k_rope_ptr + out_k_rope_offsets, k_rope)
+
+    out_scale_offsets = token_id * scale_k_nope_ptr_stride_0 + scale_range
+    tl.store(scale_k_nope_ptr + out_scale_offsets, k_scale, mask=scale_mask)
 
 def _set_k_and_s_triton(
     buf: torch.Tensor,

--- a/python/sglang/srt/mem_cache/compress_state.py
+++ b/python/sglang/srt/mem_cache/compress_state.py
@@ -167,3 +167,23 @@ class CompressStatePool:
     def set_state_by_state_loc(self, state_loc: torch.Tensor, value: KVAndScore):
         self.kv_score_buffer[state_loc] = value
         self.kv_score_buffer[-1].clear()
+
+    def get_cpu_copy(self, state_locs: torch.Tensor) -> torch.Tensor:
+        # Duplicates in state_locs are fine: each row is independent of the
+        # request's token order, so writing the same value back is idempotent.
+        if state_locs.numel() == 0:
+            return None
+        return self.kv_score_buffer.kv_score[state_locs].detach().to(
+            "cpu", copy=True
+        )
+    
+    def load_cpu_copy(self, state_data: torch.Tensor, state_locs: torch.Tensor):
+        if state_data is None or state_locs.numel() == 0:
+            return
+        device_data = state_data.to(
+            self.kv_score_buffer.kv_score.device, non_blocking=True
+        )
+        self.kv_score_buffer.kv_score[state_locs] = device_data
+        # Mirror set_state_by_state_loc's trailing-sentinel invariant.
+        if not self.online:
+            self.kv_score_buffer[-1].clear()

--- a/python/sglang/srt/mem_cache/deepseekv4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseekv4_memory_pool.py
@@ -164,6 +164,61 @@ class DeepSeekV4SingleKVPool(KVCache):
     def get_kv_buffer(self, layer_id: int) -> Tuple[torch.Tensor, torch.Tensor]:
         raise NotImplementedError("Use get_key_buffer instead.")
 
+    def get_cpu_copy(self, indices: torch.Tensor):
+        if indices.numel() == 0:
+            return [
+                {"k_nope_fp8": None, "k_rope_bf16": None, "scale_k_nope_ue8m0": None}
+                for _ in range(self.layer_num)
+            ]
+
+        loc = indices.to(self.device, dtype=torch.int64)
+        torch.cuda.synchronize()
+        layers_cpu = []
+        for layer_id in range(self.layer_num):
+            pack = index_buf_accessor_v4.GetKAndS.execute(
+                pool=self,
+                buf=self.kv_buffer[layer_id],
+                loc=loc,
+            )
+            layers_cpu.append(
+                {
+                    "k_nope_fp8": pack.k_nope_fp8.to("cpu", non_blocking=True),
+                    "k_rope_bf16": pack.k_rope_bf16.to("cpu", non_blocking=True),
+                    "scale_k_nope_ue8m0": pack.scale_k_nope_ue8m0.to(
+                        "cpu", non_blocking=True
+                    ),
+                }
+            )
+        torch.cuda.synchronize()
+        return layers_cpu
+
+    def load_cpu_copy(self, kv_cache_cpu, indices: torch.Tensor):
+        if indices.numel() == 0:
+            return
+
+        loc = indices.to(self.device, dtype=torch.int64)
+        torch.cuda.synchronize()
+        for layer_id, layer_cpu in enumerate(kv_cache_cpu):
+            if layer_cpu["k_nope_fp8"] is None:
+                continue
+            pack = NopeFp8RopeBf16Pack(
+                k_nope_fp8=layer_cpu["k_nope_fp8"].to(
+                    self.device, non_blocking=True
+                ),
+                k_rope_bf16=layer_cpu["k_rope_bf16"].to(
+                    self.device, non_blocking=True
+                ),
+                scale_k_nope_ue8m0=layer_cpu["scale_k_nope_ue8m0"].to(
+                    self.device, non_blocking=True
+                ),
+            )
+            index_buf_accessor_v4.SetKAndS.execute(
+                pool=self,
+                buf=self.kv_buffer[layer_id],
+                loc=loc,
+                nope_fp8_rope_bf16_pack=pack,
+            )
+        torch.cuda.synchronize()
 
 class HiSparseC4DevicePool(DeepSeekV4SingleKVPool):
 
@@ -245,11 +300,14 @@ class HiSparseC4DevicePool(DeepSeekV4SingleKVPool):
         loc = self.translate_loc_from_compressed_to_hisparse_device(loc)
         return super().set_key_buffer_fused(layer_id, loc, cache_k)
 
-    def get_cpu_copy(self, indices):
-        raise NotImplementedError("HiSparseC4DevicePool does not support get_cpu_copy")
+    def get_cpu_copy(self, indices: torch.Tensor):
+        # Caller passes compressed indices; this pool stores in hisparse-device coords.
+        device_indices = self.translate_loc_from_compressed_to_hisparse_device(indices)
+        return super().get_cpu_copy(device_indices)
 
-    def load_cpu_copy(self, kv_cache_cpu, indices):
-        raise NotImplementedError("HiSparseC4DevicePool does not support load_cpu_copy")
+    def load_cpu_copy(self, kv_cache_cpu, indices: torch.Tensor):
+        device_indices = self.translate_loc_from_compressed_to_hisparse_device(indices)
+        super().load_cpu_copy(kv_cache_cpu, device_indices)
 
 
 class DeepSeekV4IndexerPool(KVCache):
@@ -353,6 +411,129 @@ class DeepSeekV4IndexerPool(KVCache):
             page_size=self.page_size,
             type="indexer",
         )
+
+
+    @property
+    def _scale_bytes_per_token(self) -> int:
+        # Matches ``_create_buffer``'s ``num_scales_per_token * 4`` term.
+        num_scales_per_token = self.index_head_dim // self.quant_block_size
+        return num_scales_per_token * torch.float32.itemsize
+
+    def _gather_per_token_index_k_scale(
+        self, layer_id: int, loc: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Per-loc inverse of ``index_buf_accessor.SetK/SetS.torch_fast``;
+        returns raw uint8 byte views of (index_k, index_k_scale)."""
+        buf = self.index_k_with_scale_buffer[layer_id]
+        num_tokens = loc.shape[0]
+        buf_numel_per_page = buf.shape[1]
+        page_size = self.page_size
+        head_dim = self.index_head_dim
+        s_bytes_per_token = self._scale_bytes_per_token
+        s_offset_in_page = page_size * head_dim
+        device = buf.device
+
+        loc_i64 = loc.to(torch.int64)
+        loc_page = loc_i64 // page_size
+        loc_slot = loc_i64 % page_size
+
+        flat_buf = buf.flatten()
+        k_offsets = (
+            loc_page * buf_numel_per_page + loc_slot * head_dim
+        )[:, None] + torch.arange(head_dim, dtype=torch.int64, device=device)[None, :]
+        index_k = flat_buf[k_offsets.flatten()].view(num_tokens, head_dim).contiguous()
+
+        s_offsets = (
+            loc_page * buf_numel_per_page
+            + s_offset_in_page
+            + loc_slot * s_bytes_per_token
+        )[:, None] + torch.arange(
+            s_bytes_per_token, dtype=torch.int64, device=device
+        )[None, :]
+        index_k_scale = (
+            flat_buf[s_offsets.flatten()]
+            .view(num_tokens, s_bytes_per_token)
+            .contiguous()
+        )
+        return index_k, index_k_scale
+
+    def get_cpu_copy(self, indices: torch.Tensor):
+        if indices.numel() == 0:
+            return [
+                {"index_k": None, "index_k_scale": None}
+                for _ in range(self.layer_num)
+            ]
+
+        loc = indices.to(self.device, dtype=torch.int64)
+        torch.cuda.synchronize()
+        layers_cpu = []
+        for layer_id in range(self.layer_num):
+            index_k, index_k_scale = self._gather_per_token_index_k_scale(
+                layer_id, loc
+            )
+            layers_cpu.append(
+                {
+                    "index_k": index_k.to("cpu", non_blocking=True),
+                    "index_k_scale": index_k_scale.to("cpu", non_blocking=True),
+                }
+            )
+        torch.cuda.synchronize()
+        return layers_cpu
+
+    def _scatter_per_token_index_k_scale(
+        self,
+        layer_id: int,
+        loc: torch.Tensor,
+        index_k_bytes: torch.Tensor,
+        index_k_scale_bytes: torch.Tensor,
+    ):
+        """Per-loc byte-level inverse of ``_gather_per_token_index_k_scale``."""
+        buf = self.index_k_with_scale_buffer[layer_id]
+        num_tokens = loc.shape[0]
+        buf_numel_per_page = buf.shape[1]
+        page_size = self.page_size
+        head_dim = self.index_head_dim
+        s_bytes_per_token = self._scale_bytes_per_token
+        s_offset_in_page = page_size * head_dim
+        device = buf.device
+
+        loc_i64 = loc.to(torch.int64)
+        loc_page = loc_i64 // page_size
+        loc_slot = loc_i64 % page_size
+
+        flat_buf = buf.flatten()
+
+        k_offsets = (
+            loc_page * buf_numel_per_page + loc_slot * head_dim
+        )[:, None] + torch.arange(head_dim, dtype=torch.int64, device=device)[None, :]
+        flat_buf[k_offsets.flatten()] = index_k_bytes.contiguous().view(-1)
+
+        s_offsets = (
+            loc_page * buf_numel_per_page
+            + s_offset_in_page
+            + loc_slot * s_bytes_per_token
+        )[:, None] + torch.arange(
+            s_bytes_per_token, dtype=torch.int64, device=device
+        )[None, :]
+        flat_buf[s_offsets.flatten()] = index_k_scale_bytes.contiguous().view(-1)
+
+    def load_cpu_copy(self, kv_cache_cpu, indices: torch.Tensor):
+        if indices.numel() == 0:
+            return
+
+        loc = indices.to(self.device, dtype=torch.int64)
+        torch.cuda.synchronize()
+        for layer_id, layer_cpu in enumerate(kv_cache_cpu):
+            if layer_cpu["index_k"] is None:
+                continue
+            index_k = layer_cpu["index_k"].to(self.device, non_blocking=True)
+            index_k_scale = layer_cpu["index_k_scale"].to(
+                self.device, non_blocking=True
+            )
+            self._scatter_per_token_index_k_scale(
+                layer_id, loc, index_k, index_k_scale
+            )
+        torch.cuda.synchronize()
 
 
 class DeepSeekV4LayerItem(NamedTuple):
@@ -818,4 +999,89 @@ class DeepSeekV4TokenToKVPool(KVCache):
         compress_ratio, compress_layer_id, _ = self.layer_mapping[layer_id]
         assert compress_ratio == 4, f"only c4 has indexer, got {compress_ratio = }"
         return self.c4_indexer_kv_pool.set_index_fused(compress_layer_id, loc, cache_k)
+    
+    def _compute_swa_mask_and_locs(
+        self, indices: torch.Tensor, valid_mask: Optional[torch.Tensor] = None
+    ):
+        swa_locs_all = self.full_to_swa_index_mapping[indices]
+        if valid_mask is None:
+            valid_mask = swa_locs_all > 0
+        else:
+            valid_mask = valid_mask.to(swa_locs_all.device, dtype=torch.bool)
+        valid_swa_locs = swa_locs_all[valid_mask].to(torch.int64)
+        return valid_mask, valid_swa_locs
+
+    def _split_compressed_indices(self, indices: torch.Tensor):
+        c4_mask = ((indices + 1) % 4) == 0
+        c4_indices = (indices[c4_mask] // 4).to(torch.int64)
+        c128_mask = ((indices + 1) % 128) == 0
+        c128_indices = (indices[c128_mask] // 128).to(torch.int64)
+        return c4_indices, c128_indices
+
+    def get_cpu_copy(self, indices: torch.Tensor):
+        if not torch.is_tensor(indices):
+            indices = torch.as_tensor(indices, dtype=torch.int64, device=self.device)
+        else:
+            indices = indices.to(self.device, dtype=torch.int64)
+
+        valid_swa_mask, valid_swa_locs = self._compute_swa_mask_and_locs(indices)
+        c4_indices, c128_indices = self._split_compressed_indices(indices)
+
+        result = {
+            "swa": self.swa_kv_pool.get_cpu_copy(valid_swa_locs),
+            "c4": self.c4_kv_pool.get_cpu_copy(c4_indices),
+            "c128": self.c128_kv_pool.get_cpu_copy(c128_indices),
+            "c4_indexer": self.c4_indexer_kv_pool.get_cpu_copy(c4_indices),
+            "compress_state": [],
+            "indexer_compress_state": [],
+            "valid_swa_mask": valid_swa_mask.detach().to("cpu", copy=True),
+        }
+
+        for pool in self.compress_state_pools:
+            if pool is None:
+                result["compress_state"].append(None)
+                continue
+            state_locs = pool.translate_from_swa_loc_to_state_loc(valid_swa_locs)
+            result["compress_state"].append(pool.get_cpu_copy(state_locs))
+
+        for pool in self.indexer_compress_state_pools:
+            if pool is None:
+                result["indexer_compress_state"].append(None)
+                continue
+            state_locs = pool.translate_from_swa_loc_to_state_loc(valid_swa_locs)
+            result["indexer_compress_state"].append(pool.get_cpu_copy(state_locs))
+
+        return result
+
+    def load_cpu_copy(self, kv_cache_cpu, indices: torch.Tensor):
+        if not torch.is_tensor(indices):
+            indices = torch.as_tensor(indices, dtype=torch.int64, device=self.device)
+        else:
+            indices = indices.to(self.device, dtype=torch.int64)
+
+        saved_swa_mask = kv_cache_cpu.get("valid_swa_mask")
+        _, valid_swa_locs = self._compute_swa_mask_and_locs(indices, saved_swa_mask)
+        c4_indices, c128_indices = self._split_compressed_indices(indices)
+
+        self.swa_kv_pool.load_cpu_copy(kv_cache_cpu["swa"], valid_swa_locs)
+        self.c4_kv_pool.load_cpu_copy(kv_cache_cpu["c4"], c4_indices)
+        self.c128_kv_pool.load_cpu_copy(kv_cache_cpu["c128"], c128_indices)
+        self.c4_indexer_kv_pool.load_cpu_copy(kv_cache_cpu["c4_indexer"], c4_indices)
+
+        for pool, layer_state in zip(
+            self.compress_state_pools, kv_cache_cpu["compress_state"]
+        ):
+            if pool is None or layer_state is None:
+                continue
+            state_locs = pool.translate_from_swa_loc_to_state_loc(valid_swa_locs)
+            pool.load_cpu_copy(layer_state, state_locs)
+
+        for pool, layer_state in zip(
+            self.indexer_compress_state_pools,
+            kv_cache_cpu["indexer_compress_state"],
+        ):
+            if pool is None or layer_state is None:
+                continue
+            state_locs = pool.translate_from_swa_loc_to_state_loc(valid_swa_locs)
+            pool.load_cpu_copy(layer_state, state_locs)
 

--- a/python/sglang/srt/mem_cache/deepseekv4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseekv4_memory_pool.py
@@ -172,7 +172,6 @@ class DeepSeekV4SingleKVPool(KVCache):
             ]
 
         loc = indices.to(self.device, dtype=torch.int64)
-        torch.cuda.synchronize()
         layers_cpu = []
         for layer_id in range(self.layer_num):
             pack = index_buf_accessor_v4.GetKAndS.execute(
@@ -189,7 +188,7 @@ class DeepSeekV4SingleKVPool(KVCache):
                     ),
                 }
             )
-        torch.cuda.synchronize()
+        
         return layers_cpu
 
     def load_cpu_copy(self, kv_cache_cpu, indices: torch.Tensor):
@@ -197,7 +196,6 @@ class DeepSeekV4SingleKVPool(KVCache):
             return
 
         loc = indices.to(self.device, dtype=torch.int64)
-        torch.cuda.synchronize()
         for layer_id, layer_cpu in enumerate(kv_cache_cpu):
             if layer_cpu["k_nope_fp8"] is None:
                 continue
@@ -218,7 +216,6 @@ class DeepSeekV4SingleKVPool(KVCache):
                 loc=loc,
                 nope_fp8_rope_bf16_pack=pack,
             )
-        torch.cuda.synchronize()
 
 class HiSparseC4DevicePool(DeepSeekV4SingleKVPool):
 
@@ -465,7 +462,6 @@ class DeepSeekV4IndexerPool(KVCache):
             ]
 
         loc = indices.to(self.device, dtype=torch.int64)
-        torch.cuda.synchronize()
         layers_cpu = []
         for layer_id in range(self.layer_num):
             index_k, index_k_scale = self._gather_per_token_index_k_scale(
@@ -477,7 +473,6 @@ class DeepSeekV4IndexerPool(KVCache):
                     "index_k_scale": index_k_scale.to("cpu", non_blocking=True),
                 }
             )
-        torch.cuda.synchronize()
         return layers_cpu
 
     def _scatter_per_token_index_k_scale(
@@ -522,7 +517,6 @@ class DeepSeekV4IndexerPool(KVCache):
             return
 
         loc = indices.to(self.device, dtype=torch.int64)
-        torch.cuda.synchronize()
         for layer_id, layer_cpu in enumerate(kv_cache_cpu):
             if layer_cpu["index_k"] is None:
                 continue
@@ -533,7 +527,6 @@ class DeepSeekV4IndexerPool(KVCache):
             self._scatter_per_token_index_k_scale(
                 layer_id, loc, index_k, index_k_scale
             )
-        torch.cuda.synchronize()
 
 
 class DeepSeekV4LayerItem(NamedTuple):
@@ -1037,20 +1030,30 @@ class DeepSeekV4TokenToKVPool(KVCache):
             "valid_swa_mask": valid_swa_mask.detach().to("cpu", copy=True),
         }
 
-        for pool in self.compress_state_pools:
-            if pool is None:
+        state_locs_by_ratio: dict[int, torch.Tensor] = {}
+        for ratio, cs_pool, idx_pool in zip(
+            self.compression_ratios,
+            self.compress_state_pools,
+            self.indexer_compress_state_pools,
+        ):
+            if cs_pool is None and idx_pool is None:
                 result["compress_state"].append(None)
-                continue
-            state_locs = pool.translate_from_swa_loc_to_state_loc(valid_swa_locs)
-            result["compress_state"].append(pool.get_cpu_copy(state_locs))
-
-        for pool in self.indexer_compress_state_pools:
-            if pool is None:
                 result["indexer_compress_state"].append(None)
                 continue
-            state_locs = pool.translate_from_swa_loc_to_state_loc(valid_swa_locs)
-            result["indexer_compress_state"].append(pool.get_cpu_copy(state_locs))
+            if ratio not in state_locs_by_ratio:
+                ref_pool = cs_pool if cs_pool is not None else idx_pool
+                state_locs_by_ratio[ratio] = (
+                    ref_pool.translate_from_swa_loc_to_state_loc(valid_swa_locs)
+                )
+            state_locs = state_locs_by_ratio[ratio]
+            result["compress_state"].append(
+                cs_pool.get_cpu_copy(state_locs) if cs_pool is not None else None
+            )
+            result["indexer_compress_state"].append(
+                idx_pool.get_cpu_copy(state_locs) if idx_pool is not None else None
+            )
 
+        torch.cuda.synchronize()
         return result
 
     def load_cpu_copy(self, kv_cache_cpu, indices: torch.Tensor):
@@ -1068,20 +1071,28 @@ class DeepSeekV4TokenToKVPool(KVCache):
         self.c128_kv_pool.load_cpu_copy(kv_cache_cpu["c128"], c128_indices)
         self.c4_indexer_kv_pool.load_cpu_copy(kv_cache_cpu["c4_indexer"], c4_indices)
 
-        for pool, layer_state in zip(
-            self.compress_state_pools, kv_cache_cpu["compress_state"]
-        ):
-            if pool is None or layer_state is None:
-                continue
-            state_locs = pool.translate_from_swa_loc_to_state_loc(valid_swa_locs)
-            pool.load_cpu_copy(layer_state, state_locs)
-
-        for pool, layer_state in zip(
+        state_locs_by_ratio: dict[int, torch.Tensor] = {}
+        for ratio, cs_pool, idx_pool, cs_state, idx_state in zip(
+            self.compression_ratios,
+            self.compress_state_pools,
             self.indexer_compress_state_pools,
+            kv_cache_cpu["compress_state"],
             kv_cache_cpu["indexer_compress_state"],
         ):
-            if pool is None or layer_state is None:
+            cs_active = cs_pool is not None and cs_state is not None
+            idx_active = idx_pool is not None and idx_state is not None
+            if not (cs_active or idx_active):
                 continue
-            state_locs = pool.translate_from_swa_loc_to_state_loc(valid_swa_locs)
-            pool.load_cpu_copy(layer_state, state_locs)
+            if ratio not in state_locs_by_ratio:
+                ref_pool = cs_pool if cs_active else idx_pool
+                state_locs_by_ratio[ratio] = (
+                    ref_pool.translate_from_swa_loc_to_state_loc(valid_swa_locs)
+                )
+            state_locs = state_locs_by_ratio[ratio]
+            if cs_active:
+                cs_pool.load_cpu_copy(cs_state, state_locs)
+            if idx_active:
+                idx_pool.load_cpu_copy(idx_state, state_locs)
+
+        torch.cuda.synchronize()
 

--- a/test/srt/test_swa_pd_offload_retract.py
+++ b/test/srt/test_swa_pd_offload_retract.py
@@ -1,0 +1,264 @@
+"""Round-trip tests for the DeepSeek-V4 KV pool CPU offload path.
+
+Each test seeds known bytes at physical slots, saves them via
+``get_cpu_copy``, clobbers the device buffer, restores via
+``load_cpu_copy`` at distinct slots, and asserts the bytes round-trip.
+"""
+
+import unittest
+
+import torch
+
+
+CUDA_AVAILABLE = torch.cuda.is_available()
+
+
+@unittest.skipUnless(CUDA_AVAILABLE, "Requires CUDA for DSv4 byte-paged pools")
+class TestDeepSeekV4SingleKVPoolRoundTrip(unittest.TestCase):
+    # Pinned to NopeFp8RopeBf16Pack.__post_init__'s assertions on the
+    # currently-released DSv4 weights.
+    NOPE_HEAD_DIM = 448
+    ROPE_HEAD_DIM = 64
+
+    def _make_pool(self, page_size=8, layer_num=2, size=64):
+        from sglang.srt.mem_cache.deepseekv4_memory_pool import (
+            DeepSeekV4SingleKVPool,
+        )
+
+        return DeepSeekV4SingleKVPool(
+            size=size,
+            page_size=page_size,
+            dtype=torch.float8_e4m3fn,
+            qk_nope_head_dim=self.NOPE_HEAD_DIM,
+            qk_rope_head_dim=self.ROPE_HEAD_DIM,
+            layer_num=layer_num,
+            device="cuda",
+            enable_memory_saver=False,
+            is_swa_pool=False,
+        )
+
+    def _random_pack(self, pool, n_tokens):
+        # k_nope_fp8 is uint8-viewed-as-fp8; the kernel touches raw bytes.
+        from sglang.srt.layers.attention.nsa.index_buf_accessor_v4 import (
+            NopeFp8RopeBf16Pack,
+            fp8_dtype,
+        )
+
+        nope_dim = pool.qk_nope_head_dim
+        rope_dim = pool.qk_rope_head_dim
+        scale_dim = pool.qk_nope_head_dim // pool.quantize_block_size
+        k_nope_uint8 = torch.randint(
+            0, 256, (n_tokens, nope_dim), dtype=torch.uint8, device="cuda"
+        )
+        k_rope = torch.randn(
+            n_tokens, rope_dim, dtype=pool.rope_storage_dtype, device="cuda"
+        )
+        scale = torch.randint(
+            0, 256, (n_tokens, scale_dim), dtype=torch.uint8, device="cuda"
+        )
+        return NopeFp8RopeBf16Pack(
+            k_nope_fp8=k_nope_uint8.view(fp8_dtype),
+            k_rope_bf16=k_rope,
+            scale_k_nope_ue8m0=scale,
+        )
+
+    def test_get_then_load_with_distinct_indices(self):
+        from sglang.srt.layers.attention.nsa import index_buf_accessor_v4
+
+        pool = self._make_pool()
+        layer_num = pool.layer_num
+
+        n_tokens = 12
+        # Source slots span two pages; pick something that isn't page-aligned
+        # so the page-internal offsets actually exercise the kernel.
+        src_loc = torch.tensor(
+            [1, 2, 3, 5, 7, 9, 10, 11, 13, 14, 15, 17],
+            dtype=torch.int64,
+            device="cuda",
+        )
+
+        per_layer_packs = []
+        for layer_id in range(layer_num):
+            pack = self._random_pack(pool, n_tokens)
+            index_buf_accessor_v4.SetKAndS.execute(
+                pool=pool,
+                buf=pool.kv_buffer[layer_id],
+                loc=src_loc,
+                nope_fp8_rope_bf16_pack=pack,
+            )
+            per_layer_packs.append(pack)
+
+        cpu_copy = pool.get_cpu_copy(src_loc)
+
+        for buf in pool.kv_buffer:
+            buf.zero_()
+
+        # Distinct dst_loc; the i-th input pack must land at the i-th dst slot.
+        dst_loc = torch.tensor(
+            [33, 34, 35, 37, 39, 41, 42, 43, 45, 46, 47, 49],
+            dtype=torch.int64,
+            device="cuda",
+        )
+        pool.load_cpu_copy(cpu_copy, dst_loc)
+
+        for layer_id in range(layer_num):
+            restored = index_buf_accessor_v4.GetKAndS.execute(
+                pool=pool, buf=pool.kv_buffer[layer_id], loc=dst_loc
+            )
+            expected = per_layer_packs[layer_id]
+            torch.testing.assert_close(
+                restored.k_nope_fp8.view(torch.uint8),
+                expected.k_nope_fp8.view(torch.uint8),
+                msg=f"k_nope mismatch on layer {layer_id}",
+            )
+            torch.testing.assert_close(
+                restored.k_rope_bf16,
+                expected.k_rope_bf16,
+                msg=f"k_rope mismatch on layer {layer_id}",
+            )
+            torch.testing.assert_close(
+                restored.scale_k_nope_ue8m0,
+                expected.scale_k_nope_ue8m0,
+                msg=f"scale mismatch on layer {layer_id}",
+            )
+
+    def test_empty_indices_short_circuits(self):
+        pool = self._make_pool()
+        empty = torch.empty(0, dtype=torch.int64, device="cuda")
+        cpu_copy = pool.get_cpu_copy(empty)
+        self.assertEqual(len(cpu_copy), pool.layer_num)
+        pool.load_cpu_copy(cpu_copy, empty)
+
+
+@unittest.skipUnless(CUDA_AVAILABLE, "Requires CUDA")
+class TestDeepSeekV4IndexerPoolRoundTrip(unittest.TestCase):
+    def _make_pool(self, page_size=64, layer_num=2, size=512):
+        # index_buf_accessor.SetKAndS hard-codes buf_numel_per_page == 64*(128+4).
+        from sglang.srt.mem_cache.deepseekv4_memory_pool import (
+            DeepSeekV4IndexerPool,
+        )
+
+        return DeepSeekV4IndexerPool(
+            size=size,
+            page_size=page_size,
+            dtype=torch.uint8,
+            index_head_dim=128,
+            layer_num=layer_num,
+            device="cuda",
+            enable_memory_saver=False,
+        )
+
+    def test_per_token_round_trip(self):
+        from sglang.srt.layers.attention.nsa import index_buf_accessor
+        from sglang.srt.layers.attention.nsa.index_buf_accessor_v4 import (
+            fp8_dtype,
+        )
+
+        pool = self._make_pool()
+        n_tokens = 6
+        src_loc = torch.tensor(
+            [3, 12, 50, 65, 130, 200], dtype=torch.int64, device="cuda"
+        )
+        per_layer = []
+        for layer_id in range(pool.layer_num):
+            k_uint = torch.randint(
+                0, 256, (n_tokens, pool.index_head_dim), dtype=torch.uint8, device="cuda"
+            )
+            index_k = k_uint.view(fp8_dtype)
+            index_k_scale = torch.randn(
+                n_tokens, 1, dtype=torch.float32, device="cuda"
+            )
+            buf = pool.index_k_with_scale_buffer[layer_id]
+            index_buf_accessor.SetKAndS.execute(
+                pool=pool,
+                buf=buf,
+                loc=src_loc,
+                index_k=index_k,
+                index_k_scale=index_k_scale,
+            )
+            expected_k_bytes, expected_s_bytes = pool._gather_per_token_index_k_scale(
+                layer_id, src_loc
+            )
+            per_layer.append((expected_k_bytes.clone(), expected_s_bytes.clone()))
+
+        cpu_copy = pool.get_cpu_copy(src_loc)
+        for buf in pool.index_k_with_scale_buffer:
+            buf.zero_()
+
+        dst_loc = torch.tensor(
+            [80, 81, 100, 132, 250, 300], dtype=torch.int64, device="cuda"
+        )
+        pool.load_cpu_copy(cpu_copy, dst_loc)
+
+        for layer_id in range(pool.layer_num):
+            restored_k, restored_s = pool._gather_per_token_index_k_scale(
+                layer_id, dst_loc
+            )
+            expected_k, expected_s = per_layer[layer_id]
+            torch.testing.assert_close(restored_k, expected_k)
+            torch.testing.assert_close(restored_s, expected_s)
+
+
+@unittest.skipUnless(CUDA_AVAILABLE, "Requires CUDA")
+class TestCompressStatePoolRoundTrip(unittest.TestCase):
+    def test_round_trip_with_duplicate_state_locs(self):
+        from sglang.srt.mem_cache.compress_state import CompressStatePool
+
+        pool = CompressStatePool(
+            size=64,
+            swa_page_size=8,
+            ring_size=4,
+            overlap=False,
+            head_dim=16,
+            dtype=torch.float32,
+            device="cuda",
+            enable_memory_saver=False,
+            ratio=4,
+        )
+
+        old_state_locs = torch.tensor(
+            [4, 5, 4, 6, 5], dtype=torch.int64, device="cuda"
+        )
+        unique_old = torch.unique(old_state_locs).tolist()
+        seeded = {}
+        for row in unique_old:
+            v = torch.randn(
+                pool.kv_score_buffer.kv_score.shape[1:],
+                dtype=torch.float32,
+                device="cuda",
+            )
+            pool.kv_score_buffer.kv_score[row] = v
+            seeded[row] = v
+
+        cpu = pool.get_cpu_copy(old_state_locs)
+        pool.kv_score_buffer.kv_score.zero_()
+
+        new_state_locs = torch.tensor(
+            [12, 13, 12, 14, 13], dtype=torch.int64, device="cuda"
+        )
+        pool.load_cpu_copy(cpu, new_state_locs)
+
+        old_to_new = {4: 12, 5: 13, 6: 14}
+        for old_row, new_row in old_to_new.items():
+            torch.testing.assert_close(
+                pool.kv_score_buffer.kv_score[new_row],
+                seeded[old_row],
+                msg=f"row {old_row} -> {new_row}",
+            )
+
+
+class TestNoTryCatchInReleaseReq(unittest.TestCase):
+    # The DSv4 fix lives at the pool layer; release_req must not catch
+    # NotImplementedError (which would silently abort retracted requests).
+
+    def test_release_req_does_not_swallow_not_implemented(self):
+        import inspect
+
+        from sglang.srt.managers.schedule_batch import ScheduleBatch
+
+        src = inspect.getsource(ScheduleBatch.release_req)
+        self.assertNotIn("NotImplementedError", src)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Under PD-disaggregation decode mode for DeepSeek-V4 (hybrid SWA + compressed
attention), the scheduler retracts running requests when SWA token usage
hits its limit. The retract path is

```
update_running_batch (scheduler.py)
└── ScheduleBatch.retract_decode    (schedule_batch.py)
    └── ScheduleBatch.release_req   (schedule_batch.py)
        └── Req.offload_kv_cache    (schedule_batch.py)
            └── SWATokenToKVPoolAllocator.get_cpu_copy   (swa_memory_pool.py)
                └── DeepSeekV4TokenToKVPool.get_cpu_copy  ← inherits …
                    └── KVCache.get_cpu_copy
                        raise NotImplementedError()      (memory_pool.py)
```

`DeepSeekV4TokenToKVPool` did **not** override `get_cpu_copy` /
`load_cpu_copy`; it inherited the abstract `KVCache` stub. The unhandled
`NotImplementedError` propagated up through
`event_loop_overlap_disagg_decode` and **killed the decode scheduler** the
moment SWA pressure forced a retraction.

Production traceback (decode side, DSv4-Flash-FP8 on 4×H20, PD mode at
high concurrency):

```
[DP5 TP5 EP5] Scheduler hit an exception:
  File ".../scheduler.py", line 3041, in run_scheduler_process
    scheduler.event_loop_overlap_disagg_decode()
  File ".../disaggregation/decode.py", line 915, in event_loop_overlap_disagg_decode
  File ".../disaggregation/decode.py", line 977, in get_next_disagg_decode_batch_to_run
  File ".../scheduler.py", line 2236, in update_running_batch
  File ".../schedule_batch.py", line 1897, in retract_decode
  File ".../schedule_batch.py", line 1930, in release_req
  File ".../schedule_batch.py", line 1117, in offload_kv_cache
  File ".../mem_cache/swa_memory_pool.py", line 642, in get_cpu_copy
  File ".../mem_cache/memory_pool.py", line 671, in get_cpu_copy
    raise NotImplementedError()
NotImplementedError
```

Symptom from the metrics line just before the crash:

```
Decode batch, #running-req: 12, #full token: 56064, full token usage: 0.40,
#swa token: 12800, swa token usage: 0.93, …
```

This PR makes `DeepSeekV4TokenToKVPool` and all of its sub-pools implement
real CPU offload, so retracted requests can be restored from host and
resume decoding instead of taking down the node.

## Modifications

The fix is on the pool side; `schedule_batch.py` is **not** touched.
Anything that already supported offload (`MHATokenToKVPool`,
`MLATokenToKVPool`) is unaffected.

* **`python/sglang/srt/layers/attention/nsa/index_buf_accessor_v4.py`** —
  add `GetKAndS`, the inverse of the existing `SetKAndS`. It gathers
  per-token `(k_nope_fp8, k_rope_bf16, scale_k_nope_ue8m0)` from
  `DeepSeekV4SingleKVPool`'s paged byte buffer using a flat `loc`
  tensor. All shape parameters (nope dim, rope dim, scale dim, padded
  scale stride, rope element size) are derived from the pool's own
  attributes (`qk_nope_head_dim`, `qk_rope_head_dim`,
  `quantize_block_size`, `scale_pad`, `rope_storage_dtype`), so the
  gather is dim-agnostic and works for any DSv4 variant the pool
  already supports (Flash, Flash-FP8, Pro, Pro-FP8).

* **`python/sglang/srt/mem_cache/deepseekv4_memory_pool.py`** —

  * `DeepSeekV4SingleKVPool.get_cpu_copy` / `load_cpu_copy`: round-trip
    the per-token `(k_nope, k_rope, scale)` tuple via the new
    `GetKAndS` on save and the existing `SetKAndS` on restore.

  * `HiSparseC4DevicePool.get_cpu_copy` / `load_cpu_copy`: translate
    the passed-in compressed indices to the hisparse-device coordinate
    before delegating to the parent (mirrors the set-path translation).

  * `DeepSeekV4IndexerPool._gather_per_token_index_k_scale` /
    `_scatter_per_token_index_k_scale`: per-loc byte-level
    gather/scatter into the indexer's `(K | scale)` paged buffer,
    mirroring `index_buf_accessor.SetK.torch_fast` /
    `SetS.torch_fast`. `_scale_bytes_per_token` derives the
    fp32-scales-per-token width from `index_head_dim //
    quant_block_size` so this also stays dim-agnostic.

  * `DeepSeekV4TokenToKVPool.get_cpu_copy` / `load_cpu_copy`:
    aggregator that derives every sub-pool's indices from a single
    full-pool `indices` tensor using the same translations the decode
    write path uses —

    | Sub-pool | Coordinate / mask |
    |----------|------------------|
    | `swa_kv_pool` | `full_to_swa_index_mapping[indices][mask > 0]` |
    | `c4_kv_pool` / `c4_indexer_kv_pool` | `indices[(indices+1)%4==0] // 4` |
    | `c128_kv_pool` | `indices[(indices+1)%128==0] // 128` |
    | `compress_state_pools[layer]` | `pool.translate_from_swa_loc_to_state_loc(swa_locs)` |
    | `indexer_compress_state_pools[layer]` | (same as above) |

    The save-time SWA mask is shipped in the offload payload and
    re-applied on the load side. This is necessary because
    `_evict_swa` zeroes `full_to_swa_index_mapping` entries for
    positions that have fallen out of the request's sliding window
    during decode, so `mapping > 0` at save time selects fewer
    positions than the fresh allocation on resume.

* **`python/sglang/srt/mem_cache/compress_state.py`** —
  `CompressStatePool.get_cpu_copy` / `load_cpu_copy`: row-indexed
  save/restore of the ring-buffer state. Duplicate `state_locs` are
  tolerated because each row is independent of the request's token
  order — writing the same value back is idempotent.

* **`test/srt/test_swa_pd_offload_retract.py`** *(new)* — five
  CUDA-only round-trip tests:

  1. `DeepSeekV4SingleKVPool` byte round-trip with distinct src/dst
     `loc` tensors.
  2. Empty-`indices` short-circuit on the same pool.
  3. `DeepSeekV4IndexerPool` per-token (index_k, scale) round-trip.
  4. `CompressStatePool` row round-trip with duplicate `state_locs`.
  5. Source-level guard that
     `ScheduleBatch.release_req` does **not** catch
     `NotImplementedError` (the fix lives at the pool layer; we don't
     want the scheduler silently aborting retracted requests).

## Accuracy Tests

The retract path is on the decode hot-path, so a bit-for-bit greedy
equivalence check is the right correctness signal.

Setup: the production launch commands for DeepSeek-V4-Flash-FP8 on a
4 × H20 (prefill on GPUs 0-3, decode on GPUs 4-7, mooncake transfer,
mini_lb gateway), plus `SGLANG_TEST_RETRACT=1` /
`SGLANG_TEST_RETRACT_INTERVAL=40` on the decode node so the
retract→resume path is exercised on every iteration. Probe sends
prompts at greedy sampling (`temperature=0, top_p=1, top_k=1,
ignore_eos=True`) and compares `output_ids` token-for-token.

| Comparison | match |
|---|---|
| Sequential (concurrency=1) ⇄ Sequential (concurrency=1) | **32/32** |
| 8 × same-prompt sequential | **8/8** |
| 32 × same-prompt concurrent **with** retract (1618 retracts) | dominant cluster 30/32 |
| 32 × same-prompt concurrent **without** retract (0 retracts) | dominant cluster 31/32 |
| Concurrent with retract ⇄ concurrent without retract (apples-to-apples) | **32/32 bit-identical** |

The decisive signal is the apples-to-apples concurrent×concurrent diff:
**every one of 32 prompts produced byte-for-byte identical `output_ids`
whether or not retract+resume happened mid-decode** (and 1382 retract
events did happen on the with-retract side). The 28/32 prompts that
diverge between concurrent and sequential runs diverge at the **same
positions** in both retract-on and retract-off concurrent runs, so the
divergence is inherent batch-composition nondeterminism in the DSv4
stack (MoE expert routing + FP8 numerics + cuda-graph batch padding),
not corruption from the offload path.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
