### PR TITLE
[AMD][MoRI] Support per-layer KV item lens in disaggregated serving 

### DIFF
--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -191,6 +191,7 @@ class KVArgsRegisterInfo:
     dst_kv_item_len: int
     dst_state_item_lens: List[List[int]]
     dst_state_dim_per_tensor: List[List[int]]
+    dst_kv_item_lens: List[int]
 
     @property
     def engine_key(self) -> str:
@@ -218,6 +219,14 @@ class KVArgsRegisterInfo:
             if len(payload) > 12 and payload[12]
             else []
         )
+        # Per-layer KV item lens (payload[13]); falls back to broadcasting
+        # the scalar dst_kv_item_len across every dst KV descriptor when
+        # the sender is older and does not include this slot.
+        dst_kv_item_lens = (
+            list(struct.unpack(f"{len(payload[13]) // 4}I", payload[13]))
+            if len(payload) > 13 and len(payload[13]) > 0
+            else [dst_kv_item_len] * len(dst_kv_mem_descs)
+        )
         return cls(
             endpoint=endpoint,
             dst_port=dst_port,
@@ -231,6 +240,7 @@ class KVArgsRegisterInfo:
             dst_kv_item_len=dst_kv_item_len,
             dst_state_item_lens=dst_state_item_lens,
             dst_state_dim_per_tensor=dst_state_dim_per_tensor,
+            dst_kv_item_lens=dst_kv_item_lens,
         )
 
 
@@ -753,11 +763,13 @@ class MoriKVManager(CommonKVManager):
         # Reuse grouped indices across all layers/tensors that share the same item length.
         return grouped_plan.materialize(item_len)
 
-    def _build_tp_slice_config(self, peer_info: KVArgsRegisterInfo) -> TPSliceConfig:
+    def _build_tp_slice_config(
+        self,
+        peer_info: KVArgsRegisterInfo,
+        src_item_len: int,
+        dst_item_len: int,
+    ) -> TPSliceConfig:
         page_size = self.kv_args.page_size
-
-        src_item_len = self.kv_args.kv_item_lens[0]
-        dst_item_len = peer_info.dst_kv_item_len
 
         bytes_per_token_src = src_item_len // page_size
         bytes_per_token_dst = dst_item_len // page_size
@@ -878,15 +890,29 @@ class MoriKVManager(CommonKVManager):
             )
         )
         statuses: List[TransferStatus] = []
-        kv_item_len = self.kv_args.kv_item_lens[0]
+        src_kv_item_lens = self.kv_args.kv_item_lens
+        dst_kv_item_lens = peer_info.dst_kv_item_lens
+        start_layer = self.kv_args.prefill_start_layer
+
+        def _layer_item_lens(src_idx: int, dst_idx: int) -> tuple[int, int]:
+            src_len = src_kv_item_lens[src_idx]
+            dst_len = dst_kv_item_lens[dst_idx] if dst_kv_item_lens else src_len
+            if src_len != dst_len:
+                raise ValueError(
+                    "MoRI requires matching src/dst KV item lens per layer: "
+                    f"src_idx={src_idx} ({src_len}) vs dst_idx={dst_idx} "
+                    f"({dst_len})"
+                )
+            return src_len, dst_len
 
         if self.is_mla_backend:
             src_descs, dst_descs, layers_current_pp_stage = (
                 self._get_mla_mem_desc_slices(peer_info.dst_kv_mem_descs)
             )
             for layer_id in range(layers_current_pp_stage):
