### PR TITLE
[Bench] fix bench_hf.py KeyError + reduce print spam + add --limit

### DIFF
--- a/benchmark/mmmu/bench_hf.py
+++ b/benchmark/mmmu/bench_hf.py
@@ -70,6 +70,10 @@ def eval_mmmu(args):
     )
 
     samples = prepare_samples(eval_args)
+    if getattr(args, "limit", None):
+        total = len(samples)
+        samples = samples[: args.limit]
+        print(f"--limit {args.limit}: keeping {len(samples)} of {total} samples")
     out_samples = dict()
 
     answer_dict = {}
@@ -95,7 +99,7 @@ def eval_mmmu(args):
             response = model.chat(
                 tokenizer, pixel_values, contents, generation_config_internvl
             )
-            print(f"response: {response}")
+            sample["original_response"] = response
             process_result(response, sample, answer_dict, out_samples)
             continue
 
@@ -143,7 +147,7 @@ def eval_mmmu(args):
                 generate_audio=False,
                 temperature=0.0,
             )
-        print(f"response: {response}")
+        sample["original_response"] = response
         process_result(response, sample, answer_dict, out_samples)
 
     args.output_path = f"{args.model_path}_answer_hf.json"
@@ -162,6 +166,12 @@ if __name__ == "__main__":
         type=str,
         help="The path of the model weights. This can be a local folder or a Hugging Face repo ID.",
         required=True,
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="If set, only evaluate this many samples (debug / smoke runs).",
     )
     EvalArgs.add_cli_args(parser)
     args = parser.parse_args()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fix the `KeyError: 'original_response'` bug

## Modifications

- Set `sample["original_response"] = response` before calling `process_result`, just as `bench_sglang.py` does.
- Add `--limit N` for debug / smoke runs against a subset of samples.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
