### PR TITLE
[SWA] Ensure we use pre-computed SWA cache location during prefill

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -183,16 +183,18 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
     def _get_layer_cache_loc(
         self,
         layer: RadixAttention,
-        cache_loc: torch.Tensor,
+        forward_batch: ForwardBatch,
     ) -> torch.Tensor:
         """Return cache locations in the correct index space for the given layer."""
         if self.use_sliding_window_kv_pool:
             _, is_swa = self._swa_kv_pool.layers_mapping[layer.layer_id]
             if is_swa:
-                if self._swa_kv_pool.swa_loc is not None:
-                    return self._swa_kv_pool.swa_loc
-                return self._swa_kv_pool.translate_loc_from_full_to_swa(cache_loc)
-        return cache_loc
+                if forward_batch.out_cache_loc_swa is not None:
+                    return forward_batch.out_cache_loc_swa
+                return self._swa_kv_pool.translate_loc_from_full_to_swa(
+                    forward_batch.out_cache_loc
+                )
+        return forward_batch.out_cache_loc
 
     def _bind_swa_page_table(
         self, metadata: TRTLLMMHAMetadata, source: dict, key: str, bs: int
@@ -565,7 +567,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         **kwargs,
     ):
         """Fused FP8 quantization and KV cache write."""
-        cache_loc = self._get_layer_cache_loc(layer, forward_batch.out_cache_loc)
+        cache_loc = self._get_layer_cache_loc(layer, forward_batch)
 
         # Get K/V cache buffers from token_to_kv_pool
         k_cache, v_cache = forward_batch.token_to_kv_pool.get_kv_buffer(layer.layer_id)

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -189,6 +189,8 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         if self.use_sliding_window_kv_pool:
             _, is_swa = self._swa_kv_pool.layers_mapping[layer.layer_id]
             if is_swa:
+                if self._swa_kv_pool.swa_loc is not None:
+                    return self._swa_kv_pool.swa_loc
                 return self._swa_kv_pool.translate_loc_from_full_to_swa(cache_loc)
         return cache_loc
 


### PR DESCRIPTION
## Summary
- When a sliding-window attention (SWA) layer already has a pre-computed `swa_loc`, return it directly instead of re-translating from the full cache location.
- This fixes an issue where during prefill, the pre-computed SWA cache location was being ignored.

Upstream from: https://github.com/meta-llama/prod_inference/commit/bdebd0f4bf3607f6495e65b13e3aa274f67508c6

## Test plan
- CI