### PR TITLE
Fix mamba pool index map size

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -545,7 +545,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
         # when max_running_requests > max_mamba_cache_size, indexing OOBs silently
         # in CUDA (only the assertion message prints; subsequent corrupted reads
         # surface as 'unspecified launch failure' in unrelated kernels).
-        mapping_size = max(self.size, size)
+        mapping_size = self.size
         self.req_index_to_mamba_index_mapping: torch.Tensor = torch.zeros(
             mapping_size, dtype=torch.int32, device=self.device
         )

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -540,13 +540,19 @@ class HybridReqToTokenPool(ReqToTokenPool):
         self.mamba_map = {layer_id: i for i, layer_id in enumerate(mamba_layer_ids)}
 
         self.device = device
+        # The mapping is indexed by req_pool_idx (range [0, self.size)), so it must
+        # be sized by req_to_token pool size, NOT the mamba pool size. Otherwise,
+        # when max_running_requests > max_mamba_cache_size, indexing OOBs silently
+        # in CUDA (only the assertion message prints; subsequent corrupted reads
+        # surface as 'unspecified launch failure' in unrelated kernels).
+        mapping_size = max(self.size, size)
         self.req_index_to_mamba_index_mapping: torch.Tensor = torch.zeros(
-            size, dtype=torch.int32, device=self.device
+            mapping_size, dtype=torch.int32, device=self.device
         )
         if enable_mamba_extra_buffer:
             self.req_index_to_mamba_ping_pong_track_buffer_mapping: torch.Tensor = (
                 torch.zeros(
-                    (size, self.mamba_ping_pong_track_buffer_size),
+                    (mapping_size, self.mamba_ping_pong_track_buffer_size),
                     dtype=torch.int32,
                     device=self.device,
                 )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

HybridReqToTokenPool.req_index_to_mamba_index_mapping (and the optional ping-pong track buffer) was sized by the mamba pool size, but it's indexed by req_pool_idx, which lives in [0,req_to_token_pool_size). When max_running_requests > max_mamba_cache_size, indexing into the mapping silently goes out of bounds on the GPU — only the assert message prints, and subsequent  corrupted reads surface as unspecified launch failure in unrelated kernels.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->



## Checklist

- [X] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [X] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
