### PR TITLE
Add AIME 26 eval with correct answer format and fix AIME 25 eval in `sglang.test.run_eval`

### DIFF
--- a/python/sglang/test/run_eval.py
+++ b/python/sglang/test/run_eval.py
@@ -169,6 +169,10 @@ def run_eval(args):
         from sglang.test.simple_eval_aime25 import AIME25Eval
 
         eval_obj = AIME25Eval(args.num_examples, args.num_threads)
+    elif args.eval_name == "aime26":
+        from sglang.test.simple_eval_aime26 import AIME26Eval
+
+        eval_obj = AIME26Eval(args.num_examples, args.num_threads)
     elif args.eval_name == "gsm8k":
         from sglang.test.simple_eval_gsm8k import GSM8KEval
 

--- a/python/sglang/test/simple_eval_aime25.py
+++ b/python/sglang/test/simple_eval_aime25.py
@@ -7,11 +7,12 @@ https://huggingface.co/datasets/MathArena/aime_2025
 
 Prompt, dataset, and answer-extraction follow the matharena evaluation
 (https://github.com/eth-sri/matharena), which reproduces the published
-reasoning-model AIME numbers. Reasoning models are trained to emit \\boxed{N},
-so we extract the last \\boxed{...} or \\fbox{...}.
+reasoning-model AIME numbers. Reasoning models emit \\boxed{N}, so we extract
+the last \\boxed{...} or \\fbox{...}; matharena's AIME configs set
+strict_parsing: false, so on a miss we fall back to the last bare integer.
 """
 
-from typing import Optional
+import re
 
 from sglang.test import simple_eval_common as common
 from sglang.test.simple_eval_common import (
@@ -28,7 +29,7 @@ The answer is an integer between 0 and 999 inclusive.
 {question}"""
 
 
-def normalize_aime_answer(answer: str) -> Optional[str]:
+def normalize_aime_answer(answer: str) -> str | None:
     """Normalize AIME answer to a canonical integer-string in 0..999."""
     if answer is None:
         return None
@@ -42,7 +43,7 @@ def normalize_aime_answer(answer: str) -> Optional[str]:
     return answer
 
 
-def extract_boxed_answer(text: str) -> Optional[str]:
+def extract_boxed_answer(text: str) -> str | None:
     """Return the content of the last \\boxed{...} or \\fbox{...} with balanced braces."""
     if not text:
         return None
@@ -77,10 +78,26 @@ def extract_boxed_answer(text: str) -> Optional[str]:
     return last_content
 
 
+def extract_last_integer(text: str) -> str | None:
+    """Return the last bare integer in the text, as a string."""
+    if not text:
+        return None
+    matches = re.findall(r"\b\d+\b", text)
+    return matches[-1] if matches else None
+
+
+def extract_aime_answer(text: str) -> str | None:
+    """Boxed extraction with matharena's strict_parsing=False fallback to last integer."""
+    answer = extract_boxed_answer(text)
+    if answer is not None:
+        return answer.strip()
+    return extract_last_integer(text)
+
+
 class AIME25Eval(Eval):
     def __init__(
         self,
-        num_examples: Optional[int],
+        num_examples: int | None,
         num_threads: int,
     ):
         from datasets import load_dataset
@@ -105,8 +122,7 @@ class AIME25Eval(Eval):
             response_text = sampler(prompt_messages)
             response_text = response_text or ""
 
-            extracted_answer = extract_boxed_answer(response_text)
-            extracted_answer = extracted_answer.strip() if extracted_answer else None
+            extracted_answer = extract_aime_answer(response_text)
 
             normalized_extracted = normalize_aime_answer(extracted_answer)
             normalized_correct = normalize_aime_answer(row["answer"])

--- a/python/sglang/test/simple_eval_aime25.py
+++ b/python/sglang/test/simple_eval_aime25.py
@@ -2,19 +2,19 @@
 
 """
 AIME 2025 - American Invitational Mathematics Examination 2025
-Dataset: opencompass/AIME2025
-https://huggingface.co/datasets/opencompass/AIME2025
+Dataset: MathArena/aime_2025
+https://huggingface.co/datasets/MathArena/aime_2025
 
-The American Invitational Mathematics Examination (AIME) is a challenging
-competition math exam. All answers are integers from 000 to 999.
+Prompt, dataset, and answer-extraction follow the matharena evaluation
+(https://github.com/eth-sri/matharena), which reproduces the published
+reasoning-model AIME numbers. Reasoning models are trained to emit \\boxed{N},
+so we extract the last \\boxed{...} or \\fbox{...}.
 """
 
-import re
 from typing import Optional
 
 from sglang.test import simple_eval_common as common
 from sglang.test.simple_eval_common import (
-    ANSWER_PATTERN,
     HTML_JINJA,
     Eval,
     EvalResult,
@@ -22,29 +22,18 @@ from sglang.test.simple_eval_common import (
     SingleEvalResult,
 )
 
-QUERY_TEMPLATE = """
-Solve the following AIME (American Invitational Mathematics Examination) problem step by step. The last line of your response should be of the form Answer: $ANSWER (without quotes) where $ANSWER is the answer to the problem.
+QUERY_TEMPLATE = """Put your final answer within \\boxed{{}}.
+The answer is an integer between 0 and 999 inclusive.
 
-Note: AIME answers are always integers from 000 to 999 (inclusive). If you get a non-integer answer, you likely made a computational error.
-
-{question}
-
-Remember to put your answer on its own line after "Answer:", and express your answer as an integer from 000 to 999.
-""".strip()
+{question}"""
 
 
 def normalize_aime_answer(answer: str) -> Optional[str]:
-    """
-    Normalize AIME answer to standard format.
-    AIME answers are integers from 000 to 999.
-    """
+    """Normalize AIME answer to a canonical integer-string in 0..999."""
     if answer is None:
         return None
-    # Remove whitespace and convert to string
     answer = str(answer).strip()
-    # Try to extract integer from answer
     try:
-        # Handle various formats like "42", "042", "42.0", etc.
         num = int(float(answer))
         if 0 <= num <= 999:
             return str(num)
@@ -53,32 +42,54 @@ def normalize_aime_answer(answer: str) -> Optional[str]:
     return answer
 
 
+def extract_boxed_answer(text: str) -> Optional[str]:
+    """Return the content of the last \\boxed{...} or \\fbox{...} with balanced braces."""
+    if not text:
+        return None
+    markers = ("\\boxed{", "\\fbox{")
+    last_content = None
+    i = 0
+    while i < len(text):
+        next_idx = -1
+        next_marker_len = 0
+        for marker in markers:
+            j = text.find(marker, i)
+            if j != -1 and (next_idx == -1 or j < next_idx):
+                next_idx = j
+                next_marker_len = len(marker)
+        if next_idx == -1:
+            break
+        start = next_idx + next_marker_len
+        depth = 1
+        k = start
+        while k < len(text) and depth > 0:
+            c = text[k]
+            if c == "{":
+                depth += 1
+            elif c == "}":
+                depth -= 1
+            k += 1
+        if depth == 0:
+            last_content = text[start : k - 1]
+            i = k
+        else:
+            break
+    return last_content
+
+
 class AIME25Eval(Eval):
     def __init__(
         self,
         num_examples: Optional[int],
         num_threads: int,
     ):
-        try:
-            from datasets import load_dataset
-        except ImportError:
-            raise ImportError(
-                "The 'datasets' package is required for AIME25 evaluation. "
-                "Please install it with: pip install datasets"
-            )
+        from datasets import load_dataset
 
-        # Load AIME 2025 dataset from HuggingFace
-        dataset1 = load_dataset("opencompass/AIME2025", "AIME2025-I", split="test")
-        dataset2 = load_dataset("opencompass/AIME2025", "AIME2025-II", split="test")
-        examples1 = [
-            {"question": row["question"], "answer": str(row["answer"])}
-            for row in dataset1
+        dataset = load_dataset("MathArena/aime_2025", split="train")
+        examples = [
+            {"question": row["problem"], "answer": str(row["answer"])}
+            for row in dataset
         ]
-        examples2 = [
-            {"question": row["question"], "answer": str(row["answer"])}
-            for row in dataset2
-        ]
-        examples = examples1 + examples2
 
         if num_examples:
             examples = examples[: min(num_examples, len(examples))]
@@ -94,15 +105,12 @@ class AIME25Eval(Eval):
             response_text = sampler(prompt_messages)
             response_text = response_text or ""
 
-            # Extract answer from response
-            match = re.search(ANSWER_PATTERN, response_text)
-            extracted_answer = match.group(1).strip() if match else None
+            extracted_answer = extract_boxed_answer(response_text)
+            extracted_answer = extracted_answer.strip() if extracted_answer else None
 
-            # Normalize both answers for comparison
             normalized_extracted = normalize_aime_answer(extracted_answer)
             normalized_correct = normalize_aime_answer(row["answer"])
 
-            # Score: 1.0 if correct, 0.0 otherwise
             score = 1.0 if normalized_extracted == normalized_correct else 0.0
 
             html = common.jinja_env.from_string(HTML_JINJA).render(

--- a/python/sglang/test/simple_eval_aime26.py
+++ b/python/sglang/test/simple_eval_aime26.py
@@ -14,7 +14,7 @@ so we extract the last \\boxed{...} or \\fbox{...}.
 from typing import Optional
 
 from sglang.test import simple_eval_common as common
-from sglang.test.simple_eval_aime25 import normalize_aime_answer
+from sglang.test.simple_eval_aime25 import extract_boxed_answer, normalize_aime_answer
 from sglang.test.simple_eval_common import (
     HTML_JINJA,
     Eval,
@@ -29,54 +29,13 @@ The answer is an integer between 0 and 999 inclusive.
 {question}"""
 
 
-def extract_boxed_answer(text: str) -> Optional[str]:
-    """Return the content of the last \\boxed{...} or \\fbox{...} with balanced braces."""
-    if not text:
-        return None
-    markers = ("\\boxed{", "\\fbox{")
-    last_content = None
-    i = 0
-    while i < len(text):
-        next_idx = -1
-        next_marker_len = 0
-        for marker in markers:
-            j = text.find(marker, i)
-            if j != -1 and (next_idx == -1 or j < next_idx):
-                next_idx = j
-                next_marker_len = len(marker)
-        if next_idx == -1:
-            break
-        start = next_idx + next_marker_len
-        depth = 1
-        k = start
-        while k < len(text) and depth > 0:
-            c = text[k]
-            if c == "{":
-                depth += 1
-            elif c == "}":
-                depth -= 1
-            k += 1
-        if depth == 0:
-            last_content = text[start : k - 1]
-            i = k
-        else:
-            break
-    return last_content
-
-
 class AIME26Eval(Eval):
     def __init__(
         self,
         num_examples: Optional[int],
         num_threads: int,
     ):
-        try:
-            from datasets import load_dataset
-        except ImportError:
-            raise ImportError(
-                "The 'datasets' package is required for AIME26 evaluation. "
-                "Please install it with: pip install datasets"
-            )
+        from datasets import load_dataset
 
         dataset = load_dataset("MathArena/aime_2026", split="train")
         examples = [

--- a/python/sglang/test/simple_eval_aime26.py
+++ b/python/sglang/test/simple_eval_aime26.py
@@ -1,0 +1,125 @@
+# Adapted from https://github.com/openai/simple-evals/
+
+"""
+AIME 2026 - American Invitational Mathematics Examination 2026
+Dataset: MathArena/aime_2026
+https://huggingface.co/datasets/MathArena/aime_2026
+
+Prompt, dataset, and answer-extraction follow the matharena evaluation
+(https://github.com/eth-sri/matharena), which reproduces the published
+reasoning-model AIME numbers. Reasoning models are trained to emit \\boxed{N},
+so we extract the last \\boxed{...} or \\fbox{...}.
+"""
+
+from typing import Optional
+
+from sglang.test import simple_eval_common as common
+from sglang.test.simple_eval_aime25 import normalize_aime_answer
+from sglang.test.simple_eval_common import (
+    HTML_JINJA,
+    Eval,
+    EvalResult,
+    SamplerBase,
+    SingleEvalResult,
+)
+
+QUERY_TEMPLATE = """Put your final answer within \\boxed{{}}.
+The answer is an integer between 0 and 999 inclusive.
+
+{question}"""
+
+
+def extract_boxed_answer(text: str) -> Optional[str]:
+    """Return the content of the last \\boxed{...} or \\fbox{...} with balanced braces."""
+    if not text:
+        return None
+    markers = ("\\boxed{", "\\fbox{")
+    last_content = None
+    i = 0
+    while i < len(text):
+        next_idx = -1
+        next_marker_len = 0
+        for marker in markers:
+            j = text.find(marker, i)
+            if j != -1 and (next_idx == -1 or j < next_idx):
+                next_idx = j
+                next_marker_len = len(marker)
+        if next_idx == -1:
+            break
+        start = next_idx + next_marker_len
+        depth = 1
+        k = start
+        while k < len(text) and depth > 0:
+            c = text[k]
+            if c == "{":
+                depth += 1
+            elif c == "}":
+                depth -= 1
+            k += 1
+        if depth == 0:
+            last_content = text[start : k - 1]
+            i = k
+        else:
+            break
+    return last_content
+
+
+class AIME26Eval(Eval):
+    def __init__(
+        self,
+        num_examples: Optional[int],
+        num_threads: int,
+    ):
+        try:
+            from datasets import load_dataset
+        except ImportError:
+            raise ImportError(
+                "The 'datasets' package is required for AIME26 evaluation. "
+                "Please install it with: pip install datasets"
+            )
+
+        dataset = load_dataset("MathArena/aime_2026", split="train")
+        examples = [
+            {"question": row["problem"], "answer": str(row["answer"])}
+            for row in dataset
+        ]
+
+        if num_examples:
+            examples = examples[: min(num_examples, len(examples))]
+
+        self.examples = examples
+        self.num_threads = num_threads
+
+    def __call__(self, sampler: SamplerBase) -> EvalResult:
+        def fn(row: dict):
+            prompt_messages = [
+                sampler._pack_message(content=QUERY_TEMPLATE.format(**row), role="user")
+            ]
+            response_text = sampler(prompt_messages)
+            response_text = response_text or ""
+
+            extracted_answer = extract_boxed_answer(response_text)
+            extracted_answer = extracted_answer.strip() if extracted_answer else None
+
+            normalized_extracted = normalize_aime_answer(extracted_answer)
+            normalized_correct = normalize_aime_answer(row["answer"])
+
+            score = 1.0 if normalized_extracted == normalized_correct else 0.0
+
+            html = common.jinja_env.from_string(HTML_JINJA).render(
+                prompt_messages=prompt_messages,
+                next_message=dict(content=response_text, role="assistant"),
+                score=score,
+                correct_answer=row["answer"],
+                extracted_answer=extracted_answer,
+            )
+            convo = prompt_messages + [dict(content=response_text, role="assistant")]
+            return SingleEvalResult(
+                html=html,
+                score=score,
+                convo=convo,
+                metrics={"chars": len(response_text)},
+            )
+
+        results = common.map_with_progress(fn, self.examples, self.num_threads)
+        return common.aggregate_results(results)

--- a/python/sglang/test/simple_eval_aime26.py
+++ b/python/sglang/test/simple_eval_aime26.py
@@ -7,14 +7,13 @@ https://huggingface.co/datasets/MathArena/aime_2026
 
 Prompt, dataset, and answer-extraction follow the matharena evaluation
 (https://github.com/eth-sri/matharena), which reproduces the published
-reasoning-model AIME numbers. Reasoning models are trained to emit \\boxed{N},
-so we extract the last \\boxed{...} or \\fbox{...}.
+reasoning-model AIME numbers. Reasoning models emit \\boxed{N}, so we extract
+the last \\boxed{...} or \\fbox{...}; matharena's AIME configs set
+strict_parsing: false, so on a miss we fall back to the last bare integer.
 """
 
-from typing import Optional
-
 from sglang.test import simple_eval_common as common
-from sglang.test.simple_eval_aime25 import extract_boxed_answer, normalize_aime_answer
+from sglang.test.simple_eval_aime25 import extract_aime_answer, normalize_aime_answer
 from sglang.test.simple_eval_common import (
     HTML_JINJA,
     Eval,
@@ -32,7 +31,7 @@ The answer is an integer between 0 and 999 inclusive.
 class AIME26Eval(Eval):
     def __init__(
         self,
-        num_examples: Optional[int],
+        num_examples: int | None,
         num_threads: int,
     ):
         from datasets import load_dataset
@@ -57,8 +56,7 @@ class AIME26Eval(Eval):
             response_text = sampler(prompt_messages)
             response_text = response_text or ""
 
-            extracted_answer = extract_boxed_answer(response_text)
-            extracted_answer = extracted_answer.strip() if extracted_answer else None
+            extracted_answer = extract_aime_answer(response_text)
 
             normalized_extracted = normalize_aime_answer(extracted_answer)
             normalized_correct = normalize_aime_answer(row["answer"])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

It was wrong before, regarding the system prompt (anyway, I think it was vibe coded in https://github.com/sgl-project/sglang/pull/14990). I suspected something was wrong that was not the pass@k metric or reported discrepancy, because GPQA Diamond can reach the correct score in `run_eval`, as well as AIME 25 through Nemo Skills. Thus, I copy the standard in https://matharena.ai/, which is what GLM-5 answers are reported on.

Here is what Claude says:

  - Prompt rewritten to `Put your final answer within \boxed{}.\nThe answer is an integer between 0 and 999 inclusive.\n\n{question}.`                                          
  - Extractor replaced with a balanced-brace scanner that finds the last \boxed{...} or \fbox{...}. No "Answer:" fallback.                                                                                                                                    
  - Dataset switched to MathArena/aime_2026 split=train (30 problems; --num-examples 15 slices Part I, matching the paper's reporting), which is in line with https://huggingface.co/zai-org/GLM-5/blob/main/.eval_results/MathArena--aime_2026.yaml
  - System prompt stayed None because matharena also doesn't use one — both pipelines send a single user message.       

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

Fix it.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

The paper results showcase the **AIME I** 2026, the first 15 questions are AIME I, the second 15 are AIME II. We can still run 30 to get the average of I and II, for stability.

```
nohup python3 -u -m sglang.launch_server --model-path zai-org/GLM-5-FP8 --trust-remote-code --tp-size 8 --ep 8 --tool-call-parser glm47 --reasoning-parser glm45 --port 30020 --max-running-requests 256 --mem-fraction-static 0.93 > sglang_server.log 2>&1 &
```

```
nohup python3 -u -m sglang.test.run_eval --port 30020 --eval-name aime26 --max-tokens 131072 --repeat 8 --top-p 0.95 --temperature 1.0 --thinking-mode glm-45 --num-examples 15 > c 2>&1 &
```

Before:

```
Repeat: 8, mean: 0.617 [42:06<00:00, 189.66s/it]
Scores: ['0.667', '0.667', '0.733', '0.533', '0.533', '0.600', '0.600', '0.600']
Mean latency: 2246.927 s41:54<00:00, 186.04s/it]
```

After:

```
Repeat: 8, mean: 0.933
Scores: ['0.933', '0.933', '0.933', '0.933', '0.933', '0.933', '0.933', '0.933']
Mean latency: 2041.575 s
```

<img width="909" height="457" alt="Screenshot 2026-04-29 at 10 47 21 AM" src="https://github.com/user-attachments/assets/5729862d-ab1c-47fb-aec5-78858f4224c4" />

Which match the official score in https://arxiv.org/pdf/2602.15763. 
cc @guapisolo @zyzshishui 