### PR TITLE
[PD] Fix bootstrap metadata for parallel sampling

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -572,37 +572,65 @@ class GenerateReqInput(BaseReq):
 
     def _normalize_bootstrap_params(self, num):
         """Normalize bootstrap parameters for batch processing."""
+
+        def expand_bootstrap_list(values, param_name):
+            if len(values) == self.batch_size:
+                # Some routers only attach one value per original batch item.
+                return values * self.parallel_sample_num
+
+            # Some routers already expand bootstrap metadata for parallel samples.
+            return values
+
+        def expand_bootstrap_room_list(values):
+            if len(values) == self.batch_size:
+                # Expand per-original-request rooms to per-parallel-sample rooms.
+                # Rooms must differ across expanded requests to avoid PD transfer collisions.
+                return [
+                    room + sample_idx * self.batch_size if room is not None else None
+                    for sample_idx in range(self.parallel_sample_num)
+                    for room in values
+                ]
+
+            # Upstream already provided one room per expanded request.
+            return values
+
         # Normalize bootstrap_host
         if self.bootstrap_host is None:
             self.bootstrap_host = [None] * num
         elif not isinstance(self.bootstrap_host, list):
             self.bootstrap_host = [self.bootstrap_host] * num
-        elif isinstance(self.bootstrap_host, list):
-            self.bootstrap_host = self.bootstrap_host * self.parallel_sample_num
+        else:
+            self.bootstrap_host = expand_bootstrap_list(
+                self.bootstrap_host, "bootstrap_host"
+            )
 
         # Normalize bootstrap_port
         if self.bootstrap_port is None:
             self.bootstrap_port = [None] * num
         elif not isinstance(self.bootstrap_port, list):
             self.bootstrap_port = [self.bootstrap_port] * num
-        elif isinstance(self.bootstrap_port, list):
-            self.bootstrap_port = self.bootstrap_port * self.parallel_sample_num
+        else:
+            self.bootstrap_port = expand_bootstrap_list(
+                self.bootstrap_port, "bootstrap_port"
+            )
 
         # Normalize bootstrap_room
         if self.bootstrap_room is None:
             self.bootstrap_room = [None] * num
         elif not isinstance(self.bootstrap_room, list):
             self.bootstrap_room = [self.bootstrap_room + i for i in range(num)]
-        elif isinstance(self.bootstrap_room, list):
-            self.bootstrap_room = self.bootstrap_room * self.parallel_sample_num
+        else:
+            self.bootstrap_room = expand_bootstrap_room_list(self.bootstrap_room)
 
         # Normalize bootstrap_pair_key
         if self.bootstrap_pair_key is None:
             self.bootstrap_pair_key = [None] * num
         elif not isinstance(self.bootstrap_pair_key, list):
             self.bootstrap_pair_key = [self.bootstrap_pair_key] * num
-        elif isinstance(self.bootstrap_pair_key, list):
-            self.bootstrap_pair_key = self.bootstrap_pair_key * self.parallel_sample_num
+        else:
+            self.bootstrap_pair_key = expand_bootstrap_list(
+                self.bootstrap_pair_key, "bootstrap_pair_key"
+            )
 
     def _validate_session_params(self):
         """Validate that session parameters are properly formatted."""

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -573,7 +573,7 @@ class GenerateReqInput(BaseReq):
     def _normalize_bootstrap_params(self, num):
         """Normalize bootstrap parameters for batch processing."""
 
-        def expand_bootstrap_list(values, param_name):
+        def expand_bootstrap_list(values):
             if len(values) == self.batch_size:
                 # Some routers only attach one value per original batch item.
                 return values * self.parallel_sample_num
@@ -600,9 +600,7 @@ class GenerateReqInput(BaseReq):
         elif not isinstance(self.bootstrap_host, list):
             self.bootstrap_host = [self.bootstrap_host] * num
         else:
-            self.bootstrap_host = expand_bootstrap_list(
-                self.bootstrap_host, "bootstrap_host"
-            )
+            self.bootstrap_host = expand_bootstrap_list(self.bootstrap_host)
 
         # Normalize bootstrap_port
         if self.bootstrap_port is None:
@@ -610,9 +608,7 @@ class GenerateReqInput(BaseReq):
         elif not isinstance(self.bootstrap_port, list):
             self.bootstrap_port = [self.bootstrap_port] * num
         else:
-            self.bootstrap_port = expand_bootstrap_list(
-                self.bootstrap_port, "bootstrap_port"
-            )
+            self.bootstrap_port = expand_bootstrap_list(self.bootstrap_port)
 
         # Normalize bootstrap_room
         if self.bootstrap_room is None:
@@ -628,9 +624,7 @@ class GenerateReqInput(BaseReq):
         elif not isinstance(self.bootstrap_pair_key, list):
             self.bootstrap_pair_key = [self.bootstrap_pair_key] * num
         else:
-            self.bootstrap_pair_key = expand_bootstrap_list(
-                self.bootstrap_pair_key, "bootstrap_pair_key"
-            )
+            self.bootstrap_pair_key = expand_bootstrap_list(self.bootstrap_pair_key)
 
     def _validate_session_params(self):
         """Validate that session parameters are properly formatted."""

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1435,10 +1435,20 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
             # Expand requests, assign new rids for them, and send them
             for i in range(batch_size):
