### PR TITLE
[CI] Add 1-gpu-h100-h200 to rerun-test runner_label choices

### DIFF
--- a/.github/workflows/rerun-test.yml
+++ b/.github/workflows/rerun-test.yml
@@ -14,6 +14,7 @@ on:
         type: choice
         options:
           - 1-gpu-h100
+          - 1-gpu-h100-h200
           - 1-gpu-5090
           - 2-gpu-h100
           - 4-gpu-h100


### PR DESCRIPTION
## Summary
- The slash command handler maps suite `stage-b-test-1-gpu-large` to runner label `1-gpu-h100-h200` (`scripts/ci/utils/slash_command_handler.py:481`), but `rerun-test.yml`'s `runner_label` `choice` input did not include it.
- This caused `/rerun-test` on any test registered to that suite to fail with `Dispatch failed: 422` from GitHub's `workflow_dispatch` API (e.g. https://github.com/sgl-project/sglang/pull/23182#issuecomment-4363066641).
- `1-gpu-h100-h200` is already a real shared runner label used by `pr-test.yml:827` for the same suite, so this just lets `rerun-test.yml` accept it too.

## Test plan
- [ ] Trigger `/rerun-test test/registered/model_loading/test_utils_update_weights.py` on a follow-up PR and confirm the workflow dispatches successfully instead of returning 422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)