### PR TITLE
[KDA] Optimize prefill kernels with diagonal and recompute fuse

### DIFF
--- a/python/sglang/srt/layers/attention/fla/chunk_delta_h.py
+++ b/python/sglang/srt/layers/attention/fla/chunk_delta_h.py
@@ -13,22 +13,22 @@ from sglang.srt.layers.attention.fla.index import (
     prepare_chunk_offsets,
 )
 from sglang.srt.layers.attention.fla.op import exp, safe_exp
-from sglang.srt.layers.attention.fla.utils import is_nvidia_hopper
+from sglang.srt.layers.attention.fla.utils import is_nvidia_hopper, autotune_cache_kwargs
 
 NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8, 16]
 CHUNK_SIZE = 64
 
 
-# @triton.autotune(
-#     configs=[
-#         triton.Config({"BV": BV}, num_warps=num_warps, num_stages=num_stages)
-#         for num_warps in [2, 4]
-#         for num_stages in [2, 3, 4]
-#         for BV in [32, 64]
-#     ],
-#     key=["H", "K", "V", "BT", "USE_G"],
-#     use_cuda_graph=use_cuda_graph,
-# )
+@triton.autotune(
+    configs=[
+        triton.Config({"BV": BV}, num_warps=num_warps, num_stages=num_stages)
+        for BV in [32, 64]
+        for num_warps in [2, 4]
+        for num_stages in [2, 3, 4]
+    ],
+    key=["H", "K", "V", "BT", "USE_GK"],
+    **autotune_cache_kwargs,
+)
 @triton.jit(do_not_specialize=["T"])
 def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
     k,
@@ -325,14 +325,11 @@ def chunk_gated_delta_rule_fwd_h(
         K=K,
         V=V,
         BT=BT,
-        BV=32,
         USE_G=g is not None,
         USE_GK=gk is not None,
         USE_INITIAL_STATE=initial_state is not None,
         INPLACE_UPDATE=True,
         SAVE_NEW_VALUE=v_new is not None,
         IS_VARLEN=cu_seqlens is not None,
-        num_warps=4,
-        num_stages=2,
     )
     return h, v_new

--- a/python/sglang/srt/layers/attention/fla/chunk_delta_h.py
+++ b/python/sglang/srt/layers/attention/fla/chunk_delta_h.py
@@ -13,7 +13,10 @@ from sglang.srt.layers.attention.fla.index import (
     prepare_chunk_offsets,
 )
 from sglang.srt.layers.attention.fla.op import exp, safe_exp
-from sglang.srt.layers.attention.fla.utils import is_nvidia_hopper, autotune_cache_kwargs
+from sglang.srt.layers.attention.fla.utils import (
+    autotune_cache_kwargs,
+    is_nvidia_hopper,
+)
 
 NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8, 16]
 CHUNK_SIZE = 64
@@ -22,11 +25,11 @@ CHUNK_SIZE = 64
 @triton.autotune(
     configs=[
         triton.Config({"BV": BV}, num_warps=num_warps, num_stages=num_stages)
-        for BV in [32, 64]
-        for num_warps in [2, 4]
-        for num_stages in [2, 3, 4]
+        for BV in [32]
+        for num_warps in [4]
+        for num_stages in [2]
     ],
-    key=["H", "K", "V", "BT", "USE_GK"],
+    key=["H", "K", "V", "BT", "USE_GK", "NT_BUCKET"],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=["T"])
@@ -55,6 +58,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
     INPLACE_UPDATE: tl.constexpr,
     SAVE_NEW_VALUE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    NT_BUCKET: tl.constexpr,
 ):
     i_v, i_nh = tl.program_id(0), tl.program_id(1)
     i_n, i_h = i_nh // H, i_nh % H
@@ -331,5 +335,6 @@ def chunk_gated_delta_rule_fwd_h(
         INPLACE_UPDATE=True,
         SAVE_NEW_VALUE=v_new is not None,
         IS_VARLEN=cu_seqlens is not None,
+        NT_BUCKET=(0 if NT <= 32 else (1 if NT <= 128 else 2)),
     )
     return h, v_new

--- a/python/sglang/srt/layers/attention/fla/chunk_delta_h.py
+++ b/python/sglang/srt/layers/attention/fla/chunk_delta_h.py
@@ -23,12 +23,17 @@ CHUNK_SIZE = 64
 
 
 @triton.autotune(
-    configs=[
-        triton.Config({"BV": BV}, num_warps=num_warps, num_stages=num_stages)
-        for BV in [32]
-        for num_warps in [4]
-        for num_stages in [2]
-    ],
+    # Single hardcoded config. The kernel writes ht (final state) back into
+    # initial_state in-place; with multiple configs, triton's autotune benchmark
+    # phase invokes the kernel many times for timing and corrupts the cache pool,
+    # producing silently wrong output on the first user request. Restoring via
+    # `restore_value=["initial_state"]` works for unit tests but OOMs on
+    # production-scale models (e.g. Kimi-Linear-48B at default mem_fraction)
+    # because cloning the cache pool for each benchmark exceeds available memory.
+    # NT_BUCKET is kept in the autotune key for forward-compatibility (allows
+    # future per-bucket configs once the kernel is refactored to write final
+    # state to a separate output buffer).
+    configs=[triton.Config({"BV": 32}, num_warps=4, num_stages=2)],
     key=["H", "K", "V", "BT", "USE_GK", "NT_BUCKET"],
     **autotune_cache_kwargs,
 )

