### PR TITLE
fix(sgl-kernel): sm90 compile flashmla failed

### DIFF
--- a/sgl-kernel/cmake/flashmla.cmake
+++ b/sgl-kernel/cmake/flashmla.cmake
@@ -17,6 +17,8 @@ set(FLASHMLA_CUDA_FLAGS
     "-Xcudafe=--diag_suppress=177"   # variable was declared but never referenced
 )
 
+set(FLASHMLA_ENABLE_SM100 OFF)
+
 # The FlashMLA kernels only work on hopper and require CUDA 12.4 or later.
 # Only build FlashMLA kernels if we are building for something compatible with
 # sm90a
@@ -29,6 +31,7 @@ if(${CUDA_VERSION} VERSION_GREATER 12.8)
     list(APPEND FLASHMLA_CUDA_FLAGS
         "-gencode=arch=compute_100a,code=sm_100a"
     )
+    set(FLASHMLA_ENABLE_SM100 ON)
 endif()
 if(${CUDA_VERSION} VERSION_GREATER_EQUAL "13.0")
     # Patch FlashMLA sources for SM103a support.
@@ -113,26 +116,30 @@ set(FlashMLA_SOURCES
     ${repo-flashmla_SOURCE_DIR}/csrc/sm90/prefill/sparse/instantiations/phase1_k576.cu
     ${repo-flashmla_SOURCE_DIR}/csrc/sm90/prefill/sparse/instantiations/phase1_k576_topklen.cu
 
-    # sm100 dense prefill/bwd.
-    ${repo-flashmla_SOURCE_DIR}/csrc/sm100/prefill/dense/fmha_cutlass_fwd_sm100.cu
-    ${repo-flashmla_SOURCE_DIR}/csrc/sm100/prefill/dense/fmha_cutlass_bwd_sm100.cu
-
-    # sm100 sparse prefill.
-    ${repo-flashmla_SOURCE_DIR}/csrc/sm100/prefill/sparse/fwd/head64/instantiations/phase1_k512.cu
-    ${repo-flashmla_SOURCE_DIR}/csrc/sm100/prefill/sparse/fwd/head64/instantiations/phase1_k576.cu
-    ${repo-flashmla_SOURCE_DIR}/csrc/sm100/prefill/sparse/fwd/head128/instantiations/phase1_k512.cu
-    ${repo-flashmla_SOURCE_DIR}/csrc/sm100/prefill/sparse/fwd/head128/instantiations/phase1_k576.cu
-    ${repo-flashmla_SOURCE_DIR}/csrc/sm100/prefill/sparse/fwd_for_small_topk/head128/instantiations/phase1_prefill_k512.cu
-
-    # sm100 sparse decode.
-    ${repo-flashmla_SOURCE_DIR}/csrc/sm100/decode/head64/instantiations/v32.cu
-    ${repo-flashmla_SOURCE_DIR}/csrc/sm100/decode/head64/instantiations/model1.cu
-    ${repo-flashmla_SOURCE_DIR}/csrc/sm100/prefill/sparse/fwd_for_small_topk/head128/instantiations/phase1_decode_k512.cu
-
     ${repo-flashmla_SOURCE_DIR}/csrc/extension/sm90/dense_fp8/dense_fp8_python_api.cpp
     ${repo-flashmla_SOURCE_DIR}/csrc/extension/sm90/dense_fp8/flash_fwd_mla_fp8_sm90.cu
     ${repo-flashmla_SOURCE_DIR}/csrc/extension/sm90/dense_fp8/flash_fwd_mla_metadata.cu
 )
