### PR TITLE
Fix: glm47 streaming parser drops closing tag when value ends with '<'

### DIFF
--- a/python/sglang/srt/function_call/glm47_moe_detector.py
+++ b/python/sglang/srt/function_call/glm47_moe_detector.py
@@ -412,7 +412,28 @@ class Glm47MoeDetector(BaseFormatDetector):
                     ) and closing_tag.startswith(self._xml_tag_buffer)
 
                     if not is_potential_closing:
-                        content = self._xml_tag_buffer
+                        # The buffer is not a prefix of "</arg_value>", but a
+                        # proper suffix of it might still be. Slide forward to
+                        # the smallest k > 0 such that buffer[k:] is a prefix
+                        # of the closing tag and keep that suffix buffered;
+                        # everything before it is real value content. Without
+                        # this, a value ending with "<" (e.g. ".<") followed
+                        # immediately by "</arg_value>" would yield buffer
+                        # "<<", get ejected wholesale, and the actual closing
+                        # tag would never match — leaking "</arg_value>" into
+                        # the emitted JSON arguments.
+                        kept_suffix = ""
+                        for k in range(1, len(self._xml_tag_buffer)):
+                            candidate = self._xml_tag_buffer[k:]
+                            if closing_tag.startswith(candidate):
+                                kept_suffix = candidate
+                                break
+                        content = (
+                            self._xml_tag_buffer[: -len(kept_suffix)]
+                            if kept_suffix
+                            else self._xml_tag_buffer
+                        )
+
                         # Use cached value type for consistency
                         value_type = self._cached_value_type or "string"
 
@@ -425,14 +446,12 @@ class Glm47MoeDetector(BaseFormatDetector):
                                     1:-1
                                 ]
                                 self._current_value += content
-                                self._xml_tag_buffer = ""
                         elif value_type == "number":
                             if content:
                                 if not self._value_started:
                                     self._value_started = True
                                 json_output += content
                                 self._current_value += content
-                                self._xml_tag_buffer = ""
                         else:
                             # For object/array types, output as-is
                             if content:
@@ -440,7 +459,8 @@ class Glm47MoeDetector(BaseFormatDetector):
                                     self._value_started = True
                                 json_output += content
                                 self._current_value += content
-                                self._xml_tag_buffer = ""
+
+                        self._xml_tag_buffer = kept_suffix
 
         return json_output
 

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -2618,6 +2618,77 @@ class TestGlm47MoeDetector(unittest.TestCase):
         self.assertEqual(params["old_string"], "    indented code")
         self.assertEqual(params["new_string"], "        also indented")
 
