### PR TITLE
[Docs] quick fix delete --enable-dp-attention in sgl-jax

### DIFF
--- a/docs_new/src/snippets/autoregressive/mimo-v25-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/mimo-v25-deployment.jsx
@@ -230,6 +230,12 @@ export const MiMoV25Deployment = () => {
       // Recipe sources:
       //   v7x: tp=ep=32, dp=4, omits --attention-backend, mem-frac 0.95, swa 0.25
       //   v6e: tp=ep=64, dp=8, --attention-backend fa,    mem-frac 0.92, swa 0.15
+      //
+      // sgl-jax conventions:
+      //   - `--tp-size` is always the total JAX device count; per-DP TP is
+      //     derived automatically as tp/dp.
+      //   - No `--enable-dp-attention` flag — DP attention is the default
+      //     (FFN layers auto-pick EP-split for MoE, attn-TP-split for dense).
       const isV7x = hardware === "tpu-v7x";
       const useEp = expertParallelism === "enabled";
       const useDpAttn = dpAttention === "enabled";

--- a/docs_new/src/snippets/autoregressive/mimo-v25-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/mimo-v25-deployment.jsx
@@ -239,7 +239,7 @@ export const MiMoV25Deployment = () => {
       flags.push("  --trust-remote-code");
       flags.push(`  --tp-size ${tp}`);
       if (useEp) flags.push(`  --ep-size ${tp}`);
-      if (useDpAttn) flags.push(`  --dp-size ${dpSize}`, "  --enable-dp-attention");
+      if (useDpAttn) flags.push(`  --dp-size ${dpSize}`);
       flags.push("  --moe-backend fused");
       if (!isV7x) flags.push("  --attention-backend fa");
       flags.push("  --host 0.0.0.0");


### PR DESCRIPTION
## Motivation

In sgl-jax, DP attention is enabled by default and the `--enable-dp-attention` flag does not exist. The MiMo-V2.5-Pro TPU launch command in the cookbook included this flag, which would cause the server to fail at argument parsing.

## Modifications

`docs_new/src/snippets/autoregressive/mimo-v25-deployment.jsx`: drop `--enable-dp-attention` from the TPU (sgl-jax) branch of the deployment panel. The CUDA branch is unchanged — the flag is still required for GPU paths.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).