### PR TITLE
[ROCm]Add RDNA4 GPU Support for sgl-kernel

### DIFF
--- a/sgl-kernel/csrc/common_extension_rocm.cc
+++ b/sgl-kernel/csrc/common_extension_rocm.cc
@@ -93,7 +93,8 @@ TORCH_LIBRARY_EXPAND(sgl_kernel, m) {
   m.def("get_meta_buffer_ipc_handle", &get_meta_buffer_ipc_handle);
   m.impl("get_meta_buffer_ipc_handle", torch::kCPU, &get_meta_buffer_ipc_handle);
 
-  // quick allreduce
+  // quick allreduce — CDNA only (uses MUBUF instructions unavailable on RDNA)
+#ifndef SGL_IS_RDNA
   m.def(
       "qr_all_reduce(int fa, Tensor inp, Tensor out, int quant_level, bool "
       "cast_bf2half) -> ()");
@@ -109,6 +110,7 @@ TORCH_LIBRARY_EXPAND(sgl_kernel, m) {
 
   // Max input size in bytes
   m.def("qr_max_size", &qr_max_size);
+#endif  // !SGL_IS_RDNA
 
   /*
    * From csrc/moe

--- a/sgl-kernel/include/sgl_kernel_ops.h
+++ b/sgl-kernel/include/sgl_kernel_ops.h
@@ -66,13 +66,15 @@ void register_graph_buffers(
     fptr_t _fa, const std::vector<std::string>& handles, const std::vector<std::vector<int64_t>>& offsets);
 torch::Tensor allocate_meta_buffer(int64_t size);
 torch::Tensor get_meta_buffer_ipc_handle(torch::Tensor& inp);
-// quick allreduce
+// quick allreduce — CDNA only (MUBUF instructions not available on RDNA)
+#ifndef SGL_IS_RDNA
 fptr_t init_custom_qr(int64_t rank, int64_t world_size, std::optional<int64_t> qr_max_size = std::nullopt);
 void qr_destroy(fptr_t _fa);
 torch::Tensor qr_get_handle(fptr_t _fa);
 void qr_open_handles(fptr_t _fa, const std::vector<torch::Tensor>& handles);
 void qr_all_reduce(fptr_t _fa, torch::Tensor& inp, torch::Tensor& out, int64_t quant_level, bool cast_bf2half = false);
 int64_t qr_max_size();
+#endif  // !SGL_IS_RDNA
 #else
 // custom allreduce
 fptr_t

--- a/sgl-kernel/include/utils.h
+++ b/sgl-kernel/include/utils.h
@@ -384,7 +384,7 @@ constexpr auto FP8_E4M3_MAX = 224.0f;
 using FP8_TYPE = c10::Float8_e4m3fn;
 C10_HOST_DEVICE constexpr auto FP8_E4M3_MAX = std::numeric_limits<FP8_TYPE>::max();
 #else
-#error "fp8 is not supported in this processor (arch < gfx942)."
+#error "FP8 is not supported on this AMD GPU. Enable FP8 only for gfx942+ (CDNA3) or RDNA4 (gfx1200+)."
 #endif  // HIP_FP8_TYPE_E4M3
 #endif  // HIP_FP8_TYPE_FNUZ
 #endif  // USE_ROCM

--- a/sgl-kernel/include/utils.h
+++ b/sgl-kernel/include/utils.h
@@ -342,7 +342,14 @@ inline bool getEnvEnablePDL() {
 #ifndef USE_ROCM
 #define WARP_SIZE 32
 #else
-#if defined(__GFX9__) || !defined(__HIP_DEVICE_COMPILE__)
+// ROCm: host code used to always see WARP_SIZE 64 via !__HIP_DEVICE_COMPILE__, while RDNA
+// device code used 32 — breaking host-side grid/block math in MoE topk launchers.
+#ifdef SGL_ROCM_WARP_SIZE
+#define WARP_SIZE SGL_ROCM_WARP_SIZE
+#elif defined(__gfx942__) || defined(__gfx941__) || defined(__gfx940__) || defined(__gfx950__) || \
+    defined(__gfx90a__) || defined(__gfx908__) || defined(__gfx906__)
+#define WARP_SIZE 64
+#elif defined(__HIP_DEVICE_COMPILE__) && defined(__GFX9__)
 #define WARP_SIZE 64
 #else
 #define WARP_SIZE 32

--- a/sgl-kernel/include/utils.h
+++ b/sgl-kernel/include/utils.h
@@ -391,7 +391,9 @@ constexpr auto FP8_E4M3_MAX = 224.0f;
 using FP8_TYPE = c10::Float8_e4m3fn;
 C10_HOST_DEVICE constexpr auto FP8_E4M3_MAX = std::numeric_limits<FP8_TYPE>::max();
 #else
+#ifdef ENABLE_FP8
 #error "FP8 is not supported on this AMD GPU. Enable FP8 only for gfx942+ (CDNA3) or RDNA4 (gfx1200+)."
+#endif  // ENABLE_FP8
 #endif  // HIP_FP8_TYPE_E4M3
 #endif  // HIP_FP8_TYPE_FNUZ
 #endif  // USE_ROCM

--- a/sgl-kernel/python/sgl_kernel/allreduce.py
+++ b/sgl-kernel/python/sgl_kernel/allreduce.py
@@ -85,7 +85,7 @@ if torch.version.hip is not None:
             rank: int, world_size: int, qr_max_size: Optional[int] = None
         ) -> int:
             return torch.ops.sgl_kernel.init_custom_qr.default(
-                world_size, rank, qr_max_size
+                rank, world_size, qr_max_size
             )
 
         def qr_get_handle(fa: int) -> torch.Tensor:
@@ -96,13 +96,13 @@ if torch.version.hip is not None:
 
         def qr_all_reduce(
             fa: int,
-            profile: int,
             inp: torch.Tensor,
             out: torch.Tensor,
-            cast_bf162half: bool,
+            quant_level: int,
+            cast_bf2half: bool = False,
         ) -> None:
             torch.ops.sgl_kernel.qr_all_reduce.default(
-                fa, profile, inp, out, cast_bf162half
+                fa, inp, out, quant_level, cast_bf2half
             )
 
         def qr_destroy(fa: int) -> None:

--- a/sgl-kernel/python/sgl_kernel/allreduce.py
+++ b/sgl-kernel/python/sgl_kernel/allreduce.py
@@ -2,6 +2,23 @@ from typing import List, Optional, Tuple
 
 import torch
 
+
+def _is_rdna() -> bool:
+    """Return True if the current AMD GPU is an RDNA architecture (GFX10/11/12)."""
+    if torch.version.hip is None:
+        return False
+    if not torch.cuda.is_available():
+        return False
+    try:
+        arch = torch.cuda.get_device_properties(0).gcnArchName.split(":")[0]
+        # RDNA3: gfx1100/gfx1101/gfx1102; RDNA4: gfx1200/gfx1201
+        return arch.startswith("gfx11") or arch.startswith("gfx12")
+    except Exception:
+        return False
+
+
+_HIP_IS_RDNA = _is_rdna()
+
 if torch.version.hip is not None:
     # ROCM custom allreduce
     def init_custom_ar(
@@ -61,36 +78,38 @@ if torch.version.hip is not None:
     def get_meta_buffer_ipc_handle(inp: torch.Tensor) -> torch.Tensor:
         return torch.ops.sgl_kernel.get_meta_buffer_ipc_handle.default(inp)
 
-    # ROCM quick allreduce
-    def init_custom_qr(
-        rank: int, world_size: int, qr_max_size: Optional[int] = None
-    ) -> int:
-        return torch.ops.sgl_kernel.init_custom_qr.default(
-            world_size, rank, qr_max_size
-        )
+    # ROCM quick allreduce — CDNA only (not available on RDNA)
+    if not _HIP_IS_RDNA:
 
-    def qr_get_handle(fa: int) -> torch.Tensor:
-        return torch.ops.sgl_kernel.qr_get_handle.default(fa)
+        def init_custom_qr(
+            rank: int, world_size: int, qr_max_size: Optional[int] = None
+        ) -> int:
+            return torch.ops.sgl_kernel.init_custom_qr.default(
+                world_size, rank, qr_max_size
+            )
 
-    def qr_open_handles(fa: int, handles: list[torch.Tensor]) -> None:
-        torch.ops.sgl_kernel.qr_open_handles.default(fa, handles)
+        def qr_get_handle(fa: int) -> torch.Tensor:
+            return torch.ops.sgl_kernel.qr_get_handle.default(fa)
 
-    def qr_all_reduce(
-        fa: int,
-        profile: int,
-        inp: torch.Tensor,
-        out: torch.Tensor,
-        cast_bf162half: bool,
-    ) -> None:
-        torch.ops.sgl_kernel.qr_all_reduce.default(
-            fa, profile, inp, out, cast_bf162half
-        )
+        def qr_open_handles(fa: int, handles: list[torch.Tensor]) -> None:
+            torch.ops.sgl_kernel.qr_open_handles.default(fa, handles)
 
-    def qr_destroy(fa: int) -> None:
-        torch.ops.sgl_kernel.qr_destroy.default(fa)
+        def qr_all_reduce(
+            fa: int,
+            profile: int,
+            inp: torch.Tensor,
+            out: torch.Tensor,
+            cast_bf162half: bool,
+        ) -> None:
+            torch.ops.sgl_kernel.qr_all_reduce.default(
+                fa, profile, inp, out, cast_bf162half
+            )
 
-    def qr_max_size() -> int:
-        return torch.ops.sgl_kernel.qr_max_size.default()
+        def qr_destroy(fa: int) -> None:
+            torch.ops.sgl_kernel.qr_destroy.default(fa)
+
+        def qr_max_size() -> int:
+            return torch.ops.sgl_kernel.qr_max_size.default()
 
     # mscclpp
     def mscclpp_generate_unique_id() -> bytes:

--- a/sgl-kernel/setup_rocm.py
+++ b/sgl-kernel/setup_rocm.py
@@ -77,6 +77,17 @@ is_rdna3 = amdgpu_target in RDNA3_TARGETS
 is_rdna4 = amdgpu_target in RDNA4_TARGETS
 is_rdna = is_rdna3 or is_rdna4
 
+# common_extension_rocm.cc is built with cxx-only flags; HIP sources get hipcc_flags.
+# Mirror RDNA macros on cxx so #ifndef SGL_IS_RDNA matches the linked objects (CDNA-only
+# quick_all_reduce / qr_* are omitted on RDNA — otherwise we link references to qr_destroy
+# without defining it).
+if is_rdna:
+    cxx_flags.append("-DSGL_IS_RDNA")
+if is_rdna3:
+    cxx_flags.append("-DSGL_IS_RDNA3")
+if is_rdna4:
+    cxx_flags.append("-DSGL_IS_RDNA4")
+
 # FP8 format selection:
 #   gfx942 (CDNA3):  FNUZ (non-IEEE, max=224)
 #   gfx950 (CDNA3+): standard E4M3 (IEEE, same as NVIDIA)
@@ -139,6 +150,11 @@ if is_rdna4:
 
 if fp8_macro is not None:
     hipcc_flags.extend(["-DENABLE_FP8", fp8_macro])
+
+# MoE topk: host and device must agree on logical warp width (64 CDNA, 32 RDNA).
+_rocm_warp = 64 if is_cdna else 32
+hipcc_flags.append(f"-DSGL_ROCM_WARP_SIZE={_rocm_warp}")
+cxx_flags.append(f"-DSGL_ROCM_WARP_SIZE={_rocm_warp}")
 
 ext_modules = [
     CUDAExtension(

--- a/sgl-kernel/setup_rocm.py
+++ b/sgl-kernel/setup_rocm.py
@@ -40,23 +40,6 @@ include_dirs = [
     root / "csrc",
 ]
 
-sources = [
-    "csrc/allreduce/custom_all_reduce.hip",
-    "csrc/allreduce/deterministic_all_reduce.hip",
-    "csrc/allreduce/quick_all_reduce.cu",
-    "csrc/common_extension_rocm.cc",
-    "csrc/elementwise/activation.cu",
-    "csrc/elementwise/topk.cu",
-    "csrc/grammar/apply_token_bitmask_inplace_cuda.cu",
-    "csrc/moe/moe_align_kernel.cu",
-    "csrc/moe/moe_topk_softmax_kernels.cu",
-    "csrc/moe/moe_topk_sigmoid_kernels.cu",
-    "csrc/speculative/eagle_utils.cu",
-    "csrc/kvcacheio/transfer.cu",
-    "csrc/memory/weak_ref_tensor.cpp",
-    "csrc/elementwise/pos_enc.cu",
-]
-
 cxx_flags = ["-O3"]
 libraries = ["hiprtc", "amdhip64", "c10", "torch", "torch_python"]
 extra_link_args = ["-Wl,-rpath,$ORIGIN/../../torch/lib", f"-L/usr/lib/{arch}-linux-gnu"]
@@ -72,21 +55,68 @@ if torch.cuda.is_available():
 else:
     print(f"Warning: torch.cuda not available. Using default target: {amdgpu_target}")
 
-if amdgpu_target not in ["gfx942", "gfx950"]:
+# Supported architectures:
+#   CDNA3:  gfx942  (MI300X/MI325X)
+#   CDNA3+: gfx950  (MI350X)
+#   RDNA3:  gfx1100, gfx1101, gfx1102  (RX 7900 series)
+#   RDNA4:  gfx1200, gfx1201           (RX 9070 series)
+CDNA_TARGETS = ["gfx942", "gfx950"]
+RDNA3_TARGETS = ["gfx1100", "gfx1101", "gfx1102"]
+RDNA4_TARGETS = ["gfx1200", "gfx1201"]
+SUPPORTED_TARGETS = CDNA_TARGETS + RDNA3_TARGETS + RDNA4_TARGETS
+
+if amdgpu_target not in SUPPORTED_TARGETS:
     print(
-        f"Warning: Unsupported GPU architecture detected '{amdgpu_target}'. Expected 'gfx942' or 'gfx950'."
+        f"Warning: Unsupported GPU architecture detected '{amdgpu_target}'. "
+        f"Supported: {SUPPORTED_TARGETS}"
     )
     sys.exit(1)
 
-fp8_macro = (
-    "-DHIP_FP8_TYPE_FNUZ" if amdgpu_target == "gfx942" else "-DHIP_FP8_TYPE_E4M3"
-)
+is_cdna = amdgpu_target in CDNA_TARGETS
+is_rdna3 = amdgpu_target in RDNA3_TARGETS
+is_rdna4 = amdgpu_target in RDNA4_TARGETS
+is_rdna = is_rdna3 or is_rdna4
+
+# FP8 format selection:
+#   gfx942 (CDNA3):  FNUZ (non-IEEE, max=224)
+#   gfx950 (CDNA3+): standard E4M3 (IEEE, same as NVIDIA)
+#   RDNA3:           no hardware FP8 support
+#   RDNA4:           standard E4M3 (IEEE, same as NVIDIA)
+if amdgpu_target == "gfx942":
+    fp8_macro = "-DHIP_FP8_TYPE_FNUZ"
+elif amdgpu_target in ["gfx950"] + RDNA4_TARGETS:
+    fp8_macro = "-DHIP_FP8_TYPE_E4M3"
+else:
+    fp8_macro = None  # RDNA3: no FP8
 
 # Dynamic shared-memory budget for the TopK kernels.
-# - gfx942 (MI300/MI325): LDS is typically 64KB per workgroup -> keep dynamic smem <= ~48KB
-#   (leaves room for static shared allocations in the kernel).
-# - gfx95x (MI350): LDS is larger (e.g. 160KB per CU) -> allow the original 128KB dynamic smem.
-topk_dynamic_smem_bytes = 48 * 1024 if amdgpu_target == "gfx942" else 32 * 1024 * 4
+# - gfx942 (MI300/MI325): LDS 64KB per workgroup -> cap at 48KB
+# - gfx95x (MI350):       LDS 160KB per CU -> 128KB dynamic smem
+# - RDNA3/4:              LDS 64KB per workgroup -> cap at 48KB
+if amdgpu_target == "gfx950":
+    topk_dynamic_smem_bytes = 32 * 1024 * 4
+else:
+    topk_dynamic_smem_bytes = 48 * 1024
+
+sources = [
+    "csrc/common_extension_rocm.cc",
+    "csrc/allreduce/custom_all_reduce.hip",
+    "csrc/allreduce/deterministic_all_reduce.hip",
+    "csrc/elementwise/activation.cu",
+    "csrc/elementwise/topk.cu",
+    "csrc/grammar/apply_token_bitmask_inplace_cuda.cu",
+    "csrc/moe/moe_align_kernel.cu",
+    "csrc/moe/moe_topk_softmax_kernels.cu",
+    "csrc/moe/moe_topk_sigmoid_kernels.cu",
+    "csrc/speculative/eagle_utils.cu",
+    "csrc/kvcacheio/transfer.cu",
+    "csrc/memory/weak_ref_tensor.cpp",
+    "csrc/elementwise/pos_enc.cu",
+]
+
+# quick_all_reduce uses CDNA-specific MUBUF instructions; not available on RDNA.
+if is_cdna:
+    sources.append("csrc/allreduce/quick_all_reduce.cu")
 
 hipcc_flags = [
     "-DNDEBUG",
@@ -97,10 +127,18 @@ hipcc_flags = [
     "-std=c++17",
     f"--amdgpu-target={amdgpu_target}",
     "-DENABLE_BF16",
-    "-DENABLE_FP8",
-    fp8_macro,
     f"-DSGL_TOPK_DYNAMIC_SMEM_BYTES={topk_dynamic_smem_bytes}",
 ]
+
+if is_rdna:
+    hipcc_flags.append("-DSGL_IS_RDNA")
+if is_rdna3:
+    hipcc_flags.append("-DSGL_IS_RDNA3")
+if is_rdna4:
+    hipcc_flags.append("-DSGL_IS_RDNA4")
+
+if fp8_macro is not None:
+    hipcc_flags.extend(["-DENABLE_FP8", fp8_macro])
 
 ext_modules = [
     CUDAExtension(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Based on the existed sgl-kernel codes, added the AMD Radeon GPU support for sgl-kernel  

## Modifications

- RDNA4 architecture support (setup_rocm.py): Extended the build system to recognize and compile for  RDNA4 (gfx1200/1201) targets in addition to the existing CDNA3/4 (gfx942, gfx950). Introduced SGL_IS_RDNA, SGL_IS_RDNA3, SGL_IS_RDNA4 compile-time macros propagated to both hipcc and cxx compilation units.
- Quick allreduce gated to CDNA only (common_extension_rocm.cc, sgl_kernel_ops.h, allreduce.py): The quick_all_reduce (qr_*) family relies on CDNA-specific MUBUF instructions that are unavailable on RDNA. These are now conditionally compiled (#ifndef SGL_IS_RDNA) and skipped at runtime on RDNA devices, preventing link errors and undefined symbol crashes.
- WARP_SIZE fix for ROCm host code (utils.h): Host-side code previously always resolved WARP_SIZE to 64 via the !__HIP_DEVICE_COMPILE__ branch, causing incorrect grid/block math in MoE topk launchers on RDNA (which uses warp size 32). A new SGL_ROCM_WARP_SIZE macro (64 for CDNA, 32 for RDNA) is injected at build time and takes priority, making both host and device code agree on the logical warp width.
- FP8 handling for RDNA3: RDNA3 has no hardware FP8 support; the build now skips -DENABLE_FP8 for those targets instead of raising a compile error.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
This PR didn't change the kernel codes directly, so doesn't run the accuracy test 

used sgl-kernel unit test to verify the PR on RDNA4 GPU.

python3 -m pytest test_moe_align.py test_moe_topk_softmax.py test_apply_token_bitmask_inplace.py test_activation.py test_topk.py  test_moe_topk_sigmoid.py test_torch_defaults_reset.py speculative/test_eagle_utils.py

<img width="1891" height="554" alt="{0B8784AA-8A24-474D-B216-42761B376416}" src="https://github.com/user-attachments/assets/5c573a82-39b5-4bbf-90d9-220940503460" />

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [* ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [* ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
