### PR TITLE
fix(r-fork): allow weight-transfer endpoints with --enable-dp-attention

### DIFF
--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -445,10 +445,12 @@ class TokenizerControlMixin:
         request: Optional[fastapi.Request] = None,
     ) -> Tuple[bool, str]:
         self.auto_create_handle_loop()
-        # TODO: support DP
+        # Plain DP would race for the same per-tp_rank port. With dp_attention
+        # there is one global TP world, so distinct tp_ranks pick distinct
+        # ports (ports_list[self.tp_rank]) and the protocol is well-formed.
         assert (
-            self.server_args.dp_size == 1
-        ), "dp_size must be 1 for init_weights_send_group_for_remote_instance"
+            self.server_args.dp_size == 1 or self.server_args.enable_dp_attention
+        ), "dp_size must be 1 or dp attention must be enabled for init_weights_send_group_for_remote_instance"
         result = (
             await self.init_weights_send_group_for_remote_instance_communicator(obj)
         )[0]
@@ -460,10 +462,10 @@ class TokenizerControlMixin:
         request: Optional[fastapi.Request] = None,
     ) -> Tuple[bool, str]:
         self.auto_create_handle_loop()
-        # TODO: support DP
+        # See init_weights_send_group_for_remote_instance for the rationale.
         assert (
-            self.server_args.dp_size == 1
-        ), "dp_size must be 1 for send_weights_to_remote_instance"
+            self.server_args.dp_size == 1 or self.server_args.enable_dp_attention
+        ), "dp_size must be 1 or dp attention must be enabled for send_weights_to_remote_instance"
         result = (await self.send_weights_to_remote_instance_communicator(obj))[0]
         return result.success, result.message
 

