### PR TITLE
Fix HiSparse EAGLE decode compatibility

### DIFF
--- a/python/sglang/jit_kernel/csrc/hisparse.cuh
+++ b/python/sglang/jit_kernel/csrc/hisparse.cuh
@@ -73,8 +73,9 @@ template <int NUM_TOP_K, int HOT_BUFFER_SIZE>
 struct SmemLayout {
   static constexpr int HASH_SIZE = NUM_TOP_K * 2;
   static constexpr int NUM_BUFFER_CHUNKS = (HOT_BUFFER_SIZE + WARP_SIZE - 1) / WARP_SIZE;
-  // int32_t region: top_k_tokens + chunk_offset + evict_chunk_offset + hash_keys + total_hits + newest_hit
-  static constexpr int TOTAL_INT32 = NUM_TOP_K + (NUM_BUFFER_CHUNKS + 1) + (NUM_BUFFER_CHUNKS + 1) + HASH_SIZE + 2;
+  // int32_t region: top_k_tokens + chunk_offset + evict_chunk_offset + hash_keys
+  // + total_hits + newest_hit + valid_count
+  static constexpr int TOTAL_INT32 = NUM_TOP_K + (NUM_BUFFER_CHUNKS + 1) + (NUM_BUFFER_CHUNKS + 1) + HASH_SIZE + 3;
   // int16_t region: lru_slots_out + hash_vals
   static constexpr int TOTAL_INT16 = HOT_BUFFER_SIZE + HASH_SIZE;
   static constexpr size_t BYTES = TOTAL_INT32 * sizeof(int32_t) + TOTAL_INT16 * sizeof(int16_t);
@@ -138,7 +139,7 @@ __global__ void load_cache_to_device_buffer_kernel(
     const int count = (seq_len < NUM_TOP_K) ? static_cast<int>(seq_len) : NUM_TOP_K;
     for (int i = tid; i < count; i += BLOCK_SIZE) {
       int32_t token_pos = req_top_k_tokens[i];
-      if (token_pos >= 0) {
+      if (token_pos >= 0 && token_pos < seq_len) {
         req_top_k_device_locs[i] = req_device_buffer_locs[token_pos];
       }
     }
@@ -162,6 +163,7 @@ __global__ void load_cache_to_device_buffer_kernel(
   // Scalar counters
   int32_t& s_total_hits = s_hash_keys[HASH_SIZE];
   int32_t& s_newest_hit = s_hash_keys[HASH_SIZE + 1];
+  int32_t& s_valid_count = s_hash_keys[HASH_SIZE + 2];
 
   int16_t* smem_i16 = reinterpret_cast<int16_t*>(smem_i32 + Layout::TOTAL_INT32);
   // Compacted slot ordering: [hits fwd→  ...  ←evictables bwd]
@@ -173,6 +175,7 @@ __global__ void load_cache_to_device_buffer_kernel(
   if (tid == 0) {
     s_total_hits = 0;
     s_newest_hit = 0;
+    s_valid_count = 0;
   }
   for (int i = tid; i < HASH_SIZE; i += BLOCK_SIZE) {
     s_hash_keys[i] = HASH_EMPTY;
@@ -189,13 +192,20 @@ __global__ void load_cache_to_device_buffer_kernel(
   // Insert top-k tokens into shared-memory hash table.
   for (int i = tid; i < NUM_TOP_K; i += BLOCK_SIZE) {
     int32_t token_idx = req_top_k_tokens[i];
-    if (token_idx == newest_token) {
+    if (token_idx < 0 || token_idx >= seq_len) {
+      // Padded or otherwise invalid top-k entries must not become host-cache
+      // misses. A -1 miss would index req_host_cache_locs[-1] and can trigger
+      // illegal memory access under CUDA graph padding.
+      s_top_k_tokens[i] = TOKEN_HIT;
+    } else if (token_idx == newest_token) {
       // If topk includes the latest token, bind its canonical occurrence to newest_slot (at HOT_BUFFER_SIZE) and mark
       // it as a hit. newest_slot is at the first position of the extra page, excluded from LRU tracking.
       s_top_k_tokens[i] = TOKEN_HIT;
       req_top_k_device_locs[i] = req_device_buffer_locs[newest_slot];
-      s_newest_hit = 1;
+      atomicAdd(&s_newest_hit, 1);
+      atomicAdd(&s_valid_count, 1);
     } else {
+      atomicAdd(&s_valid_count, 1);
       int slot = hash_slot(token_idx, HASH_SIZE);
       while (true) {
         int32_t old = atomicCAS(&s_hash_keys[slot], HASH_EMPTY, token_idx);
@@ -336,7 +346,7 @@ __global__ void load_cache_to_device_buffer_kernel(
   }
   __syncthreads();
 
-  total_misses = NUM_TOP_K - s_total_hits - s_newest_hit;
+  total_misses = s_valid_count - s_total_hits - s_newest_hit;
   // Write back LRU order: evictables at front (LRU), hits at back (MRU).
   {
     const int total_evictable = HOT_BUFFER_SIZE - s_total_hits;
@@ -361,6 +371,326 @@ __global__ void load_cache_to_device_buffer_kernel(
 
     const int64_t src_loc = req_host_cache_locs[miss_token];
     const int64_t dst_loc = static_cast<int64_t>(req_device_buffer_locs[evict_slot]);
+
+    const auto src_k = static_cast<const char*>(host_cache_k) + src_loc * item_size_bytes;
+    auto dst_k = static_cast<char*>(device_buffer_k) + dst_loc * item_size_bytes;
+    transfer_item_warp(lane_id, src_k, dst_k, item_size_bytes);
+
+    if constexpr (!IsMLA) {
+      const auto src_v = static_cast<const char*>(host_cache_v) + src_loc * item_size_bytes;
+      auto dst_v = static_cast<char*>(device_buffer_v) + dst_loc * item_size_bytes;
+      transfer_item_warp(lane_id, src_v, dst_v, item_size_bytes);
+    }
+  }
+}
+
+template <int BLOCK_SIZE, int NUM_TOP_K, int HOT_BUFFER_SIZE, bool IsMLA, typename SeqLensT>
+__global__ void prepare_swap_kernel(
+    const int32_t* __restrict__ top_k_tokens,
+    int32_t* __restrict__ device_buffer_tokens,
+    const int64_t* __restrict__ host_cache_locs,
+    const int32_t* __restrict__ device_buffer_locs,
+    int32_t* __restrict__ top_k_device_locs,
+    int32_t* __restrict__ hit_device_locs,
+    int32_t* __restrict__ miss_device_locs,
+    int32_t* __restrict__ hit_count,
+    int64_t* __restrict__ miss_src_locs,
+    int64_t* __restrict__ miss_dst_locs,
+    const int64_t* __restrict__ req_pool_indices,
+    const SeqLensT* __restrict__ seq_lens,
+    int16_t* __restrict__ lru_slots,
+    const int32_t* __restrict__ num_real_reqs,
+    int64_t buffer_stride_0,
+    int64_t host_stride,
+    int64_t lru_slot_stride_0,
+    int64_t top_k_tokens_stride,
+    int64_t top_k_device_locs_stride,
+    int64_t hit_device_locs_stride,
+    int64_t miss_device_locs_stride,
+    int64_t miss_src_locs_stride,
+    int64_t miss_dst_locs_stride,
+    int64_t page_size,
+    int64_t item_size_bytes) {
+  constexpr int NUM_WARPS = BLOCK_SIZE / WARP_SIZE;
+  constexpr int NUM_TOKEN_CHUNKS = (NUM_TOP_K + WARP_SIZE - 1) / WARP_SIZE;
+  constexpr int NUM_BUFFER_CHUNKS = (HOT_BUFFER_SIZE + WARP_SIZE - 1) / WARP_SIZE;
+
+  const int bid = blockIdx.x;
+  if (bid >= num_real_reqs[0]) return;
+
+  const int tid = threadIdx.x;
+  const int warp_id = tid / WARP_SIZE;
+  const int lane_id = tid % WARP_SIZE;
+  const unsigned int lanes_before = ((unsigned int)1 << lane_id) - 1;
+
+  const int64_t rid = req_pool_indices[bid];
+  const int64_t seq_len = seq_lens[bid];
+
+  const int32_t* req_top_k_tokens = top_k_tokens + bid * top_k_tokens_stride;
+  int32_t* req_top_k_device_locs = top_k_device_locs + bid * top_k_device_locs_stride;
+  int32_t* req_hit_device_locs = hit_device_locs + bid * hit_device_locs_stride;
+  int32_t* req_miss_device_locs = miss_device_locs + bid * miss_device_locs_stride;
+  int64_t* req_miss_src_locs = miss_src_locs + bid * miss_src_locs_stride;
+  int64_t* req_miss_dst_locs = miss_dst_locs + bid * miss_dst_locs_stride;
+
+  const int64_t buffer_offset = rid * buffer_stride_0;
+  int32_t* req_device_buffer_tokens = device_buffer_tokens + buffer_offset;
+  const int32_t* req_device_buffer_locs = device_buffer_locs + buffer_offset;
+  const int64_t* req_host_cache_locs = host_cache_locs + rid * host_stride;
+  int16_t* req_lru_slots = lru_slots + rid * lru_slot_stride_0;
+
+  if (tid == 0) {
+    hit_count[bid] = 0;
+  }
+  __syncthreads();
+
+  if (seq_len <= HOT_BUFFER_SIZE) {
+    const int count = (seq_len < NUM_TOP_K) ? static_cast<int>(seq_len) : NUM_TOP_K;
+    for (int i = tid; i < count; i += BLOCK_SIZE) {
+      int32_t token_pos = req_top_k_tokens[i];
+      if (token_pos >= 0 && token_pos < seq_len) {
+        int32_t loc = req_device_buffer_locs[token_pos];
+        req_top_k_device_locs[i] = loc;
+        req_hit_device_locs[i] = loc;
+        atomicAdd(&hit_count[bid], 1);
+      }
+    }
+    return;
+  }
+
+  extern __shared__ char smem_raw[];
+  using Layout = SmemLayout<NUM_TOP_K, HOT_BUFFER_SIZE>;
+  constexpr int HASH_SIZE = Layout::HASH_SIZE;
+
+  int32_t* smem_i32 = reinterpret_cast<int32_t*>(smem_raw);
+  int32_t* s_top_k_tokens = smem_i32;
+  int32_t* s_chunk_offset = s_top_k_tokens + NUM_TOP_K;
+  int32_t* s_evict_chunk_offset = s_chunk_offset + (NUM_BUFFER_CHUNKS + 1);
+  int32_t* s_hash_keys = s_evict_chunk_offset + (NUM_BUFFER_CHUNKS + 1);
+  int32_t& s_total_hits = s_hash_keys[HASH_SIZE];
+  int32_t& s_newest_hit = s_hash_keys[HASH_SIZE + 1];
+  int32_t& s_valid_count = s_hash_keys[HASH_SIZE + 2];
+
+  int16_t* smem_i16 = reinterpret_cast<int16_t*>(smem_i32 + Layout::TOTAL_INT32);
+  int16_t* s_lru_slots_out = smem_i16;
+  int16_t* s_hash_vals = s_lru_slots_out + HOT_BUFFER_SIZE;
+
+  if (tid == 0) {
+    s_total_hits = 0;
+    s_newest_hit = 0;
+    s_valid_count = 0;
+  }
+  for (int i = tid; i < HASH_SIZE; i += BLOCK_SIZE) {
+    s_hash_keys[i] = HASH_EMPTY;
+  }
+  for (int i = tid; i < NUM_BUFFER_CHUNKS + 1; i += BLOCK_SIZE) {
+    s_chunk_offset[i] = 0;
+    s_evict_chunk_offset[i] = 0;
+  }
+  __syncthreads();
+
+  const int newest_slot = HOT_BUFFER_SIZE;
+  const int32_t newest_token = seq_len - 1;
+
+  for (int i = tid; i < NUM_TOP_K; i += BLOCK_SIZE) {
+    int32_t token_idx = req_top_k_tokens[i];
+    if (token_idx < 0 || token_idx >= seq_len) {
+      s_top_k_tokens[i] = TOKEN_HIT;
+    } else if (token_idx == newest_token) {
+      int32_t loc = req_device_buffer_locs[newest_slot];
+      s_top_k_tokens[i] = TOKEN_HIT;
+      req_top_k_device_locs[i] = loc;
+      req_hit_device_locs[i] = loc;
+      atomicAdd(&s_newest_hit, 1);
+      atomicAdd(&s_valid_count, 1);
+    } else {
+      atomicAdd(&s_valid_count, 1);
+      int slot = hash_slot(token_idx, HASH_SIZE);
+      while (true) {
+        int32_t old = atomicCAS(&s_hash_keys[slot], HASH_EMPTY, token_idx);
+        if (old == HASH_EMPTY || old == token_idx) {
+          s_hash_vals[slot] = static_cast<int16_t>(i);
+          break;
+        }
+        slot = (slot + 1) % HASH_SIZE;
+      }
+      s_top_k_tokens[i] = token_idx;
+    }
+  }
+  __syncthreads();
+
+  constexpr int ITERATIONS_PER_WARP_BUFFER = (NUM_BUFFER_CHUNKS + NUM_WARPS - 1) / NUM_WARPS;
+  int total_hit_count = 0;
+  int total_evict_count = 0;
+  for (int iter = 0; iter < ITERATIONS_PER_WARP_BUFFER; iter++) {
+    int chunk_idx = warp_id + iter * NUM_WARPS;
+    bool has_valid_chunk = chunk_idx < NUM_BUFFER_CHUNKS;
+    const int slot_idx = chunk_idx * WARP_SIZE + lane_id;
+    const bool has_valid_slot = has_valid_chunk && (slot_idx < HOT_BUFFER_SIZE);
+    const int16_t buf_slot = has_valid_slot ? req_lru_slots[slot_idx] : -1;
+    int32_t my_buffer_token = (buf_slot >= 0) ? req_device_buffer_tokens[buf_slot] : -1;
+    int my_found_top_k_idx = -1;
+    if (my_buffer_token >= 0) {
+      int h = hash_slot(my_buffer_token, HASH_SIZE);
+      while (true) {
+        int32_t k = s_hash_keys[h];
+        if (k == my_buffer_token) {
+          my_found_top_k_idx = static_cast<int32_t>(s_hash_vals[h]);
+          break;
+        }
+        if (k == HASH_EMPTY) break;
+        h = (h + 1) % HASH_SIZE;
+      }
+    }
+    bool is_hit = my_found_top_k_idx >= 0;
+    bool is_evictable = has_valid_slot && !is_hit;
+
+    if (is_hit) {
+      int32_t loc = req_device_buffer_locs[buf_slot];
+      s_top_k_tokens[my_found_top_k_idx] = TOKEN_HIT;
+      req_top_k_device_locs[my_found_top_k_idx] = loc;
+      req_hit_device_locs[my_found_top_k_idx] = loc;
+    }
+
+    int local_hit_offset = 0;
+    int local_evict_offset = 0;
+    if (has_valid_chunk) {
+      const unsigned int hit_mask = __ballot_sync(0xFFFFFFFF, is_hit);
+      const unsigned int evict_mask = __ballot_sync(0xFFFFFFFF, is_evictable);
+      local_hit_offset = __popc(hit_mask & lanes_before);
+      local_evict_offset = __popc(evict_mask & lanes_before);
+      if (lane_id == 0) {
+        s_chunk_offset[chunk_idx + 1] = __popc(hit_mask);
+        s_evict_chunk_offset[chunk_idx + 1] = __popc(evict_mask);
+      }
+    }
+    __syncthreads();
+
+    if (warp_id == 0) {
+      total_hit_count =
+          warp_inclusive_scan(s_chunk_offset, lane_id, chunk_idx + 1, NUM_BUFFER_CHUNKS + 1, total_hit_count);
+      total_evict_count =
+          warp_inclusive_scan(s_evict_chunk_offset, lane_id, chunk_idx + 1, NUM_BUFFER_CHUNKS + 1, total_evict_count);
+      if (tid == 0) {
+        s_total_hits = total_hit_count;
+      }
+    }
+    __syncthreads();
+
+    if (is_hit) {
+      int hit_offset = s_chunk_offset[chunk_idx] + local_hit_offset;
+      s_lru_slots_out[hit_offset] = buf_slot;
+    }
+    if (is_evictable) {
+      int evict_offset = s_evict_chunk_offset[chunk_idx] + local_evict_offset;
+      s_lru_slots_out[HOT_BUFFER_SIZE - 1 - evict_offset] = buf_slot;
+    }
+  }
+  __syncthreads();
+
+  {
+    const int total_evictable = HOT_BUFFER_SIZE - s_total_hits;
+    for (int i = tid; i < HOT_BUFFER_SIZE; i += BLOCK_SIZE) {
+      if (i < total_evictable) {
+        req_lru_slots[i] = s_lru_slots_out[HOT_BUFFER_SIZE - 1 - i];
+      } else {
+        req_lru_slots[i] = s_lru_slots_out[i - total_evictable];
+      }
+    }
+  }
+
+  for (int i = tid; i < NUM_TOKEN_CHUNKS + 1; i += BLOCK_SIZE) {
+    s_chunk_offset[i] = 0;
+  }
+  __syncthreads();
+
+  int total_misses = 0;
+  constexpr int ITERATIONS_PER_WARP_TOKEN = (NUM_TOKEN_CHUNKS + NUM_WARPS - 1) / NUM_WARPS;
+  for (int iter = 0; iter < ITERATIONS_PER_WARP_TOKEN; iter++) {
+    int chunk_idx = warp_id + iter * NUM_WARPS;
+    bool has_valid_chunk = chunk_idx < NUM_TOKEN_CHUNKS;
+    const int chunk_token_start = chunk_idx * WARP_SIZE;
+    const int my_token_idx = chunk_token_start + lane_id;
+    const bool has_valid_token = has_valid_chunk && (my_token_idx < NUM_TOP_K);
+
+    int32_t my_token = 0;
+    bool is_miss = false;
+    int local_miss_offset = 0;
+    if (has_valid_token) {
+      is_miss = s_top_k_tokens[my_token_idx] != TOKEN_HIT;
+      if (is_miss) {
+        my_token = s_top_k_tokens[my_token_idx];
+      }
+    }
+
+    if (has_valid_chunk) {
+      const unsigned int miss_mask = __ballot_sync(0xFFFFFFFF, is_miss);
+      local_miss_offset = __popc(miss_mask & lanes_before);
+      if (lane_id == 0) {
+        s_chunk_offset[chunk_idx + 1] = __popc(miss_mask);
+      }
+    }
+    __syncthreads();
+
+    if (warp_id == 0) {
+      total_misses = warp_inclusive_scan(s_chunk_offset, lane_id, chunk_idx + 1, NUM_TOKEN_CHUNKS + 1, total_misses);
+    }
+    __syncthreads();
+
+    if (is_miss) {
+      int miss_offset = s_chunk_offset[chunk_idx] + local_miss_offset;
+      int16_t evict_slot = s_lru_slots_out[HOT_BUFFER_SIZE - 1 - miss_offset];
+      s_top_k_tokens[miss_offset] = my_token;
+      int64_t src_loc = req_host_cache_locs[my_token];
+      int64_t dst_loc = static_cast<int64_t>(req_device_buffer_locs[evict_slot]);
+      if (src_loc >= 0 && dst_loc >= 0) {
+        req_top_k_device_locs[my_token_idx] = static_cast<int32_t>(dst_loc);
+        req_miss_device_locs[my_token_idx] = static_cast<int32_t>(dst_loc);
+        req_miss_src_locs[my_token_idx] = src_loc;
+        req_miss_dst_locs[my_token_idx] = dst_loc;
+        req_device_buffer_tokens[evict_slot] = my_token;
+      }
+    }
+  }
+  __syncthreads();
+
+  if (tid == 0) {
+    hit_count[bid] = s_total_hits + s_newest_hit;
+  }
+}
+
+template <int BLOCK_SIZE, bool IsMLA>
+__global__ void execute_h2d_copy_kernel(
+    const int64_t* __restrict__ miss_src_locs,
+    const int64_t* __restrict__ miss_dst_locs,
+    const int32_t* __restrict__ hit_count,
+    const void* __restrict__ host_cache_k,
+    const void* __restrict__ host_cache_v,
+    void* __restrict__ device_buffer_k,
+    void* __restrict__ device_buffer_v,
+    const int32_t* __restrict__ num_real_reqs,
+    int64_t miss_src_locs_stride,
+    int64_t miss_dst_locs_stride,
+    int32_t num_top_k,
+    int64_t item_size_bytes) {
+  constexpr int NUM_WARPS = BLOCK_SIZE / WARP_SIZE;
+
+  const int bid = blockIdx.x;
+  if (bid >= num_real_reqs[0]) return;
+
+  const int tid = threadIdx.x;
+  const int warp_id = tid / WARP_SIZE;
+  const int lane_id = tid % WARP_SIZE;
+
+  const int64_t* req_miss_src_locs = miss_src_locs + bid * miss_src_locs_stride;
+  const int64_t* req_miss_dst_locs = miss_dst_locs + bid * miss_dst_locs_stride;
+
+  for (int miss_idx = warp_id; miss_idx < num_top_k; miss_idx += NUM_WARPS) {
+    const int64_t src_loc = req_miss_src_locs[miss_idx];
+    const int64_t dst_loc = req_miss_dst_locs[miss_idx];
+    if (src_loc < 0 || dst_loc < 0) {
+      continue;
+    }
 
     const auto src_k = static_cast<const char*>(host_cache_k) + src_loc * item_size_bytes;
     auto dst_k = static_cast<char*>(device_buffer_k) + dst_loc * item_size_bytes;
@@ -442,6 +772,119 @@ void load_cache_to_device_buffer(
         load_cache_to_device_buffer_kernel<BLOCK_SIZE, NUM_TOP_K, HOT_BUFFER_SIZE, IsMLA, int32_t>,
         static_cast<const int32_t*>(seq_lens.data_ptr()));
   }
+}
+
+template <int BLOCK_SIZE, int NUM_TOP_K, int HOT_BUFFER_SIZE, bool IsMLA>
+void prepare_swap(
+    tvm::ffi::TensorView top_k_tokens,
+    tvm::ffi::TensorView device_buffer_tokens,
+    tvm::ffi::TensorView host_cache_locs,
+    tvm::ffi::TensorView device_buffer_locs,
+    tvm::ffi::TensorView top_k_device_locs,
+    tvm::ffi::TensorView hit_device_locs,
+    tvm::ffi::TensorView miss_device_locs,
+    tvm::ffi::TensorView hit_count,
+    tvm::ffi::TensorView miss_src_locs,
+    tvm::ffi::TensorView miss_dst_locs,
+    tvm::ffi::TensorView req_pool_indices,
+    tvm::ffi::TensorView seq_lens,
+    tvm::ffi::TensorView lru_slots,
+    tvm::ffi::TensorView num_real_reqs,
+    int64_t page_size,
+    int64_t item_size_bytes) {
+  using namespace host;
+
+  const int64_t bs = top_k_tokens.shape()[0];
+  const int64_t host_stride = host_cache_locs.shape()[1];
+  const int64_t buffer_stride_0 = device_buffer_tokens.strides()[0];
+  const int64_t lru_slot_stride_0 = lru_slots.strides()[0];
+  const int64_t top_k_tokens_stride = top_k_tokens.strides()[0];
+  const int64_t top_k_device_locs_stride = top_k_device_locs.strides()[0];
+  const int64_t hit_device_locs_stride = hit_device_locs.strides()[0];
+  const int64_t miss_device_locs_stride = miss_device_locs.strides()[0];
+  const int64_t miss_src_locs_stride = miss_src_locs.strides()[0];
+  const int64_t miss_dst_locs_stride = miss_dst_locs.strides()[0];
+  const auto device = LaunchKernel::resolve_device(top_k_tokens.device());
+
+  auto launch = [&](auto kernel_fn, const auto* seq_lens_ptr) {
+    constexpr size_t smem_bytes = SmemLayout<NUM_TOP_K, HOT_BUFFER_SIZE>::BYTES;
+    if constexpr (smem_bytes > 48u * 1024u) {
+      cudaFuncSetAttribute(kernel_fn, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_bytes);
+    }
+    LaunchKernel(bs, BLOCK_SIZE, device, smem_bytes)(
+        kernel_fn,
+        static_cast<const int32_t*>(top_k_tokens.data_ptr()),
+        static_cast<int32_t*>(device_buffer_tokens.data_ptr()),
+        static_cast<const int64_t*>(host_cache_locs.data_ptr()),
+        static_cast<const int32_t*>(device_buffer_locs.data_ptr()),
+        static_cast<int32_t*>(top_k_device_locs.data_ptr()),
+        static_cast<int32_t*>(hit_device_locs.data_ptr()),
+        static_cast<int32_t*>(miss_device_locs.data_ptr()),
+        static_cast<int32_t*>(hit_count.data_ptr()),
+        static_cast<int64_t*>(miss_src_locs.data_ptr()),
+        static_cast<int64_t*>(miss_dst_locs.data_ptr()),
+        static_cast<const int64_t*>(req_pool_indices.data_ptr()),
+        seq_lens_ptr,
+        static_cast<int16_t*>(lru_slots.data_ptr()),
+        static_cast<const int32_t*>(num_real_reqs.data_ptr()),
+        buffer_stride_0,
+        host_stride,
+        lru_slot_stride_0,
+        top_k_tokens_stride,
+        top_k_device_locs_stride,
+        hit_device_locs_stride,
+        miss_device_locs_stride,
+        miss_src_locs_stride,
+        miss_dst_locs_stride,
+        page_size,
+        item_size_bytes);
+  };
+
+  const auto dtype = seq_lens.dtype();
+  if (dtype.code == kDLInt && dtype.bits == 64) {
+    launch(
+        prepare_swap_kernel<BLOCK_SIZE, NUM_TOP_K, HOT_BUFFER_SIZE, IsMLA, int64_t>,
+        static_cast<const int64_t*>(seq_lens.data_ptr()));
+  } else {
+    launch(
+        prepare_swap_kernel<BLOCK_SIZE, NUM_TOP_K, HOT_BUFFER_SIZE, IsMLA, int32_t>,
+        static_cast<const int32_t*>(seq_lens.data_ptr()));
+  }
+}
+
+template <int BLOCK_SIZE, bool IsMLA>
+void execute_h2d_copy(
+    tvm::ffi::TensorView miss_src_locs,
+    tvm::ffi::TensorView miss_dst_locs,
+    tvm::ffi::TensorView hit_count,
+    tvm::ffi::TensorView host_cache_k,
+    tvm::ffi::TensorView host_cache_v,
+    tvm::ffi::TensorView device_buffer_k,
+    tvm::ffi::TensorView device_buffer_v,
+    tvm::ffi::TensorView num_real_reqs,
+    int64_t num_top_k,
+    int64_t item_size_bytes) {
+  using namespace host;
+
+  const int64_t bs = miss_src_locs.shape()[0];
+  const int64_t miss_src_locs_stride = miss_src_locs.strides()[0];
+  const int64_t miss_dst_locs_stride = miss_dst_locs.strides()[0];
+  const auto device = LaunchKernel::resolve_device(miss_src_locs.device());
+
+  LaunchKernel(bs, BLOCK_SIZE, device)(
+      execute_h2d_copy_kernel<BLOCK_SIZE, IsMLA>,
+      static_cast<const int64_t*>(miss_src_locs.data_ptr()),
+      static_cast<const int64_t*>(miss_dst_locs.data_ptr()),
+      static_cast<const int32_t*>(hit_count.data_ptr()),
+      host_cache_k.data_ptr(),
+      (IsMLA || host_cache_v.ndim() == 0) ? (const void*)nullptr : host_cache_v.data_ptr(),
+      device_buffer_k.data_ptr(),
+      (IsMLA || device_buffer_v.ndim() == 0) ? (void*)nullptr : device_buffer_v.data_ptr(),
+      static_cast<const int32_t*>(num_real_reqs.data_ptr()),
+      miss_src_locs_stride,
+      miss_dst_locs_stride,
+      static_cast<int32_t>(num_top_k),
+      item_size_bytes);
 }
 
 }  // namespace

--- a/python/sglang/jit_kernel/csrc/hisparse_utils.cuh
+++ b/python/sglang/jit_kernel/csrc/hisparse_utils.cuh
@@ -1,0 +1,168 @@
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+#include <sgl_kernel/utils.cuh>
+#include <dlpack/dlpack.h>
+#include <tvm/ffi/container/tensor.h>
+#include <cuda_runtime.h>
+#include <stdint.h>
+
+namespace {
+
+// Variable-length gather from a 2D buffer into a flat output.
+// One block per request. Each request gathers counts[bid] contiguous elements
+// starting at column start_col from the row indexed by req_indices[bid].
+template <int BLOCK_SIZE>
+__global__ void gather_variable_length_kernel(
+    const int64_t* __restrict__ buffer,        // (max_reqs, padded_buf_size)
+    const int64_t* __restrict__ req_indices,   // (bs,)
+    const int32_t* __restrict__ counts,        // (bs,) elements per request
+    const int64_t* __restrict__ offsets,        // (bs+1,) exclusive prefix-sum
+    int64_t* __restrict__ output,              // (total_elements,)
+    int64_t buffer_stride,                      // row stride of buffer
+    int64_t start_col,                          // column offset
+    int32_t bs) {
+
+  const int bid = blockIdx.x;
+  if (bid >= bs) return;
+
+  const int n = counts[bid];
+  if (n <= 0) return;
+
+  const int64_t req_idx = req_indices[bid];
+  const int64_t out_start = offsets[bid];
+  const int64_t* src = buffer + req_idx * buffer_stride + start_col;
+
+  for (int i = threadIdx.x; i < n; i += BLOCK_SIZE) {
+    output[out_start + i] = src[i];
+  }
+}
+
+template <int BLOCK_SIZE>
+void gather_variable_length(
+    tvm::ffi::TensorView buffer,
+    tvm::ffi::TensorView req_indices,
+    tvm::ffi::TensorView counts,
+    tvm::ffi::TensorView offsets,
+    tvm::ffi::TensorView output,
+    int64_t start_col) {
+  using namespace host;
+
+  const int64_t bs = req_indices.shape()[0];
+  if (bs == 0) return;
+  const int64_t buffer_stride = buffer.strides()[0];
+  const auto device = LaunchKernel::resolve_device(buffer.device());
+
+  LaunchKernel(bs, BLOCK_SIZE, device)(
+      gather_variable_length_kernel<BLOCK_SIZE>,
+      static_cast<const int64_t*>(buffer.data_ptr()),
+      static_cast<const int64_t*>(req_indices.data_ptr()),
+      static_cast<const int32_t*>(counts.data_ptr()),
+      static_cast<const int64_t*>(offsets.data_ptr()),
+      static_cast<int64_t*>(output.data_ptr()),
+      buffer_stride,
+      start_col,
+      static_cast<int32_t>(bs));
+}
+
+
+// Per-request finalization of accepted speculative tokens.
+// One block per request. Performs three operations in parallel:
+// 1. Scatter host_locs into req_to_host_pool at correct token positions
+// 2. Update device_mapping: last accepted -> newest_phys, others -> 0
+// 3. Output needs_move flag per request
+template <int BLOCK_SIZE>
+__global__ void finalize_accepted_kernel(
+    int64_t* __restrict__ req_to_host_pool,        // (max_reqs, max_seq_len)
+    int64_t* __restrict__ device_mapping,           // (total_pool_size,)
+    const int64_t* __restrict__ req_pool_indices,   // (bs,)
+    const int32_t* __restrict__ seq_lens,           // (bs,)
+    const int64_t* __restrict__ host_locs,          // (total_accepted,)
+    const int64_t* __restrict__ accepted_locs,      // (total_accepted,) logical cache locs
+    const int64_t* __restrict__ device_locs,        // (total_accepted,) physical device locs
+    const int64_t* __restrict__ newest_phys,        // (bs,) newest slot per request
+    const int64_t* __restrict__ cumsum,             // (bs+1,) exclusive prefix-sum of counts
+    int32_t* __restrict__ needs_move,               // (bs,) output
+    int64_t* __restrict__ last_accepted_out,        // (bs,) output: last accepted device loc
+    int64_t* __restrict__ newest_slot_out,          // (bs,) output: newest slot device loc
+    int64_t host_pool_stride,
+    int32_t bs) {
+
+  const int bid = blockIdx.x;
+  if (bid >= bs) return;
+
+  const int64_t start = cumsum[bid];
+  const int64_t end = cumsum[bid + 1];
+  const int n = static_cast<int>(end - start);
+
+  if (n == 0) {
+    if (threadIdx.x == 0) {
+      needs_move[bid] = 0;
+    }
+    return;
+  }
+
+  const int64_t req_idx = req_pool_indices[bid];
+  const int32_t seq_len = seq_lens[bid];
+  const int64_t newest = newest_phys[bid];
+
+  // 1. Scatter host_locs into req_to_host_pool[req_idx, seq_len-n .. seq_len-1]
+  int64_t* host_row = req_to_host_pool + req_idx * host_pool_stride;
+  for (int i = threadIdx.x; i < n; i += BLOCK_SIZE) {
+    host_row[seq_len - n + i] = host_locs[start + i];
+  }
+
+  // 2. Update device_mapping: last accepted -> newest slot; rest -> 0 (host-only)
+  for (int i = threadIdx.x; i < n; i += BLOCK_SIZE) {
+    int64_t loc = accepted_locs[start + i];
+    device_mapping[loc] = (i == n - 1) ? newest : 0;
+  }
+
+  // 3. Output needs_move flag and device locs for batched KV move
+  if (threadIdx.x == 0) {
+    int64_t last_dev = device_locs[end - 1];
+    needs_move[bid] = (last_dev != newest) ? 1 : 0;
+    last_accepted_out[bid] = last_dev;
+    newest_slot_out[bid] = newest;
+  }
+}
+
+template <int BLOCK_SIZE>
+void finalize_accepted(
+    tvm::ffi::TensorView req_to_host_pool,
+    tvm::ffi::TensorView device_mapping,
+    tvm::ffi::TensorView req_pool_indices,
+    tvm::ffi::TensorView seq_lens,
+    tvm::ffi::TensorView host_locs,
+    tvm::ffi::TensorView accepted_locs,
+    tvm::ffi::TensorView device_locs,
+    tvm::ffi::TensorView newest_phys,
+    tvm::ffi::TensorView cumsum,
+    tvm::ffi::TensorView needs_move,
+    tvm::ffi::TensorView last_accepted_out,
+    tvm::ffi::TensorView newest_slot_out) {
+  using namespace host;
+
+  const int64_t bs = req_pool_indices.shape()[0];
+  if (bs == 0) return;
+  const int64_t host_pool_stride = req_to_host_pool.strides()[0];
+  const auto device = LaunchKernel::resolve_device(req_pool_indices.device());
+
+  LaunchKernel(bs, BLOCK_SIZE, device)(
+      finalize_accepted_kernel<BLOCK_SIZE>,
+      static_cast<int64_t*>(req_to_host_pool.data_ptr()),
+      static_cast<int64_t*>(device_mapping.data_ptr()),
+      static_cast<const int64_t*>(req_pool_indices.data_ptr()),
+      static_cast<const int32_t*>(seq_lens.data_ptr()),
+      static_cast<const int64_t*>(host_locs.data_ptr()),
+      static_cast<const int64_t*>(accepted_locs.data_ptr()),
+      static_cast<const int64_t*>(device_locs.data_ptr()),
+      static_cast<const int64_t*>(newest_phys.data_ptr()),
+      static_cast<const int64_t*>(cumsum.data_ptr()),
+      static_cast<int32_t*>(needs_move.data_ptr()),
+      static_cast<int64_t*>(last_accepted_out.data_ptr()),
+      static_cast<int64_t*>(newest_slot_out.data_ptr()),
+      host_pool_stride,
+      static_cast<int32_t>(bs));
+}
+
+}  // namespace

--- a/python/sglang/jit_kernel/hisparse.py
+++ b/python/sglang/jit_kernel/hisparse.py
@@ -20,6 +20,7 @@ def _jit_sparse_module(
     is_mla: bool = False,
 ) -> Module:
     template_args = make_cpp_args(block_size, num_top_k, hot_buffer_size, is_mla)
+    h2d_template_args = make_cpp_args(block_size, is_mla)
     cache_args = make_cpp_args(
         item_size_bytes, block_size, num_top_k, hot_buffer_size, is_mla
     )
@@ -29,10 +30,121 @@ def _jit_sparse_module(
         cuda_files=["hisparse.cuh"],
         cuda_wrappers=[
             (
+                "prepare_swap",
+                f"prepare_swap<{template_args}>",
+            ),
+            (
+                "execute_h2d_copy",
+                f"execute_h2d_copy<{h2d_template_args}>",
+            ),
+            (
                 "load_cache_to_device_buffer",
                 f"load_cache_to_device_buffer<{template_args}>",
-            )
+            ),
         ],
+    )
+
+
+@functools.cache
+def _jit_hisparse_utils_module() -> Module:
+    return load_jit(
+        "hisparse_utils",
+        cuda_files=["hisparse_utils.cuh"],
+        cuda_wrappers=[
+            ("gather_variable_length", "gather_variable_length<256>"),
+            ("finalize_accepted", "finalize_accepted<256>"),
+        ],
+    )
+
+
+def prepare_swap_mla(
+    top_k_tokens: torch.Tensor,
+    device_buffer_tokens: torch.Tensor,
+    host_cache_locs: torch.Tensor,
+    device_buffer_locs: torch.Tensor,
+    top_k_device_locs: torch.Tensor,
+    hit_device_locs: torch.Tensor,
+    miss_device_locs: torch.Tensor,
+    hit_count: torch.Tensor,
+    miss_src_locs: torch.Tensor,
+    miss_dst_locs: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    seq_lens: torch.Tensor,
+    lru_slots: torch.Tensor,
+    item_size_bytes: int,
+    num_top_k: int,
+    hot_buffer_size: int,
+    page_size: int = 1,
+    block_size: int = 256,
+    num_real_reqs: torch.Tensor | None = None,
+) -> None:
+    assert (
+        hot_buffer_size >= num_top_k
+    ), f"hot_buffer_size ({hot_buffer_size}) must be >= num_top_k ({num_top_k})"
+
+    module = _jit_sparse_module(
+        item_size_bytes, block_size, num_top_k, hot_buffer_size, is_mla=True
+    )
+
+    if num_real_reqs is None:
+        num_real_reqs = torch.tensor(
+            [top_k_tokens.size(0)], dtype=torch.int32, device=top_k_tokens.device
+        )
+
+    module.prepare_swap(
+        top_k_tokens,
+        device_buffer_tokens,
+        host_cache_locs,
+        device_buffer_locs,
+        top_k_device_locs,
+        hit_device_locs,
+        miss_device_locs,
+        hit_count,
+        miss_src_locs,
+        miss_dst_locs,
+        req_pool_indices,
+        seq_lens,
+        lru_slots,
+        num_real_reqs,
+        page_size,
+        item_size_bytes,
+    )
+
+
+def execute_h2d_copy_mla(
+    miss_src_locs: torch.Tensor,
+    miss_dst_locs: torch.Tensor,
+    hit_count: torch.Tensor,
+    host_cache: torch.Tensor,
+    device_buffer: torch.Tensor,
+    item_size_bytes: int,
+    num_top_k: int,
+    hot_buffer_size: int,
+    block_size: int = 256,
+    num_real_reqs: torch.Tensor | None = None,
+) -> None:
+    module = _jit_sparse_module(
+        item_size_bytes, block_size, num_top_k, hot_buffer_size, is_mla=True
+    )
+
+    empty = torch.empty(0)
+
+    if num_real_reqs is None:
+        num_real_reqs = torch.tensor(
+            [miss_src_locs.size(0)], dtype=torch.int32, device=miss_src_locs.device
+        )
+
+    module.execute_h2d_copy(
+        miss_src_locs,
+        miss_dst_locs,
+        hit_count,
+        host_cache,
+        empty,
+        device_buffer,
+        empty,
+        num_real_reqs,
+        num_top_k,
+        item_size_bytes,
     )
 
 
@@ -85,4 +197,54 @@ def load_cache_to_device_buffer_mla(
         num_real_reqs,
         page_size,
         item_size_bytes,
+    )
+
+
+def gather_variable_length(
+    buffer: torch.Tensor,
+    req_indices: torch.Tensor,
+    counts: torch.Tensor,
+    offsets: torch.Tensor,
+    output: torch.Tensor,
+    start_col: int,
+) -> None:
+    module = _jit_hisparse_utils_module()
+    module.gather_variable_length(
+        buffer,
+        req_indices,
+        counts,
+        offsets,
+        output,
+        start_col,
+    )
+
+
+def finalize_accepted(
+    req_to_host_pool: torch.Tensor,
+    device_mapping: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    seq_lens: torch.Tensor,
+    host_locs: torch.Tensor,
+    accepted_locs: torch.Tensor,
+    device_locs: torch.Tensor,
+    newest_phys: torch.Tensor,
+    cumsum: torch.Tensor,
+    needs_move: torch.Tensor,
+    last_accepted_out: torch.Tensor,
+    newest_slot_out: torch.Tensor,
+) -> None:
+    module = _jit_hisparse_utils_module()
+    module.finalize_accepted(
+        req_to_host_pool,
+        device_mapping,
+        req_pool_indices,
+        seq_lens,
+        host_locs,
+        accepted_locs,
+        device_locs,
+        newest_phys,
+        cumsum,
+        needs_move,
+        last_accepted_out,
+        newest_slot_out,
     )

--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -1558,12 +1558,60 @@ class NativeSparseAttnBackend(
             topk_indices = self._pad_topk_indices(topk_indices, q_nope.shape[0])
 
         if forward_batch.hisparse_coordinator is not None:
-            page_table_1 = forward_batch.hisparse_coordinator.swap_in_selected_pages(
+            coord = forward_batch.hisparse_coordinator
+            (
+                page_table_1,
+                hit_device_locs,
+                miss_device_locs,
+                hit_count,
+                miss_src_locs,
+                miss_dst_locs,
+            ) = coord.swap_in_selected_pages(
                 forward_batch.req_pool_indices,
                 forward_batch.seq_lens,
                 topk_indices,
                 layer.layer_id,
             )
+            if self.nsa_decode_impl == "flashmla_kv":
+                # Dual-attention: async H2D overlaps hit-attention
+                coord.execute_h2d_async(
+                    miss_src_locs, miss_dst_locs, hit_count, layer.layer_id
+                )
+
+                # Speculative decoding: draft tokens live in the extra page,
+                # outside the swap-in kernel's scope. Append their device locs
+                # to the hit list so the sparse attention kernel sees them.
+                # forward_decode is only dispatched for DECODE mode, so these checks
+                # are currently unreachable. They serve as defensive guards in case
+                # future dispatch changes route verify/extend through this path.
+                if (
+                    forward_batch.forward_mode.is_target_verify()
+                    or forward_batch.forward_mode.is_draft_extend(include_v2=True)
+                ) and forward_batch.spec_info is not None:
+                    draft_locs = self._get_draft_device_locs(forward_batch, layer)
+                    if draft_locs is not None:
+                        hit_device_locs = torch.cat(
+                            [hit_device_locs, draft_locs], dim=-1
+                        )
+
+                if q_rope is not None:
+                    q_all = concat_mla_absorb_q_general(q_nope, q_rope)
+                return self._forward_flashmla_sparse_dual(
+                    q_all=q_all,
+                    kv_cache=kv_cache,
+                    hit_device_locs=hit_device_locs,
+                    miss_device_locs=miss_device_locs,
+                    sm_scale=layer.scaling,
+                    v_head_dim=layer.v_head_dim,
+                    hisparse_coordinator=coord,
+                    layer=layer,
+                    metadata=metadata,
+                )
+            else:
+                # Non-dual backends: synchronous H2D before attention
+                coord.execute_h2d_sync(
+                    miss_src_locs, miss_dst_locs, hit_count, layer.layer_id
+                )
         elif envs.SGLANG_NSA_FUSE_TOPK.get():
             page_table_1 = topk_indices
         else:
@@ -1722,6 +1770,148 @@ class NativeSparseAttnBackend(
             o = o[:, :num_heads, :]
 
         return o
+
+    def _get_draft_device_locs(self, forward_batch, layer):
+        """Get device buffer locations for draft tokens in the extra page.
+
+        During speculative decoding (TARGET_VERIFY / DRAFT_EXTEND), draft tokens'
+        KV lives in the extra page.  The swap-in kernel only manages the main
+        buffer [0, device_buffer_size), so draft tokens are invisible to hit/miss
+        classification.
+
+        Returns (num_reqs, num_draft_per_req) int32 tensor matching the per-request
+        convention of hit_device_locs, or None if not applicable.
+        """
+        out_cache_loc = getattr(forward_batch, "out_cache_loc", None)
+        if out_cache_loc is None or out_cache_loc.numel() == 0:
+            return None
+
+        device_locs = forward_batch.token_to_kv_pool._translate_loc_to_hisparse_device(
+            out_cache_loc
+        )
+
+        num_reqs = forward_batch.req_pool_indices.shape[0]
+        total = device_locs.numel()
+        if num_reqs == 0 or total == 0:
+            return None
+
+        # out_cache_loc is flat across the batch.  Reshape to per-request.
+        num_draft_per_req = total // num_reqs
+        if total != num_reqs * num_draft_per_req:
+            # Uneven distribution: scatter into padded 2D tensor using cumsum offsets
+            extend_lens = getattr(forward_batch, "extend_seq_lens_cpu", None)
+            if extend_lens is not None:
+                counts = torch.tensor(
+                    extend_lens, dtype=torch.int32, device=device_locs.device
+                )
+            else:
+                # Fallback: assume uniform truncated to total
+                counts = torch.full(
+                    (num_reqs,),
+                    num_draft_per_req,
+                    dtype=torch.int32,
+                    device=device_locs.device,
+                )
+            max_per_req = int(counts.max().item())
+            padded = torch.full(
+                (num_reqs, max_per_req),
+                -1,
+                dtype=torch.int32,
+                device=device_locs.device,
+            )
+            offsets = torch.zeros(
+                num_reqs + 1, dtype=torch.int64, device=device_locs.device
+            )
+            offsets[1:] = torch.cumsum(counts.to(torch.int64), dim=0)
+            # Vectorized scatter: build flat indices into padded, then scatter
+            col_offsets = torch.arange(max_per_req, device=device_locs.device)
+            # mask[i, j] = (j < counts[i])
+            mask = col_offsets.unsqueeze(0) < counts.unsqueeze(1)
+            # flat_src_idx[i, j] = offsets[i] + j (valid only where mask is True)
+            flat_src_idx = offsets[:num_reqs].unsqueeze(1) + col_offsets.unsqueeze(0)
+            padded[mask] = device_locs[flat_src_idx[mask].long()].to(torch.int32)
+            return padded
+
+        return device_locs.to(torch.int32).reshape(num_reqs, num_draft_per_req)
+
+    def _forward_flashmla_sparse_dual(
+        self,
+        q_all: torch.Tensor,
+        kv_cache: torch.Tensor,
+        hit_device_locs: torch.Tensor,
+        miss_device_locs: torch.Tensor,
+        sm_scale: float,
+        v_head_dim: int,
+        hisparse_coordinator,
+        layer,
+        metadata: "NSAMetadata",
+    ) -> torch.Tensor:
+        """Dual-attention: hit attn overlaps H2D, then miss attn, then combine."""
+        import torch.cuda.nvtx as nvtx
+        from sgl_kernel.flash_mla import flash_mla_with_kvcache
+
+        from sglang.srt.layers.attention.merge_state import merge_state
+
+        with nvtx.range("hisparse::dual_attn"):
+            num_tokens = q_all.shape[0]
+
+            q = q_all.view(num_tokens, 1, layer.tp_q_head_num, layer.head_dim)
+            kv_cache = kv_cache.view(-1, self.real_page_size, 1, self.kv_cache_dim)
+
+            if not self.nsa_kv_cache_store_fp8:
+                kv_cache = quantize_k_cache(kv_cache)
+
+            cache_seqlens = metadata.nsa_cache_seqlens_int32
+            tile_meta = metadata.flashmla_metadata.flashmla_metadata
+            num_splits = metadata.flashmla_metadata.num_splits
+            block_table = torch.empty(
+                (num_tokens, 0), dtype=torch.int32, device=q.device
+            )
+
+            # Hit attention (overlaps with H2D on transfer stream)
+            with nvtx.range("hisparse::hit_attn"):
+                hit_indices = hit_device_locs.unsqueeze(1)  # (num_reqs, 1, topk)
+                o_hit, lse_hit = flash_mla_with_kvcache(
+                    q=q,
+                    k_cache=kv_cache,
+                    cache_seqlens=cache_seqlens,
+                    head_dim_v=v_head_dim,
+                    tile_scheduler_metadata=tile_meta,
+                    num_splits=num_splits,
+                    softmax_scale=sm_scale,
+                    block_table=block_table,
+                    is_fp8_kvcache=True,
+                    indices=hit_indices,
+                )
+
+            hisparse_coordinator.wait_h2d()
+
+            # Miss attention: -1 indices → lse=-inf, merge_state gives zero weight
+            with nvtx.range("hisparse::miss_attn"):
+                miss_indices = miss_device_locs.unsqueeze(1)  # (num_reqs, 1, topk)
+                o_miss, lse_miss = flash_mla_with_kvcache(
+                    q=q,
+                    k_cache=kv_cache,
+                    cache_seqlens=cache_seqlens,
+                    head_dim_v=v_head_dim,
+                    tile_scheduler_metadata=tile_meta,
+                    num_splits=num_splits,
+                    softmax_scale=sm_scale,
+                    block_table=block_table,
+                    is_fp8_kvcache=True,
+                    indices=miss_indices,
+                )
+
+            # flash_mla_with_kvcache returns natural-log lse; merge_state expects the same
+            with nvtx.range("hisparse::merge_state"):
+                o, _ = merge_state(
+                    o_hit.squeeze(1),
+                    lse_hit.squeeze(-1),
+                    o_miss.squeeze(1),
+                    lse_miss.squeeze(-1),
+                )
+        # Restore seq_len_q dim to match _forward_flashmla_kv output shape
+        return o.unsqueeze(1)
 
     def _forward_flashmla_kv(
         self,

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -4,6 +4,7 @@ import logging
 from typing import List, NamedTuple
 
 import torch
+import torch.cuda.nvtx as nvtx
 
 from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.mem_cache.hisparse_memory_pool import (
@@ -15,10 +16,24 @@ from sglang.srt.utils import get_device_module
 
 device_module = get_device_module()
 
-from sglang.jit_kernel.hisparse import load_cache_to_device_buffer_mla
+from sglang.jit_kernel.hisparse import (
+    execute_h2d_copy_mla,
+    finalize_accepted,
+    gather_variable_length,
+    prepare_swap_mla,
+)
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
 
 logger = logging.getLogger(__name__)
+
+
+class SwapResult(NamedTuple):
+    top_k_device_locs: torch.Tensor
+    hit_device_locs: torch.Tensor
+    miss_device_locs: torch.Tensor
+    hit_count: torch.Tensor
+    miss_src_locs: torch.Tensor
+    miss_dst_locs: torch.Tensor
 
 
 class HiSparseAct(NamedTuple):
@@ -125,9 +140,48 @@ class HiSparseCoordinator:
         # Updated before each graph replay so padded blocks early-return.
         self.num_real_reqs = torch.zeros(1, dtype=torch.int32, device=device)
 
+        # --- Dual-attention overlap buffers ---
+        self.transfer_stream = device_module.Stream()
+        self.h2d_start_event = device_module.Event()
+        self.h2d_finish_event = device_module.Event()
+        self.d2h_finish_event = device_module.Event()
+        # Pre-record so waits pass before the corresponding transfer path runs.
+        self.h2d_finish_event.record()
+        self.d2h_finish_event.record()
+
+        self.hit_device_locs_buffer = torch.full(
+            (max_num_reqs, self.top_k), -1, dtype=torch.int32, device=device
+        )
+        self.miss_device_locs_buffer = torch.full(
+            (max_num_reqs, self.top_k), -1, dtype=torch.int32, device=device
+        )
+        self.hit_count_buffer = torch.empty(
+            (max_num_reqs,), dtype=torch.int32, device=device
+        )
+        self.miss_src_locs_buffer = torch.empty(
+            (max_num_reqs, self.top_k), dtype=torch.int64, device=device
+        )
+        self.miss_dst_locs_buffer = torch.empty(
+            (max_num_reqs, self.top_k), dtype=torch.int64, device=device
+        )
+
         # CPU flag: True means "skip backup on the next decode step" because
         # staging already backed up all prefill tokens.  Cleared after one step.
         self._skip_first_backup = [False] * max_num_reqs
+
+        # Buffers for finalize_accepted_tokens kernel
+        self.needs_move_buffer = torch.zeros(
+            max_num_reqs, dtype=torch.int32, device=device
+        )
+        self.last_accepted_device_buffer = torch.empty(
+            max_num_reqs, dtype=torch.int64, device=device
+        )
+        self.newest_slot_device_buffer = torch.empty(
+            max_num_reqs, dtype=torch.int64, device=device
+        )
+        self.cumsum_buffer = torch.empty(
+            max_num_reqs + 1, dtype=torch.int64, device=device
+        )
 
     def set_decode_producer_stream(self, stream) -> None:
         self.decode_producer_stream = stream
@@ -398,7 +452,25 @@ class HiSparseCoordinator:
             :, req_pool_indices, self.device_buffer_size
         ] = reserved_buffer_loc.to(torch.int32)
 
-        # todo, clear the prior mapping as well
+        # Once we reuse the reserved newest-token slot, the previous decode token
+        # must stop pointing at it. Otherwise multiple logical tokens alias the
+        # same physical HiSparse slot and request cleanup can double-free it.
+        long_decode_mask = seq_lens > (self.device_buffer_size + 1)
+        if torch.any(long_decode_mask):
+            previous_token_pos = seq_lens[long_decode_mask].to(torch.int64) - 2
+            previous_req_pool_indices = req_pool_indices[long_decode_mask]
+            previous_cache_locs = self.req_to_token_pool.req_to_token[
+                previous_req_pool_indices, previous_token_pos
+            ]
+            mapping = self.mem_pool_device.full_to_hisparse_device_index_mapping
+            stale_mask = (
+                mapping[previous_cache_locs] == reserved_buffer_loc[long_decode_mask]
+            )
+            if torch.any(stale_mask):
+                self.token_to_kv_pool_allocator.clear_device_mapping(
+                    previous_cache_locs[stale_mask]
+                )
+
         self.mem_pool_device.full_to_hisparse_device_index_mapping[out_cache_loc] = (
             reserved_buffer_loc
         )
@@ -439,6 +511,9 @@ class HiSparseCoordinator:
         #  - long seq:  slot = device_buffer_size  (the reserved slot)
         actual_token_pos = seq_lens[backup_indices_gpu] - 2
         buffer_slot = actual_token_pos.clamp(max=self.device_buffer_size)
+        reuses_reserved_slot = any(
+            int(seq_lens_cpu[i]) > self.device_buffer_size + 1 for i in backup_indices
+        )
 
         backup_req_indices = req_pool_indices[backup_indices_gpu]
         device_locs = self.req_to_device_buffer[backup_req_indices, buffer_slot]
@@ -479,6 +554,14 @@ class HiSparseCoordinator:
             if device_locs.is_cuda:
                 device_locs.record_stream(self.decode_backup_stream)
         self._has_pending_backup = True
+        if reuses_reserved_slot:
+            # Long decode reuses the reserved newest-token slot on the next
+            # forward pass; the producer must not overwrite it before the D2H
+            # backup has consumed the previous token.
+            if self.decode_producer_stream is not None:
+                self._backup_done_event.wait(self.decode_producer_stream)
+            else:
+                self._backup_done_event.wait(schedule_stream)
 
     def wait_for_pending_backup(self) -> None:
         if not self._has_pending_backup:
@@ -620,18 +703,30 @@ class HiSparseCoordinator:
         if self._has_pending_backup:
             self._backup_done_event.wait(device_module.current_stream())
             self._has_pending_backup = False
+        # Speculative verify / dual attention can leave transfer-stream work
+        # running. Do not release host/device slots until those kernels have
+        # consumed their source and destination indices.
+        device_module.current_stream().wait_event(self.d2h_finish_event)
+        device_module.current_stream().wait_event(self.h2d_finish_event)
 
         # release memory — only free actually-allocated buffer indices
         current_cap = int(self.req_device_buffer_size[req.req_pool_idx])
         buffer_indices = self.req_to_device_buffer[req.req_pool_idx, :current_cap]
-        self.token_to_kv_pool_allocator.free_hisparse_indices(buffer_indices)
+        self.token_to_kv_pool_allocator.free_hisparse_indices(
+            buffer_indices, source="request_finished.buffer"
+        )
 
         allocated_locs = self.req_to_token_pool.req_to_token[
             req.req_pool_idx, : req.kv_allocated_len
         ]
-        self.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping[
-            allocated_locs
-        ] = 0
+        # Only clear the mapping when alloc_device_buffer was actually called
+        # (current_cap > 0).  When current_cap == 0 the mapping still holds valid
+        # hisparse indices that will be freed by the subsequent release_kv_cache →
+        # cache_finished_req → free() → free_hisparse() path.
+        if current_cap > 0:
+            self.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping[
+                allocated_locs
+            ] = 0
 
         host_indices = self.req_to_host_pool[req.req_pool_idx, : req.kv_allocated_len]
         host_indices = host_indices[host_indices >= 0]
@@ -652,8 +747,17 @@ class HiSparseCoordinator:
         seq_lens: torch.Tensor,
         top_k_result: torch.Tensor,
         layer_id: int,
-    ) -> torch.Tensor:
-        """Swap selected top-k tokens into device memory and return their indices."""
+    ):
+        """Classify hit/miss, update LRU, assign slots. H2D copy is NOT done here.
+
+        Returns:
+            (top_k_device_locs, hit_device_locs, miss_device_locs,
+             hit_count, miss_src_locs, miss_dst_locs)
+        """
+        # Ensure any pending D2H backup from finalize_accepted_tokens has completed
+        # before reading host cache data.
+        device_module.current_stream().wait_event(self.d2h_finish_event)
+
         # The CUDA kernel expects req_pool_indices as int64 and seq_lens as int32 or int64.
         if req_pool_indices.dtype != torch.int64:
             raise ValueError(
@@ -668,19 +772,32 @@ class HiSparseCoordinator:
                 f"top_k_result dtype {top_k_result.dtype} is not int32 as expected"
             )
 
+        nvtx.range_push(f"hisparse::prepare_swap L{layer_id}")
         num_reqs = req_pool_indices.size(0)
         top_k_indices = self.top_k_device_locs_buffer[:num_reqs]
         top_k_indices.fill_(-1)
-        # todo, adjustable for performance
+        hit_locs = self.hit_device_locs_buffer[:num_reqs]
+        hit_locs.fill_(-1)
+        miss_locs = self.miss_device_locs_buffer[:num_reqs]
+        miss_locs.fill_(-1)
+        hit_count = self.hit_count_buffer[:num_reqs]
+        miss_src = self.miss_src_locs_buffer[:num_reqs]
+        miss_src.fill_(-1)
+        miss_dst = self.miss_dst_locs_buffer[:num_reqs]
+        miss_dst.fill_(-1)
+
         block_size = 1024
-        load_cache_to_device_buffer_mla(
+        prepare_swap_mla(
             top_k_tokens=top_k_result,
             device_buffer_tokens=self.req_device_buffer_tokens[layer_id],
             host_cache_locs=self.req_to_host_pool,
             device_buffer_locs=self.req_device_buffer_token_locs[layer_id],
-            host_cache=self.mem_pool_host.kv_buffer[layer_id],
-            device_buffer=self.mem_pool_device.kv_buffer[layer_id],
             top_k_device_locs=top_k_indices,
+            hit_device_locs=hit_locs,
+            miss_device_locs=miss_locs,
+            hit_count=hit_count,
+            miss_src_locs=miss_src,
+            miss_dst_locs=miss_dst,
             req_pool_indices=req_pool_indices,
             seq_lens=seq_lens,
             lru_slots=self.lru_slots[layer_id],
@@ -691,4 +808,243 @@ class HiSparseCoordinator:
             block_size=block_size,
             num_real_reqs=self.num_real_reqs,
         )
-        return top_k_indices
+        nvtx.range_pop()
+        return SwapResult(
+            top_k_indices, hit_locs, miss_locs, hit_count, miss_src, miss_dst
+        )
+
+    def execute_h2d_async(
+        self,
+        miss_src_locs: torch.Tensor,
+        miss_dst_locs: torch.Tensor,
+        hit_count: torch.Tensor,
+        layer_id: int,
+    ) -> None:
+        """Launch H2D copy on the transfer stream. Non-blocking."""
+        nvtx.range_push(f"hisparse::h2d_async L{layer_id}")
+        if logger.isEnabledFor(logging.DEBUG):
+            hit = int(hit_count.sum().item())
+            miss = int((miss_src_locs >= 0).sum().item())
+            logger.debug(
+                "hisparse H2D async: layer=%d hit=%d miss=%d total=%d",
+                layer_id,
+                hit,
+                miss,
+                miss_src_locs.numel(),
+            )
+        self.h2d_start_event.record()
+        self.transfer_stream.wait_event(self.h2d_start_event)
+
+        with device_module.stream(self.transfer_stream):
+            execute_h2d_copy_mla(
+                miss_src_locs=miss_src_locs,
+                miss_dst_locs=miss_dst_locs,
+                hit_count=hit_count,
+                host_cache=self.mem_pool_host.kv_buffer[layer_id],
+                device_buffer=self.mem_pool_device.kv_buffer[layer_id],
+                item_size_bytes=self.mem_pool_host.token_stride_size,
+                num_top_k=self.top_k,
+                hot_buffer_size=self.device_buffer_size,
+                block_size=1024,
+                num_real_reqs=self.num_real_reqs,
+            )
+        self.h2d_finish_event.record(self.transfer_stream)
+        nvtx.range_pop()
+
+    def execute_h2d_sync(
+        self,
+        miss_src_locs: torch.Tensor,
+        miss_dst_locs: torch.Tensor,
+        hit_count: torch.Tensor,
+        layer_id: int,
+    ) -> None:
+        """Synchronous H2D copy on the current stream. Used by non-dual-attention backends."""
+        nvtx.range_push(f"hisparse::h2d_sync L{layer_id}")
+        execute_h2d_copy_mla(
+            miss_src_locs=miss_src_locs,
+            miss_dst_locs=miss_dst_locs,
+            hit_count=hit_count,
+            host_cache=self.mem_pool_host.kv_buffer[layer_id],
+            device_buffer=self.mem_pool_device.kv_buffer[layer_id],
+            item_size_bytes=self.mem_pool_host.token_stride_size,
+            num_top_k=self.top_k,
+            hot_buffer_size=self.device_buffer_size,
+            block_size=1024,
+            num_real_reqs=self.num_real_reqs,
+        )
+        nvtx.range_pop()
+
+    def wait_h2d(self) -> None:
+        """Block current stream until H2D transfer completes."""
+        nvtx.range_push("hisparse::wait_h2d")
+        device_module.current_stream().wait_event(self.h2d_finish_event)
+        nvtx.range_pop()
+
+    # --- Speculative decoding integration ---
+
+    def get_draft_device_slots(
+        self,
+        req_pool_indices: torch.Tensor,
+        num_tokens_per_req: int,
+    ) -> torch.Tensor:
+        """Return device buffer physical KV locations from the extra page.
+
+        The extra page occupies buffer positions [device_buffer_size .. padded_buffer_size-1].
+        Position device_buffer_size is the newest-decode slot; positions
+        device_buffer_size+1 .. padded_buffer_size-1 are available for draft tokens.
+
+        Returns:
+            (bs * num_tokens_per_req,) int64 tensor of physical KV buffer row indices.
+        """
+        start = self.device_buffer_size + 1
+        end = start + num_tokens_per_req
+        if end > self.padded_buffer_size:
+            raise ValueError(
+                f"Requested {num_tokens_per_req} draft slots but extra page only "
+                f"has {self.padded_buffer_size - self.device_buffer_size - 1} "
+                f"available (padded_buffer_size={self.padded_buffer_size}, "
+                f"device_buffer_size={self.device_buffer_size})"
+            )
+        return self.req_to_device_buffer[req_pool_indices, start:end].reshape(-1)
+
+    def get_draft_device_slots_variable(
+        self,
+        req_pool_indices: torch.Tensor,
+        tokens_per_req: torch.Tensor,
+    ) -> torch.Tensor:
+        """Like get_draft_device_slots, but each request can need a different count."""
+        start = self.device_buffer_size + 1
+        max_tokens = (
+            int(tokens_per_req.max().item()) if tokens_per_req.numel() > 0 else 0
+        )
+        if start + max_tokens > self.padded_buffer_size:
+            raise ValueError(
+                f"Max per-request draft slots ({max_tokens}) exceeds extra page "
+                f"capacity ({self.padded_buffer_size - self.device_buffer_size - 1})"
+            )
+        bs = req_pool_indices.shape[0]
+        if bs == 0:
+            return torch.empty(0, dtype=torch.int64, device=req_pool_indices.device)
+
+        counts = tokens_per_req.to(torch.int32)
+        offsets = self.cumsum_buffer[: bs + 1]
+        offsets[0] = 0
+        offsets[1:] = torch.cumsum(counts, dim=0)
+        total = int(offsets[bs].item())
+        output = torch.empty(total, dtype=torch.int64, device=req_pool_indices.device)
+
+        gather_variable_length(
+            self.req_to_device_buffer,
+            req_pool_indices,
+            counts,
+            offsets,
+            output,
+            start,
+        )
+        return output
+
+    def finalize_accepted_tokens(
+        self,
+        req_pool_indices: torch.Tensor,
+        accepted_cache_locs: torch.Tensor,
+        accept_length: torch.Tensor,
+        seq_lens: torch.Tensor,
+    ) -> None:
+        """Transition accepted draft tokens from extra page into the coordinator lifecycle.
+
+        After speculative verify, accepted tokens' KV lives in the extra page.
+        This method:
+        1. Backs up all accepted tokens' KV from device to host (batched).
+        2. Moves the last accepted token per request to the newest slot.
+        3. Clears device mapping for host-only tokens.
+        4. Sets _skip_first_backup for each request.
+        """
+        if accepted_cache_locs.numel() == 0:
+            return
+
+        self.wait_for_pending_backup()
+
+        bs = len(req_pool_indices)
+        total_accepted = accepted_cache_locs.numel()
+        mapping = self.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping
+
+        # --- Step 1: Batched D2H backup for ALL accepted tokens ---
+        all_device_locs = self.mem_pool_device._translate_loc_to_hisparse_device(
+            accepted_cache_locs
+        )
+        host_locs = self.mem_pool_host.alloc(total_accepted)
+        if host_locs is None:
+            logger.error(
+                "HiSparse: host alloc failed for %d accepted draft tokens",
+                total_accepted,
+            )
+            raise RuntimeError(
+                f"HiSparse host alloc failed for {total_accepted} accepted draft tokens"
+            )
+        host_locs = host_locs.to(device=self.device)
+        device_locs_for_backup = all_device_locs.contiguous()
+
+        self.transfer_stream.wait_event(device_module.current_stream().record_event())
+        with device_module.stream(self.transfer_stream):
+            self.mem_pool_host.backup_from_device_all_layer(
+                self.mem_pool_device,
+                host_locs,
+                device_locs_for_backup,
+                io_backend="kernel",
+            )
+        self.d2h_finish_event.record(self.transfer_stream)
+        if host_locs.is_cuda:
+            host_locs.record_stream(self.transfer_stream)
+        if device_locs_for_backup.is_cuda:
+            device_locs_for_backup.record_stream(self.transfer_stream)
+
+        # Accepted EAGLE draft tokens live in the per-request extra page. The
+        # next draft forward reuses those slots, so the producer stream must not
+        # overwrite them before the asynchronous D2H backup has consumed them.
+        if self.decode_producer_stream is not None:
+            self.decode_producer_stream.wait_event(self.d2h_finish_event)
+        else:
+            device_module.current_stream().wait_event(self.d2h_finish_event)
+
+        # --- Step 2: Per-request bookkeeping via CUDA kernel ---
+        # (host pool scatter, device mapping update, needs_move computation)
+        n_per_req = accept_length + 1  # (bs,) actual counts
+        cumsum = self.cumsum_buffer[: bs + 1]
+        cumsum[0] = 0
+        cumsum[1:] = torch.cumsum(n_per_req, dim=0)
+
+        newest_buf_pos = self.device_buffer_size
+        all_newest_phys = self.req_to_device_buffer[req_pool_indices, newest_buf_pos]
+
+        needs_move = self.needs_move_buffer[:bs]
+        last_accepted_device = self.last_accepted_device_buffer[:bs]
+        newest_slot_device = self.newest_slot_device_buffer[:bs]
+
+        finalize_accepted(
+            self.req_to_host_pool,
+            mapping,
+            req_pool_indices,
+            seq_lens.to(torch.int32),
+            host_locs,
+            accepted_cache_locs,
+            all_device_locs,
+            all_newest_phys,
+            cumsum,
+            needs_move,
+            last_accepted_device,
+            newest_slot_device,
+        )
+
+        # _skip_first_backup: CPU list, must iterate (cheap, bs is small)
+        req_pool_indices_cpu = req_pool_indices.cpu()
+        for i in range(bs):
+            self._skip_first_backup[int(req_pool_indices_cpu[i])] = True
+
+        # --- Step 3: Batched KV move for last-accepted → newest slot ---
+        move_mask = needs_move.bool()
+        if move_mask.any():
+            idx = torch.where(move_mask)[0].to(torch.int64)
+            self.mem_pool_device.transfer_values_on_device(
+                dst_indices=newest_slot_device[idx],
+                src_indices=last_accepted_device[idx],
+            )

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -898,6 +898,7 @@ class Req(ReqDllmMixin):
 
         # For hisparse
         self.hisparse_staging = False
+        self.hisparse_spec_info = None
 
     @property
     def seqlen(self) -> int:
@@ -2244,6 +2245,20 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         assert not ret or self.spec_algorithm.supports_spec_v2()
         return ret
 
+    def get_spec_v2_draft_input(self) -> Optional["EagleDraftInput"]:
+        if not self.is_spec_v2:
+            return None
+        draft_input = self.spec_info
+        if draft_input is None:
+            logger.warning(
+                "Spec v2 batch missing spec_info; skipping overlap-specific sync/prep. "
+                "forward_mode=%s reqs=%d",
+                self.forward_mode,
+                len(self.reqs),
+            )
+            return None
+        return draft_input
+
     def prepare_for_decode(self):
         self.forward_mode = ForwardMode.DECODE
         bs = len(self.reqs)
@@ -2255,9 +2270,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         if hasattr(self, "attn_cp_metadata") and self.attn_cp_metadata is not None:
             self.attn_cp_metadata = None
 
-        if self.is_spec_v2:
+        draft_input = self.get_spec_v2_draft_input()
+        if draft_input is not None:
             # TODO(spec-v2): all spec v2 should go through this path
-            draft_input: EagleDraftInput = self.spec_info
             draft_input.prepare_for_decode(self)
 
         if not self.spec_algorithm.is_none():
@@ -2356,10 +2371,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             )
 
     def maybe_wait_verify_done(self):
-        if self.is_spec_v2:
-            draft_input: EagleDraftInput = self.spec_info
-            if draft_input.verify_done is not None:
-                draft_input.verify_done.synchronize()
+        draft_input = self.get_spec_v2_draft_input()
+        if draft_input is not None and draft_input.verify_done is not None:
+            draft_input.verify_done.synchronize()
 
     def filter_batch(
         self,
@@ -2493,8 +2507,17 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.return_hidden_states |= other.return_hidden_states
         self.is_prefill_only = self.is_prefill_only and other.is_prefill_only
 
-        if self.spec_info:
+        if self.spec_info is None:
+            self.spec_info = other.spec_info
+        elif other.spec_info is not None:
             self.spec_info.merge_batch(other.spec_info)
+        elif self.is_spec_v2:
+            logger.warning(
+                "Spec v2 merge_batch received empty other.spec_info; keeping current "
+                "spec_info. self_reqs=%d other_reqs=%d",
+                len(self.reqs),
+                len(other.reqs),
+            )
 
     def get_model_worker_batch(
         self, seq_lens_cpu_cache: Optional[torch.Tensor] = None

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2382,7 +2382,41 @@ class Scheduler(
         batch.sampling_info = SamplingBatchInfo.from_schedule_batch(
             batch, self.model_config.vocab_size
         )
-        # todo hisparse, maybe other info to contain for the new batch
+
+        if not batch.spec_algorithm.is_none():
+            missing_spec_info_rids = [
+                req.rid
+                for req in reqs
+                if getattr(req, "hisparse_spec_info", None) is None
+            ]
+            if missing_spec_info_rids:
+                raise RuntimeError(
+                    "HiSparse decode batch is missing speculative draft state for requests: "
+                    + ", ".join(missing_spec_info_rids)
+                )
+
+            batch.spec_info = reqs[0].hisparse_spec_info
+            reqs[0].hisparse_spec_info = None
+            for req in reqs[1:]:
+                batch.spec_info.merge_batch(req.hisparse_spec_info)
+                req.hisparse_spec_info = None
+
+            if batch.is_spec_v2:
+                if batch.spec_info.new_seq_lens is None:
+                    raise RuntimeError(
+                        "HiSparse spec-v2 decode batch is missing new_seq_lens for draft state rebuild."
+                    )
+                future_indices = self.future_map.alloc_future_indices(len(reqs))
+                self.future_map.store_to_map_for_new_batch(
+                    future_indices, batch.spec_info
+                )
+                batch.spec_info.future_indices = future_indices
+                batch.spec_info.verify_done = None
+                batch.seq_lens = batch.spec_info.new_seq_lens
+                batch.seq_lens_cpu = batch.seq_lens.cpu()
+                batch.orig_seq_lens = batch.seq_lens.to(dtype=torch.int32)
+                batch.seq_lens_sum = batch.seq_lens_cpu.sum().item()
+
         return batch
 
     def get_next_batch_to_run(self) -> Optional[ScheduleBatch]:

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -125,6 +125,14 @@ class SchedulerOutputProcessorMixin:
                     elem = elem.copy()
                 req.customized_info[k].append(elem)
 
+    def _stash_hisparse_spec_info(
+        self: Scheduler, batch: ScheduleBatch, batch_index: int, req: Req
+    ) -> None:
+        if not self.enable_hisparse or batch.spec_info is None:
+            return
+
+        req.hisparse_spec_info = batch.spec_info.slice_single(batch_index)
+
     def process_batch_result_prefill(
         self: Scheduler,
         batch: ScheduleBatch,
@@ -201,6 +209,7 @@ class SchedulerOutputProcessorMixin:
                     elif not batch.decoding_reqs or req not in batch.decoding_reqs:
                         self.tree_cache.cache_unfinished_req(req)
                         if self.enable_hisparse:
+                            self._stash_hisparse_spec_info(batch, i, req)
                             self.hisparse_coordinator.admit_request_into_staging(req)
 
                     self.maybe_collect_customized_info(i, req, logits_output)
@@ -453,7 +462,10 @@ class SchedulerOutputProcessorMixin:
                 req.finished() or req.is_retracted
             ):
                 # NOTE: This (req.finished() or req.is_retracted) should only happen when overlap scheduling is enabled.
-                # And all the over-allocated tokens will be freed in `release_kv_cache`.
+                # EAGLE V1 can mark a request as finished in the verify phase, before
+                # decode post-processing reaches the normal cleanup block below.
+                if req.finished() and not req.kv_committed_freed:
+                    self._handle_finished_req(req, i, logits_output)
                 continue
 
             if is_spec_v1:

--- a/python/sglang/srt/mem_cache/hisparse_memory_pool.py
+++ b/python/sglang/srt/mem_cache/hisparse_memory_pool.py
@@ -1,5 +1,4 @@
-# mapping on device memory, host memory and memory allocator
-
+import logging
 import weakref
 from typing import Optional
 
@@ -26,6 +25,9 @@ else:
             "HiSparse device KV transfer requires sgl_kernel.kvcacheio (CUDA/ROCm). "
             "It is not available on this backend."
         )
+
+
+logger = logging.getLogger(__name__)
 
 
 class HiSparseNSATokenToKVPool(NSATokenToKVPool):
@@ -208,7 +210,7 @@ class HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         Used in the direct-to-host transfer path where KV data is written
         directly to host memory by the prefill node, skipping GPU staging.
         """
-        return self.logical_attn_allocator.alloc_extend(
+        logical_indices = self.logical_attn_allocator.alloc_extend(
             prefix_lens,
             prefix_lens_cpu,
             seq_lens,
@@ -216,16 +218,20 @@ class HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             last_loc,
             extend_num_tokens,
         )
+        if logical_indices is not None:
+            self.full_to_hisparse_device_index_mapping[logical_indices] = 0
+        return logical_indices
 
     def alloc_device_buffer(self, allocated_indices, need_size: int):
         assert need_size % self.page_size == 0
         # clear original reference and isolate the buffer from outside addressing, allocate new buffer if needed
         hisparse_indices = self.full_to_hisparse_device_index_mapping[allocated_indices]
         self.full_to_hisparse_device_index_mapping[allocated_indices] = 0
-        # Filter valid (non-zero) hisparse indices.
+        # Filter valid hisparse indices. Page 0 is reserved by the paged
+        # allocator, so indices below page_size must never be reused or freed.
         # In the direct-to-host path, mapping is all zeros since no hisparse
         # device indices were pre-allocated.
-        hisparse_indices = hisparse_indices[hisparse_indices > 0]
+        hisparse_indices = hisparse_indices[hisparse_indices >= self.page_size]
         if len(hisparse_indices) >= need_size:
             buffer_indices = hisparse_indices[:need_size]
             self.free_hisparse_indices(hisparse_indices[need_size:])
@@ -253,16 +259,113 @@ class HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
                 extra_indices is not None
             ), "Hisparse allocation failed in alloc_device_buffer"
             buffer_indices = torch.cat([hisparse_indices, extra_indices])
+
+        # CRITICAL: Map buffer indices back to logical indices for the used portion.
+        # This ensures free_hisparse() can find the mapping when release_kv_cache
+        # is called, preventing memory leaks from page alignment mismatches.
+        map_len = min(need_size, len(allocated_indices))
+        if map_len > 0:
+            self.full_to_hisparse_device_index_mapping[allocated_indices[:map_len]] = (
+                buffer_indices[:map_len]
+            )
+
         return buffer_indices
 
-    def free_hisparse_indices(self, buffer_indices: torch.Tensor):
+    def free_hisparse_indices(
+        self, buffer_indices: torch.Tensor, source: str = "unknown"
+    ):
+        # Request teardown can observe stale aliases (for example reserved newest
+        # slot / speculative draft slots) that point multiple logical tokens to
+        # the same physical HiSparse buffer slot. Free each physical slot once.
+        valid_indices = buffer_indices[buffer_indices >= self.page_size]
+        if valid_indices.numel() == 0:
+            return
+        free_page_indices = torch.unique(valid_indices // self.page_size, sorted=False)
+
+        already_free_mask = torch.zeros_like(free_page_indices, dtype=torch.bool)
+        if self.hisparse_attn_allocator.free_pages.numel() > 0:
+            already_free_mask |= torch.isin(
+                free_page_indices, self.hisparse_attn_allocator.free_pages
+            )
+        if self.hisparse_attn_allocator.release_pages.numel() > 0:
+            already_free_mask |= torch.isin(
+                free_page_indices, self.hisparse_attn_allocator.release_pages
+            )
+        if torch.any(already_free_mask):
+            already_free_pages = free_page_indices[already_free_mask]
+            logger.warning(
+                "HiSparse double-free candidate skipped: pages already free before "
+                "release. source=%s pages=%s physical_indices_sample=%s total_physical=%d",
+                source,
+                already_free_pages[:16].tolist(),
+                valid_indices[:32].tolist(),
+                int(valid_indices.numel()),
+            )
+            free_page_indices = free_page_indices[~already_free_mask]
+            if free_page_indices.numel() == 0:
+                return
+
+        # PagedTokenToKVPoolAllocator.free() releases whole pages from any token
+        # index in that page. Pass one representative token per page explicitly so
+        # HiSparse cleanup stays page-granular and idempotent.
+        valid_indices = free_page_indices * self.page_size
+
         # disable free group mechanism for device buffer free
         self.hisparse_attn_allocator.is_not_in_free_group = True
-        self.hisparse_attn_allocator.free(buffer_indices[buffer_indices > 0])
+        self.hisparse_attn_allocator.free(valid_indices)
 
     def get_last_loc_hisparse_device(self, last_locs: torch.Tensor):
         hisparse_last_locs = self._kvcache._translate_loc_to_hisparse_device(last_locs)
         return hisparse_last_locs
+
+    def alloc_extend_with_device_mapping(
+        self,
+        prefix_lens: torch.Tensor,
+        prefix_lens_cpu: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_cpu: torch.Tensor,
+        last_loc: torch.Tensor,
+        extend_num_tokens: int,
+        device_slots: torch.Tensor,
+        backup_state: bool = False,
+    ):
+        """Allocate logical indices and map them to hisparse device slots atomically.
+
+        Combines logical allocation + device mapping into one call to prevent
+        callers from forgetting the mapping step (which causes silent corruption).
+        """
+        # Pre-flight capacity check to avoid launching a Triton kernel
+        # only to discover there aren't enough free pages.
+        avail = self.logical_attn_allocator.available_size()
+        if avail < extend_num_tokens:
+            raise RuntimeError(
+                f"HiSparse logical alloc: need {extend_num_tokens} tokens but only "
+                f"{avail} available"
+            )
+        state = self.backup_state() if backup_state else None
+        out = self.logical_attn_allocator.alloc_extend(
+            prefix_lens,
+            prefix_lens_cpu,
+            seq_lens,
+            seq_lens_cpu,
+            last_loc,
+            extend_num_tokens,
+        )
+        if out is None:
+            raise RuntimeError(
+                f"HiSparse logical alloc failed for {extend_num_tokens} tokens. "
+                f"Logical pool available: {self.logical_attn_allocator.available_size()}"
+            )
+        self.full_to_hisparse_device_index_mapping[out] = device_slots
+        if backup_state:
+            return out, state
+        return out
+
+    def clear_device_mapping(self, logical_indices: torch.Tensor):
+        """Clear hisparse device mapping. Must be called before free() for
+        indices whose device slots were not allocated from hisparse_attn_allocator,
+        otherwise free_hisparse() would corrupt the hisparse allocator's free list."""
+        self.full_to_hisparse_device_index_mapping[logical_indices] = 0
 
     def alloc_extend(
         self,
@@ -300,6 +403,34 @@ class HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         assert logical_indices is not None, "Logical allocation failed in alloc_extend"
 
         hisparse_last_loc = self.get_last_loc_hisparse_device(last_loc)
+        invalid_partial_prefix = (hisparse_last_loc < self.page_size) & (
+            prefix_lens % self.page_size != 0
+        )
+        if torch.any(invalid_partial_prefix):
+            # Direct-to-host requests can have logical prefix pages without a
+            # matching device page. Allocate fresh HiSparse pages for the new
+            # target/draft tokens instead of extending from reserved page 0.
+            zero_prefix_lens = torch.zeros_like(prefix_lens)
+            zero_prefix_lens_cpu = torch.zeros_like(prefix_lens_cpu)
+            extend_lens = seq_lens - prefix_lens
+            extend_lens_cpu = seq_lens_cpu - prefix_lens_cpu
+            hisparse_last_loc = torch.full_like(last_loc, -1)
+            hisparse_indices = self.hisparse_attn_allocator.alloc_extend(
+                zero_prefix_lens,
+                zero_prefix_lens_cpu,
+                extend_lens,
+                extend_lens_cpu,
+                hisparse_last_loc,
+                len(logical_indices),
+            )
+            assert (
+                hisparse_indices is not None
+            ), "Hisparse allocation failed in alloc_extend"
+            self.full_to_hisparse_device_index_mapping[logical_indices] = (
+                hisparse_indices
+            )
+            return logical_indices
+
         hisparse_indices = self.hisparse_attn_allocator.alloc_extend(
             prefix_lens,
             prefix_lens_cpu,
@@ -354,8 +485,20 @@ class HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
 
     def free_hisparse(self, free_indices: torch.Tensor):
         hisparse_indices = self._kvcache._translate_loc_to_hisparse_device(free_indices)
-        hisparse_indices = hisparse_indices[hisparse_indices > 0]
-        self.free_hisparse_indices(hisparse_indices)
+        hisparse_indices = hisparse_indices[hisparse_indices >= self.page_size]
+        if hisparse_indices.numel() > 0:
+            logical_pages = torch.unique(free_indices // self.page_size)
+            physical_pages = torch.unique(hisparse_indices // self.page_size)
+            if logical_pages.numel() != physical_pages.numel():
+                logger.warning(
+                    "HiSparse free logical/physical page fanout mismatch. "
+                    "logical_pages=%d physical_pages=%d logical_indices_sample=%s physical_indices_sample=%s",
+                    int(logical_pages.numel()),
+                    int(physical_pages.numel()),
+                    free_indices[:32].tolist(),
+                    hisparse_indices[:32].tolist(),
+                )
+        self.free_hisparse_indices(hisparse_indices, source="logical_release")
         self.full_to_hisparse_device_index_mapping[free_indices] = 0
 
     def clear(self):
@@ -366,6 +509,34 @@ class HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         self.full_to_hisparse_device_index_mapping[:-1].fill_(0)
         self.is_not_in_free_group = True
         self.free_group = []
+
+    def backup_state(self):
+        return [
+            self.logical_attn_allocator.backup_state(),
+            self.hisparse_attn_allocator.backup_state(),
+        ]
+
+    def restore_state(self, state):
+        assert len(state) == 2
+        logical_state = state[0]
+        restored_free_pages = torch.cat(logical_state)
+        current_free_pages = torch.cat(self.logical_attn_allocator.backup_state())
+        page_lookup = torch.zeros(
+            self.logical_attn_allocator.num_pages + 1,
+            dtype=torch.bool,
+            device=self.device,
+        )
+        page_lookup[current_free_pages] = True
+        restored_pages = restored_free_pages[~page_lookup[restored_free_pages]]
+        if restored_pages.numel() > 0:
+            restored_indices = (
+                restored_pages[:, None] * self.page_size
+                + torch.arange(self.page_size, device=self.device)
+            ).reshape(-1)
+            self.full_to_hisparse_device_index_mapping[restored_indices] = 0
+
+        self.logical_attn_allocator.restore_state(state[0])
+        self.hisparse_attn_allocator.restore_state(state[1])
 
     def free_group_begin(self):
         return

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -666,6 +666,20 @@ class ModelRunnerKVCacheMixin:
                     self.token_to_kv_pool_allocator.full_to_swa_index_mapping
                 )
 
+        if (
+            self.enable_hisparse
+            and isinstance(
+                self.token_to_kv_pool_allocator, HiSparseTokenToKVPoolAllocator
+            )
+            and isinstance(self.token_to_kv_pool, HiSparseNSATokenToKVPool)
+        ):
+            # Draft workers can reuse an allocator while recreating their local
+            # KV pool. Register the mapping unconditionally once both objects
+            # exist so every worker sees the logical->hisparse index table.
+            self.token_to_kv_pool.register_mapping(
+                self.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping
+            )
+
     def _apply_token_constraints(self: ModelRunner, token_capacity: int) -> int:
         """Apply external constraints to token capacity: user cap, PP sync.
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1585,15 +1585,21 @@ class ServerArgs:
         user_set_prefill = self.nsa_prefill_backend is not None
         user_set_decode = self.nsa_decode_backend is not None
 
-        # HiSparse requires flashmla_sparse for both prefill and decode
+        # HiSparse: BF16 KV -> flashmla_sparse (native BF16 sparse).
+        # FP8 KV   -> flashmla_kv (native FP8 + sparse via is_fp8_kvcache=True + indices=...).
+        # flashmla_sparse does not accept FP8, and flashmla_kv does not accept BF16 sparse,
+        # so the KV dtype determines the backend when the user does not override.
         if self.enable_hisparse:
+            hisparse_default_backend = (
+                "flashmla_kv" if kv_cache_dtype == "fp8_e4m3" else "flashmla_sparse"
+            )
             if not user_set_prefill:
-                self.nsa_prefill_backend = "flashmla_sparse"
+                self.nsa_prefill_backend = hisparse_default_backend
             if not user_set_decode:
-                self.nsa_decode_backend = "flashmla_sparse"
+                self.nsa_decode_backend = hisparse_default_backend
             logger.warning(
-                f"HiSparse enabled: using flashmla_sparse NSA backends "
-                f"(prefill={self.nsa_prefill_backend}, decode={self.nsa_decode_backend})."
+                f"HiSparse enabled ({kv_cache_dtype}): using NSA backends "
+                f"prefill={self.nsa_prefill_backend}, decode={self.nsa_decode_backend}."
             )
             return
 
@@ -6794,23 +6800,57 @@ class ServerArgs:
             assert (
                 self.disable_radix_cache
             ), "Hierarchical sparse attention currently requires --disable-radix-cache."
+            if self.kv_cache_dtype not in ("bfloat16", "auto", "fp8_e4m3"):
+                raise ValueError(
+                    f"HiSparse requires bfloat16 or fp8_e4m3 KV cache, "
+                    f"but got --kv-cache-dtype={self.kv_cache_dtype}. "
+                    f"Please use --kv-cache-dtype=bfloat16 or fp8_e4m3."
+                )
+
+            # Backend/dtype pairing: flashmla_sparse only takes BF16 KV;
+            # flashmla_kv only supports FP8 (it always reads KV as FP8 via
+            # is_fp8_kvcache=True, inline-quantizing BF16 would defeat HiSparse).
+            allowed_backends_for_dtype = {
+                "bfloat16": {"flashmla_sparse"},
+                "fp8_e4m3": {"flashmla_kv"},
+            }.get(self.kv_cache_dtype, {"flashmla_sparse", "flashmla_kv"})
             for attr, label in [
                 ("nsa_prefill_backend", "prefill"),
                 ("nsa_decode_backend", "decode"),
             ]:
                 backend = getattr(self, attr)
-                if backend is not None and backend != "flashmla_sparse":
+                if backend is not None and backend not in allowed_backends_for_dtype:
                     raise ValueError(
-                        f"HiSparse requires flashmla_sparse NSA {label} backend, "
-                        f"but got --nsa-{label}-backend={backend}. "
-                        f"Please use --nsa-{label}-backend=flashmla_sparse or omit it."
+                        f"HiSparse with --kv-cache-dtype={self.kv_cache_dtype} requires "
+                        f"--nsa-{label}-backend in {sorted(allowed_backends_for_dtype)}, "
+                        f"but got {backend}."
                     )
+            if self.speculative_algorithm is not None:
+                from sglang.srt.mem_cache.sparsity import parse_hisparse_config
 
-            if self.kv_cache_dtype != "bfloat16":
-                raise ValueError(
-                    f"HiSparse requires bfloat16 KV cache, but got --kv-cache-dtype={self.kv_cache_dtype}. "
-                    f"Please use --kv-cache-dtype=bfloat16."
+                hisparse_cfg = parse_hisparse_config(self)
+                # HiSparse can inherit page size from the global KV layout when the
+                # per-feature JSON does not set one explicitly.
+                hisparse_page_size = (
+                    getattr(hisparse_cfg, "page_size", None) or self.page_size or 1
                 )
+                max_draft = self.speculative_num_draft_tokens
+                if max_draft > 0 and max_draft >= hisparse_page_size:
+                    raise ValueError(
+                        f"hiSparse extra page capacity ({hisparse_page_size - 1} slots) "
+                        f"is insufficient for speculative_num_draft_tokens={max_draft}. "
+                        f"Reduce draft tokens or increase hiSparse page_size."
+                    )
+                if (
+                    self.speculative_eagle_topk is not None
+                    and self.speculative_eagle_topk > 1
+                    and self.page_size > 1
+                ):
+                    raise ValueError(
+                        "HiSparse + EAGLE topk > 1 + page_size > 1 is not yet supported: "
+                        "move_kv_cache needs hisparse-aware loc translation. "
+                        "Use speculative_eagle_topk=1 or page_size=1."
+                    )
 
         assert (
             self.schedule_conservativeness >= 0

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -129,15 +129,31 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 batch.req_pool_indices,
                 prefix_lens,
             )
-            batch.out_cache_loc = alloc_paged_token_slots_extend(
-                batch.tree_cache,
-                prefix_lens,
-                prefix_lens_cpu,
-                end_offset,
-                end_offset_cpu,
-                last_loc,
-                len(batch.input_ids),
-            )
+            if batch.hisparse_coordinator is not None:
+                allocator = batch.tree_cache.token_to_kv_pool_allocator
+                device_slots = batch.hisparse_coordinator.get_draft_device_slots(
+                    batch.req_pool_indices,
+                    self.draft_token_num,
+                )
+                batch.out_cache_loc = allocator.alloc_extend_with_device_mapping(
+                    prefix_lens,
+                    prefix_lens_cpu,
+                    end_offset,
+                    end_offset_cpu,
+                    last_loc,
+                    len(batch.input_ids),
+                    device_slots,
+                )
+            else:
+                batch.out_cache_loc = alloc_paged_token_slots_extend(
+                    batch.tree_cache,
+                    prefix_lens,
+                    prefix_lens_cpu,
+                    end_offset,
+                    end_offset_cpu,
+                    last_loc,
+                    len(batch.input_ids),
+                )
             self.last_loc = last_loc
 
         bs = batch.batch_size()
@@ -473,6 +489,23 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
         num_accepted_drafts_list = num_accepted_drafts_cpu.tolist()
         num_accepted_tokens_list = num_accepted_tokens_cpu.tolist()
 
+        hisparse_coordinator = getattr(batch, "hisparse_coordinator", None)
+
+        # HiSparse: finalize accepted tokens FIRST (reads device mapping for D2H backup),
+        # then clear rejected mappings, then free. Non-hisparse: free immediately.
+        if hisparse_coordinator is not None:
+            hisparse_coordinator.finalize_accepted_tokens(
+                batch.req_pool_indices,
+                batch.out_cache_loc[accept_index],
+                num_accepted_drafts,
+                batch.seq_lens + num_accepted_drafts + 1,  # post-accept seq_lens
+            )
+            # Clear mapping for rejected tokens so free_hisparse() won't corrupt allocator.
+            # Accepted tokens' mapping was already set by finalize (last→newest, rest→0).
+            token_to_kv_pool_allocator.clear_device_mapping(
+                batch.out_cache_loc[evict_mask]
+            )
+
         if page_size == 1:
             # TODO: boolean array index leads to a device sync. Remove it.
             token_to_kv_pool_allocator.free(batch.out_cache_loc[evict_mask])
@@ -528,11 +561,15 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 token_to_kv_pool_allocator.free(to_free_slots)
 
                 # Copy the kv cache
+                if hisparse_coordinator is not None:
+                    raise NotImplementedError(
+                        "HiSparse + EAGLE topk > 1 + page_size > 1: move_kv_cache "
+                        "needs hisparse-aware loc translation (not yet implemented)"
+                    )
                 batch.token_to_kv_pool_allocator.get_kvcache().move_kv_cache(
                     tgt_cache_loc, src_cache_loc
                 )
 
-        # Construct EagleVerifyOutput
         if not has_finished:
             if page_size == 1 or self.topk == 1:
                 batch.out_cache_loc = batch.out_cache_loc[accept_index]
@@ -696,6 +733,45 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
     def __post_init__(self):
         super().__init__(SpecInputType.EAGLE_DRAFT)
 
+    @staticmethod
+    def _slice_tensor(
+        value: Optional[torch.Tensor], idx: int
+    ) -> Optional[torch.Tensor]:
+        """Slice a single element from a tensor, preserving batch dimension."""
+        if value is None:
+            return None
+        if value.ndim == 0:
+            return value.clone()
+        return value[idx : idx + 1].clone()
+
+    def slice_single(self, batch_index: int) -> "EagleDraftInput":
+        """Create a new EagleDraftInput with a single request sliced from this batch."""
+        return EagleDraftInput(
+            topk_p=self._slice_tensor(self.topk_p, batch_index),
+            topk_index=self._slice_tensor(self.topk_index, batch_index),
+            hidden_states=self._slice_tensor(self.hidden_states, batch_index),
+            capture_hidden_mode=self.capture_hidden_mode,
+            verified_id=self._slice_tensor(self.verified_id, batch_index),
+            accept_length=self._slice_tensor(self.accept_length, batch_index),
+            accept_length_cpu=(
+                None
+                if self.accept_length_cpu is None
+                else [self.accept_length_cpu[batch_index]]
+            ),
+            seq_lens_for_draft_extend=self._slice_tensor(
+                self.seq_lens_for_draft_extend, batch_index
+            ),
+            seq_lens_for_draft_extend_cpu=self._slice_tensor(
+                self.seq_lens_for_draft_extend_cpu, batch_index
+            ),
+            req_pool_indices_for_draft_extend=self._slice_tensor(
+                self.req_pool_indices_for_draft_extend, batch_index
+            ),
+            num_tokens_per_req=self.num_tokens_per_req,
+            num_tokens_for_logprob_per_req=self.num_tokens_for_logprob_per_req,
+            new_seq_lens=self._slice_tensor(self.new_seq_lens, batch_index),
+        )
+
     def get_spec_adjust_token_coefficient(self) -> Tuple[int, int]:
         return self.num_tokens_per_req, self.num_tokens_for_logprob_per_req
 
@@ -751,6 +827,7 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
         batch.extend_num_tokens = sum(batch.extend_lens)
         batch.seq_lens = batch.spec_info.seq_lens_for_draft_extend
         batch.seq_lens_cpu = batch.spec_info.seq_lens_for_draft_extend_cpu
+        batch.prefix_lens = batch.seq_lens_cpu.tolist()
         batch.req_pool_indices = batch.spec_info.req_pool_indices_for_draft_extend
         batch.return_logprob = False
         batch.return_hidden_states = False
@@ -827,7 +904,29 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
             self.hidden_states = self.hidden_states[new_indices]
             self.verified_id = self.verified_id[new_indices]
 
+    @staticmethod
+    def _merge_tensor(
+        a: Optional[torch.Tensor], b: Optional[torch.Tensor]
+    ) -> Optional[torch.Tensor]:
+        """Merge two optional tensors by concatenation."""
+        if a is None:
+            return b
+        if b is None:
+            return a
+        return torch.cat([a, b], dim=0)
+
+    @staticmethod
+    def _merge_list(a: Optional[List], b: Optional[List]) -> Optional[List]:
+        """Merge two optional lists by concatenation."""
+        if a is None:
+            return b
+        if b is None:
+            return a
+        return a + b
+
     def merge_batch(self, spec_info: "EagleDraftInput"):
+        if spec_info is None:
+            return
         if self.future_indices is not None:
             assert spec_info.future_indices is not None
             self.future_indices = FutureIndices(
@@ -842,15 +941,43 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
             self.verified_id = spec_info.verified_id
             self.topk_p = spec_info.topk_p
             self.topk_index = spec_info.topk_index
+            self.accept_length = spec_info.accept_length
+            self.accept_length_cpu = spec_info.accept_length_cpu
+            self.seq_lens_for_draft_extend = spec_info.seq_lens_for_draft_extend
+            self.seq_lens_for_draft_extend_cpu = spec_info.seq_lens_for_draft_extend_cpu
+            self.req_pool_indices_for_draft_extend = (
+                spec_info.req_pool_indices_for_draft_extend
+            )
+            self.new_seq_lens = spec_info.new_seq_lens
             return
         if spec_info.hidden_states is None:
             return
+
         self.hidden_states = torch.cat(
-            [self.hidden_states, spec_info.hidden_states], axis=0
+            [self.hidden_states, spec_info.hidden_states], dim=0
         )
-        self.verified_id = torch.cat([self.verified_id, spec_info.verified_id], axis=0)
-        self.topk_p = torch.cat([self.topk_p, spec_info.topk_p])
-        self.topk_index = torch.cat([self.topk_index, spec_info.topk_index])
+        self.verified_id = torch.cat([self.verified_id, spec_info.verified_id], dim=0)
+        self.topk_p = torch.cat([self.topk_p, spec_info.topk_p], dim=0)
+        self.topk_index = torch.cat([self.topk_index, spec_info.topk_index], dim=0)
+        self.accept_length = self._merge_tensor(
+            self.accept_length, spec_info.accept_length
+        )
+        self.accept_length_cpu = self._merge_list(
+            self.accept_length_cpu, spec_info.accept_length_cpu
+        )
+        self.seq_lens_for_draft_extend = self._merge_tensor(
+            self.seq_lens_for_draft_extend, spec_info.seq_lens_for_draft_extend
+        )
+        self.seq_lens_for_draft_extend_cpu = self._merge_tensor(
+            self.seq_lens_for_draft_extend_cpu, spec_info.seq_lens_for_draft_extend_cpu
+        )
+        self.req_pool_indices_for_draft_extend = self._merge_tensor(
+            self.req_pool_indices_for_draft_extend,
+            spec_info.req_pool_indices_for_draft_extend,
+        )
+        self.new_seq_lens = self._merge_tensor(
+            self.new_seq_lens, spec_info.new_seq_lens
+        )
 
 
 @dataclass

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -143,15 +143,36 @@ class EagleDraftInputV2Mixin:
                 batch.req_pool_indices,
                 cur_kv_lens,
             )
-            out_cache_loc = alloc_paged_token_slots_extend(
-                batch.tree_cache,
-                cur_kv_lens,
-                cur_kv_lens_cpu,
-                nxt_kv_lens,
-                nxt_kv_lens_cpu,
-                last_loc,
-                num_needed_tokens,
-            )
+            if batch.hisparse_coordinator is not None:
+                allocator = batch.tree_cache.token_to_kv_pool_allocator
+                tokens_per_req_tensor = (nxt_kv_lens_cpu - cur_kv_lens_cpu).to(
+                    device=batch.device
+                )
+                device_slots = (
+                    batch.hisparse_coordinator.get_draft_device_slots_variable(
+                        batch.req_pool_indices,
+                        tokens_per_req_tensor,
+                    )
+                )
+                out_cache_loc = allocator.alloc_extend_with_device_mapping(
+                    cur_kv_lens,
+                    cur_kv_lens_cpu,
+                    nxt_kv_lens,
+                    nxt_kv_lens_cpu,
+                    last_loc,
+                    num_needed_tokens,
+                    device_slots,
+                )
+            else:
+                out_cache_loc = alloc_paged_token_slots_extend(
+                    batch.tree_cache,
+                    cur_kv_lens,
+                    cur_kv_lens_cpu,
+                    nxt_kv_lens,
+                    nxt_kv_lens_cpu,
+                    last_loc,
+                    num_needed_tokens,
+                )
 
         assign_req_to_token_pool_func(
             batch.req_pool_indices,

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -289,7 +289,11 @@ class EAGLEWorker(TpModelWorker):
             )
 
         # Capture extend
-        if self.draft_extend_attn_backend and not _is_npu:
+        if (
+            self.draft_extend_attn_backend
+            and not _is_npu
+            and not self.server_args.enable_hisparse
+        ):
             tic = time.perf_counter()
             before_mem = get_available_gpu_memory(self.device, self.gpu_id)
             logger.info(
@@ -301,6 +305,10 @@ class EAGLEWorker(TpModelWorker):
             after_mem = get_available_gpu_memory(self.device, self.gpu_id)
             logger.info(
                 f"Capture draft extend cuda graph end. Time elapsed: {time.perf_counter() - tic:.2f} s. mem usage={(before_mem - after_mem):.2f} GB. avail mem={after_mem:.2f} GB."
+            )
+        elif self.draft_extend_attn_backend and self.server_args.enable_hisparse:
+            logger.info(
+                "Skip draft extend cuda graph because HiSparse remaps KV locations during EAGLE verification."
             )
 
     def apply_runtime_state(self, state: SpecRuntimeState):
@@ -644,18 +652,42 @@ class EAGLEWorker(TpModelWorker):
                 )
                 extend_num_tokens = torch.sum((seq_lens_cpu - prefix_lens_cpu)).item()
 
-            out_cache_loc, token_to_kv_pool_state_backup = (
-                alloc_paged_token_slots_extend(
-                    batch.tree_cache,
-                    prefix_lens,
-                    prefix_lens_cpu,
-                    seq_lens,
-                    seq_lens_cpu,
-                    last_loc,
-                    extend_num_tokens,
-                    backup_state=True,
+            if batch.hisparse_coordinator is not None:
+                allocator = self.token_to_kv_pool_allocator
+                tokens_per_req = (seq_lens_cpu - prefix_lens_cpu).to(
+                    device=batch.device
                 )
-            )
+                device_slots = (
+                    batch.hisparse_coordinator.get_draft_device_slots_variable(
+                        batch.req_pool_indices,
+                        tokens_per_req,
+                    )
+                )
+                out_cache_loc, token_to_kv_pool_state_backup = (
+                    allocator.alloc_extend_with_device_mapping(
+                        prefix_lens,
+                        prefix_lens_cpu,
+                        seq_lens,
+                        seq_lens_cpu,
+                        last_loc,
+                        extend_num_tokens,
+                        device_slots,
+                        backup_state=True,
+                    )
+                )
+            else:
+                out_cache_loc, token_to_kv_pool_state_backup = (
+                    alloc_paged_token_slots_extend(
+                        batch.tree_cache,
+                        prefix_lens,
+                        prefix_lens_cpu,
+                        seq_lens,
+                        seq_lens_cpu,
+                        last_loc,
+                        extend_num_tokens,
+                        backup_state=True,
+                    )
+                )
 
         if self.page_size > 1 and self.topk > 1:
             last_page_lens_cumsum = torch.cumsum(last_page_lens, dim=0)

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -302,10 +302,14 @@ class EagleDraftWorker(BaseDraftWorker):
         )
         # Capture extend
         # TODO: support draft extend cuda graph for more attention backends
-        if self.draft_extend_attn_backend and (
-            _is_npu
-            or supports_cuda_draft_extend_graph
-            or supports_hip_aiter_draft_extend_graph
+        if (
+            self.draft_extend_attn_backend
+            and (
+                _is_npu
+                or supports_cuda_draft_extend_graph
+                or supports_hip_aiter_draft_extend_graph
+            )
+            and not self.server_args.enable_hisparse
         ):
             tic = time.perf_counter()
             before_mem = get_available_gpu_memory(self.device, self.gpu_id)
@@ -318,6 +322,10 @@ class EagleDraftWorker(BaseDraftWorker):
             after_mem = get_available_gpu_memory(self.device, self.gpu_id)
             logger.info(
                 f"Capture draft extend cuda graph end. Time elapsed: {time.perf_counter() - tic:.2f} s. mem usage={(before_mem - after_mem):.2f} GB. avail mem={after_mem:.2f} GB."
+            )
+        elif self.draft_extend_attn_backend and self.server_args.enable_hisparse:
+            logger.info(
+                "Skip draft extend cuda graph because HiSparse remaps KV locations during EAGLE verification."
             )
 
     def draft(self, model_worker_batch: ModelWorkerBatch):


### PR DESCRIPTION
## Summary

- Add HiSparse-aware draft KV allocation for EAGLE V1/V2 so speculative draft tokens use coordinator-managed device slots.
- Finalize accepted draft tokens before rejected slots are freed, clear rejected mappings, and wait for transfer-stream work before request teardown.
- Split HiSparse swap-in into prepare/copy phases so `flashmla_kv` can overlap hit attention with async H2D while keeping the synchronous path for other backends.
- Harden allocator mapping/free behavior, keep the existing HiSparse JIT wrapper API for tests and benchmarks, and choose the HiSparse NSA backend from the KV dtype.

## Test Plan

- `python3 -m compileall -q <changed Python files>`
- `uvx ruff@0.15.1 check --select=F401,F821 <changed Python files>`
- `black --check <changed Python files>`
- `isort --check-only <changed Python files>`
- `git diff --check origin/main...HEAD`
- Validated on a local hotfix deployment with HiSparse + EAGLE enabled using smoke and score-style workloads; no decode restarts, transfer failures, or CUDA illegal-memory-access failures were observed.
