### PR TITLE
fix: pass KV scales to paged attention in ragged+paged split path

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -875,6 +875,8 @@ class FlashInferAttnBackend(AttentionBackend):
                     causal=False,
                     sm_scale=layer.scaling,
                     logits_soft_cap=logits_soft_cap,
+                    k_scale=layer.k_scale_float,
+                    v_scale=layer.v_scale_float,
                 )
 
                 o, _ = merge_state(o1, s1, o2, s2)


### PR DESCRIPTION
## Motivation

Fixes silent FP8 KV cache corruption when radix cache produces a prefix hit. The ragged+paged split in `forward_extend()` was missing `k_scale` and `v_scale` parameters on the paged attention call, causing cached KV to be read back without undoing the quantization division.

**Impact:** Models using FP8 KV cache (`--kv-cache-dtype fp8_e4m3`) produce garbage output on any request that reuses cached prefix tokens. First request correct, subsequent requests with shared prefix → corrupted answers. No crash, no error — silently wrong.

**Root cause:** The fix for KV scales (commit `2695ab053`, April 2025) correctly added scales to the non-ragged paged path and decode path, but the ragged+paged split (added earlier in `99ec439da`) was overlooked.

## Modifications

Added `k_scale=layer.k_scale_float` and `v_scale=layer.v_scale_float` to `prefill_wrapper_paged.forward_return_lse()` in the ragged+paged split path. Matches the pattern already used in the non-ragged paged path and decode path.

## Accuracy Tests

- **Before patch:** FP8 KV cache with radix cache hits → garbled/repetitive output (documented in #19603)
- **After patch:** Coherent output on 182K+ cached tokens, tested on Qwen3.6-27B-FP8 (DeltaNet) + SM120

## Reproduction

```bash
# Start server with FP8 KV cache
sglang serve --model-path Qwen/Qwen3.6-27B-FP8   --kv-cache-dtype fp8_e4m3   --attention-backend flashinfer

# Send two requests with shared prefix
# Without patch: second request produces garbage
# With patch: both requests correct
```

## Related

- #19603 — Qwen3.5-122B FP8 on SM120: FP8 KV silent corruption finding
- #22277 — Gemma4 E4B: fp8 KV cache crashes with shared layers
- #18904 — Earlier attempt (closed, 3600 lines, fix buried in unrelated changes)
- Commit `2695ab053` — Partial fix (missed ragged+paged split)