### PR TITLE
ci: run setup_ld_library_path before install_sglang_kernel

### DIFF
--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -488,6 +488,7 @@ main() {
     setup_pip_toolchain
     uninstall_stale_flashinfer
     install_sglang
+    setup_ld_library_path
     install_sglang_kernel
     install_sglang_router
     download_flashinfer_cache
@@ -496,7 +497,6 @@ main() {
     fix_nvidia_deps
     install_test_tools
     prepare_runner
-    setup_ld_library_path
     verify_imports
 }
 

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -234,6 +234,16 @@ install_sglang() {
     echo "Installing python extras: [${EXTRAS}]"
     $PIP_CMD install -e "python[${EXTRAS}]" $PIP_INSTALL_SUFFIX
 
+    # Defensive: some runners ended up with nvidia-cusparselt-cu13 metadata
+    # present but libcusparseLt.so.0 missing on disk, breaking any torch import.
+    # If the file is missing, force-reinstall the wheel before downstream steps.
+    SITE_PACKAGES=$(python3 -c "import site; print(site.getsitepackages()[0])")
+    if [ ! -f "$SITE_PACKAGES/nvidia/cusparselt/lib/libcusparseLt.so.0" ] \
+       && pip show nvidia-cusparselt-cu13 >/dev/null 2>&1; then
+        echo "WARNING: nvidia-cusparselt-cu13 metadata present but libcusparseLt.so.0 missing — reinstalling"
+        $PIP_CMD install --reinstall nvidia-cusparselt-cu13 $PIP_INSTALL_SUFFIX
+    fi
+
     mark_step_done "${FUNCNAME[0]}"
 }
 
@@ -266,9 +276,12 @@ install_sglang_kernel() {
         fi
     fi
 
-    # Reinstall torch with matching CUDA version if needed
+    # Reinstall torch with matching CUDA version if needed.
+    # Read the CUDA tag from the installed wheel's local-version label (e.g. 2.9.1+cu130 → cu130)
+    # rather than `import torch`: importing torch dlopens libcusparseLt etc., which can fail when
+    # the matching nvidia-* wheel left only its .dist-info on disk (#23592 follow-up).
     # TODO: Remove after torch 2.11 where cu13 is enabled by default
-    TORCH_CUDA_VER=$(python3 -c "import torch; v=torch.version.cuda; parts=v.split('.'); print(f'cu{parts[0]}{parts[1]}')")
+    TORCH_CUDA_VER=$(pip show torch 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed -n 's/.*+\(cu[0-9]\+\).*/\1/p')
     echo "Detected torch CUDA version: ${TORCH_CUDA_VER}"
     if [ "${TORCH_CUDA_VER}" != "${CU_VERSION}" ]; then
         TORCH_VER=$(pip show torch 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed 's/+.*//')
@@ -488,7 +501,6 @@ main() {
     setup_pip_toolchain
     uninstall_stale_flashinfer
     install_sglang
-    setup_ld_library_path
     install_sglang_kernel
     install_sglang_router
     download_flashinfer_cache
@@ -497,6 +509,7 @@ main() {
     fix_nvidia_deps
     install_test_tools
     prepare_runner
+    setup_ld_library_path
     verify_imports
 }
 

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -276,12 +276,9 @@ install_sglang_kernel() {
         fi
     fi
 
-    # Reinstall torch with matching CUDA version if needed.
-    # Read the CUDA tag from the installed wheel's local-version label (e.g. 2.9.1+cu130 → cu130)
-    # rather than `import torch`: importing torch dlopens libcusparseLt etc., which can fail when
-    # the matching nvidia-* wheel left only its .dist-info on disk (#23592 follow-up).
+    # Reinstall torch with matching CUDA version if needed
     # TODO: Remove after torch 2.11 where cu13 is enabled by default
-    TORCH_CUDA_VER=$(pip show torch 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed -n 's/.*+\(cu[0-9]\+\).*/\1/p')
+    TORCH_CUDA_VER=$(python3 -c "import torch; v=torch.version.cuda; parts=v.split('.'); print(f'cu{parts[0]}{parts[1]}')")
     echo "Detected torch CUDA version: ${TORCH_CUDA_VER}"
     if [ "${TORCH_CUDA_VER}" != "${CU_VERSION}" ]; then
         TORCH_VER=$(pip show torch 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed 's/+.*//')


### PR DESCRIPTION
## Summary

`nvidia-cusparselt-cu13` was bumped on PyPI from 0.9.0 → 0.9.1 on 2026-04-29 18:36 UTC. On the affected runners, uv's upgrade install partially failed: it wrote the new `0.9.1` dist-info (registering the package as installed) but did not extract the bundled `nvidia/cusparselt/lib/libcusparseLt.so.0`. Because the dist-info looks intact, every subsequent `uv pip install` skips it as "already satisfied," so the broken state is sticky and `import torch` fails with `libcusparseLt.so.0: cannot open shared object file`.

Fix: at the end of `install_sglang`, if the wheel metadata is present but the `.so` is missing on disk, force-reinstall the wheel.

Failure example: https://github.com/sgl-project/sglang/actions/runs/25158915002/job/73748785757

## Test plan
- [ ] Trigger PR Test on a 1-GPU runner (5090 or h100); verify install dependency completes without `libcusparseLt.so.0` ImportError
- [ ] Confirm the WARNING fires on a runner where the file is missing, and is silent on a runner where it's present