### PR TITLE
[Speculative] Support topk>1 in adaptive speculative decoding

### DIFF
--- a/docs_new/docs/advanced_features/adaptive_speculative_decoding.mdx
+++ b/docs_new/docs/advanced_features/adaptive_speculative_decoding.mdx
@@ -9,9 +9,9 @@ It is designed for workloads whose accept length changes over time, where one st
 
 ## Current support
 
-- Only `--speculative-algorithm EAGLE`
-- Only `--speculative-eagle-topk 1`
-- If either condition is not met, SGLang falls back to static speculative settings
+- Only `--speculative-algorithm EAGLE` / `EAGLE3`
+- Both `--speculative-eagle-topk 1` (chain) and `> 1` (tree) are supported. For tree mode, the smallest tier in `candidate_steps` must produce a draft pool of at least `--speculative-num-draft-tokens - 1` candidates, where pool size is `topk + (num_steps - 1) * topk^2`. The default `candidate_steps = [1, 3, 7]` does not satisfy typical tree budgets — pass `{"candidate_steps": [2, 3]}` (or similar) for `topk > 1`.
+- If the algorithm condition is not met, SGLang falls back to static speculative settings
 
 ## Why adaptive steps help
 

--- a/docs_new/docs/advanced_features/speculative_decoding.mdx
+++ b/docs_new/docs/advanced_features/speculative_decoding.mdx
@@ -27,7 +27,7 @@ SGLang provides several speculative decoding options, including EAGLE-2/EAGLE-3,
 
 - **Best speed/quality (recommended)**: Use **EAGLE-3** with `--speculative-algorithm EAGLE3`.
 - **Strong default / broad compatibility**: Use **EAGLE-2** with `--speculative-algorithm EAGLE`.
-- **Workload acceptance changes over time**: Use [**Adaptive speculative decoding**](./adaptive_speculative_decoding) on top of **EAGLE** with `--speculative-eagle-topk 1`.
+- **Workload acceptance changes over time**: Use [**Adaptive speculative decoding**](./adaptive_speculative_decoding) on top of **EAGLE** (chain or tree).
 - **Lower `lm_head` overhead for EAGLE-2**: Enable **FR-Spec** with `--speculative-token-map`.
 - **Model is MTP-enabled**: Use **MTP via speculative decoding** (often with small `speculative_num_steps/topk/num_draft_tokens`, see the example section).
 - **You have a DFlash draft checkpoint**: Use **DFLASH** with `--speculative-algorithm DFLASH` and `--speculative-draft-model-path ...`.
@@ -230,7 +230,7 @@ To enable EAGLE speculative decoding the following parameters are relevant:
 
 These parameters are mostly the same for EAGLE-2 and EAGLE-3. `--speculative-token-map` is ignored for EAGLE-3 models.
 For `--speculative-num-steps`, `--speculative-eagle-topk`, and `--speculative-num-draft-tokens`: leave all three unset to use auto-tuning, or set all three explicitly when tuning.
