### PR TITLE
Code cleanup and device timer refactor for metrics collector

### DIFF
--- a/docs/references/environment_variables.md
+++ b/docs/references/environment_variables.md
@@ -12,7 +12,6 @@ SGLang supports various environment variables that can be used to configure its 
 | `SGLANG_HOST_IP`                          | Host IP address for the server                                                                                                   | `0.0.0.0`                    |
 | `SGLANG_PORT`                             | Port for the server                                                                                                              | auto-detected                |
 | `SGLANG_LOGGING_CONFIG_PATH`              | Custom logging configuration path                                                                                                | Not set                      |
-| `SGLANG_DISABLE_REQUEST_LOGGING`          | Disable request logging                                                                                                          | `false`                      |
 | `SGLANG_LOG_REQUEST_HEADERS`              | Comma-separated list of additional HTTP headers to log when `--log-requests` is enabled. Appends to the default `x-smg-routing-key`. | Not set                      |
 | `SGLANG_HEALTH_CHECK_TIMEOUT`             | Timeout for health check in seconds                                                                                              | `20`                         |
 | `SGLANG_EPLB_HEATMAP_COLLECTION_INTERVAL` | The interval of passes to collect the metric of selected count of physical experts on each layer and GPU rank. 0 means disabled. | `0`                          |

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -169,7 +169,6 @@ class Envs:
     SGLANG_LOG_GC = EnvBool(False)
     SGLANG_LOG_FORWARD_ITERS = EnvBool(False)
     SGLANG_LOG_MS = EnvBool(False)
-    SGLANG_DISABLE_REQUEST_LOGGING = EnvBool(False)
     SGLANG_LOG_REQUEST_EXCEEDED_MS = EnvInt(-1)
     SGLANG_LOG_REQUEST_HEADERS = EnvTuple(tuple())
     SGLANG_LOG_SCHEDULER_STATUS_TARGET = EnvStr("")
@@ -186,7 +185,6 @@ class Envs:
     SGLANG_GRAMMAR_POLL_INTERVAL = EnvFloat(0.005)
     SGLANG_GRAMMAR_MAX_POLL_ITERATIONS = EnvInt(10000)
     SGLANG_DISABLE_OUTLINES_DISK_CACHE = EnvBool(False)
-
 
     # Test & Debug
     SGLANG_DETECT_SLOW_RANK = EnvBool(False)
@@ -425,9 +423,7 @@ class Envs:
     # Flash Attention
     SGLANG_USE_SGL_FA3_KERNEL = EnvBool(True)
 
-    # vLLM dependencies (TODO: they have been deprecated, we can remove them safely)
-    USE_VLLM_CUTLASS_W8A8_FP8_KERNEL = EnvBool(False)
-
+    # Kernels
     USE_TRITON_W8A8_FP8_KERNEL = EnvBool(False)
     SGLANG_RETURN_ORIGINAL_LOGPROB = EnvBool(False)
     SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN = EnvBool(False)

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -119,7 +119,6 @@ if _is_cuda:
         return mat_a.new_empty((M, N), dtype=out_dtype)
 
 
