### PR TITLE
[Metrics] Bound priority label cardinality via --priority-label-bucket-size

### DIFF
--- a/python/sglang/srt/dllm/mixin/scheduler.py
+++ b/python/sglang/srt/dllm/mixin/scheduler.py
@@ -227,7 +227,10 @@ class SchedulerDllmMixin:
         from sglang.srt.observability.scheduler_metrics_mixin import PrefillStats
 
         new_batch.prefill_stats = PrefillStats.from_adder(
-            self.adder, self.running_batch.reqs, self.enable_priority_scheduling
+            self.adder,
+            self.running_batch.reqs,
+            self.enable_priority_scheduling,
+            priority_label_bucket_size=self.priority_label_bucket_size,
         )
 
         return new_batch

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -367,6 +367,7 @@ class Scheduler(
         self.nccl_port = port_args.nccl_port
         self.schedule_policy = server_args.schedule_policy
         self.enable_priority_scheduling = server_args.enable_priority_scheduling
+        self.priority_label_bucket_size = server_args.priority_label_bucket_size
         self.abort_on_priority_when_disabled = (
             server_args.abort_on_priority_when_disabled
         )
@@ -2769,6 +2770,7 @@ class Scheduler(
             adder,
             self.running_batch.reqs,
             self.enable_priority_scheduling,
+            priority_label_bucket_size=self.priority_label_bucket_size,
             num_pending_tokens=self._get_num_pending_tokens(
                 chunk_deduct=(
                     self.chunked_req.extend_input_len

--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -500,27 +500,38 @@ class SchedulerRuntimeCheckerMixin:
         self.stats.streaming_session_held_tokens = self._session_held_tokens()
 
         priority_enabled = self.enable_priority_scheduling
+        bucket_size = self.priority_label_bucket_size
         self.stats.num_running_reqs = QueueCount.from_reqs(
-            self.running_batch.reqs, priority_enabled
+            self.running_batch.reqs,
+            priority_enabled,
+            priority_label_bucket_size=bucket_size,
         )
         self.stats.gen_throughput = 0
         self.stats.num_queue_reqs = QueueCount.from_reqs(
-            self.waiting_queue, priority_enabled
+            self.waiting_queue, priority_enabled, priority_label_bucket_size=bucket_size
         )
         self.stats.num_grammar_queue_reqs = len(self.grammar_manager)
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
             self.stats.num_prefill_prealloc_queue_reqs = QueueCount.from_reqs(
-                self.disagg_prefill_bootstrap_queue.queue, priority_enabled
+                self.disagg_prefill_bootstrap_queue.queue,
+                priority_enabled,
+                priority_label_bucket_size=bucket_size,
             )
             self.stats.num_prefill_inflight_queue_reqs = QueueCount.from_reqs(
-                self.disagg_prefill_inflight_queue, priority_enabled
+                self.disagg_prefill_inflight_queue,
+                priority_enabled,
+                priority_label_bucket_size=bucket_size,
             )
         if self.disaggregation_mode == DisaggregationMode.DECODE:
             self.stats.num_decode_prealloc_queue_reqs = QueueCount.from_reqs(
-                self.disagg_decode_prealloc_queue.queue, priority_enabled
+                self.disagg_decode_prealloc_queue.queue,
+                priority_enabled,
+                priority_label_bucket_size=bucket_size,
             )
             self.stats.num_decode_transfer_queue_reqs = QueueCount.from_reqs(
-                self.disagg_decode_transfer_queue.queue, priority_enabled
+                self.disagg_decode_transfer_queue.queue,
+                priority_enabled,
+                priority_label_bucket_size=bucket_size,
             )
         self.metrics_collector.log_stats(self.stats)
 

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -81,7 +81,10 @@ from sglang.srt.managers.tokenizer_manager_score_mixin import (
     TokenizerManagerScoreMixin,
 )
 from sglang.srt.observability.cpu_monitor import start_cpu_monitor_thread
-from sglang.srt.observability.metrics_collector import TokenizerMetricsCollector
+from sglang.srt.observability.metrics_collector import (
+    TokenizerMetricsCollector,
+    fold_priority_label,
+)
 from sglang.srt.observability.req_time_stats import (
     APIServerReqTimeStats,
     convert_time_to_realtime,
@@ -271,6 +274,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         self.max_req_input_len = None  # Will be set later in engine.py
         self.enable_priority_scheduling = server_args.enable_priority_scheduling
         self.default_priority_value = server_args.default_priority_value
+        self.priority_label_bucket_size = server_args.priority_label_bucket_size
         speculative_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )
@@ -2139,7 +2143,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         if self.enable_priority_scheduling:
             priority = getattr(state.obj, "priority", None)
             if priority is not None:
-                labels["priority"] = str(priority)
+                labels["priority"] = str(
+                    fold_priority_label(priority, self.priority_label_bucket_size)
+                )
         if (
             not state.ttft_observed
             and self.disaggregation_mode != DisaggregationMode.PREFILL

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -40,6 +40,19 @@ SGLANG_TEST_REQUEST_TIME_STATS = get_bool_env_var("SGLANG_TEST_REQUEST_TIME_STAT
 logger = logging.getLogger(__name__)
 
 
+def fold_priority_label(priority: Optional[int], bucket_size: int) -> Optional[int]:
+    """Fold a raw integer priority into the lower bound of its Prometheus label bucket.
+
+    Bucket size K=1 (default) is the identity function — original behavior. K>1
+    bounds metric cardinality by collapsing priorities that share floor(p/K).
+    None passes through unchanged so that the existing `priority="None"` label
+    semantics for unset-default-priority is preserved.
+    """
+    if priority is None or bucket_size <= 1:
+        return priority
+    return (priority // bucket_size) * bucket_size
+
+
 @dataclass
 class QueueCount:
     """Holds both the total count and optional per-priority breakdown for a queue."""
@@ -48,12 +61,22 @@ class QueueCount:
     by_priority: Optional[Dict[int, int]] = None
 
     @classmethod
-    def from_reqs(cls, reqs: List[Req], enable_priority_scheduling: bool = False):
+    def from_reqs(
+        cls,
+        reqs: List[Req],
+        enable_priority_scheduling: bool = False,
+        priority_label_bucket_size: int = 1,
+    ):
         # NOTE: If requests have priority=None (no --default-priority-value set),
         # Counter will produce {None: N}, resulting in priority="None" Prometheus labels.
         # Set --default-priority-value when enabling priority scheduling to avoid this.
         by_priority = (
-            dict(Counter(req.priority for req in reqs))
+            dict(
+                Counter(
+                    fold_priority_label(req.priority, priority_label_bucket_size)
+                    for req in reqs
+                )
+            )
             if enable_priority_scheduling
             else None
         )

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -60,13 +60,16 @@ class PrefillStats:
         running_reqs: List[Req],
         enable_priority_scheduling: bool = False,
         num_pending_tokens: int = 0,
+        priority_label_bucket_size: int = 1,
     ):
         return cls(
             log_input_tokens=adder.log_input_tokens,
             log_hit_tokens=adder.log_hit_tokens,
             new_token_ratio=adder.new_token_ratio,
             num_running_reqs=QueueCount.from_reqs(
-                running_reqs, enable_priority_scheduling
+                running_reqs,
+                enable_priority_scheduling,
+                priority_label_bucket_size=priority_label_bucket_size,
             ),
             num_new_seqs=len(adder.can_run_list),
             num_pending_tokens=num_pending_tokens,
@@ -415,6 +418,7 @@ class SchedulerMetricsMixin:
                 )
 
             priority_enabled = self.enable_priority_scheduling
+            bucket_size = self.priority_label_bucket_size
             total_tokens = prefill_stats.log_input_tokens + prefill_stats.log_hit_tokens
             cache_hit_rate = (
                 prefill_stats.log_hit_tokens / total_tokens if total_tokens > 0 else 0.0
@@ -423,7 +427,9 @@ class SchedulerMetricsMixin:
             # Basics
             self.stats.num_running_reqs = prefill_stats.num_running_reqs
             self.stats.num_queue_reqs = QueueCount.from_reqs(
-                self.waiting_queue, priority_enabled
+                self.waiting_queue,
+                priority_enabled,
+                priority_label_bucket_size=bucket_size,
             )
             self.stats.num_grammar_queue_reqs = len(self.grammar_manager)
             self.stats.cache_hit_rate = cache_hit_rate
@@ -439,19 +445,27 @@ class SchedulerMetricsMixin:
             # PD disaggregation
             if self.disaggregation_mode == DisaggregationMode.PREFILL:
                 self.stats.num_prefill_prealloc_queue_reqs = QueueCount.from_reqs(
-                    self.disagg_prefill_bootstrap_queue.queue, priority_enabled
+                    self.disagg_prefill_bootstrap_queue.queue,
+                    priority_enabled,
+                    priority_label_bucket_size=bucket_size,
                 )
                 self.stats.num_prefill_inflight_queue_reqs = QueueCount.from_reqs(
-                    self.disagg_prefill_inflight_queue, priority_enabled
+                    self.disagg_prefill_inflight_queue,
+                    priority_enabled,
+                    priority_label_bucket_size=bucket_size,
                 )
                 self.stats.kv_transfer_speed_gb_s = self.kv_transfer_speed_gb_s
                 self.stats.kv_transfer_latency_ms = self.kv_transfer_latency_ms
             elif self.disaggregation_mode == DisaggregationMode.DECODE:
                 self.stats.num_decode_prealloc_queue_reqs = QueueCount.from_reqs(
-                    self.disagg_decode_prealloc_queue.queue, priority_enabled
+                    self.disagg_decode_prealloc_queue.queue,
+                    priority_enabled,
+                    priority_label_bucket_size=bucket_size,
                 )
                 self.stats.num_decode_transfer_queue_reqs = QueueCount.from_reqs(
-                    self.disagg_decode_transfer_queue.queue, priority_enabled
+                    self.disagg_decode_transfer_queue.queue,
+                    priority_enabled,
+                    priority_label_bucket_size=bucket_size,
                 )
 
             # Utilization / LoRA / HiCache
@@ -588,13 +602,16 @@ class SchedulerMetricsMixin:
             logger.info(msg)
         if self.current_scheduler_metrics_enabled:
             priority_enabled = self.enable_priority_scheduling
+            bucket_size = self.priority_label_bucket_size
 
             # Basics
             self.stats.num_running_reqs = QueueCount.from_reqs(
-                batch.reqs, priority_enabled
+                batch.reqs, priority_enabled, priority_label_bucket_size=bucket_size
             )
             self.stats.num_queue_reqs = QueueCount.from_reqs(
-                self.waiting_queue, priority_enabled
+                self.waiting_queue,
+                priority_enabled,
+                priority_label_bucket_size=bucket_size,
             )
             self.stats.num_grammar_queue_reqs = len(self.grammar_manager)
             self.stats.gen_throughput = self.last_gen_throughput
@@ -616,17 +633,25 @@ class SchedulerMetricsMixin:
             # PD disaggregation
             if self.disaggregation_mode == DisaggregationMode.PREFILL:
                 self.stats.num_prefill_prealloc_queue_reqs = QueueCount.from_reqs(
-                    self.disagg_prefill_bootstrap_queue.queue, priority_enabled
+                    self.disagg_prefill_bootstrap_queue.queue,
+                    priority_enabled,
+                    priority_label_bucket_size=bucket_size,
                 )
                 self.stats.num_prefill_inflight_queue_reqs = QueueCount.from_reqs(
-                    self.disagg_prefill_inflight_queue, priority_enabled
+                    self.disagg_prefill_inflight_queue,
+                    priority_enabled,
+                    priority_label_bucket_size=bucket_size,
                 )
             elif self.disaggregation_mode == DisaggregationMode.DECODE:
                 self.stats.num_decode_prealloc_queue_reqs = QueueCount.from_reqs(
-                    self.disagg_decode_prealloc_queue.queue, priority_enabled
+                    self.disagg_decode_prealloc_queue.queue,
+                    priority_enabled,
+                    priority_label_bucket_size=bucket_size,
                 )
                 self.stats.num_decode_transfer_queue_reqs = QueueCount.from_reqs(
-                    self.disagg_decode_transfer_queue.queue, priority_enabled
+                    self.disagg_decode_transfer_queue.queue,
+                    priority_enabled,
+                    priority_label_bucket_size=bucket_size,
                 )
 
             # Streaming session metrics

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -369,6 +369,7 @@ class ServerArgs:
     abort_on_priority_when_disabled: bool = False
     schedule_low_priority_values_first: bool = False
     priority_scheduling_preemption_threshold: int = 10
+    priority_label_bucket_size: int = 1
     schedule_conservativeness: float = 1.0
     page_size: Optional[int] = None
     swa_full_tokens_ratio: float = 0.8
@@ -4573,6 +4574,16 @@ class ServerArgs:
             help="If specified with --enable-priority-scheduling, the scheduler will schedule requests with lower priority integer values first.",
         )
         parser.add_argument(
+            "--priority-label-bucket-size",
+            type=int,
+            default=ServerArgs.priority_label_bucket_size,
+            help="Bucket size K for folding integer priorities into Prometheus label "
+            "values. Each priority p is mapped to (p // K) * K, so K=10 collapses "
+            "0..9 into priority='0', 10..19 into priority='10', etc. Default 1 = no "
+            "folding (label values are identical to raw priorities). Increase K to "
+            "bound metric cardinality when priorities span a wide range.",
+        )
+        parser.add_argument(
             "--priority-scheduling-preemption-threshold",
             type=int,
             default=ServerArgs.priority_scheduling_preemption_threshold,
@@ -6865,6 +6876,9 @@ class ServerArgs:
                 logger.warning(
                     "--default-priority-value has no effect without --enable-priority-scheduling"
                 )
+        assert (
+            self.priority_label_bucket_size >= 1
+        ), f"--priority-label-bucket-size must be >= 1, got {self.priority_label_bucket_size}"
 
         # Check hisparse
         if self.enable_hisparse:

--- a/test/registered/observability/test_priority_metrics.py
+++ b/test/registered/observability/test_priority_metrics.py
@@ -1,12 +1,19 @@
+"""GPU smoke test for priority metrics — drives a real Qwen3-0.6B server,
+sends HTTP requests with `priority` set, and verifies the `/metrics` scrape
+exposes the expected priority label dimension.
+
+Pure-logic tests (fold helper, QueueCount.from_reqs, PrefillStats plumbing,
+ServerArgs validation, in-process collect_metrics fold) live in
+test/registered/unit/observability/test_priority_metrics.py.
+"""
+
 import unittest
 from typing import Dict, List
-from unittest.mock import Mock
 
 import requests
 from prometheus_client.parser import text_string_to_metric_families
 from prometheus_client.samples import Sample
 
-from sglang.srt.observability.metrics_collector import QueueCount
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import (
@@ -39,46 +46,9 @@ def _get_samples_by_name(metrics: Dict[str, List[Sample]], name: str) -> List[Sa
     return metrics.get(name, [])
 
 
-def _get_sample_value_by_labels(samples: List[Sample], labels: Dict[str, str]) -> float:
-    for sample in samples:
-        if all(sample.labels.get(k) == v for k, v in labels.items()):
-            return sample.value
-    raise KeyError(f"No sample found with labels {labels}")
-
-
-class TestQueueCount(CustomTestCase):
-    """Unit tests for QueueCount (no server needed)."""
-
-    def test_queue_count_from_reqs(self):
-        """QueueCount correctly counts per-priority breakdown."""
-        reqs = [
-            Mock(priority=1),
-            Mock(priority=1),
-            Mock(priority=5),
-            Mock(priority=5),
-            Mock(priority=10),
-        ]
-        qc = QueueCount.from_reqs(reqs, enable_priority_scheduling=True)
-        self.assertEqual(qc.total, 5)
-        self.assertEqual(qc.by_priority, {1: 2, 5: 2, 10: 1})
-
-    def test_queue_count_from_reqs_disabled(self):
-        """Priority scheduling disabled → no breakdown."""
-        reqs = [Mock(priority=1), Mock(priority=5)]
-        qc = QueueCount.from_reqs(reqs, enable_priority_scheduling=False)
-        self.assertEqual(qc.total, 2)
-        self.assertIsNone(qc.by_priority)
-
-    def test_queue_count_empty(self):
-        """Empty request list."""
-        qc = QueueCount.from_reqs([], enable_priority_scheduling=True)
-        self.assertEqual(qc.total, 0)
-        self.assertEqual(qc.by_priority, {})
-
-
 class TestPriorityMetrics(CustomTestCase):
-    """Test that priority-based metrics are correctly emitted when
-    --enable-priority-scheduling is enabled."""
+    """End-to-end: priority label dimension is exposed on gauges and
+    histograms when --enable-priority-scheduling is set."""
 
     @classmethod
     def setUpClass(cls):

--- a/test/registered/unit/observability/test_priority_metrics.py
+++ b/test/registered/unit/observability/test_priority_metrics.py
@@ -1,0 +1,243 @@
+"""CPU-only unit tests for priority-label bucketing.
+
+The corresponding GPU smoke test that drives a real server is in
+test/registered/observability/test_priority_metrics.py. This file isolates the
+pure-logic surface (fold helper, QueueCount.from_reqs, PrefillStats.from_adder
+plumbing, ServerArgs validation, and the in-process fold inside
+TokenizerManager.collect_metrics) so it can run on the CPU CI lane.
+"""
+
+import unittest
+from unittest.mock import Mock
+
+from sglang.srt.observability.metrics_collector import (
+    QueueCount,
+    fold_priority_label,
+)
+from sglang.srt.observability.scheduler_metrics_mixin import PrefillStats
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=6, suite="stage-a-test-cpu")
+
+
+class TestQueueCount(CustomTestCase):
+    """Unit tests for QueueCount and the fold helper."""
+
+    def test_queue_count_from_reqs(self):
+        """QueueCount correctly counts per-priority breakdown."""
+        reqs = [
+            Mock(priority=1),
+            Mock(priority=1),
+            Mock(priority=5),
+            Mock(priority=5),
+            Mock(priority=10),
+        ]
+        qc = QueueCount.from_reqs(reqs, enable_priority_scheduling=True)
+        self.assertEqual(qc.total, 5)
+        self.assertEqual(qc.by_priority, {1: 2, 5: 2, 10: 1})
+
+    def test_queue_count_from_reqs_disabled(self):
+        """Priority scheduling disabled → no breakdown."""
+        reqs = [Mock(priority=1), Mock(priority=5)]
+        qc = QueueCount.from_reqs(reqs, enable_priority_scheduling=False)
+        self.assertEqual(qc.total, 2)
+        self.assertIsNone(qc.by_priority)
+
+    def test_queue_count_empty(self):
+        """Empty request list."""
+        qc = QueueCount.from_reqs([], enable_priority_scheduling=True)
+        self.assertEqual(qc.total, 0)
+        self.assertEqual(qc.by_priority, {})
+
+    def test_fold_priority_label_identity(self):
+        """K=1 (default) is the identity — preserves existing label values exactly."""
+        for p in [-7, -1, 0, 1, 5, 17, 999]:
+            self.assertEqual(fold_priority_label(p, 1), p)
+        self.assertIsNone(fold_priority_label(None, 1))
+        self.assertIsNone(fold_priority_label(None, 10))
+
+    def test_fold_priority_label_buckets(self):
+        """K>1 folds priorities into the lower bound of [bucket, bucket+K)."""
+        # Non-negative
+        self.assertEqual(fold_priority_label(0, 10), 0)
+        self.assertEqual(fold_priority_label(5, 10), 0)
+        self.assertEqual(fold_priority_label(9, 10), 0)
+        self.assertEqual(fold_priority_label(10, 10), 10)
+        self.assertEqual(fold_priority_label(19, 10), 10)
+        self.assertEqual(fold_priority_label(999, 10), 990)
+        # Negative — Python floor division gives the mathematically lower bucket
+        self.assertEqual(fold_priority_label(-1, 10), -10)
+        self.assertEqual(fold_priority_label(-10, 10), -10)
+        self.assertEqual(fold_priority_label(-11, 10), -20)
+
+    def test_queue_count_with_bucketing(self):
+        """Bucketed counting collapses adjacent priorities into shared keys."""
+        reqs = [
+            Mock(priority=0),
+            Mock(priority=3),
+            Mock(priority=9),
+            Mock(priority=10),
+            Mock(priority=15),
+            Mock(priority=29),
+        ]
+        qc = QueueCount.from_reqs(
+            reqs,
+            enable_priority_scheduling=True,
+            priority_label_bucket_size=10,
+        )
+        self.assertEqual(qc.total, 6)
+        # 0,3,9 → bucket 0; 10,15 → bucket 10; 29 → bucket 20
+        self.assertEqual(qc.by_priority, {0: 3, 10: 2, 20: 1})
+
+    def test_queue_count_bucketing_disabled_when_priority_disabled(self):
+        """Bucket size has no effect when priority scheduling is disabled."""
+        reqs = [Mock(priority=0), Mock(priority=99)]
+        qc = QueueCount.from_reqs(
+            reqs,
+            enable_priority_scheduling=False,
+            priority_label_bucket_size=10,
+        )
+        self.assertEqual(qc.total, 2)
+        self.assertIsNone(qc.by_priority)
+
+
+class TestPriorityLabelBucketSizeValidation(CustomTestCase):
+    """ServerArgs validation for --priority-label-bucket-size."""
+
+    def _make(self, bucket_size: int) -> ServerArgs:
+        return ServerArgs(model_path="dummy", priority_label_bucket_size=bucket_size)
+
+    def test_default_accepted(self):
+        """K=1 (default) passes validation."""
+        self._make(1).check_server_args()
+
+    def test_large_bucket_accepted(self):
+        """Large K passes validation."""
+        self._make(1000).check_server_args()
+
+    def test_zero_rejected(self):
+        """K=0 fails validation (would crash on floor-division)."""
+        with self.assertRaises(AssertionError):
+            self._make(0).check_server_args()
+
+    def test_negative_rejected(self):
+        """Negative K fails validation."""
+        with self.assertRaises(AssertionError):
+            self._make(-5).check_server_args()
+
+
+class TestPrefillStatsBucketing(CustomTestCase):
+    """PrefillStats.from_adder threads priority_label_bucket_size through."""
+
+    def test_from_adder_folds_priorities(self):
+        """priority_label_bucket_size kwarg reaches QueueCount in num_running_reqs."""
+        adder = Mock(
+            log_input_tokens=10,
+            log_hit_tokens=5,
+            new_token_ratio=1.0,
+            can_run_list=[Mock(), Mock()],
+        )
+        running_reqs = [
+            Mock(priority=3),
+            Mock(priority=7),
+            Mock(priority=12),
+            Mock(priority=27),
+        ]
+        stats = PrefillStats.from_adder(
+            adder,
+            running_reqs,
+            enable_priority_scheduling=True,
+            priority_label_bucket_size=10,
+        )
+        # 3,7 → bucket 0; 12 → bucket 10; 27 → bucket 20
+        self.assertEqual(stats.num_running_reqs.total, 4)
+        self.assertEqual(stats.num_running_reqs.by_priority, {0: 2, 10: 1, 20: 1})
+
+    def test_from_adder_default_is_identity(self):
+        """Without bucket_size, PrefillStats keeps raw priority keys (back-compat)."""
+        adder = Mock(
+            log_input_tokens=0,
+            log_hit_tokens=0,
+            new_token_ratio=0.0,
+            can_run_list=[],
+        )
+        stats = PrefillStats.from_adder(
+            adder,
+            [Mock(priority=3), Mock(priority=7)],
+            enable_priority_scheduling=True,
+        )
+        self.assertEqual(stats.num_running_reqs.by_priority, {3: 1, 7: 1})
+
+
+class TestTokenizerManagerCollectMetricsFold(CustomTestCase):
+    """The fold is applied in TokenizerManager.collect_metrics before the
+    priority is stringified into a Prometheus label.
+
+    Tests the method as an unbound function with a mock self — no model load,
+    no server, no GPU. Catches regressions where someone drops the
+    fold_priority_label(...) wrap at the histogram label site.
+    """
+
+    def _invoke_collect_metrics(
+        self,
+        priority,
+        bucket_size,
+        finished=True,
+        ttft_observed=False,
+    ):
+        from sglang.srt.disaggregation.utils import DisaggregationMode
+        from sglang.srt.managers.tokenizer_manager import TokenizerManager
+
+        mock_self = Mock()
+        mock_self.enable_priority_scheduling = True
+        mock_self.priority_label_bucket_size = bucket_size
+        mock_self.disaggregation_mode = DisaggregationMode.NULL
+        mock_self.metrics_collector.labels = {"engine_type": "test"}
+        mock_self._request_has_grammar.return_value = False
+
+        recv_obj = Mock(
+            completion_tokens=[5],
+            cached_tokens=[0],
+            cached_tokens_details=None,
+            prompt_tokens=[10],
+        )
+        state = Mock(
+            ttft_observed=ttft_observed,
+            last_completion_tokens=0,
+            finished=finished,
+        )
+        state.obj.priority = priority
+        state.obj.custom_labels = None
+
+        TokenizerManager.collect_metrics(mock_self, state, recv_obj, 0)
+        return mock_self.metrics_collector
+
+    def test_priority_folded_for_finished_request(self):
+        """observe_one_finished_request gets the folded priority label."""
+        mc = self._invoke_collect_metrics(priority=17, bucket_size=10)
+        labels = mc.observe_one_finished_request.call_args.args[0]
+        self.assertEqual(labels["priority"], "10")
+
+    def test_priority_folded_for_ttft(self):
+        """observe_time_to_first_token gets the folded priority label."""
+        mc = self._invoke_collect_metrics(priority=23, bucket_size=10)
+        labels = mc.observe_time_to_first_token.call_args.args[0]
+        self.assertEqual(labels["priority"], "20")
+
+    def test_priority_unchanged_at_default_bucket_size(self):
+        """K=1 (default) preserves the raw priority — back-compat."""
+        mc = self._invoke_collect_metrics(priority=17, bucket_size=1)
+        labels = mc.observe_one_finished_request.call_args.args[0]
+        self.assertEqual(labels["priority"], "17")
+
+    def test_priority_none_skips_label(self):
+        """priority=None must NOT produce a `priority` label (avoid 'None' string)."""
+        mc = self._invoke_collect_metrics(priority=None, bucket_size=10)
+        labels = mc.observe_one_finished_request.call_args.args[0]
+        self.assertNotIn("priority", labels)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

When `--enable-priority-scheduling` is on, the integer request priority is emitted as a Prometheus label on queue gauges (`sglang:num_running_reqs`, `sglang:num_queue_reqs`, the four PD disagg queue gauges) and per-request histograms (TTFT, ITL, `e2e_request_latency`, `num_requests_total`, etc.). Nothing constrains how the integer is chosen, so callers using unbounded values (timestamps, monotonic counters, request IDs) blow up Prometheus cardinality and slow `/metrics` scrapes. The accumulator `SchedulerMetricsCollector._known_priorities` also grows monotonically and the per-priority gauge loop in `_log_gauge_queue_count` grows linearly with it on every prefill/decode batch.

This PR adds `--priority-label-bucket-size K` (default `1`) that folds raw priorities into the lower bound of `[bucket, bucket+K)` before they become a Prometheus label value.

- **`K=1` (default)**: identity — byte-identical labels and dashboards as before this change.
- **`K>1`**: priorities `0..K-1` collapse to `priority="0"`, `K..2K-1` to `priority="K"`, etc. Bounds both Prometheus cardinality and the per-batch `_log_gauge_queue_count` loop cost.

The fold is applied at two sites:

- `QueueCount.from_reqs` (queue gauges; threaded through 17 call sites in `scheduler_metrics_mixin.py` / `scheduler_runtime_checker_mixin.py` and `PrefillStats.from_adder`).
- `TokenizerManager.collect_metrics` (TTFT / ITL / e2e / finished / aborted histogram labels).

## Why this trade-off

Two simpler approaches were considered and rejected:

- **Hard cap with overflow bucket**: gives a no-knob safe default but loses signal once any priority exceeds the cap.
- **Hardcoded clamp to `[0, 31]` with `LOW`/`HIGH`/`UNKNOWN` sentinels** (an existing unused helper in `python/sglang/srt/observability/label_transform.py`): no-knob, but the boundaries are presumptuous and it changes existing dashboards because labels become non-numeric.

Bucket folding preserves original behavior at `K=1` (an explicit requirement) and stays numeric across the entire integer range. Operators with a wide priority scheme set `K` once; users with a small enum (the common case) set nothing and observe no change.

Caveat: `K=1` does **not** fix the linear-cost loop on its own. Operators must set `K` to bound the loop and the cardinality. This is the deliberate choice for backward compatibility — the alternative was a forced behavior change.

## Test plan

- [x] `pre-commit run --all-files` passes
- [ ] `python3 test/registered/unit/observability/test_priority_metrics.py` — runs on CPU CI lane (`stage-a-test-cpu`), no model load
- [ ] `python3 test/registered/observability/test_priority_metrics.py` — existing GPU smoke test, unchanged, runs on `stage-b-test-1-gpu-small`

CPU unit coverage:
- `TestQueueCount` — fold helper (identity, positive/negative bucketing) + `QueueCount.from_reqs` end-to-end with bucketing on/off.
- `TestPriorityLabelBucketSizeValidation` — `--priority-label-bucket-size >= 1` validation (zero and negative rejected).
- `TestPrefillStatsBucketing` — `PrefillStats.from_adder` threads `priority_label_bucket_size` into `QueueCount`.
- `TestTokenizerManagerCollectMetricsFold` — calls `TokenizerManager.collect_metrics` as an unbound method against a mocked `self`, asserts `observe_one_finished_request` / `observe_time_to_first_token` receive the folded label.

GPU smoke coverage (unchanged, in `test/registered/observability/test_priority_metrics.py`):
- HTTP `priority` field flowing into `state.obj.priority`.
- Real `prometheus_client` emission and multi-process `/metrics` scrape format.
- `--default-priority-value` propagation through the request lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)