### PR TITLE
[BugFix][JIT] Disambiguate activation member template lookup on CUDA 12.8 Hopper runtime

### DIFF
--- a/python/sglang/jit_kernel/csrc/elementwise/activation.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/activation.cuh
@@ -93,14 +93,14 @@ struct ActivationKernel {
 
   template <bool kFilterExpert>
   static auto select_kernel(const std::string& type)
-      -> decltype(ActivationKernel<T, kUsePDL>::template activation_kernel<ActivationKind::kSiLU, kFilterExpert>) {
+      -> decltype(ActivationKernel::template activation_kernel<ActivationKind::kSiLU, kFilterExpert>) {
     using namespace host;
     if (type == "silu") {
-      return ActivationKernel<T, kUsePDL>::template activation_kernel<ActivationKind::kSiLU, kFilterExpert>;
+      return ActivationKernel::template activation_kernel<ActivationKind::kSiLU, kFilterExpert>;
     } else if (type == "gelu") {
-      return ActivationKernel<T, kUsePDL>::template activation_kernel<ActivationKind::kGELU, kFilterExpert>;
+      return ActivationKernel::template activation_kernel<ActivationKind::kGELU, kFilterExpert>;
     } else if (type == "gelu_tanh") {
-      return ActivationKernel<T, kUsePDL>::template activation_kernel<ActivationKind::kGELUTanh, kFilterExpert>;
+      return ActivationKernel::template activation_kernel<ActivationKind::kGELUTanh, kFilterExpert>;
     } else {
       Panic("unsupported activation type: ", type);
     }
@@ -150,10 +150,10 @@ struct ActivationKernel {
     };
     if (expert_ids != nullptr) {
       RuntimeCheck(expert_step > 0, "expert_step must be positive");
-      const auto kernel = ActivationKernel<T, kUsePDL>::template select_kernel<true>(type);
+      const auto kernel = ActivationKernel::template select_kernel<true>(type);
       LaunchKernel(num_blocks, kBlockSize, device).enable_pdl(kUsePDL)(kernel, params);
     } else {
-      const auto kernel = ActivationKernel<T, kUsePDL>::template select_kernel<false>(type);
+      const auto kernel = ActivationKernel::template select_kernel<false>(type);
       LaunchKernel(num_blocks, kBlockSize, device).enable_pdl(kUsePDL)(kernel, params);
     }
   }

--- a/python/sglang/jit_kernel/csrc/elementwise/activation.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/activation.cuh
@@ -93,14 +93,14 @@ struct ActivationKernel {
 
   template <bool kFilterExpert>
   static auto select_kernel(const std::string& type)
-      -> decltype(activation_kernel<ActivationKind::kSiLU, kFilterExpert>) {
+      -> decltype(ActivationKernel<T, kUsePDL>::template activation_kernel<ActivationKind::kSiLU, kFilterExpert>) {
     using namespace host;
     if (type == "silu") {
-      return activation_kernel<ActivationKind::kSiLU, kFilterExpert>;
+      return ActivationKernel<T, kUsePDL>::template activation_kernel<ActivationKind::kSiLU, kFilterExpert>;
     } else if (type == "gelu") {
-      return activation_kernel<ActivationKind::kGELU, kFilterExpert>;
+      return ActivationKernel<T, kUsePDL>::template activation_kernel<ActivationKind::kGELU, kFilterExpert>;
     } else if (type == "gelu_tanh") {
-      return activation_kernel<ActivationKind::kGELUTanh, kFilterExpert>;
+      return ActivationKernel<T, kUsePDL>::template activation_kernel<ActivationKind::kGELUTanh, kFilterExpert>;
     } else {
       Panic("unsupported activation type: ", type);
     }
@@ -150,10 +150,10 @@ struct ActivationKernel {
     };
     if (expert_ids != nullptr) {
       RuntimeCheck(expert_step > 0, "expert_step must be positive");
-      const auto kernel = select_kernel<true>(type);
+      const auto kernel = ActivationKernel<T, kUsePDL>::template select_kernel<true>(type);
       LaunchKernel(num_blocks, kBlockSize, device).enable_pdl(kUsePDL)(kernel, params);
     } else {
-      const auto kernel = select_kernel<false>(type);
+      const auto kernel = ActivationKernel<T, kUsePDL>::template select_kernel<false>(type);
       LaunchKernel(num_blocks, kBlockSize, device).enable_pdl(kUsePDL)(kernel, params);
     }
   }


### PR DESCRIPTION
## Motivation

After [#23707](https://github.com/sgl-project/sglang/pull/23707), the JIT activation kernel can fail to compile on a CUDA 12.8 Hopper `sm_90` runtime JIT path when a Qwen3.6 shared expert first reaches `silu_and_mul`. The failure happens in `tvm_ffi` inline compilation with `kUsePDL=true`, where NVCC parses the dependent member template calls in `ActivationKernel<T, kUsePDL>` incorrectly.
```
  [2026-04-29 16:02:48 TP6] Scheduler hit an exception: Traceback (most recent call last):
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 3820, in run_scheduler_process
    scheduler.run_event_loop()
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 1389, in run_event_loop
    dispatch_event_loop(self)
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 3692, in dispatch_event_loop
    scheduler.event_loop_normal()
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 1408, in event_loop_normal
    result = self.run_batch(batch)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 2870, in run_batch
    batch_result = self.model_worker.forward_batch_generation(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/managers/tp_worker.py", line 470, in forward_batch_generation
    out = self.model_runner.forward(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 3043, in forward
    output = self._forward_raw(
             ^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 3167, in _forward_raw
    ret, can_run_graph = self.forward_extend(
                         ^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 2966, in forward_extend
    self.model.forward(
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/models/qwen3_vl.py", line 1272, in forward
    hidden_states = general_mm_embed_routine(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/managers/mm_utils.py", line 1106, in general_mm_embed_routine
    hidden_states = language_model(
                    ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/models/qwen3_5.py", line 1051, in forward
    hidden_states, residual = layer(
                              ^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/models/qwen3_5.py", line 643, in forward
    hidden_states = self.mlp(
                    ^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/models/qwen2_moe.py", line 460, in forward
    shared_output = self._forward_shared_experts(hidden_states)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/models/qwen2_moe.py", line 365, in _forward_shared_experts
    shared_output = self.shared_expert(hidden_states)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/models/qwen2_moe.py", line 188, in forward
    x = self.act_fn(gate_up)
        ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/layers/utils/multi_platform.py", line 83, in forward
    return self._forward_method(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/layers/activation.py", line 87, in forward_cuda
    silu_and_mul(x, out)
  File "/sgl-workspace/sglang/python/sglang/jit_kernel/activation.py", line 109, in silu_and_mul
    return run_activation("silu", input, out, expert_ids, expert_step)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/jit_kernel/activation.py", line 97, in run_activation
    _run_activation_inplace(op_name, input, out)
  File "/usr/local/lib/python3.12/dist-packages/torch/_ops.py", line 1255, in __call__
    return self._op(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/jit_kernel/activation.py", line 57, in _run_activation_inplace
    module = _jit_activation_module(input.dtype)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/jit_kernel/utils.py", line 57, in wrapper
    result_map[key] = fn(*args, **kwargs)
                      ^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/jit_kernel/activation.py", line 34, in _jit_activation_module
    return load_jit(
           ^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/jit_kernel/utils.py", line 208, in load_jit
    return load_inline(
           ^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/tvm_ffi/cpp/extension.py", line 1123, in load_inline
    build_inline(
  File "/usr/local/lib/python3.12/dist-packages/tvm_ffi/cpp/extension.py", line 965, in build_inline
    return _build_impl(
           ^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/tvm_ffi/cpp/extension.py", line 729, in _build_impl
    build_ninja(str(build_dir))
  File "/usr/local/lib/python3.12/dist-packages/tvm_ffi/cpp/extension.py", line 601, in build_ninja
    raise RuntimeError("\n".join(msg))
RuntimeError: ninja exited with status 1
stdout:
[1/2] /usr/local/cuda/bin/nvcc  --generate-dependencies-with-compile --dependency-output cuda_0.o.d -Xcompiler -fPIC -std=c++17 -O2 -gencode=arch=compute_90,code=sm_90 -DSGL_CUDA_ARCH=900 -std=c++20 -O3 --expt-relaxed-constexpr --use_fast_math -I/usr/local/lib/python3.12/dist-packages/tvm_ffi/include -I/usr/local/lib/python3.12/dist-packages/tvm_ffi/include -I/sgl-workspace/sglang/python/sglang/jit_kernel/include -c /root/.cache/tvm-ffi/sgl_kernel_jit_activation_bf16_t_true_45d0672c397c596d/cuda.cu -o cuda_0.o
FAILED: [code=1] cuda_0.o
/usr/local/cuda/bin/nvcc  --generate-dependencies-with-compile --dependency-output cuda_0.o.d -Xcompiler -fPIC -std=c++17 -O2 -gencode=arch=compute_90,code=sm_90 -DSGL_CUDA_ARCH=900 -std=c++20 -O3 --expt-relaxed-constexpr --use_fast_math -I/usr/local/lib/python3.12/dist-packages/tvm_ffi/include -I/usr/local/lib/python3.12/dist-packages/tvm_ffi/include -I/sgl-workspace/sglang/python/sglang/jit_kernel/include -c /root/.cache/tvm-ffi/sgl_kernel_jit_activation_bf16_t_true_45d0672c397c596d/cuda.cu -o cuda_0.o
nvcc warning : incompatible redefinition for option 'std', the last value of this option was used
nvcc warning : incompatible redefinition for option 'optimize', the last value of this option was used
/sgl-workspace/sglang/python/sglang/jit_kernel/csrc/elementwise/activation.cuh(146): warning #2361-D: invalid narrowing conversion from "signed long" to "unsigned int"
          .hidden_dim = hidden_size,
                        ^

Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"

/sgl-workspace/sglang/python/sglang/jit_kernel/csrc/elementwise/activation.cuh(146): warning #2361-D: invalid narrowing conversion from "signed long" to "unsigned int"
          .hidden_dim = hidden_size,
                        ^
          detected during instantiation of "void <unnamed>::ActivationKernel<T, kUsePDL>::run_activation(tvm::ffi::TensorView, tvm::ffi::TensorView, std::string) [with T=bf16_t, kUsePDL=true]" at line 8 of /root/.cache/tvm-ffi/sgl_kernel_jit_activation_bf16_t_true_45d0672c397c596d/cuda.cu

Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"

/sgl-workspace/sglang/python/sglang/jit_kernel/csrc/elementwise/activation.cuh: In static member function 'static void _GLOBAL__N__dd15a818_7_cuda_cu_fc7cb620::ActivationKernel<T, kUsePDL>::launch(const tvm::ffi::TensorView&, const tvm::ffi::TensorView&, const std::string&, const int32_t*, uint32_t)':
/sgl-workspace/sglang/python/sglang/jit_kernel/csrc/elementwise/activation.cuh:153:42: error: no matching function for call to '_GLOBAL__N__dd15a818_7_cuda_cu_fc7cb620::ActivationKernel<T, kUsePDL>::select_kernel<true>(const std::string&)'
  153 |       const auto kernel = select_kernel<true>(type);
      |                     ~~~~~~~~~~~~~~~~~~~~~^~~~~~
/sgl-workspace/sglang/python/sglang/jit_kernel/csrc/elementwise/activation.cuh:95:1: note: candidate: 'template<class T, bool kUsePDL> template<bool kFilterExpert> static decltype (activation_kernel<_GLOBAL__N__dd15a818_7_cuda_cu_fc7cb620::ActivationKind::kSiLU, kFilterExpert>) _GLOBAL__N__dd15a818_7_cuda_cu_fc7cb620::ActivationKernel<T, kUsePDL>::select_kernel(const std::string&)'
   95 |   static auto select_kernel(const std::string& type)
      | ^ ~~~~~~~~~~~
/sgl-workspace/sglang/python/sglang/jit_kernel/csrc/elementwise/activation.cuh:95:1: note:   template argument deduction/substitution failed:
/sgl-workspace/sglang/python/sglang/jit_kernel/csrc/elementwise/activation.cuh: In substitution of 'template<class T, bool kUsePDL> template<bool kFilterExpert> static decltype (activation_kernel<_GLOBAL__N__dd15a818_7_cuda_cu_fc7cb620::ActivationKind::kSiLU, kFilterExpert>) _GLOBAL__N__dd15a818_7_cuda_cu_fc7cb620::ActivationKernel<T, kUsePDL>::select_kernel(const std::string&) [with bool kFilterExpert = <missing>; T = true; bool kUsePDL = <missing>]':
/sgl-workspace/sglang/python/sglang/jit_kernel/csrc/elementwise/activation.cuh:153:42:   required from here
/sgl-workspace/sglang/python/sglang/jit_kernel/csrc/elementwise/activation.cuh:95:52: error: type/value mismatch at argument 1 in template parameter list for 'template<class T, bool kUsePDL> template<_GLOBAL__N__dd15a818_7_cuda_cu_fc7cb620::ActivationKind kAct, bool kFilterExpert> constexpr const auto _GLOBAL__N__dd15a818_7_cuda_cu_fc7cb620::ActivationKernel<T, kUsePDL>::activation_kernel<kAct, kFilterExpert>'
   95 |   static auto select_kernel(const std::string& type)
      |                                                    ^
/sgl-workspace/sglang/python/sglang/jit_kernel/csrc/elementwise/activation.cuh:95:52: note:   expected a type, got '_GLOBAL__N__dd15a818_7_cuda_cu_fc7cb620::ActivationKind::kSiLU'
/sgl-workspace/sglang/python/sglang/jit_kernel/csrc/elementwise/activation.cuh:156:43: error: no matching function for call to '_GLOBAL__N__dd15a818_7_cuda_cu_fc7cb620::ActivationKernel<T, kUsePDL>::select_kernel<false>(const std::string&)'
  156 |       const auto kernel = select_kernel<false>(type);
      |                     ~~~~~~~~~~~~~~~~~~~~~~^~~~~~
/sgl-workspace/sglang/python/sglang/jit_kernel/csrc/elementwise/activation.cuh:95:1: note: candidate: 'template<class T, bool kUsePDL> template<bool kFilterExpert> static decltype (activation_kernel<_GLOBAL__N__dd15a818_7_cuda_cu_fc7cb620::ActivationKind::kSiLU, kFilterExpert>) _GLOBAL__N__dd15a818_7_cuda_cu_fc7cb620::ActivationKernel<T, kUsePDL>::select_kernel(const std::string&)'
   95 |   static auto select_kernel(const std::string& type)
      | ^ ~~~~~~~~~~~
/sgl-workspace/sglang/python/sglang/jit_kernel/csrc/elementwise/activation.cuh:95:1: note:   template argument deduction/substitution failed:
/sgl-workspace/sglang/python/sglang/jit_kernel/csrc/elementwise/activation.cuh: In substitution of 'template<class T, bool kUsePDL> template<bool kFilterExpert> static decltype (activation_kernel<_GLOBAL__N__dd15a818_7_cuda_cu_fc7cb620::ActivationKind::kSiLU, kFilterExpert>) _GLOBAL__N__dd15a818_7_cuda_cu_fc7cb620::ActivationKernel<T, kUsePDL>::select_kernel(const std::string&) [with bool kFilterExpert = <missing>; T = false; bool kUsePDL = <missing>]':
/sgl-workspace/sglang/python/sglang/jit_kernel/csrc/elementwise/activation.cuh:156:43:   required from here
/sgl-workspace/sglang/python/sglang/jit_kernel/csrc/elementwise/activation.cuh:95:52: error: type/value mismatch at argument 1 in template parameter list for 'template<class T, bool kUsePDL> template<_GLOBAL__N__dd15a818_7_cuda_cu_fc7cb620::ActivationKind kAct, bool kFilterExpert> constexpr const auto _GLOBAL__N__dd15a818_7_cuda_cu_fc7cb620::ActivationKernel<T, kUsePDL>::activation_kernel<kAct, kFilterExpert>'
   95 |   static auto select_kernel(const std::string& type)
      |                                                    ^
/sgl-workspace/sglang/python/sglang/jit_kernel/csrc/elementwise/activation.cuh:95:52: note:   expected a type, got '_GLOBAL__N__dd15a818_7_cuda_cu_fc7cb620::ActivationKind::kSiLU'
/sgl-workspace/sglang/python/sglang/jit_kernel/csrc/elementwise/activation.cuh: In instantiation of 'static void _GLOBAL__N__dd15a818_7_cuda_cu_fc7cb620::ActivationKernel<T, kUsePDL>::launch(const tvm::ffi::TensorView&, const tvm::ffi::TensorView&, const std::string&, const int32_t*, uint32_t) [with T = __nv_bfloat16; bool kUsePDL = true; std::string = std::__cxx11::basic_string<char>; int32_t = int; uint32_t = unsigned int]':
/sgl-workspace/sglang/python/sglang/jit_kernel/csrc/elementwise/activation.cuh:162:9:   required from 'static void _GLOBAL__N__dd15a818_7_cuda_cu_fc7cb620::ActivationKernel<T, kUsePDL>::run_activation(tvm::ffi::TensorView, tvm::ffi::TensorView, std::string) [with T = __nv_bfloat16; bool kUsePDL = true; std::string = std::__cxx11::basic_string<char>]'
/root/.cache/tvm-ffi/sgl_kernel_jit_activation_bf16_t_true_45d0672c397c596d/cuda.cu:8:427:   required from here
/sgl-workspace/sglang/python/sglang/jit_kernel/csrc/elementwise/activation.cuh:143:102: warning: narrowing conversion of '(long int)hidden_size' from 'long int' to 'uint32_t' {aka 'unsigned int'} [-Wnarrowing]
  143 |     const auto params = ActivationParams{
      |                                                                                                      ^
ninja: build stopped: subcommand failed.

[2026-04-29 16:02:48] SIGQUIT received. signum=None, frame=None. It usually means one child failed.
```

The complete observed launch command is:

```text
python3 -m sglang.launch_server \
  --model-path Qwen/Qwen3.6-35B-A3B \
  --tp-size 8 \
  --pp-size 1 \
  --page-size 1 \
  --host 0.0.0.0 \
  --port 30000 \
  --mem-fraction-static 0.7 \
  --chunked-prefill-size 8192
```

## Modifications

Make the dependent member template references explicit by qualifying `activation_kernel` and `select_kernel` with `ActivationKernel::template`.

This does not change which kernel is selected or how it runs. It only removes a template parsing ambiguity in the existing code path.

## Accuracy Tests

## Speed Tests and Profiling

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
