### PR TITLE
[sgl] fix for kimi2.5 + dp + eagle3

### DIFF
--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -512,13 +512,19 @@ class EagleDraftWorker(BaseDraftWorker):
         """
         # Construct input_ids
         if not batch.forward_mode.is_idle():
-            pt = 0
-            for i, extend_len in enumerate(batch.extend_seq_lens):
-                input_ids = batch.input_ids[pt : pt + extend_len]
-                batch.input_ids[pt : pt + extend_len] = torch.cat(
-                    (input_ids[1:], next_token_ids[i].reshape(1))
-                )
-                pt += extend_len
+            if batch.extend_seq_lens is not None:
+                # Real prefill case.
+                pt = 0
+                for i, extend_len in enumerate(batch.extend_seq_lens):
+                    input_ids = batch.input_ids[pt : pt + extend_len]
+                    batch.input_ids[pt : pt + extend_len] = torch.cat(
+                        (input_ids[1:], next_token_ids[i].reshape(1))
+                    )
+                    pt += extend_len
+            else:
+                # Divert path: this rank is locally DECODE/IDLE but got dragged
+                # into target_prefill by is_extend_in_batch=True.
+                batch.input_ids = next_token_ids.to(batch.input_ids.dtype)
 
         # Construct spec_info
         next_draft_input = EagleDraftInput(
@@ -701,8 +707,32 @@ class EAGLEWorkerV2(BaseSpecWorker):
         ):
             # Target prefill
             model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
+
+            # Divert path: when this rank is locally DECODE but a peer
+            # DP rank is prefilling, we need to fill input_ids and out_cache_loc.
+            if (
+                not model_worker_batch.forward_mode.is_extend()
+                and isinstance(model_worker_batch.spec_info, EagleDraftInput)
+                and model_worker_batch.spec_info.verified_id is not None
+                and model_worker_batch.spec_info.verified_id.shape
+                == model_worker_batch.seq_lens.shape
+            ):
+                model_worker_batch.input_ids = (
+                    model_worker_batch.spec_info.verified_id.to(torch.int64)
+                )
+                model_worker_batch.out_cache_loc = self.req_to_token_pool.req_to_token[
+                    model_worker_batch.req_pool_indices,
+                    model_worker_batch.seq_lens - 1,
+                ].to(torch.int64)
+
             batch_output = self.target_worker.forward_batch_generation(
                 model_worker_batch
+            )
+
+            # Decode diverted into prefill path.
+            diverted_no_local_extend = (
+                not model_worker_batch.forward_mode.is_extend()
+                and getattr(batch_output, "accept_lens", None) is None
             )
 
             # Draft prefill
@@ -718,6 +748,38 @@ class EAGLEWorkerV2(BaseSpecWorker):
                         batch_output.logits_output.mm_input_embeds,
                     )
                 )
+
+                # for Decode diverted into prefill path, need to pad
+                # batch_output.next_token_ids with same num_draft_tokens length,
+                # synthesize accept_lens, and reshape logprob fields.
+                if diverted_no_local_extend:
+                    bs = len(model_worker_batch.seq_lens)
+                    stride = self.speculative_num_draft_tokens
+                    batch_output.accept_lens = torch.ones(
+                        bs, dtype=torch.int32, device="cpu"
+                    )
+                    next_token_ids = batch_output.next_token_ids
+                    if next_token_ids.shape[0] != bs * stride:
+                        padded = torch.zeros(
+                            bs * stride,
+                            dtype=next_token_ids.dtype,
+                            device=next_token_ids.device,
+                        )
+                        padded[::stride] = next_token_ids
+                        batch_output.next_token_ids = padded
+
+                    # process_batch_result_decode expects logprobs
+                    # to be 2D tensor which aligned with spec decode path.
+                    logits = batch_output.logits_output
+                    if (
+                        logits is not None
+                        and logits.next_token_logprobs is not None
+                        and logits.next_token_logprobs.dim() == 1
+                    ):
+                        logits.next_token_logprobs = (
+                            logits.next_token_logprobs.unsqueeze(1)
+                        )
+
                 return batch_output
         else:
             if model_worker_batch.spec_info is None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When some DP ranks are doing prefill while others are in spec_v2 DECODE, the global is_extend_in_batch=True flag forces the DECODE ranks into EAGLEWorkerV2.forward_batch_generation's target-prefill branch. That divert path was unfinished — it crashes on _pad_tensor_to_size, would silently corrupt KV cache, and would produce wrong tokens / shapes for the spec-v2 result schema. This PR finishes the divert path with three targeted fixes, all in eagle_worker_v2.py.

--------------

Fix 1 — Worker entry: align input_ids and out_cache_loc for the cosplay extend (forward_batch_generation)
prepare_mlp_sync_batch synthesizes a cosplay extend (extend_seq_lens=1, extend_prefix_lens=seq_lens-1) for diverted ranks but doesn't touch model_worker_batch.input_ids / out_cache_loc. Both still carry their last-step prefill/decode shapes (sum(extend_lens) or bs * num_draft_tokens), causing two distinct failures:

Shape: _pad_inputs_to_size does pad = num_tokens(=bs) - input_ids.shape[0], blows up at _pad_tensor_to_size with RuntimeError: Trying to create tensor with negative dimension -N: [-N].
Semantics (even if shapes matched): input_ids = stale would make target sample the bonus from embed()-equivalent logits, and out_cache_loc = stale would dump the bonus K/V into a slot that req_to_token[..., seq_lens-1] doesn't point at — silent KV corruption.
Fix: before target_worker.forward_batch_generation, swap to the spec-v2 analogue of the non-spec decode handoff:

input_ids ← spec_info.verified_id (last verify's bonus token; (bs,) int64). The spec-v2 mirror of non-spec decode's self.input_ids = self.output_ids.
out_cache_loc ← req_to_token[req_pool_indices, seq_lens-1] (the slot the bonus K/V should land in; (bs,) int64). Same gather pattern as the verify path's assign_extend_cache_locs_func, just for one position per req.
Guarded so it only runs on the divert path (not is_extend(), EagleDraftInput spec_info, valid verified_id shape).

--------------

Fix 2 — Draft prefill: rotation collapse for divert path (_draft_extend_for_prefill)
The rotation loop iterates batch.extend_seq_lens, but get_model_worker_batch sets extend_seq_lens=None for is_decode_or_idle() ranks at schedule_batch.py:2461. Without a guard, the divert rank crashes with TypeError: 'NoneType' object is not iterable, hanging the DP collective.

A bare is not None guard fixes the crash but leaves the draft seeing yesterday's bonus (verified_id from the worker-entry swap), producing hidden_states one position behind the just-sampled next_token_ids. That misalignment hurts spec acceptance on the first post-divert decode step.

Fix: add an else branch — batch.input_ids = next_token_ids.to(...). Mirrors what prepare_for_extend_to_fill_draft_kvcache line 220 does for happy-path decode (batch.input_ids = predict), so the draft sees the freshly-sampled X and produces aligned hidden states.

--------------

Fix 3 — Result schema: synthesize accept_lens and pad next_token_ids (forward_batch_generation)
_resolve_spec_overlap_token_ids (scheduler_output_processor_mixin.py:352) asserts result.accept_lens.is_cpu and slices next_token_ids[istride : istride + accept_lens[i]] with stride = speculative_num_draft_tokens. The cosplay extend outputs accept_lens=None (no spec verify ran) and next_token_ids of shape (bs,) — both fail that contract.

Fix: after the draft prefill returns, for diverted ranks synthesize:

accept_lens = ones(bs, int32, cpu) — exactly 1 token committed per req this step.
next_token_ids padded from (bs,) to (bs * stride,) via padded[::stride] = next_token_ids — places the bonus at offset i * stride so the resolver's per-req slice picks it up. Done after the draft call because the draft's own indexing assumes the unpadded (bs,) shape.

-------------

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
