### PR TITLE
[Bug] Size mamba mappings from req pool, not mamba pool

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -228,7 +228,7 @@ class HybridMambaDecodeReqToTokenPool(HybridReqToTokenPool):
         self.start_layer = start_layer if start_layer is not None else 0
         self.layer_transfer_counter = None
         self._init_mamba_pool(
-            size=effective_mamba_size,
+            mamba_size=effective_mamba_size,
             mamba_spec_state_size=size + pre_alloc_size,
             cache_params=cache_params,
             mamba_layer_ids=mamba_layer_ids,

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -509,7 +509,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
         self.start_layer = start_layer if start_layer is not None else 0
         self.layer_transfer_counter = None
         self._init_mamba_pool(
-            size=mamba_size,
+            mamba_size=mamba_size,
             mamba_spec_state_size=mamba_spec_state_size,
             cache_params=cache_params,
             mamba_layer_ids=mamba_layer_ids,
@@ -520,7 +520,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
 
     def _init_mamba_pool(
         self,
-        size: int,
+        mamba_size: int,
         mamba_spec_state_size: int,
         cache_params: BaseLinearStateParams,
         mamba_layer_ids: List[int],
@@ -529,7 +529,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
         speculative_num_draft_tokens: int = None,
     ):
         self.mamba_pool = MambaPool(
-            size=size,
+            size=mamba_size,
             spec_state_size=mamba_spec_state_size,
             cache_params=cache_params,
             mamba_layer_ids=mamba_layer_ids,
@@ -540,13 +540,16 @@ class HybridReqToTokenPool(ReqToTokenPool):
         self.mamba_map = {layer_id: i for i, layer_id in enumerate(mamba_layer_ids)}
 
         self.device = device
+        # Indexed by req_pool_idx, so size from the req pool buffer
+        # (self.req_to_token.shape[0]), not from the mamba state pool size.
+        req_pool_size = self.req_to_token.shape[0]
         self.req_index_to_mamba_index_mapping: torch.Tensor = torch.zeros(
-            size, dtype=torch.int32, device=self.device
+            req_pool_size, dtype=torch.int32, device=self.device
         )
         if enable_mamba_extra_buffer:
             self.req_index_to_mamba_ping_pong_track_buffer_mapping: torch.Tensor = (
                 torch.zeros(
-                    (size, self.mamba_ping_pong_track_buffer_size),
+                    (req_pool_size, self.mamba_ping_pong_track_buffer_size),
                     dtype=torch.int32,
                     device=self.device,
                 )


### PR DESCRIPTION
`HybridReqToTokenPool._init_mamba_pool` allocated `req_index_to_mamba_index_mapping` and the ping-pong mapping from its `size` parameter, which is the **mamba** pool size. But these mappings are indexed by `req_pool_idx` from the request pool, so they should be sized from the request pool buffer.

## Why this is a real bug, not just defensive

Only the disagg decode path is currently safe. `HybridMambaDecodeReqToTokenPool.__init__` floors its `mamba_size` to `max(mamba_size, (size + pre_alloc_size) * slots_per_req)`, guaranteeing `mamba_size >= req_pool_size`.

The non-disagg path has no such floor. `model_runner_kv_cache_mixin.py` passes `mamba_size=server_args.max_mamba_cache_size` directly into `HybridReqToTokenPool`, and `max_mamba_cache_size` can be `< max_running_requests` via two reachable paths:

1. User passes `--max-mamba-cache-size N` with `N < max_running_requests` — no lower-bound check
2. Default ratio-based auto-sizing (`mamba_full_memory_ratio`) — small GPU memory + large mamba state can produce a value below `max_running_requests`

When this happens, `HybridReqToTokenPool.alloc()` does `self.req_index_to_mamba_index_mapping[select_index] = ...` with `select_index >= mamba_size`. CUDA has no bounds check, so it silently writes into the next tensor's memory.

## Fix

- Rename the parameter `size` -> `mamba_size` in `_init_mamba_pool` to remove the ambiguity
- Size the two mappings from `self.req_to_token.shape[0]`, which equals the full req pool buffer in both `HybridReqToTokenPool` (`size`) and `HybridMambaDecodeReqToTokenPool` (`size + pre_alloc_size`)