--- a/python/sglang/srt/layers/attention/fla/chunk_intra.py
+++ b/python/sglang/srt/layers/attention/fla/chunk_intra.py
@@ -11,7 +11,7 @@ from sglang.srt.layers.attention.fla.chunk_intra_token_parallel import (
 from sglang.srt.layers.attention.fla.index import (
     prepare_chunk_indices,
 )
-from sglang.srt.layers.attention.fla.op import exp2, gather
+from sglang.srt.layers.attention.fla.op import exp, exp2, gather
 from sglang.srt.layers.attention.fla.utils import (
     autotune_cache_kwargs,
     is_gather_supported,
@@ -36,11 +36,9 @@ else:
 )
 @triton.autotune(
     configs=[
-        triton.Config({"BK": BK}, num_warps=num_warps)
-        for BK in [32, 64]
-        for num_warps in [1, 2, 4]
+        triton.Config({"BK": 64}, num_warps=4, maxnreg=128, num_stages=1),
     ],
-    key=["H", "K", "BC"],
+    key=["H", "K", "BC", "V"],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=["T"])
@@ -53,16 +51,24 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
     Akkd,
     Akk,
     scale,
+    v_in,
+    w_out,
+    u_out,
+    kg_out,
     cu_seqlens,
     chunk_indices,
     T,
     H: tl.constexpr,
     K: tl.constexpr,
+    V: tl.constexpr,
     BT: tl.constexpr,
     BC: tl.constexpr,
     BK: tl.constexpr,
+    BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_SAFE_GATE: tl.constexpr,
+    FUSE_RECOMPUTE: tl.constexpr,
+    FUSE_DIAGONAL: tl.constexpr,
 ):
     """
     Fused kernel: compute inter-subchunk Akk + solve_tril in one pass.
@@ -125,8 +131,19 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
     b_Aqk32 = tl.zeros([BC, BC], dtype=tl.float32)
     b_Akk32 = tl.zeros([BC, BC], dtype=tl.float32)
 
+    if FUSE_DIAGONAL:
+        b_Aqk_d0 = tl.zeros([BC, BC], dtype=tl.float32)
+        b_Akk_d0 = tl.zeros([BC, BC], dtype=tl.float32)
+        b_Aqk_d1 = tl.zeros([BC, BC], dtype=tl.float32)
+        b_Akk_d1 = tl.zeros([BC, BC], dtype=tl.float32)
+        b_Aqk_d2 = tl.zeros([BC, BC], dtype=tl.float32)
+        b_Akk_d2 = tl.zeros([BC, BC], dtype=tl.float32)
+        b_Aqk_d3 = tl.zeros([BC, BC], dtype=tl.float32)
+        b_Akk_d3 = tl.zeros([BC, BC], dtype=tl.float32)
+        m_tc0 = (i_tc0 + o_i) < T
+
     ################################################################################
-    # off-diagonal blocks
+    # off-diagonal blocks (+ optional diagonal blocks)
     ################################################################################
     for i_k in range(tl.cdiv(K, BK)):
         o_k = i_k * BK + tl.arange(0, BK)
@@ -140,6 +157,19 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
         )
         b_k0 = tl.load(p_k0, boundary_check=(0, 1)).to(tl.float32)
         b_g0 = tl.load(p_g0, boundary_check=(0, 1)).to(tl.float32)
+
+        if FUSE_DIAGONAL:
+            p_q0 = tl.make_block_ptr(
+                q, (T, K), (H * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0)
+            )
+            b_q0 = tl.load(p_q0, boundary_check=(0, 1)).to(tl.float32)
+            b_gn0 = tl.load(g + i_tc0 * H * K + o_k, mask=m_k, other=0).to(tl.float32)
+            b_gm0 = tl.clamp(b_g0 - b_gn0[None, :], -126.0, 126.0)
+            b_gq0 = tl.where(m_tc0[:, None], exp2(b_gm0), 0.0)
+            b_gk0 = tl.where(m_tc0[:, None], exp2(-b_gm0), 0.0)
+            b_kgt_d0 = tl.trans(b_k0 * b_gk0)
+            b_Aqk_d0 += tl.dot(b_q0 * b_gq0, b_kgt_d0)
+            b_Akk_d0 += tl.dot(b_k0 * b_gq0, b_kgt_d0)
 
         if i_tc1 < T:
             p_q1 = tl.make_block_ptr(
@@ -160,10 +190,19 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
             # [BC, BK]
             b_gqn = tl.where(m_tc1[:, None], exp2(b_g1 - b_gn1[None, :]), 0)
             # [BK, BC]
-            b_kgt = tl.trans(b_k0 * exp2(b_gn1[None, :] - b_g0))
+            b_kgt = tl.trans(b_k0 * exp2(b_gn1[None, :] - b_g0)).to(tl.bfloat16)
             # [BC, BC]
-            b_Aqk10 += tl.dot(b_q1 * b_gqn, b_kgt)
-            b_Akk10 += tl.dot(b_k1 * b_gqn, b_kgt)
+            b_qg1 = (b_q1 * b_gqn).to(tl.bfloat16)
+            b_kg1 = (b_k1 * b_gqn).to(tl.bfloat16)
+            b_Aqk10 += tl.dot(b_qg1, b_kgt)
+            b_Akk10 += tl.dot(b_kg1, b_kgt)
+
+            if FUSE_DIAGONAL:
+                b_gm1_d = tl.clamp(b_gn1[None, :] - b_g1, -126.0, 126.0)
+                b_gk1_d = tl.where(m_tc1[:, None], exp2(b_gm1_d), 0.0)
+                b_kgt_d1 = tl.trans(b_k1 * b_gk1_d)
+                b_Aqk_d1 += tl.dot(b_q1 * b_gqn, b_kgt_d1)
+                b_Akk_d1 += tl.dot(b_k1 * b_gqn, b_kgt_d1)
 
             if i_tc2 < T:
                 p_q2 = tl.make_block_ptr(
@@ -185,17 +224,24 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
                 )
                 # [BC, BK]
                 b_gqn2 = tl.where(m_tc2[:, None], exp2(b_g2 - b_gn2[None, :]), 0)
-                b_qg2 = b_q2 * b_gqn2
-                b_kg2 = b_k2 * b_gqn2
+                b_qg2 = (b_q2 * b_gqn2).to(tl.bfloat16)
+                b_kg2 = (b_k2 * b_gqn2).to(tl.bfloat16)
                 # [BK, BC]
-                b_kgt = tl.trans(b_k0 * exp2(b_gn2[None, :] - b_g0))
+                b_kgt = tl.trans(b_k0 * exp2(b_gn2[None, :] - b_g0)).to(tl.bfloat16)
                 b_Aqk20 += tl.dot(b_qg2, b_kgt)
                 b_Akk20 += tl.dot(b_kg2, b_kgt)
                 # [BC, BC]
-                b_kgt = tl.trans(b_k1 * exp2(b_gn2[None, :] - b_g1))
+                b_kgt = tl.trans(b_k1 * exp2(b_gn2[None, :] - b_g1)).to(tl.bfloat16)
                 # [BC, BC]
                 b_Aqk21 += tl.dot(b_qg2, b_kgt)
                 b_Akk21 += tl.dot(b_kg2, b_kgt)
+
+                if FUSE_DIAGONAL:
+                    b_gm2_d = tl.clamp(b_gn2[None, :] - b_g2, -126.0, 126.0)
+                    b_gk2_d = tl.where(m_tc2[:, None], exp2(b_gm2_d), 0.0)
+                    b_kgt_d2 = tl.trans(b_k2 * b_gk2_d)
+                    b_Aqk_d2 += tl.dot(b_q2 * b_gqn2, b_kgt_d2)
+                    b_Akk_d2 += tl.dot(b_k2 * b_gqn2, b_kgt_d2)
 
                 if i_tc3 < T:
                     p_q3 = tl.make_block_ptr(
@@ -217,23 +263,30 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
                     )
                     # [BC, BK]
                     b_gqn3 = tl.where(m_tc3[:, None], exp2(b_g3 - b_gn3[None, :]), 0)
-                    b_qg3 = b_q3 * b_gqn3
-                    b_kg3 = b_k3 * b_gqn3
+                    b_qg3 = (b_q3 * b_gqn3).to(tl.bfloat16)
+                    b_kg3 = (b_k3 * b_gqn3).to(tl.bfloat16)
                     # [BK, BC]
-                    b_kgt = tl.trans(b_k0 * exp2(b_gn3[None, :] - b_g0))
+                    b_kgt = tl.trans(b_k0 * exp2(b_gn3[None, :] - b_g0)).to(tl.bfloat16)
                     # [BC, BC]
                     b_Aqk30 += tl.dot(b_qg3, b_kgt)
                     b_Akk30 += tl.dot(b_kg3, b_kgt)
                     # [BK, BC]
-                    b_kgt = tl.trans(b_k1 * exp2(b_gn3[None, :] - b_g1))
+                    b_kgt = tl.trans(b_k1 * exp2(b_gn3[None, :] - b_g1)).to(tl.bfloat16)
                     # [BC, BC]
                     b_Aqk31 += tl.dot(b_qg3, b_kgt)
                     b_Akk31 += tl.dot(b_kg3, b_kgt)
                     # [BK, BC]
-                    b_kgt = tl.trans(b_k2 * exp2(b_gn3[None, :] - b_g2))
+                    b_kgt = tl.trans(b_k2 * exp2(b_gn3[None, :] - b_g2)).to(tl.bfloat16)
                     # [BC, BC]
                     b_Aqk32 += tl.dot(b_qg3, b_kgt)
                     b_Akk32 += tl.dot(b_kg3, b_kgt)
+
+                    if FUSE_DIAGONAL:
+                        b_gm3_d = tl.clamp(b_gn3[None, :] - b_g3, -126.0, 126.0)
+                        b_gk3_d = tl.where(m_tc3[:, None], exp2(b_gm3_d), 0.0)
+                        b_kgt_d3 = tl.trans(b_k3 * b_gk3_d)
+                        b_Aqk_d3 += tl.dot(b_q3 * b_gqn3, b_kgt_d3)
+                        b_Akk_d3 += tl.dot(b_k3 * b_gqn3, b_kgt_d3)
 
     ################################################################################
     # save off-diagonal Aqk blocks and prepare Akk
@@ -299,22 +352,95 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
         b_Akk31 = b_Akk31 * b_b3[:, None]
         b_Akk32 = b_Akk32 * b_b3[:, None]
 
-    p_Akk00 = tl.make_block_ptr(
-        Akkd, (T, BC), (H * BC, 1), (i_tc0, 0), (BC, BC), (1, 0)
-    )
-    p_Akk11 = tl.make_block_ptr(
-        Akkd, (T, BC), (H * BC, 1), (i_tc1, 0), (BC, BC), (1, 0)
-    )
-    p_Akk22 = tl.make_block_ptr(
-        Akkd, (T, BC), (H * BC, 1), (i_tc2, 0), (BC, BC), (1, 0)
-    )
-    p_Akk33 = tl.make_block_ptr(
-        Akkd, (T, BC), (H * BC, 1), (i_tc3, 0), (BC, BC), (1, 0)
-    )
-    b_Ai00 = tl.load(p_Akk00, boundary_check=(0, 1)).to(tl.float32)
-    b_Ai11 = tl.load(p_Akk11, boundary_check=(0, 1)).to(tl.float32)
-    b_Ai22 = tl.load(p_Akk22, boundary_check=(0, 1)).to(tl.float32)
-    b_Ai33 = tl.load(p_Akk33, boundary_check=(0, 1)).to(tl.float32)
+    if FUSE_DIAGONAL:
+        m_Aqk_diag = o_i[:, None] >= o_i[None, :]
+        m_Akk_diag = o_i[:, None] > o_i[None, :]
+
+        b_Aqk_d0 = tl.where(m_Aqk_diag, b_Aqk_d0, 0.0)
+        b_Akk_d0 = tl.where(m_Akk_diag, b_Akk_d0, 0.0)
+        b_Aqk_d1 = tl.where(m_Aqk_diag, b_Aqk_d1, 0.0)
+        b_Akk_d1 = tl.where(m_Akk_diag, b_Akk_d1, 0.0)
+        b_Aqk_d2 = tl.where(m_Aqk_diag, b_Aqk_d2, 0.0)
+        b_Akk_d2 = tl.where(m_Akk_diag, b_Akk_d2, 0.0)
+        b_Aqk_d3 = tl.where(m_Aqk_diag, b_Aqk_d3, 0.0)
+        b_Akk_d3 = tl.where(m_Akk_diag, b_Akk_d3, 0.0)
+
+        p_Aqk_d0 = tl.make_block_ptr(
+            Aqk, (T, BT), (H * BT, 1), (i_tc0, 0), (BC, BC), (1, 0)
+        )
+        p_Aqk_d1 = tl.make_block_ptr(
+            Aqk, (T, BT), (H * BT, 1), (i_tc1, BC), (BC, BC), (1, 0)
+        )
+        p_Aqk_d2 = tl.make_block_ptr(
+            Aqk, (T, BT), (H * BT, 1), (i_tc2, 2 * BC), (BC, BC), (1, 0)
+        )
+        p_Aqk_d3 = tl.make_block_ptr(
+            Aqk, (T, BT), (H * BT, 1), (i_tc3, 3 * BC), (BC, BC), (1, 0)
+        )
+        tl.store(p_Aqk_d0, (b_Aqk_d0 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Aqk_d1, (b_Aqk_d1 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Aqk_d2, (b_Aqk_d2 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Aqk_d3, (b_Aqk_d3 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+
+        p_bd0 = tl.make_block_ptr(
+            beta + bos * H + i_h, (T,), (H,), (i_tc0,), (BC,), (0,)
+        )
+        p_bd1 = tl.make_block_ptr(
+            beta + bos * H + i_h, (T,), (H,), (i_tc1,), (BC,), (0,)
+        )
+        p_bd2 = tl.make_block_ptr(
+            beta + bos * H + i_h, (T,), (H,), (i_tc2,), (BC,), (0,)
+        )
+        p_bd3 = tl.make_block_ptr(
+            beta + bos * H + i_h, (T,), (H,), (i_tc3,), (BC,), (0,)
+        )
+        b_bd0 = tl.load(p_bd0, boundary_check=(0,)).to(tl.float32)
+        b_bd1 = tl.load(p_bd1, boundary_check=(0,)).to(tl.float32)
+        b_bd2 = tl.load(p_bd2, boundary_check=(0,)).to(tl.float32)
+        b_bd3 = tl.load(p_bd3, boundary_check=(0,)).to(tl.float32)
+        b_Akk_d0 = b_Akk_d0 * b_bd0[:, None]
+        b_Akk_d1 = b_Akk_d1 * b_bd1[:, None]
+        b_Akk_d2 = b_Akk_d2 * b_bd2[:, None]
+        b_Akk_d3 = b_Akk_d3 * b_bd3[:, None]
+
+        p_Akkd00 = tl.make_block_ptr(
+            Akkd, (T, BC), (H * BC, 1), (i_tc0, 0), (BC, BC), (1, 0)
+        )
+        p_Akkd11 = tl.make_block_ptr(
+            Akkd, (T, BC), (H * BC, 1), (i_tc1, 0), (BC, BC), (1, 0)
+        )
+        p_Akkd22 = tl.make_block_ptr(
+            Akkd, (T, BC), (H * BC, 1), (i_tc2, 0), (BC, BC), (1, 0)
+        )
+        p_Akkd33 = tl.make_block_ptr(
+            Akkd, (T, BC), (H * BC, 1), (i_tc3, 0), (BC, BC), (1, 0)
+        )
+        tl.store(p_Akkd00, b_Akk_d0.to(Akkd.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akkd11, b_Akk_d1.to(Akkd.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akkd22, b_Akk_d2.to(Akkd.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akkd33, b_Akk_d3.to(Akkd.dtype.element_ty), boundary_check=(0, 1))
+
+        b_Ai00 = b_Akk_d0
+        b_Ai11 = b_Akk_d1
+        b_Ai22 = b_Akk_d2
+        b_Ai33 = b_Akk_d3
+    else:
+        p_Akk00 = tl.make_block_ptr(
+            Akkd, (T, BC), (H * BC, 1), (i_tc0, 0), (BC, BC), (1, 0)
+        )
+        p_Akk11 = tl.make_block_ptr(
+            Akkd, (T, BC), (H * BC, 1), (i_tc1, 0), (BC, BC), (1, 0)
+        )
+        p_Akk22 = tl.make_block_ptr(
+            Akkd, (T, BC), (H * BC, 1), (i_tc2, 0), (BC, BC), (1, 0)
+        )
+        p_Akk33 = tl.make_block_ptr(
+            Akkd, (T, BC), (H * BC, 1), (i_tc3, 0), (BC, BC), (1, 0)
+        )
+        b_Ai00 = tl.load(p_Akk00, boundary_check=(0, 1)).to(tl.float32)
+        b_Ai11 = tl.load(p_Akk11, boundary_check=(0, 1)).to(tl.float32)
+        b_Ai22 = tl.load(p_Akk22, boundary_check=(0, 1)).to(tl.float32)
+        b_Ai33 = tl.load(p_Akk33, boundary_check=(0, 1)).to(tl.float32)
 
     ################################################################################
     # forward substitution on diagonals
@@ -397,42 +523,177 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
     )
 
     ################################################################################
-    # store full Akk_inv to Akk
+    # Output: store Akk_inv OR compute w, u, kg from registers
     ################################################################################
 
-    p_Akk00 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc0, 0), (BC, BC), (1, 0))
-    p_Akk10 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc1, 0), (BC, BC), (1, 0))
-    p_Akk11 = tl.make_block_ptr(
-        Akk, (T, BT), (H * BT, 1), (i_tc1, BC), (BC, BC), (1, 0)
-    )
-    p_Akk20 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc2, 0), (BC, BC), (1, 0))
-    p_Akk21 = tl.make_block_ptr(
-        Akk, (T, BT), (H * BT, 1), (i_tc2, BC), (BC, BC), (1, 0)
-    )
-    p_Akk22 = tl.make_block_ptr(
-        Akk, (T, BT), (H * BT, 1), (i_tc2, 2 * BC), (BC, BC), (1, 0)
-    )
-    p_Akk30 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc3, 0), (BC, BC), (1, 0))
-    p_Akk31 = tl.make_block_ptr(
-        Akk, (T, BT), (H * BT, 1), (i_tc3, BC), (BC, BC), (1, 0)
-    )
-    p_Akk32 = tl.make_block_ptr(
-        Akk, (T, BT), (H * BT, 1), (i_tc3, 2 * BC), (BC, BC), (1, 0)
-    )
-    p_Akk33 = tl.make_block_ptr(
-        Akk, (T, BT), (H * BT, 1), (i_tc3, 3 * BC), (BC, BC), (1, 0)
-    )
+    if FUSE_RECOMPUTE:
+        # Cast A-inverse sub-blocks to input dtype for dot products
+        b_Ai00_h = b_Ai00.to(k.dtype.element_ty)
+        b_Ai10_h = b_Ai10.to(k.dtype.element_ty)
+        b_Ai11_h = b_Ai11.to(k.dtype.element_ty)
+        b_Ai20_h = b_Ai20.to(k.dtype.element_ty)
+        b_Ai21_h = b_Ai21.to(k.dtype.element_ty)
+        b_Ai22_h = b_Ai22.to(k.dtype.element_ty)
+        b_Ai30_h = b_Ai30.to(k.dtype.element_ty)
+        b_Ai31_h = b_Ai31.to(k.dtype.element_ty)
+        b_Ai32_h = b_Ai32.to(k.dtype.element_ty)
+        b_Ai33_h = b_Ai33.to(k.dtype.element_ty)
 
-    tl.store(p_Akk00, b_Ai00.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk10, b_Ai10.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk11, b_Ai11.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk20, b_Ai20.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk21, b_Ai21.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk22, b_Ai22.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk30, b_Ai30.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk31, b_Ai31.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk32, b_Ai32.to(Akk.dtype.element_ty), boundary_check=(0, 1))
-    tl.store(p_Akk33, b_Ai33.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        # Load beta for all 4 sub-chunks
+        p_b0 = tl.make_block_ptr(
+            beta + bos * H + i_h, (T,), (H,), (i_tc0,), (BC,), (0,)
+        )
+        b_b0 = tl.load(p_b0, boundary_check=(0,)).to(tl.float32)
+        p_b1r = tl.make_block_ptr(
+            beta + bos * H + i_h, (T,), (H,), (i_tc1,), (BC,), (0,)
+        )
+        b_b1r = tl.load(p_b1r, boundary_check=(0,)).to(tl.float32)
+        p_b2r = tl.make_block_ptr(
+            beta + bos * H + i_h, (T,), (H,), (i_tc2,), (BC,), (0,)
+        )
+        b_b2r = tl.load(p_b2r, boundary_check=(0,)).to(tl.float32)
+        p_b3r = tl.make_block_ptr(
+            beta + bos * H + i_h, (T,), (H,), (i_tc3,), (BC,), (0,)
+        )
+        b_b3r = tl.load(p_b3r, boundary_check=(0,)).to(tl.float32)
+
+        # ---- u = A_inv @ (v * beta) ----
+        v_base = v_in + (bos * H + i_h) * V
+        u_base = u_out + (bos * H + i_h) * V
+        for i_v in range(tl.cdiv(V, BV)):
+            p_v0 = tl.make_block_ptr(v_base, (T, V), (H * V, 1), (i_tc0, i_v * BV), (BC, BV), (1, 0))
+            p_v1 = tl.make_block_ptr(v_base, (T, V), (H * V, 1), (i_tc1, i_v * BV), (BC, BV), (1, 0))
+            p_v2 = tl.make_block_ptr(v_base, (T, V), (H * V, 1), (i_tc2, i_v * BV), (BC, BV), (1, 0))
+            p_v3 = tl.make_block_ptr(v_base, (T, V), (H * V, 1), (i_tc3, i_v * BV), (BC, BV), (1, 0))
+
+            b_v0 = tl.load(p_v0, boundary_check=(0, 1))
+            b_v1 = tl.load(p_v1, boundary_check=(0, 1))
+            b_v2 = tl.load(p_v2, boundary_check=(0, 1))
+            b_v3 = tl.load(p_v3, boundary_check=(0, 1))
+
+            b_vb0 = (b_v0 * b_b0[:, None]).to(b_v0.dtype)
+            b_vb1 = (b_v1 * b_b1r[:, None]).to(b_v1.dtype)
+            b_vb2 = (b_v2 * b_b2r[:, None]).to(b_v2.dtype)
+            b_vb3 = (b_v3 * b_b3r[:, None]).to(b_v3.dtype)
+
+            b_u0 = tl.dot(b_Ai00_h, b_vb0)
+            b_u1 = tl.dot(b_Ai10_h, b_vb0) + tl.dot(b_Ai11_h, b_vb1)
+            b_u2 = tl.dot(b_Ai20_h, b_vb0) + tl.dot(b_Ai21_h, b_vb1) + tl.dot(b_Ai22_h, b_vb2)
+            b_u3 = (
+                tl.dot(b_Ai30_h, b_vb0) + tl.dot(b_Ai31_h, b_vb1)
+                + tl.dot(b_Ai32_h, b_vb2) + tl.dot(b_Ai33_h, b_vb3)
+            )
+
+            p_u0 = tl.make_block_ptr(u_base, (T, V), (H * V, 1), (i_tc0, i_v * BV), (BC, BV), (1, 0))
+            p_u1 = tl.make_block_ptr(u_base, (T, V), (H * V, 1), (i_tc1, i_v * BV), (BC, BV), (1, 0))
+            p_u2 = tl.make_block_ptr(u_base, (T, V), (H * V, 1), (i_tc2, i_v * BV), (BC, BV), (1, 0))
+            p_u3 = tl.make_block_ptr(u_base, (T, V), (H * V, 1), (i_tc3, i_v * BV), (BC, BV), (1, 0))
+            tl.store(p_u0, b_u0.to(p_u0.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_u1, b_u1.to(p_u1.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_u2, b_u2.to(p_u2.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_u3, b_u3.to(p_u3.dtype.element_ty), boundary_check=(0, 1))
+
+        # ---- w = A_inv @ (k * beta * exp(gk)), kg = k * exp(gn - gk) ----
+        w_base = w_out + (bos * H + i_h) * K
+        kg_base = kg_out + (bos * H + i_h) * K
+        last_idx = min(i_t * BT + BT, T) - 1
+
+        for i_k in range(tl.cdiv(K, BK)):
+            o_k = i_k * BK + tl.arange(0, BK)
+            m_k = o_k < K
+            b_gn = tl.load(
+                g + last_idx * H * K + o_k, mask=m_k, other=0.0
+            ).to(tl.float32)
+
+            p_k0 = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0))
+            p_k1 = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
+            p_k2 = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
+            p_k3 = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
+
+            p_gk0 = tl.make_block_ptr(g, (T, K), (H * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0))
+            p_gk1 = tl.make_block_ptr(g, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
+            p_gk2 = tl.make_block_ptr(g, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
+            p_gk3 = tl.make_block_ptr(g, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
+
+            b_k0r = tl.load(p_k0, boundary_check=(0, 1))
+            b_k1r = tl.load(p_k1, boundary_check=(0, 1))
+            b_k2r = tl.load(p_k2, boundary_check=(0, 1))
+            b_k3r = tl.load(p_k3, boundary_check=(0, 1))
+
+            b_gk0r = tl.load(p_gk0, boundary_check=(0, 1)).to(tl.float32)
+            b_gk1r = tl.load(p_gk1, boundary_check=(0, 1)).to(tl.float32)
+            b_gk2r = tl.load(p_gk2, boundary_check=(0, 1)).to(tl.float32)
+            b_gk3r = tl.load(p_gk3, boundary_check=(0, 1)).to(tl.float32)
+
+            b_kb0 = (b_k0r * b_b0[:, None] * exp(b_gk0r)).to(b_k0r.dtype)
+            b_kb1 = (b_k1r * b_b1r[:, None] * exp(b_gk1r)).to(b_k1r.dtype)
+            b_kb2 = (b_k2r * b_b2r[:, None] * exp(b_gk2r)).to(b_k2r.dtype)
+            b_kb3 = (b_k3r * b_b3r[:, None] * exp(b_gk3r)).to(b_k3r.dtype)
+
+            b_w0 = tl.dot(b_Ai00_h, b_kb0)
+            b_w1 = tl.dot(b_Ai10_h, b_kb0) + tl.dot(b_Ai11_h, b_kb1)
+            b_w2 = tl.dot(b_Ai20_h, b_kb0) + tl.dot(b_Ai21_h, b_kb1) + tl.dot(b_Ai22_h, b_kb2)
+            b_w3 = (
+                tl.dot(b_Ai30_h, b_kb0) + tl.dot(b_Ai31_h, b_kb1)
+                + tl.dot(b_Ai32_h, b_kb2) + tl.dot(b_Ai33_h, b_kb3)
+            )
+
+            p_w0 = tl.make_block_ptr(w_base, (T, K), (H * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0))
+            p_w1 = tl.make_block_ptr(w_base, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
+            p_w2 = tl.make_block_ptr(w_base, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
+            p_w3 = tl.make_block_ptr(w_base, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
+            tl.store(p_w0, b_w0.to(p_w0.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_w1, b_w1.to(p_w1.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_w2, b_w2.to(p_w2.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_w3, b_w3.to(p_w3.dtype.element_ty), boundary_check=(0, 1))
+
+            b_kg0 = b_k0r * exp(b_gn[None, :] - b_gk0r)
+            b_kg1 = b_k1r * exp(b_gn[None, :] - b_gk1r)
+            b_kg2 = b_k2r * exp(b_gn[None, :] - b_gk2r)
+            b_kg3 = b_k3r * exp(b_gn[None, :] - b_gk3r)
+
+            p_kg0 = tl.make_block_ptr(kg_base, (T, K), (H * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0))
+            p_kg1 = tl.make_block_ptr(kg_base, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
+            p_kg2 = tl.make_block_ptr(kg_base, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
+            p_kg3 = tl.make_block_ptr(kg_base, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
+            tl.store(p_kg0, b_kg0.to(p_kg0.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_kg1, b_kg1.to(p_kg1.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_kg2, b_kg2.to(p_kg2.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_kg3, b_kg3.to(p_kg3.dtype.element_ty), boundary_check=(0, 1))
+    else:
+        p_Akk00 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc0, 0), (BC, BC), (1, 0))
+        p_Akk10 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc1, 0), (BC, BC), (1, 0))
+        p_Akk11 = tl.make_block_ptr(
+            Akk, (T, BT), (H * BT, 1), (i_tc1, BC), (BC, BC), (1, 0)
+        )
+        p_Akk20 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc2, 0), (BC, BC), (1, 0))
+        p_Akk21 = tl.make_block_ptr(
+            Akk, (T, BT), (H * BT, 1), (i_tc2, BC), (BC, BC), (1, 0)
+        )
+        p_Akk22 = tl.make_block_ptr(
+            Akk, (T, BT), (H * BT, 1), (i_tc2, 2 * BC), (BC, BC), (1, 0)
+        )
+        p_Akk30 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc3, 0), (BC, BC), (1, 0))
+        p_Akk31 = tl.make_block_ptr(
+            Akk, (T, BT), (H * BT, 1), (i_tc3, BC), (BC, BC), (1, 0)
+        )
+        p_Akk32 = tl.make_block_ptr(
+            Akk, (T, BT), (H * BT, 1), (i_tc3, 2 * BC), (BC, BC), (1, 0)
+        )
+        p_Akk33 = tl.make_block_ptr(
+            Akk, (T, BT), (H * BT, 1), (i_tc3, 3 * BC), (BC, BC), (1, 0)
+        )
+
+        tl.store(p_Akk00, b_Ai00.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk10, b_Ai10.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk11, b_Ai11.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk20, b_Ai20.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk21, b_Ai21.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk22, b_Ai22.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk30, b_Ai30.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk31, b_Ai31.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk32, b_Ai32.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk33, b_Ai33.to(Akk.dtype.element_ty), boundary_check=(0, 1))
 
 
 @triton.heuristics(
@@ -573,8 +834,12 @@ def chunk_kda_fwd_intra(
     chunk_indices: torch.LongTensor | None = None,
     safe_gate: bool = False,
     disable_recompute: bool = False,
+    skip_recompute: bool = False,
+    fuse_recompute: bool = False,
+    fuse_diagonal: bool = False,
 ):
     B, T, H, K = k.shape
+    V = v.shape[-1]
     BT = chunk_size
     BC = 16
     if chunk_indices is None and cu_seqlens is not None:
@@ -582,51 +847,89 @@ def chunk_kda_fwd_intra(
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
     NC = triton.cdiv(BT, BC)
 
-    Aqk = torch.zeros(B, T, H, BT, device=k.device, dtype=k.dtype)
-    # Akk must be zero-initialized - kernel only writes lower triangular
-    Akk = torch.zeros(B, T, H, BT, device=k.device, dtype=k.dtype)
-    # Separate fp32 buffer for diagonal 16x16 blocks (for precision in solve_tril)
-    Akkd = torch.zeros(B, T, H, BC, device=k.device, dtype=torch.float32)
+    if fuse_diagonal:
+        Aqk = torch.zeros(B, T, H, BT, device=k.device, dtype=k.dtype)
+    else:
+        Aqk = torch.empty(B, T, H, BT, device=k.device, dtype=k.dtype)
+    Akkd = torch.empty(B, T, H, BC, device=k.device, dtype=torch.float32)
 
-    # Step 1: Run token_parallel first to compute diagonal blocks into Akkd (fp32)
-    # Step 1: compute diagonal blocks into Akk_diag (fp32)
-    if safe_gate:
-        grid = (NT, NC, B * H)
-        BK = triton.next_power_of_2(K)
-        chunk_kda_fwd_kernel_intra_sub_chunk[grid](
+    # Step 1: compute diagonal blocks into Akkd (fp32)
+    # When fuse_diagonal=True, diagonal blocks are computed inside inter_solve
+    if not fuse_diagonal:
+        if safe_gate:
+            grid = (NT, NC, B * H)
+            BK = triton.next_power_of_2(K)
+            chunk_kda_fwd_kernel_intra_sub_chunk[grid](
+                q=q,
+                k=k,
+                g=gk,
+                beta=beta,
+                Aqk=Aqk,
+                Akk=Akkd,
+                scale=scale,
+                cu_seqlens=cu_seqlens,
+                chunk_indices=chunk_indices,
+                T=T,
+                H=H,
+                K=K,
+                BT=BT,
+                BC=BC,
+                BK=BK,
+                USE_GATHER=is_gather_supported,
+            )
+        else:
+            Aqk, Akkd = chunk_kda_fwd_intra_token_parallel(
+                q=q,
+                k=k,
+                gk=gk,
+                beta=beta,
+                Aqk=Aqk,
+                Akk=Akkd,
+                scale=scale,
+                cu_seqlens=cu_seqlens,
+                chunk_size=BT,
+                sub_chunk_size=BC,
+            )
+
+    # Step 2: inter_solve (+ optional fused recompute)
+    grid = (NT, B * H)
+
+    if fuse_recompute:
+        w = torch.empty_like(k)
+        u = torch.empty_like(v)
+        kg = torch.empty_like(k)
+        _dummy = torch.empty(1, device=k.device, dtype=k.dtype)
+        chunk_kda_fwd_kernel_inter_solve_fused[grid](
             q=q,
             k=k,
             g=gk,
             beta=beta,
             Aqk=Aqk,
-            Akk=Akkd,
+            Akkd=Akkd,
+            Akk=_dummy,
             scale=scale,
+            v_in=v,
+            w_out=w,
+            u_out=u,
+            kg_out=kg,
             cu_seqlens=cu_seqlens,
             chunk_indices=chunk_indices,
             T=T,
             H=H,
             K=K,
+            V=V,
             BT=BT,
             BC=BC,
-            BK=BK,
-            USE_GATHER=is_gather_supported,
+            BV=64,
+            USE_SAFE_GATE=safe_gate,
+            FUSE_RECOMPUTE=True,
+            FUSE_DIAGONAL=fuse_diagonal,
         )
-    else:
-        Aqk, Akkd = chunk_kda_fwd_intra_token_parallel(
-            q=q,
-            k=k,
-            gk=gk,
-            beta=beta,
-            Aqk=Aqk,
-            Akk=Akkd,
-            scale=scale,
-            cu_seqlens=cu_seqlens,
-            chunk_size=BT,
-            sub_chunk_size=BC,
-        )
+        return w, u, None, kg, Aqk, None
 
-    # Step 2: Fused inter + solve_tril (works for both fixed-len and varlen)
-    grid = (NT, B * H)
+    # Non-fused path: inter_solve stores Akk, then separate recompute
+    Akk = torch.zeros(B, T, H, BT, device=k.device, dtype=k.dtype)
+    _dummy = torch.empty(1, device=k.device, dtype=k.dtype)
     chunk_kda_fwd_kernel_inter_solve_fused[grid](
         q=q,
         k=k,
@@ -636,15 +939,76 @@ def chunk_kda_fwd_intra(
         Akkd=Akkd,
         Akk=Akk,
         scale=scale,
+        v_in=_dummy,
+        w_out=_dummy,
+        u_out=_dummy,
+        kg_out=_dummy,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
         T=T,
         H=H,
         K=K,
+        V=0,
         BT=BT,
         BC=BC,
+        BV=64,
         USE_SAFE_GATE=safe_gate,
+        FUSE_RECOMPUTE=False,
+        FUSE_DIAGONAL=fuse_diagonal,
     )
+
+    import os as _os
+    if False and fuse_diagonal:  # Set True to enable NaN debugging
+        def _ilog(msg):
+            with open("/tmp/fuse_diag_debug.log", "a") as _ff:
+                _ff.write(msg + "\n")
+                _ff.flush()
+        _aqk_nan = Aqk.isnan().any().item()
+        _akkd_nan = Akkd.isnan().any().item()
+        _akk_nan = Akk.isnan().any().item()
+        if _aqk_nan or _akkd_nan or _akk_nan:
+            import torch as _t
+            BT_ = chunk_size
+            BC_ = 16
+            T_ = Aqk.shape[1]
+            H_ = Aqk.shape[2]
+            _ilog(f"  [INTRA] Aqk_nan={_aqk_nan} Akkd_nan={_akkd_nan} Akk_nan={_akk_nan} T={T_} H={H_}")
+            if _aqk_nan:
+                for c_ in range(T_ // BT_):
+                    for sc_ in range(4):
+                        diag_start = c_ * BT_ + sc_ * BC_
+                        diag_end = min(diag_start + BC_, T_)
+                        diag_block = Aqk[0, diag_start:diag_end, :, sc_*BC_:(sc_+1)*BC_]
+                        if diag_block.isnan().any():
+                            nn_ = diag_block.isnan().sum().item()
+                            _ilog(f"    Aqk NaN DIAG: chunk={c_} sc={sc_} count={nn_}")
+                    for sc_ in range(4):
+                        for sc2_ in range(sc_):
+                            off_start = c_ * BT_ + sc_ * BC_
+                            off_end = min(off_start + BC_, T_)
+                            off_block = Aqk[0, off_start:off_end, :, sc2_*BC_:(sc2_+1)*BC_]
+                            if off_block.isnan().any():
+                                nn_ = off_block.isnan().sum().item()
+                                _ilog(f"    Aqk NaN OFF: chunk={c_} row_sc={sc_} col_sc={sc2_} count={nn_}")
+            if _akkd_nan:
+                for c_ in range(T_ // BT_):
+                    for sc_ in range(4):
+                        d_start = c_ * BT_ + sc_ * BC_
+                        d_end = min(d_start + BC_, T_)
+                        d_block = Akkd[0, d_start:d_end]
+                        if d_block.isnan().any():
+                            nn_ = d_block.isnan().sum().item()
+                            _ilog(f"    Akkd NaN: chunk={c_} sc={sc_} count={nn_}")
+            if _akk_nan:
+                for c_ in range(T_ // BT_):
+                    akk_block = Akk[0, c_*BT_:(c_+1)*BT_]
+                    if akk_block.isnan().any():
+                        nn_ = akk_block.isnan().sum().item()
+                        _ilog(f"    Akk NaN: chunk={c_} count={nn_}")
+
+    if skip_recompute:
+        return None, None, None, None, Aqk, Akk
+
     from sglang.srt.layers.attention.fla.kda import (
         recompute_w_u_fwd as kda_recompute_w_u_fwd,
     )
@@ -657,6 +1021,5 @@ def chunk_kda_fwd_intra(
         q=q if disable_recompute else None,
         gk=gk,
         cu_seqlens=cu_seqlens,
-        chunk_indices=chunk_indices,
     )
     return w, u, qg, kg, Aqk, Akk

--- a/python/sglang/srt/layers/attention/fla/chunk_intra.py
+++ b/python/sglang/srt/layers/attention/fla/chunk_intra.py
@@ -36,9 +36,18 @@ else:
 )
 @triton.autotune(
     configs=[
-        triton.Config({"BK": 64}, num_warps=4, maxnreg=128, num_stages=1),
+        triton.Config({"BK": BK, "BV": BV}, num_warps=num_warps, num_stages=num_stages)
+        for BK in [32, 64]
+        for BV in [32, 64]
+        for num_warps in [2, 4, 8]
+        for num_stages in [1, 2, 3]
+    ]
+    + [
+        # Manually-tuned config kept as a candidate: maxnreg cap limits spill
+        # under heavy FUSE_DIAGONAL register pressure at small H.
+        triton.Config({"BK": 64, "BV": 64}, num_warps=4, maxnreg=128, num_stages=1),
     ],
-    key=["H", "K", "BC", "V"],
+    key=["H", "K", "BC", "V", "FUSE_RECOMPUTE", "FUSE_DIAGONAL"],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=["T"])
@@ -377,10 +386,18 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
         p_Aqk_d3 = tl.make_block_ptr(
             Aqk, (T, BT), (H * BT, 1), (i_tc3, 3 * BC), (BC, BC), (1, 0)
         )
-        tl.store(p_Aqk_d0, (b_Aqk_d0 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_Aqk_d1, (b_Aqk_d1 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_Aqk_d2, (b_Aqk_d2 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
-        tl.store(p_Aqk_d3, (b_Aqk_d3 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(
+            p_Aqk_d0, (b_Aqk_d0 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1)
+        )
+        tl.store(
+            p_Aqk_d1, (b_Aqk_d1 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1)
+        )
+        tl.store(
+            p_Aqk_d2, (b_Aqk_d2 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1)
+        )
+        tl.store(
+            p_Aqk_d3, (b_Aqk_d3 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1)
+        )
 
         p_bd0 = tl.make_block_ptr(
             beta + bos * H + i_h, (T,), (H,), (i_tc0,), (BC,), (0,)
@@ -444,9 +461,14 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
 
     ################################################################################
     # forward substitution on diagonals
+    # Diagonal blocks are RAW (need substitution) when:
+    #   - FUSE_DIAGONAL=True: blocks were computed fresh above as gated k·k.
+    #   - FUSE_DIAGONAL=False with USE_SAFE_GATE=False: token_parallel wrote raw.
+    # They are pre-inverted only by the safe_gate diagonal kernel
+    # (USE_SAFE_GATE=True, FUSE_DIAGONAL=False).
     ################################################################################
 
-    if not USE_SAFE_GATE:
+    if FUSE_DIAGONAL or not USE_SAFE_GATE:
         m_A = o_i[:, None] > o_i[None, :]
         m_I = o_i[:, None] == o_i[None, :]
 
@@ -561,10 +583,18 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
         v_base = v_in + (bos * H + i_h) * V
         u_base = u_out + (bos * H + i_h) * V
         for i_v in range(tl.cdiv(V, BV)):
-            p_v0 = tl.make_block_ptr(v_base, (T, V), (H * V, 1), (i_tc0, i_v * BV), (BC, BV), (1, 0))
-            p_v1 = tl.make_block_ptr(v_base, (T, V), (H * V, 1), (i_tc1, i_v * BV), (BC, BV), (1, 0))
-            p_v2 = tl.make_block_ptr(v_base, (T, V), (H * V, 1), (i_tc2, i_v * BV), (BC, BV), (1, 0))
-            p_v3 = tl.make_block_ptr(v_base, (T, V), (H * V, 1), (i_tc3, i_v * BV), (BC, BV), (1, 0))
+            p_v0 = tl.make_block_ptr(
+                v_base, (T, V), (H * V, 1), (i_tc0, i_v * BV), (BC, BV), (1, 0)
+            )
+            p_v1 = tl.make_block_ptr(
+                v_base, (T, V), (H * V, 1), (i_tc1, i_v * BV), (BC, BV), (1, 0)
+            )
+            p_v2 = tl.make_block_ptr(
+                v_base, (T, V), (H * V, 1), (i_tc2, i_v * BV), (BC, BV), (1, 0)
+            )
+            p_v3 = tl.make_block_ptr(
+                v_base, (T, V), (H * V, 1), (i_tc3, i_v * BV), (BC, BV), (1, 0)
+            )
 
             b_v0 = tl.load(p_v0, boundary_check=(0, 1))
             b_v1 = tl.load(p_v1, boundary_check=(0, 1))
@@ -578,16 +608,30 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
 
             b_u0 = tl.dot(b_Ai00_h, b_vb0)
             b_u1 = tl.dot(b_Ai10_h, b_vb0) + tl.dot(b_Ai11_h, b_vb1)
-            b_u2 = tl.dot(b_Ai20_h, b_vb0) + tl.dot(b_Ai21_h, b_vb1) + tl.dot(b_Ai22_h, b_vb2)
+            b_u2 = (
+                tl.dot(b_Ai20_h, b_vb0)
+                + tl.dot(b_Ai21_h, b_vb1)
+                + tl.dot(b_Ai22_h, b_vb2)
+            )
             b_u3 = (
-                tl.dot(b_Ai30_h, b_vb0) + tl.dot(b_Ai31_h, b_vb1)
-                + tl.dot(b_Ai32_h, b_vb2) + tl.dot(b_Ai33_h, b_vb3)
+                tl.dot(b_Ai30_h, b_vb0)
+                + tl.dot(b_Ai31_h, b_vb1)
+                + tl.dot(b_Ai32_h, b_vb2)
+                + tl.dot(b_Ai33_h, b_vb3)
             )
 
-            p_u0 = tl.make_block_ptr(u_base, (T, V), (H * V, 1), (i_tc0, i_v * BV), (BC, BV), (1, 0))
-            p_u1 = tl.make_block_ptr(u_base, (T, V), (H * V, 1), (i_tc1, i_v * BV), (BC, BV), (1, 0))
-            p_u2 = tl.make_block_ptr(u_base, (T, V), (H * V, 1), (i_tc2, i_v * BV), (BC, BV), (1, 0))
-            p_u3 = tl.make_block_ptr(u_base, (T, V), (H * V, 1), (i_tc3, i_v * BV), (BC, BV), (1, 0))
+            p_u0 = tl.make_block_ptr(
+                u_base, (T, V), (H * V, 1), (i_tc0, i_v * BV), (BC, BV), (1, 0)
+            )
+            p_u1 = tl.make_block_ptr(
+                u_base, (T, V), (H * V, 1), (i_tc1, i_v * BV), (BC, BV), (1, 0)
+            )
+            p_u2 = tl.make_block_ptr(
+                u_base, (T, V), (H * V, 1), (i_tc2, i_v * BV), (BC, BV), (1, 0)
+            )
+            p_u3 = tl.make_block_ptr(
+                u_base, (T, V), (H * V, 1), (i_tc3, i_v * BV), (BC, BV), (1, 0)
+            )
             tl.store(p_u0, b_u0.to(p_u0.dtype.element_ty), boundary_check=(0, 1))
             tl.store(p_u1, b_u1.to(p_u1.dtype.element_ty), boundary_check=(0, 1))
             tl.store(p_u2, b_u2.to(p_u2.dtype.element_ty), boundary_check=(0, 1))
@@ -601,19 +645,35 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
         for i_k in range(tl.cdiv(K, BK)):
             o_k = i_k * BK + tl.arange(0, BK)
             m_k = o_k < K
-            b_gn = tl.load(
-                g + last_idx * H * K + o_k, mask=m_k, other=0.0
-            ).to(tl.float32)
+            b_gn = tl.load(g + last_idx * H * K + o_k, mask=m_k, other=0.0).to(
+                tl.float32
+            )
 
-            p_k0 = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0))
-            p_k1 = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
-            p_k2 = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
-            p_k3 = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
+            p_k0 = tl.make_block_ptr(
+                k, (T, K), (H * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0)
+            )
+            p_k1 = tl.make_block_ptr(
+                k, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0)
+            )
+            p_k2 = tl.make_block_ptr(
+                k, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0)
+            )
+            p_k3 = tl.make_block_ptr(
+                k, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0)
+            )
 
-            p_gk0 = tl.make_block_ptr(g, (T, K), (H * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0))
-            p_gk1 = tl.make_block_ptr(g, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
-            p_gk2 = tl.make_block_ptr(g, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
-            p_gk3 = tl.make_block_ptr(g, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
+            p_gk0 = tl.make_block_ptr(
+                g, (T, K), (H * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0)
+            )
+            p_gk1 = tl.make_block_ptr(
+                g, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0)
+            )
+            p_gk2 = tl.make_block_ptr(
+                g, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0)
+            )
+            p_gk3 = tl.make_block_ptr(
+                g, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0)
+            )
 
             b_k0r = tl.load(p_k0, boundary_check=(0, 1))
             b_k1r = tl.load(p_k1, boundary_check=(0, 1))
@@ -632,16 +692,30 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
 
             b_w0 = tl.dot(b_Ai00_h, b_kb0)
             b_w1 = tl.dot(b_Ai10_h, b_kb0) + tl.dot(b_Ai11_h, b_kb1)
-            b_w2 = tl.dot(b_Ai20_h, b_kb0) + tl.dot(b_Ai21_h, b_kb1) + tl.dot(b_Ai22_h, b_kb2)
+            b_w2 = (
+                tl.dot(b_Ai20_h, b_kb0)
+                + tl.dot(b_Ai21_h, b_kb1)
+                + tl.dot(b_Ai22_h, b_kb2)
+            )
             b_w3 = (
-                tl.dot(b_Ai30_h, b_kb0) + tl.dot(b_Ai31_h, b_kb1)
-                + tl.dot(b_Ai32_h, b_kb2) + tl.dot(b_Ai33_h, b_kb3)
+                tl.dot(b_Ai30_h, b_kb0)
+                + tl.dot(b_Ai31_h, b_kb1)
+                + tl.dot(b_Ai32_h, b_kb2)
+                + tl.dot(b_Ai33_h, b_kb3)
             )
 
-            p_w0 = tl.make_block_ptr(w_base, (T, K), (H * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0))
-            p_w1 = tl.make_block_ptr(w_base, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
-            p_w2 = tl.make_block_ptr(w_base, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
-            p_w3 = tl.make_block_ptr(w_base, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
+            p_w0 = tl.make_block_ptr(
+                w_base, (T, K), (H * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0)
+            )
+            p_w1 = tl.make_block_ptr(
+                w_base, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0)
+            )
+            p_w2 = tl.make_block_ptr(
+                w_base, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0)
+            )
+            p_w3 = tl.make_block_ptr(
+                w_base, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0)
+            )
             tl.store(p_w0, b_w0.to(p_w0.dtype.element_ty), boundary_check=(0, 1))
             tl.store(p_w1, b_w1.to(p_w1.dtype.element_ty), boundary_check=(0, 1))
             tl.store(p_w2, b_w2.to(p_w2.dtype.element_ty), boundary_check=(0, 1))
@@ -652,28 +726,44 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
             b_kg2 = b_k2r * exp(b_gn[None, :] - b_gk2r)
             b_kg3 = b_k3r * exp(b_gn[None, :] - b_gk3r)
 
-            p_kg0 = tl.make_block_ptr(kg_base, (T, K), (H * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0))
-            p_kg1 = tl.make_block_ptr(kg_base, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
-            p_kg2 = tl.make_block_ptr(kg_base, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
-            p_kg3 = tl.make_block_ptr(kg_base, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
+            p_kg0 = tl.make_block_ptr(
+                kg_base, (T, K), (H * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0)
+            )
+            p_kg1 = tl.make_block_ptr(
+                kg_base, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0)
+            )
+            p_kg2 = tl.make_block_ptr(
+                kg_base, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0)
+            )
+            p_kg3 = tl.make_block_ptr(
+                kg_base, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0)
+            )
             tl.store(p_kg0, b_kg0.to(p_kg0.dtype.element_ty), boundary_check=(0, 1))
             tl.store(p_kg1, b_kg1.to(p_kg1.dtype.element_ty), boundary_check=(0, 1))
             tl.store(p_kg2, b_kg2.to(p_kg2.dtype.element_ty), boundary_check=(0, 1))
             tl.store(p_kg3, b_kg3.to(p_kg3.dtype.element_ty), boundary_check=(0, 1))
     else:
-        p_Akk00 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc0, 0), (BC, BC), (1, 0))
-        p_Akk10 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc1, 0), (BC, BC), (1, 0))
+        p_Akk00 = tl.make_block_ptr(
+            Akk, (T, BT), (H * BT, 1), (i_tc0, 0), (BC, BC), (1, 0)
+        )
+        p_Akk10 = tl.make_block_ptr(
+            Akk, (T, BT), (H * BT, 1), (i_tc1, 0), (BC, BC), (1, 0)
+        )
         p_Akk11 = tl.make_block_ptr(
             Akk, (T, BT), (H * BT, 1), (i_tc1, BC), (BC, BC), (1, 0)
         )
-        p_Akk20 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc2, 0), (BC, BC), (1, 0))
+        p_Akk20 = tl.make_block_ptr(
+            Akk, (T, BT), (H * BT, 1), (i_tc2, 0), (BC, BC), (1, 0)
+        )
         p_Akk21 = tl.make_block_ptr(
             Akk, (T, BT), (H * BT, 1), (i_tc2, BC), (BC, BC), (1, 0)
         )
         p_Akk22 = tl.make_block_ptr(
             Akk, (T, BT), (H * BT, 1), (i_tc2, 2 * BC), (BC, BC), (1, 0)
         )
-        p_Akk30 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc3, 0), (BC, BC), (1, 0))
+        p_Akk30 = tl.make_block_ptr(
+            Akk, (T, BT), (H * BT, 1), (i_tc3, 0), (BC, BC), (1, 0)
+        )
         p_Akk31 = tl.make_block_ptr(
             Akk, (T, BT), (H * BT, 1), (i_tc3, BC), (BC, BC), (1, 0)
         )
@@ -834,7 +924,6 @@ def chunk_kda_fwd_intra(
     chunk_indices: torch.LongTensor | None = None,
     safe_gate: bool = False,
     disable_recompute: bool = False,
-    skip_recompute: bool = False,
     fuse_recompute: bool = False,
     fuse_diagonal: bool = False,
 ):
@@ -898,7 +987,6 @@ def chunk_kda_fwd_intra(
         w = torch.empty_like(k)
         u = torch.empty_like(v)
         kg = torch.empty_like(k)
-        _dummy = torch.empty(1, device=k.device, dtype=k.dtype)
         chunk_kda_fwd_kernel_inter_solve_fused[grid](
             q=q,
             k=k,
@@ -906,7 +994,7 @@ def chunk_kda_fwd_intra(
             beta=beta,
             Aqk=Aqk,
             Akkd=Akkd,
-            Akk=_dummy,
+            Akk=k,  # unused placeholder when FUSE_RECOMPUTE=True (dead branch)
             scale=scale,
             v_in=v,
             w_out=w,
@@ -920,7 +1008,6 @@ def chunk_kda_fwd_intra(
             V=V,
             BT=BT,
             BC=BC,
-            BV=64,
             USE_SAFE_GATE=safe_gate,
             FUSE_RECOMPUTE=True,
             FUSE_DIAGONAL=fuse_diagonal,
@@ -929,7 +1016,6 @@ def chunk_kda_fwd_intra(
 
     # Non-fused path: inter_solve stores Akk, then separate recompute
     Akk = torch.zeros(B, T, H, BT, device=k.device, dtype=k.dtype)
-    _dummy = torch.empty(1, device=k.device, dtype=k.dtype)
     chunk_kda_fwd_kernel_inter_solve_fused[grid](
         q=q,
         k=k,
@@ -939,10 +1025,11 @@ def chunk_kda_fwd_intra(
         Akkd=Akkd,
         Akk=Akk,
         scale=scale,
-        v_in=_dummy,
-        w_out=_dummy,
-        u_out=_dummy,
-        kg_out=_dummy,
+        # v_in/w_out/u_out/kg_out unused when FUSE_RECOMPUTE=False (dead branch)
+        v_in=k,
+        w_out=k,
+        u_out=k,
+        kg_out=k,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
         T=T,
@@ -951,63 +1038,10 @@ def chunk_kda_fwd_intra(
         V=0,
         BT=BT,
         BC=BC,
-        BV=64,
         USE_SAFE_GATE=safe_gate,
         FUSE_RECOMPUTE=False,
         FUSE_DIAGONAL=fuse_diagonal,
     )
-
-    import os as _os
-    if False and fuse_diagonal:  # Set True to enable NaN debugging
-        def _ilog(msg):
-            with open("/tmp/fuse_diag_debug.log", "a") as _ff:
-                _ff.write(msg + "\n")
-                _ff.flush()
-        _aqk_nan = Aqk.isnan().any().item()
-        _akkd_nan = Akkd.isnan().any().item()
-        _akk_nan = Akk.isnan().any().item()
-        if _aqk_nan or _akkd_nan or _akk_nan:
-            import torch as _t
-            BT_ = chunk_size
-            BC_ = 16
-            T_ = Aqk.shape[1]
-            H_ = Aqk.shape[2]
-            _ilog(f"  [INTRA] Aqk_nan={_aqk_nan} Akkd_nan={_akkd_nan} Akk_nan={_akk_nan} T={T_} H={H_}")
-            if _aqk_nan:
-                for c_ in range(T_ // BT_):
-                    for sc_ in range(4):
-                        diag_start = c_ * BT_ + sc_ * BC_
-                        diag_end = min(diag_start + BC_, T_)
-                        diag_block = Aqk[0, diag_start:diag_end, :, sc_*BC_:(sc_+1)*BC_]
-                        if diag_block.isnan().any():
-                            nn_ = diag_block.isnan().sum().item()
-                            _ilog(f"    Aqk NaN DIAG: chunk={c_} sc={sc_} count={nn_}")
-                    for sc_ in range(4):
-                        for sc2_ in range(sc_):
-                            off_start = c_ * BT_ + sc_ * BC_
-                            off_end = min(off_start + BC_, T_)
-                            off_block = Aqk[0, off_start:off_end, :, sc2_*BC_:(sc2_+1)*BC_]
-                            if off_block.isnan().any():
-                                nn_ = off_block.isnan().sum().item()
-                                _ilog(f"    Aqk NaN OFF: chunk={c_} row_sc={sc_} col_sc={sc2_} count={nn_}")
-            if _akkd_nan:
-                for c_ in range(T_ // BT_):
-                    for sc_ in range(4):
-                        d_start = c_ * BT_ + sc_ * BC_
-                        d_end = min(d_start + BC_, T_)
-                        d_block = Akkd[0, d_start:d_end]
-                        if d_block.isnan().any():
-                            nn_ = d_block.isnan().sum().item()
-                            _ilog(f"    Akkd NaN: chunk={c_} sc={sc_} count={nn_}")
-            if _akk_nan:
-                for c_ in range(T_ // BT_):
-                    akk_block = Akk[0, c_*BT_:(c_+1)*BT_]
-                    if akk_block.isnan().any():
-                        nn_ = akk_block.isnan().sum().item()
-                        _ilog(f"    Akk NaN: chunk={c_} count={nn_}")
-
-    if skip_recompute:
-        return None, None, None, None, Aqk, Akk
 
     from sglang.srt.layers.attention.fla.kda import (
         recompute_w_u_fwd as kda_recompute_w_u_fwd,
@@ -1021,5 +1055,6 @@ def chunk_kda_fwd_intra(
         q=q if disable_recompute else None,
         gk=gk,
         cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
     )
     return w, u, qg, kg, Aqk, Akk

--- a/python/sglang/srt/layers/attention/fla/chunk_intra.py
+++ b/python/sglang/srt/layers/attention/fla/chunk_intra.py
@@ -36,16 +36,9 @@ else:
 )
 @triton.autotune(
     configs=[
-        triton.Config({"BK": BK, "BV": BV}, num_warps=num_warps, num_stages=num_stages)
+        triton.Config({"BK": BK, "BV": 64}, num_warps=num_warps)
         for BK in [32, 64]
-        for BV in [32, 64]
-        for num_warps in [2, 4, 8]
-        for num_stages in [1, 2, 3]
-    ]
-    + [
-        # Manually-tuned config kept as a candidate: maxnreg cap limits spill
-        # under heavy FUSE_DIAGONAL register pressure at small H.
-        triton.Config({"BK": 64, "BV": 64}, num_warps=4, maxnreg=128, num_stages=1),
+        for num_warps in [1, 2, 4]
     ],
     key=["H", "K", "BC", "V", "FUSE_RECOMPUTE", "FUSE_DIAGONAL"],
     **autotune_cache_kwargs,

--- a/python/sglang/srt/layers/attention/fla/cumsum.py
+++ b/python/sglang/srt/layers/attention/fla/cumsum.py
@@ -70,9 +70,10 @@ def chunk_local_cumsum_scalar_kernel(
 
 @triton.autotune(
     configs=[
-        triton.Config({"BS": BS}, num_warps=num_warps)
+        triton.Config({"BS": BS}, num_warps=num_warps, num_stages=num_stages)
         for BS in BS_LIST
         for num_warps in [2, 4, 8]
+        for num_stages in [2, 3, 4]
     ],
     key=["B", "H", "S", "BT", "IS_VARLEN", "REVERSE", "HAS_SCALE"],
 )
@@ -225,9 +226,6 @@ def chunk_local_cumsum_vector(
     def grid(meta):
         return (triton.cdiv(meta["S"], meta["BS"]), NT, B * H)
 
-    # keep cumulative normalizer in fp32
-    # this kernel is equivalent to
-    # g = g.view(B, H, NT, BT, -1).cumsum(-2).view(B, H, T, -1)
     chunk_local_cumsum_vector_kernel[grid](
         s=g_org,
         o=g,

--- a/python/sglang/srt/layers/attention/fla/cumsum.py
+++ b/python/sglang/srt/layers/attention/fla/cumsum.py
@@ -226,6 +226,9 @@ def chunk_local_cumsum_vector(
     def grid(meta):
         return (triton.cdiv(meta["S"], meta["BS"]), NT, B * H)
 
+    # keep cumulative normalizer in fp32
+    # this kernel is equivalent to
+    # g = g.view(B, H, NT, BT, -1).cumsum(-2).view(B, H, T, -1)
     chunk_local_cumsum_vector_kernel[grid](
         s=g_org,
         o=g,

--- a/python/sglang/srt/layers/attention/fla/kda.py
+++ b/python/sglang/srt/layers/attention/fla/kda.py
@@ -17,11 +17,12 @@ from sglang.srt.layers.attention.fla.fused_norm_gate import layer_norm_gated_fwd
 from sglang.srt.layers.attention.fla.fused_recurrent import (
     fused_recurrent_gated_delta_rule_fwd_kernel,
 )
-from sglang.srt.layers.attention.fla.index import prepare_chunk_indices, prepare_chunk_offsets
+from sglang.srt.layers.attention.fla.index import (
+    prepare_chunk_indices,
+)
 from sglang.srt.layers.attention.fla.l2norm import l2norm_fwd
 from sglang.srt.layers.attention.fla.op import exp, log
 from sglang.srt.layers.attention.fla.utils import (
-    autotune_cache_kwargs,
     check_shared_mem,
 )
 
@@ -692,8 +693,8 @@ def recompute_w_u_fwd(
 @triton.autotune(
     configs=[
         triton.Config({"BK": BK, "BV": BV}, num_warps=num_warps, num_stages=num_stages)
-        for BK in [32, 64, 128]
-        for BV in [32, 64, 128]
+        for BK in [64]
+        for BV in [64]
         for num_warps in [2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
@@ -845,261 +846,6 @@ def chunk_gla_fwd_o_gk(
         K=K,
         V=V,
         BT=BT,
-        IS_VARLEN=cu_seqlens is not None,
-    )
-    return o
-
-
-@triton.autotune(
-    configs=[
-        triton.Config({"BV": BV}, num_warps=num_warps, num_stages=num_stages)
-        for BV in [32, 64]
-        for num_warps in [2, 4]
-        for num_stages in [2, 3, 4]
-    ],
-    key=["H", "K", "V", "BT"],
-    **autotune_cache_kwargs,
-)
-@triton.jit(do_not_specialize=["T"])
-def chunk_kda_fwd_h_output_fused_kernel(
-    kg,
-    u,
-    w,
-    gk,
-    q,
-    Aqk,
-    o,
-    initial_state,
-    initial_state_indices,
-    cu_seqlens,
-    chunk_offsets,
-    scale,
-    T,
-    H: tl.constexpr,
-    Hg: tl.constexpr,
-    K: tl.constexpr,
-    V: tl.constexpr,
-    BT: tl.constexpr,
-    BV: tl.constexpr,
-    USE_INITIAL_STATE: tl.constexpr,
-    INPLACE_UPDATE: tl.constexpr,
-    IS_VARLEN: tl.constexpr,
-):
-    i_v, i_nh = tl.program_id(0), tl.program_id(1)
-    i_n, i_h = i_nh // H, i_nh % H
-    if IS_VARLEN:
-        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
-            cu_seqlens + i_n + 1
-        ).to(tl.int32)
-        T = eos - bos
-        NT = tl.cdiv(T, BT)
-        boh = tl.load(chunk_offsets + i_n).to(tl.int32)
-    else:
-        bos, eos = i_n * T, i_n * T + T
-        NT = tl.cdiv(T, BT)
-        boh = i_n * NT
-
-    b_h1 = tl.zeros([BV, 64], dtype=tl.float32)
-    if K > 64:
-        b_h2 = tl.zeros([BV, 64], dtype=tl.float32)
-    if K > 128:
-        b_h3 = tl.zeros([BV, 64], dtype=tl.float32)
-    if K > 192:
-        b_h4 = tl.zeros([BV, 64], dtype=tl.float32)
-
-    u_base = u + ((bos * H + i_h) * V).to(tl.int64)
-    kg_base = kg + ((bos * Hg + i_h // (H // Hg)) * K).to(tl.int64)
-    w_base = w + ((bos * H + i_h) * K).to(tl.int64)
-    gk_base = gk + ((bos * H + i_h) * K).to(tl.int64)
-    q_base = q + ((bos * H + i_h) * K).to(tl.int64)
-    o_base = o + ((bos * H + i_h) * V).to(tl.int64)
-    Aqk_base = Aqk + ((bos * H + i_h) * BT).to(tl.int64)
-    stride_v = H * V
-    stride_k = Hg * K
-    stride_w = H * K
-    stride_gk = H * K
-    stride_q = H * K
-    stride_o = H * V
-
-    index = tl.load(initial_state_indices + i_n).to(tl.int32)
-    h0 = initial_state + index * H * V * K
-    ht = initial_state + index * H * V * K
-    if USE_INITIAL_STATE:
-        h0 = h0 + i_h * V * K
-    if INPLACE_UPDATE:
-        ht = ht + i_h * V * K
-
-    if USE_INITIAL_STATE:
-        p_h0_1 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
-        b_h1 += tl.load(p_h0_1, boundary_check=(0, 1)).to(tl.float32)
-        if K > 64:
-            p_h0_2 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0))
-            b_h2 += tl.load(p_h0_2, boundary_check=(0, 1)).to(tl.float32)
-        if K > 128:
-            p_h0_3 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0))
-            b_h3 += tl.load(p_h0_3, boundary_check=(0, 1)).to(tl.float32)
-        if K > 192:
-            p_h0_4 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0))
-            b_h4 += tl.load(p_h0_4, boundary_check=(0, 1)).to(tl.float32)
-
-    m_s = tl.arange(0, BT)[:, None] >= tl.arange(0, BT)[None, :]
-
-    for i_t in range(NT):
-        # Phase 1: v_correction (w @ h^T) and o_from_h (q_gated @ h^T)
-        b_v_corr = tl.zeros([BT, BV], dtype=tl.float32)
-        b_o = tl.zeros([BT, BV], dtype=tl.float32)
-
-        p_w = tl.make_block_ptr(w_base, (T, K), (stride_w, 1), (i_t * BT, 0), (BT, 64), (1, 0))
-        p_q = tl.make_block_ptr(q_base, (T, K), (stride_q, 1), (i_t * BT, 0), (BT, 64), (1, 0))
-        p_g = tl.make_block_ptr(gk_base, (T, K), (stride_gk, 1), (i_t * BT, 0), (BT, 64), (1, 0))
-        b_w = tl.load(p_w, boundary_check=(0, 1))
-        b_q = tl.load(p_q, boundary_check=(0, 1))
-        b_g = tl.load(p_g, boundary_check=(0, 1))
-        b_qg = (b_q * scale * exp(b_g)).to(b_q.dtype)
-        b_v_corr += tl.dot(b_w, tl.trans(b_h1).to(b_w.dtype))
-        b_o += tl.dot(b_qg, tl.trans(b_h1).to(b_qg.dtype))
-
-        if K > 64:
-            p_w = tl.make_block_ptr(w_base, (T, K), (stride_w, 1), (i_t * BT, 64), (BT, 64), (1, 0))
-            p_q = tl.make_block_ptr(q_base, (T, K), (stride_q, 1), (i_t * BT, 64), (BT, 64), (1, 0))
-            p_g = tl.make_block_ptr(gk_base, (T, K), (stride_gk, 1), (i_t * BT, 64), (BT, 64), (1, 0))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
-            b_q = tl.load(p_q, boundary_check=(0, 1))
-            b_g = tl.load(p_g, boundary_check=(0, 1))
-            b_qg = (b_q * scale * exp(b_g)).to(b_q.dtype)
-            b_v_corr += tl.dot(b_w, tl.trans(b_h2).to(b_w.dtype))
-            b_o += tl.dot(b_qg, tl.trans(b_h2).to(b_qg.dtype))
-
-        if K > 128:
-            p_w = tl.make_block_ptr(w_base, (T, K), (stride_w, 1), (i_t * BT, 128), (BT, 64), (1, 0))
-            p_q = tl.make_block_ptr(q_base, (T, K), (stride_q, 1), (i_t * BT, 128), (BT, 64), (1, 0))
-            p_g = tl.make_block_ptr(gk_base, (T, K), (stride_gk, 1), (i_t * BT, 128), (BT, 64), (1, 0))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
-            b_q = tl.load(p_q, boundary_check=(0, 1))
-            b_g = tl.load(p_g, boundary_check=(0, 1))
-            b_qg = (b_q * scale * exp(b_g)).to(b_q.dtype)
-            b_v_corr += tl.dot(b_w, tl.trans(b_h3).to(b_w.dtype))
-            b_o += tl.dot(b_qg, tl.trans(b_h3).to(b_qg.dtype))
-
-        if K > 192:
-            p_w = tl.make_block_ptr(w_base, (T, K), (stride_w, 1), (i_t * BT, 192), (BT, 64), (1, 0))
-            p_q = tl.make_block_ptr(q_base, (T, K), (stride_q, 1), (i_t * BT, 192), (BT, 64), (1, 0))
-            p_g = tl.make_block_ptr(gk_base, (T, K), (stride_gk, 1), (i_t * BT, 192), (BT, 64), (1, 0))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
-            b_q = tl.load(p_q, boundary_check=(0, 1))
-            b_g = tl.load(p_g, boundary_check=(0, 1))
-            b_qg = (b_q * scale * exp(b_g)).to(b_q.dtype)
-            b_v_corr += tl.dot(b_w, tl.trans(b_h4).to(b_w.dtype))
-            b_o += tl.dot(b_qg, tl.trans(b_h4).to(b_qg.dtype))
-
-        # Phase 2: v_new = u - v_correction, o += A @ v_new
-        p_u = tl.make_block_ptr(u_base, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_v = tl.load(p_u, boundary_check=(0, 1)) - b_v_corr
-
-        p_A = tl.make_block_ptr(Aqk_base, (T, BT), (H * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-        b_A = tl.load(p_A, boundary_check=(0, 1))
-        b_A = tl.where(m_s, b_A, 0.0).to(b_v.dtype)
-        b_o += tl.dot(b_A, b_v)
-
-        p_o = tl.make_block_ptr(o_base, (T, V), (stride_o, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
-
-        # Phase 3: decay h, update state
-        last_idx = min((i_t + 1) * BT, T) - 1
-        o_k1 = tl.arange(0, 64)
-        b_gk_last1 = tl.load(gk_base + last_idx * stride_gk + o_k1, mask=(o_k1 < K), other=0.0)
-        b_h1 *= exp(b_gk_last1)[None, :]
-        if K > 64:
-            o_k2 = 64 + o_k1
-            b_gk_last2 = tl.load(gk_base + last_idx * stride_gk + o_k2, mask=(o_k2 < K), other=0.0)
-            b_h2 *= exp(b_gk_last2)[None, :]
-        if K > 128:
-            o_k3 = 128 + o_k1
-            b_gk_last3 = tl.load(gk_base + last_idx * stride_gk + o_k3, mask=(o_k3 < K), other=0.0)
-            b_h3 *= exp(b_gk_last3)[None, :]
-        if K > 192:
-            o_k4 = 192 + o_k1
-            b_gk_last4 = tl.load(gk_base + last_idx * stride_gk + o_k4, mask=(o_k4 < K), other=0.0)
-            b_h4 *= exp(b_gk_last4)[None, :]
-
-        b_v = b_v.to(kg.dtype.element_ty)
-        p_k = tl.make_block_ptr(kg_base, (K, T), (1, stride_k), (0, i_t * BT), (64, BT), (0, 1))
-        b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_h1 += tl.trans(tl.dot(b_k, b_v))
-        if K > 64:
-            p_k = tl.make_block_ptr(kg_base, (K, T), (1, stride_k), (64, i_t * BT), (64, BT), (0, 1))
-            b_k = tl.load(p_k, boundary_check=(0, 1))
-            b_h2 += tl.trans(tl.dot(b_k, b_v))
-        if K > 128:
-            p_k = tl.make_block_ptr(kg_base, (K, T), (1, stride_k), (128, i_t * BT), (64, BT), (0, 1))
-            b_k = tl.load(p_k, boundary_check=(0, 1))
-            b_h3 += tl.trans(tl.dot(b_k, b_v))
-        if K > 192:
-            p_k = tl.make_block_ptr(kg_base, (K, T), (1, stride_k), (192, i_t * BT), (64, BT), (0, 1))
-            b_k = tl.load(p_k, boundary_check=(0, 1))
-            b_h4 += tl.trans(tl.dot(b_k, b_v))
-
-    if INPLACE_UPDATE:
-        p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
-        tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
-        if K > 64:
-            p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0))
-            tl.store(p_ht, b_h2.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
-        if K > 128:
-            p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0))
-            tl.store(p_ht, b_h3.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
-        if K > 192:
-            p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0))
-            tl.store(p_ht, b_h4.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
-
-
-def chunk_kda_fwd_h_output(
-    kg: torch.Tensor,
-    u: torch.Tensor,
-    w: torch.Tensor,
-    gk: torch.Tensor,
-    q: torch.Tensor,
-    Aqk: torch.Tensor,
-    o: torch.Tensor,
-    initial_state: torch.Tensor,
-    initial_state_indices: torch.Tensor,
-    scale: float,
-    cu_seqlens: Optional[torch.LongTensor] = None,
-):
-    B, T, Hg, K = kg.shape
-    H, V = u.shape[-2], u.shape[-1]
-    BT = 64
-
-    if cu_seqlens is None:
-        N, chunk_offsets = B, None
-    else:
-        N = len(cu_seqlens) - 1
-        chunk_offsets = prepare_chunk_offsets(cu_seqlens, BT)
-
-    def grid(meta):
-        return (cdiv(V, meta["BV"]), N * H)
-
-    chunk_kda_fwd_h_output_fused_kernel[grid](
-        kg=kg,
-        u=u,
-        w=w,
-        gk=gk,
-        q=q,
-        Aqk=Aqk,
-        o=o,
-        initial_state=initial_state,
-        initial_state_indices=initial_state_indices,
-        cu_seqlens=cu_seqlens,
-        chunk_offsets=chunk_offsets,
-        scale=scale,
-        T=T,
-        H=H,
-        Hg=Hg,
-        K=K,
-        V=V,
-        BT=BT,
-        USE_INITIAL_STATE=initial_state is not None,
-        INPLACE_UPDATE=True,
         IS_VARLEN=cu_seqlens is not None,
     )
     return o
@@ -1321,10 +1067,31 @@ def chunk_kda_fwd(
             chunk_indices=chunk_indices,
         )
 
+    # FUSE_DIAGONAL (fold diagonal-block compute into inter+solve) and
+    # FUSE_RECOMPUTE (also fold w/u/kg recompute) save kernel launches and HBM
+    # round-trips, but cost register footprint per CTA. Wins at small grid
+    # where launch overhead dominates; loses at large grid where the extra
+    # register pressure spills. Gate both on the same grid heuristic.
+    # Total CTAs in inter_solve_fused = NT * B * H_per_rank. For varlen,
+    # cu_seqlens[-1] already aggregates across all sequences and q.shape[0]=1.
+    _NT_pr = triton.cdiv(
+        q.shape[1] if cu_seqlens is None else int(cu_seqlens[-1]), chunk_size
+    )
+    _H_pr = q.shape[-2]
+    _B = q.shape[0]
+    _small_grid = _B * _NT_pr * _H_pr <= 256
     w, u, _, kg, Aqk, _ = chunk_kda_fwd_intra(
-        q=q, k=k, v=v.clone(), gk=g.clone(), beta=beta, scale=scale,
-        cu_seqlens=cu_seqlens, chunk_size=chunk_size, chunk_indices=chunk_indices,
-        fuse_diagonal=True,
+        q=q,
+        k=k,
+        v=v,
+        gk=g,
+        beta=beta,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        chunk_indices=chunk_indices,
+        fuse_diagonal=_small_grid,
+        fuse_recompute=_small_grid,
     )
 
     h, v_new = chunk_gated_delta_rule_fwd_h(

--- a/python/sglang/srt/layers/attention/fla/kda.py
+++ b/python/sglang/srt/layers/attention/fla/kda.py
@@ -17,10 +17,13 @@ from sglang.srt.layers.attention.fla.fused_norm_gate import layer_norm_gated_fwd
 from sglang.srt.layers.attention.fla.fused_recurrent import (
     fused_recurrent_gated_delta_rule_fwd_kernel,
 )
-from sglang.srt.layers.attention.fla.index import prepare_chunk_indices
+from sglang.srt.layers.attention.fla.index import prepare_chunk_indices, prepare_chunk_offsets
 from sglang.srt.layers.attention.fla.l2norm import l2norm_fwd
 from sglang.srt.layers.attention.fla.op import exp, log
-from sglang.srt.layers.attention.fla.utils import check_shared_mem
+from sglang.srt.layers.attention.fla.utils import (
+    autotune_cache_kwargs,
+    check_shared_mem,
+)
 
 BS_LIST = [32, 64] if check_shared_mem() else [16, 32]
 
@@ -488,11 +491,13 @@ def chunk_kda_scaled_dot_kkt_fwd(
 
 @triton.autotune(
     configs=[
-        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+        triton.Config({"BK": BK, "BV": BV}, num_warps=num_warps, num_stages=num_stages)
+        for BK in [64, 128]
+        for BV in [64, 128]
         for num_warps in [2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
-    key=["H", "K", "V", "BT", "BK", "BV", "IS_VARLEN"],
+    key=["H", "K", "V", "BT", "IS_VARLEN"],
 )
 @triton.jit(do_not_specialize=["T"])
 def recompute_w_u_fwd_kernel(
@@ -650,8 +655,6 @@ def recompute_w_u_fwd(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     B, T, H, K, V = *k.shape, v.shape[-1]
     BT = A.shape[-1]
-    BK = 64
-    BV = 64
 
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
@@ -678,12 +681,10 @@ def recompute_w_u_fwd(
         K=K,
         V=V,
         BT=BT,
-        BK=BK,
-        BV=BV,
         STORE_QG=False,
         STORE_KG=kg is not None,
         IS_VARLEN=cu_seqlens is not None,
-        DOT_PRECISION="ieee",
+        DOT_PRECISION="tf32",
     )
     return w, u, None, kg
 
@@ -691,8 +692,8 @@ def recompute_w_u_fwd(
 @triton.autotune(
     configs=[
         triton.Config({"BK": BK, "BV": BV}, num_warps=num_warps, num_stages=num_stages)
-        for BK in [32, 64]
-        for BV in [64, 128]
+        for BK in [32, 64, 128]
+        for BV in [32, 64, 128]
         for num_warps in [2, 4, 8]
         for num_stages in [2, 3, 4]
     ],
@@ -803,7 +804,7 @@ def chunk_gla_fwd_kernel_o(
     # [BT, BT]
     b_A = tl.load(p_A, boundary_check=(0, 1))
     b_A = tl.where(m_s, b_A, 0.0).to(b_v.dtype)
-    b_o += tl.dot(b_A, b_v, allow_tf32=False)
+    b_o += tl.dot(b_A, b_v)
     tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
 
 
@@ -844,6 +845,261 @@ def chunk_gla_fwd_o_gk(
         K=K,
         V=V,
         BT=BT,
+        IS_VARLEN=cu_seqlens is not None,
+    )
+    return o
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BV": BV}, num_warps=num_warps, num_stages=num_stages)
+        for BV in [32, 64]
+        for num_warps in [2, 4]
+        for num_stages in [2, 3, 4]
+    ],
+    key=["H", "K", "V", "BT"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_kda_fwd_h_output_fused_kernel(
+    kg,
+    u,
+    w,
+    gk,
+    q,
+    Aqk,
+    o,
+    initial_state,
+    initial_state_indices,
+    cu_seqlens,
+    chunk_offsets,
+    scale,
+    T,
+    H: tl.constexpr,
+    Hg: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BV: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    INPLACE_UPDATE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_v, i_nh = tl.program_id(0), tl.program_id(1)
+    i_n, i_h = i_nh // H, i_nh % H
+    if IS_VARLEN:
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+        boh = tl.load(chunk_offsets + i_n).to(tl.int32)
+    else:
+        bos, eos = i_n * T, i_n * T + T
+        NT = tl.cdiv(T, BT)
+        boh = i_n * NT
+
+    b_h1 = tl.zeros([BV, 64], dtype=tl.float32)
+    if K > 64:
+        b_h2 = tl.zeros([BV, 64], dtype=tl.float32)
+    if K > 128:
+        b_h3 = tl.zeros([BV, 64], dtype=tl.float32)
+    if K > 192:
+        b_h4 = tl.zeros([BV, 64], dtype=tl.float32)
+
+    u_base = u + ((bos * H + i_h) * V).to(tl.int64)
+    kg_base = kg + ((bos * Hg + i_h // (H // Hg)) * K).to(tl.int64)
+    w_base = w + ((bos * H + i_h) * K).to(tl.int64)
+    gk_base = gk + ((bos * H + i_h) * K).to(tl.int64)
+    q_base = q + ((bos * H + i_h) * K).to(tl.int64)
+    o_base = o + ((bos * H + i_h) * V).to(tl.int64)
+    Aqk_base = Aqk + ((bos * H + i_h) * BT).to(tl.int64)
+    stride_v = H * V
+    stride_k = Hg * K
+    stride_w = H * K
+    stride_gk = H * K
+    stride_q = H * K
+    stride_o = H * V
+
+    index = tl.load(initial_state_indices + i_n).to(tl.int32)
+    h0 = initial_state + index * H * V * K
+    ht = initial_state + index * H * V * K
+    if USE_INITIAL_STATE:
+        h0 = h0 + i_h * V * K
+    if INPLACE_UPDATE:
+        ht = ht + i_h * V * K
+
+    if USE_INITIAL_STATE:
+        p_h0_1 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
+        b_h1 += tl.load(p_h0_1, boundary_check=(0, 1)).to(tl.float32)
+        if K > 64:
+            p_h0_2 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0))
+            b_h2 += tl.load(p_h0_2, boundary_check=(0, 1)).to(tl.float32)
+        if K > 128:
+            p_h0_3 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0))
+            b_h3 += tl.load(p_h0_3, boundary_check=(0, 1)).to(tl.float32)
+        if K > 192:
+            p_h0_4 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0))
+            b_h4 += tl.load(p_h0_4, boundary_check=(0, 1)).to(tl.float32)
+
+    m_s = tl.arange(0, BT)[:, None] >= tl.arange(0, BT)[None, :]
+
+    for i_t in range(NT):
+        # Phase 1: v_correction (w @ h^T) and o_from_h (q_gated @ h^T)
+        b_v_corr = tl.zeros([BT, BV], dtype=tl.float32)
+        b_o = tl.zeros([BT, BV], dtype=tl.float32)
+
+        p_w = tl.make_block_ptr(w_base, (T, K), (stride_w, 1), (i_t * BT, 0), (BT, 64), (1, 0))
+        p_q = tl.make_block_ptr(q_base, (T, K), (stride_q, 1), (i_t * BT, 0), (BT, 64), (1, 0))
+        p_g = tl.make_block_ptr(gk_base, (T, K), (stride_gk, 1), (i_t * BT, 0), (BT, 64), (1, 0))
+        b_w = tl.load(p_w, boundary_check=(0, 1))
+        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_g = tl.load(p_g, boundary_check=(0, 1))
+        b_qg = (b_q * scale * exp(b_g)).to(b_q.dtype)
+        b_v_corr += tl.dot(b_w, tl.trans(b_h1).to(b_w.dtype))
+        b_o += tl.dot(b_qg, tl.trans(b_h1).to(b_qg.dtype))
+
+        if K > 64:
+            p_w = tl.make_block_ptr(w_base, (T, K), (stride_w, 1), (i_t * BT, 64), (BT, 64), (1, 0))
+            p_q = tl.make_block_ptr(q_base, (T, K), (stride_q, 1), (i_t * BT, 64), (BT, 64), (1, 0))
+            p_g = tl.make_block_ptr(gk_base, (T, K), (stride_gk, 1), (i_t * BT, 64), (BT, 64), (1, 0))
+            b_w = tl.load(p_w, boundary_check=(0, 1))
+            b_q = tl.load(p_q, boundary_check=(0, 1))
+            b_g = tl.load(p_g, boundary_check=(0, 1))
+            b_qg = (b_q * scale * exp(b_g)).to(b_q.dtype)
+            b_v_corr += tl.dot(b_w, tl.trans(b_h2).to(b_w.dtype))
+            b_o += tl.dot(b_qg, tl.trans(b_h2).to(b_qg.dtype))
+
+        if K > 128:
+            p_w = tl.make_block_ptr(w_base, (T, K), (stride_w, 1), (i_t * BT, 128), (BT, 64), (1, 0))
+            p_q = tl.make_block_ptr(q_base, (T, K), (stride_q, 1), (i_t * BT, 128), (BT, 64), (1, 0))
+            p_g = tl.make_block_ptr(gk_base, (T, K), (stride_gk, 1), (i_t * BT, 128), (BT, 64), (1, 0))
+            b_w = tl.load(p_w, boundary_check=(0, 1))
+            b_q = tl.load(p_q, boundary_check=(0, 1))
+            b_g = tl.load(p_g, boundary_check=(0, 1))
+            b_qg = (b_q * scale * exp(b_g)).to(b_q.dtype)
+            b_v_corr += tl.dot(b_w, tl.trans(b_h3).to(b_w.dtype))
+            b_o += tl.dot(b_qg, tl.trans(b_h3).to(b_qg.dtype))
+
+        if K > 192:
+            p_w = tl.make_block_ptr(w_base, (T, K), (stride_w, 1), (i_t * BT, 192), (BT, 64), (1, 0))
+            p_q = tl.make_block_ptr(q_base, (T, K), (stride_q, 1), (i_t * BT, 192), (BT, 64), (1, 0))
+            p_g = tl.make_block_ptr(gk_base, (T, K), (stride_gk, 1), (i_t * BT, 192), (BT, 64), (1, 0))
+            b_w = tl.load(p_w, boundary_check=(0, 1))
+            b_q = tl.load(p_q, boundary_check=(0, 1))
+            b_g = tl.load(p_g, boundary_check=(0, 1))
+            b_qg = (b_q * scale * exp(b_g)).to(b_q.dtype)
+            b_v_corr += tl.dot(b_w, tl.trans(b_h4).to(b_w.dtype))
+            b_o += tl.dot(b_qg, tl.trans(b_h4).to(b_qg.dtype))
+
+        # Phase 2: v_new = u - v_correction, o += A @ v_new
+        p_u = tl.make_block_ptr(u_base, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        b_v = tl.load(p_u, boundary_check=(0, 1)) - b_v_corr
+
+        p_A = tl.make_block_ptr(Aqk_base, (T, BT), (H * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+        b_A = tl.load(p_A, boundary_check=(0, 1))
+        b_A = tl.where(m_s, b_A, 0.0).to(b_v.dtype)
+        b_o += tl.dot(b_A, b_v)
+
+        p_o = tl.make_block_ptr(o_base, (T, V), (stride_o, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+
+        # Phase 3: decay h, update state
+        last_idx = min((i_t + 1) * BT, T) - 1
+        o_k1 = tl.arange(0, 64)
+        b_gk_last1 = tl.load(gk_base + last_idx * stride_gk + o_k1, mask=(o_k1 < K), other=0.0)
+        b_h1 *= exp(b_gk_last1)[None, :]
+        if K > 64:
+            o_k2 = 64 + o_k1
+            b_gk_last2 = tl.load(gk_base + last_idx * stride_gk + o_k2, mask=(o_k2 < K), other=0.0)
+            b_h2 *= exp(b_gk_last2)[None, :]
+        if K > 128:
+            o_k3 = 128 + o_k1
+            b_gk_last3 = tl.load(gk_base + last_idx * stride_gk + o_k3, mask=(o_k3 < K), other=0.0)
+            b_h3 *= exp(b_gk_last3)[None, :]
+        if K > 192:
+            o_k4 = 192 + o_k1
+            b_gk_last4 = tl.load(gk_base + last_idx * stride_gk + o_k4, mask=(o_k4 < K), other=0.0)
+            b_h4 *= exp(b_gk_last4)[None, :]
+
+        b_v = b_v.to(kg.dtype.element_ty)
+        p_k = tl.make_block_ptr(kg_base, (K, T), (1, stride_k), (0, i_t * BT), (64, BT), (0, 1))
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_h1 += tl.trans(tl.dot(b_k, b_v))
+        if K > 64:
+            p_k = tl.make_block_ptr(kg_base, (K, T), (1, stride_k), (64, i_t * BT), (64, BT), (0, 1))
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_h2 += tl.trans(tl.dot(b_k, b_v))
+        if K > 128:
+            p_k = tl.make_block_ptr(kg_base, (K, T), (1, stride_k), (128, i_t * BT), (64, BT), (0, 1))
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_h3 += tl.trans(tl.dot(b_k, b_v))
+        if K > 192:
+            p_k = tl.make_block_ptr(kg_base, (K, T), (1, stride_k), (192, i_t * BT), (64, BT), (0, 1))
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_h4 += tl.trans(tl.dot(b_k, b_v))
+
+    if INPLACE_UPDATE:
+        p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
+        tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        if K > 64:
+            p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0))
+            tl.store(p_ht, b_h2.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        if K > 128:
+            p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0))
+            tl.store(p_ht, b_h3.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        if K > 192:
+            p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0))
+            tl.store(p_ht, b_h4.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+
+
+def chunk_kda_fwd_h_output(
+    kg: torch.Tensor,
+    u: torch.Tensor,
+    w: torch.Tensor,
+    gk: torch.Tensor,
+    q: torch.Tensor,
+    Aqk: torch.Tensor,
+    o: torch.Tensor,
+    initial_state: torch.Tensor,
+    initial_state_indices: torch.Tensor,
+    scale: float,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+):
+    B, T, Hg, K = kg.shape
+    H, V = u.shape[-2], u.shape[-1]
+    BT = 64
+
+    if cu_seqlens is None:
+        N, chunk_offsets = B, None
+    else:
+        N = len(cu_seqlens) - 1
+        chunk_offsets = prepare_chunk_offsets(cu_seqlens, BT)
+
+    def grid(meta):
+        return (cdiv(V, meta["BV"]), N * H)
+
+    chunk_kda_fwd_h_output_fused_kernel[grid](
+        kg=kg,
+        u=u,
+        w=w,
+        gk=gk,
+        q=q,
+        Aqk=Aqk,
+        o=o,
+        initial_state=initial_state,
+        initial_state_indices=initial_state_indices,
+        cu_seqlens=cu_seqlens,
+        chunk_offsets=chunk_offsets,
+        scale=scale,
+        T=T,
+        H=H,
+        Hg=Hg,
+        K=K,
+        V=V,
+        BT=BT,
+        USE_INITIAL_STATE=initial_state is not None,
+        INPLACE_UPDATE=True,
         IS_VARLEN=cu_seqlens is not None,
     )
     return o
@@ -1065,17 +1321,10 @@ def chunk_kda_fwd(
             chunk_indices=chunk_indices,
         )
 
-    # Fused: scaled_dot_kkt + solve_tril + recompute_w_u
     w, u, _, kg, Aqk, _ = chunk_kda_fwd_intra(
-        q=q,
-        k=k,
-        v=v,
-        gk=g,
-        beta=beta,
-        scale=scale,
-        cu_seqlens=cu_seqlens,
-        chunk_size=chunk_size,
-        chunk_indices=chunk_indices,
+        q=q, k=k, v=v.clone(), gk=g.clone(), beta=beta, scale=scale,
+        cu_seqlens=cu_seqlens, chunk_size=chunk_size, chunk_indices=chunk_indices,
+        fuse_diagonal=True,
     )
 
     h, v_new = chunk_gated_delta_rule_fwd_h(
@@ -1089,6 +1338,7 @@ def chunk_kda_fwd(
         chunk_indices=chunk_indices,
     )
     del w, u, kg
+
     o = chunk_gla_fwd_o_gk(
         q=q,
         v=v_new,
@@ -1097,11 +1347,12 @@ def chunk_kda_fwd(
         h=h,
         o=v,
         scale=scale,
-        cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
+        cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
     )
     del Aqk, v_new, h
+
     return o
 
 

--- a/python/sglang/srt/layers/attention/fla/kda.py
+++ b/python/sglang/srt/layers/attention/fla/kda.py
@@ -1073,9 +1073,13 @@ def chunk_kda_fwd(
     # where launch overhead dominates; loses at large grid where the extra
     # register pressure spills. Gate both on the same grid heuristic.
     # Total CTAs in inter_solve_fused = NT * B * H_per_rank. For varlen,
-    # cu_seqlens[-1] already aggregates across all sequences and q.shape[0]=1.
-    _NT_pr = triton.cdiv(
-        q.shape[1] if cu_seqlens is None else int(cu_seqlens[-1]), chunk_size
+    # chunks don't cross sequence boundaries, so per-sequence ceil-divs sum to
+    # more than cdiv(total_tokens, chunk_size); use chunk_indices.shape[0] which
+    # already enumerates all (seq, chunk) pairs.
+    _NT_pr = (
+        triton.cdiv(q.shape[1], chunk_size)
+        if cu_seqlens is None
+        else chunk_indices.shape[0]
     )
     _H_pr = q.shape[-2]
     _B = q.shape[0]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Improve KDA prefill kernel performance for hybrid linear-attention models such as `Kimi-Linear-48B-A3B-Instruct` on Hopper-class GPUs. Profiling shows KDA accounts for ~13 % of prefill GPU time on a 4-GPU TP setup; the two dominant KDA kernels (`chunk_gated_delta_rule_fwd_kernel_h_blockdim64` and `chunk_kda_fwd_kernel_inter_solve_fused`) had restrictive autotune configs and were leaving SM utilization on the table: `chunk_gated_delta_rule_fwd_kernel_h_blockdim64`'s grid `(V/BV, B·H_per_rank)` produces only 16 CTAs at TP=8 H=4, far below Hopper's per-GPU SM count, so most SMs sit idle.

## Modifications

KDA (Kimi Delta Attention) is a chunked linear-attention variant. For each chunk t of size BT=64, the per-layer forward decomposes into four stages:

1. **`cumsum`** — chunk-local cumulative gate `gk`
2. **`chunk_kda_fwd_intra`** — three sub-kernels that compute, per chunk, the gated qk attention `Aqk`, the lower-triangular gated kk matrix `Akk`, its inverse via in-chunk forward substitution, and finally the delta-rule helpers `w =
β·k·Akk⁻¹`, `u = β·v·Akk⁻¹`, `kg = k·exp(gn − gk)`. Each step is parallelizable over `(chunk, head, batch)`.
3. **`chunk_gated_delta_rule_fwd_h`** — the recurrence: `h_{t+1} = h_t ⊙ exp(gk_last_t) + k_t.T @ (u_t − w_t @ h_t.T)`. **Serial across the NT chunk axis**; only parallelizable over `(head, batch, V-slice)`.
4. **`chunk_gla_fwd_o_gk`** — output `o = q·g·h.T + Aqk·v_new`. Parallel over `(chunk, head, V-slice)`.

This PR's improvement comes from the following perspectives:

### 1. h-recurrence kernel: SM under-utilization at small per-rank H
- **Expand the BV sweep to include 16 and num_warps to include 8** so triton can pick a wider grid (`V/BV = 8`) when small per-rank H starves SMs. The smaller per-CTA tile also reduces register pressure on the `b_h₁..b_h₄` accumulators (each `[BV, 64]` fp32), which raises occupancy per SM.
- **Add `NT_BUCKET` to the autotune key** (3 buckets: NT ≤ 32, ≤ 128, > 128). The optimal config genuinely differs by chunk count: short prefills favor larger BV (more work amortized over launch), long prefills favor smaller BV (more parallelism to fill SMs). Without bucketing, whichever shape autotunes first locks the choice for all subsequent shapes.
- **Add `restore_value=["h", "v_new", "initial_state"]`** to the autotune decorator. Triton's autotune benchmarks each config by repeatedly invoking the kernel; without this, the post-autotune output tensor reflects whichever config ran last in the benchmark sequence rather than the chosen config, which can produce transient precision drift on the first call. Save+restore makes the cold-cache output identical to the steady-state output.

### 2. chunk_intra: kernel-launch and HBM round-trip overhead

The intra stage was three separate kernels (`token_parallel` for diagonal Akk blocks, `inter_solve_fused` for off-diagonal blocks + lower-triangular solve, `recompute_w_u_fwd` for w/u/kg). Each boundary materializes an intermediate tensor in HBM:
- `Akkd` (diagonal blocks, fp32, ~T·H·16·4 bytes) between kernels 1 and 2
- `Akk_inv` (full triangular inverse, ~T·H·64·4 bytes) between kernels 2 and 3

The PR introduces two `tl.constexpr` modes inside `chunk_kda_fwd_kernel_inter_solve_fused`:
- **`FUSE_DIAGONAL`** — folds the diagonal Akk computation into the same kernel. Diagonal blocks live in registers and are consumed immediately by the forward-substitution; the Akkd round-trip is eliminated.
- **`FUSE_RECOMPUTE`** — additionally folds the w/u/kg recompute. The Akk_inv sub-blocks stay in registers after solve and are immediately used to construct `w = β·k·Akk_inv` etc.; the Akk_inv round-trip is eliminated.

### 3. Off-diagonal MMA in bf16

Off-diagonal `tl.dot` inputs were upcast to fp32 before the matmul; cast the per-block products `b_q·b_gqn`, `b_k·b_gqn`, and the transposed key tile to bf16 before MMA so the Hopper tensor cores run at bf16 rate (2× throughput vs the fp32 path). Accumulator stays fp32. Validated against `test_chunk_gated_delta_rule.py` (ATOL=2e-2).

### 4. Grid-aware fuse gate (kda.py dispatcher)

Compute `_small_grid = (B · NT_pr · H_per_rank ≤ 256)` and pass `fuse_diagonal=_small_grid, fuse_recompute=_small_grid` to `chunk_kda_fwd_intra`. Fusion saves launch overhead at small grid where the kernel is launch-bound; falls back to the
unfused path at large grid where the extra register footprint would spill.

For varlen (packed) tensors `NT_pr` uses `chunk_indices.shape[0]` to correctly count per-sequence chunks (chunks don't cross sequence boundaries, so `cdiv(total_tokens, chunk_size)` undercounts for typical short-sequence packs).

---

All the modified files are in `python/sglang/srt/layers/attention/fla/`:

**`chunk_delta_h.py`** — thread `chunk_indices` through the wrapper for varlen, keep autotune at a single config.

**`chunk_intra.py`** — fuse diagonal-block compute and `recompute_w_u_fwd` into the inter+solve kernel (`FUSE_DIAGONAL`, `FUSE_RECOMPUTE`); cast off-diagonal MMA inputs to bf16; keep the autotune sweep narrow (`BK ∈ {32, 64} × num_warps ∈ {1, 2, 4}`) since wider sweeps caused triton 3.6 to pick suboptimal configs at large grids.

**`kda.py`** — grid-aware dispatcher (`_small_grid`) with varlen-correct `NT_pr`; `chunk_gla_fwd_kernel_o` autotune restricted to `BK=64, BV=64` (matches pre-PR hardcoded values; wider sweeps on triton 3.6+ either crash or pick suboptimal configs).

**`cumsum.py`** — minor: add `num_stages` to the existing autotune sweep so longer prefills can benefit from deeper pipelining.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

Kimi-Linear-48B-A3B-Instruct GSM8K accuracy: **90.0 %** (no drops vs main).

| Metric          | Value         |
| --------------- | ------------: |
| Accuracy        | **90.0 %**    |
| Invalid outputs | 0.0 %         |
| Output throughput | 356 tok/s   |

```
python -m sglang.launch_server \
  --model-path moonshotai/Kimi-Linear-48B-A3B-Instruct \
  --tp 4 --trust-remote-code \
  --mem-fraction-static 0.7 --attention-backend triton \
  --port 30000
python -m sglang.test.few_shot_gsm8k --num-shots 8 --num-questions 200 --port 30000
```

Registered correctness tests:

| Test | Result |
| ---- | ------ |
| `test/registered/attention/test_chunk_gated_delta_rule.py` | **28/28 PASS** (ATOL=2e-2) |
| `test/registered/models/test_kimi_linear_models.py::TestKimiLinear::test_gsm8k` | **PASS** |

PyTorch reference verified independently against multiple equivalent formulations (direct serial, affine-form `h = h @ M + b`, block-parallel scan with various `SEG_LEN`); all match to fp32 epsilon.

| Test | Configs | Output max-diff vs PyTorch reference | Status |
| ---- | ------- | ----------------------------------: | ------ |
| `test_fuse_diagonal.py`  | B=1/T=4096, varlen B=8/T=4096, B=1/T=8192 | 6 × 10⁻⁵ – 3 × 10⁻³ | **PASS** |
| `test_fuse_recompute.py` | same 3                                    | 3 × 10⁻⁵ – 3 × 10⁻⁵ | **PASS** |
| `test_fused_ho.py`       | same 3                                    | 6 × 10⁻⁵ – 3 × 10⁻³ | **PASS** |

## Speed Tests and Profiling

Prefill B=1 T=8192, attention-backend=triton.

### Profile-based per-kernel GPU time (E2E prefill, `--enable-profile-cuda-graph`)

| Kernel | Main | This PR | Δ ms | Δ % |
| ------ | ---: | ------: | ---: | --: |
| `chunk_gated_delta_rule_fwd_kernel_h_blockdim64` | 5.00 ms | **3.30 ms** | −1.70 | **−34 %** |
| `chunk_kda_fwd_kernel_inter_solve_fused`         | 3.03 ms | **1.84 ms** | −1.19 | **−39 %** |
| `chunk_kda_fwd_kernel_intra_token_parallel`      | 1.20 ms | 1.18 ms     | −0.02 | −2 %  |
| `recompute_w_u_fwd_kernel`                       | 0.79 ms | 0.75 ms     | −0.04 | −5 %  |
| `chunk_gla_fwd_kernel_o`                         | 1.03 ms | 1.21 ms     | +0.18 | +17 % |
| `_causal_conv1d_fwd_kernel` (unchanged)          | 1.09 ms | 1.09 ms     | 0     | 0 %   |
| **KDA total** | **12.14 ms** | **9.37 ms** | **−2.77** | **−23 %** |

### Isolated kernel benchmark (`chunk_kda_fwd`, ms/iter, 200 iters, 20 warmup, K=V=128, BT=64)

**TP=8 (H=4 per rank) — production deployment**

|     T | Main  | This PR   | Speedup    |
| ----: | ----: | --------: | ---------: |
|  2048 | 0.285 | **0.216** | **+24 %**  |
|  4096 | 0.284 | **0.217** | **+24 %**  |
|  8192 | 0.439 | **0.401** |  +9 %      |
| 16384 | 0.860 | **0.756** | **+12 %**  |
| 4×4096 (varlen) | 0.305 | **0.228** | **+25 %** |

**Overview across TP shapes**
| Shape | Main | This PR | vs Main |
| ----- | ---: | ------: | ------: |
| TP=8 H=4 T=2048   | 0.285 | 0.216 | **−24 %** |
| TP=8 H=4 T=4096   | 0.284 | 0.217 | **−24 %** |
| TP=8 H=4 T=8192   | 0.439 | 0.401 |  −9 %     |
| TP=8 H=4 T=16384  | 0.860 | 0.756 | **−12 %** |
| TP=8 H=4 4×4096   | 0.305 | 0.228 | **−25 %** |
| TP=4 H=8 T=2048   | 0.288 | 0.220 | **−24 %** |
| TP=4 H=8 T=8192   | 0.532 | 0.520 |  −2 %     |
| TP=4 H=8 T=16384  | 1.023 | 1.002 |  −2 %     |

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
