### PR TITLE
Fix lora buffer sizing for tp>num_kv cases

### DIFF
--- a/python/sglang/srt/lora/layers.py
+++ b/python/sglang/srt/lora/layers.py
@@ -629,7 +629,15 @@ class QKVParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
         kv_start_idx = kv_proj_shard_size * kv_shard_id
         kv_end_idx = kv_start_idx + kv_proj_shard_size
 
-        q_size, k_size, _ = base_layer.output_sizes
+        # The adapter weight `B` is in pre-replication layout
+        # [q_total, k_total, v_total]. When tp_size > total_num_kv_heads,
+        # base_layer.output_sizes reflects the post-replication kv size, which
+        # over-counts and pushes the v offset past the end of `B`. Compute
+        # offsets from the pre-replication head counts instead.
+        head_size = base_layer.head_size
+        q_size = base_layer.total_num_heads * head_size
+        k_size = base_layer.total_num_kv_heads * head_size
+
         B_q_shard = B[q_start_idx:q_end_idx, :]
         B_k_shard = B[q_size + kv_start_idx : q_size + kv_end_idx, :]
         B_v_shard = B[q_size + k_size + kv_start_idx : q_size + k_size + kv_end_idx, :]

--- a/python/sglang/srt/lora/utils.py
+++ b/python/sglang/srt/lora/utils.py
@@ -54,6 +54,29 @@ class LoRAType(Enum):
     LORA_B = 1
 
 
+def get_qkv_lora_kv_total(num_key_value_heads: int) -> int:
+    """Return the kv-head count the LoRA qkv buffer must reserve for, accounting
+    for KV-head replication when ``tp_size > num_key_value_heads``.
+
+    Asserts that DP-attention / context-parallel are off, because the rest of
+    the LoRA path assumes ``attn_tp_size == tp_size`` (the mem_pool divides
+    buffer shapes by global ``tp_size``, not ``attn_tp_size``).
+    """
+    from sglang.srt.distributed import get_tensor_model_parallel_world_size
+    from sglang.srt.layers.dp_attention import get_attention_tp_size
+
+    tp_size = get_tensor_model_parallel_world_size()
+    attn_tp_size = get_attention_tp_size()
+    assert attn_tp_size == tp_size, (
+        f"LoRA qkv sizing assumes attn_tp_size == tp_size, got "
+        f"attn_tp_size={attn_tp_size}, tp_size={tp_size}. DP-attention or "
+        f"context-parallel is not supported with LoRA today (the mem_pool "
+        f"sizes buffers by global tp_size; see lora/mem_pool.py)."
+    )
+    kv_heads_per_rank = max(1, num_key_value_heads // tp_size)
+    return kv_heads_per_rank * tp_size
+
+
 def get_hidden_dim(
     module_name: str,
     config: AutoConfig,
@@ -79,8 +102,9 @@ def get_hidden_dim(
             config, "head_dim", config.hidden_size // config.num_attention_heads
         )
         if module_name == "qkv_proj":
+            kv_total_replicated = get_qkv_lora_kv_total(config.num_key_value_heads)
             return config.hidden_size, head_dim * (
-                config.num_attention_heads + config.num_key_value_heads * 2
+                config.num_attention_heads + kv_total_replicated * 2
             )
         elif module_name == "o_proj":
             o_head_dim = getattr(config, "v_head_dim", None) or head_dim

--- a/python/sglang/srt/models/nemotron_h.py
+++ b/python/sglang/srt/models/nemotron_h.py
@@ -778,10 +778,12 @@ class NemotronHForCausalLM(nn.Module):
         )
 
         if module_name == "qkv_proj":
+            from sglang.srt.lora.utils import get_qkv_lora_kv_total
+
+            kv_total_replicated = get_qkv_lora_kv_total(config.num_key_value_heads)
             return (
                 hidden_size,
-                head_dim
-                * (config.num_attention_heads + config.num_key_value_heads * 2),
+                head_dim * (config.num_attention_heads + kv_total_replicated * 2),
             )
         elif module_name == "o_proj":
             return (

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -957,11 +957,14 @@ class Qwen3_5ForCausalLM(nn.Module):
         head_dim = config.head_dim or (config.hidden_size // config.num_attention_heads)
 
         if module_name == "qkv_proj":
+            from sglang.srt.lora.utils import get_qkv_lora_kv_total
+
             attn_output_gate = getattr(config, "attn_output_gate", True)
             q_heads = config.num_attention_heads * (2 if attn_output_gate else 1)
+            kv_total_replicated = get_qkv_lora_kv_total(config.num_key_value_heads)
             return (
                 config.hidden_size,
-                head_dim * (q_heads + config.num_key_value_heads * 2),
+                head_dim * (q_heads + kv_total_replicated * 2),
             )
         elif module_name == "o_proj":
             return config.num_attention_heads * head_dim, config.hidden_size


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

- LoRA loading failed (or silently dropped V) at TP sizes that require KV-head replication. Fixes both the buffer allocation and the slice-time offset arithmetic so adapters load correctly at any TP.
- Concrete trigger: `Qwen3.5-35B-A3B` (`num_kv_heads=2`) at TP=8 errored with `LoRA buffer shape [1152, 32] does not match weight shape [1280, 32]`; at TP=4 it loaded but the V slice was empty (0 rows), silently producing wrong logprobs.

## Modifications

<!-- Detail the changes made in this pull request. -->

 - QKVParallelLinearWithLoRA.slice_lora_b_weights: compute q_size / k_size from the pre-replication head counts (base_layer.total_num_heads * head_size, base_layer.total_num_kv_heads * head_size) instead of output_sizes.
  - New helper lora.utils.get_qkv_lora_kv_total(num_key_value_heads): returns the kv-head count the qkv LoRA buffer must reserve for after replication. Asserts attn_tp_size == tp_size since the rest of the LoRA path (esp. mem_pool.py) sizes by global tp_size — DP-attention / context-parallel are not yet supported with LoRA.
  - Use get_qkv_lora_kv_total(...) in the qkv_proj branch of get_hidden_dim in lora/utils.py, models/nemotron_h.py, and models/qwen3_5.py.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [X] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [X] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
