### PR TITLE
Fix mega-MoE crash on idle DP-attention ranks under tvm-ffi DeepGEMM

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1252,8 +1252,10 @@ class DeepseekV2MoE(nn.Module):
                 buf.topk_idx[num_tokens:].fill_(-1)
                 buf.topk_weights[num_tokens:].zero_()
 
+        # Allocate at least one row so y has a non-null CUDA data_ptr;
+        # the DeepGEMM tvm-ffi binding rejects nullptr in convert_to_torch_tensor().
         y = torch.empty(
-            (num_tokens, hidden_size),
+            (max(num_tokens, 1), hidden_size),
             dtype=torch.bfloat16,
             device=hidden_states.device,
         )
@@ -1268,6 +1270,7 @@ class DeepseekV2MoE(nn.Module):
             activation_clamp=swiglu_limit,
             fast_math=True,
         )
+        y = y[:num_tokens]
 
         if not self.experts.should_fuse_routed_scaling_factor_in_topk:
             y.mul_(self.routed_scaling_factor)


### PR DESCRIPTION
## Summary
- On idle DP-attention ranks (num_tokens == 0), `_run_mega_routed` allocates `y = torch.empty((0, H), ...)`, whose CUDA storage is empty so `data_ptr()` is `nullptr`.
- DeepGEMM's tvm-ffi binding (introduced upstream in commit `ffb3d29`, "support tvm ffi interfaces") reconstructs a `torch::Tensor` from the `tvm::ffi::TensorView` via `from_blob(data_ptr, ...)`, which calls `getDeviceFromPtr(data_ptr)` and rejects nullptr with `tvm.error.InternalError: The specified pointer resides on host memory and is not registered with any CUDA device.`
- Mega-MoE is collective on the EP symmetric buffer, so the rank can't skip the call. Fix: allocate `y` with at least 1 row to guarantee a valid CUDA pointer, then truncate back to `num_tokens` before return — caller-visible behavior is unchanged.

## Repro
```
CUDA_VISIBLE_DEVICES=4,5,6,7 NVSHMEM_DISABLE_IB=1 \
  SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE=1 SGLANG_OPT_FIX_HASH_MEGA_MOE=1 \
  SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK=1024 \
  SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256 \
  sglang serve --trust-remote-code --model-path deepseek-ai/DeepSeek-V4-Flash \
    --tp 4 --dp 4 --enable-dp-attention --moe-a2a-backend deepep \
    --mem-fraction-static 0.9 --cuda-graph-max-bs 64 --max-running-requests 256 \
    --deepep-config '{"normal_dispatch":{"num_sms":96},"normal_combine":{"num_sms":96}}' \
    --host 0.0.0.0 --port 30000
```
Sending any request crashes the scheduler with the `tvm.error.InternalError` above (origin frame: `deep_gemm::convert_to_torch_tensor` → `from_blob` → `getDeviceFromPtr`).

## Test plan
- [x] B200, DeepGEMM `2e21741`: server boots and `sgldev acc send-one` returns a valid 512-token response (108 tok/s) with no scheduler exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)