### PR TITLE
[DO NOT MERGE] Migrate model cache sync barriers to platform ops

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -202,6 +202,7 @@ from sglang.srt.observability.scheduler_metrics_mixin import (
 )
 from sglang.srt.observability.trace import process_tracing_init, trace_set_thread_info
 from sglang.srt.parser.reasoning_parser import ReasoningParser
+from sglang.srt.platforms import current_platform
 from sglang.srt.plugins import load_plugins
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.server_args import PortArgs, ServerArgs, get_global_server_args
@@ -3320,7 +3321,7 @@ class Scheduler(
                 self.draft_worker.clear_cache_pool()
 
             if empty_cache:
-                torch.cuda.empty_cache()
+                current_platform.empty_cache()
             logger.info("Cache flushed successfully!")
             success = True
         else:
@@ -3711,7 +3712,7 @@ class IdleSleeper:
             and real_time() - self.last_empty_time > self.empty_cache_interval
         ):
             self.last_empty_time = real_time()
-            torch.cuda.empty_cache()
+            current_platform.empty_cache()
 
 
 def is_health_check_generate_req(recv_req):

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -399,7 +399,7 @@ class MambaPool:
         return dst_index
 
     def get_cpu_copy(self, indices, **kwargs):
-        torch.cuda.synchronize()
+        current_platform.synchronize()
         conv_cpu = [
             conv[:, indices].to("cpu", non_blocking=True)
             for conv in self.mamba_cache.conv
@@ -407,18 +407,18 @@ class MambaPool:
         temporal_cpu = self.mamba_cache.temporal[:, indices].to(
             "cpu", non_blocking=True
         )
-        torch.cuda.synchronize()
+        current_platform.synchronize()
         return conv_cpu, temporal_cpu
 
     def load_cpu_copy(self, mamba_cache_cpu, indices, **kwargs):
         conv_cpu, temporal_cpu = mamba_cache_cpu
-        torch.cuda.synchronize()
+        current_platform.synchronize()
         for i, conv in enumerate(self.mamba_cache.conv):
             conv[:, indices] = conv_cpu[i].to(conv.device, non_blocking=True)
         self.mamba_cache.temporal[:, indices] = temporal_cpu.to(
             self.mamba_cache.temporal.device, non_blocking=True
         )
-        torch.cuda.synchronize()
+        current_platform.synchronize()
 
     def get_contiguous_buf_infos(self):
         """
@@ -966,7 +966,7 @@ class MHATokenToKVPool(KVCache):
         return kv_data_ptrs, kv_data_lens, kv_item_lens
 
     def get_cpu_copy(self, indices, **kwargs):
-        torch.cuda.synchronize()
+        current_platform.synchronize()
         kv_cache_cpu = []
         chunk_size = self.cpu_offloading_chunk_size
         for layer_id in range(self.layer_num):
@@ -980,11 +980,11 @@ class MHATokenToKVPool(KVCache):
                     "cpu", non_blocking=True
                 )
                 kv_cache_cpu[-1].append([k_cpu, v_cpu])
-        torch.cuda.synchronize()
+        current_platform.synchronize()
         return kv_cache_cpu
 
     def load_cpu_copy(self, kv_cache_cpu, indices, **kwargs):
-        torch.cuda.synchronize()
+        current_platform.synchronize()
         chunk_size = self.cpu_offloading_chunk_size
         for layer_id in range(self.layer_num):
             for i in range(0, len(indices), chunk_size):
@@ -998,7 +998,7 @@ class MHATokenToKVPool(KVCache):
                 v_chunk = v_cpu.to(self.v_buffer[0].device, non_blocking=True)
                 self.k_buffer[layer_id][chunk_indices] = k_chunk
                 self.v_buffer[layer_id][chunk_indices] = v_chunk
-        torch.cuda.synchronize()
+        current_platform.synchronize()
 
     def _get_key_buffer(self, layer_id: int):
         # for internal use of referencing
@@ -1696,7 +1696,7 @@ class MLATokenToKVPool(KVCache):
         return cache_k_nope, cache_k_rope
 
     def get_cpu_copy(self, indices, **kwargs):
-        torch.cuda.synchronize()
+        current_platform.synchronize()
         kv_cache_cpu = []
         chunk_size = self.cpu_offloading_chunk_size
         for layer_id in range(self.layer_num):
@@ -1707,11 +1707,11 @@ class MLATokenToKVPool(KVCache):
                     "cpu", non_blocking=True
                 )
                 kv_cache_cpu[-1].append(kv_cpu)
-        torch.cuda.synchronize()
+        current_platform.synchronize()
         return kv_cache_cpu
 
     def load_cpu_copy(self, kv_cache_cpu, indices, **kwargs):
-        torch.cuda.synchronize()
+        current_platform.synchronize()
         chunk_size = self.cpu_offloading_chunk_size
         for layer_id in range(self.layer_num):
             for i in range(0, len(indices), chunk_size):
@@ -1720,7 +1720,7 @@ class MLATokenToKVPool(KVCache):
                 assert kv_cpu.shape[0] == len(chunk_indices)
                 kv_chunk = kv_cpu.to(self.kv_buffer[0].device, non_blocking=True)
                 self.kv_buffer[layer_id][chunk_indices] = kv_chunk
-        torch.cuda.synchronize()
+        current_platform.synchronize()
 
 
 class MLATokenToKVPoolFP4(MLATokenToKVPool):

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1196,7 +1196,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 # Single warmup all_reduce to initialize NCCL/RCCL communicator
                 warmup_tensor = torch.zeros(1, device=torch.cuda.current_device())
                 dist.all_reduce(warmup_tensor, group=tp_group_handle)
-                torch.cuda.synchronize()
+                current_platform.synchronize()
 
                 warmup_elapsed = time.perf_counter() - warmup_start
                 logger.info(
@@ -1711,7 +1711,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             f"group_rank={group_rank}, world_size={world_size}, group_name={group_name}, backend={backend}"
         )
 
-        torch.cuda.empty_cache()
+        current_platform.empty_cache()
         success = False
         message = ""
         try:
@@ -1731,7 +1731,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             message = f"Failed to init group: {e}."
             logger.error(message)
 
-        torch.cuda.empty_cache()
+        current_platform.empty_cache()
         return success, message
 
     def send_weights_to_remote_instance(
@@ -1759,7 +1759,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             logger.error(message)
             return False, message
 
-        torch.cuda.empty_cache()
+        current_platform.empty_cache()
         success = False
         na = NetworkAddress(master_address, group_port)
         message = ""
@@ -1779,7 +1779,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # destroy the process group after sending weights
         del self._weights_send_group[group_name]
         torch.distributed.distributed_c10d.destroy_process_group(send_group)
-        torch.cuda.empty_cache()
+        current_platform.empty_cache()
         return success, message
 
     def init_weights_update_group(

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -105,6 +105,7 @@ from sglang.srt.model_loader.weight_utils import (
     safetensors_weights_iterator,
     set_runai_streamer_env,
 )
+from sglang.srt.platforms import current_platform
 from sglang.srt.utils import (
     get_bool_env_var,
     get_device_capability,
@@ -1201,7 +1202,7 @@ class QuantizedRLModelLoader(DefaultModelLoader):
         del current_param_data
         if is_last_update:
             gc.collect()
-            torch.cuda.empty_cache()
+            current_platform.empty_cache()
 
         logger.info("[QuantizedRL] Reload complete")
         return updated_param_names, is_last_update
@@ -1892,7 +1893,7 @@ class BitsAndBytesModelLoader(BaseModelLoader):
 
         model.load_weights(qweight_iterator)
 
-        torch.cuda.empty_cache()
+        current_platform.empty_cache()
 
         param_dict = dict(model.named_parameters())
         stacked_quant_state_dict: Dict[str, Dict[int, Any]] = {}
@@ -2200,7 +2201,7 @@ class RemoteInstanceModelLoader(BaseModelLoader):
             tp_rank=load_config.tp_rank,
             instance_ip=instance_ip,
         )
-        torch.cuda.synchronize()
+        current_platform.synchronize()
         end_build_group_tic = time.time()
         logger.debug(
             f"finish building group for remote instance, time used: {(end_build_group_tic - start_build_group_tic):.4f}s"
@@ -2226,7 +2227,7 @@ class RemoteInstanceModelLoader(BaseModelLoader):
                     src=0,
                     group=client._model_update_group,
                 )
-            torch.cuda.synchronize()
+            current_platform.synchronize()
 
             if hasattr(model, "post_load_weights"):
                 model.post_load_weights()
@@ -2238,7 +2239,7 @@ class RemoteInstanceModelLoader(BaseModelLoader):
         torch.distributed.distributed_c10d.destroy_process_group(
             client._model_update_group
         )
-        torch.cuda.empty_cache()
+        current_platform.empty_cache()
 
     def load_model_from_remote_instance_by_transfer_engine(
         self, model, transfer_engine, seed_url, tp_rank

--- a/python/sglang/srt/models/apertus.py
+++ b/python/sglang/srt/models/apertus.py
@@ -21,6 +21,7 @@ import logging
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import torch
+from sglang.srt.platforms import current_platform
 from torch import nn
 from transformers import ApertusConfig
 
@@ -646,8 +647,8 @@ class ApertusForCausalLM(nn.Module):
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def get_embed(self):
         return self.model.embed_tokens.weight
@@ -661,8 +662,8 @@ class ApertusForCausalLM(nn.Module):
             return
         del self.model.embed_tokens.weight
         self.model.embed_tokens.weight = embed
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def load_kv_cache_scales(self, quantization_param_path: str) -> None:
         self.model.load_kv_cache_scales(quantization_param_path)

--- a/python/sglang/srt/models/bailing_moe.py
+++ b/python/sglang/srt/models/bailing_moe.py
@@ -23,6 +23,7 @@ import logging
 from typing import Iterable, List, Optional, Tuple, Union
 
 import torch
+from sglang.srt.platforms import current_platform
 import torch.nn.functional as F
 from torch import nn
 from transformers import PretrainedConfig
@@ -859,8 +860,8 @@ class BailingMoEForCausalLM(nn.Module):
         del self.lm_head.weight
         self.model.word_embeddings.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     @torch.no_grad()
     def forward(

--- a/python/sglang/srt/models/bailing_moe_nextn.py
+++ b/python/sglang/srt/models/bailing_moe_nextn.py
@@ -23,6 +23,7 @@ import logging
 from typing import Iterable, Optional, Tuple
 
 import torch
+from sglang.srt.platforms import current_platform
 from torch import nn
 from transformers import PretrainedConfig
 
@@ -237,8 +238,8 @@ class BailingMoeForCausalLMNextN(nn.Module):
         del self.lm_head.weight
         self.model.word_embeddings.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         self.base_load_weights_func(self, weights, is_nextn=True)

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -23,6 +23,7 @@ from contextlib import nullcontext
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import torch
+from sglang.srt.platforms import current_platform
 import torch.nn.functional as F
 from torch import nn
 from transformers import PretrainedConfig
@@ -2342,8 +2343,8 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     @classmethod
     def get_model_config_for_expert_location(cls, config):

--- a/python/sglang/srt/models/ernie4_eagle.py
+++ b/python/sglang/srt/models/ernie4_eagle.py
@@ -17,6 +17,7 @@
 from typing import Iterable, Optional, Tuple
 
 import torch
+from sglang.srt.platforms import current_platform
 from torch import nn
 from transformers.models.ernie4_5_moe.configuration_ernie4_5_moe import (
     Ernie4_5_MoeConfig,
@@ -196,8 +197,8 @@ class Ernie4_5_MoeForCausalLMMTP(nn.Module):
         else:
             del self.lm_head.weight
             self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
 
 EntryClass = [Ernie4_5_MoeForCausalLMMTP]

--- a/python/sglang/srt/models/exaone4.py
+++ b/python/sglang/srt/models/exaone4.py
@@ -2,6 +2,7 @@ from collections.abc import Iterable
 from typing import Any, List, Optional, Tuple, Union
 
 import torch
+from sglang.srt.platforms import current_platform
 from torch import nn
 from transformers import Exaone4Config
 
@@ -694,8 +695,8 @@ class Exaone4ForCausalLM(nn.Module):
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def get_embed(self):
         return self.model.embed_tokens.weight
@@ -709,8 +710,8 @@ class Exaone4ForCausalLM(nn.Module):
             return
         del self.model.embed_tokens.weight
         self.model.embed_tokens.weight = embed
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def load_kv_cache_scales(self, quantization_param_path: str) -> None:
         self.model.load_kv_cache_scales(quantization_param_path)

--- a/python/sglang/srt/models/exaone_moe.py
+++ b/python/sglang/srt/models/exaone_moe.py
@@ -21,6 +21,7 @@ from collections.abc import Iterable
 from typing import Any, Dict, Optional, Tuple, Union
 
 import torch
+from sglang.srt.platforms import current_platform
 from torch import nn
 from transformers import PretrainedConfig
 
@@ -762,8 +763,8 @@ class ExaoneMoEForCausalLM(nn.Module):
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def load_weights(
         self, weights: Iterable[Tuple[str, torch.Tensor]], is_mtp: bool = False

--- a/python/sglang/srt/models/falcon_h1.py
+++ b/python/sglang/srt/models/falcon_h1.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any, Iterable, List, Optional, Set, Tuple
 
 import torch
+from sglang.srt.platforms import current_platform
 from torch import nn
 
 from sglang.srt.configs.falcon_h1 import FalconH1Config
@@ -508,8 +509,8 @@ class FalconH1ForCausalLM(nn.Module):
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def load_weights(
         self, weights: Iterable[Tuple[str, torch.Tensor]], is_mtp: bool = False

--- a/python/sglang/srt/models/glm4.py
+++ b/python/sglang/srt/models/glm4.py
@@ -21,6 +21,7 @@ import logging
 from typing import Any, Dict, Iterable, Optional, Tuple, Union
 
 import torch
+from sglang.srt.platforms import current_platform
 from torch import nn
 
 from sglang.srt.distributed import (
@@ -627,8 +628,8 @@ class Glm4ForCausalLM(nn.Module):
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def load_kv_cache_scales(self, quantization_param_path: str) -> None:
         self.model.load_kv_cache_scales(quantization_param_path)

--- a/python/sglang/srt/models/glm4_moe.py
+++ b/python/sglang/srt/models/glm4_moe.py
@@ -19,6 +19,7 @@ import re
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import torch
+from sglang.srt.platforms import current_platform
 import torch.nn.functional as F
 from torch import nn
 from transformers import PretrainedConfig
@@ -1454,8 +1455,8 @@ class Glm4MoeForCausalLM(nn.Module):
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     @classmethod
     def get_model_config_for_expert_location(cls, config):

--- a/python/sglang/srt/models/glm4v.py
+++ b/python/sglang/srt/models/glm4v.py
@@ -22,6 +22,7 @@ from functools import lru_cache
 from typing import Iterable, List, Optional, Tuple
 
 import torch
+from sglang.srt.platforms import current_platform
 import torch.nn as nn
 import torch.nn.functional as F
 from einops import rearrange
@@ -813,8 +814,8 @@ class Glm4vForConditionalGeneration(nn.Module):
         else:
             del self.lm_head.weight
             self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
 
 EntryClass = [Glm4vForConditionalGeneration]

--- a/python/sglang/srt/models/gpt_oss.py
+++ b/python/sglang/srt/models/gpt_oss.py
@@ -23,6 +23,7 @@ from functools import partial
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
+from sglang.srt.platforms import current_platform
 from torch import nn
 from transformers import PretrainedConfig
 
@@ -1185,8 +1186,8 @@ class GptOssForCausalLM(nn.Module):
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def set_eagle3_layers_to_capture(self, layer_ids: Optional[List[int]] = None):
         if not self.pp_group.is_last_rank:

--- a/python/sglang/srt/models/hunyuan_v3.py
+++ b/python/sglang/srt/models/hunyuan_v3.py
@@ -15,6 +15,7 @@
 from typing import Iterable, Optional, Tuple
 
 import torch
+from sglang.srt.platforms import current_platform
 from torch import nn
 from transformers import PretrainedConfig
 
@@ -506,8 +507,8 @@ class HYV3ForCausalLM(nn.Module):
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [

--- a/python/sglang/srt/models/hunyuan_v3_nextn.py
+++ b/python/sglang/srt/models/hunyuan_v3_nextn.py
@@ -18,6 +18,7 @@ import logging
 from typing import Iterable, Optional, Tuple
 
 import torch
+from sglang.srt.platforms import current_platform
 from torch import nn
 from transformers import PretrainedConfig
 
@@ -155,8 +156,8 @@ class HYV3ForCausalLMNextN(nn.Module):
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         nextn_layer_id = self.config.num_hidden_layers

--- a/python/sglang/srt/models/llada2.py
+++ b/python/sglang/srt/models/llada2.py
@@ -23,6 +23,7 @@ import logging
 from typing import Iterable, Optional, Tuple, Union
 
 import torch
+from sglang.srt.platforms import current_platform
 import torch.nn.functional as F
 from torch import nn
 from transformers import PretrainedConfig
@@ -820,8 +821,8 @@ class LLaDA2MoeModelLM(nn.Module):
         del self.lm_head.weight
         self.model.word_embeddings.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     @torch.no_grad()
     def forward(

--- a/python/sglang/srt/models/llama.py
+++ b/python/sglang/srt/models/llama.py
@@ -20,6 +20,7 @@ import logging
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import torch
+from sglang.srt.platforms import current_platform
 from torch import nn
 from transformers import LlamaConfig
 
@@ -761,8 +762,8 @@ class LlamaForCausalLM(nn.Module):
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def get_embed(self):
         return self.model.embed_tokens.weight
@@ -776,8 +777,8 @@ class LlamaForCausalLM(nn.Module):
             return
         del self.model.embed_tokens.weight
         self.model.embed_tokens.weight = embed
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def load_kv_cache_scales(self, quantization_param_path: str) -> None:
         self.model.load_kv_cache_scales(quantization_param_path)

--- a/python/sglang/srt/models/longcat_flash.py
+++ b/python/sglang/srt/models/longcat_flash.py
@@ -35,6 +35,7 @@ import logging
 from typing import Iterable, List, Optional, Tuple
 
 import torch
+from sglang.srt.platforms import current_platform
 from torch import nn
 
 from sglang.srt.configs import LongcatFlashConfig
@@ -1044,8 +1045,8 @@ class LongcatFlashForCausalLM(nn.Module):
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     @classmethod
     def get_model_config_for_expert_location(cls, config):

--- a/python/sglang/srt/models/mimo.py
+++ b/python/sglang/srt/models/mimo.py
@@ -3,6 +3,7 @@
 from typing import Iterable, Optional, Tuple
 
 import torch
+from sglang.srt.platforms import current_platform
 from torch import nn
 
 from sglang.srt.layers.logits_processor import LogitsProcessor
@@ -150,8 +151,8 @@ class MiMoForCausalLM(nn.Module):
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def load_kv_cache_scales(self, quantization_param_path: str) -> None:
         self.model.load_kv_cache_scales(quantization_param_path)

--- a/python/sglang/srt/models/mimo_mtp.py
+++ b/python/sglang/srt/models/mimo_mtp.py
@@ -3,6 +3,7 @@
 from typing import Iterable, Optional, Tuple
 
 import torch
+from sglang.srt.platforms import current_platform
 from torch import nn
 from transformers import PretrainedConfig
 
@@ -196,8 +197,8 @@ class MiMoMTP(nn.Module):
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
 
 EntryClass = MiMoMTP

--- a/python/sglang/srt/models/mimo_v2.py
+++ b/python/sglang/srt/models/mimo_v2.py
@@ -16,6 +16,7 @@ import logging
 from typing import Any, Dict, Iterable, Optional, Tuple, Union
 
 import torch
+from sglang.srt.platforms import current_platform
 import torch.nn.functional as F
 from torch import nn
 
@@ -1172,8 +1173,8 @@ class MiMoV2ForCausalLM(nn.Module):
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def load_kv_cache_scales(self, quantization_param_path: str) -> None:
         self.model.load_kv_cache_scales(quantization_param_path)

--- a/python/sglang/srt/models/mimo_v2_nextn.py
+++ b/python/sglang/srt/models/mimo_v2_nextn.py
@@ -16,6 +16,7 @@ import logging
 from typing import Iterable, Optional, Tuple
 
 import torch
+from sglang.srt.platforms import current_platform
 from torch import nn
 from transformers import PretrainedConfig
 
@@ -382,8 +383,8 @@ class MiMoV2MTP(MiMoV2ForCausalLM):
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
 
 EntryClass = MiMoV2MTP

--- a/python/sglang/srt/models/nemotron_h.py
+++ b/python/sglang/srt/models/nemotron_h.py
@@ -19,6 +19,7 @@ from collections.abc import Iterable
 from typing import Optional, Union
 
 import torch
+from sglang.srt.platforms import current_platform
 from torch import nn
 
 from sglang.srt.compilation.compilation_config import register_split_op
@@ -781,8 +782,8 @@ class NemotronHForCausalLM(nn.Module):
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def load_weights(
         self, weights: Iterable[tuple[str, torch.Tensor]], is_mtp: bool = False

--- a/python/sglang/srt/models/opt.py
+++ b/python/sglang/srt/models/opt.py
@@ -19,6 +19,7 @@ from collections.abc import Iterable
 from typing import Optional, Union
 
 import torch
+from sglang.srt.platforms import current_platform
 from torch import nn
 from transformers import OPTConfig
 
@@ -613,8 +614,8 @@ class OPTForCausalLM(nn.Module):
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def get_embed(self):
         return self.model.embed_tokens.weight
@@ -628,8 +629,8 @@ class OPTForCausalLM(nn.Module):
             return
         del self.model.embed_tokens.weight
         self.model.embed_tokens.weight = embed
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def load_kv_cache_scales(self, quantization_param_path: str) -> None:
         self.model.load_kv_cache_scales(quantization_param_path)

--- a/python/sglang/srt/models/qwen2.py
+++ b/python/sglang/srt/models/qwen2.py
@@ -20,6 +20,7 @@ import logging
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import torch
+from sglang.srt.platforms import current_platform
 from torch import nn
 
 from sglang.srt.distributed import (
@@ -631,8 +632,8 @@ class Qwen2ForCausalLM(nn.Module):
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def load_kv_cache_scales(self, quantization_param_path: str) -> None:
         self.model.load_kv_cache_scales(quantization_param_path)

--- a/python/sglang/srt/models/qwen3.py
+++ b/python/sglang/srt/models/qwen3.py
@@ -3,6 +3,7 @@ import logging
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import torch
+from sglang.srt.platforms import current_platform
 from torch import nn
 
 from sglang.srt.distributed import (
@@ -673,8 +674,8 @@ class Qwen3ForCausalLM(nn.Module):
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def load_kv_cache_scales(self, quantization_param_path: str) -> None:
         self.model.load_kv_cache_scales(quantization_param_path)

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -19,6 +19,7 @@ from functools import lru_cache
 from typing import Iterable, Optional, Set, Tuple, Union
 
 import torch
+from sglang.srt.platforms import current_platform
 import torch.nn as nn
 import triton
 
@@ -1427,8 +1428,8 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
         if self.pp_group.is_last_rank and head is not None:
             del self.lm_head.weight
             self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
@@ -1573,8 +1574,8 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
         if self.pp_group.is_last_rank and head is not None:
             del self.lm_head.weight
             self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [

--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -19,6 +19,7 @@ from contextlib import ExitStack
 from typing import Iterable, Optional, Tuple
 
 import torch
+from sglang.srt.platforms import current_platform
 from torch import nn
 from transformers import PretrainedConfig
 
@@ -114,8 +115,8 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
 
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     @torch.no_grad()
     def forward(

--- a/python/sglang/srt/models/qwen3_next.py
+++ b/python/sglang/srt/models/qwen3_next.py
@@ -3,6 +3,7 @@ import logging
 from typing import Any, Iterable, Optional, Set, Tuple
 
 import torch
+from sglang.srt.platforms import current_platform
 import triton
 from torch import nn
 
@@ -1009,8 +1010,8 @@ class Qwen3NextForCausalLM(nn.Module):
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def get_embed(self):
         return self.model.embed_tokens.weight
@@ -1024,8 +1025,8 @@ class Qwen3NextForCausalLM(nn.Module):
             return
         del self.model.embed_tokens.weight
         self.model.embed_tokens.weight = embed
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def load_weights(
         self, weights: Iterable[Tuple[str, torch.Tensor]], is_mtp: bool = False

--- a/python/sglang/srt/models/step3p5.py
+++ b/python/sglang/srt/models/step3p5.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Iterable, Optional, Tuple, Union
 
 import torch
+from sglang.srt.platforms import current_platform
 import torch.nn.functional as F
 from torch import nn
 
@@ -1030,8 +1031,8 @@ class Step3p5ForCausalLM(nn.Module):
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
 
 EntryClass = Step3p5ForCausalLM

--- a/python/sglang/srt/platforms/__init__.py
+++ b/python/sglang/srt/platforms/__init__.py
@@ -12,8 +12,9 @@ Usage:
 
 import logging
 import pkgutil
-from importlib import import_module
 from importlib.metadata import entry_points
+
+import torch
 
 from sglang.srt.environ import envs
 from sglang.srt.platforms.interface import CudaSRTPlatform, SRTPlatform
@@ -25,7 +26,6 @@ _current_platform: SRTPlatform | None = None
 
 
 def _is_cuda_available() -> bool:
-    torch = import_module("torch")
     return bool(torch.cuda.is_available() and torch.version.hip is None)
 
 

--- a/python/sglang/srt/platforms/__init__.py
+++ b/python/sglang/srt/platforms/__init__.py
@@ -26,7 +26,7 @@ _current_platform: SRTPlatform | None = None
 
 def _is_cuda_available() -> bool:
     torch = import_module("torch")
-    return bool(torch.cuda.is_available())
+    return bool(torch.cuda.is_available() and torch.version.hip is None)
 
 
 def _resolve_platform() -> SRTPlatform:
@@ -45,7 +45,8 @@ def _resolve_platform() -> SRTPlatform:
 
        SGLANG_PLATFORM unset (auto-discover):
          - Import and activate all discovered plugins
-         - 0 activated → fallback base SRTPlatform
+        - 0 activated + CUDA available → fallback CudaSRTPlatform
+        - 0 activated + no CUDA → fallback base SRTPlatform
          - 1 activated → use it
          - N activated → RuntimeError (must set SGLANG_PLATFORM)
 

--- a/python/sglang/srt/platforms/__init__.py
+++ b/python/sglang/srt/platforms/__init__.py
@@ -12,15 +12,21 @@ Usage:
 
 import logging
 import pkgutil
+from importlib import import_module
 from importlib.metadata import entry_points
 
 from sglang.srt.environ import envs
-from sglang.srt.platforms.interface import SRTPlatform
+from sglang.srt.platforms.interface import CudaSRTPlatform, SRTPlatform
 from sglang.srt.plugins import PLATFORM_PLUGINS_GROUP, load_plugins_by_group
 
 logger = logging.getLogger(__name__)
 
 _current_platform: SRTPlatform | None = None
+
+
+def _is_cuda_available() -> bool:
+    torch = import_module("torch")
+    return bool(torch.cuda.is_available())
 
 
 def _resolve_platform() -> SRTPlatform:
@@ -90,7 +96,10 @@ def _resolve_platform() -> SRTPlatform:
             logger.exception("Failed to activate platform plugin: %s", name)
 
     if len(activated) == 0:
-        logger.debug("No platform detected. Using base SRTPlatform with defaults.")
+        if _is_cuda_available():
+            logger.debug("No platform plugin detected. Using CUDA SRTPlatform defaults.")
+            return CudaSRTPlatform()
+        logger.debug("No platform detected. Using base SRTPlatform.")
         return SRTPlatform()
 
     if len(activated) == 1:

--- a/python/sglang/srt/platforms/cuda.py
+++ b/python/sglang/srt/platforms/cuda.py
@@ -10,7 +10,7 @@ from sglang.srt.platforms.device_mixin import (
 )
 
 if TYPE_CHECKING:
-    import torch
+    import torch  # pyright: ignore[reportMissingImports]
 
 
 def _import_torch() -> Any:

--- a/python/sglang/srt/platforms/cuda.py
+++ b/python/sglang/srt/platforms/cuda.py
@@ -1,20 +1,14 @@
 """CUDA device operations for the SRT platform layer."""
 
-import importlib
-from typing import TYPE_CHECKING, Any, Optional
+from typing import Optional
+
+import torch
 
 from sglang.srt.platforms.device_mixin import (
     DeviceCapability,
     DeviceMixin,
     PlatformEnum,
 )
-
-if TYPE_CHECKING:
-    import torch  # pyright: ignore[reportMissingImports]
-
-
-def _import_torch() -> Any:
-    return importlib.import_module("torch")
 
 
 class CudaDeviceMixin(DeviceMixin):
@@ -25,42 +19,33 @@ class CudaDeviceMixin(DeviceMixin):
     device_type: str = "cuda"
 
     def get_device_total_memory(self, device_id: int = 0) -> int:
-        torch = _import_torch()
         return int(torch.cuda.get_device_properties(device_id).total_memory)
 
     def get_current_memory_usage(
         self, device: Optional["torch.device"] = None
     ) -> float:
-        torch = _import_torch()
         return float(torch.cuda.max_memory_allocated(device))
 
     def get_device(self, local_rank: int) -> "torch.device":
-        torch = _import_torch()
         return torch.device("cuda", local_rank)
 
     def set_device(self, device: "torch.device") -> None:
-        torch = _import_torch()
         torch.cuda.set_device(device)
 
     def get_device_name(self, device_id: int = 0) -> str:
-        torch = _import_torch()
         return str(torch.cuda.get_device_name(device_id))
 
     def get_device_capability(self, device_id: int = 0) -> DeviceCapability:
-        torch = _import_torch()
         major, minor = torch.cuda.get_device_capability(device_id)
         return DeviceCapability(major, minor)
 
     def empty_cache(self) -> None:
-        torch = _import_torch()
         torch.cuda.empty_cache()
 
     def synchronize(self) -> None:
-        torch = _import_torch()
         torch.cuda.synchronize()
 
     def get_available_memory(self, device_id: int = 0) -> tuple[int, int]:
-        torch = _import_torch()
         return torch.cuda.mem_get_info(device_id)
 
     def get_torch_distributed_backend_str(self) -> str:

--- a/python/sglang/srt/platforms/cuda.py
+++ b/python/sglang/srt/platforms/cuda.py
@@ -1,0 +1,67 @@
+"""CUDA device operations for the SRT platform layer."""
+
+import importlib
+from typing import TYPE_CHECKING, Any, Optional
+
+from sglang.srt.platforms.device_mixin import (
+    DeviceCapability,
+    DeviceMixin,
+    PlatformEnum,
+)
+
+if TYPE_CHECKING:
+    import torch
+
+
+def _import_torch() -> Any:
+    return importlib.import_module("torch")
+
+
+class CudaDeviceMixin(DeviceMixin):
+    """CUDA implementation of the shared device operations."""
+
+    _enum: PlatformEnum = PlatformEnum.CUDA
+    device_name: str = "cuda"
+    device_type: str = "cuda"
+
+    def get_device_total_memory(self, device_id: int = 0) -> int:
+        torch = _import_torch()
+        return int(torch.cuda.get_device_properties(device_id).total_memory)
+
+    def get_current_memory_usage(
+        self, device: Optional["torch.device"] = None
+    ) -> float:
+        torch = _import_torch()
+        return float(torch.cuda.max_memory_allocated(device))
+
+    def get_device(self, local_rank: int) -> "torch.device":
+        torch = _import_torch()
+        return torch.device("cuda", local_rank)
+
+    def set_device(self, device: "torch.device") -> None:
+        torch = _import_torch()
+        torch.cuda.set_device(device)
+
+    def get_device_name(self, device_id: int = 0) -> str:
+        torch = _import_torch()
+        return str(torch.cuda.get_device_name(device_id))
+
+    def get_device_capability(self, device_id: int = 0) -> DeviceCapability:
+        torch = _import_torch()
+        major, minor = torch.cuda.get_device_capability(device_id)
+        return DeviceCapability(major, minor)
+
+    def empty_cache(self) -> None:
+        torch = _import_torch()
+        torch.cuda.empty_cache()
+
+    def synchronize(self) -> None:
+        torch = _import_torch()
+        torch.cuda.synchronize()
+
+    def get_available_memory(self, device_id: int = 0) -> tuple[int, int]:
+        torch = _import_torch()
+        return torch.cuda.mem_get_info(device_id)
+
+    def get_torch_distributed_backend_str(self) -> str:
+        return "nccl"

--- a/python/sglang/srt/platforms/device_mixin.py
+++ b/python/sglang/srt/platforms/device_mixin.py
@@ -27,7 +27,10 @@ Method status annotations:
 
 import enum
 import importlib
-from typing import Any, NamedTuple, Optional
+from typing import TYPE_CHECKING, NamedTuple, Optional
+
+if TYPE_CHECKING:
+    import torch  # pyright: ignore[reportMissingImports]
 
 
 class PlatformEnum(enum.Enum):
@@ -138,7 +141,9 @@ class DeviceMixin:
         """[Active] Get total device memory in bytes."""
         raise NotImplementedError
 
-    def get_current_memory_usage(self, device: Optional[Any] = None) -> float:
+    def get_current_memory_usage(
+        self, device: Optional["torch.device"] = None
+    ) -> float:
         """[Active] Get current peak memory usage in bytes."""
         raise NotImplementedError
 
@@ -150,11 +155,11 @@ class DeviceMixin:
 
     # ---- Device management ----
 
-    def get_device(self, local_rank: int) -> Any:
+    def get_device(self, local_rank: int) -> "torch.device":
         """[Planned] Return ``torch.device`` for the given local rank."""
         raise NotImplementedError
 
-    def set_device(self, device: Any) -> None:
+    def set_device(self, device: "torch.device") -> None:
         """[Planned] Set the current device."""
         raise NotImplementedError
 
@@ -199,7 +204,7 @@ class DeviceMixin:
     @classmethod
     def inference_mode(cls):
         """[Planned] Return inference mode context manager."""
-        torch = _import_torch()
+        torch = importlib.import_module("torch")
         return torch.inference_mode(mode=True)
 
     @classmethod
@@ -209,7 +214,7 @@ class DeviceMixin:
             import random
 
             np = importlib.import_module("numpy")
-            torch = _import_torch()
+            torch = importlib.import_module("torch")
 
             random.seed(seed)
             np.random.seed(seed)
@@ -237,55 +242,3 @@ class DeviceMixin:
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(device={self.device_name})"
-
-
-def _import_torch() -> Any:
-    return importlib.import_module("torch")
-
-
-class CudaDeviceMixin(DeviceMixin):
-    """CUDA implementation of the shared device operations."""
-
-    _enum: PlatformEnum = PlatformEnum.CUDA
-    device_name: str = "cuda"
-    device_type: str = "cuda"
-
-    def get_device_total_memory(self, device_id: int = 0) -> int:
-        torch = _import_torch()
-        return int(torch.cuda.get_device_properties(device_id).total_memory)
-
-    def get_current_memory_usage(self, device: Optional[Any] = None) -> float:
-        torch = _import_torch()
-        return float(torch.cuda.max_memory_allocated(device))
-
-    def get_device(self, local_rank: int) -> Any:
-        torch = _import_torch()
-        return torch.device("cuda", local_rank)
-
-    def set_device(self, device: Any) -> None:
-        torch = _import_torch()
-        torch.cuda.set_device(device)
-
-    def get_device_name(self, device_id: int = 0) -> str:
-        torch = _import_torch()
-        return str(torch.cuda.get_device_name(device_id))
-
-    def get_device_capability(self, device_id: int = 0) -> DeviceCapability:
-        torch = _import_torch()
-        major, minor = torch.cuda.get_device_capability(device_id)
-        return DeviceCapability(major, minor)
-
-    def empty_cache(self) -> None:
-        torch = _import_torch()
-        torch.cuda.empty_cache()
-
-    def synchronize(self) -> None:
-        torch = _import_torch()
-        torch.cuda.synchronize()
-
-    def get_available_memory(self, device_id: int = 0) -> tuple[int, int]:
-        torch = _import_torch()
-        return torch.cuda.mem_get_info(device_id)
-
-    def get_torch_distributed_backend_str(self) -> str:
-        return "nccl"

--- a/python/sglang/srt/platforms/device_mixin.py
+++ b/python/sglang/srt/platforms/device_mixin.py
@@ -26,11 +26,11 @@ Method status annotations:
 """
 
 import enum
-import importlib
-from typing import TYPE_CHECKING, NamedTuple, Optional
+import random
+from typing import NamedTuple, Optional
 
-if TYPE_CHECKING:
-    import torch  # pyright: ignore[reportMissingImports]
+import numpy as np
+import torch
 
 
 class PlatformEnum(enum.Enum):
@@ -204,18 +204,12 @@ class DeviceMixin:
     @classmethod
     def inference_mode(cls):
         """[Planned] Return inference mode context manager."""
-        torch = importlib.import_module("torch")
         return torch.inference_mode(mode=True)
 
     @classmethod
     def seed_everything(cls, seed: int | None = None) -> None:
         """[Planned] Set random seeds for reproducibility across all libraries."""
         if seed is not None:
-            import random
-
-            np = importlib.import_module("numpy")
-            torch = importlib.import_module("torch")
-
             random.seed(seed)
             np.random.seed(seed)
             torch.manual_seed(seed)

--- a/python/sglang/srt/platforms/device_mixin.py
+++ b/python/sglang/srt/platforms/device_mixin.py
@@ -26,10 +26,8 @@ Method status annotations:
 """
 
 import enum
-from typing import TYPE_CHECKING, NamedTuple, Optional
-
-if TYPE_CHECKING:
-    import torch
+import importlib
+from typing import Any, NamedTuple, Optional
 
 
 class PlatformEnum(enum.Enum):
@@ -140,9 +138,7 @@ class DeviceMixin:
         """[Active] Get total device memory in bytes."""
         raise NotImplementedError
 
-    def get_current_memory_usage(
-        self, device: Optional["torch.device"] = None
-    ) -> float:
+    def get_current_memory_usage(self, device: Optional[Any] = None) -> float:
         """[Active] Get current peak memory usage in bytes."""
         raise NotImplementedError
 
@@ -154,11 +150,11 @@ class DeviceMixin:
 
     # ---- Device management ----
 
-    def get_device(self, local_rank: int) -> "torch.device":
+    def get_device(self, local_rank: int) -> Any:
         """[Planned] Return ``torch.device`` for the given local rank."""
         raise NotImplementedError
 
-    def set_device(self, device: "torch.device") -> None:
+    def set_device(self, device: Any) -> None:
         """[Planned] Set the current device."""
         raise NotImplementedError
 
@@ -203,8 +199,7 @@ class DeviceMixin:
     @classmethod
     def inference_mode(cls):
         """[Planned] Return inference mode context manager."""
-        import torch
-
+        torch = _import_torch()
         return torch.inference_mode(mode=True)
 
     @classmethod
@@ -213,8 +208,8 @@ class DeviceMixin:
         if seed is not None:
             import random
 
-            import numpy as np
-            import torch
+            np = importlib.import_module("numpy")
+            torch = _import_torch()
 
             random.seed(seed)
             np.random.seed(seed)
@@ -242,3 +237,55 @@ class DeviceMixin:
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(device={self.device_name})"
+
+
+def _import_torch() -> Any:
+    return importlib.import_module("torch")
+
+
+class CudaDeviceMixin(DeviceMixin):
+    """CUDA implementation of the shared device operations."""
+
+    _enum: PlatformEnum = PlatformEnum.CUDA
+    device_name: str = "cuda"
+    device_type: str = "cuda"
+
+    def get_device_total_memory(self, device_id: int = 0) -> int:
+        torch = _import_torch()
+        return int(torch.cuda.get_device_properties(device_id).total_memory)
+
+    def get_current_memory_usage(self, device: Optional[Any] = None) -> float:
+        torch = _import_torch()
+        return float(torch.cuda.max_memory_allocated(device))
+
+    def get_device(self, local_rank: int) -> Any:
+        torch = _import_torch()
+        return torch.device("cuda", local_rank)
+
+    def set_device(self, device: Any) -> None:
+        torch = _import_torch()
+        torch.cuda.set_device(device)
+
+    def get_device_name(self, device_id: int = 0) -> str:
+        torch = _import_torch()
+        return str(torch.cuda.get_device_name(device_id))
+
+    def get_device_capability(self, device_id: int = 0) -> DeviceCapability:
+        torch = _import_torch()
+        major, minor = torch.cuda.get_device_capability(device_id)
+        return DeviceCapability(major, minor)
+
+    def empty_cache(self) -> None:
+        torch = _import_torch()
+        torch.cuda.empty_cache()
+
+    def synchronize(self) -> None:
+        torch = _import_torch()
+        torch.cuda.synchronize()
+
+    def get_available_memory(self, device_id: int = 0) -> tuple[int, int]:
+        torch = _import_torch()
+        return torch.cuda.mem_get_info(device_id)
+
+    def get_torch_distributed_backend_str(self) -> str:
+        return "nccl"

--- a/python/sglang/srt/platforms/interface.py
+++ b/python/sglang/srt/platforms/interface.py
@@ -7,18 +7,13 @@ and adds SRT-specific subsystem factory methods, capability flags, and
 configuration lifecycle hooks.
 
 Out-of-tree platforms register via setuptools entry_points under the
-"sglang.platform_plugins" group and should subclass SRTPlatform.
+"sglang.srt.platforms" group and should subclass SRTPlatform.
 """
 
-from typing import TYPE_CHECKING
-
-from sglang.srt.platforms.device_mixin import DeviceMixin, PlatformEnum
-
-if TYPE_CHECKING:
-    pass
+from sglang.srt.platforms.device_mixin import CudaDeviceMixin, DeviceMixin, PlatformEnum
 
 # Re-export for convenience
-__all__ = ["SRTPlatform", "PlatformEnum"]
+__all__ = ["CudaSRTPlatform", "SRTPlatform", "PlatformEnum"]
 
 
 class SRTPlatform(DeviceMixin):
@@ -131,3 +126,9 @@ class SRTPlatform(DeviceMixin):
         E.g. "cuda", "npu", "hip", "xpu", "cpu".
         """
         return "native"
+
+
+class CudaSRTPlatform(CudaDeviceMixin, SRTPlatform):
+    """Default in-tree CUDA SRT platform."""
+
+    pass

--- a/python/sglang/srt/platforms/interface.py
+++ b/python/sglang/srt/platforms/interface.py
@@ -10,7 +10,8 @@ Out-of-tree platforms register via setuptools entry_points under the
 "sglang.srt.platforms" group and should subclass SRTPlatform.
 """
 
-from sglang.srt.platforms.device_mixin import CudaDeviceMixin, DeviceMixin, PlatformEnum
+from sglang.srt.platforms.cuda import CudaDeviceMixin
+from sglang.srt.platforms.device_mixin import DeviceMixin, PlatformEnum
 
 # Re-export for convenience
 __all__ = ["CudaSRTPlatform", "SRTPlatform", "PlatformEnum"]

--- a/python/sglang/srt/platforms/interface.py
+++ b/python/sglang/srt/platforms/interface.py
@@ -131,5 +131,3 @@ class SRTPlatform(DeviceMixin):
 
 class CudaSRTPlatform(CudaDeviceMixin, SRTPlatform):
     """Default in-tree CUDA SRT platform."""
-
-    pass

--- a/test/registered/unit/platforms/test_platform_interface.py
+++ b/test/registered/unit/platforms/test_platform_interface.py
@@ -7,14 +7,17 @@ and the platform discovery / lazy initialization mechanism.
 
 from unittest.mock import MagicMock, patch
 
+import torch
+
 from sglang.srt.platforms import _load_platform_class, _resolve_platform
 from sglang.srt.platforms.device_mixin import (
+    CudaDeviceMixin,
     CpuArchEnum,
     DeviceCapability,
     DeviceMixin,
     PlatformEnum,
 )
-from sglang.srt.platforms.interface import SRTPlatform
+from sglang.srt.platforms.interface import CudaSRTPlatform, SRTPlatform
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -222,6 +225,81 @@ class TestSRTPlatform(CustomTestCase):
         base = SRTPlatform()
         self.assertEqual(base.get_compile_backend(mode="npugraph_ex"), "inductor")
 
+    def test_base_device_identity_stays_unspecified(self):
+        """The abstract SRT base should not claim any concrete in-tree device."""
+        base = SRTPlatform()
+        self.assertFalse(base.is_cuda())
+        self.assertFalse(base.is_cuda_alike())
+
+
+class TestCudaDeviceMixin(CustomTestCase):
+    """Tests for CUDA device operation defaults."""
+
+    def test_default_get_device_returns_cuda_device(self):
+        base = CudaSRTPlatform()
+        self.assertEqual(base.get_device(2), torch.device("cuda", 2))
+
+    def test_cuda_platform_identity(self):
+        base = CudaSRTPlatform()
+        self.assertTrue(base.is_cuda())
+        self.assertTrue(base.is_cuda_alike())
+        self.assertIsInstance(base, CudaDeviceMixin)
+
+    @patch("torch.cuda.get_device_properties")
+    def test_default_get_device_total_memory_uses_cuda(self, mock_get_device_properties):
+        mock_get_device_properties.return_value.total_memory = 123
+        base = CudaSRTPlatform()
+        self.assertEqual(base.get_device_total_memory(1), 123)
+        mock_get_device_properties.assert_called_once_with(1)
+
+    @patch("torch.cuda.max_memory_allocated", return_value=456)
+    def test_default_get_current_memory_usage_uses_cuda(self, mock_max_memory_allocated):
+        base = CudaSRTPlatform()
+        device = torch.device("cuda", 1)
+        self.assertEqual(base.get_current_memory_usage(device), 456.0)
+        mock_max_memory_allocated.assert_called_once_with(device)
+
+    @patch("torch.cuda.set_device")
+    def test_default_set_device_uses_cuda(self, mock_set_device):
+        base = CudaSRTPlatform()
+        device = torch.device("cuda", 1)
+        base.set_device(device)
+        mock_set_device.assert_called_once_with(device)
+
+    @patch("torch.cuda.get_device_name", return_value="NVIDIA H100")
+    def test_default_get_device_name_uses_cuda(self, mock_get_device_name):
+        base = CudaSRTPlatform()
+        self.assertEqual(base.get_device_name(1), "NVIDIA H100")
+        mock_get_device_name.assert_called_once_with(1)
+
+    @patch("torch.cuda.get_device_capability", return_value=(9, 0))
+    def test_default_get_device_capability_uses_cuda(self, mock_get_device_capability):
+        base = CudaSRTPlatform()
+        self.assertEqual(base.get_device_capability(1), DeviceCapability(9, 0))
+        mock_get_device_capability.assert_called_once_with(1)
+
+    @patch("torch.cuda.empty_cache")
+    def test_default_empty_cache_uses_cuda(self, mock_empty_cache):
+        base = CudaSRTPlatform()
+        base.empty_cache()
+        mock_empty_cache.assert_called_once_with()
+
+    @patch("torch.cuda.synchronize")
+    def test_default_synchronize_uses_cuda(self, mock_synchronize):
+        base = CudaSRTPlatform()
+        base.synchronize()
+        mock_synchronize.assert_called_once_with()
+
+    @patch("torch.cuda.mem_get_info", return_value=(123, 456), create=True)
+    def test_default_get_available_memory_uses_cuda(self, mock_mem_get_info):
+        base = CudaSRTPlatform()
+        self.assertEqual(base.get_available_memory(1), (123, 456))
+        mock_mem_get_info.assert_called_once_with(1)
+
+    def test_default_distributed_backend_is_nccl(self):
+        base = CudaSRTPlatform()
+        self.assertEqual(base.get_torch_distributed_backend_str(), "nccl")
+
 
 class TestSRTPlatformOverrides(CustomTestCase):
     """Tests for SRTPlatform method overrides via plugins."""
@@ -335,13 +413,31 @@ class TestResolvePlatformAutoDiscover(CustomTestCase):
             self.assertEqual(result, mock_instance)
 
     @patch("sglang.srt.platforms.load_plugins_by_group")
+    @patch("sglang.srt.platforms._is_cuda_available")
     @patch("sglang.srt.platforms.envs")
-    def test_no_plugin_activates_fallback(self, mock_envs, mock_load):
-        """When no plugin activates, return base SRTPlatform with warning."""
+    def test_no_plugin_activates_cuda_fallback(
+        self, mock_envs, mock_is_cuda_available, mock_load
+    ):
+        """When CUDA is available and no plugin activates, return CUDA defaults."""
         mock_envs.SGLANG_PLATFORM.get.return_value = ""
+        mock_is_cuda_available.return_value = True
+        mock_load.return_value = {}
+        result = _resolve_platform()
+        self.assertIsInstance(result, CudaSRTPlatform)
+
+    @patch("sglang.srt.platforms.load_plugins_by_group")
+    @patch("sglang.srt.platforms._is_cuda_available")
+    @patch("sglang.srt.platforms.envs")
+    def test_no_plugin_no_cuda_activates_base_fallback(
+        self, mock_envs, mock_is_cuda_available, mock_load
+    ):
+        """When no plugin or CUDA is available, return the abstract base platform."""
+        mock_envs.SGLANG_PLATFORM.get.return_value = ""
+        mock_is_cuda_available.return_value = False
         mock_load.return_value = {}
         result = _resolve_platform()
         self.assertIsInstance(result, SRTPlatform)
+        self.assertNotIsInstance(result, CudaSRTPlatform)
 
     @patch("sglang.srt.platforms.load_plugins_by_group")
     @patch("sglang.srt.platforms.envs")

--- a/test/registered/unit/platforms/test_platform_interface.py
+++ b/test/registered/unit/platforms/test_platform_interface.py
@@ -398,6 +398,18 @@ class TestResolvePlatformWithEnv(CustomTestCase):
 class TestResolvePlatformAutoDiscover(CustomTestCase):
     """Tests for _resolve_platform auto-discovery when SGLANG_PLATFORM is not set."""
 
+    @patch("sglang.srt.platforms.import_module")
+    def test_is_cuda_available_excludes_rocm(self, mock_import_module):
+        """ROCm exposes torch.cuda, but should not use the CUDA platform identity."""
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.version.hip = "6.0"
+        mock_import_module.return_value = mock_torch
+
+        import sglang.srt.platforms as plat_mod
+
+        self.assertFalse(plat_mod._is_cuda_available())
+
     @patch("sglang.srt.platforms.load_plugins_by_group")
     @patch("sglang.srt.platforms.envs")
     def test_single_plugin_activates(self, mock_envs, mock_load):

--- a/test/registered/unit/platforms/test_platform_interface.py
+++ b/test/registered/unit/platforms/test_platform_interface.py
@@ -10,8 +10,8 @@ from unittest.mock import MagicMock, patch
 import torch
 
 from sglang.srt.platforms import _load_platform_class, _resolve_platform
+from sglang.srt.platforms.cuda import CudaDeviceMixin
 from sglang.srt.platforms.device_mixin import (
-    CudaDeviceMixin,
     CpuArchEnum,
     DeviceCapability,
     DeviceMixin,

--- a/test/registered/unit/platforms/test_platform_interface.py
+++ b/test/registered/unit/platforms/test_platform_interface.py
@@ -398,13 +398,11 @@ class TestResolvePlatformWithEnv(CustomTestCase):
 class TestResolvePlatformAutoDiscover(CustomTestCase):
     """Tests for _resolve_platform auto-discovery when SGLANG_PLATFORM is not set."""
 
-    @patch("sglang.srt.platforms.import_module")
-    def test_is_cuda_available_excludes_rocm(self, mock_import_module):
+    @patch("sglang.srt.platforms.torch")
+    def test_is_cuda_available_excludes_rocm(self, mock_torch):
         """ROCm exposes torch.cuda, but should not use the CUDA platform identity."""
-        mock_torch = MagicMock()
         mock_torch.cuda.is_available.return_value = True
         mock_torch.version.hip = "6.0"
-        mock_import_module.return_value = mock_torch
 
         import sglang.srt.platforms as plat_mod
 


### PR DESCRIPTION
## Summary
- Replaces model-file `torch.cuda.empty_cache()` / `torch.cuda.synchronize()` barriers with `current_platform` device ops.
- Keeps the change mechanical and scoped to model weight-swap cleanup paths.

## Test plan
- `uv run --project python python -m py_compile <touched model files>`
- Confirmed no remaining `torch.cuda.empty_cache()` / `torch.cuda.synchronize()` in `python/sglang/srt/models`.