### PR TITLE
[CI] Publish nightly sglang wheel under both cu129 and cu130 indexes

### DIFF
--- a/.github/workflows/release-pypi-nightly.yml
+++ b/.github/workflows/release-pypi-nightly.yml
@@ -14,11 +14,6 @@ on:
         description: 'Specific commit SHA to build (leave empty for latest)'
         required: false
         type: string
-      cuda_version:
-        description: 'CUDA version (e.g., 129 or 130)'
-        required: false
-        default: '129'
-        type: string
 
 concurrency:
   group: release-pypi-nightly-${{ github.ref }}
@@ -112,6 +107,15 @@ jobs:
     needs: build-nightly-wheel
     runs-on: ubuntu-latest
     environment: 'prod'
+    strategy:
+      fail-fast: false
+      # The wheel is CUDA-agnostic and built once — we just register the same
+      # artifact under cu129/sglang/ and cu130/sglang/ wheel indexes so users
+      # can install via either --extra-index-url. Serialize because both matrix
+      # runs clone and push to the same sgl-whl branch.
+      max-parallel: 1
+      matrix:
+        cuda_version: ['129', '130']
     steps:
       - uses: actions/checkout@v4
 
@@ -160,12 +164,12 @@ jobs:
           python3 scripts/update_nightly_whl_index.py \
             --commit-hash ${{ needs.build-nightly-wheel.outputs.commit_hash }} \
             --nightly-version ${{ needs.build-nightly-wheel.outputs.nightly_version }} \
-            --cuda-version ${{ inputs.cuda_version || '129' }} \
+            --cuda-version ${{ matrix.cuda_version }} \
             --build-date ${{ needs.build-nightly-wheel.outputs.build_date }}
 
       - name: Push wheel index
         run: |
           cd sgl-whl
           git add -A
-          git diff --staged --quiet || git commit -m "Update nightly wheel index for commit ${{ needs.build-nightly-wheel.outputs.commit_hash }}"
+          git diff --staged --quiet || git commit -m "Update cu${{ matrix.cuda_version }} nightly wheel index for commit ${{ needs.build-nightly-wheel.outputs.commit_hash }}"
           git push

--- a/scripts/update_nightly_whl_index.py
+++ b/scripts/update_nightly_whl_index.py
@@ -42,8 +42,10 @@ def update_wheel_index(
     whl_repo_dir = pathlib.Path("sgl-whl")
 
     if not dist_dir.exists():
-        print(f"Warning: {dist_dir} does not exist, skipping index update")
-        return
+        raise FileNotFoundError(
+            f"{dist_dir} does not exist — the download-artifact step did not "
+            f"populate it; refusing to silently no-op the index update"
+        )
 
     # Format CUDA version with 'cu' prefix if not already present
     if not cuda_version.startswith("cu"):
@@ -87,23 +89,21 @@ def update_wheel_index(
     # Generate new links for current wheels
     new_links = []
     for wheel_path in sorted(dist_dir.glob("*.whl")):
-        try:
-            filename = wheel_path.name
-            sha256 = compute_sha256(wheel_path)
+        filename = wheel_path.name
+        sha256 = compute_sha256(wheel_path)
 
-            # URL format: {base_url}/{release_tag}/{filename}#sha256={hash}
-            wheel_url = f"{base_url}/{release_tag}/{filename}#sha256={sha256}"
-            link = f'<a href="{wheel_url}">{filename}</a><br>'
+        # URL format: {base_url}/{release_tag}/{filename}#sha256={hash}
+        wheel_url = f"{base_url}/{release_tag}/{filename}#sha256={sha256}"
+        link = f'<a href="{wheel_url}">{filename}</a><br>'
 
-            new_links.append(link)
-            print(f"  Added: {filename}")
-        except Exception as e:
-            print(f"  Error processing {wheel_path.name}: {e}")
-            continue
+        new_links.append(link)
+        print(f"  Added: {filename}")
 
     if not new_links:
-        print("  No new wheels to add")
-        return
+        raise RuntimeError(
+            f"No wheels found in {dist_dir} — index update for {cuda_version} "
+            f"would be a no-op; failing loudly instead of pushing an empty change"
+        )
 
     # Combine existing and new links (new links first for latest)
     all_links = new_links + existing_links


### PR DESCRIPTION
## Summary

- Matrix `release-nightly` over `cuda_version: ['129', '130']` so the daily nightly wheel is registered under both `cu129/sglang/` and `cu130/sglang/` on `sgl-project/whl`. The wheel itself is CUDA-agnostic and built once; only the index registration differs. `max-parallel: 1` serializes the two legs since they both clone and push to the same `sgl-whl` branch.
- Removed the now-unused `cuda_version` workflow_dispatch input — both variants are always published.
- Tightened silent-return paths in `scripts/update_nightly_whl_index.py` so a broken artifact download fails loudly instead of producing a green workflow run with no index update:
  - missing `dist/` → `FileNotFoundError`
  - empty `dist/` → `RuntimeError`
  - per-wheel hash error: propagate instead of silently skipping

## Effect on `sgl-project/whl` (default branch `gh-pages`)

| path | before | after |
|---|---|---|
| `cu129/sglang/index.html` | live nightly index | new wheel link prepended |
| `cu130/sglang/` | does not exist | created; index written |
| `cu130/index.html` | `sgl-kernel`, `sglang-kernel` | `sgl-kernel`, `sglang`, `sglang-kernel` (sorted, merged) |

After this lands, users can install nightlies via either:
```
pip install sglang --pre --extra-index-url https://sgl-project.github.io/whl/cu129/
pip install sglang --pre --extra-index-url https://sgl-project.github.io/whl/cu130/
```

## Test plan

- [x] `python3 -c "import ast; ast.parse(...)"` on the modified script
- [x] Smoke-tested `update_nightly_whl_index.py` against synthetic `dist/`:
  - happy path (cu130, fresh folder) → exit 0, correct `cu130/index.html` and `cu130/sglang/index.html`
  - missing `dist/` → exit 1, `FileNotFoundError`
  - empty `dist/` → exit 1, `RuntimeError`
- [ ] First scheduled run (or manual `workflow_dispatch`) confirms both `cu129/sglang/` and `cu130/sglang/` are updated and the GH Release contains the wheel exactly once

🤖 Generated with [Claude Code](https://claude.com/claude-code)