### PR TITLE
[Fix] Qwen3-ASR config: set thinker_config before super().__init__

### DIFF
--- a/python/sglang/srt/configs/qwen3_asr.py
+++ b/python/sglang/srt/configs/qwen3_asr.py
@@ -148,7 +148,6 @@ class Qwen3ASRConfig(PretrainedConfig):
     }
 
     def __init__(self, thinker_config=None, **kwargs):
-        super().__init__(**kwargs)
         if thinker_config is None:
             thinker_config = {}
             logger.info(
@@ -159,6 +158,7 @@ class Qwen3ASRConfig(PretrainedConfig):
             self.thinker_config = Qwen3ASRThinkerConfig(**thinker_config)
         else:
             self.thinker_config = thinker_config
+        super().__init__(**kwargs)
 
     def get_text_config(self, decoder=False) -> PretrainedConfig:
         return self.thinker_config.text_config


### PR DESCRIPTION
## Motivation

Launching any Qwen3-ASR model crashes during config init under `huggingface_hub >= 1.12`:

```
File "python/sglang/srt/configs/qwen3_asr.py", line 151, in __init__
    super().__init__(**kwargs)
File "huggingface_hub/dataclasses.py", line 276, in init_with_validate
    cls.validate(self)
File "transformers/configuration_utils.py", line 446, in validate_token_ids
    text_config = self.get_text_config(decoder=True)
File "python/sglang/srt/configs/qwen3_asr.py", line 164, in get_text_config
    return self.thinker_config.text_config
AttributeError: 'Qwen3ASRConfig' object has no attribute 'thinker_config'
```

`PretrainedConfig.__init__` is wrapped by `huggingface_hub.dataclasses.init_with_validate`, which runs `validate_token_ids` → `get_text_config(decoder=True)` during base init. Our `get_text_config` reads `self.thinker_config.text_config`, but `self.thinker_config` is only set **after** `super().__init__` returns. Result: every Qwen3-ASR launch hard-fails before model load.

This was introduced in #22073 (Qwen3-ASR support) and started crashing once `huggingface_hub` 1.12+ began running validation inside the base `__init__`. The current sglang `pyproject.toml` already requires `huggingface_hub >= 1.0`, so users hit this on any reasonably recent install.

Registered unittest for this model is covered here: https://github.com/sgl-project/sglang/pull/22731 

## Modifications

`python/sglang/srt/configs/qwen3_asr.py` — set `self.thinker_config` **before** calling `super().__init__(**kwargs)`, so the base validator finds the attribute it needs. One-line move; no behavior change for callers that already construct successfully on older `huggingface_hub`.

## Accuracy Tests

## Speed Tests and Profiling

## Test plan

Verified locally on H200 with `transformers 5.5.4` + `huggingface_hub 1.12.2`:

- Without this fix: `python -m sglang.launch_server --model-path Qwen/Qwen3-ASR-0.6B` and the existing `test/manual/models/test_qwen3_asr.py` suite both crash at server startup with the `AttributeError` above (every test ERRORs in `setUpClass`).
- With this fix: server launches cleanly; all 19 tests in `test/manual/models/test_qwen3_asr.py` run end-to-end (HTTP + WebSocket paths), passing or failing on their own merits.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