--- a/test/registered/unit/managers/test_rfork_dp_attention_assertions.py
+++ b/test/registered/unit/managers/test_rfork_dp_attention_assertions.py
@@ -1,0 +1,98 @@
+"""Regression test for the R-Fork weight-transfer DP precondition.
+
+Two NCCL-only HTTP endpoints used by R-Fork weight transfer
+(`init_weights_send_group_for_remote_instance` and
+`send_weights_to_remote_instance` in `tokenizer_control_mixin.py`)
+previously hard-asserted `dp_size == 1`, blocking the working
+DP-attention path. This test guards the relaxed precondition:
+
+    assert dp_size == 1 or enable_dp_attention
+
+which matches the pattern already used by sibling weight-update
+methods in the same file. Plain DP (no dp_attention) is intentionally
+still rejected because the seed-side per-tp_rank port allocation is
+not safe for it.
+"""
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from sglang.srt.managers.tokenizer_control_mixin import TokenizerControlMixin
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+
+
+def _make_obj(dp_size: int, enable_dp_attention: bool):
+    """Minimal stand-in for TokenizerManager — only the attrs the methods read."""
+    obj = MagicMock()
+    obj.server_args = MagicMock()
+    obj.server_args.dp_size = dp_size
+    obj.server_args.enable_dp_attention = enable_dp_attention
+    obj.auto_create_handle_loop = MagicMock()
+
+    fake_result = MagicMock()
+    fake_result.success = True
+    fake_result.message = "ok"
+    comm = AsyncMock(return_value=[fake_result])
+    obj.init_weights_send_group_for_remote_instance_communicator = comm
+    obj.send_weights_to_remote_instance_communicator = comm
+    return obj
+
+
+class TestRForkDPAttentionAssertions(unittest.IsolatedAsyncioTestCase):
+    """Verify the relaxed `dp_size == 1 or enable_dp_attention` precondition."""
+
+    # ---- init_weights_send_group_for_remote_instance ----
+
+    async def test_init_dp1_accepts(self):
+        """dp_size=1 keeps working — no regression for the common case."""
+        obj = _make_obj(dp_size=1, enable_dp_attention=False)
+        ok, _ = await TokenizerControlMixin.init_weights_send_group_for_remote_instance(
+            obj, MagicMock()
+        )
+        self.assertTrue(ok)
+        obj.auto_create_handle_loop.assert_called_once()
+
+    async def test_init_dp_attention_accepts(self):
+        """dp_size>1 with enable_dp_attention=True is now accepted."""
+        obj = _make_obj(dp_size=8, enable_dp_attention=True)
+        ok, _ = await TokenizerControlMixin.init_weights_send_group_for_remote_instance(
+            obj, MagicMock()
+        )
+        self.assertTrue(ok)
+
+    async def test_init_plain_dp_still_rejected(self):
+        """Plain DP (no dp_attention) is intentionally still rejected."""
+        obj = _make_obj(dp_size=8, enable_dp_attention=False)
+        with self.assertRaises(AssertionError):
+            await TokenizerControlMixin.init_weights_send_group_for_remote_instance(
+                obj, MagicMock()
+            )
+
+    # ---- send_weights_to_remote_instance ----
+
+    async def test_send_dp1_accepts(self):
+        obj = _make_obj(dp_size=1, enable_dp_attention=False)
+        ok, _ = await TokenizerControlMixin.send_weights_to_remote_instance(
+            obj, MagicMock()
+        )
+        self.assertTrue(ok)
+
+    async def test_send_dp_attention_accepts(self):
+        obj = _make_obj(dp_size=8, enable_dp_attention=True)
+        ok, _ = await TokenizerControlMixin.send_weights_to_remote_instance(
+            obj, MagicMock()
+        )
+        self.assertTrue(ok)
+
+    async def test_send_plain_dp_still_rejected(self):
+        obj = _make_obj(dp_size=8, enable_dp_attention=False)
+        with self.assertRaises(AssertionError):
+            await TokenizerControlMixin.send_weights_to_remote_instance(
+                obj, MagicMock()
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Two NCCL-only HTTP endpoints used by R-Fork weight transfer hard-assert `dp_size == 1`:

- `init_weights_send_group_for_remote_instance`
- `send_weights_to_remote_instance`

The `# TODO: support DP` comments date back to the original R-Fork PR (#8215). The communicators in `init_communicators` are already created with `fan_out=server_args.dp_size`, so the requests fan out to every dp replica out of the box — the assertion is the only thing blocking the working DP-attention path.

These endpoints are NCCL-only: TransferEngine uses `/get_remote_instance_transfer_engine_info` instead, and ModelExpress goes through its own coordination, so this change only affects the NCCL backend.

## Why this guard, not just removing the assertion

Without `--enable-dp-attention`, every DP replica is a separate fully-replicated copy of the model with its own scheduler and `tp_rank == 0`. The seed-side weight-send group is built with `ports_list[self.tp_rank]`, so all DP replicas would race for the same TCP port. Removing the assertion outright would expose that broken path.

With `--enable-dp-attention`, the schedulers form a single global TP world of size `tp_size`, where each `tp_rank` is also a `dp_rank` for attention. Distinct `tp_rank` values pick distinct ports and the protocol is well-formed.

This patch matches the precondition pattern already used by the sibling weight-update methods in the same file (lines 393, 406, 419, 477, 509):

```python
assert dp_size == 1 or enable_dp_attention
```

so plain DP keeps its safety net while DP-attention is unblocked.

## Test

Added `test/registered/unit/managers/test_rfork_dp_attention_assertions.py` (CPU-only, registered as `stage-a-test-cpu`, ~5 s).

Six test cases — three per method:

| Case | Expected |
|---|---|
| `dp_size=1` | accepts (no regression for the common single-replica case) |
| `dp_size=8` + `enable_dp_attention=True` | accepts (the case unblocked by this PR) |
| `dp_size=8` + `enable_dp_attention=False` | still raises `AssertionError` |

## Verified

Tested end-to-end on TP=8 DP=8 with `--enable-dp-attention` on IPv6-only pods, NCCL backend. After this fix (plus #24057 and #24064 for the IPv6 paths in the same flow), all 8 tp_ranks complete weight transfer in ~3.2 s.

## Out of scope

Plain DP (no `dp_attention`) support is intentionally left to a follow-up. It would need a longer `ports_list` (one port per global rank), a port-allocation contract documented for users, and likely a sequential-start mechanism on the client to avoid simultaneous connections to the same seed port.

## Checklist

- [x] No behaviour change for `dp_size == 1` (the previously supported case)
- [x] Plain DP without `dp_attention` is still rejected at the assertion (no new broken path opened)
- [x] CPU unit tests added and registered in CI
- [x] Matches precondition style used by sibling methods in the same file
- [x] No new dependencies