### PR TITLE
[Tool Call] Fix DeepSeek V3.2 tool calling 

### DIFF
--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -188,35 +188,54 @@ class DeepSeekV32Detector(BaseFormatDetector):
         """
         One-time parsing: Detects and parses tool calls in the provided text.
 
+        Accepts both shapes the model may emit:
+
+        1. Wrapped (model's natural format, used by `tool_choice="auto"`):
+           ``<｜DSML｜function_calls>...invokes...</｜DSML｜function_calls>``
+        2. Bare invokes (no outer wrapper): emitted when the structural_tag
+           grammar is enforced with ``at_least_one=True`` (i.e.,
+           ``tool_choice="required"``/named/strict). The grammar built from
+           ``structure_info()`` only constrains the inner ``<｜DSML｜invoke>``
+           pattern, so the surrounding ``<｜DSML｜function_calls>`` wrapper
+           is omitted and the model jumps straight to the trigger.
+
+        Mirrors the (already permissive) behavior of
+        ``parse_streaming_increment``; without this, tool calls produced under
+        ``tool_choice="required"`` silently disappear in the non-streaming path.
+
         :param text: The complete text to parse.
         :param tools: List of available tools.
-        :return: ParseResult indicating success or failure, consumed text, leftover text, and parsed calls.
+        :return: ParseResult with leading prose in ``normal_text`` and any
+            extracted tool calls in ``calls``.
         """
-        idx = text.find(self.bot_token)
-        normal_text = text[:idx].strip() if idx != -1 else text
-        if self.bot_token not in text:
-            return StreamingParseResult(normal_text=normal_text, calls=[])
+        invoke_token = "<｜DSML｜invoke"
+        bot_idx = text.find(self.bot_token)
+        invoke_idx = text.find(invoke_token)
 
-        calls = []
+        # Tool-call section starts at whichever marker appears first.
+        if bot_idx != -1 and (invoke_idx == -1 or bot_idx <= invoke_idx):
+            section_start = bot_idx
+        elif invoke_idx != -1:
+            section_start = invoke_idx
+        else:
+            return StreamingParseResult(normal_text=text, calls=[])
+
+        normal_text = text[:section_start].strip()
+
         try:
