### PR TITLE
[CI] Fix black formatting on main (unblocks PR #21247 lint)

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1003,9 +1003,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 sv = torch.empty(0, dtype=torch.uint8, device=t.device).set_(
                     t.untyped_storage()
                 )
-                if sv.data_ptr() not in {
-                    v.data_ptr() for v in model_tensors.values()
-                }:
+                if sv.data_ptr() not in {v.data_ptr() for v in model_tensors.values()}:
                     model_tensors[f"{name}.__storage"] = sv
 
         nixl_metadata = nixl_mgr.register_tensors(model_tensors)

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -2408,9 +2408,7 @@ class RemoteInstanceModelLoader(BaseModelLoader):
 
         # --- Transport-specific transfer ---
         if transport == "nixl":
-            self._transfer_via_nixl(
-                model, nixl_mgr, source_worker, tp_rank
-            )
+            self._transfer_via_nixl(model, nixl_mgr, source_worker, tp_rank)
         else:
             self._transfer_via_transfer_engine(
                 model, transfer_engine, source_worker, tp_rank
@@ -2555,8 +2553,7 @@ class RemoteInstanceModelLoader(BaseModelLoader):
         )
 
         logger.info(
-            "ModelExpress [nixl]: transferred %d tensors, "
-            "%.2f GB in %.2fs",
+            "ModelExpress [nixl]: transferred %d tensors, " "%.2f GB in %.2fs",
             matched,
             total_bytes / 1e9,
             duration,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7109,7 +7109,10 @@ class ServerArgs:
         if self.remote_instance_weight_loader_start_seed_via_transfer_engine:
             return True
         # ModelExpress source mode needs TransferEngine init only if transport is transfer_engine.
-        if self.modelexpress_source and self.modelexpress_transport == "transfer_engine":
+        if (
+            self.modelexpress_source
+            and self.modelexpress_transport == "transfer_engine"
+        ):
             return True
         # Use TransferEngine as client backend.
         elif (


### PR DESCRIPTION
## Summary
- Run `black` (26.1.0, version pinned in `.pre-commit-config.yaml`) on three files where the formatting on `main` no longer matches what `black-jupyter` produces. No behavioral changes, formatting only.
- Files: `python/sglang/srt/model_executor/model_runner.py`, `python/sglang/srt/model_loader/loader.py`, `python/sglang/srt/server_args.py`.

## Why
The `lint` job runs `pre-commit run --all-files` and currently fails on `main` for these three files. This breaks the lint check on every PR that builds against `main`, including the Torch 2.11 upgrade PR #21247 — see the failing run: https://github.com/sgl-project/sglang/actions/runs/25132074962/job/73660689648?pr=21247

The diff produced by black here matches exactly what that CI run reported.

## Test plan
- [x] `pre-commit run black-jupyter --files <the 3 files>` → Passed
- [x] `pre-commit run --files <the 3 files>` → all hooks Passed
- [ ] CI lint job on this PR is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)