### PR TITLE
[RL] Add Engine.drain() / POST /drain to wait for in-flight requests

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -1071,6 +1071,23 @@ class Engine(EngineScoreMixin, EngineBase):
 
         return await self.tokenizer_manager.unload_lora_adapter(obj, None)
 
+    def drain(self, timeout: Optional[float] = None) -> Tuple[bool, int]:
+        """Block until in-flight requests complete or ``timeout`` seconds pass.
+
+        Returns ``(success, remaining_requests)``. ``success`` is True when
+        the engine reaches an idle state, False on timeout. Intended for the
+        RL inner loop where the trainer needs to confirm nothing is mid
+        decode before pushing new weights.
+
+        The caller is responsible for not submitting new requests during the
+        drain window; this method does not block submission. A pause / quiesce
+        flag is the right place to enforce that and is intentionally left to a
+        follow-up PR.
+        """
+        return self.loop.run_until_complete(
+            self.tokenizer_manager.drain(timeout=timeout)
+        )
+
     def release_memory_occupation(self, tags: Optional[List[str]] = None):
         obj = ReleaseMemoryOccupationReqInput(tags=tags)
         return self.loop.run_until_complete(

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -116,6 +116,7 @@ from sglang.srt.managers.io_struct import (
     ConfigureLoggingReq,
     ContinueGenerationReqInput,
     DestroyWeightsUpdateGroupReqInput,
+    DrainReqInput,
     DumperControlReqInput,
     EmbeddingReqInput,
     GenerateReqInput,
@@ -1266,6 +1267,24 @@ async def get_weights_by_name(obj: GetWeightsByNameReqInput, request: Request):
             return ORJSONResponse(ret, status_code=200)
     except Exception as e:
         return _create_error_response(e)
+
+
+@app.api_route("/drain", methods=["POST"])
+@auth_level(AuthLevel.ADMIN_OPTIONAL)
+async def drain(obj: DrainReqInput, request: Request):
+    """Block until in-flight requests complete or `timeout` seconds elapse.
+
+    Returns 200 with `{"success": bool, "remaining_requests": int}`. The
+    caller is responsible for not submitting new requests during the drain
+    window; this endpoint does not block submission.
+    """
+    success, remaining = await _global_state.tokenizer_manager.drain(
+        timeout=obj.timeout
+    )
+    return ORJSONResponse(
+        {"success": success, "remaining_requests": remaining},
+        status_code=200,
+    )
 
 
 @app.api_route("/release_memory_occupation", methods=["GET", "POST"])

--- a/python/sglang/srt/entrypoints/http_server_engine.py
+++ b/python/sglang/srt/entrypoints/http_server_engine.py
@@ -134,6 +134,10 @@ class HttpServerEngineAdapter(EngineBase):
 
         return self._make_request("generate", payload)
 
+    def drain(self, timeout: Optional[float] = None) -> Tuple[bool, int]:
+        response = self._make_request("drain", {"timeout": timeout})
+        return response.get("success", False), response.get("remaining_requests", 0)
+
     def release_memory_occupation(self):
         return self._make_request("release_memory_occupation")
 

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1898,6 +1898,13 @@ class BlockReqInput(BaseReq):
 
 
 @dataclass
+class DrainReqInput(BaseReq):
+    """Block until in-flight requests complete or `timeout` seconds elapse."""
+
+    timeout: Optional[float] = None
+
+
+@dataclass
 class MemoryMetrics:
     """Memory breakdown metrics."""
 

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -744,6 +744,30 @@ class TokenizerControlMixin:
         else:
             return all_parameters
 
+    async def drain(
+        self: TokenizerManager,
+        timeout: Optional[float] = None,
+        poll_interval: float = 0.05,
+    ) -> Tuple[bool, int]:
+        """Block until no requests are in flight at the tokenizer manager.
+
+        Polls ``rid_to_state`` every ``poll_interval`` seconds. Returns
+        ``(success, remaining_requests)`` where ``success`` is False if the
+        wait was cut short by ``timeout``.
+
+        This does not prevent new requests from being submitted while the
+        wait is in progress; callers are responsible for not feeding new
+        work in during the drain window. A separate paused / quiesce flag
+        is the right place to enforce that and is left to a follow-up.
+        """
+        self.auto_create_handle_loop()
+        deadline = None if timeout is None else (time.monotonic() + timeout)
+        while self.rid_to_state:
+            if deadline is not None and time.monotonic() >= deadline:
+                return False, len(self.rid_to_state)
+            await asyncio.sleep(poll_interval)
+        return True, 0
+
     async def release_memory_occupation(
         self: TokenizerManager,
         obj: ReleaseMemoryOccupationReqInput,

--- a/test/registered/rl/test_engine_drain.py
+++ b/test/registered/rl/test_engine_drain.py
@@ -1,0 +1,124 @@
+"""Tests for the drain primitive — block until in-flight requests complete
+or a timeout elapses. The drain primitive is the first piece of the RL
+inner-loop API discussed in #24119 section 1.
+
+The in-flight test uses the HTTP server because Engine.drain and Engine.generate
+both call self.loop.run_until_complete on the same event loop and cannot be
+issued concurrently from two threads against a single Engine instance. The
+HTTP path naturally handles that.
+"""
+
+import threading
+import time
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import (
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=180, suite="stage-b-test-1-gpu-small")
+
+
+class TestEngineDrain(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process") and cls.process:
+            kill_process_tree(cls.process.pid)
+
+    def _drain(self, timeout):
+        r = requests.post(
+            self.base_url + "/drain",
+            json={"timeout": timeout},
+            timeout=timeout + 30 if timeout is not None else 60,
+        )
+        self.assertEqual(r.status_code, 200)
+        return r.json()
+
+    def test_drain_idle_returns_immediately(self):
+        start = time.perf_counter()
+        body = self._drain(timeout=5.0)
+        elapsed = time.perf_counter() - start
+        self.assertTrue(body["success"])
+        self.assertEqual(body["remaining_requests"], 0)
+        self.assertLess(elapsed, 1.0)
+
+    def test_drain_with_inflight_request_times_out(self):
+        result_holder = {}
+
+        def submit_long_generate():
+            try:
+                r = requests.post(
+                    self.base_url + "/generate",
+                    json={
+                        "text": "Tell me a long story about a robot.",
+                        "sampling_params": {
+                            "temperature": 0,
+                            "max_new_tokens": 64,
+                        },
+                    },
+                    timeout=120,
+                )
+                result_holder["status"] = r.status_code
+            except Exception as e:
+                result_holder["error"] = repr(e)
+
+        t = threading.Thread(target=submit_long_generate)
+        t.start()
+        # Let the request reach the tokenizer manager and register a rid.
+        time.sleep(0.5)
+
+        try:
+            body = self._drain(timeout=0.2)
+            self.assertFalse(body["success"])
+            self.assertGreater(body["remaining_requests"], 0)
+        finally:
+            t.join(timeout=120)
+            self.assertFalse(t.is_alive(), "background generate did not finish")
+
+        # After the request finishes, drain should report idle.
+        body = self._drain(timeout=5.0)
+        self.assertTrue(body["success"])
+        self.assertEqual(body["remaining_requests"], 0)
+        self.assertEqual(result_holder.get("status"), 200)
+
+    def test_drain_no_timeout_completes_after_inflight_finishes(self):
+        def submit_short_generate():
+            requests.post(
+                self.base_url + "/generate",
+                json={
+                    "text": "Hello",
+                    "sampling_params": {"temperature": 0, "max_new_tokens": 8},
+                },
+                timeout=60,
+            )
+
+        t = threading.Thread(target=submit_short_generate)
+        t.start()
+        time.sleep(0.2)
+
+        body = self._drain(timeout=None)
+        t.join(timeout=60)
+        self.assertTrue(body["success"])
+        self.assertEqual(body["remaining_requests"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)

--- a/test/registered/rl/test_engine_drain.py
+++ b/test/registered/rl/test_engine_drain.py
@@ -1,6 +1,5 @@
 """Tests for the drain primitive — block until in-flight requests complete
-or a timeout elapses. The drain primitive is the first piece of the RL
-inner-loop API discussed in #24119 section 1.
+or a timeout elapses.
 
 The in-flight test uses the HTTP server because Engine.drain and Engine.generate
 both call self.loop.run_until_complete on the same event loop and cannot be


### PR DESCRIPTION
Implements section 1 of the RL inner-loop discussion in #24119: a minimal `drain` primitive that lets a framework block until no requests are in flight, so a follow-up `update_weights_*` or `release_memory_*` call lands cleanly without racing mid-decode requests. Independent of the section 3 work in #24123 (which surfaces in-flight detection on `release_memory_occupation`); the two compose naturally.

## What this PR adds

`Engine.drain(timeout=None)` returns `(success, remaining_requests)` and is the sync entry point. `TokenizerManager.drain` is the async counterpart for in-process callers, and `POST /drain` exposes the same shape over HTTP, returning `{"success": bool, "remaining_requests": int}` with status 200 in either outcome — the operation itself completes successfully even when the wait times out, and the caller distinguishes via the body.

Idleness is tracked via ``tokenizer_manager.rid_to_state``, which the existing detokenizer feedback loop populates and clears as requests start and finish. That dictionary is the natural mirror of "what did the caller submit and is still pending" — exactly the question the RL inner loop needs answered before pushing new weights. The same idiom is already used by ``sigterm_watchdog`` for the graceful-shutdown drain; this PR exposes it as a public API. Implementation is a 50ms poll loop with optional timeout, with no scheduler-side communication.

## What this PR does NOT add

The ``paused`` / quiesce flag from the RFC. The infrastructure for that flag is already in tree as ``SchedulerInputBlocker`` (used internally behind ``SGLANG_ENABLE_COLOCATED_BATCH_GEN`` for colocated batch generation), but not exposed as a public engine-control API. Whether requests submitted during the drain window should be queued, rejected, or 5xx-ed is the design question that warrants its own discussion. Today the precondition is documented: callers should not submit new requests during the drain window. A follow-up PR can layer the paused flag on top of this drain without changing the drain surface itself.

The scheduler-side ``is_fully_idle()`` check is also not consulted directly. In steady state it converges with ``rid_to_state`` — a request stays in ``rid_to_state`` until the detokenizer reports completion, by which point the scheduler has also moved past it. If maintainer feedback wants a stronger guarantee, that is a small extension to the same shape.

## Tests

Added ``test/registered/rl/test_engine_drain.py`` (registered for ``stage-b-test-1-gpu-small``):

- drain on a fully idle engine returns immediately with ``success=True``, ``remaining_requests=0``,
- drain with a short timeout while a long generation is in flight returns ``success=False`` with ``remaining_requests > 0`` and does not wait for the generation to finish,
- drain without a timeout blocks until an in-flight request finishes naturally, then reports idle.

Tests use ``popen_launch_server`` rather than driving an in-process Engine because ``Engine.drain`` and ``Engine.generate`` both call ``self.loop.run_until_complete`` on the same event loop and cannot be issued concurrently from two threads against a single Engine instance; the HTTP path naturally handles that concurrency.