### PR TITLE
[CI] Broaden stage-b-test-1-gpu-large runner pool to H100 + H200

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -820,7 +820,10 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    runs-on: 1-gpu-h100
+    # `1-gpu-h100-h200` is a shared label advertised by both the 1-GPU H100 and
+    # 1-GPU H200 runner pools, so this job can land on either. Multimodal_gen
+    # jobs in pr-test-multimodal-gen.yml continue to pin to `1-gpu-h100`.
+    runs-on: 1-gpu-h100-h200
     timeout-minutes: 240
     strategy:
       fail-fast: false

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -479,7 +479,7 @@ CUDA_SUITE_TO_RUNNER = {
     "stage-a-test-1-gpu-small": "1-gpu-5090",
     "stage-a-test-cpu": "ubuntu-latest",
     "stage-b-test-1-gpu-small": "1-gpu-5090",
-    "stage-b-test-1-gpu-large": "1-gpu-h100",
+    "stage-b-test-1-gpu-large": "1-gpu-h100-h200",
     "stage-b-test-2-gpu-large": "2-gpu-h100",
     "stage-b-test-4-gpu-b200": "4-gpu-b200",
     "stage-c-test-4-gpu-h100": "4-gpu-h100",


### PR DESCRIPTION
## Summary
- Switch `stage-b-test-1-gpu-large` from the `1-gpu-h100` label to a shared `1-gpu-h100-h200` label so the job can land on either the H100 or H200 1-GPU runner pool.
- Multimodal_gen jobs in `pr-test-multimodal-gen.yml` keep `runs-on: 1-gpu-h100` and remain H100-only — they have hardware-specific expectations and should not float to H200.
- Update `scripts/ci/utils/slash_command_handler.py` `CUDA_SUITE_TO_RUNNER` mapping so `/rerun-stage stage-b-test-1-gpu-large`'s runner health check queries the new label.

This follows the same shared-label pattern used in #23505 (`4-gpu-b200-low-disk` advertised by both old and new b200 runners).

## Runner-side prerequisite
Before this lands, the `1-gpu-h100-h200` label must be advertised by **both** the 1-GPU H100 and 1-GPU H200 self-hosted runner pools (in addition to their existing `1-gpu-h100` / `1-gpu-h200` labels). Without that, `stage-b-test-1-gpu-large` will queue indefinitely.

## Test plan
- [ ] Add the `1-gpu-h100-h200` label to all 1-GPU H100 and 1-GPU H200 runners
- [ ] Verify `stage-b-test-1-gpu-large` is picked up by both H100 and H200 runners across a few PR runs
- [ ] Verify multimodal_gen jobs still land only on H100 runners
- [ ] Verify `/rerun-stage stage-b-test-1-gpu-large` health check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)