### PR TITLE
fix(aiter): drop FP8 KV upcast; use native FP8 path in paged_attentio…

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -300,6 +300,21 @@ class AiterAttnBackend(AttentionBackend):
 
             self.fix_max_split_per_batch = self.max_split_per_batch
 
+    def _get_aiter_paged_ragged_kv_cache_dtype(self) -> str:
+        """``kv_cache_dtype`` string for ``paged_attention_ragged`` (aiter ``pa/pa_ragged.py``).
+
+        **Behavior change:** we no longer upcast FP8 KV to the activations dtype for this decode path.
+        Paged K/V stay in native FP8 storage; we pass ``\"fp8_e4m3\"`` so the kernel dequants on read
+        (``k_scale`` / ``v_scale``) instead of widening the cache to bf16/fp16 for ``\"auto\"``.
+
+        **Context (short):** aiter accepts ``auto`` / ``fp8`` / ``fp8_e4m3`` only (not ``fp8_e5m2``).
+        On HIP, ``configure_kv_cache_dtype`` maps CLI ``fp8_e5m2`` and ``fp8_e4m3`` to ``fp8_dtype``;
+        return ``\"fp8_e4m3\"`` when ``self.kv_cache_dtype == fp8_dtype``, else ``\"auto\"``.
+        """
+        if self.kv_cache_dtype != fp8_dtype:
+            return "auto"
+        return "fp8_e4m3"
+
     def make_mla_decode_meta_data_buffer(self, max_seqlen_qo, batch_size):
         nhead = self.num_head_padded
         dtype = self.kv_cache_dtype
@@ -2914,9 +2929,10 @@ class AiterAttnBackend(AttentionBackend):
                     sinks=sinks,
                 )
             else:
-                if self.kv_cache_dtype == fp8_dtype:
-                    k_cache = k_cache.to(self.input_dtype)
-                    v_cache = v_cache.to(self.input_dtype)
+                # Drop FP8 KV upcast: keep paged cache in native FP8 and use ``fp8_e4m3`` for
+                # in-kernel dequant in ``paged_attention_ragged``. (HIP maps CLI e5m2/e4m3 to
+                # ``fp8_dtype``; aiter has no ``fp8_e5m2`` string.)
+                aiter_kv_str = self._get_aiter_paged_ragged_kv_cache_dtype()
 
                 paged_attention_ragged(
                     o.view(-1, layer.tp_q_head_num, layer.v_head_dim),
@@ -2931,7 +2947,7 @@ class AiterAttnBackend(AttentionBackend):
                     1,
                     self.max_num_partitions,
                     None,
-                    "auto",
+                    aiter_kv_str,
                     "NHD",
                     self.logits_soft_cap,
                     self.k_scale,


### PR DESCRIPTION


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

On the Aiter backend, FP8 KV cache was effectively handled by upcasting to a wider dtype before attention on every layer. That adds redundant memory traffic and compute and becomes a major bottleneck for latency and throughput, even though the hardware and kernels are meant to run native FP8. The paged_attention_ragged path already supports FP8 KV; we should use it end-to-end instead of paying an implicit per-layer cast.

## Modifications

- Remove the per-layer FP8 KV upcast on the Aiter attention path.
- Route KV through the native FP8 execution in paged_attention_ragged, relying on the existing FP8-capable paged-attention interface.
- Eliminate redundant casts so behavior and performance align with FP8-first backends (fewer conversions, better utilization of FP8 KV storage).

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
