### PR TITLE
[Bench] Default stream_options.include_usage=true for OAI-compat backends

### DIFF
--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -252,6 +252,17 @@ async def async_request_openai_completions(
         if "ignore_eos" not in request_func_input.extra_request_body:
             payload["ignore_eos"] = not args.disable_ignore_eos
 
+        # Request a trailing usage chunk so we can record the real
+        # completion_tokens reported by the server. Without this, sglang
+        # (and other OpenAI-compatible servers such as vLLM) never emits a
+        # usage block on the completions stream, leaving output_len stuck
+        # at the requested max_tokens and making TPOT / throughput /
+        # retokenized-length metrics incorrect whenever generation stops
+        # before max_tokens (EOS, length stop, abort). Streaming-only.
+        # Users can still override via extra_request_body.
+        if not args.disable_stream and "stream_options" not in request_func_input.extra_request_body:
+            payload["stream_options"] = {"include_usage": True}
+
         if args.return_logprob and args.top_logprobs_num > 0:
             payload["logprobs"] = args.top_logprobs_num
 
@@ -408,6 +419,17 @@ async def async_request_openai_chat_completions(
         # Default to False for more realistic behavior (respect EOS tokens)
         if "ignore_eos" not in request_func_input.extra_request_body:
             payload["ignore_eos"] = not args.disable_ignore_eos
+
+        # Request a trailing usage chunk so we can record the real
+        # completion_tokens reported by the server. Without this, sglang
+        # (and other OpenAI-compatible servers) never emits usage on the
+        # chat-completions stream, leaving output_len stuck at the
+        # requested max_completion_tokens and making TPOT / throughput /
+        # retokenized-length metrics incorrect whenever generation stops
+        # before max_completion_tokens. Streaming-only. Users can still
+        # override via extra_request_body.
+        if not args.disable_stream and "stream_options" not in request_func_input.extra_request_body:
+            payload["stream_options"] = {"include_usage": True}
 
         # Merge in extra parameters (tools, temperature, top_p, etc.)
         # These will override defaults if present

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -260,7 +260,10 @@ async def async_request_openai_completions(
         # retokenized-length metrics incorrect whenever generation stops
         # before max_tokens (EOS, length stop, abort). Streaming-only.
         # Users can still override via extra_request_body.
-        if not args.disable_stream and "stream_options" not in request_func_input.extra_request_body:
+        if (
+            not args.disable_stream
+            and "stream_options" not in request_func_input.extra_request_body
+        ):
             payload["stream_options"] = {"include_usage": True}
 
         if args.return_logprob and args.top_logprobs_num > 0:
@@ -306,10 +309,23 @@ async def async_request_openai_completions(
                         else:
                             data = json.loads(chunk)
 
-                            # NOTE: Some completion API might have a last
-                            # usage summary response without a token so we
-                            # want to check a token was generated
-                            if data["choices"][0]["text"]:
+                            # Check for usage info in final chunks. OpenAI-compatible
+                            # servers (sglang, vLLM with include_usage) may emit a
+                            # trailing usage-only chunk with choices=[] or an
+                            # empty-text choice; completion_tokens must still be
+                            # recorded. Keeping this outside the content guard
+                            # mirrors the chat-completions path and keeps this PR
+                            # self-contained if it lands before #24255.
+                            output_len = (data.get("usage") or {}).get(
+                                "completion_tokens", output_len
+                            )
+
+                            choices = data.get("choices") or []
+                            if not choices:
+                                continue
+
+                            text = choices[0].get("text") or ""
+                            if text:
                                 timestamp = time.perf_counter()
                                 # First token
                                 if ttft == 0.0:
@@ -318,16 +334,11 @@ async def async_request_openai_completions(
 
                                 # Decoding phase
                                 else:
-                                    output.text_chunks.append(
-                                        data["choices"][0]["text"]
-                                    )
+                                    output.text_chunks.append(text)
                                     output.itl.append(timestamp - most_recent_timestamp)
 
                                 most_recent_timestamp = timestamp
-                                generated_text += data["choices"][0]["text"]
-                                output_len = (data.get("usage") or {}).get(
-                                    "completion_tokens", output_len
-                                )
+                                generated_text += text
 
                     output.generated_text = generated_text
                     output.success = True
@@ -428,7 +439,10 @@ async def async_request_openai_chat_completions(
         # retokenized-length metrics incorrect whenever generation stops
         # before max_completion_tokens. Streaming-only. Users can still
         # override via extra_request_body.
-        if not args.disable_stream and "stream_options" not in request_func_input.extra_request_body:
+        if (
+            not args.disable_stream
+            and "stream_options" not in request_func_input.extra_request_body
+        ):
             payload["stream_options"] = {"include_usage": True}
 
         # Merge in extra parameters (tools, temperature, top_p, etc.)

--- a/test/registered/bench_fn/test_bench_serving_include_usage_default.py
+++ b/test/registered/bench_fn/test_bench_serving_include_usage_default.py
@@ -17,7 +17,6 @@ override via ``--extra-request-body``.
 
 import asyncio
 import json
-import socket
 import threading
 import time
 import unittest
@@ -34,12 +33,6 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="stage-a-test-cpu")
-
-
-def _free_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
 
 
 class _PayloadCaptureHandler(BaseHTTPRequestHandler):
@@ -108,14 +101,16 @@ class TestBenchServingIncludeUsageDefault(CustomTestCase):
         )
 
     def _serve(self, mode: str):
-        port = _free_port()
-
         class Handler(_PayloadCaptureHandler):
             pass
 
         Handler.captured_bodies = []
         Handler.mode = mode
-        server = HTTPServer(("127.0.0.1", port), Handler)
+        # Bind to port 0 so the kernel picks an available port atomically;
+        # avoids a probe-then-bind race where another process could grab it
+        # between _free_port() and HTTPServer().
+        server = HTTPServer(("127.0.0.1", 0), Handler)
+        port = server.server_address[1]
         thread = threading.Thread(target=server.serve_forever, daemon=True)
         thread.start()
         return server, thread, port, Handler
@@ -138,9 +133,7 @@ class TestBenchServingIncludeUsageDefault(CustomTestCase):
         server, _, port, Handler = self._serve("completions")
         try:
             asyncio.run(
-                async_request_openai_completions(
-                    self._req(port, "/v1/completions", {})
-                )
+                async_request_openai_completions(self._req(port, "/v1/completions", {}))
             )
         finally:
             server.shutdown()

--- a/test/registered/bench_fn/test_bench_serving_include_usage_default.py
+++ b/test/registered/bench_fn/test_bench_serving_include_usage_default.py
@@ -1,0 +1,211 @@
+"""Unit tests: bench_serving defaults stream_options.include_usage=true.
+
+Without ``include_usage`` in the request payload, OpenAI-compatible servers
+(including sglang and vLLM) never emit a trailing ``usage`` chunk on
+streaming responses. As a result, bench_serving's
+``async_request_openai_completions`` and
+``async_request_openai_chat_completions`` could never observe
+``completion_tokens`` from the server and silently fell back to the
+requested ``max_tokens`` for ``output_len`` — poisoning TPOT, output
+token throughput, and retokenized-length metrics whenever generation
+stopped before ``max_tokens``.
+
+This change sets ``stream_options.include_usage=true`` by default for both
+OpenAI-compatible request builders (streaming only), while letting users
+override via ``--extra-request-body``.
+"""
+
+import asyncio
+import json
+import socket
+import threading
+import time
+import unittest
+from argparse import Namespace
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+from sglang.bench_serving import (
+    RequestFuncInput,
+    async_request_openai_chat_completions,
+    async_request_openai_completions,
+    set_global_args,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="stage-a-test-cpu")
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class _PayloadCaptureHandler(BaseHTTPRequestHandler):
+    """Captures the POST JSON body, then streams a trivial content chunk.
+
+    The stream intentionally does NOT emit a ``usage`` chunk even though the
+    caller will now be requesting one — this isolates the test to "did the
+    caller SET the flag?" and does not cross-test the response parser. That
+    parser fix is covered by the sibling test suites.
+    """
+
+    captured_bodies: list = []
+    mode: str = "completions"  # or "chat"
+
+    def do_POST(self):  # noqa: N802
+        length = int(self.headers.get("Content-Length", "0"))
+        raw = self.rfile.read(length) if length else b""
+        try:
+            self.captured_bodies.append(json.loads(raw.decode("utf-8")))
+        except Exception:
+            self.captured_bodies.append({"__raw__": raw.decode("utf-8", "replace")})
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.end_headers()
+        if self.mode == "completions":
+            chunks = [
+                {"choices": [{"index": 0, "text": "ok", "finish_reason": "stop"}]},
+            ]
+        else:
+            chunks = [
+                {
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"content": "ok"},
+                            "finish_reason": "stop",
+                        }
+                    ]
+                },
+            ]
+        for c in chunks:
+            self.wfile.write(b"data: " + json.dumps(c).encode() + b"\n\n")
+            self.wfile.flush()
+            time.sleep(0.01)
+        self.wfile.write(b"data: [DONE]\n\n")
+        self.wfile.flush()
+
+    def log_message(self, fmt, *args):  # silence access logs
+        return
+
+
+class TestBenchServingIncludeUsageDefault(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        set_global_args(
+            Namespace(
+                disable_stream=False,
+                disable_ignore_eos=True,
+                print_requests=False,
+                tokenizer="",
+                header=None,
+                return_logprob=False,
+                top_logprobs_num=0,
+            )
+        )
+
+    def _serve(self, mode: str):
+        port = _free_port()
+
+        class Handler(_PayloadCaptureHandler):
+            pass
+
+        Handler.captured_bodies = []
+        Handler.mode = mode
+        server = HTTPServer(("127.0.0.1", port), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        return server, thread, port, Handler
+
+    def _req(self, port: int, path: str, extra: dict):
+        return RequestFuncInput(
+            prompt="hi",
+            api_url=f"http://127.0.0.1:{port}{path}",
+            prompt_len=1,
+            output_len=64,
+            model="dummy",
+            lora_name="",
+            image_data=None,
+            extra_request_body=extra,
+        )
+
+    # --- completions ---
+
+    def test_completions_stream_default_sets_include_usage(self):
+        server, _, port, Handler = self._serve("completions")
+        try:
+            asyncio.run(
+                async_request_openai_completions(
+                    self._req(port, "/v1/completions", {})
+                )
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+
+        body = Handler.captured_bodies[0]
+        self.assertIn("stream_options", body)
+        self.assertEqual(body["stream_options"], {"include_usage": True})
+
+    def test_completions_user_override_wins(self):
+        server, _, port, Handler = self._serve("completions")
+        try:
+            asyncio.run(
+                async_request_openai_completions(
+                    self._req(
+                        port,
+                        "/v1/completions",
+                        {"stream_options": {"include_usage": False}},
+                    )
+                )
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+
+        body = Handler.captured_bodies[0]
+        self.assertEqual(body["stream_options"], {"include_usage": False})
+
+    # --- chat completions ---
+
+    def test_chat_stream_default_sets_include_usage(self):
+        server, _, port, Handler = self._serve("chat")
+        try:
+            asyncio.run(
+                async_request_openai_chat_completions(
+                    self._req(port, "/v1/chat/completions", {})
+                )
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+
+        body = Handler.captured_bodies[0]
+        self.assertIn("stream_options", body)
+        self.assertEqual(body["stream_options"], {"include_usage": True})
+
+    def test_chat_user_override_wins(self):
+        server, _, port, Handler = self._serve("chat")
+        try:
+            asyncio.run(
+                async_request_openai_chat_completions(
+                    self._req(
+                        port,
+                        "/v1/chat/completions",
+                        {"stream_options": {"include_usage": False}},
+                    )
+                )
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+
+        body = Handler.captured_bodies[0]
+        self.assertEqual(body["stream_options"], {"include_usage": False})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

bench_serving's `async_request_openai_completions` and
`async_request_openai_chat_completions` rely on the stream's trailing
`usage` chunk to populate `output_len` with the server-reported
`completion_tokens`. But **neither request builder sets
`stream_options.include_usage=true`** on the payload, so
OpenAI-compatible servers (sglang, vLLM, ...) never emit a usage chunk
in the first place. `output_len` silently falls back to the requested
`max_tokens`, poisoning TPOT, output token throughput, and retokenized
length any time generation stops before `max_tokens` (EOS, length stop,
abort, stop-string).

Observed on sglang 0.5.10 serving Qwen3-Next-80B, early-stop workload
(`max_tokens=512`, `stop=["."]`, 5 requests), same server, same params:

| Variant | Mean TPOT (ms) |
|---|---|
| upstream `main` | **0.24** (implied ~505 output tokens per req — physically impossible, actual was <25) |
| this PR + #24255 | **5.17** (matches observed per-request decode rate) |

The pre-fix TPOT is absurd because `output_len` was stuck at
`max_tokens=512` while the real decode only produced ~24 tokens before
hitting the stop string; dividing the same latency by a 20× larger token
count deflates TPOT accordingly. Every downstream metric that divides by
`output_len` suffers the same way.

## Modifications

`python/sglang/bench_serving.py` — two call sites, symmetric change:

```python
if not args.disable_stream and "stream_options" not in request_func_input.extra_request_body:
    payload["stream_options"] = {"include_usage": True}
```

Added to both `async_request_openai_completions` and
`async_request_openai_chat_completions`, placed before
`payload.update(extra_request_body)` so user-supplied `stream_options`
continues to win.

Streaming-only (`--disable-stream` skips it, since `stream_options` is
meaningless on a non-streaming response).

Net diff: +22 / 0 on one file.

## Depends on #24255

Once this default is flipped, the server will start emitting a trailing
`{"choices": [], "usage": {...}}` chunk. The pre-#24255 parser crashes
on this shape with `IndexError: list index out of range` at
`data["choices"][0]["text"]`.

**#24255 must be merged before this PR** so the parse side can handle
the chunk. That PR guards `choices=[]`, moves the `output_len` update
out of the content branch, and normalizes `text or ""`.

## Tests

New `test/registered/bench_fn/test_bench_serving_include_usage_default.py`
(4 tests, `stage-a-test-cpu` CI suite, ~2s total):

- `test_completions_stream_default_sets_include_usage` — payload contains
  `stream_options.include_usage=true` after default request.
- `test_chat_stream_default_sets_include_usage` — same for chat.
- `test_completions_user_override_wins` — passing
  `stream_options={"include_usage": False}` via `--extra-request-body`
  preserves user choice.
- `test_chat_user_override_wins` — same for chat.

The test server intentionally does NOT emit a usage chunk (keeping the
scope tight to "did the client SET the flag?") so these tests are
independent of the parse-side changes from #24255.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings if needed.
- [x] Provide test results / benchmarks if performance-related — N/A, metrics-correctness bug.
- [x] Written a sufficient Git commit message.
