### PR TITLE
test(moe): add fused_moe_native import smoke test

### DIFF
--- a/test/registered/unit/layers/test_fused_moe_native_import.py
+++ b/test/registered/unit/layers/test_fused_moe_native_import.py
@@ -1,0 +1,19 @@
+import importlib
+import unittest
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+
+
+class TestFusedMoeNativeImport(CustomTestCase):
+    def test_fused_moe_native_imports(self):
+        module = importlib.import_module("sglang.srt.layers.moe.fused_moe_native")
+
+        self.assertTrue(hasattr(module, "fused_moe_forward_native"))
+        self.assertTrue(hasattr(module, "moe_forward_native"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a CPU stage-a import smoke test for `sglang.srt.layers.moe.fused_moe_native`
- verify the native MoE module still exposes `fused_moe_forward_native` and `moe_forward_native`

## Context
This is split out from #24069 as a regression guard. It is expected to fail on the current `main` branch until #24069 lands, because current `main` still has the dead `sglang.srt.layers.moe.fused_moe_triton.fused_moe` import.

## Testing
- `pre-commit run --files test/registered/unit/layers/test_fused_moe_native_import.py`
- `PYTHONPATH=python python3 test/registered/unit/layers/test_fused_moe_native_import.py` currently stops in the fresh worktree before project deps are installed (`numpy` missing); CI will exercise the registered stage-a CPU test, and the test is intentionally dependent on #24069.