-use_vllm_cutlass_w8a8_fp8_kernel = get_bool_env_var("USE_VLLM_CUTLASS_W8A8_FP8_KERNEL")
 use_triton_w8a8_fp8_kernel = get_bool_env_var("USE_TRITON_W8A8_FP8_KERNEL")
 
 # Input scaling factors are no longer optional in _scaled_mm starting

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2933,11 +2933,6 @@ class Scheduler(
                     batch.spec_info = batch_result.next_draft_input
                     batch.spec_info.future_indices = future_indices
 
-                    # batch.spec_info = EagleDraftInput(
-                    #     future_indices=future_indices,
-                    #     verify_done=batch_result.next_draft_input.verify_done,
-                    # )
-
                     # The future value, usually for next batch preparation
                     # Current implementation strictly synchronizes the seq_lens
                     batch.seq_lens = batch_result.next_draft_input.new_seq_lens

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -760,7 +760,9 @@ class Scheduler(
         if self.enable_metrics and hasattr(self, "metrics_collector"):
             self.metrics_collector.emit_constants(
                 max_total_num_tokens=self.max_total_num_tokens,
-                max_running_requests_under_SLO=getattr(self, "max_running_requests_under_SLO", None),
+                max_running_requests_under_SLO=getattr(
+                    self, "max_running_requests_under_SLO", None
+                ),
                 engine_startup_time=0.0,
                 engine_load_weights_time=0.0,
                 page_size=self.page_size,
@@ -1480,7 +1482,6 @@ class Scheduler(
             recv_reqs = self.recv_requests()
             self.process_input_requests(recv_reqs)
             if self._engine_paused:
-                self.cancel_bubble_timer()
                 continue
 
             # Get the next batch to run
@@ -1535,7 +1536,6 @@ class Scheduler(
                 self.result_queue.append((batch.copy(), batch_result))
             else:
                 batch_result = None
-                self.cancel_bubble_timer()
 
             # Process the last batch
             if self.last_batch:
@@ -2907,7 +2907,7 @@ class Scheduler(
                 bs = len(model_worker_batch.seq_lens)
                 future_indices = self.future_map.alloc_future_indices(bs)
 
-                with self.forward_stream_ctx, self.record_bubble_metrics(batch):
+                with self.forward_stream_ctx:
                     self.forward_stream.wait_stream(self.schedule_stream)
                     self.future_map.resolve_future(model_worker_batch)
                     with self.record_forward_metrics(batch):
@@ -2983,7 +2983,7 @@ class Scheduler(
 
             if self.enable_overlap:
                 self.record_batch_in_overlap(model_worker_batch)
-                with self.forward_stream_ctx, self.record_bubble_metrics(batch):
+                with self.forward_stream_ctx:
                     self.forward_stream.wait_stream(self.schedule_stream)
                     pooler_output = self.tp_worker.forward_batch_embedding(
                         model_worker_batch

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -744,10 +744,10 @@ class Scheduler(
         set_random_seed(self.random_seed)
 
         # Print debug info
+        avail_mem = get_available_gpu_memory(
+            self.device, self.gpu_id, empty_cache=False
+        )
         if self.tp_rank == 0:
-            avail_mem = get_available_gpu_memory(
-                self.device, self.gpu_id, empty_cache=False
-            )
             logger.info(
                 f"max_total_num_tokens={self.max_total_num_tokens}, "
                 f"chunked_prefill_size={self.server_args.chunked_prefill_size}, "
@@ -758,8 +758,15 @@ class Scheduler(
             )
 
         if self.enable_metrics and hasattr(self, "metrics_collector"):
-            self.metrics_collector.emit_cache_config_info(
-                self.page_size, self.max_total_num_tokens // self.page_size
+            self.metrics_collector.emit_constants(
+                max_total_num_tokens=self.max_total_num_tokens,
+                max_running_requests_under_SLO=self.stats.max_running_requests_under_SLO,
+                engine_startup_time=0.0,
+                engine_load_weights_time=0.0,
+                page_size=self.page_size,
+                num_pages=self.max_total_num_tokens // self.page_size,
+                context_len=self.model_config.context_len,
+                available_gpu_memory_gb=avail_mem,
             )
 
     def init_cache_with_memory_pool(self):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -766,7 +766,7 @@ class Scheduler(
                 page_size=self.page_size,
                 num_pages=self.max_total_num_tokens // self.page_size,
                 context_len=self.model_config.context_len,
-                available_gpu_memory_gb=avail_mem,
+                startup_available_gpu_memory_gb=avail_mem,
             )
 
     def init_cache_with_memory_pool(self):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -760,7 +760,7 @@ class Scheduler(
         if self.enable_metrics and hasattr(self, "metrics_collector"):
             self.metrics_collector.emit_constants(
                 max_total_num_tokens=self.max_total_num_tokens,
-                max_running_requests_under_SLO=self.stats.max_running_requests_under_SLO,
+                max_running_requests_under_SLO=getattr(self, "max_running_requests_under_SLO", None),
                 engine_startup_time=0.0,
                 engine_load_weights_time=0.0,
                 page_size=self.page_size,

--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -555,6 +555,9 @@ class SchedulerRuntimeCheckerMixin:
         # reset token ratio
         self.new_token_ratio = self.init_new_token_ratio
 
+        # reset device timer window so idle time isn't counted
+        self.reset_device_timer_window()
+
         # sleep until next event
         self.maybe_sleep_on_idle()
 

--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -10,7 +10,6 @@ from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.environ import envs
 from sglang.srt.observability.metrics_collector import QueueCount
 from sglang.srt.utils.common import ceil_align, raise_error_or_warn
-from sglang.srt.utils.request_logger import disable_request_logging
 from sglang.srt.utils.watchdog import WatchdogRaw
 
 if TYPE_CHECKING:
@@ -564,7 +563,7 @@ def create_scheduler_watchdog(
     scheduler: Scheduler, watchdog_timeout: float, soft: bool = False
 ) -> WatchdogRaw:
     def dump_info() -> str:
-        if scheduler.is_initializing or disable_request_logging():
+        if scheduler.is_initializing:
             return ""
         _, messages = scheduler._check_all_pools(scheduler.get_pool_stats())
         return (

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -2161,13 +2161,6 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 state.last_completion_tokens = completion_tokens
 
         if state.finished:
-            retraction_count = (
-                recv_obj.retraction_counts[i]
-                if getattr(recv_obj, "retraction_counts", None)
-                and i < len(recv_obj.retraction_counts)
-                else 0
-            )
-
             # Get detailed cache breakdown if available
             cached_tokens_details = None
             if (
@@ -2183,7 +2176,6 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 recv_obj.cached_tokens[i],
                 state.time_stats.get_e2e_latency(),
                 self._request_has_grammar(state.obj),
-                retraction_count,
                 cached_tokens_details,
             )
 

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -743,14 +743,6 @@ class SchedulerMetricsCollector:
             ),
             labelnames=list(labels.keys()) + ["category"],
         )
-        self.gpu_overlap_wait_seconds_total = Counter(
-            name="sglang:gpu_overlap_wait_seconds_total",
-            documentation=(
-                "Total time that GPU forward stream was idle waiting for "
-                "the CPU schedule stream (overlap bubble)."
-            ),
-            labelnames=list(labels.keys()) + ["category"],
-        )
         self.estimated_flops_per_gpu_total = Counter(
             name="sglang:estimated_flops_per_gpu_total",
             documentation=(
@@ -1021,16 +1013,6 @@ class SchedulerMetricsCollector:
                     **dp_cooperation_info.to_labels(),
                 ).inc(delta)
 
-    def increment_gpu_overlap_wait_seconds(
-        self,
-        category: str,
-        t: float,
-        dp_cooperation_info: Optional[DPCooperationInfo],
-    ):
-        self.gpu_overlap_wait_seconds_total.labels(
-            **self.labels, category=category
-        ).inc(t)
-
     def increment_gpu_execution_seconds(
         self,
         category: str,
@@ -1246,23 +1228,24 @@ class TokenizerMetricsCollector:
             8000,
             9000,
             10000,
-            12000,
+            12500,
             15000,
-            18000,
+            17500,
             20000,
-            22000,
+            22500,
             25000,
-            28000,
+            27500,
             30000,
             35000,
             40000,
             60000,
-            90000,
+            80000,
             100000,
             200000,
             300000,
+            400000,
             600000,
-            900000,
+            800000,
             1000000,
             1100000,
         ]

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -97,7 +97,6 @@ class SchedulerStats:
 
     # Utilization
     utilization: float = 0.0
-    max_running_requests_under_SLO: Optional[int] = None
 
     # Scheduler policy
     new_token_ratio: float = 0.0

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -41,6 +41,26 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
+class QueueCount:
+    """Holds both the total count and optional per-priority breakdown for a queue."""
+
+    total: int = 0
+    by_priority: Optional[Dict[int, int]] = None
+
+    @classmethod
+    def from_reqs(cls, reqs: List[Req], enable_priority_scheduling: bool = False):
+        # NOTE: If requests have priority=None (no --default-priority-value set),
+        # Counter will produce {None: N}, resulting in priority="None" Prometheus labels.
+        # Set --default-priority-value when enabling priority scheduling to avoid this.
+        by_priority = (
+            dict(Counter(req.priority for req in reqs))
+            if enable_priority_scheduling
+            else None
+        )
+        return cls(total=len(reqs), by_priority=by_priority)
+
+
+@dataclass
 class SchedulerStats:
     # Basics
     num_running_reqs: QueueCount = field(default_factory=QueueCount)
@@ -1180,7 +1200,9 @@ class SchedulerMetricsCollector:
         self._log_gauge(self.page_size, page_size)
         self._log_gauge(self.num_pages, num_pages)
         self._log_gauge(self.context_len, context_len)
-        self._log_gauge(self.startup_available_gpu_memory_gb, startup_available_gpu_memory_gb)
+        self._log_gauge(
+            self.startup_available_gpu_memory_gb, startup_available_gpu_memory_gb
+        )
 
 
 class TokenizerMetricsCollector:
@@ -1688,23 +1710,3 @@ def get_histogram_conf_from_env(env_var_name: str) -> Optional[List[float]]:
     if not env_var_value:
         return None
     return [float(x) for x in env_var_value.split(",")]
-
-
-@dataclass
-class QueueCount:
-    """Holds both the total count and optional per-priority breakdown for a queue."""
-
-    total: int = 0
-    by_priority: Optional[Dict[int, int]] = None
-
-    @classmethod
-    def from_reqs(cls, reqs: List[Req], enable_priority_scheduling: bool = False):
-        # NOTE: If requests have priority=None (no --default-priority-value set),
-        # Counter will produce {None: N}, resulting in priority="None" Prometheus labels.
-        # Set --default-priority-value when enabling priority scheduling to avoid this.
-        by_priority = (
-            dict(Counter(req.priority for req in reqs))
-            if enable_priority_scheduling
-            else None
-        )
-        return cls(total=len(reqs), by_priority=by_priority)

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -864,8 +864,8 @@ class SchedulerMetricsCollector:
             labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
         )
-        self.available_gpu_memory_gb = Gauge(
-            name="sglang:available_gpu_memory_gb",
+        self.startup_available_gpu_memory_gb = Gauge(
+            name="sglang:startup_available_gpu_memory_gb",
             documentation="Available GPU memory in GB at startup.",
             labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
@@ -1017,7 +1017,6 @@ class SchedulerMetricsCollector:
         t: float,
         dp_cooperation_info: Optional[DPCooperationInfo],
     ):
-        logger.debug(f"GPU execution seconds: {category=} {t=:.3f}")
         self.gpu_execution_seconds_total.labels(**self.labels, category=category).inc(t)
         if dp_cooperation_info is not None:
             self.dp_cooperation_gpu_execution_seconds_total.labels(
@@ -1169,7 +1168,7 @@ class SchedulerMetricsCollector:
         page_size: int,
         num_pages: int,
         context_len: int,
-        available_gpu_memory_gb: float,
+        startup_available_gpu_memory_gb: float,
     ) -> None:
         self._log_gauge(self.max_total_num_tokens, max_total_num_tokens)
         if max_running_requests_under_SLO is not None:
@@ -1181,7 +1180,7 @@ class SchedulerMetricsCollector:
         self._log_gauge(self.page_size, page_size)
         self._log_gauge(self.num_pages, num_pages)
         self._log_gauge(self.context_len, context_len)
-        self._log_gauge(self.available_gpu_memory_gb, available_gpu_memory_gb)
+        self._log_gauge(self.startup_available_gpu_memory_gb, startup_available_gpu_memory_gb)
 
 
 class TokenizerMetricsCollector:

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -66,15 +66,14 @@ class SchedulerStats:
     # Absolute token counts for the full-attention KV cache pool.
     # Invariant: kv_available_tokens + kv_evictable_tokens + kv_used_tokens <= max_total_num_tokens
     # (the gap accounts for protected/session-held tokens not exposed here).
+    # max_total_num_tokens is emitted once at startup via emit_constants.
     #
-    # max_total_num_tokens: total capacity of the full-attention KV cache pool.
     # kv_available_tokens:  free (unallocated) slots in the pool.
     # kv_evictable_tokens:  slots holding radix-cached KV data that can be evicted for new requests.
     # kv_used_tokens:       actively used slots (locked by running requests). Equals full_num_used.
     # num_used_tokens:      max(full_num_used, swa_num_used) for hybrid-SWA models, else full_num_used.
     #                       Does NOT include the mamba pool.
     num_used_tokens: int = 0
-    max_total_num_tokens: int = 0
     kv_available_tokens: int = 0
     kv_evictable_tokens: int = 0
     kv_used_tokens: int = 0
@@ -99,10 +98,6 @@ class SchedulerStats:
     # Utilization
     utilization: float = 0.0
     max_running_requests_under_SLO: Optional[int] = None
-
-    # Engine startup
-    engine_startup_time: float = 0.0
-    engine_load_weights_time: float = 0.0
 
     # Scheduler policy
     new_token_ratio: float = 0.0
@@ -257,12 +252,6 @@ class SchedulerMetricsCollector:
             labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
         )
-        self.max_total_num_tokens = Gauge(
-            name="sglang:max_total_num_tokens",
-            documentation="Maximum total number of tokens in the KV cache pool.",
-            labelnames=labels.keys(),
-            multiprocess_mode="mostrecent",
-        )
         self.kv_available_tokens = Gauge(
             name="sglang:kv_available_tokens",
             documentation="Number of free token slots in the KV cache pool.",
@@ -414,28 +403,6 @@ class SchedulerMetricsCollector:
         self.utilization = Gauge(
             name="sglang:utilization",
             documentation="The utilization.",
-            labelnames=labels.keys(),
-            multiprocess_mode="mostrecent",
-        )
-        self.max_running_requests_under_SLO = Gauge(
-            name="sglang:max_running_requests_under_SLO",
-            documentation="The maximum number of running requests under SLO.",
-            labelnames=labels.keys(),
-            multiprocess_mode="mostrecent",
-        )
-
-        # =================================================================
-        # Engine startup
-        # =================================================================
-        self.engine_startup_time = Gauge(
-            name="sglang:engine_startup_time",
-            documentation="The time taken for the engine to start up.",
-            labelnames=labels.keys(),
-            multiprocess_mode="mostrecent",
-        )
-        self.engine_load_weights_time = Gauge(
-            name="sglang:engine_load_weights_time",
-            documentation="The time taken for the engine to load weights.",
             labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
         )
@@ -854,15 +821,54 @@ class SchedulerMetricsCollector:
         )
 
         # =================================================================
-        # Other
+        # Constants (set once at startup via emit_constants)
         # =================================================================
-        # This is a work-around Info metric since Info metrics are not supported in Prometheus.
-        # Similar to vLLM, https://github.com/vllm-project/vllm/blob/main/vllm/v1/metrics/loggers.py
-        # If more Info metrics are needed, we can create a common _log_info function.
-        self.cache_config_info = Gauge(
-            name="sglang:cache_config_info",
-            documentation="Cache configuration information.",
-            labelnames=["page_size", "num_pages"],
+        self.max_total_num_tokens = Gauge(
+            name="sglang:max_total_num_tokens",
+            documentation="Maximum total number of tokens in the KV cache pool.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+        self.max_running_requests_under_SLO = Gauge(
+            name="sglang:max_running_requests_under_SLO",
+            documentation="The maximum number of running requests under SLO.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+        self.engine_startup_time = Gauge(
+            name="sglang:engine_startup_time",
+            documentation="The time taken for the engine to start up.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+        self.engine_load_weights_time = Gauge(
+            name="sglang:engine_load_weights_time",
+            documentation="The time taken for the engine to load weights.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+        self.page_size = Gauge(
+            name="sglang:page_size",
+            documentation="KV cache page size in tokens.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+        self.num_pages = Gauge(
+            name="sglang:num_pages",
+            documentation="Number of KV cache pages.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+        self.context_len = Gauge(
+            name="sglang:context_len",
+            documentation="Maximum context length.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+        self.available_gpu_memory_gb = Gauge(
+            name="sglang:available_gpu_memory_gb",
+            documentation="Available GPU memory in GB at startup.",
+            labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
         )
 
@@ -1057,7 +1063,6 @@ class SchedulerMetricsCollector:
 
         # Absolute token counts
         self._log_gauge(self.num_used_tokens, stats.num_used_tokens)
-        self._log_gauge(self.max_total_num_tokens, stats.max_total_num_tokens)
         self._log_gauge(self.kv_available_tokens, stats.kv_available_tokens)
         self._log_gauge(self.kv_evictable_tokens, stats.kv_evictable_tokens)
         self._log_gauge(self.kv_used_tokens, stats.kv_used_tokens)
@@ -1089,18 +1094,6 @@ class SchedulerMetricsCollector:
 
         # Utilization
         self._log_gauge(self.utilization, stats.utilization)
-        if stats.max_running_requests_under_SLO is not None:
-            self._log_gauge(
-                self.max_running_requests_under_SLO,
-                stats.max_running_requests_under_SLO,
-            )
-
-        # Engine startup
-        self._log_gauge(self.engine_startup_time, stats.engine_startup_time)
-        if stats.engine_load_weights_time is not None:
-            self._log_gauge(
-                self.engine_load_weights_time, stats.engine_load_weights_time
-            )
 
         # Scheduler policy
         self._log_gauge(self.new_token_ratio, stats.new_token_ratio)
@@ -1168,8 +1161,28 @@ class SchedulerMetricsCollector:
             )
         self.num_grammar_total.labels(**self.labels).inc(1)
 
-    def emit_cache_config_info(self, page_size: int, num_pages: int) -> None:
-        self.cache_config_info.labels(page_size=page_size, num_pages=num_pages).set(1)
+    def emit_constants(
+        self,
+        max_total_num_tokens: int,
+        max_running_requests_under_SLO: Optional[int],
+        engine_startup_time: float,
+        engine_load_weights_time: float,
+        page_size: int,
+        num_pages: int,
+        context_len: int,
+        available_gpu_memory_gb: float,
+    ) -> None:
+        self._log_gauge(self.max_total_num_tokens, max_total_num_tokens)
+        if max_running_requests_under_SLO is not None:
+            self._log_gauge(
+                self.max_running_requests_under_SLO, max_running_requests_under_SLO
+            )
+        self._log_gauge(self.engine_startup_time, engine_startup_time)
+        self._log_gauge(self.engine_load_weights_time, engine_load_weights_time)
+        self._log_gauge(self.page_size, page_size)
+        self._log_gauge(self.num_pages, num_pages)
+        self._log_gauge(self.context_len, context_len)
+        self._log_gauge(self.available_gpu_memory_gb, available_gpu_memory_gb)
 
 
 class TokenizerMetricsCollector:

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -40,59 +40,40 @@ SGLANG_TEST_REQUEST_TIME_STATS = get_bool_env_var("SGLANG_TEST_REQUEST_TIME_STAT
 logger = logging.getLogger(__name__)
 
 
-def get_histogram_conf_from_env(env_var_name: str) -> Optional[List[float]]:
-    """
-    Get the histogram configuration from the environment variable.
-    env value should be like "0.1,0.2,0.5,1,2"
-    """
-    if env_var_name not in os.environ:
-        return None
-    # if the env var is not set or empty, return None
-    env_var_value = os.environ[env_var_name]
-    if not env_var_value:
-        return None
-    return [float(x) for x in env_var_value.split(",")]
-
-
-@dataclass
-class QueueCount:
-    """Holds both the total count and optional per-priority breakdown for a queue."""
-
-    total: int = 0
-    by_priority: Optional[Dict[int, int]] = None
-
-    @classmethod
-    def from_reqs(cls, reqs: List[Req], enable_priority_scheduling: bool = False):
-        # NOTE: If requests have priority=None (no --default-priority-value set),
-        # Counter will produce {None: N}, resulting in priority="None" Prometheus labels.
-        # Set --default-priority-value when enabling priority scheduling to avoid this.
-        by_priority = (
-            dict(Counter(req.priority for req in reqs))
-            if enable_priority_scheduling
-            else None
-        )
-        return cls(total=len(reqs), by_priority=by_priority)
-
-
 @dataclass
 class SchedulerStats:
     # Basics
     num_running_reqs: QueueCount = field(default_factory=QueueCount)
-    num_used_tokens: int = 0
-    # FIXME: token_usage is actually max usage across all pools (KV, SWA, mamba),
-    # not just KV token usage. Rename requires API deprecation.
-    token_usage: float = 0.0
-    full_token_usage: float = 0.0
-    pending_prealloc_token_usage: float = 0.0
-    swa_token_usage: float = 0.0
-    mamba_usage: float = 0.0
-    decode_sum_seq_lens: int = 0
-    gen_throughput: float = 0.0
     num_queue_reqs: QueueCount = field(default_factory=QueueCount)
     num_grammar_queue_reqs: int = 0
-    num_running_reqs_offline_batch: int = 0
+    gen_throughput: float = 0.0
     cache_hit_rate: float = 0.0
+    decode_sum_seq_lens: int = 0
 
+    # Memory pool usage ratios (0.0–1.0).
+    # Each pool tracks: used = total - available - evictable, usage = used / total.
+    #
+    # token_usage:      max(full, swa, mamba) — the bottleneck across all pools.
+    #                   FIXME: misleadingly named "token_usage"; rename requires API deprecation.
+    # full_token_usage: full-attention KV cache pool usage (always active).
+    # swa_token_usage:  sliding-window attention KV cache pool usage (hybrid SWA models only, e.g. Gemma2).
+    # mamba_usage:      Mamba SSM state pool usage (hybrid SSM models only, e.g. Jamba).
+    token_usage: float = 0.0
+    full_token_usage: float = 0.0
+    swa_token_usage: float = 0.0
+    mamba_usage: float = 0.0
+
+    # Absolute token counts for the full-attention KV cache pool.
+    # Invariant: kv_available_tokens + kv_evictable_tokens + kv_used_tokens <= max_total_num_tokens
+    # (the gap accounts for protected/session-held tokens not exposed here).
+    #
+    # max_total_num_tokens: total capacity of the full-attention KV cache pool.
+    # kv_available_tokens:  free (unallocated) slots in the pool.
+    # kv_evictable_tokens:  slots holding radix-cached KV data that can be evicted for new requests.
+    # kv_used_tokens:       actively used slots (locked by running requests). Equals full_num_used.
+    # num_used_tokens:      max(full_num_used, swa_num_used) for hybrid-SWA models, else full_num_used.
+    #                       Does NOT include the mamba pool.
+    num_used_tokens: int = 0
     max_total_num_tokens: int = 0
     kv_available_tokens: int = 0
     kv_evictable_tokens: int = 0
@@ -113,6 +94,7 @@ class SchedulerStats:
     num_decode_transfer_queue_reqs: QueueCount = field(default_factory=QueueCount)
     kv_transfer_speed_gb_s: float = 0.0
     kv_transfer_latency_ms: float = 0.0
+    pending_prealloc_token_usage: float = 0.0
 
     # Utilization
     utilization: float = 0.0
@@ -121,10 +103,12 @@ class SchedulerStats:
     # Engine startup
     engine_startup_time: float = 0.0
     engine_load_weights_time: float = 0.0
+
+    # Scheduler policy
     new_token_ratio: float = 0.0
 
     # CUDA graph
-    is_cuda_graph: float = 0.0
+    is_cuda_graph: int = 0
 
     # LoRA pool metrics
     lora_pool_slots_used: int = 0
@@ -196,57 +180,12 @@ class SchedulerMetricsCollector:
         self.last_log_time = time.perf_counter()
         self._known_priorities: Set[int] = set()
 
+        # =================================================================
+        # Basics
+        # =================================================================
         self.num_running_reqs = Gauge(
             name="sglang:num_running_reqs",
             documentation="The number of running requests.",
-            labelnames=labels.keys(),
-            multiprocess_mode="mostrecent",
-        )
-        self.num_used_tokens = Gauge(
-            name="sglang:num_used_tokens",
-            documentation="The number of used tokens.",
-            labelnames=labels.keys(),
-            multiprocess_mode="mostrecent",
-        )
-        self.token_usage = Gauge(
-            name="sglang:token_usage",
-            documentation="The token usage.",
-            labelnames=labels.keys(),
-            multiprocess_mode="mostrecent",
-        )
-        self.full_token_usage = Gauge(
-            name="sglang:full_token_usage",
-            documentation="The token usage for full attention layers.",
-            labelnames=labels.keys(),
-            multiprocess_mode="mostrecent",
-        )
-        self.pending_prealloc_token_usage = Gauge(
-            name="sglang:pending_prealloc_token_usage",
-            documentation="The token usage for pending preallocated tokens (not preallocated yet).",
-            labelnames=labels.keys(),
-            multiprocess_mode="mostrecent",
-        )
-        self.swa_token_usage = Gauge(
-            name="sglang:swa_token_usage",
-            documentation="The token usage for SWA layers.",
-            labelnames=labels.keys(),
-            multiprocess_mode="mostrecent",
-        )
-        self.mamba_usage = Gauge(
-            name="sglang:mamba_usage",
-            documentation="The token usage for Mamba layers.",
-            labelnames=labels.keys(),
-            multiprocess_mode="mostrecent",
-        )
-        self.decode_sum_seq_lens = Gauge(
-            name="sglang:decode_sum_seq_lens",
-            documentation="The sum of all sequence lengths in decode.",
-            labelnames=labels.keys(),
-            multiprocess_mode="mostrecent",
-        )
-        self.gen_throughput = Gauge(
-            name="sglang:gen_throughput",
-            documentation="The generation throughput (token/s).",
             labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
         )
@@ -262,9 +201,9 @@ class SchedulerMetricsCollector:
             labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
         )
-        self.num_running_reqs_offline_batch = Gauge(
-            name="sglang:num_running_reqs_offline_batch",
-            documentation="The number of running low-priority offline batch requests(label is 'batch').",
+        self.gen_throughput = Gauge(
+            name="sglang:gen_throughput",
+            documentation="The generation throughput (token/s).",
             labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
         )
@@ -274,14 +213,56 @@ class SchedulerMetricsCollector:
             labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
         )
+        self.decode_sum_seq_lens = Gauge(
+            name="sglang:decode_sum_seq_lens",
+            documentation="The sum of all sequence lengths in decode.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
 
+        # =================================================================
+        # Memory pool usage ratios
+        # =================================================================
+        self.token_usage = Gauge(
+            name="sglang:token_usage",
+            documentation="The token usage.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+        self.full_token_usage = Gauge(
+            name="sglang:full_token_usage",
+            documentation="The token usage for full attention layers.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+        self.swa_token_usage = Gauge(
+            name="sglang:swa_token_usage",
+            documentation="The token usage for SWA layers.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+        self.mamba_usage = Gauge(
+            name="sglang:mamba_usage",
+            documentation="The token usage for Mamba layers.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+
+        # =================================================================
+        # Absolute token counts
+        # =================================================================
+        self.num_used_tokens = Gauge(
+            name="sglang:num_used_tokens",
+            documentation="The number of used tokens.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
         self.max_total_num_tokens = Gauge(
             name="sglang:max_total_num_tokens",
             documentation="Maximum total number of tokens in the KV cache pool.",
             labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
         )
-
         self.kv_available_tokens = Gauge(
             name="sglang:kv_available_tokens",
             documentation="Number of free token slots in the KV cache pool.",
@@ -301,7 +282,9 @@ class SchedulerMetricsCollector:
             multiprocess_mode="mostrecent",
         )
 
+        # =================================================================
         # Speculative decoding
+        # =================================================================
         self.spec_accept_length = Gauge(
             name="sglang:spec_accept_length",
             documentation="Mean acceptance length of speculative decoding (accepted drafts + bonus token per forward).",
@@ -315,7 +298,9 @@ class SchedulerMetricsCollector:
             multiprocess_mode="mostrecent",
         )
 
+        # =================================================================
         # Retract
+        # =================================================================
         # TODO maybe remove this old gauge in favor of the new counter
         self.num_retracted_reqs = Gauge(
             name="sglang:num_retracted_reqs",
@@ -344,7 +329,9 @@ class SchedulerMetricsCollector:
             labelnames=labels.keys(),
         )
 
+        # =================================================================
         # PD disaggregation
+        # =================================================================
         self.num_prefill_prealloc_queue_reqs = Gauge(
             name="sglang:num_prefill_prealloc_queue_reqs",
             documentation="The number of requests in the prefill prealloc queue.",
@@ -369,6 +356,24 @@ class SchedulerMetricsCollector:
             labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
         )
+        self.kv_transfer_speed_gb_s = Histogram(
+            name="sglang:kv_transfer_speed_gb_s",
+            documentation="Histogram of KV cache transfer speed in GB/s.",
+            labelnames=labels.keys(),
+            buckets=(0.1, 0.5, 1, 5, 10, 25, 50, 100, 200, 400),
+        )
+        self.kv_transfer_latency_ms = Histogram(
+            name="sglang:kv_transfer_latency_ms",
+            documentation="Histogram of KV cache transfer latency in ms.",
+            labelnames=labels.keys(),
+            buckets=(1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000),
+        )
+        self.pending_prealloc_token_usage = Gauge(
+            name="sglang:pending_prealloc_token_usage",
+            documentation="The token usage for pending preallocated tokens (not preallocated yet).",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
         self.num_bootstrap_failed_reqs = Counter(
             name="sglang:num_bootstrap_failed_reqs_total",
             documentation="The number of bootstrap failed requests.",
@@ -383,18 +388,6 @@ class SchedulerMetricsCollector:
             name="sglang:num_prefill_retries_total",
             documentation="Total number of prefill retries.",
             labelnames=labels.keys(),
-        )
-        self.kv_transfer_speed_gb_s = Histogram(
-            name="sglang:kv_transfer_speed_gb_s",
-            documentation="Histogram of KV cache transfer speed in GB/s.",
-            labelnames=labels.keys(),
-            buckets=(0.1, 0.5, 1, 5, 10, 25, 50, 100, 200, 400),
-        )
-        self.kv_transfer_latency_ms = Histogram(
-            name="sglang:kv_transfer_latency_ms",
-            documentation="Histogram of KV cache transfer latency in ms.",
-            labelnames=labels.keys(),
-            buckets=(1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000),
         )
         self.kv_transfer_bootstrap_ms = Histogram(
             name="sglang:kv_transfer_bootstrap_ms",
@@ -415,7 +408,9 @@ class SchedulerMetricsCollector:
             buckets=(1, 5, 10, 50, 100, 500, 1000, 5000, 10000),
         )
 
+        # =================================================================
         # Utilization
+        # =================================================================
         self.utilization = Gauge(
             name="sglang:utilization",
             documentation="The utilization.",
@@ -429,7 +424,9 @@ class SchedulerMetricsCollector:
             multiprocess_mode="mostrecent",
         )
 
+        # =================================================================
         # Engine startup
+        # =================================================================
         self.engine_startup_time = Gauge(
             name="sglang:engine_startup_time",
             documentation="The time taken for the engine to start up.",
@@ -443,7 +440,114 @@ class SchedulerMetricsCollector:
             multiprocess_mode="mostrecent",
         )
 
-        # Additional queueing time histogram
+        # =================================================================
+        # Scheduler policy
+        # =================================================================
+        self.new_token_ratio = Gauge(
+            name="sglang:new_token_ratio",
+            documentation="The new token ratio.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+
+        # =================================================================
+        # CUDA graph
+        # =================================================================
+        # TODO maybe remove this old gauge in favor of the new counter
+        self.is_cuda_graph = Gauge(
+            name="sglang:is_cuda_graph",
+            documentation="Whether the batch is using CUDA graph.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+        self.cuda_graph_passes_total = Counter(
+            name="sglang:cuda_graph_passes_total",
+            documentation="Total number of forward passes categorized by CUDA graph.",
+            labelnames=list(labels.keys()) + ["mode"],
+        )
+
+        # =================================================================
+        # LoRA pool metrics (only created when LoRA is enabled)
+        # =================================================================
+        if self.enable_lora:
+            self.lora_pool_slots_used = Gauge(
+                name="sglang:lora_pool_slots_used",
+                documentation="Number of LoRA adapter slots currently occupied in GPU memory.",
+                labelnames=labels.keys(),
+                multiprocess_mode="mostrecent",
+            )
+            self.lora_pool_slots_total = Gauge(
+                name="sglang:lora_pool_slots_total",
+                documentation="Total number of LoRA adapter slots available (max_loras_per_batch).",
+                labelnames=labels.keys(),
+                multiprocess_mode="mostrecent",
+            )
+            self.lora_pool_utilization = Gauge(
+                name="sglang:lora_pool_utilization",
+                documentation="LoRA pool utilization ratio (used/total). 1.0 means pool is full.",
+                labelnames=labels.keys(),
+                multiprocess_mode="mostrecent",
+            )
+
+        # =================================================================
+        # HiCache metrics (only created when hierarchical cache is enabled)
+        # =================================================================
+        if self.enable_hierarchical_cache:
+            self.hicache_host_used_tokens = Gauge(
+                name="sglang:hicache_host_used_tokens",
+                documentation="Number of tokens currently used in the host KV cache.",
+                labelnames=labels.keys(),
+                multiprocess_mode="mostrecent",
+            )
+            self.hicache_host_total_tokens = Gauge(
+                name="sglang:hicache_host_total_tokens",
+                documentation="Total capacity of the host KV cache in tokens.",
+                labelnames=labels.keys(),
+                multiprocess_mode="mostrecent",
+            )
+
+        # =================================================================
+        # Streaming session metrics (only created when streaming sessions are enabled)
+        # =================================================================
+        if self.enable_streaming_session:
+            self.num_streaming_sessions = Gauge(
+                name="sglang:num_streaming_sessions",
+                documentation="The number of streaming sessions.",
+                labelnames=labels.keys(),
+                multiprocess_mode="mostrecent",
+            )
+            self.streaming_session_held_tokens = Gauge(
+                name="sglang:streaming_session_held_tokens",
+                documentation="The number of KV tokens currently held by streaming session slots.",
+                labelnames=labels.keys(),
+                multiprocess_mode="mostrecent",
+            )
+
+        # =================================================================
+        # Routing key metrics
+        # =================================================================
+        self.num_unique_running_routing_keys = Gauge(
+            name="sglang:num_unique_running_routing_keys",
+            documentation="Number of unique routing keys in running batch.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+        self.routing_key_running_req_count = GaugeHistogram(
+            name="sglang:routing_key_running_req_count",
+            documentation="Distribution of routing keys by running request count (gt < count <= le).",
+            labelnames=list(labels.keys()),
+            bucket_bounds=ROUTING_KEY_REQ_COUNT_BUCKET_BOUNDS,
+        )
+        self.routing_key_all_req_count = GaugeHistogram(
+            name="sglang:routing_key_all_req_count",
+            documentation="Distribution of routing keys by running+waiting request count (gt < count <= le).",
+            labelnames=list(labels.keys()),
+            bucket_bounds=ROUTING_KEY_REQ_COUNT_BUCKET_BOUNDS,
+        )
+
+        # =================================================================
+        # Request latency
+        # =================================================================
         self.queue_time = Histogram(
             name="sglang:queue_time_seconds",
             documentation="Histogram of queueing time in seconds.",
@@ -487,8 +591,17 @@ class SchedulerMetricsCollector:
                 3000,
             ],
         )
+        self.per_stage_req_latency_seconds = Histogram(
+            name="sglang:per_stage_req_latency_seconds",
+            documentation="The latency of each stage of requests.",
+            # captures latency in range [1ms - ~1191s]
+            buckets=exponential_buckets(start=0.001, width=1.62, length=30),
+            labelnames=list(labels.keys()) + ["stage"],
+        )
 
-        # Grammar metrics
+        # =================================================================
+        # Grammar
+        # =================================================================
         self.grammar_compilation_time = Histogram(
             name="sglang:grammar_compilation_time_seconds",
             documentation="Histogram of grammar compilation time in seconds.",
@@ -616,27 +729,9 @@ class SchedulerMetricsCollector:
             buckets=tree_traversal_time_buckets,
         )
 
-        self.per_stage_req_latency_seconds = Histogram(
-            name="sglang:per_stage_req_latency_seconds",
-            documentation="The latency of each stage of requests.",
-            # captures latency in range [1ms - ~1191s]
-            buckets=exponential_buckets(start=0.001, width=1.62, length=30),
-            labelnames=list(labels.keys()) + ["stage"],
-        )
-
-        # TODO maybe remove this old gauge in favor of the new counter
-        self.is_cuda_graph = Gauge(
-            name="sglang:is_cuda_graph",
-            documentation="Whether the batch is using CUDA graph.",
-            labelnames=labels.keys(),
-            multiprocess_mode="mostrecent",
-        )
-        self.cuda_graph_passes_total = Counter(
-            name="sglang:cuda_graph_passes_total",
-            documentation="Total number of forward passes categorized by CUDA graph.",
-            labelnames=list(labels.keys()) + ["mode"],
-        )
-
+        # =================================================================
+        # Execution
+        # =================================================================
         if (
             labels["moe_ep_rank"] == 0
         ) and envs.SGLANG_ENABLE_EPLB_BALANCEDNESS_METRIC.get():
@@ -645,83 +740,6 @@ class SchedulerMetricsCollector:
                 documentation="Balancedness of MoE in expert parallelism.",
                 labelnames=list(labels.keys()) + ["forward_mode"],
             )
-
-        # LoRA pool metrics (only created when LoRA is enabled)
-        if self.enable_lora:
-            self.lora_pool_slots_used = Gauge(
-                name="sglang:lora_pool_slots_used",
-                documentation="Number of LoRA adapter slots currently occupied in GPU memory.",
-                labelnames=labels.keys(),
-                multiprocess_mode="mostrecent",
-            )
-            self.lora_pool_slots_total = Gauge(
-                name="sglang:lora_pool_slots_total",
-                documentation="Total number of LoRA adapter slots available (max_loras_per_batch).",
-                labelnames=labels.keys(),
-                multiprocess_mode="mostrecent",
-            )
-            self.lora_pool_utilization = Gauge(
-                name="sglang:lora_pool_utilization",
-                documentation="LoRA pool utilization ratio (used/total). 1.0 means pool is full.",
-                labelnames=labels.keys(),
-                multiprocess_mode="mostrecent",
-            )
-
-        # HiCache host-tier metrics (only created when hierarchical cache is enabled)
-        if self.enable_hierarchical_cache:
-            self.hicache_host_used_tokens = Gauge(
-                name="sglang:hicache_host_used_tokens",
-                documentation="Number of tokens currently used in the host KV cache.",
-                labelnames=labels.keys(),
-                multiprocess_mode="mostrecent",
-            )
-            self.hicache_host_total_tokens = Gauge(
-                name="sglang:hicache_host_total_tokens",
-                documentation="Total capacity of the host KV cache in tokens.",
-                labelnames=labels.keys(),
-                multiprocess_mode="mostrecent",
-            )
-
-        # Streaming session metrics (only created when streaming sessions are enabled)
-        if self.enable_streaming_session:
-            self.num_streaming_sessions = Gauge(
-                name="sglang:num_streaming_sessions",
-                documentation="The number of streaming sessions.",
-                labelnames=labels.keys(),
-                multiprocess_mode="mostrecent",
-            )
-            self.streaming_session_held_tokens = Gauge(
-                name="sglang:streaming_session_held_tokens",
-                documentation="The number of KV tokens currently held by streaming session slots.",
-                labelnames=labels.keys(),
-                multiprocess_mode="mostrecent",
-            )
-
-        self.num_unique_running_routing_keys = Gauge(
-            name="sglang:num_unique_running_routing_keys",
-            documentation="Number of unique routing keys in running batch.",
-            labelnames=labels.keys(),
-            multiprocess_mode="mostrecent",
-        )
-        self.routing_key_running_req_count = GaugeHistogram(
-            name="sglang:routing_key_running_req_count",
-            documentation="Distribution of routing keys by running request count (gt < count <= le).",
-            labelnames=list(labels.keys()),
-            bucket_bounds=ROUTING_KEY_REQ_COUNT_BUCKET_BOUNDS,
-        )
-        self.routing_key_all_req_count = GaugeHistogram(
-            name="sglang:routing_key_all_req_count",
-            documentation="Distribution of routing keys by running+waiting request count (gt < count <= le).",
-            labelnames=list(labels.keys()),
-            bucket_bounds=ROUTING_KEY_REQ_COUNT_BUCKET_BOUNDS,
-        )
-
-        self.new_token_ratio = Gauge(
-            name="sglang:new_token_ratio",
-            documentation="The new token ratio.",
-            labelnames=labels.keys(),
-            multiprocess_mode="mostrecent",
-        )
 
         self.realtime_tokens_total = Counter(
             name="sglang:realtime_tokens_total",
@@ -789,6 +807,9 @@ class SchedulerMetricsCollector:
             labelnames=list(labels.keys()) + ["category", "num_prefill_ranks"],
         )
 
+        # =================================================================
+        # Prefill delayer
+        # =================================================================
         max_delay = server_args.prefill_delayer_max_delay_passes
         self.prefill_delayer_wait_forward_passes = Histogram(
             name="sglang:prefill_delayer_wait_forward_passes",
@@ -832,6 +853,9 @@ class SchedulerMetricsCollector:
             ],
         )
 
+        # =================================================================
+        # Other
+        # =================================================================
         # This is a work-around Info metric since Info metrics are not supported in Prometheus.
         # Similar to vLLM, https://github.com/vllm-project/vllm/blob/main/vllm/v1/metrics/loggers.py
         # If more Info metrics are needed, we can create a common _log_info function.
@@ -1017,24 +1041,22 @@ class SchedulerMetricsCollector:
             )
 
     def log_stats(self, stats: SchedulerStats) -> None:
+        # Basics
         self._log_gauge_queue_count(self.num_running_reqs, stats.num_running_reqs)
-        self._log_gauge(self.num_used_tokens, stats.num_used_tokens)
-        self._log_gauge(self.token_usage, stats.token_usage)
-        self._log_gauge(self.full_token_usage, stats.full_token_usage)
-        self._log_gauge(
-            self.pending_prealloc_token_usage, stats.pending_prealloc_token_usage
-        )
-        self._log_gauge(self.swa_token_usage, stats.swa_token_usage)
-        self._log_gauge(self.mamba_usage, stats.mamba_usage)
-        self._log_gauge(self.decode_sum_seq_lens, stats.decode_sum_seq_lens)
-        self._log_gauge(self.gen_throughput, stats.gen_throughput)
         self._log_gauge_queue_count(self.num_queue_reqs, stats.num_queue_reqs)
         self._log_gauge(self.num_grammar_queue_reqs, stats.num_grammar_queue_reqs)
-        self._log_gauge(
-            self.num_running_reqs_offline_batch, stats.num_running_reqs_offline_batch
-        )
+        self._log_gauge(self.gen_throughput, stats.gen_throughput)
         self._log_gauge(self.cache_hit_rate, stats.cache_hit_rate)
+        self._log_gauge(self.decode_sum_seq_lens, stats.decode_sum_seq_lens)
 
+        # Memory pool usage ratios
+        self._log_gauge(self.token_usage, stats.token_usage)
+        self._log_gauge(self.full_token_usage, stats.full_token_usage)
+        self._log_gauge(self.swa_token_usage, stats.swa_token_usage)
+        self._log_gauge(self.mamba_usage, stats.mamba_usage)
+
+        # Absolute token counts
+        self._log_gauge(self.num_used_tokens, stats.num_used_tokens)
         self._log_gauge(self.max_total_num_tokens, stats.max_total_num_tokens)
         self._log_gauge(self.kv_available_tokens, stats.kv_available_tokens)
         self._log_gauge(self.kv_evictable_tokens, stats.kv_evictable_tokens)
@@ -1043,6 +1065,10 @@ class SchedulerMetricsCollector:
         # Speculative decoding
         self._log_gauge(self.spec_accept_length, stats.spec_accept_length)
         self._log_gauge(self.spec_accept_rate, stats.spec_accept_rate)
+
+        # Retract
+        self._log_gauge(self.num_retracted_reqs, stats.num_retracted_reqs)
+        self._log_gauge(self.num_paused_reqs, stats.num_paused_reqs)
 
         # PD disaggregation
         self._log_gauge_queue_count(
@@ -1057,9 +1083,9 @@ class SchedulerMetricsCollector:
         self._log_gauge_queue_count(
             self.num_decode_transfer_queue_reqs, stats.num_decode_transfer_queue_reqs
         )
-        # Retract
-        self._log_gauge(self.num_retracted_reqs, stats.num_retracted_reqs)
-        self._log_gauge(self.num_paused_reqs, stats.num_paused_reqs)
+        self._log_gauge(
+            self.pending_prealloc_token_usage, stats.pending_prealloc_token_usage
+        )
 
         # Utilization
         self._log_gauge(self.utilization, stats.utilization)
@@ -1069,24 +1095,26 @@ class SchedulerMetricsCollector:
                 stats.max_running_requests_under_SLO,
             )
 
-        # Engine startup time
+        # Engine startup
         self._log_gauge(self.engine_startup_time, stats.engine_startup_time)
         if stats.engine_load_weights_time is not None:
             self._log_gauge(
                 self.engine_load_weights_time, stats.engine_load_weights_time
             )
+
+        # Scheduler policy
         self._log_gauge(self.new_token_ratio, stats.new_token_ratio)
 
         # CUDA graph
         self._log_gauge(self.is_cuda_graph, stats.is_cuda_graph)
 
-        # LoRA pool metrics (only logged if LoRA is enabled)
+        # LoRA pool metrics
         if self.enable_lora:
             self._log_gauge(self.lora_pool_slots_used, stats.lora_pool_slots_used)
             self._log_gauge(self.lora_pool_slots_total, stats.lora_pool_slots_total)
             self._log_gauge(self.lora_pool_utilization, stats.lora_pool_utilization)
 
-        # HiCache host-tier metrics (only logged if hierarchical cache is enabled)
+        # HiCache metrics
         if self.enable_hierarchical_cache:
             self._log_gauge(
                 self.hicache_host_used_tokens, stats.hicache_host_used_tokens
@@ -1095,13 +1123,14 @@ class SchedulerMetricsCollector:
                 self.hicache_host_total_tokens, stats.hicache_host_total_tokens
             )
 
-        # Streaming session metrics (only logged if streaming sessions are enabled)
+        # Streaming session metrics
         if self.enable_streaming_session:
             self._log_gauge(self.num_streaming_sessions, stats.num_streaming_sessions)
             self._log_gauge(
                 self.streaming_session_held_tokens, stats.streaming_session_held_tokens
             )
 
+        # Routing key metrics
         self._log_gauge(
             self.num_unique_running_routing_keys, stats.num_unique_running_routing_keys
         )
@@ -1162,7 +1191,6 @@ class TokenizerMetricsCollector:
             documentation="Number of prefill tokens processed.",
             labelnames=labels.keys(),
         )
-
         self.generation_tokens_total = Counter(
             name="sglang:generation_tokens_total",
             documentation="Number of generation tokens processed.",
@@ -1187,18 +1215,22 @@ class TokenizerMetricsCollector:
             10000,
             12000,
             15000,
+            18000,
             20000,
             22000,
             25000,
+            28000,
             30000,
             35000,
             40000,
-            66000,
-            99000,
-            132000,
+            60000,
+            90000,
+            100000,
+            200000,
             300000,
             600000,
             900000,
+            1000000,
             1100000,
         ]
         self.prompt_tokens_histogram = Histogram(
@@ -1339,34 +1371,6 @@ class TokenizerMetricsCollector:
             buckets=bucket_e2e_request_latency,
         )
 
-        # Retraction count histogram
-        self.num_retractions = Histogram(
-            name="sglang:num_retractions",
-            documentation="Histogram of retraction counts per request.",
-            labelnames=labels.keys(),
-            buckets=[
-                0,
-                1,
-                2,
-                3,
-                4,
-                5,
-                6,
-                7,
-                8,
-                9,
-                10,
-                15,
-                20,
-                25,
-                30,
-                40,
-                50,
-                75,
-                100,
-            ],
-        )
-
     def observe_one_finished_request(
         self,
         labels: Dict[str, str],
@@ -1375,7 +1379,6 @@ class TokenizerMetricsCollector:
         cached_tokens: int,
         e2e_latency: float,
         has_grammar: bool,
-        retraction_count: int,
         cached_tokens_details: Optional[Dict[str, Any]] = None,
     ):
         self.prompt_tokens_total.labels(**labels).inc(prompt_tokens)
@@ -1414,7 +1417,6 @@ class TokenizerMetricsCollector:
         self.generation_tokens_histogram.labels(**labels).observe(
             float(generation_tokens)
         )
-        self.num_retractions.labels(**labels).observe(retraction_count)
 
     def observe_time_to_first_token(self, labels: Dict[str, str], value: float):
         self.histogram_time_to_first_token.labels(**labels).observe(value)
@@ -1661,3 +1663,37 @@ class RadixCacheMetricsCollector:
 
     def observe_load_back_duration(self, duration_seconds: float) -> None:
         self.load_back_duration_seconds.labels(**self.labels).observe(duration_seconds)
+
+
+def get_histogram_conf_from_env(env_var_name: str) -> Optional[List[float]]:
+    """
+    Get the histogram configuration from the environment variable.
+    env value should be like "0.1,0.2,0.5,1,2"
+    """
+    if env_var_name not in os.environ:
+        return None
+    # if the env var is not set or empty, return None
+    env_var_value = os.environ[env_var_name]
+    if not env_var_value:
+        return None
+    return [float(x) for x in env_var_value.split(",")]
+
+
+@dataclass
+class QueueCount:
+    """Holds both the total count and optional per-priority breakdown for a queue."""
+
+    total: int = 0
+    by_priority: Optional[Dict[int, int]] = None
+
+    @classmethod
+    def from_reqs(cls, reqs: List[Req], enable_priority_scheduling: bool = False):
+        # NOTE: If requests have priority=None (no --default-priority-value set),
+        # Counter will produce {None: N}, resulting in priority="None" Prometheus labels.
+        # Set --default-priority-value when enabling priority scheduling to avoid this.
+        by_priority = (
+            dict(Counter(req.priority for req in reqs))
+            if enable_priority_scheduling
+            else None
+        )
+        return cls(total=len(reqs), by_priority=by_priority)

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -926,10 +926,9 @@ class SchedulerMetricsMixin:
             yield
             return
 
-        category = "forward_" + batch.forward_mode.name.lower()
         with self.forward_pass_device_timer.wrap(
             metadata=dict(
-                category=category,
+                category="forward_" + batch.forward_mode.name.lower(),
                 dp_cooperation_info=batch.dp_cooperation_info,
             ),
         ):

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -74,16 +74,16 @@ class PrefillStats:
         )
 
 
+@dataclasses.dataclass
 class KvMetrics:
-    def __init__(self):
-        self.request_active_slots = None
-        self.request_total_slots = None
-        self.kv_active_blocks = None
-        self.kv_total_blocks = None
-        self.num_requests_waiting = None
-        self.gpu_cache_usage_perc = None
-        self.gpu_prefix_cache_hit_rate = None
-        self.data_parallel_rank = None
+    request_active_slots: int = 0
+    request_total_slots: int = 0
+    kv_active_blocks: int = 0
+    kv_total_blocks: int = 0
+    num_requests_waiting: int = 0
+    gpu_cache_usage_perc: float = 0.0
+    gpu_prefix_cache_hit_rate: float = 0.0
+    data_parallel_rank: int = 0
 
 
 class SchedulerMetricsMixin:
@@ -98,6 +98,12 @@ class SchedulerMetricsMixin:
         self.last_gen_throughput: float = 0.0
         self.last_input_throughput: float = 0.0
         self.step_time_dict = defaultdict(list)  # Dict[batch size -> step time]
+        self.stats = SchedulerStats()
+        self._graph_backend_label = {
+            "cpu": "cpu graph",
+            "npu": "npu graph",
+            "musa": "musa graph",
+        }.get(getattr(self, "device", ""), "cuda graph")
 
         # Cumulative spec-decoding counters (reset every decode_log_interval).
         # Each update adds (num_accepted_drafts + bs, bs).
@@ -111,15 +117,14 @@ class SchedulerMetricsMixin:
         self.kv_transfer_speed_gb_s: float = 0.0
         self.kv_transfer_latency_ms: float = 0.0
 
-        self.stats = SchedulerStats()
-
         # Metrics
-        self.enable_mfu_metrics = False
         self.enable_metrics = self.server_args.enable_metrics
         self.is_stats_logging_rank = self.attn_tp_rank == 0
         self.current_scheduler_metrics_enabled = self.enable_metrics and (
-            self.is_stats_logging_rank == 0 or self.server_args.enable_metrics_for_all_schedulers
+            self.is_stats_logging_rank or self.server_args.enable_metrics_for_all_schedulers
         )
+        self.enable_mfu_metrics = False
+
         if self.enable_metrics:
             engine_type = DisaggregationMode.to_engine_type(
                 self.server_args.disaggregation_mode
@@ -145,7 +150,7 @@ class SchedulerMetricsMixin:
                 enable_streaming_session=self.server_args.enable_streaming_session,
                 server_args=self.server_args,
             )
-            self.enable_mfu_metrics = bool(self.server_args.enable_mfu_metrics)
+            self.enable_mfu_metrics = self.server_args.enable_mfu_metrics
             if self.enable_mfu_metrics:
                 self._init_estimated_perf_constants()
                 self._mfu_log_flops = 0.0
@@ -380,16 +385,8 @@ class SchedulerMetricsMixin:
             and self.server_args.encoder_transfer_backend == "zmq_to_scheduler"
         ):
             msg += f"waiting-image-req: {len(self.mm_receiver.waiting_list)}, "
-        graph_backend = defaultdict(
-            lambda: "cuda graph",
-            {
-                "cpu": "cpu graph",
-                "npu": "npu graph",
-                "musa": "musa graph",
-            },
-        )
 
-        msg += f"{graph_backend[self.device]}: {can_run_cuda_graph}, "
+        msg += f"{self._graph_backend_label}: {can_run_cuda_graph}, "
         msg += f"input throughput (token/s): {self.last_input_throughput:.2f}"
 
         if self.enable_mfu_metrics and gap_latency > 0:
@@ -399,7 +396,6 @@ class SchedulerMetricsMixin:
 
         if self.is_stats_logging_rank:
             logger.info(msg)
-
         if self.current_scheduler_metrics_enabled:
             self.metrics_collector.increment_prefill_cuda_graph_pass(
                 value=can_run_cuda_graph
@@ -564,16 +560,8 @@ class SchedulerMetricsMixin:
         ):
             msg += f"waiting-image-req: {len(self.mm_receiver.waiting_list)}, "
 
-        graph_backend = defaultdict(
-            lambda: "cuda graph",
-            {
-                "cpu": "cpu graph",
-                "npu": "npu graph",
-                "musa": "musa graph",
-            },
-        )
         msg += (
-            f"{graph_backend[self.device]}: {can_run_cuda_graph}, "
+            f"{self._graph_backend_label}: {can_run_cuda_graph}, "
             f"gen throughput (token/s): {self.last_gen_throughput:.2f}, "
             f"#queue-req: {len(self.waiting_queue)}"
         )
@@ -650,15 +638,17 @@ class SchedulerMetricsMixin:
             self.stats.streaming_session_held_tokens = self._session_held_tokens()
 
             # Routing key metrics
-            running_routing_keys = [r.routing_key for r in batch.reqs]
-            waiting_routing_keys = [r.routing_key for r in self.waiting_queue]
-            (
-                self.stats.num_unique_running_routing_keys,
-                self.stats.routing_key_running_req_counts,
-            ) = compute_routing_key_stats(running_routing_keys)
-            _, self.stats.routing_key_all_req_counts = compute_routing_key_stats(
-                running_routing_keys + waiting_routing_keys
-            )
+            # (to reduce the overhead, we only compute this when all requests have routing_key)
+            if all(r.routing_key is not None for r in batch.reqs):
+                running_routing_keys = [r.routing_key for r in batch.reqs]
+                waiting_routing_keys = [r.routing_key for r in self.waiting_queue]
+                (
+                    self.stats.num_unique_running_routing_keys,
+                    self.stats.routing_key_running_req_counts,
+                ) = compute_routing_key_stats(running_routing_keys)
+                _, self.stats.routing_key_all_req_counts = compute_routing_key_stats(
+                    running_routing_keys + waiting_routing_keys
+                )
 
             # Utilization / LoRA / HiCache
             self.calculate_utilization()

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -408,23 +408,22 @@ class SchedulerMetricsMixin:
                     num_write_bytes_per_gpu=write_bytes,
                 )
 
-            # Basics
+            priority_enabled = self.enable_priority_scheduling
             total_tokens = prefill_stats.log_input_tokens + prefill_stats.log_hit_tokens
             cache_hit_rate = (
                 prefill_stats.log_hit_tokens / total_tokens if total_tokens > 0 else 0.0
             )
 
+            # Basics
             self.stats.num_running_reqs = prefill_stats.num_running_reqs
-            self.stats.num_running_reqs_offline_batch = 0
-            pool_stats.update_scheduler_stats(self.stats)
-
-            priority_enabled = self.enable_priority_scheduling
             self.stats.num_queue_reqs = QueueCount.from_reqs(
                 self.waiting_queue, priority_enabled
             )
             self.stats.num_grammar_queue_reqs = len(self.grammar_manager)
             self.stats.cache_hit_rate = cache_hit_rate
 
+            # Memory pool usage ratios / Absolute token counts
+            pool_stats.update_scheduler_stats(self.stats)
             self.stats.max_total_num_tokens = self.max_total_num_tokens
 
             # Retract
@@ -450,7 +449,7 @@ class SchedulerMetricsMixin:
                     self.disagg_decode_transfer_queue.queue, priority_enabled
                 )
 
-            # Others
+            # Utilization / LoRA / HiCache
             self.calculate_utilization()
             self.update_lora_metrics()
             self._log_hicache_stats()
@@ -505,7 +504,6 @@ class SchedulerMetricsMixin:
 
         self.num_generated_tokens = 0
         num_running_reqs = len(batch.reqs)
-        num_running_reqs_offline_batch = 0
 
         pool_stats = self.get_pool_stats()
         token_usage_msg = ", ".join(pool_stats.get_decode_usage_msg_parts()) + ", "
@@ -590,27 +588,26 @@ class SchedulerMetricsMixin:
             logger.info(msg)
         if self.current_scheduler_metrics_enabled:
             priority_enabled = self.enable_priority_scheduling
+
             # Basics
             self.stats.num_running_reqs = QueueCount.from_reqs(
                 batch.reqs, priority_enabled
             )
-            self.stats.num_running_reqs_offline_batch = num_running_reqs_offline_batch
-            pool_stats.update_scheduler_stats(self.stats)
-            self.stats.decode_sum_seq_lens = batch.seq_lens_cpu.sum().item()
-            self.stats.gen_throughput = self.last_gen_throughput
             self.stats.num_queue_reqs = QueueCount.from_reqs(
                 self.waiting_queue, priority_enabled
             )
             self.stats.num_grammar_queue_reqs = len(self.grammar_manager)
+            self.stats.gen_throughput = self.last_gen_throughput
             self.stats.cache_hit_rate = cache_hit_rate
+            self.stats.decode_sum_seq_lens = batch.seq_lens_cpu.sum().item()
 
+            # Memory pool usage ratios / Absolute token counts
+            pool_stats.update_scheduler_stats(self.stats)
             self.stats.max_total_num_tokens = self.max_total_num_tokens
-            self.stats.num_streaming_sessions = self._streaming_session_count()
-            self.stats.streaming_session_held_tokens = self._session_held_tokens()
 
             # Speculative decoding
-            self.stats.spec_accept_rate = spec_accept_rate
             self.stats.spec_accept_length = spec_accept_length
+            self.stats.spec_accept_rate = spec_accept_rate
 
             # Retract
             self.stats.num_retracted_reqs = self.num_retracted_reqs
@@ -632,6 +629,12 @@ class SchedulerMetricsMixin:
                 self.stats.num_decode_transfer_queue_reqs = QueueCount.from_reqs(
                     self.disagg_decode_transfer_queue.queue, priority_enabled
                 )
+
+            # Streaming session metrics
+            self.stats.num_streaming_sessions = self._streaming_session_count()
+            self.stats.streaming_session_held_tokens = self._session_held_tokens()
+
+            # Routing key metrics
             running_routing_keys = [r.routing_key for r in batch.reqs]
             waiting_routing_keys = [r.routing_key for r in self.waiting_queue]
             (
@@ -642,7 +645,7 @@ class SchedulerMetricsMixin:
                 running_routing_keys + waiting_routing_keys
             )
 
-            # Others
+            # Utilization / LoRA / HiCache
             self.calculate_utilization()
             self.update_lora_metrics()
             self._log_hicache_stats()

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -159,13 +159,13 @@ class SchedulerMetricsMixin:
                 self._mfu_log_write_bytes = 0.0
 
         if ENABLE_METRICS_DEVICE_TIMER:
-            self._device_timer_window_execution_s = 0.0
-            self._device_timer_window_start = time.perf_counter()
             self._device_timer_window_batch_count = 0
+            self._device_timer_window_gpu_time = 0
+            self._device_timer_window_start = None
             self._device_timer_gpu_busy_pct = 0.0
 
             def _wrap_execution_reporter(**kwargs):
-                self._device_timer_window_execution_s += kwargs["t"]
+                self._device_timer_window_gpu_time += kwargs["t"]
                 if self.enable_metrics:
                     self.metrics_collector.increment_gpu_execution_seconds(**kwargs)
 
@@ -392,7 +392,7 @@ class SchedulerMetricsMixin:
             msg += f", est. prefill TFLOPS/s (per GPU): {tflops_per_s:.2f}"
 
         if ENABLE_METRICS_DEVICE_TIMER:
-            msg += f", GPU busy: {self._device_timer_gpu_busy_pct:.1f}%"
+            msg += f", GPU busy: {self._device_timer_gpu_busy_pct:.2f}%"
 
         if self.is_stats_logging_rank:
             logger.info(msg)
@@ -583,7 +583,7 @@ class SchedulerMetricsMixin:
             self._mfu_log_write_bytes = 0.0
 
         if ENABLE_METRICS_DEVICE_TIMER:
-            msg += f", GPU busy: {self._device_timer_gpu_busy_pct:.1f}%"
+            msg += f", GPU busy: {self._device_timer_gpu_busy_pct:.2f}%"
 
         if self.is_stats_logging_rank:
             logger.info(msg)
@@ -934,14 +934,30 @@ class SchedulerMetricsMixin:
         ):
             yield
 
-        self._device_timer_window_batch_count += 1
         now = time.perf_counter()
-        elapsed = now - self._device_timer_window_start
-        if elapsed > 0:
-            self._device_timer_gpu_busy_pct = min(
-                self._device_timer_window_execution_s / elapsed * 100, 100.0
-            )
-        if self._device_timer_window_batch_count >= 10:
-            self._device_timer_window_execution_s = 0.0
+
+        if self._device_timer_window_batch_count == 0:
+            # Reset the window
             self._device_timer_window_start = now
+            self._device_timer_gpu_busy_pct = float("nan")
+            self._device_timer_window_gpu_time = 0.0
+        elif self._device_timer_window_batch_count <= 3:
+            # The window is too small, do not report
+            self._device_timer_gpu_busy_pct = float("nan")
+        else:
+            # The window is large enough, let us report
+            elapsed = now - self._device_timer_window_start
+            self._device_timer_gpu_busy_pct = (
+                self._device_timer_window_gpu_time / elapsed * 100
+            )
+
+        self._device_timer_window_batch_count += 1
+        if (
+            self._device_timer_window_batch_count
+            >= self.server_args.decode_log_interval // 2 + 1
+        ):
+            self._device_timer_window_batch_count = 0
+
+    def reset_device_timer_window(self: Scheduler):
+        if ENABLE_METRICS_DEVICE_TIMER:
             self._device_timer_window_batch_count = 0

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -946,8 +946,8 @@ class SchedulerMetricsMixin:
         now = time.perf_counter()
         elapsed = now - self._device_timer_window_start
         if elapsed > 0:
-            self._device_timer_gpu_busy_pct = (
-                self._device_timer_window_execution_s / elapsed * 100
+            self._device_timer_gpu_busy_pct = min(
+                self._device_timer_window_execution_s / elapsed * 100, 100.0
             )
         if self._device_timer_window_batch_count >= 10:
             self._device_timer_window_execution_s = 0.0

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -121,7 +121,8 @@ class SchedulerMetricsMixin:
         self.enable_metrics = self.server_args.enable_metrics
         self.is_stats_logging_rank = self.attn_tp_rank == 0
         self.current_scheduler_metrics_enabled = self.enable_metrics and (
-            self.is_stats_logging_rank or self.server_args.enable_metrics_for_all_schedulers
+            self.is_stats_logging_rank
+            or self.server_args.enable_metrics_for_all_schedulers
         )
         self.enable_mfu_metrics = False
 
@@ -157,24 +158,27 @@ class SchedulerMetricsMixin:
                 self._mfu_log_read_bytes = 0.0
                 self._mfu_log_write_bytes = 0.0
 
-            if ENABLE_METRICS_DEVICE_TIMER:
-                self._device_timer_log_execution_s = 0.0
-                self._device_timer_log_bubble_s = 0.0
+        if ENABLE_METRICS_DEVICE_TIMER:
+            self._device_timer_window_execution_s = 0.0
+            self._device_timer_window_start = time.perf_counter()
+            self._device_timer_window_batch_count = 0
+            self._device_timer_gpu_busy_pct = 0.0
 
-                def _wrap_execution_reporter(**kwargs):
-                    self._device_timer_log_execution_s += kwargs["t"]
+            def _wrap_execution_reporter(**kwargs):
+                self._device_timer_window_execution_s += kwargs["t"]
+                if self.enable_metrics:
                     self.metrics_collector.increment_gpu_execution_seconds(**kwargs)
 
-                def _wrap_bubble_reporter(**kwargs):
-                    self._device_timer_log_bubble_s += kwargs["t"]
+            def _wrap_bubble_reporter(**kwargs):
+                if self.enable_metrics:
                     self.metrics_collector.increment_gpu_overlap_wait_seconds(**kwargs)
 
-                self.forward_pass_device_timer = DeviceTimer(
-                    reporter=_wrap_execution_reporter,
-                )
-                self.bubble_timer = GapTimer(
-                    reporter=_wrap_bubble_reporter,
-                )
+            self.forward_pass_device_timer = DeviceTimer(
+                reporter=_wrap_execution_reporter,
+            )
+            self.bubble_timer = GapTimer(
+                reporter=_wrap_bubble_reporter,
+            )
 
         self.init_kv_events(self.server_args.kv_events_config)
 
@@ -394,6 +398,9 @@ class SchedulerMetricsMixin:
             tflops_per_s = flops / gap_latency / 1e12
             msg += f", est. prefill TFLOPS/s (per GPU): {tflops_per_s:.2f}"
 
+        if ENABLE_METRICS_DEVICE_TIMER:
+            msg += f", GPU busy: {self._device_timer_gpu_busy_pct:.1f}%"
+
         if self.is_stats_logging_rank:
             logger.info(msg)
         if self.current_scheduler_metrics_enabled:
@@ -582,11 +589,8 @@ class SchedulerMetricsMixin:
             self._mfu_log_read_bytes = 0.0
             self._mfu_log_write_bytes = 0.0
 
-        if ENABLE_METRICS_DEVICE_TIMER and gap_latency > 0:
-            gpu_util_pct = self._device_timer_log_execution_s / gap_latency * 100
-            msg += f", GPU util: {gpu_util_pct:.1f}%"
-            self._device_timer_log_execution_s = 0.0
-            self._device_timer_log_bubble_s = 0.0
+        if ENABLE_METRICS_DEVICE_TIMER:
+            msg += f", GPU busy: {self._device_timer_gpu_busy_pct:.1f}%"
 
         if self.is_stats_logging_rank:
             logger.info(msg)
@@ -925,7 +929,7 @@ class SchedulerMetricsMixin:
 
     @contextmanager
     def record_forward_metrics(self: Scheduler, batch: ScheduleBatch):
-        if not (self.enable_metrics and ENABLE_METRICS_DEVICE_TIMER):
+        if not ENABLE_METRICS_DEVICE_TIMER:
             yield
             return
 
@@ -938,9 +942,21 @@ class SchedulerMetricsMixin:
         ):
             yield
 
+        self._device_timer_window_batch_count += 1
+        now = time.perf_counter()
+        elapsed = now - self._device_timer_window_start
+        if elapsed > 0:
+            self._device_timer_gpu_busy_pct = (
+                self._device_timer_window_execution_s / elapsed * 100
+            )
+        if self._device_timer_window_batch_count >= 10:
+            self._device_timer_window_execution_s = 0.0
+            self._device_timer_window_start = now
+            self._device_timer_window_batch_count = 0
+
     @contextmanager
     def record_bubble_metrics(self: Scheduler, batch: ScheduleBatch):
-        if not (self.enable_metrics and ENABLE_METRICS_DEVICE_TIMER):
+        if not ENABLE_METRICS_DEVICE_TIMER:
             yield
             return
 
@@ -954,5 +970,5 @@ class SchedulerMetricsMixin:
             yield
 
     def cancel_bubble_timer(self: Scheduler):
-        if self.enable_metrics and ENABLE_METRICS_DEVICE_TIMER:
+        if ENABLE_METRICS_DEVICE_TIMER:
             self.bubble_timer.cancel()

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -760,13 +760,10 @@ class SchedulerMetricsMixin:
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
             self.stats.utilization = -1
         else:
-            if (
-                self.stats.max_running_requests_under_SLO is not None
-                and self.stats.max_running_requests_under_SLO > 0
-            ):
+            max_under_slo = getattr(self, "max_running_requests_under_SLO", None)
+            if max_under_slo is not None and max_under_slo > 0:
                 self.stats.utilization = max(
-                    self.stats.num_running_reqs.total
-                    / self.stats.max_running_requests_under_SLO,
+                    self.stats.num_running_reqs.total / max_under_slo,
                     self.stats.token_usage / 0.9,
                 )
 

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -118,7 +118,7 @@ class SchedulerMetricsMixin:
         self.enable_metrics = self.server_args.enable_metrics
         self.is_stats_logging_rank = self.attn_tp_rank == 0
         self.current_scheduler_metrics_enabled = self.enable_metrics and (
-            self.attn_tp_rank == 0 or self.server_args.enable_metrics_for_all_schedulers
+            self.is_stats_logging_rank == 0 or self.server_args.enable_metrics_for_all_schedulers
         )
         if self.enable_metrics:
             engine_type = DisaggregationMode.to_engine_type(
@@ -424,7 +424,6 @@ class SchedulerMetricsMixin:
 
             # Memory pool usage ratios / Absolute token counts
             pool_stats.update_scheduler_stats(self.stats)
-            self.stats.max_total_num_tokens = self.max_total_num_tokens
 
             # Retract
             self.stats.num_retracted_reqs = self.num_retracted_reqs
@@ -603,7 +602,6 @@ class SchedulerMetricsMixin:
 
             # Memory pool usage ratios / Absolute token counts
             pool_stats.update_scheduler_stats(self.stats)
-            self.stats.max_total_num_tokens = self.max_total_num_tokens
 
             # Speculative decoding
             self.stats.spec_accept_length = spec_accept_length

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -153,11 +153,22 @@ class SchedulerMetricsMixin:
                 self._mfu_log_write_bytes = 0.0
 
             if ENABLE_METRICS_DEVICE_TIMER:
+                self._device_timer_log_execution_s = 0.0
+                self._device_timer_log_bubble_s = 0.0
+
+                def _wrap_execution_reporter(**kwargs):
+                    self._device_timer_log_execution_s += kwargs["t"]
+                    self.metrics_collector.increment_gpu_execution_seconds(**kwargs)
+
+                def _wrap_bubble_reporter(**kwargs):
+                    self._device_timer_log_bubble_s += kwargs["t"]
+                    self.metrics_collector.increment_gpu_overlap_wait_seconds(**kwargs)
+
                 self.forward_pass_device_timer = DeviceTimer(
-                    reporter=self.metrics_collector.increment_gpu_execution_seconds,
+                    reporter=_wrap_execution_reporter,
                 )
                 self.bubble_timer = GapTimer(
-                    reporter=self.metrics_collector.increment_gpu_overlap_wait_seconds,
+                    reporter=_wrap_bubble_reporter,
                 )
 
         self.init_kv_events(self.server_args.kv_events_config)
@@ -582,6 +593,12 @@ class SchedulerMetricsMixin:
             self._mfu_log_flops = 0.0
             self._mfu_log_read_bytes = 0.0
             self._mfu_log_write_bytes = 0.0
+
+        if ENABLE_METRICS_DEVICE_TIMER and gap_latency > 0:
+            gpu_util_pct = self._device_timer_log_execution_s / gap_latency * 100
+            msg += f", GPU util: {gpu_util_pct:.1f}%"
+            self._device_timer_log_execution_s = 0.0
+            self._device_timer_log_bubble_s = 0.0
 
         if self.is_stats_logging_rank:
             logger.info(msg)

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -28,7 +28,7 @@ from sglang.srt.observability.metrics_collector import (
     SchedulerStats,
     compute_routing_key_stats,
 )
-from sglang.srt.utils.device_timer import DeviceTimer, GapTimer
+from sglang.srt.utils.device_timer import DeviceTimer
 from sglang.srt.utils.scheduler_status_logger import SchedulerStatusLogger
 
 if TYPE_CHECKING:
@@ -169,15 +169,8 @@ class SchedulerMetricsMixin:
                 if self.enable_metrics:
                     self.metrics_collector.increment_gpu_execution_seconds(**kwargs)
 
-            def _wrap_bubble_reporter(**kwargs):
-                if self.enable_metrics:
-                    self.metrics_collector.increment_gpu_overlap_wait_seconds(**kwargs)
-
             self.forward_pass_device_timer = DeviceTimer(
                 reporter=_wrap_execution_reporter,
-            )
-            self.bubble_timer = GapTimer(
-                reporter=_wrap_bubble_reporter,
             )
 
         self.init_kv_events(self.server_args.kv_events_config)
@@ -953,22 +946,3 @@ class SchedulerMetricsMixin:
             self._device_timer_window_execution_s = 0.0
             self._device_timer_window_start = now
             self._device_timer_window_batch_count = 0
-
-    @contextmanager
-    def record_bubble_metrics(self: Scheduler, batch: ScheduleBatch):
-        if not ENABLE_METRICS_DEVICE_TIMER:
-            yield
-            return
-
-        category = "forward_" + batch.forward_mode.name.lower()
-        with self.bubble_timer.wrap(
-            metadata=dict(
-                category=category,
-                dp_cooperation_info=batch.dp_cooperation_info,
-            ),
-        ):
-            yield
-
-    def cancel_bubble_timer(self: Scheduler):
-        if ENABLE_METRICS_DEVICE_TIMER:
-            self.bubble_timer.cancel()

--- a/python/sglang/srt/utils/request_logger.py
+++ b/python/sglang/srt/utils/request_logger.py
@@ -237,12 +237,6 @@ class RequestLogger:
             target.info(msg)
 
 
-# TODO remove this?
-@lru_cache(maxsize=2)
-def disable_request_logging() -> bool:
-    return get_bool_env_var("SGLANG_DISABLE_REQUEST_LOGGING")
-
-
 # TODO unify this w/ `_transform_data_for_logging` if we find performance enough
 def _dataclass_to_string_truncated(
     data: Any, max_length: int = 2048, skip_names: Optional[Set[str]] = None

--- a/test/registered/perf/test_bench_one_batch_1gpu.py
+++ b/test/registered/perf/test_bench_one_batch_1gpu.py
@@ -1,4 +1,9 @@
+import os
+import re
+import subprocess
 import unittest
+
+import numpy as np
 
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import (
@@ -6,7 +11,7 @@ from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
     CustomTestCase,
     is_in_ci,
-    run_bench_offline_throughput,
+    kill_process_tree,
     run_bench_one_batch,
     write_github_step_summary,
 )
@@ -24,9 +29,45 @@ class TestBenchOneBatch1GPU(CustomTestCase):
         self.assertGreater(output_throughput, 50)
 
     def test_bs1_default(self):
-        output_throughput = run_bench_offline_throughput(
-            DEFAULT_MODEL_NAME_FOR_TEST, ["--cuda-graph-max-bs", "2"]
+        env = os.environ.copy()
+        env["SGLANG_ENABLE_METRICS_DEVICE_TIMER"] = "1"
+
+        command = [
+            "python3",
+            "-m",
+            "sglang.bench_offline_throughput",
+            "--num-prompts",
+            "1",
+            "--dataset-name",
+            "random",
+            "--random-input-len",
+            "256",
+            "--random-output-len",
+            "1024",
+            "--model-path",
+            DEFAULT_MODEL_NAME_FOR_TEST,
+            "--cuda-graph-max-bs",
+            "2",
+        ]
+
+        print(f"command={' '.join(command)}")
+        process = subprocess.Popen(
+            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env
         )
+
+        try:
+            stdout, stderr = process.communicate()
+            output = stdout.decode(errors="backslashreplace")
+            error = stderr.decode(errors="backslashreplace")
+            print(f"Output: {output}", flush=True)
+            print(f"Error: {error}", flush=True)
+
+            output_throughput = -1
+            for line in output.split("\n"):
+                if "Last generation throughput (tok/s):" in line:
+                    output_throughput = float(line.split(":")[-1])
+        finally:
+            kill_process_tree(process.pid)
 
         if is_in_ci():
             write_github_step_summary(
@@ -34,6 +75,21 @@ class TestBenchOneBatch1GPU(CustomTestCase):
                 f"output_throughput: {output_throughput:.2f} token/s\n"
             )
             self.assertGreater(output_throughput, 135)
+
+        gpu_busy_values = []
+        for line in error.split("\n"):
+            match = re.search(r"GPU busy:\s*([\d.]+|nan)%", line)
+            if match:
+                val = match.group(1)
+                if val != "nan":
+                    gpu_busy_values.append(float(val))
+
+        print(f"{gpu_busy_values=}", flush=True)
+        self.assertGreater(len(gpu_busy_values), 0, "No GPU busy values found in logs")
+
+        gpu_busy_values_p90 = float(np.percentile(gpu_busy_values, 90))
+        print(f"{gpu_busy_values_p90=}", flush=True)
+        self.assertGreater(gpu_busy_values_p90, 99.1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Clean up and reorganize metrics_collector.py
- Remove unused config flags (use_vllm_cutlass_w8a8_fp8_kernel, SGLANG_DISABLE_REQUEST_LOGGING)
- Remove bubble timer and gpu_overlap_wait_seconds metric
- Rename available_gpu_memory_gb to startup_available_gpu_memory_gb
- Move max_running_requests_under_SLO out of SchedulerStats
- Move constant metrics to emit_constants
- Refactor device timer: windowed GPU busy computation with explicit lifecycle (reset/warm-up/report), reset on scheduler idle
- Enable printing GPU busy percentage in decode log
- Add GPU busy p90 CI assertion in test_bs1_default

## Test plan
- CI test_bench_one_batch_1gpu (test_bs1_default asserts GPU busy p90 > 99.1%)
- Existing metrics and scheduler tests pass