### PR TITLE
SM120 FP4 config various changes

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_b12x.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_b12x.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from sglang.srt.layers.moe.moe_runner.base import (
+    MoeQuantInfo,
+    MoeRunnerConfig,
+    register_fused_func,
+)
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.moe.token_dispatcher import (
+        StandardCombineInput,
+        StandardDispatchOutput,
+    )
+
+
+def ensure_b12x_wrapper(layer: torch.nn.Module) -> None:
+    """Lazily create a B12xMoEWrapper on the layer.
+
+    Created lazily because it depends on EP/TP-resolved shapes. inference_mode(False)
+    ensures the pre-allocated CUDA-graph buffers are normal tensors, since inference
+    tensors cannot be inplace-updated during later CUDA graph capture.
+    """
+    if getattr(layer, "_b12x_wrapper", None) is not None:
+        return
+
+    try:
+        from flashinfer import B12xMoEWrapper
+    except ImportError as e:
+        raise ImportError(
+            "flashinfer_b12x backend requires FlashInfer with B12x support."
+        ) from e
+
+    from sglang.srt.server_args import get_global_server_args
+
+    assert layer.intermediate_size_per_partition > 0, (
+        f"B12x MoE: intermediate_size_per_partition must be > 0, "
+        f"got {layer.intermediate_size_per_partition}. Check EP/TP configuration."
+    )
+
+    server_args = get_global_server_args()
+    use_cuda_graph = server_args is not None and not server_args.disable_cuda_graph
+    max_num_tokens = max(
+        getattr(server_args, "cuda_graph_max_bs", None) or 512,
+        getattr(server_args, "chunked_prefill_size", None) or 8192,
+    )
+    top_k = layer.top_k if layer.top_k is not None else layer.moe_runner_config.top_k
+
+    with torch.inference_mode(False):
+        layer._b12x_wrapper = B12xMoEWrapper(
+            num_experts=layer.num_experts,
+            top_k=top_k,
+            hidden_size=layer.hidden_size,
+            intermediate_size=layer.intermediate_size_per_partition,
+            use_cuda_graph=use_cuda_graph,
+            max_num_tokens=max_num_tokens,
+            num_local_experts=layer.num_local_experts,
+            output_dtype=torch.bfloat16,
+            device=str(layer.w13_weight.device),
+            activation=layer.moe_runner_config.activation,
+        )
+
+
+@dataclass
+class B12xFp4MoeQuantInfo(MoeQuantInfo):
+    """Quantization payload consumed by FlashInfer B12x FP4 MoE kernels."""
+
+    wrapper: Any
+
+    w13_weight: torch.Tensor
+    w2_weight: torch.Tensor
+
+    w13_weight_sf: torch.Tensor
+    w2_weight_sf: torch.Tensor
+
+    w1_alpha: torch.Tensor
+    w2_alpha: torch.Tensor
+
+    fc2_input_scale: torch.Tensor
+
+
+@register_fused_func("none", "flashinfer_b12x")
+def fused_experts_none_to_flashinfer_b12x_fp4(
+    dispatch_output: "StandardDispatchOutput",
+    quant_info: B12xFp4MoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+) -> "StandardCombineInput":
+    from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
+    from sglang.srt.layers.moe.topk import TopKOutputChecker
+
+    assert runner_config.activation in ("silu", "relu2"), (
+        f"B12x MoE supports activation in ('silu', 'relu2'), "
+        f"got {runner_config.activation!r}."
+    )
+    assert (
+        dispatch_output.hidden_states_scale is None
+    ), "B12x MoE expects bf16 input; pre-quantized FP4 dispatch is not supported."
+
+    topk_output = dispatch_output.topk_output
+    assert TopKOutputChecker.format_is_standard(topk_output)
+
+    output = quant_info.wrapper.run(
+        x=dispatch_output.hidden_states,
+        w1_weight=quant_info.w13_weight,
+        w1_weight_sf=quant_info.w13_weight_sf,
+        w2_weight=quant_info.w2_weight,
+        w2_weight_sf=quant_info.w2_weight_sf,
+        token_selected_experts=topk_output.topk_ids,
+        token_final_scales=topk_output.topk_weights,
+        w1_alpha=quant_info.w1_alpha,
+        w2_alpha=quant_info.w2_alpha,
+        fc2_input_scale=quant_info.fc2_input_scale,
+    )
+
+    return StandardCombineInput(hidden_states=output)

