### PR TITLE
[codex] fix NGRAM shared-prefix cache corruption

### DIFF
--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -44,6 +44,18 @@ class SchedulerOutputProcessorMixin:
     We put them into a separate file to make the `scheduler.py` shorter.
     """
 
+    def _cache_unfinished_req_after_prefill(
+        self: Scheduler, batch: ScheduleBatch, req: Req
+    ) -> None:
+        # NGRAM target verify can keep using these KV slots across the next
+        # decode/cancel step. Do not publish them for shared-prefix reuse yet.
+        if (
+            batch.spec_algorithm is not None
+            and batch.spec_algorithm.is_ngram()
+        ):
+            return
+        self.tree_cache.cache_unfinished_req(req)
+
     def _get_storage_backend_type(self) -> str:
         """Get storage backend type from tree_cache."""
         storage_backend_type = "none"
@@ -199,7 +211,7 @@ class SchedulerOutputProcessorMixin:
                         release_kv_cache(req, self.tree_cache)
                         req.time_stats.set_completion_time()
                     elif not batch.decoding_reqs or req not in batch.decoding_reqs:
-                        self.tree_cache.cache_unfinished_req(req)
+                        self._cache_unfinished_req_after_prefill(batch, req)
                         if self.enable_hisparse:
                             self.hisparse_coordinator.admit_request_into_staging(req)
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3539,6 +3539,12 @@ class ServerArgs:
 
             self.disable_overlap_schedule = True
             self.enable_mixed_chunk = False
+            if not self.disable_radix_cache:
+                self.disable_radix_cache = True
+                logger.warning(
+                    "Radix cache is disabled because NGRAM speculative decoding "
+                    "can reuse KV from canceled or in-flight requests."
+                )
             self.speculative_eagle_topk = self.speculative_ngram_max_bfs_breadth
             if self.speculative_num_draft_tokens is None:
                 self.speculative_num_draft_tokens = 12

--- a/test/registered/unit/managers/test_scheduler_output_processor_mixin.py
+++ b/test/registered/unit/managers/test_scheduler_output_processor_mixin.py
@@ -1,0 +1,49 @@
+import types
+
+from sglang.srt.managers.scheduler_output_processor_mixin import (
+    SchedulerOutputProcessorMixin,
+)
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+
+
+class _FakeTreeCache:
+    def __init__(self):
+        self.unfinished_reqs = []
+
+    def cache_unfinished_req(self, req):
+        self.unfinished_reqs.append(req)
+
+
+class _FakeScheduler(SchedulerOutputProcessorMixin):
+    def __init__(self):
+        self.tree_cache = _FakeTreeCache()
+
+
+def test_ngram_prefill_does_not_publish_unfinished_req_to_radix_cache():
+    scheduler = _FakeScheduler()
+    batch = types.SimpleNamespace(spec_algorithm=SpeculativeAlgorithm.NGRAM)
+    req = object()
+
+    scheduler._cache_unfinished_req_after_prefill(batch, req)
+
+    assert scheduler.tree_cache.unfinished_reqs == []
+
+
+def test_non_ngram_prefill_publishes_unfinished_req_to_radix_cache():
+    scheduler = _FakeScheduler()
+    batch = types.SimpleNamespace(spec_algorithm=SpeculativeAlgorithm.NONE)
+    req = object()
+
+    scheduler._cache_unfinished_req_after_prefill(batch, req)
+
+    assert scheduler.tree_cache.unfinished_reqs == [req]
+
+
+def test_missing_spec_algorithm_keeps_previous_cache_behavior():
+    scheduler = _FakeScheduler()
+    batch = types.SimpleNamespace(spec_algorithm=None)
+    req = object()
+
+    scheduler._cache_unfinished_req_after_prefill(batch, req)
+
+    assert scheduler.tree_cache.unfinished_reqs == [req]


### PR DESCRIPTION
## Summary

Fixes #23392 by keeping unfinished prefill KV from being published to the shared radix cache during NGRAM speculative decoding.

NGRAM target verification can still be using those KV slots across the following decode/cancel step. If another request reuses that shared prefix before the owning request is settled, unrelated temperature=0 requests can observe divergent output. This change keeps the existing `cache_unfinished_req` behavior for non-NGRAM paths, while skipping that publish for NGRAM speculative prefill.

## Changes

- Add a scheduler helper for caching unfinished prefill requests.
- Skip unfinished radix-cache publish only when `batch.spec_algorithm.is_ngram()`.
- Preserve existing behavior for non-NGRAM and `spec_algorithm is None`.
- Add focused unit coverage for the NGRAM skip and unchanged non-NGRAM behavior.

## Before/After Proof

Reproduced on a GCP `g2-standard-4` L4 VM using `lmsysorg/sglang:v0.5.10.post1-cu130-runtime`, `Qwen/Qwen2.5-0.5B-Instruct`, and the issue gist's server flags:

```text
--model-path Qwen/Qwen2.5-0.5B-Instruct
--mem-fraction-static 0.88
--context-length 32768
--speculative-algorithm NGRAM
--speculative-num-draft-tokens 5
```

Baseline, unpatched release image:

```text
[DIVERGED] 2 request(s)
  6327450a (unexpected)
    variant 1: ' u1252_888 u'
    variant 2: ' u1252_882 u'
  scn_1_retry (expected)
    variant 1: ' u7257_148 u72'
    variant 2: ' u7257_1446 u7'
RESULT: PARTIAL (found=['6327450a', 'scn_1_retry'], expected=['77681d56', 'scn_0_retry', 'scn_1_retry'])
```

Control with radix cache disabled:

```text
[CLEAN] no output divergence detected
[STABLE] 6 request(s): 5c3e7afe, 622af575, 6327450a, 77681d56, scn_0_retry, scn_1_retry
RESULT: NOT_REPRODUCED
```

Patched scheduler, same image and flags, 50 repro runs:

```text
[CLEAN] no output divergence detected
[STABLE] 6 request(s): 5c3e7afe, 622af575, 6327450a, 77681d56, scn_0_retry, scn_1_retry
RESULT: NOT_REPRODUCED
```

## Validation

```text
git diff --check
ruff check python/sglang/srt/managers/scheduler_output_processor_mixin.py test/registered/unit/managers/test_scheduler_output_processor_mixin.py
python3 -m py_compile python/sglang/srt/managers/scheduler_output_processor_mixin.py test/registered/unit/managers/test_scheduler_output_processor_mixin.py
```

Local pytest collection was not run on the host because the host Python environment is missing repo runtime dependencies. The behavioral repro was run in the CUDA SGLang container on GCP.

## A100 validation and follow-up fix (2026-05-01)

Additional validation on GCP Spot `a2-highgpu-1g` in `[redacted-region]` with 1x NVIDIA A100-SXM4-40GB, driver `580.126.20`, using `lmsysorg/sglang:v0.5.10.post1-cu130-runtime`, `Qwen/Qwen2.5-0.5B-Instruct`, and the issue gist plus companion finding JSON.

The original PR head `d7f32532b455e442274e29c873e8f5892d843f72` did **not** hold on A100. With the original server flags over 50 repro runs, the issue still reproduced:

```text
[DIVERGED] 4 request(s)
RESULT: CONFIRMED (3/3 expected requests diverged)
```

A narrower follow-up that avoided inserting NGRAM-aborted/finished requests into the radix cache improved one retry but still did not fix the issue:

```text
[DIVERGED] 3 request(s)
[STABLE] 3 request(s): 5c3e7afe, 622af575, scn_0_retry
RESULT: PARTIAL (found=[6327450a, 77681d56, scn_1_retry], expected=[77681d56, scn_0_retry, scn_1_retry])
```

The A100 control with `--disable-radix-cache` was clean:

```text
[CLEAN] no output divergence detected
[STABLE] 6 request(s): 5c3e7afe, 622af575, 6327450a, 77681d56, scn_0_retry, scn_1_retry
RESULT: NOT_REPRODUCED
```

The branch now includes commit `9f03dd50f83fc94a3a13a4cd2579b6bba525546c`, which automatically disables radix cache when `--speculative-algorithm NGRAM` is selected. Re-running the original server flags, without manually passing `--disable-radix-cache`, logged `disable_radix_cache=True` and was clean over 50 repro runs:

```text
Radix cache is disabled because NGRAM speculative decoding can reuse KV from canceled or in-flight requests.
[CLEAN] no output divergence detected
[STABLE] 6 request(s): 5c3e7afe, 622af575, 6327450a, 77681d56, scn_0_retry, scn_1_retry
RESULT: NOT_REPRODUCED
```

Final validation:

```text
git diff --check
ruff check python/sglang/srt/server_args.py python/sglang/srt/managers/scheduler_output_processor_mixin.py test/registered/unit/managers/test_scheduler_output_processor_mixin.py
PYTHONPYCACHEPREFIX=/tmp/sglang-pycache python3 -m py_compile python/sglang/srt/server_args.py python/sglang/srt/managers/scheduler_output_processor_mixin.py test/registered/unit/managers/test_scheduler_output_processor_mixin.py
python3 -m pytest -q test/registered/unit/managers/test_scheduler_output_processor_mixin.py
```

Results: ruff/check/py_compile passed; focused container pytest passed (`3 passed`).
