### PR TITLE
Add SGLang report for Qwen3-0.6B model

### DIFF
--- a/docs/basic_usage/Qwen3-0.6B
+++ b/docs/basic_usage/Qwen3-0.6B
@@ -1,0 +1,170 @@
+
+# SGLang Benchmark on Ascend Atlas 800I A2 (Single NPU)
+
+This document presents a baseline performance evaluation of SGLang on Ascend Atlas 800I A2 using the Qwen3-0.6B model. The goal is to verify service availability, streaming latency, and concurrency scalability on Ascend backend.
+
+---
+
+## 1. Environment
+
+| Item | Value |
+|------|------|
+| Model | Qwen/Qwen3-0.6B |
+| Backend | Ascend NPU |
+| Device | Atlas 800I A2 (single card) |
+| SGLang Version | 7603b226c |
+| Python | 3.11.6 |
+| OS | Linux 5.15 |
+| Context Length | 40960 |
+
+---
+
+## 2. Service Setup
+
+### Launch Parameters
+
+```bash
+--device npu
+--attention-backend ascend
+--host 127.0.0.1
+--port 8188
+--mem-fraction-static 0.4
+--chunked-prefill-size 4096
+--disable-cuda-graph
+````
+
+> Note: `--disable-cuda-graph` is required. See Section 6.
+
+---
+
+## 3. Functionality Verification
+
+The following endpoints were validated:
+
+* `/health`
+* `/v1/models`
+* `/model_info`
+* `/generate`
+* `/v1/chat/completions`
+
+All endpoints responded correctly.
+
+---
+
+## 4. Benchmark Method
+
+Benchmark script:
+
+```bash
+python3 benchmark_sglang.py \
+  --base-url http://127.0.0.1:8188 \
+  --model Qwen/Qwen3-0.6B \
+  --concurrency 1,4,8
+```
+
+### Metrics
+
+* TTFT (Time To First Token)
+* End-to-End Latency
+* Request Throughput
+* Token Throughput
+
+---
+
+## 5. Results
+
+### 5.1 Streaming Performance
+
+| Metric              | Value     |
+| ------------------- | --------- |
+| TTFT                | 79.93 ms  |
+| Total Response Time | 344.18 ms |
+
+This indicates good interactive latency for a 0.6B model.
+
+---
+
+### 5.2 Concurrency Scaling
+
+| Concurrency | Req/s | Tok/s  | Avg Latency |
+| ----------- | ----- | ------ | ----------- |
+| 1           | 2.93  | 93.89  | 340.73 ms   |
+| 4           | 3.28  | 104.80 | 1220.75 ms  |
+| 8           | 6.43  | 205.89 | 1233.78 ms  |
+
+### Observation
+
+* Throughput increases with concurrency
+* Latency increases significantly
+
+This suggests scheduling overhead under higher load.
+
+---
+
+## 6. Known Issue: CUDA Graph on Ascend
+
+When enabling CUDA graph (default behavior), the service fails with:
+
+```
+0 active drivers ([])
+```
+
+### Workaround
+
+```bash
+--disable-cuda-graph
+```
+
+### Analysis
+
+Possible reasons:
+
+1. CUDA graph is not supported on Ascend backend
+2. Graph runner cannot find valid backend driver
+3. Triton-Ascend lacks graph execution support
+
+### Recommendation
+
+* Add automatic fallback when graph init fails
+* Improve logging for backend compatibility
+
+---
+
+## 7. Additional Observations
+
+### Cold Start
+
+* First request latency: ~9s
+* Likely due to model initialization and memory allocation
+
+### Multi-turn Stability
+
+* 5-turn latency: 341–389 ms
+* Stable across turns
+
+### Long Context
+
+* ~7k tokens prompt processed in ~513 ms
+* No obvious degradation observed
+
+---
+
+## 8. Conclusion
+
+* SGLang runs successfully on Ascend Atlas 800I A2
+* Streaming latency is low (TTFT ~80 ms)
+* Throughput scales with concurrency
+* CUDA graph must be disabled
+
+This report provides a baseline for future optimization.
+
+---
+
+## 9. Future Work
+
+* Enable CUDA graph or equivalent optimization on Ascend
+* Improve scheduling under high concurrency
+* Optimize KV cache management
+
+```
+


### PR DESCRIPTION

This document evaluates the performance of SGLang on Ascend Atlas 800I A2 using the Qwen3-0.6B model, covering service setup, functionality verification, benchmarking, and results.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR adds a benchmark report for running SGLang on Ascend Atlas 800I A2 (NPU backend).

Currently, most performance references are focused on CUDA/GPU environments. This contribution aims to:

- Provide a reproducible baseline for Ascend deployment
- Validate service availability on NPU backend
- Evaluate streaming latency (TTFT) and concurrency scalability
- Document known issues (e.g., CUDA graph incompatibility)

This can help users who deploy SGLang in non-CUDA environments better understand expected performance and limitations.

---

## Modifications

- Add a new benchmark document:

```

docs/performance/ascend_a2_sglang_benchmark.md

```

The document includes:

- Environment and hardware setup
- Service launch configuration for Ascend backend
- Endpoint functionality verification
- Benchmark methodology and scripts
- Streaming performance (TTFT)
- Concurrency scaling results
- Known issue analysis (CUDA graph failure)
- Practical observations (cold start, long context, multi-turn)

No code changes are introduced in this PR.

---

## Accuracy Tests

This PR does not modify model logic or kernel implementation.

However, basic correctness is verified:

- `/generate` produces valid outputs
- `/v1/chat/completions` supports multi-turn conversations
- Model metadata (`/model_info`) is correctly loaded

All outputs are consistent with expected behavior.

---

## Speed Tests and Profiling

Benchmark results (Ascend Atlas 800I A2, single card):

### Streaming Performance

- TTFT: **~79.93 ms**
- Total response time: **~344.18 ms**

### Concurrency Scaling

| Concurrency | Request Throughput | Token Throughput | Avg Latency |
|------------|------------------|------------------|------------|
| 1 | 2.93 req/s | 93.89 tok/s | 340.73 ms |
| 4 | 3.28 req/s | 104.80 tok/s | 1220.75 ms |
| 8 | 6.43 req/s | 205.89 tok/s | 1233.78 ms |

### Key Observations

- Throughput increases with concurrency
- Latency increases significantly under higher load
- Indicates scheduling overhead and resource contention

### Known Limitation

CUDA graph must be disabled:

```

--disable-cuda-graph

```

Otherwise, initialization fails with:

```

0 active drivers ([])

```

---

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

---

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with comments or contact authorized users if needed.
4. After approvals, request merge.

---

## Additional Notes

- All results are collected under **graph-off baseline** due to Ascend compatibility.
- This report is intended as a **reference baseline**, not peak performance.
- Future work may include enabling graph execution or improving scheduling on NPU backend.
```
