### PR TITLE
fix(model_runner): bootstrap registration must respect --host bind family

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -840,23 +840,24 @@ class ModelRunner(ModelRunnerKVCacheMixin):
     def _register_to_engine_info_bootstrap(self):
         """Register transfer engine info with the EngineInfoBootstrapServer via HTTP PUT.
 
-        The bootstrap server runs on node_rank==0. For multi-node setups, the
-        host is derived from dist_init_addr. For single-node, use 127.0.0.1.
+        The bootstrap server runs on node_rank==0. For multi-node setups the
+        host is derived from dist_init_addr. For single-node we reuse
+        engine_info_bootstrap_url so the loopback respects the bind family
+        (`::` -> `::1`, `0.0.0.0` -> `127.0.0.1`); hardcoding 127.0.0.1 breaks
+        IPv6-only pods where the bootstrap server only accepts IPv6 connections.
         """
         import requests as http_requests
 
         if self.server_args.dist_init_addr:
-            # Multi-node: bootstrap server is on the head node (node_rank==0).
-            # Derive host from dist_init_addr (shared across all nodes).
             bootstrap_host = (
                 NetworkAddress.parse(self.server_args.dist_init_addr).resolved().host
             )
+            bootstrap_port = self.server_args.engine_info_bootstrap_port
+            bootstrap_url = NetworkAddress(bootstrap_host, bootstrap_port).to_url()
         else:
-            bootstrap_host = "127.0.0.1"
+            bootstrap_url = self.server_args.engine_info_bootstrap_url
 
