### PR TITLE
[codex] Support text-only Devstral serving

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -259,6 +259,7 @@ class ModelConfig:
 
         self.hf_config.encoder_only = encoder_only
         self.hf_config.language_only = language_only
+        self.hf_config.enable_multimodal = enable_multimodal
 
         # matryoshka embeddings
         self.matryoshka_dimensions = getattr(

--- a/python/sglang/srt/models/ministral3.py
+++ b/python/sglang/srt/models/ministral3.py
@@ -1,9 +1,14 @@
 from typing import Any, Dict, Optional
 
 import torch
+from torch import nn
 from transformers import PretrainedConfig
 
+from sglang.srt.distributed import get_pp_group
+from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.utils import PPMissingLayer
+from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.models.llama import (
     LlamaAttention,
@@ -122,9 +127,20 @@ class Ministral3Model(LlamaModel):
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
     ) -> None:
-        # Override layer creation to use Ministral3Attention
-        super().__init__(config, quant_config, prefix)
-
+        nn.Module.__init__(self)
+        self.config = config
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+        self.pp_group = get_pp_group()
+        if self.pp_group.is_first_rank:
+            self.embed_tokens = VocabParallelEmbedding(
+                config.vocab_size,
+                config.hidden_size,
+                quant_config=quant_config,
+                prefix=add_prefix("embed_tokens", prefix),
+            )
+        else:
+            self.embed_tokens = PPMissingLayer()
         self.layers, self.start_layer, self.end_layer = make_layers(
             config.num_hidden_layers,
             lambda idx, prefix: Ministral3DecoderLayer(
@@ -134,6 +150,11 @@ class Ministral3Model(LlamaModel):
             pp_size=self.pp_group.world_size,
             prefix="model.layers",
         )
+        if self.pp_group.is_last_rank:
+            self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        else:
+            self.norm = PPMissingLayer(return_tuple=True)
+        self.layers_to_capture = []
 
 
 class Ministral3ForCausalLM(LlamaForCausalLM):

--- a/python/sglang/srt/models/mistral.py
+++ b/python/sglang/srt/models/mistral.py
@@ -92,6 +92,20 @@ class Mistral3ForConditionalGeneration:
     MULTIMODAL_PROJECTOR_TYPE = Mistral3MultiModalProjector
 
     def __init__(self, **kwargs):
+        self.text_only = (
+            getattr(kwargs["config"], "language_only", False)
+            or getattr(kwargs["config"], "enable_multimodal", None) is False
+        )
+        if self.text_only:
+            from sglang.srt.models.ministral3 import Ministral3ForCausalLM
+
+            self.inner = Ministral3ForCausalLM(
+                kwargs["config"].text_config,
+                quant_config=kwargs.get("quant_config"),
+                prefix=kwargs.get("prefix", ""),
+            )
+            return
+
         # lazy load inner class
         # to bypass circular import
         from sglang.srt.models.llava import LlavaForConditionalGeneration
@@ -173,7 +187,16 @@ class Mistral3ForConditionalGeneration:
           lm_head.X                -> language_model.lm_head.X
         """
 
-        def normalize(ws):
+        def normalize_text_only(ws):
+            for name, w in ws:
+                if name.startswith("language_model."):
+                    yield name[len("language_model.") :], w
+                elif name.startswith("model.language_model."):
+                    yield "model." + name[len("model.language_model.") :], w
+                elif name.startswith("lm_head."):
+                    yield name, w
+
+        def normalize_multimodal(ws):
             for name, w in ws:
                 if name.startswith("model.language_model."):
                     rest = name[len("model.language_model.") :]
@@ -189,7 +212,9 @@ class Mistral3ForConditionalGeneration:
                     name = "language_model." + name
                 yield name, w
 
-        return self.inner.load_weights(normalize(weights))
+        if self.text_only:
+            return self.inner.load_weights(normalize_text_only(weights))
+        return self.inner.load_weights(normalize_multimodal(weights))
 
 
 EntryClass = [MistralForCausalLM, Mistral3ForConditionalGeneration]

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4191,8 +4191,8 @@ class ServerArgs:
         parser.add_argument(
             "--enable-multimodal",
             default=ServerArgs.enable_multimodal,
-            action="store_true",
-            help="Enable the multimodal functionality for the served model. If the model being served is not multimodal, nothing will happen",
+            action=argparse.BooleanOptionalAction,
+            help="Enable or disable the multimodal functionality for the served model. If the model being served is not multimodal, nothing will happen",
         )
         parser.add_argument(
             "--revision",

--- a/test/registered/unit/models/test_mistral3.py
+++ b/test/registered/unit/models/test_mistral3.py
@@ -1,0 +1,71 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.models.mistral import Mistral3ForConditionalGeneration
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+
+
+class FakeMinistral3ForCausalLM:
+    def __init__(self, config, quant_config=None, prefix=""):
+        self.config = config
+        self.quant_config = quant_config
+        self.prefix = prefix
+        self.loaded_weights = None
+
+    def load_weights(self, weights):
+        self.loaded_weights = list(weights)
+        return "loaded"
+
+
+class TestMistral3TextOnlyWrapper(CustomTestCase):
+    def test_disable_multimodal_uses_text_model_and_strips_weight_prefix(self):
+        text_config = SimpleNamespace(model_type="ministral3")
+        config = SimpleNamespace(enable_multimodal=False, text_config=text_config)
+        weight_a = object()
+        weight_b = object()
+        weight_c = object()
+        weight_d = object()
+        ignored_weight = object()
+
+        with patch(
+            "sglang.srt.models.ministral3.Ministral3ForCausalLM",
+            FakeMinistral3ForCausalLM,
+        ):
+            model = Mistral3ForConditionalGeneration(
+                config=config,
+                quant_config="quant",
+                prefix="language_model",
+            )
+            result = model.load_weights(
+                [
+                    ("language_model.model.embed_tokens.weight", weight_a),
+                    ("model.language_model.layers.0.self_attn.q_proj.weight", weight_c),
+                    ("vision_model.embeddings.weight", ignored_weight),
+                    ("model.vision_tower.embeddings.weight", ignored_weight),
+                    ("lm_head.weight", weight_d),
+                    ("language_model.lm_head.weight", weight_b),
+                ]
+            )
+
+        self.assertTrue(model.text_only)
+        self.assertIs(model.inner.config, text_config)
+        self.assertEqual(model.inner.quant_config, "quant")
+        self.assertEqual(model.inner.prefix, "language_model")
+        self.assertEqual(result, "loaded")
+        self.assertEqual(
+            model.inner.loaded_weights,
+            [
+                ("model.embed_tokens.weight", weight_a),
+                ("model.layers.0.self_attn.q_proj.weight", weight_c),
+                ("lm_head.weight", weight_d),
+                ("lm_head.weight", weight_b),
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -33,6 +33,16 @@ class TestPrepareServerArgs(CustomTestCase):
             {"rope_scaling": {"factor": 2.0, "rope_type": "linear"}},
         )
 
+    def test_prepare_server_args_disable_multimodal(self):
+        server_args = prepare_server_args(
+            [
+                "--model-path",
+                DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN,
+                "--no-enable-multimodal",
+            ]
+        )
+        self.assertFalse(server_args.enable_multimodal)
+
 
 class TestLoadBalanceMethod(unittest.TestCase):
     def test_non_pd_defaults_to_round_robin(self):


### PR DESCRIPTION
## Summary

This PR adds a text-only serving path for Mistral3/Devstral models when multimodal serving is explicitly disabled.

Changes:
- allow `--no-enable-multimodal` by switching `--enable-multimodal` to `argparse.BooleanOptionalAction`
- propagate `enable_multimodal` into the HF config so model wrappers can select the right path
- route Mistral3/Devstral text-only serving directly through `Ministral3ForCausalLM(config.text_config)`
- filter and normalize text-only weight names while preserving the existing multimodal Mistral3 weight-name normalization
- initialize `Ministral3Model` directly instead of constructing and replacing a full Llama layer stack
- add CPU unit coverage for the CLI flag and text-only Mistral3 wrapper behavior

## Why

On `mistralai/Devstral-Small-2-24B-Instruct-2512`, SGLang was loading through the multimodal `LlavaForConditionalGeneration` wrapper even for text-only serving. In the H100 validation run this consumed 45.15 GB for model weights and left room for 167,050 KV tokens. With this patch, the same model loads as `Ministral3ForCausalLM`, uses 23.83 GB for model weights, and allocates 306,775 KV tokens.

## Validation

H100 container, single H100, real model runs:
- real-model smoke passed for `mistralai/Devstral-Small-2-24B-Instruct-2512`
- SGLang c13 chat qps4: 1.2833 req/s, p99 TTFT 163.1 ms, p99 TPOT 12.20 ms
- SGLang c13 summarization qps4: 0.6867 req/s, p99 TTFT 3823.0 ms, p99 TPOT 23.33 ms
- vLLM same-client chat qps4: 1.3476 req/s, p99 TTFT 158.7 ms, p99 TPOT 11.70 ms
- vLLM same-client summarization qps4: 0.6653 req/s, p99 TTFT 4076.0 ms, p99 TPOT 25.03 ms

Targeted tests in the H100 container:

```bash
PYTHONPATH=python pytest -q \
  test/registered/unit/server_args/test_server_args.py::TestPrepareServerArgs::test_prepare_server_args_disable_multimodal \
  test/registered/unit/models/test_mistral3.py::TestMistral3TextOnlyWrapper::test_disable_multimodal_uses_text_model_and_strips_weight_prefix
```

Result: `2 passed`.

Syntax check:

```bash
python3 -m py_compile \
  python/sglang/srt/server_args.py \
  python/sglang/srt/configs/model_config.py \
  python/sglang/srt/models/mistral.py \
  python/sglang/srt/models/ministral3.py \
  test/registered/unit/models/test_mistral3.py
```

## Profiling note

This patch fixes the memory/KV issue. The remaining small chat gap versus vLLM is not MoE/router/top-k related for this dense model. The profile comparison points to graph-safe FP8 static activation quant / adjacent pointwise fusion as the next optimization area. The current SGLang PCG+inductor path crashed on real traffic with `PCG capture stream is not set`, so that follow-up is intentionally left out of this minimal PR.