-                for _ in range(obj.parallel_sample_num):
+                for sample_idx in range(obj.parallel_sample_num):
+                    expanded_index = sample_idx * batch_size + i
                     tmp_obj = copy.copy(objs[i])
                     tokenized_obj = copy.copy(tokenized_objs[i])
                     tokenized_obj.rid = tmp_obj.regenerate_rid()
+                    for attr in (
+                        "bootstrap_host",
+                        "bootstrap_port",
+                        "bootstrap_room",
+                        "bootstrap_pair_key",
+                    ):
+                        value = getattr(obj, attr)[expanded_index]
+                        setattr(tmp_obj, attr, value)
+                        setattr(tokenized_obj, attr, value)
                     self._init_req_state(tmp_obj)
                     tokenized_obj.time_stats = self.rid_to_state[tmp_obj.rid].time_stats
                     self._send_one_request(tokenized_obj)

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -478,6 +478,57 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         req.normalize_batch_and_arguments()
         self.assertEqual(req.custom_logit_processor, ["processor1", "processor2"])
 
+    def test_bootstrap_params_with_parallel_sampling(self):
+        """Test bootstrap metadata normalization with parallel sampling."""
+        req = GenerateReqInput(
+            text=["Prompt 1", "Prompt 2"],
+            sampling_params={"n": 3},
+            bootstrap_host=["host1", "host2"],
+            bootstrap_port=[1001, 1002],
+            bootstrap_room=[10, 20],
+            bootstrap_pair_key=["key1", "key2"],
+        )
+        req.normalize_batch_and_arguments()
+
+        self.assertEqual(req.bootstrap_host, ["host1", "host2"] * 3)
+        self.assertEqual(req.bootstrap_port, [1001, 1002] * 3)
+        self.assertEqual(req.bootstrap_pair_key, ["key1", "key2"] * 3)
+        self.assertEqual(req.bootstrap_room, [10, 20, 12, 22, 14, 24])
+
+    def test_bootstrap_params_already_expanded_with_parallel_sampling(self):
+        """Test bootstrap metadata that is already expanded by the router."""
+        req = GenerateReqInput(
+            text="Prompt",
+            sampling_params={"n": 3},
+            bootstrap_host=["host1", "host1", "host1"],
+            bootstrap_port=[1001, 1001, 1001],
+            bootstrap_room=[10, 11, 12],
+            bootstrap_pair_key=["key1", "key2", "key3"],
+        )
+        req.normalize_batch_and_arguments()
+
+        self.assertEqual(req.bootstrap_host, ["host1", "host1", "host1"])
+        self.assertEqual(req.bootstrap_port, [1001, 1001, 1001])
+        self.assertEqual(req.bootstrap_room, [10, 11, 12])
+        self.assertEqual(req.bootstrap_pair_key, ["key1", "key2", "key3"])
+
+    def test_bootstrap_room_scalar_with_parallel_sampling(self):
+        """Test scalar bootstrap room expansion keeps rooms unique."""
+        req = GenerateReqInput(
+            text=["Prompt 1", "Prompt 2"],
+            sampling_params={"n": 2},
+            bootstrap_host="host",
+            bootstrap_port=1001,
+            bootstrap_room=10,
+            bootstrap_pair_key="key",
+        )
+        req.normalize_batch_and_arguments()
+
+        self.assertEqual(req.bootstrap_host, ["host"] * 4)
+        self.assertEqual(req.bootstrap_port, [1001] * 4)
+        self.assertEqual(req.bootstrap_pair_key, ["key"] * 4)
+        self.assertEqual(req.bootstrap_room, [10, 11, 12, 13])
+
     def test_session_params_handling(self):
         """Test handling of session_params."""
         # Test with dict


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->


## Motivation

In PD disaggregation mode, setting `parallel_sample_num > 1` currently produces inaccurate results or just hangs. The root cause is an incorrect `bootstrap_room`.

I reproduced this with GLM-5-w8a8 PD disaggregation (4 nodes, 2 for prefill 2 for decode):

```bash
curl http://localhost:8025/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "your-model-name",
    "messages": [
      {"role": "user", "content": "Hello, please write a short story."}
    ],
    "n": 4,
    "temperature": 0.8,
    "top_p": 0.95,
    "stream": false,
    "max_tokens": 100
  }'
```

Notice the `n` parameter — it spawns four sequences, but they all end up with the same room ID. This can be comfirmed by abort the request when it is hanging.
<img width="960" height="202" alt="图片" src="https://github.com/user-attachments/assets/9baff27c-00d5-49fa-baee-aea51388d081 " />

## Modifications

- Normalize `bootstrap_host`, `bootstrap_port`, `bootstrap_room`, and `bootstrap_pair_key` to support both original-batch and already-expanded list formats.
- Generate distinct `bootstrap_room` values when expanding per-original-batch rooms for parallel sampling.
- Update parallel sampling expansion in `TokenizerManager` to:
  - read bootstrap metadata from the normalized expanded slot
  - propagate bootstrap metadata to both request state and tokenized scheduler request


## Accuracy Tests

N/A. This change does not affect model computation or output accuracy.


## Speed Tests and Profiling

N/A. This change only affects request metadata normalization and routing metadata propagation.


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