--- a/python/sglang/srt/layers/moe/moe_runner/runner.py
+++ b/python/sglang/srt/layers/moe/moe_runner/runner.py
@@ -57,6 +57,8 @@ class MoeRunner:
             self.runner_core = None  # FlashInfer TRT-LLM only supports fused path
         elif runner_backend.is_flashinfer_cutedsl():
             self.runner_core = None  # FlashInfer CuteDSL only supports fused path
+        elif runner_backend.is_flashinfer_b12x():
+            self.runner_core = None  # FlashInfer B12x only supports fused path
         else:
             raise NotImplementedError(f"Unsupported runner backend: {runner_backend}")
 

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -76,6 +76,7 @@ class MoeRunnerBackend(Enum):
     FLASHINFER_CUTLASS = "flashinfer_cutlass"
     FLASHINFER_MXFP4 = "flashinfer_mxfp4"
     FLASHINFER_CUTEDSL = "flashinfer_cutedsl"
+    FLASHINFER_B12X = "flashinfer_b12x"
     CUTLASS = "cutlass"
     MARLIN = "marlin"
 
@@ -105,6 +106,9 @@ class MoeRunnerBackend(Enum):
 
     def is_flashinfer_mxfp4(self):
         return self == MoeRunnerBackend.FLASHINFER_MXFP4
+
+    def is_flashinfer_b12x(self):
+        return self == MoeRunnerBackend.FLASHINFER_B12X
 
     def is_cutlass(self):
         return self == MoeRunnerBackend.CUTLASS

--- a/python/sglang/srt/layers/quantization/fp4_utils.py
+++ b/python/sglang/srt/layers/quantization/fp4_utils.py
@@ -62,18 +62,8 @@ def initialize_fp4_gemm_config(server_args: ServerArgs) -> None:
     global FP4_GEMM_RUNNER_BACKEND
 
     backend = server_args.fp4_gemm_runner_backend
-    if backend == "auto":
-        if is_sm120_supported():
-            # flashinfer_cutlass produces NaN in dense MLP layers with
-            # heterogeneous batches on SM120 (Blackwell).  cudnn is stable.
-            # See: https://github.com/sgl-project/sglang/issues/20043
-            backend = "flashinfer_cudnn"
-            logger.info(
-                "SM120 (Blackwell) detected: auto-selecting "
-                "fp4-gemm-backend=flashinfer_cudnn"
-            )
-        else:
-            backend = "flashinfer_cutlass"
+    if backend == "auto" and not is_sm120_supported():
+        backend = "flashinfer_cutlass"
 
     FP4_GEMM_RUNNER_BACKEND = Fp4GemmRunnerBackend(backend)
 

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -1549,6 +1549,12 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
 
         return get_moe_runner_backend().is_flashinfer_cutedsl()
 
+    @property
+    def enable_flashinfer_b12x_moe(self) -> bool:
+        from sglang.srt.layers.moe import get_moe_runner_backend
+
+        return get_moe_runner_backend().is_flashinfer_b12x()
+
     # ----- CuteDSL v1 vs v2 path helpers -----
     #
     # "v1": cutedsl + deepep low-latency.
@@ -1983,9 +1989,12 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
         moe_runner_backend = get_moe_runner_backend()
 
         if moe_runner_backend.is_auto():
