### PR TITLE
[Bug Fix] Fix NSA FA3 shape mismatch under DP Attention + EAGLE

### DIFF
--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -28,6 +28,24 @@ from sglang.srt.utils import (
     is_hip,
     is_npu,
 )
+from sglang.srt.distributed import (
+    get_attn_context_model_parallel_rank,
+    get_attn_context_model_parallel_world_size,
+)
+from sglang.srt.distributed.parallel_state import get_pp_group
+from sglang.srt.layers import deep_gemm_wrapper
+from sglang.srt.layers.attention.nsa.utils import (
+    is_nsa_enable_prefill_cp,
+    is_nsa_prefill_cp_in_seq_split,
+)
+from sglang.srt.layers.communicator import ScatterMode
+from sglang.srt.layers.linear import ReplicatedLinear
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.rotary_embedding import get_rope_wrapper
+from sglang.srt.layers.utils.cp_utils import cp_all_gather_rerange_output
+from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.server_args import get_global_server_args
 
 global _use_multi_stream
 _is_cuda = is_cuda()
@@ -48,25 +66,6 @@ if _use_aiter:
 if is_npu():
     import torch_npu
     from sglang.srt.hardware_backend.npu.utils import get_indexer_weight_stream
-
-from sglang.srt.distributed import (
-    get_attn_context_model_parallel_rank,
-    get_attn_context_model_parallel_world_size,
-)
-from sglang.srt.distributed.parallel_state import get_pp_group
-from sglang.srt.layers import deep_gemm_wrapper
-from sglang.srt.layers.attention.nsa.utils import (
-    is_nsa_enable_prefill_cp,
-    is_nsa_prefill_cp_in_seq_split,
-)
-from sglang.srt.layers.communicator import ScatterMode
-from sglang.srt.layers.linear import ReplicatedLinear
-from sglang.srt.layers.quantization.base_config import QuantizationConfig
-from sglang.srt.layers.rotary_embedding import get_rope_wrapper
-from sglang.srt.layers.utils.cp_utils import cp_all_gather_rerange_output
-from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch
-from sglang.srt.server_args import get_global_server_args
 
 _use_ag_after_qlora = envs.SGLANG_USE_AG_AFTER_QLORA.get()
 if TYPE_CHECKING:
@@ -939,10 +938,6 @@ class Indexer(MultiPlatformOp):
         assert len(weights.shape) == 3
         weights = weights.squeeze(-1)
 
