### PR TITLE
[CI] release-whl-kernel: skip musa wheels in update_kernel_whl_index

### DIFF
--- a/scripts/update_kernel_whl_index.py
+++ b/scripts/update_kernel_whl_index.py
@@ -11,8 +11,10 @@ DEFAULT_CUDA_VERSION = "130"
 
 
 def check_wheel_cuda_version(path_name, target_cuda_version):
-    # Pass ROCm wheel
-    if re.search(f"rocm", path_name):
+    # Skip non-CUDA backend wheels (rocm, musa, ...). Their +<backend><ver>
+    # local-version tags don't match the CUDA wheel regex below, and they are
+    # published by the dedicated release-rocm*/release-musa* jobs.
+    if re.search(r"\+(rocm|musa)", path_name):
         return False
 
     # For other CUDA versions, the wheel path name will contain the cuda version suffix, e.g. sglang_kernel-0.4.0+cu130-cp310-abi3-manylinux2014_x86_64.whl


### PR DESCRIPTION
## Summary
- Fixes `release-cu130` failing in the **Update wheel index** step with `IndexError: list index out of range` (e.g. [run 25191517717](https://github.com/sgl-project/sglang/actions/runs/25191517717/job/73873803051)).
- Root cause: #24162 flipped `DEFAULT_CUDA_VERSION` from `129` → `130`. With cu130 now the default, `check_wheel_cuda_version()` takes the loose default-cuda branch, which only excludes other-CUDA wheels and rocm. The `sglang_kernel-X.Y.Z+musa43-...` wheel slips through, and the CUDA-only regex `sglang_kernel-([0-9.]+...)(?:\+cu[0-9]+)?-` fails to match it, so `re.findall(...)[0]` raises.
- Fix: skip non-CUDA backend wheels (`+rocm`, `+musa`) up-front. Those are indexed by their dedicated `release-rocm*` / `release-musa*` jobs already.

## Test plan
- [x] Verified locally: with the fix, `--cuda 129` keeps only `+cu129` wheels and `--cuda 130` keeps only `+cu130` wheels; `+musa43` and `+rocm*` are skipped in both modes.
- [ ] Re-run `Release SGLang Kernels` after merge / on next version bump; confirm the `release-cu130` "Update wheel index" step passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)