### PR TITLE
[sgl-kernel] Prep for torch 2.11 upgrade and switch PyPI default to cu130

### DIFF
--- a/.github/workflows/release-whl-kernel.yml
+++ b/.github/workflows/release-whl-kernel.yml
@@ -182,12 +182,6 @@ jobs:
           BUILD_JOBS: 64
           NVCC_THREADS: 8
 
-      # rename_wheels.sh tags the cu130 wheel's METADATA Version with +cu130
-      # (needed elsewhere — e.g. local install discrimination — see PR #23587),
-      # but PyPI rejects PEP 440 local version labels with HTTP 400. Repack a
-      # PyPI-clean copy with the +cu130 segment stripped into dist-pypi/, and
-      # upload that copy. dist/ is left untouched so the +cu130 wheel still
-      # flows through the upload-artifact -> sgl-project/whl index path below.
       - name: Strip +cu130 local version for PyPI upload
         working-directory: sgl-kernel
         run: |

--- a/.github/workflows/release-whl-kernel.yml
+++ b/.github/workflows/release-whl-kernel.yml
@@ -34,6 +34,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # cu130 is the PyPI-released variant; cu129 wheels are published only to the
+  # sgl-project/whl index (consumed via `pip install ...+cu129` for the legacy
+  # cuda 12.9 path), not to PyPI.
   build-cu129-matrix:
     if: |
       github.repository == 'sgl-project/sglang' &&
@@ -77,43 +80,6 @@ jobs:
         env:
           BUILD_JOBS: 64
           NVCC_THREADS: 8
