### PR TITLE
[SMG] feat: support return_routed_experts on sgl-model-gateway

### DIFF
--- a/sgl-model-gateway/benches/wasm_middleware_latency.rs
+++ b/sgl-model-gateway/benches/wasm_middleware_latency.rs
@@ -6,6 +6,7 @@ use axum::{
     middleware,
     response::IntoResponse,
 };
+use bytes::Bytes;
 use criterion::{criterion_group, criterion_main, Criterion};
 use http_body_util::BodyExt;
 use smg::{
@@ -27,6 +28,7 @@ impl RouterTrait for MockRouter {
         &self,
         _headers: Option<&HeaderMap>,
         _body: &ChatCompletionRequest,
+        _body_raw: Option<&Bytes>,
         _model_id: Option<&str>,
     ) -> Response<Body> {
         StatusCode::OK.into_response()
@@ -43,13 +45,13 @@ async fn mock_next_streaming(_req: Request<Body>) -> Response<Body> {
     tokio::spawn(async move {
         // Send first chunk immediately
         let _ = tx
-            .send(Ok::<_, std::io::Error>(bytes::Bytes::from("chunk 1 ")))
+            .send(Ok::<_, std::io::Error>(Bytes::from("chunk 1 ")))
             .await;
         // Simulate generation delay
         tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
         // Send final chunk
         let _ = tx
-            .send(Ok::<_, std::io::Error>(bytes::Bytes::from("chunk 2")))
+            .send(Ok::<_, std::io::Error>(Bytes::from("chunk 2")))
             .await;
     });
 

--- a/sgl-model-gateway/e2e_test/router/test_routed_experts.py
+++ b/sgl-model-gateway/e2e_test/router/test_routed_experts.py
@@ -1,0 +1,314 @@
+"""Real-GPU e2e tests for `return_routed_experts` on sgl-model-gateway.
+
+Verifies that the gateway correctly forwards `return_routed_experts: true`
+to a live SGLang server (MoE model) and propagates the resulting
+`sglext.routed_experts` (or `meta_info.routed_experts` for `/generate`)
+back to the client. Mirrors the mock-based suites under
+``tests/routing/pd_routing_test.rs`` and
+``tests/api/api_endpoints_test.rs::sglang_extension_tests`` but against
+real workers — catches regressions where the mock and the real SGLang
+protocol have drifted (e.g. the typed `SglExt` envelope shape upstream
+in ``python/sglang/srt/entrypoints/openai/protocol.py``).
+
+Two scenarios:
+
+* Unified router (1 worker, no merge step). Streaming + flag is a
+  passthrough — the gateway does not gate it.
+
+* PD router (1 prefill + 1 decode worker, gateway merges
+  `prefill_bytes ++ decode_bytes[prefill_len..]` on the response).
+  Streaming + flag is rejected with 400 because the SSE pipeline does
+  not merge.
+
+Model: ``openai/gpt-oss-20b`` (MoE, ``tp=2``; the smallest MoE in
+``MODEL_SPECS``). Picking an MoE matters — `return_routed_experts` is a
+no-op on dense models, which would weaken the assertion to "no 5xx".
+
+GPU footprint:
+
+* Unified: 2 GPUs (``tp=2``).
+* PD: 4 GPUs (1 prefill ``tp=2`` + 1 decode ``tp=2``).
+
+Run locally::
+
+    pytest e2e_test/router/test_routed_experts.py -v
+
+These tests are decorated with ``@pytest.mark.e2e`` so they're filtered
+out of unit-style runs.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+
+import pytest
+import requests
+
+logger = logging.getLogger(__name__)
+
+# API key is not validated by the gateway, but required for OpenAI-compatible
+# headers (matches the convention from other e2e_test/chat_completions tests).
+API_KEY = "not-used"
+
+# gpt-oss requires its own reasoning parser; pulling it from the responses-API
+# tests that already exercise this model.
+_GPT_OSS_GATEWAY_ARGS = ["--reasoning-parser=gpt-oss"]
+
+
+def _assert_valid_routed_experts_b64(b64: str, where: str) -> None:
+    """Decode `b64` as base64 and assert it carries at least one byte of
+    expert-id data. The exact byte-pattern depends on the model and the
+    request — the gateway only forwards bytes — so we validate shape
+    rather than value."""
+    assert isinstance(b64, str), f"{where}: expected str, got {type(b64)}"
+    decoded = base64.b64decode(b64, validate=True)
+    assert len(decoded) > 0, f"{where}: routed_experts decoded to empty bytes"
+
+
+# =============================================================================
+# Unified router (regular HTTP, no PD merge)
+# =============================================================================
+
+
+@pytest.mark.e2e
+@pytest.mark.model("gpt-oss")
+@pytest.mark.gateway(extra_args=_GPT_OSS_GATEWAY_ARGS)
+@pytest.mark.parametrize("setup_backend", ["http"], indirect=True)
+class TestUnifiedRoutedExperts:
+    """Unified-router e2e against a single real SGLang MoE worker."""
+
+    def test_chat_completion_returns_routed_experts(self, setup_backend):
+        """`return_routed_experts: true` on /v1/chat/completions surfaces
+        the field in `sglext.routed_experts` (the typed `SglExt`
+        envelope SGLang emits on `ChatCompletionResponse`)."""
+        _, model, _, gateway = setup_backend
+
+        resp = requests.post(
+            f"{gateway.base_url}/v1/chat/completions",
+            headers={"Authorization": f"Bearer {API_KEY}"},
+            json={
+                "model": model,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_tokens": 4,
+                "temperature": 0,
+                "return_routed_experts": True,
+                "stream": False,
+            },
+            timeout=120,
+        )
+        assert resp.status_code == 200, f"{resp.status_code}: {resp.text}"
+        data = resp.json()
+        sglext = data.get("sglext")
+        assert sglext is not None, f"expected sglext envelope: {data}"
+        _assert_valid_routed_experts_b64(
+            sglext.get("routed_experts"), "sglext.routed_experts"
+        )
+
+    def test_generate_returns_routed_experts(self, setup_backend):
+        """Same contract on /generate via `meta_info.routed_experts`
+        (the SGLang-native envelope, not the OpenAI-shaped one)."""
+        _, model, _, gateway = setup_backend
+
+        resp = requests.post(
+            f"{gateway.base_url}/generate",
+            headers={"Authorization": f"Bearer {API_KEY}"},
+            json={
+                "model": model,
+                "text": "Hello",
+                "sampling_params": {"max_new_tokens": 4, "temperature": 0},
+                "return_routed_experts": True,
+                "stream": False,
+            },
+            timeout=120,
+        )
+        assert resp.status_code == 200, f"{resp.status_code}: {resp.text}"
+        data = resp.json()
+        meta_info = data.get("meta_info")
+        assert meta_info is not None, f"expected meta_info envelope: {data}"
+        _assert_valid_routed_experts_b64(
+            meta_info.get("routed_experts"), "meta_info.routed_experts"
+        )
+
+    def test_streaming_chat_with_routed_experts_is_not_rejected(self, setup_backend):
+        """Unified streaming + flag must NOT be rejected — the unified
+        router has no merge step, so SGLang's per-chunk SglExt envelope
+        flows through SSE proxying unchanged. (PD rejects this combo
+        with 400; see TestPDRoutedExperts.)"""
+        _, model, _, gateway = setup_backend
+
+        with requests.post(
+            f"{gateway.base_url}/v1/chat/completions",
+            headers={"Authorization": f"Bearer {API_KEY}"},
+            json={
+                "model": model,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_tokens": 4,
+                "temperature": 0,
+                "return_routed_experts": True,
+                "stream": True,
+            },
+            stream=True,
+            timeout=120,
+        ) as resp:
+            assert (
+                resp.status_code == 200
+            ), f"streaming + flag should be 200 on unified, got {resp.status_code}: {resp.text}"
+
+            # Drain at least one SSE event to confirm the stream is alive.
+            saw_event = False
+            for raw_line in resp.iter_lines():
+                if not raw_line:
+                    continue
+                line = raw_line.decode("utf-8", errors="replace")
+                if line.startswith("data: "):
+                    saw_event = True
+                    payload = line[len("data: ") :].strip()
+                    if payload == "[DONE]":
+                        break
+                    try:
+                        json.loads(payload)
+                    except json.JSONDecodeError:
+                        pytest.fail(f"non-JSON SSE payload: {payload!r}")
+                    break
+            assert saw_event, "expected at least one SSE event from the unified stream"
+
+    def test_chat_completion_rejects_invalid_extension_type(self, setup_backend):
+        """Type-mismatched extension fields surface as 400 on the
+        unified router (mirrors the PD contract)."""
+        _, model, _, gateway = setup_backend
+
+        resp = requests.post(
+            f"{gateway.base_url}/v1/chat/completions",
+            headers={"Authorization": f"Bearer {API_KEY}"},
+            json={
+                "model": model,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_tokens": 4,
+                "temperature": 0,
+                "return_routed_experts": "yes",  # wrong type
+                "stream": False,
+            },
+            timeout=30,
+        )
+        assert (
+            resp.status_code == 400
+        ), f"non-bool return_routed_experts should yield 400, got {resp.status_code}: {resp.text}"
+
+
+# =============================================================================
+# PD router (prefill + decode, merge on the response)
+# =============================================================================
+
+
+@pytest.mark.e2e
+@pytest.mark.model("gpt-oss")
+@pytest.mark.workers(prefill=1, decode=1)
+@pytest.mark.gateway(extra_args=_GPT_OSS_GATEWAY_ARGS)
+@pytest.mark.parametrize("setup_backend", ["pd"], indirect=True)
+class TestPDRoutedExperts:
+    """PD-router e2e: real prefill + decode SGLang MoE workers."""
+
+    def test_chat_completion_merges_routed_experts(self, setup_backend):
+        """Round-trip through `route_chat → execute_dual_dispatch →
+        merge_prefill_json`. The merged `sglext.routed_experts` is
+        `prefill_bytes ++ decode_bytes[prefill_len..]`; we can't compare
+        against an oracle (would need to intercept both legs) but
+        non-empty valid base64 + non-zero length proves the merge ran
+        and produced output, which is the gateway-side contract."""
+        _, model, _, gateway = setup_backend
+
+        resp = requests.post(
+            f"{gateway.base_url}/v1/chat/completions",
+            headers={"Authorization": f"Bearer {API_KEY}"},
+            json={
+                "model": model,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_tokens": 4,
+                "temperature": 0,
+                "return_routed_experts": True,
+                "stream": False,
+            },
+            timeout=180,
+        )
+        assert resp.status_code == 200, f"{resp.status_code}: {resp.text}"
+        data = resp.json()
+        sglext = data.get("sglext")
+        assert sglext is not None, f"expected sglext envelope: {data}"
+        _assert_valid_routed_experts_b64(
+            sglext.get("routed_experts"), "sglext.routed_experts (PD merged)"
+        )
+
+    def test_generate_merges_routed_experts(self, setup_backend):
+        """Same shape on `/generate`, exercising the `meta_info` branch
+        of `merge_prefill_json` (the chat test exercises the `sglext`
+        branch)."""
+        _, model, _, gateway = setup_backend
+
+        resp = requests.post(
+            f"{gateway.base_url}/generate",
+            headers={"Authorization": f"Bearer {API_KEY}"},
+            json={
+                "model": model,
+                "text": "Hello",
+                "sampling_params": {"max_new_tokens": 4, "temperature": 0},
+                "return_routed_experts": True,
+                "stream": False,
+            },
+            timeout=180,
+        )
+        assert resp.status_code == 200, f"{resp.status_code}: {resp.text}"
+        data = resp.json()
+        meta_info = data.get("meta_info")
+        assert meta_info is not None, f"expected meta_info envelope: {data}"
+        _assert_valid_routed_experts_b64(
+            meta_info.get("routed_experts"), "meta_info.routed_experts (PD merged)"
+        )
+
+    def test_streaming_chat_with_routed_experts_returns_400(self, setup_backend):
+        """The SSE pipeline doesn't merge prefill/decode bytes, so PD
+        rejects this combo up front rather than silently returning
+        decode-only experts."""
+        _, model, _, gateway = setup_backend
+
+        resp = requests.post(
+            f"{gateway.base_url}/v1/chat/completions",
+            headers={"Authorization": f"Bearer {API_KEY}"},
+            json={
+                "model": model,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_tokens": 4,
+                "temperature": 0,
+                "return_routed_experts": True,
+                "stream": True,
+            },
+            timeout=30,
+        )
+        assert (
+            resp.status_code == 400
+        ), f"PD streaming + flag should yield 400, got {resp.status_code}: {resp.text}"
+
+    def test_chat_completion_rejects_invalid_extension_type(self, setup_backend):
+        """Type-mismatched extension fields are surfaced as 400 by the
+        PD router. This complements the unified-side reject test —
+        each router has its own `parse_sglang_extensions` call
+        (`pd_router.rs::route_chat` vs `router.rs::route_chat`)."""
+        _, model, _, gateway = setup_backend
+
+        resp = requests.post(
+            f"{gateway.base_url}/v1/chat/completions",
+            headers={"Authorization": f"Bearer {API_KEY}"},
+            json={
+                "model": model,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_tokens": 4,
+                "temperature": 0,
+                "return_routed_experts": "yes",  # wrong type
+                "stream": False,
+            },
+            timeout=30,
+        )
+        assert (
+            resp.status_code == 400
+        ), f"PD non-bool return_routed_experts should yield 400, got {resp.status_code}: {resp.text}"

--- a/sgl-model-gateway/src/lib.rs
+++ b/sgl-model-gateway/src/lib.rs
@@ -10,6 +10,7 @@ pub use reasoning_parser;
 pub mod routers;
 pub mod server;
 pub mod service_discovery;
+pub mod sglang_extensions;
 pub use llm_tokenizer as tokenizer;
 pub use tool_parser;
 pub mod version;

--- a/sgl-model-gateway/src/routers/grpc/pd_router.rs
+++ b/sgl-model-gateway/src/routers/grpc/pd_router.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use axum::{http::HeaderMap, response::Response};
+use bytes::Bytes;
 use tracing::debug;
 
 use super::{context::SharedComponents, pipeline::RequestPipeline};
@@ -224,6 +225,7 @@ impl RouterTrait for GrpcPDRouter {
         &self,
         headers: Option<&HeaderMap>,
         body: &GenerateRequest,
+        _body_raw: Option<&Bytes>,
         model_id: Option<&str>,
     ) -> Response {
         self.route_generate_impl(headers, body, model_id).await
@@ -233,6 +235,7 @@ impl RouterTrait for GrpcPDRouter {
         &self,
         headers: Option<&HeaderMap>,
         body: &ChatCompletionRequest,
+        _body_raw: Option<&Bytes>,
         model_id: Option<&str>,
     ) -> Response {
         self.route_chat_impl(headers, body, model_id).await

--- a/sgl-model-gateway/src/routers/grpc/router.rs
+++ b/sgl-model-gateway/src/routers/grpc/router.rs
@@ -5,6 +5,7 @@ use axum::{
     http::HeaderMap,
     response::{IntoResponse, Response},
 };
+use bytes::Bytes;
 use tracing::debug;
 
 use super::{
@@ -378,6 +379,7 @@ impl RouterTrait for GrpcRouter {
         &self,
         headers: Option<&HeaderMap>,
         body: &GenerateRequest,
+        _body_raw: Option<&Bytes>,
         model_id: Option<&str>,
     ) -> Response {
         self.route_generate_impl(headers, body, model_id).await
@@ -387,6 +389,7 @@ impl RouterTrait for GrpcRouter {
         &self,
         headers: Option<&HeaderMap>,
         body: &ChatCompletionRequest,
+        _body_raw: Option<&Bytes>,
         model_id: Option<&str>,
     ) -> Response {
         self.route_chat_impl(headers, body, model_id).await

--- a/sgl-model-gateway/src/routers/http/mod.rs
+++ b/sgl-model-gateway/src/routers/http/mod.rs
@@ -3,3 +3,55 @@
 pub mod pd_router;
 pub mod pd_types;
 pub mod router;
+
+use axum::response::Response;
+use bytes::Bytes;
+use serde_json::Value;
+use tracing::warn;
+
+use crate::{routers::error, sglang_extensions::SglangExtensions};
+
+/// Parse SGLang extension fields from the raw request bytes. A type
+/// mismatch (e.g. `return_routed_experts: "yes"`) is surfaced as a 400
+/// `invalid_sglang_extension` instead of silently defaulting later. An
+/// absent `body_raw` produces the all-defaults extensions, which is the
+/// right answer for callers that didn't read the original bytes
+/// (e.g. gRPC ingress that arrives as a typed proto).
+pub(crate) fn parse_sglang_extensions(
+    body_raw: Option<&Bytes>,
+) -> Result<SglangExtensions, Response> {
+    match body_raw {
+        Some(raw) => SglangExtensions::parse(raw).map_err(|e| {
+            error::bad_request(
+                "invalid_sglang_extension",
+                format!("Invalid SGLang extension field: {e}"),
+            )
+        }),
+        None => Ok(SglangExtensions::default()),
+    }
+}
+
+/// Parse `body_raw` (the original request bytes) into a JSON `Value` so
+/// SGLang extension fields the typed deserializer dropped survive when
+/// the gateway forwards the request to a backend. Returns `None` when
+/// `body_raw` is absent, or — with a `warn!` — when the bytes don't
+/// parse as JSON; callers fall back to typed serialization.
+///
+/// In production the parse-failure path is unreachable: HTTP ingress at
+/// `server.rs` only invokes routers after `serde_json::from_slice` has
+/// already produced a typed request from the same bytes. The `warn!`
+/// exists to surface that impossible state if a future internal caller
+/// passes raw bytes through a different path.
+pub(crate) fn body_raw_to_value(body_raw: Option<&Bytes>) -> Option<Value> {
+    let raw = body_raw?;
+    match serde_json::from_slice(raw) {
+        Ok(v) => Some(v),
+        Err(e) => {
+            warn!(
+                "body_raw is not valid JSON ({}); falling back to typed serialization",
+                e
+            );
+            None
+        }
+    }
+}

--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -7,10 +7,11 @@ use axum::{
     http::{header::CONTENT_TYPE, HeaderMap, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
 };
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine};
+use bytes::Bytes;
 use futures_util::StreamExt;
 use memchr::memmem;
 use reqwest::Client;
-use serde::Serialize;
 use serde_json::{json, Value};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, error, warn};
@@ -40,7 +41,9 @@ use crate::{
     routers::{
         error,
         grpc::utils::{error_type_from_status, route_to_endpoint},
-        header_utils, RouterTrait,
+        header_utils,
+        http::{body_raw_to_value, parse_sglang_extensions},
+        RouterTrait,
     },
 };
 
@@ -60,9 +63,16 @@ struct PDRequestContext<'a> {
     batch_size: Option<usize>,
     is_stream: bool,
     return_logprob: bool,
+    return_routed_experts: bool,
     request_text: Option<String>,
     model_id: Option<&'a str>,
     headers: Option<HeaderMap>,
+}
+
+impl PDRequestContext<'_> {
+    fn needs_prefill_json_merge(&self) -> bool {
+        !self.is_stream && (self.return_logprob || self.return_routed_experts)
+    }
 }
 
 impl PDRouter {
@@ -274,10 +284,10 @@ impl PDRouter {
         Ok(original)
     }
 
-    async fn execute_dual_dispatch<T: Serialize + Clone>(
+    async fn execute_dual_dispatch(
         &self,
         headers: Option<&HeaderMap>,
-        original_request: &T,
+        request_json: Value,
         context: PDRequestContext<'_>,
     ) -> Response {
         let start_time = Instant::now();
@@ -295,9 +305,9 @@ impl PDRouter {
             endpoint,
             bool_to_static_str(context.is_stream),
         );
-        // Clone request once outside the retry loop, then use Arc to share across attempts
-        // This avoids O(retries) clones by sharing the same data
-        let shared_request = Arc::new(original_request.clone());
+        // Share the JSON across retry attempts via Arc to avoid O(retries)
+        // clones of potentially large multimodal payloads.
+        let shared_request = Arc::new(request_json);
         let response = RetryExecutor::execute_response_with_retry(
             &self.retry_config,
             {
@@ -327,10 +337,7 @@ impl PDRouter {
                             decode.url()
                         );
 
-                        let mut json_request = match serde_json::to_value(shared_request.as_ref()) {
-                            Ok(v) => v,
-                            Err(e) => return Self::handle_serialization_error(e),
-                        };
+                        let mut json_request = (*shared_request).clone();
 
                         json_request = match Self::inject_bootstrap_into_value(
                             json_request,
@@ -444,7 +451,7 @@ impl PDRouter {
                 "data: {{'error': {}}}",
                 serde_json::to_string(&error_payload).unwrap_or_default()
             );
-            let error_stream = tokio_stream::once(Ok(axum::body::Bytes::from(sse_data)));
+            let error_stream = tokio_stream::once(Ok(Bytes::from(sse_data)));
 
             let decode_url = decode.url().to_string();
             self.create_streaming_response(
@@ -601,12 +608,12 @@ impl PDRouter {
                 }
 
                 // Process prefill response
-                let prefill_body = if context.return_logprob {
+                let prefill_body = if context.needs_prefill_json_merge() {
                     match self
                         .process_prefill_response(
                             prefill_result,
                             prefill.url(),
-                            context.return_logprob,
+                            context.needs_prefill_json_merge(),
                         )
                         .await
                     {
@@ -627,12 +634,26 @@ impl PDRouter {
                 if context.is_stream {
                     // Streaming response
                     let prefill_logprobs = if context.return_logprob {
-                        prefill_body
-                            .as_ref()
-                            .and_then(|body| serde_json::from_slice::<Value>(body).ok())
-                            .and_then(|json| {
-                                json.pointer("/meta_info/input_token_logprobs").cloned()
-                            })
+                        prefill_body.as_ref().and_then(|body| {
+                            // On parse failure the client won't get
+                            // prefill logprobs merged into the stream;
+                            // warn so this is visible in logs (the
+                            // value is still `None` so the stream
+                            // degrades gracefully).
+                            match serde_json::from_slice::<Value>(body) {
+                                Ok(json) => {
+                                    json.pointer("/meta_info/input_token_logprobs").cloned()
+                                }
+                                Err(e) => {
+                                    warn!(
+                                        "streaming prefill logprobs unavailable: \
+                                         failed to parse prefill body as JSON: {}",
+                                        e
+                                    );
+                                    None
+                                }
+                            }
+                        })
                     } else {
                         None
                     };
@@ -651,11 +672,12 @@ impl PDRouter {
                     )
                 } else {
                     // Non-streaming response
-                    if context.return_logprob {
+                    if context.needs_prefill_json_merge() {
                         self.process_non_streaming_response(
                             res,
                             status,
                             context.return_logprob,
+                            context.return_routed_experts,
                             prefill_body,
                         )
                         .await
@@ -833,7 +855,7 @@ impl PDRouter {
     #[allow(clippy::too_many_arguments)]
     fn create_streaming_response(
         &self,
-        stream: impl futures_util::Stream<Item = Result<bytes::Bytes, reqwest::Error>> + Send + 'static,
+        stream: impl futures_util::Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
         status: StatusCode,
         prefill_logprobs: Option<Value>,
         return_logprob: bool,
@@ -897,13 +919,15 @@ impl PDRouter {
         AttachedBody::wrap_response(response, guards)
     }
 
-    // Helper to process non-streaming decode response with logprob merging
+    // Helper to process non-streaming decode response, merging prefill metadata
+    // (logprobs and/or routed_experts) into decode's JSON when requested.
     async fn process_non_streaming_response(
         &self,
         res: reqwest::Response,
         status: StatusCode,
         return_logprob: bool,
-        prefill_body: Option<bytes::Bytes>,
+        return_routed_experts: bool,
+        prefill_body: Option<Bytes>,
     ) -> Response {
         let response = res.bytes().await;
         let decode_body = match response {
@@ -914,7 +938,7 @@ impl PDRouter {
             }
         };
 
-        if !return_logprob {
+        if !return_logprob && !return_routed_experts {
             return (status, decode_body).into_response();
         }
 
@@ -922,16 +946,24 @@ impl PDRouter {
             return (status, decode_body).into_response();
         };
 
-        // Merge logprobs from prefill and decode
+        // Parse both bodies and merge prefill metadata (logprobs and/or
+        // routed_experts) into decode's JSON. Parse failure here means the
+        // client requested merged data but will receive decode-only — log as
+        // an error so it surfaces in dashboards, then degrade gracefully.
         let (Ok(prefill_json), Ok(mut decode_json)) = (
             serde_json::from_slice::<Value>(&prefill_body),
             serde_json::from_slice::<Value>(&decode_body),
         ) else {
-            warn!("Failed to parse responses for logprob merging");
+            error!("pd_response_parse_failed: returning decode-only response");
             return (status, decode_body).into_response();
         };
 
-        Self::merge_logprobs_in_json(&prefill_json, &mut decode_json);
+        Self::merge_prefill_json(
+            &prefill_json,
+            &mut decode_json,
+            return_logprob,
+            return_routed_experts,
+        );
 
         // Return merged response
         match serde_json::to_vec(&decode_json) {
@@ -943,13 +975,15 @@ impl PDRouter {
         }
     }
 
-    // Helper to process prefill response and extract body if needed for logprobs
+    // Helper to process prefill response and extract its body when prefill
+    // metadata needs to be merged into the decode response (logprobs or
+    // routed_experts).
     async fn process_prefill_response(
         &self,
         prefill_result: Result<reqwest::Response, reqwest::Error>,
         prefill_url: &str,
-        return_logprob: bool,
-    ) -> Result<(StatusCode, Option<bytes::Bytes>), Response> {
+        need_merge_prefill: bool,
+    ) -> Result<(StatusCode, Option<Bytes>), Response> {
         // Check prefill result first - it's critical for disaggregated mode
         let prefill_response = match prefill_result {
             Ok(response) => response,
@@ -1017,18 +1051,27 @@ impl PDRouter {
             return Err(error_response);
         }
 
-        // Read prefill body if needed for logprob merging
-        let prefill_body = if return_logprob {
+        // Read prefill body when the caller needs to merge prefill metadata back into decode.
+        let prefill_body = if need_merge_prefill {
             match prefill_response.bytes().await {
                 Ok(body) => Some(body),
                 Err(e) => {
-                    warn!("Failed to read prefill response body for logprobs: {}", e);
+                    // Client explicitly asked for merged data
+                    // (logprobs/routed_experts); without the prefill
+                    // body the response will silently degrade to
+                    // decode-only. Log as error so this surfaces in
+                    // dashboards.
+                    error!(
+                        "prefill_body_read_failed: caller wanted PD merge but \
+                         couldn't read prefill body, will return decode-only: {}",
+                        e
+                    );
                     None
                 }
             }
         } else {
-            // For non-logprob requests, just consume the response without storing
-            debug!("Consuming prefill response body (non-logprob request)");
+            // For passthrough requests, just consume the response without storing.
+            debug!("Consuming prefill response body (no PD merge requested)");
             match prefill_response.bytes().await {
                 Ok(_) => debug!("Prefill response consumed successfully"),
                 Err(e) => warn!("Error consuming prefill response: {}", e),
@@ -1092,12 +1135,107 @@ impl PDRouter {
         false
     }
 
+    /// Merge `routed_experts` from prefill into the decode response.
+    ///
+    /// SGLang's RL extension ships expert ids as a base64-packed byte
+    /// string. The decode worker echoes the prefill's leading bytes
+    /// (first `prefill_len` bytes of decode are the same as prefill)
+    /// and appends per-token expert ids in the suffix. To produce the
+    /// merged stream the gateway concatenates `prefill_bytes ++
+    /// decode_bytes[prefill_len..]` and writes that back into
+    /// `decode_json["routed_experts"]`. Returns `true` when a merge
+    /// happened, `false` if either side was missing or unparsable.
+    ///
+    /// Caller (`merge_prefill_json`) walks two known envelopes for this
+    /// field: `meta_info.routed_experts` on `/generate` responses, and
+    /// `sglext.routed_experts` on OpenAI-compatible responses. The
+    /// `sglext` envelope is a typed contract upstream — see
+    /// `python/sglang/srt/entrypoints/openai/protocol.py::SglExt`,
+    /// which currently carries `routed_experts` and
+    /// `cached_tokens_details` and is hung off `CompletionResponse`,
+    /// `ChatCompletionResponse`, and their streaming variants.
+    fn merge_routed_experts_in_json(prefill_json: &Value, decode_json: &mut Value) -> bool {
+        let (Some(prefill_routed_experts), Some(decode_routed_experts)) = (
+            prefill_json.get("routed_experts").and_then(Value::as_str),
+            decode_json.get("routed_experts").and_then(Value::as_str),
+        ) else {
+            return false;
+        };
+
+        // Base64 decode failures here mean the client asked for merged
+        // routed_experts but will receive only the decode-side payload (or
+        // none, depending on which side failed). Log as error so data-integrity
+        // events show up in dashboards, then leave decode_json untouched.
+        let prefill_bytes = match BASE64_STANDARD.decode(prefill_routed_experts) {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                error!(
+                    "routed_experts_decode_failed (prefill): merge skipped: {}",
+                    error
+                );
+                return false;
+            }
+        };
+
+        let decode_bytes = match BASE64_STANDARD.decode(decode_routed_experts) {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                error!(
+                    "routed_experts_decode_failed (decode): merge skipped: {}",
+                    error
+                );
+                return false;
+            }
+        };
+
+        let suffix = decode_bytes.get(prefill_bytes.len()..).unwrap_or_default();
+        let mut merged = Vec::with_capacity(prefill_bytes.len() + suffix.len());
+        merged.extend_from_slice(&prefill_bytes);
+        merged.extend_from_slice(suffix);
+
+        if let Some(obj) = decode_json.as_object_mut() {
+            obj.insert(
+                "routed_experts".to_string(),
+                Value::String(BASE64_STANDARD.encode(merged)),
+            );
+            return true;
+        }
+
+        false
+    }
+
+    fn merge_prefill_json(
+        prefill_json: &Value,
+        decode_json: &mut Value,
+        merge_logprobs: bool,
+        merge_routed_experts: bool,
+    ) {
+        if merge_logprobs {
+            Self::merge_logprobs_in_json(prefill_json, decode_json);
+        }
+
+        if merge_routed_experts {
+            if let (Some(prefill_meta), Some(decode_meta)) = (
+                prefill_json.get("meta_info"),
+                decode_json.get_mut("meta_info"),
+            ) {
+                Self::merge_routed_experts_in_json(prefill_meta, decode_meta);
+            }
+
+            if let (Some(prefill_sglext), Some(decode_sglext)) =
+                (prefill_json.get("sglext"), decode_json.get_mut("sglext"))
+            {
+                Self::merge_routed_experts_in_json(prefill_sglext, decode_sglext);
+            }
+        }
+    }
+
     // Simple helper to merge logprobs in streaming responses
     // Optimized to reduce allocations in the merge path
     fn merge_streaming_logprobs(
         prefill_logprobs: Option<Value>,
         decode_chunk: &[u8],
-    ) -> Result<bytes::Bytes, ()> {
+    ) -> Result<Bytes, ()> {
         // Skip non-data chunks
         let chunk_str = std::str::from_utf8(decode_chunk).map_err(|_| ())?;
         if !chunk_str.starts_with("data: ") || chunk_str.contains("[DONE]") {
@@ -1132,7 +1270,7 @@ impl PDRouter {
             "data: {}\n\n",
             serde_json::to_string(&decode_json).unwrap_or_default()
         );
-        Ok(bytes::Bytes::from(merged_str))
+        Ok(Bytes::from(merged_str))
     }
 }
 
@@ -1249,6 +1387,7 @@ impl RouterTrait for PDRouter {
         &self,
         headers: Option<&HeaderMap>,
         body: &GenerateRequest,
+        body_raw: Option<&Bytes>,
         model_id: Option<&str>,
     ) -> Response {
         let is_stream = body.stream;
@@ -1262,23 +1401,53 @@ impl RouterTrait for PDRouter {
 
         let batch_size = Self::get_generate_batch_size(body);
 
+        let extensions = match parse_sglang_extensions(body_raw) {
+            Ok(ext) => ext,
+            Err(resp) => return resp,
+        };
+
+        if is_stream && extensions.return_routed_experts {
+            return error::bad_request(
+                "streaming_routed_experts_unsupported",
+                "return_routed_experts is not supported with stream=true on PD mode \
+                 (the streaming SSE path does not merge routed_experts across \
+                 prefill/decode); send the request with stream=false to receive \
+                 merged routed_experts",
+            );
+        }
+
+        // Prefer the raw request JSON so SGLang extension fields the typed
+        // GenerateRequest dropped survive through to the backend.
+        let body_json = body_raw_to_value(body_raw);
+
         let context = PDRequestContext {
             route: "/generate",
             batch_size,
             is_stream,
             return_logprob,
+            return_routed_experts: extensions.return_routed_experts,
             request_text,
             model_id,
             headers: headers.cloned(),
         };
 
-        self.execute_dual_dispatch(headers, body, context).await
+        let request_json = match body_json {
+            Some(v) => v,
+            None => match serde_json::to_value(body) {
+                Ok(v) => v,
+                Err(e) => return Self::handle_serialization_error(e),
+            },
+        };
+
+        self.execute_dual_dispatch(headers, request_json, context)
+            .await
     }
 
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
         body: &ChatCompletionRequest,
+        body_raw: Option<&Bytes>,
         model_id: Option<&str>,
     ) -> Response {
         let is_stream = body.stream;
@@ -1304,17 +1473,44 @@ impl RouterTrait for PDRouter {
         // Calculate batch size
         let batch_size = Self::get_chat_batch_size(body);
 
+        let extensions = match parse_sglang_extensions(body_raw) {
+            Ok(ext) => ext,
+            Err(resp) => return resp,
+        };
+
+        if is_stream && extensions.return_routed_experts {
+            return error::bad_request(
+                "streaming_routed_experts_unsupported",
+                "return_routed_experts is not supported with stream=true on PD mode \
+                 (the streaming SSE path does not merge routed_experts across \
+                 prefill/decode); send the request with stream=false to receive \
+                 merged routed_experts",
+            );
+        }
+
+        let body_json = body_raw_to_value(body_raw);
+
         let context = PDRequestContext {
             route: "/v1/chat/completions",
             batch_size,
             is_stream,
             return_logprob,
+            return_routed_experts: extensions.return_routed_experts,
             request_text,
             model_id,
             headers: headers.cloned(),
         };
 
-        self.execute_dual_dispatch(headers, body, context).await
+        let request_json = match body_json {
+            Some(v) => v,
+            None => match serde_json::to_value(body) {
+                Ok(v) => v,
+                Err(e) => return Self::handle_serialization_error(e),
+            },
+        };
+
+        self.execute_dual_dispatch(headers, request_json, context)
+            .await
     }
 
     async fn route_completion(
@@ -1343,12 +1539,19 @@ impl RouterTrait for PDRouter {
             batch_size,
             is_stream,
             return_logprob,
+            return_routed_experts: false,
             request_text,
             model_id,
             headers: headers.cloned(),
         };
 
-        self.execute_dual_dispatch(headers, body, context).await
+        let request_json = match serde_json::to_value(body) {
+            Ok(v) => v,
+            Err(e) => return Self::handle_serialization_error(e),
+        };
+
+        self.execute_dual_dispatch(headers, request_json, context)
+            .await
     }
 
     async fn route_rerank(
@@ -1369,12 +1572,19 @@ impl RouterTrait for PDRouter {
             batch_size: None,
             is_stream: false,
             return_logprob: false,
+            return_routed_experts: false,
             request_text: req_text,
             model_id,
             headers: headers.cloned(),
         };
 
-        self.execute_dual_dispatch(headers, body, context).await
+        let request_json = match serde_json::to_value(body) {
+            Ok(v) => v,
+            Err(e) => return Self::handle_serialization_error(e),
+        };
+
+        self.execute_dual_dispatch(headers, request_json, context)
+            .await
     }
 
     async fn route_embeddings(
@@ -1558,7 +1768,7 @@ mod tests {
             assert_eq!(prefill_ref.load(), 1);
             assert_eq!(decode_ref.load(), 1);
 
-            tx.send(bytes::Bytes::from("test data")).unwrap();
+            tx.send(Bytes::from("test data")).unwrap();
 
             sleep(Duration::from_millis(10)).await;
 
@@ -1575,5 +1785,286 @@ mod tests {
         // Guards dropped when response dropped
         assert_eq!(prefill_ref.load(), 0);
         assert_eq!(decode_ref.load(), 0);
+    }
+
+    // ---------- needs_prefill_json_merge ----------
+
+    fn make_ctx(
+        is_stream: bool,
+        return_logprob: bool,
+        return_routed_experts: bool,
+    ) -> PDRequestContext<'static> {
+        PDRequestContext {
+            route: "/v1/chat/completions",
+            batch_size: None,
+            is_stream,
+            return_logprob,
+            return_routed_experts,
+            request_text: None,
+            model_id: None,
+            headers: None,
+        }
+    }
+
+    #[test]
+    fn needs_prefill_json_merge_streaming_is_always_false() {
+        // Streaming responses are merged in the SSE pipeline, not here, so
+        // needs_prefill_json_merge() must short-circuit even when flags are on.
+        assert!(!make_ctx(true, true, true).needs_prefill_json_merge());
+        assert!(!make_ctx(true, true, false).needs_prefill_json_merge());
+        assert!(!make_ctx(true, false, true).needs_prefill_json_merge());
+    }
+
+    #[test]
+    fn needs_prefill_json_merge_non_streaming_gates_on_either_flag() {
+        assert!(!make_ctx(false, false, false).needs_prefill_json_merge());
+        assert!(make_ctx(false, true, false).needs_prefill_json_merge());
+        assert!(make_ctx(false, false, true).needs_prefill_json_merge());
+        assert!(make_ctx(false, true, true).needs_prefill_json_merge());
+    }
+
+    // ---------- merge_routed_experts_in_json ----------
+
+    fn b64(bytes: &[u8]) -> String {
+        BASE64_STANDARD.encode(bytes)
+    }
+
+    fn decode_b64(s: &str) -> Vec<u8> {
+        BASE64_STANDARD.decode(s).expect("valid base64")
+    }
+
+    #[test]
+    fn merge_routed_experts_concatenates_prefill_prefix_with_decode_suffix() {
+        // Decode echoes prefill's leading bytes and appends per-token expert
+        // ids; merging must yield prefill_bytes ++ decode_bytes[prefill_len..].
+        let prefill_bytes = vec![1u8, 2, 3, 4];
+        let decode_bytes = vec![1u8, 2, 3, 4, 9, 9, 9];
+        let prefill = json!({ "routed_experts": b64(&prefill_bytes) });
+        let mut decode = json!({ "routed_experts": b64(&decode_bytes) });
+
+        assert!(PDRouter::merge_routed_experts_in_json(
+            &prefill,
+            &mut decode
+        ));
+
+        let merged = decode_b64(decode["routed_experts"].as_str().unwrap());
+        assert_eq!(merged, vec![1u8, 2, 3, 4, 9, 9, 9]);
+        // prefill input is untouched
+        assert_eq!(
+            decode_b64(prefill["routed_experts"].as_str().unwrap()),
+            prefill_bytes
+        );
+    }
+
+    #[test]
+    fn merge_routed_experts_when_decode_shorter_keeps_prefill_only() {
+        // Defensive: decode shorter than prefill (shouldn't happen in practice)
+        // — suffix slice is empty so the merged value equals prefill_bytes.
+        let prefill_bytes = vec![10u8, 20, 30, 40];
+        let decode_bytes = vec![10u8, 20];
+        let prefill = json!({ "routed_experts": b64(&prefill_bytes) });
+        let mut decode = json!({ "routed_experts": b64(&decode_bytes) });
+
+        assert!(PDRouter::merge_routed_experts_in_json(
+            &prefill,
+            &mut decode
+        ));
+
+        let merged = decode_b64(decode["routed_experts"].as_str().unwrap());
+        assert_eq!(merged, prefill_bytes);
+    }
+
+    #[test]
+    fn merge_routed_experts_returns_false_when_field_missing() {
+        let prefill_only = json!({ "routed_experts": b64(&[1u8, 2]) });
+        let mut decode_no_field = json!({ "other": "x" });
+        assert!(!PDRouter::merge_routed_experts_in_json(
+            &prefill_only,
+            &mut decode_no_field
+        ));
+
+        let prefill_no_field = json!({ "other": "x" });
+        let mut decode_only = json!({ "routed_experts": b64(&[1u8, 2]) });
+        assert!(!PDRouter::merge_routed_experts_in_json(
+            &prefill_no_field,
+            &mut decode_only
+        ));
+        // decode_only stays untouched on missing-prefill side
+        assert_eq!(
+            decode_b64(decode_only["routed_experts"].as_str().unwrap()),
+            vec![1u8, 2]
+        );
+    }
+
+    #[test]
+    fn merge_routed_experts_returns_false_on_invalid_base64() {
+        let prefill = json!({ "routed_experts": "!!!not-base64!!!" });
+        let mut decode = json!({ "routed_experts": b64(&[1u8]) });
+        assert!(!PDRouter::merge_routed_experts_in_json(
+            &prefill,
+            &mut decode
+        ));
+
+        let prefill = json!({ "routed_experts": b64(&[1u8]) });
+        let mut decode = json!({ "routed_experts": "!!!not-base64!!!" });
+        assert!(!PDRouter::merge_routed_experts_in_json(
+            &prefill,
+            &mut decode
+        ));
+    }
+
+    #[test]
+    fn merge_routed_experts_returns_false_when_value_not_string() {
+        // routed_experts is documented as a base64 string. If a server emits
+        // it as an array or number, treat as missing and bail out cleanly.
+        let prefill = json!({ "routed_experts": [1, 2, 3] });
+        let mut decode = json!({ "routed_experts": b64(&[1u8]) });
+        assert!(!PDRouter::merge_routed_experts_in_json(
+            &prefill,
+            &mut decode
+        ));
+    }
+
+    // ---------- merge_prefill_json ----------
+
+    #[test]
+    fn merge_prefill_json_logprobs_only_does_not_touch_routed_experts() {
+        let prefill_logprobs = json!([1.0, 2.0]);
+        let prefill = json!({
+            "meta_info": {
+                "input_token_logprobs": prefill_logprobs.clone(),
+                "routed_experts": b64(&[7u8, 7])
+            },
+            "sglext": { "routed_experts": b64(&[8u8, 8]) }
+        });
+        let mut decode = json!({
+            "meta_info": {
+                "input_token_logprobs": [3.0],
+                "routed_experts": b64(&[7u8, 7, 9])
+            },
+            "sglext": { "routed_experts": b64(&[8u8, 8, 9]) }
+        });
+
+        PDRouter::merge_prefill_json(&prefill, &mut decode, true, false);
+
+        // Logprobs merged: prefill ++ decode
+        assert_eq!(
+            decode["meta_info"]["input_token_logprobs"],
+            json!([1.0, 2.0, 3.0])
+        );
+        // Routed experts untouched on both meta_info and sglext
+        assert_eq!(
+            decode_b64(decode["meta_info"]["routed_experts"].as_str().unwrap()),
+            vec![7u8, 7, 9]
+        );
+        assert_eq!(
+            decode_b64(decode["sglext"]["routed_experts"].as_str().unwrap()),
+            vec![8u8, 8, 9]
+        );
+    }
+
+    #[test]
+    fn merge_prefill_json_routed_experts_only_does_not_touch_logprobs() {
+        let prefill = json!({
+            "meta_info": {
+                "input_token_logprobs": [1.0, 2.0],
+                "routed_experts": b64(&[1u8, 2])
+            },
+            "sglext": { "routed_experts": b64(&[3u8, 4]) }
+        });
+        let mut decode = json!({
+            "meta_info": {
+                "input_token_logprobs": [3.0],
+                "routed_experts": b64(&[1u8, 2, 5])
+            },
+            "sglext": { "routed_experts": b64(&[3u8, 4, 6]) }
+        });
+
+        PDRouter::merge_prefill_json(&prefill, &mut decode, false, true);
+
+        // Logprobs untouched (decode-only value preserved)
+        assert_eq!(decode["meta_info"]["input_token_logprobs"], json!([3.0]));
+        // Both routed_experts locations were merged
+        assert_eq!(
+            decode_b64(decode["meta_info"]["routed_experts"].as_str().unwrap()),
+            vec![1u8, 2, 5]
+        );
+        assert_eq!(
+            decode_b64(decode["sglext"]["routed_experts"].as_str().unwrap()),
+            vec![3u8, 4, 6]
+        );
+    }
+
+    #[test]
+    fn merge_prefill_json_both_flags_merges_both() {
+        let prefill = json!({
+            "meta_info": {
+                "input_token_logprobs": [0.5, 0.25],
+                "routed_experts": b64(&[1u8, 2])
+            },
+            "sglext": { "routed_experts": b64(&[10u8]) }
+        });
+        let mut decode = json!({
+            "meta_info": {
+                "input_token_logprobs": [0.1],
+                "routed_experts": b64(&[1u8, 2, 3])
+            },
+            "sglext": { "routed_experts": b64(&[10u8, 11]) }
+        });
+
+        PDRouter::merge_prefill_json(&prefill, &mut decode, true, true);
+
+        assert_eq!(
+            decode["meta_info"]["input_token_logprobs"],
+            json!([0.5, 0.25, 0.1])
+        );
+        assert_eq!(
+            decode_b64(decode["meta_info"]["routed_experts"].as_str().unwrap()),
+            vec![1u8, 2, 3]
+        );
+        assert_eq!(
+            decode_b64(decode["sglext"]["routed_experts"].as_str().unwrap()),
+            vec![10u8, 11]
+        );
+    }
+
+    #[test]
+    fn merge_prefill_json_both_false_is_noop() {
+        let prefill = json!({
+            "meta_info": {
+                "input_token_logprobs": [0.5],
+                "routed_experts": b64(&[1u8])
+            }
+        });
+        let original_decode = json!({
+            "meta_info": {
+                "input_token_logprobs": [0.1],
+                "routed_experts": b64(&[1u8, 2])
+            }
+        });
+        let mut decode = original_decode.clone();
+
+        PDRouter::merge_prefill_json(&prefill, &mut decode, false, false);
+
+        assert_eq!(decode, original_decode);
+    }
+
+    #[test]
+    fn merge_prefill_json_routed_experts_handles_missing_sections() {
+        // Only meta_info present; sglext absent on both sides.
+        let prefill = json!({
+            "meta_info": { "routed_experts": b64(&[1u8, 2]) }
+        });
+        let mut decode = json!({
+            "meta_info": { "routed_experts": b64(&[1u8, 2, 3]) }
+        });
+
+        PDRouter::merge_prefill_json(&prefill, &mut decode, false, true);
+
+        assert_eq!(
+            decode_b64(decode["meta_info"]["routed_experts"].as_str().unwrap()),
+            vec![1u8, 2, 3]
+        );
+        assert!(decode.get("sglext").is_none());
     }
 }

--- a/sgl-model-gateway/src/routers/http/router.rs
+++ b/sgl-model-gateway/src/routers/http/router.rs
@@ -7,6 +7,7 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use bytes::Bytes;
 use futures_util::{stream, StreamExt};
 use reqwest::Client;
 use tokio_stream::wrappers::UnboundedReceiverStream;
@@ -38,7 +39,9 @@ use crate::{
     routers::{
         error::{self, extract_error_code_from_response},
         grpc::utils::{error_type_from_status, route_to_endpoint},
-        header_utils, RouterTrait,
+        header_utils,
+        http::{body_raw_to_value, parse_sglang_extensions},
+        RouterTrait,
     },
 };
 
@@ -194,6 +197,7 @@ impl Router {
         &self,
         headers: Option<&HeaderMap>,
         typed_req: &T,
+        body_raw: Option<&Bytes>,
         route: &'static str,
         model_id: Option<&str>,
     ) -> Response {
@@ -218,7 +222,9 @@ impl Router {
             // operation per attempt
             |_: u32| async {
                 let res = self
-                    .route_typed_request_once(headers, typed_req, route, model_id, is_stream, &text)
+                    .route_typed_request_once(
+                        headers, typed_req, body_raw, route, model_id, is_stream, &text,
+                    )
                     .await;
 
                 // Need to be outside `route_typed_request_once` because that function has multiple return paths
@@ -273,6 +279,7 @@ impl Router {
         &self,
         headers: Option<&HeaderMap>,
         typed_req: &T,
+        body_raw: Option<&Bytes>,
         route: &'static str,
         model_id: Option<&str>,
         is_stream: bool,
@@ -310,6 +317,7 @@ impl Router {
             .send_typed_request(
                 headers,
                 typed_req,
+                body_raw,
                 route,
                 worker.url(),
                 is_stream,
@@ -486,6 +494,7 @@ impl Router {
         &self,
         headers: Option<&HeaderMap>,
         typed_req: &T,
+        body_raw: Option<&Bytes>,
         route: &'static str,
         worker_url: &str,
         is_stream: bool,
@@ -497,6 +506,13 @@ impl Router {
 
         // Static key string to avoid per-request allocations
         const DP_RANK_KEY: &str = "data_parallel_rank";
+
+        // Prefer the raw client bytes so SGLang extension fields (e.g.
+        // `return_routed_experts`) the typed struct dropped on deserialise
+        // still reach the backend. Falls back to the typed payload when
+        // the raw bytes aren't valid JSON or aren't available (callers
+        // that don't extract them from the request).
+        let body_value_from_raw = body_raw_to_value(body_raw);
 
         let mut request_builder = if self.dp_aware {
             let (worker_url_prefix, dp_rank) = match Self::extract_dp_rank(worker_url) {
@@ -510,14 +526,17 @@ impl Router {
                 }
             };
 
-            let mut json_val = match serde_json::to_value(typed_req) {
-                Ok(j) => j,
-                Err(e) => {
-                    return error::bad_request(
-                        "serialization_failed",
-                        format!("Convert into serde_json::Value failed: {}", e),
-                    );
-                }
+            let mut json_val = match body_value_from_raw {
+                Some(v) => v,
+                None => match serde_json::to_value(typed_req) {
+                    Ok(j) => j,
+                    Err(e) => {
+                        return error::bad_request(
+                            "serialization_failed",
+                            format!("Convert into serde_json::Value failed: {}", e),
+                        );
+                    }
+                },
             };
 
             if let Some(map) = json_val.as_object_mut() {
@@ -539,6 +558,10 @@ impl Router {
 
             self.client
                 .post(format!("{}{}", worker_url_prefix, route))
+                .json(&json_val)
+        } else if let Some(json_val) = body_value_from_raw {
+            self.client
+                .post(format!("{}{}", worker_url, route))
                 .json(&json_val)
         } else {
             self.client
@@ -739,9 +762,18 @@ impl RouterTrait for Router {
         &self,
         headers: Option<&HeaderMap>,
         body: &GenerateRequest,
+        body_raw: Option<&Bytes>,
         model_id: Option<&str>,
     ) -> Response {
-        self.route_typed_request(headers, body, "/generate", model_id)
+        // Validate SGLang extension types up front (e.g. reject
+        // `return_routed_experts: "yes"` as 400) so the unified router
+        // surfaces the same input-validation contract as the PD router.
+        // The parsed value is unused here — the unified path is pure
+        // passthrough — but the parse-side-effect still runs.
+        if let Err(resp) = parse_sglang_extensions(body_raw) {
+            return resp;
+        }
+        self.route_typed_request(headers, body, body_raw, "/generate", model_id)
             .await
     }
 
@@ -749,11 +781,24 @@ impl RouterTrait for Router {
         &self,
         headers: Option<&HeaderMap>,
         body: &ChatCompletionRequest,
+        body_raw: Option<&Bytes>,
         model_id: Option<&str>,
     ) -> Response {
-        self.route_typed_request(headers, body, "/v1/chat/completions", model_id)
+        if let Err(resp) = parse_sglang_extensions(body_raw) {
+            return resp;
+        }
+        self.route_typed_request(headers, body, body_raw, "/v1/chat/completions", model_id)
             .await
     }
+
+    // route_completion / route_responses / route_embeddings /
+    // route_classify / route_rerank pass `None` for `body_raw` because
+    // their handlers in `server.rs` consume the body via the
+    // `Json<T>` extractor, which never preserves the original bytes.
+    // SGLang extension fields on these endpoints (e.g. `regex`,
+    // `min_tokens`, `lora_path` on /v1/completions) are therefore
+    // dropped on this path; thread `body_raw` through if/when SGLang
+    // RL or similar features start needing them on completions etc.
 
     async fn route_completion(
         &self,
@@ -761,7 +806,7 @@ impl RouterTrait for Router {
         body: &CompletionRequest,
         model_id: Option<&str>,
     ) -> Response {
-        self.route_typed_request(headers, body, "/v1/completions", model_id)
+        self.route_typed_request(headers, body, None, "/v1/completions", model_id)
             .await
     }
 
@@ -771,7 +816,7 @@ impl RouterTrait for Router {
         body: &ResponsesRequest,
         model_id: Option<&str>,
     ) -> Response {
-        self.route_typed_request(headers, body, "/v1/responses", model_id)
+        self.route_typed_request(headers, body, None, "/v1/responses", model_id)
             .await
     }
 
@@ -796,7 +841,7 @@ impl RouterTrait for Router {
         body: &EmbeddingRequest,
         model_id: Option<&str>,
     ) -> Response {
-        self.route_typed_request(headers, body, "/v1/embeddings", model_id)
+        self.route_typed_request(headers, body, None, "/v1/embeddings", model_id)
             .await
     }
 
@@ -806,7 +851,7 @@ impl RouterTrait for Router {
         body: &ClassifyRequest,
         model_id: Option<&str>,
     ) -> Response {
-        self.route_typed_request(headers, body, "/v1/classify", model_id)
+        self.route_typed_request(headers, body, None, "/v1/classify", model_id)
             .await
     }
 
@@ -817,7 +862,7 @@ impl RouterTrait for Router {
         model_id: Option<&str>,
     ) -> Response {
         let response = self
-            .route_typed_request(headers, body, "/v1/rerank", model_id)
+            .route_typed_request(headers, body, None, "/v1/rerank", model_id)
             .await;
         if response.status().is_success() {
             match Self::build_rerank_response(body, response).await {

--- a/sgl-model-gateway/src/routers/mod.rs
+++ b/sgl-model-gateway/src/routers/mod.rs
@@ -9,6 +9,7 @@ use axum::{
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
 };
+use bytes::Bytes;
 
 use crate::protocols::{
     chat::ChatCompletionRequest,
@@ -75,11 +76,26 @@ pub trait RouterTrait: Send + Sync + Debug {
             .into_response()
     }
 
-    /// Route a generate request
+    /// Route a generate request.
+    ///
+    /// `body_raw` is the original request bytes. Both HTTP routers (PD
+    /// and regular) call `parse_sglang_extensions` on it to validate
+    /// SGLang extension types up front (e.g. `return_routed_experts:
+    /// "yes"` becomes a 400) and forward the raw JSON to backend
+    /// servers verbatim — this preserves SGLang extension fields (e.g.
+    /// `return_routed_experts`, `routed_dp_rank`) that the typed
+    /// `GenerateRequest` would have dropped as unknown on a typed
+    /// re-serialize. The PD router additionally branches on
+    /// `return_routed_experts` to merge prefill/decode response bytes;
+    /// the regular router is pure passthrough since it has only one
+    /// backend per request. The gRPC routers and OpenAI provider router
+    /// ignore `body_raw`. `None` means raw access wasn't captured (e.g.
+    /// test callers, gRPC paths that build their own proto payload).
     async fn route_generate(
         &self,
         _headers: Option<&HeaderMap>,
         _body: &GenerateRequest,
+        _body_raw: Option<&Bytes>,
         _model_id: Option<&str>,
     ) -> Response {
         (
@@ -89,11 +105,13 @@ pub trait RouterTrait: Send + Sync + Debug {
             .into_response()
     }
 
-    /// Route a chat completion request
+    /// Route a chat completion request. See `route_generate` for the meaning
+    /// of `body_raw`.
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
         body: &ChatCompletionRequest,
+        body_raw: Option<&Bytes>,
         model_id: Option<&str>,
     ) -> Response;
 

--- a/sgl-model-gateway/src/routers/openai/provider.rs
+++ b/sgl-model-gateway/src/routers/openai/provider.rs
@@ -6,37 +6,16 @@ use reqwest::RequestBuilder;
 use serde_json::Value;
 use thiserror::Error;
 
-use crate::core::{model_type::Endpoint, ProviderType};
+use crate::{
+    core::{model_type::Endpoint, ProviderType},
+    sglang_extensions::EXTENSION_FIELD_NAMES,
+};
 
-const SGLANG_FIELDS: &[&str] = &[
-    "request_id",
-    "priority",
-    "top_k",
-    "min_p",
-    "min_tokens",
-    "regex",
-    "ebnf",
-    "json_schema",
-    "stop_token_ids",
-    "no_stop_trim",
-    "ignore_eos",
-    "continue_final_message",
-    "skip_special_tokens",
-    "lora_path",
-    "session_params",
-    "separate_reasoning",
-    "stream_reasoning",
-    "chat_template",
-    "chat_template_kwargs",
-    "return_hidden_states",
-    "repetition_penalty",
-    "sampling_seed",
-    "backend_url",
-];
-
+/// Strip every SGLang extension field from the request payload before
+/// forwarding to OpenAI (which would 400 on unknown fields).
 fn strip_sglang_fields(payload: &mut Value) {
     if let Some(obj) = payload.as_object_mut() {
-        for field in SGLANG_FIELDS {
+        for field in EXTENSION_FIELD_NAMES {
             obj.remove(*field);
         }
     }
@@ -248,5 +227,96 @@ impl ProviderRegistry {
 
     pub fn default_provider_arc(&self) -> Arc<dyn Provider> {
         Arc::clone(&self.default_provider)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn strip_sglang_fields_removes_every_known_extension() {
+        // Build a payload that sets every EXTENSION_FIELD_NAMES entry alongside two
+        // standard OpenAI fields. After stripping, only the OpenAI fields
+        // should remain — otherwise we'd forward unknown fields to OpenAI's
+        // API and get a 400 back.
+        let mut payload = json!({
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "hi"}],
+        });
+
+        let payload_obj = payload.as_object_mut().unwrap();
+        for field in EXTENSION_FIELD_NAMES {
+            payload_obj.insert((*field).to_string(), json!("sentinel"));
+        }
+
+        strip_sglang_fields(&mut payload);
+
+        let remaining: Vec<&str> = payload
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(remaining, vec!["model", "messages"]);
+    }
+
+    #[test]
+    fn strip_sglang_fields_strips_every_new_extension_field() {
+        // Spot-check the fields added in the SGLang RL extension PR. If a
+        // new field name is misspelled in EXTENSION_FIELD_NAMES, this test fires.
+        let new_fields = [
+            "return_routed_experts",
+            "return_cached_tokens_details",
+            "return_prompt_token_ids",
+            "return_meta_info",
+            "input_ids",
+            "stop_regex",
+            "custom_logit_processor",
+            "custom_params",
+            "max_dynamic_patch",
+            "min_dynamic_patch",
+            "rid",
+            "extra_key",
+            "cache_salt",
+            "bootstrap_host",
+            "bootstrap_port",
+            "bootstrap_room",
+            "routed_dp_rank",
+            "disagg_prefill_dp_rank",
+            "data_parallel_rank",
+        ];
+
+        for field in new_fields {
+            assert!(
+                EXTENSION_FIELD_NAMES.contains(&field),
+                "{field} missing from EXTENSION_FIELD_NAMES — would leak to OpenAI"
+            );
+
+            let mut payload = json!({ "model": "gpt-4o", field: 1 });
+            strip_sglang_fields(&mut payload);
+            assert!(
+                payload.get(field).is_none(),
+                "strip_sglang_fields did not remove {field}",
+            );
+        }
+    }
+
+    #[test]
+    fn strip_sglang_fields_preserves_unknown_keys() {
+        // Custom passthrough fields the user adds but aren't in EXTENSION_FIELD_NAMES
+        // should survive the strip — only known SGLang extension keys are
+        // removed.
+        let mut payload = json!({
+            "model": "gpt-4o",
+            "custom_user_metadata": {"trace_id": "abc"},
+            "return_routed_experts": true,
+        });
+
+        strip_sglang_fields(&mut payload);
+
+        assert!(payload.get("custom_user_metadata").is_some());
+        assert!(payload.get("return_routed_experts").is_none());
     }
 }

--- a/sgl-model-gateway/src/routers/openai/router.rs
+++ b/sgl-model-gateway/src/routers/openai/router.rs
@@ -12,6 +12,7 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use bytes::Bytes;
 use data_connector::{ConversationId, ListParams, ResponseId, SortOrder};
 use futures_util::{future::join_all, StreamExt};
 use serde_json::{json, to_value, Value};
@@ -471,6 +472,7 @@ impl crate::routers::RouterTrait for OpenAIRouter {
         &self,
         headers: Option<&HeaderMap>,
         body: &ChatCompletionRequest,
+        _body_raw: Option<&Bytes>,
         model_id: Option<&str>,
     ) -> Response {
         let start = Instant::now();

--- a/sgl-model-gateway/src/routers/router_manager.rs
+++ b/sgl-model-gateway/src/routers/router_manager.rs
@@ -14,6 +14,7 @@ use axum::{
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
 };
+use bytes::Bytes;
 use dashmap::DashMap;
 use serde_json::Value;
 use tracing::{debug, info, warn};
@@ -495,6 +496,7 @@ impl RouterTrait for RouterManager {
         &self,
         headers: Option<&HeaderMap>,
         body: &GenerateRequest,
+        body_raw: Option<&Bytes>,
         model_id: Option<&str>,
     ) -> Response {
         // In IGW mode, resolve model_id and fail fast if not resolvable
@@ -513,7 +515,12 @@ impl RouterTrait for RouterManager {
 
         if let Some(router) = router {
             router
-                .route_generate(headers, body, effective_model_id.as_deref().or(model_id))
+                .route_generate(
+                    headers,
+                    body,
+                    body_raw,
+                    effective_model_id.as_deref().or(model_id),
+                )
                 .await
         } else {
             (
@@ -528,6 +535,7 @@ impl RouterTrait for RouterManager {
         &self,
         headers: Option<&HeaderMap>,
         body: &ChatCompletionRequest,
+        body_raw: Option<&Bytes>,
         model_id: Option<&str>,
     ) -> Response {
         // In IGW mode, resolve model_id and fail fast if not resolvable
@@ -548,7 +556,12 @@ impl RouterTrait for RouterManager {
 
         if let Some(router) = router {
             router
-                .route_chat(headers, body, effective_model_id.as_deref().or(model_id))
+                .route_chat(
+                    headers,
+                    body,
+                    body_raw,
+                    effective_model_id.as_deref().or(model_id),
+                )
                 .await
         } else {
             (

--- a/sgl-model-gateway/src/server.rs
+++ b/sgl-model-gateway/src/server.rs
@@ -7,12 +7,14 @@ use std::{
 };
 
 use axum::{
+    body::to_bytes,
     extract::{Path, Query, Request, State},
     http::StatusCode,
     response::{IntoResponse, Response},
     routing::{delete, get, post},
     Json, Router,
 };
+use bytes::Bytes;
 use rustls::crypto::ring;
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -21,6 +23,7 @@ use smg_mesh::{
 };
 use tokio::{signal, spawn};
 use tracing::{debug, error, info, warn, Level};
+use validator::Validate;
 use wfaas::LoggingSubscriber;
 
 use crate::{
@@ -49,7 +52,7 @@ use crate::{
         rerank::V1RerankReqInput,
         responses::{ResponsesGetParams, ResponsesRequest},
         tokenize::{AddTokenizerRequest, DetokenizeRequest, TokenizeRequest},
-        validated::ValidatedJson,
+        validated::{Normalizable, ValidatedJson},
         worker_spec::{WorkerConfigRequest, WorkerUpdateRequest},
     },
     routers::{
@@ -169,26 +172,90 @@ async fn get_model_info(State(state): State<Arc<AppState>>, req: Request) -> Res
     state.router.get_model_info(req).await
 }
 
+/// Read the raw request body up to a generous limit. Matches what
+/// `Json::from_request` would have consumed.
+async fn read_body_bytes(request: Request) -> Result<Bytes, Response> {
+    to_bytes(request.into_body(), usize::MAX)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(json!({
+                    "error": {
+                        "message": format!("Failed to read request body: {}", e),
+                        "type": "invalid_request_error",
+                        "code": "body_read_error"
+                    }
+                })),
+            )
+                .into_response()
+        })
+}
+
+fn json_parse_error(message: String) -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(json!({
+            "error": {
+                "message": message,
+                "type": "invalid_request_error",
+                "code": "json_parse_error"
+            }
+        })),
+    )
+        .into_response()
+}
+
 async fn generate(
     State(state): State<Arc<AppState>>,
     headers: http::HeaderMap,
-    Json(body): Json<GenerateRequest>,
+    request: Request,
 ) -> Response {
+    let body_raw = match read_body_bytes(request).await {
+        Ok(b) => b,
+        Err(resp) => return resp,
+    };
+    let body: GenerateRequest = match serde_json::from_slice(&body_raw) {
+        Ok(v) => v,
+        Err(e) => return json_parse_error(format!("Invalid JSON data: {}", e)),
+    };
     let model_id = body.model.as_deref();
     state
         .router
-        .route_generate(Some(&headers), &body, model_id)
+        .route_generate(Some(&headers), &body, Some(&body_raw), model_id)
         .await
 }
 
 async fn v1_chat_completions(
     State(state): State<Arc<AppState>>,
     headers: http::HeaderMap,
-    ValidatedJson(body): ValidatedJson<ChatCompletionRequest>,
+    request: Request,
 ) -> Response {
+    let body_raw = match read_body_bytes(request).await {
+        Ok(b) => b,
+        Err(resp) => return resp,
+    };
+    let mut body: ChatCompletionRequest = match serde_json::from_slice(&body_raw) {
+        Ok(v) => v,
+        Err(e) => return json_parse_error(format!("Invalid JSON data: {}", e)),
+    };
+    body.normalize();
+    if let Err(validation_errors) = body.validate() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": {
+                    "message": validation_errors.to_string(),
+                    "type": "invalid_request_error",
+                    "code": 400
+                }
+            })),
+        )
+            .into_response();
+    }
     state
         .router
-        .route_chat(Some(&headers), &body, Some(&body.model))
+        .route_chat(Some(&headers), &body, Some(&body_raw), Some(&body.model))
         .await
 }
 

--- a/sgl-model-gateway/src/sglang_extensions.rs
+++ b/sgl-model-gateway/src/sglang_extensions.rs
@@ -1,0 +1,203 @@
+//! SGLang server extension fields.
+//!
+//! Request-body keys SGLang servers accept that other OpenAI-compatible
+//! backends (vendor APIs like OpenAI/Anthropic/etc.) reject as 400. Some
+//! of these names also happen to be defined on the upstream
+//! `openai-protocol` types we deserialize against and so do round-trip
+//! through the typed structs (e.g. `lora_path`, `bootstrap_host`); the
+//! list here is the *union* — every key that needs to be either stripped
+//! before forwarding to a non-SGLang backend or read out of the original
+//! request bytes by an SGLang-aware router.
+//!
+//! Two consumers:
+//!
+//! 1. Routers that proxy to non-SGLang backends (e.g.
+//!    [`crate::routers::openai::provider`]): they must strip every entry
+//!    in [`EXTENSION_FIELD_NAMES`] before forwarding, otherwise the
+//!    backend 400s.
+//!
+//! 2. Routers that need to *read* a flag's value (e.g. the PD HTTP
+//!    router branches on `return_routed_experts` to decide whether to
+//!    merge prefill/decode responses): the typed
+//!    `ChatCompletionRequest` / `GenerateRequest` drop fields that
+//!    aren't on the upstream types, so reading happens via
+//!    [`SglangExtensions`] from the original request bytes.
+//!
+//! Adding a new SGLang field:
+//! - If routers only need to forward/strip it, add the name to
+//!   [`EXTENSION_FIELD_NAMES`] so the OpenAI provider strips it.
+//! - If a router needs to read its value, also add a typed field to
+//!   [`SglangExtensions`]. The reflective test
+//!   `every_typed_extension_field_is_in_strip_list` enforces both lists
+//!   stay in sync.
+
+use serde::{Deserialize, Serialize};
+
+/// Every request-body key recognised as an SGLang extension. Source of
+/// truth for both stripping (OpenAI passthrough) and typed parsing.
+pub const EXTENSION_FIELD_NAMES: &[&str] = &[
+    "request_id",
+    "priority",
+    "top_k",
+    "min_p",
+    "min_tokens",
+    "regex",
+    "ebnf",
+    "json_schema",
+    "stop_token_ids",
+    "no_stop_trim",
+    "ignore_eos",
+    "continue_final_message",
+    "skip_special_tokens",
+    "lora_path",
+    "session_params",
+    "separate_reasoning",
+    "stream_reasoning",
+    "chat_template",
+    "chat_template_kwargs",
+    "return_hidden_states",
+    "return_routed_experts",
+    "return_cached_tokens_details",
+    "return_prompt_token_ids",
+    "return_meta_info",
+    "input_ids",
+    "stop_regex",
+    "custom_logit_processor",
+    "custom_params",
+    "max_dynamic_patch",
+    "min_dynamic_patch",
+    "use_audio_in_video",
+    "rid",
+    "extra_key",
+    "cache_salt",
+    "bootstrap_host",
+    "bootstrap_port",
+    "bootstrap_room",
+    "routed_dp_rank",
+    "disagg_prefill_dp_rank",
+    "data_parallel_rank",
+    "repetition_penalty",
+    "sampling_seed",
+    "custom_labels",
+    "backend_url",
+];
+
+/// Typed view over the SGLang extension fields the gateway *reads*.
+///
+/// Most extension fields are passthrough — the gateway forwards them to
+/// the backend without inspecting their values. Only the fields a router
+/// branches on are listed here. Add a field when a code path needs typed
+/// access; passthrough-only fields just need to be in
+/// [`EXTENSION_FIELD_NAMES`].
+///
+/// Deserialization is strict on type: `return_routed_experts: "yes"`
+/// returns a `serde_json::Error` rather than silently defaulting to
+/// `false`. The HTTP routers wrap this via
+/// [`crate::routers::http::parse_sglang_extensions`], which surfaces
+/// the error as a 400 `invalid_sglang_extension` response.
+#[derive(Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(default)]
+pub struct SglangExtensions {
+    pub return_routed_experts: bool,
+}
+
+impl SglangExtensions {
+    /// Parse extensions from the original request bytes. Missing fields
+    /// take their `Default` value; type-mismatched fields return `Err`.
+    pub fn parse(body_raw: &[u8]) -> Result<Self, serde_json::Error> {
+        serde_json::from_slice(body_raw)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_returns_default_when_field_absent() {
+        let bytes = br#"{"model": "x", "messages": []}"#;
+        let ext = SglangExtensions::parse(bytes).unwrap();
+        assert!(!ext.return_routed_experts);
+    }
+
+    #[test]
+    fn parse_reads_return_routed_experts_when_present() {
+        let bytes = br#"{"return_routed_experts": true}"#;
+        let ext = SglangExtensions::parse(bytes).unwrap();
+        assert!(ext.return_routed_experts);
+    }
+
+    #[test]
+    fn parse_rejects_wrong_type_for_return_routed_experts() {
+        // Strict type check is the whole point of this struct: a typo
+        // like passing a string should surface as 400, not silently
+        // default to false.
+        let bytes = br#"{"return_routed_experts": "yes"}"#;
+        let err = SglangExtensions::parse(bytes).unwrap_err();
+        assert!(
+            err.to_string().contains("return_routed_experts")
+                || err.to_string().contains("boolean"),
+            "error should mention the offending field or expected type: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_ignores_unknown_extension_fields() {
+        // Forward-compat: a future SGLang field we don't yet read
+        // shouldn't fail extension parsing — it just rides through via
+        // the raw bytes the caller still holds.
+        let bytes = br#"{"some_future_field": 42, "return_routed_experts": true}"#;
+        let ext = SglangExtensions::parse(bytes).unwrap();
+        assert!(ext.return_routed_experts);
+    }
+
+    #[test]
+    fn extension_field_names_includes_known_sglang_keys() {
+        // Spot-check a few entries to catch accidental deletions.
+        for required in [
+            "return_routed_experts",
+            "return_hidden_states",
+            "bootstrap_host",
+            "data_parallel_rank",
+            "sampling_seed",
+        ] {
+            assert!(
+                EXTENSION_FIELD_NAMES.contains(&required),
+                "{required} missing from EXTENSION_FIELD_NAMES"
+            );
+        }
+    }
+
+    #[test]
+    fn extension_field_names_are_unique() {
+        // `EXTENSION_FIELD_NAMES` is morally a set, expressed as a slice
+        // for `pub const` ergonomics. Duplicates wouldn't break behaviour
+        // (`contains` would still answer correctly) but would hide a
+        // careless rebase merge that re-added an entry. Cheap to check.
+        let mut seen = std::collections::HashSet::new();
+        for name in EXTENSION_FIELD_NAMES {
+            assert!(seen.insert(*name), "duplicate entry: {name}");
+        }
+    }
+
+    #[test]
+    fn every_typed_extension_field_is_in_strip_list() {
+        // Cross-invariant: every field on `SglangExtensions` (the typed
+        // read-list) MUST also live in `EXTENSION_FIELD_NAMES` (the strip
+        // list). Otherwise a router that forwards to OpenAI would leak
+        // the extension and trigger a 400 — even though we read it
+        // server-side. Catches "added a typed field, forgot the
+        // strip-list" foot-gun without any extra code at the call sites.
+        let serialized =
+            serde_json::to_value(SglangExtensions::default()).expect("SglangExtensions serialises");
+        let object = serialized
+            .as_object()
+            .expect("SglangExtensions serialises to a JSON object");
+        for key in object.keys() {
+            assert!(
+                EXTENSION_FIELD_NAMES.contains(&key.as_str()),
+                "typed SglangExtensions field {key} missing from EXTENSION_FIELD_NAMES",
+            );
+        }
+    }
+}

--- a/sgl-model-gateway/tests/api/api_endpoints_test.rs
+++ b/sgl-model-gateway/tests/api/api_endpoints_test.rs
@@ -41,6 +41,8 @@ mod health_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -85,6 +87,8 @@ mod health_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             },
             MockWorkerConfig {
                 port: 18004,
@@ -92,6 +96,8 @@ mod health_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             },
         ])
         .await;
@@ -118,6 +124,8 @@ mod health_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -154,6 +162,8 @@ mod generation_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -195,6 +205,8 @@ mod generation_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -231,6 +243,8 @@ mod generation_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 1.0, // Always fail
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -262,6 +276,8 @@ mod generation_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -307,6 +323,8 @@ mod model_info_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -345,6 +363,8 @@ mod model_info_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -390,6 +410,8 @@ mod model_info_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -503,6 +525,8 @@ mod model_info_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             },
             MockWorkerConfig {
                 port: 18205,
@@ -510,6 +534,8 @@ mod model_info_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             },
         ])
         .await;
@@ -547,6 +573,8 @@ mod model_info_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 1.0, // Always fail
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -584,6 +612,8 @@ mod router_policy_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             },
             MockWorkerConfig {
                 port: 18802,
@@ -591,6 +621,8 @@ mod router_policy_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             },
         ])
         .await;
@@ -626,6 +658,8 @@ mod router_policy_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -656,6 +690,8 @@ mod responses_endpoint_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -695,6 +731,8 @@ mod responses_endpoint_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -736,6 +774,8 @@ mod responses_endpoint_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -785,6 +825,8 @@ mod responses_endpoint_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -834,6 +876,8 @@ mod responses_endpoint_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -932,6 +976,8 @@ mod responses_endpoint_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             },
             MockWorkerConfig {
                 port: 18961,
@@ -939,6 +985,8 @@ mod responses_endpoint_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             },
         ])
         .await;
@@ -1006,6 +1054,8 @@ mod error_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -1043,6 +1093,8 @@ mod error_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -1097,6 +1149,8 @@ mod error_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             }],
         )
         .await;
@@ -1116,6 +1170,8 @@ mod error_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -1154,6 +1210,8 @@ mod error_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -1192,6 +1250,8 @@ mod cache_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -1230,6 +1290,8 @@ mod cache_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             },
             MockWorkerConfig {
                 port: 18503,
@@ -1237,6 +1299,8 @@ mod cache_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             },
         ])
         .await;
@@ -1300,6 +1364,8 @@ mod load_balancing_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             },
             MockWorkerConfig {
                 port: 18602,
@@ -1307,6 +1373,8 @@ mod load_balancing_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             },
         ])
         .await;
@@ -1354,6 +1422,8 @@ mod pd_mode_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         });
 
         let mut decode_worker = MockWorker::new(MockWorkerConfig {
@@ -1362,6 +1432,8 @@ mod pd_mode_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         });
 
         let prefill_url = prefill_worker.start().await.unwrap();
@@ -1416,6 +1488,8 @@ mod request_id_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -1535,6 +1609,8 @@ mod request_id_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             }],
         )
         .await;
@@ -1578,6 +1654,8 @@ mod rerank_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -1623,6 +1701,338 @@ mod rerank_tests {
         for result in results {
             assert!(result.get("document").is_some());
         }
+
+        ctx.shutdown().await;
+    }
+}
+
+/// SGLang extension fields (`return_routed_experts`, `routed_dp_rank`, etc.)
+/// must reach the backend in unified (non-PD) mode too — same SGLang
+/// server, same wire contract, just no prefill/decode merge step. The
+/// gateway forwards the raw request bytes (instead of re-serialising the
+/// typed struct) so unknown fields aren't lost to the typed-deserialize-
+/// then-reserialize round-trip.
+#[cfg(test)]
+mod sglang_extension_tests {
+    use super::*;
+
+    /// `return_routed_experts: true` against a unified backend should
+    /// surface the field in the response. This is pure passthrough — no
+    /// merge — so the test is satisfied by the field arriving back from
+    /// the worker (which echoes whatever `routed_experts_b64` it was
+    /// configured with).
+    #[tokio::test]
+    async fn test_unified_generate_forwards_routed_experts() {
+        let expected_b64 =
+            base64::Engine::encode(&base64::engine::general_purpose::STANDARD, [10u8, 20, 30]);
+        let ctx = AppTestContext::new(vec![MockWorkerConfig {
+            port: 18120,
+            routed_experts_b64: Some(expected_b64.clone()),
+            ..MockWorkerConfig::default()
+        }])
+        .await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "text": "hi",
+            "return_routed_experts": true,
+            "stream": false,
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/generate")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+        assert_eq!(
+            body.pointer("/meta_info/routed_experts")
+                .and_then(serde_json::Value::as_str),
+            Some(expected_b64.as_str()),
+            "unified /generate should pass routed_experts through (got: {body})"
+        );
+
+        // The backend must have actually seen the flag — proves the
+        // gateway didn't strip it during the typed-struct round-trip.
+        let received = &ctx.workers[0].recorded_requests()[0];
+        assert_eq!(received.get("return_routed_experts"), Some(&json!(true)));
+
+        ctx.shutdown().await;
+    }
+
+    /// Same shape for `/v1/chat/completions`.
+    #[tokio::test]
+    async fn test_unified_chat_forwards_routed_experts() {
+        let expected_b64 =
+            base64::Engine::encode(&base64::engine::general_purpose::STANDARD, [40u8, 50, 60]);
+        let ctx = AppTestContext::new(vec![MockWorkerConfig {
+            port: 18121,
+            routed_experts_b64: Some(expected_b64.clone()),
+            ..MockWorkerConfig::default()
+        }])
+        .await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "model": "mock-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "return_routed_experts": true,
+            "stream": false,
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+        assert_eq!(
+            body.pointer("/sglext/routed_experts")
+                .and_then(serde_json::Value::as_str),
+            Some(expected_b64.as_str()),
+            "unified chat completion should pass routed_experts through (got: {body})"
+        );
+
+        let received = &ctx.workers[0].recorded_requests()[0];
+        assert_eq!(received.get("return_routed_experts"), Some(&json!(true)));
+
+        ctx.shutdown().await;
+    }
+
+    /// Companion of the PD passthrough test: unknown SGLang fields
+    /// (`routed_dp_rank` and any future-named field) must survive the
+    /// gateway round-trip in unified mode too.
+    #[tokio::test]
+    async fn test_unified_forwards_unknown_sglang_extensions() {
+        let ctx = AppTestContext::new(vec![MockWorkerConfig {
+            port: 18122,
+            ..MockWorkerConfig::default()
+        }])
+        .await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "text": "hi",
+            "stream": false,
+            "routed_dp_rank": 3,
+            "some_future_field": {"nested": [1, 2, 3]},
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/generate")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let received = &ctx.workers[0].recorded_requests()[0];
+        assert_eq!(received.get("routed_dp_rank"), Some(&json!(3)));
+        assert_eq!(
+            received.get("some_future_field"),
+            Some(&json!({"nested": [1, 2, 3]})),
+        );
+
+        ctx.shutdown().await;
+    }
+
+    /// Mirrors the PD test: malformed extension types must yield 400.
+    /// The PD path returned 400 from day one; the unified path was added
+    /// in this PR so without an explicit test a regression here would
+    /// be invisible.
+    #[tokio::test]
+    async fn test_unified_chat_rejects_invalid_extension_type() {
+        let ctx = AppTestContext::new(vec![MockWorkerConfig {
+            port: 18123,
+            ..MockWorkerConfig::default()
+        }])
+        .await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "model": "mock-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "return_routed_experts": "yes",
+            "stream": false,
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        ctx.shutdown().await;
+    }
+
+    /// Companion of the chat reject test, covering `/generate`. Each
+    /// route does its own `parse_sglang_extensions` call.
+    #[tokio::test]
+    async fn test_unified_generate_rejects_invalid_extension_type() {
+        let ctx = AppTestContext::new(vec![MockWorkerConfig {
+            port: 18124,
+            ..MockWorkerConfig::default()
+        }])
+        .await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "text": "hi",
+            "return_routed_experts": "yes",
+            "stream": false,
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/generate")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        ctx.shutdown().await;
+    }
+
+    /// `dp_aware: true` takes a separate code path inside
+    /// `Router::send_typed_request` — it parses the body into a
+    /// `serde_json::Value` and injects `data_parallel_rank`. A
+    /// regression that read from `to_value(typed_req)` again instead of
+    /// from `body_raw_to_value` would silently strip every SGLang
+    /// extension field for dp-aware deployments while every other
+    /// unified test would still pass. The mock worker advertises
+    /// `dp_size: 1` via /server_info, so a single backend yields one
+    /// DPAwareWorker at rank 0.
+    #[tokio::test]
+    async fn test_unified_dp_aware_forwards_extensions() {
+        let port: u16 = 18125;
+        let config = RouterConfig::builder()
+            .regular_mode(vec![format!("http://127.0.0.1:{port}")])
+            .random_policy()
+            .enable_dp_aware()
+            .host("127.0.0.1")
+            .port(3850)
+            .max_payload_size(256 * 1024 * 1024)
+            .request_timeout_secs(600)
+            .worker_startup_timeout_secs(5)
+            .worker_startup_check_interval_secs(1)
+            .max_concurrent_requests(64)
+            .queue_timeout_secs(60)
+            .build_unchecked();
+
+        let ctx = AppTestContext::new_with_config(
+            config,
+            vec![MockWorkerConfig {
+                port,
+                ..MockWorkerConfig::default()
+            }],
+        )
+        .await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "text": "hi",
+            "stream": false,
+            "return_routed_experts": true,
+            "routed_dp_rank": 7,
+            "some_future_field": "preserved",
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/generate")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let received = &ctx.workers[0].recorded_requests()[0];
+        assert_eq!(
+            received.get("data_parallel_rank"),
+            Some(&json!(0)),
+            "dp_aware path must inject data_parallel_rank"
+        );
+        assert_eq!(
+            received.get("return_routed_experts"),
+            Some(&json!(true)),
+            "extension fields must survive the dp_aware JSON re-injection"
+        );
+        assert_eq!(received.get("routed_dp_rank"), Some(&json!(7)));
+        assert_eq!(received.get("some_future_field"), Some(&json!("preserved")));
+
+        ctx.shutdown().await;
+    }
+
+    /// Unified router has no merge step, so streaming + return_routed_experts
+    /// should *not* be rejected (unlike PD where the SSE pipeline can't
+    /// merge prefill/decode bytes). The SGLang server emits the SglExt
+    /// envelope on each stream chunk (see `ChatCompletionStreamResponse`
+    /// upstream); the gateway just proxies SSE bytes unchanged. This
+    /// test pins that contract: 200 OK + the flag actually reached the
+    /// backend (proving the gateway didn't silently drop it during the
+    /// streaming setup).
+    #[tokio::test]
+    async fn test_unified_chat_streaming_forwards_routed_experts() {
+        let ctx = AppTestContext::new(vec![MockWorkerConfig {
+            port: 18126,
+            ..MockWorkerConfig::default()
+        }])
+        .await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "model": "mock-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "return_routed_experts": true,
+            "stream": true,
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "unified streaming + return_routed_experts must not be rejected"
+        );
+
+        let received = &ctx.workers[0].recorded_requests()[0];
+        assert_eq!(
+            received.get("return_routed_experts"),
+            Some(&json!(true)),
+            "the streaming setup must still forward the flag to the backend"
+        );
+        assert_eq!(received.get("stream"), Some(&json!(true)));
 
         ctx.shutdown().await;
     }

--- a/sgl-model-gateway/tests/api/request_formats_test.rs
+++ b/sgl-model-gateway/tests/api/request_formats_test.rs
@@ -17,6 +17,8 @@ mod request_format_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -64,6 +66,8 @@ mod request_format_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -112,6 +116,8 @@ mod request_format_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -164,6 +170,8 @@ mod request_format_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -198,6 +206,8 @@ mod request_format_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -246,6 +256,8 @@ mod request_format_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 

--- a/sgl-model-gateway/tests/api/responses_api_test.rs
+++ b/sgl-model-gateway/tests/api/responses_api_test.rs
@@ -39,6 +39,8 @@ async fn test_non_streaming_mcp_minimal_e2e_with_persistence() {
         health_status: HealthStatus::Healthy,
         response_delay_ms: 0,
         fail_rate: 0.0,
+        routed_experts_b64: None,
+        always_emit_routed_experts: false,
     });
     let worker_url = worker.start().await.expect("start worker");
 
@@ -532,6 +534,8 @@ async fn test_multi_turn_loop_with_mcp() {
         health_status: HealthStatus::Healthy,
         response_delay_ms: 0,
         fail_rate: 0.0,
+        routed_experts_b64: None,
+        always_emit_routed_experts: false,
     });
     let worker_url = worker.start().await.expect("start worker");
 
@@ -685,6 +689,8 @@ async fn test_max_tool_calls_limit() {
         health_status: HealthStatus::Healthy,
         response_delay_ms: 0,
         fail_rate: 0.0,
+        routed_experts_b64: None,
+        always_emit_routed_experts: false,
     });
     let worker_url = worker.start().await.expect("start worker");
 
@@ -803,6 +809,8 @@ async fn setup_streaming_mcp_test() -> (
         health_status: HealthStatus::Healthy,
         response_delay_ms: 0,
         fail_rate: 0.0,
+        routed_experts_b64: None,
+        always_emit_routed_experts: false,
     });
     let worker_url = worker.start().await.expect("start worker");
 

--- a/sgl-model-gateway/tests/api/streaming_tests.rs
+++ b/sgl-model-gateway/tests/api/streaming_tests.rs
@@ -17,6 +17,8 @@ mod tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 10,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -47,6 +49,8 @@ mod tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 10,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -91,6 +95,8 @@ mod tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 10,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -118,6 +124,8 @@ mod tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 1.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -140,6 +148,8 @@ mod tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 100,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -171,6 +181,8 @@ mod tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 10,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 

--- a/sgl-model-gateway/tests/common/mock_worker.rs
+++ b/sgl-model-gateway/tests/common/mock_worker.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use axum::{
-    extract::{Json, Path, State},
+    extract::{FromRef, Json, Path, State},
     http::StatusCode,
     response::{
         sse::{Event, KeepAlive},
@@ -19,9 +19,42 @@ use axum::{
     Router,
 };
 use futures_util::stream::{self, StreamExt};
-use serde_json::json;
+use serde_json::{json, Value};
 use tokio::sync::RwLock;
 use uuid::Uuid;
+
+/// Shared state passed to mock-worker axum handlers. Wraps the existing
+/// config Arc plus a request-capture buffer so tests can assert what
+/// payload the worker actually received (e.g. that SGLang extension
+/// fields the typed openai-protocol struct dropped were forwarded
+/// verbatim by the gateway).
+///
+/// `recorded_requests` is intentionally `std::sync::Mutex` rather than
+/// `tokio::sync::Mutex`: the lock is only held across `.push(...)` and
+/// is released before any `.await`, so a sync mutex is correct *and*
+/// keeps the recording API non-async (tests can call `record(...)`
+/// from anywhere). Don't "fix" this to `tokio::sync::Mutex` — that
+/// would introduce an `await` opportunity inside the critical section.
+#[derive(Clone)]
+pub struct MockWorkerState {
+    pub config: Arc<RwLock<MockWorkerConfig>>,
+    recorded_requests: Arc<Mutex<Vec<Value>>>,
+}
+
+impl MockWorkerState {
+    fn record(&self, payload: Value) {
+        self.recorded_requests.lock().unwrap().push(payload);
+    }
+}
+
+// Existing handlers extract `Arc<RwLock<MockWorkerConfig>>` directly via
+// State; this lets them keep working unchanged when the router is built
+// with `MockWorkerState`.
+impl FromRef<MockWorkerState> for Arc<RwLock<MockWorkerConfig>> {
+    fn from_ref(state: &MockWorkerState) -> Self {
+        state.config.clone()
+    }
+}
 
 /// Configuration for mock worker behavior
 #[derive(Clone)]
@@ -31,6 +64,20 @@ pub struct MockWorkerConfig {
     pub health_status: HealthStatus,
     pub response_delay_ms: u64,
     pub fail_rate: f32,
+    /// Optional base64 string injected as `meta_info.routed_experts` (and
+    /// `sglext.routed_experts` for chat completions) in non-streaming
+    /// generate/chat responses, but **only when the request payload has
+    /// `return_routed_experts: true`**. The gating is what makes
+    /// forwarding tests load-bearing: a buggy gateway that strips the
+    /// flag would not see this echoed back. Used by PD-merge integration
+    /// tests to verify merge across prefill+decode.
+    pub routed_experts_b64: Option<String>,
+    /// Bypass the `return_routed_experts: true` gate on `routed_experts_b64`.
+    /// Set this for the no-merge inverse test, which configures both
+    /// workers to emit experts unconditionally so it can prove the
+    /// gateway *did not* merge when the flag is absent (the only way to
+    /// observe a non-merge is for both backends to emit something).
+    pub always_emit_routed_experts: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -50,6 +97,7 @@ pub enum HealthStatus {
 /// Mock worker server for testing
 pub struct MockWorker {
     config: Arc<RwLock<MockWorkerConfig>>,
+    recorded_requests: Arc<Mutex<Vec<Value>>>,
     shutdown_handle: Option<tokio::task::JoinHandle<()>>,
     shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
 }
@@ -58,9 +106,18 @@ impl MockWorker {
     pub fn new(config: MockWorkerConfig) -> Self {
         Self {
             config: Arc::new(RwLock::new(config)),
+            recorded_requests: Arc::new(Mutex::new(Vec::new())),
             shutdown_handle: None,
             shutdown_tx: None,
         }
+    }
+
+    /// Snapshot of every JSON request body received by `/generate` and
+    /// `/v1/chat/completions` since startup, in arrival order. Tests use
+    /// this to verify the gateway forwarded SGLang extension fields the
+    /// typed openai-protocol struct drops on deserialise.
+    pub fn recorded_requests(&self) -> Vec<Value> {
+        self.recorded_requests.lock().unwrap().clone()
     }
 
     /// Start the mock worker server
@@ -77,6 +134,11 @@ impl MockWorker {
             port
         } else {
             port
+        };
+
+        let state = MockWorkerState {
+            config,
+            recorded_requests: self.recorded_requests.clone(),
         };
 
         let app = Router::new()
@@ -96,7 +158,7 @@ impl MockWorker {
             )
             .route("/flush_cache", post(flush_cache_handler))
             .route("/v1/models", get(v1_models_handler))
-            .with_state(config);
+            .with_state(state);
 
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
         self.shutdown_tx = Some(shutdown_tx);
@@ -295,10 +357,11 @@ async fn model_info_handler(State(config): State<Arc<RwLock<MockWorkerConfig>>>)
 }
 
 async fn generate_handler(
-    State(config): State<Arc<RwLock<MockWorkerConfig>>>,
-    Json(payload): Json<serde_json::Value>,
+    State(state): State<MockWorkerState>,
+    Json(payload): Json<Value>,
 ) -> Response {
-    let config = config.read().await;
+    state.record(payload.clone());
+    let config = state.config.read().await;
     let worker_id = format!("worker-{}", config.port);
 
     if should_fail(&config).await {
@@ -381,35 +444,47 @@ async fn generate_handler(
         )
             .into_response()
     } else {
-        (
-            [("x-worker-id", worker_id)],
-            Json(json!({
-                "text": "This is a mock response.",
-                "meta_info": {
-                    "prompt_tokens": 10,
-                    "completion_tokens": 5,
-                    "completion_tokens_wo_jump_forward": 5,
-                    "input_token_logprobs": null,
-                    "output_token_logprobs": null,
-                    "first_token_latency": config.response_delay_ms as f64 / 1000.0,
-                    "time_to_first_token": config.response_delay_ms as f64 / 1000.0,
-                    "time_per_output_token": 0.01,
-                    "finish_reason": {
-                        "type": "stop",
-                        "reason": "length"
-                    }
+        let mut body = json!({
+            "text": "This is a mock response.",
+            "meta_info": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "completion_tokens_wo_jump_forward": 5,
+                "input_token_logprobs": null,
+                "output_token_logprobs": null,
+                "first_token_latency": config.response_delay_ms as f64 / 1000.0,
+                "time_to_first_token": config.response_delay_ms as f64 / 1000.0,
+                "time_per_output_token": 0.01,
+                "finish_reason": {
+                    "type": "stop",
+                    "reason": "length"
                 }
-            })),
-        )
-            .into_response()
+            }
+        });
+        // Only echo routed_experts when the request actually asked for
+        // it. Without this gate, forwarding tests would pass even if
+        // the gateway stripped `return_routed_experts` from the request.
+        // `always_emit_routed_experts` is the explicit opt-out for the
+        // no-merge inverse test.
+        let client_asked_for_experts = payload
+            .get("return_routed_experts")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if client_asked_for_experts || config.always_emit_routed_experts {
+            if let Some(b64) = config.routed_experts_b64.as_deref() {
+                body["meta_info"]["routed_experts"] = json!(b64);
+            }
+        }
+        ([("x-worker-id", worker_id)], Json(body)).into_response()
     }
 }
 
 async fn chat_completions_handler(
-    State(config): State<Arc<RwLock<MockWorkerConfig>>>,
-    Json(payload): Json<serde_json::Value>,
+    State(state): State<MockWorkerState>,
+    Json(payload): Json<Value>,
 ) -> Response {
-    let config = config.read().await;
+    state.record(payload.clone());
+    let config = state.config.read().await;
 
     if should_fail(&config).await {
         return (
@@ -465,7 +540,7 @@ async fn chat_completions_handler(
             .keep_alive(KeepAlive::default())
             .into_response()
     } else {
-        Json(json!({
+        let mut body = json!({
             "id": format!("chatcmpl-{}", Uuid::new_v4()),
             "object": "chat.completion",
             "created": timestamp,
@@ -483,14 +558,29 @@ async fn chat_completions_handler(
                 "completion_tokens": 5,
                 "total_tokens": 15
             }
-        }))
-        .into_response()
+        });
+        // Only echo routed_experts when the request actually asked for
+        // it (see generate_handler for rationale).
+        let client_asked_for_experts = payload
+            .get("return_routed_experts")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if client_asked_for_experts || config.always_emit_routed_experts {
+            if let Some(b64) = config.routed_experts_b64.as_deref() {
+                // SGLang chat responses surface routed_experts under
+                // `sglext` (the merge code in pd_router.rs walks both
+                // `meta_info` and `sglext`); use sglext here so chat
+                // tests exercise that path.
+                body["sglext"] = json!({ "routed_experts": b64 });
+            }
+        }
+        Json(body).into_response()
     }
 }
 
 async fn completions_handler(
     State(config): State<Arc<RwLock<MockWorkerConfig>>>,
-    Json(payload): Json<serde_json::Value>,
+    Json(payload): Json<Value>,
 ) -> Response {
     let config = config.read().await;
 
@@ -570,7 +660,7 @@ async fn completions_handler(
 
 async fn responses_handler(
     State(config): State<Arc<RwLock<MockWorkerConfig>>>,
-    Json(payload): Json<serde_json::Value>,
+    Json(payload): Json<Value>,
 ) -> Response {
     let config = config.read().await;
 
@@ -1217,7 +1307,7 @@ fn response_exists_for_port(port: u16, response_id: &str) -> bool {
 // Minimal rerank handler returning mock results; router shapes final response
 async fn rerank_handler(
     State(config): State<Arc<RwLock<MockWorkerConfig>>>,
-    Json(payload): Json<serde_json::Value>,
+    Json(payload): Json<Value>,
 ) -> impl IntoResponse {
     let config = config.read().await;
 
@@ -1273,6 +1363,8 @@ impl Default for MockWorkerConfig {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }
     }
 }

--- a/sgl-model-gateway/tests/common/test_config.rs
+++ b/sgl-model-gateway/tests/common/test_config.rs
@@ -240,10 +240,7 @@ impl TestWorkerConfig {
     pub fn healthy(port: u16) -> MockWorkerConfig {
         MockWorkerConfig {
             port,
-            worker_type: WorkerType::Regular,
-            health_status: HealthStatus::Healthy,
-            response_delay_ms: 0,
-            fail_rate: 0.0,
+            ..MockWorkerConfig::default()
         }
     }
 
@@ -256,10 +253,8 @@ impl TestWorkerConfig {
     pub fn unhealthy(port: u16) -> MockWorkerConfig {
         MockWorkerConfig {
             port,
-            worker_type: WorkerType::Regular,
             health_status: HealthStatus::Unhealthy,
-            response_delay_ms: 0,
-            fail_rate: 0.0,
+            ..MockWorkerConfig::default()
         }
     }
 
@@ -267,10 +262,8 @@ impl TestWorkerConfig {
     pub fn slow(port: u16, delay_ms: u64) -> MockWorkerConfig {
         MockWorkerConfig {
             port,
-            worker_type: WorkerType::Regular,
-            health_status: HealthStatus::Healthy,
             response_delay_ms: delay_ms,
-            fail_rate: 0.0,
+            ..MockWorkerConfig::default()
         }
     }
 
@@ -285,10 +278,8 @@ impl TestWorkerConfig {
     pub fn flaky(port: u16, fail_rate: f32) -> MockWorkerConfig {
         MockWorkerConfig {
             port,
-            worker_type: WorkerType::Regular,
-            health_status: HealthStatus::Healthy,
-            response_delay_ms: 0,
             fail_rate,
+            ..MockWorkerConfig::default()
         }
     }
 
@@ -297,9 +288,7 @@ impl TestWorkerConfig {
         MockWorkerConfig {
             port,
             worker_type: WorkerType::Decode,
-            health_status: HealthStatus::Healthy,
-            response_delay_ms: 0,
-            fail_rate: 0.0,
+            ..MockWorkerConfig::default()
         }
     }
 
@@ -308,9 +297,7 @@ impl TestWorkerConfig {
         MockWorkerConfig {
             port,
             worker_type: WorkerType::Prefill,
-            health_status: HealthStatus::Healthy,
-            response_delay_ms: 0,
-            fail_rate: 0.0,
+            ..MockWorkerConfig::default()
         }
     }
 }

--- a/sgl-model-gateway/tests/inflight_tracker_test.rs
+++ b/sgl-model-gateway/tests/inflight_tracker_test.rs
@@ -22,6 +22,8 @@ async fn test_multiple_concurrent_requests_tracking() {
         health_status: HealthStatus::Healthy,
         response_delay_ms: 50,
         fail_rate: 0.0,
+        routed_experts_b64: None,
+        always_emit_routed_experts: false,
     }])
     .await;
 
@@ -65,6 +67,8 @@ async fn test_inflight_request_appears_in_bucket() {
         health_status: HealthStatus::Healthy,
         response_delay_ms: 2000,
         fail_rate: 0.0,
+        routed_experts_b64: None,
+        always_emit_routed_experts: false,
     }])
     .await;
 
@@ -119,6 +123,8 @@ async fn test_failed_request_still_deregisters() {
         health_status: HealthStatus::Healthy,
         response_delay_ms: 0,
         fail_rate: 1.0,
+        routed_experts_b64: None,
+        always_emit_routed_experts: false,
     }])
     .await;
 

--- a/sgl-model-gateway/tests/otel_tracing_test.rs
+++ b/sgl-model-gateway/tests/otel_tracing_test.rs
@@ -112,6 +112,8 @@ async fn test_router_with_tracing() {
         health_status: HealthStatus::Healthy,
         response_delay_ms: 0,
         fail_rate: 0.0,
+        routed_experts_b64: None,
+        always_emit_routed_experts: false,
     });
 
     let worker_url = mock_worker.start().await.unwrap();

--- a/sgl-model-gateway/tests/routing/header_forwarding_test.rs
+++ b/sgl-model-gateway/tests/routing/header_forwarding_test.rs
@@ -29,6 +29,8 @@ mod header_forwarding_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -91,6 +93,8 @@ mod header_forwarding_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             }],
         )
         .await;
@@ -135,6 +139,8 @@ mod header_forwarding_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -178,6 +184,8 @@ mod header_forwarding_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -226,6 +234,8 @@ mod header_forwarding_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -270,6 +280,8 @@ mod header_forwarding_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 

--- a/sgl-model-gateway/tests/routing/payload_size_test.rs
+++ b/sgl-model-gateway/tests/routing/payload_size_test.rs
@@ -44,6 +44,8 @@ mod payload_size_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             }],
         )
         .await;
@@ -96,6 +98,8 @@ mod payload_size_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             }],
         )
         .await;
@@ -150,6 +154,8 @@ mod payload_size_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             }],
         )
         .await;
@@ -209,6 +215,8 @@ mod payload_size_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             }],
         )
         .await;
@@ -265,6 +273,8 @@ mod payload_size_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             }],
         )
         .await;

--- a/sgl-model-gateway/tests/routing/pd_routing_test.rs
+++ b/sgl-model-gateway/tests/routing/pd_routing_test.rs
@@ -7,7 +7,8 @@ use axum::{
     extract::Request,
     http::{header::CONTENT_TYPE, StatusCode},
 };
-use serde_json::json;
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine};
+use serde_json::{json, Value};
 use smg::config::RouterConfig;
 use tower::ServiceExt;
 
@@ -189,6 +190,8 @@ mod pd_routing_tests {
                     health_status: HealthStatus::Healthy,
                     response_delay_ms: 0,
                     fail_rate: 1.0, // Failing decode worker
+                    routed_experts_b64: None,
+                    always_emit_routed_experts: false,
                 },
                 TestWorkerConfig::decode(19822), // Healthy decode worker
             ],
@@ -215,6 +218,539 @@ mod pd_routing_tests {
             resp.status(),
             StatusCode::OK,
             "Request should succeed via retry to healthy decode worker"
+        );
+
+        ctx.shutdown().await;
+    }
+
+    /// Verify the end-to-end PD merge of `routed_experts` for chat
+    /// completions. The prefill worker emits a base64 prefix; the decode
+    /// worker emits the prefix plus per-token suffix bytes; the gateway
+    /// must concatenate `prefill_bytes ++ decode_bytes[prefill_len..]`
+    /// into the response payload under `sglext.routed_experts`.
+    ///
+    /// This test exercises the full chain
+    /// `v1_chat_completions -> RouterTrait::route_chat -> PDRouter ->
+    ///  execute_dual_dispatch -> merge_prefill_json` and would catch a
+    /// regression where `body_raw` collapses to `None` upstream (every
+    /// existing pd_router unit test would still pass).
+    #[tokio::test]
+    async fn test_pd_chat_completion_merges_routed_experts() {
+        let prefill_bytes = vec![1u8, 2, 3, 4];
+        let decode_bytes = vec![1u8, 2, 3, 4, 9, 9, 9, 9];
+        let prefill_b64 = BASE64_STANDARD.encode(&prefill_bytes);
+        let decode_b64 = BASE64_STANDARD.encode(&decode_bytes);
+
+        let config = RouterConfig::builder()
+            .prefill_decode_mode(
+                vec![("http://127.0.0.1:19840".to_string(), None)],
+                vec!["http://127.0.0.1:19841".to_string()],
+            )
+            .power_of_two_policy(1)
+            .host("127.0.0.1")
+            .port(3840)
+            .max_payload_size(256 * 1024 * 1024)
+            .request_timeout_secs(600)
+            .worker_startup_timeout_secs(5)
+            .worker_startup_check_interval_secs(1)
+            .max_concurrent_requests(64)
+            .queue_timeout_secs(60)
+            .build_unchecked();
+
+        let mut prefill_worker = TestWorkerConfig::prefill(19840);
+        prefill_worker.routed_experts_b64 = Some(prefill_b64.clone());
+        let mut decode_worker = TestWorkerConfig::decode(19841);
+        decode_worker.routed_experts_b64 = Some(decode_b64.clone());
+
+        let ctx =
+            AppTestContext::new_with_config(config, vec![prefill_worker, decode_worker]).await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "model": "mock-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "return_routed_experts": true,
+            "stream": false,
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "PD chat completion with return_routed_experts should succeed"
+        );
+
+        let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: Value =
+            serde_json::from_slice(&body_bytes).expect("response body should be JSON");
+
+        let merged_b64 = body
+            .pointer("/sglext/routed_experts")
+            .and_then(Value::as_str)
+            .unwrap_or_else(|| panic!("expected sglext.routed_experts in merged response: {body}"));
+        let merged_bytes = BASE64_STANDARD
+            .decode(merged_b64)
+            .expect("merged routed_experts should be valid base64");
+
+        // Expected: prefill prefix + decode-suffix beyond prefill_len.
+        let mut expected = prefill_bytes.clone();
+        expected.extend_from_slice(&decode_bytes[prefill_bytes.len()..]);
+        assert_eq!(
+            merged_bytes, expected,
+            "merged routed_experts should be prefill prefix + decode suffix",
+        );
+
+        ctx.shutdown().await;
+    }
+
+    /// Same shape as `test_pd_chat_completion_merges_routed_experts` but
+    /// for `/generate`. The merge helper inspects both `meta_info` and
+    /// `sglext`; the chat test exercises the `sglext` branch and this
+    /// test exercises the `meta_info` branch. A regression that broke
+    /// just the `meta_info` path (or that forgot to thread `body_raw`
+    /// into `route_generate`) would slip past the chat test.
+    #[tokio::test]
+    async fn test_pd_generate_merges_routed_experts() {
+        let prefill_bytes = vec![1u8, 2, 3, 4];
+        let decode_bytes = vec![1u8, 2, 3, 4, 9, 9, 9, 9];
+        let prefill_b64 = BASE64_STANDARD.encode(&prefill_bytes);
+        let decode_b64 = BASE64_STANDARD.encode(&decode_bytes);
+
+        let config = RouterConfig::builder()
+            .prefill_decode_mode(
+                vec![("http://127.0.0.1:19842".to_string(), None)],
+                vec!["http://127.0.0.1:19843".to_string()],
+            )
+            .power_of_two_policy(1)
+            .host("127.0.0.1")
+            .port(3842)
+            .max_payload_size(256 * 1024 * 1024)
+            .request_timeout_secs(600)
+            .worker_startup_timeout_secs(5)
+            .worker_startup_check_interval_secs(1)
+            .max_concurrent_requests(64)
+            .queue_timeout_secs(60)
+            .build_unchecked();
+
+        let mut prefill_worker = TestWorkerConfig::prefill(19842);
+        prefill_worker.routed_experts_b64 = Some(prefill_b64);
+        let mut decode_worker = TestWorkerConfig::decode(19843);
+        decode_worker.routed_experts_b64 = Some(decode_b64);
+
+        let ctx =
+            AppTestContext::new_with_config(config, vec![prefill_worker, decode_worker]).await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "text": "hi",
+            "return_routed_experts": true,
+            "stream": false,
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/generate")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "PD /generate with return_routed_experts should succeed"
+        );
+
+        let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&body_bytes).unwrap();
+
+        let merged_b64 = body
+            .pointer("/meta_info/routed_experts")
+            .and_then(Value::as_str)
+            .unwrap_or_else(|| {
+                panic!("expected meta_info.routed_experts in merged response: {body}")
+            });
+        let merged_bytes = BASE64_STANDARD.decode(merged_b64).unwrap();
+
+        let mut expected = prefill_bytes.clone();
+        expected.extend_from_slice(&decode_bytes[prefill_bytes.len()..]);
+        assert_eq!(merged_bytes, expected);
+
+        ctx.shutdown().await;
+    }
+
+    /// `return_routed_experts` must be a bool. The PD router parses it
+    /// into a strict-typed `SglangExtensions` and surfaces type errors as
+    /// a 400 — protects against a regression where the parse error gets
+    /// swallowed and the request silently runs without merge enabled.
+    /// `route_chat` and `route_generate` each have their own copy of the
+    /// parse-then-`bad_request` ladder, so this test covers chat and the
+    /// next one covers `/generate`.
+    #[tokio::test]
+    async fn test_pd_chat_rejects_invalid_extension_type() {
+        let config = RouterConfig::builder()
+            .prefill_decode_mode(
+                vec![("http://127.0.0.1:19844".to_string(), None)],
+                vec!["http://127.0.0.1:19845".to_string()],
+            )
+            .power_of_two_policy(1)
+            .host("127.0.0.1")
+            .port(3844)
+            .max_payload_size(256 * 1024 * 1024)
+            .request_timeout_secs(600)
+            .worker_startup_timeout_secs(5)
+            .worker_startup_check_interval_secs(1)
+            .max_concurrent_requests(64)
+            .queue_timeout_secs(60)
+            .build_unchecked();
+
+        let ctx = AppTestContext::new_with_config(
+            config,
+            vec![
+                TestWorkerConfig::prefill(19844),
+                TestWorkerConfig::decode(19845),
+            ],
+        )
+        .await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "model": "mock-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "return_routed_experts": "yes",
+            "stream": false,
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "non-bool return_routed_experts should yield 400"
+        );
+
+        ctx.shutdown().await;
+    }
+
+    /// Companion of the chat test: `route_generate` has its own copy of
+    /// the parse-then-`bad_request` ladder. A regression that loosens
+    /// only the generate-side parser (e.g. log-and-default-false) would
+    /// slip past the chat test.
+    #[tokio::test]
+    async fn test_pd_generate_rejects_invalid_extension_type() {
+        let config = RouterConfig::builder()
+            .prefill_decode_mode(
+                vec![("http://127.0.0.1:19850".to_string(), None)],
+                vec!["http://127.0.0.1:19851".to_string()],
+            )
+            .power_of_two_policy(1)
+            .host("127.0.0.1")
+            .port(3850)
+            .max_payload_size(256 * 1024 * 1024)
+            .request_timeout_secs(600)
+            .worker_startup_timeout_secs(5)
+            .worker_startup_check_interval_secs(1)
+            .max_concurrent_requests(64)
+            .queue_timeout_secs(60)
+            .build_unchecked();
+
+        let ctx = AppTestContext::new_with_config(
+            config,
+            vec![
+                TestWorkerConfig::prefill(19850),
+                TestWorkerConfig::decode(19851),
+            ],
+        )
+        .await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "text": "hi",
+            "return_routed_experts": "yes",
+            "stream": false,
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/generate")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        ctx.shutdown().await;
+    }
+
+    /// Streaming PD with `return_routed_experts: true` is unsupported:
+    /// the SSE pipeline does not merge routed_experts across
+    /// prefill/decode, so silently honouring the flag would return
+    /// decode-only bytes with no signal to the user. The router rejects
+    /// with 400 up front. This test covers the chat-completions branch.
+    #[tokio::test]
+    async fn test_pd_chat_streaming_rejects_routed_experts() {
+        let config = RouterConfig::builder()
+            .prefill_decode_mode(
+                vec![("http://127.0.0.1:19852".to_string(), None)],
+                vec!["http://127.0.0.1:19853".to_string()],
+            )
+            .power_of_two_policy(1)
+            .host("127.0.0.1")
+            .port(3852)
+            .max_payload_size(256 * 1024 * 1024)
+            .request_timeout_secs(600)
+            .worker_startup_timeout_secs(5)
+            .worker_startup_check_interval_secs(1)
+            .max_concurrent_requests(64)
+            .queue_timeout_secs(60)
+            .build_unchecked();
+
+        let ctx = AppTestContext::new_with_config(
+            config,
+            vec![
+                TestWorkerConfig::prefill(19852),
+                TestWorkerConfig::decode(19853),
+            ],
+        )
+        .await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "model": "mock-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "return_routed_experts": true,
+            "stream": true,
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "streaming + return_routed_experts should yield 400"
+        );
+
+        ctx.shutdown().await;
+    }
+
+    /// Companion of the chat streaming reject test, covering `/generate`.
+    /// `route_generate` has its own copy of the streaming-incompat guard.
+    #[tokio::test]
+    async fn test_pd_generate_streaming_rejects_routed_experts() {
+        let config = RouterConfig::builder()
+            .prefill_decode_mode(
+                vec![("http://127.0.0.1:19854".to_string(), None)],
+                vec!["http://127.0.0.1:19855".to_string()],
+            )
+            .power_of_two_policy(1)
+            .host("127.0.0.1")
+            .port(3854)
+            .max_payload_size(256 * 1024 * 1024)
+            .request_timeout_secs(600)
+            .worker_startup_timeout_secs(5)
+            .worker_startup_check_interval_secs(1)
+            .max_concurrent_requests(64)
+            .queue_timeout_secs(60)
+            .build_unchecked();
+
+        let ctx = AppTestContext::new_with_config(
+            config,
+            vec![
+                TestWorkerConfig::prefill(19854),
+                TestWorkerConfig::decode(19855),
+            ],
+        )
+        .await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "text": "hi",
+            "return_routed_experts": true,
+            "stream": true,
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/generate")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        ctx.shutdown().await;
+    }
+
+    /// Inverse of the merge tests: when `return_routed_experts` is
+    /// absent, the gateway must NOT merge — the response should mirror
+    /// what the decode worker produced. Catches a regression that
+    /// always-merges regardless of the flag.
+    #[tokio::test]
+    async fn test_pd_does_not_merge_when_flag_absent() {
+        // Asymmetric so a stray merge would be visible: prefill bytes
+        // are not a prefix of decode bytes, so concatenation would
+        // produce something different from either side alone.
+        let prefill_b64 = BASE64_STANDARD.encode(b"PPPP");
+        let decode_b64 = BASE64_STANDARD.encode(b"DDDD");
+
+        let config = RouterConfig::builder()
+            .prefill_decode_mode(
+                vec![("http://127.0.0.1:19846".to_string(), None)],
+                vec!["http://127.0.0.1:19847".to_string()],
+            )
+            .power_of_two_policy(1)
+            .host("127.0.0.1")
+            .port(3846)
+            .max_payload_size(256 * 1024 * 1024)
+            .request_timeout_secs(600)
+            .worker_startup_timeout_secs(5)
+            .worker_startup_check_interval_secs(1)
+            .max_concurrent_requests(64)
+            .queue_timeout_secs(60)
+            .build_unchecked();
+
+        // always_emit_routed_experts bypasses the request-flag gate so
+        // both workers emit experts regardless of what the request asked
+        // for. That's how this test observes "no merge happened" — the
+        // response must equal decode's bytes alone.
+        let mut prefill_worker = TestWorkerConfig::prefill(19846);
+        prefill_worker.routed_experts_b64 = Some(prefill_b64);
+        prefill_worker.always_emit_routed_experts = true;
+        let mut decode_worker = TestWorkerConfig::decode(19847);
+        decode_worker.routed_experts_b64 = Some(decode_b64.clone());
+        decode_worker.always_emit_routed_experts = true;
+
+        let ctx =
+            AppTestContext::new_with_config(config, vec![prefill_worker, decode_worker]).await;
+        let app = ctx.create_app().await;
+
+        // Note: no return_routed_experts field at all.
+        let payload = json!({
+            "text": "hi",
+            "stream": false,
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/generate")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&body_bytes).unwrap();
+
+        let response_b64 = body
+            .pointer("/meta_info/routed_experts")
+            .and_then(Value::as_str)
+            .unwrap_or_else(|| panic!("expected meta_info.routed_experts in response: {body}"));
+        assert_eq!(
+            response_b64, decode_b64,
+            "without the flag, response should pass through decode's routed_experts unchanged"
+        );
+
+        ctx.shutdown().await;
+    }
+
+    /// SGLang fields the typed openai-protocol struct drops — like
+    /// `routed_dp_rank`, `disagg_prefill_dp_rank`, or any future
+    /// extension — must reach the backend verbatim. The PD router does
+    /// this by forwarding the raw request bytes; this test pins that
+    /// contract by inspecting what the mock worker actually received.
+    #[tokio::test]
+    async fn test_pd_forwards_unknown_sglang_extensions() {
+        let config = RouterConfig::builder()
+            .prefill_decode_mode(
+                vec![("http://127.0.0.1:19848".to_string(), None)],
+                vec!["http://127.0.0.1:19849".to_string()],
+            )
+            .power_of_two_policy(1)
+            .host("127.0.0.1")
+            .port(3848)
+            .max_payload_size(256 * 1024 * 1024)
+            .request_timeout_secs(600)
+            .worker_startup_timeout_secs(5)
+            .worker_startup_check_interval_secs(1)
+            .max_concurrent_requests(64)
+            .queue_timeout_secs(60)
+            .build_unchecked();
+
+        let ctx = AppTestContext::new_with_config(
+            config,
+            vec![
+                TestWorkerConfig::prefill(19848),
+                TestWorkerConfig::decode(19849),
+            ],
+        )
+        .await;
+        let app = ctx.create_app().await;
+
+        // routed_dp_rank is in EXTENSION_FIELD_NAMES but NOT in typed
+        // SglangExtensions, so it'll only survive if the gateway forwards
+        // raw bytes. some_future_field tests the forward-compat case.
+        let payload = json!({
+            "text": "hi",
+            "stream": false,
+            "routed_dp_rank": 7,
+            "some_future_field": {"nested": [1, 2, 3]},
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/generate")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let prefill_recv = ctx.workers[0].recorded_requests();
+        assert_eq!(
+            prefill_recv.len(),
+            1,
+            "prefill worker should have received exactly one request"
+        );
+        let received = &prefill_recv[0];
+        assert_eq!(
+            received.get("routed_dp_rank"),
+            Some(&json!(7)),
+            "routed_dp_rank should pass through to backend (received: {received})"
+        );
+        assert_eq!(
+            received.get("some_future_field"),
+            Some(&json!({"nested": [1, 2, 3]})),
+            "unknown fields should pass through to backend (received: {received})"
         );
 
         ctx.shutdown().await;

--- a/sgl-model-gateway/tests/routing/service_discovery_test.rs
+++ b/sgl-model-gateway/tests/routing/service_discovery_test.rs
@@ -44,6 +44,8 @@ mod service_discovery_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             }],
         )
         .await;
@@ -92,6 +94,8 @@ mod service_discovery_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             }],
         )
         .await;
@@ -151,6 +155,8 @@ mod service_discovery_tests {
                     health_status: HealthStatus::Healthy,
                     response_delay_ms: 0,
                     fail_rate: 0.0,
+                    routed_experts_b64: None,
+                    always_emit_routed_experts: false,
                 },
                 MockWorkerConfig {
                     port: 20004,
@@ -158,6 +164,8 @@ mod service_discovery_tests {
                     health_status: HealthStatus::Healthy,
                     response_delay_ms: 0,
                     fail_rate: 0.0,
+                    routed_experts_b64: None,
+                    always_emit_routed_experts: false,
                 },
             ],
         )
@@ -235,6 +243,8 @@ mod service_discovery_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             }],
         )
         .await;

--- a/sgl-model-gateway/tests/routing/test_openai_routing.rs
+++ b/sgl-model-gateway/tests/routing/test_openai_routing.rs
@@ -635,7 +635,9 @@ async fn test_unsupported_endpoints() {
         rid: None,
     };
 
-    let response = router.route_generate(None, &generate_request, None).await;
+    let response = router
+        .route_generate(None, &generate_request, None, None)
+        .await;
     assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
 
     let completion_request = create_minimal_completion_request();
@@ -666,7 +668,7 @@ async fn test_openai_router_chat_completion_with_mock() {
     chat_request.temperature = Some(0.7);
 
     // Route the request
-    let response = router.route_chat(None, &chat_request, None).await;
+    let response = router.route_chat(None, &chat_request, None, None).await;
 
     // Should get a successful response from mock server
     assert_eq!(response.status(), StatusCode::OK);
@@ -709,7 +711,7 @@ async fn test_openai_e2e_with_server() {
                         serde_json::from_str(&body_str).unwrap();
 
                     router
-                        .route_chat(Some(&parts.headers), &chat_request, None)
+                        .route_chat(Some(&parts.headers), &chat_request, None, None)
                         .await
                 }
             }
@@ -769,7 +771,7 @@ async fn test_openai_router_chat_streaming_with_mock() {
     });
     let chat_request: ChatCompletionRequest = serde_json::from_value(val).unwrap();
 
-    let response = router.route_chat(None, &chat_request, None).await;
+    let response = router.route_chat(None, &chat_request, None, None).await;
     assert_eq!(response.status(), StatusCode::OK);
 
     // Should be SSE
@@ -806,7 +808,7 @@ async fn test_openai_router_circuit_breaker() {
 
     // First few requests should fail and record failures
     for _ in 0..3 {
-        let response = router.route_chat(None, &chat_request, None).await;
+        let response = router.route_chat(None, &chat_request, None, None).await;
         // Should get either an error or circuit breaker response
         assert!(
             response.status() == StatusCode::INTERNAL_SERVER_ERROR


### PR DESCRIPTION
## Summary

Plumbs SGLang RL extension fields through `sgl-model-gateway` by threading the original request bytes alongside the typed request struct, so unknown fields (those the upstream `openai-protocol` crate drops) reach SGLang backends verbatim.

Covers both HTTP routers — **PD** (with prefill/decode response merging) and **unified** (pure passthrough, including the `dp_aware` code path). Strict-typed validation (`return_routed_experts: "yes"` → 400) is consistent across both routers, and PD additionally rejects `stream=true && return_routed_experts=true` (its SSE pipeline doesn't merge prefill/decode bytes).

Adapts two upstream commits from [`radixark/sgl-router-for-miles`](https://github.com/radixark/sgl-router-for-miles):

- [`ba49367`](https://github.com/radixark/sgl-router-for-miles/commit/ba49367c92415ec1728614abe19c9cb336309946) — extends `ChatCompletionRequest` / `GenerateRequest` with the SGLang RL extension fields. We don't own `openai-protocol` (`=1.0.0` pin), so instead of vendoring or forking, the gateway treats those fields as a side channel.
- [`96d630e`](https://github.com/radixark/sgl-router-for-miles/commit/96d630e3997b02d10a85fbe920942d6ab6e9b0a9) — plumbs `return_routed_experts` through `PDRequestContext`; adds `merge_routed_experts_in_json` (base64 prefix-suffix concat) and `merge_prefill_json` so PD-mode responses merge experts the way they already merge logprobs.

## Design

- **`src/sglang_extensions.rs` (new)** is the single source of truth for SGLang extension field names. Holds `EXTENSION_FIELD_NAMES` (the full strip-list, used by the OpenAI provider) and a strict-typed `SglangExtensions { return_routed_experts: bool }` used by routers that branch on the flag. Adding a new SGLang field that's purely passthrough goes in the const list; a field the gateway needs to *read* gets a typed entry. Two reflective tests pin the invariants: every typed field must be in the strip list, and the strip list has no duplicates.
- **`src/routers/http/mod.rs`** hosts shared helpers `parse_sglang_extensions` and `body_raw_to_value`, used by both HTTP routers so error surfacing and raw-bytes parsing are identical across PD and unified.
- **`RouterTrait::route_chat` / `route_generate`** gain `body_raw: Option<&Bytes>`. Both HTTP routers consume it: PD uses it for forwarding *and* merge branching; unified uses it for pure forwarding (no merge — only one backend per request). Both routers call `parse_sglang_extensions` and return `400 invalid_sglang_extension` on type mismatch. gRPC routers and the OpenAI provider ignore `body_raw`.
- **PD router rejects `stream=true && return_routed_experts=true`** with `400 streaming_routed_experts_unsupported` up front. The streaming SSE path does not merge `routed_experts`, so honouring the flag silently would return decode-only bytes with no signal to the user. **Unified streaming is not gated** — it has no merge step, and SGLang's per-chunk `SglExt` envelope (see `python/sglang/srt/entrypoints/openai/protocol.py::ChatCompletionStreamResponse`) flows through SSE proxying unchanged.
- **Unified router's `send_typed_request`** (both `dp_aware` and non-`dp_aware` branches) prefers raw client bytes via `body_raw_to_value` and falls back to typed serialization when raw is unavailable. The `dp_aware` branch parses raw → `Value`, injects `data_parallel_rank`, then sends — preserving SGLang extension fields that re-serialising the typed struct would have stripped.
- **`server.rs` `v1_chat_completions` and `generate` handlers** extract `Bytes` instead of `Json<T>` / `ValidatedJson<T>`; we manually deserialize, run normalize+validate (matching `ValidatedJson` semantics), and pass both raw + typed to the router.
- **`execute_dual_dispatch`** is now non-generic over `Value` rather than `<T: Serialize + Clone>`, so callers can hand it raw JSON when they have it (chat/generate) and serialize the typed struct only when they don't (completion/rerank).
- On the merge path, several silent failures were upgraded: base64 decode and PD-response parse failures `error!` with stable message prefixes; streaming prefill JSON parse failure `warn!`s instead of silently dropping logprobs; prefill body-read failure during merge `error!`s instead of warning.

## Why not vendor the protocol crate?

`openai-protocol` ships ~12 days apart on average (9 minor releases in 3.5 months as of writing) and lives inside the [`lightseekorg/smg`](https://github.com/lightseekorg/smg) monorepo at `crates/protocols/`. Vendoring or forking would put us on a continuous rebase treadmill while still leaving us with thousands of unchanged lines from the rest of the crate riding along. The `body_raw` side channel costs ~50 lines of trait surface and is implicitly forward-compatible — every future SGLang field rides through to the backend without a gateway PR (passthrough) or with a one-liner addition to `EXTENSION_FIELD_NAMES` (strip).

## Tests

- **`sglang_extensions`**: 7 unit tests (parse roundtrip, defaults, strict-type rejection, forward-compat unknown fields, strip-list spot check, every-typed-field-is-stripped invariant, no-duplicates invariant).
- **`pd_router`**: 12 unit tests on the merge helpers and the `needs_prefill_json_merge` truth table.
- **PD e2e** (`tests/routing/pd_routing_test.rs`):
  - `test_pd_chat_completion_merges_routed_experts` — `sglext` branch of the merge helper.
  - `test_pd_generate_merges_routed_experts` — `meta_info` branch.
  - `test_pd_chat_rejects_invalid_extension_type` — chat 400 on bad type.
  - `test_pd_generate_rejects_invalid_extension_type` — generate 400 on bad type.
  - `test_pd_chat_streaming_rejects_routed_experts` — streaming + flag → 400 (chat).
  - `test_pd_generate_streaming_rejects_routed_experts` — streaming + flag → 400 (generate).
  - `test_pd_does_not_merge_when_flag_absent` — inverse-direction: asymmetric workers, flag absent, response is decode-only.
  - `test_pd_forwards_unknown_sglang_extensions` — `routed_dp_rank` and unknown fields reach backend verbatim.
- **Unified e2e** (`tests/api/api_endpoints_test.rs::sglang_extension_tests`):
  - `test_unified_generate_forwards_routed_experts`, `test_unified_chat_forwards_routed_experts` — non-streaming passthrough.
  - `test_unified_chat_streaming_forwards_routed_experts` — proves there's no streaming gate on unified mode.
  - `test_unified_forwards_unknown_sglang_extensions` — unknown field passthrough.
  - `test_unified_chat_rejects_invalid_extension_type`, `test_unified_generate_rejects_invalid_extension_type` — unified 400 on bad type.
  - `test_unified_dp_aware_forwards_extensions` — covers `Router::send_typed_request`'s `dp_aware` branch.
- **Real-GPU e2e** (`e2e_test/router/test_routed_experts.py`): pytest suite driving a live SGLang MoE server through the gateway, covering both unified and PD topologies. Asserts the same contracts as the mock-based tests against the real `SglExt` protocol envelope so the suites can't drift apart silently.
- **`provider`**: 3 `strip_sglang_fields` tests (every known extension is stripped; new fields explicitly named; unknown user keys preserved).
- **`MockWorker`** grew a `recorded_requests` buffer (via new `MockWorkerState` + `FromRef` bridge) so forwarding tests can assert what backends actually received. `MockWorkerConfig` grew `routed_experts_b64` (gated on the request flag by default — guarantees forwarding tests are load-bearing, not vacuous) and `always_emit_routed_experts` (override for the no-merge inverse test).

## Test plan

- [x] `cargo build`, `cargo build --tests --benches` — clean.
- [x] `cargo test --no-fail-fast` — **576 mock tests pass**. The only failing test is `common::redis_test_server::test_redis_server_start_stop`, which requires a `redis-server` binary not installed on macOS dev hosts (pre-existing).
- [x] `cargo fmt --check` — clean.
- [x] `pre-commit run` on touched files — passes.
- [x] **Manual e2e against real SGLang MoE on H100** — `deepseek-ai/DeepSeek-V2-Lite` (64 routed experts, 6 selected/token), `--enable-return-routed-experts`:
  - Unified mode: chat `sglext.routed_experts` 7128 bytes, `/generate` `meta_info.routed_experts` 3240 bytes, `400 invalid_sglang_extension` on bad type, `200` + SSE on streaming + flag.
  - PD mode (1 prefill + 1 decode): chat merge 7128 bytes, `/generate` merge 3240 bytes, `400 streaming_routed_experts_unsupported` on streaming + flag, `400 invalid_sglang_extension` on bad type.

## Out of scope

- **Streaming `routed_experts` merge on PD.** The request now 400s instead of silently no-op'ing; implementing a streaming merge would let `stream=true && return_routed_experts=true` actually work on PD. **Unified streaming works today** — covered by `test_unified_chat_streaming_forwards_routed_experts` and verified on GPU.
- **Wiring `routed_dp_rank` / `disagg_prefill_dp_rank` to dispatch policy.** Both fields ride through to the backend via `body_raw` but no router consults them for selection yet.
- **Threading `body_raw` through `route_completion` / `route_responses` / `route_embeddings` / `route_classify` / `route_rerank`.** `server.rs` uses `Json<T>` extractors there, so SGLang extension fields on those endpoints are still dropped. Note that `CompletionResponse` and `CompletionStreamResponse` upstream do carry the typed `SglExt` envelope (see `protocol.py`), so this gap is real once anyone uses `/v1/completions` for `routed_experts` on SMG — file as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)