### PR TITLE
ci: temporarily disable multimodal-gen-test-1-b200

### DIFF
--- a/.github/workflows/pr-test-multimodal-gen.yml
+++ b/.github/workflows/pr-test-multimodal-gen.yml
@@ -278,8 +278,16 @@ jobs:
     # TODO: Temporarily disabled (`if: false`) — deterministically failing
     # with `RobertaProcessing.__new__() got an unexpected keyword argument
     # 'cls'` (tokenizer/transformers compatibility) and blocking CI.
-    # Restore the original `if:` condition once the underlying fix lands.
+    # Restore the original `if:` condition (commented below) once the
+    # underlying fix lands.
     if: false
+    # if: |
+    #   (inputs.target_stage == 'multimodal-gen-test-1-b200') ||
+    #   (
+    #     !inputs.target_stage &&
+    #     ((github.event_name == 'schedule' || inputs.test_parallel_dispatch == 'true') || (inputs.caller_needs_failure != 'true' && !cancelled())) &&
+    #     inputs.multimodal_gen == 'true'
+    #   )
     runs-on: ${{ inputs.b200_runner }}
     timeout-minutes: 240
     steps:

--- a/.github/workflows/pr-test-multimodal-gen.yml
+++ b/.github/workflows/pr-test-multimodal-gen.yml
@@ -274,61 +274,65 @@ jobs:
         with:
           artifact-suffix: component-accuracy
 
