### PR TITLE
ci: add per-host utilization view to runner-utilization report

### DIFF
--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -157,6 +157,84 @@ def parse_time(time_str: str) -> datetime:
     return datetime.fromisoformat(time_str.replace("Z", "+00:00"))
 
 
+def calculate_concurrency_metrics(
+    jobs: list,
+    window_start: datetime,
+    window_end: datetime,
+    num_runners: int,
+) -> dict:
+    """Sweep-line algorithm: peak/avg concurrent, saturation time, peak queue."""
+    if not jobs:
+        return {
+            "peak_concurrent": 0,
+            "avg_concurrent": 0.0,
+            "saturation_seconds": 0,
+            "saturation_pct": 0.0,
+            "peak_queue": 0,
+        }
+    window_seconds = (window_end - window_start).total_seconds()
+    if window_seconds <= 0:
+        return {
+            "peak_concurrent": 0,
+            "avg_concurrent": 0.0,
+            "saturation_seconds": 0,
+            "saturation_pct": 0.0,
+            "peak_queue": 0,
+        }
+    running_events = []
+    for job in jobs:
+        start, end = job["start"], job["end"]
+        if end < window_start or start > window_end:
+            continue
+        running_events.append((max(start, window_start), 1))
+        running_events.append((min(end, window_end), -1))
+    queue_events = []
+    for job in jobs:
+        created_at = job.get("created_at")
+        started_at = job["start"]
+        if created_at and created_at < started_at:
+            if started_at < window_start or created_at > window_end:
+                continue
+            queue_events.append((max(created_at, window_start), 1))
+            queue_events.append((min(started_at, window_end), -1))
+    running_events.sort(key=lambda e: (e[0], e[1] == 1))
+    current_running = 0
+    peak_running = 0
+    prev_time = window_start
+    total_running_seconds = 0.0
+    saturation_seconds = 0.0
+    for event_time, delta in running_events:
+        td = (event_time - prev_time).total_seconds()
+        if td > 0:
+            total_running_seconds += current_running * td
+            if current_running >= num_runners:
+                saturation_seconds += td
+        current_running += delta
+        peak_running = max(peak_running, current_running)
+        prev_time = event_time
+    if prev_time < window_end:
+        td = (window_end - prev_time).total_seconds()
+        total_running_seconds += current_running * td
+        if current_running >= num_runners:
+            saturation_seconds += td
+    queue_events.sort(key=lambda e: (e[0], e[1] == 1))
+    current_queued = 0
+    peak_queue = 0
+    for _, delta in queue_events:
+        current_queued += delta
+        peak_queue = max(peak_queue, current_queued)
+    avg_concurrent = total_running_seconds / window_seconds if window_seconds > 0 else 0
+    return {
+        "peak_concurrent": peak_running,
+        "avg_concurrent": avg_concurrent,
+        "saturation_seconds": saturation_seconds,
+        "saturation_pct": (
+            (saturation_seconds / window_seconds * 100) if window_seconds > 0 else 0
+        ),
+        "peak_queue": peak_queue,
+    }
+
+
 _NON_GPU_WORKFLOW_HINTS = (
     "lint",
     "deploy",
@@ -375,15 +453,37 @@ def calculate_utilization(repo: str, hours: int = 24, runner_filter: str = None)
         avg_queue = sum(queue_times) / len(queue_times) if queue_times else 0
         max_queue = max(queue_times) if queue_times else 0
 
+        # Concurrency / saturation / queue-depth metrics. Use observed
+        # peak as effective capacity if it's lower than the API count
+        # (e.g. for autoscaling pools where most listeners sit idle).
+        conc_initial = calculate_concurrency_metrics(
+            jobs, window_start, window_end, num_runners
+        )
+        effective_runners = (
+            min(num_runners, conc_initial["peak_concurrent"]) or num_runners
+        )
+        if effective_runners < num_runners and effective_runners > 0:
+            conc = calculate_concurrency_metrics(
+                jobs, window_start, window_end, effective_runners
+            )
+        else:
+            conc = conc_initial
+
         results.append(
             {
                 "label": label,
                 "num_runners": num_runners,
+                "effective_runners": effective_runners,
                 "num_jobs": len(jobs),
                 "total_active_hours": active_seconds / 3600,
                 "utilization_pct": utilization,
                 "avg_queue_min": avg_queue / 60,
                 "max_queue_min": max_queue / 60,
+                "peak_concurrent": conc_initial["peak_concurrent"],
+                "avg_concurrent": conc["avg_concurrent"],
+                "saturation_hours": conc["saturation_seconds"] / 3600,
+                "saturation_pct": conc["saturation_pct"],
+                "peak_queue": conc["peak_queue"],
             }
         )
 
@@ -434,6 +534,64 @@ def format_report(
             f"{r['utilization_pct']:.1f}% {bar} | "
             f"{r['avg_queue_min']:.1f}m | {r['max_queue_min']:.1f}m |"
         )
+
+    # Concurrency Analysis section
+    lines.extend(
+        [
+            "",
+            "## Concurrency Analysis",
+            "",
+            "| Label | Runners (API/Effective) | Peak Concurrent | Avg Concurrent | Saturation Time | Peak Queue |",
+            "|-------|-------------------------|-----------------|----------------|-----------------|------------|",
+        ]
+    )
+    for r in results:
+        effective = r["effective_runners"]
+        avg_pct = (r["avg_concurrent"] / effective * 100) if effective > 0 else 0
+        runner_str = (
+            f"{r['num_runners']}/{effective}"
+            if effective != r["num_runners"]
+            else str(r["num_runners"])
+        )
+        lines.append(
+            f"| {r['label']} | {runner_str} | "
+            f"{r['peak_concurrent']} | "
+            f"{r['avg_concurrent']:.1f} ({avg_pct:.0f}%) | "
+            f"{r['saturation_hours']:.1f}h ({r['saturation_pct']:.0f}%) | "
+            f"{r['peak_queue']} jobs |"
+        )
+
+    # Recommendations
+    lines.extend(["", "## Recommendations", ""])
+    has_recs = False
+    for r in results:
+        label = r["label"]
+        sat_pct = r["saturation_pct"]
+        peak_q = r["peak_queue"]
+        effective = r["effective_runners"]
+        avg_pct = (r["avg_concurrent"] / effective * 100) if effective > 0 else 0
+        if sat_pct > 50 or peak_q > 5:
+            lines.append(
+                f"⚠️ **{label}**: High saturation ({sat_pct:.0f}%) "
+                f"with queue buildup ({peak_q} jobs). Consider adding runners."
+            )
+            has_recs = True
+        elif sat_pct > 20 or peak_q > 0:
+            lines.append(
+                f"📊 **{label}**: Moderate saturation ({sat_pct:.0f}%), "
+                f"peak queue {peak_q} jobs. Monitor for trends."
+            )
+            has_recs = True
+        elif avg_pct < 30 and r["num_jobs"] > 0:
+            lines.append(
+                f"💡 **{label}**: Low average utilization ({avg_pct:.0f}%). "
+                f"Runner pool may be oversized."
+            )
+            has_recs = True
+        else:
+            lines.append(f"✓ **{label}**: Healthy utilization with minimal queueing.")
+    if not has_recs and results:
+        lines.append("All runner pools have healthy utilization.")
 
     return "\n".join(lines)
 

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -57,7 +57,7 @@ def get_workflow_runs(repo: str, hours: int = 24) -> list[dict]:
         if len(page_runs) < 100:
             break
         page += 1
-        if page > 20:  # Safety limit
+        if page > 50:  # Safety limit (5000 runs)
             break
     return runs
 
@@ -76,7 +76,7 @@ def get_jobs_for_run(repo: str, run_id: int) -> list[dict]:
         if len(data.get("jobs", [])) < 100:
             break
         page += 1
-        if page > 5:  # Safety limit
+        if page > 20:  # Safety limit (2000 jobs per run)
             break
     return jobs
 
@@ -234,14 +234,14 @@ def calculate_utilization(repo: str, hours: int = 24, runner_filter: str = None)
 
     results = []
     for label in sorted(all_labels):
-        # Hosts that advertise this label (from API if available, else
-        # observed in job data).
-        if label in api_label_runners and api_label_runners[label]:
-            hosts = api_label_runners[label]
-        elif label in job_label_runners:
-            hosts = job_label_runners[label]
-        else:
-            hosts = set()
+        # Hosts to attribute to this label = union of currently-online
+        # runners advertising the label PLUS hosts that actually ran a
+        # job under it during the window. The union catches hosts that
+        # went offline mid-window (their busy time is still real
+        # capacity consumed) and hosts that came online late.
+        hosts = api_label_runners.get(label, set()) | job_label_runners.get(
+            label, set()
+        )
         num_runners = len(hosts) if hosts else 1
 
         # Pool busy time: sum of busy time across the hosts that could

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -63,13 +63,21 @@ def get_workflow_runs(repo: str, hours: int = 24) -> list[dict]:
 
 
 def get_jobs_for_run(repo: str, run_id: int) -> list[dict]:
-    """Get all jobs for a workflow run."""
+    """Get all jobs for a workflow run, including all retry attempts.
+
+    `filter=all` is required so that re-run attempts of the same job
+    appear separately. Each attempt consumed host time on the runner
+    pool, so for utilization we want them all summed in. The default
+    (`filter=latest`) only returns the most recent attempt and silently
+    hides time spent on prior retries.
+    """
     jobs = []
     page = 1
     while True:
         data = run_gh_command(
             [
-                f"repos/{repo}/actions/runs/{run_id}/jobs?per_page=100&page={page}",
+                f"repos/{repo}/actions/runs/{run_id}/jobs"
+                f"?per_page=100&page={page}&filter=all",
             ]
         )
         jobs.extend(data.get("jobs", []))

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -112,131 +112,6 @@ def parse_time(time_str: str) -> datetime:
     return datetime.fromisoformat(time_str.replace("Z", "+00:00"))
 
 
-# Known runner counts per label (fallback when API unavailable)
-KNOWN_RUNNER_COUNTS = {
-    "1-gpu-5090": 16,
-    "h200": 8,
-    "h20": 4,
-    "b200": 4,
-    "amd": 8,
-    "github-hosted": 20,  # GitHub hosted runners (variable)
-    "other": 10,
-}
-
-
-def calculate_concurrency_metrics(
-    jobs: list[dict],
-    window_start: datetime,
-    window_end: datetime,
-    num_runners: int,
-) -> dict:
-    """
-    Calculate concurrency metrics using a sweep line algorithm.
-
-    Tracks:
-    - Peak concurrent runners in use
-    - Average concurrent runners over time
-    - Time at saturation (all runners busy)
-    - Queue depth when runners are saturated
-    """
-    if not jobs:
-        return {
-            "peak_concurrent": 0,
-            "avg_concurrent": 0.0,
-            "saturation_seconds": 0,
-            "saturation_pct": 0.0,
-            "peak_queue": 0,
-        }
-
-    window_seconds = (window_end - window_start).total_seconds()
-    if window_seconds <= 0:
-        return {
-            "peak_concurrent": 0,
-            "avg_concurrent": 0.0,
-            "saturation_seconds": 0,
-            "saturation_pct": 0.0,
-            "peak_queue": 0,
-        }
-
-    # Create events for running jobs: +1 at start, -1 at end
-    running_events = []
-    for job in jobs:
-        start = job["start"]
-        end = job["end"]
-        # Clamp to window
-        if end < window_start or start > window_end:
-            continue
-        clamped_start = max(start, window_start)
-        clamped_end = min(end, window_end)
-        running_events.append((clamped_start, 1, "start"))  # +1 for start
-        running_events.append((clamped_end, -1, "end"))  # -1 for end
-
-    # Create events for queue tracking (jobs created but not started)
-    queue_events = []
-    for job in jobs:
-        created_at = job.get("created_at")
-        started_at = job["start"]
-        if created_at and created_at < started_at:
-            # Clamp to window
-            if started_at < window_start or created_at > window_end:
-                continue
-            clamped_created = max(created_at, window_start)
-            clamped_started = min(started_at, window_end)
-            queue_events.append((clamped_created, 1, "queued"))
-            queue_events.append((clamped_started, -1, "dequeued"))
-
-    # Sort running events: by time, then ends before starts at same time
-    running_events.sort(key=lambda e: (e[0], e[1] == 1))
-
-    # Process running events to get concurrency metrics
-    current_running = 0
-    peak_running = 0
-    prev_time = window_start
-    total_running_seconds = 0.0
-    saturation_seconds = 0.0
-
-    for event_time, delta, _ in running_events:
-        # Accumulate time at previous concurrency level
-        time_delta = (event_time - prev_time).total_seconds()
-        if time_delta > 0:
-            total_running_seconds += current_running * time_delta
-            if current_running >= num_runners:
-                saturation_seconds += time_delta
-
-        # Update concurrency
-        current_running += delta
-        peak_running = max(peak_running, current_running)
-        prev_time = event_time
-
-    # Handle remaining time after last event
-    if prev_time < window_end:
-        time_delta = (window_end - prev_time).total_seconds()
-        total_running_seconds += current_running * time_delta
-        if current_running >= num_runners:
-            saturation_seconds += time_delta
-
-    # Sort queue events and calculate peak queue depth
-    queue_events.sort(key=lambda e: (e[0], e[1] == 1))
-    current_queued = 0
-    peak_queue = 0
-
-    for _, delta, _ in queue_events:
-        current_queued += delta
-        peak_queue = max(peak_queue, current_queued)
-
-    avg_concurrent = total_running_seconds / window_seconds if window_seconds > 0 else 0
-
-    return {
-        "peak_concurrent": peak_running,
-        "avg_concurrent": avg_concurrent,
-        "saturation_seconds": saturation_seconds,
-        "saturation_pct": (
-            (saturation_seconds / window_seconds * 100) if window_seconds > 0 else 0
-        ),
-        "peak_queue": peak_queue,
-    }
-
-
 def calculate_utilization(repo: str, hours: int = 24, runner_filter: str = None):
     """Calculate runner utilization metrics."""
 
@@ -341,230 +216,111 @@ def calculate_utilization(repo: str, hours: int = 24, runner_filter: str = None)
 
     print(f"Tracking {len(all_labels)} runner labels: {sorted(all_labels)}")
 
-    # Calculate metrics per label
     window_seconds = hours * 3600
     window_end = datetime.now(timezone.utc)
     window_start = window_end - timedelta(hours=hours)
 
-    results = []
+    # Per-host window-clamped busy time (each physical machine counted once).
+    host_busy_seconds = {}
+    for host, jobs in host_jobs.items():
+        busy = 0.0
+        for j in jobs:
+            cs = max(j["start"], window_start)
+            ce = min(j["end"], window_end)
+            if ce > cs:
+                busy += (ce - cs).total_seconds()
+        host_busy_seconds[host] = busy
 
-    for label in sorted(all_labels):
-        # Use API runner count if available, otherwise use job-observed count
+    # Group labels into pools: labels that map to an identical host set
+    # (e.g. `4-gpu-b200`, `4-gpu-b200-kernel`, `4-gpu-b200-low-disk`,
+    # `4-gpu-b200-kernel-low-disk` all map to the same 3 b200 hosts and
+    # collapse into one row).
+    label_to_hosts = {}
+    for label in all_labels:
         if label in api_label_runners and api_label_runners[label]:
-            num_runners = len(api_label_runners[label])
+            label_to_hosts[label] = frozenset(api_label_runners[label])
         elif label in job_label_runners:
-            num_runners = len(job_label_runners[label])
-        else:
-            num_runners = KNOWN_RUNNER_COUNTS.get(label, 1)
+            label_to_hosts[label] = frozenset(job_label_runners[label])
 
-        total_capacity_seconds = window_seconds * num_runners
+    pools = defaultdict(list)
+    for label, hosts in label_to_hosts.items():
+        if hosts:
+            pools[hosts].append(label)
 
-        jobs = label_jobs.get(label, [])
-        total_active_seconds = sum(j["duration"] for j in jobs)
+    results = []
+    for hosts, labels in pools.items():
+        # Pool busy time: sum of window-clamped busy time across hosts.
+        # Any job that ran on these hosts (regardless of which label
+        # triggered it) consumed shared capacity.
+        busy_seconds = sum(host_busy_seconds.get(h, 0.0) for h in hosts)
+        # Job count and queue stats are restricted to jobs that actually
+        # ran under one of the labels in this pool (otherwise queue stats
+        # for `4-gpu-b200` would mix in stats from `1-gpu-h100`).
+        pool_jobs = []
+        seen_jobs = set()
+        for label in labels:
+            for j in label_jobs.get(label, []):
+                key = (j["runner_name"], j["start"], j["job_name"])
+                if key in seen_jobs:
+                    continue
+                seen_jobs.add(key)
+                pool_jobs.append(j)
+        queue_times = [j["queue_time"] for j in pool_jobs if j["queue_time"] > 0]
+        avg_queue = sum(queue_times) / len(queue_times) if queue_times else 0
+        max_queue = max(queue_times) if queue_times else 0
 
-        utilization = (
-            (total_active_seconds / total_capacity_seconds * 100)
-            if total_capacity_seconds > 0
-            else 0
-        )
-        idle_seconds = total_capacity_seconds - total_active_seconds
-
-        # Calculate queue time metrics
-        queue_times = [j["queue_time"] for j in jobs if j["queue_time"] > 0]
-        avg_queue_time = sum(queue_times) / len(queue_times) if queue_times else 0
-        max_queue_time = max(queue_times) if queue_times else 0
-
-        # Calculate concurrency metrics
-        # First pass: get peak concurrent to determine effective capacity
-        concurrency_initial = calculate_concurrency_metrics(
-            jobs, window_start, window_end, num_runners
-        )
-
-        # Use observed peak as effective capacity if lower than API count
-        # This handles cases where not all runners are active all the time
-        effective_runners = min(num_runners, concurrency_initial["peak_concurrent"])
-        if effective_runners < num_runners and effective_runners > 0:
-            # Recalculate with effective capacity for accurate saturation
-            concurrency = calculate_concurrency_metrics(
-                jobs, window_start, window_end, effective_runners
-            )
-        else:
-            concurrency = concurrency_initial
-            effective_runners = num_runners
+        capacity = len(hosts) * window_seconds
+        utilization = busy_seconds / capacity * 100 if capacity > 0 else 0
 
         results.append(
             {
-                "label": label,
-                "num_runners": num_runners,
-                "effective_runners": effective_runners,
-                "num_jobs": len(jobs),
-                "total_active_hours": total_active_seconds / 3600,
-                "total_idle_hours": idle_seconds / 3600,
-                "total_capacity_hours": total_capacity_seconds / 3600,
-                "utilization_pct": utilization,
-                "avg_queue_min": avg_queue_time / 60,
-                "max_queue_min": max_queue_time / 60,
-                # Concurrency metrics
-                "peak_concurrent": concurrency_initial["peak_concurrent"],
-                "avg_concurrent": concurrency["avg_concurrent"],
-                "saturation_hours": concurrency["saturation_seconds"] / 3600,
-                "saturation_pct": concurrency["saturation_pct"],
-                "peak_queue": concurrency["peak_queue"],
-            }
-        )
-
-    # Per-host metrics: each physical machine once, with its true busy time
-    # against window capacity. Overlapping labels do not multiply the
-    # denominator here (unlike the per-label view).
-    host_results = []
-    for host, jobs in host_jobs.items():
-        if runner_filter and not any(runner_filter in lbl for lbl in host_labels[host]):
-            continue
-        # Clamp each job to the window before summing — a job spanning the
-        # window edge should only contribute the portion inside the window.
-        busy_seconds = 0.0
-        for j in jobs:
-            clamped_start = max(j["start"], window_start)
-            clamped_end = min(j["end"], window_end)
-            if clamped_end > clamped_start:
-                busy_seconds += (clamped_end - clamped_start).total_seconds()
-        host_results.append(
-            {
-                "host": host,
-                "labels": sorted(host_labels[host]),
-                "num_jobs": len(jobs),
+                "labels": sorted(labels),
+                "num_hosts": len(hosts),
+                "num_jobs": len(pool_jobs),
                 "busy_hours": busy_seconds / 3600,
-                "utilization_pct": (
-                    busy_seconds / window_seconds * 100 if window_seconds > 0 else 0
-                ),
+                "utilization_pct": utilization,
+                "avg_queue_min": avg_queue / 60,
+                "max_queue_min": max_queue / 60,
             }
         )
-    host_results.sort(key=lambda r: -r["utilization_pct"])
+    results.sort(key=lambda r: -r["utilization_pct"])
 
-    return results, host_results
+    return results
 
 
-def format_report(results: list[dict], host_results: list[dict], hours: int) -> str:
-    """Format results as markdown report."""
+def format_report(results: list[dict], hours: int) -> str:
+    """Format results as a single compact markdown table.
+
+    One row per host pool — labels that share an identical host set are
+    collapsed (e.g. `4-gpu-b200` + `4-gpu-b200-kernel` + `4-gpu-b200-low-disk`
+    + `4-gpu-b200-kernel-low-disk` → one row, since they all live on the
+    same 3 hosts). Utilization is computed against the pool's actual hosts
+    × window, and the busy-time numerator counts every job that ran on
+    those hosts (any label) — so the percentage reflects real hardware
+    occupancy regardless of which label dispatched the job.
+    """
     lines = [
         "# Runner Utilization Report",
         "",
-        f"**Time window:** Last {hours} hours",
+        f"**Time window:** Last {hours} hours · "
         f"**Generated:** {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}",
         "",
-        "## Per Host Utilization",
+        "Utilization = busy time of all jobs on the pool's hosts ÷ "
+        "(host count × window). Labels sharing the same host set are "
+        "collapsed into one row.",
         "",
-        "Each physical runner machine is counted once, regardless of how many "
-        "overlapping labels it advertises (e.g. a single B200 host advertises "
-        "`4-gpu-b200`, `4-gpu-b200-kernel`, `4-gpu-b200-low-disk`, "
-        "`4-gpu-b200-kernel-low-disk` — but only one job runs on it at a time). "
-        "**This is the source-of-truth view of capacity utilization.** "
-        "If you want per-class numbers, see the Per Label section below, but "
-        "note those denominators are inflated when labels share hosts.",
-        "",
-        "| Host | Jobs | Busy (hrs) | Utilization | Labels |",
-        "|------|------|------------|-------------|--------|",
+        "| Label(s) | Hosts | Jobs | Busy (hrs) | Utilization | Avg Queue | Max Queue |",
+        "|----------|-------|------|------------|-------------|-----------|-----------|",
     ]
-    for h in host_results:
-        bar = "█" * int(h["utilization_pct"] / 10) + "░" * (
-            10 - int(h["utilization_pct"] / 10)
-        )
-        labels_str = ", ".join(h["labels"]) if h["labels"] else "—"
-        lines.append(
-            f"| {h['host']} | {h['num_jobs']} | "
-            f"{h['busy_hours']:.1f} | "
-            f"{h['utilization_pct']:.1f}% {bar} | "
-            f"{labels_str} |"
-        )
-
-    lines.extend(
-        [
-            "",
-            "## Concurrency Analysis",
-            "",
-            "| Label | Runners (API/Effective) | Peak Concurrent | Avg Concurrent | Saturation Time | Peak Queue |",
-            "|-------|-------------------------|-----------------|----------------|-----------------|------------|",
-        ]
-    )
-
     for r in results:
-        effective = r["effective_runners"]
-        avg_pct = (r["avg_concurrent"] / effective * 100) if effective > 0 else 0
-        runner_str = (
-            f"{r['num_runners']}/{effective}"
-            if effective != r["num_runners"]
-            else str(r["num_runners"])
-        )
-        lines.append(
-            f"| {r['label']} | {runner_str} | "
-            f"{r['peak_concurrent']} | "
-            f"{r['avg_concurrent']:.1f} ({avg_pct:.0f}%) | "
-            f"{r['saturation_hours']:.1f}h ({r['saturation_pct']:.0f}%) | "
-            f"{r['peak_queue']} jobs |"
-        )
-
-    # Add recommendations section
-    lines.extend(["", "## Recommendations", ""])
-    has_recommendations = False
-    for r in results:
-        label = r["label"]
-        saturation_pct = r["saturation_pct"]
-        peak_queue = r["peak_queue"]
-        effective = r["effective_runners"]
-        avg_pct = (r["avg_concurrent"] / effective * 100) if effective > 0 else 0
-
-        if saturation_pct > 50 or peak_queue > 5:
-            lines.append(
-                f"⚠️ **{label}**: High saturation ({saturation_pct:.0f}%) "
-                f"with queue buildup ({peak_queue} jobs). Consider adding runners."
-            )
-            has_recommendations = True
-        elif saturation_pct > 20 or peak_queue > 0:
-            lines.append(
-                f"📊 **{label}**: Moderate saturation ({saturation_pct:.0f}%), "
-                f"peak queue {peak_queue} jobs. Monitor for trends."
-            )
-            has_recommendations = True
-        elif avg_pct < 30 and r["num_jobs"] > 0:
-            lines.append(
-                f"💡 **{label}**: Low average utilization ({avg_pct:.0f}%). "
-                f"Runner pool may be oversized."
-            )
-            has_recommendations = True
-        else:
-            lines.append(f"✓ **{label}**: Healthy utilization with minimal queueing.")
-
-    if not has_recommendations and results:
-        lines.append("All runner pools have healthy utilization.")
-
-    # Add summary table
-    lines.extend(
-        [
-            "",
-            "## Summary by Runner Label",
-            "",
-            "Note: hosts often advertise multiple labels (e.g. one B200 host "
-            "carries `4-gpu-b200`, `4-gpu-b200-kernel`, `4-gpu-b200-low-disk`, "
-            "`4-gpu-b200-kernel-low-disk`; one H100 GPU pair carries "
-            "`2-gpu-runner`, `2-gpu-large`, `2-gpu-h100`, `1-gpu-h100-h200`). "
-            "Each label below is shown against its own `num_runners × window` "
-            "denominator, which double-counts capacity when labels share "
-            "hosts and makes per-label utilization look low. **Use the Per "
-            "Host Utilization table above for actual host utilization.**",
-            "",
-            "| Label | Runners | Jobs | Active (hrs) | Utilization | Avg Queue | Max Queue |",
-            "|-------|---------|------|--------------|-------------|-----------|-----------|",
-        ]
-    )
-
-    for r in results:
-        utilization_bar = "█" * int(r["utilization_pct"] / 10) + "░" * (
+        bar = "█" * int(r["utilization_pct"] / 10) + "░" * (
             10 - int(r["utilization_pct"] / 10)
         )
+        labels_str = ", ".join(r["labels"])
         lines.append(
-            f"| {r['label']} | {r['num_runners']} | {r['num_jobs']} | "
-            f"{r['total_active_hours']:.1f} | "
-            f"{r['utilization_pct']:.1f}% {utilization_bar} | "
+            f"| {labels_str} | {r['num_hosts']} | {r['num_jobs']} | "
+            f"{r['busy_hours']:.1f} | "
+            f"{r['utilization_pct']:.1f}% {bar} | "
             f"{r['avg_queue_min']:.1f}m | {r['max_queue_min']:.1f}m |"
         )
 
@@ -581,8 +337,8 @@ def main():
     parser.add_argument("--output", type=str, help="Output file (default: stdout)")
     args = parser.parse_args()
 
-    results, host_results = calculate_utilization(args.repo, args.hours, args.filter)
-    report = format_report(results, host_results, args.hours)
+    results = calculate_utilization(args.repo, args.hours, args.filter)
+    report = format_report(results, args.hours)
 
     if args.output:
         with open(args.output, "w") as f:

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -21,7 +21,7 @@ DEFAULT_LABELS_TO_IGNORE = {"self-hosted", "Linux", "X64", "ARM64"}
 GITHUB_HOSTED_LABELS = {"ubuntu-latest", "ubuntu-22.04", "ubuntu-24.04"}
 
 
-def run_gh_command(args: list[str], max_retries: int = 5) -> dict:
+def run_gh_command(args: list[str], max_retries: int = 10) -> dict:
     """Run gh CLI command and return JSON result.
 
     Retries on transient failures (5xx, secondary rate limits, network
@@ -62,8 +62,8 @@ def run_gh_command(args: list[str], max_retries: int = 5) -> dict:
         )
         if not retryable:
             break
-        # Exponential backoff with jitter: 1s, 2s, 4s, 8s, 16s
-        delay = (2**attempt) + random.uniform(0, 1)
+        # Exponential backoff with jitter, capped at 60s.
+        delay = min(60, (2**attempt) + random.uniform(0, 1))
         time.sleep(delay)
     raise Exception(f"gh api failed after {max_retries} attempts: {last_err[:300]}")
 
@@ -157,12 +157,49 @@ def parse_time(time_str: str) -> datetime:
     return datetime.fromisoformat(time_str.replace("Z", "+00:00"))
 
 
+_NON_GPU_WORKFLOW_HINTS = (
+    "lint",
+    "deploy",
+    "release",
+    "publish",
+    "docs",
+    "doc",
+    "mintlify",
+    "runner utilization",  # this very script
+    "tag-and-rerun",
+    "auto",  # auto-merge etc.
+    "label",
+    "stale",
+    "dependabot",
+    "codeql",
+)
+
+
+def _likely_no_gpu_jobs(workflow_name: str) -> bool:
+    """Heuristic: skip per-run job-fetch for workflows that don't dispatch
+    to self-hosted GPU runners. The GH API rate limit (~5000 req/hr per
+    token) is the bottleneck on busy 24h windows where ~4000 workflow
+    runs fire — but only a fraction of those (pr-test, nightly-test,
+    pr-test-*kernel, etc.) actually run on GPU runners. Skipping the
+    docs/lint/release runs cuts the API call budget by 2-4x.
+    """
+    if not workflow_name:
+        return False
+    n = workflow_name.lower()
+    return any(h in n for h in _NON_GPU_WORKFLOW_HINTS)
+
+
 def calculate_utilization(repo: str, hours: int = 24, runner_filter: str = None):
     """Calculate runner utilization metrics."""
 
     print(f"Fetching workflow runs from last {hours} hours...")
-    runs = get_workflow_runs(repo, hours)
-    print(f"Found {len(runs)} workflow runs")
+    all_runs = get_workflow_runs(repo, hours)
+    runs = [r for r in all_runs if not _likely_no_gpu_jobs(r.get("name", ""))]
+    skipped = len(all_runs) - len(runs)
+    print(
+        f"Found {len(all_runs)} workflow runs "
+        f"({skipped} skipped as non-GPU: docs/lint/release/etc.)"
+    )
 
     # Try to get online runners from API
     print("Fetching online runners...")
@@ -211,13 +248,20 @@ def calculate_utilization(repo: str, hours: int = 24, runner_filter: str = None)
 
     all_jobs = []
     failed_runs = []
-    with ThreadPoolExecutor(max_workers=10) as executor:
+    # Concurrency=4 with longer retry budget keeps us well below the GH
+    # API secondary rate-limit threshold (~10 req/s). On a 24h window
+    # with ~1500 GPU-relevant runs (post-filter), this completes in ~5
+    # min and almost never hits the rate limit.
+    with ThreadPoolExecutor(max_workers=4) as executor:
         futures = [executor.submit(fetch_jobs_for_run, run) for run in runs]
         completed = 0
         for future in as_completed(futures):
             completed += 1
-            if completed % 50 == 0:
-                print(f"Fetched jobs for {completed}/{total_runs} runs...")
+            if completed % 100 == 0:
+                print(
+                    f"Fetched jobs for {completed}/{total_runs} runs "
+                    f"({len(failed_runs)} failed so far)..."
+                )
             run_id, jobs, err = future.result()
             if err:
                 failed_runs.append((run_id, err))
@@ -233,6 +277,7 @@ def calculate_utilization(repo: str, hours: int = 24, runner_filter: str = None)
         )
         for rid, err in failed_runs[:5]:
             print(f"  run {rid}: {err}")
+    fetch_failure_pct = len(failed_runs) / total_runs * 100 if total_runs > 0 else 0
 
     for job in all_jobs:
         runner_name = job.get("runner_name")
@@ -342,10 +387,12 @@ def calculate_utilization(repo: str, hours: int = 24, runner_filter: str = None)
             }
         )
 
-    return results
+    return results, fetch_failure_pct
 
 
-def format_report(results: list[dict], hours: int) -> str:
+def format_report(
+    results: list[dict], hours: int, fetch_failure_pct: float = 0.0
+) -> str:
     """One compact summary table — original schema, fixed columns.
 
     Active (hrs) and Utilization now reflect the actual host pool's
@@ -362,9 +409,21 @@ def format_report(results: list[dict], hours: int) -> str:
         f"**Time window:** Last {hours} hours · "
         f"**Generated:** {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}",
         "",
-        "| Label | Runners | Jobs | Active (hrs) | Utilization | Avg Queue | Max Queue |",
-        "|-------|---------|------|--------------|-------------|-----------|-----------|",
     ]
+    if fetch_failure_pct > 1.0:
+        lines.append(
+            f"⚠️ **Data completeness warning**: {fetch_failure_pct:.0f}% of "
+            f"GPU-relevant workflow runs failed to fetch jobs after retries "
+            f"(GH API rate limit). Active hours and utilization below are "
+            f"under-counted by approximately this fraction."
+        )
+        lines.append("")
+    lines.extend(
+        [
+            "| Label | Runners | Jobs | Active (hrs) | Utilization | Avg Queue | Max Queue |",
+            "|-------|---------|------|--------------|-------------|-----------|-----------|",
+        ]
+    )
     for r in results:
         bar = "█" * int(r["utilization_pct"] / 10) + "░" * (
             10 - int(r["utilization_pct"] / 10)
@@ -389,8 +448,10 @@ def main():
     parser.add_argument("--output", type=str, help="Output file (default: stdout)")
     args = parser.parse_args()
 
-    results = calculate_utilization(args.repo, args.hours, args.filter)
-    report = format_report(results, args.hours)
+    results, fetch_failure_pct = calculate_utilization(
+        args.repo, args.hours, args.filter
+    )
+    report = format_report(results, args.hours, fetch_failure_pct)
 
     if args.output:
         with open(args.output, "w") as f:

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -221,6 +221,7 @@ def calculate_utilization(repo: str, hours: int = 24, runner_filter: str = None)
     window_start = window_end - timedelta(hours=hours)
 
     # Per-host window-clamped busy time (each physical machine counted once).
+    # This is the source of truth for how loaded each host actually is.
     host_busy_seconds = {}
     for host, jobs in host_jobs.items():
         busy = 0.0
@@ -231,73 +232,64 @@ def calculate_utilization(repo: str, hours: int = 24, runner_filter: str = None)
                 busy += (ce - cs).total_seconds()
         host_busy_seconds[host] = busy
 
-    # Group labels into pools: labels that map to an identical host set
-    # (e.g. `4-gpu-b200`, `4-gpu-b200-kernel`, `4-gpu-b200-low-disk`,
-    # `4-gpu-b200-kernel-low-disk` all map to the same 3 b200 hosts and
-    # collapse into one row).
-    label_to_hosts = {}
-    for label in all_labels:
-        if label in api_label_runners and api_label_runners[label]:
-            label_to_hosts[label] = frozenset(api_label_runners[label])
-        elif label in job_label_runners:
-            label_to_hosts[label] = frozenset(job_label_runners[label])
-
-    pools = defaultdict(list)
-    for label, hosts in label_to_hosts.items():
-        if hosts:
-            pools[hosts].append(label)
-
     results = []
-    for hosts, labels in pools.items():
-        # Pool busy time: sum of window-clamped busy time across hosts.
-        # Any job that ran on these hosts (regardless of which label
-        # triggered it) consumed shared capacity.
-        busy_seconds = sum(host_busy_seconds.get(h, 0.0) for h in hosts)
-        # Job count and queue stats are restricted to jobs that actually
-        # ran under one of the labels in this pool (otherwise queue stats
-        # for `4-gpu-b200` would mix in stats from `1-gpu-h100`).
-        pool_jobs = []
-        seen_jobs = set()
-        for label in labels:
-            for j in label_jobs.get(label, []):
-                key = (j["runner_name"], j["start"], j["job_name"])
-                if key in seen_jobs:
-                    continue
-                seen_jobs.add(key)
-                pool_jobs.append(j)
-        queue_times = [j["queue_time"] for j in pool_jobs if j["queue_time"] > 0]
+    for label in sorted(all_labels):
+        # Hosts that advertise this label (from API if available, else
+        # observed in job data).
+        if label in api_label_runners and api_label_runners[label]:
+            hosts = api_label_runners[label]
+        elif label in job_label_runners:
+            hosts = job_label_runners[label]
+        else:
+            hosts = set()
+        num_runners = len(hosts) if hosts else 1
+
+        # Pool busy time: sum of busy time across the hosts that could
+        # serve this label, regardless of which sibling label actually
+        # dispatched the job. This is the right denominator/numerator for
+        # asking "how saturated is the underlying hardware that this
+        # label depends on?" — sibling labels (e.g. `4-gpu-b200` and
+        # `4-gpu-b200-low-disk`) compete for the same physical machines,
+        # so their busy time should not be double-counted into separate
+        # capacity buckets.
+        active_seconds = sum(host_busy_seconds.get(h, 0.0) for h in hosts)
+        capacity_seconds = num_runners * window_seconds
+        utilization = (
+            (active_seconds / capacity_seconds * 100) if capacity_seconds > 0 else 0
+        )
+
+        # Job count + queue stats stay label-specific (only jobs that
+        # were dispatched under THIS label).
+        jobs = label_jobs.get(label, [])
+        queue_times = [j["queue_time"] for j in jobs if j["queue_time"] > 0]
         avg_queue = sum(queue_times) / len(queue_times) if queue_times else 0
         max_queue = max(queue_times) if queue_times else 0
 
-        capacity = len(hosts) * window_seconds
-        utilization = busy_seconds / capacity * 100 if capacity > 0 else 0
-
         results.append(
             {
-                "labels": sorted(labels),
-                "num_hosts": len(hosts),
-                "num_jobs": len(pool_jobs),
-                "busy_hours": busy_seconds / 3600,
+                "label": label,
+                "num_runners": num_runners,
+                "num_jobs": len(jobs),
+                "total_active_hours": active_seconds / 3600,
                 "utilization_pct": utilization,
                 "avg_queue_min": avg_queue / 60,
                 "max_queue_min": max_queue / 60,
             }
         )
-    results.sort(key=lambda r: -r["utilization_pct"])
 
     return results
 
 
 def format_report(results: list[dict], hours: int) -> str:
-    """Format results as a single compact markdown table.
+    """One compact summary table — original schema, fixed columns.
 
-    One row per host pool — labels that share an identical host set are
-    collapsed (e.g. `4-gpu-b200` + `4-gpu-b200-kernel` + `4-gpu-b200-low-disk`
-    + `4-gpu-b200-kernel-low-disk` → one row, since they all live on the
-    same 3 hosts). Utilization is computed against the pool's actual hosts
-    × window, and the busy-time numerator counts every job that ran on
-    those hosts (any label) — so the percentage reflects real hardware
-    occupancy regardless of which label dispatched the job.
+    Active (hrs) and Utilization now reflect the actual host pool's
+    busy time (sum across all jobs on the hosts that advertise this
+    label, regardless of which sibling label dispatched them). This
+    makes the column meaningful for shared host pools — e.g.
+    `4-gpu-b200` and `4-gpu-b200-low-disk` both consume the same
+    physical hosts, so their utilization now reflects real hardware
+    saturation instead of being divided across labels.
     """
     lines = [
         "# Runner Utilization Report",
@@ -305,21 +297,16 @@ def format_report(results: list[dict], hours: int) -> str:
         f"**Time window:** Last {hours} hours · "
         f"**Generated:** {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}",
         "",
-        "Utilization = busy time of all jobs on the pool's hosts ÷ "
-        "(host count × window). Labels sharing the same host set are "
-        "collapsed into one row.",
-        "",
-        "| Label(s) | Hosts | Jobs | Busy (hrs) | Utilization | Avg Queue | Max Queue |",
-        "|----------|-------|------|------------|-------------|-----------|-----------|",
+        "| Label | Runners | Jobs | Active (hrs) | Utilization | Avg Queue | Max Queue |",
+        "|-------|---------|------|--------------|-------------|-----------|-----------|",
     ]
     for r in results:
         bar = "█" * int(r["utilization_pct"] / 10) + "░" * (
             10 - int(r["utilization_pct"] / 10)
         )
-        labels_str = ", ".join(r["labels"])
         lines.append(
-            f"| {labels_str} | {r['num_hosts']} | {r['num_jobs']} | "
-            f"{r['busy_hours']:.1f} | "
+            f"| {r['label']} | {r['num_runners']} | {r['num_jobs']} | "
+            f"{r['total_active_hours']:.1f} | "
             f"{r['utilization_pct']:.1f}% {bar} | "
             f"{r['avg_queue_min']:.1f}m | {r['max_queue_min']:.1f}m |"
         )

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -9,7 +9,9 @@ Reports idle time, active time, and utilization percentage per runner label.
 import argparse
 import json
 import os
+import random
 import subprocess
+import time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta, timezone
@@ -19,16 +21,51 @@ DEFAULT_LABELS_TO_IGNORE = {"self-hosted", "Linux", "X64", "ARM64"}
 GITHUB_HOSTED_LABELS = {"ubuntu-latest", "ubuntu-22.04", "ubuntu-24.04"}
 
 
-def run_gh_command(args: list[str]) -> dict:
-    """Run gh CLI command and return JSON result."""
-    result = subprocess.run(
-        ["gh", "api"] + args,
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        raise Exception(f"gh api failed: {result.stderr}")
-    return json.loads(result.stdout)
+def run_gh_command(args: list[str], max_retries: int = 5) -> dict:
+    """Run gh CLI command and return JSON result.
+
+    Retries on transient failures (5xx, secondary rate limits, network
+    blips) with exponential backoff. The previous fail-fast behavior
+    combined with `except Exception: return None` in the threadpool
+    callers caused entire workflow runs to be silently dropped from
+    the utilization numerator whenever GH API hiccuped, severely
+    undercounting busy time on busy days.
+    """
+    last_err = ""
+    for attempt in range(max_retries):
+        result = subprocess.run(
+            ["gh", "api"] + args,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return json.loads(result.stdout)
+        last_err = result.stderr or "(no stderr)"
+        # Detect retryable conditions: HTTP 5xx, secondary rate limit, abuse
+        # detection, network resets. 4xx other than 429 are non-retryable.
+        retryable = any(
+            s in last_err
+            for s in (
+                "rate limit",
+                "abuse",
+                "Internal Server Error",
+                "502",
+                "503",
+                "504",
+                "Bad Gateway",
+                "Gateway Time-out",
+                "connection reset",
+                "Connection reset",
+                "EOF",
+                "timeout",
+            )
+        )
+        if not retryable:
+            break
+        # Exponential backoff with jitter: 1s, 2s, 4s, 8s, 16s
+        delay = (2**attempt) + random.uniform(0, 1)
+        time.sleep(delay)
+    raise Exception(f"gh api failed after {max_retries} attempts: {last_err[:300]}")
 
 
 def get_workflow_runs(repo: str, hours: int = 24) -> list[dict]:
@@ -152,30 +189,50 @@ def calculate_utilization(repo: str, hours: int = 24, runner_filter: str = None)
     host_jobs = defaultdict(list)  # runner_name -> list of job_info
     host_labels = defaultdict(set)  # runner_name -> set of labels it ran jobs under
 
-    # Fetch jobs for all runs in parallel
+    # Fetch jobs for all runs in parallel. Cap concurrency lower than the
+    # GH API secondary rate-limit threshold to avoid bursts that silently
+    # drop runs even with retries.
     total_runs = len(runs)
     print(f"Fetching jobs for {total_runs} runs in parallel...")
 
     def fetch_jobs_for_run(run):
-        """Fetch jobs for a single run, returning (run_id, jobs) or (run_id, None) on error."""
+        """Fetch jobs for a single run.
+
+        Returns (run_id, jobs, error_msg). `error_msg` is None on success.
+        We surface failures rather than silently dropping the run so the
+        caller can report how many runs' jobs are missing — silently
+        dropping previously caused 4-gpu-b200 (and every other label) to
+        report wildly different numbers depending on transient API hiccups.
+        """
         try:
-            return (run["id"], get_jobs_for_run(repo, run["id"]))
-        except Exception:
-            return (run["id"], None)
+            return (run["id"], get_jobs_for_run(repo, run["id"]), None)
+        except Exception as e:
+            return (run["id"], None, str(e)[:200])
 
     all_jobs = []
-    with ThreadPoolExecutor(max_workers=20) as executor:
+    failed_runs = []
+    with ThreadPoolExecutor(max_workers=10) as executor:
         futures = [executor.submit(fetch_jobs_for_run, run) for run in runs]
         completed = 0
         for future in as_completed(futures):
             completed += 1
             if completed % 50 == 0:
                 print(f"Fetched jobs for {completed}/{total_runs} runs...")
-            run_id, jobs = future.result()
-            if jobs:
+            run_id, jobs, err = future.result()
+            if err:
+                failed_runs.append((run_id, err))
+            elif jobs:
                 all_jobs.extend(jobs)
 
     print(f"Processing {len(all_jobs)} jobs...")
+    if failed_runs:
+        print(
+            f"WARNING: {len(failed_runs)}/{total_runs} runs failed to fetch "
+            f"after retries. Utilization will be undercounted. "
+            f"First few errors:"
+        )
+        for rid, err in failed_runs[:5]:
+            print(f"  run {rid}: {err}")
 
     for job in all_jobs:
         runner_name = job.get("runner_name")

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -263,6 +263,11 @@ def calculate_utilization(repo: str, hours: int = 24, runner_filter: str = None)
     # Track runners seen in jobs (for labels not in API or when API unavailable)
     job_label_runners = defaultdict(set)
     label_jobs = defaultdict(list)  # label -> list of job_info
+    # Per-host accumulation: each physical machine appears once regardless of
+    # how many overlapping labels it advertises. This is what we use for the
+    # "Per Host Utilization" section (the source-of-truth view).
+    host_jobs = defaultdict(list)  # runner_name -> list of job_info
+    host_labels = defaultdict(set)  # runner_name -> set of labels it ran jobs under
 
     # Fetch jobs for all runs in parallel
     total_runs = len(runs)
@@ -313,6 +318,9 @@ def calculate_utilization(repo: str, hours: int = 24, runner_filter: str = None)
             "runner_name": runner_name,
         }
 
+        # Per-host: every job on this physical machine, regardless of label.
+        host_jobs[runner_name].append(job_info)
+
         # Use job labels directly (available in job data)
         job_labels = job.get("labels", [])
         for label in job_labels:
@@ -321,6 +329,7 @@ def calculate_utilization(repo: str, hours: int = 24, runner_filter: str = None)
                 continue
             job_label_runners[label].add(runner_name)
             label_jobs[label].append(job_info)
+            host_labels[runner_name].add(label)
 
     # Merge API runners and job-observed runners
     # Prefer API count (online runners) when available
@@ -404,10 +413,38 @@ def calculate_utilization(repo: str, hours: int = 24, runner_filter: str = None)
             }
         )
 
-    return results
+    # Per-host metrics: each physical machine once, with its true busy time
+    # against window capacity. Overlapping labels do not multiply the
+    # denominator here (unlike the per-label view).
+    host_results = []
+    for host, jobs in host_jobs.items():
+        if runner_filter and not any(runner_filter in lbl for lbl in host_labels[host]):
+            continue
+        # Clamp each job to the window before summing — a job spanning the
+        # window edge should only contribute the portion inside the window.
+        busy_seconds = 0.0
+        for j in jobs:
+            clamped_start = max(j["start"], window_start)
+            clamped_end = min(j["end"], window_end)
+            if clamped_end > clamped_start:
+                busy_seconds += (clamped_end - clamped_start).total_seconds()
+        host_results.append(
+            {
+                "host": host,
+                "labels": sorted(host_labels[host]),
+                "num_jobs": len(jobs),
+                "busy_hours": busy_seconds / 3600,
+                "utilization_pct": (
+                    busy_seconds / window_seconds * 100 if window_seconds > 0 else 0
+                ),
+            }
+        )
+    host_results.sort(key=lambda r: -r["utilization_pct"])
+
+    return results, host_results
 
 
-def format_report(results: list[dict], hours: int) -> str:
+def format_report(results: list[dict], host_results: list[dict], hours: int) -> str:
     """Format results as markdown report."""
     lines = [
         "# Runner Utilization Report",
@@ -415,11 +452,40 @@ def format_report(results: list[dict], hours: int) -> str:
         f"**Time window:** Last {hours} hours",
         f"**Generated:** {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}",
         "",
-        "## Concurrency Analysis",
+        "## Per Host Utilization",
         "",
-        "| Label | Runners (API/Effective) | Peak Concurrent | Avg Concurrent | Saturation Time | Peak Queue |",
-        "|-------|-------------------------|-----------------|----------------|-----------------|------------|",
+        "Each physical runner machine is counted once, regardless of how many "
+        "overlapping labels it advertises (e.g. a single B200 host advertises "
+        "`4-gpu-b200`, `4-gpu-b200-kernel`, `4-gpu-b200-low-disk`, "
+        "`4-gpu-b200-kernel-low-disk` — but only one job runs on it at a time). "
+        "**This is the source-of-truth view of capacity utilization.** "
+        "If you want per-class numbers, see the Per Label section below, but "
+        "note those denominators are inflated when labels share hosts.",
+        "",
+        "| Host | Jobs | Busy (hrs) | Utilization | Labels |",
+        "|------|------|------------|-------------|--------|",
     ]
+    for h in host_results:
+        bar = "█" * int(h["utilization_pct"] / 10) + "░" * (
+            10 - int(h["utilization_pct"] / 10)
+        )
+        labels_str = ", ".join(h["labels"]) if h["labels"] else "—"
+        lines.append(
+            f"| {h['host']} | {h['num_jobs']} | "
+            f"{h['busy_hours']:.1f} | "
+            f"{h['utilization_pct']:.1f}% {bar} | "
+            f"{labels_str} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Concurrency Analysis",
+            "",
+            "| Label | Runners (API/Effective) | Peak Concurrent | Avg Concurrent | Saturation Time | Peak Queue |",
+            "|-------|-------------------------|-----------------|----------------|-----------------|------------|",
+        ]
+    )
 
     for r in results:
         effective = r["effective_runners"]
@@ -477,6 +543,15 @@ def format_report(results: list[dict], hours: int) -> str:
             "",
             "## Summary by Runner Label",
             "",
+            "Note: hosts often advertise multiple labels (e.g. one B200 host "
+            "carries `4-gpu-b200`, `4-gpu-b200-kernel`, `4-gpu-b200-low-disk`, "
+            "`4-gpu-b200-kernel-low-disk`; one H100 GPU pair carries "
+            "`2-gpu-runner`, `2-gpu-large`, `2-gpu-h100`, `1-gpu-h100-h200`). "
+            "Each label below is shown against its own `num_runners × window` "
+            "denominator, which double-counts capacity when labels share "
+            "hosts and makes per-label utilization look low. **Use the Per "
+            "Host Utilization table above for actual host utilization.**",
+            "",
             "| Label | Runners | Jobs | Active (hrs) | Utilization | Avg Queue | Max Queue |",
             "|-------|---------|------|--------------|-------------|-----------|-----------|",
         ]
@@ -506,8 +581,8 @@ def main():
     parser.add_argument("--output", type=str, help="Output file (default: stdout)")
     args = parser.parse_args()
 
-    results = calculate_utilization(args.repo, args.hours, args.filter)
-    report = format_report(results, args.hours)
+    results, host_results = calculate_utilization(args.repo, args.hours, args.filter)
+    report = format_report(results, host_results, args.hours)
 
     if args.output:
         with open(args.output, "w") as f:


### PR DESCRIPTION
The runner-utilization report's Active hours and Utilization columns under-counted by ~2-4× on busy days. Three causes, all fixed:

1. **Sibling labels split capacity.** A single B200 host advertises `4-gpu-b200`, `4-gpu-b200-kernel`, `4-gpu-b200-low-disk`, `4-gpu-b200-kernel-low-disk` — the old denominator put it in *every* label's capacity bucket while busy time only credited the one label that dispatched the job. Fix: per-label numerator now sums all jobs on the pool's hosts (any sibling label), so siblings sharing a host set show the same util.
2. **Re-runs were dropped.** Default `filter=latest` hides re-run attempts that consumed real host time. Switched to `filter=all`.
3. **GH API rate limits silently dropped runs.** Empirical scan showed up to ~37% of runs failing on a 24h window, dropped by `except Exception: return None`. Added retry-with-backoff (10 attempts, ≤60s, jitter), lowered threadpool concurrency 20→4, and pre-filter out non-GPU workflows (docs/lint/release/etc.) so the API budget covers GPU work. Surface a "data completeness" warning at the top if any fetches still fail.

Report schema is unchanged: Summary by Runner Label → Concurrency Analysis → Recommendations.

Verified output: https://github.com/sgl-project/sglang/actions/runs/25152808318