### PR TITLE
[CI] Fix stage-b-test-4-gpu-b200 silently skipped, hanging wait-for-stage-b

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -942,10 +942,7 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    # The `*-low-disk` label (resolved by `set-runner` to `4-gpu-b200-low-disk` or
-    # `4-gpu-b200-kernel-low-disk`) is advertised by both the existing large-disk B200
-    # runners and the new low-disk runner, so this job can land on either pool.
-    runs-on: ${{ needs.check-changes.outputs.b200_low_disk_runner }}
+    runs-on: ${{ needs.check-changes.outputs.b200_runner }}
     timeout-minutes: 240
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- `stage-b-test-4-gpu-b200`'s `runs-on:` references `needs.check-changes.outputs.b200_low_disk_runner`, which no longer exists — the revert in #24163 removed that output but did not revert the consumer-side change from #23505. GitHub Actions silently skips jobs whose `runs-on` evaluates to empty, so the job never runs.
- Meanwhile `wait-for-stage-b` still lists `stage-b-test-4-gpu-b200` with `expected_count: 1` (total 27), so it polls forever and eventually times out — observed e.g. on https://github.com/sgl-project/sglang/actions/runs/25195250632/job/73890630667 (`Progress: 26/26 jobs completed (expected 27)` on every iteration).
- Fix: restore `runs-on:` to `b200_runner` (the pre-#23505 value). This brings the consumer back in sync with the outputs that `check-changes` actually produces.

## Test plan
- [ ] CI on this PR: confirm `stage-b-test-4-gpu-b200` is dispatched and `wait-for-stage-b` completes without hitting the 27/27 timeout.
- [ ] Verify the dispatched job lands on a `4-gpu-b200` (or `4-gpu-b200-kernel`) runner as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)