-        bootstrap_port = self.server_args.engine_info_bootstrap_port
-        bootstrap_na = NetworkAddress(bootstrap_host, bootstrap_port)
-        url = f"{bootstrap_na.to_url()}/register_transfer_engine_info"
+        url = f"{bootstrap_url}/register_transfer_engine_info"
 
         payload = {
             "tp_rank": self.tp_rank,
@@ -871,7 +872,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             if resp.status_code == 200:
                 logger.info(
                     f"Registered transfer engine info for tp_rank={self.tp_rank} "
-                    f"with bootstrap server at {bootstrap_na}"
+                    f"with bootstrap server at {bootstrap_url}"
                 )
             else:
                 logger.error(

--- a/test/registered/unit/model_executor/test_engine_info_bootstrap_ipv6.py
+++ b/test/registered/unit/model_executor/test_engine_info_bootstrap_ipv6.py
@@ -1,0 +1,88 @@
+"""Regression test: bootstrap registration URL must respect --host bind family.
+
+Bug: ModelRunner._register_to_engine_info_bootstrap hardcoded
+    bootstrap_host = "127.0.0.1"
+for the single-node path. When the SGLang server is launched with `--host ::`
+(IPv6-only pods, V6ONLY=1), the EngineInfoBootstrapServer only accepts IPv6
+connections, so the IPv4 PUT is refused → registration silently fails → the
+seed's transfer_engine_info dict stays empty → R-Fork client gets 404 from
+/get_remote_instance_transfer_engine_info and weight transfer hangs.
+
+Fix: reuse server_args.engine_info_bootstrap_url, which already maps
+`::` → `::1` and `0.0.0.0` → `127.0.0.1` (see ServerArgs.url() in
+server_args.py). This matches what http_server.py:1122 already does for
+/get_transfer_engine_info, so the seed-side registration and lookup now agree
+on the loopback family.
+"""
+
+import inspect
+import unittest
+from unittest.mock import patch
+
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+
+# CPU CI runners don't have CUDA — match the precedent in test_server_args.py.
+_mock_device = patch("sglang.srt.server_args.get_device", return_value="cuda")
+_mock_device.start()
+
+
+def _make_server_args(host: str) -> ServerArgs:
+    return ServerArgs(model_path="dummy", host=host, port=30000)
+
+
+class TestEngineInfoBootstrapURLLoopbackFamily(CustomTestCase):
+    """ServerArgs.engine_info_bootstrap_url must produce a URL whose loopback
+    matches the bind family that EngineInfoBootstrapServer listens on."""
+
+    def test_ipv6_host_produces_ipv6_loopback_url(self):
+        sa = _make_server_args(host="::")
+        url = sa.engine_info_bootstrap_url
+        self.assertIn("[::1]", url, f"expected [::1] in URL, got: {url}")
+        self.assertNotIn("127.0.0.1", url)
+
+    def test_ipv4_wildcard_produces_ipv4_loopback_url(self):
+        sa = _make_server_args(host="0.0.0.0")
+        url = sa.engine_info_bootstrap_url
+        self.assertIn("127.0.0.1", url)
+        self.assertNotIn("[::1]", url)
+
+    def test_specific_ipv4_host_used_verbatim(self):
+        sa = _make_server_args(host="192.0.2.10")
+        url = sa.engine_info_bootstrap_url
+        self.assertIn("192.0.2.10", url)
+
+    def test_url_uses_bootstrap_port_not_server_port(self):
+        sa = _make_server_args(host="::")
+        url = sa.engine_info_bootstrap_url
+        self.assertIn(f":{sa.engine_info_bootstrap_port}", url)
+        self.assertNotIn(":30000", url)
+
+
+class TestRegisterUsesBootstrapURL(CustomTestCase):
+    """Source-level guard: _register_to_engine_info_bootstrap must build its URL
+    via engine_info_bootstrap_url for the single-node path. Catches a regression
+    that re-introduces the hardcoded "127.0.0.1"."""
+
+    def test_register_method_references_engine_info_bootstrap_url(self):
+        from sglang.srt.model_executor.model_runner import ModelRunner
+
+        src = inspect.getsource(ModelRunner._register_to_engine_info_bootstrap)
+        self.assertIn(
+            "engine_info_bootstrap_url",
+            src,
+            "Single-node path must use server_args.engine_info_bootstrap_url; "
+            "hardcoding 127.0.0.1 breaks IPv6-only pods.",
+        )
+        self.assertNotIn(
+            '"127.0.0.1"',
+            src,
+            "Hardcoded 127.0.0.1 was re-introduced — IPv6-only pods will hang.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`ModelRunner._register_to_engine_info_bootstrap` hardcodes the loopback as IPv4 for the single-node path:

```python
# python/sglang/srt/model_executor/model_runner.py
bootstrap_host = "127.0.0.1"
```

When the seed is launched with `--host ::` (IPv6-only pods, `IPV6_V6ONLY=1`), the `EngineInfoBootstrapServer` (started in `engine.py` with `host=server_args.host`) only accepts IPv6 connections. The IPv4 `PUT /register_transfer_engine_info` is then refused, so:

1. tp_rank info never registers on the seed.
2. The R-Fork client gets `404 Not Found` from `/get_remote_instance_transfer_engine_info`.
3. Weight transfer hangs forever.

The bootstrap server itself, the lookup endpoint at [http_server.py:1122](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/entrypoints/http_server.py#L1122), and `ServerArgs.url()` already handle the `::` → `::1` mapping correctly. This single registration call is the one outlier that still hardcodes IPv4.

## Fix

Reuse `server_args.engine_info_bootstrap_url` for the single-node path. It already maps `::` → `::1`, `0.0.0.0` → `127.0.0.1`, and otherwise echoes the bind host. This makes registration and lookup agree on the loopback family.

The multi-node path (which derives the bootstrap host from `dist_init_addr`) is unchanged.

**Changed file:** `python/sglang/srt/model_executor/model_runner.py`

## Test

Added `test/registered/unit/model_executor/test_engine_info_bootstrap_ipv6.py` (CPU-only, registered as `stage-a-test-cpu`).

Tests cover:
- `--host ::` produces a URL containing `[::1]` (IPv6 loopback)
- `--host 0.0.0.0` produces a URL containing `127.0.0.1` (IPv4 loopback)
- `--host 192.0.2.10` produces a URL using that bind address verbatim
- The URL uses `engine_info_bootstrap_port`, not `port`
- Source-level guard: `_register_to_engine_info_bootstrap` references `engine_info_bootstrap_url` and does not hardcode `"127.0.0.1"` (catches re-introduction of the bug)

## Notes

- Independent of #24057 (which fixes a different IPv6 issue in NCCL R-Fork rendezvous via `loader.py`); both are needed for IPv6-only pods to do TransferEngine R-Fork end-to-end.
- One-line behavioural change; IPv4-only and dual-stack hosts keep working exactly as before.
- No new dependencies.

## Checklist

- [x] One-line behavioural change, no impact on IPv4 hosts
- [x] CPU unit tests added and registered in CI
- [x] Multi-node path (`dist_init_addr`) unchanged
- [x] No new dependencies