-            # Extract content between function_calls tags
-            function_calls_match = re.search(
-                self.function_calls_regex,
-                text,
-                re.DOTALL,
+            # Prefer the explicit wrapper for scoping when the closing tag is
+            # also present; otherwise scan from the first invoke to end of text.
+            # `invoke_regex` already handles both complete and (terminal-only)
+            # incomplete invokes via its `(... | $)` end alternative.
+            wrapper_match = re.search(self.function_calls_regex, text, re.DOTALL)
+            scope = (
+                wrapper_match.group(1) if wrapper_match else text[section_start:]
             )
-            if not function_calls_match:
-                return StreamingParseResult(normal_text=normal_text, calls=[])
 
-            function_calls_content = function_calls_match.group(1)
-
-            # Find all invoke blocks
-            for invoke_match in re.finditer(
-                self.invoke_regex, function_calls_content, re.DOTALL
-            ):
+            calls = []
+            for invoke_match in re.finditer(self.invoke_regex, scope, re.DOTALL):
                 func_name, invoke_content, _ = self._unpack_invoke_match(invoke_match)
                 func_args = self._parse_parameters_from_xml(invoke_content)
-                # construct match_result for parse_base_json
                 match_result = {"name": func_name, "parameters": json.loads(func_args)}
                 calls.extend(self.parse_base_json(match_result, tools))
 

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -1518,6 +1518,90 @@ class TestDeepSeekV32Detector(unittest.TestCase):
         params = json.loads(call.parameters)
         self.assertEqual(params, {})
 
+    def test_detect_and_parse_bare_invoke_json(self):
+        """Bare `<｜DSML｜invoke>` block without the outer `<｜DSML｜function_calls>`
+        wrapper must still parse correctly.
+
+        This is the shape the model emits when the structural_tag grammar built
+        from `structure_info()` is enforced with `at_least_one=True` (i.e., for
+        `tool_choice="required"`/named/strict): the grammar only constrains the
+        inner `<｜DSML｜invoke ...>...</｜DSML｜invoke>` pattern, so the surrounding
+        `<｜DSML｜function_calls>` wrapper is omitted. The streaming path already
+        accepts this shape; the non-streaming path must too, otherwise tool calls
+        silently disappear (returns empty `calls`).
+        """
+        text = (
+            '<｜DSML｜invoke name="get_favorite_tourist_spot">\n'
+            '{"city": "San Francisco"}\n'
+            "</｜DSML｜invoke>"
+        )
+
+        result = self.detector.detect_and_parse(text, self.tools)
+
+        self.assertEqual(len(result.calls), 1)
+        call = result.calls[0]
+        self.assertEqual(call.name, "get_favorite_tourist_spot")
+        self.assertEqual(json.loads(call.parameters), {"city": "San Francisco"})
+
+    def test_detect_and_parse_bare_invoke_xml(self):
+        """Bare `<｜DSML｜invoke>` (no outer wrapper) with XML parameter tags."""
+        text = (
+            '<｜DSML｜invoke name="get_favorite_tourist_spot">'
+            '<｜DSML｜parameter name="city" string="true">San Francisco</｜DSML｜parameter>'
+            "</｜DSML｜invoke>"
+        )
+
+        result = self.detector.detect_and_parse(text, self.tools)
+
+        self.assertEqual(len(result.calls), 1)
+        call = result.calls[0]
+        self.assertEqual(call.name, "get_favorite_tourist_spot")
+        self.assertEqual(json.loads(call.parameters), {"city": "San Francisco"})
+
+    def test_detect_and_parse_bare_invoke_multiple(self):
+        """Multiple consecutive bare `<｜DSML｜invoke>` blocks without the outer
+        wrapper must all be extracted (mirrors `parse_streaming_increment`)."""
+        text = (
+            '<｜DSML｜invoke name="get_favorite_tourist_spot">'
+            '{"city": "San Francisco"}'
+            "</｜DSML｜invoke>"
+            '<｜DSML｜invoke name="search">'
+            '{"query": "WebNav benchmark", "topn": 10, "source": "web"}'
+            "</｜DSML｜invoke>"
+        )
+
+        result = self.detector.detect_and_parse(text, self.tools)
+
+        self.assertEqual(len(result.calls), 2)
+        self.assertEqual(result.calls[0].name, "get_favorite_tourist_spot")
+        self.assertEqual(
+            json.loads(result.calls[0].parameters), {"city": "San Francisco"}
+        )
+        self.assertEqual(result.calls[1].name, "search")
+        self.assertEqual(
+            json.loads(result.calls[1].parameters),
+            {"query": "WebNav benchmark", "topn": 10, "source": "web"},
+        )
+
+    def test_detect_and_parse_bare_invoke_with_preceding_text(self):
+        """Bare invoke preceded by free text - the prose must end up in
+        `normal_text` and the invoke must be extracted as a tool call."""
+        text = (
+            "Let me look that up for you.\n"
+            '<｜DSML｜invoke name="get_favorite_tourist_spot">'
+            '{"city": "San Francisco"}'
+            "</｜DSML｜invoke>"
+        )
+
+        result = self.detector.detect_and_parse(text, self.tools)
+
+        self.assertEqual(len(result.calls), 1)
+        self.assertIn("Let me look that up for you.", result.normal_text)
+        self.assertNotIn("DSML", result.normal_text)
+        call = result.calls[0]
+        self.assertEqual(call.name, "get_favorite_tourist_spot")
+        self.assertEqual(json.loads(call.parameters), {"city": "San Francisco"})
+
     def test_streaming_no_parameters(self):
         """Test streaming parsing of function calls with no parameters.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

DeepSeek-V3.2 tool-call tests have been failing in nightly CI (6/9 subtests across all 4 configs: DP8 / DP8+MTP / TP8 / TP8+MTP) for at least a week. Root cause: `DeepSeekV32Detector.detect_and_parse` requires the outer `<｜DSML｜function_calls>...</｜DSML｜function_calls>` wrapper, but when `tool_choice="required"`/named/strict is enforced via structural_tag (`at_least_one=True`), the grammar built from `structure_info()` only constrains the inner `<｜DSML｜invoke>` pattern — so the model emits bare invokes without the wrapper and the parser silently returns 0 calls. 

Observed Nightly CI failure https://github.com/sgl-project/sglang/actions/runs/25192084660/job/73864201775
Same root cause as user report #21176 (PD/streaming users seeing empty `tool_calls` or raw DSML in `content`).

The streaming counterpart (`parse_streaming_increment`) was already permissive — only the non-streaming path was the outlier, which is why `streaming` and `parallel` (auto+strict) pass while `basic_format` / `required` / `specific` / `strict` / `multiturn` / `thinking` all fail.

## Modifications

- `python/sglang/srt/function_call/deepseekv32_detector.py`: make `detect_and_parse` accept both shapes — wrapped (model's natural format under `tool_choice="auto"`) and bare invoke blocks (emitted under `at_least_one=True`). Mirrors the existing `parse_streaming_increment` behavior. As a side benefit, also handles incomplete output (wrapper opened-but-not-closed, truncated invokes).
- `test/registered/unit/function_call/test_function_call_parser.py`: add 4 unit tests under `TestDeepSeekV32Detector` covering bare invoke (JSON args, XML args, multiple, with preceding prose). All 4 reproduce the CI failure on main and pass with the fix.

## Accuracy Tests

N/A — parser-only change, no model-output behavior changes.

Verification:
- 4 new tests **fail** on main (`AssertionError: 0 != 1`), **pass** with fix
- All 11 `TestDeepSeekV32Detector` tests pass (4 new + 7 existing)
- Full `test_function_call_parser.py` suite: 194/194 pass — no regressions
- End-to-end simulation of all 6 failing CI subtests through `FunctionCallParser.parse_non_stream`: now extracts the expected tool calls

## Speed Tests and Profiling

N/A — no hot-path changes; only adds a single `re.search` on the ~few-KB tool-call response when the wrapper is absent.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
