### PR TITLE
[PATCH] fix(hicache): defer prefill-aligned slot free to request finish

### DIFF
--- a/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
+++ b/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
@@ -153,9 +153,11 @@ class DecodeKVCacheOffloadManager:
         incremental_tokens = all_tokens[start:end]
         incremental_indices = token_indices[start:end]
 
-        # Early free prefill-offloaded GPU memory
-        if state.prefill_len > 0 and state.inc_len == 0:
-            self.token_to_kv_pool_allocator.free(token_indices[: state.prefill_len])
+        # Prefill-aligned GPU slots are freed at request finish in
+        # _release_finished_req, NOT here. The decoding request
+        # continues to attend to those slots via req_to_token; freeing
+        # them mid-decode races with concurrent admission, which can
+        # reuse the slots and produce cross-pollinated KV reads.
 
         # Asynchronously offload incremental KV cache from device to host
         self.request_counter += 1
@@ -236,6 +238,18 @@ class DecodeKVCacheOffloadManager:
 
     def _release_finished_req(self, req: Req, start_offset: int):
         kv_committed_len = req.pop_committed_kv_cache()
+
+        # Free the prefill-aligned slots. Previously this was done
+        # eagerly in offload_kv_cache (mid-decode), which raced with
+        # concurrent admission. Now consolidated here at request
+        # finish, where the request is guaranteed to no longer attend
+        # to those slots.
+        state = self.offloaded_state.get(req.rid)
+        if state is not None and state.prefill_len > 0:
+            prefill_indices = self.req_to_token_pool.req_to_token[
+                req.req_pool_idx, : state.prefill_len
+            ]
+            self.token_to_kv_pool_allocator.free(prefill_indices)
         start = start_offset
         end = kv_committed_len
         # Free the incremental part of the request (NSA-aware)
@@ -305,13 +319,11 @@ class DecodeKVCacheOffloadManager:
         else:
             prefill_len = state.prefill_len
             inc_len = state.inc_len