+
+if(FLASHMLA_ENABLE_SM100)
+    list(APPEND FlashMLA_SOURCES
+        # sm100 dense prefill/bwd.
+        ${repo-flashmla_SOURCE_DIR}/csrc/sm100/prefill/dense/fmha_cutlass_fwd_sm100.cu
+        ${repo-flashmla_SOURCE_DIR}/csrc/sm100/prefill/dense/fmha_cutlass_bwd_sm100.cu
+
+        # sm100 sparse prefill.
+        ${repo-flashmla_SOURCE_DIR}/csrc/sm100/prefill/sparse/fwd/head64/instantiations/phase1_k512.cu
+        ${repo-flashmla_SOURCE_DIR}/csrc/sm100/prefill/sparse/fwd/head64/instantiations/phase1_k576.cu
+        ${repo-flashmla_SOURCE_DIR}/csrc/sm100/prefill/sparse/fwd/head128/instantiations/phase1_k512.cu
+        ${repo-flashmla_SOURCE_DIR}/csrc/sm100/prefill/sparse/fwd/head128/instantiations/phase1_k576.cu
+        ${repo-flashmla_SOURCE_DIR}/csrc/sm100/prefill/sparse/fwd_for_small_topk/head128/instantiations/phase1_prefill_k512.cu
+
+        # sm100 sparse decode.
+        ${repo-flashmla_SOURCE_DIR}/csrc/sm100/decode/head64/instantiations/v32.cu
+        ${repo-flashmla_SOURCE_DIR}/csrc/sm100/decode/head64/instantiations/model1.cu
+        ${repo-flashmla_SOURCE_DIR}/csrc/sm100/prefill/sparse/fwd_for_small_topk/head128/instantiations/phase1_decode_k512.cu
+    )
+endif()
 
 Python_add_library(flashmla_ops MODULE USE_SABI ${SKBUILD_SABI_VERSION} WITH_SOABI ${FlashMLA_SOURCES})
 target_compile_options(flashmla_ops PRIVATE
@@ -140,6 +147,9 @@ target_compile_options(flashmla_ops PRIVATE
     $<$<COMPILE_LANGUAGE:CUDA>:-std=c++20>
     $<$<COMPILE_LANGUAGE:CUDA>:${FLASHMLA_CUDA_FLAGS}>
 )
+if(FLASHMLA_ENABLE_SM100)
+    target_compile_definitions(flashmla_ops PRIVATE FLASHMLA_ENABLE_SM100)
+endif()
 target_include_directories(flashmla_ops PRIVATE
     ${repo-flashmla_SOURCE_DIR}/csrc
     ${repo-flashmla_SOURCE_DIR}/csrc/kerutils/include

--- a/sgl-kernel/csrc/flashmla_extension.cc
+++ b/sgl-kernel/csrc/flashmla_extension.cc
@@ -36,11 +36,13 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "-> Tensor[]");
   m.impl("fwd_kvcache_mla", torch::kCUDA, &fwd_kvcache_mla);
 
+#ifdef FLASHMLA_ENABLE_SM100
   m.def(
       "dense_prefill_fwd(Tensor workspace_buffer, Tensor q, Tensor k, Tensor v, Tensor cumulative_seqlen_q, Tensor "
       "cumulative_seqlen_kv, Tensor o, Tensor lse, int mask_mode_code, float softmax_scale, int max_seqlen_q, int "
       "max_seqlen_kv, bool is_varlen) -> ()");
   m.impl("dense_prefill_fwd", torch::kCUDA, &FMHACutlassSM100FwdRun);
+#endif
 
   m.def("sparse_prefill_fwd(Tensor q, Tensor kv, Tensor indices, float sm_scale, int d_v) -> Tensor[]");
   m.impl("sparse_prefill_fwd", torch::kCUDA, &sparse_prefill_fwd);


### PR DESCRIPTION
## Motivation

### close https://github.com/sgl-project/sglang/issues/24126

Fixes a FlashMLA build issue on Hopper GPUs such as H20 when buildingwith CUDA 12.8.

In `sgl-kernel/cmake/flashmla.cmake`, the `sm100` Blackwell source files were always appended to `FlashMLA_SOURCES`, even when the build only targeted Hopper (`sm90a`). At the same time,`sm100` gencode was only added when `CUDA_VERSION > 12.8`.

That mismatch meant a CUDA 12.8 Hopper build could still compile Blackwell-only FlashMLA source files unnecessarily, which can lead to compilation failures or toolchain incompatibilities on H20 / SM90 environments.

## Modifications

- Add a local `FLASHMLA_ENABLE_SM100` switch in `sgl-kernel/cmake/flashmla.cmake`.
- Enable that switch only when `CUDA_VERSION > 12.8`, the same condition used to add `-gencode=arch=compute_100a,code=sm_100a`.
- Move all `sm100` FlashMLA source files behind `if(FLASHMLA_ENABLE_SM100)` so Hopper-only builds do not compile Blackwell sources.

## Accuracy Tests

N/A. This change only affects build-time source and architecture selection in
the FlashMLA CMake configuration. No kernel math or model runtime logic was
changed.

After fix, compile succeed.
<img width="1184" height="233" alt="image" src="https://github.com/user-attachments/assets/5f93390b-ba63-4bdc-86e8-b0486772fcc2" />

Install the `.whl` file and run DeepSeek V3.2. It works properly.
<img width="1500" height="305" alt="image" src="https://github.com/user-attachments/assets/b9a52476-080d-44bf-ba7b-24c252d46662" />
<img width="1255" height="667" alt="image" src="https://github.com/user-attachments/assets/233bc6be-9298-41c0-a672-17480074d6a9" />

## Speed Tests and Profiling

N/A. This PR does not change runtime execution paths or kernel implementations.
It only prevents unnecessary `sm100` FlashMLA compilation on Hopper builds.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No documentation update is needed because this is a build-only fix.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable for this build-only change.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
