### PR TITLE
[mem_cache] feat: reduce SLRU burst distortion and stagnation

### DIFF
--- a/benchmark/slru/bench_hit_rate.py
+++ b/benchmark/slru/bench_hit_rate.py
@@ -1,0 +1,468 @@
+"""SLRU hit-rate simulator.
+
+Pure-Python, no GPU needed. Replays a scripted traffic pattern through a
+simulated ``RadixCache`` under both legacy and optimized SLRU, then emits a
+CSV of hit-rate samples over time. The output is a lightweight stand-in for
+full ``bench_serving`` runs.
+
+Two scenarios are supported:
+
+* ``mixed`` (default) — adversarial burst workload that stresses the
+  **Burst Distortion** failure mode (debounce fix).
+* ``shifting_zipfian`` — rotating-popularity Zipfian workload that
+  stresses the **Stagnation** failure mode (lazy-decay + cap fix).
+
+Example:
+
+    python benchmark/slru/bench_hit_rate.py \\
+        --output /tmp/slru_hit_rate.csv \\
+        --scenario mixed --duration-sec 300
+
+    python benchmark/slru/bench_hit_rate.py \\
+        --output /tmp/slru_shifting.csv \\
+        --scenario shifting_zipfian --duration-sec 600
+
+The CSV columns are: ``scenario, policy, t, hits, misses, hit_rate``.
+
+This is *not* a TTFT / throughput benchmark — it operates purely on the
+cache-hit dimension. Combine with the real ``bench_serving`` run to get
+the full picture.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import importlib.abc
+import importlib.machinery
+import random
+import sys
+from dataclasses import dataclass
+from typing import Iterator, List, Tuple
+
+import torch
+
+
+def _maybe_stub_sgl_kernel_for_cpu_sim() -> None:
+    """Keep the CPU-only simulator usable when local CUDA kernels are absent."""
+    try:
+        import sgl_kernel  # noqa: F401
+
+        return
+    except (ImportError, OSError):
+        pass
+
+    from unittest.mock import MagicMock
+
+    class _SglKernelLoader(importlib.abc.Loader):
+        def create_module(self, spec):
+            return None
+
+        def exec_module(self, module):
+            module.__getattr__ = lambda name: MagicMock()
+
+    class _SglKernelFinder(importlib.abc.MetaPathFinder):
+        def find_spec(self, fullname, path, target=None):
+            if fullname == "sgl_kernel" or fullname.startswith("sgl_kernel."):
+                return importlib.machinery.ModuleSpec(
+                    fullname,
+                    _SglKernelLoader(),
+                    is_package=True,
+                )
+            return None
+
+    sys.meta_path.insert(0, _SglKernelFinder())
+
+
+_maybe_stub_sgl_kernel_for_cpu_sim()
+
+from sglang.srt.environ import envs
+from sglang.srt.mem_cache import evict_policy as _ep_module
+from sglang.srt.mem_cache import radix_cache as _rc_module
+from sglang.srt.mem_cache.base_prefix_cache import (
+    EvictParams,
+    InsertParams,
+    MatchPrefixParams,
+)
+from sglang.srt.mem_cache.evict_policy import SLRUStrategy
+from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey
+
+
+class _MockAllocator:
+    def __init__(self):
+        self.device = "cpu"
+
+    def free(self, value):
+        pass
+
+
+class _FakeClock:
+    def __init__(self, start: float = 0.0):
+        self._t = start
+
+    def advance(self, seconds: float):
+        self._t += seconds
+
+    def now(self) -> float:
+        return self._t
+
+
+def _patch_clock(clock: _FakeClock):
+    rc_orig = _rc_module.time.monotonic
+    ep_orig = _ep_module.time.monotonic
+    _rc_module.time.monotonic = clock.now
+    _ep_module.time.monotonic = clock.now
+
+    def restore():
+        _rc_module.time.monotonic = rc_orig
+        _ep_module.time.monotonic = ep_orig
+
+    return restore
+
+
+@dataclass
+class Event:
+    """A single traffic event.
+
+    ``kind == "access"`` → cache lookup; if miss, also insert.
+    ``kind == "advance"`` → advance the fake clock by ``seconds``.
+    """
+
+    kind: str
+    token_ids: Tuple[int, ...] = ()
+    seconds: float = 0.0
+
+
+def scenario_mixed(rng: random.Random, duration_sec: float = 300.0) -> Iterator[Event]:
+    """Adversarial burst-distortion workload.
+
+    Hot prompts receive steady reuse, while throwaway prefixes arrive in
+    near-simultaneous bursts. Legacy SLRU may promote those bursts into the
+    protected tier; optimized SLRU should keep them probationary.
+    """
+    hot_prompts = [tuple(range(10 + i * 32, 10 + i * 32 + 16)) for i in range(40)]
+    next_unique = 100000
+    t = 0.0
+    last_burst_at = -5.0  # allow a burst right away
+
+    while t < duration_sec:
+        r = rng.random()
+        if r < 0.60:
+            # 60% hot access.
+            yield Event("access", rng.choice(hot_prompts))
+            yield Event("advance", seconds=0.01)
+            t += 0.01
+        elif t - last_burst_at >= 5.0 and r < 0.70:
+            # 10% burst when cooldown allows.
+            burst = tuple(range(next_unique, next_unique + 16))
+            next_unique += 16
+            for _ in range(50):
+                yield Event("access", burst)
+                yield Event("advance", seconds=0.0002)
+            t += 0.01
+            last_burst_at = t
+        else:
+            # 30-40% unique user prompts.
+            uniq = tuple(range(next_unique, next_unique + 16))
+            next_unique += 16
+            yield Event("access", uniq)
+            yield Event("advance", seconds=0.05)
+            t += 0.05
+
+
+def scenario_shifting_zipfian(
+    rng: random.Random,
+    duration_sec: float = 600.0,
+    pool_size: int = 100,
+    hot_size: int = 10,
+    rotate_sec: float = 30.0,
+    zipf_alpha: float = 1.2,
+    rate_rps: float = 50.0,
+    shift_stride: int = 5,
+) -> Iterator[Event]:
+    """Rotating-popularity Zipfian workload for lazy decay.
+
+    A pool of ``pool_size`` distinct prefixes. At any moment, a
+    contiguous "hot set" of ``hot_size`` prefixes receives
+    ~all the traffic, with intra-set popularity skewed via Zipf(alpha).
+    Every ``rotate_sec`` virtual seconds the hot set slides forward by
+    ``shift_stride`` positions: prefixes that were hot become cold, and
+    new prefixes enter the hot set.
+
+    Once a prefix leaves the hot set, optimized SLRU's hit-count cap and lazy
+    decay let it yield protected capacity to newly hot prefixes.
+    """
+    if pool_size < 1:
+        raise ValueError(f"pool_size must be >= 1, got {pool_size}")
+    if hot_size < 1:
+        raise ValueError(f"hot_size must be >= 1, got {hot_size}")
+    if hot_size > pool_size:
+        raise ValueError(f"hot_size ({hot_size}) must be <= pool_size ({pool_size})")
+    if rotate_sec <= 0:
+        raise ValueError(f"rotate_sec must be > 0, got {rotate_sec}")
+    if rate_rps <= 0:
+        raise ValueError(f"rate_rps must be > 0, got {rate_rps}")
+    if zipf_alpha < 0:
+        raise ValueError(f"zipf_alpha must be >= 0, got {zipf_alpha}")
+    if shift_stride < 0:
+        raise ValueError(f"shift_stride must be >= 0, got {shift_stride}")
+
+    # Distinct, non-overlapping prefix IDs (16-token width, matching
+    # ``scenario_mixed``'s convention).
+    prefixes = [tuple(range(10 + i * 32, 10 + i * 32 + 16)) for i in range(pool_size)]
+
+    # Pre-compute Zipfian CDF within the hot set: weights[i] ∝
+    # 1/(i+1)^alpha. The CDF lets us sample in O(hot_size) per draw
+    # without importing numpy — the simulator is deliberately
+    # numpy-free elsewhere.
+    raw = [1.0 / ((i + 1) ** zipf_alpha) for i in range(hot_size)]
+    total_w = sum(raw)
+    cdf: List[float] = []
+    cum = 0.0
+    for w in raw:
+        cum += w / total_w
+        cdf.append(cum)
+    # Fix trailing float drift so the last bucket is reachable even if
+    # rng.random() returns 0.999...9.
+    cdf[-1] = 1.0
+
+    dt = 1.0 / rate_rps
+    t = 0.0
+
+    while t < duration_sec:
+        rotation_idx = int(t / rotate_sec)
+        # Hot set is ``hot_size`` consecutive prefixes from ``center``,
+        # wrapping around the pool. shift_stride=0 degenerates to a
+        # fixed hot set (static Zipfian) — intentionally allowed as a
+        # controlled baseline; pass --shifting-stride 0 to compare.
+        center = (rotation_idx * shift_stride) % pool_size
+        hot_set = [prefixes[(center + i) % pool_size] for i in range(hot_size)]
+
+        rotation_end = min((rotation_idx + 1) * rotate_sec, duration_sec)
+
+        while t < rotation_end:
+            # Inverse-CDF sample the Zipfian position in the hot set.
+            u = rng.random()
+            idx = 0
+            while idx < hot_size - 1 and u > cdf[idx]:
+                idx += 1
+            yield Event("access", hot_set[idx])
+            yield Event("advance", seconds=dt)
+            t += dt
+
+
+def _run_simulation(
+    events: List[Event],
+    optimization_enabled: bool,
+    cache_capacity_tokens: int,
+    sample_every_sec: float,
+) -> List[Tuple[float, int, int, float]]:
+    """Drive the events through a fresh SLRU-equipped ``RadixCache``.
+    Returns a list of (t, hits, misses, hit_rate) tuples sampled
+    roughly every ``sample_every_sec`` seconds of virtual time."""
+    clock = _FakeClock()
+    restore = _patch_clock(clock)
+    samples: List[Tuple[float, int, int, float]] = []
+    try:
+        with envs.SGLANG_ENABLE_SLRU_OPTIMIZATION.override(optimization_enabled):
+            cache = RadixCache.create_simulated(
+                mock_allocator=_MockAllocator(), page_size=1
+            )
+            cache.eviction_strategy = SLRUStrategy(
+                protected_threshold=2,
+                debounce_sec=0.1,
+                decay_sec=60.0,
+            )
+
+            hits = 0
+            misses = 0
+            window_hits = 0
+            window_misses = 0
+            next_sample_at = sample_every_sec
+
+            for ev in events:
+                if ev.kind == "advance":
+                    clock.advance(ev.seconds)
+                    if clock.now() >= next_sample_at:
+                        window_total = window_hits + window_misses
+                        rate = window_hits / window_total if window_total else 0.0
+                        samples.append(
+                            (
+                                clock.now(),
+                                window_hits,
+                                window_misses,
+                                rate,
+                            )
+                        )
+                        window_hits = 0
+                        window_misses = 0
+                        next_sample_at += sample_every_sec
+                    continue
+
+                key = RadixKey(token_ids=list(ev.token_ids), extra_key=None)
+                # Mirror real serving behavior: every request runs
+                # match_prefix (for the scheduler's prefix lookup) AND
+                # insert (cache_{un,}finished_req). ``insert`` walks
+                # the tree and bumps hit_count on every matching node
+                # along the path — without it, the cache would never
+                # promote anything to Protected.
+                result = cache.match_prefix(MatchPrefixParams(key=key))
+                if int(result.device_indices.numel()) == len(ev.token_ids):
+                    hits += 1
+                    window_hits += 1
+                else:
+                    misses += 1
+                    window_misses += 1
+                value = torch.tensor(list(ev.token_ids), dtype=torch.int64)
+                cache.insert(InsertParams(key=key, value=value))
+
+                # Evict on capacity — keeps the working set under a
+                # steady ceiling so eviction policy matters.
+                if cache.evictable_size_ > cache_capacity_tokens:
+                    overflow = cache.evictable_size_ - cache_capacity_tokens
+                    cache.evict(EvictParams(num_tokens=overflow))
+    finally:
+        restore()
+
+    return samples
+
+
+def main(argv: List[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Path to write the CSV. Columns: scenario, policy, t, "
+        "hits, misses, hit_rate.",
+    )
+    parser.add_argument(
+        "--scenario",
+        default="mixed",
+        choices=["mixed", "shifting_zipfian"],
+        help="Traffic pattern to replay. ``mixed`` targets burst "
+        "distortion; ``shifting_zipfian`` targets stagnation.",
+    )
+    parser.add_argument(
+        "--duration-sec",
+        type=float,
+        default=300.0,
+        help="Virtual seconds of traffic to replay.",
+    )
+    parser.add_argument(
+        "--cache-capacity-tokens",
+        type=int,
+        default=2048,
+        help="Target evictable footprint — eviction kicks in when "
+        "the cache exceeds this.",
+    )
+    parser.add_argument(
+        "--sample-every-sec",
+        type=float,
+        default=5.0,
+        help="Emit one hit-rate sample every N virtual seconds.",
+    )
+    parser.add_argument("--seed", type=int, default=0xC0FFEE, help="RNG seed.")
+    # shifting_zipfian-specific knobs. Ignored unless
+    # --scenario shifting_zipfian is selected.
+    parser.add_argument(
+        "--shifting-pool-size",
+        type=int,
+        default=100,
+        help="shifting_zipfian: total distinct prefixes in the pool.",
+    )
+    parser.add_argument(
+        "--shifting-hot-size",
+        type=int,
+        default=10,
+        help="shifting_zipfian: number of prefixes in the hot set at " "any moment.",
+    )
+    parser.add_argument(
+        "--shifting-rotate-sec",
+        type=float,
+        default=30.0,
+        help="shifting_zipfian: slide the hot set every N virtual " "seconds.",
+    )
+    parser.add_argument(
+        "--shifting-zipf-alpha",
+        type=float,
+        default=1.2,
+        help="shifting_zipfian: Zipf exponent for within-hot-set "
+        "popularity skew. Higher = more skewed toward the top.",
+    )
+    parser.add_argument(
+        "--shifting-rate-rps",
+        type=float,
+        default=50.0,
+        help="shifting_zipfian: virtual requests per second.",
+    )
+    parser.add_argument(
+        "--shifting-stride",
+        type=int,
+        default=5,
+        help="shifting_zipfian: positions to slide the hot set per "
+        "rotation. 0 degenerates to a static Zipfian baseline.",
+    )
+    args = parser.parse_args(argv)
+
+    # Materialize events once so both policies see identical traffic.
+    rng = random.Random(args.seed)
+    if args.scenario == "mixed":
+        events = list(scenario_mixed(rng, duration_sec=args.duration_sec))
+    elif args.scenario == "shifting_zipfian":
+        events = list(
+            scenario_shifting_zipfian(
+                rng,
+                duration_sec=args.duration_sec,
+                pool_size=args.shifting_pool_size,
+                hot_size=args.shifting_hot_size,
+                rotate_sec=args.shifting_rotate_sec,
+                zipf_alpha=args.shifting_zipf_alpha,
+                rate_rps=args.shifting_rate_rps,
+                shift_stride=args.shifting_stride,
+            )
+        )
+    else:
+        # argparse ``choices`` already rejects anything else, but guard
+        # in case that list is extended without updating this dispatch.
+        print(f"unsupported scenario: {args.scenario}", file=sys.stderr)
+        return 2
+
+    print(
+        f"[bench_hit_rate] scenario={args.scenario} "
+        f"events={len(events)} capacity={args.cache_capacity_tokens}"
+    )
+
+    rows = []
+    for policy, enabled in (("naive", False), ("optimized", True)):
+        samples = _run_simulation(
+            events,
+            optimization_enabled=enabled,
+            cache_capacity_tokens=args.cache_capacity_tokens,
+            sample_every_sec=args.sample_every_sec,
+        )
+        total_hits = sum(h for _, h, _, _ in samples)
+        total_misses = sum(m for _, _, m, _ in samples)
+        overall = (
+            total_hits / (total_hits + total_misses)
+            if (total_hits + total_misses)
+            else 0.0
+        )
+        print(
+            f"[bench_hit_rate] policy={policy} "
+            f"samples={len(samples)} total_hits={total_hits} "
+            f"total_misses={total_misses} hit_rate={overall:.4f}"
+        )
+        for t, h, m, rate in samples:
+            rows.append((args.scenario, policy, t, h, m, rate))
+
+    with open(args.output, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["scenario", "policy", "t", "hits", "misses", "hit_rate"])
+        writer.writerows(rows)
+
+    print(f"[bench_hit_rate] wrote {len(rows)} rows to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/benchmark/slru/run_bench_compare.py
+++ b/benchmark/slru/run_bench_compare.py
@@ -1,0 +1,661 @@
+"""SLRU three-way benchmark compare runner.
+
+Launches ``python -m sglang.launch_server`` under each of {LRU, legacy SLRU,
+optimized SLRU}, waits for readiness, runs ``python -m sglang.bench_serving``
+with a dataset-specific preset, collects metrics, shuts the server down, and
+emits a markdown comparison table alongside the raw JSONL outputs.
+
+Designed to run on a single GPU box (PAI-DSW A10, AutoDL 4090, RunPod A10, etc.)
+without any manual orchestration — one command, three runs, one report.
+
+Usage:
+
+    python benchmark/slru/run_bench_compare.py \\
+        --model Qwen/Qwen2.5-7B-Instruct \\
+        --dataset sharegpt \\
+        --output-dir results/
+
+    # Or pick a different dataset preset:
+    python benchmark/slru/run_bench_compare.py \\
+        --model Qwen/Qwen2.5-7B-Instruct \\
+        --dataset gsp \\
+        --output-dir results/
+
+Outputs (in ``<output-dir>/<timestamp>/``):
+  * ``compare.md``    — side-by-side table with deltas vs LRU baseline
+  * ``<policy>.jsonl``— raw bench_serving output per policy
+  * ``<policy>.log``  — stdout/stderr of the server + bench for each run
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import os
+import shlex
+import signal
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+try:
+    from sglang.srt.utils.common import kill_process_tree
+except ImportError:  # sglang not installed (e.g. running --help in a fresh env)
+    kill_process_tree = None  # type: ignore[assignment]
+
+# -----------------------------------------------------------------------------
+# Dataset presets. Tune via CLI overrides when adapting the stress profile to a
+# new model.
+# -----------------------------------------------------------------------------
+
+DATASET_PRESETS: Dict[str, Dict[str, List[str]]] = {
+    "sharegpt": {
+        "bench_args": [
+            "--dataset-name",
+            "sharegpt",
+            "--num-prompts",
+            "1000",
+            "--request-rate",
+            "10",
+        ],
+        # Required dataset file — bench_serving expects a ShareGPT dump.
+        # Users pass it via --sharegpt-path (we forward through).
+    },
+    "gsp": {
+        "bench_args": [
+            "--dataset-name",
+            "generated-shared-prefix",
+            "--gsp-num-groups",
+            "4",
+            "--gsp-prompts-per-group",
+            "256",
+            "--gsp-system-prompt-len",
+            "2048",
+            "--num-prompts",
+            "1024",
+            "--request-rate",
+            "8",
+        ],
+    },
+    "longbench": {
+        "bench_args": [
+            "--dataset-name",
+            "longbench_v2",
+            "--num-prompts",
+            "500",
+            "--request-rate",
+            "5",
+        ],
+    },
+    "random": {
+        # Smoke-test preset: no dataset file needed, synthetic prompts. Useful
+        # for verifying the compare runner end-to-end on a fresh GPU box
+        # before committing to a full ShareGPT run.
+        "bench_args": [
+            "--dataset-name",
+            "random",
+            "--random-input",
+            "1024",
+            "--random-output",
+            "256",
+            "--random-range-ratio",
+            "0.5",
+            "--num-prompts",
+            "300",
+            "--request-rate",
+            "8",
+        ],
+    },
+    "mooncake": {
+        # Production trace from Moonshot AI's Kimi.ai service, released with
+        # the Mooncake paper (FAST'25, "Mooncake: A KVCache-centric
+        # Disaggregated Architecture for LLM Serving"). Drives the three
+        # policies with a real prefix-reuse distribution: ``hash_id=0``
+        # appears in 100% of requests (universal system prompt), ~24% of
+        # remaining hash_ids are repeated across sessions (legitimate
+        # hotness), and ~76% are one-shot (the "burst-false-hot" trap
+        # optimized-slru is designed to filter out).
+        #
+        # ``--mooncake-num-rounds 2`` turns each trace record into a 2-turn
+        # burst (chat_history grows across rounds). Two rounds is enough to
+        # exercise the within-session prefix-reuse burst — the second round
+        # arriving back-to-back on the same shared prefix is exactly the
+        # debounce/cap trigger. Higher values saturate the single-4090
+        # prefill budget; see load math below.
+        #
+        # ``--mooncake-slowdown-factor 3.0`` paces the replay at one third
+        # real-trace speed. Native arrival rate on the conversation trace
+        # is ~3 sessions/s; with num_rounds=2 and mean effective prefill
+        # ~3,250 tokens per request, sustainable QPS on a 4090 is about
+        # 2–2.5 req/s → slowdown=3 puts us at ~2 req/s, ~65% of the low
+        # estimate of prefill capacity. Bump to 4.0 on older GPUs if
+        # queue-req grows past 20 in the first 2 min of benching.
+        #
+        # ``--num-prompts 2000`` subsamples 2,000 of the 12,031 records,
+        # giving ~4,000 generated requests once the 2-round expansion is
+        # applied — ~40 samples at p99 TTFT, enough for a bootstrap CI.
+        #
+        # NOTE: the mooncake loader IGNORES --request-rate; pacing is
+        # controlled entirely by the replay slowdown factor.
+        "bench_args": [
+            "--dataset-name",
+            "mooncake",
+            "--mooncake-workload",
+            "conversation",
+            "--mooncake-num-rounds",
+            "2",
+            "--mooncake-slowdown-factor",
+            "3.0",
+            "--num-prompts",
+            "2000",
+        ],
+    },
+}
+
+
+@dataclasses.dataclass(frozen=True)
+class Policy:
+    """One eviction-policy variant to benchmark."""
+
+    label: str  # shown in output table
+    eviction_policy: str  # --radix-eviction-policy value
+    optimization_enabled: bool  # toggles SGLANG_ENABLE_SLRU_OPTIMIZATION
+
+
+POLICIES: List[Policy] = [
+    Policy(label="lru", eviction_policy="lru", optimization_enabled=False),
+    Policy(
+        label="naive-slru",
+        eviction_policy="slru",
+        optimization_enabled=False,
+    ),
+    Policy(
+        label="optimized-slru",
+        eviction_policy="slru",
+        optimization_enabled=True,
+    ),
+]
+
+
+# -----------------------------------------------------------------------------
+# Server lifecycle
+# -----------------------------------------------------------------------------
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_server_ready(
+    host: str, port: int, timeout_sec: int, log_path: Path
+) -> bool:
+    """Poll ``/health`` until ready or timeout."""
+    deadline = time.time() + timeout_sec
+    url = f"http://{host}:{port}/health"
+    last_err: Optional[str] = None
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=2) as resp:
+                if resp.status == 200:
+                    return True
+        except (urllib.error.URLError, ConnectionError, socket.timeout) as e:
+            last_err = repr(e)
+        time.sleep(2)
+    print(
+        f"  [readiness] timed out after {timeout_sec}s; last error: {last_err}. "
+        f"See {log_path} for server logs.",
+        file=sys.stderr,
+    )
+    return False
+
+
+def _launch_server(
+    policy: Policy,
+    model: str,
+    port: int,
+    log_path: Path,
+    extra_server_args: List[str],
+    slru_knobs: Dict[str, float],
+) -> subprocess.Popen:
+    """Spawn ``sglang.launch_server`` for the given policy.
+
+    Returns the Popen handle so the caller can terminate it when the
+    bench run finishes.
+    """
+    cmd = [
+        sys.executable,
+        "-m",
+        "sglang.launch_server",
+        "--model-path",
+        model,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
+        "--radix-eviction-policy",
+        policy.eviction_policy,
+    ]
+
+    # Forward SLRU tuning knobs — only meaningful when policy is slru
+    # AND optimization_enabled, but passing them for lru/legacy SLRU is a no-op.
+    # at the server_args level and keeps the launch command uniform.
+    if policy.eviction_policy == "slru":
+        cmd += [
+            "--slru-protected-threshold",
+            str(int(slru_knobs["protected_threshold"])),
+            "--slru-debounce-sec",
+            str(slru_knobs["debounce_sec"]),
+            "--slru-decay-sec",
+            str(slru_knobs["decay_sec"]),
+        ]
+
+    cmd += extra_server_args
+
+    env = os.environ.copy()
+    env["SGLANG_ENABLE_SLRU_OPTIMIZATION"] = "1" if policy.optimization_enabled else "0"
+
+    log_f = open(log_path, "w")
+    log_f.write(f"# cmd: {shlex.join(cmd)}\n")
+    log_f.write(
+        f"# SGLANG_ENABLE_SLRU_OPTIMIZATION="
+        f"{env['SGLANG_ENABLE_SLRU_OPTIMIZATION']}\n"
+    )
+    log_f.flush()
+
+    # Start in its own process group so we can clean-kill children if the
+    # server spawns workers.
+    return subprocess.Popen(
+        cmd,
+        stdout=log_f,
+        stderr=subprocess.STDOUT,
+        env=env,
+        start_new_session=True,
+    )
+
+
+# The currently-running server, so the SIGINT/SIGTERM handler can hard-kill
+# it before the interpreter exits. Without this, ^C during a bench leaves
+# the server orphaned (PPID=1) holding all its GPU memory.
+_current_server: Optional[subprocess.Popen] = None
+
+
+def _install_signal_handlers() -> None:
+    """Hard-kill the current server + descendants on SIGINT/SIGTERM before
+    re-raising. The ``finally`` block in ``main`` may not run at all on a
+    double-^C; this guarantees the GPU memory is always released."""
+
+    def _handler(signum: int, frame) -> None:
+        server = _current_server
+        if server is not None and server.poll() is None:
+            print(
+                f"\n[compare] signal {signum} received; killing server tree "
+                f"pid={server.pid}",
+                file=sys.stderr,
+            )
+            try:
+                if kill_process_tree is not None:
+                    kill_process_tree(server.pid, include_parent=True)
+                else:
+                    os.killpg(os.getpgid(server.pid), signal.SIGKILL)
+            except Exception as e:  # best-effort — never mask the signal
+                print(f"[compare] kill failed: {e}", file=sys.stderr)
+        signal.signal(signum, signal.SIG_DFL)
+        os.kill(os.getpid(), signum)
+
+    signal.signal(signal.SIGINT, _handler)
+    signal.signal(signal.SIGTERM, _handler)
+
+
+def _shutdown_server(proc: subprocess.Popen, grace_sec: float = 20.0) -> None:
+    if proc.poll() is not None:
+        return
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    try:
+        proc.wait(timeout=grace_sec)
+    except subprocess.TimeoutExpired:
+        # psutil-based recursive kill catches scheduler/detokenizer children
+        # that may have escaped the process group (SGLang spawns them via
+        # multiprocessing with their own session).
+        try:
+            if kill_process_tree is not None:
+                kill_process_tree(proc.pid, include_parent=True)
+            else:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except Exception:
+            pass
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            pass
+
+
+# -----------------------------------------------------------------------------
+# Benchmark execution
+# -----------------------------------------------------------------------------
+
+
+def _run_bench(
+    dataset: str,
+    host: str,
+    port: int,
+    output_file: Path,
+    log_path: Path,
+    model: str,
+    extra_bench_args: List[str],
+) -> Optional[dict]:
+    """Run sglang.bench_serving and return the parsed result dict."""
+    preset = DATASET_PRESETS[dataset]
+    cmd = [
+        sys.executable,
+        "-m",
+        "sglang.bench_serving",
+        "--backend",
+        "sglang",
+        "--host",
+        host,
+        "--port",
+        str(port),
+        "--model",
+        model,
+        "--output-file",
+        str(output_file),
+        *preset["bench_args"],
+        *extra_bench_args,
+    ]
+
+    with open(log_path, "a") as log_f:
+        log_f.write(f"\n# bench cmd: {shlex.join(cmd)}\n")
+        log_f.flush()
+        rc = subprocess.call(cmd, stdout=log_f, stderr=subprocess.STDOUT)
+
+    if rc != 0:
+        print(
+            f"  [bench] non-zero exit code {rc}; see {log_path}",
+            file=sys.stderr,
+        )
+        return None
+
+    # bench_serving appends one JSONL line per run — there will be exactly one.
+    if not output_file.exists():
+        print(f"  [bench] no output file at {output_file}", file=sys.stderr)
+        return None
+    with open(output_file) as f:
+        lines = [json.loads(line) for line in f if line.strip()]
+    if not lines:
+        return None
+    return lines[-1]
+
+
+# -----------------------------------------------------------------------------
+# Reporting
+# -----------------------------------------------------------------------------
+
+HEADLINE_KEYS = [
+    ("median_ttft_ms", "median TTFT (ms)", "lower"),
+    ("p99_ttft_ms", "p99 TTFT (ms)", "lower"),
+    ("mean_e2e_latency_ms", "mean e2e (ms)", "lower"),
+    ("output_throughput", "output tok/s", "higher"),
+    ("request_throughput", "req/s", "higher"),
+    ("median_itl_ms", "median ITL (ms)", "lower"),
+    ("p99_itl_ms", "p99 ITL (ms)", "lower"),
+]
+
+
+def _format_delta(value: float, baseline: float, direction: str) -> str:
+    if baseline == 0 or value is None or baseline is None:
+        return "—"
+    pct = (value - baseline) / baseline * 100.0
+    # Color/sign convention: down-arrow is "good" for "lower", up-arrow for "higher".
+    good = (direction == "lower" and pct < 0) or (direction == "higher" and pct > 0)
+    marker = "↓" if pct < 0 else "↑"
+    qualifier = " ✓" if good and abs(pct) >= 1 else ""
+    return f"{pct:+.1f}% {marker}{qualifier}"
+
+
+def _render_markdown(
+    dataset: str,
+    model: str,
+    results: Dict[str, dict],
+    extra_server_args: List[str],
+    extra_bench_args: List[str],
+    slru_knobs: Dict[str, float],
+    timestamp: str,
+) -> str:
+    lines: List[str] = []
+    lines.append(f"# SLRU benchmark compare — {dataset} — {timestamp}")
+    lines.append("")
+    lines.append(f"- **Model**: `{model}`")
+    lines.append(
+        f"- **Dataset**: `{dataset}` (preset: `{' '.join(DATASET_PRESETS[dataset]['bench_args'])}`)"
+    )
+    if extra_bench_args:
+        lines.append(f"- **Extra bench args**: `{' '.join(extra_bench_args)}`")
+    if extra_server_args:
+        lines.append(f"- **Extra server args**: `{' '.join(extra_server_args)}`")
+    lines.append(
+        f"- **SLRU knobs**: threshold={int(slru_knobs['protected_threshold'])}, "
+        f"debounce={slru_knobs['debounce_sec']}s, decay={slru_knobs['decay_sec']}s"
+    )
+    lines.append("")
+    lines.append("## Headline metrics")
+    lines.append("")
+
+    header = (
+        ["metric"]
+        + [p.label for p in POLICIES]
+        + [f"{p.label} Δ vs lru" for p in POLICIES if p.label != "lru"]
+    )
+    lines.append("| " + " | ".join(header) + " |")
+    lines.append("| " + " | ".join(["---"] * len(header)) + " |")
+
+    lru_result = results.get("lru") or {}
+    for key, display, direction in HEADLINE_KEYS:
+        row = [display]
+        for p in POLICIES:
+            r = results.get(p.label) or {}
+            v = r.get(key)
+            row.append(f"{v:.2f}" if isinstance(v, (int, float)) else "—")
+        # Delta columns (only for non-lru rows)
+        baseline = lru_result.get(key)
+        for p in POLICIES:
+            if p.label == "lru":
+                continue
+            r = results.get(p.label) or {}
+            v = r.get(key)
+            row.append(
+                _format_delta(v, baseline, direction)
+                if isinstance(v, (int, float)) and isinstance(baseline, (int, float))
+                else "—"
+            )
+        lines.append("| " + " | ".join(row) + " |")
+
+    lines.append("")
+    lines.append("## Raw outputs")
+    lines.append("")
+    for p in POLICIES:
+        lines.append(f"- `{p.label}.jsonl` — bench_serving record for {p.label}")
+        lines.append(f"- `{p.label}.log` — combined server + bench stdout/stderr")
+    lines.append("")
+    lines.append(
+        "> Interpretation: compare `optimized-slru` vs `naive-slru` on the same row — "
+        "the optimization should improve (lower) TTFT percentiles and leave "
+        "throughput within a few percent on ShareGPT (baseline regression guard), "
+        "and produce a larger improvement on GSP (which has heavy prefix reuse)."
+    )
+
+    return "\n".join(lines) + "\n"
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+
+
+def main(argv: List[str]) -> int:
+    _install_signal_handlers()
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--model",
+        required=True,
+        help="Model path/name for both the server and the bench client.",
+    )
+    parser.add_argument(
+        "--dataset",
+        default="sharegpt",
+        choices=list(DATASET_PRESETS.keys()),
+        help="Dataset preset to run.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="benchmark/slru/results",
+        help="Directory to write compare.md + per-policy raw outputs into.",
+    )
+    parser.add_argument(
+        "--policies",
+        default="lru,naive-slru,optimized-slru",
+        help="Comma-separated subset of policies to benchmark. Useful for "
+        "re-running just one variant. Default: all three.",
+    )
+    parser.add_argument(
+        "--readiness-timeout-sec",
+        type=int,
+        default=600,
+        help="Seconds to wait for the server to become /health-ready after "
+        "launch. Default: 600 (first load pulls the model weights).",
+    )
+    parser.add_argument(
+        "--server-arg",
+        action="append",
+        default=[],
+        help="Extra argument forwarded to sglang.launch_server. Repeat as "
+        "needed, e.g. --server-arg=--mem-fraction-static=0.8 "
+        "--server-arg=--tp=1 .",
+    )
+    parser.add_argument(
+        "--bench-arg",
+        action="append",
+        default=[],
+        help="Extra argument forwarded to sglang.bench_serving. Repeat as "
+        "needed, e.g. --bench-arg=--sharegpt-path=/data/sharegpt.json .",
+    )
+    parser.add_argument(
+        "--slru-protected-threshold",
+        type=int,
+        default=2,
+    )
+    parser.add_argument("--slru-debounce-sec", type=float, default=0.1)
+    parser.add_argument("--slru-decay-sec", type=float, default=60.0)
+    args = parser.parse_args(argv)
+
+    selected = [p for p in POLICIES if p.label in args.policies.split(",")]
+    if not selected:
+        print(f"No known policies in {args.policies!r}.", file=sys.stderr)
+        return 2
+
+    slru_knobs = {
+        "protected_threshold": args.slru_protected_threshold,
+        "debounce_sec": args.slru_debounce_sec,
+        "decay_sec": args.slru_decay_sec,
+    }
+
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    out_dir = Path(args.output_dir) / f"{args.dataset}-{timestamp}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    print(f"[compare] output dir: {out_dir}")
+
+    results: Dict[str, dict] = {}
+    for policy in selected:
+        print(
+            f"[compare] === {policy.label}  "
+            f"(eviction={policy.eviction_policy}, "
+            f"optimization={policy.optimization_enabled}) ==="
+        )
+
+        port = _find_free_port()
+        server_log = out_dir / f"{policy.label}.log"
+        bench_out = out_dir / f"{policy.label}.jsonl"
+
+        server = _launch_server(
+            policy=policy,
+            model=args.model,
+            port=port,
+            log_path=server_log,
+            extra_server_args=args.server_arg,
+            slru_knobs=slru_knobs,
+        )
+        global _current_server
+        _current_server = server
+        print(f"  [server] pid={server.pid} port={port} log={server_log}")
+
+        try:
+            if not _wait_for_server_ready(
+                "127.0.0.1", port, args.readiness_timeout_sec, server_log
+            ):
+                print(f"  [server] readiness check FAILED; skipping bench run")
+                continue
+
+            print(f"  [bench] writing output to {bench_out}")
+            result = _run_bench(
+                dataset=args.dataset,
+                host="127.0.0.1",
+                port=port,
+                output_file=bench_out,
+                log_path=server_log,
+                model=args.model,
+                extra_bench_args=args.bench_arg,
+            )
+            if result is None:
+                print(f"  [bench] FAILED; see {server_log}")
+                continue
+
+            results[policy.label] = result
+            print(
+                f"  [bench] OK — "
+                f"median_ttft_ms={result.get('median_ttft_ms'):.1f}, "
+                f"p99_ttft_ms={result.get('p99_ttft_ms'):.1f}, "
+                f"output_tok/s={result.get('output_throughput'):.1f}"
+            )
+        finally:
+            print(f"  [server] shutting down pid={server.pid}")
+            _shutdown_server(server)
+            _current_server = None
+
+    report = _render_markdown(
+        dataset=args.dataset,
+        model=args.model,
+        results=results,
+        extra_server_args=args.server_arg,
+        extra_bench_args=args.bench_arg,
+        slru_knobs=slru_knobs,
+        timestamp=timestamp,
+    )
+    report_path = out_dir / "compare.md"
+    report_path.write_text(report)
+    print(f"[compare] wrote report: {report_path}")
+    if len(results) < len(selected):
+        print(
+            f"[compare] WARNING — only {len(results)}/{len(selected)} runs "
+            f"produced metrics; check per-policy .log files.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -489,6 +489,12 @@ class Envs:
     # Unified Radix Tree
     SGLANG_ENABLE_UNIFIED_RADIX_TREE = EnvBool(False)
 
+    # Radix Cache: SLRU hit-count optimization (debounce + cap + lazy decay).
+    # When False, ``SLRUStrategy`` preserves the legacy two-tier behavior
+    # (hit_count bumped unconditionally, no decay) so existing users see
+    # zero change. When True, SLRU activates the optimized code path.
+    SGLANG_ENABLE_SLRU_OPTIMIZATION = EnvBool(False)
+
     # Breakable CUDA Graph
     SGLANG_USE_BREAKABLE_CUDA_GRAPH = EnvBool(False)
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -810,7 +810,7 @@ class Scheduler(
             ),
             attn_cp_cache_group=self.attn_cp_cpu_group,
             attn_tp_cache_group=self.attn_tp_cpu_group,
-            eviction_policy=server_args.radix_eviction_policy,
+            eviction_config=server_args.radix_eviction_config(),
             enable_metrics=self.enable_metrics,
             enable_kv_cache_events=self.enable_kv_cache_events,
             enable_mamba_extra_buffer=server_args.enable_mamba_extra_buffer(),

--- a/python/sglang/srt/mem_cache/cache_init_params.py
+++ b/python/sglang/srt/mem_cache/cache_init_params.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import torch
 
@@ -9,6 +9,12 @@ if TYPE_CHECKING:
     from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
     from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
     from sglang.srt.mem_cache.unified_cache_components import ComponentType
+
+
+@dataclasses.dataclass
+class EvictionConfig:
+    policy: str = "lru"
+    params: dict[str, Any] = dataclasses.field(default_factory=dict)
 
 
 @dataclasses.dataclass
@@ -22,7 +28,7 @@ class CacheInitParams:
     tp_cache_group: Optional[torch.distributed.ProcessGroup] = None
     attn_cp_cache_group: Optional[torch.distributed.ProcessGroup] = None
     attn_tp_cache_group: Optional[torch.distributed.ProcessGroup] = None
-    eviction_policy: str = "lru"
+    eviction_config: EvictionConfig = dataclasses.field(default_factory=EvictionConfig)
     disable_finished_insert: bool = False
 
     enable_metrics: bool = False

--- a/python/sglang/srt/mem_cache/evict_policy.py
+++ b/python/sglang/srt/mem_cache/evict_policy.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import time
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Tuple, Union
+from typing import TYPE_CHECKING, Optional, Tuple, Union
+
+from sglang.srt.environ import envs
 
 if TYPE_CHECKING:
     from sglang.srt.mem_cache.radix_cache import TreeNode
@@ -9,57 +12,142 @@ if TYPE_CHECKING:
 
 class EvictionStrategy(ABC):
     @abstractmethod
-    def get_priority(self, node: "TreeNode") -> Union[float, Tuple]:
-        pass
+    def get_priority(
+        self, node: "TreeNode", now: Optional[float] = None
+    ) -> Union[float, Tuple]:
+        """Compute the eviction priority of ``node``.
+
+        ``now`` is an optional wall-clock snapshot (``time.monotonic()``) that
+        lets callers amortise clock reads across a whole eviction scan. Most
+        strategies don't need it (their priority is a pure function of the
+        node's own bookkeeping fields) and may ignore the argument. Strategies
+        that *do* need a current time reference (e.g. ``SLRUStrategy`` for lazy
+        decay) should fall back to ``time.monotonic()`` when ``now`` is None so
+        the signature stays ergonomic for standalone calls in tests.
+        """
+
+    def on_hit(self, node: "TreeNode", now: Optional[float] = None) -> None:
+        """Hook invoked when a radix-tree node is reused by a new insert.
+
+        Default behaviour is the classical LFU counter bump: `hit_count += 1`.
+        Strategies that need a different accounting (e.g. SLRU with debounce)
+        can override this without touching the radix-tree hot path.
+        """
+        node.hit_count += 1
 
 
 class LRUStrategy(EvictionStrategy):
-    def get_priority(self, node: "TreeNode") -> float:
+    def get_priority(self, node: "TreeNode", now: Optional[float] = None) -> float:
         return node.last_access_time
 
 
 class LFUStrategy(EvictionStrategy):
-    def get_priority(self, node: "TreeNode") -> Tuple[int, float]:
+    def get_priority(
+        self, node: "TreeNode", now: Optional[float] = None
+    ) -> Tuple[int, float]:
         return (node.hit_count, node.last_access_time)
 
 
 class FIFOStrategy(EvictionStrategy):
-    def get_priority(self, node: "TreeNode") -> float:
+    def get_priority(self, node: "TreeNode", now: Optional[float] = None) -> float:
         return node.creation_time
 
 
 class MRUStrategy(EvictionStrategy):
-    def get_priority(self, node: "TreeNode") -> float:
+    def get_priority(self, node: "TreeNode", now: Optional[float] = None) -> float:
         return -node.last_access_time
 
 
 class FILOStrategy(EvictionStrategy):
-    def get_priority(self, node: "TreeNode") -> float:
+    def get_priority(self, node: "TreeNode", now: Optional[float] = None) -> float:
         return -node.creation_time
 
 
 class PriorityStrategy(EvictionStrategy):
     """Priority-aware eviction: lower priority values evicted first, then LRU within same priority."""
 
-    def get_priority(self, node: "TreeNode") -> Tuple[int, float]:
+    def get_priority(
+        self, node: "TreeNode", now: Optional[float] = None
+    ) -> Tuple[int, float]:
         # Return (priority, last_access_time) so lower priority nodes are evicted first
         return (node.priority, node.last_access_time)
 
 
 class SLRUStrategy(EvictionStrategy):
-    def __init__(self, protected_threshold: int = 2):
+    """Segmented LRU with write-side debounce and read-side lazy decay.
+
+    ``debounce_sec`` prevents near-simultaneous hits from promoting a
+    one-shot prefix. ``decay_sec`` lazily lowers the effective hit count during
+    eviction so stale protected nodes can fall back to probationary without a
+    background sweeper.
+    """
+
+    def __init__(
+        self,
+        protected_threshold: int = 2,
+        debounce_sec: float = 0.1,
+        decay_sec: float = 60.0,
+    ):
+        # Keep zero debounce valid for legacy-equivalent hit accounting, and
+        # guard decay against division by zero.
         self.protected_threshold = protected_threshold
+        self.debounce_sec = max(0.0, debounce_sec)
+        self.decay_sec = max(1e-3, decay_sec)
+        self._optimization_enabled = envs.SGLANG_ENABLE_SLRU_OPTIMIZATION.get()
 
-    def get_priority(self, node: "TreeNode") -> Tuple[int, float]:
-        # Priority Logic:
-        # Smaller value = Evicted earlier.
-        #
-        # Segment 0 (Probationary): hit_count < threshold
-        # Segment 1 (Protected): hit_count >= threshold
-        #
-        # Tuple comparison: (segment, last_access_time)
-        # Nodes in segment 0 will always be evicted before segment 1.
-        # Inside the same segment, older nodes (smaller time) are evicted first.
+    def on_hit(self, node: "TreeNode", now: Optional[float] = None) -> None:
+        if not self._optimization_enabled:
+            node.hit_count += 1
+            return
 
-        is_protected = 1 if node.hit_count >= self.protected_threshold else 0
+        if now is None:
+            now = time.monotonic()
+
+        # Debounce suppresses repeated hits in a burst, but the first observed
+        # access is the baseline count for this node.
+        if node.hit_count == 0:
+            node.hit_count = 1
+            node.last_accessed_timestamp = now
+            return
+
+        # Protected nodes refresh recency but do not accumulate unbounded heat.
+        if node.hit_count >= self.protected_threshold:
+            node.last_accessed_timestamp = now
+            return
+
+        # Probationary tier: debounce successive hits so a burst of concurrent
+        # requests cannot single-handedly promote a node.
+        if now - node.last_accessed_timestamp >= self.debounce_sec:
+            node.hit_count += 1
+            node.last_accessed_timestamp = now
+
+    def _effective_hit_count(self, node: "TreeNode", now: float) -> int:
+        # Lazy decay: every `decay_sec` period halves the effective hit count.
+        # During eviction we use this decayed score for tiering:
+        # newer nodes keep more heat, very stale nodes naturally drop to 0.
+        hit_count = node.hit_count
+        age = now - node.last_accessed_timestamp
+        if age <= 0:
+            return hit_count
+
+        halvings = int(age // self.decay_sec)
+
+        # Saturate on huge ages rather than attempting a >> bit_length() shift
+        if halvings >= hit_count.bit_length():
+            return 0
+        return hit_count >> halvings
+
+    def get_priority(
+        self, node: "TreeNode", now: Optional[float] = None
+    ) -> Tuple[int, float]:
+        # Lower priority is evicted earlier: probationary before protected,
+        # then LRU within the same segment.
+        if not self._optimization_enabled:
+            is_protected = 1 if node.hit_count >= self.protected_threshold else 0
+            return (is_protected, node.last_access_time)
+
+        if now is None:
+            now = time.monotonic()
+        eff = self._effective_hit_count(node, now)
+        is_protected = 1 if eff >= self.protected_threshold else 0
         return (is_protected, node.last_access_time)

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -728,7 +728,7 @@ class HiRadixCache(RadixCache):
         # skip the hit count update for chunked requests
         if self.cache_controller.write_policy == "write_back" or chunked:
             return
-        node.hit_count += 1
+        self.eviction_strategy.on_hit(node)
 
         if not node.backuped:
             if node.hit_count >= self.write_through_threshold:
@@ -858,8 +858,11 @@ class HiRadixCache(RadixCache):
         start_time = time.perf_counter()
         num_tokens = params.num_tokens
         leaves = list(self.evictable_leaves)
+        # See RadixCache.evict for the rationale - amortise time.monotonic
+        # across the whole eviction scan.
+        now = time.monotonic()
         eviction_heap = [
-            (self.eviction_strategy.get_priority(node), node) for node in leaves
+            (self.eviction_strategy.get_priority(node, now), node) for node in leaves
         ]
         heapq.heapify(eviction_heap)
 
@@ -890,7 +893,7 @@ class HiRadixCache(RadixCache):
                     break
             else:
                 # all children are evicted or no children
-                new_priority = self.eviction_strategy.get_priority(x.parent)
+                new_priority = self.eviction_strategy.get_priority(x.parent, now)
                 heapq.heappush(eviction_heap, (new_priority, x.parent))
 
         if self.cache_controller.write_policy == "write_back":
@@ -929,8 +932,9 @@ class HiRadixCache(RadixCache):
 
     def evict_host(self, num_tokens: int):
         leaves = list(self.evictable_host_leaves)
+        now = time.monotonic()
         eviction_heap = [
-            (self.eviction_strategy.get_priority(node), node) for node in leaves
+            (self.eviction_strategy.get_priority(node, now), node) for node in leaves
         ]
         heapq.heapify(eviction_heap)
 
@@ -959,7 +963,7 @@ class HiRadixCache(RadixCache):
             self._update_host_leaf_status(x.parent)
 
             if len(x.parent.children) == 0 and x.parent.evicted:
-                new_priority = self.eviction_strategy.get_priority(x.parent)
+                new_priority = self.eviction_strategy.get_priority(x.parent, now)
                 heapq.heappush(eviction_heap, (new_priority, x.parent))
 
     def load_back(
@@ -1391,6 +1395,8 @@ class HiRadixCache(RadixCache):
         new_node.lock_ref = child.lock_ref
         new_node.key = child.key[:split_len]
         new_node.hit_count = child.hit_count
+        new_node.last_access_time = child.last_access_time
+        new_node.last_accessed_timestamp = child.last_accessed_timestamp
 
         # split value and host value if exists
         if child.evicted:

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -222,6 +222,10 @@ class TreeNode:
         self.creation_time = time.monotonic()
 
         self.hit_count = 0
+        # SLRU's last counted-hit timestamp. This starts at creation time but
+        # can diverge from ``last_access_time`` because cache lookups and
+        # debounced hits still refresh LRU recency.
+        self.last_accessed_timestamp = self.last_access_time
         # indicating the node is locked to protect from eviction
         # incremented when the node is referenced by a storage operation
         self.host_ref_counter = 0
@@ -327,7 +331,7 @@ class RadixCache(BasePrefixCache):
         self.enable_kv_cache_events = params.enable_kv_cache_events
         self.is_eagle = params.is_eagle
         self.disable_finished_insert = params.disable_finished_insert
-        self.eviction_policy = params.eviction_policy.lower()
+        self.eviction_policy = params.eviction_config.policy.lower()
 
         self.kv_event_queue = []
 
@@ -352,8 +356,9 @@ class RadixCache(BasePrefixCache):
         elif self.eviction_policy == "priority":
             self.eviction_strategy: EvictionStrategy = PriorityStrategy()
         elif self.eviction_policy == "slru":
-            self.eviction_strategy: EvictionStrategy = SLRUStrategy()
-
+            self.eviction_strategy: EvictionStrategy = SLRUStrategy(
+                **params.eviction_config.params
+            )
         else:
             raise ValueError(
                 f"Unknown eviction policy: {self.eviction_policy}. Supported policies: 'lru', 'lfu', 'fifo', 'mru', 'filo', 'priority', 'slru'."
@@ -612,8 +617,13 @@ class RadixCache(BasePrefixCache):
         start_time = time.perf_counter()
         num_tokens = params.num_tokens
         leaves = list(self.evictable_leaves)
+        # Snapshot the monotonic clock once and thread it through each
+        # ``get_priority`` call. With N leaves this turns N clock reads into 1,
+        # and incidentally guarantees all priorities in the initial heap are
+        # evaluated against a single, consistent "now" reference.
+        now = time.monotonic()
         eviction_heap = [
-            (self.eviction_strategy.get_priority(node), node) for node in leaves
+            (self.eviction_strategy.get_priority(node, now), node) for node in leaves
         ]
         heapq.heapify(eviction_heap)
 
@@ -626,7 +636,7 @@ class RadixCache(BasePrefixCache):
             self._delete_leaf(x)
 
             if len(x.parent.children) == 0 and x.parent.lock_ref == 0:
-                new_priority = self.eviction_strategy.get_priority(x.parent)
+                new_priority = self.eviction_strategy.get_priority(x.parent, now)
                 heapq.heappush(eviction_heap, (new_priority, x.parent))
 
             self._record_remove_event(x)
@@ -721,6 +731,10 @@ class RadixCache(BasePrefixCache):
         # New node inherits child's priority (represents shared prefix)
         new_node = TreeNode(priority=child.priority)
         new_node.hit_count = child.hit_count
+        # Preserve the counted-hit timestamp across splits so lazy decay sees
+        # the represented prefix's real SLRU age.
+        new_node.last_access_time = child.last_access_time
+        new_node.last_accessed_timestamp = child.last_accessed_timestamp
         new_node.children = {key[split_len:].child_key(self.page_size): child}
         new_node.parent = child.parent
         new_node.lock_ref = child.lock_ref
@@ -744,7 +758,10 @@ class RadixCache(BasePrefixCache):
         # in previous chunks.
         if chunked:
             return
-        node.hit_count += 1
+        # Delegate to the eviction strategy so policy-specific accounting
+        # (e.g. SLRU debounce, future custom policies) stays out of the radix
+        # tree hot path.
+        self.eviction_strategy.on_hit(node)
 
     def _insert_helper(
         self,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -32,6 +32,7 @@ from sglang.srt.environ import envs
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.layers.attention.fla.chunk_delta_h import CHUNK_SIZE as FLA_CHUNK_SIZE
 from sglang.srt.lora.lora_registry import LoRARef
+from sglang.srt.mem_cache.cache_init_params import EvictionConfig
 from sglang.srt.parser.reasoning_parser import ReasoningParser
 from sglang.srt.utils.common import (
     LORA_TARGET_ALL_MODULES,
@@ -368,6 +369,9 @@ class ServerArgs:
     swa_full_tokens_ratio: float = 0.8
     disable_hybrid_swa_memory: bool = False
     radix_eviction_policy: str = "lru"
+    slru_protected_threshold: int = 2
+    slru_debounce_sec: float = 0.1
+    slru_decay_sec: float = 60.0
     enable_prefill_delayer: bool = False
     prefill_delayer_max_delay_passes: int = 30
     prefill_delayer_token_usage_low_watermark: Optional[float] = None
@@ -4540,6 +4544,31 @@ class ServerArgs:
             help="The eviction policy of radix trees. 'lru' stands for Least Recently Used, 'lfu' stands for Least Frequently Used, 'slru' stands for Segmented Least Recently Used, and 'priority' evicts lower-priority requests first.",
         )
         parser.add_argument(
+            "--slru-protected-threshold",
+            type=int,
+            default=ServerArgs.slru_protected_threshold,
+            help="SLRU: hit_count >= threshold promotes a node to the Protected tier. "
+            "Only active with --radix-eviction-policy slru. When "
+            "SGLANG_ENABLE_SLRU_OPTIMIZATION=1, hit_count is also capped at this value.",
+        )
+        parser.add_argument(
+            "--slru-debounce-sec",
+            type=float,
+            default=ServerArgs.slru_debounce_sec,
+            help="SLRU write-side debounce window. Hits within this many seconds of "
+            "the last counted hit do not bump hit_count. Only active when "
+            "SGLANG_ENABLE_SLRU_OPTIMIZATION=1.",
+        )
+        parser.add_argument(
+            "--slru-decay-sec",
+            type=float,
+            default=ServerArgs.slru_decay_sec,
+            help="SLRU lazy-decay half-life. At eviction time, effective hit_count is "
+            "hit_count >> floor(age / decay_sec), so a cold Protected node demotes "
+            "itself back to Probationary. Only active when "
+            "SGLANG_ENABLE_SLRU_OPTIMIZATION=1.",
+        )
+        parser.add_argument(
             "--enable-prefill-delayer",
             action="store_true",
             help="Enable prefill delayer for DP attention to reduce idle time.",
@@ -6662,6 +6691,19 @@ class ServerArgs:
 
     def enable_mamba_extra_buffer(self) -> bool:
         return self.mamba_scheduler_strategy == "extra_buffer"
+
+    def radix_eviction_config(self) -> EvictionConfig:
+        params = {}
+        if self.radix_eviction_policy.lower() == "slru":
+            params = {
+                "protected_threshold": self.slru_protected_threshold,
+                "debounce_sec": self.slru_debounce_sec,
+                "decay_sec": self.slru_decay_sec,
+            }
+        return EvictionConfig(
+            policy=self.radix_eviction_policy,
+            params=params,
+        )
 
     @property
     def mamba_cache_chunk_size(self) -> int:

--- a/test/registered/unit/mem_cache/test_bench_hit_rate_scenarios.py
+++ b/test/registered/unit/mem_cache/test_bench_hit_rate_scenarios.py
@@ -1,0 +1,283 @@
+"""Unit tests for the hit-rate simulator scenario generators.
+
+Covers ``benchmark/slru/bench_hit_rate.py``'s pure-Python event
+generators — determinism, event-count math, hot-set rotation, Zipfian
+skew, and input validation. These tests do **not** drive a RadixCache;
+policy-level assertions are in ``test_slru_hit_rate.py``. Kept in the
+same suite because the scenarios exist to support that policy work.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="stage-a-test-cpu")
+
+import random
+import sys
+import unittest
+from collections import Counter
+from pathlib import Path
+
+# ``benchmark/slru`` is a script directory, not an importable package,
+# so extend sys.path to pull in the generator functions by module name.
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_BENCH_SLRU = _REPO_ROOT / "benchmark" / "slru"
+if str(_BENCH_SLRU) not in sys.path:
+    sys.path.insert(0, str(_BENCH_SLRU))
+
+try:
+    import torch  # noqa: F401 — bench_hit_rate imports torch at top
+    from bench_hit_rate import (  # type: ignore[import-not-found]
+        scenario_mixed,
+        scenario_shifting_zipfian,
+    )
+
+    _IMPORT_ERROR = None
+    _AVAILABLE = True
+except Exception as exc:  # pragma: no cover — env-dependent
+    _IMPORT_ERROR = exc
+    _AVAILABLE = False
+
+
+@unittest.skipUnless(
+    _AVAILABLE,
+    f"bench_hit_rate import unavailable: {_IMPORT_ERROR}",
+)
+class TestShiftingZipfian(unittest.TestCase):
+    """Behavioural tests for ``scenario_shifting_zipfian``."""
+
+    def test_determinism_same_seed(self):
+        """Same seed ⇒ identical event sequence."""
+        a = list(scenario_shifting_zipfian(random.Random(42), duration_sec=60))
+        b = list(scenario_shifting_zipfian(random.Random(42), duration_sec=60))
+        self.assertEqual(a, b)
+        self.assertGreater(len(a), 0)
+
+    def test_different_seeds_differ(self):
+        """Different seeds produce non-identical sequences."""
+        a = list(scenario_shifting_zipfian(random.Random(1), duration_sec=60))
+        b = list(scenario_shifting_zipfian(random.Random(2), duration_sec=60))
+        self.assertNotEqual(a, b)
+
+    def test_event_count_matches_rate(self):
+        """``rate_rps × duration`` access events are emitted (±rounding)."""
+        evs = list(
+            scenario_shifting_zipfian(random.Random(0), duration_sec=60, rate_rps=50)
+        )
+        accesses = [e for e in evs if e.kind == "access"]
+        advances = [e for e in evs if e.kind == "advance"]
+        # Allow a small boundary tolerance on the last rotation slice.
+        self.assertAlmostEqual(len(accesses), 3000, delta=5)
+        self.assertEqual(len(accesses), len(advances))
+
+    def test_hot_set_rotates(self):
+        """Each rotation window introduces at least one new prefix."""
+        evs = list(
+            scenario_shifting_zipfian(
+                random.Random(7),
+                duration_sec=40,
+                rotate_sec=10,
+                shift_stride=5,
+                hot_size=10,
+                pool_size=100,
+                rate_rps=20,
+            )
+        )
+        windows = [set() for _ in range(4)]
+        t = 0.0
+        w = 0
+        for ev in evs:
+            if ev.kind == "access":
+                windows[w].add(ev.token_ids)
+            else:
+                t += ev.seconds
+                if t >= (w + 1) * 10 and w < 3:
+                    w += 1
+        for i in range(len(windows) - 1):
+            new_prefixes = windows[i + 1] - windows[i]
+            self.assertGreater(
+                len(new_prefixes),
+                0,
+                f"rotation {i+1} must introduce at least one new prefix",
+            )
+
+    def test_zipfian_skew_matches_theory(self):
+        """Observed popularity distribution matches Zipf(α).
+
+        For Zipf(α=1.2, n=10), theory: top ≈ 40.5 %, bot ≈ 2.6 %.
+        We pin the hot set (``shift_stride=0``) so the counts reflect
+        the within-set distribution directly.
+        """
+        evs = list(
+            scenario_shifting_zipfian(
+                random.Random(123),
+                duration_sec=100,
+                rate_rps=500,
+                rotate_sec=1000,
+                shift_stride=0,
+                hot_size=10,
+                pool_size=100,
+                zipf_alpha=1.2,
+            )
+        )
+        counts = sorted(
+            Counter(e.token_ids for e in evs if e.kind == "access").values(),
+            reverse=True,
+        )
+        total = sum(counts)
+        top_frac = counts[0] / total
+        bot_frac = counts[-1] / total
+        # ±5 pp tolerance around the theoretical 40.5 % / 2.6 %.
+        self.assertGreater(top_frac, 0.35)
+        self.assertLess(top_frac, 0.45)
+        self.assertGreater(bot_frac, 0.015)
+        self.assertLess(bot_frac, 0.04)
+        # Top should be at least 10× more popular than bottom.
+        self.assertGreater(top_frac / bot_frac, 10)
+
+    def test_static_zipfian_when_stride_zero(self):
+        """``shift_stride=0`` degenerates to a fixed hot set."""
+        evs = list(
+            scenario_shifting_zipfian(
+                random.Random(0),
+                duration_sec=100,
+                rotate_sec=10,
+                shift_stride=0,
+                hot_size=5,
+                pool_size=50,
+            )
+        )
+        unique = {e.token_ids for e in evs if e.kind == "access"}
+        self.assertEqual(len(unique), 5)
+
+    def test_pool_size_bound_respected(self):
+        """Across long runs with wrap-around, we never exceed
+        ``pool_size`` distinct prefixes."""
+        evs = list(
+            scenario_shifting_zipfian(
+                random.Random(0),
+                duration_sec=1000,
+                rotate_sec=10,
+                shift_stride=5,
+                pool_size=10,
+                hot_size=3,
+            )
+        )
+        unique = {e.token_ids for e in evs if e.kind == "access"}
+        self.assertLessEqual(len(unique), 10)
+
+    def test_prefix_shape(self):
+        """Every access event carries a 16-int token tuple."""
+        evs = list(
+            scenario_shifting_zipfian(
+                random.Random(0), duration_sec=30, pool_size=10, hot_size=3
+            )
+        )
+        for ev in evs:
+            if ev.kind == "access":
+                self.assertEqual(len(ev.token_ids), 16)
+                self.assertTrue(all(isinstance(t, int) for t in ev.token_ids))
+
+    def test_rotation_placement_math(self):
+        """Rotation N's top prefix must be ``prefixes[(N*stride) % pool]``.
+
+        With ``zipf_alpha=5`` the top prefix collects ≥90 % of hits,
+        so ``mode`` per rotation window unambiguously identifies it.
+        """
+        evs = list(
+            scenario_shifting_zipfian(
+                random.Random(0),
+                duration_sec=35,
+                rotate_sec=10,
+                shift_stride=5,
+                pool_size=100,
+                hot_size=3,
+                rate_rps=50,
+                zipf_alpha=5,
+            )
+        )
+        top_per_rotation = [Counter() for _ in range(4)]
+        t = 0.0
+        r = 0
+        for ev in evs:
+            if ev.kind == "access":
+                top_per_rotation[r][ev.token_ids] += 1
+            else:
+                t += ev.seconds
+                if t >= (r + 1) * 10 and r < 3:
+                    r += 1
+        for r_idx in range(4):
+            center = (r_idx * 5) % 100
+            expected = tuple(range(10 + center * 32, 10 + center * 32 + 16))
+            observed_top = max(
+                top_per_rotation[r_idx],
+                key=top_per_rotation[r_idx].get,
+            )
+            self.assertEqual(
+                observed_top,
+                expected,
+                f"rotation {r_idx}: center={center} — top prefix mismatch",
+            )
+
+    def test_invalid_params_raise(self):
+        """All invalid parameter combos raise ``ValueError`` with a
+        clear message."""
+        rng = random.Random(0)
+        bad_kwargs = [
+            ("hot_size > pool_size", dict(pool_size=5, hot_size=10)),
+            ("rate_rps = 0", dict(rate_rps=0)),
+            ("rotate_sec = 0", dict(rotate_sec=0)),
+            ("pool_size = 0", dict(pool_size=0)),
+            ("hot_size = 0", dict(hot_size=0)),
+            ("zipf_alpha < 0", dict(zipf_alpha=-0.5)),
+            ("shift_stride < 0", dict(shift_stride=-1)),
+        ]
+        for desc, kw in bad_kwargs:
+            with self.subTest(case=desc):
+                with self.assertRaises(ValueError):
+                    list(scenario_shifting_zipfian(rng, duration_sec=10, **kw))
+
+
+@unittest.skipUnless(
+    _AVAILABLE,
+    f"bench_hit_rate import unavailable: {_IMPORT_ERROR}",
+)
+class TestMixedScenarioUnchanged(unittest.TestCase):
+    """Backward-compat regression: ``scenario_mixed`` must be
+    deterministic and unaltered by the shifting_zipfian addition."""
+
+    def test_mixed_deterministic(self):
+        a = list(scenario_mixed(random.Random(0xC0FFEE), duration_sec=30))
+        b = list(scenario_mixed(random.Random(0xC0FFEE), duration_sec=30))
+        self.assertEqual(a, b)
+        self.assertGreater(len(a), 0)
+
+    def test_mixed_emits_bursts(self):
+        """Burst hits (50 rapid accesses) should still appear."""
+        evs = list(scenario_mixed(random.Random(0), duration_sec=60))
+        # A burst is signalled by many "access" events in a row with
+        # identical token_ids and an "advance" of 0.0002.
+        access_runs: list[tuple[tuple, int]] = []
+        cur_key = None
+        cur_count = 0
+        for ev in evs:
+            if ev.kind == "access":
+                if ev.token_ids == cur_key:
+                    cur_count += 1
+                else:
+                    if cur_key is not None:
+                        access_runs.append((cur_key, cur_count))
+                    cur_key = ev.token_ids
+                    cur_count = 1
+        if cur_key is not None:
+            access_runs.append((cur_key, cur_count))
+        burst_runs = [r for r in access_runs if r[1] >= 50]
+        self.assertGreater(
+            len(burst_runs),
+            0,
+            "scenario_mixed should emit at least one burst run (>=50 "
+            "back-to-back accesses on the same prefix)",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_evict_policy.py
+++ b/test/registered/unit/mem_cache/test_evict_policy.py
@@ -7,7 +7,9 @@ register_cpu_ci(est_time=6, suite="stage-a-test-cpu")
 import unittest
 from unittest.mock import MagicMock
 
+from sglang.srt.environ import envs
 from sglang.srt.mem_cache.evict_policy import (
+    EvictionStrategy,
     FIFOStrategy,
     FILOStrategy,
     LFUStrategy,
@@ -18,12 +20,28 @@ from sglang.srt.mem_cache.evict_policy import (
 )
 
 
+def _make_slru_optimized(**kwargs):
+    """Construct an SLRUStrategy with the optimization gate forced ON.
+
+    ``SLRUStrategy`` snapshots ``SGLANG_ENABLE_SLRU_OPTIMIZATION`` at
+    construction time, so tests that exercise the optimized code path
+    toggle the env var inside a context manager and build a fresh
+    instance. Tests that exercise the legacy (gate-off) path just call
+    ``SLRUStrategy(...)`` directly; default env is off.
+    """
+    with envs.SGLANG_ENABLE_SLRU_OPTIMIZATION.override(True):
+        return SLRUStrategy(**kwargs)
+
+
 def _make_node(**kwargs):
     node = MagicMock()
     node.last_access_time = kwargs.get("last_access_time", 0.0)
     node.hit_count = kwargs.get("hit_count", 0)
     node.creation_time = kwargs.get("creation_time", 0.0)
     node.priority = kwargs.get("priority", 0)
+    node.last_accessed_timestamp = kwargs.get(
+        "last_accessed_timestamp", node.last_access_time
+    )
     return node
 
 
@@ -212,6 +230,604 @@ class TestEvictionOrdering(unittest.TestCase):
         ]
         actual = [strategy.get_priority(n) for n in eviction_order]
         self.assertEqual(actual, expected)
+
+
+class TestEvictionStrategyDefaultOnHit(unittest.TestCase):
+    """The default on_hit hook preserves legacy hit-count accounting.
+
+    Non-SLRU policies inherit this hook and must not mutate the SLRU-specific
+    ``last_accessed_timestamp`` field.
+    """
+
+    def _check_default_on_hit_is_pure_increment(self, strategy):
+        node = _make_node(hit_count=7, last_accessed_timestamp=42.0)
+        strategy.on_hit(node)
+        self.assertEqual(node.hit_count, 8)
+        # Default on_hit must not mutate the SLRU-specific timestamp.
+        self.assertEqual(node.last_accessed_timestamp, 42.0)
+
+    def test_lru_default_on_hit(self):
+        self._check_default_on_hit_is_pure_increment(LRUStrategy())
+
+    def test_lfu_default_on_hit(self):
+        self._check_default_on_hit_is_pure_increment(LFUStrategy())
+
+    def test_fifo_default_on_hit(self):
+        self._check_default_on_hit_is_pure_increment(FIFOStrategy())
+
+    def test_mru_default_on_hit(self):
+        self._check_default_on_hit_is_pure_increment(MRUStrategy())
+
+    def test_filo_default_on_hit(self):
+        self._check_default_on_hit_is_pure_increment(FILOStrategy())
+
+    def test_priority_default_on_hit(self):
+        self._check_default_on_hit_is_pure_increment(PriorityStrategy())
+
+    def test_slru_inherits_default_on_hit_in_pr1(self):
+        # With the optimization gate off, SLRU keeps legacy accounting.
+        self._check_default_on_hit_is_pure_increment(SLRUStrategy())
+
+
+class TestBatchedNowSnapshot(unittest.TestCase):
+    """All strategies accept a shared eviction-time snapshot.
+
+    Non-time-based strategies ignore ``now`` and preserve their priorities.
+    """
+
+    def test_non_time_strategies_accept_now_without_side_effects(self):
+        strategies = [
+            LRUStrategy(),
+            LFUStrategy(),
+            FIFOStrategy(),
+            MRUStrategy(),
+            FILOStrategy(),
+            PriorityStrategy(),
+        ]
+        for strategy in strategies:
+            node = _make_node(
+                hit_count=3,
+                last_access_time=5.0,
+                creation_time=1.0,
+                priority=2,
+            )
+            without_now = strategy.get_priority(node)
+            with_now = strategy.get_priority(node, now=999.0)
+            self.assertEqual(
+                without_now,
+                with_now,
+                f"{type(strategy).__name__} changed output when `now` was supplied",
+            )
+
+    def test_slru_accepts_now_kwarg_in_pr1(self):
+        # With the optimization gate off, SLRU ignores ``now``.
+        strategy = SLRUStrategy()
+        node = _make_node(hit_count=5, last_access_time=3.0)
+        self.assertEqual(strategy.get_priority(node), (1, 3.0))
+        self.assertEqual(strategy.get_priority(node, now=1e18), (1, 3.0))
+
+
+class TestEvictionStrategyBaseClass(unittest.TestCase):
+    """Sanity checks on the ABC itself."""
+
+    def test_cannot_instantiate_abstract_base(self):
+        with self.assertRaises(TypeError):
+            EvictionStrategy()  # abstract — no concrete get_priority
+
+    def test_slru_has_optimization_knobs(self):
+        strategy = SLRUStrategy()
+        self.assertEqual(strategy.protected_threshold, 2)
+        self.assertEqual(strategy.debounce_sec, 0.1)
+        self.assertEqual(strategy.decay_sec, 60.0)
+
+
+# -----------------------------------------------------------------------------
+# Integration tests against RadixCache. These require the full sglang runtime
+# (torch, allocators, kv_events), so we skip gracefully when imports fail —
+# CI runs these in a full environment, while minimal dev boxes (no GPU toolchain)
+# still get the strategy-layer coverage above.
+# -----------------------------------------------------------------------------
+
+try:
+    import torch  # noqa: F401
+
+    from sglang.srt.mem_cache import radix_cache as _radix_cache_module
+    from sglang.srt.mem_cache.base_prefix_cache import (
+        EvictParams,
+        InsertParams,
+    )
+    from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey
+
+    _RADIX_CACHE_AVAILABLE = True
+    _RADIX_CACHE_IMPORT_ERROR = None
+except Exception as exc:  # pragma: no cover — depends on environment
+    _RADIX_CACHE_AVAILABLE = False
+    _RADIX_CACHE_IMPORT_ERROR = exc
+
+
+class _MockAllocator:
+    """Counts freed tokens; enough to satisfy ``evict()`` without a real pool."""
+
+    def __init__(self):
+        self.device = None
+        self.freed_tokens = 0
+
+    def free(self, value):
+        # value is a torch.Tensor of token indices
+        self.freed_tokens += int(value.numel())
+
+
+@unittest.skipUnless(
+    _RADIX_CACHE_AVAILABLE,
+    f"RadixCache import unavailable: {_RADIX_CACHE_IMPORT_ERROR}",
+)
+class TestRadixCacheSLRUScaffolding(unittest.TestCase):
+    """RadixCache contracts required by SLRU debounce and lazy decay."""
+
+    def setUp(self):
+        self.allocator = _MockAllocator()
+        self.cache = RadixCache.create_simulated(
+            mock_allocator=self.allocator, page_size=1
+        )
+
+    def test_tree_node_has_last_accessed_timestamp_field(self):
+        # The SLRU timestamp is initialized from the node's access time.
+        import torch
+
+        key = RadixKey(token_ids=[1, 2, 3], extra_key=None)
+        value = torch.tensor([10, 20, 30], dtype=torch.int64)
+        self.cache.insert(InsertParams(key=key, value=value))
+        # Find the leaf we just inserted.
+        node = list(self.cache.evictable_leaves)[0]
+        self.assertTrue(hasattr(node, "last_accessed_timestamp"))
+        self.assertEqual(node.last_accessed_timestamp, node.last_access_time)
+
+    def test_evict_snapshots_monotonic_once_per_scan(self):
+        """The decisive scaling guarantee: when the eviction heap is built
+        across N leaves, ``time.monotonic()`` must be called exactly ONCE
+        (the sweep snapshot), not N times. This test inserts 32 distinct
+        leaves and spies on ``radix_cache.time.monotonic`` during evict().
+        If any future refactor forgets to thread ``now`` through, call
+        count explodes and this test fires.
+        """
+        import torch
+
+        # Insert 32 disjoint prefixes so each becomes its own evictable leaf.
+        for i in range(32):
+            key = RadixKey(token_ids=[1000 + i, 2000 + i], extra_key=None)
+            value = torch.tensor([i, i + 1], dtype=torch.int64)
+            self.cache.insert(InsertParams(key=key, value=value))
+        self.assertGreaterEqual(len(self.cache.evictable_leaves), 32)
+
+        real_monotonic = _radix_cache_module.time.monotonic
+        call_log = []
+
+        def spy():
+            call_log.append(None)
+            return real_monotonic()
+
+        original = _radix_cache_module.time.monotonic
+        _radix_cache_module.time.monotonic = spy
+        try:
+            self.cache.evict(EvictParams(num_tokens=4))
+        finally:
+            _radix_cache_module.time.monotonic = original
+
+        # Exactly one sweep snapshot; time.perf_counter() is a different
+        # symbol and does not show up in this counter.
+        self.assertEqual(
+            len(call_log),
+            1,
+            f"evict() must snapshot time.monotonic exactly once per sweep, "
+            f"got {len(call_log)} calls",
+        )
+
+    def test_split_inherits_last_accessed_timestamp(self):
+        """When ``_split_node`` creates an intermediate node, it must
+        inherit ``last_accessed_timestamp`` from the child so lazy decay keeps
+        the original age of the represented prefix.
+        """
+        import torch
+
+        # Insert a long prefix, then a shorter prefix that forces a split
+        # inside the first one.
+        long_key = RadixKey(token_ids=[1, 2, 3, 4, 5, 6], extra_key=None)
+        long_val = torch.tensor([10, 20, 30, 40, 50, 60], dtype=torch.int64)
+        self.cache.insert(InsertParams(key=long_key, value=long_val))
+
+        # Pin a known SLRU-timestamp on the inserted leaf. Only SLRU's
+        # on_hit advances this field, so a subsequent insert on a
+        # different prefix will NOT overwrite it.
+        leaf = list(self.cache.evictable_leaves)[0]
+        leaf.last_accessed_timestamp = 123.456
+
+        # Now insert a diverging prefix that shares the first 3 tokens —
+        # _split_node will cleave the original into a parent + child.
+        divergent_key = RadixKey(token_ids=[1, 2, 3, 99, 100], extra_key=None)
+        divergent_val = torch.tensor([10, 20, 30, 990, 1000], dtype=torch.int64)
+        self.cache.insert(InsertParams(key=divergent_key, value=divergent_val))
+
+        # Walk from root down the shared prefix to find the newly-split
+        # intermediate. It must carry the child's SLRU timestamp, NOT a
+        # fresh time.monotonic() from TreeNode.__init__.
+        node = self.cache.root_node
+        child_key = RadixKey(token_ids=[1, 2, 3], extra_key=None).child_key(
+            self.cache.page_size
+        )
+        self.assertIn(child_key, node.children)
+        split_node = node.children[child_key]
+        self.assertEqual(split_node.last_accessed_timestamp, 123.456)
+
+
+# -----------------------------------------------------------------------------
+# Core SLRU optimization: debounce, cap, and lazy decay.
+#
+# Tests below exercise the *optimized* code path, activated by the env var
+# ``SGLANG_ENABLE_SLRU_OPTIMIZATION``. They all construct a fresh
+# ``SLRUStrategy`` inside the override so the gate snapshot is captured ON.
+# -----------------------------------------------------------------------------
+
+
+class TestSLRUOptimizationGateOff(unittest.TestCase):
+    """With the gate OFF (default), the new SLRU must behave byte-for-byte
+    like the historical two-tier SLRU. Every on-disk behavior that
+    existing users depend on is locked here as a regression guard.
+    """
+
+    def test_on_hit_is_pure_increment_when_gate_off(self):
+        strategy = SLRUStrategy()
+        node = _make_node(hit_count=3, last_accessed_timestamp=100.0)
+        # Even far inside a would-be debounce window, the gate-off path
+        # must ignore debounce entirely and just bump the count.
+        strategy.on_hit(node, now=100.0001)
+        self.assertEqual(node.hit_count, 4)
+
+    def test_get_priority_ignores_now_when_gate_off(self):
+        strategy = SLRUStrategy()
+        node = _make_node(
+            hit_count=5,
+            last_access_time=10.0,
+            last_accessed_timestamp=0.0,
+        )
+        # A huge ``now`` would collapse eff -> 0 if the gate were ON.
+        self.assertEqual(strategy.get_priority(node, now=1e18), (1, 10.0))
+        self.assertEqual(strategy.get_priority(node), (1, 10.0))
+
+
+class TestSLRUDebounce(unittest.TestCase):
+    """Write-side debounce: hits inside ``debounce_sec`` do not count."""
+
+    def test_burst_within_debounce_only_counts_once(self):
+        # 50 concurrent hits in a 10ms span must count as 1 (burst-one-shot).
+        strategy = _make_slru_optimized(debounce_sec=5.0)
+        node = _make_node(hit_count=0, last_accessed_timestamp=0.0)
+        base = 100.0
+        strategy.on_hit(node, now=base)
+        for i in range(1, 50):
+            strategy.on_hit(node, now=base + i * 0.0002)  # 50 hits in 10ms
+        self.assertEqual(node.hit_count, 1)
+        # Timestamp anchors on the FIRST counted hit — so the 50th hit
+        # arriving at base+0.0098 is still inside the 5s window.
+        self.assertEqual(node.last_accessed_timestamp, base)
+
+    def test_first_hit_counts_even_at_creation_timestamp(self):
+        strategy = _make_slru_optimized(debounce_sec=5.0)
+        node = _make_node(hit_count=0, last_accessed_timestamp=100.0)
+        strategy.on_hit(node, now=100.0)
+        self.assertEqual(node.hit_count, 1)
+        self.assertEqual(node.last_accessed_timestamp, 100.0)
+
+    def test_hits_outside_debounce_accumulate(self):
+        strategy = _make_slru_optimized(debounce_sec=1.0)
+        node = _make_node(hit_count=0, last_accessed_timestamp=0.0)
+        # 5 hits well-spaced past the debounce window ⇒ counter ramps
+        # up to the cap (protected_threshold default 2).
+        for i in range(5):
+            strategy.on_hit(node, now=10.0 + i * 2.0)
+        # With default cap of 2 (protected_threshold), hit_count plateaus
+        # at 2 — but the *timestamp* keeps advancing past the cap (Cap
+        # semantics, tested separately below).
+        self.assertEqual(node.hit_count, 2)
+
+    def test_zero_debounce_behaves_like_plain_counter(self):
+        # debounce_sec=0 means "always count" (legacy-equivalent hit
+        # bumping). Useful for tests that want to isolate Cap from
+        # Debounce.
+        strategy = _make_slru_optimized(debounce_sec=0.0)
+        node = _make_node(hit_count=0, last_accessed_timestamp=0.0)
+        for i in range(5):
+            strategy.on_hit(node, now=1.0 + i * 0.001)
+        # Hits 1 and 2 accumulate to hit_count=2 (threshold); subsequent
+        # hits fall into the cap branch and don't bump.
+        self.assertEqual(node.hit_count, 2)
+
+
+class TestSLRUCap(unittest.TestCase):
+    """Write-side cap: ``hit_count`` is bounded at ``protected_threshold``."""
+
+    def test_hit_count_is_capped_at_threshold(self):
+        strategy = _make_slru_optimized(debounce_sec=0.0, protected_threshold=2)
+        node = _make_node(hit_count=0, last_accessed_timestamp=0.0)
+        for i in range(1000):
+            strategy.on_hit(node, now=1.0 + i * 0.001)
+        # 1000 hits ⇒ hit_count saturates at threshold, no overflow.
+        self.assertEqual(node.hit_count, 2)
+
+    def test_cap_still_refreshes_timestamp(self):
+        # A Protected node that keeps receiving hits must keep getting
+        # its ``last_accessed_timestamp`` refreshed; otherwise lazy
+        # decay would kick it out even while it's actively being used.
+        strategy = _make_slru_optimized(debounce_sec=0.0, protected_threshold=2)
+        node = _make_node(hit_count=2, last_accessed_timestamp=0.0)
+        strategy.on_hit(node, now=555.0)
+        self.assertEqual(node.hit_count, 2)  # capped
+        self.assertEqual(node.last_accessed_timestamp, 555.0)  # refreshed
+
+
+class TestSLRULazyDecay(unittest.TestCase):
+    """Read-side lazy decay: ``get_priority`` synthesizes the effective
+    hit count at scan time without mutating the node. Cold Protected
+    nodes silently drop back to Probationary.
+    """
+
+    def test_cold_node_drops_back_to_probationary(self):
+        strategy = _make_slru_optimized(decay_sec=1.0, protected_threshold=2)
+        node = _make_node(
+            hit_count=2,  # capped, in Protected
+            last_access_time=100.0,
+            last_accessed_timestamp=100.0,
+        )
+        # After 10s with decay_sec=1s, halvings=10 >> bit_length(2)=2 ⇒
+        # eff=0, which is Probationary.
+        priority = strategy.get_priority(node, now=110.0)
+        self.assertEqual(priority, (0, 100.0))
+        # Crucially: the node's hit_count is NOT mutated by this read.
+        self.assertEqual(node.hit_count, 2)
+        self.assertEqual(node.last_accessed_timestamp, 100.0)
+
+    def test_recent_protected_node_stays_protected(self):
+        strategy = _make_slru_optimized(decay_sec=60.0, protected_threshold=2)
+        node = _make_node(
+            hit_count=2,
+            last_access_time=100.0,
+            last_accessed_timestamp=100.0,
+        )
+        # 1s < 60s ⇒ 0 halvings ⇒ eff=2, still Protected.
+        priority = strategy.get_priority(node, now=101.0)
+        self.assertEqual(priority, (1, 100.0))
+
+    def test_effective_hit_count_math_is_precise(self):
+        strategy = _make_slru_optimized(decay_sec=1.0, protected_threshold=1)
+        # hit_count=16, age=3s, decay=1s ⇒ halvings=3 ⇒ 16>>3=2
+        node = _make_node(
+            hit_count=16,
+            last_access_time=0.0,
+            last_accessed_timestamp=0.0,
+        )
+        self.assertEqual(strategy._effective_hit_count(node, 3.0), 2)
+        # age=5s ⇒ halvings=5 >= bit_length(16)=5 ⇒ eff=0
+        self.assertEqual(strategy._effective_hit_count(node, 5.0), 0)
+
+    def test_decay_handles_huge_age_without_overflow(self):
+        strategy = _make_slru_optimized(decay_sec=0.001, protected_threshold=2)
+        node = _make_node(
+            hit_count=2,
+            last_access_time=0.0,
+            last_accessed_timestamp=0.0,
+        )
+        # 1e10 / 0.001 = 1e13 halvings — no negative shift, no crash,
+        # just saturates to 0.
+        self.assertEqual(strategy._effective_hit_count(node, 1e10), 0)
+
+    def test_zero_hit_count_fast_path(self):
+        strategy = _make_slru_optimized(decay_sec=60.0, protected_threshold=2)
+        node = _make_node(
+            hit_count=0,
+            last_access_time=0.0,
+            last_accessed_timestamp=0.0,
+        )
+        # Never-hit node always has eff=0; short-circuits before any math.
+        self.assertEqual(strategy._effective_hit_count(node, 999.0), 0)
+        self.assertEqual(strategy.get_priority(node, now=999.0), (0, 0.0))
+
+
+class TestBatchedNowSnapshotSLRU(unittest.TestCase):
+    """Contract: when the caller provides ``now``, SLRU must use it
+    instead of reading the wall clock. A refactor that accidentally
+    re-reads ``time.monotonic()`` inside ``get_priority`` would silently
+    degrade eviction-scan performance from O(1) to O(N) clock reads —
+    this test makes that regression impossible to ship.
+    """
+
+    def test_slru_uses_caller_supplied_now_without_reading_clock(self):
+        strategy = _make_slru_optimized(decay_sec=1.0, protected_threshold=2)
+        node = _make_node(
+            hit_count=2,
+            last_access_time=0.0,
+            last_accessed_timestamp=0.0,
+        )
+
+        import sglang.srt.mem_cache.evict_policy as ep_module
+
+        original_monotonic = ep_module.time.monotonic
+        try:
+            # Any call to time.monotonic() inside on_hit/get_priority
+            # when `now` is supplied MUST be considered a bug.
+            def exploding_clock():
+                raise AssertionError(
+                    "time.monotonic() was called despite explicit now="
+                )
+
+            ep_module.time.monotonic = exploding_clock
+            # These must not raise.
+            strategy.on_hit(node, now=500.0)
+            priority = strategy.get_priority(node, now=500.5)
+            self.assertIsInstance(priority, tuple)
+        finally:
+            ep_module.time.monotonic = original_monotonic
+
+
+# -----------------------------------------------------------------------------
+# Three-way scenarios: LRU vs legacy SLRU vs optimized SLRU.
+#
+# Legacy SLRU is the gate-off path; optimized SLRU is constructed with the
+# environment gate enabled.
+# -----------------------------------------------------------------------------
+
+
+class TestSLRUScenarios(unittest.TestCase):
+    """Locks eviction decisions for LRU, legacy SLRU, and optimized SLRU.
+
+    A. One-shot flood (scan attack) — SLRU family beats LRU.
+    B. Concurrent burst on a one-shot prefix — debounce protects real hot data.
+    C. Stale protected prefix vs newcomer — lazy decay admits the newcomer.
+    """
+
+    def test_scenario_a_one_shot_flood_lru_loses_slru_wins(self):
+        """HOT prefix hit 10× (last at t=10) vs one-shot SHOT at t=11.
+        LRU orders by age and picks HOT first (wrong). Both SLRUs keep
+        HOT in Protected while SHOT sits in Probationary."""
+        hot = _make_node(
+            hit_count=10, last_access_time=10.0, last_accessed_timestamp=10.0
+        )
+        shot = _make_node(
+            hit_count=1, last_access_time=11.0, last_accessed_timestamp=11.0
+        )
+
+        # LRU: older = evicted first → HOT loses (known weakness).
+        lru = LRUStrategy()
+        self.assertLess(lru.get_priority(hot), lru.get_priority(shot))
+
+        # Naive SLRU (gate off): HOT is Protected, SHOT is Probationary,
+        # so SHOT (lower tier) is evicted first.
+        naive = SLRUStrategy()
+        self.assertLess(naive.get_priority(shot), naive.get_priority(hot))
+
+        # Optimized SLRU: same decision — SHOT first, HOT stays.
+        new = _make_slru_optimized()
+        self.assertLess(
+            new.get_priority(shot, now=11.1),
+            new.get_priority(hot, now=11.1),
+        )
+
+    def test_scenario_b_concurrent_burst_fools_legacy_only(self):
+        """VIP hit 10× with 1s spacing (last at t=10) vs a 50-concurrent
+        BURST on a throwaway prefix that lands in a 10ms window at t=11.
+
+        * LRU: BURST is newer than VIP ⇒ VIP evicted first (wrong).
+        * Legacy SLRU: BURST racks up hit_count=50 >> threshold, lands
+          in Protected alongside VIP, and since VIP is older in
+          Protected, VIP is evicted first (wrong — Protected got
+          polluted by a one-shot).
+        * Optimized SLRU: debounce compresses BURST to hit_count=1, so
+          BURST stays in Probationary and is evicted first (right).
+        """
+        # Step 1: construct end states.
+        # VIP has ten 1s-spaced real hits; reaches the cap at threshold=2
+        # and keeps refreshing timestamp.
+        # BURST has 50 hits within 10ms; in legacy SLRU it would be
+        # hit_count=50, while optimized SLRU holds it at 1.
+
+        # --- LRU ---
+        lru_vip = _make_node(hit_count=10, last_access_time=10.0)
+        lru_burst = _make_node(hit_count=50, last_access_time=11.0)
+        lru = LRUStrategy()
+        # Older = evicted first. VIP loses.
+        self.assertLess(lru.get_priority(lru_vip), lru.get_priority(lru_burst))
+
+        # --- Naive SLRU ---
+        naive_vip = _make_node(hit_count=10, last_access_time=10.0)
+        naive_burst = _make_node(hit_count=50, last_access_time=11.0)
+        naive = SLRUStrategy()
+        # Both in Protected (hit_count >= 2); within Protected, older
+        # VIP is evicted first; debounce avoids this protected-tier pollution.
+        self.assertLess(naive.get_priority(naive_vip), naive.get_priority(naive_burst))
+
+        # --- Optimized SLRU ---
+        strategy = _make_slru_optimized(
+            debounce_sec=5.0, decay_sec=3600.0, protected_threshold=2
+        )
+        pr2_vip = _make_node(
+            hit_count=0,
+            last_access_time=0.0,
+            last_accessed_timestamp=0.0,
+        )
+        pr2_burst = _make_node(
+            hit_count=0,
+            last_access_time=0.0,
+            last_accessed_timestamp=0.0,
+        )
+        # VIP: ten 1s-spaced hits, reaches cap.
+        for i in range(10):
+            t = 1.0 + i * 1.0
+            strategy.on_hit(pr2_vip, now=t)
+            pr2_vip.last_access_time = t
+        # BURST: 50 hits within 10ms at t=11.
+        base = 11.0
+        for i in range(50):
+            t = base + i * 0.0002
+            strategy.on_hit(pr2_burst, now=t)
+            pr2_burst.last_access_time = t
+        # VIP at cap (Protected). BURST's debounce held it at 1 hit
+        # (Probationary).
+        self.assertEqual(pr2_vip.hit_count, 2)
+        self.assertEqual(pr2_burst.hit_count, 1)
+        # At eviction (now=11.1), BURST is lower tier → evicted first.
+        now = 11.1
+        self.assertLess(
+            strategy.get_priority(pr2_burst, now=now),
+            strategy.get_priority(pr2_vip, now=now),
+        )
+
+    def test_scenario_c_stale_protected_starves_newcomer_in_legacy_only(
+        self,
+    ):
+        """OLD hit heavily ages ago (hit_count=10, last access t=0);
+        NEW is a newcomer with one hit at t=999. At eviction time
+        (now=1000, decay_sec=60):
+
+        * LRU: OLD is older ⇒ evicted first.
+        * Legacy SLRU: OLD is Protected, NEW is Probationary ⇒ NEW
+          evicted first.
+        * Optimized SLRU: lazy decay reduces OLD's eff to 0, demoting it to
+          Probationary; within Probationary, older OLD goes first
+          and NEW stays.
+        """
+        now = 1000.0
+
+        # --- LRU ---
+        self.assertLess(
+            LRUStrategy().get_priority(_make_node(last_access_time=0.0)),
+            LRUStrategy().get_priority(_make_node(last_access_time=999.0)),
+        )
+
+        # --- Naive SLRU ---
+        naive = SLRUStrategy()
+        naive_old = _make_node(hit_count=10, last_access_time=0.0)
+        naive_new = _make_node(hit_count=1, last_access_time=999.0)
+        # NEW loses because OLD never leaves Protected.
+        self.assertLess(naive.get_priority(naive_new), naive.get_priority(naive_old))
+
+        # --- Optimized SLRU ---
+        strategy = _make_slru_optimized(decay_sec=60.0, protected_threshold=2)
+        pr2_old = _make_node(
+            hit_count=2,  # hit the cap long ago
+            last_access_time=0.0,
+            last_accessed_timestamp=0.0,
+        )
+        pr2_new = _make_node(
+            hit_count=1,
+            last_access_time=999.0,
+            last_accessed_timestamp=999.0,
+        )
+        # At now=1000s with decay=60s, OLD gets halvings=16 >>
+        # bit_length(2)=2 ⇒ eff=0 (Probationary). NEW has hit_count=1 <
+        # threshold=2 ⇒ also Probationary. Within Probationary, older
+        # OLD is evicted first — newcomer stays.
+        self.assertLess(
+            strategy.get_priority(pr2_old, now=now),
+            strategy.get_priority(pr2_new, now=now),
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_radix_cache_slru_accuracy.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_slru_accuracy.py
@@ -8,7 +8,10 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     InsertParams,
     MatchPrefixParams,
 )
-from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.cache_init_params import (
+    CacheInitParams,
+    EvictionConfig,
+)
 from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool, ReqToTokenPool
 from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey
 from sglang.test.ci.ci_register import register_cuda_ci
@@ -52,7 +55,7 @@ class TestSLRUAccuracy(unittest.TestCase):
             req_to_token_pool=self.req_to_token_pool,
             token_to_kv_pool_allocator=self.token_to_kv_pool,
             page_size=1,
-            eviction_policy="slru",
+            eviction_config=EvictionConfig(policy="slru"),
             enable_kv_cache_events=False,
         )
 

--- a/test/registered/unit/mem_cache/test_slru_hit_rate.py
+++ b/test/registered/unit/mem_cache/test_slru_hit_rate.py
@@ -1,0 +1,288 @@
+"""End-to-end SLRU hit-rate tests under burst and decay workloads.
+
+These tests drive a real ``RadixCache`` with deterministic traffic, force
+eviction, and probe which prefixes remain. A fake clock keeps the scenarios
+fast and repeatable.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="stage-a-test-cpu")
+
+import unittest
+
+try:
+    import torch
+
+    from sglang.srt.environ import envs
+    from sglang.srt.mem_cache import evict_policy as _ep_module
+    from sglang.srt.mem_cache import radix_cache as _rc_module
+    from sglang.srt.mem_cache.base_prefix_cache import (
+        EvictParams,
+        InsertParams,
+        MatchPrefixParams,
+    )
+    from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey
+
+    _IMPORT_ERROR = None
+    _AVAILABLE = True
+except Exception as exc:  # pragma: no cover — env-dependent
+    _IMPORT_ERROR = exc
+    _AVAILABLE = False
+
+
+class _MockAllocator:
+    """Stand-in for ``TokenToKVPoolAllocator``. ``evict()`` only uses
+    ``.free(tensor)`` and ``.device`` on the allocator, so that's all
+    we need to satisfy. ``free`` is a no-op since we don't care about
+    the underlying KV cache pool for these hit-rate tests — only
+    whether the *tree node* survives eviction.
+    """
+
+    def __init__(self):
+        self.device = "cpu"
+
+    def free(self, value):
+        # value is a torch.Tensor of token indices. No-op — the RadixCache
+        # already detached it from its tree when calling us.
+        pass
+
+
+class _FakeClock:
+    """Deterministic monotonic clock. Exposes ``.now()`` as a callable
+    that can replace ``time.monotonic`` inside both the radix cache and
+    the evict_policy module.
+    """
+
+    def __init__(self, start: float = 0.0):
+        self._t = start
+
+    def advance(self, seconds: float):
+        self._t += seconds
+
+    def now(self) -> float:
+        return self._t
+
+
+def _patch_clock(clock: "_FakeClock"):
+    """Redirect ``time.monotonic`` in both modules to ``clock.now``.
+
+    We cannot simply monkey-patch the ``time`` module — other imports
+    use it. We patch the ``time`` attribute used inside each module.
+    Returns a tuple (restore_fn).
+    """
+    rc_original = _rc_module.time.monotonic
+    ep_original = _ep_module.time.monotonic
+    _rc_module.time.monotonic = clock.now
+    _ep_module.time.monotonic = clock.now
+
+    def restore():
+        _rc_module.time.monotonic = rc_original
+        _ep_module.time.monotonic = ep_original
+
+    return restore
+
+
+def _make_cache() -> "RadixCache":
+    return RadixCache.create_simulated(mock_allocator=_MockAllocator(), page_size=1)
+
+
+def _insert_prefix(cache, token_ids):
+    """Insert and mark the prefix as an evictable leaf. Unlocks it so
+    the eviction scan considers it."""
+    key = RadixKey(token_ids=list(token_ids), extra_key=None)
+    value = torch.tensor(list(token_ids), dtype=torch.int64)
+    cache.insert(InsertParams(key=key, value=value))
+
+
+def _probe_hit(cache, token_ids) -> bool:
+    """Return True if the probe finds the full prefix in cache."""
+    key = RadixKey(token_ids=list(token_ids), extra_key=None)
+    result = cache.match_prefix(MatchPrefixParams(key=key))
+    return int(result.device_indices.numel()) == len(token_ids)
+
+
+@unittest.skipUnless(
+    _AVAILABLE,
+    f"RadixCache import chain unavailable: {_IMPORT_ERROR}",
+)
+class TestSLRUHitRate(unittest.TestCase):
+    """Compare the gate-off and optimized SLRU paths on identical traffic."""
+
+    def _run_scenario_b(self, optimization_enabled: bool):
+        """Burst traffic should not evict the genuine hot prefix.
+
+        The VIP prefix is reused across seconds. Burst prefixes are reused many
+        times inside a short debounce window. Optimized SLRU should protect VIP
+        while avoiding protected-tier pollution from bursts.
+        """
+        clock = _FakeClock(start=100.0)
+        restore = _patch_clock(clock)
+        try:
+            with envs.SGLANG_ENABLE_SLRU_OPTIMIZATION.override(optimization_enabled):
+                cache = _make_cache()
+                from sglang.srt.mem_cache.evict_policy import SLRUStrategy
+
+                cache.eviction_strategy = SLRUStrategy(
+                    protected_threshold=2,
+                    debounce_sec=0.1,
+                    decay_sec=60.0,
+                )
+
+                # VIP: repeated, well-spaced hits.
+                vip_tokens = list(range(1000, 1016))
+                for _ in range(4):
+                    _insert_prefix(cache, vip_tokens)
+                    clock.advance(1.0)
+
+                # Burst prefixes: many hits inside a 10ms window.
+                burst_tokens_list = []
+                for b in range(10):
+                    btokens = list(range(2000 + b * 20, 2016 + b * 20))
+                    burst_tokens_list.append(btokens)
+                    for _ in range(100):
+                        _insert_prefix(cache, btokens)
+                        clock.advance(0.0001)  # 100 hits in 10ms
+
+                # Pressure prefixes are well-spaced enough to become protected
+                # in both paths, making burst promotion the differentiator.
+                pressure_tokens_list = []
+                for p in range(40):
+                    ptokens = [5000 + p * 50 + i for i in range(16)]
+                    pressure_tokens_list.append(ptokens)
+                    for _ in range(2):
+                        _insert_prefix(cache, ptokens)
+                        clock.advance(0.5)  # > debounce_sec
+
+                # Eviction: free roughly half the evictable tokens.
+                target_evict = max(int(cache.evictable_size_ * 0.5), 16)
+                cache.evict(EvictParams(num_tokens=target_evict))
+
+                vip_hit = _probe_hit(cache, vip_tokens)
+                burst_hits = sum(1 for b in burst_tokens_list if _probe_hit(cache, b))
+                return vip_hit, burst_hits, len(burst_tokens_list)
+        finally:
+            restore()
+
+    def test_scenario_b_burst_preserves_vip_hit_rate(self):
+        """Optimized SLRU keeps VIP when burst traffic creates pressure."""
+        naive_vip, naive_bursts, n_bursts = self._run_scenario_b(
+            optimization_enabled=False
+        )
+        opt_vip, opt_bursts, _ = self._run_scenario_b(optimization_enabled=True)
+
+        # Optimized SLRU keeps the genuine hot prefix.
+        self.assertTrue(
+            opt_vip,
+            "Scenario B: optimized SLRU must retain VIP after burst+pressure "
+            f"(vip_hit={opt_vip}, naive_vip={naive_vip})",
+        )
+        # VIP retention is the measured hit-rate delta for genuine hot data.
+        self.assertGreater(
+            int(opt_vip),
+            int(naive_vip),
+            "Scenario B: optimized SLRU's VIP retention must beat legacy SLRU. "
+            f"naive_vip={naive_vip}, opt_vip={opt_vip}",
+        )
+        # Burst prefixes should not be preserved more aggressively than VIP.
+        self.assertLessEqual(
+            opt_bursts,
+            naive_bursts,
+            "Scenario B: optimized SLRU must not preserve more bursts than "
+            f"legacy SLRU (naive={naive_bursts}, opt={opt_bursts}, total={n_bursts})",
+        )
+
+    def _run_scenario_c(self, optimization_enabled: bool):
+        """Lazy decay should let a fresh prefix replace stale protected data.
+
+        OLD becomes protected, idles for more than two decay periods, and NEW
+        arrives just before eviction pressure. Optimized SLRU should demote OLD
+        at scan time and retain NEW.
+        """
+        clock = _FakeClock(start=0.0)
+        restore = _patch_clock(clock)
+        try:
+            with envs.SGLANG_ENABLE_SLRU_OPTIMIZATION.override(optimization_enabled):
+                cache = _make_cache()
+                from sglang.srt.mem_cache.evict_policy import SLRUStrategy
+
+                cache.eviction_strategy = SLRUStrategy(
+                    protected_threshold=2,
+                    debounce_sec=0.1,
+                    decay_sec=60.0,
+                )
+
+                # OLD becomes protected before going idle.
+                old_tokens = list(range(100, 116))
+                for _ in range(6):
+                    _insert_prefix(cache, old_tokens)
+                    clock.advance(1.0)
+
+                # Long idle — well past 2 × decay_sec.
+                clock.advance(150.0)
+
+                # NEW arrives shortly before eviction pressure.
+                new_tokens = list(range(200, 216))
+                _insert_prefix(cache, new_tokens)
+                clock.advance(0.5)
+
+                # Pressure — 40 disjoint prefixes, 1 hit each.
+                # Probationary.
+                for p in range(40):
+                    ptokens = [5000 + p * 50 + i for i in range(16)]
+                    _insert_prefix(cache, ptokens)
+                    clock.advance(0.05)
+
+                # Evict one prefix: legacy SLRU drops NEW, optimized SLRU drops
+                # the decayed OLD prefix.
+                cache.evict(EvictParams(num_tokens=len(old_tokens)))
+
+                return _probe_hit(cache, old_tokens), _probe_hit(cache, new_tokens)
+        finally:
+            restore()
+
+    def test_scenario_c_decay_admits_new_hotspot(self):
+        """Optimized SLRU admits NEW by decaying stale protected data."""
+        naive_old, naive_new = self._run_scenario_c(optimization_enabled=False)
+        opt_old, opt_new = self._run_scenario_c(optimization_enabled=True)
+
+        # Optimized SLRU retains the newcomer.
+        self.assertTrue(
+            opt_new,
+            f"Scenario C: optimized SLRU must retain NEW hotspot "
+            f"(opt_old={opt_old}, opt_new={opt_new})",
+        )
+        # Lazy decay makes OLD a preferred eviction target.
+        self.assertFalse(
+            opt_old,
+            f"Scenario C: optimized SLRU must evict stale OLD "
+            f"after 150s idle (opt_old={opt_old}, opt_new={opt_new})",
+        )
+        # Legacy SLRU keeps OLD protected and evicts NEW.
+        self.assertTrue(
+            naive_old,
+            f"Scenario C: legacy SLRU is expected to keep OLD, "
+            f"got naive_old={naive_old}",
+        )
+        self.assertFalse(
+            naive_new,
+            f"Scenario C: legacy SLRU is expected to evict NEW, "
+            f"got naive_new={naive_new}",
+        )
+
+    def test_optimization_off_matches_naive(self):
+        """Regression guard: with the gate OFF, the new code path must
+        be behaviorally indistinguishable from main. Running Scenario B
+        twice with gate=OFF must produce identical results."""
+        a = self._run_scenario_b(optimization_enabled=False)
+        b = self._run_scenario_b(optimization_enabled=False)
+        self.assertEqual(
+            a,
+            b,
+            "Gate-off path is expected to be deterministic and "
+            "identical to legacy SLRU",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Improve SLRU radix-cache eviction with debounce and lazy decay

## Motivation

The current SLRU radix-cache eviction policy promotes a prefix once its `hit_count` reaches the Protected threshold. This works well for stable hot prefixes, but it has two failure modes under shared-prefix and high-pressure KV-cache workloads:

1. **Burst distortion**: many concurrent requests can hit the same short-lived prefix within a few milliseconds, inflating `hit_count` and promoting data that may never be reused.
2. **Zombie Protected entries**: once a prefix enters Protected, historical heat never decays, so stale prefixes can stay protected long after the workload has shifted.

This PR does not try to make SLRU universally better than LRU. It makes SLRU less fragile in workloads where SLRU is already the intended policy, especially workloads with reusable shared prefixes.

## Modifications

This PR keeps the existing SLRU policy shape, but changes hit accounting when `SGLANG_ENABLE_SLRU_OPTIMIZATION=1`:

- Add write-side debounce: hits inside `slru_debounce_sec` do not increment `hit_count`.
- Cap protected nodes at `slru_protected_threshold`: Protected nodes refresh their timestamp but do not accumulate unbounded historical heat.
- Add eviction-time lazy decay: SLRU computes an effective hit count during eviction.

```text
effective_hit_count = hit_count >> floor(age / slru_decay_sec)
```

If the effective hit count falls below `slru_protected_threshold`, the node is treated as Probationary for that eviction scan.

The default knobs are:

- `slru_protected_threshold = 2`
- `slru_debounce_sec = 0.1`
- `slru_decay_sec = 60.0`

For GSP-style shared-prefix workloads, a shorter debounce window such as `0.01s` or `0.02s` can be better because true hot prefixes need to enter Protected quickly. For more heterogeneous trace workloads such as Mooncake, `0.1s` is often a better default because many short-interval hits are burst artifacts rather than durable prefix reuse.

## Accuracy Tests

Not applicable. This PR changes radix-cache eviction priority and hit accounting. It does not change model weights, kernels, sampling, logits, or model forward computation.

## Speed Tests and Profiling

### GSP shared-prefix benchmark

Config:

```text
Model: Qwen/Qwen2.5-7B-Instruct
--gsp-num-groups=120
--gsp-prompts-per-group=70
--gsp-system-prompt-len=2048
--request-rate=3
SLRU knobs: threshold=2, debounce=0.02s, decay=60.0s
```

On a saturated GSP shared-prefix workload, optimized SLRU reduced p99 TTFT relative to naive SLRU:

| policy | p99 TTFT |
| --- | ---: |
| lru | 13869.53 ms |
| naive-slru | 19160.66 ms |
| optimized-slru | 15418.49 ms |

Optimized SLRU improved p99 TTFT vs naive SLRU by:

```text
(15418.49 - 19160.66) / 19160.66 = -19.53%
```

This recovers a large part of naive SLRU's tail regression under bursty shared-prefix pressure, although LRU is still the best policy in this particular run.

On the same type of GSP shared-prefix workload, optimized SLRU also improved median TTFT and prefix-cache reuse:

| metric | naive SLRU | optimized SLRU | delta |
| --- | ---: | ---: | ---: |
| median TTFT | 533.88 ms | 485.76 ms | -9.01% |
| prefix-cache hit ratio | 0.2911 | 0.3009 | +0.0098 |
| cached tokens | 5,034,434 | 5,196,267 | +161,833 |
| new prefill tokens | 12,260,897 | 12,073,571 | -187,326 |
| retracts | 44 | 44 | tied |

The equal retract count indicates comparable physical KV pressure. The latency improvement comes from better cache reuse rather than reduced load.

### Mooncake benchmark

In a larger Mooncake run with default SLRU knobs, optimized SLRU improved both median and p99 TTFT relative to naive SLRU:

| metric | naive SLRU | optimized SLRU | delta |
| --- | ---: | ---: | ---: |
| median TTFT | 183321.93 ms | 179673.90 ms | -2.0% |
| p99 TTFT | 358232.13 ms | 351048.60 ms | -2.0% |
| output tok/s | 463.62 | 464.81 | +0.3% |

In a low-pressure Mooncake run, LRU, naive SLRU, and optimized SLRU were within roughly 0.2%, suggesting the optimization does not introduce measurable overhead when the failure mode is absent.

### Limitations

This PR does not claim that SLRU is always better than LRU.

In fast-churn or tight-KV workloads, LRU can still outperform both naive and optimized SLRU. For example, in a BurstGPT-derived tight-KV run, optimized SLRU improved median TTFT relative to naive SLRU, but both SLRU variants were still slower than LRU.

The intended claim is narrower:

- naive SLRU has burst and stale-hot-prefix failure modes
- this PR reduces those failure modes
- the best eviction policy can still depend on workload shape

## Unit Tests

Added unit coverage for:

- legacy SLRU behavior with the optimization gate disabled
- debounce preventing burst prefixes from entering Protected
- hit-count cap behavior
- lazy decay demoting stale Protected nodes
- radix-tree split preserving the timestamp needed by lazy decay

Suggested local validation:

```bash
python3 -m pytest test/registered/unit/mem_cache/test_evict_policy.py -q
python3 -m pytest test/registered/unit/mem_cache/test_slru_hit_rate.py -q
python3 -m pytest test/registered/unit/mem_cache -q
pre-commit run --all-files
```

## Checklist

- [ ] Format code according to the SGLang pre-commit guidance.
- [ ] Add or update unit tests for radix-cache eviction behavior.
- [ ] Update documentation if maintainers want these SLRU knobs documented publicly.
- [ ] Provide speed benchmark results for shared-prefix and trace-style workloads.
- [ ] Follow SGLang code style guidance, especially keeping runtime-path overhead small.

## Review and Merge Notes

This change touches KV-cache code under `python/sglang/srt/mem_cache`, so the relevant reviewers are the KV Cache maintainers listed in `.github/MAINTAINER.md`.

After opening the PR:

1. Wait for the bot to assign a Merge Oncall and request Codeowner review.
2. If CI does not start, ask an authorized maintainer to add the `run-ci` label or run `/tag-and-rerun-ci`.
3. As the PR author, use `/rerun-failed-ci` if a failed check appears flaky after CI has run.
