### PR TITLE
fix(l2norm): eliminate Triton JIT recompilation per ISL

### DIFF
--- a/python/sglang/srt/layers/attention/fla/l2norm.py
+++ b/python/sglang/srt/layers/attention/fla/l2norm.py
@@ -51,7 +51,7 @@ def l2norm_fwd_kernel1(
 #     ],
 #     key=["D", "NB"],
 # )
-@triton.jit(do_not_specialize=["T"])
+@triton.jit(do_not_specialize=["T", "NB"])
 def l2norm_fwd_kernel(
     x,
     y,

--- a/python/sglang/srt/layers/attention/fla/l2norm.py
+++ b/python/sglang/srt/layers/attention/fla/l2norm.py
@@ -51,13 +51,13 @@ def l2norm_fwd_kernel1(
 #     ],
 #     key=["D", "NB"],
 # )
-@triton.jit
+@triton.jit(do_not_specialize=["T"])
 def l2norm_fwd_kernel(
     x,
     y,
     eps,
-    NB: tl.constexpr,
-    T: tl.constexpr,
+    NB,
+    T,
     D: tl.constexpr,
     BT: tl.constexpr,
     BD: tl.constexpr,
@@ -91,7 +91,9 @@ def l2norm_fwd(
         raise RuntimeError("This layer doesn't support feature dim >= 64KB.")
 
     if D <= 512:
-        NB = triton.cdiv(T, 2048)
+        # NOTE: Use a coarser granularity (2048 * 32) instead of 2048 to avoid
+        # excessive recompilation when T varies. Synced from fla upstream.
+        NB = triton.cdiv(T, 2048 * 32)
 
         def grid(meta):
             return (triton.cdiv(T, meta["BT"]),)


### PR DESCRIPTION
## Motivation
`l2norm_fwd_kernel` triggers a Triton JIT recompilation for every unique prefill
token count `T`, because `T` and `NB` are declared as `tl.constexpr`. For
workloads with diverse input lengths (chat, RAG, agent), this causes significant
TTFT spikes during warm-up.
This pattern is already addressed in other fla kernels in this repo
(e.g. `chunk_scaled_dot_kkt.py`, `fused_recurrent.py`) using
`@triton.jit(do_not_specialize=["T"])`. This PR applies the same fix to
`l2norm_fwd_kernel`, syncing with fla upstream:
https://github.com/fla-org/flash-linear-attention/blob/main/fla/modules/l2norm.py
## Modifications
In `python/sglang/srt/layers/attention/fla/l2norm.py`:
1. Add `@triton.jit(do_not_specialize=["T"])` and remove `tl.constexpr` from
   `T` and `NB` parameters of `l2norm_fwd_kernel`.
   - `T` is only used as a runtime shape argument for `boundary_check`
   - `NB` is unused in the kernel body (leftover from a commented-out autotune)
2. Coarsen the `NB` granularity from `T/2048` to `T/(2048*32)` to further reduce
   potential recompilation when `T` varies in a small range. Synced from fla upstream.
The kernel body is **unchanged** — these are pure JIT-specialization hints, not
algorithm changes.
## Accuracy Tests
Numerical correctness verified by comparing kernel output against a fp32
reference implementation across diverse `T` values (100 to 65000):
T=   100: max_err_vs_fp32=9.56e-04
T=   500: max_err_vs_fp32=9.70e-04
T=  1000: max_err_vs_fp32=9.76e-04
T=  5000: max_err_vs_fp32=9.75e-04
T= 11000: max_err_vs_fp32=9.77e-04
T= 11500: max_err_vs_fp32=9.76e-04
T= 12000: max_err_vs_fp32=9.77e-04
T= 30000: max_err_vs_fp32=9.77e-04
T= 65000: max_err_vs_fp32=9.77e-04
All errors are within bfloat16's machine epsilon (~7.8e-3), and output is
bit-for-bit identical to the original implementation when compared against the
same bf16 reference.
## Speed Tests and Profiling
Tested on Qwen3-Next (GatedDeltaNet, mamba hybrid arch), TP=4, H800,
1000 requests with 1000 unique ISLs in [10800, 11799], `--disable-radix-cache`
to isolate JIT effect from prefix cache hits.
| Metric | Before (cold) | Before (warm) | After (cold) | After (warm) |
|--------|---------------|---------------|--------------|--------------|
| TTFT avg | 377.5 ms | 293.0 ms | 288.9 ms | 282.1 ms |
| TTFT p50 | 377.4 ms | 284.0 ms | 283.0 ms | 281.5 ms |
| TTFT p99 | 839.8 ms | 407.4 ms | 340.1 ms | 335.9 ms |
| Triton cubin variants per 1000 reqs | +922 | +0 | +0~29 | +0 |


**Cold-warm gap reduction**:
- avg: 84.5 ms → 6.8 ms (**92% improvement**)
- p50: 93.4 ms → 1.5 ms (**98% improvement**)
- p99: 432.4 ms → 4.2 ms (**99% improvement**)
Warm-state TTFT is unchanged (282 ms vs 293 ms), confirming no regression on the
hot path.
## Checklist
- [x] Format your code according to the Format code with pre-commit
- [ ] Add unit tests according to the Run and add unit tests
      *Note: No existing unit test for l2norm in `test/registered/unit/`. Since
      this PR is a JIT-specialization hint change without altering kernel logic
      or numerical behavior, accuracy is verified by the existing end-to-end
      Qwen3-Next/Qwen3.5 model tests.*
- [x] Update documentation according to Write documentations *(N/A)*
- [x] Provide accuracy and speed benchmark results
- [x] Follow the SGLang code style guidance