-  multimodal-gen-test-1-b200:
-    if: |
-      (inputs.target_stage == 'multimodal-gen-test-1-b200') ||
-      (
-        !inputs.target_stage &&
-        ((github.event_name == 'schedule' || inputs.test_parallel_dispatch == 'true') || (inputs.caller_needs_failure != 'true' && !cancelled())) &&
-        inputs.multimodal_gen == 'true'
-      )
-    runs-on: ${{ inputs.b200_runner }}
-    timeout-minutes: 240
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
-
-      - uses: ./.github/actions/check-stage-health
-
-      - uses: ./.github/actions/check-maintenance
-
-      - name: Download artifacts
-        if: inputs.sgl_kernel == 'true'
-        uses: actions/download-artifact@v4
-        with:
-          path: sgl-kernel/dist/
-          merge-multiple: true
-          pattern: wheel-python3.10-cuda*
-
-      - name: Install dependencies
-        timeout-minutes: 20
-        run: |
-          CUSTOM_BUILD_SGL_KERNEL=${{inputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh diffusion
-
-      - name: Run diffusion server tests
-        timeout-minutes: 240
-        env:
-          RUNAI_STREAMER_MEMORY_LIMIT: 0
-          CONTINUE_ON_ERROR_FLAG: ${{ inputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
-          SGLANG_DIFFUSION_ARTIFACT_DIR: ${{ github.workspace }}/diffusion-artifacts
-        run: |
-          cd python
-          python3 sglang/multimodal_gen/test/run_suite.py \
-            --suite 1-gpu-b200 \
-            $CONTINUE_ON_ERROR_FLAG
-
-      - name: Upload diffusion artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: diffusion-artifacts-${{ github.job }}-${{ github.run_attempt }}
-          path: diffusion-artifacts/
-          if-no-files-found: ignore
-
-      - uses: ./.github/actions/upload-cuda-coredumps
-        if: failure()
+  # TODO: Temporarily disabled — deterministically failing with a
+  # `RobertaProcessing.__new__() got an unexpected keyword argument 'cls'`
+  # tokenizer/transformers compatibility error and blocking CI. Re-enable
+  # once the underlying fix lands.
+  # multimodal-gen-test-1-b200:
+  #   if: |
+  #     (inputs.target_stage == 'multimodal-gen-test-1-b200') ||
+  #     (
+  #       !inputs.target_stage &&
+  #       ((github.event_name == 'schedule' || inputs.test_parallel_dispatch == 'true') || (inputs.caller_needs_failure != 'true' && !cancelled())) &&
+  #       inputs.multimodal_gen == 'true'
+  #     )
+  #   runs-on: ${{ inputs.b200_runner }}
+  #   timeout-minutes: 240
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
+  #
+  #     - uses: ./.github/actions/check-stage-health
+  #
+  #     - uses: ./.github/actions/check-maintenance
+  #
+  #     - name: Download artifacts
+  #       if: inputs.sgl_kernel == 'true'
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         path: sgl-kernel/dist/
+  #         merge-multiple: true
+  #         pattern: wheel-python3.10-cuda*
+  #
+  #     - name: Install dependencies
+  #       timeout-minutes: 20
+  #       run: |
+  #         CUSTOM_BUILD_SGL_KERNEL=${{inputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh diffusion
+  #
+  #     - name: Run diffusion server tests
+  #       timeout-minutes: 240
+  #       env:
+  #         RUNAI_STREAMER_MEMORY_LIMIT: 0
+  #         CONTINUE_ON_ERROR_FLAG: ${{ inputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+  #         SGLANG_DIFFUSION_ARTIFACT_DIR: ${{ github.workspace }}/diffusion-artifacts
+  #       run: |
+  #         cd python
+  #         python3 sglang/multimodal_gen/test/run_suite.py \
+  #           --suite 1-gpu-b200 \
+  #           $CONTINUE_ON_ERROR_FLAG
+  #
+  #     - name: Upload diffusion artifacts
+  #       if: always()
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: diffusion-artifacts-${{ github.job }}-${{ github.run_attempt }}
+  #         path: diffusion-artifacts/
+  #         if-no-files-found: ignore
+  #
+  #     - uses: ./.github/actions/upload-cuda-coredumps
+  #       if: failure()
 
   multimodal-gen-unit-test:
     if: |

--- a/.github/workflows/pr-test-multimodal-gen.yml
+++ b/.github/workflows/pr-test-multimodal-gen.yml
@@ -274,65 +274,59 @@ jobs:
         with:
           artifact-suffix: component-accuracy
 
-  # TODO: Temporarily disabled — deterministically failing with a
-  # `RobertaProcessing.__new__() got an unexpected keyword argument 'cls'`
-  # tokenizer/transformers compatibility error and blocking CI. Re-enable
-  # once the underlying fix lands.
-  # multimodal-gen-test-1-b200:
-  #   if: |
-  #     (inputs.target_stage == 'multimodal-gen-test-1-b200') ||
-  #     (
-  #       !inputs.target_stage &&
-  #       ((github.event_name == 'schedule' || inputs.test_parallel_dispatch == 'true') || (inputs.caller_needs_failure != 'true' && !cancelled())) &&
-  #       inputs.multimodal_gen == 'true'
-  #     )
-  #   runs-on: ${{ inputs.b200_runner }}
-  #   timeout-minutes: 240
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
-  #
-  #     - uses: ./.github/actions/check-stage-health
-  #
-  #     - uses: ./.github/actions/check-maintenance
-  #
-  #     - name: Download artifacts
-  #       if: inputs.sgl_kernel == 'true'
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         path: sgl-kernel/dist/
-  #         merge-multiple: true
-  #         pattern: wheel-python3.10-cuda*
-  #
-  #     - name: Install dependencies
-  #       timeout-minutes: 20
-  #       run: |
-  #         CUSTOM_BUILD_SGL_KERNEL=${{inputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh diffusion
-  #
-  #     - name: Run diffusion server tests
-  #       timeout-minutes: 240
-  #       env:
-  #         RUNAI_STREAMER_MEMORY_LIMIT: 0
-  #         CONTINUE_ON_ERROR_FLAG: ${{ inputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
-  #         SGLANG_DIFFUSION_ARTIFACT_DIR: ${{ github.workspace }}/diffusion-artifacts
-  #       run: |
-  #         cd python
-  #         python3 sglang/multimodal_gen/test/run_suite.py \
-  #           --suite 1-gpu-b200 \
-  #           $CONTINUE_ON_ERROR_FLAG
-  #
-  #     - name: Upload diffusion artifacts
-  #       if: always()
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: diffusion-artifacts-${{ github.job }}-${{ github.run_attempt }}
-  #         path: diffusion-artifacts/
-  #         if-no-files-found: ignore
-  #
-  #     - uses: ./.github/actions/upload-cuda-coredumps
-  #       if: failure()
+  multimodal-gen-test-1-b200:
+    # TODO: Temporarily disabled (`if: false`) — deterministically failing
+    # with `RobertaProcessing.__new__() got an unexpected keyword argument
+    # 'cls'` (tokenizer/transformers compatibility) and blocking CI.
+    # Restore the original `if:` condition once the underlying fix lands.
+    if: false
+    runs-on: ${{ inputs.b200_runner }}
+    timeout-minutes: 240
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
+
+      - uses: ./.github/actions/check-stage-health
+
+      - uses: ./.github/actions/check-maintenance
+
+      - name: Download artifacts
+        if: inputs.sgl_kernel == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          path: sgl-kernel/dist/
+          merge-multiple: true
+          pattern: wheel-python3.10-cuda*
+
+      - name: Install dependencies
+        timeout-minutes: 20
+        run: |
+          CUSTOM_BUILD_SGL_KERNEL=${{inputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh diffusion
+
+      - name: Run diffusion server tests
+        timeout-minutes: 240
+        env:
+          RUNAI_STREAMER_MEMORY_LIMIT: 0
+          CONTINUE_ON_ERROR_FLAG: ${{ inputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+          SGLANG_DIFFUSION_ARTIFACT_DIR: ${{ github.workspace }}/diffusion-artifacts
+        run: |
+          cd python
+          python3 sglang/multimodal_gen/test/run_suite.py \
+            --suite 1-gpu-b200 \
+            $CONTINUE_ON_ERROR_FLAG
+
+      - name: Upload diffusion artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: diffusion-artifacts-${{ github.job }}-${{ github.run_attempt }}
+          path: diffusion-artifacts/
+          if-no-files-found: ignore
+
+      - uses: ./.github/actions/upload-cuda-coredumps
+        if: failure()
 
   multimodal-gen-unit-test:
     if: |


### PR DESCRIPTION
## Summary
- Temporarily comment out the `multimodal-gen-test-1-b200` job in `.github/workflows/pr-test-multimodal-gen.yml`. It is deterministically failing during server startup with `RobertaProcessing.__new__() got an unexpected keyword argument 'cls'` (tokenizer/transformers compatibility) and blocking CI on every run.
- Failing job: https://github.com/sgl-project/sglang/actions/runs/25180119879/job/73842109475
- A fix is expected soon; re-enable by uncommenting the job once it lands.

## Test plan
- [ ] Verify the `multimodal-gen-test-1-b200` job no longer appears in the CI run for this PR
- [ ] Confirm the rest of the multimodal-gen jobs (1-gpu, 2-gpu, component-accuracy, unit-test) still dispatch as expected