### PR TITLE
Allow configuring NIXL backend parameters from env

### DIFF
--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import json
 import logging
 import struct
 import threading
@@ -173,11 +174,28 @@ class NixlKVManager(CommonKVManager):
             ) from e
 
         backend = envs.SGLANG_DISAGGREGATION_NIXL_BACKEND.get()
-        agent_config = nixl_agent_config(
-            backends=[backend],
-            num_threads=(8 if disaggregation_mode == DisaggregationMode.PREFILL else 0),
-        )
+        num_threads = 8 if disaggregation_mode == DisaggregationMode.PREFILL else 0
+        backend_params = json.loads(envs.SGLANG_DISAGGREGATION_NIXL_BACKEND_PARAMS.get())
+        if not isinstance(backend_params, dict) or not all(
+            isinstance(key, str) and isinstance(value, str)
+            for key, value in backend_params.items()
+        ):
+            raise ValueError(
+                "SGLANG_DISAGGREGATION_NIXL_BACKEND_PARAMS must be a JSON object "
+                "with string keys and string values"
+            )
+        agent_config = nixl_agent_config(backends=[], num_threads=num_threads)
         self.agent = nixl_agent(str(uuid.uuid4()), agent_config)
+        if num_threads > 0:
+            # TODO: Remove this once NIXL passes thread parameters from
+            # nixl_agent_config to explicitly-created backends.
+            if backend == "UCX" or backend == "OBJ":
+                backend_params.setdefault("num_threads", str(num_threads))
+            elif backend == "GDS_MT":
+                backend_params.setdefault("thread_count", str(num_threads))
+            elif backend == "UCCL":
+                backend_params.setdefault("num_cpus", str(num_threads))
+        self.agent.create_backend(backend, backend_params)
 
         available_plugins = self.agent.get_plugin_list()
         if backend not in available_plugins:

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -175,7 +175,9 @@ class NixlKVManager(CommonKVManager):
 
         backend = envs.SGLANG_DISAGGREGATION_NIXL_BACKEND.get()
         num_threads = 8 if disaggregation_mode == DisaggregationMode.PREFILL else 0
-        backend_params = json.loads(envs.SGLANG_DISAGGREGATION_NIXL_BACKEND_PARAMS.get())
+        backend_params = json.loads(
+            envs.SGLANG_DISAGGREGATION_NIXL_BACKEND_PARAMS.get()
+        )
         if not isinstance(backend_params, dict) or not all(
             isinstance(key, str) and isinstance(value, str)
             for key, value in backend_params.items()

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -242,6 +242,7 @@ class Envs:
     SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE = EnvInt(2)
     SGLANG_DISAGGREGATION_WAITING_TIMEOUT = EnvInt(300)
     SGLANG_DISAGGREGATION_NIXL_BACKEND = EnvStr("UCX")
+    SGLANG_DISAGGREGATION_NIXL_BACKEND_PARAMS = EnvStr("{}")
     SGLANG_DISAGGREGATION_ALL_CP_RANKS_TRANSFER = EnvBool(False)
     # Extra slots in req_to_token_pool for decode workers (only effective when
     # max_num_reqs > 32). Increases pool capacity so more KV cache transfers


### PR DESCRIPTION
## Summary

- Add an environment variable for passing backend-specific NIXL parameters from SGLang deployments.
- Create the selected NIXL backend explicitly so those parameters are applied at backend initialization.
- Preserve the existing prefill thread-count behavior when the new env var does not override it.

## Details

**`python/sglang/srt/environ.py`** — adds `SGLANG_DISAGGREGATION_NIXL_BACKEND_PARAMS`, defaulting to `{}`.

**`python/sglang/srt/disaggregation/nixl/conn.py`** — parses `SGLANG_DISAGGREGATION_NIXL_BACKEND_PARAMS` as a JSON object with string keys and values, then passes it to `nixl_agent.create_backend`.

Example:

```bash
export SGLANG_DISAGGREGATION_NIXL_BACKEND_PARAMS='{"ucx_error_handling_mode":"none"}'
```