### PR TITLE
[codex] Remove parametrized-only from diffusion PR test

### DIFF
--- a/.github/workflows/pr-test-multimodal-gen.yml
+++ b/.github/workflows/pr-test-multimodal-gen.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Compute partitions
         id: compute
         run: |
-          python scripts/ci/utils/diffusion/compute_diffusion_partitions.py --min-time 1200 --target-time 1800 --max-time 2400 --max-partitions 10 --parametrized-only
+          python scripts/ci/utils/diffusion/compute_diffusion_partitions.py --min-time 1200 --target-time 1800 --max-time 2400 --max-partitions 10
 
   multimodal-gen-test-1-gpu:
     needs: compute-diffusion-partitions


### PR DESCRIPTION
## Summary
- Remove `--parametrized-only` from the diffusion partition computation in `pr-test-multimodal-gen.yml`.
- This lets the PR test partitions include standalone diffusion tests needed by the coverage check.

## Root Cause
The PR test workflow computed diffusion partitions with `--parametrized-only`, which ignored standalone test files while the coverage check expects their execution reports.

## Validation
- `python scripts/ci/utils/diffusion/compute_diffusion_partitions.py --min-time 1200 --target-time 1800 --max-time 2400 --max-partitions 10`
- `git diff --check`