### PR TITLE
[bugfix] Support MIXED forward mode in TBO splitter for DP attention

### DIFF
--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -81,7 +81,7 @@ def compute_split_seq_index(
     extend_lens: Optional[Sequence[int]],
     token_num_per_seq: Optional[int],
 ) -> Optional[int]:
-    if forward_mode == ForwardMode.EXTEND:
+    if forward_mode == ForwardMode.EXTEND or forward_mode == ForwardMode.MIXED:
         assert extend_lens is not None
         return _split_extend_seqs(extend_lens)
     elif forward_mode.is_target_verify() or forward_mode.is_decode():
@@ -270,7 +270,7 @@ def compute_split_token_index(
     extend_seq_lens: Optional[Sequence[int]],
     token_num_per_seq: Optional[int],
 ) -> int:
-    if forward_mode == ForwardMode.EXTEND:
+    if forward_mode == ForwardMode.EXTEND or forward_mode == ForwardMode.MIXED:
         assert extend_seq_lens is not None
         if _is_two_chunk_split_enabled(extend_seq_lens):
             return sum(extend_seq_lens) // 2

--- a/test/registered/distributed/test_dp_attention.py
+++ b/test/registered/distributed/test_dp_attention.py
@@ -68,6 +68,38 @@ class TestDPAttentionDP2TP2(
         cls._env_override.__exit__(None, None, None)
 
 
+class TestDPAttentionMixedChunk(
+    CustomTestCase,
+    GSM8KMixin,
+):
+    gsm8k_accuracy_thres = 0.6
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_MLA_MODEL_NAME_FOR_TEST
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--tp",
+                "2",
+                "--enable-dp-attention",
+                "--dp",
+                "2",
+                "--enable-mixed-chunk",
+                "--chunked-prefill-size",
+                "256",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+
 class TestDPRetract(
     CustomTestCase,
     JSONConstrainedMixin,


### PR DESCRIPTION
## Motivation

\`--enable-dp-attention\` together with \`--enable-mixed-chunk\` crashes
deterministically at the first chunked-prefill iteration that merges a
running decode. The combination is silently broken — there's no validation
in \`server_args.py\` rejecting it, but no scheduler iteration with
\`forward_mode = MIXED\` ever survives long enough to reach the model.

Under DP attention, \`prepare_mlp_sync_batch_raw\` (\`scheduler_dp_attn_mixin.py:187\`)
unconditionally calls \`TboDPAttentionPreparer.prepare_all_gather\`, which
calls \`compute_split_seq_index\` on the local batch's \`forward_mode\` —
**even when \`--enable-two-batch-overlap\` is off**. That function (and
its companion \`compute_split_token_index\`) only handled
\`EXTEND / TARGET_VERIFY / DECODE / IDLE / PREBUILT\` and raised
\`NotImplementedError\` for \`ForwardMode.MIXED\`.

Repro on the failing combination:

\`\`\`
File \"python/sglang/srt/managers/scheduler_dp_attn_mixin.py\", line 187, in prepare_mlp_sync_batch_raw
    local_can_run_tbo, local_forward_mode = tbo_preparer.prepare_all_gather(local_batch)
File \"python/sglang/srt/batch_overlap/two_batch_overlap.py\", line 398, in prepare_all_gather
    self.local_tbo_split_seq_index = compute_split_seq_index(
File \"python/sglang/srt/batch_overlap/two_batch_overlap.py\", line 94, in compute_split_seq_index
    raise NotImplementedError()
NotImplementedError
\`\`\`

## Modifications

Treat \`ForwardMode.MIXED\` like \`ForwardMode.EXTEND\` in both
\`compute_split_seq_index\` and \`compute_split_token_index\`. After
\`mix_with_running\`, the running-decode reqs are appended to
\`extend_lens\` as length-1 entries, so \`_split_extend_seqs\` and the
cumulative-sum split logic apply unchanged.

Two-line fix in \`python/sglang/srt/batch_overlap/two_batch_overlap.py\`.
Added a regression test \`TestDPAttentionMixedChunk\` in
\`test/registered/distributed/test_dp_attention.py\` that exercises
\`--enable-dp-attention --enable-mixed-chunk --chunked-prefill-size 256\`
on the existing 2-GPU CI suite.

**Out of scope:** \`--enable-two-batch-overlap\` + \`--enable-mixed-chunk\`
is still unsupported. \`OperationsStrategy.init_new_tbo\` →
\`_compute_moe_*_layer_operations_strategy_tbo\` in
\`batch_overlap/operations_strategy.py\` (lines 84, 163, 240) also raise
\`NotImplementedError\` on MIXED. Non-TBO setups never reach those paths
because \`can_run_tbo\` requires \`enable_two_batch_overlap=True\`. Happy
to extend in a follow-up if there's interest.

## Accuracy Tests

DeepSeek-Coder-V2-Lite-Instruct, \`--tp 2 --enable-dp-attention --dp 2 --enable-mixed-chunk --chunked-prefill-size 256\`,
gsm8k 200 examples / 128 threads:

\`\`\`
gsm8k_score = 0.795   (threshold: 0.6)
output_throughput = 1138 token/s
\`\`\`

Mixed batches confirmed in scheduler logs (\`Prefill batch ... #running-req: 36\`).

8/8 outputs on a separate hand-crafted long+short prompt mix exactly match
a \`--enable-dp-attention\` (no mixed_chunk) baseline run, indicating
correct cross-DP token routing under MIXED.

Local run had to substitute \`deepseek-coder-v2-lite\` (cached) for
\`lmsys/sglang-ci-dsv3-test\` (gated on this box) and use
\`--attention-backend triton --disable-cuda-graph\` (an outdated local
\`sgl-kernel\` install passes an unsupported \`out=\` kwarg to FA3). The
registered CI test does not include those overrides — CI will run with
the canonical FA3 + cuda graph configuration.

## Speed Tests and Profiling

N/A — bugfix on a previously crashing path.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).