### PR TITLE
Reserve slot 0 as padding in all req pools

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -130,13 +130,14 @@ class DecodeReqToTokenPool:
         self.device = device
         self.pre_alloc_size = pre_alloc_size
         with memory_saver_adapter.region(tag=GPU_MEMORY_TYPE_KV_CACHE):
+            # +1 row 0 padding; mirrors ReqToTokenPool / KV pool padding slot 0.
             self.req_to_token = torch.zeros(
-                (size + pre_alloc_size, max_context_len),
+                (size + pre_alloc_size + 1, max_context_len),
                 dtype=torch.int32,
                 device=device,
             )
 
-        self.free_slots = list(range(size + pre_alloc_size))
+        self.free_slots = list(range(1, size + pre_alloc_size + 1))
 
     def write(self, indices, values):
         self.req_to_token[indices] = values
@@ -173,7 +174,7 @@ class DecodeReqToTokenPool:
         req.req_pool_idx = None
 
     def clear(self):
-        self.free_slots = list(range(self.size + self.pre_alloc_size))
+        self.free_slots = list(range(1, self.size + self.pre_alloc_size + 1))
 
 
 class HybridMambaDecodeReqToTokenPool(HybridReqToTokenPool):
@@ -238,7 +239,7 @@ class HybridMambaDecodeReqToTokenPool(HybridReqToTokenPool):
         )
 
     def clear(self):
-        self.free_slots = list(range(self.size + self.pre_alloc_size))
+        self.free_slots = list(range(1, self.size + self.pre_alloc_size + 1))
         self.mamba_pool.clear()
 
 

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -544,14 +544,16 @@ class HybridReqToTokenPool(ReqToTokenPool):
         self.mamba_map = {layer_id: i for i, layer_id in enumerate(mamba_layer_ids)}
 
         self.device = device
-        # +1 to match parent's padding row.
+        # Indexed by req_pool_idx, so size from parent's req_to_token (covers
+        # all req slots incl. the padding row), not from mamba pool size.
+        req_pool_size = self.req_to_token.shape[0]
         self.req_index_to_mamba_index_mapping: torch.Tensor = torch.zeros(
-            size + 1, dtype=torch.int32, device=self.device
+            req_pool_size, dtype=torch.int32, device=self.device
         )
         if enable_mamba_extra_buffer:
             self.req_index_to_mamba_ping_pong_track_buffer_mapping: torch.Tensor = (
                 torch.zeros(
-                    (size + 1, self.mamba_ping_pong_track_buffer_size),
+                    (req_pool_size, self.mamba_ping_pong_track_buffer_size),
                     dtype=torch.int32,
                     device=self.device,
                 )

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -142,12 +142,10 @@ class ReqToTokenPool:
         self.max_context_len = max_context_len
         self.device = device
         with memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
-            # Buffer holds size+1 rows: row 0 is the padding slot, rows 1..size
-            # are user-allocatable. Mirrors KV pool's padding slot 0 design so
-            # cuda-graph padded batches (req_pool_indices[raw_bs:] = 0) route
-            # dummy reqs through the unowned slot 0; req_to_token[0, :] stays
-            # zero throughout, and downstream KV writes land in the padding
-            # slot without corrupting real state.
+            # +1 row for padding slot 0 (mirrors KV pool): cuda-graph padded
+            # batches default req_pool_indices to 0, so routing dummies through
+            # unowned slot 0 keeps req_to_token[0, :] zero and downstream writes
+            # harmless.
             self.req_to_token = torch.zeros(
                 (size + 1, max_context_len), dtype=torch.int32, device=device
             )
@@ -546,7 +544,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
         self.mamba_map = {layer_id: i for i, layer_id in enumerate(mamba_layer_ids)}
 
         self.device = device
-        # +1 to match parent ReqToTokenPool's padding row (row 0 is padding).
+        # +1 to match parent's padding row.
         self.req_index_to_mamba_index_mapping: torch.Tensor = torch.zeros(
             size + 1, dtype=torch.int32, device=self.device
         )

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -142,10 +142,16 @@ class ReqToTokenPool:
         self.max_context_len = max_context_len
         self.device = device
         with memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
+            # Buffer holds size+1 rows: row 0 is the padding slot, rows 1..size
+            # are user-allocatable. Mirrors KV pool's padding slot 0 design so
+            # cuda-graph padded batches (req_pool_indices[raw_bs:] = 0) route
+            # dummy reqs through the unowned slot 0; req_to_token[0, :] stays
+            # zero throughout, and downstream KV writes land in the padding
+            # slot without corrupting real state.
             self.req_to_token = torch.zeros(
-                (size, max_context_len), dtype=torch.int32, device=device
+                (size + 1, max_context_len), dtype=torch.int32, device=device
             )
-        self.free_slots = list(range(size))
+        self.free_slots = list(range(1, size + 1))
 
     def write(self, indices, values):
         self.req_to_token[indices] = values
@@ -185,7 +191,7 @@ class ReqToTokenPool:
         req.req_pool_idx = None
 
     def clear(self):
-        self.free_slots = list(range(self.size))
+        self.free_slots = list(range(1, self.size + 1))
 
 
 class MambaPool:
@@ -540,13 +546,14 @@ class HybridReqToTokenPool(ReqToTokenPool):
         self.mamba_map = {layer_id: i for i, layer_id in enumerate(mamba_layer_ids)}
 
         self.device = device
+        # +1 to match parent ReqToTokenPool's padding row (row 0 is padding).
         self.req_index_to_mamba_index_mapping: torch.Tensor = torch.zeros(
-            size, dtype=torch.int32, device=self.device
+            size + 1, dtype=torch.int32, device=self.device
         )
         if enable_mamba_extra_buffer:
             self.req_index_to_mamba_ping_pong_track_buffer_mapping: torch.Tensor = (
                 torch.zeros(
-                    (size, self.mamba_ping_pong_track_buffer_size),
+                    (size + 1, self.mamba_ping_pong_track_buffer_size),
                     dtype=torch.int32,
                     device=self.device,
                 )


### PR DESCRIPTION
## Summary
- Mirror KV pool's padding slot 0 design across all request pools: each buffer gets a `+1` padding row at index 0, `free_slots` starts at 1, `size` still represents logical capacity so external code is unchanged.

## Changes
- `ReqToTokenPool`: `req_to_token` shape `(size, ...)` -> `(size + 1, ...)`; `free_slots = range(1, size + 1)`
- `HybridReqToTokenPool`: `req_index_to_mamba_index_mapping` and ping-pong mapping extended to `size + 1` to match
- `DecodeReqToTokenPool`: shape `(size + pre_alloc_size, ...)` -> `(size + pre_alloc_size + 1, ...)`; `free_slots = range(1, ...)`
- `HybridMambaDecodeReqToTokenPool.clear`: same shift

## Motivation
Prep upstream for the upcoming DeepSeek V4 integration (`dsv4-rebase`). The V4 compressor / state-pool path reads `req_to_token[req_pool_indices, ...]` and translates results through `full_to_swa` -> `state_loc`. Cuda-graph padded batches leave `req_pool_indices[raw_bs:] = 0` (zero-init buffer), so the only way to keep their dummy writes from corrupting real state is to make `req_pool_idx = 0` permanently unowned. Adopting the padding row upstream first keeps the contract symmetric with KV pool padding and lets the V4 branch drop local `-1` workarounds.

### Acknowledgment

Actually, this issue is also fixed in #https://github.com/sgl-project/sglang/pull/23635, which was contributed by @foraxe.

Co-author: @foraxe.