### PR TITLE
perf: batch GPU->CPU sync for per-request logprobs and embeddings

### DIFF
--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -20,6 +20,7 @@ from sglang.srt.managers.schedule_batch import (
     Req,
     ScheduleBatch,
 )
+from sglang.srt.managers.utils import batch_convert_tensors_to_lists
 from sglang.srt.mem_cache.common import release_kv_cache
 from sglang.srt.server_args import MIS_DELIMITER_TOKEN_ID, get_global_server_args
 
@@ -169,11 +170,13 @@ class SchedulerOutputProcessorMixin:
                     logits_output.next_token_top_logprobs_idx = [
                         x.tolist() for x in logits_output.next_token_top_logprobs_idx
                     ]
+                # Batch-sync to avoid N individual GPU→CPU syncs (one per req).
                 if logits_output.next_token_token_ids_logprobs_val:
-                    logits_output.next_token_token_ids_logprobs_val = [
-                        v.tolist()
-                        for v in logits_output.next_token_token_ids_logprobs_val
-                    ]
+                    logits_output.next_token_token_ids_logprobs_val = (
+                        batch_convert_tensors_to_lists(
+                            logits_output.next_token_token_ids_logprobs_val
+                        )
+                    )
 
             hidden_state_offset = 0
 
@@ -307,7 +310,7 @@ class SchedulerOutputProcessorMixin:
                 if isinstance(embeddings, torch.Tensor):
                     embeddings = embeddings.tolist()
                 else:
-                    embeddings = [tensor.tolist() for tensor in embeddings]
+                    embeddings = batch_convert_tensors_to_lists(embeddings)
 
             if phs is not None:
                 if isinstance(phs, list):
@@ -424,11 +427,13 @@ class SchedulerOutputProcessorMixin:
                         x.tolist() for x in logits_output.next_token_top_logprobs_idx
                     ]
 
+                # Batch-sync to avoid N individual GPU→CPU syncs (one per req).
                 if logits_output.next_token_token_ids_logprobs_val:
-                    logits_output.next_token_token_ids_logprobs_val = [
-                        v.tolist()
-                        for v in logits_output.next_token_token_ids_logprobs_val
-                    ]
+                    logits_output.next_token_token_ids_logprobs_val = (
+                        batch_convert_tensors_to_lists(
+                            logits_output.next_token_token_ids_logprobs_val
+                        )
+                    )
         # else: Spec V1 — output_ids, check_finished, grammar, and reasoning tokens
         # are already handled in the verify phase (eagle_info.py / ngram_info.py).
 

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -150,6 +150,35 @@ def validate_input_length(
     return None
 
 
+def batch_convert_tensors_to_lists(tensors: List) -> List:
+    """Convert a list of per-request GPU tensors to (nested) Python lists
+    with a single GPU→CPU sync.
+
+    Concatenates along dim 0, does one ``.tolist()``, then splits back by
+    per-tensor ``shape[0]``. Works for 1D tensors of varying length
+    (``shape[0] == numel()``) and for ND tensors with a matching trailing
+    shape (e.g. per-request 2D outputs with a uniform last dim).
+
+    Falls back to per-tensor ``.tolist()`` when trailing shapes differ
+    (mixed dims, non-uniform last dim). Returns the input unchanged when
+    the first entry is not a tensor (already-converted lists).
+    """
+    if not tensors or not isinstance(tensors[0], torch.Tensor):
+        return tensors
+
+    trailing = tensors[0].shape[1:]
+    if not all(t.shape[1:] == trailing for t in tensors):
+        return [t.tolist() for t in tensors]
+
+    sizes = [t.shape[0] for t in tensors]
+    flat = torch.cat(tensors, dim=0).tolist()
+    out, offset = [], 0
+    for n in sizes:
+        out.append(flat[offset : offset + n])
+        offset += n
+    return out
+
+
 def get_logprob_dict_from_result(result: GenerationBatchResult) -> dict:
 
     logits_output = result.logits_output


### PR DESCRIPTION
## Motivation

The scheduler's prefill/decode output paths convert per-request GPU tensors to Python lists with per-tensor `.tolist()` inside list comprehensions. Each `.tolist()` is a separate D2H copy + stream sync, so at batch size N this costs N independent syncs in the critical path of `process_batch_result_{prefill,decode}`.

Three sites in `scheduler_output_processor_mixin.py`:
- `next_token_token_ids_logprobs_val` on the prefill branch (e.g. scoring with `token_ids_logprob`).
- `next_token_token_ids_logprobs_val` on the decode branch.
- `embeddings` on the non-generation (embedding/reward) branch when the pooler returns a list of per-request 2D tensors.

## Modifications

Add `batch_convert_tensors_to_lists` in `srt/managers/utils.py`: cat along dim 0, one `.tolist()` (single sync), split back by per-tensor `shape[0]`. Keyed on trailing shape (`shape[1:]`):

- All 1D tensors of varying length share `shape[1:] == ()` and `shape[0] == numel()` — handles the logprobs-val case.
- All ND tensors with a matching trailing shape (e.g. 2D pooler outputs `(rows_i, cols)` with uniform `cols`) cat cleanly along dim 0 — handles the embedding case.
- Mismatched trailing shapes (mixed 1D/2D, non-uniform last dim) fall back to per-tensor `.tolist()` for correctness.
- Already-converted lists (first entry not a tensor) pass through unchanged.

Wire the helper into all three sites. The single-tensor (`isinstance(embeddings, torch.Tensor)`) and sparse-embedding (`SGLANG_EMBEDDINGS_SPARSE_HEAD`) paths are untouched — both are already one sync.

Behavior is otherwise identical: same Python list values reach the consumer; only the sync count drops from N to 1 per batch per affected site.

## Accuracy Tests

N/A — the helper preserves bit-exact `.tolist()` output (verified against per-tensor reference for variable-length 1D, uniform 2D, mixed-dim fallback, and non-uniform-last-dim fallback).

## Speed Tests and Profiling

Score-API benchmark on 0.5.10 with `--enable-mis` and `token_ids_logprob` (Yes/No), HTTP scoring at RPS=40, item_count=50, concurrency=16: 2825 requests in 60s, 2342 items/sec, P99 442 ms (from the original internal benchmark of the equivalent generation-side fix). Profiling confirmed the previous N `cudaMemcpyAsync` D2H + `cudaStreamSynchronize` events at the per-tensor `.tolist()` site collapse to a single sync.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
