### PR TITLE
fix(causal_conv1d_triton): cast conv_states loads to compute dtype to fix Triton type mismatch

### DIFF
--- a/python/sglang/kernels/ops/mamba/causal_conv1d_triton.py
+++ b/python/sglang/kernels/ops/mamba/causal_conv1d_triton.py
@@ -126,28 +126,28 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
             mask_w = idx_feats < dim
             if KERNEL_WIDTH == 2:
                 conv_states_ptrs = prior_tokens  # [BLOCK_N]
-                col0 = tl.load(conv_states_ptrs, mask_w, 0.0)
+                col0 = tl.load(conv_states_ptrs, mask_w, 0.0).to(x_ptr.dtype.element_ty)
             if KERNEL_WIDTH == 3:
                 conv_states_ptrs = prior_tokens  # [BLOCK_N]
-                col1 = tl.load(conv_states_ptrs, mask_w, 0.0)
+                col1 = tl.load(conv_states_ptrs, mask_w, 0.0).to(x_ptr.dtype.element_ty)
                 conv_states_ptrs = prior_tokens - 1 * stride_conv_state_tok  # [BLOCK_N]
-                col0 = tl.load(conv_states_ptrs, mask_w, 0.0)
+                col0 = tl.load(conv_states_ptrs, mask_w, 0.0).to(x_ptr.dtype.element_ty)
             if KERNEL_WIDTH == 4:
                 conv_states_ptrs = prior_tokens  # [BLOCK_N]
-                col2 = tl.load(conv_states_ptrs, mask_w, 0.0)
+                col2 = tl.load(conv_states_ptrs, mask_w, 0.0).to(x_ptr.dtype.element_ty)
                 conv_states_ptrs = prior_tokens - 1 * stride_conv_state_tok  # [BLOCK_N]
-                col1 = tl.load(conv_states_ptrs, mask_w, 0.0)
+                col1 = tl.load(conv_states_ptrs, mask_w, 0.0).to(x_ptr.dtype.element_ty)
                 conv_states_ptrs = prior_tokens - 2 * stride_conv_state_tok  # [BLOCK_N]
-                col0 = tl.load(conv_states_ptrs, mask_w, 0.0)
+                col0 = tl.load(conv_states_ptrs, mask_w, 0.0).to(x_ptr.dtype.element_ty)
             if KERNEL_WIDTH == 5:
                 conv_states_ptrs = prior_tokens  # [BLOCK_N]
-                col3 = tl.load(conv_states_ptrs, mask_w, 0.0)
+                col3 = tl.load(conv_states_ptrs, mask_w, 0.0).to(x_ptr.dtype.element_ty)
                 conv_states_ptrs = prior_tokens - 1 * stride_conv_state_tok  # [BLOCK_N]
-                col2 = tl.load(conv_states_ptrs, mask_w, 0.0)
+                col2 = tl.load(conv_states_ptrs, mask_w, 0.0).to(x_ptr.dtype.element_ty)
                 conv_states_ptrs = prior_tokens - 2 * stride_conv_state_tok  # [BLOCK_N]
-                col1 = tl.load(conv_states_ptrs, mask_w, 0.0)
+                col1 = tl.load(conv_states_ptrs, mask_w, 0.0).to(x_ptr.dtype.element_ty)
                 conv_states_ptrs = prior_tokens - 3 * stride_conv_state_tok  # [BLOCK_N]
-                col0 = tl.load(conv_states_ptrs, mask_w, 0.0)
+                col0 = tl.load(conv_states_ptrs, mask_w, 0.0).to(x_ptr.dtype.element_ty)
         else:
             # prior-tokens are zeros
             if KERNEL_WIDTH >= 2:  # STRATEGY1


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->



## Motivation

Fixes #23739

When running a Mamba/GDN-based model (e.g. `Qwen3.5-35B-A3B-GPTQ-Int4`) with `--dtype float16` and `--attention-backend triton`, the first generation request crashed the scheduler with a Triton compile-time error:

```
triton.compiler.errors.CompilationError
AssertionError("Mismatched type for col0 between then block (<['256'], bf16>)
               and else block (<['256'], fp16>)")
```

The root cause is a dtype mismatch in `_causal_conv1d_fwd_kernel`. Two dtype decisions are made independently in SGLang:

- `conv_states` (the persistent conv cache) is allocated as **`bfloat16`** by default via `mamba2_state_dtype()` in mamba_utils.py, regardless of the model's compute dtype
- When the user passes `--dtype float16`, the input tensor `x` is **`fp16`**

Inside the kernel, both branches of an `if/else` assign to the same variable `col0`:

- The `if load_init_state:` branch loads from `conv_states` via `tl.load`, which inherits the pointer's element type: **`bf16`**
- The `else:` branch initializes zeros using `x_ptr.dtype.element_ty`: **`fp16`**

Triton is a statically typed compiler. It analyses both branches and requires every variable to have a consistent type across all branches. Since `col0` is `bf16` in one branch and `fp16` in the other, Triton refuses to compile. This error only surfaces at the first request because Triton compiles kernels lazily on first use, not at server startup.

## Modifications

Added `.to(x_ptr.dtype.element_ty)` to all `tl.load` calls from `conv_states` inside the `if load_init_state:` block of `_causal_conv1d_fwd_kernel` in `python/sglang/kernels/ops/mamba/causal_conv1d_triton.py`, covering all supported `KERNEL_WIDTH` values (2, 3, 4, 5) and all `col*` variables.

```python
# Before
col0 = tl.load(conv_states_ptrs, mask_w, 0.0)

# After
col0 = tl.load(conv_states_ptrs, mask_w, 0.0).to(x_ptr.dtype.element_ty)
```

This ensures both branches always produce `col*` variables in the same dtype (the compute dtype of `x`), satisfying Triton's type checker. The cast is semantically correct: `conv_states` is a cache whose storage dtype is a memory efficiency choice, and normalizing to the compute dtype on load is the right behavior regardless of what dtype combination is used.


**Tested with:**

```bash
python -m sglang.launch_server \
  --model-path /workspace/models/Qwen3.5-35B-A3B-GPTQ-Int4 \
  --trust-remote-code \
  --dtype float16 \
  --quantization gptq_marlin \
  --context-length 8096 \
  --mem-fraction-static 0.85 \
  --schedule-policy lpm \
  --chunked-prefill-size 8192 \
  --attention-backend triton \
  --tensor-parallel-size 1 \
  --host 127.0.0.1 \
  --port 19182
```

```bash
curl -X POST http://127.0.0.1:19182/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "/workspace/models/Qwen3.5-35B-A3B-GPTQ-Int4",
    "messages": [{"role": "user", "content": "What is the capital of France?"}],
    "max_tokens": 1024,
    "temperature": 0
  }'
```

**Before fix:** Triton `CompilationError`, scheduler crash on first request.

**After fix:**
```json
{
  "choices": [{
    "message": {
      "content": "Thinking Process:\n\n...\n</think>\n\nThe capital of France is **Paris**."
    },
    "finish_reason": "stop"
  }]
}
```

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29714232345](https://github.com/sgl-project/sglang/actions/runs/29714232345)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29714232233](https://github.com/sgl-project/sglang/actions/runs/29714232233)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->