### PR TITLE
[RL] Surface release/resume_memory_occupation state errors to callers

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -1073,15 +1073,19 @@ class Engine(EngineScoreMixin, EngineBase):
 
     def release_memory_occupation(self, tags: Optional[List[str]] = None):
         obj = ReleaseMemoryOccupationReqInput(tags=tags)
-        return self.loop.run_until_complete(
+        success, message = self.loop.run_until_complete(
             self.tokenizer_manager.release_memory_occupation(obj, None)
         )
+        if not success:
+            raise RuntimeError(f"release_memory_occupation failed: {message}")
 
     def resume_memory_occupation(self, tags: Optional[List[str]] = None):
         obj = ResumeMemoryOccupationReqInput(tags=tags)
-        return self.loop.run_until_complete(
+        success, message = self.loop.run_until_complete(
             self.tokenizer_manager.resume_memory_occupation(obj, None)
         )
+        if not success:
+            raise RuntimeError(f"resume_memory_occupation failed: {message}")
 
     def freeze_gc(self):
         """

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1275,8 +1275,10 @@ async def release_memory_occupation(
 ):
     """Release GPU memory occupation temporarily."""
     try:
-        success, message = await _global_state.tokenizer_manager.release_memory_occupation(
-            obj, request
+        success, message = (
+            await _global_state.tokenizer_manager.release_memory_occupation(
+                obj, request
+            )
         )
     except Exception as e:
         return _create_error_response(e)
@@ -1294,8 +1296,8 @@ async def resume_memory_occupation(
 ):
     """Resume GPU memory occupation."""
     try:
-        success, message = await _global_state.tokenizer_manager.resume_memory_occupation(
-            obj, request
+        success, message = (
+            await _global_state.tokenizer_manager.resume_memory_occupation(obj, request)
         )
     except Exception as e:
         return _create_error_response(e)

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1275,9 +1275,16 @@ async def release_memory_occupation(
 ):
     """Release GPU memory occupation temporarily."""
     try:
-        await _global_state.tokenizer_manager.release_memory_occupation(obj, request)
+        success, message = await _global_state.tokenizer_manager.release_memory_occupation(
+            obj, request
+        )
     except Exception as e:
         return _create_error_response(e)
+
+    content = {"success": success, "message": message}
+    if success:
+        return ORJSONResponse(content, status_code=200)
+    return ORJSONResponse(content, status_code=HTTPStatus.BAD_REQUEST)
 
 
 @app.api_route("/resume_memory_occupation", methods=["GET", "POST"])
@@ -1287,9 +1294,16 @@ async def resume_memory_occupation(
 ):
     """Resume GPU memory occupation."""
     try:
-        await _global_state.tokenizer_manager.resume_memory_occupation(obj, request)
+        success, message = await _global_state.tokenizer_manager.resume_memory_occupation(
+            obj, request
+        )
     except Exception as e:
         return _create_error_response(e)
+
+    content = {"success": success, "message": message}
+    if success:
+        return ORJSONResponse(content, status_code=200)
+    return ORJSONResponse(content, status_code=HTTPStatus.BAD_REQUEST)
 
 
 @app.post("/weights_checker")

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1590,7 +1590,8 @@ class ReleaseMemoryOccupationReqInput(BaseReq):
 
 @dataclass
 class ReleaseMemoryOccupationReqOutput(BaseReq):
-    pass
+    success: bool = True
+    message: str = ""
 
 
 @dataclass
@@ -1602,7 +1603,8 @@ class ResumeMemoryOccupationReqInput(BaseReq):
 
 @dataclass
 class ResumeMemoryOccupationReqOutput(BaseReq):
-    pass
+    success: bool = True
+    message: str = ""
 
 
 @dataclass

--- a/python/sglang/srt/managers/scheduler_update_weights_mixin.py
+++ b/python/sglang/srt/managers/scheduler_update_weights_mixin.py
@@ -136,14 +136,29 @@ class SchedulerUpdateWeightsMixin:
     def release_memory_occupation(
         self: Scheduler, recv_req: ReleaseMemoryOccupationReqInput
     ):
-        assert (
-            self.is_fully_idle()
-        ), "release_memory_occupation should be called only when server is idle."
+        if not self.is_fully_idle():
+            return ReleaseMemoryOccupationReqOutput(
+                success=False,
+                message=(
+                    "release_memory_occupation called while requests are in flight; "
+                    "drain pending work before releasing GPU memory."
+                ),
+            )
 
         tags = recv_req.tags
 
         if tags is None or len(tags) == 0:
             tags = GPU_MEMORY_ALL_TYPES
+
+        already_released = [t for t in tags if t in self.offload_tags]
+        if already_released:
+            return ReleaseMemoryOccupationReqOutput(
+                success=False,
+                message=(
+                    f"release_memory_occupation called for tags {already_released} "
+                    "that are already released."
+                ),
+            )
 
         for tag in tags:
             self.offload_tags.add(tag)
@@ -173,6 +188,16 @@ class SchedulerUpdateWeightsMixin:
 
         if tags is None or len(tags) == 0:
             tags = GPU_MEMORY_ALL_TYPES
+
+        not_released = [t for t in tags if t not in self.offload_tags]
+        if not_released:
+            return ResumeMemoryOccupationReqOutput(
+                success=False,
+                message=(
+                    f"resume_memory_occupation called for tags {not_released} "
+                    "that are not currently released."
+                ),
+            )
 
         for tag in tags:
             self.offload_tags.remove(tag)

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -748,17 +748,19 @@ class TokenizerControlMixin:
         self: TokenizerManager,
         obj: ReleaseMemoryOccupationReqInput,
         request: Optional[fastapi.Request] = None,
-    ):
+    ) -> Tuple[bool, str]:
         self.auto_create_handle_loop()
-        await self.release_memory_occupation_communicator(obj)
+        results = await self.release_memory_occupation_communicator(obj)
+        return FanOutCommunicator.merge_results(results)
 
     async def resume_memory_occupation(
         self: TokenizerManager,
         obj: ResumeMemoryOccupationReqInput,
         request: Optional[fastapi.Request] = None,
-    ):
+    ) -> Tuple[bool, str]:
         self.auto_create_handle_loop()
-        await self.resume_memory_occupation_communicator(obj)
+        results = await self.resume_memory_occupation_communicator(obj)
+        return FanOutCommunicator.merge_results(results)
 
     async def check_weights(
         self: TokenizerManager,

--- a/test/registered/rl/test_release_resume_state_errors.py
+++ b/test/registered/rl/test_release_resume_state_errors.py
@@ -1,0 +1,81 @@
+"""Tests that release_memory_occupation and resume_memory_occupation surface
+state-machine errors (resume-without-release, double-release) as a clean
+RuntimeError on the Engine surface, instead of crashing the scheduler with
+an AssertionError or KeyError.
+"""
+
+import unittest
+
+import sglang as sgl
+from sglang.srt.constants import (
+    GPU_MEMORY_TYPE_KV_CACHE,
+    GPU_MEMORY_TYPE_WEIGHTS,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import (
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+    CustomTestCase,
+)
+
+register_cuda_ci(est_time=120, suite="stage-b-test-1-gpu-small")
+
+
+class TestReleaseResumeStateErrors(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.engine = sgl.Engine(
+            model_path=DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+            random_seed=42,
+            enable_memory_saver=True,
+            mem_fraction_static=0.6,
+            disable_cuda_graph=True,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "engine") and cls.engine is not None:
+            cls.engine.shutdown()
+
+    def test_resume_without_prior_release_errors(self):
+        with self.assertRaises(RuntimeError) as cm:
+            self.engine.resume_memory_occupation(tags=[GPU_MEMORY_TYPE_KV_CACHE])
+        self.assertIn("not currently released", str(cm.exception))
+
+    def test_resume_other_tag_while_only_one_released_errors(self):
+        self.engine.release_memory_occupation(tags=[GPU_MEMORY_TYPE_KV_CACHE])
+        try:
+            with self.assertRaises(RuntimeError) as cm:
+                self.engine.resume_memory_occupation(tags=[GPU_MEMORY_TYPE_WEIGHTS])
+            self.assertIn("not currently released", str(cm.exception))
+        finally:
+            self.engine.resume_memory_occupation(tags=[GPU_MEMORY_TYPE_KV_CACHE])
+
+    def test_double_release_errors(self):
+        self.engine.release_memory_occupation(tags=[GPU_MEMORY_TYPE_KV_CACHE])
+        try:
+            with self.assertRaises(RuntimeError) as cm:
+                self.engine.release_memory_occupation(tags=[GPU_MEMORY_TYPE_KV_CACHE])
+            self.assertIn("already released", str(cm.exception))
+        finally:
+            self.engine.resume_memory_occupation(tags=[GPU_MEMORY_TYPE_KV_CACHE])
+
+    def test_release_then_resume_cycle_still_serves(self):
+        # The error-path changes should not regress the existing happy path:
+        # a paired release / resume cycle still leaves the engine able to
+        # generate.
+        self.engine.release_memory_occupation(
+            tags=[GPU_MEMORY_TYPE_KV_CACHE, GPU_MEMORY_TYPE_WEIGHTS],
+        )
+        self.engine.resume_memory_occupation(
+            tags=[GPU_MEMORY_TYPE_KV_CACHE, GPU_MEMORY_TYPE_WEIGHTS],
+        )
+        out = self.engine.generate(
+            prompt="Hello",
+            sampling_params={"temperature": 0, "max_new_tokens": 4},
+        )
+        self.assertIsInstance(out["text"], str)
+        self.assertGreater(len(out["text"]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)


### PR DESCRIPTION
Addresses one piece of the RL inner-loop discussion in #24119 (section 3, narrowed by the follow-up notes on the issue). Independent of section 1's drain / quiesce design and of the section 2 IPC question.

## What is broken today

`Scheduler.release_memory_occupation` (in `scheduler_update_weights_mixin.py`) guarded against in-flight requests with a bare ``assert self.is_fully_idle()``. When the assertion trips, it crashes the scheduler process with ``AssertionError`` instead of returning a usable error to the caller, and it is stripped entirely under ``python -O``. ``resume_memory_occupation`` had no equivalent guard at all and would raise ``KeyError`` on ``offload_tags.remove(tag)`` when invoked without a paired release, which also propagates as an uncaught exception in the scheduler.

In both cases the caller — typically an RL framework driver — sees the engine become unresponsive rather than a clean error it can react to, and there is no protocol for distinguishing "you called this in the wrong state" from a genuine engine fault.

## What this PR does

`ReleaseMemoryOccupationReqOutput` and `ResumeMemoryOccupationReqOutput` now carry ``success`` and ``message`` fields, mirroring the existing ``UpdateWeightsFromIPCReqOutput`` shape. The scheduler returns ``success=False`` with a descriptive message in three cases: release while requests are in flight, double-release (a tag already in ``offload_tags``), and resume of a tag that was not previously released (state-machine error, not in-flight; resume during a partial release window with other requests legitimately queued is fine and is not blocked here).

The tokenizer manager merges per-rank results via ``FanOutCommunicator.merge_results`` and returns a ``(bool, str)`` tuple (matching ``update_weights_from_ipc``). The ``/release_memory_occupation`` and ``/resume_memory_occupation`` HTTP handlers turn failures into ``HTTP 400`` with the merged message in the body. ``Engine.release_memory_occupation`` and ``Engine.resume_memory_occupation`` raise ``RuntimeError`` so direct in-process callers see a clear exception rather than silent corruption.

Successful calls keep their previous return shape (``None`` from the Engine API, no body change beyond the added ``success: True`` field on the dataclasses), so existing happy-path callers are unaffected.

## Tests

Added ``test/registered/rl/test_release_resume_state_errors.py`` (registered for ``stage-b-test-1-gpu-small``) covering:

- resume without prior release raises ``RuntimeError`` with a "not currently released" message,
- resume of a tag that was not part of the prior partial release raises the same error,
- double-release of the same tag raises ``RuntimeError`` with an "already released" message,
- a clean release / resume cycle still leaves the engine able to generate.

Each error-path test restores engine state in ``finally`` so subsequent tests are unaffected.

## Out of scope

This PR does not touch the larger drain / quiesce primitive proposed in section 1 of the discussion, nor the section 2 question about whether ``update_weights_from_ipc`` should accept a raw ``cudaIpcMemHandle`` dictionary alongside ZMQ handles. Those will follow as separate PRs once the design lands in the discussion.