### PR TITLE
[bugfix] auto-truncate: leave room for max_new_tokens and reserved tokens

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -828,7 +828,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 # Leave room for max_new_tokens and reserved tokens so the
                 # request can still produce output after truncation; without
                 # this, truncating to exactly context_len forces max_new_tokens
-                # to 0 in the next check (issue #21136).
+                # to 0 in the next check.
                 target_input_len = max(
                     1,
                     _max_req_len - (max_new_tokens or 0) - self.num_reserved_tokens,

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -818,19 +818,28 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         """Validates that the input token count and the requested token count doesn't exceed the model's context length."""
         # FIXME: unify the length validation logic with the one in the scheduler.
         _max_req_len = self.context_len
+        max_new_tokens = obj.sampling_params.get("max_new_tokens")
         input_token_num = len(input_ids) if input_ids is not None else 0
         input_token_num += self.num_reserved_tokens
 
         # Validate input length
         if input_token_num >= self.context_len:
             if self.server_args.allow_auto_truncate:
+                # Leave room for max_new_tokens and reserved tokens so the
+                # request can still produce output after truncation; without
+                # this, truncating to exactly context_len forces max_new_tokens
+                # to 0 in the next check (issue #21136).
+                target_input_len = max(
+                    1,
+                    _max_req_len - (max_new_tokens or 0) - self.num_reserved_tokens,
+                )
                 logger.warning(
                     f"The input ({input_token_num} tokens) is longer than the "
                     f"model's context length ({self.context_len} tokens). "
-                    "Truncating the input."
+                    f"Truncating the input to {target_input_len} tokens."
                 )
-                del input_ids[_max_req_len:]
-                input_token_num = len(input_ids)
+                del input_ids[target_input_len:]
+                input_token_num = len(input_ids) + self.num_reserved_tokens
             else:
                 raise ValueError(
                     f"The input ({input_token_num} tokens) is longer than the "
@@ -838,7 +847,6 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 )
 
         # Validate total tokens (input + max_new_tokens)
-        max_new_tokens = obj.sampling_params.get("max_new_tokens")
         if (
             self.validate_total_tokens
             and max_new_tokens is not None

--- a/test/registered/unit/managers/test_tokenizer_manager_auto_truncate.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_auto_truncate.py
@@ -1,0 +1,116 @@
+"""Unit tests for tokenizer_manager._validate_one_request truncation behavior
+when allow_auto_truncate is enabled. Covers issue #21136: a too-long input
+should leave room for max_new_tokens and num_reserved_tokens so the request
+can still produce output, instead of being truncated to exactly context_len
+which forces max_new_tokens to 0.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from sglang.srt.managers.io_struct import GenerateReqInput
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="stage-a-test-cpu")
+
+
+def _make_mock(context_len=100, num_reserved_tokens=0, allow_auto_truncate=True):
+    mock = MagicMock(spec=TokenizerManager)
+    mock.context_len = context_len
+    mock.num_reserved_tokens = num_reserved_tokens
+    mock.validate_total_tokens = True
+    mock.is_generation = True
+    mock.server_args = SimpleNamespace(
+        allow_auto_truncate=allow_auto_truncate,
+        enable_return_hidden_states=False,
+    )
+    return mock
+
+
+def _validate(mock, obj, input_ids):
+    """Invoke the unbound _validate_one_request against a mock self."""
+    return TokenizerManager._validate_one_request(mock, obj, input_ids)
+
+
+def _gen_req(max_new_tokens):
+    obj = GenerateReqInput(text="x", sampling_params={"max_new_tokens": max_new_tokens})
+    return obj
+
+
+class TestAutoTruncateLeavesRoomForGeneration(CustomTestCase):
+    def test_long_input_leaves_room_for_max_new_tokens(self):
+        # context_len=100, max_new_tokens=10. After truncation the input
+        # should be 90 tokens, and max_new_tokens should remain 10 — the
+        # second check (input + max_new_tokens >= context_len) must not
+        # force max_new_tokens to 0.
+        mock = _make_mock(context_len=100, num_reserved_tokens=0)
+        obj = _gen_req(max_new_tokens=10)
+        input_ids = [1] * 200
+
+        _validate(mock, obj, input_ids)
+
+        self.assertEqual(len(input_ids), 90)
+        self.assertEqual(obj.sampling_params["max_new_tokens"], 10)
+
+    def test_long_input_with_reserved_tokens(self):
+        # EAGLE-style reserved tokens must be subtracted from the truncation
+        # cap so the post-truncation total stays within context_len.
+        mock = _make_mock(context_len=100, num_reserved_tokens=20)
+        obj = _gen_req(max_new_tokens=10)
+        input_ids = [1] * 200
+
+        _validate(mock, obj, input_ids)
+
+        # 100 - 10 - 20 = 70
+        self.assertEqual(len(input_ids), 70)
+        self.assertEqual(obj.sampling_params["max_new_tokens"], 10)
+
+    def test_long_input_without_max_new_tokens(self):
+        # When max_new_tokens is unset, the truncation should still succeed
+        # and not strip the input below 1 token.
+        mock = _make_mock(context_len=100, num_reserved_tokens=0)
+        obj = GenerateReqInput(text="x", sampling_params={})
+        input_ids = [1] * 200
+
+        _validate(mock, obj, input_ids)
+
+        self.assertEqual(len(input_ids), 100)
+
+    def test_short_input_unchanged(self):
+        # An input that already fits should not be touched.
+        mock = _make_mock(context_len=100, num_reserved_tokens=0)
+        obj = _gen_req(max_new_tokens=10)
+        input_ids = [1] * 30
+
+        _validate(mock, obj, input_ids)
+
+        self.assertEqual(len(input_ids), 30)
+        self.assertEqual(obj.sampling_params["max_new_tokens"], 10)
+
+    def test_long_input_raises_when_truncate_disabled(self):
+        mock = _make_mock(context_len=100, allow_auto_truncate=False)
+        obj = _gen_req(max_new_tokens=10)
+        input_ids = [1] * 200
+
+        with self.assertRaises(ValueError):
+            _validate(mock, obj, input_ids)
+
+    def test_truncation_target_clamped_to_one_when_max_new_tokens_huge(self):
+        # If max_new_tokens >= context_len, the cap would go negative; we
+        # clamp to 1 so we still have at least one input token (the second
+        # check then drops max_new_tokens to fit).
+        mock = _make_mock(context_len=100, num_reserved_tokens=0)
+        obj = _gen_req(max_new_tokens=200)
+        input_ids = [1] * 500
+
+        _validate(mock, obj, input_ids)
+
+        self.assertEqual(len(input_ids), 1)
+        self.assertEqual(obj.sampling_params["max_new_tokens"], 99)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)

--- a/test/registered/unit/managers/test_tokenizer_manager_auto_truncate.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_auto_truncate.py
@@ -1,8 +1,8 @@
 """Unit tests for tokenizer_manager._validate_one_request truncation behavior
-when allow_auto_truncate is enabled. Covers issue #21136: a too-long input
-should leave room for max_new_tokens and num_reserved_tokens so the request
-can still produce output, instead of being truncated to exactly context_len
-which forces max_new_tokens to 0.
+when allow_auto_truncate is enabled. A too-long input should leave room for
+max_new_tokens and num_reserved_tokens so the request can still produce
+output, instead of being truncated to exactly context_len which forces
+max_new_tokens to 0.
 """
 
 import unittest


### PR DESCRIPTION
Closes #21136.

## What is broken

When `--allow-auto-truncate` is enabled and the input alone is longer than `context_len`, `_validate_one_request` truncates the input to exactly `context_len`:

```python
del input_ids[_max_req_len:]
input_token_num = len(input_ids)
```

The very next check is

```python
if max_new_tokens + input_token_num >= _max_req_len:
    obj.sampling_params[\"max_new_tokens\"] = max(0, _max_req_len - input_token_num)
```

With `input_token_num == _max_req_len`, that forces `max_new_tokens` to 0 and the request returns no output — the opposite of what the caller asked for when they enabled auto-truncation.

The same path also fails to subtract `num_reserved_tokens` (used by EAGLE speculative decoding to reserve token slots), so the post-truncation total can still exceed the effective usable length.

## Fix

Truncate the input to `context_len - max_new_tokens - num_reserved_tokens`, clamped to at least one input token, so the request actually has room to produce `max_new_tokens` of output:

```python
target_input_len = max(
    1,
    _max_req_len - (max_new_tokens or 0) - self.num_reserved_tokens,
)
del input_ids[target_input_len:]
input_token_num = len(input_ids) + self.num_reserved_tokens
```

The existing downstream `(max_new_tokens + input_token_num)` check still runs and tightens `max_new_tokens` further if anything is off-by-one, so the reliability contract of the function is unchanged.

## Tests

`test/registered/unit/managers/test_tokenizer_manager_auto_truncate.py` (CPU unit suite, registered for `stage-a-test-cpu`) covers:

- long input leaves room for `max_new_tokens` (the regression in #21136),
- reserved tokens are subtracted from the truncation cap,
- missing `max_new_tokens` still truncates safely without a `TypeError`,
- short input within the limit is unchanged,
- truncation disabled still raises `ValueError`,
- an oversized `max_new_tokens` clamps the input to one token rather than going negative.

## Relationship to prior PRs

#8104 was an earlier attempt to fix `--allow-auto-truncate`. Before it merged, #9391 landed an independent fix that resolved the original "engine raises ValueError" symptom but introduced the residual `max_new_tokens=0` problem above. This PR builds on the #9391 code rather than the #8104 diff. I will close #8104 separately.