-If you use EAGLE with `--speculative-eagle-topk 1` and your acceptance rate varies across requests, see [Adaptive Speculative Decoding](./adaptive_speculative_decoding).
+If you use EAGLE and your acceptance rate varies across requests, see [Adaptive Speculative Decoding](./adaptive_speculative_decoding).
 
 You can find the best combinations of these parameters with [bench_speculative.py](https://github.com/sgl-project/sglang/blob/main/scripts/playground/bench_speculative.py).
 

--- a/python/sglang/srt/speculative/adaptive_runtime_state.py
+++ b/python/sglang/srt/speculative/adaptive_runtime_state.py
@@ -53,6 +53,8 @@ class AdaptiveSpecWorker(Protocol):
     """Protocol that a worker must implement to use AdaptiveController."""
 
     speculative_num_steps: int
+    speculative_num_draft_tokens: int
+    topk: int
 
     def build_adaptive_runtime_state(
         self, speculative_num_steps: int, speculative_num_draft_tokens: int
@@ -82,6 +84,45 @@ class AdaptiveController:
             config=cfg,
         )
         self._states: dict[int, SpecRuntimeState] = {}
+        self._validate_candidate_steps_against_topk()
+
+    def _validate_candidate_steps_against_topk(self) -> None:
+        """For topk>1, ensure the smallest candidate step yields enough draft
+        candidates to satisfy speculative_num_draft_tokens.
+
+        EAGLE draft_forward (eagle_worker.py) builds a score pool via
+        select_top_k_tokens (spec_utils.py):
+          - step i=0: appends `topk` scores
+          - step i>=1: appends `topk * topk` scores per step
+        organize_draft_results (eagle_utils.py) then selects
+        (num_draft_tokens - 1) entries from this pool.
+
+        Pool size at num_steps=s, topk=k (s >= 1):
+            pool(s, k) = k + (s - 1) * k**2
+
+        For topk=1 the existing server_args post-init already enforces
+        num_draft_tokens = num_steps + 1, so no check is needed there.
+        """
+        topk = self.worker.topk
+        if topk == 1:
+            return
+        num_draft_tokens = self.worker.speculative_num_draft_tokens
+        min_step = min(self.params.candidate_steps)
+        if min_step < 1:
+            raise ValueError(
+                "adaptive candidate_steps must be >= 1 for topk>1 "
+                f"(got min={min_step}); step=0 support is tracked separately."
+            )
+        pool_size = topk + (min_step - 1) * topk * topk
+        if pool_size < num_draft_tokens - 1:
+            raise ValueError(
+                f"adaptive candidate_steps min={min_step} with topk={topk} "
+                f"yields a draft pool of only {pool_size} candidates, but "
+                f"speculative_num_draft_tokens={num_draft_tokens} requires "
+                f">= {num_draft_tokens - 1}. "
+                "Increase the smallest candidate step or lower "
+                "speculative_num_draft_tokens."
+            )
 
     @property
     def candidate_steps(self) -> list[int]:
@@ -100,9 +141,19 @@ class AdaptiveController:
         for steps in self.params.candidate_steps:
             if steps in self._states:
                 continue
+            # Chain (topk=1): num_draft_tokens is always num_steps + 1
+            # (server_args enforces this in post-init).
+            # Tree (topk>1): num_draft_tokens is the user-specified tree
+            # budget; build_tree_kernel selects top-N from the score pool.
+            # Hold it constant across tiers so the user retains direct
+            # control over the verifier graph size.
+            if self.worker.topk == 1:
+                draft_tokens = steps + 1
+            else:
+                draft_tokens = self.worker.speculative_num_draft_tokens
             state = self.worker.build_adaptive_runtime_state(
                 speculative_num_steps=steps,
-                speculative_num_draft_tokens=steps + 1,
+                speculative_num_draft_tokens=draft_tokens,
             )
             self._states[steps] = state
         self._activate(self.params.current_steps)

--- a/python/sglang/srt/speculative/adaptive_runtime_state.py
+++ b/python/sglang/srt/speculative/adaptive_runtime_state.py
@@ -50,11 +50,34 @@ class SpecRuntimeState:
 
 
 class AdaptiveSpecWorker(Protocol):
-    """Protocol that a worker must implement to use AdaptiveController."""
+    """Protocol that a worker must implement to use AdaptiveController.
+
+    Algorithm-specific formulas (the draft pool size at a given number of
+    steps, and the per-tier ``speculative_num_draft_tokens``) live on the
+    worker so the controller stays generic across speculative algorithms.
+    """
 
     speculative_num_steps: int
     speculative_num_draft_tokens: int
     topk: int
+
+    def get_draft_pool_size(self, num_steps: int) -> int:
+        """Number of draft candidates produced for tier=*num_steps*.
+
+        The controller checks this against ``speculative_num_draft_tokens``
+        before activating any tier; raise / return 0 for unsupported step
+        values (e.g. step=0).
+        """
+        ...
+
+    def get_num_draft_tokens(self, num_steps: int) -> int:
+        """``speculative_num_draft_tokens`` to use when this tier is active.
+
+        Chain-shape workers typically tie this to ``num_steps``; tree-shape
+        workers usually hold it constant across tiers and let the user pick
+        the verifier graph size directly.
+        """
+        ...
 
     def build_adaptive_runtime_state(
         self, speculative_num_steps: int, speculative_num_draft_tokens: int
@@ -84,42 +107,35 @@ class AdaptiveController:
             config=cfg,
         )
         self._states: dict[int, SpecRuntimeState] = {}
-        self._validate_candidate_steps_against_topk()
+        self._validate_candidate_steps()
 
-    def _validate_candidate_steps_against_topk(self) -> None:
-        """For topk>1, ensure the smallest candidate step yields enough draft
-        candidates to satisfy speculative_num_draft_tokens.
+    def _validate_candidate_steps(self) -> None:
+        """Ensure the smallest candidate step yields enough draft candidates
+        to satisfy that tier's ``num_draft_tokens``.
 
-        EAGLE draft_forward (eagle_worker.py) builds a score pool via
-        select_top_k_tokens (spec_utils.py):
-          - step i=0: appends `topk` scores
-          - step i>=1: appends `topk * topk` scores per step
-        organize_draft_results (eagle_utils.py) then selects
-        (num_draft_tokens - 1) entries from this pool.
-
-        Pool size at num_steps=s, topk=k (s >= 1):
-            pool(s, k) = k + (s - 1) * k**2
-
-        For topk=1 the existing server_args post-init already enforces
-        num_draft_tokens = num_steps + 1, so no check is needed there.
+        Both formulas are algorithm-specific and live on the worker (see
+        ``AdaptiveSpecWorker.get_draft_pool_size`` /
+        ``get_num_draft_tokens``); the controller only enforces the generic
+        invariant ``pool_size >= num_draft_tokens - 1`` for the smallest
+        tier. Bigger tiers have at least as much pool as the smallest one,
+        so a single check is sufficient when the per-tier budget is
+        non-decreasing in ``num_steps`` (true for both EAGLE chain and tree
+        policies).
         """
-        topk = self.worker.topk
-        if topk == 1:
-            return
-        num_draft_tokens = self.worker.speculative_num_draft_tokens
         min_step = min(self.params.candidate_steps)
         if min_step < 1:
             raise ValueError(
-                "adaptive candidate_steps must be >= 1 for topk>1 "
+                "adaptive candidate_steps must be >= 1 "
                 f"(got min={min_step}); step=0 support is tracked separately."
             )
-        pool_size = topk + (min_step - 1) * topk * topk
+        num_draft_tokens = self.worker.get_num_draft_tokens(min_step)
+        pool_size = self.worker.get_draft_pool_size(min_step)
         if pool_size < num_draft_tokens - 1:
             raise ValueError(
-                f"adaptive candidate_steps min={min_step} with topk={topk} "
-                f"yields a draft pool of only {pool_size} candidates, but "
-                f"speculative_num_draft_tokens={num_draft_tokens} requires "
-                f">= {num_draft_tokens - 1}. "
+                f"adaptive candidate_steps min={min_step} yields a draft "
+                f"pool of only {pool_size} candidates, but the tier needs "
+                f"speculative_num_draft_tokens={num_draft_tokens} "
+                f"(>= {num_draft_tokens - 1}). "
                 "Increase the smallest candidate step or lower "
                 "speculative_num_draft_tokens."
             )
@@ -141,19 +157,9 @@ class AdaptiveController:
         for steps in self.params.candidate_steps:
             if steps in self._states:
                 continue
-            # Chain (topk=1): num_draft_tokens is always num_steps + 1
-            # (server_args enforces this in post-init).
-            # Tree (topk>1): num_draft_tokens is the user-specified tree
-            # budget; build_tree_kernel selects top-N from the score pool.
-            # Hold it constant across tiers so the user retains direct
-            # control over the verifier graph size.
-            if self.worker.topk == 1:
-                draft_tokens = steps + 1
-            else:
-                draft_tokens = self.worker.speculative_num_draft_tokens
             state = self.worker.build_adaptive_runtime_state(
                 speculative_num_steps=steps,
-                speculative_num_draft_tokens=draft_tokens,
+                speculative_num_draft_tokens=self.worker.get_num_draft_tokens(steps),
             )
             self._states[steps] = state
         self._activate(self.params.current_steps)

--- a/python/sglang/srt/speculative/adaptive_spec_params.py
+++ b/python/sglang/srt/speculative/adaptive_spec_params.py
@@ -24,11 +24,6 @@ def adaptive_unsupported_reason(server_args: ServerArgs) -> str | None:
             f"speculative_algorithm={server_args.speculative_algorithm} "
             "(only EAGLE/EAGLE3 are supported)"
         )
-    if server_args.speculative_eagle_topk != 1:
-        return (
-            f"speculative_eagle_topk={server_args.speculative_eagle_topk} "
-            "(only topk=1 is supported)"
-        )
     if server_args.enable_dp_attention:
         return (
             "enable_dp_attention=True is not supported "

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -344,6 +344,36 @@ class EAGLEWorker(TpModelWorker):
             state.speculative_num_draft_tokens
         )
 
+    def get_draft_pool_size(self, num_steps: int) -> int:
+        """Number of draft candidates produced by the EAGLE draft loop.
+
+        ``select_top_k_tokens`` (in ``spec_utils.py``) appends ``topk``
+        scores at step 0 and ``topk * topk`` scores at every subsequent
+        step. ``organize_draft_results`` then selects
+        ``num_draft_tokens - 1`` entries from this pool.
+
+        Returns 0 for ``num_steps < 1`` so the controller's invariant
+        check fails with a clear "pool too small" message.
+        """
+        if num_steps < 1:
+            return 0
+        return self.topk + (num_steps - 1) * self.topk * self.topk
+
+    def get_num_draft_tokens(self, num_steps: int) -> int:
+        """Per-tier ``speculative_num_draft_tokens``.
+
+        Chain (``topk == 1``): server_args enforces
+        ``num_draft_tokens = num_steps + 1`` in post-init, so each tier
+        gets its own size.
+
+        Tree (``topk > 1``): hold the user-supplied budget constant across
+        tiers so the user retains direct control over the verifier graph
+        size; ``build_tree_kernel`` then selects top-N by score.
+        """
+        if self.topk == 1:
+            return num_steps + 1
+        return self.speculative_num_draft_tokens
+
     def build_adaptive_runtime_state(
         self, speculative_num_steps: int, speculative_num_draft_tokens: int
     ) -> SpecRuntimeState:

--- a/test/registered/spec/eagle/test_adaptive_speculative.py
+++ b/test/registered/spec/eagle/test_adaptive_speculative.py
@@ -34,6 +34,9 @@ LOW_ACCEPT_PROMPT = (
 MAX_UPSHIFT_ATTEMPTS = 4
 MAX_DOWNSHIFT_ATTEMPTS = 6
 
+EXPECTED_UPSHIFT_STEPS = 3
+EXPECTED_DOWNSHIFT_STEPS = 1
+
 
 class TestAdaptiveSpeculativeServer(CustomTestCase):
     """Test adaptive speculative decoding with state switching and GSM8K accuracy."""
@@ -116,34 +119,40 @@ class TestAdaptiveSpeculativeServer(CustomTestCase):
         self.assertEqual(response.status_code, 200, response.text)
         return response.json()
 
-    def _drive_upshift(self) -> dict:
-        """Send high-acceptance prompts until steps upshift to 3."""
+    def _drive_upshift(self, target: int = EXPECTED_UPSHIFT_STEPS) -> dict:
+        """Send high-acceptance prompts until steps upshift to *target*."""
         state = self._get_internal_state()
         for _ in range(MAX_UPSHIFT_ATTEMPTS):
             self._generate(HIGH_ACCEPT_PROMPT)
             state = self._get_internal_state()
-            if state["speculative_num_steps"] == 3:
+            if state["speculative_num_steps"] == target:
                 return state
         return state
 
-    def _drive_downshift(self) -> dict:
-        """Send low-acceptance prompts until steps downshift to 1."""
+    def _drive_downshift(self, target: int = EXPECTED_DOWNSHIFT_STEPS) -> dict:
+        """Send low-acceptance prompts until steps downshift to *target*."""
         state = self._get_internal_state()
         for _ in range(MAX_DOWNSHIFT_ATTEMPTS):
             self._generate(LOW_ACCEPT_PROMPT)
             state = self._get_internal_state()
-            if state["speculative_num_steps"] == 1:
+            if state["speculative_num_steps"] == target:
                 return state
         return state
 
     def test_gsm8k_after_adaptive_switches(self):
         """Exercise up/down/up adaptive switches, then verify GSM8K accuracy."""
         state = self._drive_upshift()
-        self.assertEqual(state["speculative_num_steps"], 3, f"Never upshifted: {state}")
+        self.assertEqual(
+            state["speculative_num_steps"],
+            EXPECTED_UPSHIFT_STEPS,
+            f"Never upshifted: {state}",
+        )
 
         state = self._drive_downshift()
         self.assertEqual(
-            state["speculative_num_steps"], 1, f"Never downshifted: {state}"
+            state["speculative_num_steps"],
+            EXPECTED_DOWNSHIFT_STEPS,
+            f"Never downshifted: {state}",
         )
 
         self._drive_upshift()

--- a/test/registered/spec/eagle/test_adaptive_speculative_topk.py
+++ b/test/registered/spec/eagle/test_adaptive_speculative_topk.py
@@ -1,0 +1,177 @@
+import json
+import os
+import tempfile
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import (
+    DEFAULT_DRAFT_MODEL_EAGLE,
+    DEFAULT_TARGET_MODEL_EAGLE,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=80, suite="stage-b-test-1-gpu-large")
+
+HIGH_ACCEPT_PROMPT = (
+    "Output exactly 128 new lines. "
+    "Every line must be READY. "
+    "Do not add numbering, punctuation, or commentary."
+)
+
+LOW_ACCEPT_PROMPT = (
+    "Compose a poem in the style of Emily Dickinson about quantum entanglement. "
+    "Make it emotionally resonant and at least 100 words."
+)
+
+MAX_UPSHIFT_ATTEMPTS = 4
+MAX_DOWNSHIFT_ATTEMPTS = 6
+
+# candidate_steps=[2, 3] is required at topk=4: min_step=1 would only yield a
+# pool of 4 < num_draft_tokens-1=15 and fail _validate_candidate_steps_against_topk.
+EXPECTED_UPSHIFT_STEPS = 3
+EXPECTED_DOWNSHIFT_STEPS = 2
+
+
+class TestAdaptiveSpeculativeTopkServer(CustomTestCase):
+    """Adaptive speculative decoding under tree EAGLE (topk > 1).
+
+    Exercises tier swap correctness: both runtime states init under topk=4,
+    upshift drives steps to 3, downshift drives to 2 (the floor of
+    candidate_steps=[2, 3], not 1), and a smoke decode after the second
+    upshift confirms the verify path runs cleanly post-swap.
+    """
+
+    model = DEFAULT_TARGET_MODEL_EAGLE
+    draft_model = DEFAULT_DRAFT_MODEL_EAGLE
+    base_url = DEFAULT_URL_FOR_TEST
+
+    @classmethod
+    def setUpClass(cls):
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            json.dump(
+                {
+                    "candidate_steps": [2, 3],
+                    "ema_alpha": 1.0,
+                    "warmup_batches": 1,
+                    "update_interval": 1,
+                    "up_hysteresis": 0.0,
+                },
+                f,
+            )
+            cls.adaptive_config_path = f.name
+
+        try:
+            cls.process = popen_launch_server(
+                cls.model,
+                cls.base_url,
+                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                other_args=[
+                    "--trust-remote-code",
+                    "--attention-backend",
+                    "flashinfer",
+                    "--speculative-algorithm",
+                    "EAGLE",
+                    "--speculative-draft-model-path",
+                    cls.draft_model,
+                    "--speculative-num-steps",
+                    "3",
+                    "--speculative-eagle-topk",
+                    "4",
+                    "--speculative-num-draft-tokens",
+                    "16",
+                    "--speculative-adaptive",
+                    "--speculative-adaptive-config",
+                    cls.adaptive_config_path,
+                    "--skip-server-warmup",
+                    "--mem-fraction-static",
+                    "0.7",
+                ],
+            )
+        except Exception:
+            os.unlink(cls.adaptive_config_path)
+            raise
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process"):
+            kill_process_tree(cls.process.pid)
+        if os.path.exists(cls.adaptive_config_path):
+            os.unlink(cls.adaptive_config_path)
+
+    def _get_internal_state(self) -> dict:
+        response = requests.get(self.base_url + "/server_info", timeout=30)
+        self.assertEqual(response.status_code, 200, response.text)
+        return response.json()["internal_states"][0]
+
+    def _generate(self, prompt: str, max_new_tokens: int = 64) -> dict:
+        response = requests.post(
+            self.base_url + "/generate",
+            json={
+                "text": prompt,
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": max_new_tokens,
+                    "ignore_eos": True,
+                },
+            },
+            timeout=180,
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        return response.json()
+
+    def _drive_upshift(self, target: int = EXPECTED_UPSHIFT_STEPS) -> dict:
+        state = self._get_internal_state()
+        for _ in range(MAX_UPSHIFT_ATTEMPTS):
+            self._generate(HIGH_ACCEPT_PROMPT)
+            state = self._get_internal_state()
+            if state["speculative_num_steps"] == target:
+                return state
+        return state
+
+    def _drive_downshift(self, target: int = EXPECTED_DOWNSHIFT_STEPS) -> dict:
+        state = self._get_internal_state()
+        for _ in range(MAX_DOWNSHIFT_ATTEMPTS):
+            self._generate(LOW_ACCEPT_PROMPT)
+            state = self._get_internal_state()
+            if state["speculative_num_steps"] == target:
+                return state
+        return state
+
+    def test_adaptive_switches_under_topk_gt_1(self):
+        """Up -> down -> up sequence under topk=4, then a smoke decode."""
+        state = self._drive_upshift()
+        self.assertEqual(
+            state["speculative_num_steps"],
+            EXPECTED_UPSHIFT_STEPS,
+            f"Never upshifted: {state}",
+        )
+
+        state = self._drive_downshift()
+        self.assertEqual(
+            state["speculative_num_steps"],
+            EXPECTED_DOWNSHIFT_STEPS,
+            f"Never downshifted: {state}",
+        )
+
+        state = self._drive_upshift()
+        self.assertEqual(
+            state["speculative_num_steps"],
+            EXPECTED_UPSHIFT_STEPS,
+            f"Never re-upshifted: {state}",
+        )
+
+        # Smoke decode: confirms the verify path runs cleanly after the
+        # last tier swap; a non-empty output is enough signal here, broader
+        # parity is left to local-only smokes.
+        result = self._generate("Hello", max_new_tokens=8)
+        self.assertTrue(result.get("text"), f"Empty decode after swap: {result}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/spec/eagle/test_adaptive_speculative_topk.py
+++ b/test/registered/spec/eagle/test_adaptive_speculative_topk.py
@@ -57,10 +57,11 @@ class TestAdaptiveSpeculativeTopkServer(CustomTestCase):
             json.dump(
                 {
                     "candidate_steps": [2, 3],
-                    "ema_alpha": 1.0,
+                    "ema_alpha": 0.3,
                     "warmup_batches": 1,
                     "update_interval": 1,
                     "up_hysteresis": 0.0,
+                    "down_hysteresis": -0.5,
                 },
                 f,
             )

--- a/test/registered/unit/spec/test_adaptive_spec_params.py
+++ b/test/registered/unit/spec/test_adaptive_spec_params.py
@@ -229,14 +229,25 @@ class TestAdaptiveUnsupportedReason(unittest.TestCase):
 class _StubWorker:
     """Minimal AdaptiveSpecWorker implementer for controller-construction tests.
 
-    Only the validation path runs in __init__, so build/apply are stubbed but
-    must exist to satisfy the Protocol's structural shape.
+    Mirrors EAGLEWorker's pool / num_draft_tokens formulas so the controller
+    sees realistic values without touching real GPU paths. build/apply are
+    stubbed but must exist to satisfy the Protocol's structural shape.
     """
 
     def __init__(self, *, speculative_num_steps, speculative_num_draft_tokens, topk):
         self.speculative_num_steps = speculative_num_steps
         self.speculative_num_draft_tokens = speculative_num_draft_tokens
         self.topk = topk
+
+    def get_draft_pool_size(self, num_steps):
+        if num_steps < 1:
+            return 0
+        return self.topk + (num_steps - 1) * self.topk * self.topk
+
+    def get_num_draft_tokens(self, num_steps):
+        if self.topk == 1:
+            return num_steps + 1
+        return self.speculative_num_draft_tokens
 
     def build_adaptive_runtime_state(
         self, speculative_num_steps, speculative_num_draft_tokens
@@ -249,7 +260,7 @@ class _StubWorker:
         raise NotImplementedError
 
 
-class TestValidateCandidateStepsAgainstTopk(unittest.TestCase):
+class TestValidateCandidateSteps(unittest.TestCase):
     def _make_config(self, candidate_steps):
         f = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False)
         json.dump({"candidate_steps": candidate_steps, "warmup_batches": 1}, f)
@@ -257,13 +268,25 @@ class TestValidateCandidateStepsAgainstTopk(unittest.TestCase):
         self.addCleanup(os.unlink, f.name)
         return f.name
 
-    def test_topk_one_skips_validation(self):
-        # server_args already enforces num_draft_tokens = num_steps + 1 at topk=1,
-        # so the controller must not raise even if numbers look mismatched.
+    def test_topk_one_passes_validation(self):
+        # server_args enforces num_draft_tokens = num_steps + 1 at topk=1,
+        # so the per-tier budget always matches that tier's pool size.
         worker = _StubWorker(
             speculative_num_steps=1, speculative_num_draft_tokens=2, topk=1
         )
         cfg = self._make_config([1, 3])
+        AdaptiveController(worker, config_path=cfg)  # must not raise
+
+    def test_topk_one_default_candidate_steps_passes(self):
+        # Regression: at topk=1 with the default candidate_steps=[1, 3, 7],
+        # the smallest tier (s=1) must validate against its own
+        # num_draft_tokens (=2 by the chain rule), not against the worker's
+        # initial num_draft_tokens (which tracks the user's --speculative-num-steps
+        # and could be much larger).
+        worker = _StubWorker(
+            speculative_num_steps=3, speculative_num_draft_tokens=4, topk=1
+        )
+        cfg = self._make_config([1, 3, 7])
         AdaptiveController(worker, config_path=cfg)  # must not raise
 
     def test_undersized_pool_raises(self):

--- a/test/registered/unit/spec/test_adaptive_spec_params.py
+++ b/test/registered/unit/spec/test_adaptive_spec_params.py
@@ -1,9 +1,17 @@
+import json
+import os
+import tempfile
 import unittest
+from types import SimpleNamespace
 
-from sglang.srt.speculative.adaptive_spec_params import AdaptiveSpeculativeParams
+from sglang.srt.speculative.adaptive_runtime_state import AdaptiveController
+from sglang.srt.speculative.adaptive_spec_params import (
+    AdaptiveSpeculativeParams,
+    adaptive_unsupported_reason,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="base-a-test-cpu")
 
 
 class TestAdaptiveSpeculativeParams(unittest.TestCase):
@@ -190,6 +198,111 @@ class TestAdaptiveSpeculativeParams(unittest.TestCase):
         self.assertTrue(params.update([0, 0]))
         self.assertEqual(params.current_steps, 1)
         self.assertEqual(params.ema_accept_len, 0.375)
+
+
+def _supported_server_args(**overrides):
+    """Minimal SimpleNamespace with the attributes adaptive_unsupported_reason reads."""
+    base = dict(
+        speculative_algorithm="EAGLE",
+        enable_dp_attention=False,
+        disable_overlap_schedule=True,
+        enable_multi_layer_eagle=False,
+        enable_two_batch_overlap=False,
+        enable_pdmux=False,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class TestAdaptiveUnsupportedReason(unittest.TestCase):
+    def test_topk_greater_than_one_is_supported(self):
+        # topk != 1 used to disable adaptive; tree EAGLE is now supported.
+        for topk in (2, 4, 8):
+            args = _supported_server_args(speculative_eagle_topk=topk)
+            self.assertIsNone(adaptive_unsupported_reason(args))
+
+    def test_non_eagle_algorithm_still_disables(self):
+        args = _supported_server_args(speculative_algorithm="STANDALONE")
+        self.assertIsNotNone(adaptive_unsupported_reason(args))
+
+
+class _StubWorker:
+    """Minimal AdaptiveSpecWorker implementer for controller-construction tests.
+
+    Only the validation path runs in __init__, so build/apply are stubbed but
+    must exist to satisfy the Protocol's structural shape.
+    """
+
+    def __init__(self, *, speculative_num_steps, speculative_num_draft_tokens, topk):
+        self.speculative_num_steps = speculative_num_steps
+        self.speculative_num_draft_tokens = speculative_num_draft_tokens
+        self.topk = topk
+
+    def build_adaptive_runtime_state(
+        self, speculative_num_steps, speculative_num_draft_tokens
+    ):
+        del speculative_num_steps, speculative_num_draft_tokens
+        raise NotImplementedError
+
+    def apply_runtime_state(self, state):
+        del state
+        raise NotImplementedError
+
+
+class TestValidateCandidateStepsAgainstTopk(unittest.TestCase):
+    def _make_config(self, candidate_steps):
+        f = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False)
+        json.dump({"candidate_steps": candidate_steps, "warmup_batches": 1}, f)
+        f.close()
+        self.addCleanup(os.unlink, f.name)
+        return f.name
+
+    def test_topk_one_skips_validation(self):
+        # server_args already enforces num_draft_tokens = num_steps + 1 at topk=1,
+        # so the controller must not raise even if numbers look mismatched.
+        worker = _StubWorker(
+            speculative_num_steps=1, speculative_num_draft_tokens=2, topk=1
+        )
+        cfg = self._make_config([1, 3])
+        AdaptiveController(worker, config_path=cfg)  # must not raise
+
+    def test_undersized_pool_raises(self):
+        # topk=4, candidate_steps=[1, 3], num_draft_tokens=20
+        # min_step=1 -> pool = 4; required >= 19 -> must raise.
+        worker = _StubWorker(
+            speculative_num_steps=1, speculative_num_draft_tokens=20, topk=4
+        )
+        cfg = self._make_config([1, 3])
+        with self.assertRaisesRegex(ValueError, "draft pool of only 4"):
+            AdaptiveController(worker, config_path=cfg)
+
+    def test_sufficient_pool_accepts(self):
+        # topk=4, candidate_steps=[2, 3], num_draft_tokens=20
+        # min_step=2 -> pool = 4 + 1*16 = 20; required >= 19 -> OK.
+        worker = _StubWorker(
+            speculative_num_steps=3, speculative_num_draft_tokens=20, topk=4
+        )
+        cfg = self._make_config([2, 3])
+        AdaptiveController(worker, config_path=cfg)  # must not raise
+
+    def test_boundary_pool_equals_required_passes(self):
+        # topk=4, candidate_steps=[2, 3], num_draft_tokens=21
+        # min_step=2 -> pool = 20; required = 20 -> exactly at boundary, OK.
+        worker = _StubWorker(
+            speculative_num_steps=3, speculative_num_draft_tokens=21, topk=4
+        )
+        cfg = self._make_config([2, 3])
+        AdaptiveController(worker, config_path=cfg)
+
+    def test_off_by_one_above_boundary_raises(self):
+        # topk=4, candidate_steps=[2, 3], num_draft_tokens=22
+        # min_step=2 -> pool = 20; required = 21 -> fails by exactly 1.
+        worker = _StubWorker(
+            speculative_num_steps=3, speculative_num_draft_tokens=22, topk=4
+        )
+        cfg = self._make_config([2, 3])
+        with self.assertRaisesRegex(ValueError, "draft pool of only 20"):
+            AdaptiveController(worker, config_path=cfg)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Tracking issue: #23705 (Compatibility → topk > 1).

## Motivation

Extends adaptive speculative decoding to support `speculative_eagle_topk > 1` (tree EAGLE). Static EAGLE already supports topk>1; only the adaptive runtime-state pool assumed a chain shape (`num_draft_tokens = num_steps + 1`).

## Changes

- Tighten the `AdaptiveSpecWorker` Protocol: declare `topk: int` and `speculative_num_draft_tokens: int` alongside the existing `speculative_num_steps`, plus two algorithm-specific helpers (`get_draft_pool_size(steps)`, `get_num_draft_tokens(steps)`) so the controller stays generic. `EAGLEWorker` already exposed the attributes; the helpers are new.
- Drop the `topk != 1` guard in `adaptive_unsupported_reason`.
- Generalize `AdaptiveController.init_states` to ask the worker for the per-tier draft-token budget via `get_num_draft_tokens(steps)`. For EAGLE tree mode (`topk > 1`), the worker keeps `num_draft_tokens` constant across tiers; per-tier tree budgets are intentionally deferred (see Out of scope).
- Add validation through the worker-provided `get_draft_pool_size(steps)`: the smallest `candidate_steps` tier must yield at least `num_draft_tokens(min_step) - 1` draft candidates. For EAGLE the pool is `topk + (num_steps - 1) * topk^2` (derived from `select_top_k_tokens` and `organize_draft_results`); chain-mode (`topk = 1`) trivially satisfies this. The controller raises at startup when violated, naming both the failing min step and the cap. Note: `topk > 1` users with larger tree budgets may need an adaptive config such as `candidate_steps=[2,3]` instead of the default `[1,3,7]`.
- Refactor `test_adaptive_speculative.py` helpers to take an explicit step target so the new `topk > 1` test can reuse the same shape with a different downshift floor (2 instead of 1). Pure no-op for the existing topk=1 expectations.

## Tests

CI:
- `test_adaptive_spec_params.py` — `TestAdaptiveUnsupportedReason` (topk != 1 no longer disables; non-EAGLE still does) and `TestValidateCandidateSteps` (chain default passes, topk=1 default candidate_steps=[1,3,7] regression, undersized-pool reject, sufficient-pool accept, exact off-by-one boundary in both directions).
- `test_adaptive_speculative_topk.py` — EAGLE topk=4 with `candidate_steps=[2,3]`, drives upshift to 3, downshift to 2, upshift back to 3, plus a smoke decode after the second upshift. `est_time=80`, same suite as the existing adaptive test.

Test config note: this test uses lightly smoothed `ema_alpha=0.3` with `down_hysteresis=-0.5` instead of the topk=1 test's fast-mode `ema_alpha=1.0`. The fast-mode config inherited from #21599 implicitly assumes per-batch deterministic accept_len, which holds for chain-mode + repetitive prompt but breaks for tree mode where path selection introduces algorithmic per-batch variance even under HIGH_ACCEPT prompts. Empirically with fast-mode the controller oscillates between tiers every batch (~200 switches in a 568s run) and post-`_generate` polling reliably lands on the downshifted tier. The smoothing absorbs that variance — controller settles, polling catches the target. Production-config behavior is exercised separately in the throughput benchmark below.

Local — both topk=1 regression e2e and the new topk>1 e2e run cleanly on a Blackwell sm_120 dev box (driver 580 / CUDA 13.0). `FLASHINFER_CUDA_ARCH_LIST="12.0f"` env override needed only because the dev box's nvcc is 12.8 while flashinfer's normalize path requires 12.9+ for sm_120 — unrelated to this PR.

## Throughput Benchmark (topk=4)

Run via `benchmark/bench_adaptive_speculative.py` against parallel servers (one per GPU). All servers share `--speculative-eagle-topk 4 --speculative-num-draft-tokens 16 --mem-fraction-static 0.7 --disable-radix-cache --attention-backend flashinfer`. The compared modes are `static-n2` (`--speculative-num-steps 2`), `static-n3` (`--speculative-num-steps 3`), and `adaptive` (`--speculative-num-steps 3 --speculative-adaptive --speculative-adaptive-config <production-like>`).

### Environment

- GPU: 2× NVIDIA RTX PRO 4500 Blackwell (sm_120, 32 GB) — one server per GPU
- Target: `meta-llama/Llama-2-7b-chat-hf`
- Draft: `lmsys/sglang-EAGLE-llama2-chat-7B`
- Workload: `transition` (low_1 → high_1 → low_2 → high_2), 16 requests/phase, concurrency 8, max_tokens 256, warmup 2
- Adaptive config (production-like): `ema_alpha=0.2, warmup_batches=10, update_interval=5, down_hysteresis=-0.25, up_hysteresis=0.0, candidate_steps=[2,3]`

### Per-phase throughput (tok/s) and accept length

| Mode | low_1 | high_1 | low_2 | high_2 | overall |
|---|---:|---:|---:|---:|---:|
| static-n2 | 499.5 (acc 2.03) | 885.9 (acc 2.98) | 568.5 (acc 2.03) | 884.6 (acc 2.98) | 666.2 |
| static-n3 | 287.6 (acc 2.19) | **1090.5** (acc 3.88) | **586.0** (acc 2.19) | **1084.3** (acc 3.88) | 572.1 |
| **adaptive** | **563.5** (acc 2.03) | 1078.2 (acc 3.82) | 567.6 (acc 2.04) | 1082.7 (acc 3.88) | **744.6** |

### Summary

- **adaptive overall throughput is +11.8% vs the best static (`static-n2`, 666.2 tok/s) and +30% vs `static-n3` (572.1 tok/s)**. No single static config wins both regimes; adaptive follows the better tier closely enough to win overall.
- In `high` phases, adaptive (1078, 1082) matches `static-n3` (1090, 1084) — controller upshifts to `num_steps=3` cleanly. `static-n2` lags by ~19% because its smaller tree underutilizes acceptance.
- In `low` phases, adaptive's accept length (2.03, 2.04) matches `static-n2`'s (2.03, 2.03) — controller has downshifted to `num_steps=2`. Throughput in `low_1` clearly favors adaptive and `static-n2` over `static-n3` (which wastes compute on rejected drafts at 287.6 tok/s, ~50% of the others); `low_2` is roughly comparable across all three modes (single-run variance).
- The per-phase accept-length values directly confirm the controller swaps `num_steps` tiers: adaptive's accept (~2.03 in low, ~3.85 in high) tracks `static-n2`'s in low phases and `static-n3`'s in high phases. Static configs hold a single tier — `static-n2` caps accept at ~2.98 in high (smaller tree limits ceiling), and `static-n3` carries `num_steps=3` cost into low for only ~2.19 accept (vs `static-n2`'s 2.03 there).

### Controller behavior

Under the production-like config above, the controller logged 6 tier transitions (3 up, 3 down) across the full run, with continuous EMA values at transition points (1.58, 1.61, 0.98, 0.93, 0.87, 0.72) — i.e. responsive but not noisy. Under the test's fast-mode config (`ema_alpha=1.0`), the same workload produces ~200 transitions, confirming smoothing is doing real work.

## Accuracy Test (GSM8K, topk=4)

Same environment as the throughput benchmark; `static-n3` and `adaptive` servers running in parallel; eval via `python -m sglang.test.run_eval --eval-name gsm8k --num-examples 100 --num-threads 8`.

| Mode | Score | Latency | Output throughput |
|---|---:|---:|---:|
| static-n3 | 0.100 | 62.26 s | 564.3 tok/s |
| adaptive | **0.100** | **61.63 s** | **569.1 tok/s** |

Score parity confirms the adaptive runtime-state swap does not introduce correctness drift mid-decode. (`Llama-2-7b-chat` is a chat model, so its absolute GSM8K score at N=100 is low — what matters here is that adaptive matches static.)


## Out of scope (follow-up)

- **Per-tier `num_draft_tokens`** — needs API/config design and additional runtime-state coverage.
- **Per-tier `topk`** — `_override_worker_state` does not currently swap `self.topk`, and several worker-init buffers / draft attention backend factories are sized at startup with a fixed topk.
- **Lazy-init of tiers** — tracked under Reliability in #23705.
- **`step = 0` adaptive on/off** — separate roadmap item, currently assigned.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

cc @alphabetc1 @Qiaolin-Yu











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26076911989](https://github.com/sgl-project/sglang/actions/runs/26076911989)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->