-        # logits = deep_gemm.fp8_mqa_logits(q_fp8, kv_fp8, weights, ks, ke)
-        k_fp8_list = []
-        k_scale_list = []
-
         topk_indices_list = []
 
         block_tables = forward_batch.req_to_token_pool.req_to_token[
@@ -1365,7 +1360,7 @@ class Indexer(MultiPlatformOp):
                     q = self.wq_b(q_lora)[
                         0
                     ]  # [bs, 1536] @ [1536, 64 * 128] = [bs, 64 * 128]
-                    wq_b_event = self.alt_stream.record_event()
+                    self.alt_stream.record_event()
                     q = q.view(bs, self.n_heads, self.head_dim)  # [bs, 64, 128]
                     q_pe, q_nope = torch.split(
                         q,

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -489,6 +489,13 @@ class Indexer(MultiPlatformOp):
         # When attn_tp_size > 1 or in the MAX_LEN padding mode, padding may exist in the hidden states,
         # and it is necessary to extract the actual q length.
         q_offset = sum(metadata.get_nsa_extend_len_cpu())
+        if q_offset == 0:
+            return torch.full(
+                (q_fp8.shape[0], self.index_topk),
+                -1,
+                dtype=torch.int,
+                device=q_fp8.device,
+            )
         if _is_hip:
             from aiter.ops.triton.pa_mqa_logits import deepgemm_fp8_paged_mqa_logits
 

--- a/python/sglang/srt/layers/attention/nsa/utils.py
+++ b/python/sglang/srt/layers/attention/nsa/utils.py
@@ -9,6 +9,7 @@ from sglang.srt.layers.dp_attention import (
     get_attention_cp_rank,
     get_attention_cp_size,
     get_attention_dp_rank,
+    get_attention_tp_size,
 )
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils.common import ceil_align, ceil_div
@@ -88,6 +89,9 @@ def cal_padded_tokens(forward_batch: "ForwardBatch"):
     # calculate the actual token length after padding when attn_tp_size > 1 or in the MAX_LEN padding mode.
     global_num_tokens = forward_batch.global_num_tokens_cpu.copy()
     sync_group_size = len(global_num_tokens)
+    attn_tp_size = get_attention_tp_size()
+    for i in range(sync_group_size):
+        global_num_tokens[i] = ceil_align(global_num_tokens[i], attn_tp_size)
     attn_cp_size = get_attention_cp_size()
     for i in range(sync_group_size):
         global_num_tokens[i] = ceil_align(global_num_tokens[i], attn_cp_size)

--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -392,13 +392,13 @@ class NativeSparseAttnBackend(
         else:
             self.workspace_buffer = None
 
-    def get_device_int32_arange(self, l: int) -> torch.Tensor:
-        if l > len(self._arange_buf):
-            next_pow_of_2 = 1 << (l - 1).bit_length()
+    def get_device_int32_arange(self, length: int) -> torch.Tensor:
+        if length > len(self._arange_buf):
+            next_pow_of_2 = 1 << (length - 1).bit_length()
             self._arange_buf = torch.arange(
                 next_pow_of_2, device=self.device, dtype=torch.int32
             )
-        return self._arange_buf[:l]
+        return self._arange_buf[:length]
 
     def _transform_table_1_to_real(self, page_table: torch.Tensor) -> torch.Tensor:
         page_size = self.real_page_size

--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -423,7 +423,11 @@ class NativeSparseAttnBackend(
         cache_seqlens_int32 = (forward_batch.seq_lens + draft_token_num).to(torch.int32)
         cu_seqlens_k = compute_cu_seqlens(cache_seqlens_int32)
         assert forward_batch.seq_lens_cpu is not None
-        max_seqlen_k = int(forward_batch.seq_lens_cpu.max().item() + draft_token_num)
+        max_seqlen_k = (
+            int(forward_batch.seq_lens_cpu.max().item() + draft_token_num)
+            if batch_size > 0
+            else 0
+        )
         # [b, max_seqlen_k]
         page_table = forward_batch.req_to_token_pool.req_to_token[
             forward_batch.req_pool_indices, :max_seqlen_k
@@ -640,11 +644,17 @@ class NativeSparseAttnBackend(
 
         paged_mqa_schedule_metadata = None
         # DeepGEMM paged MQA logits path needs a schedule metadata tensor.
-        # Compute it once per forward batch and reuse it across layers.
-        if is_cuda() and (
-            forward_batch.forward_mode.is_decode_or_idle()
-            or forward_batch.forward_mode.is_target_verify()
-            or forward_batch.forward_mode.is_draft_extend()
+        # Compute it once per forward batch and reuse it across layers. When
+        # the real batch is empty (e.g. a DP-padded idle rank), there is no
+        # attention work to schedule, so keeping this field as None is correct.
+        if (
+            is_cuda()
+            and seqlens_expanded.numel() > 0
+            and (
+                forward_batch.forward_mode.is_decode_or_idle()
+                or forward_batch.forward_mode.is_target_verify()
+                or forward_batch.forward_mode.is_draft_extend()
+            )
         ):
             try:
                 import deep_gemm
@@ -1673,12 +1683,42 @@ class NativeSparseAttnBackend(
         qk_rope_dim = k_rope_cache.shape[-1]
         k_rope_cache = k_rope_cache.view(-1, page_size, 1, qk_rope_dim)
         c_kv_cache = c_kv_cache.view(-1, page_size, 1, v_head_dim)
+
+        # Under DP attention, prepare_mlp_sync_batch may pad Q across DP ranks.
+        padded_num_tokens = q_rope.shape[0]
+        assert q_nope.shape[0] == padded_num_tokens, (
+            f"FA3 Q/QV mismatch: q_rope_tokens={padded_num_tokens}, "
+            f"q_nope_tokens={q_nope.shape[0]}"
+        )
+        if padded_num_tokens == 0:
+            return q_nope.new_zeros(q_nope.shape)
+
+        metadata_num_tokens = cache_seqlens.shape[0]
+        assert metadata_num_tokens == padded_num_tokens, (
+            f"FA3 metadata/Q mismatch: metadata_num_tokens={metadata_num_tokens} "
+            f"!= padded_num_tokens={padded_num_tokens}"
+        )
+        assert page_table.shape[0] >= padded_num_tokens, (
+            f"FA3 page_table has fewer rows than Q: "
+            f"page_table_rows={page_table.shape[0]}, q_tokens={padded_num_tokens}"
+        )
+
+        expected_cu_len = padded_num_tokens + 1
+        cu_q_len = None if cu_seqlens_q is None else cu_seqlens_q.shape[0]
+        cu_k_len = None if cu_seqlens_k is None else cu_seqlens_k.shape[0]
+        assert (
+            cu_q_len is None or cu_q_len == expected_cu_len
+        ), f"FA3 cu_seqlens_q mismatch: got={cu_q_len}, expected={expected_cu_len}"
+        assert (
+            cu_k_len is None or cu_k_len == expected_cu_len
+        ), f"FA3 cu_seqlens_k mismatch: got={cu_k_len}, expected={expected_cu_len}"
+
         o = flash_attn_with_kvcache(
             q=q_rope,
             k_cache=k_rope_cache,
             v_cache=c_kv_cache,
             qv=q_nope,
-            page_table=page_table,
+            page_table=page_table[:padded_num_tokens],
             cache_seqlens=cache_seqlens,
             cu_seqlens_q=cu_seqlens_q,
             cu_seqlens_k_new=cu_seqlens_k,


### PR DESCRIPTION
## Summary
- Defer NSA draft attention metadata initialization on DP-attention EAGLE eager paths until after MLP-sync padding is applied.
- Track the real pre-padding batch/token sizes and initialize NSA metadata from a real-batch view while keeping the padded tensors for downstream DP sync.
- Make FA3 decode consume only real metadata rows and restore a padded output tail for shape compatibility.

fix #24233

## Test plan
- aligned with #24233:
  - Start latest main with NSA + DP Attention + EAGLE/NextN (`--tp 8 --dp 4 --enable-dp-attention --cuda-graph-max-bs 2 --speculative-algorithm NEXTN --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 --page-size 1`).
  - Vanilla latest main + `python3 test-dpa-repro.py http://localhost:30000 1v3` reproduces `RuntimeError: batch_size must be equal to batch_size_k`.
  - Patched latest main + the same `test-dpa-repro.py ... 1v3` client returns `Total: 4/4 ok, 0 failed` after warmup. The local repro script exits non-zero on the fixed path because it encodes "crash confirmed" as success.
  - Verified patched backend logs contain 0 `batch_size must be equal`, 0 FA3 metadata/page table mismatch, 0 scheduler exception, 0 HTTP 500, and 0 traceback/assertion.