### PR TITLE
[VLM] Optimize Gemma4 VLM with PCG and fuse RMSNorm + residual add + scalar

### DIFF
--- a/python/sglang/srt/layers/gemma4_fused_ops.py
+++ b/python/sglang/srt/layers/gemma4_fused_ops.py
@@ -77,3 +77,94 @@ def gemma_rmsnorm_residual_scalar(
         BLOCK_SIZE=BLOCK_SIZE,
     )
     return out
+
+
+@triton.jit
+def _gemma_dual_rmsnorm_residual_kernel(
+    X1_ptr,
+    W1_ptr,
+    X2_ptr,
+    W2_ptr,
+    W3_ptr,
+    Residual_ptr,
+    Scalar_ptr,
+    Out_ptr,
+    stride_x1,
+    stride_x2,
+    stride_r,
+    stride_o,
+    N,
+    eps1,
+    eps2,
+    eps3,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Fused: out = (rmsnorm(rmsnorm(x1,w1) + rmsnorm(x2,w2), w3) + residual) * scalar"""
+    row = tl.program_id(0)
+    cols = tl.arange(0, BLOCK_SIZE)
+    mask = cols < N
+
+    x1 = tl.load(X1_ptr + row * stride_x1 + cols, mask=mask, other=0.0).to(tl.float32)
+    w1 = tl.load(W1_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+    x2 = tl.load(X2_ptr + row * stride_x2 + cols, mask=mask, other=0.0).to(tl.float32)
+    w2 = tl.load(W2_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+    w3 = tl.load(W3_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+    r = tl.load(Residual_ptr + row * stride_r + cols, mask=mask, other=0.0).to(
+        tl.float32
+    )
+
+    var1 = tl.sum(x1 * x1, axis=0) / N
+    norm1 = x1 * tl.rsqrt(var1 + eps1) * w1
+
+    var2 = tl.sum(x2 * x2, axis=0) / N
+    norm2 = x2 * tl.rsqrt(var2 + eps2) * w2
+
+    combined = norm1 + norm2
+
+    var3 = tl.sum(combined * combined, axis=0) / N
+    norm3 = combined * tl.rsqrt(var3 + eps3) * w3
+
+    scalar = tl.load(Scalar_ptr).to(tl.float32)
+    out = (norm3 + r) * scalar
+
+    tl.store(Out_ptr + row * stride_o + cols, out.to(x1.dtype), mask=mask)
+
+
+def gemma_dual_rmsnorm_residual_scalar(
+    x1: torch.Tensor,
+    weight1: torch.Tensor,
+    x2: torch.Tensor,
+    weight2: torch.Tensor,
+    weight3: torch.Tensor,
+    residual: torch.Tensor,
+    scalar: torch.Tensor,
+    eps1: float = 1e-6,
+    eps2: float = 1e-6,
+    eps3: float = 1e-6,
+) -> torch.Tensor:
+    """Fused (rmsnorm(rmsnorm(x1,w1) + rmsnorm(x2,w2), w3) + residual) * scalar."""
+    assert x1.dim() == 2 and x1.stride(-1) == 1
+    M, N = x1.shape
+    BLOCK_SIZE = triton.next_power_of_2(N)
+    out = torch.empty_like(x1)
+
+    _gemma_dual_rmsnorm_residual_kernel[(M,)](
+        x1,
+        weight1,
+        x2,
+        weight2,
+        weight3,
+        residual,
+        scalar,
+        out,
+        x1.stride(0),
+        x2.stride(0),
+        residual.stride(0),
+        out.stride(0),
+        N,
+        eps1,
+        eps2,
+        eps3,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+    return out

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -278,6 +278,10 @@ def resolve_language_model(model: nn.Module) -> nn.Module:
     model_cls_name = model.__class__.__name__
     if model_cls_name == "Qwen3OmniMoeForConditionalGeneration":
         return model.thinker.model
+    if hasattr(model, "model"):
+        return model.model
+    if hasattr(model, "language_model"):
+        return model.language_model
     return model.model
 
 
@@ -2830,8 +2834,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self.model.model = resolve_language_model(self.model)
         language_model = getattr(self.model, "language_model", self.model)
 
-        # Some draft models (e.g. eagle3) don't have a standard 'layers' attribute
-        if not hasattr(language_model.model, "layers"):
+        # Resolve model with layers: handle CausalLM wrapper (.model.layers) and direct TextModel (.layers)
+        if hasattr(language_model, "model") and hasattr(language_model.model, "layers"):
+            layer_model = language_model.model
+        elif hasattr(language_model, "layers"):
+            layer_model = language_model
+        else:
             logger.warning(
                 "Disable piecewise CUDA graph because the model does not have a 'layers' attribute"
             )
@@ -2840,7 +2848,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self.attention_layers = []
         self.moe_layers = []
         self.moe_fusions = []
-        for layer in language_model.model.layers:
+        for layer in layer_model.layers:
             attn_layer = None
             if hasattr(layer, "self_attn"):
                 if hasattr(layer.self_attn, "attn"):

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -304,8 +304,14 @@ class PiecewiseCudaGraphRunner:
             language_model = getattr(
                 self.model_runner.model, "language_model", self.model_runner.model
             )
+            layer_model = (
+                language_model.model
+                if hasattr(language_model, "model")
+                and hasattr(language_model.model, "layers")
+                else language_model
+            )
             with patch_model(
-                language_model.model, self.compile_config.compiler
+                layer_model, self.compile_config.compiler
             ) as patched_model:
 
                 # Dummy warmup for jit kernel

--- a/python/sglang/srt/models/gemma4_causal.py
+++ b/python/sglang/srt/models/gemma4_causal.py
@@ -27,7 +27,10 @@ from transformers import (
 from sglang.srt.distributed import (
     get_tensor_model_parallel_world_size,
 )
-from sglang.srt.layers.gemma4_fused_ops import gemma_rmsnorm_residual_scalar
+from sglang.srt.layers.gemma4_fused_ops import (
+    gemma_dual_rmsnorm_residual_scalar,
+    gemma_rmsnorm_residual_scalar,
+)
 from sglang.srt.layers.layernorm import Gemma4RMSNorm, RMSNorm
 from sglang.srt.layers.linear import (
     QKVParallelLinear,
@@ -545,12 +548,36 @@ class Gemma4DecoderLayer(nn.Module):
 
             # Dense MLP branch
             hidden_states_1 = self.mlp(hidden_states)
-            hidden_states_1 = self.post_feedforward_layernorm_1(hidden_states_1)
 
             # MoE branch: router sees residual (= post_attn_out + old_residual)
             router_logits = self.router(moe_input)
             hidden_states_2 = self.pre_feedforward_layernorm_2(moe_input)
             hidden_states_2 = self.moe(hidden_states_2, router_logits)
+
+            # Fused: (rmsnorm(rmsnorm(h1,w1) + rmsnorm(h2,w2), w3) + residual) * scalar
+            if (
+                not self.has_ple
+                and hidden_states_1.is_cuda
+                and hidden_states_1.dim() == 2
+            ):
+                norm1 = self.post_feedforward_layernorm_1
+                norm2 = self.post_feedforward_layernorm_2
+                norm3 = self.post_feedforward_layernorm
+                hidden_states = gemma_dual_rmsnorm_residual_scalar(
+                    hidden_states_1,
+                    norm1.weight.data,
+                    hidden_states_2,
+                    norm2.weight.data,
+                    norm3.weight.data,
+                    residual,
+                    self.layer_scalar,
+                    norm1.variance_epsilon,
+                    norm2.variance_epsilon,
+                    norm3.variance_epsilon,
+                )
+                return hidden_states, None
+
+            hidden_states_1 = self.post_feedforward_layernorm_1(hidden_states_1)
             hidden_states_2 = self.post_feedforward_layernorm_2(hidden_states_2)
 
             # Combine branches

--- a/python/sglang/srt/models/gemma4_mm.py
+++ b/python/sglang/srt/models/gemma4_mm.py
@@ -224,6 +224,26 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
 
         self.post_init()
 
+    @property
+    def model(self):
+        # Alias .model to .language_model so this class satisfies the piecewise
+        # CUDA graph gate (which checks `hasattr(model, "model")`). Implemented
+        # as a property to avoid registering a duplicate submodule in
+        # `_modules`, which would double state_dict keys and disturb
+        # ShardedStateLoader / CPU-offload / dummy-init paths.
+        return self.language_model
+
+    def __setattr__(self, name, value):
+        # Block writes to "model" so the runner's
+        # `self.model.model = resolve_language_model(self.model)` (which for
+        # this class returns language_model itself) is a no-op rather than a
+        # nn.Module submodule registration. Without this, nn.Module.__setattr__
+        # would bypass the @property's setter for Module values and pollute
+        # `_modules` with a duplicate alias, doubling state_dict keys.
+        if name == "model":
+            return
+        super().__setattr__(name, value)
+
     def pad_input_ids(
         self,
         input_ids: List[int],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Optimize Gemma4 26B-A4B prefill performance through two complementary approaches:
1. Fused Triton kernels for Gemma4 decoder layers — Reduces kernel launch overhead by fusing multiple operations into single kernels.
2. Enable Piecewise CUDA Graph (PCG) for VLM models — Fixes PCG support for multimodal models that use self.language_model instead of self.model to reference their text backbone.

Main:
<img width="2037" height="1034" alt="image" src="https://github.com/user-attachments/assets/0835b8a3-e89b-4734-a4d5-35d2b96679fd" />

PR:
<img width="2063" height="1005" alt="image" src="https://github.com/user-attachments/assets/307dba65-fd00-4244-a793-308de38c64cb" />


## Modifications

<!-- Detail the changes made in this pull request. -->
###  Fused Triton Kernels (sglang/srt/layers/gemma4_fused_ops.py)

  - gemma_rmsnorm_residual_scalar: Fuses RMSNorm + residual add + scalar multiply into a single Triton kernel (replaces 3 separate ops).
  - gemma_dual_rmsnorm_residual_scalar: Fuses the full MoE post-processing pipeline — rmsnorm(rmsnorm(dense_out, w1) + rmsnorm(moe_out, w2), w3) + residual) * scalar — into a single kernel (replaces 5+ separate ops per MoE layer).

###  Gemma4 Model Integration (sglang/srt/models/gemma4_causal.py)

  - Updated Gemma4DecoderLayer.forward() to use the fused kernels in the MoE block, eliminating redundant kernel launches.

###  PCG VLM Compatibility (sglang/srt/model_executor/model_runner.py)

  - resolve_language_model(): Added fallback to model.language_model when model.model is not present, supporting VLM architectures like Gemma4ForConditionalGeneration.
  - PCG gate check: Extended the guard condition to also check for language_model attribute, preventing false disabling of PCG for VLMs.
  - Layer resolution: Added flexible layer discovery that handles both language_model.model.layers (standard) and language_model.layers (Gemma4 VLM where TextModel is the language_model directly).

###  PCG Runner Fix (sglang/srt/model_executor/piecewise_cuda_graph_runner.py)

  - Updated patch_model target resolution to handle models where the TextModel (with .layers) is the language_model itself, not nested under .model.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
MMMU match official 54.9%. 
| Tasks  |Filter|n-shot| Metric |   |Value |   |Stderr|
|--------|------|-----:|--------|---|-----:|---|------|
|mmmu_val|none  |     0|mmmu_acc|↑  |0.5489|±  |N/A   |

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
PCG eliminates CPU dispatch overhead by capturing per-layer CUDA graphs for prefill. The benefit is most significant at small-to-medium token counts where kernel launch latency dominates compute time.

| Tokens | Baseline | Fused + PCG | Improvement |
|--------|----------|-------------|-------------|
| 93     | 35.6ms   | 16.5ms      | -53.7%      |
| 189    | 35.4ms   | 17.1ms      | -51.7%      |
| 1453   | 36.3ms   | 25.1ms      | -30.9%      |
| 2893   | 40.6ms   | 30.6ms      | -24.6%      |
| 5773   | ~49ms    | 41.6ms      | -15.1%      |
| 11533  | ~70ms    | 66.4ms      | -5.1%       |

## Compatibility
  - Non-VLM models: No change — existing model.model path is tried first.
  - VLM models with self.model (e.g., Qwen2.5-VL): No change — hasattr(model, "model") succeeds as before.
  - VLM models with self.language_model (e.g., Gemma4): Now correctly supported.
  - Verified correctness on both Gemma4 (text + image) and Qwen2.5-VL (text + image) with PCG enabled.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
4. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
5. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
6. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
