### PR TITLE
fix: accept 0-indexed safetensors shard names in CI weight validator

### DIFF
--- a/python/sglang/srt/model_loader/ci_weight_validation.py
+++ b/python/sglang/srt/model_loader/ci_weight_validation.py
@@ -1426,7 +1426,10 @@ def _validate_sharded_model(
     for group_key, group_info in shard_groups.items():
         total_shards = group_info["total"]
         found_shards = set(group_info["found_shards"])
-        expected_shards = set(range(1, total_shards + 1))
+        # Shards may be 0-indexed (e.g. inclusionAI/Ring-2.5-1T) or 1-indexed
+        # (e.g. deepseek-ai/DeepSeek-V3); both are valid HF conventions.
+        min_idx = min(found_shards) if found_shards else 1
+        expected_shards = set(range(min_idx, min_idx + total_shards))
 
         # Check for missing shards
         missing_shards = expected_shards - found_shards

--- a/test/manual/test_weight_validation.py
+++ b/test/manual/test_weight_validation.py
@@ -104,40 +104,6 @@ class TestWeightValidation(unittest.TestCase):
             self.assertIsNone(error_msg)
             self.assertEqual(corrupted_files, [])
 
-    def test_validate_sharded_model_all_present_zero_indexed(self):
-        """Test that complete shards numbered from 0 (e.g. Ring-2.5-1T) pass validation."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            for i in [0, 1, 2]:
-                filepath = os.path.join(tmpdir, f"model-0000{i}-of-00003.safetensors")
-                header = b'{"__metadata__":{}}'
-                header_size = len(header)
-                with open(filepath, "wb") as f:
-                    f.write(struct.pack("<Q", header_size))
-                    f.write(header)
-
-            index_data = {
-                "weight_map": {
-                    "layer0": "model-00000-of-00003.safetensors",
-                    "layer1": "model-00001-of-00003.safetensors",
-                    "layer2": "model-00002-of-00003.safetensors",
-                }
-            }
-            with open(os.path.join(tmpdir, "model.safetensors.index.json"), "w") as f:
-                json.dump(index_data, f)
-
-            weight_files = [
-                os.path.join(tmpdir, f"model-0000{i}-of-00003.safetensors")
-                for i in [0, 1, 2]
-            ]
-
-            is_valid, error_msg, corrupted_files = _validate_sharded_model(
-                tmpdir, weight_files
-            )
-
-            self.assertTrue(is_valid)
-            self.assertIsNone(error_msg)
-            self.assertEqual(corrupted_files, [])
-
     def test_validate_sharded_model_corrupted_shard(self):
         """
         Test that corrupted shards are detected and returned in corrupted_files.

--- a/test/manual/test_weight_validation.py
+++ b/test/manual/test_weight_validation.py
@@ -104,6 +104,40 @@ class TestWeightValidation(unittest.TestCase):
             self.assertIsNone(error_msg)
             self.assertEqual(corrupted_files, [])
 
+    def test_validate_sharded_model_all_present_zero_indexed(self):
+        """Test that complete shards numbered from 0 (e.g. Ring-2.5-1T) pass validation."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for i in [0, 1, 2]:
+                filepath = os.path.join(tmpdir, f"model-0000{i}-of-00003.safetensors")
+                header = b'{"__metadata__":{}}'
+                header_size = len(header)
+                with open(filepath, "wb") as f:
+                    f.write(struct.pack("<Q", header_size))
+                    f.write(header)
+
+            index_data = {
+                "weight_map": {
+                    "layer0": "model-00000-of-00003.safetensors",
+                    "layer1": "model-00001-of-00003.safetensors",
+                    "layer2": "model-00002-of-00003.safetensors",
+                }
+            }
+            with open(os.path.join(tmpdir, "model.safetensors.index.json"), "w") as f:
+                json.dump(index_data, f)
+
+            weight_files = [
+                os.path.join(tmpdir, f"model-0000{i}-of-00003.safetensors")
+                for i in [0, 1, 2]
+            ]
+
+            is_valid, error_msg, corrupted_files = _validate_sharded_model(
+                tmpdir, weight_files
+            )
+
+            self.assertTrue(is_valid)
+            self.assertIsNone(error_msg)
+            self.assertEqual(corrupted_files, [])
+
     def test_validate_sharded_model_corrupted_shard(self):
         """
         Test that corrupted shards are detected and returned in corrupted_files.


### PR DESCRIPTION
## Summary

`_validate_sharded_model` in `python/sglang/srt/model_loader/ci_weight_validation.py` hardcodes the expected shard-id set as `set(range(1, total_shards + 1))`. This works for 1-indexed releases (e.g. `deepseek-ai/DeepSeek-V3`) but produces a false positive for 0-indexed releases.

Concrete example seen on `inclusionAI/Ring-2.5-1T`: the cache holds `model-00000-of-00160.safetensors` through `model-00159-of-00160.safetensors` (all 160 shards present), but the validator returns:
```
Validation failed for inclusionAI/Ring-2.5-1T: Missing shards in model-of-00160.safetensors: [160]. Will attempt to download missing files.
```
Shard 160 doesn't exist — the highest index is 159. The follow-up `snapshot_download` no-ops against the complete cache, so this is mostly noise, but it can mislead any debugging session and would trigger an actual (and failing) re-download attempt against any cold-cache 0-indexed model.

Fix: derive the expected shard-id range from `min(found_shards)`, accepting either `{0..N-1}` or `{1..N}` as valid. Both are HF naming conventions in the wild.

## Verification (paper)

| Case | Found | `min_idx` | Expected | Missing |
|---|---|---|---|---|
| 1-indexed all-present | `{1,2,3}` | 1 | `{1,2,3}` | ∅ ✅ |
| 0-indexed all-present (Ring case) | `{0,1,2}` | 0 | `{0,1,2}` | ∅ ✅ (was: `{3}` false positive) |
| 1-indexed, shard 3 missing | `{1,2}` | 1 | `{1,2,3}` | `{3}` ✅ |
| 0-indexed, shard 2 missing | `{0,1}` | 0 | `{0,1,2}` | `{2}` ✅ |

## Test plan

- [ ] Real-model verification: load `inclusionAI/Ring-2.5-1T` from a complete cache — log no longer prints `Missing shards in model-of-00160.safetensors: [160]`.
- [ ] No CI-side regression for 1-indexed models (DeepSeek-V3, Qwen, etc.) since the `range` start now follows the data instead of hardcoding `1`.