### PR TITLE
[Docker][ROCm] Bump ROCm720 base image from 7.2.0 to 7.2.2 to fix hipEventQuery race

### DIFF
--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -16,9 +16,9 @@
 
 # Default base images
 ARG BASE_IMAGE_942="rocm/sgl-dev:rocm7-vllm-20250904"
-ARG BASE_IMAGE_942_ROCM720="rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1"
+ARG BASE_IMAGE_942_ROCM720="rocm/pytorch:rocm7.2.2_ubuntu22.04_py3.10_pytorch_release_2.9.1"
 ARG BASE_IMAGE_950="rocm/sgl-dev:rocm7-vllm-20250904"
-ARG BASE_IMAGE_950_ROCM720="rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1"
+ARG BASE_IMAGE_950_ROCM720="rocm/pytorch:rocm7.2.2_ubuntu22.04_py3.10_pytorch_release_2.9.1"
 
 # This is necessary for scope purpose
 ARG GPU_ARCH=gfx950


### PR DESCRIPTION
## Motivation

The current ROCm720 base image
```
rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1
```
points at **ROCm 7.2.0**, which has a known `hipEventQuery` runtime bug — cross-thread calls ignore `THREAD_LOCAL` capture mode, so the NCCL watchdog can invalidate in-flight HIP graph captures.

This surfaces as multi-GPU AITER custom all-reduce crashes (sgl-project/sglang#23580, #23581). AITER's `IPCBufferPool` change in v0.1.12.post1 only widened the race window — the bug also exists with SGLang's own `CustomAllreduce`, just narrower.

The fix landed upstream in **ROCm 7.2.2** ([pytorch/pytorch#176251](https://github.com/pytorch/pytorch/pull/176251)), confirmed by the AMD AITER team in [ROCm/aiter#2941](https://github.com/ROCm/aiter/issues/2941) and [ROCm/aiter#2857](https://github.com/ROCm/aiter/issues/2857).

## Modifications

Bump both `BASE_IMAGE_*_ROCM720` ARGs in `docker/rocm.Dockerfile` to the 7.2.2 build:
```
- rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1
+ rocm/pytorch:rocm7.2.2_ubuntu22.04_py3.10_pytorch_release_2.9.1
```

Same Ubuntu / Python / PyTorch version, only the ROCm patch level changes. No C++ rebuild requirement, no Python change.

## Result

With this change, AITER custom all-reduce is safe to use again on the rebuilt SGLang ROCm720 images. The defensive default `SGLANG_USE_AITER_AR=false` from #23581 remains useful for users stuck on ROCm 7.2.0 environments, but the bug class is gone on this base image.

## Refs

- sgl-project/sglang#23580 — original repro of the multi-GPU crash
- sgl-project/sglang#23581 — defensive default-off (already merged-pending)
- ROCm/aiter#2941, ROCm/aiter#2857 — root cause investigations
- pytorch/pytorch#176251 — the upstream THREAD_LOCAL fix

cc @sunway513, @TennyWang1223, @HaiShaw
