### PR TITLE
[Fix] Clear mrope position tensors in MultimodalInputs.release_features()

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -453,6 +453,10 @@ class MultimodalInputs:
         """Release feature tensors to free GPU memory."""
         for item in self.mm_items:
             item.feature = None
+        # Clear Qwen-VL mrope tensors (GPU-resident, survive per-item cleanup)
+        self.mrope_positions = None
+        self.mrope_position_delta = None
+        self.mrope_position_delta_repeated_cache = None
 
     @staticmethod
     def from_processor_output(obj: "MultimodalProcessorOutput"):


### PR DESCRIPTION
Fixes a GPU VRAM memory leak when processing image inputs with Qwen-VL derived models (Qwen2-VL, Qwen3-VL, Qwen3.5-VL, Qwen3.6).

## Problem

Every image request creates `mrope_positions`, `mrope_position_delta`, and `mrope_position_delta_repeated_cache` tensors on GPU via `MRotaryEmbedding.get_rope_index()`. These are not cleared by `MultimodalInputs.release_features()`, which only clears `item.feature`. The tensors accumulate across requests until OOM and server crash.

## Root Cause

`release_features()` (added in #17324) clears `item.feature` (pixel values) but misses the mrope-level tensors on the `MultimodalInputs` struct itself. These eventually get cleaned up by GC after `req.multimodal_inputs = None`, but under load the delay is enough to cause OOM.

## Fix

Clear the three mrope tensors in `release_features()`:

```python
self.mrope_positions = None
self.mrope_position_delta = None
self.mrope_position_delta_repeated_cache = None
```

## Testing

- **Before:** Baseline ~94GB VRAM → +3GB per image request, never released → OOM crash
- **After:** Peaks at ~97GB during image processing, holds steady across subsequent requests. The ~3GB delta is normal PyTorch CUDA cache retention, not a leak.
- Verified under sustained real traffic on 2x GPU, TP=2.

## Notes

- `--disable-fast-image-processor` (recommended in #6239) is a no-op for Qwen2VL — the `device="cuda"` kwarg is silently dropped by `Qwen2VLProcessorKwargs._merge_kwargs`. Image preprocessing always runs on CPU regardless of this flag.
- Affects all Qwen-VL derived models that use mrope.

**Related:** #17324, #6239