-            # TRTLLM is currently the most performant and tested FP4 MoE
-            # backend, so use it as the default.
-            moe_runner_backend = MoeRunnerBackend.FLASHINFER_TRTLLM
+            if is_sm120_supported():
+                moe_runner_backend = MoeRunnerBackend.FLASHINFER_B12X
+            else:
+                # TRTLLM is currently the most performant and tested FP4 MoE
+                # backend, so use it as the default.
+                moe_runner_backend = MoeRunnerBackend.FLASHINFER_TRTLLM
 
         if moe_runner_backend.is_flashinfer_cutedsl():
             import sglang.srt.layers.moe.moe_runner.flashinfer_cutedsl  # noqa: F401 – triggers @register_fused_func
@@ -1994,6 +2003,9 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             # path (flashinfer_cutedsl_moe_masked) and does not need a MoeRunner.
             if self._is_cutedsl_v1_deepep:
                 return
+
+        if moe_runner_backend.is_flashinfer_b12x():
+            import sglang.srt.layers.moe.moe_runner.flashinfer_b12x  # noqa: F401 – triggers @register_fused_func
 
         if not moe_runner_backend.is_flashinfer_cutlass():
             self.runner = MoeRunner(moe_runner_backend, moe_runner_config)
@@ -2073,6 +2085,25 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
                 w2_alpha=w2_alpha,
                 fc2_input_scale=fc2_input_scale,
                 input_scale=layer._cutedsl_input_scale,
+            )
+            return self.runner.run(dispatch_output, quant_info)
+
+        if self.enable_flashinfer_b12x_moe:
+            from sglang.srt.layers.moe.moe_runner.flashinfer_b12x import (
+                B12xFp4MoeQuantInfo,
+                ensure_b12x_wrapper,
+            )
+
+            ensure_b12x_wrapper(layer)
+            quant_info = B12xFp4MoeQuantInfo(
+                wrapper=layer._b12x_wrapper,
+                w13_weight=layer.w13_weight,
+                w2_weight=layer.w2_weight,
+                w13_weight_sf=layer.w13_blockscale_swizzled,
+                w2_weight_sf=layer.w2_blockscale_swizzled,
+                w1_alpha=layer.g1_alphas,
+                w2_alpha=layer.g2_alphas,
+                fc2_input_scale=layer.w2_input_scale_quant,
             )
             return self.runner.run(dispatch_output, quant_info)
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -178,6 +178,7 @@ MOE_RUNNER_BACKEND_CHOICES = [
     "flashinfer_cutlass",
     "flashinfer_mxfp4",
     "flashinfer_cutedsl",
+    "flashinfer_b12x",
     "cutlass",
 ]
 
@@ -2920,6 +2921,14 @@ class ServerArgs:
                 1,
                 self.tp_size,
             ], "The expert parallel size must be 1 or the same as the tensor parallel size"
+
+        if self.moe_runner_backend == "flashinfer_b12x":
+            assert self.quantization in [
+                "modelopt_fp4"
+            ], f"Invalid quantization '{self.quantization}'. \nFlashInfer B12x MOE supports only: 'modelopt_fp4'."
+            assert (
+                is_sm120_supported()
+            ), "FlashInfer B12x MOE is only supported on SM120."
 
         if self.moe_runner_backend == "flashinfer_cutedsl":
             assert self.quantization in [
@@ -7109,7 +7118,10 @@ class ServerArgs:
         if self.remote_instance_weight_loader_start_seed_via_transfer_engine:
             return True
         # ModelExpress source mode needs TransferEngine init only if transport is transfer_engine.
-        if self.modelexpress_source and self.modelexpress_transport == "transfer_engine":
+        if (
+            self.modelexpress_source
+            and self.modelexpress_transport == "transfer_engine"
+        ):
             return True
         # Use TransferEngine as client backend.
         elif (


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

1. Ref: https://github.com/flashinfer-ai/flashinfer/pull/3051 to allow `backend=b12x` to be chosen, performance changes are in the PR
2. Enable b12x fused MoE, needs more benchmarking for num tokens 1 to 8192 to determine whether setting to default for NVFP4 on SM120
3. TBD one more thing

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

TODO

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->