### PR TITLE
fix(bench_serving): always update output_len for sglang-oai completions

### DIFF
--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -301,14 +301,15 @@ async def async_request_openai_completions(
                             # final chunk with empty `text` that carries the
                             # usage summary. Both must be tolerated, mirroring
                             # the chat path's handling.
-                            choice = (data.get("choices") or [{}])[0]
+                            choices = data.get("choices") or []
+                            choice = choices[0] if choices else {}
                             text = choice.get("text") or ""
 
                             if text:
                                 timestamp = time.perf_counter()
                                 # First token
                                 if ttft == 0.0:
-                                    ttft = time.perf_counter() - st
+                                    ttft = timestamp - st
                                     output.ttft = ttft
                                 # Decoding phase
                                 else:

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -295,28 +295,35 @@ async def async_request_openai_completions(
                         else:
                             data = json.loads(chunk)
 
-                            # NOTE: Some completion API might have a last
-                            # usage summary response without a token so we
-                            # want to check a token was generated
-                            if data["choices"][0]["text"]:
+                            # vLLM (and similar) emit usage-only chunks with
+                            # an empty `choices` list when stream_options
+                            # include_usage is set; sglang itself emits a
+                            # final chunk with empty `text` that carries the
+                            # usage summary. Both must be tolerated, mirroring
+                            # the chat path's handling.
+                            choice = (data.get("choices") or [{}])[0]
+                            text = choice.get("text") or ""
+
+                            if text:
                                 timestamp = time.perf_counter()
                                 # First token
                                 if ttft == 0.0:
                                     ttft = time.perf_counter() - st
                                     output.ttft = ttft
-
                                 # Decoding phase
                                 else:
-                                    output.text_chunks.append(
-                                        data["choices"][0]["text"]
-                                    )
+                                    output.text_chunks.append(text)
                                     output.itl.append(timestamp - most_recent_timestamp)
 
                                 most_recent_timestamp = timestamp
-                                generated_text += data["choices"][0]["text"]
-                                output_len = (data.get("usage") or {}).get(
-                                    "completion_tokens", output_len
-                                )
+                                generated_text += text
+
+                            # Always update output_len from the usage summary
+                            # if present; the trailing chunk has no text but
+                            # carries the authoritative completion_tokens.
+                            output_len = (data.get("usage") or {}).get(
+                                "completion_tokens", output_len
+                            )
 
                     output.generated_text = generated_text
                     output.success = True


### PR DESCRIPTION
Fixes #24254.

Two related fixes in `async_request_openai_completions`:

1. **`output_len` was nested inside `if data['choices'][0]['text']`**, sglang's trailing usage chunk has empty `text`, so the assignment was skipped and `output_len` stayed pinned at the requested `max_tokens`. Every metric derived from it (TPOT, output token throughput, retokenized length) was wrong whenever generation stopped before `max_tokens`. Move the usage update outside the text guard, mirroring the chat path's structure (already correct).
2. **Indexing `choices[0]` on usage-only chunks panicked**, vLLM with `stream_options.include_usage=true` emits chunks with `choices=[]`. Tolerate that with `(data.get('choices') or [{}])[0]`.

Chat path (`async_request_openai_chat_completions`) already does both and is unaffected.