-        # If no incremental offload ever happened, the prefill-aligned part was never freed.
-        # Free the prefill portion on request finish to avoid leaks.
-        if prefill_len > 0 and inc_len == 0:
-            token_indices = self.req_to_token_pool.req_to_token[req.req_pool_idx]
-            self.token_to_kv_pool_allocator.free(token_indices[:prefill_len])
-            logger.info(
-                f"Finalize release: freed prefill-aligned KV for req {req.rid}, len:{prefill_len}"
+        # Prefill-aligned slots are freed by _release_finished_req. Make
+        # sure state exists so it can find prefill_len.
+        if state is None:
+            self.offloaded_state[req.rid] = OffloadedState(
+                prefill_len=prefill_len, inc_len=0, last_hash=None
             )
         start_offset = prefill_len + inc_len
         self._release_finished_req(req, start_offset)

--- a/test/registered/disaggregation/test_disaggregation_decode_offload.py
+++ b/test/registered/disaggregation/test_disaggregation_decode_offload.py
@@ -20,7 +20,6 @@ from sglang.test.test_utils import (
 register_cuda_ci(
     est_time=600,
     suite="stage-b-test-2-gpu-large",
-    disabled="Temporarily disable the flaky test.",
 )
 
 

--- a/test/registered/disaggregation/test_specv2_kvcache_offloading.py
+++ b/test/registered/disaggregation/test_specv2_kvcache_offloading.py
@@ -15,6 +15,7 @@ import torch
 from sglang.srt.disaggregation.decode_kvcache_offload_manager import (
     DecodeKVCacheOffloadManager,
 )
+from sglang.srt.disaggregation.kv_events import OffloadedState
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=8, suite="stage-b-test-1-gpu-small")
@@ -175,6 +176,94 @@ class TestReleaseFinishedReq(unittest.TestCase):
         manager._release_finished_req(req, start_offset=0)
 
         self.assertEqual(manager.tree_cache.protected_size_, 5)
+
+    def test_release_finished_req_frees_prefill_when_state_present(self):
+        """
+        When offloaded_state[rid].prefill_len > 0, _release_finished_req must
+        free the prefill-aligned slots in addition to the committed range.
+
+        This is the consolidated free path that replaces the eager free that
+        previously happened in offload_kv_cache (which raced with concurrent
+        admission and produced cross-pollinated KV reads).
+        """
+        manager, freed = _make_manager(pool_size=32)
+        rid = "req-prefill-present"
+        req = _make_mock_req(
+            req_pool_idx=0,
+            kv_committed_len=20,
+            kv_allocated_len=20,
+            rid=rid,
+        )
+        manager.offloaded_state[rid] = OffloadedState(
+            prefill_len=8, inc_len=0, last_hash=None
+        )
+
+        manager._release_finished_req(req, start_offset=8)
+
+        # Two frees in order: prefill [0:8] then committed [8:20].
+        self.assertEqual(len(freed), 2)
+        expected_prefill = torch.arange(0, 8, dtype=torch.int64)
+        expected_committed = torch.arange(8, 20, dtype=torch.int64)
+        self.assertTrue(torch.equal(freed[0], expected_prefill))
+        self.assertTrue(torch.equal(freed[1], expected_committed))
+        # State entry is removed at the end of _release_finished_req.
+        self.assertNotIn(rid, manager.offloaded_state)
+
+    def test_release_finished_req_skips_prefill_free_when_prefill_len_zero(self):
+        """
+        When state exists but prefill_len == 0 (request shorter than page_size,
+        so no prefill chunk was ever offloaded), no prefill-aligned free is
+        emitted.
+        """
+        manager, freed = _make_manager(pool_size=32)
+        rid = "req-prefill-zero"
+        req = _make_mock_req(
+            req_pool_idx=0,
+            kv_committed_len=10,
+            kv_allocated_len=10,
+            rid=rid,
+        )
+        manager.offloaded_state[rid] = OffloadedState(
+            prefill_len=0, inc_len=0, last_hash=None
+        )
+
+        manager._release_finished_req(req, start_offset=0)
+
+        # Only the committed range [0:10] is freed.
+        self.assertEqual(len(freed), 1)
+        expected_committed = torch.arange(0, 10, dtype=torch.int64)
+        self.assertTrue(torch.equal(freed[0], expected_committed))
+
+    def test_finalize_release_creates_state_so_prefill_is_freed(self):
+        """
+        finalize_release_on_finish handles the case where no incremental
+        offload ever ran (offloaded_state is empty). It must materialize an
+        OffloadedState with the correct prefill_len so that the consolidated
+        free site in _release_finished_req can locate and free those slots.
+        """
+        page_size = 4
+        manager, freed = _make_manager(pool_size=32, page_size=page_size)
+        rid = "req-finalize-no-state"
+        req = _make_mock_req(
+            req_pool_idx=0,
+            kv_committed_len=13,
+            kv_allocated_len=13,
+            rid=rid,
+        )
+        # 12 input tokens => prefill_len = 12 // 4 * 4 = 12
+        req.origin_input_ids = list(range(12))
+
+        manager.finalize_release_on_finish(req)
+
+        # finalize creates state, then _release_finished_req frees:
+        #   prefill [0:12] then committed [12:13].
+        self.assertEqual(len(freed), 2)
+        expected_prefill = torch.arange(0, 12, dtype=torch.int64)
+        expected_committed = torch.arange(12, 13, dtype=torch.int64)
+        self.assertTrue(torch.equal(freed[0], expected_prefill))
+        self.assertTrue(torch.equal(freed[1], expected_committed))
+        # State is deleted by _release_finished_req on the way out.
+        self.assertNotIn(rid, manager.offloaded_state)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`DecodeKVCacheOffloadManager.offload_kv_cache` previously called `token_to_kv_pool_allocator.free(token_indices[:state.prefill_len])` on the first incremental offload of each request (after `offload_stride` = `page_size` decode tokens). The request continues to decode and attend to those slot indices via `req_to_token_pool.req_to_token`, so reusing them by a concurrent new request's prefill produces cross-pollinated KV reads. Symptom: ~5% of responses collapse mid-decode into a degenerate fixed-point loop of literal substrings from a peer request's prompt under sustained load.

## Modifications

Move all prefill-aligned slot freeing into `_release_finished_req`, which is only invoked once the request is finished and no longer reads from those slots. Update `finalize_release_on_finish` to ensure `offloaded_state[req.rid]` exists so the consolidated free site can find `prefill_len`. Re-enable the upstream e2e test that was disabled on 2026-03-15 in PR #20622, which was likely seeing the same race at lower rates with `--page-size 16` + file-backed HiCache.

## Accuracy Tests

This behavior could be triggered by sending sufficient concurrent load (depending on deployment size) to cause KV pages to be re-used after free, while the original request was still decoding. Request sizes must be sufficiently large to trigger KV offload. In my case I observed a roughly 5% error rate prior to this patch, and 0% error rate after applying this patch.

## Speed Tests and Profiling

I do not believe this should impact performance, although it will result in slots being held longer. This seems to me to be unavoidable, but its possible I'm missing something.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
