### PR TITLE
[Router] Fix PD router hang when prefill server returns error

### DIFF
--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -576,8 +576,53 @@ impl PDRouter {
         }
         .emit();
 
-        let (prefill_result, decode_result) =
-            tokio::join!(prefill_request.send(), decode_request.send());
+        let prefill_future = prefill_request.send();
+        let decode_future = decode_request.send();
+
+        tokio::pin!(prefill_future);
+        tokio::pin!(decode_future);
+
+        // Use select! instead of join! to detect prefill failure early.
+        // In PD disaggregation, if prefill fails, decode will hang forever
+        // waiting for KV cache that will never arrive. We must cancel decode
+        // and return the prefill error immediately.
+        let (prefill_result, decode_result) = tokio::select! {
+            prefill_res = &mut prefill_future => {
+                let prefill_failed = match &prefill_res {
+                    Ok(resp) => !resp.status().is_success(),
+                    Err(_) => true,
+                };
+                if prefill_failed {
+                    // Prefill failed - decode will hang forever waiting for KV
+                    // cache. Return prefill error immediately; dropping
+                    // decode_future on return cancels the pending request.
+                    error!(
+                        "Prefill failed, cancelling decode request to avoid hang. \
+                         prefill_url={}", prefill.url()
+                    );
+                    events::RequestReceivedEvent {}.emit();
+                    return match self
+                        .process_prefill_response(prefill_res, prefill.url(), false)
+                        .await
+                    {
+                        Err(error_response) => error_response,
+                        Ok((status, _)) => error::internal_error(
+                            "prefill_unexpected",
+                            format!(
+                                "Prefill status {} was not caught by process_prefill_response",
+                                status
+                            ),
+                        ),
+                    };
+                }
+                // Prefill succeeded, wait for decode normally
+                (prefill_res, decode_future.await)
+            }
+            decode_res = &mut decode_future => {
+                // Decode completed first (e.g. immediate error), wait for prefill
+                (prefill_future.await, decode_res)
+            }
+        };
 
         events::RequestReceivedEvent {}.emit();
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

This patch is for 

- Fix a hang in PD disaggregation mode where the router blocks forever if the prefill server returns a non-2xx response (e.g. 400 Bad Request)
- Replace `tokio::join!` with `tokio::select!` in `execute_dual_dispatch_internal` to detect prefill failure early and cancel the decode request immediately


## Motivation

<!-- Describe the purpose and goals of this pull request. -->

In PD (prefill-decode) disaggregation mode, the router sends requests to both prefill and decode servers concurrently using `tokio::join!`. The decode server depends on receiving the KV cache from the prefill server before it can produce a response.

If the prefill server rejects the request (e.g. input exceeds context length → 400, or any other error), the KV cache transfer never happens. The decode server then waits indefinitely for KV data that will never arrive, and `tokio::join!` blocks forever because the decode future never completes. This causes the entire request to hang in the router until the HTTP client timeout (default 1800s), effectively making the benchmark or client appear stuck at ~100% progress.

This was observed in production with 40960-prompt benchmarks where a small number of requests hit the context length boundary (`input_tokens + output_tokens == context_length`), causing the prefill server to return 400. The benchmark would hang at 40959/40960 indefinitely.

## Modifications

<!-- Detail the changes made in this pull request. -->
Replace `tokio::join!` with `tokio::select!` to race the prefill and decode futures:
- If **prefill completes first with an error**: immediately return the error to the client. The decode future is dropped (cancelled) on return, preventing the hang.
- If **prefill completes first with success**: wait for decode normally (same as before).
- If **decode completes first**: wait for prefill (same as before).

This preserves the concurrent dispatch behavior on the happy path while adding early termination on prefill failure.


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