+                src_item_len, _ = _layer_item_lens(layer_id, start_layer + layer_id)
                 layer_plan = self._build_contiguous_transfer_plan(
-                    grouped_plan, self.kv_args.kv_item_lens[layer_id]
+                    grouped_plan, src_item_len
                 )
                 statuses.extend(
                     self._submit_batch_transfer_plan(
@@ -904,43 +930,66 @@ class MoriKVManager(CommonKVManager):
             dst_v_descs,
             layers_current_pp_stage,
         ) = self._get_mha_mem_desc_slices(peer_info.dst_kv_mem_descs)
+        # MHA KV item lens layout: K-layers first, then V-layers.
+        # Source has num_local_layers per side; destination spans the full
+        # decode-side model so K starts at start_layer and V starts at
+        # dst_total_layers + start_layer.
+        num_local_layers = layers_current_pp_stage
+        dst_total_layers = len(peer_info.dst_kv_mem_descs) // 2
+        k_src_off = 0
+        v_src_off = num_local_layers
+        k_dst_off = start_layer
+        v_dst_off = dst_total_layers + start_layer
 
         if peer_info.decode_tp_size != self.attn_tp_size:
-            tp_cfg = self._build_tp_slice_config(peer_info)
-            slice_plan = self._build_tp_slice_transfer_plan(
-                prefill_kv_indices, dst_kv_indices, tp_cfg
-            )
             for layer_id in range(layers_current_pp_stage):
+                k_src_len, k_dst_len = _layer_item_lens(
+                    k_src_off + layer_id, k_dst_off + layer_id
+                )
+                k_tp_cfg = self._build_tp_slice_config(peer_info, k_src_len, k_dst_len)
+                k_slice_plan = self._build_tp_slice_transfer_plan(
+                    prefill_kv_indices, dst_kv_indices, k_tp_cfg
+                )
                 statuses.extend(
                     self._submit_batch_transfer_plan(
                         src_k_descs[layer_id],
                         dst_k_descs[layer_id],
-                        slice_plan,
+                        k_slice_plan,
                     )
+                )
+                v_src_len, v_dst_len = _layer_item_lens(
+                    v_src_off + layer_id, v_dst_off + layer_id
+                )
+                v_tp_cfg = self._build_tp_slice_config(peer_info, v_src_len, v_dst_len)
+                v_slice_plan = self._build_tp_slice_transfer_plan(
+                    prefill_kv_indices, dst_kv_indices, v_tp_cfg
                 )
                 statuses.extend(
                     self._submit_batch_transfer_plan(
                         src_v_descs[layer_id],
                         dst_v_descs[layer_id],
-                        slice_plan,
+                        v_slice_plan,
                     )
                 )
             return statuses
 
-        layer_plan = self._build_contiguous_transfer_plan(grouped_plan, kv_item_len)
         for layer_id in range(layers_current_pp_stage):
+            k_src_len, _ = _layer_item_lens(k_src_off + layer_id, k_dst_off + layer_id)
+            k_layer_plan = self._build_contiguous_transfer_plan(grouped_plan, k_src_len)
             statuses.extend(
                 self._submit_batch_transfer_plan(
                     src_k_descs[layer_id],
                     dst_k_descs[layer_id],
-                    layer_plan,
+                    k_layer_plan,
                 )
             )
+            v_src_len, _ = _layer_item_lens(v_src_off + layer_id, v_dst_off + layer_id)
+            v_layer_plan = self._build_contiguous_transfer_plan(grouped_plan, v_src_len)
             statuses.extend(
                 self._submit_batch_transfer_plan(
                     src_v_descs[layer_id],
                     dst_v_descs[layer_id],
-                    layer_plan,
+                    v_layer_plan,
                 )
             )
         return statuses
@@ -1641,6 +1690,9 @@ class MoriKVReceiver(CommonKVReceiver):
         packed_state_dim_per_tensor = pack_int_lists(
             self.kv_mgr.kv_args.state_dim_per_tensor, "I"
         )
+        packed_kv_item_lens = b"".join(
+            struct.pack("I", item_len) for item_len in self.kv_mgr.kv_args.kv_item_lens
+        )
 
         for bootstrap_info in self.bootstrap_infos:
             sock, lock = self._connect_to_bootstrap_server(bootstrap_info)
@@ -1661,6 +1713,7 @@ class MoriKVReceiver(CommonKVReceiver):
                         kv_item_len,
                         packed_state_item_lens,
                         packed_state_dim_per_tensor,
+                        packed_kv_item_lens,
                     ]
                 )
 


### PR DESCRIPTION
## Motivation

The current MoRI disaggregation path assumes a single `dst_kv_item_len` (int) applies to every layer on the destination. For architectures that expose different item sizes per layer (e.g., MLA models, or cases where the prefill and decode sides have non-uniform KV shapes), this causes address computation to use the wrong stride for all layers but the first, corrupting the KV cache transfer.

## Modifications

All changes are confined to `python/sglang/srt/disaggregation/mori/conn.py`.

- `KVArgsRegisterInfo`: replace `dst_kv_item_len: int` with `dst_kv_item_lens: List[int]` (per-layer). A `dst_kv_item_len` property is retained for backward compatibility (returns the first element).
- Wire format: the list is sent in `payload[11]` using msgpack; when absent or empty, the parser falls back to broadcasting the legacy scalar across all layers, so peers still running the old protocol remain compatible.
- `MoriKVManager._split_descs_and_lens()` (renamed): accepts `KVArgsRegisterInfo` and returns per-layer `src_/dst_k_item_lens` and `src_/dst_v_item_lens` alongside the descriptor lists.
- RDMA scheduling uses the per-layer lens when computing source and destination strides.

## Known overlap / caveat for reviewers

Open PR #22665 ("[PD] MORI-IO: Add state transfer, inline transfer model, and high-concurrency fixes") also extends `KVArgsRegisterInfo` and the `from_zmq` parser, introducing `dst_state_item_lens` / `dst_state_dim_per_tensor` at `payload[11]` / `payload[12]`. This PR uses `payload[11]` for `dst_kv_item_lens`. Both changes are orthogonal in intent (state transfer vs. per-layer KV item lens) but collide on the wire slot. If either lands first, the second should renumber its slot(s) during rebase.

## Accuracy Tests

TODO before push: rerun GSM8K on a 2-node PD setup with MLA-type model (where per-layer item lens differ) to show correctness regression before this fix and correct results after.

## Speed Tests and Profiling

Not expected to affect hot path throughput; only changes the per-request stride computation at transfer-setup time.

This change was developed with AI assistance; the author has reviewed and tested each hunk and is accountable for the behavior.


Signed-off-by: Chaemin Lim <chaemin.lim@mangoboost.io>

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27677865338](https://github.com/sgl-project/sglang/actions/runs/27677865338)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27677864896](https://github.com/sgl-project/sglang/actions/runs/27677864896)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->