### PR TITLE
fix: rename mimo spec threshold attr to num_accepted_drafts_thres

### DIFF
--- a/test/registered/8-gpu-models/test_mimo_models.py
+++ b/test/registered/8-gpu-models/test_mimo_models.py
@@ -45,7 +45,7 @@ class TestMiMoV2Flash(GSM8KMixin, SpecDecodingMixin, DefaultServerBase):
     ]
 
     bs_1_speed_thres = 170
-    accept_length_thres = 3.2
+    num_accepted_drafts_thres = 3.2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #23962: `SpecDecodingMixin` was renamed from `accept_length_thres` to `num_accepted_drafts_thres`, but `TestMiMoV2Flash` still set the old name. Causes `AttributeError` on stage-c-test-8-gpu-h200.