### PR TITLE
[hybrid-swa]: preserve computed prefix when SWA chunk is not admitted

### DIFF
--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -661,6 +661,11 @@ class PrefillAdder:
             # Therefore, in certain cases where _rem_tokens <= 0, it should be replaced with rem_chunk_tokens.
             if _rem_tokens <= 0:
                 if self.is_hybrid_swa:
+                    # init_next_round_input may have expanded fill_ids beyond
+                    # the committed prefix. This req will be stashed before it
+                    # is scheduled again, so keep only computed tokens here.
+                    req.fill_ids = req.fill_ids[: len(req.prefix_indices)]
+                    req.set_extend_input_len(0)
                     return req
                 _rem_tokens = self.rem_chunk_tokens
 

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -443,7 +443,14 @@ class TestPrefillAdder(CustomTestCase):
         self.assertEqual(result3, AddReqResult.OTHER)
 
     def _build_hybrid_swa_chunked_req(
-        self, *, page_size, rem_swa, rem_chunk=2048, extend_input_len=500
+        self,
+        *,
+        page_size,
+        rem_swa,
+        rem_chunk=2048,
+        prefix_len=0,
+        cache_protected_len=None,
+        extend_input_len=500,
     ):
         self.mock_token_allocator.swa_available_size.return_value = rem_swa
         self.mock_token_allocator.full_available_size.return_value = 100_000
@@ -458,9 +465,16 @@ class TestPrefillAdder(CustomTestCase):
 
         req = self.create_mock_req("chunked", priority=0, max_new_tokens=128)
         req.extend_input_len = extend_input_len
-        req.prefix_indices = []
-        req.fill_ids = list(range(extend_input_len))
-        req.set_extend_input_len = MagicMock()
+        req.prefix_indices = list(range(prefix_len))
+        req.cache_protected_len = (
+            prefix_len if cache_protected_len is None else cache_protected_len
+        )
+        req.fill_ids = list(range(prefix_len + extend_input_len))
+
+        def set_extend_input_len(value):
+            req.extend_input_len = value
+
+        req.set_extend_input_len = MagicMock(side_effect=set_extend_input_len)
         return adder, req
 
     def test_add_chunked_req_hybrid_swa_reserves_page_for_alloc_extend(self):
@@ -484,19 +498,41 @@ class TestPrefillAdder(CustomTestCase):
 
     def test_add_chunked_req_hybrid_swa_defers_when_swa_below_page(self):
         # When rem_swa_tokens <= page_size there is no room to serve even the
-        # reservation, so the chunked req must be deferred (returned unchanged)
-        # instead of falling back to rem_chunk_tokens and bypassing SWA budget.
+        # reservation, so the chunked req must be deferred instead of falling
+        # back to rem_chunk_tokens and bypassing SWA budget.
         PAGE_SIZE = 64
         adder, req = self._build_hybrid_swa_chunked_req(
             page_size=PAGE_SIZE, rem_swa=PAGE_SIZE
         )
-        original_len = req.extend_input_len
 
         result = adder.add_chunked_req(req)
 
         self.assertIs(result, req)
-        req.set_extend_input_len.assert_not_called()
-        self.assertEqual(req.extend_input_len, original_len)
+        self.assertEqual(len(adder.can_run_list), 0)
+
+    def test_add_chunked_req_hybrid_swa_deferral_keeps_only_computed_prefix(self):
+        PAGE_SIZE = 64
+        PREFIX_LEN = PAGE_SIZE * 2
+        CACHE_PROTECTED_LEN = PAGE_SIZE
+        UNCOMPUTED_TAIL_LEN = PAGE_SIZE * 4
+        adder, req = self._build_hybrid_swa_chunked_req(
+            page_size=PAGE_SIZE,
+            rem_swa=PAGE_SIZE,
+            prefix_len=PREFIX_LEN,
+            cache_protected_len=CACHE_PROTECTED_LEN,
+            extend_input_len=UNCOMPUTED_TAIL_LEN,
+        )
+        req.fill_ids = [10_000 + i * 7 for i in range(PREFIX_LEN + UNCOMPUTED_TAIL_LEN)]
+        computed_fill_ids = req.fill_ids[:PREFIX_LEN]
+        self.assertEqual(len(req.fill_ids), PREFIX_LEN + UNCOMPUTED_TAIL_LEN)
+        self.assertLess(req.cache_protected_len, len(req.prefix_indices))
+
+        result = adder.add_chunked_req(req)
+
+        self.assertIs(result, req)
+        req.set_extend_input_len.assert_called_once_with(0)
+        self.assertEqual(req.extend_input_len, 0)
+        self.assertEqual(req.fill_ids, computed_fill_ids)
         self.assertEqual(len(adder.can_run_list), 0)
 
 


### PR DESCRIPTION
## Motivation

Fixes #24252.

Gemma4 with hybrid SWA can produce an empty extend micro-batch after KV-pool pressure and decode retraction. The crash appears later in rotary embedding / KV cache store / logits processing, but the invalid state is created earlier in the scheduler admission path for chunked prefill.

## Root Cause

From debugging the hybrid-SWA chunked-prefill path, I found that a prepared-but-not-admitted chunked request could cross the scheduler/cache boundary with `fill_ids` still expanded beyond the computed prefix.

`init_next_round_input()` prepares the next chunk by expanding `fill_ids` and recomputing `extend_input_len`. That is expected. The bug was in the hybrid-SWA no-admission branch of `PrefillAdder.add_chunked_req()`: when SWA budget was below the reserved page requirement, the request was kept as `self.chunked_req` for a later round without being added to `can_run_list`, so no model forward computed the expanded tail.

On the next scheduler iteration, `Scheduler.stash_chunked_request()` called `SWARadixCache.cache_unfinished_req()`, which trusts `req.fill_ids` as the computed token range for an unfinished chunk. Since `fill_ids` still included the uncomputed tail, SWA radix cache advanced `prefix_indices` to the full prompt. The next prefill preparation then produced `extend_input_len == 0`, creating an empty extend micro-batch.

From debug trace:

```text
cache_unfinished_req(chunked=True): fill_len=19846 prefix_len=8702 extend_input_len=11144
cache_unfinished_req after update:  prefix_len=19846
init_next_round_input:              fill_len=19846 prefix_len=19846 max_prefix_len=19845
add_chunked_req:                    kept as chunked_req with extend_input_len=0
prepare_for_extend:                 empty extend batch
```

## Modifications

- In `PrefillAdder.add_chunked_req()`, when hybrid SWA cannot admit the next chunk because SWA budget is below the reserved page requirement, keep the request deferred but trim `fill_ids` back to the committed prefix.
- Set `extend_input_len` to `0` for that deferred state so a later stash cannot cache uncomputed tokens.
- Added a targeted regression to the existing `test_prefill_adder.py` unit tests for the failing state: committed prefix, expanded uncomputed tail, no SWA budget, and deferred chunked request.

## Accuracy Tests

- Reproduced the original failing workload from #24252. The repro produced an empty extend micro-batch after KV-pool retraction and crashed downstream.
- Re-ran the same Gemma4 31B / TP=2 / `--swa-full-tokens-ratio 0.1` repro after this fix: PASSED.
- Unit test:
  - `python3 -m pytest -q test/registered/unit/managers/test_prefill_adder.py`: PASSED.

## Speed Tests and Profiling

N/A


## Checklist

- [x] Add or update tests as needed.
- [x] Provide accuracy results for the failing repro.
- [x] Format your code according to the contribution guide.
- [ ] Update documentation as needed.
