### PR TITLE
[CI] drop --prerelease allow from uv pip install suffix

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = [
   "IPython",
   "aiohttp",
-  "apache-tvm-ffi>=0.1.5,<0.1.11",
+  "apache-tvm-ffi>=0.1.5,<0.2",
   "anthropic>=0.20.0",
   "blobfile==3.0.0",
   "build",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = [
   "IPython",
   "aiohttp",
-  "apache-tvm-ffi>=0.1.5,<0.2",
+  "apache-tvm-ffi>=0.1.5,<0.1.11",
   "anthropic>=0.20.0",
   "blobfile==3.0.0",
   "build",

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -176,7 +176,7 @@ setup_pip_toolchain() {
 
     export UV_LINK_MODE=copy
     PIP_CMD="uv pip"
-    PIP_INSTALL_SUFFIX="--index-strategy unsafe-best-match --prerelease allow"
+    PIP_INSTALL_SUFFIX="--index-strategy unsafe-best-match"
     PIP_UNINSTALL_CMD="uv pip uninstall"
     PIP_UNINSTALL_SUFFIX=""
 


### PR DESCRIPTION
## Summary

Drop `--prerelease allow` from `PIP_INSTALL_SUFFIX` in `scripts/ci/cuda/ci_install_dependency.sh` so uv prefers stable releases on every fleet. Pure CI hygiene — no functional fix.

### History (for the record)

This PR was originally opened as a fix for a `FileNotFoundError: '/root/.cache/tvm-ffi/sgl_kernel_jit_nvfp4_quant_*'` crash on `stage-c-test-4-gpu-b200`. First diagnosis blamed `apache-tvm-ffi 0.1.11rc2` (released 2026-04-28) being auto-pulled under `--prerelease allow`.

After landing the flag drop and capping `<0.1.11`, the same crash reproduced under stable `apache-tvm-ffi 0.1.10` — so the version was a red herring. Real cause: every failing job ran on `b200-di01-0123`, where the container's bind-mounted `/root/.cache/tvm-ffi` was an **orphaned inode** (`Links: 0`) — the host's `/data/cache/tvm-ffi` had been deleted and recreated while the container kept its old mount, so the kernel could `stat` the path but `mkdir` of any child returned ENOENT. Fixed out-of-band by `docker restart` on the affected containers.

The `<0.1.11` cap commit was reverted; only the `--prerelease allow` drop remains in this PR.

## Test plan

- [ ] CI passes on this PR
- [ ] `pip list | grep apache-tvm-ffi` in any post-install CI log shows `0.1.10` (not `0.1.11rc2`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)