-
-      # rename_wheels.sh tags the cu129 wheel's METADATA Version with +cu129
-      # (needed elsewhere — e.g. local install discrimination — see PR #23587),
-      # but PyPI rejects PEP 440 local version labels with HTTP 400. Repack a
-      # PyPI-clean copy with the +cu129 segment stripped into dist-pypi/, and
-      # upload that copy. dist/ is left untouched so the +cu129 wheel still
-      # flows through the upload-artifact -> sgl-project/whl index path below.
-      - name: Strip +cu129 local version for PyPI upload
-        working-directory: sgl-kernel
-        run: |
-          set -eux
-          pip install wheel
-          mkdir -p dist-pypi
-          for w in dist/*.whl; do
-            tmp=$(mktemp -d)
-            python3 -m wheel unpack "$w" --dest "$tmp"
-            unpacked=$(find "$tmp" -mindepth 1 -maxdepth 1 -type d | head -1)
-            info=$(find "$unpacked" -maxdepth 1 -type d -name "*.dist-info" | head -1)
-            meta="$info/METADATA"
-            orig=$(grep '^Version:' "$meta" | head -1 | sed 's/^Version:[[:space:]]*//')
-            new=$(echo "$orig" | sed 's/+cu[0-9]\+$//')
-            if [ "$orig" != "$new" ]; then
-              sed -i "s/^Version:.*/Version: ${new}/" "$meta"
-              old_base=$(basename "$info")
-              new_base="${old_base/${orig}/${new}}"
-              mv "$info" "$(dirname "$info")/${new_base}"
-            fi
-            python3 -m wheel pack "$unpacked" --dest-dir dist-pypi
-            rm -rf "$tmp"
-          done
-          ls -lh dist-pypi/
-
-      - name: Upload to PyPI
-        working-directory: sgl-kernel
-        run: |
-          pip install twine
-          python3 -m twine upload --skip-existing dist-pypi/* -u __token__ -p ${{ secrets.PYPI_TOKEN_SGLANG_KERNEL }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -172,7 +138,6 @@ jobs:
           git commit -m "update whl index"
           git push
 
-  # for now we do not release CUDA 13.0 wheels to pypi
   build-cu130-matrix:
     if: |
       github.repository == 'sgl-project/sglang' &&
@@ -216,6 +181,43 @@ jobs:
         env:
           BUILD_JOBS: 64
           NVCC_THREADS: 8
+
+      # rename_wheels.sh tags the cu130 wheel's METADATA Version with +cu130
+      # (needed elsewhere — e.g. local install discrimination — see PR #23587),
+      # but PyPI rejects PEP 440 local version labels with HTTP 400. Repack a
+      # PyPI-clean copy with the +cu130 segment stripped into dist-pypi/, and
+      # upload that copy. dist/ is left untouched so the +cu130 wheel still
+      # flows through the upload-artifact -> sgl-project/whl index path below.
+      - name: Strip +cu130 local version for PyPI upload
+        working-directory: sgl-kernel
+        run: |
+          set -eux
+          pip install wheel
+          mkdir -p dist-pypi
+          for w in dist/*.whl; do
+            tmp=$(mktemp -d)
+            python3 -m wheel unpack "$w" --dest "$tmp"
+            unpacked=$(find "$tmp" -mindepth 1 -maxdepth 1 -type d | head -1)
+            info=$(find "$unpacked" -maxdepth 1 -type d -name "*.dist-info" | head -1)
+            meta="$info/METADATA"
+            orig=$(grep '^Version:' "$meta" | head -1 | sed 's/^Version:[[:space:]]*//')
+            new=$(echo "$orig" | sed 's/+cu[0-9]\+$//')
+            if [ "$orig" != "$new" ]; then
+              sed -i "s/^Version:.*/Version: ${new}/" "$meta"
+              old_base=$(basename "$info")
+              new_base="${old_base/${orig}/${new}}"
+              mv "$info" "$(dirname "$info")/${new_base}"
+            fi
+            python3 -m wheel pack "$unpacked" --dest-dir dist-pypi
+            rm -rf "$tmp"
+          done
+          ls -lh dist-pypi/
+
+      - name: Upload to PyPI
+        working-directory: sgl-kernel
+        run: |
+          pip install twine
+          python3 -m twine upload --skip-existing dist-pypi/* -u __token__ -p ${{ secrets.PYPI_TOKEN_SGLANG_KERNEL }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/scripts/update_kernel_whl_index.py
+++ b/scripts/update_kernel_whl_index.py
@@ -7,7 +7,7 @@ import re
 
 # All the CUDA versions that the wheels will cover
 SUPPORTED_CUDA_VERSIONS = ["129", "130"]
-DEFAULT_CUDA_VERSION = "129"
+DEFAULT_CUDA_VERSION = "130"
 
 
 def check_wheel_cuda_version(path_name, target_cuda_version):

--- a/sgl-kernel/Dockerfile
+++ b/sgl-kernel/Dockerfile
@@ -79,10 +79,10 @@ RUN set -eux; \
 RUN --mount=type=cache,id=sgl-kernel-pip,target=/root/.cache/pip \
     set -eux; \
     case "${CUDA_VERSION}" in \
-      13.0) TORCH_VER=2.9.1; CU_TAG=cu130 ;; \
-      12.9) TORCH_VER=2.9.1; CU_TAG=cu128 ;; \
-      12.8) TORCH_VER=2.9.1; CU_TAG=cu128 ;; \
-      *)    TORCH_VER=2.9.1; CU_TAG=cu126 ;; \
+      13.0) TORCH_VER=2.11.0; CU_TAG=cu130 ;; \
+      12.9) TORCH_VER=2.11.0; CU_TAG=cu129 ;; \
+      12.8) TORCH_VER=2.11.0; CU_TAG=cu128 ;; \
+      *)    TORCH_VER=2.11.0; CU_TAG=cu126 ;; \
     esac; \
     ${PYTHON_ROOT_PATH}/bin/pip install torch==${TORCH_VER} --index-url https://${PYTORCH_MIRROR}/whl/${CU_TAG}; \
     ${PYTHON_ROOT_PATH}/bin/pip install ninja setuptools==75.0.0 wheel==0.41.0 numpy uv scikit-build-core --index-url ${PIP_DEFAULT_INDEX}

--- a/sgl-kernel/README.md
+++ b/sgl-kernel/README.md
@@ -12,7 +12,7 @@
 `sglang-kernel` provides optimized compute primitives for LLM inference engines, enabling efficient inference for large language models and vision-language models through custom kernel operations. The source tree remains under the `sgl-kernel/` directory and the Python import path remains `sgl_kernel`.
 
 ## Installation
-Requires torch == 2.9.1
+Requires torch == 2.11.0
 
 ```bash
 # Latest version


### PR DESCRIPTION
## Summary

Slim subset of #21247 covering only the sgl-kernel side of the torch
2.11 upgrade.

- Bump `sgl-kernel/Dockerfile` and `sgl-kernel/README.md` to torch 2.11.0.
  Torch 2.11 ships cu129 wheels (torch 2.9 didn't), so the 12.9 row of
  the build matrix now resolves to `cu129` instead of falling back to
  `cu128`.
- In `.github/workflows/release-whl-kernel.yml`, move the "Strip +cu
  local version" + "Upload to PyPI" steps from `build-cu129-matrix`
  to `build-cu130-matrix`. cu130 becomes the PyPI-released variant;
  cu129 wheels remain available via the sgl-project/whl index (with
  the `+cu129` PEP 440 local-version label) but no longer reach PyPI.
  The strip-script regex (`+cu[0-9]\+$`) is generic, so the cu130
  side is identical to the prior cu129 path.

## Test plan

- [ ] Trigger `Release SGLang Kernels` via workflow_dispatch with
      `target=cu130`; confirm the wheel lands on PyPI with no `+cu130`
      suffix on the `Version:` line.
- [ ] Same for `target=cu129`; confirm no PyPI upload happens, and the
      wheel still lands on sgl-project/whl with `+cu129`.
- [ ] On the next sgl-kernel `version.py` bump, confirm the auto-push
      flow publishes cu130 to PyPI as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)