+    def test_streaming_value_ending_with_less_than(self):
+        """Streaming: a value whose last character overlaps the start of </arg_value>.
+
+        When the value ends with '<', the next character emitted by the model
+        is the '<' that opens the closing tag. Without correct prefix-suffix
+        sliding, the buffer becomes '<<', fails the prefix check, and the
+        entire buffer is ejected as content — at which point the actual
+        closing tag is never matched and "</arg_value>" leaks into the
+        emitted JSON arguments.
+        """
+
+        def _stream(chunks):
+            detector = Glm47MoeDetector()
+            emitted = ""
+            for chunk in chunks:
+                result = detector.parse_streaming_increment(chunk, self.tools)
+                for call in result.calls:
+                    if call.parameters:
+                        emitted += call.parameters
+            return emitted
+
+        # Single chunk, value ending in '<'.
+        text = (
+            "<tool_call>get_weather"
+            "<arg_key>city</arg_key><arg_value>.<</arg_value>"
+            "<arg_key>date</arg_key><arg_value>2024-06-27</arg_value>"
+            "</tool_call>"
+        )
+        emitted = _stream([text])
+        self.assertEqual(json.loads(emitted), {"city": ".<", "date": "2024-06-27"})
+
+        # Realistic chunking: value and closing tag arrive in separate chunks.
+        emitted = _stream(
+            [
+                "<tool_call>get_weather<arg_key>city</arg_key><arg_value>",
+                ".<",
+                "</arg_value><arg_key>date</arg_key>"
+                "<arg_value>2024-06-27</arg_value></tool_call>",
+            ]
+        )
+        self.assertEqual(json.loads(emitted), {"city": ".<", "date": "2024-06-27"})
+
+        # Pathological chunking: every character on its own.
+        emitted = _stream(list(text))
+        self.assertEqual(json.loads(emitted), {"city": ".<", "date": "2024-06-27"})
+
+    def test_streaming_value_ending_with_closing_tag_prefix(self):
+        """Streaming: a value ending with a longer prefix of </arg_value>.
+
+        Same class of bug as the trailing-'<' case, but with a multi-char
+        overlap. The state machine must drop the smallest leading chunk such
+        that what remains is a prefix of "</arg_value>" — not eject the whole
+        buffer.
+        """
+        detector = Glm47MoeDetector()
+        text = (
+            "<tool_call>get_weather"
+            "<arg_key>city</arg_key><arg_value></arg_va</arg_value>"
+            "<arg_key>date</arg_key><arg_value>2024-06-27</arg_value>"
+            "</tool_call>"
+        )
+        emitted = ""
+        for chunk in list(text):
+            result = detector.parse_streaming_increment(chunk, self.tools)
+            for call in result.calls:
+                if call.parameters:
+                    emitted += call.parameters
+        self.assertEqual(
+            json.loads(emitted), {"city": "</arg_va", "date": "2024-06-27"}
+        )
+
 
 class TestJsonArrayParser(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary

`Glm47MoeDetector._process_xml_to_json_streaming` (the IN_VALUE state machine in `python/sglang/srt/function_call/glm47_moe_detector.py`) cannot recover when an argument value ends with a character that overlaps the start of `</arg_value>`. For a value like `.<` followed immediately by the closing tag, the buffer accumulates `<<`. That string is not a prefix of `</arg_value>` from position 0, so the current code ejects the entire buffer as value content including the second `<`, which is the actual start of the closing tag. The remaining 11 characters of `</arg_value>` are then ejected one by one as content, the closer is never detected, and the streamed `tool_calls.function.arguments` ends up containing a literal `</arg_value>` substring with an unclosed string. Clients reject the result as malformed JSON.

## Repro

Observed on a deployed GLM-5.1-FP8 SGLang server (`lmsysorg/sglang:dev` `glm5-hopper-*`) running with `--tool-call-parser glm47`, on a long-context tool-calling session where the model emitted a string-typed argument whose value ended in `<`. Streamed arguments deltas (verbatim from the server):

```
{
{"ptn": 
"."
<</arg_value>     ← bug
}
```

Concatenated, the client receives `{"ptn": ".<</arg_value>}` unparseable.

The non-streaming `detect_and_parse` regex path is unaffected; only `parse_streaming_increment` is broken. Cloud / proxy layers that stream from SGLang and reassemble preserve the broken output even when the user requests `stream: false`.

## Fix

When the buffer fails the prefix check, slide forward to the smallest `k > 0` such that `buffer[k:]` is still a prefix of `</arg_value>`. Emit `buffer[:k]` as value content and keep `buffer[k:]` in the buffer for the next character. For `<<` this leaves one `<` buffered to seed the closing-tag match; for any value whose tail does not overlap the start of the closing tag, behavior is unchanged.

## Tests

Two new unit tests in `test/registered/unit/function_call/test_function_call_parser.py::TestGlm47MoeDetector`:

- `test_streaming_value_ending_with_less_than` value `.<` followed by `</arg_value>`, exercised with three chunk arrangements (single chunk, value/close split, char-by-char). Both fail before the fix and pass after.
- `test_streaming_value_ending_with_closing_tag_prefix` value `</arg_va` (a longer 8-char prefix overlap) followed by the actual closing tag.

All 9 existing `TestGlm47MoeDetector` tests still pass, the change does not affect the prefix-from-zero or no-overlap paths.

```
Ran 11 tests in 0.003s
OK
```

## Test plan

- [x] New tests fail on `main`, pass on this branch.
- [x] All existing `TestGlm47MoeDetector` tests pass.
- [x] `pre-commit run --files` clean on both touched files (ruff, isort, black, codespell).