### PR TITLE
[Bug][VLM] Fix shared memory bug: deep copy mm_items to prevent cross…

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1443,6 +1443,12 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             for i in range(batch_size):
                 tmp_obj = copy.copy(objs[i])
                 tokenized_obj = copy.copy(tokenized_objs[i])
+                # Ensure independent mm_items so wrap_shm_features won't mutate the original
+                if hasattr(tokenized_obj, "mm_inputs") and tokenized_obj.mm_inputs:
+                    tokenized_obj.mm_inputs = copy.copy(tokenized_obj.mm_inputs)
+                    tokenized_obj.mm_inputs.mm_items = [
+                        copy.copy(item) for item in tokenized_obj.mm_inputs.mm_items
+                    ]
                 tokenized_obj.rid = tmp_obj.regenerate_rid()
                 tokenized_obj.sampling_params = copy.copy(tokenized_obj.sampling_params)
                 tokenized_obj.sampling_params.max_new_tokens = 0
@@ -1456,6 +1462,12 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 for _ in range(obj.parallel_sample_num):
                     tmp_obj = copy.copy(objs[i])
                     tokenized_obj = copy.copy(tokenized_objs[i])
+                    # Ensure independent mm_items so wrap_shm_features won't mutate the original
+                    if hasattr(tokenized_obj, "mm_inputs") and tokenized_obj.mm_inputs:
+                        tokenized_obj.mm_inputs = copy.copy(tokenized_obj.mm_inputs)
+                        tokenized_obj.mm_inputs.mm_items = [
+                            copy.copy(item) for item in tokenized_obj.mm_inputs.mm_items
+                        ]
                     tokenized_obj.rid = tmp_obj.regenerate_rid()
                     self._init_req_state(tmp_obj)
                     tokenized_obj.time_stats = self.rid_to_state[tmp_obj.rid].time_stats


### PR DESCRIPTION
## Motivation
When request parameter n > 1 (parallel_sample_num > 1), shallow-copied tokenized objects share the same mm_inputs.mm_items list. wrap_shm_features then mutates the shared list, causing incorrect multimodal data for subsequent requests. 
```
[2026-04-28 14:30:39 TP0] Scheduler hit an exception: Traceback (most recent call last):
  File "/opt/conda/lib/python3.12/site-packages/sglang/srt/managers/scheduler.py", line 3616, in run_scheduler_process
    scheduler.run_event_loop()
  File "/opt/conda/lib/python3.12/site-packages/sglang/srt/managers/scheduler.py", line 1300, in run_event_loop
    dispatch_event_loop(self)
  File "/opt/conda/lib/python3.12/site-packages/sglang/srt/managers/scheduler.py", line 3497, in dispatch_event_loop
    scheduler.event_loop_overlap()
  File "/opt/conda/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/site-packages/sglang/srt/managers/scheduler.py", line 1344, in event_loop_overlap
    recv_reqs = self.recv_requests()
                ^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/site-packages/sglang/srt/managers/scheduler.py", line 1443, in recv_requests
    recv_req = self.recv_from_tokenizer.recv_pyobj(zmq.NOBLOCK)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/site-packages/zmq/sugar/socket.py", line 990, in recv_pyobj
    return self._deserialize(msg, pickle.loads)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/site-packages/zmq/sugar/socket.py", line 828, in _deserialize
    return load(recvd)
           ^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/site-packages/sglang/srt/managers/mm_utils.py", line 1564, in __setstate__
    self._shm_handle = shared_memory.SharedMemory(name=self.shm_name)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/multiprocessing/shared_memory.py", line 104, in __init__
    self._fd = _posixshmem.shm_open(
               ^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/psm_538bbbf7'
```
## Root Cause
When n > 1 is set in the API request, multiple tokenized requests are created via shallow copy and share the same mm_items references pointing to the same shared memory files. When the scheduler consumes the first request, TP rank that calls materialize() first will unlink the shm file. 
When the tokenizer subsequently sends the remaining requests to the scheduler, they still reference the same now-deleted shm paths, causing errors.


## Fix
Fix by deep copying mm_inputs and mm_items for each expanded request, ensuring each request holds independent shm references that won't be invalidated when another request's shm is consumed and unlinked.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26021587602](https://github.com/sgl-project/sglang/actions/runs/26021587602)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** -- add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->